### PR TITLE
Fix shipping_address for DropShipping

### DIFF
--- a/erpnext/public/js/utils/party.js
+++ b/erpnext/public/js/utils/party.js
@@ -171,7 +171,7 @@ erpnext.utils.validate_mandatory = function(frm, label, value, trigger_on) {
 }
 
 erpnext.utils.get_shipping_address = function(frm, callback){
-	if (frm.doc.company) {
+	if (frm.doc.company && !frm.doc.shipping_address) {
 		frappe.call({
 			method: "frappe.contacts.doctype.address.address.get_shipping_address",
 			args: {


### PR DESCRIPTION
This stretch of javascript go against the address definition for DropShipping.
When we create an PO from SO with dropshipping items, the backend code update fine the shipping address, but this stretch of code, replace the customer address to the Company address.

To reproduce that behavior, pick one sales order with Drop Shipping Items, make and purchase order, and take a look into the delivery address.

Please read the pull request checklist to make sure your changes are merged: https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

