### PR TITLE
[fix] reorder items

### DIFF
--- a/erpnext/stock/reorder_item.py
+++ b/erpnext/stock/reorder_item.py
@@ -48,7 +48,7 @@ def _reorder_item():
 		# projected_qty will be 0 if Bin does not exist
 		projected_qty = flt(item_warehouse_projected_qty.get(item_code, {}).get(warehouse))
 
-		if reorder_level and projected_qty <= reorder_level:
+		if reorder_level and projected_qty < reorder_level:
 			deficiency = reorder_level - projected_qty
 			if deficiency > reorder_qty:
 				reorder_qty = deficiency


### PR DESCRIPTION
To test this issue:
Create new Item with 'Maintain Stock' and reorder_level=1 reorder_qty=1
Create and submit a Sales Order with 2 units of previous item.
For two days pass in two minutes: move tasks "erpnext.stock.reorder_item.reorder_item" from "daily" to "all" in hooks.py and DEFAULT_SCHEDULER_INTERVAL from 300 to 60 in celery_app.py

First run task: this will make a 'Material Request' with 3 units of the item, up here all right.

Second run task: this will make a second 'Material Request' with 1 units. I think this is wrong.
