### PR TITLE
fix: desk for selling module, sales invoice now avaialble at module page (WN-SUP41771).

### DIFF
--- a/erpnext/config/selling.py
+++ b/erpnext/config/selling.py
@@ -29,6 +29,13 @@ def get_data():
 				},
 				{
 					"type": "doctype",
+					"name": "Sales Invoice",
+					"description": _("Invoices for Costumers."),
+					"onboard": 1,
+					"dependencies": ["Item", "Customer"],
+				},
+				{
+					"type": "doctype",
 					"name": "Sales Partner",
 					"description": _("Manage Sales Partners."),
 					"dependencies": ["Item"],


### PR DESCRIPTION
Please read the pull request checklist to make sure your changes are merged: https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

