### PR TITLE
[fix] Compounding error in task weight

### DIFF
--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -75,7 +75,7 @@ class Project(Document):
 		sum = 0
 		for task in self.tasks:
 			if task.task_weight > 0:
-				sum = round(sum + task.task_weight, 3)
+				sum = flt(sum + task.task_weight, task.precision('task_weight'))
 		if sum > 0 and sum != 1:
 			frappe.throw(_("Total of all task weights should be 1. Please adjust weights of all Project tasks accordingly"))
 

--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -75,7 +75,8 @@ class Project(Document):
 		sum = 0
 		for task in self.tasks:
 			if task.task_weight > 0:
-				sum = sum + task.task_weight
+				sum = round(sum + task.task_weight, 3)
+				print("sum", sum)
 		if sum > 0 and sum != 1:
 			frappe.throw(_("Total of all task weights should be 1. Please adjust weights of all Project tasks accordingly"))
 

--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -76,7 +76,6 @@ class Project(Document):
 		for task in self.tasks:
 			if task.task_weight > 0:
 				sum = round(sum + task.task_weight, 3)
-				print("sum", sum)
 		if sum > 0 and sum != 1:
 			frappe.throw(_("Total of all task weights should be 1. Please adjust weights of all Project tasks accordingly"))
 


### PR DESCRIPTION
Failure rate
Sum of 2 numbers between 0.00 and 1.00
0.01 + 0.05 != 0.06
0.01 + 0.06 != 0.07
0.01 + 0.09 != 0.10
0.01 + 0.14 != 0.15
0.01 + 0.17 != 0.18
0.01 + 0.20 != 0.21
0.01 + 0.23 != 0.24
0.01 + 0.28 != 0.29
...
0.99 + 0.87 != 1.86
0.99 + 0.90 != 1.89
0.99 + 0.92 != 1.91
2106 failures (21%) out of 10000 sums
Failure rate: 21%

https://ge0ffrey.github.io/ge0ffrey-presentations/cornerCaseCheatSheet/CornerCaseCheatSheet.pdf

In our case, we have 86 task out of which 
72 contain weight 0.010 = 0.72
14 contain weight 0.020 = 0.28
the result should be 1.00
but it gives 1.0000000007
I have attached screenshot below
before 
![beforeweight](https://user-images.githubusercontent.com/6947417/39747492-16b3cf72-52cb-11e8-8e03-8f3e6fa42377.gif)

after:
![afterweight](https://user-images.githubusercontent.com/6947417/39747612-643dc48c-52cb-11e8-9792-7e261fe816f2.gif)
