### PR TITLE
Look like a minor bug

### DIFF
--- a/erpnext/hr/doctype/salary_slip/salary_slip.py
+++ b/erpnext/hr/doctype/salary_slip/salary_slip.py
@@ -45,7 +45,7 @@ class SalarySlip(TransactionBase):
 
 	def get_leave_details(self, lwp=None):
 		if not self.fiscal_year:
-			self.fiscal_year = frappe.get_default("fiscal_year")
+			self.fiscal_year = frappe.db.get_default("fiscal_year")
 		if not self.month:
 			self.month = "%02d" % getdate(nowdate()).month
 


### PR DESCRIPTION
- There is no frappe.get_default but only frappe.db.get_default ?
- Error return if selecting Employee in Salary Slip without specifying the Fiscal Year first
