### PR TITLE
Simple Trial Balance

### DIFF
--- a/erpnext/accounts/report/trial_balance_simple/trial_balance_simple.json
+++ b/erpnext/accounts/report/trial_balance_simple/trial_balance_simple.json
@@ -1,0 +1,30 @@
+{
+ "add_total_row": 1, 
+ "creation": "2018-11-22 16:53:19.167935", 
+ "disabled": 0, 
+ "docstatus": 0, 
+ "doctype": "Report", 
+ "idx": 0, 
+ "is_standard": "Yes", 
+ "modified": "2018-11-22 17:40:11.317567", 
+ "modified_by": "Administrator", 
+ "module": "Accounts", 
+ "name": "Trial Balance (Simple)", 
+ "owner": "Administrator", 
+ "prepared_report": 0, 
+ "query": "select fiscal_year as \"Fiscal Year:Data:80\",\n\tcompany as \"Company:Data:220\",\n\tposting_date as \"Posting Date:Date:100\",\n\taccount as \"Account:Data:380\",\n\tsum(debit) as \"Debit:Currency:140\",\n\tsum(credit) as \"Credit:Currency:140\"\nfrom `tabGL Entry`\ngroup by fiscal_year, company, posting_date, account\norder by fiscal_year, company, posting_date, account", 
+ "ref_doctype": "GL Entry", 
+ "report_name": "Trial Balance (Simple)", 
+ "report_type": "Query Report", 
+ "roles": [
+  {
+   "role": "Accounts User"
+  }, 
+  {
+   "role": "Accounts Manager"
+  }, 
+  {
+   "role": "Auditor"
+  }
+ ]
+}


### PR DESCRIPTION
Current trial balance report has many columns and also group totals etc. which are not needed in a simple trial balance. This report is a simple version of Trial balance.

Testing Video

![trial_balance_simple](https://user-images.githubusercontent.com/20460498/48902967-2fcd2c00-ee80-11e8-9148-6f429a353232.gif)





