### PR TITLE
fix: replace sql with orm query for deleting company communications

### DIFF
--- a/erpnext/setup/doctype/company/delete_company_transactions.py
+++ b/erpnext/setup/doctype/company/delete_company_transactions.py
@@ -106,7 +106,10 @@ def delete_lead_addresses(company_name):
 		frappe.db.sql("""update tabCustomer set lead_name=NULL where lead_name in ({leads})""".format(leads=",".join(leads)))
 
 def delete_communications(doctype, company_name, company_fieldname):
-		frappe.db.sql("""
-			DELETE FROM `tabCommunication` WHERE reference_doctype = %s AND
-			EXISTS (SELECT name FROM `tab{0}` WHERE {1} = %s AND `tabCommunication`.reference_name = name)
-			""".format(doctype, company_fieldname), (doctype, company_name))
+		reference_docs = frappe.get_all(doctype, filters={company_fieldname:company_name})
+		reference_doc_names = [r.name for r in reference_docs]
+		
+		communications = frappe.get_all("Communication", filters={"reference_doctype":doctype,"reference_name":["in", reference_doc_names]})
+		communication_names = [c.name for c in communications]
+
+		frappe.delete_doc("Communication", communication_names)

--- a/erpnext/setup/doctype/company/test_company.py
+++ b/erpnext/setup/doctype/company/test_company.py
@@ -88,6 +88,57 @@ class TestCompany(unittest.TestCase):
 					self.delete_mode_of_payment(template)
 					frappe.delete_doc("Company", template)
 
+	def test_delete_communication(self):
+		from erpnext.setup.doctype.company.delete_company_transactions import delete_communications
+		company = create_child_company()
+		lead = create_test_lead_in_company(company)
+		communication = create_company_communication("Lead", lead)
+		delete_communications("Lead", "Test Company", "company")
+		self.assertFalse(frappe.db.exists("Communcation", communication))
+		self.assertFalse(frappe.db.exists({"doctype":"Comunication Link", "link_name": communication}))
+
 	def delete_mode_of_payment(self, company):
 		frappe.db.sql(""" delete from `tabMode of Payment Account`
 			where company =%s """, (company))
+
+def create_company_communication(doctype, docname):
+	comm = frappe.get_doc({
+			"doctype": "Communication",
+			"communication_type": "Communication",
+			"content": "Deduplication of Links",
+			"communication_medium": "Email",
+			"reference_doctype":doctype,
+			"reference_name":docname
+		})
+	comm.insert()
+
+def create_child_company():
+	child_company = frappe.db.exists("Company", "Test Company")
+	if not child_company:
+		child_company = frappe.get_doc({
+			"doctype":"Company",
+			"company_name":"Test Company",
+			"abbr":"test_company",
+			"default_currency":"INR"
+		})
+		child_company.insert()
+	else:
+		child_company = frappe.get_doc("Company", child_company)
+	
+	return child_company.name
+
+def create_test_lead_in_company(company):
+	lead = frappe.db.exists("Lead", "Test Lead in new company")
+	if not lead:
+		lead = frappe.get_doc({
+			"doctype": "Lead",
+			"lead_name": "Test Lead in new company",
+			"scompany": company
+		})
+		lead.insert()
+	else:
+		lead = frappe.get_doc("Lead", lead)
+		lead.company = company
+		lead.save()
+	return lead.name
+


### PR DESCRIPTION
Issue: Customer was linked with communication links docs.

Cause: SQL query was used to delete communications which doesn't delete child table `Communication Links`

Fix: replace SQL query with ORM.