### PR TITLE
Sales invoice creation from sales order correction

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -611,8 +611,8 @@ def make_sales_invoice(source_name, target_doc=None, ignore_permissions=False):
 		if source_parent.project:
 			target.cost_center = frappe.db.get_value("Project", source_parent.project, "cost_center")
 		if not target.cost_center and target.item_code:
-			item = get_item_defaults(target.item_code, target.company)
-			item_group = get_item_group_defaults(target.item_code, target.company)
+			item = get_item_defaults(target.item_code, source_parent.company)
+			item_group = get_item_group_defaults(target.item_code, source_parent.company)
 			target.cost_center = item.get("selling_cost_center") \
 				or item_group.get("selling_cost_center")
 


### PR DESCRIPTION
Hi,

Just a small issue in the code that prevents the creation of a sales invoice from a sales order.

The company is not defined at the child level and should be fetched from the parent document if I'm not mistaken.

Thanks!

