### PR TITLE
fix: Get Accounting Dimension only if user has read permission on it

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -66,7 +66,7 @@ $.extend(erpnext, {
 
 	get_dimension_filters: async function() {
 		if (!frappe.model.can_read('Accounting Dimension')) {
-			return
+			return [];
 		}
 		let dimensions = await frappe.db.get_list('Accounting Dimension', {
 			fields: ['label', 'fieldname', 'document_type'],

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -65,6 +65,9 @@ $.extend(erpnext, {
 	},
 
 	get_dimension_filters: async function() {
+		if (!frappe.boot.user.can_read.includes('Accounting Dimension')) {
+			return
+		}
 		let dimensions = await frappe.db.get_list('Accounting Dimension', {
 			fields: ['label', 'fieldname', 'document_type'],
 			filters: {

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -65,7 +65,7 @@ $.extend(erpnext, {
 	},
 
 	get_dimension_filters: async function() {
-		if (!frappe.boot.user.can_read.includes('Accounting Dimension')) {
+		if (!frappe.model.can_read('Accounting Dimension')) {
 			return
 		}
 		let dimensions = await frappe.db.get_list('Accounting Dimension', {


### PR DESCRIPTION
On desk load user used to get following error: 

<img width="636" alt="Screenshot 2019-06-20 at 5 22 47 PM" src="https://user-images.githubusercontent.com/13928957/59847462-29545380-9380-11e9-94d3-d7a3877ad1ed.png">
