### PR TITLE
If is pos is enabled and no pos profile then use the item's default warehouse for packing materials

### DIFF
--- a/erpnext/stock/doctype/packed_item/packed_item.py
+++ b/erpnext/stock/doctype/packed_item/packed_item.py
@@ -49,8 +49,9 @@ def update_packing_list_item(doc, packing_item_code, qty, main_item_row, descrip
 	pi.qty = flt(qty)
 	pi.description = description
 	if not pi.warehouse:
-		pi.warehouse = (main_item_row.warehouse
-			if (doc.get('is_pos') or not item.default_warehouse) else item.default_warehouse)
+		pi.warehouse = (main_item_row.warehouse if ((doc.get('is_pos')
+			or not item.default_warehouse) and main_item_row.warehouse) else item.default_warehouse)
+
 	if not pi.batch_no:
 		pi.batch_no = cstr(main_item_row.get("batch_no"))
 	if not pi.target_warehouse:


### PR DESCRIPTION
- User has created is pos without pos profile
- In code if is pos in enabled then we use the parent item's warehouse
- But parent warehouse always be empty because pos profile has no warehouse and parent item is service item