### PR TITLE
fix: update node to version supported by Yarn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
   - sudo rm /etc/apt/sources.list.d/docker.list
   - sudo apt-get install hhvm && rm -rf /home/travis/.kiex/
   - sudo apt-get purge -y mysql-common mysql-server mysql-client
-  - nvm install v7.10.0
+  - nvm install v8.10.0
   - pip install python-coveralls
   - wget https://raw.githubusercontent.com/frappe/bench/master/playbooks/install.py
   - sudo python install.py --develop --user travis --without-bench-setup


### PR DESCRIPTION
Refer:
https://travis-ci.com/frappe/erpnext/jobs/180066793#L1381

Already set in Frappe:
https://github.com/frappe/frappe/blob/develop/.travis/install.sh#L10
