### PR TITLE
[Bug] Exclude current doc while validating in salary component

### DIFF
--- a/erpnext/hr/doctype/salary_component/salary_component.py
+++ b/erpnext/hr/doctype/salary_component/salary_component.py
@@ -17,6 +17,5 @@ class SalaryComponent(Document):
 				self.salary_component.split()]).upper()
 
 		self.salary_component_abbr = self.salary_component_abbr.strip()
-
-		self.salary_component_abbr = append_number_if_name_exists('Salary Component',
-			self.salary_component_abbr, 'salary_component_abbr', separator='_')
+		self.salary_component_abbr = append_number_if_name_exists('Salary Component', self.salary_component_abbr,
+			'salary_component_abbr', separator='_', filters={"name": ["!=", self.name]})


### PR DESCRIPTION
Fixes: #13436 
Issue:
![salary-abbr-issue](https://user-images.githubusercontent.com/17617465/38132790-397fb3be-342a-11e8-82d0-2e5fa04e6986.gif)

After fix: 
![salary-abbr-fix](https://user-images.githubusercontent.com/17617465/38132624-63f556e0-3429-11e8-8a6a-f0ce1763c487.gif)

Depends on: https://github.com/frappe/frappe/pull/5323