### PR TITLE
fix: not able to create the sales invoice without item code

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -506,8 +506,8 @@ class SalesInvoice(SellingController):
 		for i in dic:
 			if frappe.db.get_single_value('Selling Settings', dic[i][0]) == 'Yes':
 				for d in self.get('items'):
-					if frappe.get_cached_value('Item', d.item_code, 'is_stock_item') == 1 \
-						and not d.get(i.lower().replace(' ','_')) and not self.get(dic[i][1]):
+					if (d.item_code and frappe.get_cached_value('Item', d.item_code, 'is_stock_item') == 1
+						and not d.get(i.lower().replace(' ','_')) and not self.get(dic[i][1])):
 						msgprint(_("{0} is mandatory for Item {1}").format(i,d.item_code), raise_exception=1)
 
 


### PR DESCRIPTION
**Issue**
While creating the sales invoice if item code is not added then getting below error
![Screen Shot 2019-05-14 at 11 48 23 pm](https://user-images.githubusercontent.com/8780500/57723210-cba85980-76a5-11e9-8918-4d7ef50a642f.png)

Same error is getting while making the sales invoice using Opening Invoice Creation Tool
![Screen Shot 2019-05-15 at 12 10 35 am](https://user-images.githubusercontent.com/8780500/57723293-f2ff2680-76a5-11e9-8feb-ca5e21ee7728.png)
