### PR TITLE
fix: Update the field name for Payment Entry

### DIFF
--- a/erpnext/selling/doctype/customer/customer_dashboard.py
+++ b/erpnext/selling/doctype/customer/customer_dashboard.py
@@ -9,7 +9,7 @@ def get_data():
 		'heatmap_message': _('This is based on transactions against this Customer. See timeline below for details'),
 		'fieldname': 'customer',
 		'non_standard_fieldnames': {
-			'Payment Entry': 'party_name',
+			'Payment Entry': 'party',
 			'Quotation': 'party_name',
 			'Opportunity': 'party_name'
 		},


### PR DESCRIPTION
In the Payment Entry Form, the field name for customer name is 'party' instead of 'party_name'. 
See below page:
![image](https://user-images.githubusercontent.com/30763348/63990837-8b2bf900-cb39-11e9-9e5a-e538090ae849.png)

Need to update the field name for customer_dashboard file accordingly.

Please read the pull request checklist to make sure your changes are merged: https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

