### PR TITLE
[Minor] Python 2 - 3 issue

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -701,7 +701,7 @@ def add_additional_cost(stock_entry, work_order):
 		items.setdefault(d.item_code, d.rate)
 
 	non_stock_items = frappe.get_all('Item',
-		fields="name", filters={'name': ('in', items.keys()), 'ifnull(is_stock_item, 0)': 0}, as_list=1)
+		fields="name", filters={'name': ('in', list(items.keys())), 'ifnull(is_stock_item, 0)': 0}, as_list=1)
 
 	for name in non_stock_items:
 		stock_entry.append('additional_costs', {


### PR DESCRIPTION
```bash
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 62, in application
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 22, in handle
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 57, in execute_cmd
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1007, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/manufacturing/doctype/work_order/work_order.py", line 623, in make_stock_entry
    stock_entry.get_items()
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.py", line 756, in get_items
    add_additional_cost(self, work_order)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/manufacturing/doctype/bom/bom.py", line 704, in add_additional_cost
    fields="name", filters={'name': ('in', items.keys()), 'ifnull(is_stock_item, 0)': 0}, as_list=1)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1262, in get_all
    return get_list(doctype, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1235, in get_list
    return frappe.model.db_query.DatabaseQuery(doctype).execute(None, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/db_query.py", line 87, in execute
    result = self.build_and_run()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/db_query.py", line 99, in build_and_run
    args = self.prepare_args()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/db_query.py", line 118, in prepare_args
    self.build_conditions()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/db_query.py", line 287, in build_conditions
    self.build_filter_conditions(self.filters, self.conditions)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/db_query.py", line 308, in build_filter_conditions
    conditions.append(self.prepare_filter_condition(f))
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/db_query.py", line 366, in prepare_filter_condition
    values = values.split(",")
AttributeError: 'dict_keys' object has no attribute 'split'
```
 item.keys() return dict_keys object in python 3
