### PR TITLE
Allow to add items in manufacturing process which are not part of bom items

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -49,6 +49,9 @@ class StockEntry(StockController):
 		self.validate_with_material_request()
 		self.validate_batch()
 
+		if not self.from_bom:
+			self.fg_completed_qty = 0.0
+
 		if self._action == 'submit':
 			self.make_batches('t_warehouse')
 		else:


### PR DESCRIPTION
**Issue**
We need solution of Multiple Stock Entry "Material Transfer to Manufacture" of against one Production order(Qty 1 ). and final we make Manufacture entry of that Production order, it will fetched all the items from Stock entry against related to Production order.

Right now, we can able to create only one Stock entry against production order.
when we trying to add more stock entry against production order. gives me an error
"Material Transferred for Manufacturing (2.0) cannot be greater than planned quantity (1.0) in Production Order PRO-0002"

https://github.com/frappe/erpnext/issues/7864