### PR TITLE
fix: now allow to over production against work order

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -605,6 +605,8 @@ erpnext.work_order = {
 				description: __('Max: {0}', [max]),
 				default: max
 			}, data => {
+				max += (max * (frm.doc.__onload.overproduction_percentage || 0.0)) / 100;
+
 				if (data.qty > max) {
 					frappe.msgprint(__('Quantity must not be more than {0}', [max]));
 					reject();

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -38,7 +38,7 @@ class WorkOrder(Document):
 		ms = frappe.get_doc("Manufacturing Settings")
 		self.set_onload("material_consumption", ms.material_consumption)
 		self.set_onload("backflush_raw_materials_based_on", ms.backflush_raw_materials_based_on)
-
+		self.set_onload("overproduction_percentage", ms.overproduction_percentage_for_work_order)
 
 	def validate(self):
 		self.validate_production_item()


### PR DESCRIPTION
**Issue**

In manufacturing settings set "Overproduction Percentage For Work Order" to 100 still giving an error while producing 2 quantity for the work order where qty is set as 1.

![image](https://user-images.githubusercontent.com/8780500/70903582-313a3b00-2025-11ea-9d4f-ffe9cca9131b.png)

**Work Order > Finish**

![image](https://user-images.githubusercontent.com/8780500/70903602-38614900-2025-11ea-805d-2ca8ee87d8ba.png)
