### PR TITLE
Fixes in Appraisal doc

### DIFF
--- a/erpnext/hr/doctype/appraisal/appraisal.json
+++ b/erpnext/hr/doctype/appraisal/appraisal.json
@@ -142,10 +142,10 @@
    "permlevel": 0
   }, 
   {
-   "description": "Any other comments, noteworthy effort that should go in the records.", 
-   "fieldname": "comments", 
+   "description": "Any other remarks, noteworthy effort that should go in the records.", 
+   "fieldname": "remarks", 
    "fieldtype": "Text", 
-   "label": "Comments", 
+   "label": "Remarks", 
    "permlevel": 0
   }, 
   {
@@ -165,6 +165,12 @@
    "options": "Company", 
    "permlevel": 0, 
    "reqd": 1
+  }, 
+  {
+   "fieldname": "column_break_17", 
+   "fieldtype": "Column Break", 
+   "permlevel": 0, 
+   "precision": ""
   }, 
   {
    "fieldname": "fiscal_year", 
@@ -197,7 +203,7 @@
  "icon": "icon-thumbs-up", 
  "idx": 1, 
  "is_submittable": 1, 
- "modified": "2015-02-20 05:08:10.903126", 
+ "modified": "2015-03-02 07:00:45.803789", 
  "modified_by": "Administrator", 
  "module": "HR", 
  "name": "Appraisal", 

--- a/erpnext/hr/doctype/appraisal/test_appraisal.py
+++ b/erpnext/hr/doctype/appraisal/test_appraisal.py
@@ -1,0 +1,11 @@
+# Copyright (c) 2015, Web Notes Technologies Pvt. Ltd. and Contributors and Contributors
+# See license.txt
+from __future__ import unicode_literals
+
+import frappe
+import unittest
+
+# test_records = frappe.get_test_records('Appraisal')
+
+class TestAppraisal(unittest.TestCase):
+	pass

--- a/erpnext/hr/doctype/appraisal_goal/appraisal_goal.json
+++ b/erpnext/hr/doctype/appraisal_goal/appraisal_goal.json
@@ -18,6 +18,12 @@
    "width": "240px"
   }, 
   {
+   "fieldname": "section_break_2", 
+   "fieldtype": "Section Break", 
+   "permlevel": 0, 
+   "precision": ""
+  }, 
+  {
    "fieldname": "per_weightage", 
    "fieldtype": "Float", 
    "in_list_view": 1, 
@@ -30,7 +36,13 @@
    "width": "70px"
   }, 
   {
-   "allow_on_submit": 1, 
+   "fieldname": "column_break_4", 
+   "fieldtype": "Column Break", 
+   "permlevel": 0, 
+   "precision": ""
+  }, 
+  {
+   "allow_on_submit": 0, 
    "fieldname": "score", 
    "fieldtype": "Float", 
    "in_list_view": 1, 
@@ -38,10 +50,16 @@
    "no_copy": 1, 
    "oldfieldname": "score", 
    "oldfieldtype": "Select", 
-   "options": "\n0\n1\n2\n3\n4\n5", 
+   "options": "", 
    "permlevel": 0, 
    "print_width": "70px", 
    "width": "70px"
+  }, 
+  {
+   "fieldname": "section_break_6", 
+   "fieldtype": "Section Break", 
+   "permlevel": 0, 
+   "precision": ""
   }, 
   {
    "fieldname": "score_earned", 
@@ -59,7 +77,7 @@
  ], 
  "idx": 1, 
  "istable": 1, 
- "modified": "2015-02-19 01:06:59.212681", 
+ "modified": "2015-03-02 06:48:00.380426", 
  "modified_by": "Administrator", 
  "module": "HR", 
  "name": "Appraisal Goal", 

--- a/erpnext/hr/doctype/appraisal_template/appraisal_template.json
+++ b/erpnext/hr/doctype/appraisal_template/appraisal_template.json
@@ -36,18 +36,11 @@
    "oldfieldtype": "Table", 
    "options": "Appraisal Template Goal", 
    "permlevel": 0
-  }, 
-  {
-   "fieldname": "total_points", 
-   "fieldtype": "Int", 
-   "in_list_view": 1, 
-   "label": "Total Points", 
-   "permlevel": 0
   }
  ], 
  "icon": "icon-file-text", 
  "idx": 1, 
- "modified": "2015-02-05 05:11:34.496238", 
+ "modified": "2015-03-02 06:32:50.109677", 
  "modified_by": "Administrator", 
  "module": "HR", 
  "name": "Appraisal Template", 

--- a/erpnext/hr/doctype/appraisal_template/appraisal_template.py
+++ b/erpnext/hr/doctype/appraisal_template/appraisal_template.py
@@ -3,15 +3,19 @@
 
 from __future__ import unicode_literals
 import frappe
+from frappe.utils import cint
 from frappe import _
 
 from frappe.model.document import Document
 
 class AppraisalTemplate(Document):
 	def validate(self):
-		self.total_points = 0
+		self.check_total_points()
+		
+	def check_total_points(self):	
+		total_points = 0
 		for d in self.get("goals"):
-			self.total_points += int(d.per_weightage or 0)
+			total_points += int(d.per_weightage or 0)
 
-		if int(self.total_points) != 100:
-			frappe.throw(_("Total points for all goals should be 100. It is {0}").format(self.total_points))
+		if cint(total_points) != 100:
+			frappe.throw(_("Sum of points for all goals should be 100. It is {0}").format(total_points))

--- a/erpnext/hr/doctype/appraisal_template/test_appraisal_template.py
+++ b/erpnext/hr/doctype/appraisal_template/test_appraisal_template.py
@@ -1,0 +1,11 @@
+# Copyright (c) 2015, Web Notes Technologies Pvt. Ltd. and Contributors and Contributors
+# See license.txt
+from __future__ import unicode_literals
+
+import frappe
+import unittest
+
+# test_records = frappe.get_test_records('Appraisal Template')
+
+class TestAppraisalTemplate(unittest.TestCase):
+	pass

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -129,3 +129,4 @@ erpnext.patches.v5_0.replace_renamed_fields_in_custom_scripts_and_print_formats
 erpnext.patches.v5_0.update_from_bom
 erpnext.patches.v5_0.update_account_types
 erpnext.patches.v5_0.update_sms_sender
+erpnext.patches.v5_0.set_appraisal_remarks

--- a/erpnext/patches/v5_0/set_appraisal_remarks.py
+++ b/erpnext/patches/v5_0/set_appraisal_remarks.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2013, Web Notes Technologies Pvt. Ltd. and Contributors
+# License: GNU General Public License v3. See license.txt
+
+from __future__ import unicode_literals
+import frappe
+
+def execute():
+	frappe.reload_doctype("Appraisal")
+	frappe.db.sql("update `tabAppraisal` set remarks = comments")


### PR DESCRIPTION
 #2892
- [x] 'total points' removed from Appraisal template.
- [x]  'score' allow on submit property removed.
- [x] 'comments' renamed to 'remarks' (patch written and tested)
