### PR TITLE
[fix] if terms exists then only call render_template

### DIFF
--- a/erpnext/setup/doctype/terms_and_conditions/terms_and_conditions.py
+++ b/erpnext/setup/doctype/terms_and_conditions/terms_and_conditions.py
@@ -18,4 +18,6 @@ def get_terms_and_conditions(template_name, doc):
 		doc = json.loads(doc)
 
 	terms_and_conditions = frappe.get_doc("Terms and Conditions", template_name)
-	return frappe.render_template(terms_and_conditions.terms, doc)
+	
+	if terms_and_conditions.terms:
+		return frappe.render_template(terms_and_conditions.terms, doc)


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2016-12-29/apps/frappe/frappe/app.py", line 55, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2016-12-29/apps/frappe/frappe/handler.py", line 19, in handle
    execute_cmd(cmd)
  File "/home/frappe/benches/bench-2016-12-29/apps/frappe/frappe/handler.py", line 40, in execute_cmd
    ret = frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2016-12-29/apps/frappe/frappe/__init__.py", line 896, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2016-12-29/apps/erpnext/erpnext/setup/doctype/terms_and_conditions/terms_and_conditions.py", line 21, in get_terms_and_conditions
    return frappe.render_template(terms_and_conditions.terms, doc)
  File "/home/frappe/benches/bench-2016-12-29/apps/frappe/frappe/utils/jinja.py", line 46, in render_template
    or template.startswith("templates/")
AttributeError: 'NoneType' object has no attribute 'startswith'
```