### PR TITLE
[fixes] raise exception on deletion of fiscal year if fiscal year is set as Default

### DIFF
--- a/erpnext/accounts/doctype/fiscal_year/fiscal_year.py
+++ b/erpnext/accounts/doctype/fiscal_year/fiscal_year.py
@@ -40,6 +40,11 @@ class FiscalYear(Document):
 
 	def on_update(self):
 		check_duplicate_fiscal_year(self)
+	
+	def on_trash(self):
+		global_defaults = frappe.get_doc("Global Defaults")
+		if global_defaults.current_fiscal_year == self.name:
+			frappe.throw(_("You cannot delete Fiscal Year {0}. Fiscal Year {0} is set as default in Global Settings").format(self.name))
 
 @frappe.whitelist()
 def check_duplicate_fiscal_year(doc):

--- a/erpnext/hr/doctype/process_payroll/process_payroll.py
+++ b/erpnext/hr/doctype/process_payroll/process_payroll.py
@@ -206,3 +206,5 @@ def get_month_details(year, month):
 			'month_end_date': med,
 			'month_days': month_days
 		})
+	else:
+		frappe.throw(_("Fiscal Year {0} not found").format(year))


### PR DESCRIPTION
## Issue/WN-SUP18239

Raise exception,
- while deleting fiscal year if fiscal year is set as default in Global Settings
- while calculating get_month_details if year_start_date not found
