### PR TITLE
fix: Reorder currency column

### DIFF
--- a/erpnext/accounts/report/profitability_analysis/profitability_analysis.py
+++ b/erpnext/accounts/report/profitability_analysis/profitability_analysis.py
@@ -134,6 +134,13 @@ def get_columns(filters):
 			"width": 300
 		},
 		{
+			"fieldname": "currency",
+			"label": _("Currency"),
+			"fieldtype": "Link",
+			"options": "Currency",
+			"hidden": 1
+		},
+		{
 			"fieldname": "income",
 			"label": _("Income"),
 			"fieldtype": "Currency",
@@ -153,13 +160,6 @@ def get_columns(filters):
 			"fieldtype": "Currency",
 			"options": "currency",
 			"width": 120
-		},
-		{
-			"fieldname": "currency",
-			"label": _("Currency"),
-			"fieldtype": "Link",
-			"options": "Currency",
-			"hidden": 1
 		}
 	]
 


### PR DESCRIPTION
Every Financial Report's 2nd column is Currency, which is an implicit requirement to Print them properly. In this case, Income column was not printed. This fixes that.

![profitability-analysis-print](https://user-images.githubusercontent.com/9355208/54344908-eccdd900-4667-11e9-99f7-4dd93645f016.gif)


