### PR TITLE
fix: not able to select department in instructor form

### DIFF
--- a/erpnext/education/doctype/instructor/instructor.js
+++ b/erpnext/education/doctype/instructor/instructor.js
@@ -4,11 +4,11 @@ cur_frm.add_fetch("employee", "image", "image");
 frappe.ui.form.on("Instructor", {
 	employee: function(frm) {
 		if(!frm.doc.employee) return;
-		frappe.db.get_value('Employee', {name: frm.doc.employee}, 'company', (company) => {
+		frappe.db.get_value('Employee', {name: frm.doc.employee}, 'company', (d) => {
 			frm.set_query("department", function() {
 				return {
 					"filters": {
-						"company": company,
+						"company": d.company,
 					}
 				};
 			});
@@ -16,7 +16,7 @@ frappe.ui.form.on("Instructor", {
 			frm.set_query("department", "instructor_log", function() {
 				return {
 					"filters": {
-						"company": company,
+						"company": d.company,
 					}
 				};
 			});


### PR DESCRIPTION
**Issue**

```
Syntax error in query:
select `tabDepartment`.`name`, locate('', `tabDepartment`.`name`) as `_relevance`
			from `tabDepartment`
			where `tabDepartment`.company = {'company': 'Gadgets'} and `tabDepartment`.disabled != 1.0
			
			 order by _relevance, `tabDepartment`.`modified` ASC, `tabDepartment`.idx desc
			limit 20 offset 0
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/handler.py", line 61, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/__init__.py", line 1038, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/desk/search.py", line 53, in search_link
    search_widget(doctype, txt, query, searchfield=searchfield, page_length=page_length, filters=filters, reference_doctype=reference_doctype, ignore_user_permissions=ignore_user_permissions)
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/desk/search.py", line 157, in search_widget
    strict=False)
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/__init__.py", line 1274, in get_list
    return frappe.model.db_query.DatabaseQuery(doctype).execute(None, *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/model/db_query.py", line 96, in execute
    result = self.build_and_run()
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/model/db_query.py", line 130, in build_and_run
    return frappe.db.sql(query, as_dict=not self.as_list, debug=self.debug, update=self.update)
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/database/database.py", line 171, in sql
    self._cursor.execute(query)
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/pymysql/cursors.py", line 170, in execute
    result = self._query(query)
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/pymysql/cursors.py", line 328, in _query
    conn.query(q)
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/pymysql/connections.py", line 517, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/pymysql/connections.py", line 732, in _read_query_result
    result.read()
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/pymysql/connections.py", line 1075, in read
    first_packet = self.connection._read_packet()
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/pymysql/connections.py", line 684, in _read_packet
    packet.check_error()
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/pymysql/protocol.py", line 220, in check_error
    err.raise_mysql_exception(self._data)
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.ProgrammingError: (1064, "You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ''company': 'Gadgets'} and `tabDepartment`.disabled != 1.0\n\t\t\t\n\t\t\t order by _re' at line 3")
```