### PR TITLE
fix(Item Group): Don't clean description html

### DIFF
--- a/erpnext/setup/doctype/item_group/item_group.py
+++ b/erpnext/setup/doctype/item_group/item_group.py
@@ -12,7 +12,6 @@ from frappe.website.render import clear_cache
 from frappe.website.doctype.website_slideshow.website_slideshow import get_slideshow
 from erpnext.shopping_cart.product_info import set_product_info_for_website
 from erpnext.utilities.product import get_qty_in_stock
-from frappe.utils.html_utils import clean_html
 
 class ItemGroup(NestedSet, WebsiteGenerator):
 	nsm_parent_field = 'parent_item_group'
@@ -27,7 +26,6 @@ class ItemGroup(NestedSet, WebsiteGenerator):
 
 	def validate(self):
 		super(ItemGroup, self).validate()
-		self.description = clean_html(self.description)
 		self.make_route()
 
 	def on_update(self):


### PR DESCRIPTION
Description was cleaned forcefully which also removed images. This PR reverts that behaviour.

![image](https://user-images.githubusercontent.com/9355208/55549656-00fb7800-56f4-11e9-9d36-d1ac3d4dc128.png)
