### PR TITLE
Required On date for Material Request not auto populating after first instance (#9980)

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -36,9 +36,14 @@ frappe.ui.form.on("Material Request Item", {
 			frappe.msgprint(__("Warning: Material Requested Qty is less than Minimum Order Qty"));
 		}
 	},
+
 	item_code: function(frm, doctype, name) {
 		frm.script_manager.copy_from_first_row('items', frm.selected_doc,
 			'schedule_date');
+	},
+
+	schedule_date: function(frm, cdt, cdn) {
+		erpnext.utils.copy_value_in_all_row(frm.doc, cdt, cdn, "items", "schedule_date");
 	}
 });
 


### PR DESCRIPTION
Fixed #9980 
![peek 2017-07-24 12-43](https://user-images.githubusercontent.com/818803/28573775-9574a9fe-7143-11e7-9ab0-eb0344c34caf.gif)

Correction of #10061 