### PR TITLE
fix: POS batch not set correctly

### DIFF
--- a/erpnext/accounts/page/pos/pos.js
+++ b/erpnext/accounts/page/pos/pos.js
@@ -1957,6 +1957,12 @@ erpnext.pos.PointOfSale = erpnext.taxes_and_totals.extend({
 			}],
 			function(values){
 				me.item_batch_no[me.items[0].item_code] = values.batch;
+				const item = me.frm.doc.items.find(
+					({ item_code }) => item_code === me.items[0].item_code
+				);
+				if (item) {
+					item.batch_no = values.batch;
+				}
 			},
 			__('Select Batch No'))
 		}


### PR DESCRIPTION
Fixes https://discuss.erpnext.com/t/no-batch-in-offline-pos/39246

This issue only crops up when one uses the **Select Batch No** prompt to select batch; or in other words when the method `mandatory_batch_no` runs. **NOT** when one enters the batch number directly in the search field.

This is happening because the code that sets the batch from the user response to the property `item_batch_no` is executed inside a callback

https://github.com/frappe/erpnext/blob/09145674ece9a906f6198de5e862f062237044a1/erpnext/accounts/page/pos/pos.js#L1958-L1960

Whereas, the code that sets the item `batch_no` in `this.frm.doc.items` is executed in synchronous flow. Therefore, `me.item_batch_no[d.item_code]` is `undefined` during its run.
https://github.com/frappe/erpnext/blob/09145674ece9a906f6198de5e862f062237044a1/erpnext/accounts/page/pos/pos.js#L1408-L1410

The proposed change will leave intact the earlier behavior of the search field.
