### PR TITLE
[fix] Invoice/Delivery note customer po_no overwritten by Sales order

### DIFF
--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -345,7 +345,8 @@ class SellingController(StockController):
 			sales_orders = list(set([d.get(ref_fieldname) for d in self.items if d.get(ref_fieldname)]))
 			if sales_orders:
 				po_nos = frappe.get_all('Sales Order', 'po_no', filters = {'name': ('in', sales_orders)})
-				self.po_no = ', '.join(list(set([d.po_no for d in po_nos if d.po_no])))
+				if po_nos and po_nos[0].get('po_no'):
+					self.po_no = ', '.join(list(set([d.po_no for d in po_nos if d.po_no])))
 
 	def validate_items(self):
 		# validate items to see if they have is_sales_item enabled


### PR DESCRIPTION
Validation Issue: In Sales Invoice/Delivery Note, customer po_no is overwritten by Null po_no from Sales Order

Issue ref: [#14812](https://github.com/frappe/erpnext/issues/14812)



Sangram Patil
Indictranstech Technologies Pvt. Ltd, Pune
