### PR TITLE
fix: Update Training Level

### DIFF
--- a/erpnext/hr/doctype/training_event/training_event.json
+++ b/erpnext/hr/doctype/training_event/training_event.json
@@ -214,7 +214,7 @@
    "label": "Level", 
    "length": 0, 
    "no_copy": 0, 
-   "options": "\nBeginner\nExpert\nAdvance", 
+   "options": "\nBeginner\nIntermediate\nAdvance", 
    "permlevel": 0, 
    "precision": "", 
    "print_hide": 0, 

--- a/erpnext/hr/doctype/training_event/training_event.json
+++ b/erpnext/hr/doctype/training_event/training_event.json
@@ -809,7 +809,7 @@
  "issingle": 0, 
  "istable": 0, 
  "max_attachments": 0, 
- "modified": "2017-10-23 06:13:29.065781", 
+ "modified": "2019-03-12 10:56:29.065781", 
  "modified_by": "Administrator", 
  "module": "HR", 
  "name": "Training Event", 


### PR DESCRIPTION
- Rename Expert to Intermediate, since it was ambiguous with Advance


