### PR TITLE
[minor] set description to '' if template description is not available

### DIFF
--- a/erpnext/controllers/item_variant.py
+++ b/erpnext/controllers/item_variant.py
@@ -169,7 +169,6 @@ def create_variant(item, args):
 
 	return variant
 
-
 def copy_attributes_to_variant(item, variant):
 	from frappe.model import no_value_fields
 
@@ -189,6 +188,8 @@ def copy_attributes_to_variant(item, variant):
 				variant.set(field.fieldname, item.get(field.fieldname))
 	variant.variant_of = item.name
 	variant.has_variants = 0
+	if not variant.description:
+		variant.description = ''
 
 	if item.variant_based_on=='Item Attribute':
 		if variant.attributes:


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 56, in application
    response = frappe.handler.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 52, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 922, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/controllers/item_variant.py", line 167, in create_variant
    copy_attributes_to_variant(template, variant)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/controllers/item_variant.py", line 195, in copy_attributes_to_variant
    variant.description += "\n"
TypeError: unsupported operand type(s) for +=: 'NoneType' and 'unicode'
```