### PR TITLE
[Hotfix] Encoding correction

### DIFF
--- a/erpnext/accounts/report/financial_statements.py
+++ b/erpnext/accounts/report/financial_statements.py
@@ -342,7 +342,7 @@ def set_gl_entries_by_account(
 	accounts = frappe.db.sql_list("""select name from `tabAccount`
 		where lft >= %s and rgt <= %s""", (root_lft, root_rgt))
 	additional_conditions += " and account in ('{}')"\
-		.format("', '".join([frappe.db.escape(d) for d in accounts]))
+		.format("', '".join([frappe.safe_encode(frappe.db.escape(d)) for d in accounts]))
 
 	gl_entries = frappe.db.sql("""select posting_date, account, debit, credit, is_opening, fiscal_year, debit_in_account_currency, credit_in_account_currency, account_currency from `tabGL Entry`
 		where company=%(company)s


### PR DESCRIPTION
Hi,

This PR is to fix an encoding issue in the accounts reports in Staging branch.

Before the fix:
![image](https://user-images.githubusercontent.com/4903591/47798437-a915ab00-dd28-11e8-9a94-00ce124b49d6.png)

Exact traceback:
```
Traceback (most recent call last):
  File "/home/frappe/dev-bench/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/home/frappe/dev-bench/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/dev-bench/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/dev-bench/apps/frappe/frappe/__init__.py", line 1007, in call
    return fn(*args, **newargs)
  File "/home/frappe/dev-bench/apps/frappe/frappe/__init__.py", line 489, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "/home/frappe/dev-bench/apps/frappe/frappe/desk/query_report.py", line 174, in run
    result = generate_report_result(report, filters, user)
  File "/home/frappe/dev-bench/apps/frappe/frappe/desk/query_report.py", line 65, in generate_report_result
    res = frappe.get_attr(method_name)(frappe._dict(filters))
  File "/home/frappe/dev-bench/apps/erpnext/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.py", line 16, in execute
    ignore_closing_entries=True, ignore_accumulated_values_for_fy= True)
  File "/home/frappe/dev-bench/apps/erpnext/erpnext/accounts/report/financial_statements.py", line 146, in get_data
    gl_entries_by_account, ignore_closing_entries=ignore_closing_entries
  File "/home/frappe/dev-bench/apps/erpnext/erpnext/accounts/report/financial_statements.py", line 345, in set_gl_entries_by_account
    .format("', '".join([frappe.db.escape(d) for d in accounts]))
UnicodeEncodeError: 'ascii' codec can't encode character u'\xe9' in position 59: ordinal not in range(128)
```

After the fix:
![image](https://user-images.githubusercontent.com/4903591/47798397-9602db00-dd28-11e8-8420-98ff7453281c.png)


Thanks!

