### PR TITLE
fix: purchase order issue, margin_rate_or_amount not there in the purchase documents

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1172,6 +1172,7 @@ def set_purchase_order_defaults(parent_doctype, parent_doctype_name, child_docna
 def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, child_docname="items"):
 	data = json.loads(trans_items)
 
+	sales_doctypes = ['Sales Order', 'Sales Invoice', 'Delivery Note', 'Quotation']
 	parent = frappe.get_doc(parent_doctype, parent_doctype_name)
 
 	for d in data:
@@ -1204,18 +1205,22 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 				#  if rate is greater than price_list_rate, set margin
 				#  or set discount
 				child_item.discount_percentage = 0
-				child_item.margin_type = "Amount"
-				child_item.margin_rate_or_amount = flt(child_item.rate - child_item.price_list_rate,
-					child_item.precision("margin_rate_or_amount"))
-				child_item.rate_with_margin = child_item.rate
+
+				if parent_doctype in sales_doctypes:
+					child_item.margin_type = "Amount"
+					child_item.margin_rate_or_amount = flt(child_item.rate - child_item.price_list_rate,
+						child_item.precision("margin_rate_or_amount"))
+					child_item.rate_with_margin = child_item.rate
 			else:
 				child_item.discount_percentage = flt((1 - flt(child_item.rate) / flt(child_item.price_list_rate)) * 100.0,
 					child_item.precision("discount_percentage"))
 				child_item.discount_amount = flt(
 					child_item.price_list_rate) - flt(child_item.rate)
-				child_item.margin_type = ""
-				child_item.margin_rate_or_amount = 0
-				child_item.rate_with_margin = 0
+
+				if parent_doctype in sales_doctypes:
+					child_item.margin_type = ""
+					child_item.margin_rate_or_amount = 0
+					child_item.rate_with_margin = 0
 
 		child_item.flags.ignore_validate_update_after_submit = True
 		if new_child_flag:


### PR DESCRIPTION
**Issue**
margin_rate_or_amount is not available in the purchase documents therefore getting below error on change of weights

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-11-2019-10-04/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/home/frappe/benches/bench-version-11-2019-10-04/apps/frappe/frappe/handler.py", line 21, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-11-2019-10-04/apps/frappe/frappe/handler.py", line 56, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-11-2019-10-04/apps/frappe/frappe/__init__.py", line 1036, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-11-2019-10-04/apps/erpnext/erpnext/controllers/accounts_controller.py", line 1123, in update_child_qty_rate
    child_item.precision("margin_rate_or_amount"))
  File "/home/frappe/benches/bench-version-11-2019-10-04/apps/frappe/frappe/model/base_document.py", line 690, in precision
    if df.fieldtype in ("Currency", "Float", "Percent"):
AttributeError: 'NoneType' object has no attribute 'fieldtype'
```