### PR TITLE
Update employee_advance.py

### DIFF
--- a/erpnext/hr/doctype/employee_advance/employee_advance.py
+++ b/erpnext/hr/doctype/employee_advance/employee_advance.py
@@ -69,7 +69,7 @@ class EmployeeAdvance(Document):
 			where employee_advance = %s and docstatus=1 and allocated_amount > 0
 		""", self.name)[0][0]
 
-		frappe.db.set_value("Employee Advance", self.name, "claimed_amount", claimed_amount)
+		frappe.db.set_value("Employee Advance", self.name, "claimed_amount", flt(claimed_amount))
 
 @frappe.whitelist()
 def get_due_advance_amount(employee, posting_date):


### PR DESCRIPTION
https://github.com/frappe/erpnext/issues/13694
Cancel of  already paid "Expense Claim" gives error IntegrityError: (1048, u"Column 'claimed_amount' cannot be null")
Sol: claimed_amount should be flt

Please read the pull request checklist to make sure your changes are merged: https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

