### PR TITLE
allow creating sales order on the last valid day of a quotation

### DIFF
--- a/erpnext/selling/doctype/quotation/quotation.js
+++ b/erpnext/selling/doctype/quotation/quotation.js
@@ -50,7 +50,7 @@ erpnext.selling.QuotationController = erpnext.selling.SellingController.extend({
 		}
 
 		if(doc.docstatus == 1 && doc.status!=='Lost') {
-			if(!doc.valid_till || frappe.datetime.get_diff(doc.valid_till, frappe.datetime.get_today()) > 0) {
+			if(!doc.valid_till || frappe.datetime.get_diff(doc.valid_till, frappe.datetime.get_today()) >= 0) {
 				cur_frm.add_custom_button(__('Sales Order'),
 					cur_frm.cscript['Make Sales Order'], __("Make"));
 			}


### PR DESCRIPTION
The quotation reqord has a valid until (date) field.

When this date is reached, it is no longer possible to create a sales order from the quotation.

Actual behaviour: on the last day of the validity, it is already not possible to create a sales order.

Expected behaviour: it should be possible until the last day to create sales orders.

This bugfix improves the filter to include the last day of the validity.

