### PR TITLE
fix: Get contact details

### DIFF
--- a/erpnext/crm/doctype/opportunity/opportunity.js
+++ b/erpnext/crm/doctype/opportunity/opportunity.js
@@ -100,6 +100,10 @@ frappe.ui.form.on("Opportunity", {
 				});
 			}
 		}
+
+		if (frm.doc.opportunity_from && frm.doc.party_name && !frm.doc.contact_person) {
+			frm.trigger("party_name");
+		}
 	},
 
 	set_contact_link: function(frm) {

--- a/erpnext/selling/doctype/quotation/quotation.js
+++ b/erpnext/selling/doctype/quotation/quotation.js
@@ -23,6 +23,9 @@ frappe.ui.form.on('Quotation', {
 	refresh: function(frm) {
 		frm.trigger("set_label");
 		frm.trigger("set_dynamic_field_label");
+		if (frm.doc.quotation_to && frm.doc.party_name && !frm.doc.contact_person) {
+			frm.trigger("party_name");
+		}
 	},
 
 	quotation_to: function(frm) {


### PR DESCRIPTION
- When creating a Quotation or Opportunity, Contact details were not fetched as the function `party_name` wasn't getting triggered to fetch the details.