### PR TITLE
fix: Reconciliation dashboard py3 and matching corrections

### DIFF
--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 import frappe
 from frappe.model.document import Document
 from frappe.utils import flt
+from six.moves import reduce
 
 class BankTransaction(Document):
 	def after_insert(self):

--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction_upload.py
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction_upload.py
@@ -7,6 +7,7 @@ import frappe
 import json
 from frappe.utils import getdate
 from frappe.utils.dateutils import parse_date
+from six import iteritems
 
 @frappe.whitelist()
 def upload_bank_statement():
@@ -17,11 +18,11 @@ def upload_bank_statement():
 		from frappe.utils.file_manager import get_uploaded_content
 		fname, fcontent = get_uploaded_content()
 
-	if frappe.safe_encode(fname).lower().endswith("csv"):
+	if frappe.safe_encode(fname).lower().endswith("csv".encode('utf-8')):
 		from frappe.utils.csvutils import read_csv_content
 		rows = read_csv_content(fcontent, False)
 
-	elif frappe.safe_encode(fname).lower().endswith("xlsx"):
+	elif frappe.safe_encode(fname).lower().endswith("xlsx".encode('utf-8')):
 		from frappe.utils.xlsxutils import read_xlsx_file_from_attached_file
 		rows = read_xlsx_file_from_attached_file(fcontent=fcontent)
 
@@ -40,7 +41,7 @@ def create_bank_entries(columns, data, bank_account):
 		if all(item is None for item in d) is True:
 			continue
 		fields = {}
-		for key, value in header_map.iteritems():
+		for key, value in iteritems(header_map):
 			fields.update({key: d[int(value)-1]})
 
 

--- a/erpnext/accounts/page/bank_reconciliation/bank_reconciliation.js
+++ b/erpnext/accounts/page/bank_reconciliation/bank_reconciliation.js
@@ -32,7 +32,6 @@ erpnext.accounts.bankReconciliation = class BankReconciliation {
 			fieldname: 'company',
 			options: "Company",
 			onchange: function() {
-				console.log(this.value)
 				if (this.value) {
 					me.company = this.value;
 				} else {


### PR DESCRIPTION
Hi,

These corrections are the result of several days of usage of the new reconciliation dashboard in production:

1. Small corrections have been made to use it with Python 3 (it was developed initially on Python 2)
2. Some issues in the matching system have been corrected

Thanks in advance for your help!

