### PR TITLE
Adding get_query for item field to be able to search for item based on barcode

### DIFF
--- a/erpnext/stock/page/stock_balance/stock_balance.js
+++ b/erpnext/stock/page/stock_balance/stock_balance.js
@@ -22,6 +22,11 @@ frappe.pages['stock-balance'].on_page_load = function(wrapper) {
 		label: __('Item'),
 		fieldtype:'Link',
 		options:'Item',
+		get_query: function() {
+			return {
+				query: "erpnext.controllers.queries.item_query"
+			}
+		},
 		change: function() {
 			page.item_dashboard.start = 0;
 			page.item_dashboard.refresh();

--- a/erpnext/stock/report/item_price_stock/item_price_stock.js
+++ b/erpnext/stock/report/item_price_stock/item_price_stock.js
@@ -8,7 +8,12 @@ frappe.query_reports["Item Price Stock"] = {
 			"fieldname":"item_code",
 			"label": __("Item"),
 			"fieldtype": "Link",
-			"options": "Item"
+			"options": "Item",
+			"get_query": function() {
+				return {
+					query: "erpnext.controllers.queries.item_query"
+				}
+			}
 		}
 	]
 }

--- a/erpnext/stock/report/stock_ageing/stock_ageing.js
+++ b/erpnext/stock/report/stock_ageing/stock_ageing.js
@@ -28,7 +28,12 @@ frappe.query_reports["Stock Ageing"] = {
 			"fieldname":"item_code",
 			"label": __("Item"),
 			"fieldtype": "Link",
-			"options": "Item"
+			"options": "Item",
+			"get_query": function() {
+				return {
+					query: "erpnext.controllers.queries.item_query"
+				}
+			}
 		},
 		{
 			"fieldname":"brand",

--- a/erpnext/stock/report/stock_analytics/stock_analytics.js
+++ b/erpnext/stock/report/stock_analytics/stock_analytics.js
@@ -16,6 +16,11 @@ frappe.query_reports["Stock Analytics"] = {
 			label: __("Item"),
 			fieldtype: "Link",
 			options:"Item",
+			get_query: function() {
+				return {
+					query: "erpnext.controllers.queries.item_query"
+				}
+			},
 			default: "",
 		},
 		{


### PR DESCRIPTION
Hello;

I add get_query for item field for the below stock reports to be able to search for the item based on the barcode (otherwise, searching for item will be very complex as most of the users are depending on the barcode and not item name):

Stock Summary (it is stock balance page)
Stock Ageing
Item Price Stock
Stock Analytics

Please I need your kindly support to complete the merge.
Regards
Bilal
