### PR TITLE
fix: not able to submit the work order

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -328,6 +328,10 @@ class StockEntry(StockController):
 			completed_qty = d.completed_qty + (allowance_percentage/100 * d.completed_qty)
 			if total_completed_qty > flt(completed_qty):
 				job_card = frappe.db.get_value('Job Card', {'operation_id': d.name}, 'name')
+				if not job_card:
+					frappe.throw(_("Work Order {0}: job card not found for the operation {1}")
+						.format(self.work_order, job_card))
+
 				work_order_link = frappe.utils.get_link_to_form('Work Order', self.work_order)
 				job_card_link = frappe.utils.get_link_to_form('Job Card', job_card)
 				frappe.throw(_("Row #{0}: Operation {1} is not completed for {2} qty of finished goods in Work Order {3}. Please update operation status via Job Card {4}.")


### PR DESCRIPTION
**Issue**

frappe.utils.get_link_to_form("Job Card", None)

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2019-09-24-1/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-12-2019-09-24-1/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-12-2019-09-24-1/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-12-2019-09-24-1/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-12-2019-09-24-1/apps/frappe/frappe/__init__.py", line 1036, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-12-2019-09-24-1/apps/erpnext/erpnext/manufacturing/doctype/work_order/work_order.py", line 637, in make_stock_entry
    stock_entry.get_items()
  File "/home/frappe/benches/bench-version-12-2019-09-24-1/apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.py", line 761, in get_items
    self.validate_work_order()
  File "/home/frappe/benches/bench-version-12-2019-09-24-1/apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.py", line 315, in validate_work_order
    self.check_if_operations_completed()
  File "/home/frappe/benches/bench-version-12-2019-09-24-1/apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.py", line 332, in check_if_operations_completed
    job_card_link = frappe.utils.get_link_to_form('Job Card', job_card)
  File "/home/frappe/benches/bench-version-12-2019-09-24-1/apps/frappe/frappe/utils/data.py", line 772, in get_link_to_form
    return """{1}""".format(get_url_to_form(doctype, name), label)
  File "/home/frappe/benches/bench-version-12-2019-09-24-1/apps/frappe/frappe/utils/data.py", line 796, in get_url_to_form
    return get_url(uri = "desk#Form/{0}/{1}".format(quoted(doctype), quoted(name)))
  File "/home/frappe/benches/bench-version-12-2019-09-24-1/apps/frappe/frappe/utils/data.py", line 980, in quoted
    return cstr(quote(encode(url), safe=b"~@#$&()*!+=:;,.?/'"))
  File "/usr/lib64/python3.6/urllib/parse.py", line 789, in quote
    return quote_from_bytes(string, safe)
  File "/usr/lib64/python3.6/urllib/parse.py", line 814, in quote_from_bytes
    raise TypeError("quote_from_bytes() expected bytes")
TypeError: quote_from_bytes() expected bytes
```