### PR TITLE
Disallow renaming of root accounts

### DIFF
--- a/erpnext/accounts/doctype/account/account.js
+++ b/erpnext/accounts/doctype/account/account.js
@@ -47,18 +47,6 @@ frappe.ui.form.on('Account', {
 			// show / hide convert buttons
 			frm.trigger('add_toolbar_buttons');
 		}
-
-		if(!frm.doc.__islocal) {
-			frm.add_custom_button(__('Update Account Name / Number'), function () {
-				frm.trigger("update_account_number");
-			});
-		}
-
-		if(!frm.doc.__islocal) {
-			frm.add_custom_button(__('Merge Account'), function () {
-				frm.trigger("merge_account");
-			});
-		}
 	},
 	account_type: function (frm) {
 		if (frm.doc.is_group == 0) {
@@ -67,6 +55,12 @@ frappe.ui.form.on('Account', {
 		}
 	},
 	add_toolbar_buttons: function(frm) {
+		frm.add_custom_button(__('Update Account Name / Number'), function () {
+			frm.trigger("update_account_number");
+		});
+		frm.add_custom_button(__('Merge Account'), function () {
+			frm.trigger("merge_account");
+		});
 		frm.add_custom_button(__('Chart of Accounts'),
 			function () { frappe.set_route("Tree", "Account"); });
 


### PR DESCRIPTION
Hide rename and merge account buttons for root accounts.

<img width="1207" alt="screen shot 2018-08-29 at 4 41 55 pm" src="https://user-images.githubusercontent.com/17617465/44784385-1f702280-abab-11e8-8ebe-2175373d96ff.png">
