### PR TITLE
feat: added domain info on footer

### DIFF
--- a/erpnext/templates/includes/footer/footer_powered.html
+++ b/erpnext/templates/includes/footer/footer_powered.html
@@ -1,1 +1,3 @@
-<a href="https://erpnext.com?source=website_footer" target="_blank" class="text-muted">Powered by ERPNext</a>
+{% set domains = frappe.get_doc("Domain Settings").active_domains %}
+
+<a href="https://erpnext.com?source=website_footer" target="_blank" class="text-muted">Powered by ERPNext - {{ domains[0].domain if domains else 'Open Source' }} ERP Software</a>


### PR DESCRIPTION
Added domain info on website footer. 
It shall show the first domain from the list of active domains or will say **Open Source ERP Software** instead

![image](https://user-images.githubusercontent.com/18097732/63665331-81785d80-c7e8-11e9-9fb4-a870b40d9637.png)
