### PR TITLE
fix(desktop_icon): remove land unit icon if exists

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -565,3 +565,4 @@ erpnext.patches.v11_0.make_job_card
 erpnext.patches.v11_0.redesign_healthcare_billing_work_flow
 erpnext.patches.v10_0.delete_hub_documents # 12-08-2018
 erpnext.patches.v11_0.rename_healthcare_fields
+erpnext.patches.v11_0.remove_land_unit_icon

--- a/erpnext/patches/v11_0/remove_land_unit_icon.py
+++ b/erpnext/patches/v11_0/remove_land_unit_icon.py
@@ -1,0 +1,17 @@
+# Copyright (c) 2018, Frappe and Contributors
+# License: GNU General Public License v3. See license.txt
+
+# imports - module imports
+import frappe
+
+
+def execute():
+	"""
+	Delete the "Land Unit" doc if exists from "Desktop Icon" doctype
+	"""
+	try:
+		doc = frappe.get_doc('Desktop Icon', {'standard': 1, 'module_name': 'Land Unit'})
+		frappe.delete_doc('Desktop Icon', doc.name)
+	except ValidationError:
+		# The 'Land Unit' doc doesn't exist, nothing to do
+		pass

--- a/erpnext/patches/v11_0/remove_land_unit_icon.py
+++ b/erpnext/patches/v11_0/remove_land_unit_icon.py
@@ -12,6 +12,6 @@ def execute():
 	try:
 		doc = frappe.get_doc('Desktop Icon', {'standard': 1, 'module_name': 'Land Unit'})
 		frappe.delete_doc('Desktop Icon', doc.name)
-	except ValidationError:
+	except frappe.ValidationError:
 		# The 'Land Unit' doc doesn't exist, nothing to do
 		pass


### PR DESCRIPTION
Patch to delete the 'Land Unit' icon form 'Desktop Icon' doctype if
exists, since 'Land Unit' has been merged with 'Location'