### PR TITLE
Add Ends-On field in the Lead doctype

### DIFF
--- a/erpnext/crm/doctype/lead/lead.js
+++ b/erpnext/crm/doctype/lead/lead.js
@@ -75,6 +75,14 @@ erpnext.LeadController = frappe.ui.form.Controller.extend({
 		if (this.frm.doc.organization_lead == 1) {
 			this.frm.set_value("lead_name", this.frm.doc.company_name);
 		}
+	},
+
+	contact_date: function() {
+		if (this.frm.doc.contact_date) {
+			let d = moment(this.frm.doc.contact_date);
+			d.add(1, "hours");
+			this.frm.set_value("ends_on", d.format(moment.defaultDatetimeFormat));
+		}
 	}
 });
 

--- a/erpnext/crm/doctype/lead/lead.json
+++ b/erpnext/crm/doctype/lead/lead.json
@@ -41,6 +41,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 1, 
+   "translatable": 0,
    "unique": 0
   }, 
   {
@@ -71,6 +72,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0,
    "unique": 0
   }, 
   {
@@ -103,6 +105,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 1, 
+   "translatable": 0,
    "unique": 0
   }, 
   {
@@ -135,6 +138,7 @@
    "reqd": 1, 
    "search_index": 1, 
    "set_only_once": 0, 
+   "translatable": 0,
    "unique": 0
   }, 
   {
@@ -166,6 +170,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0,
    "unique": 0
   }, 
   {
@@ -198,6 +203,7 @@
    "reqd": 0, 
    "search_index": 1, 
    "set_only_once": 0, 
+   "translatable": 0,
    "unique": 0
   }, 
   {
@@ -226,6 +232,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0,
    "unique": 0, 
    "width": "50%"
   }, 
@@ -260,6 +267,7 @@
    "reqd": 1, 
    "search_index": 1, 
    "set_only_once": 0, 
+   "translatable": 0,
    "unique": 0
   }, 
   {
@@ -291,6 +299,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0,
    "unique": 0
   }, 
   {
@@ -324,6 +333,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0,
    "unique": 0
   }, 
   {
@@ -357,6 +367,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0,
    "unique": 0
   }, 
   {
@@ -391,6 +402,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0,
    "unique": 0
   }, 
   {
@@ -421,6 +433,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0,
    "unique": 0
   }, 
   {
@@ -451,6 +464,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0,
    "unique": 0
   }, 
   {
@@ -484,8 +498,43 @@
    "reqd": 0, 
    "search_index": 1, 
    "set_only_once": 0, 
+   "translatable": 0,
    "unique": 0
   }, 
+  {
+   "allow_bulk_edit": 0,
+   "allow_on_submit": 0,
+   "bold": 0,
+   "collapsible": 0,
+   "columns": 0,
+   "fieldname": "contact_by",
+   "fieldtype": "Link",
+   "hidden": 0,
+   "ignore_user_permissions": 0,
+   "ignore_xss_filter": 0,
+   "in_filter": 0,
+   "in_global_search": 0,
+   "in_list_view": 0,
+   "in_standard_filter": 0,
+   "label": "Next Contact By",
+   "length": 0,
+   "no_copy": 0,
+   "oldfieldname": "contact_by",
+   "oldfieldtype": "Link",
+   "options": "User",
+   "permlevel": 0,
+   "print_hide": 0,
+   "print_hide_if_no_value": 0,
+   "read_only": 0,
+   "remember_last_selected_value": 0,
+   "report_hide": 0,
+   "reqd": 0,
+   "search_index": 0,
+   "set_only_once": 0,
+   "translatable": 0,
+   "unique": 0,
+   "width": "100px"
+  },
   {
    "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
@@ -513,6 +562,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0,
    "unique": 0
   }, 
   {
@@ -545,17 +595,18 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0,
    "unique": 0, 
    "width": "100px"
   }, 
   {
    "allow_bulk_edit": 0, 
    "allow_on_submit": 0, 
-   "bold": 0, 
+   "bold": 1,
    "collapsible": 0, 
    "columns": 0, 
-   "fieldname": "contact_by", 
-   "fieldtype": "Link", 
+   "fieldname": "ends_on",
+   "fieldtype": "Datetime",
    "hidden": 0, 
    "ignore_user_permissions": 0, 
    "ignore_xss_filter": 0, 
@@ -563,13 +614,11 @@
    "in_global_search": 0, 
    "in_list_view": 0, 
    "in_standard_filter": 0, 
-   "label": "Next Contact By", 
+   "label": "Ends On",
    "length": 0, 
-   "no_copy": 0, 
-   "oldfieldname": "contact_by", 
-   "oldfieldtype": "Link", 
-   "options": "User", 
+   "no_copy": 1,
    "permlevel": 0, 
+   "precision": "",
    "print_hide": 0, 
    "print_hide_if_no_value": 0, 
    "read_only": 0, 
@@ -578,8 +627,8 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
-   "unique": 0, 
-   "width": "100px"
+   "translatable": 0,
+   "unique": 0
   }, 
   {
    "allow_bulk_edit": 0, 
@@ -610,6 +659,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0,
    "unique": 0
   }, 
   {
@@ -640,6 +690,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0,
    "unique": 0
   }, 
   {
@@ -669,6 +720,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0,
    "unique": 0
   }, 
   {
@@ -697,6 +749,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0,
    "unique": 0
   }, 
   {
@@ -728,6 +781,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0,
    "unique": 0
   }, 
   {
@@ -760,6 +814,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0,
    "unique": 0
   }, 
   {
@@ -792,6 +847,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0,
    "unique": 0
   }, 
   {
@@ -824,6 +880,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0,
    "unique": 0
   }, 
   {
@@ -856,6 +913,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0,
    "unique": 0
   }, 
   {
@@ -887,6 +945,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0,
    "unique": 0
   }, 
   {
@@ -920,6 +979,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0,
    "unique": 0
   }, 
   {
@@ -951,6 +1011,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0,
    "unique": 0
   }, 
   {
@@ -983,6 +1044,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0,
    "unique": 0
   }, 
   {
@@ -1015,6 +1077,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0,
    "unique": 0
   }, 
   {
@@ -1047,6 +1110,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0,
    "unique": 0
   }, 
   {
@@ -1079,6 +1143,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0,
    "unique": 0
   }, 
   {
@@ -1108,6 +1173,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0,
    "unique": 0, 
    "width": "50%"
   }, 
@@ -1141,6 +1207,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0,
    "unique": 0
   }, 
   {
@@ -1170,6 +1237,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0,
    "unique": 0
   }, 
   {
@@ -1199,6 +1267,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0,
    "unique": 0
   }
  ], 
@@ -1214,7 +1283,7 @@
  "issingle": 0, 
  "istable": 0, 
  "max_attachments": 0, 
- "modified": "2017-11-24 11:10:56.485917", 
+ "modified": "2018-03-02 05:25:11.675481",
  "modified_by": "Administrator", 
  "module": "CRM", 
  "name": "Lead", 

--- a/erpnext/crm/doctype/lead/lead.py
+++ b/erpnext/crm/doctype/lead/lead.py
@@ -27,6 +27,8 @@ class Lead(SellingController):
 		self._prev = frappe._dict({
 			"contact_date": frappe.db.get_value("Lead", self.name, "contact_date") if \
 				(not cint(self.get("__islocal"))) else None,
+			"ends_on": frappe.db.get_value("Lead", self.name, "ends_on") if \
+				(not cint(self.get("__islocal"))) else None,
 			"contact_by": frappe.db.get_value("Lead", self.name, "contact_by") if \
 				(not cint(self.get("__islocal"))) else None,
 		})
@@ -50,6 +52,10 @@ class Lead(SellingController):
 		if self.contact_date and getdate(self.contact_date) < getdate(nowdate()):
 			frappe.throw(_("Next Contact Date cannot be in the past"))
 
+		if self.ends_on and self.contact_date and\
+			(self.ends_on < self.contact_date):
+			frappe.throw(_("Ends On date cannot be before Next Contact Date."))
+
 	def on_update(self):
 		self.add_calendar_event()
 
@@ -57,6 +63,7 @@ class Lead(SellingController):
 		super(Lead, self).add_calendar_event({
 			"owner": self.lead_owner,
 			"starts_on": self.contact_date,
+			"ends_on": self.ends_on or "",
 			"subject": ('Contact ' + cstr(self.lead_name)),
 			"description": ('Contact ' + cstr(self.lead_name)) + \
 				(self.contact_by and ('. By : ' + cstr(self.contact_by)) or '')

--- a/erpnext/utilities/transaction_base.py
+++ b/erpnext/utilities/transaction_base.py
@@ -36,7 +36,8 @@ class TransactionBase(StatusUpdater):
 
 	def add_calendar_event(self, opts, force=False):
 		if cstr(self.contact_by) != cstr(self._prev.contact_by) or \
-				cstr(self.contact_date) != cstr(self._prev.contact_date) or force:
+				cstr(self.contact_date) != cstr(self._prev.contact_date) or force or \
+				(hasattr(self, "ends_on") and cstr(self.ends_on) != cstr(self._prev.ends_on)):
 
 			self.delete_events()
 			self._add_calendar_event(opts)
@@ -58,6 +59,7 @@ class TransactionBase(StatusUpdater):
 				"subject": opts.subject,
 				"description": opts.description,
 				"starts_on":  self.contact_date,
+				"ends_on": opts.ends_on,
 				"event_type": "Private",
 				"ref_type": self.doctype,
 				"ref_name": self.name


### PR DESCRIPTION
![lead-enhance](https://user-images.githubusercontent.com/11695402/36896237-ddbb91c2-1e37-11e8-9044-e8a798cf6fdf.gif)

Earlier if a contact_date was set for Lead, an event was added in the calendar. The ends_on date of the event added had to be manually changed by going to the Event doc created for the Lead.
If the contact_date was changed from the Lead, the events linked with it were all deleted and new event would be created. Which means manually going to the Event doc and changing the ends_on for the event.

Now - ends_on can directly be set from Lead itself and will be mapped with the event.