### PR TITLE
Fix ISO standard references in Agriculture

### DIFF
--- a/erpnext/agriculture/doctype/crop_cycle/crop_cycle.json
+++ b/erpnext/agriculture/doctype/crop_cycle/crop_cycle.json
@@ -15,6 +15,7 @@
  "fields": [
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -41,11 +42,12 @@
    "reqd": 1, 
    "search_index": 0, 
    "set_only_once": 0, 
-   "translatable": 0,
+   "translatable": 0, 
    "unique": 0
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -73,11 +75,12 @@
    "reqd": 1, 
    "search_index": 0, 
    "set_only_once": 0, 
-   "translatable": 0,
+   "translatable": 0, 
    "unique": 0
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -105,11 +108,12 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
-   "translatable": 0,
+   "translatable": 0, 
    "unique": 0
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -138,11 +142,12 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
-   "translatable": 0,
+   "translatable": 0, 
    "unique": 0
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -168,11 +173,12 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
-   "translatable": 0,
+   "translatable": 0, 
    "unique": 0
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -201,11 +207,12 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
-   "translatable": 0,
+   "translatable": 0, 
    "unique": 0
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -231,11 +238,12 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
-   "translatable": 0,
+   "translatable": 0, 
    "unique": 0
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -264,16 +272,17 @@
    "reqd": 1, 
    "search_index": 0, 
    "set_only_once": 0, 
-   "translatable": 0,
+   "translatable": 0, 
    "unique": 0
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
    "columns": 0, 
-   "fetch_from": "project.expected_end_date",
+   "fetch_from": "project.expected_end_date", 
    "fieldname": "end_date", 
    "fieldtype": "Data", 
    "hidden": 0, 
@@ -297,11 +306,12 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
-   "translatable": 0,
+   "translatable": 0, 
    "unique": 0
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -327,16 +337,17 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
-   "translatable": 0,
+   "translatable": 0, 
    "unique": 0
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
    "columns": 0, 
-   "fieldname": "iso_8016_standard", 
+   "fieldname": "iso_8601_standard", 
    "fieldtype": "Check", 
    "hidden": 0, 
    "ignore_user_permissions": 0, 
@@ -345,7 +356,7 @@
    "in_global_search": 0, 
    "in_list_view": 0, 
    "in_standard_filter": 0, 
-   "label": "ISO 8016 standard", 
+   "label": "ISO 8601 standard", 
    "length": 0, 
    "no_copy": 0, 
    "permlevel": 0, 
@@ -358,11 +369,12 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
-   "translatable": 0,
+   "translatable": 0, 
    "unique": 0
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -388,11 +400,12 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
-   "translatable": 0,
+   "translatable": 0, 
    "unique": 0
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -420,11 +433,12 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
-   "translatable": 0,
+   "translatable": 0, 
    "unique": 0
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -450,11 +464,12 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
-   "translatable": 0,
+   "translatable": 0, 
    "unique": 0
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -484,11 +499,12 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
-   "translatable": 0,
+   "translatable": 0, 
    "unique": 0
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -516,11 +532,12 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
-   "translatable": 0,
+   "translatable": 0, 
    "unique": 0
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -546,11 +563,12 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
-   "translatable": 0,
+   "translatable": 0, 
    "unique": 0
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -580,11 +598,12 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
-   "translatable": 0,
+   "translatable": 0, 
    "unique": 0
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -612,11 +631,12 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
-   "translatable": 0,
+   "translatable": 0, 
    "unique": 0
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -645,11 +665,12 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
-   "translatable": 0,
+   "translatable": 0, 
    "unique": 0
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -677,11 +698,12 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
-   "translatable": 0,
+   "translatable": 0, 
    "unique": 0
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 1, 
@@ -709,11 +731,12 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
-   "translatable": 0,
+   "translatable": 0, 
    "unique": 0
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -741,11 +764,12 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
-   "translatable": 0,
+   "translatable": 0, 
    "unique": 0
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -773,11 +797,12 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
-   "translatable": 0,
+   "translatable": 0, 
    "unique": 0
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -805,7 +830,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
-   "translatable": 0,
+   "translatable": 0, 
    "unique": 0
   }
  ], 
@@ -819,7 +844,7 @@
  "issingle": 0, 
  "istable": 0, 
  "max_attachments": 0, 
- "modified": "2018-05-25 22:43:33.462001",
+ "modified": "2018-06-05 03:24:09.054864", 
  "modified_by": "Administrator", 
  "module": "Agriculture", 
  "name": "Crop Cycle", 

--- a/erpnext/docs/user/manual/en/agriculture/crops_and_land/crop_cycle.md
+++ b/erpnext/docs/user/manual/en/agriculture/crops_and_land/crop_cycle.md
@@ -12,7 +12,7 @@ On the top right, click on New to create the first Crop Cycle. A new Crop Cycle 
 * Land Unit: Add a row, and select, Carrot Field 1
 * Crop: Carrot from carrot-top
 * Start Date: Today
-* Leave the ISO 8016 Standard (week count) box unchecked
+* Leave the ISO 8601 Standard (week count) box unchecked
 * Skip the next four fields for Crop Spacing
 
 Save the new Crop Cycle

--- a/erpnext/translations/af.csv
+++ b/erpnext/translations/af.csv
@@ -1012,7 +1012,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1201,7 +1201,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,Waardevermindering Inskrywing
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,Kies asseblief die dokument tipe eerste
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,Kanselleer materiaalbesoeke {0} voordat u hierdie onderhoudsbesoek kanselleer
-DocType: Crop Cycle,ISO 8016 standard,ISO 8016 standaard
+DocType: Crop Cycle,ISO 8601 standard,ISO 8601 standaard
 DocType: Pricing Rule,Rate or Discount,Tarief of Korting
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},Reeksnommer {0} behoort nie aan item {1} nie
 DocType: Purchase Receipt Item Supplied,Required Qty,Vereiste aantal
@@ -3021,7 +3021,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3916,11 +3916,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,Kies &#39;n werknemer om die werknemer vooraf te kry.
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,Kies asseblief &#39;n geldige datum
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,Kies die aard van jou besigheid.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5005,7 +5005,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,Aansoeker Naam
 DocType: Authorization Rule,Customer / Item Name,Kliënt / Item Naam
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","As dit geaktiveer is, sal die laaste aankoopbesonderhede van items nie van vorige aankoopbestellings of aankope ontvang word nie"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 

--- a/erpnext/translations/am.csv
+++ b/erpnext/translations/am.csv
@@ -1020,7 +1020,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1210,7 +1210,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,የእርጅና Entry
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,በመጀመሪያ ስለ ሰነዱ አይነት ይምረጡ
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,ይህ ጥገና ይጎብኙ በመሰረዝ በፊት ይቅር ቁሳዊ ጥገናዎች {0}
-DocType: Crop Cycle,ISO 8016 standard,ISO 8016 ደረጃ
+DocType: Crop Cycle,ISO 8601 standard,ISO 8601 ደረጃ
 DocType: Pricing Rule,Rate or Discount,ደረጃ ወይም ቅናሽ
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},ተከታታይ አይ {0} ንጥል የእርሱ ወገን አይደለም {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,ያስፈልጋል ብዛት
@@ -3033,7 +3033,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3934,11 +3934,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,ሰራተኞቹን ለማሻሻል ሰራተኛን ይምረጡ.
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,እባክዎ ትክክለኛ ቀን ይምረጡ
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,የንግድ ተፈጥሮ ይምረጡ.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5023,7 +5023,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,የአመልካች ስም
 DocType: Authorization Rule,Customer / Item Name,ደንበኛ / ንጥል ስም
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","ከነቃ, የንጥል የመጨረሻው የግዢ ዝርዝሮች ከቀድሞው የግዢ ትዕዛዝ ወይም የግዥ ደረሰኝ አይመጣጩም"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 

--- a/erpnext/translations/ar.csv
+++ b/erpnext/translations/ar.csv
@@ -1020,7 +1020,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1031,19 +1031,19 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 6. Amount: Tax amount.
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
-9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","قالب الضرائب القياسية التي يمكن تطبيقها على جميع عمليات البيع. يمكن أن يحتوي هذا القالب قائمة رؤساء الضريبية، وكذلك غيرهم من رؤساء حساب / الدخل مثل ""شحن""، ""التأمين""، ""معالجة""، وغيرها 
+9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","قالب الضرائب القياسية التي يمكن تطبيقها على جميع عمليات البيع. يمكن أن يحتوي هذا القالب قائمة رؤساء الضريبية، وكذلك غيرهم من رؤساء حساب / الدخل مثل ""شحن""، ""التأمين""، ""معالجة""، وغيرها
 
- #### ملاحظة 
+ #### ملاحظة
 
  معدل الضريبة لك تعريف هنا سوف يكون معدل الضريبة موحد لجميع الأصناف ** **. إذا كانت هناك بنود ** ** التي لها أسعار مختلفة، وأنها يجب أن يضاف في * الضرائب البند ** الجدول في البند ** ** الرئيسي.
 
- #### وصف الأعمدة 
+ #### وصف الأعمدة
 
- 1. نوع الحساب: 
+ 1. نوع الحساب:
  - وهذا يمكن أن يكون على ** صافي إجمالي ** (وهذا هو مجموع المبلغ الأساسي).
  - ** في الصف السابق الكل / المكونات ** (للضرائب أو رسوم التراكمية). إذا قمت بتحديد هذا الخيار، سيتم تطبيق الضريبة كنسبة مئوية من الصف السابق (في الجدول الضرائب) كمية أو المجموع.
  - ** ** الفعلية (كما ذكر).
- 2. رئيس الحساب: حساب دفتر الأستاذ والتي بموجبها سيتم حجز هذه الضريبة 
+ 2. رئيس الحساب: حساب دفتر الأستاذ والتي بموجبها سيتم حجز هذه الضريبة
  3. مركز التكلفة: إذا الضرائب / الرسوم هو الدخل (مثل الشحن) أو حساب فإنه يحتاج إلى أن يتم الحجز مقابل مركز التكلفة.
  4. الوصف: وصف الضريبية (التي ستتم طباعتها في الفواتير / الاقتباس).
  5. معدل: معدل الضريبة.
@@ -1229,7 +1229,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,انخفاض الدخول
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,يرجى تحديد نوع الوثيقة أولاً
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,إلغاء المواد الخاصة بالزيارة {0} قبل إلغاء زيارة الصيانة هذه
-DocType: Crop Cycle,ISO 8016 standard,إسو 8016 القياسية
+DocType: Crop Cycle,ISO 8601 standard,إسو 8601 القياسية
 DocType: Pricing Rule,Rate or Discount,معدل أو خصم
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},رقم المسلسل {0} لا ينتمي إلى البند {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,مطلوب الكمية
@@ -2187,7 +2187,7 @@ DocType: Course Assessment Criteria,Weightage,الوزن
 DocType: Purchase Invoice,Tax Breakup,تفكيك الضرائب
 DocType: Packing Slip,PS-,ملحوظة:
 DocType: Member,Non Profit Member,عضو غير ربحي
-apps/erpnext/erpnext/accounts/doctype/gl_entry/gl_entry.py +67,{0} {1}: Cost Center is required for 'Profit and Loss' account {2}. Please set up a default Cost Center for the Company.,"{0} {1}: مركز التكلفة مطلوب لحساب 'الربح والخسارة' {2}. 
+apps/erpnext/erpnext/accounts/doctype/gl_entry/gl_entry.py +67,{0} {1}: Cost Center is required for 'Profit and Loss' account {2}. Please set up a default Cost Center for the Company.,"{0} {1}: مركز التكلفة مطلوب لحساب 'الربح والخسارة' {2}.
 يرجى إعداد مركز تكلفة افتراضي للشركة."
 DocType: Payment Schedule,Payment Term,مصطلح الدفع
 apps/erpnext/erpnext/selling/doctype/customer/customer.py +160,A Customer Group exists with same name please change the Customer name or rename the Customer Group,يوجد تصنيف مجموعة زبائن بنفس الاسم يرجى تغيير اسم الزبون أو إعادة تسمية مجموعة الزبائن
@@ -3055,7 +3055,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3067,19 +3067,19 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
 9. Consider Tax or Charge for: In this section you can specify if the tax / charge is only for valuation (not a part of total) or only for total (does not add value to the item) or for both.
-10. Add or Deduct: Whether you want to add or deduct the tax.","قالب الضرائب القياسية التي يمكن تطبيقها على جميع المعاملات شراء. يمكن أن يحتوي هذا القالب قائمة رؤساء الضريبية، وكذلك غيرهم من رؤساء حساب مثل ""شحن""، ""التأمين""، ""معالجة""، وغيرها 
+10. Add or Deduct: Whether you want to add or deduct the tax.","قالب الضرائب القياسية التي يمكن تطبيقها على جميع المعاملات شراء. يمكن أن يحتوي هذا القالب قائمة رؤساء الضريبية، وكذلك غيرهم من رؤساء حساب مثل ""شحن""، ""التأمين""، ""معالجة""، وغيرها
 
- #### ملاحظة 
+ #### ملاحظة
 
  معدل الضريبة التي تحدد هنا سوف يكون معدل الضريبة موحد لجميع الأصناف ** **. إذا كانت هناك بنود ** ** التي لها أسعار مختلفة، وأنها يجب أن يضاف في * الضرائب البند ** الجدول في البند ** ** الرئيسي.
 
- #### وصف الأعمدة 
+ #### وصف الأعمدة
 
- 1. نوع الحساب: 
+ 1. نوع الحساب:
  - وهذا يمكن أن يكون على ** صافي إجمالي ** (وهذا هو مجموع المبلغ الأساسي).
  - ** في الصف السابق الكل / المكونات ** (للضرائب أو رسوم التراكمية). إذا قمت بتحديد هذا الخيار، سيتم تطبيق الضريبة كنسبة مئوية من الصف السابق (في الجدول الضرائب) كمية أو المجموع.
  - ** ** الفعلية (كما ذكر).
- 2. رئيس الحساب: حساب دفتر الأستاذ والتي بموجبها سيتم حجز هذه الضريبة 
+ 2. رئيس الحساب: حساب دفتر الأستاذ والتي بموجبها سيتم حجز هذه الضريبة
  3. مركز التكلفة: إذا الضرائب / الرسوم هو الدخل (مثل الشحن) أو حساب فإنه يحتاج إلى أن يتم الحجز مقابل مركز التكلفة.
  4. الوصف: وصف الضريبية (التي ستتم طباعتها في الفواتير / الاقتباس).
  5. معدل: معدل الضريبة.
@@ -3357,7 +3357,7 @@ Examples:
 1. Ways of addressing disputes, indemnity, liability, etc.
 1. Address and Contact of your Company.","الشروط والأحكام التي يمكن أن تضاف إلى المبيعات والمشتريات القياسية.
 
- أمثلة: 
+ أمثلة:
 
  1. صلاحية العرض.
  1. شروط الدفع (مقدما، وعلى الائتمان، وجزء مسبقا الخ).
@@ -3366,7 +3366,7 @@ Examples:
  1. الضمان إن وجدت.
  1. عودة السياسة.
  1. شروط الشحن، إذا كان ذلك ممكنا.
- 1. سبل معالجة النزاعات، التعويض، والمسؤولية، الخ 
+ 1. سبل معالجة النزاعات، التعويض، والمسؤولية، الخ
  1. معالجة والاتصال من الشركة الخاصة بك."
 DocType: Issue,Issue Type,نوع القضية
 DocType: Attendance,Leave Type,نوع الاجازة
@@ -3989,11 +3989,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,حدد الموظف للحصول على تقدم الموظف.
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,يرجى تحديد تاريخ صالح
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,حدد طبيعة عملك.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -4816,7 +4816,7 @@ DocType: Accounts Settings,"If enabled, the system will post accounting entries 
 apps/erpnext/erpnext/setup/setup_wizard/data/industry_type.py +15,Brokerage,أعمال سمسرة
 apps/erpnext/erpnext/hr/doctype/leave_application/leave_application.py +207,Attendance for employee {0} is already marked for this day,تم بالفعل تسجيل الحضور للموظف {0} لهذا اليوم
 DocType: Work Order Operation,"in Minutes
-Updated via 'Time Log'","في دقائق 
+Updated via 'Time Log'","في دقائق
  تحديث عبر 'وقت دخول """
 DocType: Customer,From Lead,من الزبون المحتمل
 apps/erpnext/erpnext/config/manufacturing.py +13,Orders released for production.,أوامر أصدرت للإنتاج.
@@ -5080,7 +5080,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,اسم طالب الوظيفة
 DocType: Authorization Rule,Customer / Item Name,الزبون / أسم البند
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt",إذا تم تمكينه، فلن يتم جلب تفاصيل شراء العناصر الأخيرة من أمر الشراء السابق أو إيصال الشراء
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 
@@ -5547,7 +5547,7 @@ apps/erpnext/erpnext/accounts/doctype/fiscal_year/fiscal_year.py +82,Year start 
 apps/erpnext/erpnext/selling/doctype/customer/customer.py +122,Please mention the Lead Name in Lead {0},يرجى ذكر الاسم الرائد في العميل {0}
 apps/erpnext/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py +156,Start date should be less than end date for Item {0},يجب أن يكون تاريخ البدء قبل تاريخ الانتهاء للبند {0}
 DocType: Item,"Example: ABCD.#####
-If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","مثال: ABCD ##### 
+If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","مثال: ABCD #####
  إذا تم تعيين سلسلة وليس المذكورة لا المسلسل في المعاملات، سيتم إنشاء الرقم التسلسلي ثم تلقائي على أساس هذه السلسلة. إذا كنت تريد دائما أن يذكر صراحة المسلسل رقم لهذا البند. ترك هذا فارغا."
 DocType: Upload Attendance,Upload Attendance,رفع الحضور
 apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.js +616,BOM and Manufacturing Quantity are required,مطلوب، قائمة مكونات المواد و كمية التصنيع

--- a/erpnext/translations/bg.csv
+++ b/erpnext/translations/bg.csv
@@ -1020,7 +1020,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1210,7 +1210,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,Амортизация - Запис
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,"Моля, изберете вида на документа първо"
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,Отменете Материал Посещения {0} преди да анулирате тази поддръжка посещение
-DocType: Crop Cycle,ISO 8016 standard,Стандарт ISO 8016
+DocType: Crop Cycle,ISO 8601 standard,Стандарт ISO 8601
 DocType: Pricing Rule,Rate or Discount,Процент или Отстъпка
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},Сериен № {0} не принадлежи на позиция {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,Необходим Количество
@@ -3034,7 +3034,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3936,11 +3936,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,"Изберете служител, за да накарате служителя предварително."
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,"Моля, изберете валидна дата"
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,Изберете естеството на вашия бизнес.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5026,7 +5026,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,Заявител Име
 DocType: Authorization Rule,Customer / Item Name,Клиент / Име на артикул
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","Ако е активирана, последните данни за покупката на елементите няма да бъдат извлечени от предишната поръчка за покупка или разписка за покупка"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 

--- a/erpnext/translations/bn.csv
+++ b/erpnext/translations/bn.csv
@@ -1020,7 +1020,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1210,7 +1210,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,অবচয় এণ্ট্রি
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,প্রথম ডকুমেন্ট টাইপ নির্বাচন করুন
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,এই রক্ষণাবেক্ষণ পরিদর্শন বাতিল আগে বাতিল উপাদান ভিজিট {0}
-DocType: Crop Cycle,ISO 8016 standard,আইএসও 8016 স্ট্যান্ডার্ড
+DocType: Crop Cycle,ISO 8601 standard,আইএসও 8601 স্ট্যান্ডার্ড
 DocType: Pricing Rule,Rate or Discount,রেট বা ডিসকাউন্ট
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},সিরিয়াল কোন {0} আইটেম অন্তর্গত নয় {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,প্রয়োজনীয় Qty
@@ -3034,7 +3034,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3935,11 +3935,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,কর্মচারী অগ্রিম পেতে একটি কর্মচারী নির্বাচন করুন
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,একটি বৈধ তারিখ নির্বাচন করুন
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,আপনার ব্যবসার প্রকৃতি নির্বাচন করুন.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5025,7 +5025,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,আবেদনকারীর নাম
 DocType: Authorization Rule,Customer / Item Name,গ্রাহক / আইটেম নাম
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt",যদি সক্ষম করা থাকে তবে আইটেমগুলির সর্বশেষ ক্রয় বিশদগুলি পূর্বের ক্রয় অর্ডার থেকে বা ক্রয়ের প্রাপ্তি থেকে ক্রয় করা হবে না
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 

--- a/erpnext/translations/bs.csv
+++ b/erpnext/translations/bs.csv
@@ -1020,7 +1020,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1031,19 +1031,19 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 6. Amount: Tax amount.
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
-9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","Standard poreza predložak koji se može primijeniti na sve poslove prodaje. Ovaj predložak može sadržavati popis poreskih glava i ostali rashodi / prihodi glave kao što su ""Shipping"", ""osiguranje"", ""Rukovanje"" itd 
+9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","Standard poreza predložak koji se može primijeniti na sve poslove prodaje. Ovaj predložak može sadržavati popis poreskih glava i ostali rashodi / prihodi glave kao što su ""Shipping"", ""osiguranje"", ""Rukovanje"" itd
 
- #### Napomena 
+ #### Napomena
 
  Stopa poreza te definirati ovdje će biti standardna stopa poreza za sve ** Predmeti **. Ako postoje ** ** Predmeti koji imaju različite stope, oni moraju biti dodan u ** Stavka poreza na stolu ** u ** ** Stavka master.
 
- #### Opis Kolumne 
+ #### Opis Kolumne
 
- 1. Obračun Tip: 
+ 1. Obračun Tip:
  - To može biti na ** Neto Ukupno ** (to je zbroj osnovnog iznosa).
  - ** Na Prethodna Row Ukupan / Iznos ** (za kumulativni poreza ili naknada). Ako odaberete ovu opciju, porez će se primjenjivati kao postotak prethodnog reda (u tabeli poreza) iznos ili ukupno.
  - ** Stvarna ** (kao što je spomenuto).
- 2. Račun Head: The račun knjigu pod kojima porez će biti kažnjen 
+ 2. Račun Head: The račun knjigu pod kojima porez će biti kažnjen
  3. Trošak Center: Ako porez / zadužen je prihod (kao što je shipping) ili rashod treba da se rezervirati protiv troška.
  4. Opis: Opis poreza (koje će se štampati u fakturama / navodnika).
  5. Rate: Stopa poreza.
@@ -1229,7 +1229,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,Amortizacija Entry
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,Molimo odaberite vrstu dokumenta prvi
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,Odustani Posjeta materijala {0} prije otkazivanja ovog održavanja pohod
-DocType: Crop Cycle,ISO 8016 standard,ISO 8016 standard
+DocType: Crop Cycle,ISO 8601 standard,ISO 8601 standard
 DocType: Pricing Rule,Rate or Discount,Stopa ili popust
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},Serijski Ne {0} ne pripada točki {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,Potrebna Kol
@@ -3055,7 +3055,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3067,19 +3067,19 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
 9. Consider Tax or Charge for: In this section you can specify if the tax / charge is only for valuation (not a part of total) or only for total (does not add value to the item) or for both.
-10. Add or Deduct: Whether you want to add or deduct the tax.","Standard poreza predložak koji se može primijeniti na sve kupovnih transakcija. Ovaj predložak može sadržavati popis poreskih glava i drugih rashoda glave kao što su ""Shipping"", ""osiguranje"", ""Rukovanje"" itd 
+10. Add or Deduct: Whether you want to add or deduct the tax.","Standard poreza predložak koji se može primijeniti na sve kupovnih transakcija. Ovaj predložak može sadržavati popis poreskih glava i drugih rashoda glave kao što su ""Shipping"", ""osiguranje"", ""Rukovanje"" itd
 
- #### Napomena 
+ #### Napomena
 
  Stopa poreza te definirati ovdje će biti standardna stopa poreza za sve ** Predmeti **. Ako postoje ** ** Predmeti koji imaju različite stope, oni moraju biti dodan u ** Stavka poreza na stolu ** u ** ** Stavka master.
 
- #### Opis Kolumne 
+ #### Opis Kolumne
 
- 1. Obračun Tip: 
+ 1. Obračun Tip:
  - To može biti na ** Neto Ukupno ** (to je zbroj osnovnog iznosa).
  - ** Na Prethodna Row Ukupan / Iznos ** (za kumulativni poreza ili naknada). Ako odaberete ovu opciju, porez će se primjenjivati kao postotak prethodnog reda (u tabeli poreza) iznos ili ukupno.
  - ** Stvarna ** (kao što je spomenuto).
- 2. Račun Head: The račun knjigu pod kojima porez će biti kažnjen 
+ 2. Račun Head: The račun knjigu pod kojima porez će biti kažnjen
  3. Trošak Center: Ako porez / zadužen je prihod (kao što je shipping) ili rashod treba da se rezervirati protiv troška.
  4. Opis: Opis poreza (koje će se štampati u fakturama / navodnika).
  5. Rate: Stopa poreza.
@@ -3357,7 +3357,7 @@ Examples:
 1. Ways of addressing disputes, indemnity, liability, etc.
 1. Address and Contact of your Company.","Standardnim uvjetima koji se mogu dodati da prodaje i kupovine.
 
- Primjeri: 
+ Primjeri:
 
  1. Valjanost ponude.
  1. Uslovi plaćanja (unaprijed, na kredit, dio unaprijed itd).
@@ -3366,7 +3366,7 @@ Examples:
  1. Jamstvo ako ih ima.
  1. Vraća politike.
  1. Uvjeti shipping, ako je primjenjivo.
- 1. Načini adresiranja sporova, naknadu štete, odgovornosti, itd 
+ 1. Načini adresiranja sporova, naknadu štete, odgovornosti, itd
  1. Adresu i kontakt vaše kompanije."
 DocType: Issue,Issue Type,Vrsta izdanja
 DocType: Attendance,Leave Type,Ostavite Vid
@@ -3989,11 +3989,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,Izaberi zaposlenog da unapredi radnika.
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,Izaberite važeći datum
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,Odaberite priroda vašeg poslovanja.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -4816,7 +4816,7 @@ DocType: Accounts Settings,"If enabled, the system will post accounting entries 
 apps/erpnext/erpnext/setup/setup_wizard/data/industry_type.py +15,Brokerage,posredništvo
 apps/erpnext/erpnext/hr/doctype/leave_application/leave_application.py +207,Attendance for employee {0} is already marked for this day,Posjećenost za zaposlenog {0} je već označena za ovaj dan
 DocType: Work Order Operation,"in Minutes
-Updated via 'Time Log'","u minutama 
+Updated via 'Time Log'","u minutama
  ažurirano preko 'Time Log'"
 DocType: Customer,From Lead,Od Lead-a
 apps/erpnext/erpnext/config/manufacturing.py +13,Orders released for production.,Narudžbe objavljen za proizvodnju.
@@ -5080,7 +5080,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,Podnositelj zahtjeva Ime
 DocType: Authorization Rule,Customer / Item Name,Kupac / Stavka Ime
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","Ako je omogućeno, poslednji podaci o kupovini stavki neće biti preuzeti iz prethodnog naloga za kupovinu ili potvrde o kupovini"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 
@@ -5545,7 +5545,7 @@ apps/erpnext/erpnext/accounts/doctype/fiscal_year/fiscal_year.py +82,Year start 
 apps/erpnext/erpnext/selling/doctype/customer/customer.py +122,Please mention the Lead Name in Lead {0},Molim vas da navedete Lead Lead u Lead-u {0}
 apps/erpnext/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py +156,Start date should be less than end date for Item {0},Početak bi trebao biti manji od krajnjeg datuma za točke {0}
 DocType: Item,"Example: ABCD.#####
-If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","Primjer:. ABCD ##### 
+If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","Primjer:. ABCD #####
  Ako serije je postavljen i serijski broj se ne spominje u transakcijama, a zatim automatski serijski broj će biti kreiran na osnovu ove serije. Ako želite uvijek izričito spomenuti Serial Nos za ovu stavku. ovo ostavite prazno."
 DocType: Upload Attendance,Upload Attendance,Upload Attendance
 apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.js +616,BOM and Manufacturing Quantity are required,BOM i proizvodnja Količina su potrebne

--- a/erpnext/translations/ca.csv
+++ b/erpnext/translations/ca.csv
@@ -1020,7 +1020,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1031,19 +1031,19 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 6. Amount: Tax amount.
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
-9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","Plantilla de gravamen que es pot aplicar a totes les transaccions de venda. Aquesta plantilla pot contenir llista de caps d'impostos i també altres caps de despeses / ingressos com ""enviament"", ""Assegurances"", ""Maneig"", etc. 
+9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","Plantilla de gravamen que es pot aplicar a totes les transaccions de venda. Aquesta plantilla pot contenir llista de caps d'impostos i també altres caps de despeses / ingressos com ""enviament"", ""Assegurances"", ""Maneig"", etc.
 
- #### Nota 
+ #### Nota
 
  La taxa d'impost que definir aquí serà el tipus impositiu general per a tots els articles ** **. Si hi ha ** ** Els articles que tenen diferents taxes, han de ser afegits en l'Impost ** ** Article taula a l'article ** ** mestre.
 
- #### Descripció de les Columnes 
+ #### Descripció de les Columnes
 
- 1. Tipus de Càlcul: 
+ 1. Tipus de Càlcul:
  - Això pot ser en ** Net Total ** (que és la suma de la quantitat bàsica).
  - ** En Fila Anterior total / import ** (per impostos o càrrecs acumulats). Si seleccioneu aquesta opció, l'impost s'aplica com un percentatge de la fila anterior (a la taula d'impostos) Quantitat o total.
  - Actual ** ** (com s'ha esmentat).
- 2. Compte Cap: El llibre major de comptes en què es va reservar aquest impost 
+ 2. Compte Cap: El llibre major de comptes en què es va reservar aquest impost
  3. Centre de Cost: Si l'impost / càrrega és un ingrés (com l'enviament) o despesa en què ha de ser reservat en contra d'un centre de costos.
  4. Descripció: Descripció de l'impost (que s'imprimiran en factures / cometes).
  5. Rate: Taxa d'impost.
@@ -1229,7 +1229,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,Entrada depreciació
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,Si us plau. Primer seleccioneu el tipus de document
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,Cancel·la Visites Materials {0} abans de cancel·lar aquesta visita de manteniment
-DocType: Crop Cycle,ISO 8016 standard,Norma ISO 8016
+DocType: Crop Cycle,ISO 8601 standard,Norma ISO 8601
 DocType: Pricing Rule,Rate or Discount,Tarifa o descompte
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},El número de Sèrie {0} no pertany a l'article {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,Quantitat necessària
@@ -3054,7 +3054,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3066,19 +3066,19 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
 9. Consider Tax or Charge for: In this section you can specify if the tax / charge is only for valuation (not a part of total) or only for total (does not add value to the item) or for both.
-10. Add or Deduct: Whether you want to add or deduct the tax.","Plantilla de gravamen que es pot aplicar a totes les operacions de compra. Aquesta plantilla pot contenir llista de caps d'impostos i també altres caps de despeses com ""enviament"", ""Assegurances"", ""Maneig"", etc. 
+10. Add or Deduct: Whether you want to add or deduct the tax.","Plantilla de gravamen que es pot aplicar a totes les operacions de compra. Aquesta plantilla pot contenir llista de caps d'impostos i també altres caps de despeses com ""enviament"", ""Assegurances"", ""Maneig"", etc.
 
- #### Nota 
+ #### Nota
 
  El tipus impositiu es defineix aquí serà el tipus de gravamen general per a tots els articles ** **. Si hi ha ** ** Els articles que tenen diferents taxes, han de ser afegits en l'Impost ** ** Article taula a l'article ** ** mestre.
 
- #### Descripció de les Columnes 
+ #### Descripció de les Columnes
 
- 1. Tipus de Càlcul: 
+ 1. Tipus de Càlcul:
  - Això pot ser en ** Net Total ** (que és la suma de la quantitat bàsica).
  - ** En Fila Anterior total / import ** (per impostos o càrrecs acumulats). Si seleccioneu aquesta opció, l'impost s'aplica com un percentatge de la fila anterior (a la taula d'impostos) Quantitat o total.
  - Actual ** ** (com s'ha esmentat).
- 2. Compte Cap: El llibre major de comptes en què es va reservar aquest impost 
+ 2. Compte Cap: El llibre major de comptes en què es va reservar aquest impost
  3. Centre de Cost: Si l'impost / càrrega és un ingrés (com l'enviament) o despesa en què ha de ser reservat en contra d'un centre de costos.
  4. Descripció: Descripció de l'impost (que s'imprimiran en factures / cometes).
  5. Rate: Taxa d'impost.
@@ -3356,7 +3356,7 @@ Examples:
 1. Ways of addressing disputes, indemnity, liability, etc.
 1. Address and Contact of your Company.","Termes i Condicions que es poden afegir a compres i vendes estàndard.
 
- Exemples: 
+ Exemples:
 
  1. Validesa de l'oferta.
  1. Condicions de pagament (per avançat, el crèdit, part antelació etc.).
@@ -3365,7 +3365,7 @@ Examples:
  1. Garantia si n'hi ha.
  1. Política de les voltes.
  1. Termes d'enviament, si escau.
- 1. Formes de disputes que aborden, indemnització, responsabilitat, etc. 
+ 1. Formes de disputes que aborden, indemnització, responsabilitat, etc.
  1. Adreça i contacte de la seva empresa."
 DocType: Issue,Issue Type,Tipus d&#39;emissió
 DocType: Attendance,Leave Type,Tipus de llicència
@@ -3988,11 +3988,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,Seleccioneu un empleat per fer avançar l&#39;empleat.
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,Seleccioneu una data vàlida
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,Seleccioneu la naturalesa del seu negoci.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -4816,7 +4816,7 @@ DocType: Accounts Settings,"If enabled, the system will post accounting entries 
 apps/erpnext/erpnext/setup/setup_wizard/data/industry_type.py +15,Brokerage,Corretatge
 apps/erpnext/erpnext/hr/doctype/leave_application/leave_application.py +207,Attendance for employee {0} is already marked for this day,L&#39;assistència per a l&#39;empleat {0} ja està marcat per al dia d&#39;avui
 DocType: Work Order Operation,"in Minutes
-Updated via 'Time Log'","en minuts 
+Updated via 'Time Log'","en minuts
  Actualitzat a través de 'Hora de registre'"
 DocType: Customer,From Lead,De client potencial
 apps/erpnext/erpnext/config/manufacturing.py +13,Orders released for production.,Comandes llançades per a la producció.
@@ -5080,7 +5080,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,Nom del sol·licitant
 DocType: Authorization Rule,Customer / Item Name,Client / Nom de l'article
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","Si està habilitat, els detalls de l&#39;última compra dels articles no seran obtinguts a partir de l&#39;ordre de compra anterior o el rebut de compra"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 
@@ -5543,7 +5543,7 @@ DocType: Purchase Invoice Item,Rejected Serial No,Número de sèrie Rebutjat
 apps/erpnext/erpnext/accounts/doctype/fiscal_year/fiscal_year.py +82,Year start date or end date is overlapping with {0}. To avoid please set company,"Any d'inici o any finalització es solapa amb {0}. Per evitar, configuri l'empresa"
 apps/erpnext/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py +156,Start date should be less than end date for Item {0},La data d'inici ha de ser anterior a la data de finalització per l'article {0}
 DocType: Item,"Example: ABCD.#####
-If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","Exemple :. ABCD ##### 
+If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","Exemple :. ABCD #####
  Si la sèrie s'estableix i Nombre de sèrie no s'esmenta en les transaccions, nombre de sèrie a continuació automàtica es crearà sobre la base d'aquesta sèrie. Si sempre vol esmentar explícitament els números de sèrie per a aquest article. deixeu en blanc."
 DocType: Upload Attendance,Upload Attendance,Pujar Assistència
 apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.js +616,BOM and Manufacturing Quantity are required,Llista de materials i de fabricació es requereixen Quantitat

--- a/erpnext/translations/cs.csv
+++ b/erpnext/translations/cs.csv
@@ -1020,7 +1020,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1031,19 +1031,19 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 6. Amount: Tax amount.
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
-9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","Standardní daň šablona, která může být použita pro všechny prodejních transakcí. Tato šablona může obsahovat seznam daňových hlav a také další náklady / příjmy hlavy jako ""doprava"", ""pojištění"", ""manipulace"" atd. 
+9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","Standardní daň šablona, která může být použita pro všechny prodejních transakcí. Tato šablona může obsahovat seznam daňových hlav a také další náklady / příjmy hlavy jako ""doprava"", ""pojištění"", ""manipulace"" atd.
 
- #### Poznámka: 
+ #### Poznámka:
 
  daňovou sazbu, vy definovat zde bude základní sazba daně pro všechny ** položky **. Pokud jsou položky ** **, které mají různé ceny, musí být přidány v ** Položka daních ** stůl v ** položky ** mistra.
 
- #### Popis sloupců 
+ #### Popis sloupců
 
- 1. Výpočet Type: 
+ 1. Výpočet Type:
  - To může být na ** Čistý Total ** (což je součet základní částky).
  - ** Na předchozí řady Total / Částka ** (pro kumulativní daní a poplatků). Zvolíte-li tuto možnost, bude daň se použije jako procento z předchozí řady (v daňové tabulky) množství nebo celkem.
  - ** Aktuální ** (jak je uvedeno).
- 2. Účet Hlava: kniha účtu, pod kterým se bude tato daň rezervovat 
+ 2. Účet Hlava: kniha účtu, pod kterým se bude tato daň rezervovat
  3. Nákladové středisko: V případě, že daň / poplatek je příjmem (jako poštovné) nebo nákladů je třeba rezervovat na nákladové středisko.
  4. Popis: Popis daně (které budou vytištěny v faktur / uvozovek).
  5. Rate: Sazba daně.
@@ -1229,7 +1229,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,odpisy Entry
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,Vyberte první typ dokumentu
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,Zrušit Materiál Návštěvy {0} před zrušením tohoto návštěv údržby
-DocType: Crop Cycle,ISO 8016 standard,ISO 8016 standard
+DocType: Crop Cycle,ISO 8601 standard,ISO 8601 standard
 DocType: Pricing Rule,Rate or Discount,Cena nebo sleva
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},Pořadové číslo {0} nepatří k bodu {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,Požadované množství
@@ -3055,7 +3055,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3067,19 +3067,19 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
 9. Consider Tax or Charge for: In this section you can specify if the tax / charge is only for valuation (not a part of total) or only for total (does not add value to the item) or for both.
-10. Add or Deduct: Whether you want to add or deduct the tax.","Standardní daň šablona, která může být použita pro všechny nákupních transakcí. Tato šablona může obsahovat seznam daňových hlav a také ostatní náklady hlavy jako ""doprava"", ""pojištění"", ""manipulace"" atd. 
+10. Add or Deduct: Whether you want to add or deduct the tax.","Standardní daň šablona, která může být použita pro všechny nákupních transakcí. Tato šablona může obsahovat seznam daňových hlav a také ostatní náklady hlavy jako ""doprava"", ""pojištění"", ""manipulace"" atd.
 
- #### Poznámka: 
+ #### Poznámka:
 
  daňovou sazbu, můžete definovat zde bude základní sazba daně pro všechny ** položky **. Pokud jsou položky ** **, které mají různé ceny, musí být přidány v ** Položka daních ** stůl v ** položky ** mistra.
 
- #### Popis sloupců 
+ #### Popis sloupců
 
- 1. Výpočet Type: 
+ 1. Výpočet Type:
  - To může být na ** Čistý Total ** (což je součet základní částky).
  - ** Na předchozí řady Total / Částka ** (pro kumulativní daní a poplatků). Zvolíte-li tuto možnost, bude daň se použije jako procento z předchozí řady (v daňové tabulky) množství nebo celkem.
  - ** Aktuální ** (jak je uvedeno).
- 2. Účet Hlava: kniha účtu, pod kterým se bude tato daň rezervovat 
+ 2. Účet Hlava: kniha účtu, pod kterým se bude tato daň rezervovat
  3. Nákladové středisko: V případě, že daň / poplatek je příjmem (jako poštovné) nebo nákladů je třeba rezervovat na nákladové středisko.
  4. Popis: Popis daně (které budou vytištěny v faktur / uvozovek).
  5. Rate: Sazba daně.
@@ -3357,7 +3357,7 @@ Examples:
 1. Ways of addressing disputes, indemnity, liability, etc.
 1. Address and Contact of your Company.","Všeobecné obchodní podmínky, které mohou být přidány do prodejů a nákupů.
 
- Příklady: 
+ Příklady:
 
  1. Platnost nabídky.
  1. Platební podmínky (v předstihu, na úvěr, část zálohy atd.)
@@ -3366,7 +3366,7 @@ Examples:
  1. Záruka, pokud existuje.
  1. Vrátí zásady.
  1. Podmínky přepravy, v případě potřeby.
- 1. Způsoby řešení sporů, náhrady škody, odpovědnosti za škodu, atd 
+ 1. Způsoby řešení sporů, náhrady škody, odpovědnosti za škodu, atd
  1. Adresa a kontakt na vaši společnost."
 DocType: Issue,Issue Type,Typ vydání
 DocType: Attendance,Leave Type,Typ absence
@@ -3989,11 +3989,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,"Vyberte zaměstnance, chcete-li zaměstnance předem."
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,Vyberte prosím platný datum
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,Vyberte podstatu svého podnikání.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -4815,7 +4815,7 @@ DocType: Accounts Settings,"If enabled, the system will post accounting entries 
 apps/erpnext/erpnext/setup/setup_wizard/data/industry_type.py +15,Brokerage,Makléřská
 apps/erpnext/erpnext/hr/doctype/leave_application/leave_application.py +207,Attendance for employee {0} is already marked for this day,Účast na zaměstnance {0} je již označen pro tento den
 DocType: Work Order Operation,"in Minutes
-Updated via 'Time Log'","v minutách 
+Updated via 'Time Log'","v minutách
  aktualizovat přes ""Time Log"""
 DocType: Customer,From Lead,Od Leadu
 apps/erpnext/erpnext/config/manufacturing.py +13,Orders released for production.,Objednávky uvolněna pro výrobu.
@@ -5079,7 +5079,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,Žadatel Název
 DocType: Authorization Rule,Customer / Item Name,Zákazník / Název zboží
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","Pokud je povoleno, poslední podrobnosti o nákupu položek nebudou získány z předchozí objednávky nebo dokladu o nákupu"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 
@@ -5544,7 +5544,7 @@ apps/erpnext/erpnext/accounts/doctype/fiscal_year/fiscal_year.py +82,Year start 
 apps/erpnext/erpnext/selling/doctype/customer/customer.py +122,Please mention the Lead Name in Lead {0},Uvedete prosím vedoucí jméno ve vedoucím {0}
 apps/erpnext/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py +156,Start date should be less than end date for Item {0},Datum zahájení by měla být menší než konečné datum pro bod {0}
 DocType: Item,"Example: ABCD.#####
-If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","Příklad:. ABCD ##### 
+If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","Příklad:. ABCD #####
  Je-li série nastavuje a pořadové číslo není uvedeno v transakcích, bude vytvořen poté automaticky sériové číslo na základě této série. Pokud chcete vždy výslovně uvést pořadová čísla pro tuto položku. ponechte prázdné."
 DocType: Upload Attendance,Upload Attendance,Nahrát Návštěvnost
 apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.js +616,BOM and Manufacturing Quantity are required,BOM a výroba množství jsou povinné

--- a/erpnext/translations/da.csv
+++ b/erpnext/translations/da.csv
@@ -1020,7 +1020,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1210,7 +1210,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,Afskrivninger indtastning
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,Vælg dokumenttypen først
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,"Annuller Materiale Besøg {0}, før den annullerer denne vedligeholdelse Besøg"
-DocType: Crop Cycle,ISO 8016 standard,ISO 8016 standard
+DocType: Crop Cycle,ISO 8601 standard,ISO 8601 standard
 DocType: Pricing Rule,Rate or Discount,Pris eller rabat
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},Serienummer {0} hører ikke til vare {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,Nødvendigt antal
@@ -3034,7 +3034,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3936,11 +3936,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,Vælg en medarbejder for at få medarbejderen forskud.
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,Vælg venligst en gyldig dato
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,Vælg arten af din virksomhed.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -4157,7 +4157,7 @@ apps/erpnext/erpnext/projects/doctype/task/task.py +54,Progress % for a task can
 DocType: Stock Reconciliation Item,Before reconciliation,Før forsoning
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +12,To {0},Til {0}
 DocType: Purchase Invoice,Taxes and Charges Added (Company Currency),Skatter og Afgifter Tilføjet (Company Valuta)
-apps/erpnext/erpnext/stock/doctype/item/item.py +476,Item Tax Row {0} must have account of type Tax or Income or Expense or Chargeable,"Varemoms række {0} skal have en konto med 
+apps/erpnext/erpnext/stock/doctype/item/item.py +476,Item Tax Row {0} must have account of type Tax or Income or Expense or Chargeable,"Varemoms række {0} skal have en konto med
 typen moms, indtægt, omkostning eller kan debiteres"
 DocType: Sales Order,Partly Billed,Delvist faktureret
 apps/erpnext/erpnext/assets/doctype/asset/asset.py +43,Item {0} must be a Fixed Asset Item,Vare {0} skal være en anlægsaktiv-vare
@@ -5027,7 +5027,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,Ansøgernavn
 DocType: Authorization Rule,Customer / Item Name,Kunde / Varenavn
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","Hvis aktiveret, hentes de sidste købsoplysninger for varer ikke fra tidligere købsordre eller købskvittering"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 

--- a/erpnext/translations/de.csv
+++ b/erpnext/translations/de.csv
@@ -1020,7 +1020,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1031,15 +1031,15 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 6. Amount: Tax amount.
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
-9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","Standard-Steuer-Vorlage, die für alle Kauftransaktionen angewandt werden kann. Diese Vorlage kann eine Liste der Steuern und auch anderer Kosten wie ""Versand"", ""Versicherung"", ""Handhabung"" usw. enthalten. 
+9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","Standard-Steuer-Vorlage, die für alle Kauftransaktionen angewandt werden kann. Diese Vorlage kann eine Liste der Steuern und auch anderer Kosten wie ""Versand"", ""Versicherung"", ""Handhabung"" usw. enthalten.
 
- #### Hinweis 
+ #### Hinweis
 
 Der Steuersatz, den sie hier definieren, wird der Standardsteuersatz für alle Artikel. Wenn es Artikel mit davon abweichenden Steuersätzen gibt, müssen diese in der Tabelle ""Artikelsteuer"" im Artikelstamm hinzugefügt werden.
 
- #### Beschreibung der Spalten 
+ #### Beschreibung der Spalten
 
-1. Berechnungsart: 
+1. Berechnungsart:
 - Dies kann sein ""Auf Nettosumme"" (das ist die Summe der Grundbeträge).
 - ""Auf vorherige Zeilensumme/-Betrag"" (für kumulative Steuern oder Abgaben). Wenn diese Option ausgewählt wird, wird die Steuer als Prozentsatz der vorherigen Zeilesumme/des vorherigen Zeilenbetrags (in der Steuertabelle) angewendet.
 - ""Unmittelbar"" (wie bereits erwähnt).
@@ -1229,7 +1229,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,Abschreibungs Eintrag
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,Bitte zuerst den Dokumententyp auswählen
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,Materialkontrolle {0} stornieren vor Abbruch dieses Wartungsbesuchs
-DocType: Crop Cycle,ISO 8016 standard,ISO 8016 Standard
+DocType: Crop Cycle,ISO 8601 standard,ISO 8601 Standard
 DocType: Pricing Rule,Rate or Discount,Rate oder Rabatt
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},Seriennummer {0} gehört nicht zu Artikel {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,Erforderliche Anzahl
@@ -3053,7 +3053,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3065,15 +3065,15 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
 9. Consider Tax or Charge for: In this section you can specify if the tax / charge is only for valuation (not a part of total) or only for total (does not add value to the item) or for both.
-10. Add or Deduct: Whether you want to add or deduct the tax.","Standard-Steuer-Vorlage, die für alle Kauftransaktionen angewandt werden kann. Diese Vorlage kann eine Liste der Steuern und auch anderer Kosten wie ""Versand"", ""Versicherung"", ""Handhabung"" usw. enthalten. 
+10. Add or Deduct: Whether you want to add or deduct the tax.","Standard-Steuer-Vorlage, die für alle Kauftransaktionen angewandt werden kann. Diese Vorlage kann eine Liste der Steuern und auch anderer Kosten wie ""Versand"", ""Versicherung"", ""Handhabung"" usw. enthalten.
 
- #### Hinweis 
+ #### Hinweis
 
 Der Steuersatz, den sie hier definieren, wird der Standardsteuersatz für alle Artikel. Wenn es Artikel mit davon abweichenden Steuersätzen gibt, müssen diese in der Tabelle ""Artikelsteuer"" im Artikelstamm hinzugefügt werden.
 
- #### Beschreibung der Spalten 
+ #### Beschreibung der Spalten
 
-1. Berechnungsart: 
+1. Berechnungsart:
 - Dies kann sein ""Auf Nettosumme"" (das ist die Summe der Grundbeträge).
 - ""Auf vorherige Zeilensumme/-Betrag"" (für kumulative Steuern oder Abgaben). Wenn diese Option ausgewählt wird, wird die Steuer als Prozentsatz der vorherigen Zeilesumme/des vorherigen Zeilenbetrags (in der Steuertabelle) angewendet.
 - ""Unmittelbar"" (wie bereits erwähnt).
@@ -3355,7 +3355,7 @@ Examples:
 1. Ways of addressing disputes, indemnity, liability, etc.
 1. Address and Contact of your Company.","Allgemeine Geschäftsbedingungen, die bei Ver- und Einkäufen verwendet werden können.
 
- Beispiele: 
+ Beispiele:
 
 1. Gültigkeit des Angebots.
 2. Zahlungsbedingungen (Vorkasse, auf Rechnung, Teilweise Vorkasse usw.)
@@ -3364,7 +3364,7 @@ Examples:
 5. Garantie, falls vorhanden.
 6. Rückgabebedingungen.
 7. Lieferbedingungen, falls zutreffend.
-8. Beschwerdemanagement, Schadensersatz, Haftung usw. 
+8. Beschwerdemanagement, Schadensersatz, Haftung usw.
 9. Adresse und Kontaktdaten des Unternehmens."
 DocType: Issue,Issue Type,Fehlertyp
 DocType: Attendance,Leave Type,Urlaubstyp
@@ -3987,11 +3987,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,"Wählen Sie einen Mitarbeiter aus, um den Mitarbeiter vorab zu erreichen."
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,Bitte wähle ein gültiges Datum aus
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,Wählen Sie die Art Ihres Unternehmens.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5077,7 +5077,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,Bewerbername
 DocType: Authorization Rule,Customer / Item Name,Kunde / Artikelname
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","Wenn diese Option aktiviert ist, werden die letzten Einkaufsdetails von Artikeln nicht aus früheren Bestellungen oder Kaufquittungen abgerufen"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 
@@ -5542,7 +5542,7 @@ apps/erpnext/erpnext/accounts/doctype/fiscal_year/fiscal_year.py +82,Year start 
 apps/erpnext/erpnext/selling/doctype/customer/customer.py +122,Please mention the Lead Name in Lead {0},Bitte erwähnen Sie den Lead Name in Lead {0}
 apps/erpnext/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py +156,Start date should be less than end date for Item {0},Startdatum sollte für den Artikel {0} vor dem Enddatum liegen
 DocType: Item,"Example: ABCD.#####
-If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","Beispiel: ABCD.##### 
+If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","Beispiel: ABCD.#####
  Wenn ""Serie"" eingestellt ist und ""Seriennummer"" in den Transaktionen nicht aufgeführt ist, dann wird eine Seriennummer automatisch auf der Grundlage dieser Serie erstellt. Wenn immer explizit Seriennummern für diesen Artikel aufgeführt werden sollen, muss das Feld leer gelassen werden."
 DocType: Upload Attendance,Upload Attendance,Anwesenheit hochladen
 apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.js +616,BOM and Manufacturing Quantity are required,Stückliste und Fertigungsmenge werden benötigt

--- a/erpnext/translations/el.csv
+++ b/erpnext/translations/el.csv
@@ -1020,7 +1020,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1031,15 +1031,15 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 6. Amount: Tax amount.
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
-9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","""Πρότυπο τυπικού φόρου που μπορεί να εφαρμοστεί σε όλες τις συναλλαγές πωλήσεων. Αυτό το πρότυπο μπορεί να περιέχει έναν κατάλογο των φορολογικών λογαριασμών και λογαριασμών άλλων δαπανών, όπως """"κόστος αποστολής"""", """"ασφάλιση"""", """"χειρισμός"""" κλπ 
+9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","""Πρότυπο τυπικού φόρου που μπορεί να εφαρμοστεί σε όλες τις συναλλαγές πωλήσεων. Αυτό το πρότυπο μπορεί να περιέχει έναν κατάλογο των φορολογικών λογαριασμών και λογαριασμών άλλων δαπανών, όπως """"κόστος αποστολής"""", """"ασφάλιση"""", """"χειρισμός"""" κλπ
 
-#### σημείωση 
+#### σημείωση
 
 Ο φορολογικός συντελεστής που ορίζετε εδώ θα είναι ο τυπικός φορολογικός συντελεστής για όλα τα **είδη**. Εάν υπάρχουν **είδη** που έχουν διαφορετικούς συντελεστές, θα πρέπει να προστεθούν στον πίνακα **φόρων είδους** στην κύρια εγγραφή **είδους**.
 
  #### Περιγραφή στηλών
 
- 1. Τύπος υπολογισμού: 
+ 1. Τύπος υπολογισμού:
  - αυτό μπορεί να είναι στο **καθαρό σύνολο** (το άθροισμα του βασικού ποσού).
  - **Το σύνολο/ποσό προηγούμενης σειράς** (για σωρευτικούς φόρους ή επιβαρύνσεις). Αν επιλέξετε αυτή την επιλογή, ο φόρος θα εφαρμοστεί ως ποσοστό του ποσό ή συνόλου της προηγούμενης σειράς (στο φορολογικό πίνακα).
  - ** ** Πραγματική (όπως αναφέρθηκε).
@@ -1229,7 +1229,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,αποσβέσεις Έναρξη
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,Παρακαλώ επιλέξτε τον τύπο του εγγράφου πρώτα
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,Ακύρωση επισκέψεων {0} πριν από την ακύρωση αυτής της επίσκεψης για συντήρηση
-DocType: Crop Cycle,ISO 8016 standard,Πρότυπο ISO 8016
+DocType: Crop Cycle,ISO 8601 standard,Πρότυπο ISO 8601
 DocType: Pricing Rule,Rate or Discount,Τιμή ή Έκπτωση
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},Ο σειριακός αριθμός {0} δεν ανήκει στο είδος {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,Απαιτούμενη ποσότητα
@@ -3053,7 +3053,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3065,15 +3065,15 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
 9. Consider Tax or Charge for: In this section you can specify if the tax / charge is only for valuation (not a part of total) or only for total (does not add value to the item) or for both.
-10. Add or Deduct: Whether you want to add or deduct the tax.","""Πρότυπο τυπικού φόρου που μπορεί να εφαρμοστεί σε όλες τις συναλλαγές αγορών. Αυτό το πρότυπο μπορεί να περιέχει έναν κατάλογο των φορολογικών λογαριασμών και λογαριασμών άλλων δαπανών, όπως """"κόστος αποστολής"""", """"ασφάλιση"""", """"χειρισμός"""" κλπ 
+10. Add or Deduct: Whether you want to add or deduct the tax.","""Πρότυπο τυπικού φόρου που μπορεί να εφαρμοστεί σε όλες τις συναλλαγές αγορών. Αυτό το πρότυπο μπορεί να περιέχει έναν κατάλογο των φορολογικών λογαριασμών και λογαριασμών άλλων δαπανών, όπως """"κόστος αποστολής"""", """"ασφάλιση"""", """"χειρισμός"""" κλπ
 
-#### σημείωση 
+#### σημείωση
 
 Ο φορολογικός συντελεστής που ορίζετε εδώ θα είναι ο τυπικός φορολογικός συντελεστής για όλα τα **είδη**. Εάν υπάρχουν **είδη** που έχουν διαφορετικούς συντελεστές, θα πρέπει να προστεθούν στον πίνακα **φόρων είδους** στην κύρια εγγραφή **είδους**.
 
  #### Περιγραφή στηλών
 
- 1. Τύπος υπολογισμού: 
+ 1. Τύπος υπολογισμού:
  - αυτό μπορεί να είναι στο **καθαρό σύνολο** (το άθροισμα του βασικού ποσού).
  - **Το σύνολο/ποσό προηγούμενης σειράς** (για σωρευτικούς φόρους ή επιβαρύνσεις). Αν επιλέξετε αυτή την επιλογή, ο φόρος θα εφαρμοστεί ως ποσοστό του ποσό ή συνόλου της προηγούμενης σειράς (στο φορολογικό πίνακα).
  - **Πραγματική**  (όπως αναφέρθηκε).
@@ -3353,9 +3353,9 @@ Examples:
 1. Returns Policy.
 1. Terms of shipping, if applicable.
 1. Ways of addressing disputes, indemnity, liability, etc.
-1. Address and Contact of your Company.","Βασικοί όροι και προϋποθέσεις που μπορούν να προστεθούν σε πωλήσεις και αγορές. 
+1. Address and Contact of your Company.","Βασικοί όροι και προϋποθέσεις που μπορούν να προστεθούν σε πωλήσεις και αγορές.
 
-Παραδείγματα 
+Παραδείγματα
 
  1. Διάρκεια ισχύος της προσφοράς.
  2. Όροι πληρωμής (προκαταβολή, επί πιστώσει, μερική προκαταβολή κλπ).
@@ -3364,7 +3364,7 @@ Examples:
  5. Εγγύηση αν υπάρχει.
  6. Πολιτική επιστροφών.
  7. Όροι αποστολής αν είναι εφαρμοστέοι.
- 8. Τρόποι αντιμετώπισης των διαφορών, αποζημίωση, ευθύνη, κλπ ||| 
+ 8. Τρόποι αντιμετώπισης των διαφορών, αποζημίωση, ευθύνη, κλπ |||
  9. Διεύθυνση και στοιχεία επικοινωνίας της εταιρείας σας."
 DocType: Issue,Issue Type,Τύπος Θέματος
 DocType: Attendance,Leave Type,Τύπος άδειας
@@ -3987,11 +3987,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,Επιλέξτε έναν υπάλληλο για να προχωρήσει ο εργαζόμενος.
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,Επιλέξτε μια έγκυρη ημερομηνία
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,Επιλέξτε τη φύση της επιχείρησής σας.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -4814,7 +4814,7 @@ DocType: Accounts Settings,"If enabled, the system will post accounting entries 
 apps/erpnext/erpnext/setup/setup_wizard/data/industry_type.py +15,Brokerage,Μεσιτεία
 apps/erpnext/erpnext/hr/doctype/leave_application/leave_application.py +207,Attendance for employee {0} is already marked for this day,Η φοίτηση για εργαζόμενο {0} έχει ήδη επισημανθεί για αυτήν την ημέρα
 DocType: Work Order Operation,"in Minutes
-Updated via 'Time Log'","Σε λεπτά 
+Updated via 'Time Log'","Σε λεπτά
  ενημέρωση μέσω «αρχείου καταγραφής ώρας»"
 DocType: Customer,From Lead,Από Σύσταση
 apps/erpnext/erpnext/config/manufacturing.py +13,Orders released for production.,Παραγγελίες ανοιχτές για παραγωγή.
@@ -5078,7 +5078,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,Όνομα αιτούντος
 DocType: Authorization Rule,Customer / Item Name,Πελάτης / όνομα είδους
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","Αν είναι ενεργοποιημένη, τα τελευταία στοιχεία αγοράς των στοιχείων δεν θα ληφθούν από προηγούμενη παραγγελία αγοράς ή απόδειξη αγοράς"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 

--- a/erpnext/translations/es.csv
+++ b/erpnext/translations/es.csv
@@ -1020,7 +1020,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1210,7 +1210,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,Entrada de Depreciación
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,"Por favor, seleccione primero el tipo de documento"
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,Cancelar visitas {0} antes de cancelar la visita de mantenimiento
-DocType: Crop Cycle,ISO 8016 standard,Estándar ISO 8016
+DocType: Crop Cycle,ISO 8601 standard,Estándar ISO 8601
 DocType: Pricing Rule,Rate or Discount,Tarifa o Descuento
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},Número de serie {0} no pertenece al producto {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,Cant. Solicitada
@@ -3034,7 +3034,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3316,7 +3316,7 @@ Examples:
 1. Ways of addressing disputes, indemnity, liability, etc.
 1. Address and Contact of your Company.","Términos y Condiciones Estándar que se pueden agregar a compras y ventas.
 
- Ejemplos: 
+ Ejemplos:
 
  1. Validez de la oferta.
  1. Condiciones de pago (por adelantado, el crédito, parte antelación etc).
@@ -3325,7 +3325,7 @@ Examples:
  1. Garantía si la hay.
  1. Política de devolución.
  1. Términos de envío, si aplica.
- 1. Formas de abordar disputas, indemnización, responsabilidad, etc. 
+ 1. Formas de abordar disputas, indemnización, responsabilidad, etc.
  1. Dirección y contacto de su empresa."
 DocType: Issue,Issue Type,Tipo de Problema
 DocType: Attendance,Leave Type,Tipo de Licencia
@@ -3948,11 +3948,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,Seleccione un empleado para obtener el adelanto del empleado.
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,Por favor seleccione una fecha valida
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,Seleccione la naturaleza de su negocio.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5038,7 +5038,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,Nombre del Solicitante
 DocType: Authorization Rule,Customer / Item Name,Cliente / Nombre de Artículo
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","Si está habilitado, los detalles de la última compra de los artículos no se obtendrán de la orden de compra anterior o recibo de compra"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 
@@ -5503,7 +5503,7 @@ apps/erpnext/erpnext/accounts/doctype/fiscal_year/fiscal_year.py +82,Year start 
 apps/erpnext/erpnext/selling/doctype/customer/customer.py +122,Please mention the Lead Name in Lead {0},Por favor mencione el nombre principal en la iniciativa {0}
 apps/erpnext/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py +156,Start date should be less than end date for Item {0},La fecha de inicio debe ser menor que la fecha de finalización para el producto {0}
 DocType: Item,"Example: ABCD.#####
-If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","Ejemplo:. ABCD ##### 
+If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","Ejemplo:. ABCD #####
  Si la serie se establece y el número de serie no se menciona en las transacciones, entonces se creara un número de serie automático sobre la base de esta serie. Si siempre quiere mencionar explícitamente los números de serie para este artículo, déjelo en blanco."
 DocType: Upload Attendance,Upload Attendance,Subir Asistencia
 apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.js +616,BOM and Manufacturing Quantity are required,Se requiere la lista de materiales (LdM) y cantidad a manufacturar.

--- a/erpnext/translations/et.csv
+++ b/erpnext/translations/et.csv
@@ -1020,7 +1020,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1210,7 +1210,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,Põhivara Entry
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,Palun valige dokumendi tüüp esimene
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,Tühista Material Külastusi {0} enne tühistades selle Hooldus Külasta
-DocType: Crop Cycle,ISO 8016 standard,ISO 8016 standard
+DocType: Crop Cycle,ISO 8601 standard,ISO 8601 standard
 DocType: Pricing Rule,Rate or Discount,Hind või soodustus
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},Serial No {0} ei kuulu Punkt {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,Nõutav Kogus
@@ -3033,7 +3033,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3935,11 +3935,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,"Valige töötaja, et saada töötaja ette."
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,Valige kehtiv kuupäev
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,Vali laadi oma äri.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5024,7 +5024,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,Taotleja nimi
 DocType: Authorization Rule,Customer / Item Name,Klienditeenindus / Nimetus
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","Kui see on lubatud, ei võeta eelmise ostutellimuse või ostukviitungi kohta eelmiste ostude üksikasju"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 

--- a/erpnext/translations/fa.csv
+++ b/erpnext/translations/fa.csv
@@ -1020,7 +1020,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1210,7 +1210,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,ورود استهلاک
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,لطفا ابتدا نوع سند را انتخاب کنید
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,لغو مواد بازدید {0} قبل از لغو این نگهداری سایت
-DocType: Crop Cycle,ISO 8016 standard,ایزو 8016 استاندارد
+DocType: Crop Cycle,ISO 8601 standard,ایزو 8601 استاندارد
 DocType: Pricing Rule,Rate or Discount,نرخ یا تخفیف
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},سریال بدون {0} به مورد تعلق ندارد {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,مورد نیاز تعداد
@@ -3034,7 +3034,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3936,11 +3936,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,یک کارمند را برای پیشبرد کارمند انتخاب کنید
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,لطفا یک تاریخ معتبر را انتخاب کنید
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,ماهیت کسب و کار خود را انتخاب کنید.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5026,7 +5026,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,نام متقاضی
 DocType: Authorization Rule,Customer / Item Name,مشتری / نام آیتم
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt",در صورت فعال بودن، آخرین جزئیات خرید اقلام از سفارش خرید قبلی یا رسید خرید بدست نمی آید
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 

--- a/erpnext/translations/fi.csv
+++ b/erpnext/translations/fi.csv
@@ -1020,7 +1020,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1210,7 +1210,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,Poistot Entry
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,Valitse ensin asiakirjan tyyppi
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,Peru materiaalikäynti {0} ennen huoltokäynnin perumista
-DocType: Crop Cycle,ISO 8016 standard,ISO 8016 -standardi
+DocType: Crop Cycle,ISO 8601 standard,ISO 8601 -standardi
 DocType: Pricing Rule,Rate or Discount,Hinta tai alennus
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},Sarjanumero {0} ei kuulu tuotteelle {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,vaadittu yksikkömäärä
@@ -3034,7 +3034,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3936,11 +3936,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,"Valitse työntekijä, jotta työntekijä etenee."
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,Valitse voimassa oleva päivämäärä
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,Valitse liiketoiminnan luonteesta.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5026,18 +5026,18 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,hakijan nimi
 DocType: Authorization Rule,Customer / Item Name,Asiakas / Nimikkeen nimi
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","Jos tämä asetus on otettu käyttöön, viimeisiä ostotiedot eivät noudu edellisestä ostotilauksesta tai ostokuitista"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 
 For Example: If you are selling Laptops and Backpacks separately and have a special price if the customer buys both, then the Laptop + Backpack will be a new Product Bundle Item.
 
-Note: BOM = Bill of Materials","Koosta useita nimikkeitä tuotepaketiksi. 
+Note: BOM = Bill of Materials","Koosta useita nimikkeitä tuotepaketiksi.
 Koostaminen on kätevä tapa ryhmitellä tietyt nimikkeet paketiksi ja se mahdollistaa paketissa olevien nimikkeiden varastosaldon seurannan tuotepaketti -nimikkeen sijaan.
 
 Tuotepaketti -nimike ""ei ole varastonimike"" mutta ""on myyntinimike"".
 
-Esimerkki: 
+Esimerkki:
 Myytäessä kannettavia tietokoneita sekä niihin sopivia laukkuja, asiakkaalle annetaan alennus mikäli hän ostaa molemmat. Täten ""tietokone + laukku"" muodostavat uuden tuotepaketin."
 apps/erpnext/erpnext/selling/doctype/installation_note/installation_note.py +42,Serial No is mandatory for Item {0},Sarjanumero vaaditaan tuotteelle {0}
 DocType: Item Variant Attribute,Attribute,tuntomerkki

--- a/erpnext/translations/fr.csv
+++ b/erpnext/translations/fr.csv
@@ -1020,7 +1020,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1031,15 +1031,15 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 6. Amount: Tax amount.
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
-9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","Modèle de la taxe standard qui peut être appliqué à toutes les Opérations d'Achat. Ce modèle peut contenir la liste des titres d'impôts ainsi que d'autres titre de charges comme ""Livraison"", ""Assurance"", ""Gestion"", etc. 
+9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","Modèle de la taxe standard qui peut être appliqué à toutes les Opérations d'Achat. Ce modèle peut contenir la liste des titres d'impôts ainsi que d'autres titre de charges comme ""Livraison"", ""Assurance"", ""Gestion"", etc.
 
-#### Remarque 
+#### Remarque
 
 Le taux d'imposition que vous définissez ici sera le taux d'imposition standard pour tous les **Articles**. S'il y a des **Articles** qui ont des taux différents, ils doivent être ajoutés dans la table **Taxe de l'Article** dans les données de base **Article**.
 
 #### Description des Colonnes
 
-1. Type de Calcul : 
+1. Type de Calcul :
     - Cela peut être le **Total Net** (qui est la somme des montants de base).
     - **Total / Montant Sur la Ligne Précédente** (pour les taxes ou frais accumulés). Si vous sélectionnez cette option, la taxe sera appliquée en pourcentage du montant ou du total de la ligne précédente (dans la table d'impôts).
     - **Réel** (comme mentionné).
@@ -1230,7 +1230,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,Ecriture d’Amortissement
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,Veuillez d’abord sélectionner le type de document
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,Annuler les Visites Matérielles {0} avant d'annuler cette Visite de Maintenance
-DocType: Crop Cycle,ISO 8016 standard,Norme ISO 8016
+DocType: Crop Cycle,ISO 8601 standard,Norme ISO 8601
 DocType: Pricing Rule,Rate or Discount,Prix unitaire ou réduction
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},N° de Série {0} n'appartient pas à l'Article {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,Qté Requise
@@ -3055,7 +3055,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3067,15 +3067,15 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
 9. Consider Tax or Charge for: In this section you can specify if the tax / charge is only for valuation (not a part of total) or only for total (does not add value to the item) or for both.
-10. Add or Deduct: Whether you want to add or deduct the tax.","Modèle de la taxe standard qui peut être appliqué à toutes les Opérations d'Achat. Ce modèle peut contenir la liste des titres d'impôts ainsi que d'autres titre de charges comme ""Livraison"", ""Assurance"", ""Gestion"", etc. 
+10. Add or Deduct: Whether you want to add or deduct the tax.","Modèle de la taxe standard qui peut être appliqué à toutes les Opérations d'Achat. Ce modèle peut contenir la liste des titres d'impôts ainsi que d'autres titre de charges comme ""Livraison"", ""Assurance"", ""Gestion"", etc.
 
-#### Remarque 
+#### Remarque
 
 Le taux d'imposition que vous définissez ici sera le taux d'imposition standard pour tous les **Articles**. S'il y a des **Articles** qui ont des taux différents, ils doivent être ajoutés dans la table **Taxe de l'Article** dans les données de base **Article**.
 
 #### Description des Colonnes
 
-1. Type de Calcul : 
+1. Type de Calcul :
     - Cela peut être le **Total Net** (qui est la somme des montants de base).
     - **Total / Montant Sur la Ligne Précédente** (pour les taxes ou frais accumulés). Si vous sélectionnez cette option, la taxe sera appliquée en pourcentage du montant ou du total de la ligne précédente (dans la table d'impôts).
     - **Réel** (comme mentionné).
@@ -3357,7 +3357,7 @@ Examples:
 1. Ways of addressing disputes, indemnity, liability, etc.
 1. Address and Contact of your Company.","Termes et Conditions Standard qui peuvent être ajoutés aux Ventes et Achats.
 
-Exemples : 
+Exemples :
 
 1. Validité de l'offre.
 2. Conditions de paiement (À l'Avance, À Crédit, une partie en avance, etc).
@@ -3366,7 +3366,7 @@ Exemples :
 4. Garantie, le cas échéant.
 5. Politique de Retour.
 6. Conditions de Livraison, le cas échéant.
-7. Règlement des litiges, indemnisation, responsabilité, etc. 
+7. Règlement des litiges, indemnisation, responsabilité, etc.
 8. Adresse et Contact de votre Société."
 DocType: Issue,Issue Type,type de probleme
 DocType: Attendance,Leave Type,Type de Congé
@@ -3989,11 +3989,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,Sélectionnez un employé pour obtenir l'avance employé.
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,S&#39;il vous plaît sélectionnez une date valide
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,Sélectionner la nature de votre entreprise.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5079,7 +5079,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,Nom du Candidat
 DocType: Authorization Rule,Customer / Item Name,Nom du Client / de l'Article
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","Si cette option est activée, les derniers détails d&#39;achat des articles ne seront pas récupérés à partir du bon de commande précédent ou du reçu d&#39;achat."
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 

--- a/erpnext/translations/gu.csv
+++ b/erpnext/translations/gu.csv
@@ -1020,7 +1020,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1210,7 +1210,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,અવમૂલ્યન એન્ટ્રી
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,પ્રથમ દસ્તાવેજ પ્રકાર પસંદ કરો
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,આ જાળવણી મુલાકાત લો રદ રદ સામગ્રી મુલાકાત {0}
-DocType: Crop Cycle,ISO 8016 standard,આઇએસઓ 8016 સ્ટાન્ડર્ડ
+DocType: Crop Cycle,ISO 8601 standard,આઇએસઓ 8601 સ્ટાન્ડર્ડ
 DocType: Pricing Rule,Rate or Discount,દર અથવા ડિસ્કાઉન્ટ
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},સીરીયલ કોઈ {0} વસ્તુ ને અનુલક્ષતું નથી {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,જરૂરી Qty
@@ -3033,7 +3033,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3934,11 +3934,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,કર્મચારીને આગળ વધારવા માટે એક કર્મચારીને પસંદ કરો
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,કૃપા કરી કોઈ માન્ય તારીખ પસંદ કરો
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,તમારા વેપાર સ્વભાવ પસંદ કરો.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5024,7 +5024,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,અરજદારનું નામ
 DocType: Authorization Rule,Customer / Item Name,ગ્રાહક / વસ્તુ નામ
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","જો સક્ષમ કરેલ હોય, તો આઇટમ્સની છેલ્લી ખરીદીની વિગતો પાછલી ખરીદ ઑર્ડર અથવા ખરીદી રસીદથી મેળવવામાં આવશે નહીં"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 

--- a/erpnext/translations/hi.csv
+++ b/erpnext/translations/hi.csv
@@ -1020,7 +1020,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1031,19 +1031,19 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 6. Amount: Tax amount.
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
-9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","सभी बिक्री लेनदेन करने के लिए लागू किया जा सकता है कि मानक कर टेम्पलेट। इस टेम्पलेट 
+9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","सभी बिक्री लेनदेन करने के लिए लागू किया जा सकता है कि मानक कर टेम्पलेट। इस टेम्पलेट
 
- कर की दर आप ध्यान दें #### 
+ कर की दर आप ध्यान दें ####
 
  आदि ""हैंडलिंग"", कर सिर और ""नौवहन"", ""बीमा"" की तरह भी अन्य व्यय / आय प्रमुखों की सूची में शामिल कर सकते हैं ** सब ** आइटम के लिए मानक कर की दर हो जाएगा यहाँ परिभाषित करते हैं। अलग दर है ** कि ** आइटम हैं, तो वे ** आइटम टैक्स में जोड़ा जाना चाहिए ** ** आइटम ** मास्टर में मेज।
 
- #### कॉलम 
+ #### कॉलम
 
- 1 का विवरण। गणना के प्रकार: 
+ 1 का विवरण। गणना के प्रकार:
  - इस पर हो सकता है ** नेट (कि मूल राशि का योग है) ** कुल।
  - ** पिछली पंक्ति कुल / राशि ** पर (संचयी कर या शुल्क के लिए)। यदि आप इस विकल्प का चयन करते हैं, कर राशि या कुल (कर तालिका में) पिछली पंक्ति के एक प्रतिशत के रूप में लागू किया जाएगा।
  - ** ** वास्तविक (उल्लेख किया है)।
- दो। खाता सिर: इस कर 
+ दो। खाता सिर: इस कर
  3 बुक किया जा जाएगा, जिसके तहत खाता बही। लागत केंद्र: टैक्स / प्रभारी (शिपिंग) की तरह एक आय है या खर्च तो यह एक लागत केंद्र के खिलाफ बुक किया जा करने की जरूरत है।
  4। विवरण: टैक्स का विवरण (चालान कि / उद्धरण में मुद्रित किया जाएगा)।
  5। दर: टैक्स की दर।
@@ -1229,7 +1229,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,मूल्यह्रास एंट्री
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,पहला दस्तावेज़ प्रकार का चयन करें
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,इस रखरखाव भेंट रद्द करने से पहले सामग्री का दौरा {0} रद्द
-DocType: Crop Cycle,ISO 8016 standard,आईएसओ 8016 मानक
+DocType: Crop Cycle,ISO 8601 standard,आईएसओ 8601 मानक
 DocType: Pricing Rule,Rate or Discount,दर या डिस्काउंट
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},धारावाहिक नहीं {0} मद से संबंधित नहीं है {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,आवश्यक मात्रा
@@ -3055,7 +3055,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3067,19 +3067,19 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
 9. Consider Tax or Charge for: In this section you can specify if the tax / charge is only for valuation (not a part of total) or only for total (does not add value to the item) or for both.
-10. Add or Deduct: Whether you want to add or deduct the tax.","सभी खरीद लेनदेन करने के लिए लागू किया जा सकता है कि मानक कर टेम्पलेट। इस टेम्पलेट आप यहाँ को परिभाषित 
+10. Add or Deduct: Whether you want to add or deduct the tax.","सभी खरीद लेनदेन करने के लिए लागू किया जा सकता है कि मानक कर टेम्पलेट। इस टेम्पलेट आप यहाँ को परिभाषित
 
- कर की दर नोट #### 
+ कर की दर नोट ####
 
  आदि ""हैंडलिंग"", कर सिर और ""नौवहन"", ""बीमा"" की तरह भी अन्य व्यय प्रमुखों की सूची में शामिल कर सकते हैं ** सब ** आइटम के लिए मानक कर की दर हो जाएगा। अलग दर है ** कि ** आइटम हैं, तो वे ** आइटम टैक्स में जोड़ा जाना चाहिए ** ** आइटम ** मास्टर में मेज।
 
- #### कॉलम 
+ #### कॉलम
 
- 1 का विवरण। गणना के प्रकार: 
+ 1 का विवरण। गणना के प्रकार:
  - इस पर हो सकता है ** नेट (कि मूल राशि का योग है) ** कुल।
  - ** पिछली पंक्ति कुल / राशि ** पर (संचयी कर या शुल्क के लिए)। यदि आप इस विकल्प का चयन करते हैं, कर राशि या कुल (कर तालिका में) पिछली पंक्ति के एक प्रतिशत के रूप में लागू किया जाएगा।
  - ** ** वास्तविक (उल्लेख किया है)।
- दो। खाता सिर: इस कर 
+ दो। खाता सिर: इस कर
  3 बुक किया जा जाएगा, जिसके तहत खाता बही। लागत केंद्र: टैक्स / प्रभारी (शिपिंग) की तरह एक आय है या खर्च तो यह एक लागत केंद्र के खिलाफ बुक किया जा करने की जरूरत है।
  4। विवरण: टैक्स का विवरण (चालान कि / उद्धरण में मुद्रित किया जाएगा)।
  5। दर: टैक्स की दर।
@@ -3357,7 +3357,7 @@ Examples:
 1. Ways of addressing disputes, indemnity, liability, etc.
 1. Address and Contact of your Company.","मानक नियमों और बिक्री और खरीद के लिए जोड़ा जा सकता है कि स्थितियां।
 
- उदाहरण: 
+ उदाहरण:
 
  1। ऑफर की वैधता।
  1। भुगतान की शर्तें (क्रेडिट पर अग्रिम में, भाग अग्रिम आदि)।
@@ -3366,7 +3366,7 @@ Examples:
  1। वारंटी यदि कोई हो।
  1। वापस नीती।
  1। शिपिंग की शर्तें, यदि लागू हो।
- 1। आदि को संबोधित विवाद, क्षतिपूर्ति, दायित्व, 
+ 1। आदि को संबोधित विवाद, क्षतिपूर्ति, दायित्व,
  1 के तरीके। पता और अपनी कंपनी के संपर्क।"
 DocType: Issue,Issue Type,समस्या का प्रकार
 DocType: Attendance,Leave Type,प्रकार छोड़ दो
@@ -3989,11 +3989,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,कर्मचारी अग्रिम के लिए एक कर्मचारी का चयन करें
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,कृपया एक वैध तिथि चुनें
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,आपके व्यवसाय की प्रकृति का चयन करें।
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -4815,7 +4815,7 @@ DocType: Accounts Settings,"If enabled, the system will post accounting entries 
 apps/erpnext/erpnext/setup/setup_wizard/data/industry_type.py +15,Brokerage,दलाली
 apps/erpnext/erpnext/hr/doctype/leave_application/leave_application.py +207,Attendance for employee {0} is already marked for this day,कर्मचारी {0} के लिए उपस्थिति पहले से ही इस दिन के लिए चिह्नित किया गया है
 DocType: Work Order Operation,"in Minutes
-Updated via 'Time Log'","मिनट में 
+Updated via 'Time Log'","मिनट में
  'टाइम प्रवेश' के माध्यम से अद्यतन"
 DocType: Customer,From Lead,लीड से
 apps/erpnext/erpnext/config/manufacturing.py +13,Orders released for production.,उत्पादन के लिए आदेश जारी किया.
@@ -5079,7 +5079,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,आवेदक के नाम
 DocType: Authorization Rule,Customer / Item Name,ग्राहक / मद का नाम
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","यदि सक्षम किया गया है, तो पिछले खरीदारी आदेश या खरीद रसीद से आइटम का अंतिम खरीदारी विवरण प्राप्त नहीं किया जाएगा"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 
@@ -5544,7 +5544,7 @@ apps/erpnext/erpnext/accounts/doctype/fiscal_year/fiscal_year.py +82,Year start 
 apps/erpnext/erpnext/selling/doctype/customer/customer.py +122,Please mention the Lead Name in Lead {0},लीड में लीड नाम का उल्लेख करें {0}
 apps/erpnext/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py +156,Start date should be less than end date for Item {0},प्रारंभ तिथि मद के लिए समाप्ति तिथि से कम होना चाहिए {0}
 DocType: Item,"Example: ABCD.#####
-If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","उदाहरण:। श्रृंखला के लिए निर्धारित है और सीरियल कोई लेन-देन में उल्लेख नहीं किया गया है, तो एबीसीडी ##### 
+If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","उदाहरण:। श्रृंखला के लिए निर्धारित है और सीरियल कोई लेन-देन में उल्लेख नहीं किया गया है, तो एबीसीडी #####
 , तो स्वत: सीरियल नंबर इस श्रृंखला के आधार पर बनाया जाएगा। आप हमेशा स्पष्ट रूप से इस मद के लिए सीरियल नंबर का उल्लेख करना चाहते हैं। इस खाली छोड़ दें।"
 DocType: Upload Attendance,Upload Attendance,उपस्थिति अपलोड
 apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.js +616,BOM and Manufacturing Quantity are required,बीओएम और विनिर्माण मात्रा की आवश्यकता होती है

--- a/erpnext/translations/hr.csv
+++ b/erpnext/translations/hr.csv
@@ -1020,7 +1020,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1031,19 +1031,19 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 6. Amount: Tax amount.
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
-9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","Standardni porez predložak koji se može primijeniti na sve prodajnih transakcija. Ovaj predložak može sadržavati popis poreznih glava, a također ostali rashodi / dohotka glave poput ""brodova"", ""osiguranje"", ""Rukovanje"" itd 
+9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","Standardni porez predložak koji se može primijeniti na sve prodajnih transakcija. Ovaj predložak može sadržavati popis poreznih glava, a također ostali rashodi / dohotka glave poput ""brodova"", ""osiguranje"", ""Rukovanje"" itd
 
- #### Napomena 
+ #### Napomena
 
  stopa poreza na vas definirati ovdje će biti standardna stopa poreza za sve ** Opcije **. Ako postoje ** Predmeti ** koji imaju različite cijene, one moraju biti dodan u ** točke poreza ** stol u ** točke ** majstora.
 
- #### Opis Kolumne 
+ #### Opis Kolumne
 
- 1. Vrsta Proračun: 
+ 1. Vrsta Proračun:
  - To može biti na ** Neto Ukupno ** (to je zbroj osnovnog iznosa).
  - ** U odnosu na prethodnu Row ukupno / Iznos ** (za kumulativne poreza ili troškova). Ako odaberete ovu opciju, porez će se primjenjivati postotak prethodnog reda (u poreznom sustavu) iznos ili ukupno.
  - ** Stvarni ** (kao što je navedeno).
- 2. Voditelj račun: knjiga računa pod kojima se ovaj porez će biti rezervirano 
+ 2. Voditelj račun: knjiga računa pod kojima se ovaj porez će biti rezervirano
  3. Trošak Centar: Ako porezni / naboj je prihod (kao što su utovar) i rashoda treba biti rezervirano protiv troška.
  4. Opis: Opis poreza (koji će se tiskati u račune / citati).
  5. Rate: Porezna stopa.
@@ -1229,7 +1229,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,Amortizacija Ulaz
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,Molimo odaberite vrstu dokumenta prvi
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,Odustani Posjeta materijala {0} prije otkazivanja ovog održavanja pohod
-DocType: Crop Cycle,ISO 8016 standard,ISO 8016 standard
+DocType: Crop Cycle,ISO 8601 standard,ISO 8601 standard
 DocType: Pricing Rule,Rate or Discount,Stopa ili Popust
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},Serijski Ne {0} ne pripada točki {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,Potrebna Kol
@@ -3055,7 +3055,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3067,19 +3067,19 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
 9. Consider Tax or Charge for: In this section you can specify if the tax / charge is only for valuation (not a part of total) or only for total (does not add value to the item) or for both.
-10. Add or Deduct: Whether you want to add or deduct the tax.","Standardni porez predložak koji se može primijeniti na sve kupovnih transakcija. Ovaj predložak može sadržavati popis poreznih glava, a također ostalih rashoda glave poput ""brodova"", ""osiguranje"", ""Rukovanje"" itd 
+10. Add or Deduct: Whether you want to add or deduct the tax.","Standardni porez predložak koji se može primijeniti na sve kupovnih transakcija. Ovaj predložak može sadržavati popis poreznih glava, a također ostalih rashoda glave poput ""brodova"", ""osiguranje"", ""Rukovanje"" itd
 
- #### Napomena 
+ #### Napomena
 
  porezna stopa ste odredili ovdje će biti standardna stopa poreza za sve ** Opcije **. Ako postoje ** Predmeti ** koji imaju različite cijene, one moraju biti dodan u ** točke poreza ** stol u ** točke ** majstora.
 
- #### Opis Kolumne 
+ #### Opis Kolumne
 
- 1. Vrsta Proračun: 
+ 1. Vrsta Proračun:
  - To može biti na ** Neto Ukupno ** (to je zbroj osnovnog iznosa).
  - ** U odnosu na prethodnu Row ukupno / Iznos ** (za kumulativne poreza ili troškova). Ako odaberete ovu opciju, porez će se primjenjivati postotak prethodnog reda (u poreznom sustavu) iznos ili ukupno.
  - ** Stvarni ** (kao što je navedeno).
- 2. Voditelj račun: knjiga računa pod kojima se ovaj porez će biti rezervirano 
+ 2. Voditelj račun: knjiga računa pod kojima se ovaj porez će biti rezervirano
  3. Trošak Centar: Ako porezni / naboj je prihod (kao što su utovar) i rashoda treba biti rezervirano protiv troška.
  4. Opis: Opis poreza (koji će se tiskati u račune / citati).
  5. Rate: Porezna stopa.
@@ -3357,7 +3357,7 @@ Examples:
 1. Ways of addressing disputes, indemnity, liability, etc.
 1. Address and Contact of your Company.","Standardni uvjeti koji se mogu dodati prodaje i kupnje.
 
- Primjeri: 
+ Primjeri:
 
  1. Valjanost ponude.
  1. Uvjeti plaćanja (unaprijed na kredit, dio unaprijed i sl).
@@ -3366,7 +3366,7 @@ Examples:
  1. Jamstvo ako ih ima.
  1. Vraća politike.
  1. Uvjeti dostave, ako je potrebno.
- 1. Načini adresiranja sporova, naknade štete, odgovornosti, itd 
+ 1. Načini adresiranja sporova, naknade štete, odgovornosti, itd
  1. Kontakt Vaše tvrtke."
 DocType: Issue,Issue Type,Vrsta izdanja
 DocType: Attendance,Leave Type,Vrsta odsustva
@@ -3989,11 +3989,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,Odaberite zaposlenika kako biste dobili zaposlenika unaprijed.
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,Odaberite valjani datum
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,Odaberite prirodu Vašeg poslovanja.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -4815,7 +4815,7 @@ DocType: Accounts Settings,"If enabled, the system will post accounting entries 
 apps/erpnext/erpnext/setup/setup_wizard/data/industry_type.py +15,Brokerage,Posredništvo
 apps/erpnext/erpnext/hr/doctype/leave_application/leave_application.py +207,Attendance for employee {0} is already marked for this day,Gledatelja za zaposlenika {0} već označena za ovaj dan
 DocType: Work Order Operation,"in Minutes
-Updated via 'Time Log'","U nekoliko minuta 
+Updated via 'Time Log'","U nekoliko minuta
  Ažurirano putem 'Time Log'"
 DocType: Customer,From Lead,Od Olovo
 apps/erpnext/erpnext/config/manufacturing.py +13,Orders released for production.,Narudžbe objavljen za proizvodnju.
@@ -5079,7 +5079,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,Podnositelj zahtjeva Ime
 DocType: Authorization Rule,Customer / Item Name,Kupac / Stavka Ime
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","Ako je omogućeno, posljednje pojedinosti o kupnji stavki neće se preuzeti iz prethodne narudžbenice ili računa za kupnju"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 
@@ -5544,7 +5544,7 @@ apps/erpnext/erpnext/accounts/doctype/fiscal_year/fiscal_year.py +82,Year start 
 apps/erpnext/erpnext/selling/doctype/customer/customer.py +122,Please mention the Lead Name in Lead {0},Navedite Lead Name u Lead {0}
 apps/erpnext/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py +156,Start date should be less than end date for Item {0},Početak bi trebao biti manji od krajnjeg datuma za točke {0}
 DocType: Item,"Example: ABCD.#####
-If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","Primjer:. ABCD ##### 
+If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","Primjer:. ABCD #####
  Ako Serija je postavljena i serijski broj ne spominje u prometu, a zatim automatsko serijski broj će biti izrađen na temelju ove serije. Ako ste uvijek žele eksplicitno spomenuti serijski brojevi za tu stavku. ostavite praznim."
 DocType: Upload Attendance,Upload Attendance,Upload Attendance
 apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.js +616,BOM and Manufacturing Quantity are required,BOM i proizvodnja Količina potrebne su

--- a/erpnext/translations/hu.csv
+++ b/erpnext/translations/hu.csv
@@ -1020,7 +1020,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1210,7 +1210,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,ÉCS bejegyzés
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,"Kérjük, válassza ki a dokumentum típusát először"
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,Törölje az anyag szemlét: {0}mielőtt törölné ezt a karbantartási látogatást
-DocType: Crop Cycle,ISO 8016 standard,ISO 8016 szabvány
+DocType: Crop Cycle,ISO 8601 standard,ISO 8601 szabvány
 DocType: Pricing Rule,Rate or Discount,Árérték vagy kedvezmény
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},Széria sz {0} nem tartozik ehhez a tételhez {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,Kötelező Mennyiség
@@ -2169,7 +2169,7 @@ DocType: Packing Slip,PS-,CSOMJ-
 DocType: Member,Non Profit Member,Nonprofit alapítvány tagja
 apps/erpnext/erpnext/accounts/doctype/gl_entry/gl_entry.py +67,{0} {1}: Cost Center is required for 'Profit and Loss' account {2}. Please set up a default Cost Center for the Company.,"{0} {1}: Költséghely szükséges az 'Eredménykimutatás' számlához {2}. Kérjük, állítsa be az alapértelmezett Költséghelyet a Vállalkozáshoz."
 DocType: Payment Schedule,Payment Term,Fizetési feltétel
-apps/erpnext/erpnext/selling/doctype/customer/customer.py +160,A Customer Group exists with same name please change the Customer name or rename the Customer Group,"Egy vevő csoport létezik azonos névvel, kérjük változtassa meg a Vevő nevét vagy nevezze át a 
+apps/erpnext/erpnext/selling/doctype/customer/customer.py +160,A Customer Group exists with same name please change the Customer name or rename the Customer Group,"Egy vevő csoport létezik azonos névvel, kérjük változtassa meg a Vevő nevét vagy nevezze át a
 Vevői csoportot"
 DocType: Land Unit,Area,Terület
 apps/erpnext/erpnext/public/js/templates/contact_list.html +37,New Contact,Új kapcsolat
@@ -3034,7 +3034,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3936,11 +3936,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,"Válassza ki a munkavállalót, hogy megkapja a munkavállaló előleget."
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,"Kérjük, válasszon egy érvényes dátumot"
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,Válassza ki a vállalkozása fajtáját.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5026,7 +5026,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,Kérelmező neve
 DocType: Authorization Rule,Customer / Item Name,Vevő / Tétel Név
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","Ha engedélyezve van, az elemek utolsó vásárlási adatai nem származnak a korábbi vásárlói rendelésről vagy vásárlási nyugtaról"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 

--- a/erpnext/translations/id.csv
+++ b/erpnext/translations/id.csv
@@ -1020,7 +1020,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1210,7 +1210,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,penyusutan Masuk
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,Silakan pilih jenis dokumen terlebih dahulu
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,Batal Kunjungan Material {0} sebelum membatalkan ini Maintenance Visit
-DocType: Crop Cycle,ISO 8016 standard,Standar ISO 8016
+DocType: Crop Cycle,ISO 8601 standard,Standar ISO 8601
 DocType: Pricing Rule,Rate or Discount,Tarif atau Diskon
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},Serial ada {0} bukan milik Stok Barang {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,Qty Diperlukan
@@ -3036,7 +3036,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3048,19 +3048,19 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
 9. Consider Tax or Charge for: In this section you can specify if the tax / charge is only for valuation (not a part of total) or only for total (does not add value to the item) or for both.
-10. Add or Deduct: Whether you want to add or deduct the tax.","Pajak standar template yang dapat diterapkan untuk semua Transaksi Pembelian. Template ini dapat berisi daftar kepala pajak dan juga kepala biaya lain seperti ""Pengiriman"", ""Asuransi"", ""Penanganan"" dll 
+10. Add or Deduct: Whether you want to add or deduct the tax.","Pajak standar template yang dapat diterapkan untuk semua Transaksi Pembelian. Template ini dapat berisi daftar kepala pajak dan juga kepala biaya lain seperti ""Pengiriman"", ""Asuransi"", ""Penanganan"" dll
 
- #### Catatan 
+ #### Catatan
 
  Tarif pajak Anda mendefinisikan sini akan menjadi tarif pajak standar untuk semua item ** **. Jika ada Item ** ** yang memiliki tarif yang berbeda, mereka harus ditambahkan dalam ** Pajak Stok Barang ** meja di ** Stok Barang ** menguasai.
 
- #### Deskripsi Kolom 
+ #### Deskripsi Kolom
 
- 1. Perhitungan Type: 
+ 1. Perhitungan Type:
  - Ini bisa berada di ** Net Jumlah ** (yang adalah jumlah dari jumlah dasar).
  - ** Pada Row Sebelumnya Jumlah / Amount ** (untuk pajak kumulatif atau biaya). Jika Anda memilih opsi ini, pajak akan diterapkan sebagai persentase dari baris sebelumnya (dalam tabel pajak) jumlah atau total.
  - ** Aktual ** (seperti yang disebutkan).
- 2. Akun Kepala: Account buku di mana pajak ini akan dipesan 
+ 2. Akun Kepala: Account buku di mana pajak ini akan dipesan
  3. Biaya Center: Jika pajak / biaya adalah penghasilan (seperti pengiriman) atau beban perlu dipesan terhadap Cost Center.
  4. Keterangan: Deskripsi pajak (yang akan dicetak dalam faktur / tanda kutip).
  5. Tarif: Tarif Pajak.
@@ -3958,11 +3958,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,Pilih karyawan untuk mendapatkan uang muka karyawan.
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,Silakan pilih tanggal yang valid
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,Pilih jenis bisnis anda.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5048,7 +5048,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,Nama Pemohon
 DocType: Authorization Rule,Customer / Item Name,Nama Pelanggan / Barang
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","Jika diaktifkan, rincian pembelian terakhir barang tidak akan diambil dari pesanan pembelian sebelumnya atau tanda terima pembelian"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 
@@ -5513,7 +5513,7 @@ apps/erpnext/erpnext/accounts/doctype/fiscal_year/fiscal_year.py +82,Year start 
 apps/erpnext/erpnext/selling/doctype/customer/customer.py +122,Please mention the Lead Name in Lead {0},Harap sebutkan Nama Prospek di Prospek {0}
 apps/erpnext/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py +156,Start date should be less than end date for Item {0},Tanggal mulai harus kurang dari tanggal akhir untuk Item {0}
 DocType: Item,"Example: ABCD.#####
-If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","Contoh:. ABCD ##### 
+If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","Contoh:. ABCD #####
  Jika seri diatur dan Nomor Seri tidak disebutkan dalam transaksi, maka nomor seri otomatis akan dibuat berdasarkan seri ini. Jika Anda ingin selalu menetapkan Nomor Seri untuk item ini, biarkan kosong."
 DocType: Upload Attendance,Upload Attendance,Unggah Kehadiran
 apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.js +616,BOM and Manufacturing Quantity are required,BOM dan Kuantitas Manufaktur diperlukan

--- a/erpnext/translations/is.csv
+++ b/erpnext/translations/is.csv
@@ -1020,7 +1020,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1210,7 +1210,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,Afskriftir Entry
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,Vinsamlegast veldu tegund skjals fyrst
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,Hætta Efni Heimsóknir {0} áður hætta þessu Viðhald Farðu
-DocType: Crop Cycle,ISO 8016 standard,ISO 8016 staðall
+DocType: Crop Cycle,ISO 8601 standard,ISO 8601 staðall
 DocType: Pricing Rule,Rate or Discount,Verð eða afsláttur
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},Serial Nei {0} ekki tilheyra lið {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,Required Magn
@@ -3034,7 +3034,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3936,11 +3936,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,Veldu starfsmann til að fá starfsmanninn fyrirfram.
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,Vinsamlegast veldu gild dagsetningu
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,Veldu eðli rekstrar þíns.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5025,7 +5025,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,umsækjandi Nafn
 DocType: Authorization Rule,Customer / Item Name,Viðskiptavinur / Item Name
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt",Ef slökkt er á því verður ekki hægt að sækja síðasta kaupupplýsingarnar um hluti úr fyrri kaupáfangi eða kvittun
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 

--- a/erpnext/translations/it.csv
+++ b/erpnext/translations/it.csv
@@ -1009,7 +1009,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1020,19 +1020,19 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 6. Amount: Tax amount.
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
-9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","Modello fiscale standard che può essere applicato a tutte le transazioni di vendita. Questo modello può contenere l'elenco delle teste fiscali e anche altri capi oneri / proventi come ""spedizione"", ""Assicurazioni"", ""Gestione"", ecc 
+9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","Modello fiscale standard che può essere applicato a tutte le transazioni di vendita. Questo modello può contenere l'elenco delle teste fiscali e anche altri capi oneri / proventi come ""spedizione"", ""Assicurazioni"", ""Gestione"", ecc
 
- #### Nota 
+ #### Nota
 
  Il tax rate si definire qui sarà l'aliquota standard per tutti gli articoli ** **. Se ci sono gli articoli ** ** che hanno tariffe diverse, devono essere aggiunti nella voce imposte ** ** tavolo in ** ** Item master.
 
- #### Descrizione di colonne 
+ #### Descrizione di colonne
 
- 1. Tipo di calcolo: 
+ 1. Tipo di calcolo:
  - Questo può essere di ** Net Total ** (che è la somma di importo di base).
  - ** Il Fila Indietro Total / Importo ** (per le imposte o tasse cumulative). Selezionando questa opzione, l'imposta sarà applicata come percentuale della riga precedente (nella tabella fiscale) importo o totale.
  - ** ** Actual (come detto).
- 2. Account testa: Il registro account con cui questa imposta sarà prenotato 
+ 2. Account testa: Il registro account con cui questa imposta sarà prenotato
  3. Centro di costo: se l'imposta / tassa è di un reddito (come il trasporto) o spese deve essere prenotato contro un centro di costo.
  4. Descrizione: Descrizione della tassa (che sarà stampato in fatture / virgolette).
  5. Vota: Aliquota.
@@ -1218,7 +1218,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,Ammortamenti Entry
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,Si prega di selezionare il tipo di documento prima
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,Annulla Visite Materiale {0} prima di annullare questa visita di manutenzione
-DocType: Crop Cycle,ISO 8016 standard,ISO 8016 standard
+DocType: Crop Cycle,ISO 8601 standard,ISO 8601 standard
 DocType: Pricing Rule,Rate or Discount,Tasso o Sconto
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},Serial No {0} non appartiene alla voce {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,Quantità richiesta
@@ -3013,7 +3013,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3025,19 +3025,19 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
 9. Consider Tax or Charge for: In this section you can specify if the tax / charge is only for valuation (not a part of total) or only for total (does not add value to the item) or for both.
-10. Add or Deduct: Whether you want to add or deduct the tax.","Modello fiscale standard che può essere applicato a tutte le transazioni di acquisto. Questo modello può contenere l'elenco delle teste fiscali e anche altri capi di spesa come ""spedizione"", ""Assicurazioni"", ""Gestione"", ecc 
+10. Add or Deduct: Whether you want to add or deduct the tax.","Modello fiscale standard che può essere applicato a tutte le transazioni di acquisto. Questo modello può contenere l'elenco delle teste fiscali e anche altri capi di spesa come ""spedizione"", ""Assicurazioni"", ""Gestione"", ecc
 
- #### Nota 
+ #### Nota
 
  Il tax rate si definisce qui sarà l'aliquota standard per tutti gli articoli ** **. Se ci sono gli articoli ** ** che hanno tariffe diverse, devono essere aggiunti nella voce imposte ** ** tavolo in ** ** Item master.
 
- #### Descrizione di colonne 
+ #### Descrizione di colonne
 
- 1. Tipo di calcolo: 
+ 1. Tipo di calcolo:
  - Questo può essere di ** Net Total ** (che è la somma di importo di base).
  - ** Il Fila Indietro Total / Importo ** (per le imposte o tasse cumulative). Selezionando questa opzione, l'imposta sarà applicata come percentuale della riga precedente (nella tabella fiscale) importo o totale.
  - ** ** Actual (come detto).
- 2. Account testa: Il registro account con cui questa imposta sarà prenotato 
+ 2. Account testa: Il registro account con cui questa imposta sarà prenotato
  3. Centro di costo: se l'imposta / tassa è di un reddito (come il trasporto) o spese deve essere prenotato contro un centro di costo.
  4. Descrizione: Descrizione della tassa (che sarà stampato in fatture / virgolette).
  5. Vota: Aliquota.
@@ -3307,7 +3307,7 @@ Examples:
 1. Ways of addressing disputes, indemnity, liability, etc.
 1. Address and Contact of your Company.","Condizioni generali e condizioni che possono essere aggiunti alle Vendite e Acquisti.
 
- Esempi: 
+ Esempi:
 
  1. Validità dell'offerta.
  1. Termini di pagamento (in anticipo, a credito, parte prima, ecc).
@@ -3316,7 +3316,7 @@ Examples:
  1. Garanzia se presente.
  1. Recesso.
  1. Condizioni di trasporto, se applicabile.
- 1. Modi di controversie indirizzamento, indennità, responsabilità, ecc 
+ 1. Modi di controversie indirizzamento, indennità, responsabilità, ecc
  1. Indirizzo e contatti della vostra azienda."
 DocType: Issue,Issue Type,tipo di Problema
 DocType: Attendance,Leave Type,Lascia Tipo
@@ -3931,11 +3931,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,Seleziona un dipendente per far avanzare il dipendente.
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,Si prega di selezionare una data valida
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,Selezionare la natura della vostra attività.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -4996,7 +4996,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,Nome del Richiedente
 DocType: Authorization Rule,Customer / Item Name,Cliente / Nome Articolo
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","Se abilitato, gli ultimi dettagli di acquisto degli articoli non saranno recuperati dal precedente ordine di acquisto o dalla ricevuta di acquisto"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 

--- a/erpnext/translations/ja.csv
+++ b/erpnext/translations/ja.csv
@@ -1021,7 +1021,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1237,7 +1237,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,減価償却エントリ
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,文書タイプを選択してください
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,この保守訪問をキャンセルする前に資材訪問{0}をキャンセルしなくてはなりません
-DocType: Crop Cycle,ISO 8016 standard,ISO 8016規格
+DocType: Crop Cycle,ISO 8601 standard,ISO 8601規格
 DocType: Pricing Rule,Rate or Discount,レートまたは割引
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},アイテム {1} に関連付けが無いシリアル番号 {0}
 DocType: Purchase Receipt Item Supplied,Required Qty,必要な数量
@@ -3067,7 +3067,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -4007,11 +4007,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,従業員を選択して従業員の進級を取得します。
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,有効な日付を選択してください
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,あなたのビジネスの性質を選択します。
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5098,7 +5098,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,申請者名
 DocType: Authorization Rule,Customer / Item Name,顧客／アイテム名
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt",有効にした場合、前回の発注または領収書からアイテムの最新の購入詳細が取得されません
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 

--- a/erpnext/translations/km.csv
+++ b/erpnext/translations/km.csv
@@ -1019,7 +1019,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1209,7 +1209,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,ចូលរំលស់
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,សូមជ្រើសប្រភេទឯកសារនេះជាលើកដំបូង
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,បោះបង់ការមើលសម្ភារៈ {0} មុនពេលលុបចោលដំណើរទស្សនកិច្ចនេះជួសជុល
-DocType: Crop Cycle,ISO 8016 standard,ស្តង់ដារ ISO 8016
+DocType: Crop Cycle,ISO 8601 standard,ស្តង់ដារ ISO 8601
 DocType: Pricing Rule,Rate or Discount,អត្រាឬបញ្ចុះតម្លៃ
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},សៀរៀលគ្មាន {0} មិនមែនជារបស់ធាតុ {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,តម្រូវការ Qty
@@ -3033,7 +3033,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3938,11 +3938,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,ជ្រើសរើសនិយោជិកដើម្បីទទួលបានបុគ្គលិក។
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,សូមជ្រើសរើសកាលបរិច្ឆេទដែលត្រឹមត្រូវ
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,ជ្រើសធម្មជាតិនៃអាជីវកម្មរបស់អ្នក។
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5046,7 +5046,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,ឈ្មោះកម្មវិធី
 DocType: Authorization Rule,Customer / Item Name,អតិថិជន / ធាតុឈ្មោះ
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt",ប្រសិនបើបានបើកព័ត៌មានលំអិតនៃការទិញចុងក្រោយនៃទំនិញនឹងមិនត្រូវបានយកចេញពីលំដាប់ទិញឬបង្កាន់ដៃទិញមុនទេ
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 

--- a/erpnext/translations/kn.csv
+++ b/erpnext/translations/kn.csv
@@ -1033,7 +1033,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1044,19 +1044,19 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 6. Amount: Tax amount.
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
-9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","ಎಲ್ಲಾ ಮಾರಾಟದ ಟ್ರಾನ್ಸಾಕ್ಷನ್ಸ್ ಅನ್ವಯಿಸಬಹುದು ಸ್ಟ್ಯಾಂಡರ್ಡ್ ತೆರಿಗೆ ಟೆಂಪ್ಲೆಟ್. ಈ ಟೆಂಪ್ಲೇಟ್ 
+9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","ಎಲ್ಲಾ ಮಾರಾಟದ ಟ್ರಾನ್ಸಾಕ್ಷನ್ಸ್ ಅನ್ವಯಿಸಬಹುದು ಸ್ಟ್ಯಾಂಡರ್ಡ್ ತೆರಿಗೆ ಟೆಂಪ್ಲೆಟ್. ಈ ಟೆಂಪ್ಲೇಟ್
 
- ತೆರಿಗೆ ನೀವು ಗಮನಿಸಿ #### 
+ ತೆರಿಗೆ ನೀವು ಗಮನಿಸಿ ####
 
  ಇತ್ಯಾದಿ ""ನಿರ್ವಹಣೆ"" ತೆರಿಗೆ ತಲೆ ಮತ್ತು ""ಶಿಪ್ಪಿಂಗ್"", ""ವಿಮೆ"" ನಂತಹ ಇತರ ವೆಚ್ಚದಲ್ಲಿ / ಆದಾಯ ತಲೆ ಪಟ್ಟಿ ಹೊಂದಿರಬಹುದು ** ಎಲ್ಲಾ ** ಐಟಂಗಳು ಗುಣಮಟ್ಟ ತೆರಿಗೆ ಇರುತ್ತದೆ ಇಲ್ಲಿ ವ್ಯಾಖ್ಯಾನಿಸಲು. ಬೇರೆ ಬೇರೆ ದರಗಳನ್ನು ಹೊಂದಿವೆ ** ಎಂದು ** ಐಟಂಗಳು ಎಂದಾದರೆ ಅವರು ** ಐಟಂ ತೆರಿಗೆ ಸೇರಿಸಬೇಕು ** ** ಐಟಂ ** ಮಾಸ್ಟರ್ ಟೇಬಲ್.
 
- #### ಕಾಲಮ್ಗಳು 
+ #### ಕಾಲಮ್ಗಳು
 
- 1 ವಿವರಣೆ. ಲೆಕ್ಕ ಕೌಟುಂಬಿಕತೆ: 
+ 1 ವಿವರಣೆ. ಲೆಕ್ಕ ಕೌಟುಂಬಿಕತೆ:
  - ಈ ಮಾಡಬಹುದು ** ನೆಟ್ (ಮೂಲ ಪ್ರಮಾಣದ ಮೊತ್ತ) ** ಒಟ್ಟು.
  - ** ಹಿಂದಿನ ರೋ ಒಟ್ಟು / ಪ್ರಮಾಣ ** ರಂದು (ಸಂಚಿತ ತೆರಿಗೆ ಅಥವಾ ಆರೋಪಗಳನ್ನು). ನೀವು ಈ ಆಯ್ಕೆಯನ್ನು ಆರಿಸಿದರೆ, ತೆರಿಗೆ ಪ್ರಮಾಣವನ್ನು ಅಥವಾ ಒಟ್ಟು (ತೆರಿಗೆ ಕೋಷ್ಟಕದಲ್ಲಿ) ಹಿಂದಿನ ಸಾಲು ಶೇಕಡಾವಾರು ಅನ್ವಯಿಸಲಾಗುತ್ತದೆ.
  - ** ** ನಿಜವಾದ (ಹೇಳಿದಂತೆ).
- 2. ಖಾತೆ ಹೆಡ್: ಈ ತೆರಿಗೆ 
+ 2. ಖಾತೆ ಹೆಡ್: ಈ ತೆರಿಗೆ
  3 ಕಾಯ್ದಿರಿಸಬೇಕು ಇದು ಅಡಿಯಲ್ಲಿ ಖಾತೆ ಲೆಡ್ಜರ್. ವೆಚ್ಚ ಸೆಂಟರ್: ತೆರಿಗೆ / ಚಾರ್ಜ್ (ಹಡಗು ರೀತಿಯಲ್ಲಿ) ಒಂದು ಆದಾಯ ಅಥವಾ ಖರ್ಚು ವೇಳೆ ಇದು ಒಂದು ವೆಚ್ಚದ ಕೇಂದ್ರವಾಗಿ ವಿರುದ್ಧ ಕಾಯ್ದಿರಿಸಬೇಕು ಅಗತ್ಯವಿದೆ.
  4. ವಿವರಣೆ: ತೆರಿಗೆ ವಿವರಣೆ (ಇನ್ವಾಯ್ಸ್ಗಳು / ಉಲ್ಲೇಖಗಳಲ್ಲಿ ಮುದ್ರಿಸಲಾಗುತ್ತದೆ).
  5. ದರ: ತೆರಿಗೆ.
@@ -1243,7 +1243,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,ಸವಕಳಿ ಎಂಟ್ರಿ
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,ಮೊದಲ ದಾಖಲೆ ಪ್ರಕಾರ ಆಯ್ಕೆ ಮಾಡಿ
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,ಈ ನಿರ್ವಹಣೆ ಭೇಟಿ ರದ್ದು ಮೊದಲು ವಸ್ತು ಭೇಟಿ {0} ರದ್ದು
-DocType: Crop Cycle,ISO 8016 standard,ಐಎಸ್ಒ 8016 ಪ್ರಮಾಣಿತ
+DocType: Crop Cycle,ISO 8601 standard,ಐಎಸ್ಒ 8601 ಪ್ರಮಾಣಿತ
 DocType: Pricing Rule,Rate or Discount,ದರ ಅಥವಾ ರಿಯಾಯಿತಿ
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},ಯಾವುದೇ ಸೀರಿಯಲ್ {0} ಐಟಂ ಸೇರುವುದಿಲ್ಲ {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,ಅಗತ್ಯವಿದೆ ಪ್ರಮಾಣ
@@ -3097,7 +3097,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3109,19 +3109,19 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
 9. Consider Tax or Charge for: In this section you can specify if the tax / charge is only for valuation (not a part of total) or only for total (does not add value to the item) or for both.
-10. Add or Deduct: Whether you want to add or deduct the tax.","ಎಲ್ಲ ಖರೀದಿ ವ್ಯವಹಾರಗಳು ಅನ್ವಯಿಸಬಹುದು ಸ್ಟ್ಯಾಂಡರ್ಡ್ ತೆರಿಗೆ ಟೆಂಪ್ಲೆಟ್. ಈ ಟೆಂಪ್ಲೇಟ್ ನೀವು ಇಲ್ಲಿ ವ್ಯಾಖ್ಯಾನಿಸಲು 
+10. Add or Deduct: Whether you want to add or deduct the tax.","ಎಲ್ಲ ಖರೀದಿ ವ್ಯವಹಾರಗಳು ಅನ್ವಯಿಸಬಹುದು ಸ್ಟ್ಯಾಂಡರ್ಡ್ ತೆರಿಗೆ ಟೆಂಪ್ಲೆಟ್. ಈ ಟೆಂಪ್ಲೇಟ್ ನೀವು ಇಲ್ಲಿ ವ್ಯಾಖ್ಯಾನಿಸಲು
 
- ತೆರಿಗೆ ಗಮನಿಸಿ #### 
+ ತೆರಿಗೆ ಗಮನಿಸಿ ####
 
  ಇತ್ಯಾದಿ ""ನಿರ್ವಹಣೆ"" ತೆರಿಗೆ ತಲೆ ಮತ್ತು ""ಶಿಪ್ಪಿಂಗ್"", ""ವಿಮೆ"" ನಂತಹ ಇತರ ವೆಚ್ಚದಲ್ಲಿ ತಲೆ ಪಟ್ಟಿ ಹೊಂದಿರಬಹುದು ** ಎಲ್ಲಾ ** ಐಟಂಗಳು ಗುಣಮಟ್ಟ ತೆರಿಗೆ ಇರುತ್ತದೆ. ಬೇರೆ ಬೇರೆ ದರಗಳನ್ನು ಹೊಂದಿವೆ ** ಎಂದು ** ಐಟಂಗಳು ಎಂದಾದರೆ ಅವರು ** ಐಟಂ ತೆರಿಗೆ ಸೇರಿಸಬೇಕು ** ** ಐಟಂ ** ಮಾಸ್ಟರ್ ಟೇಬಲ್.
 
- #### ಕಾಲಮ್ಗಳು 
+ #### ಕಾಲಮ್ಗಳು
 
- 1 ವಿವರಣೆ. ಲೆಕ್ಕ ಕೌಟುಂಬಿಕತೆ: 
+ 1 ವಿವರಣೆ. ಲೆಕ್ಕ ಕೌಟುಂಬಿಕತೆ:
  - ಈ ಮಾಡಬಹುದು ** ನೆಟ್ (ಮೂಲ ಪ್ರಮಾಣದ ಮೊತ್ತ) ** ಒಟ್ಟು.
  - ** ಹಿಂದಿನ ರೋ ಒಟ್ಟು / ಪ್ರಮಾಣ ** ರಂದು (ಸಂಚಿತ ತೆರಿಗೆ ಅಥವಾ ಆರೋಪಗಳನ್ನು). ನೀವು ಈ ಆಯ್ಕೆಯನ್ನು ಆರಿಸಿದರೆ, ತೆರಿಗೆ ಪ್ರಮಾಣವನ್ನು ಅಥವಾ ಒಟ್ಟು (ತೆರಿಗೆ ಕೋಷ್ಟಕದಲ್ಲಿ) ಹಿಂದಿನ ಸಾಲು ಶೇಕಡಾವಾರು ಅನ್ವಯಿಸಲಾಗುತ್ತದೆ.
  - ** ** ನಿಜವಾದ (ಹೇಳಿದಂತೆ).
- 2. ಖಾತೆ ಹೆಡ್: ಈ ತೆರಿಗೆ 
+ 2. ಖಾತೆ ಹೆಡ್: ಈ ತೆರಿಗೆ
  3 ಕಾಯ್ದಿರಿಸಬೇಕು ಇದು ಅಡಿಯಲ್ಲಿ ಖಾತೆ ಲೆಡ್ಜರ್. ವೆಚ್ಚ ಸೆಂಟರ್: ತೆರಿಗೆ / ಚಾರ್ಜ್ (ಹಡಗು ರೀತಿಯಲ್ಲಿ) ಒಂದು ಆದಾಯ ಅಥವಾ ಖರ್ಚು ವೇಳೆ ಇದು ಒಂದು ವೆಚ್ಚದ ಕೇಂದ್ರವಾಗಿ ವಿರುದ್ಧ ಕಾಯ್ದಿರಿಸಬೇಕು ಅಗತ್ಯವಿದೆ.
  4. ವಿವರಣೆ: ತೆರಿಗೆ ವಿವರಣೆ (ಇನ್ವಾಯ್ಸ್ಗಳು / ಉಲ್ಲೇಖಗಳಲ್ಲಿ ಮುದ್ರಿಸಲಾಗುತ್ತದೆ).
  5. ದರ: ತೆರಿಗೆ.
@@ -3401,7 +3401,7 @@ Examples:
 1. Ways of addressing disputes, indemnity, liability, etc.
 1. Address and Contact of your Company.","ಪ್ರಮಾಣಿತ ನಿಯಮಗಳು ಮತ್ತು ಮಾರಾಟಗಳು ಮತ್ತು ಖರೀದಿಗಳ ಸೇರಿಸಬಹುದು ಸ್ಥಿತಿ.
 
- ಉದಾಹರಣೆಗಳು: 
+ ಉದಾಹರಣೆಗಳು:
 
  1. ಪ್ರಸ್ತಾಪವನ್ನು ಸಿಂಧುತ್ವವನ್ನು.
  1. ಪಾವತಿ ನಿಯಮಗಳು (ಕ್ರೆಡಿಟ್ ಮುಂಚಿತವಾಗಿ, ಭಾಗವಾಗಿ ಮುಂಗಡ ಇತ್ಯಾದಿ).
@@ -3410,7 +3410,7 @@ Examples:
  1. ಖಾತರಿ ಯಾವುದೇ ವೇಳೆ.
  1. ಆದಾಯ ನೀತಿ.
  1. ಹಡಗು ನಿಯಮಗಳು, ಅನ್ವಯಿಸಿದರೆ.
- 1. ಇತ್ಯಾದಿ ವಿಳಾಸ ವಿವಾದಗಳು, ನಷ್ಟ, ಹೊಣೆಗಾರಿಕೆ, 
+ 1. ಇತ್ಯಾದಿ ವಿಳಾಸ ವಿವಾದಗಳು, ನಷ್ಟ, ಹೊಣೆಗಾರಿಕೆ,
  1 ಮಾರ್ಗಗಳು. ವಿಳಾಸ ಮತ್ತು ನಿಮ್ಮ ಕಂಪನಿ ಸಂಪರ್ಕಿಸಿ."
 DocType: Issue,Issue Type,ಸಂಚಿಕೆ ಪ್ರಕಾರ
 DocType: Attendance,Leave Type,ಪ್ರಕಾರ ಬಿಡಿ
@@ -4042,11 +4042,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,ನೌಕರ ಮುಂಗಡವನ್ನು ಪಡೆಯಲು ಉದ್ಯೋಗಿಯನ್ನು ಆಯ್ಕೆಮಾಡಿ.
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,ದಯವಿಟ್ಟು ಮಾನ್ಯವಾದ ದಿನಾಂಕವನ್ನು ಆಯ್ಕೆ ಮಾಡಿ
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,ನಿಮ್ಮ ವ್ಯಾಪಾರ ಸ್ವರೂಪ ಆಯ್ಕೆಮಾಡಿ.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -4884,7 +4884,7 @@ DocType: Accounts Settings,"If enabled, the system will post accounting entries 
 apps/erpnext/erpnext/setup/setup_wizard/data/industry_type.py +15,Brokerage,ದಲ್ಲಾಳಿಗೆ ಕೊಡುವ ಹಣ
 apps/erpnext/erpnext/hr/doctype/leave_application/leave_application.py +207,Attendance for employee {0} is already marked for this day,ನೌಕರ {0} ಹಾಜರಾತಿ ಈಗಾಗಲೇ ಈ ದಿನ ಗುರುತಿಸಲಾಗಿದೆ
 DocType: Work Order Operation,"in Minutes
-Updated via 'Time Log'","ನಿಮಿಷಗಳಲ್ಲಿ 
+Updated via 'Time Log'","ನಿಮಿಷಗಳಲ್ಲಿ
  'ಟೈಮ್ ಲಾಗ್' ಮೂಲಕ ಅಪ್ಡೇಟ್ಗೊಳಿಸಲಾಗಿದೆ"
 DocType: Customer,From Lead,ಮುಂಚೂಣಿಯಲ್ಲಿವೆ
 apps/erpnext/erpnext/config/manufacturing.py +13,Orders released for production.,ಉತ್ಪಾದನೆಗೆ ಬಿಡುಗಡೆ ಆರ್ಡರ್ಸ್ .
@@ -5151,7 +5151,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,ಅರ್ಜಿದಾರರ ಹೆಸರು
 DocType: Authorization Rule,Customer / Item Name,ಗ್ರಾಹಕ / ಐಟಂ ಹೆಸರು
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","ಸಕ್ರಿಯಗೊಳಿಸಿದಲ್ಲಿ, ಐಟಂಗಳ ಕೊನೆಯ ಖರೀದಿ ವಿವರಗಳನ್ನು ಹಿಂದಿನ ಖರೀದಿಯ ಆದೇಶದಿಂದ ಪಡೆಯಲಾಗುವುದಿಲ್ಲ ಅಥವಾ ರಶೀದಿಯನ್ನು ಖರೀದಿಸಲಾಗುವುದಿಲ್ಲ"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 
@@ -5620,7 +5620,7 @@ apps/erpnext/erpnext/accounts/doctype/fiscal_year/fiscal_year.py +82,Year start 
 apps/erpnext/erpnext/selling/doctype/customer/customer.py +122,Please mention the Lead Name in Lead {0},ಲೀಡ್ನಲ್ಲಿರುವ ಲೀಡ್ ಹೆಸರು {0} ಅನ್ನು ದಯವಿಟ್ಟು ಗಮನಿಸಿ.
 apps/erpnext/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py +156,Start date should be less than end date for Item {0},ಪ್ರಾರಂಭ ದಿನಾಂಕ ಐಟಂ ಅಂತಿಮ ದಿನಾಂಕವನ್ನು ಕಡಿಮೆ Shoulderstand {0}
 DocType: Item,"Example: ABCD.#####
-If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","ಉದಾಹರಣೆಗೆ:. ಸರಣಿ ಹೊಂದಿಸಲಾಗಿದೆ ಮತ್ತು ಸೀರಿಯಲ್ ಯಾವುದೇ ವ್ಯವಹಾರಗಳಲ್ಲಿ ಉಲ್ಲೇಖಿಸಲ್ಪಟ್ಟಿಲ್ಲ ವೇಳೆ ABCD ##### 
+If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","ಉದಾಹರಣೆಗೆ:. ಸರಣಿ ಹೊಂದಿಸಲಾಗಿದೆ ಮತ್ತು ಸೀರಿಯಲ್ ಯಾವುದೇ ವ್ಯವಹಾರಗಳಲ್ಲಿ ಉಲ್ಲೇಖಿಸಲ್ಪಟ್ಟಿಲ್ಲ ವೇಳೆ ABCD #####
 , ನಂತರ ಸ್ವಯಂಚಾಲಿತ ಕ್ರಮಸಂಖ್ಯೆ ಈ ಸರಣಿ ಮೇಲೆ ನಡೆಯಲಿದೆ. ನೀವು ಯಾವಾಗಲೂ ಸ್ಪಷ್ಟವಾಗಿ ಈ ಐಟಂ ಸೀರಿಯಲ್ ನಾವು ಬಗ್ಗೆ ಬಯಸಿದರೆ. ಈ ಜಾಗವನ್ನು ಖಾಲಿ ಬಿಡುತ್ತಾರೆ."
 DocType: Upload Attendance,Upload Attendance,ಅಟೆಂಡೆನ್ಸ್ ಅಪ್ಲೋಡ್
 apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.js +616,BOM and Manufacturing Quantity are required,BOM ಮತ್ತು ಉತ್ಪಾದನೆ ಪ್ರಮಾಣ ಅಗತ್ಯವಿದೆ

--- a/erpnext/translations/ko.csv
+++ b/erpnext/translations/ko.csv
@@ -1032,7 +1032,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1043,19 +1043,19 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 6. Amount: Tax amount.
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
-9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","모든 판매 거래에 적용 할 수있는 표준 세금 템플릿입니다.이 템플릿은 
+9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","모든 판매 거래에 적용 할 수있는 표준 세금 템플릿입니다.이 템플릿은
 
- 세율을 주 #### 
+ 세율을 주 ####
 
  등 ""처리"", 세금 머리와 ""배송"", ""보험""와 같은 다른 비용 / 소득 헤드의 목록을 포함 할 수 있습니다 ** 모든 ** 항목에 대한 표준 세율 될 것입니다 여기에 정의합니다.다른 비율이 ** ** 항목이있는 경우, 그들은 ** 항목 세금에 추가해야합니다 ** ** 항목 ** 마스터 테이블.
 
- #### 열 
+ #### 열
 
- 1에 대한 설명.계산 유형 : 
+ 1에 대한 설명.계산 유형 :
  -이에있을 수 있습니다 ** 순 (즉, 기본 금액의 합계입니다) ** 총.
  - ** 이전 행 전체 / 양 **에 (누적 세금이나 요금에 대한).이 옵션을 선택하면 세금 금액 또는 총 (세금 테이블에) 이전 행의 비율로 적용됩니다.
  - ** 실제 (언급 한 바와 같이).
- 2.계정 머리 :이 세금 
+ 2.계정 머리 :이 세금
  3을 예약 할하는 계정 원장.비용 센터 : 세금 / 요금 (운송 등) 소득 또는 경비 경우는 비용 센터에 예약 할 필요가있다.
  4.설명 : 세금의 설명 (즉,이 송장 / 따옴표로 인쇄됩니다).
  5.속도 : 세율.
@@ -1242,7 +1242,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,감가 상각 항목
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,첫 번째 문서 유형을 선택하세요
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,"이 유지 보수 방문을 취소하기 전, 재질 방문 {0} 취소"
-DocType: Crop Cycle,ISO 8016 standard,ISO 8016 표준
+DocType: Crop Cycle,ISO 8601 standard,ISO 8601 표준
 DocType: Pricing Rule,Rate or Discount,요금 또는 할인
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},일련 번호 {0} 항목에 속하지 않는 {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,필요한 수량
@@ -3093,7 +3093,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3105,19 +3105,19 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
 9. Consider Tax or Charge for: In this section you can specify if the tax / charge is only for valuation (not a part of total) or only for total (does not add value to the item) or for both.
-10. Add or Deduct: Whether you want to add or deduct the tax.","모든 구매 거래에 적용 할 수있는 표준 세금 템플릿입니다.이 템플릿은 여기에 정의 
+10. Add or Deduct: Whether you want to add or deduct the tax.","모든 구매 거래에 적용 할 수있는 표준 세금 템플릿입니다.이 템플릿은 여기에 정의
 
- 세율을 주 #### 
+ 세율을 주 ####
 
  등 ""처리"", 세금 머리와 ""배송"", ""보험""와 같은 다른 비용 헤드의 목록을 포함 할 수 있습니다 ** 모든 ** 항목에 대한 표준 세율 될 것입니다.다른 비율이 ** ** 항목이있는 경우, 그들은 ** 항목 세금에 추가해야합니다 ** ** 항목 ** 마스터 테이블.
 
- #### 열 
+ #### 열
 
- 1에 대한 설명.계산 유형 : 
+ 1에 대한 설명.계산 유형 :
  -이에있을 수 있습니다 ** 순 (즉, 기본 금액의 합계입니다) ** 총.
  - ** 이전 행 전체 / 양 **에 (누적 세금이나 요금에 대한).이 옵션을 선택하면 세금 금액 또는 총 (세금 테이블에) 이전 행의 비율로 적용됩니다.
  - ** 실제 (언급 한 바와 같이).
- 2.계정 머리 :이 세금 
+ 2.계정 머리 :이 세금
  3을 예약 할하는 계정 원장.비용 센터 : 세금 / 요금 (운송 등) 소득 또는 경비 경우는 비용 센터에 예약 할 필요가있다.
  4.설명 : 세금의 설명 (즉,이 송장 / 따옴표로 인쇄됩니다).
  5.속도 : 세율.
@@ -3397,7 +3397,7 @@ Examples:
 1. Ways of addressing disputes, indemnity, liability, etc.
 1. Address and Contact of your Company.","표준 약관과 판매 및 구매에 추가 할 수있는 조건.
 
- 예 : 
+ 예 :
 
  1.제안의 유효 기간.
  1.지불 조건 (신용에 사전에, 일부 사전 등).
@@ -3406,7 +3406,7 @@ Examples:
  1.보증 (있는 경우).
  1.정책을 돌려줍니다.
  1.운송 약관 (해당되는 경우).
- 1.등 주소 분쟁, 손해 배상, 책임, 
+ 1.등 주소 분쟁, 손해 배상, 책임,
  하나의 방법.주소 및 회사의 연락."
 DocType: Issue,Issue Type,이슈 유형
 DocType: Attendance,Leave Type,휴가 유형
@@ -4038,11 +4038,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,직원을 선택하여 직원을 진급시킬 수 있습니다.
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,유효한 날짜를 선택하십시오.
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,비즈니스의 성격을 선택합니다.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5146,7 +5146,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,신청자 이름
 DocType: Authorization Rule,Customer / Item Name,고객 / 상품 이름
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt",이 옵션을 사용하면 이전 구매 주문 또는 구매 영수증에서 항목의 마지막 구매 세부 정보를 가져올 수 없습니다
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 
@@ -5615,7 +5615,7 @@ apps/erpnext/erpnext/accounts/doctype/fiscal_year/fiscal_year.py +82,Year start 
 apps/erpnext/erpnext/selling/doctype/customer/customer.py +122,Please mention the Lead Name in Lead {0},Lead {0}의 리드 이름을 언급하십시오.
 apps/erpnext/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py +156,Start date should be less than end date for Item {0},시작 날짜는 항목에 대한 종료 날짜보다 작아야합니다 {0}
 DocType: Item,"Example: ABCD.#####
-If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","예 :. 시리즈가 설정되고 일련 번호가 트랜잭션에 언급되지 않은 경우 ABCD ##### 
+If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","예 :. 시리즈가 설정되고 일련 번호가 트랜잭션에 언급되지 않은 경우 ABCD #####
  후 자동 일련 번호는이 시리즈를 기반으로 생성됩니다.당신은 항상 명시 적으로이 항목에 대한 일련 번호를 언급합니다. 이 비워 둡니다."
 DocType: Upload Attendance,Upload Attendance,출석 업로드
 apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.js +616,BOM and Manufacturing Quantity are required,BOM 및 제조 수량이 필요합니다

--- a/erpnext/translations/ku.csv
+++ b/erpnext/translations/ku.csv
@@ -1031,7 +1031,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1222,7 +1222,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,Peyam Farhad.
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,Ji kerema xwe re ji cureyê pelgeyê hilbijêre
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,Betal Serdan Material {0} berî betalkirinê ev Maintenance Visit
-DocType: Crop Cycle,ISO 8016 standard,ISO 8016 standard
+DocType: Crop Cycle,ISO 8601 standard,ISO 8601 standard
 DocType: Pricing Rule,Rate or Discount,Nirxandin û dakêşin
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},Serial No {0} nayê to Babetê girêdayî ne {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,required Qty
@@ -3069,7 +3069,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3981,11 +3981,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,Vebijêrkek karker hilbijêre da ku pêşmerge karmendê.
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,Ji kerema xwe Dîrokek rastîn hilbijêre
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,xwezaya business xwe hilbijêrin.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5087,7 +5087,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,Navê Applicant
 DocType: Authorization Rule,Customer / Item Name,Mişterî / Navê babetî
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","Heke çalak kirin, navnîşên kirîna paşîn ên tiştên ji hêla kirîna kirîna berê ve an qeydkirina kirînê ve nebînin"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 

--- a/erpnext/translations/lo.csv
+++ b/erpnext/translations/lo.csv
@@ -1033,7 +1033,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1224,7 +1224,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,Entry ຄ່າເສື່ອມລາຄາ
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,ກະລຸນາເລືອກປະເພດເອກະສານທໍາອິດ
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,ຍົກເລີກການໄປຢ້ຽມຢາມວັດສະດຸ {0} ກ່ອນຍົກເລີກການນີ້ບໍາລຸງຮັກສາ Visit
-DocType: Crop Cycle,ISO 8016 standard,ມາດຕະຖານ ISO 8016
+DocType: Crop Cycle,ISO 8601 standard,ມາດຕະຖານ ISO 8601
 DocType: Pricing Rule,Rate or Discount,ອັດຕາຫລືລາຄາຜ່ອນຜັນ
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},Serial No {0} ບໍ່ໄດ້ຂຶ້ນກັບ Item {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,ທີ່ກໍານົດໄວ້ຈໍານວນ
@@ -3076,7 +3076,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3989,11 +3989,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,ເລືອກເອົາພະນັກງານເພື່ອໃຫ້ພະນັກງານລ່ວງຫນ້າ.
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,ກະລຸນາເລືອກວັນທີ່ຖືກຕ້ອງ
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,ເລືອກລັກສະນະຂອງທຸລະກິດຂອງທ່ານ.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5097,7 +5097,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,ຊື່ຜູ້ສະຫມັກ
 DocType: Authorization Rule,Customer / Item Name,ລູກຄ້າ / ສິນຄ້າ
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","ຖ້າເປີດໃຊ້, ລາຍະລະອຽດການຊື້ສິນຄ້າສຸດທ້າຍຂອງລາຍະການຈະບໍ່ຖືກເກັບຈາກຄໍາສັ່ງຊື້ກ່ອນຫຼືໃບຢັ້ງຢືນການຊື້"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 

--- a/erpnext/translations/lt.csv
+++ b/erpnext/translations/lt.csv
@@ -1033,7 +1033,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1224,7 +1224,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,Nusidėvėjimas įrašas
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,Prašome pasirinkti dokumento tipą pirmas
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,Atšaukti Medžiaga Apsilankymai {0} prieš atšaukiant šią Priežiūros vizitas
-DocType: Crop Cycle,ISO 8016 standard,ISO 8016 standartas
+DocType: Crop Cycle,ISO 8601 standard,ISO 8601 standartas
 DocType: Pricing Rule,Rate or Discount,Įkainiai arba nuolaidos
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},Serijos Nr {0} nepriklauso punkte {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,Reikalinga Kiekis
@@ -1517,7 +1517,7 @@ apps/erpnext/erpnext/public/js/setup_wizard.js +18,Select your Domains,Pasirinki
 apps/erpnext/erpnext/accounts/doctype/budget/budget.py +34,Another Budget record '{0}' already exists against {1} '{2}' for fiscal year {3},Kitas Biudžeto įrašas &#39;{0} &quot;jau egzistuoja nuo {1} {2}&quot; fiskalinio metų {3}
 DocType: Item Variant Settings,Fields will be copied over only at time of creation.,Laukai bus kopijuojami tik kūrimo metu.
 DocType: Setup Progress Action,Domains,Domenai
-apps/erpnext/erpnext/projects/doctype/task/task.py +41,'Actual Start Date' can not be greater than 'Actual End Date',"'Pradžios data' negali būti didesnė nei 
+apps/erpnext/erpnext/projects/doctype/task/task.py +41,'Actual Start Date' can not be greater than 'Actual End Date',"'Pradžios data' negali būti didesnė nei
 'Pabaigos data'"
 apps/erpnext/erpnext/setup/setup_wizard/operations/install_fixtures.py +118,Management,valdymas
 DocType: Cheque Print Template,Payer Settings,mokėtojo Nustatymai
@@ -3076,7 +3076,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3988,11 +3988,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,"Pasirinkite darbuotoją, kad darbuotojas gautų anksčiau."
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,Pasirinkite teisingą datą
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,Pasirinkite savo verslo pobūdį.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5096,7 +5096,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,Vardas pareiškėjas
 DocType: Authorization Rule,Customer / Item Name,Klientas / Prekės pavadinimas
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","Jei įjungta, paskutiniai elementų pirkimo duomenys nebus surinkti iš ankstesnio pirkimo užsakymo ar pirkimo kvito"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 

--- a/erpnext/translations/lv.csv
+++ b/erpnext/translations/lv.csv
@@ -1031,7 +1031,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1222,7 +1222,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,nolietojums Entry
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,"Lūdzu, izvēlieties dokumenta veidu pirmais"
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,Atcelt Materiāls Vizītes {0} pirms lauzt šo apkopes vizīte
-DocType: Crop Cycle,ISO 8016 standard,ISO 8016 standarts
+DocType: Crop Cycle,ISO 8601 standard,ISO 8601 standarts
 DocType: Pricing Rule,Rate or Discount,Likme vai atlaide
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},Sērijas Nr {0} nepieder posteni {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,Nepieciešamais Daudz
@@ -3074,7 +3074,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3987,11 +3987,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,"Izvēlieties darbinieku, lai saņemtu darbinieku iepriekš."
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,"Lūdzu, izvēlieties derīgu datumu"
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,Izvēlieties raksturu jūsu biznesu.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5094,7 +5094,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,Pieteikuma iesniedzēja nosaukums
 DocType: Authorization Rule,Customer / Item Name,Klients / vienības nosaukums
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","Ja ir iespējota, pēdējās preces pirkuma detaļas netiks iegūtas no iepriekšējā pirkuma pasūtījuma vai pirkuma kvītis"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 

--- a/erpnext/translations/mk.csv
+++ b/erpnext/translations/mk.csv
@@ -1033,7 +1033,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1224,7 +1224,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,амортизација за влез
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,Изберете го типот на документот прв
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,Откажи материјал Посети {0} пред да го раскине овој Одржување Посета
-DocType: Crop Cycle,ISO 8016 standard,ISO 8016 стандард
+DocType: Crop Cycle,ISO 8601 standard,ISO 8601 стандард
 DocType: Pricing Rule,Rate or Discount,Стапка или попуст
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},Сериски № {0} не припаѓаат на Точка {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,Потребни Количина
@@ -3076,7 +3076,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3989,11 +3989,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,Изберете вработен за да го унапредите работникот.
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,Ве молиме изберете важечки Датум
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,Изберете од природата на вашиот бизнис.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5096,7 +5096,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,Подносител на барањето Име
 DocType: Authorization Rule,Customer / Item Name,Клиент / Item Име
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","Доколку е овозможено, последните детали за набавка на ставки нема да се преземат од претходната нарачка за нарачка или куповна потврда"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 

--- a/erpnext/translations/ml.csv
+++ b/erpnext/translations/ml.csv
@@ -1030,7 +1030,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1221,7 +1221,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,മൂല്യത്തകർച്ച എൻട്രി
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,ആദ്യം ഡോക്യുമെന്റ് തരം തിരഞ്ഞെടുക്കുക
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,ഈ മെയിൻറനൻസ് സന്ദർശനം റദ്ദാക്കുന്നതിൽ മുമ്പ് മെറ്റീരിയൽ സന്ദർശനങ്ങൾ {0} റദ്ദാക്കുക
-DocType: Crop Cycle,ISO 8016 standard,ISO 8016 സ്റ്റാൻഡേർഡ്
+DocType: Crop Cycle,ISO 8601 standard,ISO 8601 സ്റ്റാൻഡേർഡ്
 DocType: Pricing Rule,Rate or Discount,നിരക്ക് അല്ലെങ്കിൽ കിഴിവ്
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},സീരിയൽ ഇല്ല {0} ഇനം വരെ {1} സ്വന്തമല്ല
 DocType: Purchase Receipt Item Supplied,Required Qty,ആവശ്യമായ Qty
@@ -3065,7 +3065,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3976,11 +3976,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,ജീവനക്കാരുടെ മുൻകൂറായി ലഭിക്കാൻ ഒരു ജീവനക്കാരനെ തിരഞ്ഞെടുക്കുക.
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,സാധുതയുള്ള ഒരു തീയതി തിരഞ്ഞെടുക്കുക
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,നിങ്ങളുടെ ബിസിനസ്സ് സ്വഭാവം തിരഞ്ഞെടുക്കുക.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5079,7 +5079,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,അപേക്ഷകന് പേര്
 DocType: Authorization Rule,Customer / Item Name,കസ്റ്റമർ / ഇനം പേര്
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","പ്രാപ്തമാക്കിയിട്ടുണ്ടെങ്കിൽ, മുമ്പത്തെ വാങ്ങൽ ഓർഡർ അല്ലെങ്കിൽ വാങ്ങൽ രസീതിൽ നിന്നുള്ള ഇനങ്ങളുടെ അവസാന വാങ്ങൽ വിശദാംശങ്ങൾ ലഭ്യമാകില്ല"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 

--- a/erpnext/translations/mr.csv
+++ b/erpnext/translations/mr.csv
@@ -1033,7 +1033,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1224,7 +1224,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,घसारा प्रवेश
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,पहले दस्तऐवज प्रकार निवडा
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,साहित्य भेट रद्द करा {0} ही  देखभाल भेट रद्द होण्यापुर्वी रद्द करा
-DocType: Crop Cycle,ISO 8016 standard,आयएसओ 8016 मानक
+DocType: Crop Cycle,ISO 8601 standard,आयएसओ 8601 मानक
 DocType: Pricing Rule,Rate or Discount,दर किंवा सवलत
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},सिरियल क्रमांक {0} आयटम  {1} शी संबंधित नाही
 DocType: Purchase Receipt Item Supplied,Required Qty,आवश्यक Qty
@@ -3075,7 +3075,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3987,11 +3987,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,कर्मचारी अग्रिम प्राप्त करण्यासाठी एक कर्मचारी निवडा
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,कृपया एक वैध तारीख निवडा
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,आपल्या व्यवसाय स्वरूप निवडा.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5095,7 +5095,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,अर्जदाराचे नाव
 DocType: Authorization Rule,Customer / Item Name,ग्राहक / आयटम नाव
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","सक्षम असल्यास, मागील खरेदी ऑर्डर किंवा खरेदी पावतीवरून आयटमची अंतिम खरेदीची माहिती प्राप्त केली जाणार नाही"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 

--- a/erpnext/translations/ms.csv
+++ b/erpnext/translations/ms.csv
@@ -1033,7 +1033,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1224,7 +1224,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,Kemasukan susutnilai
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,Sila pilih jenis dokumen pertama
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,Batal Bahan Lawatan {0} sebelum membatalkan Lawatan Penyelenggaraan ini
-DocType: Crop Cycle,ISO 8016 standard,Standard ISO 8016
+DocType: Crop Cycle,ISO 8601 standard,Standard ISO 8601
 DocType: Pricing Rule,Rate or Discount,Kadar atau Diskaun
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},No siri {0} bukan milik Perkara {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,Diperlukan Qty
@@ -3076,7 +3076,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3989,11 +3989,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,Pilih pekerja untuk mendapatkan pekerja terlebih dahulu.
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,Sila pilih Tarikh yang sah
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,Pilih jenis perniagaan anda.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5097,7 +5097,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,Nama pemohon
 DocType: Authorization Rule,Customer / Item Name,Pelanggan / Nama Item
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","Jika diaktifkan, butiran pembelian terakhir item tidak akan diambil dari pesanan pembelian atau pembelian semula sebelumnya"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 

--- a/erpnext/translations/my.csv
+++ b/erpnext/translations/my.csv
@@ -1033,7 +1033,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1224,7 +1224,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,တန်ဖိုး Entry &#39;
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,ပထမဦးဆုံး Document အမျိုးအစားကိုရွေးချယ်ပါ
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,ဒီ Maintenance ခရီးစဉ်ပယ်ဖျက်မီပစ္စည်းလည်ပတ်သူ {0} Cancel
-DocType: Crop Cycle,ISO 8016 standard,က ISO 8016 စံ
+DocType: Crop Cycle,ISO 8601 standard,က ISO 8601 စံ
 DocType: Pricing Rule,Rate or Discount,rate သို့မဟုတ်လျှော့
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},serial No {0} Item မှ {1} ပိုင်ပါဘူး
 DocType: Purchase Receipt Item Supplied,Required Qty,မရှိမဖြစ်တဲ့ Qty
@@ -3076,7 +3076,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3989,11 +3989,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,အလုပျသမားကြိုတင်မဲရဖို့တစ်ခုဝန်ထမ်းရွေးချယ်ပါ။
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,ခိုင်လုံသောနေ့စွဲကို select ပေးပါ
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,သင့်ရဲ့စီးပွားရေးလုပ်ငန်း၏သဘောသဘာဝကို Select လုပ်ပါ။
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5097,7 +5097,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,လျှောက်ထားသူအမည်
 DocType: Authorization Rule,Customer / Item Name,customer / Item အမည်
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","enabled လြှငျ, ပစ္စည်းများနောက်ဆုံးဝယ်ယူအသေးစိတ်ကိုယခင်ဝယ်ယူမှုအမိန့်သို့မဟုတ်ဝယ်ယူလက်ခံရရှိမှခေါ်ယူမည်မဟုတ်ပါ"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 

--- a/erpnext/translations/nl.csv
+++ b/erpnext/translations/nl.csv
@@ -1030,7 +1030,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1041,19 +1041,19 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 6. Amount: Tax amount.
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
-9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","Standaard belasting sjabloon die kan worden toegepast op alle verkooptransacties. Deze sjabloon kan lijst van fiscale hoofden en ook andere kosten / baten koppen als ""Verzenden"", ""Verzekering"" bevatten, ""Omgaan met"" enz 
+9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","Standaard belasting sjabloon die kan worden toegepast op alle verkooptransacties. Deze sjabloon kan lijst van fiscale hoofden en ook andere kosten / baten koppen als ""Verzenden"", ""Verzekering"" bevatten, ""Omgaan met"" enz
 
- #### Opmerking 
+ #### Opmerking
 
  Het belastingtarief u definiëren hier zal het normale belastingtarief voor alle ** Items worden **. Als er ** Items ** dat verschillende tarieven hebben, moeten ze worden toegevoegd in de ** Item Tax ** tafel in de ** Item ** meester.
 
- #### Beschrijving van Kolommen 
+ #### Beschrijving van Kolommen
 
- 1. Berekening Type: 
+ 1. Berekening Type:
  - Dit kan op ** Netto Totaal ** (dat is de som van het basisbedrag).
  - ** Op Vorige Row Total / Bedrag ** (voor cumulatieve belastingen of heffingen). Als u deze optie selecteert, zal de belasting worden berekend als een percentage van de vorige rij (in de fiscale tabel) bedrag of totaal.
  - ** Werkelijke ** (zoals vermeld).
- 2. Account Head: De Account grootboek waaronder deze belasting 
+ 2. Account Head: De Account grootboek waaronder deze belasting
  3 zal worden geboekt. Cost Center: Als de belasting / heffing is een inkomen (zoals de scheepvaart) of kosten die het nodig heeft tegen een kostenplaats worden geboekt.
  4. Beschrijving: Beschrijving van de belasting (die zullen worden afgedrukt in de facturen / offertes).
  5. Rate: belastingtarief.
@@ -1239,7 +1239,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,afschrijvingen Entry
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,Selecteer eerst het documenttype
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,Annuleren Materiaal Bezoeken {0} voor het annuleren van deze Maintenance Visit
-DocType: Crop Cycle,ISO 8016 standard,ISO 8016-norm
+DocType: Crop Cycle,ISO 8601 standard,ISO 8601-norm
 DocType: Pricing Rule,Rate or Discount,Tarief of korting
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},Serienummer {0} behoort niet tot Artikel {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,Benodigde hoeveelheid
@@ -3087,7 +3087,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3099,19 +3099,19 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
 9. Consider Tax or Charge for: In this section you can specify if the tax / charge is only for valuation (not a part of total) or only for total (does not add value to the item) or for both.
-10. Add or Deduct: Whether you want to add or deduct the tax.","Standaard belasting sjabloon die kan worden toegepast op alle inkooptransacties. Deze sjabloon kan lijst van fiscale hoofden en ook andere kosten koppen als ""Verzenden"", ""Verzekering"" bevatten, ""Omgaan met"" enz 
+10. Add or Deduct: Whether you want to add or deduct the tax.","Standaard belasting sjabloon die kan worden toegepast op alle inkooptransacties. Deze sjabloon kan lijst van fiscale hoofden en ook andere kosten koppen als ""Verzenden"", ""Verzekering"" bevatten, ""Omgaan met"" enz
 
- #### Opmerking 
+ #### Opmerking
 
  De belastingdruk die u hier definieert zal het normale belastingtarief voor alle ** Items worden **. Als er ** Items ** dat verschillende tarieven hebben, moeten ze worden toegevoegd in de ** Item Tax ** tafel in de ** Item ** meester.
 
- #### Beschrijving van Kolommen 
+ #### Beschrijving van Kolommen
 
- 1. Berekening Type: 
+ 1. Berekening Type:
  - Dit kan op ** Netto Totaal ** (dat is de som van het basisbedrag).
  - ** Op Vorige Row Total / Bedrag ** (voor cumulatieve belastingen of heffingen). Als u deze optie selecteert, zal de belasting worden berekend als een percentage van de vorige rij (in de fiscale tabel) bedrag of totaal.
  - ** Werkelijke ** (zoals vermeld).
- 2. Account Head: De Account grootboek waaronder deze belasting 
+ 2. Account Head: De Account grootboek waaronder deze belasting
  3 zal worden geboekt. Cost Center: Als de belasting / heffing is een inkomen (zoals de scheepvaart) of kosten die het nodig heeft tegen een kostenplaats worden geboekt.
  4. Beschrijving: Beschrijving van de belasting (die zullen worden afgedrukt in de facturen / offertes).
  5. Rate: belastingtarief.
@@ -3390,7 +3390,7 @@ Examples:
 1. Ways of addressing disputes, indemnity, liability, etc.
 1. Address and Contact of your Company.","Algemene Voorwaarden die kunnen worden toegevoegd aan de verkopen en aankopen.
 
- Voorbeelden: 
+ Voorbeelden:
 
  1. Geldigheid van het aanbod.
  1. Betalingscondities (In Advance, op krediet, een deel vooraf etc).
@@ -3399,7 +3399,7 @@ Examples:
  1. Garantie indien van toepassing.
  1. Returns Policy '.
  1. Termen van de scheepvaart, indien van toepassing.
- 1. Methoden voor het aanpakken geschillen, schadevergoeding, aansprakelijkheid, enz. 
+ 1. Methoden voor het aanpakken geschillen, schadevergoeding, aansprakelijkheid, enz.
  1. Adres en contactgegevens van uw bedrijf."
 DocType: Issue,Issue Type,Uitgiftetype
 DocType: Attendance,Leave Type,Verlof Type
@@ -4030,11 +4030,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,Selecteer een medewerker om de werknemer voor te bereiden.
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,Selecteer een geldige datum alstublieft
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,Selecteer de aard van uw bedrijf.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -4872,7 +4872,7 @@ DocType: Accounts Settings,"If enabled, the system will post accounting entries 
 apps/erpnext/erpnext/setup/setup_wizard/data/industry_type.py +15,Brokerage,makelaardij
 apps/erpnext/erpnext/hr/doctype/leave_application/leave_application.py +207,Attendance for employee {0} is already marked for this day,Attendance voor personeelsbeloningen {0} is al gemarkeerd voor deze dag
 DocType: Work Order Operation,"in Minutes
-Updated via 'Time Log'","in Minuten 
+Updated via 'Time Log'","in Minuten
  Bijgewerkt via 'Time Log'"
 DocType: Customer,From Lead,Van Lead
 apps/erpnext/erpnext/config/manufacturing.py +13,Orders released for production.,Orders vrijgegeven voor productie.
@@ -5139,7 +5139,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,Aanvrager Naam
 DocType: Authorization Rule,Customer / Item Name,Klant / Naam van het punt
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","Indien ingeschakeld, worden de laatste aankoopgegevens van items niet opgehaald van de vorige bestelling of aankoopbon"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 

--- a/erpnext/translations/no.csv
+++ b/erpnext/translations/no.csv
@@ -1033,7 +1033,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1224,7 +1224,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,avskrivninger Entry
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,Velg dokumenttypen først
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,Avbryt Material Besøk {0} før den sletter denne Maintenance Visit
-DocType: Crop Cycle,ISO 8016 standard,ISO 8016 standard
+DocType: Crop Cycle,ISO 8601 standard,ISO 8601 standard
 DocType: Pricing Rule,Rate or Discount,Pris eller rabatt
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},Serial No {0} tilhører ikke Element {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,Påkrevd antall
@@ -3071,7 +3071,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3982,11 +3982,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,Velg en ansatt for å få ansatt på forhånd.
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,Vennligst velg en gyldig dato
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,Velg formålet med virksomheten.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5087,7 +5087,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,Søkerens navn
 DocType: Authorization Rule,Customer / Item Name,Kunde / Navn
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","Hvis aktivert, vil siste kjøpsdetaljer for elementer ikke bli hentet fra tidligere innkjøpsordre eller kjøpskvittering"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 

--- a/erpnext/translations/pl.csv
+++ b/erpnext/translations/pl.csv
@@ -1033,7 +1033,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1044,19 +1044,19 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 6. Amount: Tax amount.
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
-9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","Standardowy szablon podatek, który może być stosowany do wszystkich transakcji sprzedaży. Ten szablon może zawierać listę szefów podatkowych, a także innych głów koszty / dochodów jak ""Żegluga"", ""Ubezpieczenia"", ""Obsługa"" itp 
+9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","Standardowy szablon podatek, który może być stosowany do wszystkich transakcji sprzedaży. Ten szablon może zawierać listę szefów podatkowych, a także innych głów koszty / dochodów jak ""Żegluga"", ""Ubezpieczenia"", ""Obsługa"" itp
 
- #### Uwaga 
+ #### Uwaga
 
  Stopa Ciebie podatku definiujemy tu będzie standardowa stawka podatku w odniesieniu do wszystkich pozycji ** **. Jeśli istnieją ** Pozycje **, które mają różne ceny, muszą być dodane w podatku od towaru ** ** tabeli w poz ** ** mistrza.
 
- #### Opis Kolumny 
+ #### Opis Kolumny
 
- 1. Obliczenie Typ: 
+ 1. Obliczenie Typ:
  i - może to być na całkowita ** ** (to jest suma ilości wyjściowej).
  - ** Na Poprzedni Row Całkowita / Kwota ** (dla skumulowanych podatków lub opłat). Jeśli wybierzesz tę opcję, podatek będzie stosowana jako procent poprzedniego rzędu (w tabeli podatkowej) kwoty lub łącznie.
  - ** Rzeczywista ** (jak wspomniano).
- 2. Szef konta: księga konto, na którym podatek ten zostanie zaksięgowany 
+ 2. Szef konta: księga konto, na którym podatek ten zostanie zaksięgowany
  3. Centrum koszt: Jeżeli podatek / opłata jest dochód (jak wysyłką) lub kosztów musi zostać zaliczony na centrum kosztów.
  4. Opis: Opis podatków (które będą drukowane w faktur / cudzysłowów).
  5. Cena: Stawka podatku.
@@ -1243,7 +1243,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,Amortyzacja
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,Najpierw wybierz typ dokumentu
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,Anuluj Fizyczne Wizyty {0} zanim anulujesz Wizytę Pośrednią
-DocType: Crop Cycle,ISO 8016 standard,Norma ISO 8016
+DocType: Crop Cycle,ISO 8601 standard,Norma ISO 8601
 DocType: Pricing Rule,Rate or Discount,Stawka lub zniżka
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},Nr seryjny {0} nie należy do żadnej rzeczy {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,Wymagana ilość
@@ -3093,7 +3093,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3105,19 +3105,19 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
 9. Consider Tax or Charge for: In this section you can specify if the tax / charge is only for valuation (not a part of total) or only for total (does not add value to the item) or for both.
-10. Add or Deduct: Whether you want to add or deduct the tax.","Standardowy szablon podatek, który może być stosowany do wszystkich transakcji kupna. Ten szablon może zawierać listę szefów podatkowych, a także innych głów wydatków jak ""Żegluga"", ""Ubezpieczenia"", ""Obsługa"" itp 
+10. Add or Deduct: Whether you want to add or deduct the tax.","Standardowy szablon podatek, który może być stosowany do wszystkich transakcji kupna. Ten szablon może zawierać listę szefów podatkowych, a także innych głów wydatków jak ""Żegluga"", ""Ubezpieczenia"", ""Obsługa"" itp
 
- #### Uwaga 
+ #### Uwaga
 
  stawki podatku zdefiniować tutaj będzie standardowa stawka podatku w odniesieniu do wszystkich pozycji ** **. Jeśli istnieją ** Pozycje **, które mają różne ceny, muszą być dodane w podatku od towaru ** ** tabeli w poz ** ** mistrza.
 
- #### Opis Kolumny 
+ #### Opis Kolumny
 
- 1. Obliczenie Typ: 
+ 1. Obliczenie Typ:
  i - może to być na całkowita ** ** (to jest suma ilości wyjściowej).
  - ** Na Poprzedni Row Całkowita / Kwota ** (dla skumulowanych podatków lub opłat). Jeśli wybierzesz tę opcję, podatek będzie stosowana jako procent poprzedniego rzędu (w tabeli podatkowej) kwoty lub łącznie.
  - ** Rzeczywista ** (jak wspomniano).
- 2. Szef konta: księga konto, na którym podatek ten zostanie zaksięgowany 
+ 2. Szef konta: księga konto, na którym podatek ten zostanie zaksięgowany
  3. Centrum koszt: Jeżeli podatek / opłata jest dochód (jak wysyłką) lub kosztów musi zostać zaliczony na centrum kosztów.
  4. Opis: Opis podatków (które będą drukowane w faktur / cudzysłowów).
  5. Cena: Stawka podatku.
@@ -3397,7 +3397,7 @@ Examples:
 1. Ways of addressing disputes, indemnity, liability, etc.
 1. Address and Contact of your Company.","Standardowe Zasady i warunki, które mogą być dodawane do sprzedaży i zakupów.
 
- Przykłady: 
+ Przykłady:
 
  1. Ważność oferty.
  1. Warunki płatności (z góry, na kredyt, część zaliczki itp).
@@ -3406,7 +3406,7 @@ Examples:
  1. Gwarancja jeśli w ogóle.
  1. Zwraca Polityka.
  1. Warunki wysyłki, jeśli dotyczy.
- 1. Sposobów rozwiązywania sporów, odszkodowania, odpowiedzialność itp 
+ 1. Sposobów rozwiązywania sporów, odszkodowania, odpowiedzialność itp
  1. Adres i kontakt z Twojej firmy."
 DocType: Issue,Issue Type,rodzaj zagadnienia
 DocType: Attendance,Leave Type,Typ urlopu
@@ -4037,11 +4037,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,"Wybierz pracownika, aby uzyskać awans pracownika."
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,Proszę wybrać prawidłową datę
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,Wybierz charakteru swojej działalności.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -4879,7 +4879,7 @@ DocType: Accounts Settings,"If enabled, the system will post accounting entries 
 apps/erpnext/erpnext/setup/setup_wizard/data/industry_type.py +15,Brokerage,Pośrednictwo
 apps/erpnext/erpnext/hr/doctype/leave_application/leave_application.py +207,Attendance for employee {0} is already marked for this day,Frekwencja na pracownika {0} jest już zaznaczone na ten dzień
 DocType: Work Order Operation,"in Minutes
-Updated via 'Time Log'","w minutach 
+Updated via 'Time Log'","w minutach
  Aktualizacja poprzez ""Czas Zaloguj"""
 DocType: Customer,From Lead,Od śladu
 apps/erpnext/erpnext/config/manufacturing.py +13,Orders released for production.,Zamówienia puszczone do produkcji.
@@ -5146,7 +5146,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,Imię Aplikanta
 DocType: Authorization Rule,Customer / Item Name,Klient / Nazwa Przedmiotu
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","Jeśli opcja jest włączona, szczegóły ostatniego zakupu przedmiotów nie zostaną pobrane z poprzedniego zamówienia zakupu lub dowodu zakupu"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 
@@ -5615,7 +5615,7 @@ apps/erpnext/erpnext/accounts/doctype/fiscal_year/fiscal_year.py +82,Year start 
 apps/erpnext/erpnext/selling/doctype/customer/customer.py +122,Please mention the Lead Name in Lead {0},Zapoznaj się z nazwą wiodącego wiodącego {0}
 apps/erpnext/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py +156,Start date should be less than end date for Item {0},Data startu powinna być niższa od daty końca dla {0}
 DocType: Item,"Example: ABCD.#####
-If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","Przykład:. ABCD ##### 
+If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","Przykład:. ABCD #####
  Jeśli seria jest ustawiona i nr seryjny nie jest wymieniony w transakcjach, automatyczny numer seryjny zostanie utworzony na podstawie tej serii. Jeśli chcesz zawsze jednoznacznie ustawiać numery seryjne dla tej pozycji, pozostaw to pole puste."
 DocType: Upload Attendance,Upload Attendance,Wyślij obecność
 apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.js +616,BOM and Manufacturing Quantity are required,BOM i ilości są wymagane Manufacturing

--- a/erpnext/translations/ps.csv
+++ b/erpnext/translations/ps.csv
@@ -1031,7 +1031,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1221,7 +1221,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,د استهالک د داخلولو
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,مهرباني وکړئ لومړی انتخاب سند ډول
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,لغوه مواد ليدنه {0} بندول د دې د ساتنې سفر مخکې
-DocType: Crop Cycle,ISO 8016 standard,د ISO 8016 معیارونه
+DocType: Crop Cycle,ISO 8601 standard,د ISO 8601 معیارونه
 DocType: Pricing Rule,Rate or Discount,اندازه یا رخصتۍ
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},شعبه {0} نه د قالب سره تړاو نه لري {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,مطلوب Qty
@@ -3061,7 +3061,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3968,11 +3968,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,د کارموندنې د ترلاسه کولو لپاره یو مامور غوره کړئ.
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,لطفا یو باوري نیټه وټاکئ
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,د خپلې سوداګرۍ د ماهیت وټاکئ.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5073,7 +5073,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,متقاضي نوم
 DocType: Authorization Rule,Customer / Item Name,پيرودونکو / د قالب نوم
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt",که چیرې فعال وي، د توکو اخستل به د پخوانۍ پیرود امر یا د پیرود رسید څخه نه اخیستل کیږي
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 

--- a/erpnext/translations/pt.csv
+++ b/erpnext/translations/pt.csv
@@ -1028,7 +1028,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1039,15 +1039,15 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 6. Amount: Tax amount.
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
-9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","O modelo de impostos padrão que pode ser aplicado a todas as Transações de Vendas. Este modelo pode conter a lista de livros fiscais e também outros livros de despesas / receitas como ""Envio"", ""Seguro"", ""Processamento"" etc. 
+9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","O modelo de impostos padrão que pode ser aplicado a todas as Transações de Vendas. Este modelo pode conter a lista de livros fiscais e também outros livros de despesas / receitas como ""Envio"", ""Seguro"", ""Processamento"" etc.
 
- #### Nota 
+ #### Nota
 
 A taxa de imposto que definir aqui será a taxa normal de IVA para todos os **Itens**. Se houver **Itens** que possuam taxas diferentes, eles devem ser adicionados na tabela **Imposto de Item** no definidor de **Item**.
 
- #### Descrição das Colunas 
+ #### Descrição das Colunas
 
- 1. Tipo de Cálculo: 
+ 1. Tipo de Cálculo:
     - Isto pode ser no **Total Líquido** (que é a soma do montante base).
     - **Na linha Total / Montante Anterior** (para os impostos ou encargos cumulativos). Se selecionar esta opção, o imposto será aplicado como uma percentagem do montante da linha anterior (na tabela de impostos) ou montante total.
  - **Atual** (como indicado).
@@ -1237,7 +1237,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,Registo de Depreciação
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,"Por favor, selecione primeiro o tipo de documento"
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,Cancelar Visitas Materiais {0} antes de cancelar esta Visita de Manutenção
-DocType: Crop Cycle,ISO 8016 standard,Padrão ISO 8016
+DocType: Crop Cycle,ISO 8601 standard,Padrão ISO 8601
 DocType: Pricing Rule,Rate or Discount,Taxa ou desconto
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},O Nr. de Série {0} não pertence ao Item {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,Qtd Necessária
@@ -3087,7 +3087,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3099,15 +3099,15 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
 9. Consider Tax or Charge for: In this section you can specify if the tax / charge is only for valuation (not a part of total) or only for total (does not add value to the item) or for both.
-10. Add or Deduct: Whether you want to add or deduct the tax.","O modelo de impostos padrão que pode ser aplicado a todas as Operações de Compra. Este modelo pode conter a lista de títulos de impostos e também outros títulos de despesas como ""Envio"", ""Seguro"", ""Manutenção"" etc. 
+10. Add or Deduct: Whether you want to add or deduct the tax.","O modelo de impostos padrão que pode ser aplicado a todas as Operações de Compra. Este modelo pode conter a lista de títulos de impostos e também outros títulos de despesas como ""Envio"", ""Seguro"", ""Manutenção"" etc.
 
- #### Nota 
+ #### Nota
 
  A taxa de imposto que definir aqui será a taxa normal de impostos para todos os **Itens**. Se houver **Itens** que têm taxas diferentes, eles devem ser adicionados na tabela de **Imposto do Item** no definidor de **Item**.
 
- #### Descrição das Colunas 
+ #### Descrição das Colunas
 
- 1. Tipo de Cálculo: 
+ 1. Tipo de Cálculo:
  - Isto pode ser em **Total Líquido** (que é a soma do montante de base).
  - **No Total / Montante da Linha Anterior** (para os impostos ou encargos cumulativos). Se você essa opção, o imposto será aplicado como uma percentagem da linha anterior (na tabela de impostos) ou montante total.
  - **Real** (como mencionado).
@@ -3391,7 +3391,7 @@ Examples:
 1. Ways of addressing disputes, indemnity, liability, etc.
 1. Address and Contact of your Company.","Termos e Condições Padrão que podem ser adicionados às Compras e Vendas.
 
- Exemplos: 
+ Exemplos:
 
  1. Validade da oferta.
  1. Condições de pagamento (Com Antecedência, No Crédito, parte com antecedência etc).
@@ -3400,7 +3400,7 @@ Examples:
  1. Garantia, se houver.
  1. Política de Devolução.
  1. Condições de entrega, caso seja aplicável.
- 1. Formas de abordar litígios, indemnização, responsabilidade, etc. 
+ 1. Formas de abordar litígios, indemnização, responsabilidade, etc.
  1. Endereço e Contacto da sua Empresa."
 DocType: Issue,Issue Type,Tipo de problema
 DocType: Attendance,Leave Type,Tipo de Licença
@@ -4031,11 +4031,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,Selecione um funcionário para obter o adiantamento do funcionário.
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,Por favor selecione uma data válida
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,Seleccione a natureza do seu negócio.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5139,7 +5139,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,Nome do Candidato
 DocType: Authorization Rule,Customer / Item Name,Cliente / Nome do Item
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","Se ativado, os detalhes da última compra dos itens não serão obtidos do pedido anterior ou recibo de compra"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 

--- a/erpnext/translations/ro.csv
+++ b/erpnext/translations/ro.csv
@@ -1032,7 +1032,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1043,19 +1043,19 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 6. Amount: Tax amount.
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
-9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","Șablon de impozitare standard, care pot fi aplicate la toate tranzacțiile de vânzare. Acest model poate conține lista de capete fiscale și, de asemenea, mai multe capete de cheltuieli / venituri, cum ar fi ""de transport"", ""asigurare"", ""manipulare"" etc. 
+9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","Șablon de impozitare standard, care pot fi aplicate la toate tranzacțiile de vânzare. Acest model poate conține lista de capete fiscale și, de asemenea, mai multe capete de cheltuieli / venituri, cum ar fi ""de transport"", ""asigurare"", ""manipulare"" etc.
 
- #### Notă 
+ #### Notă
 
  vă Rata de impozitare defini aici va fi cota de impozitare standard pentru toate Articole ** **. Dacă există articole ** **, care au preturi diferite, acestea trebuie să fie adăugate în ** Impozitul Postul ** masă în ** ** postul comandantului.
 
- #### Descrierea de coloane 
+ #### Descrierea de coloane
 
- 1. Calcul Tip: 
+ 1. Calcul Tip:
  - Acest lucru poate fi pe ** net total ** (care este suma cuantum de bază).
  - ** La rândul precedent Raport / Suma ** (pentru impozite sau taxe cumulative). Dacă selectați această opțiune, impozitul va fi aplicat ca procent din rândul anterior (în tabelul de impozitare) suma totală sau.
  - ** ** Real (după cum sa menționat).
- 2. Șeful cont: Registrul cont în care acest impozit va fi rezervat 
+ 2. Șeful cont: Registrul cont în care acest impozit va fi rezervat
  3. Cost Center: În cazul în care taxa / taxa este un venit (cum ar fi de transport maritim) sau cheltuieli trebuie să se rezervat împotriva unui centru de cost.
  4. Descriere: Descriere a taxei (care vor fi tipărite în facturi / citate).
  5. Notă: Rata de Profit Brut.
@@ -1242,7 +1242,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,amortizare intrare
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,Vă rugăm să selectați tipul de document primul
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,Anuleaza Vizite Material {0} înainte de a anula această Vizita de întreținere
-DocType: Crop Cycle,ISO 8016 standard,Standardul ISO 8016
+DocType: Crop Cycle,ISO 8601 standard,Standardul ISO 8601
 DocType: Pricing Rule,Rate or Discount,Tarif sau Discount
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},Serial Nu {0} nu aparține postul {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,Cantitate ceruta
@@ -3093,7 +3093,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3105,19 +3105,19 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
 9. Consider Tax or Charge for: In this section you can specify if the tax / charge is only for valuation (not a part of total) or only for total (does not add value to the item) or for both.
-10. Add or Deduct: Whether you want to add or deduct the tax.","Șablon de impozitare standard care pot fi aplicate la toate tranzacțiile de cumpărare. Acest model poate conține lista de capete fiscale și, de asemenea, mai multe capete de cheltuieli, cum ar fi ""de transport"", ""asigurare"", ""manipulare"" etc. 
+10. Add or Deduct: Whether you want to add or deduct the tax.","Șablon de impozitare standard care pot fi aplicate la toate tranzacțiile de cumpărare. Acest model poate conține lista de capete fiscale și, de asemenea, mai multe capete de cheltuieli, cum ar fi ""de transport"", ""asigurare"", ""manipulare"" etc.
 
- #### Notă 
+ #### Notă
 
  Rata de impozitare pe care o definiți aici va fi rata de impozitare standard pentru toate Articole ** **. Dacă există articole ** **, care au preturi diferite, acestea trebuie să fie adăugate în ** Impozitul Postul ** masă în ** ** postul comandantului.
 
- #### Descrierea de coloane 
+ #### Descrierea de coloane
 
- 1. Calcul Tip: 
+ 1. Calcul Tip:
  - Acest lucru poate fi pe ** net total ** (care este suma cuantum de bază).
  - ** La rândul precedent Raport / Suma ** (pentru impozite sau taxe cumulative). Dacă selectați această opțiune, impozitul va fi aplicat ca procent din rândul anterior (în tabelul de impozitare) suma totală sau.
  - ** ** Real (după cum sa menționat).
- 2. Șeful cont: Registrul cont în care acest impozit va fi rezervat 
+ 2. Șeful cont: Registrul cont în care acest impozit va fi rezervat
  3. Cost Center: În cazul în care taxa / taxa este un venit (cum ar fi de transport maritim) sau cheltuieli trebuie să se rezervat împotriva unui centru de cost.
  4. Descriere: Descriere a taxei (care vor fi tipărite în facturi / citate).
  5. Notă: Rata de Profit Brut.
@@ -3397,7 +3397,7 @@ Examples:
 1. Ways of addressing disputes, indemnity, liability, etc.
 1. Address and Contact of your Company.","Termeni și Condiții care pot fi adăugate la vânzările și achizițiile standard.
 
- Exemple: 
+ Exemple:
 
  1. Perioada de valabilitate a ofertei.
  1. Conditii de plata (in avans, pe credit, parte în avans etc.).
@@ -3406,7 +3406,7 @@ Examples:
  1. Garantie dacă este cazul.
  1. Politica de Returnare.
  1. Condiții de transport maritim, dacă este cazul.
- 1. Modalitati de litigii de adresare, indemnizație, răspunderea, etc. 
+ 1. Modalitati de litigii de adresare, indemnizație, răspunderea, etc.
  1. Adresa și de contact ale companiei."
 DocType: Issue,Issue Type,Tipul problemei
 DocType: Attendance,Leave Type,Tip Concediu
@@ -4037,11 +4037,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,Selectați un angajat pentru a avansa angajatul.
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,Selectați o dată validă
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,Selectați natura afacerii dumneavoastră.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -4879,7 +4879,7 @@ DocType: Accounts Settings,"If enabled, the system will post accounting entries 
 apps/erpnext/erpnext/setup/setup_wizard/data/industry_type.py +15,Brokerage,Brokeraj
 apps/erpnext/erpnext/hr/doctype/leave_application/leave_application.py +207,Attendance for employee {0} is already marked for this day,Prezența pentru angajatul {0} este deja marcată pentru această zi
 DocType: Work Order Operation,"in Minutes
-Updated via 'Time Log'","în procesul-verbal 
+Updated via 'Time Log'","în procesul-verbal
  Actualizat prin ""Ora Log"""
 DocType: Customer,From Lead,Din Conducere
 apps/erpnext/erpnext/config/manufacturing.py +13,Orders released for production.,Comenzi lansat pentru producție.
@@ -5145,7 +5145,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,Nume solicitant
 DocType: Authorization Rule,Customer / Item Name,Client / Denumire articol
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","Dacă este activată, detaliile ultimei achiziții a elementelor nu vor fi preluate din comanda de cumpărare sau din chitanța de achiziție anterioară"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 
@@ -5615,7 +5615,7 @@ apps/erpnext/erpnext/accounts/doctype/fiscal_year/fiscal_year.py +82,Year start 
 apps/erpnext/erpnext/selling/doctype/customer/customer.py +122,Please mention the Lead Name in Lead {0},Menționați numele de plumb din plumb {0}
 apps/erpnext/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py +156,Start date should be less than end date for Item {0},Data de începere trebuie să fie mai mică decât data de sfârșit pentru postul {0}
 DocType: Item,"Example: ABCD.#####
-If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","Exemplu:. ABCD ##### 
+If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","Exemplu:. ABCD #####
  Dacă seria este setat și nu de serie nu este menționat în tranzacții, numărul de atunci automat de serie va fi creat pe baza acestei serii. Dacă întotdeauna doriți să se menționeze explicit Serial nr de acest articol. părăsi acest gol."
 DocType: Upload Attendance,Upload Attendance,Încărcați Spectatori
 apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.js +616,BOM and Manufacturing Quantity are required,BOM și cantitatea de producție sunt necesare

--- a/erpnext/translations/ru.csv
+++ b/erpnext/translations/ru.csv
@@ -1032,7 +1032,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1043,19 +1043,19 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 6. Amount: Tax amount.
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
-9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","Стандартный шаблон налог, который может быть применен ко всем сделок купли-продажи. Этот шаблон может содержать перечень налоговых руководителей, а также других глав расходы / доходы, как ""Shipping"", ""Insurance"", ""Обращение"" и т.д. 
+9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","Стандартный шаблон налог, который может быть применен ко всем сделок купли-продажи. Этот шаблон может содержать перечень налоговых руководителей, а также других глав расходы / доходы, как ""Shipping"", ""Insurance"", ""Обращение"" и т.д.
 
- #### Примечание 
+ #### Примечание
 
  ставка налога на Вы Определить здесь будет стандартная ставка налога на прибыль для всех ** деталей **. Если есть ** товары **, которые имеют различные цены, они должны быть добавлены в ** деталь налога ** стол в ** деталь ** мастера.
 
- #### Описание колонок 
+ #### Описание колонок
 
- 1. Расчет Тип: 
+ 1. Расчет Тип:
  - Это может быть ** Чистый Всего ** (то есть сумма основной суммы).
  - ** На предыдущей строке Total / сумма ** (по совокупности налогов и сборов). Если вы выбираете эту опцию, налог будет применяться в процентах от предыдущего ряда (в налоговом таблицы) суммы или объема.
  - ** ** Фактический (как уже упоминалось).
- 2. Счет Руководитель: лицевому счету, при которых этот налог будут забронированы 
+ 2. Счет Руководитель: лицевому счету, при которых этот налог будут забронированы
  3. Центр Стоимость: Если налог / налог на заряд доход (как перевозка груза) или расходов это должен быть забронирован на МВЗ.
  4. Описание: Описание налога (которые будут напечатаны в счетах-фактурах / кавычек).
  5. Оценить: Налоговая ставка.
@@ -1242,7 +1242,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,Износ Вход
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,"Пожалуйста, выберите тип документа сначала"
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,Отменить Материал просмотров {0} до отмены этого обслуживания визит
-DocType: Crop Cycle,ISO 8016 standard,Стандарт ISO 8016
+DocType: Crop Cycle,ISO 8601 standard,Стандарт ISO 8601
 DocType: Pricing Rule,Rate or Discount,Стоимость или скидка
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},Серийный номер {0} не принадлежит Пункт {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,Обязательные Кол-во
@@ -3090,7 +3090,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3102,19 +3102,19 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
 9. Consider Tax or Charge for: In this section you can specify if the tax / charge is only for valuation (not a part of total) or only for total (does not add value to the item) or for both.
-10. Add or Deduct: Whether you want to add or deduct the tax.","Стандартный шаблон налог, который может быть применен ко всем операциям купли-. Этот шаблон может содержать перечень налоговых руководителей, а также других расходов руководителей как ""Shipping"", ""Insurance"", ""Обращение"" и т.д. 
+10. Add or Deduct: Whether you want to add or deduct the tax.","Стандартный шаблон налог, который может быть применен ко всем операциям купли-. Этот шаблон может содержать перечень налоговых руководителей, а также других расходов руководителей как ""Shipping"", ""Insurance"", ""Обращение"" и т.д.
 
- #### Примечание 
+ #### Примечание
 
  ставка налога на которые вы указали здесь будет стандартная ставка налога на прибыль для всех ** деталей **. Если есть ** товары **, которые имеют различные цены, они должны быть добавлены в ** деталь налога ** стол в ** деталь ** мастера.
 
- #### Описание колонок 
+ #### Описание колонок
 
- 1. Расчет Тип: 
+ 1. Расчет Тип:
  - Это может быть ** Чистый Всего ** (то есть сумма основной суммы).
  - ** На предыдущей строке Total / сумма ** (по совокупности налогов и сборов). Если вы выбираете эту опцию, налог будет применяться в процентах от предыдущего ряда (в налоговом таблицы) суммы или объема.
  - ** ** Фактический (как уже упоминалось).
- 2. Счет Руководитель: лицевому счету, при которых этот налог будут забронированы 
+ 2. Счет Руководитель: лицевому счету, при которых этот налог будут забронированы
  3. Центр Стоимость: Если налог / налог на заряд доход (как перевозка груза) или расходов это должен быть забронирован на МВЗ.
  4. Описание: Описание налога (которые будут напечатаны в счетах-фактурах / кавычек).
  5. Оценить: Налоговая ставка.
@@ -3393,7 +3393,7 @@ Examples:
 1. Ways of addressing disputes, indemnity, liability, etc.
 1. Address and Contact of your Company.","Стандартные положения и условия, которые могут быть добавлены к продажам и покупкам.
 
- Примеры: 
+ Примеры:
 
  1. Срок действия предложения.
  1. Условия оплаты (заранее, в кредит, часть заранее и т.д.).
@@ -3402,7 +3402,7 @@ Examples:
  1. Гарантия, если таковые имеются.
  1. Возвращает политики.
  1. Условия доставки, если применимо.
- 1. Пути решения споров, возмещения, ответственности и т.д. 
+ 1. Пути решения споров, возмещения, ответственности и т.д.
  1. Адрес и контактная Вашей компании."
 DocType: Issue,Issue Type,Тип вопроса
 DocType: Attendance,Leave Type,Оставьте Тип
@@ -4033,11 +4033,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,"Выберите сотрудника, чтобы получить работу сотрудника."
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,Пожалуйста выберите правильную дату
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,Выберите характер вашего бизнеса.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -4873,7 +4873,7 @@ DocType: Accounts Settings,"If enabled, the system will post accounting entries 
 apps/erpnext/erpnext/setup/setup_wizard/data/industry_type.py +15,Brokerage,Посредничество
 apps/erpnext/erpnext/hr/doctype/leave_application/leave_application.py +207,Attendance for employee {0} is already marked for this day,Участие для работника {0} уже помечено на этот день
 DocType: Work Order Operation,"in Minutes
-Updated via 'Time Log'","в минутах 
+Updated via 'Time Log'","в минутах
  Обновлено помощью ""Time Вход"""
 DocType: Customer,From Lead,От лида
 apps/erpnext/erpnext/config/manufacturing.py +13,Orders released for production.,"Заказы, выпущенные для производства."
@@ -5140,7 +5140,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,Имя заявителя
 DocType: Authorization Rule,Customer / Item Name,Клиент / Название продукта
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","Если включено, последние данные о покупке товаров не будут получены из предыдущего заказа на покупку или квитанции о покупке"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 
@@ -5608,7 +5608,7 @@ apps/erpnext/erpnext/accounts/doctype/fiscal_year/fiscal_year.py +82,Year start 
 apps/erpnext/erpnext/selling/doctype/customer/customer.py +122,Please mention the Lead Name in Lead {0},"Пожалуйста, укажите имя Lead in Lead {0}"
 apps/erpnext/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py +156,Start date should be less than end date for Item {0},Дата начала должна быть раньше даты окончания для продукта {0}
 DocType: Item,"Example: ABCD.#####
-If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","Пример:. ABCD ##### 
+If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","Пример:. ABCD #####
  Если серия установлен и Серийный номер не упоминается в сделках, то автоматическая серийный номер будет создан на основе этой серии. Если вы хотите всегда явно упомянуть заводским номером для этого элемента. оставить это поле пустым,."
 DocType: Upload Attendance,Upload Attendance,Добавить посещаемости
 apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.js +616,BOM and Manufacturing Quantity are required,ВМ и количество продукции обязательны

--- a/erpnext/translations/si.csv
+++ b/erpnext/translations/si.csv
@@ -1031,7 +1031,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1222,7 +1222,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,ක්ෂය සටහන්
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,කරුණාකර පළමු ලිපි වර්ගය තෝරා
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,මෙම නඩත්තු සංචාරය අවලංගු කර පෙර ද්රව්ය සංචාර {0} අවලංගු කරන්න
-DocType: Crop Cycle,ISO 8016 standard,ISO 8016 ප්රමිතිය
+DocType: Crop Cycle,ISO 8601 standard,ISO 8601 ප්රමිතිය
 DocType: Pricing Rule,Rate or Discount,අනුපාතිකය හෝ වට්ටම්
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},අනු අංකය {0} අයිතමය අයිති නැත {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,අවශ්ය යවන ලද
@@ -3069,7 +3069,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3982,11 +3982,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,සේවකයා ලබා ගැනීමට සේවකයෙකු තෝරන්න.
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,කරුණාකර වලංගු දිනය තෝරන්න
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,ඔබේ ව්යාපාරයේ ස්වභාවය තෝරන්න.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5089,7 +5089,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,අයදුම්කරු නම
 DocType: Authorization Rule,Customer / Item Name,පාරිභෝගික / අයිතම නම
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","සක්රිය කර ඇත්නම්, භාණ්ඩයේ අවසන් මිලදී ගැනීමේ තොරතුරු පූර්ව මිලදී ගැනීමේ ඇණවුමෙන් හෝ කුවිතාන්සිය මිලදී නොගැනේ"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 

--- a/erpnext/translations/sk.csv
+++ b/erpnext/translations/sk.csv
@@ -1032,7 +1032,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1043,19 +1043,19 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 6. Amount: Tax amount.
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
-9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","Standardní daň šablona, která může být použita pro všechny prodejních transakcí. Tato šablona může obsahovat seznam daňových hlav a také další náklady / příjmy hlavy jako ""doprava"", ""pojištění"", ""manipulace"" atd. 
+9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","Standardní daň šablona, která může být použita pro všechny prodejních transakcí. Tato šablona může obsahovat seznam daňových hlav a také další náklady / příjmy hlavy jako ""doprava"", ""pojištění"", ""manipulace"" atd.
 
- #### Poznámka: 
+ #### Poznámka:
 
  daňovou sazbu, vy definovat zde bude základní sazba daně pro všechny ** položky **. Pokud jsou položky ** **, které mají různé ceny, musí být přidány v ** Položka daních ** stůl v ** položky ** mistra.
 
- #### Popis sloupců 
+ #### Popis sloupců
 
- 1. Výpočet Type: 
+ 1. Výpočet Type:
  - To může být na ** Čistý Total ** (což je součet základní částky).
  - ** Na předchozí řady Total / Částka ** (pro kumulativní daní a poplatků). Zvolíte-li tuto možnost, bude daň se použije jako procento z předchozí řady (v daňové tabulky) množství nebo celkem.
  - ** Aktuální ** (jak je uvedeno).
- 2. Účet Hlava: kniha účtu, pod kterým se bude tato daň rezervovat 
+ 2. Účet Hlava: kniha účtu, pod kterým se bude tato daň rezervovat
  3. Nákladové středisko: V případě, že daň / poplatek je příjmem (jako poštovné) nebo nákladů je třeba rezervovat na nákladové středisko.
  4. Popis: Popis daně (které budou vytištěny v faktur / uvozovek).
  5. Rate: Sazba daně.
@@ -1242,7 +1242,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,odpisy Entry
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,Najprv vyberte typ dokumentu
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,Zrušit Materiál Návštěvy {0} před zrušením tohoto návštěv údržby
-DocType: Crop Cycle,ISO 8016 standard,ISO 8016
+DocType: Crop Cycle,ISO 8601 standard,ISO 8601
 DocType: Pricing Rule,Rate or Discount,Sadzba alebo zľava
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},Pořadové číslo {0} nepatří k bodu {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,Požadované množství
@@ -3095,7 +3095,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3107,19 +3107,19 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
 9. Consider Tax or Charge for: In this section you can specify if the tax / charge is only for valuation (not a part of total) or only for total (does not add value to the item) or for both.
-10. Add or Deduct: Whether you want to add or deduct the tax.","Standardní daň šablona, která může být použita pro všechny nákupních transakcí. Tato šablona může obsahovat seznam daňových hlav a také ostatní náklady hlavy jako ""doprava"", ""pojištění"", ""manipulace"" atd. 
+10. Add or Deduct: Whether you want to add or deduct the tax.","Standardní daň šablona, která může být použita pro všechny nákupních transakcí. Tato šablona může obsahovat seznam daňových hlav a také ostatní náklady hlavy jako ""doprava"", ""pojištění"", ""manipulace"" atd.
 
- #### Poznámka: 
+ #### Poznámka:
 
  daňovou sazbu, můžete definovat zde bude základní sazba daně pro všechny ** položky **. Pokud jsou položky ** **, které mají různé ceny, musí být přidány v ** Položka daních ** stůl v ** položky ** mistra.
 
- #### Popis sloupců 
+ #### Popis sloupců
 
- 1. Výpočet Type: 
+ 1. Výpočet Type:
  - To může být na ** Čistý Total ** (což je součet základní částky).
  - ** Na předchozí řady Total / Částka ** (pro kumulativní daní a poplatků). Zvolíte-li tuto možnost, bude daň se použije jako procento z předchozí řady (v daňové tabulky) množství nebo celkem.
  - ** Aktuální ** (jak je uvedeno).
- 2. Účet Hlava: kniha účtu, pod kterým se bude tato daň rezervovat 
+ 2. Účet Hlava: kniha účtu, pod kterým se bude tato daň rezervovat
  3. Nákladové středisko: V případě, že daň / poplatek je příjmem (jako poštovné) nebo nákladů je třeba rezervovat na nákladové středisko.
  4. Popis: Popis daně (které budou vytištěny v faktur / uvozovek).
  5. Rate: Sazba daně.
@@ -3398,7 +3398,7 @@ Examples:
 1. Ways of addressing disputes, indemnity, liability, etc.
 1. Address and Contact of your Company.","Všeobecné obchodní podmínky, které mohou být přidány do prodejů a nákupů.
 
- Příklady: 
+ Příklady:
 
  1. Platnost nabídky.
  1. Platební podmínky (v předstihu, na úvěr, část zálohy atd.)
@@ -3407,7 +3407,7 @@ Examples:
  1. Záruka, pokud existuje.
  1. Vrátí zásady.
  1. Podmínky přepravy, v případě potřeby.
- 1. Způsoby řešení sporů, náhrady škody, odpovědnosti za škodu, atd 
+ 1. Způsoby řešení sporů, náhrady škody, odpovědnosti za škodu, atd
  1. Adresa a kontakt na vaši společnost."
 DocType: Issue,Issue Type,Typ vydania
 DocType: Attendance,Leave Type,Leave Type
@@ -4039,11 +4039,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,"Vyberte zamestnanca, aby ste zamestnanca vopred."
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,Vyberte platný dátum
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,Vyberte podstatu svojho podnikania.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -4880,7 +4880,7 @@ DocType: Accounts Settings,"If enabled, the system will post accounting entries 
 apps/erpnext/erpnext/setup/setup_wizard/data/industry_type.py +15,Brokerage,Makléřská
 apps/erpnext/erpnext/hr/doctype/leave_application/leave_application.py +207,Attendance for employee {0} is already marked for this day,Účasť na zamestnancov {0} je už označený pre tento deň
 DocType: Work Order Operation,"in Minutes
-Updated via 'Time Log'","v minútach 
+Updated via 'Time Log'","v minútach
  aktualizované pomocou ""Time Log"""
 DocType: Customer,From Lead,Od Obchodnej iniciatívy
 apps/erpnext/erpnext/config/manufacturing.py +13,Orders released for production.,Objednávky uvolněna pro výrobu.
@@ -5147,7 +5147,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,Žadatel Název
 DocType: Authorization Rule,Customer / Item Name,Zákazník / Název zboží
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","Ak je povolené, posledné nákupné údaje o položkách nebudú stiahnuté z predchádzajúcej objednávky alebo nákupného dokladu"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 
@@ -5616,7 +5616,7 @@ apps/erpnext/erpnext/accounts/doctype/fiscal_year/fiscal_year.py +82,Year start 
 apps/erpnext/erpnext/selling/doctype/customer/customer.py +122,Please mention the Lead Name in Lead {0},Označte vedúci názov vo vedúcej {0}
 apps/erpnext/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py +156,Start date should be less than end date for Item {0},Datum zahájení by měla být menší než konečné datum pro bod {0}
 DocType: Item,"Example: ABCD.#####
-If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","Příklad:. ABCD ##### 
+If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","Příklad:. ABCD #####
  Je-li série nastavuje a pořadové číslo není uvedeno v transakcích, bude vytvořen poté automaticky sériové číslo na základě této série. Pokud chcete vždy výslovně uvést pořadová čísla pro tuto položku. ponechte prázdné."
 DocType: Upload Attendance,Upload Attendance,Nahráť Dochádzku
 apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.js +616,BOM and Manufacturing Quantity are required,BOM a Výrobné množstvo sú povinné

--- a/erpnext/translations/sl.csv
+++ b/erpnext/translations/sl.csv
@@ -1032,7 +1032,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1223,7 +1223,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,Amortizacija Začetek
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,"Prosimo, najprej izberite vrsto dokumenta"
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,Preklic Material Obiski {0} pred preklicem to vzdrževanje obisk
-DocType: Crop Cycle,ISO 8016 standard,ISO 8016 standard
+DocType: Crop Cycle,ISO 8601 standard,ISO 8601 standard
 DocType: Pricing Rule,Rate or Discount,Stopnja ali popust
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},Serijska št {0} ne pripada postavki {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,Zahtevani Kol
@@ -3072,7 +3072,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3982,11 +3982,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,"Izberite zaposlenega, da zaposleni vnaprej napreduje."
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,Izberite veljaven datum
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,Izberite naravo vašega podjetja.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5089,7 +5089,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,Predlagatelj Ime
 DocType: Authorization Rule,Customer / Item Name,Stranka / Item Name
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","Če je omogočeno, zadnji podatki o nakupu predmetov ne bodo pridobljeni iz prejšnjega naročila ali potrdila o nakupu"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 

--- a/erpnext/translations/sq.csv
+++ b/erpnext/translations/sq.csv
@@ -1031,7 +1031,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1221,7 +1221,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,Zhvlerësimi Hyrja
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,Ju lutem zgjidhni llojin e dokumentit të parë
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,Anuloje Vizitat Materiale {0} para anulimit të kësaj vizite Mirëmbajtja
-DocType: Crop Cycle,ISO 8016 standard,ISO 8016 standard
+DocType: Crop Cycle,ISO 8601 standard,ISO 8601 standard
 DocType: Pricing Rule,Rate or Discount,Rate ose zbritje
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},Serial Asnjë {0} nuk i përkasin Item {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,Kerkohet Qty
@@ -3071,7 +3071,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3983,11 +3983,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,Përzgjidhni një punonjës që të merrni punonjësin përpara.
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,Zgjidh një datë të vlefshme
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,Zgjidhni natyrën e biznesit tuaj.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5075,7 +5075,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,Emri i aplikantit
 DocType: Authorization Rule,Customer / Item Name,Customer / Item Emri
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","Nëse aktivizohet, detajet e fundit të blerjes së artikujve nuk do të tërhiqen nga urdhri i blerjes së mëparshme ose faturën e blerjes"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 

--- a/erpnext/translations/sr.csv
+++ b/erpnext/translations/sr.csv
@@ -1031,7 +1031,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1042,19 +1042,19 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 6. Amount: Tax amount.
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
-9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","Стандардни порез шаблон који се може применити на свим продајним трансакцијама. Овај шаблон може садржати листу пореских глава и такође других шефова расходи / приходима као што су ""Схиппинг"", ""осигурање"", ""Руковање"" итд 
+9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","Стандардни порез шаблон који се може применити на свим продајним трансакцијама. Овај шаблон може садржати листу пореских глава и такође других шефова расходи / приходима као што су ""Схиппинг"", ""осигурање"", ""Руковање"" итд
 
- 
+
 
  #### Напомена Порески оцењујете дефине овде ће бити стандардна стопа пореза за све ** ставки **. Ако постоје ** ** артикала које имају различите цене, они морају да се додају у ** тачка порезу ** сто у ** тачка ** господара.
 
- #### Опис Цолумнс 
+ #### Опис Цолумнс
 
- 1. Обрачун Тип: 
+ 1. Обрачун Тип:
  - Ово може бити на ** Нето Укупно ** (да је збир основног износа).
  - ** На Претходна Ров укупно / Износ ** (за кумулативних наплати пореза и). Ако изаберете ову опцију, порез ће се применити као проценат претходни ред (у пореском табели) износу или укупно.
  - ** Стварни ** (као што је поменуто).
- 2. Рачун Шеф: Рачун књига под којима ће овај порез бити кажњен 
+ 2. Рачун Шеф: Рачун књига под којима ће овај порез бити кажњен
  3. Трошак Центар: Ако порески / наплаћује приход (као бродарства) или трошак треба да буде кажњен против трошкова Центра.
  4. Опис: Опис пореза (који ће бити штампан у фактурама / наводницима).
  5. Рате: Пореска стопа.
@@ -1241,7 +1241,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,Амортизација Ступање
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,Прво изаберите врсту документа
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,Отменить Материал просмотров {0} до отмены этого обслуживания визит
-DocType: Crop Cycle,ISO 8016 standard,ИСО 8016 стандард
+DocType: Crop Cycle,ISO 8601 standard,ИСО 8601 стандард
 DocType: Pricing Rule,Rate or Discount,Стопа или попуст
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},Серийный номер {0} не принадлежит Пункт {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,Обавезно Кол
@@ -3091,7 +3091,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3103,19 +3103,19 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
 9. Consider Tax or Charge for: In this section you can specify if the tax / charge is only for valuation (not a part of total) or only for total (does not add value to the item) or for both.
-10. Add or Deduct: Whether you want to add or deduct the tax.","Стандардни порез шаблон који се може применити на све трансакције куповине. Овај шаблон може садржати листу пореских глава и такође других шефова трошкова као што су ""Схиппинг"", ""осигурање"", ""Руковање"" итд 
+10. Add or Deduct: Whether you want to add or deduct the tax.","Стандардни порез шаблон који се може применити на све трансакције куповине. Овај шаблон може садржати листу пореских глава и такође других шефова трошкова као што су ""Схиппинг"", ""осигурање"", ""Руковање"" итд
 
- 
+
 
  #### Напомена Тхе пореску стопу сте овде дефинишете ће бити стандардна стопа пореза за све ** ставки **. Ако постоје ** ** артикала које имају различите цене, они морају да се додају у ** тачка порезу ** сто у ** тачка ** господара.
 
- #### Опис Цолумнс 
+ #### Опис Цолумнс
 
- 1. Обрачун Тип: 
+ 1. Обрачун Тип:
  - Ово може бити на ** Нето Укупно ** (да је збир основног износа).
  - ** На Претходна Ров укупно / Износ ** (за кумулативних наплати пореза и). Ако изаберете ову опцију, порез ће се применити као проценат претходни ред (у пореском табели) износу или укупно.
  - ** Стварни ** (као што је поменуто).
- 2. Рачун Шеф: Рачун књига под којима ће овај порез бити кажњен 
+ 2. Рачун Шеф: Рачун књига под којима ће овај порез бити кажњен
  3. Трошак Центар: Ако порески / наплаћује приход (као бродарства) или трошак треба да буде кажњен против трошкова Центра.
  4. Опис: Опис пореза (који ће бити штампан у фактурама / наводницима).
  5. Рате: Пореска стопа.
@@ -3395,7 +3395,7 @@ Examples:
 1. Ways of addressing disputes, indemnity, liability, etc.
 1. Address and Contact of your Company.","Стандардним условима који се могу додати да продаје и куповине.
 
- 
+
 
  Примери: 1. Рок важења понуде.
  1. Услови плаћања (унапред, на кредит, део унапред итд).
@@ -3404,7 +3404,7 @@ Examples:
  1. Гаранција ако их има.
  1. Ретурнс Полици.
  1. Услови бродарства, по потреби.
- 1. Начини баве споровима, одштета, одговорности итд 
+ 1. Начини баве споровима, одштета, одговорности итд
  1. Адреса и контакт Ваше фирме."
 DocType: Issue,Issue Type,врста издања
 DocType: Attendance,Leave Type,Оставите Вид
@@ -4035,11 +4035,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,Изаберите запосленог да запослени напредује.
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,Изаберите важећи датум
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,Изаберите природу вашег посла.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -4877,7 +4877,7 @@ DocType: Accounts Settings,"If enabled, the system will post accounting entries 
 apps/erpnext/erpnext/setup/setup_wizard/data/industry_type.py +15,Brokerage,посредништво
 apps/erpnext/erpnext/hr/doctype/leave_application/leave_application.py +207,Attendance for employee {0} is already marked for this day,Присуство за запосленог {0} је већ означена за овај дан
 DocType: Work Order Operation,"in Minutes
-Updated via 'Time Log'","у Минутес 
+Updated via 'Time Log'","у Минутес
  ажурирано преко 'Време Приступи'"
 DocType: Customer,From Lead,Од Леад
 apps/erpnext/erpnext/config/manufacturing.py +13,Orders released for production.,Поруџбине пуштен за производњу.
@@ -5142,7 +5142,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,Подносилац захтева Име
 DocType: Authorization Rule,Customer / Item Name,Кориснички / Назив
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","Ако је омогућено, последњи подаци о куповини ставки неће бити преузети из претходног налога за куповину или куповине рачуна"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 
@@ -5611,7 +5611,7 @@ apps/erpnext/erpnext/accounts/doctype/fiscal_year/fiscal_year.py +82,Year start 
 apps/erpnext/erpnext/selling/doctype/customer/customer.py +122,Please mention the Lead Name in Lead {0},Молим вас да наведете Леад Леад у Леад-у {0}
 apps/erpnext/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py +156,Start date should be less than end date for Item {0},Дата начала должна быть меньше даты окончания для Пункт {0}
 DocType: Item,"Example: ABCD.#####
-If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","Пример:. АБЦД ##### 
+If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","Пример:. АБЦД #####
  Ако Радња је смештена и серијски број се не помиње у трансакцијама, онда аутоматски серијски број ће бити креирана на основу ове серије. Ако сте одувек желели да помиње експлицитно Сериал Нос за ову ставку. оставите празно."
 DocType: Upload Attendance,Upload Attendance,Уплоад присуствовање
 apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.js +616,BOM and Manufacturing Quantity are required,БОМ и Производња Количина се тражи

--- a/erpnext/translations/sv.csv
+++ b/erpnext/translations/sv.csv
@@ -1031,7 +1031,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1221,7 +1221,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,avskrivningar Entry
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,Välj dokumenttyp först
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,Avbryt Material {0} innan du avbryter detta Underhållsbesök
-DocType: Crop Cycle,ISO 8016 standard,ISO 8016-standarden
+DocType: Crop Cycle,ISO 8601 standard,ISO 8601-standarden
 DocType: Pricing Rule,Rate or Discount,Betygsätt eller rabatt
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},Löpnummer {0} inte tillhör punkt {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,Obligatorisk Antal
@@ -3071,7 +3071,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3984,11 +3984,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,Välj en anställd för att få arbetstagaren att gå vidare.
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,Var god välj ett giltigt datum
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,Välj typ av ditt företag.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5090,7 +5090,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,Sökandes Namn
 DocType: Authorization Rule,Customer / Item Name,Kund / artikelnamn
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt",Om den är aktiverad kommer inte de senaste inköpsuppgifterna för objekt att hämtas från tidigare inköpsorder eller inköpsbevis
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 

--- a/erpnext/translations/sw.csv
+++ b/erpnext/translations/sw.csv
@@ -1020,7 +1020,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1210,7 +1210,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,Kuingia kwa kushuka kwa thamani
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,Tafadhali chagua aina ya hati kwanza
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,Futa Ziara Nyenzo {0} kabla ya kufuta Kutembelea Utunzaji huu
-DocType: Crop Cycle,ISO 8016 standard,Kiwango cha ISO 8016
+DocType: Crop Cycle,ISO 8601 standard,Kiwango cha ISO 8601
 DocType: Pricing Rule,Rate or Discount,Kiwango au Punguzo
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},Serial Hakuna {0} si ya Bidhaa {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,Uliohitajika Uchina
@@ -3029,7 +3029,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3930,11 +3930,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,Chagua mfanyakazi ili aendelee mfanyakazi.
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,Tafadhali chagua Tarehe halali
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,Chagua asili ya biashara yako.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5016,7 +5016,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,Jina la Msaidizi
 DocType: Authorization Rule,Customer / Item Name,Jina la Wateja / Bidhaa
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","Ikiwa imewezeshwa, maelezo ya mwisho ya ununuzi ya vitu hayatafutwa kutoka kwa amri ya ununuzi uliopita au risiti ya ununuzi"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 

--- a/erpnext/translations/ta.csv
+++ b/erpnext/translations/ta.csv
@@ -39,7 +39,7 @@ apps/erpnext/erpnext/controllers/sales_and_purchase_return.py +43,Exchange Rate 
 DocType: Sales Invoice,Customer Name,வாடிக்கையாளர் பெயர்
 DocType: Vehicle,Natural Gas,இயற்கை எரிவாயு
 apps/erpnext/erpnext/setup/setup_wizard/operations/company_setup.py +64,Bank account cannot be named as {0},வங்கி கணக்கு என பெயரிடப்பட்டது {0}
-DocType: Account,Heads (or groups) against which Accounting Entries are made and balances are maintained.,"தலைவர்கள் (குழுக்களின்) எதிராக, 
+DocType: Account,Heads (or groups) against which Accounting Entries are made and balances are maintained.,"தலைவர்கள் (குழுக்களின்) எதிராக,
 கணக்கு  பதிவுகள் செய்யப்படுகின்றன மற்றும் சமநிலைகள் பராமரிக்கப்படுகிறது."
 apps/erpnext/erpnext/accounts/doctype/gl_entry/gl_entry.py +196,Outstanding for {0} cannot be less than zero ({1}),சிறந்த {0} பூஜ்யம் விட குறைவாக இருக்க முடியாது ( {1} )
 apps/erpnext/erpnext/hr/doctype/payroll_entry/payroll_entry.py +356,There are no submitted Salary Slips to process.,செயலாற்றுவதற்கு சமர்ப்பிக்கப்படாத எந்த சம்பளமும் இல்லை.
@@ -461,7 +461,7 @@ DocType: Appointment Type,Is Inpatient,உள்நோயாளி
 apps/erpnext/erpnext/education/report/student_and_guardian_contact_details/student_and_guardian_contact_details.py +55,Guardian1 Name,Guardian1 பெயர்
 DocType: Delivery Note,In Words (Export) will be visible once you save the Delivery Note.,நீங்கள் டெலிவரி குறிப்பு சேமிக்க முறை வேர்ட்ஸ் (ஏற்றுமதி) காண முடியும்.
 DocType: Cheque Print Template,Distance from left edge,இடது ஓரத்தில் இருந்து தூரம்
-apps/erpnext/erpnext/utilities/bot.py +29,{0} units of [{1}](#Form/Item/{1}) found in [{2}](#Form/Warehouse/{2}),"{0} [{1}] 
+apps/erpnext/erpnext/utilities/bot.py +29,{0} units of [{1}](#Form/Item/{1}) found in [{2}](#Form/Warehouse/{2}),"{0} [{1}]
 அலகுகள் (# படிவம் / பொருள் / {1}) [{2}] காணப்படுகிறது (# படிவம் / சேமிப்பு கிடங்கு / {2})"
 DocType: Lead,Industry,தொழில்
 DocType: Employee,Job Profile,வேலை விவரம்
@@ -1032,7 +1032,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1043,19 +1043,19 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 6. Amount: Tax amount.
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
-9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","அனைத்து விற்பனை நடவடிக்கைகள் பயன்படுத்த முடியும் என்று ஸ்டாண்டர்ட் வரி வார்ப்புரு. இந்த டெம்ப்ளேட் 
+9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","அனைத்து விற்பனை நடவடிக்கைகள் பயன்படுத்த முடியும் என்று ஸ்டாண்டர்ட் வரி வார்ப்புரு. இந்த டெம்ப்ளேட்
 
- வரி விகிதம் நீங்கள் குறிப்பு #### 
+ வரி விகிதம் நீங்கள் குறிப்பு ####
 
  முதலியன ""கையாளும்"", வரி தலைவர்கள் மற்றும் ""கப்பல்"", ""காப்பீடு"" போன்ற மற்ற இழப்பில் / வருமான தலைவர்கள் பட்டியலில் கொண்டிருக்க முடியாது ** எல்லா ** பொருட்கள் நிலையான வரி விதிக்கப்படும் இங்கே வரையறுக்க. விகிதங்களைக் கொண்டிருக்கின்றன ** என்று ** பொருட்கள் இருந்தால், அவர்கள் ** பொருள் வரி சேர்க்கப்படும் ** ** பொருள் ** மாஸ்டர் அட்டவணை.
 
- #### பத்திகள் 
+ #### பத்திகள்
 
- 1 விளக்கம். கணக்கீடு வகை: 
+ 1 விளக்கம். கணக்கீடு வகை:
  - இந்த இருக்க முடியும் ** நிகர (என்று அடிப்படை அளவு கூடுதல் ஆகும்) ** மொத்த.
  - ** முந்தைய வரிசை மொத்த / தொகை ** அன்று (ஒட்டுமொத்தமாக வரி அல்லது குற்றச்சாட்டுக்களை பதிவு). நீங்கள் இந்த விருப்பத்தை தேர்வு செய்தால், வரி அளவு அல்லது மொத் (வரி அட்டவணையில்) முந்தைய வரிசையில் ஒரு சதவீதம் என பயன்படுத்தப்படும்.
  - ** ** உண்மையான (குறிப்பிட்டுள்ள).
- 2. கணக்கு தலைமை: இந்த வரி 
+ 2. கணக்கு தலைமை: இந்த வரி
  3 முன்பதிவு கீழ் கணக்கு பேரேட்டில். விலை மையம்: வரி / கட்டணம் (கப்பல் போன்றவை) வருமானம் அல்லது செலவு என்றால் அது ஒரு செலவு மையம் எதிரான பதிவு செய்து கொள்ள வேண்டும்.
  4. விளக்கம்: வரி விளக்கம் (என்று பொருள் / மேற்கோள்கள் ல் அச்சிடப்பட்ட வேண்டும்).
  5. விலை: வரி வீதம்.
@@ -1241,7 +1241,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,தேய்மானம் நுழைவு
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,முதல் ஆவணம் வகையை தேர்ந்தெடுக்கவும்
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,இந்த பராமரிப்பு பணிகள் முன் பொருள் வருகைகள் {0} ரத்து
-DocType: Crop Cycle,ISO 8016 standard,ISO 8016 தரநிலை
+DocType: Crop Cycle,ISO 8601 standard,ISO 8601 தரநிலை
 DocType: Pricing Rule,Rate or Discount,விகிதம் அல்லது தள்ளுபடி
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},தொடர் இல {0} பொருள் அல்ல {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,தேவையான அளவு
@@ -1249,7 +1249,7 @@ apps/erpnext/erpnext/public/js/hub/hub_listing.js +58,Favourites,பிடித
 DocType: Hub Settings,Custom Data,தனிப்பயன் தரவு
 apps/erpnext/erpnext/stock/doctype/warehouse/warehouse.py +126,Warehouses with existing transaction can not be converted to ledger.,தற்போதுள்ள பரிவர்த்தனை கிடங்குகள் பேரேடு மாற்றப்பட முடியாது.
 DocType: Bank Reconciliation,Total Amount,மொத்த தொகை
-apps/erpnext/erpnext/setup/setup_wizard/data/industry_type.py +32,Internet Publishing,"இணைய 
+apps/erpnext/erpnext/setup/setup_wizard/data/industry_type.py +32,Internet Publishing,"இணைய
 வெளியிடுதல்"
 DocType: Prescription Duration,Number,எண்
 apps/erpnext/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.js +25,Creating {0} Invoice,{0} விலைப்பட்டியல் உருவாக்குதல்
@@ -1773,7 +1773,7 @@ DocType: Asset Settings,This value is used for pro-rata temporis calculation,ச
 apps/erpnext/erpnext/shopping_cart/doctype/shopping_cart_settings/shopping_cart_settings.py +90,You need to enable Shopping Cart,வண்டியில் செயல்படுத்த வேண்டும்
 DocType: Payment Entry,Writeoff,Writeoff
 DocType: Stock Settings,Naming Series Prefix,பெயரிடும் தொடர் முன்னொட்டு
-DocType: Appraisal Template Goal,Appraisal Template Goal,"மதிப்பீட்டு வார்ப்புரு 
+DocType: Appraisal Template Goal,Appraisal Template Goal,"மதிப்பீட்டு வார்ப்புரு
 இலக்கு"
 DocType: Salary Component,Earning,சம்பாதித்து
 DocType: Supplier Scorecard,Scoring Criteria,மதிப்பீட்டு அளவுகோல்
@@ -1957,7 +1957,7 @@ DocType: Maintenance Schedule,Schedules,கால அட்டவணைகள்
 apps/erpnext/erpnext/selling/page/point_of_sale/point_of_sale.js +472,POS Profile is required to use Point-of-Sale,பாயிண்ட்-ன்-விற்பனைக்கு POS விவரம் தேவை
 DocType: Purchase Invoice Item,Net Amount,நிகர விலை
 apps/erpnext/erpnext/stock/doctype/material_request/material_request.py +141,{0} {1} has not been submitted so the action cannot be completed,{0} {1} ஓர் செயல் முடிவடைந்தால் முடியாது சமர்ப்பிக்க செய்யப்படவில்லை
-DocType: Purchase Order Item Supplied,BOM Detail No,"BOM 
+DocType: Purchase Order Item Supplied,BOM Detail No,"BOM
 விபரம் எண்"
 DocType: Landed Cost Voucher,Additional Charges,கூடுதல் கட்டணங்கள்
 DocType: Purchase Invoice,Additional Discount Amount (Company Currency),கூடுதல் தள்ளுபடி தொகை (நிறுவனத்தின் நாணயம்)
@@ -2845,7 +2845,7 @@ DocType: Fee Schedule,Fee Structure,கட்டணம் அமைப்பு
 DocType: Timesheet Detail,Costing Amount,இதற்கான செலவு தொகை
 DocType: Student Admission Program,Application Fee,விண்ணப்பக் கட்டணம்
 apps/erpnext/erpnext/hr/doctype/payroll_entry/payroll_entry.js +52,Submit Salary Slip,சம்பளம் ஸ்லிப் &#39;to
-apps/erpnext/erpnext/controllers/selling_controller.py +137,Maxiumm discount for Item {0} is {1}%,"பொருள் {0} {1}% க்கான 
+apps/erpnext/erpnext/controllers/selling_controller.py +137,Maxiumm discount for Item {0} is {1}%,"பொருள் {0} {1}% க்கான
 அதிகபட்ச தள்ளுபடி"
 apps/erpnext/erpnext/stock/doctype/item_price/item_price.js +16,Import in Bulk,மொத்த  இறக்குமதி
 DocType: Sales Partner,Address & Contacts,முகவரி மற்றும் தொடர்புகள்
@@ -3094,7 +3094,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3106,19 +3106,19 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
 9. Consider Tax or Charge for: In this section you can specify if the tax / charge is only for valuation (not a part of total) or only for total (does not add value to the item) or for both.
-10. Add or Deduct: Whether you want to add or deduct the tax.","அனைத்து கொள்முதல் நடவடிக்கை பயன்படுத்த முடியும் என்று ஸ்டாண்டர்ட் வரி வார்ப்புரு. இந்த டெம்ப்ளேட் நீங்கள் இங்கே வரையறுக்க 
+10. Add or Deduct: Whether you want to add or deduct the tax.","அனைத்து கொள்முதல் நடவடிக்கை பயன்படுத்த முடியும் என்று ஸ்டாண்டர்ட் வரி வார்ப்புரு. இந்த டெம்ப்ளேட் நீங்கள் இங்கே வரையறுக்க
 
- வரி விகிதம் குறிப்பு #### 
+ வரி விகிதம் குறிப்பு ####
 
  முதலியன ""கையாளும்"", வரி தலைவர்கள் மற்றும் ""கப்பல்"", ""காப்பீடு"" போன்ற மற்ற இழப்பில் தலைவர்கள் பட்டியலில் கொண்டிருக்க முடியாது ** எல்லா ** பொருட்கள் நிலையான வரி விதிக்கப்படும். விகிதங்களைக் கொண்டிருக்கின்றன ** என்று ** பொருட்கள் இருந்தால், அவர்கள் ** பொருள் வரி சேர்க்கப்படும் ** ** பொருள் ** மாஸ்டர் அட்டவணை.
 
- #### பத்திகள் 
+ #### பத்திகள்
 
- 1 விளக்கம். கணக்கீடு வகை: 
+ 1 விளக்கம். கணக்கீடு வகை:
  - இந்த இருக்க முடியும் ** நிகர (என்று அடிப்படை அளவு கூடுதல் ஆகும்) ** மொத்த.
  - ** முந்தைய வரிசை மொத்த / தொகை ** அன்று (ஒட்டுமொத்தமாக வரி அல்லது குற்றச்சாட்டுக்களை பதிவு). நீங்கள் இந்த விருப்பத்தை தேர்வு செய்தால், வரி அளவு அல்லது மொத் (வரி அட்டவணையில்) முந்தைய வரிசையில் ஒரு சதவீதம் என பயன்படுத்தப்படும்.
  - ** ** உண்மையான (குறிப்பிட்டுள்ள).
- 2. கணக்கு தலைமை: இந்த வரி 
+ 2. கணக்கு தலைமை: இந்த வரி
  3 முன்பதிவு கீழ் கணக்கு பேரேட்டில். விலை மையம்: வரி / கட்டணம் (கப்பல் போன்றவை) வருமானம் அல்லது செலவு என்றால் அது ஒரு செலவு மையம் எதிரான பதிவு செய்து கொள்ள வேண்டும்.
  4. விளக்கம்: வரி விளக்கம் (என்று பொருள் / மேற்கோள்கள் ல் அச்சிடப்பட்ட வேண்டும்).
  5. விலை: வரி வீதம்.
@@ -3398,7 +3398,7 @@ Examples:
 1. Ways of addressing disputes, indemnity, liability, etc.
 1. Address and Contact of your Company.","நிலையான விதிமுறைகள் மற்றும் விற்பனை மற்றும் கொள்முதல் சேர்க்க முடியும் என்று நிபந்தனைகள்.
 
- எடுத்துக்காட்டுகள்: 
+ எடுத்துக்காட்டுகள்:
 
  1. சலுகை செல்லுபடியாகும்.
  1. கட்டணம் விதிமுறைகள் (கடன் அட்வான்ஸ், பகுதியாக முன்கூட்டியே போன்றவை).
@@ -3407,7 +3407,7 @@ Examples:
  1. உத்தரவாதத்தை ஏதேனும்.
  1. கொள்கை திருப்பும்.
  1. கப்பல் விதிமுறைகள், பொருந்தினால்.
- 1. முதலியன உரையாற்றும் மோதல்களில், ஈட்டுறுதி, பொறுப்பு, 
+ 1. முதலியன உரையாற்றும் மோதல்களில், ஈட்டுறுதி, பொறுப்பு,
  1 வழிகள். முகவரி மற்றும் உங்கள் நிறுவனத்தின் தொடர்பு."
 DocType: Issue,Issue Type,வெளியீடு வகை
 DocType: Attendance,Leave Type,வகை விட்டு
@@ -4036,11 +4036,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,ஊழியர் முன்கூட்டியே பெற ஒரு ஊழியரைத் தேர்ந்தெடுக்கவும்.
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,சரியான தேதி ஒன்றைத் தேர்ந்தெடுக்கவும்
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,உங்கள் வணிக தன்மை தேர்ந்தெடுக்கவும்.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5140,7 +5140,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,விண்ணப்பதாரர் பெயர்
 DocType: Authorization Rule,Customer / Item Name,வாடிக்கையாளர் / உருப்படி பெயர்
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","இயக்கப்பட்டிருந்தால், முந்தைய கொள்முதல் ஆர்டர் அல்லது கொள்முதல் பெறுதலில் இருந்து உருப்படிகளின் கடைசி கொள்முதல் விவரங்கள் பெறப்படாது"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 
@@ -5607,7 +5607,7 @@ apps/erpnext/erpnext/accounts/doctype/fiscal_year/fiscal_year.py +82,Year start 
 apps/erpnext/erpnext/selling/doctype/customer/customer.py +122,Please mention the Lead Name in Lead {0},முன்னணி தலைப்பில் குறிப்பிடவும் {0}
 apps/erpnext/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py +156,Start date should be less than end date for Item {0},தொடக்க தேதி பொருள் முடிவு தேதி விட குறைவாக இருக்க வேண்டும் {0}
 DocType: Item,"Example: ABCD.#####
-If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","உதாரணம்:. தொடர் அமைக்க மற்றும் சீரியல் பரிமாற்றங்கள் குறிப்பிடப்பட்டுள்ளது இல்லை என்றால் ABCD, ##### 
+If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","உதாரணம்:. தொடர் அமைக்க மற்றும் சீரியல் பரிமாற்றங்கள் குறிப்பிடப்பட்டுள்ளது இல்லை என்றால் ABCD, #####
 , பின்னர் தானாக வரிசை எண் இந்த தொடரை அடிப்படையாக கொண்டு உருவாக்கப்பட்டது. நீங்கள் எப்போதும் வெளிப்படையாக இந்த உருப்படியை தொடர் இல குறிப்பிட வேண்டும் என்றால். இதை நிரப்புவதில்லை."
 DocType: Upload Attendance,Upload Attendance,பங்கேற்கும் பதிவேற்ற
 apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.js +616,BOM and Manufacturing Quantity are required,"BOM, மற்றும் தயாரிப்பு தேவையான அளவு"

--- a/erpnext/translations/te.csv
+++ b/erpnext/translations/te.csv
@@ -1032,7 +1032,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1223,7 +1223,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,అరుగుదల ఎంట్రీ
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,మొదటి డాక్యుమెంట్ రకాన్ని ఎంచుకోండి
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,ఈ నిర్వహణ సందర్శించండి రద్దు ముందు రద్దు మెటీరియల్ సందర్శనల {0}
-DocType: Crop Cycle,ISO 8016 standard,ISO 8016 స్టాండర్డ్
+DocType: Crop Cycle,ISO 8601 standard,ISO 8601 స్టాండర్డ్
 DocType: Pricing Rule,Rate or Discount,రేటు లేదా డిస్కౌంట్
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},సీరియల్ లేవు {0} అంశం చెందినది కాదు {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,Required ప్యాక్ చేసిన అంశాల
@@ -3067,7 +3067,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3968,11 +3968,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,ఉద్యోగి ముందస్తు సంపాదించడానికి ఉద్యోగిని ఎంచుకోండి.
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,దయచేసి చెల్లుబాటు అయ్యే తేదీని ఎంచుకోండి
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,మీ వ్యాపార స్వభావం ఎంచుకోండి.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5072,7 +5072,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,దరఖాస్తుదారు పేరు
 DocType: Authorization Rule,Customer / Item Name,కస్టమర్ / అంశం పేరు
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","ప్రారంభించబడితే, అంశాల యొక్క చివరి కొనుగోలు వివరాలు మునుపటి కొనుగోలు ఆర్డర్ లేదా కొనుగోలు రసీదు నుండి పొందబడవు"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 

--- a/erpnext/translations/th.csv
+++ b/erpnext/translations/th.csv
@@ -1033,7 +1033,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1044,19 +1044,19 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 6. Amount: Tax amount.
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
-9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","แม่แบบภาษีมาตรฐานที่สามารถนำไปใช้กับการทำธุรกรรมการขายทั้งหมด แม่แบบนี้สามารถมีรายชื่อของหัวภาษีและค่าใช้จ่ายอื่น ๆ ที่ยัง / หัวรายได้เช่น ""การจัดส่งสินค้า"", ""ประกันภัย"", ""การจัดการ"" ฯลฯ 
+9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","แม่แบบภาษีมาตรฐานที่สามารถนำไปใช้กับการทำธุรกรรมการขายทั้งหมด แม่แบบนี้สามารถมีรายชื่อของหัวภาษีและค่าใช้จ่ายอื่น ๆ ที่ยัง / หัวรายได้เช่น ""การจัดส่งสินค้า"", ""ประกันภัย"", ""การจัดการ"" ฯลฯ
 
- #### หมายเหตุ 
+ #### หมายเหตุ
 
  อัตราภาษีคุณ กำหนดที่นี่จะเป็นอัตราภาษีมาตรฐานสำหรับรายการทั้งหมด ** ** หากมีรายการ ** ** ที่มีอัตราที่แตกต่างกันพวกเขาจะต้องถูกเพิ่มในรายการภาษี ** ** ตารางในรายการ ** ** ต้นแบบ
 
- #### คำอธิบายของคอลัมน์ 
+ #### คำอธิบายของคอลัมน์
 
- 1 การคำนวณประเภท: 
+ 1 การคำนวณประเภท:
  - นี้สามารถอยู่บน ** สุทธิรวม ** (นั่นคือผลรวมของจำนวนเงินขั้นพื้นฐาน)
  - ** เมื่อก่อนแถวทั้งหมด / จำนวนเงิน ** (สำหรับภาษีสะสมหรือค่าใช้จ่าย) ถ้าคุณเลือกตัวเลือกนี้ภาษีจะถูกนำมาใช้เป็นร้อยละของแถวก่อนหน้า (ในตารางภาษี) จำนวนเงินหรือทั้งหมด
  - ** ** ที่เกิดขึ้นจริง (กล่าว)
- 2 หัวหน้าบัญชี: บัญชีแยกประเภทบัญชีตามที่ภาษีนี้จะถูกจอง 
+ 2 หัวหน้าบัญชี: บัญชีแยกประเภทบัญชีตามที่ภาษีนี้จะถูกจอง
  3 ศูนย์ต้นทุน: ถ้าภาษี / ค่าใช้จ่ายเป็นรายได้ (เช่นค่าจัดส่ง) หรือค่าใช้จ่ายจะต้องมีการจองกับศูนย์ต้นทุน
  4 คำอธิบาย: คำอธิบายของภาษี (ที่จะได้รับการตีพิมพ์ในใบแจ้งหนี้ / คำพูด)
  5 อัตราอัตราภาษี
@@ -1243,7 +1243,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,รายการค่าเสื่อมราคา
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,เลือกประเภทของเอกสารที่แรก
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,ยกเลิก การเข้าชม วัสดุ {0} ก่อนที่จะ ยกเลิก การบำรุงรักษา นี้ เยี่ยมชม
-DocType: Crop Cycle,ISO 8016 standard,มาตรฐาน ISO 8016
+DocType: Crop Cycle,ISO 8601 standard,มาตรฐาน ISO 8601
 DocType: Pricing Rule,Rate or Discount,ราคาหรือส่วนลด
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},อนุกรม ไม่มี {0} ไม่ได้อยู่ใน รายการ {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,จำนวนที่ต้องการ
@@ -3095,7 +3095,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3107,19 +3107,19 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
 9. Consider Tax or Charge for: In this section you can specify if the tax / charge is only for valuation (not a part of total) or only for total (does not add value to the item) or for both.
-10. Add or Deduct: Whether you want to add or deduct the tax.","แม่แบบภาษีมาตรฐานที่สามารถนำไปใช้กับการทำธุรกรรมการซื้อทั้งหมด แม่แบบนี้สามารถมีรายชื่อของหัวภาษีและค่าใช้จ่ายนอกจากนี้ยังมีหัวอื่น ๆ เช่น ""การจัดส่งสินค้า"", ""ประกันภัย"", ""การจัดการ"" ฯลฯ 
+10. Add or Deduct: Whether you want to add or deduct the tax.","แม่แบบภาษีมาตรฐานที่สามารถนำไปใช้กับการทำธุรกรรมการซื้อทั้งหมด แม่แบบนี้สามารถมีรายชื่อของหัวภาษีและค่าใช้จ่ายนอกจากนี้ยังมีหัวอื่น ๆ เช่น ""การจัดส่งสินค้า"", ""ประกันภัย"", ""การจัดการ"" ฯลฯ
 
- #### หมายเหตุ 
+ #### หมายเหตุ
 
  อัตราภาษีที่คุณกำหนดที่นี่ จะเสียภาษีในอัตรามาตรฐานสำหรับรายการทั้งหมด ** ** หากมีรายการ ** ** ที่มีอัตราที่แตกต่างกันพวกเขาจะต้องถูกเพิ่มในรายการภาษี ** ** ตารางในรายการ ** ** ต้นแบบ
 
- #### คำอธิบายของคอลัมน์ 
+ #### คำอธิบายของคอลัมน์
 
- 1 การคำนวณประเภท: 
+ 1 การคำนวณประเภท:
  - นี้สามารถอยู่บน ** สุทธิรวม ** (นั่นคือผลรวมของจำนวนเงินขั้นพื้นฐาน)
  - ** เมื่อก่อนแถวทั้งหมด / จำนวนเงิน ** (สำหรับภาษีสะสมหรือค่าใช้จ่าย) ถ้าคุณเลือกตัวเลือกนี้ภาษีจะถูกนำมาใช้เป็นร้อยละของแถวก่อนหน้า (ในตารางภาษี) จำนวนเงินหรือทั้งหมด
  - ** ** ที่เกิดขึ้นจริง (กล่าว)
- 2 หัวหน้าบัญชี: บัญชีแยกประเภทบัญชีตามที่ภาษีนี้จะถูกจอง 
+ 2 หัวหน้าบัญชี: บัญชีแยกประเภทบัญชีตามที่ภาษีนี้จะถูกจอง
  3 ศูนย์ต้นทุน: ถ้าภาษี / ค่าใช้จ่ายเป็นรายได้ (เช่นค่าจัดส่ง) หรือค่าใช้จ่ายจะต้องมีการจองกับศูนย์ต้นทุน
  4 คำอธิบาย: คำอธิบายของภาษี (ที่จะได้รับการตีพิมพ์ในใบแจ้งหนี้ / คำพูด)
  5 อัตราอัตราภาษี
@@ -3399,7 +3399,7 @@ Examples:
 1. Ways of addressing disputes, indemnity, liability, etc.
 1. Address and Contact of your Company.","ตกลงและเงื่อนไขมาตรฐานที่สามารถเพิ่มการขายและการซื้อ
 
- ตัวอย่าง: 
+ ตัวอย่าง:
 
  1 ความถูกต้องของข้อเสนอ
  1 เงื่อนไขการชำระเงิน (ล่วงหน้าในเครดิตส่วนล่วงหน้า ฯลฯ )
@@ -3408,7 +3408,7 @@ Examples:
  1 ถ้ามีการรับประกัน
  1 นโยบายการคืนสินค้า
  1 ข้อตกลงการจัดส่งสินค้าถ้ามีการใช้
- 1 วิธีของข้อพิพาทที่อยู่, การชดใช้หนี้สิน ฯลฯ 
+ 1 วิธีของข้อพิพาทที่อยู่, การชดใช้หนี้สิน ฯลฯ
  1 ที่อยู่และการติดต่อของ บริษัท ของคุณ"
 DocType: Issue,Issue Type,ประเภทการออก
 DocType: Attendance,Leave Type,ฝากประเภท
@@ -4040,11 +4040,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,เลือกพนักงานเพื่อรับพนักงานล่วงหน้า
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,โปรดเลือกวันที่ที่ถูกต้อง
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,เลือกลักษณะของธุรกิจของคุณ
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5147,7 +5147,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,ชื่อผู้ยื่นคำขอ
 DocType: Authorization Rule,Customer / Item Name,ชื่อลูกค้า / รายการ
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt",หากเปิดใช้รายละเอียดการซื้อครั้งล่าสุดของรายการจะไม่ถูกเรียกจากใบสั่งซื้อหรือใบเสร็จการรับสินค้าก่อนหน้านี้
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 
@@ -5616,7 +5616,7 @@ apps/erpnext/erpnext/accounts/doctype/fiscal_year/fiscal_year.py +82,Year start 
 apps/erpnext/erpnext/selling/doctype/customer/customer.py +122,Please mention the Lead Name in Lead {0},โปรดระบุชื่อตะกั่วในผู้นำ {0}
 apps/erpnext/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py +156,Start date should be less than end date for Item {0},วันที่เริ่มต้น ควรจะน้อยกว่า วันที่ สิ้นสุดสำหรับ รายการ {0}
 DocType: Item,"Example: ABCD.#####
-If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","ตัวอย่าง:. ABCD ##### 
+If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","ตัวอย่าง:. ABCD #####
  ถ้าชุดคือชุดและที่เก็บไม่ได้กล่าวถึงในการทำธุรกรรมแล้วหมายเลขประจำเครื่องอัตโนมัติจะถูกสร้างขึ้นบนพื้นฐานของซีรีส์นี้ หากคุณเคยต้องการที่จะพูดถึงอย่างชัดเจนเลขที่ผลิตภัณฑ์สำหรับรายการนี้ ปล่อยให้ว่างนี้"
 DocType: Upload Attendance,Upload Attendance,อัพโหลดผู้เข้าร่วม
 apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.js +616,BOM and Manufacturing Quantity are required,รายการวัสดุและปริมาณการผลิตจะต้อง

--- a/erpnext/translations/tr.csv
+++ b/erpnext/translations/tr.csv
@@ -1163,7 +1163,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1174,19 +1174,19 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 6. Amount: Tax amount.
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
-9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","Tüm Satış İşlemlerine uygulanabilir standart vergi şablonu. Bu şablon 
+9. Is this Tax included in Basic Rate?: If you check this, it means that this tax will not be shown below the item table, but will be included in the Basic Rate in your main item table. This is useful where you want give a flat price (inclusive of all taxes) price to customers.","Tüm Satış İşlemlerine uygulanabilir standart vergi şablonu. Bu şablon
 
- vergi oranını size Not #### 
+ vergi oranını size Not ####
 
  vb ""Handling"", vergi başkanları ve ""Denizcilik"", ""Sigorta"" gibi diğer gider / gelir başkanları listesini içerebilir ** Tüm ** Öğeler için standart vergi oranı olacaktır burada tanımlayın. Farklı fiyat bilgisi ** ** Ürünleri varsa, bunlar ** Ürün Vergisinde eklenmesi gerekir ** ** ** Ürün ana tablo.
 
- #### Kolonların 
+ #### Kolonların
 
- 1 Açıklaması. Hesaplama Türü: 
+ 1 Açıklaması. Hesaplama Türü:
  - Bu üzerinde olabilir ** Net (yani temel miktarın toplamı) ** Toplam.
  - ** Önceki Satır Toplam / Tutar ** On (kümülatif vergi ya da harç için). Bu seçeneği seçerseniz, vergi miktarı veya toplam (vergi tablosunda) önceki satırın bir yüzdesi olarak uygulanacaktır.
  - ** ** Gerçek (belirtildiği gibi).
- 2. Hesap Başkanı: Bu vergi 
+ 2. Hesap Başkanı: Bu vergi
  3 rezerve edileceği altında Hesap defteri. Maliyet Merkezi: Vergi / şarj (nakliye gibi) bir gelir veya gider ise bir Maliyet Merkezi karşı rezervasyonu gerekmektedir.
  4. Açıklama: Vergi Açıklaması (Bu faturalar / tırnak içinde basılacaktır).
  5. Puan: Vergi oranı.
@@ -1390,7 +1390,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,Amortisman kayıt
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,Önce belge türünü seçiniz
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,Bu Bakım Ziyaretini iptal etmeden önce Malzeme Ziyareti {0} iptal edin
-DocType: Crop Cycle,ISO 8016 standard,ISO 8016 standardı
+DocType: Crop Cycle,ISO 8601 standard,ISO 8601 standardı
 DocType: Pricing Rule,Rate or Discount,Oran veya İndirim
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},Seri No {0} Ürün {1} e ait değil
 DocType: Purchase Receipt Item Supplied,Required Qty,Gerekli Adet
@@ -3438,7 +3438,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3450,19 +3450,19 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 7. Total: Cumulative total to this point.
 8. Enter Row: If based on ""Previous Row Total"" you can select the row number which will be taken as a base for this calculation (default is the previous row).
 9. Consider Tax or Charge for: In this section you can specify if the tax / charge is only for valuation (not a part of total) or only for total (does not add value to the item) or for both.
-10. Add or Deduct: Whether you want to add or deduct the tax.","Tüm Satınalma İşlemleri uygulanabilir standart vergi şablonu. Bu şablon burada tanımlamak 
+10. Add or Deduct: Whether you want to add or deduct the tax.","Tüm Satınalma İşlemleri uygulanabilir standart vergi şablonu. Bu şablon burada tanımlamak
 
- vergi oranı Not #### 
+ vergi oranı Not ####
 
  vb ""Handling"", vergi başkanları ve ""Denizcilik"", ""Sigorta"" gibi diğer gider başkanlarının listesini içerebilir ** Tüm ** Öğeler için standart vergi oranı olacaktır. Farklı fiyat bilgisi ** ** Ürünleri varsa, bunlar ** Ürün Vergisinde eklenmesi gerekir ** ** ** Ürün ana tablo.
 
- #### Kolonların 
+ #### Kolonların
 
- 1 Açıklaması. Hesaplama Türü: 
+ 1 Açıklaması. Hesaplama Türü:
  - Bu üzerinde olabilir ** Net (yani temel miktarın toplamı) ** Toplam.
  - ** Önceki Satır Toplam / Tutar ** On (kümülatif vergi ya da harç için). Bu seçeneği seçerseniz, vergi miktarı veya toplam (vergi tablosunda) önceki satırın bir yüzdesi olarak uygulanacaktır.
  - ** ** Gerçek (belirtildiği gibi).
- 2. Hesap Başkanı: Bu vergi 
+ 2. Hesap Başkanı: Bu vergi
  3 rezerve edileceği altında Hesap defteri. Maliyet Merkezi: Vergi / şarj (nakliye gibi) bir gelir veya gider ise bir Maliyet Merkezi karşı rezervasyonu gerekmektedir.
  4. Açıklama: Vergi Açıklaması (Bu faturalar / tırnak içinde basılacaktır).
  5. Puan: Vergi oranı.
@@ -3772,7 +3772,7 @@ Examples:
 1. Ways of addressing disputes, indemnity, liability, etc.
 1. Address and Contact of your Company.","Standart Şartlar ve Satış ve Alımlar eklenebilir Koşullar.
 
- Örnekler: 
+ Örnekler:
 
  1. Teklifin geçerliliği.
  1. Ödeme Koşulları (Kredi On Önceden, bölüm avans vb).
@@ -3781,7 +3781,7 @@ Examples:
  1. Garanti alınırlar.
  1. Politikası döndürür.
  1. Nakliye koşulları, varsa.
- 1. Vb adresleme uyuşmazlıkların, tazminat, sorumluluk, 
+ 1. Vb adresleme uyuşmazlıkların, tazminat, sorumluluk,
  1 Yolları. Adres ve Şirket İletişim."
 DocType: Issue,Issue Type,Sorun Tipi
 DocType: Attendance,Leave Type,İzin Tipi
@@ -4468,11 +4468,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,Çalışan avansını elde etmek için bir çalışan seçin.
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,Lütfen geçerli bir tarih seçiniz
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,işinizin doğası seçin.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5391,7 +5391,7 @@ apps/erpnext/erpnext/setup/setup_wizard/data/industry_type.py +15,Brokerage,Komi
 apps/erpnext/erpnext/setup/setup_wizard/data/industry_type.py +15,Brokerage,Komisyonculuk
 apps/erpnext/erpnext/hr/doctype/leave_application/leave_application.py +207,Attendance for employee {0} is already marked for this day,çalışan {0} için Seyirci zaten bu gün için işaretlenmiş
 DocType: Work Order Operation,"in Minutes
-Updated via 'Time Log'","Dakika 
+Updated via 'Time Log'","Dakika
  'Zaman Log' aracılığıyla Güncelleme"
 DocType: Customer,From Lead,Baştan
 apps/erpnext/erpnext/config/manufacturing.py +13,Orders released for production.,Üretim için verilen emirler.
@@ -5682,7 +5682,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,Başvuru sahibinin adı
 DocType: Authorization Rule,Customer / Item Name,Müşteri / Ürün İsmi
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","Etkinleştirilirse, öğelerin son satın alma ayrıntıları önceki satın alma siparişinden veya satın alma makbuzundan alınmaz."
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 
@@ -6212,7 +6212,7 @@ apps/erpnext/erpnext/accounts/doctype/fiscal_year/fiscal_year.py +82,Year start 
 apps/erpnext/erpnext/selling/doctype/customer/customer.py +122,Please mention the Lead Name in Lead {0},Lütfen Kurşun Adını {0} Kurşun&#39;dan belirtin
 apps/erpnext/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py +156,Start date should be less than end date for Item {0},Başlangıç tarihi Ürün {0} için bitiş tarihinden daha az olmalıdır
 DocType: Item,"Example: ABCD.#####
-If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","Örnek:. Serisi ayarlanır ve Seri No işlemlerinde belirtilen değilse ABCD ##### 
+If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","Örnek:. Serisi ayarlanır ve Seri No işlemlerinde belirtilen değilse ABCD #####
 , daha sonra otomatik seri numarası bu serisine dayanan oluşturulur. Her zaman açıkça bu öğe için seri No. bahsetmek istiyorum. Bu boş bırakın."
 DocType: Upload Attendance,Upload Attendance,Devamlılığı Güncelle
 apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.js +616,BOM and Manufacturing Quantity are required,Ürün Ağacı ve Üretim Miktarı gereklidir

--- a/erpnext/translations/uk.csv
+++ b/erpnext/translations/uk.csv
@@ -1031,7 +1031,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1222,7 +1222,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,Операція амортизації
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,"Будь ласка, виберіть тип документа в першу чергу"
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,Скасування матеріалів переглядів {0} до скасування цього обслуговування візит
-DocType: Crop Cycle,ISO 8016 standard,Стандарт ISO 8016
+DocType: Crop Cycle,ISO 8601 standard,Стандарт ISO 8601
 DocType: Pricing Rule,Rate or Discount,Ставка або знижка
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},Серійний номер {0} не належить до номенклатурної позиції {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,Необхідна к-сть
@@ -3074,7 +3074,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3986,11 +3986,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,"Виберіть співробітника, щоб заздалегідь отримати працівника."
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,"Будь ласка, виберіть дійсну дату"
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,Виберіть характер вашого бізнесу.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -4152,7 +4152,7 @@ apps/erpnext/erpnext/stock/dashboard/item_dashboard.js +179,Add more items or op
 apps/erpnext/erpnext/selling/doctype/sales_order/sales_order.py +212,Delivery Notes {0} must be cancelled before cancelling this Sales Order,Доставка Примітки {0} має бути скасований до скасування цього замовлення клієнта
 apps/erpnext/erpnext/utilities/user_progress.py +259,Go to Users,Перейти до Користувачів
 apps/erpnext/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py +85,Paid amount + Write Off Amount can not be greater than Grand Total,"Оплачена сума + Сума списання не може бути більше, ніж загальний підсумок"
-apps/erpnext/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py +78,{0} is not a valid Batch Number for Item {1},"{0} не є допустимим номером партії 
+apps/erpnext/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py +78,{0} is not a valid Batch Number for Item {1},"{0} не є допустимим номером партії
 для товару {1}"
 apps/erpnext/erpnext/hr/doctype/leave_application/leave_application.py +141,Note: There is not enough leave balance for Leave Type {0},Примітка: Недостатньо днів залишилося для типу відпусток {0}
 apps/erpnext/erpnext/regional/india/utils.py +16,Invalid GSTIN or Enter NA for Unregistered,Invalid GSTIN або Enter NA для Незареєстрований
@@ -5093,7 +5093,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,Заявник Ім&#39;я
 DocType: Authorization Rule,Customer / Item Name,Замовник / Назва товару
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","Якщо ввімкнено, останні деталі купівлі товарів не будуть отримані з попереднього замовлення на покупку чи квитанцію про покупку"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 

--- a/erpnext/translations/ur.csv
+++ b/erpnext/translations/ur.csv
@@ -1029,7 +1029,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1220,7 +1220,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,ہراس انٹری
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,پہلی دستاویز کی قسم منتخب کریں
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,اس کی بحالی کا منسوخ کرنے سے پہلے منسوخ مواد دورہ {0}
-DocType: Crop Cycle,ISO 8016 standard,ISO 8016 معیار
+DocType: Crop Cycle,ISO 8601 standard,ISO 8601 معیار
 DocType: Pricing Rule,Rate or Discount,شرح یا ڈسکاؤنٹ
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},سیریل نمبر {0} آئٹم سے تعلق نہیں ہے {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,مطلوبہ مقدار
@@ -3060,7 +3060,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3969,11 +3969,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,ملازم کو پیش کرنے کے لئے ملازم کا انتخاب کریں.
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,براہ کرم ایک درست تاریخ منتخب کریں
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,آپ کے کاروبار کی نوعیت کو منتخب کریں.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5074,7 +5074,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,درخواست گزار کا نام
 DocType: Authorization Rule,Customer / Item Name,کسٹمر / نام شے
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt",اگر فعال ہو تو، اشیاء کی آخری خریداری کی تفصیلات پچھلے خریداری آرڈر یا خرید رسید سے نہیں لی جائے گی
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 

--- a/erpnext/translations/uz.csv
+++ b/erpnext/translations/uz.csv
@@ -1018,7 +1018,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1208,7 +1208,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,Amortizatsiyani kiritish
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,"Iltimos, avval hujjat turini tanlang"
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,Materialni bekor qilish Bu Xizmat tashrifini bekor qilishdan avval {0} tashrif
-DocType: Crop Cycle,ISO 8016 standard,ISO 8016 standarti
+DocType: Crop Cycle,ISO 8601 standard,ISO 8601 standarti
 DocType: Pricing Rule,Rate or Discount,Tezlik yoki chegirma
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},No {0} seriyasi {1} mahsulotiga tegishli emas
 DocType: Purchase Receipt Item Supplied,Required Qty,Kerakli son
@@ -3022,7 +3022,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3916,11 +3916,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,Xodimni oldindan olish uchun xodimni tanlang.
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,"Iltimos, to&#39;g&#39;ri Sana tanlang"
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,Biznesingizning xususiyatini tanlang.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5002,7 +5002,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,Ariza beruvchi nomi
 DocType: Authorization Rule,Customer / Item Name,Xaridor / Mahsulot nomi
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","Agar yoqilsa, mahsulotning so&#39;nggi sotib olish tafsilotlari oldingi buyurtma buyurtmasi yoki sotib olish qo&#39;liga topshirilmaydi"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 

--- a/erpnext/translations/vi.csv
+++ b/erpnext/translations/vi.csv
@@ -1032,7 +1032,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1223,7 +1223,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,Nhập Khấu hao
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,Hãy chọn các loại tài liệu đầu tiên
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,Hủy bỏ {0} thăm Vật liệu trước khi hủy bỏ bảo trì đăng nhập này
-DocType: Crop Cycle,ISO 8016 standard,Tiêu chuẩn ISO 8016
+DocType: Crop Cycle,ISO 8601 standard,Tiêu chuẩn ISO 8601
 DocType: Pricing Rule,Rate or Discount,Xếp hạng hoặc Giảm giá
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},Không nối tiếp {0} không thuộc về hàng {1}
 DocType: Purchase Receipt Item Supplied,Required Qty,Số lượng yêu cầu
@@ -3079,7 +3079,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3363,7 +3363,7 @@ Examples:
 1. Ways of addressing disputes, indemnity, liability, etc.
 1. Address and Contact of your Company.","Điều khoản và Điều kiện Chuẩn có thể được bổ sung cho Bán hàng và Thu mua.
 
- Ví dụ: 
+ Ví dụ:
 
  1. Giá trị pháp lý của đề nghị.
  1. Điều khoản Thanh toán (Thanh toán trước, Tín dụng, Đặt cọc v.v.).
@@ -4004,11 +4004,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,Chọn một nhân viên để có được nhân viên trước.
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,Vui lòng chọn ngày hợp lệ
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,Chọn bản chất của doanh nghiệp của bạn.
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5111,7 +5111,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,Tên đơn
 DocType: Authorization Rule,Customer / Item Name,Khách hàng / tên hàng hóa
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt","Nếu được bật, chi tiết mua hàng cuối cùng của các mặt hàng sẽ không được lấy ra từ đơn đặt hàng trước hoặc biên nhận mua hàng"
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 
@@ -5580,7 +5580,7 @@ apps/erpnext/erpnext/accounts/doctype/fiscal_year/fiscal_year.py +82,Year start 
 apps/erpnext/erpnext/selling/doctype/customer/customer.py +122,Please mention the Lead Name in Lead {0},Hãy đề cập tới tên của tiềm năng trong mục Tiềm năng {0}
 apps/erpnext/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py +156,Start date should be less than end date for Item {0},Ngày bắt đầu phải nhỏ hơn ngày kết thúc cho mẫu hàng {0}
 DocType: Item,"Example: ABCD.#####
-If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","Ví dụ:. ABCD ##### 
+If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","Ví dụ:. ABCD #####
  Nếu series được thiết lập và Serial No không được đề cập trong các giao dịch, số serial sau đó tự động sẽ được tạo ra dựa trên series này. Nếu bạn luôn muốn đề cập đến một cách rõ ràng nối tiếp Nos cho mặt hàng này. để trống này."
 DocType: Upload Attendance,Upload Attendance,Tải lên bảo quản
 apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.js +616,BOM and Manufacturing Quantity are required,BOM và số lượng sx được yêu cầu

--- a/erpnext/translations/zh-TW.csv
+++ b/erpnext/translations/zh-TW.csv
@@ -927,7 +927,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1121,7 +1121,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,折舊分錄
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,請先選擇文檔類型
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,取消取消此保養訪問之前，材質訪問{0}
-DocType: Crop Cycle,ISO 8016 standard,ISO 8016標準
+DocType: Crop Cycle,ISO 8601 standard,ISO 8601標準
 DocType: Pricing Rule,Rate or Discount,價格或折扣
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},序列號{0}不屬於項目{1}
 DocType: Purchase Receipt Item Supplied,Required Qty,所需數量
@@ -2804,7 +2804,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -3665,11 +3665,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,選擇一名員工以推進員工。
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,請選擇一個有效的日期
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,選擇您的業務的性質。
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -4676,7 +4676,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,申請人名稱
 DocType: Authorization Rule,Customer / Item Name,客戶／品項名稱
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt",如果啟用，則上次採購訂單或採購收據不會從上次採購詳細信息中提取
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 
@@ -5095,7 +5095,7 @@ apps/erpnext/erpnext/accounts/doctype/fiscal_year/fiscal_year.py +82,Year start 
 apps/erpnext/erpnext/selling/doctype/customer/customer.py +122,Please mention the Lead Name in Lead {0},請提及潛在客戶名稱{0}
 apps/erpnext/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py +156,Start date should be less than end date for Item {0},項目{0}的開始日期必須小於結束日期
 DocType: Item,"Example: ABCD.#####
-If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","例如：ABCD ##### 
+If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","例如：ABCD #####
 如果串聯設定並且序列號沒有在交易中提到，然後自動序列號將在此基礎上創建的系列。如果你總是想明確提到序號為這個項目。留空。"
 DocType: Upload Attendance,Upload Attendance,上傳考勤
 apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.js +616,BOM and Manufacturing Quantity are required,BOM和生產量是必需的

--- a/erpnext/translations/zh.csv
+++ b/erpnext/translations/zh.csv
@@ -1032,7 +1032,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -1234,7 +1234,7 @@ apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py +218,Closi
 DocType: Journal Entry,Depreciation Entry,折旧分录
 apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py +32,Please select the document type first,请选择文档类型第一
 apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py +65,Cancel Material Visits {0} before cancelling this Maintenance Visit,取消此上门保养之前请先取消物料访问{0}
-DocType: Crop Cycle,ISO 8016 standard,ISO 8016标准
+DocType: Crop Cycle,ISO 8601 standard,ISO 8601标准
 DocType: Pricing Rule,Rate or Discount,价格或折扣
 apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py +215,Serial No {0} does not belong to Item {1},序列号{0}不属于品目{1}
 DocType: Purchase Receipt Item Supplied,Required Qty,所需数量
@@ -3084,7 +3084,7 @@ The tax rate you define here will be the standard tax rate for all **Items**. If
 
 #### Description of Columns
 
-1. Calculation Type: 
+1. Calculation Type:
     - This can be on **Net Total** (that is the sum of basic amount).
     - **On Previous Row Total / Amount** (for cumulative taxes or charges). If you select this option, the tax will be applied as a percentage of the previous row (in the tax table) amount or total.
     - **Actual** (as mentioned).
@@ -4007,11 +4007,11 @@ apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py +37,Atleast o
 apps/erpnext/erpnext/hr/doctype/expense_claim/expense_claim.js +308,Select an employee to get the employee advance.,选择一名员工以推进员工。
 apps/erpnext/erpnext/healthcare/doctype/patient/patient.js +56,Please select a valid Date,请选择一个有效的日期
 apps/erpnext/erpnext/public/js/setup_wizard.js +36,Select the nature of your business.,选择您的业务的性质。
-DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value 
+DocType: Lab Test Template,"Single for results which require only a single input, result UOM and normal value
 <br>
 Compound for results which require multiple input fields with corresponding event names, result UOMs and normal values
 <br>
-Descriptive for tests which have multiple result components and corresponding result entry fields. 
+Descriptive for tests which have multiple result components and corresponding result entry fields.
 <br>
 Grouped for test templates which are a group of other test templates.
 <br>
@@ -5114,7 +5114,7 @@ apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconcil
 DocType: Job Applicant,Applicant Name,申请人姓名
 DocType: Authorization Rule,Customer / Item Name,客户/项目名称
 DocType: Buying Settings,"If enabled, last purchase details of items will not be fetched from previous purchase order or purchase receipt",如果启用，则上次采购订单或采购收据不会从上次采购详细信息中提取
-DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**. 
+DocType: Product Bundle,"Aggregate group of **Items** into another **Item**. This is useful if you are bundling a certain **Items** into a package and you maintain stock of the packed **Items** and not the aggregate **Item**.
 
 The package **Item** will have ""Is Stock Item"" as ""No"" and ""Is Sales Item"" as ""Yes"".
 
@@ -5583,7 +5583,7 @@ apps/erpnext/erpnext/accounts/doctype/fiscal_year/fiscal_year.py +82,Year start 
 apps/erpnext/erpnext/selling/doctype/customer/customer.py +122,Please mention the Lead Name in Lead {0},请提及潜在客户名称{0}
 apps/erpnext/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py +156,Start date should be less than end date for Item {0},品目{0}的开始日期必须小于结束日期
 DocType: Item,"Example: ABCD.#####
-If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","例如：ABCD ##### 
+If series is set and Serial No is not mentioned in transactions, then automatic serial number will be created based on this series. If you always want to explicitly mention Serial Nos for this item. leave this blank.","例如：ABCD #####
 如果设置了序列但是没有在交易中输入序列号，那么系统会根据序列自动生产序列号。如果要强制手动输入序列号，请不要勾选此项。"
 DocType: Upload Attendance,Upload Attendance,上传考勤记录
 apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.js +616,BOM and Manufacturing Quantity are required,BOM和生产量是必需的


### PR DESCRIPTION
Pull-Request

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] Have you lint your code locally prior to submission?
- [ ] Have you successfully run tests with your changes locally?
- [x] Does your commit message have an explanation for your changes and why you'd like us to include them?
- [x] Docs have been added / updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Did you modify the existing test cases? If yes, why?

---

What type of a PR is this? 

- [ ] Changes to Existing Features
- [ ] New Feature Submissions
- [x] Bug Fix
- [ ] Breaking Change

--- 

- Motivation and Context (What existing problem does the pull request solve):

Currently, the Agriculture module makes references to [ISO-8016](https://www.iso.org/standard/15024.html), which is related to agriculture machinery - the actual intended reference to week formats is defined in [ISO-8601](https://en.wikipedia.org/wiki/ISO_8601) instead.