### PR TITLE
fix: Get leave approvers in Employee leave balance report

### DIFF
--- a/erpnext/hr/report/employee_leave_balance/employee_leave_balance.py
+++ b/erpnext/hr/report/employee_leave_balance/employee_leave_balance.py
@@ -60,7 +60,10 @@ def get_data(filters, leave_types):
 
 	data = []
 	for employee in active_employees:
-		leave_approvers = department_approver_map.get(employee.department_name, []).append(employee.leave_approver)
+		leave_approvers = department_approver_map.get(employee.department_name, [])
+		if employee.leave_approver:
+			leave_approvers.append(employee.leave_approver)
+
 		if (len(leave_approvers) and user in leave_approvers) or (user in ["Administrator", employee.user_id]) or ("HR Manager" in frappe.get_roles(user)):
 			row = [employee.name, employee.employee_name, employee.department]
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/deploy/frappe-bench/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/home/deploy/frappe-bench/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/home/deploy/frappe-bench/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/deploy/frappe-bench/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/deploy/frappe-bench/apps/frappe/frappe/__init__.py", line 1036, in call
    return fn(*args, **newargs)
  File "/home/deploy/frappe-bench/apps/frappe/frappe/__init__.py", line 511, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "/home/deploy/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 200, in run
    result = generate_report_result(report, filters, user)
  File "/home/deploy/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 75, in generate_report_result
    res = frappe.get_attr(method_name)(frappe._dict(filters))
  File "/home/deploy/frappe-bench/apps/erpnext/erpnext/hr/report/employee_leave_balance/employee_leave_balance.py", line 18, in execute
    data = get_data(filters, leave_types)
  File "/home/deploy/frappe-bench/apps/erpnext/erpnext/hr/report/employee_leave_balance/employee_leave_balance.py", line 64, in get_data
    if (len(leave_approvers) and user in leave_approvers) or (user in ["Administrator", employee.user_id]) or ("HR Manager" in frappe.get_roles(user)):
TypeError: object of type 'NoneType' has no len()
```