### PR TITLE
Replace Company Abbreviation in Taxes Template too

### DIFF
--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -363,7 +363,7 @@ def replace_abbr(company, old, new):
 		for d in doc:
 			_rename_record(d)
 
-	for dt in ["Warehouse", "Account", "Cost Center"]:
+	for dt in ["Warehouse", "Account", "Cost Center", "Sales Taxes and Charges Template", "Purchase Taxes and Charges Template"]:
 		_rename_records(dt)
 		frappe.db.commit()
 


### PR DESCRIPTION
Replace Company Abbreviation in Taxes and Charges Template documents too.