### PR TITLE
[Fix] Incorrect stock value difference because of negative stock

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -176,7 +176,11 @@ class update_entries_after(object):
 		# rounding as per precision
 		self.stock_value = flt(self.stock_value, self.precision)
 
-		stock_value_difference = self.stock_value - self.prev_stock_value
+		if self.prev_stock_value < 0 and self.stock_value >= 0:
+			stock_value_difference = sle.actual_qty * self.valuation_rate
+		else:
+			stock_value_difference = self.stock_value - self.prev_stock_value
+
 		self.prev_stock_value = self.stock_value
 
 		# update current sle


### PR DESCRIPTION
**Issue**

If existing stock value is in negative and user is trying to pass positive stock entry, system was calculating incorrect stock value difference which leads to incorrect posting of accounting entry