### PR TITLE
fix: added default value for projected_qty in bin_dict

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -505,7 +505,7 @@ def get_material_request_items(row, sales_order,
 	total_qty = row['qty']
 
 	required_qty = 0
-	if ignore_existing_ordered_qty or bin_dict.get("projected_qty") < 0:
+	if ignore_existing_ordered_qty or bin_dict.get("projected_qty", 0) < 0:
 		required_qty = total_qty
 	elif total_qty > bin_dict.get("projected_qty"):
 		required_qty = total_qty - bin_dict.get("projected_qty")


### PR DESCRIPTION
`projected_qty` if not in `bin_dict` would return None. And when compared to an integer would result in a TypeError.

This PR fixes this

