### PR TITLE
fix(address): get the address title at the top and mandatory in display

### DIFF
--- a/erpnext/public/js/templates/address_list.html
+++ b/erpnext/public/js/templates/address_list.html
@@ -1,23 +1,22 @@
 <div class="clearfix"></div>
 {% for(var i=0, l=addr_list.length; i<l; i++) { %}
-    <div class="address-box">
-    <p class="h6">
-        {%= i+1 %}. {%= addr_list[i].address_type!="Other" ? __(addr_list[i].address_type) : addr_list[i].address_title %}
-        {% if(addr_list[i].is_primary_address) { %}
-            <span class="text-muted">({%= __("Primary") %})</span>{% } %}
-        {% if(addr_list[i].is_shipping_address) { %}
-            <span class="text-muted">({%= __("Shipping") %})</span>{% } %}
+<div class="address-box">
+	<p class="h6">
+		{%= i+1 %}. {%= addr_list[i].address_title %}{% if(addr_list[i].address_type!="Other") { %}
+		<span class="text-muted">({%= __(addr_list[i].address_type) %})</span>{% } %}
+		{% if(addr_list[i].is_primary_address) { %}
+		<span class="text-muted">({%= __("Primary") %})</span>{% } %}
+		{% if(addr_list[i].is_shipping_address) { %}
+		<span class="text-muted">({%= __("Shipping") %})</span>{% } %}
 
-        <a href="#Form/Address/{%= encodeURIComponent(addr_list[i].name) %}"
-            class="btn btn-default btn-xs pull-right"
-				style="margin-top:-3px; margin-right: -5px;">
-            {%= __("Edit") %}</a>
-    </p>
-        <p>{%= addr_list[i].display %}</p>
-    </div>
+		<a href="#Form/Address/{%= encodeURIComponent(addr_list[i].name) %}" class="btn btn-default btn-xs pull-right"
+			style="margin-top:-3px; margin-right: -5px;">
+			{%= __("Edit") %}</a>
+	</p>
+	<p>{%= addr_list[i].display %}</p>
+</div>
 {% } %}
 {% if(!addr_list.length) { %}
 <p class="text-muted small">{%= __("No address added yet.") %}</p>
 {% } %}
 <p><button class="btn btn-xs btn-default btn-address">{{ __("New Address") }}</button></p>
-


### PR DESCRIPTION
**Problem:**
In the Address and Contacts section it doesn't display the address title.

**Screenshots/Gifs:**
Previous System - 
![Screenshot 2019-10-03 at 4 34 03 PM](https://user-images.githubusercontent.com/13060550/66121814-a89e2800-e5fb-11e9-8f42-0efcf8e1596e.png)

Addition - 
![Screenshot 2019-10-03 at 3 48 46 PM](https://user-images.githubusercontent.com/13060550/66121857-c66b8d00-e5fb-11e9-8972-f052b00c2fdc.png)

