### PR TITLE
[fix] check if null for mode of payments

### DIFF
--- a/erpnext/accounts/report/sales_payment_summary/sales_payment_summary.py
+++ b/erpnext/accounts/report/sales_payment_summary/sales_payment_summary.py
@@ -66,12 +66,12 @@ def get_mode_of_payments(filters):
 	invoice_list = get_invoices(filters)
 	invoice_list_names = ",".join(['"' + invoice['name'] + '"' for invoice in invoice_list])
 	if invoice_list:
-		inv_mop = frappe.db.sql("""select a.owner,a.posting_date,b.mode_of_payment
+		inv_mop = frappe.db.sql("""select a.owner,a.posting_date, ifnull(b.mode_of_payment, '')
 			from `tabSales Invoice` a, `tabSales Invoice Payment` b
 			where a.name = b.parent
 			and a.name in ({invoice_list_names})
 			union
-			select a.owner,a.posting_date,b.mode_of_payment
+			select a.owner,a.posting_date, ifnull(b.mode_of_payment, '')
 			from `tabSales Invoice` a, `tabPayment Entry` b,`tabPayment Entry Reference` c
 			where a.name = c.reference_name 
 			and b.name = c.parent


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2017-12-29/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2017-12-29/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2017-12-29/apps/frappe/frappe/handler.py", line 53, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2017-12-29/apps/frappe/frappe/__init__.py", line 939, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2017-12-29/apps/frappe/frappe/desk/query_report.py", line 96, in run
    res = frappe.get_attr(method_name)(frappe._dict(filters))
  File "/home/frappe/benches/bench-2017-12-29/apps/erpnext/erpnext/accounts/report/sales_payment_summary/sales_payment_summary.py", line 11, in execute
    data=get_sales_payment_data(filters, columns)
  File "/home/frappe/benches/bench-2017-12-29/apps/erpnext/erpnext/accounts/report/sales_payment_summary/sales_payment_summary.py", line 31, in get_sales_payment_data
    row = [inv.posting_date, inv.owner,", ".join(mode_of_payments.get(mode_of_payment, [])),
TypeError: sequence item 0: expected string or Unicode, NoneType found
```