### PR TITLE
[minor] reload Domain doctype before executing patch

### DIFF
--- a/erpnext/patches/v8_0/create_domain_docs.py
+++ b/erpnext/patches/v8_0/create_domain_docs.py
@@ -7,6 +7,7 @@ import erpnext
 
 def execute():
 	"""Create domain documents"""
+	frappe.reload_doctype("Domain")
 
 	for domain in ("Distribution", "Manufacturing", "Retail", "Services", "Education"):
 		if not frappe.db.exists({'doctype': 'Domain', 'domain': domain}):


### PR DESCRIPTION
```
Executing erpnext.patches.v8_0.create_domain_docs	#16-05-2017 in site1.local (1bd3e0294da19198)
Traceback (most recent call last):
File "/usr/lib/python2.7/runpy.py", line 174, in runmodule_as_main
"main", fname, loader, pkg_name)
File "/usr/lib/python2.7/runpy.py", line 72, in runcode
exec code in run_globals
File "/home/user/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 91, in 
main()
File "/home/user/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 17, in main
click.Group(commands=commands)(prog_name='bench')
File "/home/user/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 722, in call
return self.main(*args, **kwargs)
File "/home/user/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 697, in main
rv = self.invoke(ctx)
File "/home/user/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
return processresult(sub_ctx.command.invoke(sub_ctx))
File "/home/user/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
return processresult(sub_ctx.command.invoke(sub_ctx))
File "/home/user/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 895, in invoke
return ctx.invoke(self.callback, **ctx.params)
File "/home/user/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 535, in invoke
return callback(*args, **kwargs)
File "/home/user/frappe-bench/env/local/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
return f(get_current_context(), *args, **kwargs)
File "/home/user/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 24, in _func
ret = f(frappe._dict(ctx.obj), *args, **kwargs)
File "/home/user/frappe-bench/apps/frappe/frappe/commands/site.py", line 216, in migrate
migrate(context.verbose, rebuild_website=rebuild_website)
File "/home/user/frappe-bench/apps/frappe/frappe/migrate.py", line 31, in migrate
frappe.modules.patch_handler.run_all()
File "/home/user/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 29, in run_all
if not run_single(patchmodule = patch):
File "/home/user/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 63, in run_single
return execute_patch(patchmodule, method, methodargs)
File "/home/user/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 83, in execute_patch
frappe.get_attr(patchmodule.split()[0] + ".execute")()
File "/home/user/frappe-bench/apps/erpnext/erpnext/patches/v8_0/create_domain_docs.py", line 13, in execute
doc = frappe.new_doc("Domain")
File "/home/user/frappe-bench/apps/frappe/frappe/__init__.py", line 582, in new_doc
return get_new_doc(doctype, parent_doc, parentfield, as_dict=as_dict)
File "/home/user/frappe-bench/apps/frappe/frappe/model/create_new.py", line 19, in get_new_doc
frappe.local.new_doc_templates[doctype] = make_new_doc(doctype)
File "/home/user/frappe-bench/apps/frappe/frappe/model/create_new.py", line 37, in make_new_doc
"docstatus": 0
File "/home/user/frappe-bench/apps/frappe/frappe/__init__.py", line 606, in get_doc
return frappe.model.document.get_doc(arg1, arg2)
File "/home/user/frappe-bench/apps/frappe/frappe/model/document.py", line 51, in get_doc
return controller(arg1, arg2)
File "/home/user/frappe-bench/apps/frappe/frappe/model/document.py", line 88, in init
self.init_valid_columns()
File "/home/user/frappe-bench/apps/frappe/frappe/model/base_document.py", line 228, in init_valid_columns
for key in self.get_valid_columns():
File "/home/user/frappe-bench/apps/frappe/frappe/model/base_document.py", line 238, in get_valid_columns
valid = self.meta.get_valid_columns()
File "/home/user/frappe-bench/apps/frappe/frappe/model/base_document.py", line 62, in meta
self.meta = frappe.getmeta(self.doctype)
File "/home/user/frappe-bench/apps/frappe/frappe/__init__.py", line 623, in get_meta
return frappe.model.meta.get_meta(doctype, cached=cached)
File "/home/user/frappe-bench/apps/frappe/frappe/model/meta.py", line 31, in get_meta
return frappe.cache().hget("meta", doctype, lambda: Meta(doctype))
File "/home/user/frappe-bench/apps/frappe/frappe/utils/redis_wrapper.py", line 171, in hget
value = generator()
File "/home/user/frappe-bench/apps/frappe/frappe/model/meta.py", line 31, in 
return frappe.cache().hget("meta", doctype, lambda: Meta(doctype))
File "/home/user/frappe-bench/apps/frappe/frappe/model/meta.py", line 66, in init
super(Meta, self).init("DocType", doctype)
File "/home/user/frappe-bench/apps/frappe/frappe/model/document.py", line 84, in init
self.load_from_db()
File "/home/user/frappe-bench/apps/frappe/frappe/model/meta.py", line 71, in load_from_db
super(Meta, self).load_from_db()
File "/home/user/frappe-bench/apps/frappe/frappe/model/document.py", line 115, in load_from_db
frappe.throw(("{0} {1} not found").format((self.doctype), self.name), frappe.DoesNotExistError)
File "/home/user/frappe-bench/apps/frappe/frappe/__init__.py", line 316, in throw
msgprint(msg, raise_exception=exc, title=title, indicator='red')
File "/home/user/frappe-bench/apps/frappe/frappe/__init__.py", line 306, in msgprint
raiseexception()
File "/home/user/frappe-bench/apps/frappe/frappe/__init__.py", line 279, in raiseexception
raise raise_exception, encode(msg)
frappe.exceptions.DoesNotExistError: DocType Domain not found
```