### PR TITLE
fix: Remove unnecessary Duplicate Entry Error

### DIFF
--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -518,7 +518,7 @@ class Item(WebsiteGenerator):
 						"""select parent from `tabItem Barcode` where barcode = %s and parent != %s""", (item_barcode.barcode, self.name))
 					if duplicate:
 						frappe.throw(_("Barcode {0} already used in Item {1}").format(
-							item_barcode.barcode, duplicate[0][0]), frappe.DuplicateEntryError)
+							item_barcode.barcode, duplicate[0][0]))
 
 					item_barcode.barcode_type = "" if item_barcode.barcode_type not in options else item_barcode.barcode_type
 					if item_barcode.barcode_type and item_barcode.barcode_type.upper() in ('EAN', 'UPC-A', 'EAN-13', 'EAN-8'):


### PR DESCRIPTION
On Barcode validation, Duplicate Error was thrown unneccesarily
**Before:**
![Screenshot 2019-12-27 at 3 45 04 PM](https://user-images.githubusercontent.com/25857446/71513229-74b36580-28bf-11ea-8437-7d62c9fd3920.png)


**After:**
![Screenshot 2019-12-27 at 3 44 10 PM](https://user-images.githubusercontent.com/25857446/71513208-59e0f100-28bf-11ea-9990-0f1750dd0539.png)
