### PR TITLE
[Hot Fix] barcode_type auto set to a wrong value

### DIFF
--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -487,7 +487,8 @@ class Item(WebsiteGenerator):
 					if duplicate:
 						frappe.throw(_("Barcode {0} already used in Item {1}").format(
 							item_barcode.barcode, duplicate[0][0]))
-
+						
+					item_barcode.barcode_type = "" if item_barcode.barcode_type not in ["EAN", "UPC-A"] else item_barcode.barcode_type
 					if item_barcode.barcode_type:
 						if not ean.is_valid(item_barcode.barcode):
 							frappe.throw(_("Barcode {0} is not a valid {1} code").format(

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -487,7 +487,7 @@ class Item(WebsiteGenerator):
 					if duplicate:
 						frappe.throw(_("Barcode {0} already used in Item {1}").format(
 							item_barcode.barcode, duplicate[0][0]))
-						
+
 					item_barcode.barcode_type = "" if item_barcode.barcode_type not in ["EAN", "UPC-A"] else item_barcode.barcode_type
 					if item_barcode.barcode_type:
 						if not ean.is_valid(item_barcode.barcode):


### PR DESCRIPTION
This fix a problem that arise, for some weird reason that i can't figure out, when the barcode length == 8, 9,10 or 12,13 and barcode_type is not set; barcode_type become "ean8, ean9, ean10, ean11, ean12, ean13"