### PR TITLE
fix: do not cache value while creating item group, in setup wizard it will raise link validation error

### DIFF
--- a/erpnext/setup/doctype/item_group/item_group.py
+++ b/erpnext/setup/doctype/item_group/item_group.py
@@ -29,7 +29,7 @@ class ItemGroup(NestedSet, WebsiteGenerator):
 		super(ItemGroup, self).validate()
 
 		if not self.parent_item_group and not frappe.flags.in_test:
-			if frappe.db.exists("Item Group", _('All Item Groups'), cache=True):
+			if frappe.db.exists("Item Group", _('All Item Groups')):
 				self.parent_item_group = _('All Item Groups')
 
 		self.make_route()


### PR DESCRIPTION
```
import frappe
from frappe import _
from frappe import _dict
from frappe.modules import scrub

itg_list = [
    # item group
    {'doctype': 'Item Group', 'item_group_name': _('All Item Groups'),
        'is_group': 1, 'parent_item_group': ''},
    {'doctype': 'Item Group', 'item_group_name': _('Products'),
        'is_group': 0, 'parent_item_group': _('All Item Groups'), "show_in_website": 1 },
    {'doctype': 'Item Group', 'item_group_name': _('Raw Material'),
        'is_group': 0, 'parent_item_group': _('All Item Groups') },
    {'doctype': 'Item Group', 'item_group_name': _('Services'),
        'is_group': 0, 'parent_item_group': _('All Item Groups') },
    {'doctype': 'Item Group', 'item_group_name': _('Sub Assemblies'),
        'is_group': 0, 'parent_item_group': _('All Item Groups') },
    {'doctype': 'Item Group', 'item_group_name': _('Consumable'),
        'is_group': 0, 'parent_item_group': _('All Item Groups') },
]

for record in itg_list:
    doctype = record.get("doctype")
    doc = frappe.new_doc(doctype)
    doc.update(record)

    parent_link_field = ("parent_" + scrub(doc.doctype))
    if doc.meta.get_field(parent_link_field) and not doc.get(parent_link_field):
        doc.flags.ignore_mandatory = True
    try:
        print(doc.item_group_name)
        print(doc.parent_item_group)
        doc.insert(ignore_permissions=True)
    except Exception as e:
        print(e)

```
<img width="1020" alt="Screen Shot 2019-09-10 at 7 41 36 PM" src="https://user-images.githubusercontent.com/3784093/64621681-b77e2a00-d403-11e9-9623-e0fd65f715c5.png">

---

If you are not committing a transaction, then do not use `cache=True` with `frappe.db.exists`

reasons
- https://github.com/frappe/frappe/blob/develop/frappe/database/database.py#L457
- https://github.com/frappe/frappe/blob/develop/frappe/database/database.py#L425

