### PR TITLE
[Minor] Get items for Material Requests fix

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -514,7 +514,7 @@ def get_items_for_material_requests(doc, company=None):
 		doc = frappe._dict(json.loads(doc))
 
 	doc['mr_items'] = []
-	po_items = doc['po_items'] if doc.get('po_items') else doc['items']
+	po_items = doc.get('po_items') if doc.get('po_items') else doc.get('items')
 
 	for data in po_items:
 		warehouse = None
@@ -533,10 +533,10 @@ def get_items_for_material_requests(doc, company=None):
 		else:
 			planned_qty = data.get('planned_qty')
 			bom_no = data.get('bom_no')
-			include_subcontracted_items = doc['include_subcontracted_items']
-			company = doc['company']
-			include_non_stock_items = doc['include_non_stock_items']
-			ignore_existing_ordered_qty = doc['ignore_existing_ordered_qty']
+			include_subcontracted_items = doc.get('include_subcontracted_items')
+			company = doc.get('company')
+			include_non_stock_items = doc.get('include_non_stock_items')
+			ignore_existing_ordered_qty = doc.get('ignore_existing_ordered_qty')
 		if not planned_qty:
 			frappe.throw(_("For row {0}: Enter Planned Qty").format(data.get('idx')))
 


### PR DESCRIPTION
Issue :-
```
Traceback (most recent call last):
  File "/Users/allen/frappe-bench/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/Users/allen/frappe-bench/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/Users/allen/frappe-bench/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/allen/frappe-bench/apps/frappe/frappe/__init__.py", line 1007, in call
    return fn(*args, **newargs)
  File "/Users/allen/frappe-bench/apps/erpnext/erpnext/manufacturing/doctype/production_plan/production_plan.py", line 539, in get_items_for_material_requests
    ignore_existing_ordered_qty = doc['ignore_existing_ordered_qty']
KeyError: u'ignore_existing_ordered_qty'
```

![mr_items_issue](https://user-images.githubusercontent.com/11695402/49940567-e5325300-ff05-11e8-9570-0f904aff9ed2.gif)

Fix:-
![mr_items_fix](https://user-images.githubusercontent.com/11695402/49940571-e82d4380-ff05-11e8-9c67-6b6c9329e397.gif)


