### PR TITLE
[fix] User not able to complete the production order because of decimal issue

### DIFF
--- a/erpnext/manufacturing/doctype/production_order/production_order.js
+++ b/erpnext/manufacturing/doctype/production_order/production_order.js
@@ -346,6 +346,7 @@ erpnext.production_order = {
 			var max = flt(frm.doc.qty) - flt(frm.doc.produced_qty);
 		}
 
+		max = flt(max, precision("qty"));
 		frappe.prompt({fieldtype:"Float", label: __("Qty for {0}", [purpose]), fieldname:"qty",
 			description: __("Max: {0}", [max]), 'default': max },
 			function(data) {


### PR DESCRIPTION
User has created production order with qty 53,346
He has transferred 53,345 qty and produced 53,345 qty, while transferring remaining 0,001 qty system throwing an error "Quantity must not be more than 0.0009999999999976694"

![screen shot 2017-09-21 at 1 31 52 pm](https://user-images.githubusercontent.com/8780500/30685086-4bb35dcc-9ed1-11e7-8c13-47eace58994d.png)
![screen shot 2017-09-21 at 1 32 00 pm](https://user-images.githubusercontent.com/8780500/30685087-4bb517a2-9ed1-11e7-9092-30ec1248fefe.png)
