### PR TITLE
show error message if cannot get accounts details (#10680)

### DIFF
--- a/erpnext/accounts/report/financial_statements.py
+++ b/erpnext/accounts/report/financial_statements.py
@@ -142,10 +142,16 @@ def get_data(company, root_type, balance_must_be, period_list, filters=None,
 
 	return out
 
+
 def calculate_values(accounts_by_name, gl_entries_by_account, period_list, accumulated_values, ignore_accumulated_values_for_fy):
 	for entries in gl_entries_by_account.values():
 		for entry in entries:
 			d = accounts_by_name.get(entry.account)
+			if not d:
+				frappe.msgprint(
+					_("Could not retrieve information for {0}.".format(entry.account)), title="Error",
+					raise_exception=1
+				)
 			for period in period_list:
 				# check if posting date is within the period
 


### PR DESCRIPTION
```(python)
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2017-08-30/apps/frappe/frappe/app.py", line 57, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2017-08-30/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2017-08-30/apps/frappe/frappe/handler.py", line 53, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2017-08-30/apps/frappe/frappe/__init__.py", line 922, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2017-08-30/apps/frappe/frappe/desk/query_report.py", line 96, in run
    res = frappe.get_attr(method_name)(frappe._dict(filters))
  File "/home/frappe/benches/bench-2017-08-30/apps/erpnext/erpnext/accounts/report/balance_sheet/balance_sheet.py", line 16, in execute
    accumulated_values=filters.accumulated_values)
  File "/home/frappe/benches/bench-2017-08-30/apps/erpnext/erpnext/accounts/report/financial_statements.py", line 135, in get_data
    calculate_values(accounts_by_name, gl_entries_by_account, period_list, accumulated_values, ignore_accumulated_values_for_fy)
  File "/home/frappe/benches/bench-2017-08-30/apps/erpnext/erpnext/accounts/report/financial_statements.py", line 156, in calculate_values
    d[period.key] = d.get(period.key, 0.0) + flt(entry.debit) - flt(entry.credit)
AttributeError: 'NoneType' object has no attribute 'get'
```

This PR shows a message if the code branches into a case where `d` is `None` to make it clearer what might have gone wrong.

Fix #10680 