### PR TITLE
[Fix] Patch rename_bom_wo_fields

### DIFF
--- a/erpnext/manufacturing/doctype/bom_item/bom_item.json
+++ b/erpnext/manufacturing/doctype/bom_item/bom_item.json
@@ -1121,7 +1121,7 @@
  "issingle": 0,
  "istable": 1,
  "max_attachments": 0,
- "modified": "2018-11-22 15:04:55.187136",
+ "modified": "2018-12-26 15:04:56.187136",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "BOM Item",


### PR DESCRIPTION
**Issue**

```
Executing erpnext.patches.v11_0.rename_bom_wo_fields in data.erpnext (6a090ca3acb7162e)
rename_field: include_item_in_manufacturing not found in BOM Item
rename_field: include_item_in_manufacturing not found in BOM Item
rename_field: include_item_in_manufacturing not found in BOM Item
rename_field: include_item_in_manufacturing not found in BOM Item


There was an issue while migrating the DocType: BOM

Traceback (most recent call last):
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 162, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 97, in <module>
    main()
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 1066, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "/Users/saurabh/project/frappe-bench/env/lib/python2.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 25, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/commands/site.py", line 227, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/migrate.py", line 39, in migrate
    frappe.modules.patch_handler.run_all()
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 29, in run_all
    if not run_single(patchmodule = patch):
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 63, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 83, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/Users/saurabh/project/frappe-bench/apps/erpnext/erpnext/patches/v11_0/rename_bom_wo_fields.py", line 14, in execute
    frappe.reload_doc('manufacturing', 'doctype', frappe.scrub(doctype))
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/__init__.py", line 780, in reload_doc
    return frappe.modules.reload_doc(module, dt, dn, force=force, reset_permissions=reset_permissions)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/modules/utils.py", line 155, in reload_doc
    return import_files(module, dt, dn, force=force, reset_permissions=reset_permissions)

  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/modules/import_file.py", line 26, in import_files
    reset_permissions=reset_permissions)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/modules/import_file.py", line 31, in import_file
    ret = import_file_by_path(path, force, pre_process=pre_process, reset_permissions=reset_permissions)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/modules/import_file.py", line 65, in import_file_by_path
    ignore_version=ignore_version, reset_permissions=reset_permissions)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/modules/import_file.py", line 132, in import_doc
    doc.insert()
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/model/document.py", line 249, in insert
    self.run_post_save_methods()
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/model/document.py", line 905, in run_post_save_methods
    self.run_method("on_update")
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/model/document.py", line 772, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/model/document.py", line 1048, in composer
    return composed(self, method, *args, **kwargs)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/model/document.py", line 1031, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/model/document.py", line 766, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/Users/saurabh/project/frappe-bench/apps/frappe/frappe/core/doctype/doctype/doctype.py", line 247, in on_update
    raise e
pymysql.err.DataError: (1265, u"Data truncated for column 'allow_same_item_multiple_times' at row 1")
```