### PR TITLE
[Fix] Raw materials are not showing in the stock entry if skip transfer is enabled and backflush is based on stock entry

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -666,8 +666,9 @@ class StockEntry(StockController):
 							item["to_warehouse"] = self.pro_doc.wip_warehouse
 					self.add_to_stock_entry_detail(item_dict)
 
-				elif self.work_order and (self.purpose == "Manufacture" or self.purpose == "Material Consumption for Manufacture") and \
-					frappe.db.get_single_value("Manufacturing Settings", "backflush_raw_materials_based_on")== "Material Transferred for Manufacture":
+				elif (self.work_order and (self.purpose == "Manufacture" or self.purpose == "Material Consumption for Manufacture")
+					and not self.pro_doc.skip_transfer and frappe.db.get_single_value("Manufacturing Settings",
+					"backflush_raw_materials_based_on")== "Material Transferred for Manufacture"):
 					self.get_transfered_raw_materials()
 
 				elif self.work_order and (self.purpose == "Manufacture" or self.purpose == "Material Consumption for Manufacture") and \


### PR DESCRIPTION
### Issue
- In Manufacturing Settings set Backflush Raw Materials is based on stock entries
- Enabled Skip Transfer in work order
- When click on finish, system has not pulled the raw materials in the stock entry
![screen shot 2018-08-21 at 6 00 01 pm](https://user-images.githubusercontent.com/8780500/44401526-8a4aa980-a56c-11e8-876b-30bc1d69e3b0.png)


### After Fix

![screen shot 2018-08-21 at 5 59 40 pm](https://user-images.githubusercontent.com/8780500/44401538-96366b80-a56c-11e8-9e6f-e26375fe57e8.png)
