### PR TITLE
Updating fixed_cycle_cost in bom_operations on clicking "Update Cost" button

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -285,6 +285,7 @@ class BOM(Document):
 				if not d.hour_rate:
 					d.hour_rate = flt(w[0])
 
+				d.fixed_cycle_cost = flt(w[1])
 				fixed_cost += flt(w[1])
 
 			if d.hour_rate and d.time_in_mins:


### PR DESCRIPTION
"Fixed Cycle Cost" in Child table "BOM Operations" should update on clicking "Update Cost" button in BoM.
"Update Cost" button updates fixed_cycle_cost from selected workstation's fixed_cycle_cost
