### PR TITLE
fix: Translated string method in Jinja

### DIFF
--- a/erpnext/templates/pages/cart.html
+++ b/erpnext/templates/pages/cart.html
@@ -60,7 +60,7 @@
 				{{doc.terms}}
 			</div>
 			<div class="cart-link">
-				<a href="#" onclick="show_terms();return false;">*{{ __("Terms and Conditions") }}</a>
+				<a href="#" onclick="show_terms();return false;">*{{ _("Terms and Conditions") }}</a>
 			</div>
 		{% endif %}
 


### PR DESCRIPTION
Fix for `/cart`

![image](https://user-images.githubusercontent.com/9355208/55740001-dab53f80-5a47-11e9-8f07-6c937c403c62.png)
