### PR TITLE
Ignore mandatory for default warehouses

### DIFF
--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -122,6 +122,7 @@ class Company(Document):
 						if not wh_detail["is_group"] else ""
 				})
 				warehouse.flags.ignore_permissions = True
+				warehouse.flags.ignore_mandatory = True
 				warehouse.insert()
 
 	def create_default_accounts(self):


### PR DESCRIPTION
Will allow saving default Warehouses with mandatory custom fields. (Advised by @nabinhait)