### PR TITLE
fix: Python 3 Sales Invoice Return Validation "validate_pos"

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -523,8 +523,8 @@ class SalesInvoice(SellingController):
 
 	def validate_pos(self):
 		if self.is_return:
-			if flt(self.paid_amount) + flt(self.write_off_amount) - flt(self.grand_total) < \
-				1/(10**(self.precision("grand_total") + 1)):
+			if flt(self.paid_amount) + flt(self.write_off_amount) - flt(self.grand_total) > \
+				1.0/(10.0**(self.precision("grand_total") + 1.0)):
 					frappe.throw(_("Paid amount + Write Off Amount can not be greater than Grand Total"))
 
 	def validate_item_code(self):


### PR DESCRIPTION
#16822 
We found that below formula in "validate_pos" is wrong.
This was working in Python 2.7 due to auto rounding of float to int.
`flt(self.paid_amount) + flt(self.write_off_amount) - flt(self.grand_total) < 1/(10**(self.precision("grand_total") + 1))`

The comparison is reversed. Correct formula should be
`flt(self.paid_amount) + flt(self.write_off_amount) - flt(self.grand_total) > 1.0/(10.0**(self.precision("grand_total") + 1.0))`