### PR TITLE
fix: Task overdue status propagates to project

### DIFF
--- a/erpnext/projects/doctype/task/task.py
+++ b/erpnext/projects/doctype/task/task.py
@@ -160,7 +160,7 @@ class Task(NestedSet):
 		self.update_nsm_model()
 
 	def update_status(self):
-		if self.status not in ('Cancelled', 'Closed'):
+		if self.status not in ('Cancelled', 'Closed') and self.exp_end_date:
 			from datetime import datetime
 			if self.exp_end_date < datetime.now().date():
 				self.date = 'Overdue'
@@ -193,7 +193,7 @@ def set_multiple_status(names, status):
 		task.save()
 
 def set_tasks_as_overdue():
-	tasks = frappe.get_all("Task")
+	tasks = frappe.get_all("Task", filters={'status':['not in',['Cancelled', 'Closed']]})
 	for task in tasks:
 		frappe.get_doc("Task", task.name).update_status()
 

--- a/erpnext/projects/doctype/task/task.py
+++ b/erpnext/projects/doctype/task/task.py
@@ -163,7 +163,8 @@ class Task(NestedSet):
 		if self.status not in ('Cancelled', 'Closed') and self.exp_end_date:
 			from datetime import datetime
 			if self.exp_end_date < datetime.now().date():
-				self.date = 'Overdue'
+				print(self.subject)
+				self.status = 'Overdue'
 				self.save()
 
 @frappe.whitelist()

--- a/erpnext/projects/doctype/task/task.py
+++ b/erpnext/projects/doctype/task/task.py
@@ -163,9 +163,8 @@ class Task(NestedSet):
 		if self.status not in ('Cancelled', 'Closed') and self.exp_end_date:
 			from datetime import datetime
 			if self.exp_end_date < datetime.now().date():
-				print(self.subject)
-				self.status = 'Overdue'
-				self.save()
+				self.db_set('status', 'Overdue')
+				self.update_project()
 
 @frappe.whitelist()
 def check_if_child_exists(name):

--- a/erpnext/projects/doctype/task/task.py
+++ b/erpnext/projects/doctype/task/task.py
@@ -159,6 +159,13 @@ class Task(NestedSet):
 
 		self.update_nsm_model()
 
+	def update_status(self):
+		if self.status not in ('Cancelled', 'Closed'):
+			from datetime import datetime
+			if self.exp_end_date < datetime.now().date():
+				self.date = 'Overdue'
+				self.save()
+
 @frappe.whitelist()
 def check_if_child_exists(name):
 	child_tasks = frappe.get_all("Task", filters={"parent_task": name})
@@ -186,10 +193,9 @@ def set_multiple_status(names, status):
 		task.save()
 
 def set_tasks_as_overdue():
-	frappe.db.sql("""update tabTask set `status`='Overdue'
-		where exp_end_date is not null
-		and exp_end_date < CURDATE()
-		and `status` not in ('Closed', 'Cancelled')""")
+	tasks = frappe.get_all("Task")
+	for task in tasks:
+		frappe.get_doc("Task", task.name).update_status()
 
 @frappe.whitelist()
 def get_children(doctype, parent, task=None, project=None, is_root=False):

--- a/erpnext/projects/doctype/task/test_task.py
+++ b/erpnext/projects/doctype/task/test_task.py
@@ -104,7 +104,7 @@ def create_task(subject, start=None, end=None, depends_on=None, project=None, sa
 		task.subject = subject
 		task.exp_start_date = start or nowdate()
 		task.exp_end_date = end or nowdate()
-		# task.project = project or "_Test Project"
+		task.project = project or "_Test Project"
 		if save:
 			task.save()
 	else:

--- a/erpnext/projects/doctype/task/test_task.py
+++ b/erpnext/projects/doctype/task/test_task.py
@@ -104,7 +104,7 @@ def create_task(subject, start=None, end=None, depends_on=None, project=None, sa
 		task.subject = subject
 		task.exp_start_date = start or nowdate()
 		task.exp_end_date = end or nowdate()
-		task.project = project or "_Test Project"
+		# task.project = project or "_Test Project"
 		if save:
 			task.save()
 	else:


### PR DESCRIPTION
## Issue
The task of the Project shows Open as the status but when opened from Task List, it says Overdue.
The status of the Tasks are not fetching.
![LbOii6N](https://user-images.githubusercontent.com/18097732/54879743-9da35780-4e62-11e9-9284-39cda5fded95.png)


## Changes Made
- Used ORM instead of a SQL for set_task_as_overdue
- update_status function compares the time and marks the appropriate task as overdue
- The on_update hook makes the changes in project as well

