### PR TITLE
fix: breadcrumb for company list

### DIFF
--- a/erpnext/setup/doctype/company/company_list.js
+++ b/erpnext/setup/doctype/company/company_list.js
@@ -1,0 +1,10 @@
+frappe.listview_settings['Company'] = {
+    onload: () => {
+        frappe.breadcrumbs.add({
+            type: 'Custom',
+            module: __('Accounts'),
+            label: __('Accounts'),
+            route: '#modules/Accounts'
+        });
+    }
+}


### PR DESCRIPTION
Set custom breadcrumb for Company List Page. 

Before:

![Screenshot 2019-12-23 at 2 18 39 PM](https://user-images.githubusercontent.com/25369014/71346931-25072e00-258f-11ea-8a29-0a5a77264e94.png)

After:

![Screenshot 2019-12-23 at 2 18 21 PM](https://user-images.githubusercontent.com/25369014/71346926-220c3d80-258f-11ea-8423-27d4f8326b40.png)

