### PR TITLE
fix: job_opining.py

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -39,9 +39,11 @@ class BOM(WebsiteGenerator):
 			names = [d[-1][1:] for d in filter(lambda x: len(x) > 1 and x[-1], names)]
 
 			# split by (-) if cancelled
-			names = [cint(name.split('-')[-1]) for name in names]
-
-			idx = max(names) + 1
+			if names:
+				names = [cint(name.split('-')[-1]) for name in names]
+				idx = max(names) + 1
+			else:
+				idx = 1
 		else:
 			idx = 1
 


### PR DESCRIPTION
## Description of the issue

when creating a job opening depends on  staffing plan get an error message "`Job Openings for designation `**Analaystic** `already open or hiring completed as per Staffing Plan` **Test**"

## UseCase
I create staffing plan Called **Test** for designation **Analaystic** with  `Vacancies=1` and already have one employee with designation **Analaystic** 

## Reason of Issue
https://github.com/frappe/erpnext/blob/642441688687286ba0fce0df1b2319529c723bdd/erpnext/hr/doctype/job_opening/job_opening.py#L45

## Error			

`if self.planned_vacancies <= current_count:`

## Correction 		

`if self.planned_vacancies < current_count:
`
