### PR TITLE
[fix] add ignore validate flag

### DIFF
--- a/erpnext/patches/v11_0/rename_supplier_type_to_supplier_group.py
+++ b/erpnext/patches/v11_0/rename_supplier_type_to_supplier_group.py
@@ -25,10 +25,13 @@ def build_tree():
 		where is_group = 0""".format(_('All Supplier Groups')))
 
 	if not frappe.db.exists("Supplier Group", _('All Supplier Groups')):
-		frappe.get_doc({
+		supplier_group = frappe.get_doc({
 			'doctype': 'Supplier Group',
 			'supplier_group_name': _('All Supplier Groups'),
-			'is_group': 1
-		}).insert(ignore_permissions=True)
+			'is_group': 1,
+			'parent_supplier_group': ''
+		})
+		supplier_group.flags.ignore_validate=True
+		supplier_group.insert(ignore_permissions=True)
 
 	rebuild_tree("Supplier Group", "parent_supplier_group")


### PR DESCRIPTION
### Error while `bench update` or `bench migrate`:
```
Executing erpnext.patches.v11_0.rename_supplier_type_to_supplier_group in site1.local (1bd3e0294da19198)
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 97, in <module>
    main()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 25, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/site.py", line 222, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py", line 39, in migrate
    frappe.modules.patch_handler.run_all()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 29, in run_all
    if not run_single(patchmodule = patch):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 63, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 83, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/patches/v11_0/rename_supplier_type_to_supplier_group.py", line 21, in execute
    build_tree()
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/patches/v11_0/rename_supplier_type_to_supplier_group.py", line 32, in build_tree
    }).insert(ignore_permissions=True)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 249, in insert
    self.run_post_save_methods()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 898, in run_post_save_methods
    self.run_method("on_update")
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 765, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1040, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1023, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 759, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/setup/doctype/supplier_group/supplier_group.py", line 19, in on_update
    self.update_nsm_model()
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/setup/doctype/supplier_group/supplier_group.py", line 16, in update_nsm_model
    frappe.utils.nestedset.update_nsm(self)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/nestedset.py", line 40, in update_nsm
    update_add_node(doc, p or '', pf)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/nestedset.py", line 64, in update_add_node
    validate_loop(doc.doctype, doc.name, left, right)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/nestedset.py", line 181, in validate_loop
    frappe.throw(_("Item cannot be added to its own descendents"), NestedSetRecursionError)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 327, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red')
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 313, in msgprint
    _raise_exception()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 286, in _raise_exception
    raise raise_exception(msg)
frappe.utils.nestedset.NestedSetRecursionError: Item cannot be added to its own descendents

```
---

### Reason:
While creating Supplier Group, in validate method,the system tries to set parent group.
https://github.com/frappe/erpnext/blob/develop/erpnext/setup/doctype/supplier_group/supplier_group.py#L11
```

def validate(self):
    if not self.parent_supplier_group:
        self.parent_supplier_group = get_root_of("Supplier Group")
```

- As in the previous version, there is no tree for Supplier Type, the system tring to set Distributor as parent group to All Supplier Groups. 
- In patch, at line no 24, we set parent_supplier_group as **All Supplier Groups**.

Due to this patch is breaking by rasing exception `frappe.utils.nestedset.NestedSetRecursionError: Item cannot be added to its own descendents`

---
### Fix:

To fix the issue, in patch, ignoring setting parent while creating parent group for Supplier Group.

---
### After Fix:
<img width="564" alt="screen shot 2018-05-26 at 6 22 11 pm" src="https://user-images.githubusercontent.com/3784093/40576364-9b606b90-6112-11e8-9a6b-bf79ebe5e4dc.png">
