### PR TITLE
[Minor] Fix print settings for custom print format

### DIFF
--- a/erpnext/controllers/print_settings.py
+++ b/erpnext/controllers/print_settings.py
@@ -8,22 +8,22 @@ from frappe.utils import cint
 def print_settings_for_item_table(doc):
 
 	doc.print_templates = {
-		"description": "templates/print_formats/includes/item_table_description.html",
 		"qty": "templates/print_formats/includes/item_table_qty.html"
 	}
-
-	doc.hide_in_print_layout = ["item_code", "item_name", "image", "uom", "stock_uom"]
+	doc.hide_in_print_layout = ["uom", "stock_uom"]
 
 	doc.flags.compact_item_print = cint(frappe.db.get_value("Features Setup", None, "compact_item_print"))
-	doc.flags.compact_item_fields = doc.hide_in_print_layout + ["description", "qty", "rate", "amount"]
-	doc.flags.show_in_description = []
 
 	if doc.flags.compact_item_print:
+		doc.print_templates["description"] = "templates/print_formats/includes/item_table_description.html"
+		doc.hide_in_print_layout += ["item_code", "item_name", "image"]
+
+		doc.flags.compact_item_fields = ["description", "qty", "rate", "amount"]
+		doc.flags.show_in_description = []
+
 		for df in doc.meta.fields:
 			if df.fieldtype not in ("Section Break", "Column Break", "Button"):
 				if not doc.is_print_hide(df.fieldname):
 					if df.fieldname not in doc.hide_in_print_layout and df.fieldname not in doc.flags.compact_item_fields:
 						doc.hide_in_print_layout.append(df.fieldname)
 						doc.flags.show_in_description.append(df.fieldname)
-
-

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -252,3 +252,4 @@ erpnext.patches.v6_21.rename_material_request_fields
 erpnext.patches.v6_23.update_stopped_status_to_closed
 erpnext.patches.v6_24.repost_valuation_rate_for_serialized_items
 erpnext.patches.v6_24.set_recurring_id
+erpnext.patches.v6_20x.set_compact_print

--- a/erpnext/patches/v6_20x/__init__.py
+++ b/erpnext/patches/v6_20x/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import unicode_literals

--- a/erpnext/patches/v6_20x/set_compact_print.py
+++ b/erpnext/patches/v6_20x/set_compact_print.py
@@ -1,0 +1,5 @@
+from __future__ import unicode_literals
+import frappe
+
+def execute():
+	frappe.db.set_value("Features Setup", None, "compact_item_print", 1)

--- a/erpnext/setup/install.py
+++ b/erpnext/setup/install.py
@@ -36,7 +36,7 @@ def feature_setup():
 		'fs_exports', 'fs_imports', 'fs_discounts', 'fs_purchase_discounts',
 		'fs_after_sales_installations', 'fs_projects', 'fs_sales_extras',
 		'fs_recurring_invoice', 'fs_pos', 'fs_manufacturing', 'fs_quality',
-		'fs_page_break', 'fs_more_info', 'fs_pos_view'
+		'fs_page_break', 'fs_more_info', 'fs_pos_view', 'compact_item_print'
 	]
 	for f in flds:
 		doc.set(f, 1)


### PR DESCRIPTION
- Image, description, item and item code will be displayed in separate fields when 'compact item print' is checked
- When the option is unchecked, user will be able to customize the print format using print format builder.
- By default 'custom item print' will be set to checked set while erpnext is installed.
