### PR TITLE
fix: incorrect number of entries while making deferred revenue entry

### DIFF
--- a/erpnext/accounts/deferred_revenue.py
+++ b/erpnext/accounts/deferred_revenue.py
@@ -174,6 +174,8 @@ def make_gl_entries(doc, credit_account, debit_account, against,
 	# GL Entry for crediting the amount in the deferred expense
 	from erpnext.accounts.general_ledger import make_gl_entries
 
+	if amount == 0: return
+
 	gl_entries = []
 	gl_entries.append(
 		doc.get_gl_dict({


### PR DESCRIPTION
**Issue**

```
Traceback (most recent call last): 
File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/deferred_revenue.py", line 206, in make_gl_entries make_gl_entries(gl_entries, cancel=(doc.docstatus == 2), merge_entries=True) File 
"/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/general_ledger.py", line 24, in make_gl_entries frappe.throw(_("Incorrect number of General Ledger Entries found. You might have selected a wrong Account in the transaction.")) File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 360, in throw msgprint(msg, raise_exception=exc, title=title, indicator='red') File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 346, in msgprint _raise_exception() File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 315, in _raise_exception raise raise_exception(msg) 


frappe.exceptions.ValidationError: Incorrect number of General Ledger Entries found. You might have selected a wrong Account in the transaction.
--



```