### PR TITLE
[minor] disabled the instructor role if the company domain is not Education

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -391,3 +391,4 @@ erpnext.patches.v8_0.set_project_copied_from
 erpnext.patches.v8_0.update_status_as_paid_for_completed_expense_claim
 erpnext.patches.v7_2.stock_uom_in_selling
 erpnext.patches.v8_0.revert_manufacturers_table_from_item
+erpnext.patches.v8_0.disable_instructor_role

--- a/erpnext/patches/v8_0/disable_instructor_role.py
+++ b/erpnext/patches/v8_0/disable_instructor_role.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2013, Web Notes Technologies Pvt. Ltd. and Contributors
+# License: GNU General Public License v3. See license.txt
+
+from __future__ import unicode_literals
+import frappe
+
+def execute():
+	""" 
+		disable the instructor role for companies with domain other than
+		Education.
+	"""
+
+	domains = frappe.db.sql_list("select domain from tabCompany")
+	if "Education" not in domains:
+		role = frappe.get_doc("Role", "Instructor")
+		role.disabled = 1
+		role.save(ignore_permissions=True)

--- a/erpnext/setup/setup_wizard/domainify.py
+++ b/erpnext/setup/setup_wizard/domainify.py
@@ -11,7 +11,7 @@ def get_domain(domain):
 			'desktop_icons': ['Item', 'BOM', 'Customer', 'Supplier', 'Sales Order',
 				'Production Order',  'Stock Entry', 'Purchase Order', 'Task', 'Buying', 'Selling',
 				 'Accounts', 'HR', 'ToDo'],
-			'remove_roles': ['Academics User'],
+			'remove_roles': ['Academics User', 'Instructor'],
 			'properties': [
 				{'doctype': 'Item', 'fieldname': 'manufacturing', 'property': 'collapsible_depends_on', 'value': 'is_stock_item'},
 			],
@@ -24,7 +24,7 @@ def get_domain(domain):
 		'Retail': {
 			'desktop_icons': ['POS', 'Item', 'Customer', 'Sales Invoice',  'Purchase Order',
 			'Warranty Claim', 'Accounts', 'Task', 'Buying', 'ToDo'],
-			'remove_roles': ['Manufacturing User', 'Manufacturing Manager', 'Academics User'],
+			'remove_roles': ['Manufacturing User', 'Manufacturing Manager', 'Academics User', 'Instructor'],
 			'properties': [
 				{'doctype': 'Item', 'fieldname': 'manufacturing', 'property': 'hidden', 'value': 1},
 				{'doctype': 'Customer', 'fieldname': 'credit_limit_section', 'property': 'hidden', 'value': 1},
@@ -38,7 +38,7 @@ def get_domain(domain):
 		'Distribution': {
 			'desktop_icons': ['Item', 'Customer', 'Supplier', 'Lead', 'Sales Order', 'Task',
 				 'Sales Invoice', 'CRM', 'Selling', 'Buying', 'Stock', 'Accounts', 'HR', 'ToDo'],
-			'remove_roles': ['Manufacturing User', 'Manufacturing Manager', 'Academics User'],
+			'remove_roles': ['Manufacturing User', 'Manufacturing Manager', 'Academics User', 'Instructor'],
 			'set_value': [
 				['Stock Settings', None, 'show_barcode_field', 1]
 			],
@@ -48,7 +48,7 @@ def get_domain(domain):
 		'Services': {
 			'desktop_icons': ['Project', 'Timesheet', 'Customer', 'Sales Order', 'Sales Invoice',
 				'Lead', 'Opportunity', 'Task', 'Expense Claim', 'Employee', 'HR', 'ToDo'],
-			'remove_roles': ['Manufacturing User', 'Manufacturing Manager', 'Academics User'],
+			'remove_roles': ['Manufacturing User', 'Manufacturing Manager', 'Academics User', 'Instructor'],
 			'properties': [
 				{'doctype': 'Item', 'fieldname': 'is_stock_item', 'property': 'default', 'value': 0},
 			],

--- a/erpnext/setup/setup_wizard/domainify.py
+++ b/erpnext/setup/setup_wizard/domainify.py
@@ -62,7 +62,7 @@ def get_domain(domain):
 				'Fees',  'Task', 'ToDo', 'Schools'],
 			'allow_roles': ['Academics User', 'Accounts User', 'Accounts Manager', 'Item Manager',
 				'Website Manager', 'HR User', 'HR Manager', 'Purchase User', 'Purchase Manager',
-				'Student', 'Projects User'],
+				'Student', 'Projects User', 'Instructor'],
 			'default_portal_role': 'Student'
 		},
 	}


### PR DESCRIPTION
`before`

School module doctypes should be hidden from the User if the Company domain is not Education.

<img width="1184" alt="screen shot 2017-04-29 at 3 46 38 pm" src="https://cloud.githubusercontent.com/assets/11224291/25554821/0104fa18-2cf5-11e7-9d32-319de20fb85a.png">

`after`

<img width="1193" alt="screen shot 2017-04-29 at 4 05 13 pm" src="https://cloud.githubusercontent.com/assets/11224291/25554842/a9048c10-2cf5-11e7-938f-fde63228d7b1.png">
