### PR TITLE
Set billing hours to 0 in timesheet #9535

### DIFF
--- a/erpnext/projects/doctype/timesheet/test_timesheet.py
+++ b/erpnext/projects/doctype/timesheet/test_timesheet.py
@@ -14,14 +14,24 @@ from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sal
 
 class TestTimesheet(unittest.TestCase):
 	def test_timesheet_billing_amount(self):
-		salary_structure = make_salary_structure("_T-Employee-0001")
-		timesheet = make_timesheet("_T-Employee-0001", simulate = True, billable=1)
+		make_salary_structure("_T-Employee-0001")
+		timesheet = make_timesheet("_T-Employee-0001", simulate=True, billable=1)
 
 		self.assertEquals(timesheet.total_hours, 2)
 		self.assertEquals(timesheet.total_billable_hours, 2)
 		self.assertEquals(timesheet.time_logs[0].billing_rate, 50)
 		self.assertEquals(timesheet.time_logs[0].billing_amount, 100)
 		self.assertEquals(timesheet.total_billable_amount, 100)
+
+	def test_timesheet_billing_amount_not_billable(self):
+		make_salary_structure("_T-Employee-0001")
+		timesheet = make_timesheet("_T-Employee-0001", simulate=True, billable=0)
+
+		self.assertEquals(timesheet.total_hours, 2)
+		self.assertEquals(timesheet.total_billable_hours, 0)
+		self.assertEquals(timesheet.time_logs[0].billing_rate, 0)
+		self.assertEquals(timesheet.time_logs[0].billing_amount, 0)
+		self.assertEquals(timesheet.total_billable_amount, 0)
 
 	def test_salary_slip_from_timesheet(self):
 		salary_structure = make_salary_structure("_T-Employee-0001")
@@ -43,7 +53,7 @@ class TestTimesheet(unittest.TestCase):
 		self.assertEquals(timesheet.status, 'Submitted')
 
 	def test_sales_invoice_from_timesheet(self):
-		timesheet = make_timesheet("_T-Employee-0001", simulate = True, billable = 1)
+		timesheet = make_timesheet("_T-Employee-0001", simulate=True, billable=1)
 		sales_invoice = make_sales_invoice(timesheet.name)
 		sales_invoice.customer = "_Test Customer"
 		sales_invoice.due_date = nowdate()

--- a/erpnext/projects/doctype/timesheet/timesheet.js
+++ b/erpnext/projects/doctype/timesheet/timesheet.js
@@ -106,6 +106,7 @@ frappe.ui.form.on("Timesheet Detail", {
 
 	billable: function(frm, cdt, cdn) {
 		update_billing_hours(frm, cdt, cdn);
+		update_time_rates(frm, cdt, cdn);
 		calculate_billing_costing_amount(frm, cdt, cdn);
 	},
 
@@ -150,12 +151,20 @@ var calculate_end_time = function(frm, cdt, cdn) {
 }
 
 var update_billing_hours = function(frm, cdt, cdn){
-	var child = locals[cdt][cdn]
+	var child = locals[cdt][cdn];
 	if(!child.billable) frappe.model.set_value(cdt, cdn, 'billing_hours', 0.0);
 }
 
+var update_time_rates = function(frm, cdt, cdn){
+	var child = locals[cdt][cdn];
+	if(!child.billable){
+		frappe.model.set_value(cdt, cdn, 'billing_rate', 0.0);
+		frappe.model.set_value(cdt, cdn, 'costing_rate', 0.0);
+	}
+}
+
 var calculate_billing_costing_amount = function(frm, cdt, cdn){
-	var child = locals[cdt][cdn]
+	var child = locals[cdt][cdn];
 	var billing_amount = 0.0;
 	var costing_amount = 0.0;
 
@@ -166,7 +175,7 @@ var calculate_billing_costing_amount = function(frm, cdt, cdn){
 
 	frappe.model.set_value(cdt, cdn, 'billing_amount', billing_amount);
 	frappe.model.set_value(cdt, cdn, 'costing_amount', costing_amount);
-	calculate_time_and_amount(frm)
+	calculate_time_and_amount(frm);
 }
 
 var calculate_time_and_amount = function(frm) {

--- a/erpnext/projects/doctype/timesheet/timesheet.js
+++ b/erpnext/projects/doctype/timesheet/timesheet.js
@@ -105,7 +105,8 @@ frappe.ui.form.on("Timesheet Detail", {
 	},
 
 	billable: function(frm, cdt, cdn) {
-		calculate_billing_costing_amount(frm, cdt, cdn)
+		update_billing_hours(frm, cdt, cdn);
+		calculate_billing_costing_amount(frm, cdt, cdn);
 	},
 
 	activity_type: function(frm, cdt, cdn) {
@@ -146,6 +147,11 @@ var calculate_end_time = function(frm, cdt, cdn) {
 	if((frm.doc.__islocal || frm.doc.__onload.maintain_bill_work_hours_same) && child.hours){
 		frappe.model.set_value(cdt, cdn, "billing_hours", child.hours);
 	}
+}
+
+var update_billing_hours = function(frm, cdt, cdn){
+	var child = locals[cdt][cdn]
+	if(!child.billable) frappe.model.set_value(cdt, cdn, 'billing_hours', 0.0);
 }
 
 var calculate_billing_costing_amount = function(frm, cdt, cdn){

--- a/erpnext/projects/doctype/timesheet/timesheet.py
+++ b/erpnext/projects/doctype/timesheet/timesheet.py
@@ -61,7 +61,7 @@ class Timesheet(Document):
 			self.per_billed = (self.total_billed_amount * 100) / self.total_billable_amount
 
 	def update_billing_hours(self, args):
-		if cint(args.billing_hours) == 0:
+		if flt(args.billing_hours) == 0.0:
 			args.billing_hours = args.hours
 
 	def set_status(self):

--- a/erpnext/projects/doctype/timesheet/timesheet.py
+++ b/erpnext/projects/doctype/timesheet/timesheet.py
@@ -61,8 +61,10 @@ class Timesheet(Document):
 			self.per_billed = (self.total_billed_amount * 100) / self.total_billable_amount
 
 	def update_billing_hours(self, args):
-		if flt(args.billing_hours) == 0.0:
+		if args.billable and flt(args.billing_hours) == 0.0:
 			args.billing_hours = args.hours
+		else:
+			args.billing_hours = 0
 
 	def set_status(self):
 		self.status = {
@@ -263,7 +265,7 @@ class Timesheet(Document):
 		for data in self.time_logs:
 			if data.activity_type and data.billable:
 				rate = get_activity_cost(self.employee, data.activity_type)
-				hours =  data.billing_hours or 0
+				hours = data.billing_hours or 0
 				if rate:
 					data.billing_rate = flt(rate.get('billing_rate')) if flt(data.billing_rate) == 0 else data.billing_rate
 					data.costing_rate = flt(rate.get('costing_rate')) if flt(data.costing_rate) == 0 else data.costing_rate

--- a/erpnext/projects/doctype/timesheet/timesheet.py
+++ b/erpnext/projects/doctype/timesheet/timesheet.py
@@ -46,6 +46,7 @@ class Timesheet(Document):
 
 		for d in self.get("time_logs"):
 			self.update_billing_hours(d)
+			self.update_time_rates(d)
 
 			self.total_hours += flt(d.hours)
 			if d.billable:
@@ -61,8 +62,9 @@ class Timesheet(Document):
 			self.per_billed = (self.total_billed_amount * 100) / self.total_billable_amount
 
 	def update_billing_hours(self, args):
-		if args.billable and flt(args.billing_hours) == 0.0:
-			args.billing_hours = args.hours
+		if args.billable:
+			if flt(args.billing_hours) == 0.0:
+				args.billing_hours = args.hours
 		else:
 			args.billing_hours = 0
 
@@ -271,6 +273,12 @@ class Timesheet(Document):
 					data.costing_rate = flt(rate.get('costing_rate')) if flt(data.costing_rate) == 0 else data.costing_rate
 					data.billing_amount = data.billing_rate * hours
 					data.costing_amount = data.costing_rate * hours
+
+	def update_time_rates(self, ts_detail):
+		if not ts_detail.billable:
+			ts_detail.billing_rate = 0.0
+			ts_detail.costing_rate = 0.0
+
 
 @frappe.whitelist()
 def get_projectwise_timesheet_data(project, parent=None):


### PR DESCRIPTION
- If billable hours is set as 0 and the activity is set as to be billed, ERPNext will assume that billable hours is the same as hours worked. To set billable hours to 0, simply un-check the billable check box.
- If activity is not billable, the billable hours, billing rate and costing rate fields are reset.