### PR TITLE
fix: Trial balance finance book issue

### DIFF
--- a/erpnext/accounts/report/financial_statements.py
+++ b/erpnext/accounts/report/financial_statements.py
@@ -359,7 +359,8 @@ def set_gl_entries_by_account(
 			"from_date": from_date,
 			"to_date": to_date,
 			"cost_center": filters.cost_center,
-			"project": filters.project
+			"project": filters.project,
+			"finance_book": filters.get("finance_book")
 		},
 		as_dict=True)
 


### PR DESCRIPTION
Issue
```
{'event': None, 'retry': 0, 'log': <function log at 0x7f2ecf9ad9b0>, 'site': u'erpnext.awgp.in', 'job_name': u'<function run_background at 0x7f1682229488>', 'method_name': u'run_background', 'method': <function run_background at 0x7f2ecfa3c230>, 'user': u'nishthabhatnagar51@gmail.com', 'kwargs': {'instance': <frappe.core.doctype.prepared_report.prepared_report.PreparedReport object at 0x7f2ecfa13d90>}, 'is_async': True}
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/background_jobs.py", line 99, in execute_job
    method(**kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/prepared_report/prepared_report.py", line 49, in run_background
    result = generate_report_result(report, filters=instance.filters, user=instance.owner)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 75, in generate_report_result
    res = frappe.get_attr(method_name)(frappe._dict(filters))
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/report/trial_balance/trial_balance.py", line 15, in execute
    data = get_data(filters)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/report/trial_balance/trial_balance.py", line 72, in get_data
    filters.to_date, min_lft, max_rgt, filters, gl_entries_by_account, ignore_closing_entries=not flt(filters.with_period_closing_entry))
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/report/financial_statements.py", line 364, in set_gl_entries_by_account
    as_dict=True)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/database.py", line 155, in sql
    self._cursor.execute(query, values)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/pymysql/cursors.py", line 168, in execute
    query = self.mogrify(query, args)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/pymysql/cursors.py", line 147, in mogrify
    query = query % self._escape_args(args, conn)
KeyError: 'finance_book'
```