### PR TITLE
fix: unknown column credit limit in accounts receivable report

### DIFF
--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.js
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.js
@@ -90,7 +90,6 @@ frappe.query_reports["Accounts Receivable"] = {
 					frappe.db.get_value('Customer Credit Limit', {'parent': customer, 'company': company}, 
 						["credit_limit"], function(value) {
 						if (value) {
-							debugger
 							frappe.query_report.set_filter_value('credit_limit', value["credit_limit"]);
 						}
 					}, "Customer");

--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.js
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.js
@@ -79,13 +79,21 @@ frappe.query_reports["Accounts Receivable"] = {
 			"options": "Customer",
 			on_change: () => {
 				var customer = frappe.query_report.get_filter_value('customer');
+				var company = frappe.query_report.get_filter_value('company');
 				if (customer) {
-					frappe.db.get_value('Customer', customer, ["tax_id", "customer_name", "credit_limit", "payment_terms"], function(value) {
+					frappe.db.get_value('Customer', customer, ["tax_id", "customer_name", "payment_terms"], function(value) {
 						frappe.query_report.set_filter_value('tax_id', value["tax_id"]);
 						frappe.query_report.set_filter_value('customer_name', value["customer_name"]);
-						frappe.query_report.set_filter_value('credit_limit', value["credit_limit"]);
 						frappe.query_report.set_filter_value('payment_terms', value["payment_terms"]);
 					});
+
+					frappe.db.get_value('Customer Credit Limit', {'parent': customer, 'company': company}, 
+						["credit_limit"], function(value) {
+						if (value) {
+							debugger
+							frappe.query_report.set_filter_value('credit_limit', value["credit_limit"]);
+						}
+					}, "Customer");
 				} else {
 					frappe.query_report.set_filter_value('tax_id', "");
 					frappe.query_report.set_filter_value('customer_name', "");


### PR DESCRIPTION
**Issue**

Recently we have moved credit_limit to child table, so there is no field credit_limit in the customer form and when user trying to select the customer filter in the Accounts Receivable Report, they are getting the below error

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/handler.py", line 61, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/__init__.py", line 1038, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/client.py", line 88, in get_value
    return frappe.db.get_value(doctype, filters, fieldname, as_dict=as_dict, debug=debug)
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/database/database.py", line 400, in get_value
    order_by, cache=cache)
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/database/database.py", line 444, in get_values
    out = self._get_values_from_table(fields, filters, doctype, as_dict, debug, order_by, update)
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/database/database.py", line 591, in _get_values_from_table
    as_dict=as_dict, debug=debug, update=update)
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/database/database.py", line 156, in sql
    self._cursor.execute(query, values)
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/pymysql/cursors.py", line 170, in execute
    result = self._query(query)
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/pymysql/cursors.py", line 328, in _query
    conn.query(q)
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/pymysql/connections.py", line 517, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/pymysql/connections.py", line 732, in _read_query_result
    result.read()
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/pymysql/connections.py", line 1075, in read
    first_packet = self.connection._read_packet()
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/pymysql/connections.py", line 684, in _read_packet
    packet.check_error()
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/pymysql/protocol.py", line 220, in check_error
    err.raise_mysql_exception(self._data)
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.InternalError: (1054, "Unknown column 'credit_limit' in 'field list'")
```
