### PR TITLE
[fixes] time sheet patch fix

### DIFF
--- a/erpnext/patches/v7_0/set_naming_series_for_timesheet.py
+++ b/erpnext/patches/v7_0/set_naming_series_for_timesheet.py
@@ -7,8 +7,8 @@ import frappe
 from frappe.custom.doctype.property_setter.property_setter import make_property_setter
 
 def execute():
-	frappe.reload_doctype('Time Sheet')
-	frappe.reload_doctype('Time Sheet Detail')
+	frappe.reload_doc('projects', 'doctype','time_sheet')
+	frappe.reload_doc('projects', 'doctype', 'time_sheet_detail')
 	
 	make_property_setter('Time Sheet', "naming_series", "options", 'TS-', "Text")
 	make_property_setter('Time Sheet', "naming_series", "default", 'TS-', "Text")


### PR DESCRIPTION
```
Executing erpnext.patches.v7_0.set_naming_series_for_timesheet in demo (89e495e794)
Traceback (most recent call last):
  File "/usr/local/Cellar/python/2.7.8_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/local/Cellar/python/2.7.8_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Users/nlasrado/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 79, in <module>
    main()
  File "/Users/nlasrado/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 16, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/Users/nlasrado/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 610, in __call__
    return self.main(*args, **kwargs)
  File "/Users/nlasrado/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 590, in main
    rv = self.invoke(ctx)
  File "/Users/nlasrado/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 936, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/nlasrado/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 936, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/nlasrado/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 782, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/nlasrado/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 416, in invoke
    return callback(*args, **kwargs)
  File "/Users/nlasrado/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 24, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/Users/nlasrado/frappe-bench/apps/frappe/frappe/commands/site.py", line 165, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website)
  File "/Users/nlasrado/frappe-bench/apps/frappe/frappe/migrate.py", line 27, in migrate
    frappe.modules.patch_handler.run_all()
  File "/Users/nlasrado/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 25, in run_all
    if not run_single(patchmodule = patch):
  File "/Users/nlasrado/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 52, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/Users/nlasrado/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 68, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/Users/nlasrado/frappe-bench/apps/erpnext/erpnext/patches/v7_0/set_naming_series_for_timesheet.py", line 10, in execute
    frappe.reload_doctype('Time Sheet')
  File "/Users/nlasrado/frappe-bench/apps/frappe/frappe/__init__.py", line 620, in reload_doctype
    reload_doc(scrub(db.get_value("DocType", doctype, "module")), "doctype", scrub(doctype), force=force)
  File "/Users/nlasrado/frappe-bench/apps/frappe/frappe/__init__.py", line 645, in scrub
    return txt.replace(' ','_').replace('-', '_').lower()
AttributeError: 'NoneType' object has no attribute 'replace'
```
