### PR TITLE
syntax error causing issue upon install

### DIFF
--- a/erpnext/setup/utils.py
+++ b/erpnext/setup/utils.py
@@ -128,7 +128,7 @@ def insert_record(records):
 		doc.update(r)
 		try:
 			doc.insert(ignore_permissions=True)
-		except frappe.DuplicateEntryError, e:
+		except frappe.DuplicateEntryError as e:
 			# pass DuplicateEntryError and continue
 			if e.args and e.args[0]==doc.doctype and e.args[1]==doc.name:
 				# make sure DuplicateEntryError is for the exact same doc and not a related doc


### PR DESCRIPTION
using ubuntu 18.04, python3, this syntax error causing installation failure.

