### PR TITLE
fix(Stock Entry): "Select Serial Numbers" dialog won't fill mandatory field

### DIFF
--- a/erpnext/public/js/utils/serial_no_batch_selector.js
+++ b/erpnext/public/js/utils/serial_no_batch_selector.js
@@ -208,6 +208,7 @@ erpnext.SerialNoBatchSelector = Class.extend({
 
 	map_row_values: function(row, values, number, qty_field, warehouse) {
 		row.qty = values[qty_field];
+		row.transfer_qty = flt(values[qty_field]) * flt(row.conversion_factor);
 		row[number] = values[number];
 		if(this.warehouse_details.type === 'Source Warehouse') {
 			row.s_warehouse = values.warehouse || warehouse;


### PR DESCRIPTION
Will solve this issue https://github.com/frappe/erpnext/issues/16481

In `Stock Entry` DocType

`"Select Serial Numbers" Dialog` which will pop-up if item has serial_no.

It will cause Error when tried to submit.

```
Mandatory fields required in table Items, Row 1
   - Qty as per Stock UOM
```

Because dialog didn't calculate "Qty as per Stock UOM" (transfer_qty) field, which is mandatory field.

This pull request will fill transfer_qty field by made calculation form 
`row.transfer_qty = values[qty_field] * row.conversion_factor`

![after](https://user-images.githubusercontent.com/24489363/51663668-f5038380-1fe9-11e9-9def-fe83d95f6c3b.gif)
