### PR TITLE
Fix account renaming error

### DIFF
--- a/erpnext/accounts/doctype/account/account.py
+++ b/erpnext/accounts/doctype/account/account.py
@@ -207,10 +207,13 @@ def validate_account_number(name, account_number, company):
 @frappe.whitelist()
 def update_account_number(name, account_name, account_number=None):
 
-	account = frappe.db.get_value("Account", name, ["company"], as_dict=True)
+	account = frappe.db.get_value("Account", name, "company", as_dict=True)
+	if not account: return
 	validate_account_number(name, account_number, account.company)
 	if account_number:
 		frappe.db.set_value("Account", name, "account_number", account_number.strip())
+	else:
+		frappe.db.set_value("Account", name, "account_number", "")
 	frappe.db.set_value("Account", name, "account_name", account_name.strip())
 
 	new_name = get_account_autoname(account_number, account_name, account.company)


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2018-08-07/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2018-08-07/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2018-08-07/apps/frappe/frappe/handler.py", line 53, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2018-08-07/apps/frappe/frappe/__init__.py", line 939, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2018-08-07/apps/erpnext/erpnext/accounts/doctype/account/account.py", line 211, in update_account_number
    validate_account_number(name, account_number, account.company)
AttributeError: 'NoneType' object has no attribute 'company'
```