### PR TITLE
Fixed error due to incorrect use of 'this' while calculating rate

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -33,7 +33,7 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 				item.margin_rate_or_amount = 0;
 				item.rate_with_margin = 0;
 			}
-			item.base_rate_with_margin = item.rate_with_margin * flt(this.frm.doc.conversion_rate);
+			item.base_rate_with_margin = item.rate_with_margin * flt(frm.doc.conversion_rate);
 
 			cur_frm.cscript.set_gross_profit(item);
 			cur_frm.cscript.calculate_taxes_and_totals();


### PR DESCRIPTION
Error due to incorrect use of `this`, use `frm` instead. No need for description I believe.