### PR TITLE
[fix] Discount amount not reset for new order in offline pos

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/pos.py
+++ b/erpnext/accounts/doctype/sales_invoice/pos.py
@@ -88,7 +88,7 @@ def update_pos_profile_data(doc, pos_profile, company_data):
 	doc.naming_series = pos_profile.get('naming_series') or 'SINV-'
 	doc.letter_head = pos_profile.get('letter_head') or company_data.default_letter_head
 	doc.ignore_pricing_rule = pos_profile.get('ignore_pricing_rule') or 0
-	doc.apply_discount_on = pos_profile.get('apply_discount_on') or ''
+	doc.apply_discount_on = pos_profile.get('apply_discount_on') or 'Grand Total'
 	doc.customer_group = pos_profile.get('customer_group') or get_root('Customer Group')
 	doc.territory = pos_profile.get('territory') or get_root('Territory')
 	doc.terms = frappe.db.get_value('Terms and Conditions', pos_profile.get('tc_name'), 'terms') or doc.terms or ''

--- a/erpnext/accounts/page/pos/pos.js
+++ b/erpnext/accounts/page/pos/pos.js
@@ -84,6 +84,7 @@ erpnext.pos.PointOfSale = erpnext.taxes_and_totals.extend({
 		this.get_data_from_server(function () {
 			me.make_control();
 			me.create_new();
+			me.make();
 		});
 	},
 
@@ -382,7 +383,6 @@ erpnext.pos.PointOfSale = erpnext.taxes_and_totals.extend({
 	},
 
 	setup: function () {
-		this.make();
 		this.set_primary_action();
 		this.party_field.$input.attr('disabled', false);
 		if(this.selected_row) {
@@ -1341,6 +1341,12 @@ erpnext.pos.PointOfSale = erpnext.taxes_and_totals.extend({
 
 		this.wrapper.find('input.discount-percentage').on("change", function () {
 			me.frm.doc.additional_discount_percentage = flt($(this).val(), precision("additional_discount_percentage"));
+
+			if(me.frm.doc.additional_discount_percentage && me.frm.doc.discount_amount) {
+				// Reset discount amount
+				me.frm.doc.discount_amount = 0;
+			}
+
 			var total = me.frm.doc.grand_total
 
 			if (me.frm.doc.apply_discount_on == 'Net Total') {
@@ -1348,15 +1354,15 @@ erpnext.pos.PointOfSale = erpnext.taxes_and_totals.extend({
 			}
 
 			me.frm.doc.discount_amount = flt(total * flt(me.frm.doc.additional_discount_percentage) / 100, precision("discount_amount"));
-			me.wrapper.find('input.discount-amount').val(me.frm.doc.discount_amount)
 			me.refresh();
+			me.wrapper.find('input.discount-amount').val(me.frm.doc.discount_amount)
 		});
 
 		this.wrapper.find('input.discount-amount').on("change", function () {
 			me.frm.doc.discount_amount = flt($(this).val(), precision("discount_amount"));
 			me.frm.doc.additional_discount_percentage = 0.0;
-			me.wrapper.find('input.discount-percentage').val(0);
 			me.refresh();
+			me.wrapper.find('input.discount-percentage').val(0);
 		});
 	},
 
@@ -1517,6 +1523,8 @@ erpnext.pos.PointOfSale = erpnext.taxes_and_totals.extend({
 		var me = this;
 		this.wrapper.find(".net-total").text(format_currency(me.frm.doc.total, me.frm.doc.currency));
 		this.wrapper.find(".grand-total").text(format_currency(me.frm.doc.grand_total, me.frm.doc.currency));
+		this.wrapper.find('input.discount-percentage').val(this.frm.doc.additional_discount_percentage);
+		this.wrapper.find('input.discount-amount').val(this.frm.doc.discount_amount);
 	},
 
 	set_primary_action: function () {


### PR DESCRIPTION
**Issue**
Offline POS discount field calculates wrong discount when entered percentage and only when refreshed it calculates accurately

Fixed https://github.com/frappe/erpnext/issues/11167