### PR TITLE
fix: user not able to create chart of account in parent if child has no chart of account

### DIFF
--- a/erpnext/accounts/doctype/account/account.py
+++ b/erpnext/accounts/doctype/account/account.py
@@ -112,6 +112,8 @@ class Account(NestedSet):
 				["company", "name"], as_dict=True):
 				acc_name_map[d["company"]] = d["name"]
 
+			if not acc_name_map: return
+
 			for company in descendants:
 				doc = frappe.copy_doc(self)
 				doc.flags.ignore_root_company_validation = True


### PR DESCRIPTION
**Issue**

![Screen Shot 2019-03-29 at 7 01 02 pm](https://user-images.githubusercontent.com/8780500/55237302-df177680-5257-11e9-89e6-54b24a70e522.png)
