### PR TITLE
Added date filters for the Timesheet query in Salary Slip

### DIFF
--- a/erpnext/hr/doctype/salary_slip/salary_slip.py
+++ b/erpnext/hr/doctype/salary_slip/salary_slip.py
@@ -64,8 +64,8 @@ class SalarySlip(TransactionBase):
 		if self.salary_slip_based_on_timesheet and not self.get('timesheets'):
 			self.set("timesheets", [])
 
-			timesheets = frappe.db.sql(""" select * from `tabTimesheet` where employee = %(employee)s and (status = 'Submitted' or
-				status = 'Billed')""", {'employee': self.employee}, as_dict=1)
+			timesheets = frappe.db.sql(""" select * from `tabTimesheet` where employee = %(employee)s and start_date BETWEEN %(start_date)s AND %(end_date)s and (status = 'Submitted' or
+				status = 'Billed')""", {'employee': self.employee, 'start_date': self.start_date, 'end_date': self.end_date}, as_dict=1)
 
 			for data in timesheets:
 				self.append('timesheets', {


### PR DESCRIPTION
The current Salary Slip loads all the timesheets from an employee regardless of the month being queried. This resolves that issue.
