### PR TITLE
fix: Don't show make jv button if  equity or liability account and as set account not specified

### DIFF
--- a/erpnext/accounts/doctype/share_transfer/share_transfer.js
+++ b/erpnext/accounts/doctype/share_transfer/share_transfer.js
@@ -16,7 +16,7 @@ frappe.ui.form.on('Share Transfer', {
 				};
 			};
 		});
-		if (frm.doc.docstatus == 1) {
+		if (frm.doc.docstatus == 1 && frm.doc.equity_or_liability_account && frm.doc.asset_account) {
 			frm.add_custom_button(__('Create Journal Entry'), function () {
 				erpnext.share_transfer.make_jv(frm);
 			});


### PR DESCRIPTION

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-11-2019-10-04/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-version-11-2019-10-04/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-11-2019-10-04/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-11-2019-10-04/apps/frappe/frappe/__init__.py", line 1036, in call
    return fn(*args, **newargs)
TypeError: make_jv_entry() takes exactly 8 arguments (6 given)
```

