### PR TITLE
fix: Division by zero error in Stock Entry

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -536,7 +536,7 @@ frappe.ui.form.on('Stock Entry Detail', {
 					if(r.message) {
 						var d = locals[cdt][cdn];
 						$.each(r.message, function(k, v) {
-							d[k] = v;
+							frappe.model.set_value(cdt, cdn, k, v); // qty and it's subsequent fields weren't triggered
 						});
 						refresh_field("items");
 						erpnext.stock.select_batch_and_serial_no(frm, d);

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -27,6 +27,7 @@ class IncorrectValuationRateError(frappe.ValidationError): pass
 class DuplicateEntryForWorkOrderError(frappe.ValidationError): pass
 class OperationsNotCompleteError(frappe.ValidationError): pass
 class MaxSampleAlreadyRetainedError(frappe.ValidationError): pass
+class TotalBasicAmountZeroError(frappe.ValidationError): pass
 
 from erpnext.controllers.stock_controller import StockController
 
@@ -649,6 +650,12 @@ class StockEntry(StockController):
 		gl_entries = super(StockEntry, self).get_gl_entries(warehouse_account)
 
 		total_basic_amount = sum([flt(t.basic_amount) for t in self.get("items") if t.t_warehouse])
+
+		if self.get("additional_costs") and not total_basic_amount:
+			#If additional costs table is populated and total basic amount is
+			#somehow 0, interrupt transaction.
+			frappe.throw(_("Total Basic Amount in Items Table cannot be 0"), TotalBasicAmountZeroError)
+
 		item_account_wise_additional_cost = {}
 
 		for t in self.get("additional_costs"):
@@ -657,7 +664,7 @@ class StockEntry(StockController):
 					item_account_wise_additional_cost.setdefault((d.item_code, d.name), {})
 					item_account_wise_additional_cost[(d.item_code, d.name)].setdefault(t.expense_account, 0.0)
 					item_account_wise_additional_cost[(d.item_code, d.name)][t.expense_account] += \
-						(t.amount * d.basic_amount) / total_basic_amount if total_basic_amount else 0
+						(t.amount * d.basic_amount) / total_basic_amount
 
 		if item_account_wise_additional_cost:
 			for d in self.get("items"):

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -657,7 +657,7 @@ class StockEntry(StockController):
 					item_account_wise_additional_cost.setdefault((d.item_code, d.name), {})
 					item_account_wise_additional_cost[(d.item_code, d.name)].setdefault(t.expense_account, 0.0)
 					item_account_wise_additional_cost[(d.item_code, d.name)][t.expense_account] += \
-						(t.amount * d.basic_amount) / total_basic_amount
+						(t.amount * d.basic_amount) / total_basic_amount if total_basic_amount else 0
 
 		if item_account_wise_additional_cost:
 			for d in self.get("items"):


### PR DESCRIPTION
- On changing item_code in Stock Entry Details **Quantity** wasn't triggered and so Basic Amount as well as subsequent fields didn't change.
- 'total_basic_amount' was 0 for some instances.
```
File "/home/frappe/benches/bench-12-2019-11-25-1/apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.py", line 90, in on_submit
    self.make_gl_entries()
  File "/home/frappe/benches/bench-12-2019-11-25-1/apps/erpnext/erpnext/controllers/stock_controller.py", line 33, in make_gl_entries
    gl_entries = self.get_gl_entries(warehouse_account)
  File "/home/frappe/benches/bench-12-2019-11-25-1/apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.py", line 658, in get_gl_entries
    (t.amount * d.basic_amount) / total_basic_amount
ZeroDivisionError: float division by zero
```
- After Fix:
  - Trigger Quantity as well to recalculate Basic Amount.
  - In presence of additional costs and absence of total basic amount , distribute additional costs based on quantity:
 ``` additional_cost_for_row = row_quantity * additional_cost / total_quantity```
  - Test case to secure the conditions: total basic amount =0 , additional costs >0, gl entries created for the additional costs only

  - ![Screenshot 2019-12-12 at 4 45 04 PM](https://user-images.githubusercontent.com/25857446/70707565-70534e00-1cfe-11ea-9642-0823cd6af4f3.png)
