### PR TITLE
fix(stock): Remove hardcoded validation for Item

### DIFF
--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -67,8 +67,6 @@ class Item(WebsiteGenerator):
 				from frappe.model.naming import set_name_by_naming_series
 				set_name_by_naming_series(self)
 				self.item_code = self.name
-		elif not self.item_code:
-			msgprint(_("Item Code is mandatory because Item is not automatically numbered"), raise_exception=1)
 
 		self.item_code = strip(self.item_code)
 		self.name = self.item_code


### PR DESCRIPTION
Made to hotfix at #17917.

This is mostly to remove legacy code (the logic removed here was added ~6 years ago, before form validations would occur on the front-end).