### PR TITLE
[Fix] chart of accounts, root type is mandatory issue in charts.erpnext.com

### DIFF
--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -252,16 +252,11 @@ def add_ac(args=None):
 	if not ac.parent_account:
 		ac.parent_account = args.get("parent")
 
-	if getattr(ac, 'is_root', None):
-		ac.parent_account=''
-
 	ac.old_parent = ""
 	ac.freeze_account = "No"
 	if cint(ac.get("is_root")):
 		ac.parent_account = None
 		ac.flags.ignore_mandatory = True
-	else:
-		ac.root_type = None
 
 	ac.insert()
 


### PR DESCRIPTION
**Issue**
![before_fix_coa](https://user-images.githubusercontent.com/8780500/38170736-5afd188e-35aa-11e8-9aca-5db3d002f7a4.gif)

**After Fix**
![after_fix_coa](https://user-images.githubusercontent.com/8780500/38170738-60a69d78-35aa-11e8-83dc-6a2aac61c321.gif)


Fixed https://github.com/frappe/erpnext/issues/13126