### PR TITLE
fix: Incorrect argument name in frappe.call

### DIFF
--- a/erpnext/accounts/doctype/cost_center/cost_center.js
+++ b/erpnext/accounts/doctype/cost_center/cost_center.js
@@ -46,7 +46,7 @@ frappe.ui.form.on('Cost Center', {
 						doctype_name: frm.doc.doctype,
 						name: frm.doc.name,
 						field_name: d.fields[0].fieldname,
-						field_value: data.cost_center_number,
+						number_value: data.cost_center_number,
 						company: frm.doc.company
 					},
 					callback: function(r) {


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2019-01-23-a/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2019-01-23-a/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2019-01-23-a/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2019-01-23-a/apps/frappe/frappe/__init__.py", line 1013, in call
    return fn(*args, **newargs)
TypeError: update_number_field() takes exactly 5 arguments (4 given)
```