### PR TITLE
Fix AttributeError in POS (Barcode / Serial / Batch lookup)

### DIFF
--- a/erpnext/selling/page/point_of_sale/point_of_sale.py
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.py
@@ -125,6 +125,8 @@ def search_serial_or_batch_or_barcode_number(search_value):
 	if batch_no_data:
 		return batch_no_data
 
+	return {}
+
 def get_conditions(item_code, serial_no, batch_no, barcode):
 	if serial_no or batch_no or barcode:
 		return frappe.db.escape(item_code), "i.name = %(item_code)s"


### PR DESCRIPTION
**Traceback:**

```
AttributeError: 'NoneType' object has no attribute 'get'
  File "frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "frappe/__init__.py", line 1007, in call
    return fn(*args, **newargs)
  File "erpnext/selling/page/point_of_sale/point_of_sale.py", line 27, in get_items
    item_code = data.get("item_code") if data.get("item_code") else search_value

AttributeError: 'NoneType' object has no attribute 'get'
```