### PR TITLE
Journal Entry - Cost Center of default Company fetching always (#10034)

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.js
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.js
@@ -43,8 +43,26 @@ frappe.ui.form.on("Journal Entry", {
 		$.each(frm.doc.accounts || [], function(i, row) {
 			erpnext.journal_entry.set_exchange_rate(frm, row.doctype, row.name);
 		})
+	},
+
+	company: function(frm) {
+		frappe.call({
+			method: "frappe.client.get_value",
+			args: {
+				doctype: "Company",
+				filters: {"name": frm.doc.company},
+				fieldname: "cost_center"
+			},
+			callback: function(r){
+				if(r.message){
+					$.each(frm.doc.accounts || [], function(i, jvd) {
+						frappe.model.set_value(jvd.doctype, jvd.name, "cost_center", r.message.cost_center);
+					});
+				}
+			}
+		});
 	}
-})
+});
 
 erpnext.accounts.JournalEntry = frappe.ui.form.Controller.extend({
 	onload: function() {


### PR DESCRIPTION
Fixed #10034 
It makes sense that when you change the company, the cost center should change accordingly. For this, I monitor the company field and ask the server for the default cost center for the selected company.

### Now
![peek 2017-07-25 00-19](https://user-images.githubusercontent.com/818803/28548964-0ffca00c-70cf-11e7-8fae-27bbfb801e72.gif)

