### PR TITLE
feat: allow user to sync stock_value and account_balance jv if perpetual inventory is checked 

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/test_journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/test_journal_entry.py
@@ -82,12 +82,11 @@ class TestJournalEntry(unittest.TestCase):
 		from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import set_perpetual_inventory
 		set_perpetual_inventory()
 
-		# Making stock value and account balance
+		# Making journal Entry to balance stock value and account difference
 		diff = get_stock_and_account_difference(account_list=['_Test Bank - _TC', 'Stock In Hand - _TC'], company='_Test Company')
 		jv1 = frappe.copy_doc(test_records[0])
 
 		if diff > 0:
-			print(" iam here")
 			jv1.get("accounts")[0].update({
 				"account": get_inventory_account('_Test Company'),
 				"company": "_Test Company",
@@ -101,7 +100,6 @@ class TestJournalEntry(unittest.TestCase):
 				"debit_in_account_currency": 0.0,
 			})
 		elif diff < 0:
-			print("i am here also")
 			jv1.get("accounts")[0].update({
 				"account": get_inventory_account('_Test Company'),
 				"company": "_Test Company",

--- a/erpnext/accounts/doctype/journal_entry/test_journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/test_journal_entry.py
@@ -312,6 +312,8 @@ def sync_stock_value_and_account_balance(diff ,account_list, company):
 		to_credit = -(diff)
 		to_debit = 0
 
+	print("---------------->>>>", to_credit, to_debit, to_credit-to_debit)
+
 	if diff != 0:
 		jv = frappe.new_doc("Journal Entry")
 		jv.cheque_date =  "2013-03-14"
@@ -331,6 +333,7 @@ def sync_stock_value_and_account_balance(diff ,account_list, company):
 		})
 
 		for acc in account_list:
+			print("----------->>>>>>>>>>>",acc ,flt(to_debit/len(account_list)))
 			jv.append('accounts', {
 				"account": acc,
 				'party': "_Test Supplier",

--- a/erpnext/accounts/doctype/loyalty_program/test_loyalty_program.py
+++ b/erpnext/accounts/doctype/loyalty_program/test_loyalty_program.py
@@ -6,6 +6,7 @@ from __future__ import unicode_literals
 import frappe
 import unittest
 from frappe.utils import today, cint, flt, getdate
+from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import set_perpetual_inventory
 from erpnext.accounts.doctype.loyalty_program.loyalty_program import get_loyalty_program_details_with_points
 from erpnext.accounts.party import get_dashboard_info
 
@@ -261,6 +262,8 @@ def create_records():
 			}
 		]
 	}).insert()
+
+	set_perpetual_inventory(0, '_Test Company')
 
 	# create an item
 	item = frappe.get_doc({

--- a/erpnext/accounts/doctype/loyalty_program/test_loyalty_program.py
+++ b/erpnext/accounts/doctype/loyalty_program/test_loyalty_program.py
@@ -9,10 +9,12 @@ from frappe.utils import today, cint, flt, getdate
 from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import set_perpetual_inventory
 from erpnext.accounts.doctype.loyalty_program.loyalty_program import get_loyalty_program_details_with_points
 from erpnext.accounts.party import get_dashboard_info
+from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import set_perpetual_inventory
 
 class TestLoyaltyProgram(unittest.TestCase):
 	@classmethod
 	def setUpClass(self):
+		set_perpetual_inventory(0)
 		# create relevant item, customer, loyalty program, etc
 		create_records()
 

--- a/erpnext/accounts/general_ledger.py
+++ b/erpnext/accounts/general_ledger.py
@@ -120,8 +120,10 @@ def validate_account_for_perpetual_inventory(gl_map):
 	aii_accounts = [d[0] for d in frappe.db.sql("""select name from tabAccount
 				where account_type = 'Stock' and is_group=0""")]
 
-	stock_value_and_account_balance_difference = get_stock_and_account_difference(account_list=account_list ,company= gl_map[0].company)
+	print("aaaaaaaa",account_list, gl_map[0].company)
 
+	stock_value_and_account_balance_difference = get_stock_and_account_difference(account_list=account_list ,company= gl_map[0].company)
+	print("------->>>diff", stock_value_and_account_balance_difference)
 
 	if cint(erpnext.is_perpetual_inventory_enabled(gl_map[0].company)) \
 		and gl_map[0].voucher_type=="Journal Entry":

--- a/erpnext/accounts/general_ledger.py
+++ b/erpnext/accounts/general_ledger.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 import frappe, erpnext
 from frappe.utils import flt, cstr, cint
 from frappe import _
+from erpnext.accounts.utils import get_stock_and_account_difference
 from frappe.model.meta import get_field_precision
 from erpnext.accounts.doctype.budget.budget import validate_expense_against_budget
 from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import get_accounting_dimensions
@@ -113,15 +114,26 @@ def make_entry(args, adv_adj, update_outstanding, from_repost=False):
 	gle.submit()
 
 def validate_account_for_perpetual_inventory(gl_map):
-	if cint(erpnext.is_perpetual_inventory_enabled(gl_map[0].company)) \
-		and gl_map[0].voucher_type=="Journal Entry":
-			aii_accounts = [d[0] for d in frappe.db.sql("""select name from tabAccount
+	account_list = [gl_entries.account for gl_entries in gl_map]
+	account_list = list(dict.fromkeys(account_list))
+
+	aii_accounts = [d[0] for d in frappe.db.sql("""select name from tabAccount
 				where account_type = 'Stock' and is_group=0""")]
 
-			for entry in gl_map:
-				if entry.account in aii_accounts:
-					frappe.throw(_("Account: {0} can only be updated via Stock Transactions")
-						.format(entry.account), StockAccountInvalidTransaction)
+	stock_value_and_account_balance_difference = get_stock_and_account_difference(account_list=account_list ,company= gl_map[0].company)
+
+
+	if cint(erpnext.is_perpetual_inventory_enabled(gl_map[0].company)) \
+		and gl_map[0].voucher_type=="Journal Entry":
+
+			if stock_value_and_account_balance_difference == 0:
+				for entry in gl_map:
+					if entry.account in aii_accounts:
+						frappe.throw(_("Account: {0} can only be updated via Stock Transactions")
+							.format(entry.account), StockAccountInvalidTransaction)
+
+	if stock_value_and_account_balance_difference != 0 and gl_map[0].voucher_type != "Journal Entry":
+		frappe.msgprint(_("Account Balance and Stock Value is Out of sync please Create Journal Entry to Balance"))
 
 def round_off_debit_credit(gl_map):
 	precision = get_field_precision(frappe.get_meta("GL Entry").get_field("debit"),

--- a/erpnext/accounts/general_ledger.py
+++ b/erpnext/accounts/general_ledger.py
@@ -12,6 +12,7 @@ from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import g
 
 
 class StockAccountInvalidTransaction(frappe.ValidationError): pass
+class StockValueAndAccountBalanceOutOfSync(frappe.ValidationError): pass
 
 def make_gl_entries(gl_map, cancel=False, adv_adj=False, merge_entries=True, update_outstanding='Yes', from_repost=False):
 	if gl_map:
@@ -132,7 +133,7 @@ def validate_account_for_perpetual_inventory(gl_map):
 							.format(entry.account), StockAccountInvalidTransaction)
 
 	if stock_value_and_account_balance_difference != 0 and gl_map[0].voucher_type != "Journal Entry":
-		frappe.msgprint(_("Account Balance and Stock Value is Out of sync please Create Journal Entry to Balance"))
+		frappe.throw(_("Account Balance and Stock Value is Out of sync please Create Journal Entry to Balance"), StockValueAndAccountBalanceOutOfSync)
 
 def round_off_debit_credit(gl_map):
 	precision = get_field_precision(frappe.get_meta("GL Entry").get_field("debit"),

--- a/erpnext/accounts/general_ledger.py
+++ b/erpnext/accounts/general_ledger.py
@@ -120,10 +120,7 @@ def validate_account_for_perpetual_inventory(gl_map):
 	aii_accounts = [d[0] for d in frappe.db.sql("""select name from tabAccount
 				where account_type = 'Stock' and is_group=0""")]
 
-	print("aaaaaaaa",account_list, gl_map[0].company)
-
 	stock_value_and_account_balance_difference = get_stock_and_account_difference(account_list=account_list ,company= gl_map[0].company)
-	print("------->>>diff", stock_value_and_account_balance_difference)
 
 	if cint(erpnext.is_perpetual_inventory_enabled(gl_map[0].company)) \
 		and gl_map[0].voucher_type=="Journal Entry":

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -571,7 +571,7 @@ def get_stock_and_account_difference(account_list=None, posting_date=None, compa
 			balance = get_balance_on(account, posting_date, in_account_currency=False)
 			total_account_balance += balance
 
-	total_diff = abs(flt(total_stock_value) - flt(total_account_balance))
+	total_diff = flt(total_stock_value) - flt(total_account_balance)
 
 	return total_diff
 

--- a/erpnext/manufacturing/doctype/bom/test_bom.py
+++ b/erpnext/manufacturing/doctype/bom/test_bom.py
@@ -10,11 +10,13 @@ from frappe.test_runner import make_test_records
 from erpnext.stock.doctype.stock_reconciliation.test_stock_reconciliation import create_stock_reconciliation
 from erpnext.manufacturing.doctype.bom_update_tool.bom_update_tool import update_cost
 from six import string_types
+from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import set_perpetual_inventory
 
 test_records = frappe.get_test_records('BOM')
 
 class TestBOM(unittest.TestCase):
 	def setUp(self):
+		set_perpetual_inventory(0)
 		if not frappe.get_value('Item', '_Test Item'):
 			make_test_records('Item')
 

--- a/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
@@ -11,9 +11,11 @@ from erpnext.manufacturing.doctype.production_plan.production_plan import get_sa
 from erpnext.stock.doctype.stock_reconciliation.test_stock_reconciliation import create_stock_reconciliation
 from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
 from erpnext.manufacturing.doctype.production_plan.production_plan import get_items_for_material_requests
+from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import set_perpetual_inventory
 
 class TestProductionPlan(unittest.TestCase):
 	def setUp(self):
+		set_perpetual_inventory(0)
 		for item in ['Test Production Item 1', 'Subassembly Item 1',
 			'Raw Material Item 1', 'Raw Material Item 2']:
 			create_item(item, valuation_rate=100)

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -17,6 +17,7 @@ from erpnext.manufacturing.doctype.production_plan.test_production_plan import m
 
 class TestWorkOrder(unittest.TestCase):
 	def setUp(self):
+		set_perpetual_inventory(0)
 		self.warehouse = '_Test Warehouse 2 - _TC'
 		self.item = '_Test Item'
 

--- a/erpnext/stock/doctype/batch/test_batch.py
+++ b/erpnext/stock/doctype/batch/test_batch.py
@@ -8,9 +8,13 @@ import unittest
 
 from erpnext.stock.doctype.batch.batch import get_batch_qty, UnableToSelectBatchError, get_batch_no
 from frappe.utils import cint
+from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import set_perpetual_inventory
 
 
 class TestBatch(unittest.TestCase):
+
+	def setUp(self):
+		set_perpetual_inventory(0)
 
 	def test_item_has_batch_enabled(self):
 		self.assertRaises(ValidationError, frappe.get_doc({

--- a/erpnext/stock/doctype/delivery_note/test_delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/test_delivery_note.py
@@ -22,6 +22,9 @@ from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_orde
 from erpnext.accounts.doctype.account.test_account import get_inventory_account, create_account
 
 class TestDeliveryNote(unittest.TestCase):
+	def setUp(self):
+		set_perpetual_inventory(0)
+
 	def tearDown(self):
 		target_warehouse = "_Test Warehouse 1 - _TC"
 		company = "_Test Company"

--- a/erpnext/stock/doctype/item_alternative/test_item_alternative.py
+++ b/erpnext/stock/doctype/item_alternative/test_item_alternative.py
@@ -11,6 +11,7 @@ from erpnext.manufacturing.doctype.work_order.work_order import make_stock_entry
 from erpnext.stock.doctype.stock_reconciliation.test_stock_reconciliation import create_stock_reconciliation
 from erpnext.manufacturing.doctype.work_order.test_work_order import make_wo_order_test_record
 from erpnext.buying.doctype.purchase_order.purchase_order import make_purchase_receipt, make_rm_stock_entry
+from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import set_perpetual_inventory
 import unittest
 
 class TestItemAlternative(unittest.TestCase):
@@ -18,6 +19,7 @@ class TestItemAlternative(unittest.TestCase):
 		make_items()
 
 	def test_alternative_item_for_subcontract_rm(self):
+		set_perpetual_inventory(enable=0)
 		create_stock_reconciliation(item_code='Alternate Item For A RW 1', warehouse='_Test Warehouse - _TC',
 			qty=5, rate=2000)
 		create_stock_reconciliation(item_code='Test FG A RW 2', warehouse='_Test Warehouse - _TC',
@@ -67,6 +69,7 @@ class TestItemAlternative(unittest.TestCase):
 		self.assertEqual(status, True)
 
 	def test_alternative_item_for_production_rm(self):
+		set_perpetual_inventory(enable=0)
 		create_stock_reconciliation(item_code='Alternate Item For A RW 1',
 			warehouse='_Test Warehouse - _TC',qty=5, rate=2000)
 		create_stock_reconciliation(item_code='Test FG A RW 2', warehouse='_Test Warehouse - _TC',

--- a/erpnext/stock/doctype/landed_cost_voucher/test_landed_cost_voucher.py
+++ b/erpnext/stock/doctype/landed_cost_voucher/test_landed_cost_voucher.py
@@ -12,6 +12,9 @@ from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make
 from erpnext.accounts.doctype.account.test_account import get_inventory_account
 
 class TestLandedCostVoucher(unittest.TestCase):
+	def setUp(self):
+		set_perpetual_inventory(0)
+
 	def test_landed_cost_voucher(self):
 		frappe.db.set_value("Buying Settings", None, "allow_multiple_items", 1)
 		set_perpetual_inventory(1)
@@ -48,7 +51,7 @@ class TestLandedCostVoucher(unittest.TestCase):
 		self.assertTrue(gl_entries)
 
 		stock_in_hand_account = get_inventory_account(pr.company, pr.get("items")[0].warehouse)
-		fixed_asset_account = get_inventory_account(pr.company, pr.get("items")[1].warehouse)  
+		fixed_asset_account = get_inventory_account(pr.company, pr.get("items")[1].warehouse)
 
 		if stock_in_hand_account == fixed_asset_account:
 			expected_values = {
@@ -56,7 +59,7 @@ class TestLandedCostVoucher(unittest.TestCase):
 				"Stock Received But Not Billed - _TC": [0.0, 500.0],
 				"Expenses Included In Valuation - _TC": [0.0, 300.0]
 			}
-			
+
 		else:
 			expected_values = {
 				stock_in_hand_account: [400.0, 0.0],
@@ -70,10 +73,10 @@ class TestLandedCostVoucher(unittest.TestCase):
 			self.assertEqual(expected_values[gle.account][1], gle.credit)
 
 		set_perpetual_inventory(0)
-		
+
 	def test_landed_cost_voucher_against_purchase_invoice(self):
 		set_perpetual_inventory(1)
-		
+
 		pi = make_purchase_invoice(update_stock=1, posting_date=frappe.utils.nowdate(),
 			posting_time=frappe.utils.nowtime())
 
@@ -86,10 +89,10 @@ class TestLandedCostVoucher(unittest.TestCase):
 			fieldname=["qty_after_transaction", "stock_value"], as_dict=1)
 
 		submit_landed_cost_voucher("Purchase Invoice", pi.name)
-		
-		pi_lc_value = frappe.db.get_value("Purchase Invoice Item", {"parent": pi.name}, 
+
+		pi_lc_value = frappe.db.get_value("Purchase Invoice Item", {"parent": pi.name},
 			"landed_cost_voucher_amount")
-			
+
 		self.assertEqual(pi_lc_value, 50.0)
 
 		last_sle_after_landed_cost = frappe.db.get_value("Stock Ledger Entry", {
@@ -120,7 +123,7 @@ class TestLandedCostVoucher(unittest.TestCase):
 			self.assertEqual(expected_values[gle.account][1], gle.credit)
 
 		set_perpetual_inventory(0)
-		
+
 	def test_landed_cost_voucher_for_serialized_item(self):
 		set_perpetual_inventory(1)
 		frappe.db.sql("delete from `tabSerial No` where name in ('SN001', 'SN002', 'SN003', 'SN004', 'SN005')")
@@ -158,19 +161,19 @@ class TestLandedCostVoucher(unittest.TestCase):
 		pr.submit()
 
 		lcv = submit_landed_cost_voucher("Purchase Receipt", pr.name, 123.22)
-		
+
 		self.assertEqual(lcv.items[0].applicable_charges, 41.07)
-		self.assertEqual(lcv.items[2].applicable_charges, 41.08)		
-		
+		self.assertEqual(lcv.items[2].applicable_charges, 41.08)
+
 		set_perpetual_inventory(0)
 
 def submit_landed_cost_voucher(receipt_document_type, receipt_document, charges=50):
 	ref_doc = frappe.get_doc(receipt_document_type, receipt_document)
-	
+
 	lcv = frappe.new_doc("Landed Cost Voucher")
 	lcv.company = "_Test Company"
 	lcv.distribute_charges_based_on = 'Amount'
-	
+
 	lcv.set("purchase_receipts", [{
 		"receipt_document_type": receipt_document_type,
 		"receipt_document": receipt_document,
@@ -178,7 +181,7 @@ def submit_landed_cost_voucher(receipt_document_type, receipt_document, charges=
 		"posting_date": ref_doc.posting_date,
 		"grand_total": ref_doc.base_grand_total
 	}])
-	
+
 	lcv.set("taxes", [{
 		"description": "Insurance Charges",
 		"account": "_Test Account Insurance Charges - _TC",
@@ -186,13 +189,13 @@ def submit_landed_cost_voucher(receipt_document_type, receipt_document, charges=
 	}])
 
 	lcv.insert()
-	
+
 	distribute_landed_cost_on_items(lcv)
-	
+
 	lcv.submit()
 
 	return lcv
-		
+
 def distribute_landed_cost_on_items(lcv):
 	based_on = lcv.distribute_charges_based_on.lower()
 	total = sum([flt(d.get(based_on)) for d in lcv.get("items")])

--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -14,6 +14,7 @@ from erpnext.stock.doctype.item.test_item import make_item
 from six import iteritems
 class TestPurchaseReceipt(unittest.TestCase):
 	def setUp(self):
+		set_perpetual_inventory(0)
 		frappe.db.set_value("Buying Settings", None, "allow_multiple_items", 1)
 
 	def test_make_purchase_invoice(self):

--- a/erpnext/stock/doctype/serial_no/test_serial_no.py
+++ b/erpnext/stock/doctype/serial_no/test_serial_no.py
@@ -12,6 +12,7 @@ from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import make_pu
 from erpnext.stock.doctype.delivery_note.test_delivery_note import create_delivery_note
 from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos
 from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import set_perpetual_inventory
 
 test_dependencies = ["Item"]
 test_records = frappe.get_test_records('Serial No')
@@ -37,6 +38,8 @@ class TestSerialNo(unittest.TestCase):
 		self.assertTrue(SerialNoCannotCannotChangeError, sr.save)
 
 	def test_inter_company_transfer(self):
+		set_perpetual_inventory(0, "_Test Company 1")
+		set_perpetual_inventory(0)
 		se = make_serialized_item(target_warehouse="_Test Warehouse - _TC")
 		serial_nos = get_serial_nos(se.get("items")[0].serial_no)
 

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -74,6 +74,7 @@ class TestStockEntry(unittest.TestCase):
 		frappe.db.set_default("allow_negative_stock", 0)
 
 	def test_auto_material_request(self):
+		set_perpetual_inventory(0)
 		make_item_variant()
 		self._test_auto_material_request("_Test Item")
 		self._test_auto_material_request("_Test Item", material_request_type="Transfer")

--- a/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
@@ -16,6 +16,7 @@ from erpnext.stock.doctype.item.test_item import create_item
 
 class TestStockReconciliation(unittest.TestCase):
 	def setUp(self):
+		set_perpetual_inventory(enable=0)
 		frappe.db.set_value("Stock Settings", None, "allow_negative_stock", 1)
 		self.insert_existing_sle()
 

--- a/erpnext/stock/doctype/warehouse/test_warehouse.py
+++ b/erpnext/stock/doctype/warehouse/test_warehouse.py
@@ -15,6 +15,7 @@ test_records = frappe.get_test_records('Warehouse')
 
 class TestWarehouse(unittest.TestCase):
 	def setUp(self):
+		set_perpetual_inventory(0)
 		if not frappe.get_value('Item', '_Test Item'):
 			make_test_records('Item')
 


### PR DESCRIPTION
Before: if perpetual inventory is enabled then we are not allow to create journal entry.
now: if perpetual inventory is enabled then we are allow to create journal entry only if stock value and account balance miss match to balance record.
