### PR TITLE
Delivery Date Change based on Delivery Date change in child table

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.json
+++ b/erpnext/selling/doctype/sales_order/sales_order.json
@@ -388,7 +388,7 @@
   {
    "allow_bulk_edit": 0, 
    "allow_in_quick_entry": 0, 
-   "allow_on_submit": 0, 
+   "allow_on_submit": 1, 
    "bold": 0, 
    "collapsible": 0, 
    "columns": 0, 
@@ -3917,7 +3917,7 @@
  "issingle": 0, 
  "istable": 0, 
  "max_attachments": 0, 
- "modified": "2018-07-30 08:36:11.652659",
+ "modified": "2018-08-01 08:36:11.652659",
  "modified_by": "Administrator", 
  "module": "Selling", 
  "name": "Sales Order", 

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -105,17 +105,19 @@ class SalesOrder(SellingController):
 
 	def validate_delivery_date(self):
 		if self.order_type == 'Sales':
+			delivery_date_list = [d.delivery_date for d in self.get("items") if d.delivery_date]
+			max_delivery_date = max(delivery_date_list) if delivery_date_list else None
 			if not self.delivery_date:
-				delivery_date_list = [d.delivery_date for d in self.get("items") if d.delivery_date]
-				self.delivery_date = max(delivery_date_list) if delivery_date_list else None
+				self.delivery_date = max_delivery_date
 			if self.delivery_date:
 				for d in self.get("items"):
 					if not d.delivery_date:
 						d.delivery_date = self.delivery_date
-
 					if getdate(self.transaction_date) > getdate(d.delivery_date):
 						frappe.msgprint(_("Expected Delivery Date should be after Sales Order Date"),
-							indicator='orange', title=_('Warning'))
+							indicator='orange', title=_('Warning'))		
+				if getdate(self.delivery_date) != getdate(max_delivery_date):
+					self.delivery_date = max_delivery_date
 			else:
 				frappe.throw(_("Please enter Delivery Date"))
 
@@ -302,6 +304,7 @@ class SalesOrder(SellingController):
 		self.validate_po()
 		self.validate_drop_ship()
 		self.validate_supplier_after_submit()
+		self.validate_delivery_date()
 
 	def validate_supplier_after_submit(self):
 		"""Check that supplier is the same after submit if PO is already made"""


### PR DESCRIPTION
- Made Delivery Date allow on submit since Delivery Date in child table is also allowed on submit.
- Based on the delivery date change in childtable, change the delivery date on document too.
- This is necessary to update the Status accordingly.

![q](https://user-images.githubusercontent.com/16913064/43519424-0c5dedb2-95ad-11e8-9e46-0a8a4558b9a0.gif)

Like in this example, if we change the delivery date in childtable, it should change in document too and update status from **Overdue** to **To Delivery and Bill**