### PR TITLE
fix: sc object not loaded

### DIFF
--- a/erpnext/buying/doctype/supplier_scorecard/supplier_scorecard.py
+++ b/erpnext/buying/doctype/supplier_scorecard/supplier_scorecard.py
@@ -138,7 +138,7 @@ def refresh_scorecards():
 		# Check to see if any new scorecard periods are created
 		if make_all_scorecards(sc.name) > 0:
 			# Save the scorecard to update the score and standings
-			sc.save()
+			frappe.get_doc('Supplier Scorecard', sc.name).save()
 
 
 @frappe.whitelist()


### PR DESCRIPTION
fix for object not loaded and errors in auto-generate :

> Traceback (most recent call last):
>   File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/background_jobs.py", line 103, in execute_job
>     method(**kwargs)
>   File "/home/frappe/frappe-bench/apps/erpnext/erpnext/buying/doctype/supplier_scorecard/supplier_scorecard.py", line 141, in refresh_scorecards
>     sc.save()
> TypeError: 'NoneType' object is not callable

