### PR TITLE
[minor] Allow Rename for Custom Tariff

### DIFF
--- a/erpnext/stock/doctype/customs_tariff_number/customs_tariff_number.json
+++ b/erpnext/stock/doctype/customs_tariff_number/customs_tariff_number.json
@@ -2,7 +2,7 @@
  "allow_copy": 0, 
  "allow_guest_to_view": 0, 
  "allow_import": 0, 
- "allow_rename": 0, 
+ "allow_rename": 1, 
  "autoname": "field:tariff_number", 
  "beta": 0, 
  "creation": "2017-03-24 15:30:36.314639", 
@@ -14,6 +14,8 @@
  "engine": "InnoDB", 
  "fields": [
   {
+   "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -40,9 +42,12 @@
    "reqd": 1, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0, 
    "unique": 1
   }, 
   {
+   "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -69,6 +74,7 @@
    "reqd": 1, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0, 
    "unique": 0
   }
  ], 
@@ -82,7 +88,7 @@
  "issingle": 0, 
  "istable": 0, 
  "max_attachments": 0, 
- "modified": "2017-03-24 15:33:09.035885", 
+ "modified": "2018-09-12 09:30:03.951743", 
  "modified_by": "Administrator", 
  "module": "Stock", 
  "name": "Customs Tariff Number", 
@@ -91,7 +97,6 @@
  "permissions": [
   {
    "amend": 0, 
-   "apply_user_permissions": 0, 
    "cancel": 0, 
    "create": 1, 
    "delete": 1, 
@@ -111,7 +116,6 @@
   }, 
   {
    "amend": 0, 
-   "apply_user_permissions": 0, 
    "cancel": 0, 
    "create": 0, 
    "delete": 0, 
@@ -137,5 +141,6 @@
  "sort_field": "modified", 
  "sort_order": "DESC", 
  "track_changes": 1, 
- "track_seen": 0
+ "track_seen": 0, 
+ "track_views": 0
 }

--- a/erpnext/stock/doctype/customs_tariff_number/test_customs_tariff_number.js
+++ b/erpnext/stock/doctype/customs_tariff_number/test_customs_tariff_number.js
@@ -1,0 +1,23 @@
+/* eslint-disable */
+// rename this file from _test_[name] to test_[name] to activate
+// and remove above this line
+
+QUnit.test("test: Customs Tariff Number", function (assert) {
+	let done = assert.async();
+
+	// number of asserts
+	assert.expect(1);
+
+	frappe.run_serially([
+		// insert a new Customs Tariff Number
+		() => frappe.tests.make('Customs Tariff Number', [
+			// values to be set
+			{key: 'value'}
+		]),
+		() => {
+			assert.equal(cur_frm.doc.key, 'value');
+		},
+		() => done()
+	]);
+
+});


### PR DESCRIPTION
Allow Rename in `Customs Tariff Number` doctype.

<img width="445" alt="screen shot 2018-09-12 at 11 08 51 am" src="https://user-images.githubusercontent.com/21003054/45414729-5569d800-b67c-11e8-99a0-d33c0c49ecdd.png">

