### PR TITLE
fix(pos): error when loyalty program is not used

### DIFF
--- a/erpnext/accounts/doctype/loyalty_program/loyalty_program.py
+++ b/erpnext/accounts/doctype/loyalty_program/loyalty_program.py
@@ -38,6 +38,8 @@ def get_loyalty_details(customer, loyalty_program, expiry_date=None, company=Non
 @frappe.whitelist()
 def get_loyalty_program_details_with_points(customer, loyalty_program=None, expiry_date=None, company=None, silent=False, include_expired_entry=False, current_transaction_amount=0):
 	lp_details = get_loyalty_program_details(customer, loyalty_program, company=company, silent=silent)
+	if not loyalty_program and not lp_details.loyalty_program:
+		return {}
 	loyalty_program = frappe.get_doc("Loyalty Program", loyalty_program or lp_details.loyalty_program)
 	lp_details.update(get_loyalty_details(customer, loyalty_program.name, expiry_date, company, include_expired_entry))
 

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -1099,7 +1099,8 @@ class SalesInvoice(SellingController):
 	def set_loyalty_program_tier(self):
 		lp_details = get_loyalty_program_details_with_points(self.customer, company=self.company,
 				loyalty_program=self.loyalty_program, include_expired_entry=True)
-		frappe.db.set_value("Customer", self.customer, "loyalty_program_tier", lp_details.tier_name)
+		if lp_details:
+			frappe.db.set_value("Customer", self.customer, "loyalty_program_tier", lp_details.tier_name)
 
 	def get_returned_amount(self):
 		returned_amount = frappe.db.sql("""


### PR DESCRIPTION
This fixes an error that is occurring in online POS, for organizations not using **Loyalty Program**. Apparently this error was introduced by PR #18111 (which I made).

Change to **Sales Invoice** code was necessary following similar reasoning.

