### PR TITLE
[Fix] Only fetch distinct names for Sales Order Calendar

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -668,7 +668,7 @@ def get_events(start, end, filters=None):
 
 	data = frappe.db.sql("""
 		select
-			`tabSales Order`.name, `tabSales Order`.customer_name, `tabSales Order`.status,
+			distinct `tabSales Order`.name, `tabSales Order`.customer_name, `tabSales Order`.status,
 			`tabSales Order`.delivery_status, `tabSales Order`.billing_status,
 			`tabSales Order Item`.delivery_date
 		from


### PR DESCRIPTION
Issue:- [#11411](https://github.com/frappe/erpnext/issues/11411)
![error-so-date](https://user-images.githubusercontent.com/11695402/33552062-86f9aef4-d919-11e7-87fd-cf20cc5a3b2f.gif)
Fix:-
![fix-so-date](https://user-images.githubusercontent.com/11695402/33552065-8a43d18e-d919-11e7-8e32-cea7567b93df.gif)
