### PR TITLE
Permission error for new Sales invoice

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -939,7 +939,9 @@ var set_primary_action= function(frm, dialog, $results, invoice_healthcare_servi
 	dialog.set_primary_action(__('Add'), function() {
 		let checked_values = get_checked_values($results);
 		if(checked_values.length > 0){
-			frm.set_value("patient", dialog.fields_dict.patient.input.value);
+			if(invoice_healthcare_services) {
+				frm.set_value("patient", dialog.fields_dict.patient.input.value);
+			}
 			frm.set_value("items", []);
 			add_to_item_line(frm, checked_values, invoice_healthcare_services);
 			dialog.hide();


### PR DESCRIPTION
In version
```
Installed Apps
ERPNext: v11.0.3-beta.20 () (staging)
Frappe Framework: v11.0.3-beta.25 () (staging)
```

When creating a new Sales invoice without healthcare active we have this error
```
Not permitted
Insufficient Permission for Patient
```
Console log
```
Traceback (most recent call last):
  File "/home/frappe/auroraone-v11/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/home/frappe/auroraone-v11/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/auroraone-v11/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/auroraone-v11/apps/frappe/frappe/__init__.py", line 1007, in call
    return fn(*args, **newargs)
  File "/home/frappe/auroraone-v11/apps/frappe/frappe/desk/search.py", line 53, in search_link
    search_widget(doctype, txt, query, searchfield=searchfield, page_length=page_length, filters=filters, ignore_user_permissions=ignore_user_permissions)
  File "/home/frappe/auroraone-v11/apps/frappe/frappe/desk/search.py", line 149, in search_widget
    as_list=not as_dict)
  File "/home/frappe/auroraone-v11/apps/frappe/frappe/__init__.py", line 1235, in get_list
    return frappe.model.db_query.DatabaseQuery(doctype).execute(None, *args, **kwargs)
  File "/home/frappe/auroraone-v11/apps/frappe/frappe/model/db_query.py", line 40, in execute
    raise frappe.PermissionError(self.doctype)
PermissionError: Patient
```

![new_sales_invoice_permission_error](https://user-images.githubusercontent.com/7780466/48306629-50ba8680-e53c-11e8-83a8-6dab9fe41ffe.gif)

