### PR TITLE
[fix] get barcode string instead of dict

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/pos.py
+++ b/erpnext/accounts/doctype/sales_invoice/pos.py
@@ -291,7 +291,7 @@ def get_barcode_data(items_list):
 		for barcode in barcodes:
 			if item.item_code not in itemwise_barcode:
 				itemwise_barcode.setdefault(item.item_code, [])
-			itemwise_barcode[item.item_code].append(barcode)
+			itemwise_barcode[item.item_code].append(barcode.get("barcode"))
 
 	return itemwise_barcode
 

--- a/erpnext/accounts/doctype/sales_invoice/pos.py
+++ b/erpnext/accounts/doctype/sales_invoice/pos.py
@@ -285,8 +285,8 @@ def get_barcode_data(items_list):
 	itemwise_barcode = {}
 	for item in items_list:
 		barcodes = frappe.db.sql("""
-		select barcode from `tabItem Barcode` where parent = '{0}'
-		""".format(item.item_code), as_dict=1)
+			select barcode from `tabItem Barcode` where parent = %s
+		""", item.item_code, as_dict=1)
 
 		for barcode in barcodes:
 			if item.item_code not in itemwise_barcode:


### PR DESCRIPTION
The `db.sql` gets a list of dicts, because of which the POS's search for barcodes doesn't work anymore. This fixes that. 