### PR TITLE
[Fix] Safe decode project name for languages with special characters

### DIFF
--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -16,7 +16,7 @@ from six import iteritems
 
 class Project(Document):
 	def get_feed(self):
-		return '{0}: {1}'.format(_(self.status), self.project_name)
+		return '{0}: {1}'.format(_(self.status), frappe.safe_decode(self.project_name))
 
 	def onload(self):
 		"""Load project tasks for quick view"""
@@ -76,7 +76,7 @@ class Project(Document):
 
 	def validate_project_name(self):
 		if self.get("__islocal") and frappe.db.exists("Project", self.project_name):
-			frappe.throw(_("Project {0} already exists").format(self.project_name))
+			frappe.throw(_("Project {0} already exists").format(frappe.safe_decode(self.project_name)))
 
 	def validate_dates(self):
 		if self.expected_start_date and self.expected_end_date:


### PR DESCRIPTION
Hi,

Another quick fix to avoid ERPNext to throw an error when the project name is using special characters.

Thanks!

