### PR TITLE
Make pricing rule from Supplier and Customer Doc

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.js
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.js
@@ -116,6 +116,18 @@ frappe.ui.form.on('Pricing Rule', {
 		};
 	},
 
+	onload: function(frm) {
+		if(frm.doc.__islocal && !frm.doc.applicable_for && (frm.doc.customer || frm.doc.supplier)) {
+			if(frm.doc.customer) {
+				frm.doc.applicable_for = "Customer";
+				frm.doc.selling = 1
+			} else {
+				frm.doc.applicable_for = "Supplier";
+				frm.doc.buying = 1
+			}
+		}
+	},
+
 	refresh: function(frm) {
 		var help_content =
 			`<table class="table table-bordered" style="background-color: #f9f9f9;">

--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -384,3 +384,13 @@ def set_transaction_type(args):
 		args.transaction_type = "selling"
 	else:
 		args.transaction_type = "buying"
+
+@frappe.whitelist()
+def make_pricing_rule(doctype, docname):
+	doc = frappe.new_doc("Pricing Rule")
+	doc.applicable_for = doctype
+	doc.set(frappe.scrub(doctype), docname)
+	doc.selling = 1 if doctype == "Customer" else 0
+	doc.buying = 1 if doctype == "Supplier" else 0
+
+	return doc

--- a/erpnext/buying/doctype/supplier/supplier.js
+++ b/erpnext/buying/doctype/supplier/supplier.js
@@ -49,6 +49,10 @@ frappe.ui.form.on("Supplier", {
 				erpnext.utils.make_bank_account(frm.doc.doctype, frm.doc.name);
 			}, __("Make"));
 
+			frm.add_custom_button(__('Pricing Rule'), function () {
+				erpnext.utils.make_pricing_rule(frm.doc.doctype, frm.doc.name);
+			}, __("Make"));
+
 			// indicators
 			erpnext.utils.set_party_dashboard_indicators(frm);
 		}

--- a/erpnext/buying/doctype/supplier/supplier_dashboard.py
+++ b/erpnext/buying/doctype/supplier/supplier_dashboard.py
@@ -13,6 +13,10 @@ def get_data():
 			{
 				'label': _('Orders'),
 				'items': ['Purchase Order', 'Purchase Receipt', 'Purchase Invoice']
+			},
+			{
+				'label': _('Pricing'),
+				'items': ['Pricing Rule']
 			}
 		]
 	}

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -173,6 +173,20 @@ $.extend(erpnext.utils, {
 		})
 	},
 
+	make_pricing_rule: function(doctype, docname) {
+		frappe.call({
+			method: "erpnext.accounts.doctype.pricing_rule.pricing_rule.make_pricing_rule",
+			args: {
+				doctype: doctype,
+				docname: docname
+			},
+			callback: function(r) {
+				var doclist = frappe.model.sync(r.message);
+				frappe.set_route("Form", doclist[0].doctype, doclist[0].name);
+			}
+		})
+	},
+
 	/**
 	* Checks if the first row of a given child table is empty
 	* @param child_table - Child table Doctype

--- a/erpnext/selling/doctype/customer/customer.js
+++ b/erpnext/selling/doctype/customer/customer.js
@@ -106,6 +106,10 @@ frappe.ui.form.on("Customer", {
 				frappe.set_route('query-report', 'Accounts Receivable', {customer:frm.doc.name});
 			});
 
+			frm.add_custom_button(__('Pricing Rule'), function () {
+				erpnext.utils.make_pricing_rule(frm.doc.doctype, frm.doc.name);
+			}, __("Make"));
+
 			// indicator
 			erpnext.utils.set_party_dashboard_indicators(frm);
 

--- a/erpnext/selling/doctype/customer/customer_dashboard.py
+++ b/erpnext/selling/doctype/customer/customer_dashboard.py
@@ -21,6 +21,10 @@ def get_data():
 			{
 				'label': _('Projects'),
 				'items': ['Project']
+			},
+			{
+				'label': _('Pricing'),
+				'items': ['Pricing Rule']
 			}
 		]
 	}


### PR DESCRIPTION
Users feel that pricing rules are a complicated and I made it a little bit easier for them by:

* Adding a Make -> Pricing Rule button on Customer and Supplier Forms
* Adding Pricing Rule in Customer and Supplier dashboard

![pricingrulepr](https://user-images.githubusercontent.com/328330/46243641-182d7600-c3f0-11e8-9e38-5bf41d4cbf6c.gif)
