### PR TITLE
fix: Don't name Asset Maintenance Task after field maintenance_task

### DIFF
--- a/erpnext/assets/doctype/asset_maintenance_task/asset_maintenance_task.py
+++ b/erpnext/assets/doctype/asset_maintenance_task/asset_maintenance_task.py
@@ -7,5 +7,4 @@ import frappe
 from frappe.model.document import Document
 
 class AssetMaintenanceTask(Document):
-	def autoname(self):
-		self.name = self.maintenance_task
+	pass


### PR DESCRIPTION
If name == maintenance_task, it is impossible to create two separate tasks with the same title/name, 
even if they are attached to completely different Asset Maintenance documents.

Fix this by removing the autoname method.

