### PR TITLE
[hotfix] ignore if project type is None

### DIFF
--- a/erpnext/patches/v8_5/remove_project_type_property_setter.py
+++ b/erpnext/patches/v8_5/remove_project_type_property_setter.py
@@ -9,7 +9,7 @@ def execute():
 	project_types = frappe.db.sql_list('select distinct project_type from tabProject')
 
 	for project_type in project_types:
-		if not frappe.db.exists("Project Type", project_type):
+		if project_type and not frappe.db.exists("Project Type", project_type):
 			p_type = frappe.get_doc({
 				"doctype": "Project Type",
 				"project_type": project_type


### PR DESCRIPTION
**Issue**
Executing erpnext.patches.v8_5.remove_project_type_property_setter in test_stock_issue (64bbb359df)
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 94, in <module>
    main()
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/env/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 24, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/commands/site.py", line 217, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/migrate.py", line 31, in migrate
    frappe.modules.patch_handler.run_all()
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 29, in run_all
    if not run_single(patchmodule = patch):
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 63, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 83, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/erpnext/erpnext/patches/v8_5/remove_project_type_property_setter.py", line 17, in execute
    p_type.insert()
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/model/document.py", line 187, in insert
    self.set_new_name()
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/model/document.py", line 333, in set_new_name
    set_new_name(self)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/model/naming.py", line 44, in set_new_name
    frappe.throw(_("{0} is required").format(doc.meta.get_label(fieldname)))
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/__init__.py", line 319, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red')
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/__init__.py", line 309, in msgprint
    _raise_exception()
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/__init__.py", line 282, in _raise_exception
    raise raise_exception(encode(msg))
frappe.exceptions.ValidationError: Project Type is required