### PR TITLE
fix: Add missing Cost Centre filter in cash flow statement

### DIFF
--- a/erpnext/accounts/report/cash_flow/cash_flow.js
+++ b/erpnext/accounts/report/cash_flow/cash_flow.js
@@ -8,17 +8,19 @@ frappe.require("assets/erpnext/js/financial_statements.js", function() {
 	// The last item in the array is the definition for Presentation Currency
 	// filter. It won't be used in cash flow for now so we pop it. Please take
 	// of this if you are working here.
-	frappe.query_reports["Cash Flow"]["filters"].pop();
 
-	frappe.query_reports["Cash Flow"]["filters"].push({
-		"fieldname": "accumulated_values",
-		"label": __("Accumulated Values"),
-		"fieldtype": "Check"
-	});
+	frappe.query_reports["Cash Flow"]["filters"].splice(5, 1);
 
-	frappe.query_reports["Cash Flow"]["filters"].push({
-		"fieldname": "include_default_book_entries",
-		"label": __("Include Default Book Entries"),
-		"fieldtype": "Check"
-	});
+	frappe.query_reports["Cash Flow"]["filters"].push(
+		{
+			"fieldname": "accumulated_values",
+			"label": __("Accumulated Values"),
+			"fieldtype": "Check"
+		},
+		{
+			"fieldname": "include_default_book_entries",
+			"label": __("Include Default Book Entries"),
+			"fieldtype": "Check"
+		}
+	);
 });


### PR DESCRIPTION
Fixes: https://github.com/frappe/erpnext/issues/18240
![image](https://user-images.githubusercontent.com/42651287/60988633-9a749e80-a361-11e9-90b8-7d9998b7fa84.png)


