### PR TITLE
fix: error while trying to get directions (develop)

### DIFF
--- a/erpnext/stock/doctype/delivery_trip/delivery_trip.py
+++ b/erpnext/stock/doctype/delivery_trip/delivery_trip.py
@@ -238,7 +238,7 @@ class DeliveryTrip(Document):
 		try:
 			directions = maps_client.directions(**directions_data)
 		except Exception as e:
-			frappe.throw(_(e.message))
+			frappe.throw(_(e))
 
 		return directions[0] if directions else False
 


### PR DESCRIPTION
```python
Traceback (most recent call last):
  File "/home/rohan/weed/apps/erpnext/erpnext/stock/doctype/delivery_trip/delivery_trip.py", line 352, in get_directions
    frappe.throw(_(e.message))
AttributeError: 'TransportError' object has no attribute 'message'
```