### PR TITLE
fix: Holidays from Holiday List was showing on same date in Calendar View(v12)

### DIFF
--- a/erpnext/hr/doctype/holiday_list/holiday_list.py
+++ b/erpnext/hr/doctype/holiday_list/holiday_list.py
@@ -79,6 +79,7 @@ def get_events(start, end, filters=None):
 		filters.append(['Holiday', 'holiday_date', '>', getdate(start)])
 	if end:
 		filters.append(['Holiday', 'holiday_date', '<', getdate(end)])
+
 	return frappe.get_list('Holiday List',
 		fields=['name', '`tabHoliday`.holiday_date', '`tabHoliday`.description', '`tabHoliday List`.color'],
 		filters = filters,

--- a/erpnext/hr/doctype/holiday_list/holiday_list_calendar.js
+++ b/erpnext/hr/doctype/holiday_list/holiday_list_calendar.js
@@ -3,8 +3,8 @@
 
 frappe.views.calendar["Holiday List"] = {
 	field_map: {
-		"start": "from_date",
-		"end": "to_date",
+		"start": "holiday_date",
+		"end": "holiday_date",
 		"id": "name",
 		"title": "description",
 		"allDay": "allDay"


### PR DESCRIPTION
Before: Holidays fetching from Holiday list in calendar view was on same day.
so this PR aim to fix this

![](https://frappe.erpnext.com/files/yjGTA4a.png)
 Now:


![image](https://user-images.githubusercontent.com/32095923/58398091-5e1b0680-8071-11e9-9d8a-b4973cd26b93.png)


