### PR TITLE
fix: Set some mandatory address fields as reqd in customer quick entry form

### DIFF
--- a/erpnext/public/js/utils/customer_quick_entry.js
+++ b/erpnext/public/js/utils/customer_quick_entry.js
@@ -37,7 +37,8 @@ frappe.ui.form.CustomerQuickEntryForm = frappe.ui.form.QuickEntryForm.extend({
 		{
 			label: __("Address Line 1"),
 			fieldname: "address_line1",
-			fieldtype: "Data"
+			fieldtype: "Data",
+			reqd: 1
 		},
 		{
 			label: __("Address Line 2"),
@@ -55,7 +56,8 @@ frappe.ui.form.CustomerQuickEntryForm = frappe.ui.form.QuickEntryForm.extend({
 		{
 			label: __("City"),
 			fieldname: "city",
-			fieldtype: "Data"
+			fieldtype: "Data",
+			reqd: 1,
 		},
 		{
 			label: __("State"),
@@ -66,7 +68,8 @@ frappe.ui.form.CustomerQuickEntryForm = frappe.ui.form.QuickEntryForm.extend({
 			label: __("Country"),
 			fieldname: "country",
 			fieldtype: "Link",
-			options: "Country"
+			options: "Country",
+			reqd: 1
 		},
 		{
 			label: __("Customer POS Id"),


### PR DESCRIPTION
Set some mandatory address fields as reqd in customer quick entry form to avoid unexpected error during save.

**Issue:** 
![customer-quick-view](https://user-images.githubusercontent.com/13928957/64581691-c2f03780-d3a8-11e9-9018-56db66796162.gif)

