### PR TITLE
Added Actual Batch Qty for item in DN & SI

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -244,7 +244,7 @@ cur_frm.cscript.hide_fields = function(doc) {
 		cur_frm.fields_dict['entries'].grid.set_column_disp(item_flds_normal, true);
 	}
 
-	item_flds_stock = ['serial_no', 'batch_no', 'actual_qty', 'expense_account', 'warehouse']
+	item_flds_stock = ['serial_no', 'batch_no', 'actual_qty', 'actual_batch_qty', 'expense_account', 'warehouse']
 	cur_frm.fields_dict['entries'].grid.set_column_disp(item_flds_stock,
 		(cint(doc.update_stock)==1 ? true : false));
 

--- a/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
+++ b/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
@@ -341,6 +341,19 @@
   }, 
   {
    "allow_on_submit": 1, 
+   "fieldname": "actual_batch_qty", 
+   "fieldtype": "Float", 
+   "label": "Available Batch Qty at Warehouse", 
+   "no_copy": 1, 
+   "permlevel": 0, 
+   "precision": "", 
+   "print_hide": 1, 
+   "print_width": "150px", 
+   "read_only": 1, 
+   "width": "150px"
+  }, 
+  {
+   "allow_on_submit": 1, 
    "fieldname": "actual_qty", 
    "fieldtype": "Float", 
    "label": "Available Qty at Warehouse", 
@@ -439,7 +452,7 @@
  ], 
  "idx": 1, 
  "istable": 1, 
- "modified": "2014-09-09 05:35:36.019576", 
+ "modified": "2015-03-10 14:56:45.641026", 
  "modified_by": "Administrator", 
  "module": "Accounts", 
  "name": "Sales Invoice Item", 

--- a/erpnext/selling/sales_common.js
+++ b/erpnext/selling/sales_common.js
@@ -215,7 +215,10 @@ erpnext.selling.SellingController = erpnext.TransactionController.extend({
 	},
 
 	warehouse: function(doc, cdt, cdn) {
+		var me = this;
+		this.batch_no(doc, cdt, cdn);
 		var item = frappe.get_doc(cdt, cdn);
+		this.batch_no(doc)
 		if(item.item_code && item.warehouse) {
 			return this.frm.call({
 				method: "erpnext.stock.get_item_details.get_available_qty",
@@ -474,6 +477,21 @@ erpnext.selling.SellingController = erpnext.TransactionController.extend({
 				}
 			})
 		}
+	},
+
+	batch_no: function(doc, cdt, cdn) {
+		var me = this;
+		var item = frappe.get_doc(cdt, cdn);
+	    return this.frm.call({
+	        method: "erpnext.stock.get_item_details.get_batch_qty",
+	        child: item,
+	        args: {
+	           "batch_no": item.batch_no,
+	           "warehouse": item.warehouse,
+	           "item_code": item.item_code
+	        },
+	         "fieldname": "actual_batch_qty"
+	    });
 	},
 
 	set_dynamic_labels: function() {

--- a/erpnext/selling/sales_common.js
+++ b/erpnext/selling/sales_common.js
@@ -218,7 +218,6 @@ erpnext.selling.SellingController = erpnext.TransactionController.extend({
 		var me = this;
 		this.batch_no(doc, cdt, cdn);
 		var item = frappe.get_doc(cdt, cdn);
-		this.batch_no(doc)
 		if(item.item_code && item.warehouse) {
 			return this.frm.call({
 				method: "erpnext.stock.get_item_details.get_available_qty",

--- a/erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
+++ b/erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -316,6 +316,19 @@
   }, 
   {
    "allow_on_submit": 1, 
+   "fieldname": "actual_batch_qty", 
+   "fieldtype": "Float", 
+   "label": "Available Batch Qty at Warehouse", 
+   "no_copy": 1, 
+   "permlevel": 0, 
+   "precision": "", 
+   "print_hide": 1, 
+   "print_width": "150px", 
+   "read_only": 1, 
+   "width": "150px"
+  }, 
+  {
+   "allow_on_submit": 1, 
    "fieldname": "actual_qty", 
    "fieldtype": "Float", 
    "label": "Available Qty at Warehouse", 
@@ -426,7 +439,7 @@
  ], 
  "idx": 1, 
  "istable": 1, 
- "modified": "2014-09-09 05:35:37.460939", 
+ "modified": "2015-03-10 12:21:17.028911", 
  "modified_by": "Administrator", 
  "module": "Stock", 
  "name": "Delivery Note Item", 

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -302,7 +302,7 @@ def get_available_qty(item_code, warehouse):
 	return frappe.db.get_value("Bin", {"item_code": item_code, "warehouse": warehouse},
 		["projected_qty", "actual_qty"], as_dict=True) or {}
 
-@frappe.whitelist(allow_guest=False)
+@frappe.whitelist()
 def get_batch_qty(batch_no,warehouse,item_code):
 	actual_batch_qty = get_actual_batch_qty(batch_no,warehouse,item_code)
 	if batch_no:

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -278,6 +278,15 @@ def get_serial_nos_by_fifo(args, item_doc):
 			"qty": cint(args.qty)
 		}))
 
+def get_actual_batch_qty(batch_no,warehouse,item_code):
+        actual_batch_qty = 0
+        if batch_no:
+            actual_batch_qty = flt(frappe.db.sql("""select sum(actual_qty)
+				from `tabStock Ledger Entry`
+				where warehouse=%s and item_code=%s and batch_no=%s""",
+				(warehouse, item_code, batch_no))[0][0])
+        return actual_batch_qty
+
 @frappe.whitelist()
 def get_conversion_factor(item_code, uom):
 	return {"conversion_factor": frappe.db.get_value("UOM Conversion Detail",
@@ -293,6 +302,12 @@ def get_available_qty(item_code, warehouse):
 	return frappe.db.get_value("Bin", {"item_code": item_code, "warehouse": warehouse},
 		["projected_qty", "actual_qty"], as_dict=True) or {}
 
+@frappe.whitelist(allow_guest=False)
+def get_batch_qty(batch_no,warehouse,item_code):
+	actual_batch_qty = get_actual_batch_qty(batch_no,warehouse,item_code)
+	if batch_no:
+		return {'actual_batch_qty': actual_batch_qty}
+	
 @frappe.whitelist()
 def apply_price_list(args):
 	"""


### PR DESCRIPTION
Hi,

with reference to: https://github.com/frappe/erpnext/issues/1873

When we select item in DN & SI, available total quantity at warehouse is displayed.
When we select Batch Id. system should show available quantity for that batch in warehouse.

It will be easy for sales person to decide order qty if he knows available batch quantity at the time of creating order.

I have added Available Batch Qty at Warehouse in Sales Order and Delivery Note.
Please let me know if there is any improvement about this issue.
Thanks,
Sambhaji
