### PR TITLE
chore: Add error logging for failed get_exchange_rate call

### DIFF
--- a/erpnext/setup/utils.py
+++ b/erpnext/setup/utils.py
@@ -109,6 +109,7 @@ def get_exchange_rate(from_currency, to_currency, transaction_date=None, args=No
 			cache.setex(key, value, 6 * 60 * 60)
 		return flt(value)
 	except:
+		frappe.log_error(title="Get Exchange Rate")
 		frappe.msgprint(_("Unable to find exchange rate for {0} to {1} for key date {2}. Please create a Currency Exchange record manually").format(from_currency, to_currency, transaction_date))
 		return 0.0
 


### PR DESCRIPTION
`get_exchange_rate` fails sometimes and the error is captured in an innocent `except:` block. Adding the exception to Error Log will help in fixing it.