### PR TITLE
fix: customer price list being overidden by default price list

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -169,7 +169,7 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 	onload: function() {
 		var me = this;
 
-		if(this.frm.doc.__islocal) {
+		if(this.frm.is_new()) {
 			var currency = frappe.defaults.get_user_default("currency");
 
 			let set_value = (fieldname, value) => {
@@ -183,6 +183,9 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 				() => set_value('price_list_currency', currency),
 				() => set_value('status', 'Draft'),
 				() => set_value('is_subcontracted', 'No'),
+				() => {
+					if(this.frm.doc.party_name) { return this.frm.trigger('party_name'); } // fetch details if party name is set
+				},
 				() => {
 					if(this.frm.doc.company && !this.frm.doc.amended_from) {
 						this.frm.trigger("company");


### PR DESCRIPTION
Issue: When creating a quotation from Customer form. Correct Selling price list would not be fetched, instead the default price list would be applied. GIF below


![quotation issued wrong](https://user-images.githubusercontent.com/6195660/70603214-f03dc300-1bed-11ea-8687-58a6a853212f.gif)


Cause: `party_name` trigger wasn't being triggered onload.

Fix: Add `party_name` trigger in `onload`. GIF Below


![quotation issue fixed](https://user-images.githubusercontent.com/6195660/70603932-88887780-1bef-11ea-9f9c-7cd3c78106d9.gif)



Notes:

Also changed `this.frm.doc.__islocal` to `this.frm.is_new()` as it is more semantic.