### PR TITLE
fix: Validation msg fix in GSTR-1 report

### DIFF
--- a/erpnext/regional/report/gstr_1/gstr_1.js
+++ b/erpnext/regional/report/gstr_1/gstr_1.js
@@ -55,14 +55,25 @@ frappe.query_reports["GSTR-1"] = {
 		report.page.add_inner_button(__("Download as JSON"), function () {
 			var filters = report.get_values();
 
-			const args = {
-				cmd: 'erpnext.regional.report.gstr_1.gstr_1.get_json',
-				data: report.data,
-				report_name: report.report_name,
-				filters: filters
-			};
-
-			open_url_post(frappe.request.url, args);
+			frappe.call({
+				method: 'erpnext.regional.report.gstr_1.gstr_1.get_json',
+				args: {
+					data: report.data,
+					report_name: report.report_name,
+					filters: filters
+				},
+				callback: function(r) {
+					if (r.message) {
+						const args = {
+							cmd: 'erpnext.regional.report.gstr_1.gstr_1.download_json_file',
+							data: r.message.data,
+							report_name: r.message.report_name,
+							report_type: r.message.report_type
+						};
+						open_url_post(frappe.request.url, args);
+					}
+				}
+			})
 		});
 	}
 }

--- a/erpnext/regional/report/gstr_1/gstr_1.js
+++ b/erpnext/regional/report/gstr_1/gstr_1.js
@@ -73,7 +73,7 @@ frappe.query_reports["GSTR-1"] = {
 						open_url_post(frappe.request.url, args);
 					}
 				}
-			})
+			});
 		});
 	}
 }


### PR DESCRIPTION
Before:
The validation msg was shown with the entire traceback which many times user is not able to understand
![image](https://user-images.githubusercontent.com/42651287/70328922-34346f00-1860-11ea-94b7-4c8f885579a1.png)

After:
![image](https://user-images.githubusercontent.com/42651287/70328828-ffc0b300-185f-11ea-83ae-179bf8a76aa2.png)
