### PR TITLE
[Fix] Showing valuation rate even if incoming rate is set zero

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -346,7 +346,11 @@ class update_entries_after(object):
 		stock_value = sum((flt(batch[0]) * flt(batch[1]) for batch in self.stock_queue))
 		stock_qty = sum((flt(batch[0]) for batch in self.stock_queue))
 
-		if stock_qty:
+		if (not incoming_rate and not outgoing_rate and
+			self.check_if_allow_zero_valuation_rate(sle.voucher_type, sle.voucher_detail_no)):
+			self.valuation_rate = incoming_rate
+
+		elif stock_qty:
 			self.valuation_rate = stock_value / flt(stock_qty)
 
 		if not self.stock_queue:


### PR DESCRIPTION
**Issue**
1. I have item against which there are multiple stock ledger entries present
1. Against same Item, I have created purchase receipt with Incoming Rate as 0 and enabled Allow Zero Valuation Rate.
1.  Still after submission system showing the valuation rate as 12579.8