### PR TITLE
fix(accounts): fetch subscription details only if required fields are populated

### DIFF
--- a/erpnext/accounts/doctype/payment_request/payment_request.js
+++ b/erpnext/accounts/doctype/payment_request/payment_request.js
@@ -54,7 +54,7 @@ frappe.ui.form.on("Payment Request", "is_a_subscription", function(frm) {
 	frm.toggle_reqd("payment_gateway_account", frm.doc.is_a_subscription);
 	frm.toggle_reqd("subscription_plans", frm.doc.is_a_subscription);
 
-	if (frm.doc.is_a_subscription) {
+	if (frm.doc.is_a_subscription && frm.doc.reference_doctype && frm.doc.reference_name) {
 		frappe.call({
 			method: "erpnext.accounts.doctype.payment_request.payment_request.get_subscription_details",
 			args: {"reference_doctype": frm.doc.reference_doctype, "reference_name": frm.doc.reference_name},


### PR DESCRIPTION
**Payment Request** > **New** > Check **Is A Subscription**
throws following error
```traceback-python
Traceback (most recent call last):
  File "/Users/aditya/Frappe/frappe2/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/Users/aditya/Frappe/frappe2/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/Users/aditya/Frappe/frappe2/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/aditya/Frappe/frappe2/apps/frappe/frappe/__init__.py", line 1019, in call
    return fn(*args, **newargs)
TypeError: get_subscription_details() takes exactly 2 arguments (0 given)
```

This fixes that