### PR TITLE
[minor] don't trigger source_warehouse if item_code is not set in Production Order

### DIFF
--- a/erpnext/manufacturing/doctype/production_order/production_order.js
+++ b/erpnext/manufacturing/doctype/production_order/production_order.js
@@ -212,7 +212,9 @@ frappe.ui.form.on("Production Order", {
 frappe.ui.form.on("Production Order Item", {
 	source_warehouse: function(frm, cdt, cdn) {
 		var row = locals[cdt][cdn];
-		if(row.source_warehouse) {
+		if(!row.item_code) {
+			frappe.throw(__("Please set the Item Code first"));
+		} else if(row.source_warehouse) {
 			frappe.call({
 				"method": "erpnext.stock.utils.get_latest_stock_qty",
 				args: {


### PR DESCRIPTION
fixes https://github.com/frappe/erpnext/issues/9805

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2017-07-11/apps/frappe/frappe/app.py", line 56, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2017-07-11/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2017-07-11/apps/frappe/frappe/handler.py", line 52, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2017-07-11/apps/frappe/frappe/__init__.py", line 913, in call
    return fn(*args, **newargs)
TypeError: get_latest_stock_qty() takes at least 1 argument (1 given)
```