### PR TITLE
[Fix] Calendar view not working for leave application

### DIFF
--- a/erpnext/hr/doctype/leave_application/leave_application.py
+++ b/erpnext/hr/doctype/leave_application/leave_application.py
@@ -412,7 +412,7 @@ def get_events(start, end, filters=None):
 		company=frappe.db.get_value("Global Defaults", None, "default_company")
 
 	from frappe.desk.reportview import get_filters_cond
-	conditions = get_filters_cond("Leave Application")
+	conditions = get_filters_cond("Leave Application", filters, [])
 
 	# show department leaves for employee
 	if "Employee" in frappe.get_roles():
@@ -435,7 +435,7 @@ def add_department_leaves(events, start, end, employee, company):
 	department_employees = frappe.db.sql_list("""select name from tabEmployee where department=%s
 		and company=%s""", (department, company))
 
-	match_conditions = "employee in (\"%s\")" % '", "'.join(department_employees)
+	match_conditions = "and employee in (\"%s\")" % '", "'.join(department_employees)
 	add_leaves(events, start, end, match_conditions=match_conditions)
 
 def add_leaves(events, start, end, match_conditions=None):
@@ -446,7 +446,7 @@ def add_leaves(events, start, end, match_conditions=None):
 		and docstatus < 2
 		and status!="Rejected" """
 	if match_conditions:
-		query += " and " + match_conditions
+		query += match_conditions
 
 	for d in frappe.db.sql(query, {"start":start, "end": end}, as_dict=True):
 		e = {


### PR DESCRIPTION
**Issue**

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2017-07-18/apps/frappe/frappe/app.py", line 56, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2017-07-18/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2017-07-18/apps/frappe/frappe/handler.py", line 52, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2017-07-18/apps/frappe/frappe/__init__.py", line 922, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2017-07-18/apps/erpnext/erpnext/hr/doctype/leave_application/leave_application.py", line 415, in get_events
    conditions = get_filters_cond("Leave Application")
TypeError: get_filters_cond() takes at least 3 arguments (1 given)

```


After adding parameters into the get_filters_cond method getting following an error
```
File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/app.py", line 56, in application
    response = frappe.handler.handle()
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/handler.py", line 52, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/__init__.py", line 922, in call
    return fn(*args, **newargs)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/erpnext/erpnext/hr/doctype/leave_application/leave_application.py", line 422, in get_events
    add_leaves(events, start, end, conditions)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/erpnext/erpnext/hr/doctype/leave_application/leave_application.py", line 452, in add_leaves
    for d in frappe.db.sql(query, {"start":start, "end": end}, as_dict=True):
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/database.py", line 142, in sql
    self._cursor.execute(query, values)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/env/lib/python2.7/site-packages/MySQLdb/cursors.py", line 250, in execute
    self.errorhandler(self, exc, value)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/env/lib/python2.7/site-packages/MySQLdb/connections.py", line 50, in defaulterrorhandler
    raise errorvalue
ProgrammingError: (1064, 'You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near \'and ifnull(`tabLeave Application`.status, "") != "Rejected"\' at line 6')
```

Fixed https://github.com/frappe/erpnext/issues/9962