### PR TITLE
fix: not able to cancel maintenance visit

### DIFF
--- a/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py
+++ b/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py
@@ -41,12 +41,19 @@ class MaintenanceVisit(TransactionBase):
 						work_done = nm and nm[0][3] or ''
 					else:
 						status = 'Open'
-						mntc_date = ''
-						service_person = ''
-						work_done = ''
+						mntc_date = None
+						service_person = None
+						work_done = None
 
-				frappe.db.sql("update `tabWarranty Claim` set resolution_date=%s, resolved_by=%s, resolution_details=%s, status=%s where name =%s",(mntc_date,service_person,work_done,status,d.prevdoc_docname))
+				wc_doc = frappe.get_doc('Warranty Claim', d.prevdoc_docname)
+				wc_doc.update({
+					'resolution_date': mntc_date,
+					'resolved_by': service_person,
+					'resolution_details': work_done,
+					'status': status
+				})
 
+				wc_doc.db_update()
 
 	def check_if_last_visit(self):
 		"""check if last maintenance visit against same sales order/ Warranty Claim"""


### PR DESCRIPTION
**Issue**

While cancelling maintenance visit getting below error

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2019-02-13/apps/frappe/frappe/desk/form/save.py", line 45, in cancel
    doc.cancel()
  File "/home/frappe/benches/bench-2019-02-13/apps/frappe/frappe/model/document.py", line 853, in cancel
    self._cancel()
  File "/home/frappe/benches/bench-2019-02-13/apps/frappe/frappe/model/document.py", line 843, in _cancel
    self.save()
  File "/home/frappe/benches/bench-2019-02-13/apps/frappe/frappe/model/document.py", line 260, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-2019-02-13/apps/frappe/frappe/model/document.py", line 313, in _save
    self.run_post_save_methods()
  File "/home/frappe/benches/bench-2019-02-13/apps/frappe/frappe/model/document.py", line 910, in run_post_save_methods
    self.run_method("on_cancel")
  File "/home/frappe/benches/bench-2019-02-13/apps/frappe/frappe/model/document.py", line 772, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-2019-02-13/apps/frappe/frappe/model/document.py", line 1048, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-2019-02-13/apps/frappe/frappe/model/document.py", line 1031, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-2019-02-13/apps/frappe/frappe/model/document.py", line 766, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-2019-02-13/apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py", line 75, in on_cancel
    self.check_if_last_visit()
  File "/home/frappe/benches/bench-2019-02-13/apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py", line 68, in check_if_last_visit
    self.update_customer_issue(0)
  File "/home/frappe/benches/bench-2019-02-13/apps/erpnext/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py", line 48, in update_customer_issue
    frappe.db.sql("update `tabWarranty Claim` set resolution_date=%s, resolved_by=%s, resolution_details=%s, status=%s where name =%s",(mntc_date,service_person,work_done,status,d.prevdoc_docname))
  File "/home/frappe/benches/bench-2019-02-13/apps/frappe/frappe/database.py", line 199, in sql
    self._cursor.execute(query, values)
  File "/home/frappe/benches/bench-2019-02-13/env/lib/python2.7/site-packages/pymysql/cursors.py", line 170, in execute
    result = self._query(query)
  File "/home/frappe/benches/bench-2019-02-13/env/lib/python2.7/site-packages/pymysql/cursors.py", line 328, in _query
    conn.query(q)
  File "/home/frappe/benches/bench-2019-02-13/env/lib/python2.7/site-packages/pymysql/connections.py", line 517, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/home/frappe/benches/bench-2019-02-13/env/lib/python2.7/site-packages/pymysql/connections.py", line 732, in _read_query_result
    result.read()
  File "/home/frappe/benches/bench-2019-02-13/env/lib/python2.7/site-packages/pymysql/connections.py", line 1075, in read
    first_packet = self.connection._read_packet()
  File "/home/frappe/benches/bench-2019-02-13/env/lib/python2.7/site-packages/pymysql/connections.py", line 684, in _read_packet
    packet.check_error()
  File "/home/frappe/benches/bench-2019-02-13/env/lib/python2.7/site-packages/pymysql/protocol.py", line 220, in check_error
    err.raise_mysql_exception(self._data)
  File "/home/frappe/benches/bench-2019-02-13/env/lib/python2.7/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
    raise errorclass(errno, errval)
InternalError: (1292, u"Incorrect datetime value: '' for column 'resolution_date' at row 1")
```