### PR TITLE
[fix] pass company filter as string in get_value

### DIFF
--- a/erpnext/utilities/__init__.py
+++ b/erpnext/utilities/__init__.py
@@ -2,6 +2,7 @@
 
 import frappe
 from erpnext.utilities.activation import get_level
+from frappe.utils import cstr
 
 def update_doctypes():
 	for d in frappe.db.sql("""select df.parent, df.fieldname
@@ -26,7 +27,7 @@ def get_site_info(site_info):
 		company = company[0][0] if company else None
 
 	if company:
-		domain = frappe.db.get_value('Company', company, 'domain')
+		domain = frappe.db.get_value('Company', cstr(company), 'domain')
 
 	return {
 		'company': company,


### PR DESCRIPTION
```
bench --site aaaa.erpnext.com execute frappe.utils.get_site_info
Traceback (most recent call last):
  File "/usr/lib64/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib64/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/frappe/benches/bench-2017-05-11/apps/frappe/frappe/utils/bench_helper.py", line 79, in <module>
    main()
  File "/home/frappe/benches/bench-2017-05-11/apps/frappe/frappe/utils/bench_helper.py", line 16, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/frappe/benches/bench-2017-05-11/env/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/benches/bench-2017-05-11/env/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/frappe/benches/bench-2017-05-11/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/benches/bench-2017-05-11/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/benches/bench-2017-05-11/env/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/benches/bench-2017-05-11/env/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/benches/bench-2017-05-11/env/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/frappe/benches/bench-2017-05-11/apps/frappe/frappe/commands/__init__.py", line 24, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/frappe/benches/bench-2017-05-11/apps/frappe/frappe/commands/utils.py", line 113, in execute
    ret = frappe.get_attr(method)(*args, **kwargs)
  File "/home/frappe/benches/bench-2017-05-11/apps/frappe/frappe/utils/__init__.py", line 513, in get_site_info
    site_info.update(frappe.get_attr(method_name)(site_info) or {})
  File "/home/frappe/benches/bench-2017-05-11/apps/erpnext/erpnext/utilities/__init__.py", line 29, in get_site_info
    domain = frappe.db.get_value('Company', company, 'domain')
  File "/home/frappe/benches/bench-2017-05-11/apps/frappe/frappe/database.py", line 413, in get_value
    order_by, cache=cache)
  File "/home/frappe/benches/bench-2017-05-11/apps/frappe/frappe/database.py", line 457, in get_values
    out = self._get_values_from_table(fields, filters, doctype, as_dict, debug, order_by, update)
  File "/home/frappe/benches/bench-2017-05-11/apps/frappe/frappe/database.py", line 583, in _get_values_from_table
    conditions, values = self.build_conditions(filters)
  File "/home/frappe/benches/bench-2017-05-11/apps/frappe/frappe/database.py", line 376, in build_conditions
    for f in filters:
TypeError: 'int' object is not iterable
```