### PR TITLE
fix: Divide by zero exception handling

### DIFF
--- a/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py
+++ b/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py
@@ -54,8 +54,10 @@ def _execute(filters=None, additional_table_columns=None, additional_query_colum
 			delivery_note, d.income_account, d.cost_center, d.stock_qty, d.stock_uom
 		]
 
-		row += [(d.base_net_rate * d.qty)/d.stock_qty, d.base_net_amount] \
-			if d.stock_uom != d.uom and d.stock_qty != 0 else [d.base_net_rate, d.base_net_amount]
+		if d.stock_uom != d.uom and d.stock_qty:
+			row += [(d.base_net_rate * d.qty)/d.stock_qty, d.base_net_amount]
+		else:
+			row += [d.base_net_rate, d.base_net_amount]
 
 		total_tax = 0
 		for tax in tax_columns:
@@ -108,13 +110,13 @@ def get_conditions(filters):
 		conditions += """ and exists(select name from `tabSales Invoice Payment`
 			where parent=`tabSales Invoice`.name
 				and ifnull(`tabSales Invoice Payment`.mode_of_payment, '') = %(mode_of_payment)s)"""
-	
+
 	if filters.get("warehouse"):
 		conditions +=  """ and exists(select name from `tabSales Invoice Item`
 			 where parent=`tabSales Invoice`.name
 			 	and ifnull(`tabSales Invoice Item`.warehouse, '') = %(warehouse)s)"""
 
-	
+
 	if filters.get("brand"):
 		conditions +=  """ and exists(select name from `tabSales Invoice Item`
 			 where parent=`tabSales Invoice`.name
@@ -131,10 +133,10 @@ def get_conditions(filters):
 def get_items(filters, additional_query_columns):
 	conditions = get_conditions(filters)
 	match_conditions = frappe.build_match_conditions("Sales Invoice")
-	
+
 	if match_conditions:
 		match_conditions = " and {0} ".format(match_conditions)
-	
+
 	if additional_query_columns:
 		additional_query_columns = ', ' + ', '.join(additional_query_columns)
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 55, in application
    response = frappe.handler.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 20, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 55, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1007, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 489, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 174, in run
    result = generate_report_result(report, filters, user)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 65, in generate_report_result
    res = frappe.get_attr(method_name)(frappe._dict(filters))
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py", line 13, in execute
    return _execute(filters)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py", line 58, in _execute
    if d.stock_uom != d.uom else [d.base_net_rate, d.base_net_amount]
ZeroDivisionError: float division by zero
```

