### PR TITLE
Land unit tree

### DIFF
--- a/erpnext/agriculture/doctype/land_unit/land_unit.js
+++ b/erpnext/agriculture/doctype/land_unit/land_unit.js
@@ -27,15 +27,4 @@ frappe.ui.form.on('Land Unit', {
 			frm.doc.longitude = frm.fields_dict.location.map.getCenter()['lng'];
 		}
 	},
-	refresh: function(frm) {
-		if(!frm.doc.parent_land_unit) {
-			frm.set_read_only();
-			frm.set_intro(__("This is a root land unit and cannot be edited."));
-		} else {
-			frm.set_intro(null);
-		}
-	},
-	parent_land_unit: function(frm) {
-		frm.set_intro(null);
-	},
 });

--- a/erpnext/agriculture/doctype/land_unit/land_unit.py
+++ b/erpnext/agriculture/doctype/land_unit/land_unit.py
@@ -32,6 +32,7 @@ class LandUnit(NestedSet):
 				ancestor_features[index] = json.loads(feature)
 			ancestor_doc.set_location_value(features = ancestor_features)	
 			ancestor_doc.db_set(fieldname='area', value=ancestor_doc.get('area')-self.get('area'),commit=True)
+		super(LandUnit, self).on_update()
 
 	def validate(self):
 		if not self.is_new():
@@ -78,9 +79,6 @@ class LandUnit(NestedSet):
 		self.db_set(fieldname='location', value=json.dumps(location), commit=True)
 
 	def on_update(self):
-		super(LandUnit, self).on_update()
-
-	def on_trash(self):
 		super(LandUnit, self).on_update()
 
 	def add_child_property(self):

--- a/erpnext/agriculture/doctype/land_unit/land_unit.py
+++ b/erpnext/agriculture/doctype/land_unit/land_unit.py
@@ -79,7 +79,9 @@ class LandUnit(NestedSet):
 
 	def on_update(self):
 		super(LandUnit, self).on_update()
-		self.validate_one_root()
+
+	def on_trash(self):
+		super(LandUnit, self).on_update()
 
 	def add_child_property(self):
 		location = self.get('location')
@@ -163,4 +165,18 @@ def ring_area(coords):
 
 		area = area * RADIUS * RADIUS / 2
 	return area
+
+@frappe.whitelist()
+def get_children(doctype, parent, is_root=False):
+	if is_root:
+		parent = ''
+
+	land_units = frappe.db.sql("""select name as value,
+		is_group as expandable
+		from `tabLand Unit`
+		where ifnull(`parent_land_unit`,'') = %s
+		order by name""", (parent), as_dict=1)
+
+	# return nodes
+	return land_units
 		

--- a/erpnext/agriculture/doctype/land_unit/land_unit_tree.js
+++ b/erpnext/agriculture/doctype/land_unit/land_unit_tree.js
@@ -1,11 +1,28 @@
 frappe.treeview_settings["Land Unit"] = {
+	get_tree_nodes: "erpnext.agriculture.doctype.land_unit.land_unit.get_children",
 	ignore_fields:["parent_land_unit"],
+	get_tree_root: false,
 	disable_add_node: true,
+	root_label: "All Land Units",
+	onload: function(me) {
+		me.make_tree();
+	},
 	toolbar: [
 		{ toggle_btn: true },
 		{
-			label:__("Add Child"),
+			label:__("Edit"),
+			condition: function(node) { return (node.label!='All Land Units'); },
 			click: function(node) {
+				var lu = frappe.new_doc("Land Unit", {
+					"parent_land_unit": node.label
+				});
+			}
+		},
+		{
+			label:__("Add Child"),
+			condition: function(node) { return node.expandable; },
+			click: function(node) {
+				if(node.label=='All Land Units') node.label='';
 				var lu = frappe.new_doc("Land Unit", {
 					"parent_land_unit": node.label
 				});

--- a/erpnext/agriculture/doctype/land_unit/land_unit_tree.js
+++ b/erpnext/agriculture/doctype/land_unit/land_unit_tree.js
@@ -13,9 +13,7 @@ frappe.treeview_settings["Land Unit"] = {
 			label:__("Edit"),
 			condition: function(node) { return (node.label!='All Land Units'); },
 			click: function(node) {
-				var lu = frappe.new_doc("Land Unit", {
-					"parent_land_unit": node.label
-				});
+				frappe.set_route('Form', 'Land Unit', node.data.value);
 			}
 		},
 		{

--- a/erpnext/agriculture/doctype/land_unit/test_land_unit.js
+++ b/erpnext/agriculture/doctype/land_unit/test_land_unit.js
@@ -12,7 +12,6 @@ QUnit.test("test: Land Unit", function (assert) {
 		// insert a new Land Unit
 		() => frappe.tests.make('Land Unit', [
 			// values to be set
-			{parent_land_unit: 'All Land Units'},
 			{land_unit_name: 'Basil Farm'}
 		]),
 		() => {

--- a/erpnext/agriculture/doctype/land_unit/test_land_unit.py
+++ b/erpnext/agriculture/doctype/land_unit/test_land_unit.py
@@ -9,7 +9,7 @@ import unittest
 class TestLandUnit(unittest.TestCase):
 
 	def runTest(self):
-		land_units = ['Basil Farm', 'Division 1', 'Field 1', 'Block 1']
+		land_units = ['Division 1', 'Field 1', 'Block 1']
 		area = 0                                                             
 		formatted_land_units = []	
 		for land_unit in land_units:
@@ -21,6 +21,6 @@ class TestLandUnit(unittest.TestCase):
 			temp['features'][0]['properties']['feature_of'] =	land_unit 
 			formatted_land_units.extend(temp['features'])
 		formatted_land_unit_string = str(formatted_land_units)
-		all_land_units = frappe.get_doc('Land Unit', 'All Land Units')
-		self.assertEquals(formatted_land_unit_string, str(json.loads(all_land_units.get('location'))['features']))
-		self.assertEquals(area, all_land_units.get('area'))
+		basil_farm = frappe.get_doc('Land Unit', 'Basil Farm')
+		self.assertEquals(formatted_land_unit_string, str(json.loads(basil_farm.get('location'))['features']))
+		self.assertEquals(area, basil_farm.get('area'))

--- a/erpnext/agriculture/doctype/land_unit/test_land_unit.py
+++ b/erpnext/agriculture/doctype/land_unit/test_land_unit.py
@@ -9,7 +9,7 @@ import unittest
 class TestLandUnit(unittest.TestCase):
 
 	def runTest(self):
-		land_units = ['Division 1', 'Field 1', 'Block 1']
+		land_units = ['Basil Farm', 'Division 1', 'Field 1', 'Block 1']
 		area = 0                                                             
 		formatted_land_units = []	
 		for land_unit in land_units:
@@ -21,6 +21,6 @@ class TestLandUnit(unittest.TestCase):
 			temp['features'][0]['properties']['feature_of'] =	land_unit 
 			formatted_land_units.extend(temp['features'])
 		formatted_land_unit_string = str(formatted_land_units)
-		basil_farm = frappe.get_doc('Land Unit', 'Basil Farm')
-		self.assertEquals(formatted_land_unit_string, str(json.loads(basil_farm.get('location'))['features']))
-		self.assertEquals(area, basil_farm.get('area'))
+		test_land = frappe.get_doc('Land Unit', 'Test Land')
+		self.assertEquals(formatted_land_unit_string, str(json.loads(test_land.get('location'))['features']))
+		self.assertEquals(area, test_land.get('area'))

--- a/erpnext/agriculture/doctype/land_unit/test_records.json
+++ b/erpnext/agriculture/doctype/land_unit/test_records.json
@@ -1,10 +1,16 @@
 [
 	{
 		"doctype": "Land Unit",
+		"land_unit_name": "Test Land",
+		"is_group": 1,
+		"is_container": 1
+	},
+	{
+		"doctype": "Land Unit",
 		"land_unit_name": "Basil Farm",
 		"location": "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{\"point_type\":\"circle\",\"radius\":884.5625420736483},\"geometry\":{\"type\":\"Point\",\"coordinates\":[72.875834,19.100566]}}]}",
-		"parent_land_unit": "",
-		"parent": "",
+		"parent_land_unit": "Test Land",
+		"parent": "Test Land",
 		"is_group": 1,
 		"is_container": 1
 	},

--- a/erpnext/agriculture/doctype/land_unit/test_records.json
+++ b/erpnext/agriculture/doctype/land_unit/test_records.json
@@ -3,8 +3,8 @@
 		"doctype": "Land Unit",
 		"land_unit_name": "Basil Farm",
 		"location": "{\"type\":\"FeatureCollection\",\"features\":[{\"type\":\"Feature\",\"properties\":{\"point_type\":\"circle\",\"radius\":884.5625420736483},\"geometry\":{\"type\":\"Point\",\"coordinates\":[72.875834,19.100566]}}]}",
-		"parent_land_unit": "All Land Units",
-		"parent": "All Land Units",
+		"parent_land_unit": "",
+		"parent": "",
 		"is_group": 1,
 		"is_container": 1
 	},

--- a/erpnext/agriculture/setup.py
+++ b/erpnext/agriculture/setup.py
@@ -4,18 +4,10 @@ from frappe import _
 from erpnext.setup.utils import insert_record
 
 def setup_agriculture():
-	if frappe.db.exists('Land Unit', 'All Land Units'):
-		# already setup
-		return
 	create_agriculture_data()
 
 def create_agriculture_data():
 	records = [
-		dict(
-			doctype="Land Unit",
-			land_unit_name="All Land Units",
-			is_group=1,
-			is_container=1),
 		dict(
 			doctype='Item Group',
 			item_group_name='Fertilizer',

--- a/erpnext/agriculture/setup.py
+++ b/erpnext/agriculture/setup.py
@@ -4,6 +4,9 @@ from frappe import _
 from erpnext.setup.utils import insert_record
 
 def setup_agriculture():
+	if frappe.get_all('Agriculture Analysis Criteria'):
+		# already setup
+		return
 	create_agriculture_data()
 
 def create_agriculture_data():


### PR DESCRIPTION
![agri-tree](https://user-images.githubusercontent.com/11695402/34078860-0fc59184-e348-11e7-85a7-c60395a64dc7.gif)
Summary:-
Made 'All land Unit' as label rather than a node (just like incase of every other tree structure).
Updated test cases.
