### PR TITLE
fix(employee onboarding): stop showing irrelevant job offer links for…

### DIFF
--- a/erpnext/hr/doctype/employee_onboarding/employee_onboarding.js
+++ b/erpnext/hr/doctype/employee_onboarding/employee_onboarding.js
@@ -7,6 +7,14 @@ frappe.ui.form.on('Employee Onboarding', {
 		frm.add_fetch("employee_onboarding_template", "department", "department");
 		frm.add_fetch("employee_onboarding_template", "designation", "designation");
 		frm.add_fetch("employee_onboarding_template", "employee_grade", "employee_grade");
+
+		frm.set_query('job_offer', function () {
+			return {
+				filters: {
+					'job_applicant': frm.doc.job_applicant
+				}
+			};
+		});
 	},
 
 	refresh: function(frm) {


### PR DESCRIPTION
**Problem:**

It shows all the job offers for a selected job applicant while creating a new Employee Onboarding document.

![Screenshot 2019-12-23 at 4 19 50 PM](https://user-images.githubusercontent.com/13060550/71356318-de71fd80-25a7-11ea-97e3-c8dc6dc99f65.png)

**Proposed System:**

![Screenshot 2019-12-23 at 4 25 05 PM](https://user-images.githubusercontent.com/13060550/71356332-e9c52900-25a7-11ea-8148-f87bc3b40322.png)
