### PR TITLE
[Fix] Filter cancelled and draft payments in sales payment summary

### DIFF
--- a/erpnext/accounts/report/sales_payment_summary/sales_payment_summary.py
+++ b/erpnext/accounts/report/sales_payment_summary/sales_payment_summary.py
@@ -156,7 +156,6 @@ def get_sales_invoice_data(filters):
 
 
 def get_mode_of_payments(filters):
-	frappe.log_error(filters, 'filters')
 	mode_of_payments = {}
 	invoice_list = get_invoices(filters)
 	invoice_list_names = ",".join(['"' + invoice['name'] + '"' for invoice in invoice_list])
@@ -164,6 +163,7 @@ def get_mode_of_payments(filters):
 		inv_mop = frappe.db.sql("""select a.owner,a.posting_date, ifnull(b.mode_of_payment, '') as mode_of_payment
 			from `tabSales Invoice` a, `tabSales Invoice Payment` b
 			where a.name = b.parent
+			and a.docstatus = 1
 			and a.name in ({invoice_list_names})
 			union
 			select a.owner,a.posting_date, ifnull(b.mode_of_payment, '') as mode_of_payment
@@ -197,13 +197,13 @@ def get_invoices(filters):
 def get_mode_of_payment_details(filters):
 	mode_of_payment_details = {}
 	invoice_list = get_invoices(filters)
-	frappe.log_error(invoice_list, 'invoice_list')
 	invoice_list_names = ",".join(['"' + invoice['name'] + '"' for invoice in invoice_list])
 	if invoice_list:
 		inv_mop_detail = frappe.db.sql("""select a.owner, a.posting_date,
 			ifnull(b.mode_of_payment, '') as mode_of_payment, sum(b.base_amount) as paid_amount
 			from `tabSales Invoice` a, `tabSales Invoice Payment` b
 			where a.name = b.parent
+			and a.docstatus = 1
 			and a.name in ({invoice_list_names})
 			group by a.owner, a.posting_date, mode_of_payment
 			union

--- a/erpnext/accounts/report/sales_payment_summary/sales_payment_summary.py
+++ b/erpnext/accounts/report/sales_payment_summary/sales_payment_summary.py
@@ -108,33 +108,33 @@ def get_conditions(filters):
 def get_pos_invoice_data(filters):
 	conditions = get_conditions(filters)
 	result = frappe.db.sql(''
-						   'SELECT '
-						   'posting_date, owner, sum(net_total) as "net_total", sum(total_taxes) as "total_taxes", '
-						   'sum(paid_amount) as "paid_amount", sum(outstanding_amount) as "outstanding_amount", '
-						   'mode_of_payment, warehouse, cost_center '
-						   'FROM ('
-						   'SELECT '
-						   'parent, item_code, sum(amount) as "base_total", warehouse, cost_center '
-						   'from `tabSales Invoice Item`  group by parent'
-						   ') t1 '
-						   'left join '
-						   '(select parent, mode_of_payment from `tabSales Invoice Payment` group by parent) t3 '
-						   'on (t3.parent = t1.parent) '
-						   'JOIN ('
-						   'SELECT '
-						   'docstatus, company, is_pos, name, posting_date, owner, sum(base_total) as "base_total", '
-						   'sum(net_total) as "net_total", sum(total_taxes_and_charges) as "total_taxes", '
-						   'sum(base_paid_amount) as "paid_amount", sum(outstanding_amount) as "outstanding_amount" '
-						   'FROM `tabSales Invoice` '
-						   'GROUP BY name'
-						   ') a '
-						   'ON ('
-						   't1.parent = a.name and t1.base_total = a.base_total) '
-						   'WHERE a.docstatus = 1'
-						   ' AND {conditions} '
-						   'GROUP BY '
-						   'owner, posting_date, warehouse'.format(conditions=conditions), filters, as_dict=1
-						   )
+							'SELECT '
+							'posting_date, owner, sum(net_total) as "net_total", sum(total_taxes) as "total_taxes", '
+							'sum(paid_amount) as "paid_amount", sum(outstanding_amount) as "outstanding_amount", '
+							'mode_of_payment, warehouse, cost_center '
+							'FROM ('
+							'SELECT '
+							'parent, item_code, sum(amount) as "base_total", warehouse, cost_center '
+							'from `tabSales Invoice Item`  group by parent'
+							') t1 '
+							'left join '
+							'(select parent, mode_of_payment from `tabSales Invoice Payment` group by parent) t3 '
+							'on (t3.parent = t1.parent) '
+							'JOIN ('
+							'SELECT '
+							'docstatus, company, is_pos, name, posting_date, owner, sum(base_total) as "base_total", '
+							'sum(net_total) as "net_total", sum(total_taxes_and_charges) as "total_taxes", '
+							'sum(base_paid_amount) as "paid_amount", sum(outstanding_amount) as "outstanding_amount" '
+							'FROM `tabSales Invoice` '
+							'GROUP BY name'
+							') a '
+							'ON ('
+							't1.parent = a.name and t1.base_total = a.base_total) '
+							'WHERE a.docstatus = 1'
+							' AND {conditions} '
+							'GROUP BY '
+							'owner, posting_date, warehouse'.format(conditions=conditions), filters, as_dict=1
+							)
 	return result
 
 
@@ -170,6 +170,7 @@ def get_mode_of_payments(filters):
 			from `tabSales Invoice` a, `tabPayment Entry` b,`tabPayment Entry Reference` c
 			where a.name = c.reference_name
 			and b.name = c.parent
+			and b.docstatus = 1
 			and a.name in ({invoice_list_names})
 			union
 			select a.owner, a.posting_date,
@@ -211,6 +212,7 @@ def get_mode_of_payment_details(filters):
 			from `tabSales Invoice` a, `tabPayment Entry` b,`tabPayment Entry Reference` c
 			where a.name = c.reference_name
 			and b.name = c.parent
+			and b.docstatus = 1
 			and a.name in ({invoice_list_names})
 			group by a.owner, a.posting_date, mode_of_payment
 			union

--- a/erpnext/accounts/report/sales_payment_summary/test_sales_payment_summary.py
+++ b/erpnext/accounts/report/sales_payment_summary/test_sales_payment_summary.py
@@ -16,10 +16,13 @@ class TestSalesPaymentSummary(unittest.TestCase):
 		create_records()
 		pes = frappe.get_all("Payment Entry")
 		jes = frappe.get_all("Journal Entry")
+		sis = frappe.get_all("Sales Invoice")
 		for pe in pes:
 			frappe.db.set_value("Payment Entry", pe.name, "docstatus", 2)
 		for je in jes:
 			frappe.db.set_value("Journal Entry", je.name, "docstatus", 2)
+		for si in sis:
+			frappe.db.set_value("Sales Invoice", si.name, "docstatus", 2)
 
 	def test_get_mode_of_payments(self):
 		filters = get_filters()

--- a/erpnext/accounts/report/sales_payment_summary/test_sales_payment_summary.py
+++ b/erpnext/accounts/report/sales_payment_summary/test_sales_payment_summary.py
@@ -15,8 +15,11 @@ class TestSalesPaymentSummary(unittest.TestCase):
 	def setUpClass(self):
 		create_records()
 		pes = frappe.get_all("Payment Entry")
+		jes = frappe.get_all("Journal Entry")
 		for pe in pes:
 			frappe.db.set_value("Payment Entry", pe.name, "docstatus", 2)
+		for je in jes:
+			frappe.db.set_value("Journal Entry", je.name, "docstatus", 2)
 
 	def test_get_mode_of_payments(self):
 		filters = get_filters()
@@ -51,8 +54,6 @@ class TestSalesPaymentSummary(unittest.TestCase):
 			pe.cancel()
 
 		mop = get_mode_of_payments(filters)
-		print(frappe.get_all("Payment Entry", filters={"docstatus": 1}))
-		print(mop)
 		self.assertTrue('Credit Card' in mop.values()[0])
 		self.assertTrue('Cash' not in mop.values()[0])
 

--- a/erpnext/accounts/report/sales_payment_summary/test_sales_payment_summary.py
+++ b/erpnext/accounts/report/sales_payment_summary/test_sales_payment_summary.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
+# License: GNU General Public License v3. See license.txt
+
+from __future__ import unicode_literals
+import unittest
+import frappe
+import erpnext
+from erpnext.accounts.report.sales_payment_summary.sales_payment_summary import get_mode_of_payments, get_mode_of_payment_details
+from frappe.utils import nowdate
+from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
+
+test_dependencies = ["Sales Invoice"]
+
+class TestSalesPaymentSummary(unittest.TestCase):
+	def setUp(self):
+		pass
+
+	def tearDown(self):
+		pass
+
+	def test_get_mode_of_payments(self):
+		si = frappe.get_all("Sales Invoice", fields=["name", "docstatus"])
+		filters = get_filters()
+
+		for invoice in si[:2]:
+			doc = frappe.get_doc("Sales Invoice", invoice.name)
+			new_doc = frappe.copy_doc(doc)
+			new_doc.insert()
+			new_doc.submit()
+			try:
+				new_doc.submit()
+			except Exception as e:
+				pass
+
+			if int(new_doc.name[-3:])%2 == 0:
+				bank_account = "_Test Cash - _TC"
+				mode_of_payment = "Cash"
+			else:
+				bank_account = "_Test Bank - _TC"
+				mode_of_payment = "Credit Card"
+
+			pe = get_payment_entry("Sales Invoice", new_doc.name, bank_account=bank_account)
+			pe.reference_no = "_Test"
+			pe.reference_date = nowdate()
+			pe.mode_of_payment = mode_of_payment
+			pe.insert()
+			pe.submit()
+
+		mop = get_mode_of_payments(filters)
+		self.assertTrue('Credit Card' in mop.values()[0])
+		self.assertTrue('Cash' in mop.values()[0])
+
+		# Cancel all Cash payment entry and check if this mode of payment is still fetched.
+		payment_entries = frappe.get_all("Payment Entry", filters={"mode_of_payment": "Cash", "docstatus": 1}, fields=["name", "docstatus"])
+		for payment_entry in payment_entries:
+			pe = frappe.get_doc("Payment Entry", payment_entry.name)
+			pe.cancel()
+
+		mop = get_mode_of_payments(filters)
+		self.assertTrue('Credit Card' in mop.values()[0])
+		self.assertTrue('Cash' not in mop.values()[0])
+
+	def test_get_mode_of_payments_details(self):
+		si = frappe.get_all("Sales Invoice", fields=["name", "docstatus"])
+		filters = get_filters()
+
+		for invoice in si[:2]:
+			doc = frappe.get_doc("Sales Invoice", invoice.name)
+			new_doc = frappe.copy_doc(doc)
+			new_doc.insert()
+			new_doc.submit()
+			try:
+				new_doc.submit()
+			except Exception as e:
+				pass
+
+			if int(new_doc.name[-3:])%2 == 0:
+				bank_account = "_Test Cash - _TC"
+				mode_of_payment = "Cash"
+			else:
+				bank_account = "_Test Bank - _TC"
+				mode_of_payment = "Credit Card"
+
+			pe = get_payment_entry("Sales Invoice", new_doc.name, bank_account=bank_account)
+			pe.reference_no = "_Test"
+			pe.reference_date = nowdate()
+			pe.mode_of_payment = mode_of_payment
+			pe.insert()
+			pe.submit()
+
+		mopd = get_mode_of_payment_details(filters)
+
+		mopd_values = mopd.values()[0]
+		for mopd_value in mopd_values:
+			if mopd_value[0] == "Credit Card":
+				cc_init_amount = mopd_value[1]
+
+		# Cancel one Credit Card Payment Entry and check that it is not fetched in mode of payment details.
+		payment_entries = frappe.get_all("Payment Entry", filters={"mode_of_payment": "Credit Card", "docstatus": 1}, fields=["name", "docstatus"])
+		for payment_entry in payment_entries[:1]:
+			pe = frappe.get_doc("Payment Entry", payment_entry.name)
+			pe.cancel()
+
+		mopd = get_mode_of_payment_details(filters)
+		mopd_values = mopd.values()[0]
+		for mopd_value in mopd_values:
+			if mopd_value[0] == "Credit Card":
+				cc_final_amount = mopd_value[1]
+
+		self.assertTrue(cc_init_amount > cc_final_amount)
+
+def get_filters():
+	return {
+		"from_date": "1900-01-01",
+		"to_date": nowdate(),
+		"company": "_Test Company"
+	}

--- a/erpnext/accounts/report/sales_payment_summary/test_sales_payment_summary.py
+++ b/erpnext/accounts/report/sales_payment_summary/test_sales_payment_summary.py
@@ -4,7 +4,6 @@
 from __future__ import unicode_literals
 import unittest
 import frappe
-import erpnext
 from erpnext.accounts.report.sales_payment_summary.sales_payment_summary import get_mode_of_payments, get_mode_of_payment_details
 from frappe.utils import nowdate
 from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
@@ -29,8 +28,8 @@ class TestSalesPaymentSummary(unittest.TestCase):
 			new_doc.submit()
 			try:
 				new_doc.submit()
-			except Exception:
-				pass
+			except Exception as e:
+				print(e)
 
 			if int(new_doc.name[-3:])%2 == 0:
 				bank_account = "_Test Cash - _TC"
@@ -71,8 +70,8 @@ class TestSalesPaymentSummary(unittest.TestCase):
 			new_doc.submit()
 			try:
 				new_doc.submit()
-			except Exception:
-				pass
+			except Exception as e:
+				print(e)
 
 			if int(new_doc.name[-3:])%2 == 0:
 				bank_account = "_Test Cash - _TC"

--- a/erpnext/accounts/report/sales_payment_summary/test_sales_payment_summary.py
+++ b/erpnext/accounts/report/sales_payment_summary/test_sales_payment_summary.py
@@ -24,6 +24,7 @@ class TestSalesPaymentSummary(unittest.TestCase):
 		for invoice in si[:2]:
 			doc = frappe.get_doc("Sales Invoice", invoice.name)
 			new_doc = frappe.copy_doc(doc)
+			new_doc.ignore_pricing_rule = 1
 			new_doc.insert()
 			new_doc.submit()
 			try:

--- a/erpnext/accounts/report/sales_payment_summary/test_sales_payment_summary.py
+++ b/erpnext/accounts/report/sales_payment_summary/test_sales_payment_summary.py
@@ -14,6 +14,9 @@ class TestSalesPaymentSummary(unittest.TestCase):
 	@classmethod
 	def setUpClass(self):
 		create_records()
+		pes = frappe.get_all("Payment Entry")
+		for pe in pes:
+			frappe.db.set_value("Payment Entry", pe.name, "docstatus", 2)
 
 	def test_get_mode_of_payments(self):
 		filters = get_filters()

--- a/erpnext/accounts/report/sales_payment_summary/test_sales_payment_summary.py
+++ b/erpnext/accounts/report/sales_payment_summary/test_sales_payment_summary.py
@@ -19,10 +19,12 @@ class TestSalesPaymentSummary(unittest.TestCase):
 
 	def test_get_mode_of_payments(self):
 		si = frappe.get_all("Sales Invoice", filters={"company": "_Test Company", "customer": "_Test Customer"}, fields=["name", "docstatus"])
+		print(si)
 		filters = get_filters()
 
 		for invoice in si[:-2]:
 			doc = frappe.get_doc("Sales Invoice", invoice.name)
+			print(doc.__dict__)
 			new_doc = frappe.copy_doc(doc)
 			new_doc.ignore_pricing_rule = 1
 			new_doc.insert()

--- a/erpnext/accounts/report/sales_payment_summary/test_sales_payment_summary.py
+++ b/erpnext/accounts/report/sales_payment_summary/test_sales_payment_summary.py
@@ -18,10 +18,10 @@ class TestSalesPaymentSummary(unittest.TestCase):
 		pass
 
 	def test_get_mode_of_payments(self):
-		si = frappe.get_all("Sales Invoice", fields=["name", "docstatus"])
+		si = frappe.get_all("Sales Invoice", filters={"company": "_Test Company", "customer": "_Test Customer"}, fields=["name", "docstatus"])
 		filters = get_filters()
 
-		for invoice in si[:2]:
+		for invoice in si[:-2]:
 			doc = frappe.get_doc("Sales Invoice", invoice.name)
 			new_doc = frappe.copy_doc(doc)
 			new_doc.ignore_pricing_rule = 1
@@ -61,10 +61,10 @@ class TestSalesPaymentSummary(unittest.TestCase):
 		self.assertTrue('Cash' not in mop.values()[0])
 
 	def test_get_mode_of_payments_details(self):
-		si = frappe.get_all("Sales Invoice", fields=["name", "docstatus"])
+		si = frappe.get_all("Sales Invoice", filters={"company": "_Test Company", "customer": "_Test Customer"}, fields=["name", "docstatus"])
 		filters = get_filters()
 
-		for invoice in si[:2]:
+		for invoice in si[:-2]:
 			doc = frappe.get_doc("Sales Invoice", invoice.name)
 			new_doc = frappe.copy_doc(doc)
 			new_doc.insert()

--- a/erpnext/accounts/report/sales_payment_summary/test_sales_payment_summary.py
+++ b/erpnext/accounts/report/sales_payment_summary/test_sales_payment_summary.py
@@ -29,7 +29,7 @@ class TestSalesPaymentSummary(unittest.TestCase):
 			new_doc.submit()
 			try:
 				new_doc.submit()
-			except Exception as e:
+			except Exception:
 				pass
 
 			if int(new_doc.name[-3:])%2 == 0:
@@ -71,7 +71,7 @@ class TestSalesPaymentSummary(unittest.TestCase):
 			new_doc.submit()
 			try:
 				new_doc.submit()
-			except Exception as e:
+			except Exception:
 				pass
 
 			if int(new_doc.name[-3:])%2 == 0:

--- a/erpnext/accounts/report/sales_payment_summary/test_sales_payment_summary.py
+++ b/erpnext/accounts/report/sales_payment_summary/test_sales_payment_summary.py
@@ -19,14 +19,14 @@ class TestSalesPaymentSummary(unittest.TestCase):
 
 	def test_get_mode_of_payments(self):
 		si = frappe.get_all("Sales Invoice", filters={"company": "_Test Company", "customer": "_Test Customer"}, fields=["name", "docstatus"])
-		print(si)
 		filters = get_filters()
 
 		for invoice in si[:-2]:
 			doc = frappe.get_doc("Sales Invoice", invoice.name)
-			print(doc.__dict__)
 			new_doc = frappe.copy_doc(doc)
 			new_doc.ignore_pricing_rule = 1
+			for item in new_doc.items:
+				item.pricing_rule = ""
 			new_doc.insert()
 			new_doc.submit()
 			try:
@@ -69,6 +69,9 @@ class TestSalesPaymentSummary(unittest.TestCase):
 		for invoice in si[:-2]:
 			doc = frappe.get_doc("Sales Invoice", invoice.name)
 			new_doc = frappe.copy_doc(doc)
+			new_doc.ignore_pricing_rule = 1
+			for item in new_doc.items:
+				item.pricing_rule = ""
 			new_doc.insert()
 			new_doc.submit()
 			try:

--- a/erpnext/accounts/report/sales_payment_summary/test_sales_payment_summary.py
+++ b/erpnext/accounts/report/sales_payment_summary/test_sales_payment_summary.py
@@ -51,6 +51,8 @@ class TestSalesPaymentSummary(unittest.TestCase):
 			pe.cancel()
 
 		mop = get_mode_of_payments(filters)
+		print(frappe.get_all("Payment Entry", filters={"docstatus": 1}))
+		print(mop)
 		self.assertTrue('Credit Card' in mop.values()[0])
 		self.assertTrue('Cash' not in mop.values()[0])
 


### PR DESCRIPTION
Hi,

The sales payment summary report is currently incorrect if you have cancelled or draft payments.
These should be filtered for the report to be accurate.

I have also replaced some dots by tabs in the code.

Thanks! 

