### PR TITLE
fix: cost center not able to access

### DIFF
--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -721,7 +721,6 @@ def get_children(doctype, parent, company, is_root=False):
 	parent_fieldname = 'parent_' + doctype.lower().replace(' ', '_')
 	fields = [
 		'name as value',
-		'root_type',
 		'is_group as expandable'
 	]
 	filters = [['docstatus', '<', 2]]
@@ -729,11 +728,11 @@ def get_children(doctype, parent, company, is_root=False):
 	filters.append(['ifnull(`{0}`,"")'.format(parent_fieldname), '=', '' if is_root else parent])
 
 	if is_root:
-		fields += ['report_type', 'account_currency'] if doctype == 'Account' else []
+		fields += ['root_type', 'report_type', 'account_currency'] if doctype == 'Account' else []
 		filters.append(['company', '=', company])
 
 	else:
-		fields += ['account_currency'] if doctype == 'Account' else []
+		fields += ['root_type', 'account_currency'] if doctype == 'Account' else []
 		fields += [parent_fieldname + ' as parent']
 
 	acc = frappe.get_list(doctype, fields=fields, filters=filters)


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/__init__.py", line 1036, in call
    return fn(*args, **newargs)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/erpnext/erpnext/accounts/utils.py", line 739, in get_children
    acc = frappe.get_list(doctype, fields=fields, filters=filters)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/__init__.py", line 1264, in get_list
    return frappe.model.db_query.DatabaseQuery(doctype).execute(None, *args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/model/db_query.py", line 93, in execute
    result = self.build_and_run()
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/model/db_query.py", line 117, in build_and_run
    return frappe.db.sql(query, as_dict=not self.as_list, debug=self.debug, update=self.update)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/database.py", line 214, in sql
    self._cursor.execute(query)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/env/lib/python2.7/site-packages/pymysql/cursors.py", line 170, in execute
    result = self._query(query)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/env/lib/python2.7/site-packages/pymysql/cursors.py", line 328, in _query
    conn.query(q)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 517, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 732, in _read_query_result
    result.read()
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1075, in read
    first_packet = self.connection._read_packet()
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 684, in _read_packet
    packet.check_error()
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/env/lib/python2.7/site-packages/pymysql/protocol.py", line 220, in check_error
    err.raise_mysql_exception(self._data)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/env/lib/python2.7/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
    raise errorclass(errno, errval)
InternalError: (1054, u"Unknown column 'root_type' in 'field list'")
```