### PR TITLE
fix: Actual qty in the sales order showing different on the sales ord…

### DIFF
--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -31,7 +31,7 @@ class SellingController(StockController):
 
 	def onload(self):
 		super(SellingController, self).onload()
-		if self.doctype in ("Sales Order", "Delivery Note", "Sales Invoice"):
+		if self.docstatus==0 and self.doctype in ("Sales Order", "Delivery Note", "Sales Invoice"):
 			for item in self.get("items"):
 				item.update(get_bin_details(item.item_code, item.warehouse))
 


### PR DESCRIPTION
**Issue**

While submitting the sales order actual qty was zero and therefore in the database value is set as zero. Later on user has added the 5 qty in the warehouse due to which bin has available qty as 5. System fetch the available qty in the sales order from the bin even after submit of the sales order and not from the database. Due to this the value of the field actual qty in the sales order form is different than the value in the report.

**Sales Order Form**
<img width="1131" alt="Screenshot 2019-08-23 at 11 49 52 AM" src="https://user-images.githubusercontent.com/8780500/63571027-96f94780-c59c-11e9-852c-22358b718747.png">

**Standard Report View**


<img width="1057" alt="Screenshot 2019-08-23 at 11 50 04 AM" src="https://user-images.githubusercontent.com/8780500/63571010-8ea10c80-c59c-11e9-814f-3bafff118c16.png">