### PR TITLE
fix: while submitting landed cost voucher user getting negative stock…

### DIFF
--- a/erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.py
+++ b/erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.py
@@ -129,7 +129,7 @@ class LandedCostVoucher(Document):
 
 			# update stock & gl entries for submit state of PR
 			doc.docstatus = 1
-			doc.update_stock_ledger(via_landed_cost_voucher=True)
+			doc.update_stock_ledger(allow_negative_stock=True, via_landed_cost_voucher=True)
 			doc.make_gl_entries()
 
 	def update_rate_in_serial_no(self, receipt_document):


### PR DESCRIPTION
**Issue**

- User has created purchase receipt and added same item two times, eg ABC item added two times with 3000 qty against each

- Then created some stock entries to transfer the same items.

- Then tries to create landed cost voucher but got the negative stock error

**After Fix**

- Before Submission the available qty in stock was 2500

- While submitting landed cost voucher system has removed the stock ledger entries of 6000 qty and tries to make stock ledger entries with new value. But while making the stock ledger entry for 1st 3000 qty, system got the negative stock error because remain 3000 qty stock ledger was not created. So enable allow negative stock error flag while making the stock ledger entry