### PR TITLE
Removed "Asset" filter on payment account

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -225,7 +225,8 @@ cur_frm.fields_dict.cash_bank_account.get_query = function(doc) {
 		filters: [
 			["Account", "account_type", "in", ["Cash", "Bank"]],
 			["Account", "is_group", "=",0],
-			["Account", "company", "=", doc.company]
+			["Account", "company", "=", doc.company],
+			["Account", "report_type", "=", "Balance Sheet"]
 		]
 	}
 }

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -224,7 +224,6 @@ cur_frm.fields_dict.cash_bank_account.get_query = function(doc) {
 	return {
 		filters: [
 			["Account", "account_type", "in", ["Cash", "Bank"]],
-			["Account", "root_type", "=", "Asset"],
 			["Account", "is_group", "=",0],
 			["Account", "company", "=", doc.company]
 		]


### PR DESCRIPTION
Fix toward #9415 
Purchase Invoice should also have "Liability" root type, so removed the current "Asset" filter. 
So now user can choose any account.
![capture 86](https://user-images.githubusercontent.com/10139291/27389540-4b5a9c44-56bc-11e7-914e-455096ff4244.png)
