### PR TITLE
[fix] if item code exists then only call get_item_details

### DIFF
--- a/erpnext/agriculture/doctype/crop/crop.js
+++ b/erpnext/agriculture/doctype/crop/crop.js
@@ -25,7 +25,7 @@ erpnext.crop.update_item_rate_uom = function(frm, cdt, cdn) {
 	let material_list = ['materials_required', 'produce', 'byproducts'];
 	material_list.forEach((material) => {
 		frm.doc[material].forEach((item, index) => {
-			if (item.name == cdn){
+			if (item.name == cdn && item.item_code){
 				frappe.call({
 					method:'erpnext.agriculture.doctype.crop.crop.get_item_details',
 					args: {


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2017-12-29/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2017-12-29/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2017-12-29/apps/frappe/frappe/handler.py", line 53, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2017-12-29/apps/frappe/frappe/__init__.py", line 939, in call
    return fn(*args, **newargs)
TypeError: get_item_details() takes exactly 1 argument (0 given)
```