### PR TITLE
Select multiple raw material items for Sub Contract Stock Entries

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -143,12 +143,7 @@ erpnext.buying.PurchaseOrderController = erpnext.buying.BuyingController.extend(
 		var items = $.map(cur_frm.doc.items, function(d) { return d.bom ? d.item_code : false; });
 		var me = this;
 
-		if(items.length===1) {
-			me._make_stock_entry(items[0]);
-			return;
-		}
-
-		if(items.length > 1){
+		if(items.length >= 1){
 			me.raw_material_data = [];
 			me.show_dialog = 1;
 			let title = "";
@@ -157,17 +152,15 @@ erpnext.buying.PurchaseOrderController = erpnext.buying.BuyingController.extend(
 			{fieldname: 'sub_con_rm_items', fieldtype: 'Table',
 				fields: [
 					{
-						fieldtype:'Link',
+						fieldtype:'Data',
 						fieldname:'item_code',
-						options: 'Item',
 						label: __('Item'),
 						read_only:1,
 						in_list_view:1
 					},
 					{
-						fieldtype:'Link',
+						fieldtype:'Data',
 						fieldname:'rm_item_code',
-						options:'Item',
 						label: __('Raw Material'),
 						read_only:1,
 						in_list_view:1
@@ -181,11 +174,10 @@ erpnext.buying.PurchaseOrderController = erpnext.buying.BuyingController.extend(
 						in_list_view:1
 					},
 					{
-						fieldtype:'Link',
+						fieldtype:'Data',
 						read_only:1,
 						fieldname:'warehouse',
 						label: __('Reserve Warehouse'),
-						read_only:1,
 						in_list_view:1
 					},
 					{
@@ -259,20 +251,6 @@ erpnext.buying.PurchaseOrderController = erpnext.buying.BuyingController.extend(
 			me.dialog.hide();
 		});
 
-	},
-
-	_make_stock_entry: function(item) {
-		frappe.call({
-			method:"erpnext.buying.doctype.purchase_order.purchase_order.make_stock_entry",
-			args: {
-				purchase_order: cur_frm.doc.name,
-				item_code: item
-			},
-			callback: function(r) {
-				var doclist = frappe.model.sync(r.message);
-				frappe.set_route("Form", doclist[0].doctype, doclist[0].name);
-			}
-		});
 	},
 
 	_make_rm_stock_entry: function(rm_items) {

--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -140,126 +140,126 @@ erpnext.buying.PurchaseOrderController = erpnext.buying.BuyingController.extend(
 	},
 
 	make_stock_entry: function() {
-				var items = $.map(cur_frm.doc.items, function(d) { return d.bom ? d.item_code : false; });
-				var me = this;
+		var items = $.map(cur_frm.doc.items, function(d) { return d.bom ? d.item_code : false; });
+		var me = this;
 
-				if(items.length===1) {
-					me._make_stock_entry(items[0]);
-					return;
-				}
+		if(items.length===1) {
+			me._make_stock_entry(items[0]);
+			return;
+		}
 
-				if(items.length > 1){
-					me.raw_material_data = [];
-					me.show_dialog = 1;
-					let title = "";
-					let fields = [
-					{fieldtype:'Section Break', label: __('Raw Materials')},
-					{fieldname: 'sub_con_rm_items', fieldtype: 'Table',
-						fields: [
-							{
-								fieldtype:'Link',
-								fieldname:'item_code',
-								options: 'Item',
-								label: __('Item'),
-								read_only:1,
-								in_list_view:1
-							},
-							{
-								fieldtype:'Link',
-								fieldname:'rm_item_code',
-								options:'Item',
-								label: __('Raw Material'),
-								read_only:1,
-								in_list_view:1
-							},
-							{
-								fieldtype:'Float',
-								read_only:1,
-								fieldname:'qty',
-								label: __('Quantity'),
-								read_only:1,
-								in_list_view:1
-							},
-							{
-								fieldtype:'Link',
-								read_only:1,
-								fieldname:'warehouse',
-								label: __('Reserve Warehouse'),
-								read_only:1,
-								in_list_view:1
-							},
-							{
-								fieldtype:'Float',
-								read_only:1,
-								fieldname:'rate',
-								label: __('Rate'),
-								hidden:1
-							},
-							{
-								fieldtype:'Float',
-								read_only:1,
-								fieldname:'amount',
-								label: __('Amount'),
-								hidden:1
-							},
-							{
-								fieldtype:'Link',
-								read_only:1,
-								fieldname:'uom',
-								label: __('UOM'),
-								hidden:1
-							}
-						],
-						data: me.raw_material_data,
-						get_data: function() {
-							return me.raw_material_data;
-						}
+		if(items.length > 1){
+			me.raw_material_data = [];
+			me.show_dialog = 1;
+			let title = "";
+			let fields = [
+			{fieldtype:'Section Break', label: __('Raw Materials')},
+			{fieldname: 'sub_con_rm_items', fieldtype: 'Table',
+				fields: [
+					{
+						fieldtype:'Link',
+						fieldname:'item_code',
+						options: 'Item',
+						label: __('Item'),
+						read_only:1,
+						in_list_view:1
+					},
+					{
+						fieldtype:'Link',
+						fieldname:'rm_item_code',
+						options:'Item',
+						label: __('Raw Material'),
+						read_only:1,
+						in_list_view:1
+					},
+					{
+						fieldtype:'Float',
+						read_only:1,
+						fieldname:'qty',
+						label: __('Quantity'),
+						read_only:1,
+						in_list_view:1
+					},
+					{
+						fieldtype:'Link',
+						read_only:1,
+						fieldname:'warehouse',
+						label: __('Reserve Warehouse'),
+						read_only:1,
+						in_list_view:1
+					},
+					{
+						fieldtype:'Float',
+						read_only:1,
+						fieldname:'rate',
+						label: __('Rate'),
+						hidden:1
+					},
+					{
+						fieldtype:'Float',
+						read_only:1,
+						fieldname:'amount',
+						label: __('Amount'),
+						hidden:1
+					},
+					{
+						fieldtype:'Link',
+						read_only:1,
+						fieldname:'uom',
+						label: __('UOM'),
+						hidden:1
 					}
-				]
-
-				me.dialog = new frappe.ui.Dialog({
-					title: title,fields: fields
-					});
-
-				if (me.frm.doc['supplied_items']) {
-					me.frm.doc['supplied_items'].forEach((item, index) => {
-					if (item.rm_item_code && item.main_item_code) {
-							me.raw_material_data.push ({
-								'name':index,
-								'item_code': item.main_item_code,
-								'rm_item_code': item.rm_item_code,
-								'item_name': item.rm_item_code,
-								'qty': item.required_qty,
-								'warehouse':item.reserve_warehouse,
-								'rate':item.rate,
-								'amount':item.amount,
-								'stock_uom':item.stock_uom
-							});
-							me.dialog.fields_dict.sub_con_rm_items.grid.refresh();
-						}
-					})
+				],
+				data: me.raw_material_data,
+				get_data: function() {
+					return me.raw_material_data;
 				}
+			}
+		]
 
-				me.dialog.show()
-				this.dialog.set_primary_action(__('Transfer'), function() {
-					me.values = me.dialog.get_values();
-					if(me.values) {
-						me.values.sub_con_rm_items.map((row,i) => {
-							if (!row.item_code || !row.rm_item_code || !row.warehouse || !row.qty || row.qty === 0) {
-								frappe.throw(__("Item Code, warehouse, quantity are required on row" + (i+1)));
-							}
-						})
-						me._make_rm_stock_entry(me.dialog.fields_dict.sub_con_rm_items.grid.get_selected_children())
-						me.dialog.hide()
-						}
+		me.dialog = new frappe.ui.Dialog({
+			title: title,fields: fields
+			});
+
+		if (me.frm.doc['supplied_items']) {
+			me.frm.doc['supplied_items'].forEach((item, index) => {
+			if (item.rm_item_code && item.main_item_code) {
+					me.raw_material_data.push ({
+						'name':index,
+						'item_code': item.main_item_code,
+						'rm_item_code': item.rm_item_code,
+						'item_name': item.rm_item_code,
+						'qty': item.required_qty,
+						'warehouse':item.reserve_warehouse,
+						'rate':item.rate,
+						'amount':item.amount,
+						'stock_uom':item.stock_uom
 					});
+					me.dialog.fields_dict.sub_con_rm_items.grid.refresh();
 				}
+			})
+		}
 
-				me.dialog.get_close_btn().on('click', () => {
-					me.dialog.hide();
-				});
+		me.dialog.show()
+		this.dialog.set_primary_action(__('Transfer'), function() {
+			me.values = me.dialog.get_values();
+			if(me.values) {
+				me.values.sub_con_rm_items.map((row,i) => {
+					if (!row.item_code || !row.rm_item_code || !row.warehouse || !row.qty || row.qty === 0) {
+						frappe.throw(__("Item Code, warehouse, quantity are required on row" + (i+1)));
+					}
+				})
+				me._make_rm_stock_entry(me.dialog.fields_dict.sub_con_rm_items.grid.get_selected_children())
+				me.dialog.hide()
+				}
+			});
+		}
 
-			},
+		me.dialog.get_close_btn().on('click', () => {
+			me.dialog.hide();
+		});
+
+	},
 
 	_make_stock_entry: function(item) {
 		frappe.call({

--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -140,18 +140,126 @@ erpnext.buying.PurchaseOrderController = erpnext.buying.BuyingController.extend(
 	},
 
 	make_stock_entry: function() {
-		var items = $.map(cur_frm.doc.items, function(d) { return d.bom ? d.item_code : false; });
-		var me = this;
+				var items = $.map(cur_frm.doc.items, function(d) { return d.bom ? d.item_code : false; });
+				var me = this;
 
-		if(items.length===1) {
-			me._make_stock_entry(items[0]);
-			return;
-		}
-		frappe.prompt({fieldname:"item", options: items, fieldtype:"Select",
-			label: __("Select Item for Transfer"), reqd: 1}, function(data) {
-			me._make_stock_entry(data.item);
-		}, __("Select Item"), __("Make"));
-	},
+				if(items.length===1) {
+					me._make_stock_entry(items[0]);
+					return;
+				}
+
+				if(items.length > 1){
+					me.raw_material_data = [];
+					me.show_dialog = 1;
+					let title = "";
+					let fields = [
+					{fieldtype:'Section Break', label: __('Raw Materials')},
+					{fieldname: 'sub_con_rm_items', fieldtype: 'Table',
+						fields: [
+							{
+								fieldtype:'Link',
+								fieldname:'item_code',
+								options: 'Item',
+								label: __('Item'),
+								read_only:1,
+								in_list_view:1
+							},
+							{
+								fieldtype:'Link',
+								fieldname:'rm_item_code',
+								options:'Item',
+								label: __('Raw Material'),
+								read_only:1,
+								in_list_view:1
+							},
+							{
+								fieldtype:'Float',
+								read_only:1,
+								fieldname:'qty',
+								label: __('Quantity'),
+								read_only:1,
+								in_list_view:1
+							},
+							{
+								fieldtype:'Link',
+								read_only:1,
+								fieldname:'warehouse',
+								label: __('Reserve Warehouse'),
+								read_only:1,
+								in_list_view:1
+							},
+							{
+								fieldtype:'Float',
+								read_only:1,
+								fieldname:'rate',
+								label: __('Rate'),
+								hidden:1
+							},
+							{
+								fieldtype:'Float',
+								read_only:1,
+								fieldname:'amount',
+								label: __('Amount'),
+								hidden:1
+							},
+							{
+								fieldtype:'Link',
+								read_only:1,
+								fieldname:'uom',
+								label: __('UOM'),
+								hidden:1
+							}
+						],
+						data: me.raw_material_data,
+						get_data: function() {
+							return me.raw_material_data;
+						}
+					}
+				]
+
+				me.dialog = new frappe.ui.Dialog({
+					title: title,fields: fields
+					});
+
+				if (me.frm.doc['supplied_items']) {
+					me.frm.doc['supplied_items'].forEach((item, index) => {
+					if (item.rm_item_code && item.main_item_code) {
+							me.raw_material_data.push ({
+								'name':index,
+								'item_code': item.main_item_code,
+								'rm_item_code': item.rm_item_code,
+								'item_name': item.rm_item_code,
+								'qty': item.required_qty,
+								'warehouse':item.reserve_warehouse,
+								'rate':item.rate,
+								'amount':item.amount,
+								'stock_uom':item.stock_uom
+							});
+							me.dialog.fields_dict.sub_con_rm_items.grid.refresh();
+						}
+					})
+				}
+
+				me.dialog.show()
+				this.dialog.set_primary_action(__('Transfer'), function() {
+					me.values = me.dialog.get_values();
+					if(me.values) {
+						me.values.sub_con_rm_items.map((row,i) => {
+							if (!row.item_code || !row.rm_item_code || !row.warehouse || !row.qty || row.qty === 0) {
+								frappe.throw(__("Item Code, warehouse, quantity are required on row" + (i+1)));
+							}
+						})
+						me._make_rm_stock_entry(me.dialog.fields_dict.sub_con_rm_items.grid.get_selected_children())
+						me.dialog.hide()
+						}
+					});
+				}
+
+				me.dialog.get_close_btn().on('click', () => {
+					me.dialog.hide();
+				});
+
+			},
 
 	_make_stock_entry: function(item) {
 		frappe.call({
@@ -163,6 +271,20 @@ erpnext.buying.PurchaseOrderController = erpnext.buying.BuyingController.extend(
 			callback: function(r) {
 				var doclist = frappe.model.sync(r.message);
 				frappe.set_route("Form", doclist[0].doctype, doclist[0].name);
+			}
+		});
+	},
+
+	_make_rm_stock_entry: function(rm_items) {
+		frappe.call({
+			method:"erpnext.buying.doctype.purchase_order.purchase_order.make_rm_stock_entry",
+			args: {
+				purchase_order: cur_frm.doc.name,
+				rm_items: rm_items
+			}
+			,
+			callback: function(r) {
+				frappe.set_route("List", "Stock Entry", "List",{"purchase_order":r.message,"doc_status":0})
 			}
 		});
 	},

--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -284,7 +284,8 @@ erpnext.buying.PurchaseOrderController = erpnext.buying.BuyingController.extend(
 			}
 			,
 			callback: function(r) {
-				frappe.set_route("List", "Stock Entry", "List",{"purchase_order":r.message,"doc_status":0})
+				var doclist = frappe.model.sync(r.message);
+				frappe.set_route("Form", doclist[0].doctype, doclist[0].name);
 			}
 		});
 	},

--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -34,6 +34,12 @@ class PurchaseOrder(BuyingController):
 			'overflow_type': 'order'
 		}]
 
+	def onload(self):
+		super(PurchaseOrder, self).onload()
+
+		self.set_onload('disable_fetch_last_purchase_rate',
+		cint(frappe.db.get_single_value("Buying Settings", "disable_fetch_last_purchase_rate")))
+
 	def validate(self):
 		super(PurchaseOrder, self).validate()
 
@@ -393,6 +399,7 @@ def make_purchase_invoice(source_name, target_doc=None):
 @frappe.whitelist()
 def make_stock_entry(purchase_order, item_code):
 	purchase_order = frappe.get_doc("Purchase Order", purchase_order)
+
 	stock_entry = frappe.new_doc("Stock Entry")
 	stock_entry.purpose = "Subcontract"
 	stock_entry.purchase_order = purchase_order.name
@@ -437,6 +444,7 @@ def make_rm_stock_entry(purchase_order, rm_items):
 			stock_entry.supplier_address = purchase_order.supplier_address
 			stock_entry.address_display = purchase_order.address_display
 			stock_entry.company = purchase_order.company
+			stock_entry.docstatus = 0
 			stock_entry.from_bom = 1
 			po_item = [d for d in purchase_order.items if d.item_code == item_code][0]
 			stock_entry.fg_completed_qty = po_item.qty

--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -435,30 +435,29 @@ def make_rm_stock_entry(purchase_order, rm_items):
 		item_wh = frappe._dict(frappe.db.sql("""select item_code, description
 										from `tabItem` where name in ({0})""".
 										format(", ".join(["%s"] * len(item_code_list))), item_code_list))
+		stock_entry = frappe.new_doc("Stock Entry")
+		stock_entry.purpose = "Subcontract"
+		stock_entry.purchase_order = purchase_order.name
+		stock_entry.supplier = purchase_order.supplier
+		stock_entry.supplier_name = purchase_order.supplier_name
+		stock_entry.supplier_address = purchase_order.supplier_address
+		stock_entry.address_display = purchase_order.address_display
+		stock_entry.company = purchase_order.company
+		stock_entry.from_bom = 1
 		for item_code in item_code_list:
-			stock_entry = frappe.new_doc("Stock Entry")
-			stock_entry.purpose = "Subcontract"
-			stock_entry.purchase_order = purchase_order.name
-			stock_entry.supplier = purchase_order.supplier
-			stock_entry.supplier_name = purchase_order.supplier_name
-			stock_entry.supplier_address = purchase_order.supplier_address
-			stock_entry.address_display = purchase_order.address_display
-			stock_entry.company = purchase_order.company
-			stock_entry.docstatus = 0
-			stock_entry.from_bom = 1
 			po_item = [d for d in purchase_order.items if d.item_code == item_code][0]
-			stock_entry.fg_completed_qty = po_item.qty
-			stock_entry.bom_no = po_item.bom
+			bom_no = po_item.bom
 			for rm_item_data in rm_items_list:
 				if rm_item_data["item_code"] == item_code:
 					items_dict = {rm_item_data["rm_item_code"]:
-					{"item_name":rm_item_data["item_name"],
-					"description":item_wh.get(rm_item_data["rm_item_code"]),
-					'qty':rm_item_data["qty"],
-					'from_warehouse':rm_item_data["warehouse"],
-					'stock_uom':rm_item_data["stock_uom"]}}
-					stock_entry.add_to_stock_entry_detail(items_dict)
-			stock_entry.save()
+								{"item_name":rm_item_data["item_name"],
+								"description":item_wh.get(rm_item_data["rm_item_code"]),
+								'qty':rm_item_data["qty"],
+								'from_warehouse':rm_item_data["warehouse"],
+								'stock_uom':rm_item_data["stock_uom"],
+								'bom_no':bom_no}}
+					stock_entry.add_to_stock_entry_detail(items_dict, bom_no)
+		return stock_entry.as_dict()
 	else:
 		frappe.throw(_("No Items selected for transfer"))
 	return purchase_order.name

--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -38,7 +38,7 @@ class PurchaseOrder(BuyingController):
 		super(PurchaseOrder, self).onload()
 
 		self.set_onload('disable_fetch_last_purchase_rate',
-		cint(frappe.db.get_single_value("Buying Settings", "disable_fetch_last_purchase_rate")))
+			cint(frappe.db.get_single_value("Buying Settings", "disable_fetch_last_purchase_rate")))
 
 	def validate(self):
 		super(PurchaseOrder, self).validate()

--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -397,25 +397,6 @@ def make_purchase_invoice(source_name, target_doc=None):
 	return doc
 
 @frappe.whitelist()
-def make_stock_entry(purchase_order, item_code):
-	purchase_order = frappe.get_doc("Purchase Order", purchase_order)
-
-	stock_entry = frappe.new_doc("Stock Entry")
-	stock_entry.purpose = "Subcontract"
-	stock_entry.purchase_order = purchase_order.name
-	stock_entry.supplier = purchase_order.supplier
-	stock_entry.supplier_name = purchase_order.supplier_name
-	stock_entry.supplier_address = purchase_order.supplier_address
-	stock_entry.address_display = purchase_order.address_display
-	stock_entry.company = purchase_order.company
-	stock_entry.from_bom = 1
-	po_item = [d for d in purchase_order.items if d.item_code == item_code][0]
-	stock_entry.fg_completed_qty = po_item.qty
-	stock_entry.bom_no = po_item.bom
-	stock_entry.get_items()
-	return stock_entry.as_dict()
-
-@frappe.whitelist()
 def make_rm_stock_entry(purchase_order, rm_items):
 
 	if isinstance(rm_items, basestring):

--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -6,8 +6,9 @@ import unittest
 import frappe
 import frappe.defaults
 from frappe.utils import flt, add_days, nowdate
-from erpnext.buying.doctype.purchase_order.purchase_order import (make_purchase_receipt, make_purchase_invoice, make_stock_entry as make_subcontract_transfer_entry)
+from erpnext.buying.doctype.purchase_order.purchase_order import (make_purchase_receipt, make_purchase_invoice, make_rm_stock_entry as make_subcontract_transfer_entry)
 from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
+import json
 
 class TestPurchaseOrder(unittest.TestCase):
 	def test_make_purchase_receipt(self):
@@ -202,11 +203,11 @@ class TestPurchaseOrder(unittest.TestCase):
 		self.assertEquals(bin2.projected_qty, bin1.projected_qty - 10)
 
 		# Create stock transfer
-		se = frappe.get_doc(make_subcontract_transfer_entry(po.name, "_Test FG Item"))
+		rm_item = [{"item_code":"_Test FG Item","rm_item_code":"_Test Item","item_name":"_Test Item",
+					"qty":6,"warehouse":"_Test Warehouse - _TC","rate":100,"amount":600,"stock_uom":"Nos"}]
+		rm_item_string = json.dumps(rm_item)
+		se = frappe.get_doc(make_subcontract_transfer_entry(po.name, rm_item_string))
 		se.to_warehouse = "_Test Warehouse 1 - _TC"
-		for d in se.get("items"):
-			if d.item_code == "_Test Item":
-				d.qty = 6
 		se.save()
 		se.submit()
 

--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -589,9 +589,11 @@ def validate_bom_no(item, bom_no):
 	if item:
 		rm_item_exists = False
 		for d in bom.items:
-			if (d.item_code.lower() == item.lower() or \
-		d.item_code.lower() == cstr(frappe.db.get_value("Item", item, "variant_of")).lower()):
+			if (d.item_code.lower() == item.lower()):
 				rm_item_exists = True
+		if bom.item.lower() == item.lower() or \
+			bom.item.lower() == cstr(frappe.db.get_value("Item", item, "variant_of")).lower():
+ 				rm_item_exists = True
 		if not rm_item_exists:
 			frappe.throw(_("BOM {0} does not belong to Item {1}").format(bom_no, item))
 

--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -586,9 +586,14 @@ def validate_bom_no(item, bom_no):
 	if bom.docstatus != 1:
 		if not getattr(frappe.flags, "in_test", False):
 			frappe.throw(_("BOM {0} must be submitted").format(bom_no))
-	if item and not (bom.item.lower() == item.lower() or \
-		bom.item.lower() == cstr(frappe.db.get_value("Item", item, "variant_of")).lower()):
-		frappe.throw(_("BOM {0} does not belong to Item {1}").format(bom_no, item))
+	if item:
+		rm_item_exists = False
+		for d in bom.items:
+			if (d.item_code.lower() == item.lower() or \
+		d.item_code.lower() == cstr(frappe.db.get_value("Item", item, "variant_of")).lower()):
+				rm_item_exists = True
+		if not rm_item_exists:
+			frappe.throw(_("BOM {0} does not belong to Item {1}").format(bom_no, item))
 
 @frappe.whitelist()
 def get_children(doctype, parent=None, is_root=False, **filters):

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -126,7 +126,11 @@ class StockEntry(StockController):
 		"""perform various (sometimes conditional) validations on warehouse"""
 
 		source_mandatory = ["Material Issue", "Material Transfer", "Subcontract", "Material Transfer for Manufacture"]
-		target_mandatory = ["Material Receipt", "Material Transfer", "Subcontract", "Material Transfer for Manufacture"]
+		#Allow creation of draft subcontract entries without target warehouse
+		if self.purpose == "Subcontract" and not frappe.db.exists("Stock Entry",{"name": self.name}):
+			target_mandatory = ["Material Receipt", "Material Transfer", "Material Transfer for Manufacture"]
+		else:
+			target_mandatory = ["Material Receipt", "Material Transfer", "Subcontract", "Material Transfer for Manufacture"]
 
 		validate_for_manufacture_repack = any([d.bom_no for d in self.get("items")])
 
@@ -672,7 +676,7 @@ class StockEntry(StockController):
 		# item dict = { item_code: {qty, description, stock_uom} }
 		item_dict = get_bom_items_as_dict(self.bom_no, self.company, qty=qty,
 			fetch_exploded = self.use_multi_level_bom)
-
+		print item_dict
 		for item in item_dict.values():
 			# if source warehouse presents in BOM set from_warehouse as bom source_warehouse
 			item.from_warehouse = self.from_warehouse or item.source_warehouse or item.default_warehouse

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -64,12 +64,13 @@ class StockEntry(StockController):
 		self.calculate_rate_and_amount(update_finished_item_rate=False)
 
 	def on_submit(self):
-		for d in self.items:
-			if self.purpose == "Subcontract" and not d.t_warehouse:
-				if self.to_warehouse:
-					d.t_warehouse = self.to_warehouse
-				else:
-					frappe.throw(_("Target warehouse is mandatory for row {0}").format(d.idx))
+		if self.purpose == "Subcontract":
+			for d in self.items:
+				if not d.t_warehouse:
+					if self.to_warehouse:
+						d.t_warehouse = self.to_warehouse
+					else:
+						frappe.throw(_("Target warehouse is mandatory for row {0}").format(d.idx))
 
 		self.update_stock_ledger()
 

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -676,7 +676,7 @@ class StockEntry(StockController):
 		# item dict = { item_code: {qty, description, stock_uom} }
 		item_dict = get_bom_items_as_dict(self.bom_no, self.company, qty=qty,
 			fetch_exploded = self.use_multi_level_bom)
-		print item_dict
+
 		for item in item_dict.values():
 			# if source warehouse presents in BOM set from_warehouse as bom source_warehouse
 			item.from_warehouse = self.from_warehouse or item.source_warehouse or item.default_warehouse


### PR DESCRIPTION
Testing Video

![subcontract testing](https://user-images.githubusercontent.com/20460498/35220001-9a03bdcc-ff6c-11e7-92b9-2c517fac9027.gif)

1. Allow selection of multiple items from Sub Contract PO based on BOM.
2. Group raw material stock entries by BOM Finished Goods and create the stock entries.