### PR TITLE
Query report print

### DIFF
--- a/erpnext/accounts/report/accounts_payable/accounts_payable.js
+++ b/erpnext/accounts/report/accounts_payable/accounts_payable.js
@@ -22,9 +22,9 @@ frappe.query_reports["Accounts Payable"] = {
 			"fieldtype": "Link",
 			"options": "Supplier",
 			on_change: () => {
-				var supplier = frappe.query_report_filters_by_name.supplier.get_value();
+				var supplier = frappe.query_report.get_filter_value('supplier');
 				frappe.db.get_value('Supplier', supplier, "tax_id", function(value) {
-					frappe.query_report_filters_by_name.tax_id.set_value(value["tax_id"]);
+					frappe.query_report.set_filter_value('tax_id', value["tax_id"]);
 				});
 			}
 		},

--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.js
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.js
@@ -22,10 +22,10 @@ frappe.query_reports["Accounts Receivable"] = {
 			"fieldtype": "Link",
 			"options": "Customer",
 			on_change: () => {
-				var customer = frappe.query_report_filters_by_name.customer.get_value();
+				var customer = frappe.query_report.get_filter_value('customer');
 				frappe.db.get_value('Customer', customer, ["tax_id", "customer_name"], function(value) {
-					frappe.query_report_filters_by_name.tax_id.set_value(value["tax_id"]);
-					frappe.query_report_filters_by_name.customer_name.set_value(value["customer_name"]);
+					frappe.query_report.set_filter_value('tax_id', value["tax_id"]);
+					frappe.query_report.set_filter_value('customer_name', value["customer_name"]);
 				});
 			}
 		},

--- a/erpnext/accounts/report/financial_statements.html
+++ b/erpnext/accounts/report/financial_statements.html
@@ -1,5 +1,7 @@
 {%
-	if (report.columns.length > 8) {
+	var report_columns = report.get_columns_for_print();
+
+	if (report_columns.length > 8) {
 		frappe.throw(__("Too many columns. Export the report and print it using a spreadsheet application."));
 	}
 %}
@@ -30,9 +32,9 @@
 <table class="table table-bordered">
 	<thead>
 		<tr>
-			<th style="width: {%= 100 - (report.columns.length - 2) * 13 %}%"></th>
-			{% for(var i=2, l=report.columns.length; i<l; i++) { %}
-				<th class="text-right">{%= report.columns[i].label %}</th>
+			<th style="width: {%= 100 - (report_columns.length - 2) * 13 %}%"></th>
+			{% for(var i=2, l=report_columns.length; i<l; i++) { %}
+				<th class="text-right">{%= report_columns[i].label %}</th>
 			{% } %}
 		</tr>
 	</thead>
@@ -47,9 +49,9 @@
 				<td>
 					<span style="padding-left: {%= cint(data[j].indent) * 2 %}em">{%= row.account_name %}</span>
 				</td>
-				{% for(var i=2, l=report.columns.length; i<l; i++) { %}
+				{% for(var i=2, l=report_columns.length; i<l; i++) { %}
 					<td class="text-right">
-						{% var fieldname = report.columns[i].field || report.columns[i].fieldname; %}
+						{% var fieldname = report_columns[i].field || report_columns[i].fieldname; %}
 						{% if (!is_null(row[fieldname])) { %}
 							{%= format_currency(row[fieldname], filters.presentation_currency) %}
 						{% } %}

--- a/erpnext/accounts/report/general_ledger/general_ledger.js
+++ b/erpnext/accounts/report/general_ledger/general_ledger.js
@@ -39,7 +39,7 @@ frappe.query_reports["General Ledger"] = {
 			"fieldtype": "Link",
 			"options": "Account",
 			"get_query": function() {
-				var company = frappe.query_report_filters_by_name.company.get_value();
+				var company = frappe.query_report.get_filter_value('company');
 				return {
 					"doctype": "Account",
 					"filters": {
@@ -53,7 +53,7 @@ frappe.query_reports["General Ledger"] = {
 			"label": __("Voucher No"),
 			"fieldtype": "Data",
 			on_change: function() {
-				frappe.query_report_filters_by_name.group_by.set_value("");
+				frappe.query_report.set_filter_value('group_by', "");
 			}
 		},
 		{
@@ -72,7 +72,7 @@ frappe.query_reports["General Ledger"] = {
 			"options": "Party Type",
 			"default": "",
 			on_change: function() {
-				frappe.query_report_filters_by_name.party.set_value("");
+				frappe.query_report.set_filter_value('party', "");
 			}
 		},
 		{
@@ -80,10 +80,8 @@ frappe.query_reports["General Ledger"] = {
 			"label": __("Party"),
 			"fieldtype": "MultiSelect",
 			get_data: function() {
-				if(!frappe.query_report_filters_by_name) return;
-
-				var party_type = frappe.query_report_filters_by_name.party_type.get_value();
-				var parties = frappe.query_report_filters_by_name.party.get_value();
+				var party_type = frappe.query_report.get_filter_value('party_type');
+				var parties = frappe.query_report.get_filter_value('party');
 				if(!party_type) return;
 
 				const values = parties.split(/\s*,\s*/).filter(d => d);
@@ -96,7 +94,7 @@ frappe.query_reports["General Ledger"] = {
 					async: false,
 					no_spinner: true,
 					args: {
-						doctype: frappe.query_report_filters_by_name.party_type.get_value(),
+						doctype: frappe.query_report.get_filter_value('party_type'),
 						txt: txt,
 						filters: {
 							"name": ["not in", values]
@@ -109,25 +107,24 @@ frappe.query_reports["General Ledger"] = {
 				return data;
 			},
 			on_change: function() {
-				var party_type = frappe.query_report_filters_by_name.party_type.get_value();
-				var parties = frappe.query_report_filters_by_name.party.get_value();
+				var party_type = frappe.query_report.get_filter_value('party_type');
+				var parties = frappe.query_report.get_filter_value('party');
 				const values = parties.split(/\s*,\s*/).filter(d => d);
 
 				if(!party_type || !parties || values.length>1) {
-					frappe.query_report_filters_by_name.party_name.set_value("");
-					frappe.query_report_filters_by_name.tax_id.set_value("");
+					frappe.query_report.set_filter_value('party_name', "");
+					frappe.query_report.set_filter_value('tax_id', "");
 					return;
 				} else {
 					var party = values[0];
-					frappe.query_report_filters_by_name.show_name = true;
 					var fieldname = erpnext.utils.get_party_name(party_type) || "name";
 					frappe.db.get_value(party_type, party, fieldname, function(value) {
-						frappe.query_report_filters_by_name.party_name.set_value(value[fieldname]);
+						frappe.query_report.set_filter_value('party_name', value[fieldname]);
 					});
 
 					if (party_type === "Customer" || party_type === "Supplier") {
 						frappe.db.get_value(party_type, party, "tax_id", function(value) {
-							frappe.query_report_filters_by_name.tax_id.set_value(value["tax_id"]);
+							frappe.query_report.set_filter_value('tax_id', value["tax_id"]);
 						});
 					}
 				}

--- a/erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.js
+++ b/erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.js
@@ -46,8 +46,8 @@ frappe.query_reports["Payment Period Based On Invoice Date"] = {
 			"label": __("Party"),
 			"fieldtype": "Dynamic Link",
 			"get_options": function() {
-				var party_type = frappe.query_report_filters_by_name.party_type.get_value();
-				var party = frappe.query_report_filters_by_name.party.get_value();
+				var party_type = frappe.query_report.get_filter_value('party_type');
+				var party = frappe.query_report.get_filter_value('party');
 				if(party && !party_type) {
 					frappe.throw(__("Please select Party Type first"));
 				}

--- a/erpnext/accounts/report/profitability_analysis/profitability_analysis.js
+++ b/erpnext/accounts/report/profitability_analysis/profitability_analysis.js
@@ -34,9 +34,10 @@ frappe.require("assets/erpnext/js/financial_statements.js", function() {
 					}
 					frappe.model.with_doc("Fiscal Year", fiscal_year, function(r) {
 						var fy = frappe.model.get_doc("Fiscal Year", fiscal_year);
-						frappe.query_report_filters_by_name.from_date.set_input(fy.year_start_date);
-						frappe.query_report_filters_by_name.to_date.set_input(fy.year_end_date);
-						query_report.trigger_refresh();
+						frappe.query_report.set_filter_value({
+							from_date: fy.year_start_date,
+							to_date: fy.year_end_date
+						});
 					});
 				}
 			},
@@ -84,7 +85,7 @@ frappe.require("assets/erpnext/js/financial_statements.js", function() {
 			if (!data.account) return;
 
 			frappe.route_options = {
-				"company": frappe.query_report_filters_by_name.company.get_value(),
+				"company": frappe.query_report.get_filter_value('company'),
 				"from_fiscal_year": data.fiscal_year,
 				"to_fiscal_year": data.fiscal_year
 			};

--- a/erpnext/accounts/report/trial_balance/trial_balance.js
+++ b/erpnext/accounts/report/trial_balance/trial_balance.js
@@ -26,9 +26,10 @@ frappe.require("assets/erpnext/js/financial_statements.js", function() {
 					}
 					frappe.model.with_doc("Fiscal Year", fiscal_year, function(r) {
 						var fy = frappe.model.get_doc("Fiscal Year", fiscal_year);
-						frappe.query_report_filters_by_name.from_date.set_input(fy.year_start_date);
-						frappe.query_report_filters_by_name.to_date.set_input(fy.year_end_date);
-						query_report.trigger_refresh();
+						frappe.query_report.set_filter_value({
+							from_date: fy.year_start_date,
+							to_date: fy.year_end_date
+						});
 					});
 				}
 			},

--- a/erpnext/accounts/report/trial_balance_for_party/trial_balance_for_party.js
+++ b/erpnext/accounts/report/trial_balance_for_party/trial_balance_for_party.js
@@ -25,9 +25,10 @@ frappe.query_reports["Trial Balance for Party"] = {
 				}
 				frappe.model.with_doc("Fiscal Year", fiscal_year, function(r) {
 					var fy = frappe.model.get_doc("Fiscal Year", fiscal_year);
-					frappe.query_report_filters_by_name.from_date.set_input(fy.year_start_date);
-					frappe.query_report_filters_by_name.to_date.set_input(fy.year_end_date);
-					query_report.trigger_refresh();
+					frappe.query_report.set_filter_value({
+						from_date: fy.year_start_date,
+						to_date: fy.year_end_date
+					});
 				});
 			}
 		},
@@ -56,8 +57,8 @@ frappe.query_reports["Trial Balance for Party"] = {
 			"label": __("Party"),
 			"fieldtype": "Dynamic Link",
 			"get_options": function() {
-				var party_type = frappe.query_report_filters_by_name.party_type.get_value();
-				var party = frappe.query_report_filters_by_name.party.get_value();
+				var party_type = frappe.query_report.get_filter_value('party_type');
+				var party = frappe.query_report.get_filter_value('party');
 				if(party && !party_type) {
 					frappe.throw(__("Please select Party Type first"));
 				}

--- a/erpnext/buying/report/quoted_item_comparison/quoted_item_comparison.js
+++ b/erpnext/buying/report/quoted_item_comparison/quoted_item_comparison.js
@@ -21,7 +21,7 @@ frappe.query_reports["Quoted Item Comparison"] = {
 			fieldname: "item",
 			fieldtype: "Link",
 			get_query: () => {
-				let quote = frappe.query_report_filters_by_name.supplier_quotation.get_value();
+				let quote = frappe.query_report.get_filter_value('supplier_quotation');
 				if (quote != "") {
 					return {
 						query: "erpnext.stock.doctype.quality_inspection.quality_inspection.item_query",

--- a/erpnext/education/report/course_wise_assessment_report/course_wise_assessment_report.html
+++ b/erpnext/education/report/course_wise_assessment_report/course_wise_assessment_report.html
@@ -1,5 +1,8 @@
-{% var letterhead= filters.letter_head || (frappe.get_doc(":Company", filters.company) && frappe.get_doc(":Company", filters.company).default_letter_head) || frappe.defaults.get_default("letter_head"); %}
-{% if(letterhead) { %} 
+{%
+	var letterhead = filters.letter_head || (frappe.get_doc(":Company", filters.company) && frappe.get_doc(":Company", filters.company).default_letter_head) || frappe.defaults.get_default("letter_head");
+	var report_columns = report.get_columns_for_print();
+%}
+{% if(letterhead) { %}
 <div style="margin-bottom: 7px;" class="text-center">
 	{%= frappe.boot.letter_heads[letterhead].header %}
 </div>
@@ -20,8 +23,8 @@
 <table class="table table-bordered">
 	<thead>
 		<tr>
-			{% for(var i=1, l=report.columns.length; i<l; i++) { %}
-				<th style="text-transform: uppercase; max-width: 100px">{%= report.columns[i].label %}</th>
+			{% for(var i=1, l=report_columns.length; i<l; i++) { %}
+				<th style="text-transform: uppercase; max-width: 100px">{%= report_columns[i].label %}</th>
 			{% } %}
 		</tr>
 	</thead>
@@ -31,9 +34,9 @@
 				var row = data[j];
 			%}
 			<tr>
-				{% for(var i=1, l=report.columns.length; i<l; i++) { %}
+				{% for(var i=1, l=report_columns.length; i<l; i++) { %}
 					<td class="text-center">
-						{% var fieldname = report.columns[i].field; %}
+						{% var fieldname = report_columns[i].field; %}
 						{% if (!is_null(row[fieldname])) { %}
 							{%= row[fieldname] %}
 						{% } %}

--- a/erpnext/education/report/final_assessment_grades/final_assessment_grades.js
+++ b/erpnext/education/report/final_assessment_grades/final_assessment_grades.js
@@ -21,7 +21,7 @@ frappe.query_reports["Final Assessment Grades"] = {
 				return{
 					filters: {
 						"group_based_on": "Batch",
-						"academic_year": frappe.query_report_filters_by_name.academic_year.value
+						"academic_year": frappe.query_report.get_filter_value('academic_year')
 					}
 				};
 			}

--- a/erpnext/education/report/student_monthly_attendance_sheet/student_monthly_attendance_sheet.js
+++ b/erpnext/education/report/student_monthly_attendance_sheet/student_monthly_attendance_sheet.js
@@ -31,7 +31,7 @@ frappe.query_reports["Student Monthly Attendance Sheet"] = {
 		return frappe.call({
 			method: "erpnext.education.report.student_monthly_attendance_sheet.student_monthly_attendance_sheet.get_attendance_years",
 			callback: function(r) {
-				var year_filter = frappe.query_report_filters_by_name.year;
+				var year_filter = frappe.query_report.get_filter('year');
 				year_filter.df.options = r.message;
 				year_filter.df.default = r.message.split("\n")[0];
 				year_filter.refresh();

--- a/erpnext/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js
+++ b/erpnext/hr/report/monthly_attendance_sheet/monthly_attendance_sheet.js
@@ -38,7 +38,7 @@ frappe.query_reports["Monthly Attendance Sheet"] = {
 		return  frappe.call({
 			method: "erpnext.hr.report.monthly_attendance_sheet.monthly_attendance_sheet.get_attendance_years",
 			callback: function(r) {
-				var year_filter = frappe.query_report_filters_by_name.year;
+				var year_filter = frappe.query_report.get_filter('year');
 				year_filter.df.options = r.message;
 				year_filter.df.default = r.message.split("\n")[0];
 				year_filter.refresh();

--- a/erpnext/hr/report/salary_register/salary_register.html
+++ b/erpnext/hr/report/salary_register/salary_register.html
@@ -1,3 +1,6 @@
+{%
+	var report_columns = report.get_columns_for_print();
+%}
 <div style="margin-bottom: 7px;" class="text-center">
 	{%= frappe.boot.letter_heads[filters.letter_head || frappe.defaults.get_default("letter_head")] %}
 </div>
@@ -7,8 +10,8 @@
 <table class="table table-bordered">
 	<thead>
 		<tr>
-			{% for(var i=1, l=report.columns.length; i<l; i++) { %}
-				<th class="text-right">{%= report.columns[i].label %}</th>
+			{% for(var i=1, l=report_columns.length; i<l; i++) { %}
+				<th class="text-right">{%= report_columns[i].label %}</th>
 			{% } %}
 		</tr>
 	</thead>
@@ -18,10 +21,10 @@
 				var row = data[j];
 			%}
 			<tr>
-				{% for(var i=1, l=report.columns.length; i<l; i++) { %}
+				{% for(var i=1, l=report_columns.length; i<l; i++) { %}
 					<td class="text-right">
-						{% var fieldname = report.columns[i].field; %}
-						{% if (report.columns[i].fieldtype=='Currency' && !isNaN(row[fieldname])) { %}
+						{% var fieldname = report_columns[i].field; %}
+						{% if (report_columns[i].fieldtype=='Currency' && !isNaN(row[fieldname])) { %}
 							{%= format_currency(row[fieldname]) %}
 						{% } else { %}
 							{% if (!is_null(row[fieldname])) { %}

--- a/erpnext/hr/report/vehicle_expenses/vehicle_expenses.js
+++ b/erpnext/hr/report/vehicle_expenses/vehicle_expenses.js
@@ -17,9 +17,11 @@ frappe.require("assets/erpnext/js/financial_statements.js", function() {
 					}
 					frappe.model.with_doc("Fiscal Year", fiscal_year, function(r) {
 						var fy = frappe.model.get_doc("Fiscal Year", fiscal_year);
-						frappe.query_report_filters_by_name.from_date.set_input(fy.year_start_date);
-						frappe.query_report_filters_by_name.to_date.set_input(fy.year_end_date);
-						query_report.trigger_refresh();
+
+						frappe.query_report.set_filter({
+							from_date: fy.year_start_date,
+							to_date: fy.year_end_date
+						});
 					});
 				}
 			}

--- a/erpnext/manufacturing/report/bom_variance_report/bom_variance_report.js
+++ b/erpnext/manufacturing/report/bom_variance_report/bom_variance_report.js
@@ -16,7 +16,7 @@ frappe.query_reports["BOM Variance Report"] = {
 			"fieldtype": "Link",
 			"options": "Work Order",
 			"get_query": function() {
-				var bom_no = frappe.query_report_filters_by_name.bom_no.get_value();
+				var bom_no = frappe.query_report.get_filter_value('bom_no');
 				return{
 					query: "erpnext.manufacturing.report.bom_variance_report.bom_variance_report.get_work_orders",
 					filters: {

--- a/erpnext/public/js/financial_statements.js
+++ b/erpnext/public/js/financial_statements.js
@@ -30,7 +30,7 @@ erpnext.financial_statements = {
 
 		frappe.route_options = {
 			"account": data.account,
-			"company": frappe.query_report_filters_by_name.company.get_value(),
+			"company": frappe.query_report.get_filter_value('company'),
 			"from_date": data.from_date || data.year_start_date,
 			"to_date": data.to_date || data.year_end_date,
 			"project": (project && project.length > 0) ? project[0].$input.val() : ""

--- a/erpnext/regional/report/gstr_1/gstr_1.js
+++ b/erpnext/regional/report/gstr_1/gstr_1.js
@@ -17,7 +17,7 @@ frappe.query_reports["GSTR-1"] = {
 			"fieldtype": "Link",
 			"options": "Address",
 			"get_query": function() {
-				var company = frappe.query_report_filters_by_name.company.get_value();
+				var company = frappe.query_report.get_filter_value('company');
 				if (company) {
 					return {
 						"query": 'frappe.contacts.doctype.address.address.address_query',

--- a/erpnext/selling/report/address_and_contacts/address_and_contacts.js
+++ b/erpnext/selling/report/address_and_contacts/address_and_contacts.js
@@ -23,7 +23,7 @@ frappe.query_reports["Address And Contacts"] = {
 			"label": __("Party Name"),
 			"fieldtype": "Dynamic Link",
 			"get_options": function() {
-				let party_type = frappe.query_report_filters_by_name.party_type.get_value();
+				let party_type = frappe.query_report.get_filter_value('party_type');
 				if(!party_type) {
 					frappe.throw(__("Please select Party Type first"));
 				}


### PR DESCRIPTION
Depends on: https://github.com/frappe/frappe/pull/5834/

- Replace usage of `frappe.query_report_filters_by_name` with the new API
- Use report.get_columns_for_print() in Report Print formats so that it only prints the visible columns and not the ones that are hidden by user.

General Ledger Print with 1 column hidden:
![image](https://user-images.githubusercontent.com/9355208/42813576-18f10bce-89df-11e8-93b1-3dd187579715.png)
