### PR TITLE
fix: format values for charts

### DIFF
--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -599,9 +599,12 @@ class ReceivablePayableReport(object):
 
 		rows = []
 		for d in data:
+			values = d[self.ageing_col_idx_start : self.ageing_col_idx_start+5]
+			precision = cint(frappe.db.get_default("float_precision")) or 2
+			formatted_values = [frappe.utils.rounded(val, precision) for val in values]
 			rows.append(
 				{
-					'values': d[self.ageing_col_idx_start : self.ageing_col_idx_start+5]
+					'values': formatted_values
 				}
 			)
 


### PR DESCRIPTION
`d[self.ageing_col_idx_start : self.ageing_col_idx_start+5]` has float values with no precision limit. 
This PR formats it with default precision