### PR TITLE
fix: Item qty cannot be zero in Purchase Receipt

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -375,9 +375,10 @@ class AccountsController(TransactionBase):
 		return gl_dict
 
 	def validate_qty_is_not_zero(self):
-		for item in self.items:
-			if not item.qty:
-				frappe.throw(_("Item quantity can not be zero"))
+		if self.doctype != "Purchase Receipt":
+			for item in self.items:
+				if not item.qty:
+					frappe.throw(_("Item quantity can not be zero"))
 
 	def validate_account_currency(self, account, account_currency=None):
 		valid_currency = [self.company_currency]


### PR DESCRIPTION
Port of #19779
- In Purchase Receipt, accepted qty should be allowed to have the value 0 in case of rejecting the entirety of the incoming stock