### PR TITLE
Allow reorder_level to be set to 0

### DIFF
--- a/erpnext/stock/reorder_item.py
+++ b/erpnext/stock/reorder_item.py
@@ -48,7 +48,7 @@ def _reorder_item():
 		# projected_qty will be 0 if Bin does not exist
 		projected_qty = flt(item_warehouse_projected_qty.get(item_code, {}).get(warehouse))
 
-		if reorder_level and projected_qty <= reorder_level:
+		if (reorder_level or reorder_qty) and projected_qty < reorder_level:
 			deficiency = reorder_level - projected_qty
 			if deficiency > reorder_qty:
 				reorder_qty = deficiency

--- a/erpnext/stock/report/stock_projected_qty/stock_projected_qty.py
+++ b/erpnext/stock/report/stock_projected_qty/stock_projected_qty.py
@@ -47,7 +47,7 @@ def get_data(filters):
 				re_order_level = d.warehouse_reorder_level
 				re_order_qty = d.warehouse_reorder_qty
 
-		shortage_qty = re_order_level - flt(bin.projected_qty) if re_order_level else 0
+		shortage_qty = re_order_level - flt(bin.projected_qty) if (re_order_level or re_order_qty) else 0
 
 		data.append([item.name, item.item_name, item.description, item.item_group, item.brand, bin.warehouse,
 			item.stock_uom, bin.actual_qty, bin.planned_qty, bin.indented_qty, bin.ordered_qty,


### PR DESCRIPTION
For items you don’t want to keep in stock, you can set the reorder_level to 0 and just define reorder_qty.

If there is e.g. a sales order for that item, the projected quantity will fall below 0, which will trigger an automatic material request.

Includes #4791 
