### PR TITLE
fix: task validation error when adding tasks to projects

### DIFF
--- a/erpnext/projects/doctype/task/task.py
+++ b/erpnext/projects/doctype/task/task.py
@@ -47,9 +47,10 @@ class Task(NestedSet):
 		if not self.project or frappe.flags.in_test:
 			return
 
-		expected_end_date = getdate(frappe.db.get_value("Project", self.project, "expected_end_date"))
+		expected_end_date = frappe.db.get_value("Project", self.project, "expected_end_date")
 
 		if expected_end_date:
+			expected_end_date = getdate(expected_end_date)
 			validate_project_dates(expected_end_date, self, "exp_start_date", "exp_end_date", "Expected")
 			validate_project_dates(expected_end_date, self, "act_start_date", "act_end_date", "Actual")
 

--- a/erpnext/projects/doctype/task/task.py
+++ b/erpnext/projects/doctype/task/task.py
@@ -50,9 +50,8 @@ class Task(NestedSet):
 		expected_end_date = frappe.db.get_value("Project", self.project, "expected_end_date")
 
 		if expected_end_date:
-			expected_end_date = getdate(expected_end_date)
-			validate_project_dates(expected_end_date, self, "exp_start_date", "exp_end_date", "Expected")
-			validate_project_dates(expected_end_date, self, "act_start_date", "act_end_date", "Actual")
+			validate_project_dates(getdate(expected_end_date), self, "exp_start_date", "exp_end_date", "Expected")
+			validate_project_dates(getdate(expected_end_date), self, "act_start_date", "act_end_date", "Actual")
 
 	def validate_status(self):
 		if self.status!=self.get_db_value("status") and self.status == "Completed":


### PR DESCRIPTION
When adding a task to a project, if the project didn't have an Expected End Date the validation would fail.

This is because passing a None value to getdate() returns today's date, rather than being optional as expected.