### PR TITLE
Sales Payment Summart Report Improvement

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -341,9 +341,8 @@ class SalesInvoice(SellingController):
 			# set pos values in items
 			for item in self.get("items"):
 				if item.get('item_code'):
-					for fname, val in get_pos_profile_item_details(pos,
-						iteritems(frappe._dict(item.as_dict()), pos)):
-
+					profile_details = get_pos_profile_item_details(pos, frappe._dict(item.as_dict()), pos)
+					for fname, val in iteritems(profile_details):
 						if (not for_validate) or (for_validate and not item.get(fname)):
 							item.set(fname, val)
 

--- a/erpnext/accounts/report/sales_payment_summary/sales_payment_summary.py
+++ b/erpnext/accounts/report/sales_payment_summary/sales_payment_summary.py
@@ -88,14 +88,21 @@ def get_sales_payment_data(filters, columns):
 			data.append(row)
 	return data
 
+
 def get_conditions(filters):
 	conditions = "1=1"
-	if filters.get("from_date"): conditions += " and a.posting_date >= %(from_date)s"
-	if filters.get("to_date"): conditions += " and a.posting_date <= %(to_date)s"
-	if filters.get("company"): conditions += " and a.company=%(company)s"
-	if filters.get("customer"): conditions += " and a.customer = %(customer)s"
-	if filters.get("owner"): conditions += " and a.owner = %(owner)s"
-	if filters.get("is_pos"): conditions += " and a.is_pos = %(is_pos)s"
+	if filters.get("from_date"):
+		conditions += " and a.posting_date >= %(from_date)s"
+	if filters.get("to_date"):
+		conditions += " and a.posting_date <= %(to_date)s"
+	if filters.get("company"):
+		conditions += " and a.company=%(company)s"
+	if filters.get("customer"):
+		conditions += " and a.customer = %(customer)s"
+	if filters.get("owner"):
+		conditions += " and a.owner = %(owner)s"
+	if filters.get("is_pos"):
+		conditions += " and a.is_pos = %(is_pos)s"
 	return conditions
 
 
@@ -177,12 +184,14 @@ def get_mode_of_payments(filters):
 			mode_of_payments.setdefault(d["owner"]+cstr(d["posting_date"]), []).append(d.mode_of_payment)
 	return mode_of_payments
 
+
 def get_invoices(filters):
 	conditions = get_conditions(filters)
 	return frappe.db.sql("""select a.name
 		from `tabSales Invoice` a
 		where a.docstatus = 1 and {conditions}""".format(conditions=conditions),
 		filters, as_dict=1)
+
 
 def get_mode_of_payment_details(filters):
 	mode_of_payment_details = {}

--- a/erpnext/accounts/report/sales_payment_summary/sales_payment_summary.py
+++ b/erpnext/accounts/report/sales_payment_summary/sales_payment_summary.py
@@ -8,8 +8,8 @@ from frappe.utils import cstr
 
 def execute(filters=None):
 	columns, data = [], []
-	columns=get_columns()
-	data=get_sales_payment_data(filters, columns)
+	columns = get_columns(filters)
+	data = get_pos_sales_payment_data(filters) if filters.get('is_pos') else get_sales_payment_data(filters, columns)
 	return columns, data
 
 
@@ -24,6 +24,21 @@ def get_pos_columns():
 		_("Warehouse") + ":Data:200",
 		_("Cost Center") + ":Data:200"
 	]
+
+
+def get_columns(filters):
+	if filters.get('is_pos'):
+		return get_pos_columns()
+	else:
+		return [
+			_("Date") + ":Date:80",
+			_("Owner") + ":Data:200",
+			_("Payment Mode") + ":Data:240",
+			_("Sales and Returns") + ":Currency/currency:120",
+			_("Taxes") + ":Currency/currency:120",
+			_("Payments") + ":Currency/currency:120",
+			_("Warehouse") + ":Data:200"
+		]
 
 
 def get_pos_sales_payment_data(filters):
@@ -42,49 +57,6 @@ def get_pos_sales_payment_data(filters):
 
 	return data
 
-
-def get_pos_invoice_data(filters):
-	conditions = get_conditions(filters)
-	result = frappe.db.sql(''
-						   'SELECT '
-						   'posting_date, owner, sum(net_total) as "net_total", sum(total_taxes) as "total_taxes", '
-						   'sum(paid_amount) as "paid_amount", sum(outstanding_amount) as "outstanding_amount", '
-						   'mode_of_payment, warehouse, cost_center '
-						   'FROM ('
-						   'SELECT '
-						   'parent, item_code, sum(amount) as "base_total", warehouse, cost_center '
-						   'from `tabSales Invoice Item`  group by parent'
-						   ') t1 '
-						   'left join '
-						   '(select parent, mode_of_payment from `tabSales Invoice Payment` group by parent) t3 '
-						   'on (t3.parent = t1.parent) '
-						   'JOIN ('
-						   'SELECT '
-						   'docstatus, company, is_pos, name, posting_date, owner, sum(base_total) as "base_total", '
-						   'sum(net_total) as "net_total", sum(total_taxes_and_charges) as "total_taxes", '
-						   'sum(base_paid_amount) as "paid_amount", sum(outstanding_amount) as "outstanding_amount" '
-						   'FROM `tabSales Invoice` '
-						   'GROUP BY name'
-						   ') a '
-						   'ON ('
-						   't1.parent = a.name and t1.base_total = a.base_total) '
-						   'WHERE a.docstatus = 1'
-						   ' AND {conditions} '
-						   'GROUP BY '
-						   'owner, posting_date, warehouse'.format(conditions=conditions), filters, as_dict=1
-						   )
-	return result
-
-
-def get_columns():
-	return [
-		_("Date") + ":Date:80",
-		_("Owner") + ":Data:200",
-		_("Payment Mode") + ":Data:240",
-		_("Sales and Returns") + ":Currency/currency:120",
-		_("Taxes") + ":Currency/currency:120",
-		_("Payments") + ":Currency/currency:120"
-	]
 
 def get_sales_payment_data(filters, columns):
 	data = []
@@ -126,6 +98,40 @@ def get_conditions(filters):
 	if filters.get("is_pos"): conditions += " and a.is_pos = %(is_pos)s"
 	return conditions
 
+
+def get_pos_invoice_data(filters):
+	conditions = get_conditions(filters)
+	result = frappe.db.sql(''
+						   'SELECT '
+						   'posting_date, owner, sum(net_total) as "net_total", sum(total_taxes) as "total_taxes", '
+						   'sum(paid_amount) as "paid_amount", sum(outstanding_amount) as "outstanding_amount", '
+						   'mode_of_payment, warehouse, cost_center '
+						   'FROM ('
+						   'SELECT '
+						   'parent, item_code, sum(amount) as "base_total", warehouse, cost_center '
+						   'from `tabSales Invoice Item`  group by parent'
+						   ') t1 '
+						   'left join '
+						   '(select parent, mode_of_payment from `tabSales Invoice Payment` group by parent) t3 '
+						   'on (t3.parent = t1.parent) '
+						   'JOIN ('
+						   'SELECT '
+						   'docstatus, company, is_pos, name, posting_date, owner, sum(base_total) as "base_total", '
+						   'sum(net_total) as "net_total", sum(total_taxes_and_charges) as "total_taxes", '
+						   'sum(base_paid_amount) as "paid_amount", sum(outstanding_amount) as "outstanding_amount" '
+						   'FROM `tabSales Invoice` '
+						   'GROUP BY name'
+						   ') a '
+						   'ON ('
+						   't1.parent = a.name and t1.base_total = a.base_total) '
+						   'WHERE a.docstatus = 1'
+						   ' AND {conditions} '
+						   'GROUP BY '
+						   'owner, posting_date, warehouse'.format(conditions=conditions), filters, as_dict=1
+						   )
+	return result
+
+
 def get_sales_invoice_data(filters):
 	conditions = get_conditions(filters)
 	return frappe.db.sql("""
@@ -141,6 +147,7 @@ def get_sales_invoice_data(filters):
 			group by
 			a.owner, a.posting_date
 	""".format(conditions=conditions), filters, as_dict=1)
+
 
 def get_mode_of_payments(filters):
 	mode_of_payments = {}


### PR DESCRIPTION
### Problem
Initially, the report was not fetching warehouse and cost center data. For non-POS invoices, this is understandable as there is no error prone way to correctly determine `paid_amount` considering the fact that the items on an invoice can be fetched from different warehouses and charged to different cost centers. However, for POS invoices, warehouse and cost center information are fetched from the POS profile therefore all items on a POS invoices are guaranteed to be linked to one warehouse and one cost center. This however was not implemented

### Solution
This PR adds the ability to:
- Fetch warehouse information for POS invoices only
- Fetch cost center information for POS invoices only
- Consequently, users can sort by cost center and warehouse

![screenshot-2018-5-27 sales invoice](https://user-images.githubusercontent.com/818803/40591137-5bcdbc0c-6203-11e8-808d-0387df6b1254.png)

![peek 2018-05-27 23-14](https://user-images.githubusercontent.com/818803/40591157-ca1c4be2-6203-11e8-9656-35f3800d9a7e.gif)
