### PR TITLE
[fix] do not escape % while using `in` clause

### DIFF
--- a/erpnext/stock/report/stock_balance/stock_balance.py
+++ b/erpnext/stock/report/stock_balance/stock_balance.py
@@ -104,7 +104,7 @@ def get_stock_ledger_entries(filters, items):
 	item_conditions_sql = ''
 	if items:
 		item_conditions_sql = ' and sle.item_code in ({})'\
-			.format(', '.join(['"' + frappe.db.escape(i) + '"' for i in items]))
+			.format(', '.join(['"' + frappe.db.escape(i, percent=False) + '"' for i in items]))
 
 	conditions = get_conditions(filters)
 
@@ -205,7 +205,7 @@ def get_item_details(items, sle, filters):
 		select name, item_name, description, item_group, brand, stock_uom
 		from `tabItem`
 		where name in ({0})
-		""".format(', '.join(['"' + frappe.db.escape(i) + '"' for i in items])), as_dict=1):
+		""".format(', '.join(['"' + frappe.db.escape(i, percent=False) + '"' for i in items])), as_dict=1):
 			item_details.setdefault(item.name, item)
 
 	if filters.get('show_variant_attributes', 0) == 1:
@@ -219,7 +219,7 @@ def get_item_reorder_details(items):
 		select parent, warehouse, warehouse_reorder_qty, warehouse_reorder_level
 		from `tabItem Reorder`
 		where parent in ({0})
-	""".format(', '.join(['"' + frappe.db.escape(i) + '"' for i in items])), as_dict=1)
+	""".format(', '.join(['"' + frappe.db.escape(i, percent=False) + '"' for i in items])), as_dict=1)
 
 	return dict((d.parent + d.warehouse, d) for d in item_reorder_details)
 

--- a/erpnext/stock/report/stock_ledger/stock_ledger.py
+++ b/erpnext/stock/report/stock_ledger/stock_ledger.py
@@ -56,7 +56,7 @@ def get_stock_ledger_entries(filters, items):
 	item_conditions_sql = ''
 	if items:
 		item_conditions_sql = 'and sle.item_code in ({})'\
-			.format(', '.join(['"' + frappe.db.escape(i) + '"' for i in items]))
+			.format(', '.join(['"' + frappe.db.escape(i,percent=False) + '"' for i in items]))
 
 	return frappe.db.sql("""select concat_ws(" ", posting_date, posting_time) as date,
 			item_code, warehouse, actual_qty, qty_after_transaction, incoming_rate, valuation_rate,
@@ -97,7 +97,7 @@ def get_item_details(items, sl_entries):
 		select name, item_name, description, item_group, brand, stock_uom
 		from `tabItem`
 		where name in ({0})
-		""".format(', '.join(['"' + frappe.db.escape(i) + '"' for i in items])), as_dict=1):
+		""".format(', '.join(['"' + frappe.db.escape(i,percent=False) + '"' for i in items])), as_dict=1):
 			item_details.setdefault(item.name, item)
 
 	return item_details


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2018-03-27/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2018-03-27/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2018-03-27/apps/frappe/frappe/handler.py", line 53, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2018-03-27/apps/frappe/frappe/__init__.py", line 939, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2018-03-27/apps/frappe/frappe/desk/query_report.py", line 96, in run
    res = frappe.get_attr(method_name)(frappe._dict(filters))
  File "/home/frappe/benches/bench-2018-03-27/apps/erpnext/erpnext/stock/report/stock_balance/stock_balance.py", line 31, in execute
    report_data = [item, item_map[item]["item_name"],
KeyError: u'Bromocresol Purple 0.04% indicator solution (ph 5-2-6.8) 0.125 ltr pack'
```