### PR TITLE
fix: name 'link_link_doctype' is not defined

### DIFF
--- a/erpnext/crm/doctype/utils.py
+++ b/erpnext/crm/doctype/utils.py
@@ -17,7 +17,7 @@ def get_last_interaction(contact=None, lead=None):
 			if link.link_doctype == 'Customer':
 				last_issue = get_last_issue_from_customer(link.link_name)
 			query_condition += "(`reference_doctype`=%s AND `reference_name`=%s) OR"
-			values += [link_link_doctype, link_link_name]
+			values += [link.link_doctype, link.link_name]
 
 		if query_condition:
 			# remove extra appended 'OR'


### PR DESCRIPTION
**Issue**

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2019-10-03/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-12-2019-10-03/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-12-2019-10-03/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-12-2019-10-03/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-12-2019-10-03/apps/frappe/frappe/__init__..py", line 1036, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-12-2019-10-03/apps/erpnext/erpnext/crm/doctype/utils..py", line 20, in get_last_interaction
    values += [link_link_doctype, link_link_name]
NameError: name 'link_link_doctype' is not defined
```