### PR TITLE
fix: Person / Org name is not mandatory while creation of lead from email

### DIFF
--- a/erpnext/crm/doctype/lead/lead.py
+++ b/erpnext/crm/doctype/lead/lead.py
@@ -110,7 +110,7 @@ class Lead(SellingController):
 	def set_lead_name(self):
 		if not self.lead_name:
 			# Check for leads being created through data import
-			if not self.company_name:
+			if not self.company_name and not self.flags.ignore_mandatory:
 				frappe.throw(_("A Lead requires either a person's name or an organization's name"))
 
 			self.lead_name = self.company_name


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/background_jobs.py", line 103, in execute_job
    method(**kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/email/doctype/email_account/email_account.py", line 713, in pull_from_email_account
    email_account.receive()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/email/doctype/email_account/email_account.py", line 301, in receive
    raise Exception(frappe.as_json(exceptions))
Exception: [
 "Traceback (most recent call last):\n  File \"/home/frappe/frappe-bench/apps/frappe/frappe/email/doctype/email_account/email_account.py\", line 278, in receive
communication = self.insert_communication(msg, args=args)
 File \"/home/frappe/frappe-bench/apps/frappe/frappe/email/doctype/email_account/email_account.py\", line 380, in insert_communication
self.set_thread(communication, email)
 File \"/home/frappe/frappe-bench/apps/frappe/frappe/email/doctype/email_account/email_account.py\", line 431, in set_thread
parent = self.create_new_parent(communication, email)
File \"/home/frappe/frappe-bench/apps/frappe/frappe/email/doctype/email_account/email_account.py\", line 507, in create_new_parent\n    parent.insert(ignore_permissions=True)
File \"/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py\", line 222, in insert\n    self.run_before_save_methods()
File \"/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py\", line 876, in run_before_save_methods\n    self.run_method(\"validate\")
File \"/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py\", line 772, in run_method\n    out = Document.hook(fn)(self, *args, **kwargs)
File \"/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py\", line 1048, in composer\n    return composed(self, method, *args, **kwargs)
File \"/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py\", line 1031, in runner\n    add_to_return_value(self, fn(self, *args, **kwargs))
File \"/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py\", line 766, in <lambda>\n    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
File \"/home/frappe/frappe-bench/apps/erpnext/erpnext/crm/doctype/lead/lead.py\", line 27, in validate\n    self.set_lead_name()
File \"/home/frappe/frappe-bench/apps/erpnext/erpnext/crm/doctype/lead/lead.py\", line 114, in set_lead_name
frappe.throw(_(\"A Lead requires either a person's name or an organization's name\"))
File \"/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py\", line 351, in throw
msgprint(msg, raise_exception=exc, title=title, indicator='red')
File \"/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py\", line 337, in msgprint\n    _raise_exception()
File \"/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py\", line 310, in _raise_exception
raise raise_exception(msg)\nValidationError: A Lead requires either a person's name or an organization's name
"
]
```