### PR TITLE
fix: Hardcoded link added to node_modules

### DIFF
--- a/erpnext/public/.gitignore
+++ b/erpnext/public/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/erpnext/public/node_modules
+++ b/erpnext/public/node_modules
@@ -1,1 +1,0 @@
-/Users/netchampfaris/frappe-bench/apps/erpnext/node_modules


### PR DESCRIPTION
Fixes https://github.com/frappe/erpnext/issues/16970

