### PR TITLE
[Fix] Allow user to edit rate in online POS

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -242,7 +242,10 @@ class SalesInvoice(SellingController):
 		super(SalesInvoice, self).set_missing_values(for_validate)
 
 		if pos:
-			return {"print_format": pos.get("print_format_for_online") }
+			return {
+				"print_format": pos.get("print_format_for_online"),
+				"allow_edit_rate": pos.get("allow_user_to_edit_rate")
+			}
 
 	def update_time_sheet(self, sales_invoice):
 		for d in self.timesheets:

--- a/erpnext/selling/page/point_of_sale/point_of_sale.js
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.js
@@ -463,6 +463,7 @@ erpnext.pos.PointOfSale = class PointOfSale {
 
 					if (r.message) {
 						this.frm.meta.default_print_format = r.message.print_format || 'POS Invoice';
+						this.frm.allow_edit_rate = r.message.allow_edit_rate;
 					}
 				}
 
@@ -727,6 +728,7 @@ class POSCart {
 			disable_highlight: ['Qty', 'Disc', 'Rate', 'Pay'],
 			reset_btns: ['Qty', 'Disc', 'Rate', 'Pay'],
 			del_btn: 'Del',
+			disable_btns: !this.frm.allow_edit_rate ? ['Rate']: [],
 			wrapper: this.wrapper.find('.number-pad-container'),
 			onclick: (btn_value) => {
 				// on click
@@ -1257,7 +1259,7 @@ class NumberPad {
 	constructor({
 		wrapper, onclick, button_array,
 		add_class={}, disable_highlight=[],
-		reset_btns=[], del_btn='',
+		reset_btns=[], del_btn='', disable_btns
 	}) {
 		this.wrapper = wrapper;
 		this.onclick = onclick;
@@ -1266,6 +1268,7 @@ class NumberPad {
 		this.disable_highlight = disable_highlight;
 		this.reset_btns = reset_btns;
 		this.del_btn = del_btn;
+		this.disable_btns = disable_btns;
 		this.make_dom();
 		this.bind_events();
 		this.value = '';
@@ -1296,6 +1299,14 @@ class NumberPad {
 		}
 
 		this.set_class();
+
+		this.disable_btns.forEach((btn) => {
+			const $btn = this.get_btn(btn);
+			$btn.prop("disabled", true)
+			$btn.hover(() => {
+				$btn.css('cursor','not-allowed');
+			})
+		})
 	}
 
 	set_class() {


### PR DESCRIPTION
**Disabled allow user to edit rate**
![screen shot 2018-01-30 at 9 49 06 am](https://user-images.githubusercontent.com/8780500/35548044-eae84abe-05a2-11e8-8009-b839c3c2d7e3.png)

**User can't click on Rate button in the POS after disabled the allow user to edit rate field in POS Profile**
![disabled_rate](https://user-images.githubusercontent.com/8780500/35548276-6133894e-05a4-11e8-8f1f-7decaf26e4e0.gif)

