### PR TITLE
syntax fix

### DIFF
--- a/erpnext/regional/india/setup.py
+++ b/erpnext/regional/india/setup.py
@@ -184,7 +184,7 @@ def make_custom_fields():
 		'Employee': [
 			dict(fieldname='ifsc_code', label='IFSC Code',
 				fieldtype='Data', insert_after='bank_ac_no', print_hide=1, 
-				depends_on='eval:doc.salary_mode == 'Bank'') ]
+				depends_on='eval:doc.salary_mode == "Bank"') ]
 	}
 
 	create_custom_fields(custom_fields)


### PR DESCRIPTION
```
Migrating tcentral.erpnext
Executing frappe.patches.v11_0.drop_column_apply_user_permissions in tcentral.erpnext (6233af8a75c8eca1)
Success
Updating DocTypes for frappe        : [========================================]
Updating DocTypes for erpnext_com   : [========================================]
Updating DocTypes for central       : [========================================]
Compiling ../apps/erpnext/erpnext/regional/india/setup.py ...
  File "../apps/erpnext/erpnext/regional/india/setup.py", line 187
    depends_on='eval:doc.salary_mode == 'Bank'') ]
                                            ^
SyntaxError: invalid syntax
```