### PR TITLE
fix: Removed Address section in Customer Quick Entry Dialog Box

### DIFF
--- a/erpnext/public/js/utils/customer_quick_entry.js
+++ b/erpnext/public/js/utils/customer_quick_entry.js
@@ -30,48 +30,6 @@ frappe.ui.form.CustomerQuickEntryForm = frappe.ui.form.QuickEntryForm.extend({
 			fieldtype: "Data"
 		},
 		{
-			fieldtype: "Section Break",
-			label: __("Primary Address Details"),
-			collapsible: 1
-		},
-		{
-			label: __("Address Line 1"),
-			fieldname: "address_line1",
-			fieldtype: "Data",
-			reqd: 1
-		},
-		{
-			label: __("Address Line 2"),
-			fieldname: "address_line2",
-			fieldtype: "Data"
-		},
-		{
-			label: __("ZIP Code"),
-			fieldname: "pincode",
-			fieldtype: "Data"
-		},
-		{
-			fieldtype: "Column Break"
-		},
-		{
-			label: __("City"),
-			fieldname: "city",
-			fieldtype: "Data",
-			reqd: 1,
-		},
-		{
-			label: __("State"),
-			fieldname: "state",
-			fieldtype: "Data"
-		},
-		{
-			label: __("Country"),
-			fieldname: "country",
-			fieldtype: "Link",
-			options: "Country",
-			reqd: 1
-		},
-		{
 			label: __("Customer POS Id"),
 			fieldname: "customer_pos_id",
 			fieldtype: "Data",


### PR DESCRIPTION
Removed address section with it's mandatory fields as it slowed down quick entry process

![Screenshot 2019-09-20 at 6 38 04 AM](https://user-images.githubusercontent.com/25857446/65291501-4829d800-db71-11e9-9dae-62b44d0e039a.png)

