### PR TITLE
Adding "Include UOM" in Reports with Qty and Rates

### DIFF
--- a/erpnext/stock/report/stock_balance/stock_balance.js
+++ b/erpnext/stock/report/stock_balance/stock_balance.js
@@ -52,6 +52,12 @@ frappe.query_reports["Stock Balance"] = {
 			"options": "Warehouse"
 		},
 		{
+			"fieldname":"include_uom",
+			"label": __("Include UOM"),
+			"fieldtype": "Link",
+			"options": "UOM"
+		},
+		{
 			"fieldname": "show_variant_attributes",
 			"label": __("Show Variant Attributes"),
 			"fieldtype": "Check"

--- a/erpnext/stock/report/stock_balance/stock_balance.py
+++ b/erpnext/stock/report/stock_balance/stock_balance.py
@@ -72,25 +72,25 @@ def get_columns():
 	"""return columns"""
 
 	columns = [
-		_("Item")+":Link/Item:100",
-		_("Item Name")+"::150",
-		_("Item Group")+":Link/Item Group:100",
-		_("Brand")+":Link/Brand:90",
-		_("Description")+"::140",
-		_("Warehouse")+":Link/Warehouse:100",
-		_("Stock UOM")+":Link/UOM:90",
+		{"label": _("Item"), "fieldname": "item_code", "fieldtype": "Link", "options": "Item", "width": 100},
+		{"label": _("Item Name"), "fieldname": "item_name", "width": 150},
+		{"label": _("Item Group"), "fieldname": "item_group", "fieldtype": "Link", "options": "Item Group", "width": 100},
+		{"label": _("Brand"), "fieldname": "brand", "fieldtype": "Link", "options": "Brand", "width": 90},
+		{"label": _("Description"), "fieldname": "description", "width": 140},
+		{"label": _("Warehouse"), "fieldname": "warehouse", "fieldtype": "Link", "options": "Warehouse", "width": 100},
+		{"label": _("Stock UOM"), "fieldname": "stock_uom", "fieldtype": "Link", "options": "UOM", "width": 90},
 		{"label": _("Opening Qty"), "fieldname": "opening_qty", "fieldtype": "Float", "width": 100, "convertible": "qty"},
-		_("Opening Value")+":Float:110",
+		{"label": _("Opening Value"), "fieldname": "opening_val", "fieldtype": "Float", "width": 110},
 		{"label": _("In Qty"), "fieldname": "in_qty", "fieldtype": "Float", "width": 80, "convertible": "qty"},
-		_("In Value")+":Float:80",
+		{"label": _("In Value"), "fieldname": "in_val", "fieldtype": "Float", "width": 80},
 		{"label": _("Out Qty"), "fieldname": "out_qty", "fieldtype": "Float", "width": 80, "convertible": "qty"},
-		_("Out Value")+":Float:80",
+		{"label": _("Out Value"), "fieldname": "out_val", "fieldtype": "Float", "width": 80},
 		{"label": _("Balance Qty"), "fieldname": "bal_qty", "fieldtype": "Float", "width": 100, "convertible": "qty"},
-		_("Balance Value")+":Float:100",
+		{"label": _("Balance Value"), "fieldname": "bal_val", "fieldtype": "Currency", "width": 100},
 		{"label": _("Valuation Rate"), "fieldname": "val_rate", "fieldtype": "Currency", "width": 90, "convertible": "rate"},
 		{"label": _("Reorder Level"), "fieldname": "reorder_level", "fieldtype": "Float", "width": 80, "convertible": "qty"},
 		{"label": _("Reorder Qty"), "fieldname": "reorder_qty", "fieldtype": "Float", "width": 80, "convertible": "qty"},
-		_("Company")+":Link/Company:100"
+		{"label": _("Company"), "fieldname": "company", "fieldtype": "Link", "options": "Company", "width": 100}
 	]
 
 	return columns
@@ -217,24 +217,23 @@ def get_item_details(items, sle, filters):
 		items = list(set([d.item_code for d in sle]))
 
 	if items:
+		cf_field = cf_join = ""
+		if filters.get("include_uom"):
+			cf_field = ", ucd.conversion_factor"
+			cf_join = "left join `tabUOM Conversion Detail` ucd on ucd.parent=item.name and ucd.uom=%(include_uom)s"
+
 		for item in frappe.db.sql("""
-			select name, item_name, description, item_group, brand, stock_uom
-			from `tabItem`
-			where name in ({0}) and ifnull(disabled, 0) = 0
-			""".format(', '.join(['"' + frappe.db.escape(i, percent=False) + '"' for i in items])), as_dict=1):
+			select item.name, item.item_name, item.description, item.item_group, item.brand, item.stock_uom{cf_field}
+			from `tabItem` item
+			{cf_join}
+			where item.name in ({names}) and ifnull(item.disabled, 0) = 0
+			""".format(cf_field=cf_field, cf_join=cf_join, names=', '.join(['"' + frappe.db.escape(i, percent=False) + '"' for i in items])),
+			{"include_uom": filters.get("include_uom")}, as_dict=1):
 				item_details.setdefault(item.name, item)
 
 	if filters.get('show_variant_attributes', 0) == 1:
 		variant_values = get_variant_values_for(list(item_details))
 		item_details = {k: v.update(variant_values.get(k, {})) for k, v in iteritems(item_details)}
-
-	if filters.get("include_uom"):
-		for item in frappe.db.sql("""select item.name, ucd.conversion_factor from `tabItem` item
-				inner join `tabUOM Conversion Detail` ucd on ucd.parent=item.name and ucd.uom=%s
-				where item.name in ({0})
-				""".format(', '.join(['"' + frappe.db.escape(i, percent=False) + '"' for i in items])),
-				filters.get("include_uom"), as_dict=1):
-			item_details[item.name].conversion_factor = item.conversion_factor
 
 	return item_details
 

--- a/erpnext/stock/report/stock_balance/stock_balance.py
+++ b/erpnext/stock/report/stock_balance/stock_balance.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 import frappe
 from frappe import _
 from frappe.utils import flt, cint, getdate, now
+from erpnext.stock.utils import update_included_uom_in_report
 from erpnext.stock.report.stock_ledger.stock_ledger import get_item_group_condition
 
 from six import iteritems
@@ -15,7 +16,7 @@ def execute(filters=None):
 	validate_filters(filters)
 
 	include_uom = filters.get("include_uom")
-	columns, qty_columns, rate_columns = get_columns(include_uom)
+	columns = get_columns()
 	items = get_items(filters)
 	sle = get_stock_ledger_entries(filters, items)
 
@@ -27,14 +28,8 @@ def execute(filters=None):
 	item_map = get_item_details(items, sle, filters)
 	item_reorder_detail_map = get_item_reorder_details(item_map.keys())
 
-	def update_converted_qty_rate(row, conversion_factor):
-		if include_uom and conversion_factor:
-			for c in qty_columns:
-				row[c + "_alt"] = flt(row[c] / conversion_factor)
-			for c in rate_columns:
-				row[c + "_alt"] = flt(row[c] * conversion_factor)
-
 	data = []
+	conversion_factors = []
 	for (company, item, warehouse) in sorted(iwb_map):
 		if item_map.get(item):
 			qty_dict = iwb_map[(company, item, warehouse)]
@@ -44,70 +39,61 @@ def execute(filters=None):
 				item_reorder_level = item_reorder_detail_map[item + warehouse]["warehouse_reorder_level"]
 				item_reorder_qty = item_reorder_detail_map[item + warehouse]["warehouse_reorder_qty"]
 
-			report_data = frappe._dict(qty_dict)
-			report_data.company = company
-			report_data.reorder_level = item_reorder_level
-			report_data.reorder_qty = item_reorder_qty
-			report_data.warehouse = warehouse
-			report_data.item_code = item
-			for col in ['item_name', 'description', 'item_group', 'brand', 'stock_uom']:
-				report_data[col] = item_map[item][col]
+			report_data = [item, item_map[item]["item_name"],
+				item_map[item]["item_group"],
+				item_map[item]["brand"],
+				item_map[item]["description"], warehouse,
+				item_map[item]["stock_uom"], qty_dict.opening_qty,
+				qty_dict.opening_val, qty_dict.in_qty,
+				qty_dict.in_val, qty_dict.out_qty,
+				qty_dict.out_val, qty_dict.bal_qty,
+				qty_dict.bal_val, qty_dict.val_rate,
+				item_reorder_level,
+				item_reorder_qty,
+				company
+			]
 
-			update_converted_qty_rate(report_data, item_map[item].get("conversion_factor"))
+			if filters.get('show_variant_attributes', 0) == 1:
+				variants_attributes = get_variants_attributes()
+				report_data += [item_map[item].get(i) for i in variants_attributes]
+
+			if include_uom:
+				conversion_factors.append(item_map[item].conversion_factor)
 
 			data.append(report_data)
 
 	if filters.get('show_variant_attributes', 0) == 1:
-		columns += [{"label": "{}".format(i), "fieldname": "attr_{}".format(i), "fieldtype": "Data", "width": 100}
-			for i in get_variants_attributes()]
+		columns += ["{}:Data:100".format(i) for i in get_variants_attributes()]
 
+	update_included_uom_in_report(columns, data, include_uom, conversion_factors)
 	return columns, data
 
-def get_columns(include_uom=None):
+def get_columns():
 	"""return columns"""
 
 	columns = [
-		{"label": _("Item"), "fieldname": "item_code", "fieldtype": "Link", "options": "Item", "width": 100},
-		{"label": _("Item Name"), "fieldname": "item_name", "width": 150},
-		{"label": _("Item Group"), "fieldname": "item_group", "fieldtype": "Link", "options": "Item Group", "width": 100},
-		{"label": _("Brand"), "fieldname": "brand", "fieldtype": "Link", "options": "Brand", "width": 90},
-		{"label": _("Description"), "fieldname": "description", "width": 140},
-		{"label": _("Warehouse"), "fieldname": "warehouse", "fieldtype": "Link", "options": "Warehouse", "width": 100},
-		{"label": _("Stock UOM"), "fieldname": "stock_uom", "fieldtype": "Link", "options": "UOM", "width": 90},
-		{"label": _("Opening Qty"), "fieldname": "opening_qty", "fieldtype": "Float", "width": 100},
-		{"label": _("Opening Value"), "fieldname": "opening_val", "fieldtype": "Float", "width": 110},
-		{"label": _("In Qty"), "fieldname": "in_qty", "fieldtype": "Float", "width": 80},
-		{"label": _("In Value"), "fieldname": "in_val", "fieldtype": "Float", "width": 80},
-		{"label": _("Out Qty"), "fieldname": "out_qty", "fieldtype": "Float", "width": 80},
-		{"label": _("Out Value"), "fieldname": "out_val", "fieldtype": "Float", "width": 80},
-		{"label": _("Balance Qty"), "fieldname": "bal_qty", "fieldtype": "Float", "width": 100},
-		{"label": _("Balance Value"), "fieldname": "bal_val", "fieldtype": "Currency", "width": 100,
-			"options": "Company:company:default_currency"},
-		{"label": _("Valuation Rate"), "fieldname": "val_rate", "fieldtype": "Currency", "width": 90,
-			"options": "Company:company:default_currency"},
-		{"label": _("Reorder Level"), "fieldname": "reorder_level", "fieldtype": "Float", "width": 80},
-		{"label": _("Reorder Qty"), "fieldname": "reorder_qty", "fieldtype": "Float", "width": 80},
-		{"label": _("Company"), "fieldname": "company", "fieldtype": "Link", "options": "Company", "width": 100}
+		_("Item")+":Link/Item:100",
+		_("Item Name")+"::150",
+		_("Item Group")+":Link/Item Group:100",
+		_("Brand")+":Link/Brand:90",
+		_("Description")+"::140",
+		_("Warehouse")+":Link/Warehouse:100",
+		_("Stock UOM")+":Link/UOM:90",
+		{"label": _("Opening Qty"), "fieldname": "opening_qty", "fieldtype": "Float", "width": 100, "convertible": "qty"},
+		_("Opening Value")+":Float:110",
+		{"label": _("In Qty"), "fieldname": "in_qty", "fieldtype": "Float", "width": 80, "convertible": "qty"},
+		_("In Value")+":Float:80",
+		{"label": _("Out Qty"), "fieldname": "out_qty", "fieldtype": "Float", "width": 80, "convertible": "qty"},
+		_("Out Value")+":Float:80",
+		{"label": _("Balance Qty"), "fieldname": "bal_qty", "fieldtype": "Float", "width": 100, "convertible": "qty"},
+		_("Balance Value")+":Float:100",
+		{"label": _("Valuation Rate"), "fieldname": "val_rate", "fieldtype": "Currency", "width": 90, "convertible": "rate"},
+		{"label": _("Reorder Level"), "fieldname": "reorder_level", "fieldtype": "Float", "width": 80, "convertible": "qty"},
+		{"label": _("Reorder Qty"), "fieldname": "reorder_qty", "fieldtype": "Float", "width": 80, "convertible": "qty"},
+		_("Company")+":Link/Company:100"
 	]
 
-	qty_columns = ["opening_qty", "in_qty", "out_qty", "bal_qty", "reorder_level", "reorder_qty"]
-	rate_columns = ["val_rate"]
-
-	# Insert alternate uom column for each qty column
-	if include_uom:
-		i = len(columns) - 1
-		while i >= 0:
-			if columns[i].get("fieldname") in qty_columns:
-				columns.insert(i + 1, dict(columns[i]))
-				columns[i + 1]['fieldname'] = columns[i + 1]['fieldname'] + "_alt"
-				columns[i + 1]['label'] += " ({})".format(include_uom)
-			elif columns[i].get("fieldname") in rate_columns:
-				columns.insert(i + 1, dict(columns[i]))
-				columns[i + 1]['fieldname'] = columns[i + 1]['fieldname'] + "_alt"
-				columns[i + 1]['label'] += " (per {})".format(include_uom)
-			i -= 1
-
-	return columns, qty_columns, rate_columns
+	return columns
 
 def get_conditions(filters):
 	conditions = ""
@@ -238,18 +224,17 @@ def get_item_details(items, sle, filters):
 			""".format(', '.join(['"' + frappe.db.escape(i, percent=False) + '"' for i in items])), as_dict=1):
 				item_details.setdefault(item.name, item)
 
-	if filters.get("include_uom"):
-		for item in frappe.db.sql("""
-			select item.name, ucd.conversion_factor from `tabItem` item
-			inner join `tabUOM Conversion Detail` ucd on ucd.parent=item.name and ucd.uom=%s
-			where item.name in ({0})
-			""".format(', '.join(['"' + frappe.db.escape(i, percent=False) + '"' for i in items])),
-			filters.get("include_uom"), as_dict=1):
-				item_details[item.name].conversion_factor = item.conversion_factor
-
 	if filters.get('show_variant_attributes', 0) == 1:
 		variant_values = get_variant_values_for(list(item_details))
-		item_details = {item: v.update(variant_values.get(item, {})) for item, v in iteritems(item_details)}
+		item_details = {k: v.update(variant_values.get(k, {})) for k, v in iteritems(item_details)}
+
+	if filters.get("include_uom"):
+		for item in frappe.db.sql("""select item.name, ucd.conversion_factor from `tabItem` item
+				inner join `tabUOM Conversion Detail` ucd on ucd.parent=item.name and ucd.uom=%s
+				where item.name in ({0})
+				""".format(', '.join(['"' + frappe.db.escape(i, percent=False) + '"' for i in items])),
+				filters.get("include_uom"), as_dict=1):
+			item_details[item.name].conversion_factor = item.conversion_factor
 
 	return item_details
 
@@ -282,6 +267,6 @@ def get_variant_values_for(items):
 		from `tabItem Variant Attribute` where parent in (%s)
 		''' % ", ".join(["%s"] * len(items)), tuple(items), as_dict=1):
 			attribute_map.setdefault(attr['parent'], {})
-			attribute_map[attr['parent']].update({"attr_"+attr['attribute']: attr['attribute_value']})
+			attribute_map[attr['parent']].update({attr['attribute']: attr['attribute_value']})
 
 	return attribute_map

--- a/erpnext/stock/report/stock_ledger/stock_ledger.js
+++ b/erpnext/stock/report/stock_ledger/stock_ledger.js
@@ -70,6 +70,12 @@ frappe.query_reports["Stock Ledger"] = {
 			"label": __("Project"),
 			"fieldtype": "Link",
 			"options": "Project"
+		},
+		{
+			"fieldname":"include_uom",
+			"label": __("Include UOM"),
+			"fieldtype": "Link",
+			"options": "UOM"
 		}
 	]
 }

--- a/erpnext/stock/report/stock_ledger/stock_ledger.py
+++ b/erpnext/stock/report/stock_ledger/stock_ledger.py
@@ -4,84 +4,61 @@
 from __future__ import unicode_literals
 import frappe
 from frappe import _
-from frappe.utils import flt
+from erpnext.stock.utils import update_included_uom_in_report
 
 def execute(filters=None):
 	include_uom = filters.get("include_uom")
-	columns, qty_columns, rate_columns = get_columns(include_uom)
+	columns = get_columns()
 	items = get_items(filters)
 	sl_entries = get_stock_ledger_entries(filters, items)
 	item_details = get_item_details(items, sl_entries, include_uom)
-	opening_row = get_opening_balance(filters)
-
-	def update_converted_qty_rate(row, conversion_factor):
-		if include_uom and conversion_factor:
-			for c in qty_columns:
-				row[c + "_alt"] = flt(row[c] / conversion_factor)
-			for c in rate_columns:
-				row[c + "_alt"] = flt(row[c] * conversion_factor)
+	opening_row = get_opening_balance(filters, columns)
 
 	data = []
+	conversion_factors = []
 	if opening_row:
-		update_converted_qty_rate(opening_row, item_details[filters.item_code])
 		data.append(opening_row)
 
 	for sle in sl_entries:
 		item_detail = item_details[sle.item_code]
 
-		sle.incoming_rate = sle.incoming_rate if sle.actual_qty > 0 else 0.0
-		for col in ['item_name', 'description', 'item_group', 'brand', 'stock_uom']:
-			sle[col] = item_detail[col]
+		data.append([sle.date, sle.item_code, item_detail.item_name, item_detail.item_group,
+			item_detail.brand, item_detail.description, sle.warehouse,
+			item_detail.stock_uom, sle.actual_qty, sle.qty_after_transaction,
+			(sle.incoming_rate if sle.actual_qty > 0 else 0.0),
+			sle.valuation_rate, sle.stock_value, sle.voucher_type, sle.voucher_no,
+			sle.batch_no, sle.serial_no, sle.project, sle.company])
 
-		update_converted_qty_rate(sle, item_detail.conversion_factor)
-		data.append(sle)
+		if include_uom:
+			conversion_factors.append(item_detail.conversion_factor)
 
+	update_included_uom_in_report(columns, data, include_uom, conversion_factors)
 	return columns, data
 
-def get_columns(include_uom=None):
+def get_columns():
 	columns = [
-		{"label": _("Date"), "fieldname": "date", "fieldtype": "Datetime", "width": 95},
-		{"label": _("Item"), "fieldname": "item_code", "fieldtype": "Link", "options": "Item", "width": 130},
-		{"label": _("Item Name"), "fieldname": "item_name", "width": 100},
-		{"label": _("Item Group"), "fieldname": "item_group", "fieldtype": "Link", "options": "Item Group", "width": 100},
-		{"label": _("Brand"), "fieldname": "brand", "fieldtype": "Link", "options": "Brand", "width": 100},
-		{"label": _("Description"), "fieldname": "description", "width": 200},
-		{"label": _("Warehouse"), "fieldname": "warehouse", "fieldtype": "Link", "options": "Warehouse", "width": 100},
-		{"label": _("Stock UOM"), "fieldname": "stock_uom", "fieldtype": "Link", "options": "UOM", "width": 100},
-		{"label": _("Qty"), "fieldname": "actual_qty", "fieldtype": "Float", "width": 50},
-		{"label": _("Balance Qty"), "fieldname": "qty_after_transaction", "fieldtype": "Float", "width": 100},
+		_("Date") + ":Datetime:95", _("Item") + ":Link/Item:130",
+		_("Item Name") + "::100", _("Item Group") + ":Link/Item Group:100",
+		_("Brand") + ":Link/Brand:100", _("Description") + "::200",
+		_("Warehouse") + ":Link/Warehouse:100", _("Stock UOM") + ":Link/UOM:100",
+		{"label": _("Qty"), "fieldname": "actual_qty", "fieldtype": "Float", "width": 50, "convertible": "qty"},
+		{"label": _("Balance Qty"), "fieldname": "qty_after_transaction", "fieldtype": "Float", "width": 100, "convertible": "qty"},
 		{"label": _("Incoming Rate"), "fieldname": "incoming_rate", "fieldtype": "Currency", "width": 110,
-			"options": "Company:company:default_currency"},
+			"options": "Company:company:default_currency", "convertible": "rate"},
 		{"label": _("Valuation Rate"), "fieldname": "valuation_rate", "fieldtype": "Currency", "width": 110,
-			"options": "Company:company:default_currency"},
+			"options": "Company:company:default_currency", "convertible": "rate"},
 		{"label": _("Balance Value"), "fieldname": "stock_value", "fieldtype": "Currency", "width": 110,
 			"options": "Company:company:default_currency"},
-		{"label": _("Voucher Type"), "fieldname": "voucher_type", "width": 110},
-		{"label": _("Voucher #"), "fieldname": "voucher_no", "fieldtype": "Dynamic Link", "options": "voucher_type", "width": 100},
-		{"label": _("Batch"), "fieldname": "batch_no", "fieldtype": "Link", "options": "Batch", "width": 100},
-		{"label": _("Serial #"), "fieldname": "serial_no", "fieldtype": "Link", "options": "Serial No", "width": 100},
-		{"label": _("Project"), "fieldname": "project", "fieldtype": "Link", "options": "Project", "width": 100},
-		{"label": _("Company"), "fieldname": "company", "fieldtype": "Link", "options": "Company", "width": 110}
+		_("Voucher Type") + "::110",
+		_("Voucher #") + ":Dynamic Link/" + _("Voucher Type") + ":100",
+		_("Batch") + ":Link/Batch:100",
+		_("Serial #") + ":Link/Serial No:100",
+		_("Project") + ":Link/Project:100",
+		{"label": _("Company"), "fieldtype": "Link", "width": 110,
+			"options": "Company", "fieldname": "company"}
 	]
 
-	qty_columns = ["actual_qty", "qty_after_transaction"]
-	rate_columns = ["incoming_rate", "valuation_rate"]
-
-	# Insert alternate uom column for each qty column
-	if include_uom:
-		i = len(columns)-1
-		while i >= 0:
-			if columns[i].get("fieldname") in qty_columns:
-				columns.insert(i+1, dict(columns[i]))
-				columns[i+1]['fieldname'] = columns[i+1]['fieldname'] + "_alt"
-				columns[i+1]['label'] += " ({})".format(include_uom)
-			elif columns[i].get("fieldname") in rate_columns:
-				columns.insert(i+1, dict(columns[i]))
-				columns[i+1]['fieldname'] = columns[i+1]['fieldname'] + "_alt"
-				columns[i+1]['label'] += " (per {})".format(include_uom)
-			i -= 1
-
-	return columns, qty_columns, rate_columns
+	return columns
 
 def get_stock_ledger_entries(filters, items):
 	item_conditions_sql = ''
@@ -135,11 +112,11 @@ def get_item_details(items, sl_entries, include_uom):
 			item_details.setdefault(item.name, item)
 
 	if include_uom:
-		for item in frappe.db.sql("""
-				select item.name, ucd.conversion_factor from `tabItem` item
+		for item in frappe.db.sql("""select item.name, ucd.conversion_factor from `tabItem` item
 				inner join `tabUOM Conversion Detail` ucd on ucd.parent=item.name and ucd.uom=%s
 				where item.name in ({0})
-				""".format(', '.join(['"' + frappe.db.escape(i, percent=False) + '"' for i in items])), include_uom, as_dict=1):
+				""".format(', '.join(['"' + frappe.db.escape(i, percent=False) + '"' for i in items])), include_uom,
+				as_dict=1):
 			item_details[item.name].conversion_factor = item.conversion_factor
 
 	return item_details
@@ -159,7 +136,7 @@ def get_sle_conditions(filters):
 
 	return "and {}".format(" and ".join(conditions)) if conditions else ""
 
-def get_opening_balance(filters):
+def get_opening_balance(filters, columns):
 	if not (filters.item_code and filters.warehouse and filters.from_date):
 		return
 
@@ -170,10 +147,10 @@ def get_opening_balance(filters):
 		"posting_date": filters.from_date,
 		"posting_time": "00:00:00"
 	})
-	row = frappe._dict()
-	row.item_code = _("'Opening'")
-	for v in ('qty_after_transaction', 'valuation_rate', 'stock_value'):
-		row[v] = last_entry.get(v, 0)
+	row = [""]*len(columns)
+	row[1] = _("'Opening'")
+	for i, v in ((9, 'qty_after_transaction'), (11, 'valuation_rate'), (12, 'stock_value')):
+			row[i] = last_entry.get(v, 0)
 
 	return row
 

--- a/erpnext/stock/report/stock_projected_qty/stock_projected_qty.js
+++ b/erpnext/stock/report/stock_projected_qty/stock_projected_qty.js
@@ -31,6 +31,12 @@ frappe.query_reports["Stock Projected Qty"] = {
 			"label": __("Brand"),
 			"fieldtype": "Link",
 			"options": "Brand"
+		},
+		{
+			"fieldname":"include_uom",
+			"label": __("Include UOM"),
+			"fieldtype": "Link",
+			"options": "UOM"
 		}
 	]
 }

--- a/erpnext/stock/report/stock_projected_qty/stock_projected_qty.py
+++ b/erpnext/stock/report/stock_projected_qty/stock_projected_qty.py
@@ -5,63 +5,18 @@ from __future__ import unicode_literals
 import frappe
 from frappe import _
 from frappe.utils import flt, today
+from erpnext.stock.utils import update_included_uom_in_report
 
 def execute(filters=None):
 	filters = frappe._dict(filters or {})
-	columns, qty_columns = get_columns(filters.get("include_uom"))
-
-	return columns, get_data(filters, qty_columns)
-
-def get_columns(include_uom=None):
-	columns = [
-		{"label": _("Item Code"), "fieldname": "item_code", "fieldtype": "Link", "options": "Item", "width": 140},
-		{"label": _("Item Name"), "fieldname": "item_name", "width": 100},
-		{"label": _("Description"), "fieldname": "description", "width": 200},
-		{"label": _("Item Group"), "fieldname": "item_group", "fieldtype": "Link", "options": "Item Group", "width": 100},
-		{"label": _("Brand"), "fieldname": "brand", "fieldtype": "Link", "options": "Brand", "width": 100},
-		{"label": _("Warehouse"), "fieldname": "warehouse", "fieldtype": "Link", "options": "Warehouse", "width": 120},
-		{"label": _("UOM"), "fieldname": "stock_uom", "fieldtype": "Link", "options": "UOM", "width": 100},
-		{"label": _("Actual Qty"), "fieldname": "actual_qty", "fieldtype": "Float", "width": 100},
-		{"label": _("Planned Qty"), "fieldname": "planned_qty", "fieldtype": "Float", "width": 100},
-		{"label": _("Requested Qty"), "fieldname": "indented_qty", "fieldtype": "Float", "width": 110},
-		{"label": _("Ordered Qty"), "fieldname": "ordered_qty", "fieldtype": "Float", "width": 100},
-		{"label": _("Reserved Qty"), "fieldname": "reserved_qty", "fieldtype": "Float", "width": 100},
-		{"label": _("Reserved Qty for Production"), "fieldname": "reserved_qty_for_production", "fieldtype": "Float", "width": 100},
-		{"label": _("Reserved for sub contracting"), "fieldname": "reserved_qty_for_sub_contract", "fieldtype": "Float", "width": 100},
-		{"label": _("Projected Qty"), "fieldname": "projected_qty", "fieldtype": "Float", "width": 100},
-		{"label": _("Reorder Level"), "fieldname": "re_order_level", "fieldtype": "Float", "width": 100},
-		{"label": _("Reorder Qty"), "fieldname": "re_order_qty", "fieldtype": "Float", "width": 100},
-		{"label": _("Shortage Qty"), "fieldname": "shortage_qty", "fieldtype": "Float", "width": 100}
-	]
-
-	qty_columns = ["actual_qty", "planned_qty", "indented_qty", "ordered_qty", "reserved_qty",
-		"reserved_qty_for_production", "reserved_qty_for_sub_contract", "projected_qty", "re_order_level",
-		"re_order_level", "shortage_qty"]
-
-	# Insert alternate uom column for each qty column
-	if include_uom:
-		i = len(columns) - 1
-		while i >= 0:
-			if columns[i].get("fieldname") in qty_columns:
-				columns.insert(i + 1, dict(columns[i]))
-				columns[i + 1]['fieldname'] = columns[i + 1]['fieldname'] + "_alt"
-				columns[i + 1]['label'] += " ({})".format(include_uom)
-			i -= 1
-
-	return columns, qty_columns
-
-def get_data(filters, qty_columns):
 	include_uom = filters.get("include_uom")
+	columns = get_columns()
 	bin_list = get_bin_list(filters)
 	item_map = get_item_map(filters.get("item_code"), include_uom)
+
 	warehouse_company = {}
 	data = []
-
-	def update_converted_qty_rate(row, conversion_factor):
-		if include_uom and conversion_factor:
-			for c in qty_columns:
-				row[c + "_alt"] = flt(row[c] / conversion_factor)
-
+	conversion_factors = []
 	for bin in bin_list:
 		item = item_map.get(bin.item_code)
 
@@ -88,18 +43,40 @@ def get_data(filters, qty_columns):
 
 		shortage_qty = re_order_level - flt(bin.projected_qty) if (re_order_level or re_order_qty) else 0
 
-		row = frappe._dict(bin)
-		row.re_order_level = re_order_level
-		row.re_order_qty = re_order_qty
-		row.shortage_qty = shortage_qty
-		for col in ['item_name', 'description', 'item_group', 'brand', 'stock_uom']:
-			row[col] = item[col]
+		data.append([item.name, item.item_name, item.description, item.item_group, item.brand, bin.warehouse,
+			item.stock_uom, bin.actual_qty, bin.planned_qty, bin.indented_qty, bin.ordered_qty,
+			bin.reserved_qty, bin.reserved_qty_for_production, bin.reserved_qty_for_sub_contract,
+			bin.projected_qty, re_order_level, re_order_qty, shortage_qty])
 
-		update_converted_qty_rate(row, item.get("conversion_factor"))
+		if include_uom:
+			conversion_factors.append(item.conversion_factor)
 
-		data.append(row)
+	update_included_uom_in_report(columns, data, include_uom, conversion_factors)
+	return columns, data
 
-	return data
+def get_columns():
+	return [
+		_("Item Code") + ":Link/Item:140",
+		_("Item Name") + "::100",
+		_("Description") + "::200",
+		_("Item Group") + ":Link/Item Group:100",
+		_("Brand") + ":Link/Brand:100",
+		_("Warehouse") + ":Link/Warehouse:120",
+		_("UOM") + ":Link/UOM:100",
+		{"label": _("Actual Qty"), "fieldname": "actual_qty", "fieldtype": "Float", "width": 100, "convertible": "qty"},
+		{"label": _("Planned Qty"), "fieldname": "planned_qty", "fieldtype": "Float", "width": 100, "convertible": "qty"},
+		{"label": _("Requested Qty"), "fieldname": "indented_qty", "fieldtype": "Float", "width": 110, "convertible": "qty"},
+		{"label": _("Ordered Qty"), "fieldname": "ordered_qty", "fieldtype": "Float", "width": 100, "convertible": "qty"},
+		{"label": _("Reserved Qty"), "fieldname": "reserved_qty", "fieldtype": "Float", "width": 100, "convertible": "qty"},
+		{"label": _("Reserved Qty for Production"), "fieldname": "reserved_qty_for_production", "fieldtype": "Float",
+			"width": 100, "convertible": "qty"},
+		{"label": _("Reserved for sub contracting"), "fieldname": "reserved_qty_for_sub_contract", "fieldtype": "Float",
+			"width": 100, "convertible": "qty"},
+		{"label": _("Projected Qty"), "fieldname": "projected_qty", "fieldtype": "Float", "width": 100, "convertible": "qty"},
+		{"label": _("Reorder Level"), "fieldname": "re_order_level", "fieldtype": "Float", "width": 100, "convertible": "qty"},
+		{"label": _("Reorder Qty"), "fieldname": "re_order_qty", "fieldtype": "Float", "width": 100, "convertible": "qty"},
+		{"label": _("Shortage Qty"), "fieldname": "shortage_qty", "fieldtype": "Float", "width": 100, "convertible": "qty"}
+	]
 
 def get_bin_list(filters):
 	conditions = []
@@ -129,9 +106,7 @@ def get_item_map(item_code, include_uom):
 	if item_code:
 		condition = 'and item_code = "{0}"'.format(frappe.db.escape(item_code, percent=False))
 
-	items = frappe.db.sql("""
-		select item.name, item.item_name, item.description, item.item_group, item.brand, item.stock_uom
-		from `tabItem` item
+	items = frappe.db.sql("""select * from `tabItem` item
 		where is_stock_item = 1
 		and disabled=0
 		{condition}
@@ -156,8 +131,7 @@ def get_item_map(item_code, include_uom):
 		item_map[item.name] = item
 
 	if include_uom:
-		for item in frappe.db.sql("""
-				select item.name, ucd.conversion_factor from `tabItem` item
+		for item in frappe.db.sql("""select item.name, ucd.conversion_factor from `tabItem` item
 				inner join `tabUOM Conversion Detail` ucd on ucd.parent=item.name and ucd.uom=%s
 				where item.name in ({0})
 				""".format(', '.join(['"' + frappe.db.escape(i.name, percent=False) + '"' for i in items])),

--- a/erpnext/stock/utils.py
+++ b/erpnext/stock/utils.py
@@ -254,29 +254,28 @@ def update_included_uom_in_report(columns, result, include_uom, conversion_facto
 		return
 
 	convertible_cols = {}
-	for iCol in reversed(range(0, len(columns))):
-		col = columns[iCol]
+	for col_idx in reversed(range(0, len(columns))):
+		col = columns[col_idx]
 		if isinstance(col, dict) and col.get("convertible") in ['rate', 'qty']:
-			convertible_cols[iCol] = col['convertible']
-			del col['convertible']
-			columns.insert(iCol+1, col.copy())
-			columns[iCol+1]['fieldname'] += "_alt"
-			if convertible_cols[iCol] == 'rate':
-				columns[iCol+1]['label'] += " (per {})".format(include_uom)
+			convertible_cols[col_idx] = col['convertible']
+			columns.insert(col_idx+1, col.copy())
+			columns[col_idx+1]['fieldname'] += "_alt"
+			if convertible_cols[col_idx] == 'rate':
+				columns[col_idx+1]['label'] += " (per {})".format(include_uom)
 			else:
-				columns[iCol+1]['label'] += " ({})".format(include_uom)
+				columns[col_idx+1]['label'] += " ({})".format(include_uom)
 
-	for iRow, row in enumerate(result):
+	for row_idx, row in enumerate(result):
 		new_row = []
-		for iCol, d in enumerate(row):
+		for col_idx, d in enumerate(row):
 			new_row.append(d)
-			if iCol in convertible_cols:
-				if conversion_factors[iRow]:
-					if convertible_cols[iCol] == 'rate':
-						new_row.append(flt(d) * conversion_factors[iRow])
+			if col_idx in convertible_cols:
+				if conversion_factors[row_idx]:
+					if convertible_cols[col_idx] == 'rate':
+						new_row.append(flt(d) * conversion_factors[row_idx])
 					else:
-						new_row.append(flt(d) / conversion_factors[iRow])
+						new_row.append(flt(d) / conversion_factors[row_idx])
 				else:
 					new_row.append(None)
 
-		result[iRow] = new_row
+		result[row_idx] = new_row


### PR DESCRIPTION
**Problem**: Stock reports only show in stock UOM and does not show other UOMs
**Solution**: Include a filter field "Include UOM" and add extra columns for converted rate and qty columns using conversion_factor

**Thoughts for the future**: Maybe use MultiSelect for Include UOM field.
**Missing out on**: Due to the complexity of getting conversion_factors from UOM Conversion Factor DocType, I did not consider those conversion factors. Should the reports also convert using UOM Conversion Factor?

**Implemented on reports**: Stock Ledger, Stock Balance, Stock Projected Qty 
**Further implementation**: Since qty and rate fields are included in many reports, I will continue updating reports to include the "Include UOM" field whenever the need arises. I would encourage the community to update the rest of the reports.