### PR TITLE
fix(employee): show only active employees in the error while marking …

### DIFF
--- a/erpnext/hr/doctype/employee/employee.py
+++ b/erpnext/hr/doctype/employee/employee.py
@@ -157,10 +157,11 @@ class Employee(NestedSet):
 	def validate_status(self):
 		if self.status == 'Left':
 			reports_to = frappe.db.get_all('Employee',
-				filters={'reports_to': self.name}
+				filters={'reports_to': self.name, 'status': "Active"},
+				fields = ['name','employee_name']
 			)
 			if reports_to:
-				link_to_employees = [frappe.utils.get_link_to_form('Employee', employee.name) for employee in reports_to]
+				link_to_employees = [frappe.utils.get_link_to_form('Employee', employee.name, label=employee.employee_name) for employee in reports_to]
 				throw(_("Employee status cannot be set to 'Left' as following employees are currently reporting to this employee:&nbsp;")
 					+ ', '.join(link_to_employees), EmployeeLeftValidationError)
 			if not self.relieving_date:


### PR DESCRIPTION
**Problem**: Currently it fetches inactive/left employees as well to show up in the error message display while trying to set a "reporting to" employee as left:

The below validation appears while changing an employee status to "left" if the employee is set as a 'reports to' in another employee's record

![Screenshot 2019-11-11 at 7 34 37 PM](https://user-images.githubusercontent.com/13060550/68593052-8fba4980-04ba-11ea-948f-521ecf5d0f8a.png)


**Addtions**:

- Display only the active employees

- Make the label in the error message readable

**Screenshots:**

![Screenshot 2019-11-11 at 6 12 35 PM](https://user-images.githubusercontent.com/13060550/68593066-9943b180-04ba-11ea-9175-46fad1f97c63.png)


