### PR TITLE
fix: replaced str to cstr in genral ledger report

### DIFF
--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -25,7 +25,7 @@ def execute(filters=None):
 		account_details.setdefault(acc.name, acc)
 
 	if filters.get('party'):
-		parties = str(filters.get("party")).strip()
+		parties = cstr(filters.get("party")).strip()
 		filters.party = [d.strip() for d in parties.split(',') if d]
 
 	validate_filters(filters, account_details)
@@ -60,11 +60,11 @@ def validate_filters(filters, account_details):
 		frappe.throw(_("From Date must be before To Date"))
 
 	if filters.get('project'):
-		projects = str(filters.get("project")).strip()
+		projects = cstr(filters.get("project")).strip()
 		filters.project = [d.strip() for d in projects.split(',') if d]
 
 	if filters.get('cost_center'):
-		cost_centers = str(filters.get("cost_center")).strip()
+		cost_centers = cstr(filters.get("cost_center")).strip()
 		filters.cost_center = [d.strip() for d in cost_centers.split(',') if d]
 
 


### PR DESCRIPTION
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2018-12-24/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2018-12-24/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2018-12-24/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2018-12-24/apps/frappe/frappe/__init__.py", line 1007, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2018-12-24/apps/frappe/frappe/__init__.py", line 489, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "/home/frappe/benches/bench-2018-12-24/apps/frappe/frappe/desk/query_report.py", line 179, in run
    result = generate_report_result(report, filters, user)
  File "/home/frappe/benches/bench-2018-12-24/apps/frappe/frappe/desk/query_report.py", line 66, in generate_report_result
    res = frappe.get_attr(method_name)(frappe._dict(filters))
  File "/home/frappe/benches/bench-2018-12-24/apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py", line 28, in execute
    parties = str(filters.get("party")).strip()
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-3: ordinal not in range(128)