### PR TITLE
fix: only set times if job card is filled (develop)

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -105,7 +105,6 @@ class JobCard(Document):
 		for_quantity, time_in_mins = 0, 0
 		from_time_list, to_time_list = [], []
 
-
 		for d in frappe.get_all('Job Card',
 			filters = {'docstatus': 1, 'operation_id': self.operation_id}):
 			doc = frappe.get_doc('Job Card', d.name)
@@ -125,8 +124,8 @@ class JobCard(Document):
 				if data.name == self.operation_id:
 					data.completed_qty = for_quantity
 					data.actual_operation_time = time_in_mins
-					data.actual_start_time = min(from_time_list)
-					data.actual_end_time = max(to_time_list)
+					data.actual_start_time = min(from_time_list) if from_time_list else None
+					data.actual_end_time = max(to_time_list) if to_time_list else None
 
 			wo.flags.ignore_validate_update_after_submit = True
 			wo.update_operation_status()


### PR DESCRIPTION
```
Traceback
  File "frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "frappe/__init__.py", line 1036, in call
    return fn(*args, **newargs)
  File "frappe/desk/form/save.py", line 19, in savedocs
    doc.submit()
  File "frappe/model/document.py", line 848, in submit
    self._submit()
  File "frappe/model/document.py", line 837, in _submit
    self.save()
  File "frappe/model/document.py", line 260, in save
    return self._save(*args, **kwargs)
  File "frappe/model/document.py", line 313, in _save
    self.run_post_save_methods()
  File "frappe/model/document.py", line 908, in run_post_save_methods
    self.run_method("on_submit")
  File "frappe/model/document.py", line 772, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "frappe/model/document.py", line 1048, in composer
    return composed(self, method, *args, **kwargs)
  File "frappe/model/document.py", line 1031, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "frappe/model/document.py", line 766, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "erpnext/manufacturing/doctype/job_card/job_card.py", line 85, in on_submit
    self.update_work_order()
  File "erpnext/manufacturing/doctype/job_card/job_card.py", line 130, in update_work_order
    data.actual_end_time = max(to_time_list)
ValueError: max() arg is an empty sequence
```