### PR TITLE
[Fix] User not able to view projects from the portal

### DIFF
--- a/erpnext/templates/includes/projects/project_tasks.html
+++ b/erpnext/templates/includes/projects/project_tasks.html
@@ -6,7 +6,7 @@
 				<span class="indicator {{ "red" if task.status=="Open" else "green" if task.status=="Closed" else "darkgrey" }}" title="{{ task.status }}"  > {{ task.subject }}</span> 
 	 				<div class="small text-muted item-timestamp"
 	 					title="{{ frappe.utils.pretty_date(task.modified) }}">
-	 					{{ __("modified") }} {{ frappe.utils.pretty_date(task.modified) }}
+						{{ _("modified") }} {{ frappe.utils.pretty_date(task.modified) }}
 	 				</div>
 			</div>
 			<div class='col-xs-1'>{% if task.todo %}


### PR DESCRIPTION
This is error shown to the customer when the customer click the project name from the portal.

Traceback (most recent call last):
File "/home/frappe/frappe-bench/apps/frappe/frappe/website/render.py", line 32, in render
data = render_page_by_language(path)
File "/home/frappe/frappe-bench/apps/frappe/frappe/website/render.py", line 101, in render_page_by_language
return render_page(path)
File "/home/frappe/frappe-bench/apps/frappe/frappe/website/render.py", line 117, in render_page
return build(path)
File "/home/frappe/frappe-bench/apps/frappe/frappe/website/render.py", line 124, in build
return build_page(path)
File "/home/frappe/frappe-bench/apps/frappe/frappe/website/render.py", line 140, in build_page
html = frappe.render_template(context.source, context)
File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/jinja.py", line 50, in render_template
return get_jenv().from_string(template).render(context)
File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/jinja2/environment.py", line 1008, in render
return self.environment.handle_exception(exc_info, True)
File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/jinja2/environment.py", line 780, in handle_exception
reraise(exc_type, exc_value, tb)
File "<template>", line 1, in top-level template code
File "/home/frappe/frappe-bench/apps/frappe/frappe/./templates/web.html", line 1, in top-level template code
{% extends base_template_path %}
File "/home/frappe/frappe-bench/apps/frappe/frappe/./templates/base.html", line 69, in top-level template code
{% block content %}{% endblock %}
File "/home/frappe/frappe-bench/apps/frappe/frappe/./templates/web.html", line 46, in block "content"
{%- block page_content -%}{%- endblock -%}
File "<template>", line 37, in block "page_content"
File "/home/frappe/frappe-bench/apps/erpnext/erpnext/./templates/includes/projects/project_tasks.html", line 9, in top-level template code
```
{{ __("modified") }} {{ frappe.utils.pretty_date(task.modified) }}
UndefinedError: '__' is undefined
```