### PR TITLE
[Fix] Set default conversion factor in case none exist

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -239,7 +239,9 @@ class AccountsController(TransactionBase):
 								item.set(fieldname, value)
 
 							elif fieldname == "serial_no":
-								item_qty = abs(item.get("qty")) * item.get("conversion_factor")
+								# Ensure that serial numbers are matched against Stock UOM
+								item_conversion_factor = item.get("conversion_factor") or 1.0
+								item_qty = abs(item.get("qty")) * item_conversion_factor
 
 								if item_qty != len(get_serial_nos(item.get('serial_no'))):
 									item.set(fieldname, value)


### PR DESCRIPTION
**Problem:** The check for matching item quantity with serial numbers would not match for UOMs that do not have a stored conversion factor, which then defaults to 0.

**Solution:** Set a default conversion factor of 1 for cases when it's either not set or zero.