### PR TITLE
Fixed PDC data in AR/AP report

### DIFF
--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -453,7 +453,7 @@ def get_pdc_details(party_type, report_date):
 		on
 			(pref.parent = pent.name)
 		where
-			pent.docstatus=1 and pent.posting_date > %s
+			pent.docstatus < 2 and pent.posting_date > %s
 			and pent.party_type = %s
 			group by pent.party, pref.reference_name""", (report_date, party_type), as_dict=1):
 			pdc_details.setdefault((pdc.invoice_no, pdc.party), pdc)
@@ -474,7 +474,7 @@ def get_pdc_details(party_type, report_date):
 		on
 			(jea.parent = je.name)
 		where
-			je.docstatus=1 and je.posting_date > %s
+			je.docstatus < 2 and je.posting_date > %s
 			and jea.party_type = %s
 			group by jea.party, jea.reference_name""".format(amount_field), (report_date, party_type), as_dict=1):
 			if (pdc.invoice_no, pdc.party) in pdc_details:

--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -446,14 +446,14 @@ def get_pdc_details(party_type, report_date):
 	for pdc in frappe.db.sql("""
 		select
 			pref.reference_name as invoice_no, pent.party, pent.party_type,
-			max(pent.reference_date) as pdc_date, sum(ifnull(pref.allocated_amount,0)) as pdc_amount,
+			max(pent.posting_date) as pdc_date, sum(ifnull(pref.allocated_amount,0)) as pdc_amount,
 			GROUP_CONCAT(pent.reference_no SEPARATOR ', ') as pdc_ref
 		from
 			`tabPayment Entry` as pent inner join `tabPayment Entry Reference` as pref
 		on
 			(pref.parent = pent.name)
 		where
-			pent.docstatus < 2 and pent.reference_date >= %s
+			pent.docstatus=1 and pent.posting_date > %s
 			and pent.party_type = %s
 			group by pent.party, pref.reference_name""", (report_date, party_type), as_dict=1):
 			pdc_details.setdefault((pdc.invoice_no, pdc.party), pdc)
@@ -467,18 +467,23 @@ def get_pdc_details(party_type, report_date):
 	for pdc in frappe.db.sql("""
 		select
 			jea.reference_name as invoice_no, jea.party, jea.party_type,
-			max(je.cheque_date) as pdc_date, sum(ifnull({0},0)) as pdc_amount,
+			max(je.posting_date) as pdc_date, sum(ifnull({0},0)) as pdc_amount,
 			GROUP_CONCAT(je.cheque_no SEPARATOR ', ') as pdc_ref
 		from
 			`tabJournal Entry` as je inner join `tabJournal Entry Account` as jea
 		on
 			(jea.parent = je.name)
 		where
-			je.docstatus < 2 and je.cheque_date >= %s
+			je.docstatus=1 and je.posting_date > %s
 			and jea.party_type = %s
 			group by jea.party, jea.reference_name""".format(amount_field), (report_date, party_type), as_dict=1):
 			if (pdc.invoice_no, pdc.party) in pdc_details:
-				pdc_details[(pdc.invoice_no, pdc.party)]["pdc_amount"] += pdc.pdc_amount
+				key = (pdc.invoice_no, pdc.party)
+				pdc_details[key]["pdc_amount"] += pdc.pdc_amount
+				if pdc.pdc_ref:
+					pdc_details[key]["pdc_ref"] += ", " + pdc.pdc_ref
+				if pdc.pdc_date:
+					pdc_details[key]["pdc_date"] = max(pdc_details[key]["pdc_date"], pdc.pdc_date)
 			else:
 				pdc_details.setdefault((pdc.invoice_no, pdc.party), pdc)
 


### PR DESCRIPTION
I found a bug in AR/AP report's PDC columns that if there is a payment with posting_date=reference_date then the amount of that payment would be included in BOTH pdc amount and paid amount on that posting/reference_date. This led to an incorrect value in the "Remaining Balance" column.

I wasn't complete sure of the intention of the PDC fields so I made a guess and I made the following changes:
-Get PDC date from posting_date instead of reference date since posting_date is the date at which the post dated cheque can be cleared or paid. Incase the payment isn't a PDC date (reference_date=posting_date), it still serves to show as future payments. I have no idea what the LC in PDC/LC means. 
-Get PDC data from submitted documents only

