### PR TITLE
fix: use open_mapped_doc instead of create_new_doc

### DIFF
--- a/erpnext/selling/doctype/customer/customer.js
+++ b/erpnext/selling/doctype/customer/customer.js
@@ -5,13 +5,13 @@ frappe.ui.form.on("Customer", {
 	setup: function(frm) {
 
 		frm.make_methods = {
-			'Quotation': () => erpnext.utils.create_new_doc('Quotation', {
-				'quotation_to': frm.doc.doctype,
-				'party_name': frm.doc.name
+			'Quotation': () => frappe.model.open_mapped_doc({
+				method: "erpnext.selling.doctype.customer.customer.make_quotation",
+				frm: cur_frm
 			}),
-			'Opportunity': () => erpnext.utils.create_new_doc('Opportunity', {
-				'opportunity_from': frm.doc.doctype,
-				'party_name': frm.doc.name
+			'Opportunity': () => frappe.model.open_mapped_doc({
+				method: "erpnext.selling.doctype.customer.customer.make_opportunity",
+				frm: cur_frm
 			})
 		}
 

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -258,7 +258,10 @@ def make_quotation(source_name, target_doc=None):
 	target_doc.run_method("set_other_charges")
 	target_doc.run_method("calculate_taxes_and_totals")
 
-	target_doc.selling_price_list = frappe.get_doc("Customer",source_name).default_price_list
+	price_list = frappe.get_value("Customer",source_name, 'default_price_list')
+	if price_list:
+		target_doc.selling_price_list = price_list
+
 	return target_doc
 
 @frappe.whitelist()

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -243,9 +243,9 @@ def create_contact(contact, party_type, party, email):
 def make_quotation(source_name, target_doc=None):
 
 	def set_missing_values(source, target):
-		_set_missing_values(source,target)
+		_set_missing_values(source, target)
 
-	target_doc = get_mapped_doc("Customer", source_name, 
+	target_doc = get_mapped_doc("Customer", source_name,
 		{"Customer": {
 			"doctype": "Quotation",
 			"field_map": {
@@ -258,7 +258,7 @@ def make_quotation(source_name, target_doc=None):
 	target_doc.run_method("set_other_charges")
 	target_doc.run_method("calculate_taxes_and_totals")
 
-	price_list = frappe.get_value("Customer",source_name, 'default_price_list')
+	price_list = frappe.get_value("Customer", source_name, 'default_price_list')
 	if price_list:
 		target_doc.selling_price_list = price_list
 
@@ -267,17 +267,16 @@ def make_quotation(source_name, target_doc=None):
 @frappe.whitelist()
 def make_opportunity(source_name, target_doc=None):
 	def set_missing_values(source, target):
-		_set_missing_values(source,target)
+		_set_missing_values(source, target)
 
-	target_doc = get_mapped_doc("Customer", source_name, 
+	target_doc = get_mapped_doc("Customer", source_name,
 		{"Customer": {
 			"doctype": "Opportunity",
 			"field_map": {
 				"name": "party_name",
 				"doctype": "opportunity_from",
 			}
-		}}, target_doc, set_missing_values
-	)
+		}}, target_doc, set_missing_values)
 
 	return target_doc
 

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -12,6 +12,7 @@ from erpnext.utilities.transaction_base import TransactionBase
 from erpnext.accounts.party import validate_party_accounts, get_dashboard_info, get_timeline_data # keep this
 from frappe.contacts.address_and_contact import load_address_and_contact, delete_contact_and_address
 from frappe.model.rename_doc import update_linked_doctypes
+from frappe.model.mapper import get_mapped_doc
 
 class Customer(TransactionBase):
 	def get_feed(self):
@@ -237,6 +238,64 @@ def create_contact(contact, party_type, party, email):
 	contact.append('email_ids', dict(email_id=email, is_primary=1))
 	contact.append('links', dict(link_doctype=party_type, link_name=party))
 	contact.insert()
+
+@frappe.whitelist()
+def make_quotation(source_name, target_doc=None):
+
+	def set_missing_values(source, target):
+		_set_missing_values(source,target)
+
+	target_doc = get_mapped_doc("Customer", source_name, 
+		{"Customer": {
+			"doctype": "Quotation",
+			"field_map": {
+				"name":"party_name"
+			}
+		}}, target_doc, set_missing_values)
+
+	target_doc.quotation_to = "Customer"
+	target_doc.run_method("set_missing_values")
+	target_doc.run_method("set_other_charges")
+	target_doc.run_method("calculate_taxes_and_totals")
+
+	target_doc.selling_price_list = frappe.get_doc("Customer",source_name).default_price_list
+	return target_doc
+
+@frappe.whitelist()
+def make_opportunity(source_name, target_doc=None):
+	def set_missing_values(source, target):
+		_set_missing_values(source,target)
+
+	target_doc = get_mapped_doc("Customer", source_name, 
+		{"Customer": {
+			"doctype": "Opportunity",
+			"field_map": {
+				"name": "party_name",
+				"doctype": "opportunity_from",
+			}
+		}}, target_doc, set_missing_values
+	)
+
+	return target_doc
+
+def _set_missing_values(source, target):
+	address = frappe.get_all('Dynamic Link', {
+			'link_doctype': source.doctype,
+			'link_name': source.name,
+			'parenttype': 'Address',
+		}, ['parent'], limit=1)
+
+	contact = frappe.get_all('Dynamic Link', {
+			'link_doctype': source.doctype,
+			'link_name': source.name,
+			'parenttype': 'Contact',
+		}, ['parent'], limit=1)
+
+	if address:
+		target.customer_address = address[0].parent
+
+	if contact:
+		target.contact_person = contact[0].parent
 
 @frappe.whitelist()
 def get_loyalty_programs(doc):


### PR DESCRIPTION
Issue: `erpnext.utils.create_new_doc` method used in Customer dashboard would not trigger fetches in quotation form. Similar issue seems to have been there. Similar issue was fixed in past in Lead dashboard using `open_mapped_doc`

Fix: Use `open_mapped_doc` instead of instead of `erpnext.utils.create_new_doc`