### PR TITLE
fix: Quotation list in customer portal

### DIFF
--- a/erpnext/controllers/website_list_for_contact.py
+++ b/erpnext/controllers/website_list_for_contact.py
@@ -77,7 +77,7 @@ def get_list_for_transactions(doctype, txt, filters, limit_start, limit_page_len
 
 	if or_filters:
 		for r in frappe.get_list(doctype, fields=fields,filters=filters, or_filters=or_filters,
-			limit_start=limit_start, limit_page_length=limit_page_length, 
+			limit_start=limit_start, limit_page_length=limit_page_length,
 			ignore_permissions=ignore_permissions, order_by=order_by):
 			data.append(r)
 
@@ -130,38 +130,57 @@ def get_customers_suppliers(doctype, user):
 	suppliers = []
 	meta = frappe.get_meta(doctype)
 
+	customer_field_name = get_customer_field_name(doctype)
+
+	has_customer_field = meta.has_field(customer_field_name)
+	has_supplier_field = meta.has_field('supplier')
+
 	if has_common(["Supplier", "Customer"], frappe.get_roles(user)):
 		contacts = frappe.db.sql("""
-			select 
+			select
 				`tabContact`.email_id,
 				`tabDynamic Link`.link_doctype,
 				`tabDynamic Link`.link_name
-			from 
+			from
 				`tabContact`, `tabDynamic Link`
 			where
 				`tabContact`.name=`tabDynamic Link`.parent and `tabContact`.email_id =%s
 			""", user, as_dict=1)
-		customers = [c.link_name for c in contacts if c.link_doctype == 'Customer'] \
-			if meta.get_field("customer") else None
-		suppliers = [c.link_name for c in contacts if c.link_doctype == 'Supplier'] \
-			if meta.get_field("supplier") else None
+		customers = [c.link_name for c in contacts if c.link_doctype == 'Customer']
+		suppliers = [c.link_name for c in contacts if c.link_doctype == 'Supplier']
 	elif frappe.has_permission(doctype, 'read', user=user):
-		customers = [customer.name for customer in frappe.get_list("Customer")] \
-			if meta.get_field("customer") else None
-		suppliers = [supplier.name for supplier in frappe.get_list("Customer")] \
-			if meta.get_field("supplier") else None
+		customer_list = frappe.get_list("Customer")
+		customers = [customer.name for customer in customer_list]
+		suppliers = [supplier.name for supplier in customer_list]
 
-	return customers, suppliers
+	return customers if has_customer_field else None, \
+		suppliers if has_supplier_field else None
 
 def has_website_permission(doc, ptype, user, verbose=False):
 	doctype = doc.doctype
 	customers, suppliers = get_customers_suppliers(doctype, user)
 	if customers:
-		return frappe.get_all(doctype, filters=[(doctype, "customer", "in", customers),
-			(doctype, "name", "=", doc.name)]) and True or False
+		return frappe.db.exists(doctype, filters=get_customer_filter(doc, customers))
 	elif suppliers:
 		fieldname = 'suppliers' if doctype == 'Request for Quotation' else 'supplier'
-		return frappe.get_all(doctype, filters=[(doctype, fieldname, "in", suppliers),
-			(doctype, "name", "=", doc.name)]) and True or False
+		return frappe.db.exists(doctype, filters={
+			'name': doc.name,
+			fieldname: ["in", suppliers]
+		})
 	else:
 		return False
+
+def get_customer_filter(doc, customers):
+	doctype = doc.doctype
+	filters = frappe._dict()
+	filters.name = doc.name
+	filters[get_customer_field_name(doctype)] = ['in', customers]
+	if doctype == 'Quotation':
+		filters.party_type = 'Customer'
+	return filters
+
+def get_customer_field_name(doctype):
+	if doctype == 'Quotation':
+		return 'party_name'
+	else:
+		return 'customer'

--- a/erpnext/controllers/website_list_for_contact.py
+++ b/erpnext/controllers/website_list_for_contact.py
@@ -150,8 +150,7 @@ def get_customers_suppliers(doctype, user):
 		suppliers = [c.link_name for c in contacts if c.link_doctype == 'Supplier']
 	elif frappe.has_permission(doctype, 'read', user=user):
 		customer_list = frappe.get_list("Customer")
-		customers = [customer.name for customer in customer_list]
-		suppliers = [supplier.name for supplier in customer_list]
+		customers = suppliers = [customer.name for customer in customer_list]
 
 	return customers if has_customer_field else None, \
 		suppliers if has_supplier_field else None


### PR DESCRIPTION
Customers were not able to see their quotations because of
 the recent `customer` field removal from Quotation

ref: https://github.com/frappe/erpnext/pull/17097