### PR TITLE
Fetching Document ID also in Email Subject while clicking "Send Supplier Emails" button

### DIFF
--- a/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
+++ b/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
@@ -138,7 +138,7 @@ class RequestforQuotation(BuyingController):
 			'user_fullname': full_name
 		}
 
-		subject = _("Request for Quotation")
+		subject = _("Request for Quotation: {0}".format(self.name))
 		template = "templates/emails/request_for_quotation.html"
 		sender = frappe.session.user not in STANDARD_USERS and frappe.session.user or None
 		message = frappe.get_template(template).render(args)


### PR DESCRIPTION
If we normally send email, it will fetch the document id in subject. But if we send email via "Send Supplier Emails" button it doesn't fetch currently. This code will solve that issue.