### PR TITLE
fix: get_bin_details_and_serial_nos() takes at least 3 arguments (4 g…

### DIFF
--- a/erpnext/selling/sales_common.js
+++ b/erpnext/selling/sales_common.js
@@ -234,7 +234,7 @@ erpnext.selling.SellingController = erpnext.TransactionController.extend({
 					args: {
 						item_code: item.item_code,
 						warehouse: item.warehouse,
-						has_batch_no: has_batch_no,
+						has_batch_no: has_batch_no || 0,
 						stock_qty: item.stock_qty,
 						serial_no: item.serial_no || "",
 					},

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -808,7 +808,7 @@ def get_serial_no_details(item_code, warehouse, stock_qty, serial_no):
 	return {'serial_no': serial_no}
 
 @frappe.whitelist()
-def get_bin_details_and_serial_nos(item_code, warehouse, has_batch_no, stock_qty=None, serial_no=None):
+def get_bin_details_and_serial_nos(item_code, warehouse, has_batch_no=None, stock_qty=None, serial_no=None):
 	bin_details_and_serial_nos = {}
 	bin_details_and_serial_nos.update(get_bin_details(item_code, warehouse))
 	if flt(stock_qty) > 0:


### PR DESCRIPTION
**Issue**

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-11-2019-09-10/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-version-11-2019-09-10/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-11-2019-09-10/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-11-2019-09-10/apps/frappe/frappe/__init__.py", line 1036, in call
    return fn(*args, **newargs)
TypeError: get_bin_details_and_serial_nos() takes at least 3 arguments (4 given)
```