### PR TITLE
fix(website): Pagination in child item groups

### DIFF
--- a/erpnext/setup/doctype/item_group/item_group.py
+++ b/erpnext/setup/doctype/item_group/item_group.py
@@ -136,7 +136,10 @@ def get_child_groups_for_list_in_html(item_group, start, limit, search):
 			rgt = ('<', item_group.rgt),
 		),
 		or_filters = search_filters,
-		order_by = 'weightage desc, name asc')
+		order_by = 'weightage desc, name asc',
+		start = start,
+		limit = limit
+	)
 
 	return [get_item_for_list_in_html(r) for r in data]
 


### PR DESCRIPTION
Item groups pages which had child item groups were not paged at all despite having next, prev buttons