### PR TITLE
fix: null check for valuation rate

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -286,6 +286,9 @@ class BOM(WebsiteGenerator):
 		if not valuation_rate:
 			valuation_rate = frappe.db.get_value("Item", args['item_code'], "valuation_rate")
 
+		if not valuation_rate:
+			frappe.throw(_("Please set valuation rate for item {0}.".format(args['item_code'])))
+
 		return valuation_rate
 
 	def manage_default_bom(self):

--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -173,7 +173,7 @@ class BOM(WebsiteGenerator):
 			#Customer Provided parts will have zero rate
 			if not frappe.db.get_value('Item', arg["item_code"], 'is_customer_provided_item'):
 				if arg.get('bom_no') and self.set_rate_of_sub_assembly_item_based_on_bom:
-					rate = self.get_bom_unitcost(arg['bom_no']) * (arg.get("conversion_factor") or 1)
+					rate = flt(self.get_bom_unitcost(arg['bom_no'])) * (arg.get("conversion_factor") or 1)
 				else:
 					if self.rm_cost_as_per == 'Valuation Rate':
 						rate = self.get_valuation_rate(arg) * (arg.get("conversion_factor") or 1)
@@ -285,9 +285,6 @@ class BOM(WebsiteGenerator):
 
 		if not valuation_rate:
 			valuation_rate = frappe.db.get_value("Item", args['item_code'], "valuation_rate")
-
-		if not valuation_rate:
-			frappe.throw(_("Please set valuation rate for item {0}.".format(args['item_code'])))
 
 		return valuation_rate
 

--- a/erpnext/stock/doctype/item/test_records.json
+++ b/erpnext/stock/doctype/item/test_records.json
@@ -220,7 +220,6 @@
   "item_name": "_Test Serialized Item With Series",
   "serial_no_series": "ABCD.#####",
   "stock_uom": "_Test UOM",
-  "rate": 5000,
   "gst_hsn_code": "999800",
   "item_defaults": [{
     "company": "_Test Company",

--- a/erpnext/stock/doctype/item/test_records.json
+++ b/erpnext/stock/doctype/item/test_records.json
@@ -220,6 +220,7 @@
   "item_name": "_Test Serialized Item With Series",
   "serial_no_series": "ABCD.#####",
   "stock_uom": "_Test UOM",
+  "rate": 5000,
   "gst_hsn_code": "999800",
   "item_defaults": [{
     "company": "_Test Company",


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2019-09-24/apps/frappe/frappe/app.py", line 60, in application
...
  File "/home/frappe/benches/bench-version-12-2019-09-24/apps/erpnext/erpnext/manufacturing/doctype/bom/bom.py", line 229, in update_cost
    "conversion_factor": d.conversion_factor
  File "/home/frappe/benches/bench-version-12-2019-09-24/apps/erpnext/erpnext/manufacturing/doctype/bom/bom.py", line 179, in get_rm_rate
    rate = self.get_valuation_rate(arg) * (arg.get("conversion_factor") or 1)
TypeError: unsupported operand type(s) for *: 'NoneType' and 'int'
```

Valuation rate if null would break, added a `frappe.throw`