### PR TITLE
[probot-stale][config] Mark and close inactive PRs

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,33 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 7
+
+# Number of days of inactivity before a stale Issue or Pull Request is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 2
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - hotfix
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: true
+
+# Label to use when marking as stale
+staleLabel: inactive
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This pull request has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs, but it
+  only takes a comment to keep a contribution alive :) Thank you
+  for contributing.
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+# Limit to only `issues` or `pulls`
+only: pulls


### PR DESCRIPTION
_Mark and close PRs inactive for over 7 days._

 The [Probot project](https://github.com/probot/probot) is good to build Github apps that’d do some maintenance for us. [Stale](https://github.com/probot/stale) is one of those useful ones that already exist. 
This PR adds the `stale.yml` config required.  

Have installed the app on the `frappe` org, don’t have access to check it’s status though.
Created an `inactive` label that the app will use to mark the PRs to close.
