### PR TITLE
Fix incorrect YouTube link on Video Tutorials

### DIFF
--- a/erpnext/docs/user/videos/learn/report-builder.md
+++ b/erpnext/docs/user/videos/learn/report-builder.md
@@ -1,6 +1,6 @@
 # Report Builder
 
-<iframe width="660" height="371" src="https://www.youtube.com/embed/y0o5iYZOioU" frameborder="0" allowfullscreen></iframe>
+<iframe width="660" height="371" src="https://www.youtube.com/embed/ECRyhMvIf6Q" frameborder="0" allowfullscreen></iframe>
 
 **Duration: 4:27**
 


### PR DESCRIPTION
The original YouTube video is private and not viewable by anyone. I linked the publicly viewable YouTube video for "Report Builder" now.