### PR TITLE
[fix] No module namd student_batch_name.student_batch_name error in the patch

### DIFF
--- a/erpnext/patches/v8_0/merge_student_batch_and_student_group.py
+++ b/erpnext/patches/v8_0/merge_student_batch_and_student_group.py
@@ -9,7 +9,8 @@ from frappe.model.mapper import get_mapped_doc
 
 def execute():
 	# for converting student batch into student group
-	for doctype in ["Student Group", "Student Group Student", "Student Group Instructor", "Student Attendance", "Student"]:
+	for doctype in ["Student Group", "Student Group Student",
+		"Student Group Instructor", "Student Attendance", "Student", "Student Batch Name"]:
 		frappe.reload_doc("schools", "doctype", frappe.scrub(doctype))
 
 	if frappe.db.table_exists("Student Batch"):


### PR DESCRIPTION
Issue
```
Executing erpnext.patches.v8_0.merge_student_batch_and_student_group in site1.local (1bd3e0294da19198)
Traceback (most recent call last):
File “/usr/lib/python2.7/runpy.py”, line 174, in _run_module_as_main
"main", fname, loader, pkg_name)
File “/usr/lib/python2.7/runpy.py”, line 72, in _run_code
exec code in run_globals
File “/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py”, line 94, in 
main()
File “/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py”, line 18, in main
click.Group(commands=commands)(prog_name=‘bench’)
File “/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py”, line 716, in call
return self.main(*args, **kwargs)
File “/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py”, line 696, in main
rv = self.invoke(ctx)
File “/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py”, line 1060, in invoke
return _process_result(sub_ctx.command.invoke(sub_ctx))
File “/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py”, line 1060, in invoke
return _process_result(sub_ctx.command.invoke(sub_ctx))
File “/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py”, line 889, in invoke
return ctx.invoke(self.callback, **ctx.params)
File “/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py”, line 534, in invoke
return callback(*args, **kwargs)
File “/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/decorators.py”, line 17, in new_func
return f(get_current_context(), *args, **kwargs)
File “/home/frappe/frappe-bench/apps/frappe/frappe/commands/init.py”, line 24, in _func
ret = f(frappe._dict(ctx.obj), *args, **kwargs)
File “/home/frappe/frappe-bench/apps/frappe/frappe/commands/site.py”, line 217, in migrate
migrate(context.verbose, rebuild_website=rebuild_website)
File “/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py”, line 31, in migrate
frappe.modules.patch_handler.run_all()
File “/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py”, line 29, in run_all
if not run_single(patchmodule = patch):
File “/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py”, line 63, in run_single
return execute_patch(patchmodule, method, methodargs)
File “/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py”, line 83, in execute_patch
frappe.get_attr(patchmodule.split()[0] + “.execute”)()
File “/home/frappe/frappe-bench/apps/erpnext/erpnext/patches/v8_0/merge_student_batch_and_student_group.py”, line 24, in execute
"batch_name": student_batch.get(“batch”)
File “/home/frappe/frappe-bench/apps/frappe/frappe/init.py”, line 622, in get_doc
return frappe.model.document.get_doc(arg1, arg2)
File “/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py”, line 49, in get_doc
controller = get_controller(doctype)
File “/home/frappe/frappe-bench/apps/frappe/frappe/model/base_document.py”, line 35, in get_controller
module = load_doctype_module(doctype, module_name)
File “/home/frappe/frappe-bench/apps/frappe/frappe/modules/utils.py”, line 185, in load_doctype_module
raise ImportError(‘Module import failed for {0} ({1})’.format(doctype, module_name + ’ Error: ’ + str(e)))
ImportError: Module import failed for Student Batch Name (frappe.core.doctype.student_batch_name.student_batch_name Error: No module named student_batch_name.student_batch_name)
azureuser@erpmaqtro:/home/frappe/frappe-bench$ ImportError: Module import failed for Student Batch Name (frappe.core.doctype.student_batch_name.student_batch_name Error: No module named student_batch_name.student_batch_name)

```