### PR TITLE
Skip validate_duplicate_apply_on if not necessary

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -34,6 +34,9 @@ class PricingRule(Document):
 
 	def validate_duplicate_apply_on(self):
 		field = apply_on_dict.get(self.apply_on)
+		if not field:
+			return False
+
 		values = [d.get(frappe.scrub(self.apply_on)) for d in self.get(field)]
 
 		if len(values) != len(set(values)):


### PR DESCRIPTION
Skip the validation of duplicate fields if the type is transaction, for example.