### PR TITLE
[fix] fee component rename patch fix

### DIFF
--- a/erpnext/patches/v7_0/rename_fee_amount_to_fee_component.py
+++ b/erpnext/patches/v7_0/rename_fee_amount_to_fee_component.py
@@ -7,9 +7,10 @@ import frappe
 from frappe.model.utils.rename_field import rename_field
 
 def execute():
-	frappe.rename_doc("DocType", "Fee Amount", "Fee Component")
-	for dt in ("Fees", "Fee Structure"):
-		frappe.reload_doctype(dt)
-		rename_field(dt, "amount", "components")
+	if frappe.db.exists("DocType", "Fee Amount"):
+		frappe.rename_doc("DocType", "Fee Amount", "Fee Component")
+		for dt in ("Fees", "Fee Structure"):
+			frappe.reload_doctype(dt)
+			rename_field(dt, "amount", "components")
 		
 	


### PR DESCRIPTION
```

Executing erpnext.patches.v7_0.rename_fee_amount_to_fee_component in site3.local (1dd227d3c8)
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 79, in <module>
    main()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 16, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 664, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 644, in main
    rv = self.invoke(ctx)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 991, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 991, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 837, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 464, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 24, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/site.py", line 203, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py", line 27, in migrate
    frappe.modules.patch_handler.run_all()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 25, in run_all
    if not run_single(patchmodule = patch):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 52, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 68, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/patches/v7_0/rename_fee_amount_to_fee_component.py", line 13, in execute
    rename_field(dt, "amount", "components")
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/utils/rename_field.py", line 24, in rename_field
    (new_fieldname, old_fieldname))
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database.py", line 137, in sql
    self._cursor.execute(query, values)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/MySQLdb/cursors.py", line 205, in execute
    self.errorhandler(self, exc, value)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/MySQLdb/connections.py", line 36, in defaulterrorhandler
    raise errorclass, errorvalue
_mysql_exceptions.ProgrammingError: (1146, "Table '1dd227d3c8.tabFee Component' doesn't exist")
```
