### PR TITLE
fix(bom): maintain a default bom for an item

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -290,7 +290,8 @@ class BOM(WebsiteGenerator):
 		return valuation_rate
 
 	def manage_default_bom(self):
-		""" Uncheck others if current one is selected as default,
+		""" Uncheck others if current one is selected as default or
+			check the current one as default if it the only bom for the selected item,
 			update default bom in item master
 		"""
 		if self.is_default and self.is_active:
@@ -299,6 +300,9 @@ class BOM(WebsiteGenerator):
 			item = frappe.get_doc("Item", self.item)
 			if item.default_bom != self.name:
 				frappe.db.set_value('Item', self.item, 'default_bom', self.name)
+		elif not frappe.db.exists(dict(doctype='BOM', docstatus=1, item=self.item, is_default=1)) \
+			and self.is_active:
+			frappe.db.set(self, "is_default", 1)
 		else:
 			frappe.db.set(self, "is_default", 0)
 			item = frappe.get_doc("Item", self.item)


### PR DESCRIPTION
**Issue:** In work order items to be manufactured need a default bom associated with it, currently it is possible to have multiple active boms but no default bom. Items with no default bom are not fetched in the work order. This allows an easy way to identify the items which have a bom associated with it.

**Fix:** This PR proposes a fix to maintain a default bom at all times for any item with active bom. This ensures that the items with active boms are fetched in work order