### PR TITLE
fix: not able to make salary slip based on timesheet

### DIFF
--- a/erpnext/hr/doctype/salary_slip/salary_slip.py
+++ b/erpnext/hr/doctype/salary_slip/salary_slip.py
@@ -281,7 +281,9 @@ class SalarySlip(TransactionBase):
 			wages_row = {
 				"salary_component": salary_component,
 				"abbr": frappe.db.get_value("Salary Component", salary_component, "salary_component_abbr"),
-				"amount": self.hour_rate * self.total_working_hours
+				"amount": self.hour_rate * self.total_working_hours,
+				"default_amount": 0.0,
+				"additional_amount": 0.0
 			}
 			doc.append('earnings', wages_row)
 


### PR DESCRIPTION
**Issue**

```
Traceback (most recent call last):
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/__init__.py", line 1036, in call
    return fn(*args, **newargs)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/handler.py", line 84, in runserverobj
    frappe.desk.form.run_method.runserverobj(method, docs=docs, dt=dt, dn=dn, arg=arg, args=args)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/desk/form/run_method.py", line 36, in runserverobj
    r = doc.run_method(method)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/model/document.py", line 772, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/model/document.py", line 1048, in composer
    return composed(self, method, *args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/model/document.py", line 1031, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/model/document.py", line 766, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/erpnext/erpnext/hr/doctype/salary_slip/salary_slip.py", line 132, in get_emp_and_leave_details
    self.pull_sal_struct()
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/erpnext/erpnext/hr/doctype/salary_slip/salary_slip.py", line 182, in pull_sal_struct
    make_salary_slip(self._salary_structure_doc.name, self)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/erpnext/erpnext/hr/doctype/salary_structure/salary_structure.py", line 160, in make_salary_slip
    }, target_doc, postprocess, ignore_child_tables=True)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/model/mapper.py", line 113, in get_mapped_doc
    postprocess(source_doc, target_doc)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/erpnext/erpnext/hr/doctype/salary_structure/salary_structure.py", line 150, in postprocess
    target.run_method('process_salary_structure', for_preview=for_preview)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/model/document.py", line 772, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/model/document.py", line 1048, in composer
    return composed(self, method, *args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/model/document.py", line 1031, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/frappe/frappe/model/document.py", line 766, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/erpnext/erpnext/hr/doctype/salary_slip/salary_slip.py", line 819, in process_salary_structure
    self.calculate_net_pay()
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/erpnext/erpnext/hr/doctype/salary_slip/salary_slip.py", line 290, in calculate_net_pay
    self.calculate_component_amounts()
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/erpnext/erpnext/hr/doctype/salary_slip/salary_slip.py", line 310, in calculate_component_amounts
    self.set_component_amounts_based_on_payment_days()
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/erpnext/erpnext/hr/doctype/salary_slip/salary_slip.py", line 739, in set_component_amounts_based_on_payment_days
    d.amount = self.get_amount_based_on_payment_days(d, joining_date, relieving_date)[0]
  File "/Users/rohitwaghchaure/Documents/new_erpnext/frappe-bench/apps/erpnext/erpnext/hr/doctype/salary_slip/salary_slip.py", line 619, in get_amount_based_on_payment_days
    amount = row.default_amount + row.additional_amount
TypeError: unsupported operand type(s) for +: 'NoneType' and 'NoneType'
```