### PR TITLE
fix: travis failing

### DIFF
--- a/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
+++ b/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "autoname": "hash",
  "creation": "2013-05-24 19:29:06",
  "doctype": "DocType",
@@ -43,6 +44,7 @@
   "base_amount",
   "pricing_rules",
   "is_free_item",
+  "is_fixed_asset",
   "section_break_29",
   "net_rate",
   "net_amount",
@@ -708,11 +710,20 @@
    "fieldname": "against_blanket_order",
    "fieldtype": "Check",
    "label": "Against Blanket Order"
+  },
+  {
+   "default": "0",
+   "fetch_from": "item_code.is_fixed_asset",
+   "fieldname": "is_fixed_asset",
+   "fieldtype": "Check",
+   "label": "Is Fixed Asset",
+   "read_only": 1
   }
  ],
  "idx": 1,
  "istable": 1,
- "modified": "2019-11-19 14:10:52.865006",
+ "links": [],
+ "modified": "2019-12-06 13:17:12.142799",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Purchase Order Item",

--- a/erpnext/setup/doctype/email_digest/email_digest.py
+++ b/erpnext/setup/doctype/email_digest/email_digest.py
@@ -283,7 +283,7 @@ class EmailDigest(Document):
 						card.value = card.value *-1
 					card.value = self.fmt_money(card.value,False if key in ("bank_balance", "credit_balance") else True)
 
-					cache.setex(cache_key, card, 24 * 60 * 60)
+					cache.set_value(cache_key, card, expires_in_sec=24 * 60 * 60)
 
 				context.cards.append(card)
 

--- a/erpnext/setup/utils.py
+++ b/erpnext/setup/utils.py
@@ -106,7 +106,8 @@ def get_exchange_rate(from_currency, to_currency, transaction_date=None, args=No
 			# expire in 6 hours
 			response.raise_for_status()
 			value = response.json()["rates"][to_currency]
-			cache.setex(key, value, 6 * 60 * 60)
+
+			cache.set_value(key, value, expires_in_sec=6 * 60 * 60)
 		return flt(value)
 	except:
 		frappe.log_error(title="Get Exchange Rate")


### PR DESCRIPTION
1) def setex(key, time, value) is the syntax in the latest version of redis cache where as we are using the old style setex(key, value, time)

2) is_fixed_asset field was [removed](https://github.com/frappe/erpnext/pull/19612/files#diff-00751eb885104f585b2eeb3f16b48d48L46) from the purchase order item doctype but the code was preset against the field. Added the field is_fixed_asset again in the purchase order item doctype