### PR TITLE
fix: show only party_type doctypes in Party Type field of bank account

### DIFF
--- a/erpnext/accounts/doctype/bank_account/bank_account.js
+++ b/erpnext/accounts/doctype/bank_account/bank_account.js
@@ -12,6 +12,11 @@ frappe.ui.form.on('Bank Account', {
 				}
 			};
 		});
+		frm.set_query("party_type", function() {
+			return {
+				query: "erpnext.setup.doctype.party_type.party_type.get_party_type",
+			}
+		});
 	},
 	refresh: function(frm) {
 		frappe.dynamic_link = { doc: frm.doc, fieldname: 'name', doctype: 'Bank Account' }

--- a/erpnext/accounts/doctype/bank_account/bank_account.js
+++ b/erpnext/accounts/doctype/bank_account/bank_account.js
@@ -15,7 +15,7 @@ frappe.ui.form.on('Bank Account', {
 		frm.set_query("party_type", function() {
 			return {
 				query: "erpnext.setup.doctype.party_type.party_type.get_party_type",
-			}
+			};
 		});
 	},
 	refresh: function(frm) {


### PR DESCRIPTION
fix for https://github.com/frappe/erpnext/issues/16767
