### PR TITLE
[minor][fix] remove website generator call on after rename

### DIFF
--- a/erpnext/setup/doctype/item_group/item_group.py
+++ b/erpnext/setup/doctype/item_group/item_group.py
@@ -46,7 +46,6 @@ class ItemGroup(NestedSet, WebsiteGenerator):
 
 	def after_rename(self, olddn, newdn, merge=False):
 		NestedSet.after_rename(self, olddn, newdn, merge)
-		WebsiteGenerator.after_rename(self, olddn, newdn, merge)
 
 	def on_trash(self):
 		NestedSet.on_trash(self)

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -512,7 +512,6 @@ class Item(WebsiteGenerator):
 			frappe.db.sql("delete from `tabBin` where item_code=%s", old_name)
 
 	def after_rename(self, old_name, new_name, merge):
-		super(Item, self).after_rename(old_name, new_name, merge)
 		if self.route:
 			invalidate_cache_for_item(self)
 			clear_cache(self.route)


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/app.py", line 55, in application
    response = frappe.handler.handle()
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/handler.py", line 19, in handle
    execute_cmd(cmd)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/handler.py", line 36, in execute_cmd
    ret = frappe.call(method, **frappe.form_dict)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/__init__.py", line 874, in call
    return fn(*args, **newargs)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/model/rename_doc.py", line 57, in rename_doc
    new_doc.run_method("after_rename", old, new, merge)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/model/document.py", line 603, in run_method
    return Document.hook(fn)(self, *args, **kwargs)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/model/document.py", line 768, in composer
    return composed(self, method, *args, **kwargs)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/model/document.py", line 751, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/model/document.py", line 597, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/Users/saurabh/frappe-bench/apps/erpnext/erpnext/setup/doctype/item_group/item_group.py", line 49, in after_rename
    WebsiteGenerator.after_rename(self, olddn, newdn, merge)
AttributeError: type object 'WebsiteGenerator' has no attribute 'after_rename'
```
