### PR TITLE
"Make" Option for a submitted Material Issue/Transfer from Material Request doesn't show any dropdown options.

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -61,11 +61,11 @@ erpnext.buying.MaterialRequestController = erpnext.buying.BuyingController.exten
 		if(doc.docstatus == 1 && doc.status != 'Stopped') {
 			if(flt(doc.per_ordered, 2) < 100) {
 				// make
-				if(doc.material_request_type === "Material Transfer" && doc.status === "Submitted")
+				if(doc.material_request_type === "Material Transfer")
 					cur_frm.add_custom_button(__("Transfer Material"),
 					this.make_stock_entry, __("Make"));
 
-				if(doc.material_request_type === "Material Issue" && doc.status === "Submitted")
+				if(doc.material_request_type === "Material Issue")
 					cur_frm.add_custom_button(__("Issue Material"),
 					this.make_stock_entry, __("Make"));
 
@@ -81,7 +81,7 @@ erpnext.buying.MaterialRequestController = erpnext.buying.BuyingController.exten
 					cur_frm.add_custom_button(__("Supplier Quotation"),
 					this.make_supplier_quotation, __("Make"));
 
-				if(doc.material_request_type === "Manufacture" && doc.status === "Submitted")
+				if(doc.material_request_type === "Manufacture")
 					cur_frm.add_custom_button(__("Production Order"),
 					function() { me.raise_production_orders() }, __("Make"));
 


### PR DESCRIPTION
Fixed #9172 
For Material Requests, the possible values for `status` has changed to:-
```
If docstatus = 0 then status = "Draft"
If docstatus = 2 then status = "Cancelled"
If docstatus = 1 then status = ["Stopped", "Pending", "Partially Ordered", "Ordered", "Transferred", "Issued"]
```

### Before
![peek 2017-06-07 12-44](https://user-images.githubusercontent.com/818803/26876946-42503b28-4b80-11e7-9c70-b3078743f33d.gif)

### After
![peek 2017-06-07 12-50](https://user-images.githubusercontent.com/818803/26876956-4b0476b2-4b80-11e7-9e69-67dca622e70e.gif)
