### PR TITLE
[minor] don't create lead if customer contact is already created against contact_email

### DIFF
--- a/erpnext/crm/doctype/opportunity/opportunity.py
+++ b/erpnext/crm/doctype/opportunity/opportunity.py
@@ -42,10 +42,28 @@ class Opportunity(TransactionBase):
 		if not self.with_items:
 			self.items = []
 
-
 	def make_new_lead_if_required(self):
 		"""Set lead against new opportunity"""
 		if not (self.lead or self.customer) and self.contact_email:
+			# check if customer is already created agains the self.contact_email
+			customer = frappe.db.sql("""select
+				distinct `tabDynamic Link`.link_name as customer
+				from 
+					`tabContact`,
+					`tabDynamic Link`
+				where `tabContact`.email_id='{0}'
+				and 
+					`tabContact`.name=`tabDynamic Link`.parent
+				and
+					ifnull(`tabDynamic Link`.link_name, '')<>'' 
+				and 
+					`tabDynamic Link`.link_doctype='Customer' 
+			""".format(self.contact_email), as_dict=True)
+			if customer and customer[0].customer:
+				self.customer = customer[0].customer
+				self.enquiry_from = "Customer"
+				return
+
 			lead_name = frappe.db.get_value("Lead", {"email_id": self.contact_email})
 			if not lead_name:
 				sender_name = get_fullname(self.contact_email)
@@ -68,10 +86,8 @@ class Opportunity(TransactionBase):
 
 				lead.flags.ignore_email_validation = True
 				lead.insert(ignore_permissions=True)
-				lead_name = lead.name
-
-			self.enquiry_from = "Lead"
-			self.lead = lead_name
+				self.enquiry_from = "Lead"
+				self.lead = lead.name
 
 	def declare_enquiry_lost(self,arg):
 		if not self.has_active_quotation():

--- a/erpnext/crm/doctype/opportunity/opportunity.py
+++ b/erpnext/crm/doctype/opportunity/opportunity.py
@@ -86,8 +86,10 @@ class Opportunity(TransactionBase):
 
 				lead.flags.ignore_email_validation = True
 				lead.insert(ignore_permissions=True)
-				self.enquiry_from = "Lead"
-				self.lead = lead.name
+				lead_name = lead.name
+
+			self.enquiry_from = "Lead"
+			self.lead = lead_name
 
 	def declare_enquiry_lost(self,arg):
 		if not self.has_active_quotation():


### PR DESCRIPTION
fixes for https://github.com/frappe/erpnext/issues/6242

- [x] Set customer instead of creating new Lead if the customer contact is already available
- [x] fix or add test cases for Opportunity.