### PR TITLE
improvement for self-postbacks

### DIFF
--- a/erpnext/templates/includes/product_page.js
+++ b/erpnext/templates/includes/product_page.js
@@ -73,7 +73,7 @@ frappe.ready(function() {
 			}
 		}
 
-		if (window.location.search.indexOf(item_code)!==-1) {
+		if (window.location.search == ("?variant=" + item_code)) {
 			return;
 		}
 

--- a/erpnext/templates/includes/product_page.js
+++ b/erpnext/templates/includes/product_page.js
@@ -73,7 +73,7 @@ frappe.ready(function() {
 			}
 		}
 
-		if (window.location.search == ("?variant=" + item_code)) {
+		if (window.location.search == ("?variant=" + item_code) || window.location.search.includes(item_code)) {
 			return;
 		}
 


### PR DESCRIPTION
In the product_page.js is a code wich shall prevent of self-postbacks, this code does not allow that variants of an article has an article number like a substring of the other variants article number.
For example, Variant # 1 = 12345 and variant # 2 = 12345-1 causes errors in the webshop.

This PR would be a more elegant solution.