### PR TITLE
[Fix] System allocated grand total amount instead of non zero rounded total for advanced entry in the sales invoice

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -405,7 +405,8 @@ class AccountsController(TransactionBase):
 			if d.against_order:
 				allocated_amount = flt(d.amount)
 			else:
-				allocated_amount = min(self.grand_total - advance_allocated, d.amount)
+				amount = self.rounded_total or self.grand_total
+				allocated_amount = min(amount - advance_allocated, d.amount)
 			advance_allocated += flt(allocated_amount)
 
 			self.append("advances", {


### PR DESCRIPTION
**Issue**
![screen shot 2018-11-27 at 11 24 43 am](https://user-images.githubusercontent.com/8780500/49063385-358a8f00-f23d-11e8-8d5e-017c46b94d99.png)


**After fix**
![screen shot 2018-11-27 at 12 04 25 pm](https://user-images.githubusercontent.com/8780500/49063396-3c190680-f23d-11e8-9759-4a575f31c607.png)
