### PR TITLE
[Payroll Entry] Set posting date only if null

### DIFF
--- a/erpnext/hr/doctype/payroll_entry/payroll_entry.js
+++ b/erpnext/hr/doctype/payroll_entry/payroll_entry.js
@@ -5,7 +5,9 @@ var in_progress = false;
 
 frappe.ui.form.on('Payroll Entry', {
 	onload: function (frm) {
-		frm.doc.posting_date = frappe.datetime.nowdate();
+		if (!frm.doc.posting_date) {
+			frm.doc.posting_date = frappe.datetime.nowdate();
+		}
 		frm.toggle_reqd(['payroll_frequency'], !frm.doc.salary_slip_based_on_timesheet);
 	},
 


### PR DESCRIPTION
Whenever the form loads, posting_date used to get updated to nowdate even if the form was submitted.
https://discuss.erpnext.com/t/payroll-entry-posting-date/32877