### PR TITLE
[Fix] Asset date validation

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -95,7 +95,7 @@ class Asset(AccountsController):
 			date = frappe.db.get_value(doctype, docname, 'posting_date')
 
 		if self.available_for_use_date and getdate(self.available_for_use_date) < getdate(date):
-			frappe.throw(_("Available-for-use Date is entered as past date"))
+			frappe.throw(_("Available-for-use Date should be after purchase date"))
 
 	def make_depreciation_schedule(self):
 		if self.depreciation_method != 'Manual':

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -85,7 +85,16 @@ class Asset(AccountsController):
 		elif not self.finance_books:
 			frappe.throw(_("Enter depreciation details"))
 
-		if self.available_for_use_date and getdate(self.available_for_use_date) < getdate(nowdate()):
+		if self.is_existing_asset:
+			return
+
+		date =  nowdate()
+		docname = self.purchase_receipt or self.purchase_invoice
+		if docname:
+			doctype = 'Purchase Receipt' if self.purchase_receipt else 'Purchase Invoice'
+			date = frappe.db.get_value(doctype, docname, 'posting_date')
+
+		if self.available_for_use_date and getdate(self.available_for_use_date) < getdate(date):
 			frappe.throw(_("Available-for-use Date is entered as past date"))
 
 	def make_depreciation_schedule(self):


### PR DESCRIPTION
User not able to put in use date for back dated entries.
For example user has created purchase receipt with date as 20-10-2018 and after 10 days he is submitting the asset in which he has added the in use date as 21-10-2018. But because of validation use not able to submit the asset because current date is greater than in use date

After fix:
Now we are checking in use date with the date of purchase receipt or purchase invoice(update stock enabled) and not checking with current date