### PR TITLE
Sorting in Production Order BOM Items

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -512,6 +512,7 @@ def get_bom_items_as_dict(bom, company, qty=1, fetch_exploded=1, fetch_scrap_ite
 
 	# Did not use qty_consumed_per_unit in the query, as it leads to rounding loss
 	query = """select
+				(Select idx from `tabBOM Item` where item_code = bom_item.item_code and parent = %(parent)s ) as idx,
 				bom_item.item_code,
 				item.item_name,
 				sum(bom_item.stock_qty/ifnull(bom.quantity, 1)) * %(qty)s as qty,
@@ -531,20 +532,21 @@ def get_bom_items_as_dict(bom, company, qty=1, fetch_exploded=1, fetch_scrap_ite
 				and item.name = bom_item.item_code
 				and is_stock_item = 1
 				{where_conditions}
-				group by item_code, stock_uom"""
+				group by item_code, stock_uom
+				order by idx"""
 
 	if fetch_exploded:
 		query = query.format(table="BOM Explosion Item",
 			where_conditions="""and item.is_sub_contracted_item = 0""",
 			select_columns = ", bom_item.source_warehouse")
-		items = frappe.db.sql(query, { "qty": qty,	"bom": bom }, as_dict=True)
+		items = frappe.db.sql(query, { "parent": bom, "qty": qty,	"bom": bom }, as_dict=True)
 	elif fetch_scrap_items:
 		query = query.format(table="BOM Scrap Item", where_conditions="", select_columns="")
-		items = frappe.db.sql(query, { "qty": qty, "bom": bom }, as_dict=True)
+		items = frappe.db.sql(query, { "parent": bom, "qty": qty, "bom": bom }, as_dict=True)
 	else:
 		query = query.format(table="BOM Item", where_conditions="",
 			select_columns = ", bom_item.source_warehouse")
-		items = frappe.db.sql(query, { "qty": qty, "bom": bom }, as_dict=True)
+		items = frappe.db.sql(query, { "parent": bom, "qty": qty, "bom": bom }, as_dict=True)
 
 	for item in items:
 		if item_dict.has_key(item.item_code):

--- a/erpnext/manufacturing/doctype/production_order/production_order.py
+++ b/erpnext/manufacturing/doctype/production_order/production_order.py
@@ -437,7 +437,7 @@ class ProductionOrder(Document):
 			item_dict = get_bom_items_as_dict(self.bom_no, self.company, qty=self.qty,
 				fetch_exploded = self.use_multi_level_bom)
 
-			for item in item_dict.values():
+			for item in sorted(item_dict.values(), key=lambda d: d['idx']):
 				self.append('required_items', {
 					'item_code': item.item_code,
 					'required_qty': item.qty,


### PR DESCRIPTION
In most of the Manufacturing companies, BOM Items in BOM Setup are arranged because of important reasons. When Production Order is done for a specific BOM, it currently don't follow the same arrangement in the setup. It would be best to have it set exactly like it for efficiency:

Suggested Feature:

**BOM Setup**

![bom 1](https://user-images.githubusercontent.com/21003054/30054697-7d753cf0-925f-11e7-86b3-a66d09c6d071.png)

**Production Order**

![prod 1](https://user-images.githubusercontent.com/21003054/30054711-8c2148ac-925f-11e7-80a5-89e92c2b1779.png)

