### PR TITLE
feat: Provision to fetch items from multiple BOMs in Stock Entry

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -599,6 +599,7 @@ def get_bom_items_as_dict(bom, company, qty=1, fetch_exploded=1, fetch_scrap_ite
 				item.image,
 				bom.project,
 				item.stock_uom,
+				item.item_group,
 				item.allow_alternative_item,
 				item_default.default_warehouse,
 				item_default.expense_account as expense_account,

--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -238,6 +238,8 @@ frappe.ui.form.on('Stock Entry', {
 			}, __("Get items from"));
 		}
 
+		frm.events.show_bom_custom_button(frm);
+
 		if (frm.doc.company) {
 			frm.trigger("toggle_display_account_head");
 		}
@@ -253,13 +255,7 @@ frappe.ui.form.on('Stock Entry', {
 
 	stock_entry_type: function(frm){
 		frm.remove_custom_button('Bill of Materials', "Get items from");
-
-		if (frm.doc.docstatus === 0 &&
-			['Material Issue', 'Material Receipt', 'Material Transfer', 'Send to Subcontractor'].includes(frm.doc.purpose)) {
-				frm.add_custom_button(__('Bill of Materials'), function() {
-					frm.events.get_items_from_bom(frm);
-				}, __("Get items from"));
-		}
+		frm.events.show_bom_custom_button(frm);
 	},
 
 	purpose: function(frm) {
@@ -398,6 +394,15 @@ frappe.ui.form.on('Stock Entry', {
 		}
 	},
 
+	show_bom_custom_button: function(frm){
+		if (frm.doc.docstatus === 0 &&
+			['Material Issue', 'Material Receipt', 'Material Transfer', 'Send to Subcontractor'].includes(frm.doc.purpose)) {
+				frm.add_custom_button(__('Bill of Materials'), function() {
+					frm.events.get_items_from_bom(frm);
+				}, __("Get items from"));
+		}
+	},
+
 	get_items_from_bom: function(frm) {
 		let filters = function(){
 			return {filters: { docstatus:1 }};
@@ -417,11 +422,11 @@ frappe.ui.form.on('Stock Entry', {
 			{"fieldname":"fetch", "label":__("Get Items from BOM"), "fieldtype":"Button"}
 		]
 
-		//Exclude field 'Target Warehouse' in case of Material Issue
+		// Exclude field 'Target Warehouse' in case of Material Issue
 		if (frm.doc.purpose == 'Material Issue'){
 			fields.splice(2,1);
 		}
-		//Exclude field 'Source Warehouse' in case of Material Receipt
+		// Exclude field 'Source Warehouse' in case of Material Receipt
 		else if(frm.doc.purpose == 'Material Receipt'){
 			fields.splice(1,1);
 		}

--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -254,11 +254,11 @@ frappe.ui.form.on('Stock Entry', {
 	stock_entry_type: function(frm){
 		frm.remove_custom_button('Bill of Materials', "Get items from");
 
-		if (frm.doc.docstatus === 0 && ['Material Issue','Material Receipt',
-		'Material Transfer','Send to Subcontractor'].includes(frm.doc.purpose)) {
-			frm.add_custom_button(__('Bill of Materials'), function(){
-				frm.events.get_items_from_bom(frm);
-			}, __("Get items from"));
+		if (frm.doc.docstatus === 0 &&
+			['Material Issue', 'Material Receipt', 'Material Transfer', 'Send to Subcontractor'].includes(frm.doc.purpose)) {
+				frm.add_custom_button(__('Bill of Materials'), function() {
+					frm.events.get_items_from_bom(frm);
+				}, __("Get items from"));
 		}
 	},
 
@@ -449,7 +449,7 @@ frappe.ui.form.on('Stock Entry', {
 							d.t_warehouse = values.target_warehouse;
 							d.uom = item.stock_uom;
 							d.stock_uom = item.stock_uom;
-							d.conversion_factor = 1;
+							d.conversion_factor = item.conversion_factor ? item.conversion_factor : 1;
 							d.qty = item.qty;
 							d.expense_account = item.expense_account;
 							d.project = item.project;

--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -181,12 +181,6 @@ frappe.ui.form.on('Stock Entry', {
 			}
 		}
 
-		if (frm.doc.docstatus === 0) {
-			frm.add_custom_button(__('Bill of Materials'), function(){
-				frm.events.get_items_from_bom(frm);
-			}, __("Get items from"));
-		}
-
 		if (frm.doc.docstatus===0) {
 			frm.add_custom_button(__('Purchase Invoice'), function() {
 				erpnext.utils.map_current_doc({
@@ -255,6 +249,17 @@ frappe.ui.form.on('Stock Entry', {
 		}
 
 		frm.trigger("setup_quality_inspection");
+	},
+
+	stock_entry_type: function(frm){
+		frm.remove_custom_button('Bill of Materials', "Get items from");
+
+		if (frm.doc.docstatus === 0 && ['Material Issue','Material Receipt',
+		'Material Transfer','Send to Subcontractor'].includes(frm.doc.purpose)) {
+			frm.add_custom_button(__('Bill of Materials'), function(){
+				frm.events.get_items_from_bom(frm);
+			}, __("Get items from"));
+		}
 	},
 
 	purpose: function(frm) {
@@ -411,10 +416,10 @@ frappe.ui.form.on('Stock Entry', {
 			"label":__("Fetch exploded BOM (including sub-assemblies)"), "default":1},
 			{"fieldname":"fetch", "label":__("Get Items from BOM"), "fieldtype":"Button"}
 		]
-		if (frm.doc.stock_entry_type == 'Material Issue'){
+		if (frm.doc.purpose == 'Material Issue'){
 			fields.splice(2,1);
 		}
-		else if(frm.doc.stock_entry_type == 'Material Receipt'){
+		else if(frm.doc.purpose == 'Material Receipt'){
 			fields.splice(1,1);
 		}
 

--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -416,9 +416,12 @@ frappe.ui.form.on('Stock Entry', {
 			"label":__("Fetch exploded BOM (including sub-assemblies)"), "default":1},
 			{"fieldname":"fetch", "label":__("Get Items from BOM"), "fieldtype":"Button"}
 		]
+
+		//Exclude field 'Target Warehouse' in case of Material Issue
 		if (frm.doc.purpose == 'Material Issue'){
 			fields.splice(2,1);
 		}
+		//Exclude field 'Source Warehouse' in case of Material Receipt
 		else if(frm.doc.purpose == 'Material Receipt'){
 			fields.splice(1,1);
 		}


### PR DESCRIPTION
- Currently the **'From BOM'** checkbox in Stock Entry allows only one BOM per Stock Entry
- Added **'Bill of Materials'** option in **'Get Items From'**
- Provision to fetch items from multiple BOMs
- Fields in popup toggle according to Purpose
- Working:

![_2](https://user-images.githubusercontent.com/25857446/68128600-034ddb00-ff3e-11e9-8485-bd59e46e4dcb.gif)

- Accesibiity:
  - It will be visible in draft condition depending on the Purpose 

![_stock_entry_bom](https://user-images.githubusercontent.com/25857446/70052335-144f4200-15f9-11ea-861c-b65f4c22304b.gif)
 