### PR TITLE
Fix: error report for item price

### DIFF
--- a/erpnext/stock/doctype/item_price/item_price.py
+++ b/erpnext/stock/doctype/item_price/item_price.py
@@ -31,13 +31,16 @@ class ItemPrice(Document):
 				frappe.throw(_("Valid From Date must be lesser than Valid Upto Date."))
 
 	def update_price_list_details(self):
-		self.buying, self.selling, self.currency = \
-			frappe.db.get_value("Price List",
-								{"name": self.price_list, "enabled": 1},
-								["buying", "selling", "currency"])
+		if self.price_list:
+			self.buying, self.selling, self.currency = \
+				frappe.db.get_value("Price List",
+					{"name": self.price_list, "enabled": 1},
+					["buying", "selling", "currency"])
 
 	def update_item_details(self):
-		self.item_name, self.item_description = frappe.db.get_value("Item",self.item_code,["item_name", "description"])
+		if self.item_code:
+			self.item_name, self.item_description = frappe.db.get_value("Item",
+				self.item_code,["item_name", "description"])
 
 	def check_duplicates(self):
 		conditions = "where item_code=%(item_code)s and price_list=%(price_list)s and name != %(name)s"


### PR DESCRIPTION
Issue

```

Route
Form/Item Price/ITEM-PRICE-02767
Error Report
Traceback (most recent call last):
  File "/home/frappe/benches/bench-11-2019-07-04-1/apps/frappe/frappe/desk/form/save.py", line 22, in savedocs
    doc.save()
  File "/home/frappe/benches/bench-11-2019-07-04-1/apps/frappe/frappe/model/document.py", line 260, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-11-2019-07-04-1/apps/frappe/frappe/model/document.py", line 296, in _save
    self.run_before_save_methods()
  File "/home/frappe/benches/bench-11-2019-07-04-1/apps/frappe/frappe/model/document.py", line 876, in run_before_save_methods
    self.run_method("validate")
  File "/home/frappe/benches/bench-11-2019-07-04-1/apps/frappe/frappe/model/document.py", line 772, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-11-2019-07-04-1/apps/frappe/frappe/model/document.py", line 1048, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-11-2019-07-04-1/apps/frappe/frappe/model/document.py", line 1031, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-11-2019-07-04-1/apps/frappe/frappe/model/document.py", line 766, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-11-2019-07-04-1/apps/erpnext/erpnext/stock/doctype/item_price/item_price.py", line 20, in validate
    self.update_price_list_details()
  File "/home/frappe/benches/bench-11-2019-07-04-1/apps/erpnext/erpnext/stock/doctype/item_price/item_price.py", line 37, in update_price_list_details
    ["buying", "selling", "currency"])
TypeError: 'NoneType' object is not iterable
```