### PR TITLE
fix: Return employee_emails instead of employee

### DIFF
--- a/erpnext/communication/doctype/call_log/call_log.py
+++ b/erpnext/communication/doctype/call_log/call_log.py
@@ -60,7 +60,7 @@ def get_employees_with_number(number):
 	employee_emails = [employee.user_id for employee in employees]
 	frappe.cache().hset('employees_with_number', number, employee_emails)
 
-	return employee
+	return employee_emails
 
 def set_caller_information(doc, state):
 	'''Called from hooks on creation of Lead or Contact'''


### PR DESCRIPTION
Fixes the following error while creating call log.
```
  File "/home/frappe/benches/bench-version-12-2019-09-10/apps/frappe/frappe/model/document.py", line 271, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2019-09-10/apps/frappe/frappe/model/document.py", line 294, in _save
    self.insert()
  File "/home/frappe/benches/bench-version-12-2019-09-10/apps/frappe/frappe/model/document.py", line 252, in insert
    self.run_method("after_insert")
  File "/home/frappe/benches/bench-version-12-2019-09-10/apps/frappe/frappe/model/document.py", line 786, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2019-09-10/apps/frappe/frappe/model/document.py", line 1056, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2019-09-10/apps/frappe/frappe/model/document.py", line 1039, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-version-12-2019-09-10/apps/frappe/frappe/model/document.py", line 780, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2019-09-10/apps/erpnext/erpnext/communication/doctype/call_log/call_log.py", line 20, in after_insert
    self.trigger_call_popup()
  File "/home/frappe/benches/bench-version-12-2019-09-10/apps/erpnext/erpnext/communication/doctype/call_log/call_log.py", line 32, in trigger_call_popup
    employee_emails = get_employees_with_number(self.to)
  File "/home/frappe/benches/bench-version-12-2019-09-10/apps/erpnext/erpnext/communication/doctype/call_log/call_log.py", line 63, in get_employees_with_number
    return employee
NameError: name 'employee' is not defined
```