### PR TITLE
[Fix] System only shows 20 attribute values while making variants

### DIFF
--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -426,7 +426,9 @@ $.extend(erpnext.item, {
 						filters: [
 							["parent","=", attribute]
 						],
-						fields: ["attribute_value"]
+						fields: ["attribute_value"],
+						limit_start: 0,
+						limit_page_length: 500
 					}
 				}).then((r) => {
 					if(r.message) {


### PR DESCRIPTION
**Issue**
User has set 238 attribute values for attribute Colour, while making multiple variants system only showing 20 values.

![screen shot 2018-03-04 at 2 23 08 pm](https://user-images.githubusercontent.com/8780500/36943902-9987fb72-1fb7-11e8-9482-085ef3de0fa8.png)
