### PR TITLE
Change accumulated_depreciation_account filter to be depends on account type

### DIFF
--- a/erpnext/assets/doctype/asset_category/asset_category.js
+++ b/erpnext/assets/doctype/asset_category/asset_category.js
@@ -22,7 +22,7 @@ frappe.ui.form.on('Asset Category', {
 			var d  = locals[cdt][cdn];
 			return {
 				"filters": {
-					"root_type": "Asset",
+					"account_type": "Accumulated Depreciation",
 					"is_group": 0,
 					"company": d.company_name
 				}


### PR DESCRIPTION
change accumulated_depreciation_account filter to be depends on account type because accumulated depreciation accounts could be under Liability root type 