### PR TITLE
[hotfix] fixes for UnicodeDecodeError

### DIFF
--- a/erpnext/accounts/doctype/account/chart_of_accounts/chart_of_accounts.py
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/chart_of_accounts.py
@@ -78,6 +78,7 @@ def get_chart(chart_template, existing_company=None):
 		for folder in folders:
 			path = os.path.join(os.path.dirname(__file__), folder)
 			for fname in os.listdir(path):
+				fname = frappe.as_unicode(fname)
 				if fname.endswith(".json"):
 					with open(os.path.join(path, fname), "r") as f:
 						chart = f.read()
@@ -105,6 +106,7 @@ def get_charts_for_country(country):
 			path = os.path.join(os.path.dirname(__file__), folder)
 
 			for fname in os.listdir(path):
+				fname = frappe.as_unicode(fname)
 				if (fname.startswith(country_code) or fname.startswith(country)) and fname.endswith(".json"):
 					with open(os.path.join(path, fname), "r") as f:
 						_get_chart_name(f.read())


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/installed/apps/frappe/frappe/app.py", line 57, in application
    response = frappe.handler.handle()
  File "/home/frappe/frappe-bench/installed/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/frappe-bench/installed/apps/frappe/frappe/handler.py", line 53, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-bench/installed/apps/frappe/frappe/__init__.py", line 922, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench/installed/apps/erpnext/erpnext/accounts/doctype/account/chart_of_accounts/chart_of_accounts.py", line 108, in get_charts_for_country
    if (fname.startswith(country_code) or fname.startswith(country)) and fname.endswith(".json"):
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 19: ordinal not in range(128)
```