### PR TITLE
[Minor] Authorization Control fix when item is None

### DIFF
--- a/erpnext/setup/doctype/authorization_control/authorization_control.py
+++ b/erpnext/setup/doctype/authorization_control/authorization_control.py
@@ -40,7 +40,7 @@ class AuthorizationControl(TransactionBase):
 		chk = 1
 		add_cond1,add_cond2	= '',''
 		if based_on == 'Itemwise Discount':
-			add_cond1 += " and master_name = '"+cstr(frappe.db.escape(item)).replace("'", "\\'")+"'"
+			add_cond1 += " and master_name = '"+frappe.db.escape(cstr(item))+"'"
 			itemwise_exists = frappe.db.sql("""select value from `tabAuthorization Rule`
 				where transaction = %s and value <= %s
 				and based_on = %s and company = %s and docstatus != 2 %s %s""" %


### PR DESCRIPTION
Opening Invoice Creation Tool throws error for item if Authorization Rule is set.