### PR TITLE
[Staging] Patch fix - Shopify Settings

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -289,7 +289,7 @@ class SalesInvoice(SellingController):
 
 		super(SalesInvoice, self).set_missing_values(for_validate)
 
-		print_format = pos.get("print_format_for_online")
+		print_format = pos.get("print_format_for_online") if pos else None
 		if not print_format and not cint(frappe.db.get_value('Print Format', 'POS Invoice', 'disabled')):
 			print_format = 'POS Invoice'
 

--- a/erpnext/erpnext_integrations/doctype/shopify_settings/shopify_settings.json
+++ b/erpnext/erpnext_integrations/doctype/shopify_settings/shopify_settings.json
@@ -49,7 +49,7 @@
    "bold": 0, 
    "collapsible": 0, 
    "columns": 0, 
-   "default": "1", 
+   "default": "",
    "fieldname": "enable_shopify", 
    "fieldtype": "Check", 
    "hidden": 0, 
@@ -1219,7 +1219,7 @@
  "issingle": 1, 
  "istable": 0, 
  "max_attachments": 0, 
- "modified": "2018-04-11 19:04:53.396557", 
+ "modified": "2018-09-07 09:11:49.403176",
  "modified_by": "Administrator", 
  "module": "ERPNext Integrations", 
  "name": "Shopify Settings", 
@@ -1253,5 +1253,6 @@
  "sort_field": "modified", 
  "sort_order": "DESC", 
  "track_changes": 0, 
- "track_seen": 0
+ "track_seen": 0,
+ "track_views": 0
 }

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -538,7 +538,7 @@ erpnext.patches.v11_0.make_location_from_warehouse
 erpnext.patches.v11_0.make_asset_finance_book_against_old_entries
 erpnext.patches.v11_0.check_buying_selling_in_currency_exchange
 erpnext.patches.v11_0.move_item_defaults_to_child_table_for_multicompany #02-07-2018
-erpnext.patches.v11_0.refactor_erpnext_shopify
+erpnext.patches.v11_0.refactor_erpnext_shopify #2018-09-07
 erpnext.patches.v11_0.rename_overproduction_percent_field
 erpnext.patches.v11_0.update_backflush_subcontract_rm_based_on_bom
 erpnext.patches.v10_0.update_status_in_purchase_receipt

--- a/erpnext/patches/v11_0/refactor_erpnext_shopify.py
+++ b/erpnext/patches/v11_0/refactor_erpnext_shopify.py
@@ -19,15 +19,26 @@ def execute():
 		frappe.db.sql("truncate `tabShopify Log`")
 
 		setup_app_type()
+	else:
+		disable_shopify()
 
 def setup_app_type():
 	try:
 		shopify_settings = frappe.get_doc("Shopify Settings")
 		shopify_settings.app_type = 'Private'
-		shopify_settings.update_price_in_erpnext_price_list =  0 if getattr(shopify_settings, 'push_prices_to_shopify', None) else 1
+		shopify_settings.update_price_in_erpnext_price_list = 0 if getattr(shopify_settings, 'push_prices_to_shopify', None) else 1
 		shopify_settings.flags.ignore_mandatory = True
 		shopify_settings.ignore_permissions = True
 		shopify_settings.save()
 	except Exception:
-		frappe.db.set_value("Shopify Shopify", None, "enable_shopify", 0)
+		frappe.db.set_value("Shopify Settings", None, "enable_shopify", 0)
 		frappe.log_error(frappe.get_traceback())
+
+def disable_shopify():
+	# due to frappe.db.set_value wrongly written and enable_shopify being default 1
+	# Shopify Settings isn't properly configured and leads to error
+	shopify = frappe.get_doc('Shopify Settings')
+
+	if shopify.app_type == "Public" or shopify.app_type == None or \
+		(shopify.enable_shopify and not (shopify.shopify_url or shopify.api_key)):
+		frappe.db.set_value("Shopify Settings", None, "enable_shopify", 0)


### PR DESCRIPTION
- default for enable_shopify shouldn't be 1
- Shopify refactor patch had a typo issue due to which it didn't disabled 'enable_shopify'
- patch re-run to disable Shopify if
```bash
app_type = Public or no shopify_url or no shopify api_key found
```

