### PR TITLE
[New Feature]Scan Item Barcode label to quick create/update records in items child table

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -256,10 +256,10 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 			}
 			else{
 				this.frm.$wrapper.find('.field_barcode') && this.frm.$wrapper.find('.field_barcode').remove();
-		    }
+			}
 	      }
 	},
-	
+
 	scan_barcode: function(e){
 		var barcode = e.target.value;
 		if (barcode){

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -313,7 +313,7 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 				}
 			});
 			e.target.value="";
-	    }
+		}
 		return false;
 	},
 

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -222,15 +222,95 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 			this.setup_item_selector();
 		}
 	},
-
 	refresh: function() {
 		erpnext.toggle_naming_series();
 		erpnext.hide_company();
 		this.set_dynamic_labels();
 		this.setup_sms();
 		this.setup_quality_inspection();
+		this.setup_barcode_scan();
+		this.frm.$wrapper.find('div.frappe-control.field_barcode p.help-box').text('');
 	},
-
+	setup_barcode_scan: function(){
+	      var field_items = this.frm.fields_dict["items"];
+	      console.log('called scan barcode');
+ 	      if  (field_items) {
+		    var grid = field_items.grid;
+		    var display_status = frappe.perm.get_field_display_status(grid.df, grid.frm.doc, grid.perm);
+		    if (frappe.meta.get_field(grid.doctype,'item_code') && frappe.meta.get_field(grid.doctype,'qty') &&
+			(this.frm.doc.__islocal || display_status == 'Write')){
+			if (!this.frm.$wrapper.find('.field_barcode')[0]){
+				 var field_barcode = frappe.ui.form.make_control({
+					df: {fieldtype:"Data", label:__("  Scan Barcode"), fieldname:"scan_barcode"},
+					parent: "<div></div>",
+					change: this.scan_barcode,
+					render_input:true
+				});			         
+				field_barcode.$wrapper.addClass('field_barcode col-sm-6');			  	
+			        this.frm.fields_dict["items"].$wrapper.parents('div.section-body').prepend(field_barcode.wrapper);
+			}
+			else{
+				this.frm.$wrapper.find('div.frappe-control.field_barcode p.help-box').text('');//after save and submit, remove the description
+			}
+		    }
+		    else{
+			this.frm.$wrapper.find('.field_barcode') && this.frm.$wrapper.find('.field_barcode').remove();
+		    }
+	      }
+	},
+	scan_barcode: function(e){
+	    var barcode = e.target.value;
+	    if (barcode){
+		frappe.db.get_value('Item', {barcode:barcode}, 'item_code', (r) => {
+			var scan_barcode_wrapper = $(e.target).parents("[data-fieldname='scan_barcode']")[0];
+                        var scan_barcode_field = scan_barcode_wrapper.fieldobj;
+			if(r){
+				var cur_grid= cur_frm.fields_dict["items"].grid;
+				var cur_doctype= cur_grid.doctype;
+				var cur_grid_rows = cur_grid.grid_rows;
+				var row_count=cur_grid_rows.length;
+				var find_exist_row = "no";
+				for (var i = 0; i < row_count; i++) {
+					if (cur_grid_rows[i].doc.item_code) {
+						if (cur_grid_rows[i].doc.item_code !==r.item_code) {
+							continue;
+						}
+						else{
+							find_exist_row = "yes";
+							break;
+						}
+					}
+					else {
+						find_exist_row = "empty";
+						break;
+					}
+				}
+				if (find_exist_row === "no"){
+					var new_row= cur_grid.add_new_row(-1)
+					if (new_row){
+						locals[cur_doctype][new_row.name]['qty'] = 1;					
+						frappe.model.set_value(cur_doctype, new_row.name, {"item_code":r.item_code});
+						scan_barcode_field.set_new_description('New row:' + cur_grid_rows[0].doc.idx + ' ' +cur_grid_rows[0].doc.item_code + '  Created')
+					};
+				}
+				else if (find_exist_row === "empty"){
+					locals[cur_doctype][cur_grid_rows[i].doc.name]['qty'] = 1;
+					frappe.model.set_value(cur_doctype, cur_grid_rows[i].doc.name, "item_code", r.item_code);
+					scan_barcode_field.set_new_description('New row:' + cur_grid_rows[i].doc.idx + ' ' +cur_grid_rows[i].doc.item_code + '  Created')
+				}
+				else{
+					frappe.model.set_value(cur_doctype, cur_grid_rows[i].doc.name, "qty", cur_grid_rows[i].doc.qty + 1);
+					scan_barcode_field.set_new_description('Row:' + cur_grid_rows[i].doc.idx + ' ' +cur_grid_rows[i].doc.item_code + ' Qty incresed by 1')
+				}
+			}
+			else{
+				scan_barcode_field.set_new_description(barcode +' does not exist!')
+			}
+		});
+		e.target.value="";
+	    }
+	return false;
+	},
 	apply_default_taxes: function() {
 		var me = this;
 		var taxes_and_charges_field = frappe.meta.get_docfield(me.frm.doc.doctype, "taxes_and_charges",

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -257,7 +257,7 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 			else{
 				this.frm.$wrapper.find('.field_barcode') && this.frm.$wrapper.find('.field_barcode').remove();
 			}
-	      }
+		}
 	},
 
 	scan_barcode: function(e){

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -222,6 +222,7 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 			this.setup_item_selector();
 		}
 	},
+	
 	refresh: function() {
 		erpnext.toggle_naming_series();
 		erpnext.hide_company();
@@ -231,9 +232,9 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 		this.setup_barcode_scan();
 		this.frm.$wrapper.find('div.frappe-control.field_barcode p.help-box').text('');
 	},
+	
 	setup_barcode_scan: function(){
 	      var field_items = this.frm.fields_dict["items"];
-	      console.log('called scan barcode');
  	      if  (field_items) {
 		    var grid = field_items.grid;
 		    var display_status = frappe.perm.get_field_display_status(grid.df, grid.frm.doc, grid.perm);
@@ -241,7 +242,7 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 			(this.frm.doc.__islocal || display_status == 'Write')){
 			if (!this.frm.$wrapper.find('.field_barcode')[0]){
 				 var field_barcode = frappe.ui.form.make_control({
-					df: {fieldtype:"Data", label:__("  Scan Barcode"), fieldname:"scan_barcode"},
+					df: {fieldtype:"Data", label:__("Scan Barcode"), fieldname:"scan_barcode"},
 					parent: "<div></div>",
 					change: this.scan_barcode,
 					render_input:true
@@ -250,7 +251,7 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 			        this.frm.fields_dict["items"].$wrapper.parents('div.section-body').prepend(field_barcode.wrapper);
 			}
 			else{
-				this.frm.$wrapper.find('div.frappe-control.field_barcode p.help-box').text('');//after save and submit, remove the description
+				this.frm.$wrapper.find('div.frappe-control.field_barcode p.help-box').text('');//for save and submit
 			}
 		    }
 		    else{
@@ -258,6 +259,7 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 		    }
 	      }
 	},
+	
 	scan_barcode: function(e){
 	    var barcode = e.target.value;
 	    if (barcode){
@@ -288,29 +290,33 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 				if (find_exist_row === "no"){
 					var new_row= cur_grid.add_new_row(-1)
 					if (new_row){
-						locals[cur_doctype][new_row.name]['qty'] = 1;					
+						locals[cur_doctype][new_row.name]['qty'] = 1;
 						frappe.model.set_value(cur_doctype, new_row.name, {"item_code":r.item_code});
-						scan_barcode_field.set_new_description('New row:' + cur_grid_rows[0].doc.idx + ' ' +cur_grid_rows[0].doc.item_code + '  Created')
+						scan_barcode_field.set_new_description(__('New row:') + cur_grid_rows[0].doc.idx + ' ' +
+										       cur_grid_rows[0].doc.item_code + __('  Created'));
 					};
 				}
 				else if (find_exist_row === "empty"){
 					locals[cur_doctype][cur_grid_rows[i].doc.name]['qty'] = 1;
 					frappe.model.set_value(cur_doctype, cur_grid_rows[i].doc.name, "item_code", r.item_code);
-					scan_barcode_field.set_new_description('New row:' + cur_grid_rows[i].doc.idx + ' ' +cur_grid_rows[i].doc.item_code + '  Created')
+					scan_barcode_field.set_new_description(__('New row:') + cur_grid_rows[i].doc.idx + ' ' +
+									       cur_grid_rows[i].doc.item_code + __('  Created'));
 				}
 				else{
 					frappe.model.set_value(cur_doctype, cur_grid_rows[i].doc.name, "qty", cur_grid_rows[i].doc.qty + 1);
-					scan_barcode_field.set_new_description('Row:' + cur_grid_rows[i].doc.idx + ' ' +cur_grid_rows[i].doc.item_code + ' Qty incresed by 1')
+					scan_barcode_field.set_new_description(__('Row:') + cur_grid_rows[i].doc.idx + ' ' +
+									       cur_grid_rows[i].doc.item_code + __(' Qty incresed by 1'));
 				}
 			}
 			else{
-				scan_barcode_field.set_new_description(barcode +' does not exist!')
+				scan_barcode_field.set_new_description(barcode +__(' does not exist!'));
 			}
 		});
 		e.target.value="";
 	    }
 	return false;
 	},
+
 	apply_default_taxes: function() {
 		var me = this;
 		var taxes_and_charges_field = frappe.meta.get_docfield(me.frm.doc.doctype, "taxes_and_charges",

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -232,10 +232,10 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 		this.setup_barcode_scan();
 		this.frm.$wrapper.find('div.frappe-control.field_barcode p.help-box').text('');
 	},
-	
+
 	setup_barcode_scan: function(){
 		var field_items = this.frm.fields_dict["items"];
- 		if  (field_items) {
+		if  (field_items) {
 			var grid = field_items.grid;
 			var display_status = frappe.perm.get_field_display_status(grid.df, grid.frm.doc, grid.perm);
 			if (frappe.meta.get_field(grid.doctype,'item_code') && frappe.meta.get_field(grid.doctype,'qty') &&
@@ -248,12 +248,12 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 						render_input:true
 					});
 					field_barcode.$wrapper.addClass('field_barcode col-sm-6');
-			        	this.frm.fields_dict["items"].$wrapper.parents('div.section-body').prepend(field_barcode.wrapper);
+					this.frm.fields_dict["items"].$wrapper.parents('div.section-body').prepend(field_barcode.wrapper);
 				}
 				else{
 					this.frm.$wrapper.find('div.frappe-control.field_barcode p.help-box').text('');//	for save and submit
 				}
-		    }
+			}
 			else{
 				this.frm.$wrapper.find('.field_barcode') && this.frm.$wrapper.find('.field_barcode').remove();
 		    }
@@ -293,28 +293,28 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 							locals[cur_doctype][new_row.name]['qty'] = 1;
 							frappe.model.set_value(cur_doctype, new_row.name, {"item_code":r.item_code});
 							scan_barcode_field.set_new_description(__('New row:') + cur_grid_rows[0].doc.idx + ' ' +
-										       cur_grid_rows[0].doc.item_code + __('  Created'));
+									cur_grid_rows[0].doc.item_code + __('  Created'));
 						}
 					}
 					else if (find_exist_row === "empty"){
 						locals[cur_doctype][cur_grid_rows[i].doc.name]['qty'] = 1;
 						frappe.model.set_value(cur_doctype, cur_grid_rows[i].doc.name, "item_code", r.item_code);
 						scan_barcode_field.set_new_description(__('New row:') + cur_grid_rows[i].doc.idx + ' ' +
-									       cur_grid_rows[i].doc.item_code + __('  Created'));
+								cur_grid_rows[i].doc.item_code + __('  Created'));
 					}
 					else{
 						frappe.model.set_value(cur_doctype, cur_grid_rows[i].doc.name, "qty", cur_grid_rows[i].doc.qty + 1);
 						scan_barcode_field.set_new_description(__('Row:') + cur_grid_rows[i].doc.idx + ' ' +
-									       cur_grid_rows[i].doc.item_code + __(' Qty incresed by 1'));
+								cur_grid_rows[i].doc.item_code + __(' Qty incresed by 1'));
 					}
 				}
 				else{
 					scan_barcode_field.set_new_description(barcode +__(' does not exist!'));
 				}
 			});
-		e.target.value="";
+			e.target.value="";
 	    }
-	return false;
+		return false;
 	},
 
 	apply_default_taxes: function() {

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -222,7 +222,7 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 			this.setup_item_selector();
 		}
 	},
-	
+
 	refresh: function() {
 		erpnext.toggle_naming_series();
 		erpnext.hide_company();
@@ -234,84 +234,84 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 	},
 	
 	setup_barcode_scan: function(){
-	      var field_items = this.frm.fields_dict["items"];
- 	      if  (field_items) {
-		    var grid = field_items.grid;
-		    var display_status = frappe.perm.get_field_display_status(grid.df, grid.frm.doc, grid.perm);
-		    if (frappe.meta.get_field(grid.doctype,'item_code') && frappe.meta.get_field(grid.doctype,'qty') &&
+		var field_items = this.frm.fields_dict["items"];
+ 		if  (field_items) {
+			var grid = field_items.grid;
+			var display_status = frappe.perm.get_field_display_status(grid.df, grid.frm.doc, grid.perm);
+			if (frappe.meta.get_field(grid.doctype,'item_code') && frappe.meta.get_field(grid.doctype,'qty') &&
 			(this.frm.doc.__islocal || display_status == 'Write')){
-			if (!this.frm.$wrapper.find('.field_barcode')[0]){
-				 var field_barcode = frappe.ui.form.make_control({
-					df: {fieldtype:"Data", label:__("Scan Barcode"), fieldname:"scan_barcode"},
-					parent: "<div></div>",
-					change: this.scan_barcode,
-					render_input:true
-				});			         
-				field_barcode.$wrapper.addClass('field_barcode col-sm-6');			  	
-			        this.frm.fields_dict["items"].$wrapper.parents('div.section-body').prepend(field_barcode.wrapper);
-			}
-			else{
-				this.frm.$wrapper.find('div.frappe-control.field_barcode p.help-box').text('');//for save and submit
-			}
+				if (!this.frm.$wrapper.find('.field_barcode')[0]){
+					var field_barcode = frappe.ui.form.make_control({
+						df: {fieldtype:"Data", label:__("Scan Barcode"), fieldname:"scan_barcode"},
+						parent: "<div></div>",
+						change: this.scan_barcode,
+						render_input:true
+					});
+					field_barcode.$wrapper.addClass('field_barcode col-sm-6');
+			        	this.frm.fields_dict["items"].$wrapper.parents('div.section-body').prepend(field_barcode.wrapper);
+				}
+				else{
+					this.frm.$wrapper.find('div.frappe-control.field_barcode p.help-box').text('');//	for save and submit
+				}
 		    }
-		    else{
-			this.frm.$wrapper.find('.field_barcode') && this.frm.$wrapper.find('.field_barcode').remove();
+			else{
+				this.frm.$wrapper.find('.field_barcode') && this.frm.$wrapper.find('.field_barcode').remove();
 		    }
 	      }
 	},
 	
 	scan_barcode: function(e){
-	    var barcode = e.target.value;
-	    if (barcode){
-		frappe.db.get_value('Item', {barcode:barcode}, 'item_code', (r) => {
-			var scan_barcode_wrapper = $(e.target).parents("[data-fieldname='scan_barcode']")[0];
-                        var scan_barcode_field = scan_barcode_wrapper.fieldobj;
-			if(r){
-				var cur_grid= cur_frm.fields_dict["items"].grid;
-				var cur_doctype= cur_grid.doctype;
-				var cur_grid_rows = cur_grid.grid_rows;
-				var row_count=cur_grid_rows.length;
-				var find_exist_row = "no";
-				for (var i = 0; i < row_count; i++) {
-					if (cur_grid_rows[i].doc.item_code) {
-						if (cur_grid_rows[i].doc.item_code !==r.item_code) {
-							continue;
+		var barcode = e.target.value;
+		if (barcode){
+			frappe.db.get_value('Item', {barcode:barcode}, 'item_code', (r) => {
+				var scan_barcode_wrapper = $(e.target).parents("[data-fieldname='scan_barcode']")[0];
+				var scan_barcode_field = scan_barcode_wrapper.fieldobj;
+				if(r){
+					var cur_grid= cur_frm.fields_dict["items"].grid;
+					var cur_doctype= cur_grid.doctype;
+					var cur_grid_rows = cur_grid.grid_rows;
+					var row_count=cur_grid_rows.length;
+					var find_exist_row = "no";
+					for (var i = 0; i < row_count; i++) {
+						if (cur_grid_rows[i].doc.item_code) {
+							if (cur_grid_rows[i].doc.item_code !==r.item_code) {
+								continue;
+							}
+							else{
+								find_exist_row = "yes";
+								break;
+							}
 						}
-						else{
-							find_exist_row = "yes";
+						else {
+							find_exist_row = "empty";
 							break;
 						}
 					}
-					else {
-						find_exist_row = "empty";
-						break;
+					if (find_exist_row === "no"){
+						var new_row= cur_grid.add_new_row(-1);
+						if (new_row){
+							locals[cur_doctype][new_row.name]['qty'] = 1;
+							frappe.model.set_value(cur_doctype, new_row.name, {"item_code":r.item_code});
+							scan_barcode_field.set_new_description(__('New row:') + cur_grid_rows[0].doc.idx + ' ' +
+										       cur_grid_rows[0].doc.item_code + __('  Created'));
+						}
+					}
+					else if (find_exist_row === "empty"){
+						locals[cur_doctype][cur_grid_rows[i].doc.name]['qty'] = 1;
+						frappe.model.set_value(cur_doctype, cur_grid_rows[i].doc.name, "item_code", r.item_code);
+						scan_barcode_field.set_new_description(__('New row:') + cur_grid_rows[i].doc.idx + ' ' +
+									       cur_grid_rows[i].doc.item_code + __('  Created'));
+					}
+					else{
+						frappe.model.set_value(cur_doctype, cur_grid_rows[i].doc.name, "qty", cur_grid_rows[i].doc.qty + 1);
+						scan_barcode_field.set_new_description(__('Row:') + cur_grid_rows[i].doc.idx + ' ' +
+									       cur_grid_rows[i].doc.item_code + __(' Qty incresed by 1'));
 					}
 				}
-				if (find_exist_row === "no"){
-					var new_row= cur_grid.add_new_row(-1)
-					if (new_row){
-						locals[cur_doctype][new_row.name]['qty'] = 1;
-						frappe.model.set_value(cur_doctype, new_row.name, {"item_code":r.item_code});
-						scan_barcode_field.set_new_description(__('New row:') + cur_grid_rows[0].doc.idx + ' ' +
-										       cur_grid_rows[0].doc.item_code + __('  Created'));
-					};
-				}
-				else if (find_exist_row === "empty"){
-					locals[cur_doctype][cur_grid_rows[i].doc.name]['qty'] = 1;
-					frappe.model.set_value(cur_doctype, cur_grid_rows[i].doc.name, "item_code", r.item_code);
-					scan_barcode_field.set_new_description(__('New row:') + cur_grid_rows[i].doc.idx + ' ' +
-									       cur_grid_rows[i].doc.item_code + __('  Created'));
-				}
 				else{
-					frappe.model.set_value(cur_doctype, cur_grid_rows[i].doc.name, "qty", cur_grid_rows[i].doc.qty + 1);
-					scan_barcode_field.set_new_description(__('Row:') + cur_grid_rows[i].doc.idx + ' ' +
-									       cur_grid_rows[i].doc.item_code + __(' Qty incresed by 1'));
+					scan_barcode_field.set_new_description(barcode +__(' does not exist!'));
 				}
-			}
-			else{
-				scan_barcode_field.set_new_description(barcode +__(' does not exist!'));
-			}
-		});
+			});
 		e.target.value="";
 	    }
 	return false;

--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -592,6 +592,8 @@ erpnext.stock.StockEntry = erpnext.stock.StockController.extend({
 		}
 		erpnext.hide_company();
 		erpnext.utils.add_item(this.frm);
+		var  transaction_controller= new erpnext.TransactionController({frm:this.frm});
+		transaction_controller.setup_barcode_scan();
 	},
 
 	on_submit: function() {

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -617,7 +617,7 @@ class StockEntry(StockController):
 			'item_name' 		  	: item.item_name,
 			'expense_account'		: args.get("expense_account"),
 			'cost_center'			: get_default_cost_center(args, item, item_group_defaults),
-			'qty'					: 0,
+			'qty'				: args.get("qty"),
 			'transfer_qty'			: 0,
 			'conversion_factor'		: 1,
 			'batch_no'				: '',


### PR DESCRIPTION
How It Works

- Maintain barcode field in Item doctype
<img width="685" alt="barcode item master" src="https://user-images.githubusercontent.com/12823863/45146102-bf096280-b1f4-11e8-89c4-295e3ec084a0.PNG">

- Scan barcode in target docs in form view on New / change mode 
<img width="587" alt="material request barcode scan" src="https://user-images.githubusercontent.com/12823863/45146118-c7fa3400-b1f4-11e8-9db5-ea8bc2d4adbf.png">

target docs should have
- field items, field type as Table type
- items child table have fields: item_code and qty
 A new scan barcode field above the items table will be added, scan the item barcode label,( ensure the carriage RETURN is attached as suffix in the scanner setting), or manual key in barcode then press ENTER), the program will auto fetch the item based on barcode, when first time scanning the material, it auto creates a new record at top of the items table with item_code and qty as 1, otherwise, the existing record will be changed by adding 1 to existing qty. no impact to opening existing submitted doc with non editable status.

Currently this new feature will be automatically enabled for the following standard doctypes ,

- Material Request
- Purchase Order
- Sales Order
- Purchase Receipt
- Delivery Note
- Stock Entry
- Purchase Invoice
- Sales Invoice


discussion thread
https://discuss.erpnext.com/t/new-feature-proposal-barcode-scan-to-create-update-records-in-child-table-useful-for-stock-movement-and-orders/33695/5

Please read the pull request checklist to make sure your changes are merged: https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

