### PR TITLE
[Fix] Getting an error while making delivery note from sales order and sales order has no item code

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -477,9 +477,11 @@ def make_delivery_note(source_name, target_doc=None):
 		target.qty = flt(source.qty) - flt(source.delivered_qty)
 
 		item = frappe.db.get_value("Item", target.item_code, ["item_group", "selling_cost_center"], as_dict=1)
-		target.cost_center = frappe.db.get_value("Project", source_parent.project, "cost_center") \
-			or item.selling_cost_center \
-			or frappe.db.get_value("Item Group", item.item_group, "default_cost_center")
+
+		if item:
+			target.cost_center = frappe.db.get_value("Project", source_parent.project, "cost_center") \
+				or item.selling_cost_center \
+				or frappe.db.get_value("Item Group", item.item_group, "default_cost_center")
 
 	target_doc = get_mapped_doc("Sales Order", source_name, {
 		"Sales Order": {


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2017-10-25/apps/frappe/frappe/app.py", line 57, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2017-10-25/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2017-10-25/apps/frappe/frappe/handler.py", line 53, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2017-10-25/apps/frappe/frappe/__init__.py", line 935, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2017-10-25/apps/frappe/frappe/model/mapper.py", line 38, in map_docs
    target_doc = method(src, target_doc)
  File "/home/frappe/benches/bench-2017-10-25/apps/erpnext/erpnext/selling/doctype/sales_order/sales_order.py", line 509, in make_delivery_note
    }, target_doc, set_missing_values)
  File "/home/frappe/benches/bench-2017-10-25/apps/frappe/frappe/model/mapper.py", line 107, in get_mapped_doc
    map_child_doc(source_d, target_doc, table_map, source_doc)
  File "/home/frappe/benches/bench-2017-10-25/apps/frappe/frappe/model/mapper.py", line 201, in map_child_doc
    map_doc(source_d, target_d, table_map, source_parent)
  File "/home/frappe/benches/bench-2017-10-25/apps/frappe/frappe/model/mapper.py", line 126, in map_doc
    table_map["postprocess"](source_doc, target_doc, source_parent)
  File "/home/frappe/benches/bench-2017-10-25/apps/erpnext/erpnext/selling/doctype/sales_order/sales_order.py", line 481, in update_item
    or item.selling_cost_center \
AttributeError: 'NoneType' object has no attribute 'selling_cost_center'
```