### PR TITLE
[Fix] Incorrect rate in item-wise sales register

### DIFF
--- a/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py
+++ b/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py
@@ -50,9 +50,11 @@ def _execute(filters=None, additional_table_columns=None, additional_query_colum
 		row += [
 			d.customer_group, d.debit_to, ", ".join(mode_of_payments.get(d.parent, [])),
 			d.territory, d.project, d.company, d.sales_order,
-			delivery_note, d.income_account, d.cost_center, d.stock_qty, d.stock_uom,
-			d.base_net_rate, d.base_net_amount
+			delivery_note, d.income_account, d.cost_center, d.stock_qty, d.stock_uom
 		]
+
+		row += [d.base_net_rate/d.stock_qty, d.base_net_amount] \
+			if d.stock_uom != d.uom else [d.base_net_rate, d.base_net_amount]
 
 		total_tax = 0
 		for tax in tax_columns:
@@ -131,7 +133,7 @@ def get_items(filters, additional_query_columns):
 			`tabSales Invoice Item`.stock_uom, `tabSales Invoice Item`.base_net_rate,
 			`tabSales Invoice Item`.base_net_amount, `tabSales Invoice`.customer_name,
 			`tabSales Invoice`.customer_group, `tabSales Invoice Item`.so_detail,
-			`tabSales Invoice`.update_stock {0}
+			`tabSales Invoice`.update_stock, `tabSales Invoice Item`.uom {0}
 		from `tabSales Invoice`, `tabSales Invoice Item`
 		where `tabSales Invoice`.name = `tabSales Invoice Item`.parent
 			and `tabSales Invoice`.docstatus = 1 %s %s


### PR DESCRIPTION
In item-wise sales register report rate is showing based on the UOM, not based on stock uom
**Issue**
![screen shot 2018-02-15 at 4 21 55 pm](https://user-images.githubusercontent.com/8780500/36253041-7500c87c-126c-11e8-9fe4-7790cb50e315.png)

**After fix**
![screen shot 2018-02-15 at 4 18 18 pm](https://user-images.githubusercontent.com/8780500/36253052-79560298-126c-11e8-8fbc-32df335b9175.png)

Fixed https://github.com/frappe/erpnext/issues/12551
