### PR TITLE
fix: get totals of gross profit amount on call of the method get_invoiced_item_gross_margin

### DIFF
--- a/erpnext/accounts/report/utils.py
+++ b/erpnext/accounts/report/utils.py
@@ -137,7 +137,7 @@ def get_appropriate_company(filters):
 	return company
 
 @frappe.whitelist()
-def get_invoiced_item_gross_margin(sales_invoice=None, item_code=None, company=None):
+def get_invoiced_item_gross_margin(sales_invoice=None, item_code=None, company=None, with_item_data=False):
 	from erpnext.accounts.report.gross_profit.gross_profit import GrossProfitGenerator
 
 	sales_invoice = sales_invoice or frappe.form_dict.get('sales_invoice')
@@ -152,5 +152,8 @@ def get_invoiced_item_gross_margin(sales_invoice=None, item_code=None, company=N
 	}
 
 	gross_profit_data = GrossProfitGenerator(filters)
+	result = gross_profit_data.grouped_data
+	if not with_item_data:
+		result = sum([d.gross_profit for d in result])
 
-	return gross_profit_data.grouped_data
+	return result


### PR DESCRIPTION
**Output will look like as below**
![Screen Shot 2019-05-08 at 3 30 36 pm](https://user-images.githubusercontent.com/8780500/57367402-84523280-71a6-11e9-9e94-2fef76db7ccc.png)
