### PR TITLE
fix: restrict the payment order to non received type payment entries

### DIFF
--- a/erpnext/accounts/doctype/payment_order/payment_order.js
+++ b/erpnext/accounts/doctype/payment_order/payment_order.js
@@ -66,6 +66,7 @@ frappe.ui.form.on('Payment Order', {
 			get_query_filters: {
 				bank: frm.doc.bank,
 				docstatus: 1,
+				payment_type: ("!=", "Receive"),
 				bank_account: frm.doc.company_bank_account,
 				paid_from: frm.doc.account,
 				payment_order_status: ["=", "Initiated"],


### PR DESCRIPTION
Payment Order is an order or an instruction of a sender to a receiving bank directing the transfer of funds to a designated account or beneficiary. Payment entries cannot be of type "Received"

