### PR TITLE
Make the address type translatable in the Address_HTML field

### DIFF
--- a/erpnext/public/js/templates/address_list.html
+++ b/erpnext/public/js/templates/address_list.html
@@ -2,7 +2,7 @@
 <div class="clearfix"></div>
 {% for(var i=0, l=addr_list.length; i<l; i++) { %}
     <p class="h6">
-        {%= i+1 %}. {%= addr_list[i].address_type!="Other" ? addr_list[i].address_type : addr_list[i].address_title %}
+        {%= i+1 %}. {%= addr_list[i].address_type!="Other" ? __(addr_list[i].address_type) : addr_list[i].address_title %}
         {% if(addr_list[i].is_primary_address) { %}
             <span class="text-muted">({%= __("Primary") %})</span>{% } %}
         {% if(addr_list[i].is_shipping_address) { %}


### PR DESCRIPTION
Hi,

A small correction in the Address_HTML template to allow the address type to be translated.

Thanks!