### PR TITLE
fix: Ambigious column in query

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/utils.py
+++ b/erpnext/accounts/doctype/pricing_rule/utils.py
@@ -382,7 +382,7 @@ def get_qty_amount_data_for_cumulative(pr_doc, doc, items=[]):
 			`tab{child_doc}`.amount
 		FROM `tab{child_doc}`, `tab{parent_doc}`
 		WHERE
-			`tab{child_doc}`.parent = `tab{parent_doc}`.name and {date_field}
+			`tab{child_doc}`.parent = `tab{parent_doc}`.name and `tab{parent_doc}`.{date_field}
 			between %s and %s and `tab{parent_doc}`.docstatus = 1
 			{condition} group by `tab{child_doc}`.name
 	""".format(parent_doc = doctype,


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2019-05-09/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-2019-05-09/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-2019-05-09/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2019-05-09/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2019-05-09/apps/frappe/frappe/__init__.py", line 1036, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2019-05-09/apps/erpnext/erpnext/stock/get_item_details.py", line 76, in get_item_details
    data = get_pricing_rule_for_item(args, out.price_list_rate, doc)
  File "/home/frappe/benches/bench-2019-05-09/apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py", line 238, in get_pricing_rule_for_item
    pricing_rules = get_pricing_rules(args, doc)
  File "/home/frappe/benches/bench-2019-05-09/apps/erpnext/erpnext/accounts/doctype/pricing_rule/utils.py", line 41, in get_pricing_rules
    pricing_rule = filter_pricing_rules(args, pricing_rules, doc)
  File "/home/frappe/benches/bench-2019-05-09/apps/erpnext/erpnext/accounts/doctype/pricing_rule/utils.py", line 179, in filter_pricing_rules
    stock_qty, amount = get_qty_and_rate_for_mixed_conditions(doc, pr_doc, args)
  File "/home/frappe/benches/bench-2019-05-09/apps/erpnext/erpnext/accounts/doctype/pricing_rule/utils.py", line 336, in get_qty_and_rate_for_mixed_conditions
    data = get_qty_amount_data_for_cumulative(pr_doc, doc, items)
  File "/home/frappe/benches/bench-2019-05-09/apps/erpnext/erpnext/accounts/doctype/pricing_rule/utils.py", line 392, in get_qty_amount_data_for_cumulative
    ), tuple(values), as_dict=1)
  File "/home/frappe/benches/bench-2019-05-09/apps/frappe/frappe/database/database.py", line 156, in sql
    self._cursor.execute(query, values)
  File "/home/frappe/benches/bench-2019-05-09/env/lib/python3.6/site-packages/pymysql/cursors.py", line 170, in execute
    result = self._query(query)
  File "/home/frappe/benches/bench-2019-05-09/env/lib/python3.6/site-packages/pymysql/cursors.py", line 328, in _query
    conn.query(q)
  File "/home/frappe/benches/bench-2019-05-09/env/lib/python3.6/site-packages/pymysql/connections.py", line 517, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/home/frappe/benches/bench-2019-05-09/env/lib/python3.6/site-packages/pymysql/connections.py", line 732, in _read_query_result
    result.read()
  File "/home/frappe/benches/bench-2019-05-09/env/lib/python3.6/site-packages/pymysql/connections.py", line 1075, in read
    first_packet = self.connection._read_packet()
  File "/home/frappe/benches/bench-2019-05-09/env/lib/python3.6/site-packages/pymysql/connections.py", line 684, in _read_packet
    packet.check_error()
  File "/home/frappe/benches/bench-2019-05-09/env/lib/python3.6/site-packages/pymysql/protocol.py", line 220, in check_error
    err.raise_mysql_exception(self._data)
  File "/home/frappe/benches/bench-2019-05-09/env/lib/python3.6/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.InternalError: (1052, "Column 'transaction_date' in where clause is ambiguous")
```
