### PR TITLE
[Minor] Department tree fixes

### DIFF
--- a/erpnext/hr/doctype/department/department.js
+++ b/erpnext/hr/doctype/department/department.js
@@ -2,7 +2,16 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Department', {
-	onload: function(frm) {
-
+	refresh: function(frm) {
+		// read-only for root department
+		if(!frm.doc.parent_department) {
+			cur_frm.set_read_only();
+			cur_frm.set_intro(__("This is a root customer group and cannot be edited."));
+		}
+	},
+	validate: function(frm) {
+		if(frm.doc.name=="All Departments") {
+			frappe.throw(__("You cannot edit root node."));
+		}
 	}
 });

--- a/erpnext/hr/doctype/department/department.py
+++ b/erpnext/hr/doctype/department/department.py
@@ -11,8 +11,11 @@ class Department(NestedSet):
 	nsm_parent_field = 'parent_department'
 
 	def autoname(self):
-		abbr = frappe.db.get_value('Company', self.company, 'abbr')
-		self.name = '{0} - {1}'.format(self.department_name, abbr)
+		if not self.department_name=="All Departments":
+			abbr = frappe.db.get_value('Company', self.company, 'abbr')
+			self.name = '{0} - {1}'.format(self.department_name, abbr)
+		else:
+			self.name = self.department_name
 
 	def update_nsm_model(self):
 		frappe.utils.nestedset.update_nsm(self)

--- a/erpnext/patches/v11_0/create_department_records_for_each_company.py
+++ b/erpnext/patches/v11_0/create_department_records_for_each_company.py
@@ -2,7 +2,7 @@ import frappe
 from frappe.utils.nestedset import rebuild_tree
 
 def execute():
-	for doctype in ['department', 'leave_period', 'staffing_plan']:
+	for doctype in ['department', 'leave_period', 'staffing_plan', 'job_opening']:
 		frappe.reload_doc("hr", "doctype", doctype)
 
 	companies = frappe.db.get_all("Company", fields=["name", "abbr"])

--- a/erpnext/setup/setup_wizard/operations/install_fixtures.py
+++ b/erpnext/setup/setup_wizard/operations/install_fixtures.py
@@ -104,22 +104,6 @@ def install(country=None):
 		{'doctype': 'Employment Type', 'employee_type_name': _('Intern')},
 		{'doctype': 'Employment Type', 'employee_type_name': _('Apprentice')},
 
-		# Department
-		{'doctype': 'Department', 'department_name': _('All Departments'), 'is_group': 1, 'parent_department': ''},
-		{'doctype': 'Department', 'department_name': _('Accounts'), 'parent_department': _('All Departments')},
-		{'doctype': 'Department', 'department_name': _('Marketing'), 'parent_department': _('All Departments')},
-		{'doctype': 'Department', 'department_name': _('Sales'), 'parent_department': _('All Departments')},
-		{'doctype': 'Department', 'department_name': _('Purchase'), 'parent_department': _('All Departments')},
-		{'doctype': 'Department', 'department_name': _('Operations'), 'parent_department': _('All Departments')},
-		{'doctype': 'Department', 'department_name': _('Production'), 'parent_department': _('All Departments')},
-		{'doctype': 'Department', 'department_name': _('Dispatch'), 'parent_department': _('All Departments')},
-		{'doctype': 'Department', 'department_name': _('Customer Service'), 'parent_department': _('All Departments')},
-		{'doctype': 'Department', 'department_name': _('Human Resources'), 'parent_department': _('All Departments')},
-		{'doctype': 'Department', 'department_name': _('Management'), 'parent_department': _('All Departments')},
-		{'doctype': 'Department', 'department_name': _('Quality Management'), 'parent_department': _('All Departments')},
-		{'doctype': 'Department', 'department_name': _('Research & Development'), 'parent_department': _('All Departments')},
-		{'doctype': 'Department', 'department_name': _('Legal'), 'parent_department': _('All Departments')},
-
 		# Designation
 		{'doctype': 'Designation', 'designation_name': _('CEO')},
 		{'doctype': 'Designation', 'designation_name': _('Manager')},
@@ -276,6 +260,14 @@ def install(country=None):
 	from erpnext.buying.doctype.supplier_scorecard.supplier_scorecard import make_default_records
 	make_default_records()
 
+	make_fixture_records(records)
+
+	# set default customer group and territory
+	selling_settings = frappe.get_doc("Selling Settings")
+	selling_settings.set_default_customer_group_and_territory()
+	selling_settings.save()
+
+def make_fixture_records(records):
 	from frappe.modules import scrub
 	for r in records:
 		doc = frappe.new_doc(r.get("doctype"))
@@ -296,7 +288,23 @@ def install(country=None):
 			else:
 				raise
 
-	# set default customer group and territory
-	selling_settings = frappe.get_doc("Selling Settings")
-	selling_settings.set_default_customer_group_and_territory()
-	selling_settings.save()
+def install_post_company_fixtures(company=None):
+	records = [
+		# Department
+		{'doctype': 'Department', 'department_name': _('All Departments'), 'is_group': 1, 'parent_department': ''},
+		{'doctype': 'Department', 'department_name': _('Accounts'), 'parent_department': _('All Departments'), 'company': company},
+		{'doctype': 'Department', 'department_name': _('Marketing'), 'parent_department': _('All Departments'), 'company': company},
+		{'doctype': 'Department', 'department_name': _('Sales'), 'parent_department': _('All Departments'), 'company': company},
+		{'doctype': 'Department', 'department_name': _('Purchase'), 'parent_department': _('All Departments'), 'company': company},
+		{'doctype': 'Department', 'department_name': _('Operations'), 'parent_department': _('All Departments'), 'company': company},
+		{'doctype': 'Department', 'department_name': _('Production'), 'parent_department': _('All Departments'), 'company': company},
+		{'doctype': 'Department', 'department_name': _('Dispatch'), 'parent_department': _('All Departments'), 'company': company},
+		{'doctype': 'Department', 'department_name': _('Customer Service'), 'parent_department': _('All Departments'), 'company': company},
+		{'doctype': 'Department', 'department_name': _('Human Resources'), 'parent_department': _('All Departments'), 'company': company},
+		{'doctype': 'Department', 'department_name': _('Management'), 'parent_department': _('All Departments'), 'company': company},
+		{'doctype': 'Department', 'department_name': _('Quality Management'), 'parent_department': _('All Departments'), 'company': company},
+		{'doctype': 'Department', 'department_name': _('Research & Development'), 'parent_department': _('All Departments'), 'company': company},
+		{'doctype': 'Department', 'department_name': _('Legal'), 'parent_department': _('All Departments'), 'company': company},
+	]
+
+	make_fixture_records(records)

--- a/erpnext/setup/setup_wizard/setup_wizard.py
+++ b/erpnext/setup/setup_wizard/setup_wizard.py
@@ -56,6 +56,11 @@ def get_setup_stages(args=None):
 				'fail_msg': 'Failed to set defaults',
 				'tasks': [
 					{
+						'fn': setup_post_company_fixtures,
+						'args': args,
+						'fail_msg': _("Failed to setup post company fixtures")
+					},
+					{
 						'fn': stage_three,
 						'args': args,
 						'fail_msg': _("Failed to set defaults")
@@ -92,6 +97,7 @@ def setup_complete(args=None):
 	stage_fixtures(args)
 	setup_company(args)
 	setup_taxes(args)
+	setup_post_company_fixtures(args)
 	stage_three(args)
 	stage_four(args)
 	fin(args)
@@ -107,6 +113,9 @@ def setup_company(args):
 
 def setup_taxes(args):
 	taxes_setup.create_sales_tax(args)
+
+def setup_post_company_fixtures(args):
+	install_fixtures.install_post_company_fixtures(args.get("company_name"))
 
 def stage_three(args):
 	defaults_setup.create_employee_for_self(args)


### PR DESCRIPTION
Skip abbreviation for "All Departments". Make root node non editable. Reload doc with department field.

Install Fixture changes -> Removed department fixtures from records as it was dependent on company but while installing fixtures company record was not yet created. Created a new method for `post_company_fixtures` and staged it in setup_wizard to be called after creating company.