### PR TITLE
fix: returned qty issue while making sales invoice from dn if same item added multiple times

### DIFF
--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -443,7 +443,12 @@ def make_sales_invoice(source_name, target_doc=None):
 
 	def get_pending_qty(item_row):
 		pending_qty = item_row.qty - invoiced_qty_map.get(item_row.name, 0)
-		returned_qty = flt(returned_qty_map.get(item_row.item_code, 0))
+
+		returned_qty = 0
+		if returned_qty_map.get(item_row.item_code) > 0:
+			returned_qty = flt(returned_qty_map.get(item_row.item_code, 0))
+			returned_qty_map[item_row.item_code] -= pending_qty
+
 		if returned_qty:
 			if returned_qty >= pending_qty:
 				pending_qty = 0
@@ -451,6 +456,7 @@ def make_sales_invoice(source_name, target_doc=None):
 			else:
 				pending_qty -= returned_qty
 				returned_qty = 0
+
 		return pending_qty, returned_qty
 
 	doc = get_mapped_doc("Delivery Note", source_name, {


### PR DESCRIPTION
**Issue**

1.  Added same item 3 times with qty as 2,4,10 in the delivery note and submitted
- Created sales invoice against above delivery note for the 3rd row with qty as 10
- Created delivery note return against above delivery note for the 2nd row with qty as 4
- Now when making the sales invoice for the 1st item, system throwing message that "all items are invoiced"

After debug issue identified that for the 1st row system considered that it is already retuned because in the code we get the retuned qty group by item code and in the above example same item code added multiple times.

