### PR TITLE
[fix] format fiscal year docname to proper date before using

### DIFF
--- a/erpnext/accounts/doctype/fiscal_year/fiscal_year.py
+++ b/erpnext/accounts/doctype/fiscal_year/fiscal_year.py
@@ -109,3 +109,14 @@ def auto_create_fiscal_year():
 			new_fy.insert(ignore_permissions=True)
 		except frappe.NameError:
 			pass
+
+def get_from_and_to_date(fiscal_year):
+	from_and_to_date_tuple = frappe.db.sql("""select year_start_date, year_end_date
+		from `tabFiscal Year` where name=%s""", (fiscal_year))[0]
+
+	from_and_to_date = {
+		"from_date": from_and_to_date_tuple[0],
+		"to_date": from_and_to_date_tuple[1]
+	}
+
+	return from_and_to_date

--- a/erpnext/accounts/report/utils.py
+++ b/erpnext/accounts/report/utils.py
@@ -1,7 +1,8 @@
 import frappe
 from erpnext import get_company_currency, get_default_company
 from erpnext.setup.utils import get_exchange_rate
-from frappe.utils import cint
+from erpnext.accounts.doctype.fiscal_year.fiscal_year import get_from_and_to_date
+from frappe.utils import cint, get_datetime_str, formatdate
 
 __exchange_rates = {}
 P_OR_L_ACCOUNTS = list(
@@ -26,7 +27,12 @@ def get_currency(filters):
 	company = get_appropriate_company(filters)
 	company_currency = get_company_currency(company)
 	presentation_currency = filters['presentation_currency'] if filters.get('presentation_currency') else company_currency
-	report_date = filters.get('to_date') or filters.get('to_fiscal_year')
+
+	report_date = filters.get('to_date')
+
+	if not report_date:
+		fiscal_year_to_date = get_from_and_to_date(filters.get('to_fiscal_year')).to_date
+		report_date = formatdate(get_datetime_str(fiscal_year_to_date), "dd-MM-yyyy")
 
 	currency_map = dict(company=company, company_currency=company_currency, presentation_currency=presentation_currency, report_date=report_date)
 
@@ -58,6 +64,7 @@ def get_rate_as_at(date, from_currency, to_currency):
 	:param to_currency: Quote currency
 	:return: Retrieved exchange rate
 	"""
+
 	rate = __exchange_rates.get('{0}-{1}@{2}'.format(from_currency, to_currency, date))
 	if not rate:
 		rate = get_exchange_rate(from_currency, to_currency, date) or 1


### PR DESCRIPTION
Balance Sheet error on setting currency, due to using fiscal year docname instead of date:

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2017-01-23/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2017-01-23/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2017-01-23/apps/frappe/frappe/handler.py", line 55, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2017-01-23/apps/frappe/frappe/__init__.py", line 942, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2017-01-23/apps/frappe/frappe/desk/query_report.py", line 163, in run
    return generate_report_result(report, filters, user)
  File "/home/frappe/benches/bench-2017-01-23/apps/frappe/frappe/desk/query_report.py", line 64, in generate_report_result
    res = frappe.get_attr(method_name)(frappe._dict(filters))
  File "/home/frappe/benches/bench-2017-01-23/apps/erpnext/erpnext/accounts/report/balance_sheet/balance_sheet.py", line 16, in execute
    accumulated_values=filters.accumulated_values)
  File "/home/frappe/benches/bench-2017-01-23/apps/erpnext/erpnext/accounts/report/financial_statements.py", line 146, in get_data
    gl_entries_by_account, ignore_closing_entries=ignore_closing_entries
  File "/home/frappe/benches/bench-2017-01-23/apps/erpnext/erpnext/accounts/report/financial_statements.py", line 357, in set_gl_entries_by_account
    convert_to_presentation_currency(gl_entries, get_currency(filters))
  File "/home/frappe/benches/bench-2017-01-23/apps/erpnext/erpnext/accounts/report/utils.py", line 104, in convert_to_presentation_currency
    converted_value = convert(value, presentation_currency, company_currency, date)
  File "/home/frappe/benches/bench-2017-01-23/apps/erpnext/erpnext/accounts/report/utils.py", line 45, in convert
    rate = get_rate_as_at(date, from_, to)
  File "/home/frappe/benches/bench-2017-01-23/apps/erpnext/erpnext/accounts/report/utils.py", line 63, in get_rate_as_at
    rate = get_exchange_rate(from_currency, to_currency, date) or 1
  File "/home/frappe/benches/bench-2017-01-23/apps/erpnext/erpnext/setup/utils.py", line 89, in get_exchange_rate
    ["date", "<=", get_datetime_str(transaction_date)],
  File "/home/frappe/benches/bench-2017-01-23/apps/frappe/frappe/utils/data.py", line 200, in get_datetime_str
    datetime_obj = get_datetime(datetime_obj)
  File "/home/frappe/benches/bench-2017-01-23/apps/frappe/frappe/utils/data.py", line 63, in get_datetime
    return parser.parse(datetime_str)
  File "/home/frappe/benches/bench-2017-01-23/env/lib/python2.7/site-packages/dateutil/parser.py", line 1168, in parse
    return DEFAULTPARSER.parse(timestr, **kwargs)
  File "/home/frappe/benches/bench-2017-01-23/env/lib/python2.7/site-packages/dateutil/parser.py", line 578, in parse
    if cday > monthrange(cyear, cmonth)[1]:
  File "/usr/lib64/python2.7/calendar.py", line 120, in monthrange
    raise IllegalMonthError(month)
IllegalMonthError: bad month number 2019; must be 1-12
```
