### PR TITLE
removed {next} from documentation and removed the globals from custom scripts

### DIFF
--- a/erpnext/docs/user/manual/de/buying/setup/supplier-type.md
+++ b/erpnext/docs/user/manual/de/buying/setup/supplier-type.md
@@ -16,5 +16,3 @@ Sie können Ihre Lieferanten aus einem breiten Angebot verfügbarer Typen in ERP
 Wenn Sie Ihre Lieferanten in verschiedene Typen unterteilen, erleichtert Ihnen das die Buchhaltung und die Rechnungslegung.
 
 Geben Sie Ihre neue Lieferantenkategorie ein und speichern Sie.
-
-{next}

--- a/erpnext/docs/user/manual/de/customize-erpnext/custom-scripts/custom-script-examples/date-validation.md
+++ b/erpnext/docs/user/manual/de/customize-erpnext/custom-scripts/custom-script-examples/date-validation.md
@@ -3,8 +3,8 @@
 
 	frappe.ui.form.on("Event", "validate", function(frm) {
         if (frm.doc.from_date < get_today()) {
-            msgprint(__("You can not select past date in From Date"));
-            throw "past date selected"
+            frappe.msgprint(__("You can not select past date in From Date"));
+            frappe.throw(__("past date selected"))
         }
 	});
 

--- a/erpnext/docs/user/manual/de/customize-erpnext/custom-scripts/custom-script-examples/restrict-cancel-rights.md
+++ b/erpnext/docs/user/manual/de/customize-erpnext/custom-scripts/custom-script-examples/restrict-cancel-rights.md
@@ -4,12 +4,12 @@
 Fügen Sie dem Ereignis custom_before_cancel eine Steuerungsfunktion hinzu:
 
     cur_frm.cscript.custom_before_cancel = function(doc) {
-        if (user_roles.indexOf("Accounts User")!=-1 && user_roles.indexOf("Accounts Manager")==-1
+        if (frappe.user_roles.indexOf("Accounts User")!=-1 && frappe.user_roles.indexOf("Accounts Manager")==-1
                 && user_roles.indexOf("System Manager")==-1) {
             if (flt(doc.grand_total) > 10000) {
-                msgprint("You can not cancel this transaction, because grand total \
+                frappe.msgprint("You can not cancel this transaction, because grand total \
                     is greater than 10000");
-                validated = false;
+                frappe.validated = false;
             }
         }
     }

--- a/erpnext/docs/user/manual/de/customize-erpnext/custom-scripts/custom-script-examples/restrict-purpose-of-stock-entry.md
+++ b/erpnext/docs/user/manual/de/customize-erpnext/custom-scripts/custom-script-examples/restrict-purpose-of-stock-entry.md
@@ -3,8 +3,8 @@
 
     frappe.ui.form.on("Material Request", "validate", function(frm) {
         if(user=="user1@example.com" && frm.doc.purpose!="Material Receipt") {
-            msgprint("You are only allowed Material Receipt");
-            throw "Not allowed";
+            frappe.msgprint("You are only allowed Material Receipt");
+            frappe.throw(__("Not allowed"));
         }
     }
 

--- a/erpnext/docs/user/manual/de/customize-erpnext/custom-scripts/custom-script-examples/restrict-user-based-on-child-record.md
+++ b/erpnext/docs/user/manual/de/customize-erpnext/custom-scripts/custom-script-examples/restrict-user-based-on-child-record.md
@@ -3,17 +3,16 @@
 
     // restrict certain warehouse to Material Manager
     cur_frm.cscript.custom_validate = function(doc) {
-        if(user_roles.indexOf("Material Manager")==-1) {
-
-            var restricted_in_source = wn.model.get("Stock Entry Detail",
+        if(frappe.user_roles.indexOf("Material Manager")==-1) {
+            var restricted_in_source = frappe.model.get_list("Stock Entry Detail", 
                 {parent:cur_frm.doc.name, s_warehouse:"Restricted"});
 
-            var restricted_in_target = wn.model.get("Stock Entry Detail",
-                {parent:cur_frm.doc.name, t_warehouse:"Restricted"})
+            var restricted_in_target = frappe.model.get_list("Stock Entry Detail", 
+                {parent:cur_frm.doc.name, t_warehouse:"Restricted"});
 
             if(restricted_in_source.length || restricted_in_target.length) {
-                msgprint("Only Material Manager can make entry in Restricted Warehouse");
-                validated = false;
+                frappe.msgprint(__("Only Material Manager can make entry in Restricted Warehouse"));
+                frappe.validated = false;
             }
         }
     }

--- a/erpnext/docs/user/manual/de/setting-up/data/bulk-rename.md
+++ b/erpnext/docs/user/manual/de/setting-up/data/bulk-rename.md
@@ -14,5 +14,3 @@ Dieses Werkzeug ermöglicht es Ihnen, gleichzeitig mehrere Datensätze umzubenen
 Um mehrere Datensätze umzubenennen, laden Sie eine CSV-Datei mit den alten Namen in der ersten Spalte und den neuen Namen in der zweiten Spalte hoch indem Sie auf "Hochladen" klicken.
 
 <img class="screenshot" alt="Bulk Rename" src="{{docs_base_url}}/assets/img/setup/data/rename.png">
-
-{next}

--- a/erpnext/docs/user/manual/en/buying/setup/supplier-type.md
+++ b/erpnext/docs/user/manual/en/buying/setup/supplier-type.md
@@ -24,5 +24,3 @@ Classifying your supplier into different types facilitates accounting and
 payments.
 
 Type your new supplier category and Save.
-
-{next}

--- a/erpnext/docs/user/manual/en/customize-erpnext/custom-scripts/custom-script-examples/date-validation.md
+++ b/erpnext/docs/user/manual/en/customize-erpnext/custom-scripts/custom-script-examples/date-validation.md
@@ -3,8 +3,8 @@
 
 	frappe.ui.form.on("Task", "validate", function(frm) {
         if (frm.doc.from_date < get_today()) {
-            msgprint(__("You can not select past date in From Date"));
-            validated = false;
+            frappe.msgprint(__("You can not select past date in From Date"));
+            frappe.validated = false;
         }
 	});
 

--- a/erpnext/docs/user/manual/en/customize-erpnext/custom-scripts/custom-script-examples/restrict-cancel-rights.md
+++ b/erpnext/docs/user/manual/en/customize-erpnext/custom-scripts/custom-script-examples/restrict-cancel-rights.md
@@ -3,12 +3,12 @@ Add a handler to `custom_before_cancel` event:
 
 
     cur_frm.cscript.custom_before_cancel = function(doc) {
-        if (user_roles.indexOf("Accounts User")!=-1 && user_roles.indexOf("Accounts Manager")==-1
+        if (frappe.user_roles.indexOf("Accounts User")!=-1 && frappe.user_roles.indexOf("Accounts Manager")==-1
                 && user_roles.indexOf("System Manager")==-1) {
             if (flt(doc.grand_total) > 10000) {
-                msgprint("You can not cancel this transaction, because grand total \
+                frappe.msgprint("You can not cancel this transaction, because grand total \
                     is greater than 10000");
-                validated = false;
+                frappe.validated = false;
             }
         }
     }

--- a/erpnext/docs/user/manual/en/customize-erpnext/custom-scripts/custom-script-examples/restrict-purpose-of-stock-entry.md
+++ b/erpnext/docs/user/manual/en/customize-erpnext/custom-scripts/custom-script-examples/restrict-purpose-of-stock-entry.md
@@ -1,8 +1,8 @@
 
     frappe.ui.form.on("Material Request", "validate", function(frm) {
-        if(user=="user1@example.com" && frm.doc.purpose!="Material Receipt") {
-            msgprint("You are only allowed Material Receipt");
-            throw "Not allowed";
+        if(frappe.user=="user1@example.com" && frm.doc.purpose!="Material Receipt") {
+            frappe.msgprint("You are only allowed Material Receipt");
+            frappe.throw(__("Not allowed"));
         }
     }
 

--- a/erpnext/docs/user/manual/en/customize-erpnext/custom-scripts/custom-script-examples/restrict-user-based-on-child-record.md
+++ b/erpnext/docs/user/manual/en/customize-erpnext/custom-scripts/custom-script-examples/restrict-user-based-on-child-record.md
@@ -1,16 +1,16 @@
 
     // restrict certain warehouse to Material Manager
     cur_frm.cscript.custom_validate = function(doc) {
-        if(user_roles.indexOf("Material Manager")==-1) {
+        if(frappe.user_roles.indexOf("Material Manager")==-1) {
 
-            var restricted_in_source = wn.model.get("Stock Entry Detail",
+            var restricted_in_source = frappe.model.get_list("Stock Entry Detail",
                 {parent:cur_frm.doc.name, s_warehouse:"Restricted"});
 
-            var restricted_in_target = wn.model.get("Stock Entry Detail",
+            var restricted_in_target = frappe.model.get_list("Stock Entry Detail",
                 {parent:cur_frm.doc.name, t_warehouse:"Restricted"})
 
             if(restricted_in_source.length || restricted_in_target.length) {
-                msgprint("Only Material Manager can make entry in Restricted Warehouse");
+                frappe.msgprint(__("Only Material Manager can make entry in Restricted Warehouse"));
                 validated = false;
             }
         }

--- a/erpnext/docs/user/manual/en/setting-up/data/bulk-rename.md
+++ b/erpnext/docs/user/manual/en/setting-up/data/bulk-rename.md
@@ -13,5 +13,3 @@ This tool will allow you to rename multiple records at the same time.
 To rename multiple records, upload a **.csv** file with the old name in the first column and the new name in the second column and click on **Upload**.
 
 <img class="screenshot" alt="Bulk Rename" src="{{docs_base_url}}/assets/img/setup/data/rename.png">
-
-{next}

--- a/erpnext/docs/user/manual/en/using-erpnext/articles/bulk-rename.md
+++ b/erpnext/docs/user/manual/en/using-erpnext/articles/bulk-rename.md
@@ -22,4 +22,6 @@ Select DocType which you want to rename. Here DocType will be Item. Then Browse 
 
 ![Upload Data]({{docs_base_url}}/assets/img/articles/Selection_0173436a8.png) 
 
+{next}
+
 <!-- markdown -->


### PR DESCRIPTION
`{next}` text in documentation

<img width="529" alt="screen shot 2017-06-09 at 5 32 02 pm" src="https://user-images.githubusercontent.com/11224291/26974573-9a3b4dea-4d39-11e7-9838-b746bce3b09c.png">

replaced `msgprint` globals with `frappe.msgprint`