### PR TITLE
Don't validate delivery note and sales order required for the POS invoice

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -54,7 +54,10 @@ class SalesInvoice(SellingController):
 	def validate(self):
 		super(SalesInvoice, self).validate()
 		self.validate_auto_set_posting_time()
-		self.so_dn_required()
+
+		if not self.is_pos:
+			self.so_dn_required()
+
 		self.validate_proj_cust()
 		self.validate_with_previous_doc()
 		self.validate_uom_is_integer("stock_uom", "stock_qty")


### PR DESCRIPTION
Enable Sales Order Required and Delivery Note Required in selling settings and getting following error during making of sales invoice
![screen shot 2017-06-23 at 12 54 25 pm](https://user-images.githubusercontent.com/8780500/27470984-c82df68c-5813-11e7-825b-9a23fa51ddf0.png)


Fixed #https://github.com/frappe/erpnext/issues/9444