### PR TITLE
[py3] Convert filter object to list

### DIFF
--- a/erpnext/hr/doctype/upload_attendance/upload_attendance.py
+++ b/erpnext/hr/doctype/upload_attendance/upload_attendance.py
@@ -98,7 +98,7 @@ def upload():
 	from frappe.modules import scrub
 
 	rows = read_csv_content_from_uploaded_file()
-	rows = filter(lambda x: x and any(x), rows)
+	rows = list(filter(lambda x: x and any(x), rows))
 	if not rows:
 		msg = [_("Please select a csv file")]
 		return {"messages": msg, "error": msg}

--- a/erpnext/setup/doctype/email_digest/email_digest.py
+++ b/erpnext/setup/doctype/email_digest/email_digest.py
@@ -45,8 +45,8 @@ class EmailDigest(Document):
 		# send email only to enabled users
 		valid_users = [p[0] for p in frappe.db.sql("""select name from `tabUser`
 			where enabled=1""")]
-		recipients = filter(lambda r: r in valid_users,
-			self.recipient_list.split("\n"))
+		recipients = list(filter(lambda r: r in valid_users,
+			self.recipient_list.split("\n")))
 
 		original_user = frappe.session.user
 

--- a/erpnext/setup/doctype/naming_series/naming_series.py
+++ b/erpnext/setup/doctype/naming_series/naming_series.py
@@ -49,7 +49,7 @@ class NamingSeries(Document):
 		}
 
 	def scrub_options_list(self, ol):
-		options = filter(lambda x: x, [cstr(n).strip() for n in ol])
+		options = list(filter(lambda x: x, [cstr(n).strip() for n in ol]))
 		return options
 
 	def update_series(self, arg=None):

--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -61,7 +61,7 @@ class StockReconciliation(StockController):
 					- flt(qty, item.precision("qty")) * flt(rate, item.precision("valuation_rate")))
 				return True
 
-		items = filter(lambda d: _changed(d), self.items)
+		items = list(filter(lambda d: _changed(d), self.items))
 
 		if not items:
 			frappe.throw(_("None of the items have any change in quantity or value."),


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 123, in uploadfile
    ret = method()
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/hr/doctype/upload_attendance/upload_attendance.py", line 105, in upload
    columns = [scrub(f) for f in rows[4]]
TypeError: 'filter' object is not subscriptable
```