### PR TITLE
chore: remove internal fields from print of purchase documents

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
@@ -1,1349 +1,1352 @@
 {
-   "allow_import": 1,
-   "autoname": "naming_series:",
-   "creation": "2013-05-21 16:16:39",
-   "doctype": "DocType",
-   "document_type": "Document",
-   "field_order": [
-    "title",
-    "naming_series",
-    "supplier",
-    "supplier_name",
-    "tax_id",
-    "due_date",
-    "is_paid",
-    "is_return",
-    "apply_tds",
-    "column_break1",
-    "company",
-    "posting_date",
-    "posting_time",
-    "set_posting_time",
-    "amended_from",
-    "accounting_dimensions_section",
-    "cost_center",
-    "dimension_col_break",
-    "sb_14",
-    "on_hold",
-    "release_date",
-    "cb_17",
-    "hold_comment",
-    "supplier_invoice_details",
-    "bill_no",
-    "column_break_15",
-    "bill_date",
-    "returns",
-    "return_against",
-    "section_addresses",
-    "supplier_address",
-    "address_display",
-    "contact_person",
-    "contact_display",
-    "contact_mobile",
-    "contact_email",
-    "col_break_address",
-    "shipping_address",
-    "shipping_address_display",
-    "currency_and_price_list",
-    "currency",
-    "conversion_rate",
-    "column_break2",
-    "buying_price_list",
-    "price_list_currency",
-    "plc_conversion_rate",
-    "ignore_pricing_rule",
-    "sec_warehouse",
-    "set_warehouse",
-    "rejected_warehouse",
-    "col_break_warehouse",
-    "is_subcontracted",
-    "supplier_warehouse",
-    "items_section",
-    "update_stock",
-    "scan_barcode",
-    "items",
-    "pricing_rule_details",
-    "pricing_rules",
-    "raw_materials_supplied",
-    "supplied_items",
-    "section_break_26",
-    "total_qty",
-    "base_total",
-    "base_net_total",
-    "column_break_28",
-    "total",
-    "net_total",
-    "total_net_weight",
-    "taxes_section",
-    "tax_category",
-    "column_break_49",
-    "shipping_rule",
-    "section_break_51",
-    "taxes_and_charges",
-    "taxes",
-    "sec_tax_breakup",
-    "other_charges_calculation",
-    "totals",
-    "base_taxes_and_charges_added",
-    "base_taxes_and_charges_deducted",
-    "base_total_taxes_and_charges",
-    "column_break_40",
-    "taxes_and_charges_added",
-    "taxes_and_charges_deducted",
-    "total_taxes_and_charges",
-    "section_break_44",
-    "apply_discount_on",
-    "base_discount_amount",
-    "column_break_46",
-    "additional_discount_percentage",
-    "discount_amount",
-    "section_break_49",
-    "base_grand_total",
-    "base_rounding_adjustment",
-    "base_rounded_total",
-    "base_in_words",
-    "column_break8",
-    "grand_total",
-    "rounding_adjustment",
-    "rounded_total",
-    "in_words",
-    "total_advance",
-    "outstanding_amount",
-    "disable_rounded_total",
-    "payments_section",
-    "mode_of_payment",
-    "cash_bank_account",
-    "clearance_date",
-    "col_br_payments",
-    "paid_amount",
-    "base_paid_amount",
-    "write_off",
-    "write_off_amount",
-    "base_write_off_amount",
-    "column_break_61",
-    "write_off_account",
-    "write_off_cost_center",
-    "advances_section",
-    "allocate_advances_automatically",
-    "get_advances",
-    "advances",
-    "payment_schedule_section",
-    "payment_terms_template",
-    "payment_schedule",
-    "terms_section_break",
-    "tc_name",
-    "terms",
-    "printing_settings",
-    "letter_head",
-    "group_same_items",
-    "column_break_112",
-    "select_print_heading",
-    "language",
-    "more_info",
-    "credit_to",
-    "party_account_currency",
-    "is_opening",
-    "against_expense_account",
-    "column_break_63",
-    "status",
-    "inter_company_invoice_reference",
-    "remarks",
-    "subscription_section",
-    "from_date",
-    "to_date",
-    "column_break_114",
-    "auto_repeat",
-    "update_auto_repeat_reference"
-   ],
-   "fields": [
-    {
-     "allow_on_submit": 1,
-     "default": "{supplier_name}",
-     "fieldname": "title",
-     "fieldtype": "Data",
-     "hidden": 1,
-     "label": "Title",
-     "no_copy": 1,
-     "print_hide": 1
-    },
-    {
-     "fieldname": "naming_series",
-     "fieldtype": "Select",
-     "label": "Series",
-     "no_copy": 1,
-     "oldfieldname": "naming_series",
-     "oldfieldtype": "Select",
-     "options": "ACC-PINV-.YYYY.-",
-     "print_hide": 1,
-     "reqd": 1,
-     "set_only_once": 1
-    },
-    {
-     "fieldname": "supplier",
-     "fieldtype": "Link",
-     "in_standard_filter": 1,
-     "label": "Supplier",
-     "oldfieldname": "supplier",
-     "oldfieldtype": "Link",
-     "options": "Supplier",
-     "print_hide": 1,
-     "search_index": 1
-    },
-    {
-     "bold": 1,
-     "depends_on": "supplier",
-     "fetch_from": "supplier.supplier_name",
-     "fieldname": "supplier_name",
-     "fieldtype": "Data",
-     "in_global_search": 1,
-     "label": "Supplier Name",
-     "oldfieldname": "supplier_name",
-     "oldfieldtype": "Data",
-     "read_only": 1
-    },
-    {
-     "fetch_from": "supplier.tax_id",
-     "fieldname": "tax_id",
-     "fieldtype": "Read Only",
-     "label": "Tax Id",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "fieldname": "due_date",
-     "fieldtype": "Date",
-     "label": "Due Date",
-     "oldfieldname": "due_date",
-     "oldfieldtype": "Date"
-    },
-    {
-     "default": "0",
-     "fieldname": "is_paid",
-     "fieldtype": "Check",
-     "label": "Is Paid",
-     "print_hide": 1
-    },
-    {
-     "default": "0",
-     "fieldname": "is_return",
-     "fieldtype": "Check",
-     "label": "Is Return (Debit Note)",
-     "no_copy": 1,
-     "print_hide": 1
-    },
-    {
-     "default": "0",
-     "fieldname": "apply_tds",
-     "fieldtype": "Check",
-     "label": "Apply Tax Withholding Amount",
-     "print_hide": 1
-    },
-    {
-     "fieldname": "column_break1",
-     "fieldtype": "Column Break",
-     "oldfieldtype": "Column Break",
-     "width": "50%"
-    },
-    {
-     "fieldname": "company",
-     "fieldtype": "Link",
-     "in_standard_filter": 1,
-     "label": "Company",
-     "options": "Company",
-     "print_hide": 1,
-     "remember_last_selected_value": 1
-    },
-    {
-     "fieldname": "cost_center",
-     "fieldtype": "Link",
-     "label": "Cost Center",
-     "options": "Cost Center"
-    },
-    {
-     "default": "Today",
-     "fieldname": "posting_date",
-     "fieldtype": "Date",
-     "in_list_view": 1,
-     "label": "Date",
-     "oldfieldname": "posting_date",
-     "oldfieldtype": "Date",
-     "print_hide": 1,
-     "reqd": 1,
-     "search_index": 1
-    },
-    {
-     "fieldname": "posting_time",
-     "fieldtype": "Time",
-     "label": "Posting Time",
-     "no_copy": 1,
-     "print_hide": 1,
-     "print_width": "100px",
-     "width": "100px"
-    },
-    {
-     "default": "0",
-     "depends_on": "eval:doc.docstatus==0",
-     "fieldname": "set_posting_time",
-     "fieldtype": "Check",
-     "label": "Edit Posting Date and Time",
-     "print_hide": 1
-    },
-    {
-     "fieldname": "amended_from",
-     "fieldtype": "Link",
-     "ignore_user_permissions": 1,
-     "label": "Amended From",
-     "no_copy": 1,
-     "oldfieldname": "amended_from",
-     "oldfieldtype": "Link",
-     "options": "Purchase Invoice",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "collapsible": 1,
-     "collapsible_depends_on": "eval:doc.on_hold",
-     "fieldname": "sb_14",
-     "fieldtype": "Section Break",
-     "label": "Hold Invoice"
-    },
-    {
-     "default": "0",
-     "fieldname": "on_hold",
-     "fieldtype": "Check",
-     "label": "Hold Invoice"
-    },
-    {
-     "depends_on": "eval:doc.on_hold",
-     "description": "Once set, this invoice will be on hold till the set date",
-     "fieldname": "release_date",
-     "fieldtype": "Date",
-     "label": "Release Date"
-    },
-    {
-     "fieldname": "cb_17",
-     "fieldtype": "Column Break"
-    },
-    {
-     "depends_on": "eval:doc.on_hold",
-     "fieldname": "hold_comment",
-     "fieldtype": "Small Text",
-     "label": "Reason For Putting On Hold"
-    },
-    {
-     "collapsible": 1,
-     "collapsible_depends_on": "bill_no",
-     "fieldname": "supplier_invoice_details",
-     "fieldtype": "Section Break",
-     "label": "Supplier Invoice Details"
-    },
-    {
-     "fieldname": "bill_no",
-     "fieldtype": "Data",
-     "label": "Supplier Invoice No",
-     "oldfieldname": "bill_no",
-     "oldfieldtype": "Data",
-     "print_hide": 1
-    },
-    {
-     "fieldname": "column_break_15",
-     "fieldtype": "Column Break"
-    },
-    {
-     "fieldname": "bill_date",
-     "fieldtype": "Date",
-     "label": "Supplier Invoice Date",
-     "oldfieldname": "bill_date",
-     "oldfieldtype": "Date",
-     "print_hide": 1
-    },
-    {
-     "depends_on": "return_against",
-     "fieldname": "returns",
-     "fieldtype": "Section Break",
-     "label": "Returns"
-    },
-    {
-     "depends_on": "return_against",
-     "fieldname": "return_against",
-     "fieldtype": "Link",
-     "label": "Return Against Purchase Invoice",
-     "no_copy": 1,
-     "options": "Purchase Invoice",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "collapsible": 1,
-     "fieldname": "section_addresses",
-     "fieldtype": "Section Break",
-     "label": "Address and Contact"
-    },
-    {
-     "fieldname": "supplier_address",
-     "fieldtype": "Link",
-     "label": "Select Supplier Address",
-     "options": "Address",
-     "print_hide": 1
-    },
-    {
-     "fieldname": "address_display",
-     "fieldtype": "Small Text",
-     "label": "Address",
-     "read_only": 1
-    },
-    {
-     "fieldname": "contact_person",
-     "fieldtype": "Link",
-     "in_global_search": 1,
-     "label": "Contact Person",
-     "options": "Contact",
-     "print_hide": 1
-    },
-    {
-     "fieldname": "contact_display",
-     "fieldtype": "Small Text",
-     "label": "Contact",
-     "read_only": 1
-    },
-    {
-     "fieldname": "contact_mobile",
-     "fieldtype": "Small Text",
-     "label": "Mobile No",
-     "read_only": 1
-    },
-    {
-     "fieldname": "contact_email",
-     "fieldtype": "Small Text",
-     "label": "Contact Email",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "fieldname": "col_break_address",
-     "fieldtype": "Column Break"
-    },
-    {
-     "fieldname": "shipping_address",
-     "fieldtype": "Link",
-     "label": "Select Shipping Address",
-     "options": "Address",
-     "print_hide": 1
-    },
-    {
-     "fieldname": "shipping_address_display",
-     "fieldtype": "Small Text",
-     "label": "Shipping Address",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "collapsible": 1,
-     "fieldname": "currency_and_price_list",
-     "fieldtype": "Section Break",
-     "label": "Currency and Price List",
-     "options": "fa fa-tag"
-    },
-    {
-     "fieldname": "currency",
-     "fieldtype": "Link",
-     "label": "Currency",
-     "oldfieldname": "currency",
-     "oldfieldtype": "Select",
-     "options": "Currency",
-     "print_hide": 1
-    },
-    {
-     "fieldname": "conversion_rate",
-     "fieldtype": "Float",
-     "label": "Exchange Rate",
-     "oldfieldname": "conversion_rate",
-     "oldfieldtype": "Currency",
-     "precision": "9",
-     "print_hide": 1
-    },
-    {
-     "fieldname": "column_break2",
-     "fieldtype": "Column Break"
-    },
-    {
-     "fieldname": "buying_price_list",
-     "fieldtype": "Link",
-     "label": "Price List",
-     "options": "Price List",
-     "print_hide": 1
-    },
-    {
-     "fieldname": "price_list_currency",
-     "fieldtype": "Link",
-     "label": "Price List Currency",
-     "options": "Currency",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "fieldname": "plc_conversion_rate",
-     "fieldtype": "Float",
-     "label": "Price List Exchange Rate",
-     "precision": "9",
-     "print_hide": 1
-    },
-    {
-     "default": "0",
-     "fieldname": "ignore_pricing_rule",
-     "fieldtype": "Check",
-     "label": "Ignore Pricing Rule",
-     "no_copy": 1,
-     "permlevel": 1,
-     "print_hide": 1
-    },
-    {
-     "fieldname": "sec_warehouse",
-     "fieldtype": "Section Break"
-    },
-    {
-     "depends_on": "update_stock",
-     "fieldname": "set_warehouse",
-     "fieldtype": "Link",
-     "label": "Set Accepted Warehouse",
-     "options": "Warehouse",
-     "print_hide": 1
-    },
-    {
-     "depends_on": "update_stock",
-     "description": "Warehouse where you are maintaining stock of rejected items",
-     "fieldname": "rejected_warehouse",
-     "fieldtype": "Link",
-     "label": "Rejected Warehouse",
-     "no_copy": 1,
-     "options": "Warehouse",
-     "print_hide": 1
-    },
-    {
-     "fieldname": "col_break_warehouse",
-     "fieldtype": "Column Break"
-    },
-    {
-     "default": "No",
-     "fieldname": "is_subcontracted",
-     "fieldtype": "Select",
-     "label": "Raw Materials Supplied",
-     "options": "No\nYes",
-     "print_hide": 1
-    },
-    {
-     "depends_on": "eval:doc.is_subcontracted==\"Yes\"",
-     "fieldname": "supplier_warehouse",
-     "fieldtype": "Link",
-     "label": "Supplier Warehouse",
-     "no_copy": 1,
-     "options": "Warehouse",
-     "print_hide": 1,
-     "print_width": "50px",
-     "width": "50px"
-    },
-    {
-     "fieldname": "items_section",
-     "fieldtype": "Section Break",
-     "oldfieldtype": "Section Break",
-     "options": "fa fa-shopping-cart"
-    },
-    {
-     "default": "0",
-     "fieldname": "update_stock",
-     "fieldtype": "Check",
-     "label": "Update Stock",
-     "print_hide": 1
-    },
-    {
-     "fieldname": "scan_barcode",
-     "fieldtype": "Data",
-     "label": "Scan Barcode"
-    },
-    {
-     "allow_bulk_edit": 1,
-     "fieldname": "items",
-     "fieldtype": "Table",
-     "label": "Items",
-     "oldfieldname": "entries",
-     "oldfieldtype": "Table",
-     "options": "Purchase Invoice Item",
-     "reqd": 1
-    },
-    {
-     "fieldname": "pricing_rule_details",
-     "fieldtype": "Section Break",
-     "label": "Pricing Rules"
-    },
-    {
-     "fieldname": "pricing_rules",
-     "fieldtype": "Table",
-     "label": "Pricing Rule Detail",
-     "options": "Pricing Rule Detail",
-     "read_only": 1
-    },
-    {
-     "collapsible_depends_on": "supplied_items",
-     "fieldname": "raw_materials_supplied",
-     "fieldtype": "Section Break",
-     "label": "Raw Materials Supplied"
-    },
-    {
-     "fieldname": "supplied_items",
-     "fieldtype": "Table",
-     "label": "Supplied Items",
-     "options": "Purchase Receipt Item Supplied",
-     "read_only": 1
-    },
-    {
-     "fieldname": "section_break_26",
-     "fieldtype": "Section Break"
-    },
-    {
-     "fieldname": "total_qty",
-     "fieldtype": "Float",
-     "label": "Total Quantity",
-     "read_only": 1
-    },
-    {
-     "fieldname": "base_total",
-     "fieldtype": "Currency",
-     "label": "Total (Company Currency)",
-     "options": "Company:company:default_currency",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "fieldname": "base_net_total",
-     "fieldtype": "Currency",
-     "label": "Net Total (Company Currency)",
-     "oldfieldname": "net_total",
-     "oldfieldtype": "Currency",
-     "options": "Company:company:default_currency",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "fieldname": "column_break_28",
-     "fieldtype": "Column Break"
-    },
-    {
-     "fieldname": "total",
-     "fieldtype": "Currency",
-     "label": "Total",
-     "options": "currency",
-     "read_only": 1
-    },
-    {
-     "fieldname": "net_total",
-     "fieldtype": "Currency",
-     "label": "Net Total",
-     "oldfieldname": "net_total_import",
-     "oldfieldtype": "Currency",
-     "options": "currency",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "fieldname": "total_net_weight",
-     "fieldtype": "Float",
-     "label": "Total Net Weight",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "fieldname": "taxes_section",
-     "fieldtype": "Section Break",
-     "oldfieldtype": "Section Break",
-     "options": "fa fa-money"
-    },
-    {
-     "fieldname": "tax_category",
-     "fieldtype": "Link",
-     "label": "Tax Category",
-     "options": "Tax Category",
-     "print_hide": 1
-    },
-    {
-     "fieldname": "column_break_49",
-     "fieldtype": "Column Break"
-    },
-    {
-     "fieldname": "shipping_rule",
-     "fieldtype": "Link",
-     "label": "Shipping Rule",
-     "options": "Shipping Rule",
-     "print_hide": 1
-    },
-    {
-     "fieldname": "section_break_51",
-     "fieldtype": "Section Break"
-    },
-    {
-     "fieldname": "taxes_and_charges",
-     "fieldtype": "Link",
-     "label": "Purchase Taxes and Charges Template",
-     "oldfieldname": "purchase_other_charges",
-     "oldfieldtype": "Link",
-     "options": "Purchase Taxes and Charges Template",
-     "print_hide": 1
-    },
-    {
-     "fieldname": "taxes",
-     "fieldtype": "Table",
-     "label": "Purchase Taxes and Charges",
-     "oldfieldname": "purchase_tax_details",
-     "oldfieldtype": "Table",
-     "options": "Purchase Taxes and Charges"
-    },
-    {
-     "collapsible": 1,
-     "fieldname": "sec_tax_breakup",
-     "fieldtype": "Section Break",
-     "label": "Tax Breakup"
-    },
-    {
-     "fieldname": "other_charges_calculation",
-     "fieldtype": "Text",
-     "label": "Taxes and Charges Calculation",
-     "no_copy": 1,
-     "oldfieldtype": "HTML",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "fieldname": "totals",
-     "fieldtype": "Section Break",
-     "oldfieldtype": "Section Break",
-     "options": "fa fa-money"
-    },
-    {
-     "fieldname": "base_taxes_and_charges_added",
-     "fieldtype": "Currency",
-     "label": "Taxes and Charges Added (Company Currency)",
-     "oldfieldname": "other_charges_added",
-     "oldfieldtype": "Currency",
-     "options": "Company:company:default_currency",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "fieldname": "base_taxes_and_charges_deducted",
-     "fieldtype": "Currency",
-     "label": "Taxes and Charges Deducted (Company Currency)",
-     "oldfieldname": "other_charges_deducted",
-     "oldfieldtype": "Currency",
-     "options": "Company:company:default_currency",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "fieldname": "base_total_taxes_and_charges",
-     "fieldtype": "Currency",
-     "label": "Total Taxes and Charges (Company Currency)",
-     "oldfieldname": "total_tax",
-     "oldfieldtype": "Currency",
-     "options": "Company:company:default_currency",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "fieldname": "column_break_40",
-     "fieldtype": "Column Break"
-    },
-    {
-     "fieldname": "taxes_and_charges_added",
-     "fieldtype": "Currency",
-     "label": "Taxes and Charges Added",
-     "oldfieldname": "other_charges_added_import",
-     "oldfieldtype": "Currency",
-     "options": "currency",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "fieldname": "taxes_and_charges_deducted",
-     "fieldtype": "Currency",
-     "label": "Taxes and Charges Deducted",
-     "oldfieldname": "other_charges_deducted_import",
-     "oldfieldtype": "Currency",
-     "options": "currency",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "fieldname": "total_taxes_and_charges",
-     "fieldtype": "Currency",
-     "label": "Total Taxes and Charges",
-     "options": "currency",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "collapsible": 1,
-     "collapsible_depends_on": "discount_amount",
-     "fieldname": "section_break_44",
-     "fieldtype": "Section Break",
-     "label": "Additional Discount"
-    },
-    {
-     "default": "Grand Total",
-     "fieldname": "apply_discount_on",
-     "fieldtype": "Select",
-     "label": "Apply Additional Discount On",
-     "options": "\nGrand Total\nNet Total",
-     "print_hide": 1
-    },
-    {
-     "fieldname": "base_discount_amount",
-     "fieldtype": "Currency",
-     "label": "Additional Discount Amount (Company Currency)",
-     "options": "Company:company:default_currency",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "fieldname": "column_break_46",
-     "fieldtype": "Column Break"
-    },
-    {
-     "fieldname": "additional_discount_percentage",
-     "fieldtype": "Float",
-     "label": "Additional Discount Percentage",
-     "print_hide": 1
-    },
-    {
-     "fieldname": "discount_amount",
-     "fieldtype": "Currency",
-     "label": "Additional Discount Amount",
-     "options": "currency",
-     "print_hide": 1
-    },
-    {
-     "fieldname": "section_break_49",
-     "fieldtype": "Section Break"
-    },
-    {
-     "fieldname": "base_grand_total",
-     "fieldtype": "Currency",
-     "label": "Grand Total (Company Currency)",
-     "oldfieldname": "grand_total",
-     "oldfieldtype": "Currency",
-     "options": "Company:company:default_currency",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "fieldname": "base_rounding_adjustment",
-     "fieldtype": "Currency",
-     "label": "Rounding Adjustment (Company Currency)",
-     "no_copy": 1,
-     "options": "Company:company:default_currency",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "depends_on": "eval:!doc.disable_rounded_total",
-     "fieldname": "base_rounded_total",
-     "fieldtype": "Currency",
-     "label": "Rounded Total (Company Currency)",
-     "no_copy": 1,
-     "options": "Company:company:default_currency",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "fieldname": "base_in_words",
-     "fieldtype": "Data",
-     "label": "In Words (Company Currency)",
-     "oldfieldname": "in_words",
-     "oldfieldtype": "Data",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "fieldname": "column_break8",
-     "fieldtype": "Column Break",
-     "oldfieldtype": "Column Break",
-     "print_hide": 1,
-     "width": "50%"
-    },
-    {
-     "fieldname": "grand_total",
-     "fieldtype": "Currency",
-     "in_list_view": 1,
-     "label": "Grand Total",
-     "oldfieldname": "grand_total_import",
-     "oldfieldtype": "Currency",
-     "options": "currency",
-     "read_only": 1
-    },
-    {
-     "fieldname": "rounding_adjustment",
-     "fieldtype": "Currency",
-     "label": "Rounding Adjustment",
-     "no_copy": 1,
-     "options": "currency",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "depends_on": "eval:!doc.disable_rounded_total",
-     "fieldname": "rounded_total",
-     "fieldtype": "Currency",
-     "label": "Rounded Total",
-     "no_copy": 1,
-     "options": "currency",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "fieldname": "in_words",
-     "fieldtype": "Data",
-     "label": "In Words",
-     "oldfieldname": "in_words_import",
-     "oldfieldtype": "Data",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "fieldname": "total_advance",
-     "fieldtype": "Currency",
-     "label": "Total Advance",
-     "no_copy": 1,
-     "oldfieldname": "total_advance",
-     "oldfieldtype": "Currency",
-     "options": "party_account_currency",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "fieldname": "outstanding_amount",
-     "fieldtype": "Currency",
-     "label": "Outstanding Amount",
-     "no_copy": 1,
-     "oldfieldname": "outstanding_amount",
-     "oldfieldtype": "Currency",
-     "options": "party_account_currency",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "default": "0",
-     "depends_on": "grand_total",
-     "fieldname": "disable_rounded_total",
-     "fieldtype": "Check",
-     "label": "Disable Rounded Total"
-    },
-    {
-     "collapsible": 1,
-     "collapsible_depends_on": "paid_amount",
-     "depends_on": "eval:doc.is_paid===1||(doc.advances && doc.advances.length>0)",
-     "fieldname": "payments_section",
-     "fieldtype": "Section Break",
-     "label": "Payments"
-    },
-    {
-     "fieldname": "mode_of_payment",
-     "fieldtype": "Link",
-     "label": "Mode of Payment",
-     "options": "Mode of Payment",
-     "print_hide": 1
-    },
-    {
-     "fieldname": "cash_bank_account",
-     "fieldtype": "Link",
-     "label": "Cash/Bank Account",
-     "options": "Account"
-    },
-    {
-     "fieldname": "clearance_date",
-     "fieldtype": "Date",
-     "hidden": 1,
-     "label": "Clearance Date"
-     },
-    {
-     "fieldname": "col_br_payments",
-     "fieldtype": "Column Break"
-    },
-    {
-     "depends_on": "is_paid",
-     "fieldname": "paid_amount",
-     "fieldtype": "Currency",
-     "label": "Paid Amount",
-     "no_copy": 1,
-     "options": "currency",
-     "print_hide": 1
-    },
-    {
-     "fieldname": "base_paid_amount",
-     "fieldtype": "Currency",
-     "label": "Paid Amount (Company Currency)",
-     "no_copy": 1,
-     "options": "Company:company:default_currency",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "collapsible": 1,
-     "collapsible_depends_on": "write_off_amount",
-     "depends_on": "grand_total",
-     "fieldname": "write_off",
-     "fieldtype": "Section Break",
-     "label": "Write Off"
-    },
-    {
-     "fieldname": "write_off_amount",
-     "fieldtype": "Currency",
-     "label": "Write Off Amount",
-     "no_copy": 1,
-     "options": "currency",
-     "print_hide": 1
-    },
-    {
-     "fieldname": "base_write_off_amount",
-     "fieldtype": "Currency",
-     "label": "Write Off Amount (Company Currency)",
-     "no_copy": 1,
-     "options": "Company:company:default_currency",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "fieldname": "column_break_61",
-     "fieldtype": "Column Break"
-    },
-    {
-     "depends_on": "eval:flt(doc.write_off_amount)!=0",
-     "fieldname": "write_off_account",
-     "fieldtype": "Link",
-     "label": "Write Off Account",
-     "options": "Account",
-     "print_hide": 1
-    },
-    {
-     "depends_on": "eval:flt(doc.write_off_amount)!=0",
-     "fieldname": "write_off_cost_center",
-     "fieldtype": "Link",
-     "label": "Write Off Cost Center",
-     "options": "Cost Center",
-     "print_hide": 1
-    },
-    {
-     "collapsible": 1,
-     "collapsible_depends_on": "advances",
-     "fieldname": "advances_section",
-     "fieldtype": "Section Break",
-     "label": "Advance Payments",
-     "oldfieldtype": "Section Break",
-     "options": "fa fa-money",
-     "print_hide": 1
-    },
-    {
-     "default": "0",
-     "fieldname": "allocate_advances_automatically",
-     "fieldtype": "Check",
-     "label": "Set Advances and Allocate (FIFO)"
-    },
-    {
-     "depends_on": "eval:!doc.allocate_advances_automatically",
-     "fieldname": "get_advances",
-     "fieldtype": "Button",
-     "label": "Get Advances Paid",
-     "oldfieldtype": "Button",
-     "print_hide": 1
-    },
-    {
-     "fieldname": "advances",
-     "fieldtype": "Table",
-     "label": "Advances",
-     "no_copy": 1,
-     "oldfieldname": "advance_allocation_details",
-     "oldfieldtype": "Table",
-     "options": "Purchase Invoice Advance",
-     "print_hide": 1
-    },
-    {
-     "collapsible": 1,
-     "collapsible_depends_on": "eval:(!doc.is_return)",
-     "fieldname": "payment_schedule_section",
-     "fieldtype": "Section Break",
-     "label": "Payment Terms"
-    },
-    {
-     "fieldname": "payment_terms_template",
-     "fieldtype": "Link",
-     "label": "Payment Terms Template",
-     "options": "Payment Terms Template"
-    },
-    {
-     "fieldname": "payment_schedule",
-     "fieldtype": "Table",
-     "label": "Payment Schedule",
-     "no_copy": 1,
-     "options": "Payment Schedule",
-     "print_hide": 1
-    },
-    {
-     "collapsible": 1,
-     "collapsible_depends_on": "terms",
-     "fieldname": "terms_section_break",
-     "fieldtype": "Section Break",
-     "label": "Terms and Conditions",
-     "options": "fa fa-legal"
-    },
-    {
-     "fieldname": "tc_name",
-     "fieldtype": "Link",
-     "label": "Terms",
-     "options": "Terms and Conditions",
-     "print_hide": 1
-    },
-    {
-     "fieldname": "terms",
-     "fieldtype": "Text Editor",
-     "label": "Terms and Conditions1"
-    },
-    {
-     "collapsible": 1,
-     "fieldname": "printing_settings",
-     "fieldtype": "Section Break",
-     "label": "Printing Settings"
-    },
-    {
-     "allow_on_submit": 1,
-     "fieldname": "letter_head",
-     "fieldtype": "Link",
-     "label": "Letter Head",
-     "options": "Letter Head",
-     "print_hide": 1
-    },
-    {
-     "allow_on_submit": 1,
-     "default": "0",
-     "fieldname": "group_same_items",
-     "fieldtype": "Check",
-     "label": "Group same items",
-     "print_hide": 1
-    },
-    {
-     "fieldname": "column_break_112",
-     "fieldtype": "Column Break"
-    },
-    {
-     "allow_on_submit": 1,
-     "fieldname": "select_print_heading",
-     "fieldtype": "Link",
-     "label": "Print Heading",
-     "no_copy": 1,
-     "oldfieldname": "select_print_heading",
-     "oldfieldtype": "Link",
-     "options": "Print Heading",
-     "print_hide": 1,
-     "report_hide": 1
-    },
-    {
-     "fieldname": "language",
-     "fieldtype": "Data",
-     "label": "Print Language",
-     "read_only": 1
-    },
-    {
-     "collapsible": 1,
-     "fieldname": "more_info",
-     "fieldtype": "Section Break",
-     "label": "More Information",
-     "oldfieldtype": "Section Break",
-     "options": "fa fa-file-text",
-     "print_hide": 1
-    },
-    {
-     "fieldname": "credit_to",
-     "fieldtype": "Link",
-     "label": "Credit To",
-     "oldfieldname": "credit_to",
-     "oldfieldtype": "Link",
-     "options": "Account",
-     "print_hide": 1,
-     "reqd": 1,
-     "search_index": 1
-    },
-    {
-     "fieldname": "party_account_currency",
-     "fieldtype": "Link",
-     "hidden": 1,
-     "label": "Party Account Currency",
-     "no_copy": 1,
-     "options": "Currency",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "default": "No",
-     "fieldname": "is_opening",
-     "fieldtype": "Select",
-     "label": "Is Opening",
-     "oldfieldname": "is_opening",
-     "oldfieldtype": "Select",
-     "options": "No\nYes",
-     "print_hide": 1
-    },
-    {
-     "fieldname": "against_expense_account",
-     "fieldtype": "Small Text",
-     "hidden": 1,
-     "label": "Against Expense Account",
-     "no_copy": 1,
-     "oldfieldname": "against_expense_account",
-     "oldfieldtype": "Small Text",
-     "print_hide": 1
-    },
-    {
-     "fieldname": "column_break_63",
-     "fieldtype": "Column Break"
-    },
-    {
-     "default": "Draft",
-     "fieldname": "status",
-     "fieldtype": "Select",
-     "in_standard_filter": 1,
-     "label": "Status",
-     "options": "\nDraft\nReturn\nDebit Note Issued\nSubmitted\nPaid\nUnpaid\nOverdue\nCancelled"
-    },
-    {
-     "fieldname": "inter_company_invoice_reference",
-     "fieldtype": "Link",
-     "label": "Inter Company Invoice Reference",
-     "options": "Sales Invoice",
-     "read_only": 1
-    },
-    {
-     "fieldname": "remarks",
-     "fieldtype": "Small Text",
-     "label": "Remarks",
-     "no_copy": 1,
-     "oldfieldname": "remarks",
-     "oldfieldtype": "Text",
-     "print_hide": 1
-    },
-    {
-     "fieldname": "subscription_section",
-     "fieldtype": "Section Break",
-     "label": "Subscription Section",
-     "print_hide": 1
-    },
-    {
-     "allow_on_submit": 1,
-     "description": "Start date of current invoice's period",
-     "fieldname": "from_date",
-     "fieldtype": "Date",
-     "label": "From Date",
-     "no_copy": 1,
-     "print_hide": 1
-    },
-    {
-     "allow_on_submit": 1,
-     "description": "End date of current invoice's period",
-     "fieldname": "to_date",
-     "fieldtype": "Date",
-     "label": "To Date",
-     "no_copy": 1,
-     "print_hide": 1
-    },
-    {
-     "fieldname": "column_break_114",
-     "fieldtype": "Column Break"
-    },
-    {
-     "fieldname": "auto_repeat",
-     "fieldtype": "Link",
-     "label": "Auto Repeat",
-     "no_copy": 1,
-     "options": "Auto Repeat",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "allow_on_submit": 1,
-     "depends_on": "eval: doc.auto_repeat",
-     "fieldname": "update_auto_repeat_reference",
-     "fieldtype": "Button",
-     "label": "Update Auto Repeat Reference"
-    },
-    {
-     "collapsible": 1,
-     "fieldname": "accounting_dimensions_section",
-     "fieldtype": "Section Break",
-     "label": "Accounting Dimensions "
-    },
-    {
-     "fieldname": "dimension_col_break",
-     "fieldtype": "Column Break"
-    }
-   ],
-   "icon": "fa fa-file-text",
-   "idx": 204,
-   "is_submittable": 1,
-   "modified": "2019-06-18 22:04:28.889159",
-   "modified_by": "Administrator",
-   "module": "Accounts",
-   "name": "Purchase Invoice",
-   "name_case": "Title Case",
-   "owner": "Administrator",
-   "permissions": [
-    {
-     "amend": 1,
-     "cancel": 1,
-     "create": 1,
-     "email": 1,
-     "print": 1,
-     "read": 1,
-     "report": 1,
-     "role": "Accounts User",
-     "share": 1,
-     "submit": 1,
-     "write": 1
-    },
-    {
-     "email": 1,
-     "print": 1,
-     "read": 1,
-     "report": 1,
-     "role": "Purchase User"
-    },
-    {
-     "amend": 1,
-     "cancel": 1,
-     "create": 1,
-     "delete": 1,
-     "email": 1,
-     "print": 1,
-     "read": 1,
-     "report": 1,
-     "role": "Accounts Manager",
-     "share": 1,
-     "submit": 1,
-     "write": 1
-    },
-    {
-     "email": 1,
-     "print": 1,
-     "read": 1,
-     "report": 1,
-     "role": "Auditor"
-    },
-    {
-     "permlevel": 1,
-     "read": 1,
-     "role": "Accounts Manager",
-     "write": 1
-    }
-   ],
-   "search_fields": "posting_date, supplier, bill_no, base_grand_total, outstanding_amount",
-   "show_name_in_global_search": 1,
-   "sort_field": "modified",
-   "sort_order": "DESC",
-   "timeline_field": "supplier",
-   "title_field": "title",
-   "track_changes": 1
+ "allow_import": 1,
+ "autoname": "naming_series:",
+ "creation": "2013-05-21 16:16:39",
+ "doctype": "DocType",
+ "document_type": "Document",
+ "engine": "InnoDB",
+ "field_order": [
+  "title",
+  "naming_series",
+  "supplier",
+  "supplier_name",
+  "tax_id",
+  "due_date",
+  "is_paid",
+  "is_return",
+  "apply_tds",
+  "column_break1",
+  "company",
+  "posting_date",
+  "posting_time",
+  "set_posting_time",
+  "amended_from",
+  "accounting_dimensions_section",
+  "cost_center",
+  "dimension_col_break",
+  "sb_14",
+  "on_hold",
+  "release_date",
+  "cb_17",
+  "hold_comment",
+  "supplier_invoice_details",
+  "bill_no",
+  "column_break_15",
+  "bill_date",
+  "returns",
+  "return_against",
+  "section_addresses",
+  "supplier_address",
+  "address_display",
+  "contact_person",
+  "contact_display",
+  "contact_mobile",
+  "contact_email",
+  "col_break_address",
+  "shipping_address",
+  "shipping_address_display",
+  "currency_and_price_list",
+  "currency",
+  "conversion_rate",
+  "column_break2",
+  "buying_price_list",
+  "price_list_currency",
+  "plc_conversion_rate",
+  "ignore_pricing_rule",
+  "sec_warehouse",
+  "set_warehouse",
+  "rejected_warehouse",
+  "col_break_warehouse",
+  "is_subcontracted",
+  "supplier_warehouse",
+  "items_section",
+  "update_stock",
+  "scan_barcode",
+  "items",
+  "pricing_rule_details",
+  "pricing_rules",
+  "raw_materials_supplied",
+  "supplied_items",
+  "section_break_26",
+  "total_qty",
+  "base_total",
+  "base_net_total",
+  "column_break_28",
+  "total",
+  "net_total",
+  "total_net_weight",
+  "taxes_section",
+  "tax_category",
+  "column_break_49",
+  "shipping_rule",
+  "section_break_51",
+  "taxes_and_charges",
+  "taxes",
+  "sec_tax_breakup",
+  "other_charges_calculation",
+  "totals",
+  "base_taxes_and_charges_added",
+  "base_taxes_and_charges_deducted",
+  "base_total_taxes_and_charges",
+  "column_break_40",
+  "taxes_and_charges_added",
+  "taxes_and_charges_deducted",
+  "total_taxes_and_charges",
+  "section_break_44",
+  "apply_discount_on",
+  "base_discount_amount",
+  "column_break_46",
+  "additional_discount_percentage",
+  "discount_amount",
+  "section_break_49",
+  "base_grand_total",
+  "base_rounding_adjustment",
+  "base_rounded_total",
+  "base_in_words",
+  "column_break8",
+  "grand_total",
+  "rounding_adjustment",
+  "rounded_total",
+  "in_words",
+  "total_advance",
+  "outstanding_amount",
+  "disable_rounded_total",
+  "payments_section",
+  "mode_of_payment",
+  "cash_bank_account",
+  "clearance_date",
+  "col_br_payments",
+  "paid_amount",
+  "base_paid_amount",
+  "write_off",
+  "write_off_amount",
+  "base_write_off_amount",
+  "column_break_61",
+  "write_off_account",
+  "write_off_cost_center",
+  "advances_section",
+  "allocate_advances_automatically",
+  "get_advances",
+  "advances",
+  "payment_schedule_section",
+  "payment_terms_template",
+  "payment_schedule",
+  "terms_section_break",
+  "tc_name",
+  "terms",
+  "printing_settings",
+  "letter_head",
+  "group_same_items",
+  "column_break_112",
+  "select_print_heading",
+  "language",
+  "more_info",
+  "credit_to",
+  "party_account_currency",
+  "is_opening",
+  "against_expense_account",
+  "column_break_63",
+  "status",
+  "inter_company_invoice_reference",
+  "remarks",
+  "subscription_section",
+  "from_date",
+  "to_date",
+  "column_break_114",
+  "auto_repeat",
+  "update_auto_repeat_reference"
+ ],
+ "fields": [
+  {
+   "allow_on_submit": 1,
+   "default": "{supplier_name}",
+   "fieldname": "title",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Title",
+   "no_copy": 1,
+   "print_hide": 1
+  },
+  {
+   "fieldname": "naming_series",
+   "fieldtype": "Select",
+   "label": "Series",
+   "no_copy": 1,
+   "oldfieldname": "naming_series",
+   "oldfieldtype": "Select",
+   "options": "ACC-PINV-.YYYY.-",
+   "print_hide": 1,
+   "reqd": 1,
+   "set_only_once": 1
+  },
+  {
+   "fieldname": "supplier",
+   "fieldtype": "Link",
+   "in_standard_filter": 1,
+   "label": "Supplier",
+   "oldfieldname": "supplier",
+   "oldfieldtype": "Link",
+   "options": "Supplier",
+   "print_hide": 1,
+   "search_index": 1
+  },
+  {
+   "bold": 1,
+   "depends_on": "supplier",
+   "fetch_from": "supplier.supplier_name",
+   "fieldname": "supplier_name",
+   "fieldtype": "Data",
+   "in_global_search": 1,
+   "label": "Supplier Name",
+   "oldfieldname": "supplier_name",
+   "oldfieldtype": "Data",
+   "read_only": 1
+  },
+  {
+   "fetch_from": "supplier.tax_id",
+   "fieldname": "tax_id",
+   "fieldtype": "Read Only",
+   "label": "Tax Id",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "due_date",
+   "fieldtype": "Date",
+   "label": "Due Date",
+   "oldfieldname": "due_date",
+   "oldfieldtype": "Date"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_paid",
+   "fieldtype": "Check",
+   "label": "Is Paid",
+   "print_hide": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "is_return",
+   "fieldtype": "Check",
+   "label": "Is Return (Debit Note)",
+   "no_copy": 1,
+   "print_hide": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "apply_tds",
+   "fieldtype": "Check",
+   "label": "Apply Tax Withholding Amount",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "column_break1",
+   "fieldtype": "Column Break",
+   "oldfieldtype": "Column Break",
+   "width": "50%"
+  },
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "in_standard_filter": 1,
+   "label": "Company",
+   "options": "Company",
+   "print_hide": 1,
+   "remember_last_selected_value": 1
+  },
+  {
+   "fieldname": "cost_center",
+   "fieldtype": "Link",
+   "label": "Cost Center",
+   "options": "Cost Center"
+  },
+  {
+   "default": "Today",
+   "fieldname": "posting_date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Date",
+   "oldfieldname": "posting_date",
+   "oldfieldtype": "Date",
+   "print_hide": 1,
+   "reqd": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "posting_time",
+   "fieldtype": "Time",
+   "label": "Posting Time",
+   "no_copy": 1,
+   "print_hide": 1,
+   "print_width": "100px",
+   "width": "100px"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.docstatus==0",
+   "fieldname": "set_posting_time",
+   "fieldtype": "Check",
+   "label": "Edit Posting Date and Time",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "ignore_user_permissions": 1,
+   "label": "Amended From",
+   "no_copy": 1,
+   "oldfieldname": "amended_from",
+   "oldfieldtype": "Link",
+   "options": "Purchase Invoice",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "collapsible_depends_on": "eval:doc.on_hold",
+   "fieldname": "sb_14",
+   "fieldtype": "Section Break",
+   "label": "Hold Invoice"
+  },
+  {
+   "default": "0",
+   "fieldname": "on_hold",
+   "fieldtype": "Check",
+   "label": "Hold Invoice"
+  },
+  {
+   "depends_on": "eval:doc.on_hold",
+   "description": "Once set, this invoice will be on hold till the set date",
+   "fieldname": "release_date",
+   "fieldtype": "Date",
+   "label": "Release Date"
+  },
+  {
+   "fieldname": "cb_17",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "eval:doc.on_hold",
+   "fieldname": "hold_comment",
+   "fieldtype": "Small Text",
+   "label": "Reason For Putting On Hold"
+  },
+  {
+   "collapsible": 1,
+   "collapsible_depends_on": "bill_no",
+   "fieldname": "supplier_invoice_details",
+   "fieldtype": "Section Break",
+   "label": "Supplier Invoice Details"
+  },
+  {
+   "fieldname": "bill_no",
+   "fieldtype": "Data",
+   "label": "Supplier Invoice No",
+   "oldfieldname": "bill_no",
+   "oldfieldtype": "Data",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "column_break_15",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "bill_date",
+   "fieldtype": "Date",
+   "label": "Supplier Invoice Date",
+   "oldfieldname": "bill_date",
+   "oldfieldtype": "Date",
+   "print_hide": 1
+  },
+  {
+   "depends_on": "return_against",
+   "fieldname": "returns",
+   "fieldtype": "Section Break",
+   "label": "Returns"
+  },
+  {
+   "depends_on": "return_against",
+   "fieldname": "return_against",
+   "fieldtype": "Link",
+   "label": "Return Against Purchase Invoice",
+   "no_copy": 1,
+   "options": "Purchase Invoice",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "section_addresses",
+   "fieldtype": "Section Break",
+   "label": "Address and Contact"
+  },
+  {
+   "fieldname": "supplier_address",
+   "fieldtype": "Link",
+   "label": "Select Supplier Address",
+   "options": "Address",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "address_display",
+   "fieldtype": "Small Text",
+   "label": "Address",
+   "read_only": 1
+  },
+  {
+   "fieldname": "contact_person",
+   "fieldtype": "Link",
+   "in_global_search": 1,
+   "label": "Contact Person",
+   "options": "Contact",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "contact_display",
+   "fieldtype": "Small Text",
+   "label": "Contact",
+   "read_only": 1
+  },
+  {
+   "fieldname": "contact_mobile",
+   "fieldtype": "Small Text",
+   "label": "Mobile No",
+   "read_only": 1
+  },
+  {
+   "fieldname": "contact_email",
+   "fieldtype": "Small Text",
+   "label": "Contact Email",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "col_break_address",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "shipping_address",
+   "fieldtype": "Link",
+   "label": "Select Shipping Address",
+   "options": "Address",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "shipping_address_display",
+   "fieldtype": "Small Text",
+   "label": "Shipping Address",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "currency_and_price_list",
+   "fieldtype": "Section Break",
+   "label": "Currency and Price List",
+   "options": "fa fa-tag"
+  },
+  {
+   "fieldname": "currency",
+   "fieldtype": "Link",
+   "label": "Currency",
+   "oldfieldname": "currency",
+   "oldfieldtype": "Select",
+   "options": "Currency",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "conversion_rate",
+   "fieldtype": "Float",
+   "label": "Exchange Rate",
+   "oldfieldname": "conversion_rate",
+   "oldfieldtype": "Currency",
+   "precision": "9",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "column_break2",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "buying_price_list",
+   "fieldtype": "Link",
+   "label": "Price List",
+   "options": "Price List",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "price_list_currency",
+   "fieldtype": "Link",
+   "label": "Price List Currency",
+   "options": "Currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "plc_conversion_rate",
+   "fieldtype": "Float",
+   "label": "Price List Exchange Rate",
+   "precision": "9",
+   "print_hide": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "ignore_pricing_rule",
+   "fieldtype": "Check",
+   "label": "Ignore Pricing Rule",
+   "no_copy": 1,
+   "permlevel": 1,
+   "print_hide": 1
+  },
+  {
+   "fieldname": "sec_warehouse",
+   "fieldtype": "Section Break"
+  },
+  {
+   "depends_on": "update_stock",
+   "fieldname": "set_warehouse",
+   "fieldtype": "Link",
+   "label": "Set Accepted Warehouse",
+   "options": "Warehouse",
+   "print_hide": 1
+  },
+  {
+   "depends_on": "update_stock",
+   "description": "Warehouse where you are maintaining stock of rejected items",
+   "fieldname": "rejected_warehouse",
+   "fieldtype": "Link",
+   "label": "Rejected Warehouse",
+   "no_copy": 1,
+   "options": "Warehouse",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "col_break_warehouse",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "No",
+   "fieldname": "is_subcontracted",
+   "fieldtype": "Select",
+   "label": "Raw Materials Supplied",
+   "options": "No\nYes",
+   "print_hide": 1
+  },
+  {
+   "depends_on": "eval:doc.is_subcontracted==\"Yes\"",
+   "fieldname": "supplier_warehouse",
+   "fieldtype": "Link",
+   "label": "Supplier Warehouse",
+   "no_copy": 1,
+   "options": "Warehouse",
+   "print_hide": 1,
+   "print_width": "50px",
+   "width": "50px"
+  },
+  {
+   "fieldname": "items_section",
+   "fieldtype": "Section Break",
+   "oldfieldtype": "Section Break",
+   "options": "fa fa-shopping-cart"
+  },
+  {
+   "default": "0",
+   "fieldname": "update_stock",
+   "fieldtype": "Check",
+   "label": "Update Stock",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "scan_barcode",
+   "fieldtype": "Data",
+   "label": "Scan Barcode"
+  },
+  {
+   "allow_bulk_edit": 1,
+   "fieldname": "items",
+   "fieldtype": "Table",
+   "label": "Items",
+   "oldfieldname": "entries",
+   "oldfieldtype": "Table",
+   "options": "Purchase Invoice Item",
+   "reqd": 1
+  },
+  {
+   "fieldname": "pricing_rule_details",
+   "fieldtype": "Section Break",
+   "label": "Pricing Rules"
+  },
+  {
+   "fieldname": "pricing_rules",
+   "fieldtype": "Table",
+   "label": "Pricing Rule Detail",
+   "options": "Pricing Rule Detail",
+   "read_only": 1
+  },
+  {
+   "collapsible_depends_on": "supplied_items",
+   "fieldname": "raw_materials_supplied",
+   "fieldtype": "Section Break",
+   "label": "Raw Materials Supplied"
+  },
+  {
+   "fieldname": "supplied_items",
+   "fieldtype": "Table",
+   "label": "Supplied Items",
+   "options": "Purchase Receipt Item Supplied",
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_26",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "total_qty",
+   "fieldtype": "Float",
+   "label": "Total Quantity",
+   "read_only": 1
+  },
+  {
+   "fieldname": "base_total",
+   "fieldtype": "Currency",
+   "label": "Total (Company Currency)",
+   "options": "Company:company:default_currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "base_net_total",
+   "fieldtype": "Currency",
+   "label": "Net Total (Company Currency)",
+   "oldfieldname": "net_total",
+   "oldfieldtype": "Currency",
+   "options": "Company:company:default_currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_28",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "total",
+   "fieldtype": "Currency",
+   "label": "Total",
+   "options": "currency",
+   "read_only": 1
+  },
+  {
+   "fieldname": "net_total",
+   "fieldtype": "Currency",
+   "label": "Net Total",
+   "oldfieldname": "net_total_import",
+   "oldfieldtype": "Currency",
+   "options": "currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "total_net_weight",
+   "fieldtype": "Float",
+   "label": "Total Net Weight",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "taxes_section",
+   "fieldtype": "Section Break",
+   "oldfieldtype": "Section Break",
+   "options": "fa fa-money"
+  },
+  {
+   "fieldname": "tax_category",
+   "fieldtype": "Link",
+   "label": "Tax Category",
+   "options": "Tax Category",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "column_break_49",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "shipping_rule",
+   "fieldtype": "Link",
+   "label": "Shipping Rule",
+   "options": "Shipping Rule",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "section_break_51",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "taxes_and_charges",
+   "fieldtype": "Link",
+   "label": "Purchase Taxes and Charges Template",
+   "oldfieldname": "purchase_other_charges",
+   "oldfieldtype": "Link",
+   "options": "Purchase Taxes and Charges Template",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "taxes",
+   "fieldtype": "Table",
+   "label": "Purchase Taxes and Charges",
+   "oldfieldname": "purchase_tax_details",
+   "oldfieldtype": "Table",
+   "options": "Purchase Taxes and Charges"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "sec_tax_breakup",
+   "fieldtype": "Section Break",
+   "label": "Tax Breakup"
+  },
+  {
+   "fieldname": "other_charges_calculation",
+   "fieldtype": "Text",
+   "label": "Taxes and Charges Calculation",
+   "no_copy": 1,
+   "oldfieldtype": "HTML",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "totals",
+   "fieldtype": "Section Break",
+   "oldfieldtype": "Section Break",
+   "options": "fa fa-money"
+  },
+  {
+   "fieldname": "base_taxes_and_charges_added",
+   "fieldtype": "Currency",
+   "label": "Taxes and Charges Added (Company Currency)",
+   "oldfieldname": "other_charges_added",
+   "oldfieldtype": "Currency",
+   "options": "Company:company:default_currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "base_taxes_and_charges_deducted",
+   "fieldtype": "Currency",
+   "label": "Taxes and Charges Deducted (Company Currency)",
+   "oldfieldname": "other_charges_deducted",
+   "oldfieldtype": "Currency",
+   "options": "Company:company:default_currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "base_total_taxes_and_charges",
+   "fieldtype": "Currency",
+   "label": "Total Taxes and Charges (Company Currency)",
+   "oldfieldname": "total_tax",
+   "oldfieldtype": "Currency",
+   "options": "Company:company:default_currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_40",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "taxes_and_charges_added",
+   "fieldtype": "Currency",
+   "label": "Taxes and Charges Added",
+   "oldfieldname": "other_charges_added_import",
+   "oldfieldtype": "Currency",
+   "options": "currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "taxes_and_charges_deducted",
+   "fieldtype": "Currency",
+   "label": "Taxes and Charges Deducted",
+   "oldfieldname": "other_charges_deducted_import",
+   "oldfieldtype": "Currency",
+   "options": "currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "total_taxes_and_charges",
+   "fieldtype": "Currency",
+   "label": "Total Taxes and Charges",
+   "options": "currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "collapsible_depends_on": "discount_amount",
+   "fieldname": "section_break_44",
+   "fieldtype": "Section Break",
+   "label": "Additional Discount"
+  },
+  {
+   "default": "Grand Total",
+   "fieldname": "apply_discount_on",
+   "fieldtype": "Select",
+   "label": "Apply Additional Discount On",
+   "options": "\nGrand Total\nNet Total",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "base_discount_amount",
+   "fieldtype": "Currency",
+   "label": "Additional Discount Amount (Company Currency)",
+   "options": "Company:company:default_currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_46",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "additional_discount_percentage",
+   "fieldtype": "Float",
+   "label": "Additional Discount Percentage",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "discount_amount",
+   "fieldtype": "Currency",
+   "label": "Additional Discount Amount",
+   "options": "currency",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "section_break_49",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "base_grand_total",
+   "fieldtype": "Currency",
+   "label": "Grand Total (Company Currency)",
+   "oldfieldname": "grand_total",
+   "oldfieldtype": "Currency",
+   "options": "Company:company:default_currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "base_rounding_adjustment",
+   "fieldtype": "Currency",
+   "label": "Rounding Adjustment (Company Currency)",
+   "no_copy": 1,
+   "options": "Company:company:default_currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval:!doc.disable_rounded_total",
+   "fieldname": "base_rounded_total",
+   "fieldtype": "Currency",
+   "label": "Rounded Total (Company Currency)",
+   "no_copy": 1,
+   "options": "Company:company:default_currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "base_in_words",
+   "fieldtype": "Data",
+   "label": "In Words (Company Currency)",
+   "oldfieldname": "in_words",
+   "oldfieldtype": "Data",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break8",
+   "fieldtype": "Column Break",
+   "oldfieldtype": "Column Break",
+   "print_hide": 1,
+   "width": "50%"
+  },
+  {
+   "fieldname": "grand_total",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Grand Total",
+   "oldfieldname": "grand_total_import",
+   "oldfieldtype": "Currency",
+   "options": "currency",
+   "read_only": 1
+  },
+  {
+   "fieldname": "rounding_adjustment",
+   "fieldtype": "Currency",
+   "label": "Rounding Adjustment",
+   "no_copy": 1,
+   "options": "currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval:!doc.disable_rounded_total",
+   "fieldname": "rounded_total",
+   "fieldtype": "Currency",
+   "label": "Rounded Total",
+   "no_copy": 1,
+   "options": "currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "in_words",
+   "fieldtype": "Data",
+   "label": "In Words",
+   "oldfieldname": "in_words_import",
+   "oldfieldtype": "Data",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "total_advance",
+   "fieldtype": "Currency",
+   "label": "Total Advance",
+   "no_copy": 1,
+   "oldfieldname": "total_advance",
+   "oldfieldtype": "Currency",
+   "options": "party_account_currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "outstanding_amount",
+   "fieldtype": "Currency",
+   "label": "Outstanding Amount",
+   "no_copy": 1,
+   "oldfieldname": "outstanding_amount",
+   "oldfieldtype": "Currency",
+   "options": "party_account_currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "depends_on": "grand_total",
+   "fieldname": "disable_rounded_total",
+   "fieldtype": "Check",
+   "label": "Disable Rounded Total"
+  },
+  {
+   "collapsible": 1,
+   "collapsible_depends_on": "paid_amount",
+   "depends_on": "eval:doc.is_paid===1||(doc.advances && doc.advances.length>0)",
+   "fieldname": "payments_section",
+   "fieldtype": "Section Break",
+   "label": "Payments"
+  },
+  {
+   "fieldname": "mode_of_payment",
+   "fieldtype": "Link",
+   "label": "Mode of Payment",
+   "options": "Mode of Payment",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "cash_bank_account",
+   "fieldtype": "Link",
+   "label": "Cash/Bank Account",
+   "options": "Account"
+  },
+  {
+   "fieldname": "clearance_date",
+   "fieldtype": "Date",
+   "hidden": 1,
+   "label": "Clearance Date"
+  },
+  {
+   "fieldname": "col_br_payments",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "is_paid",
+   "fieldname": "paid_amount",
+   "fieldtype": "Currency",
+   "label": "Paid Amount",
+   "no_copy": 1,
+   "options": "currency",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "base_paid_amount",
+   "fieldtype": "Currency",
+   "label": "Paid Amount (Company Currency)",
+   "no_copy": 1,
+   "options": "Company:company:default_currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "collapsible_depends_on": "write_off_amount",
+   "depends_on": "grand_total",
+   "fieldname": "write_off",
+   "fieldtype": "Section Break",
+   "label": "Write Off"
+  },
+  {
+   "fieldname": "write_off_amount",
+   "fieldtype": "Currency",
+   "label": "Write Off Amount",
+   "no_copy": 1,
+   "options": "currency",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "base_write_off_amount",
+   "fieldtype": "Currency",
+   "label": "Write Off Amount (Company Currency)",
+   "no_copy": 1,
+   "options": "Company:company:default_currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_61",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "eval:flt(doc.write_off_amount)!=0",
+   "fieldname": "write_off_account",
+   "fieldtype": "Link",
+   "label": "Write Off Account",
+   "options": "Account",
+   "print_hide": 1
+  },
+  {
+   "depends_on": "eval:flt(doc.write_off_amount)!=0",
+   "fieldname": "write_off_cost_center",
+   "fieldtype": "Link",
+   "label": "Write Off Cost Center",
+   "options": "Cost Center",
+   "print_hide": 1
+  },
+  {
+   "collapsible": 1,
+   "collapsible_depends_on": "advances",
+   "fieldname": "advances_section",
+   "fieldtype": "Section Break",
+   "label": "Advance Payments",
+   "oldfieldtype": "Section Break",
+   "options": "fa fa-money",
+   "print_hide": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "allocate_advances_automatically",
+   "fieldtype": "Check",
+   "label": "Set Advances and Allocate (FIFO)"
+  },
+  {
+   "depends_on": "eval:!doc.allocate_advances_automatically",
+   "fieldname": "get_advances",
+   "fieldtype": "Button",
+   "label": "Get Advances Paid",
+   "oldfieldtype": "Button",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "advances",
+   "fieldtype": "Table",
+   "label": "Advances",
+   "no_copy": 1,
+   "oldfieldname": "advance_allocation_details",
+   "oldfieldtype": "Table",
+   "options": "Purchase Invoice Advance",
+   "print_hide": 1
+  },
+  {
+   "collapsible": 1,
+   "collapsible_depends_on": "eval:(!doc.is_return)",
+   "fieldname": "payment_schedule_section",
+   "fieldtype": "Section Break",
+   "label": "Payment Terms"
+  },
+  {
+   "fieldname": "payment_terms_template",
+   "fieldtype": "Link",
+   "label": "Payment Terms Template",
+   "options": "Payment Terms Template"
+  },
+  {
+   "fieldname": "payment_schedule",
+   "fieldtype": "Table",
+   "label": "Payment Schedule",
+   "no_copy": 1,
+   "options": "Payment Schedule",
+   "print_hide": 1
+  },
+  {
+   "collapsible": 1,
+   "collapsible_depends_on": "terms",
+   "fieldname": "terms_section_break",
+   "fieldtype": "Section Break",
+   "label": "Terms and Conditions",
+   "options": "fa fa-legal"
+  },
+  {
+   "fieldname": "tc_name",
+   "fieldtype": "Link",
+   "label": "Terms",
+   "options": "Terms and Conditions",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "terms",
+   "fieldtype": "Text Editor",
+   "label": "Terms and Conditions1"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "printing_settings",
+   "fieldtype": "Section Break",
+   "label": "Printing Settings"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "letter_head",
+   "fieldtype": "Link",
+   "label": "Letter Head",
+   "options": "Letter Head",
+   "print_hide": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "default": "0",
+   "fieldname": "group_same_items",
+   "fieldtype": "Check",
+   "label": "Group same items",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "column_break_112",
+   "fieldtype": "Column Break"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "select_print_heading",
+   "fieldtype": "Link",
+   "label": "Print Heading",
+   "no_copy": 1,
+   "oldfieldname": "select_print_heading",
+   "oldfieldtype": "Link",
+   "options": "Print Heading",
+   "print_hide": 1,
+   "report_hide": 1
+  },
+  {
+   "fieldname": "language",
+   "fieldtype": "Data",
+   "label": "Print Language",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "more_info",
+   "fieldtype": "Section Break",
+   "label": "More Information",
+   "oldfieldtype": "Section Break",
+   "options": "fa fa-file-text",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "credit_to",
+   "fieldtype": "Link",
+   "label": "Credit To",
+   "oldfieldname": "credit_to",
+   "oldfieldtype": "Link",
+   "options": "Account",
+   "print_hide": 1,
+   "reqd": 1,
+   "search_index": 1
+  },
+  {
+   "fieldname": "party_account_currency",
+   "fieldtype": "Link",
+   "hidden": 1,
+   "label": "Party Account Currency",
+   "no_copy": 1,
+   "options": "Currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "default": "No",
+   "fieldname": "is_opening",
+   "fieldtype": "Select",
+   "label": "Is Opening",
+   "oldfieldname": "is_opening",
+   "oldfieldtype": "Select",
+   "options": "No\nYes",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "against_expense_account",
+   "fieldtype": "Small Text",
+   "hidden": 1,
+   "label": "Against Expense Account",
+   "no_copy": 1,
+   "oldfieldname": "against_expense_account",
+   "oldfieldtype": "Small Text",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "column_break_63",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "Draft",
+   "fieldname": "status",
+   "fieldtype": "Select",
+   "in_standard_filter": 1,
+   "label": "Status",
+   "options": "\nDraft\nReturn\nDebit Note Issued\nSubmitted\nPaid\nUnpaid\nOverdue\nCancelled",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "inter_company_invoice_reference",
+   "fieldtype": "Link",
+   "label": "Inter Company Invoice Reference",
+   "options": "Sales Invoice",
+   "read_only": 1
+  },
+  {
+   "fieldname": "remarks",
+   "fieldtype": "Small Text",
+   "label": "Remarks",
+   "no_copy": 1,
+   "oldfieldname": "remarks",
+   "oldfieldtype": "Text",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "subscription_section",
+   "fieldtype": "Section Break",
+   "label": "Subscription Section",
+   "print_hide": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "description": "Start date of current invoice's period",
+   "fieldname": "from_date",
+   "fieldtype": "Date",
+   "label": "From Date",
+   "no_copy": 1,
+   "print_hide": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "description": "End date of current invoice's period",
+   "fieldname": "to_date",
+   "fieldtype": "Date",
+   "label": "To Date",
+   "no_copy": 1,
+   "print_hide": 1
+  },
+  {
+   "fieldname": "column_break_114",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "auto_repeat",
+   "fieldtype": "Link",
+   "label": "Auto Repeat",
+   "no_copy": 1,
+   "options": "Auto Repeat",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "depends_on": "eval: doc.auto_repeat",
+   "fieldname": "update_auto_repeat_reference",
+   "fieldtype": "Button",
+   "label": "Update Auto Repeat Reference"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "accounting_dimensions_section",
+   "fieldtype": "Section Break",
+   "label": "Accounting Dimensions "
+  },
+  {
+   "fieldname": "dimension_col_break",
+   "fieldtype": "Column Break"
   }
+ ],
+ "icon": "fa fa-file-text",
+ "idx": 204,
+ "is_submittable": 1,
+ "modified": "2019-09-17 22:31:42.666601",
+ "modified_by": "Administrator",
+ "module": "Accounts",
+ "name": "Purchase Invoice",
+ "name_case": "Title Case",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "amend": 1,
+   "cancel": 1,
+   "create": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Accounts User",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Purchase User"
+  },
+  {
+   "amend": 1,
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Accounts Manager",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Auditor"
+  },
+  {
+   "permlevel": 1,
+   "read": 1,
+   "role": "Accounts Manager",
+   "write": 1
+  }
+ ],
+ "search_fields": "posting_date, supplier, bill_no, base_grand_total, outstanding_amount",
+ "show_name_in_global_search": 1,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "timeline_field": "supplier",
+ "title_field": "title",
+ "track_changes": 1
+}

--- a/erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
+++ b/erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
@@ -591,7 +591,6 @@
    "oldfieldname": "purchase_order",
    "oldfieldtype": "Link",
    "options": "Purchase Order",
-   "print_hide": 1,
    "read_only": 1,
    "search_index": 1
   },
@@ -607,6 +606,7 @@
    "fieldname": "include_exploded_items",
    "fieldtype": "Check",
    "label": "Include Exploded Items",
+   "print_hide": 1,
    "read_only": 1
   },
   {
@@ -758,7 +758,7 @@
  ],
  "idx": 1,
  "istable": 1,
- "modified": "2019-06-02 06:36:17.078419",
+ "modified": "2019-09-17 22:32:05.984240",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Purchase Invoice Item",

--- a/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
+++ b/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
@@ -267,6 +267,7 @@
    "fieldtype": "Currency",
    "label": "Last Purchase Rate",
    "options": "currency",
+   "print_hide": 1,
    "read_only": 1
   },
   {
@@ -561,7 +562,8 @@
    "depends_on": "eval:parent.is_subcontracted == 'Yes'",
    "fieldname": "include_exploded_items",
    "fieldtype": "Check",
-   "label": "Include Exploded Items"
+   "label": "Include Exploded Items",
+   "print_hide": 1
   },
   {
    "fieldname": "section_break_56",
@@ -701,7 +703,7 @@
  ],
  "idx": 1,
  "istable": 1,
- "modified": "2019-06-23 20:03:13.818917",
+ "modified": "2019-09-17 22:32:34.703923",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Purchase Order Item",

--- a/erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
+++ b/erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
@@ -1,830 +1,830 @@
 {
-   "autoname": "hash",
-   "creation": "2013-05-24 19:29:10",
-   "doctype": "DocType",
-   "document_type": "Document",
-   "editable_grid": 1,
-   "engine": "InnoDB",
-   "field_order": [
-    "barcode",
-    "section_break_2",
-    "item_code",
-    "supplier_part_no",
-    "column_break_2",
-    "item_name",
-    "section_break_4",
-    "description",
-    "item_group",
-    "brand",
-    "image_section",
-    "image",
-    "image_view",
-    "manufacture_details",
-    "manufacturer",
-    "column_break_16",
-    "manufacturer_part_no",
-    "received_and_accepted",
-    "received_qty",
-    "qty",
-    "rejected_qty",
-    "col_break2",
-    "uom",
-    "stock_uom",
-    "conversion_factor",
-    "retain_sample",
-    "sample_quantity",
-    "rate_and_amount",
-    "price_list_rate",
-    "discount_percentage",
-    "discount_amount",
-    "col_break3",
-    "base_price_list_rate",
-    "sec_break1",
-    "rate",
-    "amount",
-    "col_break4",
-    "base_rate",
-    "base_amount",
-    "pricing_rules",
-    "is_free_item",
-    "section_break_29",
-    "net_rate",
-    "net_amount",
-    "item_tax_template",
-    "column_break_32",
-    "base_net_rate",
-    "base_net_amount",
-    "valuation_rate",
-    "item_tax_amount",
-    "rm_supp_cost",
-    "landed_cost_voucher_amount",
-    "billed_amt",
-    "item_weight_details",
-    "weight_per_unit",
-    "total_weight",
-    "column_break_41",
-    "weight_uom",
-    "warehouse_and_reference",
-    "warehouse",
-    "rejected_warehouse",
-    "quality_inspection",
-    "purchase_order",
-    "material_request",
-    "purchase_order_item",
-    "material_request_item",
-    "column_break_40",
-    "is_fixed_asset",
-    "asset",
-    "asset_location",
-    "schedule_date",
-    "stock_qty",
-    "section_break_45",
-    "serial_no",
-    "batch_no",
-    "column_break_48",
-    "rejected_serial_no",
-    "expense_account",
-    "col_break5",
-    "allow_zero_valuation_rate",
-    "bom",
-    "include_exploded_items",
-    "item_tax_rate",
-    "accounting_dimensions_section",
-    "project",
-    "dimension_col_break",
-    "cost_center",
-    "section_break_80",
-    "page_break"
-   ],
-   "fields": [
-    {
-     "fieldname": "barcode",
-     "fieldtype": "Data",
-     "label": "Barcode"
-    },
-    {
-     "fieldname": "section_break_2",
-     "fieldtype": "Section Break"
-    },
-    {
-     "bold": 1,
-     "columns": 3,
-     "fieldname": "item_code",
-     "fieldtype": "Link",
-     "in_global_search": 1,
-     "in_list_view": 1,
-     "label": "Item Code",
-     "oldfieldname": "item_code",
-     "oldfieldtype": "Link",
-     "options": "Item",
-     "print_width": "100px",
-     "reqd": 1,
-     "search_index": 1,
-     "width": "100px"
-    },
-    {
-     "fieldname": "supplier_part_no",
-     "fieldtype": "Data",
-     "hidden": 1,
-     "label": "Supplier Part Number",
-     "read_only": 1
-    },
-    {
-     "fieldname": "column_break_2",
-     "fieldtype": "Column Break"
-    },
-    {
-     "fieldname": "item_name",
-     "fieldtype": "Data",
-     "in_global_search": 1,
-     "label": "Item Name",
-     "oldfieldname": "item_name",
-     "oldfieldtype": "Data",
-     "print_hide": 1,
-     "reqd": 1
-    },
-    {
-     "collapsible": 1,
-     "fieldname": "section_break_4",
-     "fieldtype": "Section Break",
-     "label": "Description"
-    },
-    {
-     "fieldname": "description",
-     "fieldtype": "Text Editor",
-     "label": "Description",
-     "oldfieldname": "description",
-     "oldfieldtype": "Text",
-     "print_width": "300px",
-     "reqd": 1,
-     "width": "300px"
-    },
-    {
-     "fieldname": "image",
-     "fieldtype": "Attach",
-     "hidden": 1,
-     "label": "Image"
-    },
-    {
-     "fieldname": "image_view",
-     "fieldtype": "Image",
-     "label": "Image View",
-     "options": "image",
-     "print_hide": 1
-    },
-    {
-     "fieldname": "received_and_accepted",
-     "fieldtype": "Section Break",
-     "label": "Received and Accepted"
-    },
-    {
-     "bold": 1,
-     "fieldname": "received_qty",
-     "fieldtype": "Float",
-     "label": "Received Quantity",
-     "oldfieldname": "received_qty",
-     "oldfieldtype": "Currency",
-     "print_hide": 1,
-     "print_width": "100px",
-     "reqd": 1,
-     "width": "100px"
-    },
-    {
-     "columns": 2,
-     "fieldname": "qty",
-     "fieldtype": "Float",
-     "in_list_view": 1,
-     "label": "Accepted Quantity",
-     "oldfieldname": "qty",
-     "oldfieldtype": "Currency",
-     "print_width": "100px",
-     "width": "100px"
-    },
-    {
-     "fieldname": "rejected_qty",
-     "fieldtype": "Float",
-     "label": "Rejected Quantity",
-     "oldfieldname": "rejected_qty",
-     "oldfieldtype": "Currency",
-     "print_hide": 1,
-     "print_width": "100px",
-     "width": "100px"
-    },
-    {
-     "fieldname": "col_break2",
-     "fieldtype": "Column Break",
-     "print_hide": 1
-    },
-    {
-     "fieldname": "uom",
-     "fieldtype": "Link",
-     "label": "UOM",
-     "oldfieldname": "uom",
-     "oldfieldtype": "Link",
-     "options": "UOM",
-     "print_hide": 1,
-     "print_width": "100px",
-     "reqd": 1,
-     "width": "100px"
-    },
-    {
-     "fieldname": "stock_uom",
-     "fieldtype": "Link",
-     "label": "Stock UOM",
-     "oldfieldname": "stock_uom",
-     "oldfieldtype": "Data",
-     "options": "UOM",
-     "print_hide": 1,
-     "print_width": "100px",
-     "read_only": 1,
-     "reqd": 1,
-     "width": "100px"
-    },
-    {
-     "fieldname": "conversion_factor",
-     "fieldtype": "Float",
-     "label": "Conversion Factor",
-     "oldfieldname": "conversion_factor",
-     "oldfieldtype": "Currency",
-     "print_hide": 1,
-     "print_width": "100px",
-     "reqd": 1,
-     "width": "100px"
-    },
-    {
-     "default": "0",
-     "fetch_from": "item_code.retain_sample",
-     "fieldname": "retain_sample",
-     "fieldtype": "Check",
-     "label": "Retain Sample",
-     "read_only": 1
-    },
-    {
-     "depends_on": "retain_sample",
-     "fetch_from": "item_code.sample_quantity",
-     "fieldname": "sample_quantity",
-     "fieldtype": "Int",
-     "label": "Sample Quantity"
-    },
-    {
-     "fieldname": "rate_and_amount",
-     "fieldtype": "Section Break",
-     "label": "Rate and Amount"
-    },
-    {
-     "fieldname": "price_list_rate",
-     "fieldtype": "Currency",
-     "label": "Price List Rate",
-     "options": "currency",
-     "print_hide": 1
-    },
-    {
-     "depends_on": "price_list_rate",
-     "fieldname": "discount_percentage",
-     "fieldtype": "Percent",
-     "label": "Discount on Price List Rate (%)",
-     "print_hide": 1
-    },
-    {
-     "depends_on": "price_list_rate",
-     "fieldname": "discount_amount",
-     "fieldtype": "Currency",
-     "label": "Discount Amount",
-     "options": "currency"
-    },
-    {
-     "fieldname": "col_break3",
-     "fieldtype": "Column Break"
-    },
-    {
-     "fieldname": "base_price_list_rate",
-     "fieldtype": "Currency",
-     "label": "Price List Rate (Company Currency)",
-     "options": "Company:company:default_currency",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "fieldname": "sec_break1",
-     "fieldtype": "Section Break"
-    },
-    {
-     "bold": 1,
-     "columns": 3,
-     "fieldname": "rate",
-     "fieldtype": "Currency",
-     "in_list_view": 1,
-     "label": "Rate",
-     "oldfieldname": "import_rate",
-     "oldfieldtype": "Currency",
-     "options": "currency",
-     "print_width": "100px",
-     "width": "100px"
-    },
-    {
-     "fieldname": "amount",
-     "fieldtype": "Currency",
-     "in_list_view": 1,
-     "label": "Amount",
-     "oldfieldname": "import_amount",
-     "oldfieldtype": "Currency",
-     "options": "currency",
-     "read_only": 1
-    },
-    {
-     "fieldname": "col_break4",
-     "fieldtype": "Column Break"
-    },
-    {
-     "fieldname": "base_rate",
-     "fieldtype": "Currency",
-     "label": "Rate (Company Currency)",
-     "oldfieldname": "purchase_rate",
-     "oldfieldtype": "Currency",
-     "options": "Company:company:default_currency",
-     "print_hide": 1,
-     "print_width": "100px",
-     "read_only": 1,
-     "reqd": 1,
-     "width": "100px"
-    },
-    {
-     "fieldname": "base_amount",
-     "fieldtype": "Currency",
-     "label": "Amount (Company Currency)",
-     "oldfieldname": "amount",
-     "oldfieldtype": "Currency",
-     "options": "Company:company:default_currency",
-     "print_hide": 1,
-     "print_width": "100px",
-     "read_only": 1,
-     "width": "100px"
-    },
-    {
-     "fieldname": "pricing_rules",
-     "fieldtype": "Small Text",
-     "hidden": 1,
-     "label": "Pricing Rules",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "default": "0",
-     "fieldname": "is_free_item",
-     "fieldtype": "Check",
-     "label": "Is Free Item",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "fieldname": "section_break_29",
-     "fieldtype": "Section Break"
-    },
-    {
-     "fieldname": "net_rate",
-     "fieldtype": "Currency",
-     "label": "Net Rate",
-     "options": "currency",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "columns": 2,
-     "fieldname": "net_amount",
-     "fieldtype": "Currency",
-     "in_list_view": 1,
-     "label": "Net Amount",
-     "options": "currency",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "fieldname": "column_break_32",
-     "fieldtype": "Column Break"
-    },
-    {
-     "fieldname": "base_net_rate",
-     "fieldtype": "Currency",
-     "label": "Net Rate (Company Currency)",
-     "options": "Company:company:default_currency",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "fieldname": "base_net_amount",
-     "fieldtype": "Currency",
-     "label": "Net Amount (Company Currency)",
-     "options": "Company:company:default_currency",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "collapsible": 1,
-     "fieldname": "item_weight_details",
-     "fieldtype": "Section Break",
-     "label": "Item Weight Details"
-    },
-    {
-     "fieldname": "weight_per_unit",
-     "fieldtype": "Float",
-     "label": "Weight Per Unit"
-    },
-    {
-     "fieldname": "total_weight",
-     "fieldtype": "Float",
-     "label": "Total Weight",
-     "read_only": 1
-    },
-    {
-     "fieldname": "column_break_41",
-     "fieldtype": "Column Break"
-    },
-    {
-     "fieldname": "weight_uom",
-     "fieldtype": "Link",
-     "label": "Weight UOM",
-     "options": "UOM"
-    },
-    {
-     "fieldname": "warehouse_and_reference",
-     "fieldtype": "Section Break",
-     "label": "Warehouse and Reference"
-    },
-    {
-     "bold": 1,
-     "fieldname": "warehouse",
-     "fieldtype": "Link",
-     "in_list_view": 1,
-     "label": "Accepted Warehouse",
-     "oldfieldname": "warehouse",
-     "oldfieldtype": "Link",
-     "options": "Warehouse",
-     "print_hide": 1,
-     "print_width": "100px",
-     "width": "100px"
-    },
-    {
-     "fieldname": "rejected_warehouse",
-     "fieldtype": "Link",
-     "label": "Rejected Warehouse",
-     "no_copy": 1,
-     "oldfieldname": "rejected_warehouse",
-     "oldfieldtype": "Link",
-     "options": "Warehouse",
-     "print_hide": 1,
-     "print_width": "100px",
-     "width": "100px"
-    },
-    {
-     "depends_on": "eval:!doc.__islocal",
-     "fieldname": "quality_inspection",
-     "fieldtype": "Link",
-     "label": "Quality Inspection",
-     "no_copy": 1,
-     "oldfieldname": "qa_no",
-     "oldfieldtype": "Link",
-     "options": "Quality Inspection",
-     "print_hide": 1
-    },
-    {
-     "fieldname": "column_break_40",
-     "fieldtype": "Column Break"
-    },
-    {
-     "default": "0",
-     "fieldname": "is_fixed_asset",
-     "fieldtype": "Check",
-     "hidden": 1,
-     "label": "Is Fixed Asset",
-     "no_copy": 1,
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "depends_on": "is_fixed_asset",
-     "fieldname": "asset",
-     "fieldtype": "Link",
-     "label": "Asset",
-     "no_copy": 1,
-     "options": "Asset"
-    },
-    {
-     "depends_on": "is_fixed_asset",
-     "fieldname": "asset_location",
-     "fieldtype": "Link",
-     "label": "Asset Location",
-     "options": "Location"
-    },
-    {
-     "fieldname": "purchase_order",
-     "fieldtype": "Link",
-     "label": "Purchase Order",
-     "no_copy": 1,
-     "oldfieldname": "prevdoc_docname",
-     "oldfieldtype": "Link",
-     "options": "Purchase Order",
-     "print_hide": 1,
-     "print_width": "150px",
-     "read_only": 1,
-     "search_index": 1,
-     "width": "150px"
-    },
-    {
-     "fieldname": "schedule_date",
-     "fieldtype": "Date",
-     "label": "Required By",
-     "oldfieldname": "schedule_date",
-     "oldfieldtype": "Date",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "fieldname": "stock_qty",
-     "fieldtype": "Float",
-     "label": "Qty as per Stock UOM",
-     "oldfieldname": "stock_qty",
-     "oldfieldtype": "Currency",
-     "print_hide": 1,
-     "print_width": "100px",
-     "read_only": 1,
-     "width": "100px"
-    },
-    {
-     "fieldname": "section_break_45",
-     "fieldtype": "Section Break"
-    },
-    {
-     "fieldname": "serial_no",
-     "fieldtype": "Small Text",
-     "in_list_view": 1,
-     "label": "Serial No",
-     "no_copy": 1,
-     "oldfieldname": "serial_no",
-     "oldfieldtype": "Text"
-    },
-    {
-     "fieldname": "batch_no",
-     "fieldtype": "Link",
-     "in_list_view": 1,
-     "label": "Batch No",
-     "no_copy": 1,
-     "oldfieldname": "batch_no",
-     "oldfieldtype": "Link",
-     "options": "Batch",
-     "print_hide": 1
-    },
-    {
-     "fieldname": "column_break_48",
-     "fieldtype": "Column Break"
-    },
-    {
-     "fieldname": "rejected_serial_no",
-     "fieldtype": "Small Text",
-     "label": "Rejected Serial No",
-     "no_copy": 1,
-     "print_hide": 1
-    },
-    {
-     "fieldname": "item_tax_template",
-     "fieldtype": "Link",
-     "label": "Item Tax Template",
-     "options": "Item Tax Template",
-     "print_hide": 1
-    },
-    {
-     "fieldname": "project",
-     "fieldtype": "Link",
-     "label": "Project",
-     "options": "Project",
-     "print_hide": 1
-    },
-    {
-     "default": ":Company",
-     "depends_on": "eval:cint(erpnext.is_perpetual_inventory_enabled(parent.company))",
-     "fieldname": "cost_center",
-     "fieldtype": "Link",
-     "label": "Cost Center",
-     "options": "Cost Center",
-     "print_hide": 1
-    },
-    {
-     "fieldname": "purchase_order_item",
-     "fieldtype": "Data",
-     "hidden": 1,
-     "label": "Purchase Order Item",
-     "no_copy": 1,
-     "oldfieldname": "prevdoc_detail_docname",
-     "oldfieldtype": "Data",
-     "print_hide": 1,
-     "print_width": "150px",
-     "read_only": 1,
-     "search_index": 1,
-     "width": "150px"
-    },
-    {
-     "fieldname": "col_break5",
-     "fieldtype": "Column Break"
-    },
-    {
-     "default": "0",
-     "fieldname": "allow_zero_valuation_rate",
-     "fieldtype": "Check",
-     "label": "Allow Zero Valuation Rate",
-     "no_copy": 1,
-     "print_hide": 1
-    },
-    {
-     "fieldname": "bom",
-     "fieldtype": "Link",
-     "label": "BOM",
-     "no_copy": 1,
-     "options": "BOM",
-     "print_hide": 1
-    },
-    {
-     "default": "0",
-     "depends_on": "eval:parent.is_subcontracted == 'Yes'",
-     "fieldname": "include_exploded_items",
-     "fieldtype": "Check",
-     "label": "Include Exploded Items",
-     "read_only": 1
-    },
-    {
-     "fieldname": "billed_amt",
-     "fieldtype": "Currency",
-     "label": "Billed Amt",
-     "no_copy": 1,
-     "options": "currency",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "allow_on_submit": 1,
-     "fieldname": "landed_cost_voucher_amount",
-     "fieldtype": "Currency",
-     "label": "Landed Cost Voucher Amount",
-     "no_copy": 1,
-     "options": "Company:company:default_currency",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "fieldname": "brand",
-     "fieldtype": "Link",
-     "hidden": 1,
-     "label": "Brand",
-     "oldfieldname": "brand",
-     "oldfieldtype": "Link",
-     "options": "Brand",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "fieldname": "item_group",
-     "fieldtype": "Link",
-     "hidden": 1,
-     "label": "Item Group",
-     "oldfieldname": "item_group",
-     "oldfieldtype": "Link",
-     "options": "Item Group",
-     "print_hide": 1,
-     "read_only": 1
-    },
-    {
-     "fieldname": "rm_supp_cost",
-     "fieldtype": "Currency",
-     "hidden": 1,
-     "label": "Raw Materials Supplied Cost",
-     "no_copy": 1,
-     "oldfieldname": "rm_supp_cost",
-     "oldfieldtype": "Currency",
-     "options": "Company:company:default_currency",
-     "print_hide": 1,
-     "print_width": "150px",
-     "read_only": 1,
-     "width": "150px"
-    },
-    {
-     "fieldname": "item_tax_amount",
-     "fieldtype": "Currency",
-     "hidden": 1,
-     "label": "Item Tax Amount Included in Value",
-     "no_copy": 1,
-     "oldfieldname": "item_tax_amount",
-     "oldfieldtype": "Currency",
-     "options": "Company:company:default_currency",
-     "print_hide": 1,
-     "print_width": "150px",
-     "read_only": 1,
-     "width": "150px"
-    },
-    {
-     "allow_on_submit": 1,
-     "fieldname": "valuation_rate",
-     "fieldtype": "Currency",
-     "hidden": 1,
-     "label": "Valuation Rate",
-     "no_copy": 1,
-     "oldfieldname": "valuation_rate",
-     "oldfieldtype": "Currency",
-     "options": "Company:company:default_currency",
-     "print_hide": 1,
-     "print_width": "80px",
-     "read_only": 1,
-     "width": "80px"
-    },
-    {
-     "description": "Tax detail table fetched from item master as a string and stored in this field.\nUsed for Taxes and Charges",
-     "fieldname": "item_tax_rate",
-     "fieldtype": "Code",
-     "hidden": 1,
-     "label": "Item Tax Rate",
-     "oldfieldname": "item_tax_rate",
-     "oldfieldtype": "Small Text",
-     "print_hide": 1,
-     "read_only": 1,
-     "report_hide": 1
-    },
-    {
-     "allow_on_submit": 1,
-     "default": "0",
-     "fieldname": "page_break",
-     "fieldtype": "Check",
-     "label": "Page Break",
-     "oldfieldname": "page_break",
-     "oldfieldtype": "Check",
-     "print_hide": 1
-    },
-    {
-     "fieldname": "section_break_80",
-     "fieldtype": "Section Break"
-    },
-    {
-     "collapsible": 1,
-     "fieldname": "image_section",
-     "fieldtype": "Section Break",
-     "label": "Image"
-    },
-    {
-     "fieldname": "material_request",
-     "fieldtype": "Link",
-     "label": "Material Request",
-     "options": "Material Request"
-    },
-    {
-     "fieldname": "material_request_item",
-     "fieldtype": "Data",
-     "label": "Material Request Item"
-    },
-    {
-     "fieldname": "expense_account",
-     "fieldtype": "Link",
-     "hidden": 1,
-     "label": "Expense Account",
-     "options": "Account",
-     "read_only": 1
-    },
-    {
-     "fieldname": "accounting_dimensions_section",
-     "fieldtype": "Section Break",
-     "label": "Accounting Dimensions"
-    },
-    {
-     "fieldname": "dimension_col_break",
-     "fieldtype": "Column Break"
-    },
-    {
-     "collapsible": 1,
-     "fieldname": "manufacture_details",
-     "fieldtype": "Section Break",
-     "label": "Manufacture"
-    },
-    {
-     "fieldname": "manufacturer",
-     "fieldtype": "Link",
-     "label": "Manufacturer",
-     "options": "Manufacturer"
-    },
-    {
-     "fieldname": "column_break_16",
-     "fieldtype": "Column Break"
-    },
-    {
-     "fieldname": "manufacturer_part_no",
-     "fieldtype": "Data",
-     "label": "Manufacturer Part Number",
-     "read_only": 1
-    }
-   ],
-   "idx": 1,
-   "istable": 1,
-   "modified": "2019-06-02 06:37:48.198745",
-   "modified_by": "Administrator",
-   "module": "Stock",
-   "name": "Purchase Receipt Item",
-   "owner": "Administrator",
-   "permissions": [],
-   "quick_entry": 1,
-   "sort_field": "modified",
-   "sort_order": "DESC"
+ "autoname": "hash",
+ "creation": "2013-05-24 19:29:10",
+ "doctype": "DocType",
+ "document_type": "Document",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "barcode",
+  "section_break_2",
+  "item_code",
+  "supplier_part_no",
+  "column_break_2",
+  "item_name",
+  "section_break_4",
+  "description",
+  "item_group",
+  "brand",
+  "image_section",
+  "image",
+  "image_view",
+  "manufacture_details",
+  "manufacturer",
+  "column_break_16",
+  "manufacturer_part_no",
+  "received_and_accepted",
+  "received_qty",
+  "qty",
+  "rejected_qty",
+  "col_break2",
+  "uom",
+  "stock_uom",
+  "conversion_factor",
+  "retain_sample",
+  "sample_quantity",
+  "rate_and_amount",
+  "price_list_rate",
+  "discount_percentage",
+  "discount_amount",
+  "col_break3",
+  "base_price_list_rate",
+  "sec_break1",
+  "rate",
+  "amount",
+  "col_break4",
+  "base_rate",
+  "base_amount",
+  "pricing_rules",
+  "is_free_item",
+  "section_break_29",
+  "net_rate",
+  "net_amount",
+  "item_tax_template",
+  "column_break_32",
+  "base_net_rate",
+  "base_net_amount",
+  "valuation_rate",
+  "item_tax_amount",
+  "rm_supp_cost",
+  "landed_cost_voucher_amount",
+  "billed_amt",
+  "item_weight_details",
+  "weight_per_unit",
+  "total_weight",
+  "column_break_41",
+  "weight_uom",
+  "warehouse_and_reference",
+  "warehouse",
+  "rejected_warehouse",
+  "quality_inspection",
+  "purchase_order",
+  "material_request",
+  "purchase_order_item",
+  "material_request_item",
+  "column_break_40",
+  "is_fixed_asset",
+  "asset",
+  "asset_location",
+  "schedule_date",
+  "stock_qty",
+  "section_break_45",
+  "serial_no",
+  "batch_no",
+  "column_break_48",
+  "rejected_serial_no",
+  "expense_account",
+  "col_break5",
+  "allow_zero_valuation_rate",
+  "bom",
+  "include_exploded_items",
+  "item_tax_rate",
+  "accounting_dimensions_section",
+  "project",
+  "dimension_col_break",
+  "cost_center",
+  "section_break_80",
+  "page_break"
+ ],
+ "fields": [
+  {
+   "fieldname": "barcode",
+   "fieldtype": "Data",
+   "label": "Barcode"
+  },
+  {
+   "fieldname": "section_break_2",
+   "fieldtype": "Section Break"
+  },
+  {
+   "bold": 1,
+   "columns": 3,
+   "fieldname": "item_code",
+   "fieldtype": "Link",
+   "in_global_search": 1,
+   "in_list_view": 1,
+   "label": "Item Code",
+   "oldfieldname": "item_code",
+   "oldfieldtype": "Link",
+   "options": "Item",
+   "print_width": "100px",
+   "reqd": 1,
+   "search_index": 1,
+   "width": "100px"
+  },
+  {
+   "fieldname": "supplier_part_no",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Supplier Part Number",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_2",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "item_name",
+   "fieldtype": "Data",
+   "in_global_search": 1,
+   "label": "Item Name",
+   "oldfieldname": "item_name",
+   "oldfieldtype": "Data",
+   "print_hide": 1,
+   "reqd": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "section_break_4",
+   "fieldtype": "Section Break",
+   "label": "Description"
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Text Editor",
+   "label": "Description",
+   "oldfieldname": "description",
+   "oldfieldtype": "Text",
+   "print_width": "300px",
+   "reqd": 1,
+   "width": "300px"
+  },
+  {
+   "fieldname": "image",
+   "fieldtype": "Attach",
+   "hidden": 1,
+   "label": "Image"
+  },
+  {
+   "fieldname": "image_view",
+   "fieldtype": "Image",
+   "label": "Image View",
+   "options": "image",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "received_and_accepted",
+   "fieldtype": "Section Break",
+   "label": "Received and Accepted"
+  },
+  {
+   "bold": 1,
+   "fieldname": "received_qty",
+   "fieldtype": "Float",
+   "label": "Received Quantity",
+   "oldfieldname": "received_qty",
+   "oldfieldtype": "Currency",
+   "print_hide": 1,
+   "print_width": "100px",
+   "reqd": 1,
+   "width": "100px"
+  },
+  {
+   "columns": 2,
+   "fieldname": "qty",
+   "fieldtype": "Float",
+   "in_list_view": 1,
+   "label": "Accepted Quantity",
+   "oldfieldname": "qty",
+   "oldfieldtype": "Currency",
+   "print_width": "100px",
+   "width": "100px"
+  },
+  {
+   "fieldname": "rejected_qty",
+   "fieldtype": "Float",
+   "label": "Rejected Quantity",
+   "oldfieldname": "rejected_qty",
+   "oldfieldtype": "Currency",
+   "print_hide": 1,
+   "print_width": "100px",
+   "width": "100px"
+  },
+  {
+   "fieldname": "col_break2",
+   "fieldtype": "Column Break",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "uom",
+   "fieldtype": "Link",
+   "label": "UOM",
+   "oldfieldname": "uom",
+   "oldfieldtype": "Link",
+   "options": "UOM",
+   "print_hide": 1,
+   "print_width": "100px",
+   "reqd": 1,
+   "width": "100px"
+  },
+  {
+   "fieldname": "stock_uom",
+   "fieldtype": "Link",
+   "label": "Stock UOM",
+   "oldfieldname": "stock_uom",
+   "oldfieldtype": "Data",
+   "options": "UOM",
+   "print_hide": 1,
+   "print_width": "100px",
+   "read_only": 1,
+   "reqd": 1,
+   "width": "100px"
+  },
+  {
+   "fieldname": "conversion_factor",
+   "fieldtype": "Float",
+   "label": "Conversion Factor",
+   "oldfieldname": "conversion_factor",
+   "oldfieldtype": "Currency",
+   "print_hide": 1,
+   "print_width": "100px",
+   "reqd": 1,
+   "width": "100px"
+  },
+  {
+   "default": "0",
+   "fetch_from": "item_code.retain_sample",
+   "fieldname": "retain_sample",
+   "fieldtype": "Check",
+   "label": "Retain Sample",
+   "read_only": 1
+  },
+  {
+   "depends_on": "retain_sample",
+   "fetch_from": "item_code.sample_quantity",
+   "fieldname": "sample_quantity",
+   "fieldtype": "Int",
+   "label": "Sample Quantity"
+  },
+  {
+   "fieldname": "rate_and_amount",
+   "fieldtype": "Section Break",
+   "label": "Rate and Amount"
+  },
+  {
+   "fieldname": "price_list_rate",
+   "fieldtype": "Currency",
+   "label": "Price List Rate",
+   "options": "currency",
+   "print_hide": 1
+  },
+  {
+   "depends_on": "price_list_rate",
+   "fieldname": "discount_percentage",
+   "fieldtype": "Percent",
+   "label": "Discount on Price List Rate (%)",
+   "print_hide": 1
+  },
+  {
+   "depends_on": "price_list_rate",
+   "fieldname": "discount_amount",
+   "fieldtype": "Currency",
+   "label": "Discount Amount",
+   "options": "currency"
+  },
+  {
+   "fieldname": "col_break3",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "base_price_list_rate",
+   "fieldtype": "Currency",
+   "label": "Price List Rate (Company Currency)",
+   "options": "Company:company:default_currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "sec_break1",
+   "fieldtype": "Section Break"
+  },
+  {
+   "bold": 1,
+   "columns": 3,
+   "fieldname": "rate",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Rate",
+   "oldfieldname": "import_rate",
+   "oldfieldtype": "Currency",
+   "options": "currency",
+   "print_width": "100px",
+   "width": "100px"
+  },
+  {
+   "fieldname": "amount",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Amount",
+   "oldfieldname": "import_amount",
+   "oldfieldtype": "Currency",
+   "options": "currency",
+   "read_only": 1
+  },
+  {
+   "fieldname": "col_break4",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "base_rate",
+   "fieldtype": "Currency",
+   "label": "Rate (Company Currency)",
+   "oldfieldname": "purchase_rate",
+   "oldfieldtype": "Currency",
+   "options": "Company:company:default_currency",
+   "print_hide": 1,
+   "print_width": "100px",
+   "read_only": 1,
+   "reqd": 1,
+   "width": "100px"
+  },
+  {
+   "fieldname": "base_amount",
+   "fieldtype": "Currency",
+   "label": "Amount (Company Currency)",
+   "oldfieldname": "amount",
+   "oldfieldtype": "Currency",
+   "options": "Company:company:default_currency",
+   "print_hide": 1,
+   "print_width": "100px",
+   "read_only": 1,
+   "width": "100px"
+  },
+  {
+   "fieldname": "pricing_rules",
+   "fieldtype": "Small Text",
+   "hidden": 1,
+   "label": "Pricing Rules",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "is_free_item",
+   "fieldtype": "Check",
+   "label": "Is Free Item",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_29",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "net_rate",
+   "fieldtype": "Currency",
+   "label": "Net Rate",
+   "options": "currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "columns": 2,
+   "fieldname": "net_amount",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Net Amount",
+   "options": "currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_32",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "base_net_rate",
+   "fieldtype": "Currency",
+   "label": "Net Rate (Company Currency)",
+   "options": "Company:company:default_currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "base_net_amount",
+   "fieldtype": "Currency",
+   "label": "Net Amount (Company Currency)",
+   "options": "Company:company:default_currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "item_weight_details",
+   "fieldtype": "Section Break",
+   "label": "Item Weight Details"
+  },
+  {
+   "fieldname": "weight_per_unit",
+   "fieldtype": "Float",
+   "label": "Weight Per Unit"
+  },
+  {
+   "fieldname": "total_weight",
+   "fieldtype": "Float",
+   "label": "Total Weight",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_41",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "weight_uom",
+   "fieldtype": "Link",
+   "label": "Weight UOM",
+   "options": "UOM"
+  },
+  {
+   "fieldname": "warehouse_and_reference",
+   "fieldtype": "Section Break",
+   "label": "Warehouse and Reference"
+  },
+  {
+   "bold": 1,
+   "fieldname": "warehouse",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Accepted Warehouse",
+   "oldfieldname": "warehouse",
+   "oldfieldtype": "Link",
+   "options": "Warehouse",
+   "print_hide": 1,
+   "print_width": "100px",
+   "width": "100px"
+  },
+  {
+   "fieldname": "rejected_warehouse",
+   "fieldtype": "Link",
+   "label": "Rejected Warehouse",
+   "no_copy": 1,
+   "oldfieldname": "rejected_warehouse",
+   "oldfieldtype": "Link",
+   "options": "Warehouse",
+   "print_hide": 1,
+   "print_width": "100px",
+   "width": "100px"
+  },
+  {
+   "depends_on": "eval:!doc.__islocal",
+   "fieldname": "quality_inspection",
+   "fieldtype": "Link",
+   "label": "Quality Inspection",
+   "no_copy": 1,
+   "oldfieldname": "qa_no",
+   "oldfieldtype": "Link",
+   "options": "Quality Inspection",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "column_break_40",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_fixed_asset",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Is Fixed Asset",
+   "no_copy": 1,
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "depends_on": "is_fixed_asset",
+   "fieldname": "asset",
+   "fieldtype": "Link",
+   "label": "Asset",
+   "no_copy": 1,
+   "options": "Asset"
+  },
+  {
+   "depends_on": "is_fixed_asset",
+   "fieldname": "asset_location",
+   "fieldtype": "Link",
+   "label": "Asset Location",
+   "options": "Location"
+  },
+  {
+   "fieldname": "purchase_order",
+   "fieldtype": "Link",
+   "label": "Purchase Order",
+   "no_copy": 1,
+   "oldfieldname": "prevdoc_docname",
+   "oldfieldtype": "Link",
+   "options": "Purchase Order",
+   "print_width": "150px",
+   "read_only": 1,
+   "search_index": 1,
+   "width": "150px"
+  },
+  {
+   "fieldname": "schedule_date",
+   "fieldtype": "Date",
+   "label": "Required By",
+   "oldfieldname": "schedule_date",
+   "oldfieldtype": "Date",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "stock_qty",
+   "fieldtype": "Float",
+   "label": "Qty as per Stock UOM",
+   "oldfieldname": "stock_qty",
+   "oldfieldtype": "Currency",
+   "print_hide": 1,
+   "print_width": "100px",
+   "read_only": 1,
+   "width": "100px"
+  },
+  {
+   "fieldname": "section_break_45",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "serial_no",
+   "fieldtype": "Small Text",
+   "in_list_view": 1,
+   "label": "Serial No",
+   "no_copy": 1,
+   "oldfieldname": "serial_no",
+   "oldfieldtype": "Text"
+  },
+  {
+   "fieldname": "batch_no",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Batch No",
+   "no_copy": 1,
+   "oldfieldname": "batch_no",
+   "oldfieldtype": "Link",
+   "options": "Batch",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "column_break_48",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "rejected_serial_no",
+   "fieldtype": "Small Text",
+   "label": "Rejected Serial No",
+   "no_copy": 1,
+   "print_hide": 1
+  },
+  {
+   "fieldname": "item_tax_template",
+   "fieldtype": "Link",
+   "label": "Item Tax Template",
+   "options": "Item Tax Template",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "project",
+   "fieldtype": "Link",
+   "label": "Project",
+   "options": "Project",
+   "print_hide": 1
+  },
+  {
+   "default": ":Company",
+   "depends_on": "eval:cint(erpnext.is_perpetual_inventory_enabled(parent.company))",
+   "fieldname": "cost_center",
+   "fieldtype": "Link",
+   "label": "Cost Center",
+   "options": "Cost Center",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "purchase_order_item",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Purchase Order Item",
+   "no_copy": 1,
+   "oldfieldname": "prevdoc_detail_docname",
+   "oldfieldtype": "Data",
+   "print_hide": 1,
+   "print_width": "150px",
+   "read_only": 1,
+   "search_index": 1,
+   "width": "150px"
+  },
+  {
+   "fieldname": "col_break5",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "allow_zero_valuation_rate",
+   "fieldtype": "Check",
+   "label": "Allow Zero Valuation Rate",
+   "no_copy": 1,
+   "print_hide": 1
+  },
+  {
+   "fieldname": "bom",
+   "fieldtype": "Link",
+   "label": "BOM",
+   "no_copy": 1,
+   "options": "BOM",
+   "print_hide": 1
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:parent.is_subcontracted == 'Yes'",
+   "fieldname": "include_exploded_items",
+   "fieldtype": "Check",
+   "label": "Include Exploded Items",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "billed_amt",
+   "fieldtype": "Currency",
+   "label": "Billed Amt",
+   "no_copy": 1,
+   "options": "currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "landed_cost_voucher_amount",
+   "fieldtype": "Currency",
+   "label": "Landed Cost Voucher Amount",
+   "no_copy": 1,
+   "options": "Company:company:default_currency",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "brand",
+   "fieldtype": "Link",
+   "hidden": 1,
+   "label": "Brand",
+   "oldfieldname": "brand",
+   "oldfieldtype": "Link",
+   "options": "Brand",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "item_group",
+   "fieldtype": "Link",
+   "hidden": 1,
+   "label": "Item Group",
+   "oldfieldname": "item_group",
+   "oldfieldtype": "Link",
+   "options": "Item Group",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "rm_supp_cost",
+   "fieldtype": "Currency",
+   "hidden": 1,
+   "label": "Raw Materials Supplied Cost",
+   "no_copy": 1,
+   "oldfieldname": "rm_supp_cost",
+   "oldfieldtype": "Currency",
+   "options": "Company:company:default_currency",
+   "print_hide": 1,
+   "print_width": "150px",
+   "read_only": 1,
+   "width": "150px"
+  },
+  {
+   "fieldname": "item_tax_amount",
+   "fieldtype": "Currency",
+   "hidden": 1,
+   "label": "Item Tax Amount Included in Value",
+   "no_copy": 1,
+   "oldfieldname": "item_tax_amount",
+   "oldfieldtype": "Currency",
+   "options": "Company:company:default_currency",
+   "print_hide": 1,
+   "print_width": "150px",
+   "read_only": 1,
+   "width": "150px"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "valuation_rate",
+   "fieldtype": "Currency",
+   "hidden": 1,
+   "label": "Valuation Rate",
+   "no_copy": 1,
+   "oldfieldname": "valuation_rate",
+   "oldfieldtype": "Currency",
+   "options": "Company:company:default_currency",
+   "print_hide": 1,
+   "print_width": "80px",
+   "read_only": 1,
+   "width": "80px"
+  },
+  {
+   "description": "Tax detail table fetched from item master as a string and stored in this field.\nUsed for Taxes and Charges",
+   "fieldname": "item_tax_rate",
+   "fieldtype": "Code",
+   "hidden": 1,
+   "label": "Item Tax Rate",
+   "oldfieldname": "item_tax_rate",
+   "oldfieldtype": "Small Text",
+   "print_hide": 1,
+   "read_only": 1,
+   "report_hide": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "default": "0",
+   "fieldname": "page_break",
+   "fieldtype": "Check",
+   "label": "Page Break",
+   "oldfieldname": "page_break",
+   "oldfieldtype": "Check",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "section_break_80",
+   "fieldtype": "Section Break"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "image_section",
+   "fieldtype": "Section Break",
+   "label": "Image"
+  },
+  {
+   "fieldname": "material_request",
+   "fieldtype": "Link",
+   "label": "Material Request",
+   "options": "Material Request"
+  },
+  {
+   "fieldname": "material_request_item",
+   "fieldtype": "Data",
+   "label": "Material Request Item"
+  },
+  {
+   "fieldname": "expense_account",
+   "fieldtype": "Link",
+   "hidden": 1,
+   "label": "Expense Account",
+   "options": "Account",
+   "read_only": 1
+  },
+  {
+   "fieldname": "accounting_dimensions_section",
+   "fieldtype": "Section Break",
+   "label": "Accounting Dimensions"
+  },
+  {
+   "fieldname": "dimension_col_break",
+   "fieldtype": "Column Break"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "manufacture_details",
+   "fieldtype": "Section Break",
+   "label": "Manufacture"
+  },
+  {
+   "fieldname": "manufacturer",
+   "fieldtype": "Link",
+   "label": "Manufacturer",
+   "options": "Manufacturer"
+  },
+  {
+   "fieldname": "column_break_16",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "manufacturer_part_no",
+   "fieldtype": "Data",
+   "label": "Manufacturer Part Number",
+   "read_only": 1
   }
+ ],
+ "idx": 1,
+ "istable": 1,
+ "modified": "2019-09-17 22:33:01.109004",
+ "modified_by": "Administrator",
+ "module": "Stock",
+ "name": "Purchase Receipt Item",
+ "owner": "Administrator",
+ "permissions": [],
+ "quick_entry": 1,
+ "sort_field": "modified",
+ "sort_order": "DESC"
+}


### PR DESCRIPTION
This is mostly to avoid certain fields showing up in the print view, there are no functional changes.

**Changes:**
- Purchase Invoice
  - Hide "Status"
  - Hide "Print Language"
- Purchase Invoice Item
  - Hide "Include Exploded Items"
  - Show "Purchase Order"
- Purchase Order Item
  - Hide "Include Exploded Items"
  - Hide "Last Purchase Rate"
- Purchase Receipt Item
  - Hide "Include Exploded Items"
  - Show "Purchase Order"