### PR TITLE
fix: Sales Analytics Period Range

### DIFF
--- a/erpnext/selling/report/sales_analytics/sales_analytics.py
+++ b/erpnext/selling/report/sales_analytics/sales_analytics.py
@@ -40,7 +40,7 @@ class Analytics(object):
 				"fieldtype": "Data",
 				"width": 140
 			})
-		for dummy, end_date in self.periodic_daterange:
+		for end_date in self.periodic_daterange:
 			period = self.get_period(end_date)
 			self.columns.append({
 				"label": _(period),
@@ -169,7 +169,7 @@ class Analytics(object):
 				"entity_name": self.entity_names.get(entity)
 			}
 			total = 0
-			for dummy, end_date in self.periodic_daterange:
+			for end_date in self.periodic_daterange:
 				period = self.get_period(end_date)
 				amount = flt(period_data.get(period, 0.0))
 				row[scrub(period)] = amount
@@ -188,7 +188,7 @@ class Analytics(object):
 				"indent": self.depth_map.get(d.name)
 			}
 			total = 0
-			for dummy, end_date in self.periodic_daterange:
+			for end_date in self.periodic_daterange:
 				period = self.get_period(end_date)
 				amount = flt(self.entity_periodic_data.get(d.name, {}).get(period, 0.0))
 				row[scrub(period)] = amount
@@ -243,8 +243,8 @@ class Analytics(object):
 
 			if period_end_date > to_date:
 				period_end_date = to_date
-			self.periodic_daterange.append([from_date, period_end_date])
 
+			self.periodic_daterange.append(period_end_date)
 			from_date = period_end_date + relativedelta(days=1)
 			if period_end_date == to_date:
 				break

--- a/erpnext/selling/report/sales_analytics/sales_analytics.py
+++ b/erpnext/selling/report/sales_analytics/sales_analytics.py
@@ -4,7 +4,7 @@
 from __future__ import unicode_literals
 import frappe
 from frappe import _, scrub
-from frappe.utils import getdate, flt
+from frappe.utils import getdate, flt, add_to_date, add_days
 from six import iteritems
 from erpnext.accounts.utils import get_fiscal_year
 
@@ -219,12 +219,11 @@ class Analytics(object):
 			period = "Quarter " + str(((posting_date.month-1)//3)+1) +" " + str(posting_date.year)
 		else:
 			year = get_fiscal_year(posting_date, company=self.filters.company)
-			period = str(year[2])
-
+			period = str(year[0])
 		return period
 
 	def get_period_date_ranges(self):
-		from dateutil.relativedelta import relativedelta
+		from dateutil.relativedelta import relativedelta, MO
 		from_date, to_date = getdate(self.filters.from_date), getdate(self.filters.to_date)
 
 		increment = {
@@ -234,18 +233,26 @@ class Analytics(object):
 			"Yearly": 12
 		}.get(self.filters.range, 1)
 
+		if self.filters.range in ['Monthly', 'Quarterly']:
+			from_date = from_date.replace(day = 1)
+		elif self.filters.range == "Yearly":
+			from_date = get_fiscal_year(from_date)[1]
+		else:
+			from_date = from_date + relativedelta(from_date, weekday=MO(-1))
+
 		self.periodic_daterange = []
 		for dummy in range(1, 53):
 			if self.filters.range == "Weekly":
-				period_end_date = from_date + relativedelta(days=6)
+				period_end_date = add_days(from_date, 6)
 			else:
-				period_end_date = from_date + relativedelta(months=increment, days=-1)
+				period_end_date = add_to_date(from_date, months=increment, days=-1)
 
 			if period_end_date > to_date:
 				period_end_date = to_date
 
 			self.periodic_daterange.append(period_end_date)
-			from_date = period_end_date + relativedelta(days=1)
+
+			from_date = add_days(period_end_date, 1)
 			if period_end_date == to_date:
 				break
 

--- a/erpnext/selling/report/sales_analytics/sales_analytics.py
+++ b/erpnext/selling/report/sales_analytics/sales_analytics.py
@@ -235,7 +235,7 @@ class Analytics(object):
 		}.get(self.filters.range, 1)
 
 		self.periodic_daterange = []
-		for dummy in range(1, 53, increment):
+		for dummy in range(1, 53):
 			if self.filters.range == "Weekly":
 				period_end_date = from_date + relativedelta(days=6)
 			else:


### PR DESCRIPTION
- Sales Analytics bugs fixing
     - Multiple year records not displayed 
     - Improper display of monthly record for certain edge cases
     - Removed ambiguity in the code refactored it
     - Duplicate records for different dates
     - Incorrect week number for certain date ranges
- Initially displayed only a maximum of 5 years at any given time
![screenshot 2019-01-05 at 12 02 26 am](https://user-images.githubusercontent.com/14824451/50704431-5e444680-107d-11e9-8972-9a90578c378d.png)
- It will now display as many years as the user wants to view, also, refactored the column headings to represent proper fiscal year
![screenshot 2019-01-04 at 8 50 16 pm](https://user-images.githubusercontent.com/14824451/50703366-d90b6280-1079-11e9-856c-a9aec7d59712.png)

- Incorrect week number in weekly report filter.( e.g. It should be iso week 13 based on the date but it is displayed as week 14)  
![screenshot 2019-01-05 at 12 00 48 am](https://user-images.githubusercontent.com/14824451/50820533-f29afb80-1352-11e9-91ce-9c1630c6811c.png)
- Fixed view
![screenshot 2019-01-04 at 11 49 55 pm](https://user-images.githubusercontent.com/14824451/50704615-022df200-107e-11e9-88a3-b30632e4911a.png)

- Improper monthly records view
![screenshot 2019-01-04 at 11 40 34 pm](https://user-images.githubusercontent.com/14824451/50703914-a2cee280-107b-11e9-8136-23390492b5c1.png)
- Fixed view
![screenshot 2019-01-04 at 11 48 53 pm](https://user-images.githubusercontent.com/14824451/50703903-95195d00-107b-11e9-8b68-6eca91914150.png)





