### PR TITLE
Item Price track_changes default to 1

### DIFF
--- a/erpnext/stock/doctype/item_price/item_price.json
+++ b/erpnext/stock/doctype/item_price/item_price.json
@@ -1,5 +1,5 @@
 {
- "allow_copy": 0, 
+ "allow_copy": 0,
  "allow_import": 1, 
  "allow_rename": 0, 
  "autoname": "ITEM-PRICE-.#####", 
@@ -165,7 +165,7 @@
    "hidden": 0, 
    "ignore_user_permissions": 0, 
    "ignore_xss_filter": 0, 
-   "in_filter": 0, 
+   "in_filter": 0,
    "in_list_view": 0, 
    "in_standard_filter": 0, 
    "label": "", 
@@ -357,19 +357,19 @@
    "set_only_once": 0, 
    "unique": 0
   }
- ], 
+ ],
  "hide_heading": 0, 
  "hide_toolbar": 0, 
  "icon": "fa fa-flag", 
  "idx": 1, 
  "image_view": 0, 
  "in_create": 0, 
- "in_dialog": 0, 
- "is_submittable": 0, 
+ "in_dialog": 0,
+ "is_submittable": 0,
  "issingle": 0, 
  "istable": 0, 
  "max_attachments": 0, 
- "modified": "2017-02-20 13:27:23.896148", 
+ "modified": "2017-09-28 03:56:20.814993", 
  "modified_by": "Administrator", 
  "module": "Stock", 
  "name": "Item Price", 
@@ -422,6 +422,6 @@
  "show_name_in_global_search": 0, 
  "sort_order": "ASC", 
  "title_field": "item_code", 
- "track_changes": 0, 
+ "track_changes": 1, 
  "track_seen": 0
 }


### PR DESCRIPTION
Item Price Track Changes should be On by default, so that document change history is recorded.

![screenshot from 2017-09-28 15 59 58](https://user-images.githubusercontent.com/9530991/30955421-2c2d8ec4-a466-11e7-8bef-dd00e4b45741.png)
