### PR TITLE
fix: Sales and Purchase Invoice Status and Payment Reconciliation

### DIFF
--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
@@ -90,7 +90,8 @@ class PaymentReconciliation(Document):
 			FROM `tab{doc}`, `tabGL Entry`
 			WHERE
 				(`tab{doc}`.name = `tabGL Entry`.against_voucher or `tab{doc}`.name = `tabGL Entry`.voucher_no)
-				and `tab{doc}`.is_return = 1 and `tabGL Entry`.against_voucher_type = %(voucher_type)s
+				and `tab{doc}`.is_return = 1 and `tab{doc}`.return_against IS NULL
+				and `tabGL Entry`.against_voucher_type = %(voucher_type)s
 				and `tab{doc}`.docstatus = 1 and `tabGL Entry`.party = %(party)s
 				and `tabGL Entry`.party_type = %(party_type)s and `tabGL Entry`.account = %(account)s
 			GROUP BY `tab{doc}`.name

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice_list.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice_list.js
@@ -6,8 +6,8 @@ frappe.listview_settings['Purchase Invoice'] = {
 	add_fields: ["supplier", "supplier_name", "base_grand_total", "outstanding_amount", "due_date", "company",
 		"currency", "is_return", "release_date", "on_hold"],
 	get_indicator: function(doc) {
-		if(flt(doc.outstanding_amount) < 0 && doc.docstatus == 1) {
-			return [__("Debit Note Issued"), "darkgrey", "outstanding_amount,<,0"]
+		if( (flt(doc.outstanding_amount) <= 0) && doc.docstatus == 1 &&  doc.status == 'Debit Note Issued') {
+			return [__("Debit Note Issued"), "darkgrey", "outstanding_amount,<=,0"];
 		} else if(flt(doc.outstanding_amount) > 0 && doc.docstatus==1) {
 			if(cint(doc.on_hold) && !doc.release_date) {
 				return [__("On Hold"), "darkgrey"];

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -1231,7 +1231,8 @@ class SalesInvoice(SellingController):
 					self.status = "Unpaid and Discounted"
 				elif flt(self.outstanding_amount) > 0 and getdate(self.due_date) >= getdate(nowdate()):
 					self.status = "Unpaid"
-				elif flt(self.outstanding_amount) < 0 and self.is_return==0 and frappe.db.get_value('Sales Invoice', {'is_return': 1, 'return_against': self.name, 'docstatus': 1}):
+				#Check if outstanding amount is 0 due to credit note issued against invoice
+				elif flt(self.outstanding_amount) <= 0 and self.is_return == 0 and frappe.db.get_value('Sales Invoice', {'is_return': 1, 'return_against': self.name, 'docstatus': 1}):
 					self.status = "Credit Note Issued"
 				elif self.is_return == 1:
 					self.status = "Return"

--- a/erpnext/controllers/status_updater.py
+++ b/erpnext/controllers/status_updater.py
@@ -49,7 +49,8 @@ status_map = {
 		["Submitted", "eval:self.docstatus==1"],
 		["Paid", "eval:self.outstanding_amount==0 and self.docstatus==1"],
 		["Return", "eval:self.is_return==1 and self.docstatus==1"],
-		["Debit Note Issued", "eval:self.outstanding_amount < 0 and self.docstatus==1"],
+		["Debit Note Issued",
+		 "eval:self.outstanding_amount <= 0 and self.docstatus==1 and self.is_return==0 and get_value('Purchase Invoice', {'is_return': 1, 'return_against': self.name, 'docstatus': 1})"],
 		["Unpaid", "eval:self.outstanding_amount > 0 and getdate(self.due_date) >= getdate(nowdate()) and self.docstatus==1"],
 		["Overdue", "eval:self.outstanding_amount > 0 and getdate(self.due_date) < getdate(nowdate()) and self.docstatus==1"],
 		["Cancelled", "eval:self.docstatus==2"],
@@ -118,7 +119,6 @@ class StatusUpdater(Document):
 
 		if self.doctype in status_map:
 			_status = self.status
-
 			if status and update:
 				self.db_set("status", status)
 


### PR DESCRIPTION
1) **Unpaid Sales Invoice** Status showed **'Paid'** after Credit note was made against it 
     - Fix: Status is now **'Credit Note Issued'**

2) **Payment Reconciliation** will only show standalone **Debit/Credit Notes** in 'UNRECONCILED PAYMENT DETAILS' section or **Payments** Table