### PR TITLE
fix: Consider discount_amount only when provided to calculate rate

### DIFF
--- a/erpnext/public/js/controllers/buying.js
+++ b/erpnext/public/js/controllers/buying.js
@@ -144,7 +144,9 @@ erpnext.buying.BuyingController = erpnext.TransactionController.extend({
 			item.discount_amount = flt(item_rate) * flt(item.discount_percentage) / 100;
 		}
 
-		item.rate = flt((item.price_list_rate) - (item.discount_amount), precision('rate', item));
+		if (item.discount_amount) {
+			item.rate = flt((item.price_list_rate) - (item.discount_amount), precision('rate', item));
+		}
 
 		this.calculate_taxes_and_totals();
 	},


### PR DESCRIPTION
After selecting item_code in items table and not entering rate,
Clicking elsewhere will set rate to NaN.

All DocTypes on buying side have this bug.

![Some](https://frappe.erpnext.com/files/syjlnVv.png)