### PR TITLE
improve performance of stock_value retrieval using tabBin instead of …

### DIFF
--- a/erpnext/stock/doctype/warehouse/warehouse.py
+++ b/erpnext/stock/doctype/warehouse/warehouse.py
@@ -155,7 +155,7 @@ def get_children(doctype, parent=None, company=None, is_root=False):
 
 	# return warehouses
 	for wh in warehouses:
-		wh["balance"] = get_stock_value(warehouse=wh.value)
+		wh["balance"] = get_stock_value_from_bin(warehouse=wh.value)
 	return warehouses
 
 @frappe.whitelist()

--- a/erpnext/stock/doctype/warehouse/warehouse.py
+++ b/erpnext/stock/doctype/warehouse/warehouse.py
@@ -139,7 +139,7 @@ class Warehouse(NestedSet):
 
 @frappe.whitelist()
 def get_children(doctype, parent=None, company=None, is_root=False):
-	from erpnext.stock.utils import get_stock_value
+	from erpnext.stock.utils import get_stock_value_from_bin
 
 	if is_root:
 		parent = ""

--- a/erpnext/stock/doctype/warehouse/warehouse.py
+++ b/erpnext/stock/doctype/warehouse/warehouse.py
@@ -139,7 +139,7 @@ class Warehouse(NestedSet):
 
 @frappe.whitelist()
 def get_children(doctype, parent=None, company=None, is_root=False):
-	from erpnext.stock.utils import get_stock_value_on
+	from erpnext.stock.utils import get_stock_value
 
 	if is_root:
 		parent = ""
@@ -155,8 +155,7 @@ def get_children(doctype, parent=None, company=None, is_root=False):
 
 	# return warehouses
 	for wh in warehouses:
-		wh["balance"] = get_stock_value_on(warehouse=wh.value)
-
+		wh["balance"] = get_stock_value(warehouse=wh.value)
 	return warehouses
 
 @frappe.whitelist()

--- a/erpnext/stock/utils.py
+++ b/erpnext/stock/utils.py
@@ -11,21 +11,47 @@ from six import string_types
 
 class InvalidWarehouseCompany(frappe.ValidationError): pass
 
+def get_stock_value (warehouse=None, item_code=None):
+
+	values = {}
+	conditions = ""
+	if warehouse:
+		conditions += """ and warehouse in (
+						select w2.name from `tabWarehouse` w1
+						join `tabWarehouse` w2 on
+						w1.name = %(warehouse)s
+						and w2.lft between w1.lft and w1.rgt
+						) """
+
+		values['warehouse'] = warehouse
+
+	if item_code:
+		conditions += " and item_code = %(item_code)s"
+
+
+		values['item_code'] = item_code
+
+	query = "select sum(stock_value) from `tabBin` where 1 = 1" + conditions
+
+	stock_value = frappe.db.sql(query, values)
+
+	return stock_value;
+
 def get_stock_value_on(warehouse=None, posting_date=None, item_code=None):
 	if not posting_date: posting_date = nowdate()
 
 	values, condition = [posting_date], ""
 
 	if warehouse:
-		
+
 		lft, rgt, is_group = frappe.db.get_value("Warehouse", warehouse, ["lft", "rgt", "is_group"])
-		
+
 		if is_group:
 			values.extend([lft, rgt])
 			condition += "and exists (\
 				select name from `tabWarehouse` wh where wh.name = sle.warehouse\
 				and wh.lft >= %s and wh.rgt <= %s)"
-		
+
 		else:
 			values.append(warehouse)
 			condition += " AND warehouse = %s"
@@ -45,7 +71,7 @@ def get_stock_value_on(warehouse=None, posting_date=None, item_code=None):
 	for sle in stock_ledger_entries:
 		if not (sle.item_code, sle.warehouse) in sle_map:
 			sle_map[(sle.item_code, sle.warehouse)] = flt(sle.stock_value)
-		
+
 	return sum(sle_map.values())
 
 @frappe.whitelist()
@@ -75,17 +101,17 @@ def get_latest_stock_qty(item_code, warehouse=None):
 	values, condition = [item_code], ""
 	if warehouse:
 		lft, rgt, is_group = frappe.db.get_value("Warehouse", warehouse, ["lft", "rgt", "is_group"])
-	
+
 		if is_group:
 			values.extend([lft, rgt])
 			condition += "and exists (\
 				select name from `tabWarehouse` wh where wh.name = tabBin.warehouse\
 				and wh.lft >= %s and wh.rgt <= %s)"
-	
+
 		else:
 			values.append(warehouse)
 			condition += " AND warehouse = %s"
-	
+
 	actual_qty = frappe.db.sql("""select sum(actual_qty) from tabBin
 		where item_code=%s {0}""".format(condition), values)[0][0]
 
@@ -222,4 +248,3 @@ def validate_warehouse_company(warehouse, company):
 def is_group_warehouse(warehouse):
 	if frappe.db.get_value("Warehouse", warehouse, "is_group"):
 		frappe.throw(_("Group node warehouse is not allowed to select for transactions"))
-	

--- a/erpnext/stock/utils.py
+++ b/erpnext/stock/utils.py
@@ -11,7 +11,7 @@ from six import string_types
 
 class InvalidWarehouseCompany(frappe.ValidationError): pass
 
-def get_stock_value (warehouse=None, item_code=None):
+def get_stock_value_from_bin (warehouse=None, item_code=None):
 
 	values = {}
 	conditions = ""


### PR DESCRIPTION
Currently to retrieve stock value, queries are done on `tabStock Ledger Entry` table which results in entire table scan.

Refer discuss thread @ 

https://discuss.erpnext.com/t/erpnext-performance-warehouse-tree-fetches-stock-value-of-all-children/37524/3

