### PR TITLE
fix: Subquery in get_bom_items method

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -618,7 +618,7 @@ def get_bom_items_as_dict(bom, company, qty=1, fetch_exploded=1, fetch_scrap_ite
 			is_stock_item=is_stock_item,
 			qty_field="stock_qty",
 			select_columns = """, bom_item.source_warehouse, bom_item.operation, bom_item.include_item_in_manufacturing,
-				(Select idx from `tabBOM Item` where item_code = bom_item.item_code and parent = %(parent)s ) as idx""")
+				(Select idx from `tabBOM Item` where item_code = bom_item.item_code and parent = %(parent)s limit 1) as idx""")
 
 		items = frappe.db.sql(query, { "parent": bom, "qty": qty, "bom": bom, "company": company }, as_dict=True)
 	elif fetch_scrap_items:


### PR DESCRIPTION
Fixes the following issue while fetching items from BOM which has duplicate item entries (possible if BOM has "Allow Same Item Multiple Times" checked)

```
Traceback (most recent call last):
  File &quot;/home/frappe/benches/bench-2019-03-28/apps/frappe/frappe/app.py&quot;, line 61, in application
    response = frappe.handler.handle()
  File &quot;/home/frappe/benches/bench-2019-03-28/apps/frappe/frappe/handler.py&quot;, line 21, in handle
    data = execute_cmd(cmd)
  File &quot;/home/frappe/benches/bench-2019-03-28/apps/frappe/frappe/handler.py&quot;, line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File &quot;/home/frappe/benches/bench-2019-03-28/apps/frappe/frappe/__init__.py&quot;, line 1028, in call
    return fn(*args, **newargs)
  File &quot;/home/frappe/benches/bench-2019-03-28/apps/erpnext/erpnext/manufacturing/doctype/bom/bom.py&quot;, line 650, in get_bom_items
    items = get_bom_items_as_dict(bom, company, qty, fetch_exploded, include_non_stock_items=True).values()
  File &quot;/home/frappe/benches/bench-2019-03-28/apps/erpnext/erpnext/manufacturing/doctype/bom/bom.py&quot;, line 623, in get_bom_items_as_dict
    items = frappe.db.sql(query, { &quot;parent&quot;: bom, &quot;qty&quot;: qty, &quot;bom&quot;: bom, &quot;company&quot;: company }, as_dict=True)
  File &quot;/home/frappe/benches/bench-2019-03-28/apps/frappe/frappe/database.py&quot;, line 199, in sql
    self._cursor.execute(query, values)
  File &quot;/home/frappe/benches/bench-2019-03-28/env/lib/python2.7/site-packages/pymysql/cursors.py&quot;, line 170, in execute
    result = self._query(query)
  File &quot;/home/frappe/benches/bench-2019-03-28/env/lib/python2.7/site-packages/pymysql/cursors.py&quot;, line 328, in _query
    conn.query(q)
  File &quot;/home/frappe/benches/bench-2019-03-28/env/lib/python2.7/site-packages/pymysql/connections.py&quot;, line 517, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File &quot;/home/frappe/benches/bench-2019-03-28/env/lib/python2.7/site-packages/pymysql/connections.py&quot;, line 732, in _read_query_result
    result.read()
  File &quot;/home/frappe/benches/bench-2019-03-28/env/lib/python2.7/site-packages/pymysql/connections.py&quot;, line 1082, in read
    self._read_result_packet(first_packet)
  File &quot;/home/frappe/benches/bench-2019-03-28/env/lib/python2.7/site-packages/pymysql/connections.py&quot;, line 1152, in _read_result_packet
    self._read_rowdata_packet()
  File &quot;/home/frappe/benches/bench-2019-03-28/env/lib/python2.7/site-packages/pymysql/connections.py&quot;, line 1186, in _read_rowdata_packet
    packet = self.connection._read_packet()
  File &quot;/home/frappe/benches/bench-2019-03-28/env/lib/python2.7/site-packages/pymysql/connections.py&quot;, line 684, in _read_packet
    packet.check_error()
  File &quot;/home/frappe/benches/bench-2019-03-28/env/lib/python2.7/site-packages/pymysql/protocol.py&quot;, line 220, in check_error
    err.raise_mysql_exception(self._data)
  File &quot;/home/frappe/benches/bench-2019-03-28/env/lib/python2.7/site-packages/pymysql/err.py&quot;, line 109, in raise_mysql_exception
    raise errorclass(errno, errval)
InternalError: (1242, u&apos;Subquery returns more than 1 row&apos;)
```

