### PR TITLE
[fix] Serial No has already been received error while making purchase receipt entry for the returned serial no

### DIFF
--- a/erpnext/stock/doctype/serial_no/serial_no.py
+++ b/erpnext/stock/doctype/serial_no/serial_no.py
@@ -240,7 +240,8 @@ def has_duplicate_serial_no(sn, sle):
 
 	status = False
 	if sn.purchase_document_no:
-		if sle.voucher_type in ['Purchase Receipt', 'Stock Entry']:
+		if sle.voucher_type in ['Purchase Receipt', 'Stock Entry'] and \
+			sn.delivery_document_type not in ['Purchase Receipt', 'Stock Entry']:
 			status = True
 
 		if status and sle.voucher_type == 'Stock Entry' and \


### PR DESCRIPTION
**Issue**

- Purchase Receipt (into ABC warehouse)

- Purchase Return (to Supplier)

- New Purchase Receipt (from Supplier into ABC warehouse) - The error pops up when trying to submit this

Fixed https://github.com/frappe/erpnext/issues/10721
