### PR TITLE
[Fix] BOM update tool, too many writes in one request. Please send smaller requests

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/pos.py
+++ b/erpnext/accounts/doctype/sales_invoice/pos.py
@@ -506,7 +506,7 @@ def save_invoice(doc, name, name_list):
 			frappe.db.commit()
 			name_list.append(name)
 	except Exception:
-		frappe.log_error(frappe.get_traceback())
 		frappe.db.rollback()
+		frappe.log_error(frappe.get_traceback())
 
 	return name_list


### PR DESCRIPTION
**Issue**
```
{'retry': 0, 'log': <function log at 0x2e168c0>, 'site': u'sapcon.erpnext.com', 'event': None, 'method_name': u'erpnext.manufacturing.doctype.bom_update_tool.bom_update_tool.replace_bom', 'method': <function replace_bom at 0x2e749b0>, 'user': u'dharmendrap@sapcon.in', 'kwargs': {'args': {u'new_bom': u'BOM-TEST BOM UPDATE TOOL-501-002', u'current_bom': u'BOM-TEST BOM UPDATE TOOL-501-001'}}, 'async': True, 'job_name': u'erpnext.manufacturing.doctype.bom_update_tool.bom_update_tool.replace_bom'}
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2018-09-12/apps/frappe/frappe/utils/background_jobs.py", line 97, in execute_job
    method(**kwargs)
  File "/home/frappe/benches/bench-2018-09-12/apps/erpnext/erpnext/manufacturing/doctype/bom_update_tool/bom_update_tool.py", line 83, in replace_bom
    doc.replace_bom()
  File "/home/frappe/benches/bench-2018-09-12/apps/erpnext/erpnext/manufacturing/doctype/bom_update_tool/bom_update_tool.py", line 22, in replace_bom
    updated_bom = bom_obj.update_cost_and_exploded_items(updated_bom)
  File "/home/frappe/benches/bench-2018-09-12/apps/erpnext/erpnext/manufacturing/doctype/bom/bom.py", line 357, in update_cost_and_exploded_items
    bom_obj.on_update()
  File "/home/frappe/benches/bench-2018-09-12/apps/erpnext/erpnext/manufacturing/doctype/bom/bom.py", line 60, in on_update
    self.update_stock_qty()
  File "/home/frappe/benches/bench-2018-09-12/apps/erpnext/erpnext/manufacturing/doctype/bom/bom.py", line 291, in update_stock_qty
    m.db_update()
  File "/home/frappe/benches/bench-2018-09-12/apps/frappe/frappe/model/base_document.py", line 343, in db_update
    ), list(d.values()) + [name])
  File "/home/frappe/benches/bench-2018-09-12/apps/frappe/frappe/database.py", line 139, in sql
    self.check_transaction_status(query)
  File "/home/frappe/benches/bench-2018-09-12/apps/frappe/frappe/database.py", line 257, in check_transaction_status
    frappe.throw(_("Too many writes in one request. Please send smaller requests"), frappe.ValidationError)
  File "/home/frappe/benches/bench-2018-09-12/apps/frappe/frappe/__init__.py", line 323, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red')
  File "/home/frappe/benches/bench-2018-09-12/apps/frappe/frappe/__init__.py", line 309, in msgprint
    _raise_exception()
  File "/home/frappe/benches/bench-2018-09-12/apps/frappe/frappe/__init__.py", line 282, in _raise_exception
    raise raise_exception(encode(msg))
ValidationError: Too many writes in one request. Please send smaller requests
```