### PR TITLE
fix: Missing "and" in filter conditions

### DIFF
--- a/erpnext/hr/doctype/leave_application/leave_application.py
+++ b/erpnext/hr/doctype/leave_application/leave_application.py
@@ -512,7 +512,7 @@ def add_department_leaves(events, start, end, employee, company):
 	department_employees = frappe.db.sql_list("""select name from tabEmployee where department=%s
 		and company=%s""", (department, company))
 
-	filter_conditions = "employee in (\"%s\")" % '", "'.join(department_employees)
+	filter_conditions = " and employee in (\"%s\")" % '", "'.join(department_employees)
 	add_leaves(events, start, end, filter_conditions=filter_conditions)
 
 def add_leaves(events, start, end, filter_conditions=None):


### PR DESCRIPTION

I hope we get a better way to write queries than concatenating strings @adityahase 