### PR TITLE
Adds button to find MRs linked to Supplier

### DIFF
--- a/erpnext/buying/doctype/request_for_quotation/request_for_quotation.js
+++ b/erpnext/buying/doctype/request_for_quotation/request_for_quotation.js
@@ -134,6 +134,46 @@ erpnext.buying.RequestforQuotationController = erpnext.buying.BuyingController.e
 						}
 					})
 				}, __("Get items from"));
+			cur_frm.add_custom_button(__('Possible Supplier'),
+				function() {
+					
+
+					
+					//Create a dialog window for the user to pick their supplier
+					var d = new frappe.ui.Dialog({
+						title: __('Select Possible Supplier'),
+						fields: [
+						{fieldname: 'supplier', fieldtype:'Link', options:'Supplier', label:'Supplier', reqd:1},
+						{fieldname: 'ok_button', fieldtype:'Button', label:'Get Material Requests'},
+						]
+					});
+					
+					//On the user clicking the ok button
+					d.fields_dict.ok_button.input.onclick = function() {
+						var btn = d.fields_dict.ok_button.input;
+						var v = d.get_values();
+						if(v) {
+							$(btn).set_working();
+							
+							erpnext.utils.map_current_doc({
+								method: "erpnext.buying.doctype.request_for_quotation.request_for_quotation.get_matreq_from_possible_supplier",
+								source_name: v.supplier,
+								get_query_filters: {
+									material_request_type: "Purchase",
+									docstatus: 1,
+									status: ["!=", "Stopped"],
+									per_ordered: ["<", 99.99],
+									company: cur_frm.doc.company
+								}
+							});
+							$(btn).done_working();
+							//msgprint("Loaded Material Requests");
+							d.hide();
+						}
+					
+					}	
+					d.show();
+				}, __("Get items from"));
 		}
 	},
 


### PR DESCRIPTION
Creates a button on the Make drop down menu of the Request for Quotation doc which pops up a dialog. The dialog asks the user to pick a supplier. After clicking the OK button with a Supplier picked, the system searches through all the Open material requests determines which material request items have an Item Supplier (supplier part number) associated with Item. It then adds all of them into the current Request for Quotation.

This feature is badly needed, as it is extremely tedious to manually have to search through every Material Request in order to prepare Request for Quotations. Purchase Orders have the feature which allows Material Requests to be pulled based on the default supplier, but at the RFQ stage, a default supplier hasn't been set. This way, you can add possible suppliers to each Item, then pull the correct items into an RFQ with just a few clicks.