### PR TITLE
[Fix] Translation issue

### DIFF
--- a/erpnext/templates/emails/recurring_document_failed.html
+++ b/erpnext/templates/emails/recurring_document_failed.html
@@ -2,8 +2,8 @@
 
 <p>{{_("An error occured while creating recurring")}} {{ type }} <b>{{ name }}</b> {{_("for")}} <b>{{ party }}</b>.</p>
 <p>{{_("This could be because of some invalid Email Addresses in the")}} {{ type }}.</p>
-<p>{{_("To stop sending repetitive error notifications from the system, we have checked "Disabled" field in the subscription")}} {{ subscription}} {{_("for the")}} {{ type }} {{ name }}.</p>
-<p><b>{{_("Please correct the")}} {{ type }} {{_('and unchcked "Disabled" in the')}} {{ subscription }} {{_("for making recurring again.")}}</b></p>
+<p>{{_("To stop sending repetitive error notifications from the system, we have checked Disabled field in the subscription")}} {{ subscription}} {{_("for the")}} {{ type }} {{ name }}.</p>
+<p><b>{{_("Please correct the")}} {{ type }} {{_('and unchcked Disabled in the')}} {{ subscription }} {{_("for making recurring again.")}}</b></p>
 <hr>
 <p><b>{{_("It is necessary to take this action today itself for the above mentioned recurring")}} {{ type }}
 {{_('to be generated. If delayed, you will have to manually change the "Repeat on Day of Month" field


### PR DESCRIPTION
```
{'retry': 0, 'log': <function log at 0x7f67370911b8>, 'site': u'facturacion', 'event': u'hourly', 'method_name': u'erpnext.accounts.doctype.subscription.subscription.make_subscription_entry', 'method': <function make_subscription_entry at 0x7f67370ab848>, 'user': u'Administrator', 'kwargs': {}, 'async': True, 'job_name': u'erpnext.accounts.doctype.subscription.subscription.make_subscription_entry'}
Traceback (most recent call last):
  File "/home/erp/erpnext/apps/frappe/frappe/utils/background_jobs.py", line 71, in execute_job
    method(**kwargs)
  File "/home/erp/erpnext/apps/erpnext/erpnext/accounts/doctype/subscription/subscription.py", line 128, in make_subscription_entry
    create_documents(data, schedule_date)
  File "/home/erp/erpnext/apps/erpnext/erpnext/accounts/doctype/subscription/subscription.py", line 160, in create_documents
    notify_error_to_user(data)
  File "/home/erp/erpnext/apps/erpnext/erpnext/accounts/doctype/subscription/subscription.py", line 185, in notify_error_to_user
    notify_errors(data.reference_document, data.reference_doctype, party, data.owner, data.name)
  File "/home/erp/erpnext/apps/erpnext/erpnext/accounts/doctype/subscription/subscription.py", line 267, in notify_errors
    message = frappe.get_template("templates/emails/recurring_document_failed.html").render({
  File "/home/erp/erpnext/apps/frappe/frappe/utils/jinja.py", line 23, in get_template
    return get_jenv().get_template(path)
  File "/home/erp/erpnext/env/local/lib/python2.7/site-packages/jinja2/environment.py", line 830, in get_template
    return self._load_template(name, self.make_globals(globals))
  File "/home/erp/erpnext/env/local/lib/python2.7/site-packages/jinja2/environment.py", line 804, in _load_template
    template = self.loader.load(self, name, globals)
  File "/home/erp/erpnext/env/local/lib/python2.7/site-packages/jinja2/loaders.py", line 405, in load
    return loader.load(environment, name, globals)
  File "/home/erp/erpnext/env/local/lib/python2.7/site-packages/jinja2/loaders.py", line 125, in load
    code = environment.compile(source, name, filename)
  File "/home/erp/erpnext/env/local/lib/python2.7/site-packages/jinja2/environment.py", line 591, in compile
    self.handle_exception(exc_info, source_hint=source_hint)
  File "/home/erp/erpnext/env/local/lib/python2.7/site-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/home/erp/erpnext/apps/erpnext/erpnext/./templates/emails/recurring_document_failed.html", line 5, in template
    <p>{{_("To stop sending repetitive error notifications from the system, we have checked "Disabled" field in the subscription")}} {{ subscription}} {{_("for the")}} {{ type }} {{ name }}.</p>
TemplateSyntaxError: expected token ',', got 'Disabled'
```

Fixed https://github.com/frappe/erpnext/issues/11321