### PR TITLE
[fix] frappe.db.exists('Series', series) is not working because tabSeries table did not have column modified

### DIFF
--- a/erpnext/setup/doctype/naming_series/naming_series.py
+++ b/erpnext/setup/doctype/naming_series/naming_series.py
@@ -141,7 +141,7 @@ class NamingSeries(Document):
 
 	def insert_series(self, series):
 		"""insert series if missing"""
-		if not frappe.db.exists('Series', series):
+		if not frappe.db.get_value('Series', series, 'name', order_by="name"):
 			frappe.db.sql("insert into tabSeries (name, current) values (%s, 0)", (series))
 
 	def update_series_start(self):


### PR DESCRIPTION
Fixed #8610 

frappe.db.exists('Series', series) function call the query 'select `name` from `tabSeries` where `name` = 'NSE-GRN/17-18/' order by modified desc'

The table tabSeries did not have column modified and therefore it return none even if the record is exists 