### PR TITLE
fix: multiple e-invoicing issues for italy region

### DIFF
--- a/erpnext/regional/italy/e-invoice.xml
+++ b/erpnext/regional/italy/e-invoice.xml
@@ -32,10 +32,10 @@
 {%- endmacro -%}
 
 <?xml version='1.0' encoding='UTF-8'?>
-<p:FatturaElettronica xmlns:ds="http://www.w3.org/2000/09/xmldsig#" 
-  xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2" 
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
-  versione="{{ doc.transmission_format_code }}" 
+<p:FatturaElettronica xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+  xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  versione="{{ doc.transmission_format_code }}"
   xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.2 http://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.2/Schema_del_file_xml_FatturaPA_versione_1.2.xsd">
   <FatturaElettronicaHeader>
     <DatiTrasmissione>
@@ -160,7 +160,7 @@
           <CodiceTipo>CODICE</CodiceTipo>
           <CodiceValore>{{ item.item_code }}</CodiceValore>
         </CodiceArticolo>
-        <Descrizione>{{ item.description or item.item_name }}</Descrizione>
+        <Descrizione>{{ html2text(item.description) or item.item_name }}</Descrizione>
         <Quantita>{{ format_float(item.qty) }}</Quantita>
         <UnitaMisura>{{ item.stock_uom }}</UnitaMisura>
         <PrezzoUnitario>{{ format_float(item.price_list_rate or item.rate) }}</PrezzoUnitario>


### PR DESCRIPTION
**Issue 1**
Not able to open system generated XML file because &(ampersand) is used, ```& should be replaced by &amp;```

**Issue 2**
Not able to open system generated XML file because extra br tag has added in the description

**Issue 3**
Not able to generate the XML file because company regime is not set in the company

**Issue 4**
Not able to generate the XML file because "mode of payment code" is not set in the mode of payment

**Issue 4**
```
Traceback (most recent call last):

  File "/home/frappe/benches/bench-2019-02-20/apps/frappe/frappe/app.py", line 66, in application

    response = frappe.api.handle()

  File "/home/frappe/benches/bench-2019-02-20/apps/frappe/frappe/api.py", line 56, in handle

    return frappe.handler.handle()

  File "/home/frappe/benches/bench-2019-02-20/apps/frappe/frappe/handler.py", line 21, in handle

    data = execute_cmd(cmd)

  File "/home/frappe/benches/bench-2019-02-20/apps/frappe/frappe/handler.py", line 56, in execute_cmd

    return frappe.call(method, **frappe.form_dict)

  File "/home/frappe/benches/bench-2019-02-20/apps/frappe/frappe/__init__.py", line 1026, in call

    return fn(*args, **newargs)

  File "/home/frappe/benches/bench-2019-02-20/apps/erpnext/erpnext/regional/italy/utils.py", line 33, in export_invoices

    attachments = get_e_invoice_attachments(invoice)

  File "/home/frappe/benches/bench-2019-02-20/apps/erpnext/erpnext/regional/italy/utils.py", line 268, in get_e_invoice_attachments

    company_tax_id = invoice.company_tax_id if invoice.company_tax_id.startswith("IT") else "IT" + invoice.company_tax_id

AttributeError: 'NoneType' object has no attribute 'startswith'
```