### PR TITLE
Payment Entry - Latest Exchange Rate not fetched

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -873,7 +873,7 @@ def get_exchange_rate(posting_date, account=None, account_currency=None, company
 
 		# The date used to retreive the exchange rate here is the date passed
 		# in as an argument to this function.
-		elif account_currency and posting_date:
+		elif (not exchange_rate or exchange_rate==1) and account_currency and posting_date:
 			exchange_rate = get_exchange_rate(account_currency, company_currency, posting_date)
 	else:
 		exchange_rate = 1

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -871,14 +871,9 @@ def get_exchange_rate(posting_date, account=None, account_currency=None, company
 		if reference_type in ("Sales Invoice", "Purchase Invoice") and reference_name:
 			exchange_rate = frappe.db.get_value(reference_type, reference_name, "conversion_rate")
 
-		elif account_details and account_details.account_type == "Bank" and \
-			((account_details.root_type == "Asset" and flt(credit) > 0) or
-				(account_details.root_type == "Liability" and debit)):
-			exchange_rate = get_average_exchange_rate(account)
-
 		# The date used to retreive the exchange rate here is the date passed
 		# in as an argument to this function.
-		if not exchange_rate and account_currency and posting_date:
+		elif account_currency and posting_date:
 			exchange_rate = get_exchange_rate(account_currency, company_currency, posting_date)
 	else:
 		exchange_rate = 1

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -317,10 +317,12 @@ frappe.ui.form.on('Payment Entry', {
 			frm.set_value("source_exchange_rate", 1);
 		} else if (frm.doc.paid_from){
 			if (in_list(["Internal Transfer", "Pay"], frm.doc.payment_type)) {
+				var company_currency = frappe.get_doc(":Company", frm.doc.company).default_currency;
 				frappe.call({
-					method: "erpnext.accounts.doctype.journal_entry.journal_entry.get_average_exchange_rate",
+					method: "erpnext.setup.utils.get_exchange_rate",
 					args: {
-						account: frm.doc.paid_from
+						from_currency: frm.doc.paid_from_account_currency,
+						to_currency: company_currency
 					},
 					callback: function(r, rt) {
 						frm.set_value("source_exchange_rate", r.message);

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -149,8 +149,6 @@ class PaymentEntry(AccountsController):
 		if self.paid_from and not self.source_exchange_rate:
 			if self.paid_from_account_currency == self.company_currency:
 				self.source_exchange_rate = 1
-			elif self.payment_type in ("Pay", "Internal Transfer"):
-				self.source_exchange_rate = get_average_exchange_rate(self.paid_from)
 			else:
 				self.source_exchange_rate = get_exchange_rate(self.paid_from_account_currency, 
 					self.company_currency, self.posting_date)

--- a/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
@@ -112,6 +112,29 @@ class TestPaymentEntry(unittest.TestCase):
 		
 		outstanding_amount = flt(frappe.db.get_value("Sales Invoice", si.name, "outstanding_amount"))
 		self.assertEqual(outstanding_amount, 80)
+
+	def test_payment_entry_retrieves_last_exchange_rate(self):
+		pe = frappe.new_doc("Payment Entry")
+		pe.payment_type = "Pay"
+		pe.company = "_Test Company"
+		pe.posting_date = "2016-01-10"
+		pe.paid_from = "_Test Bank USD - _TC"
+		pe.paid_to = "_Test Bank - _TC"
+		pe.paid_amount = 100
+		pe.reference_no = "3"
+		pe.reference_date = nowdate()
+		pe.party_type = "Supplier"
+		pe.party = "_Test Supplier USD"
+
+		pe.setup_party_account_field()
+		pe.set_missing_values()
+		pe.set_exchange_rate()
+		pe.set_amounts()
+
+		self.assertEqual(
+			pe.source_exchange_rate, 65.1,
+			"{0} is not equal to {1}".format(pe.source_exchange_rate, 65.1)
+		)
 		
 	def test_internal_transfer_usd_to_inr(self):
 		pe = frappe.new_doc("Payment Entry")

--- a/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
@@ -114,6 +114,11 @@ class TestPaymentEntry(unittest.TestCase):
 		self.assertEqual(outstanding_amount, 80)
 
 	def test_payment_entry_retrieves_last_exchange_rate(self):
+		from erpnext.setup.doctype.currency_exchange.test_currency_exchange import test_records, save_new_records
+
+		test_records = test_records
+		save_new_records(test_records)
+
 		pe = frappe.new_doc("Payment Entry")
 		pe.payment_type = "Pay"
 		pe.company = "_Test Company"
@@ -122,7 +127,7 @@ class TestPaymentEntry(unittest.TestCase):
 		pe.paid_to = "_Test Bank - _TC"
 		pe.paid_amount = 100
 		pe.reference_no = "3"
-		pe.reference_date = nowdate()
+		pe.reference_date = "2016-01-10"
 		pe.party_type = "Supplier"
 		pe.party = "_Test Supplier USD"
 

--- a/erpnext/accounts/doctype/payment_request/test_payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/test_payment_request.py
@@ -87,8 +87,8 @@ class TestPaymentRequest(unittest.TestCase):
 		
 		expected_gle = dict((d[0], d) for d in [
 			["_Test Receivable USD - _TC", 0, 5000, si_usd.name],
-			[pr.payment_account, 6000.0, 0, None],
-			["_Test Exchange Gain/Loss - _TC", 0, 1000, None]
+			[pr.payment_account, 6290.0, 0, None],
+			["_Test Exchange Gain/Loss - _TC", 0, 1290, None]
 		])
 		
 		gl_entries = frappe.db.sql("""select account, debit, credit, against_voucher

--- a/erpnext/setup/doctype/currency_exchange/test_currency_exchange.py
+++ b/erpnext/setup/doctype/currency_exchange/test_currency_exchange.py
@@ -6,15 +6,42 @@ from __future__ import unicode_literals
 import frappe, unittest
 test_records = frappe.get_test_records('Currency Exchange')
 
+
+def save_new_records(test_records):
+	for record in test_records:
+		kwargs = dict(
+			doctype=record.get("doctype"),
+			docname=record.get("date") + '-' + record.get("from_currency") + '-' + record.get("to_currency"),
+			fieldname="exchange_rate",
+			value=record.get("exchange_rate"),
+		)
+
+		try:
+			frappe.set_value(**kwargs)
+		except frappe.DoesNotExistError:
+			curr_exchange = frappe.new_doc(record.get("doctype"))
+			curr_exchange.date = record["date"]
+			curr_exchange.from_currency = record["from_currency"]
+			curr_exchange.to_currency = record["to_currency"]
+			curr_exchange.exchange_rate = record["exchange_rate"]
+			curr_exchange.insert()
+
+
 class TestCurrencyExchange(unittest.TestCase):
 	def test_exchnage_rate(self):
 		from erpnext.setup.utils import get_exchange_rate
-		
-		# Exchange rate as on 15th Jan, 2016, should be fetched from Currency Exchange record
-		exchange_rate = get_exchange_rate("USD", "INR", "2016-01-15")
+
+		save_new_records(test_records)
+
+		exchange_rate = get_exchange_rate("USD", "INR", "2016-01-01")
 		self.assertEqual(exchange_rate, 60.0)
+
+		exchange_rate = get_exchange_rate("USD", "INR", "2016-01-15")
+		self.assertEqual(exchange_rate, 65.1)
+
+		exchange_rate = get_exchange_rate("USD", "INR", "2016-01-30")
+		self.assertEqual(exchange_rate, 62.9)
 		
 		# Exchange rate as on 15th Dec, 2015, should be fetched from fixer.io
 		exchange_rate = get_exchange_rate("USD", "INR", "2015-12-15")
 		self.assertFalse(exchange_rate==60)
-		

--- a/erpnext/setup/doctype/currency_exchange/test_records.json
+++ b/erpnext/setup/doctype/currency_exchange/test_records.json
@@ -19,5 +19,19 @@
   "exchange_rate": 0.0167, 
   "from_currency": "INR", 
   "to_currency": "USD"
+ },
+ {
+  "doctype": "Currency Exchange",
+  "date": "2016-01-10",
+  "exchange_rate": 65.1,
+  "from_currency": "USD",
+  "to_currency": "INR"
+ },
+  {
+  "doctype": "Currency Exchange",
+  "date": "2016-01-30",
+  "exchange_rate": 62.9,
+  "from_currency": "USD",
+  "to_currency": "INR"
  }
 ]


### PR DESCRIPTION
This fixes #8919, #9180

These two issues arise from the fact that "Pay" payment entries retrieve the average exchange rate used for transactions to the specified bank account. The side effect of this is that ERPNext can present different exchange rates for two different accounts with the same currency (#8919). Also, ERPNext will not be able to provide any exchange rate if the bank account balance is zero (#9180).

Technically, [IAS 21](https://www.iasplus.com/en/standards/ias/ias21#link8) does not allow for averaging exchange rates. Rather each transaction should be converted at the closing exchange rate on the day the transaction took place. Thus, the exchange rate automatically drawn should be the last saved exchange rate.