### PR TITLE
fix: Company None not found in get_valuation_rate

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -348,7 +348,7 @@ class StockEntry(StockController):
 			elif d.t_warehouse and not d.basic_rate:
 				d.basic_rate = get_valuation_rate(d.item_code, d.t_warehouse,
 					self.doctype, d.name, d.allow_zero_valuation_rate,
-					currency=erpnext.get_company_currency(self.company))
+					currency=erpnext.get_company_currency(self.company), company=self.company)
 
 	def set_actual_qty(self):
 		allow_negative_stock = cint(frappe.db.get_value("Stock Settings", None, "allow_negative_stock"))


### PR DESCRIPTION
```
File "/home/frappe/benches/bench-12-2019-11-26/apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.py", line 77, in validate
self.set_incoming_rate()
File "/home/frappe/benches/bench-12-2019-11-26/apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.py", line 373, in set_incoming_rate
currency=erpnext.get_company_currency(self.company))
File "/home/frappe/benches/bench-12-2019-11-26/apps/erpnext/erpnext/stock/stock_ledger.py", line 499, in get_valuation_rate
and cint(erpnext.is_perpetual_inventory_enabled(company)):
File "/home/frappe/benches/bench-12-2019-11-26/apps/erpnext/erpnext/__init__.py", line 78, in is_perpetual_inventory_enabled
company, "enable_perpetual_inventory") or 0
File "/home/frappe/benches/bench-12-2019-11-26/apps/frappe/frappe/__init__.py", line 712, in get_cached_value
doc = get_cached_doc(doctype, name)
File "/home/frappe/benches/bench-12-2019-11-26/apps/frappe/frappe/__init__.py", line 697, in get_cached_doc
doc = get_doc(*args, **kwargs)
File "/home/frappe/benches/bench-12-2019-11-26/apps/frappe/frappe/__init__.py", line 740, in get_doc
doc = frappe.model.document.get_doc(*args, **kwargs)
File "/home/frappe/benches/bench-12-2019-11-26/apps/frappe/frappe/model/document.py", line 70, in get_doc
return controller(*args, **kwargs)
File "/home/frappe/benches/bench-12-2019-11-26/apps/frappe/frappe/model/document.py", line 105, in __init__
self.load_from_db()
File "/home/frappe/benches/bench-12-2019-11-26/apps/frappe/frappe/model/document.py", line 148, in load_from_db
frappe.throw(_("{0} {1} not found").format(_(self.doctype), self.name), frappe.DoesNotExistError)
File "/home/frappe/benches/bench-12-2019-11-26/apps/frappe/frappe/__init__.py", line 364, in throw
msgprint(msg, raise_exception=exc, title=title, indicator='red')
File "/home/frappe/benches/bench-12-2019-11-26/apps/frappe/frappe/__init__.py", line 350, in msgprint
_raise_exception()
File "/home/frappe/benches/bench-12-2019-11-26/apps/frappe/frappe/__init__.py", line 316, in _raise_exception
raise raise_exception(msg)
frappe.exceptions.DoesNotExistError: Company None not found

```