### PR TITLE
fix(ar-summary): Changes to column list to match recent changes

### DIFF
--- a/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py
+++ b/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py
@@ -190,7 +190,7 @@ class AccountsReceivableSummary(ReceivablePayableReport):
 	def get_voucherwise_data(self, party_naming_by, args):
 		voucherwise_data = ReceivablePayableReport(self.filters).run(args)[1]
 
-		cols = ["posting_date", "party", "customer-contact"]
+		cols = ["posting_date", "party"]
 
 		if party_naming_by == "Naming Series":
 			cols += ["party_name"]


### PR DESCRIPTION
PR https://github.com/frappe/erpnext/pull/16447 is useless after https://github.com/frappe/erpnext/pull/16406. Reverting.

Before
![screenshot 2019-01-24 at 7 16 30 pm](https://user-images.githubusercontent.com/8528887/51682196-cfd43c80-200c-11e9-8eaa-1e555d32337d.png)

After
![screenshot 2019-01-24 at 7 15 25 pm](https://user-images.githubusercontent.com/8528887/51682192-cc40b580-200c-11e9-90db-3026bcdca6e1.png)