### PR TITLE
[fix] Production planning tool, unable to download material required report

### DIFF
--- a/erpnext/manufacturing/doctype/production_planning_tool/production_planning_tool.py
+++ b/erpnext/manufacturing/doctype/production_planning_tool/production_planning_tool.py
@@ -376,19 +376,20 @@ class ProductionPlanningTool(Document):
 				else:
 					bom_wise_item_details[d.item_code] = d
 
-			if include_sublevel:
+			if include_sublevel and d.default_bom:
 				if ((d.default_material_request_type == "Purchase" and d.is_sub_contracted and supply_subs)
 					or (d.default_material_request_type == "Manufacture")):
 
 					my_qty = 0
 					projected_qty = self.get_item_projected_qty(d.item_code)
-
 					if self.create_material_requests_for_all_required_qty:
 						my_qty = d.qty
-					elif (bom_wise_item_details[d.item_code].qty - d.qty) < projected_qty:
-						my_qty = bom_wise_item_details[d.item_code].qty - projected_qty
 					else:
-						my_qty = d.qty
+						total_required_qty = flt(bom_wise_item_details.get(d.item_code, frappe._dict()).qty)
+						if (total_required_qty - d.qty) < projected_qty:
+							my_qty = total_required_qty - projected_qty
+						else:
+							my_qty = d.qty
 
 					if my_qty > 0:
 						self.get_subitems(bom_wise_item_details,
@@ -483,14 +484,15 @@ class ProductionPlanningTool(Document):
 		return items_to_be_requested
 
 	def get_item_projected_qty(self,item):
+		conditions = ""
+		if self.purchase_request_for_warehouse:
+			conditions = " and warehouse='{0}'".format(frappe.db.escape(self.purchase_request_for_warehouse))
+
 		item_projected_qty = frappe.db.sql("""
 			select ifnull(sum(projected_qty),0) as qty
 			from `tabBin`
-			where item_code = %(item_code)s and warehouse=%(warehouse)s
-		""", {
-			"item_code": item,
-			"warehouse": self.purchase_request_for_warehouse
-		}, as_dict=1)
+			where item_code = %(item_code)s {conditions}
+		""".format(conditions=conditions), { "item_code": item }, as_dict=1)
 
 		return item_projected_qty[0].qty
 


### PR DESCRIPTION
Production planning tool, unable to download material required for the item which has default material request type is manufacture and only obtain raw materials is enabled in production planning tool.

![screen shot 2017-09-07 at 12 32 39 pm](https://user-images.githubusercontent.com/8780500/30150657-dd99cf0e-93c9-11e7-91ba-1a7b3a764d8e.png)

**Error traceback**

```
Traceback (most recent call last):
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/app.py", line 57, in application
    response = frappe.handler.handle()
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/handler.py", line 53, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/__init__.py", line 923, in call
    return fn(*args, **newargs)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/handler.py", line 81, in runserverobj
    frappe.desk.form.run_method.runserverobj(method, docs=docs, dt=dt, dn=dn, arg=arg, args=args)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/desk/form/run_method.py", line 36, in runserverobj
    r = doc.run_method(method)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/model/document.py", line 666, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/model/document.py", line 887, in composer
    return composed(self, method, *args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/model/document.py", line 870, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/model/document.py", line 660, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/erpnext/erpnext/manufacturing/doctype/production_planning_tool/production_planning_tool.py", line 307, in download_raw_materials
    self.get_raw_materials(bom_dict)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/erpnext/erpnext/manufacturing/doctype/production_planning_tool/production_planning_tool.py", line 337, in get_raw_materials
    self.use_multi_level_bom,self.only_raw_materials, self.include_subcontracted,non_stock_item)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/erpnext/erpnext/manufacturing/doctype/production_planning_tool/production_planning_tool.py", line 389, in get_subitems
    elif (bom_wise_item_details[d.item_code].qty - d.qty) < projected_qty:
KeyError: u'Assembly Item A'
```