### PR TITLE
feat: multiple company pos profile

### DIFF
--- a/erpnext/selling/page/point_of_sale/point_of_sale.js
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.js
@@ -483,9 +483,7 @@ erpnext.pos.PointOfSale = class PointOfSale {
 					reqd: 1,
 					onchange: function(e) {
 							me.get_default_pos_profile(this.value).then((r) => {
-								if (r && r.name) {
-									dialog.set_value('pos_profile', r.name);
-								}
+								dialog.set_value('pos_profile', (r && r.name)? r.name : '');
 							});
 						}
 					},

--- a/erpnext/selling/page/point_of_sale/point_of_sale.js
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.js
@@ -451,7 +451,7 @@ erpnext.pos.PointOfSale = class PointOfSale {
 
 	change_pos_profile() {
 		return new Promise((resolve) => {
-			const on_submit = ({ pos_profile, set_as_default }) => {
+			const on_submit = ({ company, pos_profile, set_as_default }) => {
 				if (pos_profile) {
 					this.pos_profile = pos_profile;
 				}
@@ -461,7 +461,7 @@ erpnext.pos.PointOfSale = class PointOfSale {
 						method: "erpnext.accounts.doctype.pos_profile.pos_profile.set_default_profile",
 						args: {
 							'pos_profile': pos_profile,
-							'company': this.frm.doc.company
+							'company': company
 						}
 					}).then(() => {
 						this.on_change_pos_profile();
@@ -495,7 +495,19 @@ erpnext.pos.PointOfSale = class PointOfSale {
 	}
 
 	get_prompt_fields() {
+		var company_field = this.frm.doc.company;
 		return [{
+			fieldtype: 'Link',
+			label: __('Company'),
+			options: 'Company',
+			fieldname: 'company',
+			default: this.frm.doc.company,
+			reqd: 1,
+			onchange: function(e) {
+					company_field = this.value;
+				}
+			},
+			{
 			fieldtype: 'Link',
 			label: __('POS Profile'),
 			options: 'POS Profile',
@@ -505,7 +517,7 @@ erpnext.pos.PointOfSale = class PointOfSale {
 				return {
 					query: 'erpnext.accounts.doctype.pos_profile.pos_profile.pos_profile_query',
 					filters: {
-						company: this.frm.doc.company
+						company: company_field
 					}
 				};
 			}


### PR DESCRIPTION
**Issue:** Currently changing POS profile is allowed for only the company that is currently loaded by default in sales invoice
**Proposed Fix:** Adding a company field in model on changing the POS profile will allow user to change to a POS profile to one that belongs to a non default company.
![multipos_profile](https://user-images.githubusercontent.com/14824451/68154659-fea11b00-ff6d-11e9-87fb-40eb4859a359.gif)
