### PR TITLE
Update qty from stock_qty before validate materials

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -51,6 +51,7 @@ class BOM(WebsiteGenerator):
 		from erpnext.utilities.transaction_base import validate_uom_is_integer
 		validate_uom_is_integer(self, "stock_uom", "stock_qty", "BOM Item")
 
+		self.update_stock_qty()
 		self.validate_materials()
 		self.set_bom_material_details()
 		self.validate_operations()


### PR DESCRIPTION
This is so that you can create a BOM over the REST API and set quantities without knowing the stock quantity and conversion_factor.