### PR TITLE
fix Program enrollment error raised when Program has children that are not Courses

### DIFF
--- a/erpnext/education/doctype/program_enrollment/program_enrollment.py
+++ b/erpnext/education/doctype/program_enrollment/program_enrollment.py
@@ -71,7 +71,7 @@ class ProgramEnrollment(Document):
 	def create_course_enrollments(self):
 		student = frappe.get_doc("Student", self.student)
 		program = frappe.get_doc("Program", self.program)
-		course_list = [course.course for course in program.get_all_children()]
+		course_list = [course.course for course in program.courses]
 		for course_name in course_list:
 			student.enroll_in_course(course_name=course_name, program_enrollment=self.name)
 


### PR DESCRIPTION
The code that creates program enrollments for students uses `program.get_all_children()` to fetch the Program's courses. This breaks if the Program has children that are not courses. This patch updates that code to use `program.courses` instead.