### PR TITLE
[minor] use reload_doc instead of reload_doctype

### DIFF
--- a/erpnext/patches/v8_0/create_domain_docs.py
+++ b/erpnext/patches/v8_0/create_domain_docs.py
@@ -7,14 +7,13 @@ import erpnext
 
 def execute():
 	"""Create domain documents"""
-	frappe.reload_doctype("Domain")
+	frappe.reload_doc("core", "doctype", "domain")
+	frappe.reload_doc("core", "doctype", "domain_settings")
+	frappe.reload_doc("core", "doctype", "has_domain")
 
 	for domain in ("Distribution", "Manufacturing", "Retail", "Services", "Education"):
-		if not frappe.db.exists({'doctype': 'Domain', 'domain': domain}):
-			doc = frappe.new_doc("Domain")
-			doc.domain = domain
-			doc.save()
-
+		if not frappe.db.exists({"doctype": "Domain", "domain": domain}):
+			create_domain(domain)
 
 	# set domain in domain settings based on company domain
 
@@ -37,6 +36,17 @@ def execute():
 		if domain in checked_domains:
 			continue
 
+		if not frappe.db.get_value("Domain", domain):
+			# user added custom domain in companies domain field
+			create_domain(domain)
+
 		row = domain_settings.append("active_domains", dict(domain=domain))
 
 	domain_settings.save(ignore_permissions=True)
+
+def create_domain(domain):
+	# create new domain
+
+	doc = frappe.new_doc("Domain")
+	doc.domain = domain
+	doc.db_update()


### PR DESCRIPTION
```
File "/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/local/Cellar/python/2.7.13/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 91, in <module>
    main()
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 17, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/env/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/commands/__init__.py", line 24, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/commands/site.py", line 216, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website)
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/migrate.py", line 31, in migrate
    frappe.modules.patch_handler.run_all()
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 29, in run_all
    if not run_single(patchmodule = patch):
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 63, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 83, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/erpnext/erpnext/patches/v8_0/create_domain_docs.py", line 10, in execute
    frappe.reload_doctype("Domain")
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/__init__.py", line 650, in reload_doctype
    reload_doc(scrub(db.get_value("DocType", doctype, "module")), "doctype", scrub(doctype),
  File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/__init__.py", line 676, in scrub
    return txt.replace(' ','_').replace('-', '_').lower()
AttributeError: 'NoneType' object has no attribute 'replace'
```