### PR TITLE
[Fix] Incorrect assignment of Serial No in POS Invoice

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -239,8 +239,8 @@ class AccountsController(TransactionBase):
 								item.set(fieldname, value)
 
 							elif fieldname == "serial_no":
-								stock_qty = item.get("stock_qty") * -1 if item.get("stock_qty") < 0 else item.get("stock_qty")
-								if stock_qty != len(get_serial_nos(item.get('serial_no'))):
+								item_qty = abs(item.get("qty"))
+								if item_qty != len(get_serial_nos(item.get('serial_no'))):
 									item.set(fieldname, value)
 
 					if ret.get("pricing_rule"):

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -239,7 +239,8 @@ class AccountsController(TransactionBase):
 								item.set(fieldname, value)
 
 							elif fieldname == "serial_no":
-								item_qty = abs(item.get("qty"))
+								item_qty = abs(item.get("qty")) * item.get("conversion_factor")
+
 								if item_qty != len(get_serial_nos(item.get('serial_no'))):
 									item.set(fieldname, value)
 


### PR DESCRIPTION
Pull-Request

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] Have you lint your code locally prior to submission?
- [ ] Have you successfully run tests with your changes locally?
- [x] Does your commit message have an explanation for your changes and why you'd like us to include them?
- [ ] Docs have been added / updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Did you modify the existing test cases? If yes, why?

---

What type of a PR is this? 

- [ ] Changes to Existing Features
- [ ] New Feature Submissions
- [x] Bug Fix
- [ ] Breaking Change

--- 

- Motivation and Context (What existing problem does the pull request solve):

**Notes:** Although it works, this might not be the most optimal fix, considering how the Controller might affect other documents, hence comments and suggestions are appreciated.

**Problem:** Currently in the POS, if you search an item using an existing Serial No and complete the transaction, the wrong Serial No gets added to the Sales Invoice - it finds the first available Serial No and uses that instead.

**Cause:** In code, this switch happens because the Sales Invoice tries to validate the amount of Serial Nos added to the POS with the item's `stock_qty`, which is 0 by default and is set at a later step. Due to the resulting mismatch, an arbitrary Serial No for that item is set.

**Solution:** Instead of comparing the amount of Serial Nos with the `stock_qty`, the controller now uses the `qty` field for the comparison.

---

- Screenshots (if applicable, remember, a picture tells a thousand words):

1. Adding the Serial No (725272730836) in the POS.
![image](https://user-images.githubusercontent.com/13396535/42152842-01d4872c-7dff-11e8-9916-6218fddff3f3.png)
1. Checking out with 1 quantity of the associated item.
![image](https://user-images.githubusercontent.com/13396535/42152862-0c00760c-7dff-11e8-9dd3-7d81bfd3dd4c.png)
1. After syncing the offline invoice, the item has picked up the wrong Serial No (WB20180020).
![image](https://user-images.githubusercontent.com/13396535/42152870-105d0288-7dff-11e8-91b1-82d57f295a4d.png)
1. The actual Serial No (725272730836) is still in Stores.
![image](https://user-images.githubusercontent.com/13396535/42152986-6539348e-7dff-11e8-90d1-c06ed47f8e2e.png)