### PR TITLE
fix: Error handling in taxes and totals

### DIFF
--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -77,7 +77,7 @@ class calculate_taxes_and_totals(object):
 
 				item.net_rate = item.rate
 
-				if not item.qty and self.doc.is_return:
+				if not item.qty and self.doc.get("is_return"):
 					item.amount = flt(-1 * item.rate, item.precision("amount"))
 				else:
 					item.amount = flt(item.rate * item.qty,	item.precision("amount"))


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-11-2019-08-02/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-version-11-2019-08-02/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-11-2019-08-02/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-11-2019-08-02/apps/frappe/frappe/__init__.py", line 1036, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-11-2019-08-02/apps/frappe/frappe/model/mapper.py", line 30, in make_mapped_doc
    return method(source_name)
  File "/home/frappe/benches/bench-version-11-2019-08-02/apps/erpnext/erpnext/crm/doctype/opportunity/opportunity.py", line 251, in make_quotation
    }, target_doc, set_missing_values)
  File "/home/frappe/benches/bench-version-11-2019-08-02/apps/frappe/frappe/model/mapper.py", line 113, in get_mapped_doc
    postprocess(source_doc, target_doc)
  File "/home/frappe/benches/bench-version-11-2019-08-02/apps/erpnext/erpnext/crm/doctype/opportunity/opportunity.py", line 229, in set_missing_values
    quotation.run_method("calculate_taxes_and_totals")
  File "/home/frappe/benches/bench-version-11-2019-08-02/apps/frappe/frappe/model/document.py", line 772, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-version-11-2019-08-02/apps/frappe/frappe/model/document.py", line 1048, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-version-11-2019-08-02/apps/frappe/frappe/model/document.py", line 1031, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-version-11-2019-08-02/apps/frappe/frappe/model/document.py", line 766, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-version-11-2019-08-02/apps/erpnext/erpnext/controllers/accounts_controller.py", line 160, in calculate_taxes_and_totals
    calculate_taxes_and_totals(self)
  File "/home/frappe/benches/bench-version-11-2019-08-02/apps/erpnext/erpnext/controllers/taxes_and_totals.py", line 15, in __init__
    self.calculate()
  File "/home/frappe/benches/bench-version-11-2019-08-02/apps/erpnext/erpnext/controllers/taxes_and_totals.py", line 22, in calculate
    self._calculate()
  File "/home/frappe/benches/bench-version-11-2019-08-02/apps/erpnext/erpnext/controllers/taxes_and_totals.py", line 36, in _calculate
    self.calculate_item_values()
  File "/home/frappe/benches/bench-version-11-2019-08-02/apps/erpnext/erpnext/controllers/taxes_and_totals.py", line 80, in calculate_item_values
    if not item.qty and self.doc.is_return:
AttributeError: 'Quotation' object has no attribute 'is_return'
```

