### PR TITLE
fix(report): Return if not list

### DIFF
--- a/erpnext/education/report/student_monthly_attendance_sheet/student_monthly_attendance_sheet.py
+++ b/erpnext/education/report/student_monthly_attendance_sheet/student_monthly_attendance_sheet.py
@@ -73,6 +73,7 @@ def get_attendance_list(from_date, to_date, student_group, students_list):
 	return att_map
 
 def get_students_with_leave_application(from_date, to_date, students_list):
+	if not students_list: return
 	leave_applications = frappe.db.sql("""
 		select student, from_date, to_date 
 		from `tabStudent Leave Application` 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/Users/speedy/bench-master/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.handler.handle()
  File "/Users/speedy/bench-master/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/Users/speedy/bench-master/apps/frappe/frappe/handler.py", line 53, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/speedy/bench-master/apps/frappe/frappe/__init__.py", line 939, in call
    return fn(*args, **newargs)
  File "/Users/speedy/bench-master/apps/frappe/frappe/desk/query_report.py", line 96, in run
    res = frappe.get_attr(method_name)(frappe._dict(filters))
  File "/Users/speedy/bench-master/apps/erpnext/erpnext/education/report/student_monthly_attendance_sheet/student_monthly_attendance_sheet.py", line 20, in execute
    att_map = get_attendance_list(from_date, to_date, filters.get("student_group"), students_list)
  File "/Users/speedy/bench-master/apps/erpnext/erpnext/education/report/student_monthly_attendance_sheet/student_monthly_attendance_sheet.py", line 66, in get_attendance_list
    students_with_leave_application = get_students_with_leave_application(from_date, to_date, students_list)
  File "/Users/speedy/bench-master/apps/erpnext/erpnext/education/report/student_monthly_attendance_sheet/student_monthly_attendance_sheet.py", line 92, in get_students_with_leave_application
    }, as_dict=True)
  File "/Users/speedy/bench-master/apps/frappe/frappe/database.py", line 166, in sql
    self._cursor.execute(query, values)
  File "/Users/speedy/bench-master/env/lib/python2.7/site-packages/pymysql/cursors.py", line 165, in execute
    result = self._query(query)
  File "/Users/speedy/bench-master/env/lib/python2.7/site-packages/pymysql/cursors.py", line 321, in _query
    conn.query(q)
  File "/Users/speedy/bench-master/env/lib/python2.7/site-packages/pymysql/connections.py", line 860, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/Users/speedy/bench-master/env/lib/python2.7/site-packages/pymysql/connections.py", line 1061, in _read_query_result
    result.read()
  File "/Users/speedy/bench-master/env/lib/python2.7/site-packages/pymysql/connections.py", line 1349, in read
    first_packet = self.connection._read_packet()
  File "/Users/speedy/bench-master/env/lib/python2.7/site-packages/pymysql/connections.py", line 1018, in _read_packet
    packet.check_error()
  File "/Users/speedy/bench-master/env/lib/python2.7/site-packages/pymysql/connections.py", line 384, in check_error
    err.raise_mysql_exception(self._data)
  File "/Users/speedy/bench-master/env/lib/python2.7/site-packages/pymysql/err.py", line 107, in raise_mysql_exception
    raise errorclass(errno, errval)
ProgrammingError: (1064, u"You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ')\n\t\t\tand (\n\t\t\t\tfrom_date between '2018-10-01' and '2018-10-31'\n\t\t\t\tor to_date be' at line 5")
```