### PR TITLE
[fix] erpnext.patches.v9_1.create_issue_opportunity_type patch failed

### DIFF
--- a/erpnext/patches/v9_1/create_issue_opportunity_type.py
+++ b/erpnext/patches/v9_1/create_issue_opportunity_type.py
@@ -30,5 +30,5 @@ def execute():
 
 	# fixtures
 	for name in ('Hub', _('Sales'), _('Support'), _('Maintenance')):
-		if not frappe.db.exists('Opportunity', name):
+		if not frappe.db.exists('Opportunity Type', name):
 			frappe.get_doc(dict(doctype = 'Opportunity Type', name=name)).insert()


### PR DESCRIPTION
frappe.exceptions.DuplicateEntryError: (u'Opportunity Type', u'Sales', IntegrityError(1062, u"Duplicate entry 'Sales' for key 'PRIMARY'"))