### PR TITLE
Required On date for Material Request not auto populating after first instance (#9980)

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -122,6 +122,18 @@ erpnext.buying.MaterialRequestController = erpnext.buying.BuyingController.exten
 
 	},
 
+	schedule_date: function(doc, cdt, cdn) {
+		var val = locals[cdt][cdn].schedule_date;
+		if(val) {
+			$.each((doc.items || []), function(i, d) {
+				if(!d.schedule_date) {
+					d.schedule_date = val;
+				}
+			});
+			refresh_field("items");
+		}
+	},
+
 	get_items_from_bom: function() {
 		var d = new frappe.ui.Dialog({
 			title: __("Get Items from BOM"),


### PR DESCRIPTION
Fixed #9980 

### Before
![peek 2017-07-24 12-57](https://user-images.githubusercontent.com/818803/28522511-2ba1c30a-7070-11e7-8a22-95276f39830f.gif)

### After
![peek 2017-07-24 12-43](https://user-images.githubusercontent.com/818803/28522516-2faf4f9e-7070-11e7-9f1e-c14236adc805.gif)
