### PR TITLE
fix: Unable to see parties with negative outstanding balance in AR/AP Summary

### DIFF
--- a/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py
+++ b/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py
@@ -36,7 +36,7 @@ class AccountsReceivableSummary(ReceivablePayableReport):
 			self.filters.report_date) or {}
 
 		for party, party_dict in iteritems(self.party_total):
-			if party_dict.outstanding <= 0:
+			if party_dict.outstanding == 0:
 				continue
 
 			row = frappe._dict()


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/42651287/69949641-ef36d280-1517-11ea-98b1-5e7aab44682d.png)

After:
![image](https://user-images.githubusercontent.com/42651287/69949556-beef3400-1517-11ea-8d7e-f36930675562.png)
