### PR TITLE
[Hotfix]Wrong Bank Entry Computation for Salary Processing (#11030)

### DIFF
--- a/erpnext/hr/doctype/process_payroll/process_payroll.py
+++ b/erpnext/hr/doctype/process_payroll/process_payroll.py
@@ -284,7 +284,7 @@ class ProcessPayroll(Document):
 					})
 
 			# Deductions
-			for acc, amt in deductions.items():
+			for acc, amount in deductions.items():
 				payable_amount -= flt(amount, precision)
 				accounts.append({
 						"account": acc,


### PR DESCRIPTION
Fixed #11030 
Bug was introduced by a wrong variable name.

Before:
![screenshot from 2017-10-04 12-37-52](https://user-images.githubusercontent.com/818803/31173955-92b15a28-a901-11e7-9bb9-57756add57ad.png)

Payroll Process was creating a wrong JV
![screenshot from 2017-10-04 12-37-21](https://user-images.githubusercontent.com/818803/31174027-da6ee36c-a901-11e7-9943-765f099914aa.png)

Now, it generates as expected...
![screenshot from 2017-10-04 12-38-57](https://user-images.githubusercontent.com/818803/31174060-0142c7c4-a902-11e7-9893-37f77bef8d0f.png)


