### PR TITLE
revert: Address and contact report fix

### DIFF
--- a/erpnext/selling/report/address_and_contacts/address_and_contacts.py
+++ b/erpnext/selling/report/address_and_contacts/address_and_contacts.py
@@ -102,8 +102,7 @@ def get_party_details(party_type, party_list, doctype, party_details):
 	records = frappe.get_list(doctype, filters=filters, fields=fields, as_list=True)
 	for d in records:
 		details = party_details.get(d[0])
-		if details:
-			details.setdefault(frappe.scrub(doctype), []).append(d[1:])
+		details.setdefault(frappe.scrub(doctype), []).append(d[1:])
 
 	return party_details
 


### PR DESCRIPTION
Reverts #16674 

Address and other info are not visible in address and contact report
![screenshot 2019-02-27 at 11 31 38 am](https://user-images.githubusercontent.com/42651287/53469309-6029f500-3a83-11e9-9672-e5e7d14dc470.png)


