### PR TITLE
fix: Delete button in POS mobile

### DIFF
--- a/erpnext/public/less/erpnext.less
+++ b/erpnext/public/less/erpnext.less
@@ -412,6 +412,12 @@ body[data-route="pos"] {
 	.collapse-btn {
 		cursor: pointer;
 	}
+	
+	@media (max-width: @screen-xs) {
+		.page-actions {
+			max-width: 110px;
+		}
+	}
 }
 
 .price-info {


### PR DESCRIPTION
Delete button was covered by page-actions container

Before:
![image](https://user-images.githubusercontent.com/9355208/47642008-8a2ee180-db8d-11e8-97c2-28aadcb5809f.png)


After:
![image](https://user-images.githubusercontent.com/9355208/47641994-7d11f280-db8d-11e8-8dc3-07e124ad3db3.png)

