### PR TITLE
fix: get_batch_qty_and_serial_no() requires argument 'stock_qty'

### DIFF
--- a/erpnext/selling/sales_common.js
+++ b/erpnext/selling/sales_common.js
@@ -309,7 +309,7 @@ erpnext.selling.SellingController = erpnext.TransactionController.extend({
 					child: item,
 					args: {
 						"batch_no": item.batch_no,
-						"stock_qty": item.stock_qty,
+						"stock_qty": item.stock_qty || item.qty, //if stock_qty field is not available fetch qty (in case of Packed Items table)
 						"warehouse": item.warehouse,
 						"item_code": item.item_code,
 						"has_serial_no": has_serial_no

--- a/erpnext/stock/doctype/packed_item/packed_item.json
+++ b/erpnext/stock/doctype/packed_item/packed_item.json
@@ -18,6 +18,7 @@
   "serial_no",
   "column_break_11",
   "batch_no",
+  "actual_batch_qty",
   "section_break_13",
   "actual_qty",
   "projected_qty",
@@ -189,15 +190,26 @@
    "oldfieldtype": "Data",
    "print_hide": 1,
    "read_only": 1
+  },
+  {
+   "depends_on": "batch_no",
+   "fieldname": "actual_batch_qty",
+   "fieldtype": "Float",
+   "label": "Actual Batch Quantity",
+   "no_copy": 1,
+   "print_hide": 1,
+   "read_only": 1
   }
  ],
  "idx": 1,
  "istable": 1,
- "modified": "2019-08-27 18:17:37.167512",
+ "modified": "2019-11-26 20:09:59.400960",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Packed Item",
  "owner": "Administrator",
  "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
  "track_changes": 1
 }


### PR DESCRIPTION
Issue:
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/handler.py", line 61, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-12-2019-10-30/apps/frappe/frappe/__init__..py", line 1038, in call
    return fn(*args, **newargs)
TypeError: get_batch_qty_and_serial_no() missing 1 required positional argument: 'stock_qty'
```
- The method was written with only the 'items' table in mind. Although it's triggered on Packed items table as well.
- 'Packed items' does not have a field called 'stock_qty'.
- Added a field 'actual batch quantity' in Packed Items table to see the current batch quantity that is returned via this method

![Screenshot 2019-11-26 at 9 01 50 PM](https://user-images.githubusercontent.com/25857446/69647603-cc2b9f00-108f-11ea-9844-3fe5c1af6d51.png)
