### PR TITLE
[Minor] [Hotfix] Label for discount configurable

### DIFF
--- a/erpnext/templates/print_formats/includes/taxes.html
+++ b/erpnext/templates/print_formats/includes/taxes.html
@@ -2,7 +2,7 @@
 	{%- if doc.discount_amount -%}
 		<div class="row">
 			<div class="col-xs-5 {%- if doc._align_labels_right %} text-right{%- endif -%}">
-				<label>{{ _("Discount Amount") }}</label></div>
+				<label>{{ _(doc.meta.get_label('discount_amount')) }}</label></div>
 			<div class="col-xs-7 text-right">
 				- {{ doc.get_formatted("discount_amount", doc) }}
 			</div>


### PR DESCRIPTION
Support issue - WN-SUP35678

'Discount Amount' label was hardcoded and if someone wish to change the label from Customize Form won't affect print format. Fetching label from doc meta instead.
