### PR TITLE
fix: daily_work_summary_settings migration patch

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -495,7 +495,7 @@ erpnext.patches.v10_0.set_b2c_limit
 erpnext.patches.v10_0.update_translatable_fields
 erpnext.patches.v10_0.rename_offer_letter_to_job_offer
 execute:frappe.delete_doc('DocType', 'Production Planning Tool', ignore_missing=True)
-erpnext.patches.v10_0.migrate_daily_work_summary_settings_to_daily_work_summary_group
+erpnext.patches.v10_0.migrate_daily_work_summary_settings_to_daily_work_summary_group # 24-12-2018
 erpnext.patches.v10_0.add_default_cash_flow_mappers
 erpnext.patches.v11_0.make_quality_inspection_template
 erpnext.patches.v10_0.update_status_for_multiple_source_in_po

--- a/erpnext/patches/v10_0/migrate_daily_work_summary_settings_to_daily_work_summary_group.py
+++ b/erpnext/patches/v10_0/migrate_daily_work_summary_settings_to_daily_work_summary_group.py
@@ -6,37 +6,36 @@ import frappe
 
 
 def execute():
-	frappe.reload_doc("hr", "doctype", "daily_work_summary_group")
-	frappe.reload_doc("hr", "doctype", "daily_work_summary_group_user")
+	if not frappe.db.table_exists('Daily Work Summary Group'):
+		frappe.reload_doc("hr", "doctype", "daily_work_summary_group")
+		frappe.reload_doc("hr", "doctype", "daily_work_summary_group_user")
 
-	# check if Daily Work Summary Settings Company table exists
-	try:
-		frappe.db.sql('DESC `tabDaily Work Summary Settings Company`')
-	except Exception:
-		return
+		# check if Daily Work Summary Settings Company table exists
+		try:
+			frappe.db.sql('DESC `tabDaily Work Summary Settings Company`')
+		except Exception:
+			return
 
-	# get the previously saved settings
-	previous_setting = get_previous_setting()
-	if previous_setting["companies"]:
-		for d in previous_setting["companies"]:
-			users = frappe.get_list("Employee", dict(
-				company=d.company, user_id=("!=", " ")), "user_id as user")
-			if(len(users)):
-				# create new group entry for each company entry
-				new_group = frappe.get_doc(dict(doctype="Daily Work Summary Group",
-					name="Daily Work Summary for " + d.company,
-					users=users,
-					send_emails_at=d.send_emails_at,
-					subject=previous_setting["subject"],
-					message=previous_setting["message"]))
-				new_group.flags.ignore_permissions = True
-				new_group.flags.ignore_validate = True
-				new_group.insert(ignore_if_duplicate = True)
-	frappe.delete_doc("Daily Work Summary Settings")
-	frappe.delete_doc("Daily Work Summary Settings Company")
+		# get the previously saved settings
+		previous_setting = get_previous_setting()
+		if previous_setting["companies"]:
+			for d in previous_setting["companies"]:
+				users = frappe.get_list("Employee", dict(
+					company=d.company, user_id=("!=", " ")), "user_id as user")
+				if(len(users)):
+					# create new group entry for each company entry
+					new_group = frappe.get_doc(dict(doctype="Daily Work Summary Group",
+						name="Daily Work Summary for " + d.company,
+						users=users,
+						send_emails_at=d.send_emails_at,
+						subject=previous_setting["subject"],
+						message=previous_setting["message"]))
+					new_group.flags.ignore_permissions = True
+					new_group.flags.ignore_validate = True
+					new_group.insert(ignore_if_duplicate = True)
 
-def get_setting_companies():
-	return frappe.db.sql("select * from `tabDaily Work Summary Settings Company`", as_dict=True)
+	frappe.delete_doc("DocType", "Daily Work Summary Settings")
+	frappe.delete_doc("DocType", "Daily Work Summary Settings Company")
 
 
 def get_previous_setting():
@@ -47,3 +46,6 @@ def get_previous_setting():
 		obj[field] = value
 	obj["companies"] = get_setting_companies()
 	return obj
+
+def get_setting_companies():
+	return frappe.db.sql("select * from `tabDaily Work Summary Settings Company`", as_dict=True)


### PR DESCRIPTION
The patch `migrate_daily_work_summary_settings_to_daily_work_summary_group.py` was supposed to delete `Daily Work Summary Settings` doctype from the database after migration which was not working due to the incorrect usage of frappe.delete_doc()

This fix will delete that doctype even if the patch has been already executed.


