### PR TITLE
GST section under Accounts should be visible only if country is India, other countries do not need it (#10960)

### DIFF
--- a/erpnext/config/accounts.py
+++ b/erpnext/config/accounts.py
@@ -4,7 +4,13 @@ import frappe
 from frappe import _
 
 
-def get_data():
+def get_data(**kwargs):
+	"""
+	Returns the data to be displayed in a modules page.
+
+	:param kwargs: Parameters to be supplied into `frappe.get_list`. **kwargs was added to make testing easier.
+	:return: List of dict
+	"""
 
 	# Seperate data for GST so that we can maintain the order of display
 	GST_DATA = {
@@ -496,7 +502,10 @@ def get_data():
 	]
 
 	# If there is no Company with country == India, remove GST_DATA from data
-	india_coy = frappe.get_list('Company', fields=['name'], filters={'country': 'India'})
+	if kwargs:
+		india_coy = frappe.get_list(**kwargs)
+	else:
+		india_coy = frappe.get_list('Company', fields=['name'], filters={'country': 'India'})
 	if not india_coy:
 		data.remove(GST_DATA)
 

--- a/erpnext/config/accounts.py
+++ b/erpnext/config/accounts.py
@@ -1,8 +1,47 @@
 from __future__ import unicode_literals
+
+import frappe
 from frappe import _
 
+
 def get_data():
-	return [
+
+	# Seperate data for GST so that we can maintain the order of display
+	GST_DATA = {
+			"label": _("Goods and Services Tax (GST India)"),
+			"items": [
+				{
+					"type": "doctype",
+					"name": "GST Settings",
+				},
+				{
+					"type": "doctype",
+					"name": "GST HSN Code",
+				},
+				{
+					"type": "report",
+					"name": "GST Sales Register",
+					"is_query_report": True
+				},
+				{
+					"type": "report",
+					"name": "GST Purchase Register",
+					"is_query_report": True
+				},
+				{
+					"type": "report",
+					"name": "GST Itemised Sales Register",
+					"is_query_report": True
+				},
+				{
+					"type": "report",
+					"name": "GST Itemised Purchase Register",
+					"is_query_report": True
+				},
+			]
+		}
+
+	data = [
 		{
 			"label": _("Billing"),
 			"items": [
@@ -204,39 +243,7 @@ def get_data():
 				},
 			]
 		},
-		{
-			"label": _("Goods and Services Tax (GST India)"),
-			"items": [
-				{
-					"type": "doctype",
-					"name": "GST Settings",
-				},
-				{
-					"type": "doctype",
-					"name": "GST HSN Code",
-				},
-				{
-					"type": "report",
-					"name": "GST Sales Register",
-					"is_query_report": True
-				},
-				{
-					"type": "report",
-					"name": "GST Purchase Register",
-					"is_query_report": True
-				},
-				{
-					"type": "report",
-					"name": "GST Itemised Sales Register",
-					"is_query_report": True
-				},
-				{
-					"type": "report",
-					"name": "GST Itemised Purchase Register",
-					"is_query_report": True
-				},
-			]
-		},
+		GST_DATA,
 		{
 			"label": _("Budget and Cost Center"),
 			"items": [
@@ -487,3 +494,10 @@ def get_data():
 			]
 		}
 	]
+
+	# If there is no Company with country == India, remove GST_DATA from data
+	india_coy = frappe.get_list('Company', fields=['name'], filters={'country': 'India'})
+	if not india_coy:
+		data.remove(GST_DATA)
+
+	return data

--- a/erpnext/config/tests/test_accounts.py
+++ b/erpnext/config/tests/test_accounts.py
@@ -1,0 +1,507 @@
+import unittest
+
+from erpnext.config.accounts import get_data
+from frappe import _
+
+test_dependencies = ['Company']
+
+
+class TestAccountsConfig(unittest.TestCase):
+	def test_remove_gst_data(self):
+		GST_DATA = {
+			"label": _("Goods and Services Tax (GST India)"),
+			"items": [
+				{
+					"type": "doctype",
+					"name": "GST Settings",
+				},
+				{
+					"type": "doctype",
+					"name": "GST HSN Code",
+				},
+				{
+					"type": "report",
+					"name": "GST Sales Register",
+					"is_query_report": True
+				},
+				{
+					"type": "report",
+					"name": "GST Purchase Register",
+					"is_query_report": True
+				},
+				{
+					"type": "report",
+					"name": "GST Itemised Sales Register",
+					"is_query_report": True
+				},
+				{
+					"type": "report",
+					"name": "GST Itemised Purchase Register",
+					"is_query_report": True
+				},
+			]
+		}
+
+		DATA = [
+			{
+				"label": _("Billing"),
+				"items": [
+					{
+						"type": "doctype",
+						"name": "Sales Invoice",
+						"description": _("Bills raised to Customers.")
+					},
+					{
+						"type": "doctype",
+						"name": "Purchase Invoice",
+						"description": _("Bills raised by Suppliers.")
+					},
+					{
+						"type": "doctype",
+						"name": "Payment Request",
+						"description": _("Payment Request")
+					},
+					{
+						"type": "doctype",
+						"name": "Payment Entry",
+						"description": _("Bank/Cash transactions against party or for internal transfer")
+					},
+					{
+						"type": "page",
+						"name": "pos",
+						"label": _("POS"),
+						"description": _("Point of Sale")
+					},
+					{
+						"type": "doctype",
+						"name": "Subscription",
+						"label": _("Subscription"),
+						"description": _("To make recurring documents")
+					},
+					{
+						"type": "report",
+						"name": "Accounts Receivable",
+						"doctype": "Sales Invoice",
+						"is_query_report": True
+					},
+					{
+						"type": "report",
+						"name": "Accounts Payable",
+						"doctype": "Purchase Invoice",
+						"is_query_report": True
+					},
+				]
+
+			},
+			{
+				"label": _("Company and Accounts"),
+				"items": [
+					{
+						"type": "doctype",
+						"name": "Company",
+						"description": _("Company (not Customer or Supplier) master.")
+					},
+					{
+						"type": "doctype",
+						"name": "Journal Entry",
+						"description": _("Accounting journal entries.")
+					},
+					{
+						"type": "doctype",
+						"name": "Account",
+						"icon": "fa fa-sitemap",
+						"label": _("Chart of Accounts"),
+						"route": "Tree/Account",
+						"description": _("Tree of financial accounts."),
+					},
+					{
+						"type": "report",
+						"name": "General Ledger",
+						"doctype": "GL Entry",
+						"is_query_report": True,
+					},
+				]
+			},
+			{
+				"label": _("Masters"),
+				"items": [
+					{
+						"type": "doctype",
+						"name": "Customer",
+						"description": _("Customer database.")
+					},
+					{
+						"type": "doctype",
+						"name": "Supplier",
+						"description": _("Supplier database.")
+					},
+					{
+						"type": "doctype",
+						"name": "Item",
+					},
+					{
+						"type": "doctype",
+						"name": "Asset",
+					},
+					{
+						"type": "doctype",
+						"name": "Asset Category",
+					}
+				]
+			},
+			{
+				"label": _("Accounting Statements"),
+				"items": [
+					{
+						"type": "report",
+						"name": "Trial Balance",
+						"doctype": "GL Entry",
+						"is_query_report": True,
+					},
+					{
+						"type": "report",
+						"name": "Balance Sheet",
+						"doctype": "GL Entry",
+						"is_query_report": True
+					},
+					{
+						"type": "report",
+						"name": "Cash Flow",
+						"doctype": "GL Entry",
+						"is_query_report": True
+					},
+					{
+						"type": "report",
+						"name": "Profit and Loss Statement",
+						"doctype": "GL Entry",
+						"is_query_report": True
+					},
+				]
+			},
+			{
+				"label": _("Banking and Payments"),
+				"items": [
+					{
+						"type": "doctype",
+						"label": _("Update Bank Transaction Dates"),
+						"name": "Bank Reconciliation",
+						"description": _("Update bank payment dates with journals.")
+					},
+					{
+						"type": "doctype",
+						"label": _("Match Payments with Invoices"),
+						"name": "Payment Reconciliation",
+						"description": _("Match non-linked Invoices and Payments.")
+					},
+					{
+						"type": "report",
+						"name": "Bank Reconciliation Statement",
+						"is_query_report": True,
+						"doctype": "Journal Entry"
+					},
+					{
+						"type": "report",
+						"name": "Bank Clearance Summary",
+						"is_query_report": True,
+						"doctype": "Journal Entry"
+					},
+					{
+						"type": "doctype",
+						"name": "Bank Guarantee",
+						"doctype": "Bank Guarantee"
+					},
+				]
+			},
+			{
+				"label": _("Taxes"),
+				"items": [
+					{
+						"type": "doctype",
+						"name": "Sales Taxes and Charges Template",
+						"description": _("Tax template for selling transactions.")
+					},
+					{
+						"type": "doctype",
+						"name": "Purchase Taxes and Charges Template",
+						"description": _("Tax template for buying transactions.")
+					},
+					{
+						"type": "doctype",
+						"name": "Tax Rule",
+						"description": _("Tax Rule for transactions.")
+					},
+					{
+						"type": "report",
+						"name": "Sales Register",
+						"doctype": "Sales Invoice",
+						"is_query_report": True
+					},
+					{
+						"type": "report",
+						"name": "Purchase Register",
+						"doctype": "Purchase Invoice",
+						"is_query_report": True
+					},
+				]
+			},
+			GST_DATA,
+			{
+				"label": _("Budget and Cost Center"),
+				"items": [
+					{
+						"type": "doctype",
+						"name": "Cost Center",
+						"icon": "fa fa-sitemap",
+						"label": _("Chart of Cost Centers"),
+						"route": "Tree/Cost Center",
+						"description": _("Tree of financial Cost Centers."),
+					},
+					{
+						"type": "doctype",
+						"name": "Budget",
+						"description": _("Define budget for a financial year.")
+					},
+					{
+						"type": "report",
+						"name": "Budget Variance Report",
+						"is_query_report": True,
+						"doctype": "Cost Center"
+					},
+					{
+						"type": "doctype",
+						"name": "Monthly Distribution",
+						"description": _("Seasonality for setting budgets, targets etc.")
+					},
+				]
+			},
+			{
+				"label": _("Tools"),
+				"items": [
+					{
+						"type": "doctype",
+						"name": "Period Closing Voucher",
+						"description": _("Close Balance Sheet and book Profit or Loss.")
+					},
+					{
+						"type": "doctype",
+						"name": "Asset Movement",
+						"description": _("Transfer an asset from one warehouse to another")
+					},
+					{
+						"type": "doctype",
+						"name": "Cheque Print Template",
+						"description": _("Setup cheque dimensions for printing")
+					},
+				]
+			},
+			{
+				"label": _("Setup"),
+				"icon": "fa fa-cog",
+				"items": [
+					{
+						"type": "doctype",
+						"name": "Accounts Settings",
+						"description": _("Default settings for accounting transactions.")
+					},
+					{
+						"type": "doctype",
+						"name": "Fiscal Year",
+						"description": _("Financial / accounting year.")
+					},
+					{
+						"type": "doctype",
+						"name": "Currency",
+						"description": _("Enable / disable currencies.")
+					},
+					{
+						"type": "doctype",
+						"name": "Currency Exchange",
+						"description": _("Currency exchange rate master.")
+					},
+					{
+						"type": "doctype",
+						"name": "Payment Gateway Account",
+						"description": _("Setup Gateway accounts.")
+					},
+					{
+						"type": "doctype",
+						"name": "POS Profile",
+						"label": _("Point-of-Sale Profile"),
+						"description": _("Rules to calculate shipping amount for a sale")
+					},
+					{
+						"type": "doctype",
+						"name": "Terms and Conditions",
+						"label": _("Terms and Conditions Template"),
+						"description": _("Template of terms or contract.")
+					},
+					{
+						"type": "doctype",
+						"name": "Mode of Payment",
+						"description": _("e.g. Bank, Cash, Credit Card")
+					},
+					{
+						"type": "doctype",
+						"name": "C-Form",
+						"description": _("C-Form records"),
+						"country": "India"
+					}
+				]
+			},
+			{
+				"label": _("To Bill"),
+				"items": [
+					{
+						"type": "report",
+						"name": "Ordered Items To Be Billed",
+						"is_query_report": True,
+						"doctype": "Sales Invoice"
+					},
+					{
+						"type": "report",
+						"name": "Delivered Items To Be Billed",
+						"is_query_report": True,
+						"doctype": "Sales Invoice"
+					},
+					{
+						"type": "report",
+						"name": "Purchase Order Items To Be Billed",
+						"is_query_report": True,
+						"doctype": "Purchase Invoice"
+					},
+					{
+						"type": "report",
+						"name": "Received Items To Be Billed",
+						"is_query_report": True,
+						"doctype": "Purchase Invoice"
+					},
+				]
+
+			},
+			{
+				"label": _("Analytics"),
+				"items": [
+					{
+						"type": "report",
+						"name": "Gross Profit",
+						"doctype": "Sales Invoice",
+						"is_query_report": True
+					},
+					{
+						"type": "report",
+						"name": "Purchase Invoice Trends",
+						"is_query_report": True,
+						"doctype": "Purchase Invoice"
+					},
+					{
+						"type": "report",
+						"name": "Sales Invoice Trends",
+						"is_query_report": True,
+						"doctype": "Sales Invoice"
+					},
+				]
+			},
+			{
+				"label": _("Other Reports"),
+				"icon": "fa fa-table",
+				"items": [
+					{
+						"type": "report",
+						"name": "Asset Depreciation Ledger",
+						"doctype": "Asset",
+						"is_query_report": True,
+					},
+					{
+						"type": "report",
+						"name": "Asset Depreciations and Balances",
+						"doctype": "Asset",
+						"is_query_report": True,
+					},
+					{
+						"type": "report",
+						"name": "Trial Balance for Party",
+						"doctype": "GL Entry",
+						"is_query_report": True,
+					},
+					{
+						"type": "report",
+						"name": "Profitability Analysis",
+						"doctype": "GL Entry",
+						"is_query_report": True,
+					},
+					{
+						"type": "report",
+						"name": "Payment Period Based On Invoice Date",
+						"is_query_report": True,
+						"doctype": "Journal Entry"
+					},
+					{
+						"type": "report",
+						"name": "Sales Partners Commission",
+						"is_query_report": True,
+						"doctype": "Sales Invoice"
+					},
+					{
+						"type": "report",
+						"name": "Item-wise Sales Register",
+						"is_query_report": True,
+						"doctype": "Sales Invoice"
+					},
+					{
+						"type": "report",
+						"name": "Item-wise Purchase Register",
+						"is_query_report": True,
+						"doctype": "Purchase Invoice"
+					},
+					{
+						"type": "report",
+						"name": "Accounts Receivable Summary",
+						"doctype": "Sales Invoice",
+						"is_query_report": True
+					},
+					{
+						"type": "report",
+						"name": "Accounts Payable Summary",
+						"doctype": "Purchase Invoice",
+						"is_query_report": True
+					},
+					{
+						"type": "report",
+						"is_query_report": True,
+						"name": "Customer Credit Balance",
+						"doctype": "Customer"
+					},
+				]
+			},
+			{
+				"label": _("Help"),
+				"icon": "fa fa-facetime-video",
+				"items": [
+					{
+						"type": "help",
+						"label": _("Chart of Accounts"),
+						"youtube_id": "DyR-DST-PyA"
+					},
+					{
+						"type": "help",
+						"label": _("Opening Accounting Balance"),
+						"youtube_id": "kdgM20Q-q68"
+					},
+					{
+						"type": "help",
+						"label": _("Setting up Taxes"),
+						"youtube_id": "nQ1zZdPgdaQ"
+					}
+				]
+			}
+		]
+
+		self.assertEqual(get_data(), DATA)
+
+		DATA.remove(GST_DATA)
+		self.assertEqual(
+			get_data(**{'doctype': 'Company', 'fields':['name'], 'filters': {'country': 'empty'}}), DATA
+		)
+
+
+


### PR DESCRIPTION
As pointed out in #10960, ERPNext will only show GST links if it finds a Company that has its country set as India in the Accounts module page.

I needed to be able to test `get_data` so I changed the signature thus: `get_data(**kwargs).

Test case added.