### PR TITLE
Bank statement import corrections

### DIFF
--- a/erpnext/accounts/doctype/bank_statement_transaction_entry/bank_statement_transaction_entry.js
+++ b/erpnext/accounts/doctype/bank_statement_transaction_entry/bank_statement_transaction_entry.js
@@ -85,7 +85,7 @@ frappe.ui.form.on('Bank Statement Transaction Invoice Item', {
 		} else if (row.party_type == "Account") {
 			row.invoice_type = "Journal Entry";
 		}
-		refresh_field("invoice_type", row.name, "payment_invoice_items")
+		refresh_field("invoice_type", row.name, "payment_invoice_items");
 
 	},
 	invoice_type: function(frm, cdt, cdn) {
@@ -95,6 +95,6 @@ frappe.ui.form.on('Bank Statement Transaction Invoice Item', {
 		} else if (row.invoice_type == "Sales Invoice") {
 			row.party_type = "Customer";
 		}
-		refresh_field("party_type", row.name, "payment_invoice_items")
+		refresh_field("party_type", row.name, "payment_invoice_items");
 	}
-})
+});

--- a/erpnext/accounts/doctype/bank_statement_transaction_entry/bank_statement_transaction_entry.js
+++ b/erpnext/accounts/doctype/bank_statement_transaction_entry/bank_statement_transaction_entry.js
@@ -44,21 +44,21 @@ frappe.ui.form.on('Bank Statement Transaction Entry', {
 
 	invoice_filter: function(frm) {
 		frm.set_query("invoice", "payment_invoice_items", function(doc, cdt, cdn) {
-			row = locals[cdt][cdn]
+			let row = locals[cdt][cdn]
 			if (row.party_type == "Customer") {
 				return {
-								filters:[[row.invoice_type, "customer", "in", [row.party]],
-												[row.invoice_type, "status", "!=", "Cancelled" ],
-											  [row.invoice_type, "posting_date", "<", row.transaction_date ],
-											  [row.invoice_type, "outstanding_amount", ">", 0 ]]
-							}
+					filters:[[row.invoice_type, "customer", "in", [row.party]],
+									[row.invoice_type, "status", "!=", "Cancelled" ],
+									[row.invoice_type, "posting_date", "<", row.transaction_date ],
+									[row.invoice_type, "outstanding_amount", ">", 0 ]]
+				}
 			} else if (row.party_type == "Supplier") {
 				return {
-								filters:[[row.invoice_type, "supplier", "in", [row.party]],
-												[row.invoice_type, "status", "!=", "Cancelled" ],
-												[row.invoice_type, "posting_date", "<", row.transaction_date ],
-												[row.invoice_type, "outstanding_amount", ">", 0 ]]
-							}
+					filters:[[row.invoice_type, "supplier", "in", [row.party]],
+									[row.invoice_type, "status", "!=", "Cancelled" ],
+									[row.invoice_type, "posting_date", "<", row.transaction_date ],
+									[row.invoice_type, "outstanding_amount", ">", 0 ]]
+				}
 			}
 		});
 	},
@@ -73,3 +73,28 @@ frappe.ui.form.on('Bank Statement Transaction Entry', {
 		frm.events.invoke_doc_function(frm, "submit_payment_entries");
 	},
 });
+
+
+frappe.ui.form.on('Bank Statement Transaction Invoice Item', {
+	party_type: function(frm, cdt, cdn) {
+		let row = locals[cdt][cdn];
+		if (row.party_type == "Customer") {
+			row.invoice_type = "Sales Invoice";
+		} else if (row.party_type == "Supplier") {
+			row.invoice_type = "Purchase Invoice";
+		} else if (row.party_type == "Account") {
+			row.invoice_type = "Journal Entry";
+		}
+		refresh_field("invoice_type", row.name, "payment_invoice_items")
+
+	},
+	invoice_type: function(frm, cdt, cdn) {
+		let row = locals[cdt][cdn];
+		if (row.invoice_type == "Purchase Invoice") {
+			row.party_type = "Supplier";
+		} else if (row.invoice_type == "Sales Invoice") {
+			row.party_type = "Customer";
+		}
+		refresh_field("party_type", row.name, "payment_invoice_items")
+	}
+})

--- a/erpnext/accounts/doctype/bank_statement_transaction_entry/bank_statement_transaction_entry.json
+++ b/erpnext/accounts/doctype/bank_statement_transaction_entry/bank_statement_transaction_entry.json
@@ -14,6 +14,7 @@
  "fields": [
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -46,6 +47,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -77,6 +79,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -108,6 +111,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -140,6 +144,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -170,6 +175,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -202,6 +208,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -234,6 +241,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -266,6 +274,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -297,10 +306,12 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
    "columns": 0, 
+   "depends_on": "", 
    "fieldname": "section_break_6", 
    "fieldtype": "Section Break", 
    "hidden": 0, 
@@ -328,6 +339,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -360,10 +372,12 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
    "columns": 0, 
+   "depends_on": "eval:doc.new_transaction_items && doc.new_transaction_items.length", 
    "fieldname": "section_break_9", 
    "fieldtype": "Section Break", 
    "hidden": 0, 
@@ -390,10 +404,12 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
    "columns": 0, 
+   "depends_on": "", 
    "fieldname": "match_invoices", 
    "fieldtype": "Button", 
    "hidden": 0, 
@@ -421,6 +437,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -451,6 +468,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -482,6 +500,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -512,6 +531,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -543,10 +563,12 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
    "columns": 0, 
+   "depends_on": "eval:doc.new_transaction_items && doc.new_transaction_items.length", 
    "fieldname": "section_break_18", 
    "fieldtype": "Section Break", 
    "hidden": 0, 
@@ -574,6 +596,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -606,6 +629,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -637,6 +661,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -669,6 +694,7 @@
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -709,7 +735,7 @@
  "issingle": 0, 
  "istable": 0, 
  "max_attachments": 0, 
- "modified": "2018-04-07 17:01:47.480572", 
+ "modified": "2018-09-14 18:04:44.170455", 
  "modified_by": "Administrator", 
  "module": "Accounts", 
  "name": "Bank Statement Transaction Entry", 
@@ -718,7 +744,6 @@
  "permissions": [
   {
    "amend": 1, 
-   "apply_user_permissions": 0, 
    "cancel": 1, 
    "create": 1, 
    "delete": 1, 
@@ -738,7 +763,6 @@
   }, 
   {
    "amend": 1, 
-   "apply_user_permissions": 0, 
    "cancel": 1, 
    "create": 1, 
    "delete": 1, 

--- a/erpnext/accounts/doctype/bank_statement_transaction_invoice_item/bank_statement_transaction_invoice_item.json
+++ b/erpnext/accounts/doctype/bank_statement_transaction_invoice_item/bank_statement_transaction_invoice_item.json
@@ -14,6 +14,7 @@
  "fields": [
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -40,10 +41,12 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0, 
    "unique": 0
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -70,10 +73,12 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0, 
    "unique": 0
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -95,16 +100,18 @@
    "precision": "", 
    "print_hide": 0, 
    "print_hide_if_no_value": 0, 
-   "read_only": 1, 
+   "read_only": 0, 
    "remember_last_selected_value": 0, 
    "report_hide": 0, 
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0, 
    "unique": 0
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -132,10 +139,12 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0, 
    "unique": 0
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -161,10 +170,12 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0, 
    "unique": 0
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -191,10 +202,12 @@
    "reqd": 1, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0, 
    "unique": 0
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -211,7 +224,7 @@
    "label": "Invoice Type", 
    "length": 0, 
    "no_copy": 0, 
-   "options": "Purchase Invoice\nSales Invoice\nJournal Entry", 
+   "options": "Sales Invoice\nPurchase Invoice\nJournal Entry", 
    "permlevel": 0, 
    "precision": "", 
    "print_hide": 0, 
@@ -222,10 +235,12 @@
    "reqd": 1, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0, 
    "unique": 0
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -253,10 +268,12 @@
    "reqd": 1, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0, 
    "unique": 0
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -283,10 +300,12 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0, 
    "unique": 0
   }, 
   {
    "allow_bulk_edit": 0, 
+   "allow_in_quick_entry": 0, 
    "allow_on_submit": 0, 
    "bold": 0, 
    "collapsible": 0, 
@@ -313,6 +332,7 @@
    "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
+   "translatable": 0, 
    "unique": 0
   }
  ], 
@@ -326,7 +346,7 @@
  "issingle": 0, 
  "istable": 1, 
  "max_attachments": 0, 
- "modified": "2017-11-15 09:41:45.840947", 
+ "modified": "2018-09-14 19:03:30.949831", 
  "modified_by": "Administrator", 
  "module": "Accounts", 
  "name": "Bank Statement Transaction Invoice Item", 
@@ -340,5 +360,6 @@
  "sort_field": "modified", 
  "sort_order": "DESC", 
  "track_changes": 1, 
- "track_seen": 0
+ "track_seen": 0, 
+ "track_views": 0
 }


### PR DESCRIPTION
Hello,

I have been testing the new bank statement import tool and I have to say that it looks very promising. Thank you!

While testing I have faced some blocking issues for which I propose the following corrections + some UX corrections. It took me a while to understand how it works, so I guess some additional love should be provided to help end users.


1. The header mapping was not working and the original headers where hard coded, whereas there is a mapping table.
I corrected it to allow using different headers (as intented in the initial design)
![image](https://user-images.githubusercontent.com/4903591/45565114-e7c3d480-b852-11e8-85d0-0ac149ac07cb.png)

2. I added the safe_decode function to all description references to avoid ASCII errors (very common with french).

3. I made the party_type field editable for manual entries in the invoice table and made a mapping between the party type and the invoice type to avoid errors with the query filter:
![image](https://user-images.githubusercontent.com/4903591/45565548-1c845b80-b854-11e8-8d87-974cd90d4b15.png)

Thanks in advance for reviewing this PR


**PS: Personal thoughts on things to improve**

- Display error messages when the headers are not found. It is always confusing when the system just does nothing when there is an error

- Add error/display messages for the buttons when there is no transaction to generate. Maybe provide additional information below to explain what they are meant to do.

- Improve the reconciliation of already existing payment entries: having to select two elements + the payment entry number (without context) from a dropdown is horrible... I understand it's not the initial intent of this functionality, but it would be a wonderful addition to have a simple drag'n'drop or selectable table to easily match bank entries with payment entries manually.
