### PR TITLE
[Fix] Error in stock move from batch dashboard

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry_utils.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry_utils.py
@@ -23,7 +23,7 @@ def make_stock_entry(**args):
 
 	def process_serial_numbers(serial_nos_list):
 		serial_nos_list = [
-			'\n'.join(serial_num['serial_no'] for serial_num in serial_nos_list)
+			'\n'.join(serial_num['serial_no'] for serial_num in serial_nos_list if serial_num.serial_no)
 		]
 
 		uniques = list(set(serial_nos_list[0].split('\n')))


### PR DESCRIPTION
**Error Traceback**
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2018-01-05/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2018-01-05/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2018-01-05/apps/frappe/frappe/handler.py", line 53, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2018-01-05/apps/frappe/frappe/__init__.py", line 939, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2018-01-05/apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry_utils.py", line 105, in make_stock_entry
    serial_number = process_serial_numbers(serial_number_list)
  File "/home/frappe/benches/bench-2018-01-05/apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry_utils.py", line 26, in process_serial_numbers
    '\n'.join(serial_num['serial_no'] for serial_num in serial_nos_list)
TypeError: sequence item 0: expected string, NoneType found
```