### PR TITLE
feat: Web view for Customer Provided Items for Customers

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -140,6 +140,7 @@ website_route_rules = [
 			"parents": [{"label": _("Material Request"), "route": "material-requests"}]
 		}
 	},
+	{"from_route": "/customer-provided-items", "to_route": "customer_provided_item"}
 ]
 
 standard_portal_menu_items = [
@@ -163,6 +164,7 @@ standard_portal_menu_items = [
 	{"title": _("Admission"), "route": "/admissions", "reference_doctype": "Student Admission"},
 	{"title": _("Certification"), "route": "/certification", "reference_doctype": "Certification Application"},
 	{"title": _("Material Request"), "route": "/material-requests", "reference_doctype": "Material Request", "role": "Customer"},
+	{"title": _("Customer Provided Item"), "route": "/customer-provided-items", "reference_doctype": "Item", "role": "Customer"}
 ]
 
 default_roles = [

--- a/erpnext/templates/pages/customer_provided_item.html
+++ b/erpnext/templates/pages/customer_provided_item.html
@@ -1,0 +1,42 @@
+{% extends "templates/web.html" %}
+{% from "erpnext/templates/includes/order/order_macros.html" import item_name_and_description %}
+
+{% block title %} {{ title }} {% endblock %}
+
+{% block header %}<h2>{{ title }}</h2>{% endblock %}
+
+{% block page_content %}
+<div class="items-content">
+	<div class="row order-items order-item-header text-muted">
+		<div class="col-sm-5 col-xs-5 h6 text-uppercase">
+			{{ _("Item") }}
+		</div>
+		<div class="col-sm-2 col-xs-2 text-right h6 text-uppercase">
+			{{ _("Stock Qty") }}
+		</div>
+		<div class="col-sm-3 col-xs-3 text-right h6 text-uppercase">
+			{{ _("Required Qty") }}
+		</div>
+		<div class="col-sm-2 col-xs-2 text-right h6 text-uppercase">
+			{{ _("Balance") }}
+		</div>
+	</div>
+	{% for item_info in items %}
+	<div class="row order-items">
+		<div class="col-sm-5 col-xs-5">
+			{{ item_name_and_description(item_info) }}
+		</div>
+		<div class="col-sm-2 col-xs-2 text-right">
+			{{ item_info.stock_qty }}
+		</div>
+		<div class="col-sm-3 col-xs-3 text-right">
+			{{ item_info.reqd_qty }}
+		</div>
+		<div class="col-sm-2 col-xs-2 text-right">
+			{{ item_info.bal_qty }}
+		</div>
+	</div>
+	<hr>
+	{% endfor %}
+</div>
+{% endblock %}

--- a/erpnext/templates/pages/customer_provided_item.py
+++ b/erpnext/templates/pages/customer_provided_item.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
+# License: GNU General Public License v3. See license.txt
+
+from __future__ import unicode_literals
+import frappe
+import frappe.website.render
+from frappe.utils import flt
+from frappe import _
+from erpnext.controllers.website_list_for_contact import get_customers_suppliers
+
+page_title = "Customer Provided Items"
+
+def get_context(context):
+	customer = get_customers_suppliers("Item", frappe.session.user)
+
+	if not customer[0]:
+		frappe.throw(_("Not Permitted"), frappe.PermissionError)
+
+	items = frappe.db.sql("""select * from `tabItem`
+			where is_customer_provided_item=%s and customer = '%s' order by name asc"""%('1', customer[0][0]), as_dict=True)
+
+	for item in items:
+		item.stock_qty = flt(frappe.db.sql("""
+				select sum(actual_qty) from `tabStock Ledger Entry`
+							where item_code = '%s' and docstatus = %s"""%(item.item_code, '1'))[0][0])
+		item.reqd_qty = flt(frappe.db.sql("""
+			SELECT SUM(GREATEST(woi.required_qty - woi.consumed_qty,0)) AS reqd_qty
+			FROM `tabWork Order Item` woi
+			LEFT OUTER JOIN `tabWork Order` wo ON wo.name = woi.parent
+			WHERE woi.item_code = '%s' and wo.docstatus < 2
+				  and wo.status !='%s'"""%(item.item_code, 'Completed'))[0][0])
+		item.bal_qty = item.stock_qty - item.reqd_qty
+
+	return {
+		"items": items,
+		"title": page_title
+	}


### PR DESCRIPTION
Since Customers do not have access to the stock. It is really helpful for them to check what all items provided by them are with us and what all is required. This has been requested by our customer time and again. Making it a core contribution so that others can use it too.

<img width="735" alt="screen shot 2019-01-08 at 2 43 15 pm" src="https://user-images.githubusercontent.com/16913064/50821348-fcbdf980-1354-11e9-9710-339f20bad69c.png">
Created a simple web view which shows the Quantity, Req Quantity and Balance. 
<img width="1081" alt="screen shot 2019-01-08 at 3 39 44 pm" src="https://user-images.githubusercontent.com/16913064/50824119-b28c4680-135b-11e9-90ef-8793fba8f94a.png">

Customer can view only the items provided by them.
<img width="698" alt="screen shot 2019-01-08 at 2 43 01 pm" src="https://user-images.githubusercontent.com/16913064/50821366-06dff800-1355-11e9-91f6-8888d5b87891.png">
