### PR TITLE
chore: Update module name

### DIFF
--- a/erpnext/patches/v10_1/transfer_subscription_to_auto_repeat.py
+++ b/erpnext/patches/v10_1/transfer_subscription_to_auto_repeat.py
@@ -4,7 +4,7 @@ from frappe.model.utils.rename_field import rename_field
 
 
 def execute():
-	frappe.reload_doc('desk', 'doctype', 'auto_repeat')
+	frappe.reload_doc('automation', 'doctype', 'auto_repeat')
 
 	doctypes_to_rename = {
 		'accounts': ['Journal Entry', 'Payment Entry', 'Purchase Invoice', 'Sales Invoice'],


### PR DESCRIPTION
Fixes 
```python-traceback
ImportError: Module import failed for Auto Repeat (frappe.core.doctype.auto_repeat.auto_repeat Error: No module named auto_repeat.auto_repeat)
```