### PR TITLE
[minor] added get_terms methods to erpnext.utils so that it can be used in non transactional documents

### DIFF
--- a/erpnext/hr/doctype/offer_letter/offer_letter.js
+++ b/erpnext/hr/doctype/offer_letter/offer_letter.js
@@ -5,8 +5,10 @@ frappe.provide("erpnext.offer_letter");
 
 frappe.ui.form.on("Offer Letter", {
 	select_terms: function(frm) {
-		frappe.model.get_value("Terms and Conditions", frm.doc.select_terms, "terms", function(value) {
-			frm.set_value("terms", value.terms);
+		erpnext.utils.get_terms(frm.doc.select_terms, frm.doc, function(r) {
+			if(!r.exc) {
+				me.frm.set_value("terms", r.message);
+			}
 		});
 	},
 

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -993,20 +993,12 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 
 	get_terms: function() {
 		var me = this;
-		if(this.frm.doc.tc_name) {
-			return frappe.call({
-				method: 'erpnext.setup.doctype.terms_and_conditions.terms_and_conditions.get_terms_and_conditions',
-				args: {
-					template_name: this.frm.doc.tc_name,
-					doc: this.frm.doc
-				},
-				callback: function(r) {
-					if(!r.exc) {
-						me.frm.set_value("terms", r.message);
-					}
-				}
-			});
-		}
+
+		erpnext.utils.get_terms(this.frm.doc.tc_name, this.frm.doc, function(r) {
+			if(!r.exc) {
+				me.frm.set_value("terms", r.message);
+			}
+		});
 	},
 
 	taxes_and_charges: function() {

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -104,6 +104,21 @@ $.extend(erpnext.utils, {
 			}
 		}
 		refresh_field(table_fieldname);
+	},
+
+	get_terms: function(tc_name, doc, callback) {
+		if(tc_name) {
+			return frappe.call({
+				method: 'erpnext.setup.doctype.terms_and_conditions.terms_and_conditions.get_terms_and_conditions',
+				args: {
+					template_name: tc_name,
+					doc: doc
+				},
+				callback: function(r) {
+					callback(r)
+				}
+			});
+		}
 	}
 });
 


### PR DESCRIPTION
fixes for https://github.com/frappe/erpnext/issues/8981

`before`

![terms-before](https://cloud.githubusercontent.com/assets/11224291/26486336/4b75a43e-4218-11e7-8d33-0127ba0d86c3.gif)

`after`
![terms-after](https://cloud.githubusercontent.com/assets/11224291/26486306/2119eaba-4218-11e7-9de8-81ccb2e40848.gif)
