### PR TITLE
fix: Bank statement not getting attached in Bank Reconciliation

### DIFF
--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction_upload.py
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction_upload.py
@@ -15,8 +15,8 @@ def upload_bank_statement():
 		with open(frappe.uploaded_file, "rb") as upfile:
 			fcontent = upfile.read()
 	else:
-		from frappe.utils.file_manager import get_uploaded_content
-		fname, fcontent = get_uploaded_content()
+		fcontent = frappe.local.uploaded_file
+		fname = frappe.local.uploaded_filename
 
 	if frappe.safe_encode(fname).lower().endswith("csv".encode('utf-8')):
 		from frappe.utils.csvutils import read_csv_content


### PR DESCRIPTION
Before fix:
![upload not working](https://user-images.githubusercontent.com/19775888/70606233-0cf3ee00-1c22-11ea-9215-c1812d75a0a2.gif)


After fix:
![upload bank statement](https://user-images.githubusercontent.com/19775888/70606251-12e9cf00-1c22-11ea-8d36-18a118379728.gif)
