### PR TITLE
fix: fallback to stock uom if uom is not defined

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -281,7 +281,7 @@ def get_basic_details(args, item):
 		out.conversion_factor = 1.0
 	else:
 		out.conversion_factor = args.conversion_factor or \
-			get_conversion_factor(item.item_code, args.uom).get("conversion_factor") or 1.0
+			get_conversion_factor(item.item_code, args.uom).get("conversion_factor")
 
 	args.conversion_factor = out.conversion_factor
 	out.stock_qty = out.qty * out.conversion_factor

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -651,7 +651,7 @@ def get_conversion_factor(item_code, uom):
 	if not conversion_factor:
 		stock_uom = frappe.db.get_value("Item", item_code, "stock_uom")
 		conversion_factor = get_uom_conv_factor(uom, stock_uom)
-	return {"conversion_factor": conversion_factor}
+	return {"conversion_factor": conversion_factor or 1.0}
 
 @frappe.whitelist()
 def get_projected_qty(item_code, warehouse):


### PR DESCRIPTION
**Issue**

If UOM is not added then getting below error
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2018-11-15/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2018-11-15/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2018-11-15/apps/frappe/frappe/handler.py", line 53, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2018-11-15/apps/frappe/frappe/__init__.py", line 939, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2018-11-15/apps/erpnext/erpnext/stock/get_item_details.py", line 44, in get_item_details
    out = get_basic_details(args, item)
  File "/home/frappe/benches/bench-2018-11-15/apps/erpnext/erpnext/stock/get_item_details.py", line 261, in get_basic_details
    out.stock_qty = out.qty * out.conversion_factor
TypeError: can't multiply sequence by non-int of type 'float'
```