### PR TITLE
fix: Wrong Casual Leave Opening in Employee Leave Balance Report

### DIFF
--- a/erpnext/hr/doctype/leave_application/leave_application.py
+++ b/erpnext/hr/doctype/leave_application/leave_application.py
@@ -400,19 +400,6 @@ def get_leave_balance_on(employee, leave_type, date, allocation_records=None, do
 
 	return flt(allocation.total_leaves_allocated) - (flt(leaves_taken) + flt(leaves_encashed))
 
-def get_total_allocated_leaves(employee, leave_type, date):
-	filters= {
-		'from_date': ['<=', date],
-		'to_date': ['>=', date],
-		'docstatus': 1,
-		'leave_type': leave_type,
-		'employee': employee
-	}
-
-	leave_allocation_records = frappe.db.get_all('Leave Allocation', filters=filters, fields=['total_leaves_allocated'])
-
-	return flt(leave_allocation_records[0]['total_leaves_allocated']) if leave_allocation_records else flt(0)
-
 def get_leaves_for_period(employee, leave_type, from_date, to_date, status, docname=None):
 	leave_applications = frappe.db.sql("""
 		select name, employee, leave_type, from_date, to_date, total_leave_days

--- a/erpnext/hr/report/employee_leave_balance/employee_leave_balance.py
+++ b/erpnext/hr/report/employee_leave_balance/employee_leave_balance.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 import frappe
 from frappe import _
 from erpnext.hr.doctype.leave_application.leave_application \
-	import get_leave_allocation_records, get_leave_balance_on, get_approved_leaves_for_period, get_total_allocated_leaves
+	import get_leave_allocation_records, get_leave_balance_on, get_approved_leaves_for_period
 
 
 def execute(filters=None):

--- a/erpnext/hr/report/employee_leave_balance/employee_leave_balance.py
+++ b/erpnext/hr/report/employee_leave_balance/employee_leave_balance.py
@@ -35,6 +35,9 @@ def get_data(filters, leave_types):
 	allocation_records_based_on_to_date = get_leave_allocation_records(filters.to_date)
 	allocation_records_based_on_from_date = get_leave_allocation_records(filters.from_date)
 
+	if filters.to_date <= filters.from_date:
+		frappe.throw(_("From date can not be greater than than To date"))
+
 	active_employees = frappe.get_all("Employee",
 		filters = { "status": "Active", "company": filters.company},
 		fields = ["name", "employee_name", "department", "user_id"])
@@ -51,7 +54,8 @@ def get_data(filters, leave_types):
 					filters.from_date, filters.to_date)
 
 				# opening balance
-				opening = get_total_allocated_leaves(employee.name, leave_type, filters.to_date)
+				opening = get_leave_balance_on(employee.name, leave_type, filters.from_date,
+					allocation_records_based_on_to_date.get(employee.name, frappe._dict()))
 
 				# closing balance
 				closing = get_leave_balance_on(employee.name, leave_type, filters.to_date,


### PR DESCRIPTION
Before a casual opening balance in the leave balance report was not getting value correct.
Now it is fixed.

