### PR TITLE
fix(patch): update status and set auto repeat as not submittable

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -641,3 +641,4 @@ erpnext.patches.v12_0.set_produced_qty_field_in_sales_order_for_work_order
 erpnext.patches.v12_0.generate_leave_ledger_entries
 erpnext.patches.v12_0.set_default_shopify_app_type
 erpnext.patches.v12_0.replace_accounting_with_accounts_in_home_settings
+erpnext.patches.v12_0.update_auto_repeat_status_and_not_submittable

--- a/erpnext/patches/v12_0/update_auto_repeat_status_and_not_submittable.py
+++ b/erpnext/patches/v12_0/update_auto_repeat_status_and_not_submittable.py
@@ -1,0 +1,23 @@
+from __future__ import unicode_literals
+import frappe
+from frappe.custom.doctype.custom_field.custom_field import create_custom_field
+
+def execute():
+	#auto repeat is not submittable in v12
+	frappe.reload_doctype("Auto Repeat")
+	frappe.db.sql("update `tabDocPerm` set submit=0, cancel=0, amend=0 where parent='Auto Repeat'")
+	frappe.db.sql("update `tabAuto Repeat` set docstatus=0 where docstatus=1 or docstatus=2")
+
+	for entry in frappe.get_all('Auto Repeat'):
+		doc = frappe.get_doc('Auto Repeat', entry.name)
+
+		#create custom field for allow auto repeat 
+		df = dict(fieldname='auto_repeat', label='Auto Repeat', fieldtype='Link', insert_after='sender',
+			options='Auto Repeat', hidden=1, print_hide=1, read_only=1)
+		create_custom_field(doc.reference_doctype, df)
+
+		if doc.status in ['Draft', 'Stopped', 'Cancelled']:
+			doc.disabled = 1
+
+		#updates current status as Active, Disabled or Completed on validate
+		doc.save()


### PR DESCRIPTION
Depends on: https://github.com/frappe/frappe/pull/8721

- **Problem**: Auto Repeat Permission and docstatus issue after upgrading to v12
![auto_repeat_submit_perm_issue](https://user-images.githubusercontent.com/24353136/67867190-0a48a800-fb50-11e9-9105-4017b5eb442d.png)
**Fix**: Update DocPerm and docstatus for older auto repeat as Auto Repeat is not submittable in v12.

- **Problem**: Old Auto Repeat not working after upgrade to v12 (due to different statuses)
Statuses in v11: Active, Stopped, Cancelled, Draft, Expired, Disabled
Statuses in v12: Active, Disabled, Completed
**Fix**: Set Draft, Cancelled and Stopped as Disabled, Expired set to Completed on save and remaining set to Active

**In v11:**
![auto-repeat-v12-issues](https://user-images.githubusercontent.com/24353136/67867380-53006100-fb50-11e9-874c-0bdce5cd37eb.png)

**After upgrading to v12:**
![auto_repeat_after_upgrade_to_v12](https://user-images.githubusercontent.com/24353136/67867386-55fb5180-fb50-11e9-9c6d-435f03dbb0cf.png)

**After patch:**
![after_patch](https://user-images.githubusercontent.com/24353136/67867389-572c7e80-fb50-11e9-831c-e972bc948768.png)

