### PR TITLE
fix: Change other_charges_calculation type from text to longtext

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.json
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.json
@@ -2176,7 +2176,7 @@
    "columns": 0, 
    "fetch_if_empty": 0, 
    "fieldname": "other_charges_calculation", 
-   "fieldtype": "Text", 
+   "fieldtype": "Long Text", 
    "hidden": 0, 
    "ignore_user_permissions": 0, 
    "ignore_xss_filter": 0, 


### PR DESCRIPTION
update other_charges_calculation from type text to longtext, to hold more items in Taxes and Charges Calculation, because the maximum text capacity is only 65535 characters.
