### PR TITLE
fix: update actual qty even after submission of the sales transactions

### DIFF
--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -31,7 +31,7 @@ class SellingController(StockController):
 
 	def onload(self):
 		super(SellingController, self).onload()
-		if self.docstatus==0 and self.doctype in ("Sales Order", "Delivery Note", "Sales Invoice"):
+		if self.doctype in ("Sales Order", "Delivery Note", "Sales Invoice"):
 			for item in self.get("items"):
 				item.update(get_bin_details(item.item_code, item.warehouse))
 


### PR DESCRIPTION
**Issue**

Actual qty in sales order print preview and qty in the pdf is not matching. Because the value in the database if different and the value in the form is different