### PR TITLE
fix: Show stock validation message while placing order and Quotation series field fix in shopping cart settings. 

### DIFF
--- a/erpnext/shopping_cart/cart.py
+++ b/erpnext/shopping_cart/cart.py
@@ -66,7 +66,7 @@ def place_order():
 	sales_order = frappe.get_doc(_make_sales_order(quotation.name, ignore_permissions=True))
 	for item in sales_order.get("items"):
 		item.reserved_warehouse, is_stock_item = frappe.db.get_value("Item",
-			item.item_code, ["website_warehouse", "is_stock_item"]) or None, None
+			item.item_code, ["website_warehouse", "is_stock_item"])
 
 		if is_stock_item:
 			item_stock = get_qty_in_stock(item.item_code, "website_warehouse")

--- a/erpnext/shopping_cart/doctype/shopping_cart_settings/shopping_cart_settings.js
+++ b/erpnext/shopping_cart/doctype/shopping_cart_settings/shopping_cart_settings.js
@@ -5,6 +5,7 @@ $.extend(cur_frm.cscript, {
 	onload: function() {
 		if(cur_frm.doc.__onload && cur_frm.doc.__onload.quotation_series) {
 			cur_frm.fields_dict.quotation_series.df.options = cur_frm.doc.__onload.quotation_series;
+			cur_frm.refresh_field("quotation_series");
 		}
 	},
 	refresh: function(){


### PR DESCRIPTION
Couple of bugfixes. 
1. Show message when quantity of item in order placed is greater than stock available in website warehouse.
![cart-message-pullreq-fix](https://user-images.githubusercontent.com/20857931/51301577-c61f6780-1a55-11e9-9adb-8a6021ff436b.png)

2. Show quotation series in shopping cart settings doctype. 
Before fix:  
![cart-pullreq](https://user-images.githubusercontent.com/20857931/51301633-e818ea00-1a55-11e9-84eb-a6dc5a1d1e47.png)
After fix: 
![cart-pullreq-fix](https://user-images.githubusercontent.com/20857931/51301635-e94a1700-1a55-11e9-8d23-c68835d5f045.png)
