### PR TITLE
[Fix] Fixed condition and formula issue in Salary Slip

### DIFF
--- a/erpnext/hr/doctype/salary_slip/salary_slip.py
+++ b/erpnext/hr/doctype/salary_slip/salary_slip.py
@@ -84,6 +84,7 @@ class SalarySlip(TransactionBase):
 			if d.amount_based_on_formula:
 				if d.formula:
 					amount = eval(d.formula, None, data)
+			if amount:		
 				data[d.abbr] = amount
 			return amount
 			


### PR DESCRIPTION
Salary component amount was not getting updated for condition and formula.