### PR TITLE
fix: Division by zero error in Stock Entry

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -657,7 +657,7 @@ class StockEntry(StockController):
 					item_account_wise_additional_cost.setdefault((d.item_code, d.name), {})
 					item_account_wise_additional_cost[(d.item_code, d.name)].setdefault(t.expense_account, 0.0)
 					item_account_wise_additional_cost[(d.item_code, d.name)][t.expense_account] += \
-						(t.amount * d.basic_amount) / total_basic_amount
+						(t.amount * d.basic_amount) / total_basic_amount if total_basic_amount else 0
 
 		if item_account_wise_additional_cost:
 			for d in self.get("items"):


### PR DESCRIPTION
Basic Amount in Stock Entry Detail table (with 1 entry) glitched for one user and was 0 due to which 'total_basic_amount' being calculated was also 0
```
File "/home/frappe/benches/bench-12-2019-11-25-1/apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.py", line 90, in on_submit
    self.make_gl_entries()
  File "/home/frappe/benches/bench-12-2019-11-25-1/apps/erpnext/erpnext/controllers/stock_controller.py", line 33, in make_gl_entries
    gl_entries = self.get_gl_entries(warehouse_account)
  File "/home/frappe/benches/bench-12-2019-11-25-1/apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.py", line 658, in get_gl_entries
    (t.amount * d.basic_amount) / total_basic_amount
ZeroDivisionError: float division by zero
```