### PR TITLE
[Fix] Check for prefix before return EcritureNum

### DIFF
--- a/erpnext/regional/report/fichier_des_ecritures_comptables_[fec]/fichier_des_ecritures_comptables_[fec].py
+++ b/erpnext/regional/report/fichier_des_ecritures_comptables_[fec]/fichier_des_ecritures_comptables_[fec].py
@@ -105,9 +105,12 @@ def get_result_as_list(data, filters):
 
 	for d in data:
 
-		JournalCode = re.split("-|/", d.get("voucher_no"))[0]
+		JournalCode = re.split("-|/|[0-9]", d.get("voucher_no"))[0]
 
-		EcritureNum = re.split("-|/", d.get("voucher_no"))[1]
+		if d.get("voucher_no").startswith("{0}-".format(JournalCode)) or d.get("voucher_no").startswith("{0}/".format(JournalCode)):
+			EcritureNum = re.split("-|/", d.get("voucher_no"))[1]
+		else:
+			EcritureNum = re.search("{0}(\d+)".format(JournalCode), d.get("voucher_no"), re.IGNORECASE).group(1)
 
 		EcritureDate = format_datetime(d.get("GlPostDate"), "yyyyMMdd")
 


### PR DESCRIPTION
Hi,

This PR adds an additional check for the FEC report:

If the naming series prefix doesn't have a '-' or a '/' the report can currently not being generated.

Now it also takes into account prefixes that doesn't have a '-' or a '/' within.

Thanks you!

