### PR TITLE
Show Batch Selector Dialog Only If There Are Multiple Batches

### DIFF
--- a/erpnext/selling/page/point_of_sale/point_of_sale.js
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.js
@@ -168,8 +168,8 @@ erpnext.pos.PointOfSale = class PointOfSale {
 				value = item.serial_no + '\n'+ value;
 			}
 
-            // if actual_batch_qty and actual_qty if there is only one batch. In such
-            // a case, no point showing the dialog
+			// if actual_batch_qty and actual_qty if there is only one batch. In such
+			// a case, no point showing the dialog
 			if(field === 'qty' && (item.serial_no || item.batch_no)
 			    && (item.actual_batch_qty != item.actual_qty)) {
 				this.select_batch_and_serial_no(item);
@@ -196,8 +196,8 @@ erpnext.pos.PointOfSale = class PointOfSale {
 			.then(() => {
 				const show_dialog = item.has_serial_no || item.has_batch_no;
 
-                // if actual_batch_qty and actual_qty if then there is only one batch. In such
-                // a case, no point showing the dialog
+				// if actual_batch_qty and actual_qty if then there is only one batch. In such
+				// a case, no point showing the dialog
 				if (show_dialog && field == 'qty' && (item.actual_batch_qty != item.actual_qty)) {
 					// check has serial no/batch no and update cart
 					this.select_batch_and_serial_no(item);

--- a/erpnext/selling/page/point_of_sale/point_of_sale.js
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.js
@@ -168,7 +168,10 @@ erpnext.pos.PointOfSale = class PointOfSale {
 				value = item.serial_no + '\n'+ value;
 			}
 
-			if(field === 'qty' && (item.serial_no || item.batch_no)) {
+            // if actual_batch_qty and actual_qty if there is only one batch. In such
+            // a case, no point showing the dialog
+			if(field === 'qty' && (item.serial_no || item.batch_no)
+			    && (item.actual_batch_qty != item.actual_qty)) {
 				this.select_batch_and_serial_no(item);
 			} else {
 				this.update_item_in_frm(item, field, value)
@@ -192,7 +195,10 @@ erpnext.pos.PointOfSale = class PointOfSale {
 			.trigger('item_code', item.doctype, item.name)
 			.then(() => {
 				const show_dialog = item.has_serial_no || item.has_batch_no;
-				if (show_dialog && field == 'qty') {
+
+                // if actual_batch_qty and actual_qty if then there is only one batch. In such
+                // a case, no point showing the dialog
+				if (show_dialog && field == 'qty' && (item.actual_batch_qty != item.actual_qty)) {
 					// check has serial no/batch no and update cart
 					this.select_batch_and_serial_no(item);
 				} else {


### PR DESCRIPTION
Fixes #9643

Batch Selector Dialog will be displayed only if there are multiple batches. In the animated gif below, there is only one batch so the dialog is not displayed.

![peek 2017-11-29 23-44](https://user-images.githubusercontent.com/818803/33403385-805f8620-d560-11e7-80a0-4869b9820f4d.gif)
