### PR TITLE
fix: call base class onload method

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -46,6 +46,7 @@ class PurchaseInvoice(BuyingController):
 		}]
 
 	def onload(self):
+		super(PurchaseInvoice, self).onload()
 		supplier_tds = frappe.db.get_value("Supplier", self.supplier, "tax_withholding_category")
 		self.set_onload("supplier_tds", supplier_tds)
 


### PR DESCRIPTION
'make_payment_via_journal_entry' variable in the '__onload' object is not being set for Purchase Invoice due to an overriding method, hence the Make > Payment flow always goes to Payment Entry irrespective of what is set in Accounts Settings