### PR TITLE
[fix] don't allow string values in limits to avoid sql injection

### DIFF
--- a/erpnext/templates/pages/product_search.py
+++ b/erpnext/templates/pages/product_search.py
@@ -3,7 +3,7 @@
 
 from __future__ import unicode_literals
 import frappe
-from frappe.utils import cstr, nowdate
+from frappe.utils import cstr, nowdate, cint
 from erpnext.setup.doctype.item_group.item_group import get_item_for_list_in_html
 
 no_cache = 1
@@ -33,7 +33,7 @@ def get_product_list(search=None, start=0, limit=12):
 		search = "%" + cstr(search) + "%"
 
 	# order by
-	query += """ order by weightage desc, idx desc, modified desc limit %s, %s""" % (start, limit)
+	query += """ order by weightage desc, idx desc, modified desc limit %s, %s""" % (cint(start), cint(limit))
 
 	data = frappe.db.sql(query, {
 		"search": search,


### PR DESCRIPTION
`URL: http://data.erpnext.dev:8000/?cmd=erpnext.templates.pages.product_search.get_product_list&start=1%20PROCEDURE%20ANALYSE(EXTRACTVALUE(2288,CONCAT(0x5c,(BENCHMARK(5000000,MD5(0x4f716f73))))),1)-afDR&search`

Before

```
Traceback (most recent call last):
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/app.py", line 55, in application
    response = frappe.handler.handle()
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/handler.py", line 52, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/__init__.py", line 907, in call
    return fn(*args, **newargs)
  File "/Users/saurabh/frappe-bench/apps/erpnext/erpnext/templates/pages/product_search.py", line 50, in get_product_list
    }, as_dict=1)
  File "/Users/saurabh/frappe-bench/apps/frappe/frappe/database.py", line 138, in sql
    self._cursor.execute(query, values)
  File "/Users/saurabh/frappe-bench/env/lib/python2.7/site-packages/MySQLdb/cursors.py", line 205, in execute
    self.errorhandler(self, exc, value)
  File "/Users/saurabh/frappe-bench/env/lib/python2.7/site-packages/MySQLdb/connections.py", line 36, in defaulterrorhandler
    raise errorclass, errorvalue
ProgrammingError: (1064, "You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '-afDR, 12' at line 6")
```

---
after

<img width="242" alt="screen shot 2017-05-11 at 4 59 29 pm" src="https://cloud.githubusercontent.com/assets/3784093/25947011/3d486468-366b-11e7-9fed-497400ed6206.png">
