### PR TITLE
[Fix] Consolidated Financial Statement report

### DIFF
--- a/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py
+++ b/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py
@@ -193,6 +193,8 @@ def get_data(companies, root_type, balance_must_be, fiscal_year, filters=None, i
 	accounts, accounts_by_name = get_account_heads(root_type,
 		companies, filters)
 
+	if not accounts: return []
+
 	company_currency = get_company_currency(filters)
 
 	gl_entries_by_account = {}
@@ -246,7 +248,7 @@ def get_account_heads(root_type, companies, filters):
 	accounts = get_accounts(root_type, filters)
 
 	if not accounts:
-		return None
+		return None, None
 
 	accounts, accounts_by_name, parent_children_map = filter_accounts(accounts)
 


### PR DESCRIPTION
**Issue**
```
Traceback (most recent call last):
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.handler.handle()
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/handler.py", line 53, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/__init__.py", line 942, in call
    return fn(*args, **newargs)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 96, in run
    res = frappe.get_attr(method_name)(frappe._dict(filters))
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/erpnext/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py", line 27, in execute
    data, message, chart = get_balance_sheet_data(fiscal_year, companies, columns, filters)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/erpnext/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py", line 44, in get_balance_sheet_data
    equity = get_data(companies, "Equity", "Credit", fiscal_year, filters=filters)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/erpnext/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py", line 194, in get_data
    companies, filters)
TypeError: 'NoneType' object is not iterable
```

Fixed https://github.com/frappe/erpnext/issues/14521