### PR TITLE
[fix] Change communication to Linked

### DIFF
--- a/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
+++ b/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
@@ -131,7 +131,8 @@ class RequestforQuotation(BuyingController):
 
 	def send_email(self, data, sender, subject, message, attachments):
 		make(subject = subject, content=message,recipients=data.email_id, 
-			sender=sender,attachments = attachments, send_email=True)["name"]
+			sender=sender,attachments = attachments, send_email=True,
+		    	doctype=self.doctype, name = self.name)["name"]
 
 		frappe.msgprint(_("Email sent to supplier {0}").format(data.supplier))
 


### PR DESCRIPTION
Currently, the Request for Quotation emails are not linked to the RFQ document. This resolves that issue.

https://discuss.erpnext.com/t/open-communications-for-rfq/17184
