### PR TITLE
fix(encoding): Fixed encoding issue in financial statements

### DIFF
--- a/erpnext/accounts/report/financial_statements.py
+++ b/erpnext/accounts/report/financial_statements.py
@@ -1,7 +1,9 @@
+# -*- coding: utf-8 -*-
+
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
 
-
+from __future__ import unicode_literals
 
 import re
 from past.builtins import cmp
@@ -342,7 +344,7 @@ def set_gl_entries_by_account(
 	accounts = frappe.db.sql_list("""select name from `tabAccount`
 		where lft >= %s and rgt <= %s""", (root_lft, root_rgt))
 	additional_conditions += " and account in ('{}')"\
-		.format("', '".join([frappe.safe_encode(frappe.db.escape(d)) for d in accounts]))
+		.format("', '".join([frappe.db.escape(d) for d in accounts]))
 
 	gl_entries = frappe.db.sql("""select posting_date, account, debit, credit, is_opening, fiscal_year, debit_in_account_currency, credit_in_account_currency, account_currency from `tabGL Entry`
 		where company=%(company)s

--- a/erpnext/accounts/report/financial_statements.py
+++ b/erpnext/accounts/report/financial_statements.py
@@ -402,7 +402,6 @@ def get_additional_conditions(from_date, ignore_closing_entries, filters):
 
 def get_cost_centers_with_children(cost_centers):
 	if not isinstance(cost_centers, list):
-		cost_centers = frappe.safe_encode(cost_centers)
 		cost_centers = [d.strip() for d in cost_centers.strip().split(',') if d]
 
 	all_cost_centers = []


### PR DESCRIPTION
**Before:**
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 55, in application
    response = frappe.handler.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 20, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 55, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1007, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 489, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 174, in run
    result = generate_report_result(report, filters, user)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 65, in generate_report_result
    res = frappe.get_attr(method_name)(frappe._dict(filters))
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/report/trial_balance/trial_balance.py", line 15, in execute
    data = get_data(filters)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/report/trial_balance/trial_balance.py", line 71, in get_data
    filters.to_date, min_lft, max_rgt, filters, gl_entries_by_account, ignore_closing_entries=not flt(filters.with_period_closing_entry))
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/report/financial_statements.py", line 345, in set_gl_entries_by_account
    .format(", ".join([frappe.safe_encode(frappe.db.escape(d)) for d in accounts]))
TypeError: sequence item 0: expected str instance, bytes found

**After**
<img width="1080" alt="screen shot 2018-11-06 at 11 52 35 am" src="https://user-images.githubusercontent.com/836784/48046435-7d784200-e1ba-11e8-8f16-860e53defcc4.png">
