### PR TITLE
Description correction

### DIFF
--- a/erpnext/setup/doctype/territory/territory.json
+++ b/erpnext/setup/doctype/territory/territory.json
@@ -79,7 +79,7 @@
    "bold": 1, 
    "collapsible": 0, 
    "columns": 0, 
-   "description": "Only leaf nodes are allowed in transaction", 
+   "description": "", 
    "fieldname": "is_group", 
    "fieldtype": "Check", 
    "hidden": 0, 


### PR DESCRIPTION
Hi,

This is a very small correction, but I haven't found any reasons to have this description in territory groups since they can be used in customers: "Only leaf nodes are allowed in transaction"

A few people have told me that it is disturbing.

If I'm wrong please feel free to close this PR.

Thank you.