### PR TITLE
[Setup fail] Fix setup taxes

### DIFF
--- a/erpnext/setup/setup_wizard/operations/taxes_setup.py
+++ b/erpnext/setup/setup_wizard/operations/taxes_setup.py
@@ -50,7 +50,7 @@ def make_tax_account(company, account_name, tax_rate):
 				"tax_rate": flt(tax_rate) if tax_rate else None
 			}).insert(ignore_permissions=True, ignore_mandatory=True)
 		except frappe.NameError:
-			frappe.message_log.pop()
+			if frappe.message_log: frappe.message_log.pop()
 			abbr = frappe.get_cached_value('Company',  company,  'abbr')
 			account = '{0} - {1}'.format(account_name, abbr)
 			return frappe.get_doc('Account', account)


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2018-09-12/apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.py", line 72, in setup_complete
    task.get('fn')(task.get('args'))
  File "/home/frappe/benches/bench-2018-09-12/apps/erpnext/erpnext/setup/setup_wizard/setup_wizard.py", line 109, in setup_taxes
    taxes_setup.create_sales_tax(args)
  File "/home/frappe/benches/bench-2018-09-12/apps/erpnext/erpnext/setup/setup_wizard/operations/taxes_setup.py", line 16, in create_sales_tax
    tax_data.get('tax_rate'), sales_tax)
  File "/home/frappe/benches/bench-2018-09-12/apps/erpnext/erpnext/setup/setup_wizard/operations/taxes_setup.py", line 25, in make_tax_account_and_template
    tax_account = make_tax_account(company, account_name[i], tax_rate[i])
  File "/home/frappe/benches/bench-2018-09-12/apps/erpnext/erpnext/setup/setup_wizard/operations/taxes_setup.py", line 53, in make_tax_account
    frappe.message_log.pop()
IndexError: pop from empty list
```