### PR TITLE
tests: Upgrade to the current version of Python and flake8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
-dist: trusty
+dist: xenial  # required for Python >= 3.7 on Travis CI
 
 python:
   - "2.7"
-  - "3.6"
+  - "3.7"
 
 env:
   - TEST_TYPE="Server Side Test"
@@ -15,7 +15,7 @@ services:
 install:
   # fix mongodb travis error
   - sudo rm /etc/apt/sources.list.d/mongodb*.list
-  - pip install flake8==3.3.0
+  - pip install flake8==3.7.7
   - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
   - sudo rm /etc/apt/sources.list.d/docker.list
   - sudo apt-get install hhvm && rm -rf /home/travis/.kiex/

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   - sudo rm /etc/apt/sources.list.d/mongodb*.list || true
   - pip install flake8==3.7.7
   - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
-  - sudo rm /etc/apt/sources.list.d/docker.list
+  - sudo rm /etc/apt/sources.list.d/docker.list || true
   - sudo apt-get install hhvm && rm -rf /home/travis/.kiex/
   - sudo apt-get purge -y mysql-common mysql-server mysql-client
   - nvm install 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ services:
 
 install:
   # fix mongodb travis error
-  - sudo rm /etc/apt/sources.list.d/mongodb*.list
+  - sudo rm /etc/apt/sources.list.d/mongodb*.list || true
   - pip install flake8==3.7.7
   - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
   - sudo rm /etc/apt/sources.list.d/docker.list


### PR DESCRIPTION
Please read the pull request checklist to make sure your changes are merged: https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

Avoids hardcoding __dist: trusty__ which is beyond its normal support date.

Fails with [__AttributeError: 'module' object has no attribute 'SSL_ST_INIT__](https://travis-ci.com/frappe/erpnext/jobs/212113377#L478)

