### PR TITLE
[fix] conditional discount_amount print_hide

### DIFF
--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -28,6 +28,13 @@ class BuyingController(StockController):
 				"taxes": "templates/print_formats/includes/taxes.html"
 			}
 
+	def before_print(self):
+		def toggle_print_hide(meta, fieldname):
+			df = meta.get_field(fieldname)
+			df.set("print_hide", 1 if self.get("taxes") else 0)
+
+		toggle_print_hide(self.meta, "discount_amount")
+
 	def get_feed(self):
 		if self.get("supplier_name"):
 			return _("From {0} | {1} {2}").format(self.supplier_name, self.currency,

--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -24,6 +24,13 @@ class SellingController(StockController):
 				"taxes": "templates/print_formats/includes/taxes.html"
 			}
 
+	def before_print(self):
+		def toggle_print_hide(meta, fieldname):
+			df = meta.get_field(fieldname)
+			df.set("print_hide", 1 if self.get("taxes") else 0)
+
+		toggle_print_hide(self.meta, "discount_amount")
+
 	def get_feed(self):
 		return _("To {0} | {1} {2}").format(self.customer_name, self.currency,
 			self.grand_total)


### PR DESCRIPTION
Discount Amount field is part of taxes.html. So, the discount amount is not visible on print if taxes are absent. So, I have added conditional print_hide for Discount Amount field. So, it will show on Print if taxes are not available.

Ref : [15458](https://github.com/frappe/erpnext/issues/15458)
