### PR TITLE
fix: Item-wise Sales History report not working

### DIFF
--- a/erpnext/selling/report/item_wise_sales_history/item_wise_sales_history.js
+++ b/erpnext/selling/report/item_wise_sales_history/item_wise_sales_history.js
@@ -20,11 +20,15 @@ frappe.query_reports["Item-wise Sales History"] = {
 		},
 		{
 			fieldname:"from_date",
+			reqd: 1,
 			label: __("From Date"),
 			fieldtype: "Date",
+			default: frappe.datetime.add_months(frappe.datetime.get_today(), -1),
 		},
 		{
 			fieldname:"to_date",
+			reqd: 1,
+			default: frappe.datetime.get_today(),
 			label: __("To Date"),
 			fieldtype: "Date",
 		},

--- a/erpnext/selling/report/item_wise_sales_history/item_wise_sales_history.py
+++ b/erpnext/selling/report/item_wise_sales_history/item_wise_sales_history.py
@@ -196,6 +196,7 @@ def get_customer_details():
 
 def get_sales_order_details(company_list, filters):
 	conditions = get_conditions(filters)
+
 	return frappe.db.sql("""
 		SELECT
 			so_item.item_code, so_item.item_name, so_item.item_group,
@@ -208,7 +209,6 @@ def get_sales_order_details(company_list, filters):
 			`tabSales Order` so, `tabSales Order Item` so_item
 		WHERE
 			so.name = so_item.parent
-			AND so.company in (%s)
-			AND so.docstatus = 1
-			{0}
-	""".format(conditions), company_list, as_dict=1) #nosec
+			AND so.company in ({0})
+			AND so.docstatus = 1 {1}
+	""".format(','.join(["%s"] * len(company_list)), conditions), tuple(company_list), as_dict=1)


### PR DESCRIPTION
**Issue**

```
Traceback (most recent call last):
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/handler.py", line 61, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/__init__.py", line 1041, in call
    return fn(*args, **newargs)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/__init__.py", line 514, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 183, in run
    result = generate_report_result(report, filters, user)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 68, in generate_report_result
    res = report.execute_script_report(filters)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/core/doctype/report/report.py", line 104, in execute_script_report
    res = self.execute_module(filters)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/core/doctype/report/report.py", line 121, in execute_module
    return frappe.get_attr(method_name)(frappe._dict(filters))
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/erpnext/erpnext/selling/report/item_wise_sales_history/item_wise_sales_history.py", line 13, in execute
    data = get_data(filters)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/erpnext/erpnext/selling/report/item_wise_sales_history/item_wise_sales_history.py", line 145, in get_data
    sales_order_records = get_sales_order_details(company_list, filters)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/erpnext/erpnext/selling/report/item_wise_sales_history/item_wise_sales_history.py", line 214, in get_sales_order_details
    """.format(conditions), company_list, as_dict=1) #nosec
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/database/database.py", line 156, in sql
    self._cursor.execute(query, values)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/env/lib/python2.7/site-packages/pymysql/cursors.py", line 168, in execute
    query = self.mogrify(query, args)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/env/lib/python2.7/site-packages/pymysql/cursors.py", line 147, in mogrify
    query = query % self._escape_args(args, conn)
TypeError: not all arguments converted during string formatting
```

**After Fix**

<img width="1244" alt="Screenshot 2019-12-10 at 5 42 57 PM" src="https://user-images.githubusercontent.com/8780500/70528817-1410f280-1b75-11ea-8254-3e2853c82f79.png">
