### PR TITLE
fix: Error "TypeError: unorderable types: int() > str()" When Trying …

### DIFF
--- a/erpnext/stock/doctype/packing_slip/packing_slip.py
+++ b/erpnext/stock/doctype/packing_slip/packing_slip.py
@@ -49,7 +49,7 @@ class PackingSlip(Document):
 			frappe.msgprint(_("Please specify a valid 'From Case No.'"), raise_exception=1)
 		elif not self.to_case_no:
 			self.to_case_no = self.from_case_no
-		elif self.from_case_no > self.to_case_no:
+		elif cint(self.from_case_no) > cint(self.to_case_no):
 			frappe.msgprint(_("'To Case No.' cannot be less than 'From Case No.'"),
 				raise_exception=1)
 


### PR DESCRIPTION
…to Create Packing Slip

User report here https://discuss.erpnext.com/t/error-typeerror-unorderable-types-int-str-when-trying-to-create-packing-slip/52445

This has not been noted to github issues and is just a suggested fix, an expert may need to refactor more here?

User and traceback does not state whether Python 2 or 3 but perhaps 3 since that apparently does not 'guess' when types do not match?

See also https://stackoverflow.com/questions/14886881/unorderable-types-int-str

Please read the pull request checklist to make sure your changes are merged: https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

