### PR TITLE
[minor] dont append empty list to parent item groups list

### DIFF
--- a/erpnext/setup/doctype/item_group/item_group.py
+++ b/erpnext/setup/doctype/item_group/item_group.py
@@ -136,11 +136,16 @@ def get_group_item_count(item_group):
 
 def get_parent_item_groups(item_group_name):
 	item_group = frappe.get_doc("Item Group", item_group_name)
-	return 	[{"name": frappe._("Home"),"route":"/"}]+\
-		frappe.db.sql("""select name, route from `tabItem Group`
+	home_group = frappe._dict({"name": frappe._("Home"),"route":"/"})
+	parent_groups = frappe.db.sql("""select name, route from `tabItem Group`
 		where lft <= %s and rgt >= %s
 		and show_in_website=1
 		order by lft asc""", (item_group.lft, item_group.rgt), as_dict=True)
+
+	if parent_groups:
+		return [home_group] + parent_groups
+	else:
+		return [home_group]
 
 def invalidate_cache_for(doc, item_group=None):
 	if not item_group:


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/travis/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 91, in <module>
    main()
  File "/home/travis/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 17, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/travis/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/travis/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/travis/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/travis/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/travis/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/travis/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/travis/frappe-bench/env/local/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 24, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/commands/utils.py", line 317, in run_tests
    ui_tests = ui_tests)
  File "/home/travis/frappe-bench/apps/frappe/frappe/test_runner.py", line 54, in main
    frappe.get_attr(fn)()
  File "/home/travis/frappe-bench/apps/erpnext/erpnext/setup/utils.py", line 44, in before_tests
    "domain"			: "Manufacturing"
  File "/home/travis/frappe-bench/apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.py", line 39, in setup_complete
    frappe.get_attr(method)(args)
  File "/home/travis/frappe-bench/apps/erpnext/erpnext/setup/setup_wizard/setup_wizard.py", line 23, in setup_complete
    install_fixtures.install(args.get("country"))
  File "/home/travis/frappe-bench/apps/erpnext/erpnext/setup/setup_wizard/install_fixtures.py", line 227, in install
    doc.insert(ignore_permissions=True)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 219, in insert
   Wrote js/print_format_v3.min.js - 23.64 KB
   Wrote css/erpnext.css - 7.95 KB
    self.run_post_save_methods()
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 790, in run_post_save_methods
    self.run_method("on_update")
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 666, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 887, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 870, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 660, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/travis/frappe-bench/apps/erpnext/erpnext/setup/doctype/item_group/item_group.py", line 31, in on_update
    invalidate_cache_for(self)
  File "/home/travis/frappe-bench/apps/erpnext/erpnext/setup/doctype/item_group/item_group.py", line 150, in invalidate_cache_for
    d = frappe.get_doc("Item Group", d.name)
AttributeError: 'dict' object has no attribute 'name'
```