### PR TITLE
Minor bug fix python3 compatibility

### DIFF
--- a/erpnext/setup/doctype/email_digest/email_digest.py
+++ b/erpnext/setup/doctype/email_digest/email_digest.py
@@ -135,7 +135,7 @@ class EmailDigest(Document):
 		notifications = frappe.desk.notifications.get_notifications()
 
 		notifications = sorted(notifications.get("open_count_doctype", {}).items(),
-			lambda a, b: 1 if a[1] < b[1] else -1)
+			cmp=lambda a, b: 1 if a[1] < b[1] else -1)
 
 		notifications = [{"key": n[0], "value": n[1],
 			"link": get_url_to_list(n[0])} for n in notifications if n[1]]

--- a/erpnext/setup/doctype/email_digest/email_digest.py
+++ b/erpnext/setup/doctype/email_digest/email_digest.py
@@ -135,7 +135,7 @@ class EmailDigest(Document):
 		notifications = frappe.desk.notifications.get_notifications()
 
 		notifications = sorted(notifications.get("open_count_doctype", {}).items(),
-			key=lambda a, b: 1 if a[1] < b[1] else -1)
+			key=lambda a: a[1])
 
 		notifications = [{"key": n[0], "value": n[1],
 			"link": get_url_to_list(n[0])} for n in notifications if n[1]]

--- a/erpnext/setup/doctype/email_digest/email_digest.py
+++ b/erpnext/setup/doctype/email_digest/email_digest.py
@@ -135,7 +135,7 @@ class EmailDigest(Document):
 		notifications = frappe.desk.notifications.get_notifications()
 
 		notifications = sorted(notifications.get("open_count_doctype", {}).items(),
-			cmp=lambda a, b: 1 if a[1] < b[1] else -1)
+			key=lambda a, b: 1 if a[1] < b[1] else -1)
 
 		notifications = [{"key": n[0], "value": n[1],
 			"link": get_url_to_list(n[0])} for n in notifications if n[1]]


### PR DESCRIPTION
Fixes the following error:

Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.handler.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1007, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/setup/doctype/email_digest/email_digest.py", line 544, in get_digest_msg
    return frappe.get_doc("Email Digest", name).get_msg_html()
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/setup/doctype/email_digest/email_digest.py", line 88, in get_msg_html
    context.notifications = self.get_notifications()
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/setup/doctype/email_digest/email_digest.py", line 138, in get_notifications
    lambda a, b: 1 if a[1] < b[1] else -1)
TypeError: must use keyword argument for key function