### PR TITLE
Update issue.js

### DIFF
--- a/erpnext/support/doctype/issue/issue.js
+++ b/erpnext/support/doctype/issue/issue.js
@@ -4,7 +4,7 @@ frappe.ui.form.on("Issue", {
 	},
 
 	"refresh": function(frm) {
-		if(frm.doc.status==="Open") {
+		if(frm.doc.status!=="Closed") {
 			frm.add_custom_button(__("Close"), function() {
 				frm.set_value("status", "Closed");
 				frm.save();


### PR DESCRIPTION
Make the close / reopen button more flexible for customized user status.

For example, if the user has several status, it will now show the Close button every time the ticket is not closed! It will show Reopen only, if the ticket is closed, and not if it's on hold for example.

This will make it more flexible.