### PR TITLE
[minor] link formatter fixes for Item and Employee

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -192,7 +192,7 @@ erpnext.utils.map_current_doc = function(opts) {
 
 frappe.form.link_formatters['Item'] = function(value, doc) {
 	if(doc && doc.item_name && doc.item_name !== value) {
-		return value + ': ' + doc.item_name;
+		return value? value + ': ' + doc.item_name: doc.item_name;
 	} else {
 		return value;
 	}
@@ -200,7 +200,7 @@ frappe.form.link_formatters['Item'] = function(value, doc) {
 
 frappe.form.link_formatters['Employee'] = function(value, doc) {
 	if(doc && doc.employee_name && doc.employee_name !== value) {
-		return value + ': ' + doc.employee_name;
+		return value? value + ': ' + doc.employee_name: doc.employee_name;
 	} else {
 		return value;
 	}


### PR DESCRIPTION
In Sales Order, Item code is not mandatory so in Grid View Item Code Link will display like " : Item Name" instead of just "Item Name"

e.g. 
![before](https://cloud.githubusercontent.com/assets/11224291/19755103/c082c45c-9c30-11e6-8ddc-c3a7e37ea307.png)
