### PR TITLE
fix: only select serial no that are present in the selected batch

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -70,8 +70,9 @@ $.extend(erpnext, {
 						"get_query": function () {
 							return {
 								filters: {
-									item_code:grid_row.doc.item_code,
-									warehouse:cur_frm.doc.is_return ? null : grid_row.doc.warehouse
+									item_code: grid_row.doc.item_code,
+									warehouse: cur_frm.doc.is_return ? null : grid_row.doc.warehouse,
+									batch_no: grid_row.doc.batch_no || null
 								}
 							}
 						}


### PR DESCRIPTION
**Problem:**

If an Item is setup to have both batches and serialized inventory, and a Batch is selected in any of the related documents, the "Add Serial No" dialog doesn't filter for serials present in that Batch.

**Solution:**

If a batch is selected, only pull Serial Nos that are allocated to that batch in the selected warehouse, otherwise pull all Serial Nos for that item in the selected warehouse.

<hr>

**Screenshots / GIFs:**

**Before:**

![serial-no-before](https://user-images.githubusercontent.com/13396535/63003370-9c1c0f80-be95-11e9-88fb-14ff6820004b.gif)

**After:**

![serial-no-after](https://user-images.githubusercontent.com/13396535/63003375-9de5d300-be95-11e9-8467-bc1c34f7b904.gif)