### PR TITLE
fix: Rendered Email Template in Email Campaign

### DIFF
--- a/erpnext/crm/doctype/email_campaign/email_campaign.py
+++ b/erpnext/crm/doctype/email_campaign/email_campaign.py
@@ -73,13 +73,13 @@ def send_mail(entry, email_campaign):
 
 	email_template = frappe.get_doc("Email Template", entry.get("email_template"))
 	sender = frappe.db.get_value("User", email_campaign.get("sender"), 'email')
-
+	context = { "doc":frappe.get_doc(email_campaign.email_campaign_for,email_campaign.recipient) }
 	# send mail and link communication to document
 	comm = make(
 		doctype = "Email Campaign",
 		name = email_campaign.name,
 		subject = email_template.get("subject"),
-		content = email_template.get("response"),
+		content = frappe.render_template(email_template.get("response"),context),
 		sender = sender,
 		recipients = recipient,
 		communication_medium = "Email",


### PR DESCRIPTION
Currently, there was no support for rendering jinja in the response field in Email Campain. We have modified the code such that it can render jinja added in the response field.