### PR TITLE
[Hotfix] Selecting create on blank field throws error

### DIFF
--- a/erpnext/stock/doctype/delivery_trip/delivery_trip.py
+++ b/erpnext/stock/doctype/delivery_trip/delivery_trip.py
@@ -163,9 +163,9 @@ def notify_customers(docname, date, driver, vehicle, sender_email, delivery_noti
 
 		if delivery_stop_info.delivery_notes:
 			delivery_notes = (delivery_stop_info.delivery_notes).split(",")
+			default_print_format = frappe.get_meta('Delivery Note').default_print_format
 			attachments = []
 			for delivery_note in delivery_notes:
-				default_print_format = frappe.get_value('Delivery Note', delivery_note, 'default_print_format')
 				attachments.append(
 					frappe.attach_print('Delivery Note',
 	 					 delivery_note,

--- a/erpnext/utilities/user_progress.py
+++ b/erpnext/utilities/user_progress.py
@@ -45,7 +45,7 @@ def get_slide_settings():
 			help=_("Set a sales goal you'd like to achieve for your company."),
 			fields=[
 				{"fieldtype":"Currency", "fieldname":"monthly_sales_target",
-					"label":_("Monthly Sales Target (" + currency + ")")},
+					"label":_("Monthly Sales Target (" + currency + ")"), "reqd":1},
 			],
 			submit_method="erpnext.utilities.user_progress_utils.set_sales_target",
 			done_state_title=_("Go to " + company),


### PR DESCRIPTION
In user progress on the Monthly Sales Target slide, if create is clicked without entering any data - Error thrown

In Delivery Trip if delivery_notes are selected in its child table, then error is thrown when it tries to fetch default_print_format.