### PR TITLE
fix: pricing rule working on non pricing rule items

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -247,6 +247,7 @@ def get_pricing_rule_for_item(args, price_list_rate=0, doc=None):
 
 			rules.append(get_pricing_rule_details(args, pricing_rule))
 			if pricing_rule.mixed_conditions or pricing_rule.apply_rule_on_other:
+				item_details.apply_rule_on_other_items = 1
 				continue
 
 			if pricing_rule.coupon_code_based==1 and args.coupon_code==None:

--- a/erpnext/accounts/doctype/pricing_rule/utils.py
+++ b/erpnext/accounts/doctype/pricing_rule/utils.py
@@ -410,7 +410,8 @@ def validate_pricing_rule_on_items(doc, item_row, do_not_validate = False):
 	for pricing_rule in get_applied_pricing_rules(doc, item_row):
 		pr_doc = frappe.get_doc('Pricing Rule', pricing_rule)
 
-		if pr_doc.get('apply_on') == 'Transaction': continue
+		if (pr_doc.get('apply_on') == 'Transaction'
+			or not pr_doc.get("mixed_conditions")): continue
 
 		if pr_doc.get('price_or_product_discount') == 'Product':
 			apply_pricing_rule_for_free_items(doc, pr_doc)

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1352,7 +1352,7 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 		let me = this;
 		const fields = ["discount_percentage", "discount_amount", "pricing_rules"];
 
-		if (item.pricing_rules) {
+		if (item.pricing_rules && item.apply_rule_on_other_items) {
 			frappe.call({
 				method: "erpnext.accounts.doctype.pricing_rule.utils.validate_pricing_rule_for_different_cond",
 				args: {


### PR DESCRIPTION
**Issue**

On Item A pricing rule applied
If qty is between 10-20 then 10% discount

In Sales Invoice 
At row 1) Item A -> Qty 10 -> Rule Applied (which is correct)
At row 2) Item A -> Qty 5 -> Rule Applied (which is incorrect, rule should not applied)