### PR TITLE
[hotfix] remove the white spaces from condition and formula fields

### DIFF
--- a/erpnext/hr/doctype/salary_slip/salary_slip.py
+++ b/erpnext/hr/doctype/salary_slip/salary_slip.py
@@ -75,13 +75,15 @@ class SalarySlip(TransactionBase):
 
 	def eval_condition_and_formula(self, d, data):
 		try:
-			if d.condition:
-				if not frappe.safe_eval(d.condition, None, data):
+			condition = d.condition.strip() if d.condition else None
+			if condition:
+				if not frappe.safe_eval(condition, None, data):
 					return None
 			amount = d.amount
 			if d.amount_based_on_formula:
-				if d.formula:
-					amount = frappe.safe_eval(d.formula, None, data)
+				formula = d.formula.strip() if d.formula else None
+				if formula:
+					amount = frappe.safe_eval(formula, None, data)
 			if amount:
 				data[d.abbr] = amount
 

--- a/erpnext/hr/doctype/salary_structure/salary_structure.py
+++ b/erpnext/hr/doctype/salary_structure/salary_structure.py
@@ -17,6 +17,7 @@ class SalaryStructure(Document):
 		for e in self.get('employees'):
 			set_employee_name(e)
 		self.validate_date()
+		self.strip_condition_and_formula_fields()
 
 	def get_ss_values(self,employee):
 		basic_info = frappe.db.sql("""select bank_name, bank_ac_no
@@ -61,6 +62,16 @@ class SalaryStructure(Document):
 		if st_name:
 			frappe.throw(_("Active Salary Structure {0} found for employee {1} for the given dates")
 				.format(st_name[0][0], employee.employee))
+
+	def strip_condition_and_formula_fields(self):
+		# remove whitespaces from condition and formula fields
+		for row in self.earnings:
+			row.condition = row.condition.strip() if row.condition else ""
+			row.formula = row.formula.strip() if row.formula else ""
+
+		for row in self.deductions:
+			row.condition = row.condition.strip() if row.condition else ""
+			row.formula = row.formula.strip() if row.formula else ""
 
 @frappe.whitelist()
 def make_salary_slip(source_name, target_doc = None, employee = None, as_print = False, print_format = None):

--- a/erpnext/hr/doctype/salary_structure/test_salary_structure.py
+++ b/erpnext/hr/doctype/salary_structure/test_salary_structure.py
@@ -44,6 +44,26 @@ class TestSalaryStructure(unittest.TestCase):
 			self.assertEquals(sal_slip.get("deductions")[1].amount, 2500)
 			self.assertEquals(sal_slip.get("total_deduction"), 7500)
 			self.assertEquals(sal_slip.get("net_pay"), 7500)
+
+	def test_whitespaces_in_formula_conditions_fields(self):
+		make_salary_structure("Salary Structure Sample")
+		salary_structure = frappe.get_doc("Salary Structure", "Salary Structure Sample")
+
+		for row in salary_structure.earnings:
+			row.formula = "\n%s\n\n"%row.formula
+			row.condition = "\n%s\n\n"%row.condition
+
+		for row in salary_structure.deductions:
+			row.formula = "\n%s\n\n"%row.formula
+			row.condition = "\n%s\n\n"%row.condition
+
+		salary_structure.save()
+
+		for row in salary_structure.earnings:
+			self.assertFalse("\n" in row.formula or "\n" in row.condition)
+
+		for row in salary_structure.deductions:
+			self.assertFalse(("\n" in row.formula) or ("\n" in row.condition))
 			
 def make_employee(user):
 	if not frappe.db.get_value("User", user):


### PR DESCRIPTION
removed the white spaces from formula and condition fields in earnings and deductions table in salary structure.

`before`

![salary-structure](https://user-images.githubusercontent.com/11224291/29072824-f60e7a82-7c66-11e7-9603-e96f1e92afb6.gif)

`after`

![after-fix](https://user-images.githubusercontent.com/11224291/29072830-febe38b6-7c66-11e7-9d16-6d0da2747ef9.gif)