### PR TITLE
fix: attribute error when trying to fetch items (v11)

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -97,7 +97,7 @@ class ProductionPlan(Document):
 			self.get_mr_items()
 
 	def get_so_items(self):
-		so_list = [d.sales_order for d in self.sales_orders if d.sales_order]
+		so_list = [d.sales_order for d in self.get("sales_orders", []) if d.sales_order]
 		if not so_list:
 			msgprint(_("Please enter Sales Orders in the above table"))
 			return []
@@ -132,7 +132,7 @@ class ProductionPlan(Document):
 		self.calculate_total_planned_qty()
 
 	def get_mr_items(self):
-		mr_list = [d.material_request for d in self.material_requests if d.material_request]
+		mr_list = [d.material_request for d in self.get("material_requests", []) if d.material_request]
 		if not mr_list:
 			msgprint(_("Please enter Material Requests in the above table"))
 			return []


### PR DESCRIPTION
**Problem:**

Frappe does not build tables as document attributes until it's actually processed first, causing the Production Plan to error out for new Plans.

<hr>

**Tracebacks:**

**Sales Orders:**

```python
Traceback (most recent call last):
  File "/home/rohan/weed/apps/erpnext/erpnext/manufacturing/doctype/production_plan/production_plan.py", line 95, in get_items
    self.get_so_items()
  File "/home/rohan/weed/apps/erpnext/erpnext/manufacturing/doctype/production_plan/production_plan.py", line 100, in get_so_items
    so_list = [d.sales_order for d in self.sales_orders if d.sales_order]
AttributeError: 'ProductionPlan' object has no attribute 'sales_orders'
```

**Material Requests**

```python
Traceback (most recent call last):
  File "/home/rohan/weed/apps/erpnext/erpnext/manufacturing/doctype/production_plan/production_plan.py", line 97, in get_items
    self.get_mr_items()
  File "/home/rohan/weed/apps/erpnext/erpnext/manufacturing/doctype/production_plan/production_plan.py", line 135, in get_mr_items
    mr_list = [d.material_request for d in self.material_requests if d.material_request]
AttributeError: 'ProductionPlan' object has no attribute 'material_requests'
```