### PR TITLE
[fix] email digest date range problem

### DIFF
--- a/erpnext/setup/doctype/email_digest/email_digest.py
+++ b/erpnext/setup/doctype/email_digest/email_digest.py
@@ -340,14 +340,11 @@ class EmailDigest(Document):
 		balance = past_balance = 0.0
 		count = 0
 		for account in accounts:
-			balance += (get_balance_on(account, date = self.future_to_date)
-				- get_balance_on(account, date = self.future_from_date - timedelta(days=1)))
+			balance += get_balance_on(account, date = self.future_to_date)
 
-			count += (get_count_on(account,fieldname, date = self.future_to_date )
-				- get_count_on(account,fieldname, date = self.future_from_date - timedelta(days=1)))
+			count += get_count_on(account,fieldname, date = self.future_to_date)
 
-			past_balance += (get_balance_on(account, date = self.past_to_date)
-				- get_balance_on(account, date = self.past_from_date - timedelta(days=1)))
+			past_balance += get_balance_on(account, date = self.past_to_date)
 
 		return balance, past_balance, count
 


### PR DESCRIPTION
**Email Digest tested on Monthly, Weekly and Daily summary across Fiscal Years**

To test it I have used current fiscal year 01-07-2018 to 30-06-2019 and I made one sales invoice of tests on June-18 and one sales invoice in July 2018 (same invoice amounts, but one for last fiscal year and one for current fiscal year).

The example make was Monthly Summary values were expected only from July 2018, but then I got the wrong results for “New Income” like the amount of July 2018 subtracting everything in the past fiscal year (June 2018). So, the result was zero:

![image](https://user-images.githubusercontent.com/14797383/44962437-b95f0480-aef6-11e8-8dc3-01a8b6d3ce9a.png)

**AFTER FIX:**

After fix it shows correctly just amounts for this financial year, in this case only the invoice I made in July 2018 is showing. For Weekly and Daily Summaries occurs the same error.

![image](https://user-images.githubusercontent.com/14797383/44962439-c54ac680-aef6-11e8-8dad-4e62df8ecd18.png)


