### PR TITLE
fix(selling): Remove Totals row for Sales Analytics

### DIFF
--- a/erpnext/selling/report/sales_analytics/sales_analytics.json
+++ b/erpnext/selling/report/sales_analytics/sales_analytics.json
@@ -1,5 +1,5 @@
 {
- "add_total_row": 1, 
+ "add_total_row": 0, 
  "creation": "2018-09-21 12:46:29.451048", 
  "disable_prepared_report": 0, 
  "disabled": 0, 
@@ -7,7 +7,7 @@
  "doctype": "Report", 
  "idx": 0, 
  "is_standard": "Yes", 
- "modified": "2019-02-12 14:30:40.043652", 
+ "modified": "2019-05-24 05:37:02.866139", 
  "modified_by": "Administrator", 
  "module": "Selling", 
  "name": "Sales Analytics", 


### PR DESCRIPTION
Made to hotfix at #17808.

<hr>

**Problem:**

The Sales Analytics report has a tree structure, wherein group nodes indicate the total sum of all their child nodes. Having a Totals row makes no sense, because the root node already displays the totals.

**After fix:**

![image](https://user-images.githubusercontent.com/13396535/58328218-34829500-7e4f-11e9-9d36-6da89528fcc3.png)
