### PR TITLE
v8.x.x  Allow Doctypes with space in name to be filtered in General Ledger

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -348,6 +348,7 @@ def apply_internal_priority(pricing_rules, field_set, args):
 	return filtered_rules or pricing_rules
 
 def set_transaction_type(args):
+	if args.transaction_type:return
 	if args.doctype in ("Opportunity", "Quotation", "Sales Order", "Delivery Note", "Sales Invoice"):
 		args.transaction_type = "selling"
 	elif args.doctype in ("Material Request", "Supplier Quotation", "Purchase Order",

--- a/erpnext/accounts/report/general_ledger/general_ledger.js
+++ b/erpnext/accounts/report/general_ledger/general_ledger.js
@@ -83,7 +83,7 @@ frappe.query_reports["General Ledger"] = {
 					return;
 				}
 
-				var fieldname = party_type.toLowerCase() + "_name";
+				var fieldname = frappe.model.scrub(party_type)+"_name";
 				frappe.db.get_value(party_type, party, fieldname, function(value) {
 					frappe.query_report_filters_by_name.party_name.set_value(value[fieldname]);
 				});


### PR DESCRIPTION
For party_type value that has a space in its name, when a party is selected in general ledger report for filtering this error occurs
![gledger_err_scrub](https://user-images.githubusercontent.com/17238907/31828721-0391e786-b5b3-11e7-93a7-f749f78484f0.png)
This solves it.

