### PR TITLE
fix: incorrect value of ImponibileImporto in the xml invoice

### DIFF
--- a/erpnext/regional/italy/utils.py
+++ b/erpnext/regional/italy/utils.py
@@ -129,6 +129,8 @@ def download_zip(files, output_filename):
 
 def get_invoice_summary(items, taxes):
 	summary_data = frappe._dict()
+
+	applied_tax_row_ids = []
 	for tax in taxes:
 		#Include only VAT charges.
 		if tax.charge_type == "Actual":
@@ -153,7 +155,9 @@ def get_invoice_summary(items, taxes):
 						net_amount=reference_row.tax_amount,
 						taxable_amount=reference_row.tax_amount,
 						item_tax_rate={tax.account_head: tax.rate},
-						charges=True
+						charges=True,
+						type="Actual",
+						tax_row_name=tax.name
 					)
 				)
 
@@ -165,13 +169,21 @@ def get_invoice_summary(items, taxes):
 					item_tax_rate = json.loads(item.item_tax_rate)
 
 				if item_tax_rate and tax.account_head in item_tax_rate:
+					if (item.get("tax_row_name")
+						and item.get("tax_row_name") in applied_tax_row_ids):
+						continue
+
 					key = cstr(item_tax_rate[tax.account_head])
 					if key not in summary_data:
 						summary_data.setdefault(key, {"tax_amount": 0.0, "taxable_amount": 0.0,
 							"tax_exemption_reason": "", "tax_exemption_law": ""})
 
+					if item.get("type") and item.get("type") == "Actual":
+						applied_tax_row_ids.append(item.get("tax_row_name"))
+
 					summary_data[key]["tax_amount"] += item.tax_amount
 					summary_data[key]["taxable_amount"] += item.net_amount
+
 					if key == "0.0":
 						summary_data[key]["tax_exemption_reason"] = tax.tax_exemption_reason
 						summary_data[key]["tax_exemption_law"] = tax.tax_exemption_law


### PR DESCRIPTION
If same taxes set multiple times in the invoice them ImponibileImporto showing incorrect vale
![image](https://user-images.githubusercontent.com/8780500/62692371-2ecc3280-b9ee-11e9-98da-86ab799f412e.png)
