### PR TITLE
fix: taxes are not overriding after changing the tax template for the POS invoice

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -384,6 +384,10 @@ erpnext.accounts.SalesInvoiceController = erpnext.selling.SellingController.exte
 								me.frm.pos_print_format = r.message.print_format;
 							}
 							me.frm.script_manager.trigger("update_stock");
+							if(me.frm.doc.taxes_and_charges) {
+								me.frm.script_manager.trigger("taxes_and_charges");
+							}
+
 							frappe.model.set_default_values(me.frm.doc);
 							me.set_dynamic_labels();
 							me.calculate_taxes_and_totals();


### PR DESCRIPTION
**Issue**

Taxes CGST, SGST is not related to the template "UAE Excise 50% - GTPL"

![Screen Shot 2019-06-13 at 3 21 48 pm](https://user-images.githubusercontent.com/8780500/59424818-4f16b100-8df2-11e9-99b0-b1ad5088466d.png)


**After Fix**
![Screen Shot 2019-06-13 at 3 36 00 pm](https://user-images.githubusercontent.com/8780500/59424833-55a52880-8df2-11e9-9cfd-b90c397538b7.png)
