### PR TITLE
fix: Setting expire_allocation to None

### DIFF
--- a/erpnext/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
+++ b/erpnext/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
@@ -115,6 +115,8 @@ def process_expired_allocation():
 				'is_carry_forward': 0,
 				'leave_type': ('in', leave_type)
 			})
+	else:
+		expire_allocation = None
 
 	if expire_allocation:
 		create_expiry_ledger_entry(expire_allocation)


### PR DESCRIPTION
This fixes the error where there are no leave_type_records and expire_allocation doesn't get assigned any value causing the following error:

UnboundLocalError: local variable 'expire_allocation' referenced before assignment