### PR TITLE
fix: removed mandatory property for address field in quick entry

### DIFF
--- a/erpnext/public/js/utils/customer_quick_entry.js
+++ b/erpnext/public/js/utils/customer_quick_entry.js
@@ -2,6 +2,7 @@ frappe.provide('frappe.ui.form');
 
 frappe.ui.form.CustomerQuickEntryForm = frappe.ui.form.QuickEntryForm.extend({
 	init: function(doctype, after_insert) {
+		this.skip_redirect_on_error = true;
 		this._super(doctype, after_insert);
 	},
 
@@ -37,8 +38,7 @@ frappe.ui.form.CustomerQuickEntryForm = frappe.ui.form.QuickEntryForm.extend({
 		{
 			label: __("Address Line 1"),
 			fieldname: "address_line1",
-			fieldtype: "Data",
-			reqd: 1
+			fieldtype: "Data"
 		},
 		{
 			label: __("Address Line 2"),
@@ -56,8 +56,7 @@ frappe.ui.form.CustomerQuickEntryForm = frappe.ui.form.QuickEntryForm.extend({
 		{
 			label: __("City"),
 			fieldname: "city",
-			fieldtype: "Data",
-			reqd: 1,
+			fieldtype: "Data"
 		},
 		{
 			label: __("State"),
@@ -68,8 +67,7 @@ frappe.ui.form.CustomerQuickEntryForm = frappe.ui.form.QuickEntryForm.extend({
 			label: __("Country"),
 			fieldname: "country",
 			fieldtype: "Link",
-			options: "Country",
-			reqd: 1
+			options: "Country"
 		},
 		{
 			label: __("Customer POS Id"),

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -357,6 +357,16 @@ def make_contact(args, is_primary_contact=1):
 	return contact
 
 def make_address(args, is_primary_address=1):
+	reqd_fields = []
+	for field in ['city', 'country']:
+		if not args.get(field):
+			reqd_fields.append( '<li>' + field.title() + '</li>')
+
+	if reqd_fields:
+		msg = _("Following fields are mandatory to create address:")
+		frappe.throw("{0} <br><br> <ul>{1}</ul>".format(msg, '\n'.join(reqd_fields)),
+			title = _("Missing Values Required"))
+
 	address = frappe.get_doc({
 		'doctype': 'Address',
 		'address_title': args.get('name'),


### PR DESCRIPTION
Removed mandatory property for address field in quick entry and if user has added address line 1 and not city or country then they will get following error message

<img width="979" alt="Screenshot 2019-09-20 at 12 17 08 PM" src="https://user-images.githubusercontent.com/8780500/65305527-057ff400-dba1-11e9-9f92-87a647b65894.png">
