### PR TITLE
fix(print): Fix group same items for print view

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -52,11 +52,6 @@ class JournalEntry(AccountsController):
 		self.update_loan()
 		self.update_inter_company_jv()
 
-	def before_print(self):
-		self.gl_entries = frappe.get_list("GL Entry",filters={"voucher_type": "Journal Entry",
-			"voucher_no": self.name} ,
-			fields=["account", "party_type", "party", "debit", "credit", "remarks"]
-		)
 
 	def get_title(self):
 		return self.pay_to_recd_from or self.accounts[0].account

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -70,11 +70,6 @@ class PaymentEntry(AccountsController):
 		self.update_advance_paid()
 		self.update_expense_claim()
 
-	def before_print(self):
-		self.gl_entries = frappe.get_list("GL Entry",filters={"voucher_type": "Payment Entry",
-			"voucher_no": self.name} ,
-			fields=["account", "party_type", "party", "debit", "credit", "remarks"]
-		)
 
 	def on_cancel(self):
 		self.setup_party_account_field()

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -55,11 +55,6 @@ class PurchaseInvoice(BuyingController):
 		if not self.on_hold:
 			self.release_date = ''
 
-	def before_print(self):
-		self.gl_entries = frappe.get_list("GL Entry",filters={"voucher_type": "Purchase Invoice",
-			"voucher_no": self.name} ,
-			fields=["account", "party_type", "party", "debit", "credit"]
-		)
 
 	def invoice_is_blocked(self):
 		return self.on_hold and (not self.release_date or self.release_date > getdate(nowdate()))

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -205,11 +205,6 @@ class SalesInvoice(SellingController):
 	def before_cancel(self):
 		self.update_time_sheet(None)
 
-	def before_print(self):
-		self.gl_entries = frappe.get_list("GL Entry",filters={"voucher_type": "Sales Invoice",
-			"voucher_no": self.name} ,
-			fields=["account", "party_type", "party", "debit", "credit"]
-		)
 
 	def on_cancel(self):
 		self.check_close_sales_order("sales_order")

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -116,6 +116,13 @@ class AccountsController(TransactionBase):
 			self.validate_non_invoice_documents_schedule()
 
 	def before_print(self):
+		if self.doctype in ['Journal Entry', 'Payment Entry', 'Sales Invoice', 'Purchase Invoice']:
+			self.gl_entries = frappe.get_list("GL Entry", filters={
+				"voucher_type": self.doctype,
+				"voucher_no": self.name} ,
+				fields=["account", "party_type", "party", "debit", "credit", "remarks"]
+			)
+
 		if self.doctype in ['Purchase Order', 'Sales Order', 'Sales Invoice', 'Purchase Invoice',
 							'Supplier Quotation', 'Purchase Receipt', 'Delivery Note', 'Quotation']:
 			if self.get("group_same_items"):

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -119,9 +119,8 @@ class AccountsController(TransactionBase):
 		if self.doctype in ['Journal Entry', 'Payment Entry', 'Sales Invoice', 'Purchase Invoice']:
 			self.gl_entries = frappe.get_list("GL Entry", filters={
 				"voucher_type": self.doctype,
-				"voucher_no": self.name} ,
-				fields=["account", "party_type", "party", "debit", "credit", "remarks"]
-			)
+				"voucher_no": self.name
+			}, fields=["account", "party_type", "party", "debit", "credit", "remarks"])
 
 		if self.doctype in ['Purchase Order', 'Sales Order', 'Sales Invoice', 'Purchase Invoice',
 							'Supplier Quotation', 'Purchase Receipt', 'Delivery Note', 'Quotation']:


### PR DESCRIPTION
Commonify attach `gl_entries` code by moving it to accounts_controller, this also fixes the problem on not grouping the same items in the print view

**Before**
even if **Group Same Items** was checked
<img width="1189" alt="Screenshot 2019-03-27 at 8 28 31 PM" src="https://user-images.githubusercontent.com/13928957/55087605-5b7f4d80-50d0-11e9-88ed-7e85e70ce883.png">


**After**
<img width="1195" alt="Screenshot 2019-03-27 at 8 31 43 PM" src="https://user-images.githubusercontent.com/13928957/55087544-486c7d80-50d0-11e9-89fb-4fae44620045.png">


The bug was introduced in [this PR](https://github.com/frappe/erpnext/pull/16704)


