### PR TITLE
Issue in the Production Order if new item is added.

### DIFF
--- a/erpnext/manufacturing/doctype/production_order/production_order.py
+++ b/erpnext/manufacturing/doctype/production_order/production_order.py
@@ -462,7 +462,8 @@ class ProductionOrder(Document):
 
 			if reset_only_qty:
 				for d in self.get("required_items"):
-					d.required_qty = item_dict.get(d.item_code).get("qty")
+					if item_dict.get(d.item_code):
+						d.required_qty = item_dict.get(d.item_code).get("qty")
 			else:
 				for item in sorted(item_dict.values(), key=lambda d: d['idx']):
 					self.append('required_items', {


### PR DESCRIPTION
File "/home/frappe/benches/bench-2018-01-09/apps/erpnext/erpnext/manufacturing/doctype/production_order/production_order.py", line 47, in validate
    self.set_required_items(reset_only_qty = len(self.get("required_items")))
  File "/home/frappe/benches/bench-2018-01-09/apps/erpnext/erpnext/manufacturing/doctype/production_order/production_order.py", line 465, in set_required_items
    d.required_qty = item_dict.get(d.item_code).get("qty")
AttributeError: 'NoneType' object has no attribute 'get'