### PR TITLE
[Fix] Permissions issue while making item variants

### DIFF
--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -458,7 +458,7 @@ $.extend(erpnext.item, {
 						fields: ["attribute_value"],
 						limit_start: 0,
 						limit_page_length: 500,
-						parent: "Item"
+						parent: "Item Attribute"
 					}
 				}).then((r) => {
 					if(r.message) {
@@ -579,7 +579,7 @@ $.extend(erpnext.item, {
 								["attribute_value", "like", term + "%"]
 							],
 							fields: ["attribute_value"],
-							parent: "Item"
+							parent: "Item Attribute"
 						},
 						callback: function(r) {
 							if (r.message) {


### PR DESCRIPTION
We have recently [fixed](https://github.com/frappe/frappe/pull/6509) vulnerability issue in which we always check the passed parent is actual parent of the child doctype or not 

**Issue**
![screen shot 2018-12-03 at 11 44 19 am](https://user-images.githubusercontent.com/8780500/49356509-c2c45c80-f6f1-11e8-99f3-3f2f3121d42c.png)


**After fix**
![image](https://user-images.githubusercontent.com/8780500/49356516-c7891080-f6f1-11e8-971c-bd91fc3e1d13.png)
