### PR TITLE
fix(hr): Delete salary slip when cancel payroll entry

### DIFF
--- a/erpnext/hr/doctype/payroll_entry/payroll_entry.py
+++ b/erpnext/hr/doctype/payroll_entry/payroll_entry.py
@@ -20,6 +20,10 @@ class PayrollEntry(Document):
 			if self.validate_employee_attendance():
 				frappe.throw(_("Cannot Submit, Employees left to mark attendance"))
 
+	def on_cancel(self):
+		frappe.delete_doc("Salary Slip", frappe.db.sql_list("""select name from `tabSalary Slip`
+			where payroll_entry=%s """, (self.name)))
+
 	def get_emp_list(self):
 		"""
 			Returns list of active employees based on selected criteria


### PR DESCRIPTION
Please read the pull request checklist to make sure your changes are merged: https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist
Hi there!
We usually use payroll entry to estimate money have to pay for a period and create salary slip draft many time so I want to delete all of salary slip related when cancel a payroll entry.
Let's me know if it not suitable 