### PR TITLE
fix: Default cost center fix for delivery note item

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -574,8 +574,8 @@ def make_delivery_note(source_name, target_doc=None):
 
 		if item:
 			target.cost_center = frappe.db.get_value("Project", source_parent.project, "cost_center") \
-				or item.get("selling_cost_center") \
-				or item_group.get("selling_cost_center")
+				or item.get("buying_cost_center") \
+				or item_group.get("buying_cost_center")
 
 	target_doc = get_mapped_doc("Sales Order", source_name, {
 		"Sales Order": {


### PR DESCRIPTION
Since expenses are booked while making delivery note it should fetch "buying cost centre" from item defaults rather than "selling cost centre"

