### PR TITLE
Fixed patch create_warehouse_nestedset

### DIFF
--- a/erpnext/patches/v7_0/create_warehouse_nestedset.py
+++ b/erpnext/patches/v7_0/create_warehouse_nestedset.py
@@ -73,7 +73,7 @@ def validate_parent_account_for_warehouse(company=None):
 	if not company:
 		return
 
-	if cint(erpnext.is_perpetual_inventory_enabled(company)):
+	if cint(erpnext.is_perpetual_inventory_enabled(company.name)):
 		parent_account = frappe.db.sql("""select name from tabAccount
 			where account_type='Stock' and company=%s and is_group=1
 			and (warehouse is null or warehouse = '')""", company.name)


### PR DESCRIPTION
**Issue**

Executing erpnext.patches.v7_0.create_warehouse_nestedset in test1 (b444ac06613fc8d6) Traceback (most recent call last): File "/usr/lib64/python2.7/runpy.py", line 162, in _run_module_as_main "__main__", fname, loader, pkg_name) File "/usr/lib64/python2.7/runpy.py", line 72, in _run_code exec code in run_globals File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 91, in <module> main() File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 17, in main click.Group(commands=commands)(prog_name='bench') File "/home/frappe/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 716, in __call__ return self.main(*args, **kwargs) File "/home/frappe/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 696, in main rv = self.invoke(ctx) File "/home/frappe/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1060, in invoke return _process_result(sub_ctx.command.invoke(sub_ctx)) File "/home/frappe/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1060, in invoke return _process_result(sub_ctx.command.invoke(sub_ctx)) File "/home/frappe/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 889, in invoke return ctx.invoke(self.callback, **ctx.params) File "/home/frappe/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 534, in invoke return callback(*args, **kwargs) File "/home/frappe/frappe-bench/env/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func return f(get_current_context(), *args, **kwargs) File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 24, in _func ret = f(frappe._dict(ctx.obj), *args, **kwargs) File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/site.py", line 216, in migrate migrate(context.verbose, rebuild_website=rebuild_website) File "/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py", line 31, in migrate frappe.modules.patch_handler.run_all() File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 29, in run_all if not run_single(patchmodule = patch): File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 63, in run_single return execute_patch(patchmodule, method, methodargs) File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 83, in execute_patch frappe.get_attr(patchmodule.split()[0] + ".execute")() File "/home/frappe/frappe-bench/apps/erpnext/erpnext/patches/v7_0/create_warehouse_nestedset.py", line 29, in execute make_warehouse_nestedset(company) File "/home/frappe/frappe-bench/apps/erpnext/erpnext/patches/v7_0/create_warehouse_nestedset.py", line 52, in make_warehouse_nestedset validate_parent_account_for_warehouse(company) File "/home/frappe/frappe-bench/apps/erpnext/erpnext/patches/v7_0/create_warehouse_nestedset.py", line 76, in validate_parent_account_for_warehouse if cint(erpnext.is_perpetual_inventory_enabled(company)): File "/home/frappe/frappe-bench/apps/erpnext/erpnext/__init__.py", line 64, in is_perpetual_inventory_enabled if not company in frappe.local.enable_perpetual_inventory: TypeError: unhashable type: '_dict'
Fixed https://github.com/frappe/erpnext/issues/9653