### PR TITLE
Modify renaming process of Account

### DIFF
--- a/erpnext/accounts/doctype/account/account.js
+++ b/erpnext/accounts/doctype/account/account.js
@@ -107,7 +107,15 @@ frappe.ui.form.on('Account', {
 					"fieldname": "account_number",
 					"fieldtype": "Data",
 					"reqd": 1
+				},
+				{
+					"label": "Account Name",
+					"fieldname": "account_name",
+					"fieldtype": "Data",
+					"reqd": 1,
+					"default": frm.doc.account_name
 				}
+
 			],
 			primary_action: function() {
 				var data = d.get_values();
@@ -120,6 +128,7 @@ frappe.ui.form.on('Account', {
 					method: "erpnext.accounts.doctype.account.account.update_account_number",
 					args: {
 						account_number: data.account_number,
+						account_name: data.account_name,
 						name: frm.doc.name
 					},
 					callback: function(r) {
@@ -128,6 +137,7 @@ frappe.ui.form.on('Account', {
 								frappe.set_route("Form", "Account", r.message);
 							} else {
 								frm.set_value("account_number", data.account_number);
+								frm.set_value("account_name", data.account_name);
 							}
 							d.hide();
 						}

--- a/erpnext/accounts/doctype/account/account.js
+++ b/erpnext/accounts/doctype/account/account.js
@@ -49,7 +49,7 @@ frappe.ui.form.on('Account', {
 		}
 
 		if(!frm.doc.__islocal) {
-			frm.add_custom_button(__('Update Account Number'), function () {
+			frm.add_custom_button(__('Update Account Number / Account Name'), function () {
 				frm.trigger("update_account_number");
 			});
 		}
@@ -100,13 +100,14 @@ frappe.ui.form.on('Account', {
 
 	update_account_number: function(frm) {
 		var d = new frappe.ui.Dialog({
-			title: __('Update Account Number'),
+			title: __('Update Account Number / Account Name'),
 			fields: [
 				{
 					"label": "Account Number",
 					"fieldname": "account_number",
 					"fieldtype": "Data",
-					"reqd": 1
+					"reqd": 1,
+					"default": frm.doc.account_number
 				},
 				{
 					"label": "Account Name",

--- a/erpnext/accounts/doctype/account/account.js
+++ b/erpnext/accounts/doctype/account/account.js
@@ -120,7 +120,7 @@ frappe.ui.form.on('Account', {
 			],
 			primary_action: function() {
 				var data = d.get_values();
-				if(data.account_number === frm.doc.account_number) {
+				if(data.account_number === frm.doc.account_number && data.account_name === frm.doc.account_name) {
 					d.hide();
 					return;
 				}

--- a/erpnext/accounts/doctype/account/account.js
+++ b/erpnext/accounts/doctype/account/account.js
@@ -49,7 +49,7 @@ frappe.ui.form.on('Account', {
 		}
 
 		if(!frm.doc.__islocal) {
-			frm.add_custom_button(__('Update Account Number / Name'), function () {
+			frm.add_custom_button(__('Update Account Name / Number'), function () {
 				frm.trigger("update_account_number");
 			});
 		}
@@ -103,20 +103,18 @@ frappe.ui.form.on('Account', {
 			title: __('Update Account Number / Name'),
 			fields: [
 				{
-					"label": "Account Number",
-					"fieldname": "account_number",
-					"fieldtype": "Data",
-					"reqd": 1,
-					"default": frm.doc.account_number
-				},
-				{
 					"label": "Account Name",
 					"fieldname": "account_name",
 					"fieldtype": "Data",
 					"reqd": 1,
 					"default": frm.doc.account_name
+				},
+				{
+					"label": "Account Number",
+					"fieldname": "account_number",
+					"fieldtype": "Data",
+					"default": frm.doc.account_number
 				}
-
 			],
 			primary_action: function() {
 				var data = d.get_values();

--- a/erpnext/accounts/doctype/account/account.js
+++ b/erpnext/accounts/doctype/account/account.js
@@ -49,7 +49,7 @@ frappe.ui.form.on('Account', {
 		}
 
 		if(!frm.doc.__islocal) {
-			frm.add_custom_button(__('Update Account Number / Account Name'), function () {
+			frm.add_custom_button(__('Update Account Number / Name'), function () {
 				frm.trigger("update_account_number");
 			});
 		}
@@ -100,7 +100,7 @@ frappe.ui.form.on('Account', {
 
 	update_account_number: function(frm) {
 		var d = new frappe.ui.Dialog({
-			title: __('Update Account Number / Account Name'),
+			title: __('Update Account Number / Name'),
 			fields: [
 				{
 					"label": "Account Number",

--- a/erpnext/accounts/doctype/account/account.json
+++ b/erpnext/accounts/doctype/account/account.json
@@ -2,7 +2,7 @@
  "allow_copy": 1, 
  "allow_guest_to_view": 0, 
  "allow_import": 1, 
- "allow_rename": 1, 
+ "allow_rename": 0, 
  "beta": 0, 
  "creation": "2013-01-30 12:49:46", 
  "custom": 0, 
@@ -40,6 +40,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0, 
    "unique": 0
   }, 
   {
@@ -68,6 +69,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0, 
    "unique": 0, 
    "width": "50%"
   }, 
@@ -100,6 +102,7 @@
    "reqd": 1, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0, 
    "unique": 0
   }, 
   {
@@ -130,6 +133,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0, 
    "unique": 0
   }, 
   {
@@ -161,6 +165,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0, 
    "unique": 0
   }, 
   {
@@ -193,6 +198,7 @@
    "reqd": 1, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0, 
    "unique": 0
   }, 
   {
@@ -223,6 +229,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0, 
    "unique": 0
   }, 
   {
@@ -253,6 +260,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0, 
    "unique": 0
   }, 
   {
@@ -285,6 +293,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0, 
    "unique": 0
   }, 
   {
@@ -313,6 +322,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0, 
    "unique": 0, 
    "width": "50%"
   }, 
@@ -346,6 +356,7 @@
    "reqd": 1, 
    "search_index": 1, 
    "set_only_once": 0, 
+   "translatable": 0, 
    "unique": 0
   }, 
   {
@@ -379,6 +390,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0, 
    "unique": 0
   }, 
   {
@@ -411,6 +423,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0, 
    "unique": 0
   }, 
   {
@@ -444,6 +457,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0, 
    "unique": 0
   }, 
   {
@@ -474,6 +488,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0, 
    "unique": 0
   }, 
   {
@@ -503,6 +518,7 @@
    "reqd": 0, 
    "search_index": 1, 
    "set_only_once": 0, 
+   "translatable": 0, 
    "unique": 0
   }, 
   {
@@ -532,6 +548,7 @@
    "reqd": 0, 
    "search_index": 1, 
    "set_only_once": 0, 
+   "translatable": 0, 
    "unique": 0
   }, 
   {
@@ -561,6 +578,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0, 
    "unique": 0
   }
  ], 
@@ -575,7 +593,7 @@
  "issingle": 0, 
  "istable": 0, 
  "max_attachments": 0, 
- "modified": "2017-08-22 17:39:10.711343", 
+ "modified": "2018-07-08 09:47:04.287841", 
  "modified_by": "Administrator", 
  "module": "Accounts", 
  "name": "Account", 

--- a/erpnext/accounts/doctype/account/account.py
+++ b/erpnext/accounts/doctype/account/account.py
@@ -217,8 +217,3 @@ def update_account_number(name, account_name, account_number=None):
 	if name != new_name:
 		frappe.rename_doc("Account", name, new_name, ignore_permissions=1)
 		return new_name
-
-def get_name_with_number(new_account, account_number):
-	if account_number and not new_account[0].isdigit():
-		new_account = account_number + " - " + new_account
-	return new_account

--- a/erpnext/accounts/doctype/account/account.py
+++ b/erpnext/accounts/doctype/account/account.py
@@ -165,53 +165,6 @@ class Account(NestedSet):
 
 		super(Account, self).on_trash(True)
 
-	def before_rename(self, old, new, merge=False):
-		# Add company abbr if not provided
-		from erpnext.setup.doctype.company.company import get_name_with_abbr
-		new_account = get_name_with_abbr(new, self.company)
-		if not merge:
-			new_account = get_name_with_number(new_account, self.account_number)
-		else:
-			# Validate properties before merging
-			if not frappe.db.exists("Account", new):
-				throw(_("Account {0} does not exist").format(new))
-
-			val = list(frappe.db.get_value("Account", new_account,
-				["is_group", "root_type", "company"]))
-
-			if val != [self.is_group, self.root_type, self.company]:
-				throw(_("""Merging is only possible if following properties are same in both records. Is Group, Root Type, Company"""))
-
-			if self.is_group and frappe.db.get_value("Account", new, "parent_account") == old:
-				frappe.db.set_value("Account", new, "parent_account",
-					frappe.db.get_value("Account", old, "parent_account"))
-
-		return new_account
-
-	def after_rename(self, old, new, merge=False):
-		super(Account, self).after_rename(old, new, merge)
-
-		if not merge:
-			new_acc = frappe.db.get_value("Account", new, ["account_name", "account_number"], as_dict=1)
-
-			# exclude company abbr
-			new_parts = new.split(" - ")[:-1]
-			# update account number and remove from parts
-			if new_parts[0][0].isdigit():
-				# if account number is separate by space, split using space
-				if len(new_parts) == 1:
-					new_parts = new.split(" ")
-				if new_acc.account_number != new_parts[0]:
-					self.account_number = new_parts[0]
-					self.db_set("account_number", new_parts[0])
-				new_parts = new_parts[1:]
-
-			# update account name
-			account_name = " - ".join(new_parts)
-			if new_acc.account_name != account_name:
-				self.account_name = account_name
-				self.db_set("account_name", account_name)
-
 def get_parent_account(doctype, txt, searchfield, start, page_len, filters):
 	return frappe.db.sql("""select name from tabAccount
 		where is_group = 1 and docstatus != 2 and company = %s
@@ -258,11 +211,6 @@ def update_account_number(name, account_number, account_name):
 	validate_account_number(name, account_number, account.company)
 
 	frappe.db.set_value("Account", name, "account_number", account_number)
-	frappe.db.set_value("Account", name, "account_name", account_name)
-
-	if account_name[0].isdigit():
-		separator = " - " if " - " in account_name else " "
-		account_name = account_name.split(separator, 1)[1]
 	frappe.db.set_value("Account", name, "account_name", account_name)
 
 	new_name = get_account_autoname(account_number, account_name, account.company)

--- a/erpnext/accounts/doctype/account/account.py
+++ b/erpnext/accounts/doctype/account/account.py
@@ -188,7 +188,7 @@ class Account(NestedSet):
 
 		return new_account
 
-	def after_rename(self, old, new, merge=False):
+	def after_not(self, old, new, merge=False):
 		super(Account, self).after_rename(old, new, merge)
 
 		if not merge:
@@ -252,14 +252,14 @@ def validate_account_number(name, account_number, company):
 				.format(account_number, account_with_same_number))
 
 @frappe.whitelist()
-def update_account_number(name, account_number):
-	account = frappe.db.get_value("Account", name, ["account_name", "company"], as_dict=True)
+def update_account_number(name, account_number, account_name):
 
+	account = frappe.db.get_value("Account", name, ["company"], as_dict=True)
 	validate_account_number(name, account_number, account.company)
 
 	frappe.db.set_value("Account", name, "account_number", account_number)
+	frappe.db.set_value("Account", name, "account_name", account_name)
 
-	account_name = account.account_name
 	if account_name[0].isdigit():
 		separator = " - " if " - " in account_name else " "
 		account_name = account_name.split(separator, 1)[1]
@@ -267,7 +267,7 @@ def update_account_number(name, account_number):
 
 	new_name = get_account_autoname(account_number, account_name, account.company)
 	if name != new_name:
-		frappe.rename_doc("Account", name, new_name)
+		frappe.rename_doc("Account", name, new_name, ignore_permissions=1)
 		return new_name
 
 def get_name_with_number(new_account, account_number):

--- a/erpnext/accounts/doctype/account/account.py
+++ b/erpnext/accounts/doctype/account/account.py
@@ -188,7 +188,7 @@ class Account(NestedSet):
 
 		return new_account
 
-	def after_not(self, old, new, merge=False):
+	def after_rename(self, old, new, merge=False):
 		super(Account, self).after_rename(old, new, merge)
 
 		if not merge:

--- a/erpnext/accounts/doctype/account/account.py
+++ b/erpnext/accounts/doctype/account/account.py
@@ -205,12 +205,12 @@ def validate_account_number(name, account_number, company):
 				.format(account_number, account_with_same_number))
 
 @frappe.whitelist()
-def update_account_number(name, account_number, account_name):
+def update_account_number(name, account_name, account_number=None):
 
 	account = frappe.db.get_value("Account", name, ["company"], as_dict=True)
 	validate_account_number(name, account_number, account.company)
-
-	frappe.db.set_value("Account", name, "account_number", account_number.strip())
+	if account_number:
+		frappe.db.set_value("Account", name, "account_number", account_number.strip())
 	frappe.db.set_value("Account", name, "account_name", account_name.strip())
 
 	new_name = get_account_autoname(account_number, account_name, account.company)

--- a/erpnext/accounts/doctype/account/account.py
+++ b/erpnext/accounts/doctype/account/account.py
@@ -210,8 +210,8 @@ def update_account_number(name, account_number, account_name):
 	account = frappe.db.get_value("Account", name, ["company"], as_dict=True)
 	validate_account_number(name, account_number, account.company)
 
-	frappe.db.set_value("Account", name, "account_number", account_number)
-	frappe.db.set_value("Account", name, "account_name", account_name)
+	frappe.db.set_value("Account", name, "account_number", account_number.strip())
+	frappe.db.set_value("Account", name, "account_name", account_name.strip())
 
 	new_name = get_account_autoname(account_number, account_name, account.company)
 	if name != new_name:

--- a/erpnext/accounts/doctype/account/test_account.py
+++ b/erpnext/accounts/doctype/account/test_account.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 import unittest
 import frappe
 from erpnext.stock import get_warehouse_account, get_company_default_inventory_account
+from erpnext.accounts.doctype.account.account import update_account_number
 
 class TestAccount(unittest.TestCase):
 	def test_rename_account(self):
@@ -21,21 +22,18 @@ class TestAccount(unittest.TestCase):
 		self.assertEqual(account_number, "1210")
 		self.assertEqual(account_name, "Debtors")
 
-		frappe.rename_doc("Account", "1210 - Debtors - _TC", "1211 - Debtors 1 - _TC", ignore_permissions=1)
+		new_account_number = "1211-11-4 - 6 - "
+		new_account_name = "Debtors 1 - Test - "
 
-		new_acc = frappe.db.get_value("Account", "1211 - Debtors 1 - _TC",
+		update_account_number("1210 - Debtors - _TC", new_account_number, new_account_name)
+
+		new_acc = frappe.db.get_value("Account", "1211-11-4 - 6 - - Debtors 1 - Test - - _TC",
 			["account_name", "account_number"], as_dict=1)
-		self.assertEqual(new_acc.account_name, "Debtors 1")
-		self.assertEqual(new_acc.account_number, "1211")
 
-		frappe.rename_doc("Account", "1211 - Debtors 1 - _TC", "Debtors 2", ignore_permissions=1)
+		self.assertEqual(new_acc.account_name, "Debtors 1 - Test -")
+		self.assertEqual(new_acc.account_number, "1211-11-4 - 6 -")
 
-		new_acc = frappe.db.get_value("Account", "1211 - Debtors 2 - _TC",
-			["account_name", "account_number"], as_dict=1)
-		self.assertEqual(new_acc.account_name, "Debtors 2")
-		self.assertEqual(new_acc.account_number, "1211")
-
-		frappe.delete_doc("Account", "1211 - Debtors 2 - _TC")
+		frappe.delete_doc("Account", "1211-11-4 - 6 - Debtors 1 - Test - - _TC")
 
 def _make_test_records(verbose):
 	from frappe.test_runner import make_test_objects

--- a/erpnext/accounts/doctype/account/test_account.py
+++ b/erpnext/accounts/doctype/account/test_account.py
@@ -21,14 +21,14 @@ class TestAccount(unittest.TestCase):
 		self.assertEqual(account_number, "1210")
 		self.assertEqual(account_name, "Debtors")
 
-		frappe.rename_doc("Account", "1210 - Debtors - _TC", "1211 - Debtors 1 - _TC")
+		frappe.rename_doc("Account", "1210 - Debtors - _TC", "1211 - Debtors 1 - _TC", ignore_permissions=1)
 
 		new_acc = frappe.db.get_value("Account", "1211 - Debtors 1 - _TC",
 			["account_name", "account_number"], as_dict=1)
 		self.assertEqual(new_acc.account_name, "Debtors 1")
 		self.assertEqual(new_acc.account_number, "1211")
 
-		frappe.rename_doc("Account", "1211 - Debtors 1 - _TC", "Debtors 2")
+		frappe.rename_doc("Account", "1211 - Debtors 1 - _TC", "Debtors 2", ignore_permissions=1)
 
 		new_acc = frappe.db.get_value("Account", "1211 - Debtors 2 - _TC",
 			["account_name", "account_number"], as_dict=1)


### PR DESCRIPTION
- Removed Allow Rename from Account master
- Account name and number could only be renamed by clicking on `Update Account Number` button.

![account number](https://user-images.githubusercontent.com/17617465/42418020-8c2a7e72-82b4-11e8-91a1-fa8ef4624149.gif)
