### PR TITLE
Copy source project into Purchase Order Item

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -708,6 +708,7 @@ def make_purchase_order_for_drop_shipment(source_name, for_supplier, target_doc=
 		target.schedule_date = source.delivery_date
 		target.qty = flt(source.qty) - flt(source.ordered_qty)
 		target.stock_qty = (flt(source.qty) - flt(source.ordered_qty)) * flt(source.conversion_factor)
+		target.project = source_parent.project
 
 	doclist = get_mapped_doc("Sales Order", source_name, {
 		"Sales Order": {


### PR DESCRIPTION
When using "Make -> Purchase Order" from a drop shipped Sales Order, if the Sales Order has part of a Project, then copy that into the Purchase Order Item doctype. 

![screen shot 2018-03-18 at 10 15 50 am](https://user-images.githubusercontent.com/340768/37560916-677cc264-2a95-11e8-914a-6978f9a21639.png)

An incredibly simple addition, but very powerful if you need it. 