### PR TITLE
fix: mismatch between warehouse tree value and warehouse based stock balance report value

### DIFF
--- a/erpnext/stock/utils.py
+++ b/erpnext/stock/utils.py
@@ -15,7 +15,7 @@ def get_stock_value_from_bin(warehouse=None, item_code=None):
 	values = {}
 	conditions = ""
 	if warehouse:
-		conditions += """ and warehouse in (
+		conditions += """ and `tabBin`.warehouse in (
 						select w2.name from `tabWarehouse` w1
 						join `tabWarehouse` w2 on
 						w1.name = %(warehouse)s
@@ -25,11 +25,12 @@ def get_stock_value_from_bin(warehouse=None, item_code=None):
 		values['warehouse'] = warehouse
 
 	if item_code:
-		conditions += " and item_code = %(item_code)s"
+		conditions += " and `tabBin`.item_code = %(item_code)s"
 
 		values['item_code'] = item_code
 
-	query = "select sum(stock_value) from `tabBin` where 1 = 1 %s" % conditions
+	query = """select sum(stock_value) from `tabBin`, `tabItem` where 1 = 1
+		and `tabItem`.name = `tabBin`.item_code and ifnull(`tabItem`.disabled, 0) = 0 %s""" % conditions
 
 	stock_value = frappe.db.sql(query, values)
 


### PR DESCRIPTION
**Issue**

Disabled items value has considered in the warehouse tree value, due to which the value in the stock balance report is not matching with the value in the warehouse tree

<img width="1131" alt="Screenshot 2019-08-30 at 3 29 09 PM" src="https://user-images.githubusercontent.com/8780500/64012333-178aeb80-cb3b-11e9-9485-801b9612146f.png">
**After Fix**
<img width="1150" alt="Screenshot 2019-08-30 at 3 28 27 PM" src="https://user-images.githubusercontent.com/8780500/64012335-178aeb80-cb3b-11e9-9d2f-727313110c51.png">
