### PR TITLE
[Hotfix] Naming Series dropdown & Validation

### DIFF
--- a/erpnext/setup/doctype/naming_series/naming_series.py
+++ b/erpnext/setup/doctype/naming_series/naming_series.py
@@ -20,7 +20,7 @@ class NamingSeries(Document):
 			+ frappe.db.sql_list("""select dt from `tabCustom Field`
 				where fieldname='naming_series'""")))
 
-		doctypes = list(set(get_doctypes_with_read()) | set(doctypes))
+		doctypes = list(set(get_doctypes_with_read()).intersection(set(doctypes)))
 		prefixes = ""
 		for d in doctypes:
 			options = ""
@@ -47,6 +47,7 @@ class NamingSeries(Document):
 
 	def update_series(self, arg=None):
 		"""update series list"""
+		self.validate_series_set()
 		self.check_duplicate()
 		series_list = self.set_options.split("\n")
 
@@ -59,6 +60,10 @@ class NamingSeries(Document):
 		msgprint(_("Series Updated"))
 
 		return self.get_transactions()
+
+	def validate_series_set(self):
+		if self.select_doc_for_series and not self.set_options:
+			frappe.throw(_("Please set the series to be used."))
 
 	def set_series_for(self, doctype, ol):
 		options = self.scrub_options_list(ol)


### PR DESCRIPTION
Issue:- 
![naming-series-issue](https://user-images.githubusercontent.com/11695402/37449631-fce22d54-2850-11e8-9e78-b4a7a5a0d7de.gif)

Fix:-
![naming-series-fix](https://user-images.githubusercontent.com/11695402/37449434-31cd8172-2850-11e8-9f61-15f7be1a3513.gif)

Set validation for series - Empty is not valid.
Dropdown used to show all those doctypes for which the user had permission instead of the intersection of permission enabled doctype and doctypes that have naming series.

