### PR TITLE
feat: added provision to disable rounded total for salary slips

### DIFF
--- a/erpnext/hr/doctype/hr_settings/hr_settings.json
+++ b/erpnext/hr/doctype/hr_settings/hr_settings.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "creation": "2013-08-02 13:45:23",
  "doctype": "DocType",
  "document_type": "Other",
@@ -13,6 +14,7 @@
   "expense_approver_mandatory_in_expense_claim",
   "payroll_settings",
   "include_holidays_in_total_working_days",
+  "disable_rounded_total",
   "max_working_hours_against_timesheet",
   "column_break_11",
   "email_salary_slip_to_employee",
@@ -160,12 +162,20 @@
    "fieldname": "auto_leave_encashment",
    "fieldtype": "Check",
    "label": "Auto Leave Encashment"
+  },
+  {
+   "default": "0",
+   "description": "If checked, hides and disables Rounded Total field in Salary Slips",
+   "fieldname": "disable_rounded_total",
+   "fieldtype": "Check",
+   "label": "Disable Rounded Total"
   }
  ],
  "icon": "fa fa-cog",
  "idx": 1,
  "issingle": 1,
- "modified": "2019-08-05 13:07:17.993968",
+ "links": [],
+ "modified": "2019-12-31 14:28:32.004121",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "HR Settings",

--- a/erpnext/hr/doctype/hr_settings/hr_settings.py
+++ b/erpnext/hr/doctype/hr_settings/hr_settings.py
@@ -7,6 +7,8 @@ from __future__ import unicode_literals
 import frappe
 from frappe import _
 from frappe.model.document import Document
+from frappe.utils import cint
+from frappe.custom.doctype.property_setter.property_setter import make_property_setter
 
 class HRSettings(Document):
 	def validate(self):
@@ -22,3 +24,12 @@ class HRSettings(Document):
 		if self.email_salary_slip_to_employee and self.encrypt_salary_slips_in_emails:
 			if not self.password_policy:
 				frappe.throw(_("Password policy for Salary Slips is not set"))
+	
+	def on_update(self):
+		self.toggle_rounded_total()
+		frappe.clear_cache()
+
+	def toggle_rounded_total(self):
+		self.disable_rounded_total = cint(self.disable_rounded_total)
+		make_property_setter("Salary Slip", "rounded_total", "hidden", self.disable_rounded_total, "Check")
+		make_property_setter("Salary Slip", "rounded_total", "print_hide", self.disable_rounded_total, "Check")

--- a/erpnext/hr/doctype/salary_slip/salary_slip.py
+++ b/erpnext/hr/doctype/salary_slip/salary_slip.py
@@ -50,7 +50,8 @@ class SalarySlip(TransactionBase):
 		self.calculate_net_pay()
 
 		company_currency = erpnext.get_company_currency(self.company)
-		self.total_in_words = money_in_words(self.rounded_total, company_currency)
+		total = self.net_pay if self.is_rounding_total_disabled() else self.rounded_total
+		self.total_in_words = money_in_words(total, company_currency)
 
 		if frappe.db.get_single_value("HR Settings", "max_working_hours_against_timesheet"):
 			max_working_hours = frappe.db.get_single_value("HR Settings", "max_working_hours_against_timesheet")
@@ -89,6 +90,9 @@ class SalarySlip(TransactionBase):
 	def validate_dates(self):
 		if date_diff(self.end_date, self.start_date) < 0:
 			frappe.throw(_("To date cannot be before From date"))
+
+	def is_rounding_total_disabled(self):
+		return cint(frappe.db.get_single_value("HR Settings", "disable_rounded_total"))
 
 	def check_existing(self):
 		if not self.salary_slip_based_on_timesheet:


### PR DESCRIPTION
Added a check to disable rounded totals in Salary Slips in HR Settings.

Issue:
![lDpXAxi](https://user-images.githubusercontent.com/25369014/71616192-fc101a00-2bda-11ea-9b60-a1d2c2e96c7a.png)
