### PR TITLE
Remove a redundant for loop that uses old python syntax

### DIFF
--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -266,9 +266,6 @@ class Project(Document):
 				dependency_map[task.title] = [x['subject'] for x in frappe.get_list(
 					'Task Depends On', {"parent": name}, ['subject'])]
 
-			for key, value in dependency_map.iteritems():
-				task_name = frappe.db.get_value('Task', {"subject": key, "project": self.name})
-
 			for key, value in iteritems(dependency_map):
 				task_name = frappe.db.get_value('Task', {"subject": key, "project": self.name })
 


### PR DESCRIPTION
Remove a redundant for loop that uses dict.iteritems() instead of six.iteritems(dict)

This should also fix #13909 as a side effect.