### PR TITLE
fix: sync delivery note status in both list view and form view

### DIFF
--- a/erpnext/stock/doctype/delivery_note/delivery_note_list.js
+++ b/erpnext/stock/doctype/delivery_note/delivery_note_list.js
@@ -6,9 +6,9 @@ frappe.listview_settings['Delivery Note'] = {
 			return [__("Return"), "darkgrey", "is_return,=,Yes"];
 		} else if (doc.status === "Closed") {
 			return [__("Closed"), "green", "status,=,Closed"];
-		} else if (doc.grand_total !== 0 && flt(doc.per_billed, 2) < 100) {
+		} else if (flt(doc.per_billed, 2) < 100) {
 			return [__("To Bill"), "orange", "per_billed,<,100"];
-		} else if (doc.grand_total === 0 || flt(doc.per_billed, 2) == 100) {
+		} else if (flt(doc.per_billed, 2) == 100) {
 			return [__("Completed"), "green", "per_billed,=,100"];
 		}
 	},


### PR DESCRIPTION
**Fixes:** currently list view and form view maintain separate status for the document with zero grand total. A  sales invoice can always be created against this delivery note to complete the transaction. Hence, this difference is not needed.