### PR TITLE
fix: Item Price changes are not persistent after updating cost on submitted BOM

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.js
+++ b/erpnext/manufacturing/doctype/bom/bom.js
@@ -117,7 +117,7 @@ frappe.ui.form.on("BOM", {
 			args: {
 				update_parent: true,
 				from_child_bom:false,
-				save: false
+				save: frm.doc.docstatus === 1 ? true : false
 			},
 			callback: function(r) {
 				refresh_field("items");


### PR DESCRIPTION
If raw materials are updated using the `Update Cost` button prices are updated but they are not persistent for a submitted doc and changes back to old one on refresh
