### PR TITLE
fix: Not able to save salary slip

### DIFF
--- a/erpnext/hr/doctype/salary_slip/salary_slip.py
+++ b/erpnext/hr/doctype/salary_slip/salary_slip.py
@@ -443,7 +443,7 @@ class SalarySlip(TransactionBase):
 				else:
 					component_row.additional_amount = amount
 
-				if not overwrite:
+				if not overwrite and component_row.default_amount:
 					amount += component_row.default_amount
 
 			component_row.amount = amount


### PR DESCRIPTION
**Issue**

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-11-2019-06-05/apps/frappe/frappe/desk/form/save.py", line 22, in savedocs
    doc.save()
  File "/home/frappe/benches/bench-11-2019-06-05/apps/frappe/frappe/model/document.py", line 260, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-11-2019-06-05/apps/frappe/frappe/model/document.py", line 296, in _save
    self.run_before_save_methods()
  File "/home/frappe/benches/bench-11-2019-06-05/apps/frappe/frappe/model/document.py", line 876, in run_before_save_methods
    self.run_method("validate")
  File "/home/frappe/benches/bench-11-2019-06-05/apps/frappe/frappe/model/document.py", line 772, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-11-2019-06-05/apps/frappe/frappe/model/document.py", line 1048, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-11-2019-06-05/apps/frappe/frappe/model/document.py", line 1031, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-11-2019-06-05/apps/frappe/frappe/model/document.py", line 766, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-11-2019-06-05/apps/erpnext/erpnext/hr/doctype/salary_slip/salary_slip.py", line 50, in validate
    self.calculate_net_pay()
  File "/home/frappe/benches/bench-11-2019-06-05/apps/erpnext/erpnext/hr/doctype/salary_slip/salary_slip.py", line 290, in calculate_net_pay
    self.calculate_component_amounts()
  File "/home/frappe/benches/bench-11-2019-06-05/apps/erpnext/erpnext/hr/doctype/salary_slip/salary_slip.py", line 308, in calculate_component_amounts
    self.add_additional_salary_components()
  File "/home/frappe/benches/bench-11-2019-06-05/apps/erpnext/erpnext/hr/doctype/salary_slip/salary_slip.py", line 398, in add_additional_salary_components
    self.update_component_row(frappe._dict(additional_component.struct_row), amount, key, overwrite=overwrite)
  File "/home/frappe/benches/bench-11-2019-06-05/apps/erpnext/erpnext/hr/doctype/salary_slip/salary_slip.py", line 447, in update_component_row
    amount += component_row.default_amount
TypeError: unsupported operand type(s) for +=: 'float' and 'NoneType'
```