### PR TITLE
[Fix] 'Supplier' object has no attribute 'on_hold'

### DIFF
--- a/erpnext/buying/doctype/supplier/supplier.json
+++ b/erpnext/buying/doctype/supplier/supplier.json
@@ -1322,7 +1322,7 @@
  "issingle": 0, 
  "istable": 0, 
  "max_attachments": 0, 
- "modified": "2018-05-11 15:15:19.912308", 
+ "modified": "2018-05-16 15:15:19.912308", 
  "modified_by": "Administrator", 
  "module": "Buying", 
  "name": "Supplier", 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/desk/form/save.py", line 22, in savedocs
    doc.save()
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/model/document.py", line 260, in save
    return self._save(*args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/model/document.py", line 283, in _save
    self.insert()
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/model/document.py", line 222, in insert
    self.run_before_save_methods()
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/model/document.py", line 869, in run_before_save_methods
    self.run_method("validate")
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/model/document.py", line 765, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/model/document.py", line 1040, in composer
    return composed(self, method, *args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/model/document.py", line 1023, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/model/document.py", line 759, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/erpnext/erpnext/buying/doctype/purchase_order/purchase_order.py", line 44, in validate
    super(PurchaseOrder, self).validate()
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/erpnext/erpnext/controllers/buying_controller.py", line 37, in validate
    super(BuyingController, self).validate()
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/erpnext/erpnext/controllers/stock_controller.py", line 17, in validate
    super(StockController, self).validate()
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/erpnext/erpnext/controllers/accounts_controller.py", line 60, in validate
    self.ensure_supplier_is_not_blocked()
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/erpnext/erpnext/controllers/accounts_controller.py", line 49, in ensure_supplier_is_not_blocked
    if supplier and supplier_name and supplier.on_hold:
AttributeError: 'Supplier' object has no attribute 'on_hold'
```