### PR TITLE
[hotfix] allow only 5 character in company_abbr field in setup wizard

### DIFF
--- a/erpnext/public/js/setup_wizard.js
+++ b/erpnext/public/js/setup_wizard.js
@@ -68,13 +68,13 @@ var erpnext_slides = [
 			slide.get_input("company_name").on("change", function () {
 				var parts = slide.get_input("company_name").val().split(" ");
 				var abbr = $.map(parts, function (p) { return p ? p.substr(0, 1) : null }).join("");
-				slide.get_field("company_abbr").set_input(abbr.slice(0, 5).toUpperCase());
+				slide.get_field("company_abbr").set_value(abbr.slice(0, 5).toUpperCase());
 			}).val(frappe.boot.sysdefaults.company_name || "").trigger("change");
 
 			slide.get_input("company_abbr").on("change", function () {
 				if (slide.get_input("company_abbr").val().length > 5) {
 					frappe.msgprint("Company Abbreviation cannot have more than 5 characters");
-					slide.get_field("company_abbr").set_input("");
+					slide.get_field("company_abbr").set_value("");
 				}
 			});
 		}


### PR DESCRIPTION
`before fix`

If we enter more than 5 characters then system shows validation error but we can click on Next button and complete the setup wizard

`After fix`
![setup](https://user-images.githubusercontent.com/11224291/28053586-dc0382c0-662e-11e7-8940-8bd6a1bc7669.gif)