### PR TITLE
fix: fetch allocated amount for individual invoice

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -1045,7 +1045,7 @@ def make_payment_order(source_name, target_doc=None):
 
 	def update_item(source_doc, target_doc, source_parent):
 		target_doc.bank_account = source_parent.party_bank_account
-		target_doc.amount = source_parent.base_paid_amount
+		target_doc.amount = source_doc.allocated_amount
 		target_doc.account = source_parent.paid_to
 		target_doc.payment_entry = source_parent.name
 		target_doc.supplier = source_parent.party


### PR DESCRIPTION
Each row in payment order corresponds to the individual invoices in the payment entry/request, currently, the entire payment entry amount is getting fetched. It should only fetch the amount that is allocated in the payment entry for each row.