### PR TITLE
If Project has no Tasks, let the status be set as Completed

### DIFF
--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -187,6 +187,7 @@ class Project(Document):
 			frappe.db.set_value("Sales Order", self.sales_order, "project", self.name)
 
 	def update_percent_complete(self):
+		if not self.tasks: return
 		total = frappe.db.sql("""select count(name) from tabTask where project=%s""", self.name)[0][0]
 		if not total and self.percent_complete:
 			self.percent_complete = 0


### PR DESCRIPTION
While changing status of a Project, if it has no Tasks and you change the status to Completed, it sets it back to Open. So, user should be allowed to change if no Tasks are present.