### PR TITLE
fix: 'NoneType' object is not iterable

### DIFF
--- a/erpnext/accounts/dashboard_chart_source/account_balance_timeline/account_balance_timeline.py
+++ b/erpnext/accounts/dashboard_chart_source/account_balance_timeline/account_balance_timeline.py
@@ -3,6 +3,7 @@
 
 from __future__ import unicode_literals
 import frappe, json
+from frappe import _
 from frappe.utils import add_to_date, date_diff, getdate, nowdate, get_last_day, formatdate
 from erpnext.accounts.report.general_ledger.general_ledger import execute
 from frappe.core.page.dashboard.dashboard import cache_source, get_from_date_from_timespan
@@ -23,6 +24,9 @@ def get(chart_name = None, chart = None, no_cache = None, from_date = None, to_d
 
 	account = filters.get("account")
 	company = filters.get("company")
+
+	if not account and chart:
+		frappe.throw(_("Account is not set for the dashboard chart {0}").format(chart))
 
 	if not to_date:
 		to_date = nowdate()

--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -33,6 +33,10 @@ class Company(NestedSet):
 		return exists
 
 	def validate(self):
+		self.update_default_account = False
+		if self.is_new():
+			self.update_default_account = True
+
 		self.validate_abbr()
 		self.validate_default_accounts()
 		self.validate_currency()
@@ -203,8 +207,8 @@ class Company(NestedSet):
 				"default_expense_account": "Cost of Goods Sold"
 			})
 
-		for default_account in default_accounts:
-			if self.is_new() or frappe.flags.in_test or frappe.flags.in_demo:
+		if self.update_default_account or frappe.flags.in_test:
+			for default_account in default_accounts:
 				self._set_default_account(default_account, default_accounts.get(default_account))
 
 		if not self.default_income_account:


### PR DESCRIPTION
**Issue**

Default account is not set while making the company therefore default expense account has not set in the dashboard chart

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2019-10-24/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-2019-10-24/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-2019-10-24/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2019-10-24/apps/frappe/frappe/handler.py", line 61, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2019-10-24/apps/frappe/frappe/__init__.py", line 1038, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2019-10-24/apps/frappe/frappe/core/page/dashboard/dashboard.py", line 27, in wrapper
    results = generate_and_cache_results(chart, chart_name, function, cache_key)
  File "/home/frappe/benches/bench-2019-10-24/apps/frappe/frappe/core/page/dashboard/dashboard.py", line 32, in generate_and_cache_results
    results = function(chart_name = chart_name)
  File "/home/frappe/benches/bench-2019-10-24/apps/erpnext/erpnext/accounts/dashboard_chart_source/account_balance_timeline/account_balance_timeline.py", line 37, in get
    gl_entries = get_gl_entries(account, get_period_ending(to_date, timegrain))
  File "/home/frappe/benches/bench-2019-10-24/apps/erpnext/erpnext/accounts/dashboard_chart_source/account_balance_timeline/account_balance_timeline.py", line 80, in get_gl_entries
    child_accounts = get_descendants_of('Account', account, ignore_permissions=True)
  File "/home/frappe/benches/bench-2019-10-24/apps/frappe/frappe/utils/nestedset.py", line 281, in get_descendants_of
    lft, rgt = frappe.db.get_value(doctype, name, ['lft', 'rgt'])
TypeError: 'NoneType' object is not iterable
```