### PR TITLE
Companywise default tax template

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.js
@@ -18,7 +18,7 @@ QUnit.test("test purchase invoice", function(assert) {
 				{update_stock:1},
 				{supplier_address: 'Test1-Billing'},
 				{contact_person: 'Contact 3-Test Supplier'},
-				{taxes_and_charges: 'TEST In State GST'},
+				{taxes_and_charges: 'TEST In State GST - FT'},
 				{tc_name: 'Test Term 1'},
 				{terms: 'This is Test'},
 				{payment_terms_template: '_Test Payment Term Template UI'}
@@ -29,7 +29,7 @@ QUnit.test("test purchase invoice", function(assert) {
 			// get_item_details
 			assert.ok(cur_frm.doc.items[0].item_name=='Test Product 1', "Item name correct");
 			// get tax details
-			assert.ok(cur_frm.doc.taxes_and_charges=='TEST In State GST', "Tax details correct");
+			assert.ok(cur_frm.doc.taxes_and_charges=='TEST In State GST - FT', "Tax details correct");
 			// get tax account head details
 			assert.ok(cur_frm.doc.taxes[0].account_head=='CGST - '+frappe.get_abbr(frappe.defaults.get_default('Company')), " Account Head abbr correct");
 			// grand_total Calculated

--- a/erpnext/accounts/doctype/purchase_taxes_and_charges_template/purchase_taxes_and_charges_template.py
+++ b/erpnext/accounts/doctype/purchase_taxes_and_charges_template/purchase_taxes_and_charges_template.py
@@ -3,6 +3,7 @@
 # License: GNU General Public License v3. See license.txt
 
 from __future__ import unicode_literals
+import frappe
 from frappe.model.document import Document
 from erpnext.accounts.doctype.sales_taxes_and_charges_template.sales_taxes_and_charges_template \
 	import valdiate_taxes_and_charges_template
@@ -10,3 +11,8 @@ from erpnext.accounts.doctype.sales_taxes_and_charges_template.sales_taxes_and_c
 class PurchaseTaxesandChargesTemplate(Document):
 	def validate(self):
 		valdiate_taxes_and_charges_template(self)
+
+	def autoname(self):
+		if self.company and self.title:
+			abbr = frappe.db.get_value('Company', self.company, 'abbr')
+			self.name = '{0} - {1}'.format(self.title, abbr)

--- a/erpnext/accounts/doctype/purchase_taxes_and_charges_template/test_purchase_taxes_and_charges_template.js
+++ b/erpnext/accounts/doctype/purchase_taxes_and_charges_template/test_purchase_taxes_and_charges_template.js
@@ -1,7 +1,7 @@
 QUnit.module('Sales Taxes and Charges Template');
 
 QUnit.test("test sales taxes and charges template", function(assert) {
-	assert.expect(1);
+	assert.expect(2);
 	let done = assert.async();
 	frappe.run_serially([
 		() => {
@@ -19,7 +19,10 @@ QUnit.test("test sales taxes and charges template", function(assert) {
 				]}
 			]);
 		},
-		() => {assert.ok(cur_frm.doc.title=='TEST In State GST');},
+		() => {
+			assert.ok(cur_frm.doc.title=='TEST In State GST');
+			assert.ok(cur_frm.doc.name=='TEST In State GST - FT');
+		},
 		() => done()
 	]);
 });

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.js
@@ -17,7 +17,7 @@ QUnit.test("test sales Invoice", function(assert) {
 				{customer_address: 'Test1-Billing'},
 				{shipping_address_name: 'Test1-Shipping'},
 				{contact_person: 'Contact 1-Test Customer 1'},
-				{taxes_and_charges: 'TEST In State GST'},
+				{taxes_and_charges: 'TEST In State GST - FT'},
 				{tc_name: 'Test Term 1'},
 				{terms: 'This is Test'},
 				{payment_terms_template: '_Test Payment Term Template UI'}
@@ -28,7 +28,7 @@ QUnit.test("test sales Invoice", function(assert) {
 			// get_item_details
 			assert.ok(cur_frm.doc.items[0].item_name=='Test Product 1', "Item name correct");
 			// get tax details
-			assert.ok(cur_frm.doc.taxes_and_charges=='TEST In State GST', "Tax details correct");
+			assert.ok(cur_frm.doc.taxes_and_charges=='TEST In State GST - FT', "Tax details correct");
 			// get tax account head details
 			assert.ok(cur_frm.doc.taxes[0].account_head=='CGST - '+frappe.get_abbr(frappe.defaults.get_default('Company')), " Account Head abbr correct");
 			// grand_total Calculated

--- a/erpnext/accounts/doctype/sales_invoice/tests/test_sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/tests/test_sales_invoice.js
@@ -17,7 +17,7 @@ QUnit.test("test sales Invoice", function(assert) {
 				{customer_address: 'Test1-Billing'},
 				{shipping_address_name: 'Test1-Shipping'},
 				{contact_person: 'Contact 1-Test Customer 1'},
-				{taxes_and_charges: 'TEST In State GST'},
+				{taxes_and_charges: 'TEST In State GST - FT'},
 				{tc_name: 'Test Term 1'},
 				{terms: 'This is Test'}
 			]);
@@ -27,7 +27,7 @@ QUnit.test("test sales Invoice", function(assert) {
 			// get_item_details
 			assert.ok(cur_frm.doc.items[0].item_name=='Test Product 1', "Item name correct");
 			// get tax details
-			assert.ok(cur_frm.doc.taxes_and_charges=='TEST In State GST', "Tax details correct");
+			assert.ok(cur_frm.doc.taxes_and_charges=='TEST In State GST - FT', "Tax details correct");
 			// get tax account head details
 			assert.ok(cur_frm.doc.taxes[0].account_head=='CGST - '+frappe.get_abbr(frappe.defaults.get_default('Company')), " Account Head abbr correct");
 			// grand_total Calculated

--- a/erpnext/accounts/doctype/sales_invoice/tests/test_sales_invoice_with_payment.js
+++ b/erpnext/accounts/doctype/sales_invoice/tests/test_sales_invoice_with_payment.js
@@ -17,7 +17,7 @@ QUnit.test("test sales Invoice with payment", function(assert) {
 				{customer_address: 'Test1-Billing'},
 				{shipping_address_name: 'Test1-Shipping'},
 				{contact_person: 'Contact 1-Test Customer 1'},
-				{taxes_and_charges: 'TEST In State GST'},
+				{taxes_and_charges: 'TEST In State GST - FT'},
 				{tc_name: 'Test Term 1'},
 				{terms: 'This is Test'},
 				{payment_terms_template: '_Test Payment Term Template UI'}
@@ -28,7 +28,7 @@ QUnit.test("test sales Invoice with payment", function(assert) {
 			// get_item_details
 			assert.ok(cur_frm.doc.items[0].item_name=='Test Product 1', "Item name correct");
 			// get tax details
-			assert.ok(cur_frm.doc.taxes_and_charges=='TEST In State GST', "Tax details correct");
+			assert.ok(cur_frm.doc.taxes_and_charges=='TEST In State GST - FT', "Tax details correct");
 			// grand_total Calculated
 			assert.ok(cur_frm.doc.grand_total==590, "Grad Total correct");
 

--- a/erpnext/accounts/doctype/sales_invoice/tests/test_sales_invoice_with_payment_request.js
+++ b/erpnext/accounts/doctype/sales_invoice/tests/test_sales_invoice_with_payment_request.js
@@ -17,7 +17,7 @@ QUnit.test("test sales Invoice with payment request", function(assert) {
 				{customer_address: 'Test1-Billing'},
 				{shipping_address_name: 'Test1-Shipping'},
 				{contact_person: 'Contact 1-Test Customer 1'},
-				{taxes_and_charges: 'TEST In State GST'},
+				{taxes_and_charges: 'TEST In State GST - FT'},
 				{tc_name: 'Test Term 1'},
 				{terms: 'This is Test'}
 			]);
@@ -27,7 +27,7 @@ QUnit.test("test sales Invoice with payment request", function(assert) {
 			// get_item_details
 			assert.ok(cur_frm.doc.items[0].item_name=='Test Product 1', "Item name correct");
 			// get tax details
-			assert.ok(cur_frm.doc.taxes_and_charges=='TEST In State GST', "Tax details correct");
+			assert.ok(cur_frm.doc.taxes_and_charges=='TEST In State GST - FT', "Tax details correct");
 			// grand_total Calculated
 			assert.ok(cur_frm.doc.grand_total==590, "Grad Total correct");
 

--- a/erpnext/accounts/doctype/sales_invoice/tests/test_sales_invoice_with_serialize_item.js
+++ b/erpnext/accounts/doctype/sales_invoice/tests/test_sales_invoice_with_serialize_item.js
@@ -17,7 +17,7 @@ QUnit.test("test sales Invoice with serialize item", function(assert) {
 				{customer_address: 'Test1-Billing'},
 				{shipping_address_name: 'Test1-Shipping'},
 				{contact_person: 'Contact 1-Test Customer 1'},
-				{taxes_and_charges: 'TEST In State GST'},
+				{taxes_and_charges: 'TEST In State GST - FT'},
 				{tc_name: 'Test Term 1'},
 				{terms: 'This is Test'}
 			]);
@@ -27,7 +27,7 @@ QUnit.test("test sales Invoice with serialize item", function(assert) {
 			// get_item_details
 			assert.ok(cur_frm.doc.items[0].item_name=='Test Product 4', "Item name correct");
 			// get tax details
-			assert.ok(cur_frm.doc.taxes_and_charges=='TEST In State GST', "Tax details correct");
+			assert.ok(cur_frm.doc.taxes_and_charges=='TEST In State GST - FT', "Tax details correct");
 			// get tax account head details
 			assert.ok(cur_frm.doc.taxes[0].account_head=='CGST - '+frappe.get_abbr(frappe.defaults.get_default('Company')), " Account Head abbr correct");
 			// get batch number

--- a/erpnext/accounts/doctype/sales_taxes_and_charges_template/sales_taxes_and_charges_template.py
+++ b/erpnext/accounts/doctype/sales_taxes_and_charges_template/sales_taxes_and_charges_template.py
@@ -11,7 +11,12 @@ from erpnext.controllers.accounts_controller import validate_taxes_and_charges, 
 class SalesTaxesandChargesTemplate(Document):
 	def validate(self):
 		valdiate_taxes_and_charges_template(self)
-		
+
+	def autoname(self):
+		if self.company and self.title:
+			abbr = frappe.db.get_value('Company', self.company, 'abbr')
+			self.name = '{0} - {1}'.format(self.title, abbr)
+
 	def set_missing_values(self):
 		for data in self.taxes:
 			if data.charge_type == 'On Net Total' and flt(data.rate) == 0.0:

--- a/erpnext/accounts/doctype/sales_taxes_and_charges_template/test_sales_taxes_and_charges_template.js
+++ b/erpnext/accounts/doctype/sales_taxes_and_charges_template/test_sales_taxes_and_charges_template.js
@@ -1,7 +1,7 @@
 QUnit.module('Sales Taxes and Charges Template');
 
 QUnit.test("test sales taxes and charges template", function(assert) {
-	assert.expect(1);
+	assert.expect(2);
 	let done = assert.async();
 	frappe.run_serially([
 		() => {
@@ -19,7 +19,10 @@ QUnit.test("test sales taxes and charges template", function(assert) {
 				]}
 			]);
 		},
-		() => {assert.ok(cur_frm.doc.title=='TEST In State GST');},
+		() => {
+			assert.ok(cur_frm.doc.title=='TEST In State GST');
+			assert.ok(cur_frm.doc.name=='TEST In State GST - FT');
+		},
 		() => done()
 	]);
 });

--- a/erpnext/accounts/doctype/tax_rule/test_records.json
+++ b/erpnext/accounts/doctype/tax_rule/test_records.json
@@ -2,7 +2,7 @@
 	{
 		"doctype": "Tax Rule",
 		"tax_type" : "Sales",
-		"sales_tax_template": "_Test Tax 1",
+		"sales_tax_template": "_Test Tax 1 - _TC",
 		"use_for_shopping_cart": 1,
 		"billing_city": "_Test City",
 		"billing_state": "Test State",
@@ -15,7 +15,7 @@
 	{
 		"doctype": "Tax Rule",
 		"tax_type" : "Sales",
-		"sales_tax_template": "_Test Tax 2",
+		"sales_tax_template": "_Test Tax 2 - _TC",
 		"use_for_shopping_cart": 0,
 		"billing_city": "_Test City",
 		"billing_country": "India",

--- a/erpnext/accounts/doctype/tax_rule/test_tax_rule.py
+++ b/erpnext/accounts/doctype/tax_rule/test_tax_rule.py
@@ -18,40 +18,40 @@ class TestTaxRule(unittest.TestCase):
 
 	def test_conflict(self):
 		tax_rule1 = make_tax_rule(customer= "_Test Customer",
-			sales_tax_template = "_Test Sales Taxes and Charges Template", priority = 1)
+			sales_tax_template = "_Test Sales Taxes and Charges Template - _TC", priority = 1)
 		tax_rule1.save()
 
 		tax_rule2 = make_tax_rule(customer= "_Test Customer",
-			sales_tax_template = "_Test Sales Taxes and Charges Template", priority = 1)
+			sales_tax_template = "_Test Sales Taxes and Charges Template - _TC", priority = 1)
 
 		self.assertRaises(ConflictingTaxRule, tax_rule2.save)
 
 	def test_conflict_with_non_overlapping_dates(self):
 		tax_rule1 = make_tax_rule(customer= "_Test Customer",
-			sales_tax_template = "_Test Sales Taxes and Charges Template", priority = 1, from_date = "2015-01-01")
+			sales_tax_template = "_Test Sales Taxes and Charges Template - _TC", priority = 1, from_date = "2015-01-01")
 		tax_rule1.save()
 
 		tax_rule2 = make_tax_rule(customer= "_Test Customer",
-			sales_tax_template = "_Test Sales Taxes and Charges Template", priority = 1, to_date = "2013-01-01")
+			sales_tax_template = "_Test Sales Taxes and Charges Template - _TC", priority = 1, to_date = "2013-01-01")
 
 		tax_rule2.save()
 		self.assertTrue(tax_rule2.name)
 
 	def test_for_parent_customer_group(self):
 		tax_rule1 = make_tax_rule(customer_group= "All Customer Groups",
-			sales_tax_template = "_Test Sales Taxes and Charges Template", priority = 1, from_date = "2015-01-01")
+			sales_tax_template = "_Test Sales Taxes and Charges Template - _TC", priority = 1, from_date = "2015-01-01")
 		tax_rule1.save()
 
 		self.assertEquals(get_tax_template("2015-01-01", {"customer_group" : "Commercial", "use_for_shopping_cart":0}),
-			"_Test Sales Taxes and Charges Template")
+			"_Test Sales Taxes and Charges Template - _TC")
 
 	def test_conflict_with_overlapping_dates(self):
 		tax_rule1 = make_tax_rule(customer= "_Test Customer",
-			sales_tax_template = "_Test Sales Taxes and Charges Template", priority = 1, from_date = "2015-01-01", to_date = "2015-01-05")
+			sales_tax_template = "_Test Sales Taxes and Charges Template - _TC", priority = 1, from_date = "2015-01-01", to_date = "2015-01-05")
 		tax_rule1.save()
 
 		tax_rule2 = make_tax_rule(customer= "_Test Customer",
-			sales_tax_template = "_Test Sales Taxes and Charges Template", priority = 1, from_date = "2015-01-03", to_date = "2015-01-09")
+			sales_tax_template = "_Test Sales Taxes and Charges Template - _TC", priority = 1, from_date = "2015-01-03", to_date = "2015-01-09")
 
 		self.assertRaises(ConflictingTaxRule, tax_rule2.save)
 
@@ -62,66 +62,66 @@ class TestTaxRule(unittest.TestCase):
 
 	def test_select_tax_rule_based_on_customer(self):
 		make_tax_rule(customer= "_Test Customer",
-			sales_tax_template = "_Test Sales Taxes and Charges Template", save=1)
+			sales_tax_template = "_Test Sales Taxes and Charges Template - _TC", save=1)
 
 		make_tax_rule(customer= "_Test Customer 1",
-			sales_tax_template = "_Test Sales Taxes and Charges Template 1", save=1)
+			sales_tax_template = "_Test Sales Taxes and Charges Template 1 - _TC", save=1)
 
 		make_tax_rule(customer= "_Test Customer 2",
-			sales_tax_template = "_Test Sales Taxes and Charges Template 2", save=1)
+			sales_tax_template = "_Test Sales Taxes and Charges Template 2 - _TC", save=1)
 
 		self.assertEquals(get_tax_template("2015-01-01", {"customer":"_Test Customer 2"}),
-			"_Test Sales Taxes and Charges Template 2")
+			"_Test Sales Taxes and Charges Template 2 - _TC")
 
 	def test_select_tax_rule_based_on_better_match(self):
 		make_tax_rule(customer= "_Test Customer", billing_city = "Test City", billing_state = "Test State",
-			sales_tax_template = "_Test Sales Taxes and Charges Template", save=1)
+			sales_tax_template = "_Test Sales Taxes and Charges Template - _TC", save=1)
 
 		make_tax_rule(customer= "_Test Customer",  billing_city = "Test City1", billing_state = "Test State",
-			sales_tax_template = "_Test Sales Taxes and Charges Template 1", save=1)
+			sales_tax_template = "_Test Sales Taxes and Charges Template 1 - _TC", save=1)
 
 		self.assertEquals(get_tax_template("2015-01-01", {"customer":"_Test Customer", "billing_city": "Test City", "billing_state": "Test State"}),
-			"_Test Sales Taxes and Charges Template")
+			"_Test Sales Taxes and Charges Template - _TC")
 
 	def test_select_tax_rule_based_on_state_match(self):
 		make_tax_rule(customer= "_Test Customer", shipping_state = "Test State",
-			sales_tax_template = "_Test Sales Taxes and Charges Template", save=1)
+			sales_tax_template = "_Test Sales Taxes and Charges Template - _TC", save=1)
 
 		make_tax_rule(customer= "_Test Customer", shipping_state = "Test State12",
-			sales_tax_template = "_Test Sales Taxes and Charges Template 1", priority=2, save=1)
+			sales_tax_template = "_Test Sales Taxes and Charges Template 1 - _TC", priority=2, save=1)
 
 		self.assertEquals(get_tax_template("2015-01-01", {"customer":"_Test Customer", "shipping_state": "Test State"}),
-			"_Test Sales Taxes and Charges Template")
+			"_Test Sales Taxes and Charges Template - _TC")
 
 	def test_select_tax_rule_based_on_better_priority(self):
 		make_tax_rule(customer= "_Test Customer", billing_city = "Test City",
-			sales_tax_template = "_Test Sales Taxes and Charges Template", priority=1, save=1)
+			sales_tax_template = "_Test Sales Taxes and Charges Template - _TC", priority=1, save=1)
 
 		make_tax_rule(customer= "_Test Customer", billing_city = "Test City",
-			sales_tax_template = "_Test Sales Taxes and Charges Template 1", priority=2, save=1)
+			sales_tax_template = "_Test Sales Taxes and Charges Template 1 - _TC", priority=2, save=1)
 
 		self.assertEquals(get_tax_template("2015-01-01", {"customer":"_Test Customer", "billing_city": "Test City"}),
-			"_Test Sales Taxes and Charges Template 1")
+			"_Test Sales Taxes and Charges Template 1 - _TC")
 
 	def test_select_tax_rule_based_cross_matching_keys(self):
 		make_tax_rule(customer= "_Test Customer", billing_city = "Test City",
-			sales_tax_template = "_Test Sales Taxes and Charges Template", save=1)
+			sales_tax_template = "_Test Sales Taxes and Charges Template - _TC", save=1)
 
 		make_tax_rule(customer= "_Test Customer 1", billing_city = "Test City 1",
-			sales_tax_template = "_Test Sales Taxes and Charges Template 1", save=1)
+			sales_tax_template = "_Test Sales Taxes and Charges Template 1 - _TC", save=1)
 
 		self.assertEquals(get_tax_template("2015-01-01", {"customer":"_Test Customer", "billing_city": "Test City 1"}),
 			None)
 
 	def test_select_tax_rule_based_cross_partially_keys(self):
 		make_tax_rule(customer= "_Test Customer", billing_city = "Test City",
-			sales_tax_template = "_Test Sales Taxes and Charges Template", save=1)
+			sales_tax_template = "_Test Sales Taxes and Charges Template - _TC", save=1)
 
 		make_tax_rule(billing_city = "Test City 1",
-			sales_tax_template = "_Test Sales Taxes and Charges Template 1", save=1)
+			sales_tax_template = "_Test Sales Taxes and Charges Template 1 - _TC", save=1)
 
 		self.assertEquals(get_tax_template("2015-01-01", {"customer":"_Test Customer", "billing_city": "Test City 1"}),
-			"_Test Sales Taxes and Charges Template 1")
+			"_Test Sales Taxes and Charges Template 1 - _TC")
 
 
 def make_tax_rule(**args):

--- a/erpnext/buying/doctype/purchase_order/tests/test_purchase_order_with_taxes_and_charges.js
+++ b/erpnext/buying/doctype/purchase_order/tests/test_purchase_order_with_taxes_and_charges.js
@@ -24,7 +24,7 @@ QUnit.test("test: purchase order with taxes and charges", function(assert) {
 					]
 				]},
 
-				{taxes_and_charges: 'TEST In State GST'}
+				{taxes_and_charges: 'TEST In State GST - FT'}
 			]);
 		},
 

--- a/erpnext/buying/doctype/supplier_quotation/tests/test_supplier_quotation_for_taxes_and_charges.js
+++ b/erpnext/buying/doctype/supplier_quotation/tests/test_supplier_quotation_for_taxes_and_charges.js
@@ -17,7 +17,7 @@ QUnit.test("test: supplier quotation with taxes and charges", function(assert) {
 						{"warehouse": 'Stores - '+frappe.get_abbr(frappe.defaults.get_default('Company'))},
 					]
 				]},
-				{taxes_and_charges:'TEST In State GST'},
+				{taxes_and_charges:'TEST In State GST - FT'},
 			]);
 		},
 		() => {supplier_quotation_name = cur_frm.doc.name;},

--- a/erpnext/selling/doctype/quotation/tests/test_quotation_with_taxes_and_charges.js
+++ b/erpnext/selling/doctype/quotation/tests/test_quotation_with_taxes_and_charges.js
@@ -17,7 +17,7 @@ QUnit.test("test quotation with taxes and charges", function(assert) {
 				{customer_address: 'Test1-Billing'},
 				{shipping_address_name: 'Test1-Shipping'},
 				{contact_person: 'Contact 1-Test Customer 1'},
-				{taxes_and_charges: 'TEST In State GST'},
+				{taxes_and_charges: 'TEST In State GST - FT'},
 				{tc_name: 'Test Term 1'},
 				{terms: 'This is Test'}
 			]);
@@ -27,7 +27,7 @@ QUnit.test("test quotation with taxes and charges", function(assert) {
 			// get_item_details
 			assert.ok(cur_frm.doc.items[0].item_name=='Test Product 4', "Item name correct");
 			// get tax details
-			assert.ok(cur_frm.doc.taxes_and_charges=='TEST In State GST', "Tax details correct");
+			assert.ok(cur_frm.doc.taxes_and_charges=='TEST In State GST - FT', "Tax details correct");
 			// get tax account head details
 			assert.ok(cur_frm.doc.taxes[0].account_head=='CGST - '+frappe.get_abbr(frappe.defaults.get_default('Company')), " Account Head abbr correct");
 

--- a/erpnext/selling/doctype/sales_order/tests/test_sales_order.js
+++ b/erpnext/selling/doctype/sales_order/tests/test_sales_order.js
@@ -17,7 +17,7 @@ QUnit.test("test sales order", function(assert) {
 				{customer_address: 'Test1-Billing'},
 				{shipping_address_name: 'Test1-Shipping'},
 				{contact_person: 'Contact 1-Test Customer 1'},
-				{taxes_and_charges: 'TEST In State GST'},
+				{taxes_and_charges: 'TEST In State GST - FT'},
 				{tc_name: 'Test Term 1'},
 				{terms: 'This is Test'},
 				{payment_terms_template: '_Test Payment Term Template UI'}
@@ -34,7 +34,7 @@ QUnit.test("test sales order", function(assert) {
 			// get_item_details
 			assert.ok(cur_frm.doc.items[0].item_name=='Test Product 3', "Item name correct");
 			// get tax details
-			assert.ok(cur_frm.doc.taxes_and_charges=='TEST In State GST', "Tax details correct");
+			assert.ok(cur_frm.doc.taxes_and_charges=='TEST In State GST - FT', "Tax details correct");
 			// get tax account head details
 			assert.ok(cur_frm.doc.taxes[0].account_head=='CGST - '+frappe.get_abbr(frappe.defaults.get_default('Company')), " Account Head abbr correct");
 		},

--- a/erpnext/selling/doctype/sales_order/tests/test_sales_order_with_taxes_and_charges.js
+++ b/erpnext/selling/doctype/sales_order/tests/test_sales_order_with_taxes_and_charges.js
@@ -17,7 +17,7 @@ QUnit.test("test sales order with taxes and charges", function(assert) {
 				{customer_address: 'Test1-Billing'},
 				{shipping_address_name: 'Test1-Shipping'},
 				{contact_person: 'Contact 1-Test Customer 1'},
-				{taxes_and_charges: 'TEST In State GST'},
+				{taxes_and_charges: 'TEST In State GST - FT'},
 				{tc_name: 'Test Term 1'},
 				{terms: 'This is Test'}
 			]);
@@ -27,7 +27,7 @@ QUnit.test("test sales order with taxes and charges", function(assert) {
 			// get_item_details
 			assert.ok(cur_frm.doc.items[0].item_name=='Test Product 4', "Item name correct");
 			// get tax details
-			assert.ok(cur_frm.doc.taxes_and_charges=='TEST In State GST', "Tax details correct");
+			assert.ok(cur_frm.doc.taxes_and_charges=='TEST In State GST - FT', "Tax details correct");
 			// get tax account head details
 			assert.ok(cur_frm.doc.taxes[0].account_head=='CGST - '+frappe.get_abbr(frappe.defaults.get_default('Company')), " Account Head abbr correct");
 

--- a/erpnext/setup/doctype/company/company.js
+++ b/erpnext/setup/doctype/company/company.js
@@ -49,7 +49,7 @@ frappe.ui.form.on("Company", {
 			}, __("View"));
 
 			frm.add_custom_button(__('Default Tax Template'), function() {
-				frm.trigger("make_default_tax_template")
+				frm.trigger("make_default_tax_template");
 			}, __("Make"));
 
 			frm.page.set_inner_btn_group_as_primary(__("View"));
@@ -66,7 +66,7 @@ frappe.ui.form.on("Company", {
 			doc: frm.doc,
 			freeze: true,
 			callback: function() {
-				frappe.msgprint(__("Default tax templates for sales and purchase are created."))
+				frappe.msgprint(__("Default tax templates for sales and purchase are created."));
 			}
 		})
 	},

--- a/erpnext/setup/doctype/company/company.js
+++ b/erpnext/setup/doctype/company/company.js
@@ -34,24 +34,52 @@ frappe.ui.form.on("Company", {
 
 			frm.add_custom_button(__('Cost Centers'), function() {
 				frappe.set_route('Tree', 'Cost Center', {'company': frm.doc.name})
-			})
+			}, __("View"));
 
 			frm.add_custom_button(__('Chart of Accounts'), function() {
 				frappe.set_route('Tree', 'Account', {'company': frm.doc.name})
-			})
+			}, __("View"));
+
+			frm.add_custom_button(__('Sales Tax Template'), function() {
+				frappe.set_route('List', 'Sales Taxes and Charges Template', {'company': frm.doc.name});
+			}, __("View"));
+
+			frm.add_custom_button(__('Purchase Tax Template'), function() {
+				frappe.set_route('List', 'Purchase Taxes and Charges Template', {'company': frm.doc.name});
+			}, __("View"));
+
+			frm.add_custom_button(__('Default Tax Template'), function() {
+				frm.trigger("make_default_tax_template")
+			}, __("Make"));
+
+			frm.page.set_inner_btn_group_as_primary(__("View"));
+			frm.page.set_inner_btn_group_as_primary(__("Make"));
 		}
 
 		erpnext.company.set_chart_of_accounts_options(frm.doc);
 
 	},
 
+	make_default_tax_template: function(frm) {
+		frm.call({
+			method: "create_default_tax_template",
+			doc: frm.doc,
+			freeze: true,
+			callback: function() {
+				frappe.msgprint(__("Default tax templates for sales and purchase are created."))
+			}
+		})
+	},
+
 	onload_post_render: function(frm) {
 		if(frm.get_field("delete_company_transactions").$input)
 			frm.get_field("delete_company_transactions").$input.addClass("btn-danger");
 	},
+
 	country: function(frm) {
 		erpnext.company.set_chart_of_accounts_options(frm.doc);
 	},
+
 	delete_company_transactions: function(frm) {
 		frappe.verify_password(function() {
 			var d = frappe.prompt({

--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -50,6 +50,13 @@ class Company(Document):
 		if frappe.db.sql("select abbr from tabCompany where name!=%s and abbr=%s", (self.name, self.abbr)):
 			frappe.throw(_("Abbreviation already used for another company"))
 
+	def create_default_tax_template(self):
+		from erpnext.setup.setup_wizard.operations.taxes_setup import create_sales_tax
+		create_sales_tax({
+			'country': self.country,
+			'company_name': self.name
+		})
+
 	def validate_default_accounts(self):
 		for field in ["default_bank_account", "default_cash_account",
 			"default_receivable_account", "default_payable_account",

--- a/erpnext/setup/setup_wizard/operations/taxes_setup.py
+++ b/erpnext/setup/setup_wizard/operations/taxes_setup.py
@@ -16,38 +16,44 @@ def create_sales_tax(args):
 				tax_data.get('tax_rate'), sales_tax)
 
 def make_tax_account_and_template(company, account_name, tax_rate, template_name=None):
+	if not isinstance(account_name, (list, tuple)):
+		account_name = [account_name]
+		tax_rate = [tax_rate]
+
+	accounts = []
+	for i, name in enumerate(account_name):
+		tax_account = make_tax_account(company, account_name[i], tax_rate[i])
+		if tax_account:
+			accounts.append(tax_account)
+
 	try:
-		if not isinstance(account_name, (list, tuple)):
-			account_name = [account_name]
-			tax_rate = [tax_rate]
-
-		accounts = []
-		for i, name in enumerate(account_name):
-			tax_account = make_tax_account(company, account_name[i], tax_rate[i])
-			if tax_account:
-				accounts.append(tax_account)
-
 		if accounts:
 			make_sales_and_purchase_tax_templates(accounts, template_name)
 	except frappe.NameError:
-		pass
+		frappe.message_log.pop()
 	except RootNotEditable:
 		pass
 
 def make_tax_account(company, account_name, tax_rate):
 	tax_group = get_tax_account_group(company)
 	if tax_group:
-		return frappe.get_doc({
-			"doctype":"Account",
-			"company": company,
-			"parent_account": tax_group,
-			"account_name": account_name,
-			"is_group": 0,
-			"report_type": "Balance Sheet",
-			"root_type": "Liability",
-			"account_type": "Tax",
-			"tax_rate": flt(tax_rate) if tax_rate else None
-		}).insert(ignore_permissions=True, ignore_mandatory=True)
+		try:
+			return frappe.get_doc({
+				"doctype":"Account",
+				"company": company,
+				"parent_account": tax_group,
+				"account_name": account_name,
+				"is_group": 0,
+				"report_type": "Balance Sheet",
+				"root_type": "Liability",
+				"account_type": "Tax",
+				"tax_rate": flt(tax_rate) if tax_rate else None
+			}).insert(ignore_permissions=True, ignore_mandatory=True)
+		except frappe.NameError:
+			frappe.message_log.pop()
+			abbr = frappe.db.get_value('Company', company, 'abbr')
+			account = '{0} - {1}'.format(account_name, abbr)
+			return frappe.get_doc('Account', account)
 
 def make_sales_and_purchase_tax_templates(accounts, template_name=None):
 	if not template_name:
@@ -62,7 +68,7 @@ def make_sales_and_purchase_tax_templates(accounts, template_name=None):
 
 	for account in accounts:
 		sales_tax_template['taxes'].append({
-			"category": "Valuation and Total",
+			"category": "Total",
 			"charge_type": "On Net Total",
 			"account_head": account.name,
 			"description": "{0} @ {1}".format(account.account_name, account.tax_rate),

--- a/erpnext/shopping_cart/test_shopping_cart.py
+++ b/erpnext/shopping_cart/test_shopping_cart.py
@@ -128,7 +128,7 @@ class TestShoppingCart(unittest.TestCase):
 			"contact_email": frappe.session.user,
 			"selling_price_list": "_Test Price List Rest of the World",
 			"currency": "USD",
-			"taxes_and_charges" : "_Test Tax 1",
+			"taxes_and_charges" : "_Test Tax 1 - _TC",
 			"conversion_rate":1,
 			"transaction_date" : nowdate(),
 			"valid_till" : add_months(nowdate(), 1),
@@ -136,7 +136,7 @@ class TestShoppingCart(unittest.TestCase):
 				"item_code": "_Test Item",
 				"qty": 1
 			}],
-			"taxes": frappe.get_doc("Sales Taxes and Charges Template", "_Test Tax 1").taxes,
+			"taxes": frappe.get_doc("Sales Taxes and Charges Template", "_Test Tax 1 - _TC").taxes,
 			"company": "_Test Company"
 		}
 

--- a/erpnext/stock/doctype/delivery_note/test_delivery_note.js
+++ b/erpnext/stock/doctype/delivery_note/test_delivery_note.js
@@ -15,7 +15,7 @@ QUnit.test("test delivery note", function(assert) {
 				]},
 				{shipping_address_name: 'Test1-Shipping'},
 				{contact_person: 'Contact 1-Test Customer 1'},
-				{taxes_and_charges: 'TEST In State GST'},
+				{taxes_and_charges: 'TEST In State GST - FT'},
 				{tc_name: 'Test Term 1'},
 				{transporter_name:'TEST TRANSPORT'},
 				{lr_no:'MH-04-FG 1111'}

--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.js
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.js
@@ -17,7 +17,7 @@ QUnit.test("test Purchase Receipt", function(assert) {
 						{'rejected_warehouse':'Work In Progress - '+frappe.get_abbr(frappe.defaults.get_default('Company'))},
 					]
 				]},
-				{taxes_and_charges: 'TEST In State GST'},
+				{taxes_and_charges: 'TEST In State GST - FT'},
 				{tc_name: 'Test Term 1'},
 				{terms: 'This is Test'}
 			]);
@@ -27,7 +27,7 @@ QUnit.test("test Purchase Receipt", function(assert) {
 			// get_item_details
 			assert.ok(cur_frm.doc.items[0].item_name=='Test Product 1', "Item name correct");
 			// get tax details
-			assert.ok(cur_frm.doc.taxes_and_charges=='TEST In State GST', "Tax details correct");
+			assert.ok(cur_frm.doc.taxes_and_charges=='TEST In State GST - FT', "Tax details correct");
 			// get tax account head details
 			assert.ok(cur_frm.doc.taxes[0].account_head=='CGST - '+frappe.get_abbr(frappe.defaults.get_default('Company')), " Account Head abbr correct");
 			// grand_total Calculated


### PR DESCRIPTION
### Added company abbreviation to make default tax template
![screen shot 2018-01-02 at 11 35 12 am](https://user-images.githubusercontent.com/8780500/34476351-f7fb3188-efb5-11e7-9ff2-e346aa76a1f1.png)

### Provision to make default tax template for sales and purchase
![screen shot 2018-01-02 at 12 53 18 pm](https://user-images.githubusercontent.com/8780500/34477011-f053590a-efbb-11e7-8b5a-3425325d4dec.png)

### Provision to view default created tax template for sales and purchase
![screen shot 2018-01-02 at 12 53 00 pm](https://user-images.githubusercontent.com/8780500/34477012-f1fd7e84-efbb-11e7-89e7-f7753068d9a0.png)




Fixed https://github.com/frappe/erpnext/issues/12281