### PR TITLE
fix: user with invoice role not able to submit

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -350,7 +350,7 @@ class SalesInvoice(SellingController):
 				timesheet.calculate_percentage_billed()
 				timesheet.flags.ignore_validate_update_after_submit = True
 				timesheet.set_status()
-				timesheet.save()
+				timesheet.save(ignore_permissions=True)
 
 	def update_time_sheet_detail(self, timesheet, args, sales_invoice):
 		for data in timesheet.time_logs:


### PR DESCRIPTION
fix for a user not having timesheet submit privelige (e.g. a shared timesheet from another department) not being able to submit because of linked fields