### PR TITLE
fix: Displaying manufacturer part no. along with manufacturer and added Manufacturers table validation in Item master

### DIFF
--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -440,17 +440,17 @@ def get_batch_numbers(doctype, txt, searchfield, start, page_len, filters):
 
 @frappe.whitelist()
 def item_manufacturer_query(doctype, txt, searchfield, start, page_len, filters):
-	search_txt = "{0}%".format(txt)
+	item_filters = [
+		['manufacturer', 'like', '%' + txt + '%'],
+		['item_code', '=', filters.get("item_code")]
+	]
 
-	item_filters = {
-		'manufacturer': ('like', search_txt),
-		'item_code': filters.get("item_code")
-	}
-
-	return frappe.get_all("Item Manufacturer",
-		fields = "manufacturer",
-		filters = item_filters,
+	item_manufacturers = frappe.get_all(
+		"Item Manufacturer",
+		fields=["manufacturer", "manufacturer_part_no"],
+		filters=item_filters,
 		limit_start=start,
 		limit_page_length=page_len,
 		as_list=1
 	)
+	return item_manufacturers

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -125,6 +125,7 @@ class Item(WebsiteGenerator):
 		self.validate_auto_reorder_enabled_in_stock_settings()
 		self.cant_change()
 		self.update_show_in_website()
+		self.validate_manufacturer()
 
 		if not self.get("__islocal"):
 			self.old_item_group = frappe.db.get_value(self.doctype, self.name, "item_group")
@@ -143,6 +144,13 @@ class Item(WebsiteGenerator):
 		'''Clean HTML description if set'''
 		if cint(frappe.db.get_single_value('Stock Settings', 'clean_description_html')):
 			self.description = clean_html(self.description)
+
+	def validate_manufacturer(self):
+		list_man = [(x.manufacturer, x.manufacturer_part_no) for x in self.get('manufacturers')]
+		set_man = set(list_man)
+
+		if len(list_man) != len(set_man):
+			frappe.throw(_("Duplicate entry in Manufacturers table"))
 
 	def validate_customer_provided_part(self):
 		if self.is_customer_provided_item:
@@ -920,7 +928,6 @@ def validate_cancelled_item(item_code, docstatus=None, verbose=1):
 	if docstatus == 2:
 		msg = _("Item {0} is cancelled").format(item_code)
 		_msgprint(msg, verbose)
-
 
 def _msgprint(msg, verbose):
 	if verbose:


### PR DESCRIPTION
Manufacturer Link field options in Items Table of transactions will also display manufacturer part no.
Manufacturers table in Item master will check for duplicate entries.