### PR TITLE
[Fix] Item details not fetching if item has no default bom

### DIFF
--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -171,7 +171,7 @@ class BuyingController(StockController):
 			for item in self.get("items"):
 				if self.doctype in ["Purchase Receipt", "Purchase Invoice"]:
 					item.rm_supp_cost = 0.0
-				if item.item_code in self.sub_contracted_items:
+				if item.bom and item.item_code in self.sub_contracted_items:
 					self.update_raw_materials_supplied(item, raw_material_table)
 
 					if [item.item_code, item.name] not in parent_items:

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -96,16 +96,6 @@ def get_item_details(args):
 
 	return out
 
-	# print(frappe._dict({
-	# 	'has_serial_no'	: out.has_serial_no,
-	# 	'has_batch_no'	: out.has_batch_no
-	# }))
-
-	# return frappe._dict({
-	# 	'has_serial_no'	: out.has_serial_no,
-	# 	'has_batch_no'	: out.has_batch_no
-	# })
-
 def process_args(args):
 	if isinstance(args, basestring):
 		args = json.loads(args)
@@ -532,8 +522,6 @@ def get_default_bom(item_code=None):
 		bom = frappe.db.get_value("BOM", {"docstatus": 1, "is_default": 1, "is_active": 1, "item": item_code})
 		if bom:
 			return bom
-		else:
-			frappe.throw(_("No default BOM exists for Item {0}").format(item_code))
 
 def get_valuation_rate(item_code, warehouse=None):
 	item = frappe.get_doc("Item", item_code)


### PR DESCRIPTION
**Issue**
While making purchase order against subcontracted item and item has no default BOM then system not fetched item details like item name, description.