### PR TITLE
fix: Add date to currency exchange caching

### DIFF
--- a/erpnext/setup/utils.py
+++ b/erpnext/setup/utils.py
@@ -93,7 +93,7 @@ def get_exchange_rate(from_currency, to_currency, transaction_date=None, args=No
 
 	try:
 		cache = frappe.cache()
-		key = "currency_exchange_rate:{0}:{1}".format(from_currency, to_currency)
+		key = "currency_exchange_rate_{0}:{1}:{2}".format(transaction_date,from_currency, to_currency)
 		value = cache.get(key)
 
 		if not value:


### PR DESCRIPTION
The current currency exchange caching does not keep track of the transaction date, so if you are backdating transactions, the system probably isn't pulling the correct exchange rate (if it's looking up the currency exchange rate on the fly)

Please read the pull request checklist to make sure your changes are merged: https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

