### PR TITLE
fix: Always fetch exchange rate from ref document

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -160,7 +160,7 @@ class PaymentEntry(AccountsController):
 					d.reference_name, self.party_account_currency)
 
 				for field, value in iteritems(ref_details):
-					if not d.get(field) or force:
+					if field == 'exchange_rate' or not d.get(field) or force:
 						d.set(field, value)
 
 	def validate_payment_type(self):


### PR DESCRIPTION
Default exchange rate is set as 1. In case of multi currency, it should always be fetched from order/invoice.