### PR TITLE
better validation example for developer

### DIFF
--- a/erpnext/docs/user/manual/en/customize-erpnext/custom-scripts/custom-script-examples/date-validation.md
+++ b/erpnext/docs/user/manual/en/customize-erpnext/custom-scripts/custom-script-examples/date-validation.md
@@ -1,10 +1,10 @@
 # Date Validation
 
 
-	frappe.ui.form.on("Event", "validate", function(frm) {
+	frappe.ui.form.on("Task", "validate", function(frm) {
         if (frm.doc.from_date < get_today()) {
             msgprint(__("You can not select past date in From Date"));
-            throw "past date selected"
+            validated = false;
         }
 	});
 


### PR DESCRIPTION
throw "past date selected" will freeze the form and user can not correct value of  from_date.
but validated false will just throw the pop-up and user can correct value of from_date and save the form.

Example changed from Event to Task because same is available in Custom Script Help for desk user
