### PR TITLE
Fix patch

### DIFF
--- a/erpnext/patches/v11_0/create_department_records_for_each_company.py
+++ b/erpnext/patches/v11_0/create_department_records_for_each_company.py
@@ -67,6 +67,9 @@ def update_instructors(comp_dict):
 				THEN "%s"
 			'''%(employee.name, department, records[department]))
 
+	if not when_then:
+		return
+
 	frappe.db.sql("""
 		update
 			`tabInstructor`


### PR DESCRIPTION
Error on migrate:

```
File “/home/frappe/frappe-bench/apps/erpnext/erpnext/patches/v11_0/create_department_records_for_each_company.py”, line 37, in execute
update_instructors(comp_dict)
File “/home/frappe/frappe-bench/apps/erpnext/erpnext/patches/v11_0/create_department_records_for_each_company.py”, line 75, in update_instructors
"""%(" ".join(when_then)))
File “/home/frappe/frappe-bench/apps/frappe/frappe/database.py”, line 205, in sql
self._cursor.execute(query)
File “/home/frappe/frappe-bench/env/lib/python3.5/site-packages/pymysql/cursors.py”, line 170, in execute
result = self._query(query)
File “/home/frappe/frappe-bench/env/lib/python3.5/site-packages/pymysql/cursors.py”, line 328, in _query
conn.query(q)
File “/home/frappe/frappe-bench/env/lib/python3.5/site-packages/pymysql/connections.py”, line 893, in query
self._affected_rows = self._read_query_result(unbuffered=unbuffered)
File “/home/frappe/frappe-bench/env/lib/python3.5/site-packages/pymysql/connections.py”, line 1103, in _read_query_result
result.read()
File “/home/frappe/frappe-bench/env/lib/python3.5/site-packages/pymysql/connections.py”, line 1396, in read
first_packet = self.connection._read_packet()
File “/home/frappe/frappe-bench/env/lib/python3.5/site-packages/pymysql/connections.py”, line 1059, in _read_packet
packet.check_error()
File “/home/frappe/frappe-bench/env/lib/python3.5/site-packages/pymysql/connections.py”, line 384, in check_error
err.raise_mysql_exception(self._data)
File “/home/frappe/frappe-bench/env/lib/python3.5/site-packages/pymysql/err.py”, line 109, in raise_mysql_exception
raise errorclass(errno, errval)
pymysql.err.ProgrammingError: (1064, “You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ‘’ at line 4”)
```