### PR TITLE
[BugFix] Wrong Calculation of Total Weight at Purchase Invoice item for Purchasing in Different Unit (UoM) #12965

### DIFF
--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -92,7 +92,7 @@ erpnext.taxes_and_totals = erpnext.payments.extend({
 				item.amount = flt(item.rate * item.qty, precision("amount", item));
 				item.net_amount = item.amount;
 				item.item_tax_amount = 0.0;
-				item.total_weight = flt(item.weight_per_unit * item.qty);
+				item.total_weight = flt(item.weight_per_unit * item.stock_qty);
 
 				me.set_in_company_currency(item, ["price_list_rate", "rate", "amount", "net_rate", "net_amount"]);
 			});


### PR DESCRIPTION
#12965

Total Weight is calculated as item.weight_per_unit * item.stock_qty
![purchaseinvoice total weight after](https://user-images.githubusercontent.com/3703266/36296162-ec1f4636-1311-11e8-8fb5-7f5211af4771.png)
