### PR TITLE
fix: Make button not appearing in delivery note

### DIFF
--- a/erpnext/stock/doctype/delivery_note/delivery_note.js
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.js
@@ -94,7 +94,7 @@ erpnext.stock.DeliveryNoteController = erpnext.selling.SellingController.extend(
 		var me = this;
 		this._super();
 
-		if((!doc.is_return) && (doc.status=="Closed" || doc.is_new())) {
+		if((!doc.is_return) && (doc.status!="Closed" || this.frm.is_new())) {
 			if (this.frm.doc.docstatus===0) {
 				this.frm.add_custom_button(__('Sales Order'),
 					function() {


### PR DESCRIPTION
Fix for make button not appearing in delivery note
