### PR TITLE
fix: Search field entries included in Item Link field query

### DIFF
--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -152,6 +152,17 @@ def tax_account_query(doctype, txt, searchfield, start, page_len, filters):
 def item_query(doctype, txt, searchfield, start, page_len, filters, as_dict=False):
 	conditions = []
 
+	#Get searchfields from meta and use in Item Link field query
+	meta = frappe.get_meta("Item")
+	searchfields = meta.get_search_fields()
+
+	fields = [f for f in searchfields if not f in ["name", "item_group", "description"]]
+	fields = ", ".join(fields)
+
+	searchfields = searchfields + [f for f in [searchfield or "name", "item_code", "item_group", "item_name"]
+		if not f in searchfields]
+	searchfields = " or ".join([field + " like %(txt)s" for field in searchfields])
+
 	description_cond = ''
 	if frappe.db.count('Item', cache=True) < 50000:
 		# scan description only if items are less than 50000
@@ -162,17 +173,14 @@ def item_query(doctype, txt, searchfield, start, page_len, filters, as_dict=Fals
 			concat(substr(tabItem.item_name, 1, 40), "..."), item_name) as item_name,
 		tabItem.item_group,
 		if(length(tabItem.description) > 40, \
-			concat(substr(tabItem.description, 1, 40), "..."), description) as decription
+			concat(substr(tabItem.description, 1, 40), "..."), description) as description,
+		{fields}
 		from tabItem
 		where tabItem.docstatus < 2
 			and tabItem.has_variants=0
 			and tabItem.disabled=0
 			and (tabItem.end_of_life > %(today)s or ifnull(tabItem.end_of_life, '0000-00-00')='0000-00-00')
-			and (tabItem.`{key}` LIKE %(txt)s
-				or tabItem.item_code LIKE %(txt)s
-				or tabItem.item_group LIKE %(txt)s
-				or tabItem.item_name LIKE %(txt)s
-				or tabItem.item_code IN (select parent from `tabItem Barcode` where barcode LIKE %(txt)s)
+			and ({scond} or tabItem.item_code IN (select parent from `tabItem Barcode` where barcode LIKE %(txt)s)
 				{description_cond})
 			{fcond} {mcond}
 		order by
@@ -182,6 +190,8 @@ def item_query(doctype, txt, searchfield, start, page_len, filters, as_dict=Fals
 			name, item_name
 		limit %(start)s, %(page_len)s """.format(
 			key=searchfield,
+			fields=fields,
+			scond=searchfields,
 			fcond=get_filters_cond(doctype, filters, conditions).replace('%', '%%'),
 			mcond=get_match_cond(doctype).replace('%', '%%'),
 			description_cond = description_cond),


### PR DESCRIPTION
- Entries in **'Search Fields'** field were not considered while querying **Item Link field** in child tables
- Included Search field entries in search condition as well as in fields to fetch and display in **Item** Link field suggestion list.

![_1](https://user-images.githubusercontent.com/25857446/67671256-95cd0800-f99b-11e9-8156-6650b40d57ab.gif)
