### PR TITLE
refactor: added throw if supplier is not default for any item

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -370,19 +370,20 @@ def make_purchase_order_based_on_supplier(source_name, target_doc=None):
 def get_material_requests_based_on_supplier(supplier):
 	supplier_items = [d.parent for d in frappe.db.get_all("Item Default",
 		{"default_supplier": supplier}, 'parent')]
-	if supplier_items:
-		material_requests = frappe.db.sql_list("""select distinct mr.name
-			from `tabMaterial Request` mr, `tabMaterial Request Item` mr_item
-			where mr.name = mr_item.parent
-				and mr_item.item_code in (%s)
-				and mr.material_request_type = 'Purchase'
-				and mr.per_ordered < 99.99
-				and mr.docstatus = 1
-				and mr.status != 'Stopped'
-			order by mr_item.item_code ASC""" % ', '.join(['%s']*len(supplier_items)),
-			tuple(supplier_items))
-	else:
-		material_requests = []
+	if not supplier_items:
+		frappe.throw(_("{0} is not the default supplier for any items.".format(supplier)))
+
+	material_requests = frappe.db.sql_list("""select distinct mr.name
+		from `tabMaterial Request` mr, `tabMaterial Request Item` mr_item
+		where mr.name = mr_item.parent
+			and mr_item.item_code in (%s)
+			and mr.material_request_type = 'Purchase'
+			and mr.per_ordered < 99.99
+			and mr.docstatus = 1
+			and mr.status != 'Stopped'
+		order by mr_item.item_code ASC""" % ', '.join(['%s']*len(supplier_items)),
+		tuple(supplier_items))
+
 	return material_requests, supplier_items
 
 @frappe.whitelist()


### PR DESCRIPTION
Get items for open material request would return no items if the supplier is not set as default for any item, this was done silently without informing the user.

Fixed this in this PR

<img width="443" alt="Screenshot 2019-07-05 at 1 08 51 PM" src="https://user-images.githubusercontent.com/18097732/60705968-0d2ae780-9f26-11e9-9d55-bb383e2e5dd1.png">
