### PR TITLE
Minor fixes

### DIFF
--- a/erpnext/hr/doctype/daily_work_summary/daily_work_summary.py
+++ b/erpnext/hr/doctype/daily_work_summary/daily_work_summary.py
@@ -112,6 +112,6 @@ def get_user_emails_from_group(group):
 	if isinstance(group_doc, str):
 		group_doc = frappe.get_doc('Daily Work Summary Group', group)
 
-	emails = [d.email for d in group_doc.users if frappe.db.get_value("User", d.email, "enabled")]
+	emails = [d.email for d in group_doc.users if frappe.db.get_value("User", d.user, "enabled")]
 
 	return emails

--- a/erpnext/hr/doctype/leave_application/leave_application.py
+++ b/erpnext/hr/doctype/leave_application/leave_application.py
@@ -127,7 +127,7 @@ class LeaveApplication(Document):
 					frappe.db.sql("""update `tabAttendance` set status = %s, leave_type = %s\
 						where name = %s""",(status, self.leave_type, d.name))
 
-			elif self.to_date <= nowdate():
+			elif getdate(self.to_date) <= getdate(nowdate()):
 				for dt in daterange(getdate(self.from_date), getdate(self.to_date)):
 					date = dt.strftime("%Y-%m-%d")
 					if not date == self.half_day_date:

--- a/erpnext/hr/doctype/leave_application/leave_application_dashboard.html
+++ b/erpnext/hr/doctype/leave_application/leave_application_dashboard.html
@@ -10,17 +10,16 @@
 			<th style="width: 20%" class="text-right">{{ __("Pending Leaves") }}</th>
 			<th style="width: 20%" class="text-right">{{ __("Available Leaves") }}</th>
 		</tr>
-		<!-- <p> {{data["Sick Leave"][0]["leaves_taken"]}}</p> -->
-		
+
 	</thead>
 	<tbody>
 		{% for(const [key, value] of Object.entries(data)) { %}
 			<tr>
 				<td> {%= key %} </td>
-				<td> {%= value["total_leaves"] %} </td>
-				<td> {%= value["leaves_taken"] %} </td>
-				<td> {%= value["pending_leaves"] %} </td>
-				<td> {%= value["remaining_leaves"] %} </td>
+				<td class="text-right"> {%= value["total_leaves"] %} </td>
+				<td class="text-right"> {%= value["leaves_taken"] %} </td>
+				<td class="text-right"> {%= value["pending_leaves"] %} </td>
+				<td class="text-right"> {%= value["remaining_leaves"] %} </td>
 			</tr>
 		{% } %}
 	</tbody>


### PR DESCRIPTION
- Parse date using `getdate` to avoid TypeError while comparison (Leave Application)
- Use `user` instead of `email` to get value from user table (Daily Work Summary)
- Fix alignment of application dashboard table text (Leave Application)

Before
<img width="981" alt="screen shot 2018-05-25 at 5 38 07 pm" src="https://user-images.githubusercontent.com/13928957/40543537-837630d0-6042-11e8-8e92-09a444064626.png">
  After
<img width="978" alt="screen shot 2018-05-25 at 5 42 01 pm" src="https://user-images.githubusercontent.com/13928957/40543665-02eaa6ac-6043-11e8-821c-5ddcc97b72ee.png">
