### PR TITLE
[Fix] Invoices not showing in the gross profit report against which sales return entry has created

### DIFF
--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -171,7 +171,7 @@ class GrossProfitGenerator(object):
 							row.qty += returned_item_row.qty
 							row.base_amount += returned_item_row.base_amount
 						row.buying_amount = row.qty * row.buying_rate
-					if row.qty:
+					if row.qty or row.base_amount:
 						row = self.set_average_rate(row)
 						self.grouped_data.append(row)
 


### PR DESCRIPTION
**Issue**
Against sales invoice SINV-00121, sales return entry created and this invoice is not showing in the report Gross Profit report 
![screen shot 2018-07-16 at 2 20 45 pm](https://user-images.githubusercontent.com/8780500/42750207-02316e82-8904-11e8-8c9f-146413646017.png)

**After Fix**

![screen shot 2018-07-16 at 2 21 41 pm](https://user-images.githubusercontent.com/8780500/42750209-04cdfc28-8904-11e8-9ded-e4343dce22b4.png)
