### PR TITLE
fix: send sms not working for the quotation

### DIFF
--- a/erpnext/public/js/sms_manager.js
+++ b/erpnext/public/js/sms_manager.js
@@ -20,7 +20,7 @@ erpnext.SMSManager = function SMSManager(doc) {
 			'Purchase Receipt'	: 'Items has been received against purchase receipt: ' + doc.name
 		}
 
-		if (in_list(['Quotation', 'Sales Order', 'Delivery Note', 'Sales Invoice'], doc.doctype))
+		if (in_list(['Sales Order', 'Delivery Note', 'Sales Invoice'], doc.doctype))
 			this.show(doc.contact_person, 'Customer', doc.customer, '', default_msg[doc.doctype]);
 		else if (in_list(['Purchase Order', 'Purchase Receipt'], doc.doctype))
 			this.show(doc.contact_person, 'Supplier', doc.supplier, '', default_msg[doc.doctype]);
@@ -28,6 +28,8 @@ erpnext.SMSManager = function SMSManager(doc) {
 			this.show('', '', '', doc.mobile_no, default_msg[doc.doctype]);
 		else if (doc.doctype == 'Opportunity')
 			this.show('', '', '', doc.contact_no, default_msg[doc.doctype]);
+		else if (doc.doctype == 'Quotation')
+			this.show(doc.contact_person, doc.quotation_to, doc.party_name, '', default_msg[doc.doctype]);
 		else if (doc.doctype == 'Material Request')
 			this.show('', '', '', '', default_msg[doc.doctype]);
 


### PR DESCRIPTION
**Issue**

Customer field is not available in the quotation due to which below error was coming when user clicks on Send SMS button

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-11-2019-07-16/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-11-2019-07-16/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-11-2019-07-16/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-11-2019-07-16/apps/frappe/frappe/__init__.py", line 1036, in call
    return fn(*args, **newargs)
TypeError: get_contact_number() takes exactly 3 arguments (2 given)
```

After Fix

<img width="823" alt="Screenshot 2019-07-18 at 1 54 03 PM" src="https://user-images.githubusercontent.com/8780500/61441581-8cc3a800-a963-11e9-9c0b-2b5d638e9ad3.png">
