### PR TITLE
[Fix] TDS Payable Monthly report is not working

### DIFF
--- a/erpnext/accounts/report/tds_payable_monthly/tds_payable_monthly.js
+++ b/erpnext/accounts/report/tds_payable_monthly/tds_payable_monthly.js
@@ -8,6 +8,7 @@ frappe.query_reports["TDS Payable Monthly"] = {
 			"fieldname":"company",
 			"label": __("Company"),
 			"fieldtype": "Link",
+			"options": "Company",
 			"default": frappe.defaults.get_default('company')
 		},
 		{

--- a/erpnext/accounts/report/tds_payable_monthly/tds_payable_monthly.py
+++ b/erpnext/accounts/report/tds_payable_monthly/tds_payable_monthly.py
@@ -64,13 +64,16 @@ def get_result(filters):
 				total_amount_credited += k.credit
 
 		rate = [i.tax_withholding_rate for i in tds_doc.rates
-			if i.fiscal_year == gle_map[d][0].fiscal_year][0]
+			if i.fiscal_year == gle_map[d][0].fiscal_year]
 
-		if getdate(filters.from_date) <= gle_map[d][0].posting_date \
-			and getdate(filters.to_date) >= gle_map[d][0].posting_date:
-			out.append([supplier.pan, supplier.name, tds_doc.name,
-				supplier.supplier_type, rate, total_amount_credited, tds_deducted,
-				gle_map[d][0].posting_date, "Purchase Invoice", d])
+		if rate and len(rate) > 0:
+			rate = rate[0]
+
+			if getdate(filters.from_date) <= gle_map[d][0].posting_date \
+				and getdate(filters.to_date) >= gle_map[d][0].posting_date:
+				out.append([supplier.pan, supplier.name, tds_doc.name,
+					supplier.supplier_type, rate, total_amount_credited, tds_deducted,
+					gle_map[d][0].posting_date, "Purchase Invoice", d])
 
 	return out
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 55, in application
    response = frappe.handler.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 20, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 55, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1007, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 489, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 174, in run
    result = generate_report_result(report, filters, user)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 65, in generate_report_result
    res = frappe.get_attr(method_name)(frappe._dict(filters))
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/report/tds_payable_monthly/tds_payable_monthly.py", line 18, in execute
    res = get_result(filters)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/report/tds_payable_monthly/tds_payable_monthly.py", line 67, in get_result
    if i.fiscal_year == gle_map[d][0].fiscal_year][0]
IndexError: list index out of range
```