### PR TITLE
Production Order - Validation Added

### DIFF
--- a/erpnext/manufacturing/doctype/production_order/production_order.py
+++ b/erpnext/manufacturing/doctype/production_order/production_order.py
@@ -42,6 +42,8 @@ class ProductionOrder(Document):
 		self.validate_warehouse()
 		self.calculate_operating_cost()
 		self.validate_delivery_date()
+		self.validate_qty()
+		self.validate_operation_time()
 
 		from erpnext.utilities.transaction_base import validate_uom_is_integer
 		validate_uom_is_integer(self, "stock_uom", ["qty", "produced_qty"])
@@ -327,6 +329,15 @@ class ProductionOrder(Document):
 			frappe.throw(_("Production Order cannot be raised against a Item Template"), ItemHasVariantError)
 
 		validate_end_of_life(self.production_item)
+		
+	def validate_qty(self):
+		if not self.qty > 0:
+			frappe.throw(_("Quantity to Manufacture must be greater than 0."))
+			
+	def validate_operation_time(self):
+		for d in self.operations:
+			if not d.time_in_mins > 0:
+				frappe.throw(_("Operation Time must be greater than 0 for Operation {0}".format(d.operation))) 
 
 @frappe.whitelist()
 def get_item_details(item):

--- a/erpnext/manufacturing/doctype/production_order_operation/production_order_operation.json
+++ b/erpnext/manufacturing/doctype/production_order_operation/production_order_operation.json
@@ -276,7 +276,7 @@
    "print_hide": 0, 
    "read_only": 0, 
    "report_hide": 0, 
-   "reqd": 0, 
+   "reqd": 1, 
    "search_index": 0, 
    "set_only_once": 0, 
    "unique": 0
@@ -476,7 +476,7 @@
  "is_submittable": 0, 
  "issingle": 0, 
  "istable": 1, 
- "modified": "2015-08-19 12:45:53.834920", 
+ "modified": "2015-08-21 07:17:18.185276", 
  "modified_by": "Administrator", 
  "module": "Manufacturing", 
  "name": "Production Order Operation", 


### PR DESCRIPTION
- [X] Added validation to prevent creation of production orders with manufacturing qty 0
- [X] Made Operation Time mandatory in Production Order Operation Table
- [X] Added validation to prevent creation of Production Orders with operations & operation time 0

Fixed #3918  
