### PR TITLE
Validation for credit note amount

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -138,6 +138,11 @@ class SalesInvoice(SellingController):
 
 	def before_save(self):
 		set_account_for_mode_of_payment(self)
+		if self.is_return:
+			return_against = frappe.get_doc("Sales Invoice", self.return_against)
+			if abs(self.grand_total) > return_against.grand_total - return_against.outstanding_amount:
+				frappe.throw(_("Credit note amount cannot be greater than paid amount"))
+
 
 	def on_submit(self):
 		self.validate_pos_paid_amount()


### PR DESCRIPTION
If credit note amount against a sales invoice is greater than paid amount then a validation  error will be thrown .

Paid Amount = 10000 (35000-25000)
![screenshot 2018-12-26 at 11 39 19 am](https://user-images.githubusercontent.com/42651287/50438679-f66f5c80-0914-11e9-8a52-21c66564af49.png)

Credit Note Amount = 15000
![screenshot 2018-12-26 at 11 40 08 am](https://user-images.githubusercontent.com/42651287/50438681-f7a08980-0914-11e9-9bbd-c8a88f269c19.png)
![screenshot 2018-12-26 at 11 39 55 am](https://user-images.githubusercontent.com/42651287/50438683-f8d1b680-0914-11e9-8e1f-76fb3b862263.png)




