### PR TITLE
fix: set barcode on selection of item if item has one barcode

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -306,7 +306,20 @@ def get_basic_details(args, item):
 	for fieldname in ("item_name", "item_group", "barcodes", "brand", "stock_uom"):
 		out[fieldname] = item.get(fieldname)
 
+	child_doctype = args.doctype + ' Item'
+	meta = frappe.get_meta(child_doctype)
+	if meta.get_field("barcode"):
+		update_barcode_value(out)
+
 	return out
+
+def update_barcode_value(out):
+	from erpnext.accounts.doctype.sales_invoice.pos import get_barcode_data
+	barcode_data = get_barcode_data([out])
+
+	# If item has one barcode then update the value of the barcode field
+	if barcode_data and len(barcode_data.get(out.item_code)) == 1:
+		out['barcode'] = barcode_data.get(out.item_code)
 
 @frappe.whitelist()
 def calculate_service_end_date(args, item=None):


### PR DESCRIPTION
**Issue**
On selection of item system not fetched the barcode because item may have multiple barcodes. But if the item has one barcode then it should fetch

**After fix**
![fixed_barcode_issue](https://user-images.githubusercontent.com/8780500/57761518-4eb7c700-771b-11e9-93d0-08ee55bce95b.gif)
