### PR TITLE
Fix Timesheet employee query to show names

### DIFF
--- a/erpnext/projects/doctype/timesheet/timesheet.py
+++ b/erpnext/projects/doctype/timesheet/timesheet.py
@@ -295,5 +295,5 @@ def get_activity_cost(employee=None, activity_type=None):
 def get_employee_list(doctype, txt, searchfield, start, page_len, filters):
 	return frappe.db.sql("""select distinct employee, employee_name
 		from `tabSalary Structure` where salary_slip_based_on_timesheet=1
-		and employee like %(txt)s limit %(start)s, %(page_len)s""", 
-		{'txt': "%%%s%%"% txt, '_txt': txt.replace("%", ""), 'start': start, 'page_len': page_len})
+		and employee like %(txt)s or employee_name like %(txt)s) limit %(start)s, %(page_len)s""", 
+		{'txt': "%%%s%%"% txt, 'start': start, 'page_len': page_len})

--- a/erpnext/projects/doctype/timesheet/timesheet.py
+++ b/erpnext/projects/doctype/timesheet/timesheet.py
@@ -293,7 +293,8 @@ def get_activity_cost(employee=None, activity_type=None):
 
 @frappe.whitelist()
 def get_employee_list(doctype, txt, searchfield, start, page_len, filters):
-	return frappe.db.sql("""select distinct(employee) as employee
+	test = frappe.db.sql("""select distinct employee, employee_name
 		from `tabSalary Structure` where salary_slip_based_on_timesheet=1
 		and employee like %(txt)s limit %(start)s, %(page_len)s""", 
-		{'txt': "%%%s%%"%(txt), 'start': start, 'page_len': page_len})
+		{'txt': "%%%s%%"% txt, '_txt': txt.replace("%", ""), 'start': start, 'page_len': page_len})
+	return test

--- a/erpnext/projects/doctype/timesheet/timesheet.py
+++ b/erpnext/projects/doctype/timesheet/timesheet.py
@@ -295,5 +295,5 @@ def get_activity_cost(employee=None, activity_type=None):
 def get_employee_list(doctype, txt, searchfield, start, page_len, filters):
 	return frappe.db.sql("""select distinct employee, employee_name
 		from `tabSalary Structure` where salary_slip_based_on_timesheet=1
-		and employee like %(txt)s or employee_name like %(txt)s) limit %(start)s, %(page_len)s""", 
+		and employee like %(txt)s or employee_name like %(txt)s limit %(start)s, %(page_len)s""", 
 		{'txt': "%%%s%%"% txt, 'start': start, 'page_len': page_len})

--- a/erpnext/projects/doctype/timesheet/timesheet.py
+++ b/erpnext/projects/doctype/timesheet/timesheet.py
@@ -293,8 +293,7 @@ def get_activity_cost(employee=None, activity_type=None):
 
 @frappe.whitelist()
 def get_employee_list(doctype, txt, searchfield, start, page_len, filters):
-	test = frappe.db.sql("""select distinct employee, employee_name
+	return frappe.db.sql("""select distinct employee, employee_name
 		from `tabSalary Structure` where salary_slip_based_on_timesheet=1
 		and employee like %(txt)s limit %(start)s, %(page_len)s""", 
 		{'txt': "%%%s%%"% txt, '_txt': txt.replace("%", ""), 'start': start, 'page_len': page_len})
-	return test


### PR DESCRIPTION
The current Employee lookup only shows the employee number. This fix will also show the employee name to make it easy for employees to find their name.
