### PR TITLE
filter reports based on Company with User Permission Applied

### DIFF
--- a/erpnext/startup/boot.py
+++ b/erpnext/startup/boot.py
@@ -19,7 +19,7 @@ def boot_session(bootinfo):
 		res = get_user_default_from_user_permission("company",frappe.session['user'])
 		if res==None:
 			res = get_user_default_from_default_value("company")
-			bootinfo.sysdefaults.company = res			
+			bootinfo.sysdefaults.company = res
 		else:
 			bootinfo.user.defaults.company = res
 
@@ -50,7 +50,7 @@ def get_user_default_from_user_permission(key, user=None ):
 	if user:
 		if user != "Guest" and user!="Administrator":
 			#Default the oldest company when more than 1 company is there.
-			res = frappe.db.sql("""select for_value from `tabUser Permission` 
+			res = frappe.db.sql("""select for_value from `tabUser Permission`
 			where allow=%s and user=%s order by creation limit 1""", (key,user))
 			if res:
 				d= res[0][0]
@@ -58,7 +58,7 @@ def get_user_default_from_user_permission(key, user=None ):
 
 def get_user_default_from_default_value(key):
 	d=None
-	res = frappe.db.sql("""select defvalue from `tabDefaultValue` 
+	res = frappe.db.sql("""select defvalue from `tabDefaultValue`
 	where defkey=%s order by creation limit 1""", (key))
 	if res:
 		d= res[0][0]


### PR DESCRIPTION
In context to [defect](https://erpnext.org/bounties/solve-issue---unable-to-filter-reports-based-on-company-with-user-permission-applied)

Defect : At present company dropdown(ex. Trial balance report) , the default company is shown as initially created company for all user irrespective of user has permission to that company.

ERPNext, boot.py is corrected to check value from 'tabUser Permission'. Note if user has permission to more than 1 company then the first created company is set as default. The fix works for all the report/form where company dropdown is present.

After fix
1) Creat an account user and out of say 3 company assign it access to one of the company using User Permission. Note, "Apply for all Roles for this User" has to be checked
2) Login with newly created user and go to Trial balance report
3)Note the company dropdown defaults to the company to which it has access to i.e 1 company. Also options donot show name of other 2 companies.

1)Login with admin user and check the default company in trial balance report. It should be the initially created company