### PR TITLE
[hotfix] website stock not shown due to discount not set

### DIFF
--- a/erpnext/shopping_cart/product.py
+++ b/erpnext/shopping_cart/product.py
@@ -85,7 +85,7 @@ def get_price(item_code, template_item_code, price_list, qty=1):
 
 			if pricing_rule:
 				if pricing_rule.pricing_rule_for == "Discount Percentage":
-					price[0].price_list_rate = flt(price[0].price_list_rate * (1.0 - (pricing_rule.discount_percentage / 100.0)))
+					price[0].price_list_rate = flt(price[0].price_list_rate * (1.0 - (flt(pricing_rule.discount_percentage) / 100.0)))
 
 				if pricing_rule.pricing_rule_for == "Price":
 					price[0].price_list_rate = pricing_rule.price_list_rate


### PR DESCRIPTION
Raised via support:
In case the `discount_percentage` is not set in the pricing rule:

![screen shot 2017-08-02 at 8 44 44 pm](https://user-images.githubusercontent.com/5196925/28884420-5e5d3e30-77cf-11e7-963a-af26775a9989.png)

Fixed:
![screen shot 2017-08-02 at 8 46 45 pm](https://user-images.githubusercontent.com/5196925/28884425-63a33f66-77cf-11e7-912e-1ecb2304d623.png)
