### PR TITLE
[Fix] Auto batch creation not working for purchase invoice is update stock is enabled

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -53,6 +53,9 @@ class PurchaseInvoice(BuyingController):
 		if (self.is_paid == 1):
 			self.validate_cash()
 
+		if self._action=="submit" and self.update_stock:
+			self.make_batches('warehouse')
+
 		self.check_conversion_rate()
 		self.validate_credit_to_acc()
 		self.clear_unallocated_advances("Purchase Invoice Advance", "advances")

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -261,7 +261,7 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 		var item = frappe.get_doc(cdt, cdn);
 		var update_stock = 0, show_batch_dialog = 0;
 
-		if(['Sales Invoice', 'Purchase Invoice'].includes(this.frm.doc.doctype)) {
+		if(['Sales Invoice'].includes(this.frm.doc.doctype)) {
 			update_stock = cint(me.frm.doc.update_stock);
 			show_batch_dialog = update_stock;
 


### PR DESCRIPTION
Batch is not created automatically while submitting Purchase Invoice with Update Stock..
It's working fine on Stock Entry

Fixed https://github.com/frappe/erpnext/issues/10017