### PR TITLE
Fix total monthly sales

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -140,6 +140,8 @@ class SalesInvoice(SellingController):
 		if not cint(self.is_pos) == 1 and not self.is_return:
 			self.update_against_document_in_jv()
 
+		frappe.db.commit()
+	
 		self.update_time_sheet(self.name)
 
 		self.update_current_month_sales()

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -183,6 +183,8 @@ class SalesInvoice(SellingController):
 		self.make_gl_entries_on_cancel()
 		frappe.db.set(self, 'status', 'Cancelled')
 
+		frappe.db.commit()
+
 		self.update_current_month_sales()
 		self.update_project()
 


### PR DESCRIPTION
We need to commit the db queries, before we call methods which update other doctypes, which rely on SQL queries, because otherwise the calculation of them is wrong and doesn't consider the current submitted or cancelled sales invoice.

I only saw problems with the current_month_sales. However, update_project relies on a direct SQL query as well. I don't know if update_time_sheet is affected, but it doesn't do any harm to commit the database query before calling the other methods.