### PR TITLE
fix throw_overlap_error in Shift Assignment

### DIFF
--- a/erpnext/hr/doctype/shift_assignment/shift_assignment.py
+++ b/erpnext/hr/doctype/shift_assignment/shift_assignment.py
@@ -38,7 +38,7 @@ class ShiftAssignment(Document):
 	def throw_overlap_error(self, d):
 		msg = _("Employee {0} has already applied for {1} on {2} : ").format(self.employee,
 			d['shift_type'], formatdate(d['date'])) \
-			+ """ <b><a href="#Form/Shift Request/{0}">{0}</a></b>""".format(d["name"])
+			+ """ <b><a href="#Form/Shift Assignment/{0}">{0}</a></b>""".format(d["name"])
 		frappe.throw(msg, OverlapError)
 
 @frappe.whitelist()


### PR DESCRIPTION
fix throw_overlap_error in Shift Assignment

throw_overlap_error in shift_assignment.py #15102

