### PR TITLE
fix: POS loyalty issues

### DIFF
--- a/erpnext/accounts/doctype/loyalty_program/loyalty_program.py
+++ b/erpnext/accounts/doctype/loyalty_program/loyalty_program.py
@@ -38,7 +38,7 @@ def get_loyalty_details(customer, loyalty_program, expiry_date=None, company=Non
 @frappe.whitelist()
 def get_loyalty_program_details_with_points(customer, loyalty_program=None, expiry_date=None, company=None, silent=False, include_expired_entry=False, current_transaction_amount=0):
 	lp_details = get_loyalty_program_details(customer, loyalty_program, company=company, silent=silent)
-	loyalty_program = frappe.get_doc("Loyalty Program", loyalty_program)
+	loyalty_program = frappe.get_doc("Loyalty Program", loyalty_program or lp_details.loyalty_program)
 	lp_details.update(get_loyalty_details(customer, loyalty_program.name, expiry_date, company, include_expired_entry))
 
 	tier_spent_level = sorted([d.as_dict() for d in loyalty_program.collection_rules],

--- a/erpnext/selling/page/point_of_sale/point_of_sale.js
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.js
@@ -155,7 +155,7 @@ erpnext.pos.PointOfSale = class PointOfSale {
 					var me = this;
 					if (this.frm.doc.customer) {
 						frappe.call({
-							method: "erpnext.accounts.doctype.loyalty_program.loyalty_program.get_loyalty_program_details",
+							method: "erpnext.accounts.doctype.loyalty_program.loyalty_program.get_loyalty_program_details_with_points",
 							args: {
 								"customer": me.frm.doc.customer,
 								"expiry_date": me.frm.doc.posting_date,

--- a/erpnext/selling/page/point_of_sale/point_of_sale.js
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.js
@@ -1694,7 +1694,13 @@ class Payment {
 				fieldtype: 'Check',
 				label: 'Redeem Loyalty Points',
 				fieldname: 'redeem_loyalty_points',
-				onchange: () => {
+				onchange: async function () {
+					if (!cint(me.dialog.get_value('redeem_loyalty_points'))) {
+						await Promise.all([
+							me.frm.set_value('loyalty_points', 0),
+							me.dialog.set_value('loyalty_points', 0)
+						]);
+					}
 					me.update_cur_frm_value("redeem_loyalty_points", () => {
 						frappe.flags.redeem_loyalty_points = false;
 						me.update_loyalty_points();

--- a/erpnext/selling/page/point_of_sale/point_of_sale.js
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.js
@@ -1838,13 +1838,14 @@ class Payment {
 		});
 	}
 
-	update_loyalty_points() {
-		if (this.dialog.get_value("redeem_loyalty_points")) {
-			this.dialog.set_value("loyalty_points", this.frm.doc.loyalty_points);
-			this.dialog.set_value("loyalty_amount", this.frm.doc.loyalty_amount);
-			this.update_payment_amount();
-			this.show_paid_amount();
-		}
+	async update_loyalty_points() {
+		const { loyalty_points, loyalty_amount } = this.frm.doc;
+		await Promise.all([
+			this.dialog.set_value("loyalty_points", loyalty_points),
+			this.dialog.set_value("loyalty_amount", loyalty_amount)
+		]);
+		this.update_payment_amount();
+		this.show_paid_amount();
 	}
 
 }


### PR DESCRIPTION
This PR attempts to solve a few issues
- fixes #15479
- updating loyalty points was having no effect the payment amounts as intended because `set_value` calls made in `Payment.update_loyalty_points` were asynchronous.
- logical to reset `loyalty_point` to zero when `redeem_loyalty_points` is unchecked

I used `async` / `await` for the async functions. I don't know whether Promises would better for more browser compatibility, because this JS file is loaded during runtime instead of being packaged during the build process.

