### PR TITLE
fix: last purchase rate greater than selling price

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -313,7 +313,7 @@ def item_last_purchase_rate(name, conversion_rate, item_code, conversion_factor=
 
 	last_purchase_details =  get_last_purchase_details(item_code, name)
 	if last_purchase_details:
-		last_purchase_rate = (last_purchase_details['base_rate'] * (flt(conversion_factor) or 1.0)) / conversion_rate
+		last_purchase_rate = (last_purchase_details['base_net_rate'] * (flt(conversion_factor) or 1.0)) / conversion_rate
 		return last_purchase_rate
 	else:
 		item_last_purchase_rate = frappe.get_cached_value("Item", item_code, "last_purchase_rate")

--- a/erpnext/buying/utils.py
+++ b/erpnext/buying/utils.py
@@ -24,12 +24,12 @@ def update_last_purchase_rate(doc, is_submit):
 		last_purchase_rate = None
 		if last_purchase_details and \
 				(last_purchase_details.purchase_date > this_purchase_date):
-			last_purchase_rate = last_purchase_details['base_rate']
+			last_purchase_rate = last_purchase_details['base_net_rate']
 		elif is_submit == 1:
 			# even if this transaction is the latest one, it should be submitted
 			# for it to be considered for latest purchase rate
 			if flt(d.conversion_factor):
-				last_purchase_rate = flt(d.base_rate) / flt(d.conversion_factor)
+				last_purchase_rate = flt(d.base_net_rate) / flt(d.conversion_factor)
 			# Check if item code is present
 			# Conversion factor should not be mandatory for non itemized items
 			elif d.item_code:


### PR DESCRIPTION
Problem:
- An Item rate in table is set as 100 and the additional discount is set as 30 giving a net rate of 70.
- Last purchase price is set as 100 [base rate of item]
- Creating a sales invoice for this item at price 90 gives error last purchase rate is greater than selling price but net rate for item was 70.

Changes:
- Last purchase price is set as net rate considering additional discounts
