### PR TITLE
Add indexes in some transaction doctypes

### DIFF
--- a/erpnext/buying/doctype/purchase_order_item/purchase_order_item.py
+++ b/erpnext/buying/doctype/purchase_order_item/purchase_order_item.py
@@ -11,3 +11,6 @@ from erpnext.controllers.print_settings import print_settings_for_item_table
 class PurchaseOrderItem(Document):
 	def __setup__(self):
 		print_settings_for_item_table(self)
+
+def on_doctype_update():
+	frappe.db.add_index("Purchase Order Item", ["item_code", "warehouse"])

--- a/erpnext/manufacturing/doctype/production_order_item/production_order_item.py
+++ b/erpnext/manufacturing/doctype/production_order_item/production_order_item.py
@@ -8,3 +8,6 @@ from frappe.model.document import Document
 
 class ProductionOrderItem(Document):
 	pass
+
+def on_doctype_update():
+	frappe.db.add_index("Production Order Item", ["item_code", "source_warehouse"])

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -417,3 +417,4 @@ erpnext.patches.v8_1.remove_sales_invoice_from_returned_serial_no
 erpnext.patches.v8_1.allow_invoice_copy_to_edit_after_submit
 erpnext.patches.v8_1.add_hsn_sac_codes
 erpnext.patches.v8_1.update_gst_state
+erpnext.patches.v8_1.add_indexes_in_transaction_doctypes

--- a/erpnext/patches/v8_1/add_indexes_in_transaction_doctypes.py
+++ b/erpnext/patches/v8_1/add_indexes_in_transaction_doctypes.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
+# License: GNU General Public License v3. See license.txt
+
+import frappe
+
+def execute():
+	for dt in ("Sales Order Item", "Purchase Order Item",
+		"Material Request Item", "Production Order Item", "Packed Item"):
+			frappe.get_doc("DocType", dt).run_module_method("on_doctype_update")

--- a/erpnext/selling/doctype/sales_order_item/sales_order_item.py
+++ b/erpnext/selling/doctype/sales_order_item/sales_order_item.py
@@ -10,3 +10,6 @@ from erpnext.controllers.print_settings import print_settings_for_item_table
 class SalesOrderItem(Document):
 	def __setup__(self):
 		print_settings_for_item_table(self)
+
+def on_doctype_update():
+	frappe.db.add_index("Sales Order Item", ["item_code", "warehouse"])

--- a/erpnext/stock/doctype/material_request_item/material_request_item.py
+++ b/erpnext/stock/doctype/material_request_item/material_request_item.py
@@ -10,3 +10,6 @@ from frappe.model.document import Document
 
 class MaterialRequestItem(Document):
 	pass
+
+def on_doctype_update():
+	frappe.db.add_index("Material Request Item", ["item_code", "warehouse"])

--- a/erpnext/stock/doctype/packed_item/packed_item.py
+++ b/erpnext/stock/doctype/packed_item/packed_item.py
@@ -104,3 +104,6 @@ def get_items_from_product_bundle(args):
 		items.append(get_item_details(args))
 		
 	return items
+	
+def on_doctype_update():
+	frappe.db.add_index("Packed Item", ["item_code", "warehouse"])


### PR DESCRIPTION
To increase speed of posting reserved / ordered / requested / reserved for production qty.

Earlier it was giving timeout error while closing/cancelling a SO with more than 250 items.

![timeout](https://user-images.githubusercontent.com/836784/28257374-ed6b2d0c-6ae7-11e7-8af0-d5f49739c9be.png)


After adding index, it is taking only 2 seconds 😄 