### PR TITLE
Allow user to add leave application which may results in negative balance.

### DIFF
--- a/hr/doctype/leave_application/leave_application.py
+++ b/hr/doctype/leave_application/leave_application.py
@@ -124,10 +124,13 @@ class DocType(DocListController):
 			if not is_lwp(self.doc.leave_type):
 				self.doc.leave_balance = get_leave_balance(self.doc.employee,
 					self.doc.leave_type, self.doc.fiscal_year)["leave_balance"]
-			
+				# Allowing user to add leavs which will result in negative balance. This is needed for Sick Leave and other common exceptional cases. 
+				#System will check and warn but continue with saving the application. 
+				#This may needs to be changed if other ERPNext customer may not want this behaviour.
 				if self.doc.leave_balance - self.doc.total_leave_days < 0:
 					msgprint("There is not enough leave balance for Leave Type: %s" % \
-						(self.doc.leave_type,), raise_exception=1)
+						(self.doc.leave_type,))
+						# , raise_exception=1)
 
 	def validate_leave_overlap(self):
 		if not self.doc.name:


### PR DESCRIPTION
Rushabh,
Could I please request you to review the changes that I have made in order to support negative leave balance. Below is one of the reason, why we need to have this support in Leave Application functionality.

Currently the way system work is that in order to apply for a leave you need to have sufficient balance for that leave type. So for example, if I want to apply for a sick leave, I need to have sufficient sick leave allocated to me. This may not work for UK as there is no defined number of sick leaves one can take during a fiscal year. If we start to allocate this in the system, it may encourage people to take sick leave (like in Australian companies, people fake sickies to use their remaining sick leaves).

The changes that I have made is very simple, I have commented the bit where it raise exception. So this way the system will warn the user about negative leave balance but will continue with saving the form.

Do other customers of ERPNext will be okay with this changes? if not, how do we make this configurable so it doesn't affect them. One option is to have a flag in Leave Type table to set if negative leave balance should be allow for that leave type.

Look forward to your reply.

Mayur
