### PR TITLE
fix: allow pending within review date

### DIFF
--- a/erpnext/projects/doctype/task/task.py
+++ b/erpnext/projects/doctype/task/task.py
@@ -7,7 +7,7 @@ import json
 
 import frappe
 from frappe import _, throw
-from frappe.utils import add_days, cstr, date_diff, get_link_to_form, getdate
+from frappe.utils import add_days, cstr, date_diff, get_link_to_form, getdate, today
 from frappe.utils.nestedset import NestedSet
 
 

--- a/erpnext/projects/doctype/task/task.py
+++ b/erpnext/projects/doctype/task/task.py
@@ -201,6 +201,9 @@ def set_multiple_status(names, status):
 def set_tasks_as_overdue():
 	tasks = frappe.get_all("Task", filters={'status':['not in',['Cancelled', 'Closed']]})
 	for task in tasks:
+		if frappe.db.get_value("Task", task.name, "status") in 'Pending Review':
+			if getdate(frappe.db.get_value("Task", task.name, "review_date")) < getdate(today()):
+				continue
 		frappe.get_doc("Task", task.name).update_status()
 
 @frappe.whitelist()


### PR DESCRIPTION
referenced - fix: allow Pending on review date #19497
explanation for closing not valid

First PR was closed with an invalid reasoning.

This makes no sense if expected end date is including review then field review date (and closing date) make no sense. a task should be done bij exp_end_date for review (deadline), reviewed by review date and closing date should be set by the actual closing date upon closing task.

Thought experiment : how can, in response of #19497, a user see if deadlines of tasks are met if end date and review date are the same?

This is handeled because only reason setting overdue will be skipped (for loop will continue) is status is Pending Review AND date is within the review date ? if a user want he can always make custom script to set end date if review date is set ? 

I ask to please explain before closing so if wanted i can make this a setting somewhere 