### PR TITLE
fix: Code cleanup

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/pos.py
+++ b/erpnext/accounts/doctype/sales_invoice/pos.py
@@ -250,10 +250,12 @@ def get_serial_no_data(pos_profile, company):
 
 	cond = "1=1"
 	if pos_profile.get('update_stock') and pos_profile.get('warehouse'):
-		cond = "warehouse = '{0}'".format(pos_profile.get('warehouse'))
+		cond = "warehouse = %(warehouse)s"
 
-	serial_nos = frappe.db.sql("""select name, warehouse, item_code from `tabSerial No` where {0}
-				and company = %(company)s """.format(cond), {'company': company}, as_dict=1)
+	serial_nos = frappe.db.sql("""select name, warehouse, item_code
+		from `tabSerial No` where {0} and company = %(company)s """.format(cond),{
+			'company': company, 'warehouse': frappe.db.escape(pos_profile.get('warehouse'))
+		}, as_dict=1)
 
 	itemwise_serial_no = {}
 	for sn in serial_nos:


### PR DESCRIPTION
**Issue**

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2019-01-09/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2019-01-09/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2019-01-09/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2019-01-09/apps/frappe/frappe/__init__.py", line 1013, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2019-01-09/apps/erpnext/erpnext/accounts/doctype/sales_invoice/pos.py", line 53, in get_pos_data
    'serial_no_data': get_serial_no_data(pos_profile, doc.company),
  File "/home/frappe/benches/bench-2019-01-09/apps/erpnext/erpnext/accounts/doctype/sales_invoice/pos.py", line 253, in get_serial_no_data
    cond = "warehouse = '{0}'".format(pos_profile.get('warehouse'))
UnicodeEncodeError: 'ascii' codec can't encode character u'\xed' in position 8: ordinal not in range(128)
```