### PR TITLE
Validations for multiple trip records for the same driver or Delivery Note

### DIFF
--- a/erpnext/stock/doctype/delivery_note/delivery_note_list.js
+++ b/erpnext/stock/doctype/delivery_note/delivery_note_list.js
@@ -18,8 +18,8 @@ frappe.listview_settings['Delivery Note'] = {
 
 			if (selected_docs.length > 0) {
 				for (let doc of selected_docs) {
-					if (doc.docstatus === 0 || in_list(["Return"], doc.status)) {
-						frappe.throw(__("Cannot create a Delivery Trip from 'Draft' or 'Return' Delivery Notes."));
+					if (doc.docstatus !== 1 || doc.is_return) {
+						frappe.throw(__("Cannot create a Delivery Trip from 'Cancelled', 'Draft' or 'Return' Delivery Notes."));
 					}
 				};
 

--- a/erpnext/stock/doctype/delivery_note/delivery_note_list.js
+++ b/erpnext/stock/doctype/delivery_note/delivery_note_list.js
@@ -18,8 +18,8 @@ frappe.listview_settings['Delivery Note'] = {
 
 			if (selected_docs.length > 0) {
 				for (let doc of selected_docs) {
-					if (doc.docstatus === 0 || in_list(["Completed", "Return"], doc.status)) {
-						frappe.throw(__("Cannot create a Delivery Trip from 'Draft', 'Return' or 'Completed' Delivery Notes."));
+					if (doc.docstatus === 0 || in_list(["Return"], doc.status)) {
+						frappe.throw(__("Cannot create a Delivery Trip from 'Draft' or 'Return' Delivery Notes."));
 					}
 				};
 

--- a/erpnext/stock/doctype/delivery_note/delivery_note_list.js
+++ b/erpnext/stock/doctype/delivery_note/delivery_note_list.js
@@ -18,8 +18,8 @@ frappe.listview_settings['Delivery Note'] = {
 
 			if (selected_docs.length > 0) {
 				for (let doc of selected_docs) {
-					if (!doc.docstatus) {
-						frappe.throw(__("Cannot create a Delivery Trip from Draft documents."));
+					if (doc.docstatus === 0 || in_list(["Completed", "Return"], doc.status)) {
+						frappe.throw(__("Cannot create a Delivery Trip from 'Draft', 'Return' or 'Completed' Delivery Notes."));
 					}
 				};
 

--- a/erpnext/stock/doctype/delivery_trip/delivery_trip.js
+++ b/erpnext/stock/doctype/delivery_trip/delivery_trip.js
@@ -85,11 +85,11 @@ frappe.ui.form.on('Delivery Trip', {
 							}
 							existing_trips += "</ul>"
 
-							let confirm_message = `The following deliveries already exist in recent
-								trip(s): ${existing_trips} Do you still want to continue?`;
+							let confirm_message = __(`The following deliveries already exist in recent
+								trip(s): ${existing_trips} Do you still want to continue?`);
 
 							frappe.confirm(
-								__(confirm_message),
+								confirm_message,
 								() => { resolve(); },  // If "Yes" is selected
 								() => { frappe.set_route("List", frm.doc.doctype); }  // If "No" is selected
 							);
@@ -109,10 +109,10 @@ frappe.ui.form.on('Delivery Trip', {
 				departure_time: [">", frappe.datetime.nowdate()]
 			}, "name", (r) => {
 				if (r) {
-					let confirm_message = `${frm.doc.driver_name} has already been assigned a Delivery Trip
-											today (${r.name}). Do you want to modify that instead?`;
+					let confirm_message = __(`${frm.doc.driver_name} has already been assigned a Delivery Trip
+						today (${r.name}). Do you want to modify that instead?`);
 
-					frappe.confirm(__(confirm_message), function () {
+					frappe.confirm(confirm_message, function () {
 						frappe.set_route("Form", "Delivery Trip", r.name);
 					});
 				};

--- a/erpnext/stock/doctype/delivery_trip/delivery_trip.js
+++ b/erpnext/stock/doctype/delivery_trip/delivery_trip.js
@@ -81,7 +81,7 @@ frappe.ui.form.on('Delivery Trip', {
 							// create an unordered list of existing note <-> trip mappings
 							let existing_trips = "<ul>";
 							for (let trip in r.message) {
-								existing_trips += `<li><strong>${r.message[trip]}</strong> assigned to <strong>${trip}</strong></li>`
+								existing_trips += `<li><strong>${trip}</strong> exists in <strong>${r.message[trip]}</strong></li>`
 							}
 							existing_trips += "</ul>"
 

--- a/erpnext/stock/doctype/delivery_trip/delivery_trip.js
+++ b/erpnext/stock/doctype/delivery_trip/delivery_trip.js
@@ -85,11 +85,11 @@ frappe.ui.form.on('Delivery Trip', {
 							}
 							existing_trips += "</ul>"
 
-							let confirm_message = __(`The following deliveries already exist in recent
-								trip(s): ${existing_trips} Do you still want to continue?`);
+							let confirm_message = `The following deliveries already exist in recent
+								trip(s): ${existing_trips} Do you still want to continue?`;
 
 							frappe.confirm(
-								confirm_message,
+								__(confirm_message),
 								() => { resolve(); },  // If "Yes" is selected
 								() => { frappe.set_route("List", frm.doc.doctype); }  // If "No" is selected
 							);
@@ -109,10 +109,10 @@ frappe.ui.form.on('Delivery Trip', {
 				departure_time: [">", frappe.datetime.nowdate()]
 			}, "name", (r) => {
 				if (r) {
-					let confirm_message = __(`${frm.doc.driver_name} has already been assigned a Delivery Trip
-						today (${r.name}). Do you want to modify that instead?`);
+					let confirm_message = `${frm.doc.driver_name} has already been assigned a Delivery Trip
+						today (${r.name}). Do you want to modify that instead?`;
 
-					frappe.confirm(confirm_message, function () {
+					frappe.confirm(__(confirm_message), function () {
 						frappe.set_route("Form", "Delivery Trip", r.name);
 					});
 				};

--- a/erpnext/stock/doctype/delivery_trip/delivery_trip.js
+++ b/erpnext/stock/doctype/delivery_trip/delivery_trip.js
@@ -77,10 +77,16 @@ frappe.ui.form.on('Delivery Trip', {
 						delivery_stops: frm.doc.delivery_stops
 					},
 					callback: (r) => {
-						if (r.message.length) {
-							let confirm_message = `Atleast one of the entered Delivery Notes already exist in
-												the following Delivery Trips: ${r.message.join(", ")}.
-												Do you still want to continue?`;
+						if (!$.isEmptyObject(r.message)) {
+							// create an unordered list of existing note <-> trip mappings
+							let existing_trips = "<ul>";
+							for (let trip in r.message) {
+								existing_trips += `<li><strong>${r.message[trip]}</strong> assigned to <strong>${trip}</strong></li>`
+							}
+							existing_trips += "</ul>"
+
+							let confirm_message = `The following deliveries already exist in recent
+								trip(s): ${existing_trips} Do you still want to continue?`;
 
 							frappe.confirm(
 								__(confirm_message),

--- a/erpnext/stock/doctype/delivery_trip/delivery_trip.py
+++ b/erpnext/stock/doctype/delivery_trip/delivery_trip.py
@@ -352,13 +352,13 @@ def validate_unique_delivery_notes(delivery_stops):
 	delivery_notes = [stop.get("delivery_note") for stop in delivery_stops if stop.get("delivery_note")]
 
 	if not delivery_notes:
-		return []
+		return {}
 
 	existing_trips = frappe.get_all("Delivery Stop",
 									filters={"delivery_note": ["IN", delivery_notes],
 											"docstatus": ["<", 2]},
-									fields=["distinct(parent)"])
-	existing_trips = [stop.parent for stop in existing_trips]
+									fields=["parent", "delivery_note"])
+	existing_trips = {stop.parent: stop.delivery_note for stop in existing_trips}
 
 	return existing_trips
 

--- a/erpnext/stock/doctype/delivery_trip/delivery_trip.py
+++ b/erpnext/stock/doctype/delivery_trip/delivery_trip.py
@@ -355,9 +355,8 @@ def validate_unique_delivery_notes(delivery_stops):
 		return {}
 
 	existing_trips = frappe.get_all("Delivery Stop",
-									filters={"delivery_note": ["IN", delivery_notes],
-											"docstatus": ["<", 2]},
-									fields=["parent", "delivery_note"])
+		filters={"delivery_note": ["IN", delivery_notes], "docstatus": ["<", 2]},
+		fields=["parent", "delivery_note"])
 	existing_trips = {stop.parent: stop.delivery_note for stop in existing_trips}
 
 	return existing_trips

--- a/erpnext/stock/doctype/delivery_trip/delivery_trip.py
+++ b/erpnext/stock/doctype/delivery_trip/delivery_trip.py
@@ -5,6 +5,7 @@
 from __future__ import unicode_literals
 
 import datetime
+import json
 
 import frappe
 from frappe import _
@@ -89,7 +90,7 @@ class DeliveryTrip(Document):
 			note_doc.save()
 
 		delivery_notes = [get_link_to_form("Delivery Note", note) for note in delivery_notes]
-		frappe.msgprint(_("Delivery Notes {0} updated".format(", ".join(delivery_notes))))
+		frappe.msgprint(_("Delivery Notes {0} updated".format(", ".join(delivery_notes))), alert=True)
 
 	def process_route(self, optimize):
 		"""
@@ -344,6 +345,22 @@ def get_directions(route, optimize):
 		frappe.throw(_(e.message))
 
 	return directions[0] if directions else False
+
+@frappe.whitelist()
+def validate_unique_delivery_notes(delivery_stops):
+	delivery_stops = json.loads(delivery_stops)
+	delivery_notes = [stop.get("delivery_note") for stop in delivery_stops if stop.get("delivery_note")]
+
+	if not delivery_notes:
+		return []
+
+	existing_trips = frappe.get_all("Delivery Stop",
+									filters={"delivery_note": ["IN", delivery_notes],
+											"docstatus": ["<", 2]},
+									fields=["distinct(parent)"])
+	existing_trips = [stop.parent for stop in existing_trips]
+
+	return existing_trips
 
 
 @frappe.whitelist()


### PR DESCRIPTION
Changes:
- Whenever a user enters the driver, the system checks for existing trips today for that driver, and if one is found, prompts the user if they want to modify the old one, or continue with the new one.
- Whenever a Delivery Trip is created with stops, and if some/all of the Delivery Notes have already been added in another trip, the system prompts the user asking if they want to continue with the added Delivery Note.

<details>
<summary>Screenshots / GIFs</summary>

Creating a Delivery Trip for a driver with an existing trip on the same day.
- Clicking on **Yes** will take the user to the existing Delivery Trip.
- Clicking on **No** will let the user continue as normal.

![existing-driver](https://user-images.githubusercontent.com/13396535/48606033-7adcd000-e9a4-11e8-88c3-e89625580ad0.gif)

<hr>

Creating a Delivery Trip with Delivery Notes that are already present in other trips.
- Clicking on **Yes** will let the user continue as normal.
- Clicking on **No** will take the user back to the list view.

![existing-dn](https://user-images.githubusercontent.com/13396535/48606223-140be680-e9a5-11e8-9529-88650b3438c5.gif)

</details>