### PR TITLE
fix: add shopify_supplier_id custom field while setting up shopify

### DIFF
--- a/erpnext/erpnext_integrations/doctype/shopify_settings/shopify_settings.py
+++ b/erpnext/erpnext_integrations/doctype/shopify_settings/shopify_settings.py
@@ -107,10 +107,18 @@ def get_series():
 
 def setup_custom_fields():
 	custom_fields = {
-		"Customer": [dict(fieldname='shopify_customer_id', label='Shopify Customer Id',
-			fieldtype='Data', insert_after='series', read_only=1, print_hide=1)],
-		"Address": [dict(fieldname='shopify_address_id', label='Shopify Address Id',
-			fieldtype='Data', insert_after='fax', read_only=1, print_hide=1)],
+		"Customer": [
+			dict(fieldname='shopify_customer_id', label='Shopify Customer Id',
+				fieldtype='Data', insert_after='series', read_only=1, print_hide=1)
+		],
+		"Supplier": [
+			dict(fieldname='shopify_supplier_id', label='Shopify Supplier Id',
+				fieldtype='Data', insert_after='supplier_name', read_only=1, print_hide=1)
+		],
+		"Address": [
+			dict(fieldname='shopify_address_id', label='Shopify Address Id',
+				fieldtype='Data', insert_after='fax', read_only=1, print_hide=1)
+		],
 		"Item": [
 			dict(fieldname='shopify_variant_id', label='Shopify Variant Id',
 				fieldtype='Data', insert_after='item_code', read_only=1, print_hide=1),
@@ -119,16 +127,20 @@ def setup_custom_fields():
 			dict(fieldname='shopify_description', label='Shopify Description',
 				fieldtype='Text Editor', insert_after='description', read_only=1, print_hide=1)
 		],
-		"Sales Order": [dict(fieldname='shopify_order_id', label='Shopify Order Id',
-			fieldtype='Data', insert_after='title', read_only=1, print_hide=1)],
+		"Sales Order": [
+			dict(fieldname='shopify_order_id', label='Shopify Order Id',
+				fieldtype='Data', insert_after='title', read_only=1, print_hide=1)
+		],
 		"Delivery Note":[
 			dict(fieldname='shopify_order_id', label='Shopify Order Id',
 				fieldtype='Data', insert_after='title', read_only=1, print_hide=1),
 			dict(fieldname='shopify_fulfillment_id', label='Shopify Fulfillment Id',
 				fieldtype='Data', insert_after='title', read_only=1, print_hide=1)
 		],
-		"Sales Invoice": [dict(fieldname='shopify_order_id', label='Shopify Order Id',
-			fieldtype='Data', insert_after='title', read_only=1, print_hide=1)]
+		"Sales Invoice": [
+			dict(fieldname='shopify_order_id', label='Shopify Order Id',
+				fieldtype='Data', insert_after='title', read_only=1, print_hide=1)
+		]
 	}
 
 	create_custom_fields(custom_fields)


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2019-05-21/apps/erpnext/erpnext/erpnext_integrations/connectors/shopify_connection.py", line 28, in sync_sales_order
    validate_item(order, shopify_settings)
  File "/home/frappe/benches/bench-2019-05-21/apps/erpnext/erpnext/erpnext_integrations/connectors/shopify_connection.py", line 74, in validate_item
    sync_item_from_shopify(shopify_settings, item)
  File "/home/frappe/benches/bench-2019-05-21/apps/erpnext/erpnext/erpnext_integrations/doctype/shopify_settings/sync_product.py", line 20, in sync_item_from_shopify
    raise e
InternalError: (1054, u"Unknown column 'shopify_supplier_id' in 'where clause'")
```