### PR TITLE
[Fix] Travis

### DIFF
--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -330,7 +330,7 @@ class SellingController(StockController):
 		self.make_sl_entries(sl_entries)
 
 	def set_po_nos(self):
-		if self.doctype in ("Delivery Note", "Sales Invoice"):
+		if self.doctype in ("Delivery Note", "Sales Invoice") and hasattr(self, "items"):
 			ref_fieldname = "against_sales_order" if self.doctype == "Delivery Note" else "sales_order"
 			sales_orders = list(set([d.get(ref_fieldname) for d in self.items if d.get(ref_fieldname)]))
 			if sales_orders:


### PR DESCRIPTION
```
======================================================================
ERROR: test_make_sales_invoice_with_terms (erpnext.selling.doctype.sales_order.test_sales_order.TestSalesOrder)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/frappe-bench/apps/erpnext/erpnext/selling/doctype/sales_order/test_sales_order.py", line 86, in test_make_sales_invoice_with_terms
    si1 = make_sales_invoice(so.name)
  File "/home/travis/frappe-bench/apps/erpnext/erpnext/selling/doctype/sales_order/sales_order.py", line 590, in make_sales_invoice
    }, target_doc, postprocess, ignore_permissions=ignore_permissions)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/mapper.py", line 110, in get_mapped_doc
    postprocess(source_doc, target_doc)
  File "/home/travis/frappe-bench/apps/erpnext/erpnext/selling/doctype/sales_order/sales_order.py", line 534, in postprocess
    set_missing_values(source, target)
  File "/home/travis/frappe-bench/apps/erpnext/erpnext/selling/doctype/sales_order/sales_order.py", line 543, in set_missing_values
    target.run_method("set_po_nos")
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 755, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 1029, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 1012, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 749, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/travis/frappe-bench/apps/erpnext/erpnext/controllers/selling_controller.py", line 336, in set_po_nos
    sales_orders = list(set([d.get(ref_fieldname) for d in self.items]))
AttributeError: 'SalesInvoice' object has no attribute 'items'
```