### PR TITLE
[hotfix] ignore if student email address field value is None

### DIFF
--- a/erpnext/schools/doctype/fees/fees.py
+++ b/erpnext/schools/doctype/fees/fees.py
@@ -50,6 +50,7 @@ class Fees(AccountsController):
 			select g.email_address
 			from `tabGuardian` g, `tabStudent Guardian` sg
 			where g.name = sg.guardian and sg.parent = %s and sg.parenttype = 'Student'
+			and ifnull(g.email_address, '')!=''
 		""", self.student)
 
 		student_email_id = frappe.db.get_value("Student", self.student, "student_email_id")


### PR DESCRIPTION
`Error Traceback`

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2017-10-05/apps/frappe/frappe/desk/form/save.py", line 22, in savedocs
    doc.save()
  File "/home/frappe/benches/bench-2017-10-05/apps/frappe/frappe/model/document.py", line 256, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-2017-10-05/apps/frappe/frappe/model/document.py", line 279, in _save
    self.insert()
  File "/home/frappe/benches/bench-2017-10-05/apps/frappe/frappe/model/document.py", line 218, in insert
    self.run_before_save_methods()
  File "/home/frappe/benches/bench-2017-10-05/apps/frappe/frappe/model/document.py", line 809, in run_before_save_methods
    self.run_method("validate")
  File "/home/frappe/benches/bench-2017-10-05/apps/frappe/frappe/model/document.py", line 702, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-2017-10-05/apps/frappe/frappe/model/document.py", line 924, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-2017-10-05/apps/frappe/frappe/model/document.py", line 907, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-2017-10-05/apps/frappe/frappe/model/document.py", line 696, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-2017-10-05/apps/erpnext/erpnext/schools/doctype/fees/fees.py", line 28, in validate
    self.set_missing_accounts_and_fields()
  File "/home/frappe/benches/bench-2017-10-05/apps/erpnext/erpnext/schools/doctype/fees/fees.py", line 46, in set_missing_accounts_and_fields
    self.student_email = self.get_student_emails()
  File "/home/frappe/benches/bench-2017-10-05/apps/erpnext/erpnext/schools/doctype/fees/fees.py", line 59, in get_student_emails
    return ", ".join(list(set(student_emails)))
TypeError: sequence item 0: expected string or Unicode, NoneType found
```