### PR TITLE
fix: not able to save item because price list has disabled

### DIFF
--- a/erpnext/stock/doctype/item_price/item_price.py
+++ b/erpnext/stock/doctype/item_price/item_price.py
@@ -32,10 +32,16 @@ class ItemPrice(Document):
 
 	def update_price_list_details(self):
 		if self.price_list:
-			self.buying, self.selling, self.currency = \
-				frappe.db.get_value("Price List",
-					{"name": self.price_list, "enabled": 1},
-					["buying", "selling", "currency"])
+			price_list_details = frappe.db.get_value("Price List",
+				{"name": self.price_list, "enabled": 1},
+				["buying", "selling", "currency"])
+
+			if not price_list_details:
+				link = frappe.utils.get_link_to_form('Price List', self.price_list)
+				frappe.throw("The price list {0} does not exists or disabled".
+					format(link))
+
+			self.buying, self.selling, self.currency = price_list_details
 
 	def update_item_details(self):
 		if self.item_code:


### PR DESCRIPTION
**Issue**

User has set the disabled price list as a default price list in the selling settings and while making the new item against the same price list system throws bellow error

```
Traceback (most recent call last):
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/desk/form/save.py", line 22, in savedocs
    doc.save()
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/model/document.py", line 260, in save
    return self._save(*args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/model/document.py", line 283, in _save
    self.insert()
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/model/document.py", line 243, in insert
    self.run_method("after_insert")
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/model/document.py", line 772, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/model/document.py", line 1048, in composer
    return composed(self, method, *args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/model/document.py", line 1031, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/model/document.py", line 766, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/erpnext/erpnext/stock/doctype/item/item.py", line 85, in after_insert
    self.add_price(default.default_price_list)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/erpnext/erpnext/stock/doctype/item/item.py", line 160, in add_price
    item_price.insert()
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/model/document.py", line 222, in insert
    self.run_before_save_methods()
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/model/document.py", line 876, in run_before_save_methods
    self.run_method("validate")
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/model/document.py", line 772, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/model/document.py", line 1048, in composer
    return composed(self, method, *args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/model/document.py", line 1031, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/model/document.py", line 766, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/erpnext/erpnext/stock/doctype/item_price/item_price.py", line 20, in validate
    self.update_price_list_details()
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/erpnext/erpnext/stock/doctype/item_price/item_price.py", line 38, in update_price_list_details
    ["buying", "selling", "currency"])
TypeError: 'NoneType' object is not iterable
```