### PR TITLE
Always search for item code in item query

### DIFF
--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -168,6 +168,7 @@ def item_query(doctype, txt, searchfield, start, page_len, filters, as_dict=Fals
 			and tabItem.disabled=0
 			and (tabItem.end_of_life > %(today)s or ifnull(tabItem.end_of_life, '0000-00-00')='0000-00-00')
 			and (tabItem.`{key}` LIKE %(txt)s
+				or tabItem.item_code LIKE %(txt)s
 				or tabItem.item_group LIKE %(txt)s
 				or tabItem.item_name LIKE %(txt)s
 				or tabItem.item_code IN (select parent from `tabItem Barcode` where barcode LIKE %(txt)s


### PR DESCRIPTION
Item query can be called from custom script to search for an additional field with a script similar to the one below. In this case the item_name, item_group and item_description are still searchable in addition to the custom field, but not item_code. As the item code is a must have field in search results, I have added this to the hard-coded search fields in item query.

`frappe.ui.form.on("Sales Order", "refresh", function (frm, cdt, cdn) {
  cur_frm.set_query("item_code", "items", function () {
    return { 
      query: "erpnext.controllers.queries.item_query",
      searchfield: "custom_field",
      filters: {'is_sales_item': 1}
    }
  });
});`