### PR TITLE
chore: added check for auto-reorder in stock settings

### DIFF
--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -866,8 +866,6 @@ class Item(WebsiteGenerator):
 			if not enabled:
 				frappe.msgprint(msg=_("You have to enable auto re-order in Stock Settings to maintain re-order levels."), title=_("Enable Auto Re-Order"), indicator="orange")
 
-		return
-
 def get_timeline_data(doctype, name):
 	'''returns timeline data based on stock ledger entry'''
 	out = {}

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -122,6 +122,7 @@ class Item(WebsiteGenerator):
 		self.validate_item_defaults()
 		self.validate_customer_provided_part()
 		self.update_defaults_from_item_group()
+		self.validate_auto_reorder_enabled_in_stock_settings()
 		self.cant_change()
 
 		if not self.get("__islocal"):
@@ -858,6 +859,14 @@ class Item(WebsiteGenerator):
 				frappe.db.get_value("Production Order",
 					filters={"production_item": self.name, "docstatus": 1}):
 				return True
+
+	def validate_auto_reorder_enabled_in_stock_settings(self):
+		if self.reorder_levels:
+			enabled = frappe.db.get_single_value('Stock Settings', 'auto_indent')
+			if not enabled:
+				frappe.msgprint(msg=_("You have to enable auto re-order in Stock Settings to maintain re-order levels."), title=_("Enable Auto Re-Order"), indicator="orange")
+
+		return
 
 def get_timeline_data(doctype, name):
 	'''returns timeline data based on stock ledger entry'''


### PR DESCRIPTION
When setting Auto Re-Order levels for an item, the server would not validate if auto reorder is enabled or not.

This PR adds a check for that in `validate_auto_reorder_enabled_in_stock_settings` and shows a warning in case it is disabled. **Note:** The user is able to save the item anyway. 

---
Warning Message

<img width="419" alt="Screenshot 2019-07-05 at 11 05 37 AM" src="https://user-images.githubusercontent.com/18097732/60700266-e1533600-9f14-11e9-9728-af8f6951ff5f.png">
