### PR TITLE
fix: 'link to material request' button not showing any message

### DIFF
--- a/erpnext/public/js/controllers/buying.js
+++ b/erpnext/public/js/controllers/buying.js
@@ -293,7 +293,7 @@ erpnext.buying.BuyingController = erpnext.TransactionController.extend({
 				items: my_items
 			},
 			callback: function(r) {
-				if(!r.message) {
+				if(!r.message || r.message.length == 0) {
 					frappe.throw(__("No pending Material Requests found to link for the given items."))
 				}
 				else {


### PR DESCRIPTION
Problem:
The **link to material request** button in **Request for Quotation** and **Supplier Quotation** not showing any message if no pending material requests with the same items are found.

Fix:
![link_to_material_request_fix](https://user-images.githubusercontent.com/24353136/64944118-31dafe00-d88b-11e9-9c10-55e97e155ce1.png)

