### PR TITLE
Fix calendar view for Timesheet

### DIFF
--- a/erpnext/projects/doctype/timesheet/timesheet.py
+++ b/erpnext/projects/doctype/timesheet/timesheet.py
@@ -369,7 +369,7 @@ def get_events(start, end, filters=None):
 	conditions = get_conditions(filters)
 	return frappe.db.sql("""select `tabTimesheet Detail`.name as name, 
 			`tabTimesheet Detail`.docstatus as status, `tabTimesheet Detail`.parent as parent,
-			from_time, hours, activity_type, project, to_time 
+			from_time as start_date, hours, activity_type, project, to_time as end_date
 		from `tabTimesheet Detail`, `tabTimesheet` 
 		where `tabTimesheet Detail`.parent = `tabTimesheet`.name 
 			and `tabTimesheet`.docstatus < 2 


### PR DESCRIPTION
All the calendar events for Timesheets show up on one date. This is because there was a change to the timesheet_calendar.js file when the Gantt chart was added, but the get_events for the calendar wasn't fixed at the same time. Just fixing the reference to the start and end times.

In reference to issue #6597 
