### PR TITLE
Allow only submitted Blanket Order in PO/SO

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -25,11 +25,10 @@ frappe.ui.form.on("Purchase Order", {
 		frm.set_indicator_formatter('item_code',
 			function(doc) { return (doc.qty<=doc.received_qty) ? "green" : "orange" })
 
-		frm.set_query("reserve_warehouse", "supplied_items", function() {
+		frm.set_query("blanket_order", "items", function() {
 			return {
 				filters: {
-					"company": frm.doc.company,
-					"is_group": 0
+					"docstatus": 1
 				}
 			}
 		});

--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -28,6 +28,7 @@ frappe.ui.form.on("Purchase Order", {
 		frm.set_query("blanket_order", "items", function() {
 			return {
 				filters: {
+					"company": frm.doc.company,
 					"docstatus": 1
 				}
 			}

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -32,6 +32,14 @@ frappe.ui.form.on("Sales Order", {
 			}
 		});
 
+		frm.set_query("blanket_order", "items", function() {
+			return {
+				filters: {
+					"docstatus": 1
+				}
+			}
+		});
+
 		erpnext.queries.setup_warehouse_query(frm);
 	},
 

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -35,6 +35,7 @@ frappe.ui.form.on("Sales Order", {
 		frm.set_query("blanket_order", "items", function() {
 			return {
 				filters: {
+					"company": frm.doc.company,
 					"docstatus": 1
 				}
 			}


### PR DESCRIPTION
<img width="646" alt="screen shot 2018-06-26 at 9 32 31 am" src="https://user-images.githubusercontent.com/16913064/41888593-e67e27a6-7923-11e8-9384-9b723685f773.png">

Cancelled BO:
<img width="1179" alt="screen shot 2018-06-26 at 9 33 07 am" src="https://user-images.githubusercontent.com/16913064/41888618-01a342fa-7924-11e8-999b-6c0054632d2d.png">

Cancelled BO not selectable:
<img width="893" alt="screen shot 2018-06-26 at 9 33 28 am" src="https://user-images.githubusercontent.com/16913064/41888622-0580ee86-7924-11e8-839b-8a7d2dc54bd3.png">

Fixed https://github.com/frappe/erpnext/issues/14675

**Also removed duplicate set_query for reserve_warehouse**
