### PR TITLE
[Fix]Check for existing permission before adding

### DIFF
--- a/erpnext/hr/doctype/employee/employee.py
+++ b/erpnext/hr/doctype/employee/employee.py
@@ -68,8 +68,10 @@ class Employee(NestedSet):
 		if not self.create_user_permission: return
 		if not has_permission('User Permission', ptype='write'): return
 
-		add_user_permission("Employee", self.name, self.user_id)
-		set_user_permission_if_allowed("Company", self.company, self.user_id)
+		if not frappe.db.exists({'doctype':'User Permission','user':self.user_id, 'allow':'Company', 'for_value': self.company}):
+			set_user_permission_if_allowed("Company", self.company, self.user_id)
+		if not frappe.db.exists({'doctype':'User Permission','user':self.user_id, 'allow':'Employee', 'for_value': self.name}):
+			add_user_permission("Employee", self.name, self.user_id)
 
 	def update_user(self):
 		# add employee role if missing


### PR DESCRIPTION
- Every time a change is made to the User record, the User Permission are added again making duplicate permission records.
<img width="945" alt="screen shot 2018-06-18 at 9 50 00 am" src="https://user-images.githubusercontent.com/16913064/41518013-2f8cb6e4-72dd-11e8-94c1-e0043044f226.png">

- Added code to check for existing permissions.