### PR TITLE
fix: fetch leave approver defined in employee in leave application

### DIFF
--- a/erpnext/hr/doctype/department_approver/department_approver.py
+++ b/erpnext/hr/doctype/department_approver/department_approver.py
@@ -19,14 +19,19 @@ def get_approvers(doctype, txt, searchfield, start, page_len, filters):
 	approvers = []
 	department_details = {}
 	department_list = []
-	employee_department = filters.get("department") or frappe.get_value("Employee", filters.get("employee"), "department")
-	if employee_department:
-		department_details = frappe.db.get_value("Department", {"name": employee_department}, ["lft", "rgt"], as_dict=True)
+	employee = frappe.get_value("Employee", filters.get("employee"), ["department", "leave_approver"], as_dict=True)
+	if employee.leave_approver:
+		approver = frappe.db.get_value("User", leave_approver, ['name', 'first_name', 'last_name'])
+		approvers.append(approver)
+		return approvers
+
+	if employee.department:
+		department_details = frappe.db.get_value("Department", {"name": employee.department}, ["lft", "rgt"], as_dict=True)
 	if department_details:
 		department_list = frappe.db.sql("""select name from `tabDepartment` where lft <= %s
 			and rgt >= %s
 			and disabled=0
-			order by lft desc""", (department_details.lft, department_details.rgt), as_list = True)
+			order by lft desc""", (department_details.lft, department_details.rgt), as_list=True)
 
 	if filters.get("doctype") == "Leave Application":
 		parentfield = "leave_approvers"

--- a/erpnext/hr/doctype/department_approver/department_approver.py
+++ b/erpnext/hr/doctype/department_approver/department_approver.py
@@ -25,8 +25,9 @@ def get_approvers(doctype, txt, searchfield, start, page_len, filters):
 		approvers.append(approver)
 		return approvers
 
-	if employee.department:
-		department_details = frappe.db.get_value("Department", {"name": employee.department}, ["lft", "rgt"], as_dict=True)
+	employee_department = filters.get("department") or employee.department
+	if employee_department:
+		department_details = frappe.db.get_value("Department", {"name": employee_department}, ["lft", "rgt"], as_dict=True)
 	if department_details:
 		department_list = frappe.db.sql("""select name from `tabDepartment` where lft <= %s
 			and rgt >= %s


### PR DESCRIPTION
**Issue:** Leave approver defined in the employee was not getting fetched in the leave approvers list in a leave application.

**Fix:** Add approver from employee master separately in the approvers list.