### PR TITLE
Resetting batch and serial nos checks

### DIFF
--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -121,7 +121,15 @@ frappe.ui.form.on("Item", {
 		if(!frm.doc.description)
 			frm.set_value("description", frm.doc.item_code);
 	},
-
+	
+	is_stock_item: function(frm) {
+		if(!frm.doc.is_stock_item) {
+			frm.set_value("has_batch_no", 0);
+			frm.set_value("create_new_batch", 0);
+			frm.set_value("has_serial_no", 0);
+		}
+	},
+	
 	copy_from_item_group: function(frm) {
 		return frm.call({
 			doc: frm.doc,


### PR DESCRIPTION
Created a new PR for #9236 closing the old one #9238 due other commits.
Description:
While creating a new item with maintain stock, user checks all three serial and batch nos checkboxes.
![capture 79](https://user-images.githubusercontent.com/10139291/27331405-ea861c54-55da-11e7-81da-79c8611ec59f.png)
okay then user goes on and unchecking maintain stock.
![capture 80](https://user-images.githubusercontent.com/10139291/27331407-ef7c7618-55da-11e7-83a7-e1a761703737.png)
Now the previous action should reset the serial and batch nos checkboxes, but it does not. You will find it by again clicking on maintain stock checkbox and it will have previous checks as it is.
![capture 81](https://user-images.githubusercontent.com/10139291/27331419-fb22b392-55da-11e7-8daf-4a519789a057.png)

And this pull request fixed the bug for us.