### PR TITLE
fix: task overdue status propagates to project

### DIFF
--- a/erpnext/projects/doctype/task/task.py
+++ b/erpnext/projects/doctype/task/task.py
@@ -166,7 +166,7 @@ class Task(NestedSet):
 		self.update_nsm_model()
 
 	def update_status(self):
-		if self.status not in ('Cancelled', 'Completed'):
+		if self.status not in ('Cancelled', 'Completed') and self.exp_end_date:
 			from datetime import datetime
 			if self.exp_end_date < datetime.now().date():
 				self.date = 'Overdue'

--- a/erpnext/projects/doctype/task/task.py
+++ b/erpnext/projects/doctype/task/task.py
@@ -169,8 +169,8 @@ class Task(NestedSet):
 		if self.status not in ('Cancelled', 'Completed') and self.exp_end_date:
 			from datetime import datetime
 			if self.exp_end_date < datetime.now().date():
-				self.status = 'Overdue'
-				self.save()
+				self.db_set('status', 'Overdue')
+				self.update_project()
 
 @frappe.whitelist()
 def check_if_child_exists(name):

--- a/erpnext/projects/doctype/task/task.py
+++ b/erpnext/projects/doctype/task/task.py
@@ -203,7 +203,7 @@ def set_multiple_status(names, status):
 		task.save()
 
 def set_tasks_as_overdue():
-	tasks = frappe.get_all("Task")
+	tasks = frappe.get_all("Task", filters={'status':['not in',['Cancelled', 'Completed']]})
 	for task in tasks:
 		frappe.get_doc("Task", task.name).update_status()
 

--- a/erpnext/projects/doctype/task/task.py
+++ b/erpnext/projects/doctype/task/task.py
@@ -165,6 +165,13 @@ class Task(NestedSet):
 
 		self.update_nsm_model()
 
+	def update_status(self):
+		if self.status not in ('Cancelled', 'Completed'):
+			from datetime import datetime
+			if self.exp_end_date < datetime.now().date():
+				self.date = 'Overdue'
+				self.save()
+
 @frappe.whitelist()
 def check_if_child_exists(name):
 	child_tasks = frappe.get_all("Task", filters={"parent_task": name})
@@ -196,10 +203,9 @@ def set_multiple_status(names, status):
 		task.save()
 
 def set_tasks_as_overdue():
-	frappe.db.sql("""update tabTask set `status`='Overdue'
-		where exp_end_date is not null
-		and exp_end_date < CURDATE()
-		and `status` not in ('Completed', 'Cancelled')""")
+	tasks = frappe.get_all("Task")
+	for task in tasks:
+		frappe.get_doc("Task", task.name).update_status()
 
 @frappe.whitelist()
 def get_children(doctype, parent, task=None, project=None, is_root=False):

--- a/erpnext/projects/doctype/task/task.py
+++ b/erpnext/projects/doctype/task/task.py
@@ -169,7 +169,7 @@ class Task(NestedSet):
 		if self.status not in ('Cancelled', 'Completed') and self.exp_end_date:
 			from datetime import datetime
 			if self.exp_end_date < datetime.now().date():
-				self.date = 'Overdue'
+				self.status = 'Overdue'
 				self.save()
 
 @frappe.whitelist()


### PR DESCRIPTION
Same as https://github.com/frappe/erpnext/pull/17000

## Issue
The task of the Project shows Open as the status but when opened from Task List, it says Overdue.
The status of the Tasks are not fetching.
![LbOii6N](https://user-images.githubusercontent.com/18097732/54879743-9da35780-4e62-11e9-9284-39cda5fded95.png)


## Changes Made
- Used ORM instead of a SQL for set_task_as_overdue
- update_status function compares the time and marks the appropriate task as overdue
- The on_update hook makes the changes in project as well
