### PR TITLE
Copy Payment terms from Sales Order when creating Sales Invoice from SO or DN and also update due date

### DIFF
--- a/erpnext/selling/doctype/quotation/test_quotation.py
+++ b/erpnext/selling/doctype/quotation/test_quotation.py
@@ -129,8 +129,8 @@ class TestQuotation(unittest.TestCase):
 
 		sales_order = make_sales_order(quotation.name)
 		sales_order.naming_series = "_T-Quotation-"
-		sales_order.transaction_date = "2016-01-01"
-		sales_order.delivery_date = "2016-01-02"
+		sales_order.transaction_date = nowdate()
+		sales_order.delivery_date = add_months(nowdate(), 1)
 
 		sales_order.insert()
 

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -2,7 +2,7 @@
 # License: GNU General Public License v3. See license.txt
 from __future__ import unicode_literals
 import frappe
-from frappe.utils import flt, add_days
+from frappe.utils import flt, add_days, getdate
 import frappe.permissions
 import unittest
 from erpnext.selling.doctype.sales_order.sales_order \
@@ -51,6 +51,8 @@ class TestSalesOrder(unittest.TestCase):
 		self.assertEqual(len(si.get("items")), len(so.get("items")))
 		self.assertEqual(len(si.get("items")), 1)
 
+		self.assertEqual(len(si.get("payment_schedule")), len(so.get("payment_schedule")))
+
 		si.insert()
 		si.submit()
 
@@ -89,9 +91,9 @@ class TestSalesOrder(unittest.TestCase):
 		si.insert()
 
 		self.assertEqual(si.payment_schedule[0].payment_amount, 500.0)
-		self.assertEqual(si.payment_schedule[0].due_date, so.transaction_date)
+		self.assertEqual(si.payment_schedule[0].due_date.date(), getdate(so.transaction_date))
 		self.assertEqual(si.payment_schedule[1].payment_amount, 500.0)
-		self.assertEqual(si.payment_schedule[1].due_date, add_days(so.transaction_date, 30))
+		self.assertEqual(si.payment_schedule[1].due_date.date(), getdate(add_days(so.transaction_date, 30)))
 
 		si.submit()
 
@@ -545,13 +547,6 @@ class TestSalesOrder(unittest.TestCase):
 		so.insert()
 
 		self.assertTrue(so.get('payment_schedule'))
-
-	def test_terms_not_copied(self):
-		so = make_sales_order()
-		self.assertTrue(so.get('payment_schedule'))
-
-		si = make_sales_invoice(so.name)
-		self.assertFalse(si.get('payment_schedule'))
 
 	def test_terms_copied(self):
 		so = make_sales_order(do_not_copy=1, do_not_save=1)

--- a/erpnext/stock/doctype/delivery_note/test_delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/test_delivery_note.py
@@ -655,6 +655,17 @@ class TestDeliveryNote(unittest.TestCase):
 		si = make_sales_invoice(dn.name)
 		self.assertEquals(si.items[0].qty, 1)
 
+	def test_si_from_dn_with_so(self):
+		so = make_sales_order()
+		dn = create_dn_against_so(so.name, delivered_qty=2)
+
+		si = make_sales_invoice(dn.name)
+		si.submit()
+
+		dn.load_from_db()
+		self.assertEqual(dn.get("items")[0].against_sales_order, si.get("items")[0].sales_order)
+		self.assertEqual(len(so.get("payment_schedule")), len(si.get("payment_schedule")))
+
 def create_delivery_note(**args):
 	dn = frappe.new_doc("Delivery Note")
 	args = frappe._dict(args)


### PR DESCRIPTION
Issue:
On creating the Sales Invoice from Sales Order or Delivery Note, the payment schedule is not created. On save the payment schedule does appear based on Payment Terms Template but the manually added payment terms or edited payment terms does not. And also there is a need to recalculate the due date as it is based on Sales Invoice date and in case of Delivery Note, amount can be different too in case of partial delivery so needs recalculation.
<img width="1200" alt="screen shot 2018-10-02 at 11 31 57 pm" src="https://user-images.githubusercontent.com/16913064/46658500-7ae0f780-cbd0-11e8-998c-bd46ff31b1ec.png">

Solution:
In Sales Order just copy over the payment schedule and calculate the new due date.
In Delivery Note, since it does not have the payment schedule, check if items are against SO, if yes, then get payment schedule from SO and re-calculate.

Sales Order payment terms with manual edits:
<img width="1166" alt="screen shot 2018-10-09 at 2 40 16 pm" src="https://user-images.githubusercontent.com/16913064/46660094-ef696580-cbd3-11e8-98a3-4218a813703b.png">

Sales Invoice payment terms created when Sales Invoice created from Sales Order:
<img width="1183" alt="screen shot 2018-10-09 at 2 40 46 pm" src="https://user-images.githubusercontent.com/16913064/46660158-11fb7e80-cbd4-11e8-8d26-ce9263e5f676.png">

Sales Invoice payment terms created from Delivery Note on making partial delivery.
<img width="1179" alt="screen shot 2018-10-09 at 2 57 04 pm" src="https://user-images.githubusercontent.com/16913064/46660209-2d668980-cbd4-11e8-94f9-1d6107c09b5d.png">

