### PR TITLE
[patch][new] rename old members as per naming series

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -544,3 +544,4 @@ erpnext.patches.v11_0.refactor_erpnext_shopify
 erpnext.patches.v11_0.move_item_defaults_to_child_table_for_multicompany
 erpnext.patches.v11_0.rename_overproduction_percent_field
 erpnext.patches.v10_0.update_status_in_purchase_receipt
+erpnext.patches.v11_0.rename_members_with_naming_series

--- a/erpnext/patches/v11_0/rename_members_with_naming_series.py
+++ b/erpnext/patches/v11_0/rename_members_with_naming_series.py
@@ -1,0 +1,10 @@
+import frappe
+
+def execute():
+	old_named_members = frappe.get_all("Member", filters = {"name": ("not like", "MEM-%")})
+	correctly_named_members = frappe.get_all("Member", filters = {"name": ("like", "MEM-%")})
+	current_index = len(correctly_named_members)
+
+	for member in old_named_members:
+		current_index += 1
+		frappe.rename_doc("Member", member["name"], "MEM-" + str(current_index).zfill(5))


### PR DESCRIPTION
Naming Series had been introduced for the `Member` doctype, but looks like old records weren't updated. _Observed at erpnext.org_

<img width="1197" alt="screen shot 2018-06-04 at 2 09 13 pm" src="https://user-images.githubusercontent.com/5196925/40907437-7aee5098-6801-11e8-973c-23da075f4da7.png">

**After Patch:**
<img width="748" alt="screen shot 2018-06-04 at 2 06 39 pm" src="https://user-images.githubusercontent.com/5196925/40907457-880dc952-6801-11e8-8b4b-5f879011225d.png">

<img width="1171" alt="screen shot 2018-06-04 at 2 08 03 pm" src="https://user-images.githubusercontent.com/5196925/40907508-b482e652-6801-11e8-9cf9-8dc46afdb86f.png">

Will be glad if anyone can suggest an optimization.

