### PR TITLE
fix: Purchase order item description fix

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -456,7 +456,7 @@ def make_rm_stock_entry(purchase_order, rm_items):
 					items_dict = {
 						rm_item_code: {
 							"item_name": rm_item_data["item_name"],
-							"description": item_wh[rm_item_code].get('description'),
+							"description": item_wh.get(rm_item_code, {}).get('description', ""),
 							'qty': rm_item_data["qty"],
 							'from_warehouse': rm_item_data["warehouse"],
 							'stock_uom': rm_item_data["stock_uom"],


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2019-02-13/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2019-02-13/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2019-02-13/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2019-02-13/apps/frappe/frappe/__init__.py", line 1020, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2019-02-13/apps/erpnext/erpnext/buying/doctype/purchase_order/purchase_order.py", line 459, in make_rm_stock_entry
    "description": item_wh[rm_item_code].get('description'),
KeyError: u'20.612'
```

