### PR TITLE
[Fix] Handle multiple Item Defaults for a company

### DIFF
--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -122,6 +122,7 @@ class Item(WebsiteGenerator):
 		self.validate_fixed_asset()
 		self.validate_retain_sample()
 		self.validate_uom_conversion_factor()
+		self.validate_item_defaults()
 		self.update_defaults_from_item_group()
 
 		if not self.get("__islocal"):
@@ -662,6 +663,12 @@ class Item(WebsiteGenerator):
 					template_item.flags.dont_update_variants = True
 					template_item.flags.ignore_permissions = True
 					template_item.save()
+
+	def validate_item_defaults(self):
+		companies = list(set([row.company for row in self.item_defaults]))
+
+		if len(companies) != len(self.item_defaults):
+			frappe.throw(_("Cannot set multiple Item Defaults for a company."))
 
 	def update_defaults_from_item_group(self):
 		"""Get defaults from Item Group"""


### PR DESCRIPTION
Currently, the system lets you add multiple Item Defaults for the same company. This can cause unexpected behaviour elsewhere in the system.

**IMPORTANT NOTE:** This needs more discussion regarding existing implementations with multiple set Defaults.

<hr>

**Screenshots / GIFs**

![item_defaults_erpn](https://user-images.githubusercontent.com/13396535/46669141-32373780-cbec-11e8-9f4b-b11986df0b72.gif)