### PR TITLE
[Enhancement] for Sidebar Menu with "Order" Page Route

### DIFF
--- a/erpnext/templates/includes/order/order_taxes.html
+++ b/erpnext/templates/includes/order/order_taxes.html
@@ -1,22 +1,22 @@
 {% if doc.taxes %}
 <div class="row tax-net-total-row">
-    <div class="col-xs-8 text-right">{{ _("Net Total") }}</div>
-    <div class="col-xs-4 text-right">
+    <div class="col-xs-6 text-right">{{ _("Net Total") }}</div>
+    <div class="col-xs-6 text-right">
         {{ doc.get_formatted("net_total") }}</div>
 </div>
 {% endif %}
 {% for d in doc.taxes %}
 {% if d.base_tax_amount > 0 %}
 <div class="row tax-row">
-    <div class="col-xs-8 text-right">{{ d.description }}</div>
-    <div class="col-xs-4 text-right">
+    <div class="col-xs-6 text-right">{{ d.description }}</div>
+    <div class="col-xs-6 text-right">
         {{ d.get_formatted("base_tax_amount") }}</div>
 </div>
 {% endif %}
 {% endfor %}
 <div class="row tax-grand-total-row">
-    <div class="col-xs-8 text-right text-uppercase h6 text-muted">{{ _("Grand Total") }}</div>
-    <div class="col-xs-4 text-right">
+    <div class="col-xs-6 text-right text-uppercase h6 text-muted">{{ _("Grand Total") }}</div>
+    <div class="col-xs-6 text-right">
         <span class="tax-grand-total bold">
             {{ doc.get_formatted("grand_total") }}
         </span>

--- a/erpnext/templates/includes/transaction_row.html
+++ b/erpnext/templates/includes/transaction_row.html
@@ -1,23 +1,37 @@
 <div class="web-list-item transaction-list-item">
 	<a href="/{{ pathname }}/{{ doc.name }}">
 		<div class="row">
-			<div class="col-sm-5">
+			<div class="col-sm-3">
 				<span class="indicator small {{ doc.indicator_color or "darkgrey" }}">
 				{{ doc.name }}</span>
 				<div class="small text-muted transaction-time"
 					title="{{ frappe.utils.format_datetime(doc.modified, "medium") }}">
 					{{ frappe.utils.format_datetime(doc.modified, "medium") }}
 				</div>
+				{% if doc.doctype == 'Quotation'%}
+				<div class="small text-muted valid-till">
+					Valid Till {{ doc.valid_till }}
+				</div>
+				{% endif %}
 			</div>
-			<div class="col-sm-4 items-preview ellipsis small">
-				{{ doc.items_preview }}
+			<div class="col-sm-6">
+				<span class="small text-muted customer-supplier">
+					{% if doc.doctype == 'Supplier Quotation' %}
+						<b>{{ doc.supplier_name}}</b>
+					{% else %}
+						<b>{{ doc.customer_name}}</b>
+					{% endif %}
+				</span>
+				<div class="small text-muted contact">
+					Contact : {{ doc.contact_display}}
+				</div >
+				<div class="small text-muted items-preview ellipsis ">
+					{{ doc.items_preview }}
+				</div>
 			</div>
 			<div class="col-sm-3 text-right bold">
 				{{ doc.get_formatted("grand_total") }}
 			</div>
-			<!-- <div class="col-sm-3 text-right">
-
-			</div> -->
 		</div>
 	</a>
 </div>

--- a/erpnext/templates/pages/order.html
+++ b/erpnext/templates/pages/order.html
@@ -20,6 +20,34 @@
     <div class="col-xs-6 text-muted text-right small">
         {{ frappe.utils.formatdate(doc.transaction_date, 'medium') }}
     </div>
+    <div class="col-xs-6 text-muted text-right">
+		<a class='text-muted small' href='/printview?doctype={{ doc.doctype}}&name={{ doc.name }}
+		&format={{ print_format }}' target="_blank" rel="noopener noreferrer">
+            <i class='fa fa-print'></i> {{ _("Print") }}</a>
+    </div>
+</div>
+
+<div class="row customer-supplier-info">
+    <div class="col-xs-6">
+        <span>
+            {% if doc.doctype == 'Supplier Quotation' %}
+                <b>{{ doc.supplier_name}}</b>
+            {% else %}
+                <b>{{ doc.customer_name}}</b>
+            {% endif %}
+        </span>
+	</div>
+    {% if doc.doctype == 'Quotation'%}
+    <div class="col-xs-6 text-muted text-right small">
+        {{ _("Valid Till") }} {{ doc.valid_till }}
+    </div>
+    {% endif %}
+</div>
+
+<div class="row transaction-contact">
+    <div class="col-xs-6 text-muted small">
+        {{ doc.contact_display }}
+    </div>
 </div>
 
 {% if doc._header %}
@@ -31,29 +59,29 @@
     <!-- items -->
     <div class="order-item-table">
         <div class="row order-items order-item-header text-muted">
-            <div class="col-sm-8 col-xs-6 h6 text-uppercase">
+            <div class="col-sm-6 col-xs-6 h6 text-uppercase">
                 {{ _("Item") }}
             </div>
-            <div class="col-sm-2 col-xs-3 text-right h6 text-uppercase">
+            <div class="col-sm-3 col-xs-3 text-right h6 text-uppercase">
                 {{ _("Quantity") }}
             </div>
-            <div class="col-sm-2 col-xs-3 text-right h6 text-uppercase">
+            <div class="col-sm-3 col-xs-3 text-right h6 text-uppercase">
                 {{ _("Amount") }}
             </div>
         </div>
         {% for d in doc.items %}
         <div class="row order-items">
-            <div class="col-sm-8 col-xs-6">
+            <div class="col-sm-6 col-xs-6">
                 {{ item_name_and_description(d) }}
             </div>
-            <div class="col-sm-2 col-xs-3 text-right">
+            <div class="col-sm-3 col-xs-3 text-right">
                 {{ d.qty }}
                 {% if d.delivered_qty is defined and d.delivered_qty != None %}
                 <p class="text-muted small">{{
                     _("Delivered: {0}").format(d.delivered_qty) }}</p>
                 {% endif %}
             </div>
-            <div class="col-sm-2 col-xs-3 text-right">
+            <div class="col-sm-3 col-xs-3 text-right">
                 {{ d.get_formatted("amount")	 }}
                 <p class="text-muted small">{{
                     _("@ {0}").format(d.get_formatted("rate")) }}</p>
@@ -72,8 +100,8 @@
 </div>
 
 <div class="cart-taxes row small">
-    <div class="col-sm-8"><!-- empty --></div>
-    <div class="col-sm-4">
+    <div class="col-sm-6"><!-- empty --></div>
+    <div class="col-sm-6">
 		{% if enabled_checkout %}
 	        {% if (doc.doctype=="Sales Order" and doc.per_billed <= 0)
 				or (doc.doctype=="Sales Invoice" and doc.outstanding_amount > 0) %}
@@ -106,4 +134,9 @@
 </div>
 {% endif %}
 </div>
+{% if doc.terms %}
+<div class="terms-and-condition text-muted small">
+    <hr><p>{{ doc.terms }}</p>
+</div>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
I added a few enhancement and field additions for Sidebar Menu using "Order" as page route and "transaction_row.html" as list view.

1) Added Print Button:
![print](https://user-images.githubusercontent.com/21003054/28906344-950416a0-7849-11e7-882c-ff2041c1cc2d.png)

2) Added Valid Till (for Quotation Only), Customer/Supplier Name and contact name:
![name](https://user-images.githubusercontent.com/21003054/28906379-cffa8758-7849-11e7-865a-2b7b27498486.png)

3) Show Terms and Conditions if any:
![terms](https://user-images.githubusercontent.com/21003054/28906441-2a3e63e2-784a-11e7-8a93-09afeff1a5ba.png)

4) Adjust Column to avoid amounts with more precision like below:
![break](https://user-images.githubusercontent.com/21003054/28906554-e5cda0d2-784a-11e7-9eec-b7d520e14842.png)

5) Show Valid Till (for Quotation), Customer/Supplier Name and Contact in list view:
![quotation](https://user-images.githubusercontent.com/21003054/28906522-aba386b0-784a-11e7-9e47-5ab9003494b0.png)
![orders](https://user-images.githubusercontent.com/21003054/28906521-aba33822-784a-11e7-8af1-90dadee33edb.png)
![invoices](https://user-images.githubusercontent.com/21003054/28906520-aba22d42-784a-11e7-9025-7b4348607b0d.png)
![shipments](https://user-images.githubusercontent.com/21003054/28906519-aba16dee-784a-11e7-8d77-3138a7acf4d1.png)
![supplier quotation](https://user-images.githubusercontent.com/21003054/28906518-ab8d372a-784a-11e7-80e6-4c9f7f243239.png)





