### PR TITLE
fix: patch to rename additional salary component

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -580,3 +580,4 @@ erpnext.patches.v11_0.update_delivery_trip_status
 erpnext.patches.v10_0.repost_gle_for_purchase_receipts_with_rejected_items
 erpnext.patches.v11_0.set_missing_gst_hsn_code
 erpnext.patches.v11_0.rename_bom_wo_fields
+erpnext.patches.v11_0.rename_additional_salary_component_additional_salary

--- a/erpnext/patches/v11_0/rename_additional_salary_component_additional_salary.py
+++ b/erpnext/patches/v11_0/rename_additional_salary_component_additional_salary.py
@@ -1,0 +1,10 @@
+import frappe
+
+# this patch should have been included with this PR https://github.com/frappe/erpnext/pull/14302
+
+def execute():
+	if frappe.db.table_exists("Additional Salary Component"):
+		if not frappe.db.table_exists("Additional Salary"):
+			frappe.rename_doc("DocType", "Additional Salary Component", "Additional Salary")
+
+		frappe.delete_doc('DocType', "Additional Salary Component")


### PR DESCRIPTION
- Should fix 
```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 55, in application
    response = frappe.handler.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 20, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 55, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1013, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/form/load.py", line 71, in getdoctype
    docs = get_meta_bundle(doctype)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/form/load.py", line 81, in get_meta_bundle
    bundle = [frappe.desk.form.meta.get_meta(doctype)]
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/form/meta.py", line 26, in get_meta
    meta = FormMeta(doctype)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/form/meta.py", line 39, in __init__
    self.load_assets()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/form/meta.py", line 53, in load_assets
    self.load_templates()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/form/meta.py", line 174, in load_templates
    module = load_doctype_module(self.name)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/utils.py", line 186, in load_doctype_module
    raise ImportError('Module import failed for {0} ({1})'.format(doctype, module_name + ' Error: ' + str(e)))
ImportError: Module import failed for Additional Salary Component (erpnext.hr.doctype.additional_salary_component.additional_salary_component Error: No module named 'erpnext.hr.doctype.additional_salary_component.additional_salary_component')
```
(happens while clicking **Links** option in menu of Employee master)

This happens because proper renaming of additional component salary was not done [here ](https://github.com/frappe/erpnext/pull/14302) due to which there are fields of additional salary component (in the Docfield table) one of which is a Link field of `Employee`. So when we try to get all the links of Employee it tries to fetch additional_salary_component module which has been renamed manually [in this PR](https://github.com/frappe/erpnext/pull/14302)

