### PR TITLE
fix: purchase receipt not able to submit because default inventory account has not selected in another company

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -222,7 +222,7 @@ class PurchaseInvoice(BuyingController):
 			self.validate_item_code()
 			self.validate_warehouse()
 			if auto_accounting_for_stock:
-				warehouse_account = get_warehouse_account_map()
+				warehouse_account = get_warehouse_account_map(self.company)
 
 		for item in self.get("items"):
 			# in case of auto inventory accounting,
@@ -366,7 +366,8 @@ class PurchaseInvoice(BuyingController):
 			if repost_future_gle and cint(self.update_stock) and self.auto_accounting_for_stock:
 				from erpnext.controllers.stock_controller import update_gl_entries_after
 				items, warehouses = self.get_items_and_warehouses()
-				update_gl_entries_after(self.posting_date, self.posting_time, warehouses, items)
+				update_gl_entries_after(self.posting_date, self.posting_time,
+					warehouses, items, company = self.company)
 
 		elif self.docstatus == 2 and cint(self.update_stock) and self.auto_accounting_for_stock:
 			delete_gl_entries(voucher_type=self.doctype, voucher_no=self.name)
@@ -423,7 +424,7 @@ class PurchaseInvoice(BuyingController):
 		stock_items = self.get_stock_items()
 		expenses_included_in_valuation = self.get_company_default("expenses_included_in_valuation")
 		if self.update_stock and self.auto_accounting_for_stock:
-			warehouse_account = get_warehouse_account_map()
+			warehouse_account = get_warehouse_account_map(self.company)
 
 		voucher_wise_stock_value = {}
 		if self.update_stock:

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -695,7 +695,8 @@ class SalesInvoice(SellingController):
 			if repost_future_gle and cint(self.update_stock) \
 				and cint(auto_accounting_for_stock):
 					items, warehouses = self.get_items_and_warehouses()
-					update_gl_entries_after(self.posting_date, self.posting_time, warehouses, items)
+					update_gl_entries_after(self.posting_date, self.posting_time,
+						warehouses, items, company = self.company)
 		elif self.docstatus == 2 and cint(self.update_stock) \
 			and cint(auto_accounting_for_stock):
 				from erpnext.accounts.general_ledger import delete_gl_entries

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -544,14 +544,14 @@ def fix_total_debit_credit():
 				(dr_or_cr, dr_or_cr, '%s', '%s', '%s', dr_or_cr),
 				(d.diff, d.voucher_type, d.voucher_no))
 
-def get_stock_and_account_difference(account_list=None, posting_date=None):
+def get_stock_and_account_difference(account_list=None, posting_date=None, company=None):
 	from erpnext.stock.utils import get_stock_value_on
 	from erpnext.stock import get_warehouse_account_map
 
 	if not posting_date: posting_date = nowdate()
 
 	difference = {}
-	warehouse_account = get_warehouse_account_map()
+	warehouse_account = get_warehouse_account_map(company)
 
 	for warehouse, account_data in iteritems(warehouse_account):
 		if account_data.get('account') in account_list:

--- a/erpnext/patches/v7_0/repost_future_gle_for_purchase_invoice.py
+++ b/erpnext/patches/v7_0/repost_future_gle_for_purchase_invoice.py
@@ -10,14 +10,15 @@ from erpnext.controllers.stock_controller import update_gl_entries_after
 def execute():
 	company_list = frappe.db.sql_list("""Select name from tabCompany where enable_perpetual_inventory = 1""")
 	frappe.reload_doc('accounts', 'doctype', 'sales_invoice')
-	
-	frappe.reload_doctype("Purchase Invoice")	
+
+	frappe.reload_doctype("Purchase Invoice")
 	wh_account = get_warehouse_account_map()
-	
+
 	for pi in frappe.get_all("Purchase Invoice", fields=["name", "company"], filters={"docstatus": 1, "update_stock": 1}):
 		if pi.company in company_list:
 			pi_doc = frappe.get_doc("Purchase Invoice", pi.name)
 			items, warehouses = pi_doc.get_items_and_warehouses()
-			update_gl_entries_after(pi_doc.posting_date, pi_doc.posting_time, warehouses, items, wh_account)
-		
+			update_gl_entries_after(pi_doc.posting_date, pi_doc.posting_time,
+				warehouses, items, wh_account, company = pi.company)
+
 			frappe.db.commit()

--- a/erpnext/stock/__init__.py
+++ b/erpnext/stock/__init__.py
@@ -8,16 +8,21 @@ install_docs = [
 	{"doctype":"Role", "role_name":"Stock User", "name":"Stock User"},
 	{"doctype":"Role", "role_name":"Quality Manager", "name":"Quality Manager"},
 	{"doctype":"Item Group", "item_group_name":"All Item Groups", "is_group": 1},
-	{"doctype":"Item Group", "item_group_name":"Default", 
+	{"doctype":"Item Group", "item_group_name":"Default",
 		"parent_item_group":"All Item Groups", "is_group": 0},
 ]
 
-def get_warehouse_account_map():
+def get_warehouse_account_map(company=None):
 	if not frappe.flags.warehouse_account_map or frappe.flags.in_test:
 		warehouse_account = frappe._dict()
 
+		filters = {}
+		if company:
+			filters['company'] = company
+
 		for d in frappe.get_all('Warehouse',
 			fields = ["name", "account", "parent_warehouse", "company"],
+			filters = filters,
 			order_by="lft, rgt"):
 			if not d.account:
 				d.account = get_warehouse_account(d, warehouse_account)
@@ -57,6 +62,6 @@ def get_warehouse_account(warehouse, warehouse_account=None):
 		frappe.throw(_("Please set Account in Warehouse {0} or Default Inventory Account in Company {1}")
 			.format(warehouse.name, warehouse.company))
 	return account
-	
+
 def get_company_default_inventory_account(company):
 	return frappe.get_cached_value('Company',  company,  'default_inventory_account')


### PR DESCRIPTION
**Issue**
1. Created two companies Company A, KJHJ(no default inventory account)
1. Now when trying to create purchase receipt against company A system throwing an error default inventory account has to set in the company  KJHJ

![screen shot 2019-03-08 at 10 59 25 am](https://user-images.githubusercontent.com/8780500/54010114-85a9b380-4193-11e9-8a45-99251e2fe17f.png)
