### PR TITLE
fixes:(Account Receivable/Payable report) for returned debit/credit note with self ref

### DIFF
--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -381,7 +381,7 @@ class ReceivablePayableReport(object):
 		return (
 			# advance
 			(not gle.against_voucher) or
-			
+
 			# advance amount with returned invoice without any ref
 			(gle.against_voucher and gle.against_voucher==gle.voucher_no) or
 

--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -381,6 +381,9 @@ class ReceivablePayableReport(object):
 		return (
 			# advance
 			(not gle.against_voucher) or
+			
+			# advance amount with returned invoice without any ref
+			(gle.against_voucher and gle.against_voucher==gle.voucher_no) or
 
 			# against sales order/purchase order
 			(gle.against_voucher_type in ["Sales Order", "Purchase Order"]) or

--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -384,7 +384,7 @@ class ReceivablePayableReport(object):
 			
 			# advance amount with returned invoice without any ref
 			(gle.against_voucher and gle.against_voucher==gle.voucher_no) or
-			
+
 			# against sales order/purchase order
 			(gle.against_voucher_type in ["Sales Order", "Purchase Order"]) or
 

--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -384,7 +384,7 @@ class ReceivablePayableReport(object):
 			
 			# advance amount with returned invoice without any ref
 			(gle.against_voucher and gle.against_voucher==gle.voucher_no) or
-
+			
 			# against sales order/purchase order
 			(gle.against_voucher_type in ["Sales Order", "Purchase Order"]) or
 


### PR DESCRIPTION
Account Receivable/Payable report should show Advanced paid amount if it's returned invoice without any ref voucher no.

