### PR TITLE
[fix] add Stock Entry link on Material Request Dashboard

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request_dashboard.py
+++ b/erpnext/stock/doctype/material_request/material_request_dashboard.py
@@ -7,7 +7,7 @@ def get_data():
 		'transactions': [
 			{
 				'label': _('Related'),
-				'items': ['Request for Quotation', 'Supplier Quotation', 'Purchase Order']
+				'items': ['Request for Quotation', 'Supplier Quotation', 'Purchase Order', "Stock Entry"]
 			},
 			{
 				'label': _('Manufacturing'),


### PR DESCRIPTION
<img width="1170" alt="screen shot 2018-05-08 at 11 40 16 am" src="https://user-images.githubusercontent.com/3784093/39740800-e6457d6a-52b4-11e8-8650-98df1c408ea6.png">
