### PR TITLE
[Fix] Patch

### DIFF
--- a/erpnext/patches/v9_2/rename_translated_domains_in_en.py
+++ b/erpnext/patches/v9_2/rename_translated_domains_in_en.py
@@ -2,6 +2,7 @@ import frappe
 from frappe import _
 
 def execute():
+	frappe.reload_doc('stock', 'doctype', 'item')
 	language = frappe.get_single("System Settings").language
 
 	if language and language.startswith('en'): return


### PR DESCRIPTION
**Issue**
```
Executing erpnext.patches.v9_2.rename_translated_domains_in_en in site1.local (1bd3e0294da19198)
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 94, in <module>
    main()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 24, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/site.py", line 222, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py", line 31, in migrate
    frappe.modules.patch_handler.run_all()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 29, in run_all
    if not run_single(patchmodule = patch):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 63, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 83, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/patches/v9_2/rename_translated_domains_in_en.py", line 29, in execute
    domain.setup_domain()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/domain/domain.py", line 33, in setup_domain
    frappe.get_attr(self.data.on_setup)()
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/healthcare/setup.py", line 17, in setup_healthcare
    create_lab_test_items()
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/healthcare/setup.py", line 205, in create_lab_test_items
    insert_record(records)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/setup/utils.py", line 130, in insert_record
    doc.insert(ignore_permissions=True)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 218, in insert
    self.run_before_save_methods()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 859, in run_before_save_methods
    self.run_method("validate")
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 755, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1024, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1007, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 749, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/stock/doctype/item/item.py", line 100, in validate
    self.validate_retain_sample()
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/stock/doctype/item/item.py", line 261, in validate_retain_sample
    if self.retain_sample and not frappe.db.get_single_value('Stock Settings', 'sample_retention_warehouse'):
AttributeError: 'Item' object has no attribute 'retain_sample'
```

Fixed https://github.com/frappe/erpnext/issues/13102