### PR TITLE
[fix] add index on voucher type and voucher no in stock ledger entry

### DIFF
--- a/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.json
+++ b/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.json
@@ -694,7 +694,7 @@
  "issingle": 0, 
  "istable": 0, 
  "max_attachments": 0, 
- "modified": "2016-12-15 14:45:07.733480", 
+ "modified": "2017-06-09 14:45:07.888888", 
  "modified_by": "Administrator", 
  "module": "Stock", 
  "name": "Stock Ledger Entry", 

--- a/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py
+++ b/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py
@@ -129,3 +129,5 @@ def on_doctype_update():
 		frappe.db.commit()
 		frappe.db.sql("""alter table `tabStock Ledger Entry`
 			add index posting_sort_index(posting_date, posting_time, name)""")
+
+	frappe.db.add_index("Stock Ledger Entry", ["voucher_no", "voucher_type"])


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/apps/frappe/frappe/desk/form/save.py", line 45, in cancel
    doc.cancel()
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/apps/frappe/frappe/model/document.py", line 746, in cancel
    self._cancel()
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/apps/frappe/frappe/model/document.py", line 736, in _cancel
    self.save()
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/apps/frappe/frappe/model/document.py", line 230, in save
    return self._save(*args, **kwargs)
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/apps/frappe/frappe/model/document.py", line 280, in _save
    self.run_post_save_methods()
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/apps/frappe/frappe/model/document.py", line 795, in run_post_save_methods
    self.run_method("on_cancel")
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/apps/frappe/frappe/model/document.py", line 666, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/apps/frappe/frappe/model/document.py", line 892, in composer
    return composed(self, method, *args, **kwargs)
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/apps/frappe/frappe/model/document.py", line 875, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/apps/frappe/frappe/model/document.py", line 660, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.py", line 70, in on_cancel
    self.update_stock_ledger()
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.py", line 426, in update_stock_ledger
    self.make_sl_entries(sl_entries, self.amended_from and 'Yes' or 'No')
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/apps/erpnext/erpnext/controllers/stock_controller.py", line 267, in make_sl_entries
    make_sl_entries(sl_entries, is_amended, allow_negative_stock, via_landed_cost_voucher)
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/apps/erpnext/erpnext/stock/stock_ledger.py", line 23, in make_sl_entries
    set_as_cancel(sl_entries[0].get('voucher_no'), sl_entries[0].get('voucher_type'))
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/apps/erpnext/erpnext/stock/stock_ledger.py", line 47, in set_as_cancel
    (now(), frappe.session.user, voucher_type, voucher_no))
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/apps/frappe/frappe/database.py", line 138, in sql
    self._cursor.execute(query, values)
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/env/lib/python2.7/site-packages/MySQLdb/cursors.py", line 205, in execute
    self.errorhandler(self, exc, value)
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/env/lib/python2.7/site-packages/MySQLdb/connections.py", line 36, in defaulterrorhandler
    raise errorclass, errorvalue
OperationalError: (1205, 'Lock wait timeout exceeded; try restarting transaction')
```

----
Default timeout for innodb is 50 seconds, if query won't execute within time out period, innodb raise exception 1205
<img width="549" alt="screen shot 2017-06-09 at 6 59 22 pm" src="https://user-images.githubusercontent.com/3784093/26977545-e9d046d8-4d45-11e7-97e7-fec867a0de88.png">

If we increased timeout, there are the chances for deadlock, thus added index on voucher type and voucher no

**Without Indexing on Voucher Type and Voucher No**
<img width="1275" alt="screen shot 2017-06-09 at 6 53 36 pm" src="https://user-images.githubusercontent.com/3784093/26977456-960fae58-4d45-11e7-8044-81df79b7473d.png">
Locking rows = 203

**With Indexing on Voucher Type and Voucher No**
<img width="1278" alt="screen shot 2017-06-09 at 6 58 46 pm" src="https://user-images.githubusercontent.com/3784093/26977622-2b101cea-4d46-11e7-9352-c3c765a1cafd.png">
lock only single row


