### PR TITLE
[ Fix ] UOM Conversion fix

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -520,7 +520,7 @@ erpnext.patches.v11_0.move_leave_approvers_from_employee #13-06-2018
 erpnext.patches.v11_0.update_department_lft_rgt
 erpnext.patches.v11_0.add_default_email_template_for_leave
 erpnext.patches.v11_0.set_default_email_template_in_hr #08-06-2018
-erpnext.patches.v11_0.uom_conversion_data
+erpnext.patches.v11_0.uom_conversion_data #30-06-2018
 erpnext.patches.v10_0.taxes_issue_with_pos
 erpnext.patches.v11_0.update_account_type_in_party_type
 erpnext.patches.v10_1.transfer_subscription_to_auto_repeat

--- a/erpnext/patches/v11_0/uom_conversion_data.py
+++ b/erpnext/patches/v11_0/uom_conversion_data.py
@@ -9,3 +9,13 @@ def execute():
 
 	if not frappe.db.a_row_exists("UOM Conversion Factor"):
 		add_uom_data()
+	else:
+		# delete conversion data and insert again
+		frappe.db.sql("delete from `tabUOM Conversion Factor`")
+		try:
+			frappe.delete_doc('UOM', 'Hundredweight')
+			frappe.delete_doc('UOM', 'Pound Cubic Yard')
+		except frappe.LinkExistsError:
+			pass
+
+		add_uom_data()

--- a/erpnext/setup/doctype/uom_conversion_factor/uom_conversion_factor.json
+++ b/erpnext/setup/doctype/uom_conversion_factor/uom_conversion_factor.json
@@ -163,7 +163,7 @@
    "length": 0, 
    "no_copy": 0, 
    "permlevel": 0, 
-   "precision": "", 
+   "precision": "9",
    "print_hide": 0, 
    "print_hide_if_no_value": 0, 
    "read_only": 0, 
@@ -186,7 +186,7 @@
  "issingle": 0, 
  "istable": 0, 
  "max_attachments": 0, 
- "modified": "2018-06-05 12:50:02.648100", 
+ "modified": "2018-06-29 15:35:34.580831",
  "modified_by": "Administrator", 
  "module": "Setup", 
  "name": "UOM Conversion Factor", 
@@ -220,5 +220,6 @@
  "sort_field": "modified", 
  "sort_order": "DESC", 
  "track_changes": 1, 
- "track_seen": 0
+ "track_seen": 0,
+ "track_views": 0
 }

--- a/erpnext/setup/setup_wizard/data/uom_conversion_data.json
+++ b/erpnext/setup/setup_wizard/data/uom_conversion_data.json
@@ -10,207 +10,207 @@
 		"category": "Length",
 		"from_uom": "Meter",
 		"to_uom": "Barleycorn",
-		"value": "0.008467"
+		"value": "118.11"
 	},
 	{
 		"category": "Length",
 		"from_uom": "Meter",
 		"to_uom": "Calibre",
 		"abbr": "cal",
-		"value": "0.0254"
+		"value": "39.37"
 	},
 	{
 		"category": "Length",
 		"from_uom": "Meter",
 		"to_uom": "Cable Length (UK)",
 		"abbr": "cables",
-		"value": "182.88"
+		"value": "0.005396"
 	},
 	{
 		"category": "Length",
 		"from_uom": "Meter",
 		"to_uom": "Cable Length (US)",
 		"abbr": "cables",
-		"value": "219.456"
+		"value": "0.004557"
 	},
 	{
 		"category": "Length",
 		"from_uom": "Meter",
 		"to_uom": "Cable Length",
 		"abbr": "cables",
-		"value": "185.2"
+		"value": "0.0054"
 	},
 	{
 		"category": "Length",
 		"from_uom": "Meter",
 		"to_uom": "Centimeter",
 		"abbr": "cm",
-		"value": "0.01"
+		"value": "100"
 	},
 	{
 		"category": "Length",
 		"from_uom": "Meter",
 		"to_uom": "Chain",
 		"abbr": "ch",
-		"value": "20.1168"
+		"value": "0.04971"
 	},
 	{
 		"category": "Length",
 		"from_uom": "Meter",
 		"to_uom": "Decimeter",
 		"abbr": "dm",
-		"value": "0.1"
+		"value": "10"
 	},
 	{
 		"category": "Length",
 		"from_uom": "Meter",
 		"to_uom": "Ells (UK)",
 		"abbr": "ells",
-		"value": "0.875"
+		"value": "0.006993s"
 	},
 	{
 		"category": "Length",
 		"from_uom": "Meter",
 		"to_uom": "Ems(Pica)",
 		"abbr": "ems",
-		"value": "0.004233"
+		"value": "236.222"
 	},
 	{
 		"category": "Length",
 		"from_uom": "Meter",
 		"to_uom": "Fathom",
 		"abbr": "fm",
-		"value": "1.8288"
+		"value": "0.546807"
 	},
 	{
 		"category": "Length",
 		"from_uom": "Meter",
 		"to_uom": "Foot",
 		"abbr": "ft",
-		"value": "0.3048"
+		"value": "3.28084"
 	},
 	{
 		"category": "Length",
 		"from_uom": "Meter",
 		"to_uom": "Furlong",
 		"abbr": "fur",
-		"value": "201.168"
+		"value": "0.004971"
 	},
 	{
 		"category": "Length",
 		"from_uom": "Meter",
 		"to_uom": "Hand",
 		"abbr": "hand",
-		"value": "0.1016"
+		"value": "9.84252"
 	},
 	{
 		"category": "Length",
 		"from_uom": "Meter",
 		"to_uom": "Hectometer",
 		"abbr": "hm",
-		"value": "100"
+		"value": "0.01"
 	},
 	{
 		"category": "Length",
 		"from_uom": "Meter",
 		"to_uom": "Inch",
 		"abbr": "in",
-		"value": "0.0254"
+		"value": "39.370079"
 	},
 	{
 		"category": "Length",
 		"from_uom": "Meter",
 		"to_uom": "Kilometer",
 		"abbr": "km",
-		"value": "1000"
+		"value": "0.001"
 	},
 	{
 		"category": "Length",
 		"from_uom": "Meter",
 		"to_uom": "Link",
 		"abbr": "li",
-		"value": "0.201168"
+		"value": "4.975124"
 	},
 	{
 		"category": "Length",
 		"from_uom": "Meter",
 		"to_uom": "Micrometer",
 		"abbr": "µm",
-		"value": "0.000001"
+		"value": "1000000"
 	},
 	{
 		"category": "Length",
 		"from_uom": "Meter",
 		"to_uom": "Mile",
 		"abbr": "mi",
-		"value": "1609.344"
+		"value": "0.000621"
 	},
 	{
 		"category": "Length",
 		"from_uom": "Meter",
 		"to_uom": "Mile (Nautical)",
 		"abbr": "nmi(NM)",
-		"value": "1852"
+		"value": "0.00054"
 	},
 	{
 		"category": "Length",
 		"from_uom": "Meter",
 		"to_uom": "Millimeter",
 		"abbr": "mm",
-		"value": "0.001"
+		"value": "1000"
 	},
 	{
 		"category": "Length",
 		"from_uom": "Meter",
 		"to_uom": "Nanometer",
 		"abbr": "nm",
-		"value": "0.000000001"
+		"value": "1000000000"
 	},
 	{
 		"category": "Length",
 		"from_uom": "Meter",
 		"to_uom": "Rod",
 		"abbr": "rd",
-		"value": "5.02921"
+		"value": "0.198839"
 	},
 	{
 		"category": "Length",
 		"from_uom": "Meter",
 		"to_uom": "Vara",
 		"abbr": "V",
-		"value": "0.835906"
+		"value": "1.193030"
 	},
 	{
 		"category": "Length",
 		"from_uom": "Meter",
 		"to_uom": "Versta",
-		"value": "1066.8"
+		"value": "0.000937"
 	},
 	{
 		"category": "Length",
 		"from_uom": "Meter",
 		"to_uom": "Yard",
 		"abbr": "yd",
-		"value": "0.9144"
+		"value": "1.0936133"
 	},
 	{
 		"category": "Length",
 		"from_uom": "Meter",
 		"to_uom": "Arshin",
-		"value": "0.7112"
+		"value": "1.406074"
 	},
 	{
 		"category": "Length",
 		"from_uom": "Meter",
 		"to_uom": "Sazhen",
-		"value": "2.1336"
+		"value": "0.468691"
 	},
 	{
 		"category": "Length",
 		"from_uom": "Meter",
 		"to_uom": "Medio Metro",
 		"abbr": "mediom",
-		"value": "0.5"
+		"value": "2"
 	},
 	{
 		"category": "Area",
@@ -228,87 +228,80 @@
 	{
 		"category": "Area",
 		"from_uom": "Square Meter",
-		"to_uom": "Area",
-		"abbr": "Area",
-		"value": "100"
-	},
-	{
-		"category": "Area",
-		"from_uom": "Square Meter",
 		"to_uom": "Manzana",
 		"abbr": "Mz",
-		"value": "6987.388"
+		"value": "0.000143"
 	},
 	{
 		"category": "Area",
 		"from_uom": "Square Meter",
 		"to_uom": "Caballeria",
 		"abbr": "Cbll",
-		"value": "447192.86"
+		"value": "0.000007"
 	},
 	{
 		"category": "Area",
 		"from_uom": "Square Meter",
 		"to_uom": "Square Kilometer",
-		"value": "1000000"
+		"value": "0.000001"
 	},
 	{
 		"category": "Area",
 		"from_uom": "Square Meter",
 		"to_uom": "Are",
 		"abbr": "a",
-		"value": "100"
+		"value": "0.01"
 	},
 	{
 		"category": "Area",
 		"from_uom": "Square Meter",
 		"to_uom": "Acre",
 		"abbr": "ac",
-		"value": "4046.856422"
+		"value": "0.000247"
 	},
 	{
 		"category": "Area",
 		"from_uom": "Square Meter",
 		"to_uom": "Acre (US)",
 		"abbr": "ac",
-		"value": "4046.87261"
+		"value": "0.000247"
 	},
 	{
 		"category": "Area",
 		"from_uom": "Square Meter",
 		"to_uom": "Hectare",
 		"abbr": "ha",
-		"value": "10000"
-	},
-	{
-		"category": "Area",
-		"from_uom": "Square Meter",
-		"to_uom": "Square Yard",
-		"value": "0.83612736"
-	},
-	{
-		"category": "Area",
-		"from_uom": "Square Meter",
-		"to_uom": "Square Foot",
-		"value": "0.09290304"
-	},
-	{
-		"category": "Area",
-		"from_uom": "Square Meter",
-		"to_uom": "Square Inch",
-		"value": "0.00064516"
-	},
-	{
-		"category": "Area",
-		"from_uom": "Square Meter",
-		"to_uom": "Square Centimeter",
 		"value": "0.0001"
 	},
 	{
 		"category": "Area",
 		"from_uom": "Square Meter",
+		"to_uom": "Square Yard",
+		"value": "1.195990"
+	},
+	{
+		"category": "Area",
+		"from_uom": "Square Meter",
+		"to_uom": "Square Foot",
+		"value": "10.763910"
+	},
+	{
+		"category": "Area",
+		"from_uom": "Square Meter",
+		"to_uom": "Square Inch",
+		"value": "1550.0031"
+	},
+	{
+		"category": "Area",
+		"from_uom": "Square Meter",
+		"to_uom": "Square Centimeter",
+		"value": "10000"
+	},
+	{
+		"category": "Area",
+		"from_uom": "Square Meter",
 		"to_uom": "Square Mile",
-		"value": "2589988.11"
+		"value": "0.000000386"
 	},
 	{
 		"category": "Speed",
@@ -322,112 +315,119 @@
 		"from_uom": "Meter/Second",
 		"to_uom": "Inch/Minute",
 		"abbr": "ipm",
-		"value": "0.000423333"
+		"value": "2362.204724"
 	},
 	{
 		"category": "Speed",
 		"from_uom": "Meter/Second",
 		"to_uom": "Foot/Minute",
 		"abbr": "fpm",
-		"value": "0.00508"
+		"value": "196.850394"
 	},
 	{
 		"category": "Speed",
 		"from_uom": "Meter/Second",
 		"to_uom": "Inch/Second",
 		"abbr": "ips",
-		"value": "0.0254"
+		"value": "39.370079"
 	},
 	{
 		"category": "Speed",
 		"from_uom": "Meter/Second",
 		"to_uom": "Kilometer/Hour",
 		"abbr": "km/h",
-		"value": "0.277777778"
+		"value": "3.6"
 	},
 	{
 		"category": "Speed",
 		"from_uom": "Meter/Second",
 		"to_uom": "Foot/Second",
 		"abbr": "fps",
-		"value": "0.3048"
+		"value": "3.28084"
 	},
 	{
 		"category": "Speed",
 		"from_uom": "Meter/Second",
 		"to_uom": "Mile/Hour",
 		"abbr": "mph",
-		"value": "0.44704"
+		"value": "2.236936"
 	},
 	{
 		"category": "Speed",
 		"from_uom": "Meter/Second",
 		"to_uom": "Knot",
 		"abbr": "kn",
-		"value": "0.514444"
+		"value": "1.943844"
 	},
 	{
 		"category": "Speed",
 		"from_uom": "Meter/Second",
 		"to_uom": "Mile/Minute",
 		"abbr": "mpm",
-		"value": "26.8224"
+		"value": "0.037283"
 	},
 	{
 		"category": "Speed",
 		"from_uom": "Meter/Second",
 		"to_uom": "Mile/Second",
 		"abbr": "mps",
-		"value": "1609.344"
+		"value": "0.000621"
 	},
 	{
 		"category": "Mass",
 		"from_uom": "Kg",
 		"to_uom": "Carat",
 		"abbr": "carat",
-		"value": "0.0002"
+		"value": "5000"
 	},
 	{
 		"category": "Mass",
 		"from_uom": "Kg",
 		"to_uom": "Cental",
 		"abbr": "cental",
-		"value": "45.359237"
+		"value": "0.022046"
 	},
 	{
 		"category": "Mass",
 		"from_uom": "Kg",
 		"to_uom": "Dram",
 		"abbr": "dr",
-		"value": "0.001771845"
+		"value": "564.383391"
 	},
 	{
 		"category": "Mass",
 		"from_uom": "Kg",
 		"to_uom": "Grain",
 		"abbr": "gr",
-		"value": "0.000065"
+		"value": "15432.358353"
 	},
 	{
 		"category": "Mass",
 		"from_uom": "Kg",
 		"to_uom": "Gram",
 		"abbr": "g",
-		"value": "0.001"
+		"value": "1000"
 	},
 	{
 		"category": "Mass",
 		"from_uom": "Kg",
-		"to_uom": "Hundredweight",
+		"to_uom": "Hundredweight (UK)",
 		"abbr": "cwt",
-		"value": "45.359237"
+		"value": "0.019684"
+	},
+	{
+		"category": "Mass",
+		"from_uom": "Kg",
+		"to_uom": "Hundredweight (US)",
+		"abbr": "cwt",
+		"value": "0.022046"
 	},
 	{
 		"category": "Mass",
 		"from_uom": "Kg",
 		"to_uom": "Quintal",
 		"abbr": "qq",
-		"value": "45.359237"
+		"value": "0.01"
 	},
 	{
 		"category": "Mass",
@@ -440,104 +440,104 @@
 		"category": "Mass",
 		"from_uom": "Kg",
 		"to_uom": "Microgram",
-		"value": "0.000000001"
+		"value": "1000000000"
 	},
 	{
 		"category": "Mass",
 		"from_uom": "Kg",
 		"to_uom": "Milligram",
 		"abbr": "mg",
-		"value": "0.000001"
+		"value": "1000000"
 	},
 	{
 		"category": "Mass",
 		"from_uom": "Kg",
 		"to_uom": "Ounce",
 		"abbr": "oz",
-		"value": "0.02835"
+		"value": "35.273962"
 	},
 	{
 		"category": "Mass",
 		"from_uom": "Kg",
 		"to_uom": "Pood",
 		"abbr": "pood",
-		"value": "16.3805"
+		"value": "0.061048"
 	},
 	{
 		"category": "Mass",
 		"from_uom": "Kg",
 		"to_uom": "Pound",
 		"abbr": "lbm",
-		"value": "0.45359237"
+		"value": "2.204623"
 	},
 	{
 		"category": "Mass",
 		"from_uom": "Kg",
 		"to_uom": "Slug",
 		"abbr": "slug",
-		"value": "14.5939029"
+		"value": "0.0685218"
 	},
 	{
 		"category": "Mass",
 		"from_uom": "Kg",
 		"to_uom": "Stone",
 		"abbr": "stone",
-		"value": "6.350293"
+		"value": "0.157473"
 	},
 	{
 		"category": "Mass",
 		"from_uom": "Kg",
 		"to_uom": "Tonne",
 		"abbr": "t",
-		"value": "1000"
+		"value": "0.001"
 	},
 	{
 		"category": "Mass",
 		"from_uom": "Kg",
 		"to_uom": "Kip",
 		"abbr": "kip",
-		"value": "453.59237"
+		"value": "0.002205"
 	},
 	{
 		"category": "Volume",
 		"from_uom": "Litre",
 		"to_uom": "Barrel(Beer)",
 		"abbr": "bbl",
-		"value": "117.3478"
+		"value": "0.008522"
 	},
 	{
 		"category": "Volume",
 		"from_uom": "Litre",
 		"to_uom": "Barrel (Oil)",
 		"abbr": "bbl",
-		"value": "158.987295"
+		"value": "0.00629"
 	},
 	{
 		"category": "Volume",
 		"from_uom": "Litre",
 		"to_uom": "Bushel (UK)",
 		"abbr": "bu",
-		"value": "36.36872"
+		"value": "0.027496"
 	},
 	{
 		"category": "Volume",
 		"from_uom": "Litre",
 		"to_uom": "Bushel (US Dry Level)",
 		"abbr": "bu",
-		"value": "35.23907017"
+		"value": "0.028378"
 	},
 	{
 		"category": "Volume",
 		"from_uom": "Litre",
 		"to_uom": "Centilitre",
 		"abbr": "cl",
-		"value": "0.01"
+		"value": "100"
 	},
 	{
 		"category": "Volume",
 		"from_uom": "Litre",
 		"to_uom": "Cubic Centimeter",
-		"value": "0.001"
+		"value": "1000"
 	},
 	{
 		"category": "Volume",
@@ -549,80 +549,80 @@
 		"category": "Volume",
 		"from_uom": "Litre",
 		"to_uom": "Cubic Foot",
-		"value": "28.31684659"
+		"value": "0.035315"
 	},
 	{
 		"category": "Volume",
 		"from_uom": "Litre",
 		"to_uom": "Cubic Inch",
-		"value": "0.016387064"
+		"value": "61.023744"
 	},
 	{
 		"category": "Volume",
 		"from_uom": "Litre",
 		"to_uom": "Cubic Meter",
-		"value": "1000"
+		"value": "0.001"
 	},
 	{
 		"category": "Volume",
 		"from_uom": "Litre",
 		"to_uom": "Cubic Millimeter",
-		"value": "0.000001"
+		"value": "1000000"
 	},
 	{
 		"category": "Volume",
 		"from_uom": "Litre",
 		"to_uom": "Cubic Yard",
-		"value": "764.554858"
+		"value": "0.001308"
 	},
 	{
 		"category": "Volume",
 		"from_uom": "Litre",
 		"to_uom": "Cup",
 		"abbr": "cp",
-		"value": "0.236588"
+		"value": "4"
 	},
 	{
 		"category": "Volume",
 		"from_uom": "Litre",
 		"to_uom": "Decilitre",
 		"abbr": "dl",
-		"value": "0.1"
+		"value": "10"
 	},
 	{
 		"category": "Volume",
 		"from_uom": "Litre",
 		"to_uom": "Fluid Ounce (UK)",
 		"abbr": "fl oz",
-		"value": "0.028413"
+		"value": "35.19508"
 	},
 	{
 		"category": "Volume",
 		"from_uom": "Litre",
 		"to_uom": "Fluid Ounce (US)",
 		"abbr": "fl oz",
-		"value": "0.029574"
+		"value": "33.814023"
 	},
 	{
 		"category": "Volume",
 		"from_uom": "Litre",
 		"to_uom": "Gallon (UK)",
 		"abbr": "gal",
-		"value": "4.54609"
+		"value": "0.21997"
 	},
 	{
 		"category": "Volume",
 		"from_uom": "Litre",
 		"to_uom": "Gallon Dry (US)",
 		"abbr": "gal",
-		"value": "4.404884"
+		"value": "0.227021"
 	},
 	{
 		"category": "Volume",
 		"from_uom": "Litre",
 		"to_uom": "Gallon Liquid (US)",
 		"abbr": "gal",
-		"value": "3.785411784"
+		"value": "0.264172"
 	},
 	{
 		"category": "Volume",
@@ -636,90 +636,90 @@
 		"from_uom": "Litre",
 		"to_uom": "Millilitre",
 		"abbr": "ml",
-		"value": "0.001"
+		"value": "1000"
 	},
 	{
 		"category": "Volume",
 		"from_uom": "Litre",
 		"to_uom": "Peck",
 		"abbr": "pk",
-		"value": "8.809768"
+		"value": "0.113511"
 	},
 	{
 		"category": "Volume",
 		"from_uom": "Litre",
 		"to_uom": "Pint (UK)",
 		"abbr": "pt",
-		"value": "0.568261"
+		"value": "1.759754"
 	},
 	{
 		"category": "Volume",
 		"from_uom": "Litre",
 		"to_uom": "Pint, Dry (US)",
 		"abbr": "pt",
-		"value": "0.55061"
+		"value": "1.816166"
 	},
 	{
 		"category": "Volume",
 		"from_uom": "Litre",
 		"to_uom": "Pint, Liquid (US)",
 		"abbr": "pt",
-		"value": "0.473176475"
+		"value": "2.113376"
 	},
 	{
 		"category": "Volume",
 		"from_uom": "Litre",
 		"to_uom": "Quart (UK)",
 		"abbr": "qt",
-		"value": "1.136523"
+		"value": "0.879877"
 	},
 	{
 		"category": "Volume",
 		"from_uom": "Litre",
 		"to_uom": "Quart Dry (US)",
 		"abbr": "qt",
-		"value": "1.136523"
+		"value": "0.908083"
 	},
 	{
 		"category": "Volume",
 		"from_uom": "Litre",
 		"to_uom": "Quart Liquid (US)",
 		"abbr": "qt",
-		"value": "1.136523"
+		"value": "1.056688"
 	},
 	{
 		"category": "Volume",
 		"from_uom": "Litre",
 		"to_uom": "Tablespoon (US)",
 		"abbr": "tbsp",
-		"value": "0.014787"
+		"value": "67.628045"
 	},
 	{
 		"category": "Volume",
 		"from_uom": "Litre",
 		"to_uom": "Teaspoon",
 		"abbr": "tsp",
-		"value": "0.004929"
+		"value": "202.884136"
 	},
 	{
 		"category": "Time",
 		"from_uom": "Second",
 		"to_uom": "Day",
-		"value": "86400"
+		"value": "0.0000115742"
 	},
 	{
 		"category": "Time",
 		"from_uom": "Second",
 		"to_uom": "Hour",
 		"abbr": "h",
-		"value": "3600"
+		"value": "0.000277777778"
 	},
 	{
 		"category": "Time",
 		"from_uom": "Second",
 		"to_uom": "Minute",
 		"abbr": "min",
-		"value": "60"
+		"value": "0.016667"
 	},
 	{
 		"category": "Time",
@@ -733,33 +733,33 @@
 		"from_uom": "Second",
 		"to_uom": "Millisecond",
 		"abbr": "ms",
-		"value": "0.001"
+		"value": "1000"
 	},
 	{
 		"category": "Time",
 		"from_uom": "Second",
 		"to_uom": "Microsecond",
-		"value": "0.000001"
+		"value": "1000000"
 	},
 	{
 		"category": "Time",
 		"from_uom": "Second",
 		"to_uom": "Nanosecond",
 		"abbr": "ns",
-		"value": "0.000000001"
+		"value": "1000000000"
 	},
 	{
 		"category": "Time",
 		"from_uom": "Second",
 		"to_uom": "Week",
-		"value": "604800"
+		"value": "0.000001653439"
 	},
 	{
 		"category": "Pressure",
 		"from_uom": "Pascal",
 		"to_uom": "Atmosphere",
 		"abbr": "atm",
-		"value": "101325"
+		"value": "0.000009869233"
 	},
 	{
 		"category": "Pressure",
@@ -773,104 +773,104 @@
 		"from_uom": "Pascal",
 		"to_uom": "Bar",
 		"abbr": "bar",
-		"value": "100000"
+		"value": "0.00001"
 	},
 	{
 		"category": "Pressure",
 		"from_uom": "Pascal",
 		"to_uom": "Foot Of Water",
 		"abbr": "ftH2O",
-		"value": "2989.06692"
+		"value": "0.000334562292"
 	},
 	{
 		"category": "Pressure",
 		"from_uom": "Pascal",
 		"to_uom": "Hectopascal",
 		"abbr": "hPa",
-		"value": "100"
+		"value": "0.01"
 	},
 	{
 		"category": "Pressure",
 		"from_uom": "Pascal",
 		"to_uom": "Iches Of Water",
 		"abbr": "inH2O",
-		"value": "249.08891"
+		"value": "0.00401474"
 	},
 	{
 		"category": "Pressure",
 		"from_uom": "Pascal",
 		"to_uom": "Inches Of Mercury",
 		"abbr": "inHg",
-		"value": "3386.388"
+		"value": "0.000295299802"
 	},
 	{
 		"category": "Pressure",
 		"from_uom": "Pascal",
 		"to_uom": "Kilopascal",
 		"abbr": "kPa",
-		"value": "1000"
+		"value": "0.001"
 	},
 	{
 		"category": "Pressure",
 		"from_uom": "Pascal",
 		"to_uom": "Meter Of Water",
 		"abbr": "mH2O",
-		"value": "9806.65"
+		"value": "0.00010197"
 	},
 	{
 		"category": "Pressure",
 		"from_uom": "Pascal",
 		"to_uom": "Microbar",
-		"value": "0.1"
+		"value": "10"
 	},
 	{
 		"category": "Pressure",
 		"from_uom": "Pascal",
 		"to_uom": "Milibar",
 		"abbr": "mbar",
-		"value": "100"
+		"value": "0.01"
 	},
 	{
 		"category": "Pressure",
 		"from_uom": "Pascal",
 		"to_uom": "Millimeter Of Mercury",
 		"abbr": "mmHg",
-		"value": "133.322"
+		"value": "0.007501"
 	},
 	{
 		"category": "Pressure",
 		"from_uom": "Pascal",
 		"to_uom": "Millimeter Of Water",
 		"abbr": "mmH2O",
-		"value": "9.80665"
+		"value": "0.101974"
 	},
 	{
 		"category": "Pressure",
 		"from_uom": "Pascal",
 		"to_uom": "Technical Atmosphere",
 		"abbr": "at",
-		"value": "98066.5"
+		"value": "0.000010197162"
 	},
 	{
 		"category": "Pressure",
 		"from_uom": "Pascal",
 		"to_uom": "Torr",
 		"abbr": "torr",
-		"value": "133.322"
+		"value": "0.00750061505"
 	},
 	{
 		"category": "Force",
 		"from_uom": "Newton",
 		"to_uom": "Dyne",
 		"abbr": "dyn",
-		"value": "0.00001"
+		"value": "100000"
 	},
 	{
 		"category": "Force",
 		"from_uom": "Newton",
 		"to_uom": "Gram-Force",
 		"abbr": "gf",
-		"value": "0.00980665"
+		"value": "101.971621298"
 	},
 	{
 		"category": "Force",
@@ -884,21 +884,21 @@
 		"from_uom": "Newton",
 		"to_uom": "Kilogram-Force",
 		"abbr": "kgf",
-		"value": "9.80665"
+		"value": "0.101971621"
 	},
 	{
 		"category": "Force",
 		"from_uom": "Newton",
 		"to_uom": "Kilopond",
 		"abbr": "kp",
-		"value": "9.80665"
+		"value": "0.101971621"
 	},
 	{
 		"category": "Force",
 		"from_uom": "Newton",
 		"to_uom": "Kilopound-Force",
 		"abbr": "kipf",
-		"value": "4448.221615"
+		"value": "0.000224808943"
 	},
 	{
 		"category": "Force",
@@ -912,114 +912,114 @@
 		"from_uom": "Newton",
 		"to_uom": "Ounce-Force",
 		"abbr": "ozf",
-		"value": "0.278013851"
+		"value": "3.59694309"
 	},
 	{
 		"category": "Force",
 		"from_uom": "Newton",
 		"to_uom": "Pond",
 		"abbr": "p",
-		"value": "0.00980665"
+		"value": "101.9716213"
 	},
 	{
 		"category": "Force",
 		"from_uom": "Newton",
 		"to_uom": "Pound-Force",
 		"abbr": "lbf",
-		"value": "4.448222"
+		"value": "0.224808943"
 	},
 	{
 		"category": "Force",
 		"from_uom": "Newton",
 		"to_uom": "Poundal",
 		"abbr": "pdl",
-		"value": "0.138254954"
+		"value": "7.233014080147"
 	},
 	{
 		"category": "Force",
 		"from_uom": "Newton",
 		"to_uom": "Tonne-Force(Metric)",
 		"abbr": "tf",
-		"value": "9806.65"
+		"value": "0.000101971621"
 	},
 	{
 		"category": "Force",
 		"from_uom": "Newton",
 		"to_uom": "Ton-Force (UK)",
 		"abbr": "tf(UK)",
-		"value": "9964.016418"
+		"value": "0.000100361135"
 	},
 	{
 		"category": "Force",
 		"from_uom": "Newton",
 		"to_uom": "Ton-Force (US)",
 		"abbr": "tf(US)",
-		"value": "8896.443231"
+		"value": "0.000112404472"
 	},
 	{
 		"category": "Energy",
 		"from_uom": "Joule",
 		"to_uom": "Btu (It)",
 		"abbr": "dyn",
-		"value": "1055.056"
+		"value": "0.000947817"
 	},
 	{
 		"category": "Energy",
 		"from_uom": "Joule",
 		"to_uom": "Btu (Th)",
-		"value": "1054.35"
+		"value": "0.000948451653"
 	},
 	{
 		"category": "Energy",
 		"from_uom": "Joule",
 		"to_uom": "Btu (Mean)",
-		"value": "1055.87"
+		"value": "0.000947086289"
 	},
 	{
 		"category": "Energy",
 		"from_uom": "Joule",
 		"to_uom": "Calorie (It)",
 		"abbr": "cal",
-		"value": "4.1868"
+		"value": "0.238845896627"
 	},
 	{
 		"category": "Energy",
 		"from_uom": "Joule",
 		"to_uom": "Calorie (Th)",
-		"value": "4.184"
+		"value": "0.239005736138"
 	},
 	{
 		"category": "Energy",
 		"from_uom": "Joule",
 		"to_uom": "Calorie (Mean)",
-		"value": "4.19002"
+		"value": "0.238662345287"
 	},
 	{
 		"category": "Energy",
 		"from_uom": "Joule",
 		"to_uom": "Calorie (Food)",
-		"value": "4186"
+		"value": "0.000238891543"
 	},
 	{
 		"category": "Energy",
 		"from_uom": "Joule",
 		"to_uom": "Erg",
 		"abbr": "erg",
-		"value": "0.0000001"
+		"value": "10000000"
 	},
 	{
 		"category": "Energy",
 		"from_uom": "Joule",
 		"to_uom": "Horsepower-Hours",
 		"abbr": "hph",
-		"value": "2684520"
+		"value": "0.0000003725061"
 	},
 	{
 		"category": "Energy",
 		"from_uom": "Joule",
 		"to_uom": "Inch Pound-Force",
 		"abbr": "in lbf",
-		"value": "0.112985"
+		"value": "8.850745791327"
 	},
 	{
 		"category": "Energy",
@@ -1033,91 +1033,91 @@
 		"from_uom": "Joule",
 		"to_uom": "Kilojoule",
 		"abbr": "kJ",
-		"value": "1000"
+		"value": "0.0011"
 	},
 	{
 		"category": "Energy",
 		"from_uom": "Joule",
 		"to_uom": "Kilocalorie",
 		"abbr": "kcal",
-		"value": "4184"
+		"value": "0.000239005736"
 	},
 	{
 		"category": "Energy",
 		"from_uom": "Joule",
 		"to_uom": "Kilowatt-Hour",
 		"abbr": "kWh",
-		"value": "3600000"
+		"value": "0.0000002777778"
 	},
 	{
 		"category": "Energy",
 		"from_uom": "Joule",
 		"to_uom": "Litre-Atmosphere",
 		"abbr": "litre-atm",
-		"value": "101.3253354"
+		"value": "0.009869199999"
 	},
 	{
 		"category": "Energy",
 		"from_uom": "Joule",
 		"to_uom": "Megajoule",
 		"abbr": "MJ",
-		"value": "1000000"
+		"value": "0.000001"
 	},
 	{
 		"category": "Energy",
 		"from_uom": "Joule",
 		"to_uom": "Watt-Hour",
 		"abbr": "Wh",
-		"value": "3600"
+		"value": "0.000277777778"
 	},
 	{
 		"category": "Power",
 		"from_uom": "Watt",
 		"to_uom": "Btu/Hour",
 		"abbr": "B/h",
-		"value": "0.29301067"
+		"value": "3.412142450123"
 	},
 	{
 		"category": "Power",
 		"from_uom": "Watt",
 		"to_uom": "Btu/Minutes",
 		"abbr": "B/min",
-		"value": "17.56863"
+		"value": "0.05686902736"
 	},
 	{
 		"category": "Power",
 		"from_uom": "Watt",
 		"to_uom": "Btu/Seconds",
 		"abbr": "B/s",
-		"value": "1055.056"
+		"value": "0.00094781712"
 	},
 	{
 		"category": "Power",
 		"from_uom": "Watt",
 		"to_uom": "Calorie/Seconds",
 		"abbr": "cal/s",
-		"value": "4.183076"
+		"value": "0.238845896627"
 	},
 	{
 		"category": "Power",
 		"from_uom": "Watt",
 		"to_uom": "Horsepower",
 		"abbr": "hp",
-		"value": "745.6998716"
+		"value": "0.00134102209"
 	},
 	{
 		"category": "Power",
 		"from_uom": "Watt",
 		"to_uom": "Kilowatt",
 		"abbr": "kW",
-		"value": "1000"
+		"value": "0.001"
 	},
 	{
 		"category": "Power",
 		"from_uom": "Watt",
 		"to_uom": "Megawatt",
 		"abbr": "MW",
-		"value": "1000000"
+		"value": "0.000001"
 	},
 	{
 		"category": "Power",
@@ -1138,46 +1138,46 @@
 		"from_uom": "Gram/Litre",
 		"to_uom": "Centigram/Litre",
 		"abbr": "cg/l",
-		"value": "0.01"
+		"value": "100"
 	},
 	{
 		"category": "Density",
 		"from_uom": "Gram/Litre",
 		"to_uom": "Decigram/Litre",
 		"abbr": "dg/l",
-		"value": "0.1"
+		"value": "10"
 	},
 	{
 		"category": "Density",
 		"from_uom": "Gram/Litre",
 		"to_uom": "Dekagram/Litre",
 		"abbr": "dag/l",
-		"value": "10"
+		"value": "0.1"
 	},
 	{
 		"category": "Density",
 		"from_uom": "Gram/Litre",
 		"to_uom": "Hectogram/Litre",
 		"abbr": "hg/l",
-		"value": "100"
+		"value": "0.01"
 	},
 	{
 		"category": "Density",
 		"from_uom": "Gram/Litre",
 		"to_uom": "Gram/Cubic Meter",
-		"value": "0.001"
-	},
-	{
-		"category": "Density",
-		"from_uom": "Gram/Litre",
-		"to_uom": "Gram/Cubic Centimeter",
 		"value": "1000"
 	},
 	{
 		"category": "Density",
 		"from_uom": "Gram/Litre",
+		"to_uom": "Gram/Cubic Centimeter",
+		"value": "0.001"
+	},
+	{
+		"category": "Density",
+		"from_uom": "Gram/Litre",
 		"to_uom": "Gram/Cubic Millimeter",
-		"value": "1000000"
+		"value": "0.000001"
 	},
 	{
 		"category": "Density",
@@ -1190,19 +1190,19 @@
 		"category": "Density",
 		"from_uom": "Gram/Litre",
 		"to_uom": "Grain/Gallon (US)",
-		"value": "0.017118061"
+		"value": "58.4178306"
 	},
 	{
 		"category": "Density",
 		"from_uom": "Gram/Litre",
 		"to_uom": "Grain/Gallon (UK)",
-		"value": "0.014253768"
+		"value": "70.156887638"
 	},
 	{
 		"category": "Density",
 		"from_uom": "Gram/Litre",
 		"to_uom": "Grain/Cubic Foot",
-		"value": "0.002288352"
+		"value": "436.996"
 	},
 	{
 		"category": "Density",
@@ -1214,20 +1214,20 @@
 		"category": "Density",
 		"from_uom": "Gram/Litre",
 		"to_uom": "Kilogram/Cubic Centimeter",
-		"value": "1000000"
+		"value": "0.000001"
 	},
 	{
 		"category": "Density",
 		"from_uom": "Gram/Litre",
 		"to_uom": "Kilogram/Litre",
 		"abbr": "kg/l",
-		"value": "1000"
+		"value": "0.001"
 	},
 	{
 		"category": "Density",
 		"from_uom": "Gram/Litre",
 		"to_uom": "Milligram/Cubic Meter",
-		"value": "0.000001"
+		"value": "1000000"
 	},
 	{
 		"category": "Density",
@@ -1239,120 +1239,120 @@
 		"category": "Density",
 		"from_uom": "Gram/Litre",
 		"to_uom": "Milligram/Cubic Millimeter",
-		"value": "1000"
+		"value": "0.001"
 	},
 	{
 		"category": "Density",
 		"from_uom": "Gram/Litre",
 		"to_uom": "Megagram/Litre",
 		"abbr": "Mg/l",
-		"value": "1000000"
+		"value": "0.000001"
 	},
 	{
 		"category": "Density",
 		"from_uom": "Gram/Litre",
 		"to_uom": "Milligram/Litre",
 		"abbr": "mg/l",
-		"value": "0.001"
+		"value": "1000"
 	},
 	{
 		"category": "Density",
 		"from_uom": "Gram/Litre",
 		"to_uom": "Microgram/Litre",
 		"abbr": "µm/l",
-		"value": "0.000001"
+		"value": "1000000"
 	},
 	{
 		"category": "Density",
 		"from_uom": "Gram/Litre",
 		"to_uom": "Nanogram/Litre",
 		"abbr": "ng/l",
-		"value": "0.000000001"
+		"value": "1000000000"
 	},
 	{
 		"category": "Density",
 		"from_uom": "Gram/Litre",
 		"to_uom": "Ounce/Cubic Inch",
-		"value": "1729.994044"
+		"value": "0.000578036672"
 	},
 	{
 		"category": "Density",
 		"from_uom": "Gram/Litre",
 		"to_uom": "Ounce/Cubic Foot",
-		"value": "1.001153961"
+		"value": "0.998847369091"
 	},
 	{
 		"category": "Density",
 		"from_uom": "Gram/Litre",
 		"to_uom": "Ounce/Gallon (US)",
 		"abbr": "oz/gal(US)",
-		"value": "7.489151707"
+		"value": "0.13352647124"
 	},
 	{
 		"category": "Density",
 		"from_uom": "Gram/Litre",
 		"to_uom": "Ounce/Gallon (UK)",
 		"abbr": "oz/gal(UK)",
-		"value": "6.236023291"
+		"value": "0.16035860546"
 	},
 	{
 		"category": "Density",
 		"from_uom": "Gram/Litre",
 		"to_uom": "Pound/Cubic Inch",
-		"value": "27679.90471"
+		"value": "0.000036127292"
 	},
 	{
 		"category": "Density",
 		"from_uom": "Gram/Litre",
 		"to_uom": "Pound/Cubic Foot",
-		"value": "16.01846337"
+		"value": "0.062427960592"
 	},
 	{
 		"category": "Density",
 		"from_uom": "Gram/Litre",
-		"to_uom": "Pound Cubic Yard",
-		"value": "0.593276421"
+		"to_uom": "Pound/Cubic Yard",
+		"value": "1.685554935556"
 	},
 	{
 		"category": "Density",
 		"from_uom": "Gram/Litre",
 		"to_uom": "Pound/Gallon (US)",
 		"abbr": "lb/gal(US)",
-		"value": "119.8264273"
+		"value": "0.00834540423"
 	},
 	{
 		"category": "Density",
 		"from_uom": "Gram/Litre",
 		"to_uom": "Pound/Gallon (UK)",
 		"abbr": "lb/gal(UK)",
-		"value": "99.77637266"
+		"value": "0.01002241283"
 	},
 	{
 		"category": "Density",
 		"from_uom": "Gram/Litre",
 		"to_uom": "Psi/1000 Feet",
 		"abbr": "psi/1000 ft",
-		"value": "2.306658726"
+		"value": "0.433527504"
 	},
 	{
 		"category": "Density",
 		"from_uom": "Gram/Litre",
 		"to_uom": "Slug/Cubic Foot",
-		"value": "515.3788184"
+		"value": "0.00194032"
 	},
 	{
 		"category": "Density",
 		"from_uom": "Gram/Litre",
 		"to_uom": "Ton (Short)/Cubic Yard",
 		"abbr": "ton(short)/yd³",
-		"value": "1186.552843"
+		"value": "0.0008427775"
 	},
 	{
 		"category": "Density",
 		"from_uom": "Gram/Litre",
 		"to_uom": "Ton (Long)/Cubic Yard",
 		"abbr": "ton(long)/yd³",
-		"value": "1328.939184"
+		"value": "0.000752479873"
 	},
 	{
 		"category": "Temperature",
@@ -1364,13 +1364,13 @@
 		"category": "Temperature",
 		"from_uom": "Celsius",
 		"to_uom": "Fahrenheit",
-		"value": "0.555555556"
+		"value": "33.8"
 	},
 	{
 		"category": "Temperature",
 		"from_uom": "Celsius",
 		"to_uom": "Kelvin",
-		"value": "1"
+		"value": " 274.15"
 	},
 	{
 		"category": "Frequency and Wavelength",
@@ -1383,14 +1383,14 @@
 		"from_uom": "Hertz",
 		"to_uom": "Nanohertz",
 		"abbr": "nHz",
-		"value": "0.000000001"
+		"value": "1000000000"
 	},
 	{
 		"category": "Frequency and Wavelength",
 		"from_uom": "Hertz",
 		"to_uom": "Millihertz",
 		"abbr": "mHz",
-		"value": "0.001"
+		"value": "1000"
 	},
 	{
 		"category": "Frequency and Wavelength",
@@ -1404,14 +1404,14 @@
 		"from_uom": "Hertz",
 		"to_uom": "Kilohertz",
 		"abbr": "kHz",
-		"value": "1000"
+		"value": "0.001"
 	},
 	{
 		"category": "Frequency and Wavelength",
 		"from_uom": "Hertz",
 		"to_uom": "Megahertz",
 		"abbr": "MHz",
-		"value": "1000000"
+		"value": "0.000001"
 	},
 	{
 		"category": "Frequency and Wavelength",
@@ -1435,13 +1435,13 @@
 		"category": "Electrical Charge",
 		"from_uom": "Coulomb",
 		"to_uom": "Ampere-Hour",
-		"value": "3600"
+		"value": "0.000277778"
 	},
 	{
 		"category": "Electrical Charge",
 		"from_uom": "Coulomb",
 		"to_uom": "Ampere-Minute",
-		"value": "60"
+		"value": "0.016666666667"
 	},
 	{
 		"category": "Electrical Charge",
@@ -1460,41 +1460,41 @@
 		"category": "Electrical Charge",
 		"from_uom": "Coulomb",
 		"to_uom": "EMU Of Charge",
-		"value": "10"
+		"value": "0.1"
 	},
 	{
 		"category": "Electrical Charge",
 		"from_uom": "Coulomb",
 		"to_uom": "Faraday",
-		"value": "96485.309"
+		"value": "0.00001036427"
 	},
 	{
 		"category": "Electrical Charge",
 		"from_uom": "Coulomb",
 		"to_uom": "Kilocoulomb",
 		"abbr": "kC",
-		"value": "1000"
+		"value": "0.001"
 	},
 	{
 		"category": "Electrical Charge",
 		"from_uom": "Coulomb",
 		"to_uom": "Megacoulomb",
 		"abbr": "MC",
-		"value": "1000000"
+		"value": "0.000001"
 	},
 	{
 		"category": "Electrical Charge",
 		"from_uom": "Coulomb",
 		"to_uom": "Millicoulomb",
 		"abbr": "mC",
-		"value": "0.001"
+		"value": "1000"
 	},
 	{
 		"category": "Electrical Charge",
 		"from_uom": "Coulomb",
 		"to_uom": "Nanocoulomb",
 		"abbr": "nC",
-		"value": "0.000000001"
+		"value": "1000000000"
 	},
 	{
 		"category": "Electric Current",
@@ -1508,41 +1508,41 @@
 		"from_uom": "Ampere",
 		"to_uom": "Abampere",
 		"abbr": "abA",
-		"value": "10"
+		"value": "0.1"
 	},
 	{
 		"category": "Electric Current",
 		"from_uom": "Ampere",
 		"to_uom": "Biot",
 		"abbr": "Bi",
-		"value": "10"
+		"value": "0.1"
 	},
 	{
 		"category": "Electric Current",
 		"from_uom": "Ampere",
 		"to_uom": "EMU of current",
 		"abbr": "EMU",
-		"value": "10"
+		"value": "0.1"
 	},
 	{
 		"category": "Electric Current",
 		"from_uom": "Ampere",
 		"to_uom": "Kiloampere",
 		"abbr": "kA",
-		"value": "1000"
+		"value": "0.001"
 	},
 	{
 		"category": "Electric Current",
 		"from_uom": "Ampere",
 		"to_uom": "Milliampere",
 		"abbr": "mA",
-		"value": "0.001"
+		"value": "1000"
 	},
 	{
 		"category": "Magnetic Induction",
 		"from_uom": "Gauss",
 		"to_uom": "Gamma",
-		"value": "0.00001"
+		"value": "100000"
 	},
 	{
 		"category": "Magnetic Induction",
@@ -1556,7 +1556,7 @@
 		"from_uom": "Gauss",
 		"to_uom": "Tesla",
 		"abbr": "T",
-		"value": "10000"
+		"value": "0.0001"
 	},
 	{
 		"category": "Agriculture",
@@ -1570,6 +1570,6 @@
 		"from_uom": "Percent",
 		"to_uom": "Parts Per Million",
 		"abbr": "ppm",
-		"value": "0.0001"
+		"value": "10000"
 	}
 ]

--- a/erpnext/setup/setup_wizard/data/uom_data.json
+++ b/erpnext/setup/setup_wizard/data/uom_data.json
@@ -261,7 +261,11 @@
 		"must_be_whole_number": 0
 	},
 	{
-		"uom_name": "Hundredweight",
+		"uom_name": "Hundredweight (UK)",
+		"must_be_whole_number": 0
+	},
+	{
+		"uom_name": "Hundredweight (US)",
 		"must_be_whole_number": 0
 	},
 	{
@@ -789,7 +793,7 @@
 		"must_be_whole_number": 0
 	},
 	{
-		"uom_name": "Pound Cubic Yard",
+		"uom_name": "Pound/Cubic Yard",
 		"must_be_whole_number": 0
 	},
 	{

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -934,15 +934,16 @@ def get_uom_conv_factor(uom, stock_uom):
 
 	for d in uom_details:
 		if d.from_uom == stock_uom and d.to_uom == uom:
-			value = d.value
-		elif d.from_uom == uom and d.to_uom == stock_uom:
 			value = 1/flt(d.value)
-		else:
-			uom_stock = frappe.db.get_value("UOM Conversion Factor", {"to_uom": stock_uom}, ["from_uom", "value"], as_dict=1)
-			uom_row = frappe.db.get_value("UOM Conversion Factor", {"to_uom": uom}, ["from_uom", "value"], as_dict=1)
+		elif d.from_uom == uom and d.to_uom == stock_uom:
+			value = d.value
 
-			if uom_stock and uom_row:
-				if uom_stock.from_uom == uom_row.from_uom:
-					value = flt(uom_stock.value) * 1/flt(uom_row.value)
+	if not value:
+		uom_stock = frappe.db.get_value("UOM Conversion Factor", {"to_uom": stock_uom}, ["from_uom", "value"], as_dict=1)
+		uom_row = frappe.db.get_value("UOM Conversion Factor", {"to_uom": uom}, ["from_uom", "value"], as_dict=1)
+
+		if uom_stock and uom_row:
+			if uom_stock.from_uom == uom_row.from_uom:
+				value = flt(uom_stock.value) * 1/flt(uom_row.value)
 
 	return value

--- a/erpnext/stock/doctype/item/test_item.py
+++ b/erpnext/stock/doctype/item/test_item.py
@@ -255,9 +255,9 @@ class TestItem(unittest.TestCase):
 			d.conversion_factor = value
 
 		self.assertEqual(item_doc.uoms[0].uom, "Carat")
-		self.assertEqual(item_doc.uoms[0].conversion_factor, 5)
+		self.assertEqual(item_doc.uoms[0].conversion_factor, 0.2)
 		self.assertEqual(item_doc.uoms[1].uom, "Kg")
-		self.assertEqual(item_doc.uoms[1].conversion_factor, 0.001)
+		self.assertEqual(item_doc.uoms[1].conversion_factor, 1000)
 
 	def test_item_variant_by_manufacturer(self):
 		fields = [{'field_name': 'description'}, {'field_name': 'variant_based_on'}]


### PR DESCRIPTION
Pull-Request

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] Have you lint your code locally prior to submission?
- [x] Have you successfully run tests with your changes locally?
- [x] Does your commit message have an explanation for your changes and why you'd like us to include them?
- [ ] Docs have been added / updated
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Did you modify the existing test cases? If yes, why?

---

What type of a PR is this? 

- [ ] Changes to Existing Features
- [ ] New Feature Submissions
- [x] Bug Fix
- [ ] Breaking Change

--- 

- Motivation and Context (What existing problem does the pull request solve):

The conversion data was inverse according to interpretation.
Earlier From_Uom = Kg and To_Uom = Gram and value was 0.001, which is wrong according to interpretation that 1kg = 0.001gm.

In the uom measure table in Item master, the conversio . value denotes how many times is it equal to stock uom's value. Hence, if Stock_Uom is Gram and in conversion I add kg, then the conversion value should be 1000 which is as good as saying that 1 unit of kg = 1000 unit of gram.

- Related Issue: https://github.com/frappe/erpnext/issues/14399
- Screenshots (if applicable, remember, a picture tells a thousand words): 

![uom-fix](https://user-images.githubusercontent.com/11695402/42123613-9b4247f2-7c72-11e8-8dfd-c8103dedf171.gif)


**Please don't be intimidated by the long list of options you've to fill. Try to fill out as much as you can. Remember, the more the information the easier it is for us to test and get your pull request merged** :grin: 

