### PR TITLE
Fix UnicodeDecodeError

### DIFF
--- a/install_erpnext.py
+++ b/install_erpnext.py
@@ -332,9 +332,11 @@ def exec_in_shell(cmd):
 
 			stdout.seek(0)
 			out = stdout.read()
+			if out: out = out.decode('utf-8')
 
 			stderr.seek(0)
 			err = stderr.read()
+			if err: err = err.decode('utf-8')
 
 	if err and any((kw in err.lower() for kw in ["traceback", "error", "exception"])):
 		print out


### PR DESCRIPTION
``` python
Traceback (most recent call last):
  File "install_erpnext.py", line 348, in <module>
    install()
  File "install_erpnext.py", line 13, in install
    install_pre_requisites()
  File "install_erpnext.py", line 25, in install_pre_requisites
    install_using_yum()
  File "install_erpnext.py", line 90, in install_using_yum
    update_config_for_redhat()
  File "install_erpnext.py", line 106, in update_config_for_redhat
    exec_in_shell("chkconfig --level 2345 %s on" % service)
  File "install_erpnext.py", line 339, in exec_in_shell
    if err and any((kw in err.lower() for kw in ["traceback", "error", "exception"])):
  File "install_erpnext.py", line 339, in <genexpr>
    if err and any((kw in err.lower() for kw in ["traceback", "error", "exception"])):
```
