### PR TITLE
Changed button url of Gantt Chart inside projects

### DIFF
--- a/erpnext/projects/doctype/project/project.js
+++ b/erpnext/projects/doctype/project/project.js
@@ -43,9 +43,8 @@ frappe.ui.form.on("Project", {
 
 			if(frappe.model.can_read("Task")) {
 				frm.add_custom_button(__("Gantt Chart"), function() {
-					frappe.route_options = {"project": frm.doc.name,
-						"start": frm.doc.expected_start_date, "end": frm.doc.expected_end_date};
-					frappe.set_route("Gantt", "Task");
+					frappe.route_options = {"project": frm.doc.name};
+					frappe.set_route("List", "Task", "Gantt");
 				});
 			}
 


### PR DESCRIPTION
The URL seems to have changed and this seems to be the new pattern for the Gantt Diagram

is the set_route with 3 parameters ok?
