### PR TITLE
Fixed Company Abbr Update Was Not Able To Update Account

### DIFF
--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -372,7 +372,7 @@ def replace_abbr(company, old, new):
 	def _rename_record(doc):
 		parts = doc[0].rsplit(" - ", 1)
 		if len(parts) == 1 or parts[1].lower() == old.lower():
-			frappe.rename_doc(dt, doc[0], parts[0] + " - " + new)
+			frappe.rename_doc(dt, doc[0], parts[0] + " - " + new, force=True)
 
 	def _rename_records(dt):
 		# rename is expensive so let's be economical with memory usage


### PR DESCRIPTION
Please read the pull request checklist to make sure your changes are merged: https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

While changing the company abbreviation faced this issue.

Error Log:

{'event': None, 'retry': 0, 'log': <function log at 0x108b945f0>, 'site': 'test_site_on_statging_to_develop', 'job_name': u'erpnext.setup.doctype.company.company.replace_abbr', 'method_name': u'erpnext.setup.doctype.company.company.replace_abbr', 'method': <function replace_abbr at 0x108c77500>, 'user': u'Administrator', 'kwargs': {'new': u'FBR', 'company': u'Facebook', 'old': u'FB'}, 'is_async': True}
Traceback (most recent call last):
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/utils/background_jobs.py", line 99, in execute_job
    method(**kwargs)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/erpnext/erpnext/setup/doctype/company/company.py", line 382, in replace_abbr
    _rename_records(dt)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/erpnext/erpnext/setup/doctype/company/company.py", line 378, in _rename_records
    _rename_record(d)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/erpnext/erpnext/setup/doctype/company/company.py", line 372, in _rename_record
    frappe.rename_doc(dt, doc[0], parts[0] + " - " + new)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/__init__.py", line 795, in rename_doc
    return rename_doc(*args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/model/rename_doc.py", line 40, in rename_doc
    new = validate_rename(doctype, new, meta, merge, force, ignore_permissions)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/model/rename_doc.py", line 168, in validate_rename
    frappe.msgprint(_("{0} not allowed to be renamed").format(_(doctype)), raise_exception=1)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/__init__.py", line 338, in msgprint
    _raise_exception()
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/__init__.py", line 313, in _raise_exception
    raise ValidationError(msg)
ValidationError: Account not allowed to be renamed