### PR TITLE
Update opportunity.py

### DIFF
--- a/erpnext/crm/doctype/opportunity/opportunity.py
+++ b/erpnext/crm/doctype/opportunity/opportunity.py
@@ -3,7 +3,7 @@
 
 from __future__ import unicode_literals
 import frappe, json
-from frappe.utils import cstr, cint
+from frappe.utils import cstr, cint, get_fullname
 from frappe import msgprint, _
 from frappe.model.mapper import get_mapped_doc
 from erpnext.setup.utils import get_exchange_rate
@@ -46,10 +46,20 @@ class Opportunity(TransactionBase):
 		if not (self.lead or self.customer):
 			lead_name = frappe.db.get_value("Lead", {"email_id": self.contact_email})
 			if not lead_name:
+				sender_name = get_fullname(self.contact_email)
+				if sender_name == self.contact_email:
+					sender_name = None 
+				
+				account = ''
+				email_name = self.contact_email[0:self.contact_email.index('@')]
+				email_split = email_name.split('.')
+				for s in email_split:
+					account = account + s.capitalize() + ' '
+
 				lead = frappe.get_doc({
 					"doctype": "Lead",
 					"email_id": self.contact_email,
-					"lead_name": self.contact_email
+					"lead_name": sender_name or account
 				})
 				lead.insert(ignore_permissions=True)
 				lead_name = lead.name


### PR DESCRIPTION
Set the lead name be full name of email instead of email account when creating a new lead and opportunity via e-mail.
![opportunity](https://cloud.githubusercontent.com/assets/12147007/14809356/115ec176-0bbf-11e6-9919-ea7367ec2fbe.png)
