### PR TITLE
fix: supplier wise sales analytics report

### DIFF
--- a/erpnext/stock/report/supplier_wise_sales_analytics/supplier_wise_sales_analytics.py
+++ b/erpnext/stock/report/supplier_wise_sales_analytics/supplier_wise_sales_analytics.py
@@ -94,9 +94,13 @@ def get_suppliers_details(filters):
 				item_supplier_map.setdefault(d.item_code, []).append(d.supplier)
 
 	if supplier:
+		invalid_items = []
 		for item_code, suppliers in iteritems(item_supplier_map):
 			if supplier not in suppliers:
-				del item_supplier_map[item_code]
+				invalid_items.append(item_code)
+
+		for item_code in invalid_items:
+			del item_supplier_map[item_code]
 
 	return item_supplier_map
 


### PR DESCRIPTION
```
Issue: https://frappe.erpnext.com/private/files/IMG_0245.jpg

Console traceback:

jquery.min.js:4 GET https://ableteam.erpnext.com/?report_name=Supplier-Wise+Sales+Analytics&filters=%7B%22supplier%22%3A%22Original+Technology%22%2C%22from_date%22%3A%222019-04-01%22%2C%22to_date%22%3A%222019-04-30%22%7D&cmd=frappe.desk.query_report.run&_=1554454259055 500 (INTERNAL SERVER ERROR)
send @ jquery.min.js:4
ajax @ jquery.min.js:4
frappe.request.call @ request.js:199
frappe.call @ request.js:77
(anonymous) @ query_report.js:280
refresh @ query_report.js:279
(anonymous) @ utils.js:631
t.onchange @ query_report.js:215
(anonymous) @ base_control.js:168
Promise.then (async)
(anonymous) @ dom.js:249
frappe.run_serially @ dom.js:247
r @ base_control.js:161
(anonymous) @ base_control.js:177
Promise.then (async)
validate_and_set_in_model @ base_control.js:177
parse_validate_and_set_in_model @ base_control.js:151
(anonymous) @ link.js:251
dispatch @ jquery.min.js:3
r.handle @ jquery.min.js:3
i.fire @ awesomplete.js:449
select @ awesomplete.js:250
keydown @ awesomplete.js:70
request.js:321 Traceback (most recent call last):
  File "/home/frappe/benches/bench-2019-03-28/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2019-03-28/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2019-03-28/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2019-03-28/apps/frappe/frappe/__init__.py", line 1027, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2019-03-28/apps/frappe/frappe/__init__.py", line 502, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "/home/frappe/benches/bench-2019-03-28/apps/frappe/frappe/desk/query_report.py", line 185, in run
    result = generate_report_result(report, filters, user)
  File "/home/frappe/benches/bench-2019-03-28/apps/frappe/frappe/desk/query_report.py", line 66, in generate_report_result
    res = frappe.get_attr(method_name)(frappe._dict(filters))
  File "/home/frappe/benches/bench-2019-03-28/apps/erpnext/erpnext/stock/report/supplier_wise_sales_analytics/supplier_wise_sales_analytics.py", line 13, in execute
    supplier_details = get_suppliers_details(filters)
  File "/home/frappe/benches/bench-2019-03-28/apps/erpnext/erpnext/stock/report/supplier_wise_sales_analytics/supplier_wise_sales_analytics.py", line 97, in get_suppliers_details
    for item_code, suppliers in iteritems(item_supplier_map):
RuntimeError: dictionary changed size during iteration

request.js:253 Unable to handle failed response
request.js:254 SyntaxError: Unexpected token u in JSON at position 0
    at JSON.parse (<anonymous>)
    at Object.frappe.request.report_error (request.js:377)
    at 500 (request.js:172)
    at Object.<anonymous> (request.js:247)
    at i (jquery.min.js:2)
    at Object.fireWith [as rejectWith] (jquery.min.js:2)
    at z (jquery.min.js:4)
    at XMLHttpRequest.<anonymous> (jquery.min.js:4)
(anonymous) @ request.js:254
i @ jquery.min.js:2
fireWith @ jquery.min.js:2
z @ jquery.min.js:4
(anonymous) @ jquery.min.js:4
load (async)
send @ jquery.min.js:4
ajax @ jquery.min.js:4
frappe.request.call @ request.js:199
frappe.call @ request.js:77
(anonymous) @ query_report.js:280
refresh @ query_report.js:279
(anonymous) @ utils.js:631
t.onchange @ query_report.js:215
(anonymous) @ base_control.js:168
Promise.then (async)
(anonymous) @ dom.js:249
frappe.run_serially @ dom.js:247
r @ base_control.js:161
(anonymous) @ base_control.js:177
Promise.then (async)
validate_and_set_in_model @ base_control.js:177
parse_validate_and_set_in_model @ base_control.js:151
(anonymous) @ link.js:251
dispatch @ jquery.min.js:3
r.handle @ jquery.min.js:3
i.fire @ awesomplete.js:449
select @ awesomplete.js:250
keydown @ awesomplete.js:70
```