### PR TITLE
fix: enable adding of address without enabling checkout feature

### DIFF
--- a/erpnext/selling/doctype/sales_order_item/sales_order_item.json
+++ b/erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -77,10 +77,12 @@
   "ordered_qty",
   "planned_qty",
   "column_break_69",
-  "delivered_qty",
   "work_order_qty",
+  "delivered_qty",
   "produced_qty",
   "returned_qty",
+  "shopping_cart_section",
+  "additional_notes",
   "section_break_63",
   "page_break",
   "item_tax_rate",
@@ -746,15 +748,20 @@
    "label": "Image"
   },
   {
-   "default": "0",
-   "fieldname": "against_blanket_order",
-   "fieldtype": "Check",
-   "label": "Against Blanket Order"
+   "collapsible": 1,
+   "fieldname": "shopping_cart_section",
+   "fieldtype": "Section Break",
+   "label": "Shopping Cart"
+  },
+  {
+   "fieldname": "additional_notes",
+   "fieldtype": "Text",
+   "label": "Additional Notes"
   }
  ],
  "idx": 1,
  "istable": 1,
- "modified": "2019-11-19 14:19:29.491945",
+ "modified": "2019-12-11 18:06:26.238169",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order Item",

--- a/erpnext/templates/includes/cart/cart_address.html
+++ b/erpnext/templates/includes/cart/cart_address.html
@@ -65,16 +65,6 @@ frappe.ready(() => {
 					reqd: 1
 				},
 				{
-					label: __('Address Type'),
-					fieldname: 'address_type',
-					fieldtype: 'Select',
-					options: [
-						'Billing',
-						'Shipping'
-					],
-					reqd: 1
-				},
-				{
 					label: __('Address Line 1'),
 					fieldname: 'address_line1',
 					fieldtype: 'Data',
@@ -97,15 +87,36 @@ frappe.ready(() => {
 					fieldtype: 'Data'
 				},
 				{
+					label: __('Country'),
+					fieldname: 'country',
+					fieldtype: 'Link',
+					options: 'Country',
+					reqd: 1
+				},
+				{
+					fieldname: "column_break0",
+					fieldtype: "Column Break",
+					width: "50%"
+				},
+				{
+					label: __('Address Type'),
+					fieldname: 'address_type',
+					fieldtype: 'Select',
+					options: [
+						'Billing',
+						'Shipping'
+					],
+					reqd: 1
+				},
+				{
 					label: __('Pin Code'),
 					fieldname: 'pincode',
 					fieldtype: 'Data'
 				},
 				{
-					label: __('Country'),
-					fieldname: 'country',
-					fieldtype: 'Link',
-					reqd: 1
+					fieldname: "phone",
+					fieldtype: "Data",
+					label: "Phone"
 				},
 			],
 			primary_action_label: __('Save'),

--- a/erpnext/templates/pages/cart.html
+++ b/erpnext/templates/pages/cart.html
@@ -83,11 +83,9 @@
 		</div>
 	{% endif %}
 
-	{% if cart_settings.enable_checkout %}
 	<div class="cart-addresses mt-5">
 	{% include "templates/includes/cart/cart_address.html" %}
 	</div>
-	{% endif %}
 	{% endif %}
 </div>
 


### PR DESCRIPTION
Allows selecting and adding addresses in **shopping cart** without **checkout** feature enabled.
Added **Additional Notes** field in Sales Order.