### PR TITLE
[minor] added order by args to get_*_list methods

### DIFF
--- a/erpnext/controllers/website_list_for_contact.py
+++ b/erpnext/controllers/website_list_for_contact.py
@@ -18,7 +18,7 @@ def get_list_context(context=None):
 		"get_list": get_transaction_list
 	}
 
-def get_transaction_list(doctype, txt=None, filters=None, limit_start=0, limit_page_length=20):
+def get_transaction_list(doctype, txt=None, filters=None, limit_start=0, limit_page_length=20, order_by="modified"):
 	from frappe.www.list import get_list
 	user = frappe.session.user
 	key = None

--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -214,7 +214,7 @@ def get_timeline_data(doctype, name):
 			and docstatus < 2
 			group by date(from_time)''', name))
 
-def get_project_list(doctype, txt, filters, limit_start, limit_page_length=20):
+def get_project_list(doctype, txt, filters, limit_start, limit_page_length=20, order_by="modified"):
 	return frappe.db.sql('''select distinct project.*
 		from tabProject project, `tabProject User` project_user
 		where

--- a/erpnext/schools/doctype/fees/fees.py
+++ b/erpnext/schools/doctype/fees/fees.py
@@ -18,7 +18,7 @@ class Fees(Document):
 			self.total_amount += d.amount
 		self.outstanding_amount = self.total_amount
 
-def get_fee_list(doctype, txt, filters, limit_start, limit_page_length=20):
+def get_fee_list(doctype, txt, filters, limit_start, limit_page_length=20, order_by="modified"):
 	user = frappe.session.user
 	student = frappe.db.sql("select name from `tabStudent` where student_email_id= %s", user)
 	if student:


### PR DESCRIPTION
`File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/website/context.py", line 46, in update_controller_context
    ret = module.get_context(context)
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/www/list.py", line 22, in get_context
    context.update(get(**frappe.local.form_dict))
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/www/list.py", line 56, in get
    raw_result = _get_list(**kwargs)
TypeError: get_transaction_list() got an unexpected keyword argument 'order_by'`