### PR TITLE
fix: only show doctypes which impact accounting in accounting period

### DIFF
--- a/erpnext/accounts/doctype/accounting_period/accounting_period.py
+++ b/erpnext/accounts/doctype/accounting_period/accounting_period.py
@@ -41,8 +41,8 @@ class AccountingPeriod(Document):
 
 	def get_doctypes_for_closing(self):
 		docs_for_closing = []
-		doctypes = ["Sales Invoice", "Purchase Invoice", "Journal Entry", "Payroll Entry", "Bank Reconciliation",
-			"Asset", "Purchase Order", "Sales Order", "Leave Application", "Leave Allocation", "Stock Entry"]
+		doctypes = ["Sales Invoice", "Purchase Invoice", "Journal Entry", "Payroll Entry", \
+			"Bank Reconciliation", "Asset", "Stock Entry"]
 		closed_doctypes = [{"document_type": doctype, "closed": 1} for doctype in doctypes]
 		for closed_doctype in closed_doctypes:
 			docs_for_closing.append(closed_doctype)


### PR DESCRIPTION
Back port of #20091 