### PR TITLE
fix: Set default Parent Item Group

### DIFF
--- a/erpnext/setup/doctype/item_group/item_group.py
+++ b/erpnext/setup/doctype/item_group/item_group.py
@@ -26,6 +26,10 @@ class ItemGroup(NestedSet, WebsiteGenerator):
 
 	def validate(self):
 		super(ItemGroup, self).validate()
+
+		if not self.parent_item_group:
+			self.parent_item_group = 'All Item Groups'
+
 		self.make_route()
 
 	def on_update(self):


### PR DESCRIPTION
When Item Group is created via API, it should automatically set the Parent Item Group if it is not set.