### PR TITLE
fix: Homepage products styling

### DIFF
--- a/erpnext/templates/pages/home.html
+++ b/erpnext/templates/pages/home.html
@@ -33,7 +33,7 @@
 			{% for item in homepage.products %}
 			<div class="col-md-4 mb-4">
 				<div class="card h-100 justify-content-between">
-					<div class="website-image-lazy" data-class="card-img-top h-100" data-src="{{ item.image }}" data-alt="{{ item.item_name }}"></div>
+					<div class="website-image-lazy" data-class="card-img-top website-image-extra-large" data-src="{{ item.image }}" data-alt="{{ item.item_name }}"></div>
 					<div class="card-body flex-grow-0">
 						<h5 class="card-title">{{ item.item_name }}</h5>
 						<a href="{{ item.route }}" class="card-link">{{ _('More details') }}</a>


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/9355208/59344635-1f9d7100-8d2c-11e9-8bb1-d97a83aff991.png)

After:
![image](https://user-images.githubusercontent.com/9355208/59344599-101e2800-8d2c-11e9-9a51-28a868527a96.png)
