### PR TITLE
[Fix] User able to change discount if pricing rule has discount value as zero

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -185,7 +185,8 @@ def get_pricing_rule_for_item(args):
 				"discount_percentage": 0.0
 			})
 		else:
-			item_details.discount_percentage = pricing_rule.discount_percentage or args.discount_percentage
+			item_details.discount_percentage = (pricing_rule.get('discount_percentage', 0)
+				if pricing_rule else args.discount_percentage)
 	elif args.get('pricing_rule'):
 		item_details = remove_pricing_rule_for_item(args.get("pricing_rule"), item_details)
 


### PR DESCRIPTION
**Issue**

- User has created pricing rule with discount value as Zero
- In sales order, pricing rule is applied but user had changed the discount value from 0 to 10 

**After fix**

- If the discount value is Zero in the pricing rule then in the sales order also it will applied as zero.