### PR TITLE
[minor]Set variant name based on template name (frappe/erpnext#6367)

### DIFF
--- a/erpnext/controllers/item_variant.py
+++ b/erpnext/controllers/item_variant.py
@@ -165,7 +165,7 @@ def create_variant(item, args):
 
 	variant.set("attributes", variant_attributes)
 	copy_attributes_to_variant(template, variant)
-	make_variant_item_code(template.item_code, variant)
+	make_variant_item_code(template.item_code, template.item_name, variant)
 
 	return variant
 
@@ -194,7 +194,7 @@ def copy_attributes_to_variant(item, variant):
 			for d in variant.attributes:
 				variant.description += "<p>" + d.attribute + ": " + cstr(d.attribute_value) + "</p>"
 
-def make_variant_item_code(template_item_code, variant):
+def make_variant_item_code(template_item_code, template_item_name, variant):
 	"""Uses template's item code and abbreviations to make variant's item code"""
 	if variant.item_code:
 		return
@@ -220,6 +220,4 @@ def make_variant_item_code(template_item_code, variant):
 
 	if abbreviations:
 		variant.item_code = "{0}-{1}".format(template_item_code, "-".join(abbreviations))
-
-	if variant.item_code:
-		variant.item_name = variant.item_code
+		variant.item_name = "{0}-{1}".format(template_item_name, "-".join(abbreviations))


### PR DESCRIPTION
![screen shot 2017-05-18 at 10 24 27 pm](https://cloud.githubusercontent.com/assets/5196925/26214281/6e16fa74-3c19-11e7-80fc-054289052ddf.png)

The behaviour until now:
![screen shot 2017-05-18 at 10 31 51 pm](https://cloud.githubusercontent.com/assets/5196925/26214383/d99a166e-3c19-11e7-8781-03d73bad808f.png)

![screen shot 2017-05-18 at 10 29 37 pm](https://cloud.githubusercontent.com/assets/5196925/26214304/85b627f4-3c19-11e7-9937-ebb23b910e28.png)
Not sure if same name and code have a use-case.
