### PR TITLE
Safe encode payer name

### DIFF
--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -123,7 +123,7 @@ class PaymentRequest(Document):
 			"reference_doctype": "Payment Request",
 			"reference_docname": self.name,
 			"payer_email": self.email_to or frappe.session.user,
-			"payer_name": frappe.safe_decode(data.customer_name),
+			"payer_name": frappe.safe_encode(data.customer_name),
 			"order_id": self.name,
 			"currency": self.currency
 		})


### PR DESCRIPTION
Hi,

I'm sorry I made a mistake (eventhough it worked when testing...) by using safe_decode instead of safe_encode for the payer name.

But it still throws 'UnicodeEncodeError' if the payer has an accent in its name...

Please find the correction attached.

Have a nice day!

