### PR TITLE
feat: Added 'Add Multiple' options in all sales / purchase transactions

### DIFF
--- a/erpnext/crm/doctype/opportunity/opportunity.js
+++ b/erpnext/crm/doctype/opportunity/opportunity.js
@@ -20,6 +20,10 @@ frappe.ui.form.on("Opportunity", {
 		});
 	},
 
+	onload_post_render: function(frm) {
+		frm.get_field("items").grid.set_multiple_add("item_code", "qty");
+	},
+
 	party_name: function(frm) {
 		if (frm.doc.opportunity_from == "Customer") {
 			frm.trigger('set_contact_link');

--- a/erpnext/manufacturing/doctype/blanket_order/blanket_order.js
+++ b/erpnext/manufacturing/doctype/blanket_order/blanket_order.js
@@ -31,5 +31,9 @@ frappe.ui.form.on('Blanket Order', {
 				});
 			}).addClass("btn-primary");
 		}
+	},
+
+	onload_post_render: function(frm) {
+		frm.get_field("items").grid.set_multiple_add("item_code", "qty");
 	}
 });

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -260,6 +260,7 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 		}
 		if(frappe.meta.get_docfield(this.frm.doc.doctype + " Item", "item_code")) {
 			this.setup_item_selector();
+			this.frm.get_field("items").grid.set_multiple_add("item_code", "qty");
 		}
 	},
 

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -77,10 +77,6 @@ frappe.ui.form.on("Sales Order", {
 			if(!d.delivery_date) d.delivery_date = frm.doc.delivery_date;
 		});
 		refresh_field("items");
-	},
-
-	onload_post_render: function(frm) {
-		frm.get_field("items").grid.set_multiple_add("item_code", "qty");
 	}
 });
 

--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -38,6 +38,10 @@ frappe.ui.form.on('Material Request', {
 		};
 	},
 
+	onload_post_render: function(frm) {
+		frm.get_field("items").grid.set_multiple_add("item_code", "qty");
+	},
+
 	refresh: function(frm) {
 		frm.events.make_custom_buttons(frm);
 	},

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.js
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.js
@@ -26,10 +26,6 @@ frappe.ui.form.on("Purchase Receipt", {
 		});
 	},
 
-	onload_post_render: function(frm) {
-		frm.get_field("items").grid.set_multiple_add("item_code", "qty");
-	},
-
 	refresh: function(frm) {
 		if(frm.doc.company) {
 			frm.trigger("toggle_display_account_head");

--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -579,9 +579,7 @@ erpnext.stock.StockEntry = erpnext.stock.StockController.extend({
 			}
 		});
 
-		// if(!this.item_selector && false) {
-		// 	this.item_selector = new erpnext.ItemSelector({frm: this.frm});
-		// }
+		this.frm.get_field("items").grid.set_multiple_add("item_code", "qty");
 	},
 
 	refresh: function() {


### PR DESCRIPTION
Added 'Add Multiple' options in Item table for following docs:

1. Opportunity
1. Quotation
1. Sales Order
1. Delivery Note
1. Sales Invoice
1. Material Request
1. Supplier Quotation
1. Purchase Order
1. Purchase Receipt
1. Purchase Invoice
1. Blanket Order
1. Stock Entry