### PR TITLE
[minor] ingore mandatory while auto closing issues and opportunity

### DIFF
--- a/erpnext/crm/doctype/opportunity/opportunity.py
+++ b/erpnext/crm/doctype/opportunity/opportunity.py
@@ -272,4 +272,6 @@ def auto_close_opportunity():
 	for opportunity in opportunities:
 		doc = frappe.get_doc("Opportunity", opportunity.get("name"))
 		doc.status = "Closed"
-		doc.save(ignore_permissions=True)
+		doc.flags.ignore_permissions = True
+		doc.flags.ignore_mandatory = True
+		doc.save()

--- a/erpnext/support/doctype/issue/issue.py
+++ b/erpnext/support/doctype/issue/issue.py
@@ -90,7 +90,9 @@ def auto_close_tickets():
 	for issue in issues:
 		doc = frappe.get_doc("Issue", issue.get("name"))
 		doc.status = "Closed"
-		doc.save(ignore_permissions=True)
+		doc.flags.ignore_permissions = True
+		doc.flags.ignore_mandatory = True
+		doc.save()
 
 @frappe.whitelist()
 def set_multiple_status(names, status):


### PR DESCRIPTION
```
{'retry': 0, 'log': <function log at 0x381d1b8>, 'site': u'frappe.erpnext.com', 'event': u'daily', 'method_name': u'erpnext.support.doctype.issue.issue.auto_close_tickets', 'method': <function auto_close_tickets at 0x382b410>, 'user': u'Administrator', 'kwargs': {}, 'async': True, 'job_name': u'erpnext.support.doctype.issue.issue.auto_close_tickets'}
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/background_jobs.py", line 66, in execute_job
    method(**kwargs)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/support/doctype/issue/issue.py", line 93, in auto_close_tickets
    doc.save(ignore_permissions=True)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 230, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 266, in _save
    self._validate()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 399, in _validate
    self._validate_mandatory()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 619, in _validate_mandatory
    name=self.name))
MandatoryError: [Issue, WN-SUP25886]: type
```