### PR TITLE
[fix] batch qty checked against stock_qty field

### DIFF
--- a/erpnext/stock/doctype/batch/batch.py
+++ b/erpnext/stock/doctype/batch/batch.py
@@ -105,12 +105,12 @@ def set_batch_nos(doc, warehouse_field, throw = False):
 	for d in doc.items:
 		has_batch_no = frappe.db.get_value('Item', d.item_code, 'has_batch_no')
 		warehouse = d.get(warehouse_field, None)
-		if has_batch_no and warehouse and d.qty > 0:
+		if has_batch_no and warehouse and d.stock_qty > 0:
 			if not d.batch_no:
-				d.batch_no = get_batch_no(d.item_code, warehouse, d.qty, throw)
+				d.batch_no = get_batch_no(d.item_code, warehouse, d.stock_qty, throw)
 			else:
 				batch_qty = get_batch_qty(batch_no=d.batch_no, warehouse=warehouse)
-				if flt(batch_qty) < flt(d.qty):
+				if flt(batch_qty) < flt(d.stock_qty):
 					frappe.throw(_("Row #{0}: The batch {1} has only {2} qty. Please select another batch which has {3} qty available or split the row into multiple rows, to deliver/issue from multiple batches").format(d.idx, d.batch_no, batch_qty, d.qty))
 
 def get_batch_no(item_code, warehouse, qty, throw=False):


### PR DESCRIPTION
Raised via support: https://frappe.erpnext.com/desk#Form/Issue/WN-SUP28074

Batch quantity validations should be checked against the calculated stock_qty(which takes into consideration conversion factor multiplying it by qty), and not by the raw qty.