### PR TITLE
Fixed Leave Approver issue

### DIFF
--- a/erpnext/hr/doctype/employee_leave_approver/employee_leave_approver.py
+++ b/erpnext/hr/doctype/employee_leave_approver/employee_leave_approver.py
@@ -21,4 +21,4 @@ def get_approver_list(name):
 		user_role.role = "Leave Approver"
 		and user_role.parent = user.name and
 		user.name != %s 
-		""", name)
+		""", name or "")


### PR DESCRIPTION
Fixed issue where, if Employee did not have a User_Id, it would not display Leave Approvers for that Employee.
