### PR TITLE
fix: remove contact info, use international format

### DIFF
--- a/erpnext/regional/germany/address_template.html
+++ b/erpnext/regional/germany/address_template.html
@@ -1,8 +1,8 @@
 {{ address_line1 }}<br>
 {% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
-{{ pincode }} {{ city }}<br>
-{% if country %}{{ country }}<br>{% endif -%}
-<br>
-{% if phone %}Tel: {{ phone }}<br>{% endif -%}
-{% if fax %}Fax: {{ fax }}<br>{% endif -%}
-{% if email_id %}E-Mail: {{ email_id }}<br>{% endif -%}
+{% if country in ["Germany", "Deutschland"] %}
+    {{ pincode }} {{ city }}
+{% else %}
+    {{ pincode }} {{ city | upper }}<br>    
+    {{ country | upper }}
+{% endif %}


### PR DESCRIPTION
- it is not customary, to use contact information such as phone number in the address
- for international letters, city and country should be upper case: https://www.deutschepost.de/content/dam/dpag/images/B_b/Briefe_ins_Ausland/downloads/dp-brief-international-handlingbroschuere-072019.pdf#page=15

An address within Germany will look like this:

```
Teststraße 1
01234 Berlin
```

An international address will look like this:

```
1 Rue Test
01234 PARIS
FRANCE
```