### PR TITLE
fix: ascii codec while opening offline POS

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/pos.py
+++ b/erpnext/accounts/doctype/sales_invoice/pos.py
@@ -333,10 +333,12 @@ def get_bin_data(pos_profile):
 	itemwise_bin_data = {}
 	cond = "1=1"
 	if pos_profile.get('warehouse'):
-		cond = "warehouse = '{0}'".format(pos_profile.get('warehouse'))
+		cond = "warehouse = %(warehouse)s"
 
 	bin_data = frappe.db.sql(""" select item_code, warehouse, actual_qty from `tabBin`
-		where actual_qty > 0 and {cond}""".format(cond=cond), as_dict=1)
+		where actual_qty > 0 and {cond}""".format(cond=cond), {
+			'warehouse': frappe.db.escape(pos_profile.get('warehouse'))
+		}, as_dict=1)
 
 	for bins in bin_data:
 		if bins.item_code not in itemwise_bin_data:


### PR DESCRIPTION
**Issue**

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2019-01-23/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2019-01-23/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2019-01-23/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2019-01-23/apps/frappe/frappe/__init__.py", line 1013, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2019-01-23/apps/erpnext/erpnext/accounts/doctype/sales_invoice/pos.py", line 58, in get_pos_data
    'bin_data': get_bin_data(pos_profile),
  File "/home/frappe/benches/bench-2019-01-23/apps/erpnext/erpnext/accounts/doctype/sales_invoice/pos.py", line 336, in get_bin_data
    cond = "warehouse = '{0}'".format(pos_profile.get('warehouse'))
UnicodeEncodeError: 'ascii' codec can't encode character u'\xed' in position 20: ordinal not in range(128)
```