### PR TITLE
fix: precision rounding issue during pos return validation

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -207,7 +207,7 @@ class SalesInvoice(SellingController):
 			for payment in self.payments:
 				total_amount_in_payments += payment.amount
 			invoice_total = self.rounded_total or self.grand_total
-			if total_amount_in_payments < invoice_total:
+			if flt(total_amount_in_payments, self.precision("grand_total")) < invoice_total:
 				frappe.throw(_("Total payments amount can't be greater than {}".format(-invoice_total)))
 
 	def validate_pos_paid_amount(self):


### PR DESCRIPTION
![Screenshot (42)](https://user-images.githubusercontent.com/17160298/64827450-e18d4300-d5e1-11e9-8560-19b81fd7393c.png)

This error happens because operations on `total_amount_in_payments` produce floating point approximations that result in invalidation of the comparison between `total_amount_in_payments` and `invoice_total` in line **201**.

https://github.com/frappe/erpnext/blob/4111965d2ed2ac286836023dce4716562ae8644c/erpnext/accounts/doctype/sales_invoice/sales_invoice.py#L203-L211

![2019-09-13-04-43-07_1920x1080](https://user-images.githubusercontent.com/17160298/64827457-e5b96080-d5e1-11e9-80b6-53ffad2bd326.png)
