### PR TITLE
[Minor] Update Dashboards to use 'Auto Repeat' instead of 'Subscription'

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice_dashboard.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice_dashboard.py
@@ -30,7 +30,7 @@ def get_data():
 			},
 			{
 				'label': _('Subscription'),
-				'items': ['Subscription']
+				'items': ['Auto Repeat']
 			},
 		]
 	}

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice_dashboard.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice_dashboard.py
@@ -29,7 +29,7 @@ def get_data():
 			},
 			{
 				'label': _('Subscription'),
-				'items': ['Subscription']
+				'items': ['Auto Repeat']
 			},
 		]
 	}

--- a/erpnext/buying/doctype/purchase_order/purchase_order_dashboard.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order_dashboard.py
@@ -24,7 +24,7 @@ def get_data():
 			},
 			{
 				'label': _('Reference'),
-				'items': ['Material Request', 'Supplier Quotation', 'Project', 'Subscription']
+				'items': ['Material Request', 'Supplier Quotation', 'Project', 'Auto Repeat']
 			},
 			{
 				'label': _('Sub-contracting'),

--- a/erpnext/buying/doctype/supplier_quotation/supplier_quotation_dashboard.py
+++ b/erpnext/buying/doctype/supplier_quotation/supplier_quotation_dashboard.py
@@ -22,7 +22,7 @@ def get_data():
 			},
 			{
 				'label': _('Subscription'),
-				'items': ['Subscription']
+				'items': ['Auto Repeat']
 			},
 		]
 

--- a/erpnext/config/accounts.py
+++ b/erpnext/config/accounts.py
@@ -34,8 +34,8 @@ def get_data():
 				},
 				{
 					"type": "doctype",
-					"name": "Subscription",
-					"label": _("Subscription"),
+					"name": "Auto Repeat",
+					"label": _("Auto Repeat"),
 					"description": _("To make recurring documents")
 				},
 				{

--- a/erpnext/selling/doctype/quotation/quotation_dashboard.py
+++ b/erpnext/selling/doctype/quotation/quotation_dashboard.py
@@ -13,7 +13,7 @@ def get_data():
 			},
 			{
 				'label': _('Subscription'),
-				'items': ['Subscription']
+				'items': ['Auto Repeat']
 			},
 		]
 	}

--- a/erpnext/selling/doctype/sales_order/sales_order_dashboard.py
+++ b/erpnext/selling/doctype/sales_order/sales_order_dashboard.py
@@ -32,7 +32,7 @@ def get_data():
 			},
 			{
 				'label': _('Reference'),
-				'items': ['Quotation', 'Subscription']
+				'items': ['Quotation', 'Auto Repeat']
 			},
 			{
 				'label': _('Payment'),

--- a/erpnext/stock/doctype/delivery_note/delivery_note_dashboard.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note_dashboard.py
@@ -26,7 +26,7 @@ def get_data():
 			},
 			{
 				'label': _('Subscription'),
-				'items': ['Subscription']
+				'items': ['Auto Repeat']
 			},
 		]
 	}

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt_dashboard.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt_dashboard.py
@@ -28,7 +28,7 @@ def get_data():
 			},
 			{
 				'label': _('Subscription'),
-				'items': ['Subscription']
+				'items': ['Auto Repeat']
 			},
 		]
 	}


### PR DESCRIPTION
Issue:-  https://github.com/frappe/erpnext/issues/13949
![subscription-error](https://user-images.githubusercontent.com/11695402/39747108-f8bc0620-52c9-11e8-974a-1551f62159d8.gif)

Fix:-
![subscription-fix](https://user-images.githubusercontent.com/11695402/39747109-f99efb6a-52c9-11e8-82a1-d45f8410d606.gif)


Subscription was renamed to Auto Repeat, while dashboards were still trying to query Subscription doctype for open notification count.