### PR TITLE
Bug while fetching stock balance of new item.

### DIFF
--- a/erpnext/stock/utils.py
+++ b/erpnext/stock/utils.py
@@ -65,7 +65,7 @@ def get_stock_balance(item_code, warehouse, posting_date=None, posting_time=None
 	if with_valuation_rate:
 		return (last_entry.qty_after_transaction, last_entry.valuation_rate) if last_entry else (0.0, 0.0)
 	else:
-		return last_entry.qty_after_transaction or 0.0
+		return last_entry.qty_after_transaction if last_entry else 0.0
 
 def get_latest_stock_balance():
 	bin_map = {}


### PR DESCRIPTION
There may not be stock ledger entries for new item and so while fetching balance of such items we get an dict error.
```
/home/frappe/frappe-bench/apps/erpnext/erpnext/stock/utils.pyc in get_stock_balance(item_code, warehouse, posting_date, posting_time, with_valuation_rate)
     65                 return (last_entry.qty_after_transaction, last_entry.valuation_rate) if last_entry else (0.0, 0.0)
     66         else:
---> 67                 return last_entry.qty_after_transaction or 0.0
     68
     69 def get_latest_stock_balance():

AttributeError: 'dict' object has no attribute 'qty_after_transaction'
```

This PR fixed it.