### PR TITLE
fix: Accumulated Values filter disappearing

### DIFF
--- a/erpnext/accounts/report/balance_sheet/balance_sheet.js
+++ b/erpnext/accounts/report/balance_sheet/balance_sheet.js
@@ -2,7 +2,7 @@
 // License: GNU General Public License v3. See license.txt
 
 frappe.require("assets/erpnext/js/financial_statements.js", function() {
-	frappe.query_reports["Balance Sheet"] = erpnext.financial_statements;
+	frappe.query_reports["Balance Sheet"] = $.extend({}, erpnext.financial_statements);
 
 	frappe.query_reports["Balance Sheet"]["filters"].push({
 		"fieldname": "accumulated_values",


### PR DESCRIPTION
Accumulated Values filter disappear when navigate to general ledger by clicking on account and navigate back to report.