### PR TITLE
[Fix] Asset depreciations and balances report showing wrong accumulated depreciation amount if multiple asset against same asset category

### DIFF
--- a/erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py
+++ b/erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py
@@ -99,7 +99,7 @@ def get_accumulated_depreciations(assets, filters):
 		
 		for schedule in asset.get("schedules"):
 			if getdate(schedule.schedule_date) < getdate(filters.from_date):
-				if not asset.disposal_date and getdate(asset.disposal_date) >= getdate(filters.from_date):
+				if not asset.disposal_date or getdate(asset.disposal_date) >= getdate(filters.from_date):
 					depr.accumulated_depreciation_as_on_from_date += flt(schedule.depreciation_amount)
 			elif getdate(schedule.schedule_date) <= getdate(filters.to_date):
 				depr.depreciation_amount_during_the_period += flt(schedule.depreciation_amount)

--- a/erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py
+++ b/erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py
@@ -86,11 +86,14 @@ def get_accumulated_depreciations(assets, filters):
 	for d in assets:
 		asset = frappe.get_doc("Asset", d.name)
 		
-		asset_depreciations.setdefault(d.asset_category, frappe._dict({
-			"accumulated_depreciation_as_on_from_date": asset.opening_accumulated_depreciation,
-			"depreciation_amount_during_the_period": 0,
-			"depreciation_eliminated_during_the_period": 0
-		}))
+		if d.asset_category in asset_depreciations:
+			asset_depreciations[d.asset_category]['accumulated_depreciation_as_on_from_date'] += asset.opening_accumulated_depreciation
+		else:
+			asset_depreciations.setdefault(d.asset_category, frappe._dict({
+				"accumulated_depreciation_as_on_from_date": asset.opening_accumulated_depreciation,
+				"depreciation_amount_during_the_period": 0,
+				"depreciation_eliminated_during_the_period": 0
+			}))
 		
 		depr = asset_depreciations[d.asset_category]
 		


### PR DESCRIPTION
**1st Asset Entry**
![screen shot 2017-12-04 at 5 47 13 pm](https://user-images.githubusercontent.com/8780500/33552652-b6ae853c-d91b-11e7-8a16-23a505b33b86.png)

**2nd Asset Entry**
![screen shot 2017-12-04 at 5 47 27 pm](https://user-images.githubusercontent.com/8780500/33552653-b6dd052e-d91b-11e7-9c9d-630197f12750.png)

**Issue**
Not included value of 1st asset, 1199500
![screen shot 2017-12-04 at 5 35 14 pm](https://user-images.githubusercontent.com/8780500/33552702-ec5a96ee-d91b-11e7-83eb-550a66cb0fd7.png)

**After fix**
1199500 + 760000 = 1959500
![screen shot 2017-12-04 at 5 46 30 pm](https://user-images.githubusercontent.com/8780500/33552807-4e7d8a66-d91c-11e7-834f-3ab04538af9c.png)

