### PR TITLE
Add min/max amount for selecting pricing rule

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -111,8 +111,8 @@ def apply_pricing_rule(args):
 
 	item_list = args.get("items")
 	args.pop("items")
-	
-	set_serial_nos_based_on_fifo = frappe.db.get_single_value("Stock Settings", 
+
+	set_serial_nos_based_on_fifo = frappe.db.get_single_value("Stock Settings",
 		"automatically_set_serial_nos_based_on_fifo")
 
 	for item in item_list:
@@ -122,7 +122,7 @@ def apply_pricing_rule(args):
 		if set_serial_nos_based_on_fifo and not args.get('is_return'):
 			out.append(get_serial_no_for_item(args_copy))
 	return out
-	
+
 def get_serial_no_for_item(args):
 	from erpnext.stock.get_item_details import get_serial_no
 
@@ -143,7 +143,7 @@ def get_pricing_rule_for_item(args):
 		"name": args.name,
 		"pricing_rule": None
 	})
-	
+
 	if args.ignore_pricing_rule or not args.item_code:
 		if frappe.db.exists(args.doctype, args.name) and args.get("pricing_rule"):
 			item_details = remove_pricing_rule_for_item(args.get("pricing_rule"), item_details)
@@ -192,7 +192,7 @@ def get_pricing_rule_for_item(args):
 	return item_details
 
 def remove_pricing_rule_for_item(pricing_rule, item_details):
-	pricing_rule = frappe.db.get_value('Pricing Rule', pricing_rule, 
+	pricing_rule = frappe.db.get_value('Pricing Rule', pricing_rule,
 		['price_or_discount', 'margin_type'], as_dict=1)
 	if pricing_rule and pricing_rule.price_or_discount == 'Discount Percentage':
 		item_details.discount_percentage = 0.0
@@ -209,14 +209,14 @@ def remove_pricing_rule_for_item(pricing_rule, item_details):
 def remove_pricing_rules(item_list):
 	if isinstance(item_list, basestring):
 		item_list = json.loads(item_list)
-	
-	out = []	
+
+	out = []
 	for item in item_list:
 		item = frappe._dict(item)
 		out.append(remove_pricing_rule_for_item(item.get("pricing_rule"), item))
-		
+
 	return out
-	
+
 def get_pricing_rules(args):
 	def _get_tree_conditions(parenttype, allow_blank=True):
 		field = frappe.scrub(parenttype)
@@ -290,6 +290,11 @@ def filter_pricing_rules(args, pricing_rules):
 
 		pricing_rules = filter(lambda x: (flt(stock_qty)>=flt(x.min_qty)
 			and (flt(stock_qty)<=x.max_qty if x.max_qty else True)), pricing_rules)
+
+		amt = args.get('qty') * args.get('conversion_factor', 1) * args.get('price_list_rate', 0)
+
+		pricing_rules = filter(lambda x: (flt(amt)>=flt(x.min_amt)
+			and (flt(amt)<=x.max_amt if x.max_amt else True)), pricing_rules)
 
 		# add variant_of property in pricing rule
 		for p in pricing_rules:


### PR DESCRIPTION
Often there is a requirement of selecting discounts when amount of a particular item exceeds a specific amount. This PR adds a small modification to provide that functionality.

Added two fields min_amt and max_amt, on which an additional filtering happens for selecting the rule.

![screenshot from 2018-01-22 16-34-11](https://user-images.githubusercontent.com/14350421/35218376-6ee92212-ff94-11e7-87a7-73b9c5c6e95d.png)

