### PR TITLE
chore: fix unexpected keyword in shopify_settings

### DIFF
--- a/erpnext/erpnext_integrations/doctype/shopify_log/shopify_log.py
+++ b/erpnext/erpnext_integrations/doctype/shopify_log/shopify_log.py
@@ -39,7 +39,7 @@ def get_message(exception):
 	if hasattr(exception, 'message'):
 		message = exception.message
 	elif hasattr(exception, '__str__'):
-		message = e.__str__()
+		message = exception.__str__()
 	else:
 		message = "Something went wrong while syncing"
 	return message

--- a/erpnext/erpnext_integrations/doctype/shopify_settings/shopify_settings.py
+++ b/erpnext/erpnext_integrations/doctype/shopify_settings/shopify_settings.py
@@ -43,7 +43,7 @@ class ShopifySettings(Document):
 				d.raise_for_status()
 				self.update_webhook_table(method, d.json())
 			except Exception as e:
-				make_shopify_log(status="Warning", message=e, exception=False)
+				make_shopify_log(status="Warning", exception=e, rollback=True)
 
 	def unregister_webhooks(self):
 		session = get_request_session()


### PR DESCRIPTION
fixes:

```python-traceback
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2019-10-26/apps/frappe/frappe/desk/form/save.py", line 22, in savedocs
    doc.save()
  File "/home/frappe/benches/bench-version-12-2019-10-26/apps/frappe/frappe/model/document.py", line 272, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2019-10-26/apps/frappe/frappe/model/document.py", line 308, in _save
    self.run_before_save_methods()
  File "/home/frappe/benches/bench-version-12-2019-10-26/apps/frappe/frappe/model/document.py", line 888, in run_before_save_methods
    self.run_method("validate")
  File "/home/frappe/benches/bench-version-12-2019-10-26/apps/frappe/frappe/model/document.py", line 787, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2019-10-26/apps/frappe/frappe/model/document.py", line 1058, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2019-10-26/apps/frappe/frappe/model/document.py", line 1041, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-version-12-2019-10-26/apps/frappe/frappe/model/document.py", line 781, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2019-10-26/apps/erpnext/erpnext/erpnext_integrations/doctype/shopify_settings/shopify_settings.py", line 20, in validate
    self.register_webhooks()
  File "/home/frappe/benches/bench-version-12-2019-10-26/apps/erpnext/erpnext/erpnext_integrations/doctype/shopify_settings/shopify_settings.py", line 46, in register_webhooks
    make_shopify_log(status="Warning", message=e, exception=False)
TypeError: make_shopify_log() got an unexpected keyword argument 'message'
```