### PR TITLE
fix(Revert): sales order status for order type 'Maintenance

### DIFF
--- a/erpnext/controllers/status_updater.py
+++ b/erpnext/controllers/status_updater.py
@@ -34,8 +34,8 @@ status_map = {
 	],
 	"Sales Order": [
 		["Draft", None],
-		["To Deliver and Bill", "eval:self.per_delivered < 100 and self.per_billed < 100 and self.docstatus == 1 and self.order_type in ['Sales', 'Shopping Cart']"],
-		["To Bill", "eval:self.per_delivered == 100 or self.order_type == 'Maintenance' and self.per_billed < 100 and self.docstatus == 1"],
+		["To Deliver and Bill", "eval:self.per_delivered < 100 and self.per_billed < 100 and self.docstatus == 1"],
+		["To Bill", "eval:self.per_delivered == 100 and self.per_billed < 100 and self.docstatus == 1"],
 		["To Deliver", "eval:self.per_delivered < 100 and self.per_billed == 100 and self.docstatus == 1"],
 		["Completed", "eval:self.per_delivered == 100 and self.per_billed == 100 and self.docstatus == 1"],
 		["Completed", "eval:self.order_type == 'Maintenance' and self.per_billed == 100 and self.docstatus == 1"],

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -140,12 +140,15 @@ erpnext.selling.SalesOrderController = erpnext.selling.SellingController.extend(
 				}
 
 				// delivery note
-				if(flt(doc.per_delivered, 6) < 100 && ["Sales", "Shopping Cart"].indexOf(doc.order_type)!==-1 && allow_delivery) {
+				if(flt(doc.per_delivered, 6) < 100 && allow_delivery) {
 					this.frm.add_custom_button(__('Delivery'),
 						function() { me.make_delivery_note_based_on_delivery_date(); }, __("Make"));
-					this.frm.add_custom_button(__('Work Order'),
-						function() { me.make_work_order() }, __("Make"));
 
+					if(["Sales", "Shopping Cart"].indexOf(doc.order_type)!==-1){
+						this.frm.add_custom_button(__('Work Order'),
+							function() { me.make_work_order() }, __("Make"));
+
+						}
 					this.frm.page.set_inner_btn_group_as_primary(__("Make"));
 				}
 
@@ -181,8 +184,6 @@ erpnext.selling.SalesOrderController = erpnext.selling.SellingController.extend(
 				// maintenance
 				if(flt(doc.per_delivered, 2) < 100 &&
 						["Sales", "Shopping Cart"].indexOf(doc.order_type)===-1) {
-					this.frm.add_custom_button(__('Delivery'),
-						function() { me.make_delivery_note_based_on_delivery_date(); }, __("Make"));
 					this.frm.add_custom_button(__('Maintenance Visit'),
 						function() { me.make_maintenance_visit() }, __("Make"));
 					this.frm.add_custom_button(__('Maintenance Schedule'),

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -181,6 +181,8 @@ erpnext.selling.SalesOrderController = erpnext.selling.SellingController.extend(
 				// maintenance
 				if(flt(doc.per_delivered, 2) < 100 &&
 						["Sales", "Shopping Cart"].indexOf(doc.order_type)===-1) {
+					this.frm.add_custom_button(__('Delivery'),
+						function() { me.make_delivery_note_based_on_delivery_date(); }, __("Make"));
 					this.frm.add_custom_button(__('Maintenance Visit'),
 						function() { me.make_maintenance_visit() }, __("Make"));
 					this.frm.add_custom_button(__('Maintenance Schedule'),

--- a/erpnext/selling/doctype/sales_order/sales_order_list.js
+++ b/erpnext/selling/doctype/sales_order/sales_order_list.js
@@ -31,17 +31,23 @@ frappe.listview_settings['Sales Order'] = {
 					"per_delivered,<,100|per_billed,=,100|status,!=,Closed"];
 			}
 
-		} else if ((doc.order_type === "Maintenance" || flt(doc.per_delivered, 6) == 100)
+		} else if ((flt(doc.per_delivered, 6) == 100)
 			&& flt(doc.grand_total) !== 0 && flt(doc.per_billed, 6) < 100 && doc.status !== "Closed") {
 			// to bill
 
 			return [__("To Bill"), "orange", "per_delivered,=,100|per_billed,<,100|status,!=,Closed"];
 
-		} else if ((doc.order_type === "Maintenance" || flt(doc.per_delivered, 6) == 100)
+		} else if ((flt(doc.per_delivered, 6) === 100)
 			&& (flt(doc.grand_total) === 0 || flt(doc.per_billed, 6) == 100) && doc.status !== "Closed") {
-
 			return [__("Completed"), "green", "per_delivered,=,100|per_billed,=,100|status,!=,Closed"];
+
+		}else if (doc.order_type === "Maintenance" && flt(doc.per_delivered, 6) < 100 && flt(doc.per_billed, 6) < 100 && doc.status !== "Closed"){
+			return [__("To Deliver and Bill"), "orange", "per_delivered,=,100|per_billed,=,100|status,!=,Closed"];
+
+		}else if (doc.order_type === "Maintenance" && flt(doc.per_delivered, 6) < 100 && flt(doc.per_billed, 6) == 100 && doc.status !== "Closed"){
+			return [__("To Deliver"), "orange", "per_delivered,=,100|per_billed,=,100|status,!=,Closed"];
 		}
+
 	},
 	onload: function(listview) {
 		var method = "erpnext.selling.doctype.sales_order.sales_order.close_or_unclose_sales_orders";


### PR DESCRIPTION
Reverts #17119
The PR is needed to Revert because Order type Maintenance need delivery note in some cases and is not needed in some cases. So we have decided to create a checkbox Delivery Note required in Sales Order if Order Type is Maintenance

