### PR TITLE
fix: added validation for cost center

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -90,6 +90,7 @@ class SalesInvoice(SellingController):
 		self.validate_account_for_change_amount()
 		self.validate_fixed_asset()
 		self.set_income_account_for_fixed_assets()
+		self.validate_item_cost_centers()
 		validate_inter_company_party(self.doctype, self.customer, self.company, self.inter_company_invoice_reference)
 
 		if cint(self.is_pos):
@@ -146,6 +147,12 @@ class SalesInvoice(SellingController):
 
 					elif asset.status in ("Scrapped", "Cancelled", "Sold"):
 						frappe.throw(_("Row #{0}: Asset {1} cannot be submitted, it is already {2}").format(d.idx, d.asset, asset.status))
+
+	def validate_item_cost_centers(self):
+		for item in self.get("items",None):
+			cc = frappe.get_doc("Cost Center",item.cost_center)
+			if cc.company != self.company:
+				frappe.throw(_("Row #{0} : Cost Center <strong>{1}</strong> does not belong to company <strong>{2}</strong>").format(item.idx, item.cost_center, self.company))
 
 	def before_save(self):
 		set_account_for_mode_of_payment(self)

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -149,10 +149,10 @@ class SalesInvoice(SellingController):
 						frappe.throw(_("Row #{0}: Asset {1} cannot be submitted, it is already {2}").format(d.idx, d.asset, asset.status))
 
 	def validate_item_cost_centers(self):
-		for item in self.get("items",None):
-			cc = frappe.get_doc("Cost Center",item.cost_center)
-			if cc.company != self.company:
-				frappe.throw(_("Row #{0} : Cost Center <strong>{1}</strong> does not belong to company <strong>{2}</strong>").format(item.idx, item.cost_center, self.company))
+		for item in self.items:
+			cost_center_company = frappe.get_cached_value("Cost Center", item.cost_center, "company")
+			if cost_center_company != self.company:
+				frappe.throw(_("Row #{0}: Cost Center {1} does not belong to company {2}").format(frappe.bold(item.idx), frappe.bold(item.cost_center), frappe.bold(self.company)))
 
 	def before_save(self):
 		set_account_for_mode_of_payment(self)


### PR DESCRIPTION
Issue: No validation for cost center for item in item_list, to check if the cost center set for each item belongs to the company selected. If user changes company of sales invoice after saving the doc with items, the error will be thrown from GL entry which is less contextual.

Fix: add validation for cost centers in sales invoice itself.

Error message:

<img width="410" alt="Screenshot 2019-12-18 at 11 04 01 AM" src="https://user-images.githubusercontent.com/6195660/71060953-d3aa0980-215e-11ea-811b-1a66ce943809.png">

