### PR TITLE
[Fix] Tax rule is not working for the parent customer groups

### DIFF
--- a/erpnext/accounts/doctype/tax_rule/tax_rule.py
+++ b/erpnext/accounts/doctype/tax_rule/tax_rule.py
@@ -8,6 +8,7 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.utils import cstr, cint
 from frappe.contacts.doctype.address.address import get_default_address
+from erpnext.setup.doctype.customer_group.customer_group import get_parent_customer_groups
 
 class IncorrectCustomerGroup(frappe.ValidationError): pass
 class IncorrectSupplierType(frappe.ValidationError): pass
@@ -134,6 +135,9 @@ def get_tax_template(posting_date, args):
 	for key, value in args.iteritems():
 		if key=="use_for_shopping_cart":
 			conditions.append("use_for_shopping_cart = {0}".format(1 if value else 0))
+		if key == 'customer_group' and value:
+			customer_group_condition = get_customer_group_condition(value)
+			conditions.append("ifnull({0}, '') in ('', {1})".format(key, customer_group_condition))
 		else:
 			conditions.append("ifnull({0}, '') in ('', '{1}')".format(key, frappe.db.escape(cstr(value))))
 
@@ -157,3 +161,8 @@ def get_tax_template(posting_date, args):
 		return None
 
 	return tax_template
+
+def get_customer_group_condition(customer_group):
+	customer_groups = ["'%s'"%(d.name) for d in get_parent_customer_groups(frappe.db.escape(customer_group))]
+	condition = ",".join(['%s'] * len(customer_groups))%(tuple(customer_groups))
+	return condition

--- a/erpnext/accounts/doctype/tax_rule/test_tax_rule.py
+++ b/erpnext/accounts/doctype/tax_rule/test_tax_rule.py
@@ -34,6 +34,14 @@ class TestTaxRule(unittest.TestCase):
 		tax_rule2.save()
 		self.assertTrue(tax_rule2.name)
 
+	def test_for_parent_customer_group(self):
+		tax_rule1 = make_tax_rule(customer_group= "All Customer Groups",
+			sales_tax_template = "_Test Sales Taxes and Charges Template", priority = 1, from_date = "2015-01-01")
+		tax_rule1.save()
+
+		self.assertEquals(get_tax_template("2015-01-01", {"customer_group" : "Commercial"}),
+			"_Test Sales Taxes and Charges Template")
+
 	def test_conflict_with_overlapping_dates(self):
 		tax_rule1 = make_tax_rule(customer= "_Test Customer",
 			sales_tax_template = "_Test Sales Taxes and Charges Template", priority = 1, from_date = "2015-01-01", to_date = "2015-01-05")

--- a/erpnext/setup/doctype/customer_group/customer_group.py
+++ b/erpnext/setup/doctype/customer_group/customer_group.py
@@ -18,3 +18,10 @@ class CustomerGroup(NestedSet):
 	def validate_name_with_customer(self):
 		if frappe.db.exists("Customer", self.name):
 			frappe.msgprint(_("An Customer exists with same name"), raise_exception=1)
+
+def get_parent_customer_groups(customer_group):
+	lft, rgt = frappe.db.get_value("Customer Group", customer_group, ['lft', 'rgt'])
+
+	return frappe.db.sql("""select name from `tabCustomer Group`
+		where lft <= %s and rgt >= %s
+		order by lft asc""", (lft, rgt), as_dict=True)


### PR DESCRIPTION
**Issue**
If user has set parent custom group(eg All Customer Groups) in the tax rule, and in the customer has set child customer group then above tax rule not applied during making of sales order against that customer.

![tax_rule_issue](https://user-images.githubusercontent.com/8780500/29462188-230b9f78-844c-11e7-877c-e4f21d5df078.gif)

**Fixed**

![tax_rule_issue_resolved](https://user-images.githubusercontent.com/8780500/29462191-28343f5a-844c-11e7-931b-ba69d04ed40e.gif)

Fixed https://github.com/frappe/erpnext/issues/10223