### PR TITLE
[fix] Due Date cannot be before Posting Date during POS records syncing

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/pos.py
+++ b/erpnext/accounts/doctype/sales_invoice/pos.py
@@ -320,6 +320,7 @@ def make_invoice(doc_list={}, email_queue_list={}, customers_list={}):
 				si_doc = frappe.new_doc('Sales Invoice')
 				si_doc.offline_pos_name = name
 				si_doc.update(doc)
+				si_doc.set_posting_time = 1
 				si_doc.customer = get_customer_id(doc)
 				si_doc.due_date = doc.get('posting_date')
 				submit_invoice(si_doc, name, doc)


### PR DESCRIPTION
Issue
![screen shot 2017-06-12 at 12 37 04 pm](https://user-images.githubusercontent.com/8780500/27022506-dfde2a14-4f6b-11e7-813a-96b7aab09a50.png)


Fixed #9110 