### PR TITLE
Bringing indicators back in party dashboard billing and outstanding amount

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -112,10 +112,10 @@ $.extend(erpnext.utils, {
 					frm.dashboard.stats_area_row.append(
 						'<div class="flex-column col-xs-6">'+
 							'<div style="margin-bottom:20px"><h6>'+info.company+'</h6></div>'+
-							'<div class="badge-link small" style="margin-bottom:10px">Annual Billing: '
-							+format_currency(info.billing_this_year, info.currency)+'</div>'+
-							'<div class="badge-link small" style="margin-bottom:20px">Total Unpaid: '
-							+format_currency(info.total_unpaid, info.currency)+'</div>'+
+							'<div class="badge-link small" style="margin-bottom:10px"><span class="indicator blue">Annual Billing: '
+							+format_currency(info.billing_this_year, info.currency)+'</span></div>'+
+							'<div class="badge-link small" style="margin-bottom:20px"><span class="indicator orange">Total Unpaid: '
+							+format_currency(info.total_unpaid, info.currency)+'</span></div>'+
 						'</div>'
 					);
 				});
@@ -123,10 +123,10 @@ $.extend(erpnext.utils, {
 			else {
 				frm.dashboard.stats_area.removeClass('hidden');
 				frm.dashboard.stats_area_row.append(
-					'</div><div class="col-xs-6 small" style="margin-bottom:10px">Annual Billing: <b>'
-					+format_currency(company_wise_info[0].billing_this_year, company_wise_info[0].currency)+'</b></div>' +
-					'<div class="col-xs-6 small" style="margin-bottom:10px">Total Unpaid: <b>'
-					+format_currency(company_wise_info[0].billing_this_year, company_wise_info[0].currency)+'</b></div>'
+					'</div><div class="col-xs-6 small"><span class="indicator blue">Annual Billing: '
+					+format_currency(company_wise_info[0].billing_this_year, company_wise_info[0].currency)+'</span></div>'
+					+'<div class="col-xs-6 small"><span class="indicator orange">Total Unpaid: '
+					+format_currency(company_wise_info[0].total_unpaid, company_wise_info[0].currency)+'</span></div>'
 				);
 			}
 		}


### PR DESCRIPTION
Before PR:
![image](https://user-images.githubusercontent.com/328330/50045172-34b48280-00b0-11e9-99ea-85d6e9720a13.png)
From: https://beta.erpnext.com/desk#Form/Customer/Nelson%20Brothers

After PR:
![image](https://user-images.githubusercontent.com/328330/50045189-56156e80-00b0-11e9-96cb-7e4410fc0be2.png)

Note that I only added the indicators back that were recently removed for no apparent reason.