### PR TITLE
Travis Fix: bench reinstall pass MariaDB root user/pass as arguments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_script:
   - cd ~/frappe-bench
   - bench get-app erpnext $TRAVIS_BUILD_DIR
   - bench use test_site
-  - bench reinstall --yes --mariadb-root-username root --mariadb-root-password travis
+  - bench reinstall --mariadb-root-username root --mariadb-root-password travis --yes
   - bench build
   - bench scheduler disable
   - sed -i 's/9000/9001/g' sites/common_site_config.json

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_script:
   - cd ~/frappe-bench
   - bench get-app erpnext $TRAVIS_BUILD_DIR
   - bench use test_site
-  - bench reinstall --yes
+  - bench reinstall --yes --mariadb-root-username root --mariadb-root-password travis
   - bench build
   - bench scheduler disable
   - sed -i 's/9000/9001/g' sites/common_site_config.json


### PR DESCRIPTION
Requires https://github.com/frappe/frappe/pull/6599

Travis fails at the command `bench reinstall --yes` because it prompts for keyboard input (for root user/pass) and times out. This PR passes Travis's MySQL root user/pass

