### PR TITLE
[Fix] Bug fix in customer_primary_address frappe call of Customer Form

### DIFF
--- a/erpnext/selling/doctype/customer/customer.js
+++ b/erpnext/selling/doctype/customer/customer.js
@@ -45,11 +45,10 @@ frappe.ui.form.on("Customer", {
 	customer_primary_address: function(frm){
 		if(frm.doc.customer_primary_address){
 			frappe.call({
-				doc: frm.doc,
-				args: {
-					"address_title": frm.doc.customer_primary_address
-				},
 				method: 'frappe.contacts.doctype.address.address.get_address_display',
+				args: {
+					"address_dict": frm.doc.customer_primary_address
+				},
 				callback: function(r) {
 					frm.set_value("primary_address", r.message);
 				}


### PR DESCRIPTION
**Issue:** In Customer Form, the Primary Address Title link field in _'Primary Address and Contact Detail'_  section throwed an error on selection of an option.

Bug:
![bug](https://user-images.githubusercontent.com/25682214/36113619-6668223a-1053-11e8-9009-7fe959cc2fa8.gif)

After fix:
![bugfixed](https://user-images.githubusercontent.com/25682214/36113633-730da776-1053-11e8-8660-d051cc2a85b3.gif)
