### PR TITLE
fix[eslintrc]: Add Vue to globals

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,10 @@
 		"node": true,
 		"es6": true
 	},
+	"parserOptions": {
+		"ecmaVersion": 6,
+		"sourceType": "module"
+	},
 	"extends": "eslint:recommended",
 	"rules": {
 		"indent": [
@@ -50,9 +54,9 @@
 	"root": true,
 	"globals": {
 		"frappe": true,
+		"Vue": true,
 		"erpnext": true,
 		"hub": true,
-
 		"$": true,
 		"jQuery": true,
 		"moment": true,


### PR DESCRIPTION
- Add Vue to globals
- Set sourceType as "module" 

to avoid lint errors

