### PR TITLE
Correction of the get_price method for pricing rules

### DIFF
--- a/erpnext/utilities/product.py
+++ b/erpnext/utilities/product.py
@@ -87,7 +87,8 @@ def get_price(item_code, price_list, customer_group, company, qty=1):
 				"customer_group": customer_group,
 				"company": company,
 				"conversion_rate": 1,
-				"for_shopping_cart": True
+				"for_shopping_cart": True,
+				"currency": frappe.db.get_value("Price List", price_list, "currency")
 			}))
 
 			if pricing_rule:

--- a/erpnext/utilities/product.py
+++ b/erpnext/utilities/product.py
@@ -95,7 +95,7 @@ def get_price(item_code, price_list, customer_group, company, qty=1):
 				if pricing_rule.pricing_rule_for == "Discount Percentage":
 					price[0].price_list_rate = flt(price[0].price_list_rate * (1.0 - (flt(pricing_rule.discount_percentage) / 100.0)))
 
-				if pricing_rule.pricing_rule_for == "Price":
+				if pricing_rule.pricing_rule_for == "Rate":
 					price[0].price_list_rate = pricing_rule.price_list_rate
 
 			price_obj = price[0]


### PR DESCRIPTION
Hi,

I noticed that PR #14004 added a currency filter that is currently missing in the "get_price" utility.
The result is that pricing rules are not applied to prices displayed on the website.

Adding the currency filter, based on the price list solves the issue.

I also changed "Price" to "Rate" as this value has been modified in the Pricing Rule DocType.


Thanks!

