### PR TITLE
fix: e-invoice issue

### DIFF
--- a/erpnext/regional/italy/e-invoice.xml
+++ b/erpnext/regional/italy/e-invoice.xml
@@ -205,7 +205,9 @@
         {%- endif %}
         <ImponibileImporto>{{ format_float(data.taxable_amount, item_meta.get_field("tax_amount").precision) }}</ImponibileImporto>
         <Imposta>{{ format_float(data.tax_amount, item_meta.get_field("tax_amount").precision) }}</Imposta>
-        <EsigibilitaIVA>{{ doc.vat_collectability.split("-")[0] }}</EsigibilitaIVA>
+        {%- if data.vat_collectability %}
+          <EsigibilitaIVA>{{ doc.vat_collectability.split("-")[0] }}</EsigibilitaIVA>
+        {%- endif %}
         {%- if data.tax_exemption_law %}
         <RiferimentoNormativo>{{ data.tax_exemption_law }}</RiferimentoNormativo>
         {%- endif %}


### PR DESCRIPTION
**Issue**

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/desk/form/save.py", line 19, in savedocs
    doc.submit()
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/model/document.py", line 859, in submit
    self._submit()
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/model/document.py", line 848, in _submit
    self.save()
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/model/document.py", line 272, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/model/document.py", line 325, in _save
    self.run_post_save_methods()
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/model/document.py", line 922, in run_post_save_methods
    self.run_method("on_submit")
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/model/document.py", line 787, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/model/document.py", line 1058, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/model/document.py", line 1043, in runner
    add_to_return_value(self, f(self, method, *args, **kwargs))
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/erpnext/erpnext/regional/italy/utils.py", line 279, in sales_invoice_on_submit
    prepare_and_attach_invoice(doc)
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/erpnext/erpnext/regional/italy/utils.py", line 288, in prepare_and_attach_invoice
    context={"doc": invoice, "item_meta": item_meta}, is_path=True)
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/utils/jinja.py", line 74, in render_template
    return get_jenv().get_template(template).render(context)
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/jinja2/asyncsupport.py", line 76, in render
    return original_render(self, *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/jinja2/environment.py", line 1008, in render
    return self.environment.handle_exception(exc_info, True)
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/jinja2/environment.py", line 780, in handle_exception
    reraise(exc_type, exc_value, tb)
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/jinja2/_compat.py", line 37, in reraise
    raise value.with_traceback(tb)
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/erpnext/erpnext/./regional/italy/e-invoice.xml", line 208, in top-level template code
    {{ doc.vat_collectability.split("-")[0] }}
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/jinja2/sandbox.py", line 438, in call
    if not __self.is_safe_callable(__obj):
  File "/home/frappe/benches/bench-version-12-2019-10-30/env/lib/python3.6/site-packages/jinja2/sandbox.py", line 340, in is_safe_callable
    return not (getattr(obj, 'unsafe_callable', False) or
jinja2.exceptions.UndefinedError: 'None' has no attribute 'split'
```