### PR TITLE
[fix] #11337- Add multiple button on Sales Order

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -40,6 +40,10 @@ frappe.ui.form.on("Sales Order", {
 			if(!d.delivery_date) d.delivery_date = frm.doc.delivery_date;
 		});
 		refresh_field("items");
+	},
+
+	onload_post_render: function(frm) {
+		frm.get_field("items").grid.set_multiple_add("item_code", "qty");
 	}
 });
 


### PR DESCRIPTION
Testing Video
![sales_order_add_multiple](https://user-images.githubusercontent.com/20460498/32003381-76fca6ea-b9bc-11e7-9d18-718bb5a209bc.gif)
