### PR TITLE
[Fix] Packing Slip creation if custom field does not have a value

### DIFF
--- a/erpnext/stock/doctype/packing_slip/packing_slip.py
+++ b/erpnext/stock/doctype/packing_slip/packing_slip.py
@@ -2,11 +2,13 @@
 # License: GNU General Public License v3. See license.txt
 
 from __future__ import unicode_literals
-import frappe
-from frappe.utils import flt, cint
-from frappe import _
 
+import frappe
+from frappe import _
+from frappe.model import no_value_fields
 from frappe.model.document import Document
+from frappe.utils import cint, flt
+
 
 class PackingSlip(Document):
 
@@ -87,11 +89,9 @@ class PackingSlip(Document):
 		rows = [d.item_code for d in self.get("items")]
 
 		# also pick custom fields from delivery note
-		exclude_fieldtypes = ["Column Break", "Section Break"]
-
 		custom_fields = ', '.join(['dni.`{0}`'.format(d.fieldname) for d in
 							 frappe.get_meta("Delivery Note Item").get_custom_fields()
-							 if d.fieldtype not in exclude_fieldtypes])
+							 if d.fieldtype not in no_value_fields])
 
 		if custom_fields:
 			custom_fields = ', ' + custom_fields

--- a/erpnext/stock/doctype/packing_slip/packing_slip.py
+++ b/erpnext/stock/doctype/packing_slip/packing_slip.py
@@ -84,11 +84,14 @@ class PackingSlip(Document):
 			* No. of Cases of this packing slip
 		"""
 
-		# also pick custom fields from delivery note
 		rows = [d.item_code for d in self.get("items")]
 
-		custom_fields = ', '.join(['dni.`{0}`'.format(d.fieldname) for d in \
-			frappe.get_meta("Delivery Note Item").get_custom_fields()])
+		# also pick custom fields from delivery note
+		exclude_fieldtypes = ["Column Break", "Section Break"]
+
+		custom_fields = ', '.join(['dni.`{0}`'.format(d.fieldname) for d in
+							 frappe.get_meta("Delivery Note Item").get_custom_fields()
+							 if d.fieldtype not in exclude_fieldtypes])
 
 		if custom_fields:
 			custom_fields = ', ' + custom_fields

--- a/erpnext/stock/doctype/packing_slip/packing_slip.py
+++ b/erpnext/stock/doctype/packing_slip/packing_slip.py
@@ -89,9 +89,9 @@ class PackingSlip(Document):
 		rows = [d.item_code for d in self.get("items")]
 
 		# also pick custom fields from delivery note
-		custom_fields = ', '.join(['dni.`{0}`'.format(d.fieldname) for d in
-							 frappe.get_meta("Delivery Note Item").get_custom_fields()
-							 if d.fieldtype not in no_value_fields])
+		custom_fields = ', '.join(['dni.`{0}`'.format(d.fieldname)
+			for d in frappe.get_meta("Delivery Note Item").get_custom_fields()
+			if d.fieldtype not in no_value_fields])
 
 		if custom_fields:
 			custom_fields = ', ' + custom_fields


### PR DESCRIPTION
**Issue:**

If you try to create a Packing Slip from a Delivery Note with custom fields, it breaks when trying to retrieve fields that don't actually exist in the database, such as those with fieldtype "Section Break".