### PR TITLE
Fixes for update_sales_cost_in_project patch

### DIFF
--- a/erpnext/patches/v8_0/update_sales_cost_in_project.py
+++ b/erpnext/patches/v8_0/update_sales_cost_in_project.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2013, Web Notes Technologies Pvt. Ltd. and Contributors
+# Copyright (c) 2013, Frappé Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
 
 from __future__ import unicode_literals
@@ -7,6 +7,6 @@ import frappe
 def execute():
 	frappe.db.sql("""
 		update `tabProject` p
-		set total_sales_cost = (select sum(base_grand_total) 
-			from `tabSales Order` where project=p.name and docstatus=1)
+		set total_sales_cost = ifnull((select sum(base_grand_total)
+			from `tabSales Order` where project=p.name and docstatus=1), 0)
 	""")


### PR DESCRIPTION
Will break if select sum(base_grand_total) from `tabSales Order` where project=p.name and docstatus=1 returns Null. Gives - "OperationalError: (1048, "Column 'total_sales_cost' cannot be null")" Error