### PR TITLE
fix: Ignore Period Closing Voucher entries in Accounts dashboard

### DIFF
--- a/erpnext/accounts/dashboard_chart_source/account_balance_timeline/account_balance_timeline.py
+++ b/erpnext/accounts/dashboard_chart_source/account_balance_timeline/account_balance_timeline.py
@@ -93,7 +93,8 @@ def get_gl_entries(account, to_date):
 		fields = ['posting_date', 'debit', 'credit'],
 		filters = [
 			dict(posting_date = ('<', to_date)),
-			dict(account = ('in', child_accounts))
+			dict(account = ('in', child_accounts)),
+			dict(voucher_type = ('!=', 'Period Closing Voucher'))
 		],
 		order_by = 'posting_date asc')
 


### PR DESCRIPTION
Ignore Period Closing Voucher entries to avoid negative values in Income/Expenses graph:
<img width="597" alt="Screenshot 2019-11-14 at 10 45 47 PM" src="https://user-images.githubusercontent.com/19775888/68880041-86d2ad80-0730-11ea-999e-1d9802218721.png">
