### PR TITLE
fix: Validation for Suppliers in SO to PO

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -834,6 +834,10 @@ def make_purchase_order(source_name, for_supplier=None, selected_items=[], targe
 		for item in sales_order.items:
 			if item.supplier and item.supplier not in suppliers:
 				suppliers.append(item.supplier)
+
+	if not suppliers:
+		frappe.throw(_("Please set a Supplier against the Items to be considered in the Purchase Order."))
+
 	for supplier in suppliers:
 		po =frappe.get_list("Purchase Order", filters={"sales_order":source_name, "supplier":supplier, "docstatus": ("<", "2")})
 		if len(po) == 0:


### PR DESCRIPTION
(While making a Purchase Order from a Sales Order)
- Validation message earlier in case of : 
  - no suppliers found against items in SO 
  - PO already made against all SO items

![_PO_msg](https://user-images.githubusercontent.com/25857446/69615005-29a4f900-105a-11ea-94d1-58692bd80fe9.png)

The user needs feedback to add Suppliers, without which POs cannot be made

**After fix:**
 - It will first check if there is at least one item with a Supplier against it, if yes it will proceed as usual
 -  Check isn't applied on every item in the Items table to maintain flexibility.

![Screenshot 2019-11-26 at 2 30 18 PM](https://user-images.githubusercontent.com/25857446/69615313-a7690480-105a-11ea-8064-7b2eaee96a0b.png)
 