### PR TITLE
fix: remove default BOM filter in Work Order

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -77,8 +77,7 @@ frappe.ui.form.on("Work Order", {
 			return {
 				query: "erpnext.controllers.queries.item_query",
 				filters:[
-					['is_stock_item', '=',1],
-					['default_bom', '!=', '']
+					['is_stock_item', '=',1]
 				]
 			};
 		});


### PR DESCRIPTION
Not all companies use default BOM (e.g. construction companies, etc.)
Fixes #19324
