### PR TITLE
get_party_account only if company is set

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -458,7 +458,7 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 				}
 
 				var party = me.frm.doc[frappe.model.scrub(party_type)];
-				if(party) {
+				if(party && me.frm.doc.company) {
 					return frappe.call({
 						method: "erpnext.accounts.party.get_party_account",
 						args: {


### PR DESCRIPTION
Fix for:
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2018-02-04/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2018-02-04/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2018-02-04/apps/frappe/frappe/handler.py", line 53, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2018-02-04/apps/frappe/frappe/__init__.py", line 939, in call
    return fn(*args, **newargs)
TypeError: get_party_account() takes exactly 3 arguments (2 given)
```