### PR TITLE
[Minor] Show Customer's Name while printing Accounts Receivable report

### DIFF
--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.html
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.html
@@ -19,7 +19,13 @@
 
 
 <h2 class="text-center">{%= __(report.report_name) %}</h2>
-<h4 class="text-center">{%= filters.customer || filters.supplier %} </h4>
+<h4 class="text-center">
+	{% if (filters.customer_name) { %}
+		{%= filters.customer_name %}
+	{% } else { %}
+		{%= filters.customer || filters.supplier %}
+	{% } %}
+</h4>
 <h6 class="text-center">
 		{% if (filters.tax_id) { %}
 		{%= __("Tax Id: ")%}	{%= filters.tax_id %}

--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.js
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.js
@@ -17,8 +17,9 @@ frappe.query_reports["Accounts Receivable"] = {
 			"options": "Customer",
 			on_change: () => {
 				var customer = frappe.query_report_filters_by_name.customer.get_value();
-				frappe.db.get_value('Customer', customer, "tax_id", function(value) {
+				frappe.db.get_value('Customer', customer, ["tax_id", "customer_name"], function(value) {
 					frappe.query_report_filters_by_name.tax_id.set_value(value["tax_id"]);
+					frappe.query_report_filters_by_name.customer_name.set_value(value["customer_name"]);
 				});
 			}
 		},
@@ -79,6 +80,12 @@ frappe.query_reports["Accounts Receivable"] = {
 		{
 			"fieldname":"tax_id",
 			"label": __("Tax Id"),
+			"fieldtype": "Data",
+			"hidden": 1
+		},
+		{
+			"fieldname":"customer_name",
+			"label": __("Customer Name"),
 			"fieldtype": "Data",
 			"hidden": 1
 		}


### PR DESCRIPTION
Display Customer's full name in the printview of Accounts Receivable report instead of Customer's code.

![acc_print](https://user-images.githubusercontent.com/11695402/39417464-f94316e6-4c71-11e8-85b9-18e7007dfcf9.gif)
