### PR TITLE
Numeric attribute selector, smart selection of variant based on attribute combinations

### DIFF
--- a/erpnext/templates/generators/item.html
+++ b/erpnext/templates/generators/item.html
@@ -29,7 +29,8 @@
 				<div class="item-attribute-selectors">
                     {% if has_variants %}
                     {% for d in attributes %}
-                    <div class="item-view-attribute"
+					{% if attribute_values[d.attribute] -%}
+                    <div class="item-view-attribute {% if (attribute_values[d.attribute] | len)==1 -%} hidden {%- endif %}"
                             style="margin-bottom: 10px;">
                         <h6 class="text-muted">{{ _(d.attribute) }}</h6>
                         <select class="form-control"
@@ -37,12 +38,17 @@
                             data-attribute="{{ d.attribute }}">
 						{% for value in attribute_values[d.attribute] %}
                         <option value="{{ value }}"
-							{% if selected_attributes and selected_attributes[d.attribute]==value -%} selected {%- endif %}>
+						{% if selected_attributes and selected_attributes[d.attribute]==value -%}
+							selected
+						{%- elif disabled_attributes and value in disabled_attributes.get(d.attribute, []) -%}
+							disabled
+						{%- endif %}>
 							{{ _(value) }}
 						</option>
                         {% endfor %}
                         </select>
                     </div>
+					{%- endif %}
                     {% endfor %}
                     {% endif %}
 				</div>

--- a/erpnext/templates/includes/product_page.js
+++ b/erpnext/templates/includes/product_page.js
@@ -64,8 +64,23 @@ frappe.ready(function() {
 		});
 	});
 
-	$("[itemscope] .item-view-attribute select").on("change", function() {
-		var item_code = encodeURIComponent(get_item_code());
+	$("[itemscope] .item-view-attribute .form-control").on("change", function() {
+		try {
+			var item_code = encodeURIComponent(get_item_code());
+		} catch(e) {
+			// unable to find variant
+			// then chose the closest available one
+
+			var attribute = $(this).attr("data-attribute");
+			var attribute_value = $(this).val()
+			var item_code = update_attribute_selectors(attribute, attribute_value);
+
+			if (!item_code) {
+				msgprint(__("Please select some other value for {0}", [attribute]))
+				throw e;
+			}
+		}
+
 		if (window.location.search.indexOf(item_code)!==-1) {
 			return;
 		}
@@ -83,10 +98,8 @@ var toggle_update_cart = function(qty) {
 
 function get_item_code() {
 	if(window.variant_info) {
-		attributes = {};
-		$('[itemscope]').find(".item-view-attribute select").each(function() {
-			attributes[$(this).attr('data-attribute')] = $(this).val();
-		});
+		var attributes = get_selected_attributes();
+
 		for(var i in variant_info) {
 			var variant = variant_info[i];
 			var match = true;
@@ -105,4 +118,54 @@ function get_item_code() {
 	} else {
 		return item_code;
 	}
+}
+
+function update_attribute_selectors(selected_attribute, selected_attribute_value) {
+	// find the closest match keeping the selected attribute in focus and get the item code
+
+	var attributes = get_selected_attributes();
+
+	var previous_match_score = 0;
+	var matched;
+	for(var i in variant_info) {
+		var variant = variant_info[i];
+		var match_score = 0;
+		var has_selected_attribute = false;
+
+		console.log(variant);
+
+		for(var j in variant.attributes) {
+			if(attributes[variant.attributes[j].attribute]===variant.attributes[j].attribute_value) {
+				match_score = match_score + 1;
+
+				if (variant.attributes[j].attribute==selected_attribute && variant.attributes[j].attribute_value==selected_attribute_value) {
+					has_selected_attribute = true;
+				}
+			}
+		}
+
+		if (has_selected_attribute && (match_score > previous_match_score)) {
+			previous_match_score = match_score;
+			matched = variant;
+		}
+	}
+
+	if (matched) {
+		for (var j in matched.attributes) {
+			var attr = matched.attributes[j];
+			$('[itemscope]')
+				.find(repl('.item-view-attribute .form-control[data-attribute="%(attribute)s"]', attr))
+				.val(attr.attribute_value);
+		}
+
+		return matched.name;
+	}
+}
+
+function get_selected_attributes() {
+	var attributes = {};
+	$('[itemscope]').find(".item-view-attribute .form-control").each(function() {
+		attributes[$(this).attr('data-attribute')] = $(this).val();
+	});
+	return attributes;
 }


### PR DESCRIPTION
![variant attribute selection](https://cloud.githubusercontent.com/assets/836785/10731636/60d481c4-7c1c-11e5-8a22-374aa5ad1603.gif)
- [x] Dropdown for numeric attributes
- [x] Hide attribute selection if there is only 1 option
- [x] If a combination does not exist for the selected attribute, select the closest match that is available. In the example, when Blue is selected, only 0.7 length is available for Blue and so, that combination is selected.
- [x] Disable combinations that don't exist. For Blue, length of 0.2 and 0.5 don't exist so that is disabled.
