### PR TITLE
fix(auto attendance): Prevent marking attendance for the ongoing shift

### DIFF
--- a/erpnext/hr/doctype/shift_type/shift_type.py
+++ b/erpnext/hr/doctype/shift_type/shift_type.py
@@ -22,7 +22,7 @@ class ShiftType(Document):
 			'skip_auto_attendance':'0',
 			'attendance':('is', 'not set'),
 			'time':('>=', self.process_attendance_after),
-			'shift_actual_start': ('<', self.last_sync_of_checkin),
+			'shift_actual_end': ('<', self.last_sync_of_checkin),
 			'shift': self.name
 		}
 		logs = frappe.db.get_list('Employee Checkin', fields="*", filters=filters, order_by="employee,time")


### PR DESCRIPTION
the auto attendance currently marks attendance for the ongoing shift(this can lead to marking absent for current shift before the employees check-out). This PR fixes that.