### PR TITLE
[Fix] Stock Reconciliation difference amount

### DIFF
--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -55,7 +55,7 @@ class StockReconciliation(StockController):
 
 				item.current_qty = qty
 				item.current_valuation_rate = rate
-				self.difference_amount += (flt(item.qty or qty) * flt(item.valuation_rate or rate) - (flt(qty) * flt(rate)))
+				self.difference_amount += (flt(item.qty) * flt(item.valuation_rate or rate) - (flt(qty) * flt(rate)))
 				return True
 
 		items = filter(lambda d: _changed(d), self.items)


### PR DESCRIPTION
#11902 
Difference amount was calculated as 0 whenever `item_qty == 0` as it considered `qty` instead of `item_qty` and calculated the amount.

![qty](https://user-images.githubusercontent.com/17617465/33820119-c539d734-de73-11e7-83d2-fe07bf5a901a.png)
