### PR TITLE
fix: Allow Print Before Pay in POS

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -355,7 +355,8 @@ class SalesInvoice(SellingController):
 				"print_format": print_format,
 				"allow_edit_rate": pos.get("allow_user_to_edit_rate"),
 				"allow_edit_discount": pos.get("allow_user_to_edit_discount"),
-				"campaign": pos.get("campaign")
+				"campaign": pos.get("campaign"),
+				"allow_print_before_pay": pos.get("allow_print_before_pay")
 			}
 
 	def update_time_sheet(self, sales_invoice):

--- a/erpnext/selling/page/point_of_sale/point_of_sale.js
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.js
@@ -631,6 +631,7 @@ erpnext.pos.PointOfSale = class PointOfSale {
 						this.frm.allow_edit_rate = r.message.allow_edit_rate;
 						this.frm.allow_edit_discount = r.message.allow_edit_discount;
 						this.frm.doc.campaign = r.message.campaign;
+						this.frm.allow_print_before_pay = r.message.allow_print_before_pay;
 					}
 				}
 
@@ -672,7 +673,7 @@ erpnext.pos.PointOfSale = class PointOfSale {
 	}
 
 	set_form_action() {
-		if(this.frm.doc.docstatus == 1 || (this.frm.doc.allow_print_before_pay == 1&&this.frm.doc.items.length>0)){
+		if(this.frm.doc.docstatus == 1 || (this.frm.allow_print_before_pay == 1 && this.frm.doc.items.length > 0)){
 			this.page.set_secondary_action(__("Print"), async() => {
 				if(this.frm.doc.docstatus != 1 ){
 					await this.frm.save();


### PR DESCRIPTION
Print Button does not show even when Print Before Pay is enabled in the POS Profile.

When Allow Print Before Pay is selected:
![image](https://user-images.githubusercontent.com/8383249/71617725-54551500-2bf7-11ea-9b02-679fcb51e697.png)

The Print button does not show even after a Customer and Item is selected:
![image](https://user-images.githubusercontent.com/8383249/71617736-63d45e00-2bf7-11ea-84ca-d73d6184867b.png)

After the fix is applied the Print button is now available:
![image](https://user-images.githubusercontent.com/8383249/71617765-88c8d100-2bf7-11ea-9604-14975b36f80b.png)

