### PR TITLE
[fix] Don't show Receive for a Purchase Order having non-stock items, show Close button only for users with Submit rights

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -21,11 +21,13 @@ erpnext.buying.PurchaseOrderController = erpnext.buying.BuyingController.extend(
 
 		if(doc.docstatus == 1 && !in_list(["Stopped", "Closed", "Delivered"], doc.status)) {
 
-			if(flt(doc.per_billed, 2) < 100 || doc.per_received < 100) {
-				cur_frm.add_custom_button(__('Stop'), this.stop_purchase_order);
-			}
+			if (this.frm.has_perm("submit")) {
+				if(flt(doc.per_billed, 2) < 100 || doc.per_received < 100) {
+					cur_frm.add_custom_button(__('Stop'), this.stop_purchase_order);
+				}
 
-			cur_frm.add_custom_button(__('Close'), this.close_purchase_order);
+				cur_frm.add_custom_button(__('Close'), this.close_purchase_order);
+			}
 
 			if(doc.delivered_by_supplier && doc.status!="Delivered"){
 				cur_frm.add_custom_button(__('Mark as Delivered'), this.delivered_by_supplier);
@@ -35,7 +37,7 @@ erpnext.buying.PurchaseOrderController = erpnext.buying.BuyingController.extend(
 				cur_frm.add_custom_button(__('Payment'), cur_frm.cscript.make_bank_entry);
 			}
 
-			if(flt(doc.per_received, 2) < 100) {
+			if(flt(doc.per_received, 2) < 100 && this.frm.doc.__onload.has_stock_item) {
 				cur_frm.add_custom_button(__('Receive'), this.make_purchase_receipt).addClass("btn-primary");
 
 				if(doc.is_subcontracted==="Yes") {
@@ -53,7 +55,9 @@ erpnext.buying.PurchaseOrderController = erpnext.buying.BuyingController.extend(
 		}
 
 		if(doc.docstatus == 1 && in_list(["Stopped", "Closed", "Delivered"], doc.status)) {
-			cur_frm.add_custom_button(__('Re-open'), this.unstop_purchase_order);
+			if (this.frm.has_perm("submit")) {
+				cur_frm.add_custom_button(__('Re-open'), this.unstop_purchase_order);
+			}
 		}
 	},
 

--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -33,6 +33,9 @@ class PurchaseOrder(BuyingController):
 			'overflow_type': 'order'
 		}]
 
+	def onload(self):
+		self.set_onload("has_stock_item", len(self.get_stock_items()) > 0)
+
 	def validate(self):
 		super(PurchaseOrder, self).validate()
 

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -56,13 +56,15 @@ erpnext.selling.SalesOrderController = erpnext.selling.SellingController.extend(
 					cur_frm.add_custom_button(__('Payment'), cur_frm.cscript.make_bank_entry);
 				}
 
-				// stop
-				if(flt(doc.per_delivered, 2) < 100 || flt(doc.per_billed) < 100) {
-						cur_frm.add_custom_button(__('Stop'), this.stop_sales_order)
-					}
+				if (this.frm.has_perm("submit")) {
+					// stop
+					if(flt(doc.per_delivered, 2) < 100 || flt(doc.per_billed) < 100) {
+							cur_frm.add_custom_button(__('Stop'), this.stop_sales_order)
+						}
 
 
-				cur_frm.add_custom_button(__('Close'), this.close_sales_order)
+					cur_frm.add_custom_button(__('Close'), this.close_sales_order)
+				}
 
 				// maintenance
 				if(flt(doc.per_delivered, 2) < 100 && ["Sales", "Shopping Cart"].indexOf(doc.order_type)===-1) {
@@ -82,8 +84,10 @@ erpnext.selling.SalesOrderController = erpnext.selling.SellingController.extend(
 
 
 			} else {
-				// un-stop
-				cur_frm.add_custom_button(__('Re-open'), cur_frm.cscript['Unstop Sales Order']);
+				if (this.frm.has_perm("submit")) {
+					// un-stop
+					cur_frm.add_custom_button(__('Re-open'), cur_frm.cscript['Unstop Sales Order']);
+				}
 			}
 		}
 


### PR DESCRIPTION
There's just one problem: the indicator shows "To Receive and Bill"

@rmehta what do you suggest?

![image](https://cloud.githubusercontent.com/assets/836785/11119160/994415d4-896d-11e5-8760-8de0ac0b949d.png)
