### PR TITLE
[Fix] Got an unexpected keyword argument 'as_dict' patch

### DIFF
--- a/erpnext/patches/v7_0/fix_nonwarehouse_ledger_gl_entries_for_transactions.py
+++ b/erpnext/patches/v7_0/fix_nonwarehouse_ledger_gl_entries_for_transactions.py
@@ -7,10 +7,11 @@ import frappe, erpnext
 def execute():
 	frappe.reload_doctype("Account")
 
-	warehouses = frappe.db.sql_list("""select name, company from tabAccount
+	warehouses = frappe.db.sql("""select name, company from tabAccount
 		where account_type = 'Stock' and is_group = 0
-		and (warehouse is null or warehouse = '')""", as_dict)
+		and (warehouse is null or warehouse = '')""", as_dict=1)
 	warehouses = [d.name for d in warehouses if erpnext.is_perpetual_inventory_enabled(d.company)]
+
 	if len(warehouses) > 0:
 		warehouses = set_warehouse_for_stock_account(warehouses)
 		if not warehouses:


### PR DESCRIPTION
```
 File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/env/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 24, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/commands/site.py", line 216, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/migrate.py", line 31, in migrate
    frappe.modules.patch_handler.run_all()
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 29, in run_all
    if not run_single(patchmodule = patch):
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 63, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 83, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/erpnext/erpnext/patches/v7_0/fix_nonwarehouse_ledger_gl_entries_for_transactions.py", line 12, in execute
    and (warehouse is null or warehouse = '')""", as_dict=1)
TypeError: sql_list() got an unexpected keyword argument 'as_dict'
```