### PR TITLE
[Minor] Fix invoice creation tool issue

### DIFF
--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -467,7 +467,12 @@ class BuyingController(StockController):
 
 def validate_item_type(doc, fieldname, message):
 	# iterate through items and check if they are valid sales or purchase items
-	items = [d.item_code for d in doc.items]
+	items = [d.item_code for d in doc.items if d.item_code]
+
+	# No validation check inase of creating transaction using 'Opening Invoice Creation Tool'
+	if not items:
+		return
+
 	item_list = ", ".join(["'%s'" % frappe.db.escape(d) for d in items])
 
 	invalid_items = [d[0] for d in frappe.db.sql("""


### PR DESCRIPTION
![invoice-creation-tool-issue](https://user-images.githubusercontent.com/11695402/40912903-8da7d31c-6810-11e8-9861-5492403e745c.gif)

Item validation for its type was merged here - https://github.com/frappe/erpnext/pull/14316 which did not account for creating transaction through invoice creation tool.
While creating using tool, there's no item_code filled in the child table. Hence error was thrown while joining items item_code.