### PR TITLE
Removal of double parentheses in the setup wizard

### DIFF
--- a/erpnext/setup/setup_wizard/setup_wizard.py
+++ b/erpnext/setup/setup_wizard/setup_wizard.py
@@ -89,7 +89,7 @@ def create_fiscal_year_and_company(args):
 			'default_currency':args.get('currency'),
 			'country': args.get('country'),
 			'create_chart_of_accounts_based_on': 'Standard Template',
-			'chart_of_accounts': args.get(('chart_of_accounts')),
+			'chart_of_accounts': args.get('chart_of_accounts'),
 			'domain': args.get('domain')
 		}).insert()
 
@@ -607,5 +607,3 @@ def create_room(args):
 				room.save()
 			except frappe.DuplicateEntryError:
 				pass
-
-


### PR DESCRIPTION
Hi all,

I was wondering why my chart of account available in the verified folder was not picked up when setting up the first chart of account during the setup wizard. ERPNext always used the standard chart of account.

I found out that the attribute 'chart_of_accounts' was inside a double parenthesis in `'chart_of_accounts': args.get(('chart_of_accounts')),`

Double parentheses are used in python to mark a tuple, but here I don't really understand why it is used, since can only have one element. Should it not be a single parenthesis like for all other attributes ?
I would be happy to hear back from anyone, since I'm not sure to understand the problem enterely :smiley: 

It appears, when testing it, that the chart of account is correctly picked up when removing the double parentheses. 

So I am wondering if it is a real issue and why no one would have picked it since it is present in the code from the beginning.

I would love to hear your feedback!

Thanks a lot!

