### PR TITLE
fix: incorrect stock value difference when stock move from negative to positive

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -178,10 +178,7 @@ class update_entries_after(object):
 		# rounding as per precision
 		self.stock_value = flt(self.stock_value, self.precision)
 
-		if self.prev_stock_value < 0 and self.stock_value >= 0 and sle.voucher_type != 'Stock Reconciliation':
-			stock_value_difference = sle.actual_qty * self.valuation_rate
-		else:
-			stock_value_difference = self.stock_value - self.prev_stock_value
+		stock_value_difference = self.stock_value - self.prev_stock_value
 
 		self.prev_stock_value = self.stock_value
 


### PR DESCRIPTION
**Issue**

If stock in negative and user added new entry with positive stock then the stock value difference calculation is incorrect

Stock Value Difference = Actual Qty * Valuation Rate

