### PR TITLE
fix: Do not create employee user permission if already exists

### DIFF
--- a/erpnext/hr/doctype/employee/employee.py
+++ b/erpnext/hr/doctype/employee/employee.py
@@ -80,6 +80,14 @@ class Employee(NestedSet):
 		if not self.create_user_permission: return
 		if not has_permission('User Permission', ptype='write'): return
 
+		employee_user_permission_exists = frappe.db.exists('User Permission', {
+			'allow': 'Employee',
+			'for_value': self.name,
+			'user': self.user_id
+		})
+
+		if employee_user_permission_exists: return
+
 		add_user_permission("Employee", self.name, self.user_id)
 		set_user_permission_if_allowed("Company", self.company, self.user_id)
 


### PR DESCRIPTION
Do not create duplicate employee user permission if already exists