### PR TITLE
[Fix] Patch broken if serial no has single quote

### DIFF
--- a/erpnext/patches/v8_0/set_sales_invoice_serial_number_from_delivery_note.py
+++ b/erpnext/patches/v8_0/set_sales_invoice_serial_number_from_delivery_note.py
@@ -26,7 +26,7 @@ def execute():
 		if not sales_invoice or not serial_nos:
 			continue
 
-		serial_nos = ["'%s'"%no for no in serial_nos.split("\n")]
+		serial_nos = ["'%s'"%frappe.db.escape(no) for no in serial_nos.split("\n")]
 
 		frappe.db.sql("""
 			UPDATE 
@@ -36,7 +36,7 @@ def execute():
 			WHERE
 				name in ({serial_nos})
 			""".format(
-				sales_invoice=sales_invoice,
+				sales_invoice=frappe.db.escape(sales_invoice),
 				serial_nos=",".join(serial_nos)
 			)
 		)


### PR DESCRIPTION
**Issue**
Traceback (most recent call last):
File "/usr/lib/python2.7/runpy.py", line 162, in runmodule_as_main
"main", fname, loader, pkg_name)
File "/usr/lib/python2.7/runpy.py", line 72, in runcode
exec code in run_globals
File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 91, in
main()
File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 17, in main
click.Group(commands=commands)(prog_name='bench')
File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 716, in call
return self.main(*args, **kwargs)
File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 696, in main
rv = self.invoke(ctx)
File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 1060, in invoke
return processresult(sub_ctx.command.invoke(sub_ctx))
File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 1060, in invoke
return processresult(sub_ctx.command.invoke(sub_ctx))
File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 889, in invoke
return ctx.invoke(self.callback, **ctx.params)
File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 534, in invoke
return callback(*args, **kwargs)
File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
return f(get_current_context(), *args, **kwargs)
File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/init.py", line 24, in _func
ret = f(frappe._dict(ctx.obj), *args, **kwargs)
File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/site.py", line 216, in migrate
migrate(context.verbose, rebuild_website=rebuild_website)
File "/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py", line 31, in migrate
frappe.modules.patch_handler.run_all()
File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 29, in run_all
if not run_single(patchmodule = patch):
File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 63, in run_single
return execute_patch(patchmodule, method, methodargs)
File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 83, in execute_patch
frappe.get_attr(patchmodule.split()[0] + ".execute")()
File "/home/frappe/frappe-bench/apps/erpnext/erpnext/patches/v8_0/set_sales_invoice_serial_number_from_delivery_note.py", line 40, in execute
serial_nos=",".join(serial_nos)
File "/home/frappe/frappe-bench/apps/frappe/frappe/database.py", line 165, in sql
self._cursor.execute(query)
File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/MySQLdb/cursors.py", line 250, in execute
self.errorhandler(self, exc, value)
File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/MySQLdb/connections.py", line 50, in defaulterrorhandler
raise errorvalue
mysqlexceptions.ProgrammingError: (1064, "You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '8','')' at line 6")

Fixed https://github.com/frappe/erpnext/issues/10256