### PR TITLE
allow assets to cancel even if it is linked with PI

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -163,9 +163,6 @@ class Asset(Document):
 		if self.status not in ("Submitted", "Partially Depreciated", "Fully Depreciated"):
 			frappe.throw(_("Asset cannot be cancelled, as it is already {0}").format(self.status))
 
-		if self.purchase_invoice:
-			frappe.throw(_("Please cancel Purchase Invoice {0} first").format(self.purchase_invoice))
-
 	def delete_depreciation_entries(self):
 		for d in self.get("schedules"):
 			if d.journal_entry:


### PR DESCRIPTION
If the Asset is created against the Purchase Invoice, then it creates a cyclic validation and then Asset or Purchase Invoice can't be cancelled.