### PR TITLE
Patches fixes

### DIFF
--- a/erpnext/patches/v10_0/set_auto_created_serial_no_in_stock_entry.py
+++ b/erpnext/patches/v10_0/set_auto_created_serial_no_in_stock_entry.py
@@ -7,6 +7,9 @@ import frappe
 def execute():
 	serialised_items = [d.name for d in frappe.get_all("Item", filters={"has_serial_no": 1})]
 
+	if not serialised_items:
+		return
+
 	for dt in ["Stock Entry Detail", "Purchase Receipt Item", "Purchase Invoice Item"]:
 		cond = ""
 		if dt=="Purchase Invoice Item":

--- a/erpnext/patches/v10_0/update_territory_and_customer_group.py
+++ b/erpnext/patches/v10_0/update_territory_and_customer_group.py
@@ -13,22 +13,17 @@ def execute():
 		for d in customer_group_fetch:
 			when_then = []
 			for customer in batch_customers:
+				value = frappe.db.escape(frappe.as_unicode(customer.get("customer_group")))
+
 				when_then.append('''
-					WHEN `{master_fieldname}` = "{docname}" and {linked_to_fieldname} != "{value}"
-					THEN "{value}"
-				'''.format(
-					master_fieldname=d["master_fieldname"],
-					linked_to_fieldname=d["linked_to_fieldname"],
-					docname=frappe.db.escape(frappe.as_unicode(customer.name)),
-					value=frappe.db.escape(frappe.as_unicode(customer.get("customer_group")))))
+					WHEN `%s` = "%s" and %s != "%s"
+					THEN "%s"
+				'''%(d["master_fieldname"], frappe.db.escape(frappe.as_unicode(customer.name)),
+					d["linked_to_fieldname"], value, value))
 
 			frappe.db.sql("""
 				update
-					`tab{doctype}`
+					`tab%s`
 				set
-					{linked_to_fieldname} = CASE {when_then_cond}  ELSE `{linked_to_fieldname}` END
-			""".format(
-				doctype = d['doctype'],
-				when_then_cond=" ".join(when_then),
-				linked_to_fieldname=d.linked_to_fieldname
-			))
+					%s = CASE %s  ELSE `%s` END
+			"""%(d['doctype'], d.linked_to_fieldname, " ".join(when_then), d.linked_to_fieldname))


### PR DESCRIPTION
- set_auto_created_serial_no_in_stock_entry.py
```
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/apps/frappe/frappe/utils/bench_helper.py", line 94, in <module>
    main()
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/env/lib/python2.7/site-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/env/lib/python2.7/site-packages/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/env/lib/python2.7/site-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/env/lib/python2.7/site-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/env/lib/python2.7/site-packages/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/env/lib/python2.7/site-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/env/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/apps/frappe/frappe/commands/__init__.py", line 24, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/apps/frappe/frappe/commands/site.py", line 222, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website)
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/apps/frappe/frappe/migrate.py", line 31, in migrate
    frappe.modules.patch_handler.run_all()
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/apps/frappe/frappe/modules/patch_handler.py", line 29, in run_all
    if not run_single(patchmodule = patch):
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/apps/frappe/frappe/modules/patch_handler.py", line 63, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/apps/frappe/frappe/modules/patch_handler.py", line 83, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/apps/erpnext/erpnext/patches/v10_0/set_auto_created_serial_no_in_stock_entry.py", line 24, in execute
    """.format(dt, ', '.join(['%s']*len(serialised_items)), cond), tuple(serialised_items), debug=1)
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/apps/frappe/frappe/database.py", line 176, in sql
    self._cursor.execute(query)
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/env/lib/python2.7/site-packages/pymysql/cursors.py", line 165, in execute
    result = self._query(query)
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/env/lib/python2.7/site-packages/pymysql/cursors.py", line 321, in _query
    conn.query(q)
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 860, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1061, in _read_query_result
    result.read()
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1349, in read
    first_packet = self.connection._read_packet()
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1018, in _read_packet
    packet.check_error()
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 384, in check_error
    err.raise_mysql_exception(self._data)
  File "/Users/saurabh/Documents/hotfix_bench/hotfix-bench/env/lib/python2.7/site-packages/pymysql/err.py", line 107, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.ProgrammingError: (1064, u"You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ')' at line 6")

```

-----
- update_territory_and_customer_group.py
Unicode encoding fix
