### PR TITLE
fix: while saving employee user getting user permissions error

### DIFF
--- a/erpnext/hr/doctype/employee/employee.py
+++ b/erpnext/hr/doctype/employee/employee.py
@@ -78,7 +78,7 @@ class Employee(NestedSet):
 
 	def update_user_permissions(self):
 		if not self.create_user_permission: return
-		if not has_permission('User Permission', ptype='write'): return
+		if not has_permission('User Permission', ptype='write', raise_exception=False): return
 
 		employee_user_permission_exists = frappe.db.exists('User Permission', {
 			'allow': 'Employee',
@@ -237,7 +237,7 @@ def validate_employee_role(doc, method):
 def update_user_permissions(doc, method):
 	# called via User hook
 	if "Employee" in [d.role for d in doc.get("roles")]:
-		if not has_permission('User Permission', ptype='write'): return
+		if not has_permission('User Permission', ptype='write', raise_exception=False): return
 		employee = frappe.get_doc("Employee", {"user_id": doc.name})
 		employee.update_user_permissions()
 


### PR DESCRIPTION
**Issue** 

While saving the employee user getting below error

![Screen Shot 2019-04-29 at 7 14 42 pm](https://user-images.githubusercontent.com/8780500/56900310-21c8aa80-6ab3-11e9-9cc2-98d03868f01f.png)


On save of employee, if the employee in linked with the user then system auto create the user permissions. But before that we checks the user has permissions to create the user permission or not

Dependent PR https://github.com/frappe/frappe/pull/7376