### PR TITLE
fix: Employee dashboard disappear after switching from leave applicat…

### DIFF
--- a/erpnext/hr/doctype/leave_application/leave_application.js
+++ b/erpnext/hr/doctype/leave_application/leave_application.js
@@ -60,7 +60,6 @@ frappe.ui.form.on("Leave Application", {
 					}
 				}
 			});
-			$("div").remove(".form-dashboard-section");
 			frm.dashboard.add_section(
 				frappe.render_template('leave_application_dashboard', {
 					data: leave_details


### PR DESCRIPTION
After creating the Leave Application from Employee dashboard, Dashboard just got disappeared.
![before](https://user-images.githubusercontent.com/32095923/69630699-308c3580-1073-11ea-8cb3-880856fa6080.gif)
