### PR TITLE
fix: Type error handling while getting material request items

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -507,7 +507,7 @@ def get_material_request_items(row, sales_order,
 	required_qty = 0
 	if ignore_existing_ordered_qty or bin_dict.get("projected_qty", 0) < 0:
 		required_qty = total_qty
-	elif flt(total_qty) > bin_dict.get("projected_qty", 0):
+	elif total_qty > bin_dict.get("projected_qty", 0):
 		required_qty = total_qty - bin_dict.get("projected_qty", 0)
 	if required_qty > 0 and required_qty < row['min_order_qty']:
 		required_qty = row['min_order_qty']

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -430,7 +430,7 @@ def download_raw_materials(production_plan):
 					continue
 
 				item_list.append(['', '', '', '', bin_dict.get('warehouse'),
-					bin_dict.get('projected_qty'), bin_dict.get('actual_qty')])
+					bin_dict.get('projected_qty', 0), bin_dict.get('actual_qty', 0)])
 
 	build_csv_response(item_list, doc.name)
 
@@ -507,8 +507,8 @@ def get_material_request_items(row, sales_order,
 	required_qty = 0
 	if ignore_existing_ordered_qty or bin_dict.get("projected_qty", 0) < 0:
 		required_qty = total_qty
-	elif total_qty > bin_dict.get("projected_qty"):
-		required_qty = total_qty - bin_dict.get("projected_qty")
+	elif flt(total_qty) > bin_dict.get("projected_qty", 0):
+		required_qty = total_qty - bin_dict.get("projected_qty", 0)
 	if required_qty > 0 and required_qty < row['min_order_qty']:
 		required_qty = row['min_order_qty']
 	item_group_defaults = get_item_group_defaults(row.item_code, company)


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2019-05-09/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-2019-05-09/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-2019-05-09/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2019-05-09/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2019-05-09/apps/frappe/frappe/__init__.py", line 1036, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2019-05-09/apps/erpnext/erpnext/manufacturing/doctype/production_plan/production_plan.py", line 690, in get_items_for_material_requests
    ignore_existing_ordered_qty, warehouse, bin_dict)
  File "/home/frappe/benches/bench-2019-05-09/apps/erpnext/erpnext/manufacturing/doctype/production_plan/production_plan.py", line 510, in get_material_request_items
    elif total_qty > bin_dict.get("projected_qty"):
TypeError: '>' not supported between instances of 'float' and 'NoneType'

```

