### PR TITLE
fix: not able to make material request for bundle items from the sale…

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -509,10 +509,12 @@ def make_material_request(source_name, target_doc=None):
 		doc.material_request_type = "Purchase"
 
 	def update_item(source, target, source_parent):
+		# qty is for packed items, because packed items don't have stock_qty field
+		qty = source.get("stock_qty") or source.get("qty")
 		target.project = source_parent.project
-		target.qty = source.stock_qty - requested_item_qty.get(source.name, 0)
+		target.qty = qty - requested_item_qty.get(source.name, 0)
 		target.conversion_factor = 1
-		target.stock_qty = source.stock_qty - requested_item_qty.get(source.name, 0)
+		target.stock_qty = qty - requested_item_qty.get(source.name, 0)
 
 	doc = get_mapped_doc("Sales Order", source_name, {
 		"Sales Order": {


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/__init__.py", line 1036, in call
    return fn(*args, **newargs)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/model/mapper.py", line 30, in make_mapped_doc
    return method(source_name)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/erpnext/erpnext/selling/doctype/sales_order/sales_order.py", line 543, in make_material_request
    }, target_doc, postprocess)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/model/mapper.py", line 110, in get_mapped_doc
    map_child_doc(source_d, target_doc, table_map, source_doc)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/model/mapper.py", line 205, in map_child_doc
    map_doc(source_d, target_d, table_map, source_parent)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/model/mapper.py", line 129, in map_doc
    table_map["postprocess"](source_doc, target_doc, source_parent)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/erpnext/erpnext/selling/doctype/sales_order/sales_order.py", line 513, in update_item
    target.qty = source.stock_qty - requested_item_qty.get(source.name, 0)
AttributeError: 'PackedItem' object has no attribute 'stock_qty'
```