### PR TITLE
Allow NA values in GSTIN number

### DIFF
--- a/erpnext/regional/india/utils.py
+++ b/erpnext/regional/india/utils.py
@@ -7,9 +7,10 @@ def validate_gstin_for_india(doc, method):
 		return
 
 	if doc.gstin:
-		p = re.compile("[0-9]{2}[a-zA-Z]{5}[0-9]{4}[a-zA-Z]{1}[1-9A-Za-z]{1}[Z]{1}[0-9a-zA-Z]{1}")
-		if not p.match(doc.gstin):
-			frappe.throw(_("Invalid GSTIN"))
+		if doc.gstin != "NA":
+			p = re.compile("[0-9]{2}[a-zA-Z]{5}[0-9]{4}[a-zA-Z]{1}[1-9A-Za-z]{1}[Z]{1}[0-9a-zA-Z]{1}")
+			if not p.match(doc.gstin):
+				frappe.throw(_("Invalid GSTIN or Enter NA for Unregistered"))
 
 		if not doc.gst_state:
 			if doc.state in states:


### PR DESCRIPTION
-Reason for allowing NA value is that if a user wants to make GSTIN number mandatory then they can do the same easily