### PR TITLE
[Hotfix] Wrong delete query for deleting Events

### DIFF
--- a/erpnext/utilities/transaction_base.py
+++ b/erpnext/utilities/transaction_base.py
@@ -43,7 +43,7 @@ class TransactionBase(StatusUpdater):
 		events = frappe.db.sql_list("""select name from `tabEvent`
 			where ref_type=%s and ref_name=%s""", (self.doctype, self.name))
 		if events:
-			frappe.db.sql("delete from `tabEvent` where name in (%s)"
+			frappe.db.sql("delete from `tabEvent` where name in ({0})"
 				.format(", ".join(['%s']*len(events))), tuple(events))
 
 	def _add_calendar_event(self, opts):


### PR DESCRIPTION
Issue:- 
![issue-events](https://user-images.githubusercontent.com/11695402/36729449-3752b620-1bea-11e8-82c7-dbcf15f0d985.gif)

If for 1 ref document multiple events are found, a delete query is executed to delete the multiple events by forming a tuple. The tuple is not replaced inside the query though.
