### PR TITLE
fix: user permissions are not working on stock ledger report

### DIFF
--- a/erpnext/stock/report/stock_ledger/stock_ledger.py
+++ b/erpnext/stock/report/stock_ledger/stock_ledger.py
@@ -22,12 +22,8 @@ def execute(filters=None):
 	for sle in sl_entries:
 		item_detail = item_details[sle.item_code]
 
-		data.append([sle.date, sle.item_code, item_detail.item_name, item_detail.item_group,
-			item_detail.brand, item_detail.description, sle.warehouse,
-			item_detail.stock_uom, sle.actual_qty, sle.qty_after_transaction,
-			(sle.incoming_rate if sle.actual_qty > 0 else 0.0),
-			sle.valuation_rate, sle.stock_value, sle.voucher_type, sle.voucher_no,
-			sle.batch_no, sle.serial_no, sle.project, sle.company])
+		sle.update(item_detail)
+		data.append(sle)
 
 		if include_uom:
 			conversion_factors.append(item_detail.conversion_factor)


### PR DESCRIPTION
**Issue**

Created user permissions for **item group**
![Screen Shot 2019-04-12 at 4 59 49 pm](https://user-images.githubusercontent.com/8780500/56034253-785c8780-5d44-11e9-9e7d-caf168ce4704.png)

**But permissions are not applied on the stock ledger report, user can see other items groups data**
![Screen Shot 2019-04-12 at 4 59 41 pm](https://user-images.githubusercontent.com/8780500/56034320-a4780880-5d44-11e9-92e1-dec63cc15489.png)

**After Fix**
![Screen Shot 2019-04-12 at 4 59 01 pm](https://user-images.githubusercontent.com/8780500/56034360-bd80b980-5d44-11e9-91d9-5a6b6e5e6c55.png)

