### PR TITLE
[Fix] Warehouse wise item balance age and value report not working

### DIFF
--- a/erpnext/stock/report/warehouse_wise_item_balance_age_and_value/warehouse_wise_item_balance_age_and_value.js
+++ b/erpnext/stock/report/warehouse_wise_item_balance_age_and_value/warehouse_wise_item_balance_age_and_value.js
@@ -10,7 +10,7 @@ frappe.query_reports["Warehouse wise Item Balance Age and Value"] = {
                         "fieldtype": "Date",
                         "width": "80",
                         "reqd": 1,
-                        "default": frappe.sys_defaults.year_start_date,
+                        "default": frappe.datetime.add_months(frappe.datetime.get_today(), -1),
                 },
                 {
                         "fieldname":"to_date",

--- a/erpnext/stock/report/warehouse_wise_item_balance_age_and_value/warehouse_wise_item_balance_age_and_value.py
+++ b/erpnext/stock/report/warehouse_wise_item_balance_age_and_value/warehouse_wise_item_balance_age_and_value.py
@@ -8,7 +8,8 @@ from __future__ import unicode_literals
 import frappe
 from frappe import _
 from frappe.utils import flt, cint, getdate
-from erpnext.stock.report.stock_balance.stock_balance import get_item_details, get_item_reorder_details, get_item_warehouse_map
+from erpnext.stock.report.stock_balance.stock_balance import (get_item_details,
+	get_item_reorder_details, get_item_warehouse_map, get_items, get_stock_ledger_entries)
 from erpnext.stock.report.stock_ageing.stock_ageing import get_fifo_queue, get_average_age
 from six import iteritems
 
@@ -18,8 +19,12 @@ def execute(filters=None):
 	validate_filters(filters)
 
 	columns = get_columns(filters)
-	item_map = get_item_details(filters)
-	iwb_map = get_item_warehouse_map(filters)
+
+	items = get_items(filters)
+	sle = get_stock_ledger_entries(filters, items)
+
+	item_map = get_item_details(items, sle, filters)
+	iwb_map = get_item_warehouse_map(filters, sle)
 	warehouse_list = get_warehouse_list(filters)
 	item_ageing = get_fifo_queue(filters)
 	data = []
@@ -27,6 +32,8 @@ def execute(filters=None):
 	item_value = {}
 
 	for (company, item, warehouse) in sorted(iwb_map):
+		if not item_map.get(item):  continue
+
 		row = []
 		qty_dict = iwb_map[(company, item, warehouse)]
 		item_balance.setdefault((item, item_map[item]["item_group"]), [])
@@ -42,6 +49,8 @@ def execute(filters=None):
 
 	# sum bal_qty by item
 	for (item, item_group), wh_balance in iteritems(item_balance):
+		if not item_ageing.get(item):  continue
+
 		total_stock_value = sum(item_value[(item, item_group)])
 		row = [item, item_group, total_stock_value]
 


### PR DESCRIPTION
**Issue**
```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1007, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 489, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 172, in run
    return generate_report_result(report, filters, user)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 65, in generate_report_result
    res = frappe.get_attr(method_name)(frappe._dict(filters))
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/stock/report/warehouse_wise_item_balance_age_and_value/warehouse_wise_item_balance_age_and_value.py", line 21, in execute
    item_map = get_item_details(filters)
TypeError: get_item_details() missing 2 required positional arguments: 'sle' and 'filters'
```

**After Fix**

![image](https://user-images.githubusercontent.com/8780500/50332578-92b9ed80-0528-11e9-955e-9aa6c184a0a2.png)
