### PR TITLE
[hotfix] check if the item group exist or not

### DIFF
--- a/erpnext/setup/doctype/item_group/item_group.py
+++ b/erpnext/setup/doctype/item_group/item_group.py
@@ -147,6 +147,7 @@ def invalidate_cache_for(doc, item_group=None):
 		item_group = doc.name
 
 	for d in get_parent_item_groups(item_group):
-		d = frappe.get_doc("Item Group", d.name)
-		if d.route:
-			clear_cache(d.route)
+		if frappe.db.exists("Item Group", d.get("name")):
+			d = frappe.get_doc("Item Group", d.get("name"))
+			if d.route:
+				clear_cache(d.route)


### PR DESCRIPTION
Issue while saving production order

```
Traceback (most recent call last):
   File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/desk/form/save.py", line 19, in savedocs
     doc.submit()
   File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/model/document.py", line 741, in submit
     self._submit()
   File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/model/document.py", line 730, in _submit
     self.save()
   File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/model/document.py", line 230, in save
     return self._save(*args, **kwargs)
   File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/model/document.py", line 280, in _save
     self.run_post_save_methods()
   File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/model/document.py", line 793, in run_post_save_methods
     self.run_method("on_submit")
   File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/model/document.py", line 666, in run_method
     out = Document.hook(fn)(self, *args, **kwargs)
   File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/model/document.py", line 887, in composer
     return composed(self, method, *args, **kwargs)
   File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/model/document.py", line 870, in runner
     add_to_return_value(self, fn(self, *args, **kwargs))
   File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/model/document.py", line 660, in <lambda>
     fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
   File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/erpnext/erpnext/manufacturing/doctype/bom/bom.py", line 68, in on_submit
     self.manage_default_bom()
   File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/erpnext/erpnext/manufacturing/doctype/bom/bom.py", line 217, in manage_default_bom
     item.save(ignore_permissions = True)
   File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/model/document.py", line 230, in save
     return self._save(*args, **kwargs)
   File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/model/document.py", line 280, in _save
     self.run_post_save_methods()
   File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/model/document.py", line 790, in run_post_save_methods
     self.run_method("on_update")
   File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/model/document.py", line 666, in run_method
     out = Document.hook(fn)(self, *args, **kwargs)
   File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/model/document.py", line 887, in composer
     return composed(self, method, *args, **kwargs)
   File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/model/document.py", line 870, in runner
     add_to_return_value(self, fn(self, *args, **kwargs))
   File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/model/document.py", line 660, in <lambda>
     fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
   File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/erpnext/erpnext/stock/doctype/item/item.py", line 101, in on_update
     invalidate_cache_for_item(self)
   File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/erpnext/erpnext/stock/doctype/item/item.py", line 764, in invalidate_cache_for_item
     invalidate_cache_for(doc, doc.item_group)
   File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/erpnext/erpnext/setup/doctype/item_group/item_group.py", line 155, in invalidate_cache_for
     d = frappe.get_doc("Item Group", d.name)
   File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/__init__.py", line 612, in get_doc
     return frappe.model.document.get_doc(arg1, arg2)
   File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/model/document.py", line 51, in get_doc
     return controller(arg1, arg2)
   File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/website/website_generator.py", line 16, in __init__
     super(WebsiteGenerator, self).__init__(*args, **kwargs)
   File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/model/document.py", line 84, in __init__
     self.load_from_db()
   File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/model/document.py", line 115, in load_from_db
     frappe.throw(_("{0} {1} not found").format(_(self.doctype), self.name), frappe.DoesNotExistError)
   File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/__init__.py", line 319, in throw
     msgprint(msg, raise_exception=exc, title=title, indicator='red')
   File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/__init__.py", line 309, in msgprint
     _raise_exception()
   File "/Users/makarandbauskar/workspace/frappe/dev-frappe-bench/apps/frappe/frappe/__init__.py", line 282, in _raise_exception
     raise raise_exception(encode(msg))
 DoesNotExistError: Item Group Home not found
```