### PR TITLE
[Fix] Setup wizard translation issue

### DIFF
--- a/erpnext/setup/setup_wizard/setup_wizard.py
+++ b/erpnext/setup/setup_wizard/setup_wizard.py
@@ -372,8 +372,8 @@ def create_items(args):
 					"is_sales_item": is_sales_item,
 					"is_purchase_item": is_purchase_item,
 					"is_stock_item": is_stock_item and 1 or 0,
-					"item_group": item_group,
-					"stock_uom": args.get("item_uom_" + str(i)),
+					"item_group": _(item_group),
+					"stock_uom": _(args.get("item_uom_" + str(i))),
 					"default_warehouse": default_warehouse
 				}).insert()
 


### PR DESCRIPTION
Traceback (most recent call last):
File "/home/frappe/benches/bench-2017-07-06/apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.py", line 39, in setup_complete
frappe.get_attr(method)(args)
File "/home/frappe/benches/bench-2017-07-06/apps/erpnext/erpnext/setup/setup_wizard/setup_wizard.py", line 35, in setup_complete
create_items(args)
File "/home/frappe/benches/bench-2017-07-06/apps/erpnext/erpnext/setup/setup_wizard/setup_wizard.py", line 377, in create_items
"default_warehouse": default_warehouse
File "/home/frappe/benches/bench-2017-07-06/apps/frappe/frappe/model/document.py", line 193, in insert
self._validate()
File "/home/frappe/benches/bench-2017-07-06/apps/frappe/frappe/model/document.py", line 400, in _validate
self._validate_links()
File "/home/frappe/benches/bench-2017-07-06/apps/frappe/frappe/model/document.py", line 635, in _validate_links
frappe.LinkValidationError)
File "/home/frappe/benches/bench-2017-07-06/apps/frappe/frappe/init.py", line 319, in throw
msgprint(msg, raise_exception=exc, title=title, indicator='red')
File "/home/frappe/benches/bench-2017-07-06/apps/frappe/frappe/init.py", line 309, in msgprint
_raise_exception()
File "/home/frappe/benches/bench-2017-07-06/apps/frappe/frappe/init.py", line 282, in _raise_exception
raise raise_exception(encode(msg))
LinkValidationError: No se pudo encontrar Grupo de productos: Services, Unidad de Medida (UdM) predeterminada: Hour, Línea #1: UOM: Hour


Fixed https://github.com/frappe/erpnext/issues/9681