### PR TITLE
fix: show a descriptive message on submission of duplicate account

### DIFF
--- a/erpnext/accounts/doctype/account/account.py
+++ b/erpnext/accounts/doctype/account/account.py
@@ -126,7 +126,8 @@ class Account(NestedSet):
 					"account_currency": None,
 					"parent_account": parent_acc_name_map[company]
 				})
-				doc.save()
+				if not self.check_if_child_acc_exists(doc):
+					doc.save()
 				frappe.msgprint(_("Account {0} is added in the child company {1}")
 					.format(doc.name, company))
 
@@ -169,6 +170,24 @@ class Account(NestedSet):
 		elif self.account_currency != frappe.db.get_value("Account", self.name, "account_currency"):
 			if frappe.db.get_value("GL Entry", {"account": self.name}):
 				frappe.throw(_("Currency can not be changed after making entries using some other currency"))
+
+	def check_if_child_acc_exists(self, doc):
+		''' Checks if a account in parent company exists in the  '''
+		info = frappe.db.get_value("Account", {
+			"account_name": doc.account_name,
+			"account_number": doc.account_number
+		}, ['company', 'account_currency', 'is_group', 'root_type', 'account_type', 'balance_must_be', 'account_name'], as_dict=1)
+
+		if not info:
+			return
+
+		doc = vars(doc)
+		dict_diff = [k for k in info if k in doc and info[k] != doc[k] and k != "company"]
+		if dict_diff:
+			frappe.throw(_("Account {0} already exists in child company {1}. The following fields have different values, they should be same:<ul><li>{2}</li></ul>")
+				.format(info.account_name, info.company, '</li><li>'.join(dict_diff)))
+		else:
+			return True
 
 	def convert_group_to_ledger(self):
 		if self.check_if_child_exists():


### PR DESCRIPTION
On creation of parent account when child account with a similar name exists. This allows creation if all other states are similar.
![Screenshot 2019-07-25 at 7 31 42 PM](https://user-images.githubusercontent.com/14824451/61880727-08e55f00-af13-11e9-9d25-d82f528c1872.png)

