### PR TITLE
fix: not able to export accounts receivable summary report in excel

### DIFF
--- a/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py
+++ b/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py
@@ -40,7 +40,8 @@ class AccountsReceivableSummary(ReceivablePayableReport):
 
 			row.party = party
 			if self.party_naming_by == "Naming Series":
-				row.party_name = frappe.get_cached_value(self.party_type, party, [self.party_type + "_name"])
+				row.party_name = frappe.get_cached_value(self.party_type,
+					party, frappe.scrub(self.party_type) + "_name")
 
 			row.update(party_dict)
 


### PR DESCRIPTION
**Issue**

```
Traceback (most recent call last):
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/__init__.py", line 1036, in call
    return fn(*args, **newargs)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 323, in export_query
    xlsx_file = make_xlsx(xlsx_data, "Query Report")
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/utils/xlsxutils.py", line 40, in make_xlsx
    ws.append(clean_row)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/env/lib/python2.7/site-packages/openpyxl/worksheet/_write_only.py", line 160, in append
    self._rows.send(row)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/env/lib/python2.7/site-packages/openpyxl/worksheet/_write_only.py", line 112, in _write_rows
    self._writer.write_row(xf, row, row_idx)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/env/lib/python2.7/site-packages/openpyxl/worksheet/_writer.py", line 137, in write_row
    for cell in row:
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/env/lib/python2.7/site-packages/openpyxl/worksheet/_write_only.py", line 178, in _values_to_row
    raise ValueError
ValueError
```