### PR TITLE
[Fix] In sales invoice, delivery note link not showing in the dashboard if delivery note has made from sales invoice

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice_dashboard.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice_dashboard.py
@@ -11,8 +11,7 @@ def get_data():
 			'Sales Invoice': 'return_against'
 		},
 		'internal_links': {
-			'Sales Order': ['items', 'sales_order'],
-			'Delivery Note': ['items', 'delivery_note'],
+			'Sales Order': ['items', 'sales_order']
 		},
 		'transactions': [
 			{


### PR DESCRIPTION
**Issue**

![screen shot 2017-06-14 at 6 05 40 pm](https://user-images.githubusercontent.com/8780500/27132363-3dd7b43e-512c-11e7-9fbb-5e775538a29f.png)
#9242 

**Fixed**
![screen shot 2017-06-14 at 6 05 57 pm](https://user-images.githubusercontent.com/8780500/27132366-4438839e-512c-11e7-8f99-901ac562d4b2.png)

