### PR TITLE
Customer timeline data hotfix

### DIFF
--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -417,7 +417,7 @@ def get_timeline_data(doctype, name):
 		where reference_doctype='{doctype}' and reference_name='{name}'
 		and status!='Success' and creation > {after}
 		{group_by} order by creation desc
-		""".format(doctype=doctype, name=name, fields=fields,
+		""".format(doctype=frappe.db.escape(doctype), name=frappe.db.escape(name), fields=fields,
 			group_by=group_by, after=after), as_dict=False)
 
 	timeline_items = dict(data)


### PR DESCRIPTION
Pull-Request

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] Have you lint your code locally prior to submission?
- [x] Have you successfully run tests with your changes locally?
- [x] Does your commit message have an explanation for your changes and why you'd like us to include them?
- [ ] Docs have been added / updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Did you modify the existing test cases? If yes, why?

---

What type of a PR is this? 

- [ ] Changes to Existing Features
- [ ] New Feature Submissions
- [x] Bug Fix
- [ ] Breaking Change

--- 

- Motivation and Context (What existing problem does the pull request solve):
https://github.com/frappe/erpnext/pull/14276 has created a bug when opening a client with a " ' " in its name (very common in french).

This PR is a hotfix to escape the name before being passed to the sql query.

- Related Issue: 

No corresponding Github issue opened.
Here is the error message:

```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.handler.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 53, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 939, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/notifications.py", line 274, in get_open_count
    out['timeline_data'] = module.get_timeline_data(doctype, name)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/party.py", line 421, in get_timeline_data
    group_by=group_by, after=after), as_dict=False)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database.py", line 176, in sql
    self._cursor.execute(query)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/pymysql/cursors.py", line 170, in execute
    result = self._query(query)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/pymysql/cursors.py", line 328, in _query
    conn.query(q)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/pymysql/connections.py", line 893, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/pymysql/connections.py", line 1103, in _read_query_result
    result.read()
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/pymysql/connections.py", line 1396, in read
    first_packet = self.connection._read_packet()
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/pymysql/connections.py", line 1059, in _read_packet
    packet.check_error()
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/pymysql/connections.py", line 384, in check_error
    err.raise_mysql_exception(self._data)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
    raise errorclass(errno, errval)
ProgrammingError: (1064, u"You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'Essai'\n\t\tand status!='Success' and creation > 2017-06-11\n\t\tgroup by date(creati' at line 3")
```
Client name is "Client d'Essai"

- Screenshots (if applicable, remember, a picture tells a thousand words): 



**Please don't be intimidated by the long list of options you've to fill. Try to fill out as much as you can. Remember, the more the information the easier it is for us to test and get your pull request merged** :grin: 

