### PR TITLE
[hotfix] fixed Permissions Error while fetching allow_stale field value from Accounts Settings

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -405,11 +405,7 @@ frappe.ui.form.on('Payment Entry', {
 		}
 
 		// Make read only if Accounts Settings doesn't allow stale rates
-		frappe.model.get_value("Accounts Settings", null, "allow_stale",
-			function(d){
-				frm.set_df_property("source_exchange_rate", "read_only", cint(d.allow_stale) ? 0 : 1);
-			}
-		);
+		frm.set_df_property("source_exchange_rate", "read_only", erpnext.allow_stale_rate());
 	},
 
 	target_exchange_rate: function(frm) {
@@ -430,11 +426,7 @@ frappe.ui.form.on('Payment Entry', {
 		frm.set_paid_amount_based_on_received_amount = false;
 
 		// Make read only if Accounts Settings doesn't allow stale rates
-		frappe.model.get_value("Accounts Settings", null, "allow_stale",
-			function(d){
-				frm.set_df_property("target_exchange_rate", "read_only", cint(d.allow_stale) ? 0 : 1);
-			}
-		);
+		frm.set_df_property("target_exchange_rate", "read_only", erpnext.allow_stale_rate());
 	},
 
 	paid_amount: function(frm) {

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -405,7 +405,7 @@ frappe.ui.form.on('Payment Entry', {
 		}
 
 		// Make read only if Accounts Settings doesn't allow stale rates
-		frm.set_df_property("source_exchange_rate", "read_only", erpnext.allow_stale_rate());
+		frm.set_df_property("source_exchange_rate", "read_only", erpnext.stale_rate_allowed());
 	},
 
 	target_exchange_rate: function(frm) {
@@ -426,7 +426,7 @@ frappe.ui.form.on('Payment Entry', {
 		frm.set_paid_amount_based_on_received_amount = false;
 
 		// Make read only if Accounts Settings doesn't allow stale rates
-		frm.set_df_property("target_exchange_rate", "read_only", erpnext.allow_stale_rate());
+		frm.set_df_property("target_exchange_rate", "read_only", erpnext.stale_rate_allowed());
 	},
 
 	paid_amount: function(frm) {

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -542,7 +542,7 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 
 		}
 		// Make read only if Accounts Settings doesn't allow stale rates
-		this.frm.set_df_property("conversion_rate", "read_only", erpnext.allow_stale_rate());
+		this.frm.set_df_property("conversion_rate", "read_only", erpnext.stale_rate_allowed());
 	},
 
 	set_actual_charges_based_on_currency: function() {

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -542,11 +542,7 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 
 		}
 		// Make read only if Accounts Settings doesn't allow stale rates
-		frappe.model.get_value("Accounts Settings", null, "allow_stale",
-			function(d){
-				me.set_df_property("conversion_rate", "read_only", cint(d.allow_stale) ? 0 : 1);
-			}
-		);
+		this.frm.set_df_property("conversion_rate", "read_only", erpnext.allow_stale_rate());
 	},
 
 	set_actual_charges_based_on_currency: function() {

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -37,6 +37,10 @@ $.extend(erpnext, {
 		}
 	},
 
+	allow_stale_rate: () => {
+		return cint(frappe.boot.sysdefaults.allow_stale) || 0;
+	},
+
 	setup_serial_no: function() {
 		var grid_row = cur_frm.open_grid_row();
 		if(!grid_row || !grid_row.grid_form.fields_dict.serial_no ||

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -37,8 +37,8 @@ $.extend(erpnext, {
 		}
 	},
 
-	allow_stale_rate: () => {
-		return cint(frappe.boot.sysdefaults.allow_stale) || 0;
+	stale_rate_allowed: () => {
+		return cint(frappe.boot.sysdefaults.allow_stale) || 1;
 	},
 
 	setup_serial_no: function() {

--- a/erpnext/startup/boot.py
+++ b/erpnext/startup/boot.py
@@ -19,6 +19,8 @@ def boot_session(bootinfo):
 			'territory')
 		bootinfo.sysdefaults.customer_group = frappe.db.get_single_value('Selling Settings',
 			'customer_group')
+		bootinfo.sysdefaults.allow_stale = frappe.db.get_single_value('Accounts Settings',
+			'allow_stale') or 0
 
 		bootinfo.notification_settings = frappe.get_doc("Notification Control",
 			"Notification Control")

--- a/erpnext/startup/boot.py
+++ b/erpnext/startup/boot.py
@@ -20,7 +20,7 @@ def boot_session(bootinfo):
 		bootinfo.sysdefaults.customer_group = frappe.db.get_single_value('Selling Settings',
 			'customer_group')
 		bootinfo.sysdefaults.allow_stale = frappe.db.get_single_value('Accounts Settings',
-			'allow_stale') or 0
+			'allow_stale') or 1
 
 		bootinfo.notification_settings = frappe.get_doc("Notification Control",
 			"Notification Control")


### PR DESCRIPTION
Permissions Error if the Purchase User try to create the `Purchase Receipt`
`before`
![pr](https://user-images.githubusercontent.com/11224291/31533599-b0308478-b010-11e7-8f6b-16c699848a58.gif)

`after`
![pr](https://user-images.githubusercontent.com/11224291/31533516-53478a0e-b010-11e7-81ce-8a9c70f2d350.gif)