### PR TITLE
fix: Bank reconciliation corrections

### DIFF
--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction_upload.py
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction_upload.py
@@ -45,15 +45,19 @@ def create_bank_entries(columns, data, bank_account):
 			fields.update({key: d[int(value)-1]})
 
 
-		bank_transaction = frappe.get_doc({
-			"doctype": "Bank Transaction"
-		})
-		bank_transaction.update(fields)
-		bank_transaction.date = getdate(parse_date(bank_transaction.date))
-		bank_transaction.bank_account = bank_account
-		bank_transaction.insert()
-		bank_transaction.submit()
-		count = count + 1
+		try:
+			bank_transaction = frappe.get_doc({
+				"doctype": "Bank Transaction"
+			})
+			bank_transaction.update(fields)
+			bank_transaction.date = getdate(parse_date(bank_transaction.date))
+			bank_transaction.bank_account = bank_account
+			bank_transaction.insert()
+			bank_transaction.submit()
+			count = count + 1
+		except Exception as e:
+			frappe.throw(e)
+			frappe.log_error(frappe.get_traceback())
 
 	return count
 

--- a/erpnext/accounts/page/bank_reconciliation/bank_reconciliation.py
+++ b/erpnext/accounts/page/bank_reconciliation/bank_reconciliation.py
@@ -33,10 +33,12 @@ def reconcile(bank_transaction, payment_doctype, payment_name):
 	return 'reconciled'
 
 def add_payment_to_transaction(transaction, payment_entry, gl_entry):
+	gl_amount, transaction_amount = (gl_entry.credit, transaction.debit) if gl_entry.credit > 0 else (gl_entry.debit, transaction.credit)
+	allocated_amount = gl_amount if gl_amount <= transaction_amount else transaction_amount
 	transaction.append("payment_entries", {
 		"payment_document": payment_entry.doctype,
 		"payment_entry": payment_entry.name,
-		"allocated_amount": gl_entry.credit if gl_entry.credit > 0 else gl_entry.debit
+		"allocated_amount": allocated_amount
 	})
 	transaction.save()
 
@@ -274,7 +276,7 @@ def check_amount_vs_description(amount_matching, description_matching):
 						result.append(am_match)
 						continue
 
-				if hasattr(am_match, "reference_no") and hasattr(des_match, "reference_no"):
+				if "reference_no" in am_match and "reference_no" in des_match:
 					if difflib.SequenceMatcher(lambda x: x == " ", am_match["reference_no"], des_match["reference_no"]).ratio() > 70:
 						if am_match not in result:
 							result.append(am_match)


### PR DESCRIPTION
Hi,

This PR contains a few corrections related to the Bank reconciliation dashboard:

1. The system was failing silently when the import format was not correct for bank transactions
2. The allocated amount ceiling should be the transaction amount, not the payment amount
3. Description matches objects are dict

Thanks!

