### PR TITLE
fix: Vitals chart in Patient History not showing

### DIFF
--- a/erpnext/healthcare/page/patient_history/patient_history.js
+++ b/erpnext/healthcare/page/patient_history/patient_history.js
@@ -275,7 +275,7 @@ var show_patient_vital_charts = function(patient, me, btn_show_id, pts, title) {
 					datasets.push({name: "Heart Rate / Pulse", values: pulse, chartType:'line'});
 					datasets.push({name: "Respiratory Rate", values: respiratory_rate, chartType:'line'});
 				}
-				new Chart( ".patient_vital_charts", {
+				new frappe.Chart( ".patient_vital_charts", {
 					data: {
 						labels: labels,
 						datasets: datasets


### PR DESCRIPTION
Was missing the correct constructor for charts in Patients History page
