### PR TITLE
fix: if id not found then compare item name to avoid duplicate item creation

### DIFF
--- a/erpnext/erpnext_integrations/connectors/woocommerce_connection.py
+++ b/erpnext/erpnext_integrations/connectors/woocommerce_connection.py
@@ -62,7 +62,8 @@ def _order(*args, **kwargs):
 
 			item_woo_com_id = item.get("product_id")
 
-			if frappe.get_value("Item",{"woocommerce_id": item_woo_com_id}):
+			if frappe.get_value("Item",{"woocommerce_id": item_woo_com_id}) or\
+				frappe.get_value("Item",{"item_name": item.get('name')}):
 				#Edit
 				link_item(item,1)
 			else:


### PR DESCRIPTION
Check item name if product id not found on erpnext to avoid duplicate item creation
