### PR TITLE
fix: Order type restriction conflictive code

### DIFF
--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -134,13 +134,6 @@ class SellingController(StockController):
 		if sales_team and total != 100.0:
 			throw(_("Total allocated percentage for sales team should be 100"))
 
-	def validate_order_type(self):
-		valid_types = ["Sales", "Maintenance", "Shopping Cart"]
-		if not self.order_type:
-			self.order_type = "Sales"
-		elif self.order_type not in valid_types:
-			throw(_("Order Type must be one of {0}").format(comma_or(valid_types)))
-
 	def validate_max_discount(self):
 		for d in self.get("items"):
 			if d.item_code:

--- a/erpnext/selling/doctype/quotation/quotation.py
+++ b/erpnext/selling/doctype/quotation/quotation.py
@@ -26,7 +26,6 @@ class Quotation(SellingController):
 		super(Quotation, self).validate()
 		self.set_status()
 		self.update_opportunity()
-		self.validate_order_type()
 		self.validate_uom_is_integer("stock_uom", "qty")
 		self.validate_valid_till()
 		self.set_customer_name()
@@ -39,9 +38,6 @@ class Quotation(SellingController):
 
 	def has_sales_order(self):
 		return frappe.db.get_value("Sales Order Item", {"prevdoc_docname": self.name, "docstatus": 1})
-
-	def validate_order_type(self):
-		super(Quotation, self).validate_order_type()
 
 	def update_lead(self):
 		if self.quotation_to == "Lead" and self.party_name:

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -32,7 +32,6 @@ class SalesOrder(SellingController):
 
 	def validate(self):
 		super(SalesOrder, self).validate()
-		self.validate_order_type()
 		self.validate_delivery_date()
 		self.validate_proj_cust()
 		self.validate_po()
@@ -101,9 +100,6 @@ class SalesOrder(SellingController):
 				if not res:
 					frappe.msgprint(_("Quotation {0} not of type {1}")
 						.format(d.prevdoc_docname, self.order_type))
-
-	def validate_order_type(self):
-		super(SalesOrder, self).validate_order_type()
 
 	def validate_delivery_date(self):
 		if self.order_type == 'Sales':


### PR DESCRIPTION
I was experimenting and added a new `order_type` via property setter, but when I saved my new order with my brand new `order_type`, it turns out that there is a hardcoded validation in the code. I was surprised, should it be there? Does a reason for it exists?
If there is no reason for it to exists then this PR can be merged to permit the users to create their own `order_type`.
If there is a valid reason, I think that we should discuss it, because is probable that there exists a better way to solve it. This is not only bad for the users that can't add a new order_type, it's bad because is code that should be maintained. For example, if tomorrow we decide to implement a new `order_type`, we should change this code too, and that's something more to remember and, because of that,  bad.
Please, share your ideas.