### PR TITLE
fix: gst_state_number for address with Unregistered GST

### DIFF
--- a/erpnext/regional/india/utils.py
+++ b/erpnext/regional/india/utils.py
@@ -9,6 +9,8 @@ from erpnext.hr.utils import get_salary_assignment
 from erpnext.hr.doctype.salary_structure.salary_structure import make_salary_slip
 
 def validate_gstin_for_india(doc, method):
+	if hasattr(doc, 'gst_state') and doc.gst_state:
+		doc.gst_state_number = state_numbers[doc.gst_state]
 	if not hasattr(doc, 'gstin') or not doc.gstin:
 		return
 


### PR DESCRIPTION
While creating Sales Invoice for a customer who is GST Unregistered, Invoice Print does not show Place of Supply. Please refer this link: https://cleartax.in/s/place-of-supply-of-service-gst. In this link check General Rule for determining the Place of Supply.

Current Code:
If gst_state and gst_state_number of the Customer's address are not entered, the Place of Supply will not be set in Sales Invoice. The gst_state_code at Address level is set while validating the GST Number. But for an unregistered Customer GST Number will be null and hence gst_state_code will not be set even if the user has selected gst_state. So while creating Sales Invoice for Unregistered Customer, Place of Supply is not set.

Change:
Set gst_state_number in validate_gstin_for_india method even if GST Number is null