### PR TITLE
fix: State code issue fix

### DIFF
--- a/erpnext/regional/italy/utils.py
+++ b/erpnext/regional/italy/utils.py
@@ -300,6 +300,9 @@ def get_progressive_name_and_number(doc):
 	return progressive_name, progressive_number
 
 def set_state_code(doc, method):
+	if not doc.get('state'):
+		return
+
 	if not (hasattr(doc, "state_code") and doc.country in ["Italy", "Italia", "Italian Republic", "Repubblica Italiana"]):
 		return
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2019-02-20/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2019-02-20/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2019-02-20/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2019-02-20/apps/frappe/frappe/__init__.py", line 1026, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2019-02-20/apps/frappe/frappe/desk/form/save.py", line 22, in savedocs
    doc.save()
  File "/home/frappe/benches/bench-2019-02-20/apps/frappe/frappe/model/document.py", line 260, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-2019-02-20/apps/frappe/frappe/model/document.py", line 283, in _save
    self.insert()
  File "/home/frappe/benches/bench-2019-02-20/apps/frappe/frappe/model/document.py", line 222, in insert
    self.run_before_save_methods()
  File "/home/frappe/benches/bench-2019-02-20/apps/frappe/frappe/model/document.py", line 876, in run_before_save_methods
    self.run_method("validate")
  File "/home/frappe/benches/bench-2019-02-20/apps/frappe/frappe/model/document.py", line 772, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-2019-02-20/apps/frappe/frappe/model/document.py", line 1048, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-2019-02-20/apps/frappe/frappe/model/document.py", line 1033, in runner
    add_to_return_value(self, f(self, method, *args, **kwargs))
  File "/home/frappe/benches/bench-2019-02-20/apps/erpnext/erpnext/regional/italy/utils.py", line 293, in validate_address
    doc.state_code = state_codes_lower.get(doc.get('state','').lower())
AttributeError: 'NoneType' object has no attribute 'lower'
```

