### PR TITLE
Patch to add Start and End Date in Salary Slips

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -360,3 +360,4 @@ erpnext.patches.v7_1.set_sales_person_status
 erpnext.patches.v7_1.repost_stock_for_deleted_bins_for_merging_items
 execute:frappe.delete_doc('Desktop Icon', {'module_name': 'Profit and Loss Statment'})
 erpnext.patches.v7_2.update_website_for_variant
+erpnext.patches.v7_2.update_salary_slips

--- a/erpnext/patches/v7_2/update_salary_slips.py
+++ b/erpnext/patches/v7_2/update_salary_slips.py
@@ -1,0 +1,16 @@
+import frappe
+from erpnext.hr.doctype.process_payroll.process_payroll import get_month_details
+
+def execute():
+	salary_slips = frappe.db.sql("""select fiscal_year, month, name from `tabSalary Slip` 
+				where (month is not null and month != '') 
+				and (fiscal_year is not null and fiscal_year != '') and
+				(start_date is null  or start_date = '') and 
+				(end_date is null  or end_date = '') and docstatus != 2""")
+
+	for salary_slip in salary_slips:
+		get_start_end_date = get_month_details(salary_slip.fiscal_year, salary_slip.month)
+		start_date = get_start_end_date['month_start_date']
+		end_date = get_start_end_date['month_end_date']
+		frappe.db.sql("""update `tabSalary Slip` set start_date = %s, end_date = %s where name = %s""",
+		(start_date, end_date, salary_slip.name))


### PR DESCRIPTION
Salary slips generated before April does not have Start and End date hence does not show up in Monthly Salary Register Report.