### PR TITLE
fix: ImportError: Module import failed

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -595,3 +595,4 @@ erpnext.patches.v11_1.woocommerce_set_creation_user
 erpnext.patches.v11_1.delete_bom_browser
 erpnext.patches.v11_1.set_salary_details_submittable
 erpnext.patches.v11_1.rename_depends_on_lwp
+erpnext.patches.v11_1.delete_user_permission_for_page_and_report

--- a/erpnext/patches/v11_1/delete_user_permission_for_page_and_report.py
+++ b/erpnext/patches/v11_1/delete_user_permission_for_page_and_report.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
+# License: GNU General Public License v3. See license.txt
+
+from __future__ import unicode_literals
+import frappe
+
+def execute():
+	frappe.db.sql("""delete from `tabDocType` where name='User Permission For Page And Report'""")

--- a/erpnext/patches/v11_1/delete_user_permission_for_page_and_report.py
+++ b/erpnext/patches/v11_1/delete_user_permission_for_page_and_report.py
@@ -5,4 +5,4 @@ from __future__ import unicode_literals
 import frappe
 
 def execute():
-	frappe.db.sql("""delete from `tabDocType` where name='User Permission For Page And Report'""")
+	frappe.delete_doc("DocType", "User Permission For Page And Report")


### PR DESCRIPTION
fix for error while installing custom app due to presence of user_permission_for_page_and_report in db for v11 sites

> frappe.core.doctype.user_permission_for_page_and_report.user_permission_for_page_and_report Error: No module named user_permission_for_page_and_report.user_permission_for_page_and_report