### PR TITLE
Set transaction type in pricing rule only if unavailable

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -348,6 +348,7 @@ def apply_internal_priority(pricing_rules, field_set, args):
 	return filtered_rules or pricing_rules
 
 def set_transaction_type(args):
+	if args.transaction_type:return
 	if args.doctype in ("Opportunity", "Quotation", "Sales Order", "Delivery Note", "Sales Invoice"):
 		args.transaction_type = "selling"
 	elif args.doctype in ("Material Request", "Supplier Quotation", "Purchase Order",

--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -348,7 +348,8 @@ def apply_internal_priority(pricing_rules, field_set, args):
 	return filtered_rules or pricing_rules
 
 def set_transaction_type(args):
-	if args.transaction_type:return
+	if args.transaction_type:
+		return
 	if args.doctype in ("Opportunity", "Quotation", "Sales Order", "Delivery Note", "Sales Invoice"):
 		args.transaction_type = "selling"
 	elif args.doctype in ("Material Request", "Supplier Quotation", "Purchase Order",


### PR DESCRIPTION
Hi all,
We have a doctype in our custom app with the python controller extending the "AccountsController" and and js controller extending "erpnext.TransactionController". The doctype is basically an exact duplication of 'Sales invoice' doctype. 

For a new record, the 'selling_price_list' defaults to Standard Selling which is fine for Sales Invoice, but for our custom doctype, upon selection of an item under items (just like in "Sales Invoice"), the below error occurs 

![price_list_err](https://user-images.githubusercontent.com/17238907/31637058-e4e80b62-b2c4-11e7-9b6d-02f8802a34f6.png)


we have tracked it down from a chain of calls that propagates from the 'item_code' trigger function in erpnext.TransactionController 
 [/erpnext/public/js/controllers/transaction.js](https://github.com/frappe/erpnext/blob/master/erpnext/public/js/controllers/transaction.js#L286)
```
item_code: function(doc, cdt, cdn, from_barcode) {
		var me = this;
		var item = frappe.get_doc(cdt, cdn);
		var update_stock = 0, show_batch_dialog = 0;
                ........

		if(item.item_code || item.barcode || item.serial_no) {
			if(!this.validate_company_and_party()) {
				this.frm.fields_dict["items"].grid.grid_rows[item.idx - 1].remove();
			} else {
				return this.frm.call({
					method: "erpnext.stock.get_item_details.get_item_details",
					child: item,
					args: {
						args: {
							item_code: item.item_code,
							barcode: item.barcode,
							serial_no: item.serial_no,
							warehouse: item.warehouse,
                                                        customer: me.frm.doc.customer,
```
 to 'set_transaction_type' 
[erpnext/accounts/doctype/pricing_rule/pricing_rule.py](https://github.com/frappe/erpnext/blob/master/erpnext/accounts/doctype/pricing_rule/pricing_rule.py#L350) 
```
def set_transaction_type(args):
	if args.doctype in ("Opportunity", "Quotation", "Sales Order", "Delivery Note", "Sales Invoice"):
		args.transaction_type = "selling"
	elif args.doctype in ("Material Request", "Supplier Quotation", "Purchase Order",
		"Purchase Receipt", "Purchase Invoice"):
			args.transaction_type = "buying"
	elif args.customer:
		args.transaction_type = "selling"
	else:
                args.transaction_type = "buying"
```

which defaults the transaction_type attribute of the args variable to 'buying'(instead of selling) since our doctype is not recognized.
When the price_list(Standard Selling) is finally validated against the transaction type (buying),
it gives the above error.

This should solve any custom doctype with this problem.
