### PR TITLE
[Minor] Deferred Expense

### DIFF
--- a/erpnext/accounts/deferred_revenue.py
+++ b/erpnext/accounts/deferred_revenue.py
@@ -157,6 +157,7 @@ def book_deferred_income_or_expense(doc, start_date=None, end_date=None):
 				"credit": base_amount,
 				"credit_in_account_currency": amount,
 				"cost_center": item.cost_center,
+				"voucher_detail_no": item.name,
 				'posting_date': booking_end_date,
 				'project': project
 			}, account_currency)


### PR DESCRIPTION
`voucher_detail_no` wasn't passed while creating credit GL Entry. Because of which the `previous gl entry` didn't fetch any thing and start date wasn't appropriately set.