### PR TITLE
Tax amount showing under wrong tax header in the report

### DIFF
--- a/erpnext/public/js/controllers/accounts.js
+++ b/erpnext/public/js/controllers/accounts.js
@@ -145,6 +145,8 @@ cur_frm.cscript.account_head = function(doc, cdt, cdn) {
 				frappe.model.set_value(cdt, cdn, "description", r.message.account_name);
 			}
 		})
+	} else if (d.charge_type == 'Actual' && d.account_head) {
+		frappe.model.set_value(cdt, cdn, "description", d.account_head.split(' - ')[0]);
 	}
 }
 


### PR DESCRIPTION
**Issue**

1. Created and submitted sales invoice against tax head CGST

1. Copied above invoice to make new invoice and set charge type as Actual and account head as SGST - SFPL but description not changed and set as CGST
![screen shot 2018-04-30 at 6 27 39 pm](https://user-images.githubusercontent.com/8780500/39428339-a40c402a-4ca4-11e8-936b-3f7f9d89bdab.png)


In report amount showing under CGST column not under SGST column
![screen shot 2018-04-30 at 6 33 06 pm 1](https://user-images.githubusercontent.com/8780500/39428435-f398481e-4ca4-11e8-904c-cf7aa763cdc9.png)

Fixed 
https://github.com/frappe/erpnext/issues/13679