### PR TITLE
[hotfix] validate company name on 'The Brand' Slide instead of 'Your Organization'

### DIFF
--- a/erpnext/public/js/setup_wizard.js
+++ b/erpnext/public/js/setup_wizard.js
@@ -86,6 +86,10 @@ erpnext.setup.slides_settings = [
 			});
 		},
 		validate: function() {
+			if ((this.values.company_name || "").toLowerCase() == "company") {
+				frappe.msgprint(__("Company Name cannot be Company"));
+				return false;
+			}
 			if (!this.values.company_abbr) {
 				return false;
 			}
@@ -133,10 +137,6 @@ erpnext.setup.slides_settings = [
 			// validate fiscal year start and end dates
 			if (this.values.fy_start_date == 'Invalid date' || this.values.fy_end_date == 'Invalid date') {
 				frappe.msgprint(__("Please enter valid Financial Year Start and End Dates"));
-				return false;
-			}
-			if ((this.values.company_name || "").toLowerCase() == "company") {
-				frappe.msgprint(__("Company Name cannot be Company"));
 				return false;
 			}
 			return true;

--- a/erpnext/setup/setup_wizard/healthcare.py
+++ b/erpnext/setup/setup_wizard/healthcare.py
@@ -191,21 +191,21 @@ def create_healthcare_item_groups():
 def create_lab_test_items():
 	records = [
 		{"doctype": "Item", "item_code": "MCH", "item_name": "MCH", "item_group": "Laboratory",
-			"stock_uom": "Unit", "is_stock_item": 0, "is_purchase_item": 0, "is_sales_item": 1},
+			"stock_uom": _("Unit"), "is_stock_item": 0, "is_purchase_item": 0, "is_sales_item": 1},
 		{"doctype": "Item", "item_code": "LDL", "item_name": "LDL", "item_group": "Laboratory",
-			"stock_uom": "Unit", "is_stock_item": 0, "is_purchase_item": 0, "is_sales_item": 1},
+			"stock_uom": _("Unit"), "is_stock_item": 0, "is_purchase_item": 0, "is_sales_item": 1},
 		{"doctype": "Item", "item_code": "GTT", "item_name": "GTT", "item_group": "Laboratory",
-			"stock_uom": "Unit", "is_stock_item": 0, "is_purchase_item": 0, "is_sales_item": 1},
+			"stock_uom": _("Unit"), "is_stock_item": 0, "is_purchase_item": 0, "is_sales_item": 1},
 		{"doctype": "Item", "item_code": "HDL", "item_name": "HDL", "item_group": "Laboratory",
-			"stock_uom": "Unit", "is_stock_item": 0, "is_purchase_item": 0, "is_sales_item": 1},
+			"stock_uom": _("Unit"), "is_stock_item": 0, "is_purchase_item": 0, "is_sales_item": 1},
 		{"doctype": "Item", "item_code": "BILT", "item_name": "BILT", "item_group": "Laboratory",
-			"stock_uom": "Unit", "is_stock_item": 0, "is_purchase_item": 0, "is_sales_item": 1},
+			"stock_uom": _("Unit"), "is_stock_item": 0, "is_purchase_item": 0, "is_sales_item": 1},
 		{"doctype": "Item", "item_code": "BILD", "item_name": "BILD", "item_group": "Laboratory",
-			"stock_uom": "Unit", "is_stock_item": 0, "is_purchase_item": 0, "is_sales_item": 1},
+			"stock_uom": _("Unit"), "is_stock_item": 0, "is_purchase_item": 0, "is_sales_item": 1},
 		{"doctype": "Item", "item_code": "BP", "item_name": "BP", "item_group": "Laboratory",
-			"stock_uom": "Unit", "is_stock_item": 0, "is_purchase_item": 0, "is_sales_item": 1},
+			"stock_uom": _("Unit"), "is_stock_item": 0, "is_purchase_item": 0, "is_sales_item": 1},
 		{"doctype": "Item", "item_code": "BS", "item_name": "BS", "item_group": "Laboratory",
-			"stock_uom": "Unit", "is_stock_item": 0, "is_purchase_item": 0, "is_sales_item": 1}
+			"stock_uom": _("Unit"), "is_stock_item": 0, "is_purchase_item": 0, "is_sales_item": 1}
 	]
 	insert_record(records)
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2017-09-28/apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.py", line 40, in setup_complete
    frappe.get_attr(method)(args)
  File "/home/frappe/benches/bench-2017-09-28/apps/erpnext/erpnext/setup/setup_wizard/setup_wizard.py", line 28, in setup_complete
    create_fiscal_year_and_company(args)
  File "/home/frappe/benches/bench-2017-09-28/apps/erpnext/erpnext/setup/setup_wizard/setup_wizard.py", line 94, in create_fiscal_year_and_company
    'domain': args.get('domain')
  File "/home/frappe/benches/bench-2017-09-28/apps/frappe/frappe/model/document.py", line 187, in insert
    self.set_new_name()
  File "/home/frappe/benches/bench-2017-09-28/apps/frappe/frappe/model/document.py", line 338, in set_new_name
    set_new_name(self)
  File "/home/frappe/benches/bench-2017-09-28/apps/frappe/frappe/model/naming.py", line 59, in set_new_name
    doc.name = validate_name(doc.doctype, doc.name, frappe.get_meta(doc.doctype).get_field("name_case"))
  File "/home/frappe/benches/bench-2017-09-28/apps/frappe/frappe/model/naming.py", line 181, in validate_name
    frappe.throw(_("Name of {0} cannot be {1}").format(doctype, name), frappe.NameError)
  File "/home/frappe/benches/bench-2017-09-28/apps/frappe/frappe/__init__.py", line 319, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red')
  File "/home/frappe/benches/bench-2017-09-28/apps/frappe/frappe/__init__.py", line 309, in msgprint
    _raise_exception()
  File "/home/frappe/benches/bench-2017-09-28/apps/frappe/frappe/__init__.py", line 282, in _raise_exception
    raise raise_exception(encode(msg))
NameError: Name of Company cannot be Company
```