### PR TITLE
Cost center number for Cost Centers

### DIFF
--- a/erpnext/accounts/doctype/cost_center/cost_center.js
+++ b/erpnext/accounts/doctype/cost_center/cost_center.js
@@ -15,6 +15,46 @@ frappe.ui.form.on('Cost Center', {
 				}
 			}
 		})
+	},
+	update_cost_center_number: function(frm) {
+		var d = new frappe.ui.Dialog({
+			title: __('Update Cost Center Number'),
+			fields: [
+				{
+					"label": "Cost Center Number",
+					"fieldname": "cost_center_number",
+					"fieldtype": "Data",
+					"reqd": 1
+				}
+			],
+			primary_action: function() {
+				var data = d.get_values();
+				if(data.cost_center_number === frm.doc.cost_center_number) {
+					d.hide();
+					return;
+				}
+
+				frappe.call({
+					method: "erpnext.accounts.doctype.cost_center.cost_center.update_cost_center_number",
+					args: {
+						cost_center_number: data.cost_center_number,
+						name: frm.doc.name
+					},
+					callback: function(r) {
+						if(!r.exc) {
+							if(r.message) {
+								frappe.set_route("Form", "Cost Center", r.message);
+							} else {
+								frm.set_value("cost_center_number", data.cost_center_number);
+							}
+							d.hide();
+						}
+					}
+				});
+			},
+			primary_action_label: __('Update')
+		});
+		d.show();
 	}
 })
 
@@ -38,6 +78,9 @@ cur_frm.cscript.refresh = function(doc, cdt, cdn) {
 
 		cur_frm.add_custom_button(__('Budget'),
 			function() { frappe.set_route("List", "Budget", {'cost_center': cur_frm.doc.name}); });
+	
+		cur_frm.add_custom_button(__('Update Cost Center Number'), 
+			function () { cur_frm.trigger("update_cost_center_number"); });	
 	}
 }
 

--- a/erpnext/accounts/doctype/cost_center/cost_center.json
+++ b/erpnext/accounts/doctype/cost_center/cost_center.json
@@ -1,5 +1,6 @@
 {
  "allow_copy": 1, 
+ "allow_guest_to_view": 0, 
  "allow_import": 1, 
  "allow_rename": 1, 
  "autoname": "field:cost_center_name", 
@@ -13,6 +14,7 @@
  "editable_grid": 0, 
  "fields": [
   {
+   "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -41,6 +43,7 @@
    "unique": 0
   }, 
   {
+   "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -71,6 +74,37 @@
    "unique": 0
   }, 
   {
+   "allow_bulk_edit": 0, 
+   "allow_on_submit": 0, 
+   "bold": 0, 
+   "collapsible": 0, 
+   "columns": 0, 
+   "fieldname": "cost_center_number", 
+   "fieldtype": "Data", 
+   "hidden": 0, 
+   "ignore_user_permissions": 0, 
+   "ignore_xss_filter": 0, 
+   "in_filter": 0, 
+   "in_global_search": 0, 
+   "in_list_view": 0, 
+   "in_standard_filter": 0, 
+   "label": "Cost Center Number", 
+   "length": 0, 
+   "no_copy": 0, 
+   "permlevel": 0, 
+   "precision": "", 
+   "print_hide": 0, 
+   "print_hide_if_no_value": 0, 
+   "read_only": 1, 
+   "remember_last_selected_value": 0, 
+   "report_hide": 0, 
+   "reqd": 0, 
+   "search_index": 0, 
+   "set_only_once": 0, 
+   "unique": 0
+  }, 
+  {
+   "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -102,6 +136,7 @@
    "unique": 0
   }, 
   {
+   "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -133,6 +168,7 @@
    "unique": 0
   }, 
   {
+   "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -161,6 +197,7 @@
    "width": "50%"
   }, 
   {
+   "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -191,6 +228,7 @@
    "unique": 0
   }, 
   {
+   "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -221,6 +259,7 @@
    "unique": 0
   }, 
   {
+   "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -251,6 +290,7 @@
    "unique": 0
   }, 
   {
+   "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -282,19 +322,19 @@
    "unique": 0
   }
  ], 
+ "has_web_view": 0, 
  "hide_heading": 0, 
  "hide_toolbar": 0, 
  "icon": "fa fa-money", 
  "idx": 1, 
  "image_view": 0, 
  "in_create": 0, 
- "in_dialog": 0, 
  "is_submittable": 0, 
  "issingle": 0, 
  "istable": 0, 
  "max_attachments": 0, 
  "menu_index": 0, 
- "modified": "2017-02-17 16:22:27.129572", 
+ "modified": "2017-10-22 12:39:27.693321", 
  "modified_by": "Administrator", 
  "module": "Accounts", 
  "name": "Cost Center", 

--- a/erpnext/accounts/doctype/cost_center/cost_center.py
+++ b/erpnext/accounts/doctype/cost_center/cost_center.py
@@ -61,7 +61,20 @@ class CostCenter(NestedSet):
 
 	def after_rename(self, olddn, newdn, merge=False):
 		if not merge:
-			#new_cc = frappe.db.get_value("Cost Center", newdn, ["cost_center_name", "cost_center_number"], as_dict=1)
+			new_cc = frappe.db.get_value("Cost Center", newdn, ["cost_center_name", "cost_center_number"], as_dict=1)
+			# exclude company abbr
+			new_parts = newdn.split(" - ")[:-1]
+
+			# update cost center number and remove from parts
+			if new_parts[0][0].isdigit():
+				# if cost center number is separate by space, split using space
+				if len(new_parts) == 1:
+					new_parts = newdn.split(" ")
+				if new_cc.cost_center_number != new_parts[0]:
+					self.cost_center_number = new_parts[0]
+					self.db_set("cost_center_number", new_parts[0])
+				new_parts = new_parts[1:]
+
 			frappe.db.set_value("Cost Center", newdn, "cost_center_name",
 				" - ".join(newdn.split(" - ")[:-1]))
 		else:

--- a/erpnext/accounts/doctype/cost_center/cost_center.py
+++ b/erpnext/accounts/doctype/cost_center/cost_center.py
@@ -5,17 +5,17 @@ from __future__ import unicode_literals
 import frappe
 from frappe import _
 from frappe.utils.nestedset import NestedSet
+from frappe.utils import cstr
 
 class CostCenter(NestedSet):
 	nsm_parent_field = 'parent_cost_center'
 
 	def autoname(self):
-		self.name = self.cost_center_name.strip() + ' - ' + \
-			frappe.db.get_value("Company", self.company, "abbr")
+		self.name = get_cost_center_autoname(self.cost_center_number, self.cost_center_name, self.company)
 			
-
 	def validate(self):
 		self.validate_mandatory()
+		validate_cost_center_number(self.name, self.cost_center_number, self.company)
 
 	def validate_mandatory(self):
 		if self.cost_center_name != self.company and not self.parent_cost_center:
@@ -52,6 +52,7 @@ class CostCenter(NestedSet):
 		# Add company abbr if not provided
 		from erpnext.setup.doctype.company.company import get_name_with_abbr
 		new_cost_center = get_name_with_abbr(newdn, self.company)
+		new_cost_center = get_name_with_number(newdn, self.cost_center_number)
 
 		# Validate properties before merging
 		super(CostCenter, self).before_rename(olddn, new_cost_center, merge, "is_group")
@@ -60,8 +61,50 @@ class CostCenter(NestedSet):
 
 	def after_rename(self, olddn, newdn, merge=False):
 		if not merge:
+			#new_cc = frappe.db.get_value("Cost Center", newdn, ["cost_center_name", "cost_center_number"], as_dict=1)
 			frappe.db.set_value("Cost Center", newdn, "cost_center_name",
 				" - ".join(newdn.split(" - ")[:-1]))
 		else:
 			super(CostCenter, self).after_rename(olddn, newdn, merge)
 
+def get_cost_center_autoname(cost_center_number, cost_center_name, company):
+	company = frappe.db.get_value("Company", company, ["abbr", "name"], as_dict=True)
+	if not company:
+		frappe.throw(_('Company {0} does not exist').format(company))
+
+	parts = [cost_center_name.strip(), company.abbr]
+	if cstr(cost_center_number).strip():
+		parts.insert(0, cstr(cost_center_number).strip())
+	return ' - '.join(parts)
+
+def validate_cost_center_number(name, cost_center_number, company):
+	if cost_center_number:
+		cost_center_with_same_number = frappe.db.get_value("Cost Center",
+			{"cost_center_number": cost_center_number, "company": company, "name": ["!=", name]})
+		if cost_center_with_same_number:
+			frappe.throw(_("Cost Center Number {0} already used in cost center {1}")
+				.format(cost_center_number, cost_center_with_same_number))
+
+@frappe.whitelist()
+def update_cost_center_number(name, cost_center_number):
+	cost_center = frappe.db.get_value("Cost Center", name, ["cost_center_name", "company"], as_dict=True)
+
+	validate_cost_center_number(name, cost_center_number, cost_center.company)
+
+	frappe.db.set_value("Cost Center", name, "cost_center_number", cost_center_number)
+
+	cost_center_name = cost_center.cost_center_name
+	if cost_center_name[0].isdigit():
+		separator = " - " if " - " in cost_center_name else " "
+		cost_center_name = cost_center_name.split(separator, 1)[1]
+	frappe.db.set_value("Cost Center", name, "cost_center_name", cost_center_name)
+
+	new_name = get_cost_center_autoname(cost_center_number, cost_center_name, cost_center.company)
+	if name != new_name:
+		frappe.rename_doc("Cost Center", name, new_name)
+		return new_name
+
+def get_name_with_number(new_cost_center, cost_center_number):
+	if cost_center_number and not new_cost_center[0].isdigit():
+		new_cost_center = cost_center_number + " - " + new_cost_center
+	return new_cost_center

--- a/erpnext/accounts/doctype/cost_center/test_cost_center.js
+++ b/erpnext/accounts/doctype/cost_center/test_cost_center.js
@@ -1,0 +1,23 @@
+/* eslint-disable */
+// rename this file from _test_[name] to test_[name] to activate
+// and remove above this line
+
+QUnit.test("test: Cost Center", function (assert) {
+	let done = assert.async();
+
+	// number of asserts
+	assert.expect(1);
+
+	frappe.run_serially([
+		// insert a new Cost Center
+		() => frappe.tests.make('Cost Center', [
+			// values to be set
+			{key: 'value'}
+		]),
+		() => {
+			assert.equal(cur_frm.doc.key, 'value');
+		},
+		() => done()
+	]);
+
+});


### PR DESCRIPTION
### Brief:

Replicated 'Account Number for Accounts' feature for Cost centers.

User testing has been done. Works as expected in two scenarios:
1. Update Cost Center Number
2. Rename Cost Center

### Workflow

1. Edit in Cost Center Tree / Chart of Cost Centers
![cost_center_number](https://user-images.githubusercontent.com/17795124/31887364-ad53edaa-b815-11e7-9f17-3036fe4b30d5.png)

2. Click on "Update Cost Center Number"
![afterclick_update_account_number_1](https://user-images.githubusercontent.com/17795124/31887838-720cee0c-b817-11e7-8bce-9ae5e2a304c6.png)

3. Update Cost Center number
![cost_center_number_updated](https://user-images.githubusercontent.com/17795124/31887389-c7db4fa6-b815-11e7-8f04-b5b093fdc5ad.png)

4. Updated Cost Center number after rename
![renaming_cost_center](https://user-images.githubusercontent.com/17795124/31887392-cd75bb2c-b815-11e7-96d4-223df836684c.png)
![renamed_cost_center_updated_number](https://user-images.githubusercontent.com/17795124/31887397-d3e446b8-b815-11e7-94b3-f8dcb21fdbcd.png)

### ToDo:

- [ ] User Tests


