### PR TITLE
fix(Account): Pass parent currency to child currency

### DIFF
--- a/erpnext/accounts/doctype/account/account.py
+++ b/erpnext/accounts/doctype/account/account.py
@@ -123,7 +123,9 @@ class Account(NestedSet):
 				doc.flags.ignore_root_company_validation = True
 				doc.update({
 					"company": company,
-					"account_currency": None,
+					# parent account's currency should be passed down to child account's curreny
+					# if it is None, it picks it up from default company currency, which might be unintended
+					"account_currency": self.account_currency,
 					"parent_account": parent_acc_name_map[company]
 				})
 				doc.save()


### PR DESCRIPTION
In a scenario where Parent Company Account's Currency is different
from it's default currency, the Account Currency of Child would be set
from the default currency of Company which might be wrong