### PR TITLE
[fix] validate party account

### DIFF
--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -176,29 +176,34 @@ def get_party_account(party_type, party, company):
 	if not company:
 		frappe.throw(_("Please select a Company"))
 
-	if party:
+	if not party:
+		frappe.throw(_("Please select a Party"))
+
+	account = frappe.db.get_value("Party Account",
+		{"parenttype": party_type, "parent": party, "company": company}, "account")
+
+	if not account and party_type in ['Customer', 'Supplier']:
+		party_group_doctype = "Customer Group" if party_type=="Customer" else "Supplier Type"
+		group = frappe.db.get_value(party_type, party, scrub(party_group_doctype))
 		account = frappe.db.get_value("Party Account",
-			{"parenttype": party_type, "parent": party, "company": company}, "account")
+			{"parenttype": party_group_doctype, "parent": group, "company": company}, "account")
 
-		if not account and party_type in ['Customer', 'Supplier']:
-			party_group_doctype = "Customer Group" if party_type=="Customer" else "Supplier Type"
-			group = frappe.db.get_value(party_type, party, scrub(party_group_doctype))
-			account = frappe.db.get_value("Party Account",
-				{"parenttype": party_group_doctype, "parent": group, "company": company}, "account")
+	if not account and party_type in ['Customer', 'Supplier']:
+		default_account_name = "default_receivable_account" \
+			if party_type=="Customer" else "default_payable_account"
+		account = frappe.db.get_value("Company", company, default_account_name)
 
-		if not account and party_type in ['Customer', 'Supplier']:
-			default_account_name = "default_receivable_account" \
-				if party_type=="Customer" else "default_payable_account"
-			account = frappe.db.get_value("Company", company, default_account_name)
+	existing_gle_currency = get_party_gle_currency(party_type, party, company)
+	if existing_gle_currency:
+		if account:
+			account_currency = frappe.db.get_value("Account", account, "account_currency")
+		if (account and account_currency != existing_gle_currency) or not account:
+				account = get_party_gle_account(party_type, party, company)
 
-		existing_gle_currency = get_party_gle_currency(party_type, party, company)
-		if existing_gle_currency:
-			if account:
-				account_currency = frappe.db.get_value("Account", account, "account_currency")
-			if (account and account_currency != existing_gle_currency) or not account:
-					account = get_party_gle_account(party_type, party, company)
+	if not account:
+		frappe.throw(_("Party account not specified, please setup default party account in company"))
 
-		return account
+	return account
 
 def get_party_account_currency(party_type, party, company):
 	def generator():


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2017-10-25/apps/frappe/frappe/app.py", line 57, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2017-10-25/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2017-10-25/apps/frappe/frappe/handler.py", line 53, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2017-10-25/apps/frappe/frappe/__init__.py", line 935, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2017-10-25/apps/erpnext/erpnext/accounts/doctype/payment_entry/payment_entry.py", line 613, in get_party_details
    account_currency = get_account_currency(party_account)
  File "/home/frappe/benches/bench-2017-10-25/apps/erpnext/erpnext/accounts/doctype/account/account.py", line 233, in get_account_currency
    return frappe.local_cache("account_currency", account, generator)
  File "/home/frappe/benches/bench-2017-10-25/apps/frappe/frappe/__init__.py", line 1311, in local_cache
    local.cache[namespace][key] = generator()
  File "/home/frappe/benches/bench-2017-10-25/apps/erpnext/erpnext/accounts/doctype/account/account.py", line 227, in generator
    account_currency, company = frappe.db.get_value("Account", account, ["account_currency", "company"])
TypeError: 'NoneType' object is not iterable
```