### PR TITLE
[minor] added currency in Totals for Trial Balance report

### DIFF
--- a/erpnext/accounts/report/trial_balance/trial_balance.py
+++ b/erpnext/accounts/report/trial_balance/trial_balance.py
@@ -137,7 +137,8 @@ def calculate_values(accounts, gl_entries_by_account, opening_balances, filters)
 		"credit": 0.0,
 		"parent_account": None,
 		"indent": 0,
-		"has_value": True
+		"has_value": True,
+		"currency": frappe.db.get_value("Company", filters.company, "default_currency")
 	}
 
 	for d in accounts:

--- a/erpnext/accounts/report/trial_balance/trial_balance.py
+++ b/erpnext/accounts/report/trial_balance/trial_balance.py
@@ -2,7 +2,7 @@
 # License: GNU General Public License v3. See license.txt
 
 from __future__ import unicode_literals
-import frappe
+import frappe, erpnext
 from frappe import _
 from frappe.utils import flt, getdate, formatdate, cstr
 from erpnext.accounts.report.financial_statements \
@@ -53,6 +53,7 @@ def validate_filters(filters):
 def get_data(filters):
 	accounts = frappe.db.sql("""select name, parent_account, account_name, root_type, report_type, lft, rgt
 		from `tabAccount` where company=%s order by lft""", filters.company, as_dict=True)
+	company_currency = erpnext.get_company_currency(filters.company)
 
 	if not accounts:
 		return None
@@ -69,10 +70,10 @@ def get_data(filters):
 
 	opening_balances = get_opening_balances(filters)
 
-	total_row = calculate_values(accounts, gl_entries_by_account, opening_balances, filters)
+	total_row = calculate_values(accounts, gl_entries_by_account, opening_balances, filters, company_currency)
 	accumulate_values_into_parents(accounts, accounts_by_name)
 
-	data = prepare_data(accounts, filters, total_row, parent_children_map)
+	data = prepare_data(accounts, filters, total_row, parent_children_map, company_currency)
 	data = filter_out_zero_value_rows(data, parent_children_map, 
 		show_zero_values=filters.get("show_zero_values"))
 		
@@ -119,7 +120,7 @@ def get_rootwise_opening_balances(filters, report_type):
 
 	return opening
 
-def calculate_values(accounts, gl_entries_by_account, opening_balances, filters):
+def calculate_values(accounts, gl_entries_by_account, opening_balances, filters, company_currency):
 	init = {
 		"opening_debit": 0.0,
 		"opening_credit": 0.0,
@@ -138,7 +139,7 @@ def calculate_values(accounts, gl_entries_by_account, opening_balances, filters)
 		"parent_account": None,
 		"indent": 0,
 		"has_value": True,
-		"currency": frappe.db.get_value("Company", filters.company, "default_currency")
+		"currency": company_currency
 	}
 
 	for d in accounts:
@@ -165,9 +166,8 @@ def accumulate_values_into_parents(accounts, accounts_by_name):
 			for key in value_fields:
 				accounts_by_name[d.parent_account][key] += d[key]
 
-def prepare_data(accounts, filters, total_row, parent_children_map):
+def prepare_data(accounts, filters, total_row, parent_children_map, company_currency):
 	data = []
-	company_currency = frappe.db.get_value("Company", filters.company, "default_currency")
 	
 	for d in accounts:
 		has_value = False


### PR DESCRIPTION
`ERROR Report`

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2017-05-09/apps/frappe/frappe/app.py", line 55, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2017-05-09/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2017-05-09/apps/frappe/frappe/handler.py", line 52, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2017-05-09/apps/frappe/frappe/__init__.py", line 907, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2017-05-09/apps/frappe/frappe/desk/query_report.py", line 103, in run
    result = get_filtered_data(report.ref_doctype, columns, result, user)
  File "/home/frappe/benches/bench-2017-05-09/apps/frappe/frappe/desk/query_report.py", line 234, in get_filtered_data
    elif has_match(row, linked_doctypes, match_filters_per_doctype, ref_doctype, if_owner, columns_dict, user):
  File "/home/frappe/benches/bench-2017-05-09/apps/frappe/frappe/desk/query_report.py", line 279, in has_match
    if dt in match_filters and row[idx] not in match_filters[dt]:
KeyError: u'currency'
```

`Total values`

<img width="921" alt="screen shot 2017-05-10 at 3 39 50 pm" src="https://cloud.githubusercontent.com/assets/11224291/25893808/faf366e6-3596-11e7-9590-fed42ce811bf.png">
