### PR TITLE
Update travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
     </p>
 </div>
 
-[![Build Status](https://travis-ci.org/frappe/erpnext.png)](https://travis-ci.org/frappe/erpnext) [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/frappe/erpnext?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Build Status](https://travis-ci.com/frappe/erpnext.png)](https://travis-ci.com/frappe/erpnext) [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/frappe/erpnext?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 [https://erpnext.com](https://erpnext.com)
 


### PR DESCRIPTION
Update url from travis-ci.org to travis-ci.com
