### PR TITLE
[HotFix] Sales order showing advance amount even if sales order delink from the advance payment entry

### DIFF
--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -300,6 +300,7 @@ def reconcile_against_document(args):
 		doc = frappe.get_doc(d.voucher_type, d.voucher_no)
 
 		doc.make_gl_entries(cancel=1, adv_adj=1)
+		doc.update_advance_paid()
 
 		# update ref in advance entry
 		if d.voucher_type == "Journal Entry":

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -547,6 +547,8 @@ class AccountsController(TransactionBase):
 					.format(formatted_advance_paid, self.name, formatted_order_total))
 
 			frappe.db.set_value(self.doctype, self.name, "advance_paid", advance_paid)
+		else:
+			frappe.db.set_value(self.doctype, self.name, "advance_paid", 0.0)
 
 	@property
 	def company_abbr(self):

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -503,3 +503,4 @@ erpnext.patches.v10_0.taxes_issue_with_pos
 erpnext.patches.v10_0.set_qty_in_transactions_based_on_serial_no_input
 erpnext.patches.v10_0.show_leaves_of_all_department_members_in_calendar
 erpnext.patches.v10_0.update_status_in_purchase_receipt
+erpnext.patches.v10_0.update_total_advance_to_zero

--- a/erpnext/patches/v10_0/update_total_advance_to_zero.py
+++ b/erpnext/patches/v10_0/update_total_advance_to_zero.py
@@ -1,0 +1,11 @@
+# Copyright (c) 2017, Frappe and Contributors
+# License: GNU General Public License v3. See license.txt
+
+from __future__ import unicode_literals
+import frappe
+
+def execute():
+	for doctype in ['Purchase Order', 'Sales Order']:
+		for d in frappe.db.sql(""" select name, advance_paid from `tab%s`
+			where advance_paid > 0 and docstatus = 1""" % (doctype), as_dict=1):
+			frappe.get_doc(doctype, d.name).set_total_advance_paid()


### PR DESCRIPTION
To replicate the issue

- Make new sales order and do half advance payment against the sales order using payment entry
- Makes sales invoice against the above sales order and submit it
- When you submit the sales invoice, system will replace the reference name from sales order to sales invoice in the payment entry
- But in sales order advance payment still shows

- Added patch to fix the old entries