### PR TITLE
Update project.py

### DIFF
--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -80,7 +80,7 @@ class Project(Document):
 		self.update_percent_complete()
 		self.update_costing()
 		self.flags.dont_sync_tasks = True
-		self.save()
+		self.save(ignore_permissions = True)
 
 	def update_percent_complete(self):
 		total = frappe.db.sql("""select count(*) from tabTask where project=%s""", self.name)[0][0]


### PR DESCRIPTION
We found the staff cannot create a new task when he has task write permission and don't have project write permission. The reason is that it will update complete percentage field of project when create a task. So I made ignore_permissions = True for this save.
