### PR TITLE
[fix] Patch

### DIFF
--- a/erpnext/patches/v8_10/change_default_customer_credit_days.py
+++ b/erpnext/patches/v8_10/change_default_customer_credit_days.py
@@ -34,8 +34,8 @@ def execute():
 			else:
 				template = frappe.get_doc("Payment Terms Template", pyt_template_name)
 
-			payment_terms.append('WHEN `name`="%s" THEN "%s"' % (party_name, template.template_name))
-			records.append(party_name)
+			payment_terms.append('WHEN `name`="%s" THEN "%s"' % (frappe.db.escape(party_name), template.template_name))
+			records.append(frappe.db.escape(party_name))
 
 		begin_query_str = "UPDATE `tab{0}` SET `payment_terms` = CASE ".format(doctype)
 		value_query_str = " ".join(payment_terms)


### PR DESCRIPTION
**Issue**
```
Executing erpnext.patches.v8_10.change_default_customer_credit_days in test_gst (953492e79a56ba4b)
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 94, in <module>
    main()
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/env/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 24, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/commands/site.py", line 222, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/migrate.py", line 31, in migrate
    frappe.modules.patch_handler.run_all()
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 29, in run_all
    if not run_single(patchmodule = patch):
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 63, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 83, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/erpnext/erpnext/patches/v8_10/change_default_customer_credit_days.py", line 47, in execute
    (records,)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/database.py", line 166, in sql
    self._cursor.execute(query, values)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/env/lib/python2.7/site-packages/pymysql/cursors.py", line 166, in execute
    result = self._query(query)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/env/lib/python2.7/site-packages/pymysql/cursors.py", line 322, in _query
    conn.query(q)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 856, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1057, in _read_query_result
    result.read()
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1340, in read
    first_packet = self.connection._read_packet()
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1014, in _read_packet
    packet.check_error()
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 393, in check_error
    err.raise_mysql_exception(self._data)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/env/lib/python2.7/site-packages/pymysql/err.py", line 107, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.ProgrammingError: (1064, u'You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near \'G" NIG. LTD, ABUJA" THEN "Default Payment Term - N30" WHEN `name`="SKYSAT TECHNO\' at line 1')
```