### PR TITLE
corrected setup wizard tax rates for Switzerland 2018 (#13220)

### DIFF
--- a/erpnext/setup/setup_wizard/data/country_wise_tax.json
+++ b/erpnext/setup/setup_wizard/data/country_wise_tax.json
@@ -1230,14 +1230,18 @@
 	},
 
 	"Switzerland": {
-		"Switzerland VAT 8%": {
-			"account_name": "VAT 8%",
-			"tax_rate": 8.00,
+		"Switzerland normal VAT": {
+			"account_name": "VAT 7.7%",
+			"tax_rate": 7.70,
 			"default": 1
 		},
-		"Switzerland VAT 2.4%": {
-			"account_name": "VAT 2.4%",
-			"tax_rate": 2.40
+		"Switzerland reduced VAT": {
+			"account_name": "VAT 2.5%",
+			"tax_rate": 2.50
+		},
+		"Switzerland lodging VAT": {
+			"account_name": "VAT 3.7%",
+			"tax_rate": 3.70
 		}
 	},
 


### PR DESCRIPTION
This is a correction to the setup wizard for the correct taxes valid as of 1st of January 2018. Details, see #13220 

Also, the % sign in the name sometimes leads to issues (e.g. when trying to rename, there is an error resource not found), therefore clear names without % signs used.

This will require an update of the DE/FR/IT language file, which should be implemented through https://translate.erpnext.com/