### PR TITLE
Prevent Variants from Manufacturer Update

### DIFF
--- a/erpnext/patches/v8_0/manufacturer_childtable_migrate.py
+++ b/erpnext/patches/v8_0/manufacturer_childtable_migrate.py
@@ -22,4 +22,5 @@ def execute():
             })
             item_doc.flags.ignore_validate = True
             item_doc.flags.ignore_mandatory = True
+            item_doc.flags.dont_update_variants = True
             item_doc.save()


### PR DESCRIPTION
The variants of items with a manufacturer part number but no manufacturer currently get updated then don't pass validation. This will prevent them from getting updated.