### PR TITLE
fix: Show Cr or Dr symbol in chart of accounts based on balance

### DIFF
--- a/erpnext/accounts/doctype/account/account_tree.js
+++ b/erpnext/accounts/doctype/account/account_tree.js
@@ -121,7 +121,10 @@ frappe.treeview_settings["Account"] = {
 	},
 	onrender: function(node) {
 		if(frappe.boot.user.can_read.indexOf("GL Entry") !== -1){
-			var dr_or_cr = in_list(["Liability", "Income", "Equity"], node.data.root_type) ? "Cr" : "Dr";
+
+			// show Dr if positive since balance is calculatrd as debit - credit else show Cr
+			let dr_or_cr = node.data.balance_in_account_currency > 0 ? "Dr": "Cr";
+
 			if (node.data && node.data.balance!==undefined) {
 				$('<span class="balance-area pull-right text-muted small">'
 					+ (node.data.balance_in_account_currency ?

--- a/erpnext/accounts/doctype/account/account_tree.js
+++ b/erpnext/accounts/doctype/account/account_tree.js
@@ -122,7 +122,7 @@ frappe.treeview_settings["Account"] = {
 	onrender: function(node) {
 		if(frappe.boot.user.can_read.indexOf("GL Entry") !== -1){
 
-			// show Dr if positive since balance is calculatrd as debit - credit else show Cr
+			// show Dr if positive since balance is calculated as debit - credit else show Cr
 			let dr_or_cr = node.data.balance_in_account_currency > 0 ? "Dr": "Cr";
 
 			if (node.data && node.data.balance!==undefined) {


### PR DESCRIPTION
Show balance in chart of accounts based on current balance rather than root type
