### PR TITLE
fix: Error handling in payment entry

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -683,8 +683,8 @@ def get_orders_to_be_billed(posting_date, party_type, party,
 
 	order_list = []
 	for d in orders:
-		if not (d.outstanding_amount >= filters.get("outstanding_amt_greater_than")
-			and d.outstanding_amount <= filters.get("outstanding_amt_less_than")):
+		if not (flt(d.outstanding_amount) >= flt(filters.get("outstanding_amt_greater_than"))
+			and flt(d.outstanding_amount) <= flt(filters.get("outstanding_amt_less_than"))):
 			continue
 
 		d["voucher_type"] = voucher_type


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2019-08-11/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-12-2019-08-11/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-12-2019-08-11/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-12-2019-08-11/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-12-2019-08-11/apps/frappe/frappe/__init__.py", line 1036, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-12-2019-08-11/apps/erpnext/erpnext/accounts/doctype/payment_entry/payment_entry.py", line 622, in get_outstanding_reference_documents
    args.get("party"), args.get("company"), party_account_currency, company_currency, filters=args)
  File "/home/frappe/benches/bench-version-12-2019-08-11/apps/erpnext/erpnext/accounts/doctype/payment_entry/payment_entry.py", line 686, in get_orders_to_be_billed
    if not (d.outstanding_amount >= filters.get("outstanding_amt_greater_than")
TypeError: '>=' not supported between instances of 'float' and 'NoneType'
```
