### PR TITLE
Fixed the issue Serial No serial no not found

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -803,9 +803,10 @@ class SalesInvoice(SellingController):
 				continue
 
 			for serial_no in item.serial_no.split("\n"):
-				sno = frappe.get_doc('Serial No', serial_no)
-				sno.sales_invoice = invoice
-				sno.db_update()
+				if serial_no and frappe.db.exists('Serial No', serial_no):
+					sno = frappe.get_doc('Serial No', serial_no)
+					sno.sales_invoice = invoice
+					sno.db_update()
 
 	def validate_serial_numbers(self):
 		"""


### PR DESCRIPTION
![capture erp2](https://user-images.githubusercontent.com/8780500/27953603-02293c90-632a-11e7-912b-aa87b7e23850.png)

Traceback
 File "/home/frappe/benches/bench-2017-07-07/apps/erpnext/erpnext/accounts/doctype/sales_invoice/sales_invoice.py", line 806, in update_serial_no
    sno = frappe.get_doc('Serial No', serial_no)
  File "/home/frappe/benches/bench-2017-07-07/apps/frappe/frappe/__init__.py", line 612, in get_doc
    return frappe.model.document.get_doc(arg1, arg2)
  File "/home/frappe/benches/bench-2017-07-07/apps/frappe/frappe/model/document.py", line 51, in get_doc
    return controller(arg1, arg2)
  File "/home/frappe/benches/bench-2017-07-07/apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py", line 24, in __init__
    super(SerialNo, self).__init__(arg1, arg2)
  File "/home/frappe/benches/bench-2017-07-07/apps/erpnext/erpnext/controllers/accounts_controller.py", line 20, in __init__
    super(AccountsController, self).__init__(arg1, arg2)
  File "/home/frappe/benches/bench-2017-07-07/apps/frappe/frappe/model/document.py", line 84, in __init__
    self.load_from_db()
  File "/home/frappe/benches/bench-2017-07-07/apps/frappe/frappe/model/document.py", line 115, in load_from_db
    frappe.throw(_("{0} {1} not found").format(_(self.doctype), self.name), frappe.DoesNotExistError)
  File "/home/frappe/benches/bench-2017-07-07/apps/frappe/frappe/__init__.py", line 319, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red')
  File "/home/frappe/benches/bench-2017-07-07/apps/frappe/frappe/__init__.py", line 309, in msgprint
    _raise_exception()
  File "/home/frappe/benches/bench-2017-07-07/apps/frappe/frappe/__init__.py", line 282, in _raise_exception
    raise raise_exception(encode(msg))
DoesNotExistError: Serial No Serial No not found

Fixed https://github.com/frappe/erpnext/issues/9703