### PR TITLE
[Fix] Pricing rule applying only on item groups defined in POS profile

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/pos.py
+++ b/erpnext/accounts/doctype/sales_invoice/pos.py
@@ -151,13 +151,8 @@ def get_items_list(pos_profile):
 
 def get_item_groups(pos_profile):
 	item_group_dict = {}
-	if pos_profile.get('item_groups'):
-		item_groups = []
-		for d in pos_profile.get('item_groups'):
-			item_groups.extend(get_child_nodes('Item Group', d.item_group))
-	else:
-		item_groups = frappe.db.sql("""Select name,
-			lft, rgt from `tabItem Group` order by lft""", as_dict=1)
+	item_groups = frappe.db.sql("""Select name,
+		lft, rgt from `tabItem Group` order by lft""", as_dict=1)
 
 	for data in item_groups:
 		item_group_dict[data.name] = [data.lft, data.rgt]


### PR DESCRIPTION
**Issue**
User has created POS profile and added item group as "Product POS"
Created pricing rule for item group "All Item Groups"
While adding item in the cart form the POS, getting following error
![screen shot 2017-08-21 at 4 30 58 pm](https://user-images.githubusercontent.com/8780500/29516567-73fa5cc8-868e-11e7-81cc-ce9743e8e70a.png)
