### PR TITLE
[minor][fix] fix query syntax

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/pos.py
+++ b/erpnext/accounts/doctype/sales_invoice/pos.py
@@ -153,14 +153,14 @@ def update_tax_table(doc):
 
 def get_items_list(pos_profile, company):
 	cond = ""
-	args_list = []
+	args_list = [company]
 	if pos_profile.get('item_groups'):
 		# Get items based on the item groups defined in the POS profile
 		for d in pos_profile.get('item_groups'):
 			args_list.extend([d.name for d in get_child_nodes('Item Group', d.item_group)])
 		cond = "and i.item_group in (%s)" % (', '.join(['%s'] * len(args_list)))
 		
-		args_list = [company] + args_list
+		args_list += args_list
 
 	return frappe.db.sql("""
 		select

--- a/erpnext/accounts/doctype/sales_invoice/pos.py
+++ b/erpnext/accounts/doctype/sales_invoice/pos.py
@@ -153,14 +153,13 @@ def update_tax_table(doc):
 
 def get_items_list(pos_profile, company):
 	cond = ""
-	args_list = [company]
+	args_list = []
 	if pos_profile.get('item_groups'):
 		# Get items based on the item groups defined in the POS profile
 		for d in pos_profile.get('item_groups'):
 			args_list.extend([d.name for d in get_child_nodes('Item Group', d.item_group)])
-		cond = "and i.item_group in (%s)" % (', '.join(['%s'] * len(args_list)))
-		
-		args_list += args_list
+		if args_list:
+			cond = "and i.item_group in (%s)" % (', '.join(['%s'] * len(args_list)))
 
 	return frappe.db.sql("""
 		select
@@ -172,7 +171,7 @@ def get_items_list(pos_profile, company):
 		where
 			i.disabled = 0 and i.has_variants = 0 and i.is_sales_item = 1
 			{cond}
-		""".format(cond=cond), tuple(args_list), as_dict=1)
+		""".format(cond=cond), tuple([company] + args_list), as_dict=1)
 
 
 def get_item_groups(pos_profile):


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/opt/bench/erpnext/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.handler.handle()
  File "/opt/bench/erpnext/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/opt/bench/erpnext/apps/frappe/frappe/handler.py", line 53, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/opt/bench/erpnext/apps/frappe/frappe/__init__.py", line 942, in call
    return fn(*args, **newargs)
  File "/opt/bench/erpnext/apps/erpnext/erpnext/accounts/doctype/sales_invoice/pos.py", line 42, in get_pos_data
    items_list = get_items_list(pos_profile, doc.company)
  File "/opt/bench/erpnext/apps/erpnext/erpnext/accounts/doctype/sales_invoice/pos.py", line 175, in get_items_list
    """.format(cond=cond), tuple(args_list), as_dict=1)
  File "/opt/bench/erpnext/apps/frappe/frappe/database.py", line 209, in sql
    self._cursor.execute(query)
  File "/opt/bench/erpnext/env/local/lib/python2.7/site-packages/pymysql/cursors.py", line 170, in execute
    result = self._query(query)
  File "/opt/bench/erpnext/env/local/lib/python2.7/site-packages/pymysql/cursors.py", line 328, in _query
    conn.query(q)
  File "/opt/bench/erpnext/env/local/lib/python2.7/site-packages/pymysql/connections.py", line 893, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/opt/bench/erpnext/env/local/lib/python2.7/site-packages/pymysql/connections.py", line 1103, in _read_query_result
    result.read()
  File "/opt/bench/erpnext/env/local/lib/python2.7/site-packages/pymysql/connections.py", line 1396, in read
    first_packet = self.connection._read_packet()
  File "/opt/bench/erpnext/env/local/lib/python2.7/site-packages/pymysql/connections.py", line 1059, in _read_packet
    packet.check_error()
  File "/opt/bench/erpnext/env/local/lib/python2.7/site-packages/pymysql/connections.py", line 384, in check_error
    err.raise_mysql_exception(self._data)
  File "/opt/bench/erpnext/env/local/lib/python2.7/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
    raise errorclass(errno, errval)
ProgrammingError: (1064, u"You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '%s\n\t\twhere\n\t\t\ti.disabled = 0 and i.has_variants = 0 and i.is_sales_item = 1' at line 6")
```