### PR TITLE
[Fix] Alternative item, transferred qty issue for backflush method

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -554,12 +554,15 @@ class WorkOrder(Document):
 			consumed_qty = frappe.db.sql('''select sum(qty)
 				from `tabStock Entry` entry, `tabStock Entry Detail` detail
 				where
-					entry.work_order = %s
+					entry.work_order = %(name)s
 					and (entry.purpose = "Material Consumption for Manufacture"
 					or entry.purpose = "Manufacture")
 					and entry.docstatus = 1
 					and detail.parent = entry.name
-					and detail.item_code = %s''', (self.name, d.item_code))[0][0]
+					and (detail.item_code = %(item)s or detail.original_item = %(item)s)''', {
+						'name': self.name,
+						'item': d.item_code
+					})[0][0]
 
 			d.db_set('consumed_qty', flt(consumed_qty), update_modified = False)
 


### PR DESCRIPTION
**Issue**
```
Traceback (most recent call last):
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.handler.handle()
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/handler.py", line 53, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/__init__.py", line 942, in call
    return fn(*args, **newargs)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/erpnext/erpnext/manufacturing/doctype/work_order/work_order.py", line 657, in make_stock_entry
    stock_entry.get_items()
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.py", line 664, in get_items
    self.get_transfered_raw_materials()
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.py", line 873, in get_transfered_raw_materials
    req_qty = flt(req_items[0].required_qty)
IndexError: list index out of range
```

Fixed https://github.com/frappe/erpnext/issues/14448