### PR TITLE
[ Minor ] Asset Maintenance Task naming fix

### DIFF
--- a/erpnext/assets/doctype/asset_maintenance_task/asset_maintenance_task.py
+++ b/erpnext/assets/doctype/asset_maintenance_task/asset_maintenance_task.py
@@ -7,4 +7,5 @@ import frappe
 from frappe.model.document import Document
 
 class AssetMaintenanceTask(Document):
-	pass
+	def autoname(self):
+		self.name = self.maintenance_task


### PR DESCRIPTION
Maintenance Task name is used in test cases and in Asset Maintenance Log.
Asset Maintenance Task -> autoname method added to name it accordingly