### PR TITLE
Employee Loan Should Be Limited To Employee Company (#10039)

### DIFF
--- a/erpnext/hr/doctype/employee_loan/employee_loan.js
+++ b/erpnext/hr/doctype/employee_loan/employee_loan.js
@@ -23,6 +23,14 @@ frappe.ui.form.on('Employee Loan', {
 			};
 		});
 
+		frm.set_query("employee", function() {
+			return {
+				"filters": {
+					"company": frm.doc.company,
+				}
+			}
+		});
+
 		$.each(["payment_account", "employee_loan_account"], function (i, field) {
 			frm.set_query(field, function () {
 				return {

--- a/erpnext/hr/doctype/employee_loan/employee_loan.js
+++ b/erpnext/hr/doctype/employee_loan/employee_loan.js
@@ -28,7 +28,7 @@ frappe.ui.form.on('Employee Loan', {
 				"filters": {
 					"company": frm.doc.company,
 				}
-			}
+			};
 		});
 
 		$.each(["payment_account", "employee_loan_account"], function (i, field) {


### PR DESCRIPTION
Fixed #10039
When selecting employees, only the employees of the selected company should be available. It makes for a better user experience for users.

### Before
![peek 2017-07-25 16-38](https://user-images.githubusercontent.com/818803/28580771-65c52264-7158-11e7-9935-3be9a5516f16.gif)


### After
![peek 2017-07-25 16-12](https://user-images.githubusercontent.com/818803/28580214-c3c4a6ca-7156-11e7-9a0d-ed1b92b39887.gif)
