### PR TITLE
[fix] add round off difference to last row in landed cost voucher

### DIFF
--- a/erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.js
+++ b/erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.js
@@ -102,9 +102,17 @@ erpnext.stock.LandedCostVoucher = erpnext.stock.StockController.extend({
 				total_item_cost += flt(d[based_on])
 			});
 
+			var total_charges = 0.0;
 			$.each(this.frm.doc.items || [], function(i, item) {
 				item.applicable_charges = flt(item[based_on]) * flt(me.frm.doc.total_taxes_and_charges) / flt(total_item_cost)			
+				item.applicable_charges = roundNumber(item.applicable_charges, 4)
+				total_charges += item.applicable_charges
 			});
+
+			if (total_charges != this.frm.doc.total_taxes_and_charges){
+				var diff = this.frm.doc.total_taxes_and_charges - total_charges
+				this.frm.doc.items.slice(-1)[0].applicable_charges += diff
+			}
 			refresh_field("items");
 		}
 	},


### PR DESCRIPTION
Before:
![selection_014](https://cloud.githubusercontent.com/assets/16315650/26355883/e95bf46a-3fe7-11e7-911e-bf5eb1ade4a5.png)

After:
![selection_016](https://cloud.githubusercontent.com/assets/16315650/26355893/f00ed642-3fe7-11e7-8e67-e05b08069f96.png)
