### PR TITLE
key fix in demo setup completion

### DIFF
--- a/erpnext/demo/setup/setup_data.py
+++ b/erpnext/demo/setup/setup_data.py
@@ -55,7 +55,7 @@ def complete_setup(domain='Manufacturing'):
 			"fy_start_date": "2015-01-01",
 			"fy_end_date": "2015-12-31",
 			"bank_account": "National Bank",
-			"domain": domain,
+			"domains": [domain],
 			"company_name": data.get(domain).get('company_name'),
 			"chart_of_accounts": "Standard",
 			"company_abbr": ''.join([d[0] for d in data.get(domain).get('company_name').split()]).upper(),


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 94, in <module>
    main()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 664, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 644, in main
    rv = self.invoke(ctx)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 991, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 991, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 837, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 464, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 24, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/utils.py", line 115, in execute
    ret = frappe.get_attr(method)(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/demo/demo.py", line 28, in make
    setup_data.setup(domain)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/demo/setup/setup_data.py", line 12, in setup
    complete_setup(domain)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/demo/setup/setup_data.py", line 65, in complete_setup
    "language": "english"
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.py", line 40, in setup_complete
    frappe.get_attr(method)(args)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/setup/setup_wizard/setup_wizard.py", line 26, in setup_complete
    create_fiscal_year_and_company(args)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/setup/setup_wizard/setup_wizard.py", line 85, in create_fiscal_year_and_company
    'domain': args.get('domains')[0]
TypeError: 'NoneType' object has no attribute '__getitem__'
```