### PR TITLE
Payment Entry Returned (#8659)

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -112,7 +112,7 @@ frappe.ui.form.on('Payment Entry', {
 		frm.events.set_dynamic_labels(frm);
 		frm.events.show_general_ledger(frm);
 
-		if(frm.doc.docstatus === 1) {
+		if(frm.doc.docstatus === 1 && frm.doc.payment_type === 'Receive') {
 			frm.add_custom_button(
 				__('Return'),
 				function() {

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -119,6 +119,12 @@ frappe.ui.form.on('Payment Entry', {
 		}
 	},
 
+	/*
+	* Return/Deposit in Make button after deciding which is appropriate.
+	* @param {Frm} frm
+	* @param {string} reversal_button - Label of button for reversal entry
+	* @param {string} redeposit_button - Label of button for redeposit entry
+	*/
 	add_journal_entry_button: function(frm, reversal_button, redeposit_button) {
 		frappe.call({
 			method: 'erpnext.accounts.utils.payment_is_returned',

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -114,12 +114,12 @@ frappe.ui.form.on('Payment Entry', {
 
 		if(frm.doc.docstatus === 1 && frm.doc.payment_type === 'Receive') {
 			frm.events.add_journal_entry_button(
-				frm, 'Return', frm.events.show_return_journal_dialog
+				frm, 'Return', 'Redeposit'
 			);
 		}
 	},
 
-	add_journal_entry_button: function(frm, button_name) {
+	add_journal_entry_button: function(frm, reversal_button, redeposit_button) {
 		frappe.call({
 			method: 'erpnext.accounts.utils.payment_is_returned',
 			args:{
@@ -129,7 +129,16 @@ frappe.ui.form.on('Payment Entry', {
 			},
 			callback: function(r) {
 				if(r.message === 'false') {
-					frm.events.add_button(frm, button_name, frm.events.show_return_journal_dialog);
+					frm.events.add_button(
+						frm, reversal_button, frm.events.show_return_journal_dialog
+					);
+				} else if(r.message === 'true') {
+					frm.events.add_button(
+						frm, redeposit_button, frm.events.show_redeposit_dialog
+					);
+				}
+
+				if(r.message === 'true' || r.message === 'false') {
 					frm.page.set_inner_btn_group_as_primary(__('Make'));
 				}
 			}
@@ -169,14 +178,46 @@ frappe.ui.form.on('Payment Entry', {
 		});
 	},
 
-	show_return_journal_dialog: function(frm) {
-		var dialog = frm.events.get_journal_dialog(frm);
+	show_redeposit_dialog: function(frm) {
+		const dialog = frm.events.get_journal_dialog(frm);
 
 		dialog.set_primary_action(__('Make'), function() {
 			const data = dialog.get_values();
 			if(!data) return;
 
-			data.entry_type = 'Contra Entry';
+			data.voucher_type = 'Bank Entry';
+			data.company = frm.doc.company;
+			data.debit_account = frm.doc.paid_to;
+			data.credit_account = frm.doc.paid_from;
+			data.party = frm.doc.party;
+			data.party_type = frm.doc.party_type;
+			data.paid_amount = frm.doc.paid_amount;
+			data.payment_entry = frm.doc.name;
+			data.payment_entry_date = frm.doc.posting_date;
+
+			frappe.call({
+				method:"erpnext.accounts.utils.make_journal_entry",
+				args: {'args': data},
+				callback: function(r) {
+					dialog.hide();
+					if(r.message) {
+						frappe.set_route("Form", 'Journal Entry', r.message);
+					}
+				}
+			});
+		});
+
+		dialog.show();
+	},
+
+	show_return_journal_dialog: function(frm) {
+		const dialog = frm.events.get_journal_dialog(frm);
+
+		dialog.set_primary_action(__('Make'), function() {
+			const data = dialog.get_values();
+			if(!data) return;
+
+			data.voucher_type = 'Contra Entry';
 			data.company = frm.doc.company;
 			data.debit_account = frm.doc.paid_from;
 			data.credit_account = frm.doc.paid_to;
@@ -196,7 +237,7 @@ frappe.ui.form.on('Payment Entry', {
 					}
 				}
 			});
-		})
+		});
 
 		dialog.show();
 	},

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -128,8 +128,8 @@ frappe.ui.form.on('Payment Entry', {
 				posting_date: frm.doc.posting_date
 			},
 			callback: function(r) {
-				if(r.message === 'true') {
-					add_button(frm, button_name, frm.events.show_return_journal_dialog);
+				if(r.message === 'false') {
+					frm.events.add_button(frm, button_name, frm.events.show_return_journal_dialog);
 					frm.page.set_inner_btn_group_as_primary(__('Make'));
 				}
 			}
@@ -153,8 +153,8 @@ frappe.ui.form.on('Payment Entry', {
 		);
 	},
 
-	show_return_journal_dialog: function(frm) {
-		var dialog = new frappe.ui.Dialog({
+	get_journal_dialog: function(frm) {
+		return new frappe.ui.Dialog({
 			fields: [
 				{
 					fieldtype:'Date', reqd:1, label:'Posting Date',
@@ -167,6 +167,10 @@ frappe.ui.form.on('Payment Entry', {
 				},
 			]
 		});
+	},
+
+	show_return_journal_dialog: function(frm) {
+		var dialog = frm.events.get_journal_dialog(frm);
 
 		dialog.set_primary_action(__('Make'), function() {
 			const data = dialog.get_values();

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -111,6 +111,16 @@ frappe.ui.form.on('Payment Entry', {
 		frm.events.hide_unhide_fields(frm);
 		frm.events.set_dynamic_labels(frm);
 		frm.events.show_general_ledger(frm);
+
+		if(frm.doc.docstatus === 1) {
+			frm.add_custom_button(
+				__('Return'),
+				console.log('Button has been added'),
+				__('Make')
+			);
+		}
+
+		frm.page.set_inner_btn_group_as_primary(__('Make'));
 	},
 
 	company: function(frm) {

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -160,9 +160,8 @@ frappe.ui.form.on('Payment Entry', {
 				callback: function(r) {
 					dialog.hide();
 					if(r.message) {
-						console.log('Journal has been created ', r.message);
+						frappe.set_route("Form", 'Journal Entry', r.message);
 					}
-					frappe.set_route("Form", 'Journal Entry', r.message);
 				}
 			});
 		})

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -823,8 +823,8 @@ def payment_is_returned(name, amount, posting_date):
 	Tries to make a best guess to determine if a (receive) Payment Entry has been
 	returned/redeposited with a system generated Journal Entry.
 
-	This function expects a sequence of return and redeposits that start with a
-	return Journal entry:
+	This function anticipates a sequence of Contra and Bank Entries starting
+	with a Contra Journal Entry:
 
 	Payment Entry --> Returned --> Redeposited --> Returned --> Redeposited --> ...
 

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -752,7 +752,16 @@ def create_payment_gateway_account(gateway):
 
 @frappe.whitelist()
 def make_journal_entry(args):
-
+	"""
+	:param args: {
+		'debit_account': '', 'credit_account': '', 'cost_center': '',
+		'party_type': '', 'voucher_type': '', 'party': '', 'paid_amount': '',
+		'posting_date': '', 'company': '', 'payment_entry': '',
+		'payment_entry_date': ''
+	}
+	:return: name of created Journal Entry
+	"""
+	# todo: voucher type should not be hard coded
 	def accounts_values():
 		return [
 			dict(
@@ -810,6 +819,24 @@ def make_journal_entry(args):
 
 @frappe.whitelist()
 def payment_is_returned(name, amount, posting_date):
+	"""
+	Tries to make a best guess to determine if a (receive) Payment Entry has been
+	returned/redeposited with a system generated Journal Entry.
+
+	This function expects a sequence of return and redeposits that start with a
+	return Journal entry:
+
+	Payment Entry --> Returned --> Redeposited --> Returned --> Redeposited --> ...
+
+	This function assumes this sequence when trying to determine if the Payment Entry
+	is returned or not. If Returned, it returns "true". If not, it returns "false".
+	If the sequence is not as expected, it return "unknown"
+
+	:param name: name of the Payment Entry for which a return/redeposit is being made
+	:param amount: The Payment Entry total amount
+	:param posting_date: Posting date of the Payment Entry
+	:return: one of 'true', 'false' or 'unknown'
+	"""
 
 	def process_journal_entry_sequence(entries):
 		response = 'unknown'

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -793,7 +793,7 @@ def make_journal_entry(args):
 
 	journal_entry.set('accounts', accounts_values())
 
-	journal_entry.save()
+	journal_entry.submit()
 
 	return journal_entry.name
 

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -796,3 +796,19 @@ def make_journal_entry(args):
 	journal_entry.save()
 
 	return journal_entry.name
+
+
+@frappe.whitelist()
+def payment_is_returned(name, amount, posting_date):
+	journal_entry = frappe.get_list(
+		'Journal Entry',
+		filters={
+			'cheque_no': name,
+			'cheque_date': posting_date,
+			'total_debit': amount,
+			'voucher_type': 'Contra Entry',
+			'docstatus': 1
+		}
+	)
+
+	return 'true' if len(journal_entry) == 1 else 'false'

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -793,6 +793,6 @@ def make_journal_entry(args):
 
 	journal_entry.set('accounts', accounts_values())
 
-	journal_entry.submit()
+	journal_entry.save()
 
 	return journal_entry.name

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -848,10 +848,10 @@ def payment_is_returned(name, amount, posting_date):
 
 		# first and even indexed items in list should be of type Contra Entry
 		# second and odd indexed items in list should be of type Bank Entry
-		for i in range(len(entries)):
-			if (i == 0 or i % 2 == 0) and entries[i].voucher_type != 'Contra Entry':
+		for count, entry in enumerate(entries):
+			if (count == 0 or count % 2 == 0) and entry.voucher_type != 'Contra Entry':
 				break
-			elif entries[i].voucher_type != 'Bank Entry':
+			elif entry.voucher_type != 'Bank Entry':
 				break
 
 		# If loop gets to the end, sequence is ok. Use the last element in the

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -761,7 +761,6 @@ def make_journal_entry(args):
 	}
 	:return: name of created Journal Entry
 	"""
-	# todo: voucher type should not be hard coded
 	def accounts_values():
 		return [
 			dict(
@@ -783,12 +782,19 @@ def make_journal_entry(args):
 	if isinstance(args, basestring):
 		args = json.loads(args)
 
+	# Make sure `voucher_type` is either Contra Entry or Bank Entry
+	if args['voucher_type'] not in ['Contra Entry', 'Bank Entry']:
+		frappe.msgprint(
+			_('Voucher Type can only be Bank Entry or Contra Entry'),
+			title='Error', raise_exception=1
+		)
+
 	# Since these values are coming from a Submitted document, they should never
-	# be missing
+	# be missing any value
 	for key in args:
 		if not args[key]:
 			frappe.msgprint(
-				'This document has missing fields. No Journal will be created.'
+				_('This document has missing fields. No Journal will be created.')
 			)
 			return
 
@@ -798,13 +804,13 @@ def make_journal_entry(args):
 	journal_entry.posting_date = args['posting_date']
 
 	if args['voucher_type'] == 'Contra Entry':
-		remark = 'Payment Entry {0} from {1} returned.'\
-			.format(args['payment_entry'], args['party'])
-	elif args['voucher_type'] == 'Bank Entry':
-		remark = 'Cheque for Payment Entry {0} from {1} redeposited'.\
-			format(args['payment_entry'], args['party'])
+		remark = _(
+			'Payment Entry %s from %s returned.' % (args['payment_entry'], args['party'])
+		)
 	else:
-		remark = ''
+		remark = _(
+			'Cheque for Payment Entry %s from %s redeposited' % (args['payment_entry'], args['party'])
+		)
 
 	journal_entry.user_remark = _(remark)
 	journal_entry.cheque_no = args['payment_entry']
@@ -837,7 +843,6 @@ def payment_is_returned(name, amount, posting_date):
 	:param posting_date: Posting date of the Payment Entry
 	:return: one of 'true', 'false' or 'unknown'
 	"""
-
 	def process_journal_entry_sequence(entries):
 		response = 'unknown'
 

--- a/erpnext/tests/ui/make_fixtures.js
+++ b/erpnext/tests/ui/make_fixtures.js
@@ -236,6 +236,18 @@ $.extend(frappe.test_data, {
 				]
 			]}
 		]
+	},
+	"Company": {
+		"Test Company Ui Test": [
+			{company_name: "Test Company Ui Test"},
+			{abbr: "TCUT"},
+			{default_currency: "INR"}
+		]
+	},
+	"Cost Center": {
+		"Test Cost Center": [
+			{cost_center_name: "Test Cost Center"},
+		]
 	}
 });
 


### PR DESCRIPTION
This PR attempts to close #8659.

With this PR, users can have ERPNext automatically create a Journal Entry against a returned payment as well as a repayment.

When a Payment Entry is created, a "Return" button will be added. Behind the scenes, ERPNext will try to verify which button to display ("Return" or "Redeposit") or won't display the button at all if ERPNext is not sure.

![screenshot from 2017-12-08 11-01-49](https://user-images.githubusercontent.com/818803/33764358-6a27f5c6-dc14-11e7-9da7-f3860f434893.png)

![peek 2017-12-08 12-50](https://user-images.githubusercontent.com/818803/33764915-c1daba68-dc16-11e7-809f-c7abccd77c17.gif)

![peek 2017-12-08 11-41](https://user-images.githubusercontent.com/818803/33764418-99f1488e-dc14-11e7-96a3-aee9184ac7c5.gif)

I've tried to track return and redeposit journal entries by saving the generated journal entry with Reference number as the Payment Entry name and Reference Date as Payment Entry posting date. The journal entry for returns also have Entry Type as Contra Entry while for redeposit its "Bank Entry"