### PR TITLE
fix: not able to save asset if depreciation method is manual

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -291,16 +291,19 @@ class Asset(AccountsController):
 
 	def validate_expected_value_after_useful_life(self):
 		for row in self.get('finance_books'):
-			accumulated_depreciation_after_full_schedule = max([d.accumulated_depreciation_amount
-				for d in self.get("schedules") if cint(d.finance_book_id) == row.idx])
+			accumulated_depreciation_after_full_schedule = [d.accumulated_depreciation_amount
+				for d in self.get("schedules") if cint(d.finance_book_id) == row.idx]
 
-			asset_value_after_full_schedule = flt(flt(self.gross_purchase_amount) -
-				flt(accumulated_depreciation_after_full_schedule),
-				self.precision('gross_purchase_amount'))
+			if accumulated_depreciation_after_full_schedule:
+				accumulated_depreciation_after_full_schedule = max(accumulated_depreciation_after_full_schedule)
 
-			if row.expected_value_after_useful_life < asset_value_after_full_schedule:
-				frappe.throw(_("Depreciation Row {0}: Expected value after useful life must be greater than or equal to {1}")
-					.format(row.idx, asset_value_after_full_schedule))
+				asset_value_after_full_schedule = flt(flt(self.gross_purchase_amount) -
+					flt(accumulated_depreciation_after_full_schedule),
+					self.precision('gross_purchase_amount'))
+
+				if row.expected_value_after_useful_life < asset_value_after_full_schedule:
+					frappe.throw(_("Depreciation Row {0}: Expected value after useful life must be greater than or equal to {1}")
+						.format(row.idx, asset_value_after_full_schedule))
 
 	def validate_cancellation(self):
 		if self.status not in ("Submitted", "Partially Depreciated", "Fully Depreciated"):


### PR DESCRIPTION
Issue

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-11-2019-06-10/apps/frappe/frappe/desk/form/save.py", line 22, in savedocs
    doc.save()
  File "/home/frappe/benches/bench-11-2019-06-10/apps/frappe/frappe/model/document.py", line 260, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-11-2019-06-10/apps/frappe/frappe/model/document.py", line 296, in _save
    self.run_before_save_methods()
  File "/home/frappe/benches/bench-11-2019-06-10/apps/frappe/frappe/model/document.py", line 876, in run_before_save_methods
    self.run_method("validate")
  File "/home/frappe/benches/bench-11-2019-06-10/apps/frappe/frappe/model/document.py", line 772, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-11-2019-06-10/apps/frappe/frappe/model/document.py", line 1048, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-11-2019-06-10/apps/frappe/frappe/model/document.py", line 1031, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-11-2019-06-10/apps/frappe/frappe/model/document.py", line 766, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-11-2019-06-10/apps/erpnext/erpnext/assets/doctype/asset/asset.py", line 30, in validate
    self.validate_expected_value_after_useful_life()
  File "/home/frappe/benches/bench-11-2019-06-10/apps/erpnext/erpnext/assets/doctype/asset/asset.py", line 295, in validate_expected_value_after_useful_life
    for d in self.get("schedules") if cint(d.finance_book_id) == row.idx])
ValueError: max() arg is an empty sequence
```