### PR TITLE
[Fix] Unable to create production order from the sales order for the bundle items

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -326,11 +326,12 @@ class SalesOrder(SellingController):
 			bom = frappe.get_all('BOM', dict(item=i.item_code, is_active=True),
 					order_by='is_default desc')
 			bom = bom[0].name if bom else None
+			stock_qty = i.qty if self.packed_items else i.stock_qty
 			items.append(dict(
 				item_code= i.item_code,
 				bom = bom,
 				warehouse = i.warehouse,
-				pending_qty= i.stock_qty - flt(frappe.db.sql('''select sum(qty) from `tabProduction Order`
+				pending_qty= stock_qty - flt(frappe.db.sql('''select sum(qty) from `tabProduction Order`
 					where production_item=%s and sales_order=%s''', (i.item_code, self.name))[0][0])
 			))
 


### PR DESCRIPTION
**Issue**

When creating production order from a sales order form, getting following error
```
Traceback (most recent call last):
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/app.py", line 56, in application
    response = frappe.handler.handle()
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/handler.py", line 52, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/__init__.py", line 922, in call
    return fn(*args, **newargs)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/handler.py", line 80, in runserverobj
    frappe.desk.form.run_method.runserverobj(method, docs=docs, dt=dt, dn=dn, arg=arg, args=args)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/desk/form/run_method.py", line 35, in runserverobj
    r = doc.run_method(method)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/model/document.py", line 666, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/model/document.py", line 887, in composer
    return composed(self, method, *args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/model/document.py", line 870, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/model/document.py", line 660, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/erpnext/erpnext/selling/doctype/sales_order/sales_order.py", line 333, in get_production_order_items
    pending_qty= i.stock_qty - flt(frappe.db.sql('''select sum(qty) from `tabProduction Order`
AttributeError: 'PackedItem' object has no attribute 'stock_qty'
```
Fixed https://github.com/frappe/erpnext/issues/9974