### PR TITLE
Fix#6858  material request status for partially ordered

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request_list.js
+++ b/erpnext/stock/doctype/material_request/material_request_list.js
@@ -3,8 +3,10 @@ frappe.listview_settings['Material Request'] = {
 	get_indicator: function(doc) {
 		if(doc.status=="Stopped") {
 			return [__("Stopped"), "red", "status,=,Stopped"];
-		} else if(doc.docstatus==1 && flt(doc.per_ordered, 2) < 100) {
-			return [__("Pending"), "orange", "per_ordered,<,100"];
+		} else if(doc.docstatus==1 && flt(doc.per_ordered, 2) == 0) {
+			return [__("Pending"), "orange", "per_ordered,=,0"];
+		}  else if(doc.docstatus==1 && flt(doc.per_ordered, 2) < 100) {
+			return [__("Partially ordred"), "yellow", "per_ordered,<,100"];
 		} else if(doc.docstatus==1 && flt(doc.per_ordered, 2) == 100) {
 			if (doc.material_request_type == "Purchase") {
 				return [__("Ordered"), "green", "per_ordered,=,100"];


### PR DESCRIPTION
Now there will be separate status "partially ordered",  When Purchase Order is created for some of the Items in the Material Request, then it's status will be set as Partially Ordered.