### PR TITLE
fix: Removed relieving date validation form additional salary

### DIFF
--- a/erpnext/hr/doctype/additional_salary/additional_salary.py
+++ b/erpnext/hr/doctype/additional_salary/additional_salary.py
@@ -19,8 +19,6 @@ class AdditionalSalary(Document):
 			["date_of_joining", "relieving_date"])
  		if date_of_joining and getdate(self.payroll_date) < getdate(date_of_joining):
  			frappe.throw(_("Payroll date can not be less than employee's joining date"))
- 		elif relieving_date and getdate(self.payroll_date) > getdate(relieving_date):
- 			frappe.throw(_("To date can not greater than employee's relieving date"))
 
 	def get_amount(self, sal_start_date, sal_end_date):
 		start_date = getdate(sal_start_date)


### PR DESCRIPTION
There is no relation to a person leaving the company and his salary given after he leaves at the end of the month.

It is an industry practice that once an employee leaves, his/ her salary (in other words F&F) is paid after 30 - 45 days, cant keep the employee active till his salary is paid.

