### PR TITLE
fix: Show both warehouse columns in Stock Entry Grid view.

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -836,8 +836,6 @@ erpnext.stock.StockEntry = erpnext.stock.StockController.extend({
 		this.frm.toggle_enable("from_warehouse", doc.purpose!='Material Receipt');
 		this.frm.toggle_enable("to_warehouse", doc.purpose!='Material Issue');
 
-		this.frm.fields_dict["items"].grid.set_column_disp("s_warehouse", doc.purpose!='Material Receipt');
-		this.frm.fields_dict["items"].grid.set_column_disp("t_warehouse", doc.purpose!='Material Issue');
 		this.frm.fields_dict["items"].grid.set_column_disp("retain_sample", doc.purpose=='Material Receipt');
 		this.frm.fields_dict["items"].grid.set_column_disp("sample_quantity", doc.purpose=='Material Receipt');
 


### PR DESCRIPTION
Port of https://github.com/frappe/erpnext/pull/20113
**Before:**
![Screenshot 2019-12-27 at 1 05 04 PM](https://user-images.githubusercontent.com/25857446/71507051-2a26ee80-28a9-11ea-84d5-46f115e62212.png)

**After:**
![Screenshot 2019-12-27 at 1 04 28 PM](https://user-images.githubusercontent.com/25857446/71507062-2d21df00-28a9-11ea-978d-a934c4f0544f.png)