### PR TITLE
fix: (Sales Invoice) Either debit or credit amount is required for Rounded Off

### DIFF
--- a/erpnext/accounts/general_ledger.py
+++ b/erpnext/accounts/general_ledger.py
@@ -143,7 +143,6 @@ def make_round_off_gle(gl_map, debit_credit_diff):
 	round_off_gle = frappe._dict()
 	for d in gl_map:
 		if d.account == round_off_account:
-			round_off_gle = d
 			if d.debit_in_account_currency:
 				debit_credit_diff -= flt(d.debit_in_account_currency)
 			else:
@@ -155,20 +154,19 @@ def make_round_off_gle(gl_map, debit_credit_diff):
 			"posting_date", "remarks", "is_opening"]:
 				round_off_gle[k] = gl_map[0][k]
 
-	round_off_gle.update({
-		"account": round_off_account,
-		"debit_in_account_currency": abs(debit_credit_diff) if debit_credit_diff < 0 else 0,
-		"credit_in_account_currency": debit_credit_diff if debit_credit_diff > 0 else 0,
-		"debit": abs(debit_credit_diff) if debit_credit_diff < 0 else 0,
-		"credit": debit_credit_diff if debit_credit_diff > 0 else 0,
-		"cost_center": round_off_cost_center,
-		"party_type": None,
-		"party": None,
-		"against_voucher_type": None,
-		"against_voucher": None
-	})
-
 	if not round_off_account_exists:
+		round_off_gle.update({
+			"account": round_off_account,
+			"debit_in_account_currency": abs(debit_credit_diff) if debit_credit_diff < 0 else 0,
+			"credit_in_account_currency": debit_credit_diff if debit_credit_diff > 0 else 0,
+			"debit": abs(debit_credit_diff) if debit_credit_diff < 0 else 0,
+			"credit": debit_credit_diff if debit_credit_diff > 0 else 0,
+			"cost_center": round_off_cost_center,
+			"party_type": None,
+			"party": None,
+			"against_voucher_type": None,
+			"against_voucher": None
+		})
 		gl_map.append(round_off_gle)
 
 def get_round_off_account_and_cost_center(company):


### PR DESCRIPTION
**Steps to Reproduce:**
1) Create Items with Tax.
2) Select "Is this Tax included in Basic Rate?" in Sales Taxes and Charges Template.
3) Add Tax at Item Level.
4) Sale Item using Point Of Sale.
5) On Submit of Sales Invoice using POS getting below error.
![image](https://user-images.githubusercontent.com/3703266/55321797-2ab86300-5498-11e9-96c1-b37006ab3960.png)
![round-off issue](https://user-images.githubusercontent.com/3703266/55321877-618e7900-5498-11e9-9b2f-683f15a14a02.gif)

**Solution:**
In general_ledger.py file method `make_round_off_gle(gl_map, debit_credit_diff)` @ line no.146 `round_off_gle = d` is altering `gl_map`. It is modifying original `gl_map` entry while checking `round_off_account` entry.

![round-off fix](https://user-images.githubusercontent.com/3703266/55321861-5b989800-5498-11e9-97bb-89b22ba96da3.gif)
