### PR TITLE
return the account if and only if there is single account of that type

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -566,12 +566,17 @@ def get_default_bank_cash_account(company, account_type=None, mode_of_payment=No
 		account = get_bank_cash_account(mode_of_payment, company).get("account")
 
 	if not account:
+		'''
+			Set the default account first. If the user hasn't set any default account then, he doesn't
+			want us to set any random account. In this case set the account only if there is single
+			account (of that type), otherwise return empty dict.
+		'''
 		if account_type=="Bank":
 			account = frappe.db.get_value("Company", company, "default_bank_account")
 			if not account:
 				account_list = frappe.get_all("Account", filters = {"company": company,
 					"account_type": "Bank", "is_group": 0})
-				if len(account_list) > 0:
+				if len(account_list) == 1:
 					account = account_list[0].name
 
 		elif account_type=="Cash":
@@ -579,7 +584,7 @@ def get_default_bank_cash_account(company, account_type=None, mode_of_payment=No
 			if not account:
 				account_list = frappe.get_all("Account", filters = {"company": company,
 					"account_type": "Cash", "is_group": 0})
-				if len(account_list) > 0:
+				if len(account_list) == 1:
 					account = account_list[0].name
 
 	if account:


### PR DESCRIPTION
Let the user set the account in the Journal Entry explicitly, instead of any random account by us implicitly. 