### PR TITLE
fix: pull project from task (v11)

### DIFF
--- a/erpnext/projects/doctype/timesheet/timesheet.js
+++ b/erpnext/projects/doctype/timesheet/timesheet.js
@@ -147,6 +147,15 @@ frappe.ui.form.on("Timesheet Detail", {
 		calculate_time_and_amount(frm);
 	},
 
+	task: (frm, cdt, cdn) => {
+		let row = frm.selected_doc;
+		if (row.task) {
+			frappe.db.get_value("Task", row.task, "project", (r) => {
+				frappe.model.set_value(cdt, cdn, "project", r.project);
+			});
+		}
+	},
+
 	from_time: function(frm, cdt, cdn) {
 		calculate_end_time(frm, cdt, cdn);
 	},
@@ -200,9 +209,6 @@ frappe.ui.form.on("Timesheet Detail", {
 	},
 
 	activity_type: function(frm, cdt, cdn) {
-		frm.script_manager.copy_from_first_row('time_logs', frm.selected_doc,
-			'project');
-
 		frappe.call({
 			method: "erpnext.projects.doctype.timesheet.timesheet.get_activity_cost",
 			args: {

--- a/erpnext/projects/doctype/timesheet/timesheet.py
+++ b/erpnext/projects/doctype/timesheet/timesheet.py
@@ -148,11 +148,16 @@ class Timesheet(Document):
 	def validate_time_logs(self):
 		for data in self.get('time_logs'):
 			self.validate_overlap(data)
+			self.validate_task_project()
 
 	def validate_overlap(self, data):
 		settings = frappe.get_single('Projects Settings')
 		self.validate_overlap_for("user", data, self.user, settings.ignore_user_time_overlap)
 		self.validate_overlap_for("employee", data, self.employee, settings.ignore_employee_time_overlap)
+
+	def validate_task_project(self):
+		for log in self.time_logs:
+			log.project = log.project or frappe.db.get_value("Task", log.task, "project")
 
 	def validate_overlap_for(self, fieldname, args, value, ignore_validation=False):
 		if not value or ignore_validation:


### PR DESCRIPTION
**Changes:**

- Pull project from selected task in the time logs, instead of copying from first row
- After save, set missing project in time log if task is set.

<hr>

**Screenshots / GIFs:**

![set-project](https://user-images.githubusercontent.com/13396535/63255704-d3266280-c293-11e9-9ea0-1f77e008aaa0.gif)