### PR TITLE
fix(Stock): item variant description

### DIFF
--- a/erpnext/controllers/item_variant.py
+++ b/erpnext/controllers/item_variant.py
@@ -283,7 +283,7 @@ def copy_attributes_to_variant(item, variant):
 	if 'description' not in allow_fields:
 		if not variant.description:
 				variant.description = ""
-
+	else:
 		if item.variant_based_on=='Item Attribute':
 			if variant.attributes:
 				attributes_description = item.description + " "
@@ -291,7 +291,7 @@ def copy_attributes_to_variant(item, variant):
 					attributes_description += "<div>" + d.attribute + ": " + cstr(d.attribute_value) + "</div>"
 
 				if attributes_description not in variant.description:
-					variant.description += attributes_description
+					variant.description = attributes_description
 
 def make_variant_item_code(template_item_code, template_item_name, variant):
 	"""Uses template's item code and abbreviations to make variant's item code"""


### PR DESCRIPTION
Problem:
- Item variant description updated even if description field is not present in "copy fields to variant" table in  Item Variant Settings.
- Every time the description is updated in template it is appended to the description in item variant
![item_variant_prob](https://user-images.githubusercontent.com/24353136/65392541-ad5d1380-dd93-11e9-9548-07ea8e10066b.gif)
 