### PR TITLE
fix: Always set required date based on min date on item table

### DIFF
--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -589,6 +589,23 @@ class TestPurchaseOrder(unittest.TestCase):
 		frappe.db.set_value("Accounts Settings", "Accounts Settings",
 			"unlink_advance_payment_on_cancelation_of_order", 0)
 
+	def test_schedule_date(self):
+		po = create_purchase_order(do_not_submit=True)
+		po.schedule_date = None
+		po.append("items", {
+			"item_code": "_Test Item",
+			"qty": 1,
+			"rate": 100,
+			"schedule_date": add_days(nowdate(), 5)
+		})
+		po.save()
+		self.assertEqual(po.schedule_date, add_days(nowdate(), 1))
+
+		po.items[0].schedule_date = add_days(nowdate(), 2)
+		po.save()
+		self.assertEqual(po.schedule_date, add_days(nowdate(), 2))
+
+
 def make_pr_against_po(po, received_qty=0):
 	pr = make_purchase_receipt(po)
 	pr.get("items")[0].qty = received_qty or 5

--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -696,7 +696,9 @@ class BuyingController(StockController):
 		if not self.get("items"):
 			return
 
-		self.schedule_date = min([d.schedule_date for d in self.get("items")])
+		earliest_schedule_date = min([d.schedule_date for d in self.get("items")])
+		if earliest_schedule_date:
+			self.schedule_date = earliest_schedule_date
 
 		if self.schedule_date:
 			for d in self.get('items'):

--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -695,8 +695,8 @@ class BuyingController(StockController):
 	def validate_schedule_date(self):
 		if not self.get("items"):
 			return
-		if not self.schedule_date:
-			self.schedule_date = min([d.schedule_date for d in self.get("items")])
+
+		self.schedule_date = min([d.schedule_date for d in self.get("items")])
 
 		if self.schedule_date:
 			for d in self.get('items'):


### PR DESCRIPTION
Always set required date based on min date on item table on Purchase Order