### PR TITLE
keep the batch no always viewable

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -324,10 +324,13 @@ cur_frm.cscript.hide_fields = function(doc) {
 		}
 	}
 
+	// Keep all field viewable in item child table
+	/*
 	var item_fields_stock = ['batch_no', 'actual_batch_qty', 'actual_qty', 'expense_account',
 		'warehouse', 'expense_account', 'quality_inspection']
 	cur_frm.fields_dict['items'].grid.set_column_disp(item_fields_stock,
 		(cint(doc.update_stock)==1 || cint(doc.is_return)==1 ? true : false));
+	*/
 
 	// India related fields
 	if (frappe.boot.sysdefaults.country == 'India') unhide_field(['c_form_applicable', 'c_form_no']);


### PR DESCRIPTION
Leave this on the user how batch no and serial no should be handled for the different items.

Fixes https://github.com/frappe/erpnext/issues/9246