### PR TITLE
Allow for 0 valuation rate in Stock Reconciliation

### DIFF
--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -109,7 +109,7 @@ class StockReconciliation(StockController):
 				self.validation_messages.append(_get_msg(row_num,
 					_("Negative Valuation Rate is not allowed")))
 
-			if row.qty and not row.valuation_rate:
+			if row.qty and row.valuation_rate in ["", None]:
 				row.valuation_rate = get_stock_balance(row.item_code, row.warehouse,
 							self.posting_date, self.posting_time, with_valuation_rate=True)[1]
 				if not row.valuation_rate:


### PR DESCRIPTION
Currently, a valuation rate of 0 gets treated the same as an omitted
valuation rate, and gets overwritten during validation. This hotfix
allows a Stock Reconciliation Item's valuation rate to be set to 0.

Please read the pull request checklist to make sure your changes are merged: https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

Pull-Request

[X] Have you followed the guidelines in our Contributing document?
[X] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
[X] Have you linted your code locally prior to submission?
[X] Have you successfully run tests with your changes locally?
[X] Does your commit message have an explanation for your changes and why you'd like us to include them?
Did you modify the existing test cases? If yes, why?
No
What type of a PR is this?
Bug Fix
