### PR TITLE
fix: Address and contact report

### DIFF
--- a/erpnext/selling/report/address_and_contacts/address_and_contacts.py
+++ b/erpnext/selling/report/address_and_contacts/address_and_contacts.py
@@ -102,7 +102,8 @@ def get_party_details(party_type, party_list, doctype, party_details):
 	records = frappe.get_list(doctype, filters=filters, fields=fields, as_list=True)
 	for d in records:
 		details = party_details.get(d[0])
-		details.setdefault(frappe.scrub(doctype), []).append(d[1:])
+		if details:
+			details.setdefault(frappe.scrub(doctype), []).append(d[1:])
 
 	return party_details
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1013, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 495, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 179, in run
    result = generate_report_result(report, filters, user)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 66, in generate_report_result
    res = frappe.get_attr(method_name)(frappe._dict(filters))
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/selling/report/address_and_contacts/address_and_contacts.py", line 16, in execute
    columns, data = get_columns(filters), get_data(filters)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/selling/report/address_and_contacts/address_and_contacts.py", line 45, in get_data
    return get_party_addresses_and_contact(party_type, party, party_group)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/selling/report/address_and_contacts/address_and_contacts.py", line 68, in get_party_addresses_and_contact
    party_details = get_party_details(party_type, party_list, "Contact", party_details)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/selling/report/address_and_contacts/address_and_contacts.py", line 105, in get_party_details
    details.setdefault(frappe.scrub(doctype), []).append(d[1:])
AttributeError: 'NoneType' object has no attribute 'setdefault'
```

