### PR TITLE
fix: not able to change the account type in parent company account head

### DIFF
--- a/erpnext/accounts/doctype/account/account.py
+++ b/erpnext/accounts/doctype/account/account.py
@@ -100,7 +100,10 @@ class Account(NestedSet):
 		if ancestors:
 			if frappe.get_value("Company", self.company, "allow_account_creation_against_child_company"):
 				return
-			frappe.throw(_("Please add the account to root level Company - %s" % ancestors[0]))
+
+			if not frappe.db.get_value("Account",
+				{'account_name': self.account_name, 'company': ancestors[0]}, 'name'):
+				frappe.throw(_("Please add the account to root level Company - %s" % ancestors[0]))
 		else:
 			descendants = get_descendants_of('Company', self.company)
 			if not descendants: return
@@ -114,24 +117,7 @@ class Account(NestedSet):
 
 			if not parent_acc_name_map: return
 
-			for company in descendants:
-				if not parent_acc_name_map.get(company):
-					frappe.throw(_("While creating account for child Company {0}, parent account {1} not found. Please create the parent account in corresponding COA")
-						.format(company, parent_acc_name))
-
-				doc = frappe.copy_doc(self)
-				doc.flags.ignore_root_company_validation = True
-				doc.update({
-					"company": company,
-					# parent account's currency should be passed down to child account's curreny
-					# if it is None, it picks it up from default company currency, which might be unintended
-					"account_currency": self.account_currency,
-					"parent_account": parent_acc_name_map[company]
-				})
-				if not self.check_if_child_acc_exists(doc):
-					doc.save()
-				frappe.msgprint(_("Account {0} is added in the child company {1}")
-					.format(doc.name, company))
+			self.create_account_for_child_company(parent_acc_name_map, descendants)
 
 	def validate_group_or_ledger(self):
 		if self.get("__islocal"):
@@ -173,23 +159,48 @@ class Account(NestedSet):
 			if frappe.db.get_value("GL Entry", {"account": self.name}):
 				frappe.throw(_("Currency can not be changed after making entries using some other currency"))
 
-	def check_if_child_acc_exists(self, doc):
-		''' Checks if a account in parent company exists in the  '''
-		info = frappe.db.get_value("Account", {
-			"account_name": doc.account_name,
-			"account_number": doc.account_number
-		}, ['company', 'account_currency', 'is_group', 'root_type', 'account_type', 'balance_must_be', 'account_name'], as_dict=1)
+	def create_account_for_child_company(self, parent_acc_name_map, descendants):
+		for company in descendants:
+			if not parent_acc_name_map.get(company):
+				frappe.throw(_("While creating account for child Company {0}, parent account {1} not found. Please create the parent account in corresponding COA")
+					.format(company, parent_acc_name))
 
-		if not info:
-			return
+			filters = {
+				"account_name": self.account_name,
+				"company": company
+			}
 
-		doc = vars(doc)
-		dict_diff = [k for k in info if k in doc and info[k] != doc[k] and k != "company"]
-		if dict_diff:
-			frappe.throw(_("Account {0} already exists in child company {1}. The following fields have different values, they should be same:<ul><li>{2}</li></ul>")
-				.format(info.account_name, info.company, '</li><li>'.join(dict_diff)))
-		else:
-			return True
+			if self.account_number:
+				filters["account_number"] = self.account_number
+
+			child_account = frappe.db.get_value("Account", filters, 'name')
+
+			if not child_account:
+				doc = frappe.copy_doc(self)
+				doc.flags.ignore_root_company_validation = True
+				doc.update({
+					"company": company,
+					# parent account's currency should be passed down to child account's curreny
+					# if it is None, it picks it up from default company currency, which might be unintended
+					"account_currency": self.account_currency,
+					"parent_account": parent_acc_name_map[company]
+				})
+
+				doc.save()
+				frappe.msgprint(_("Account {0} is added in the child company {1}")
+					.format(doc.name, company))
+			elif child_account:
+				# update the parent company's value in child companies
+				doc = frappe.get_doc("Account", child_account)
+				parent_value_changed = False
+				for field in ['account_type', 'account_currency',
+					'freeze_account', 'balance_must_be']:
+					if doc.get(field) != self.get(field):
+						parent_value_changed = True
+						doc.set(field, self.get(field))
+
+				if parent_value_changed:
+					doc.save()
 
 	def convert_group_to_ledger(self):
 		if self.check_if_child_exists():


### PR DESCRIPTION
**Issue**

- Created parent company Parent A and added two child companies Child A1, Child B1
- Added Bank account "Bank A" in parent company, system has added same account in child company too
- After few hours tried to change the account type of the bank account in the parent company but system throwing an error "Duplicate name Account Bank A", "Account Bank A1 is already exists"

**Solution**

- If same account present in the child then update the value in child while updating value in the parent account and not create another account

