### PR TITLE
fix: for pos, paid amount has not considered the tax amount due to which outstanding amount showing for the pos invoices

### DIFF
--- a/erpnext/accounts/page/pos/pos.js
+++ b/erpnext/accounts/page/pos/pos.js
@@ -1699,13 +1699,6 @@ erpnext.pos.PointOfSale = erpnext.taxes_and_totals.extend({
 		if (this.frm.doc.offline_pos_name
 			&& in_list(existing_pos_list, this.frm.doc.offline_pos_name)) {
 			this.update_invoice()
-			//to retrieve and set the default payment
-			invoice_data[this.frm.doc.offline_pos_name] = this.frm.doc;
-			invoice_data[this.frm.doc.offline_pos_name].payments[0].amount = this.frm.doc.net_total
-			invoice_data[this.frm.doc.offline_pos_name].payments[0].base_amount = this.frm.doc.net_total
-
-			this.frm.doc.paid_amount = this.frm.doc.net_total
-			this.frm.doc.outstanding_amount = 0
 		} else if(!this.frm.doc.offline_pos_name) {
 			this.frm.doc.offline_pos_name = frappe.datetime.now_datetime();
 			this.frm.doc.posting_date = frappe.datetime.get_today();


### PR DESCRIPTION
**Issue**

![before_fix_pos_outstanding_amt_issue](https://user-images.githubusercontent.com/8780500/64846992-93049680-d62b-11e9-8fa7-9d022cfb3556.gif)

**After fix**
![after_fix_pos_outstanding_amt_issue](https://user-images.githubusercontent.com/8780500/64846998-9861e100-d62b-11e9-8d23-10c5277b283b.gif)
