### PR TITLE
Upgrade BOM Stock Report base with Qty to Produce

### DIFF
--- a/erpnext/manufacturing/report/bom_stock_report/bom_stock_report.js
+++ b/erpnext/manufacturing/report/bom_stock_report/bom_stock_report.js
@@ -16,6 +16,22 @@ frappe.query_reports["BOM Stock Report"] = {
 			"fieldname": "show_exploded_view",
 			"label": __("Show exploded view"),
 			"fieldtype": "Check"
+		}, {
+					"fieldname": "qty_to_produce",
+					"label": __("Quantity to Produce"),
+					"fieldtype": "Int",
+					"default": "1"
+		 },
+	],
+	"formatter": function(value, row, column, data, default_formatter) {
+		value = default_formatter(value, row, column, data);
+		if (column.id == "Item"){
+			if (data["Enough Parts to Build"] > 0){
+				value = `<a style='color:green' href="#Form/Item/${data['Item']}" data-doctype="Item">${data['Item']}</a>`
+			} else {
+				value = `<a style='color:red' href="#Form/Item/${data['Item']}" data-doctype="Item">${data['Item']}</a>`
+			}
 		}
-	]
+		return value
+	}
 }

--- a/erpnext/manufacturing/report/bom_stock_report/bom_stock_report.js
+++ b/erpnext/manufacturing/report/bom_stock_report/bom_stock_report.js
@@ -17,10 +17,10 @@ frappe.query_reports["BOM Stock Report"] = {
 			"label": __("Show exploded view"),
 			"fieldtype": "Check"
 		}, {
-					"fieldname": "qty_to_produce",
-					"label": __("Quantity to Produce"),
-					"fieldtype": "Int",
-					"default": "1"
+			"fieldname": "qty_to_produce",
+			"label": __("Quantity to Produce"),
+			"fieldtype": "Int",
+			"default": "1"
 		 },
 	],
 	"formatter": function(value, row, column, data, default_formatter) {

--- a/erpnext/manufacturing/report/bom_stock_report/bom_stock_report.py
+++ b/erpnext/manufacturing/report/bom_stock_report/bom_stock_report.py
@@ -7,6 +7,7 @@ from frappe import _
 
 def execute(filters=None):
 	if not filters: filters = {}
+
 	columns = get_columns()
 
 	data = get_bom_stock(filters)
@@ -18,6 +19,7 @@ def get_columns():
 	columns = [
 		_("Item") + ":Link/Item:150",
 		_("Description") + "::500",
+		_("Qty per BOM Line") + ":Float:100",
 		_("Required Qty") + ":Float:100",
 		_("In Stock Qty") + ":Float:100",
 		_("Enough Parts to Build") + ":Float:200",
@@ -32,6 +34,10 @@ def get_bom_stock(filters):
 	table = "`tabBOM Item`"
 	qty_field = "qty"
 
+	qty_to_produce = filters.get("qty_to_produce", 1)
+	if  int(qty_to_produce) <= 0:
+		frappe.throw(_("Quantity to Produce can not be less than Zero"))
+
 	if filters.get("show_exploded_view"):
 		table = "`tabBOM Explosion Item`"
 		qty_field = "stock_qty"
@@ -43,18 +49,19 @@ def get_bom_stock(filters):
 				where wh.lft >= %s and wh.rgt <= %s and ledger.warehouse = wh.name)" % (warehouse_details.lft,
 				warehouse_details.rgt)
 		else:
-			conditions += " and ledger.warehouse = %s" % frappe.db.escape(filters.get("warehouse"))
+			conditions += " and ledger.warehouse = '%s'" % frappe.db.escape(filters.get("warehouse"))
 
 	else:
 		conditions += ""
 
 	return frappe.db.sql("""
 			SELECT
-				bom_item.item_code ,
+				bom_item.item_code,
 				bom_item.description ,
 				bom_item.{qty_field},
+				bom_item.{qty_field} * {qty_to_produce},
 				sum(ledger.actual_qty) as actual_qty,
-				sum(FLOOR(ledger.actual_qty / bom_item.{qty_field}))as to_build
+				sum(FLOOR(ledger.actual_qty / (bom_item.{qty_field} * {qty_to_produce})))
 			FROM
 				{table} AS bom_item
 				LEFT JOIN `tabBin` AS ledger
@@ -63,4 +70,10 @@ def get_bom_stock(filters):
 			WHERE
 				bom_item.parent = '{bom}' and bom_item.parenttype='BOM'
 
-			GROUP BY bom_item.item_code""".format(qty_field=qty_field, table=table, conditions=conditions, bom=bom))
+			GROUP BY bom_item.item_code""".format(
+				qty_field=qty_field,
+				table=table,
+				conditions=conditions,
+				bom=bom,
+				qty_to_produce=qty_to_produce or 1)
+			)


### PR DESCRIPTION
This a minor upgrade of BOM Stock Report with the addition of Qty to Produce (Similar to the report in source bom_stock_calculated)

Qty to Produce defualts to 1 and Report behaves as it used. With the other selection there is auto calculation for the other fields.

Also, some coloring added to Item Code for easy reference if BOM line has Enought Part to Produce.

![2018-10-15 15 39 45](https://user-images.githubusercontent.com/5064612/46951996-436fc080-d092-11e8-8567-1512854a916b.gif)

