### PR TITLE
fix: handle None case for get_shipping_amount_from_rules

### DIFF
--- a/erpnext/accounts/doctype/shipping_rule/shipping_rule.py
+++ b/erpnext/accounts/doctype/shipping_rule/shipping_rule.py
@@ -70,7 +70,7 @@ class ShippingRule(Document):
 
 	def get_shipping_amount_from_rules(self, value):
 		for condition in self.get("conditions"):
-			if not condition.to_value or (flt(condition.from_value) <= value <= flt(condition.to_value)):
+			if not condition.to_value or (flt(condition.from_value) <= flt(value) <= flt(condition.to_value)):
 				return condition.shipping_amount
 
 		return 0.0


### PR DESCRIPTION
Traceback
```
  File "/home/frappe/benches/bench-12-2019-11-26/apps/frappe/frappe/model/document.py", line 781, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-12-2019-11-26/apps/erpnext/erpnext/controllers/accounts_controller.py", line 422, in apply_shipping_rule
    shipping_rule.apply(self)
  File "/home/frappe/benches/bench-12-2019-11-26/apps/erpnext/erpnext/accounts/doctype/shipping_rule/shipping_rule.py", line 63, in apply
    shipping_amount = self.get_shipping_amount_from_rules(value)
  File "/home/frappe/benches/bench-12-2019-11-26/apps/erpnext/erpnext/accounts/doctype/shipping_rule/shipping_rule.py", line 73, in get_shipping_amount_from_rules
    if not condition.to_value or (flt(condition.from_value) <= value <= flt(condition.to_value)):
TypeError: '<=' not supported between instances of 'float' and 'NoneType'
```
Wrapped value around `flt` so in case of None `flt(None)` will return None