### PR TITLE
Correct bug in abbr cause by missing " " separator

### DIFF
--- a/erpnext/setup/doctype/company/company.js
+++ b/erpnext/setup/doctype/company/company.js
@@ -29,7 +29,8 @@ frappe.ui.form.on("Company", {
 
 	company_name: function(frm) {
 		if(frm.doc.__islocal) {
-			let parts = frm.doc.company_name.split();
+			# add missing " " arg in split method
+			let parts = frm.doc.company_name.split(" ");
 			let abbr = $.map(parts, function (p) {
 				return p? p.substr(0, 1) : null;
 			}).join("");


### PR DESCRIPTION
Only 1 letter ABBR is generated after typing in a COMPANY NAME separated by spaces. This is due to missing " " value in split method.

For example: 

Company Name:    ABC Multiple Industries
Generates Abbr:     A
Correct Abbr should be:  AMI

This is caused by mission " " in split method.

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
