### PR TITLE
[fix] compact print format not longer ignores format builder

### DIFF
--- a/erpnext/controllers/print_settings.py
+++ b/erpnext/controllers/print_settings.py
@@ -16,14 +16,13 @@ def print_settings_for_item_table(doc):
 
 	if doc.flags.compact_item_print:
 		doc.print_templates["description"] = "templates/print_formats/includes/item_table_description.html"
-		doc.hide_in_print_layout += ["item_code", "item_name", "image"]
-
 		doc.flags.compact_item_fields = ["description", "qty", "rate", "amount"]
-		doc.flags.show_in_description = []
+		doc.flags.format_columns = format_columns
 
-		for df in doc.meta.fields:
-			if df.fieldtype not in ("Section Break", "Column Break", "Button"):
-				if not doc.is_print_hide(df.fieldname):
-					if df.fieldname not in doc.hide_in_print_layout and df.fieldname not in doc.flags.compact_item_fields:
-						doc.hide_in_print_layout.append(df.fieldname)
-						doc.flags.show_in_description.append(df.fieldname)
+def format_columns(display_columns, compact_fields):
+	compact_fields = compact_fields + ["image", "item_code", "item_name"]
+	final_columns = []
+	for column in display_columns:
+		if column not in compact_fields:
+			final_columns.append(column)
+	return final_columns

--- a/erpnext/templates/print_formats/includes/item_table_description.html
+++ b/erpnext/templates/print_formats/includes/item_table_description.html
@@ -1,14 +1,16 @@
 {%- set compact = doc.flags.compact_item_print -%}
 {%- set compact_fields = doc.flags.compact_item_fields -%}
+{%- set display_columns = visible_columns|map(attribute="fieldname")| list -%}
+{%- set columns = doc.flags.format_columns(display_columns, compact_fields) -%}
 
-{% if doc.in_format_data("image") and doc.get("image") and not doc.is_print_hide("image")-%}
+{% if doc.in_format_data("image") and doc.get("image") and "image" in display_columns -%}
 <div class="pull-left" style="max-width: 40%; margin-right: 10px;">
 	<img class="print-item-image" src="{{ doc.image }}" alt="">
 </div>
 {%- endif %}
 
 <div>
-	{% if doc.in_format_data("item_code") and not doc.is_print_hide("item_code") -%}
+	{% if doc.in_format_data("item_code") and "item_code" in display_columns -%}
 		<div class="primary">
 			{% if compact %}<strong>{% endif %}
 				{{ _(doc.item_code) }}
@@ -16,9 +18,8 @@
 		</div>
 	{%- endif %}
 
-	{% if (doc.in_format_data("item_name") and not doc.is_print_hide("item_name") and
-		(not doc.in_format_data("item_code") or doc.is_print_hide("item_code")
-			or doc.item_code != doc.item_name)) -%}
+	{%- if doc.in_format_data("item_name") and "item_name" in display_columns and
+		not (doc.in_format_data("item_code") and doc.item_code == doc.item_name) -%}
 		<div class="primary">{{ doc.get_formatted("item_name", translated=True) }}</div>
 	{%- endif %}
 
@@ -34,7 +35,7 @@
 	{%- endif %}
 
 	{% if compact -%}
-		{%- for fieldname in doc.flags.show_in_description -%}
+		{%- for fieldname in columns -%}
 			{% if doc.get(fieldname) and doc.in_format_data(fieldname) -%}
 			<p>
 				<strong>{{ _(doc.meta.get_label(fieldname)) }}:</strong>


### PR DESCRIPTION
part 2 of 2 see frappe for part 1
before
![image](https://cloud.githubusercontent.com/assets/15826176/22276159/b560fc9e-e2ec-11e6-8722-058742b6e800.png)
after with a print format setup to show more fields
![image](https://cloud.githubusercontent.com/assets/15826176/22276177/d6d3a64c-e2ec-11e6-9a54-3974b52933b3.png)

