### PR TITLE
[minor] minor fixes in get_company_details for Hub page

### DIFF
--- a/erpnext/hub_node/page/hub/hub.js
+++ b/erpnext/hub_node/page/hub/hub.js
@@ -483,7 +483,7 @@ erpnext.hub.Hub = class Hub {
 		}
 		frappe.call({
 			method: 'erpnext.hub_node.get_company_details',
-			args: {company_id: company_id}
+			args: {hub_sync_id: company_id}
 		}).then((r) => {
 			if (r.message) {
 				const company_details = r.message.company_details;


### PR DESCRIPTION
fixes for `get_company_details() takes exactly 1 argument (0 given)`