### PR TITLE
Fix error while saving student doc

### DIFF
--- a/erpnext/education/doctype/student/student.py
+++ b/erpnext/education/doctype/student/student.py
@@ -26,12 +26,12 @@ class Student(Document):
 			if not meta.issingle:
 				if "student_name" in [f.fieldname for f in meta.fields]:
 					frappe.db.sql("""UPDATE `tab{0}` set student_name = %s where {1} = %s"""
-						.format(d, linked_doctypes[d]["fieldname"]),(self.title, self.name))
+						.format(d, linked_doctypes[d]["fieldname"][0]),(self.title, self.name))
 
 				if "child_doctype" in linked_doctypes[d].keys() and "student_name" in \
 					[f.fieldname for f in frappe.get_meta(linked_doctypes[d]["child_doctype"]).fields]:
 					frappe.db.sql("""UPDATE `tab{0}` set student_name = %s where {1} = %s"""
-						.format(linked_doctypes[d]["child_doctype"], linked_doctypes[d]["fieldname"]),(self.title, self.name))
+						.format(linked_doctypes[d]["child_doctype"], linked_doctypes[d]["fieldname"][0]),(self.title, self.name))
 
 	def check_unique(self):
 		"""Validates if the Student Applicant is Unique"""


### PR DESCRIPTION
```
Traceback (most recent call last):

  File "/Users/speedy/frappe-bench/apps/frappe/frappe/model/document.py", line 765, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/Users/speedy/frappe-bench/apps/frappe/frappe/model/document.py", line 1040, in composer
    return composed(self, method, *args, **kwargs)
  File "/Users/speedy/frappe-bench/apps/frappe/frappe/model/document.py", line 1023, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/Users/speedy/frappe-bench/apps/frappe/frappe/model/document.py", line 759, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/Users/speedy/frappe-bench/apps/erpnext/erpnext/education/doctype/student/student.py", line 20, in validate
    self.update_student_name_in_linked_doctype()
  File "/Users/speedy/frappe-bench/apps/erpnext/erpnext/education/doctype/student/student.py", line 30, in update_student_name_in_linked_doctype
    .format(d, linked_doctypes[d]["fieldname"]),(self.title, self.name))
  File "/Users/speedy/frappe-bench/apps/frappe/frappe/database.py", line 199, in sql
    self._cursor.execute(query, values)
  File "/Users/speedy/frappe-bench/env/lib/python2.7/site-packages/pymysql/cursors.py", line 165, in execute
    result = self._query(query)
  File "/Users/speedy/frappe-bench/env/lib/python2.7/site-packages/pymysql/cursors.py", line 321, in _query
    conn.query(q)
  File "/Users/speedy/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 860, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/Users/speedy/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1061, in _read_query_result
    result.read()
  File "/Users/speedy/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1349, in read
    first_packet = self.connection._read_packet()
  File "/Users/speedy/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1018, in _read_packet
    packet.check_error()
  File "/Users/speedy/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 384, in check_error
    err.raise_mysql_exception(self._data)
  File "/Users/speedy/frappe-bench/env/lib/python2.7/site-packages/pymysql/err.py", line 107, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.ProgrammingError: (1064, u"You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near '[u'student'] = '_T-Student-00001'' at line 1")
```