### PR TITLE
fix: while making the item, default warehouse not set even if the stock settings has the default warehouse

### DIFF
--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -691,7 +691,18 @@ class Item(WebsiteGenerator):
 						'income_account': item.income_account
 					})
 			else:
-				self.append("item_defaults", {"company": frappe.defaults.get_defaults().company})
+				warehouse = ''
+				defaults = frappe.defaults.get_defaults() or {}
+
+				# To check default warehouse is belong to the default company
+				if defaults.get("default_warehouse") and frappe.db.exists("Warehouse",
+					{'name': defaults.default_warehouse, 'company': defaults.company}):
+					warehouse = defaults.default_warehouse
+
+				self.append("item_defaults", {
+					"company": defaults.get("company"),
+					"default_warehouse": warehouse
+				})
 
 	def update_variants(self):
 		if self.flags.dont_update_variants or \


### PR DESCRIPTION
**Issue**

In stock settings "Default Warehouse" is set
![Screen Shot 2019-05-21 at 10 40 26 am](https://user-images.githubusercontent.com/8780500/58069977-e81c2880-7bb4-11e9-9d0d-bbd6a42d3886.png)


Sill while making the item default warehouse is not set
![Screen Shot 2019-05-21 at 10 42 24 am](https://user-images.githubusercontent.com/8780500/58070047-30d3e180-7bb5-11e9-9a8c-85f84dba2df6.png)


**After Fix**
![Screen Shot 2019-05-21 at 11 02 04 am](https://user-images.githubusercontent.com/8780500/58070761-eb64e380-7bb7-11e9-86a1-658e2f941a6e.png)
