### PR TITLE
parse value before setting it to dissable_rounded_total on Purchase Invoice

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -18,7 +18,7 @@ erpnext.accounts.PurchaseInvoice = erpnext.buying.BuyingController.extend({
 				this.frm.set_df_property("credit_to", "print_hide", 0);
 			}
 		} else {
-			this.frm.set_value("disable_rounded_total", frappe.sys_defaults.disable_rounded_total);
+			this.frm.set_value("disable_rounded_total", cint(frappe.sys_defaults.disable_rounded_total));
 		}
 
 		// formatter for material request item

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -539,7 +539,8 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 		// due_date is to be changed, payment terms template and/or payment schedule must
 		// be removed as due_date is automatically changed based on payment terms
 		if (this.frm.doc.due_date) {
-			if (this.frm.doc.payment_terms_template || this.frm.doc.payment_schedule.length) {
+			if (this.frm.doc.payment_terms_template ||
+				(this.frm.doc.payment_schedule && this.frm.doc.payment_schedule.length)) {
 				var message1 = "";
 				var message2 = "";
 				var final_message = "Please clear the ";


### PR DESCRIPTION
### Before
![disable](https://user-images.githubusercontent.com/3784093/35270220-77dc3baa-0054-11e8-8a3f-39cead9cc3b5.gif)

`frappe.sys_defaults.disable_rounded_total`  value is in stringified form ie. "0".

 Due to this even though the value is 0, the system showing checkbox as checked!