### PR TITLE
fix: set stock adjustment account for the raw materials instead of COGS

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -648,7 +648,7 @@ def get_bom_items_as_dict(bom, company, qty=1, fetch_exploded=1, fetch_scrap_ite
 			item_dict[item.item_code] = item
 
 	for item, item_details in item_dict.items():
-		for d in [["Account", "expense_account", "default_expense_account"],
+		for d in [["Account", "expense_account", "stock_adjustment_account"],
 			["Cost Center", "cost_center", "cost_center"], ["Warehouse", "default_warehouse", ""]]:
 				company_in_record = frappe.db.get_value(d[0], item_details.get(d[1]), "company")
 				if not item_details.get(d[1]) or (company_in_record and company != company_in_record):


### PR DESCRIPTION
**Issue**

Stock entry with manufacture showing incorrect GL Entries

<img width="741" alt="Screenshot 2019-09-17 at 2 23 22 PM" src="https://user-images.githubusercontent.com/8780500/65026810-e5f58b00-d956-11e9-8369-e50c4243509b.png">


Solution: If expense account are same for the raw material and finished good then only difference will be book.