### PR TITLE
 Fix for Issue #4543: Automatic item_code generation for variants when parent item is named after a Naming Series

### DIFF
--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -30,14 +30,15 @@ class Item(WebsiteGenerator):
 		self.get("__onload").sle_exists = self.check_if_sle_exists()
 
 	def autoname(self):
-		if frappe.db.get_default("item_naming_by")=="Naming Series" and not self.variant_of:
-			from frappe.model.naming import make_autoname
-			self.item_code = make_autoname(self.naming_series+'.#####')
-		elif frappe.db.get_default("item_naming_by")=="Naming Series" and self.variant_of:
-			item_code_suffix = ""
-			for attribute in self.attributes:
-				item_code_suffix += "-" + str(attribute.attribute_value)
-			self.item_code = str(self.variant_of) + item_code_suffix
+		if frappe.db.get_default("item_naming_by")=="Naming Series":
+			if self.variant_of:
+				item_code_suffix = ""
+				for attribute in self.attributes:
+					item_code_suffix += "-" + str(attribute.attribute_value)
+				self.item_code = str(self.variant_of) + item_code_suffix
+			else:
+				from frappe.model.naming import make_autoname
+				self.item_code = make_autoname(self.naming_series+'.#####')
 		elif not self.item_code:
 			msgprint(_("Item Code is mandatory because Item is not automatically numbered"), raise_exception=1)
 

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -34,7 +34,8 @@ class Item(WebsiteGenerator):
 			if self.variant_of:
 				item_code_suffix = ""
 				for attribute in self.attributes:
-					item_code_suffix += "-" + str(attribute.attribute_value)
+					attribute_abbr = frappe.db.get_value("Item Attribute Value", {"parent": attribute.attribute, "attribute_value": attribute.attribute_value}, "abbr")
+					item_code_suffix += "-" + str(attribute_abbr or attribute.attribute_value)
 				self.item_code = str(self.variant_of) + item_code_suffix
 			else:
 				from frappe.model.naming import make_autoname

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -33,6 +33,11 @@ class Item(WebsiteGenerator):
 		if frappe.db.get_default("item_naming_by")=="Naming Series" and not self.variant_of:
 			from frappe.model.naming import make_autoname
 			self.item_code = make_autoname(self.naming_series+'.#####')
+		elif frappe.db.get_default("item_naming_by")=="Naming Series" and self.variant_of:
+			item_code_suffix = ""
+			for attribute in self.attributes:
+				item_code_suffix += "-" + str(attribute.attribute_value)
+			self.item_code = str(self.variant_of) + item_code_suffix
 		elif not self.item_code:
 			msgprint(_("Item Code is mandatory because Item is not automatically numbered"), raise_exception=1)
 


### PR DESCRIPTION
 Fix for Issue #4543: Automatic item_code generation for variants when parent item is named after a Naming Series. 

This will handle the creation of the new code by appending to the parent product item code the concatenated attribute values with dashes. So for product `SERIES-00003` and for `NumericAttribute1=5`, `Color=RED` the new item code would be `SERIES-00003-5-RED`
