### PR TITLE
[ Minor ] Translate while creating items from user progress

### DIFF
--- a/erpnext/utilities/user_progress_utils.py
+++ b/erpnext/utilities/user_progress_utils.py
@@ -108,7 +108,7 @@ def create_items(args_data):
 					"is_sales_item": 1,
 					"is_purchase_item": 1,
 					"is_stock_item": 1,
-					"item_group": "Products",
+					"item_group": _("Products"),
 					"stock_uom": _(args.get("item_uom_" + str(i))),
 					"default_warehouse": default_warehouse
 				}).insert()


### PR DESCRIPTION
Issue:- https://github.com/frappe/erpnext/issues/13306

Fixtures created Item Group in translated way while user progress was trying to create an item using english name of the Item Group instead of translated one.