### PR TITLE
[fix] do not translate domains while creating db record

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -460,3 +460,4 @@ erpnext.patches.v9_0.remove_non_existing_warehouse_from_stock_settings
 execute:frappe.delete_doc_if_exists("DocType", "Program Fee")
 erpnext.patches.v9_0.update_employee_loan_details
 erpnext.patches.v9_2.delete_healthcare_domain_default_items
+erpnext.patches.v9_2.rename_translated_domains_in_en

--- a/erpnext/patches/v9_2/rename_translated_domains_in_en.py
+++ b/erpnext/patches/v9_2/rename_translated_domains_in_en.py
@@ -1,0 +1,26 @@
+import frappe
+from frappe import _
+
+def execute():
+	language = frappe.get_single("System Settings").language
+
+	if language.startswith('en'): return
+
+	all_domains = frappe.get_hooks("domains")
+
+	for domain in all_domains:
+		translated_domain = _(domain, lang=language)
+		if frappe.db.exists("Domain", translated_domain):
+			frappe.rename_doc("Domain", translated_domain, domain, ignore_permissions=True, merge=True)
+
+	domain_settings = frappe.get_single("Domain Settings")
+	active_domains = [d.domain for d in domain_settings.active_domains]
+	
+	for domain in active_domains:
+		domain = frappe.get_doc("Domain", domain)
+		domain.setup_domain()
+
+		if int(frappe.db.get_single_value('System Settings', 'setup_complete')):
+			domain.setup_sidebar_items()
+			domain.setup_desktop_icons()
+			domain.set_default_portal_role()

--- a/erpnext/setup/setup_wizard/install_fixtures.py
+++ b/erpnext/setup/setup_wizard/install_fixtures.py
@@ -14,12 +14,12 @@ default_lead_sources = ["Existing Customer", "Reference", "Advertisement",
 def install(country=None):
 	records = [
 		# domains
-		{ 'doctype': 'Domain', 'domain': _('Distribution')},
-		{ 'doctype': 'Domain', 'domain': _('Manufacturing')},
-		{ 'doctype': 'Domain', 'domain': _('Retail')},
-		{ 'doctype': 'Domain', 'domain': _('Services')},
-		{ 'doctype': 'Domain', 'domain': _('Education')},
-		{ 'doctype': 'Domain', 'domain': _('Healthcare')},
+		{ 'doctype': 'Domain', 'domain': 'Distribution'},
+		{ 'doctype': 'Domain', 'domain': 'Manufacturing'},
+		{ 'doctype': 'Domain', 'domain': 'Retail'},
+		{ 'doctype': 'Domain', 'domain': 'Services'},
+		{ 'doctype': 'Domain', 'domain': 'Education'},
+		{ 'doctype': 'Domain', 'domain': 'Healthcare'},
 
 		# Setup Progress
 		{'doctype': "Setup Progress", "actions": [

--- a/erpnext/setup/setup_wizard/setup_wizard.py
+++ b/erpnext/setup/setup_wizard/setup_wizard.py
@@ -40,7 +40,7 @@ def setup_complete(args=None):
 
 	frappe.local.message_log = []
 	domain_settings = frappe.get_single('Domain Settings')
-	domain_settings.set_active_domains([_(args.get('domain'))])
+	domain_settings.set_active_domains([args.get('domain')])
 
 	frappe.db.commit()
 	login_as_first_user(args)
@@ -185,10 +185,6 @@ def set_defaults(args):
 	hr_settings = frappe.get_doc("HR Settings")
 	hr_settings.emp_created_by = "Naming Series"
 	hr_settings.save()
-
-	domain_settings = frappe.get_doc("Domain Settings")
-	domain_settings.append('active_domains', dict(domain=_(args.get('domain'))))
-	domain_settings.save()
 
 def create_feed_and_todo():
 	"""update Activity feed and create todo for creation of item, customer, vendor"""


### PR DESCRIPTION
 - Import non-translated domain while installing fixtures
 - Patch to rename domain in English and to reset domain settings for activated domain
 - Moved **resave_domain_settings** and **revert_domain_settings** patch from frappe to erpnext. 
     - The domains specified in both patches only belongs to ERPNext. If ERPNext is not installed then these patches will break as they are not found the domain records.
     -  Handled patch re-execution by checking  into Patch Log table 
         ```if frappe.db.get_value("Patch Log", {'patch': 'frappe.patches.v9_1.resave_domain_settings'})```
   

Dependent PR: https://github.com/frappe/frappe/pull/4506