### PR TITLE
Group by Voucher fix in General Ledger Report

### DIFF
--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -109,28 +109,27 @@ def get_result(filters, account_details):
 
 def get_gl_entries(filters):
 	currency_map = get_currency(filters)
-	select_fields = """, sum(debit_in_account_currency) as debit_in_account_currency,
-		sum(credit_in_account_currency) as credit_in_account_currency""" \
+	select_fields = """, debit_in_account_currency,
+		credit_in_account_currency""" \
 
-	group_by_condition = "group by name"
+	order_by_fields = "posting_date, account"
 	if filters.get("group_by") == "Group by Voucher":
-		group_by_condition = "group by voucher_type, voucher_no, account, cost_center"
+		order_by_fields = "posting_date, voucher_type, voucher_no"
 
 	gl_entries = frappe.db.sql(
 		"""
 		select
 			posting_date, account, party_type, party,
-			sum(debit) as debit, sum(credit) as credit,
+			debit, credit,
 			voucher_type, voucher_no, cost_center, project,
 			against_voucher_type, against_voucher, account_currency,
 			remarks, against, is_opening {select_fields}
 		from `tabGL Entry`
 		where company=%(company)s {conditions}
-		{group_by_condition}
-		order by posting_date, account
+		order by {order_by_fields}
 		""".format(
 			select_fields=select_fields, conditions=get_conditions(filters),
-			group_by_condition=group_by_condition
+			order_by_fields=order_by_fields
 		),
 		filters, as_dict=1)
 

--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -192,13 +192,14 @@ def get_data_with_opening_closing(filters, account_details, gl_entries):
 	# Opening for filtered account
 	data.append(totals.opening)
 
-	if filters.get("group_by") in ["Group by Account", "Group by Party"]:
+	if filters.get("group_by"):
 		for acc, acc_dict in iteritems(gle_map):
 			# acc
 			if acc_dict.entries:
 				# opening
 				data.append({})
-				data.append(acc_dict.totals.opening)
+				if filters.get("group_by") != "Group by Voucher":
+					data.append(acc_dict.totals.opening)
 
 				data += acc_dict.entries
 
@@ -206,7 +207,8 @@ def get_data_with_opening_closing(filters, account_details, gl_entries):
 				data.append(acc_dict.totals.total)
 
 				# closing
-				data.append(acc_dict.totals.closing)
+				if filters.get("group_by") != "Group by Voucher":
+					data.append(acc_dict.totals.closing)
 		data.append({})
 
 	else:
@@ -236,10 +238,17 @@ def get_totals_dict():
 		closing = _get_debit_credit_dict(_('Closing (Opening + Total)'))
 	)
 
+def group_by_field(group_by):
+	if group_by == 'Group by Party':
+		return 'party'
+	elif group_by == 'Group by Voucher':
+		return 'voucher_no'
+	else:
+		return 'account'
 
 def initialize_gle_map(gl_entries, filters):
 	gle_map = frappe._dict()
-	group_by = 'party' if filters.get('group_by') == 'Group by Party' else "account"
+	group_by = group_by_field(filters.get('group_by'))
 
 	for gle in gl_entries:
 		gle_map.setdefault(gle.get(group_by), _dict(totals=get_totals_dict(), entries=[]))
@@ -249,7 +258,7 @@ def initialize_gle_map(gl_entries, filters):
 def get_accountwise_gle(filters, gl_entries, gle_map):
 	totals = get_totals_dict()
 	entries = []
-	group_by = 'party' if filters.get('group_by') == 'Group by Party' else "account"
+	group_by = group_by_field(filters.get('group_by'))
 
 	def update_value_in_dict(data, key, gle):
 		data[key].debit += flt(gle.debit)
@@ -270,7 +279,7 @@ def get_accountwise_gle(filters, gl_entries, gle_map):
 		elif gle.posting_date <= to_date:
 			update_value_in_dict(gle_map[gle.get(group_by)].totals, 'total', gle)
 			update_value_in_dict(totals, 'total', gle)
-			if filters.get("group_by") in ["Group by Account", "Group by Party"]:
+			if filters.get("group_by"):
 				gle_map[gle.get(group_by)].entries.append(gle)
 			else:
 				entries.append(gle)


### PR DESCRIPTION
**Problem**: Group by Voucher in General Ledger Report doesn't actually do anything other than grouping the query, which doesn't really have any effect.

I did understand the use of Group By Voucher implemented in ERPNext so I'm assuming it should group voucher's entries together and show their totals. If I'm wrong let me know.

**What needed to be done (in my opinion)**:
* Group by Voucher requires ordering by (posting_date, voucher_type, voucher_no) and does not require grouping the query
* Grouping by 'name' field is not necessary and is the same as not grouping at all so there's no need to group the query
* Show groups of Voucher GL entries with totals at the end (no need for Opening/Closing for voucher groups)

**Some thoughts for the future**:
* The report fetches all entries (without any posting date filter) to get opening balances. Maybe the report should run another query(s) for getting opening balance when necessary into a dict
* When reporting non-grouped or grouped by account with additional filters, the balances should reflect account balances (with opening balances included)

**Screenshot of new Group By Voucher:**
![groupbyvoucher](https://user-images.githubusercontent.com/328330/44325476-58edb300-a472-11e8-80f0-fc0ec1aaca5c.png)

**Screenshot of old Group By Voucher:**
![groupbyvoucherold](https://user-images.githubusercontent.com/328330/44325483-5e4afd80-a472-11e8-879d-a832b8a2bdf8.png)
