### PR TITLE
[fix] report filter fix

### DIFF
--- a/erpnext/stock/report/stock_balance/stock_balance.py
+++ b/erpnext/stock/report/stock_balance/stock_balance.py
@@ -71,9 +71,11 @@ def get_conditions(filters):
 		conditions += " and item_code = '%s'" % frappe.db.escape(filters.get("item_code"), percent=False)
 
 	if filters.get("warehouse"):
-		lft, rgt = frappe.db.get_value("Warehouse", filters.get("warehouse"), ["lft", "rgt"])
-		conditions += " and exists (select name from `tabWarehouse` wh \
-			where wh.lft >= %s and wh.rgt <= %s and sle.warehouse = wh.name)"%(lft, rgt)
+		warehouse_details = frappe.db.get_value("Warehouse", filters.get("warehouse"), ["lft", "rgt"], as_dict=1)
+		if warehouse_details:
+			conditions += " and exists (select name from `tabWarehouse` wh \
+				where wh.lft >= %s and wh.rgt <= %s and sle.warehouse = wh.name)"%(warehouse_details.lft,
+				warehouse_details.rgt)
 
 	return conditions
 

--- a/erpnext/stock/report/stock_ledger/stock_ledger.py
+++ b/erpnext/stock/report/stock_ledger/stock_ledger.py
@@ -99,8 +99,10 @@ def get_opening_balance(filters, columns):
 	return row
 	
 def get_warehouse_condition(warehouse):
-	lft, rgt = frappe.db.get_value("Warehouse", warehouse, ["lft", "rgt"])
-	
-	return " exists (select name from `tabWarehouse` wh \
-		where wh.lft >= %s and wh.rgt <= %s and sle.warehouse = wh.name)"%(lft, rgt)
-	
+	warehouse_details = frappe.db.get_value("Warehouse", warehouse, ["lft", "rgt"], as_dict=1)
+	if warehouse_details:
+		return " exists (select name from `tabWarehouse` wh \
+			where wh.lft >= %s and wh.rgt <= %s and sle.warehouse = wh.name)"%(warehouse_details.lft,
+			warehouse_details.rgt)
+
+	return ''

--- a/erpnext/stock/report/stock_projected_qty/stock_projected_qty.py
+++ b/erpnext/stock/report/stock_projected_qty/stock_projected_qty.py
@@ -63,10 +63,12 @@ def get_bin_list(filters):
 		conditions.append("item_code = '%s' "%filters.item_code)
 		
 	if filters.warehouse:
-		lft, rgt = frappe.db.get_value("Warehouse", filters.warehouse, ["lft", "rgt"])
-	
-		conditions.append(" exists (select name from `tabWarehouse` wh \
-			where wh.lft >= %s and wh.rgt <= %s and bin.warehouse = wh.name)"%(lft, rgt))
+		warehouse_details = frappe.db.get_value("Warehouse", filters.warehouse, ["lft", "rgt"], as_dict=1)
+
+		if warehouse_details:
+			conditions.append(" exists (select name from `tabWarehouse` wh \
+				where wh.lft >= %s and wh.rgt <= %s and bin.warehouse = wh.name)"%(warehouse_details.lft,
+				warehouse_details.rgt))
 
 	bin_list = frappe.db.sql("""select item_code, warehouse, actual_qty, planned_qty, indented_qty,
 		ordered_qty, reserved_qty, reserved_qty_for_production, projected_qty


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2016-07-24-a/apps/frappe/frappe/app.py", line 55, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2016-07-24-a/apps/frappe/frappe/handler.py", line 19, in handle
    execute_cmd(cmd)
  File "/home/frappe/benches/bench-2016-07-24-a/apps/frappe/frappe/handler.py", line 36, in execute_cmd
    ret = frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2016-07-24-a/apps/frappe/frappe/__init__.py", line 876, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2016-07-24-a/apps/frappe/frappe/desk/query_report.py", line 88, in run
    res = frappe.get_attr(method_name)(frappe._dict(filters))
  File "/home/frappe/benches/bench-2016-07-24-a/apps/erpnext/erpnext/stock/report/stock_balance/stock_balance.py", line 16, in execute
    iwb_map = get_item_warehouse_map(filters)
  File "/home/frappe/benches/bench-2016-07-24-a/apps/erpnext/erpnext/stock/report/stock_balance/stock_balance.py", line 93, in get_item_warehouse_map
    sle = get_stock_ledger_entries(filters)
  File "/home/frappe/benches/bench-2016-07-24-a/apps/erpnext/erpnext/stock/report/stock_balance/stock_balance.py", line 81, in get_stock_ledger_entries
    conditions = get_conditions(filters)
  File "/home/frappe/benches/bench-2016-07-24-a/apps/erpnext/erpnext/stock/report/stock_balance/stock_balance.py", line 74, in get_conditions
    lft, rgt = frappe.db.get_value("Warehouse", filters.get("warehouse"), ["lft", "rgt"])
TypeError: 'NoneType' object is not iterable
```
