### PR TITLE
[Fix] Error in PO. No Permission for Buying Settings

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -21,10 +21,10 @@ frappe.ui.form.on("Purchase Order", {
 			return erpnext.queries.warehouse(frm.doc);
 		});
 
-		frappe.db.get_value('Buying Settings', {name: 'Buying Settings'}, 'disable_fetch_last_purchase_rate', (r) => {
-			value = r && cint(r.disable_fetch_last_purchase_rate);
-			frm.toggle_display('get_last_purchase_rate', !value);
-		});
+		if (frm.doc.__onload) {
+			frm.toggle_display('get_last_purchase_rate',
+				frm.doc.__onload.disable_fetch_last_purchase_rate);
+		}
 
 		frm.set_indicator_formatter('item_code',
 			function(doc) { return (doc.qty<=doc.received_qty) ? "green" : "orange" })

--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -34,6 +34,12 @@ class PurchaseOrder(BuyingController):
 			'overflow_type': 'order'
 		}]
 
+	def onload(self):
+		super(PurchaseOrder, self).onload()
+
+		self.set_onload('disable_fetch_last_purchase_rate',
+			cint(frappe.db.get_single_value("Buying Settings", "disable_fetch_last_purchase_rate")))
+
 	def validate(self):
 		super(PurchaseOrder, self).validate()
 


### PR DESCRIPTION
**Issue**

![screen shot 2018-01-19 at 12 41 49 pm](https://user-images.githubusercontent.com/8780500/35138783-256a7346-fd16-11e7-9fbb-b223aa7a4372.png)

```
Traceback (most recent call last):
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.handler.handle()
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/handler.py", line 53, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/__init__.py", line 939, in call
    return fn(*args, **newargs)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/client.py", line 61, in get_value
    frappe.throw(_("No permission for {0}".format(doctype)), frappe.PermissionError)
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/__init__.py", line 323, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red')
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/__init__.py", line 309, in msgprint
    _raise_exception()
  File "/Users/rohitwaghchaure/Documents/erpnext/frappe-bench/apps/frappe/frappe/__init__.py", line 282, in _raise_exception
    raise raise_exception(encode(msg))
PermissionError: No permission for Buying Settings
```