### PR TITLE
[fix] pos get_items_list

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/pos.py
+++ b/erpnext/accounts/doctype/sales_invoice/pos.py
@@ -153,12 +153,14 @@ def update_tax_table(doc):
 
 def get_items_list(pos_profile, company):
 	cond = ""
-	args_list = [company]
+	args_list = []
 	if pos_profile.get('item_groups'):
 		# Get items based on the item groups defined in the POS profile
 		for d in pos_profile.get('item_groups'):
 			args_list.extend([d.name for d in get_child_nodes('Item Group', d.item_group)])
 		cond = "and i.item_group in (%s)" % (', '.join(['%s'] * len(args_list)))
+		
+		args_list = [company] + args_list
 
 	return frappe.db.sql("""
 		select


### PR DESCRIPTION
Having the company in the list before causes the sql query to have an extra argument than it should expect, causing this error : 

```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.handler.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 53, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 942, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/doctype/sales_invoice/pos.py", line 42, in get_pos_data
    items_list = get_items_list(pos_profile, doc.company)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/doctype/sales_invoice/pos.py", line 173, in get_items_list
    """.format(cond=cond), tuple(args_list), as_dict=1)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database.py", line 195, in sql
    self._cursor.execute(query, values)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/pymysql/cursors.py", line 163, in execute
    query = self.mogrify(query, args)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/pymysql/cursors.py", line 142, in mogrify
    query = query % self._escape_args(args, conn)
TypeError: not enough arguments for format string
```