### PR TITLE
fix: Add Serial No button prompt (develop)

### DIFF
--- a/erpnext/public/js/utils/serial_no_batch_selector.js
+++ b/erpnext/public/js/utils/serial_no_batch_selector.js
@@ -139,7 +139,7 @@ erpnext.SerialNoBatchSelector = Class.extend({
 				this.dialog.set_value('serial_no', d.serial_no);
 			}
 
-			if (d.batch_no) {
+			if (d.has_batch_no && d.batch_no) {
 				this.frm.doc.items.forEach(data => {
 					if(data.item_code == d.item_code) {
 						this.dialog.fields_dict.batches.df.data.push({


### PR DESCRIPTION
**Problem:**

Trying to fetch Serial Nos for items that were setup for both batches and serial numbers would cause the "Add Serial No" dialog to fail.

**Changes:**

Added a check for batch no before rendering the dialog box.

```diff
TypeError: Cannot read property 'df' of undefined
    at <anonymous>:145:39
    at Array.forEach (<anonymous>)
    at init.make_dialog (<anonymous>:143:24)
    at init.setup (<anonymous>:21:8)
    at new init (<anonymous>:14:9)
    at transaction.js:1802
    at Object.eval_assets (assets.js:88)
    at assets.js:71
    at Object.callback (assets.js:122)
    at Object.callback [as success_callback] (request.js:76)
```