### PR TITLE
[hotfix] Unable to create an asset due to rounding issue

### DIFF
--- a/erpnext/accounts/doctype/asset/asset.py
+++ b/erpnext/accounts/doctype/asset/asset.py
@@ -114,8 +114,17 @@ class Asset(Document):
 
 	def set_accumulated_depreciation(self):
 		accumulated_depreciation = flt(self.opening_accumulated_depreciation)
-		for d in self.get("schedules"):
-			accumulated_depreciation  += flt(d.depreciation_amount, d.precision("depreciation_amount"))
+		value_after_depreciation = flt(self.value_after_depreciation)
+		for i, d in enumerate(self.get("schedules")):
+			depreciation_amount = flt(d.depreciation_amount, d.precision("depreciation_amount"))
+			value_after_depreciation -= flt(depreciation_amount)
+
+			if i==len(self.get("schedules"))-1 and self.depreciation_method == "Straight Line":
+				depreciation_amount += flt(value_after_depreciation - flt(self.expected_value_after_useful_life),
+					d.precision("depreciation_amount"))
+
+			d.depreciation_amount = depreciation_amount
+			accumulated_depreciation += d.depreciation_amount
 			d.accumulated_depreciation_amount = flt(accumulated_depreciation, d.precision("accumulated_depreciation_amount"))
 
 	def get_depreciation_amount(self, depreciable_value):


### PR DESCRIPTION
Issue

desk.min.js:140 Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 55, in application
    response = frappe.handler.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 52, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 907, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/form/save.py", line 19, in savedocs
    doc.submit()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 741, in submit
    self._submit()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 730, in _submit
    self.save()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 231, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 264, in _save
    self.run_before_save_methods()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 775, in run_before_save_methods
    self.run_method("validate")
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 667, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 892, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 875, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 661, in
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/doctype/asset/asset.py", line 22, in validate
    self.validate_expected_value_after_useful_life()
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/doctype/asset/asset.py", line 145, in validate_expected_value_after_useful_life
    .format(asset_value_after_full_schedule))
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 316, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red')
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 306, in msgprint
    _raise_exception()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 279, in _raise_exception
    raise raise_exception, encode(msg)
ValidationError: Expected value after useful life must be greater than or equal to 593309.8


