### PR TITLE
[fix] add subscribers even though some emails are invalid

### DIFF
--- a/erpnext/crm/doctype/newsletter_list/newsletter_list.py
+++ b/erpnext/crm/doctype/newsletter_list/newsletter_list.py
@@ -67,9 +67,9 @@ def add_subscribers(name, email_list):
 	count = 0
 	for email in email_list:
 		email = email.strip()
-		validate_email_add(email, True)
+		valid = validate_email_add(email, False)
 
-		if email:
+		if valid:
 			if not frappe.db.get_value("Newsletter List Subscriber",
 				{"newsletter_list": name, "email": email}):
 				frappe.get_doc({
@@ -81,6 +81,8 @@ def add_subscribers(name, email_list):
 				count += 1
 			else:
 				pass
+		else:
+			frappe.msgprint(_("{0} is not a valid email id").format(email))
 
 	frappe.msgprint(_("{0} subscribers added").format(count))
 


### PR DESCRIPTION
If you want to add a long list of subscribers and some emails are invalid then you need fix / remove these emails before you add them to a newsletter list in erpnext, with this fix all invalid emails are ignored and the rest emails are added.
