### PR TITLE
Fix: Capitalize marketplace factory class

### DIFF
--- a/erpnext/public/js/hub/hub_factory.js
+++ b/erpnext/public/js/hub/hub_factory.js
@@ -1,6 +1,6 @@
 frappe.provide('erpnext.hub');
 
-frappe.views.marketplaceFactory = class marketplaceFactory extends frappe.views.Factory {
+frappe.views.MarketplaceFactory = class MarketplaceFactory extends frappe.views.Factory {
 	show() {
 		is_marketplace_disabled()
 			.then(disabled => {


### PR DESCRIPTION
Capitalize marketplace factory class to support [recent router changes](https://github.com/frappe/frappe/commit/50af0dc3883b0cea19775ab7161329aa662dd4d3#diff-b4327c1486ba00c053528e60df741cd5R48).

