### PR TITLE
[minor edits] BOM Stock Report

### DIFF
--- a/erpnext/config/manufacturing.py
+++ b/erpnext/config/manufacturing.py
@@ -123,6 +123,12 @@ def get_data():
 					"is_query_report": True,
 					"name": "BOM Search",
 					"doctype": "BOM"
+				},
+				{
+					"type": "report",
+					"is_query_report": True,
+					"name": "BOM Stock Report",
+					"doctype": "BOM"
 				}
 			]
 		},

--- a/erpnext/manufacturing/report/bom_stock_report/bom_stock_report.html
+++ b/erpnext/manufacturing/report/bom_stock_report/bom_stock_report.html
@@ -1,0 +1,27 @@
+<h1 class="text-left"><b>{%= __("BOM Stock Report") %}</b></h1>
+<h5 class="text-left">{%= filters.bom %}</h5>
+<h5 class="text-left">{%= filters.warehouse %}</h5>
+<hr>
+
+<table class="table table-bordered">
+	<thead>
+		<tr>
+			<th style="width: 15%">{%= __("Item") %}</th>
+			<th style="width: 35%">{%= __("Description") %}</th>
+			<th style="width: 14%">{%= __("Required Qty") %}</th>
+			<th style="width: 13%">{%= __("In Stock Qty") %}</th>
+			<th style="width: 23%">{%= __("Enough Parts to Build") %}</th>
+		</tr>
+	</thead>
+	<tbody>
+        {% for(var i=0, l=data.length; i<l; i++) { %}
+        <tr>
+            <td>{%= data[i][ __("Item")] %}</td>
+            <td>{%= data[i][ __("Description")] %} </td>
+            <td align="right">{%= data[i][ __("Required Qty")] %} </td>
+            <td align="right">{%= data[i][ __("In Stock Qty")] %} </td>
+            <td align="right">{%= data[i][ __("Enough Parts to Build")] %} </td>
+        </tr>
+        {% } %}
+	</tbody>
+</table>


### PR DESCRIPTION
We needed to show filters in PDF in BOM Stock Report and we believe it is best to have it in the core using an HTML template. Since filters are both Mandatory, it make sense to have it in PDF for additional information. See below:

Current : 

![bom stock report default](https://user-images.githubusercontent.com/21003054/31070621-97f7f448-a793-11e7-9a1b-87ea4eb7a206.png)


Proposed:

![propposed](https://user-images.githubusercontent.com/21003054/31070629-9cd0da52-a793-11e7-9b67-193d7d8e5d2a.png)

Also, I have added BOM Stock Report in Manufacturing Config under Report:

![manufacturing](https://user-images.githubusercontent.com/21003054/31070658-b7d56764-a793-11e7-8ad0-3b9dd5fddb23.png)


Regards,

Dori
