### PR TITLE
[fix] Wrong company's default tax template fetch

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -233,9 +233,10 @@ class AccountsController(TransactionBase):
 		tax_master_doctype = self.meta.get_field("taxes_and_charges").options
 
 		if self.is_new() and not self.get("taxes"):
-			if not self.get("taxes_and_charges"):
+			if self.company and not self.get("taxes_and_charges"):
 				# get the default tax master
-				self.taxes_and_charges = frappe.db.get_value(tax_master_doctype, {"is_default": 1})
+				self.taxes_and_charges = frappe.db.get_value(tax_master_doctype,
+					{"is_default": 1, 'company': self.company})
 
 			self.append_taxes_from_master(tax_master_doctype)
 
@@ -717,8 +718,12 @@ def get_tax_rate(account_head):
 	return frappe.db.get_value("Account", account_head, ["tax_rate", "account_name"], as_dict=True)
 
 @frappe.whitelist()
-def get_default_taxes_and_charges(master_doctype):
-	default_tax = frappe.db.get_value(master_doctype, {"is_default": 1})
+def get_default_taxes_and_charges(master_doctype, company=None):
+	if not company: return {}
+
+	default_tax = frappe.db.get_value(master_doctype,
+		{"is_default": 1, "company": company})
+
 	return {
 		'taxes_and_charges': default_tax,
 		'taxes': get_taxes_and_charges(master_doctype, default_tax)

--- a/erpnext/crm/doctype/opportunity/opportunity.py
+++ b/erpnext/crm/doctype/opportunity/opportunity.py
@@ -232,7 +232,7 @@ def make_quotation(source_name, target_doc=None):
 		quotation.conversion_rate = exchange_rate
 
 		# get default taxes
-		taxes = get_default_taxes_and_charges("Sales Taxes and Charges Template")
+		taxes = get_default_taxes_and_charges("Sales Taxes and Charges Template", quotation.company)
 		if taxes.get('taxes'):
 			quotation.update(taxes)
 

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -235,7 +235,8 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 			return frappe.call({
 				method: "erpnext.controllers.accounts_controller.get_default_taxes_and_charges",
 				args: {
-					"master_doctype": taxes_and_charges_field.options
+					"master_doctype": taxes_and_charges_field.options,
+					"company": me.frm.doc.company
 				},
 				callback: function(r) {
 					if(!r.exc) {
@@ -420,8 +421,11 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 					me.frm.set_value("tc_name", company_doc.default_terms);
 				}
 
-				me.frm.script_manager.trigger("currency");
-				me.apply_pricing_rule();
+				frappe.run_serially([
+					() => me.frm.script_manager.trigger("currency"),
+					() => me.apply_default_taxes(),
+					() => me.apply_pricing_rule()
+				]);
 			}
 		}
 


### PR DESCRIPTION
**Fix**

1. For multiple company setup, wrong default tax template fetched while making sales invoice

1. On company change, fetch respective company's default tax template and set in the invoice