### PR TITLE
fix: leave balance reports

### DIFF
--- a/erpnext/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
+++ b/erpnext/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
@@ -116,7 +116,7 @@ def process_expired_allocation():
 		})
 
 	if expire_allocation:
-		create_expiry_ledger_entry(expire_allocation)
+			create_expiry_ledger_entry(expire_allocation)
 
 def create_expiry_ledger_entry(allocations):
 	''' Create ledger entry for expired allocation '''

--- a/erpnext/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
+++ b/erpnext/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
@@ -116,7 +116,7 @@ def process_expired_allocation():
 		})
 
 	if expire_allocation:
-			create_expiry_ledger_entry(expire_allocation)
+		create_expiry_ledger_entry(expire_allocation)
 
 def create_expiry_ledger_entry(allocations):
 	''' Create ledger entry for expired allocation '''

--- a/erpnext/hr/report/employee_leave_balance/employee_leave_balance.py
+++ b/erpnext/hr/report/employee_leave_balance/employee_leave_balance.py
@@ -60,7 +60,7 @@ def get_data(filters, leave_types):
 
 	data = []
 	for employee in active_employees:
-		leave_approvers = employee.leave_approver or department_approver_map.get(employee.department_name, [])
+		leave_approvers = department_approver_map.get(employee.department_name, []).append(employee.leave_approver)
 		if (len(leave_approvers) and user in leave_approvers) or (user in ["Administrator", employee.user_id]) or ("HR Manager" in frappe.get_roles(user)):
 			row = [employee.name, employee.employee_name, employee.department]
 

--- a/erpnext/hr/report/employee_leave_balance/employee_leave_balance.py
+++ b/erpnext/hr/report/employee_leave_balance/employee_leave_balance.py
@@ -54,13 +54,13 @@ def get_data(filters, leave_types):
 
 	active_employees = frappe.get_all("Employee",
 		filters=conditions,
-		fields=["name", "employee_name", "department", "user_id"])
+		fields=["name", "employee_name", "department", "user_id", "leave_approver"])
 
 	department_approver_map = get_department_leave_approver_map(filters.get('department'))
 
 	data = []
 	for employee in active_employees:
-		leave_approvers = department_approver_map.get(employee.department_name, [])
+		leave_approvers = employee.leave_approver or department_approver_map.get(employee.department_name, [])
 		if (len(leave_approvers) and user in leave_approvers) or (user in ["Administrator", employee.user_id]) or ("HR Manager" in frappe.get_roles(user)):
 			row = [employee.name, employee.employee_name, employee.department]
 

--- a/erpnext/hr/report/employee_leave_balance/employee_leave_balance.py
+++ b/erpnext/hr/report/employee_leave_balance/employee_leave_balance.py
@@ -66,10 +66,10 @@ def get_data(filters, leave_types):
 					filters.from_date, filters.to_date) * -1
 
 				# opening balance
-				opening = get_total_allocated_leaves(employee.name, leave_type, filters.from_date, filters.to_date)
+				opening = get_leave_balance_on(employee.name, leave_type, filters.from_date)
 
 				# closing balance
-				closing = flt(opening) - flt(leaves_taken)
+				closing = get_leave_balance_on(employee.name, leave_type, filters.to_date)
 
 				row += [opening, leaves_taken, closing]
 
@@ -94,18 +94,3 @@ def get_approvers(department):
 			where parent = %s and parentfield = 'leave_approvers'""", (d), as_dict=True)])
 
 	return approvers
-
-def get_total_allocated_leaves(employee, leave_type, from_date, to_date):
-	''' Returns leave allocation between from date and to date '''
-	leave_allocation_records = frappe.db.get_all('Leave Ledger Entry', filters={
-			'docstatus': 1,
-			'is_expired': 0,
-			'leave_type': leave_type,
-			'employee': employee,
-			'transaction_type': 'Leave Allocation'
-		}, or_filters={
-			'from_date': ['between', (from_date, to_date)],
-			'to_date': ['between', (from_date, to_date)]
-		}, fields=['SUM(leaves) as leaves'])
-
-	return flt(leave_allocation_records[0].get('leaves')) if leave_allocation_records else flt(0)

--- a/erpnext/hr/report/employee_leave_balance_summary/employee_leave_balance_summary.js
+++ b/erpnext/hr/report/employee_leave_balance_summary/employee_leave_balance_summary.js
@@ -5,6 +5,20 @@
 frappe.query_reports['Employee Leave Balance Summary'] = {
 	filters: [
 		{
+			fieldname:'from_date',
+			label: __('From Date'),
+			fieldtype: 'Date',
+			reqd: 1,
+			default: frappe.defaults.get_default('year_start_date')
+		},
+		{
+			fieldname:'to_date',
+			label: __('To Date'),
+			fieldtype: 'Date',
+			reqd: 1,
+			default: frappe.defaults.get_default('year_end_date')
+		},
+		{
 			fieldname:'company',
 			label: __('Company'),
 			fieldtype: 'Link',
@@ -19,18 +33,10 @@ frappe.query_reports['Employee Leave Balance Summary'] = {
 			options: 'Employee',
 		},
 		{
-			fieldname:'from_date',
-			label: __('From Date'),
-			fieldtype: 'Date',
-			reqd: 1,
-			default: frappe.defaults.get_default('year_start_date')
-		},
-		{
-			fieldname:'to_date',
-			label: __('To Date'),
-			fieldtype: 'Date',
-			reqd: 1,
-			default: frappe.defaults.get_default('year_end_date')
+			fieldname:'department',
+			label: __('Department'),
+			fieldtype: 'Link',
+			options: 'Department',
 		}
 	]
 };

--- a/erpnext/hr/report/employee_leave_balance_summary/employee_leave_balance_summary.py
+++ b/erpnext/hr/report/employee_leave_balance_summary/employee_leave_balance_summary.py
@@ -73,7 +73,7 @@ def get_data(filters):
 		})
 		for employee in active_employees:
 			
-			leave_approvers = employee.leave_approver or department_approver_map.get(employee.department_name, [])
+			leave_approvers = department_approver_map.get(employee.department_name, []).append(employee.leave_approver)
 
 			if (len(leave_approvers) and user in leave_approvers) or (user in ["Administrator", employee.user_id]) \
 				or ("HR Manager" in frappe.get_roles(user)):

--- a/erpnext/hr/report/employee_leave_balance_summary/employee_leave_balance_summary.py
+++ b/erpnext/hr/report/employee_leave_balance_summary/employee_leave_balance_summary.py
@@ -114,7 +114,7 @@ def get_department_leave_approver_map(department=None):
 		conditions='and department_name = %(department)s or parent_department = %(department)s'%{'department': department}
 
 	# get current department and all its child
-	department_list = frappe.db.sql_list(''' SELECT name FROM `tabDepartment` WHERE disabled=0{0}'''.format(conditions)) #nosec
+	department_list = frappe.db.sql_list(''' SELECT name FROM `tabDepartment` WHERE disabled=0 {0}'''.format(conditions)) #nosec
 
 	# retrieve approvers list from current department and from its subsequent child departments
 	approver_list = frappe.get_all('Department Approver', filters={


### PR DESCRIPTION
Fixes
- opening leave balance was fetching the leave allocation. This change fetches the leave balance based on the start date from the filter.
- Checks for leave approvers in employee leave balance summary and display only those records for which user is a leave approver(department approver).

