### PR TITLE
fix salary_slip.js

### DIFF
--- a/erpnext/hr/doctype/salary_slip/salary_slip.js
+++ b/erpnext/hr/doctype/salary_slip/salary_slip.js
@@ -126,7 +126,6 @@ var get_emp_and_leave_details = function(doc, dt, dn) {
 }
 
 cur_frm.cscript.employee = function(doc,dt,dn){
-	doc.salary_structure = ''
 	get_emp_and_leave_details(doc, dt, dn);
 }
 


### PR DESCRIPTION
This assignment `doc.salary_structure = ''` causes problem it makes salary_structure value equals to empty string (you can check its value in the browser console after selecting employee) , so when you save the salary slip the salary components will never be recalculated due to this condition [https://github.com/frappe/erpnext/blob/1ff23158995eb6deafe8df0fa4776649da7c8bba/erpnext/hr/doctype/salary_slip/salary_slip.py#L440](url), I figured this out when I created custom field in salary slip which its value is needed to calculate a new component formula and this component hasn't been calculated when I save the salary slip.
![peek 2018-08-22 18-13](https://user-images.githubusercontent.com/24436828/44472942-f1816000-a637-11e8-8037-bf0c92531ad7.gif)



