### PR TITLE
Update fiscal_year.py

### DIFF
--- a/erpnext/accounts/doctype/fiscal_year/fiscal_year.py
+++ b/erpnext/accounts/doctype/fiscal_year/fiscal_year.py
@@ -12,7 +12,9 @@ from frappe.model.document import Document
 class FiscalYear(Document):
 	def set_as_default(self):
 		frappe.db.set_value("Global Defaults", None, "current_fiscal_year", self.name)
-		frappe.get_doc("Global Defaults").on_update()
+		global_defaults = frappe.get_doc("Global Defaults")
+		global_defaults.check_permission("write")
+		global_defaults.on_update()
 
 		# clear cache
 		frappe.clear_cache()


### PR DESCRIPTION
Added check_permission("write") before on_update when click 'default' button because setting default Fiscal Year should be possible to do only for who has got write permissions of Global Defaults.
