### PR TITLE
[fix] Quality Inspection linked with stock entry

### DIFF
--- a/erpnext/buying/doctype/quality_inspection/quality_inspection.json
+++ b/erpnext/buying/doctype/quality_inspection/quality_inspection.json
@@ -36,7 +36,7 @@
    "label": "Inspection Type", 
    "oldfieldname": "inspection_type", 
    "oldfieldtype": "Select", 
-   "options": "\nIncoming\nOutgoing\nIn Process", 
+   "options": "\nIncoming\nOutgoing\nManufacture", 
    "permlevel": 0, 
    "reqd": 1
   }, 
@@ -141,6 +141,14 @@
    "search_index": 1
   }, 
   {
+   "depends_on": "eval:doc.inspection_type==\\\"Manufacture\\\"", 
+   "fieldname": "stock_entry_no", 
+   "fieldtype": "Link", 
+   "label": "Stock Entry Number", 
+   "options": "Stock Entry", 
+   "permlevel": 0
+  }, 
+  {
    "fieldname": "inspected_by", 
    "fieldtype": "Data", 
    "label": "Inspected By", 
@@ -207,7 +215,7 @@
  "icon": "icon-search", 
  "idx": 1, 
  "is_submittable": 1, 
- "modified": "2014-06-23 07:55:51.183113", 
+ "modified": "2014-09-13 22:53:56.240767", 
  "modified_by": "Administrator", 
  "module": "Buying", 
  "name": "Quality Inspection", 

--- a/erpnext/buying/doctype/quality_inspection/quality_inspection.py
+++ b/erpnext/buying/doctype/quality_inspection/quality_inspection.py
@@ -9,6 +9,14 @@ from frappe.model.document import Document
 
 class QualityInspection(Document):
 
+	def validate(self):
+		self.validate_stock_entry_no()
+
+	def validate_stock_entry_no(self):
+		if self.inspection_type == 'Manufacture':
+			if not self.stock_entry_no:
+				frappe.throw(_("Stock Entry Number is mandatory for Inspection Type Manufacture."))
+
 	def get_item_specification_details(self):
 		self.set('qa_specification_details', [])
 		specification = frappe.db.sql("select specification, value from `tabItem Quality Inspection Parameter` \

--- a/erpnext/buying/doctype/quality_inspection/test_quality_inspection.py
+++ b/erpnext/buying/doctype/quality_inspection/test_quality_inspection.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2013, Web Notes Technologies Pvt. Ltd. and Contributors and Contributors
+# See license.txt
+
+import frappe
+from frappe.exceptions import ValidationError
+import unittest
+
+class TestQualityInspection(unittest.TestCase):
+	def test_stock_no(self):
+		self.assertRaises(ValidationError, frappe.get_doc({
+			"doctype": "Quality Inspection",
+			"name": "_Test Quality Inspection 1",
+			"inspection_type": "Manufacture",
+			"report_date": "12-09-2014",
+			"item_code" : "_Test Item",
+			"sample_size": "1",
+			"inspected_by": "test Inspector",
+			"stock_entry_no": ""
+		}).save)

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -81,3 +81,4 @@ erpnext.patches.v4_2.default_website_style
 erpnext.patches.v4_2.set_company_country
 erpnext.patches.v4_2.update_sales_order_invoice_field_name
 erpnext.patches.v4_2.cost_of_production_cycle
+execute:frappe.db.sql("update `tabQuality_Inspection' set inspection_type = 'Manufacture' where inspection_type = 'In Process'")

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -7,7 +7,7 @@ import frappe.defaults
 
 from frappe.utils import cstr, cint, flt, comma_or, nowdate
 
-from frappe import _
+from frappe import _, msgprint
 from erpnext.stock.utils import get_incoming_rate
 from erpnext.stock.stock_ledger import get_previous_sle
 from erpnext.controllers.queries import get_match_cond
@@ -53,6 +53,7 @@ class StockEntry(StockController):
 		self.validate_fiscal_year()
 		self.validate_valuation_rate()
 		self.set_total_amount()
+		self.validate_quality_inspection()
 
 	def on_submit(self):
 		self.update_stock_ledger()
@@ -622,6 +623,12 @@ class StockEntry(StockController):
 				if mreq_item.item_code != item.item_code or mreq_item.warehouse != item.t_warehouse:
 					frappe.throw(_("Item or Warehouse for row {0} does not match Material Request").format(item.idx),
 						frappe.MappingMismatchError)
+
+	def validate_quality_inspection(self):
+		if self.purpose == 'Manufacture/Repack':
+			for item in self.get("mtn_details"):
+				if frappe.db.get_value("Item",item.item_code,"inspection_required") =="Yes":
+					msgprint(_("Quality Inspection is required for Item: {0}").format(item.item_code))
 
 @frappe.whitelist()
 def get_party_details(ref_dt, ref_dn):


### PR DESCRIPTION
When Update Finished Goods entry is made, user will be indicated that Quality Inspection is required for FG item, if Inspection Required is checked for FG item.

In Quality inspection DocType value of field inspection type has been changed from 'In Process' to 'Manufacture'.

New field stock entry no has been added to Quality inspection DocType. It is mandatory if inspection Type is Manufacture else hidden.
