### PR TITLE
fix: Straight line asset depreciation not working if Expected Value After Useful Life is defined

### DIFF
--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -296,6 +296,12 @@ frappe.ui.form.on('Asset', {
 		frm.toggle_reqd("finance_books", frm.doc.calculate_depreciation);
 	},
 
+	gross_purchase_amount: function(frm) {
+		frm.doc.finance_books.forEach(d => {
+			frm.events.set_depreciation_rate(frm, d);
+		})
+	},
+
 	set_depreciation_rate: function(frm, row) {
 		if (row.total_number_of_depreciations && row.frequency_of_depreciation) {
 			frappe.call({

--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -102,9 +102,9 @@ class TestAsset(unittest.TestCase):
 		asset.save()
 		self.assertEqual(asset.status, "Draft")
 		expected_schedules = [
-			["2020-06-06", 163.93, 163.93],
-			["2021-04-06", 49836.07, 50000.0],
-			["2022-02-06", 40000.0, 90000.00]
+			["2020-06-06", 147.54, 147.54],
+			["2021-04-06", 44852.46, 45000.0],
+			["2022-02-06", 45000.0, 90000.00]
 		]
 
 		schedules = [[cstr(d.schedule_date), d.depreciation_amount, d.accumulated_depreciation_amount]
@@ -130,8 +130,8 @@ class TestAsset(unittest.TestCase):
 		self.assertEqual(asset.status, "Draft")
 		asset.save()
 		expected_schedules = [
-			["2020-06-06", 197.37, 40197.37],
-			["2021-04-06", 49802.63, 90000.00]
+			["2020-06-06", 164.47, 40164.47],
+			["2021-04-06", 49835.53, 90000.00]
 		]
 		schedules = [[cstr(d.schedule_date), flt(d.depreciation_amount, 2), d.accumulated_depreciation_amount]
 			for d in asset.get("schedules")]
@@ -266,8 +266,8 @@ class TestAsset(unittest.TestCase):
 		self.assertEqual(asset.get("schedules")[0].journal_entry[:4], "DEPR")
 
 		expected_gle = (
-			("_Test Accumulated Depreciations - _TC", 0.0, 35699.15),
-			("_Test Depreciations - _TC", 35699.15, 0.0)
+			("_Test Accumulated Depreciations - _TC", 0.0, 32129.24),
+			("_Test Depreciations - _TC", 32129.24, 0.0)
 		)
 
 		gle = frappe.db.sql("""select account, debit, credit from `tabGL Entry`


### PR DESCRIPTION
**Issue**

![5-Asset](https://user-images.githubusercontent.com/8780500/56636309-f7778700-6685-11e9-8393-c6b052af786b.png)


**After Fix**

![Screen Shot 2019-04-23 at 5 25 40 pm](https://user-images.githubusercontent.com/8780500/56636313-fcd4d180-6685-11e9-8c35-86bce4182f7f.png)
