### PR TITLE
[Enhancement]Creating multiple drop ship purchase orders in one go for sales order with multiple items assigned to different suppliers 

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -413,19 +413,20 @@ erpnext.selling.SalesOrderController = erpnext.selling.SellingController.extend(
 			title: __("For Supplier"),
 			fields: [
 				{"fieldtype": "Link", "label": __("Supplier"), "fieldname": "supplier", "options":"Supplier",
+				 "description": __("Leave the field empty to make purchase orders for all suppliers"),
 					"get_query": function () {
 						return {
 							query:"erpnext.selling.doctype.sales_order.sales_order.get_supplier",
 							filters: {'parent': me.frm.doc.name}
 						}
-					}, "reqd": 1 },
+					}},
+				
 				{"fieldtype": "Button", "label": __("Make Purchase Order"), "fieldname": "make_purchase_order", "cssClass": "btn-primary"},
 			]
 		});
 
 		dialog.fields_dict.make_purchase_order.$input.click(function() {
 			var args = dialog.get_values();
-			if(!args) return;
 			dialog.hide();
 			return frappe.call({
 				type: "GET",
@@ -437,8 +438,17 @@ erpnext.selling.SalesOrderController = erpnext.selling.SellingController.extend(
 				freeze: true,
 				callback: function(r) {
 					if(!r.exc) {
-						var doc = frappe.model.sync(r.message);
-						frappe.set_route("Form", r.message.doctype, r.message.name);
+						// var args = dialog.get_values();
+						if (args.supplier){
+							var doc = frappe.model.sync(r.message);
+							frappe.set_route("Form", r.message.doctype, r.message.name);
+						}
+						else{
+							frappe.route_options = {
+								"sales_order": me.frm.doc.name
+							}
+							frappe.set_route("List", "Purchase Order");
+						}
 					}
 				}
 			})

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -702,12 +702,12 @@ def get_events(start, end, filters=None):
 @frappe.whitelist()
 def make_purchase_order_for_drop_shipment(source_name, for_supplier, target_doc=None):
 	def set_missing_values(source, target):
-		target.supplier = for_supplier
+		target.supplier = supplier
 		target.apply_discount_on = ""
 		target.additional_discount_percentage = 0.0
 		target.discount_amount = 0.0
 
-		default_price_list = frappe.get_value("Supplier", for_supplier, "default_price_list")
+		default_price_list = frappe.get_value("Supplier", supplier, "default_price_list")
 		if default_price_list:
 			target.buying_price_list = default_price_list
 
@@ -737,41 +737,61 @@ def make_purchase_order_for_drop_shipment(source_name, for_supplier, target_doc=
 		target.stock_qty = (flt(source.qty) - flt(source.ordered_qty)) * flt(source.conversion_factor)
 		target.project = source_parent.project
 
-	doclist = get_mapped_doc("Sales Order", source_name, {
-		"Sales Order": {
-			"doctype": "Purchase Order",
-			"field_no_map": [
-				"address_display",
-				"contact_display",
-				"contact_mobile",
-				"contact_email",
-				"contact_person",
-				"taxes_and_charges"
-			],
-			"validation": {
-				"docstatus": ["=", 1]
-			}
-		},
-		"Sales Order Item": {
-			"doctype": "Purchase Order Item",
-			"field_map":  [
-				["name", "sales_order_item"],
-				["parent", "sales_order"],
-				["stock_uom", "stock_uom"],
-				["uom", "uom"],
-				["conversion_factor", "conversion_factor"],
-				["delivery_date", "schedule_date"]
-			],
-			"field_no_map": [
-				"rate",
-				"price_list_rate"
-			],
-			"postprocess": update_item,
-			"condition": lambda doc: doc.ordered_qty < doc.qty and doc.supplier == for_supplier
-		}
-	}, target_doc, set_missing_values)
+	suppliers =[]
+	if for_supplier:
+		suppliers.append(for_supplier)
+	else:
+		sales_order = frappe.get_doc("Sales Order", source_name)
+		for item in sales_order.items:
+			if item.supplier and item.supplier not in suppliers:
+				suppliers.append(item.supplier)
+	for supplier in suppliers:
+		po =frappe.get_list("Purchase Order", filters={"sales_order":source_name, "supplier":supplier, "docstatus": ("<", "2")})
+		if len(po) == 0:
+			doc = get_mapped_doc("Sales Order", source_name, {
+				"Sales Order": {
+					"doctype": "Purchase Order",
+					"field_no_map": [
+						"address_display",
+						"contact_display",
+						"contact_mobile",
+						"contact_email",
+						"contact_person",
+						"taxes_and_charges"
+					],
+					"validation": {
+						"docstatus": ["=", 1]
+					}
+				},
+				"Sales Order Item": {
+					"doctype": "Purchase Order Item",
+					"field_map":  [
+						["name", "sales_order_item"],
+						["parent", "sales_order"],
+						["stock_uom", "stock_uom"],
+						["uom", "uom"],
+						["conversion_factor", "conversion_factor"],
+						["delivery_date", "schedule_date"]
+			 		],
+					"field_no_map": [
+						"rate",
+						"price_list_rate"
+					],
+					"postprocess": update_item,
+					"condition": lambda doc: doc.ordered_qty < doc.qty and doc.supplier == supplier
+				}
+			}, target_doc, set_missing_values)
+			if not for_supplier:
+				doc.insert()
+		else:
+			suppliers =[]
+	if suppliers:
+		if not for_supplier:
+			frappe.db.commit()
+		return doc
+	else:
+		frappe.msgprint(_("PO already created for all sales order items"))
 
-	return doclist
 
 @frappe.whitelist()
 def get_supplier(doctype, txt, searchfield, start, page_len, filters):
@@ -787,6 +807,8 @@ def get_supplier(doctype, txt, searchfield, start, page_len, filters):
 			and ({key} like %(txt)s
 				or supplier_name like %(txt)s)
 			and name in (select supplier from `tabSales Order Item` where parent = %(parent)s)
+			and name not in (select supplier from `tabPurchase Order` po inner join `tabPurchase Order Item` poi
+			     on po.name=poi.parent where po.docstatus<2 and poi.sales_order=%(parent)s)			
 		order by
 			if(locate(%(_txt)s, name), locate(%(_txt)s, name), 99999),
 			if(locate(%(_txt)s, supplier_name), locate(%(_txt)s, supplier_name), 99999),


### PR DESCRIPTION
Refer to issue https://github.com/frappe/erpnext/issues/15031

**Business case**

- Sales order with multi items assigned to different suppliers

**As Is**

- by clicking the create purchase order custom menu item, there is popup window to force user select one supplier, system auto fetch all the data for the new drop ship purchase order and route to the new purchase order screen, waiting for user to further modify the order and click SAVE to create the final draft PO, for each supplier, the above mentioned steps need to be repeated

- if draft purchase orders already created for the supplier, click the create purchase order menu item and select the supplier again, system will create the purchase order again without any error message, only when trying to submit the purchase order, there is limit crossed error!

**To Be**

- Allow user to leave the supplier field empty, system creates multi draft drop ship purchase orders for all suppliers assigned to sales order items
- only the supplier by which the corresponding drop ship purchase orders(draft and submitted) not yet created will be available in the supplier drop down list
![leave supplier empty](https://user-images.githubusercontent.com/12823863/43332974-37ae31f2-91fc-11e8-9dcd-be80ca2ff93d.PNG)
Fig1: Allow user leave the supplier field empty
![dropshiporders](https://user-images.githubusercontent.com/12823863/43332994-3d6fb8ea-91fc-11e8-9afc-6cf3d83f8841.PNG)
Fig2: after multi purchase orders created, route to the list instead of the form view

Please read the pull request checklist to make sure your changes are merged: https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

