### PR TITLE
Update package total on old delivery trips

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -579,3 +579,4 @@ erpnext.patches.v10_0.update_user_image_in_employee
 erpnext.patches.v11_0.update_delivery_trip_status
 erpnext.patches.v10_0.repost_gle_for_purchase_receipts_with_rejected_items
 erpnext.patches.v11_0.set_missing_gst_hsn_code
+erpnext.patches.v11_0.update_package_total_in_delivery_trips

--- a/erpnext/patches/v11_0/update_package_total_in_delivery_trips.py
+++ b/erpnext/patches/v11_0/update_package_total_in_delivery_trips.py
@@ -1,0 +1,7 @@
+import frappe
+
+def execute():
+    for trip in frappe.get_all("Delivery Trip", {"docstatus" : 1}):
+        trip_doc = frappe.get_doc("Delivery Trip", trip.name)
+        total = sum([stop.grand_total for stop in trip_doc.delivery_stops if stop.grand_total])
+        frappe.db.set_value("Delivery Trip", trip.name, "package_total", total, update_modified=False)

--- a/erpnext/stock/doctype/delivery_trip/delivery_trip.py
+++ b/erpnext/stock/doctype/delivery_trip/delivery_trip.py
@@ -25,6 +25,8 @@ class DeliveryTrip(Document):
 
 	def validate(self):
 		self.validate_stop_addresses()
+		self.update_status()
+		self.update_package_total()
 
 	def on_submit(self):
 		self.update_status()
@@ -36,11 +38,6 @@ class DeliveryTrip(Document):
 	def on_cancel(self):
 		self.update_status()
 		self.update_delivery_notes(delete=True)
-
-	def validate_stop_addresses(self):
-		for stop in self.delivery_stops:
-			if not stop.customer_address:
-				stop.customer_address = get_address_display(frappe.get_doc("Address", stop.address).as_dict())
 
 	def update_status(self):
 		status = {
@@ -57,6 +54,14 @@ class DeliveryTrip(Document):
 				status = "In Transit"
 
 		self.db_set("status", status)
+
+	def update_package_total(self):
+		self.package_total = sum([stop.grand_total for stop in self.delivery_stops if stop.grand_total])
+
+	def validate_stop_addresses(self):
+		for stop in self.delivery_stops:
+			if not stop.customer_address:
+				stop.customer_address = get_address_display(frappe.get_doc("Address", stop.address).as_dict())
 
 	def update_delivery_notes(self, delete=False):
 		"""


### PR DESCRIPTION
**Problem:**

Package total wasn't being updated if a user added or deleted Delivery Notes in the Trip.