### PR TITLE
Non ASCII symbols issue

### DIFF
--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -60,7 +60,7 @@ class DocType:
 				self.validate_warehouse(s[1], count)
 			
 				# encode as ascii
-				self.data.append([d.encode("ascii") for d in s])
+				self.data.append([d.decode("utf-8") for d in s])
 				count += 1
 			
 		if not self.validated:
@@ -186,7 +186,7 @@ class DocType:
 		# write to file
 		fname = self.doc.file_list.split(',')
 		from webnotes.utils import file_manager
-		file_manager.write_file(fname[1], out)
+		file_manager.write_file(fname[1], out.encode('utf-8'))
 		
 			
 


### PR DESCRIPTION
Before this change non ASCII symbols in "Item Code" field in csv file led to error:
"UnicodeDecodeError: 'ascii' codec can't decode byte 0xd0 in position 0: ordinal not in range(128)" which was rased by stock_reconciliation.py at row 63 (self.data.append([d.encode("​ascii") for d in s]))
