### PR TITLE
[fix] minor fix in get_context for item variants

### DIFF
--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -325,7 +325,7 @@ class Item(WebsiteGenerator):
 
 	def set_disabled_attributes(self, context):
 		"""Disable selection options of attribute combinations that do not result in a variant"""
-		if not self.attributes:
+		if not self.attributes or not self.has_variants:
 			return
 
 		context.disabled_attributes = {}


### PR DESCRIPTION
`Error Log`

- Create an item template set has_variant to 1 and add the attributes and save
- uncheck the has_variant and save the item
- search the item in /product_search to get the error

```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/website/render.py", line 32, in render
    data = render_page_by_language(path)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/website/render.py", line 101, in render_page_by_language
    return render_page(path)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/website/render.py", line 117, in render_page
    return build(path)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/website/render.py", line 124, in build
    return build_page(path)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/website/render.py", line 137, in build_page
    context = get_context(path)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/website/context.py", line 19, in get_context
    context = build_context(context)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/website/context.py", line 84, in build_context
    ret = context.doc.get_context(context)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/stock/doctype/item/item.py", line 250, in get_context
    self.set_disabled_attributes(context)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/stock/doctype/item/item.py", line 361, in set_disabled_attributes
    combination_source.append([context.selected_attributes.get(prev_attr.attribute)])
AttributeError: 'NoneType' object has no attribute 'get'
```