### PR TITLE
[Hotfix] Compatibility with Py2 in daily work summary

### DIFF
--- a/erpnext/hr/doctype/daily_work_summary/daily_work_summary.py
+++ b/erpnext/hr/doctype/daily_work_summary/daily_work_summary.py
@@ -9,6 +9,7 @@ from frappe import _
 from email_reply_parser import EmailReplyParser
 from erpnext.hr.doctype.employee.employee import is_holiday
 from frappe.utils import global_date_format
+from six import string_types
 
 
 class DailyWorkSummary(Document):
@@ -108,7 +109,7 @@ def get_user_emails_from_group(group):
 
 	:param group: Daily Work Summary Group `name`'''
 	group_doc = group
-	if isinstance(group_doc, str):
+	if isinstance(group_doc, string_types):
 		group_doc = frappe.get_doc('Daily Work Summary Group', group)
 
 	emails = [d.email for d in group_doc.users if frappe.db.get_value("User", d.user, "enabled")]


### PR DESCRIPTION
Hi,

The current code to fetch user emails from daily work summary groups is not compatible with python 2.
I added string_types to avoid the daily work summary replies report to fail.

Thank you.

