### PR TITLE
[Fix] Not able to select delivery note in delivery trip

### DIFF
--- a/erpnext/stock/doctype/delivery_trip/delivery_trip.py
+++ b/erpnext/stock/doctype/delivery_trip/delivery_trip.py
@@ -87,8 +87,7 @@ def get_contact_display(contact):
 def get_delivery_notes(customer):
 	return frappe.db.get_all("Delivery Note", filters={
 		'customer': customer,
-		'docstatus': 1,
-		'status': ('!=', 'Completed')
+		'docstatus': 1
 	})
 
 @frappe.whitelist()


### PR DESCRIPTION
User has created Sales Order > Sales Invoice > Delivery Note 
After when they are trying to make delivery trip against the delivery note getting following error
![image0012259f4](https://user-images.githubusercontent.com/8780500/36197962-5b01b372-119b-11e8-8453-068d446ca582.png)
