### PR TITLE
[Hotfix] Addition of an empty tax group in the french CoA

### DIFF
--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/fr_plan_comptable_general.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/fr_plan_comptable_general.json
@@ -851,7 +851,7 @@
                     "4457-Taxes sur le chiffre d'affaires collect\u00e9es par l'entreprise": {
                         "44571-TVA collect\u00e9e": {
                             "account_type": "Tax", 
-                            "tax_rate": 20.0
+                            "is_group": 1
                         }, 
                         "44578-Taxes assimil\u00e9es \u00e0 la TVA": {}
                     }, 


### PR DESCRIPTION
Hi,

The current french CoA doesn't have any empty group available for the creation of the taxes.

The issue has not been spotted due to issue #11304

Without this correction all installs will fail when issue #11304 is corrected.

I have tested a new install after the correction (and without the CoA field hidden in setup wizard) and the CoA is correctly installed:
![image](https://user-images.githubusercontent.com/4903591/31934116-7bd472b8-b8ab-11e7-96f2-9d11ec8df418.png)

(Tried to push it to "Hotfix" branch, but it automatically adds a lot of other commits to the PR...
![image](https://user-images.githubusercontent.com/4903591/31934259-e49236b4-b8ab-11e7-8876-e9455d9ac6ff.png)


Let me know if you need any additional information or documentation.

Best regards,

Charles-Henri