### PR TITLE
Added a Calendar view for timesheet logs

### DIFF
--- a/erpnext/projects/doctype/timesheet/timesheet_calendar.js
+++ b/erpnext/projects/doctype/timesheet/timesheet_calendar.js
@@ -1,0 +1,27 @@
+frappe.views.calendar["Timesheet"] = {
+	field_map: {
+		"start": "from_time",
+		"end": "end_time",
+		"name": "parent",
+		"id": "parent",
+		"title": "activity_type",
+		"allDay": "allDay",
+		"child_name": "name"
+	},
+	gantt: true,
+	filters: [
+		{
+			"fieldtype": "Link",
+			"fieldname": "project",
+			"options": "Project",
+			"label": __("Project")
+		},
+		{
+			"fieldtype": "Link",
+			"fieldname": "employee",
+			"options": "Employee",
+			"label": __("Employee")
+		}
+	],
+	get_events_method: "erpnext.projects.doctype.timesheet.timesheet.get_events"
+}


### PR DESCRIPTION
Added the ability to view Timesheet Log Details in the Calendar view. This commit does not allow editing or adding new Time Logs because there are bugs with the Frappe calendar framework.
