### PR TITLE
fix: format currency field in bank and cash payment voucher print format

### DIFF
--- a/erpnext/accounts/print_format/bank_and_cash_payment_voucher/bank_and_cash_payment_voucher.html
+++ b/erpnext/accounts/print_format/bank_and_cash_payment_voucher/bank_and_cash_payment_voucher.html
@@ -49,7 +49,7 @@
             {% endfor %}
             <tr>
                     <td class="right" colspan="3" ><strong>Total (debit) </strong></td>
-                    <td class="left" >{{ gl | sum(attribute='debit') }}</td>
+                    <td class="left" >{{ frappe.format((gl | sum(attribute="debit")), {fieldtype: "Currency"}) }}</td>
             </tr>
             <tr>
                     <td class="top-bottom" colspan="5"><strong>Credit</strong></td>
@@ -69,7 +69,7 @@
             {% endfor %}
             <tr>
                     <td class="right" colspan="3"><strong>Total (credit) </strong></td>
-                    <td class="left" >{{ gl | sum(attribute='credit') }}</td>
+                    <td class="left" >{{ frappe.format((gl | sum(attribute="credit")), {fieldtype: "Currency"}) }}</td>
             </tr>
         </table>
     <div>


### PR DESCRIPTION
backport of: https://github.com/frappe/erpnext/pull/20137

**Problem:** 'The Bank and Cash Payment Voucher' Print Format was not formatting the currency as per precision, though the precision has been set to 2.

![field_precision](https://user-images.githubusercontent.com/24353136/71574120-5b9ff400-2b0d-11ea-846c-d6e53b24dbc9.png)
