### PR TITLE
fix: set serial numbers as data field

### DIFF
--- a/erpnext/stock/report/stock_ledger/stock_ledger.py
+++ b/erpnext/stock/report/stock_ledger/stock_ledger.py
@@ -56,7 +56,7 @@ def get_columns():
 		{"label": _("Voucher Type"), "fieldname": "voucher_type", "width": 110},
 		{"label": _("Voucher #"), "fieldname": "voucher_no", "fieldtype": "Dynamic Link", "options": "voucher_type", "width": 100},
 		{"label": _("Batch"), "fieldname": "batch_no", "fieldtype": "Link", "options": "Batch", "width": 100},
-		{"label": _("Serial #"), "fieldname": "serial_no", "fieldtype": "Link", "options": "Serial No", "width": 100},
+		{"label": _("Serial #"), "fieldname": "serial_no", "width": 100},
 		{"label": _("Project"), "fieldname": "project", "fieldtype": "Link", "options": "Project", "width": 100},
 		{"label": _("Company"), "fieldname": "company", "fieldtype": "Link", "options": "Company", "width": 110}
 	]


### PR DESCRIPTION
Previously, the serial number field (which is a long string of all serial numbers) was rendered as a link.

<img width="1440" alt="Sinngle link for all the fucking serial nos" src="https://user-images.githubusercontent.com/18097732/60251322-f6611100-98e5-11e9-84f3-dc15eb450ba5.png">

The reason for this was that the fieldtype was set as link here 
https://github.com/frappe/erpnext/blob/0b39c4ecff88fc491381d7fb8e0cc215a3181759/erpnext/stock/report/stock_ledger/stock_ledger.py#L59

This PR fixes this. Simply removed the `fieldtype` and `options`
