### PR TITLE
fix: Show product page even if cart is not enabled

### DIFF
--- a/erpnext/shopping_cart/product_info.py
+++ b/erpnext/shopping_cart/product_info.py
@@ -13,8 +13,11 @@ from erpnext.utilities.product import get_price, get_qty_in_stock
 def get_product_info_for_website(item_code):
 	"""get product price / stock info for website"""
 
-	cart_quotation = _get_cart_quotation()
 	cart_settings = get_shopping_cart_settings()
+	if not cart_settings.enabled:
+		return frappe._dict()
+
+	cart_quotation = _get_cart_quotation()
 
 	price = get_price(
 		item_code,

--- a/erpnext/templates/generators/item/item_details.html
+++ b/erpnext/templates/generators/item/item_details.html
@@ -9,7 +9,13 @@
 </p>
 <!-- description -->
 <div itemprop="description">
-	{{ doc.web_long_description or doc.description or _("No description given") | safe }}
+{% if frappe.utils.strip_html(doc.web_long_description) %}
+	{{ doc.web_long_description | safe }}
+{% elif frappe.utils.strip_html(doc.description)  %}
+	{{ doc.description | safe }}
+{% else %}
+	{{ _("No description given") }}
+{% endif  %}
 </div>
 
 {% if has_variants %}


### PR DESCRIPTION
If cart is disabled, the `/contact` page is shown. Instead it should just hide the **Add to Cart** button and the Cart. This PR does just that.