### PR TITLE
fix: Float division by zero error handling in group similar item

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -747,7 +747,12 @@ class AccountsController(TransactionBase):
 				count += 1
 				item.qty = group_item_qty[item.item_code]
 				item.amount = group_item_amount[item.item_code]
-				item.rate = flt(flt(item.amount) / flt(item.qty), item.precision("rate"))
+
+				if item.qty:
+					item.rate = flt(flt(item.amount) / flt(item.qty), item.precision("rate"))
+				else:
+					item.rate = 0
+
 				item.idx = count
 				del group_item_qty[item.item_code]
 			else:


### PR DESCRIPTION
If an item quantity that is appearing multiple times in Sales Order is made zero using update items button then a division by zero error is thrown while printing the Sales Order

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-11-2019-06-18/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-11-2019-06-18/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-11-2019-06-18/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-11-2019-06-18/apps/frappe/frappe/__init__.py", line 1032, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-11-2019-06-18/apps/frappe/frappe/www/printview.py", line 187, in get_html_and_style
    no_letterhead=no_letterhead, trigger_print=trigger_print),
  File "/home/frappe/benches/bench-11-2019-06-18/apps/frappe/frappe/www/printview.py", line 86, in get_html
    doc.before_print()
  File "/home/frappe/benches/bench-11-2019-06-18/apps/erpnext/erpnext/controllers/accounts_controller.py", line 123, in before_print
    self.group_similar_items()
  File "/home/frappe/benches/bench-11-2019-06-18/apps/erpnext/erpnext/controllers/accounts_controller.py", line 750, in group_similar_items
    item.rate = flt(flt(item.amount) / flt(item.qty), item.precision("rate"))
ZeroDivisionError: float division by zero
```

