### PR TITLE
Create Manufacture MRs for BOM Items

### DIFF
--- a/erpnext/manufacturing/doctype/production_planning_tool/production_planning_tool.py
+++ b/erpnext/manufacturing/doctype/production_planning_tool/production_planning_tool.py
@@ -449,9 +449,12 @@ class ProductionPlanningTool(Document):
 					"transaction_date": nowdate(),
 					"status": "Draft",
 					"company": self.company,
-					"requested_by": frappe.session.user,
-					"material_request_type": "Purchase"
+					"requested_by": frappe.session.user
 				})
+				if item_wrapper.default_bom:
+					material_request.update({"material_request_type": "Manufacture"}) 
+				else:
+					material_request.update({"material_request_type": "Purchase"})
 				for sales_order, requested_qty in items_to_be_requested[item].items():
 					material_request.append("items", {
 						"doctype": "Material Request Item",


### PR DESCRIPTION
Corrects an issue where items with BOMs have Purchase material request submitted instead of Manufacture material requests.

Based off of issue:
[https://discuss.erpnext.com/t/production-planning-tool-bug/13385](https://discuss.erpnext.com/t/production-planning-tool-bug/13385)
