### PR TITLE
Bringing indicators back in party dashboard billing and outstanding amount

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -112,10 +112,10 @@ $.extend(erpnext.utils, {
 					frm.dashboard.stats_area_row.append(
 						'<div class="flex-column col-xs-6">'+
 							'<div style="margin-bottom:20px"><h6>'+info.company+'</h6></div>'+
-							'<div class="badge-link small" style="margin-bottom:10px">Annual Billing: '
-							+format_currency(info.billing_this_year, info.currency)+'</div>'+
-							'<div class="badge-link small" style="margin-bottom:20px">Total Unpaid: '
-							+format_currency(info.total_unpaid, info.currency)+'</div>'+
+							'<div class="badge-link small" style="margin-bottom:10px"><span class="indicator blue">Annual Billing: '
+							+format_currency(info.billing_this_year, info.currency)+'</span></div>'+
+							'<div class="badge-link small" style="margin-bottom:20px"><span class="indicator orange">Total Unpaid: '
+							+format_currency(info.total_unpaid, info.currency)+'</span></div>'+
 						'</div>'
 					);
 				});


### PR DESCRIPTION
Before PR:
![image](https://user-images.githubusercontent.com/328330/50045172-34b48280-00b0-11e9-99ea-85d6e9720a13.png)
From: https://beta.erpnext.com/desk#Form/Customer/Nelson%20Brothers

After PR:
![image](https://user-images.githubusercontent.com/328330/50045230-e5bb1d00-00b0-11e9-8c70-0ef20d469e69.png)

Note that I only added the indicators back that were recently removed.