### PR TITLE
[Fix] Leave Application & Expense Claim query fix | Leave Balance Report fix

### DIFF
--- a/erpnext/hr/doctype/expense_claim/expense_claim.js
+++ b/erpnext/hr/doctype/expense_claim/expense_claim.js
@@ -147,6 +147,15 @@ frappe.ui.form.on("Expense Claim", {
 				]
 			};
 		});
+		frm.set_query("expense_approver", function() {
+			return {
+				query: "erpnext.hr.doctype.department_approver.department_approver.get_approvers",
+				filters: {
+					employee: frm.doc.employee,
+					doctype: frm.doc.doctype
+				}
+			};
+		});
 	},
 
 	onload: function(frm) {
@@ -163,15 +172,6 @@ frappe.ui.form.on("Expense Claim", {
 				}
 			});
 		}
-		frm.set_query("expense_approver", function() {
-			return {
-				query: "erpnext.hr.doctype.department_approver.department_approver.get_approvers",
-				filters: {
-					employee: frm.doc.employee,
-					doctype: frm.doc.doctype
-				}
-			};
-		});
 	},
 
 	refresh: function(frm) {

--- a/erpnext/hr/doctype/leave_application/leave_application.js
+++ b/erpnext/hr/doctype/leave_application/leave_application.js
@@ -5,6 +5,19 @@ cur_frm.add_fetch('employee','employee_name','employee_name');
 cur_frm.add_fetch('employee','company','company');
 
 frappe.ui.form.on("Leave Application", {
+	setup: function(frm) {
+		frm.set_query("leave_approver", function() {
+			return {
+				query: "erpnext.hr.doctype.department_approver.department_approver.get_approvers",
+				filters: {
+					employee: frm.doc.employee,
+					doctype: frm.doc.doctype
+				}
+			};
+		}); 
+
+		frm.set_query("employee", erpnext.queries.employee);
+	},
 	onload: function(frm) {
 		if (!frm.doc.posting_date) {
 			frm.set_value("posting_date", frappe.datetime.get_today());
@@ -22,17 +35,6 @@ frappe.ui.form.on("Leave Application", {
 				}
 			});
 		}
-		frm.set_query("leave_approver", function() {
-			return {
-				query: "erpnext.hr.doctype.department_approver.department_approver.get_approvers",
-				filters: {
-					employee: frm.doc.employee,
-					doctype: frm.doc.doctype
-				}
-			};
-		}); 
-
-		frm.set_query("employee", erpnext.queries.employee);
 	},
 
 	validate: function(frm) {

--- a/erpnext/hr/report/employee_leave_balance/employee_leave_balance.py
+++ b/erpnext/hr/report/employee_leave_balance/employee_leave_balance.py
@@ -39,8 +39,7 @@ def get_data(filters, leave_types):
 	
 	data = []
 	for employee in active_employees:
-		leave_approvers = [l.leave_approver for l in frappe.db.sql("""select leave_approver from `tabEmployee Leave Approver` where parent = %s""",
-							(employee.name),as_dict=True)]
+		leave_approvers = get_approvers(employee.department)
 		if (len(leave_approvers) and user in leave_approvers) or (user in ["Administrator", employee.user_id]) or ("HR Manager" in frappe.get_roles(user)):
 			row = [employee.name, employee.employee_name, employee.department]
 
@@ -54,7 +53,25 @@ def get_data(filters, leave_types):
 					allocation_records_based_on_to_date.get(employee.name, frappe._dict()))
 
 				row += [leaves_taken, closing]
-			
+
 			data.append(row)
 		
 	return data
+
+def get_approvers(department):
+	if not department:
+		return []
+
+	approvers = []
+	# get current department and all its child
+	department_details = frappe.db.get_value("Department", {"name": department}, ["lft", "rgt"], as_dict=True)
+	department_list = frappe.db.sql("""select name from `tabDepartment`
+		where lft >= %s and rgt <= %s order by lft desc
+		""", (department_details.lft, department_details.rgt), as_list = True)
+
+	# retrieve approvers list from current department and from its subsequent child departments
+	for d in department_list:
+		approvers.extend([l.leave_approver for l in frappe.db.sql("""select approver from `tabDepartment Approver` \
+			where parent = %s and parentfield = 'leave_approver'""", (d), as_dict=True)])
+
+	return approvers


### PR DESCRIPTION
Issue:-
![leave-app-report-issue](https://user-images.githubusercontent.com/11695402/40266092-a48c5b12-5b62-11e8-8abe-0b9624484341.gif)

Fix:-
![leave-app-report-fix](https://user-images.githubusercontent.com/11695402/40266093-a591b142-5b62-11e8-9cf9-5d9c85738bc5.gif)

Summary:-
1. Set query to filter leave approver wasn't working when kept in onload function. Moved to setup seems to fix it.
2. Employee Leave Balance report throws error as its query referred to a child table that was removed. Fixed it by fetching approvers based on department.

