### PR TITLE
[Fix] 'To Bill' status even if the amount is zero

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order_list.js
+++ b/erpnext/selling/doctype/sales_order/sales_order_list.js
@@ -1,20 +1,25 @@
 frappe.listview_settings['Sales Order'] = {
 	add_fields: ["base_grand_total", "customer_name", "currency", "delivery_date",
 		"per_delivered", "per_billed", "status", "order_type", "name"],
-	get_indicator: function(doc) {
-		if(doc.status==="Closed"){
+	get_indicator: function (doc) {
+		if (doc.status === "Closed") {
 			return [__("Closed"), "green", "status,=,Closed"];
 
 		} else if (doc.order_type !== "Maintenance"
 			&& flt(doc.per_delivered, 6) < 100 && frappe.datetime.get_diff(doc.delivery_date) < 0) {
-			// to bill & overdue
+			// not delivered & overdue
 			return [__("Overdue"), "red", "per_delivered,<,100|delivery_date,<,Today|status,!=,Closed"];
 
 		} else if (doc.order_type !== "Maintenance"
-			&& flt(doc.per_delivered, 6) < 100 && doc.status!=="Closed") {
+			&& flt(doc.per_delivered, 6) < 100 && doc.status !== "Closed") {
 			// not delivered
 
-			if(flt(doc.per_billed, 6) < 100) {
+			if (flt(doc.grand_total) === 0) {
+				// not delivered (zero-amount order)
+
+				return [__("To Deliver"), "orange",
+					"per_delivered,<,100|grand_total,=,0|status,!=,Closed"];
+			} else if (flt(doc.per_billed, 6) < 100) {
 				// not delivered & not billed
 
 				return [__("To Deliver and Bill"), "orange",
@@ -27,13 +32,13 @@ frappe.listview_settings['Sales Order'] = {
 			}
 
 		} else if ((doc.order_type === "Maintenance" || flt(doc.per_delivered, 6) == 100)
-			&& flt(doc.per_billed, 6) < 100 && doc.status!=="Closed") {
-
+			&& flt(doc.grand_total) !== 0 && flt(doc.per_billed, 6) < 100 && doc.status !== "Closed") {
 			// to bill
+
 			return [__("To Bill"), "orange", "per_delivered,=,100|per_billed,<,100|status,!=,Closed"];
 
-		} else if((doc.order_type === "Maintenance" || flt(doc.per_delivered, 6) == 100)
-			&& flt(doc.per_billed, 6) == 100 && doc.status!=="Closed") {
+		} else if ((doc.order_type === "Maintenance" || flt(doc.per_delivered, 6) == 100)
+			&& (flt(doc.grand_total) === 0 || flt(doc.per_billed, 6) == 100) && doc.status !== "Closed") {
 
 			return [__("Completed"), "green", "per_delivered,=,100|per_billed,=,100|status,!=,Closed"];
 		}

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -311,8 +311,7 @@ class DeliveryNote(SellingController):
 
 		for dn in set(updated_delivery_notes):
 			dn_doc = self if (dn == self.name) else frappe.get_doc("Delivery Note", dn)
-			if dn_doc.net_total > 0:
-				dn_doc.update_billing_percentage(update_modified=update_modified)
+			dn_doc.update_billing_percentage(update_modified=update_modified)
 
 		self.load_from_db()
 
@@ -400,7 +399,7 @@ def make_sales_invoice(source_name, target_doc=None):
 		# set company address
 		target.update(get_company_address(target.company))
 		if target.company_address:
-			target.update(get_fetch_values("Sales Invoice", 'company_address', target.company_address))	
+			target.update(get_fetch_values("Sales Invoice", 'company_address', target.company_address))
 
 	def update_item(source_doc, target_doc, source_parent):
 		target_doc.qty = source_doc.qty - invoiced_qty_map.get(source_doc.name, 0)

--- a/erpnext/stock/doctype/delivery_note/delivery_note_list.js
+++ b/erpnext/stock/doctype/delivery_note/delivery_note_list.js
@@ -1,14 +1,13 @@
 frappe.listview_settings['Delivery Note'] = {
-	add_fields: ["customer", "customer_name", "base_grand_total", "per_installed", "per_billed", 
-		"transporter_name", "grand_total", "is_return", "status"],
-	get_indicator: function(doc) {
-		if(cint(doc.is_return)==1) {
+	add_fields: ["grand_total", "is_return", "per_billed", "status"],
+	get_indicator: function (doc) {
+		if (cint(doc.is_return) == 1) {
 			return [__("Return"), "darkgrey", "is_return,=,Yes"];
-		} else if(doc.status==="Closed") {
+		} else if (doc.status === "Closed") {
 			return [__("Closed"), "green", "status,=,Closed"];
-		}  else if (flt(doc.per_billed, 2) < 100) {
+		} else if (doc.grand_total !== 0 && flt(doc.per_billed, 2) < 100) {
 			return [__("To Bill"), "orange", "per_billed,<,100"];
-		} else if (flt(doc.per_billed, 2) == 100) {
+		} else if (doc.grand_total === 0 || flt(doc.per_billed, 2) == 100) {
 			return [__("Completed"), "green", "per_billed,=,100"];
 		}
 	}

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt_list.js
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt_list.js
@@ -1,14 +1,13 @@
 frappe.listview_settings['Purchase Receipt'] = {
-	add_fields: ["supplier", "supplier_name", "base_grand_total", "is_subcontracted",
-		"transporter_name", "is_return", "status", "per_billed"],
-	get_indicator: function(doc) {
-		if(cint(doc.is_return)==1) {
+	add_fields: ["is_return", "grand_total", "status", "per_billed"],
+	get_indicator: function (doc) {
+		if (cint(doc.is_return) == 1) {
 			return [__("Return"), "darkgrey", "is_return,=,Yes"];
-		} else if(doc.status==="Closed") {
+		} else if (doc.status === "Closed") {
 			return [__("Closed"), "green", "status,=,Closed"];
-		}  else if (flt(doc.per_billed, 2) < 100) {
+		} else if (flt(doc.grand_total) !== 0 && flt(doc.per_billed, 2) < 100) {
 			return [__("To Bill"), "orange", "per_billed,<,100"];
-		} else if (flt(doc.per_billed, 2) == 100) {
+		} else if (flt(doc.grand_total) === 0 || flt(doc.per_billed, 2) == 100) {
 			return [__("Completed"), "green", "per_billed,=,100"];
 		}
 	}


### PR DESCRIPTION
Pull-Request

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] Have you lint your code locally prior to submission?
- [ ] Have you successfully run tests with your changes locally?
- [x] Does your commit message have an explanation for your changes and why you'd like us to include them?
- [ ] Docs have been added / updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Did you modify the existing test cases? If yes, why?

---

What type of a PR is this? 

- [ ] Changes to Existing Features
- [ ] New Feature Submissions
- [x] Bug Fix
- [ ] Breaking Change

--- 

- Motivation and Context (What existing problem does the pull request solve):

Due to an existing bug, Delivery Note documents that have a zero-amount show their status as "To Bill" even if invoices were made against them.

- Allowed the updating of billing status even if the Delivery Note's net total is zero.
- List view statuses have been updated to reflect zero-amount orders correctly.

---

- Related Issue(s):

#5006
#12433

---

- Screenshots (if applicable, remember, a picture tells a thousand words):
![image](https://user-images.githubusercontent.com/13396535/42163778-72ba6f34-7e21-11e8-9b45-b36c27a8e6d0.png)