### PR TITLE
fix: sales invoice status when credit note is created but not paid

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -1242,12 +1242,14 @@ class SalesInvoice(SellingController):
 					self.status = "Unpaid and Discounted"
 				elif flt(self.outstanding_amount) > 0 and getdate(self.due_date) >= getdate(nowdate()):
 					self.status = "Unpaid"
-				#Check if outstanding amount is 0 due to credit note issued against invoice
-				elif flt(self.outstanding_amount) <= 0 and self.is_return == 0 and frappe.db.get_value('Sales Invoice', {'is_return': 1, 'return_against': self.name, 'docstatus': 1}):
+				# If outstanding amount is less than zero and there's a credit note issue status is set to ""
+				elif flt(self.outstanding_amount) < 0 and self.is_return == 0 and frappe.db.get_value('Sales Invoice', {'is_return': 1, 'return_against': self.name, 'docstatus': 1}):
 					self.status = "Credit Note Issued"
+				elif flt(self.outstanding_amount) == 0 and frappe.db.get_value("Sales Invoice",{"is_return": 1, "return_against": self.name, "docstatus": 1}):
+					self.status = "Credit Note Issued and Paid"
 				elif self.is_return == 1:
 					self.status = "Return"
-				elif flt(self.outstanding_amount)<=0:
+				elif flt(self.outstanding_amount) == 0:
 					self.status = "Paid"
 				else:
 					self.status = "Submitted"

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice_list.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice_list.js
@@ -12,6 +12,7 @@ frappe.listview_settings['Sales Invoice'] = {
 			"Paid": "green",
 			"Return": "darkgrey",
 			"Credit Note Issued": "darkgrey",
+			"Credit Note Issued and Paid": "darkgrey",
 			"Unpaid and Discounted": "orange",
 			"Overdue and Discounted": "red",
 			"Overdue": "red"


### PR DESCRIPTION
Add new status `Credit Note Issued and Paid`. When a credit note is created against a sales invoice and a payment entry for the return is also made this status will be applied to the Sales Invoice.

<img width="1280" alt="Screenshot 2020-01-03 at 11 42 53 AM" src="https://user-images.githubusercontent.com/6195660/71709604-1c64f200-2df0-11ea-9535-1100a005baab.png">
