### PR TITLE
fix: Remove Rogue comma in Production Plan dashboard

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.js
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.js
@@ -233,7 +233,7 @@ frappe.ui.form.on('Production Plan', {
 
 		if (item_wise_qty) {
 			for (var key in item_wise_qty) {
-				title += __('Item {0}: {1} qty produced, ', [key, item_wise_qty[key]]);
+				title += __('Item {0}: {1} qty produced', [key, item_wise_qty[key]]);
 			}
 		}
 


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/33246109/67413443-c816e800-f5de-11e9-90e2-17f5c4c2a6c9.png)

After:
![image](https://user-images.githubusercontent.com/33246109/67413309-871ed380-f5de-11e9-8639-1aa9bbb93bfe.png)
