### PR TITLE
[Fix] Validating price list currency even if price list is not defined

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -243,7 +243,8 @@ def get_price_list_rate(args, item_doc, out):
 
 	if meta.get_field("currency"):
 		validate_price_list(args)
-		validate_conversion_rate(args, meta)
+		if args.price_list:
+			validate_conversion_rate(args, meta)
 
 		price_list_rate = get_price_list_rate_for(args.price_list, item_doc.name)
 


### PR DESCRIPTION
Steps to replicate:

Removed default Price List from Buying Settings
Saved new Purchase Order (without Price List)
Edited Supplier Name in the Purchase Order and received this error message.

![28418697-44d3cf92-6d7a-11e7-93c2-286cabfcd7cd](https://user-images.githubusercontent.com/8780500/28520068-b754f2d0-708b-11e7-9b6b-5e94b79c3fd4.png)


Fixed https://github.com/frappe/erpnext/issues/9996