### PR TITLE
[Fix] New invoice showing old paid amount if POS Profile is not created

### DIFF
--- a/erpnext/selling/page/point_of_sale/point_of_sale.js
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.js
@@ -103,9 +103,7 @@ erpnext.pos.PointOfSale = class PointOfSale {
 							this.make_payment_modal();
 						} else {
 							this.frm.doc.payments.map(p => {
-								if (p.amount) {
-									this.payment.dialog.set_value(p.mode_of_payment, p.amount);
-								}
+								this.payment.dialog.set_value(p.mode_of_payment, p.amount);
 							});
 
 							this.payment.set_title();


### PR DESCRIPTION
**Fixed** 
https://discuss.erpnext.com/t/pos-brings-up-wrong-payment-details/29295