### PR TITLE
Set write permission to sales manger for permlevel 1 in Quotation doctype

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -426,3 +426,4 @@ erpnext.patches.v8_1.set_delivery_date_in_so_item #2017-07-28
 erpnext.patches.v8_5.fix_tax_breakup_for_non_invoice_docs
 erpnext.patches.v8_5.update_customer_group_in_POS_profile
 erpnext.patches.v8_6.update_timesheet_company_from_PO
+erpnext.patches.v8_6.set_write_permission_for_quotation_for_sales_manager

--- a/erpnext/patches/v8_6/set_write_permission_for_quotation_for_sales_manager.py
+++ b/erpnext/patches/v8_6/set_write_permission_for_quotation_for_sales_manager.py
@@ -6,6 +6,6 @@ import frappe
 
 def execute():
 	# Set write permission to permlevel 1 for sales manager role in Quotation doctype
-	frappe.db.sql(""" update `tabCustom Docperm` set `tabCustom Docperm`.write = 1
-		where `tabCustom Docperm`.parent = 'Quotation' and `tabCustom Docperm`.role = 'Sales Manager'
-		and `tabCustom Docperm`.permlevel = 1 """)
+	frappe.db.sql(""" update `tabCustom DocPerm` set `tabCustom DocPerm`.write = 1
+		where `tabCustom DocPerm`.parent = 'Quotation' and `tabCustom DocPerm`.role = 'Sales Manager'
+		and `tabCustom DocPerm`.permlevel = 1 """)

--- a/erpnext/patches/v8_6/set_write_permission_for_quotation_for_sales_manager.py
+++ b/erpnext/patches/v8_6/set_write_permission_for_quotation_for_sales_manager.py
@@ -1,0 +1,11 @@
+# Copyright (c) 2017, Frappe and Contributors
+# License: GNU General Public License v3. See license.txt
+
+from __future__ import unicode_literals
+import frappe
+
+def execute():
+	# Set write permission to permlevel 1 for sales manager role in Quotation doctype
+	frappe.db.sql(""" update `tabCustom Docperm` set `tabCustom Docperm`.write = 1
+		where `tabCustom Docperm`.parent = 'Quotation' and `tabCustom Docperm`.role = 'Sales Manager'
+		and `tabCustom Docperm`.permlevel = 1 """)

--- a/erpnext/selling/doctype/quotation/quotation.json
+++ b/erpnext/selling/doctype/quotation/quotation.json
@@ -2572,7 +2572,7 @@
  "istable": 0, 
  "max_attachments": 1, 
  "menu_index": 0, 
- "modified": "2017-07-19 13:49:33.388736", 
+ "modified": "2017-08-02 18:15:38.198698", 
  "modified_by": "Administrator", 
  "module": "Selling", 
  "name": "Quotation", 
@@ -2638,7 +2638,7 @@
    "set_user_permissions": 0, 
    "share": 0, 
    "submit": 0, 
-   "write": 0
+   "write": 1
   }, 
   {
    "amend": 1, 


### PR DESCRIPTION
**Issue**
Ignore Price Rule is not shown in Quotation on new docs:
<img width="1040" alt="issue1" src="https://user-images.githubusercontent.com/8780500/28874566-0866535a-77b0-11e7-8ac0-4f6302cf2bb4.png">
readonly even if document is in Draft mode:
<img width="978" alt="issue2" src="https://user-images.githubusercontent.com/8780500/28874567-086650ee-77b0-11e7-9966-3977f78272e7.png">

Ignore permission has permlevel 1 and the roles with permlevel 1 has only read permission, after giving write permission to sales manager issue has fixed

Fixed https://github.com/frappe/erpnext/issues/10187