### PR TITLE
fix(Italy Customisation): Include fiscal code in invoice xml if present

### DIFF
--- a/erpnext/regional/italy/e-invoice.xml
+++ b/erpnext/regional/italy/e-invoice.xml
@@ -95,13 +95,13 @@
             <Cognome>{{ doc.customer_data.last_name }}</Cognome>
           </Anagrafica>
         {%- else %}
-          {%- if doc.customer_data.fiscal_code %}
-            <CodiceFiscale>{{ doc.customer_data.fiscal_code }}</CodiceFiscale>
-          {%- endif %}
           <IdFiscaleIVA>
             <IdPaese>{{ doc.customer_address_data.country_code }}</IdPaese>
             <IdCodice>{{ doc.tax_id | replace("IT","") }}</IdCodice>
           </IdFiscaleIVA>
+          {%- if doc.customer_data.fiscal_code %}
+          <CodiceFiscale>{{ doc.customer_data.fiscal_code }}</CodiceFiscale>
+          {%- endif %}
           <Anagrafica>
             <Denominazione>{{ doc.customer_name }}</Denominazione>
           </Anagrafica>

--- a/erpnext/regional/italy/e-invoice.xml
+++ b/erpnext/regional/italy/e-invoice.xml
@@ -95,14 +95,13 @@
             <Cognome>{{ doc.customer_data.last_name }}</Cognome>
           </Anagrafica>
         {%- else %}
-          {%- if doc.customer_data.is_public_administration %}
-          <CodiceFiscale>{{ doc.customer_data.fiscal_code }}</CodiceFiscale>
-          {%- else %}
+          {%- if doc.customer_data.fiscal_code %}
+            <CodiceFiscale>{{ doc.customer_data.fiscal_code }}</CodiceFiscale>
+          {%- endif %}
           <IdFiscaleIVA>
             <IdPaese>{{ doc.customer_address_data.country_code }}</IdPaese>
             <IdCodice>{{ doc.tax_id | replace("IT","") }}</IdCodice>
           </IdFiscaleIVA>
-          {%- endif %}
           <Anagrafica>
             <Denominazione>{{ doc.customer_name }}</Denominazione>
           </Anagrafica>


### PR DESCRIPTION
Before
Fiscal Code missing in the customer
![image0012b2519](https://user-images.githubusercontent.com/7310479/54822913-21770b80-4ccc-11e9-80ff-2198f8fc675c.png)

After
Fiscal Code included in the customer if present
![Screenshot 2019-03-22 at 5 56 16 PM](https://user-images.githubusercontent.com/7310479/54822938-394e8f80-4ccc-11e9-934c-d997ec638fec.png)
