### PR TITLE
[Minor] Validate dates in Salary Structure

### DIFF
--- a/erpnext/hr/doctype/salary_slip/salary_slip.js
+++ b/erpnext/hr/doctype/salary_slip/salary_slip.js
@@ -29,9 +29,10 @@ frappe.ui.form.on("Salary Slip", {
 		})
 	},
 
-	start_date: function(frm){
+	start_date: function(frm, dt, dn){
 		if(frm.doc.start_date){
 			frm.trigger("set_end_date");
+			get_emp_and_leave_details(frm.doc, dt, dn);
 		}
 	},
 
@@ -65,18 +66,20 @@ frappe.ui.form.on("Salary Slip", {
 		cur_frm.fields_dict['deductions'].grid.set_column_disp(salary_detail_fields,false);
 	},	
 
-	salary_slip_based_on_timesheet: function(frm) {
+	salary_slip_based_on_timesheet: function(frm, dt, dn) {
 		frm.trigger("toggle_fields");
-		frm.set_value('start_date', '');
+		get_emp_and_leave_details(frm.doc, dt, dn);
 	},
 	
-	payroll_frequency: function(frm) {
+	payroll_frequency: function(frm, dt, dn) {
 		frm.trigger("toggle_fields");
+		frm.set_value('end_date', '');
 		frm.set_value('start_date', '');
+		get_emp_and_leave_details(frm.doc, dt, dn);
 	},
 
-	employee: function(frm){
-		frm.set_value('start_date', '');
+	employee: function(frm, dt, dn) {
+		get_emp_and_leave_details(frm.doc, dt, dn);
 	},
 
 	toggle_fields: function(frm) {
@@ -109,7 +112,7 @@ frappe.ui.form.on('Salary Slip Timesheet', {
 
 // Get leave details
 //---------------------------------------------------------------------
-cur_frm.cscript.start_date = function(doc, dt, dn){
+var get_emp_and_leave_details = function(doc, dt, dn) {
 	if(!doc.start_date){
 		return frappe.call({
 			method: 'get_emp_and_leave_details',
@@ -122,11 +125,9 @@ cur_frm.cscript.start_date = function(doc, dt, dn){
 	}
 }
 
-cur_frm.cscript.payroll_frequency = cur_frm.cscript.salary_slip_based_on_timesheet = cur_frm.cscript.start_date;
-
 cur_frm.cscript.employee = function(doc,dt,dn){
 	doc.salary_structure = ''
-	cur_frm.cscript.start_date(doc, dt, dn)
+	get_emp_and_leave_details(doc, dt, dn);
 }
 
 cur_frm.cscript.leave_without_pay = function(doc,dt,dn){

--- a/erpnext/hr/doctype/salary_structure/salary_structure.js
+++ b/erpnext/hr/doctype/salary_structure/salary_structure.js
@@ -161,6 +161,28 @@ frappe.ui.form.on('Salary Structure', {
 	}
 });
 
+frappe.ui.form.on('Salary Structure Employee', {
+	from_date: function(frm, cdt, cdn) {
+		validate_date(frm, cdt, cdn);
+	},
+	to_date: function(frm, cdt, cdn) {
+		validate_date(frm, cdt, cdn);
+	}
+});
+
+var validate_date = function(frm, cdt, cdn) {
+	var doc = locals[cdt][cdn];
+	if(doc.to_date && doc.from_date) {
+		var from_date = frappe.datetime.str_to_obj(doc.from_date);
+		var to_date = frappe.datetime.str_to_obj(doc.to_date);
+
+		if(to_date < from_date) {
+			frappe.model.set_value(cdt, cdn, "to_date", "");
+			frappe.throw(__("From Date cannot be greater than To Date"));
+		}
+	}
+}
+
 
 cur_frm.cscript.amount = function(doc, cdt, cdn){
 	calculate_totals(doc, cdt, cdn);


### PR DESCRIPTION
Issue:- 
![ss-iss](https://user-images.githubusercontent.com/11695402/39299976-d087218c-4967-11e8-9afb-530d28ead8b7.gif)

Fix:-
![ss-fix](https://user-images.githubusercontent.com/11695402/39299985-d9d6ee8e-4967-11e8-97e4-ce8afeaa883b.gif)

Summary:- In Salary Structure's employees table, there was no validation for from and to date. If to_date was set lesser than from date, then for that employee the salary structure was not being pulled while creating salary slip.

