### PR TITLE
[minor] fixed AttributeError: 'dict' object has no attribute 'company' in sales register

### DIFF
--- a/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py
+++ b/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py
@@ -24,7 +24,7 @@ def _execute(filters=None, additional_table_columns=None, additional_query_colum
 		"fieldtype": "Data",
 		"width": 80
 	})
-	company_currency = frappe.db.get_value("Company", filters.company, "default_currency")
+	company_currency = frappe.db.get_value("Company", filters.get("company"), "default_currency")
 	mode_of_payments = get_mode_of_payments(set([d.parent for d in item_list]))
 
 	data = []

--- a/erpnext/accounts/report/sales_register/sales_register.py
+++ b/erpnext/accounts/report/sales_register/sales_register.py
@@ -26,7 +26,7 @@ def _execute(filters, additional_table_columns=None, additional_query_columns=No
 	invoice_so_dn_map = get_invoice_so_dn_map(invoice_list)
 	customers = list(set([inv.customer for inv in invoice_list]))
 	customer_map = get_customer_details(customers)
-	company_currency = frappe.db.get_value("Company", filters.company, "default_currency")
+	company_currency = frappe.db.get_value("Company", filters.get("company"), "default_currency")
 	mode_of_payments = get_mode_of_payments([inv.name for inv in invoice_list])
 
 	data = []


### PR DESCRIPTION
#WN-SUP26042
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2017-06-29/apps/frappe/frappe/app.py", line 56, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2017-06-29/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2017-06-29/apps/frappe/frappe/handler.py", line 52, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2017-06-29/apps/frappe/frappe/__init__.py", line 914, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2017-06-29/apps/frappe/frappe/desk/query_report.py", line 95, in run
    res = frappe.get_attr(method_name)(frappe._dict(filters))
  File "/home/frappe/benches/bench-2017-06-29/apps/erpnext/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py", line 11, in execute
    return _execute(filters)
  File "/home/frappe/benches/bench-2017-06-29/apps/erpnext/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py", line 27, in _execute
    company_currency = frappe.db.get_value("Company", filters.company, "default_currency")
AttributeError: 'dict' object has no attribute 'company'
```