### PR TITLE
[Fix] Sales order item delivery date

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -104,8 +104,8 @@ class SalesOrder(SellingController):
 	def validate_delivery_date(self):
 		if self.order_type == 'Sales':
 			if not self.delivery_date:
-				self.delivery_date = max([d.delivery_date for d in self.get("items") if d.delivery_date])
-
+				delivery_date_list = [d.delivery_date for d in self.get("items") if d.delivery_date]
+				self.delivery_date = max(delivery_date_list) if delivery_date_list else None
 			if self.delivery_date:
 				for d in self.get("items"):
 					if not d.delivery_date:


### PR DESCRIPTION
If delivery dates are not entered in any of the rows of child table, returns an empty list and hence getting this error in data import.
```
 File "/home/shreya/frappe-bench/apps/erpnext/erpnext/selling/doctype/sales_order/sales_order.py", line 33, in validate
    self.validate_delivery_date()
  File "/home/shreya/frappe-bench/apps/erpnext/erpnext/selling/doctype/sales_order/sales_order.py", line 107, in validate_delivery_date
    self.delivery_date = max([d.delivery_date for d in self.get("items") if d.delivery_date])
ValueError: max() arg is an empty sequence
```
Fix:
![delivery date item](https://user-images.githubusercontent.com/17617465/36583919-a33cf3d2-189d-11e8-8286-c5c8de5b42d8.png)
