### PR TITLE
[minor] added safe_eval for status_updater and added getdate and nowdate

### DIFF
--- a/erpnext/controllers/status_updater.py
+++ b/erpnext/controllers/status_updater.py
@@ -3,7 +3,7 @@
 
 from __future__ import unicode_literals
 import frappe
-from frappe.utils import flt, comma_or
+from frappe.utils import flt, comma_or, nowdate, getdate
 from frappe import _
 from frappe.model.document import Document
 
@@ -119,7 +119,7 @@ class StatusUpdater(Document):
 					self.status = s[0]
 					break
 				elif s[1].startswith("eval:"):
-					if eval(s[1][5:]):
+					if frappe.safe_eval(s[1][5:], None, { "self": self.as_dict(), "getdate": getdate, "nowdate": nowdate }):
 						self.status = s[0]
 						break
 				elif getattr(self, s[1])():


### PR DESCRIPTION
Traceback (most recent call last):
  File "/home/travis/frappe-bench/apps/erpnext/erpnext/selling/doctype/sales_order/test_sales_order.py", line 156, in test_reserved_qty_for_over_delivery_via_sales_invoice
    si.submit()
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 741, in submit
    self._submit()
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 730, in _submit
    self.save()
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 231, in save
    return self._save(*args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 264, in _save
    self.run_before_save_methods()
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 775, in run_before_save_methods
    self.run_method("validate")
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 892, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 875, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 661, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/travis/frappe-bench/apps/erpnext/erpnext/accounts/doctype/sales_invoice/sales_invoice.py", line 89, in validate
    self.set_status()
  File "/home/travis/frappe-bench/apps/erpnext/erpnext/controllers/status_updater.py", line 122, in set_status
    if eval(s[1][5:]):
  File "<string>", line 1, in <module>
NameError: name 'getdate' is not defined