### PR TITLE
fix: party account currency not fetched from account for SO

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -911,7 +911,10 @@ def get_payment_entry(dt, dn, party_amount=None, bank_account=None, bank_amount=
 	else:
 		party_account = get_party_account(party_type, doc.get(party_type.lower()), doc.company)
 
-	party_account_currency = doc.get("party_account_currency") or get_account_currency(party_account)
+	if dt not in ("Sales Invoice", "Purchase Invoice"):
+		party_account_currency = get_account_currency(party_account)
+	else:
+		party_account_currency = doc.get("party_account_currency") or get_account_currency(party_account)
 
 	# payment type
 	if (dt == "Sales Order" or (dt in ("Sales Invoice", "Fees") and doc.outstanding_amount > 0)) \


### PR DESCRIPTION
Issue: `party_account_currency` field is set as default company currency in the form. When creating a payment entry if party account currency (eg. Debtors) has different currency it doesn't gets fetched. 

Only Sales Invoice and Purchase Invoice handles setting of `party_account_currency` w.r.t `debit_to` & `credit_to` field.