### PR TITLE
install company fixtures while creating company

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -27,7 +27,6 @@ doctype_js = {
 # setup wizard
 setup_wizard_requires = "assets/erpnext/js/setup_wizard.js"
 setup_wizard_complete = "erpnext.setup.setup_wizard.setup_wizard.setup_complete"
-setup_wizard_success = "erpnext.setup.setup_wizard.setup_wizard.setup_success"
 setup_wizard_test = "erpnext.setup.setup_wizard.test_setup_wizard.run_setup_wizard_test"
 
 before_install = "erpnext.setup.install.check_setup_wizard_not_completed"

--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -75,11 +75,7 @@ class Company(Document):
 			if not frappe.local.flags.ignore_chart_of_accounts:
 				self.create_default_accounts()
 				self.create_default_warehouses()
-
-				if cint(frappe.db.get_single_value('System Settings', 'setup_complete')):
-					# In the case of setup, fixtures should be installed after setup_success
-					# This also prevents db commits before setup is successful
-					install_country_fixtures(self.name)
+				install_country_fixtures(self.name)
 
 		if not frappe.db.get_value("Cost Center", {"is_group": 0, "company": self.name}):
 			self.create_default_cost_center()

--- a/erpnext/setup/setup_wizard/setup_wizard.py
+++ b/erpnext/setup/setup_wizard/setup_wizard.py
@@ -66,10 +66,6 @@ def setup_complete(args=None):
 
 		pass
 
-def setup_success(args=None):
-	company = frappe.db.sql("select name from tabCompany", as_dict=True)[0]["name"]
-	install_country_fixtures(company)
-
 def create_fiscal_year_and_company(args):
 	if (args.get('fy_start_date')):
 		curr_fiscal_year = get_fy_details(args.get('fy_start_date'), args.get('fy_end_date'))


### PR DESCRIPTION
Basically reverting back to creating country fixtures while creating company, now that frappe.db.commit has been removed from https://github.com/frappe/erpnext/blob/develop/erpnext/regional/india/setup.py ,in case the user creates second company based on India fixtures.