### PR TITLE
[minor] Escape special characters

### DIFF
--- a/erpnext/setup/doctype/item_group/item_group.py
+++ b/erpnext/setup/doctype/item_group/item_group.py
@@ -81,7 +81,7 @@ class ItemGroup(NestedSet, WebsiteGenerator):
 
 @frappe.whitelist(allow_guest=True)
 def get_product_list_for_group(product_group=None, start=0, limit=10, search=None):
-	child_groups = ", ".join(['"' + i[0] + '"' for i in get_child_groups(product_group)])
+	child_groups = ", ".join(['"' + frappe.db.escape(i[0]) + '"' for i in get_child_groups(product_group)])
 
 	# base query
 	query = """select name, item_name, item_code, route, image, website_image, thumbnail, item_group,


### PR DESCRIPTION
**Issue**
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2017-11-28/apps/frappe/frappe/website/render.py", line 39, in render
    data = render_page_by_language(path)
  File "/home/frappe/benches/bench-2017-11-28/apps/frappe/frappe/website/render.py", line 133, in render_page_by_language
    return render_page(path)
  File "/home/frappe/benches/bench-2017-11-28/apps/frappe/frappe/website/render.py", line 149, in render_page
    return build(path)
  File "/home/frappe/benches/bench-2017-11-28/apps/frappe/frappe/website/render.py", line 156, in build
    return build_page(path)
  File "/home/frappe/benches/bench-2017-11-28/apps/frappe/frappe/website/render.py", line 169, in build_page
    context = get_context(path)
  File "/home/frappe/benches/bench-2017-11-28/apps/frappe/frappe/website/context.py", line 28, in get_context
    context = build_context(context)
  File "/home/frappe/benches/bench-2017-11-28/apps/frappe/frappe/website/context.py", line 89, in build_context
    ret = context.doc.get_context(context)
  File "/home/frappe/benches/bench-2017-11-28/apps/erpnext/erpnext/setup/doctype/item_group/item_group.py", line 71, in get_context
    limit=context.page_length + 1, search=frappe.form_dict.get("search")),
  File "/home/frappe/benches/bench-2017-11-28/apps/erpnext/erpnext/setup/doctype/item_group/item_group.py", line 106, in get_product_list_for_group
    data = frappe.db.sql(query, {"product_group": product_group,"search": search, "today": nowdate()}, as_dict=1)
  File "/home/frappe/benches/bench-2017-11-28/apps/frappe/frappe/database.py", line 152, in sql
    self._cursor.execute(query, values)
  File "/home/frappe/benches/bench-2017-11-28/env/lib/python2.7/site-packages/MySQLdb/cursors.py", line 250, in execute
    self.errorhandler(self, exc, value)
  File "/home/frappe/benches/bench-2017-11-28/env/lib/python2.7/site-packages/MySQLdb/connections.py", line 50, in defaulterrorhandler
    raise errorvalue
ProgrammingError: (1064, 'You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near \'TV", "46" TV", "Air Con", "Appliances", "Blu-Ray Player", "Surround Sound Bar", \' at line 8')
```
