### PR TITLE
fix: Add Serial No. button not responding

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -63,12 +63,15 @@ $.extend(erpnext, {
 			let callback = '';
 			let on_close = '';
 
-			if (grid_row.doc.serial_no) {
-				grid_row.doc.has_serial_no = true;
-			}
-
-			me.show_serial_batch_selector(grid_row.frm, grid_row.doc,
-				callback, on_close, true);
+			frappe.model.get_value('Item', {'name':grid_row.doc.item_code}, 'has_serial_no',
+				(data) => {
+					if(data) {
+						grid_row.doc.has_serial_no = data.has_serial_no;
+						me.show_serial_batch_selector(grid_row.frm, grid_row.doc,
+							callback, on_close, true);
+					}
+				}
+			);
 		});
 	},
 });


### PR DESCRIPTION
- **Add Serial No.** didn't respond after 'Save'.
- Set value of has_serial_no every time grid form is rendered in child table
- **Before Fix**:

![serial_no_old](https://user-images.githubusercontent.com/25857446/68595515-94cdc780-04bf-11ea-9b9d-0c0667e54a86.gif)
- **After Fix:**

![serial_no_new](https://user-images.githubusercontent.com/25857446/68595522-99927b80-04bf-11ea-8b12-d4b65c4d761e.gif)