### PR TITLE
fix: Consistency in button positions in Sales Order and Purchase Order

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -112,7 +112,6 @@ erpnext.selling.SalesOrderController = erpnext.selling.SellingController.extend(
 		let allow_delivery = false;
 
 		if (doc.docstatus==1) {
-			this.frm.add_custom_button(__('Pick List'), () => this.create_pick_list(), __('Create'));
 
 			if(this.frm.has_perm("submit")) {
 				if(doc.status === 'On Hold') {
@@ -136,7 +135,7 @@ erpnext.selling.SalesOrderController = erpnext.selling.SellingController.extend(
 			if(doc.status !== 'Closed') {
 				if(doc.status !== 'On Hold') {
 
-					allow_delivery = this.frm.doc.items.some(item => item.delivered_by_supplier === 0 && item.qty > flt(item.delivered_qty)) 
+					allow_delivery = this.frm.doc.items.some(item => item.delivered_by_supplier === 0 && item.qty > flt(item.delivered_qty))
 						&& !this.frm.doc.skip_delivery_note
 
 					if (this.frm.has_perm("submit")) {
@@ -147,6 +146,8 @@ erpnext.selling.SalesOrderController = erpnext.selling.SellingController.extend(
 							this.frm.add_custom_button(__('Close'), () => this.close_sales_order(), __("Status"))
 						}
 					}
+
+					this.frm.add_custom_button(__('Pick List'), () => this.create_pick_list(), __('Create'));
 
 					// delivery note
 					if(flt(doc.per_delivered, 6) < 100 && ["Sales", "Shopping Cart"].indexOf(doc.order_type)!==-1 && allow_delivery) {
@@ -361,7 +362,7 @@ erpnext.selling.SalesOrderController = erpnext.selling.SellingController.extend(
 	},
 
 	toggle_delivery_date: function() {
-		this.frm.fields_dict.items.grid.toggle_reqd("delivery_date", 
+		this.frm.fields_dict.items.grid.toggle_reqd("delivery_date",
 			(this.frm.doc.order_type == "Sales" && !this.frm.doc.skip_delivery_note));
 	},
 


### PR DESCRIPTION
Position in Purchase Order:
![Screenshot 2019-12-06 at 5 28 54 PM](https://user-images.githubusercontent.com/42651287/70322249-a3ee2e00-184f-11ea-9829-32a4f64f8b83.png)

Before in Sales Order:
![Screenshot 2019-12-06 at 5 36 31 PM](https://user-images.githubusercontent.com/42651287/70322265-b23c4a00-184f-11ea-8443-4ecf42068a88.png)

After in sales order:
![Screenshot 2019-12-06 at 5 33 15 PM](https://user-images.githubusercontent.com/42651287/70322277-b9fbee80-184f-11ea-8d70-446f70934dd7.png)

