### PR TITLE
Fix employee separation list

### DIFF
--- a/erpnext/hr/doctype/employee_separation/employee_separation_list.js
+++ b/erpnext/hr/doctype/employee_separation/employee_separation_list.js
@@ -1,5 +1,5 @@
 frappe.listview_settings['Employee Separation'] = {
-	add_fields: ["boarding_status", "employee_name", "date_of_joining", "department"],
+	add_fields: ["boarding_status", "employee_name", "department"],
 	filters:[["boarding_status","=", "Pending"]],
 	get_indicator: function(doc) {
 		return [__(doc.boarding_status), frappe.utils.guess_colour(doc.boarding_status), "status,=," + doc.boarding_status];


### PR DESCRIPTION
As `date_of_joining` doesn't exist in Employee Separation DocType.

```
InternalError: (1054, u"Unknown column 'tabEmployee Separation.date_of_joining' in 'field list'")
```