### PR TITLE
fix: stock balance report not working if actual qty is zero

### DIFF
--- a/erpnext/stock/report/stock_balance/stock_balance.py
+++ b/erpnext/stock/report/stock_balance/stock_balance.py
@@ -39,6 +39,9 @@ def execute(filters=None):
 
 	data = []
 	conversion_factors = {}
+
+	_func = lambda x: x[1]
+
 	for (company, item, warehouse) in sorted(iwb_map):
 		if item_map.get(item):
 			qty_dict = iwb_map[(company, item, warehouse)]
@@ -70,7 +73,9 @@ def execute(filters=None):
 					'latest_age': 0
 				}
 				if fifo_queue:
-					fifo_queue = sorted(fifo_queue, key=lambda fifo_data: fifo_data[1])
+					fifo_queue = sorted(filter(_func, fifo_queue), key=_func)
+					if not fifo_queue: continue
+
 					stock_ageing_data['average_age'] = get_average_age(fifo_queue, to_date)
 					stock_ageing_data['earliest_age'] = date_diff(to_date, fifo_queue[0][1])
 					stock_ageing_data['latest_age'] = date_diff(to_date, fifo_queue[-1][1])


### PR DESCRIPTION
**Issue**

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2019-10-02/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-12-2019-10-02/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-12-2019-10-02/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-12-2019-10-02/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-12-2019-10-02/apps/frappe/frappe/__init__.py", line 1036, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-12-2019-10-02/apps/frappe/frappe/__init__.py", line 511, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "/home/frappe/benches/bench-version-12-2019-10-02/apps/frappe/frappe/desk/query_report.py", line 200, in run
    result = generate_report_result(report, filters, user)
  File "/home/frappe/benches/bench-version-12-2019-10-02/apps/frappe/frappe/desk/query_report.py", line 75, in generate_report_result
    res = frappe.get_attr(method_name)(frappe._dict(filters))
  File "/home/frappe/benches/bench-version-12-2019-10-02/apps/erpnext/erpnext/stock/report/stock_balance/stock_balance.py", line 73, in execute
    fifo_queue = sorted(fifo_queue, key=lambda fifo_data: fifo_data[1])
TypeError: '<' not supported between instances of 'NoneType' and 'NoneType'
```