### PR TITLE
 fix(employee-advance): update employee advance on change in expense claim

### DIFF
--- a/erpnext/hr/doctype/employee_advance/employee_advance.py
+++ b/erpnext/hr/doctype/employee_advance/employee_advance.py
@@ -64,13 +64,20 @@ class EmployeeAdvance(Document):
 
 	def update_claimed_amount(self):
 		claimed_amount = frappe.db.sql("""
-			select sum(ifnull(allocated_amount, 0))
-			from `tabExpense Claim Advance`
-			where employee_advance = %s and docstatus=1 and allocated_amount > 0
-		""", self.name)[0][0] or 0
+			SELECT sum(ifnull(allocated_amount, 0))
+			FROM `tabExpense Claim Advance` eca, `tabExpense Claim` ec
+			WHERE
+				eca.employee_advance = %s
+				AND ec.approval_status="Approved"
+				AND ec.name = eca.parent
+				AND ec.docstatus=1
+				AND eca.allocated_amount > 0
+		""", self.name, debug=1)[0][0] or 0
 
-		if claimed_amount:
-			frappe.db.set_value("Employee Advance", self.name, "claimed_amount", flt(claimed_amount))
+		frappe.db.set_value("Employee Advance", self.name, "claimed_amount", flt(claimed_amount))
+		self.reload()
+		self.set_status()
+		frappe.db.set_value("Employee Advance", self.name, "status", self.status)
 
 @frappe.whitelist()
 def get_due_advance_amount(employee, posting_date):

--- a/erpnext/hr/doctype/expense_claim/expense_claim.js
+++ b/erpnext/hr/doctype/expense_claim/expense_claim.js
@@ -183,7 +183,7 @@ frappe.ui.form.on("Expense Claim", {
 	refresh: function(frm) {
 		frm.trigger("toggle_fields");
 
-		if(frm.doc.docstatus == 1) {
+		if(frm.doc.docstatus === 1 && frm.doc.approval_status !== "Rejected") {
 			frm.add_custom_button(__('Accounting Ledger'), function() {
 				frappe.route_options = {
 					voucher_no: frm.doc.name,
@@ -194,7 +194,7 @@ frappe.ui.form.on("Expense Claim", {
 			}, __("View"));
 		}
 
-		if (frm.doc.docstatus===1
+		if (frm.doc.docstatus===1 && !cint(frm.doc.is_paid) && cint(frm.doc.grand_total) > 0
 				&& (cint(frm.doc.total_amount_reimbursed) < cint(frm.doc.total_sanctioned_amount))
 				&& frappe.model.can_create("Payment Entry")) {
 			frm.add_custom_button(__('Payment'),


### PR DESCRIPTION
This PR intends to fix the following problems:
- The claimed amount in employee advance gets changed even on the rejection of the related expense claim.
- expense claim shows "View>Ledger" even on the rejection of the expense claim
- "Create>Payment" is shown when grand total = 0.0(i.e.paid_amount=0.0 in payment entry)

