### PR TITLE
[hotfix] fixed 'ValueError: Unknown string format' error if the from_time value is null

### DIFF
--- a/erpnext/projects/doctype/timesheet/timesheet.js
+++ b/erpnext/projects/doctype/timesheet/timesheet.js
@@ -159,9 +159,14 @@ frappe.ui.form.on("Timesheet Detail", {
 });
 
 var calculate_end_time = function(frm, cdt, cdn) {
-	var child = locals[cdt][cdn];
+	let child = locals[cdt][cdn];
 
-	var d = moment(child.from_time);
+	if(!child.from_time) {
+		// if from_time value is not available then set the current datetime
+		frappe.model.set_value(cdt, cdn, "from_time", frappe.datetime.get_datetime_as_string());
+	}
+
+	let d = moment(child.from_time);
 	if(child.hours) {
 		d.add(child.hours, "hours");
 		frm._setting_hours = true;


### PR DESCRIPTION
fixes for https://github.com/frappe/erpnext/issues/11161
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2017-10-09/apps/frappe/frappe/desk/form/save.py", line 22, in savedocs
    doc.save()
  File "/home/frappe/benches/bench-2017-10-09/apps/frappe/frappe/model/document.py", line 256, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-2017-10-09/apps/frappe/frappe/model/document.py", line 290, in _save
    self.run_before_save_methods()
  File "/home/frappe/benches/bench-2017-10-09/apps/frappe/frappe/model/document.py", line 809, in run_before_save_methods
    self.run_method("validate")
  File "/home/frappe/benches/bench-2017-10-09/apps/frappe/frappe/model/document.py", line 702, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-2017-10-09/apps/frappe/frappe/model/document.py", line 924, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-2017-10-09/apps/frappe/frappe/model/document.py", line 907, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-2017-10-09/apps/frappe/frappe/model/document.py", line 696, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-2017-10-09/apps/erpnext/erpnext/projects/doctype/timesheet/timesheet.py", line 33, in validate
    self.set_dates()
  File "/home/frappe/benches/bench-2017-10-09/apps/erpnext/erpnext/projects/doctype/timesheet/timesheet.py", line 90, in set_dates
    end_date = max([getdate(d.to_time) for d in self.time_logs])
  File "/home/frappe/benches/bench-2017-10-09/apps/frappe/frappe/utils/data.py", line 41, in getdate
    return parser.parse(string_date).date()
  File "/home/frappe/benches/bench-2017-10-09/env/lib/python2.7/site-packages/dateutil/parser.py", line 1182, in parse
    return DEFAULTPARSER.parse(timestr, **kwargs)
  File "/home/frappe/benches/bench-2017-10-09/env/lib/python2.7/site-packages/dateutil/parser.py", line 559, in parse
    raise ValueError("Unknown string format")
ValueError: Unknown string format
```