### PR TITLE
patch fixes

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
@@ -4493,7 +4493,7 @@
  "istable": 0, 
  "max_attachments": 0, 
  "menu_index": 0, 
- "modified": "2018-07-06 02:38:40.310899",
+ "modified": "2018-07-17 02:38:40.310899",
  "modified_by": "Administrator", 
  "module": "Accounts", 
  "name": "Purchase Invoice", 

--- a/erpnext/buying/doctype/purchase_order/purchase_order.json
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.json
@@ -3737,7 +3737,7 @@
  "issingle": 0, 
  "istable": 0, 
  "max_attachments": 0, 
- "modified": "2018-07-06 11:00:05.037716", 
+ "modified": "2018-07-17 11:00:05.037716", 
  "modified_by": "Administrator", 
  "module": "Buying", 
  "name": "Purchase Order", 

--- a/erpnext/buying/doctype/supplier_quotation/supplier_quotation.json
+++ b/erpnext/buying/doctype/supplier_quotation/supplier_quotation.json
@@ -2779,7 +2779,7 @@
  "istable": 0, 
  "max_attachments": 0, 
  "menu_index": 0, 
- "modified": "2018-07-06 02:45:48.616334",
+ "modified": "2018-07-17 02:45:48.616334",
  "modified_by": "Administrator", 
  "module": "Buying", 
  "name": "Supplier Quotation", 

--- a/erpnext/patches/v11_0/set_department_for_doctypes.py
+++ b/erpnext/patches/v11_0/set_department_for_doctypes.py
@@ -3,14 +3,21 @@ import frappe
 # Set department value based on employee value
 
 def execute():
-	doctypes_to_update = ['Appraisal', 'Leave Allocation', 'Expense Claim', 'Instructor', 'Salary Slip',
-		'Attendance', 'Training Feedback', 'Training Result Employee',
-		'Leave Application', 'Employee Advance', 'Activity Cost', 'Training Event Employee',
-		'Timesheet', 'Sales Person', 'Payroll Employee Detail']
 
-	for doctype in doctypes_to_update:
-		if frappe.db.table_exists(doctype):
-			frappe.db.sql("""
-				update `tab%s` dt
-				set department=(select department from `tabEmployee` where name=dt.employee)
-			""" % doctype)
+	doctypes_to_update = {
+		'hr': ['Appraisal', 'Leave Allocation', 'Expense Claim', 'Salary Slip',
+			'Attendance', 'Training Feedback', 'Training Result Employee','Leave Application',
+			'Employee Advance', 'Training Event Employee', 'Payroll Employee Detail'],
+		'education': ['Instructor'],
+		'projects': ['Activity Cost', 'Timesheet'],
+		'setup': ['Sales Person']
+	}
+
+	for module, doctypes in doctypes_to_update.items():
+		for doctype in doctypes:
+			if frappe.db.table_exists(doctype):
+				frappe.reload_doc(module, 'doctype', frappe.scrub(doctype))
+				frappe.db.sql("""
+					update `tab%s` dt
+					set department=(select department from `tabEmployee` where name=dt.employee)
+				""" % doctype)

--- a/erpnext/selling/doctype/quotation/quotation.json
+++ b/erpnext/selling/doctype/quotation/quotation.json
@@ -3163,7 +3163,7 @@
  "istable": 0, 
  "max_attachments": 1, 
  "menu_index": 0, 
- "modified": "2018-07-06 03:23:15.354674",
+ "modified": "2018-07-17 03:23:15.354674",
  "modified_by": "Administrator",
  "module": "Selling", 
  "name": "Quotation", 

--- a/erpnext/stock/doctype/delivery_note/delivery_note.json
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.json
@@ -3881,7 +3881,7 @@
  "istable": 0, 
  "max_attachments": 0, 
  "menu_index": 0, 
- "modified": "2018-07-06 03:03:35.035396",
+ "modified": "2018-07-17 03:03:35.035396",
  "modified_by": "Administrator", 
  "module": "Stock", 
  "name": "Delivery Note", 

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.json
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.json
@@ -3436,7 +3436,7 @@
  "istable": 0, 
  "max_attachments": 0, 
  "menu_index": 0, 
- "modified": "2018-07-06 02:59:59.609643",
+ "modified": "2018-07-17 02:59:59.609643",
  "modified_by": "Administrator", 
  "module": "Stock", 
  "name": "Purchase Receipt", 


### PR DESCRIPTION
### Log 1
```
Executing erpnext.patches.v11_0.update_total_qty_field in testsite.erpnext(7dd46ce75bace24e)
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 97, in <module>
    main()
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 25, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/commands/site.py", line 222, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/migrate.py", line 39, in migrate
    frappe.modules.patch_handler.run_all()
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 29, in run_all
    if not run_single(patchmodule = patch):
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 63, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 83, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/Users/saurabh/project/frappe-bench/apps/erpnext/erpnext/patches/v11_0/update_total_qty_field.py", line 35, in execute
    ''' % (doctype, " ".join(when_then)))
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/database.py", line 209, in sql
    self._cursor.execute(query)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/pymysql/cursors.py", line 165, in execute
    result = self._query(query)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/pymysql/cursors.py", line 321, in _query
    conn.query(q)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 860, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1061, in _read_query_result
    result.read()
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1349, in read
    first_packet = self.connection._read_packet()
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1018, in _read_packet
    packet.check_error()
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 384, in check_error
    err.raise_mysql_exception(self._data)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/pymysql/err.py", line 107, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.InternalError: (1054, u"Unknown column 'dt.total_qty' in 'field list'")
```

### Log 2:
```
Executing erpnext.patches.v11_0.set_department_for_doctypes in testsite.erpnext (7dd46ce75bace24e)
Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 97, in <module>
    main()
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 25, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/commands/site.py", line 222, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/migrate.py", line 39, in migrate
    frappe.modules.patch_handler.run_all()
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 29, in run_all
    if not run_single(patchmodule = patch):
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 63, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 83, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/Users/saurabh/project/frappe-bench/apps/erpnext/erpnext/patches/v11_0/set_department_for_doctypes.py", line 17, in execute
    """ % doctype)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/database.py", line 209, in sql
    self._cursor.execute(query)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/pymysql/cursors.py", line 165, in execute
    result = self._query(query)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/pymysql/cursors.py", line 321, in _query
    conn.query(q)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 860, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1061, in _read_query_result
    result.read()
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1349, in read
    first_packet = self.connection._read_packet()
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1018, in _read_packet
    packet.check_error()
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 384, in check_error
    err.raise_mysql_exception(self._data)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/pymysql/err.py", line 107, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.InternalError: (1054, u"Unknown column 'department' in 'field list'")
```