### PR TITLE
Has Batch No field should be freezed #2023

### DIFF
--- a/erpnext/stock/doctype/batch/batch.py
+++ b/erpnext/stock/doctype/batch/batch.py
@@ -3,8 +3,15 @@
 
 from __future__ import unicode_literals
 import frappe
-
+from frappe import _
 from frappe.model.document import Document
 
 class Batch(Document):
-	pass
+	
+	def validate(self):
+		self.item_has_batch_enabled()
+
+	def item_has_batch_enabled(self):
+		has_batch_no = frappe.db.get_value("Item",self.item,"has_batch_no")
+		if has_batch_no =='No':
+			frappe.throw(_("The selected item cannot have Batch"))

--- a/erpnext/stock/doctype/batch/test_batch.py
+++ b/erpnext/stock/doctype/batch/test_batch.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2013, Web Notes Technologies Pvt. Ltd. and Contributors
+# License: GNU General Public License v3. See license.txt
+
+import frappe
+from frappe.exceptions import ValidationError
+import unittest
+
+class TestBatch(unittest.TestCase):
+	def test_item_has_batch_enabled(self):
+		self.assertRaises(ValidationError, frappe.get_doc({
+			"doctype": "Batch",
+			"name": "_test Batch",
+			"item": "_Test Item"
+		}).save)

--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -19,7 +19,7 @@ cur_frm.cscript.refresh = function(doc) {
 	cur_frm.cscript.edit_prices_button();
 
 	if (!doc.__islocal && doc.is_stock_item == 'Yes') {
-		cur_frm.toggle_enable(['has_serial_no', 'is_stock_item', 'valuation_method'],
+		cur_frm.toggle_enable(['has_serial_no', 'is_stock_item', 'valuation_method', 'has_batch_no'],
 			(doc.__onload && doc.__onload.sle_exists=="exists") ? false : true);
 	}
 

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -187,13 +187,14 @@ class Item(WebsiteGenerator):
 	def cant_change(self):
 		if not self.get("__islocal"):
 			vals = frappe.db.get_value("Item", self.name,
-				["has_serial_no", "is_stock_item", "valuation_method"], as_dict=True)
+				["has_serial_no", "is_stock_item", "valuation_method", "has_batch_no"], as_dict=True)
 
 			if vals and ((self.is_stock_item == "No" and vals.is_stock_item == "Yes") or
 				vals.has_serial_no != self.has_serial_no or
+				vals.has_batch_no != self.has_batch_no or
 				cstr(vals.valuation_method) != cstr(self.valuation_method)):
 					if self.check_if_sle_exists() == "exists":
-						frappe.throw(_("As there are existing stock transactions for this item, you can not change the values of 'Has Serial No', 'Is Stock Item' and 'Valuation Method'"))
+						frappe.throw(_("As there are existing stock transactions for this item, you can not change the values of 'Has Serial No', 'Has Batch No', 'Is Stock Item' and 'Valuation Method'"))
 
 	def validate_item_type_for_reorder(self):
 		if self.re_order_level or len(self.get("item_reorder", {"material_request_type": "Purchase"})):

--- a/erpnext/stock/doctype/item_price/test_item_price.py
+++ b/erpnext/stock/doctype/item_price/test_item_price.py
@@ -9,6 +9,6 @@ class TestItem(unittest.TestCase):
 	def test_duplicate_item(self):
 		from erpnext.stock.doctype.item_price.item_price import ItemPriceDuplicateItem
 		doc = frappe.copy_doc(test_records[0])
-		self.assertRaises(ItemPriceDuplicateItem, doc.insert)
+		self.assertRaises(ItemPriceDuplicateItem, doc.save)
 
 test_records = frappe.get_test_records('Item Price')


### PR DESCRIPTION
-> validation added in Batch doctype.
-> if has_batch_no is set to no in item master, user cannot create batch against such item
-> if stock entry has been done against an item; then has_batch_no in item master is freezer i.e. user cannot edit it.
->Test Cases added
