### PR TITLE
[Fix] Sales order erased on production order on selection of sales order

### DIFF
--- a/erpnext/manufacturing/doctype/production_order/production_order.js
+++ b/erpnext/manufacturing/doctype/production_order/production_order.js
@@ -226,6 +226,7 @@ frappe.ui.form.on("Production Order", {
 				args: { production_item: frm.doc.production_item },
 				callback: function(r) {
 					frm.set_query("sales_order", function() {
+						erpnext.in_production_item_onchange = true;
 						return {
 							filters: [
 								["Sales Order","name", "in", r.message]


### PR DESCRIPTION
**Issue**
![34383237-0e2837a4-eafb-11e7-86e4-b64b3ee4a222](https://user-images.githubusercontent.com/8780500/34408620-1b63d216-ebeb-11e7-839c-8d47b69cd16e.gif)


Fixed https://github.com/frappe/erpnext/issues/12213