### PR TITLE
fix: NoneType' object has no attribute '__getitem__'

### DIFF
--- a/erpnext/stock/doctype/packed_item/packed_item.py
+++ b/erpnext/stock/doctype/packed_item/packed_item.py
@@ -65,7 +65,7 @@ def update_packing_list_item(doc, packing_item_code, qty, main_item_row, descrip
 	bin = get_bin_qty(packing_item_code, pi.warehouse)
 	pi.actual_qty = flt(bin.get("actual_qty"))
 	pi.projected_qty = flt(bin.get("projected_qty"))
-	if old_packed_items_map:
+	if old_packed_items_map and old_packed_items_map.get((packing_item_code, main_item_row.item_code)):
 		pi.batch_no = old_packed_items_map.get((packing_item_code, main_item_row.item_code))[0].batch_no
 		pi.serial_no = old_packed_items_map.get((packing_item_code, main_item_row.item_code))[0].serial_no
 		pi.warehouse = old_packed_items_map.get((packing_item_code, main_item_row.item_code))[0].warehouse


### PR DESCRIPTION
```
Traceback (most recent call last):
File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/form/save.py", line 22, in savedocs
doc.save()
File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 272, in save
return self._save(*args, **kwargs)
File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 295, in _save
self.insert()
File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 229, in insert
self.run_before_save_methods()
File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 888, in run_before_save_methods
self.run_method("validate")
File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 787, in run_method
out = Document.hook(fn)(self, *args, **kwargs)
File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1058, in composer
return composed(self, method, *args, **kwargs)
File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1041, in runner
add_to_return_value(self, fn(self, *args, **kwargs))
File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 781, in <lambda>
fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
File "/home/frappe/frappe-bench/apps/erpnext/erpnext/selling/doctype/sales_order/sales_order.py", line 54, in validate
make_packing_list(self)
File "/home/frappe/frappe-bench/apps/erpnext/erpnext/stock/doctype/packed_item/packed_item.py", line 81, in make_packing_list
update_packing_list_item(doc, i.item_code, flt(i.qty)*flt(d.stock_qty), d, i.description)
File "/home/frappe/frappe-bench/apps/erpnext/erpnext/stock/doctype/packed_item/packed_item.py", line 69, in update_packing_list_item
pi.batch_no = old_packed_items_map.get((packing_item_code, main_item_row.item_code))[0].batch_no
TypeError: 'NoneType' object has no attribute '__getitem__'
```