### PR TITLE
[Fix] Timesheet Company Issue

### DIFF
--- a/erpnext/manufacturing/doctype/production_order/production_order.py
+++ b/erpnext/manufacturing/doctype/production_order/production_order.py
@@ -273,7 +273,7 @@ class ProductionOrder(Document):
 		timesheets = []
 		plan_days = frappe.db.get_single_value("Manufacturing Settings", "capacity_planning_for_days") or 30
 
-		timesheet = make_timesheet(self.name)
+		timesheet = make_timesheet(self.name, self.company)
 		timesheet.set('time_logs', [])
 
 		for i, d in enumerate(self.operations):
@@ -575,10 +575,11 @@ def get_events(start, end, filters=None):
 	return data
 
 @frappe.whitelist()
-def make_timesheet(production_order):
+def make_timesheet(production_order, company):
 	timesheet = frappe.new_doc("Timesheet")
 	timesheet.employee = ""
 	timesheet.production_order = production_order
+	timesheet.company = company
 	return timesheet
 
 @frappe.whitelist()

--- a/erpnext/manufacturing/doctype/production_order/test_production_order.py
+++ b/erpnext/manufacturing/doctype/production_order/test_production_order.py
@@ -87,6 +87,7 @@ class TestProductionOrder(unittest.TestCase):
 
 		name = frappe.db.get_value('Timesheet', {'production_order': prod_order.name}, 'name')
 		time_sheet_doc = frappe.get_doc('Timesheet', name)
+		self.assertEqual(prod_order.company, time_sheet_doc.company)
 		time_sheet_doc.submit()
 		
 
@@ -107,7 +108,7 @@ class TestProductionOrder(unittest.TestCase):
 		self.assertEqual(prod_order.operations[0].actual_operation_time, 60)
 		self.assertEqual(prod_order.operations[0].actual_operating_cost, 100)
 		
-		time_sheet_doc1 = make_timesheet(prod_order.name)
+		time_sheet_doc1 = make_timesheet(prod_order.name, prod_order.company)
 		self.assertEqual(len(time_sheet_doc1.get('time_logs')), 0)
 
 		time_sheet_doc.cancel()

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -425,3 +425,4 @@ erpnext.patches.v8_3.update_company_total_sales
 erpnext.patches.v8_1.set_delivery_date_in_so_item
 erpnext.patches.v8_5.fix_tax_breakup_for_non_invoice_docs
 erpnext.patches.v8_5.update_customer_group_in_POS_profile
+erpnext.patches.v8_6.update_timesheet_company_from_PO

--- a/erpnext/patches/v8_6/update_timesheet_company_from_PO.py
+++ b/erpnext/patches/v8_6/update_timesheet_company_from_PO.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2017, Frappe and Contributors
+# License: GNU General Public License v3. See license.txt
+
+from __future__ import unicode_literals
+import frappe
+
+def execute():
+	frappe.reload_doctype('Timesheet')
+	company = frappe.get_all('Company')
+
+	#Check more than one company exists
+	if len(company) > 1:
+		frappe.db.sql(""" update `tabTimesheet` set `tabTimesheet`.company =
+			(select company from `tabProduction Order` where name = `tabTimesheet`.production_order)
+			where production_order is not null and production_order !=''""")


### PR DESCRIPTION
Steps:

Have two company, A and B in an account. A is the default.
Created Production Order for Company B.
In the Timesheet, auto-created on submission of Production Order has Company A updated in it.

Fixed https://github.com/frappe/erpnext/issues/10163