### PR TITLE
[Minor] Patch Fix

### DIFF
--- a/erpnext/patches/v11_0/rename_supplier_type_to_supplier_group.py
+++ b/erpnext/patches/v11_0/rename_supplier_type_to_supplier_group.py
@@ -5,7 +5,9 @@ from frappe import _
 from frappe.utils.nestedset import rebuild_tree
 
 def execute():
-	if frappe.db.table_exists("Supplier Type") and not frappe.db.table_exists("Supplier Group"):
+	if frappe.db.table_exists("Supplier Group"):
+		frappe.reload_doc('setup', 'doctype', 'supplier_group')
+	elif frappe.db.table_exists("Supplier Type"):
 		rename_doc("DocType", "Supplier Type", "Supplier Group", force=True)
 		frappe.reload_doc('setup', 'doctype', 'supplier_group')
 		frappe.reload_doc("accounts", "doctype", "pricing_rule")


### PR DESCRIPTION
Patch ```rename_supplier_type_to_supplier_group``` failed while trying to migrate a single site.

```
Migrating castle11.mntechnique.com
Executing erpnext.patches.v11_0.rename_supplier_type_to_supplier_group in castle11.mntechnique.com (338b15cb7e1dcd02)
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/gaurav/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 97, in <module>
    main()
  File "/home/gaurav/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/gaurav/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 716, in __call__
    return self.main(*args, **kwargs)
  File "/home/gaurav/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 696, in main
    rv = self.invoke(ctx)
  File "/home/gaurav/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/gaurav/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 1060, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/gaurav/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 889, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/gaurav/frappe-bench/env/local/lib/python2.7/site-packages/click/core.py", line 534, in invoke
    return callback(*args, **kwargs)
  File "/home/gaurav/frappe-bench/env/local/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/gaurav/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 25, in _func
    ret = f(frappe._dict(ctx.obj), *Afargs, **kwargs)
  File "/home/gaurav/frappe-bench/apps/frappe/frappe/commands/site.py", line 222, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website)
  File "/home/gaurav/frappe-bench/apps/frappe/frappe/migrate.py", line 39, in migrate
    frappe.modules.patch_handler.run_all()
  File "/home/gaurav/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 29, in run_all
    if not run_single(patchmodule = patch):
  File "/home/gaurav/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 63, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/home/gaurav/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 83, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/home/gaurav/frappe-bench/apps/erpnext/erpnext/patches/v11_0/rename_supplier_type_to_supplier_group.py", line 21, in execute
    build_tree()
  File "/home/gaurav/frappe-bench/apps/erpnext/erpnext/patches/v11_0/rename_supplier_type_to_supplier_group.py", line 32, in build_tree
    'parent_supplier_group': ''
  File "/home/gaurav/frappe-bench/apps/frappe/frappe/__init__.py", line 641, in get_doc
    return frappe.model.document.get_doc(*args, **kwargs)
  File "/home/gaurav/frappe-bench/apps/frappe/frappe/model/document.py", line 67, in get_doc
    controller = get_controller(doctype)
  File "/home/gaurav/frappe-bench/apps/frappe/frappe/model/base_document.py", line 36, in get_controller
    module = load_doctype_module(doctype, module_name)
  File "/home/gaurav/frappe-bench/apps/frappe/frappe/modules/utils.py", line 187, in load_doctype_module
    raise ImportError('Module import failed for {0} ({1})'.format(doctype, module_name + ' Error: ' + str(e)))
ImportError: Module import failed for Supplier Group (frappe.core.doctype.supplier_group.supplier_group Error: No module named supplier_group.supplier_group)
```
Resumed normally after ``` bench --site <sitename> reload-doc setup doctype supplier_group ```

![rename_supplier_type_to_supplier_group_after2](https://user-images.githubusercontent.com/17795124/41104775-ce91b8b8-6a89-11e8-8406-fbc50bf405eb.png)

