### PR TITLE
fix: Better error message for plaid setting

### DIFF
--- a/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.js
+++ b/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.js
@@ -22,6 +22,10 @@ erpnext.integrations.plaidLink = class plaidLink {
 		frappe.xcall('erpnext.erpnext_integrations.doctype.plaid_settings.plaid_settings.plaid_configuration')
 			.then(result => {
 				if (result !== "disabled") {
+					console.log(result)
+					if (result.plaid_env == undefined || result.plaid_public_key == undefined) {
+						frappe.throw(__("Please add valid Plaid api keys in site_config.json first"));
+					}
 					me.plaid_env = result.plaid_env;
 					me.plaid_public_key = result.plaid_public_key;
 					me.client_name = result.client_name;

--- a/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.js
+++ b/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.js
@@ -22,7 +22,6 @@ erpnext.integrations.plaidLink = class plaidLink {
 		frappe.xcall('erpnext.erpnext_integrations.doctype.plaid_settings.plaid_settings.plaid_configuration')
 			.then(result => {
 				if (result !== "disabled") {
-					console.log(result)
 					if (result.plaid_env == undefined || result.plaid_public_key == undefined) {
 						frappe.throw(__("Please add valid Plaid api keys in site_config.json first"));
 					}


### PR DESCRIPTION
Hi,

This PR adds a better error message when people try to activate Plaid without setting up the keys in site_config.json first.

