### PR TITLE
feat: "Order Type" tree type for Sales Analytics report

### DIFF
--- a/erpnext/selling/report/sales_analytics/sales_analytics.js
+++ b/erpnext/selling/report/sales_analytics/sales_analytics.js
@@ -8,7 +8,7 @@ frappe.query_reports["Sales Analytics"] = {
 			fieldname: "tree_type",
 			label: __("Tree Type"),
 			fieldtype: "Select",
-			options: ["Customer Group","Customer","Item Group","Item","Territory"],
+			options: ["Customer Group","Customer","Item Group","Item","Territory","Order Type"],
 			default: "Customer",
 			reqd: 1
 		},

--- a/erpnext/selling/report/sales_analytics/sales_analytics.py
+++ b/erpnext/selling/report/sales_analytics/sales_analytics.py
@@ -23,15 +23,15 @@ class Analytics(object):
 		self.get_columns()
 		self.get_data()
 		self.get_chart_data()
-		return self.columns, self.data , None, self.chart
+		return self.columns, self.data, None, self.chart
 
 	def get_columns(self):
-		self.columns =[{
+		self.columns = [{
 				"label": _(self.filters.tree_type + " ID"),
-				"options": self.filters.tree_type,
+				"options": self.filters.tree_type if self.filters.tree_type != "Order Type" else "",
 				"fieldname": "entity",
-				"fieldtype": "Link",
-				"width": 140
+				"fieldtype": "Link" if self.filters.tree_type != "Order Type" else "Data",
+				"width": 140 if self.filters.tree_type != "Order Type" else 200
 			}]
 		if self.filters.tree_type in ["Customer", "Supplier", "Item"]:
 			self.columns.append({
@@ -73,6 +73,54 @@ class Analytics(object):
 			self.get_sales_transactions_based_on_item_group()
 			self.get_rows_by_group()
 
+		elif self.filters.tree_type == "Order Type":
+			if self.filters.doc_type == "Delivery Note":
+				self.data = []
+				return
+			self.get_sales_transactions_based_on_muett_sales_channel()
+			self.get_rows_by_group()
+
+	def get_sales_transactions_based_on_muett_sales_channel(self):
+		if self.filters["value_quantity"] == 'Value':
+			value_field = "base_net_total"
+		else:
+			value_field = "total_qty"
+
+		self.sep = " - "
+		if self.filters.doc_type == "Sales Invoice":
+			query = """
+					select * from (
+						select s.order_type as entity, s.{value_field} as value_field, s.{date_field}
+						from `tab{doctype}` s
+						where s.docstatus = 1 and s.company = '{compa}'
+						and s.{date_field} between '{f_date}' and '{t_date}'
+						and ifnull(s.order_type, "") != ""
+						union
+						select concat(s.order_type, '{sep}', s.punto_de_venta) as entity, s.{value_field} as value_field, s.{date_field}
+						from `tab{doctype}` s
+						where s.docstatus = 1 and s.company = '{compa}'
+						and s.{date_field} between '{f_date}' and '{t_date}'
+						and ifnull(s.order_type, "") != "") as b
+					order by b.entity
+				""".format(date_field=self.date_field, value_field=value_field, doctype=self.filters.doc_type,
+						   compa=self.filters.company, f_date=self.filters.from_date, t_date=self.filters.to_date,
+						   sep=self.sep)
+		else:
+			query = """
+					select s.order_type as entity, s.{value_field} as value_field, s.{date_field}
+						from `tab{doctype}` s
+						where s.docstatus = 1 and s.company = '{compa}'
+						and s.{date_field} between '{f_date}' and '{t_date}'
+						and ifnull(s.order_type, "") != ""
+					order by s.order_type
+				""".format(date_field=self.date_field, value_field=value_field, doctype=self.filters.doc_type,
+						   compa=self.filters.company, f_date=self.filters.from_date, t_date=self.filters.to_date,
+						   sep=self.sep)
+
+		self.entries = frappe.db.sql(query, as_dict=1)
+
+		self.get_teams()
+
 	def get_sales_transactions_based_on_customers_or_suppliers(self):
 		if self.filters["value_quantity"] == 'Value':
 			value_field = "base_net_total as value_field"
@@ -88,7 +136,7 @@ class Analytics(object):
 
 		self.entries = frappe.get_all(self.filters.doc_type,
 			fields=[entity, entity_name, value_field, self.date_field],
-			filters = {
+			filters={
 				"docstatus": 1,
 				"company": self.filters.company,
 				self.date_field: ('between', [self.filters.from_date, self.filters.to_date])
@@ -112,7 +160,7 @@ class Analytics(object):
 			where s.name = i.parent and i.docstatus = 1 and s.company = %s
 			and s.{date_field} between %s and %s
 		"""
-		.format(date_field=self.date_field, value_field = value_field, doctype=self.filters.doc_type),
+		.format(date_field=self.date_field, value_field=value_field, doctype=self.filters.doc_type),
 		(self.filters.company, self.filters.from_date, self.filters.to_date), as_dict=1)
 
 		self.entity_names = {}
@@ -135,7 +183,7 @@ class Analytics(object):
 
 		self.entries = frappe.get_all(self.filters.doc_type,
 			fields=[entity_field, value_field, self.date_field],
-			filters = {
+			filters={
 				"docstatus": 1,
 				"company": self.filters.company,
 				self.date_field: ('between', [self.filters.from_date, self.filters.to_date])
@@ -154,13 +202,13 @@ class Analytics(object):
 			from `tab{doctype} Item` i , `tab{doctype}` s
 			where s.name = i.parent and i.docstatus = 1 and s.company = %s
 			and s.{date_field} between %s and %s
-		""".format(date_field=self.date_field, value_field = value_field, doctype=self.filters.doc_type),
+		""".format(date_field=self.date_field, value_field=value_field, doctype=self.filters.doc_type),
 		(self.filters.company, self.filters.from_date, self.filters.to_date), as_dict=1)
 
 		self.get_groups()
 
 	def get_rows(self):
-		self.data=[]
+		self.data = []
 		self.get_periodic_data()
 
 		for entity, period_data in iteritems(self.entity_periodic_data):
@@ -192,7 +240,7 @@ class Analytics(object):
 				period = self.get_period(end_date)
 				amount = flt(self.entity_periodic_data.get(d.name, {}).get(period, 0.0))
 				row[scrub(period)] = amount
-				if d.parent:
+				if d.parent and (self.filters.tree_type != "Order Type" or d.parent == "Order Types"):
 					self.entity_periodic_data.setdefault(d.parent, frappe._dict()).setdefault(period, 0.0)
 					self.entity_periodic_data[d.parent][period] += amount
 				total += amount
@@ -216,7 +264,7 @@ class Analytics(object):
 		elif self.filters.range == 'Monthly':
 			period = str(self.months[posting_date.month - 1]) + " " + str(posting_date.year)
 		elif self.filters.range == 'Quarterly':
-			period = "Quarter " + str(((posting_date.month-1)//3)+1) +" " + str(posting_date.year)
+			period = "Quarter " + str(((posting_date.month - 1) // 3) + 1) + " " + str(posting_date.year)
 		else:
 			year = get_fiscal_year(posting_date, company=self.filters.company)
 			period = str(year[0])
@@ -234,7 +282,7 @@ class Analytics(object):
 		}.get(self.filters.range, 1)
 
 		if self.filters.range in ['Monthly', 'Quarterly']:
-			from_date = from_date.replace(day = 1)
+			from_date = from_date.replace(day=1)
 		elif self.filters.range == "Yearly":
 			from_date = get_fiscal_year(from_date)[1]
 		else:
@@ -269,8 +317,42 @@ class Analytics(object):
 		self.depth_map = frappe._dict()
 
 		self.group_entries = frappe.db.sql("""select name, lft, rgt , {parent} as parent
-			from `tab{tree}` order by lft"""
-			.format(tree=self.filters.tree_type, parent=parent), as_dict=1)
+			from `tab{tree}` order by lft""".format(tree=self.filters.tree_type, parent=parent), as_dict=1)
+
+		for d in self.group_entries:
+			if d.parent:
+				self.depth_map.setdefault(d.name, self.depth_map.get(d.parent) + 1)
+			else:
+				self.depth_map.setdefault(d.name, 0)
+
+	def get_teams(self):
+
+		self.depth_map = frappe._dict()
+
+		if self.filters.doc_type == "Sales Invoice":
+			query = """
+					select * from (
+						select "Order Types" as name, 0 as lft, 2 as rgt, '' as parent
+						union
+						select distinct concat(order_type, '{sep}', punto_de_venta) as name, 2 as lft, 0 as rgt, order_type as parent
+						from `tab{doctype}`
+						where ifnull(order_type, "") != ""
+						union
+						select distinct order_type as name, 1 as lft, 1 as rgt, "Order Types" as parent
+						from `tab{doctype}`
+						where ifnull(order_type, "") != "") as b
+					order by name, lft""".format(doctype=self.filters.doc_type, sep=self.sep)
+		else:
+			query = """
+					select * from (
+						select "Order Types" as name, 0 as lft, 2 as rgt, '' as parent
+						union
+						select distinct order_type as name, 1 as lft, 1 as rgt, "Order Types" as parent
+						from `tab{doctype}`
+						where ifnull(order_type, "") != "") as b
+					order by name, lft""".format(doctype=self.filters.doc_type, sep=self.sep)
+
+		self.group_entries = frappe.db.sql(query, as_dict=1)
 
 		for d in self.group_entries:
 			if d.parent:
@@ -285,13 +367,13 @@ class Analytics(object):
 		length = len(self.columns)
 
 		if self.filters.tree_type in ["Customer", "Supplier", "Item"]:
-			labels = [d.get("label") for d in self.columns[2:length-1]]
+			labels = [d.get("label") for d in self.columns[2:length - 1]]
 		else:
-			labels = [d.get("label") for d in self.columns[1:length-1]]
+			labels = [d.get("label") for d in self.columns[1:length - 1]]
 		self.chart = {
 			"data": {
 				'labels': labels,
-				'datasets':[]
+				'datasets': []
 			},
 			"type": "line"
 		}


### PR DESCRIPTION
### Description
This PR adds the "Order Type" option to the tree type filter of the Sales Analytics report.

### Utility
This option is very useful to see from where does the orders come and to compare, for example, how many orders came from the Shopping Cart and how many are from the Sales department.

### Possible Improvements
Today this only works for Sales Order, but maybe it can be improved to work with Sales Invoice and Delivery Note. I'm open to your ideas.
Another possible improvement is to make "Order Type" a link to a new doctype to make it self-administered, because this can be more useful with "Order Types" like "Shopify Order" or things like that.

**Note:** This PR can be discussed and some improvements can be made. Don't be afraid to speak up and express your ideas.