### PR TITLE
[Fix] Negative qty issue in POS

### DIFF
--- a/erpnext/selling/page/point_of_sale/point_of_sale.js
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.js
@@ -223,7 +223,7 @@ erpnext.pos.PointOfSale = class PointOfSale {
 
 	update_item_in_frm(item, field, value) {
 		if (field == 'qty' && value < 0) {
-			frappe.msgprint(__("Quantity must be positive"))
+			frappe.msgprint(__("Quantity must be positive"));
 			value = item.qty;
 		}
 

--- a/erpnext/selling/page/point_of_sale/point_of_sale.js
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.js
@@ -222,6 +222,11 @@ erpnext.pos.PointOfSale = class PointOfSale {
 	}
 
 	update_item_in_frm(item, field, value) {
+		if (field == 'qty' && value < 0) {
+			frappe.msgprint(__("Quantity must be positive"))
+			value = item.qty;
+		}
+
 		if (field) {
 			frappe.model.set_value(item.doctype, item.name, field, value);
 		}


### PR DESCRIPTION
**Issue**

1. Add item to cart.

1. In Qty instead of 1, make it -1 (Item is removed from cart but to my surprise Amount is negative. 

1. When we open form view item is still in sales invoice with negative qty!!!)

1. Again add same product to cart which will make Qty 1 and Amount (0)!!!

1. Open Form view to check Sales Invoice where you can see both positive and negative lines of item.
