### PR TITLE
[fix] email digest date range starting with opening balance of day on…

### DIFF
--- a/erpnext/setup/doctype/email_digest/email_digest.py
+++ b/erpnext/setup/doctype/email_digest/email_digest.py
@@ -340,13 +340,13 @@ class EmailDigest(Document):
 		count = 0
 		for account in accounts:
 			balance += (get_balance_on(account, date = self.future_to_date)
-				- get_balance_on(account, date = self.future_from_date))
+				- get_balance_on(account, date = self.future_from_date - timedelta(days=1)))
 
 			count += (get_count_on(account,fieldname, date = self.future_to_date )
-				- get_count_on(account,fieldname, date = self.future_from_date))
+				- get_count_on(account,fieldname, date = self.future_from_date - timedelta(days=1)))
 
 			past_balance += (get_balance_on(account, date = self.past_to_date)
-				- get_balance_on(account, date = self.past_from_date))
+				- get_balance_on(account, date = self.past_from_date - timedelta(days=1)))
 
 		return balance, past_balance, count
 


### PR DESCRIPTION
…e not closing

ie monthly currently get's balance at the end of 1st of september to the 30th of september instead of the beginning of the 1st aka the end of the 31st fo august
