### PR TITLE
fixed  divided by zero error

### DIFF
--- a/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py
+++ b/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py
@@ -54,7 +54,7 @@ def _execute(filters=None, additional_table_columns=None, additional_query_colum
 		]
 
 		row += [(d.base_net_rate * d.qty)/d.stock_qty, d.base_net_amount] \
-			if d.stock_uom != d.uom else [d.base_net_rate, d.base_net_amount]
+			if d.stock_uom != d.uom and d.stock_qty != 0 else [d.base_net_rate, d.base_net_amount]
 
 		total_tax = 0
 		for tax in tax_columns:


### PR DESCRIPTION
Users can also post  Sales Invoice with zero QTY.
But If they do so then Item Wise Sales Register report throwing divide by zero error, It's because of 0 stock qty.



