### PR TITLE
fix: Enhanced Payment reconciliation Debit/Credit Note query

### DIFF
--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
@@ -90,7 +90,11 @@ class PaymentReconciliation(Document):
 			FROM `tab{doc}`, `tabGL Entry`
 			WHERE
 				(`tab{doc}`.name = `tabGL Entry`.against_voucher or `tab{doc}`.name = `tabGL Entry`.voucher_no)
-				and `tab{doc}`.is_return = 1 and `tab{doc}`.return_against IS NULL
+				and `tab{doc}`.is_return = 1
+				and (`tab{doc}`.return_against IS NULL or
+					(`tab{doc}`.return_against in
+						(select reference_name from `tabPayment Entry Reference`
+						where reference_name = `tab{doc}`.return_against and docstatus != 2)))
 				and `tabGL Entry`.against_voucher_type = %(voucher_type)s
 				and `tab{doc}`.docstatus = 1 and `tabGL Entry`.party = %(party)s
 				and `tabGL Entry`.party_type = %(party_type)s and `tabGL Entry`.account = %(account)s


### PR DESCRIPTION
- Payment Reconciliation showed ALL debit/credit notes in Payments Table
- **Use Case:** A debit note is made against an **unpaid** Sales Invoice for adjustment purpose. There is no reconciliation required here and thus the debit note must not appear in Payment Reconcilation. 
On the other hand a **paid** invoice must have it's note available for future reconciliation.

- Payment Reconciliation will show Debit/Credit Notes in the following cases:
   1) It is a standalone note
   2) It is created against a **Paid** Invoice