### PR TITLE
fix: Sample qty validation fixes in Purchase Receipt

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.js
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.js
@@ -266,7 +266,10 @@ frappe.ui.form.on('Purchase Receipt Item', {
 			frappe.model.set_value(cdt, cdn, "sample_quantity", r.sample_quantity);
 		});
 	},
-	sample_quantity: function(frm, cdt, cdn) {
+	item_code: (frm, cdt, cdn) => {
+		validate_sample_quantity(frm, cdt, cdn);
+	},
+	qty: function(frm, cdt, cdn) {
 		validate_sample_quantity(frm, cdt, cdn);
 	},
 	batch_no: function(frm, cdt, cdn) {
@@ -283,7 +286,7 @@ cur_frm.cscript['Make Stock Entry'] = function() {
 
 var validate_sample_quantity = function(frm, cdt, cdn) {
 	var d = locals[cdt][cdn];
-	if (d.sample_quantity) {
+	if (d.sample_quantity && d.qty) {
 		frappe.call({
 			method: 'erpnext.stock.doctype.stock_entry.stock_entry.validate_sample_quantity',
 			args: {


### PR DESCRIPTION
Sample qty validation should be triggered on selection on qty or changing the item code

Fixes: #18223

