### PR TITLE
modify sql query

### DIFF
--- a/erpnext/utilities/transaction_base.py
+++ b/erpnext/utilities/transaction_base.py
@@ -41,10 +41,12 @@ class TransactionBase(StatusUpdater):
 
 	def delete_events(self):
 		events = frappe.db.sql_list("""select name from `tabEvent`
-			where ref_type=%s and ref_name=%s""", (self.doctype, self.name))
+			where ref_type="{doctype}" and ref_name="{name}"
+			""".format(doctype = self.doctype, name = self.name))
+
 		if events:
-			frappe.db.sql("delete from `tabEvent` where name in (%s)"
-				.format(", ".join(['%s']*len(events))), tuple(events))
+			frappe.db.sql("""delete from `tabEvent` where name in ({list})
+				""".format(list = ", ".join(["'{name}'".format(name = name) for name in events])))
 
 	def _add_calendar_event(self, opts):
 		opts = frappe._dict(opts)


### PR DESCRIPTION
Getting this error in a cloud user's account. Not able to replicate the error locally.
This PR might fix it.

```
File "/home/frappe/benches/bench-2018-02-14/apps/erpnext/erpnext/utilities/transaction_base.py", line 47, in delete_events
    .format(", ".join(['%s']*len(events))), tuple(events))
  File "/home/frappe/benches/bench-2018-02-14/apps/frappe/frappe/database.py", line 166, in sql
    self._cursor.execute(query, values)
  File "/home/frappe/benches/bench-2018-02-14/env/lib/python2.7/site-packages/pymysql/cursors.py", line 163, in execute
    query = self.mogrify(query, args)
  File "/home/frappe/benches/bench-2018-02-14/env/lib/python2.7/site-packages/pymysql/cursors.py", line 142, in mogrify
    query = query % self._escape_args(args, conn)
TypeError: not all arguments converted during string formatting
```