### PR TITLE
[Fix] Set fieldname for frappe prompt

### DIFF
--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.js
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.js
@@ -42,7 +42,7 @@ frappe.ui.form.on("Stock Reconciliation", {
 	},
 
 	get_items: function(frm) {
-		frappe.prompt({label:"Warehouse", fieldtype:"Link", options:"Warehouse", reqd: 1,
+		frappe.prompt({label:"Warehouse", fieldname: "warehouse", fieldtype:"Link", options:"Warehouse", reqd: 1,
 			"get_query": function() {
 				return {
 					"filters": {


### PR DESCRIPTION
Frappe doesn't auto-set the fieldname from the Label (I think it used to?). Nonetheless, this would break during `frappe.call` because `data.warehouse` didn't exist. Instead it would have a `data.undefined` because the fieldname was never explicitly set. This fixes that. 

