### PR TITLE
Add Calendar in Training Event Doctype

### DIFF
--- a/erpnext/hr/doctype/training_event/training_event.py
+++ b/erpnext/hr/doctype/training_event/training_event.py
@@ -3,6 +3,7 @@
 # For license information, please see license.txt
 
 from __future__ import unicode_literals
+import frappe
 from frappe.model.document import Document
 from erpnext.hr.doctype.employee.employee import get_employee_emails
 
@@ -10,3 +11,29 @@ class TrainingEvent(Document):
 	def validate(self):
 		self.employee_emails = ', '.join(get_employee_emails([d.employee
 			for d in self.employees]))
+
+@frappe.whitelist()
+def get_events(start, end, filters=None):
+	"""Returns events for Gantt / Calendar view rendering.
+
+	:param start: Start date-time.
+	:param end: End date-time.
+	:param filters: Filters (JSON).
+	"""
+	from frappe.desk.calendar import get_event_conditions
+	conditions = get_event_conditions("Training Event", filters)
+
+	data = frappe.db.sql("""
+		select
+			name, event_name, event_status, start_time, end_time
+		from
+			`tabTraining Event`
+		where (ifnull(start_time, '0000-00-00')!= '0000-00-00') \
+			and (start_time between %(start)s and %(end)s)
+			and docstatus < 2
+			{conditions}
+		""".format(conditions=conditions), {
+			"start": start,
+			"end": end
+		}, as_dict=True, update={"allDay": 0})
+	return data

--- a/erpnext/hr/doctype/training_event/training_event_calendar.js
+++ b/erpnext/hr/doctype/training_event/training_event_calendar.js
@@ -1,0 +1,14 @@
+// Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
+// License: GNU General Public License v3. See license.txt
+
+frappe.views.calendar["Training Event"] = {
+	field_map: {
+		"start": "start_time",
+		"end": "end_time",
+		"id": "name",
+		"title": "event_name",
+		"allDay": "allDay"
+	},
+	gantt: true,
+	get_events_method: "erpnext.hr.doctype.training_event.training_event.get_events",
+}


### PR DESCRIPTION
Training event is best tracked in a calendar form for better view of scheduling. Thus, added Calendar in the Training Event Doctype.

![calendar](https://user-images.githubusercontent.com/21003054/31263002-ca6a28be-aa91-11e7-83fa-9a241dbfe369.png)
