### PR TITLE
[hotfix] fixed mysql syntax error in Student and Guardian Contact Details report

### DIFF
--- a/erpnext/schools/report/student_and_guardian_contact_details/student_and_guardian_contact_details.py
+++ b/erpnext/schools/report/student_and_guardian_contact_details/student_and_guardian_contact_details.py
@@ -82,7 +82,7 @@ def get_guardian_map(student_list):
 		select  parent, guardian, guardian_name, relation  from `tabStudent Guardian` where parent in (%s)''' %
 		', '.join(['%s']*len(student_list)), tuple(student_list), as_dict=1)
 
-	guardian_list = list(set([g.guardian for g in guardian_details]))
+	guardian_list = list(set([g.guardian for g in guardian_details])) or ['']
 
 	guardian_mobile_no = dict(frappe.db.sql("""select name, mobile_number from `tabGuardian` 
 			where name in (%s)""" % ", ".join(['%s']*len(guardian_list)), tuple(guardian_list)))


### PR DESCRIPTION
`error log`
```
Traceback (most recent call last):
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/app.py", line 56, in application
    response = frappe.handler.handle()
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/handler.py", line 52, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/__init__.py", line 922, in call
    return fn(*args, **newargs)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/desk/query_report.py", line 95, in run
    res = frappe.get_attr(method_name)(frappe._dict(filters))
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/erpnext/erpnext/schools/report/student_and_guardian_contact_details/student_and_guardian_contact_details.py", line 27, in execute
    guardian_map = get_guardian_map(student_list)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/erpnext/erpnext/schools/report/student_and_guardian_contact_details/student_and_guardian_contact_details.py", line 88, in get_guardian_map
    where name in (%s)""" % ", ".join(['%s']*len(guardian_list)), tuple(guardian_list)))
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/database.py", line 165, in sql
    self._cursor.execute(query)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/env/lib/python2.7/site-packages/MySQLdb/cursors.py", line 250, in execute
    self.errorhandler(self, exc, value)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/env/lib/python2.7/site-packages/MySQLdb/connections.py", line 50, in defaulterrorhandler
    raise errorvalue
ProgrammingError: (1064, "You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ')' at line 2")
```