### PR TITLE
Patch to update Salary Detail where Salary Component Abbr is null

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -363,3 +363,4 @@ erpnext.patches.v7_2.update_website_for_variant
 erpnext.patches.v7_2.update_doctype_status
 erpnext.patches.v7_2.update_salary_slips
 erpnext.patches.v7_2.set_null_value_to_fields
+erpnext.patches.v7_2.update_abbr_in_salary_slips

--- a/erpnext/patches/v7_2/update_abbr_in_salary_slips.py
+++ b/erpnext/patches/v7_2/update_abbr_in_salary_slips.py
@@ -1,0 +1,13 @@
+import frappe
+
+def execute():
+	frappe.reload_doctype('Salary Slip')
+	if not frappe.db.has_column('Salary Detail', 'abbr'):
+		return
+
+	salary_details = frappe.db.sql("""select abbr, salary_component, name from `tabSalary Detail`
+				where abbr is null or abbr = ''""", as_dict=True)
+
+	for salary_detail in salary_details:
+		salary_component_abbr = frappe.get_value("Salary Component", salary_detail.salary_component, "salary_component_abbr")
+		frappe.db.sql("""update `tabSalary Detail` set abbr = %s where name = %s""",(salary_component_abbr, salary_detail.name))


### PR DESCRIPTION
Edits to Salary slips generated before abbr was added Salary Component  was not possible.
<img width="420" alt="screen shot 2017-01-22 at 11 03 09 am" src="https://cloud.githubusercontent.com/assets/16913064/22180310/7c0f0cda-e092-11e6-8813-fb86304c6aea.png">
