### PR TITLE
Revert fix: Decimal point issue for e-invoice

### DIFF
--- a/erpnext/regional/italy/e-invoice.xml
+++ b/erpnext/regional/italy/e-invoice.xml
@@ -1,11 +1,5 @@
 {%- macro format_float(value, precision=2) -%}
-{%- if frappe.utils.cint(precision) == 3 %}
-{{ "%.3f" % value|abs }}
-{%- elif frappe.utils.cint(precision) == 4 -%}
-{{ "%.4f" % value|abs }}
-{%- else -%}
-{{ "%.2f" % value|abs }}
-{%- endif %}
+{{ value|round(frappe.utils.cint(precision)) }}
 {%- endmacro -%}
 
 {%- macro render_address(address) %}


### PR DESCRIPTION
Reverts frappe/erpnext#19068

Why didn't you consider that there may be countries with decimal separator as comma "," ? Did you thoroughly test this on the interface? We cannot use the system at all now that everything we write on value fields are just converted when they have decimals in them!