### PR TITLE
update get_batch_no query to sort batch with expiry date

### DIFF
--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -232,7 +232,9 @@ def get_batch_no(doctype, txt, searchfield, start, page_len, filters):
 	from erpnext.controllers.queries import get_match_cond
 
 	if filters.has_key('warehouse'):
-		return frappe.db.sql("""select batch_no from `tabStock Ledger Entry` sle
+		return frappe.db.sql("""select batch_no, round(sum(actual_qty),2), stock_uom, expiry_date from `tabStock Ledger Entry` sle
+			    INNER JOIN `tabBatch`
+				on sle.batch_no = `tabBatch`.batch_id 
 				where item_code = '%(item_code)s'
 					and warehouse = '%(warehouse)s'
 					and batch_no like '%(txt)s'
@@ -242,7 +244,7 @@ def get_batch_no(doctype, txt, searchfield, start, page_len, filters):
 								and docstatus != 2)
 					%(mcond)s
 				group by batch_no having sum(actual_qty) > 0
-				order by batch_no desc
+				order by expiry_date,batch_no desc
 				limit %(start)s, %(page_len)s """ % {'item_code': filters['item_code'],
 					'warehouse': filters['warehouse'], 'posting_date': filters['posting_date'],
 					'txt': "%%%s%%" % txt, 'mcond':get_match_cond(doctype),

--- a/erpnext/selling/sales_common.js
+++ b/erpnext/selling/sales_common.js
@@ -481,16 +481,18 @@ erpnext.selling.SellingController = erpnext.TransactionController.extend({
 	batch_no: function(doc, cdt, cdn) {
 		var me = this;
 		var item = frappe.get_doc(cdt, cdn);
-	    return this.frm.call({
-	        method: "erpnext.stock.get_item_details.get_batch_qty",
-	        child: item,
-	        args: {
-	           "batch_no": item.batch_no,
-	           "warehouse": item.warehouse,
-	           "item_code": item.item_code
-	        },
-	         "fieldname": "actual_batch_qty"
-	    });
+		if(item.item_code) {		
+		    return this.frm.call({
+		        method: "erpnext.stock.get_item_details.get_batch_qty",
+		        child: item,
+		        args: {
+		           "batch_no": item.batch_no,
+		           "warehouse": item.warehouse,
+		           "item_code": item.item_code
+		        },
+		         "fieldname": "actual_batch_qty"
+		    });
+		}
 	},
 
 	set_dynamic_labels: function() {


### PR DESCRIPTION
with reference to https://github.com/frappe/erpnext/issues/2592

I have updated get_batch_no query,

1) Batch Id is sorted with expiry date
2) actual stock quantity and stock_uom for that warehouse is also shown in drop down.
3) I have done some more changes.
**Batch ID**
actual_batch_qty,stock_uom
expirary_date
In my case it will show,
**RN - A**
75.0,Drum, 2015-03-13

I have tried my best to keep result generic and useful for every industry.

If you want to more improvement, all suggestion are welcome.
This will helpful to take quick decision

4) I have also added small fix to my previous pull request #2942
If we select batch number before selecting item_code. it will give error message get_batch_qty takes 3 argument you given 1.

New fix will avoid this error message and shows "Please enter Item Code to get batch no"
Thanks for accepting my last request. I am really learning clean coding from you, which is very helpful for me.

Thanks,
Sambhaji
