### PR TITLE
fix: icon for opportunity

### DIFF
--- a/erpnext/crm/doctype/opportunity/opportunity.json
+++ b/erpnext/crm/doctype/opportunity/opportunity.json
@@ -1460,7 +1460,7 @@
  "has_web_view": 0, 
  "hide_heading": 0, 
  "hide_toolbar": 0, 
- "icon": "fa fa-info-sign", 
+ "icon": "fa fa-info-circle", 
  "idx": 195, 
  "image_view": 0, 
  "in_create": 0, 


### PR DESCRIPTION
Previously the icon was `fa-info-sign` which does not exist in the library as of 4.7.0, it was replaced with `fa-info-circle` instead.

Before
<img width="726" alt="Screenshot 2019-08-08 at 12 29 42 PM" src="https://user-images.githubusercontent.com/18097732/62681827-3680dc80-b9d8-11e9-8c4d-0f7da216e5df.png">

After
<img width="957" alt="Screenshot 2019-08-08 at 12 32 54 PM" src="https://user-images.githubusercontent.com/18097732/62681997-abecad00-b9d8-11e9-9c3f-e0f8134892e5.png">
