### PR TITLE
[fix] Set null values to '0' before changing column type

### DIFF
--- a/erpnext/patches/v11_0/rename_field_max_days_allowed.py
+++ b/erpnext/patches/v11_0/rename_field_max_days_allowed.py
@@ -1,7 +1,10 @@
 import frappe
-from frappe.model.utils.rename_field import rename_field
 
 def execute():
-	frappe.reload_doc("hr", "doctype", "leave_type")
+	frappe.db.sql("""
+		UPDATE `tabLeave Type`
+		SET max_days_allowed = '0'
+		WHERE trim(coalesce(max_days_allowed, '')) = ''
+	""")
 	frappe.db.sql_ddl("""ALTER table `tabLeave Type` modify max_days_allowed int(8) NOT NULL""")
-	rename_field("Leave Type", "max_days_allowed", "max_continuous_days_allowed") 
+


### PR DESCRIPTION

```
  File "/Users/farisansari/frappe-bench2/apps/frappe/frappe/model/db_schema.py", line 158, in sync
    self.alter()
  File "/Users/farisansari/frappe-bench2/apps/frappe/frappe/model/db_schema.py", line 358, in alter
    raise e
pymysql.err.DataError: (1265, u"Data truncated for column 'max_days_allowed' at row 2")
```