### PR TITLE
Check credit or debit in_account_currency is set before setting

### DIFF
--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
@@ -72,13 +72,13 @@ class PaymentReconciliation(Document):
 			row = self.append('payments', {})
 			row.update(e)
 
-	def get_invoice_entries(self):
+	def get_invoice_entries(self, paying_party=False):
 		#Fetch JVs, Sales and Purchase Invoices for 'invoices' to reconcile against
 
 		condition = self.check_condition()
 
 		non_reconciled_invoices = get_outstanding_invoices(self.party_type, self.party,
-			self.receivable_payable_account, condition=condition)
+			self.receivable_payable_account, condition=condition, paying_party=paying_party)
 
 		self.add_invoice_entries(non_reconciled_invoices)
 

--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
@@ -30,8 +30,7 @@ class PaymentReconciliation(Document):
 		return payment_entries
 
 	def get_jv_entries(self):
-		dr_or_cr = "credit_in_account_currency" if self.party_type == "Customer" \
-			else "debit_in_account_currency"
+		dr_or_cr = self.get_dr_or_cr()
 
 		bank_account_condition = "t2.against_account like %(bank_cash_account)s" \
 				if self.bank_cash_account else "1=1"
@@ -103,8 +102,7 @@ class PaymentReconciliation(Document):
 
 		self.get_invoice_entries()
 		self.validate_invoice()
-		dr_or_cr = "credit_in_account_currency" \
-			if self.party_type == "Customer" else "debit_in_account_currency"
+		dr_or_cr = self.get_dr_or_cr()
 			
 		lst = []
 		for e in self.get('payments'):
@@ -184,3 +182,12 @@ class PaymentReconciliation(Document):
 			cond += " and `{0}` <= {1}".format(dr_or_cr, flt(self.maximum_amount))
 
 		return cond
+
+	def get_dr_or_cr(self):
+		'''Return credit_in_account_currency if not set and party is customer.'''
+		if hasattr(self, "dr_or_cr"):
+			return self.dr_or_cr
+		if self.party_type == 'Customer':
+			return "credit_in_account_currency"
+		else:
+			return "debit_in_account_currency"

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -569,11 +569,11 @@ def get_stock_rbnb_difference(posting_date, company):
 	# Amount should be credited
 	return flt(stock_rbnb) + flt(sys_bal)
 
-def get_outstanding_invoices(party_type, party, account, condition=None):
+def get_outstanding_invoices(party_type, party, account, condition=None, paying_party=False):
 	outstanding_invoices = []
 	precision = frappe.get_precision("Sales Invoice", "outstanding_amount")
 
-	if party_type=="Customer":
+	if party_type=="Customer" or paying_party:
 		dr_or_cr = "debit_in_account_currency - credit_in_account_currency"
 		payment_dr_or_cr = "payment_gl_entry.credit_in_account_currency - payment_gl_entry.debit_in_account_currency"
 	else:


### PR DESCRIPTION
When the Payment Reconciliation Tool is used to reconcile invoices and payments from custom doctypes the credit_in_account_currency or debit_in_account_currency variables can be set whether the party_type is "Customer" or not.
this
```
dr_or_cr = "credit_in_account_currency" if self.party_type == "Customer" \
else "debit_in_account_currency"
```
changed to 
```
dr_or_cr = self.get_dr_or_cr()
```
with a check first
```Python
def get_dr_or_cr(self):
'''Return credit_in_account_currency if not set and party is customer.'''
if hasattr(self, "dr_or_cr"):
    return self.dr_or_cr
    if self.party_type == 'Customer':
        return "credit_in_account_currency"
    else:
        return "debit_in_account_currency"
```
This enables custom app to have the ability to reconcile payments with a different "party" doctype.