### PR TITLE
Test case for contact references

### DIFF
--- a/erpnext/tests/test_search.py
+++ b/erpnext/tests/test_search.py
@@ -1,0 +1,13 @@
+from __future__ import unicode_literals
+import unittest
+import frappe
+from frappe.contacts.address_and_contact import filter_dynamic_link_doctypes
+
+class TestSearch(unittest.TestCase):
+    #Search for the word "clie", part of the word "client" (customer) in french.
+	def test_contact_search_in_foreign_language(self):
+		frappe.local.lang = 'fr'
+		output = filter_dynamic_link_doctypes("DocType", "clie", "name", 0, 20, {'fieldtype': 'HTML', 'fieldname': 'contact_html'})
+
+		result = [['found' for x in y if x=="Customer"] for y in output]
+		self.assertTrue(['found'] in result)

--- a/erpnext/tests/test_search.py
+++ b/erpnext/tests/test_search.py
@@ -4,10 +4,13 @@ import frappe
 from frappe.contacts.address_and_contact import filter_dynamic_link_doctypes
 
 class TestSearch(unittest.TestCase):
-    #Search for the word "clie", part of the word "client" (customer) in french.
+	#Search for the word "clie", part of the word "client" (customer) in french.
 	def test_contact_search_in_foreign_language(self):
 		frappe.local.lang = 'fr'
 		output = filter_dynamic_link_doctypes("DocType", "clie", "name", 0, 20, {'fieldtype': 'HTML', 'fieldname': 'contact_html'})
 
 		result = [['found' for x in y if x=="Customer"] for y in output]
 		self.assertTrue(['found'] in result)
+
+	def tearDown(self):
+		frappe.local.lang = 'en'


### PR DESCRIPTION
Hi,

This PR is the addition of a test case linked to PR: https://github.com/frappe/frappe/pull/5745
The Frappe PR must be merged first for this one to pass Travis' tests.

I'm moving this test to ERPNext since all reference doctypes for a contact are located in ERPNext.

