### PR TITLE
undo bank recon.

### DIFF
--- a/erpnext/accounts/doctype/bank_reconciliation/bank_reconciliation.py
+++ b/erpnext/accounts/doctype/bank_reconciliation/bank_reconciliation.py
@@ -52,6 +52,8 @@ class BankReconciliation(Document):
 					frappe.throw(_("Clearance date cannot be before check date in row {0}").format(d.idx))
 
 			if d.clearance_date or self.include_reconciled_entries:
+				if not d.clearance_date:
+					d.clearance_date = None
 				frappe.db.set_value("Journal Entry", d.voucher_id, "clearance_date", d.clearance_date)
 				frappe.db.sql("""update `tabJournal Entry` set clearance_date = %s, modified = %s
 					where name=%s""", (d.clearance_date, nowdate(), d.voucher_id))


### PR DESCRIPTION
set to null if clearance_date is blank because if not it will set it just 0000-00-00
