### PR TITLE
fix: timesheet overlap error

### DIFF
--- a/erpnext/projects/doctype/timesheet/timesheet.py
+++ b/erpnext/projects/doctype/timesheet/timesheet.py
@@ -188,7 +188,8 @@ class Timesheet(Document):
 			}, as_dict=True)
 		# check internal overlap
 		for time_log in self.time_logs:
-			if not (time_log.from_time or time_log.to_time): continue
+			if not (time_log.from_time and time_log.to_time
+				and args.from_time and args.to_time): continue
 
 			if (fieldname != 'workstation' or args.get(fieldname) == time_log.get(fieldname)) and \
 				args.idx != time_log.idx and ((args.from_time > time_log.from_time and args.from_time < time_log.to_time) or


### PR DESCRIPTION
**Issue**

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-12-2019-11-26/apps/frappe/frappe/desk/form/save.py", line 22, in savedocs
    doc.save()
  File "/home/frappe/benches/bench-12-2019-11-26/apps/frappe/frappe/model/document.py", line 272, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-12-2019-11-26/apps/frappe/frappe/model/document.py", line 308, in _save
    self.run_before_save_methods()
  File "/home/frappe/benches/bench-12-2019-11-26/apps/frappe/frappe/model/document.py", line 888, in run_before_save_methods
    self.run_method("validate")
  File "/home/frappe/benches/bench-12-2019-11-26/apps/frappe/frappe/model/document.py", line 787, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-12-2019-11-26/apps/frappe/frappe/model/document.py", line 1058, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-12-2019-11-26/apps/frappe/frappe/model/document.py", line 1041, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-12-2019-11-26/apps/frappe/frappe/model/document.py", line 781, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-12-2019-11-26/apps/erpnext/erpnext/projects/doctype/timesheet/timesheet.py", line 26, in validate
    self.validate_time_logs()
  File "/home/frappe/benches/bench-12-2019-11-26/apps/erpnext/erpnext/projects/doctype/timesheet/timesheet.py", line 147, in validate_time_logs
    self.validate_overlap(data)
  File "/home/frappe/benches/bench-12-2019-11-26/apps/erpnext/erpnext/projects/doctype/timesheet/timesheet.py", line 153, in validate_overlap
    self.validate_overlap_for("employee", data, self.employee, settings.ignore_employee_time_overlap)
  File "/home/frappe/benches/bench-12-2019-11-26/apps/erpnext/erpnext/projects/doctype/timesheet/timesheet.py", line 163, in validate_overlap_for
    existing = self.get_overlap_for(fieldname, args, value)
  File "/home/frappe/benches/bench-12-2019-11-26/apps/erpnext/erpnext/projects/doctype/timesheet/timesheet.py", line 196, in get_overlap_for
    (args.from_time <= time_log.from_time and args.to_time >= time_log.to_time)):
TypeError: '>=' not supported between instances of 'str' and 'NoneType'
```