### PR TITLE
fix: invoice creation tool of invoices with no paid and outstanding amounts

### DIFF
--- a/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.py
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.py
@@ -32,8 +32,10 @@ class OpeningInvoiceCreationTool(Document):
 				})
 				invoices_summary.update({company: _summary})
 
-				paid_amount.append(invoice.paid_amount)
-				outstanding_amount.append(invoice.outstanding_amount)
+				if invoice.paid_amount:
+					paid_amount.append(invoice.paid_amount)
+				if invoice.outstanding_amount:
+					outstanding_amount.append(invoice.outstanding_amount)
 
 			if paid_amount or outstanding_amount:
 				max_count.update({


### PR DESCRIPTION
### Error:
![imageb9fe68](https://user-images.githubusercontent.com/36654812/68110053-22cf0e80-ff12-11e9-9e5d-b29cd9a75370.gif)

**Environment:** Python 3, ERPNext v12

---
### Code

```python
max([1, 34, None, 23])
```
---
### Output

**py2:** `34`

**py3:** `TypeError: '>' not supported between instances of 'NoneType' and 'int'`