### PR TITLE
[FIX] Contact form breaks on existing lead

### DIFF
--- a/erpnext/templates/utils.py
+++ b/erpnext/templates/utils.py
@@ -34,6 +34,8 @@ def send_message(subject="Website Query", message="", sender="", status="Open"):
 
 	if customer:
 		opportunity.customer = customer
+	elif lead:
+		opportunity.lead = lead
 	else:
 		opportunity.lead = new_lead.name
 


### PR DESCRIPTION
When an email address from the contacts form is from a existing lead utils.py tries to set new_lead(an undefined var) as the lead reference if a lead is found.