### PR TITLE
[Fix] Accepting duplicate serial no is purchase receipt

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -6,9 +6,10 @@ from __future__ import unicode_literals
 import unittest
 import frappe, erpnext
 import frappe.defaults
-from frappe.utils import cint, flt, cstr, today
+from frappe.utils import cint, flt, cstr, today, random_string
 from erpnext.stock.doctype.purchase_receipt.purchase_receipt import make_purchase_invoice
 from erpnext import set_perpetual_inventory
+from erpnext.stock.doctype.serial_no.serial_no import SerialNoDuplicateError
 from erpnext.accounts.doctype.account.test_account import get_inventory_account
 
 class TestPurchaseReceipt(unittest.TestCase):
@@ -250,6 +251,22 @@ class TestPurchaseReceipt(unittest.TestCase):
 		self.assertEqual(pr2.get("items")[0].billed_amt, 2000)
 		self.assertEqual(pr2.per_billed, 80)
 		self.assertEqual(pr2.status, "To Bill")
+
+	def test_not_accept_duplicate_serial_no(self):
+		from erpnext.stock.doctype.item.test_item import make_item
+		from erpnext.stock.doctype.delivery_note.test_delivery_note import create_delivery_note
+
+		item_code = frappe.db.get_value('Item', {'has_serial_no': 1})
+		if not item_code:
+			item = make_item("Test Serial Item 1", dict(has_serial_no = 1))
+			item_code = item.name
+
+		serial_no = random_string(5)
+		make_purchase_receipt(item_code=item_code, qty=1, serial_no=serial_no)
+		create_delivery_note(item_code=item_code, qty=1, serial_no=serial_no)
+
+		pr = make_purchase_receipt(item_code=item_code, qty=1, serial_no=serial_no, do_not_submit=True)
+		self.assertRaises(SerialNoDuplicateError, pr.submit)
 
 def get_gl_entries(voucher_type, voucher_no):
 	return frappe.db.sql("""select account, debit, credit

--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -253,6 +253,7 @@ class TestPurchaseReceipt(unittest.TestCase):
 		self.assertEqual(pr2.status, "To Bill")
 
 	def test_not_accept_duplicate_serial_no(self):
+		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
 		from erpnext.stock.doctype.item.test_item import make_item
 		from erpnext.stock.doctype.delivery_note.test_delivery_note import create_delivery_note
 
@@ -267,6 +268,10 @@ class TestPurchaseReceipt(unittest.TestCase):
 
 		pr = make_purchase_receipt(item_code=item_code, qty=1, serial_no=serial_no, do_not_submit=True)
 		self.assertRaises(SerialNoDuplicateError, pr.submit)
+
+		se = make_stock_entry(item_code=item_code, target="_Test Warehouse - _TC", qty=1,
+			serial_no=serial_no, basic_rate=100, do_not_submit=True)
+		self.assertRaises(SerialNoDuplicateError, se.submit)
 
 def get_gl_entries(voucher_type, voucher_no):
 	return frappe.db.sql("""select account, debit, credit

--- a/erpnext/stock/doctype/serial_no/serial_no.py
+++ b/erpnext/stock/doctype/serial_no/serial_no.py
@@ -213,7 +213,7 @@ def validate_serial_no(sle, item_det):
 							frappe.throw(_("Serial No {0} does not belong to Item {1}").format(serial_no,
 								sle.item_code), SerialNoItemError)
 
-					if sr.warehouse and sle.actual_qty > 0:
+					if (sr.warehouse or sr.purchase_document_no) and sle.actual_qty > 0:
 						frappe.throw(_("Serial No {0} has already been received").format(serial_no),
 							SerialNoDuplicateError)
 

--- a/erpnext/stock/doctype/serial_no/serial_no.py
+++ b/erpnext/stock/doctype/serial_no/serial_no.py
@@ -213,7 +213,7 @@ def validate_serial_no(sle, item_det):
 							frappe.throw(_("Serial No {0} does not belong to Item {1}").format(serial_no,
 								sle.item_code), SerialNoItemError)
 
-					if (sr.warehouse or sr.purchase_document_no) and sle.actual_qty > 0:
+					if sle.actual_qty > 0 and has_duplicate_serial_no(sr, sle):
 						frappe.throw(_("Serial No {0} has already been received").format(serial_no),
 							SerialNoDuplicateError)
 
@@ -233,6 +233,21 @@ def validate_serial_no(sle, item_det):
 		elif sle.actual_qty < 0 or not item_det.serial_no_series:
 			frappe.throw(_("Serial Nos Required for Serialized Item {0}").format(sle.item_code),
 				SerialNoRequiredError)
+
+def has_duplicate_serial_no(sn, sle):
+	if sn.warehouse:
+		return True
+
+	status = False
+	if sn.purchase_document_no:
+		if sle.voucher_type in ['Purchase Receipt', 'Stock Entry']:
+			status = True
+
+		if status and sle.voucher_type == 'Stock Entry' and \
+			frappe.db.get_value('Stock Entry', sle.voucher_no, 'purpose') != 'Material Receipt':
+			status = False
+
+	return status
 
 def allow_serial_nos_with_different_item(sle_serial_no, sle):
 	"""

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -395,7 +395,8 @@ class TestStockEntry(unittest.TestCase):
 
 	def test_serial_item_error(self):
 		se, serial_nos = self.test_serial_by_series()
-		make_serialized_item("_Test Serialized Item", "ABCD\nEFGH")
+		if not frappe.db.exists('Serial No', 'ABCD'):
+			make_serialized_item("_Test Serialized Item", "ABCD\nEFGH")
 
 		se = frappe.copy_doc(test_records[0])
 		se.purpose = "Material Transfer"


### PR DESCRIPTION
**Issue**
Created purchase receipt with serial no ABC
Created delivery note with serial no ABC
Created purchase receipt with serial no ABC again and system has allowed

Fixed https://github.com/frappe/erpnext/issues/10395