### PR TITLE
fix(website): Remove references to Product Settings.products_as_list

### DIFF
--- a/erpnext/setup/doctype/item_group/item_group.py
+++ b/erpnext/setup/doctype/item_group/item_group.py
@@ -69,8 +69,7 @@ class ItemGroup(NestedSet, WebsiteGenerator):
 			"items": get_product_list_for_group(product_group = self.name, start=start,
 				limit=context.page_length + 1, search=frappe.form_dict.get("search")),
 			"parents": get_parent_item_groups(self.parent_item_group),
-			"title": self.name,
-			"products_as_list": cint(frappe.db.get_single_value('Products Settings', 'products_as_list'))
+			"title": self.name
 		})
 
 		if self.slideshow:


### PR DESCRIPTION
This was accidentally added back in https://github.com/frappe/erpnext/commit/34c551d9a54573e5184bb16831e0baa4e7429dc2#diff-f0a387cdb305471e74e523ecc4e646ac


