### PR TITLE
[fix] return route from make_route of child class

### DIFF
--- a/erpnext/setup/doctype/item_group/item_group.py
+++ b/erpnext/setup/doctype/item_group/item_group.py
@@ -41,6 +41,8 @@ class ItemGroup(NestedSet, WebsiteGenerator):
 				self.route = frappe.get_doc('Item Group', self.parent_item_group).route + '/'
 
 			self.route += self.scrub(self.item_group_name)
+			
+			return self.route
 
 	def after_rename(self, olddn, newdn, merge=False):
 		NestedSet.after_rename(self, olddn, newdn, merge)

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -134,7 +134,7 @@ class Item(WebsiteGenerator):
 
 	def make_route(self):
 		if not self.route:
-			self.route = frappe.db.get_value('Item Group', self.item_group, 'route') + '/' + self.scrub(self.item_name)
+			return frappe.db.get_value('Item Group', self.item_group, 'route') + '/' + self.scrub(self.item_name)
 
 	def get_parents(self, context):
 		item_group, route = frappe.db.get_value('Item Group', self.item_group, ['name', 'route'])


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/app.py", line 55, in application
    response = frappe.handler.handle()
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/handler.py", line 19, in handle
    execute_cmd(cmd)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/handler.py", line 36, in execute_cmd
    ret = frappe.call(method, **frappe.form_dict)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/__init__.py", line 874, in call
    return fn(*args, **newargs)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.py", line 32, in setup_complete
    frappe.get_attr(method)(args)
  File "/Users/saurabh/frappe-bench/apps/erpnext/erpnext/setup/setup_wizard/setup_wizard.py", line 21, in setup_complete
    install_fixtures.install(args.get("country"))
  File "/Users/saurabh/frappe-bench/apps/erpnext/erpnext/setup/setup_wizard/install_fixtures.py", line 204, in install
    doc.insert(ignore_permissions=True)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/model/document.py", line 194, in insert
    self.run_before_save_methods()
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/model/document.py", line 642, in run_before_save_methods
    self.run_method("validate")
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/model/document.py", line 603, in run_method
    return Document.hook(fn)(self, *args, **kwargs)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/model/document.py", line 768, in composer
    return composed(self, method, *args, **kwargs)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/model/document.py", line 751, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/model/document.py", line 597, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/Users/saurabh/frappe-bench/apps/erpnext/erpnext/setup/doctype/item_group/item_group.py", line 26, in validate
    super(ItemGroup, self).validate()
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/website/website_generator.py", line 33, in validate
    self.route = self.route.strip('/.')
AttributeError: 'NoneType' object has no attribute 'strip'
```
