### PR TITLE
Add Items Variants Attributes columns to Stock Balance Report

### DIFF
--- a/erpnext/stock/report/stock_balance/stock_balance.py
+++ b/erpnext/stock/report/stock_balance/stock_balance.py
@@ -43,7 +43,7 @@ def execute(filters=None):
 		report_data += [get_variant_attr_val(item,i) for i in variants_attributes]
 		data.append(report_data)
 
-	columns += ["{}::Data:100".format(i) for i in variants_attributes]
+	columns += ["{}:Data:100".format(i) for i in variants_attributes]
 	
 
 	return columns, data


### PR DESCRIPTION
Show Item attributes in stock balance report for item variants if they exist.

![stock_balance_report](https://user-images.githubusercontent.com/17238907/31172016-d3985828-a8f9-11e7-9cca-726bc90a07bb.png)

