### PR TITLE
[fix] POS profile patch

### DIFF
--- a/erpnext/patches/v9_0/set_pos_profile_name.py
+++ b/erpnext/patches/v9_0/set_pos_profile_name.py
@@ -11,7 +11,7 @@ def execute():
 	for pos in frappe.get_all(doctype, filters={'disabled': 0}):
 		doc = frappe.get_doc(doctype, pos.name)
 
-		if not doc.user and doc.pos_profile_name: continue
+		if not doc.user or doc.pos_profile_name: continue
 
 		try:
 			doc.pos_profile_name = doc.user + ' - ' + doc.company


### PR DESCRIPTION
**issue**
```
Executing erpnext.patches.v9_0.set_pos_profile_name in erpdev (16071df12be8ddd4)
Traceback (most recent call last):
File "/usr/lib/python2.7/runpy.py", line 162, in _run_module_as_main
"main", fname, loader, pkg_name)
File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
exec code in run_globals
File "/home/erpdev/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 94, in 
main()
File "/home/erpdev/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
click.Group(commands=commands)(prog_name='bench')
File "/home/erpdev/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 722, in call
return self.main(*args, **kwargs)
File "/home/erpdev/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 697, in main
rv = self.invoke(ctx)
File "/home/erpdev/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
return _process_result(sub_ctx.command.invoke(sub_ctx))
File "/home/erpdev/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
return _process_result(sub_ctx.command.invoke(sub_ctx))
File "/home/erpdev/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 895, in invoke
return ctx.invoke(self.callback, **ctx.params)
File "/home/erpdev/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 535, in invoke
return callback(*args, **kwargs)
File "/home/erpdev/frappe-bench/env/local/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
return f(get_current_context(), *args, **kwargs)
File "/home/erpdev/frappe-bench/apps/frappe/frappe/commands/init.py", line 24, in _func
ret = f(frappe._dict(ctx.obj), *args, **kwargs)
File "/home/erpdev/frappe-bench/apps/frappe/frappe/commands/site.py", line 222, in migrate
migrate(context.verbose, rebuild_website=rebuild_website)
File "/home/erpdev/frappe-bench/apps/frappe/frappe/migrate.py", line 31, in migrate
frappe.modules.patch_handler.run_all()
File "/home/erpdev/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 29, in run_all
if not run_single(patchmodule = patch):
File "/home/erpdev/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 63, in run_single
return execute_patch(patchmodule, method, methodargs)
File "/home/erpdev/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 83, in execute_patch
frappe.get_attr(patchmodule.split()[0] + ".execute")()
File "/home/erpdev/frappe-bench/apps/erpnext/erpnext/patches/v9_0/set_pos_profile_name.py", line 17, in execute
doc.pos_profile_name = doc.user + ' - ' + doc.company
TypeError: unsupported operand type(s) for +: 'NoneType' and 'unicode'
```

Fixed https://github.com/frappe/erpnext/issues/11499