### PR TITLE
fix(sales-invoice): remove double rounding adjustment

### DIFF
--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -307,7 +307,10 @@ class calculate_taxes_and_totals(object):
 				for d in self.doc.get("taxes") if not d.included_in_print_rate])
 			diff = self.doc.total + non_inclusive_tax_amount \
 				- flt(last_tax.total, last_tax.precision("total"))
-			if diff < 0 and abs(diff) <= (5.0 / 10**last_tax.precision("tax_amount")):
+
+			diff = 0 if ((diff - self.doc.discount_amount) <= (1.0/ 10**last_tax.precision("tax_amount"))) else diff
+
+			if diff and abs(diff) <= (5.0 / 10**last_tax.precision("tax_amount")):
 				self.doc.rounding_adjustment = flt(flt(self.doc.rounding_adjustment) +
 					flt(diff), self.doc.precision("rounding_adjustment"))
 

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -307,7 +307,7 @@ class calculate_taxes_and_totals(object):
 				for d in self.doc.get("taxes") if not d.included_in_print_rate])
 			diff = self.doc.total + non_inclusive_tax_amount \
 				- flt(last_tax.total, last_tax.precision("total"))
-			if diff and abs(diff) <= (5.0 / 10**last_tax.precision("tax_amount")):
+			if diff < 0 and abs(diff) <= (5.0 / 10**last_tax.precision("tax_amount")):
 				self.doc.rounding_adjustment = flt(flt(self.doc.rounding_adjustment) +
 					flt(diff), self.doc.precision("rounding_adjustment"))
 

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -308,7 +308,8 @@ class calculate_taxes_and_totals(object):
 			diff = self.doc.total + non_inclusive_tax_amount \
 				- flt(last_tax.total, last_tax.precision("total"))
 
-			diff = 0 if ((diff - self.doc.discount_amount) <= (1.0/ 10**last_tax.precision("tax_amount"))) else diff
+			diff = 0 if ((diff - flt(self.doc.discount_amount, self.doc.precision('discount_amount')))\
+				<= (1.0/ 10**last_tax.precision("tax_amount"))) else diff
 
 			if diff and abs(diff) <= (5.0 / 10**last_tax.precision("tax_amount")):
 				self.doc.rounding_adjustment = flt(flt(self.doc.rounding_adjustment) +

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -386,7 +386,8 @@ erpnext.taxes_and_totals = erpnext.payments.extend({
 				var diff = me.frm.doc.total + non_inclusive_tax_amount
 					- flt(last_tax.total, precision("grand_total"));
 
-				diff = ((diff - me.frm.doc.discount_amount) <= (1.0/ Math.pow(10, precision("tax_amount", last_tax)))) ? 0 : diff;
+				diff = ((diff - flt(me.frm.doc.discount_amount, precision('discount_amount')))
+					<= (1.0/ Math.pow(10, precision("tax_amount", last_tax)))) ? 0 : diff;
 
 				if ( diff && Math.abs(diff) <= (5.0 / Math.pow(10, precision("tax_amount", last_tax))) ) {
 					this.frm.doc.rounding_adjustment = flt(flt(this.frm.doc.rounding_adjustment) + diff,

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -223,7 +223,6 @@ erpnext.taxes_and_totals = erpnext.payments.extend({
 			me.frm.doc.net_total += item.net_amount;
 			me.frm.doc.base_net_total += item.base_net_amount;
 			});
-
 		frappe.model.round_floats_in(this.frm.doc, ["total", "base_total", "net_total", "base_net_total"]);
 	},
 
@@ -387,7 +386,9 @@ erpnext.taxes_and_totals = erpnext.payments.extend({
 				var diff = me.frm.doc.total + non_inclusive_tax_amount
 					- flt(last_tax.total, precision("grand_total"));
 
-				if ( diff < 0 && Math.abs(diff) <= (5.0 / Math.pow(10, precision("tax_amount", last_tax))) ) {
+				diff = ((diff - me.frm.doc.discount_amount) <= (1.0/ Math.pow(10, precision("tax_amount", last_tax)))) ? 0 : diff;
+
+				if ( diff && Math.abs(diff) <= (5.0 / Math.pow(10, precision("tax_amount", last_tax))) ) {
 					this.frm.doc.rounding_adjustment = flt(flt(this.frm.doc.rounding_adjustment) + diff,
 						precision("rounding_adjustment"));
 				}

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -387,7 +387,7 @@ erpnext.taxes_and_totals = erpnext.payments.extend({
 				var diff = me.frm.doc.total + non_inclusive_tax_amount
 					- flt(last_tax.total, precision("grand_total"));
 
-				if ( diff && Math.abs(diff) <= (5.0 / Math.pow(10, precision("tax_amount", last_tax))) ) {
+				if ( diff < 0 && Math.abs(diff) <= (5.0 / Math.pow(10, precision("tax_amount", last_tax))) ) {
 					this.frm.doc.rounding_adjustment = flt(flt(this.frm.doc.rounding_adjustment) + diff,
 						precision("rounding_adjustment"));
 				}


### PR DESCRIPTION
**Issue:** For discount amount less than 0.05 the grand total was factoring rounding adjustment twice and throwing arbitrary values. When discount amount is considered the rounding adjustment is calculated and then due to inclusive tax amount calculation rounding adjustment is added again.
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
