### PR TITLE
[hotfix] Autonaming of stock item.

### DIFF
--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -58,8 +58,7 @@ class Item(WebsiteGenerator):
 		elif not self.item_code:
 			msgprint(_("Item Code is mandatory because Item is not automatically numbered"), raise_exception=1)
 
-		self.item_code = strip(self.item_code)
-		self.name = self.item_code
+		self.item_code = self.name
 
 	def before_insert(self):
 		if not self.description:


### PR DESCRIPTION
This fixes a bug introduced in commit f2d28ebd6a8bd7a6d94e36128378797a739c0fc9.

The Item would not get an item code on saving and an error would show saying "Item Code is required."