### PR TITLE
Properly redirect supplier after quotations submit

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -77,7 +77,7 @@ website_route_rules = [
 	{"from_route": "/supplier-quotations/<path:name>", "to_route": "order",
 		"defaults": {
 			"doctype": "Supplier Quotation",
-			"parents": [{"label": _("Supplier Quotation"), "route": "quotations"}]
+			"parents": [{"label": _("Supplier Quotation"), "route": "supplier-quotations"}]
 		}
 	},
 	{"from_route": "/quotations", "to_route": "Quotation"},

--- a/erpnext/templates/includes/rfq.js
+++ b/erpnext/templates/includes/rfq.js
@@ -85,7 +85,7 @@ rfq = Class.extend({
 					frappe.unfreeze();
 					if(r.message){
 						$('.btn-sm').hide()
-						window.location.href = "/quotations/" + encodeURIComponent(r.message);
+						window.location.href = "/supplier-quotations/" + encodeURIComponent(r.message);
 					}
 				}
 			})


### PR DESCRIPTION
As it is now, suppliers responding to RFQ, after submitting are redirected to an error page. The supplier will think the quote has not been submitted and raise an alarm.

![supplier_redirect_error](https://user-images.githubusercontent.com/17238907/30868047-78f18856-a2d5-11e7-8b2e-3935b4321edc.png)

This redirects them to the submitted quote.