### PR TITLE
[fix] Subscription patch

### DIFF
--- a/erpnext/patches/v8_7/make_subscription_from_recurring_data.py
+++ b/erpnext/patches/v8_7/make_subscription_from_recurring_data.py
@@ -18,7 +18,7 @@ def execute():
 			make_subscription(doctype, data)
 
 def get_data(doctype):
-	return frappe.db.sql(""" select name, from_date, end_date, recurring_type,recurring_id
+	return frappe.db.sql(""" select name, from_date, end_date, recurring_type,recurring_id,
 		next_date, notify_by_email, notification_email_address, recurring_print_format,
 		repeat_on_day_of_month, submit_on_creation
 		from `tab{0}` where is_recurring = 1 and next_date >= %s
@@ -40,6 +40,3 @@ def make_subscription(doctype, data):
 	}).insert(ignore_permissions=True)
 
 	doc.submit()
-
-	if not doc.subscription:
-		frappe.db.set_value(doctype, data.name, "subscription", doc.name)


### PR DESCRIPTION
**Issue**
```
Executing erpnext.patches.v8_7.make_subscription_from_recurring_data in localhots (29fa4bbbddf3ea71)
Traceback (most recent call last):
File “/usr/lib/python2.7/runpy.py”, line 174, in _run_module_as_main
"main", fname, loader, pkg_name)
File “/usr/lib/python2.7/runpy.py”, line 72, in _run_code
exec code in run_globals
File “/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py”, line 94, in 
main()
File “/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py”, line 18, in main
click.Group(commands=commands)(prog_name=‘bench’)
File “/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py”, line 722, in call
return self.main(*args, **kwargs)
File “/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py”, line 697, in main
rv = self.invoke(ctx)
File “/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py”, line 1066, in invoke
return _process_result(sub_ctx.command.invoke(sub_ctx))
File “/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py”, line 1066, in invoke
return _process_result(sub_ctx.command.invoke(sub_ctx))
File “/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py”, line 895, in invoke
return ctx.invoke(self.callback, **ctx.params)
File “/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py”, line 535, in invoke
return callback(*args, **kwargs)
File “/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/decorators.py”, line 17, in new_func
return f(get_current_context(), *args, **kwargs)
File “/home/frappe/frappe-bench/apps/frappe/frappe/commands/init.py”, line 24, in _func
ret = f(frappe._dict(ctx.obj), *args, **kwargs)
File “/home/frappe/frappe-bench/apps/frappe/frappe/commands/site.py”, line 217, in migrate
migrate(context.verbose, rebuild_website=rebuild_website)
File “/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py”, line 31, in migrate
frappe.modules.patch_handler.run_all()
File “/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py”, line 29, in run_all
if not run_single(patchmodule = patch):
File “/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py”, line 63, in run_single
return execute_patch(patchmodule, method, methodargs)
File “/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py”, line 83, in execute_patch
frappe.get_attr(patchmodule.split()[0] + “.execute”)()
File “/home/frappe/frappe-bench/apps/erpnext/erpnext/patches/v8_7/make_subscription_from_recurring_data.py”, line 18, in execute
make_subscription(doctype, data)
File “/home/frappe/frappe-bench/apps/erpnext/erpnext/patches/v8_7/make_subscription_from_recurring_data.py”, line 40, in make_subscription
}).insert(ignore_permissions=True)
File “/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py”, line 192, in insert
self.run_before_save_methods()
File “/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py”, line 777, in run_before_save_methods
self.run_method(“validate”)
File “/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py”, line 671, in run_method
out = Document.hook(fn)(self, *args, **kwargs)
File “/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py”, line 892, in composer
return composed(self, method, *args, **kwargs)
File “/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py”, line 875, in runner
add_to_return_value(self, fn(self, *args, **kwargs))
File “/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py”, line 665, in 
fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
File “/home/frappe/frappe-bench/apps/erpnext/erpnext/subscription/doctype/subscription/subscription.py”, line 20, in validate
self.validate_next_schedule_date()
File “/home/frappe/frappe-bench/apps/erpnext/erpnext/subscription/doctype/subscription/subscription.py”, line 39, in validate_next_schedule_date
next_date = getdate(self.next_schedule_date)
File “/home/frappe/frappe-bench/apps/frappe/frappe/utils/data.py”, line 41, in getdate
return parser.parse(string_date).date()
File “/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/dateutil/parser.py”, line 1182, in parse
return DEFAULTPARSER.parse(timestr, **kwargs)
File “/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/dateutil/parser.py”, line 559, in parse
raise ValueError(“Unknown string format”)
ValueError: Unknown string format
```

Fixed https://github.com/frappe/erpnext/issues/10824