### PR TITLE
Can't set Start and End Dates in Salary Slip (#9513)

### DIFF
--- a/erpnext/hr/doctype/process_payroll/process_payroll.js
+++ b/erpnext/hr/doctype/process_payroll/process_payroll.js
@@ -51,7 +51,9 @@ frappe.ui.form.on("Process Payroll", {
 	},
 
 	end_date: function (frm) {
-		frm.trigger("set_start_end_dates");
+//		console.log("catch", frm.doc.end_date);
+//		frm.trigger("set_start_end_dates");
+//		console.log("catch", frm.doc.end_date);
 	},
 
 	salary_slip_based_on_timesheet: function (frm) {

--- a/erpnext/hr/doctype/process_payroll/process_payroll.js
+++ b/erpnext/hr/doctype/process_payroll/process_payroll.js
@@ -54,15 +54,10 @@ frappe.ui.form.on("Process Payroll", {
 		if(!in_progress){
 			frm.trigger("set_end_date");
 		}else{
+			// reset flag
 			in_progress = false
 		}
 	},
-
-// 	end_date: function (frm) {
-//		console.log("catch", frm.doc.end_date);
-//		frm.trigger("set_start_end_dates");
-//		console.log("catch", frm.doc.end_date);
-//	},
 
 	salary_slip_based_on_timesheet: function (frm) {
 		frm.toggle_reqd(['payroll_frequency'], !frm.doc.salary_slip_based_on_timesheet);

--- a/erpnext/hr/doctype/process_payroll/process_payroll.js
+++ b/erpnext/hr/doctype/process_payroll/process_payroll.js
@@ -47,7 +47,11 @@ frappe.ui.form.on("Process Payroll", {
 	},
 
 	start_date: function (frm) {
-		frm.trigger("set_start_end_dates");
+//		if (!frm.doc.start_date){
+//			frm.trigger("set_start_end_dates");
+//		} else {
+//			frm.trigger("set_end_date");
+//		}
 	},
 
 	end_date: function (frm) {
@@ -66,19 +70,35 @@ frappe.ui.form.on("Process Payroll", {
 
 	set_start_end_dates: function (frm) {
 		if (!frm.doc.salary_slip_based_on_timesheet) {
-			frappe.call({
-				method: 'erpnext.hr.doctype.process_payroll.process_payroll.get_start_end_dates',
-				args: {
-					payroll_frequency: frm.doc.payroll_frequency,
-					start_date: frm.doc.start_date || frm.doc.posting_date
-				},
-				callback: function (r) {
-					if (r.message) {
-						frm.set_value('start_date', r.message.start_date);
-						frm.set_value('end_date', r.message.end_date);
+			if(!frm.doc.start_date){
+				frappe.call({
+					method: 'erpnext.hr.doctype.process_payroll.process_payroll.get_start_end_dates',
+					args: {
+						payroll_frequency: frm.doc.payroll_frequency,
+						start_date: frm.doc.start_date || frm.doc.posting_date
+					},
+					callback: function (r) {
+						if (r.message) {
+							frm.set_value('start_date', r.message.start_date);
+							frm.set_value('end_date', r.message.end_date);
+						}
 					}
-				}
-			})
+				})
+			} else{
+				frappe.call({
+					method: 'erpnext.hr.doctype.process_payroll.process_payroll.get_end_date',
+					args: {
+						frequency: frm.doc.payroll_frequency,
+						start_date: frm.doc.start_date
+					},
+					callback: function (r) {
+						if (r.message) {
+							frm.set_value('start_date', r.message.start_date);
+							frm.set_value('end_date', r.message.end_date);
+						}
+					}
+				})
+			}
 		}
 	},
 })

--- a/erpnext/hr/doctype/process_payroll/process_payroll.js
+++ b/erpnext/hr/doctype/process_payroll/process_payroll.js
@@ -45,13 +45,11 @@ frappe.ui.form.on("Process Payroll", {
 	},
 
 	payroll_frequency: function (frm) {
-		frm.set_value('start_date', '');
-		frm.set_value('end_date', '');
 		frm.trigger("set_start_end_dates");
 	},
 
 	start_date: function (frm) {
-		if(!in_progress){
+		if(!in_progress && frm.doc.start_date){
 			frm.trigger("set_end_date");
 		}else{
 			// reset flag

--- a/erpnext/hr/doctype/process_payroll/process_payroll.py
+++ b/erpnext/hr/doctype/process_payroll/process_payroll.py
@@ -412,10 +412,10 @@ def get_end_date(start_date, frequency):
 	# weekly, fortnightly and daily intervals have fixed days so no problems
 	end_date = add_to_date(start_date, **kwargs) - relativedelta(days=1)
 	if frequency != 'biweekly':
-		return end_date.strftime(DATE_FORMAT)
+		return dict(end_date=end_date.strftime(DATE_FORMAT))
 
 	else:
-		return ''
+		return dict(end_date='')
 
 
 def get_month_details(year, month):

--- a/erpnext/hr/doctype/process_payroll/process_payroll.py
+++ b/erpnext/hr/doctype/process_payroll/process_payroll.py
@@ -48,7 +48,6 @@ class ProcessPayroll(Document):
 			%s """% cond, {"sal_struct": sal_struct})
 			return emp_list
 
-
 	def get_filter_condition(self):
 		self.check_mandatory()
 
@@ -59,14 +58,12 @@ class ProcessPayroll(Document):
 
 		return cond
 
-
 	def get_joining_releiving_condition(self):
 		cond = """
 			and ifnull(t1.date_of_joining, '0000-00-00') <= '%(end_date)s'
 			and ifnull(t1.relieving_date, '2199-12-31') >= '%(start_date)s'
 		""" % {"start_date": self.start_date, "end_date": self.end_date}
 		return cond
-
 
 	def check_mandatory(self):
 		for fieldname in ['company', 'start_date', 'end_date']:
@@ -111,7 +108,6 @@ class ProcessPayroll(Document):
 					ss_list.append(ss_dict)
 		return self.create_log(ss_list)
 
-
 	def create_log(self, ss_list):
 		if not ss_list or len(ss_list) < 1: 
 			log = "<p>" + _("No employee for the above selected criteria OR salary slip already created") + "</p>"
@@ -134,7 +130,6 @@ class ProcessPayroll(Document):
 			and (t1.journal_entry is null or t1.journal_entry = "") and ifnull(salary_slip_based_on_timesheet,0) = %s %s
 		""" % ('%s', '%s', '%s','%s', cond), (ss_status, self.start_date, self.end_date, self.salary_slip_based_on_timesheet), as_dict=as_dict)
 		return ss_list
-
 
 	def submit_salary_slips(self):
 		"""
@@ -194,7 +189,6 @@ class ProcessPayroll(Document):
 
 	def format_as_links(self, salary_slip):
 		return ['<a href="#Form/Salary Slip/{0}">{0}</a>'.format(salary_slip)]
-
 
 	def get_total_salary_and_loan_amounts(self):
 		"""
@@ -257,7 +251,6 @@ class ProcessPayroll(Document):
 				.format(self.company))
 
 		return payroll_payable_account	
-
 
 	def make_accural_jv_entry(self):
 		self.check_permission('write')
@@ -359,7 +352,6 @@ class ProcessPayroll(Document):
 		self.update(get_start_end_dates(self.payroll_frequency, 
 			self.start_date or self.posting_date, self.company))
 
-
 @frappe.whitelist()
 def get_start_end_dates(payroll_frequency, start_date=None, company=None):
 	'''Returns dict of start and end dates for given payroll frequency based on start_date'''
@@ -392,7 +384,6 @@ def get_start_end_dates(payroll_frequency, start_date=None, company=None):
 		'start_date': start_date, 'end_date': end_date
 	})
 
-
 def get_frequency_kwargs(frequency_name):
 	frequency_dict = {
 		'monthly': {'months': 1},
@@ -401,7 +392,6 @@ def get_frequency_kwargs(frequency_name):
 		'daily': {'days': 1}
 	}
 	return frequency_dict.get(frequency_name)
-
 
 @frappe.whitelist()
 def get_end_date(start_date, frequency):
@@ -416,7 +406,6 @@ def get_end_date(start_date, frequency):
 
 	else:
 		return dict(end_date='')
-
 
 def get_month_details(year, month):
 	ysd = frappe.db.get_value("Fiscal Year", year, "year_start_date")

--- a/erpnext/hr/doctype/process_payroll/process_payroll.py
+++ b/erpnext/hr/doctype/process_payroll/process_payroll.py
@@ -3,7 +3,8 @@
 
 from __future__ import unicode_literals
 import frappe
-from frappe.utils import cint, flt, nowdate, add_days, getdate, fmt_money
+from dateutil.relativedelta import relativedelta
+from frappe.utils import cint, nowdate, add_days, getdate, fmt_money, add_to_date, DATE_FORMAT
 from frappe import _
 from erpnext.accounts.utils import get_fiscal_year
 
@@ -390,6 +391,32 @@ def get_start_end_dates(payroll_frequency, start_date=None, company=None):
 	return frappe._dict({
 		'start_date': start_date, 'end_date': end_date
 	})
+
+
+def get_frequency_kwargs(frequency_name):
+	frequency_dict = {
+		'monthly': {'months': 1},
+		'fortnightly': {'days': 14},
+		'weekly': {'days': 7},
+		'daily': {'days': 1}
+	}
+	return frequency_dict.get(frequency_name)
+
+
+@frappe.whitelist()
+def get_end_date(start_date, frequency):
+	start_date = getdate(start_date)
+	frequency = frequency.lower()
+	kwargs = get_frequency_kwargs(frequency) if frequency != 'biweekly' else get_frequency_kwargs('monthly')
+
+	# weekly, fortnightly and daily intervals have fixed days so no problems
+	end_date = add_to_date(start_date, **kwargs) - relativedelta(days=1)
+	if frequency != 'biweekly':
+		return end_date.strftime(DATE_FORMAT)
+
+	else:
+		return ''
+
 
 def get_month_details(year, month):
 	ysd = frappe.db.get_value("Fiscal Year", year, "year_start_date")

--- a/erpnext/hr/doctype/process_payroll/process_payroll.py
+++ b/erpnext/hr/doctype/process_payroll/process_payroll.py
@@ -406,7 +406,7 @@ def get_frequency_kwargs(frequency_name):
 @frappe.whitelist()
 def get_end_date(start_date, frequency):
 	start_date = getdate(start_date)
-	frequency = frequency.lower()
+	frequency = frequency.lower() if frequency else 'monthly'
 	kwargs = get_frequency_kwargs(frequency) if frequency != 'bimonthly' else get_frequency_kwargs('monthly')
 
 	# weekly, fortnightly and daily intervals have fixed days so no problems

--- a/erpnext/hr/doctype/process_payroll/process_payroll.py
+++ b/erpnext/hr/doctype/process_payroll/process_payroll.py
@@ -407,11 +407,11 @@ def get_frequency_kwargs(frequency_name):
 def get_end_date(start_date, frequency):
 	start_date = getdate(start_date)
 	frequency = frequency.lower()
-	kwargs = get_frequency_kwargs(frequency) if frequency != 'biweekly' else get_frequency_kwargs('monthly')
+	kwargs = get_frequency_kwargs(frequency) if frequency != 'bimonthly' else get_frequency_kwargs('monthly')
 
 	# weekly, fortnightly and daily intervals have fixed days so no problems
 	end_date = add_to_date(start_date, **kwargs) - relativedelta(days=1)
-	if frequency != 'biweekly':
+	if frequency != 'bimonthly':
 		return dict(end_date=end_date.strftime(DATE_FORMAT))
 
 	else:

--- a/erpnext/hr/doctype/process_payroll/test_process_payroll.py
+++ b/erpnext/hr/doctype/process_payroll/test_process_payroll.py
@@ -3,10 +3,12 @@
 from __future__ import unicode_literals
 
 import unittest
-import frappe
+
 import erpnext
-from frappe.utils import flt, add_months, cint, nowdate, getdate, add_days, random_string
-from frappe.utils.make_random import get_random
+import frappe
+from frappe.utils import nowdate
+from erpnext.hr.doctype.process_payroll.process_payroll import get_end_date
+
 
 class TestProcessPayroll(unittest.TestCase):
 	def test_process_payroll(self):
@@ -30,6 +32,16 @@ class TestProcessPayroll(unittest.TestCase):
 			process_payroll.submit_salary_slips()
 			if process_payroll.get_sal_slip_list(ss_status = 1):
 				r = process_payroll.make_payment_entry()
+
+	def test_get_end_date(self):
+		self.assertEqual(get_end_date('2017-01-01', 'monthly'), '2017-01-31')
+		self.assertEqual(get_end_date('2017-02-01', 'monthly'), '2017-02-28')
+		self.assertEqual(get_end_date('2017-02-01', 'fortnightly'), '2017-02-14')
+		self.assertEqual(get_end_date('2017-02-01', 'biweekly'), '')
+		self.assertEqual(get_end_date('2017-01-01', 'biweekly'), '')
+		self.assertEqual(get_end_date('2020-02-15', 'biweekly'), '')
+		self.assertEqual(get_end_date('2017-02-15', 'monthly'), '2017-03-14')
+		self.assertEqual(get_end_date('2017-02-15', 'daily'), '2017-02-15')
 	
 
 def get_salary_component_account(sal_comp):

--- a/erpnext/hr/doctype/process_payroll/test_process_payroll.py
+++ b/erpnext/hr/doctype/process_payroll/test_process_payroll.py
@@ -34,14 +34,14 @@ class TestProcessPayroll(unittest.TestCase):
 				r = process_payroll.make_payment_entry()
 
 	def test_get_end_date(self):
-		self.assertEqual(get_end_date('2017-01-01', 'monthly'), '2017-01-31')
-		self.assertEqual(get_end_date('2017-02-01', 'monthly'), '2017-02-28')
-		self.assertEqual(get_end_date('2017-02-01', 'fortnightly'), '2017-02-14')
-		self.assertEqual(get_end_date('2017-02-01', 'biweekly'), '')
-		self.assertEqual(get_end_date('2017-01-01', 'biweekly'), '')
-		self.assertEqual(get_end_date('2020-02-15', 'biweekly'), '')
-		self.assertEqual(get_end_date('2017-02-15', 'monthly'), '2017-03-14')
-		self.assertEqual(get_end_date('2017-02-15', 'daily'), '2017-02-15')
+		self.assertEqual(get_end_date('2017-01-01', 'monthly'), {'end_date': '2017-01-31'})
+		self.assertEqual(get_end_date('2017-02-01', 'monthly'), {'end_date': '2017-02-28'})
+		self.assertEqual(get_end_date('2017-02-01', 'fortnightly'), {'end_date': '2017-02-14'})
+		self.assertEqual(get_end_date('2017-02-01', 'bimonthly'), {'end_date': ''})
+		self.assertEqual(get_end_date('2017-01-01', 'bimonthly'), {'end_date': ''})
+		self.assertEqual(get_end_date('2020-02-15', 'bimonthly'), {'end_date': ''})
+		self.assertEqual(get_end_date('2017-02-15', 'monthly'), {'end_date': '2017-03-14'})
+		self.assertEqual(get_end_date('2017-02-15', 'daily'), {'end_date': '2017-02-15'})
 	
 
 def get_salary_component_account(sal_comp):


### PR DESCRIPTION
Fixed #9513 

### Before
![peek 2017-07-13 12-23](https://user-images.githubusercontent.com/818803/28330716-819e94ec-6be6-11e7-913b-05cb58c9997a.gif)

### After
![peek 2017-07-18 20-06](https://user-images.githubusercontent.com/818803/28335187-78f7c7be-6bf5-11e7-94cc-3e9b06b48a97.gif)

This makes ERPNext still do her date calculations but now the user is allowed to change the dates in lieu of strong validation.
