### PR TITLE
fix (dash): added payroll period in HR module

### DIFF
--- a/erpnext/config/hr.py
+++ b/erpnext/config/hr.py
@@ -162,6 +162,10 @@ def get_data():
 				},
 				{
 					"type": "doctype",
+					"name": "Payroll Period",
+				},
+				{
+					"type": "doctype",
 					"name": "Salary Component",
 				},
 				{


### PR DESCRIPTION
Payroll period was missing in the dashboard under the Payroll section of the HR module. Have added the same.
