### PR TITLE
enhancement: Added Set Reserve Warehouse field in Purchase Order.

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.json
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "allow_import": 1,
  "autoname": "naming_series:",
  "creation": "2013-05-21 16:16:39",
@@ -47,6 +48,7 @@
   "ignore_pricing_rule",
   "sec_warehouse",
   "set_warehouse",
+  "set_reserve_warehouse",
   "col_break_warehouse",
   "is_subcontracted",
   "supplier_warehouse",
@@ -1039,12 +1041,20 @@
    "fieldtype": "Link",
    "label": "Tax Category",
    "options": "Tax Category"
+  },
+  {
+   "depends_on": "supplied_items",
+   "fieldname": "set_reserve_warehouse",
+   "fieldtype": "Link",
+   "label": "Set Reserve Warehouse",
+   "options": "Warehouse"
   }
  ],
  "icon": "fa fa-file-text",
  "idx": 105,
  "is_submittable": 1,
- "modified": "2019-07-11 18:25:49.509343",
+ "links": [],
+ "modified": "2019-12-18 13:13:22.852412",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Purchase Order",

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1746,14 +1746,28 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 		}
 	},
 
+	set_reserve_warehouse: function() {
+		this.autofill_warehouse("reserve_warehouse");
+	},
+
 	set_warehouse: function() {
+		this.autofill_warehouse("warehouse");
+	},
+
+	autofill_warehouse : function (warehouse_field) {
+		// set warehouse in all child table rows
 		var me = this;
-		if(this.frm.doc.set_warehouse) {
-			$.each(this.frm.doc.items || [], function(i, item) {
-				frappe.model.set_value(me.frm.doctype + " Item", item.name, "warehouse", me.frm.doc.set_warehouse);
+		let warehouse = (warehouse_field === "warehouse") ? me.frm.doc.set_warehouse : me.frm.doc.set_reserve_warehouse;
+		let child_table = (warehouse_field === "warehouse") ? me.frm.doc.items : me.frm.doc.supplied_items;
+		let doctype = (warehouse_field === "warehouse") ? (me.frm.doctype + " Item") : (me.frm.doctype + " Item Supplied");
+
+		if(warehouse) {
+			$.each(child_table || [], function(i, item) {
+				frappe.model.set_value(doctype, item.name, warehouse_field, warehouse);
 			});
 		}
 	},
+
 	coupon_code: function() {
 		var me = this;
 		frappe.run_serially([


### PR DESCRIPTION
Port of https://github.com/frappe/erpnext/pull/19991
- **Supplied Items** table in **Purchase Order** requires manual entering of **Reserve Warehouse** if it is not set in the Item's Defaults or in the BOM.
- Added a field **Set Reserve Warehouse** to set all **Reserve Warehouse** fields of child table **Supplied Items** in one go.
- **Reserve Warehouse** will be visible only in presence of Supplied Items table

**Working**:

![_reserve_warehouse](https://user-images.githubusercontent.com/25857446/71080352-f960fe00-21b2-11ea-953b-d9fd3b74993a.gif)

