### PR TITLE
fix: subcontracting material transfer dialog in Purchase Order

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -196,7 +196,7 @@ erpnext.buying.PurchaseOrderController = erpnext.buying.BuyingController.extend(
 		if(items.length >= 1){
 			me.raw_material_data = [];
 			me.show_dialog = 1;
-			let title = "Transfer Material to Supplier";
+			let title = __('Transfer Material to Supplier');
 			let fields = [
 			{fieldtype:'Section Break', label: __('Raw Materials')},
 			{fieldname: 'sub_con_rm_items', fieldtype: 'Table', label: __('Items'),

--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -196,10 +196,10 @@ erpnext.buying.PurchaseOrderController = erpnext.buying.BuyingController.extend(
 		if(items.length >= 1){
 			me.raw_material_data = [];
 			me.show_dialog = 1;
-			let title = "";
+			let title = "Transfer Material to Supplier";
 			let fields = [
 			{fieldtype:'Section Break', label: __('Raw Materials')},
-			{fieldname: 'sub_con_rm_items', fieldtype: 'Table',
+			{fieldname: 'sub_con_rm_items', fieldtype: 'Table', label: __('Items'),
 				fields: [
 					{
 						fieldtype:'Data',
@@ -271,7 +271,7 @@ erpnext.buying.PurchaseOrderController = erpnext.buying.BuyingController.extend(
 						'item_code': item.main_item_code,
 						'rm_item_code': item.rm_item_code,
 						'item_name': item.rm_item_code,
-						'qty': item.required_qty,
+						'qty': item.required_qty - item.supplied_qty,
 						'warehouse':item.reserve_warehouse,
 						'rate':item.rate,
 						'amount':item.amount,


### PR DESCRIPTION
- In Purchase Order, when Transfer > Material to Transfer is clicked, the dialog fetches **Quantity** to transfer from **Required Qty**. Instead it should show **Required Qty - Supplied Qty**.

**Data:**
![subcontracting-data](https://user-images.githubusercontent.com/24353136/65237180-bb8f0380-daf7-11e9-8b6b-88f5e19894ff.png)

**Dialog before fix:** (also title and field name missing)
![subcontracting-before-fix](https://user-images.githubusercontent.com/24353136/65237188-c0ec4e00-daf7-11e9-9079-273342245df7.png)

**Dialog after fix:**
![subcontracting-after-fix](https://user-images.githubusercontent.com/24353136/65237172-b92ca980-daf7-11e9-88dd-77cdf1c0af65.png)
