### PR TITLE
fix: Allow Buying and Selling for same Currency Exchange on same day

### DIFF
--- a/erpnext/setup/doctype/currency_exchange/currency_exchange.py
+++ b/erpnext/setup/doctype/currency_exchange/currency_exchange.py
@@ -11,7 +11,7 @@ from frappe.utils import get_datetime_str, formatdate, nowdate, cint
 
 class CurrencyExchange(Document):
 	def autoname(self):
-		purpose: str = ""
+		purpose = str("")
 		if not self.date:
 			self.date = nowdate()
 		if cint(self.for_buying)==0 and cint(self.for_selling)==1:

--- a/erpnext/setup/doctype/currency_exchange/currency_exchange.py
+++ b/erpnext/setup/doctype/currency_exchange/currency_exchange.py
@@ -13,8 +13,12 @@ class CurrencyExchange(Document):
 	def autoname(self):
 		if not self.date:
 			self.date = nowdate()
-		self.name = '{0}-{1}-{2}'.format(formatdate(get_datetime_str(self.date), "yyyy-MM-dd"),
-			self.from_currency, self.to_currency)
+		if cint(self.for_buying)==0 and cint(self.for_selling)==1:
+			self.purpose = "Selling"
+		if cint(self.for_buying)==1 and cint(self.for_selling)==0:
+			self.purpose = "Buying"
+		self.name = '{0}-{1}-{2}-{3}'.format(formatdate(get_datetime_str(self.date), "yyyy-MM-dd"),
+			self.from_currency, self.to_currency, self.purpose)
 
 	def validate(self):
 		self.validate_value("exchange_rate", ">", 0)

--- a/erpnext/setup/doctype/currency_exchange/currency_exchange.py
+++ b/erpnext/setup/doctype/currency_exchange/currency_exchange.py
@@ -11,6 +11,7 @@ from frappe.utils import get_datetime_str, formatdate, nowdate, cint
 
 class CurrencyExchange(Document):
 	def autoname(self):
+		purpose = ""
 		if not self.date:
 			self.date = nowdate()
 		if cint(self.for_buying)==0 and cint(self.for_selling)==1:

--- a/erpnext/setup/doctype/currency_exchange/currency_exchange.py
+++ b/erpnext/setup/doctype/currency_exchange/currency_exchange.py
@@ -11,7 +11,7 @@ from frappe.utils import get_datetime_str, formatdate, nowdate, cint
 
 class CurrencyExchange(Document):
 	def autoname(self):
-		purpose = ""
+		purpose: str = ""
 		if not self.date:
 			self.date = nowdate()
 		if cint(self.for_buying)==0 and cint(self.for_selling)==1:

--- a/erpnext/setup/doctype/currency_exchange/currency_exchange.py
+++ b/erpnext/setup/doctype/currency_exchange/currency_exchange.py
@@ -14,11 +14,11 @@ class CurrencyExchange(Document):
 		if not self.date:
 			self.date = nowdate()
 		if cint(self.for_buying)==0 and cint(self.for_selling)==1:
-			self.purpose = "Selling"
+			purpose = "Selling"
 		if cint(self.for_buying)==1 and cint(self.for_selling)==0:
-			self.purpose = "Buying"
+			purpose = "Buying"
 		self.name = '{0}-{1}-{2}-{3}'.format(formatdate(get_datetime_str(self.date), "yyyy-MM-dd"),
-			self.from_currency, self.to_currency, self.purpose)
+			self.from_currency, self.to_currency, purpose)
 
 	def validate(self):
 		self.validate_value("exchange_rate", ">", 0)


### PR DESCRIPTION
Buying and Selling for the same Currency Exchange on the same day was not possible because of the embedded naming logic here. There may also be different sources of Currency Exchange data so we need to incorporate this in the future.

Please read the pull request checklist to make sure your changes are merged: https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

