### PR TITLE
View Attachments in portal

### DIFF
--- a/erpnext/shopping_cart/doctype/shopping_cart_settings/shopping_cart_settings.json
+++ b/erpnext/shopping_cart/doctype/shopping_cart_settings/shopping_cart_settings.json
@@ -13,6 +13,7 @@
  "editable_grid": 0, 
  "fields": [
   {
+   "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -41,6 +42,67 @@
    "unique": 0
   }, 
   {
+   "allow_bulk_edit": 0, 
+   "allow_on_submit": 0, 
+   "bold": 0, 
+   "collapsible": 0, 
+   "columns": 0, 
+   "fieldname": "column_break_2", 
+   "fieldtype": "Column Break", 
+   "hidden": 0, 
+   "ignore_user_permissions": 0, 
+   "ignore_xss_filter": 0, 
+   "in_filter": 0, 
+   "in_global_search": 0, 
+   "in_list_view": 0, 
+   "in_standard_filter": 0, 
+   "length": 0, 
+   "no_copy": 0, 
+   "permlevel": 0, 
+   "precision": "", 
+   "print_hide": 0, 
+   "print_hide_if_no_value": 0, 
+   "read_only": 0, 
+   "remember_last_selected_value": 0, 
+   "report_hide": 0, 
+   "reqd": 0, 
+   "search_index": 0, 
+   "set_only_once": 0, 
+   "unique": 0
+  }, 
+  {
+   "allow_bulk_edit": 0, 
+   "allow_on_submit": 0, 
+   "bold": 0, 
+   "collapsible": 0, 
+   "columns": 0, 
+   "description": "Attachments can be shown without enabling the shopping cart", 
+   "fieldname": "show_attachments", 
+   "fieldtype": "Check", 
+   "hidden": 0, 
+   "ignore_user_permissions": 0, 
+   "ignore_xss_filter": 0, 
+   "in_filter": 0, 
+   "in_global_search": 0, 
+   "in_list_view": 0, 
+   "in_standard_filter": 0, 
+   "label": "Show Public Attachments", 
+   "length": 0, 
+   "no_copy": 0, 
+   "permlevel": 0, 
+   "precision": "", 
+   "print_hide": 0, 
+   "print_hide_if_no_value": 0, 
+   "read_only": 0, 
+   "remember_last_selected_value": 0, 
+   "report_hide": 0, 
+   "reqd": 0, 
+   "search_index": 0, 
+   "set_only_once": 0, 
+   "unique": 0
+  }, 
+  {
+   "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -68,6 +130,7 @@
    "unique": 0
   }, 
   {
+   "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -97,6 +160,7 @@
    "unique": 0
   }, 
   {
+   "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -128,6 +192,7 @@
    "unique": 0
   }, 
   {
+   "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -157,6 +222,7 @@
    "unique": 0
   }, 
   {
+   "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -184,6 +250,7 @@
    "unique": 0
   }, 
   {
+   "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -214,6 +281,7 @@
    "unique": 0
   }, 
   {
+   "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -242,6 +310,7 @@
    "unique": 0
   }, 
   {
+   "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 1, 
@@ -272,6 +341,7 @@
    "unique": 0
   }, 
   {
+   "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -301,6 +371,7 @@
    "unique": 0
   }, 
   {
+   "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -333,6 +404,7 @@
    "unique": 0
   }, 
   {
+   "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -361,6 +433,7 @@
    "unique": 0
   }, 
   {
+   "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -402,7 +475,7 @@
  "issingle": 1, 
  "istable": 0, 
  "max_attachments": 0, 
- "modified": "2017-03-21 15:42:08.574497", 
+ "modified": "2017-05-19 09:31:38.078110", 
  "modified_by": "Administrator", 
  "module": "Shopping Cart", 
  "name": "Shopping Cart Settings", 

--- a/erpnext/shopping_cart/doctype/shopping_cart_settings/shopping_cart_settings.py
+++ b/erpnext/shopping_cart/doctype/shopping_cart_settings/shopping_cart_settings.py
@@ -89,3 +89,7 @@ def check_shopping_cart_enabled():
 	if not get_shopping_cart_settings().enabled:
 		frappe.throw(_("You need to enable Shopping Cart"), ShoppingCartSetupError)
 
+def show_attachments():
+        return get_shopping_cart_settings().show_attachments
+
+

--- a/erpnext/templates/pages/order.html
+++ b/erpnext/templates/pages/order.html
@@ -86,6 +86,7 @@
 			{% endif %}
 		{% endif %}
 	</div>
+	
 {% if attachments %}
 <div class="order-item-table">
 	<div class="row order-items order-item-header text-muted">
@@ -93,21 +94,16 @@
 			{{ _("Attachments") }}
 		</div>
 	</div>
-
 	<div class="row order-items">
 		<div class="col-sm-12">
 			{% for attachment in attachments %}
 			<p class="small">
-				<a href="{{ attachment.file_url }}" target="blank">
-      {{ attachment.file_name }}
-    		</a>
+				<a href="{{ attachment.file_url }}" target="blank"> {{ attachment.file_name }} </a>
 			</p>
 			{% endfor %}
 		</div>
 	</div>
 </div>
 {% endif %}
-
 </div>
-
 {% endblock %}

--- a/erpnext/templates/pages/order.html
+++ b/erpnext/templates/pages/order.html
@@ -86,6 +86,28 @@
 			{% endif %}
 		{% endif %}
 	</div>
+{% if attachments %}
+<div class="order-item-table">
+	<div class="row order-items order-item-header text-muted">
+		<div class="col-sm-12 h6 text-uppercase">
+			{{ _("Attachments") }}
+		</div>
+	</div>
+
+	<div class="row order-items">
+		<div class="col-sm-12">
+			{% for attachment in attachments %}
+			<p class="small">
+				<a href="{{ attachment.file_url }}" target="blank">
+      {{ attachment.file_name }}
+    		</a>
+			</p>
+			{% endfor %}
+		</div>
+	</div>
+</div>
+{% endif %}
+
 </div>
 
 {% endblock %}

--- a/erpnext/templates/pages/order.py
+++ b/erpnext/templates/pages/order.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 import frappe
 
 from frappe import _
+from erpnext.shopping_cart.doctype.shopping_cart_settings.shopping_cart_settings import show_attachments
 
 def get_context(context):
 	context.no_cache = 1
@@ -13,10 +14,8 @@ def get_context(context):
 	if hasattr(context.doc, "set_indicator"):
 		context.doc.set_indicator()
 
-	for portal_menu_item in frappe.get_all("Portal Menu Item", filters={'reference_doctype': frappe.form_dict.doctype}, fields=['view_attachments\
-']):
-                if portal_menu_item.view_attachments == 1:
-                        context.attachments = get_attachments(frappe.form_dict.doctype, frappe.form_dict.name)
+	if show_attachments():
+                context.attachments = get_attachments(frappe.form_dict.doctype, frappe.form_dict.name)
 
 	context.parents = frappe.form_dict.parents
 	context.payment_ref = frappe.db.get_value("Payment Request",

--- a/erpnext/templates/pages/order.py
+++ b/erpnext/templates/pages/order.py
@@ -13,6 +13,11 @@ def get_context(context):
 	if hasattr(context.doc, "set_indicator"):
 		context.doc.set_indicator()
 
+	for portal_menu_item in frappe.get_all("Portal Menu Item", filters={'reference_doctype': frappe.form_dict.doctype}, fields=['view_attachments\
+']):
+                if portal_menu_item.view_attachments == 1:
+                        context.attachments = get_attachments(frappe.form_dict.doctype, frappe.form_dict.name)
+
 	context.parents = frappe.form_dict.parents
 	context.payment_ref = frappe.db.get_value("Payment Request",
 		{"reference_name": frappe.form_dict.name}, "name")
@@ -21,3 +26,7 @@ def get_context(context):
 
 	if not frappe.has_website_permission(context.doc):
 		frappe.throw(_("Not Permitted"), frappe.PermissionError)
+
+def get_attachments(dt, dn):
+        return frappe.get_all("File", fields=["name", "file_name", "file_url", "is_private"],
+                              filters = {"attached_to_name": dn, "attached_to_doctype": dt, "is_private":0})


### PR DESCRIPTION
Hi,

This PR is a proposal for the addition of a new checkbox in portal menu items to allow the display of public attachments in the portal. It will work only for order display for now. 

It is linked to PR 3289 in Frappe.

Description:
If the box is checked, the system fetches all public attachments in the doctype and displays them at the bottom of the page.

![image](https://cloud.githubusercontent.com/assets/4903591/26049243/9481cade-395a-11e7-97df-0b27c0f439b5.png)