### PR TITLE
Create at_austria_chart_Einheitskontenrahmen.json

### DIFF
--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/at_austria_chart_Einheitskontenrahmen.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/at_austria_chart_Einheitskontenrahmen.json
@@ -1,0 +1,414 @@
+{
+    "country_code": "at",
+    "name": "Austria - Chart of Accounts - Einheitskontenrahmen provided by fairkom.eu",
+    "tree": {
+        "Klasse 0 Aktiva: Anlageverm\u00f6gen": {
+				"0100 Konzessionen ": {"account_type": "Fixed Asset"},
+				"0110 Patentrechte und Lizenzen ": {"account_type": "Fixed Asset"},
+				"0120 Datenverarbeitungsprogramme ": {"account_type": "Fixed Asset"},
+				"0130 Marken, Warenzeichen und Musterschutzrechte, sonstige Urheberrechte ": {"account_type": "Fixed Asset"},
+				"0140 Pacht- und Mietrechte ": {"account_type": "Fixed Asset"},
+				"0150 Bezugs- und ähnliche Rechte ": {"account_type": "Fixed Asset"},
+				"0160 Geschäfts-/Firmenwert ": {"account_type": "Fixed Asset"},
+				"0170 Umgründungsmehrwert ": {"account_type": "Fixed Asset"},
+				"0180 Geleistete Anzahlungen auf immaterielle Vermögensgegenstände": {"account_type": "Fixed Asset"},
+				"0190 Kumulierte Abschreibungen zu immateriellen Vermögensgegenständen ": {"account_type": "Fixed Asset"},
+				"0200 Unbebaute Grundstücke, soweit nicht landwirtschaftlich genutzt ": {"account_type": "Fixed Asset"},
+				"0210 Bebaute Grundstücke (Grundwert) ": {"account_type": "Fixed Asset"},
+				"0220 Landwirtschaftlich genutzte Grundstücke ": {"account_type": "Fixed Asset"},
+				"0230 Grundstücksgleiche Rechte ": {"account_type": "Fixed Asset"},
+				"0300 Betriebs- und Geschäftsgebäude auf eigenem Grund ": {"account_type": "Fixed Asset"},
+				"0310 Wohn- und Sozialgebäude auf eigenem Grund ": {"account_type": "Fixed Asset"},
+				"0320 Betriebs- und Geschäftsgebäude auf fremdem Grund ": {"account_type": "Fixed Asset"},
+				"0330 Wohn- und Sozialgebäude auf fremdem Grund ": {"account_type": "Fixed Asset"},
+				"0340 Grundstückseinrichtungen auf eigenem Grund ": {"account_type": "Fixed Asset"},
+				"0350 Grundstückseinrichtungen auf fremdem Grund ": {"account_type": "Fixed Asset"},
+				"0360 Bauliche Investitionen in fremden (gepachteten) Betriebs- und Geschäftsgebäuden": {"account_type": "Fixed Asset"},
+				"0370 Bauliche Investitionen in fremden (gepachteten) Wohn- und Sozialgebäuden": {"account_type": "Fixed Asset"},
+				"0390 Kumulierte Abschreibungen zu Grundstücken ": {"account_type": "Fixed Asset"},
+				"0400 Maschinen und Geräte ": {"account_type": "Fixed Asset"},				
+				"0500 Maschinenwerkzeuge ": {"account_type": "Fixed Asset"},
+				"0510 Allgemeine Werkzeuge und Handwerkzeuge ": {"account_type": "Fixed Asset"},
+				"0520 Prototypen, Formen, Modelle ": {"account_type": "Fixed Asset"},
+				"0530 Andere Erzeugungshilfsmittel (auch Softwarewerkzeuge)": {"account_type": "Fixed Asset"},
+				"0540 Hebezeuge und Montageanlagen ": {"account_type": "Fixed Asset"},
+				"0550 Geringwertige Vermögensgegenstände, soweit im Erzeugungsprozess ": {"account_type": "Fixed Asset"},
+				"0560 Festwerte technische Anlagen und Maschinen ": {"account_type": "Fixed Asset"},
+				"0590 Kumulierte Abschreibungen zu technischen Anlagen und Maschinen ": {"account_type": "Fixed Asset"},
+				"0600 Betriebs- und Geschäftsausstattung, soweit nicht gesondert angeführt ": {"account_type": "Fixed Asset"},
+				"0610 Andere Anlagen, soweit nicht gesondert angeführt ": {"account_type": "Fixed Asset"},
+				"0620 Büromaschinen, EDV-Anlagen ": {"account_type": "Fixed Asset"},
+				"0630 PKW und Kombis ": {"account_type": "Fixed Asset"},
+				"0640 LKW ": {"account_type": "Fixed Asset"},
+				"0650 Andere Beförderungsmittel ": {"account_type": "Fixed Asset"},
+				"0660 Gebinde ": {"account_type": "Fixed Asset"},
+				"0670 Geringwertige Vermögensgegenstände, soweit nicht im Erzeugungssprozess verwendet": {"account_type": "Fixed Asset"},
+				"0680 Festwerte außer technische Anlagen und Maschinen ": {"account_type": "Fixed Asset"},
+				"0690 Kumulierte Abschreibungen zu anderen Anlagen, Betriebs- und Geschäftsausstattung": {"account_type": "Fixed Asset"},
+				"0700 Geleistete Anzahlungen auf Sachanlagen ": {"account_type": "Fixed Asset"},
+				"0710 Anlagen in Bau ": {"account_type": "Fixed Asset"},
+				"0790 Kumulierte Abschreibungen zu geleisteten Anzahlungen auf Sachanlagen ": {"account_type": "Fixed Asset"},
+				"0800 Anteile an verbundenen Unternehmen ": {"account_type": "Fixed Asset"},
+				"0810 Beteiligungen an Gemeinschaftsunternehmen ": {"account_type": "Fixed Asset"},
+				"0820 Beteiligungen an angeschlossenen (assoziierten) Unternehmen ": {"account_type": "Fixed Asset"},
+				"0830 Eigene Anteile, Anteile an herrschenden oder mit Mehrheit beteiligten ": {"account_type": "Fixed Asset"},
+				"0840 Sonstige Beteiligungen ": {"account_type": "Fixed Asset"},
+				"0850 Ausleihungen an verbundene Unternehmen ": {"account_type": "Fixed Asset"},
+				"0860 Ausleihungen an Unternehmen mit Beteiligungsverhältnis": {"account_type": "Fixed Asset"},
+				"0870 Ausleihungen an Gesellschafter ": {"account_type": "Fixed Asset"},
+				"0880 Sonstige Ausleihungen ": {"account_type": "Fixed Asset"},
+				"0890 Anteile an Kapitalgesellschaften ohne Beteiligungscharakter ": {"account_type": "Fixed Asset"},
+				"0900 Anteile an Personengesellschaften ohne Beteiligungscharakter ": {"account_type": "Fixed Asset"},
+				"0910 Genossenschaftsanteile ohne Beteiligungscharakter ": {"account_type": "Fixed Asset"},
+				"0920 Anteile an Investmentfonds ": {"account_type": "Fixed Asset"},
+				"0930 Festverzinsliche Wertpapiere des Anlagevermögens ": {"account_type": "Fixed Asset"},
+				"0980 Geleistete Anzahlungen auf Finanzanlagen ": {"account_type": "Fixed Asset"},
+				"0990 Kumulierte Abschreibungen zu Finanzanlagen ": {"account_type": "Fixed Asset"},
+            "root_type": "Asset"
+        },    
+        "Klasse 1 Aktiva: Vorr\u00e4te": {
+            "1000 Bezugsverrechnung": {"account_type": "Stock"},
+            "1100 Rohstoffe": {"account_type": "Stock"},
+            "1200 Bezogene Teile": {"account_type": "Stock"},
+            "1300 Hilfsstoffe": {"account_type": "Stock"},
+            "1350 Betriebsstoffe": {"account_type": "Stock"},
+            "1360 Vorrat Energietraeger": {"account_type": "Stock"},            
+            "1400 Unfertige Erzeugnisse": {"account_type": "Stock"},
+            "1500 Fertige Erzeugnisse": {"account_type": "Stock"},
+            "1600 Handelswarenvorrat": {"account_type": "Stock Received But Not Billed"},
+            "1700 Noch nicht abrechenbare Leistungen": {"account_type": "Stock"},
+            "1900 Wertberichtigungen": {"account_type": "Stock"},
+            "1800 Geleistete Anzahlungen": {"account_type": "Stock"},
+            "root_type": "Asset"
+        },    
+        "Klasse 3 Passiva: Verbindlichkeiten": {
+            "3020 Steuerr\u00fcckstellungen": {"account_type": "Tax"},
+            "3040 Sonstige R\u00fcckstellungen": {"account_type": "Payable"},
+            "3110 Verbindlichkeiten gegen\u00fcber Bank": {"account_type": "Payable"},
+            "3150 Verbindlichkeiten Darlehen": {"account_type": "Payable"},
+            "3185 Verbindlichkeiten Kreditkarte": {"account_type": "Payable"},            
+            "3380 Verbindlichkeiten aus der Annahme gezogener Wechsel u. d. Ausstellungen eigener Wechsel": {
+                "account_type": "Payable"
+            },
+            "3400 Verbindlichkeiten gegen\u00fc. verb. Untern., Verbindl. gegen\u00fc. Untern., mit denen eine Beteiligungsverh\u00e4lnis besteht": {},
+            "3460 Verbindlichkeiten gegenueber Gesellschaftern": {"account_type": "Payable"},
+            "3470 Einlagen stiller Gesellschafter": {"account_type": "Payable"},
+            "3590 Verbindlichkeiten Kommunalabgaben": {"account_type": "Tax"},                        
+            "3600 Verbindlichkeiten Sozialversicherung": {"account_type": "Payable"},
+            "3000 Allgemeine Verbindlichkeiten (Schuld)": {"account_type": "Payable"},
+            "3700 Sonstige Verbindlichkeiten": {"account_type": "Payable"},
+            "3900 Passive Rechnungsabgrenzungsposten": {"account_type": "Payable"},
+            "3100 Anleihen (einschlie\u00dflich konvertibler)": {"account_type": "Payable"},
+            "3200 Erhaltene Anzahlungen auf Bestellungen": {"account_type": "Payable"},
+            "3040 R\u00fcckstellungen f\u00fcr Abfertigung": {"account_type": "Payable"},
+            "3010 R\u00fcckstellungen f\u00fcr Pensionen": {"account_type": "Payable"},
+            "3530 USt. \u00a719 (reverse charge)": {
+                "account_type": "Tax"
+            },
+            "3500 Verbindlichkeiten aus Umsatzsteuer": {"account_type": "Tax"},
+            "3580 Umsatzsteuer Zahllast": {
+                "account_type": "Tax"
+            },
+            "3510 Umsatzsteuer aus i.g. Erwerb 10%": {
+                "account_type": "Tax"
+            },
+            "3520 Umsatzsteuer aus i.g. Erwerb 20%": {
+                "account_type": "Tax"
+            },
+            "3560 Umsatzsteuer-Evidenzkonto f\u00fcr erhaltene Anzahlungen auf Bestellungen": {},
+            "3360 Verbindlichkeiten aus Lieferungen u. Leistungen EU": {
+                "account_type": "Payable"
+            },
+            "3000 Verbindlichkeiten aus Lieferungen u. Leistungen Inland": {
+                "account_type": "Payable"
+            },
+            "3370 Verbindlichkeiten aus Lieferungen u. Leistungen sonst. Ausland": {
+                "account_type": "Payable"
+            },
+            "3400 Verbindlichkeiten gegen\u00fcber verbundenen Unternehmen": {},
+            "3570 Verrechnung Finanzamt": {
+                "account_type": "Tax"
+            },
+            "root_type": "Liability"
+        },      
+        "Klasse 2 Aktiva: Umlaufverm\u00f6gen, Rechnungsabgrenzungen": {
+            "2030 Forderungen aus Lieferungen und Leistungen Inland (0% USt, umsatzsteuerfrei)": {
+                "account_type": "Receivable"
+            },
+            "2010 Forderungen aus Lieferungen und Leistungen Inland (10% USt, umsatzsteuerfrei)": {
+                "account_type": "Receivable"
+            },
+            "2000 Forderungen aus Lieferungen und Leistungen Inland (20% USt, umsatzsteuerfrei)": {
+                "account_type": "Receivable"
+            },
+            "2040 Forderungen aus Lieferungen und Leistungen Inland (sonstiger USt-Satz)": {
+                "account_type": "Receivable"
+            },                                    
+            "2100 Forderungen aus Lieferungen und Leistungen EU": {
+                "account_type": "Receivable"
+            },
+            "2150 Forderungen aus Lieferungen und Leistungen Ausland (Nicht-EU)": {
+                "account_type": "Receivable"
+            },
+            "2200 Forderungen gegen\u00fcber verbundenen Unternehmen": {
+                "account_type": "Receivable"
+            },
+            "2250 Forderungen gegen\u00fcber Unternehmen, mit denen ein Beteiligungsverh\u00e4ltnis besteht": {
+                "account_type": "Receivable"
+            },
+            "2300 Sonstige Forderungen und Verm\u00f6gensgegenst\u00e4nde": {
+                "account_type": "Receivable"
+            },
+            "2630 Sonstige Wertpapiere": {
+                "account_type": "Stock"
+            },
+            "2750 Kassenbest\u00e4nde in Fremdw\u00e4hrung": {
+                "account_type": "Cash"
+            },
+            "2900 Aktive Rechnungsabrenzungsposten": {
+                "account_type": "Receivable"
+            },
+            "2600 Anteile an verbundenen Unternehmen": {
+                "account_type": "Equity"
+            },
+            "2680 Besitzwechsel ohne Forderungen": {
+                "account_type": "Receivable"
+            },
+            "2950 Aktiviertes Disagio": {
+                "account_type": "Receivable"
+            },
+            "2610 Eigene Anteile und Wertpapiere an mit Mehrheit beteiligten Unternehmen": {
+                "account_type": "Receivable"
+            },
+            "2570 Einfuhrumsatzsteuer (bezahlt)": {"account_type": "Tax"},
+            
+            "2460 Eingeforderte aber noch nicht eingezahlte Einlagen": {
+                "account_type": "Receivable"
+            },
+            "2180 Einzelwertberichtigungen zu Forderungen aus Lief. und Leist. Ausland": {
+                "account_type": "Receivable"
+            },
+            "2130 Einzelwertberichtigungen zu Forderungen aus Lief. und Leist. EU": {
+                "account_type": "Receivable"
+            },
+            "2080 Einzelwertberichtigungen zu Forderungen aus Lief. und Leist. Inland ": {
+                "account_type": "Receivable"
+            },
+            "2270 Einzelwertberichtigungen zu Forderungen gegen\u00fcber Unternehmen mit denen ein Beteiligungsverh\u00e4ltnis besteht": {
+                "account_type": "Receivable"
+            },
+            "2230 Einzelwertberichtigungen zu Forderungen gegen\u00fcber verbundenen Unternehmen": {
+                "account_type": "Receivable"
+            },
+            "2470 Einzelwertberichtigungen zu sonstigen Forderungen und Verm\u00f6gensgegenst\u00e4nden": {
+                "account_type": "Receivable"
+            },
+            "2700 Kassenbestand": {
+                "account_type": "Cash"
+            },
+            "2190 Pauschalwertberichtigungen zu Forderungen aus Lief. und Leist. sonstiges Ausland": {
+                "account_type": "Receivable"
+            },
+            "2130 Pauschalwertberichtigungen zu Forderungen aus Lief. und Leist. EU": {
+                "account_type": "Receivable"
+            },
+            "2100 Pauschalwertberichtigungen zu Forderungen aus Lief. und Leist. Inland ": {
+                "account_type": "Receivable"
+            },
+            "2280 Pauschalwertberichtigungen zu Forderungen gegen\u00fcber Unternehmen mit denen ein Beteiligungsverh\u00e4ltnis besteht": {
+                "account_type": "Receivable"
+            },
+            "2240 Pauschalwertberichtigungen zu Forderungen gegen\u00fcber verbundenen Unternehmen": {
+                "account_type": "Receivable"
+            },
+            "2480 Pauschalwertberichtigungen zu sonstigen Forderungen und Verm\u00f6gensgegenst\u00e4nden": {
+                "account_type": "Receivable"
+            },
+            "2740 Postwertzeichen": {
+                "account_type": "Cash"
+            },
+            "2780 Schecks in Euro": {
+                "account_type": "Cash"
+            },
+            "2800 Guthaben bei Kreditinstitut": {
+                "account_type": "Bank"
+            },            
+            "2810 Guthaben bei Paypal": {
+                "account_type": "Bank"
+            },
+            "2930 Mietvorauszahlungen": {
+                "account_type": "Receivable"
+            },
+            "2980 Abgrenzung latenter Steuern": {
+                "account_type": "Receivable"
+            },
+            "2500 Vorsteuer": {
+                "account_type": "Receivable"
+            },
+            "2510 Vorsteuer aus innergemeinschaftlichem Erwerb 10%": {
+                "account_type": "Tax"
+            },
+            "2520 Vorsteuer aus innergemeinschaftlichem Erwerb 20%": {
+                "account_type": "Tax"
+            },
+            "2530 Vorsteuer \u00a719/Art 19 ( reverse charge ) ": {
+                "account_type": "Tax"
+            },
+            "2690 Wertberichtigungen zu Wertpapieren und Anteilen": {
+                "account_type": "Receivable"
+            },
+            "root_type": "Asset"
+        },
+          "Klasse 4: Betriebliche Erträge": {
+            "4000 Erlöse 20 %": {"account_type": "Income Account"},          
+            "4020 Erl\u00f6se 0 % steuerbefreit": {"account_type": "Income Account"},            
+            "4010 Erl\u00f6se 10 %": {"account_type": "Income Account"},
+            "4030 Erl\u00f6se 13 %": {"account_type": "Income Account"},            
+            "4040 Erl\u00f6se 0 % innergemeinschaftliche Lieferungen": {"account_type": "Income Account"},      
+            "4400 Erl\u00f6sreduktion 0 % steuerbefreit": {"account_type": "Expense Account"},            
+            "4410 Erl\u00f6sreduktion 10 %": {"account_type": "Expense Account"},
+            "4420 Erl\u00f6sreduktion 20 %": {"account_type": "Expense Account"},
+            "4430 Erl\u00f6sreduktion 13 %": {"account_type": "Expense Account"},            
+            "4440 Erl\u00f6sreduktion 0 % innergemeinschaftliche Lieferungen": {"account_type": "Expense Account"}, 
+            "4500 Ver\u00e4nderungen des Bestandes an fertigen und unfertigen Erzeugn. sowie an noch nicht abrechenbaren Leistungen": {"account_type": "Income Account"},
+            "4580 Aktivierte Eigenleistungen": {"account_type": "Income Account"},
+            "4600 Erl\u00f6se aus dem Abgang vom Anlageverm\u00f6gen, ausgen. Finanzanlagen": {"account_type": "Income Account"},
+            "4630 Ertr\u00e4ge aus dem Abgang vom Anlageverm\u00f6gen, ausgen. Finanzanlagen": {"account_type": "Income Account"},
+            "4660 Ertr\u00e4ge aus der Zuschreibung zum Anlageverm\u00f6gen, ausgen. Finanzanlagen": {"account_type": "Income Account"},
+            "4700 Ertr\u00e4ge aus der Aufl\u00f6sung von R\u00fcckstellungen": {"account_type": "Income Account"},
+            "4800 \u00dcbrige betriebliche Ertr\u00e4ge": {"account_type": "Income Account"},
+            "root_type": "Income"
+        },        
+        "Klasse 5: Aufwand f\u00fcr Material und Leistungen": {
+            "5000 Einkauf Partnerleistungen": {"account_type": "Cost of Goods Sold"},        
+            "5100 Verbrauch an Rohstoffen": {"account_type": "Cost of Goods Sold"},
+            "5200 Verbrauch von bezogenen Fertig- und Einzelteilen": {"account_type": "Cost of Goods Sold"},
+            "5300 Verbrauch von Hilfsstoffen": {"account_type": "Cost of Goods Sold"},
+            "5340 Verbrauch Verpackungsmaterial": {"account_type": "Cost of Goods Sold"},
+            "5470 Verbrauch von Kleinmaterial": {"account_type": "Cost of Goods Sold"},
+            "5450 Verbrauch von Reinigungsmaterial": {"account_type": "Cost of Goods Sold"},                                  
+            "5400 Verbrauch von Betriebsstoffen": {"account_type": "Cost of Goods Sold"},
+            "5500 Verbrauch von Werkzeugen und anderen Erzeugungshilfsmittel": {"account_type": "Cost of Goods Sold"},
+            "5600 Verbrauch von Brenn- und Treibstoffen, Energie und Wasser": {"account_type": "Cost of Goods Sold"},
+            "5700 Bearbeitung durch Dritte": {"account_type": "Cost of Goods Sold"},
+            "5900 Aufwandsstellenrechnung Material": {"account_type": "Cost of Goods Sold"},
+            "5820 Skontoertr\u00e4ge (20% USt.)": {"account_type": "Income Account"},
+            "5810 Skontoertr\u00e4ge (10% USt.)": {"account_type": "Income Account"},
+            "5010 Handelswareneinkauf 10 %": {"account_type": "Cost of Goods Sold"},
+            "5020 Handelswareneinkauf 20 %": {"account_type": "Cost of Goods Sold"},
+            "5040 Handelswareneinkauf innergemeinschaftlicher Erwerb 10 % VSt/10 % USt": {"account_type": "Cost of Goods Sold"},
+            "5050 Handelswareneinkauf innergemeinschaftlicher Erwerb 20 % VSt/20 % USt": {"account_type": "Cost of Goods Sold"},
+            "5070 Handelswareneinkauf innergemeinschaftlicher Erwerb ohne Vorsteuerabzug und 10 % USt": {"account_type": "Cost of Goods Sold"},
+            "5080 Handelswareneinkauf innergemeinschaftlicher Erwerb ohne Vorsteuerabzug und 20 % USt": {"account_type": "Cost of Goods Sold"},
+            "root_type": "Expense"
+        },
+        "Klasse 6: Personalaufwand": {
+            "6000 L\u00f6hne": {"account_type": "Payable"},
+            "6200 Geh\u00e4lter": {"account_type": "Payable"},
+            "6400 Aufwendungen f\u00fcr Abfertigungen": {"account_type": "Payable"},
+            "6450 Aufwendungen f\u00fcr Altersversorgung": {"account_type": "Payable"},
+            "6500 Gesetzlicher Sozialaufwand Arbeiter": {"account_type": "Payable"},
+            "6560 Gesetzlicher Sozialaufwand Angestellte": {"account_type": "Payable"},
+            "6600 Lohnabh\u00e4ngige Abgaben und Pflichtbeitr\u00e4gte": {"account_type": "Payable"},
+            "6660 Gehaltsabh\u00e4ngige Abgaben und Pflichtbeitr\u00e4gte": {"account_type": "Payable"},
+            "6700 Sonstige Sozialaufwendungen": {"account_type": "Payable"},
+            "6900 Aufwandsstellenrechnung Personal": {"account_type": "Payable"},
+            "root_type": "Expense"
+        },       
+         "Klasse 7: Abschreibungen und sonstige betriebliche Aufwendungen": {
+            "7010 Abschreibungen auf das Anlageverm\u00f6gen (ausgenommen Finanzanlagen)": {"account_type": "Depreciation"},
+            "7100 Sonstige Steuern und Geb\u00fchren": {"account_type": "Tax"},
+            "7200 Instandhaltung u. Reinigung durch Dritte, Entsorgung, Energie": {"account_type": "Expense Account"},
+            "7300 Transporte durch Dritte": {"account_type": "Expense Account"},
+            "7310 Fahrrad - Aufwand": {"account_type": "Expense Account"},
+            "7320 Kfz - Aufwand": {"account_type": "Expense Account"},
+            "7330 LKW - Aufwand": {"account_type": "Expense Account"},
+            "7340 Lastenrad - Aufwand": {"account_type": "Expense Account"},            
+            "7350 Reise- und Fahraufwand": {"account_type": "Expense Account"},
+            "7360 Tag- und N\u00e4chtigungsgelder": {"account_type": "Expense Account"},
+            "7380 Nachrichtenaufwand": {"account_type": "Expense Account"},
+            "7400 Miet- und Pachtaufwand": {"account_type": "Expense Account"},
+            "7440 Leasingaufwand": {"account_type": "Expense Account"},
+            "7480 Lizenzaufwand": {"account_type": "Expense Account"},
+            "7500 Aufwand f\u00fcr beigestelltes Personal": {"account_type": "Expense Account"},
+            "7540 Provisionen an Dritte": {"account_type": "Expense Account"},
+            "7580 Aufsichtsratsverg\u00fctungen": {"account_type": "Expense Account"},
+            "7610 Druckerzeugnisse und Vervielf\u00e4ltigungen": {"account_type": "Expense Account"},
+            "7650 Werbung und Repr\u00e4sentationen": {"account_type": "Expense Account"},
+            "7700 Versicherungen": {"account_type": "Expense Account"},
+            "7750 Beratungs- und Pr\u00fcfungsaufwand": {"account_type": "Expense Account"},
+            "7800 Forderungsverluste und Schadensf\u00e4lle": {"account_type": "Expense Account"},
+            "7840 Verschiedene betriebliche Aufwendungen": {"account_type": "Expense Account"},
+            "7910 Aufwandsstellenrechung der Hersteller": {"account_type": "Expense Account"},
+            "7060 Sofortabschreibungen geringwertig": {"account_type": "Expense Account"},
+            "7070 Abschreibungen vom Umlaufverm\u00f6gen, soweit diese die im Unternehmen \u00fcblichen Abschreibungen \u00fcbersteigen": {"account_type": "Depreciation"},
+            "7900 Aufwandsstellenrechnung": {"account_type": "Expense Account"},
+            "7770 Aus- und Fortbildung": {"account_type": "Expense Account"},
+            "7820 Buchwert abgegangener Anlagen, ausgenommen Finanzanlagen": {"account_type": "Expense Account"},
+            "7600 B\u00fcromaterial und Drucksorten": {"account_type": "Expense Account"},
+            "7630 Fachliteratur und Zeitungen ": {"account_type": "Expense Account"},
+            "7960 Herstellungskosten der zur Erzielung der Umsatzerl\u00f6se erbrachten Leistungen": {"account_type": "Expense Account"},
+            "7780 Mitgliedsbeitr\u00e4ge": {"account_type": "Expense Account"},
+            "7880 Skontoertr\u00e4ge auf sonstige betriebliche Aufwendungen": {"account_type": "Expense Account"},
+            "7990 Sonstige betrieblichen Aufwendungen": {"account_type": "Expense Account"},
+            "7680 Spenden und Trinkgelder": {"account_type": "Expense Account"},
+            "7790 Spesen des Geldverkehrs": {"account_type": "Expense Account"},
+            "7830 Verluste aus dem Abgang vom Anlageverm\u00f6gen, ausgenommen Finanzanlagen": {"account_type": "Expense Account"},
+            "7970 Vertriebskosten": {"account_type": "Expense Account"},
+            "7980 Verwaltungskosten": {"account_type": "Expense Account"},
+            "root_type": "Expense"
+        },
+         "Klasse 8: Finanz- und ausserordentliche Ertr\u00e4ge und Aufwendungen": {
+            "8000 Ertr\u00e4ge aus Beteiligungen": {"account_type": "Income Account"},
+            "8050 Ertr\u00e4ge aus anderen Wertpapieren und Ausleihungen des Finanzanlageverm\u00f6gens": {"account_type": "Income Account"},
+            "8100 Zinsen aus Bankguthaben": {"account_type": "Income Account"},
+            "8110 Zinsen aus gewaehrten Darlehen": {"account_type": "Income Account"},
+            "8130 Verzugszinsenertraege": {"account_type": "Income Account"},
+            "8220 Aufwendungen aus Beteiligungen": {"account_type": "Expense Account"},
+            "8260 Aufwendungen aus sonst. Fiananzanlagen und aus Wertpapieren des Umlaufverm\u00f6gens": {},
+            "8280 Zinsen und \u00e4hnliche Aufwendungem": {"account_type": "Expense Account"},
+            "8400 Au\u00dferordentliche Ertr\u00e4ge": {"account_type": "Income Account"},
+            "8450 Au\u00dferordentliche Aufwendungen": {"account_type": "Expense Account"},
+            "8500 Steuern vom Einkommen und vom Ertrag": {
+                "account_type": "Tax"
+            },
+            "8600 Aufl\u00f6sung unversteuerten R\u00fccklagen": {"account_type": "Income Account"},
+            "8700 Aufl\u00f6sung von Kapitalr\u00fccklagen": {"account_type": "Income Account"},
+            "8750 Aufl\u00f6sung von Gewinnr\u00fccklagen": {"account_type": "Income Account"},
+            "8800 Zuweisung zu unversteuerten R\u00fccklagen": {"account_type": "Expense Account"},
+            "8900 Zuweisung zu Gewinnr\u00fccklagen": {"account_type": "Expense Account"},
+            "8100 Buchwert abgegangener Beteiligungen": {"account_type": "Expense Account"},
+            "8130 Buchwert abgegangener Wertpapiere des Umlaufverm\u00f6gens": {"account_type": "Expense Account"},
+            "8120 Buchwert abgegangener sonstiger Finanzanlagen": {"account_type": "Expense Account"},
+            "8990 Gewinnabfuhr bzw. Verlust\u00fcberrechnung aus Ergebnisabf\u00fchrungsvertr\u00e4gen": {"account_type": "Expense Account"},
+            "8350 nicht ausgenutzte Lieferantenskonti": {"account_type": "Expense Account"},
+            "root_type": "Income"
+        },       
+        "Klasse 9 Passiva: Eigenkapital, R\u00fccklagen, stille Einlagen, Abschlusskonten": {
+            "9000 Gezeichnetes bzw. gewidmetes Kapital": {
+                "account_type": "Equity"
+            },
+            "9200 Kapitalr\u00fccklagen": {
+                "account_type": "Equity"
+            },
+            "9300 Gewinnr\u00fccklagen": {
+                "account_type": "Equity"
+            },
+            "9400 Bewertungsreserven uns sonst. unversteuerte R\u00fccklagen": {
+                "account_type": "Equity"
+            },
+            "9600 Private Entnahmen": {"account_type": "Equity"},
+            "9610 Privatsteuern": {"account_type": "Equity"},
+            "9700 Einlagen stiller Gesellschafter ": {"account_type": "Equity"},
+            "9900 Evidenzkonto": {"account_type": "Equity"},
+            "9800 Er\u00f6ffnungsbilanzkonto (EBK)": {"account_type": "Equity"},
+            "9880 Jahresergebnis laut Gewinn- und Verlustrechnung (G+V)": {"account_type": "Equity"},
+            "9850 Schlussbilanzkonto (SBK)": {"account_type": "Round Off"},
+            "9190 nicht eingeforderte ausstehende Einlagen und berechtigte Entnahmen von Gesellschaftern": {
+                "account_type": "Equity"
+            },
+            "root_type": "Equity"
+        }
+     }   
+  }
+


### PR DESCRIPTION
Austrian Chart of Accounts compiled by fairkom.eu from various sources, among them the official "Österreichischer Kontenrahmen" published by ÖPWZ - Fachsenat für Betriebswirtschaft und Organisation der Kammer der Wirtschaftstreuhänder Version May 2014. 
Numbering scheme has been slightly adapted to fit best with ERPnext setup of a company, where the most important accounts are automatically assigned. 
When using this chart of accounts, feel free to reduce / adapt the accounts - it is not legally binding but good practice to be able to compare the performance of companies in Austria.
