### PR TITLE
[UI Test] Create tax account in Charts of account

### DIFF
--- a/erpnext/accounts/doctype/account/test_make_tax_account.js
+++ b/erpnext/accounts/doctype/account/test_make_tax_account.js
@@ -1,0 +1,46 @@
+QUnit.module('accounts');
+QUnit.test("test account", assert => {
+	assert.expect(3);
+	let done = assert.async();
+	frappe.run_serially([
+		() => frappe.set_route('Tree', 'Account'),
+		() => frappe.click_button('Expand All'),
+		() => frappe.click_link('Duties and Taxes - '+ frappe.get_abbr(frappe.defaults.get_default("Company"))),
+		() => {
+			if($('a:contains("CGST"):visible').length == 0){
+				return frappe.map_tax.make('CGST', 9);
+			}
+		},
+		() => {
+			if($('a:contains("SGST"):visible').length == 0){
+				return frappe.map_tax.make('SGST', 9);
+			}
+		},
+		() => {
+			if($('a:contains("IGST"):visible').length == 0){
+				return frappe.map_tax.make('IGST', 18);
+			}
+		},
+		() => {
+			assert.ok($('a:contains("CGST"):visible').length!=0, "CGST Checked");
+			assert.ok($('a:contains("SGST"):visible').length!=0, "SGST Checked");
+			assert.ok($('a:contains("IGST"):visible').length!=0, "IGST Checked");
+		},
+		() => done()
+	]);
+});
+
+
+frappe.map_tax = {
+	make:function(text,rate){
+		return frappe.run_serially([
+			() => frappe.click_button('Add Child'),
+			() => frappe.timeout(0.2),
+			() => cur_dialog.set_value('account_name',text),
+			() => cur_dialog.set_value('account_type','Tax'),
+			() => cur_dialog.set_value('tax_rate',rate),
+			() => cur_dialog.set_value('account_currency','INR'),
+			() => frappe.click_button('Create New'),
+		]);
+	}
+}

--- a/erpnext/accounts/doctype/account/test_make_tax_account.js
+++ b/erpnext/accounts/doctype/account/test_make_tax_account.js
@@ -43,4 +43,4 @@ frappe.map_tax = {
 			() => frappe.click_button('Create New'),
 		]);
 	}
-}
+};

--- a/erpnext/tests/ui/make_fixtures.js
+++ b/erpnext/tests/ui/make_fixtures.js
@@ -199,12 +199,29 @@ $.extend(frappe.test_data, {
 	},
 	"Terms and Conditions": {
 		"Test Term 1": [
-			{title: "Test Term 1"}
+			{title: "Test Term 1"},
+			{terms: "Test 1"}
 		],
 		"Test Term 2": [
-			{title: "Test Term 2"}
+			{title: "Test Term 2"},
+			{terms: "Test 2"}
 		]
 	},
+	"Sales Taxes and Charges Template": {
+		"TEST In State GST": [
+			{title: "TEST In State GST"},
+			{taxes:[
+				[
+					{charge_type:"On Net Total"},
+					{account_head:"CGST - "+frappe.get_abbr(frappe.defaults.get_default("Company")) }
+				],
+				[
+					{charge_type:"On Net Total"},
+					{account_head:"SGST - "+frappe.get_abbr(frappe.defaults.get_default("Company")) }
+				]
+			]}
+		]
+	}
 });
 
 

--- a/erpnext/tests/ui/tests.txt
+++ b/erpnext/tests/ui/tests.txt
@@ -1,5 +1,6 @@
 erpnext/tests/ui/make_fixtures.js #long
 erpnext/accounts/doctype/account/test_account.js
+erpnext/accounts/doctype/account/test_make_tax_account.js
 erpnext/crm/doctype/lead/test_lead.js
 erpnext/crm/doctype/opportunity/test_opportunity.js
 erpnext/selling/doctype/quotation/test_quotation.js


### PR DESCRIPTION
Create CGST, SGST, IGST account in Charts of Account.
step1. Run test_make_tax_account.js 
step2. Run make_fixtures.js to create sales and tax template.

![anim](https://user-images.githubusercontent.com/6947417/28555434-78f0171c-711d-11e7-9b63-908632629c3e.gif)
