### PR TITLE
fix: Trial Balance print

### DIFF
--- a/erpnext/accounts/report/trial_balance/trial_balance.py
+++ b/erpnext/accounts/report/trial_balance/trial_balance.py
@@ -232,6 +232,13 @@ def get_columns():
 			"width": 300
 		},
 		{
+			"fieldname": "currency",
+			"label": _("Currency"),
+			"fieldtype": "Link",
+			"options": "Currency",
+			"hidden": 1
+		},
+		{
 			"fieldname": "opening_debit",
 			"label": _("Opening (Dr)"),
 			"fieldtype": "Currency",
@@ -272,13 +279,6 @@ def get_columns():
 			"fieldtype": "Currency",
 			"options": "currency",
 			"width": 120
-		},
-		{
-			"fieldname": "currency",
-			"label": _("Currency"),
-			"fieldtype": "Link",
-			"options": "Currency",
-			"hidden": 1
 		}
 	]
 


### PR DESCRIPTION
Opening (Dr) is missing in Trial Balance print. In all financial reports 2nd field is currency and its omitted in print. Trial balance has Opening (Dr), so moved currency as the second field.
Please read the pull request checklist to make sure your changes are merged: https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

