### PR TITLE
Corrected typo while translating

### DIFF
--- a/erpnext/docs/user/manual/en/manufacturing/production-order.md
+++ b/erpnext/docs/user/manual/en/manufacturing/production-order.md
@@ -28,7 +28,7 @@ by:
 
 <img class="screenshot" alt="PO Opeartions" src="{{docs_base_url}}/assets/img/manufacturing/PO-operations.png">
 
-* If you wish to reassign the wrokstation for a particular opeeration in the Production Order, you can do so before submitting the Production Order.
+* If you wish to reassign the workstation for a particular opeeration in the Production Order, you can do so before submitting the Production Order.
 
 <img class="screenshot" alt="PO reassigning Operations" src="{{docs_base_url}}/assets/img/manufacturing/PO-reassigning-operations.png">
 


### PR DESCRIPTION
Found a switch of letters:  "wrokstation" instead of "workstation".  Corrected the item appropriately.  Found this while translating my fork of this page to spanish.
