### PR TITLE
Update 'cart count' cookie when shopping cart is updated

### DIFF
--- a/erpnext/public/js/shopping_cart.js
+++ b/erpnext/public/js/shopping_cart.js
@@ -52,6 +52,7 @@ $.extend(shopping_cart, {
 				},
 				btn: opts.btn,
 				callback: function(r) {
+					document.cookie = 'cart_count='+r.message.cart_count.toString();
 					shopping_cart.set_cart_count();
 					if (r.message.shopping_cart_menu) {
 						$('.shopping-cart-menu').html(r.message.shopping_cart_menu);

--- a/erpnext/public/js/shopping_cart.js
+++ b/erpnext/public/js/shopping_cart.js
@@ -52,7 +52,7 @@ $.extend(shopping_cart, {
 				},
 				btn: opts.btn,
 				callback: function(r) {
-					document.cookie = 'cart_count='+r.message.cart_count.toString();
+					document.cookie = 'cart_count='+r.message.cart_count;
 					shopping_cart.set_cart_count();
 					if (r.message.shopping_cart_menu) {
 						$('.shopping-cart-menu').html(r.message.shopping_cart_menu);

--- a/erpnext/shopping_cart/cart.py
+++ b/erpnext/shopping_cart/cart.py
@@ -112,9 +112,11 @@ def update_cart(item_code, qty, with_items=False):
 	quotation.payment_schedule = []
 	if not empty_card:
 		quotation.save()
+		cart_count = cstr(len(quotation.get("items")))
 	else:
 		quotation.delete()
 		quotation = None
+		cart_count = 0
 
 	set_cart_count(quotation)
 
@@ -126,11 +128,13 @@ def update_cart(item_code, qty, with_items=False):
 				context),
 			"taxes": frappe.render_template("templates/includes/order/order_taxes.html",
 				context),
+			"cart_count": cart_count
 		}
 	else:
 		return {
 			'name': quotation.name,
-			'shopping_cart_menu': get_shopping_cart_menu(context)
+			'shopping_cart_menu': get_shopping_cart_menu(context),
+			'cart_count': cart_count
 		}
 
 @frappe.whitelist()

--- a/erpnext/shopping_cart/cart.py
+++ b/erpnext/shopping_cart/cart.py
@@ -112,7 +112,7 @@ def update_cart(item_code, qty, with_items=False):
 	quotation.payment_schedule = []
 	if not empty_card:
 		quotation.save()
-		cart_count = cstr(len(quotation.get("items")))
+		cart_count = cint(len(quotation.get("items")))
 	else:
 		quotation.delete()
 		quotation = None


### PR DESCRIPTION
Currently, when the website's shopping cart is updated by either adding an item or changing the quantity of an existing item, the 'cart count' cookie isn't updated until the page is refreshed. This results in an incorrect cart count in the shopping cart dropdown on the nav bar. 

For instance, if there is 1 item in the shopping cart, and you click 'Add to Cart' on an item page so that there are now 2 items in the shopping cart, the cart dropdown in the nav bar will still say there is 1 item in the shopping cart. 

This fix resets the 'cart count' cookie after the cart is updated so that the correct cart count is displayed in the nav bar without needing to reload the page. 

