### PR TITLE
Fix unicode literal issue that prevents payment entries to be created

### DIFF
--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
 
-
+from __future__ import unicode_literals
 
 import frappe, erpnext
 import frappe.defaults


### PR DESCRIPTION
Hi, 
since upgrading to the latest version I was unable to save any payment entries with the following error. 

```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.handler.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 53, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 942, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/doctype/payment_entry/payment_entry.py", line 886, in get_payment_entry
    pe.set_missing_values()
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/doctype/payment_entry/payment_entry.py", line 122, in set_missing_values
    party=self.party, date=self.posting_date, company=self.company)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/utils.py", line 156, in get_balance_on
    WHERE {1}""".format(select_field, " and ".join(cond)))[0][0]
UnicodeEncodeError: 'ascii' codec can't encode characters in position 87-89:
```

This is a fix for my issue. Maybe you want to merge it or maybe it's not needed but I thought I'd share it anyways. 