### PR TITLE
fix: Invalid reference doctypes for accounting dimensions

### DIFF
--- a/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.js
+++ b/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.js
@@ -5,9 +5,13 @@ frappe.ui.form.on('Accounting Dimension', {
 
 	refresh: function(frm) {
 		frm.set_query('document_type', () => {
+			let invalid_doctypes = frappe.model.core_doctypes_list;
+			invalid_doctypes.push('Accounting Dimension', 'Project',
+				'Cost Center', 'Accounting Dimension Detail');
+
 			return {
 				filters: {
-					name: ['not in', ['Accounting Dimension', 'Project', 'Cost Center', 'Accounting Dimension Detail']]
+					name: ['not in', invalid_doctypes]
 				}
 			};
 		});

--- a/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.py
+++ b/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.py
@@ -14,6 +14,8 @@ from frappe.utils.background_jobs import enqueue
 from frappe.model import core_doctypes_list
 
 class AccountingDimension(Document):
+	def before_insert(self):
+		self.set_fieldname_and_label()
 
 	def validate(self):
 		if self.document_type in core_doctypes_list + ('Accounting Dimension', 'Project',
@@ -23,7 +25,6 @@ class AccountingDimension(Document):
 			frappe.throw(msg)
 
 	def after_insert(self):
-		self.set_fieldname_and_label()
 		if frappe.flags.in_test:
 			make_dimension_in_accounting_doctypes(doc=self)
 		else:

--- a/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.py
+++ b/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.py
@@ -11,9 +11,18 @@ from frappe.custom.doctype.custom_field.custom_field import create_custom_field
 from frappe import scrub
 from frappe.utils import cstr
 from frappe.utils.background_jobs import enqueue
+from frappe.model import core_doctypes_list
 
 class AccountingDimension(Document):
-	def before_insert(self):
+
+	def validate(self):
+		if self.document_type in core_doctypes_list + ('Accounting Dimension', 'Project',
+				'Cost Center', 'Accounting Dimension Detail') :
+
+			msg = _("Not allowed to create accounting dimension for {0}").format(self.document_type)
+			frappe.throw(msg)
+
+	def after_insert(self):
 		self.set_fieldname_and_label()
 		if frappe.flags.in_test:
 			make_dimension_in_accounting_doctypes(doc=self)


### PR DESCRIPTION
If reference doctype is selected as doctype, `get_doc` breaks for all accounting doctypes.