### PR TITLE
fix: payment reconciliation not update the status of the expense claim

### DIFF
--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -333,6 +333,9 @@ def reconcile_against_document(args):
 		doc = frappe.get_doc(d.voucher_type, d.voucher_no)
 		doc.make_gl_entries(cancel = 0, adv_adj =1)
 
+		if d.voucher_type == 'Payment Entry':
+			doc.update_expense_claim()
+
 def check_if_advance_entry_modified(args):
 	"""
 		check if there is already a voucher reference

--- a/erpnext/hr/doctype/expense_claim/expense_claim_dashboard.py
+++ b/erpnext/hr/doctype/expense_claim/expense_claim_dashboard.py
@@ -1,0 +1,13 @@
+from __future__ import unicode_literals
+from frappe import _
+
+def get_data():
+	return {
+        'fieldname': 'reference_name',
+		'transactions': [
+			{
+				'label': _('Payment'),
+				'items': ['Payment Entry']
+			},
+		]
+	}


### PR DESCRIPTION
**Issue**

1. Created advance payment entry for employee and then expense claim.
1. Then linked them using payment reconciliation.
![Screen Shot 2019-05-20 at 5 04 40 pm](https://user-images.githubusercontent.com/8780500/58019002-0d138b80-7b22-11e9-8873-92c515156ae7.png)

1. In the payment entry reference of the expense claim if showing properly, but in the expense claim the status still showing as Unpaid

![Screen Shot 2019-05-20 at 5 04 54 pm](https://user-images.githubusercontent.com/8780500/58018892-ba39d400-7b21-11e9-99c5-127a83d752a2.png)

