### PR TITLE
Fix for "Improve this page" incorrect link generated in v10 sites

### DIFF
--- a/erpnext/config/docs.py
+++ b/erpnext/config/docs.py
@@ -1,3 +1,3 @@
 from __future__ import unicode_literals
 
-source_link = "https://github.com/frappe/erpnext"
+source_link = "https://github.com/erpnext/foundation"

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -15,6 +15,8 @@ develop_version = '10.x.x-develop'
 
 error_report_email = "support@erpnext.com"
 
+docs_app = "foundation"
+
 app_include_js = "assets/js/erpnext.min.js"
 app_include_css = "assets/css/erpnext.css"
 web_include_js = "assets/js/erpnext-web.min.js"


### PR DESCRIPTION
The issue was first noticed in the following thread:

https://discuss.erpnext.com/t/deadlinks-on-improve-this-page-in-online-manual/41891?u=kennethsequeira

![docs-improve](https://user-images.githubusercontent.com/33246109/47200104-3a346b80-d392-11e8-8cbf-882f53af7248.gif)

After fix:

![erpnext-fix](https://user-images.githubusercontent.com/17617465/47200197-b9c23a80-d392-11e8-99b8-bd08ea19a438.gif)


Fixed along with @shreyashah115 

