### PR TITLE
[Fix] Production order not displaying in the calendar view, if po has no operations

### DIFF
--- a/erpnext/manufacturing/doctype/production_order/production_order.py
+++ b/erpnext/manufacturing/doctype/production_order/production_order.py
@@ -569,7 +569,7 @@ def get_events(start, end, filters=None):
 		where ((ifnull(planned_start_date, '0000-00-00')!= '0000-00-00') \
 				and (planned_start_date <= %(end)s) \
 			and ((ifnull(planned_start_date, '0000-00-00')!= '0000-00-00') \
-				and planned_end_date >= %(start)s)) {conditions}
+				and ifnull(planned_end_date, '2199-12-31 00:00:00') >= %(start)s)) {conditions}
 		""".format(conditions=conditions), {
 			"start": start,
 			"end": end


### PR DESCRIPTION
**Issue**
Create a Production order with a BOM without Operations, save and submit 
Switch to the calendar view, it is not shown. 

Fixed https://github.com/frappe/erpnext/issues/9474