### PR TITLE
feat: Add status field in multiple reports linked with purchase order and sales order creation

### DIFF
--- a/erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py
+++ b/erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py
@@ -14,13 +14,13 @@ def execute(filters=None):
 
 def get_column():
 	return [
-		_("Delivery Note") + ":Link/Delivery Note:120", _("Date") + ":Date:100",
+		_("Delivery Note") + ":Link/Delivery Note:120", _("Status") + "::120", _("Date") + ":Date:100",
 		_("Suplier") + ":Link/Customer:120", _("Customer Name") + "::120",
-		_("Project") + ":Link/Project:120", _("Item Code") + ":Link/Item:120", 
+		_("Project") + ":Link/Project:120", _("Item Code") + ":Link/Item:120",
 		_("Amount") + ":Currency:100", _("Billed Amount") + ":Currency:100", _("Pending Amount") + ":Currency:100",
 		_("Item Name") + "::120", _("Description") + "::120", _("Company") + ":Link/Company:120",
 	]
 
 def get_args():
-	return {'doctype': 'Delivery Note', 'party': 'customer', 
+	return {'doctype': 'Delivery Note', 'party': 'customer',
 		'date': 'posting_date', 'order': 'name', 'order_by': 'desc'}

--- a/erpnext/accounts/report/non_billed_report.py
+++ b/erpnext/accounts/report/non_billed_report.py
@@ -12,14 +12,14 @@ def get_ordered_to_be_billed_data(args):
 	child_tab = doctype + " Item"
 	precision = get_field_precision(frappe.get_meta(child_tab).get_field("billed_amt"),
 		currency=get_default_currency()) or 2
-		
+
 	project_field = get_project_field(doctype, party)
 
 	return frappe.db.sql("""
 		Select
-			`{parent_tab}`.name, `{parent_tab}`.{date_field}, `{parent_tab}`.{party}, `{parent_tab}`.{party}_name,
+			`{parent_tab}`.name, `{parent_tab}`.status, `{parent_tab}`.{date_field}, `{parent_tab}`.{party}, `{parent_tab}`.{party}_name,
 			{project_field}, `{child_tab}`.item_code, `{child_tab}`.base_amount,
-			(`{child_tab}`.billed_amt * ifnull(`{parent_tab}`.conversion_rate, 1)), 
+			(`{child_tab}`.billed_amt * ifnull(`{parent_tab}`.conversion_rate, 1)),
 			(`{child_tab}`.base_amount - (`{child_tab}`.billed_amt * ifnull(`{parent_tab}`.conversion_rate, 1))),
 			`{child_tab}`.item_name, `{child_tab}`.description, `{parent_tab}`.company
 		from

--- a/erpnext/accounts/report/ordered_items_to_be_billed/ordered_items_to_be_billed.py
+++ b/erpnext/accounts/report/ordered_items_to_be_billed/ordered_items_to_be_billed.py
@@ -14,13 +14,13 @@ def execute(filters=None):
 
 def get_column():
 	return [
-		_("Sales Order") + ":Link/Sales Order:120", _("Date") + ":Date:100",
+		_("Sales Order") + ":Link/Sales Order:120", _("Status") + "::120", _("Date") + ":Date:100",
 		_("Suplier") + ":Link/Customer:120", _("Customer Name") + "::120",
-		_("Project") + ":Link/Project:120", _("Item Code") + ":Link/Item:120", 
+		_("Project") + ":Link/Project:120", _("Item Code") + ":Link/Item:120",
 		_("Amount") + ":Currency:100", _("Billed Amount") + ":Currency:100", _("Pending Amount") + ":Currency:100",
 		_("Item Name") + "::120", _("Description") + "::120", _("Company") + ":Link/Company:120",
 	]
 
 def get_args():
-	return {'doctype': 'Sales Order', 'party': 'customer', 
+	return {'doctype': 'Sales Order', 'party': 'customer',
 		'date': 'transaction_date', 'order': 'transaction_date', 'order_by': 'asc'}

--- a/erpnext/accounts/report/purchase_order_items_to_be_billed/purchase_order_items_to_be_billed.py
+++ b/erpnext/accounts/report/purchase_order_items_to_be_billed/purchase_order_items_to_be_billed.py
@@ -14,13 +14,13 @@ def execute(filters=None):
 
 def get_column():
 	return [
-		_("Purchase Order") + ":Link/Purchase Order:120", _("Date") + ":Date:100",
+		_("Purchase Order") + ":Link/Purchase Order:120", _("Status") + "::120", _("Date") + ":Date:100",
 		_("Suplier") + ":Link/Supplier:120", _("Suplier Name") + "::120",
-		_("Project") + ":Link/Project:120", _("Item Code") + ":Link/Item:120", 
+		_("Project") + ":Link/Project:120", _("Item Code") + ":Link/Item:120",
 		_("Amount") + ":Currency:100", _("Billed Amount") + ":Currency:100", _("Amount to Bill") + ":Currency:100",
 		_("Item Name") + "::120", _("Description") + "::120", _("Company") + ":Link/Company:120",
 	]
 
 def get_args():
-	return {'doctype': 'Purchase Order', 'party': 'supplier', 
+	return {'doctype': 'Purchase Order', 'party': 'supplier',
 		'date': 'transaction_date', 'order': 'transaction_date', 'order_by': 'asc'}

--- a/erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py
+++ b/erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py
@@ -14,7 +14,7 @@ def execute(filters=None):
 
 def get_column():
 	return [
-		_("Purchase Receipt") + ":Link/Purchase Receipt:120", _("Date") + ":Date:100",
+		_("Purchase Receipt") + ":Link/Purchase Receipt:120", _("Status") + "::120", _("Date") + ":Date:100",
 		_("Supplier") + ":Link/Supplier:120", _("Supplier Name") + "::120",
 		_("Project") + ":Link/Project:120", _("Item Code") + ":Link/Item:120",
 		_("Amount") + ":Currency:100", _("Billed Amount") + ":Currency:100", _("Amount to Bill") + ":Currency:100",

--- a/erpnext/stock/report/ordered_items_to_be_delivered/ordered_items_to_be_delivered.json
+++ b/erpnext/stock/report/ordered_items_to_be_delivered/ordered_items_to_be_delivered.json
@@ -1,31 +1,32 @@
 {
- "add_total_row": 1, 
- "apply_user_permissions": 1, 
- "creation": "2018-01-09 18:38:23.540100", 
- "disabled": 0, 
- "docstatus": 0, 
- "doctype": "Report", 
- "idx": 0, 
- "is_standard": "Yes", 
- "modified": "2018-01-15 15:04:15.340151", 
- "modified_by": "Administrator", 
- "module": "Stock", 
- "name": "Ordered Items To Be Delivered", 
- "owner": "Administrator", 
- "query": "select \n `tabSales Order`.`name` as \"Sales Order:Link/Sales Order:120\",\n `tabSales Order`.`customer` as \"Customer:Link/Customer:120\",\n `tabSales Order`.`customer_name` as \"Customer Name::150\",\n `tabSales Order`.`transaction_date` as \"Date:Date\",\n `tabSales Order`.`project` as \"Project:Link/Project:120\",\n `tabSales Order Item`.item_code as \"Item:Link/Item:120\",\n `tabSales Order Item`.qty as \"Qty:Float:140\",\n `tabSales Order Item`.delivered_qty as \"Delivered Qty:Float:140\",\n (`tabSales Order Item`.qty - ifnull(`tabSales Order Item`.delivered_qty, 0)) as \"Qty to Deliver:Float:140\",\n `tabSales Order Item`.base_rate as \"Rate:Float:140\",\n `tabSales Order Item`.base_amount as \"Amount:Float:140\",\n ((`tabSales Order Item`.qty - ifnull(`tabSales Order Item`.delivered_qty, 0))*`tabSales Order Item`.base_rate) as \"Amount to Deliver:Float:140\",\n `tabBin`.actual_qty as \"Available Qty:Float:120\",\n `tabBin`.projected_qty as \"Projected Qty:Float:120\",\n `tabSales Order Item`.`delivery_date` as \"Item Delivery Date:Date:120\",\n  DATEDIFF(CURDATE(),`tabSales Order Item`.`delivery_date`) as \"Delay Days:Int:120\",\n `tabSales Order Item`.item_name as \"Item Name::150\",\n `tabSales Order Item`.description as \"Description::200\",\n `tabSales Order Item`.item_group as \"Item Group:Link/Item Group:120\",\n `tabSales Order Item`.warehouse as \"Warehouse:Link/Warehouse:200\"\nfrom\n `tabSales Order` JOIN `tabSales Order Item` \n LEFT JOIN `tabBin` ON (`tabBin`.item_code = `tabSales Order Item`.item_code\n and `tabBin`.warehouse = `tabSales Order Item`.warehouse)\nwhere\n `tabSales Order Item`.`parent` = `tabSales Order`.`name`\n and `tabSales Order`.docstatus = 1\n and `tabSales Order`.status not in (\"Stopped\", \"Closed\")\n and ifnull(`tabSales Order Item`.delivered_qty,0) < ifnull(`tabSales Order Item`.qty,0)\norder by `tabSales Order`.transaction_date asc", 
- "ref_doctype": "Delivery Note", 
- "report_name": "Ordered Items To Be Delivered", 
- "report_type": "Query Report", 
+ "add_total_row": 1,
+ "creation": "2018-01-09 18:38:23.540100",
+ "disable_prepared_report": 0,
+ "disabled": 0,
+ "docstatus": 0,
+ "doctype": "Report",
+ "idx": 0,
+ "is_standard": "Yes",
+ "modified": "2019-04-01 22:10:09.829361",
+ "modified_by": "Administrator",
+ "module": "Stock",
+ "name": "Ordered Items To Be Delivered",
+ "owner": "Administrator",
+ "prepared_report": 0,
+ "query": "select \n `tabSales Order`.`name` as \"Sales Order:Link/Sales Order:120\",\n `tabSales Order`.`status` as \"Status:Data:120\",\n `tabSales Order`.`customer` as \"Customer:Link/Customer:120\",\n `tabSales Order`.`customer_name` as \"Customer Name::150\",\n `tabSales Order`.`transaction_date` as \"Date:Date\",\n `tabSales Order`.`project` as \"Project:Link/Project:120\",\n `tabSales Order Item`.item_code as \"Item:Link/Item:120\",\n `tabSales Order Item`.qty as \"Qty:Float:140\",\n `tabSales Order Item`.delivered_qty as \"Delivered Qty:Float:140\",\n (`tabSales Order Item`.qty - ifnull(`tabSales Order Item`.delivered_qty, 0)) as \"Qty to Deliver:Float:140\",\n `tabSales Order Item`.base_rate as \"Rate:Float:140\",\n `tabSales Order Item`.base_amount as \"Amount:Float:140\",\n ((`tabSales Order Item`.qty - ifnull(`tabSales Order Item`.delivered_qty, 0))*`tabSales Order Item`.base_rate) as \"Amount to Deliver:Float:140\",\n `tabBin`.actual_qty as \"Available Qty:Float:120\",\n `tabBin`.projected_qty as \"Projected Qty:Float:120\",\n `tabSales Order Item`.`delivery_date` as \"Item Delivery Date:Date:120\",\n  DATEDIFF(CURDATE(),`tabSales Order Item`.`delivery_date`) as \"Delay Days:Int:120\",\n `tabSales Order Item`.item_name as \"Item Name::150\",\n `tabSales Order Item`.description as \"Description::200\",\n `tabSales Order Item`.item_group as \"Item Group:Link/Item Group:120\",\n `tabSales Order Item`.warehouse as \"Warehouse:Link/Warehouse:200\"\nfrom\n `tabSales Order` JOIN `tabSales Order Item` \n LEFT JOIN `tabBin` ON (`tabBin`.item_code = `tabSales Order Item`.item_code\n and `tabBin`.warehouse = `tabSales Order Item`.warehouse)\nwhere\n `tabSales Order Item`.`parent` = `tabSales Order`.`name`\n and `tabSales Order`.docstatus = 1\n and `tabSales Order`.status not in (\"Stopped\", \"Closed\")\n and ifnull(`tabSales Order Item`.delivered_qty,0) < ifnull(`tabSales Order Item`.qty,0)\norder by `tabSales Order`.transaction_date asc",
+ "ref_doctype": "Delivery Note",
+ "report_name": "Ordered Items To Be Delivered",
+ "report_type": "Query Report",
  "roles": [
   {
    "role": "Stock User"
-  }, 
+  },
   {
    "role": "Stock Manager"
-  }, 
+  },
   {
    "role": "Sales User"
-  }, 
+  },
   {
    "role": "Accounts User"
   }

--- a/erpnext/stock/report/purchase_order_items_to_be_received/purchase_order_items_to_be_received.json
+++ b/erpnext/stock/report/purchase_order_items_to_be_received/purchase_order_items_to_be_received.json
@@ -1,31 +1,32 @@
 {
- "add_total_row": 1, 
- "apply_user_permissions": 1, 
- "creation": "2013-02-22 18:01:55", 
- "disabled": 0, 
- "docstatus": 0, 
- "doctype": "Report", 
- "idx": 3, 
- "is_standard": "Yes", 
- "modified": "2017-02-24 20:04:20.699195", 
- "modified_by": "Administrator", 
- "module": "Stock", 
- "name": "Purchase Order Items To Be Received", 
- "owner": "Administrator", 
- "query": "select \n    `tabPurchase Order`.`name` as \"Purchase Order:Link/Purchase Order:120\",\n\t`tabPurchase Order`.`transaction_date` as \"Date:Date:100\",\n\t`tabPurchase Order Item`.`schedule_date` as \"Reqd by Date:Date:110\",\n\t`tabPurchase Order`.`supplier` as \"Supplier:Link/Supplier:120\",\n\t`tabPurchase Order`.`supplier_name` as \"Supplier Name::150\",\n\t`tabPurchase Order Item`.`project` as \"Project\",\n\t`tabPurchase Order Item`.item_code as \"Item Code:Link/Item:120\",\n\t`tabPurchase Order Item`.qty as \"Qty:Float:100\",\n\t`tabPurchase Order Item`.received_qty as \"Received Qty:Float:100\", \n\t(`tabPurchase Order Item`.qty - ifnull(`tabPurchase Order Item`.received_qty, 0)) as \"Qty to Receive:Float:100\",\n    `tabPurchase Order Item`.warehouse as \"Warehouse:Link/Warehouse:150\",\n\t`tabPurchase Order Item`.item_name as \"Item Name::150\",\n\t`tabPurchase Order Item`.description as \"Description::200\",\n    `tabPurchase Order Item`.brand as \"Brand::100\",\n\t`tabPurchase Order`.`company` as \"Company:Link/Company:\"\nfrom\n\t`tabPurchase Order`, `tabPurchase Order Item`\nwhere\n\t`tabPurchase Order Item`.`parent` = `tabPurchase Order`.`name`\n\tand `tabPurchase Order`.docstatus = 1\n\tand `tabPurchase Order`.status not in (\"Stopped\", \"Closed\")\n\tand ifnull(`tabPurchase Order Item`.received_qty, 0) < ifnull(`tabPurchase Order Item`.qty, 0)\norder by `tabPurchase Order`.transaction_date asc", 
- "ref_doctype": "Purchase Receipt", 
- "report_name": "Purchase Order Items To Be Received", 
- "report_type": "Query Report", 
+ "add_total_row": 1,
+ "creation": "2013-02-22 18:01:55",
+ "disable_prepared_report": 0,
+ "disabled": 0,
+ "docstatus": 0,
+ "doctype": "Report",
+ "idx": 3,
+ "is_standard": "Yes",
+ "modified": "2019-04-01 22:12:05.573343",
+ "modified_by": "Administrator",
+ "module": "Stock",
+ "name": "Purchase Order Items To Be Received",
+ "owner": "Administrator",
+ "prepared_report": 0,
+ "query": "select \n    `tabPurchase Order`.`name` as \"Purchase Order:Link/Purchase Order:120\",\n    `tabPurchase Order`.`status` as \"Status:Data:120\",\n\t`tabPurchase Order`.`transaction_date` as \"Date:Date:100\",\n\t`tabPurchase Order Item`.`schedule_date` as \"Reqd by Date:Date:110\",\n\t`tabPurchase Order`.`supplier` as \"Supplier:Link/Supplier:120\",\n\t`tabPurchase Order`.`supplier_name` as \"Supplier Name::150\",\n\t`tabPurchase Order Item`.`project` as \"Project\",\n\t`tabPurchase Order Item`.item_code as \"Item Code:Link/Item:120\",\n\t`tabPurchase Order Item`.qty as \"Qty:Float:100\",\n\t`tabPurchase Order Item`.received_qty as \"Received Qty:Float:100\", \n\t(`tabPurchase Order Item`.qty - ifnull(`tabPurchase Order Item`.received_qty, 0)) as \"Qty to Receive:Float:100\",\n    `tabPurchase Order Item`.warehouse as \"Warehouse:Link/Warehouse:150\",\n\t`tabPurchase Order Item`.item_name as \"Item Name::150\",\n\t`tabPurchase Order Item`.description as \"Description::200\",\n    `tabPurchase Order Item`.brand as \"Brand::100\",\n\t`tabPurchase Order`.`company` as \"Company:Link/Company:\"\nfrom\n\t`tabPurchase Order`, `tabPurchase Order Item`\nwhere\n\t`tabPurchase Order Item`.`parent` = `tabPurchase Order`.`name`\n\tand `tabPurchase Order`.docstatus = 1\n\tand `tabPurchase Order`.status not in (\"Stopped\", \"Closed\")\n\tand ifnull(`tabPurchase Order Item`.received_qty, 0) < ifnull(`tabPurchase Order Item`.qty, 0)\norder by `tabPurchase Order`.transaction_date asc",
+ "ref_doctype": "Purchase Receipt",
+ "report_name": "Purchase Order Items To Be Received",
+ "report_type": "Query Report",
  "roles": [
   {
    "role": "Stock Manager"
-  }, 
+  },
   {
    "role": "Stock User"
-  }, 
+  },
   {
    "role": "Purchase User"
-  }, 
+  },
   {
    "role": "Accounts User"
   }


### PR DESCRIPTION
Added status field in reports to provide more information about the reason for not completing billing or delivery of ordered items.

- Purchase Order Item to be received
![Screenshot 2019-04-01 at 10 12 14 PM](https://user-images.githubusercontent.com/14824451/55347504-b353f500-54d2-11e9-986c-f54ecfa943a5.png)


- Purchase Order Item to be billed
![Screenshot 2019-04-03 at 7 02 58 PM](https://user-images.githubusercontent.com/14824451/55482927-27ada600-5643-11e9-8241-13173a6be3ca.png)


- Ordered Items to be delivered
![Screenshot 2019-04-01 at 9 53 47 PM](https://user-images.githubusercontent.com/14824451/55347510-b51db880-54d2-11e9-9582-88c8948828a0.png)


- Ordered Items to be billed
![Screenshot 2019-04-03 at 7 02 42 PM](https://user-images.githubusercontent.com/14824451/55482912-22505b80-5643-11e9-8a38-d536cbdea5ff.png)
