### PR TITLE
[minor] fixes for TypeError: get_lead_details() takes at least 1 argument (2 given)

### DIFF
--- a/erpnext/selling/doctype/quotation/quotation.js
+++ b/erpnext/selling/doctype/quotation/quotation.js
@@ -105,6 +105,10 @@ erpnext.selling.QuotationController = erpnext.selling.SellingController.extend({
 
 	lead: function() {
 		var me = this;
+		if(!this.frm.doc.lead) {
+			return;
+		}
+
 		frappe.call({
 			method: "erpnext.crm.doctype.lead.lead.get_lead_details",
 			args: {


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2017-07-13/apps/frappe/frappe/app.py", line 56, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2017-07-13/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2017-07-13/apps/frappe/frappe/handler.py", line 52, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2017-07-13/apps/frappe/frappe/__init__.py", line 920, in call
    return fn(*args, **newargs)
TypeError: get_lead_details() takes at least 1 argument (2 given)
```

fixes for 