### PR TITLE
fix(payroll-entry): Check for submitted salary slips onload for manual submission

### DIFF
--- a/erpnext/hr/doctype/payroll_entry/payroll_entry.js
+++ b/erpnext/hr/doctype/payroll_entry/payroll_entry.js
@@ -69,7 +69,7 @@ frappe.ui.form.on('Payroll Entry', {
 	},
 
 	add_context_buttons: function(frm) {
-		if(frm.doc.salary_slips_submitted) {
+		if(frm.doc.salary_slips_submitted || (frm.doc.__onload && frm.doc.__onload.submitted_ss)) {
 			frm.events.add_bank_entry_button(frm);
 		} else if(frm.doc.salary_slips_created) {
 			frm.add_custom_button(__("Submit Salary Slip"), function() {

--- a/erpnext/hr/doctype/payroll_entry/payroll_entry.py
+++ b/erpnext/hr/doctype/payroll_entry/payroll_entry.py
@@ -19,8 +19,7 @@ class PayrollEntry(Document):
 		# check if salary slips were manually submitted
 		entries = frappe.db.count("Salary Slip", {'payroll_entry': self.name, 'docstatus': 1}, ['name'])
 		if cint(entries) == len(self.employees) and not self.salary_slips_submitted:
-			self.db_set("salary_slips_submitted", 1)
-			self.reload()
+			self.db_set("salary_slips_submitted", 1, update_modified=False, commit=True)
 
 	def on_submit(self):
 		self.create_salary_slips()

--- a/erpnext/hr/doctype/payroll_entry/payroll_entry.py
+++ b/erpnext/hr/doctype/payroll_entry/payroll_entry.py
@@ -18,8 +18,8 @@ class PayrollEntry(Document):
 
 		# check if salary slips were manually submitted
 		entries = frappe.db.count("Salary Slip", {'payroll_entry': self.name, 'docstatus': 1}, ['name'])
-		if cint(entries) == len(self.employees) and not self.salary_slips_submitted:
-			self.db_set("salary_slips_submitted", 1, update_modified=False, commit=True)
+		if cint(entries) == len(self.employees):
+			self.set_onload("submitted_ss", True)
 
 	def on_submit(self):
 		self.create_salary_slips()
@@ -427,7 +427,6 @@ def get_start_end_dates(payroll_frequency, start_date=None, company=None):
 	return frappe._dict({
 		'start_date': start_date, 'end_date': end_date
 	})
-
 
 def get_frequency_kwargs(frequency_name):
 	frequency_dict = {


### PR DESCRIPTION
Fixes: Since "modified by" details changes on dbset, the user is not able to proceed with further transactions.
![Screenshot 2019-08-11 at 2 37 37 PM](https://user-images.githubusercontent.com/14824451/62832036-2706cb00-bc46-11e9-908b-e5472e8d9a4b.png)
