### PR TITLE
fix(exchange-rate-revaluation): change view on creation of journal entries

### DIFF
--- a/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.js
+++ b/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.js
@@ -21,9 +21,29 @@ frappe.ui.form.on('Exchange Rate Revaluation', {
 
 	refresh: function(frm) {
 		if(frm.doc.docstatus==1) {
-			frm.add_custom_button(__('Create Journal Entry'), function() {
-				return frm.events.make_jv(frm);
-			});
+			frappe.db.get_value("Journal Entry Account", {
+				'reference_type': 'Exchange Rate Revaluation',
+				'reference_name': frm.doc.name,
+				'docstatus': 1
+			}, "sum(debit) as sum", (r) =>{
+				let total_amt = 0;
+				frm.doc.accounts.forEach(d=> {
+					total_amt = total_amt + d['new_balance_in_base_currency'];
+				});
+				if(total_amt === r.sum) {
+					frm.add_custom_button(__("Journal Entry"), function(){
+						frappe.route_options = {
+							'reference_type': 'Exchange Rate Revaluation',
+							'reference_name': frm.doc.name
+						};
+						frappe.set_route("List", "Journal Entry");
+					}, __("View"));
+				} else {
+					frm.add_custom_button(__('Create Journal Entry'), function() {
+						return frm.events.make_jv(frm);
+					});
+				}
+			}, 'Journal Entry');
 		}
 	},
 


### PR DESCRIPTION
Earlier the 'Create Journal Entry' button was visible even after the creation of journal entries. This PR intends to fix it.
- Add View Journal Entry button that routes to appropriate journal entry after all the parties involved in the exchange rate revaluation have a corresponding journal entry.
![Screenshot 2019-07-08 at 8 03 09 PM](https://user-images.githubusercontent.com/14824451/60819706-afb0c800-a1bd-11e9-8e1f-0b353f888c54.png)


