### PR TITLE
fix: allow_items_not_in_stock should be evaluated

### DIFF
--- a/erpnext/shopping_cart/cart.py
+++ b/erpnext/shopping_cart/cart.py
@@ -66,7 +66,7 @@ def place_order():
 	from erpnext.selling.doctype.quotation.quotation import _make_sales_order
 	sales_order = frappe.get_doc(_make_sales_order(quotation.name, ignore_permissions=True))
 
-	if not cart_settings.allow_items_not_in_stock:
+	if not cint(cart_settings.allow_items_not_in_stock):
 		for item in sales_order.get("items"):
 			item.reserved_warehouse, is_stock_item = frappe.db.get_value("Item",
 				item.item_code, ["website_warehouse", "is_stock_item"])


### PR DESCRIPTION
**Technical:**
allow_items_not_in_stock is a checked field type and to evaluate it in IF condition **cint** should be used.

**Functional:**
Actual : In Shopping cart settings, 'Allow items not in stock to be added to cart' is checked.
Select items in cart having stock zero. From cart, place order. No validation is fired

Expected: When order is placed system should give below mesage for items not in stock.
throw(_("Only {0} in stock for item {1}")
