### PR TITLE
fix: NoneType object has no attribute "gstin"

### DIFF
--- a/erpnext/regional/india/utils.py
+++ b/erpnext/regional/india/utils.py
@@ -5,10 +5,10 @@ from erpnext.regional.india import states, state_numbers
 from erpnext.controllers.taxes_and_totals import get_itemised_tax, get_itemised_taxable_amount
 
 def validate_gstin_for_india(doc, method):
-	if not hasattr(doc, 'gstin'):
+	if not hasattr(doc, 'gstin') or not doc.gstin:
 		return
 
-	doc.gstin = doc.get('gstin','').upper().strip()
+	doc.gstin = doc.gstin.upper().strip()
 	if not doc.gstin or doc.gstin == 'NA':
 		return
 

--- a/erpnext/regional/india/utils.py
+++ b/erpnext/regional/india/utils.py
@@ -8,7 +8,7 @@ def validate_gstin_for_india(doc, method):
 	if not hasattr(doc, 'gstin'):
 		return
 
-	doc.gstin = doc.gstin.upper().strip()
+	doc.gstin = doc.get('gstin','').upper().strip()
 	if not doc.gstin or doc.gstin == 'NA':
 		return
 


### PR DESCRIPTION
In the latest update, if no Party GSTIN is provided, then it throws the following error:-

![screenshot 10](https://user-images.githubusercontent.com/18363620/51538202-b600f100-1e76-11e9-9407-acbcf03f0161.png)

So, we have fixed this error by using `get` method.