### PR TITLE
fix(naming): Keep naming series number on document deletion to maintain integrity

### DIFF
--- a/erpnext/hr/doctype/salary_slip/salary_slip.py
+++ b/erpnext/hr/doctype/salary_slip/salary_slip.py
@@ -73,10 +73,6 @@ class SalarySlip(TransactionBase):
 		self.update_status()
 		self.update_salary_slip_in_additional_salary()
 
-	def on_trash(self):
-		from frappe.model.naming import revert_series_if_last
-		revert_series_if_last(self.series, self.name)
-
 	def get_status(self):
 		if self.docstatus == 0:
 			status = "Draft"

--- a/erpnext/stock/doctype/batch/batch.py
+++ b/erpnext/stock/doctype/batch/batch.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.model.naming import make_autoname, revert_series_if_last
+from frappe.model.naming import make_autoname
 from frappe.utils import flt, cint
 from frappe.utils.jinja import render_template
 from frappe.utils.data import add_days
@@ -104,9 +104,6 @@ class Batch(Document):
 
 	def onload(self):
 		self.image = frappe.db.get_value('Item', self.item, 'image')
-
-	def after_delete(self):
-		revert_series_if_last(get_batch_naming_series(), self.name)
 
 	def validate(self):
 		self.item_has_batch_enabled()

--- a/erpnext/stock/doctype/batch/test_batch.py
+++ b/erpnext/stock/doctype/batch/test_batch.py
@@ -208,11 +208,6 @@ class TestBatch(unittest.TestCase):
 
 		self.assertTrue(batch_name.startswith('BATCH-'))
 
-		batch.delete()
-		batch = self.make_new_batch('_Test Stock Item For Batch Test2')
-
-		self.assertEqual(batch_name, batch.name)
-
 		# reset Stock Settings
 		if not use_naming_series:
 			frappe.set_value('Stock Settings', 'Stock Settings', 'use_naming_series', 0)


### PR DESCRIPTION
Related to https://github.com/frappe/frappe/pull/7634.

<hr>

**Reason:**

Whenever a document is created and then deleted, it resets the naming series to the previous numbering.

This can get problematic for a number of scenarios - say, for example, an Email Alert for new Sales Orders sends out the document in an email as reference. However, in case this order is deleted, and a new one created for a different Customer, it'll still have the name of the deleted document, which is bad practice.

By not unsetting the naming series whenever a document is deleted, and generate new names for each transaction / document, we avoid the issue entirely.