### PR TITLE
fix: Print letter head only if checked in Print Settings

### DIFF
--- a/erpnext/accounts/report/financial_statements.html
+++ b/erpnext/accounts/report/financial_statements.html
@@ -15,7 +15,7 @@
 		height: 37px;
 	}
 </style>
-{% var letterhead= filters.letter_head || (frappe.get_doc(":Company", filters.company) && frappe.get_doc(":Company", filters.company).default_letter_head) || frappe.defaults.get_default("letter_head"); %}
+{% var letterhead= filters.letter_head || (frappe.get_doc(":Company", filters.company) && frappe.get_doc(":Company", filters.company).default_letter_head) %}
 {% if(letterhead) { %}
 <div style="margin-bottom: 7px;" class="text-center">
 	{%= frappe.boot.letter_heads[letterhead].header %}


### PR DESCRIPTION
Letter head is printed in financial statements even if option is not checked

![letter head option](https://user-images.githubusercontent.com/42651287/53430759-26baa080-3a15-11e9-948a-bc95700a18d2.png)
