### PR TITLE
fix: Correcting the reference to web pages from item search on item_group

### DIFF
--- a/erpnext/www/all-products/item_row.html
+++ b/erpnext/www/all-products/item_row.html
@@ -2,7 +2,7 @@
 	<div class="row no-gutters">
 		<div class="col-md-3">
 			<div class="card-body">
-				<a class="no-underline" href="{{ item.route }}">
+				<a class="no-underline" href="/{{ item.route }}">
 					<img class="website-image" src="{{ item.website_image or item.image or 'no-image.jpg' }}" alt="{{ item.item_name }}">
 				</a>
 			</div>
@@ -10,7 +10,7 @@
 		<div class="col-md-9">
 			<div class="card-body">
 				<h5 class="card-title">
-					<a class="text-dark" href="{{ item.route }}">
+					<a class="text-dark" href="/{{ item.route }}">
 						{{ item.item_name or item.name }}
 					</a>
 				</h5>


### PR DESCRIPTION
Please read the pull request checklist to make sure your changes are merged: https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

This pull request solves issue https://github.com/frappe/erpnext/issues/17560. 
Currently on clicking the link on item row, it adds the address of current page to the route rather than the base url.
The changes corrects the issues and web pages are opening correctly 