### PR TITLE
fix: typo in salary register report field name

### DIFF
--- a/erpnext/hr/report/salary_register/salary_register.py
+++ b/erpnext/hr/report/salary_register/salary_register.py
@@ -19,12 +19,12 @@ def execute(filters=None):
 	data = []
 	for ss in salary_slips:
 		row = [ss.name, ss.employee, ss.employee_name, ss.branch, ss.department, ss.designation,
-			ss.company, ss.start_date, ss.end_date, ss.leave_withut_pay, ss.payment_days]
+			ss.company, ss.start_date, ss.end_date, ss.leave_without_pay, ss.payment_days]
 
 		if not ss.branch == None:columns[3] = columns[3].replace('-1','120')
 		if not ss.department  == None: columns[4] = columns[4].replace('-1','120')
 		if not ss.designation  == None: columns[5] = columns[5].replace('-1','120')
-		if not ss.leave_withut_pay  == None: columns[9] = columns[9].replace('-1','130')
+		if not ss.leave_without_pay  == None: columns[9] = columns[9].replace('-1','130')
 
 
 		for e in earning_types:


### PR DESCRIPTION
When assigning salary slip field values to row list for salary register in salary_register.py, line 22, the field was incorrectly spelled.  The correct value in the Salary Slip DocType is `leave_without_pay`, and this change reflects this. Line 27 also reflects this adjustment.

Please read the pull request checklist to make sure your changes are merged: https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

