### PR TITLE
[minor][fix] return if account details not found

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -772,6 +772,9 @@ def get_account_balance_and_party_type(account, date, company, debit=None, credi
 	company_currency = get_company_currency(company)
 	account_details = frappe.db.get_value("Account", account, ["account_type", "account_currency"], as_dict=1)
 
+	if not account_details:
+		return
+
 	if account_details.account_type == "Receivable":
 		party_type = "Customer"
 	elif account_details.account_type == "Payable":


### PR DESCRIPTION
## WN-SUP19754

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2016-08-01-a/apps/frappe/frappe/app.py", line 55, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2016-08-01-a/apps/frappe/frappe/handler.py", line 19, in handle
    execute_cmd(cmd)
  File "/home/frappe/benches/bench-2016-08-01-a/apps/frappe/frappe/handler.py", line 36, in execute_cmd
    ret = frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2016-08-01-a/apps/frappe/frappe/__init__.py", line 879, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2016-08-01-a/apps/erpnext/erpnext/accounts/doctype/journal_entry/journal_entry.py", line 775, in get_account_balance_and_party_type
    if account_details.account_type == "Receivable":
AttributeError: 'NoneType' object has no attribute 'account_type'
```
