### PR TITLE
[Fix] Meta object has no attribute permissions

### DIFF
--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -631,15 +631,10 @@ $.extend(erpnext.item, {
 				.on('input', function(e) {
 					var term = e.target.value;
 					frappe.call({
-						method:"frappe.client.get_list",
+						method:"erpnext.stock.doctype.item.item.get_item_attribute",
 						args:{
-							doctype:"Item Attribute Value",
-							filters: [
-								["parent","=", i],
-								["attribute_value", "like", term + "%"]
-							],
-							fields: ["attribute_value"],
-							parent: "Item"
+							parent: i,
+							attribute_value: term
 						},
 						callback: function(r) {
 							if (r.message) {

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -978,3 +978,11 @@ def get_uom_conv_factor(uom, stock_uom):
 				value = flt(uom_stock.value) * 1/flt(uom_row.value)
 
 	return value
+
+@frappe.whitelist()
+def get_item_attribute(parent, attribute_value=''):
+	if not frappe.has_permission("Item"):
+		frappe.msgprint(_("No Permission"), raise_exception=1)
+
+	return frappe.get_all("Item Attribute Value", fields = ["attribute_value"],
+		filters = {'parent': parent, 'attribute_value': ("like", "%%%s%%" % attribute_value)})


### PR DESCRIPTION
Issue
```

Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/Traceback (m app.py", line 62, in application
    response = frappe.handler.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 57, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1007, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/client.py", line 35, in get_list
    limit_start=limit_start, limit_page_length=limit_page_length, ignore_permissions=False)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1235, in get_list
    return frappe.model.db_query.DatabaseQuery(doctype).execute(None, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/db_query.py", line 87, in execute
    result = self.build_and_run()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/db_query.py", line 99, in build_and_run
    args = self.prepare_args()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/db_query.py", line 118, in prepare_args
    self.build_conditions()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/db_query.py", line 292, in build_conditions
    match_conditions = self.build_match_conditions()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/db_query.py", line 438, in build_match_conditions
    role_permissions = frappe.permissions.get_role_permissions(meta, user=self.user)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/permissions.py", line 164, in get_role_permissions
    applicable_permissions = list(filter(is_perm_applicable, doctype_meta.permissions))
AttributeError: 'Meta' object has no attribute 'permissions'
```