### PR TITLE
fix: typo in Budget Variance Report

### DIFF
--- a/erpnext/accounts/report/budget_variance_report/budget_variance_report.py
+++ b/erpnext/accounts/report/budget_variance_report/budget_variance_report.py
@@ -69,7 +69,7 @@ def get_columns(filters):
 	for year in fiscal_year:
 		for from_date, to_date in get_period_date_ranges(filters["period"], year[0]):
 			if filters["period"] == "Yearly":
-				labels = [_("Budget") + " " + str(year[0]), _("Actual ") + " " + str(year[0]), _("Varaiance ") + " " + str(year[0])]
+				labels = [_("Budget") + " " + str(year[0]), _("Actual ") + " " + str(year[0]), _("Variance ") + " " + str(year[0])]
 				for label in labels:
 					columns.append(label+":Float:150")
 			else:


### PR DESCRIPTION
**Before:** Varaiance

![Screenshot 2019-10-26 18 46 37](https://user-images.githubusercontent.com/40264279/67620168-70b48a00-f821-11e9-8c69-e6de07152830.png)


**After:** Variance

![Screenshot 2019-10-26 18 47 22](https://user-images.githubusercontent.com/40264279/67620161-5e3a5080-f821-11e9-877e-2379c942fece.png)

