### PR TITLE
fix: use jquery hide instead of css class

### DIFF
--- a/erpnext/templates/generators/item/item_add_to_cart.html
+++ b/erpnext/templates/generators/item/item_add_to_cart.html
@@ -27,6 +27,7 @@
 			{% endif %}
 		</div>
 		{% endif %}
+		{% if product_info.price and (cart_settings.allow_items_not_in_stock or product_info.in_stock) %}
 		<div class="mt-3">
 			<a href="/cart"
 				class="btn btn-light btn-view-in-cart {% if not product_info.qty %}hidden{% endif %}"
@@ -41,6 +42,7 @@
 				{{ _("Add to Cart") }}
 			</button>
 		</div>
+		{% endif %}
 	</div>
 </div>
 

--- a/erpnext/templates/includes/product_page.js
+++ b/erpnext/templates/includes/product_page.js
@@ -14,9 +14,10 @@ frappe.ready(function() {
 		callback: function(r) {
 			if(r.message) {
 				if(r.message.cart_settings.enabled) {
+					// NOT price OR (NOT in stock AND NOT allow_not_in_stock)
 					let hide_add_to_cart = !r.message.product_info.price
 						|| (!r.message.product_info.in_stock && !r.message.cart_settings.allow_items_not_in_stock);
-					$(".item-cart, .item-price, .item-stock").toggleClass('hide', hide_add_to_cart);
+					if (hide_add_to_cart) $(".item-cart, .item-price, .item-stock").hide();
 				}
 				if(r.message.cart_settings.show_price) {
 					$(".item-price").toggleClass("hide", false);


### PR DESCRIPTION
css hide class would not work for bootstrap 4 as the hide class was not defined. This PR fixes this by using jquery hide