### PR TITLE
fix: service item's cost showing incorrect amount in stock entry

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -767,7 +767,7 @@ def add_additional_cost(stock_entry, work_order):
 
 	items = {}
 	for d in bom.get(table):
-		items.setdefault(d.item_code, d.rate)
+		items.setdefault(d.item_code, d.amount)
 
 	non_stock_items = frappe.get_all('Item',
 		fields="name", filters={'name': ('in', list(items.keys())), 'ifnull(is_stock_item, 0)': 0}, as_list=1)
@@ -776,7 +776,7 @@ def add_additional_cost(stock_entry, work_order):
 		stock_entry.append('additional_costs', {
 			'expense_account': expenses_included_in_valuation,
 			'description': name[0],
-			'amount': items.get(name[0])
+			'amount': flt(items.get(name[0])) * flt(stock_entry.fg_completed_qty) / flt(bom.quantity)
 		})
 
 @frappe.whitelist()


### PR DESCRIPTION
**Issue**
Service items cost = 500
Qty to manufature = 5
Amount showing as = 500
Expected amount = 5 * 500 = 2500

<img width="1199" alt="Screenshot 2019-12-27 at 11 41 13 AM" src="https://user-images.githubusercontent.com/8780500/71504322-ffd03380-289e-11ea-92c9-1a4f02b4c59e.png">


**After Fix**

![image](https://user-images.githubusercontent.com/8780500/71504332-05c61480-289f-11ea-94b0-d8a38adb2647.png)
