### PR TITLE
don't send deleted doctype for updating naming series

### DIFF
--- a/erpnext/setup/doctype/naming_series/naming_series.py
+++ b/erpnext/setup/doctype/naming_series/naming_series.py
@@ -25,14 +25,17 @@ class NamingSeries(Document):
 		prefixes = ""
 		for d in doctypes:
 			options = ""
+			exist_flag = True
 			try:
 				options = self.get_options(d)
 			except frappe.DoesNotExistError:
+				exist_flag = False
 				frappe.msgprint('Unable to find DocType {0}'.format(d))
+				doctypes.remove(d)
 				#frappe.pass_does_not_exist_error()
 				continue
 
-			if options:
+			if options and exist_flag:
 				prefixes = prefixes + "\n" + options
 
 		prefixes.replace("\n\n", "\n")


### PR DESCRIPTION
If a table isn't deleted from the database and doctype is deleted then don't show the table name in option and for updating the naming series.

![naming series](https://user-images.githubusercontent.com/20757311/28006370-a071180c-656c-11e7-98cf-2cb7c3a85136.gif)

Fixes https://github.com/frappe/erpnext/issues/9665
