### PR TITLE
Only use conversion rate if using Supplier Type

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -158,11 +158,17 @@ def get_pricing_rule_for_item(args):
 		item_details.margin_type = pricing_rule.margin_type
 		item_details.margin_rate_or_amount = pricing_rule.margin_rate_or_amount
 		if pricing_rule.price_or_discount == "Price":
-			item_details.update({
-				"price_list_rate": pricing_rule.price/flt(args.conversion_rate) \
-					if args.conversion_rate else 0.0,
-				"discount_percentage": 0.0
-			})
+			if pricing_rule.application_for == "Supplier Type":
+				item_details.update({
+					"price_list_rate":  pricing_rule.price/flt(args.conversion_rate) \
+						if args.conversion_rate else 0.0,
+					"discount_percentage": 0.0
+				})
+			else:
+				item_details.update({
+					"price_list_rate":  pricing_rule.price,
+					"discount_percentage": 0.0
+				})
 		else:
 			item_details.discount_percentage = pricing_rule.discount_percentage
 	return item_details


### PR DESCRIPTION
Related to issue #6471 

Only uses the conversion factor for Pricing Rules when the Applicable For field is set to Supplier Type. When set to Supplier, it will not convert the price_rate based on the conversion_rate.
