### PR TITLE
Fix Supplier Addresses And Contacts  label to accept translation

### DIFF
--- a/erpnext/config/buying.py
+++ b/erpnext/config/buying.py
@@ -172,7 +172,7 @@ def get_data():
 				{
 					"type": "report",
 					"is_query_report": True,
-					"name": "Addresses And Contacts",
+					"name": _("Addresses And Contacts"),
 					"label": "Supplier Addresses And Contacts",
 					"doctype": "Address",
 					"route_options": {


### PR DESCRIPTION
Supplier Addresses And Contacts doesn't accept translation