### PR TITLE
[Fix] Salary structure not saving

### DIFF
--- a/erpnext/hr/doctype/salary_structure/salary_structure.py
+++ b/erpnext/hr/doctype/salary_structure/salary_structure.py
@@ -4,7 +4,7 @@
 from __future__ import unicode_literals
 import frappe
 
-from frappe.utils import flt, cint
+from frappe.utils import flt, cint, cstr
 from frappe import _
 from frappe.model.mapper import get_mapped_doc
 from frappe.model.document import Document
@@ -22,7 +22,7 @@ class SalaryStructure(Document):
 		overwritten_fields_if_missing = ["amount_based_on_formula", "formula", "amount"]
 		for table in ["earnings", "deductions"]:
 			for d in self.get(table):
-				component_default_value = frappe.db.get_value("Salary Component", str(d.salary_component),
+				component_default_value = frappe.db.get_value("Salary Component", cstr(d.salary_component),
 					overwritten_fields + overwritten_fields_if_missing, as_dict=1)
 				if component_default_value:
 					for fieldname in overwritten_fields:


### PR DESCRIPTION
**Issue**
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2018-12-24/apps/frappe/frappe/desk/form/save.py", line 22, in savedocs
    doc.save()
  File "/home/frappe/benches/bench-2018-12-24/apps/frappe/frappe/model/document.py", line 260, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-2018-12-24/apps/frappe/frappe/model/document.py", line 296, in _save
    self.run_before_save_methods()
  File "/home/frappe/benches/bench-2018-12-24/apps/frappe/frappe/model/document.py", line 876, in run_before_save_methods
    self.run_method("validate")
  File "/home/frappe/benches/bench-2018-12-24/apps/frappe/frappe/model/document.py", line 772, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-2018-12-24/apps/frappe/frappe/model/document.py", line 1048, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-2018-12-24/apps/frappe/frappe/model/document.py", line 1031, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-2018-12-24/apps/frappe/frappe/model/document.py", line 766, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-2018-12-24/apps/erpnext/erpnext/hr/doctype/salary_structure/salary_structure.py", line 15, in validate
    self.set_missing_values()
  File "/home/frappe/benches/bench-2018-12-24/apps/erpnext/erpnext/hr/doctype/salary_structure/salary_structure.py", line 25, in set_missing_values
    component_default_value = frappe.db.get_value("Salary Component", str(d.salary_component),
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-6: ordinal not in range(128)

```