### PR TITLE
fix: Set allocated amount in employee advance as per total amount

### DIFF
--- a/erpnext/hr/doctype/expense_claim/expense_claim.js
+++ b/erpnext/hr/doctype/expense_claim/expense_claim.js
@@ -208,6 +208,24 @@ frappe.ui.form.on("Expense Claim", {
 		frm.refresh_fields();
 	},
 
+	grand_total: function(frm) {
+		frm.trigger("update_employee_advance_claimed_amount");
+	},
+
+	update_employee_advance_claimed_amount: function(frm) {
+		let amount_to_be_allocated = frm.doc.grand_total;
+		$.each(frm.doc.advances || [], function(i, advance){
+			if (amount_to_be_allocated >= advance.unclaimed_amount){
+				frm.doc.advances[i].allocated_amount = frm.doc.advances[i].unclaimed_amount;
+				amount_to_be_allocated -= advance.allocated_amount;
+			} else{
+				frm.doc.advances[i].allocated_amount = amount_to_be_allocated;
+				amount_to_be_allocated = 0;
+			}
+			frm.refresh_field("advances");
+		});
+	},
+
 	make_payment_entry: function(frm) {
 		var method = "erpnext.accounts.doctype.payment_entry.payment_entry.get_payment_entry";
 		if(frm.doc.__onload && frm.doc.__onload.make_payment_via_journal_entry) {
@@ -300,7 +318,7 @@ frappe.ui.form.on("Expense Claim", {
 							row.advance_account = d.advance_account;
 							row.advance_paid = d.paid_amount;
 							row.unclaimed_amount = flt(d.paid_amount) - flt(d.claimed_amount);
-							row.allocated_amount = flt(d.paid_amount) - flt(d.claimed_amount);
+							row.allocated_amount = 0;
 						});
 						refresh_field("advances");
 					}


### PR DESCRIPTION
Before it was not allocating the amount from Employee advance correctly as per the total grand total amount.

Now: 
it has been handled by allocating the unclaimed amount of multiple employee advances.
