### PR TITLE
fix: restricted duplicate guardians on student doctype (#19194)

### DIFF
--- a/erpnext/education/doctype/student/student.js
+++ b/erpnext/education/doctype/student/student.js
@@ -27,3 +27,16 @@ frappe.ui.form.on('Student', {
 		}
 	}
 });
+
+frappe.ui.form.on('Student Guardian', {
+	guardians_add: function(frm){
+		frm.fields_dict['guardians'].grid.get_field('guardian').get_query = function(doc){
+			var guardian_list = [];
+			if(!doc.__islocal) guardian_list.push(doc.guardian);
+			$.each(doc.guardians, function(idx, val){
+				if (val.guardian) guardian_list.push(val.guardian);
+			});
+			return { filters: [['Guardian', 'name', 'not in', guardian_list]] };
+		};
+	}
+});


### PR DESCRIPTION
Please read the pull request checklist to make sure your changes are merged: https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

![duplicate_guardians](https://user-images.githubusercontent.com/35300966/66816766-41b43380-ef58-11e9-91bd-c3a3571ea8a6.png)
As seen above, duplicate guardians were getting added on Student Doctype, resulting in adding duplicate student on Guardian Doctype as seen below.
![duplicate_student](https://user-images.githubusercontent.com/35300966/66817047-b8513100-ef58-11e9-82df-2c6eeecad443.png)

Hence, restricted duplicate guardians on Student Doctype.
![restricted_duplicates](https://user-images.githubusercontent.com/35300966/66817145-dfa7fe00-ef58-11e9-9a49-8b6620748906.png)
