### PR TITLE
fix: ignore pricing rule for other item group

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/utils.py
+++ b/erpnext/accounts/doctype/pricing_rule/utils.py
@@ -495,7 +495,7 @@ def get_pricing_rule_items(pr_doc):
 
 	if pr_doc.apply_rule_on_other:
 		apply_on = frappe.scrub(pr_doc.apply_rule_on_other)
-		apply_on_data.append(pr_doc.get(apply_on))
+		apply_on_data.append(pr_doc.get("other_" + apply_on))
 
 	return list(set(apply_on_data))
 

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1398,7 +1398,8 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 
 	remove_pricing_rule: function(item) {
 		let me = this;
-		const fields = ["discount_percentage", "discount_amount", "pricing_rules"];
+		const fields = ["discount_percentage",
+			"discount_amount", "margin_rate_or_amount", "rate_with_margin"];
 
 		if(item.remove_free_item) {
 			var items = [];
@@ -1418,6 +1419,12 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 					fields.forEach(f => {
 						row[f] = 0;
 					});
+
+					["pricing_rules", "margin_type"].forEach(field => {
+						if (row[field]) {
+							row[field] = '';
+						}
+					})
 				}
 			});
 


### PR DESCRIPTION
**Issue**

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/desk/form/save.py", line 19, in savedocs
    doc.submit()
  File "/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/model/document.py", line 859, in submit
    self._submit()
  File "/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/model/document.py", line 848, in _submit
    self.save()
  File "/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/model/document.py", line 272, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/model/document.py", line 308, in _save
    self.run_before_save_methods()
  File "/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/model/document.py", line 892, in run_before_save_methods
    self.run_method("validate")
  File "/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/model/document.py", line 787, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/model/document.py", line 1058, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/model/document.py", line 1041, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-2019-12-20/apps/frappe/frappe/model/document.py", line 781, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-2019-12-20/apps/erpnext/erpnext/stock/doctype/delivery_note/delivery_note.py", line 109, in validate
    super(DeliveryNote, self).validate()
  File "/home/frappe/benches/bench-2019-12-20/apps/erpnext/erpnext/controllers/selling_controller.py", line 39, in validate
    super(SellingController, self).validate()
  File "/home/frappe/benches/bench-2019-12-20/apps/erpnext/erpnext/controllers/stock_controller.py", line 21, in validate
    super(StockController, self).validate()
  File "/home/frappe/benches/bench-2019-12-20/apps/erpnext/erpnext/controllers/accounts_controller.py", line 68, in validate
    self.set_missing_values(for_validate=True)
  File "/home/frappe/benches/bench-2019-12-20/apps/erpnext/erpnext/controllers/selling_controller.py", line 56, in set_missing_values
    self.set_price_list_and_item_details(for_validate=for_validate)
  File "/home/frappe/benches/bench-2019-12-20/apps/erpnext/erpnext/controllers/selling_controller.py", line 97, in set_price_list_and_item_details
    self.set_missing_item_details(for_validate=for_validate)
  File "/home/frappe/benches/bench-2019-12-20/apps/erpnext/erpnext/controllers/accounts_controller.py", line 278, in set_missing_item_details
    ret = get_item_details(args, self, for_validate=True, overwrite_warehouse=False)
  File "/home/frappe/benches/bench-2019-12-20/apps/erpnext/erpnext/stock/get_item_details.py", line 79, in get_item_details
    doc, for_validate=for_validate)
  File "/home/frappe/benches/bench-2019-12-20/apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py", line 213, in get_pricing_rule_for_item
    item_details, args.get('item_code'))
  File "/home/frappe/benches/bench-2019-12-20/apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py", line 369, in remove_pricing_rule_for_item
    item_details.applied_on_items = ','.join(items)
TypeError: sequence item 0: expected str instance, NoneType found
```