### PR TITLE
[hotfix] fixes for TypeError: 'NoneType' object is not iterable

### DIFF
--- a/erpnext/accounts/doctype/tax_rule/tax_rule.py
+++ b/erpnext/accounts/doctype/tax_rule/tax_rule.py
@@ -163,6 +163,8 @@ def get_tax_template(posting_date, args):
 	return tax_template
 
 def get_customer_group_condition(customer_group):
-	customer_groups = ["'%s'"%(d.name) for d in get_parent_customer_groups(frappe.db.escape(customer_group))]
-	condition = ",".join(['%s'] * len(customer_groups))%(tuple(customer_groups))
+	condition = ""
+	customer_groups = ["'%s'"%(frappe.db.escape(d.name)) for d in get_parent_customer_groups(customer_group)]
+	if customer_groups:
+		condition = ",".join(['%s'] * len(customer_groups))%(tuple(customer_groups))
 	return condition


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2017-08-21/apps/frappe/frappe/desk/form/save.py", line 22, in savedocs
    doc.save()
  File "/home/frappe/benches/bench-2017-08-21/apps/frappe/frappe/model/document.py", line 230, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-2017-08-21/apps/frappe/frappe/model/document.py", line 263, in _save
    self.run_before_save_methods()
  File "/home/frappe/benches/bench-2017-08-21/apps/frappe/frappe/model/document.py", line 772, in run_before_save_methods
    self.run_method("validate")
  File "/home/frappe/benches/bench-2017-08-21/apps/frappe/frappe/model/document.py", line 666, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-2017-08-21/apps/frappe/frappe/model/document.py", line 887, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-2017-08-21/apps/frappe/frappe/model/document.py", line 870, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-2017-08-21/apps/frappe/frappe/model/document.py", line 660, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-2017-08-21/apps/erpnext/erpnext/selling/doctype/sales_order/sales_order.py", line 29, in validate
    super(SalesOrder, self).validate()
  File "/home/frappe/benches/bench-2017-08-21/apps/erpnext/erpnext/controllers/selling_controller.py", line 33, in validate
    super(SellingController, self).validate()
  File "/home/frappe/benches/bench-2017-08-21/apps/erpnext/erpnext/controllers/stock_controller.py", line 17, in validate
    super(StockController, self).validate()
  File "/home/frappe/benches/bench-2017-08-21/apps/erpnext/erpnext/controllers/accounts_controller.py", line 34, in validate
    self.set_missing_values(for_validate=True)
  File "/home/frappe/benches/bench-2017-08-21/apps/erpnext/erpnext/controllers/selling_controller.py", line 43, in set_missing_values
    self.set_missing_lead_customer_details()
  File "/home/frappe/benches/bench-2017-08-21/apps/erpnext/erpnext/controllers/selling_controller.py", line 50, in set_missing_lead_customer_details
    ignore_permissions=self.flags.ignore_permissions)
  File "/home/frappe/benches/bench-2017-08-21/apps/erpnext/erpnext/accounts/party.py", line 53, in _get_party_details
    out["taxes_and_charges"] = set_taxes(party.name, party_type, posting_date, company, out.customer_group, out.supplier_type)
  File "/home/frappe/benches/bench-2017-08-21/apps/erpnext/erpnext/accounts/party.py", line 346, in set_taxes
    return get_tax_template(posting_date, args)
  File "/home/frappe/benches/bench-2017-08-21/apps/erpnext/erpnext/accounts/doctype/tax_rule/tax_rule.py", line 139, in get_tax_template
    customer_group_condition = get_customer_group_condition(value)
  File "/home/frappe/benches/bench-2017-08-21/apps/erpnext/erpnext/accounts/doctype/tax_rule/tax_rule.py", line 166, in get_customer_group_condition
    customer_groups = ["'%s'"%(d.name) for d in get_parent_customer_groups(frappe.db.escape(customer_group))]
  File "/home/frappe/benches/bench-2017-08-21/apps/erpnext/erpnext/setup/doctype/customer_group/customer_group.py", line 23, in get_parent_customer_groups
    lft, rgt = frappe.db.get_value("Customer Group", customer_group, ['lft', 'rgt'])
TypeError: 'NoneType' object is not iterable
```