### PR TITLE
fix: spelling in validation message for Auto-reorder

### DIFF
--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -529,7 +529,7 @@ class Item(WebsiteGenerator):
 			if d.get("warehouse") and d.get("warehouse") not in warehouse:
 				warehouse += [d.get("warehouse")]
 			else:
-				frappe.throw(_("Row {0}: An Reorder entry already exists for this warehouse {1}")
+				frappe.throw(_("Row {0}: A Reorder entry already exists for this warehouse {1}")
                                     .format(d.idx, d.warehouse), DuplicateReorderRows)
 
 			if d.warehouse_reorder_level and not d.warehouse_reorder_qty:

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -529,7 +529,7 @@ class Item(WebsiteGenerator):
 			if d.get("warehouse") and d.get("warehouse") not in warehouse:
 				warehouse += [d.get("warehouse")]
 			else:
-				frappe.throw(_("Row {0}: A Reorder entry already exists for this warehouse {1}")
+				frappe.throw(_("Row {0}: Reorder entry already exists for the warehouse {1}")
                                     .format(d.idx, d.warehouse), DuplicateReorderRows)
 
 			if d.warehouse_reorder_level and not d.warehouse_reorder_qty:


### PR DESCRIPTION
Before:

![Screenshot 2019-03-30 at 2 39 15 PM](https://user-images.githubusercontent.com/33246109/55274714-6ec52f80-5301-11e9-9c58-e133f829a18b.png)

After:

![Screenshot 2019-03-30 at 3 15 06 PM](https://user-images.githubusercontent.com/33246109/55274718-771d6a80-5301-11e9-889d-62ab1b090aa1.png)
