### PR TITLE
[fix] key error

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -591,7 +591,7 @@ def validate_bom_no(item, bom_no):
 		frappe.throw(_("BOM {0} does not belong to Item {1}").format(bom_no, item))
 
 @frappe.whitelist()
-def get_children(doctype, parent=None, is_tree=False):
+def get_children(doctype, parent=None, is_root=False, **filters):
 	if not parent:
 		frappe.msgprint(_('Please select a BOM'))
 		return


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.handler.handle()
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/apps/frappe/frappe/handler.py", line 53, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/apps/frappe/frappe/__init__.py", line 939, in call
    return fn(*args, **newargs)
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/apps/frappe/frappe/desk/treeview.py", line 20, in get_all_nodes
    data = tree_method(doctype, parent, **filters)
TypeError: get_children() got an unexpected keyword argument 'is_root'
```