### PR TITLE
Activity Summary to not show cancelled timesheets on click

### DIFF
--- a/erpnext/projects/doctype/project/project.js
+++ b/erpnext/projects/doctype/project/project.js
@@ -78,7 +78,7 @@ frappe.ui.form.on("Project", {
 			section.on('click', '.time-sheet-link', function() {
 				var activity_type = $(this).attr('data-activity_type');
 				frappe.set_route('List', 'Timesheet',
-					{'activity_type': activity_type, 'project': frm.doc.name});
+					{'activity_type': activity_type, 'project': frm.doc.name, 'status': ["!=", "Cancelled"]});
 			});
 		}
 	}


### PR DESCRIPTION
Clicking an Activity Type in the Activity summary portion of project will add filter of "Status" != "Cancelled"
