### PR TITLE
Missing parentheses in price list rate determination

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -179,8 +179,6 @@ def get_pricing_rule_for_item(args):
 		item_details.margin_type = pricing_rule.margin_type
 		item_details.margin_rate_or_amount = pricing_rule.margin_rate_or_amount
 		if pricing_rule.price_or_discount == "Price":
-			print(args.conversion_factor, 'conversion factor')
-			print(args.conversion_rate, 'conversion rate')
 			item_details.update({
 				"price_list_rate": (pricing_rule.price/flt(args.conversion_rate)) * (args.conversion_factor or 1.0) \
 					if args.conversion_rate else 0.0,

--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -111,8 +111,8 @@ def apply_pricing_rule(args):
 
 	item_list = args.get("items")
 	args.pop("items")
-	
-	set_serial_nos_based_on_fifo = frappe.db.get_single_value("Stock Settings", 
+
+	set_serial_nos_based_on_fifo = frappe.db.get_single_value("Stock Settings",
 		"automatically_set_serial_nos_based_on_fifo")
 
 	for item in item_list:
@@ -122,7 +122,7 @@ def apply_pricing_rule(args):
 		if set_serial_nos_based_on_fifo and not args.get('is_return'):
 			out.append(get_serial_no_for_item(args_copy))
 	return out
-	
+
 def get_serial_no_for_item(args):
 	from erpnext.stock.get_item_details import get_serial_no
 
@@ -143,7 +143,7 @@ def get_pricing_rule_for_item(args):
 		"name": args.name,
 		"pricing_rule": None
 	})
-	
+
 	if args.ignore_pricing_rule or not args.item_code:
 		if frappe.db.exists(args.doctype, args.name) and args.get("pricing_rule"):
 			item_details = remove_pricing_rule_for_item(args.get("pricing_rule"), item_details)
@@ -179,8 +179,10 @@ def get_pricing_rule_for_item(args):
 		item_details.margin_type = pricing_rule.margin_type
 		item_details.margin_rate_or_amount = pricing_rule.margin_rate_or_amount
 		if pricing_rule.price_or_discount == "Price":
+			print(args.conversion_factor, 'conversion factor')
+			print(args.conversion_rate, 'conversion rate')
 			item_details.update({
-				"price_list_rate": (pricing_rule.price/flt(args.conversion_rate)) * args.conversion_factor or 1.0 \
+				"price_list_rate": (pricing_rule.price/flt(args.conversion_rate)) * (args.conversion_factor or 1.0) \
 					if args.conversion_rate else 0.0,
 				"discount_percentage": 0.0
 			})
@@ -192,7 +194,7 @@ def get_pricing_rule_for_item(args):
 	return item_details
 
 def remove_pricing_rule_for_item(pricing_rule, item_details):
-	pricing_rule = frappe.db.get_value('Pricing Rule', pricing_rule, 
+	pricing_rule = frappe.db.get_value('Pricing Rule', pricing_rule,
 		['price_or_discount', 'margin_type'], as_dict=1)
 	if pricing_rule and pricing_rule.price_or_discount == 'Discount Percentage':
 		item_details.discount_percentage = 0.0
@@ -209,14 +211,14 @@ def remove_pricing_rule_for_item(pricing_rule, item_details):
 def remove_pricing_rules(item_list):
 	if isinstance(item_list, basestring):
 		item_list = json.loads(item_list)
-	
-	out = []	
+
+	out = []
 	for item in item_list:
 		item = frappe._dict(item)
 		out.append(remove_pricing_rule_for_item(item.get("pricing_rule"), item))
-		
+
 	return out
-	
+
 def get_pricing_rules(args):
 	def _get_tree_conditions(parenttype, allow_blank=True):
 		field = frappe.scrub(parenttype)


### PR DESCRIPTION
Hi,

A missing parentheses in the price list rate determination is causing the pricing rule determination to fail when using "Price" as pricing rule option:
![image](https://user-images.githubusercontent.com/4903591/40106107-2a5a5994-58f5-11e8-8801-0700e2ef027b.png)

I was trying to determine the price using `erpnext.utilities.product.get_price` which doesn't send the conversation_factor in its arguments.

Thanks!