### PR TITLE
removed duplicate keys

### DIFF
--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -25,8 +25,6 @@ def execute(filters=None):
 			"buying_rate", "base_amount", "buying_amount", "gross_profit", "gross_profit_percent"],
 		"warehouse": ["warehouse", "qty", "base_rate", "buying_rate", "base_amount", "buying_amount",
 			"gross_profit", "gross_profit_percent"],
-		"territory": ["territory", "qty", "base_rate", "buying_rate", "base_amount", "buying_amount",
-			"gross_profit", "gross_profit_percent"],
 		"brand": ["brand", "qty", "base_rate", "buying_rate", "base_amount", "buying_amount",
 			"gross_profit", "gross_profit_percent"],
 		"item_group": ["item_group", "qty", "base_rate", "buying_rate", "base_amount", "buying_amount",

--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -249,7 +249,6 @@ class PurchaseOrder(BuyingController):
 			'target_parent_dt': 'Sales Order',
 			'target_parent_field': '',
 			'join_field': 'sales_order_item',
-			'source_dt': 'Purchase Order Item',
 			'target_ref_field': 'stock_qty',
 			'source_field': 'stock_qty'
 		})

--- a/erpnext/config/desktop.py
+++ b/erpnext/config/desktop.py
@@ -56,7 +56,6 @@ def get_data():
 		{
 			"module_name": "Lead",
 			"icon": "octicon octicon-broadcast",
-			"type": "module",
 			"_doctype": "Lead",
 			"type": "link",
 			"link": "List/Lead"
@@ -81,7 +80,6 @@ def get_data():
 		{
 			"module_name": "Stock",
 			"color": "#f39c12",
-			"icon": "fa fa-truck",
 			"icon": "octicon octicon-package",
 			"type": "module",
 			"hidden": 1
@@ -96,7 +94,6 @@ def get_data():
 		{
 			"module_name": "Selling",
 			"color": "#1abc9c",
-			"icon": "fa fa-tag",
 			"icon": "octicon octicon-tag",
 			"type": "module",
 			"hidden": 1
@@ -104,7 +101,6 @@ def get_data():
 		{
 			"module_name": "Buying",
 			"color": "#c0392b",
-			"icon": "fa fa-shopping-cart",
 			"icon": "octicon octicon-briefcase",
 			"type": "module",
 			"hidden": 1
@@ -112,7 +108,6 @@ def get_data():
 		{
 			"module_name": "HR",
 			"color": "#2ecc71",
-			"icon": "fa fa-group",
 			"icon": "octicon octicon-organization",
 			"label": _("Human Resources"),
 			"type": "module",
@@ -121,7 +116,6 @@ def get_data():
 		{
 			"module_name": "Manufacturing",
 			"color": "#7f8c8d",
-			"icon": "fa fa-cogs",
 			"icon": "octicon octicon-tools",
 			"type": "module",
 			"hidden": 1
@@ -145,7 +139,6 @@ def get_data():
 		{
 			"module_name": "Projects",
 			"color": "#8e44ad",
-			"icon": "fa fa-puzzle-piece",
 			"icon": "octicon octicon-rocket",
 			"type": "module",
 			"hidden": 1
@@ -153,7 +146,6 @@ def get_data():
 		{
 			"module_name": "Support",
 			"color": "#2c3e50",
-			"icon": "fa fa-phone",
 			"icon": "octicon octicon-issue-opened",
 			"type": "module",
 			"hidden": 1

--- a/erpnext/startup/report_data_map.py
+++ b/erpnext/startup/report_data_map.py
@@ -97,17 +97,6 @@ data_map = {
 		"conditions": ["docstatus=1"],
 		"order_by": "posting_date, posting_time, name",
 	},
-	"Work Order": {
-		"columns": ["name", "production_item as item_code",
-			"(qty - produced_qty) as qty",
-			"fg_warehouse as warehouse"],
-		"conditions": ["docstatus=1", "status != 'Stopped'", "ifnull(fg_warehouse, '')!=''",
-			"qty > produced_qty"],
-		"links": {
-			"item_code": ["Item", "name"],
-			"warehouse": ["Warehouse", "name"]
-		},
-	},
 	"Material Request Item": {
 		"columns": ["item.name as name", "item_code", "warehouse",
 			"(qty - ordered_qty) as qty"],


### PR DESCRIPTION
This proposed change was made in response to issue #13639 

These changes are being suggested in order to clean up duplicated code. While the functionality of the current code is not affected by these duplicates due to how Python treats duplicate keys, this change should help to avoid confusion and improve readability for newcomers to the project.

The following screenshots are included to show that the UI does not change after the changes are made:



Here is a before-and-after (the changes were made) shot of the desktop icons:
![screen shot 2018-04-14 at 6 59 18 pm](https://user-images.githubusercontent.com/30908754/38840792-5abf2180-41af-11e8-9ba9-e4db65d75603.png)

The gross profit page after the changes were made:
![screen shot 2018-04-15 at 3 08 15 am](https://user-images.githubusercontent.com/30908754/38840851-92dc5a88-41af-11e8-829d-41605e780a5f.png)

The purchase order pages after the changes were made:
![screen shot 2018-04-15 at 3 10 10 am](https://user-images.githubusercontent.com/30908754/38840876-af8687b2-41af-11e8-94af-149d19ebf05d.png)
![screen shot 2018-04-15 at 3 14 10 am](https://user-images.githubusercontent.com/30908754/38840919-cce742f6-41af-11e8-9ebc-1cb62b242af0.png)
