### PR TITLE
fix: bank reconcilliation showing multiple entries against one JV

### DIFF
--- a/erpnext/accounts/doctype/bank_reconciliation/bank_reconciliation.py
+++ b/erpnext/accounts/doctype/bank_reconciliation/bank_reconciliation.py
@@ -26,7 +26,7 @@ class BankReconciliation(Document):
 			select 
 				"Journal Entry" as payment_document, t1.name as payment_entry, 
 				t1.cheque_no as cheque_number, t1.cheque_date, 
-				t2.debit_in_account_currency as debit, t2.credit_in_account_currency as credit, 
+				sum(t2.debit_in_account_currency) as debit, sum(t2.credit_in_account_currency) as credit,
 				t1.posting_date, t2.against_account, t1.clearance_date, t2.account_currency 
 			from
 				`tabJournal Entry` t1, `tabJournal Entry Account` t2
@@ -34,6 +34,7 @@ class BankReconciliation(Document):
 				t2.parent = t1.name and t2.account = %s and t1.docstatus=1
 				and t1.posting_date >= %s and t1.posting_date <= %s 
 				and ifnull(t1.is_opening, 'No') = 'No' {0}
+			group by t2.account, t1.name
 			order by t1.posting_date ASC, t1.name DESC
 		""".format(condition), (self.bank_account, self.from_date, self.to_date), as_dict=1)
 


### PR DESCRIPTION
**Issue**

Created JV in which selected bank account 3 times which is as follows

![image](https://user-images.githubusercontent.com/8780500/51701528-a381e580-2037-11e9-890d-297620e3ed2f.png)

In bank reconciliation 3 records showing against one JV

![image](https://user-images.githubusercontent.com/8780500/51701593-c613fe80-2037-11e9-8fad-64fb61e14dbf.png)


**After Fix** 
![image](https://user-images.githubusercontent.com/8780500/51701616-d88e3800-2037-11e9-8df0-7525a4acc3cc.png)
