### PR TITLE
[Minor] Fix Party dashboard Heatmap

### DIFF
--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -404,10 +404,21 @@ def get_timeline_data(doctype, name):
 	from frappe.desk.form.load import get_communication_data
 
 	out = {}
+	fields = 'date(creation), count(name)'
+	after = add_years(None, -1).strftime('%Y-%m-%d')
+	group_by='group by date(creation)'
+
 	data = get_communication_data(doctype, name,
-		fields = 'date(creation), count(name)',
-		after = add_years(None, -1).strftime('%Y-%m-%d'),
-		group_by='group by date(creation)', as_dict=False)
+		fields=fields, after=after, group_by=group_by, as_dict=False)
+
+	# fetch and append data from Activity Log
+	data += frappe.db.sql("""select {fields}
+		from `tabActivity Log`
+		where reference_doctype='{doctype}' and reference_name='{name}'
+		and status!='Success' and creation > {after}
+		{group_by} order by creation desc
+		""".format(doctype=doctype, name=name, fields=fields,
+			group_by=group_by, after=after), as_dict=False)
 
 	timeline_items = dict(data)
 


### PR DESCRIPTION
Issue:-
<img width="1057" alt="screen shot 2018-05-30 at 10 51 40 am" src="https://user-images.githubusercontent.com/11695402/40700563-acadea5c-63f7-11e8-9379-538b89da89fe.png">
Fix:-
<img width="1055" alt="screen shot 2018-05-30 at 10 51 53 am" src="https://user-images.githubusercontent.com/11695402/40700564-adbf0ba6-63f7-11e8-98e6-b55aa730b54d.png">

A complete set of timeline data was missed - 'Updated' type data as it was being stored in Activity Log and not in Communication anymore.
