### PR TITLE
Quoted Item Comparison: Button for setting the default_supplier

### DIFF
--- a/erpnext/buying/report/quoted_item_comparison/quoted_item_comparison.js
+++ b/erpnext/buying/report/quoted_item_comparison/quoted_item_comparison.js
@@ -11,5 +11,72 @@ frappe.query_reports["Quoted Item Comparison"] = {
 		"default": ""
 		
 	}
-	]
+	],
+	onload: function(report) {
+		//Create a button for setting the default supplier
+		report.page.add_inner_button(__("Select Default Supplier"), function() {
+
+			var reporter = frappe.query_reports["Quoted Item Comparison"];
+			
+			//Always make a new one so that the latest values get updated
+			reporter.make_default_supplier_dialog(report);
+			report.dialog.show();
+			setTimeout(function() { report.dialog.input.focus(); }, 1000);
+				
+		}, 'Tools');
+		
+	},
+	"make_default_supplier_dialog": function (report) {
+		//Get the name of the item to change
+		var filters = report.get_values();
+		var item_code = filters.item;
+		
+		//Get a list of the suppliers (with a blank as well) for the user to select
+		var select_options = "";
+		for (let supplier of report.data)
+		{
+			select_options += supplier.supplier_name+ '\n'
+		}
+		
+		//Create a dialog window for the user to pick their supplier
+		var d = new frappe.ui.Dialog({
+			title: __('Select Default Supplier'),
+			fields: [
+			{fieldname: 'supplier', fieldtype:'Select', label:'Supplier', reqd:1,options:select_options},
+			{fieldname: 'ok_button', fieldtype:'Button', label:'Set Default Supplier'},
+			]
+		});
+		
+		//On the user clicking the ok button
+		d.fields_dict.ok_button.input.onclick = function() {
+			var btn = d.fields_dict.ok_button.input;
+			var v = report.dialog.get_values();
+			if(v) {
+				$(btn).set_working();
+				
+				//Set the default_supplier field of the appropriate Item to the selected supplier
+				frappe.call({
+					method: "frappe.client.set_value",
+					args: {
+						doctype: "Item", 
+						name: item_code,
+						fieldname: "default_supplier",
+						value: v.supplier, 
+					},
+					callback: function (r){
+						$(btn).done_working();
+						msgprint("Successfully Set Supplier");
+						report.dialog.hide();
+
+					}
+				});
+			}
+		}
+		report.dialog = d;
+		
+		
+	}
+	
 }
+
+


### PR DESCRIPTION
Added a button to the report whereby the default supplier can be picked directly from the report. This allows a user to review a number of Supplier Quotations at once, decide who which supplier is best, then pick the preferred supplier directly from a list based on the supplier quotations examined.

https://www.youtube.com/watch?v=jExl-qalnxo
