### PR TITLE
Permisssion fixes for child table

### DIFF
--- a/erpnext/public/js/utils/item_quick_entry.js
+++ b/erpnext/public/js/utils/item_quick_entry.js
@@ -319,7 +319,8 @@ frappe.ui.form.ItemQuickEntryForm = frappe.ui.form.QuickEntryForm.extend({
 						["parent", "=", $(e.target).attr("data-fieldname")],
 						["attribute_value", "like", e.target.value + "%"]
 					],
-					fields: ["attribute_value"]
+					fields: ["attribute_value"],
+					parent: "Item"
 				},
 				callback: function(r) {
 					if (r.message) {

--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -457,7 +457,8 @@ $.extend(erpnext.item, {
 						],
 						fields: ["attribute_value"],
 						limit_start: 0,
-						limit_page_length: 500
+						limit_page_length: 500,
+						parent: "Item"
 					}
 				}).then((r) => {
 					if(r.message) {
@@ -577,7 +578,8 @@ $.extend(erpnext.item, {
 								["parent","=", i],
 								["attribute_value", "like", term + "%"]
 							],
-							fields: ["attribute_value"]
+							fields: ["attribute_value"],
+							parent: "Item"
 						},
 						callback: function(r) {
 							if (r.message) {


### PR DESCRIPTION
Related to commit 595929eb2432140a27dc262d4d78aca4ec5455c3
frappe.client.[get_list, get, get_value] when called on child table
needs parent as an argument or it throws an error by default