### PR TITLE
fix: shopping cart item availability

### DIFF
--- a/erpnext/templates/includes/product_page.js
+++ b/erpnext/templates/includes/product_page.js
@@ -29,7 +29,7 @@ frappe.ready(function() {
 						.html(r.message.product_info.price.formatted_price_sales_uom + "<div style='font-size: small'>\
 							(" + r.message.product_info.price.formatted_price + " / " + r.message.product_info.uom + ")</div>");
 
-					if(r.message.product_info.in_stock==0) {
+					if(r.message.product_info.in_stock==0 && r.message.cart_settings.show_stock_availability) {
 						$(".item-stock").html("<div style='color: red'> <i class='fa fa-close'></i> {{ _("Not in stock") }}</div>");
 					}
 					else if(r.message.product_info.in_stock==1) {


### PR DESCRIPTION
So, there is a configuration in Shopping Cart Settings that will allow stock (whether item is available or not, and the qty) to be displayed on the website or not. Only if these both are left unchecked, then the stock is not displayed
In a nutshell, Shopping cart settings would not reflect on the page. 