### PR TITLE
Auto Reorder: Propagate projected_qty all the way to the root warehouse

### DIFF
--- a/erpnext/stock/reorder_item.py
+++ b/erpnext/stock/reorder_item.py
@@ -90,11 +90,12 @@ def get_item_warehouse_projected_qty(items_to_consider):
 		
 		warehouse_doc = frappe.get_doc("Warehouse", warehouse)
 		
-		if warehouse_doc.parent_warehouse:
+		while warehouse_doc.parent_warehouse:
 			if not item_warehouse_projected_qty.get(item_code, {}).get(warehouse_doc.parent_warehouse):
 				item_warehouse_projected_qty.setdefault(item_code, {})[warehouse_doc.parent_warehouse] = flt(projected_qty)
 			else:
 				item_warehouse_projected_qty[item_code][warehouse_doc.parent_warehouse] += flt(projected_qty)
+			warehouse_doc = frappe.get_doc("Warehouse", warehouse_doc.parent_warehouse)
 				
 	return item_warehouse_projected_qty
 


### PR DESCRIPTION
### Problem
"Check in (group)" in item auto reoder does only entail checking the group's immediate children warehouses for quantities of the item to be ordered. This is problematic if the user requires a more complex warehouse topology with deeper nested warehouses.

### Solution
Propagate projected_qty from the leaf warehouses ("no group") up to the root warehouse instead of just one level up.
This makes "Check in (group)" work for non-trivial warehouse topologies

For further info see https://discuss.erpnext.com/t/auto-reorder-check-in-group-does-not-check-children-warehouses/28270