### PR TITLE
[fix] 'NoneType' object is not iterable while saving quotation

### DIFF
--- a/erpnext/accounts/doctype/tax_rule/tax_rule.py
+++ b/erpnext/accounts/doctype/tax_rule/tax_rule.py
@@ -8,6 +8,7 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.utils import cstr, cint
 from frappe.contacts.doctype.address.address import get_default_address
+from frappe.utils.nestedset import get_root_of
 from erpnext.setup.doctype.customer_group.customer_group import get_parent_customer_groups
 
 class IncorrectCustomerGroup(frappe.ValidationError): pass
@@ -136,7 +137,7 @@ def get_tax_template(posting_date, args):
 		if key=="use_for_shopping_cart":
 			conditions.append("use_for_shopping_cart = {0}".format(1 if value else 0))
 		if key == 'customer_group':
-			if not value: value = _("All Customer Groups")
+			if not value: value = get_root_of("Customer Group")
 			customer_group_condition = get_customer_group_condition(value)
 			conditions.append("ifnull({0}, '') in ('', {1})".format(key, customer_group_condition))
 		else:


### PR DESCRIPTION
**Issue while saving quotation**
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2017-09-27/apps/frappe/frappe/app.py", line 57, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2017-09-27/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2017-09-27/apps/frappe/frappe/handler.py", line 53, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2017-09-27/apps/frappe/frappe/__init__.py", line 923, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2017-09-27/apps/frappe/frappe/desk/form/save.py", line 22, in savedocs
    doc.save()
  File "/home/frappe/benches/bench-2017-09-27/apps/frappe/frappe/model/document.py", line 230, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-2017-09-27/apps/frappe/frappe/model/document.py", line 253, in _save
    self.insert()
  File "/home/frappe/benches/bench-2017-09-27/apps/frappe/frappe/model/document.py", line 192, in insert
    self.run_before_save_methods()
  File "/home/frappe/benches/bench-2017-09-27/apps/frappe/frappe/model/document.py", line 777, in run_before_save_methods
    self.run_method("validate")
  File "/home/frappe/benches/bench-2017-09-27/apps/frappe/frappe/model/document.py", line 671, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-2017-09-27/apps/frappe/frappe/model/document.py", line 892, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-2017-09-27/apps/frappe/frappe/model/document.py", line 875, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-2017-09-27/apps/frappe/frappe/model/document.py", line 665, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-2017-09-27/apps/erpnext/erpnext/selling/doctype/quotation/quotation.py", line 26, in validate
    super(Quotation, self).validate()
  File "/home/frappe/benches/bench-2017-09-27/apps/erpnext/erpnext/controllers/selling_controller.py", line 35, in validate
    super(SellingController, self).validate()
  File "/home/frappe/benches/bench-2017-09-27/apps/erpnext/erpnext/controllers/stock_controller.py", line 17, in validate
    super(StockController, self).validate()
  File "/home/frappe/benches/bench-2017-09-27/apps/erpnext/erpnext/controllers/accounts_controller.py", line 33, in validate
    self.set_missing_values(for_validate=True)
  File "/home/frappe/benches/bench-2017-09-27/apps/erpnext/erpnext/controllers/selling_controller.py", line 45, in set_missing_values
    self.set_missing_lead_customer_details()
  File "/home/frappe/benches/bench-2017-09-27/apps/erpnext/erpnext/controllers/selling_controller.py", line 63, in set_missing_lead_customer_details
    company=self.company))
  File "/home/frappe/benches/bench-2017-09-27/apps/erpnext/erpnext/crm/doctype/lead/lead.py", line 185, in get_lead_details
    billing_address=out.get('customer_address'), shipping_address=out.get('shipping_address_name'))
  File "/home/frappe/benches/bench-2017-09-27/apps/erpnext/erpnext/accounts/party.py", line 346, in set_taxes
    return get_tax_template(posting_date, args)
  File "/home/frappe/benches/bench-2017-09-27/apps/erpnext/erpnext/accounts/doctype/tax_rule/tax_rule.py", line 140, in get_tax_template
    customer_group_condition = get_customer_group_condition(value)
  File "/home/frappe/benches/bench-2017-09-27/apps/erpnext/erpnext/accounts/doctype/tax_rule/tax_rule.py", line 168, in get_customer_group_condition
    customer_groups = ["'%s'"%(frappe.db.escape(d.name)) for d in get_parent_customer_groups(customer_group)]
  File "/home/frappe/benches/bench-2017-09-27/apps/erpnext/erpnext/setup/doctype/customer_group/customer_group.py", line 23, in get_parent_customer_groups
    lft, rgt = frappe.db.get_value("Customer Group", customer_group, ['lft', 'rgt'])
TypeError: 'NoneType' object is not iterable
```