### PR TITLE
fix: setting incorrect field for party bank account

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -308,7 +308,7 @@ frappe.ui.form.on('Payment Entry', {
 							() => {
 								frm.set_party_account_based_on_party = false;
 								if (r.message.bank_account) {
-									frm.set_value("bank_account", r.message.bank_account);
+									frm.set_value("party_bank_account", r.message.bank_account);
 								}
 							}
 						]);


### PR DESCRIPTION
Previously
![wrong](https://user-images.githubusercontent.com/6195660/67369702-0671c000-f569-11e9-9916-a1d1a0c3ddd1.gif)

Corrected
![corrected](https://user-images.githubusercontent.com/6195660/67369663-f9ed6780-f568-11e9-859b-cbfa9857b39e.gif)

In payment entry if the customer had a default bank account set it would be fetched into company bank account rather than party bank account.