### PR TITLE
fix: not able to select item in sales order

### DIFF
--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -159,8 +159,12 @@ def item_query(doctype, txt, searchfield, start, page_len, filters, as_dict=Fals
 	if "description" in searchfields:
 		searchfields.remove("description")
 
-	columns = [field for field in searchfields if not field in ["name", "item_group", "description"]]
-	columns = ", ".join(columns)
+	columns = ''
+	extra_searchfields = [field for field in searchfields
+		if not field in ["name", "item_group", "description"]]
+
+	if extra_searchfields:
+		columns = ", " + ", ".join(extra_searchfields)
 
 	searchfields = searchfields + [field for field in[searchfield or "name", "item_code", "item_group", "item_name"]
 		if not field in searchfields]
@@ -176,7 +180,7 @@ def item_query(doctype, txt, searchfield, start, page_len, filters, as_dict=Fals
 			concat(substr(tabItem.item_name, 1, 40), "..."), item_name) as item_name,
 		tabItem.item_group,
 		if(length(tabItem.description) > 40, \
-			concat(substr(tabItem.description, 1, 40), "..."), description) as description,
+			concat(substr(tabItem.description, 1, 40), "..."), description) as description
 		{columns}
 		from tabItem
 		where tabItem.docstatus < 2


### PR DESCRIPTION
**Issue**

```
select tabItem.name,
		if(length(tabItem.item_name) > 40,
			concat(substr(tabItem.item_name, 1, 40), "..."), item_name) as item_name,
		tabItem.item_group,
		if(length(tabItem.description) > 40, 			concat(substr(tabItem.description, 1, 40), "..."), description) as description,
		
		from tabItem
		where tabItem.docstatus < 2
			and tabItem.has_variants=0
			and tabItem.disabled=0
			and (tabItem.end_of_life > %(today)s or coalesce(tabItem.end_of_life, '0000-00-00')='0000-00-00')
			and (item_group like %(txt)s or name like %(txt)s or item_code like %(txt)s or item_name like %(txt)s or tabItem.item_code IN (select parent from `tabItem Barcode` where barcode LIKE %(txt)s)
				or tabItem.description LIKE %(txt)s)
			 and `tabItem`.is_sales_item = 1.0 
		order by
			if(locate(%(_txt)s, name), locate(%(_txt)s, name), 99999),
			if(locate(%(_txt)s, item_name), locate(%(_txt)s, item_name), 99999),
			idx desc,
			name, item_name
		limit %(start)s, %(page_len)s 
request.js:355 Traceback (most recent call last):
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/handler.py", line 61, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/__init__.py", line 1038, in call
    return fn(*args, **newargs)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/desk/search.py", line 53, in search_link
    search_widget(doctype, txt, query, searchfield=searchfield, page_length=page_length, filters=filters, reference_doctype=reference_doctype, ignore_user_permissions=ignore_user_permissions)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/desk/search.py", line 78, in search_widget
    searchfield, start, page_length, filters, as_dict=as_dict)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/__init__.py", line 1038, in call
    return fn(*args, **newargs)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/erpnext/erpnext/controllers/queries.py", line 207, in item_query
    }, as_dict=as_dict)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/database/database.py", line 156, in sql
    self._cursor.execute(query, values)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/env/lib/python2.7/site-packages/pymysql/cursors.py", line 170, in execute
    result = self._query(query)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/env/lib/python2.7/site-packages/pymysql/cursors.py", line 328, in _query
    conn.query(q)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 517, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 732, in _read_query_result
    result.read()
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 1075, in read
    first_packet = self.connection._read_packet()
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/env/lib/python2.7/site-packages/pymysql/connections.py", line 684, in _read_packet
    packet.check_error()
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/env/lib/python2.7/site-packages/pymysql/protocol.py", line 220, in check_error
    err.raise_mysql_exception(self._data)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/env/lib/python2.7/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
    raise errorclass(errno, errval)
ProgrammingError: (1064, u"You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'from tabItem\n\t\twhere tabItem.docstatus < 2\n\t\t\tand tabItem.has_variants=0\n\t\t\tand ' at line 7")
```