### PR TITLE
[Fix] Is fixed asset checkbox not checked if user duplicate the existing invoice

### DIFF
--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -49,7 +49,17 @@ class TestAsset(unittest.TestCase):
 		
 		self.assertFalse(frappe.db.get_value("GL Entry",
 			{"voucher_type": "Purchase Invoice", "voucher_no": pi.name}))
-		
+
+	def test_is_fixed_asset_set(self):
+		doc = frappe.new_doc('Purchase Invoice')
+		doc.supplier = '_Test Supplier'
+		doc.append('items', {
+			'item_code': 'Macbook Pro',
+			'qty': 1
+		})
+
+		doc.set_missing_values()
+		self.assertEquals(doc.items[0].is_fixed_asset, 1)
 
 	def test_schedule_for_straight_line_method(self):
 		asset = frappe.get_doc("Asset", "Macbook Pro 1")

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -218,6 +218,9 @@ class AccountsController(TransactionBase):
 								if stock_qty != len(get_serial_nos(item.get('serial_no'))):
 									item.set(fieldname, value)
 
+					if self.doctype in ["Purchase Invoice", "Sales Invoice"] and item.meta.get_field('is_fixed_asset'):
+						item.set('is_fixed_asset', ret.get('is_fixed_asset', 0))
+
 					if ret.get("pricing_rule"):
 						# if user changed the discount percentage then set user's discount percentage ?
 						item.set("discount_percentage", ret.get("discount_percentage"))


### PR DESCRIPTION
Is fixed asset field's value is not from the server side

Test cases passed
![screen shot 2018-12-19 at 3 15 16 pm](https://user-images.githubusercontent.com/8780500/50212418-07fab680-03a1-11e9-8534-a1ece2a0efe8.png)
