### PR TITLE
get_item_list does not [item qty=0]

### DIFF
--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -339,7 +339,7 @@ class SellingController(StockController):
 			reserved_warehouse = ""
 			reserved_qty_for_main_item = 0
 
-			if not d.qty:
+			if d.qty is None:
 				frappe.throw(_("Row {0}: Qty is mandatory").format(d.idx))
 
 			if self.doctype == "Sales Order":


### PR DESCRIPTION
- By using `if not d.qty:` it totally limits the chance of creating an empty Delivery Note 
- Should be changed to `if d.qty is None` 

Use case for empty DN: 
- Open a Delivery Note and tight to a specific Sales Order first without knowing the real qty at this point.
- Using barcode scanner to receive Sales Order to this DN (multiple times).
