### PR TITLE
[Fix] Payment entry not able to submit in multi-currency 

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -791,15 +791,25 @@ frappe.ui.form.on('Payment Entry', {
 						var write_off_row = $.map(frm.doc["deductions"] || [], function(t) {
 							return t.account==r.message[account] ? t : null; });
 
-						if (!write_off_row.length) {
-							var row = frm.add_child("deductions");
+						var row = [];
+
+						var difference_amount = flt(frm.doc.difference_amount,
+							precision("difference_amount"));
+
+						if (!write_off_row.length && difference_amount) {
+							row = frm.add_child("deductions");
 							row.account = r.message[account];
 							row.cost_center = r.message["cost_center"];
 						} else {
-							var row = write_off_row[0];
+							row = write_off_row[0];
 						}
 
-						row.amount = flt(row.amount) + flt(frm.doc.difference_amount);
+						if (row) {
+							row.amount = flt(row.amount) + difference_amount;
+						} else {
+							frappe.msgprint(__("No gain or loss in the exchange rate"))
+						}
+
 						refresh_field("deductions");
 
 						frm.events.set_unallocated_amount(frm);


### PR DESCRIPTION
Steps to replicate the issue

- Created sales invoice in USD(base currency is INR) and submitted it
- Clicked on make payment > selected Accounts Paid To in USD Account and Paid From in INR 
- Clicked on button Set Exchange Gain/Loss button
- Saved payment entry and while submission getting below error
![screen shot 2018-10-30 at 12 37 10 pm](https://user-images.githubusercontent.com/8780500/47702404-d2f4a200-dc42-11e8-9ad3-873383045b10.png)
 
After debug come to know that 
Payment entry not able to submit because of precision issues
Here value of difference amount is showing as 0 in the form and on the console showing as -0.000276
