### PR TITLE
[fixes] delete auto email report of deprecated reports and other minor fixes

### DIFF
--- a/erpnext/patches/v8_1/delete_deprecated_reports.py
+++ b/erpnext/patches/v8_1/delete_deprecated_reports.py
@@ -15,17 +15,40 @@ def execute():
 	for report in reports:
 		if frappe.db.exists("Report", report):
 			check_and_update_desktop_icon_for_report(report)
+			check_and_update_auto_email_report(report)
+			frappe.db.commit()
+
 			frappe.delete_doc("Report", report, ignore_permissions=True)
 
 def check_and_update_desktop_icon_for_report(report):
-	""" delete desktop icon for deprecated desktop icon and update the _report for Addresses And Contacts"""
+	""" delete or update desktop icon"""
+	desktop_icons = frappe.db.sql_list("""select name from `tabDesktop Icon`
+		where _report='{0}'""".format(report))
+
+	if not desktop_icons:
+		return
 
 	if report == "Monthly Salary Register":
-		frappe.delete_doc("Desktop Icon", report)
+		for icon in desktop_icons:
+			frappe.delete_doc("Desktop Icon", icon)
 
 	elif report in ["Customer Addresses And Contacts", "Supplier Addresses And Contacts"]:
-		name = frappe.db.get_value("Desktop Icon", {"_report": report})
-		if name:
-			frappe.db.set_value("Desktop Icon", name, "_report", "Addresses And Contacts")
+		frappe.db.sql("""update `tabDesktop Icon` set _report='{value}'
+			where name in ({docnames})""".format(
+				value=report,
+				docnames=",".join(["'%s'"%icon for icon in desktop_icons])
+			)
+		)
 
-	frappe.db.commit()
+def check_and_update_auto_email_report(report):
+	""" delete or update auto email report for deprecated report """
+
+	auto_email_report = frappe.db.get_value("Auto Email Report", {"report": report})
+	if not auto_email_report:
+		return
+
+	if report == "Monthly Salary Register":
+		frappe.delete_doc("Auto Email Report", auto_email_report)
+
+	elif report in ["Customer Addresses And Contacts", "Supplier Addresses And Contacts"]:
+		frapppe.db.set_value("Auto Email Report", auto_email_report, "report", report)

--- a/erpnext/patches/v8_1/setup_gst_india.py
+++ b/erpnext/patches/v8_1/setup_gst_india.py
@@ -18,7 +18,7 @@ def execute():
 
 def delete_custom_field_tax_id_if_exists():
 	for field in frappe.db.sql_list("""select name from `tabCustom Field` where fieldname='tax_id'
-		and dt in ('Sales Order', 'Salse Invoice', 'Delivery Note')"""):
+		and dt in ('Sales Order', 'Sales Invoice', 'Delivery Note')"""):
 		frappe.delete_doc("Custom Field", field, ignore_permissions=True)
 		frappe.db.commit()
 

--- a/erpnext/setup/setup_wizard/setup_wizard.py
+++ b/erpnext/setup/setup_wizard/setup_wizard.py
@@ -196,7 +196,7 @@ def set_defaults(args):
 	hr_settings.save()
 
 	domain_settings = frappe.get_doc("Domain Settings")
-	domain_settings.append('active_domains', dict(domain=args.domain))
+	domain_settings.append('active_domains', dict(domain=_(args.domain)))
 	domain_settings.save()
 
 def create_feed_and_todo():


### PR DESCRIPTION
1. Patch fixes
2. SetupWizard fix dominification
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2017-06-28/apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.py", line 39, in setup_complete
    frappe.get_attr(method)(args)
  File "/home/frappe/benches/bench-2017-06-28/apps/erpnext/erpnext/setup/setup_wizard/setup_wizard.py", line 29, in setup_complete
    set_defaults(args)
  File "/home/frappe/benches/bench-2017-06-28/apps/erpnext/erpnext/setup/setup_wizard/setup_wizard.py", line 200, in set_defaults
    domain_settings.save()
  File "/home/frappe/benches/bench-2017-06-28/apps/frappe/frappe/model/document.py", line 230, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-2017-06-28/apps/frappe/frappe/model/document.py", line 266, in _save
    self._validate()
  File "/home/frappe/benches/bench-2017-06-28/apps/frappe/frappe/model/document.py", line 400, in _validate
    self._validate_links()
  File "/home/frappe/benches/bench-2017-06-28/apps/frappe/frappe/model/document.py", line 635, in _validate_links
    frappe.LinkValidationError)
  File "/home/frappe/benches/bench-2017-06-28/apps/frappe/frappe/__init__.py", line 320, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red')
  File "/home/frappe/benches/bench-2017-06-28/apps/frappe/frappe/__init__.py", line 310, in msgprint
    _raise_exception()
  File "/home/frappe/benches/bench-2017-06-28/apps/frappe/frappe/__init__.py", line 283, in _raise_exception
    raise raise_exception(encode(msg))
LinkValidationError: Zeile #1: Domäne: Manufacturing konnte nicht gefunden werden
``` 