### PR TITLE
fix: Python3 urllib use in item_group.py (now uses six.moves)

### DIFF
--- a/erpnext/setup/doctype/item_group/item_group.py
+++ b/erpnext/setup/doctype/item_group/item_group.py
@@ -3,7 +3,6 @@
 
 from __future__ import unicode_literals
 import frappe
-import urllib
 import copy
 from frappe.utils import nowdate, cint, cstr
 from frappe.utils.nestedset import NestedSet
@@ -12,6 +11,7 @@ from frappe.website.render import clear_cache
 from frappe.website.doctype.website_slideshow.website_slideshow import get_slideshow
 from erpnext.shopping_cart.product_info import set_product_info_for_website
 from erpnext.utilities.product import get_qty_in_stock
+from six.moves.urllib.parse import quote
 
 class ItemGroup(NestedSet, WebsiteGenerator):
 	nsm_parent_field = 'parent_item_group'
@@ -165,7 +165,7 @@ def get_item_for_list_in_html(context):
 	# add missing absolute link in files
 	# user may forget it during upload
 	if (context.get("website_image") or "").startswith("files/"):
-		context["website_image"] = "/" + urllib.quote(context["website_image"])
+		context["website_image"] = "/" + quote(context["website_image"])
 
 	context["show_availability_status"] = cint(frappe.db.get_single_value('Products Settings',
 		'show_availability_status'))


### PR DESCRIPTION
Relates to issue #18604
See original version-11-hotfix PR #18605

Uses six.moves.urllib.parse to provide 'quote' in Py2 and Py3.

Python3 only versions can import urllib.parse.quote directly.