### PR TITLE
Pass sender as contact email in Opportunity

### DIFF
--- a/erpnext/templates/utils.py
+++ b/erpnext/templates/utils.py
@@ -28,11 +28,12 @@ def send_message(subject="Website Query", message="", sender="", status="Open"):
 			)).insert(ignore_permissions=True)
 
     opportunity = frappe.get_doc(dict(
-    	doctype='Opportunity',
+    	doctype ='Opportunity',
     	enquiry_from = 'Customer' if customer else 'Lead',
     	status = 'Open',
     	title = subject,
-    	to_discuss=message
+	contact_email = sender,
+    	to_discuss = message
     ))
 
     if customer:


### PR DESCRIPTION
Always pass sender as the contact email while creating an opportunity for a website enquiry.