### PR TITLE
[Fix] Supplier wise sales analytics report not showing item details which is added in purchase invoice with update stock

### DIFF
--- a/erpnext/stock/report/supplier_wise_sales_analytics/supplier_wise_sales_analytics.py
+++ b/erpnext/stock/report/supplier_wise_sales_analytics/supplier_wise_sales_analytics.py
@@ -84,6 +84,14 @@ def get_suppliers_details(filters):
 			is_stock_item=1 and name=pri.item_code)""", as_dict=1):
 			item_supplier_map.setdefault(d.item_code, []).append(d.supplier)
 
+	for d in frappe.db.sql("""select pr.supplier, pri.item_code from
+		`tabPurchase Invoice` pr, `tabPurchase Invoice Item` pri
+		where pr.name=pri.parent and pr.docstatus=1 and
+		ifnull(pr.update_stock, 0) = 1 and pri.item_code=(select name from `tabItem`
+			where is_stock_item=1 and name=pri.item_code)""", as_dict=1):
+			if d.item_code not in item_supplier_map:
+				item_supplier_map.setdefault(d.item_code, []).append(d.supplier)
+
 	if supplier:
 		for item_code, suppliers in item_supplier_map.items():
 			if supplier not in suppliers:


### PR DESCRIPTION
- Added new item ITEM-00033
- Created purchase invoice with update stock for 10 qty
- Delivered to the customer by making delivery note

Item ITEM-00033 is not showing in the report Supplier wise sales analytics

**Before Fix**
![image](https://user-images.githubusercontent.com/8780500/47782638-b92c8b00-dd26-11e8-82dd-1f0babb62377.png)


**After Fix**
![image](https://user-images.githubusercontent.com/8780500/47782634-b6ca3100-dd26-11e8-9549-ad9c0195c75d.png)
