### PR TITLE
fix(hub): patch to delete hub documents

### DIFF
--- a/erpnext/patches/v10_0/delete_hub_documents.py
+++ b/erpnext/patches/v10_0/delete_hub_documents.py
@@ -12,4 +12,7 @@ def execute():
 			plan_doc = frappe.get_doc("Data Migration Plan", plan.name)
 			for m in plan_doc.get("mappings"):
 				frappe.delete_doc("Data Migration Mapping", m.mapping, force=True)
+			docs = frappe.get_all("Data Migration Run", filters={"data_migration_plan": plan.name})
+			for doc in docs:
+				frappe.delete_doc("Data Migration Run", doc.name)
 			frappe.delete_doc("Data Migration Plan", plan.name)


### PR DESCRIPTION
While deteting the "Data Migratun Plan" docs the patch used to break,
since it was linked to docs from "Data Migration Run". Modified the
patch to also delete the linked "Data Migration Run" docs.


