### PR TITLE
Allow to specify Income account in Item for each Company

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -191,8 +191,9 @@ def get_basic_details(args, item):
 
 def get_default_income_account(args, item):
 	item_account = None
-	account = frappe.get_doc("Account", item.income_account)
-	if account.company != args.company:
+        if item.income_account:
+	   account = frappe.get_doc("Account", item.income_account)
+	   if account.company != args.company:
 		company_account = frappe.db.sql("SELECT name FROM `tabAccount` WHERE account_name = %s AND account_type = %s AND company = %s",
 										(account.account_name, account.account_type, args.company))
 		if company_account:

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -190,7 +190,16 @@ def get_basic_details(args, item):
 	return out
 
 def get_default_income_account(args, item):
-	return (item.income_account
+	item_account = None
+	account = frappe.get_doc("Account", item.income_account)
+	if account.company != args.company:
+		company_account = frappe.db.sql("SELECT name FROM `tabAccount` WHERE account_name = %s AND account_type = %s AND company = %s",
+										(account.account_name, account.account_type, args.company))
+		if company_account:
+			item_account = company_account[0][0]
+
+	return (item_account
+	    or item.income_account
 		or args.income_account
 		or frappe.db.get_value("Item Group", item.item_group, "default_income_account"))
 


### PR DESCRIPTION
for simplicity if the income account specify in the transaction is not the same company in the item income account set in Item Doctype. It will try to find the same account name and account type in the Account Doctype with the same company of the transaction. If it exist this will be used as the income account.

https://github.com/frappe/erpnext/issues/8065