### PR TITLE
fix: Don't use .format in jinja templates

### DIFF
--- a/erpnext/templates/includes/cart/cart_items.html
+++ b/erpnext/templates/includes/cart/cart_items.html
@@ -21,12 +21,11 @@
                         +</button>
                 </span>
 			</div>
-		</span>    	
+		</span>
 	</div>
     <div class="col-sm-2 col-xs-3 text-right col-amount">
         {{ d.get_formatted("amount") }}
-        <p class="text-muted small item-rate">{{
-            _("Rate: {0}").format(d.get_formatted("rate")) }}</p>
+        <p class="text-muted small item-rate">{{ _("Rate") }}&nbsp;{{ d.get_formatted("rate") }}</p>
     </div>
 </div>
 {% endfor %}

--- a/erpnext/templates/pages/order.html
+++ b/erpnext/templates/pages/order.html
@@ -73,14 +73,12 @@
 			<div class="col-sm-3 col-xs-3 text-right">
 				{{ d.qty }}
 				{% if d.delivered_qty is defined and d.delivered_qty != None %}
-				<p class="text-muted small">{{
-					_("Delivered: {0}").format(d.delivered_qty) }}</p>
+				<p class="text-muted small">{{ _("Delivered") }}&nbsp;{{ d.delivered_qty }}</p>
 				{% endif %}
 			</div>
 			<div class="col-sm-3 col-xs-3 text-right">
 				{{ d.get_formatted("amount")	 }}
-				<p class="text-muted small">{{
-					_("@ {0}").format(d.get_formatted("rate")) }}</p>
+				<p class="text-muted small">{{ _("Rate:") }}&nbsp;{{ d.get_formatted("rate") }}</p>
 			</div>
 		</div>
 		{% endfor %}


### PR DESCRIPTION
- Jinja doesn't allow unicode strings to be formatted in templates

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2019-01-23-a/apps/frappe/frappe/website/render.py", line 45, in render
    data = render_page_by_language(path)
  File "/home/frappe/benches/bench-2019-01-23-a/apps/frappe/frappe/website/render.py", line 142, in render_page_by_language
    return render_page(path)
  File "/home/frappe/benches/bench-2019-01-23-a/apps/frappe/frappe/website/render.py", line 158, in render_page
    return build(path)
  File "/home/frappe/benches/bench-2019-01-23-a/apps/frappe/frappe/website/render.py", line 165, in build
    return build_page(path)
  File "/home/frappe/benches/bench-2019-01-23-a/apps/frappe/frappe/website/render.py", line 181, in build_page
    html = frappe.render_template(context.source, context)
  File "/home/frappe/benches/bench-2019-01-23-a/apps/frappe/frappe/utils/jinja.py", line 75, in render_template
    return get_jenv().from_string(template).render(context)
  File "/home/frappe/benches/bench-2019-01-23-a/env/lib/python2.7/site-packages/jinja2/environment.py", line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "/home/frappe/benches/bench-2019-01-23-a/env/lib/python2.7/site-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "<template>", line 1, in top-level template code
  File "/home/frappe/benches/bench-2019-01-23-a/apps/frappe/frappe/./templates/web.html", line 6, in top-level template code
    {%- if page_or_generator=="Generator" %}source-type="Generator" data-doctype="{{ doctype }}"{% endif %}
  File "/home/frappe/benches/bench-2019-01-23-a/apps/frappe/frappe/./templates/base.html", line 37, in top-level template code
    {% block body %}
  File "/home/frappe/benches/bench-2019-01-23-a/apps/frappe/frappe/./templates/base.html", line 63, in block "body"
    {% block content %}{% endblock %}
  File "/home/frappe/benches/bench-2019-01-23-a/apps/frappe/frappe/./templates/web.html", line 49, in block "content"
    {%- block page_content -%}{%- endblock -%}
  File "<template>", line 42, in block "page_content"
  File "/home/frappe/benches/bench-2019-01-23-a/apps/erpnext/erpnext/./templates/includes/cart/cart_items.html", line 29, in top-level template code
    _("Rate: {0}").format(d.get_formatted("rate")) }}</p>
UnicodeEncodeError: 'ascii' codec can't encode character u'\u20b9' in position 0: ordinal not in range(128)
```