### PR TITLE
[hotfix] fixed object has no attribute 'delivered_by_supplier'

### DIFF
--- a/erpnext/buying/utils.py
+++ b/erpnext/buying/utils.py
@@ -64,7 +64,7 @@ def validate_for_items(doc):
 		validate_end_of_life(d.item_code, item.end_of_life, item.disabled)
 
 		# validate stock item
-		if item.is_stock_item==1 and d.qty and not d.warehouse and not d.delivered_by_supplier:
+		if item.is_stock_item==1 and d.qty and not d.warehouse and not d.get("delivered_by_supplier"):
 			frappe.throw(_("Warehouse is mandatory for stock Item {0} in row {1}").format(d.item_code, d.idx))
 
 		items.append(cstr(d.item_code))


### PR DESCRIPTION
`steps to recreate`

- New Material Request
- Add an item (Maintain Stock should be enabled)
- remove the warehouse field value and Save

![before](https://cloud.githubusercontent.com/assets/11224291/25718485/eb53fe8e-3123-11e7-9f65-5c1278bbd3f2.gif)
