### PR TITLE
fix: report quoted item comparison not working

### DIFF
--- a/erpnext/buying/report/quoted_item_comparison/quoted_item_comparison.py
+++ b/erpnext/buying/report/quoted_item_comparison/quoted_item_comparison.py
@@ -65,8 +65,8 @@ def get_quantity_list(item):
 	
 	if item:
 		qty_list = frappe.db.sql("""select distinct qty from `tabSupplier Quotation Item`
-			where ifnull(item_code,'')=%s and docstatus < 2""", item, as_dict=1)
-		qty_list.sort(reverse=False)
+			where ifnull(item_code,'')=%s and docstatus < 2 order by qty""", item, as_dict=1)
+
 		for qt in qty_list:
 			col = frappe._dict({
 				"key": str(qt.qty),


### PR DESCRIPTION
**Issue**

```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1013, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 495, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 179, in run
    result = generate_report_result(report, filters, user)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 66, in generate_report_result
    res = frappe.get_attr(method_name)(frappe._dict(filters))
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/buying/report/quoted_item_comparison/quoted_item_comparison.py", line 10, in execute
    qty_list = get_quantity_list(filters.item)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/buying/report/quoted_item_comparison/quoted_item_comparison.py", line 69, in get_quantity_list
    qty_list.sort(reverse=False)
TypeError: '<' not supported between instances of '_dict' and '_dict'
```