### PR TITLE
fix(exchange rate revaluation): get entries failed if accounts of currency other than company currency not available

### DIFF
--- a/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.js
+++ b/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.js
@@ -39,6 +39,8 @@ frappe.ui.form.on('Exchange Rate Revaluation', {
 					});
 					frm.events.get_total_gain_loss(frm);
 					refresh_field("accounts");
+				} else {
+					frappe.msgprint(__("No records found"));
 				}
 			}
 		});

--- a/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py
+++ b/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py
@@ -67,17 +67,19 @@ class ExchangeRateRevaluation(Document):
 				and account_currency != %s
 			order by name""",(self.company, company_currency))
 
-		account_details = frappe.db.sql("""
-			select 
-				account, party_type, party, account_currency,
-				sum(debit_in_account_currency) - sum(credit_in_account_currency) as balance_in_account_currency,
-				sum(debit) - sum(credit) as balance
-			from `tabGL Entry`
-			where account in (%s)
-			group by account, party_type, party
-			having sum(debit) != sum(credit)
-			order by account
-		""" % ', '.join(['%s']*len(accounts)), tuple(accounts), as_dict=1)
+		account_details = []
+		if accounts:
+			account_details = frappe.db.sql("""
+				select
+					account, party_type, party, account_currency,
+					sum(debit_in_account_currency) - sum(credit_in_account_currency) as balance_in_account_currency,
+					sum(debit) - sum(credit) as balance
+				from `tabGL Entry`
+				where account in (%s)
+				group by account, party_type, party
+				having sum(debit) != sum(credit)
+				order by account
+			""" % ', '.join(['%s']*len(accounts)), tuple(accounts), as_dict=1)
 
 		return account_details
 


### PR DESCRIPTION
**Issue**

```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1013, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 84, in runserverobj
    frappe.desk.form.run_method.runserverobj(method, docs=docs, dt=dt, dn=dn, arg=arg, args=args)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/form/run_method.py", line 39, in runserverobj
    r = doc.run_method(method, args)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 772, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1048, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1031, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 766, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py", line 36, in get_accounts_data
    for d in self.get_accounts_from_gle():
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py", line 81, in get_accounts_from_gle
    """ % ', '.join(['%s']*len(accounts)), tuple(accounts), as_dict=1)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database.py", line 210, in sql
    self._cursor.execute(query)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/pymysql/cursors.py", line 170, in execute
    result = self._query(query)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/pymysql/cursors.py", line 328, in _query
    conn.query(q)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/pymysql/connections.py", line 516, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/pymysql/connections.py", line 727, in _read_query_result
    result.read()
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/pymysql/connections.py", line 1066, in read
    first_packet = self.connection._read_packet()
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/pymysql/connections.py", line 683, in _read_packet
    packet.check_error()
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/pymysql/protocol.py", line 220, in check_error
    err.raise_mysql_exception(self._data)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
    raise errorclass(errno, errval)
ProgrammingError: (1064, u"You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ')\n\t\t\tgroup by account, party_type, party\n\t\t\thaving sum(debit) != sum(credit)\n\t\t\t' at line 6")
```