### PR TITLE
fix: set opportunity as lost on quotation close

### DIFF
--- a/erpnext/crm/doctype/opportunity/opportunity.py
+++ b/erpnext/crm/doctype/opportunity/opportunity.py
@@ -133,7 +133,7 @@ class Opportunity(TransactionBase):
 			select q.name
 			from `tabQuotation` q, `tabQuotation Item` qi
 			where q.name = qi.parent and q.docstatus=1
-				and qi.prevdoc_docname =%s and q.status = 'Lost'
+				and q.status = 'Lost'
 			""", self.name)
 		if lost_quotation:
 			if self.has_active_quotation():

--- a/erpnext/selling/doctype/customer/customer.js
+++ b/erpnext/selling/doctype/customer/customer.js
@@ -12,7 +12,8 @@ frappe.ui.form.on("Customer", {
 			'Opportunity': () => erpnext.utils.create_new_doc('Opportunity', {
 				'opportunity_from': frm.doc.doctype,
 				'party_name': frm.doc.name
-			})
+			}),
+			'Test': () => console.log("Test")
 		}
 
 		frm.add_fetch('lead_name', 'company_name', 'customer_name');

--- a/erpnext/selling/doctype/customer/customer.json
+++ b/erpnext/selling/doctype/customer/customer.json
@@ -469,7 +469,7 @@
  "icon": "fa fa-user",
  "idx": 363,
  "image_field": "image",
- "modified": "2019-09-06 12:40:31.801424",
+ "modified": "2019-11-29 12:33:44.024684",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Customer",

--- a/erpnext/selling/doctype/quotation/quotation.py
+++ b/erpnext/selling/doctype/quotation/quotation.py
@@ -67,7 +67,6 @@ class Quotation(SellingController):
 			opportunity = self.opportunity
 
 		opp = frappe.get_doc("Opportunity", opportunity)
-		opp.status = None
 		opp.set_status(update=True)
 
 	def declare_enquiry_lost(self, lost_reasons_list, detailed_reason=None):


### PR DESCRIPTION
Issue: The status of the opportunity was set to `None` if a quotation against that opportunity was closed

Cause: It was explicitly set to `None`

Fix: When the quotation is set to lost, if the opportunity it was made against had no other quotations, the opportunity is also set to lost.

Other possible solutions: would be to not change the status of the opportunity at all 

GIF:

![image](https://user-images.githubusercontent.com/6195660/69789891-53286680-11b9-11ea-9ec0-28d8888b3558.png)

