### PR TITLE
Fix BOM Report Calculated

### DIFF
--- a/erpnext/manufacturing/report/bom_stock_calculated/bom_stock_calculated.js
+++ b/erpnext/manufacturing/report/bom_stock_calculated/bom_stock_calculated.js
@@ -3,25 +3,25 @@
 /* eslint-disable */
 
 frappe.query_reports["BOM Stock Calculated"] = {
-	"filters": [
+	filters: [
 		{
-			"fieldname": "bom",
-			"label": __("BOM"),
-			"fieldtype": "Link",
-			"options": "BOM",
-			"reqd": 1
+			fieldname: "bom",
+			label: __("BOM"),
+			fieldtype: "Link",
+			options: "BOM",
+			reqd: 1
 		},
-        	{
-	            "fieldname": "qty_to_make",
-        	    "label": __("Quantity to Make"),
-        	    "fieldtype": "Int",
-        	    "default": "1"
-	       },
-
-		 {
-			"fieldname": "show_exploded_view",
-			"label": __("Show exploded view"),
-			"fieldtype": "Check"
+		{
+			fieldname: "qty_to_make",
+			label: __("Quantity to Make"),
+			fieldtype: "Int",
+			default: "1",
+			reqd: 1
+		},
+		{
+			fieldname: "show_exploded_view",
+			label: __("Show exploded view"),
+			fieldtype: "Check"
 		}
 	]
-}
+};

--- a/erpnext/manufacturing/report/bom_stock_calculated/bom_stock_calculated.py
+++ b/erpnext/manufacturing/report/bom_stock_calculated/bom_stock_calculated.py
@@ -11,7 +11,7 @@ def execute(filters=None):
 	summ_data = []
 
 	data = get_bom_stock(filters)
-	qty_to_make = filters.get("qty_to_make")
+	qty_to_make = filters.get("qty_to_make", 1)
 
 	for rows in data:
 		item_map = get_item_details(rows[0])


### PR DESCRIPTION
<img width="953" alt="screen shot 2018-11-21 at 3 13 00 pm" src="https://user-images.githubusercontent.com/21003054/48824707-0ccb4b00-eda0-11e8-82ee-51c641f58e8a.png">

Traceback:
```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 55, in application
    response = frappe.handler.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 20, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 55, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1007, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 489, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 174, in run
    result = generate_report_result(report, filters, user)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 65, in generate_report_result
    res = frappe.get_attr(method_name)(frappe._dict(filters))
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/manufacturing/report/bom_stock_calculated/bom_stock_calculated.py", line 18, in execute
    reqd_qty = qty_to_make * rows[3]
TypeError: unsupported operand type(s) for *: 'int' and 'NoneType'
```