### PR TITLE
[Fix] Manual discount is not applying in the transaction if discount amount is zero in the pricing rule

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -185,7 +185,7 @@ def get_pricing_rule_for_item(args):
 				"discount_percentage": 0.0
 			})
 		else:
-			item_details.discount_percentage = pricing_rule.discount_percentage
+			item_details.discount_percentage = pricing_rule.discount_percentage or args.discount_percentage
 	elif args.get('pricing_rule'):
 		item_details = remove_pricing_rule_for_item(args.get("pricing_rule"), item_details)
 

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -861,6 +861,7 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 					"pricing_rule": d.pricing_rule,
 					"warehouse": d.warehouse,
 					"serial_no": d.serial_no,
+					"discount_percentage": d.discount_percentage || 0.0,
 					"conversion_factor": d.conversion_factor || 1.0
 				});
 


### PR DESCRIPTION
**ISSUE**

Objective = Apply a % margin for a specific set of products and limit the Max discount.

I tried using pricing rule, in this particular instance I want to apply a 15% (on price list) margin for a particular product range.
The system is mandating me to insert a Price/discount, and when I put 0%, then it overrides any user applied discount to back to 0%

Fixed https://github.com/frappe/erpnext/issues/9664
