### PR TITLE
fix: multiple minor issues in delayed order report

### DIFF
--- a/erpnext/stock/report/delayed_item_report/delayed_item_report.js
+++ b/erpnext/stock/report/delayed_item_report/delayed_item_report.js
@@ -55,7 +55,7 @@ frappe.query_reports["Delayed Item Report"] = {
 			label: __("Based On"),
 			fieldtype: "Select",
 			options: ["Delivery Note", "Sales Invoice"],
-			default: "Delivery Note",
+			default: "Sales Invoice",
 			reqd: 1
 		},
 	]

--- a/erpnext/stock/report/delayed_item_report/delayed_item_report.py
+++ b/erpnext/stock/report/delayed_item_report/delayed_item_report.py
@@ -46,7 +46,8 @@ class DelayedItemReport(object):
 		self.transactions = frappe.db.sql(""" SELECT `tab{child_doc}`.item_code, `tab{child_doc}`.item_name,
 				`tab{child_doc}`.item_group, `tab{child_doc}`.qty, `tab{child_doc}`.rate, `tab{child_doc}`.amount,
 				`tab{child_doc}`.so_detail, `tab{child_doc}`.{so_field} as sales_order,
-				`tab{doctype}`.customer, `tab{doctype}`.posting_date, `tab{doctype}`.name, `tab{doctype}`.grand_total
+				`tab{doctype}`.shipping_address_name, `tab{doctype}`.po_no, `tab{doctype}`.customer,
+				`tab{doctype}`.posting_date, `tab{doctype}`.name, `tab{doctype}`.grand_total
 			FROM `tab{child_doc}`, `tab{doctype}`
 			WHERE
 				`tab{child_doc}`.parent = `tab{doctype}`.name and `tab{doctype}`.docstatus = 1 and
@@ -97,12 +98,20 @@ class DelayedItemReport(object):
 			"fieldtype": "Link",
 			"options": based_on,
 			"width": 100
-		},{
+		},
+		{
 			"label": _("Customer"),
 			"fieldname": "customer",
 			"fieldtype": "Link",
 			"options": "Customer",
-			"width": 100
+			"width": 200
+		},
+		{
+			"label": _("Shipping Address"),
+			"fieldname": "shipping_address_name",
+			"fieldtype": "Link",
+			"options": "Address",
+			"width": 120
 		},
 		{
 			"label": _("Expected Delivery Date"),

--- a/erpnext/stock/report/delayed_order_report/delayed_order_report.js
+++ b/erpnext/stock/report/delayed_order_report/delayed_order_report.js
@@ -55,7 +55,7 @@ frappe.query_reports["Delayed Order Report"] = {
 			label: __("Based On"),
 			fieldtype: "Select",
 			options: ["Delivery Note", "Sales Invoice"],
-			default: "Delivery Note",
+			default: "Sales Invoice",
 			reqd: 1
 		},
 	]

--- a/erpnext/stock/report/delayed_order_report/delayed_order_report.py
+++ b/erpnext/stock/report/delayed_order_report/delayed_order_report.py
@@ -42,7 +42,14 @@ class DelayedOrderReport(DelayedItemReport):
 			"fieldname": "customer",
 			"fieldtype": "Link",
 			"options": "Customer",
-			"width": 100
+			"width": 200
+		},
+		{
+			"label": _("Shipping Address"),
+			"fieldname": "shipping_address_name",
+			"fieldtype": "Link",
+			"options": "Address",
+			"width": 140
 		},
 		{
 			"label": _("Expected Delivery Date"),
@@ -73,11 +80,11 @@ class DelayedOrderReport(DelayedItemReport):
 			"fieldname": "sales_order",
 			"fieldtype": "Link",
 			"options": "Sales Order",
-			"width": 100
+			"width": 150
 		},
 		{
 			"label": _("Customer PO"),
 			"fieldname": "po_no",
 			"fieldtype": "Data",
-			"width": 100
+			"width": 110
 		}]


### PR DESCRIPTION
Fixes

- Added column “Shipping address name” in the report

- Customer PO was showing as a blank. 

- Default value for the Based on filter set as “Delivery note”. 
