### PR TITLE
Fix: currency symbol issue in delivery note list

### DIFF
--- a/erpnext/stock/doctype/delivery_note/delivery_note_list.js
+++ b/erpnext/stock/doctype/delivery_note/delivery_note_list.js
@@ -1,5 +1,5 @@
 frappe.listview_settings['Delivery Note'] = {
-	add_fields: ["grand_total", "is_return", "per_billed", "status"],
+	add_fields: ["grand_total", "is_return", "per_billed", "status", "currency"],
 	get_indicator: function (doc) {
 		if (cint(doc.is_return) == 1) {
 			return [__("Return"), "darkgrey", "is_return,=,Yes"];


### PR DESCRIPTION
Show currency symbol based on selected currency for the doc (in list view)
**Before Fix:**
![currency_issue_before](https://user-images.githubusercontent.com/13928957/50138998-58e9ac80-02c6-11e9-83ea-9f66b4906820.gif)

**After Fix** 
![currency_issue_after](https://user-images.githubusercontent.com/13928957/50139014-6acb4f80-02c6-11e9-8660-dd23203acaee.gif)

Fix: Load currency field value as well since it's required for getting the currency symbol of each doc