### PR TITLE
fix: Item name display issue fix in item dashboard

### DIFF
--- a/erpnext/stock/dashboard/item_dashboard.py
+++ b/erpnext/stock/dashboard/item_dashboard.py
@@ -28,7 +28,7 @@ def get_data(item_code=None, warehouse=None, item_group=None,
 		# user does not have access on warehouse
 		return []
 
-	return frappe.db.get_all('Bin', fields=['item_code', 'warehouse', 'projected_qty',
+	items = frappe.db.get_all('Bin', fields=['item_code', 'warehouse', 'projected_qty',
 			'reserved_qty', 'reserved_qty_for_production', 'reserved_qty_for_sub_contract', 'actual_qty', 'valuation_rate'],
 		or_filters={
 			'projected_qty': ['!=', 0],
@@ -41,3 +41,10 @@ def get_data(item_code=None, warehouse=None, item_group=None,
 		order_by=sort_by + ' ' + sort_order,
 		limit_start=start,
 		limit_page_length='21')
+
+	for item in items:
+		item.update({
+			'item_name': frappe.get_cached_value("Item", item.item_code, 'item_name')
+		})
+
+	return items


### PR DESCRIPTION
Item name is displayed in bracket if item name and item code are different:

Before:
![screenshot 2019-02-19 at 7 36 38 pm](https://user-images.githubusercontent.com/42651287/53021808-06706c00-3480-11e9-9f03-7c79fa5d1c82.png)

After:

Different Item Name and Item Code
![screenshot 2019-02-19 at 7 43 28 pm](https://user-images.githubusercontent.com/42651287/53021821-0bcdb680-3480-11e9-9abc-72ba1bcde77b.png)
![screenshot 2019-02-19 at 7 43 37 pm](https://user-images.githubusercontent.com/42651287/53021842-14be8800-3480-11e9-9df8-a0b55688fdac.png)

Same Item Name and Item Code
![screenshot 2019-02-19 at 7 50 19 pm](https://user-images.githubusercontent.com/42651287/53021846-17b97880-3480-11e9-91ac-0953cb50e0e9.png)



