### PR TITLE
[fix] Stock Ledger report item filter

### DIFF
--- a/erpnext/stock/report/stock_ledger/stock_ledger.py
+++ b/erpnext/stock/report/stock_ledger/stock_ledger.py
@@ -56,7 +56,7 @@ def get_stock_ledger_entries(filters, items):
 	item_conditions_sql = ''
 	if items:
 		item_conditions_sql = 'and sle.item_code in ({})'\
-			.format(', '.join(['"' + frappe.db.escape(i,percent=False) + '"' for i in items]))
+			.format(', '.join(['"' + frappe.db.escape(i) + '"' for i in items]))
 
 	return frappe.db.sql("""select concat_ws(" ", posting_date, posting_time) as date,
 			item_code, warehouse, actual_qty, qty_after_transaction, incoming_rate, valuation_rate,


### PR DESCRIPTION
- breaks when Item Code contains % symbol

```
Traceback (most recent call last):
  File "/Users/farisansari/frappe-bench2/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.handler.handle()
  File "/Users/farisansari/frappe-bench2/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/Users/farisansari/frappe-bench2/apps/frappe/frappe/handler.py", line 53, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/farisansari/frappe-bench2/apps/frappe/frappe/__init__.py", line 939, in call
    return fn(*args, **newargs)
  File "/Users/farisansari/frappe-bench2/apps/frappe/frappe/desk/query_report.py", line 96, in run
    res = frappe.get_attr(method_name)(frappe._dict(filters))
  File "/Users/farisansari/frappe-bench2/apps/erpnext/erpnext/stock/report/stock_ledger/stock_ledger.py", line 11, in execute
    sl_entries = get_stock_ledger_entries(filters, items)
  File "/Users/farisansari/frappe-bench2/apps/erpnext/erpnext/stock/report/stock_ledger/stock_ledger.py", line 73, in get_stock_ledger_entries
    ), filters, as_dict=1)
  File "/Users/farisansari/frappe-bench2/apps/frappe/frappe/database.py", line 166, in sql
    self._cursor.execute(query, values)
  File "/Users/farisansari/frappe-bench2/env/lib/python2.7/site-packages/pymysql/cursors.py", line 164, in execute
    query = self.mogrify(query, args)
  File "/Users/farisansari/frappe-bench2/env/lib/python2.7/site-packages/pymysql/cursors.py", line 143, in mogrify
    query = query % self._escape_args(args, conn)
TypeError: not enough arguments for format string
```
