### PR TITLE
fix: changed fieldtype from data to float

### DIFF
--- a/erpnext/stock/doctype/material_request_item/material_request_item.json
+++ b/erpnext/stock/doctype/material_request_item/material_request_item.json
@@ -368,13 +368,13 @@
   },
   {
    "fieldname": "received_qty",
-   "fieldtype": "Data",
+   "fieldtype": "Float",
    "label": "Received Quantity"
   }
  ],
  "idx": 1,
  "istable": 1,
- "modified": "2019-05-08 10:27:25.008801",
+ "modified": "2019-05-16 17:00:00.056060",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Material Request Item",


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/api.py", line 56, in handle
    return frappe.handler.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1026, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/form/save.py", line 19, in savedocs
    doc.submit()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 852, in submit
    self._submit()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 841, in _submit
    self.save()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 266, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 319, in _save
    self.run_post_save_methods()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 915, in run_post_save_methods
    self.run_method("on_submit")
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 781, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1051, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1034, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 775, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py", line 133, in on_submit
    self.update_prevdoc_status()
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/controllers/status_updater.py", line 115, in update_prevdoc_status
    self.validate_qty()
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/controllers/status_updater.py", line 191, in validate_qty
    self.check_overflow_with_tolerance(item, args)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/controllers/status_updater.py", line 200, in check_overflow_with_tolerance
    print(item[args['target_field']], item[args['target_ref_field']], args['target_field'], args['target_ref_field'], args, item)
TypeError: unsupported operand type(s) for -: 'unicode' and 'float'
```