### PR TITLE
fix: make location from warehouse patch

### DIFF
--- a/erpnext/patches/v11_0/make_location_from_warehouse.py
+++ b/erpnext/patches/v11_0/make_location_from_warehouse.py
@@ -6,6 +6,7 @@ import frappe
 from frappe.utils.nestedset import rebuild_tree
 
 def execute():
+	if not frappe.db.get_value('Asset', {'docstatus': ('<', 2) }, 'name'): return
 	frappe.reload_doc('assets', 'doctype', 'location')
 	frappe.reload_doc('stock', 'doctype', 'warehouse')
 


### PR DESCRIPTION
- optimization by preventing patch execution if Asset doesn't exist
