### PR TITLE
[Minor] Order by clause for Patient Appointment fix

### DIFF
--- a/erpnext/education/doctype/course_schedule/course_schedule_calendar.js
+++ b/erpnext/education/doctype/course_schedule/course_schedule_calendar.js
@@ -8,7 +8,7 @@ frappe.views.calendar["Course Schedule"] = {
 		"allDay": "allDay"
 	},
 	gantt: false,
-	order_by: "from_time",
+	order_by: "schedule_date",
 	filters: [
 		{
 			"fieldtype": "Link",

--- a/erpnext/healthcare/doctype/patient_appointment/patient_appointment_calendar.js
+++ b/erpnext/healthcare/doctype/patient_appointment/patient_appointment_calendar.js
@@ -8,6 +8,7 @@ frappe.views.calendar["Patient Appointment"] = {
 		"allDay": "allDay",
 		"eventColor": "color"
 	},
+	order_by: "appointment_date",
 	gantt: true,
 	get_events_method: "erpnext.healthcare.doctype.patient_appointment.patient_appointment.get_events",
 	filters: [


### PR DESCRIPTION
Issue:- 
![gantt-order-by-error](https://user-images.githubusercontent.com/11695402/39081700-9b042b16-4563-11e8-827b-1f748b9f196a.gif)

Order by was picking up `start` which is not an actual field in `Patient Appointment` DocType.
