### PR TITLE
Embedded social login keys set up videos

### DIFF
--- a/erpnext/docs/user/manual/en/website/setup/social-login-keys.md
+++ b/erpnext/docs/user/manual/en/website/setup/social-login-keys.md
@@ -6,9 +6,26 @@ Social Login enables users to login to ERPNext via their Google, Facebook or Git
 
 Checkout the following Video Tutorials to understand how to enable social logins on ERPNext
 
-* for FaceBook - https://www.youtube.com/watch?v=zC6Q6gIfiw8
-* for Google - https://www.youtube.com/watch?v=w_EAttrE9sw 
-* for GitHub - https://www.youtube.com/watch?v=bG71DxxkVjQ
+* for FaceBook: 
+
+<div class="embed-container">
+    <iframe src="https://www.youtube.com/embed/zC6Q6gIfiw8?rel=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
+    </iframe>
+</div>
+
+* for Google:  
+
+<div class="embed-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/w_EAttrE9sw?rel=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
+    </iframe>
+</div>
+
+* for GitHub:  
+
+<div class="embed-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/bG71DxxkVjQ?rel=0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen>
+    </iframe>
+</div>
 
 For Google the *Authorized redirect URI* is [yoursite]/api/method/frappe.www.login.login_via_google
 


### PR DESCRIPTION
Updated the docs with the videos embedded. Earlier there were just links to the videos.