### PR TITLE
[Docs] changed path to login

### DIFF
--- a/erpnext/docs/user/manual/en/website/setup/social-login-keys.md
+++ b/erpnext/docs/user/manual/en/website/setup/social-login-keys.md
@@ -5,7 +5,9 @@ Social Login enables users to login to ERPNext via their Google, Facebook or Git
 Checkout the following Video Tutorials to understand how to enable social logins on ERPNext
 
 * for FaceBook - https://www.youtube.com/watch?v=zC6Q6gIfiw8
-* for Google - https://www.youtube.com/watch?v=w_EAttrE9sw
+* for Google - https://www.youtube.com/watch?v=w_EAttrE9sw 
 * for GitHub - https://www.youtube.com/watch?v=bG71DxxkVjQ
+
+For Google the *Authorized redirect URI* is [yoursite]/api/method/frappe.www.login.login_via_google
 
 {next}


### PR DESCRIPTION
frappe.templates.pages.login.login_via_google changed to frappe.www.login.login_via_google
