### PR TITLE
Allow Work Orders to be cancelled

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -209,9 +209,10 @@ class ProductionPlan(Document):
 
 	def set_status(self):
 		self.status = {
-			'0': 'Draft',
-			'1': 'Submitted'
-		}[cstr(self.docstatus or 0)]
+			0: 'Draft',
+			1: 'Submitted',
+			2: 'Cancelled'
+		}.get(self.docstatus)
 
 		if self.total_produced_qty > 0:
 			self.status = "In Process"


### PR DESCRIPTION
**Traceback:**

```diff
Traceback (most recent call last):
File "/home/frappe/frappe-develop/apps/frappe/frappe/desk/form/save.py", line 45, in cancel
    doc.cancel()
File "/home/frappe/frappe-develop/apps/frappe/frappe/model/document.py", line 853, in cancel
    self._cancel()
File "/home/frappe/frappe-develop/apps/frappe/frappe/model/document.py", line 843, in _cancel
    self.save()
File "/home/frappe/frappe-develop/apps/frappe/frappe/model/document.py", line 260, in save
    return self._save(*args, **kwargs)
File "/home/frappe/frappe-develop/apps/frappe/frappe/model/document.py", line 313, in _save
    self.run_post_save_methods()
File "/home/frappe/frappe-develop/apps/frappe/frappe/model/document.py", line 910, in run_post_save_methods
    self.run_method("on_cancel")
File "/home/frappe/frappe-develop/apps/frappe/frappe/model/document.py", line 772, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
File "/home/frappe/frappe-develop/apps/frappe/frappe/model/document.py", line 1048, in composer
    return composed(self, method, *args, **kwargs)
File "/home/frappe/frappe-develop/apps/frappe/frappe/model/document.py", line 1031, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
File "/home/frappe/frappe-develop/apps/frappe/frappe/model/document.py", line 766, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
File "/home/frappe/frappe-develop/apps/erpnext/erpnext/manufacturing/doctype/work_order/work_order.py", line 236, in on_cancel
    self.update_ordered_qty()
File "/home/frappe/frappe-develop/apps/erpnext/erpnext/manufacturing/doctype/work_order/work_order.py", line 273, in update_ordered_qty
    doc.set_status()
File "/home/frappe/frappe-develop/apps/erpnext/erpnext/manufacturing/doctype/production_plan/production_plan.py", line 214, in set_status
    }[cstr(self.docstatus or 0)]
KeyError: u'2'
```