### PR TITLE
Fixed a problem set_item_default which led to filling up Item's Item Default table

### DIFF
--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -951,7 +951,7 @@ def set_item_default(item_code, company, fieldname, value):
 			return
 
 	# no row found, add a new row for the company
-	d = item.append('item_defaults', {fieldname: value, company: company})
+	d = item.append('item_defaults', {fieldname: value, "company": company})
 	d.db_insert()
 	item.clear_cache()
 


### PR DESCRIPTION
set_item_default was referencing a variable company of "company" which caused:

![image](https://user-images.githubusercontent.com/328330/46244329-c3412e00-c3f6-11e8-9a18-da62d26ad78c.png)
