### PR TITLE
fix: purchase order not able to submit

### DIFF
--- a/erpnext/regional/italy/utils.py
+++ b/erpnext/regional/italy/utils.py
@@ -183,6 +183,9 @@ def get_invoice_summary(items, taxes):
 #Preflight for successful e-invoice export.
 def sales_invoice_validate(doc):
 	#Validate company
+	if doc.doctype != 'Sales Invoice':
+		return
+
 	if not doc.company_address:
 		frappe.throw(_("Please set an Address on the Company '%s'" % doc.company), title=_("E-Invoicing Information Missing"))
 	else:


### PR DESCRIPTION
**Issue**

```
Traceback (most recent call last):

  File "/home/frappe/benches/bench-2019-02-20/apps/frappe/frappe/desk/form/save.py", line 22, in savedocs

    doc.save()

  File "/home/frappe/benches/bench-2019-02-20/apps/frappe/frappe/model/document.py", line 260, in save

    return self._save(*args, **kwargs)

  File "/home/frappe/benches/bench-2019-02-20/apps/frappe/frappe/model/document.py", line 283, in _save

    self.insert()

  File "/home/frappe/benches/bench-2019-02-20/apps/frappe/frappe/model/document.py", line 222, in insert

    self.run_before_save_methods()

  File "/home/frappe/benches/bench-2019-02-20/apps/frappe/frappe/model/document.py", line 876, in run_before_save_methods

    self.run_method("validate")

  File "/home/frappe/benches/bench-2019-02-20/apps/frappe/frappe/model/document.py", line 772, in run_method

    out = Document.hook(fn)(self, *args, **kwargs)

  File "/home/frappe/benches/bench-2019-02-20/apps/frappe/frappe/model/document.py", line 1048, in composer

    return composed(self, method, *args, **kwargs)

  File "/home/frappe/benches/bench-2019-02-20/apps/frappe/frappe/model/document.py", line 1031, in runner

    add_to_return_value(self, fn(self, *args, **kwargs))

  File "/home/frappe/benches/bench-2019-02-20/apps/frappe/frappe/model/document.py", line 766, in

    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)

  File "/home/frappe/benches/bench-2019-02-20/apps/erpnext/erpnext/buying/doctype/purchase_order/purchase_order.py", line 41, in validate

    super(PurchaseOrder, self).validate()

  File "/home/frappe/benches/bench-2019-02-20/apps/erpnext/erpnext/controllers/buying_controller.py", line 38, in validate

    super(BuyingController, self).validate()

  File "/home/frappe/benches/bench-2019-02-20/apps/erpnext/erpnext/controllers/stock_controller.py", line 21, in validate

    super(StockController, self).validate()

  File "/home/frappe/benches/bench-2019-02-20/apps/erpnext/erpnext/controllers/accounts_controller.py", line 97, in validate

    validate_regional(self)

  File "/home/frappe/benches/bench-2019-02-20/apps/erpnext/erpnext/__init__.py", line 129, in caller

    return frappe.get_attr(regional_overrides[region][fn_name])(*args, **kwargs)

  File "/home/frappe/benches/bench-2019-02-20/apps/erpnext/erpnext/regional/italy/utils.py", line 186, in sales_invoice_validate

    if not doc.company_address:

AttributeError: 'PurchaseOrder' object has no attribute 'company_address'

```