### PR TITLE
Small improvement in maintenance scheduler

### DIFF
--- a/erpnext/support/doctype/maintenance_schedule/maintenance_schedule.py
+++ b/erpnext/support/doctype/maintenance_schedule/maintenance_schedule.py
@@ -153,7 +153,7 @@ class MaintenanceSchedule(TransactionBase):
 			elif not d.sales_person:
 				throw(_("Please select Incharge Person's name"))
 
-			if getdate(d.start_date) >= getdate(d.end_date):
+			if getdate(d.start_date) > getdate(d.end_date):
 				throw(_("Start date should be less than end date for Item {0}").format(d.item_code))
 
 	def validate_sales_order(self):

--- a/erpnext/support/doctype/maintenance_schedule/maintenance_schedule.py
+++ b/erpnext/support/doctype/maintenance_schedule/maintenance_schedule.py
@@ -57,8 +57,8 @@ class MaintenanceSchedule(TransactionBase):
 					
 			if no_email_sp:
 				frappe.msgprint(
-					frappe._("Setting Events to <b>{0}</b>, since the Employee attached to the below Sales Persons does not have a User ID<br>{1}").format(
-						doc.owner, no_email_sp.join("<br>")
+					frappe._("Setting Events to {0}, since the Employee attached to the below Sales Persons does not have a User ID{1}").format(
+						doc.owner, "<br>"+no_email_sp.join("<br>")
 				))
 
 			scheduled_date = frappe.db.sql("""select scheduled_date from

--- a/erpnext/support/doctype/maintenance_schedule/maintenance_schedule.py
+++ b/erpnext/support/doctype/maintenance_schedule/maintenance_schedule.py
@@ -57,7 +57,7 @@ class MaintenanceSchedule(TransactionBase):
 					
 			if no_email_sp:
 				frappe.msgprint(
-					"Setting Events to <b>{0}</b>, since the Employee attached to the below Sales Persons does not have a User ID<br>{1}".format(
+					frappe._("Setting Events to <b>{0}</b>, since the Employee attached to the below Sales Persons does not have a User ID<br>{1}").format(
 						doc.owner, no_email_sp.join("<br>")
 				))
 
@@ -66,7 +66,7 @@ class MaintenanceSchedule(TransactionBase):
 				parent=%s""", (d.sales_person, d.item_code, self.name), as_dict=1)
 
 			for key in scheduled_date:
-				description = "Reference: %s, Item Code: %s and Customer: %s" % \
+				description = frappe._("Reference: %s, Item Code: %s and Customer: %s") % \
 					(self.name, d.item_code, self.customer)
 				frappe.get_doc({
 					"doctype": "Event",

--- a/erpnext/support/doctype/maintenance_schedule/maintenance_schedule.py
+++ b/erpnext/support/doctype/maintenance_schedule/maintenance_schedule.py
@@ -47,12 +47,19 @@ class MaintenanceSchedule(TransactionBase):
 				self.validate_serial_no(serial_nos, d.start_date)
 				self.update_amc_date(serial_nos, d.end_date)
 
+			no_email_sp = []
 			if d.sales_person not in email_map:
 				sp = frappe.get_doc("Sales Person", d.sales_person)
 				try:
 					email_map[d.sales_person] = sp.get_email_id()
 				except frappe.ValidationError:
-					pass
+					no_email_sp.append(d.sales_person)
+					
+			if no_email_sp:
+				frappe.msgprint(
+					"Setting Events to <b>{0}</b>, since the Employee attached to the below Sales Persons does not have a User ID<br>{1}".format(
+						doc.owner, no_email_sp.join("<br>")
+				))
 
 			scheduled_date = frappe.db.sql("""select scheduled_date from
 				`tabMaintenance Schedule Detail` where sales_person=%s and item_code=%s and


### PR DESCRIPTION
This improvement is intended to start disable blocking Maintenance Schedule submit, when the `Sales Person` does not have a `user_id` in the Employee!

The old logic try to use the `sales_person` email_id or the `owner` to create the event, but due some fails in the code, it dont occurs!
