### PR TITLE
Bug - Incorrect Total and Qty in Online POS Cart #11209

### DIFF
--- a/erpnext/selling/page/point_of_sale/point_of_sale.js
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.js
@@ -738,19 +738,24 @@ class POSCart {
 	bind_events() {
 		const me = this;
 		const events = this.events;
+		var flag = false;
 
 		// quantity change
 		this.$cart_items.on('click',
 			'[data-action="increment"], [data-action="decrement"]', function() {
-				const $btn = $(this);
-				const $item = $btn.closest('.list-item[data-item-code]');
-				const item_code = $item.attr('data-item-code');
-				const action = $btn.attr('data-action');
-
-				if(action === 'increment') {
-					events.on_field_change(item_code, 'qty', '+1');
-				} else if(action === 'decrement') {
-					events.on_field_change(item_code, 'qty', '-1');
+				if(!flag){
+					flag = true;
+					setTimeout(function(){ flag = false; }, 500);
+					const $btn = $(this);
+					const $item = $btn.closest('.list-item[data-item-code]');
+					const item_code = $item.attr('data-item-code');
+					const action = $btn.attr('data-action');
+	
+					if(action === 'increment') {
+						events.on_field_change(item_code, 'qty', '+1');
+					} else if(action === 'decrement') {
+						events.on_field_change(item_code, 'qty', '-1');
+					}
 				}
 			});
 
@@ -1013,10 +1018,15 @@ class POSItems {
 
 	bind_events() {
 		var me = this;
+		var flag = false;
 		this.wrapper.on('click', '.pos-item-wrapper', function() {
-			const $item = $(this);
-			const item_code = $item.attr('data-item-code');
-			me.events.update_cart(item_code, 'qty', '+1');
+			if(!flag) {
+				flag = true;
+				setTimeout(function(){ flag=false; }, 500);
+				const $item = $(this);
+				const item_code = $item.attr('data-item-code');
+				me.events.update_cart(item_code, 'qty', '+1');
+			}
 		});
 	}
 


### PR DESCRIPTION
Steps to reproduce bug before fix:
1. Add items to cart by clicking quickly and multiple time which causes Qty field not getting updated correctly.
2. Grand Total showing incorrect value.
3. Remove all items from cart one by one clicking (-) minus sign in Qty field.
4. Check Grand Total. Which should be non zero but showing some value.
5. Goto Menu and open form view, which is showing items which have been removed from Cart.

Steps to Verify bug after fix applied:
1. Add items to cart by clicking quickly and multiple time which causes Qty field to be updated one at a time.
2. Grand Total showing correct value.
3. Remove all items from cart one by one clicking (-) minus sign in Qty field.
4. Check Grand Total. Which should be zero.
5. Goto Menu and open form view, which doesn't have any items.

Here is Corrected behavior:
![bug - incorrect total and qty in online pos cart 11209](https://user-images.githubusercontent.com/3703266/31998462-9b368044-b9ad-11e7-9f81-9218c5e0acd1.gif)