### PR TITLE
[fix] tax_rule.py args

### DIFF
--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -320,10 +320,14 @@ def set_taxes(party, party_type, posting_date, company, customer_group=None, sup
 	from erpnext.accounts.doctype.tax_rule.tax_rule import get_tax_template, get_party_details
 	args = {
 		party_type.lower(): party,
-		"customer_group":	customer_group,
-		"supplier_type":	supplier_type,
 		"company":			company
 	}
+
+	if customer_group:
+		args['customer_group'] = customer_group
+
+	if supplier_type:
+		args['supplier_type'] = supplier_type
 
 	if billing_address or shipping_address:
 		args.update(get_party_details(party, party_type, {"billing_address": billing_address, \


### PR DESCRIPTION
```
Site: site1.local

Form Dict: {

 "cmd": "erpnext.accounts.party.get_party_details", 

 "company": "xxx", 

 "currency": "EUR", 

 "doctype": "Supplier Quotation", 

 "party": "DJO", 

 "party_type": "Supplier", 

 "posting_date": "2017-09-28", 

 "price_list": "xxx"

}

Request Error

Traceback (most recent call last):

  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 57, in application

    response = frappe.handler.handle()

  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 22, in handle

    data = execute_cmd(cmd)

  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 53, in execute_cmd

    return frappe.call(method, **frappe.form_dict)

  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 923, in call

    return fn(*args, **newargs)

  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/party.py", line 34, in get_party_details

    company, posting_date, price_list, currency, doctype, ignore_permissions)

  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/party.py", line 53, in _get_party_details

    out["taxes_and_charges"] = set_taxes(party.name, party_type, posting_date, company, out.customer_group, out.supplier_type)

  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/party.py", line 346, in set_taxes

    return get_tax_template(posting_date, args)

  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/doctype/tax_rule/tax_rule.py", line 140, in get_tax_template

    customer_group_condition = get_customer_group_condition(value)

  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/doctype/tax_rule/tax_rule.py", line 168, in get_customer_group_condition

    customer_groups = ["'%s'"%(frappe.db.escape(d.name)) for d in get_parent_customer_groups(customer_group)]

  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/setup/doctype/customer_group/customer_group.py", line 23, in get_parent_customer_groups

    lft, rgt = frappe.db.get_value("Customer Group", customer_group, ['lft', 'rgt'])

TypeError: 'NoneType' object is not iterable
```