### PR TITLE
[Fixes] Defaults and User-Permission based fixes in treeview

### DIFF
--- a/erpnext/accounts/doctype/account/account_tree.js
+++ b/erpnext/accounts/doctype/account/account_tree.js
@@ -7,9 +7,9 @@ frappe.treeview_settings["Account"] = {
 	filters: [{
 		fieldname: "company",
 		fieldtype:"Select",
-		options: $.map(locals[':Company'], function(c) { return c.name; }).sort(),
+		options: erpnext.utils.get_tree_options("company"),
 		label: __("Company"),
-		default: frappe.defaults.get_default('company') ? frappe.defaults.get_default('company'): ""
+		default: erpnext.utils.get_tree_default("company")
 	}],
 	root_label: "Accounts",
 	get_tree_nodes: 'erpnext.accounts.utils.get_children',
@@ -42,6 +42,8 @@ frappe.treeview_settings["Account"] = {
 	],
 	ignore_fields:["parent_account"],
 	onload: function(treeview) {
+		frappe.treeview_settings['Account'].page = {};
+		$.extend(frappe.treeview_settings['Account'].page, treeview.page);
 		function get_company() {
 			return treeview.page.fields_dict.company.get_value();
 		}
@@ -101,7 +103,7 @@ frappe.treeview_settings["Account"] = {
 					"account": node.label,
 					"from_date": frappe.sys_defaults.year_start_date,
 					"to_date": frappe.sys_defaults.year_end_date,
-					"company": frappe.defaults.get_default('company') ? frappe.defaults.get_default('company'): ""
+					"company": frappe.treeview_settings['Account'].page.fields_dict.company.get_value()
 				};
 				frappe.set_route("query-report", "General Ledger");
 			},

--- a/erpnext/accounts/doctype/cost_center/cost_center_tree.js
+++ b/erpnext/accounts/doctype/cost_center/cost_center_tree.js
@@ -4,9 +4,9 @@ frappe.treeview_settings["Cost Center"] = {
 	filters: [{
 		fieldname: "company",
 		fieldtype:"Select",
-		options: $.map(locals[':Company'], function(c) { return c.name; }).sort(),
+		options: erpnext.utils.get_tree_options("company"),
 		label: __("Company"),
-		default: frappe.defaults.get_default('company') ? frappe.defaults.get_default('company'): ""
+		default: erpnext.utils.get_tree_default("company")
 	}],
 	root_label: "Cost Centers",
 	get_tree_nodes: 'erpnext.accounts.utils.get_children',

--- a/erpnext/hr/doctype/employee/employee_tree.js
+++ b/erpnext/hr/doctype/employee/employee_tree.js
@@ -4,9 +4,9 @@ frappe.treeview_settings['Employee'] = {
 		{
 			fieldname: "company",
 			fieldtype:"Select",
-			options: $.map(locals[':Company'], function(c) { return c.name; }).sort(),
+			options: erpnext.utils.get_tree_options("company"),
 			label: __("Company"),
-			default: frappe.defaults.get_default('company') ? frappe.defaults.get_default('company') : ""
+			default: erpnext.utils.get_tree_default("company")
 		}
 	],
 	breadcrumb: "Hr",

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -182,6 +182,25 @@ $.extend(erpnext.utils, {
 		}
 		return rows;
 	},
+	get_tree_options: function(option) {
+		// get valid options for tree based on user permission & locals dict
+		let unscrub_option = frappe.model.unscrub(option);
+		let user_permission = frappe.defaults.get_user_permissions();
+		if(user_permission && user_permission[unscrub_option]) {
+			return user_permission[unscrub_option]["docs"];
+		} else {
+			return $.map(locals[`:${unscrub_option}`], function(c) { return c.name; }).sort();
+		}
+	},
+	get_tree_default: function(option) {
+		// set default for a field based on user permission
+		let options = this.get_tree_options(option);
+		if(options.includes(frappe.defaults.get_default(option))) {
+			return frappe.defaults.get_default(option);
+		} else {
+			return options[0];
+		}
+	}
 });
 
 erpnext.utils.select_alternate_items = function(opts) {

--- a/erpnext/stock/doctype/warehouse/warehouse_tree.js
+++ b/erpnext/stock/doctype/warehouse/warehouse_tree.js
@@ -6,9 +6,9 @@ frappe.treeview_settings['Warehouse'] = {
 	filters: [{
 		fieldname: "company",
 		fieldtype:"Select",
-		options: $.map(locals[':Company'], function(c) { return c.name; }).sort(),
+		options: erpnext.utils.get_tree_options("company"),
 		label: __("Company"),
-		default: frappe.defaults.get_default('company') ? frappe.defaults.get_default('company'): ""
+		default: erpnext.utils.get_tree_default("company")
 	}],
 	fields:[
 		{fieldtype:'Data', fieldname: 'warehouse_name',


### PR DESCRIPTION
Pull-Request

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] Have you lint your code locally prior to submission?
- [x] Have you successfully run tests with your changes locally?
- [x] Does your commit message have an explanation for your changes and why you'd like us to include them?
- [ ] Docs have been added / updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Did you modify the existing test cases? If yes, why?

---

What type of a PR is this? 

- [ ] Changes to Existing Features
- [ ] New Feature Submissions
- [x] Bug Fix
- [ ] Breaking Change

--- 

- Motivation and Context (What existing problem does the pull request solve):

The select field for company in most of the treeview listed all the company even when user was restricted to only a few or one. Also in Account tree the View Ledger route was routed to default company always instead of the one that we select in the filter box.

Added utility function to fill options of select with only valid field values.

- Related Issue: 
- Screenshots (if applicable, remember, a picture tells a thousand words): 

Issue:-
![tree-issue](https://user-images.githubusercontent.com/11695402/41342365-af831d42-6f19-11e8-8730-12f99e659619.gif)

Fix:-
![tree-fix](https://user-images.githubusercontent.com/11695402/41342366-b0a658d8-6f19-11e8-80ba-e3da910a30d9.gif)


**Please don't be intimidated by the long list of options you've to fill. Try to fill out as much as you can. Remember, the more the information the easier it is for us to test and get your pull request merged** :grin: 

