### PR TITLE
use generator when updating and notify user of long process

### DIFF
--- a/erpnext/setup/doctype/company/company.js
+++ b/erpnext/setup/doctype/company/company.js
@@ -111,8 +111,9 @@ cur_frm.cscript.change_abbr = function() {
 	dialog.fields_dict.update.$input.click(function() {
 		var args = dialog.get_values();
 		if(!args) return;
+		frappe.show_alert(__("Update in progress. It might take a while."));
 		return frappe.call({
-			method: "erpnext.setup.doctype.company.company.replace_abbr",
+			method: "erpnext.setup.doctype.company.company.enqueue_replace_abbr",
 			args: {
 				"company": cur_frm.doc.name,
 				"old": cur_frm.doc.abbr,

--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -282,6 +282,13 @@ class Company(Document):
 			where doctype='Global Defaults' and field='default_company'
 			and value=%s""", self.name)
 
+
+@frappe.whitelist()
+def enqueue_replace_abbr(company, old, new):
+	kwargs = dict(company=company, old=old, new=new)
+	frappe.enqueue('erpnext.setup.doctype.company.company.replace_abbr', **kwargs)
+
+
 @frappe.whitelist()
 def replace_abbr(company, old, new):
 	new = new.strip()
@@ -292,15 +299,21 @@ def replace_abbr(company, old, new):
 
 	frappe.db.set_value("Company", company, "abbr", new)
 
-	def _rename_record(dt):
-		for d in frappe.db.sql("select name from `tab%s` where company=%s" % (dt, '%s'), company):
-			parts = d[0].rsplit(" - ", 1)
-			if len(parts) == 1 or parts[1].lower() == old.lower():
-				frappe.rename_doc(dt, d[0], parts[0] + " - " + new)
+	def _rename_record(doc):
+		parts = doc[0].rsplit(" - ", 1)
+		if len(parts) == 1 or parts[1].lower() == old.lower():
+			frappe.rename_doc(dt, doc[0], parts[0] + " - " + new)
+
+	def _rename_records(dt):
+		# rename is expensive so let's be economical with memory usage
+		doc = (d for d in frappe.db.sql("select name from `tab%s` where company=%s" % (dt, '%s'), company))
+		for d in doc:
+			_rename_record(d)
 
 	for dt in ["Warehouse", "Account", "Cost Center"]:
-		_rename_record(dt)
+		_rename_records(dt)
 		frappe.db.commit()
+
 
 def get_name_with_abbr(name, company):
 	company_abbr = frappe.db.get_value("Company", company, "abbr")


### PR DESCRIPTION
Fix #10742 
This PR prevents using up memory by doing updates using a generator. Also, because of the expensive operations going on, the heavy lifting is pushed to the background.