### PR TITLE
[Fix] Pos bugs

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -324,7 +324,8 @@ class SalesInvoice(SellingController):
 			return {
 				"print_format": print_format,
 				"allow_edit_rate": pos.get("allow_user_to_edit_rate"),
-				"allow_edit_discount": pos.get("allow_user_to_edit_discount")
+				"allow_edit_discount": pos.get("allow_user_to_edit_discount"),
+				"campaign": pos.get("campaign")
 			}
 
 	def update_time_sheet(self, sales_invoice):

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
+# Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
 from __future__ import unicode_literals
 
@@ -762,6 +762,21 @@ class TestSalesInvoice(unittest.TestCase):
 		set_perpetual_inventory(0)
 
 		frappe.db.sql("delete from `tabPOS Profile`")
+	
+	def test_pos_si_without_payment(self):
+		set_perpetual_inventory()
+		make_pos_profile()
+
+		self._insert_purchase_receipt()
+		pos = copy.deepcopy(test_records[1])
+		pos["is_pos"] = 1
+		pos["update_stock"] = 1
+
+		si = frappe.copy_doc(pos)
+		si.insert()
+
+		# Check that the invoice cannot be submitted without payments
+		self.assertRaises(frappe.ValidationError, si.submit)
 
 	def test_sales_invoice_gl_entry_with_perpetual_inventory_no_item_code(self):
 		set_perpetual_inventory()

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -767,7 +767,6 @@ class TestSalesInvoice(unittest.TestCase):
 		set_perpetual_inventory()
 		make_pos_profile()
 
-		self._insert_purchase_receipt()
 		pos = copy.deepcopy(test_records[1])
 		pos["is_pos"] = 1
 		pos["update_stock"] = 1

--- a/erpnext/accounts/page/pos/pos.js
+++ b/erpnext/accounts/page/pos/pos.js
@@ -1135,16 +1135,18 @@ erpnext.pos.PointOfSale = erpnext.taxes_and_totals.extend({
 	},
 
 	apply_category: function() {
-		var me = this;
-		category = this.selected_item_group || "All Item Groups";
+		frappe.db.get_value("Item Group", {lft: 1, is_group: 1}, "name", (r) => {
+			category = this.selected_item_group || r.name;
 
-		if(category == 'All Item Groups') {
-			return this.item_data
-		} else {
-			return this.item_data.filter(function(element, index, array){
-				return element.item_group == category;
-			});
-		}
+			if(category == r.name) {
+				return this.item_data
+			} else {
+				return this.item_data.filter(function(element, index, array){
+					return element.item_group == category;
+				});
+			}
+		})
+		
 	},
 
 	bind_items_event: function() {

--- a/erpnext/selling/page/point_of_sale/point_of_sale.js
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.js
@@ -1128,12 +1128,15 @@ class POSItems {
 		this.events = events;
 		this.currency = this.frm.doc.currency;
 
-		this.make_dom();
-		this.make_fields();
+		frappe.db.get_value("Item Group", {lft: 1, is_group: 1}, "name", (r) => {
+			this.parent_item_group = r.name;
+			this.make_dom();
+			this.make_fields();
 
-		this.init_clusterize();
-		this.bind_events();
-		this.load_items_data();
+			this.init_clusterize();
+			this.bind_events();
+			this.load_items_data();
+		})
 	}
 
 	load_items_data() {
@@ -1175,6 +1178,7 @@ class POSItems {
 
 	make_fields() {
 		// Search field
+		const me = this;
 		this.search_field = frappe.ui.form.make_control({
 			df: {
 				fieldtype: 'Data',
@@ -1202,7 +1206,7 @@ class POSItems {
 				fieldtype: 'Link',
 				label: 'Item Group',
 				options: 'Item Group',
-				default: 'All Item Groups',
+				default: me.parent_item_group,
 				onchange: () => {
 					const item_group = this.item_group_field.get_value();
 					if (item_group) {
@@ -1258,7 +1262,7 @@ class POSItems {
 		this.clusterize.update(row_items);
 	}
 
-	filter_items({ search_term='', item_group='All Item Groups' }={}) {
+	filter_items({ search_term='', item_group=this.parent_item_group }={}) {
 		if (search_term) {
 			search_term = search_term.toLowerCase();
 
@@ -1271,7 +1275,7 @@ class POSItems {
 				this.set_item_in_the_cart(items);
 				return;
 			}
-		} else if (item_group == "All Item Groups") {
+		} else if (item_group == this.parent_item_group) {
 			this.items = this.all_items;
 			return this.render_items(this.all_items);
 		}
@@ -1376,7 +1380,7 @@ class POSItems {
 		return template;
 	}
 
-	get_items({start = 0, page_length = 40, search_value='', item_group="All Item Groups"}={}) {
+	get_items({start = 0, page_length = 40, search_value='', item_group=this.parent_item_group}={}) {
 		return new Promise(res => {
 			frappe.call({
 				method: "erpnext.selling.page.point_of_sale.point_of_sale.get_items",

--- a/erpnext/selling/page/point_of_sale/point_of_sale.js
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.js
@@ -394,7 +394,7 @@ erpnext.pos.PointOfSale = class PointOfSale {
 				}
 			}
 
-			frappe.prompt(this.get_promopt_fields(),
+			frappe.prompt(this.get_prompt_fields(),
 				on_submit,
 				__('Select POS Profile')
 			);
@@ -417,11 +417,12 @@ erpnext.pos.PointOfSale = class PointOfSale {
 		]);
 	}
 
-	get_promopt_fields() {
+	get_prompt_fields() {
 		return [{
 			fieldtype: 'Link',
 			label: __('POS Profile'),
 			options: 'POS Profile',
+			fieldname: 'pos_profile',
 			reqd: 1,
 			get_query: () => {
 				return {
@@ -433,7 +434,8 @@ erpnext.pos.PointOfSale = class PointOfSale {
 			}
 		}, {
 			fieldtype: 'Check',
-			label: __('Set as default')
+			label: __('Set as default'),
+			fieldname: 'set_as_default'
 		}];
 	}
 
@@ -522,6 +524,7 @@ erpnext.pos.PointOfSale = class PointOfSale {
 						this.frm.meta.default_print_format = r.message.print_format || "";
 						this.frm.allow_edit_rate = r.message.allow_edit_rate;
 						this.frm.allow_edit_discount = r.message.allow_edit_discount;
+						this.frm.doc.campaign = r.message.campaign;
 					}
 				}
 


### PR DESCRIPTION
Hi,

This PR aims at correcting a few things on the POS:

1. The item group "All Item Groups" was hardcoded, whereas users may want to change the name of that group.
I have remove the hardcode and added a request to fetch the main group in the hierarchy.

2. The "Change POS profile" button was not working, because the fields in the dialog had no names. I have just added fieldnames for both fields.

3. I have corrected a typo in the "get_prompt_fields" function name.

4. I have added the campaign to the online POS because it is useful for some users (I have clients using the POS only on fairs and they want to categorize their POS invoices). Since the field exists for the offline POS in the POS profile, it should also be available in the online POS I guess.

Please let me know if you have any remark.

Thanks!

