### PR TITLE
[Fix] Default selling settings not fetched on customer quick entry form

### DIFF
--- a/erpnext/startup/boot.py
+++ b/erpnext/startup/boot.py
@@ -16,8 +16,10 @@ def boot_session(bootinfo):
 		update_page_info(bootinfo)
 
 		load_country_and_currency(bootinfo)
-		bootinfo.sysdefaults.territory = get_root_of('Territory')
-		bootinfo.sysdefaults.customer_group = get_root_of('Customer Group')
+		bootinfo.sysdefaults.territory = frappe.db.get_single_value('Selling Settings',
+			'territory') or get_root_of('Territory')
+		bootinfo.sysdefaults.customer_group = frappe.db.get_single_value('Selling Settings',
+			'customer_group') or get_root_of('Customer Group')
 
 		bootinfo.notification_settings = frappe.get_doc("Notification Control",
 			"Notification Control")


### PR DESCRIPTION
**Issue**
![issue1](https://user-images.githubusercontent.com/8780500/28872741-1f6d03e4-77a8-11e7-8dba-e8746605e16b.png)
![issue2](https://user-images.githubusercontent.com/8780500/28872742-1f6db8a2-77a8-11e7-98d7-11ce042d6c28.png)
Customer group and territory not set on the customer form as per selling settings
Fixed https://github.com/frappe/erpnext/issues/10130