### PR TITLE
Conversion_rate not applicable for type 'Supplier'

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -155,6 +155,8 @@ def get_pricing_rule_for_item(args):
 	if pricing_rule:
 		item_details.pricing_rule = pricing_rule.name
 		item_details.pricing_rule_for = pricing_rule.price_or_discount
+		if pricing_rule.applicable_for == "Supplier":
+			args.conversion_rate = 1
 		if pricing_rule.price_or_discount == "Price":
 			item_details.update({
 				"price_list_rate": pricing_rule.price/flt(args.conversion_rate) \


### PR DESCRIPTION
If the type is supplier, then the conversion rate is not applicable because the pricing rule is already in the currency of the supplier.

[Issue #4710 ](https://github.com/frappe/erpnext/issues/4710)
