### PR TITLE
[docs] URL fixes

### DIFF
--- a/erpnext/docs/user/manual/de/customize-erpnext/custom-field.md
+++ b/erpnext/docs/user/manual/de/customize-erpnext/custom-field.md
@@ -12,7 +12,7 @@ Um ein benutzerdefiniertes Feld hinzuzufügen, gehen Sie zu:
 
 > Einstellungen > Anpassen > Benutzerdefiniertes Feld > Neu
 
-Sie können ein neues benutzerdefiniertes Feld auch über das [Werkzeug zum Anpassen von Feldern](https://erpnext.com/customize-erpnext/customize-form) einfügen.
+Sie können ein neues benutzerdefiniertes Feld auch über das [Werkzeug zum Anpassen von Feldern]({{docs_base_url}}/user/manual/de/customize-erpnext/customize-form) einfügen.
 
 In einem benutzerdefinierten Formular finden Sie für jedes Feld die Plus(+)-Option. Wenn Sie auf dieses Symbol klicken, wird eine neue Zeile oberhalb dieses Feldes eingefügt. Sie können die Einstellungen für Ihr Feld in der neu eingefügten leeren Zeile eingeben.
 
@@ -50,7 +50,7 @@ Klicken Sie hier um weitere Informationen über Feldtypen, die Sie bei einem ben
 
 ### Optionen einstellen
 
-Wenn Sie ein Verknüpfungsfeld erstellen,dann wird der Name des DocType, mit dem dieses Feld verknüpft werden soll, in das Feld "Optionen" eingefügt. Klicken Sie [hier](https://erpnext.com/kb/customize/creating-custom-link-field) um weitere Informationen darüber zu erhalten, wie man benutzerdefinierte Verknüpfungsfelder erstellt.
+Wenn Sie ein Verknüpfungsfeld erstellen,dann wird der Name des DocType, mit dem dieses Feld verknüpft werden soll, in das Feld "Optionen" eingefügt. Klicken Sie [hier]({{docs_base_url}}/user/manual/en/customize-erpnext/articles/creating-custom-link-field) um weitere Informationen darüber zu erhalten, wie man benutzerdefinierte Verknüpfungsfelder erstellt.
 
 ![Verknüpfung mit einem benutzerdefinierten Feld]({{docs_base_url}}/assets/old_images/erpnext/custom-field-link.png)
 

--- a/erpnext/docs/user/manual/de/customize-erpnext/customize-form.md
+++ b/erpnext/docs/user/manual/de/customize-erpnext/customize-form.md
@@ -71,7 +71,7 @@ Im Folgenden erhalten Sie eine Auflistung der Eigenschaften, die Sie für ein be
     </tr>
     <tr>
       <td>Feldtyp</td>
-      <td>Klicken Sie <a href="https://erpnext.com/kb/customize/field-types">hier</a> um mehr über Feldtypen zu erfahren.</td>
+      <td>Klicken Sie <a href="{{docs_base_url}}/user/manual/en/customize-erpnext/articles/field-types">hier</a> um mehr über Feldtypen zu erfahren.</td>
     </tr>
     <tr>
       <td>Optionen</td>

--- a/erpnext/docs/user/manual/en/CRM/setup/sales-person.md
+++ b/erpnext/docs/user/manual/en/CRM/setup/sales-person.md
@@ -8,7 +8,7 @@ Group.
 ####Sales Person in Transactions
 
 You can use this Sales Person in Customer and sales transactions like Sales Order, Delivery Note and Sales Invoice.
-Click [here](https://erpnext.com/kb/selling/managing-sales-persons-in-sales-transactions) to learn more 
+Click [here]({{docs_base_url}}/user/manual/en/selling/articles/sales-persons-in-the-sales-transactions) to learn more 
 about how Sales Persons are used in the transactions of Sales Cycle.
 
 {next}

--- a/erpnext/docs/user/manual/en/accounts/payments.md
+++ b/erpnext/docs/user/manual/en/accounts/payments.md
@@ -22,7 +22,7 @@ On submitting a document against which Payment Entry can be made, you will find 
 
 <img class="screenshot" alt="Making Payment" src="{{docs_base_url}}/assets/img/accounts/payment-entry-9.png">
 
-For more details about payment entry [check here.](https://frappe.github.io/erpnext/user/manual/en/accounts/payment-entry)
+For more details about payment entry [check here.]({{docs_base_url}}/user/manual/en/accounts/payment-entry)
 
 ## Journal Entry
 
@@ -45,4 +45,4 @@ On submitting a document against which Journal Entry can be made, you will find 
 Save and submit the journal entry to record the payament against the invoice
 <img class="screenshot" alt="Making Payment" src="{{docs_base_url}}/assets/img/accounts/journal-entry.png">
 
-For more details about journal entry [check here.](https://frappe.github.io/erpnext/user/manual/en/accounts/journal-entry)
+For more details about journal entry [check here.]({{docs_base_url}}/user/manual/en/accounts/journal-entry)

--- a/erpnext/docs/user/manual/en/human-resources/articles/employees-loan-management.md
+++ b/erpnext/docs/user/manual/en/human-resources/articles/employees-loan-management.md
@@ -10,7 +10,7 @@ Create following Groups and Ledgers in Chart of Accounts if not there.
       
 #### 1.1  Employee Loan Account
 
-Create Group as 'Employees Loans' under Current Assets and create employee loan A/C (Ledger) under it. [Check this link for new account creation](https://erpnext.com/kb/setup/managing-tree-structure-masters)
+Create Group as 'Employees Loans' under Current Assets and create employee loan A/C (Ledger) under it. [Check this link for new account creation]({{docs_base_url}}/user/manual/en/setting-up/articles/managing-tree-structure-masters)
 
 ![CoA]({{docs_base_url}}/assets/img/articles/Selection_433.png)
 

--- a/erpnext/docs/user/manual/en/selling/setup/sales-person-target-allocation.md
+++ b/erpnext/docs/user/manual/en/selling/setup/sales-person-target-allocation.md
@@ -80,7 +80,7 @@ You can link Monthly Distribution while allocating targets in Sales Person as we
 
 ###See Also
 
-1. [Managing Sales Person](https://erpnext.com/selling/selling-setup/sales-person)
-2. [Using Sales Person in transactions](https://erpnext.com/kb/selling/managing-sales-persons-in-sales-transactions)
+1. [Sales Person Target Allocation]({{docs_base_url}}/user/manual/en/selling/setup/sales-person-target-allocation)
+2. [Using Sales Person in transactions]({{docs_base_url}}/user/manual/en/selling/articles/sales-persons-in-the-sales-transactions)
 
 {next}


### PR DESCRIPTION
* outdated links updated to `{{docs_base_url}}`
* as several German articles are missing, the links are redirected to their English counterparts