### PR TITLE
fix: reload global defaults

### DIFF
--- a/erpnext/patches/v11_0/update_delivery_trip_status.py
+++ b/erpnext/patches/v11_0/update_delivery_trip_status.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 import frappe
 
 def execute():
+	frappe.reload_doc('setup', 'doctype', 'global_defaults', force=True)
 	frappe.reload_doc('stock', 'doctype', 'delivery_trip')
 	frappe.reload_doc('stock', 'doctype', 'delivery_stop', force=True)
 


### PR DESCRIPTION
```
Migrating test-inr.erpnext.com
Executing erpnext.patches.v11_0.update_delivery_trip_status in test-inr.erpnext.com (3faafecdffc65449)
Traceback (most recent call last):
  File "/usr/lib64/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib64/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/utils/bench_helper.py", line 97, in <module>
    main()
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/commands/__init__.py", line 25, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/commands/site.py", line 233, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website, skip_failing=skip_failing)
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/migrate.py", line 48, in migrate
    frappe.modules.patch_handler.run_all(skip_failing)
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/modules/patch_handler.py", line 41, in run_all
    run_patch(patch)
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/modules/patch_handler.py", line 30, in run_patch
    if not run_single(patchmodule = patch):
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/modules/patch_handler.py", line 71, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/modules/patch_handler.py", line 91, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/erpnext/erpnext/patches/v11_0/update_delivery_trip_status.py", line 12, in execute
    trip_doc = frappe.get_doc("Delivery Trip", trip.name)
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/__init__.py", line 736, in get_doc
    doc = frappe.model.document.get_doc(*args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/model/document.py", line 70, in get_doc
    return controller(*args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/erpnext/erpnext/stock/doctype/delivery_trip/delivery_trip.py", line 21, in __init__
    self.default_distance_uom = frappe.db.get_single_value("Global Defaults", "default_distance_unit") or "Meter"
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/database/database.py", line 558, in get_single_value
    frappe.throw(_('Invalid field name: {0}').format(frappe.bold(fieldname)), self.InvalidColumnName)
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/__init__.py", line 360, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red')
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/__init__.py", line 346, in msgprint
    _raise_exception()
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/__init__.py", line 315, in _raise_exception
    raise raise_exception(msg)
frappe.database.database.InvalidColumnName: Invalid field name: <b>default_distance_unit</b>
```

----

also applied doc2unix on file to remove ^M