### PR TITLE
fix: render_template for subject in Email Campaign

### DIFF
--- a/erpnext/crm/doctype/email_campaign/email_campaign.py
+++ b/erpnext/crm/doctype/email_campaign/email_campaign.py
@@ -41,7 +41,8 @@ class EmailCampaign(Document):
 		email_campaign_exists = frappe.db.exists("Email Campaign", {
 			"campaign_name": self.campaign_name,
 			"recipient": self.recipient,
-			"status": ("in", ["In Progress", "Scheduled"])
+			"status": ("in", ["In Progress", "Scheduled"]),
+			"name": ("!=", self.name)
 		})
 		if email_campaign_exists:
 			frappe.throw(_("The Campaign '{0}' already exists for the {1} '{2}'").format(self.campaign_name, self.email_campaign_for, self.recipient))
@@ -78,7 +79,7 @@ def send_mail(entry, email_campaign):
 	comm = make(
 		doctype = "Email Campaign",
 		name = email_campaign.name,
-		subject = email_template.get("subject"),
+		subject = frappe.render_template(email_template.get("subject"), context),
 		content = frappe.render_template(email_template.get("response"), context),
 		sender = sender,
 		recipients = recipient,


### PR DESCRIPTION
Render Email Template for subject in Email Campaign

**Before:**
![email_template_subject](https://user-images.githubusercontent.com/24353136/69941799-19819380-150a-11ea-896c-b959e33b93f2.png)

**After:**
![email_campaign_template_fix](https://user-images.githubusercontent.com/24353136/69941825-1dadb100-150a-11ea-9648-64178e10f0fd.png)

Version 12: https://github.com/frappe/erpnext/pull/19771