### PR TITLE
Exchange Rate Error (#10913)

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -378,7 +378,8 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 			if(me.frm.doc.company && me.frm.fields_dict.currency) {
 				var company_currency = me.get_company_currency();
 				var company_doc = frappe.get_doc(":Company", me.frm.doc.company);
-				if (!me.frm.doc.currency) {
+
+				if (!me.frm.doc.currency || me.frm.doc.currency != company_currency) {
 					me.frm.set_value("currency", company_currency);
 				}
 


### PR DESCRIPTION
Fixed #10913. The error message is no longer shown and the currency is correctly set.