### PR TITLE
[Fix] Cost center issue

### DIFF
--- a/erpnext/accounts/doctype/cost_center/cost_center.py
+++ b/erpnext/accounts/doctype/cost_center/cost_center.py
@@ -58,7 +58,6 @@ class CostCenter(NestedSet):
 		# Validate properties before merging
 		super(CostCenter, self).before_rename(olddn, new_cost_center, merge, "is_group")
 		if not merge:
-			from erpnext.accounts.doctype.account.account import get_name_with_number
 			new_cost_center = get_name_with_number(new_cost_center, self.cost_center_number)
 
 		return new_cost_center
@@ -89,3 +88,8 @@ class CostCenter(NestedSet):
 
 def on_doctype_update():
 	frappe.db.add_index("Cost Center", ["lft", "rgt"])
+
+def get_name_with_number(new_account, account_number):
+	if account_number and not new_account[0].isdigit():
+		new_account = account_number + " - " + new_account
+	return new_account


### PR DESCRIPTION
**Issue**
```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1007, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/rename_doc.py", line 36, in rename_doc
    out = old_doc.run_method("before_rename", old, new, merge) or {}
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 773, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1049, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1032, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 767, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/doctype/cost_center/cost_center.py", line 61, in before_rename
    from erpnext.accounts.doctype.account.account import get_name_with_number
ImportError: cannot import name get_name_with_number
```