### PR TITLE
fix: Fixed setters for getting items from quotation/opportunity

### DIFF
--- a/erpnext/selling/doctype/quotation/quotation.js
+++ b/erpnext/selling/doctype/quotation/quotation.js
@@ -90,22 +90,29 @@ erpnext.selling.QuotationController = erpnext.selling.SellingController.extend({
 		if (this.frm.doc.docstatus===0) {
 			this.frm.add_custom_button(__('Opportunity'),
 				function() {
-					var setters = {};
-					if(me.frm.doc.quotation_to == "Customer" && me.frm.doc.party_name) {
-						setters.customer = me.frm.doc.party_name || undefined;
-					} else if (me.frm.doc.quotation_to == "Lead" && me.frm.doc.party_name) {
-						setters.lead = me.frm.doc.party_name || undefined;
-					}
 					erpnext.utils.map_current_doc({
 						method: "erpnext.crm.doctype.opportunity.opportunity.make_quotation",
 						source_doctype: "Opportunity",
 						target: me.frm,
-						setters: setters,
+						setters: [
+							{
+								label: "Party",
+								fieldname: "party_name",
+								fieldtype: "Link",
+								options: me.frm.doc.quotation_to,
+								default: me.frm.doc.party_name || undefined
+							},
+							{
+								label: "Opportunity Type",
+								fieldname: "opportunity_type",
+								fieldtype: "Link",
+								options: "Opportunity Type",
+								default: me.frm.doc.order_type || undefined
+							}
+						],
 						get_query_filters: {
 							status: ["not in", ["Lost", "Closed"]],
-							company: me.frm.doc.company,
-							// cannot set opportunity_type as setter, as the fieldname is order_type
-							opportunity_type: me.frm.doc.order_type,
+							company: me.frm.doc.company
 						}
 					})
 				}, __("Get items from"), "btn-default");

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -219,13 +219,19 @@ erpnext.selling.SalesOrderController = erpnext.selling.SellingController.extend(
 						method: "erpnext.selling.doctype.quotation.quotation.make_sales_order",
 						source_doctype: "Quotation",
 						target: me.frm,
-						setters: {
-							customer: me.frm.doc.customer || undefined
-						},
+						setters: [
+							{
+								label: "Customer",
+								fieldname: "party_name",
+								fieldtype: "Link",
+								options: "Customer",
+								default: me.frm.doc.customer || undefined
+							}
+						],
 						get_query_filters: {
 							company: me.frm.doc.company,
 							docstatus: 1,
-							status: ["!=", "Lost"],
+							status: ["!=", "Lost"]
 						}
 					})
 				}, __("Get items from"));


### PR DESCRIPTION
Depends on https://github.com/frappe/frappe/pull/7682

Setters break while pulling items from quotations in SO because different fieldnames (customer and party_name).

**Error Traceback**

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-11-2019-06-05/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-11-2019-06-05/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-11-2019-06-05/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-11-2019-06-05/apps/frappe/frappe/__init__.py", line 1032, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-11-2019-06-05/apps/frappe/frappe/desk/search.py", line 155, in search_widget
    as_list=not as_dict)
  File "/home/frappe/benches/bench-11-2019-06-05/apps/frappe/frappe/__init__.py", line 1260, in get_list
    return frappe.model.db_query.DatabaseQuery(doctype).execute(None, *args, **kwargs)
  File "/home/frappe/benches/bench-11-2019-06-05/apps/frappe/frappe/model/db_query.py", line 93, in execute
    result = self.build_and_run()
  File "/home/frappe/benches/bench-11-2019-06-05/apps/frappe/frappe/model/db_query.py", line 117, in build_and_run
    return frappe.db.sql(query, as_dict=not self.as_list, debug=self.debug, update=self.update)
  File "/home/frappe/benches/bench-11-2019-06-05/apps/frappe/frappe/database.py", line 214, in sql
    self._cursor.execute(query)
  File "/home/frappe/benches/bench-11-2019-06-05/env/lib/python2.7/site-packages/pymysql/cursors.py", line 170, in execute
    result = self._query(query)
  File "/home/frappe/benches/bench-11-2019-06-05/env/lib/python2.7/site-packages/pymysql/cursors.py", line 328, in _query
    conn.query(q)
  File "/home/frappe/benches/bench-11-2019-06-05/env/lib/python2.7/site-packages/pymysql/connections.py", line 517, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/home/frappe/benches/bench-11-2019-06-05/env/lib/python2.7/site-packages/pymysql/connections.py", line 732, in _read_query_result
    result.read()
  File "/home/frappe/benches/bench-11-2019-06-05/env/lib/python2.7/site-packages/pymysql/connections.py", line 1075, in read
    first_packet = self.connection._read_packet()
  File "/home/frappe/benches/bench-11-2019-06-05/env/lib/python2.7/site-packages/pymysql/connections.py", line 684, in _read_packet
    packet.check_error()
  File "/home/frappe/benches/bench-11-2019-06-05/env/lib/python2.7/site-packages/pymysql/protocol.py", line 220, in check_error
    err.raise_mysql_exception(self._data)
  File "/home/frappe/benches/bench-11-2019-06-05/env/lib/python2.7/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
    raise errorclass(errno, errval)
InternalError: (1054, u"Unknown column 'tabQuotation.customer' in 'field list'")

```