### PR TITLE
get_parent_item_groups() with no argument: fix for All Item Groups web generator

### DIFF
--- a/erpnext/setup/doctype/item_group/item_group.py
+++ b/erpnext/setup/doctype/item_group/item_group.py
@@ -156,6 +156,8 @@ def get_group_item_count(item_group):
 
 
 def get_parent_item_groups(item_group_name):
+	if not item_group_name:
+		return [{"name": frappe._("Home"), "route":"/"}]
 	item_group = frappe.get_doc("Item Group", item_group_name)
 	return 	[{"name": frappe._("Home"), "route":"/"}]+\
 		frappe.db.sql("""select name, route from `tabItem Group`


### PR DESCRIPTION
Added check to get_parent_item_groups; if called without an item group, return a default parents list of 'Home' only.

Pull-Request

- [x] Have you followed the guidelines in our Contributing document?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
- [x] Have you lint your code locally prior to submission?
- [x] Have you successfully run tests with your changes locally?
- [ ] Does your commit message have an explanation for your changes and why you'd like us to include them?
- [ ] Docs have been added / updated
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Did you modify the existing test cases? If yes, why?

---

What type of a PR is this? 

- [ ] Changes to Existing Features
- [ ] New Feature Submissions
- [x] Bug Fix
- [ ] Breaking Change

--- 

- Motivation and Context (What existing problem does the pull request solve):

**TL-DR: the website generator is broken for the root Item Group, 'All Item Groups'.**
Currently, the root 'Item Group' doctype is 'All Item Groups'. I have been setting up a custom website using the Item Group generator. I can therefore go to a page <mysite>/apples and see the products for the Apples item group, or /apples/cox to see the products for the Cox subgroup of the Apples item group. I have turned on the normal breadcrumbs template, and I get (for an example item CoxApple1):
Home / All Item Groups / Apples / Cox / CoxApple1
where each part is a link, as expected. Home takes me to the homepage, Apples takes me to <mysite>/apples (which works), Cox takes me to <mysite>/apples/cox (which works).
All Item Groups takes me to <mysite>/all-item-groups **which doesn't work** - I get a 404 error page (this page is missing).
After some considerable digging it turns out that the problem is in get_context for the item_group.py file, which calls:
`get_parent_item_groups(self.parent_item_group)`
when setting the context dictionary. For All Item Groups, parent_item_group is blank. This means that get_parent_item_groups gets called with a blank argument. It therefore fails with an exception when it hits the line:
`item_group = frappe.get_doc("Item Group", item_group_name)`
with an exception something like 'Item Group  not found' (as item_group_name is blank). The exception causes the entire page building to fail and a 404 error is displayed instead.
The aim is to build up a list of parents for the breadcrumbs which starts with 'Home', is normally followed by 'All Item Groups', and then relevant item groups (not including itself).
We can prevent this exception by simply checking if an item_group_name has been passed; if it has not, we only need to return a template dictionary containing only 'Home'.
-- What this allows: the route <mysite>/all-item-groups returns the products for all-item-groups as expected, rather than a 404 error.
-- Potential issues: you may not wish to expose item categories in this fashion. For the other item groups you turn off 'show in website', however you don't seem to be able to edit the All Items Group to turn this off (except by database editing). The current behaviour seems to be that this group is available by default (albeit inaccessible due to being broken).

Documentation: I am not aware of any documentation relating to the item group generators.
Test cases: the test cases I can find do not check this behaviour. Indeed test_item_group.py includes:
`if parent_item_group:
    parent_lft, parent_rgt = frappe.db.get_value("Item Group", parent_item_group, ["lft", "rgt"])`
which is essentially checking for this blank parent_item_group before testing in an analogous way to the testing done in this commit.

- Related Issue: 
- Screenshots (if applicable, remember, a picture tells a thousand words): 

**Please don't be intimidated by the long list of options you've to fill. Try to fill out as much as you can. Remember, the more the information the easier it is for us to test and get your pull request merged** :grin: 

