### PR TITLE
[fix] if rate is greater than price_list_rate, set margin instead of discount. Fixes frappe/erpnext#6468

### DIFF
--- a/erpnext/selling/sales_common.js
+++ b/erpnext/selling/sales_common.js
@@ -337,14 +337,6 @@ erpnext.selling.SellingController = erpnext.TransactionController.extend({
 		})
 	},
 
-	rate: function(doc, cdt, cdn){
-		// if user changes the rate then set margin Rate or amount to 0
-		item = locals[cdt][cdn];
-		item.margin_type = "";
-		item.margin_rate_or_amount = 0.0;
-		cur_frm.refresh_fields();
-	},
-
 	margin_rate_or_amount: function(doc, cdt, cdn) {
 		// calculated the revised total margin and rate on margin rate changes
 		item = locals[cdt][cdn];


### PR DESCRIPTION
When rate is below price list rate, set discount

![screenshot from 2017-05-16 14-55-25](https://cloud.githubusercontent.com/assets/140076/26100134/9edac134-3a4a-11e7-84db-981e3b351264.png)

---

When rate is above price list rate, set margin

![screenshot from 2017-05-16 15-00-24](https://cloud.githubusercontent.com/assets/140076/26100139/a273d42a-3a4a-11e7-99c7-f49834e52424.png)
