### PR TITLE
fix(tests): Save batch instead of submitting it

### DIFF
--- a/erpnext/stock/doctype/batch/test_batch.py
+++ b/erpnext/stock/doctype/batch/test_batch.py
@@ -176,7 +176,7 @@ class TestBatch(unittest.TestCase):
 				item = item_name,
 				batch_id = batch_name
 			)).insert(ignore_permissions=True)
-			batch.submit()
+			batch.save()
 
 		stock_entry = frappe.get_doc(dict(
 			doctype = 'Stock Entry',


### PR DESCRIPTION
**Ref:** https://travis-ci.com/frappe/erpnext/jobs/195859880

Made to develop at #17637.

<hr>

```diff
======================================================================
ERROR: test_get_batch_qty (erpnext.stock.doctype.batch.test_batch.TestBatch)
Test getting batch quantities by batch_numbers, item_code or warehouse
======================================================================

Traceback (most recent call last):
  File "/home/travis/frappe-bench/apps/erpnext/erpnext/stock/doctype/batch/test_batch.py", line 167, in test_get_batch_qty
    self.make_new_batch_and_entry('ITEM-BATCH-2', 'batch a', '_Test Warehouse - _TC')
  File "/home/travis/frappe-bench/apps/erpnext/erpnext/stock/doctype/batch/test_batch.py", line 206, in make_new_batch_and_entry
    stock_entry.submit()
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 852, in submit
    self._submit()
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 841, in _submit
    self.save()
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 266, in save
    return self._save(*args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 319, in _save
    self.run_post_save_methods()
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 915, in run_post_save_methods
    self.run_method("on_submit")
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 781, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 1051, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 1034, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 775, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/travis/frappe-bench/apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.py", line 81, in on_submit
    self.update_stock_ledger()
  File "/home/travis/frappe-bench/apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.py", line 594, in update_stock_ledger
    self.make_sl_entries(sl_entries, self.amended_from and 'Yes' or 'No')
  File "/home/travis/frappe-bench/apps/erpnext/erpnext/controllers/stock_controller.py", line 274, in make_sl_entries
    make_sl_entries(sl_entries, is_amended, allow_negative_stock, via_landed_cost_voucher)
  File "/home/travis/frappe-bench/apps/erpnext/erpnext/stock/stock_ledger.py", line 33, in make_sl_entries
    sle_id = make_entry(sle, allow_negative_stock, via_landed_cost_voucher)
  File "/home/travis/frappe-bench/apps/erpnext/erpnext/stock/stock_ledger.py", line 58, in make_entry
    sle.submit()
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 852, in submit
    self._submit()
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 841, in _submit
    self.save()
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 266, in save
    return self._save(*args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 319, in _save
    self.run_post_save_methods()
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 915, in run_post_save_methods
    self.run_method("on_submit")
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 781, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 1051, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 1034, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 775, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/travis/frappe-bench/apps/erpnext/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py", line 44, in on_submit
    batch.save()
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 266, in save
    return self._save(*args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 308, in _save
    self.validate_update_after_submit()
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 704, in validate_update_after_submit
    self._validate_update_after_submit()
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/base_document.py", line 615, in _validate_update_after_submit
    frappe.UpdateAfterSubmitError)
  File "/home/travis/frappe-bench/apps/frappe/frappe/__init__.py", line 352, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red')
  File "/home/travis/frappe-bench/apps/frappe/frappe/__init__.py", line 338, in msgprint
    _raise_exception()
  File "/home/travis/frappe-bench/apps/frappe/frappe/__init__.py", line 311, in _raise_exception
    raise raise_exception(msg)
UpdateAfterSubmitError: Not allowed to change Batch Quantity after submission
```