### PR TITLE
[hotfix] included the get_purchase_trends_filters instead of get_sales_trends_filters in Purchase Receipts trends

### DIFF
--- a/erpnext/stock/report/purchase_receipt_trends/purchase_receipt_trends.js
+++ b/erpnext/stock/report/purchase_receipt_trends/purchase_receipt_trends.js
@@ -3,7 +3,7 @@
 
 frappe.require("assets/erpnext/js/purchase_trends_filters.js", function() {
 	frappe.query_reports["Purchase Receipt Trends"] = {
-		filters: erpnext.get_sales_trends_filters()
+		filters: erpnext.get_purchase_trends_filters()
 	}
 });
 


### PR DESCRIPTION
<img width="370" alt="screen shot 2017-07-27 at 1 28 47 pm" src="https://user-images.githubusercontent.com/11224291/28660245-e5d56ffe-72cf-11e7-9f53-9b0d08d05f49.png">
