### PR TITLE
Book expense included in valuation only if perpetual inventory enabled

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -510,7 +510,7 @@ class PurchaseInvoice(BuyingController):
 
 				i += 1
 
-		if self.update_stock and valuation_tax:
+		if self.auto_accounting_for_stock and self.update_stock and valuation_tax:
 			for cost_center, amount in valuation_tax.items():
 				gl_entries.append(
 					self.get_gl_dict({


### PR DESCRIPTION
Giving error if update stock is check, valuation related tax included and perpetual inventory disabled.
<img width="1119" alt="screen shot 2017-08-03 at 4 59 43 pm" src="https://user-images.githubusercontent.com/836784/28919932-46504866-786d-11e7-82ec-6c70c5c04482.png">
