### PR TITLE
fix: Make company filter mandatory in sales person wise transaction summary 

### DIFF
--- a/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.js
+++ b/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.js
@@ -33,7 +33,8 @@ frappe.query_reports["Sales Person-wise Transaction Summary"] = {
 			label: __("Company"),
 			fieldtype: "Link",
 			options: "Company",
-			default: frappe.defaults.get_user_default("Company")
+			default: frappe.defaults.get_user_default("Company"),
+			reqd: 1
 		},
 		{
 			fieldname:"item_group",

--- a/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py
+++ b/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py
@@ -15,7 +15,7 @@ def execute(filters=None):
 	item_details = get_item_details()
 	data = []
 
-	company_currency = get_company_currency(filters["company"])
+	company_currency = get_company_currency(filters.get("company"))
 
 	for d in entries:
 		if d.stock_qty > 0 or filters.get('show_return_entries', 0):


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2019-01-30/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2019-01-30/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2019-01-30/apps/frappe/frappe/handler.py", line 53, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2019-01-30/apps/frappe/frappe/__init__.py", line 939, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2019-01-30/apps/frappe/frappe/desk/query_report.py", line 96, in run
    res = frappe.get_attr(method_name)(frappe._dict(filters))
  File "/home/frappe/benches/bench-2019-01-30/apps/erpnext/erpnext/selling/report/sales_person_wise_transaction_summary/sales_person_wise_transaction_summary.py", line 18, in execute
    company_currency = get_company_currency(filters["company"])
KeyError: u'company'
```

