### PR TITLE
fix: query for item group listing

### DIFF
--- a/erpnext/setup/doctype/item_group/item_group.py
+++ b/erpnext/setup/doctype/item_group/item_group.py
@@ -136,6 +136,7 @@ def get_child_groups_for_list_in_html(item_group, start, limit, search):
 		fields = ['name', 'route', 'description', 'image'],
 		filters = dict(
 			show_in_website = 1,
+			parent_item_group = item_group.name,
 			lft = ('>', item_group.lft),
 			rgt = ('<', item_group.rgt),
 		),


### PR DESCRIPTION
Fixed query where item group would list groups of it's children too by adding a parent filter