### PR TITLE
[Minor][fix] Holiday list message fix and company attr fix

### DIFF
--- a/erpnext/hr/doctype/employee/employee.py
+++ b/erpnext/hr/doctype/employee/employee.py
@@ -238,7 +238,7 @@ def get_holiday_list_for_employee(employee, raise_exception=True):
 		holiday_list = frappe.db.get_value("Company", company, "default_holiday_list")
 
 	if not holiday_list and raise_exception:
-		frappe.throw(_('Please set a default Holiday List for Employee {0} or Company {0}').format(employee, company))
+		frappe.throw(_('Please set a default Holiday List for Employee {0} or Company {1}').format(employee, company))
 
 	return holiday_list
 

--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -13,7 +13,7 @@ from frappe.model.document import Document
 
 class Company(Document):
 	def onload(self):
-		self.get("__onload").transactions_exist = self.check_if_transactions_exist()
+		self.get("__onload")["transactions_exist"] = self.check_if_transactions_exist()
 
 	def check_if_transactions_exist(self):
 		exists = False


### PR DESCRIPTION
<img width="612" alt="screen shot 2016-07-04 at 1 14 24 pm" src="https://cloud.githubusercontent.com/assets/3784093/16553950/60df2c1c-41e9-11e6-8ead-5d90ccce392c.png">

---

```
Traceback (most recent call last):
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/desk/form/load.py", line 33, in getdoc
    run_onload(doc)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/desk/form/load.py", line 199, in run_onload
    doc.run_method("onload")
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/model/document.py", line 603, in run_method
    return Document.hook(fn)(self, *args, **kwargs)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/model/document.py", line 768, in composer
    return composed(self, method, *args, **kwargs)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/model/document.py", line 751, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/model/document.py", line 597, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/Users/saurabh/frappe-bench/apps/erpnext/erpnext/setup/doctype/company/company.py", line 16, in onload
    self.get("__onload").transactions_exist = self.check_if_transactions_exist()
AttributeError: 'dict' object has no attribute 'transactions_exist'
```
