### PR TITLE
fix: Check if account passed is accessible under Payment Entry

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -763,12 +763,16 @@ def get_account_details(account, date, cost_center=None):
 		'name': account
 	}, reference_doctype='Payment Entry', limit=1)
 
+	account_balance = get_balance_on(account, date, cost_center=cost_center, ignore_account_permission=True)
+
+	# There might be some user permissions which will allow account under certain doctypes
+	# except for Payment Entry, only in such case we should throw permission error
 	if not account_list:
 		frappe.throw(_('Account: {0} is not permitted under Payment Entry').format(account))
 
 	return frappe._dict({
 		"account_currency": get_account_currency(account),
-		"account_balance": get_balance_on(account, date, cost_center=cost_center),
+		"account_balance": account_balance,
 		"account_type": frappe.db.get_value("Account", account, "account_type")
 	})
 

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -763,12 +763,13 @@ def get_account_details(account, date, cost_center=None):
 		'name': account
 	}, reference_doctype='Payment Entry', limit=1)
 
-	account_balance = get_balance_on(account, date, cost_center=cost_center, ignore_account_permission=True)
-
 	# There might be some user permissions which will allow account under certain doctypes
 	# except for Payment Entry, only in such case we should throw permission error
 	if not account_list:
 		frappe.throw(_('Account: {0} is not permitted under Payment Entry').format(account))
+
+	account_balance = get_balance_on(account, date, cost_center=cost_center,
+		ignore_account_permission=True)
 
 	return frappe._dict({
 		"account_currency": get_account_currency(account),

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -756,13 +756,13 @@ def get_party_details(company, party_type, party, date, cost_center=None):
 def get_account_details(account, date, cost_center=None):
 	frappe.has_permission('Payment Entry', throw=True)
 
-	# to check if passed account is accessible under Payment Entry
-	# There might be user permissions which can only allow account under certain doctypes
-	# except Payment Entry
+	# to check if the passed account is accessible if the reference doctype is Payment Entry
 	account_list = frappe.get_list('Account', {
 		'name': account
 	}, reference_doctype='Payment Entry', limit=1)
-
+	
+	# There might be some user permissions which will allow account under certain doctypes
+	# except for Payment Entry, only in such case we should throw permission error
 	if not account_list:
 		frappe.throw(_('Account: {0} is not permitted under Payment Entry').format(account))
 

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -755,6 +755,17 @@ def get_party_details(company, party_type, party, date, cost_center=None):
 @frappe.whitelist()
 def get_account_details(account, date, cost_center=None):
 	frappe.has_permission('Payment Entry', throw=True)
+
+	# to check if passed account is accessible under Payment Entry
+	# There might be user permissions which can only allow account under certain doctypes
+	# except Payment Entry
+	account_list = frappe.get_list('Account', {
+		'name': account
+	}, reference_doctype='Payment Entry', limit=1)
+
+	if not account_list:
+		frappe.throw(_('Account: {0} is not permitted under Payment Entry').format(account))
+
 	return frappe._dict({
 		"account_currency": get_account_currency(account),
 		"account_balance": get_balance_on(account, date, cost_center=cost_center),

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -84,7 +84,8 @@ def validate_fiscal_year(date, fiscal_year, company, label="Date", doc=None):
 			throw(_("{0} '{1}' not in Fiscal Year {2}").format(label, formatdate(date), fiscal_year))
 
 @frappe.whitelist()
-def get_balance_on(account=None, date=None, party_type=None, party=None, company=None, in_account_currency=True, cost_center=None):
+def get_balance_on(account=None, date=None, party_type=None, party=None, company=None,
+	in_account_currency=True, cost_center=None, ignore_account_permission=False):
 	if not account and frappe.form_dict.get("account"):
 		account = frappe.form_dict.get("account")
 	if not date and frappe.form_dict.get("date"):
@@ -140,7 +141,8 @@ def get_balance_on(account=None, date=None, party_type=None, party=None, company
 
 	if account:
 
-		if not frappe.flags.ignore_account_permission:
+		if not (frappe.flags.ignore_account_permission
+			or ignore_account_permission):
 			acc.check_permission("read")
 
 		if report_type == 'Profit and Loss':


### PR DESCRIPTION
Check if account passed is accessible under **Payment Entry**

Note: There might be user permissions which only allow account under certain doctypes except for Payment Entry. Only in this case, we should raise permission error.

