### PR TITLE
Python 3 comapatibility Fixes

### DIFF
--- a/erpnext/accounts/doctype/account/chart_of_accounts/import_from_openerp.py
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/import_from_openerp.py
@@ -11,6 +11,7 @@ import ast
 from xml.etree import ElementTree as ET
 from frappe.utils.csvutils import read_csv_content
 import frappe
+from six import iteritems
 
 path = "/Users/nabinhait/projects/odoo/addons"
 
@@ -137,7 +138,7 @@ def get_account_types(root_list, csv_content, prefix=None):
 
 def make_maps_for_xml(xml_roots, account_types, country_dir):
 	"""make maps for `charts` and `accounts`"""
-	for model, root_list in xml_roots.iteritems():
+	for model, root_list in iteritems(xml_roots):
 		for root in root_list:
 			for node in root[0].findall("record"):
 				if node.get("model")=="account.account.template":

--- a/erpnext/accounts/doctype/asset/asset.py
+++ b/erpnext/accounts/doctype/asset/asset.py
@@ -10,6 +10,7 @@ from frappe.model.document import Document
 from erpnext.accounts.doctype.purchase_invoice.purchase_invoice import get_fixed_asset_account
 from erpnext.accounts.doctype.asset.depreciation \
 	import get_disposal_account_and_cost_center, get_depreciation_accounts
+from six.moves import xrange
 
 class Asset(Document):
 	def validate(self):

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -10,6 +10,7 @@ from erpnext.accounts.utils import get_balance_on, get_account_currency
 from erpnext.accounts.party import get_party_account
 from erpnext.hr.doctype.expense_claim.expense_claim import update_reimbursed_amount
 from erpnext.hr.doctype.employee_loan.employee_loan import update_disbursement_status
+from six import iteritems
 
 class JournalEntry(AccountsController):
 	def __init__(self, arg1, arg2=None):
@@ -230,7 +231,7 @@ class JournalEntry(AccountsController):
 
 	def validate_orders(self):
 		"""Validate totals, closed and docstatus for orders"""
-		for reference_name, total in self.reference_totals.iteritems():
+		for reference_name, total in iteritems(self.reference_totals):
 			reference_type = self.reference_types[reference_name]
 			account = self.reference_accounts[reference_name]
 
@@ -262,7 +263,7 @@ class JournalEntry(AccountsController):
 
 	def validate_invoices(self):
 		"""Validate totals and docstatus for invoices"""
-		for reference_name, total in self.reference_totals.iteritems():
+		for reference_name, total in iteritems(self.reference_totals):
 			reference_type = self.reference_types[reference_name]
 
 			if reference_type in ("Sales Invoice", "Purchase Invoice"):

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -10,7 +10,7 @@ from erpnext.accounts.utils import get_balance_on, get_account_currency
 from erpnext.accounts.party import get_party_account
 from erpnext.hr.doctype.expense_claim.expense_claim import update_reimbursed_amount
 from erpnext.hr.doctype.employee_loan.employee_loan import update_disbursement_status
-from six import iteritems
+from six import iteritems, string_types
 
 class JournalEntry(AccountsController):
 	def __init__(self, arg1, arg2=None):
@@ -755,7 +755,7 @@ def get_outstanding(args):
 	if not frappe.has_permission("Account"):
 		frappe.msgprint(_("No Permission"), raise_exception=1)
 
-	if isinstance(args, basestring):
+	if isinstance(args, string_types):
 		args = json.loads(args)
 
 	company_currency = erpnext.get_company_currency(args.get("company"))

--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -10,6 +10,7 @@ import copy
 from frappe import throw, _
 from frappe.utils import flt, cint
 from frappe.model.document import Document
+from six import string_types
 
 
 class MultiplePricingRuleConflict(frappe.ValidationError): pass
@@ -96,7 +97,7 @@ def apply_pricing_rule(args):
 			"ignore_pricing_rule": "something"
 		}
 	"""
-	if isinstance(args, basestring):
+	if isinstance(args, string_types):
 		args = json.loads(args)
 
 	args = frappe._dict(args)
@@ -207,7 +208,7 @@ def remove_pricing_rule_for_item(pricing_rule, item_details):
 
 @frappe.whitelist()
 def remove_pricing_rules(item_list):
-	if isinstance(item_list, basestring):
+	if isinstance(item_list, string_types):
 		item_list = json.loads(item_list)
 	
 	out = []	

--- a/erpnext/accounts/doctype/sales_invoice/pos.py
+++ b/erpnext/accounts/doctype/sales_invoice/pos.py
@@ -10,6 +10,7 @@ from frappe.core.doctype.communication.email import make
 from erpnext.stock.get_item_details import get_pos_profile
 from erpnext.accounts.party import get_party_account_currency
 from erpnext.controllers.accounts_controller import get_taxes_and_charges
+from six import string_types
 
 @frappe.whitelist()
 def get_pos_data():
@@ -173,7 +174,7 @@ def get_customers_list(pos_profile={}):
 
 def get_customers_address(customers):
 	customer_address = {}
-	if isinstance(customers, basestring):
+	if isinstance(customers, string_types):
 		customers = [frappe._dict({'name': customers})]
 
 	for data in customers:
@@ -191,7 +192,7 @@ def get_customers_address(customers):
 
 def get_contacts(customers):
 	customer_contact = {}
-	if isinstance(customers, basestring):
+	if isinstance(customers, string_types):
 		customers = [frappe._dict({'name': customers})]
 
 	for data in customers:
@@ -299,13 +300,13 @@ def get_pricing_rule_data(doc):
 
 @frappe.whitelist()
 def make_invoice(doc_list={}, email_queue_list={}, customers_list={}):
-	if isinstance(doc_list, basestring):
+	if isinstance(doc_list, string_types):
 		doc_list = json.loads(doc_list)
 
-	if isinstance(email_queue_list, basestring):
+	if isinstance(email_queue_list, string_types):
 		email_queue_list = json.loads(email_queue_list)
 
-	if isinstance(customers_list, basestring):
+	if isinstance(customers_list, string_types):
 		customers_list = json.loads(customers_list)
 
 	customers_list = make_customer_and_address(customers_list)

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -15,6 +15,7 @@ from erpnext.stock.doctype.serial_no.serial_no import SerialNoWarehouseError
 from frappe.model.naming import make_autoname
 from erpnext.accounts.doctype.account.test_account import get_inventory_account
 from erpnext.controllers.taxes_and_totals import get_itemised_tax_breakup_data
+from six.moves import xrange
 
 class TestSalesInvoice(unittest.TestCase):
 	def make(self):

--- a/erpnext/accounts/doctype/shipping_rule/shipping_rule.py
+++ b/erpnext/accounts/doctype/shipping_rule/shipping_rule.py
@@ -8,6 +8,7 @@ import frappe, erpnext
 from frappe import _, msgprint, throw
 from frappe.utils import flt, fmt_money
 from frappe.model.document import Document
+from six.moves import xrange
 
 class OverlappingConditionError(frappe.ValidationError): pass
 class FromGreaterThanToError(frappe.ValidationError): pass

--- a/erpnext/accounts/doctype/tax_rule/tax_rule.py
+++ b/erpnext/accounts/doctype/tax_rule/tax_rule.py
@@ -9,6 +9,7 @@ from frappe.model.document import Document
 from frappe.utils import cstr, cint
 from frappe.contacts.doctype.address.address import get_default_address
 from erpnext.setup.doctype.customer_group.customer_group import get_parent_customer_groups
+from six import iteritems
 
 class IncorrectCustomerGroup(frappe.ValidationError): pass
 class IncorrectSupplierType(frappe.ValidationError): pass
@@ -132,7 +133,7 @@ def get_tax_template(posting_date, args):
 	conditions = ["""(from_date is null  or from_date = '' or from_date <= '{0}')
 		and (to_date is null  or to_date = '' or to_date >= '{0}')""".format(posting_date)]
 
-	for key, value in args.iteritems():
+	for key, value in iteritems(args):
 		if key=="use_for_shopping_cart":
 			conditions.append("use_for_shopping_cart = {0}".format(1 if value else 0))
 		if key == 'customer_group' and value:

--- a/erpnext/accounts/doctype/tax_rule/test_tax_rule.py
+++ b/erpnext/accounts/doctype/tax_rule/test_tax_rule.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 import frappe
 import unittest
 from erpnext.accounts.doctype.tax_rule.tax_rule import IncorrectCustomerGroup, IncorrectSupplierType, ConflictingTaxRule, get_tax_template
+from six import iteritems
 
 test_records = frappe.get_test_records('Tax Rule')
 
@@ -126,7 +127,7 @@ def make_tax_rule(**args):
 
 	tax_rule = frappe.new_doc("Tax Rule")
 
-	for key, val in args.iteritems():
+	for key, val in iteritems(args):
 		if key != "save":
 			tax_rule.set(key, val)
 

--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -16,6 +16,7 @@ from frappe.contacts.doctype.contact.contact import get_contact_details, get_def
 from erpnext.exceptions import PartyFrozen, PartyDisabled, InvalidAccountCurrency
 from erpnext.accounts.utils import get_fiscal_year
 from erpnext import get_default_currency, get_company_currency
+from six import iteritems
 
 
 class DuplicatePartyAccountError(frappe.ValidationError): pass
@@ -372,7 +373,7 @@ def get_timeline_data(doctype, name):
 
 	timeline_items = dict(data)
 
-	for date, count in timeline_items.iteritems():
+	for date, count in iteritems(timeline_items):
 		timestamp = get_timestamp(date)
 		out.update({ timestamp: count })
 

--- a/erpnext/accounts/report/financial_statements.py
+++ b/erpnext/accounts/report/financial_statements.py
@@ -8,7 +8,7 @@ from frappe import _
 from frappe.utils import (flt, getdate, get_first_day, get_last_day, date_diff,
 	add_months, add_days, formatdate, cint)
 from erpnext.accounts.utils import get_fiscal_year
-
+from six.moves import xrange
 
 def get_period_list(from_fiscal_year, to_fiscal_year, periodicity, accumulated_values=False,
 	company=None, reset_period_on_fy_change=True):

--- a/erpnext/accounts/report/financial_statements.py
+++ b/erpnext/accounts/report/financial_statements.py
@@ -240,7 +240,7 @@ def add_total_row(out, root_type, balance_must_be, period_list, company_currency
 			total_row["total"] += flt(row["total"])
 			row["total"] = ""
 
-	if total_row.has_key("total"):
+	if "total" in total_row:
 		out.append(total_row)
 
 		# blank row after Total

--- a/erpnext/accounts/report/purchase_register/purchase_register.py
+++ b/erpnext/accounts/report/purchase_register/purchase_register.py
@@ -178,7 +178,7 @@ def get_invoice_tax_map(invoice_list, invoice_expense_map, expense_accounts):
 	invoice_tax_map = {}
 	for d in tax_details:
 		if d.account_head in expense_accounts:
-			if invoice_expense_map[d.parent].has_key(d.account_head):
+			if d.account_head in invoice_expense_map[d.parent]:
 				invoice_expense_map[d.parent][d.account_head] += flt(d.tax_amount)
 			else:
 				invoice_expense_map[d.parent][d.account_head] = flt(d.tax_amount)

--- a/erpnext/accounts/report/sales_register/sales_register.py
+++ b/erpnext/accounts/report/sales_register/sales_register.py
@@ -172,7 +172,7 @@ def get_invoice_tax_map(invoice_list, invoice_income_map, income_accounts):
 	invoice_tax_map = {}
 	for d in tax_details:
 		if d.account_head in income_accounts:
-			if invoice_income_map[d.parent].has_key(d.account_head):
+			if d.account_head in invoice_income_map[d.parent]:
 				invoice_income_map[d.parent][d.account_head] += flt(d.tax_amount)
 			else:
 				invoice_income_map[d.parent][d.account_head] = flt(d.tax_amount)

--- a/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
+++ b/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
@@ -15,6 +15,7 @@ from erpnext.accounts.party import get_party_account_currency, get_party_details
 from erpnext.stock.doctype.material_request.material_request import set_missing_values
 from erpnext.controllers.buying_controller import BuyingController
 from erpnext.buying.utils import validate_for_items
+from six import string_types
 
 STANDARD_USERS = ("Guest", "Administrator")
 
@@ -240,7 +241,7 @@ def make_supplier_quotation(source_name, for_supplier, target_doc=None):
 # This method is used to make supplier quotation from supplier's portal.
 @frappe.whitelist()
 def create_supplier_quotation(doc):
-	if isinstance(doc, basestring):
+	if isinstance(doc, string_types):
 		doc = json.loads(doc)
 
 	try:

--- a/erpnext/controllers/item_variant.py
+++ b/erpnext/controllers/item_variant.py
@@ -6,6 +6,7 @@ import frappe
 from frappe import _
 from frappe.utils import cstr, flt
 import json
+from six import string_types
 
 class ItemVariantExistsError(frappe.ValidationError): pass
 class InvalidItemAttributeValueError(frappe.ValidationError): pass
@@ -26,7 +27,7 @@ def get_variant(template, args=None, variant=None, manufacturer=None,
 		return make_variant_based_on_manufacturer(item_template, manufacturer,
 			manufacturer_part_no)
 	else:
-		if isinstance(args, basestring):
+		if isinstance(args, string_types):
 			args = json.loads(args)
 
 		if not args:
@@ -50,7 +51,7 @@ def make_variant_based_on_manufacturer(template, manufacturer, manufacturer_part
 	return variant
 
 def validate_item_variant_attributes(item, args=None):
-	if isinstance(item, basestring):
+	if isinstance(item, string_types):
 		item = frappe.get_doc('Item', item)
 
 	if not args:
@@ -149,7 +150,7 @@ def find_variant(template, args, variant_item_code=None):
 
 @frappe.whitelist()
 def create_variant(item, args):
-	if isinstance(args, basestring):
+	if isinstance(args, string_types):
 		args = json.loads(args)
 
 	template = frappe.get_doc("Item", item)

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -156,7 +156,7 @@ class calculate_taxes_and_totals(object):
 		return current_tax_fraction
 
 	def _get_tax_rate(self, tax, item_tax_map):
-		if item_tax_map.has_key(tax.account_head):
+		if tax.account_head in item_tax_map:
 			return flt(item_tax_map.get(tax.account_head), self.doc.precision("rate", tax))
 		else:
 			return tax.rate

--- a/erpnext/controllers/tests/test_item_variant.py
+++ b/erpnext/controllers/tests/test_item_variant.py
@@ -7,16 +7,6 @@ import unittest
 from erpnext.controllers.item_variant import copy_attributes_to_variant, make_variant_item_code
 from six import string_types
 
-# python 3 compatibility stuff
-try:
-	unicode = unicode
-except NameError:
-	# Python 3
-	basestring = (str, bytes)
-else:
-	# Python 2
-	basestring = basestring
-
 
 def create_variant_with_tables(item, args):
 	if isinstance(args, string_types):

--- a/erpnext/controllers/tests/test_item_variant.py
+++ b/erpnext/controllers/tests/test_item_variant.py
@@ -5,6 +5,7 @@ import json
 import unittest
 
 from erpnext.controllers.item_variant import copy_attributes_to_variant, make_variant_item_code
+from six import string_types
 
 # python 3 compatibility stuff
 try:
@@ -18,7 +19,7 @@ else:
 
 
 def create_variant_with_tables(item, args):
-	if isinstance(args, basestring):
+	if isinstance(args, string_types):
 		args = json.loads(args)
 
 	template = frappe.get_doc("Item", item)

--- a/erpnext/controllers/tests/test_recurring_document.py
+++ b/erpnext/controllers/tests/test_recurring_document.py
@@ -6,6 +6,7 @@ import frappe
 import frappe.permissions
 from erpnext.controllers.recurring_document import date_field_map
 from frappe.utils import get_first_day, get_last_day, add_to_date, nowdate, getdate, add_days
+from six.moves import xrange
 
 def test_recurring_document(obj, test_records):
 	frappe.db.set_value("Print Settings", "Print Settings", "send_print_as_pdf", 1)

--- a/erpnext/controllers/trends.py
+++ b/erpnext/controllers/trends.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 import frappe
 from frappe.utils import getdate
 from frappe import _
+from six.moves import xrange
 
 def get_columns(filters, trans):
 	validate_filters(filters)

--- a/erpnext/demo/demo.py
+++ b/erpnext/demo/demo.py
@@ -5,6 +5,7 @@ import erpnext
 import frappe.utils
 from erpnext.demo.user import hr, sales, purchase, manufacturing, stock, accounts, projects, fixed_asset, schools
 from erpnext.demo.setup import education, manufacture, setup_data
+from six.moves import xrange
 """
 Make a demo
 

--- a/erpnext/demo/setup/manufacture.py
+++ b/erpnext/demo/setup/manufacture.py
@@ -4,6 +4,7 @@ import random, json
 import frappe
 from frappe.utils import nowdate, add_days
 from erpnext.demo.setup.setup_data import import_json
+from six import iteritems
 
 def setup_data():
 	import_json("Asset Category")
@@ -122,7 +123,7 @@ def setup_item_price():
 	}
 
 	for price_list in ("standard_buying", "standard_selling"):
-		for item, rate in locals().get(price_list).iteritems():
+		for item, rate in iteritems(locals().get(price_list)):
 			frappe.get_doc({
 				"doctype": "Item Price",
 				"price_list": price_list.replace("_", " ").title(),

--- a/erpnext/demo/setup/setup_data.py
+++ b/erpnext/demo/setup/setup_data.py
@@ -7,6 +7,7 @@ from frappe.utils import flt, now_datetime, cstr, random_string
 from frappe.utils.make_random import add_random_children, get_random
 from erpnext.demo.domains import data
 from frappe import _
+from six.moves import xrange
 
 def setup(domain):
 	complete_setup(domain)

--- a/erpnext/demo/user/purchase.py
+++ b/erpnext/demo/user/purchase.py
@@ -12,6 +12,7 @@ from erpnext.exceptions import InvalidCurrency
 from erpnext.stock.doctype.material_request.material_request import make_request_for_quotation
 from erpnext.buying.doctype.request_for_quotation.request_for_quotation import \
 			 make_supplier_quotation as make_quotation_from_rfq
+from six.moves import xrange
 
 def work():
 	frappe.set_user(frappe.db.get_global('demo_purchase_user'))

--- a/erpnext/demo/user/sales.py
+++ b/erpnext/demo/user/sales.py
@@ -9,6 +9,7 @@ from frappe.utils.make_random import add_random_children, get_random
 from erpnext.setup.utils import get_exchange_rate
 from erpnext.accounts.party import get_party_account_currency
 from erpnext.accounts.doctype.payment_request.payment_request import make_payment_request, make_payment_entry
+from six.moves import xrange
 
 def work():
 	frappe.set_user(frappe.db.get_global('demo_sales_user_2'))

--- a/erpnext/demo/user/schools.py
+++ b/erpnext/demo/user/schools.py
@@ -12,6 +12,7 @@ from erpnext.schools.api import get_student_group_students, make_attendance_reco
 								get_fee_schedule, collect_fees, get_course
 from erpnext.schools.doctype.program_enrollment.program_enrollment import get_program_courses
 from erpnext.schools.doctype.student_group.student_group import get_students
+from six.moves import xrange
 
 def work():
 	frappe.set_user(frappe.db.get_global('demo_schools_user'))

--- a/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py
+++ b/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py
@@ -10,6 +10,7 @@ from frappe import throw, _
 from erpnext.utilities.transaction_base import TransactionBase, delete_events
 from erpnext.stock.utils import get_valid_serial_nos
 from erpnext.hr.doctype.employee.employee import get_holiday_list_for_employee
+from six.moves import xrange
 
 class MaintenanceSchedule(TransactionBase):
 	def generate_schedule(self):

--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -531,7 +531,7 @@ def get_bom_items_as_dict(bom, company, qty=1, fetch_exploded=1, fetch_scrap_ite
 		items = frappe.db.sql(query, { "qty": qty, "bom": bom }, as_dict=True)
 
 	for item in items:
-		if item_dict.has_key(item.item_code):
+		if item.item_code in item_dict:
 			item_dict[item.item_code]["qty"] += flt(item.qty)
 		else:
 			item_dict[item.item_code] = item

--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -10,6 +10,7 @@ from frappe.website.website_generator import WebsiteGenerator
 from erpnext.stock.get_item_details import get_conversion_factor
 
 from operator import itemgetter
+from six import string_types
 
 form_grid_templates = {
 	"items": "templates/form_grid/item_grid.html"
@@ -109,7 +110,7 @@ class BOM(WebsiteGenerator):
 		if not args:
 			args = frappe.form_dict.get('args')
 
-		if isinstance(args, basestring):
+		if isinstance(args, string_types):
 			import json
 			args = json.loads(args)
 

--- a/erpnext/patches/v4_0/import_country_codes.py
+++ b/erpnext/patches/v4_0/import_country_codes.py
@@ -5,9 +5,10 @@ from __future__ import unicode_literals
 import frappe
 from frappe.geo.country_info import get_all
 from frappe.utils.install import import_country_and_currency
+from six import iteritems
 
 def execute():
 	frappe.reload_doc("setup", "doctype", "country")
 	import_country_and_currency()
-	for name, country in get_all().iteritems():
+	for name, country in iteritems(get_all()):
 		frappe.set_value("Country", name, "code", country.get("code"))

--- a/erpnext/patches/v4_4/make_email_accounts.py
+++ b/erpnext/patches/v4_4/make_email_accounts.py
@@ -1,5 +1,6 @@
 import frappe
 from frappe.model import default_fields
+from six import iteritems
 
 def execute():
 	frappe.reload_doc("email", "doctype", "email_account")
@@ -19,7 +20,7 @@ def execute():
 			"use_tls": "use_ssl"
 		}
 
-		for target_fieldname, source_fieldname in mapping.iteritems():
+		for target_fieldname, source_fieldname in iteritems(mapping):
 			account.set(target_fieldname, outgoing.get(source_fieldname))
 
 		account.enable_outgoing = 1
@@ -42,7 +43,7 @@ def execute():
 			"auto_reply_message": "support_autoreply"
 		}
 
-		for target_fieldname, source_fieldname in mapping.iteritems():
+		for target_fieldname, source_fieldname in iteritems(mapping):
 			account.set(target_fieldname, support.get(source_fieldname))
 
 		account.enable_outgoing = 0
@@ -63,7 +64,7 @@ def execute():
 				"use_ssl": "use_ssl",
 			}
 
-			for target_fieldname, source_fieldname in mapping.iteritems():
+			for target_fieldname, source_fieldname in iteritems(mapping):
 				account.set(target_fieldname, source.get(source_fieldname))
 
 			account.enable_outgoing = 0

--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -10,6 +10,7 @@ from frappe import _
 from frappe.model.document import Document
 from erpnext.controllers.queries import get_filters_cond
 from frappe.desk.reportview import get_match_cond
+from six import iteritems
 
 class Project(Document):
 	def get_feed(self):
@@ -241,7 +242,7 @@ class Project(Document):
 				dependency_map[task.title] = [ x['subject'] for x in frappe.get_list(
 					'Task Depends On', {"parent": name}, ['subject'])]
 
-			for key, value in dependency_map.iteritems():
+			for key, value in iteritems(dependency_map):
 				task_name = frappe.db.get_value('Task', {"subject": key, "project": self.name })
 				task_doc = frappe.get_doc('Task', task_name)
 

--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -68,7 +68,7 @@ class Project(Document):
 	def validate_weights(self):
 		sum = 0
 		for task in self.tasks:
-			if task.task_weight > 0:
+			if float(task.task_weight or 0) > 0:
 				sum = sum + task.task_weight
 		if sum > 0 and sum != 1:
 			frappe.throw(_("Total of all task weights should be 1. Please adjust weights of all Project tasks accordingly"))

--- a/erpnext/projects/doctype/task/task.py
+++ b/erpnext/projects/doctype/task/task.py
@@ -49,7 +49,7 @@ class Task(Document):
 			clear(self.doctype, self.name)
 			
 	def validate_progress(self):
-		if self.progress > 100:
+		if int(self.progress or 0) > 100:
 			frappe.throw(_("Progress % for a task cannot be more than 100."))
 
 	def update_depends_on(self):

--- a/erpnext/schools/report/student_and_guardian_contact_details/student_and_guardian_contact_details.py
+++ b/erpnext/schools/report/student_and_guardian_contact_details/student_and_guardian_contact_details.py
@@ -4,6 +4,7 @@
 from __future__ import unicode_literals
 import frappe
 from frappe import _
+from six.moves import xrange
 
 
 def execute(filters=None):

--- a/erpnext/selling/doctype/customer/test_customer.py
+++ b/erpnext/selling/doctype/customer/test_customer.py
@@ -11,6 +11,7 @@ from erpnext.exceptions import PartyFrozen, PartyDisabled
 from frappe.utils import flt
 from erpnext.selling.doctype.customer.customer import get_credit_limit, get_customer_outstanding
 from erpnext.tests.utils import create_test_contact_and_address
+from six import iteritems
 
 test_ignore = ["Price List"]
 
@@ -50,7 +51,7 @@ class TestCustomer(unittest.TestCase):
 
 		details = get_party_details("_Test Customer")
 
-		for key, value in to_check.iteritems():
+		for key, value in iteritems(to_check):
 			self.assertEquals(value, details.get(key))
 
 	def test_rename(self):

--- a/erpnext/selling/report/customer_acquisition_and_loyalty/customer_acquisition_and_loyalty.py
+++ b/erpnext/selling/report/customer_acquisition_and_loyalty/customer_acquisition_and_loyalty.py
@@ -6,6 +6,7 @@ import frappe
 from frappe import _
 from frappe.utils import getdate, cint
 import calendar
+from six.moves import xrange
 
 def execute(filters=None):
 	# key yyyy-mm

--- a/erpnext/setup/doctype/terms_and_conditions/terms_and_conditions.py
+++ b/erpnext/setup/doctype/terms_and_conditions/terms_and_conditions.py
@@ -6,6 +6,7 @@ import frappe
 import json
 from frappe.model.document import Document
 from frappe.utils.jinja import validate_template
+from six import string_types
 
 class TermsandConditions(Document):
 	def validate(self):
@@ -14,7 +15,7 @@ class TermsandConditions(Document):
 
 @frappe.whitelist()
 def get_terms_and_conditions(template_name, doc):
-	if isinstance(doc, basestring):
+	if isinstance(doc, string_types):
 		doc = json.loads(doc)
 
 	terms_and_conditions = frappe.get_doc("Terms and Conditions", template_name)

--- a/erpnext/setup/setup_wizard/domainify.py
+++ b/erpnext/setup/setup_wizard/domainify.py
@@ -4,6 +4,7 @@
 from __future__ import unicode_literals
 import frappe
 from frappe import _
+from six import iteritems
 
 def get_domain(domain):
 	'''Written as a function to prevent data mutation effects'''
@@ -155,7 +156,7 @@ def update_module_def_restrict_to_domain():
 	}
 
 	lang = frappe.db.get_single_value("System Settings", "language") or "en"
-	for module, domain in module_def_restrict_to_domain_mapper.iteritems():
+	for module, domain in iteritems(module_def_restrict_to_domain_mapper):
 		if frappe.db.exists("Domain", _(domain, lang)):
 			frappe.db.set_value("Module Def", module, "restrict_to_domain", _(domain, lang))
 		elif frappe.db.exists("Domain", domain):

--- a/erpnext/setup/setup_wizard/setup_wizard.py
+++ b/erpnext/setup/setup_wizard/setup_wizard.py
@@ -10,7 +10,7 @@ from frappe.utils import cstr, flt, getdate
 from frappe import _
 from frappe.utils.file_manager import save_file
 from .default_website import website_maker
-import install_fixtures
+from . import install_fixtures
 from .sample_data import make_sample_data
 from erpnext.accounts.doctype.account.account import RootNotEditable
 from frappe.core.doctype.communication.comment import add_info_comment

--- a/erpnext/setup/setup_wizard/setup_wizard.py
+++ b/erpnext/setup/setup_wizard/setup_wizard.py
@@ -16,6 +16,7 @@ from erpnext.accounts.doctype.account.account import RootNotEditable
 from frappe.core.doctype.communication.comment import add_info_comment
 from erpnext.setup.setup_wizard.domainify import setup_domain
 from erpnext.setup.doctype.company.company import install_country_fixtures
+from six.moves import xrange
 
 def setup_complete(args=None):
 	if frappe.db.sql("select name from tabCompany"):

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -15,6 +15,7 @@ from frappe.website.render import clear_cache
 from frappe.website.doctype.website_slideshow.website_slideshow import get_slideshow
 from erpnext.controllers.item_variant import (get_variant, copy_attributes_to_variant,
 	make_variant_item_code, validate_item_variant_attributes, ItemVariantExistsError)
+from six import iteritems
 
 class DuplicateReorderRows(frappe.ValidationError): pass
 
@@ -659,7 +660,7 @@ def get_timeline_data(doctype, name):
 			and posting_date > date_sub(curdate(), interval 1 year)
 			group by posting_date''', name))
 
-	for date, count in items.iteritems():
+	for date, count in iteritems(items):
 		timestamp = get_timestamp(date)
 		out.update({ timestamp: count })
 

--- a/erpnext/stock/doctype/item/test_item.py
+++ b/erpnext/stock/doctype/item/test_item.py
@@ -11,6 +11,7 @@ from erpnext.controllers.item_variant import (create_variant, ItemVariantExistsE
 
 from frappe.model.rename_doc import rename_doc
 from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
+from six import iteritems
 
 test_ignore = ["BOM"]
 test_dependencies = ["Warehouse"]
@@ -90,7 +91,7 @@ class TestItem(unittest.TestCase):
 			"customer": "_Test Customer"
 		})
 
-		for key, value in to_check.iteritems():
+		for key, value in iteritems(to_check):
 			self.assertEquals(value, details.get(key))
 
 	def test_item_attribute_change_after_variant(self):

--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -30,10 +30,10 @@ class MaterialRequest(BuyingController):
 		so_items = {} # Format --> {'SO/00001': {'Item/001': 120, 'Item/002': 24}}
 		for d in self.get('items'):
 			if d.sales_order:
-				if not so_items.has_key(d.sales_order):
+				if d.sales_order not in so_items:
 					so_items[d.sales_order] = {d.item_code: flt(d.qty)}
 				else:
-					if not so_items[d.sales_order].has_key(d.item_code):
+					if d.item_code not in so_items[d.sales_order]:
 						so_items[d.sales_order][d.item_code] = flt(d.qty)
 					else:
 						so_items[d.sales_order][d.item_code] += flt(d.qty)

--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -14,6 +14,7 @@ from erpnext.stock.stock_balance import update_bin_qty, get_indented_qty
 from erpnext.controllers.buying_controller import BuyingController
 from erpnext.manufacturing.doctype.production_order.production_order import get_item_details
 from erpnext.buying.utils import check_for_closed_status, validate_for_items
+from six import string_types
 
 form_grid_templates = {
 	"items": "templates/form_grid/material_request_grid.html"
@@ -278,7 +279,7 @@ def make_request_for_quotation(source_name, target_doc=None):
 @frappe.whitelist()
 def make_purchase_order_based_on_supplier(source_name, target_doc=None):
 	if target_doc:
-		if isinstance(target_doc, basestring):
+		if isinstance(target_doc, string_types):
 			import json
 			target_doc = frappe.get_doc(json.loads(target_doc))
 		target_doc.set("items", [])

--- a/erpnext/stock/doctype/serial_no/serial_no.py
+++ b/erpnext/stock/doctype/serial_no/serial_no.py
@@ -8,6 +8,7 @@ from frappe.utils import cint, cstr, flt, add_days, nowdate, getdate
 from frappe import _, ValidationError
 
 from erpnext.controllers.stock_controller import StockController
+from six.moves import xrange
 
 class SerialNoCannotCreateDirectError(ValidationError): pass
 class SerialNoCannotCannotChangeError(ValidationError): pass

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -12,6 +12,7 @@ from erpnext.stock.get_item_details import get_bin_details, get_default_cost_cen
 from erpnext.stock.doctype.batch.batch import get_batch_no, set_batch_nos
 from erpnext.manufacturing.doctype.bom.bom import validate_bom_no
 import json
+from six import string_types
 
 class IncorrectValuationRateError(frappe.ValidationError): pass
 class DuplicateEntryForProductionOrderError(frappe.ValidationError): pass
@@ -877,7 +878,7 @@ def get_uom_details(item_code, uom, qty):
 
 @frappe.whitelist()
 def get_warehouse_details(args):
-	if isinstance(args, basestring):
+	if isinstance(args, string_types):
 		args = json.loads(args)
 
 	args = frappe._dict(args)

--- a/erpnext/stock/doctype/stock_entry/stock_entry_utils.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry_utils.py
@@ -3,6 +3,7 @@
 
 import frappe, erpnext
 from frappe.utils import cint, flt
+from six import string_types
 
 @frappe.whitelist()
 def make_stock_entry(**args):
@@ -39,7 +40,7 @@ def make_stock_entry(**args):
 	if args.item_code:
 		args.item = args.item_code
 
-	if isinstance(args.qty, basestring):
+	if isinstance(args.qty, string_types):
 		if '.' in args.qty:
 			args.qty = flt(args.qty)
 		else:

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -14,10 +14,11 @@ from erpnext.stock.doctype.stock_reconciliation.test_stock_reconciliation import
 from frappe.tests.test_permissions import set_user_permission_doctypes
 from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
 from erpnext.accounts.doctype.account.test_account import get_inventory_account
+from six import iteritems
 
 def get_sle(**args):
 	condition, values = "", []
-	for key, value in args.iteritems():
+	for key, value in iteritems(args):
 		condition += " and " if condition else " where "
 		condition += "`{0}`=%s".format(key)
 		values.append(value)

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -10,6 +10,7 @@ from erpnext.accounts.doctype.pricing_rule.pricing_rule import get_pricing_rule_
 from erpnext.setup.utils import get_exchange_rate
 from frappe.model.meta import get_field_precision
 from erpnext.stock.doctype.batch.batch import get_batch_no
+from six import iteritems
 
 @frappe.whitelist()
 def get_item_details(args):
@@ -68,7 +69,7 @@ def get_item_details(args):
 		out.update(get_bin_details(args.item_code, out.warehouse))
 
 	# update args with out, if key or value not exists
-	for key, value in out.iteritems():
+	for key, value in iteritems(out):
 		if args.get(key) is None:
 			args[key] = value
 

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -10,7 +10,7 @@ from erpnext.accounts.doctype.pricing_rule.pricing_rule import get_pricing_rule_
 from erpnext.setup.utils import get_exchange_rate
 from frappe.model.meta import get_field_precision
 from erpnext.stock.doctype.batch.batch import get_batch_no
-from six import iteritems
+from six import iteritems, string_types
 
 @frappe.whitelist()
 def get_item_details(args):
@@ -108,7 +108,7 @@ def get_item_details(args):
 	# })
 
 def process_args(args):
-	if isinstance(args, basestring):
+	if isinstance(args, string_types):
 		args = json.loads(args)
 
 	args = frappe._dict(args)
@@ -556,7 +556,7 @@ def get_gross_profit(out):
 
 @frappe.whitelist()
 def get_serial_no(args):
-	if isinstance(args, basestring):
+	if isinstance(args, string_types):
 		args = json.loads(args)
 		args = frappe._dict(args)
 

--- a/erpnext/stock/report/bom_search/bom_search.py
+++ b/erpnext/stock/report/bom_search/bom_search.py
@@ -3,6 +3,7 @@
 
 from __future__ import unicode_literals
 import frappe, json
+from six import iteritems
 
 def execute(filters=None):
 	data = []
@@ -18,9 +19,9 @@ def execute(filters=None):
 		for d in frappe.get_all(doctype, fields=["parent", "item_code"]):
 			all_boms.setdefault(d.parent, []).append(d.item_code)
 
-		for parent, items in all_boms.iteritems():
+		for parent, items in iteritems(all_boms):
 			valid = True
-			for key, item in filters.iteritems():
+			for key, item in iteritems(filters):
 				if key != "search_sub_assemblies":
 					if item and item not in items:
 						valid = False

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -7,6 +7,7 @@ from frappe import _
 from frappe.utils import cint, flt, cstr, now
 from erpnext.stock.utils import get_valuation_method
 import json
+from six import iteritems
 
 # future reposting
 class NegativeStockError(frappe.ValidationError): pass
@@ -87,7 +88,7 @@ class update_entries_after(object):
 				"allow_negative_stock"))
 
 		self.args = args
-		for key, value in args.iteritems():
+		for key, value in iteritems(args):
 			setattr(self, key, value)
 
 		self.previous_sle = self.get_sle_before_datetime()

--- a/erpnext/stock/utils.py
+++ b/erpnext/stock/utils.py
@@ -41,7 +41,7 @@ def get_stock_value_on(warehouse=None, posting_date=None, item_code=None):
 
 	sle_map = {}
 	for sle in stock_ledger_entries:
-		if not sle_map.has_key((sle.item_code, sle.warehouse)):
+		if (sle.item_code, sle.warehouse) not in sle_map:
 			sle_map[(sle.item_code, sle.warehouse)] = flt(sle.stock_value)
 		
 	return sum(sle_map.values())

--- a/erpnext/stock/utils.py
+++ b/erpnext/stock/utils.py
@@ -6,6 +6,7 @@ import frappe
 from frappe import _
 import json
 from frappe.utils import flt, cstr, nowdate, nowtime
+from six import string_types
 
 class InvalidWarehouseCompany(frappe.ValidationError): pass
 
@@ -127,7 +128,7 @@ def get_incoming_rate(args):
 	"""Get Incoming Rate based on valuation method"""
 	from erpnext.stock.stock_ledger import get_previous_sle
 	
-	if isinstance(args, basestring):
+	if isinstance(args, string_types):
 		args = json.loads(args)
 
 	in_rate = 0

--- a/erpnext/templates/pages/home.py
+++ b/erpnext/templates/pages/home.py
@@ -3,6 +3,7 @@
 
 from __future__ import unicode_literals
 import frappe
+from six.moves import xrange
 
 no_cache = 1
 no_sitemap = 1

--- a/erpnext/utilities/transaction_base.py
+++ b/erpnext/utilities/transaction_base.py
@@ -7,6 +7,7 @@ import frappe.share
 from frappe import _
 from frappe.utils import cstr, now_datetime, cint, flt
 from erpnext.controllers.status_updater import StatusUpdater
+from six import string_types
 
 class UOMMustBeIntegerError(frappe.ValidationError): pass
 
@@ -134,7 +135,7 @@ def delete_events(ref_type, ref_name):
 		where ref_type=%s and ref_name=%s""", (ref_type, ref_name)), for_reload=True)
 
 def validate_uom_is_integer(doc, uom_field, qty_fields, child_dt=None):
-	if isinstance(qty_fields, basestring):
+	if isinstance(qty_fields, string_types):
 		qty_fields = [qty_fields]
 
 	distinct_uoms = list(set([d.get(uom_field) for d in doc.get_all_children()]))


### PR DESCRIPTION
After [Frappe PR #3984](https://github.com/frappe/frappe/pull/3984) and [ERPNext PR #10519](https://github.com/frappe/erpnext/pull/10519)

`bench run-tests` fails without printing test logs

this and [Frappe PR #4050](https://github.com/frappe/frappe/pull/4050) fixes that and now `bench run-tests` yields test logs



```
...


E..EEEEEEEE.....F........E..EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE.........E
E.......EE.......EEEEEE.....EEEEEEEEEEEEEEEEEEEEE.EEFEEEEEEEEEEE.............
.E....E.E.EEE.....EEEEEEEEEEE........E...E.........EE...FF..F...FFFFFF......E..E..........F
..........FFEEEEEEEF...F.EEEE..EEEEEEE.EE..........EEE..............E..E..EEEEE..EEE..
..E.EEEE.EEEEEEEEEEEEEEEEEEEE.EEEE..E...EEEEEEEEEEEE......................EEE
E.EEEE.E...............EEE..E........E..E.......E...................EEEEEEEEEEF.EEEEEEEEEE
EEEEEE..F.EFEEEEE..EEEE..EEEEEEEEEEEEEEFEEEEEEEE.EEEEEEEEE......E.EE
EEE.EEEEEEEEE.EEEEEEEEE..EEE.EEEEEEE.EEEEEEEE.EEE.E......EE......E.E.......
....................F...EEEEEE...E


...

Ran 661 tests in 272.446s

FAILED (failures=21, errors=327)
```