### PR TITLE
Validate Completed Qty and Produced qty in Stock Entry for Manufacture

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -58,6 +58,7 @@ class StockEntry(StockController):
 		self.validate_with_material_request()
 		self.validate_batch()
 		self.validate_inspection()
+		self.validate_fg_completed_qty()
 
 		if not self.from_bom:
 			self.fg_completed_qty = 0.0
@@ -184,6 +185,13 @@ class StockEntry(StockController):
 						if req_items:
 							if stock_qty > trans_qty:
 								item_code.append(item.item_code)
+
+	def validate_fg_completed_qty(self):
+		if self.purpose == "Manufacture" and self.work_order:
+			production_item = frappe.get_value('Work Order', self.work_order, 'production_item')
+			for item in self.items:
+				if item.item_code == production_item and item.qty != self.fg_completed_qty:
+					frappe.throw(_("Finished product quantity <b>{0}</b> and For Quantity <b>{1}</b> cannot be different").format(item.qty, self.fg_completed_qty))
 
 	def validate_warehouse(self):
 		"""perform various (sometimes conditional) validations on warehouse"""


### PR DESCRIPTION
Issue:
"For Quantity" must be same Qty as in the finish product in the Stock Entry Detail.

<img width="850" alt="screen shot 2018-08-29 at 3 28 26 pm" src="https://user-images.githubusercontent.com/16913064/44780721-35c4b100-aba0-11e8-8a65-d019a53772cf.png">

Solution:
Added validation if qty is different
<img width="1121" alt="screen shot 2018-08-29 at 3 22 21 pm" src="https://user-images.githubusercontent.com/16913064/44780768-58ef6080-aba0-11e8-92b5-aaa93ef48c52.png">
