### PR TITLE
Fix labels to accept translation in selling 

### DIFF
--- a/erpnext/config/selling.py
+++ b/erpnext/config/selling.py
@@ -121,7 +121,7 @@ def get_data():
 					"type": "report",
 					"is_query_report": True,
 					"name": "Addresses And Contacts",
-					"label": "Sales Partner Addresses And Contacts",
+					"label": _("Sales Partner Addresses And Contacts"),
 					"doctype": "Address",
 					"route_options": {
 						"party_type": "Sales Partner"
@@ -226,7 +226,7 @@ def get_data():
 					"type": "report",
 					"is_query_report": True,
 					"name": "Addresses And Contacts",
-					"label": "Customer Addresses And Contacts",
+					"label": _("Customer Addresses And Contacts"),
 					"doctype": "Address",
 					"route_options": {
 						"party_type": "Customer"


### PR DESCRIPTION
"label": _("Customer Addresses And Contacts"),
"label": _("Sales Partner Addresses And Contacts"),
now they can accept to be translated