### PR TITLE
fix: Set due date in accounts receivable based on payment terms

### DIFF
--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -188,7 +188,11 @@ class ReceivablePayableReport(object):
 		self.data.append(row)
 
 	def set_invoice_details(self, row):
-		row.update(self.invoice_details.get(row.voucher_no, {}))
+		invoice_details = self.invoice_details.get(row.voucher_no, {})
+		if row.due_date:
+			invoice_details.pop("due_date", None)
+		row.update(invoice_details)
+
 		if row.voucher_type == 'Sales Invoice':
 			if self.filters.show_delivery_notes:
 				self.set_delivery_notes(row)


### PR DESCRIPTION

Issues:

As per the Payment terms in Sales Invoice, there are three due Dates

<img width="1206" alt="ZXSv5i5" src="https://user-images.githubusercontent.com/836784/68737525-b33fda00-0609-11ea-80e0-087240b2d089.png">

But in the Account Receivable report, though slabs as per Payment Entry is showing fine, the due date fetched is only last one.

<img width="1224" alt="ZZ74wAQ" src="https://user-images.githubusercontent.com/836784/68737530-b63aca80-0609-11ea-9528-2d1a86d4f0db.png">
