### PR TITLE
Purchase order validation sql error

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -85,6 +85,7 @@ class PurchaseOrder(BuyingController):
 			frappe.msgprint(_("{0} currently has a {1} Supplier Scorecard standing, and Purchase Orders to this supplier should be issued with caution.").format(self.supplier, standing), title=_("Caution"), indicator='orange')
 
 	def validate_minimum_order_qty(self):
+		if not self.get("items"): return
 		items = list(set([d.item_code for d in self.get("items")]))
 
 		itemwise_min_order_qty = frappe._dict(frappe.db.sql("""select name, min_order_qty


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2018-12-13/apps/frappe/frappe/model/document.py", line 283, in _save
    self.insert()
  File "/home/frappe/benches/bench-2018-12-13/apps/frappe/frappe/model/document.py", line 222, in insert
    self.run_before_save_methods()
  File "/home/frappe/benches/bench-2018-12-13/apps/frappe/frappe/model/document.py", line 876, in run_before_save_methods
    self.run_method("validate")
  File "/home/frappe/benches/bench-2018-12-13/apps/frappe/frappe/model/document.py", line 772, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-2018-12-13/apps/frappe/frappe/model/document.py", line 766, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-2018-12-13/apps/erpnext/erpnext/buying/doctype/purchase_order/purchase_order.py", line 55, in validate
    self.validate_minimum_order_qty()
  File "/home/frappe/benches/bench-2018-12-13/apps/erpnext/erpnext/buying/doctype/purchase_order/purchase_order.py", line 97, in validate_minimum_order_qty
    from tabItem where name in ({0})""".format(", ".join(["%s"] * len(items))), items))
  File "/home/frappe/benches/bench-2018-12-13/apps/frappe/frappe/database.py", line 199, in sql
    self._cursor.execute(query, values)
  File "/home/frappe/benches/bench-2018-12-13/env/lib/python2.7/site-packages/pymysql/cursors.py", line 170, in execute
    result = self._query(query)
  File "/home/frappe/benches/bench-2018-12-13/env/lib/python2.7/site-packages/pymysql/cursors.py", line 328, in _query
    conn.query(q)
  File "/home/frappe/benches/bench-2018-12-13/env/lib/python2.7/site-packages/pymysql/connections.py", line 516, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/home/frappe/benches/bench-2018-12-13/env/lib/python2.7/site-packages/pymysql/connections.py", line 727, in _read_query_result
    result.read()
  File "/home/frappe/benches/bench-2018-12-13/env/lib/python2.7/site-packages/pymysql/connections.py", line 1066, in read
    first_packet = self.connection._read_packet()
  File "/home/frappe/benches/bench-2018-12-13/env/lib/python2.7/site-packages/pymysql/connections.py", line 683, in _read_packet
    packet.check_error()
  File "/home/frappe/benches/bench-2018-12-13/env/lib/python2.7/site-packages/pymysql/protocol.py", line 220, in check_error
    err.raise_mysql_exception(self._data)
  File "/home/frappe/benches/bench-2018-12-13/env/lib/python2.7/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
    raise errorclass(errno, errval)
ProgrammingError: (1064, u"You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ')' at line 2")
```