### PR TITLE
fix: Disable Rounded Total always showing field default value

### DIFF
--- a/erpnext/public/js/controllers/buying.js
+++ b/erpnext/public/js/controllers/buying.js
@@ -30,7 +30,7 @@ erpnext.buying.BuyingController = erpnext.TransactionController.extend({
 			&& frappe.meta.has_field(this.frm.doc.doctype, "disable_rounded_total")) {
 
 				var df = frappe.meta.get_docfield(this.frm.doc.doctype, "disable_rounded_total");
-				var disable = df.default || cint(frappe.sys_defaults.disable_rounded_total);
+				var disable = cint(df.default) || cint(frappe.sys_defaults.disable_rounded_total);
 				this.frm.set_value("disable_rounded_total", disable);
 		}
 


### PR DESCRIPTION
- Default field value was a string and so 'disable_rounded_total' never took the value of global defaults ever.
