### PR TITLE
fix: valuation rate in stock ledger

### DIFF
--- a/erpnext/stock/doctype/delivery_note/test_delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/test_delivery_note.py
@@ -701,6 +701,7 @@ def create_delivery_note(**args):
 		"qty": args.qty or 1,
 		"rate": args.rate or 100,
 		"conversion_factor": 1.0,
+		"allow_zero_valuation_rate": args.allow_zero_valuation_rate or 1,
 		"expense_account": "Cost of Goods Sold - _TC",
 		"cost_center": args.cost_center or "_Test Cost Center - _TC",
 		"serial_no": args.serial_no,

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -464,16 +464,22 @@ def get_valuation_rate(item_code, warehouse, voucher_type, voucher_no,
 
 	last_valuation_rate = frappe.db.sql("""select valuation_rate
 		from `tabStock Ledger Entry`
-		where item_code = %s and warehouse = %s
-		and valuation_rate >= 0
-		order by posting_date desc, posting_time desc, creation desc limit 1""", (item_code, warehouse))
+		where
+			item_code = %s
+			AND warehouse = %s
+			AND valuation_rate >= 0
+			AND NOT (voucher_no = %s AND voucher_type = %s)
+		order by posting_date desc, posting_time desc, name desc limit 1""", (item_code, warehouse, voucher_no, voucher_type))
 
 	if not last_valuation_rate:
 		# Get valuation rate from last sle for the item against any warehouse
 		last_valuation_rate = frappe.db.sql("""select valuation_rate
 			from `tabStock Ledger Entry`
-			where item_code = %s and valuation_rate > 0
-			order by posting_date desc, posting_time desc, creation desc limit 1""", item_code)
+			where
+				item_code = %s
+				AND valuation_rate > 0
+				AND NOT(voucher_no = %s AND voucher_type = %s)
+			order by posting_date desc, posting_time desc, name desc limit 1""", (item_code, voucher_no, voucher_type))
 
 	if last_valuation_rate:
 		return flt(last_valuation_rate[0][0]) # as there is previous records, it might come with zero rate


### PR DESCRIPTION
Last valuation rate for an item was getting fetched from the stock ledger of the same transaction. This PR fixes that by skipping the stock ledger entry for that particular transaction.

