### PR TITLE
Show duplicate button in BOM unless in draft stage

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.js
+++ b/erpnext/manufacturing/doctype/bom/bom.js
@@ -33,9 +33,7 @@ frappe.ui.form.on("BOM", {
 			});
 		}
 
-		if(frm.doc.docstatus==2) {
-			// show duplicate button when BOM is cancelled,
-			// its not very intuitive
+		if(frm.doc.docstatus!=0) {
 			frm.add_custom_button(__("Duplicate"), function() {
 				frm.copy_doc();
 			});


### PR DESCRIPTION
The Duplicate button is helpful for BOM even when the docstatus is 1 since it saves the user time in entering project, items (possibly), etc.