### PR TITLE
fix(setup-wizard): Validate abbr length before switching to next slide

### DIFF
--- a/erpnext/public/js/setup_wizard.js
+++ b/erpnext/public/js/setup_wizard.js
@@ -97,6 +97,9 @@ erpnext.setup.slides_settings = [
 			if (!this.values.company_abbr) {
 				return false;
 			}
+			if (this.values.company_abbr.length > 5) {
+				return false;
+			}
 			return true;
 		}
 	},


### PR DESCRIPTION
Company Abbreviation was validated when user clicks the "Next" button,
but not when the user is navigating via keyboard


![setupwizard-abbr](https://user-images.githubusercontent.com/9355208/49556574-76b02c80-f92a-11e8-9f50-e5543ec92306.gif)