### PR TITLE
[Fix] Validate items for saleable, purchaseable or subcontractable in transactions

### DIFF
--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -340,8 +340,8 @@ class SellingController(StockController):
 
 	def validate_items(self):
 		# validate items to see if they have is_sales_item enabled
-		from erpnext.controllers.buying_controller import items_validate
-		items_validate(self, "and is_sales_item=0", "Non saleable")
+		from erpnext.controllers.buying_controller import validate_item_type
+		validate_item_type(self, "is_sales_item", "sales")
 
 def check_active_sales_items(obj):
 	for d in obj.get("items"):

--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -35,6 +35,7 @@ class SellingController(StockController):
 
 	def validate(self):
 		super(SellingController, self).validate()
+		self.validate_items()
 		self.validate_max_discount()
 		self.validate_selling_price()
 		self.set_qty_as_per_stock_uom()
@@ -336,6 +337,11 @@ class SellingController(StockController):
 			if sales_orders:
 				po_nos = frappe.get_all('Sales Order', 'po_no', filters = {'name': ('in', sales_orders)})
 				self.po_no = ', '.join(list(set([d.po_no for d in po_nos if d.po_no])))
+
+	def validate_items(self):
+		# validate items to see if they have is_sales_item enabled
+		from erpnext.controllers.buying_controller import items_validate
+		items_validate(self, "and is_sales_item=0", "Non saleable")
 
 def check_active_sales_items(obj):
 	for d in obj.get("items"):


### PR DESCRIPTION
![validate-items](https://user-images.githubusercontent.com/11695402/40840717-7b49e130-65c5-11e8-8e7d-ea851a8f6838.gif)

Summary:- Items that have `is_sales_item` unchecked are not shown in dropdown but can be manually entered and transactions can be created against it. Same goes for `is_purchase_item` & `is_subcontract_item`. Validation for such provision added.