### PR TITLE
fix: not able to save sales order

### DIFF
--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -394,8 +394,8 @@ class SellingController(StockController):
 			elif self.doctype == "Delivery Note":
 				e = [d.item_code, d.description, d.warehouse, d.against_sales_order or d.against_sales_invoice, d.batch_no or '']
 				f = [d.item_code, d.description, d.against_sales_order or d.against_sales_invoice]
-			elif self.doctype == "Sales Order":
-				e = [d.item_code, d.description, d.warehouse, d.batch_no or '']
+			elif self.doctype in ["Sales Order", "Quotation"]:
+				e = [d.item_code, d.description, d.warehouse, '']
 				f = [d.item_code, d.description]
 
 			if frappe.db.get_value("Item", d.item_code, "is_stock_item") == 1:


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2019-08-29/apps/frappe/frappe/desk/form/save.py", line 19, in savedocs
    doc.submit()
  File "/home/frappe/benches/bench-2019-08-29/apps/frappe/frappe/model/document.py", line 848, in submit
    self._submit()
  File "/home/frappe/benches/bench-2019-08-29/apps/frappe/frappe/model/document.py", line 837, in _submit
    self.save()
  File "/home/frappe/benches/bench-2019-08-29/apps/frappe/frappe/model/document.py", line 260, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-2019-08-29/apps/frappe/frappe/model/document.py", line 296, in _save
    self.run_before_save_methods()
  File "/home/frappe/benches/bench-2019-08-29/apps/frappe/frappe/model/document.py", line 879, in run_before_save_methods
    self.run_method("validate")
  File "/home/frappe/benches/bench-2019-08-29/apps/frappe/frappe/model/document.py", line 772, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-2019-08-29/apps/frappe/frappe/model/document.py", line 1048, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-2019-08-29/apps/frappe/frappe/model/document.py", line 1031, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-2019-08-29/apps/frappe/frappe/model/document.py", line 766, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-2019-08-29/apps/erpnext/erpnext/selling/doctype/sales_order/sales_order.py", line 34, in validate
    super(SalesOrder, self).validate()
  File "/home/frappe/benches/bench-2019-08-29/apps/erpnext/erpnext/controllers/selling_controller.py", line 48, in validate
    self.validate_for_duplicate_items()
  File "/home/frappe/benches/bench-2019-08-29/apps/erpnext/erpnext/controllers/selling_controller.py", line 398, in validate_for_duplicate_items
    e = [d.item_code, d.description, d.warehouse, d.batch_no or '']
AttributeError: 'SalesOrderItem' object has no attribute 'batch_no'
```