### PR TITLE
journal entry linked with Stock Entry

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.json
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.json
@@ -13,6 +13,22 @@
    "permlevel": 0
   }, 
   {
+   "default": "Journal Entry", 
+   "fieldname": "voucher_type", 
+   "fieldtype": "Select", 
+   "in_filter": 1, 
+   "in_list_view": 1, 
+   "label": "Voucher Type", 
+   "oldfieldname": "voucher_type", 
+   "oldfieldtype": "Select", 
+   "options": "Journal Entry\nBank Entry\nCash Entry\nCredit Card Entry\nDebit Note\nCredit Note\nContra Entry\nExcise Entry\nWrite Off Entry\nOpening Entry", 
+   "permlevel": 0, 
+   "print_hide": 0, 
+   "read_only": 0, 
+   "reqd": 1, 
+   "search_index": 1
+  }, 
+  {
    "fieldname": "column_break0", 
    "fieldtype": "Column Break", 
    "oldfieldtype": "Column Break", 
@@ -34,22 +50,6 @@
    "reqd": 1
   }, 
   {
-   "default": "Journal Entry", 
-   "fieldname": "voucher_type", 
-   "fieldtype": "Select", 
-   "in_filter": 1, 
-   "in_list_view": 0, 
-   "label": "Voucher Type", 
-   "oldfieldname": "voucher_type", 
-   "oldfieldtype": "Select", 
-   "options": "Journal Entry\nBank Entry\nCash Entry\nCredit Card Entry\nDebit Note\nCredit Note\nContra Entry\nExcise Entry\nWrite Off Entry\nOpening Entry", 
-   "permlevel": 0, 
-   "print_hide": 0, 
-   "read_only": 0, 
-   "reqd": 1, 
-   "search_index": 1
-  }, 
-  {
    "fieldname": "column_break1", 
    "fieldtype": "Column Break", 
    "oldfieldtype": "Column Break", 
@@ -61,7 +61,7 @@
    "fieldname": "posting_date", 
    "fieldtype": "Date", 
    "in_filter": 1, 
-   "in_list_view": 0, 
+   "in_list_view": 1, 
    "label": "Posting Date", 
    "no_copy": 1, 
    "oldfieldname": "posting_date", 
@@ -97,6 +97,15 @@
    "fieldtype": "Section Break", 
    "permlevel": 0, 
    "read_only": 0
+  }, 
+  {
+   "depends_on": "eval:inList([\"Credit Note\", \"Debit Note\"], doc.voucher_type)", 
+   "fieldname": "stock_entry", 
+   "fieldtype": "Link", 
+   "label": "Stock Entry", 
+   "options": "Stock Entry", 
+   "permlevel": 0, 
+   "precision": ""
   }, 
   {
    "fieldname": "total_debit", 
@@ -154,7 +163,7 @@
    "fieldname": "cheque_no", 
    "fieldtype": "Data", 
    "in_filter": 1, 
-   "in_list_view": 0, 
+   "in_list_view": 1, 
    "label": "Reference Number", 
    "no_copy": 1, 
    "oldfieldname": "cheque_no", 
@@ -177,7 +186,6 @@
    "fieldname": "user_remark", 
    "fieldtype": "Small Text", 
    "in_filter": 1, 
-   "in_list_view": 1, 
    "label": "User Remark", 
    "no_copy": 1, 
    "oldfieldname": "user_remark", 
@@ -449,7 +457,7 @@
  "icon": "icon-file-text", 
  "idx": 1, 
  "is_submittable": 1, 
- "modified": "2015-01-06 12:01:51.379685", 
+ "modified": "2015-01-07 18:06:21.042991", 
  "modified_by": "Administrator", 
  "module": "Accounts", 
  "name": "Journal Entry", 

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -443,8 +443,11 @@ class JournalEntry(AccountsController):
 						Pending Amount is {2}".format(d.idx, d.against_expense_claim, pending_amount)))
 						
 	def validate_credit_debit_note(self):
-		count = frappe.db.sql("select count(stock_entry) as c from `tabJournal Entry` where \
-			stock_entry = %s and docstatus = 1", self.stock_entry, as_dict=1)[0].c
+		count = frappe.db.exists({
+			"doctype": "Journal Entry",
+			"stock_entry":self.stock_entry,
+			"docstatus":1	
+		})
 		if count:
 			frappe.throw(_("{0} already made against stock entry {1}".format(self.voucher_type, self.stock_entry)))
 

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -38,6 +38,7 @@ class JournalEntry(AccountsController):
 		self.validate_against_purchase_order()
 		self.check_credit_days()
 		self.validate_expense_claim()
+		self.validate_credit_debit_note()
 
 	def on_submit(self):
 		self.check_credit_limit()
@@ -440,6 +441,12 @@ class JournalEntry(AccountsController):
 				if d.debit > pending_amount:
 					frappe.throw(_("Row No {0}: Amount cannot be greater than Pending Amount against Expense Claim {1}. \
 						Pending Amount is {2}".format(d.idx, d.against_expense_claim, pending_amount)))
+						
+	def validate_credit_debit_note(self):
+		count = frappe.db.sql("select count(stock_entry) as c from `tabJournal Entry` where \
+			stock_entry = %s and docstatus = 1", self.stock_entry, as_dict=1)[0].c
+		if count:
+			frappe.throw(_("{0} already made against stock entry {1}".format(self.voucher_type, self.stock_entry)))
 
 @frappe.whitelist()
 def get_default_bank_cash_account(company, voucher_type):

--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -65,8 +65,8 @@ erpnext.stock.StockEntry = erpnext.stock.StockController.extend({
 		this.show_stock_ledger();
 		this.show_general_ledger();
 
-		if(this.frm.doc.docstatus === 1 &&
-				frappe.boot.user.can_create.indexOf("Journal Entry")!==-1) {
+		if(this.frm.doc.docstatus === 1 && frappe.boot.user.can_create.indexOf("Journal Entry")!==-1 
+			&& this.frm.doc.__onload.credit_debit_note_exists == 0 ) {
 			if(this.frm.doc.purpose === "Sales Return") {
 				this.frm.add_custom_button(__("Make Credit Note"),
 					function() { me.make_return_jv(); }, frappe.boot.doctype_icons["Journal Entry"]);
@@ -77,7 +77,6 @@ erpnext.stock.StockEntry = erpnext.stock.StockController.extend({
 				this.add_excise_button();
 			}
 		}
-
 	},
 
 	on_submit: function() {

--- a/erpnext/stock/doctype/stock_entry/stock_entry.json
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.json
@@ -576,6 +576,15 @@
    "report_hide": 0, 
    "reqd": 0, 
    "search_index": 0
+  }, 
+  {
+   "fieldname": "credit_note", 
+   "fieldtype": "Link", 
+   "hidden": 1, 
+   "label": "Credit Note", 
+   "options": "Journal Entry", 
+   "permlevel": 0, 
+   "precision": ""
   }
  ], 
  "hide_heading": 0, 
@@ -587,7 +596,7 @@
  "is_submittable": 1, 
  "issingle": 0, 
  "max_attachments": 0, 
- "modified": "2015-01-05 15:28:49.649079", 
+ "modified": "2015-01-07 17:38:40.170567", 
  "modified_by": "Administrator", 
  "module": "Stock", 
  "name": "Stock Entry", 

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -34,6 +34,10 @@ class StockEntry(StockController):
 			for item in self.get("items"):
 				item.update(get_available_qty(item.item_code,
 					item.s_warehouse))
+	
+		count = frappe.db.sql("select count(stock_entry) as c from `tabJournal Entry` \
+			where stock_entry = %s and docstatus = 1",self.name, as_dict=1)[0].c
+		self.get("__onload").credit_debit_note_exists = count 
 
 	def validate(self):
 		self.validate_posting_time()
@@ -825,7 +829,8 @@ def make_return_jv(stock_entry):
 		"posting_date": se.posting_date,
 		"voucher_type": se.purpose == "Sales Return" and "Credit Note" or "Debit Note",
 		"fiscal_year": se.fiscal_year,
-		"company": se.company
+		"company": se.company,
+		"stock_entry": se.name
 	})
 
 	from erpnext.accounts.utils import get_balance_on

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -35,9 +35,15 @@ class StockEntry(StockController):
 				item.update(get_available_qty(item.item_code,
 					item.s_warehouse))
 	
-		count = frappe.db.sql("select count(stock_entry) as c from `tabJournal Entry` \
-			where stock_entry = %s and docstatus = 1",self.name, as_dict=1)[0].c
-		self.get("__onload").credit_debit_note_exists = count 
+		count = frappe.db.exists({
+			"doctype": "Journal Entry",
+			"stock_entry":self.stock_entry,
+			"docstatus":1	
+		})
+		if count:
+			self.get("__onload").credit_debit_note_exists = 1
+		else:
+			self.get("__onload").credit_debit_note_exists = 0
 
 	def validate(self):
 		self.validate_posting_time()

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -37,14 +37,11 @@ class StockEntry(StockController):
 	
 		count = frappe.db.exists({
 			"doctype": "Journal Entry",
-			"stock_entry":self.stock_entry,
+			"stock_entry":self.name,
 			"docstatus":1	
 		})
-		if count:
-			self.get("__onload").credit_debit_note_exists = 1
-		else:
-			self.get("__onload").credit_debit_note_exists = 0
-
+		self.get("__onload").credit_debit_note_exists = 1 if count else 0
+	
 	def validate(self):
 		self.validate_posting_time()
 		self.validate_purpose()


### PR DESCRIPTION
Credit / Debit Note ( Journal Entries ) linked with Stock Entry

Validation added to allow user to make only a single credit / Debit note against a Sales return / purchase return ( Stock Entry)

Make Credit Note / Make Debit Note button in Stock Entry shall not be available once a credit / debit note is made against that stock entry.

Fix for Issue #2416  
