### PR TITLE
Fixed get_buying_amount in Gross Profit report:

### DIFF
--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -236,7 +236,7 @@ class GrossProfitGenerator(object):
 							previous_stock_value = len(my_sle) > i+1 and \
 								flt(my_sle[i+1].stock_value) or 0.0
 							if previous_stock_value:
-								return previous_stock_value - flt(sle.stock_value)
+								return (previous_stock_value - flt(sle.stock_value)) * flt(row.qty) / abs(flt(sle.qty))
 							else:
 								return flt(row.qty) * self.get_average_buying_rate(row, item_code)
 			else:


### PR DESCRIPTION
### Problem:
When there are multiple Sales Invoices against a Delivery Note, the Gross Profit report calculates an incorrect Buying Amount (and Buying Rate). It calculates the Buying Amount from the Delivery Note by doing `Stock Value After Delivery - Stock Value Before Delivery`, this gets the Buying Amount for the item with Qty as per the Delivery Note, for example Qty 12. But the Invoices are made as Qty 8 and Qty 4.

Notice the rows with negative profits (they are the invoices with the same delivery). They both have the same buying amount, which is incorrect since the quantities are different.
![grossprofitbugged](https://user-images.githubusercontent.com/328330/48836152-c1b33700-eda3-11e8-9525-c13795b615c4.png)

### Solution:
The solution is pretty simple: calculate the buying amount according to the ratio of invoice qty and delivery qty. See the code

Fixed Gross Profit report
![grossprofitfixed](https://user-images.githubusercontent.com/328330/48836259-0a6af000-eda4-11e8-81fb-f26b154a813e.png)
