### PR TITLE
 fix(sales-funnel): Use frappe.Chart() instead of Chart()

### DIFF
--- a/erpnext/selling/page/sales_funnel/sales_funnel.js
+++ b/erpnext/selling/page/sales_funnel/sales_funnel.js
@@ -277,7 +277,7 @@ erpnext.SalesFunnel = class SalesFunnel {
 		let chart_data = me.options.data ? me.options.data : null;
 
 		const parent = me.elements.funnel_wrapper[0];
-		this.chart = new Chart(parent, {
+		this.chart = new frappe.Chart(parent, {
 			title: __("Sales Opportunities by Source"),
 			height: 400,
 			data: chart_data,
@@ -298,7 +298,7 @@ erpnext.SalesFunnel = class SalesFunnel {
 		let chart_data = me.options.data ? me.options.data : null;
 
 		const parent = me.elements.funnel_wrapper[0];
-		this.chart = new Chart(parent, {
+		this.chart = new frappe.Chart(parent, {
 			title: __("Sales Pipeline by Stage"),
 			height: 400,
 			data: chart_data,

--- a/erpnext/selling/page/sales_funnel/sales_funnel.js
+++ b/erpnext/selling/page/sales_funnel/sales_funnel.js
@@ -90,70 +90,31 @@ erpnext.SalesFunnel = class SalesFunnel {
 
 	get_data(btn) {
 		var me = this;
-		if (me.options.chart == 'sales_funnel'){
-			frappe.call({
-				method: "erpnext.selling.page.sales_funnel.sales_funnel.get_funnel_data",
-				args: {
-					from_date: this.options.from_date,
-					to_date: this.options.to_date,
-					company: this.company
-				},
-				btn: btn,
-				callback: function(r) {
-					if(!r.exc) {
-						me.options.data = r.message;
-						if (me.options.data=='empty') {
-							const $parent = me.elements.funnel_wrapper;
-							$parent.html(__('No data for this period'));
-						} else {
-							me.render_funnel();
-						}
+		const method_map = {
+			"sales_funnel": "erpnext.selling.page.sales_funnel.sales_funnel.get_funnel_data",
+			"opp_by_lead_source": "erpnext.selling.page.sales_funnel.sales_funnel.get_opp_by_lead_source",
+			"sales_pipeline": "erpnext.selling.page.sales_funnel.sales_funnel.get_pipeline_data"
+		};
+		frappe.call({
+			method: method_map[this.options.chart],
+			args: {
+				from_date: this.options.from_date,
+				to_date: this.options.to_date,
+				company: this.company
+			},
+			btn: btn,
+			callback: function(r) {
+				if(!r.exc) {
+					me.options.data = r.message;
+					if (me.options.data=='empty') {
+						const $parent = me.elements.funnel_wrapper;
+						$parent.html(__('No data for this period'));
+					} else {
+						me.render();
 					}
 				}
-			});
-		} else if (me.options.chart == 'opp_by_lead_source'){
-			frappe.call({
-				method: "erpnext.selling.page.sales_funnel.sales_funnel.get_opp_by_lead_source",
-				args: {
-					from_date: this.options.from_date,
-					to_date: this.options.to_date,
-					company: this.company
-				},
-				btn: btn,
-				callback: function(r) {
-					if(!r.exc) {
-						me.options.data = r.message;
-						if (me.options.data=='empty') {
-							const $parent = me.elements.funnel_wrapper;
-							$parent.html(__('No data for this period'));
-						} else {
-							me.render_opp_by_lead_source();
-						}
-					}
-				}
-			});
-		} else if (me.options.chart == 'sales_pipeline'){
-			frappe.call({
-				method: "erpnext.selling.page.sales_funnel.sales_funnel.get_pipeline_data",
-				args: {
-					from_date: this.options.from_date,
-					to_date: this.options.to_date,
-					company: this.company
-				},
-				btn: btn,
-				callback: function(r) {
-					if(!r.exc) {
-						me.options.data = r.message;
-						if (me.options.data=='empty') {
-							const $parent = me.elements.funnel_wrapper;
-							$parent.html(__('No data for this period'));
-						} else {
-							me.render_pipeline();
-						}
-					}
-				}
-			});
-		}
+			}
+		});
 	}
 
 	render() {
@@ -161,9 +122,9 @@ erpnext.SalesFunnel = class SalesFunnel {
 		if (me.options.chart == 'sales_funnel'){
 			me.render_funnel();
 		} else if (me.options.chart == 'opp_by_lead_source'){
-			me.render_opp_by_lead_source();
+			me.render_chart("Sales Opportunities by Source");
 		} else if (me.options.chart == 'sales_pipeline'){
-			me.render_pipeline();
+			me.render_chart("Sales Pipeline by Stage");
 		}
 	}
 
@@ -270,7 +231,7 @@ erpnext.SalesFunnel = class SalesFunnel {
 		context.fillText(__(title), width + 20, y_mid);
 	}
 
-	render_opp_by_lead_source() {
+	render_chart(title) {
 		let me = this;
 		let currency = frappe.defaults.get_default("currency");
 
@@ -278,7 +239,7 @@ erpnext.SalesFunnel = class SalesFunnel {
 
 		const parent = me.elements.funnel_wrapper[0];
 		this.chart = new frappe.Chart(parent, {
-			title: __("Sales Opportunities by Source"),
+			title: title,
 			height: 400,
 			data: chart_data,
 			type: 'bar',
@@ -288,25 +249,6 @@ erpnext.SalesFunnel = class SalesFunnel {
 			tooltipOptions: {
 				formatTooltipY: d => format_currency(d, currency),
 			}
-		});
-	}
-
-	render_pipeline() {
-		let me = this;
-		let currency = frappe.defaults.get_default("currency");
-
-		let chart_data = me.options.data ? me.options.data : null;
-
-		const parent = me.elements.funnel_wrapper[0];
-		this.chart = new frappe.Chart(parent, {
-			title: __("Sales Pipeline by Stage"),
-			height: 400,
-			data: chart_data,
-			type: 'bar',
-			tooltipOptions: {
-				formatTooltipY: d => format_currency(d, currency),
-			},
-			colors: ['light-green', 'green']
 		});
 	}
 };


### PR DESCRIPTION
**Before**
```python-traceback
ReferenceError: Chart is not defined
    at SalesFunnel.render_pipeline (<anonymous>:301:20)
    at Object.callback (<anonymous>:151:11)
    at Object.callback [as success_callback] (request.js:76)
    at 200 (request.js:108)
    at Object.<anonymous> (request.js:231)
    at i (jquery.min.js:2)
    at Object.fireWith [as resolveWith] (jquery.min.js:2)
    at z (jquery.min.js:4)
    at XMLHttpRequest.<anonymous> (jquery.min.js:4)
(anonymous) @ request.js:235
```
**After** 
![Screenshot 2019-06-25 at 5 30 23 PM](https://user-images.githubusercontent.com/8528887/60096633-15896280-976f-11e9-8292-2b618027ae80.png)
![Screenshot 2019-06-25 at 5 30 01 PM](https://user-images.githubusercontent.com/8528887/60096635-15896280-976f-11e9-8f79-7a9e3d08fc37.png)
