### PR TITLE
Removed set_default_roles

### DIFF
--- a/erpnext/patches/v7_1/update_portal_roles.py
+++ b/erpnext/patches/v7_1/update_portal_roles.py
@@ -13,7 +13,6 @@ def execute():
 	# set customer, supplier roles
 	for c in frappe.get_all('Contact', fields=['user'], filters={'ifnull(user, "")': ('!=', '')}):
 		user = frappe.get_doc('User', c.user)
-		user.set_default_roles()
 		user.flags.ignore_validate = True
 		user.flags.ignore_mandatory = True
 		user.save()


### PR DESCRIPTION
set_default_roles was removed in https://github.com/frappe/frappe/commit/7fff0908a44a2435aa2575c965b0d921ef07b038

It is not required anymore. It currently breaks the patch.