### PR TITLE
Validate on changing from Total to Valuation/Valuation&Total when add…

### DIFF
--- a/erpnext/accounts/doctype/purchase_taxes_and_charges_template/purchase_taxes_and_charges_template.js
+++ b/erpnext/accounts/doctype/purchase_taxes_and_charges_template/purchase_taxes_and_charges_template.js
@@ -18,3 +18,13 @@ frappe.ui.form.on("Purchase Taxes and Charges", "add_deduct_tax", function(doc, 
 	}
 	refresh_field('add_deduct_tax', d.name, 'taxes');
 });
+
+frappe.ui.form.on("Purchase Taxes and Charges", "category", function(doc, cdt, cdn) {
+	var d = locals[cdt][cdn];
+
+	if (d.category != 'Total' && d.add_deduct_tax == 'Deduct') {
+		msgprint(__("Cannot deduct when category is for 'Valuation' or 'Vaulation and Total'"));
+		d.add_deduct_tax = '';
+	}
+	refresh_field('add_deduct_tax', d.name, 'taxes');
+})

--- a/erpnext/accounts/doctype/purchase_taxes_and_charges_template/purchase_taxes_and_charges_template.js
+++ b/erpnext/accounts/doctype/purchase_taxes_and_charges_template/purchase_taxes_and_charges_template.js
@@ -27,4 +27,4 @@ frappe.ui.form.on("Purchase Taxes and Charges", "category", function(doc, cdt, c
 		d.add_deduct_tax = '';
 	}
 	refresh_field('add_deduct_tax', d.name, 'taxes');
-})
+});


### PR DESCRIPTION
Had an issue with valuation not updating. To replicate issue:
1. Add a purchase taxes/charges in purchase receipt with Total + Deduct selected. 
2. Change Total to Valuation & Total -> no error message appears.
3. On submit, no valuation updates occur.

This adds the validation. 
