### PR TITLE
fix(cart): return rule instead of rule_label_map

### DIFF
--- a/erpnext/shopping_cart/cart.py
+++ b/erpnext/shopping_cart/cart.py
@@ -505,7 +505,7 @@ def get_applicable_shipping_rules(party=None, quotation=None):
 	if shipping_rules:
 		rule_label_map = frappe.db.get_values("Shipping Rule", shipping_rules, "label")
 		# we need this in sorted order as per the position of the rule in the settings page
-		return [[rule, rule_label_map.get(rule)] for rule in shipping_rules]
+		return [[rule, rule] for rule in shipping_rules]
 
 def get_shipping_rules(quotation=None, cart_settings=None):
 	if not quotation:


### PR DESCRIPTION
Fixes the issue of doc is undefined when shopping cart is opened from website.
`<div class="row mt-5">
  <div class="col-12">
    {% if cart_settings.enable_checkout %}
    <a href="/orders">
      {{ _('See past orders') }}
    </a>
    {% else %}
    <a href="/quotations">
      {{ _('See past quotations') }}
    </a>
    {% endif %}
  </div>
</div>

{% endblock %}

{% block base_scripts %}
<!-- js should be loaded in body! -->
<script type="text/javascript" src="/assets/frappe/js/lib/jquery/jquery.min.js"></script>
<script type="text/javascript" src="/assets/js/frappe-web.min.js"></script>
<script type="text/javascript" src="/assets/js/control.min.js"></script>
<script type="text/javascript" src="/assets/js/dialog.min.js"></script>
<script type="text/javascript" src="/assets/js/bootstrap-4-web.min.js"></script>
{% endblock %}
</pre><pre>Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/jinja.py", line 78, in render_template
    return get_jenv().from_string(template).render(context)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/jinja2/environment.py", line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "<template>", line 1, in top-level template code
  File "/home/frappe/frappe-bench/apps/frappe/frappe/./templates/web.html", line 1, in top-level template code
    {% extends base_template_path %}
  File "/home/frappe/frappe-bench/apps/frappe/frappe/./templates/base.html", line 68, in top-level template code
    {% block content %}
  File "/home/frappe/frappe-bench/apps/frappe/frappe/./templates/web.html", line 60, in block "content"
    {{ main_content() }}
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/jinja2/sandbox.py", line 427, in call
    return __context.call(__obj, *args, **kwargs)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/jinja2/runtime.py", line 579, in _invoke
    rv = self._func(*arguments)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/./templates/web.html", line 15, in template
    {% block page_container %}
  File "/home/frappe/frappe-bench/apps/frappe/frappe/./templates/web.html", line 22, in block "page_container"
    {% if self.header_actions() %}
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/jinja2/sandbox.py", line 427, in call
    return __context.call(__obj, *args, **kwargs)
  File "<template>", line 15, in block "header_actions"
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/jinja2/sandbox.py", line 385, in getattr
    value = getattr(obj, attribute)
UndefinedError: 'doc' is undefined
</pre>`