### PR TITLE
[Fix] Code clenaup, if supplier gstin is none

### DIFF
--- a/erpnext/regional/india/utils.py
+++ b/erpnext/regional/india/utils.py
@@ -83,7 +83,6 @@ def get_place_of_supply(out, doctype):
 		return cstr(address.gst_state_number) + "-" + cstr(address.gst_state)
 
 def get_regional_address_details(out, doctype, company):
-
 	out.place_of_supply = get_place_of_supply(out, doctype)
 
 	if not out.place_of_supply: return
@@ -97,8 +96,9 @@ def get_regional_address_details(out, doctype, company):
 		if not (out.supplier_gstin or out.place_of_supply):
 			return
 
-	if doctype in ("Sales Invoice", "Delivery Note") and out.company_gstin[:2] != out.place_of_supply[:2]\
-		or (doctype == "Purchase Invoice" and out.supplier_gstin[:2] != out.place_of_supply[:2]):
+	if ((doctype in ("Sales Invoice", "Delivery Note") and out.company_gstin
+		and out.company_gstin[:2] != out.place_of_supply[:2]) or (doctype == "Purchase Invoice"
+		and out.supplier_gstin and out.supplier_gstin[:2] != out.place_of_supply[:2])):
 		default_tax = frappe.db.get_value(master_doctype, {"company": company, "is_inter_state":1, "disabled":0})
 	else:
 		default_tax = frappe.db.get_value(master_doctype, {"company": company, "disabled":0, "is_default": 1})


### PR DESCRIPTION
Getting below error while saving purchase invoice
```
Traceback (most recent call last):
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.handler.handle()
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/handler.py", line 53, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/__init__.py", line 942, in call
    return fn(*args, **newargs)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/erpnext/erpnext/accounts/party.py", line 32, in get_party_details
    company, posting_date, bill_date, price_list, currency, doctype, ignore_permissions)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/erpnext/erpnext/accounts/party.py", line 48, in _get_party_details
    set_address_details(out, party, party_type, doctype, company)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/erpnext/erpnext/accounts/party.py", line 93, in set_address_details
    get_regional_address_details(out, doctype, company)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/erpnext/erpnext/__init__.py", line 129, in caller
    return frappe.get_attr(regional_overrides[region][fn_name])(*args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/erpnext/erpnext/regional/india/utils.py", line 101, in get_regional_address_details
    or (doctype == "Purchase Invoice" and out.supplier_gstin[:2] != out.place_of_supply[:2]):
TypeError: 'NoneType' object has no attribute '__getitem__'
```