### PR TITLE
[Minor] Deferred Expense

### DIFF
--- a/erpnext/accounts/deferred_revenue.py
+++ b/erpnext/accounts/deferred_revenue.py
@@ -157,6 +157,7 @@ def book_deferred_income_or_expense(doc, start_date=None, end_date=None):
 				"credit": base_amount,
 				"credit_in_account_currency": amount,
 				"cost_center": item.cost_center,
+				"voucher_detail_no": item.name,
 				'posting_date': booking_end_date,
 				'project': project
 			}, account_currency)


### PR DESCRIPTION
`voucher_detail_no` not recorder while creating credit GL Entry. As a result, previous gl entry logic doesn't fetch anything and start date isn't set properly.
