### PR TITLE
fix: (POS) Item listing issue in pos after submit for Multi Company POS Profile

### DIFF
--- a/erpnext/selling/page/point_of_sale/point_of_sale.js
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.js
@@ -166,7 +166,7 @@ erpnext.pos.PointOfSale = class PointOfSale {
 		});
 
 		frappe.ui.form.on('Sales Invoice', 'selling_price_list', (frm) => {
-			if(this.items) {
+			if(this.items && frm.doc.pos_profile) {
 				this.items.reset_items();
 			}
 		})


### PR DESCRIPTION
**_Version:_ erpnext 11.1.4 frappe 11.1.4**
Steps to verify:

1. Create 2 separate POS profile for 2 different users (each user is belonging to separate company)
2. Assign different item groups to both users
3. Login with one user and open POS
4. Do some sale.
5. After submit click on **New** button
6. After submission of POS entry, only mapped item group's items should be listed out which are mapped to that particular user.

![16588](https://user-images.githubusercontent.com/3703266/52477981-db596300-2bc9-11e9-8337-d32d38c43460.gif)
