### PR TITLE
fix: Unable to add details in quotation and opportunity

### DIFF
--- a/erpnext/crm/doctype/lead/lead.py
+++ b/erpnext/crm/doctype/lead/lead.py
@@ -146,14 +146,7 @@ def _make_customer(source_name, target_doc=None, ignore_permissions=False):
 @frappe.whitelist()
 def make_opportunity(source_name, target_doc=None):
 	def set_missing_values(source, target):
-		address = frappe.get_all('Dynamic Link', {
-			'link_doctype': source.doctype,
-			'link_name': source.name,
-			'parenttype': 'Address',
-		}, ['parent'], limit=1)
-
-		if address:
-			target.customer_address = address[0].parent
+		_set_missing_values(source, target)
 
 	target_doc = get_mapped_doc("Lead", source_name,
 		{"Lead": {
@@ -173,19 +166,42 @@ def make_opportunity(source_name, target_doc=None):
 
 @frappe.whitelist()
 def make_quotation(source_name, target_doc=None):
+	def set_missing_values(source, target):
+		_set_missing_values(source, target)
+
 	target_doc = get_mapped_doc("Lead", source_name,
 		{"Lead": {
 			"doctype": "Quotation",
 			"field_map": {
 				"name": "party_name"
 			}
-		}}, target_doc)
+		}}, target_doc, set_missing_values)
+
 	target_doc.quotation_to = "Lead"
 	target_doc.run_method("set_missing_values")
 	target_doc.run_method("set_other_charges")
 	target_doc.run_method("calculate_taxes_and_totals")
 
 	return target_doc
+
+def _set_missing_values(source, target):
+	address = frappe.get_all('Dynamic Link', {
+			'link_doctype': source.doctype,
+			'link_name': source.name,
+			'parenttype': 'Address',
+		}, ['parent'], limit=1)
+
+	contact = frappe.get_all('Dynamic Link', {
+			'link_doctype': source.doctype,
+			'link_name': source.name,
+			'parenttype': 'Contact',
+		}, ['parent'], limit=1)
+
+	if address:
+		target.customer_address = address[0].parent
+
+	if contact:
+		target.contact_person = contact[0].parent
 
 @frappe.whitelist()
 def get_lead_details(lead, posting_date=None, company=None):

--- a/erpnext/crm/doctype/opportunity/opportunity.js
+++ b/erpnext/crm/doctype/opportunity/opportunity.js
@@ -100,10 +100,6 @@ frappe.ui.form.on("Opportunity", {
 				});
 			}
 		}
-
-		if (frm.doc.opportunity_from && frm.doc.party_name && !frm.doc.contact_person) {
-			frm.trigger("party_name");
-		}
 	},
 
 	set_contact_link: function(frm) {
@@ -171,7 +167,7 @@ erpnext.crm.Opportunity = frappe.ui.form.Controller.extend({
 		if (me.frm.doc.opportunity_from == "Lead") {
 			me.frm.set_query('party_name', erpnext.queries['lead']);
 		}
-		else if (me.frm.doc.opportunity_from == "Cuatomer") {
+		else if (me.frm.doc.opportunity_from == "Customer") {
 			me.frm.set_query('party_name', erpnext.queries['customer']);
 		}
 	},

--- a/erpnext/selling/doctype/quotation/quotation.js
+++ b/erpnext/selling/doctype/quotation/quotation.js
@@ -23,9 +23,6 @@ frappe.ui.form.on('Quotation', {
 	refresh: function(frm) {
 		frm.trigger("set_label");
 		frm.trigger("set_dynamic_field_label");
-		if (frm.doc.quotation_to && frm.doc.party_name && !frm.doc.contact_person) {
-			frm.trigger("party_name");
-		}
 	},
 
 	quotation_to: function(frm) {


### PR DESCRIPTION
This PR reverts the changes made by this PR: https://github.com/frappe/erpnext/pull/19281
Since the triggers are written inside `refresh` trying to select any other field triggers `refresh` which in turn triggers  `party_name` and the focus again shifts to party_type due to which user is unable to enter any details.

Contact details are fetched just fine on selection of `party_name` without the trigger in refresh. Please refer below GIF:
![Address](https://user-images.githubusercontent.com/42651287/67149287-2bdf9f00-f2c7-11e9-8877-b8be3d396ed8.gif)

