### PR TITLE
fix: query for finding lost quotation

### DIFF
--- a/erpnext/crm/doctype/opportunity/opportunity.py
+++ b/erpnext/crm/doctype/opportunity/opportunity.py
@@ -130,10 +130,10 @@ class Opportunity(TransactionBase):
 
 	def has_lost_quotation(self):
 		lost_quotation = frappe.db.sql("""
-			select q.name
-			from `tabQuotation` q
-			where q.docstatus=1
-				and q.opportunity =%s and q.status = 'Lost'
+			select name
+			from `tabQuotation`
+			where docstatus=1
+				and opportunity =%s and status = 'Lost'
 			""", self.name)
 		if lost_quotation:
 			if self.has_active_quotation():

--- a/erpnext/crm/doctype/opportunity/opportunity.py
+++ b/erpnext/crm/doctype/opportunity/opportunity.py
@@ -131,9 +131,9 @@ class Opportunity(TransactionBase):
 	def has_lost_quotation(self):
 		lost_quotation = frappe.db.sql("""
 			select q.name
-			from `tabQuotation` q, `tabQuotation Item` qi
-			where q.name = qi.parent and q.docstatus=1
-				and qi.prevdoc_docname =%s and q.status = 'Lost'
+			from `tabQuotation` q
+			where q.docstatus=1
+				and q.opportunity =%s and q.status = 'Lost'
 			""", self.name)
 		if lost_quotation:
 			if self.has_active_quotation():


### PR DESCRIPTION
Issue: The status of the opportunity was set to `None` if a quotation against that opportunity was closed

Cause: It was explicitly set to `None` and the status updater wasn't able to find lost quotations

Fix: Fix the query for finding lost quotations against opportunity.

GIF:

![image](https://user-images.githubusercontent.com/6195660/69789891-53286680-11b9-11ea-9ec0-28d8888b3558.png)

