### PR TITLE
Whitelist method for adding production orders ops

### DIFF
--- a/erpnext/manufacturing/doctype/production_order/production_order.py
+++ b/erpnext/manufacturing/doctype/production_order/production_order.py
@@ -511,6 +511,12 @@ def check_if_scrap_warehouse_mandatory(bom_no):
 	return res
 
 @frappe.whitelist()
+def set_production_order_ops(name):
+	po = frappe.get_doc('Production Order', name)
+	po.set_production_order_operations()
+	po.save()
+
+@frappe.whitelist()
 def make_stock_entry(production_order_id, purpose, qty=None):
 	production_order = frappe.get_doc("Production Order", production_order_id)
 	if not frappe.db.get_value("Warehouse", production_order.wip_warehouse, "is_group"):


### PR DESCRIPTION
This allows production orders to be created fully through the REST API, which currently can't be done because there's no way to populate the operations.