### PR TITLE
[minor] fixed the child table field name

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -403,4 +403,4 @@ erpnext.patches.v8_0.rename_items_in_status_field_of_material_request
 erpnext.patches.v8_0.delete_bin_indexes
 erpnext.patches.v8_0.move_account_head_from_account_to_warehouse_for_inventory
 erpnext.patches.v8_0.change_in_words_varchar_length
-erpnext.patches.v8_0.create_domain_docs
+erpnext.patches.v8_0.create_domain_docs	#16-05-2017

--- a/erpnext/patches/v8_0/create_domain_docs.py
+++ b/erpnext/patches/v8_0/create_domain_docs.py
@@ -21,9 +21,9 @@ def execute():
 	condition = ""
 	company = erpnext.get_default_company()
 	if company:
-		condition = " where name='{0}'".format(company)
+		condition = " and name='{0}'".format(company)
 
-	domains = frappe.db.sql_list("select distinct domain from `tabCompany` {0}".format(condition))
+	domains = frappe.db.sql_list("select distinct domain from `tabCompany` where domain != 'Other' {0}".format(condition))
 
 	if not domains:
 		return
@@ -36,6 +36,6 @@ def execute():
 		if domain in checked_domains:
 			continue
 
-		row = domain_settings.append("active_domains", dict(domain=args.domain))
+		row = domain_settings.append("active_domains", dict(domain=domain))
 
 	domain_settings.save(ignore_permissions=True)

--- a/erpnext/setup/setup_wizard/setup_wizard.py
+++ b/erpnext/setup/setup_wizard/setup_wizard.py
@@ -199,7 +199,7 @@ def set_defaults(args):
 	hr_settings.save()
 
 	domain_settings = frappe.get_doc("Domain Settings")
-	domain_settings.append('active_domain', dict(domain=args.domain))
+	domain_settings.append('active_domains', dict(domain=args.domain))
 	domain_settings.save()
 
 def create_feed_and_todo():


### PR DESCRIPTION
childtable fieldname should be `active_domains` instead of `active_domain`

```
File "/Users/rushabh/frappe/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/rushabh/frappe/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/rushabh/frappe/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/rushabh/frappe/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/Users/rushabh/frappe/frappe-bench/env/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/rushabh/frappe/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 24, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/Users/rushabh/frappe/frappe-bench/apps/erpnext/erpnext/commands/__init__.py", line 41, in make_demo
    demo.make(domain, days)
  File "/Users/rushabh/frappe/frappe-bench/apps/erpnext/erpnext/demo/demo.py", line 28, in make
    setup_data.setup(domain)
  File "/Users/rushabh/frappe/frappe-bench/apps/erpnext/erpnext/demo/setup/setup_data.py", line 11, in setup
    complete_setup(domain)
  File "/Users/rushabh/frappe/frappe-bench/apps/erpnext/erpnext/demo/setup/setup_data.py", line 63, in complete_setup
    "language": "english"
  File "/Users/rushabh/frappe/frappe-bench/apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.py", line 39, in setup_complete
    frappe.get_attr(method)(args)
  File "/Users/rushabh/frappe/frappe-bench/apps/erpnext/erpnext/setup/setup_wizard/setup_wizard.py", line 29, in setup_complete
    set_defaults(args)
  File "/Users/rushabh/frappe/frappe-bench/apps/erpnext/erpnext/setup/setup_wizard/setup_wizard.py", line 202, in set_defaults
    domain_settings.append('active_domain', dict(domain=args.domain))
  File "/Users/rushabh/frappe/frappe-bench/apps/frappe/frappe/model/base_document.py", line 137, in append
    value = self._init_child(value, key)
  File "/Users/rushabh/frappe/frappe-bench/apps/frappe/frappe/model/base_document.py", line 163, in _init_child
    value["doctype"] = self.get_table_field_doctype(key)
  File "/Users/rushabh/frappe/frappe-bench/apps/frappe/frappe/model/base_document.py", line 274, in get_table_field_doctype
    return self.meta.get_field(fieldname).options
AttributeError: 'NoneType' object has no attribute 'options'
```