### PR TITLE
[Minor] Python 2&3 related fix in use of filter function

### DIFF
--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -130,9 +130,8 @@ def get_default_price_list(party):
 
 def set_price_list(out, party, party_type, given_price_list):
 	# price list
-	price_list = filter(None, get_user_permissions().get("Price List", []))
-	if isinstance(price_list, list):
-		price_list = price_list[0] if len(price_list)==1 else None
+	price_list = list(filter(None, get_user_permissions().get("Price List", [])))
+	price_list = price_list[0] if len(price_list)==1 else None
 
 	if not price_list:
 		price_list = get_default_price_list(party)


### PR DESCRIPTION
In Python 2, the filter() function returned a list, the result of filtering a sequence through a function that returned True or False for each item in the sequence. In Python 3, the filter() function returns an iterator, not a list.

Related Issues - https://github.com/frappe/erpnext/issues/13682 & https://github.com/frappe/erpnext/issues/13833