### PR TITLE
[fix] if is_root is true make parent account empty

### DIFF
--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -252,6 +252,9 @@ def add_ac(args=None):
 	if not ac.parent_account:
 		ac.parent_account = args.get("parent")
 
+	if ac.is_root:
+		ac.parent_account=''
+
 	ac.old_parent = ""
 	ac.freeze_account = "No"
 	if cint(ac.get("is_root")):


### PR DESCRIPTION
Before Fix:
![error_create_root_account_1](https://user-images.githubusercontent.com/3784093/34452840-02e6cb24-ed6e-11e7-852a-b925239743a1.gif)


After Fix:
![create_root_account](https://user-images.githubusercontent.com/3784093/34452813-a434e1ec-ed6d-11e7-9b2b-5ea8eb165aef.gif)


Dependant : https://github.com/frappe/frappe/pull/4730