### PR TITLE
Update product.py

### DIFF
--- a/erpnext/shopping_cart/product.py
+++ b/erpnext/shopping_cart/product.py
@@ -67,7 +67,7 @@ def get_price(item_code, template_item_code, price_list, qty=1):
 		price = frappe.get_all("Item Price", fields=["price_list_rate", "currency"],
 			filters={"price_list": price_list, "item_code": item_code})
 
-		if not price:
+		if template_item_code and not price:
 			price = frappe.get_all("Item Price", fields=["price_list_rate", "currency"],
 				filters={"price_list": price_list, "item_code": template_item_code})
 


### PR DESCRIPTION
Hi!

If template_item_code is None on line 68-69 the query will return ALL "Item Price" records irrespective of item_code, potentially causing the wrong price list rate to be used.

Noticed this behavior when fetching product price for a group of items without "variant_of" data.

However, I am not entirely sure if this is the expected behavior of frappe.get_all when a filter dictionary field is set to None. Should it cause underlying sql query to ignore the field(as if not set) or set it to "NULL" in the query?