### PR TITLE
[Minor] Fix Leave Application as half day on Holiday validation

### DIFF
--- a/erpnext/hr/doctype/leave_application/leave_application.py
+++ b/erpnext/hr/doctype/leave_application/leave_application.py
@@ -187,7 +187,7 @@ class LeaveApplication(Document):
 			self.total_leave_days = get_number_of_leave_days(self.employee, self.leave_type,
 				self.from_date, self.to_date, self.half_day, self.half_day_date)
 
-			if self.total_leave_days == 0:
+			if self.total_leave_days <= 0:
 				frappe.throw(_("The day(s) on which you are applying for leave are holidays. You need not apply for leave."))
 
 			if not is_lwp(self.leave_type):


### PR DESCRIPTION
https://github.com/frappe/erpnext/issues/16216

If a leave day is also a Holiday then applying leave for half day returns total number of leave days as -0.5 and the validation for "need not apply for leave" only checked for '0' thus disregarding half day leaves.