### PR TITLE
Fix for Error "ValueError: No JSON object could be decoded"

### DIFF
--- a/erpnext/accounts/page/accounts_browser/accounts_browser.py
+++ b/erpnext/accounts/page/accounts_browser/accounts_browser.py
@@ -26,9 +26,9 @@ def get_children():
 		acc = frappe.db.sql(""" select
 			name as value, is_group as expandable %s
 			from `tab%s`
-			where ifnull(parent_%s,'') = ''
+			where ifnull(`parent_%s`,'') = ''
 			and `company` = %s	and docstatus<2
-			order by name""" % (select_cond, ctype, ctype.lower().replace(' ','_'), '%s'),
+			order by name""" % (select_cond, frappe.db.escape(ctype), frappe.db.escape(ctype.lower().replace(' ','_')), '%s'),
 				company, as_dict=1)
 
 		if args["parent"]=="Accounts":
@@ -38,9 +38,9 @@ def get_children():
 		acc = frappe.db.sql("""select
 			name as value, is_group as expandable
 	 		from `tab%s`
-			where ifnull(parent_%s,'') = %s
+			where ifnull(`parent_%s`,'') = %s
 			and docstatus<2
-			order by name""" % (ctype, ctype.lower().replace(' ','_'), '%s'),
+			order by name""" % (frappe.db.escape(ctype), frappe.db.escape(ctype.lower().replace(' ','_')), '%s'),
 				args['parent'], as_dict=1)
 
 	if ctype == 'Account':

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -62,7 +62,7 @@ def get_balance_on(account=None, date=None, party_type=None, party=None):
 
 	cond = []
 	if date:
-		cond.append("posting_date <= '%s'" % date)
+		cond.append("posting_date <= '%s'" % frappe.db.escape(date))
 	else:
 		# get balance of all entries that exist
 		date = nowdate()
@@ -95,12 +95,12 @@ def get_balance_on(account=None, date=None, party_type=None, party=None):
 				and ac.lft >= %s and ac.rgt <= %s
 			)""" % (acc.lft, acc.rgt))
 		else:
-			cond.append("""gle.account = "%s" """ % (account.replace('"', '\\"'), ))
+			cond.append("""gle.account = "%s" """ % (frappe.db.escape(account),))
 
 	if party_type and party:
 		cond.append("""gle.party_type = "%s" and gle.party = "%s" """ %
-			(party_type.replace('"', '\\"'), party.replace('"', '\\"')))
-			
+			(frappe.db.escape(party_type), frappe.db.escape(party)))
+
 	if account or (party_type and party):
 		bal = frappe.db.sql("""
 			SELECT sum(ifnull(debit, 0)) - sum(ifnull(credit, 0))


### PR DESCRIPTION
Issue: There is an error appear "ValueError: No JSON object could be decoded" when data is sent from SAP to ERPNext in http request body.

Root cause: Http request is not well formed on SAP side, as result no data is coming to ERPNext.

Description: The issue was fixed on SAP side by forming http request which ERPNext could process.

Notes:
Http request is still coming to ERPNext not completely in expected format: the data are present in request body but not in form data.
I've added the following code to ERPNext to handle this case:

file frappe-bench/apps/frappe/frappe/app.py:
--- app.py.old 2015-11-18 16:47:40.297103843 +0530
+++ app.py.new 2015-11-20 23:48:44.482411978 +0530
@@ -70,10 +70,6 @@
response = frappe.handler.handle()

```
        elif frappe.request.path.startswith("/api/"):
```

+
- if frappe.local.form_dict.data is None:
- frappe.local.form_dict.data = request.get_data()
- response = frappe.api.handle()
  
  ```
      elif frappe.request.path.startswith('/backups'):
  ```
  
  Also in regards to the max 100 row Validation in the Stock Reconciliation Document, we have commented out the following code part:

75> if len(self.items) > 100:
76> frappe.throw(_("""Max 100 rows for Stock Reconciliation."""))

@rmehta If it would be possible to include the first HTTP change to the core version as well as to add an option to submit a flag thru the HTTP call to eliminate the 100-row validation, that would be great.

Thanks, David
