### PR TITLE
Filter added to Item feild in BOM

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.js
+++ b/erpnext/manufacturing/doctype/bom/bom.js
@@ -218,3 +218,11 @@ cur_frm.cscript.validate = function(doc, dt, dn) {
 	erpnext.bom.calculate_total(doc);
 }
 
+cur_frm.set_query("item", function(doc) {
+	return{
+		filters: [ 
+			['Item', 'is_manufactured_item', '=', 'Yes' ]
+		]
+	}
+});
+

--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -182,6 +182,9 @@ class BOM(Document):
 			ret = frappe.db.get_value("Item", self.item, ["description", "stock_uom"])
 			self.description = ret[0]
 			self.uom = ret[1]
+			
+		if frappe.db.get_value('Item', self.item, 'is_manufactured_item')== 'No':
+			frappe.throw(_("You cannot make a BOM against this Item."))
 
 	def validate_operations(self):
 		""" Check duplicate operation no"""


### PR DESCRIPTION
In Item master we can select 'allow item in BOM' as yes or no.
Filter added to Item field in BOM to check and allow only those items that have 'allow item in BOM' set as 'Yes' in Item Master.

Validation Added for checking the same.
