### PR TITLE
fix: pos return validation

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -206,9 +206,9 @@ class SalesInvoice(SellingController):
 			total_amount_in_payments = 0
 			for payment in self.payments:
 				total_amount_in_payments += payment.amount
-
-			if total_amount_in_payments < self.rounded_total:
-				frappe.throw(_("Total payments amount can't be greater than {}".format(-self.rounded_total)))
+			invoice_total = self.rounded_total or self.grand_total
+			if total_amount_in_payments < invoice_total
+				frappe.throw(_("Total payments amount can't be greater than {}".format(-invoice_total)))
 
 	def validate_pos_paid_amount(self):
 		if len(self.payments) == 0 and self.is_pos:


### PR DESCRIPTION
![WhatsApp Image 2019-08-21 at 3 16 22 PM](https://user-images.githubusercontent.com/17160298/63460920-1be94180-c475-11e9-8424-275a09e17c6f.jpeg)

The validation exception occurs for setups which have rounding disabled. This is because `rounded_total` is set to zero during such cases.

This change hopes to considers `grand_total` as well during the validation.

