### PR TITLE
[Fix] Leave Allocation now includes To Date in Difference

### DIFF
--- a/erpnext/hr/doctype/leave_allocation/leave_allocation.py
+++ b/erpnext/hr/doctype/leave_allocation/leave_allocation.py
@@ -77,7 +77,9 @@ class LeaveAllocation(Document):
 			frappe.throw(_("Total leaves allocated is mandatory"))
 
 	def validate_total_leaves_allocated(self):
-		if date_diff(self.to_date, self.from_date) <= flt(self.total_leaves_allocated):
+		# Adding a day to include To Date in the difference
+		date_difference = date_diff(self.to_date, self.from_date) + 1
+		if date_difference < self.total_leaves_allocated:
 			frappe.throw(_("Total allocated leaves are more than days in the period"), OverAllocationError)
 			
 	def validate_against_leave_applications(self):


### PR DESCRIPTION
Also, no exception is thrown if allocated Leave days for Leave Type are equal to the date difference
