### PR TITLE
fix: GSTR-1 query fix

### DIFF
--- a/erpnext/regional/report/gstr_1/gstr_1.py
+++ b/erpnext/regional/report/gstr_1/gstr_1.py
@@ -161,8 +161,9 @@ class Gstr1Report(object):
 					"gst_category": ["in", ["Registered Regular", "Deemed Export", "SEZ"]]
 			})
 
-			conditions += """ and ifnull(gst_category, '') != 'Overseas' and is_return != 1
-				and customer in ({0})""".format(", ".join([frappe.db.escape(c.name) for c in customers]))
+			if customers:
+				conditions += """ and ifnull(gst_category, '') != 'Overseas' and is_return != 1
+					and customer in ({0})""".format(", ".join([frappe.db.escape(c.name) for c in customers]))
 
 		if self.filters.get("type_of_business") in ("B2C Large", "B2C Small"):
 			b2c_limit = frappe.db.get_single_value('GST Settings', 'b2c_limit')
@@ -174,11 +175,11 @@ class Gstr1Report(object):
 				"gst_category": ["in", ["Unregistered"]]
 		})
 
-		if self.filters.get("type_of_business") ==  "B2C Large":
+		if self.filters.get("type_of_business") ==  "B2C Large" and customers:
 			conditions += """ and SUBSTR(place_of_supply, 1, 2) != SUBSTR(company_gstin, 1, 2)
 				and grand_total > {0} and is_return != 1 and customer in ({1})""".\
 					format(flt(b2c_limit), ", ".join([frappe.db.escape(c.name) for c in customers]))
-		elif self.filters.get("type_of_business") ==  "B2C Small":
+		elif self.filters.get("type_of_business") ==  "B2C Small" and customers:
 			conditions += """ and (
 				SUBSTR(place_of_supply, 1, 2) = SUBSTR(company_gstin, 1, 2)
 					or grand_total <= {0}) and is_return != 1 and customer in ({1})""".\


### PR DESCRIPTION
```
Syntax error in query:

			select
				
			name as invoice_number,
			customer_name,
			posting_date,
			base_grand_total,
			base_rounded_total,
			COALESCE(NULLIF(customer_gstin,''), NULLIF(billing_address_gstin, '')) as customer_gstin,
			place_of_supply,
			ecommerce_gstin,
			reverse_charge,
			return_against,
			is_return,
			gst_category,
			export_type,
			port_code,
			shipping_bill_number,
			shipping_bill_date,
			reason_for_issuing_document
		
			from `tabSales Invoice`
			where docstatus = 1  and company=%(company)s and posting_date>=%(from_date)s and posting_date<=%(to_date)s and (
				SUBSTR(place_of_supply, 1, 2) = SUBSTR(company_gstin, 1, 2)
					or grand_total <= 250000.0) and is_return != 1 and customer in ()
			order by posting_date desc
			
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2019-05-09/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-2019-05-09/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-2019-05-09/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2019-05-09/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2019-05-09/apps/frappe/frappe/__init__.py", line 1036, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2019-05-09/apps/frappe/frappe/__init__.py", line 511, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "/home/frappe/benches/bench-2019-05-09/apps/frappe/frappe/desk/query_report.py", line 200, in run
    result = generate_report_result(report, filters, user)
  File "/home/frappe/benches/bench-2019-05-09/apps/frappe/frappe/desk/query_report.py", line 75, in generate_report_result
    res = frappe.get_attr(method_name)(frappe._dict(filters))
  File "/home/frappe/benches/bench-2019-05-09/apps/erpnext/erpnext/regional/report/gstr_1/gstr_1.py", line 14, in execute
    return Gstr1Report(filters).run()
  File "/home/frappe/benches/bench-2019-05-09/apps/erpnext/erpnext/regional/report/gstr_1/gstr_1.py", line 46, in run
    self.get_invoice_data()
  File "/home/frappe/benches/bench-2019-05-09/apps/erpnext/erpnext/regional/report/gstr_1/gstr_1.py", line 142, in get_invoice_data
    where_conditions=conditions), self.filters, as_dict=1)
  File "/home/frappe/benches/bench-2019-05-09/apps/frappe/frappe/database/database.py", line 156, in sql
    self._cursor.execute(query, values)
  File "/home/frappe/benches/bench-2019-05-09/env/lib/python3.6/site-packages/pymysql/cursors.py", line 170, in execute
    result = self._query(query)
  File "/home/frappe/benches/bench-2019-05-09/env/lib/python3.6/site-packages/pymysql/cursors.py", line 328, in _query
    conn.query(q)
  File "/home/frappe/benches/bench-2019-05-09/env/lib/python3.6/site-packages/pymysql/connections.py", line 517, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/home/frappe/benches/bench-2019-05-09/env/lib/python3.6/site-packages/pymysql/connections.py", line 732, in _read_query_result
    result.read()
  File "/home/frappe/benches/bench-2019-05-09/env/lib/python3.6/site-packages/pymysql/connections.py", line 1075, in read
    first_packet = self.connection._read_packet()
  File "/home/frappe/benches/bench-2019-05-09/env/lib/python3.6/site-packages/pymysql/connections.py", line 684, in _read_packet
    packet.check_error()
  File "/home/frappe/benches/bench-2019-05-09/env/lib/python3.6/site-packages/pymysql/protocol.py", line 220, in check_error
    err.raise_mysql_exception(self._data)
  File "/home/frappe/benches/bench-2019-05-09/env/lib/python3.6/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.ProgrammingError: (1064, "You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ')\n\t\t\torder by posting_date desc' at line 24")
```
