### PR TITLE
[Fix] Add safe decode for payer name in payment request URL

### DIFF
--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -123,7 +123,7 @@ class PaymentRequest(Document):
 			"reference_doctype": "Payment Request",
 			"reference_docname": self.name,
 			"payer_email": self.email_to or frappe.session.user,
-			"payer_name": data.customer_name,
+			"payer_name": frappe.safe_decode(data.customer_name),
 			"order_id": self.name,
 			"currency": self.currency
 		})


### PR DESCRIPTION
Hi,

Currently, when a customer has an accent in its name, the following method fails with an UnicodeEncodeError:
`return get_url("./integrations/braintree_checkout?{0}".format(urlencode(kwargs)))`

I have added frappe.safe_decode on the payer name when the URL is created to avoid this error.

Thank you!


