### PR TITLE
feat: Sync Chart of Accounts in Company hierarchy

### DIFF
--- a/erpnext/accounts/doctype/account/account.py
+++ b/erpnext/accounts/doctype/account/account.py
@@ -116,6 +116,8 @@ class Account(NestedSet):
 				doc.update({"company": company, "account_currency": None,
 					"parent": acc_name_map[company], "parent_account": acc_name_map[company]})
 				doc.save()
+				frappe.msgprint(_("Account {0} is added in the child company {1}")
+					.format(doc.name, company))
 
 	def validate_group_or_ledger(self):
 		if self.get("__islocal"):

--- a/erpnext/accounts/doctype/account/account.py
+++ b/erpnext/accounts/doctype/account/account.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 import frappe
 from frappe.utils import cint, cstr
 from frappe import throw, _
-from frappe.utils.nestedset import NestedSet
+from frappe.utils.nestedset import NestedSet, get_ancestors_of, get_descendants_of
 
 class RootNotEditable(frappe.ValidationError): pass
 class BalanceMismatchError(frappe.ValidationError): pass
@@ -34,7 +34,6 @@ class Account(NestedSet):
 			return
 		self.validate_parent()
 		self.validate_root_details()
-		self.validate_root_company()
 		validate_field_number("Account", self.name, self.account_number, self.company, "account_number")
 		self.validate_group_or_ledger()
 		self.set_root_and_report_type()
@@ -42,6 +41,7 @@ class Account(NestedSet):
 		self.validate_frozen_accounts_modifier()
 		self.validate_balance_must_be_debit_or_credit()
 		self.validate_account_currency()
+		self.validate_root_company_and_sync_account_to_children()
 
 	def validate_parent(self):
 		"""Fetch Parent Details and validate parent account"""
@@ -91,12 +91,30 @@ class Account(NestedSet):
 		if not self.parent_account and not self.is_group:
 			frappe.throw(_("Root Account must be a group"))
 
-	def validate_root_company(self):
-		# fetch all ancestors in top-down hierarchy
-		if frappe.local.flags.ignore_root_company_validation: return
+	def validate_root_company_and_sync_account_to_children(self):
+		# ignore validation while creating new compnay or while syncing to child companies
+		if frappe.local.flags.ignore_root_company_validation or self.flags.ignore_root_company_validation:
+			return
+
 		ancestors = get_root_company(self.company)
 		if ancestors:
 			frappe.throw(_("Please add the account to root level Company - %s" % ancestors[0]))
+		else:
+			descendants = get_descendants_of('Company', self.company)
+			acc_name = frappe.db.get_value('Account', self.parent_account, "account_name")
+
+			acc_name_map = {}
+			for d in frappe.db.get_values('Account',
+				{"company": ["in", descendants], "account_name": acc_name},
+				["company", "name"], as_dict=True):
+				acc_name_map[d["company"]] = d["name"]
+
+			for company in descendants:
+				doc = frappe.copy_doc(self)
+				doc.flags.ignore_root_company_validation = True
+				doc.update({"company": company, "account_currency": None,
+					"parent": acc_name_map[company], "parent_account": acc_name_map[company]})
+				doc.save()
 
 	def validate_group_or_ledger(self):
 		if self.get("__islocal"):
@@ -262,5 +280,5 @@ def merge_account(old, new, is_group, root_type, company):
 @frappe.whitelist()
 def get_root_company(company):
 	# return the topmost company in the hierarchy
-	ancestors = frappe.utils.nestedset.get_ancestors_of('Company', company, "lft asc")
+	ancestors = get_ancestors_of('Company', company, "lft asc")
 	return [ancestors[0]] if ancestors else []

--- a/erpnext/accounts/doctype/account/account.py
+++ b/erpnext/accounts/doctype/account/account.py
@@ -101,9 +101,10 @@ class Account(NestedSet):
 			frappe.throw(_("Please add the account to root level Company - %s" % ancestors[0]))
 		else:
 			descendants = get_descendants_of('Company', self.company)
-			acc_name = frappe.db.get_value('Account', self.parent_account, "account_name")
+			if not descendants: return
 
 			acc_name_map = {}
+			acc_name = frappe.db.get_value('Account', self.parent_account, "account_name")
 			for d in frappe.db.get_values('Account',
 				{"company": ["in", descendants], "account_name": acc_name},
 				["company", "name"], as_dict=True):

--- a/erpnext/accounts/doctype/account/account_tree.js
+++ b/erpnext/accounts/doctype/account/account_tree.js
@@ -19,7 +19,7 @@ frappe.treeview_settings["Account"] = {
 					args: {
 						company: company,
 					},
-					callback: function(r, rt) {
+					callback: function(r) {
 						if(r.message) {
 							let root_company = r.message.length ? r.message[0] : "";
 							me.page.fields_dict.root_company.set_value(root_company);
@@ -137,7 +137,7 @@ frappe.treeview_settings["Account"] = {
 				!frappe.treeview_settings['Account'].treeview.page.fields_dict.root_company.get_value() &&
 					node.expandable && !node.hide_add;
 			},
-			click: function(node) {
+			click: function() {
 				var me = frappe.treeview_settings['Account'].treeview;
 				me.new_node();
 			},

--- a/erpnext/accounts/doctype/account/test_account.py
+++ b/erpnext/accounts/doctype/account/test_account.py
@@ -97,6 +97,19 @@ class TestAccount(unittest.TestCase):
 		self.assertRaises(frappe.ValidationError, merge_account, "Capital Stock - _TC",\
 			"Softwares - _TC", doc.is_group, doc.root_type, doc.company)
 
+	def test_account_sync(self):
+		del frappe.local.flags["ignore_root_company_validation"]
+		acc = frappe.new_doc("Account")
+		acc.account_name = "Test Sync Account"
+		acc.parent_account = "Temporary Accounts - _TC3"
+		acc.company = "_Test Company 3"
+		acc.insert()
+
+		acc_tc_4 = frappe.db.get_value('Account', {'account_name': "Test Sync Account", "company": "_Test Company 4"})
+		acc_tc_5 = frappe.db.get_value('Account', {'account_name': "Test Sync Account", "company": "_Test Company 5"})
+		self.assertEqual(acc_tc_4, "Test Sync Account - _TC4")
+		self.assertEqual(acc_tc_5, "Test Sync Account - _TC5")
+
 def _make_test_records(verbose):
 	from frappe.test_runner import make_test_objects
 

--- a/erpnext/hr/doctype/staffing_plan/staffing_plan.py
+++ b/erpnext/hr/doctype/staffing_plan/staffing_plan.py
@@ -20,6 +20,7 @@ class StaffingPlan(Document):
 		self.total_estimated_budget = 0
 
 		for detail in self.get("staffing_details"):
+			self.set_vacancies(detail)
 			self.validate_overlap(detail)
 			self.validate_with_subsidiary_plans(detail)
 			self.validate_with_parent_plan(detail)
@@ -38,6 +39,15 @@ class StaffingPlan(Document):
 				else: detail.total_estimated_cost = 0
 			else: detail.vacancies = detail.number_of_positions = detail.total_estimated_cost = 0
 			self.total_estimated_budget += detail.total_estimated_cost
+
+	def set_vacancies(self, row):
+		if not row.vacancies:
+			current_openings = 0
+			for field in ['current_count', 'current_openings']:
+				if row.get(field):
+					current_openings += row.get(field)
+
+			row.vacancies = row.number_of_positions - current_openings
 
 	def validate_overlap(self, staffing_plan_detail):
 		# Validate if any submitted Staffing Plan exist for any Designations in this plan

--- a/erpnext/hr/doctype/staffing_plan/test_staffing_plan.py
+++ b/erpnext/hr/doctype/staffing_plan/test_staffing_plan.py
@@ -18,7 +18,7 @@ class TestStaffingPlan(unittest.TestCase):
 		if frappe.db.exists("Staffing Plan", "Test"):
 			return
 		staffing_plan = frappe.new_doc("Staffing Plan")
-		staffing_plan.company = "_Test Company 3"
+		staffing_plan.company = "_Test Company 10"
 		staffing_plan.name = "Test"
 		staffing_plan.from_date = nowdate()
 		staffing_plan.to_date = add_days(nowdate(), 10)
@@ -67,7 +67,7 @@ class TestStaffingPlan(unittest.TestCase):
 		if frappe.db.exists("Staffing Plan", "Test 1"):
 			return
 		staffing_plan = frappe.new_doc("Staffing Plan")
-		staffing_plan.company = "_Test Company 3"
+		staffing_plan.company = "_Test Company 10"
 		staffing_plan.name = "Test 1"
 		staffing_plan.from_date = nowdate()
 		staffing_plan.to_date = add_days(nowdate(), 10)
@@ -85,11 +85,11 @@ def _set_up():
 	make_company()
 
 def make_company():
-	if frappe.db.exists("Company", "_Test Company 3"):
+	if frappe.db.exists("Company", "_Test Company 10"):
 		return
 	company = frappe.new_doc("Company")
-	company.company_name = "_Test Company 3"
-	company.abbr = "_TC3"
+	company.company_name = "_Test Company 10"
+	company.abbr = "_TC10"
 	company.parent_company = "_Test Company"
 	company.default_currency = "INR"
 	company.country = "India"

--- a/erpnext/setup/doctype/company/company.js
+++ b/erpnext/setup/doctype/company/company.js
@@ -16,6 +16,14 @@ frappe.ui.form.on("Company", {
 				filters: {"is_additional_component": 1}
 			}
 		});
+
+		frm.set_df_property("create_chart_of_accounts_based_on", "read_only", frm.doc.parent_company ? 1 : 0);
+		frm.set_df_property("existing_company", "read_only", frm.doc.parent_company ? 1 : 0);
+		frm.set_query("parent_company", function() {
+			return {
+				filters: {"is_group": 1}
+			}
+		});
 	},
 
 	company_name: function(frm) {
@@ -26,6 +34,12 @@ frappe.ui.form.on("Company", {
 			}).join("");
 			frm.set_value("abbr", abbr);
 		}
+	},
+
+	parent_company: function(frm) {
+		if(!frm.doc.parent_company) return;
+		frm.set_value("create_chart_of_accounts_based_on", "Existing Company");
+		frm.set_value("existing_company", frm.doc.parent_company);
 	},
 
 	date_of_commencement: function(frm) {

--- a/erpnext/setup/doctype/company/company.js
+++ b/erpnext/setup/doctype/company/company.js
@@ -17,8 +17,6 @@ frappe.ui.form.on("Company", {
 			}
 		});
 
-		frm.set_df_property("create_chart_of_accounts_based_on", "read_only", frm.doc.parent_company ? 1 : 0);
-		frm.set_df_property("existing_company", "read_only", frm.doc.parent_company ? 1 : 0);
 		frm.set_query("parent_company", function() {
 			return {
 				filters: {"is_group": 1}
@@ -37,9 +35,10 @@ frappe.ui.form.on("Company", {
 	},
 
 	parent_company: function(frm) {
-		if(!frm.doc.parent_company) return;
-		frm.set_value("create_chart_of_accounts_based_on", "Existing Company");
-		frm.set_value("existing_company", frm.doc.parent_company);
+		var bool = frm.doc.parent_company ? true : false;
+		frm.set_value('create_chart_of_accounts_based_on', bool ? "Existing Company" : "");
+		frm.set_value('existing_company', bool ? frm.doc.parent_company : "");
+		disbale_coa_fields(frm, bool);
 	},
 
 	date_of_commencement: function(frm) {
@@ -54,8 +53,9 @@ frappe.ui.form.on("Company", {
 
 	refresh: function(frm) {
 		if(!frm.doc.__islocal) {
-			frm.set_df_property("abbr", "read_only", 1);
+			frm.doc.abbr && frm.set_df_property("abbr", "read_only", 1);
 			frm.set_df_property("parent_company", "read_only", 1);
+			disbale_coa_fields(frm);
 		}
 
 		frm.toggle_display('address_html', !frm.doc.__islocal);
@@ -271,3 +271,9 @@ erpnext.company.set_custom_query = function(frm, v) {
 		}
 	});
 }
+
+var disbale_coa_fields = function(frm, bool=true) {
+	frm.set_df_property("create_chart_of_accounts_based_on", "read_only", bool);
+	frm.set_df_property("chart_of_accounts", "read_only", bool);
+	frm.set_df_property("existing_company", "read_only", bool);
+};

--- a/erpnext/setup/doctype/company/company.js
+++ b/erpnext/setup/doctype/company/company.js
@@ -53,8 +53,9 @@ frappe.ui.form.on("Company", {
 	},
 
 	refresh: function(frm) {
-		if(frm.doc.abbr && !frm.doc.__islocal) {
+		if(!frm.doc.__islocal) {
 			frm.set_df_property("abbr", "read_only", 1);
+			frm.set_df_property("parent_company", "read_only", 1);
 		}
 
 		frm.toggle_display('address_html', !frm.doc.__islocal);

--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -141,6 +141,7 @@ class Company(NestedSet):
 
 	def create_default_accounts(self):
 		from erpnext.accounts.doctype.account.chart_of_accounts.chart_of_accounts import create_charts
+		frappe.local.flags.ignore_root_company_validation = True
 		create_charts(self.name, self.chart_of_accounts, self.existing_company)
 
 		frappe.db.set(self, "default_receivable_account", frappe.db.get_value("Account",

--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -39,6 +39,7 @@ class Company(NestedSet):
 		self.validate_coa_input()
 		self.validate_perpetual_inventory()
 		self.check_country_change()
+		self.set_chart_of_accounts()
 
 	def validate_abbr(self):
 		if not self.abbr:
@@ -173,6 +174,12 @@ class Company(NestedSet):
 		if not self.get('__islocal') and \
 			self.country != frappe.get_cached_value('Company',  self.name,  'country'):
 			frappe.flags.country_change = True
+
+	def set_chart_of_accounts(self):
+		''' If parent company is set, chart of accounts will be based on that company '''
+		if self.parent_company:
+			self.create_chart_of_accounts_based_on = "Existing Company"
+			self.existing_company = self.parent_company
 
 	def set_default_accounts(self):
 		self._set_default_account("default_cash_account", "Cash")

--- a/erpnext/setup/doctype/company/test_records.json
+++ b/erpnext/setup/doctype/company/test_records.json
@@ -1,66 +1,66 @@
 [
- {
-  "abbr": "_TC",
-  "company_name": "_Test Company",
-  "country": "India",
-  "default_currency": "INR",
-  "doctype": "Company",
-  "domain": "Manufacturing",
-  "chart_of_accounts": "Standard",
-  "default_holiday_list": "_Test Holiday List"
- },
- {
-  "abbr": "_TC1",
-  "company_name": "_Test Company 1",
-  "country": "United States",
-  "default_currency": "USD",
-  "doctype": "Company",
-  "domain": "Retail",
-  "chart_of_accounts": "Standard",
-  "default_holiday_list": "_Test Holiday List"
- },
- {
-  "abbr": "_TC2",
-  "company_name": "_Test Company 2",
-  "default_currency": "EUR",
-  "country": "Germany",
-  "doctype": "Company",
-  "domain": "Retail",
-  "chart_of_accounts": "Standard",
-  "default_holiday_list": "_Test Holiday List"
- },
- {
-  "abbr": "_TC3",
-	"company_name": "_Test Company 3",
-	"is_group": 1,
-  "country": "India",
-  "default_currency": "INR",
-  "doctype": "Company",
-  "domain": "Manufacturing",
-  "chart_of_accounts": "Standard",
-  "default_holiday_list": "_Test Holiday List"
- },
- {
-  "abbr": "_TC4",
-	"company_name": "_Test Company 4",
-	"parent_company": "_Test Company 3",
-	"is_group": 1,
-  "country": "India",
-  "default_currency": "INR",
-  "doctype": "Company",
-  "domain": "Manufacturing",
-  "chart_of_accounts": "Standard",
-  "default_holiday_list": "_Test Holiday List"
- },
- {
-  "abbr": "_TC5",
-	"company_name": "_Test Company 5",
-	"parent_company": "_Test Company 4",
-  "country": "India",
-  "default_currency": "INR",
-  "doctype": "Company",
-  "domain": "Manufacturing",
-  "chart_of_accounts": "Standard",
-  "default_holiday_list": "_Test Holiday List"
- }
+	{
+		"abbr": "_TC",
+		"company_name": "_Test Company",
+		"country": "India",
+		"default_currency": "INR",
+		"doctype": "Company",
+		"domain": "Manufacturing",
+		"chart_of_accounts": "Standard",
+		"default_holiday_list": "_Test Holiday List"
+	},
+	{
+		"abbr": "_TC1",
+		"company_name": "_Test Company 1",
+		"country": "United States",
+		"default_currency": "USD",
+		"doctype": "Company",
+		"domain": "Retail",
+		"chart_of_accounts": "Standard",
+		"default_holiday_list": "_Test Holiday List"
+	},
+	{
+		"abbr": "_TC2",
+		"company_name": "_Test Company 2",
+		"default_currency": "EUR",
+		"country": "Germany",
+		"doctype": "Company",
+		"domain": "Retail",
+		"chart_of_accounts": "Standard",
+		"default_holiday_list": "_Test Holiday List"
+	},
+	{
+		"abbr": "_TC3",
+		"company_name": "_Test Company 3",
+		"is_group": 1,
+		"country": "India",
+		"default_currency": "INR",
+		"doctype": "Company",
+		"domain": "Manufacturing",
+		"chart_of_accounts": "Standard",
+		"default_holiday_list": "_Test Holiday List"
+	},
+	{
+		"abbr": "_TC4",
+		"company_name": "_Test Company 4",
+		"parent_company": "_Test Company 3",
+		"is_group": 1,
+		"country": "India",
+		"default_currency": "INR",
+		"doctype": "Company",
+		"domain": "Manufacturing",
+		"chart_of_accounts": "Standard",
+		"default_holiday_list": "_Test Holiday List"
+	},
+	{
+		"abbr": "_TC5",
+		"company_name": "_Test Company 5",
+		"parent_company": "_Test Company 4",
+		"country": "India",
+		"default_currency": "INR",
+		"doctype": "Company",
+		"domain": "Manufacturing",
+		"chart_of_accounts": "Standard",
+		"default_holiday_list": "_Test Holiday List"
+	}
 ]

--- a/erpnext/setup/doctype/company/test_records.json
+++ b/erpnext/setup/doctype/company/test_records.json
@@ -28,5 +28,39 @@
   "domain": "Retail",
   "chart_of_accounts": "Standard",
   "default_holiday_list": "_Test Holiday List"
+ },
+ {
+  "abbr": "_TC3",
+	"company_name": "_Test Company 3",
+	"is_group": 1,
+  "country": "India",
+  "default_currency": "INR",
+  "doctype": "Company",
+  "domain": "Manufacturing",
+  "chart_of_accounts": "Standard",
+  "default_holiday_list": "_Test Holiday List"
+ },
+ {
+  "abbr": "_TC4",
+	"company_name": "_Test Company 4",
+	"parent_company": "_Test Company 3",
+	"is_group": 1,
+  "country": "India",
+  "default_currency": "INR",
+  "doctype": "Company",
+  "domain": "Manufacturing",
+  "chart_of_accounts": "Standard",
+  "default_holiday_list": "_Test Holiday List"
+ },
+ {
+  "abbr": "_TC5",
+	"company_name": "_Test Company 5",
+	"parent_company": "_Test Company 4",
+  "country": "India",
+  "default_currency": "INR",
+  "doctype": "Company",
+  "domain": "Manufacturing",
+  "chart_of_accounts": "Standard",
+  "default_holiday_list": "_Test Holiday List"
  }
 ]


### PR DESCRIPTION
Issue:- https://github.com/frappe/erpnext/issues/16485

<p>

- While creating a company if `parent_company` is selected chart of accounts selection field gets set as based on "Existing Company" and company = `parent_company` and both these field becomes read only.

- Additionally, once the company is created and saved, you cannot select a parent for it.

<p>

<br>

<details>
<summary> Adding account only possible for Root Company </summary>

![coa_1_add_not](https://user-images.githubusercontent.com/11695402/51975999-a05c7e80-24a9-11e9-84b9-8f045764d1f0.gif)

</details>

<br>

<details>
<summary> Adding Account to root company syncs it across all its descendants </summary>

![coa_1_sync](https://user-images.githubusercontent.com/11695402/51976754-89b72700-24ab-11e9-9c87-5437ed079606.gif)

</details>

Travis failing because the PR depends on - https://github.com/frappe/frappe/pull/6843