### PR TITLE
Transaction Log for France

### DIFF
--- a/erpnext/docs/user/manual/en/regional/france/index.txt
+++ b/erpnext/docs/user/manual/en/regional/france/index.txt
@@ -1,1 +1,2 @@
 fichier_des_ecritures_comptables
+local_overrides

--- a/erpnext/docs/user/manual/en/regional/france/local_overrides.md
+++ b/erpnext/docs/user/manual/en/regional/france/local_overrides.md
@@ -1,0 +1,7 @@
+# Sales and Payment Transactions
+
+In order to be compliant with the latest finance law applicable to POS software, ERPNext automatically registers all sales and payment transactions in a chained log.
+
+If your country is set to "France", the deletion of sales and payment transactions will also not be permitted, even if the appropriate permissions are given to the user.
+
+Please note that ERPNext is not yet fully compliant with the 2016 Finance Law.

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -198,13 +198,19 @@ doc_events = {
 	"Website Settings": {
 		"validate": "erpnext.portal.doctype.products_settings.products_settings.home_page_is_products"
 	},
+	"Sales Invoice": {
+		'validate': 'erpnext.regional.india.utils.set_place_of_supply',
+		"on_submit": "erpnext.regional.france.utils.create_transaction_log",
+		"on_trash": "erpnext.regional.france.utils.check_deletion_permission"
+	},
 	"Payment Entry": {
-		"on_submit": "erpnext.accounts.doctype.payment_request.payment_request.make_status_as_paid"
+		"on_submit": ["erpnext.regional.france.utils.create_transaction_log", "erpnext.accounts.doctype.payment_request.payment_request.make_status_as_paid"],
+		"on_trash": "erpnext.regional.france.utils.check_deletion_permission"
 	},
 	'Address': {
 		'validate': 'erpnext.regional.india.utils.validate_gstin_for_india'
 	},
-	('Sales Invoice', 'Purchase Invoice'): {
+	'Purchase Invoice': {
 		'validate': 'erpnext.regional.india.utils.set_place_of_supply'
 	}
 }

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -263,6 +263,9 @@ get_site_info = 'erpnext.utilities.get_site_info'
 payment_gateway_enabled = "erpnext.accounts.utils.create_payment_gateway_account"
 
 regional_overrides = {
+	'France': {
+		'erpnext.tests.test_regional.test_method': 'erpnext.regional.france.utils.test_method'
+	},
 	'India': {
 		'erpnext.tests.test_regional.test_method': 'erpnext.regional.india.utils.test_method',
 		'erpnext.controllers.taxes_and_totals.get_itemised_tax_breakup_header': 'erpnext.regional.india.utils.get_itemised_tax_breakup_header',

--- a/erpnext/regional/france/utils.py
+++ b/erpnext/regional/france/utils.py
@@ -27,4 +27,9 @@ def check_deletion_permission(doc, method):
 		return
 
 	else:
-		frappe.throw(_("Deletion is not permitted for country {0}".format("France")))
+		frappe.throw(_("Deletion is not permitted for country {0}".format(region)))
+
+# don't remove this function it is used in tests
+def test_method():
+	'''test function'''
+	return 'overridden'

--- a/erpnext/regional/france/utils.py
+++ b/erpnext/regional/france/utils.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2018, Frappe Technologies and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe import _
+from erpnext import get_region
+
+def create_transaction_log(doc, method):
+	region = get_region()
+	if region not in ["France"]:
+		return
+
+	else:
+
+		data = str(doc.as_dict())
+
+		frappe.get_doc({
+			"doctype": "Transaction Log",
+			"reference_doctype": doc.doctype,
+			"document_name": doc.name,
+			"data": data
+		}).insert(ignore_permissions=True)
+
+def check_deletion_permission(doc, method):
+	region = get_region()
+	if region not in ["France"]:
+		return
+
+	else:
+		frappe.throw(_("Deletion is not permitted for country {0}".format("France")))

--- a/erpnext/tests/test_regional.py
+++ b/erpnext/tests/test_regional.py
@@ -11,3 +11,6 @@ class TestInit(unittest.TestCase):
 
 		frappe.flags.country = 'Nepal'
 		self.assertEqual(test_method(), 'original')
+
+		frappe.flags.country = 'France'
+		self.assertEqual(test_method(), 'overridden')


### PR DESCRIPTION
Hi,

This PR is linked with #4974.

As discussed in Frappe PR 4595, I created a regional hook to create a transaction log for payment and sales invoice in France.

Also added a check to avoid deletion of these transactions if the country is France.

The second step will consist in logging every time someone prints one of these documents. If you have any tips as to how to do it in a similar way as in python, that would be a great help!

The third step will be the creation of the report based on the logged data.

Thanks in advance for your review.