### PR TITLE
fix: Pass parent_acc_name to avoid NameError

### DIFF
--- a/erpnext/accounts/doctype/account/account.py
+++ b/erpnext/accounts/doctype/account/account.py
@@ -117,7 +117,7 @@ class Account(NestedSet):
 
 			if not parent_acc_name_map: return
 
-			self.create_account_for_child_company(parent_acc_name_map, descendants)
+			self.create_account_for_child_company(parent_acc_name_map, descendants, parent_acc_name)
 
 	def validate_group_or_ledger(self):
 		if self.get("__islocal"):
@@ -159,7 +159,7 @@ class Account(NestedSet):
 			if frappe.db.get_value("GL Entry", {"account": self.name}):
 				frappe.throw(_("Currency can not be changed after making entries using some other currency"))
 
-	def create_account_for_child_company(self, parent_acc_name_map, descendants):
+	def create_account_for_child_company(self, parent_acc_name_map, descendants, parent_acc_name):
 		for company in descendants:
 			if not parent_acc_name_map.get(company):
 				frappe.throw(_("While creating account for child Company {0}, parent account {1} not found. Please create the parent account in corresponding COA")


### PR DESCRIPTION
`create_account_for_child_company` was using parent_acc_name which was not defined in the method. This could have raised NameError.