### PR TITLE
fix(projects): Remove hardcode of expected end date for new Tasks

### DIFF
--- a/erpnext/projects/doctype/task/task.js
+++ b/erpnext/projects/doctype/task/task.js
@@ -19,43 +19,38 @@ frappe.ui.form.on("Task", {
 	},
 
 	refresh: function(frm) {
-		frm.fields_dict['parent_task'].get_query = function() {
+		frm.fields_dict['parent_task'].get_query = function () {
 			return {
 				filters: {
 					"is_group": 1,
 				}
 			}
 		}
-		if(!frm.is_group){
-			var doc = frm.doc;
-			if(doc.__islocal) {
-				if(!frm.doc.exp_end_date) {
-					frm.set_value("exp_end_date", frappe.datetime.add_days(new Date(), 7));
-				}
-			}
 
-			if(!doc.__islocal) {
-				if(frappe.model.can_read("Timesheet")) {
-					frm.add_custom_button(__("Timesheet"), function() {
-						frappe.route_options = {"project": doc.project, "task": doc.name}
+		if (!frm.doc.is_group) {
+			if (!frm.is_new()) {
+				if (frappe.model.can_read("Timesheet")) {
+					frm.add_custom_button(__("Timesheet"), () => {
+						frappe.route_options = { "project": frm.doc.project, "task": frm.doc.name }
 						frappe.set_route("List", "Timesheet");
 					}, __("View"), true);
 				}
-				if(frappe.model.can_read("Expense Claim")) {
-					frm.add_custom_button(__("Expense Claims"), function() {
-						frappe.route_options = {"project": doc.project, "task": doc.name}
+
+				if (frappe.model.can_read("Expense Claim")) {
+					frm.add_custom_button(__("Expense Claims"), () => {
+						frappe.route_options = { "project": frm.doc.project, "task": frm.doc.name }
 						frappe.set_route("List", "Expense Claim");
 					}, __("View"), true);
 				}
 
-				if(frm.perm[0].write) {
-					if(frm.doc.status!=="Closed" && frm.doc.status!=="Cancelled") {
-						frm.add_custom_button(__("Close"), function() {
+				if (frm.perm[0].write) {
+					if (!["Closed", "Cancelled"].includes(frm.doc.status)) {
+						frm.add_custom_button(__("Close"), () => {
 							frm.set_value("status", "Closed");
 							frm.save();
 						});
 					} else {
-						frm.add_custom_button(__("Reopen"), function() {
+						frm.add_custom_button(__("Reopen"), () => {
 							frm.set_value("status", "Open");
 							frm.save();
 						});


### PR DESCRIPTION
Made to develop at #17717.

<hr>

**Problem:**
Whenever a new Task is created, the system adds a hardcoded number of days to the current date and sets it as the expected end date. This can be un-intuitive when it comes to managing projects, since a lot of Tasks may have differing completion times.

**Solution:**
Remove the hardcode, and let the user select the expected end date for each Task manually based on its scope.

<hr>

**Screenshots / GIFs:**

![exp-end-date](https://user-images.githubusercontent.com/13396535/58242670-db423500-7d6c-11e9-987c-29db21901573.gif)