### PR TITLE
fix: reconciled entry has not clearance date set

### DIFF
--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
@@ -50,7 +50,7 @@ class BankTransaction(StatusUpdater):
 			if paid_amount and allocated_amount:
 				if  flt(allocated_amount[0]["allocated_amount"]) > flt(paid_amount):
 					frappe.throw(_("The total allocated amount ({0}) is greated than the paid amount ({1}).".format(flt(allocated_amount[0]["allocated_amount"]), flt(paid_amount))))
-				elif flt(allocated_amount[0]["allocated_amount"]) == flt(paid_amount):
+				else:
 					if payment_entry.payment_document in ["Payment Entry", "Journal Entry", "Purchase Invoice", "Expense Claim"]:
 						self.clear_simple_entry(payment_entry)
 


### PR DESCRIPTION
**Issue**

Reconciled Entry
![Capture-Bank_Transaction](https://user-images.githubusercontent.com/8780500/62856139-b88f3f00-bd11-11e9-9087-1e16c7bd5344.png)

Still this entry showing in the bank reconciliation because the payment entry has no clearance date set after reconciliation 

<img width="888" alt="Screenshot 2019-08-12 at 2 57 38 PM" src="https://user-images.githubusercontent.com/8780500/62856167-c8a71e80-bd11-11e9-9395-2a59658c1bd0.png">

Payment entry
![image](https://user-images.githubusercontent.com/8780500/62856289-1f145d00-bd12-11e9-8747-55dbafbc9ac2.png)

 