### PR TITLE
fix(payroll-entry): show make bank entry button

### DIFF
--- a/erpnext/hr/doctype/payroll_entry/payroll_entry.py
+++ b/erpnext/hr/doctype/payroll_entry/payroll_entry.py
@@ -12,6 +12,16 @@ from erpnext.accounts.utils import get_fiscal_year
 from erpnext.hr.doctype.employee.employee import get_holiday_list_for_employee
 
 class PayrollEntry(Document):
+	def onload(self):
+		if not self.docstatus==1:
+			return
+
+		# check if salary slips were manually submitted
+		entries = frappe.db.count("Salary Slip", {'payroll_entry': self.name, 'docstatus': 1}, ['name'])
+		if cint(entries) == len(self.employees) and not self.salary_slips_submitted:
+			self.db_set("salary_slips_submitted", 1)
+			self.reload()
+
 	def on_submit(self):
 		self.create_salary_slips()
 

--- a/erpnext/hr/doctype/payroll_entry/payroll_entry.py
+++ b/erpnext/hr/doctype/payroll_entry/payroll_entry.py
@@ -13,7 +13,7 @@ from erpnext.hr.doctype.employee.employee import get_holiday_list_for_employee
 
 class PayrollEntry(Document):
 	def onload(self):
-		if not self.docstatus==1:
+		if not self.docstatus==1 or self.salary_slips_submitted:
 			return
 
 		# check if salary slips were manually submitted


### PR DESCRIPTION
On manual submission of salary slip related to a payroll entry make bank entry button is not visible. This PR adds a check to find all the submitted entries and if all salary slips are submitted then it shows the button.
