### PR TITLE
fix: query for payment entry

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -648,13 +648,18 @@ def get_orders_to_be_billed(posting_date, party_type, party,
 
 	orders = []
 	if voucher_type:
-		ref_field = "base_grand_total" if party_account_currency == company_currency else "grand_total"
+		if party_account_currency == company_currency:
+			grand_total_field = "base_grand_total"
+			rounded_total_field = "base_rounded_total"
+		else:
+			grand_total_field = "grand_total"
+			rounded_total_field = "rounded_total"
 
 		orders = frappe.db.sql("""
 			select
 				name as voucher_no,
-				{ref_field} as invoice_amount,
-				({ref_field} - advance_paid) as outstanding_amount,
+				if({rounded_total_field}, {rounded_total_field}, {grand_total_field}) as invoice_amount,
+				(if({rounded_total_field}, {rounded_total_field}, {grand_total_field}) - advance_paid) as outstanding_amount,
 				transaction_date as posting_date
 			from
 				`tab{voucher_type}`
@@ -663,13 +668,14 @@ def get_orders_to_be_billed(posting_date, party_type, party,
 				and docstatus = 1
 				and company = %s
 				and ifnull(status, "") != "Closed"
-				and {ref_field} > advance_paid
+				and if({rounded_total_field}, {rounded_total_field}, {grand_total_field}) > advance_paid
 				and abs(100 - per_billed) > 0.01
 				{condition}
 			order by
 				transaction_date, name
 		""".format(**{
-			"ref_field": ref_field,
+			"rounded_total_field": rounded_total_field,
+			"grand_total_field": grand_total_field,
 			"voucher_type": voucher_type,
 			"party_type": scrub(party_type),
 			"condition": condition


### PR DESCRIPTION
before it was taking the amount, not on the basis of rounding total.
fixed the query.

Suppose,
A sales order of total 1648.90 after rounding it will be 1649.00
but on submitting it was saying that
it can't be greater than 1648.90

port of
#18468
#18465

