### PR TITLE
fix(quality-inspection): fetch all items for inspection type in process

### DIFF
--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.js
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.js
@@ -39,11 +39,12 @@ cur_frm.fields_dict['item_code'].get_query = function(doc, cdt, cdn) {
 			query: "erpnext.stock.doctype.quality_inspection.quality_inspection.item_query",
 			filters: {
 				"from": doctype,
-				"parent": doc.reference_name
+				"parent": doc.reference_name,
+				"inspection_type": doc.inspection_type
 			}
-		}
+		};
 	}
-}
+},
 
 // Serial No based on item_code
 cur_frm.fields_dict['item_serial_no'].get_query = function(doc, cdt, cdn) {

--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.py
@@ -63,10 +63,12 @@ def item_query(doctype, txt, searchfield, start, page_len, filters):
 		mcond = get_match_cond(filters["from"])
 		cond, qi_condition = "", "and (quality_inspection is null or quality_inspection = '')"
 
-		if filters.get('from') in ['Purchase Invoice Item', 'Purchase Receipt Item']:
+		if filters.get('from') in ['Purchase Invoice Item', 'Purchase Receipt Item']\
+				and filters.get("inspection_type") != "In Process":
 			cond = """and item_code in (select name from `tabItem` where
 				inspection_required_before_purchase = 1)"""
-		elif filters.get('from') in ['Sales Invoice Item', 'Delivery Note Item']:
+		elif filters.get('from') in ['Sales Invoice Item', 'Delivery Note Item']\
+				and filters.get("inspection_type") != "In Process":
 			cond = """and item_code in (select name from `tabItem` where
 				inspection_required_before_delivery = 1)"""
 		elif filters.get('from') == 'Stock Entry Detail':


### PR DESCRIPTION
In certain use cases, quality inspection needs to be performed after purchase receipt has been issued for internal transfer of goods. This PR allows the creation of quality inspection document for items with inspection "In Process"

