### PR TITLE
fix: Overwrite default cost center if item or item group has default cost center set.

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -205,7 +205,7 @@ class SalesOrder(SellingController):
 		if self.coupon_code:
 			from erpnext.accounts.doctype.pricing_rule.utils import update_coupon_code_count
 			update_coupon_code_count(self.coupon_code,'cancelled')
-			
+
 	def update_project(self):
 		if frappe.db.get_single_value('Selling Settings', 'sales_update_frequency') != "Each Transaction":
 			return
@@ -661,11 +661,14 @@ def make_sales_invoice(source_name, target_doc=None, ignore_permissions=False):
 
 		if source_parent.project:
 			target.cost_center = frappe.db.get_value("Project", source_parent.project, "cost_center")
-		if not target.cost_center and target.item_code:
+		if target.item_code:
 			item = get_item_defaults(target.item_code, source_parent.company)
 			item_group = get_item_group_defaults(target.item_code, source_parent.company)
-			target.cost_center = item.get("selling_cost_center") \
+			cost_center = item.get("selling_cost_center") \
 				or item_group.get("selling_cost_center")
+
+			if cost_center:
+				target.cost_center = cost_center
 
 	doclist = get_mapped_doc("Sales Order", source_name, {
 		"Sales Order": {


### PR DESCRIPTION
While creating a sales invoice from the sales order default cost center was getting fetched (in sales order item) instead of fetching it from item default. 

This fixes that issue.
