### PR TITLE
Item Name not loaded in Material Request via BOM (#10535)

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -125,7 +125,33 @@ $.extend(erpnext.utils, {
 				}
 			});
 		}
-	}
+	},
+
+	/**
+	* Checks if the first row of a given child table is empty
+	* @param child_table - Child table Doctype
+	* @return {Boolean}
+	**/
+	first_row_is_empty: function(child_table){
+		if($.isArray(child_table) && child_table.length > 0) {
+			return !child_table[0].item_code;
+		}
+		return false;
+	},
+
+	/**
+	* Removes the first row of a child table if it is empty
+	* @param {_Frm} frm - The current form
+	* @param {String} child_table_name - The child table field name
+	* @return {Boolean}
+	**/
+	remove_empty_first_row: function(frm, child_table_name){
+		const rows = frm['doc'][child_table_name];
+		if (this.first_row_is_empty(rows)){
+			frm['doc'][child_table_name] = rows.splice(1);
+		}
+		return rows;
+	},
 });
 
 erpnext.utils.map_current_doc = function(opts) {

--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -153,6 +153,7 @@ erpnext.buying.MaterialRequestController = erpnext.buying.BuyingController.exten
 					if(!r.message) {
 						frappe.throw(__("BOM does not contain any stock item"))
 					} else {
+						erpnext.utils.remove_empty_first_row(cur_frm, "items");
 						$.each(r.message, function(i, item) {
 							var d = frappe.model.add_child(cur_frm.doc, "Material Request Item", "items");
 							d.item_code = item.item_code;

--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -156,6 +156,7 @@ erpnext.buying.MaterialRequestController = erpnext.buying.BuyingController.exten
 						$.each(r.message, function(i, item) {
 							var d = frappe.model.add_child(cur_frm.doc, "Material Request Item", "items");
 							d.item_code = item.item_code;
+							d.item_name = item.item_name;
 							d.description = item.description;
 							d.warehouse = values.warehouse;
 							d.uom = item.stock_uom;

--- a/erpnext/stock/doctype/material_request/tests/test_material_request_from_bom.js
+++ b/erpnext/stock/doctype/material_request/tests/test_material_request_from_bom.js
@@ -1,0 +1,28 @@
+QUnit.module('manufacturing');
+
+QUnit.test("test material request get items from BOM", function(assert) {
+	assert.expect(4);
+	let done = assert.async();
+	frappe.run_serially([
+		() => frappe.set_route('Form', 'BOM'),
+		() => frappe.timeout(3),
+		() => frappe.click_button('Get Items from BOM'),
+		() => frappe.timeout(3),
+		() => {
+			assert.ok(cur_dialog, 'dialog appeared');
+		},
+		() => cur_dialog.set_value('bom', 'Laptop'),
+		() => cur_dialog.set_value('warehouse', 'Laptop Scrap Warehouse'),
+		() => frappe.click_button('Get Items from BOM'),
+		() => frappe.timeout(3),
+		() => {
+			assert.ok(cur_frm.doc.items[0].item_code, "First row is not empty");
+			assert.ok(cur_frm.doc.items[0].item_name, "Item name is not empty");
+			assert.equal(cur_frm.doc.items[0].item_name, "Laptop", cur_frm.doc.items[0].item_name);
+		},
+		() => cur_frm.doc.items[0].schedule_date = '2017-12-12',
+		() => cur_frm.save(),
+		() => done()
+	]);
+});
+


### PR DESCRIPTION
This PR fixes #10535 .
I also used the opportunity to add two new functions for `erpnext.utils` to help with removing empty first rows as it is a very common occurrence.

### Before
![peek 2017-08-25 17-16](https://user-images.githubusercontent.com/818803/29722718-c15d43e4-89b9-11e7-9cf6-64346e2134ac.gif)

### After
![peek 2017-08-25 17-19](https://user-images.githubusercontent.com/818803/29722724-c6ebc178-89b9-11e7-9e9b-337a8afaa200.gif)

I also found that this fixes #10496 