### PR TITLE
Multiple variant modal correction

### DIFF
--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -424,7 +424,8 @@ $.extend(erpnext.item, {
 						filters: [
 							["parent","=", attribute]
 						],
-						fields: ["attribute_value"]
+						fields: ["attribute_value"],
+						limit_page_length: null
 					}
 				}).then((r) => {
 					if(r.message) {


### PR DESCRIPTION
Hi,

The current design of the multiple variant creation modal is limited to 20 attributes for each variant attribute.

This PR is meant to remove this limitation to fetch all variant attributes available:

![image](https://user-images.githubusercontent.com/4903591/34767090-8fb6d594-f5f7-11e7-9ce0-227402dcfb29.png)
