### PR TITLE
fix: Mandatory offline name

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
@@ -314,7 +314,7 @@
    "in_standard_filter": 0,
    "label": "Offline POS Name",
    "length": 0,
-   "no_copy": 0,
+   "no_copy": 1,
    "permlevel": 0,
    "precision": "",
    "print_hide": 1,
@@ -325,7 +325,7 @@
    "reqd": 0,
    "search_index": 0,
    "set_only_once": 0,
-   "unique": 0
+   "unique": 1
   },
   {
    "allow_bulk_edit": 0,
@@ -4773,7 +4773,7 @@
  "istable": 0,
  "max_attachments": 0,
  "menu_index": 0,
- "modified": "2018-07-17 13:46:52.449142",
+ "modified": "2018-10-17 18:28:52.449142",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice",

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -507,3 +507,4 @@ erpnext.patches.v10_0.set_discount_amount
 erpnext.patches.v10_0.recalculate_gross_margin_for_project
 erpnext.patches.v10_0.delete_hub_documents
 erpnext.patches.v10_0.update_user_image_in_employee
+erpnext.patches.v10_0.deduplicate_offline_pos

--- a/erpnext/patches/v10_0/deduplicate_offline_pos.py
+++ b/erpnext/patches/v10_0/deduplicate_offline_pos.py
@@ -1,0 +1,26 @@
+import frappe
+
+
+def execute():
+    duplicates = frappe.db.sql(
+        'select name, offline_pos_name from `tabSales Invoice` where '
+        'offline_pos_name is not null group by '
+        'offline_pos_name having count(*) > 1'
+    )
+
+    for duplicate in duplicates:
+        keep, offline_pos_name = duplicate
+        duplicate_list = frappe.db.sql(
+            'select name from `tabSales Invoice` where '
+            'offline_pos_name=%s',
+            offline_pos_name
+        )
+
+        counter = 0
+        for item in duplicate_list:
+            name, = item
+            if name != keep:
+                si = frappe.get_doc('Sales Invoice', name)
+                counter += 1
+                new_name = '{0}-{1}'.format(si.offline_pos_name, counter)
+                si.db_set('offline_pos_name', new_name)

--- a/erpnext/patches/v10_0/deduplicate_offline_pos.py
+++ b/erpnext/patches/v10_0/deduplicate_offline_pos.py
@@ -1,3 +1,25 @@
+# What this patch attempts to do is to make sure that offline_pos_name is
+# unique. If it finds any offline_pos_name that isn't unique, it will append
+# a number to it to make it unique i.e it will turn 1234, 1234, 1234 to 1234,
+# 1234-1, 1234-2.
+#
+# This is required so that the next action (adding a unique constraint to the
+# offline_pos_name column) can be done without problems. This next step
+# strengthens the syncing logic by taking the responsibilty for keeping out
+# duplicates to the database layer and attain greater immunity from the race
+# conditions experienced in the python code.
+#
+# see:
+# 1. https://discuss.erpnext.com/t/pos-duplicated-sales-invoice-under-the-same-offline-pos-name/28956
+# 2. https://discuss.erpnext.com/t/duplicated-sales-invoice-when-using-pos/41736
+# 3. https://discuss.erpnext.com/t/erpnext-freezing-pos-sales-auto-submission-duplicate-sales/33556/
+# and more for reports of duplicate invoices with the same offline_pos_name.
+#
+# it can also happen if you create a return invoice for a POS invoice because
+# the offline pos name gets copied from the original invoice to the return
+# invoice.
+#
+
 import frappe
 
 

--- a/erpnext/patches/v10_0/deduplicate_offline_pos.py
+++ b/erpnext/patches/v10_0/deduplicate_offline_pos.py
@@ -3,16 +3,20 @@ import frappe
 
 def execute():
     duplicates = frappe.db.sql(
-        'select name, offline_pos_name from `tabSales Invoice` where '
-        'offline_pos_name is not null group by '
-        'offline_pos_name having count(*) > 1'
+        """
+        SELECT name, offline_pos_name FROM `tabSales Invoice`
+        WHERE offline_pos_name IS NOT NULL
+        GROUP BY offline_pos_name having count(*) > 1
+        """
     )
 
     for duplicate in duplicates:
         keep, offline_pos_name = duplicate
         duplicate_list = frappe.db.sql(
-            'select name from `tabSales Invoice` where '
-            'offline_pos_name=%s',
+            """
+            SELECT name FROM `tabSales Invoice` WHERE
+            offline_pos_name=%s
+            """,
             offline_pos_name
         )
 


### PR DESCRIPTION
Please read the pull request checklist to make sure your changes are merged: https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

This is a repackaged PR based on #15699.

It doesn't address the reason for the duplication experienced when the POS is under heavy use. However, it  strengthens the POS' design by taking the responsibility of ensuring there's only one Sales Invoice per offline_pos_name from the application layer to the database layer which is more resilient to the race condition bug.

PS: While I haven't been able to reproduce this, I have gone through databases with loads of such duplicates. I have also analysed logs confirming the POS sending the same data more than 4 times to ERPNext for syncing. This should be treated as critical