### PR TITLE
Return default if company not found

### DIFF
--- a/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py
+++ b/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py
@@ -16,7 +16,7 @@ def _execute(filters=None, additional_table_columns=None, additional_query_colum
 	if not filters: filters = {}
 	columns = get_columns(additional_table_columns)
 
-	company_currency = erpnext.get_company_currency(filters.company)
+	company_currency = erpnext.get_company_currency(filters.get('company'))
 
 	item_list = get_items(filters, additional_query_columns)
 	if item_list:


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2018-10-31/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2018-10-31/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2018-10-31/apps/frappe/frappe/handler.py", line 53, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2018-10-31/apps/frappe/frappe/__init__.py", line 939, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2018-10-31/apps/frappe/frappe/desk/query_report.py", line 96, in run
    res = frappe.get_attr(method_name)(frappe._dict(filters))
  File "/home/frappe/benches/bench-2018-10-31/apps/erpnext/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py", line 13, in execute
    return _execute(filters)
  File "/home/frappe/benches/bench-2018-10-31/apps/erpnext/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py", line 19, in _execute
    company_currency = erpnext.get_company_currency(filters.company)
AttributeError: 'dict' object has no attribute 'company'
```