### PR TITLE
fix(regional,italy): replace decode with safe_decode

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -587,4 +587,4 @@ erpnext.patches.v11_1.setup_guardian_role
 execute:frappe.delete_doc('DocType', 'Notification Control')
 erpnext.patches.v11_0.remove_barcodes_field_from_copy_fields_to_variants
 erpnext.patches.v10_0.item_barcode_childtable_migrate # 16-02-2019
-erpnext.patches.v11_0.make_italian_localization_fields # 26-02-2019
+erpnext.patches.v11_0.make_italian_localization_fields # 28-02-2019

--- a/erpnext/regional/italy/setup.py
+++ b/erpnext/regional/italy/setup.py
@@ -32,12 +32,12 @@ def make_custom_fields(update=True):
 				fieldtype='Section Break', insert_after='date_of_establishment', print_hide=1),
 			dict(fieldname='fiscal_regime', label='Fiscal Regime',
 				fieldtype='Select', insert_after='sb_e_invoicing', print_hide=1,
-				options="\n".join(map(lambda x: x.decode('utf-8'), fiscal_regimes))),
+				options="\n".join(map(lambda x: frappe.safe_decode(x, encoding='utf-8'), fiscal_regimes))),
 			dict(fieldname='fiscal_code', label='Fiscal Code', fieldtype='Data', insert_after='fiscal_regime', print_hide=1,
 				description=_("Applicable if the company is an Individual or a Proprietorship")),
 			dict(fieldname='vat_collectability', label='VAT Collectability',
 				fieldtype='Select', insert_after='fiscal_code', print_hide=1,
-				options="\n".join(map(lambda x: x.decode('utf-8'), vat_collectability_options))),
+				options="\n".join(map(lambda x: frappe.safe_decode(x, encoding='utf-8'), vat_collectability_options))),
 			dict(fieldname='cb_e_invoicing1', fieldtype='Column Break', insert_after='vat_collectability', print_hide=1),
 			dict(fieldname='registrar_office_province', label='Province of the Registrar Office',
 				fieldtype='Data', insert_after='cb_e_invoicing1', print_hide=1, length=2),
@@ -57,7 +57,7 @@ def make_custom_fields(update=True):
 			dict(fieldname='tax_exemption_reason', label='Tax Exemption Reason',
 				fieldtype='Select', insert_after='included_in_print_rate', print_hide=1,
 				depends_on='eval:doc.charge_type!="Actual" && doc.rate==0.0',
-				options="\n" + "\n".join(map(lambda x: x.decode('utf-8'), tax_exemption_reasons))),
+				options="\n" + "\n".join(map(lambda x: frappe.safe_decode(x, encoding='utf-8'), tax_exemption_reasons))),
 			dict(fieldname='tax_exemption_law', label='Tax Exempt Under',
 				fieldtype='Text', insert_after='tax_exemption_reason', print_hide=1,
 				depends_on='eval:doc.charge_type!="Actual" && doc.rate==0.0')
@@ -80,12 +80,12 @@ def make_custom_fields(update=True):
 		'Mode of Payment': [
 			dict(fieldname='mode_of_payment_code', label='Code',
 			fieldtype='Select', insert_after='included_in_print_rate', print_hide=1,
-			options="\n".join(map(lambda x: x.decode('utf-8'), mode_of_payment_codes)))
+			options="\n".join(map(lambda x: frappe.safe_decode(x, encoding='utf-8'), mode_of_payment_codes)))
 		],
 		'Payment Schedule': [
 			dict(fieldname='mode_of_payment_code', label='Code',
 				fieldtype='Select', insert_after='mode_of_payment', print_hide=1,
-				options="\n".join(map(lambda x: x.decode('utf-8'), mode_of_payment_codes)),
+				options="\n".join(map(lambda x: frappe.safe_decode(x, encoding='utf-8'), mode_of_payment_codes)),
 				fetch_from="mode_of_payment.mode_of_payment_code", read_only=1),
 			dict(fieldname='bank_account', label='Bank Account',
 				fieldtype='Link', insert_after='mode_of_payment_code', print_hide=1,
@@ -103,7 +103,7 @@ def make_custom_fields(update=True):
 		"Sales Invoice": [
 			dict(fieldname='vat_collectability', label='VAT Collectability',
 				fieldtype='Select', insert_after='taxes_and_charges', print_hide=1,
-				options="\n".join(map(lambda x: x.decode('utf-8'), vat_collectability_options)),
+				options="\n".join(map(lambda x: frappe.safe_decode(x, encoding='utf-8'), vat_collectability_options)),
 				fetch_from="company.vat_collectability"),
 			dict(fieldname='sb_e_invoicing_reference', label='E-Invoicing',
 				fieldtype='Section Break', insert_after='pos_total_qty', print_hide=1),


### PR DESCRIPTION

The following error was encountered while updating the bench in a python 3.6.7 environment.

![decode_error_trace](https://user-images.githubusercontent.com/17795124/53574481-b6875880-3b95-11e9-84bb-cea93d05f928.png)

Replaced the offending `x.decode('utf-8')` with `frappe.safe_decode(x, encoding='utf-8')`