### PR TITLE
Add User Remark to Quick Entry Form in Journal Entry

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.js
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.js
@@ -463,6 +463,7 @@ $.extend(erpnext.journal_entry, {
 				},
 				{fieldtype: "Date", fieldname: "posting_date", label: __("Date"), reqd: 1,
 					default: frm.doc.posting_date},
+				{fieldtype: "Small Text", fieldname: "user_remark", label: __("User Remark"), reqd: 1},
 				{fieldtype: "Select", fieldname: "naming_series", label: __("Series"), reqd: 1,
 					options: naming_series_options, default: naming_series_default},
 			]
@@ -473,6 +474,7 @@ $.extend(erpnext.journal_entry, {
 			var values = dialog.get_values();
 
 			frm.set_value("posting_date", values.posting_date);
+			frm.set_value("user_remark", values.user_remark);
 			frm.set_value("naming_series", values.naming_series);
 
 			// clear table is used because there might've been an error while adding child


### PR DESCRIPTION
User Remark is a required field in Journal entry. It is not provided in Quick Entry due to which we again need to add it via the main form. Including User Remark will make it easier.

Old Form:

![quick_entry_old](https://cloud.githubusercontent.com/assets/3918977/14224102/f2b69cca-f8af-11e5-8222-4186e2f3c0b8.png)

New Form:

![new_quick_entry](https://cloud.githubusercontent.com/assets/3918977/14224103/f7b07b2e-f8af-11e5-9147-f4863b17e00f.png)
