### PR TITLE
When save a Company, it shows error "La misma compañía se ingresa más de una vez."

### DIFF
--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -252,7 +252,7 @@ class Company(NestedSet):
 	def set_mode_of_payment_account(self):
 		cash = frappe.db.get_value('Mode of Payment', {'type': 'Cash'}, 'name')
 		if cash and self.default_cash_account \
-				and not frappe.db.get_value('Mode of Payment Account', {'company': self.name, 'parent': 'Cash'}):
+				and not frappe.db.get_value('Mode of Payment Account', {'company': self.name, 'parent': _('Cash')}):
 			mode_of_payment = frappe.get_doc('Mode of Payment', cash)
 			mode_of_payment.append('accounts', {
 				'company': self.name,


### PR DESCRIPTION
… than once."

When recording a company, it shows error "The same company is entered more than once." It happens for languages other than English, can't find the parent Cash, you should look for filter _ ("Cash") in  doctype Company -> set_mode_of_payment_account()

  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/setup/doctype/company/company.py", line 110, in on_update
    self.set_mode_of_payment_account()
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/setup/doctype/company/company.py", line 261, in set_mode_of_payment_account
    mode_of_payment.save(ignore_permissions=True)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 271, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 307, in _save
    self.run_before_save_methods()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 886, in run_before_save_methods
    self.run_method("validate")
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 786, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1055, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1038, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 780, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/doctype/mode_of_payment/mode_of_payment.py", line 13, in validate
    self.validate_repeating_companies()
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/doctype/mode_of_payment/mode_of_payment.py", line 22, in validate_repeating_companies
    frappe.throw(_("Same Company is entered more than once"))
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 360, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red')
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 346, in msgprint
    _raise_exception()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 315, in _raise_exception
    raise raise_exception(msg)
frappe.exceptions.ValidationError: La misma compañía se ingresa más de una vez.

Please read the pull request checklist to make sure your changes are merged: https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

