### PR TITLE
Update status in Purchase Receipt

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -502,3 +502,4 @@ erpnext.patches.v10_0.fix_reserved_qty_for_sub_contract
 erpnext.patches.v10_0.taxes_issue_with_pos
 erpnext.patches.v10_0.set_qty_in_transactions_based_on_serial_no_input
 erpnext.patches.v10_0.show_leaves_of_all_department_members_in_calendar
+erpnext.patches.v10_0.update_status_in_purchase_receipt

--- a/erpnext/patches/v10_0/update_status_in_purchase_receipt.py
+++ b/erpnext/patches/v10_0/update_status_in_purchase_receipt.py
@@ -1,0 +1,7 @@
+import frappe
+
+def execute():
+	frappe.reload_doc("stock", "doctype", "purchase_receipt")
+	frappe.db.sql('''
+		UPDATE `tabPurchase Receipt` SET status = "Completed" WHERE per_billed = 100 AND docstatus = 1
+	''')

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -120,6 +120,8 @@ class PurchaseReceipt(BuyingController):
 		self.update_prevdoc_status()
 		if self.per_billed < 100:
 			self.update_billing_status()
+		else:
+			self.status = "Completed"
 
 		# Updating stock ledger should always be called after updating prevdoc status,
 		# because updating ordered qty, reserved_qty_for_subcontract in bin


### PR DESCRIPTION
Whenever we create a new Purchase Order, and submit it, make a Purchase Invoice from it, submit it, and then make a Purchase Receipt, the status of the Purchase Receipt is as shown below, on submission.

<img width="593" alt="screen shot 2018-05-28 at 3 47 36 pm" src="https://user-images.githubusercontent.com/17617465/40613004-6a2e2fb0-629a-11e8-8996-8d54177a13ce.png">

Closes: #12726 