### PR TITLE
[Fix] Consolidated balance sheet report

### DIFF
--- a/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py
+++ b/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py
@@ -47,9 +47,10 @@ def get_balance_sheet_data(fiscal_year, companies, columns, filters):
 	data.extend(asset or [])
 	data.extend(liability or [])
 	data.extend(equity or [])
-	
+
+	company_currency = frappe.db.get_value("Company", filters.company, "default_currency")
 	provisional_profit_loss, total_credit = get_provisional_profit_loss(asset, liability, equity,
-		companies, filters.get('company'), True)
+		companies, filters.get('company'), company_currency, True)
 
 	message, opening_balance = check_opening_balance(asset, liability, equity)
 


### PR DESCRIPTION
**Issue**
```
Traceback (most recent call last):
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.handler.handle()
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/__init__.py", line 1007, in call
    return fn(*args, **newargs)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/__init__.py", line 489, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 169, in run
    return generate_report_result(report, filters, user)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 65, in generate_report_result
    res = frappe.get_attr(method_name)(frappe._dict(filters))
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/erpnext/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py", line 27, in execute
    data, message, chart = get_balance_sheet_data(fiscal_year, companies, columns, filters)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/erpnext/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py", line 52, in get_balance_sheet_data
    companies, filters.get('company'), True)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/erpnext/erpnext/accounts/report/balance_sheet/balance_sheet.py", line 78, in get_provisional_profit_loss
    key = period if consolidated else period.key
AttributeError: 'unicode' object has no attribute 'key'
```