### PR TITLE
[fix] query param fixes

### DIFF
--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -185,7 +185,7 @@ def item_query(doctype, txt, searchfield, start, page_len, filters, as_dict=Fals
 				"page_len": page_len
 			}, as_dict=as_dict)
 
-def bom(doctype, txt, searchfield, filters, start=0, page_len=20):
+def bom(doctype, txt, searchfield, start, page_len, filters):
 	conditions = []
 
 	return frappe.db.sql("""select tabBOM.name, tabBOM.item
@@ -204,8 +204,8 @@ def bom(doctype, txt, searchfield, filters, start=0, page_len=20):
 		{
 			'txt': "%%%s%%" % frappe.db.escape(txt),
 			'_txt': txt.replace("%", ""),
-			'start': start,
-			'page_len': page_len
+			'start': start or 0,
+			'page_len': page_len or 20
 		})
 
 def get_project_name(doctype, txt, searchfield, start, page_len, filters):


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2017-11-10/apps/frappe/frappe/app.py", line 57, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2017-11-10/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2017-11-10/apps/frappe/frappe/handler.py", line 53, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2017-11-10/apps/frappe/frappe/__init__.py", line 935, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2017-11-10/apps/frappe/frappe/desk/search.py", line 14, in search_link
    search_widget(doctype, txt, query, searchfield=searchfield, page_length=page_length, filters=filters)
  File "/home/frappe/benches/bench-2017-11-10/apps/frappe/frappe/desk/search.py", line 35, in search_widget
    searchfield, start, page_length, filters, as_dict=as_dict)
  File "/home/frappe/benches/bench-2017-11-10/apps/frappe/frappe/__init__.py", line 935, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2017-11-10/apps/erpnext/erpnext/controllers/queries.py", line 208, in bom
    'page_len': page_len
  File "/home/frappe/benches/bench-2017-11-10/apps/frappe/frappe/database.py", line 152, in sql
    self._cursor.execute(query, values)
  File "/home/frappe/benches/bench-2017-11-10/env/lib/python2.7/site-packages/MySQLdb/cursors.py", line 250, in execute
    self.errorhandler(self, exc, value)
  File "/home/frappe/benches/bench-2017-11-10/env/lib/python2.7/site-packages/MySQLdb/connections.py", line 50, in defaulterrorhandler
    raise errorvalue
ProgrammingError: (1064, "You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ''{u\\'item\\': u\\'CPRb-18M-R420-K401-60/80t\\'}'' at line 10")

```