### PR TITLE
Gocardless improvement and  payment request correction

### DIFF
--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -226,10 +226,10 @@ class PaymentRequest(Document):
 				success_url = shopping_cart_settings.payment_success_url
 				if success_url:
 					redirect_to = ({
-						"Orders": "orders",
-						"Invoices": "invoices",
-						"My Account": "me"
-					}).get(success_url, "me")
+						"Orders": "/orders",
+						"Invoices": "/invoices",
+						"My Account": "/me"
+					}).get(success_url, "/me")
 				else:
 					redirect_to = get_url("/orders/{0}".format(self.reference_name))
 

--- a/erpnext/erpnext_integrations/doctype/gocardless_settings/gocardless_settings.py
+++ b/erpnext/erpnext_integrations/doctype/gocardless_settings/gocardless_settings.py
@@ -85,7 +85,7 @@ class GoCardlessSettings(Document):
 		return get_url("./integrations/gocardless_checkout?{0}".format(urlencode(kwargs)))
 
 	def create_payment_request(self, data):
-		self.data = frappe._dict(data)
+		self.data = {str(key): str(value) for (key, value) in data.items()}
 
 		try:
 			self.integration_request = create_request_log(self.data, "Host", "GoCardless")
@@ -145,11 +145,11 @@ class GoCardlessSettings(Document):
 
 		if self.flags.status_changed_to == "Completed":
 			status = 'Completed'
-			if self.data.reference_doctype and self.data.reference_docname:
+			if 'reference_doctype' in self.data and 'reference_docname' in self.data:
 				custom_redirect_to = None
 				try:
-					custom_redirect_to = frappe.get_doc(self.data.reference_doctype,
-						self.data.reference_docname).run_method("on_payment_authorized", self.flags.status_changed_to)
+					custom_redirect_to = frappe.get_doc(self.data.get('reference_doctype'),
+						self.data.get('reference_docname')).run_method("on_payment_authorized", self.flags.status_changed_to)
 				except Exception:
 					frappe.log_error(frappe.get_traceback())
 

--- a/erpnext/erpnext_integrations/doctype/gocardless_settings/gocardless_settings.py
+++ b/erpnext/erpnext_integrations/doctype/gocardless_settings/gocardless_settings.py
@@ -85,7 +85,7 @@ class GoCardlessSettings(Document):
 		return get_url("./integrations/gocardless_checkout?{0}".format(urlencode(kwargs)))
 
 	def create_payment_request(self, data):
-		self.data = {str(key): str(value) for (key, value) in data.items()}
+		self.data = frappe._dict(data)
 
 		try:
 			self.integration_request = create_request_log(self.data, "Host", "GoCardless")

--- a/erpnext/templates/pages/integrations/gocardless_checkout.html
+++ b/erpnext/templates/pages/integrations/gocardless_checkout.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {%- block page_content -%}
-<p class='lead text-center centered'>
+<p class='lead text-center'>
 	<span class='gocardless-loading'>{{ _("Loading Payment System") }}</span>
 </p>
 

--- a/erpnext/templates/pages/integrations/gocardless_confirmation.html
+++ b/erpnext/templates/pages/integrations/gocardless_confirmation.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {%- block page_content -%}
-<p class='lead text-center centered'>
+<p class='lead text-center'>
 	<span class='gocardless-loading'>{{ _("Payment Confirmation") }}</span>
 </p>
 


### PR DESCRIPTION
Hi,

This PR provides the ability to create a custom confirmation page for GoCardless (similar to https://github.com/frappe/frappe/pull/5835) instead of the standard one provided by GoCardless.

It also corrects the data format for the creation of the payment request and changes the redirect URL to absolute paths since they can be called from /integrations and lead to a 404 error.

Thanks in advance for your help. 
