### PR TITLE
Validate if companies are same for warehouse_account and warehouse

### DIFF
--- a/erpnext/stock/__init__.py
+++ b/erpnext/stock/__init__.py
@@ -30,9 +30,11 @@ def get_warehouse_account_map():
 	return frappe.flags.warehouse_account_map
 
 def get_warehouse_account(warehouse, warehouse_account=None):
+
 	account = warehouse.account
 	if not account and warehouse.parent_warehouse:
 		if warehouse_account:
+			if warehouse_account.get('company') != warehouse.get('company'): return
 			account = warehouse_account.get(warehouse.parent_warehouse).account
 		else:
 			account = frappe.db.sql("""


### PR DESCRIPTION
Error on submitting Purchase Receipt:
```
Traceback (most recent call last):
  File "/Users/speedy/frappe-bench/apps/frappe/frappe/desk/form/save.py", line 19, in savedocs
    doc.submit()
  File "/Users/speedy/frappe-bench/apps/frappe/frappe/model/document.py", line 848, in submit
    self._submit()
  File "/Users/speedy/frappe-bench/apps/frappe/frappe/model/document.py", line 837, in _submit
    self.save()
  File "/Users/speedy/frappe-bench/apps/frappe/frappe/model/document.py", line 260, in save
    return self._save(*args, **kwargs)
  File "/Users/speedy/frappe-bench/apps/frappe/frappe/model/document.py", line 313, in _save
    self.run_post_save_methods()
  File "/Users/speedy/frappe-bench/apps/frappe/frappe/model/document.py", line 908, in run_post_save_methods
    self.run_method("on_submit")
  File "/Users/speedy/frappe-bench/apps/frappe/frappe/model/document.py", line 772, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/Users/speedy/frappe-bench/apps/frappe/frappe/model/document.py", line 1048, in composer
    return composed(self, method, *args, **kwargs)
  File "/Users/speedy/frappe-bench/apps/frappe/frappe/model/document.py", line 1031, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/Users/speedy/frappe-bench/apps/frappe/frappe/model/document.py", line 766, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/Users/speedy/frappe-bench/apps/erpnext/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py", line 137, in on_submit
    self.make_gl_entries()
  File "/Users/speedy/frappe-bench/apps/erpnext/erpnext/controllers/stock_controller.py", line 25, in make_gl_entries
    warehouse_account = get_warehouse_account_map()
  File "/Users/speedy/frappe-bench/apps/erpnext/erpnext/stock/__init__.py", line 22, in get_warehouse_account_map
    d.account = get_warehouse_account(d, warehouse_account)
  File "/Users/speedy/frappe-bench/apps/erpnext/erpnext/stock/__init__.py", line 36, in get_warehouse_account
    account = warehouse_account.get(warehouse.parent_warehouse).account
AttributeError: 'NoneType' object has no attribute 'account'

```