### PR TITLE
[Bug] GSTR1 report

### DIFF
--- a/erpnext/regional/report/gstr_1/gstr_1.py
+++ b/erpnext/regional/report/gstr_1/gstr_1.py
@@ -144,7 +144,17 @@ class Gstr1Report(object):
 		""" % (self.doctype, ', '.join(['%s']*len(self.invoices))), tuple(self.invoices), as_dict=1)
 
 		for d in items:
-			self.invoice_items.setdefault(d.parent, {}).setdefault(d.item_code, d.base_net_amount)
+			item_details = {}
+			item_details[d.item_code] = d.base_net_amount
+
+			if d.parent in self.invoice_items:
+				parent_dict = self.invoice_items[d.parent]
+				if d.item_code in parent_dict:
+					item_details[d.item_code] += parent_dict[d.item_code]
+				else:
+					item_details.update(parent_dict)
+
+			self.invoice_items[d.parent] = item_details
 
 	def get_items_based_on_tax_rate(self):
 		self.tax_details = frappe.db.sql("""


### PR DESCRIPTION
Closes: #13260

If an invoice have same items in multiple rows, the amount doesn't get added.

For eg.

<img width="949" alt="screen shot 2018-05-04 at 5 47 21 pm" src="https://user-images.githubusercontent.com/17617465/39627574-fb23b560-4fc3-11e8-908d-f9b26ed07b63.png">

Before:

<img width="1158" alt="screen shot 2018-05-04 at 5 48 07 pm" src="https://user-images.githubusercontent.com/17617465/39627679-4da6950a-4fc4-11e8-983e-b212500716a2.png">


Now:

<img width="1165" alt="screen shot 2018-05-04 at 5 50 37 pm" src="https://user-images.githubusercontent.com/17617465/39627688-54b8a2de-4fc4-11e8-8d94-f0dd8bd1f5d2.png">


