### PR TITLE
fix: reloads all newly created docs in v12

### DIFF
--- a/erpnext/patches/v12_0/make_custom_fields_for_bank_remittance.py
+++ b/erpnext/patches/v12_0/make_custom_fields_for_bank_remittance.py
@@ -3,6 +3,8 @@ import frappe
 from erpnext.regional.india.setup import make_custom_fields
 
 def execute():
+    frappe.reload_doc("accounts", "doctype", "tax_category")
+    frappe.reload_doc("stock", "doctype", "item_manufacturer")
     company = frappe.get_all('Company', filters = {'country': 'India'})
     if not company:
         return


### PR DESCRIPTION
- Fixes migration from v11 to v12
- On migrating from v11 to v12 certain doctypes are not reloaded, which is breaking the migration on adding custom fields.

