### PR TITLE
fix(HR Settings): Unable to save HR Settings

### DIFF
--- a/erpnext/hr/doctype/hr_settings/hr_settings.js
+++ b/erpnext/hr/doctype/hr_settings/hr_settings.js
@@ -13,9 +13,11 @@ frappe.ui.form.on('HR Settings', {
 
 	validate: function(frm) {
 		let policy = frm.doc.password_policy;
-		if (policy.includes(' ') || policy.includes('--')) {
-			frappe.msgprint("Password policy cannot contain spaces or simultaneous hyphens. The format will be restructured automatically");
+		if (policy) {
+			if (policy.includes(' ') || policy.includes('--')) {
+				frappe.msgprint("Password policy cannot contain spaces or simultaneous hyphens. The format will be restructured automatically");
+			}
+			frm.set_value('password_policy', policy.split(new RegExp(" |-", 'g')).filter((token) => token).join('-'));
 		}
-		frm.set_value('password_policy', policy.split(new RegExp(" |-", 'g')).filter((token) => token).join('-'));
 	}
 });


### PR DESCRIPTION
Was unable to save HR settings due to a bug in client side validation. This has been fixed in this PR.