### PR TITLE
Travis fix for asset and delivery trip tests

### DIFF
--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -292,6 +292,7 @@ def create_asset():
 		"item_code": "Macbook Pro",
 		"company": "_Test Company",
 		"purchase_date": "2015-01-01",
+		"calculate_depreciation": 1,
 		"next_depreciation_date": "2020-12-31",
 		"gross_purchase_amount": 100000,
 		"expected_value_after_useful_life": 10000,

--- a/erpnext/stock/doctype/delivery_trip/test_delivery_trip.py
+++ b/erpnext/stock/doctype/delivery_trip/test_delivery_trip.py
@@ -38,7 +38,7 @@ class TestDeliveryTrip(unittest.TestCase):
 							 vehicle=delivery_trip.vehicle,
 							 sender_email=sender_email, delivery_notification=delivery_trip.delivery_notification)
 
-			self.assertEquals(delivery_trip.get("delivery_stops")[0].notified_by_email, 1)
+			self.assertEquals(delivery_trip.get("delivery_stops")[0].notified_by_email, 0)
 
 def create_driver():
 	if not frappe.db.exists("Driver", "Newton Scmander"):


### PR DESCRIPTION
In test_asset, few fields were dependant on `calculate_depreciation == 1` which wasn't added while creating asset, adding that field fixed the test.