### PR TITLE
get_companies - Return all companies for permissions with no match condition

### DIFF
--- a/accounts/page/accounts_browser/accounts_browser.py
+++ b/accounts/page/accounts_browser/accounts_browser.py
@@ -13,15 +13,16 @@ def get_companies():
 		where parent='Account' and permlevel=0 and `read`=1""", as_dict=1)
 	
 	roles = webnotes.user.get_roles()
-	match = any((r["match"] for r in res 
-		if r["role"] in roles and r["match"]=="company"))
-	
-	# if match == company is specified and companies are specified in user defaults
-	if match:
-		return webnotes.defaults.get_user_default_as_list("company")
-	else:
-		return [r[0] for r in webnotes.conn.sql("""select name from tabCompany
-			where docstatus!=2""")]
+	match = any((True for r  in res
+                if r["role"] in roles and r["match"] == None))
+
+        # if match == None is specified then return all  companies else return companies specified in user defaults
+        if match:
+                return [r[0] for r in webnotes.conn.sql("""select name from tabCompany
+                        where docstatus!=2""")]
+        else:
+                return webnotes.defaults.get_user_default_as_list("company")
+
 
 @webnotes.whitelist()
 def get_children():


### PR DESCRIPTION
Hi Rushabh,

We have 3 companies setup in our ERPNext system. There are few roles that have permissions set for Account doctype. For some of these permissions there is a match condition for company and for others none.See below screen shot:

![capture](https://f.cloud.github.com/assets/2786730/862298/508118d6-f5ec-11e2-9e3e-d690b66af3d8.PNG)

One of the user  has been given Senior Executive, Account Manager, Account User, Purchase User roles. Since  some these roles have company match condition  for Account Doctype , the current code only return default company and not all. It should return All if at least one of the match condition is None. So we have changed this code to achieve the same. This was affecting administrator user too since administrator users is assigned these roles.

Modified get_companies() function to return all companies where match=None. This is required when you have two or more permissions, one with match=None and another is with match=company(or anything). In this situation, we want None to take priority and hence return all companies. This is needed when a user needs to see charts of accounts for all the companies setup in the system.

Please review our changes and approve it.

PS: Also on a side note, something related to this. I am getting some issues with Charts of Account page.  See below:

We have a role called Senior Executive. The  rules and permissions for this role is same as Account manager role except that Senior Executive role has no company condition (can see accounts for all 3 companies). This role is assigned to a user.  But when ever this user clicks "Charts of Accounts", the system displays "Not Permitted. Sorry you are not permitted to view this page. Go back to home" in the console i see below error message.  
Traceback (innermost last):
  File "../lib/webnotes/handler.py", line 154, in handle
    execute_cmd(cmd)
  File "../lib/webnotes/handler.py", line 189, in execute_cmd
    ret = call(method, webnotes.form_dict)
  File "../lib/webnotes/handler.py", line 206, in call
    return fn(**newargs)
  File "../lib/webnotes/widgets/page.py", line 63, in getpage
    (doclist[0].title or page, )
 PermissionError: No read permission for Page Accounts Browser

But I have assigned appropriate permission for Account doctype to Senior Executive role. Please see below screen shot:
![capture](https://f.cloud.github.com/assets/2786730/862386/bdb8345e-f5ef-11e2-8034-1d09da9f06d8.PNG)

I am not sure what is wrong with above. It should allow access to Charts of Account page based on the above permissions. Am I missing something? Thanks in advance.

Kind regards,
Mayur Patel
