### PR TITLE
Salary Slip not updating when adding/removing Timesheet links

### DIFF
--- a/erpnext/hr/doctype/salary_slip/salary_slip.js
+++ b/erpnext/hr/doctype/salary_slip/salary_slip.js
@@ -98,6 +98,18 @@ frappe.ui.form.on('Salary Detail', {
 	}
 })
 
+frappe.ui.form.on('Salary Slip Timesheet', {
+	time_sheet: function(frm, dt, dn) {
+		frappe.call({
+			method:"set_time_sheet",
+			doc: frm.doc,
+			callback: function(r, rt) {
+				console.log('hey', r)
+			}
+		});
+	}
+});
+
 // Get leave details
 //---------------------------------------------------------------------
 cur_frm.cscript.start_date = function(doc, dt, dn){

--- a/erpnext/hr/doctype/salary_slip/salary_slip.js
+++ b/erpnext/hr/doctype/salary_slip/salary_slip.js
@@ -63,6 +63,7 @@ frappe.ui.form.on("Salary Slip", {
 		var salary_detail_fields = ['formula', 'abbr', 'statistical_component']
 		cur_frm.fields_dict['earnings'].grid.set_column_disp(salary_detail_fields,false);
 		cur_frm.fields_dict['deductions'].grid.set_column_disp(salary_detail_fields,false);
+		total_w_hours(frm)
 	},	
 
 	salary_slip_based_on_timesheet: function(frm) {
@@ -100,13 +101,12 @@ frappe.ui.form.on('Salary Detail', {
 
 frappe.ui.form.on('Salary Slip Timesheet', {
 	time_sheet: function(frm, dt, dn) {
-		frappe.call({
-			method:"set_time_sheet",
-			doc: frm.doc,
-			callback: function(r, rt) {
-				console.log('hey', r)
-			}
-		});
+		total_w_hours(frm)
+		calculate_all(frm.doc)
+	},
+	timesheets_remove: function(frm, dt, dn) {
+		total_w_hours(frm)
+		calculate_all(frm.doc)
 	}
 });
 
@@ -221,4 +221,13 @@ cur_frm.fields_dict.employee.get_query = function(doc,cdt,cdn) {
 	return{
 		query: "erpnext.controllers.queries.employee_query"
 	}
+}
+
+let total_w_hours = function(frm){
+	var total = 0;
+	ts = frm.doc.timesheets
+	for (var i = 0; i < ts.length; i++) {
+		total += ts[i].working_hours
+	}
+	frm.set_value('total_working_hours', total);
 }

--- a/erpnext/hr/doctype/salary_slip/salary_slip.js
+++ b/erpnext/hr/doctype/salary_slip/salary_slip.js
@@ -100,10 +100,10 @@ frappe.ui.form.on('Salary Detail', {
 
 frappe.ui.form.on('Salary Slip Timesheet', {
 	time_sheet: function(frm, dt, dn) {
-		total_work_hours(frm, dt, dn)
+		total_work_hours(frm, dt, dn);
 	},
 	timesheets_remove: function(frm, dt, dn) {
-		total_work_hours(frm, dt, dn)
+		total_work_hours(frm, dt, dn);
 	}
 });
 
@@ -232,7 +232,7 @@ var total_work_hours = function(frm, dt, dn) {
 	});
 	frm.refresh_field('total_working_hours');
 
-	wages_amount = frm.doc.total_working_hours * frm.doc.hour_rate;
+	var wages_amount = frm.doc.total_working_hours * frm.doc.hour_rate;
 
 	frappe.db.get_value('Salary Structure', {'name': frm.doc.salary_structure}, 'salary_component', (r) => {
 		frm.set_value('gross_pay', 0);

--- a/erpnext/hr/doctype/salary_slip/salary_slip.py
+++ b/erpnext/hr/doctype/salary_slip/salary_slip.py
@@ -21,6 +21,7 @@ class SalarySlip(TransactionBase):
 		self.status = self.get_status()
 		self.validate_dates()
 		self.check_existing()
+		# self.pull_sal_struct()
 		if not self.salary_slip_based_on_timesheet:
 			self.get_date_details()
 
@@ -148,7 +149,7 @@ class SalarySlip(TransactionBase):
 			self.set("timesheets", [])
 			timesheets = frappe.db.sql(""" select * from `tabTimesheet` where employee = %(employee)s and start_date BETWEEN %(start_date)s AND %(end_date)s and (status = 'Submitted' or
 				status = 'Billed')""", {'employee': self.employee, 'start_date': self.start_date, 'end_date': self.end_date}, as_dict=1)
-
+			frappe.errprint(timesheets)
 			for data in timesheets:
 				self.append('timesheets', {
 					'time_sheet': data.name,

--- a/erpnext/hr/doctype/salary_slip/salary_slip.py
+++ b/erpnext/hr/doctype/salary_slip/salary_slip.py
@@ -149,7 +149,6 @@ class SalarySlip(TransactionBase):
 			self.set("timesheets", [])
 			timesheets = frappe.db.sql(""" select * from `tabTimesheet` where employee = %(employee)s and start_date BETWEEN %(start_date)s AND %(end_date)s and (status = 'Submitted' or
 				status = 'Billed')""", {'employee': self.employee, 'start_date': self.start_date, 'end_date': self.end_date}, as_dict=1)
-			frappe.errprint(timesheets)
 			for data in timesheets:
 				self.append('timesheets', {
 					'time_sheet': data.name,
@@ -465,3 +464,4 @@ def unlink_ref_doc_from_salary_slip(ref_no):
 		for ss in linked_ss:
 			ss_doc = frappe.get_doc("Salary Slip", ss)
 			frappe.db.set_value("Salary Slip", ss_doc.name, "journal_entry", "")
+

--- a/erpnext/hr/doctype/salary_slip/salary_slip.py
+++ b/erpnext/hr/doctype/salary_slip/salary_slip.py
@@ -21,7 +21,6 @@ class SalarySlip(TransactionBase):
 		self.status = self.get_status()
 		self.validate_dates()
 		self.check_existing()
-		# self.pull_sal_struct()
 		if not self.salary_slip_based_on_timesheet:
 			self.get_date_details()
 
@@ -149,6 +148,7 @@ class SalarySlip(TransactionBase):
 			self.set("timesheets", [])
 			timesheets = frappe.db.sql(""" select * from `tabTimesheet` where employee = %(employee)s and start_date BETWEEN %(start_date)s AND %(end_date)s and (status = 'Submitted' or
 				status = 'Billed')""", {'employee': self.employee, 'start_date': self.start_date, 'end_date': self.end_date}, as_dict=1)
+
 			for data in timesheets:
 				self.append('timesheets', {
 					'time_sheet': data.name,
@@ -464,4 +464,3 @@ def unlink_ref_doc_from_salary_slip(ref_no):
 		for ss in linked_ss:
 			ss_doc = frappe.get_doc("Salary Slip", ss)
 			frappe.db.set_value("Salary Slip", ss_doc.name, "journal_entry", "")
-


### PR DESCRIPTION
#11418 
Summary:
Added a method to update `total_working_hours` whenever Timesheets added/removed if salary slip is based on timesheet.

![timesheetrem](https://user-images.githubusercontent.com/17617465/33927446-63d5b42c-e008-11e7-9b20-6faccf782f94.gif)