### PR TITLE
Fix Empty Doctype naming series error when updationg

### DIFF
--- a/erpnext/setup/doctype/naming_series/naming_series.py
+++ b/erpnext/setup/doctype/naming_series/naming_series.py
@@ -14,6 +14,7 @@ from frappe.permissions import get_doctypes_with_read
 class NamingSeriesNotSetError(frappe.ValidationError): pass
 
 class NamingSeries(Document):
+	x=""
 	def get_transactions(self, arg=None):
 		doctypes = list(set(frappe.db.sql_list("""select parent
 				from `tabDocField` df where fieldname='naming_series'""")
@@ -49,6 +50,10 @@ class NamingSeries(Document):
 
 	def update_series(self, arg=None):
 		"""update series list"""
+		
+		if ((not self.set_options) and (not x)):
+			frappe.throw("List already emtpy can't be update to empty ")
+
 		self.check_duplicate()
 		series_list = self.set_options.split("\n")
 
@@ -131,9 +136,13 @@ class NamingSeries(Document):
 			throw(_('Special Characters except "-", "#", "." and "/" not allowed in naming series'))
 
 	def get_options(self, arg=None):
+		global x
 		if frappe.get_meta(arg or self.select_doc_for_series).get_field("naming_series"):
+			x= frappe.get_meta(arg or self.select_doc_for_series).get_field("naming_series").options
 			return frappe.get_meta(arg or self.select_doc_for_series).get_field("naming_series").options
-
+		else:
+			x=""
+			
 	def get_current(self, arg=None):
 		"""get series current"""
 		if self.prefix:


### PR DESCRIPTION
when update naming series list for empty doctype naming series it show erros like in the picture :+1: 

  File "/home/ahmad/benches-workspace/testing-benchs/test1/apps/erpnext/erpnext/setup/doctype/naming_series/naming_series.py", line 124, in check_duplicate
    options = self.scrub_options_list(self.set_options.split("\n"))
AttributeError: 'NoneType' object has no attribute 'split'