### PR TITLE
fix: Typo in attendance date filter

### DIFF
--- a/erpnext/hr/doctype/leave_application/leave_application.py
+++ b/erpnext/hr/doctype/leave_application/leave_application.py
@@ -125,7 +125,7 @@ class LeaveApplication(Document):
 				status = "Half Day" if date == self.half_day_date else "On Leave"
 
 				attendance_name = frappe.db.exists('Attendance', dict(employee = self.employee,
-					attenance_date = date, docstatus = ('!=', 2)))
+					attendance_date = date, docstatus = ('!=', 2)))
 
 				if attendance_name:
 					# update existing attendance, change absent to on leave

--- a/erpnext/hr/doctype/leave_application/leave_application_dashboard.py
+++ b/erpnext/hr/doctype/leave_application/leave_application_dashboard.py
@@ -5,6 +5,12 @@ from frappe import _
 
 def get_data():
 	return {
+		'fieldname': 'leave_application',
+		'transactions': [
+			{
+				'items': ['Attendance']
+			}
+		],
         'reports': [
 			{
                 'label': _('Reports'),

--- a/erpnext/hr/doctype/leave_application/test_leave_application.py
+++ b/erpnext/hr/doctype/leave_application/test_leave_application.py
@@ -72,7 +72,7 @@ class TestLeaveApplication(unittest.TestCase):
 		application.to_date = "2013-01-05"
 		return application
 
-	def test_attendance_creation(self):
+	def test_overwrite_attendance(self):
 		'''check attendance is automatically created on leave approval'''
 		make_allocation_record()
 		application = self.get_application(_test_records[0])
@@ -82,7 +82,8 @@ class TestLeaveApplication(unittest.TestCase):
 		application.insert()
 		application.submit()
 
-		attendance = frappe.get_all('Attendance', ['name', 'status', 'attendance_date'], dict(leave_application = application.name))
+		attendance = frappe.get_all('Attendance', ['name', 'status', 'attendance_date'],
+			dict(attendance_date=('between', ['2018-01-01', '2018-01-03']), docstatus=("!=", 2)))
 
 		# attendance created for all 3 days
 		self.assertEqual(len(attendance), 3)
@@ -94,20 +95,6 @@ class TestLeaveApplication(unittest.TestCase):
 		dates = [d.attendance_date for d in attendance]
 		for d in ('2018-01-01', '2018-01-02', '2018-01-03'):
 			self.assertTrue(getdate(d) in dates)
-
-	def test_overwrite_attendance(self):
-		# employee marked as absent
-		doc = frappe.new_doc("Attendance")
-		doc.employee = '_T-Employee-00001'
-		doc.attendance_date = '2018-01-01'
-		doc.company = '_Test Company'
-		doc.status = 'Absent'
-		doc.flags.ignore_validate = True
-		doc.insert(ignore_permissions=True)
-		doc.submit()
-
-		# now check if the status has been updated
-		self.test_attendance_creation()
 
 	def test_block_list(self):
 		self._clear_roles()


### PR DESCRIPTION
fixes typo in filter parameter which creates duplicate Attendance

Closes #19290
