### PR TITLE
[Fix] 'ascii' codec can't encode error in balance sheet report

### DIFF
--- a/erpnext/accounts/report/financial_statements.py
+++ b/erpnext/accounts/report/financial_statements.py
@@ -217,7 +217,7 @@ def prepare_data(accounts, balance_must_be, period_list, company_currency):
 			"year_end_date": year_end_date,
 			"currency": company_currency,
 			"opening_balance": d.get("opening_balance", 0.0) * (1 if balance_must_be=="Debit" else -1),
-			"account_name": ('{} - {}'.format(_(d.account_number), _(d.account_name))
+			"account_name": ('%s - %s' %(_(d.account_number), _(d.account_name))
 				if d.account_number else _(d.account_name))
 		})
 		for period in period_list:


### PR DESCRIPTION
**Issue**
```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.handler.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 55, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 956, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 488, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 168, in run
    return generate_report_result(report, filters, user)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 64, in generate_report_result
    res = frappe.get_attr(method_name)(frappe._dict(filters))
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/report/balance_sheet/balance_sheet.py", line 22, in execute
    accumulated_values=filters.accumulated_values)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/report/financial_statements.py", line 152, in get_data
    out = prepare_data(accounts, balance_must_be, period_list, company_currency)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/report/financial_statements.py", line 221, in prepare_data
    "account_name": ('{} - {}'.format(_(d.account_number), _(d.account_name))
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe9' in position 2: ordinal not in range(128)
```