### PR TITLE
[Bug] Clear leave balance in Leave Application

### DIFF
--- a/erpnext/hr/doctype/leave_application/leave_application.js
+++ b/erpnext/hr/doctype/leave_application/leave_application.js
@@ -95,6 +95,9 @@ frappe.ui.form.on("Leave Application", {
 					if (!r.exc && r.message) {
 						frm.set_value('leave_balance', r.message);
 					}
+					else {
+						frm.set_value('leave_balance', "0");
+					}
 				}
 			});
 		}


### PR DESCRIPTION
In leave application on changing the values of Leave Type, it is not updated if the selected leave type has no allocated leaves.
For eg: If Employee selects Leave Type: Casual and has balance of 1 and then selects Leave type of Earned Leave where he has no balance, it still shows 1. 

<img width="468" alt="screen shot 2018-05-14 at 11 01 25 pm" src="https://user-images.githubusercontent.com/17617465/40013375-fb73c73a-57ca-11e8-987c-39098ab42b7d.png">
