### PR TITLE
fix: Added description and title to supplier selection popup in Mater…

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -230,7 +230,8 @@ frappe.ui.form.on('Material Request', {
 
 	make_purchase_order: function(frm) {
 		frappe.prompt(
-			{fieldname:'default_supplier', label: __('For Default Supplier (optional)'), fieldtype: 'Link', options: 'Supplier'},
+			{fieldname:'default_supplier', label: __('For Default Supplier (optional)'), description: __('Selected Supplier\
+			must be the Default Supplier of one of the items below.'), fieldtype: 'Link', options: 'Supplier'},
 			(values) => {
 				frappe.model.open_mapped_doc({
 					method: "erpnext.stock.doctype.material_request.material_request.make_purchase_order",
@@ -238,7 +239,8 @@ frappe.ui.form.on('Material Request', {
 					args: { default_supplier: values.default_supplier },
 					run_link_triggers: true
 				});
-			}
+			},
+			__('Enter Supplier')
 		)
 	},
 


### PR DESCRIPTION
- On creating Purchase Order from Material Request, users entered random suppliers (which weren't default suppliers for any item in the MR), and often got a blank Supplier field in the new PO.
![_POPup](https://user-images.githubusercontent.com/25857446/71726680-dd6d8580-2e5d-11ea-897d-3b3b2a741ac9.gif)


- Added description to field in popup
![Screenshot 2020-01-03 at 7 15 38 PM](https://user-images.githubusercontent.com/25857446/71726431-16592a80-2e5d-11ea-899b-967da7185095.png)
