### PR TITLE
feat(Sales/Purchase Order): optional to reference a Blanket Order

### DIFF
--- a/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
+++ b/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
@@ -66,6 +66,7 @@
   "supplier_quotation",
   "supplier_quotation_item",
   "col_break5",
+  "against_blanket_order",
   "blanket_order",
   "blanket_order_rate",
   "item_group",
@@ -509,6 +510,7 @@
    "read_only": 1
   },
   {
+   "depends_on": "eval:doc.against_blanket_order",
    "fieldname": "blanket_order",
    "fieldtype": "Link",
    "label": "Blanket Order",
@@ -516,6 +518,7 @@
    "options": "Blanket Order"
   },
   {
+   "depends_on": "eval:doc.against_blanket_order",
    "fieldname": "blanket_order_rate",
    "fieldtype": "Currency",
    "label": "Blanket Order Rate",
@@ -697,11 +700,17 @@
    "fieldtype": "Data",
    "label": "Manufacturer Part Number",
    "read_only": 1
+  },
+  {
+   "default": "1",
+   "fieldname": "against_blanket_order",
+   "fieldtype": "Check",
+   "label": "Against Blanket Order"
   }
  ],
  "idx": 1,
  "istable": 1,
- "modified": "2019-06-02 06:34:47.495730",
+ "modified": "2019-06-11 13:41:54.329457",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Purchase Order Item",

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1668,6 +1668,13 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 		}
 	},
 
+	against_blanket_order: function(doc, cdt, cdn) {
+		var item = locals[cdt][cdn];
+		if(!item.against_blanket_order) {
+			frappe.model.set_value(this.frm.doctype + " Item", item.name, "blanket_order", null);
+			frappe.model.set_value(this.frm.doctype + " Item", item.name, "blanket_order_rate", 0.00);
+		}
+	},
 	blanket_order: function(doc, cdt, cdn) {
 		var me = this;
 		var item = locals[cdt][cdn];

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -12,6 +12,7 @@ from erpnext.selling.doctype.sales_order.sales_order import make_work_orders
 from erpnext.controllers.accounts_controller import update_child_qty_rate
 import json
 from erpnext.selling.doctype.sales_order.sales_order import make_raw_material_request
+from erpnext.manufacturing.doctype.blanket_order.test_blanket_order import make_blanket_order
 
 class TestSalesOrder(unittest.TestCase):
 	def tearDown(self):
@@ -818,6 +819,25 @@ class TestSalesOrder(unittest.TestCase):
 		mr_doc = frappe.get_doc('Material Request',mr.get('name'))
 		self.assertEqual(mr_doc.items[0].sales_order, so.name)
 
+	def test_so_optional_blanket_order(self):
+		"""
+			Expected result: Blanket order Ordered Quantity should only be affected on Sales Order with against_blanket_order = 1.
+			Second Sales Order should not add on to Blanket Orders Ordered Quantity.
+		"""
+
+		bo = make_blanket_order(blanket_order_type = "Selling", quantity = 10, rate = 10)
+
+		so = make_sales_order(item_code= "_Test Item", qty = 5, against_blanket_order = 1)
+		so_doc = frappe.get_doc('Sales Order', so.get('name'))
+		# To test if the SO has a Blanket Order
+		self.assertTrue(so_doc.items[0].blanket_order)
+
+		so = make_sales_order(item_code= "_Test Item", qty = 5, against_blanket_order = 0)
+		so_doc = frappe.get_doc('Sales Order', so.get('name'))
+		# To test if the SO does NOT have a Blanket Order
+		self.assertEqual(so_doc.items[0].blanket_order, None)
+
+
 def make_sales_order(**args):
 	so = frappe.new_doc("Sales Order")
 	args = frappe._dict(args)
@@ -844,7 +864,8 @@ def make_sales_order(**args):
 			"warehouse": args.warehouse,
 			"qty": args.qty or 10,
 			"uom": args.uom or None,
-			"rate": args.rate or 100
+			"rate": args.rate or 100,
+			"against_blanket_order": args.against_blanket_order
 		})
 
 	so.delivery_date = add_days(so.transaction_date, 10)

--- a/erpnext/selling/doctype/sales_order_item/sales_order_item.json
+++ b/erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -68,6 +68,7 @@
   "target_warehouse",
   "prevdoc_docname",
   "col_break4",
+  "against_blanket_order",
   "blanket_order",
   "blanket_order_rate",
   "planning_section",
@@ -110,6 +111,7 @@
    "read_only": 1
   },
   {
+   "default": "0",
    "fieldname": "ensure_delivery_based_on_produced_serial_no",
    "fieldtype": "Check",
    "label": "Ensure Delivery Based on Produced Serial No"
@@ -381,6 +383,7 @@
    "read_only": 1
   },
   {
+   "default": "0",
    "fieldname": "is_free_item",
    "fieldtype": "Check",
    "label": "Is Free Item",
@@ -436,6 +439,7 @@
    "print_hide": 1
   },
   {
+   "default": "0",
    "fieldname": "delivered_by_supplier",
    "fieldtype": "Check",
    "label": "Supplier delivers to Customer",
@@ -570,6 +574,7 @@
    "report_hide": 1
   },
   {
+   "depends_on": "eval:doc.against_blanket_order",
    "fieldname": "blanket_order",
    "fieldtype": "Link",
    "label": "Blanket Order",
@@ -577,6 +582,7 @@
    "options": "Blanket Order"
   },
   {
+   "depends_on": "eval:doc.against_blanket_order",
    "fieldname": "blanket_order_rate",
    "fieldtype": "Currency",
    "label": "Blanket Order Rate",
@@ -662,6 +668,7 @@
   },
   {
    "allow_on_submit": 1,
+   "default": "0",
    "fieldname": "page_break",
    "fieldtype": "Check",
    "label": "Page Break",
@@ -736,11 +743,17 @@
    "fieldname": "image_section",
    "fieldtype": "Section Break",
    "label": "Image"
+  },
+  {
+   "default": "1",
+   "fieldname": "against_blanket_order",
+   "fieldtype": "Check",
+   "label": "Against Blanket Order"
   }
  ],
  "idx": 1,
  "istable": 1,
- "modified": "2019-05-01 17:52:32.810797",
+ "modified": "2019-06-12 10:07:38.034240",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order Item",

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -209,7 +209,8 @@ def get_basic_details(args, item):
 			project: "",
 			qty: "",
 			stock_qty: "",
-			conversion_factor: ""
+			conversion_factor: "",
+			against_blanket_order: 0/1
 		}
 	:param item: `item_code` of Item object
 	:return: frappe._dict
@@ -280,9 +281,9 @@ def get_basic_details(args, item):
 		"weight_per_unit":item.weight_per_unit,
 		"weight_uom":item.weight_uom,
 		"last_purchase_rate": item.last_purchase_rate if args.get("doctype") in ["Purchase Order"] else 0,
-		"transaction_date": args.get("transaction_date")
+		"transaction_date": args.get("transaction_date"),
+		"against_blanket_order": args.get("against_blanket_order")
 	})
-
 	if item.get("enable_deferred_revenue") or item.get("enable_deferred_expense"):
 		out.update(calculate_service_end_date(args, item))
 
@@ -985,7 +986,7 @@ def get_serial_no(args, serial_nos=None, sales_order=None):
 
 def update_party_blanket_order(args, out):
 	blanket_order_details = get_blanket_order_details(args)
-	if blanket_order_details:
+	if out["against_blanket_order"] and blanket_order_details:
 		out.update(blanket_order_details)
 
 @frappe.whitelist()


### PR DESCRIPTION
This feature is to be able to have an option to reference or not a Blanket Order when creating a Sales/Purchase Order.

We encounter a customer that doesn't want a Sales Order be under a existing Blanket Order. Currently, when creating a Sales Order that has the same details on an existing Blanket Order, system will automatically set a Blanket Order for said SO.

We added a checkbox that will cater such scenario. Ticking the check box will automatically set the Blanket Order and if not ticked, system will leave it as blank.

Feature is applied to both Purchase Order and Sales Order.

We added test case for both PO and SO to validate that the feature is working as expected.


Sales Order
![sales order bo optional fix](https://user-images.githubusercontent.com/44422325/59407581-40290200-8de4-11e9-84ce-83c5cb1e2fd5.gif)

Purchase Order
![purchase order bo optional fix](https://user-images.githubusercontent.com/44422325/59407578-3e5f3e80-8de4-11e9-8204-2a77b3e410aa.gif)
