### PR TITLE
[setup] get setup records to be inserted via frappe 

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -28,6 +28,7 @@ doctype_js = {
 setup_wizard_requires = "assets/erpnext/js/setup_wizard.js"
 setup_wizard_stages = "erpnext.setup.setup_wizard.setup_wizard.get_setup_stages"
 setup_wizard_test = "erpnext.setup.setup_wizard.test_setup_wizard.run_setup_wizard_test"
+setup_wizard_success = "erpnext.setup.setup_wizard.setup_wizard.post_setup"
 
 before_install = "erpnext.setup.install.check_setup_wizard_not_completed"
 after_install = "erpnext.setup.install.after_install"
@@ -50,8 +51,6 @@ my_account_context = "erpnext.shopping_cart.utils.update_my_account_context"
 email_append_to = ["Job Applicant", "Lead", "Opportunity", "Issue"]
 
 calendars = ["Task", "Production Order", "Leave Application", "Sales Order", "Holiday List", "Course Schedule"]
-
-
 
 domains = {
 	'Agriculture': 'erpnext.domains.agriculture',

--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -75,7 +75,8 @@ class Company(Document):
 			if not frappe.local.flags.ignore_chart_of_accounts:
 				self.create_default_accounts()
 				self.create_default_warehouses()
-				install_country_fixtures(self.name)
+				if int(frappe.db.get_single_value('System Settings', 'setup_complete')):
+					install_country_fixtures(self.name)
 
 		if not frappe.db.get_value("Cost Center", {"is_group": 0, "company": self.name}):
 			self.create_default_cost_center()

--- a/erpnext/setup/setup_wizard/operations/default_website.py
+++ b/erpnext/setup/setup_wizard/operations/default_website.py
@@ -56,14 +56,14 @@ class website_maker(object):
 		blogger.full_name = user.first_name + (" " + user.last_name if user.last_name else "")
 		blogger.short_name = user.first_name.lower()
 		blogger.avatar = user.user_image
-		blogger.insert()
+		blogger.insert(ignore_if_duplicate=True)
 
 		blog_category = frappe.get_doc({
 			"doctype": "Blog Category",
 			"category_name": "general",
 			"published": 1,
 			"title": _("General")
-		}).insert()
+		}).insert(ignore_if_duplicate=True)
 
 		frappe.get_doc({
 			"doctype": "Blog Post",
@@ -74,7 +74,7 @@ class website_maker(object):
 			"blog_category": blog_category.name,
 			"blog_intro": "My First Blog",
 			"content": frappe.get_template("setup/setup_wizard/data/sample_blog_post.html").render(),
-		}).insert()
+		}).insert(ignore_if_duplicate=True)
 
 def test():
 	frappe.delete_doc("Web Page", "test-company")

--- a/erpnext/setup/setup_wizard/operations/defaults_setup.py
+++ b/erpnext/setup/setup_wizard/operations/defaults_setup.py
@@ -18,16 +18,11 @@ def set_default_settings(args):
 		'default_company':args.get('company_name')	,
 		"country": args.get("country"),
 	})
-
-	global_defaults.save()
+	global_defaults.insert()
 
 	system_settings = frappe.get_doc("System Settings")
 	system_settings.email_footer_address = args.get("company_name")
-	system_settings.save()
-
-	domain_settings = frappe.get_single('Domain Settings')
-	domain_settings.set_active_domains(args.get('domains'))
-	domain_settings.save()
+	system_settings.insert()
 
 	stock_settings = frappe.get_doc("Stock Settings")
 	stock_settings.item_naming_by = "Item Code"
@@ -37,14 +32,14 @@ def set_default_settings(args):
 	stock_settings.auto_indent = 1
 	stock_settings.auto_insert_price_list_rate_if_missing = 1
 	stock_settings.automatically_set_serial_nos_based_on_fifo = 1
-	stock_settings.save()
+	stock_settings.insert()
 
 	selling_settings = frappe.get_doc("Selling Settings")
 	selling_settings.cust_master_name = "Customer Name"
 	selling_settings.so_required = "No"
 	selling_settings.dn_required = "No"
 	selling_settings.allow_multiple_items = 1
-	selling_settings.save()
+	selling_settings.insert()
 
 	buying_settings = frappe.get_doc("Buying Settings")
 	buying_settings.supp_master_name = "Supplier Name"
@@ -52,34 +47,17 @@ def set_default_settings(args):
 	buying_settings.pr_required = "No"
 	buying_settings.maintain_same_rate = 1
 	buying_settings.allow_multiple_items = 1
-	buying_settings.save()
+	buying_settings.insert()
 
 	notification_control = frappe.get_doc("Notification Control")
 	notification_control.quotation = 1
 	notification_control.sales_invoice = 1
 	notification_control.purchase_order = 1
-	notification_control.save()
+	notification_control.insert()
 
 	hr_settings = frappe.get_doc("HR Settings")
 	hr_settings.emp_created_by = "Naming Series"
-	hr_settings.save()
-
-def set_no_copy_fields_in_variant_settings():
-	# set no copy fields of an item doctype to item variant settings
-	doc = frappe.get_doc('Item Variant Settings')
-	doc.set_default_fields()
-	doc.save()
-
-def create_price_lists(args):
-	for pl_type, pl_name in (("Selling", _("Standard Selling")), ("Buying", _("Standard Buying"))):
-		frappe.get_doc({
-			"doctype": "Price List",
-			"price_list_name": pl_name,
-			"enabled": 1,
-			"buying": 1 if pl_type == "Buying" else 0,
-			"selling": 1 if pl_type == "Selling" else 0,
-			"currency": args["currency"]
-		}).insert()
+	hr_settings.insert()
 
 def create_employee_for_self(args):
 	if frappe.session.user == 'Administrator':
@@ -94,7 +72,7 @@ def create_employee_for_self(args):
 		"company": args.get("company_name")
 	})
 	emp.flags.ignore_mandatory = True
-	emp.insert(ignore_permissions = True)
+	emp.insert(ignore_permissions = True, ignore_if_duplicate=True)
 
 def create_territories():
 	"""create two default territories, one for home country and one named Rest of the World"""
@@ -109,7 +87,7 @@ def create_territories():
 				"territory_name": name.replace("'", ""),
 				"parent_territory": root_territory,
 				"is_group": "No"
-			}).insert()
+			}).insert(ignore_if_duplicate=True)
 
 def create_feed_and_todo():
 	"""update Activity feed and create todo for creation of item, customer, vendor"""

--- a/erpnext/setup/setup_wizard/operations/install_fixtures.py
+++ b/erpnext/setup/setup_wizard/operations/install_fixtures.py
@@ -6,279 +6,249 @@ from __future__ import unicode_literals
 import frappe
 
 from frappe import _
+from frappe.desk.page.setup_wizard.setup_wizard import insert_records
 
 default_lead_sources = ["Existing Customer", "Reference", "Advertisement",
 	"Cold Calling", "Exhibition", "Supplier Reference", "Mass Mailing",
 	"Customer's Vendor", "Campaign", "Walk In"]
 
 def install(country=None):
-	records = [
-		# domains
-		{ 'doctype': 'Domain', 'domain': 'Distribution'},
-		{ 'doctype': 'Domain', 'domain': 'Manufacturing'},
-		{ 'doctype': 'Domain', 'domain': 'Retail'},
-		{ 'doctype': 'Domain', 'domain': 'Services'},
-		{ 'doctype': 'Domain', 'domain': 'Education'},
-		{ 'doctype': 'Domain', 'domain': 'Healthcare'},
-		{ 'doctype': 'Domain', 'domain': 'Agriculture'},
-		{ 'doctype': 'Domain', 'domain': 'Non Profit'},
-
-		# Setup Progress
-		{'doctype': "Setup Progress", "actions": [
-			{"action_name": "Add Company", "action_doctype": "Company", "min_doc_count": 1, "is_completed": 1,
-				"domains": '[]' },
-			{"action_name": "Set Sales Target", "action_doctype": "Company", "min_doc_count": 99,
-				"action_document": frappe.defaults.get_defaults().get("company") or '',
-				"action_field": "monthly_sales_target", "is_completed": 0,
-				"domains": '["Manufacturing", "Services", "Retail", "Distribution"]' },
-			{"action_name": "Add Customers", "action_doctype": "Customer", "min_doc_count": 1, "is_completed": 0,
-				"domains": '["Manufacturing", "Services", "Retail", "Distribution"]' },
-			{"action_name": "Add Suppliers", "action_doctype": "Supplier", "min_doc_count": 1, "is_completed": 0,
-				"domains": '["Manufacturing", "Services", "Retail", "Distribution"]' },
-			{"action_name": "Add Products", "action_doctype": "Item", "min_doc_count": 1, "is_completed": 0,
-				"domains": '["Manufacturing", "Services", "Retail", "Distribution"]' },
-			{"action_name": "Add Programs", "action_doctype": "Program", "min_doc_count": 1, "is_completed": 0,
-				"domains": '["Education"]' },
-			{"action_name": "Add Instructors", "action_doctype": "Instructor", "min_doc_count": 1, "is_completed": 0,
-				"domains": '["Education"]' },
-			{"action_name": "Add Courses", "action_doctype": "Course", "min_doc_count": 1, "is_completed": 0,
-				"domains": '["Education"]' },
-			{"action_name": "Add Rooms", "action_doctype": "Room", "min_doc_count": 1, "is_completed": 0,
-				"domains": '["Education"]' },
-			{"action_name": "Add Users", "action_doctype": "User", "min_doc_count": 4, "is_completed": 0,
-				"domains": '[]' },
-			{"action_name": "Add Letterhead", "action_doctype": "Letter Head", "min_doc_count": 1, "is_completed": 0,
-				"domains": '[]' }
-		]},
-
-		# address template
-		{'doctype':"Address Template", "country": country},
-
-		# item group
-		{'doctype': 'Item Group', 'item_group_name': _('All Item Groups'),
-			'is_group': 1, 'parent_item_group': ''},
-		{'doctype': 'Item Group', 'item_group_name': _('Products'),
-			'is_group': 0, 'parent_item_group': _('All Item Groups'), "show_in_website": 1 },
-		{'doctype': 'Item Group', 'item_group_name': _('Raw Material'),
-			'is_group': 0, 'parent_item_group': _('All Item Groups') },
-		{'doctype': 'Item Group', 'item_group_name': _('Services'),
-			'is_group': 0, 'parent_item_group': _('All Item Groups') },
-		{'doctype': 'Item Group', 'item_group_name': _('Sub Assemblies'),
-			'is_group': 0, 'parent_item_group': _('All Item Groups') },
-		{'doctype': 'Item Group', 'item_group_name': _('Consumable'),
-			'is_group': 0, 'parent_item_group': _('All Item Groups') },
-
-		# salary component
-		{'doctype': 'Salary Component', 'salary_component': _('Income Tax'), 'description': _('Income Tax'), 'type': 'Deduction'},
-		{'doctype': 'Salary Component', 'salary_component': _('Basic'), 'description': _('Basic'), 'type': 'Earning'},
-		{'doctype': 'Salary Component', 'salary_component': _('Arrear'), 'description': _('Arrear'), 'type': 'Earning'},
-		{'doctype': 'Salary Component', 'salary_component': _('Leave Encashment'), 'description': _('Leave Encashment'), 'type': 'Earning'},
-
-
-		# expense claim type
-		{'doctype': 'Expense Claim Type', 'name': _('Calls'), 'expense_type': _('Calls')},
-		{'doctype': 'Expense Claim Type', 'name': _('Food'), 'expense_type': _('Food')},
-		{'doctype': 'Expense Claim Type', 'name': _('Medical'), 'expense_type': _('Medical')},
-		{'doctype': 'Expense Claim Type', 'name': _('Others'), 'expense_type': _('Others')},
-		{'doctype': 'Expense Claim Type', 'name': _('Travel'), 'expense_type': _('Travel')},
-
-		# leave type
-		{'doctype': 'Leave Type', 'leave_type_name': _('Casual Leave'), 'name': _('Casual Leave'),
-			'is_encash': 1, 'is_carry_forward': 1, 'max_days_allowed': '3', 'include_holiday': 1},
-		{'doctype': 'Leave Type', 'leave_type_name': _('Compensatory Off'), 'name': _('Compensatory Off'),
-			'is_encash': 0, 'is_carry_forward': 0, 'include_holiday': 1},
-		{'doctype': 'Leave Type', 'leave_type_name': _('Sick Leave'), 'name': _('Sick Leave'),
-			'is_encash': 0, 'is_carry_forward': 0, 'include_holiday': 1},
-		{'doctype': 'Leave Type', 'leave_type_name': _('Privilege Leave'), 'name': _('Privilege Leave'),
-			'is_encash': 0, 'is_carry_forward': 0, 'include_holiday': 1},
-		{'doctype': 'Leave Type', 'leave_type_name': _('Leave Without Pay'), 'name': _('Leave Without Pay'),
-			'is_encash': 0, 'is_carry_forward': 0, 'is_lwp':1, 'include_holiday': 1},
-
-		# Employment Type
-		{'doctype': 'Employment Type', 'employee_type_name': _('Full-time')},
-		{'doctype': 'Employment Type', 'employee_type_name': _('Part-time')},
-		{'doctype': 'Employment Type', 'employee_type_name': _('Probation')},
-		{'doctype': 'Employment Type', 'employee_type_name': _('Contract')},
-		{'doctype': 'Employment Type', 'employee_type_name': _('Commission')},
-		{'doctype': 'Employment Type', 'employee_type_name': _('Piecework')},
-		{'doctype': 'Employment Type', 'employee_type_name': _('Intern')},
-		{'doctype': 'Employment Type', 'employee_type_name': _('Apprentice')},
-
-		# Department
-		{'doctype': 'Department', 'department_name': _('Accounts')},
-		{'doctype': 'Department', 'department_name': _('Marketing')},
-		{'doctype': 'Department', 'department_name': _('Sales')},
-		{'doctype': 'Department', 'department_name': _('Purchase')},
-		{'doctype': 'Department', 'department_name': _('Operations')},
-		{'doctype': 'Department', 'department_name': _('Production')},
-		{'doctype': 'Department', 'department_name': _('Dispatch')},
-		{'doctype': 'Department', 'department_name': _('Customer Service')},
-		{'doctype': 'Department', 'department_name': _('Human Resources')},
-		{'doctype': 'Department', 'department_name': _('Management')},
-		{'doctype': 'Department', 'department_name': _('Quality Management')},
-		{'doctype': 'Department', 'department_name': _('Research & Development')},
-		{'doctype': 'Department', 'department_name': _('Legal')},
-
-		# Designation
-		{'doctype': 'Designation', 'designation_name': _('CEO')},
-		{'doctype': 'Designation', 'designation_name': _('Manager')},
-		{'doctype': 'Designation', 'designation_name': _('Analyst')},
-		{'doctype': 'Designation', 'designation_name': _('Engineer')},
-		{'doctype': 'Designation', 'designation_name': _('Accountant')},
-		{'doctype': 'Designation', 'designation_name': _('Secretary')},
-		{'doctype': 'Designation', 'designation_name': _('Associate')},
-		{'doctype': 'Designation', 'designation_name': _('Administrative Officer')},
-		{'doctype': 'Designation', 'designation_name': _('Business Development Manager')},
-		{'doctype': 'Designation', 'designation_name': _('HR Manager')},
-		{'doctype': 'Designation', 'designation_name': _('Project Manager')},
-		{'doctype': 'Designation', 'designation_name': _('Head of Marketing and Sales')},
-		{'doctype': 'Designation', 'designation_name': _('Software Developer')},
-		{'doctype': 'Designation', 'designation_name': _('Designer')},
-		{'doctype': 'Designation', 'designation_name': _('Researcher')},
-
-		# territory
-		{'doctype': 'Territory', 'territory_name': _('All Territories'), 'is_group': 1, 'name': _('All Territories'), 'parent_territory': ''},
-
-		# customer group
-		{'doctype': 'Customer Group', 'customer_group_name': _('All Customer Groups'), 'is_group': 1, 	'name': _('All Customer Groups'), 'parent_customer_group': ''},
-		{'doctype': 'Customer Group', 'customer_group_name': _('Individual'), 'is_group': 0, 'parent_customer_group': _('All Customer Groups')},
-		{'doctype': 'Customer Group', 'customer_group_name': _('Commercial'), 'is_group': 0, 'parent_customer_group': _('All Customer Groups')},
-		{'doctype': 'Customer Group', 'customer_group_name': _('Non Profit'), 'is_group': 0, 'parent_customer_group': _('All Customer Groups')},
-		{'doctype': 'Customer Group', 'customer_group_name': _('Government'), 'is_group': 0, 'parent_customer_group': _('All Customer Groups')},
-
-		# supplier type
-		{'doctype': 'Supplier Type', 'supplier_type': _('Services')},
-		{'doctype': 'Supplier Type', 'supplier_type': _('Local')},
-		{'doctype': 'Supplier Type', 'supplier_type': _('Raw Material')},
-		{'doctype': 'Supplier Type', 'supplier_type': _('Electrical')},
-		{'doctype': 'Supplier Type', 'supplier_type': _('Hardware')},
-		{'doctype': 'Supplier Type', 'supplier_type': _('Pharmaceutical')},
-		{'doctype': 'Supplier Type', 'supplier_type': _('Distributor')},
-
-		# Sales Person
-		{'doctype': 'Sales Person', 'sales_person_name': _('Sales Team'), 'is_group': 1, "parent_sales_person": ""},
-
-		# UOM
-		{'uom_name': _('Unit'), 'doctype': 'UOM', 'name': _('Unit'), "must_be_whole_number": 1},
-		{'uom_name': _('Box'), 'doctype': 'UOM', 'name': _('Box'), "must_be_whole_number": 1},
-		{'uom_name': _('Kg'), 'doctype': 'UOM', 'name': _('Kg')},
-		{'uom_name': _('Meter'), 'doctype': 'UOM', 'name': _('Meter')},
-		{'uom_name': _('Litre'), 'doctype': 'UOM', 'name': _('Litre')},
-		{'uom_name': _('Gram'), 'doctype': 'UOM', 'name': _('Gram')},
-		{'uom_name': _('Nos'), 'doctype': 'UOM', 'name': _('Nos'), "must_be_whole_number": 1},
-		{'uom_name': _('Pair'), 'doctype': 'UOM', 'name': _('Pair'), "must_be_whole_number": 1},
-		{'uom_name': _('Set'), 'doctype': 'UOM', 'name': _('Set'), "must_be_whole_number": 1},
-		{'uom_name': _('Hour'), 'doctype': 'UOM', 'name': _('Hour')},
-		{'uom_name': _('Minute'), 'doctype': 'UOM', 'name': _('Minute')},
-
-		# Mode of Payment
-		{'doctype': 'Mode of Payment',
-			'mode_of_payment': 'Check' if country=="United States" else _('Cheque'),
-			'type': 'Bank'},
-		{'doctype': 'Mode of Payment', 'mode_of_payment': _('Cash'),
-			'type': 'Cash'},
-		{'doctype': 'Mode of Payment', 'mode_of_payment': _('Credit Card'),
-			'type': 'Bank'},
-		{'doctype': 'Mode of Payment', 'mode_of_payment': _('Wire Transfer'),
-			'type': 'Bank'},
-		{'doctype': 'Mode of Payment', 'mode_of_payment': _('Bank Draft'),
-			'type': 'Bank'},
-
-		# Activity Type
-		{'doctype': 'Activity Type', 'activity_type': _('Planning')},
-		{'doctype': 'Activity Type', 'activity_type': _('Research')},
-		{'doctype': 'Activity Type', 'activity_type': _('Proposal Writing')},
-		{'doctype': 'Activity Type', 'activity_type': _('Execution')},
-		{'doctype': 'Activity Type', 'activity_type': _('Communication')},
-
-		# Lead Source
-		{'doctype': "Item Attribute", "attribute_name": _("Size"), "item_attribute_values": [
-			{"attribute_value": _("Extra Small"), "abbr": "XS"},
-			{"attribute_value": _("Small"), "abbr": "S"},
-			{"attribute_value": _("Medium"), "abbr": "M"},
-			{"attribute_value": _("Large"), "abbr": "L"},
-			{"attribute_value": _("Extra Large"), "abbr": "XL"}
-		]},
-
-		{'doctype': "Item Attribute", "attribute_name": _("Colour"), "item_attribute_values": [
-			{"attribute_value": _("Red"), "abbr": "RED"},
-			{"attribute_value": _("Green"), "abbr": "GRE"},
-			{"attribute_value": _("Blue"), "abbr": "BLU"},
-			{"attribute_value": _("Black"), "abbr": "BLA"},
-			{"attribute_value": _("White"), "abbr": "WHI"}
-		]},
-
-		{'doctype': "Email Account", "email_id": "sales@example.com", "append_to": "Opportunity"},
-		{'doctype': "Email Account", "email_id": "support@example.com", "append_to": "Issue"},
-		{'doctype': "Email Account", "email_id": "jobs@example.com", "append_to": "Job Applicant"},
-
-		{'doctype': "Party Type", "party_type": "Customer"},
-		{'doctype': "Party Type", "party_type": "Supplier"},
-		{'doctype': "Party Type", "party_type": "Employee"},
-		{'doctype': "Party Type", "party_type": "Member"},
-
-		{'doctype': "Opportunity Type", "name": "Hub"},
-		{'doctype': "Opportunity Type", "name": _("Sales")},
-		{'doctype': "Opportunity Type", "name": _("Support")},
-		{'doctype': "Opportunity Type", "name": _("Maintenance")},
-
-		{'doctype': "Project Type", "project_type": "Internal"},
-		{'doctype': "Project Type", "project_type": "External"},
-		{'doctype': "Project Type", "project_type": "Other"},
-
-		{"doctype": "Offer Term", "offer_term": _("Date of Joining")},
-		{"doctype": "Offer Term", "offer_term": _("Annual Salary")},
-		{"doctype": "Offer Term", "offer_term": _("Probationary Period")},
-		{"doctype": "Offer Term", "offer_term": _("Employee Benefits")},
-		{"doctype": "Offer Term", "offer_term": _("Working Hours")},
-		{"doctype": "Offer Term", "offer_term": _("Stock Options")},
-		{"doctype": "Offer Term", "offer_term": _("Department")},
-		{"doctype": "Offer Term", "offer_term": _("Job Description")},
-		{"doctype": "Offer Term", "offer_term": _("Responsibilities")},
-		{"doctype": "Offer Term", "offer_term": _("Leaves per Year")},
-		{"doctype": "Offer Term", "offer_term": _("Notice Period")},
-		{"doctype": "Offer Term", "offer_term": _("Incentives")},
-
-		{'doctype': "Print Heading", 'print_heading': _("Credit Note")},
-		{'doctype': "Print Heading", 'print_heading': _("Debit Note")},
-
-		# Assessment Group
-		{'doctype': 'Assessment Group', 'assessment_group_name': _('All Assessment Groups'),
-			'is_group': 1, 'parent_assessment_group': ''},
-
-	]
+	records = []
+	for key, value in get_fixtures(country).iteritems():
+		for record in value:
+			record['doctype'] = key
+			records.append(record)
 
 	from erpnext.setup.setup_wizard.data.industry_type import get_industry_types
 	records += [{"doctype":"Industry Type", "industry": d} for d in get_industry_types()]
-	# records += [{"doctype":"Operation", "operation": d} for d in get_operations()]
-
 	records += [{'doctype': 'Lead Source', 'source_name': _(d)} for d in default_lead_sources]
 
 	# Records for the Supplier Scorecard
 	from erpnext.buying.doctype.supplier_scorecard.supplier_scorecard import make_default_records
 	make_default_records()
 
-	from frappe.modules import scrub
-	for r in records:
-		doc = frappe.new_doc(r.get("doctype"))
-		doc.update(r)
+	return records
 
-		# ignore mandatory for root
-		parent_link_field = ("parent_" + scrub(doc.doctype))
-		if doc.meta.get_field(parent_link_field) and not doc.get(parent_link_field):
-			doc.flags.ignore_mandatory = True
+def get_fixtures(country=None):
+	return {
+		'Domain': [
+			{'domain': 'Distribution'},
+			{'domain': 'Manufacturing'},
+			{'domain': 'Retail'},
+			{'domain': 'Services'},
+			{'domain': 'Education'},
+			{'domain': 'Healthcare'},
+			{'domain': 'Agriculture'},
+			{'domain': 'Non Profit'}
+		],
 
-		try:
-			doc.insert(ignore_permissions=True)
-		except frappe.DuplicateEntryError as e:
-			# pass DuplicateEntryError and continue
-			if e.args and e.args[0]==doc.doctype and e.args[1]==doc.name:
-				# make sure DuplicateEntryError is for the exact same doc and not a related doc
-				pass
-			else:
-				raise
+		'Item Group': [
+			{'item_group_name': _('All Item Groups'), 	'is_group': 1, 'parent_item_group': ''},
+			{'item_group_name': _('Products'), 			'is_group': 0, 'parent_item_group': _('All Item Groups'), "show_in_website": 1 },
+			{'item_group_name': _('Raw Material'),		'is_group': 0, 'parent_item_group': _('All Item Groups') },
+			{'item_group_name': _('Services'), 			'is_group': 0, 'parent_item_group': _('All Item Groups') },
+			{'item_group_name': _('Sub Assemblies'), 	'is_group': 0, 'parent_item_group': _('All Item Groups') },
+			{'item_group_name': _('Consumable'), 		'is_group': 0, 'parent_item_group': _('All Item Groups') }
+		],
 
-	# set default customer group and territory
-	selling_settings = frappe.get_doc("Selling Settings")
-	selling_settings.set_default_customer_group_and_territory()
-	selling_settings.save()
+		'Territory': [
+			{'territory_name': _('All Territories'), 'is_group': 1, 'name': _('All Territories'), 'parent_territory': ''}
+		],
+
+		'Address Template': [
+			{"country": country}
+		],
+
+		'Salary Component': [
+			{'salary_component': _('Income Tax'), 		'description': _('Income Tax'), 'type': 'Deduction'},
+			{'salary_component': _('Basic'), 			'description': _('Basic'), 'type': 'Earning'},
+			{'salary_component': _('Arrear'), 			'description': _('Arrear'), 'type': 'Earning'},
+			{'salary_component': _('Leave Encashment'), 'description': _('Leave Encashment'), 'type': 'Earning'}
+		],
+
+		'Expense Claim Type': [
+			{'name': _('Calls'), 	'expense_type': _('Calls')},
+			{'name': _('Food'), 	'expense_type': _('Food')},
+			{'name': _('Medical'), 	'expense_type': _('Medical')},
+			{'name': _('Others'), 	'expense_type': _('Others')},
+			{'name': _('Travel'), 	'expense_type': _('Travel')},
+		],
+
+		'Leave Type': [
+			{'leave_type_name': _('Casual Leave'), 'name': _('Casual Leave'),
+				'is_encash': 1, 'is_carry_forward': 1, 'max_days_allowed': '3', 'include_holiday': 1},
+			{'leave_type_name': _('Compensatory Off'), 'name': _('Compensatory Off'),
+				'is_encash': 0, 'is_carry_forward': 0, 'include_holiday': 1},
+			{'leave_type_name': _('Sick Leave'), 'name': _('Sick Leave'),
+				'is_encash': 0, 'is_carry_forward': 0, 'include_holiday': 1},
+			{'leave_type_name': _('Privilege Leave'), 'name': _('Privilege Leave'),
+				'is_encash': 0, 'is_carry_forward': 0, 'include_holiday': 1},
+			{'leave_type_name': _('Leave Without Pay'), 'name': _('Leave Without Pay'),
+				'is_encash': 0, 'is_carry_forward': 0, 'is_lwp':1, 'include_holiday': 1},
+		],
+
+		'Employment Type': [
+			{'employee_type_name': _('Full-time')},
+			{'employee_type_name': _('Part-time')},
+			{'employee_type_name': _('Probation')},
+			{'employee_type_name': _('Contract')},
+			{'employee_type_name': _('Commission')},
+			{'employee_type_name': _('Piecework')},
+			{'employee_type_name': _('Intern')},
+			{'employee_type_name': _('Apprentice')},
+		],
+
+		'Department': [
+			{'department_name': _('Accounts')},
+			{'department_name': _('Marketing')},
+			{'department_name': _('Sales')},
+			{'department_name': _('Purchase')},
+			{'department_name': _('Operations')},
+			{'department_name': _('Production')},
+			{'department_name': _('Dispatch')},
+			{'department_name': _('Customer Service')},
+			{'department_name': _('Human Resources')},
+			{'department_name': _('Management')},
+			{'department_name': _('Quality Management')},
+			{'department_name': _('Research & Development')},
+			{'department_name': _('Legal')},
+		],
+
+		'Designation': [
+			{'designation_name': _('CEO')},
+			{'designation_name': _('Manager')},
+			{'designation_name': _('Analyst')},
+			{'designation_name': _('Engineer')},
+			{'designation_name': _('Accountant')},
+			{'designation_name': _('Secretary')},
+			{'designation_name': _('Associate')},
+			{'designation_name': _('Administrative Officer')},
+			{'designation_name': _('Business Development Manager')},
+			{'designation_name': _('HR Manager')},
+			{'designation_name': _('Project Manager')},
+			{'designation_name': _('Head of Marketing and Sales')},
+			{'designation_name': _('Software Developer')},
+			{'designation_name': _('Designer')},
+			{'designation_name': _('Researcher')},
+		],
+
+		'Customer Group': [
+			{'customer_group_name': _('All Customer Groups'), 'is_group': 1, 	'name': _('All Customer Groups'), 'parent_customer_group': ''},
+			{'customer_group_name': _('Individual'), 'is_group': 0, 'parent_customer_group': _('All Customer Groups')},
+			{'customer_group_name': _('Commercial'), 'is_group': 0, 'parent_customer_group': _('All Customer Groups')},
+			{'customer_group_name': _('Non Profit'), 'is_group': 0, 'parent_customer_group': _('All Customer Groups')},
+			{'customer_group_name': _('Government'), 'is_group': 0, 'parent_customer_group': _('All Customer Groups')},
+		],
+
+		'Sales Person': [
+			{'sales_person_name': _('Sales Team'), 'is_group': 1, "parent_sales_person": ""}
+		],
+
+		'Supplier Type': [
+			{'supplier_type': _('Services')},
+			{'supplier_type': _('Local')},
+			{'supplier_type': _('Raw Material')},
+			{'supplier_type': _('Electrical')},
+			{'supplier_type': _('Hardware')},
+			{'supplier_type': _('Pharmaceutical')},
+			{'supplier_type': _('Distributor')},
+		],
+
+		'UOM': [
+			{'uom_name': _('Unit'), 	'name': _('Unit'), "must_be_whole_number": 1},
+			{'uom_name': _('Box'), 		'name': _('Box'), "must_be_whole_number": 1},
+			{'uom_name': _('Kg'), 		'name': _('Kg')},
+			{'uom_name': _('Meter'), 	'name': _('Meter')},
+			{'uom_name': _('Litre'),	'name': _('Litre')},
+			{'uom_name': _('Gram'), 	'name': _('Gram')},
+			{'uom_name': _('Nos'), 		'name': _('Nos'), "must_be_whole_number": 1},
+			{'uom_name': _('Pair'), 	'name': _('Pair'), "must_be_whole_number": 1},
+			{'uom_name': _('Set'), 		'name': _('Set'), "must_be_whole_number": 1},
+			{'uom_name': _('Hour'), 	'name': _('Hour')},
+			{'uom_name': _('Minute'), 	'name': _('Minute')},
+		],
+
+		'Mode of Payment': [
+			{'mode_of_payment': _('Check') if country=="United States" else _('Cheque'), 'type': 'Bank'},
+			{'mode_of_payment': _('Cash'), 			'type': 'Cash'},
+			{'mode_of_payment': _('Credit Card'), 	'type': 'Bank'},
+			{'mode_of_payment': _('Wire Transfer'), 'type': 'Bank'},
+			{'mode_of_payment': _('Bank Draft'),	'type': 'Bank'},
+		],
+
+		'Activity Type': [
+			{'activity_type': _('Planning')},
+			{'activity_type': _('Research')},
+			{'activity_type': _('Proposal Writing')},
+			{'activity_type': _('Execution')},
+			{'activity_type': _('Communication')},
+		],
+
+		'Assessment Group': [
+			{'assessment_group_name': _('All Assessment Groups'), 'is_group': 1, 'parent_assessment_group': ''}
+		],
+
+		'Item Attribute': [
+			{"attribute_name": _("Size"), "item_attribute_values": [
+				{"attribute_value": _("Extra Small"), "abbr": "XS"},
+				{"attribute_value": _("Small"), "abbr": "S"},
+				{"attribute_value": _("Medium"), "abbr": "M"},
+				{"attribute_value": _("Large"), "abbr": "L"},
+				{"attribute_value": _("Extra Large"), "abbr": "XL"}
+			]},
+
+			{"attribute_name": _("Colour"), "item_attribute_values": [
+				{"attribute_value": _("Red"), "abbr": "RED"},
+				{"attribute_value": _("Green"), "abbr": "GRE"},
+				{"attribute_value": _("Blue"), "abbr": "BLU"},
+				{"attribute_value": _("Black"), "abbr": "BLA"},
+				{"attribute_value": _("White"), "abbr": "WHI"}
+			]},
+		],
+
+		'Email Account': [
+			{"email_id": "sales@example.com", "append_to": "Opportunity"},
+			{"email_id": "support@example.com", "append_to": "Issue"},
+			{"email_id": "jobs@example.com", "append_to": "Job Applicant"},
+		],
+
+		'Party Type': [
+			{"party_type": "Customer"},
+			{"party_type": "Supplier"},
+			{"party_type": "Employee"},
+			{"party_type": "Member"},
+		],
+
+		'Opportunity Type': [
+			{"name": _("Hub")},
+			{"name": _("Sales")},
+			{"name": _("Support")},
+			{"name": _("Maintenance")},
+		],
+
+		'Project Type': [
+			{"project_type": "Internal"},
+			{"project_type": "External"},
+			{"project_type": "Other"},
+		],
+
+		'Offer Term': [
+			{"offer_term": _("Date of Joining")},
+			{"offer_term": _("Annual Salary")},
+			{"offer_term": _("Probationary Period")},
+			{"offer_term": _("Employee Benefits")},
+			{"offer_term": _("Working Hours")},
+			{"offer_term": _("Stock Options")},
+			{"offer_term": _("Department")},
+			{"offer_term": _("Job Description")},
+			{"offer_term": _("Responsibilities")},
+			{"offer_term": _("Leaves per Year")},
+			{"offer_term": _("Notice Period")},
+			{"offer_term": _("Incentives")},
+		],
+
+		'Print Heading': [
+			{'print_heading': _("Credit Note")},
+			{'print_heading': _("Debit Note")},
+		]
+	}

--- a/erpnext/setup/setup_wizard/operations/sample_data.py
+++ b/erpnext/setup/setup_wizard/operations/sample_data.py
@@ -45,7 +45,7 @@ def make_opportunity(items, customer):
 		"item_code": ["Item"]
 	}, unique="item_code")
 
-	b.insert(ignore_permissions=True)
+	b.insert(ignore_permissions=True, ignore_if_duplicate=True)
 
 	b.add_comment('Comment', text="This is a dummy record")
 
@@ -62,7 +62,7 @@ def make_quote(items, customer):
 		"item_code": ["Item"]
 	}, unique="item_code")
 
-	qtn.insert(ignore_permissions=True)
+	qtn.insert(ignore_permissions=True, ignore_if_duplicate=True)
 
 	qtn.add_comment('Comment', text="This is a dummy record")
 
@@ -78,7 +78,7 @@ def make_material_request(items):
 				"qty": 10
 			}]
 		})
-		mr.insert()
+		mr.insert(ignore_if_duplicate=True)
 		mr.submit()
 
 		mr.add_comment('Comment', text="This is a dummy record")
@@ -157,13 +157,13 @@ def make_projects(domains):
 
 		project.append('tasks', t)
 
-	project.insert(ignore_permissions=True)
+	project.insert(ignore_permissions=True, ignore_if_duplicate=True)
 
 def import_email_alert():
 	'''Import email alert for task start'''
 	with open (os.path.join(os.path.dirname(__file__), "tasks/task_alert.json")) as f:
 		email_alert = frappe.get_doc(json.loads(f.read())[0])
-		email_alert.insert()
+		email_alert.insert(ignore_if_duplicate=True)
 
 	# trigger the first message!
 	from frappe.email.doctype.email_alert.email_alert import trigger_daily_alerts

--- a/erpnext/setup/setup_wizard/utils.py
+++ b/erpnext/setup/setup_wizard/utils.py
@@ -1,12 +1,10 @@
 import json, os
 
 from frappe.desk.page.setup_wizard.setup_wizard import setup_complete
-from erpnext.setup.setup_wizard import setup_wizard
 
 def complete():
 	with open(os.path.join(os.path.dirname(__file__),
 		'data', 'test_mfg.json'), 'r') as f:
 		data = json.loads(f.read())
 
-	#setup_wizard.create_sales_tax(data)
 	setup_complete(data)


### PR DESCRIPTION
To allow for retrying.

Also cleared messages for in the case of duplicate fixture entries (we were already catching/acknowledging them); use case: some domains are already created during `install` stage as a requirement by the `restrict_to_domain` field in doctypes, that creates the missing domains on the fly. 

<img width="1032" alt="screen shot 2017-12-25 at 1 13 34 pm" src="https://user-images.githubusercontent.com/5196925/34341941-5035f44e-e9c8-11e7-9447-61cd527415f6.png">
