### PR TITLE
[minor] if address is not found then set the address_field to '' instead of None

### DIFF
--- a/erpnext/public/js/utils/party.js
+++ b/erpnext/public/js/utils/party.js
@@ -90,7 +90,7 @@ erpnext.utils.get_address_display = function(frm, address_field, display_field, 
 			}
 		})
 	} else {
-		frm.set_value(display_field, null);
+		frm.set_value(display_field, '');
 	}
 };
 


### PR DESCRIPTION
fixes for https://github.com/frappe/erpnext/issues/8449

![address_issue](https://cloud.githubusercontent.com/assets/11224291/25043359/ff66f06c-213c-11e7-9804-1a4073b6c3d0.gif)

party details set again in update_if_missing function if the value is set as null.

![after_fix](https://cloud.githubusercontent.com/assets/11224291/25043360/02380cfe-213d-11e7-8dae-c39c57c26abb.gif)
