### PR TITLE
[fix] enqueue salary slip print email after completing accounting entries

### DIFF
--- a/erpnext/hr/doctype/salary_slip/salary_slip.py
+++ b/erpnext/hr/doctype/salary_slip/salary_slip.py
@@ -411,7 +411,7 @@ class SalarySlip(TransactionBase):
 		else:
 			self.set_status()
 			self.update_status(self.name)
-			if(frappe.db.get_single_value("HR Settings", "email_salary_slip_to_employee")):
+			if(frappe.db.get_single_value("HR Settings", "email_salary_slip_to_employee")) and not frappe.flags.via_payroll_entry:
 				self.email_salary_slip()
 
 	def on_cancel(self):


### PR DESCRIPTION
If an exception takes place while processing the accrual JV entries, then the system rollback the transactions. 

On rollback, salary slip's status gets changed to Draft but as the print jobs are already enqueued the system won't rollback the email queue.

Thus added a flag `via_payroll_entry` to skip the print job enqueuing at salary slip submission. 
After accrual JV entry is completed then enqueuing the print job.