### PR TITLE
Validate rate in PO with supplier quotation only if checking is enabled via Buying Settings

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -68,11 +68,15 @@ class PurchaseOrder(BuyingController):
 			},
 			"Supplier Quotation Item": {
 				"ref_dn_field": "supplier_quotation_item",
-				"compare_fields": [["rate", "="], ["project", "="], ["item_code", "="], 
+				"compare_fields": [["project", "="], ["item_code", "="], 
 					["uom", "="], ["conversion_factor", "="]],
 				"is_child_table": True
 			}
 		})
+
+
+		if cint(frappe.db.get_single_value('Buying Settings', 'maintain_same_rate')):
+			self.validate_rate_with_reference_doc([["Supplier Quotation", "supplier_quotation", "supplier_quotation_item"]])
 
 	def validate_supplier(self):
 		prevent_po = frappe.db.get_value("Supplier", self.supplier, 'prevent_pos')


### PR DESCRIPTION
Fixes #12733