### PR TITLE
[fix] accounts heatmaps now covering 366 days not 20

### DIFF
--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -350,6 +350,6 @@ def get_timeline_data(doctype, name):
 	from frappe.desk.form.load import get_communication_data
 	data = get_communication_data(doctype, name,
 		fields = 'unix_timestamp(date(creation)), count(name)',
-		after = add_years(None, -1).strftime('%Y-%m-%d'),
+		after = add_years(None, -1).strftime('%Y-%m-%d'), limit = 366,
 		group_by='group by date(creation)', as_dict=False)
 	return dict(data)


### PR DESCRIPTION
as seen on a supplier
before
![image](https://cloud.githubusercontent.com/assets/15826176/22055000/ccf8fa7c-dd93-11e6-90f5-9980e28f73d6.png)

after
![image](https://cloud.githubusercontent.com/assets/15826176/22054971/ae96a3d6-dd93-11e6-97ee-40a109d36d45.png)
