### PR TITLE
Training Events/Results link added to Employee

### DIFF
--- a/erpnext/hr/doctype/employee/employee_dashboard.py
+++ b/erpnext/hr/doctype/employee/employee_dashboard.py
@@ -15,6 +15,10 @@ def get_data():
 				'items': ['Salary Structure', 'Salary Slip', 'Timesheet']
 			},
 			{
+				'label': _('Training Events/Results'),
+				'items': ['Training Event', 'Training Result']
+			},
+			{
 				'label': _('Expense'),
 				'items': ['Expense Claim']
 			},


### PR DESCRIPTION
Summary
link Employee to Training #9085
Training events and results link added
 on employee dashboard.
![demo](https://user-images.githubusercontent.com/6947417/27180597-d57cad92-51f1-11e7-9c87-e0913947acfe.png)
