### PR TITLE
fix: optimize bom update tool

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -381,9 +381,12 @@ class BOM(WebsiteGenerator):
 
 				frappe.throw(_("Same item has been entered multiple times. {0}").format(duplicate_list))
 
-	def check_recursion(self):
+	def check_recursion(self, bom_list=[]):
 		""" Check whether recursion occurs in any bom"""
-		bom_list = self.traverse_tree()
+
+		if not bom_list:
+			bom_list = self.traverse_tree()
+
 		bom_nos = frappe.get_all('BOM Item', fields=["bom_no"],
 			filters={'parent': ('in', bom_list), 'parenttype': 'BOM'})
 
@@ -405,7 +408,7 @@ class BOM(WebsiteGenerator):
 		bom_list = self.traverse_tree(bom_list)
 		for bom in bom_list:
 			bom_obj = frappe.get_doc("BOM", bom)
-			bom_obj.check_recursion()
+			bom_obj.check_recursion(bom_list=bom_list)
 			bom_obj.update_exploded_items()
 
 		return bom_list

--- a/erpnext/manufacturing/doctype/bom_update_tool/bom_update_tool.py
+++ b/erpnext/manufacturing/doctype/bom_update_tool/bom_update_tool.py
@@ -55,7 +55,7 @@ class BOMUpdateTool(Document):
 			bom_list = []
 
 		data = frappe.db.sql(""" select distinct parent from `tabBOM Item`
-			where ifnull(bom_no, '') = %s and docstatus < 2 and parenttype='BOM'""", bom)
+			where bom_no = %s and docstatus < 2 and parenttype='BOM'""", bom)
 
 		for d in data:
 			bom_list.append(d[0])


### PR DESCRIPTION
If column has the indexing and function has set on that column then indexing performance gets slow
For example
bom_no has the index but ifnull function has set on the column