### PR TITLE
Add excluded fields to item variants

### DIFF
--- a/erpnext/controllers/item_variant.py
+++ b/erpnext/controllers/item_variant.py
@@ -174,7 +174,7 @@ def copy_attributes_to_variant(item, variant):
 
 	# copy non no-copy fields
 
-	exclude_fields = ["item_code", "item_name", "show_in_website"]
+	exclude_fields = ["item_code", "item_name", "show_in_website", "show_variant_in_website", "standard_rate"]
 
 	if item.variant_based_on=='Manufacturer':
 		# don't copy manufacturer values if based on part no


### PR DESCRIPTION
Changes:

1. **Show in Website (Variant)** - To avoid unchecking the field in the variant since the fieldname doesn't exist for the template item.

2. **Standard rate** - To avoid the standard rates for the variants to change if they are different from the template item. 