### PR TITLE
fix(quality-inspection): fetch all items for inspection type in process

### DIFF
--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.js
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.js
@@ -39,11 +39,12 @@ cur_frm.fields_dict['item_code'].get_query = function(doc, cdt, cdn) {
 			query: "erpnext.stock.doctype.quality_inspection.quality_inspection.item_query",
 			filters: {
 				"from": doctype,
-				"parent": doc.reference_name
+				"parent": doc.reference_name,
+				"inspection_type": doc.inspection_type
 			}
-		}
+		};
 	}
-}
+},
 
 // Serial No based on item_code
 cur_frm.fields_dict['item_serial_no'].get_query = function(doc, cdt, cdn) {

--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.py
@@ -63,10 +63,12 @@ def item_query(doctype, txt, searchfield, start, page_len, filters):
 		mcond = get_match_cond(filters["from"])
 		cond, qi_condition = "", "and (quality_inspection is null or quality_inspection = '')"
 
-		if filters.get('from') in ['Purchase Invoice Item', 'Purchase Receipt Item']:
+		if filters.get('from') in ['Purchase Invoice Item', 'Purchase Receipt Item']\
+				and filters.get("inspection_type") != "In Process":
 			cond = """and item_code in (select name from `tabItem` where
 				inspection_required_before_purchase = 1)"""
-		elif filters.get('from') in ['Sales Invoice Item', 'Delivery Note Item']:
+		elif filters.get('from') in ['Sales Invoice Item', 'Delivery Note Item']\
+				and filters.get("inspection_type") != "In Process":
 			cond = """and item_code in (select name from `tabItem` where
 				inspection_required_before_delivery = 1)"""
 		elif filters.get('from') == 'Stock Entry Detail':

--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.py
@@ -3,6 +3,7 @@
 
 from __future__ import unicode_literals
 import frappe
+from frappe import _
 from frappe.model.document import Document
 from erpnext.stock.doctype.quality_inspection_template.quality_inspection_template \
 	import get_template_details
@@ -11,6 +12,7 @@ class QualityInspection(Document):
 	def validate(self):
 		if not self.readings and self.item_code:
 			self.get_item_specification_details()
+		self.validate_inspection_type()
 
 	def get_item_specification_details(self):
 		if not self.quality_inspection_template:
@@ -26,6 +28,14 @@ class QualityInspection(Document):
 			child.specification = d.specification
 			child.value = d.value
 			child.status = "Accepted"
+
+	def validate_inspection_type(self):
+		if self.inspection_type != "In Process":
+			inspection_required = frappe.db.get_value("Item", filters={
+				'name': self.item_code
+			}, fieldname=['inspection_required_before_purchase', 'inspection_required_before_delivery'])
+			if 0 in inspection_required:
+				frappe.throw(_('Inspection type for the item can only be in process.'))
 
 	def get_quality_inspection_template(self):
 		template = ''


### PR DESCRIPTION
In certain use cases, quality inspection needs to be performed after purchase receipt has been issued for internal transfer of goods. This PR allows the creation of quality inspection document for items with inspection "In Process"
