### PR TITLE
fix(website): Remove references to Product Settings.products_as_list

### DIFF
--- a/erpnext/setup/doctype/item_group/item_group.py
+++ b/erpnext/setup/doctype/item_group/item_group.py
@@ -69,8 +69,7 @@ class ItemGroup(NestedSet, WebsiteGenerator):
 			"items": get_product_list_for_group(product_group = self.name, start=start,
 				limit=context.page_length + 1, search=frappe.form_dict.get("search")),
 			"parents": get_parent_item_groups(self.parent_item_group),
-			"title": self.name,
-			"products_as_list": cint(frappe.db.get_single_value('Products Settings', 'products_as_list'))
+			"title": self.name
 		})
 
 		if self.slideshow:


### PR DESCRIPTION
This was removed in https://github.com/frappe/erpnext/commit/5f8b358fd4746394cbe5c349b0e5bd1280c5af3a#diff-f0a387cdb305471e74e523ecc4e646ac
but was accidentally added back in https://github.com/frappe/erpnext/commit/34c551d9a54573e5184bb16831e0baa4e7429dc2#diff-f0a387cdb305471e74e523ecc4e646ac

```python-traceback
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/website/render.py", line 48, in render
    data = render_page_by_language(path)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/website/render.py", line 152, in render_page_by_language
    return render_page(path)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/website/render.py", line 168, in render_page
    return build(path)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/website/render.py", line 175, in build
    return build_page(path)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/website/render.py", line 188, in build_page
    context = get_context(path)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/website/context.py", line 28, in get_context
    context = build_context(context)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/website/context.py", line 87, in build_context
    ret = context.doc.get_context(context)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/setup/doctype/item_group/item_group.py", line 73, in get_context
    "products_as_list": cint(frappe.db.get_single_value('Products Settings', 'products_as_list'))
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/database.py", line 558, in get_single_value
    frappe.throw(_('Invalid field name: {0}').format(frappe.bold(fieldname)), self.InvalidColumnName)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 360, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red')
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 346, in msgprint
    _raise_exception()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 315, in _raise_exception
    raise raise_exception(msg)
frappe.database.database.Database.InvalidColumnName: Invalid field name: products_as_list
```

