### PR TITLE
[minor] check if date of joining is available before creating Salary Structure & Salary Slip

### DIFF
--- a/erpnext/hr/doctype/salary_slip/salary_slip.py
+++ b/erpnext/hr/doctype/salary_slip/salary_slip.py
@@ -321,8 +321,12 @@ class SalarySlip(TransactionBase):
 	def sum_components(self, component_type, total_field):
 		joining_date, relieving_date = frappe.db.get_value("Employee", self.employee,
 			["date_of_joining", "relieving_date"])
+		
 		if not relieving_date:
 			relieving_date = getdate(self.end_date)
+
+		if not joining_date:
+			frappe.throw(_("Please set the Date Of Joining for employee {0}").format(frappe.bold(employee.employee)))
 
 		for d in self.get(component_type):
 			if ((cint(d.depends_on_lwp) == 1 and not self.salary_slip_based_on_timesheet) or\

--- a/erpnext/hr/doctype/salary_structure/salary_structure.py
+++ b/erpnext/hr/doctype/salary_structure/salary_structure.py
@@ -33,6 +33,7 @@ class SalaryStructure(Document):
 		for employee in self.get('employees'):
 			joining_date, relieving_date = frappe.db.get_value("Employee", employee.employee,
 				["date_of_joining", "relieving_date"])
+
 			if employee.from_date and joining_date and getdate(employee.from_date) < joining_date:
 				frappe.throw(_("From Date {0} for Employee {1} cannot be before employee's joining Date {2}")
 					    .format(employee.from_date, employee.employee, joining_date))


### PR DESCRIPTION
fixes for https://github.com/frappe/erpnext/issues/8698

`before`

![hr-before](https://cloud.githubusercontent.com/assets/11224291/25730954/3866b7bc-315f-11e7-95b0-13a869374795.gif)
`after`

![hr](https://cloud.githubusercontent.com/assets/11224291/25730955/386c83a4-315f-11e7-839a-4c0a527597b8.gif)
