### PR TITLE
Make Variant does not copy UOM properties (#10887)

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -451,3 +451,4 @@ erpnext.patches.v8_9.update_billing_gstin_for_indian_account
 erpnext.patches.v9_0.fix_subscription_next_date
 erpnext.patches.v9_0.add_healthcare_domain
 erpnext.patches.v9_0.set_variant_item_description
+erpnext.patches.v9_0.set_uoms_in_variant_field

--- a/erpnext/patches/v9_0/set_uoms_in_variant_field.py
+++ b/erpnext/patches/v9_0/set_uoms_in_variant_field.py
@@ -1,0 +1,14 @@
+from __future__ import unicode_literals
+import frappe
+
+
+def execute():
+	doc = frappe.get_doc('Item Variant Settings')
+	variant_field_names = [vf.field_name for vf in doc.fields]
+	if 'uoms' not in variant_field_names:
+		doc.append(
+			'fields', {
+					'field_name': 'uoms'
+				}
+		)
+	doc.save()

--- a/erpnext/stock/doctype/item/item.json
+++ b/erpnext/stock/doctype/item/item.json
@@ -1072,7 +1072,7 @@
    "in_standard_filter": 0, 
    "label": "UOMs", 
    "length": 0, 
-   "no_copy": 1, 
+   "no_copy": 0,
    "oldfieldname": "uom_conversion_details", 
    "oldfieldtype": "Table", 
    "options": "UOM Conversion Detail", 


### PR DESCRIPTION
Fixes #10887 
Bug stemmed from the fact that `uoms` was set as no_copy. `uoms` should also be in Item Variant Settings by default but isn't.

This PR fixes both issues
