### PR TITLE
[Fixes] Chapter DocType

### DIFF
--- a/erpnext/non_profit/doctype/chapter/templates/chapter.html
+++ b/erpnext/non_profit/doctype/chapter/templates/chapter.html
@@ -46,17 +46,18 @@
 
 <h3>Chapter Head</h3>
 <table class="table table-bordered small" style="max-width: 500px;">
+	{% set doc = frappe.get_doc('Member',chapter_head) %}
 	<tr>
 		<td style='width: 15%'>Name</td>
-		<td>{{ frappe.db.get_value('User', chapter_head, 'full_name') }}</td>
+		<td>{{ doc.member_name }}</td>
 	</tr>
 	<tr>
 		<td>Email</td>
-		<td>{{ frappe.db.get_value('User', chapter_head, 'email') or '' }}</td>
+		<td>{{ frappe.db.get_value('User', doc.email, 'email') or '' }}</td>
 	</tr>
 	<tr>
 		<td>Phone</td>
-		<td>{{ frappe.db.get_value('User', chapter_head, 'phone') or '' }}</td>
+		<td>{{ frappe.db.get_value('User', doc.email, 'phone') or '' }}</td>
 	</tr>
 </table>
 <h3>Address</h3>

--- a/erpnext/non_profit/doctype/chapter_member/chapter_member.json
+++ b/erpnext/non_profit/doctype/chapter_member/chapter_member.json
@@ -41,6 +41,7 @@
    "reqd": 1, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0, 
    "unique": 0
   }, 
   {
@@ -71,6 +72,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0, 
    "unique": 0
   }, 
   {
@@ -101,6 +103,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0, 
    "unique": 0
   }, 
   {
@@ -108,7 +111,8 @@
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
-   "columns": 0, 
+   "columns": 2, 
+   "default": "1", 
    "fieldname": "enabled", 
    "fieldtype": "Check", 
    "hidden": 0, 
@@ -116,7 +120,7 @@
    "ignore_xss_filter": 0, 
    "in_filter": 0, 
    "in_global_search": 0, 
-   "in_list_view": 0, 
+   "in_list_view": 1, 
    "in_standard_filter": 0, 
    "label": "Enabled", 
    "length": 0, 
@@ -131,6 +135,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0, 
    "unique": 0
   }, 
   {
@@ -161,6 +166,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0, 
    "unique": 0
   }
  ], 
@@ -174,7 +180,7 @@
  "issingle": 0, 
  "istable": 1, 
  "max_attachments": 0, 
- "modified": "2018-01-12 12:16:10.591039", 
+ "modified": "2018-03-07 05:36:51.664816", 
  "modified_by": "Administrator", 
  "module": "Non Profit", 
  "name": "Chapter Member", 


### PR DESCRIPTION
Fixes: #13188 

- Members were not visible in web view because only the enabled users are fetched and the field `enabled` in the Chapter Member child table was not in grid view and default = 1 wasn't set.
- Also, the name of chapter head is fetched from User DocType, which is not correct, as the member's name is set using naming_series which previously was done using email, so fixed that.

<img width="576" alt="screen shot 2018-03-07 at 4 13 07 pm" src="https://user-images.githubusercontent.com/17617465/37088218-a2a2ab04-2222-11e8-948e-0f348ad5947d.png">
