### PR TITLE
[fix] Non working hours of workstation added into the timesheet scheduling on submission of production order.

### DIFF
--- a/erpnext/manufacturing/doctype/workstation/workstation.py
+++ b/erpnext/manufacturing/doctype/workstation/workstation.py
@@ -52,9 +52,6 @@ def check_if_within_operating_hours(workstation, operation, from_datetime, to_da
 		if not cint(frappe.db.get_value("Manufacturing Settings", "None", "allow_production_on_holidays")):
 			check_workstation_for_holiday(workstation, from_datetime, to_datetime)
 
-		if not cint(frappe.db.get_value("Manufacturing Settings", None, "allow_overtime")):
-			is_within_operating_hours(workstation, operation, from_datetime, to_datetime)
-
 def is_within_operating_hours(workstation, operation, from_datetime, to_datetime):
 	operation_length = time_diff_in_seconds(to_datetime, from_datetime)
 	workstation = frappe.get_doc("Workstation", workstation)
@@ -82,3 +79,4 @@ def check_workstation_for_holiday(workstation, from_datetime, to_datetime):
 		if applicable_holidays:
 			frappe.throw(_("Workstation is closed on the following dates as per Holiday List: {0}")
 				.format(holiday_list) + "\n" + "\n".join(applicable_holidays), WorkstationHolidayError)
+


### PR DESCRIPTION
**Issue**
We can add working hours for a work station but when a time sheet is created for a workstation after production order it considers non working house as working hours.
<img width="1005" alt="workstation_timings" src="https://user-images.githubusercontent.com/8780500/30914862-9fbd8d30-a3b2-11e7-9232-52fa8fdd5b62.png">

Showing non working hours in the timesheet
<img width="1017" alt="timesheet_issue" src="https://user-images.githubusercontent.com/8780500/30914890-b1d10204-a3b2-11e7-981e-fa126f5f2b44.png">
Fixed https://github.com/frappe/erpnext/issues/10845
fixed https://github.com/frappe/erpnext/issues/3917