### PR TITLE
[Minor] [Hotfix] UOM & Stock UOM print hide fix

### DIFF
--- a/erpnext/templates/print_formats/includes/item_table_qty.html
+++ b/erpnext/templates/print_formats/includes/item_table_qty.html
@@ -1,4 +1,6 @@
-{% if (doc.stock_uom and not doc.is_print_hide("stock_uom")) or (doc.uom and not doc.is_print_hide("uom")) -%}
-<small class="pull-left">{{ _(doc.uom or doc.stock_uom) }}</small>
+{% if (doc.uom and not doc.is_print_hide("uom")) %}
+	<small class="pull-left">{{ _(doc.uom) }}</small>
+{% elif (doc.stock_uom and not doc.is_print_hide("stock_uom")) %}
+	<small class="pull-left">{{ _(doc.stock_uom) }}</small>
 {%- endif %}
 {{ doc.get_formatted("qty", doc) }}


### PR DESCRIPTION
Even if print_hide for UOM was enabled, in print view along with quantity 'uom' was being concatenated because of the or logic