### PR TITLE
apply sorting for make multiple variant attributes

### DIFF
--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -458,7 +458,8 @@ $.extend(erpnext.item, {
 						fields: ["attribute_value"],
 						limit_start: 0,
 						limit_page_length: 500,
-						parent: "Item"
+						parent: "Item",
+						order_by: "idx"
 					}
 				}).then((r) => {
 					if(r.message) {


### PR DESCRIPTION
Sorting for the Stock > Make > Multiple variants variant attributes according to their list position in the item attribute definition. Increases the usability. 