### PR TITLE
Add configurable frequency in Selling Settings for update of project …

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -149,7 +149,7 @@ class SalesInvoice(SellingController):
 
 		if frappe.db.get_single_value('Selling Settings', 'sales_update_frequency') == "Each Transaction":
 			update_company_current_month_sales(self.company)
-		self.update_project()
+			self.update_project()
 		update_linked_invoice(self.doctype, self.name, self.inter_company_invoice_reference)
 
 	def validate_pos_paid_amount(self):
@@ -190,7 +190,7 @@ class SalesInvoice(SellingController):
 
 		if frappe.db.get_single_value('Selling Settings', 'sales_update_frequency') == "Each Transaction":
 			update_company_current_month_sales(self.company)
-		self.update_project()
+			self.update_project()
 
 		unlink_inter_company_invoice(self.doctype, self.name, self.inter_company_invoice_reference)
 
@@ -908,8 +908,6 @@ class SalesInvoice(SellingController):
 					)))
 
 	def update_project(self):
-		if frappe.db.get_single_value('Selling Settings', 'sales_update_frequency') != "Each Transaction":
-			return
 		if self.project:
 			project = frappe.get_doc("Project", self.project)
 			project.flags.dont_sync_tasks = True

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -147,7 +147,8 @@ class SalesInvoice(SellingController):
 
 		self.update_time_sheet(self.name)
 
-		update_company_current_month_sales(self.company)
+		if frappe.db.get_single_value('Selling Settings', 'sales_update_frequency') == "Each Transaction":
+			update_company_current_month_sales(self.company)
 		self.update_project()
 		update_linked_invoice(self.doctype, self.name, self.inter_company_invoice_reference)
 
@@ -187,7 +188,8 @@ class SalesInvoice(SellingController):
 		self.make_gl_entries_on_cancel()
 		frappe.db.set(self, 'status', 'Cancelled')
 
-		update_company_current_month_sales(self.company)
+		if frappe.db.get_single_value('Selling Settings', 'sales_update_frequency') == "Each Transaction":
+			update_company_current_month_sales(self.company)
 		self.update_project()
 
 		unlink_inter_company_invoice(self.doctype, self.name, self.inter_company_invoice_reference)
@@ -906,6 +908,8 @@ class SalesInvoice(SellingController):
 					)))
 
 	def update_project(self):
+		if frappe.db.get_single_value('Selling Settings', 'sales_update_frequency') != "Each Transaction":
+			return
 		if self.project:
 			project = frappe.get_doc("Project", self.project)
 			project.flags.dont_sync_tasks = True

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -236,11 +236,11 @@ scheduler_events = {
 		"erpnext.assets.doctype.asset.asset.update_maintenance_status",
 		"erpnext.assets.doctype.asset.asset.make_post_gl_entry",
 		"erpnext.crm.doctype.contract.contract.update_status_for_contracts",
-		"erpnext.projects.doctype.project.project.update_project_sales_billing",
+		"erpnext.projects.doctype.project.project.update_project_sales_billing"
   ],
 	"monthly": [
 		"erpnext.accounts.doctype.sales_invoice.sales_invoice.booked_deferred_revenue",
-		"erpnext.hr.utils.allocate_earned_leaves",
+		"erpnext.hr.utils.allocate_earned_leaves"
 	]
 }
 

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -235,11 +235,13 @@ scheduler_events = {
 		"erpnext.manufacturing.doctype.bom_update_tool.bom_update_tool.update_latest_price_in_all_boms",
 		"erpnext.assets.doctype.asset.asset.update_maintenance_status",
 		"erpnext.assets.doctype.asset.asset.make_post_gl_entry",
-		"erpnext.crm.doctype.contract.contract.update_status_for_contracts"
+		"erpnext.crm.doctype.contract.contract.update_status_for_contracts",
+		"erpnext.projects.doctype.project.project.update_project_daily"
   ],
 	"monthly": [
 		"erpnext.accounts.doctype.sales_invoice.sales_invoice.booked_deferred_revenue",
-		"erpnext.hr.utils.allocate_earned_leaves"
+		"erpnext.hr.utils.allocate_earned_leaves",
+		"erpnext.projects.doctype.project.project.update_project_monthly"
 	]
 }
 

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -236,12 +236,11 @@ scheduler_events = {
 		"erpnext.assets.doctype.asset.asset.update_maintenance_status",
 		"erpnext.assets.doctype.asset.asset.make_post_gl_entry",
 		"erpnext.crm.doctype.contract.contract.update_status_for_contracts",
-		"erpnext.projects.doctype.project.project.update_project_daily"
+		"erpnext.projects.doctype.project.project.update_project_sales_billing",
   ],
 	"monthly": [
 		"erpnext.accounts.doctype.sales_invoice.sales_invoice.booked_deferred_revenue",
 		"erpnext.hr.utils.allocate_earned_leaves",
-		"erpnext.projects.doctype.project.project.update_project_monthly"
 	]
 }
 

--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -412,6 +412,24 @@ def create_project_update(project):
 			)
 	return data
 
+def update_project_daily():
+	if frappe.db.get_single_value("Selling Settings", "sales_update_frequency") != "Daily":
+		return
+	for project in frappe.get_all('Project'):
+		project = frappe.get_doc('Project', project.name)
+		project.update_sales_amount()
+		project.update_billed_amount()
+		project.save()
+
+def update_project_monthly():
+	if frappe.db.get_single_value("Selling Settings", "sales_update_frequency") != "Monthly":
+		return
+	for project in frappe.get_all('Project'):
+		project = frappe.get_doc('Project', project.name)
+		project.update_sales_amount()
+		project.update_billed_amount()
+		project.save()
+
 @frappe.whitelist()
 def create_kanban_board_if_not_exists(project):
 	from frappe.desk.doctype.kanban_board.kanban_board import quick_kanban_board

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -193,13 +193,14 @@ class SalesOrder(SellingController):
 		self.update_blanket_order()
 
 	def update_project(self):
-		project_list = []
+		if frappe.db.get_single_value('Selling Settings', 'sales_update_frequency') != "Each Transaction":
+			return
+
 		if self.project:
 			project = frappe.get_doc("Project", self.project)
 			project.flags.dont_sync_tasks = True
 			project.update_sales_amount()
 			project.save()
-			project_list.append(self.project)
 
 	def check_credit_limit(self):
 		# if bypass credit limit check is set to true (1) at sales order level,

--- a/erpnext/selling/doctype/selling_settings/selling_settings.json
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.json
@@ -343,7 +343,7 @@
    "bold": 0, 
    "collapsible": 0, 
    "columns": 0, 
-   "default": "", 
+   "default": "Each Transaction", 
    "description": "How often should project and company be updated based on Sales Transactions.", 
    "fieldname": "sales_update_frequency", 
    "fieldtype": "Select", 

--- a/erpnext/selling/doctype/selling_settings/selling_settings.json
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.json
@@ -15,6 +15,7 @@
  "fields": [
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -47,6 +48,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -78,6 +80,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -110,6 +113,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -142,6 +146,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -173,6 +178,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -206,6 +212,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -237,6 +244,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -266,6 +274,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -297,6 +306,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -328,6 +338,42 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
+   "allow_on_submit": 0, 
+   "bold": 0, 
+   "collapsible": 0, 
+   "columns": 0, 
+   "default": "", 
+   "description": "How often should project and company be updated based on Sales Transactions.", 
+   "fieldname": "sales_update_frequency", 
+   "fieldtype": "Select", 
+   "hidden": 0, 
+   "ignore_user_permissions": 0, 
+   "ignore_xss_filter": 0, 
+   "in_filter": 0, 
+   "in_global_search": 0, 
+   "in_list_view": 0, 
+   "in_standard_filter": 0, 
+   "label": "Sales Update Frequency", 
+   "length": 0, 
+   "no_copy": 0, 
+   "options": "Each Transaction\nDaily\nMonthly", 
+   "permlevel": 0, 
+   "precision": "", 
+   "print_hide": 0, 
+   "print_hide_if_no_value": 0, 
+   "read_only": 0, 
+   "remember_last_selected_value": 0, 
+   "report_hide": 0, 
+   "reqd": 1, 
+   "search_index": 0, 
+   "set_only_once": 0, 
+   "translatable": 0, 
+   "unique": 0
+  }, 
+  {
+   "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -358,6 +404,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -388,6 +435,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -419,6 +467,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -450,6 +499,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -481,6 +531,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -522,7 +573,7 @@
  "issingle": 1, 
  "istable": 0, 
  "max_attachments": 0, 
- "modified": "2018-02-23 16:23:27.768602", 
+ "modified": "2018-06-25 12:56:16.332039", 
  "modified_by": "Administrator", 
  "module": "Selling", 
  "name": "Selling Settings", 
@@ -530,7 +581,6 @@
  "permissions": [
   {
    "amend": 0, 
-   "apply_user_permissions": 0, 
    "cancel": 0, 
    "create": 1, 
    "delete": 0, 
@@ -556,5 +606,6 @@
  "sort_field": "modified", 
  "sort_order": "DESC", 
  "track_changes": 0, 
- "track_seen": 0
+ "track_seen": 0, 
+ "track_views": 0
 }

--- a/erpnext/setup/setup_wizard/operations/defaults_setup.py
+++ b/erpnext/setup/setup_wizard/operations/defaults_setup.py
@@ -44,6 +44,7 @@ def set_default_settings(args):
 	selling_settings.so_required = "No"
 	selling_settings.dn_required = "No"
 	selling_settings.allow_multiple_items = 1
+	selling_settings.sales_update_frequency = "Each Transaction"
 	selling_settings.save()
 
 	buying_settings = frappe.get_doc("Buying Settings")


### PR DESCRIPTION
…and company

Pull-Request

- [X] Have you followed the guidelines in our Contributing document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [X] Have you lint your code locally prior to submission?
- [X] Have you successfully run tests with your changes locally?
- [X] Does your commit message have an explanation for your changes and why you'd like us to include them?
- [X] Docs have been added / updated
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Did you modify the existing test cases? If yes, why?

---

What type of a PR is this? 

- [X] Changes to Existing Features
- [ ] New Feature Submissions
- [ ] Bug Fix
- [ ] Breaking Change

--- 

- Motivation and Context (What existing problem does the pull request solve):
Creating a Sales Order / Sales Invoice used to update Project and Company documents. If 100s of invoices are being generated per minute, this becomes a bottleneck as the update reads all the Sales Orders and Sales Invoices to calculate the new value.  This could be scheduled at Daily/Monthly triggers to reduce the overhead on system for creation of each document.
(Discuss Reference: [Monthly sales calculation on every Sales Invoice is slowing down ErpNext](https://discuss.erpnext.com/t/monthly-sales-calculation-on-every-sales-invoice-is-slowing-down-erpnext/37168) )

For which, this PR adds a configurable setting in "Selling Settings" to defer the billing and sales calculation at midnight instead of each transaction. However, the default will still stay at Each Transaction for new setups, which can be changed later.

The scheduler code is only added for project as functionality is already present to daily calculate company monthly sales.

![image](https://user-images.githubusercontent.com/14350421/41842681-208062b6-7889-11e8-812b-7c09487f9299.png)