### PR TITLE
recalculate terms when document date changed

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -538,7 +538,6 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 			this.payment_terms_template();
 		} else if (doc.payment_schedule) {
 			const me = this;
-			const payment_schedule = doc.payment_schedule;
 
 			doc.payment_schedule.forEach(
 				function(term) {

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -521,12 +521,37 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 						if(r.message) {
 							me.frm.set_value("due_date", r.message);
 							frappe.ui.form.trigger(me.frm.doc.doctype, "currency");
+							me.recalculate_terms();
 						}
 					}
 				})
 			} else {
 				frappe.ui.form.trigger(me.frm.doc.doctype, "currency");
 			}
+		}
+	},
+
+	recalculate_terms: function() {
+		const doc = this.frm.doc;
+
+		if (doc.payment_terms_template) {
+			this.payment_terms_template();
+		} else if (doc.payment_schedule) {
+			const me = this;
+			const payment_schedule = doc.payment_schedule;
+
+			doc.payment_schedule.forEach(
+				function(term) {
+					if (term.payment_term) {
+						me.payment_term(doc, term.doctype, term.name);
+					} else {
+						frappe.model.set_value(
+							term.doctype, term.name, 'due_date',
+							doc.posting_date || doc.transaction_date
+						);
+					}
+				}
+			);
 		}
 	},
 


### PR DESCRIPTION
### Before
![peek 2018-01-01 17-13](https://user-images.githubusercontent.com/818803/34469121-55c2e584-ef18-11e7-894f-08e972c020c8.gif)

### After
![peek 2018-01-01 16-51](https://user-images.githubusercontent.com/818803/34469086-69896cc4-ef17-11e7-95e8-bea456d4d4f7.gif)

Possible fix for #12254, #12263, #12270 
Fixes #12287 