### PR TITLE
fix: Don't show Send SMS in BOM

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -383,8 +383,9 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 
 	setup_sms: function() {
 		var me = this;
+		let blacklist = ['Purchase Invoice', 'BOM'];
 		if(this.frm.doc.docstatus===1 && !in_list(["Lost", "Stopped", "Closed"], this.frm.doc.status)
-			&& this.frm.doctype != "Purchase Invoice") {
+			&& !blacklist.includes(this.frm.doctype)) {
 			this.frm.page.add_menu_item(__('Send SMS'), function() { me.send_sms(); });
 		}
 	},


### PR DESCRIPTION
Send SMS option doesn't work in BOM, it shouldn't show up.

![image](https://user-images.githubusercontent.com/9355208/60666665-33e51180-9e85-11e9-9a67-9cc3c31aedd5.png)
