### PR TITLE
Fix conflict for taxable value having same item in GSTR-1 Report

### DIFF
--- a/erpnext/regional/report/gstr_1/gstr_1.py
+++ b/erpnext/regional/report/gstr_1/gstr_1.py
@@ -144,7 +144,7 @@ class Gstr1Report(object):
 		""" % (self.doctype, ', '.join(['%s']*len(self.invoices))), tuple(self.invoices), as_dict=1)
 
 		for d in items:
-			if not self.invoice_items or d.item_code not in self.invoice_items.values():
+			if d.item_code not in self.invoice_items.get(d.parent, {}):
 				self.invoice_items.setdefault(d.parent, {}).setdefault(d.item_code, sum(i.get('base_net_amount', 0) for i in items if i.item_code == d.item_code and i.parent == d.parent))
 
 	def get_items_based_on_tax_rate(self):

--- a/erpnext/regional/report/gstr_1/gstr_1.py
+++ b/erpnext/regional/report/gstr_1/gstr_1.py
@@ -143,18 +143,10 @@ class Gstr1Report(object):
 			where parent in (%s)
 		""" % (self.doctype, ', '.join(['%s']*len(self.invoices))), tuple(self.invoices), as_dict=1)
 
+		item_details = {}
 		for d in items:
-			item_details = {}
-			item_details[d.item_code] = d.base_net_amount
-
-			if d.parent in self.invoice_items:
-				parent_dict = self.invoice_items[d.parent]
-				if d.item_code in parent_dict:
-					item_details[d.item_code] += parent_dict[d.item_code]
-				else:
-					item_details.update(parent_dict)
-
-			self.invoice_items[d.parent] = item_details
+			if not self.invoice_items or d.item_code not in self.invoice_items.values():
+				self.invoice_items.setdefault(d.parent, {}).setdefault(d.item_code, sum(i.get('base_net_amount', 0) for i in items if i.item_code == d.item_code and i.parent == d.parent))
 
 	def get_items_based_on_tax_rate(self):
 		self.tax_details = frappe.db.sql("""

--- a/erpnext/regional/report/gstr_1/gstr_1.py
+++ b/erpnext/regional/report/gstr_1/gstr_1.py
@@ -143,7 +143,6 @@ class Gstr1Report(object):
 			where parent in (%s)
 		""" % (self.doctype, ', '.join(['%s']*len(self.invoices))), tuple(self.invoices), as_dict=1)
 
-		item_details = {}
 		for d in items:
 			if not self.invoice_items or d.item_code not in self.invoice_items.values():
 				self.invoice_items.setdefault(d.parent, {}).setdefault(d.item_code, sum(i.get('base_net_amount', 0) for i in items if i.item_code == d.item_code and i.parent == d.parent))

--- a/erpnext/regional/report/gstr_1/gstr_1.py
+++ b/erpnext/regional/report/gstr_1/gstr_1.py
@@ -145,7 +145,9 @@ class Gstr1Report(object):
 
 		for d in items:
 			if d.item_code not in self.invoice_items.get(d.parent, {}):
-				self.invoice_items.setdefault(d.parent, {}).setdefault(d.item_code, sum(i.get('base_net_amount', 0) for i in items if i.item_code == d.item_code and i.parent == d.parent))
+				self.invoice_items.setdefault(d.parent, {}).setdefault(d.item_code,
+					sum(i.get('base_net_amount', 0) for i in items
+					    if i.item_code == d.item_code and i.parent == d.parent))
 
 	def get_items_based_on_tax_rate(self):
 		self.tax_details = frappe.db.sql("""


### PR DESCRIPTION
In the current GRSR-1 report, if there are multiple same items in single parent, then it does not adds to the invoice_items values which also creates problem with Taxable Value.

![demo1](https://user-images.githubusercontent.com/18363620/41331595-6145fb76-6ef7-11e8-861a-229ee193bf98.gif)

So the revised code with different logic which resolves the above issue.

![demo2](https://user-images.githubusercontent.com/18363620/41332138-3fe5993e-6efa-11e8-9115-39839183f9b7.gif)
