### PR TITLE
[minor][hotfix] naming_series variable assignment

### DIFF
--- a/erpnext/schools/doctype/student_applicant/student_applicant.py
+++ b/erpnext/schools/doctype/student_applicant/student_applicant.py
@@ -12,6 +12,7 @@ class StudentApplicant(Document):
 	def autoname(self):
 		from frappe.model.naming import set_name_by_naming_series
 		if self.student_admission:
+			naming_series = None
 			if self.program:
 				student_admission = get_student_admission_data(self.student_admission, self.program)
 				if student_admission:


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2017-11-08/apps/frappe/frappe/desk/form/save.py", line 22, in savedocs
    doc.save()
  File "/home/frappe/benches/bench-2017-11-08/apps/frappe/frappe/model/document.py", line 256, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-2017-11-08/apps/frappe/frappe/model/document.py", line 279, in _save
    self.insert()
  File "/home/frappe/benches/bench-2017-11-08/apps/frappe/frappe/model/document.py", line 212, in insert
    self.set_new_name()
  File "/home/frappe/benches/bench-2017-11-08/apps/frappe/frappe/model/document.py", line 368, in set_new_name
    set_new_name(self)
  File "/home/frappe/benches/bench-2017-11-08/apps/frappe/frappe/model/naming.py", line 38, in set_new_name
    doc.run_method("autoname")
  File "/home/frappe/benches/bench-2017-11-08/apps/frappe/frappe/model/document.py", line 702, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-2017-11-08/apps/frappe/frappe/model/document.py", line 964, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-2017-11-08/apps/frappe/frappe/model/document.py", line 947, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-2017-11-08/apps/frappe/frappe/model/document.py", line 696, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-2017-11-08/apps/erpnext/erpnext/schools/doctype/student_applicant/student_applicant.py", line 22, in autoname
    if naming_series:
UnboundLocalError: local variable 'naming_series' referenced before assignment
```