### PR TITLE
feat(regional): enable transaction log for germany

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -212,17 +212,16 @@ doc_events = {
 	("Sales Taxes and Charges Template", 'Price List'): {
 		"on_update": "erpnext.shopping_cart.doctype.shopping_cart_settings.shopping_cart_settings.validate_cart_settings"
 	},
-
 	"Website Settings": {
 		"validate": "erpnext.portal.doctype.products_settings.products_settings.home_page_is_products"
 	},
 	"Sales Invoice": {
-		"on_submit": ["erpnext.regional.france.utils.create_transaction_log", "erpnext.regional.italy.utils.sales_invoice_on_submit"],
+		"on_submit": ["erpnext.regional.create_transaction_log", "erpnext.regional.italy.utils.sales_invoice_on_submit"],
 		"on_cancel": "erpnext.regional.italy.utils.sales_invoice_on_cancel",
 		"on_trash": "erpnext.regional.check_deletion_permission"
 	},
 	"Payment Entry": {
-		"on_submit": ["erpnext.regional.france.utils.create_transaction_log", "erpnext.accounts.doctype.payment_request.payment_request.make_status_as_paid"],
+		"on_submit": ["erpnext.regional.create_transaction_log", "erpnext.accounts.doctype.payment_request.payment_request.make_status_as_paid"],
 		"on_trash": "erpnext.regional.check_deletion_permission"
 	},
 	'Address': {

--- a/erpnext/regional/__init__.py
+++ b/erpnext/regional/__init__.py
@@ -10,3 +10,21 @@ def check_deletion_permission(doc, method):
 	region = get_region(doc.company)
 	if region in ["Nepal", "France"] and doc.docstatus != 0:
 		frappe.throw(_("Deletion is not permitted for country {0}".format(region)))
+
+def create_transaction_log(doc, method):
+	"""
+	Appends the transaction to a chain of hashed logs for legal resons.
+	Called on submit of Sales Invoice and Payment Entry.
+	"""
+	region = get_region()
+	if region not in ["France", "Germany"]:
+		return
+
+	data = str(doc.as_dict())
+
+	frappe.get_doc({
+		"doctype": "Transaction Log",
+		"reference_doctype": doc.doctype,
+		"document_name": doc.name,
+		"data": data
+	}).insert(ignore_permissions=True)

--- a/erpnext/regional/france/utils.py
+++ b/erpnext/regional/france/utils.py
@@ -3,22 +3,6 @@
 
 from __future__ import unicode_literals
 import frappe
-from frappe import _
-from erpnext import get_region
-
-def create_transaction_log(doc, method):
-	region = get_region()
-	if region not in ["France"]:
-		return
-	else:
-		data = str(doc.as_dict())
-
-		frappe.get_doc({
-			"doctype": "Transaction Log",
-			"reference_doctype": doc.doctype,
-			"document_name": doc.name,
-			"data": data
-		}).insert(ignore_permissions=True)
 
 # don't remove this function it is used in tests
 def test_method():


### PR DESCRIPTION
## Motivation
Compliance requirements described in https://github.com/frappe/frappe/pull/4974 also apply to Germany according to §3 [KassenSichV](https://www.bundesfinanzministerium.de/Content/DE/Gesetzestexte/Gesetze_Verordnungen/2017-10-06-KassenSichV.html):

> (1) The storage of current business transactions or other transactions within the meaning of § 146a paragraph 1 sentence 1 of the Fiscal Code must be complete, unchanged and tamper-proof on a non-volatile storage medium.
> (2) The stored business transactions or other transactions within the meaning of § 146a paragraph 1 sentence 1 of the Fiscal Code must be chained as transactions in such a way that gaps in the records can be identified.
> ...

## Changes
- Move `create_transaction_log` from `regional.france.utils` up to `regional`.
- Add "Germany" as allowed country