### PR TITLE
[Fix] Wrong salary slips showing when click on view salary slips from payroll entry

### DIFF
--- a/erpnext/hr/doctype/payroll_entry/payroll_entry.js
+++ b/erpnext/hr/doctype/payroll_entry/payroll_entry.js
@@ -5,7 +5,10 @@ var in_progress = false;
 
 frappe.ui.form.on('Payroll Entry', {
 	onload: function (frm) {
-		frm.doc.posting_date = frappe.datetime.nowdate();
+		if (!frm.doc.posting_date) {
+			frm.doc.posting_date = frappe.datetime.nowdate();
+		}
+
 		frm.toggle_reqd(['payroll_frequency'], !frm.doc.salary_slip_based_on_timesheet);
 	},
 

--- a/erpnext/hr/doctype/payroll_entry/payroll_entry.py
+++ b/erpnext/hr/doctype/payroll_entry/payroll_entry.py
@@ -175,7 +175,7 @@ class PayrollEntry(Document):
 			Get loan details from submitted salary slip based on selected criteria
 		"""
 		cond = self.get_filter_condition()
-		return frappe.db.sql(""" select eld.employee_loan_account,
+		return frappe.db.sql(""" select eld.employee_loan_account, eld.employee_loan,
 				eld.interest_income_account, eld.principal_amount, eld.interest_amount, eld.total_payment
 			from
 				`tabSalary Slip` t1, `tabSalary Slip Loan` eld
@@ -283,7 +283,12 @@ class PayrollEntry(Document):
 						"account": data.employee_loan_account,
 						"credit_in_account_currency": data.principal_amount
 					})
-				accounts.append({
+
+				if data.interest_amount and not data.interest_income_account:
+					frappe.throw(_("Select interest income account in employee loan {0}").format(data.employee_loan))
+
+				if data.interest_income_account and data.interest_amount:
+					accounts.append({
 						"account": data.interest_income_account,
 						"credit_in_account_currency": data.interest_amount,
 						"cost_center": self.cost_center,


### PR DESCRIPTION
- Posting date showing as today's date even if payroll entry created on 15-02-2018
![posting_date_issue](https://user-images.githubusercontent.com/8780500/36947882-fefe471e-1ff7-11e8-8d7f-a29d38b0ac89.gif)

- Allow to submit salary slips if no interest amount and interest account is not set in employee loan.

