### PR TITLE
[Fix] Balance sheet not working

### DIFF
--- a/erpnext/accounts/report/financial_statements.py
+++ b/erpnext/accounts/report/financial_statements.py
@@ -234,7 +234,7 @@ def add_total_row(out, root_type, balance_must_be, period_list, company_currency
 			for period in period_list:
 				total_row.setdefault(period.key, 0.0)
 				total_row[period.key] += row.get(period.key, 0.0)
-				row[period.key] = ""
+				row[period.key] = 0.0
 
 			total_row.setdefault("total", 0.0)
 			total_row["total"] += flt(row["total"])


### PR DESCRIPTION
**Issue**

File "/home/frappe/benches/bench-2017-08-04/apps/frappe/frappe/handler.py", line 52, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2017-08-04/apps/frappe/frappe/__init__.py", line 922, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2017-08-04/apps/frappe/frappe/desk/query_report.py", line 95, in run
    res = frappe.get_attr(method_name)(frappe._dict(filters))
  File "/home/frappe/benches/bench-2017-08-04/apps/erpnext/erpnext/accounts/report/balance_sheet/balance_sheet.py", line 16, in execute
    accumulated_values=filters.accumulated_values)
  File "/home/frappe/benches/bench-2017-08-04/apps/erpnext/erpnext/accounts/report/financial_statements.py", line 141, in get_data
    add_total_row(out, root_type, balance_must_be, period_list, company_currency)
  File "/home/frappe/benches/bench-2017-08-04/apps/erpnext/erpnext/accounts/report/financial_statements.py", line 236, in add_total_row
    total_row[period.key] += row.get(period.key, 0.0)
TypeError: unsupported operand type(s) for +=: 'float' and 'unicode'