### PR TITLE
Change for *bsd compatibility

### DIFF
--- a/install_erpnext.py
+++ b/install_erpnext.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 from __future__ import unicode_literals
 import os, commands
 


### PR DESCRIPTION
# !/usr/bin/python > #!/usr/bin/env python for *bsd compatibility

/usr/bin/python is read-only on NetBSD as Python is not a standard part of this OS.
