### PR TITLE
fix: Multilingual handling in woocommerce integration

### DIFF
--- a/erpnext/erpnext_integrations/connectors/woocommerce_connection.py
+++ b/erpnext/erpnext_integrations/connectors/woocommerce_connection.py
@@ -186,7 +186,7 @@ def link_item(item_data,item_status):
 	item.item_name = str(item_data.get("name"))
 	item.item_code = "woocommerce - " + str(item_data.get("product_id"))
 	item.woocommerce_id = str(item_data.get("product_id"))
-	item.item_group = "WooCommerce Products"
+	item.item_group = _("WooCommerce Products")
 	item.stock_uom = woocommerce_settings.uom or _("Nos")
 	item.save()
 	frappe.db.commit()

--- a/erpnext/erpnext_integrations/doctype/woocommerce_settings/woocommerce_settings.py
+++ b/erpnext/erpnext_integrations/doctype/woocommerce_settings/woocommerce_settings.py
@@ -4,8 +4,8 @@
 
 from __future__ import unicode_literals
 import frappe
-
 from frappe import _
+from frappe.utils.nestedset import get_root_of
 from frappe.model.document import Document
 from six.moves.urllib.parse import urlparse
 
@@ -62,10 +62,10 @@ class WoocommerceSettings(Document):
 					custom.read_only = 1
 					custom.save()
 
-			if not frappe.get_value("Item Group",{"name": "WooCommerce Products"}):
+			if not frappe.get_value("Item Group",{"name": _("WooCommerce Products")}):
 				item_group = frappe.new_doc("Item Group")
-				item_group.item_group_name = "WooCommerce Products"
-				item_group.parent_item_group = _("All Item Groups")
+				item_group.item_group_name = _("WooCommerce Products")
+				item_group.parent_item_group = get_root_of("Item Group")
 				item_group.save()
 
 
@@ -83,7 +83,7 @@ class WoocommerceSettings(Document):
 			for name in email_names:
 				frappe.delete_doc("Custom Field",name)
 
-			frappe.delete_doc("Item Group","WooCommerce Products")
+			frappe.delete_doc("Item Group", _("WooCommerce Products"))
 
 		frappe.db.commit()
 


### PR DESCRIPTION
Issue:
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2019-05-01/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-2019-05-01/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2019-05-01/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2019-05-01/apps/frappe/frappe/__init__.py", line 1027, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2019-05-01/apps/frappe/frappe/desk/form/save.py", line 22, in savedocs
    doc.save()
  File "/home/frappe/benches/bench-2019-05-01/apps/frappe/frappe/model/document.py", line 260, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-2019-05-01/apps/frappe/frappe/model/document.py", line 296, in _save
    self.run_before_save_methods()
  File "/home/frappe/benches/bench-2019-05-01/apps/frappe/frappe/model/document.py", line 876, in run_before_save_methods
    self.run_method("validate")
  File "/home/frappe/benches/bench-2019-05-01/apps/frappe/frappe/model/document.py", line 772, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-2019-05-01/apps/frappe/frappe/model/document.py", line 1048, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-2019-05-01/apps/frappe/frappe/model/document.py", line 1031, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-2019-05-01/apps/frappe/frappe/model/document.py", line 766, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-2019-05-01/apps/erpnext/erpnext/erpnext_integrations/doctype/woocommerce_settings/woocommerce_settings.py", line 15, in validate
    self.create_delete_custom_fields()
  File "/home/frappe/benches/bench-2019-05-01/apps/erpnext/erpnext/erpnext_integrations/doctype/woocommerce_settings/woocommerce_settings.py", line 69, in create_delete_custom_fields
    item_group.save()
  File "/home/frappe/benches/bench-2019-05-01/apps/frappe/frappe/model/document.py", line 260, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-2019-05-01/apps/frappe/frappe/model/document.py", line 283, in _save
    self.insert()
  File "/home/frappe/benches/bench-2019-05-01/apps/frappe/frappe/model/document.py", line 216, in insert
    self._validate_links()
  File "/home/frappe/benches/bench-2019-05-01/apps/frappe/frappe/model/document.py", line 741, in _validate_links
    frappe.LinkValidationError)
  File "/home/frappe/benches/bench-2019-05-01/apps/frappe/frappe/__init__.py", line 352, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red')
  File "/home/frappe/benches/bench-2019-05-01/apps/frappe/frappe/__init__.py", line 338, in msgprint
    _raise_exception()
  File "/home/frappe/benches/bench-2019-05-01/apps/frappe/frappe/__init__.py", line 311, in _raise_exception
    raise raise_exception(msg)
LinkValidationError: Could not find Parent Item Group: All Item Groups
```