### PR TITLE
[minor] sales register report fixes

### DIFF
--- a/erpnext/accounts/report/sales_register/sales_register.py
+++ b/erpnext/accounts/report/sales_register/sales_register.py
@@ -7,7 +7,7 @@ from frappe.utils import flt
 from frappe import msgprint, _
 
 def execute(filters=None):
-	if not filters: filters = {}
+	if not filters: filters = frappe._dict({})
 
 	invoice_list = get_invoices(filters)
 	columns, income_accounts, tax_accounts = get_columns(invoice_list)


### PR DESCRIPTION
fixes for  https://github.com/frappe/erpnext/issues/8443.

AttributeError: 'dict' object has no attribute 'company' in sales register report error if all the filters are set to "".

<img width="1161" alt="screen shot 2017-04-14 at 9 23 50 am" src="https://cloud.githubusercontent.com/assets/11224291/25032720/2688d5dc-20f4-11e7-94af-ae54d2d8af9e.png">
