### PR TITLE
fix: Show consolidated amount of payment entries in Bank reconciliation

### DIFF
--- a/erpnext/accounts/doctype/bank_reconciliation/bank_reconciliation.py
+++ b/erpnext/accounts/doctype/bank_reconciliation/bank_reconciliation.py
@@ -79,8 +79,12 @@ class BankReconciliation(Document):
 
 		for d in entries:
 			row = self.append('payment_entries', {})
-			amount = d.debit if d.debit else d.credit
-			d.amount = fmt_money(amount, 2, d.account_currency) + " " + (_("Dr") if d.debit else _("Cr"))
+
+			amount = d.get('debit', 0) - d.get('credit', 0)
+
+			formatted_amount = fmt_money(abs(amount), 2, d.account_currency)
+			d.amount = formatted_amount + " " + (_("Dr") if amount > 0 else _("Cr"))
+
 			d.pop("credit")
 			d.pop("debit")
 			d.pop("account_currency")


### PR DESCRIPTION
A bank account can have credit and debit transaction with the same reference number.
<img width="982" alt="Screenshot 2019-03-22 at 2 42 34 PM" src="https://user-images.githubusercontent.com/13928957/54812367-f6cb8980-4cb0-11e9-97f8-09eaa018c0f1.png">

Previously, while getting entries for reconciliation, we used to get only the sum of credit or debit.
<img width="1107" alt="Screenshot 2019-03-22 at 2 43 41 PM" src="https://user-images.githubusercontent.com/13928957/54812384-05b23c00-4cb1-11e9-892c-bffc21266e8f.png">

This fix gets the amount after consolidating the credit and debit transactions.
<img width="1122" alt="Screenshot 2019-03-22 at 2 40 04 PM" src="https://user-images.githubusercontent.com/13928957/54812409-1367c180-4cb1-11e9-86cf-cc09f43bab79.png">

