### PR TITLE
fix(UX): Move Bill of Materials section to first

### DIFF
--- a/erpnext/config/manufacturing.py
+++ b/erpnext/config/manufacturing.py
@@ -4,43 +4,6 @@ from frappe import _
 def get_data():
 	return [
 		{
-			"label": _("Production"),
-			"icon": "fa fa-star",
-			"items": [
-				{
-					"type": "doctype",
-					"name": "Work Order",
-					"description": _("Orders released for production."),
-					"onboard": 1,
-					"dependencies": ["Item", "BOM"]
-				},
-				{
-					"type": "doctype",
-					"name": "Production Plan",
-					"description": _("Generate Material Requests (MRP) and Work Orders."),
-					"onboard": 1,
-					"dependencies": ["Item", "BOM"]
-				},
-				{
-					"type": "doctype",
-					"name": "Stock Entry",
-					"onboard": 1,
-					"dependencies": ["Item"]
-				},
-				{
-					"type": "doctype",
-					"name": "Timesheet",
-					"description": _("Time Sheet for manufacturing."),
-					"onboard": 1,
-					"dependencies": ["Activity Type"]
-				},
-				{
-					"type": "doctype",
-					"name": "Job Card"
-				}
-			]
-		},
-		{
 			"label": _("Bill of Materials"),
 			"items": [
 				{
@@ -83,6 +46,43 @@ def get_data():
 					"name": "Routing"
 				}
 
+			]
+		},
+		{
+			"label": _("Production"),
+			"icon": "fa fa-star",
+			"items": [
+				{
+					"type": "doctype",
+					"name": "Work Order",
+					"description": _("Orders released for production."),
+					"onboard": 1,
+					"dependencies": ["Item", "BOM"]
+				},
+				{
+					"type": "doctype",
+					"name": "Production Plan",
+					"description": _("Generate Material Requests (MRP) and Work Orders."),
+					"onboard": 1,
+					"dependencies": ["Item", "BOM"]
+				},
+				{
+					"type": "doctype",
+					"name": "Stock Entry",
+					"onboard": 1,
+					"dependencies": ["Item"]
+				},
+				{
+					"type": "doctype",
+					"name": "Timesheet",
+					"description": _("Time Sheet for manufacturing."),
+					"onboard": 1,
+					"dependencies": ["Activity Type"]
+				},
+				{
+					"type": "doctype",
+					"name": "Job Card"
+				}
 			]
 		},
 		{


### PR DESCRIPTION
The links in the first card like "Work Order" and "Production Plan" can't be created unless "Item" and "BOM" are created. Hence, it should be first.

Before:
![image](https://user-images.githubusercontent.com/9355208/60666553-ee284900-9e84-11e9-8887-c2b63f630c5a.png)

After:
![image](https://user-images.githubusercontent.com/9355208/60666491-c933d600-9e84-11e9-8164-961020d2ff1b.png)
