### PR TITLE
[py3] Cast dict_keys to list

### DIFF
--- a/erpnext/regional/report/gstr_1/gstr_1.py
+++ b/erpnext/regional/report/gstr_1/gstr_1.py
@@ -155,7 +155,7 @@ class Gstr1Report(object):
 				and parent in (%s)
 			order by account_head
 		""" % (self.tax_doctype, '%s', ', '.join(['%s']*len(self.invoices.keys()))),
-			tuple([self.doctype] + self.invoices.keys()))
+			tuple([self.doctype] + list(self.invoices.keys())))
 
 		self.items_based_on_tax_rate = {}
 		self.invoice_cess = frappe._dict()


### PR DESCRIPTION
```sh
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.handler.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 53, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 942, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 96, in run
    res = frappe.get_attr(method_name)(frappe._dict(filters))
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/regional/report/gstr_1/gstr_1.py", line 11, in execute
    return Gstr1Report(filters).run()
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/regional/report/gstr_1/gstr_1.py", line 49, in run
    self.get_items_based_on_tax_rate()
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/regional/report/gstr_1/gstr_1.py", line 158, in get_items_based_on_tax_rate
    tuple([self.doctype] + self.invoices.keys()))
TypeError: can only concatenate list (not "dict_keys") to list
```