### PR TITLE
fix(regional,italy): renamed validate hook for address

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -210,7 +210,7 @@ doc_events = {
 		"on_trash": "erpnext.regional.check_deletion_permission"
 	},
 	'Address': {
-		'validate': ['erpnext.regional.india.utils.validate_gstin_for_india', 'erpnext.regional.italy.utils.validate_address']
+		'validate': ['erpnext.regional.india.utils.validate_gstin_for_india', 'erpnext.regional.italy.utils.set_state_code']
 	},
 	('Sales Invoice', 'Purchase Invoice', 'Delivery Note'): {
 		'validate': 'erpnext.regional.india.utils.set_place_of_supply'

--- a/erpnext/regional/italy/utils.py
+++ b/erpnext/regional/italy/utils.py
@@ -285,7 +285,7 @@ def get_progressive_name_and_number(doc):
 
 	return progressive_name, progressive_number
 
-def validate_address(doc, method):
+def set_state_code(doc, method):
 	if not (hasattr(doc, "state_code") and doc.country in ["Italy", "Italia", "Italian Republic", "Repubblica Italiana"]):
 		return
 


### PR DESCRIPTION
Changed method name from `validate_address` to `set_state_code`