### PR TITLE
fix: Task status fix

### DIFF
--- a/erpnext/projects/doctype/task/task.py
+++ b/erpnext/projects/doctype/task/task.py
@@ -143,6 +143,13 @@ class Task(NestedSet):
 
 		self.update_nsm_model()
 
+	def update_status(self):
+		if self.status not in ('Cancelled', 'Closed') and self.exp_end_date:
+			from datetime import datetime
+			if self.exp_end_date < datetime.now().date():
+				self.db_set('status', 'Overdue')
+				self.update_project()
+
 @frappe.whitelist()
 def check_if_child_exists(name):
 	return frappe.db.sql("""select name from `tabTask`
@@ -168,10 +175,9 @@ def set_multiple_status(names, status):
 		task.save()
 
 def set_tasks_as_overdue():
-	frappe.db.sql("""update tabTask set `status`='Overdue'
-		where exp_end_date is not null
-		and exp_end_date < CURDATE()
-		and `status` not in ('Closed', 'Cancelled')""")
+	tasks = frappe.get_all("Task", filters={'status':['not in',['Cancelled', 'Closed']]})
+	for task in tasks:
+		frappe.get_doc("Task", task.name).update_status()
 
 @frappe.whitelist()
 def get_children(doctype, parent, task=None, project=None, is_root=False):


### PR DESCRIPTION
Same as https://github.com/frappe/erpnext/pull/17000

## Issue
The task of the Project shows Open as the status but when opened from Task List, it says Overdue.
The status of the Tasks are not fetching.
![LbOii6N](https://user-images.githubusercontent.com/18097732/54879743-9da35780-4e62-11e9-9284-39cda5fded95.png)


## Changes Made
- Used ORM instead of a SQL for set_task_as_overdue
- update_status function compares the time and marks the appropriate task as overdue
- The on_update hook makes the changes in project as well
