### PR TITLE
Transaction Forms (Payment Entry, Sales Invoice, Purchase Invoice) can forget company currency (#10409)

### DIFF
--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -62,7 +62,7 @@ erpnext.taxes_and_totals = erpnext.payments.extend({
 		this.frm.doc.conversion_rate = flt(this.frm.doc.conversion_rate, (cur_frm) ? precision("conversion_rate") : 9);
 		var conversion_rate_label = frappe.meta.get_label(this.frm.doc.doctype, "conversion_rate",
 			this.frm.doc.name);
-		var company_currency = this.frm.doc.currency || this.get_company_currency();
+		var company_currency = this.get_company_currency();
 
 		if(!this.frm.doc.conversion_rate) {
 			if(this.frm.doc.currency == company_currency) {

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -419,7 +419,7 @@ erpnext.taxes_and_totals = erpnext.payments.extend({
 				this.frm.doc.currency, precision("rounded_total"));
 		}
 		if(frappe.meta.get_docfield(this.frm.doc.doctype, "base_rounded_total", this.frm.doc.name)) {
-			var company_currency = this.frm.doc.currency || this.get_company_currency();
+			var company_currency = this.get_company_currency();
 
 			this.frm.doc.base_rounded_total =
 				round_based_on_smallest_currency_fraction(this.frm.doc.base_grand_total,


### PR DESCRIPTION
Fixed #10409 
### Before
![peek 2017-08-15 13-30](https://user-images.githubusercontent.com/818803/29316691-da8458e0-81c0-11e7-937e-d0fc8fc5175d.gif)

### After
![peek 2017-08-15 13-47](https://user-images.githubusercontent.com/818803/29316703-e1b2753e-81c0-11e7-9ccc-6a5bcab55ab0.gif)
