### PR TITLE
fix: employee is reqd to preview salary slip from salary structure

### DIFF
--- a/erpnext/hr/doctype/salary_structure/salary_structure.js
+++ b/erpnext/hr/doctype/salary_structure/salary_structure.js
@@ -124,6 +124,7 @@ frappe.ui.form.on('Salary Structure', {
 							"label":__("Employee"),
 							"fieldname":"employee",
 							"fieldtype":"Select",
+							"reqd": true,
 							options: employees
 						}, {
 							fieldname:"fetch",


### PR DESCRIPTION
**Issue**

If employee is not selected while previewing salary slip from salary structure
![screen shot 2019-01-03 at 4 21 19 pm](https://user-images.githubusercontent.com/8780500/50634209-e63e2980-0f73-11e9-94da-e9693225c25f.png)

Below error is coming
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2018-12-24/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2018-12-24/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2018-12-24/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2018-12-24/apps/frappe/frappe/__init__.py", line 1007, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2018-12-24/apps/erpnext/erpnext/hr/doctype/salary_structure/salary_structure.py", line 159, in make_salary_slip
    }, target_doc, postprocess, ignore_child_tables=True)
  File "/home/frappe/benches/bench-2018-12-24/apps/frappe/frappe/model/mapper.py", line 113, in get_mapped_doc
    postprocess(source_doc, target_doc)
  File "/home/frappe/benches/bench-2018-12-24/apps/erpnext/erpnext/hr/doctype/salary_structure/salary_structure.py", line 149, in postprocess
    target.run_method('process_salary_structure')
  File "/home/frappe/benches/bench-2018-12-24/apps/frappe/frappe/model/document.py", line 772, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-2018-12-24/apps/frappe/frappe/model/document.py", line 1048, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-2018-12-24/apps/frappe/frappe/model/document.py", line 1031, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-2018-12-24/apps/frappe/frappe/model/document.py", line 766, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-2018-12-24/apps/erpnext/erpnext/hr/doctype/salary_slip/salary_slip.py", line 287, in process_salary_structure
    self.get_leave_details()
  File "/home/frappe/benches/bench-2018-12-24/apps/erpnext/erpnext/hr/doctype/salary_slip/salary_slip.py", line 315, in get_leave_details
    ["date_of_joining", "relieving_date"])
TypeError: 'NoneType' object is not iterable
```
