### PR TITLE
Delivery note to billing issue (#10726)

### DIFF
--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -227,21 +227,30 @@ def get_project_name(doctype, txt, searchfield, start, page_len, filters):
 				"_txt": txt.replace('%', '')
 			})
 
+
 def get_delivery_notes_to_be_billed(doctype, txt, searchfield, start, page_len, filters, as_dict):
 	return frappe.db.sql("""
 		select `tabDelivery Note`.name, `tabDelivery Note`.customer, `tabDelivery Note`.posting_date
 		from `tabDelivery Note`
 		where `tabDelivery Note`.`%(key)s` like %(txt)s and
-			`tabDelivery Note`.docstatus = 1 and `tabDelivery Note`.is_return = 0
+			`tabDelivery Note`.docstatus = 1
 			and status not in ("Stopped", "Closed") %(fcond)s
-			and (`tabDelivery Note`.per_billed < 100 or `tabDelivery Note`.grand_total = 0)
+			and (
+				`tabDelivery Note`.is_return = 0 and `tabDelivery Note`.per_billed < 100
+				or `tabDelivery Note`.grand_total = 0
+				or (
+					`tabDelivery Note`.is_return = 1
+					and return_against in (select name from `tabDelivery Note` where per_billed < 100)
+				)
+			)
 			%(mcond)s order by `tabDelivery Note`.`%(key)s` asc
 	""" % {
 		"key": searchfield,
 		"fcond": get_filters_cond(doctype, filters, []),
 		"mcond": get_match_cond(doctype),
 		"txt": "%(txt)s"
-	}, { "txt": ("%%%s%%" % txt) }, as_dict=as_dict)
+	}, {"txt": ("%%%s%%" % txt)}, as_dict=as_dict)
+
 
 def get_batch_no(doctype, txt, searchfield, start, page_len, filters):
 	cond = ""

--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -236,7 +236,7 @@ def get_delivery_notes_to_be_billed(doctype, txt, searchfield, start, page_len, 
 			`tabDelivery Note`.docstatus = 1
 			and status not in ("Stopped", "Closed") %(fcond)s
 			and (
-				`tabDelivery Note`.is_return = 0 and `tabDelivery Note`.per_billed < 100
+				(`tabDelivery Note`.is_return = 0 and `tabDelivery Note`.per_billed < 100)
 				or `tabDelivery Note`.grand_total = 0
 				or (
 					`tabDelivery Note`.is_return = 1


### PR DESCRIPTION
fixed #10726 
We need to allow users creating invoices from delivery notes to be able to create from sales returns. This PR would allow users select sales return DN where the original DN status is not completed.



![peek 2017-09-12 17-25](https://user-images.githubusercontent.com/818803/30364777-87fa3d7a-985d-11e7-9af2-2fe36eba82e2.gif)
