### PR TITLE
[minor] fixed AttributeError: 'GrossProfitGenerator' object has no attribute 'grouped_data'

### DIFF
--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -107,6 +107,8 @@ class GrossProfitGenerator(object):
 
 	def process(self):
 		self.grouped = {}
+		self.grouped_data = []
+
 		for row in self.si_list:
 			if self.skip_row(row, self.product_bundles):
 				continue
@@ -150,7 +152,6 @@ class GrossProfitGenerator(object):
 
 	def get_average_rate_based_on_group_by(self):
 		# sum buying / selling totals for group
-		self.grouped_data = []
 		for key in self.grouped.keys():
 			if self.filters.get("group_by") != "Invoice":
 				for i, row in enumerate(self.grouped[key]):


### PR DESCRIPTION
fixed https://github.com/frappe/erpnext/issues/11186

```
Traceback (most recent call last):
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/app.py", line 57, in application
    response = frappe.handler.handle()
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/handler.py", line 53, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/__init__.py", line 923, in call
    return fn(*args, **newargs)
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/frappe/frappe/desk/query_report.py", line 96, in run
    res = frappe.get_attr(method_name)(frappe._dict(filters))
  File "/Users/makarandbauskar/workspace/frappe/dev-bench/apps/erpnext/erpnext/accounts/report/gross_profit/gross_profit.py", line 47, in execute
    for src in gross_profit_data.grouped_data:
AttributeError: 'GrossProfitGenerator' object has no attribute 'grouped_data'
```