### PR TITLE
Naming Series Form Parsing Fix

### DIFF
--- a/erpnext/setup/doctype/naming_series/naming_series.py
+++ b/erpnext/setup/doctype/naming_series/naming_series.py
@@ -166,13 +166,12 @@ class NamingSeries(Document):
 
 	def parse_naming_series(self):
 		parts = self.prefix.split('.')
-		# If series contain date format like INV.YYYY.MM.#####
-		if len(parts) > 2:
-			del parts[-1] # Removed ### from the series
-			prefix = parse_naming_series(parts)
-		else:
-			prefix = parts[0]
 
+		# Remove ### from the end of series
+		if parts[-1] == "#" * len(parts[-1]):
+			del parts[-1]
+
+		prefix = parse_naming_series(parts)
 		return prefix
 
 def set_by_naming_series(doctype, fieldname, naming_series, hide_name_field=True):


### PR DESCRIPTION
When updating naming series starting number the parsing function deleted the last part of the string with the assumption that it would be a '#####'. This led to a problem that it would parse the naming series incorrectly so that the last part '-' would be removed:
![image](https://user-images.githubusercontent.com/328330/46131086-3fe7d700-c254-11e8-926a-879b033a2ca3.png)

This pull request removes the '#####' part only if it is actually a '#####' part