### PR TITLE
fix: Party Name column empty in accounts receivable/ payable summary

### DIFF
--- a/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py
+++ b/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py
@@ -3,7 +3,7 @@
 
 from __future__ import unicode_literals
 import frappe
-from frappe import _
+from frappe import _, scrub
 from frappe.utils import flt, cint
 from erpnext.accounts.party import get_partywise_advanced_payment_amount
 from erpnext.accounts.report.accounts_receivable.accounts_receivable import ReceivablePayableReport
@@ -40,7 +40,7 @@ class AccountsReceivableSummary(ReceivablePayableReport):
 
 			row.party = party
 			if self.party_naming_by == "Naming Series":
-				row.party_name = frappe.get_cached_value(self.party_type, party, [self.party_type + "_name"])
+				row.party_name = frappe.get_cached_value(self.party_type, party, scrub(self.party_type) + "_name")
 
 			row.update(party_dict)
 


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/42651287/65860947-f95a1a80-e388-11e9-8809-ac3007b2ba11.png)

After:
![image](https://user-images.githubusercontent.com/42651287/65860997-11319e80-e389-11e9-841b-4e9a1b62a89a.png)

