### PR TITLE
Added supplier quotation filter for Quoted Item Comparison

### DIFF
--- a/erpnext/buying/report/quoted_item_comparison/quoted_item_comparison.js
+++ b/erpnext/buying/report/quoted_item_comparison/quoted_item_comparison.js
@@ -4,12 +4,43 @@
 frappe.query_reports["Quoted Item Comparison"] = {
 	"filters": [
 	{
+		"fieldname":"supplier_quotation",
+		"label": __("Supplier Quotation"),
+		"fieldtype": "Link",
+		"options": "Supplier Quotation",
+		"default": "",
+		"get_query": function() {
+				return {
+					filters: {"docstatus": ["<",2]}
+				}
+			}
+		
+		
+	},{
 		"fieldname":"item",
 		"label": __("Item"),
 		"fieldtype": "Link",
 		"options": "Item",
-		"default": ""
-		
+		"default": "",
+		"reqd": 1,
+		"get_query": function() {
+				var quote = frappe.query_report_filters_by_name.supplier_quotation.get_value();
+				if (quote != "")
+				{
+					return {
+						query: "erpnext.buying.doctype.quality_inspection.quality_inspection.item_query",
+						filters: {
+							"from": "Supplier Quotation Item",
+							"parent": quote
+						}
+					}
+				}
+				else{
+					return{
+						filters: {"disabled":0}
+					}
+				}
+			}
 	}
 	],
 	onload: function(report) {


### PR DESCRIPTION
This change adds an optional filter for supplier quotation, so that uses can quickly compare all the items in a single quotation without having to remember all the item codes in that quote.
