### PR TITLE
fix: Quotation to Sales Order with different currency

### DIFF
--- a/erpnext/selling/doctype/quotation/test_quotation.py
+++ b/erpnext/selling/doctype/quotation/test_quotation.py
@@ -31,6 +31,26 @@ class TestQuotation(unittest.TestCase):
 
 		self.assertFalse(sales_order.get('payment_schedule'))
 
+	def test_make_sales_order_with_different_currency(self):
+		from erpnext.selling.doctype.quotation.quotation import make_sales_order
+
+		quotation = frappe.copy_doc(test_records[0])
+		quotation.transaction_date = nowdate()
+		quotation.valid_till = add_months(quotation.transaction_date, 1)
+		quotation.insert()
+		quotation.submit()
+
+		sales_order = make_sales_order(quotation.name)
+		sales_order.currency = "USD"
+		sales_order.conversion_rate = 20.0
+		sales_order.delivery_date = "2019-01-01"
+		sales_order.naming_series = "_T-Quotation-"
+		sales_order.transaction_date = nowdate()
+		sales_order.insert()
+
+		self.assertEquals(sales_order.currency, "USD")
+		self.assertNotEqual(sales_order.currency, quotation.currency)
+
 	def test_make_sales_order(self):
 		from erpnext.selling.doctype.quotation.quotation import make_sales_order
 

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -141,7 +141,7 @@ class SalesOrder(SellingController):
 		super(SalesOrder, self).validate_with_previous_doc({
 			"Quotation": {
 				"ref_dn_field": "prevdoc_docname",
-				"compare_fields": [["company", "="], ["currency", "="]]
+				"compare_fields": [["company", "="]]
 			}
 		})
 


### PR DESCRIPTION
This small fix allows the user to create Quotations in a specific currency and, from them, create Sales Orders with a different currency, being able to track the Quotations.

For example: You can create a quotation with a price list in USD and then create a Sales Order for that quotation in ARS.

This use case is very common in countries with a high inflation rate where you make the quotations in USD but you receive the money in your country currency (CC). We do this because if we make them in our CC, tomorrow, when we make the Sales Order we are going to lose money because our CC has less value than before.