### PR TITLE
fix: Build item cache in long worker

### DIFF
--- a/erpnext/portal/product_configurator/item_variants_cache.py
+++ b/erpnext/portal/product_configurator/item_variants_cache.py
@@ -110,4 +110,4 @@ def build_cache(item_code):
 def enqueue_build_cache(item_code):
 	if frappe.cache().hget('item_cache_build_in_progress', item_code):
 		return
-	frappe.enqueue(build_cache, item_code=item_code, queue='short')
+	frappe.enqueue(build_cache, item_code=item_code, queue='long')


### PR DESCRIPTION
Item Variants cache building is something that can be delayed or even cancelled. Because it is run anyway if it is not built before it's usage. It shouldn't block the `short` worker. 