### PR TITLE
Allow multiple Budgets for unique Cost Center + Account+ Fiscal Year

### DIFF
--- a/erpnext/accounts/doctype/budget/budget.py
+++ b/erpnext/accounts/doctype/budget/budget.py
@@ -27,12 +27,19 @@ class Budget(Document):
 	def validate_duplicate(self):
 		budget_against_field = frappe.scrub(self.budget_against)
 		budget_against = self.get(budget_against_field)
-		existing_budget = frappe.db.get_value("Budget", {budget_against_field: budget_against,
+		# get existing 'budget' doctype
+		for existing_budget in frappe.db.get_values("Budget", {budget_against_field: budget_against,
 			"fiscal_year": self.fiscal_year, "company": self.company,
-			"name": ["!=", self.name], "docstatus": ["!=", 2]})
-		if existing_budget: 
-			frappe.throw(_("Another Budget record '{0}' already exists against {1} '{2}' for fiscal year {3}")
-				.format(existing_budget, self.budget_against, budget_against, self.fiscal_year), DuplicateBudgetError)
+			"name": ["!=", self.name], "docstatus": ["!=", 2]},["name"], as_dict=1):
+			# get 'budget account' child table for existing budget doctype
+			for budget_account_details in frappe.db.get_values("Budget Account",
+			{"parent": existing_budget.name,"parenttype":"Budget"}, ["account"], as_dict=1):	
+				if budget_account_details.account:
+					# get 'account' from current doctype
+					for present_account in self.get('accounts'):
+						if present_account.account == budget_account_details.account:
+							frappe.throw(_("Another Budget record '{0}' already exists against {1} '{2}' for account '{3}' & fiscal year {4}")
+								.format(existing_budget.name, self.budget_against, budget_against, present_account.account,self.fiscal_year), DuplicateBudgetError)
 	
 	def validate_accounts(self):
 		account_list = []


### PR DESCRIPTION
In context to #12663 
Made changes to budget.py such that validate_duplicate function checks for uniqueness based on (cost center+fiscal year+company+account)
![budgetpr](https://user-images.githubusercontent.com/29812965/35480465-63a1728e-0434-11e8-955c-dd6e0836acc2.gif)
