### PR TITLE
fix: Add erpnext website theme import

### DIFF
--- a/erpnext/public/js/website_theme.js
+++ b/erpnext/public/js/website_theme.js
@@ -2,16 +2,13 @@
 // MIT License. See license.txt
 
 frappe.ui.form.on('Website Theme', {
-	apply_custom_theme(frm) {
-		let custom_theme = frm.doc.custom_theme;
-		custom_theme = custom_theme.split('\n');
-		if (
-			frm.doc.apply_custom_theme
-				&& custom_theme.length === 2
-				&& custom_theme[1].includes('frappe/public/scss/website')
+	validate(frm) {
+		let theme_scss = frm.doc.theme_scss;
+		if (theme_scss.includes('frappe/public/scss/website')
+			&& !theme_scss.includes('erpnext/public/scss/website')
 		) {
-			frm.set_value('custom_theme',
-				`$primary: #7575ff;\n@import "frappe/public/scss/website";\n@import "erpnext/public/scss/website";`);
+			frm.set_value('theme_scss',
+				`${frm.doc.theme_scss}\n@import "erpnext/public/scss/website";`);
 		}
 	}
 });


### PR DESCRIPTION
Adds the line `@import "erpnext/public/scss/website";` to a custom Website Theme on Save.