### PR TITLE
Update get_item_details.py

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -200,7 +200,8 @@ def get_default_expense_account(args, item):
 def get_default_cost_center(args, item):
 	return (frappe.db.get_value("Project", args.get("project_name"), "cost_center")
 		or (item.selling_cost_center if args.get("transaction_type") == "selling" else item.buying_cost_center)
-		or frappe.db.get_value("Item Group", item.item_group, "default_cost_center"))
+		or frappe.db.get_value("Item Group", item.item_group, "default_cost_center")
+		or args.get("cost_center"))
 
 def get_price_list_rate(args, item_doc, out):
 	meta = frappe.get_meta(args.parenttype)


### PR DESCRIPTION
like this it will be possible to correctly handle cost center for stock entries when no default cost center per company is set
