### PR TITLE
Error in the Address fetched in Sales Order.(#11129)

### DIFF
--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -14,7 +14,7 @@ from frappe.contacts.doctype.address.address import (get_address_display,
 	get_default_address, get_company_address)
 from frappe.contacts.doctype.contact.contact import get_contact_details, get_default_contact
 from erpnext.exceptions import PartyFrozen, PartyDisabled, InvalidAccountCurrency
-from erpnext.accounts.utils import get_fiscal_year
+from erpnext.accounts.utils import get_fiscal_year, get_party_shipping_address
 from erpnext import get_default_currency, get_company_currency
 
 
@@ -76,7 +76,7 @@ def set_address_details(out, party, party_type, doctype=None, company=None):
 
 	# shipping address
 	if party_type in ["Customer", "Lead"]:
-		out.shipping_address_name = get_default_address(party_type, party.name, 'is_shipping_address')
+		out.shipping_address_name = get_party_shipping_address(party_type, party.name)
 		out.shipping_address = get_address_display(out["shipping_address_name"])
 		if doctype:
 			out.update(get_fetch_values(doctype, 'shipping_address_name', out.shipping_address_name))

--- a/erpnext/accounts/test/test_utils.py
+++ b/erpnext/accounts/test/test_utils.py
@@ -1,5 +1,5 @@
 import unittest
-from erpnext.accounts.utils import get_party_shipping_address
+from erpnext.accounts.party import get_party_shipping_address
 from frappe.test_runner import make_test_objects
 
 

--- a/erpnext/accounts/test/test_utils.py
+++ b/erpnext/accounts/test/test_utils.py
@@ -1,0 +1,84 @@
+import unittest
+from erpnext.accounts.utils import get_party_shipping_address
+from frappe.test_runner import make_test_objects
+
+
+class TestUtils(unittest.TestCase):
+	@classmethod
+	def setUpClass(cls):
+		super(TestUtils, cls).setUpClass()
+		make_test_objects('Address', ADDRESS_RECORDS)
+
+	def test_get_party_shipping_address(self):
+		address = get_party_shipping_address('Customer', '_Test Customer 1')
+		self.assertEqual(address, '_Test Billing Address 2 Title-Billing')
+
+	def test_get_party_shipping_address2(self):
+		address = get_party_shipping_address('Customer', '_Test Customer 2')
+		self.assertEqual(address, '_Test Shipping Address 2 Title-Shipping')
+
+
+ADDRESS_RECORDS = [
+	{
+		"doctype": "Address",
+		"address_type": "Billing",
+		"address_line1": "Address line 1",
+		"address_title": "_Test Billing Address Title",
+		"city": "Lagos",
+		"country": "Nigeria",
+		"links": [
+			{
+				"link_doctype": "Customer",
+				"link_name": "_Test Customer 2",
+				"doctype": "Dynamic Link"
+			}
+		]
+	},
+	{
+		"doctype": "Address",
+		"address_type": "Shipping",
+		"address_line1": "Address line 2",
+		"address_title": "_Test Shipping Address 1 Title",
+		"city": "Lagos",
+		"country": "Nigeria",
+		"links": [
+			{
+				"link_doctype": "Customer",
+				"link_name": "_Test Customer 2",
+				"doctype": "Dynamic Link"
+			}
+		]
+	},
+	{
+		"doctype": "Address",
+		"address_type": "Shipping",
+		"address_line1": "Address line 3",
+		"address_title": "_Test Shipping Address 2 Title",
+		"city": "Lagos",
+		"country": "Nigeria",
+		"is_shipping_address": "1",
+		"links": [
+			{
+				"link_doctype": "Customer",
+				"link_name": "_Test Customer 2",
+				"doctype": "Dynamic Link"
+			}
+		]
+	},
+	{
+		"doctype": "Address",
+		"address_type": "Billing",
+		"address_line1": "Address line 4",
+		"address_title": "_Test Billing Address 2 Title",
+		"city": "Lagos",
+		"country": "Nigeria",
+		"is_shipping_address": "1",
+		"links": [
+			{
+				"link_doctype": "Customer",
+				"link_name": "_Test Customer 1",
+				"doctype": "Dynamic Link"
+			}
+		]
+	}
+]

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -740,32 +740,3 @@ def create_payment_gateway_account(gateway):
 	except frappe.DuplicateEntryError:
 		# already exists, due to a reinstall?
 		pass
-
-
-def get_party_shipping_address(doctype, name):
-	"""
-	Returns an Address name (best guess) for the given doctype and name for which `address_type == 'Shipping'` is true.
-	and/or `is_shipping_address = 1`.
-
-	It returns an empty string if there is no matching record.
-
-	:param doctype: Party Doctype
-	:param name: Party name
-	:return: String
-	"""
-	out = frappe.db.sql(
-		'SELECT dl.parent '
-		'from `tabDynamic Link` dl join `tabAddress` ta on dl.parent=ta.name '
-		'where '
-		'dl.link_doctype=%s '
-		'and dl.link_name=%s '
-		'and dl.parenttype="Address" '
-		'and '
-		'(ta.address_type="Shipping" or ta.is_shipping_address=1) '
-		'order by ta.is_shipping_address desc, ta.address_type desc limit 1',
-		(doctype, name)
-	)
-	if out:
-		return out[0][0]
-	else:
-		return ''

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -740,3 +740,32 @@ def create_payment_gateway_account(gateway):
 	except frappe.DuplicateEntryError:
 		# already exists, due to a reinstall?
 		pass
+
+
+def get_party_shipping_address(doctype, name):
+	"""
+	Returns an Address name (best guess) for the given doctype and name for which `address_type == 'Shipping'` is true.
+	and/or `is_shipping_address = 1`.
+
+	It returns an empty string if there is no matching record.
+
+	:param doctype: Party Doctype
+	:param name: Party name
+	:return: String
+	"""
+	out = frappe.db.sql(
+		'SELECT dl.parent '
+		'from `tabDynamic Link` dl join `tabAddress` ta on dl.parent=ta.name '
+		'where '
+		'dl.link_doctype=%s '
+		'and dl.link_name=%s '
+		'and dl.parenttype="Address" '
+		'and '
+		'(ta.address_type="Shipping" or ta.is_shipping_address=1) '
+		'order by ta.is_shipping_address, ta.address_type desc limit 1',
+		(doctype, name)
+	)
+	if out:
+		return out[0][0]
+	else:
+		return ''

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -762,7 +762,7 @@ def get_party_shipping_address(doctype, name):
 		'and dl.parenttype="Address" '
 		'and '
 		'(ta.address_type="Shipping" or ta.is_shipping_address=1) '
-		'order by ta.is_shipping_address, ta.address_type desc limit 1',
+		'order by ta.is_shipping_address desc, ta.address_type desc limit 1',
 		(doctype, name)
 	)
 	if out:


### PR DESCRIPTION
Fixed #11129 
Depends on frappe/frappe#4298 to work. Now, Sales Order will only try to retrieve Shipping Address For the party and leave blank if not found

### Before
![peek 2017-10-10 16-57](https://user-images.githubusercontent.com/818803/31397124-104955d2-addd-11e7-9726-8ad265e2e8a7.gif)

### After
![peek 2017-10-10 17-00](https://user-images.githubusercontent.com/818803/31397132-1618bdc2-addd-11e7-8086-6035e0a45677.gif)

The function returns with considerations in this order:
- Return Address with `is_shipping_address = 1` and `address_type='Shipping'`
- Return Address with `address_type = 'Shipping`
- Return Address with `is_shipping_address = 1`
- Return ''

Test cases included
