### PR TITLE
[fix] Check for existing task before appending to child table in parent task

### DIFF
--- a/erpnext/projects/doctype/task/task.py
+++ b/erpnext/projects/doctype/task/task.py
@@ -141,12 +141,13 @@ class Task(NestedSet):
 	def populate_depends_on(self):
 		if self.parent_task:
 			parent = frappe.get_doc('Task', self.parent_task)
-			parent.append("depends_on", {
-				"doctype": "Task Depends On",
-				"task": self.name,
-				"subject": self.subject
-			})
-			parent.save()
+			if not self.name in [row.task for row in parent.depends_on]:
+				parent.append("depends_on", {
+					"doctype": "Task Depends On",
+					"task": self.name,
+					"subject": self.subject
+				})
+				parent.save()
 
 	def on_trash(self):
 		if check_if_child_exists(self.name):


### PR DESCRIPTION
Currently, the logic does not check if the task already exists in the "Depends on" child table of the parent. On saving a child task multiple times, it will append the same task multiple times. 

**Note : I would actually argue that just because a task has a parent task, doesn't mean that it is a dependency for that parent task. Maybe we should consider removing this entirely**