### PR TITLE
fix: fix accounts balance timeline dashboard chart source

### DIFF
--- a/erpnext/accounts/dashboard_chart_source/account_balance_timeline/account_balance_timeline.py
+++ b/erpnext/accounts/dashboard_chart_source/account_balance_timeline/account_balance_timeline.py
@@ -12,8 +12,11 @@ from frappe.utils.nestedset import get_descendants_of
 
 @frappe.whitelist()
 @cache_source
-def get(chart = None, no_cache = None, from_date = None, to_date = None):
-	chart = frappe._dict(frappe.parse_json(chart))
+def get(chart_name = None, chart = None, no_cache = None, from_date = None, to_date = None):
+	if chart_name:
+		chart = frappe.get_doc('Dashboard Chart', chart_name)
+	else:
+		chart = frappe._dict(frappe.parse_json(chart))
 	timespan = chart.timespan
 	timegrain = chart.time_interval
 	filters = frappe.parse_json(chart.filters_json)

--- a/erpnext/accounts/dashboard_chart_source/account_balance_timeline/account_balance_timeline.py
+++ b/erpnext/accounts/dashboard_chart_source/account_balance_timeline/account_balance_timeline.py
@@ -12,11 +12,11 @@ from frappe.utils.nestedset import get_descendants_of
 
 @frappe.whitelist()
 @cache_source
-def get(chart_name=None, from_date = None, to_date = None):
-	chart = frappe.get_doc('Dashboard Chart', chart_name)
+def get(chart = None, no_cache = None, from_date = None, to_date = None):
+	chart = frappe._dict(frappe.parse_json(chart))
 	timespan = chart.timespan
 	timegrain = chart.time_interval
-	filters = json.loads(chart.filters_json)
+	filters = frappe.parse_json(chart.filters_json)
 
 	account = filters.get("account")
 	company = filters.get("company")


### PR DESCRIPTION
Fixed accounts balance timeline dashboard chart source:

<img width="1191" alt="Screenshot 2019-09-05 at 11 26 36 PM" src="https://user-images.githubusercontent.com/19775888/64366809-a5337300-d034-11e9-9762-d206257daf6f.png">

<img width="700" alt="Screenshot 2019-09-05 at 11 27 21 PM" src="https://user-images.githubusercontent.com/19775888/64366856-bed4ba80-d034-11e9-8132-d485ab329464.png">

