### PR TITLE
[fix] move linked communications with timesheet

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -329,3 +329,4 @@ erpnext.patches.v7_0.update_mode_of_payment_type
 execute:frappe.reload_doctype("Salary Slip")
 execute:frappe.db.sql("update `tabSalary Slip` set posting_date=creation")
 erpnext.patches.v7_1.update_portal_roles
+erpnext.patches.v7_0.remove_dead_links_for_time_log

--- a/erpnext/patches/v7_0/convert_timelog_to_timesheet.py
+++ b/erpnext/patches/v7_0/convert_timelog_to_timesheet.py
@@ -30,7 +30,12 @@ def execute():
 		time_sheet.flags.ignore_validate = True
 		time_sheet.flags.ignore_links = True
 		time_sheet.save(ignore_permissions=True)
-
+		frappe.db.sql("""update tabCommunication 
+				set reference_doctype = "Timesheet",
+				reference_name = %(timesheet)s
+				where reference_doctype = "Time Log"
+				and reference_name = %(timelog)s""",{'timesheet':time_sheet.name,'timelog':data.name},auto_commit=1)
+		
 		# To ignore validate_mandatory_fields function
 		if data.docstatus == 1:
 			time_sheet.db_set("docstatus", 1)

--- a/erpnext/patches/v7_0/remove_dead_links_for_time_log.py
+++ b/erpnext/patches/v7_0/remove_dead_links_for_time_log.py
@@ -1,0 +1,7 @@
+import frappe
+
+def execute():
+	frappe.db.sql("""UPDATE tabCommunication 
+				SET reference_doctype = NULL,
+				reference_name = NULL
+				WHERE reference_doctype = "Time Log" """, auto_commit=1)


### PR DESCRIPTION
moves the references on communications from timelogs to timesheets and removes any references that weren't moved
