### PR TITLE
fix: Requested Items To Be Ordered report showing records even if material request is fully ordered(Cherry-picked)

### DIFF
--- a/erpnext/buying/report/requested_items_to_be_ordered/requested_items_to_be_ordered.json
+++ b/erpnext/buying/report/requested_items_to_be_ordered/requested_items_to_be_ordered.json
@@ -1,28 +1,29 @@
 {
- "add_total_row": 1, 
- "apply_user_permissions": 1, 
- "creation": "2013-05-13 16:10:02", 
- "disabled": 0, 
- "docstatus": 0, 
- "doctype": "Report", 
- "idx": 3, 
- "is_standard": "Yes", 
- "modified": "2017-02-24 20:10:53.005589", 
- "modified_by": "Administrator", 
- "module": "Buying", 
- "name": "Requested Items To Be Ordered", 
- "owner": "Administrator", 
- "query": "select \n    mr.name as \"Material Request:Link/Material Request:120\",\n\tmr.transaction_date as \"Date:Date:100\",\n\tmr_item.item_code as \"Item Code:Link/Item:120\",\n\tsum(ifnull(mr_item.qty, 0)) as \"Qty:Float:100\",\n\tsum(ifnull(mr_item.ordered_qty, 0)) as \"Ordered Qty:Float:100\", \n\t(sum(mr_item.qty) - sum(ifnull(mr_item.ordered_qty, 0))) as \"Qty to Order:Float:100\",\n\tmr_item.item_name as \"Item Name::150\",\n\tmr_item.description as \"Description::200\",\n\tmr.company as \"Company:Link/Company:\"\nfrom\n\t`tabMaterial Request` mr, `tabMaterial Request Item` mr_item\nwhere\n\tmr_item.parent = mr.name\n\tand mr.material_request_type = \"Purchase\"\n\tand mr.docstatus = 1\n\tand mr.status != \"Stopped\"\ngroup by mr.name, mr_item.item_code\nhaving\n\tsum(ifnull(mr_item.ordered_qty, 0)) < sum(ifnull(mr_item.qty, 0))\norder by mr.transaction_date asc", 
- "ref_doctype": "Purchase Order", 
- "report_name": "Requested Items To Be Ordered", 
- "report_type": "Query Report", 
+ "add_total_row": 1,
+ "creation": "2013-05-13 16:10:02",
+ "disable_prepared_report": 0,
+ "disabled": 0,
+ "docstatus": 0,
+ "doctype": "Report",
+ "idx": 3,
+ "is_standard": "Yes",
+ "modified": "2019-04-18 19:02:03.099422",
+ "modified_by": "Administrator",
+ "module": "Buying",
+ "name": "Requested Items To Be Ordered",
+ "owner": "Administrator",
+ "prepared_report": 0,
+ "query": "select \n    mr.name as \"Material Request:Link/Material Request:120\",\n\tmr.transaction_date as \"Date:Date:100\",\n\tmr_item.item_code as \"Item Code:Link/Item:120\",\n\tsum(ifnull(mr_item.stock_qty, 0)) as \"Qty:Float:100\",\n\tifnull(mr_item.stock_uom, '') as \"UOM:Link/UOM:100\",\n\tsum(ifnull(mr_item.ordered_qty, 0)) as \"Ordered Qty:Float:100\", \n\t(sum(mr_item.stock_qty) - sum(ifnull(mr_item.ordered_qty, 0))) as \"Qty to Order:Float:100\",\n\tmr_item.item_name as \"Item Name::150\",\n\tmr_item.description as \"Description::200\",\n\tmr.company as \"Company:Link/Company:\"\nfrom\n\t`tabMaterial Request` mr, `tabMaterial Request Item` mr_item\nwhere\n\tmr_item.parent = mr.name\n\tand mr.material_request_type = \"Purchase\"\n\tand mr.docstatus = 1\n\tand mr.status != \"Stopped\"\ngroup by mr.name, mr_item.item_code\nhaving\n\tsum(ifnull(mr_item.ordered_qty, 0)) < sum(ifnull(mr_item.stock_qty, 0))\norder by mr.transaction_date asc",
+ "ref_doctype": "Purchase Order",
+ "report_name": "Requested Items To Be Ordered",
+ "report_type": "Query Report",
  "roles": [
   {
    "role": "Stock User"
-  }, 
+  },
   {
    "role": "Purchase Manager"
-  }, 
+  },
   {
    "role": "Purchase User"
   }


### PR DESCRIPTION
**Issue**

Created material request with an Item ball pen which has stock uom as BOX, but created material request with UOM as Nos.
![Screen Shot 2019-04-18 at 6 57 12 pm](https://user-images.githubusercontent.com/8780500/56364754-fb7e5180-620c-11e9-9681-642903c9bde0.png)

Even after creating the fully purchase order against the material request "MREQ-00074-1" the material request is still showing in the report "Requested Items To Be Ordered"

![Screen Shot 2019-04-18 at 6 57 30 pm](https://user-images.githubusercontent.com/8780500/56364880-3ed8c000-620d-11e9-8602-901c67cbb64c.png)

In the sql query I found that we are comparing the quantity with ordered quantity instead of stock quantity with ordered quantity

**After fix**

Updated quantity with stock quantity and issue is fixed
![Screen Shot 2019-04-18 at 7 00 04 pm](https://user-images.githubusercontent.com/8780500/56364956-6d569b00-620d-11e9-8f96-87871addd2e0.png)

