### PR TITLE
Remove controller methods from make_quotation of Lead

### DIFF
--- a/erpnext/crm/doctype/lead/lead.py
+++ b/erpnext/crm/doctype/lead/lead.py
@@ -161,7 +161,6 @@ def make_quotation(source_name, target_doc=None):
 	target_doc.quotation_to = "Lead"
 	target_doc.run_method("set_missing_values")
 	target_doc.run_method("set_other_charges")
-	target_doc.run_method("calculate_taxes_and_totals")
 
 	return target_doc
 


### PR DESCRIPTION
`make_quotation` is only called from client Make button in Lead form