### PR TITLE
fix: filter reference name by cost center in journal entry account

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.js
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.js
@@ -222,7 +222,7 @@ erpnext.accounts.JournalEntry = frappe.ui.form.Controller.extend({
 				out.filters.push([jvd.reference_type, "outstanding_amount", "!=", 0]);
 				// Filter by cost center
 				if(jvd.cost_center) {
-					out.filters.push([jvd.reference_type, "cost_center", "=", jvd.cost_center]);
+					out.filters.push([jvd.reference_type, "cost_center", "in", ["", jvd.cost_center]]);
 				}
 				// account filter
 				frappe.model.validate_missing(jvd, "account");

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.js
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.js
@@ -220,7 +220,10 @@ erpnext.accounts.JournalEntry = frappe.ui.form.Controller.extend({
 
 			if(in_list(["Sales Invoice", "Purchase Invoice"], jvd.reference_type)) {
 				out.filters.push([jvd.reference_type, "outstanding_amount", "!=", 0]);
-
+				// Filter by cost center
+				if(jvd.cost_center) {
+					out.filters.push([jvd.reference_type, "cost_center", "=", jvd.cost_center]);
+				}
 				// account filter
 				frappe.model.validate_missing(jvd, "account");
 				var party_account_field = jvd.reference_type==="Sales Invoice" ? "debit_to": "credit_to";


### PR DESCRIPTION
In Journal Entry Account if cost center is selected then filter reference_name by it. This is only for Sales Invoice and Purchase Invoice reference type.

