### PR TITLE
feat: added chart to cash-flow report

### DIFF
--- a/erpnext/accounts/report/cash_flow/cash_flow.py
+++ b/erpnext/accounts/report/cash_flow/cash_flow.py
@@ -69,7 +69,9 @@ def execute(filters=None):
 	add_total_row_account(data, data, _("Net Change in Cash"), period_list, company_currency)
 	columns = get_columns(filters.periodicity, period_list, filters.accumulated_values, filters.company)
 
-	return columns, data
+	chart = get_chart_data(columns, data)
+
+	return columns, data, None, chart
 
 def get_cash_flow_accounts():
 	operation_accounts = {
@@ -172,3 +174,18 @@ def add_total_row_account(out, data, label, period_list, currency, consolidated 
 
 	out.append(total_row)
 	out.append({})
+
+def get_chart_data(columns, data):
+	labels = [d.get("label") for d in columns[2:]]
+	datasets = [{'name':account.get('account').replace("'", ""), 'values': [account.get('total')]}  for account in data if account.get('parent_account') == None and account.get('currency')]
+	datasets = datasets[:-1]
+
+	chart = {
+		"data": {
+			'labels': labels,
+			'datasets': datasets
+		},
+		"type": "bar"
+	}
+
+	return chart

--- a/erpnext/accounts/report/cash_flow/cash_flow.py
+++ b/erpnext/accounts/report/cash_flow/cash_flow.py
@@ -187,5 +187,7 @@ def get_chart_data(columns, data):
 		},
 		"type": "bar"
 	}
+	
+	chart["fieldtype"] = "Currency"
 
 	return chart


### PR DESCRIPTION
Added missing charts for Cash Flow report

<img width="1440" alt="Screenshot 2019-07-10 at 8 29 07 PM" src="https://user-images.githubusercontent.com/18097732/60980112-7f019780-a351-11e9-8893-a19fbf434b63.png">

The bad labels have to be fixed in Charts library. Will be fixed in the next release of charts.