### PR TITLE
[Fix] Allow user to save Notification Control without selecting trans…action

### DIFF
--- a/erpnext/setup/doctype/notification_control/notification_control.js
+++ b/erpnext/setup/doctype/notification_control/notification_control.js
@@ -9,7 +9,9 @@ frappe.ui.form.on("Notification Control", {
 		frm.set_value("custom_message", frm.doc[frm.events.get_fieldname(frm)]);
 	},
 	set_message: function(frm) {
-		frm.set_value(frm.events.get_fieldname(frm), frm.doc.custom_message);
+		if(frm.doc.select_transaction) {
+			frm.set_value(frm.events.get_fieldname(frm), frm.doc.custom_message);
+		}
 		frm.save();
 	},
 	get_fieldname: function(frm) {

--- a/erpnext/setup/doctype/notification_control/notification_control.js
+++ b/erpnext/setup/doctype/notification_control/notification_control.js
@@ -9,7 +9,7 @@ frappe.ui.form.on("Notification Control", {
 		frm.set_value("custom_message", frm.doc[frm.events.get_fieldname(frm)]);
 	},
 	set_message: function(frm) {
-		if(frm.doc.select_transaction) {
+		if(frm.doc.select_transaction && frm.doc.select_transaction !== " ") {
 			frm.set_value(frm.events.get_fieldname(frm), frm.doc.custom_message);
 		}
 		frm.save();


### PR DESCRIPTION
Problem: If user does not select any transaction in Notification Control form to customize then, user was not allowed to save the form

Solution: If no transaction is selected just save the form to update values for notification prompts.

Fixes #6558 
