### PR TITLE
fix: leave application and timesheet tests

### DIFF
--- a/erpnext/hr/doctype/leave_application/test_leave_application.py
+++ b/erpnext/hr/doctype/leave_application/test_leave_application.py
@@ -457,7 +457,7 @@ def get_leave_period():
 		return frappe.get_doc(dict(
 				name = 'Test Leave Period',
 				doctype = 'Leave Period',
-				from_date = "{0}-01-01".format(now_datetime().year),
+				from_date = "{0}-12-01".format(now_datetime().year - 1),
 				to_date = "{0}-12-31".format(now_datetime().year),
 				company = "_Test Company",
 				is_active = 1

--- a/erpnext/projects/doctype/timesheet/test_timesheet.py
+++ b/erpnext/projects/doctype/timesheet/test_timesheet.py
@@ -186,6 +186,8 @@ def make_salary_structure_for_timesheet(employee):
 
 	if not frappe.db.get_value("Salary Structure Assignment",
 		{'employee':employee, 'docstatus': 1}):
+			frappe.db.set_value('Employee', employee, 'date_of_joining',
+				add_months(nowdate(), -5))
 			create_salary_structure_assignment(employee, salary_structure.name)
 
 	return salary_structure


### PR DESCRIPTION
Summary of changes made:
- increase Leave Period to ensure leave application doesn't fall outside it
(now - 7 days used to fail for first 7 days of year) 
- reset date of joining in timesheet test to prevent output of other tests to interfere with it