### PR TITLE
[Fix] Wrong projected qty for warehouse group in the process of reorder item, which making extra material requests

### DIFF
--- a/erpnext/stock/reorder_item.py
+++ b/erpnext/stock/reorder_item.py
@@ -85,18 +85,22 @@ def get_item_warehouse_projected_qty(items_to_consider):
 		from tabBin where item_code in ({0})
 			and (warehouse != "" and warehouse is not null)"""\
 		.format(", ".join(["%s"] * len(items_to_consider))), items_to_consider):
-		
-		item_warehouse_projected_qty.setdefault(item_code, {})[warehouse] = flt(projected_qty)
-		
+
+		if item_code not in item_warehouse_projected_qty:
+			item_warehouse_projected_qty.setdefault(item_code, {})
+
+		if warehouse not in item_warehouse_projected_qty.get(item_code):
+			item_warehouse_projected_qty[item_code][warehouse] = flt(projected_qty)
+
 		warehouse_doc = frappe.get_doc("Warehouse", warehouse)
-		
+
 		while warehouse_doc.parent_warehouse:
 			if not item_warehouse_projected_qty.get(item_code, {}).get(warehouse_doc.parent_warehouse):
 				item_warehouse_projected_qty.setdefault(item_code, {})[warehouse_doc.parent_warehouse] = flt(projected_qty)
 			else:
 				item_warehouse_projected_qty[item_code][warehouse_doc.parent_warehouse] += flt(projected_qty)
 			warehouse_doc = frappe.get_doc("Warehouse", warehouse_doc.parent_warehouse)
-				
+
 	return item_warehouse_projected_qty
 
 def create_material_request(material_requests):


### PR DESCRIPTION
**Reorder** 
![screen shot 2018-01-20 at 3 45 29 pm](https://user-images.githubusercontent.com/8780500/35182347-fb4c8ed0-fdf8-11e7-834c-e228f15a8b8b.png)

**Warehouse Tree**
![screen shot 2018-01-20 at 3 46 44 pm](https://user-images.githubusercontent.com/8780500/35182358-319f5a1c-fdf9-11e7-8bc8-8eb1b1fb9294.png)


In the item reorder process, for warehouse Wh-Elec-Store - SIPL projected qty calculated as zero even if it's child warehouses has the positive projected qty