### PR TITLE
Tests for payment entry against purchase invoice

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/tests/test_payment_against_purchase_invoice.js
+++ b/erpnext/accounts/doctype/payment_entry/tests/test_payment_against_purchase_invoice.js
@@ -1,0 +1,60 @@
+QUnit.module('Payment Entry');
+
+QUnit.test("test payment entry", function(assert) {
+	assert.expect(7	);
+	let done = assert.async();
+
+	frappe.run_serially([
+		() => {
+			return frappe.tests.make('Purchase Invoice', [
+				{supplier: 'Test Supplier'},
+				{bill_no: 'in1234'},
+				{items: [
+					[
+						{'qty': 2},
+						{'item_code': 'Test Product 1'},
+						{'rate':1000},
+					]
+				]},
+				{update_stock:1},
+				{supplier_address: 'Test1-Billing'},
+				{contact_person: 'Contact 3-Test Supplier'},
+				{tc_name: 'Test Term 1'},
+				{terms: 'This is just a Test'}
+			]);
+		},
+
+		() => cur_frm.save(),
+		() => frappe.tests.click_button('Submit'),
+		() => frappe.tests.click_button('Yes'),
+		() => frappe.timeout(1),
+		() => frappe.click_button('Make'),
+		() => frappe.timeout(2),
+		() => frappe.click_link('Payment'),
+		() => frappe.timeout(3),
+		() => cur_frm.set_value('mode_of_payment','Cash'),
+		() => frappe.timeout(3),
+		() => {
+			assert.equal(frappe.get_route()[1], 'Payment Entry',
+				'made payment entry');
+			assert.equal(cur_frm.doc.party, 'Test Supplier',
+				'supplier set in payment entry');
+			assert.equal(cur_frm.doc.paid_amount, 2000,
+				'paid amount set in payment entry');
+			assert.equal(cur_frm.doc.references[0].allocated_amount, 2000,
+				'amount allocated against purchase invoice');
+			assert.equal(cur_frm.doc.references[0].bill_no, 'in1234',
+				'invoice number allocated against purchase invoice');
+			assert.equal(cur_frm.get_field('total_allocated_amount').value, 2000,
+				'correct amount allocated in Write Off');
+			assert.equal(cur_frm.get_field('unallocated_amount').value, 0,
+				'correct amount unallocated in Write Off');
+		},
+
+		() => cur_frm.save(),
+		() => frappe.tests.click_button('Submit'),
+		() => frappe.tests.click_button('Yes'),
+		() => frappe.timeout(3),
+		() => done()
+	]);
+});

--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.js
@@ -7,6 +7,7 @@ QUnit.test("test purchase invoice", function(assert) {
 		() => {
 			return frappe.tests.make('Purchase Invoice', [
 				{supplier: 'Test Supplier'},
+				{bill_no: 'in123'},
 				{items: [
 					[
 						{'qty': 5},
@@ -36,7 +37,7 @@ QUnit.test("test purchase invoice", function(assert) {
 		},
 		() => frappe.tests.click_button('Submit'),
 		() => frappe.tests.click_button('Yes'),
-		() => frappe.timeout(0.3),
+		() => frappe.timeout(1),
 		() => done()
 	]);
 });

--- a/erpnext/tests/ui/tests.txt
+++ b/erpnext/tests/ui/tests.txt
@@ -86,6 +86,7 @@ erpnext/accounts/doctype/sales_invoice/tests/test_sales_invoice.js
 erpnext/accounts/doctype/sales_invoice/tests/test_sales_invoice_with_payment.js
 erpnext/accounts/doctype/sales_invoice/tests/test_sales_invoice_with_payment_request.js
 erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.js
+erpnext/accounts/doctype/payment_entry/tests/test_payment_against_purchase_invoice.js
 erpnext/buying/doctype/supplier_quotation/tests/test_supplier_quotation_for_item_wise_discount.js
 erpnext/buying/doctype/purchase_order/tests/test_purchase_order.js
 erpnext/buying/doctype/purchase_order/tests/test_purchase_order_with_multi_uom.js


### PR DESCRIPTION
To check if the supplier invoice number is correctly mapped in payment entry. 