### PR TITLE
[fix] Billed Amt does not get updated in Purchase Receipt, if Invoice exists and item has been returned once before

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -270,6 +270,9 @@ def make_purchase_receipt(source_name, target_doc=None):
 	doc = get_mapped_doc("Purchase Order", source_name,	{
 		"Purchase Order": {
 			"doctype": "Purchase Receipt",
+			"field_map": {
+				"per_billed": "per_billed"
+			},
 			"validation": {
 				"docstatus": ["=", 1],
 			}

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -119,7 +119,8 @@ class PurchaseReceipt(BuyingController):
 		frappe.db.set(self, 'status', 'Submitted')
 
 		self.update_prevdoc_status()
-		self.update_billing_status()
+		if self.per_billed < 100:
+			self.update_billing_status()
 
 		if not self.is_return:
 			update_last_purchase_rate(self, 1)


### PR DESCRIPTION
Steps:

- Purchase Receipt (PR1) created from Purchase Order

- Purchase Invoice created from Purchase Order

- Purchase Receipt Return (PR2) created against PR1

- Purchase Receipt (PR3) created against Purchase Order

Expected:
Billed Amt against items in PR3 should be set (as it has already been invoiced)

Observed:

Billed Amt not set

Fixed https://github.com/frappe/erpnext/issues/7226