### PR TITLE
fix: 'NoneType' object has no attribute 'stock_uom'

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.js
+++ b/erpnext/stock/doctype/pick_list/pick_list.js
@@ -173,8 +173,10 @@ frappe.ui.form.on('Pick List Item', {
 });
 
 function get_item_details(item_code, uom=null) {
-	return frappe.xcall('erpnext.stock.doctype.pick_list.pick_list.get_item_details', {
-		item_code,
-		uom
-	});
+	if (item_code) {
+		return frappe.xcall('erpnext.stock.doctype.pick_list.pick_list.get_item_details', {
+			item_code,
+			uom
+		});
+	}
 }


### PR DESCRIPTION
**Issue**

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/handler.py", line 61, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/__init__.py", line 1038, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/erpnext/erpnext/stock/doctype/pick_list/pick_list.py", line 331, in get_item_details
    details.uom = uom or details.stock_uom
AttributeError: 'NoneType' object has no attribute 'stock_uom'
```