### PR TITLE
[Minor] Patch fix

### DIFF
--- a/erpnext/patches/v11_0/refactor_erpnext_shopify.py
+++ b/erpnext/patches/v11_0/refactor_erpnext_shopify.py
@@ -6,6 +6,7 @@ def execute():
 	frappe.reload_doc('erpnext_integrations', 'doctype', 'shopify_settings')
 	frappe.reload_doc('erpnext_integrations', 'doctype', 'shopify_tax_account')
 	frappe.reload_doc('erpnext_integrations', 'doctype', 'shopify_log')
+	frappe.reload_doc('erpnext_integrations', 'doctype', 'shopify_webhook_detail')
 
 	if 'erpnext_shopify' in frappe.get_installed_apps():
 		remove_from_installed_apps('erpnext_shopify')

--- a/erpnext/patches/v11_0/rename_members_with_naming_series.py
+++ b/erpnext/patches/v11_0/rename_members_with_naming_series.py
@@ -1,6 +1,7 @@
 import frappe
 
 def execute():
+	frappe.reload_doc("non_profit", "doctype", "member")
 	old_named_members = frappe.get_all("Member", filters = {"name": ("not like", "MEM-%")})
 	correctly_named_members = frappe.get_all("Member", filters = {"name": ("like", "MEM-%")})
 	current_index = len(correctly_named_members)


### PR DESCRIPTION
Shopify refactor patch -
```
Executing erpnext.patches.v11_0.refactor_erpnext_shopify in testsite (9fc9e8b177b25d7a)
Traceback (most recent call last):
  File "/usr/local/Cellar/python@2/2.7.14_3/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/local/Cellar/python@2/2.7.14_3/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Users/allen/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 97, in <module>
    main()
  File "/Users/allen/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/allen/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 25, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/Users/allen/frappe-bench/apps/frappe/frappe/commands/site.py", line 222, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website)
  File "/Users/allen/frappe-bench/apps/frappe/frappe/migrate.py", line 39, in migrate
    frappe.modules.patch_handler.run_all()
  File "/Users/allen/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 29, in run_all
    if not run_single(patchmodule = patch):
  File "/Users/allen/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 63, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/Users/allen/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 83, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/Users/allen/frappe-bench/apps/erpnext/erpnext/patches/v11_0/refactor_erpnext_shopify.py", line 20, in execute
    setup_app_type()
  File "/Users/allen/frappe-bench/apps/erpnext/erpnext/patches/v11_0/refactor_erpnext_shopify.py", line 28, in setup_app_type
    shopify_settings.save()
  File "/Users/allen/frappe-bench/apps/frappe/frappe/model/document.py", line 260, in save
    return self._save(*args, **kwargs)
  File "/Users/allen/frappe-bench/apps/frappe/frappe/model/document.py", line 292, in _save
    self.validate_higher_perm_levels()
  File "/Users/allen/frappe-bench/apps/frappe/frappe/model/document.py", line 557, in validate_higher_perm_levels
    high_permlevel_fields = frappe.get_meta(df.options).meta.get_high_permlevel_fields()
  File "/Users/allen/frappe-bench/apps/frappe/frappe/__init__.py", line 658, in get_meta
    return frappe.model.meta.get_meta(doctype, cached=cached)
  File "/Users/allen/frappe-bench/apps/frappe/frappe/model/meta.py", line 34, in get_meta
    lambda: Meta(doctype))
  File "/Users/allen/frappe-bench/apps/frappe/frappe/utils/redis_wrapper.py", line 173, in hget
    value = generator()
  File "/Users/allen/frappe-bench/apps/frappe/frappe/model/meta.py", line 34, in <lambda>
    lambda: Meta(doctype))
  File "/Users/allen/frappe-bench/apps/frappe/frappe/model/meta.py", line 73, in __init__
    super(Meta, self).__init__("DocType", doctype)
  File "/Users/allen/frappe-bench/apps/frappe/frappe/model/document.py", line 104, in __init__
    self.load_from_db()
  File "/Users/allen/frappe-bench/apps/frappe/frappe/model/meta.py", line 78, in load_from_db
    super(Meta, self).load_from_db()
  File "/Users/allen/frappe-bench/apps/frappe/frappe/model/document.py", line 141, in load_from_db
    frappe.throw(_("{0} {1} not found").format(_(self.doctype), self.name), frappe.DoesNotExistError)
  File "/Users/allen/frappe-bench/apps/frappe/frappe/__init__.py", line 327, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red')
  File "/Users/allen/frappe-bench/apps/frappe/frappe/__init__.py", line 313, in msgprint
    _raise_exception()
  File "/Users/allen/frappe-bench/apps/frappe/frappe/__init__.py", line 286, in _raise_exception
    raise raise_exception(msg)
frappe.exceptions.DoesNotExistError: DocType Shopify Webhook Detail not found
```

Member naming-series update
```
Executing erpnext.patches.v11_0.rename_members_with_naming_series #04-06-2018 in testsite (9fc9e8b177b25d7a)
Traceback (most recent call last):
  File "/usr/local/Cellar/python@2/2.7.14_3/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/local/Cellar/python@2/2.7.14_3/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Users/allen/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 97, in <module>
    main()
  File "/Users/allen/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/allen/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 25, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/Users/allen/frappe-bench/apps/frappe/frappe/commands/site.py", line 222, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website)
  File "/Users/allen/frappe-bench/apps/frappe/frappe/migrate.py", line 39, in migrate
    frappe.modules.patch_handler.run_all()
  File "/Users/allen/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 29, in run_all
    if not run_single(patchmodule = patch):
  File "/Users/allen/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 63, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/Users/allen/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 83, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/Users/allen/frappe-bench/apps/erpnext/erpnext/patches/v11_0/rename_members_with_naming_series.py", line 12, in execute
    frappe.db.sql("""update `tabMember` set naming_series = 'MEM-'""")
  File "/Users/allen/frappe-bench/apps/frappe/frappe/database.py", line 209, in sql
    self._cursor.execute(query)
  File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/pymysql/cursors.py", line 165, in execute
    result = self._query(query)
  File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/pymysql/cursors.py", line 321, in _query
    conn.query(q)
  File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 860, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1061, in _read_query_result
    result.read()
  File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1349, in read
    first_packet = self.connection._read_packet()
  File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1018, in _read_packet
    packet.check_error()
  File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 384, in check_error
    err.raise_mysql_exception(self._data)
  File "/Users/allen/frappe-bench/env/lib/python2.7/site-packages/pymysql/err.py", line 107, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.InternalError: (1054, u"Unknown column 'naming_series' in 'field list'")
```