### PR TITLE
Payment schedule due date on orders should consider delivery date #12060

### DIFF
--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -18,6 +18,13 @@ class TestPurchaseOrder(unittest.TestCase):
 		pr = create_pr_against_po(po.name)
 		self.assertEquals(len(pr.get("items")), 1)
 
+	def test_purchase_order_payment_terms_due_date(self):
+		po = create_purchase_order(do_not_submit=True)
+		po.schedule_date = ''
+		po.submit()
+
+		self.assertEquals(po.payment_schedule[0].due_date, po.schedule_date)
+
 	def test_ordered_qty(self):
 		existing_ordered_qty = get_ordered_qty()
 
@@ -97,9 +104,9 @@ class TestPurchaseOrder(unittest.TestCase):
 		po.submit()
 
 		self.assertEqual(po.payment_schedule[0].payment_amount, 2500.0)
-		self.assertEqual(po.payment_schedule[0].due_date, po.transaction_date)
+		self.assertEqual(po.payment_schedule[0].due_date, po.schedule_date)
 		self.assertEqual(po.payment_schedule[1].payment_amount, 2500.0)
-		self.assertEqual(po.payment_schedule[1].due_date, add_days(po.transaction_date, 30))
+		self.assertEqual(po.payment_schedule[1].due_date, add_days(po.schedule_date, 30))
 		pi = make_purchase_invoice(po.name)
 		pi.save()
 
@@ -107,9 +114,9 @@ class TestPurchaseOrder(unittest.TestCase):
 		self.assertEquals(len(pi.get("items", [])), 1)
 
 		self.assertEqual(pi.payment_schedule[0].payment_amount, 2500.0)
-		self.assertEqual(pi.payment_schedule[0].due_date, po.transaction_date)
+		self.assertEqual(pi.payment_schedule[0].due_date, pi.posting_date)
 		self.assertEqual(pi.payment_schedule[1].payment_amount, 2500.0)
-		self.assertEqual(pi.payment_schedule[1].due_date, add_days(po.transaction_date, 30))
+		self.assertEqual(pi.payment_schedule[1].due_date, add_days(pi.posting_date, 30))
 
 	def test_subcontracting(self):
 		po = create_purchase_order(item_code="_Test FG Item", is_subcontracted="Yes")

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -646,7 +646,20 @@ class AccountsController(TransactionBase):
 			self.remove(item)
 
 	def set_payment_schedule(self):
-		posting_date = self.get("posting_date") or self.get("transaction_date")
+		# sales/purchase invoice - posting_date
+		# sales order - delivery_date/transaction_date
+		# purchase order - scheduled_date/transaction_date
+		def get_relevant_date():
+			if self.doctype in ('Sales Invoice', 'Purchase Invoice'):
+				return self.posting_date
+			elif self.doctype == 'Sales Order':
+				return self.delivery_date or self.transaction_date
+			elif self.doctype == 'Purchase Order':
+				return self.schedule_date or self.transaction_date
+			elif self.doctype == 'Quotation':
+				return self.transaction_date
+
+		posting_date = get_relevant_date()
 		date = self.get("due_date")
 		due_date = date or posting_date
 		grand_total = self.get("rounded_total") or self.grand_total

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1204,7 +1204,7 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 		const doctype = this.frm.doc.doctype;
 		const doc = this.frm.doc;
 
-		relevant_doctypes = [
+		const relevant_doctypes = [
 			'Sales Invoice', 'Purchase Invoice', 'Sales Order', 'Purchase Order',
 			'Quotation'
 		];
@@ -1243,7 +1243,6 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 	},
 
 	payment_term: function(doc, cdt, cdn) {
-		const me = this;
 		var row = locals[cdt][cdn];
 
 		if(row.payment_term) {

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1204,11 +1204,6 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 		const doctype = this.frm.doc.doctype;
 		const doc = this.frm.doc;
 
-		const relevant_doctypes = [
-			'Sales Invoice', 'Purchase Invoice', 'Sales Order', 'Purchase Order',
-			'Quotation'
-		];
-
 		switch (doctype) {
 			case 'Sales Invoice':
 			case 'Purchase Invoice':

--- a/erpnext/selling/doctype/quotation/test_quotation.py
+++ b/erpnext/selling/doctype/quotation/test_quotation.py
@@ -18,6 +18,11 @@ class TestQuotation(unittest.TestCase):
 
 		self.assertTrue(quotation.payment_schedule)
 
+	def test_quotation_payment_terms_due_date(self):
+		quotation = make_quotation()
+
+		self.assertEquals(quotation.payment_schedule[0].due_date, quotation.transaction_date)
+
 	def test_make_sales_order_terms_not_copied(self):
 		from erpnext.selling.doctype.quotation.quotation import make_sales_order
 
@@ -50,7 +55,7 @@ class TestQuotation(unittest.TestCase):
 		self.assertEquals(sales_order.get("items")[0].prevdoc_docname, quotation.name)
 		self.assertEquals(sales_order.customer, "_Test Customer")
 
-		sales_order.delivery_date = "2014-01-01"
+		sales_order.delivery_date = nowdate()
 		sales_order.naming_series = "_T-Quotation-"
 		sales_order.transaction_date = nowdate()
 		sales_order.insert()
@@ -83,7 +88,7 @@ class TestQuotation(unittest.TestCase):
 		self.assertEquals(sales_order.get("items")[0].prevdoc_docname, quotation.name)
 		self.assertEquals(sales_order.customer, "_Test Customer")
 
-		sales_order.delivery_date = "2014-01-01"
+		sales_order.delivery_date = nowdate()
 		sales_order.naming_series = "_T-Quotation-"
 		sales_order.transaction_date = nowdate()
 		sales_order.insert()

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -22,6 +22,10 @@ class TestSalesOrder(unittest.TestCase):
 			set_user_permission_doctypes(doctypes="Sales Order", role=role,
 				apply_user_permissions=0, user_permission_doctypes=None)
 
+	def test_sales_order_payment_terms_due_date(self):
+		so = make_sales_order()
+		self.assertEquals(so.payment_schedule[0].due_date, so.delivery_date)
+
 	def test_make_material_request(self):
 		so = make_sales_order(do_not_submit=True)
 


### PR DESCRIPTION
Fixes #12060 
Summary:
- Purchase Orders, will use `schedule_date` and fallback to `transaction_date`
- Sales Orders will use `delivery_date` and fallback to `transaction_date`.

### Purchase Order -before
![screenshot-2017-12-26 new purchase order 1 - new purchase order 1 2](https://user-images.githubusercontent.com/818803/34359149-ca8339ea-ea55-11e7-9349-390cdb024ad0.png)

### Purchase Order - after
![screenshot-2017-12-26 new purchase order 1 - new purchase order 1 1](https://user-images.githubusercontent.com/818803/34359152-d2340232-ea55-11e7-9cee-64518ac40801.png)
