### PR TITLE
[Enhancement + Fix] Disable buttons when Production Order is Stopped, Fixed Stopping and Re-Opening of Production Order

### DIFF
--- a/erpnext/manufacturing/doctype/production_order/production_order.js
+++ b/erpnext/manufacturing/doctype/production_order/production_order.js
@@ -38,7 +38,7 @@ frappe.ui.form.on("Production Order", {
 			frm.trigger('show_progress');
 		}
 		
-		if(frm.doc.docstatus == 1){
+		if(frm.doc.docstatus == 1 && frm.doc.status != 'Stopped'){
 			frm.add_custom_button(__('Make Timesheet'), function(){
 				frappe.model.open_mapped_doc({
 					method: "erpnext.manufacturing.doctype.production_order.production_order.make_new_timesheet",
@@ -124,20 +124,20 @@ erpnext.production_order = {
 			}
 
 			// opertions
-			if ((doc.operations || []).length) {
+			if (((doc.operations || []).length) && frm.doc.status != 'Stopped') {
 				frm.add_custom_button(__('Timesheet'), function() {
 					frappe.route_options = {"production_order": frm.doc.name};
 					frappe.set_route("List", "Timesheet");
 				}, __("View"));
 			}
 
-			if (flt(doc.material_transferred_for_manufacturing) < flt(doc.qty)) {
+			if ((flt(doc.material_transferred_for_manufacturing) < flt(doc.qty)) && frm.doc.status != 'Stopped') {
 				var btn = frm.add_custom_button(__('Start'),
 					cur_frm.cscript['Transfer Raw Materials']);
 				btn.addClass('btn-primary');
 			}
 
-			if (flt(doc.produced_qty) < flt(doc.material_transferred_for_manufacturing)) {
+			if ((flt(doc.produced_qty) < flt(doc.material_transferred_for_manufacturing)) && frm.doc.status != 'Stopped') {
 				var btn = frm.add_custom_button(__('Finish'),
 					cur_frm.cscript['Update Finished Goods']);
 

--- a/erpnext/manufacturing/doctype/production_order/production_order.py
+++ b/erpnext/manufacturing/doctype/production_order/production_order.py
@@ -105,7 +105,7 @@ class ProductionOrder(Document):
 
 	def stop_unstop(self, status):
 		""" Called from client side on Stop/Unstop event"""
-		self.update_status(status)
+		status = self.update_status(status)
 		self.update_planned_qty()
 		frappe.msgprint(_("Production Order status is {0}").format(status))
 		self.notify_update()
@@ -114,12 +114,14 @@ class ProductionOrder(Document):
 	def update_status(self, status=None):
 		'''Update status of production order if unknown'''
 		if not status:
-			status = self.get_status()
+			status = self.get_status(status)
 			
 		if status != self.status:
 			self.db_set("status", status)
 
 		self.update_required_items()
+
+		return status
 
 	def get_status(self, status=None):
 		'''Return the status based on stock entries against this production order'''


### PR DESCRIPTION
Disabled the following buttons when Production Order is Stopped:
- Make Timesheet
- Start
- Finish
- A better fix than https://github.com/frappe/erpnext/commit/316f78f8593659d95336096c493e978559870555
- Sets the Status to In Process or Not Started instead of Unstopped
- Displays this same status on the client prompt (msgprint)
