### PR TITLE
[Fix]  Set default price list in Sales Invoice, if not found

### DIFF
--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -141,7 +141,10 @@ def set_price_list(out, party, party_type, given_price_list):
 		price_list = get_default_price_list(party)
 
 	if not price_list:
-		price_list = given_price_list
+		if party.doctype == "Customer":
+			price_list = frappe.db.get_single_value('Selling Settings', 'selling_price_list')
+		else:
+			price_list = frappe.db.get_single_value('Buying Settings', 'buying_price_list')
 
 	if price_list:
 		out.price_list_currency = frappe.db.get_value("Price List", price_list, "currency")


### PR DESCRIPTION
Fixes: #13253 

Issue: Currency and Price list are fetched in Sales Invoice on Customer trigger if found in the Customer master, but on changing the customer, it triggers and sets the same previous price list if not found in customer master, instead of default price list.

Similar case in Purchase Invoice on Supplier trigger.