### PR TITLE
fix(Invoice Creation Tool): Disable P/L validation for opening invoice creation

### DIFF
--- a/erpnext/accounts/doctype/gl_entry/gl_entry.py
+++ b/erpnext/accounts/doctype/gl_entry/gl_entry.py
@@ -74,7 +74,8 @@ class GLEntry(Document):
 
 	def check_pl_account(self):
 		if self.is_opening=='Yes' and \
-				frappe.db.get_value("Account", self.account, "report_type")=="Profit and Loss":
+				frappe.db.get_value("Account", self.account, "report_type")=="Profit and Loss" and \
+				self.voucher_type not in ['Purchase Invoice', 'Sales Invoice']:
 			frappe.throw(_("{0} {1}: 'Profit and Loss' type account {2} not allowed in Opening Entry")
 				.format(self.voucher_type, self.voucher_no, self.account))
 


### PR DESCRIPTION
When adding a decimal value in the opening invoice creation tool, system validates it with a Profit n Loss account. This prevents users from opening invoices with any decimal values.

Before fix :

![kapnUc4](https://user-images.githubusercontent.com/7310479/54512641-e21e8700-497a-11e9-9119-b86f4de7a215.png)

After fix :

![invoice-creration](https://user-images.githubusercontent.com/7310479/54512660-f2cefd00-497a-11e9-9f95-c649f8543cd5.gif)
