### PR TITLE
[Performance Optimization] Stock balance report

### DIFF
--- a/erpnext/stock/report/stock_balance/stock_balance.js
+++ b/erpnext/stock/report/stock_balance/stock_balance.js
@@ -56,5 +56,13 @@ frappe.query_reports["Stock Balance"] = {
 			"label": __("Show Variant Attributes"),
 			"fieldtype": "Check"
 		},
+		{
+			"fieldname": "by_uom",
+			"lable": __("Select UOM"),
+			"fieldtype": "Select",
+			"width": "80",
+			"options": "Stock UOM\nSales UOM\nPurchase UOM",
+			"default": "Stock UOM"
+		}
 	]
 }

--- a/erpnext/stock/report/stock_balance/stock_balance.py
+++ b/erpnext/stock/report/stock_balance/stock_balance.py
@@ -9,61 +9,21 @@ from erpnext.stock.report.stock_ledger.stock_ledger import get_item_group_condit
 
 from six import iteritems
 
-def execute(filters=None):
+
+def execute(filters = None):
+
 	if not filters: filters = {}
+	# validate_filters(filters)
 
-	validate_filters(filters)
-
-	columns = get_columns()
-	items = get_items(filters)
-	sle = get_stock_ledger_entries(filters, items)
-
-	# if no stock ledger entry found return
-	if not sle:
-		return columns, []
-
-	iwb_map = get_item_warehouse_map(filters, sle)
-	item_map = get_item_details(items, sle, filters)
-	item_reorder_detail_map = get_item_reorder_details(item_map.keys())
-
-	data = []
-	for (company, item, warehouse) in sorted(iwb_map):
-		if item_map.get(item):
-			qty_dict = iwb_map[(company, item, warehouse)]
-			item_reorder_level = 0
-			item_reorder_qty = 0
-			if item + warehouse in item_reorder_detail_map:
-				item_reorder_level = item_reorder_detail_map[item + warehouse]["warehouse_reorder_level"]
-				item_reorder_qty = item_reorder_detail_map[item + warehouse]["warehouse_reorder_qty"]
-
-			report_data = [item, item_map[item]["item_name"],
-				item_map[item]["item_group"],
-				item_map[item]["brand"],
-				item_map[item]["description"], warehouse,
-				item_map[item]["stock_uom"], qty_dict.opening_qty,
-				qty_dict.opening_val, qty_dict.in_qty,
-				qty_dict.in_val, qty_dict.out_qty,
-				qty_dict.out_val, qty_dict.bal_qty,
-				qty_dict.bal_val, qty_dict.val_rate,
-				item_reorder_level,
-				item_reorder_qty,
-				company
-			]
-
-			if filters.get('show_variant_attributes', 0) == 1:
-				variants_attributes = get_variants_attributes()
-				report_data += [item_map[item].get(i) for i in variants_attributes]
-
-			data.append(report_data)
-
-	if filters.get('show_variant_attributes', 0) == 1:
-		columns += ["{}:Data:100".format(i) for i in get_variants_attributes()]
+	columns = get_columns(filters) or []
+	data = get_data(filters) or []
 
 	return columns, data
 
-def get_columns():
+def get_columns(filters):
 	"""return columns"""
 
+	uom = filters.get('by_uom') or 'Stock UOM'
 	columns = [
 		_("Item")+":Link/Item:100",
 		_("Item Name")+"::150",
@@ -71,7 +31,7 @@ def get_columns():
 		_("Brand")+":Link/Brand:90",
 		_("Description")+"::140",
 		_("Warehouse")+":Link/Warehouse:100",
-		_("Stock UOM")+":Link/UOM:90",
+		_(uom)+":Link/UOM:90",
 		_("Opening Qty")+":Float:100",
 		_("Opening Value")+":Float:110",
 		_("In Qty")+":Float:80",
@@ -89,169 +49,90 @@ def get_columns():
 	return columns
 
 def get_conditions(filters):
-	conditions = ""
-	if not filters.get("from_date"):
-		frappe.throw(_("'From Date' is required"))
-
-	if filters.get("to_date"):
-		conditions += " and sle.posting_date <= '%s'" % frappe.db.escape(filters.get("to_date"))
-	else:
-		frappe.throw(_("'To Date' is required"))
-
-	if filters.get("warehouse"):
-		warehouse_details = frappe.db.get_value("Warehouse",
-			filters.get("warehouse"), ["lft", "rgt"], as_dict=1)
-		if warehouse_details:
-			conditions += " and exists (select name from `tabWarehouse` wh \
-				where wh.lft >= %s and wh.rgt <= %s and sle.warehouse = wh.name)"%(warehouse_details.lft,
-				warehouse_details.rgt)
-
-	return conditions
-
-def get_stock_ledger_entries(filters, items):
-	item_conditions_sql = ''
-	if items:
-		item_conditions_sql = ' and sle.item_code in ({})'\
-			.format(', '.join(['"' + frappe.db.escape(i, percent=False) + '"' for i in items]))
-
-	conditions = get_conditions(filters)
-
-	return frappe.db.sql("""
-		select
-			sle.item_code, warehouse, sle.posting_date, sle.actual_qty, sle.valuation_rate,
-			sle.company, sle.voucher_type, sle.qty_after_transaction, sle.stock_value_difference
-		from
-			`tabStock Ledger Entry` sle force index (posting_sort_index)
-		where sle.docstatus < 2 %s %s
-		order by sle.posting_date, sle.posting_time, sle.name""" %
-		(item_conditions_sql, conditions), as_dict=1)
-
-def get_item_warehouse_map(filters, sle):
-	iwb_map = {}
-	from_date = getdate(filters.get("from_date"))
-	to_date = getdate(filters.get("to_date"))
-
-	for d in sle:
-		key = (d.company, d.item_code, d.warehouse)
-		if key not in iwb_map:
-			iwb_map[key] = frappe._dict({
-				"opening_qty": 0.0, "opening_val": 0.0,
-				"in_qty": 0.0, "in_val": 0.0,
-				"out_qty": 0.0, "out_val": 0.0,
-				"bal_qty": 0.0, "bal_val": 0.0,
-				"val_rate": 0.0
-			})
-
-		qty_dict = iwb_map[(d.company, d.item_code, d.warehouse)]
-
-		if d.voucher_type == "Stock Reconciliation":
-			qty_diff = flt(d.qty_after_transaction) - qty_dict.bal_qty
-		else:
-			qty_diff = flt(d.actual_qty)
-
-		value_diff = flt(d.stock_value_difference)
-
-		if d.posting_date < from_date:
-			qty_dict.opening_qty += qty_diff
-			qty_dict.opening_val += value_diff
-
-		elif d.posting_date >= from_date and d.posting_date <= to_date:
-			if qty_diff > 0:
-				qty_dict.in_qty += qty_diff
-				qty_dict.in_val += value_diff
-			else:
-				qty_dict.out_qty += abs(qty_diff)
-				qty_dict.out_val += abs(value_diff)
-
-		qty_dict.val_rate = d.valuation_rate
-		qty_dict.bal_qty += qty_diff
-		qty_dict.bal_val += value_diff
-		
-	iwb_map = filter_items_with_no_transactions(iwb_map)
-
-	return iwb_map
-	
-def filter_items_with_no_transactions(iwb_map):
-	for (company, item, warehouse) in sorted(iwb_map):
-		qty_dict = iwb_map[(company, item, warehouse)]
-		
-		no_transactions = True
-		float_precision = cint(frappe.db.get_default("float_precision")) or 3
-		for key, val in iteritems(qty_dict):
-			val = flt(val, float_precision)
-			qty_dict[key] = val
-			if key != "val_rate" and val:
-				no_transactions = False
-		
-		if no_transactions:
-			iwb_map.pop((company, item, warehouse))
-
-	return iwb_map
-
-def get_items(filters):
 	conditions = []
-	if filters.get("item_code"):
-		conditions.append("item.name=%(item_code)s")
-	else:
-		if filters.get("brand"):
-			conditions.append("item.brand=%(brand)s")
-		if filters.get("item_group"):
-			conditions.append(get_item_group_condition(filters.get("item_group")))
+	if filters.get('brand'):
+		conditions.append(" it.brand = %(brand)s ")
 
-	items = []
-	if conditions:
-		items = frappe.db.sql_list("""select name from `tabItem` item where {}"""
-			.format(" and ".join(conditions)), filters)
-	return items
+	if filters.get('item_group'):
+		conditions.append(""" it.item_group IN (SELECT ig.name
+			FROM `tabItem Group` ig
+			INNER JOIN `tabItem Group` igg on igg.name = %(item_group)s
+			AND ig.lft BETWEEN igg.lft AND igg.rgt
+		)""")
 
-def get_item_details(items, sle, filters):
-	item_details = {}
-	if not items:
-		items = list(set([d.item_code for d in sle]))
 
-	if items:
-		for item in frappe.db.sql("""
-			select name, item_name, description, item_group, brand, stock_uom
-			from `tabItem`
-			where name in ({0}) and ifnull(disabled, 0) = 0
-			""".format(', '.join(['"' + frappe.db.escape(i, percent=False) + '"' for i in items])), as_dict=1):
-				item_details.setdefault(item.name, item)
+	if filters.get('warehouse'):
+		conditions.append("""
+			sle.warehouse in (SELECT wh.name
+		    FROM `tabWarehouse` wh
+		    INNER JOIN `tabWarehouse` whh on whh.name = %(warehouse)s
+		    AND wh.is_group = 0
+		    AND wh.disabled = 0
+		    AND wh.lft BETWEEN whh.lft AND whh.rgt
+		    ORDER BY wh.name)
+		""")
 
-	if filters.get('show_variant_attributes', 0) == 1:
-		variant_values = get_variant_values_for(list(item_details))
-		item_details = {k: v.update(variant_values.get(k, {})) for k, v in iteritems(item_details)}
+	return " AND ".join(conditions)
 
-	return item_details
+def get_join_condition(filters):
 
-def get_item_reorder_details(items):
-	item_reorder_details = frappe._dict()
+	if filters.get('by_uom') == 'Stock UOM':
+		return 'inner join `tabUOM Conversion Detail` uom on uom.parent=it.name and uom.uom=it.stock_uom '
 
-	if items:
-		item_reorder_details = frappe.db.sql("""
-			select parent, warehouse, warehouse_reorder_qty, warehouse_reorder_level
-			from `tabItem Reorder`
-			where parent in ({0})
-		""".format(', '.join(['"' + frappe.db.escape(i, percent=False) + '"' for i in items])), as_dict=1)
+	if filters.get('by_uom') == 'Sales UOM':
+		return 'inner join `tabUOM Conversion Detail` uom on uom.parent=it.name and \
+		((uom.uom=it.sales_uom and IFNULL(it.sales_uom, "") != "") or \
+		(uom.uom=it.stock_uom and IFNULL(it.sales_uom, "") = "")) '
 
-	return dict((d.parent + d.warehouse, d) for d in item_reorder_details)
+	if filters.get('by_uom') == 'Purchase UOM':
+		return 'inner join `tabUOM Conversion Detail` uom on uom.parent=it.name and \
+		((uom.uom=it.purchase_uom and IFNULL(it.purchase_uom, "") != "") or \
+		(uom.uom=it.stock_uom and IFNULL(it.purchase_uom, "") = "")) '
 
-def validate_filters(filters):
-	if not (filters.get("item_code") or filters.get("warehouse")):
-		sle_count = flt(frappe.db.sql("""select count(name) from `tabStock Ledger Entry`""")[0][0])
-		if sle_count > 500000:
-			frappe.throw(_("Please set filter based on Item or Warehouse"))
 
-def get_variants_attributes():
-	'''Return all item variant attributes.'''
-	return [i.name for i in frappe.get_all('Item Attribute')]
+def get_data(filters):
 
-def get_variant_values_for(items):
-	'''Returns variant values for items.'''
-	attribute_map = {}
-	for attr in frappe.db.sql('''select parent, attribute, attribute_value
-		from `tabItem Variant Attribute` where parent in (%s)
-		''' % ", ".join(["%s"] * len(items)), tuple(items), as_dict=1):
-			attribute_map.setdefault(attr['parent'], {})
-			attribute_map[attr['parent']].update({attr['attribute']: attr['attribute_value']})
+	condition_filter = get_conditions(filters) or ''
 
-	return attribute_map
+	if condition_filter:
+		condition_filter = " and " + condition_filter
+
+	join_condition = get_join_condition(filters)
+
+	query = """
+		SELECT sle.item_code
+		,it.item_name
+		,it.item_group
+		,it.brand
+		,it.description
+		,sle.warehouse
+		,sle.stock_uom
+		,SUM( IF(sle.posting_date < %(from_date)s, sle.actual_qty, 0)) as opening_qty
+		,SUM( IF(sle.posting_date < %(from_date)s, sle.stock_value_difference, 0)) as opening_value
+		,SUM( IF(sle.actual_qty > 0 AND sle.posting_date BETWEEN %(from_date)s AND %(to_date)s, (sle.actual_qty/COALESCE(uom.conversion_factor, 1)), 0)) as in_qty
+		,SUM( IF(sle.actual_qty > 0 AND sle.posting_date BETWEEN %(from_date)s AND %(to_date)s, sle.stock_value_difference, 0)) as in_value
+		,SUM( IF(sle.actual_qty < 0 AND sle.posting_date BETWEEN %(from_date)s AND %(to_date)s, abs((sle.actual_qty/COALESCE(uom.conversion_factor, 1))), 0)) as out_qty
+		,SUM( IF(sle.actual_qty < 0 AND sle.posting_date BETWEEN %(from_date)s AND %(to_date)s, abs(sle.stock_value_difference), 0)) as out_value
+		,SUM((sle.actual_qty/COALESCE(uom.conversion_factor, 1))) as balance_qty
+		,SUM(sle.stock_value_difference) as balance_value
+		,bin.valuation_rate
+		,itr.warehouse_reorder_level
+		,itr.warehouse_reorder_qty
+		,sle.company
+		FROM `tabStock Ledger Entry` sle
+		INNER JOIN `tabItem` it
+		ON sle.docstatus = 1
+		AND it.item_code = sle.item_code
+		{condition_filter}
+		{join_condition}
+		INNER JOIN `tabBin` bin
+		on bin.item_code = sle.item_code
+		AND bin.warehouse = sle.warehouse
+		LEFT JOIN `tabItem Reorder` itr
+		ON itr.parent = it.name
+		AND sle.warehouse = itr.warehouse
+		GROUP BY sle.item_code, sle.warehouse
+		HAVING SUM(sle.actual_qty) > 0
+	"""
+
+	return frappe.db.sql(query.format(condition_filter=condition_filter, join_condition=join_condition), filters)

--- a/erpnext/stock/report/stock_balance/stock_balance.py
+++ b/erpnext/stock/report/stock_balance/stock_balance.py
@@ -54,8 +54,8 @@ def get_columns(filters):
 
 def get_conditions(filters):
 	conditions = []
-	if filters.get('brand'):
-		conditions.append(" it.brand = %(brand)s ")
+	if filters.get('item_code'):
+		conditions.append(" it.item_code = %(item_code)s ")
 
 	if filters.get('item_group'):
 		conditions.append(""" it.item_group IN (SELECT ig.name
@@ -109,8 +109,8 @@ def get_data(filters):
 		,it.brand
 		,it.description
 		,sle.warehouse
-		,sle.stock_uom
-		,SUM( IF(sle.posting_date < %(from_date)s, sle.actual_qty, 0)) as opening_qty
+		,uom.uom
+		,SUM( IF(sle.posting_date < %(from_date)s, (sle.actual_qty/COALESCE(uom.conversion_factor, 1)), 0)) as opening_qty
 		,SUM( IF(sle.posting_date < %(from_date)s, sle.stock_value_difference, 0)) as opening_value
 		,SUM( IF(sle.actual_qty > 0 AND sle.posting_date BETWEEN %(from_date)s AND %(to_date)s, (sle.actual_qty/COALESCE(uom.conversion_factor, 1)), 0)) as in_qty
 		,SUM( IF(sle.actual_qty > 0 AND sle.posting_date BETWEEN %(from_date)s AND %(to_date)s, sle.stock_value_difference, 0)) as in_value


### PR DESCRIPTION
Total number of stock ledger entry 289343

Numbers before optimization
```
In [1]: from frappe.utils.data import add_days, today
In [2]: from erpnext.stock.report.stock_balance.stock_balance import execute
In [3]: f = {'from_date': add_days(today(), -7), 'to_date': today(), 'by_uom':'Stock UOM', 'show_variant_attributes':1}
In [4]: from erpnext.stock.report.stock_balance.stock_balance import execute
In [5]: %prun -s cumulative execute(filters=f)

         48067307 function calls (48066159 primitive calls) in 26.716 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.005    0.005   26.716   26.716 <string>:1(<module>)
        1    0.079    0.079   26.711   26.711 stock_balance.py:11(execute)
        1    3.134    3.134   24.061   24.061 stock_balance.py:134(get_item_warehouse_map)
     2265    0.013    0.000   19.992    0.009 database.py:107(sql)
     2265    0.005    0.000   18.044    0.008 cursors.py:146(execute)
     2265    0.005    0.000   18.015    0.008 cursors.py:318(_query)
     2265    0.007    0.000   17.949    0.008 connections.py:851(query)
     2265    0.013    0.000   17.884    0.008 connections.py:1050(_read_query_result)
     2265    0.007    0.000   17.855    0.008 connections.py:1347(read)
        1    0.000    0.000   17.663   17.663 stock_balance.py:117(get_stock_ledger_entries)
```

Numbers after optimization

```
In [1]: from frappe.utils.data import date_diff, add_days, today, get_datetime

In [2]: from erpnext.stock.report.stock_balance.stock_balance import execute

In [3]: f = {'from_date': add_days(today(), -7), 'to_date': today(), 'by_uom':'Stock UOM', 'show_variant_attributes':1}

In [4]: %prun -s cumulative execute(filters=f)

         241857 function calls (241836 primitive calls) in 7.033 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000    7.033    7.033 <string>:1(<module>)
        1    0.000    0.000    7.033    7.033 stock_balance.py:13(execute)
        6    0.000    0.000    7.000    1.167 database.py:107(sql)
        1    0.002    0.002    6.998    6.998 stock_balance.py:96(get_data)
        6    0.000    0.000    6.993    1.166 cursors.py:146(execute)
        6    0.000    0.000    6.993    1.166 cursors.py:318(_query)
        6    0.000    0.000    6.993    1.166 connections.py:851(query)
        6    0.000    0.000    6.993    1.165 connections.py:1050(_read_query_result)
        6    0.000    0.000    6.993    1.165 connections.py:1347(read)
```

Previous code was doing a lot of operation in python code, which is now moved to database overall response time is less but as we can see the database time is high.

Apart from optimization, added feature to show stock in multiple uom, such as stock uom, sales uom or purchase uom this is required because generally there are multiple warehouses
For example a manufacturing company will have main warehouse where all goods are kept as per purchase UOM and then as per the requirement inner UOM are given to RnD, manufacturing unit. so in such scenario there is a need to see stock in different UOM in different warehouse.

By default Stock UOM is selected
![stockuom](https://user-images.githubusercontent.com/13943539/44003565-f643d62c-9e71-11e8-9cab-20ffda98be1e.png)

On Selecting Purchase UOM, if an item Purchase UOM is set then that is selected otherwise it fallback to stock UOM for that item
![screenshot from 2018-08-12 20-49-20](https://user-images.githubusercontent.com/13943539/44003586-344d78d8-9e72-11e8-83d2-8a91e08eb957.png)

as we can see row 2 and 8th UOM is updated as per Purchase UOM and there quantity is updated as per conversion factor, columns header are also updated as per the selected UOM.
