### PR TITLE
fix: not able to create invoice against patient

### DIFF
--- a/erpnext/healthcare/doctype/patient/patient.py
+++ b/erpnext/healthcare/doctype/patient/patient.py
@@ -6,7 +6,7 @@ from __future__ import unicode_literals
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import cint, cstr, getdate
+from frappe.utils import cint, cstr, getdate, flt
 import dateutil
 from frappe.model.naming import set_name_by_naming_series
 from erpnext.healthcare.doctype.healthcare_settings.healthcare_settings import get_receivable_account,get_income_account,send_registration_sms
@@ -64,7 +64,7 @@ class Patient(Document):
 	def invoice_patient_registration(self):
 		frappe.db.set_value("Patient", self.name, "disabled", 0)
 		send_registration_sms(self)
-		if(frappe.get_value("Healthcare Settings", None, "registration_fee")>0):
+		if(flt(frappe.get_value("Healthcare Settings", None, "registration_fee"))>0):
 			company = frappe.defaults.get_user_default('company')
 			if not company:
 				company = frappe.db.get_value("Global Defaults", None, "default_company")


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2019-08-20/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-12-2019-08-20/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-12-2019-08-20/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-12-2019-08-20/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-12-2019-08-20/apps/frappe/frappe/__init__.py", line 1036, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-12-2019-08-20/apps/frappe/frappe/handler.py", line 84, in runserverobj
    frappe.desk.form.run_method.runserverobj(method, docs=docs, dt=dt, dn=dn, arg=arg, args=args)
  File "/home/frappe/benches/bench-version-12-2019-08-20/apps/frappe/frappe/desk/form/run_method.py", line 36, in runserverobj
    r = doc.run_method(method)
  File "/home/frappe/benches/bench-version-12-2019-08-20/apps/frappe/frappe/model/document.py", line 786, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2019-08-20/apps/frappe/frappe/model/document.py", line 1055, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2019-08-20/apps/frappe/frappe/model/document.py", line 1038, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-version-12-2019-08-20/apps/frappe/frappe/model/document.py", line 780, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2019-08-20/apps/erpnext/erpnext/healthcare/doctype/patient/patient.py", line 67, in invoice_patient_registration
    if(frappe.get_value("Healthcare Settings", None, "registration_fee")>0):
TypeError: '>' not supported between instances of 'str' and 'int'
```