### PR TITLE
[Fix] Making of production order from so, system not fetched the items from the sales order item if packing list has items and vice versa

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -179,7 +179,7 @@ erpnext.selling.SalesOrderController = erpnext.selling.SellingController.extend(
 			doc: this.frm.doc,
 			method: 'get_production_order_items',
 			callback: function(r) {
-				if(!r.message.every(function(d) { return !!d.bom })) {
+				if(!r.message) {
 					frappe.msgprint({
 						title: __('Production Order not created'),
 						message: __('No Items with Bill of Materials to Manufacture'),


### PR DESCRIPTION
**Issue**

User has added two items in the sale order, one item has BOM and other item is bundle item. The bundle item has 2 items out of which 1 has BOM
When user trying to make production order from sales order, system throwing an error
![screen shot 2017-08-18 at 2 50 58 pm](https://user-images.githubusercontent.com/8780500/29453756-64cb61b0-8428-11e7-849e-1ffefcc6bc17.png)

**Fixed**
![screen shot 2017-08-18 at 3 10 13 pm](https://user-images.githubusercontent.com/8780500/29453769-6cb1400c-8428-11e7-80b4-543113e61e76.png)

Fixed https://github.com/frappe/erpnext/issues/10381