### PR TITLE
fix: multi-uom not working for the pricing rule rate

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -196,8 +196,9 @@ def get_pricing_rule_for_item(args):
 			pricing_rule_rate = 0.0
 			if pricing_rule.currency == args.currency:
 				pricing_rule_rate = pricing_rule.rate
+
 			item_details.update({
-				"price_list_rate": pricing_rule_rate,
+				"price_list_rate": pricing_rule_rate * args.get("conversion_factor"),
 				"discount_percentage": 0.0
 			})
 		else:


### PR DESCRIPTION
**Created pricing rule for item "Heat Sink Powder" with rate as 23.00**

![screen shot 2019-02-18 at 8 06 23 pm](https://user-images.githubusercontent.com/8780500/52957972-08232c80-33b9-11e9-9153-722a5e716bf1.png)


**Issue**
When UOM changed from Nos to Box in sales order rate has not changed
![screen shot 2019-02-18 at 8 06 08 pm](https://user-images.githubusercontent.com/8780500/52957994-1709df00-33b9-11e9-94f9-be00e5db4d62.png)


**After fix**
Price list rate = pricing rule rate * conversion factor
![image](https://user-images.githubusercontent.com/8780500/52958137-7536c200-33b9-11e9-8d7b-6d6d0656e6f9.png)
