### PR TITLE
fix: mismatch stock value between stock balance report and stock in hand in trial balance

### DIFF
--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -515,10 +515,15 @@ class BuyingController(StockController):
 			for d in self.get('supplied_items'):
 				# negative quantity is passed, as raw material qty has to be decreased
 				# when PR is submitted and it has to be increased when PR is cancelled
+				incoming_rate = 0
+				if self.is_return and self.return_against and self.docstatus==1:
+					incoming_rate = self.get_incoming_rate_for_sales_return(d.rm_item_code, self.return_against)
+
 				sl_entries.append(self.get_sl_entries(d, {
 					"item_code": d.rm_item_code,
 					"warehouse": self.supplier_warehouse,
 					"actual_qty": -1*flt(d.consumed_qty),
+					"incoming_rate": incoming_rate
 				}))
 
 	def on_submit(self):


### PR DESCRIPTION
**Issue**

1. Created subcontracted purchase receipt 
1. System has successfully added finished good in the stores and removed the raw materials from the supplier's warehouse.
1. Create purchase return entry against the subcontracted purchase receipt entry.
1. On submission of return purchase receipt, the raw materials has again added in the supplier's warehouse with incoming rate as zero. Due to this the value in the stock balance and the value in the GL has been booked incorrectly.

<img width="1183" alt="Screenshot 2019-09-30 at 1 02 37 PM" src="https://user-images.githubusercontent.com/8780500/65858905-b1d18f80-e384-11e9-8597-81ade867ae37.png">


**After fix**
![image](https://user-images.githubusercontent.com/8780500/65858917-b7c77080-e384-11e9-87bb-db1e553b1954.png)
