### PR TITLE
fix: Profit and Lost (financial statement) report

### DIFF
--- a/erpnext/accounts/report/financial_statements.html
+++ b/erpnext/accounts/report/financial_statements.html
@@ -1,5 +1,6 @@
 {%
 	var report_columns = report.get_columns_for_print();
+	report_columns = report_columns.filter(col => !col.hidden);
 
 	if (report_columns.length > 8) {
 		frappe.throw(__("Too many columns. Export the report and print it using a spreadsheet application."));
@@ -15,34 +16,35 @@
 		height: 37px;
 	}
 </style>
-{% var letterhead= filters.letter_head || (frappe.get_doc(":Company", filters.company) && frappe.get_doc(":Company", filters.company).default_letter_head) %}
-{% if(letterhead) { %}
-<div style="margin-bottom: 7px;" class="text-center">
-	{%= frappe.boot.letter_heads[letterhead].header %}
-</div>
-{% } %}
+
 <h2 class="text-center">{%= __(report.report_name) %}</h2>
 <h3 class="text-center">{%= filters.company %}</h3>
+
 {% if 'cost_center' in filters %}
 	<h3 class="text-center">{%= filters.cost_center %}</h3>
 {% endif %}
+
 <h3 class="text-center">{%= filters.fiscal_year %}</h3>
-<h5 class="text-center">{%=  __("Currency") %} : {%= filters.presentation_currency || erpnext.get_currency(filters.company) %} </h4>
+<h5 class="text-center">
+	{%=  __("Currency") %} : {%= filters.presentation_currency || erpnext.get_currency(filters.company) %}
+</h5>
 {% if (filters.from_date) { %}
-	<h4 class="text-center">{%= frappe.datetime.str_to_user(filters.from_date) %} - {%= frappe.datetime.str_to_user(filters.to_date) %}</h3>
+	<h5 class="text-center">
+		{%= frappe.datetime.str_to_user(filters.from_date) %} - {%= frappe.datetime.str_to_user(filters.to_date) %}
+	</h5>
 {% } %}
 <hr>
 <table class="table table-bordered">
 	<thead>
 		<tr>
-			<th style="width: {%= 100 - (report_columns.length - 2) * 13 %}%"></th>
-			{% for(var i=2, l=report_columns.length; i<l; i++) { %}
+			<th style="width: {%= 100 - (report_columns.length - 1) * 13 %}%"></th>
+			{% for (let i=1, l=report_columns.length; i<l; i++) { %}
 				<th class="text-right">{%= report_columns[i].label %}</th>
 			{% } %}
 		</tr>
 	</thead>
 	<tbody>
-		{% for(var j=0, k=data.length-1; j<k; j++) { %}
+		{% for(let j=0, k=data.length-1; j<k; j++) { %}
 			{%
 				var row = data[j];
 				var row_class = data[j].parent_account ? "" : "financial-statements-important";
@@ -52,11 +54,11 @@
 				<td>
 					<span style="padding-left: {%= cint(data[j].indent) * 2 %}em">{%= row.account_name %}</span>
 				</td>
-				{% for(var i=2, l=report_columns.length; i<l; i++) { %}
+				{% for(let i=1, l=report_columns.length; i<l; i++) { %}
 					<td class="text-right">
-						{% var fieldname = report_columns[i].fieldname; %}
+						{% const fieldname = report_columns[i].fieldname; %}
 						{% if (!is_null(row[fieldname])) { %}
-							{%= format_currency(row[fieldname], filters.presentation_currency) %}
+							{%= frappe.format(row[fieldname], report_columns[i], {}, row) %}
 						{% } %}
 					</td>
 				{% } %}
@@ -64,4 +66,6 @@
 		{% } %}
 	</tbody>
 </table>
-<p class="text-right text-muted">Printed On {%= frappe.datetime.str_to_user(frappe.datetime.get_datetime_as_string()) %}</p>
+<p class="text-right text-muted">
+	Printed On {%= frappe.datetime.str_to_user(frappe.datetime.get_datetime_as_string()) %}
+</p>

--- a/erpnext/accounts/report/financial_statements.py
+++ b/erpnext/accounts/report/financial_statements.py
@@ -264,8 +264,8 @@ def filter_out_zero_value_rows(data, parent_children_map, show_zero_values=False
 
 def add_total_row(out, root_type, balance_must_be, period_list, company_currency):
 	total_row = {
-		"account_name": "'" + _("Total {0} ({1})").format(_(root_type), _(balance_must_be)) + "'",
-		"account": "'" + _("Total {0} ({1})").format(_(root_type), _(balance_must_be)) + "'",
+		"account_name": _("Total {0} ({1})").format(_(root_type), _(balance_must_be)),
+		"account": _("Total {0} ({1})").format(_(root_type), _(balance_must_be)),
 		"currency": company_currency
 	}
 


### PR DESCRIPTION
- The hidden column should not be considered in the report
- Removed hardcoded currency formatting
- Removed duplicate letterhead in the report
(print_template already adds one)
- Removed extra quotes from Total Amount text

Before:
<img width="1187" alt="Screenshot 2019-12-12 at 1 14 15 PM" src="https://user-images.githubusercontent.com/13928957/70692808-2c525000-1ce2-11ea-92dd-4c384ab523a9.png">

After:
<img width="1154" alt="Screenshot 2019-12-12 at 12 58 53 PM" src="https://user-images.githubusercontent.com/13928957/70692815-2f4d4080-1ce2-11ea-969e-3dc72b7f575f.png">

port-of: https://github.com/frappe/erpnext/pull/19927