### PR TITLE
fix: incorrect account mapping for child companies

### DIFF
--- a/erpnext/accounts/doctype/account/account.py
+++ b/erpnext/accounts/doctype/account/account.py
@@ -109,12 +109,13 @@ class Account(NestedSet):
 			if not descendants: return
 
 			parent_acc_name_map = {}
-			parent_acc_name = frappe.db.get_value('Account', self.parent_account, "account_name")
+			parent_acc_name, parent_acc_number = frappe.db.get_value('Account', self.parent_account, \
+				["account_name", "account_number"])
 			for d in frappe.db.get_values('Account',
-				{"company": ["in", descendants], "account_name": parent_acc_name},
-				["company", "name"], as_dict=True):
+				{ "company": ["in", descendants], "account_name": parent_acc_name, 
+					"account_number": parent_acc_number },
+				["company", "name"], as_dict=True, debug=1):
 				parent_acc_name_map[d["company"]] = d["name"]
-
 			if not parent_acc_name_map: return
 
 			self.create_account_for_child_company(parent_acc_name_map, descendants, parent_acc_name)

--- a/erpnext/accounts/doctype/account/account.py
+++ b/erpnext/accounts/doctype/account/account.py
@@ -114,7 +114,7 @@ class Account(NestedSet):
 			for d in frappe.db.get_values('Account',
 				{ "company": ["in", descendants], "account_name": parent_acc_name, 
 					"account_number": parent_acc_number },
-				["company", "name"], as_dict=True, debug=1):
+				["company", "name"], as_dict=True):
 				parent_acc_name_map[d["company"]] = d["name"]
 			if not parent_acc_name_map: return
 


### PR DESCRIPTION
On adding an account to a parent company, accounts added into the child company had incorrect parent account. This only happens when other accounts have same name as parent account but with different account number.