### PR TITLE
Portal print format correction

### DIFF
--- a/erpnext/templates/pages/order.py
+++ b/erpnext/templates/pages/order.py
@@ -24,9 +24,9 @@ def get_context(context):
 
 	context.enabled_checkout = frappe.get_doc("Shopping Cart Settings").enable_checkout
 
-	default_print_format = frappe.db.sql("""select value from `tabProperty Setter` where property='default_print_format' and doc_type='{0}'""".format(frappe.form_dict.doctype), as_dict=True)
+	default_print_format = frappe.db.get_value('Property Setter', dict(property='default_print_format', doc_type=frappe.form_dict.doctype), "value")
 	if default_print_format:
-		context.print_format = default_print_format[0].value
+		context.print_format = default_print_format
 	else:
 		context.print_format = "Standard"
 

--- a/erpnext/templates/pages/order.py
+++ b/erpnext/templates/pages/order.py
@@ -24,6 +24,12 @@ def get_context(context):
 
 	context.enabled_checkout = frappe.get_doc("Shopping Cart Settings").enable_checkout
 
+	default_print_format = frappe.db.sql("""select value from `tabProperty Setter` where property='default_print_format' and doc_type='{0}'""".format(frappe.form_dict.doctype), as_dict=True)
+	if default_print_format:
+		context.print_format = default_print_format[0].value
+	else:
+		context.print_format = "Standard"
+
 	if not frappe.has_website_permission(context.doc):
 		frappe.throw(_("Not Permitted"), frappe.PermissionError)
 


### PR DESCRIPTION
Hi,

On the portal, we have the possibility to print orders and invoices, but the default print format set by the user is not correctly fetched, even though the link to print the PDF includes it.

This PR is meant to correct this behavior.

**Logic:**

If a default print format has been setup for a particular doctype, then the PDF will be printed with this print format, else it will use the standard print format.

Thanks.