### PR TITLE
[Feature] Query Report: Sales Order Items not requested for Manufacturing

### DIFF
--- a/erpnext/selling/report/pending_so_items_for_material_request/pending_so_items_for_material_request.json
+++ b/erpnext/selling/report/pending_so_items_for_material_request/pending_so_items_for_material_request.json
@@ -1,0 +1,36 @@
+{
+ "add_total_row": 1,
+ "creation": "2018-09-26 17:23:01.749540",
+ "disabled": 0,
+ "docstatus": 0,
+ "doctype": "Report",
+ "idx": 0,
+ "is_standard": "Yes",
+ "modified": "2018-10-11 12:21:44.887980",
+ "modified_by": "Administrator",
+ "module": "Selling",
+ "name": "Pending SO Items for Material Request",
+ "owner": "Administrator",
+ "prepared_report": 0,
+ "query": "SELECT \n\tso.`name` AS \"Sales Order ID:Link/Sales Order:120\",  \t \n\tso_item.item_code AS \"Item Code:Link/Item:120\",\n\tmr_sum.name AS \"Material Request ID:Link/Material Request:120\",\n\tso_item.qty AS \"Sales Order Qty:Float:100 \",\n\tmr_sum.qty AS \"Material Request Qty:Float:100\"\nFROM\n\t`tabSales Order` so \n \tLEFT JOIN `tabSales Order Item` AS so_item \n\t\tON so.`name` = so_item.`parent` \n \tLEFT JOIN (Select mr_item.qty, mr.name, mr_item.sales_order, mr_item.item_code \n\t\tfrom  `tabMaterial Request` AS mr, `tabMaterial Request Item` AS mr_item \n\t\twhere mr.status != \"Cancelled\"\n\t\tAND mr.status != \"Stopped\" \n\t\tAND  mr_item.parent = mr.name) AS mr_sum \n\t\tON so_item.item_code = mr_sum.item_code\n\t\tAND  so.`name` = mr_sum.sales_order\n\t\t\t\t\t \t\nWHERE \n\tso.docstatus = 1 \n\tAND so.status != \"Closed\"\n\tAND so.per_delivered < 100\n\tAND COALESCE(so_item.qty,0)> COALESCE(mr_sum.qty,0)  \nGROUP BY so.name, so_item.item_code\nORDER BY so.name desc, so_item.item_code asc; \n\n\n",
+ "ref_doctype": "Sales Order",
+ "report_name": "Pending SO Items for Material Request",
+ "report_type": "Query Report",
+ "roles": [
+  {
+   "role": "Sales User"
+  },
+  {
+   "role": "Sales Manager"
+  },
+  {
+   "role": "Maintenance User"
+  },
+  {
+   "role": "Accounts User"
+  },
+  {
+   "role": "Stock User"
+  }
+ ]
+}


### PR DESCRIPTION
- Pending Sales Order Items for Material Request
- This report has following columns(In this order):
     - Row No.
     - Sales Order ID(Only Submitted, Pending, Overdue SO should be shown)
     - Sales Order Item Code
     - Material Request ID **(Only shows if Sales Order Qty > Material Request Qty)**
     - Sales Order Qty
     - Material Request Qty **(Only shows if Sales Order Qty > Material Request Qty)**
- Sales Order for which a material request was  partially completed will only have remaining items listed,
   If a sales order is delivered 100% then that sales order is not shown in this report.
   (e.g. SAL - ORD - 2018-0001)
![pending_so_items_for_material_request](https://user-images.githubusercontent.com/14824451/46785082-4abf6300-cd4e-11e8-8d2d-712e31b4fdc2.png)
- Once a material request has been issued then that sales order is not listed anymore.
   (e.g. SAL- ORD - 2018 - 00004)
![pending_so_items_for_material_request_2](https://user-images.githubusercontent.com/14824451/46785090-4eeb8080-cd4e-11e8-9a2c-6454298ac5da.png)
