### PR TITLE
fix: status of sales and purchase invoice with credit or debit note

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice_list.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice_list.js
@@ -6,22 +6,20 @@ frappe.listview_settings['Purchase Invoice'] = {
 	add_fields: ["supplier", "supplier_name", "base_grand_total", "outstanding_amount", "due_date", "company",
 		"currency", "is_return", "release_date", "on_hold"],
 	get_indicator: function(doc) {
-		if( (flt(doc.outstanding_amount) <= 0) && doc.docstatus == 1 &&  doc.status == 'Debit Note Issued') {
-			return [__("Debit Note Issued"), "darkgrey", "outstanding_amount,<=,0"];
-		} else if(flt(doc.outstanding_amount) > 0 && doc.docstatus==1) {
+		if(flt(doc.outstanding_amount) > 0 && doc.docstatus==1) {
 			if(cint(doc.on_hold) && !doc.release_date) {
 				return [__("On Hold"), "darkgrey"];
 			} else if(cint(doc.on_hold) && doc.release_date && frappe.datetime.get_diff(doc.release_date, frappe.datetime.nowdate()) > 0) {
 				return [__("Temporarily on Hold"), "darkgrey"];
-			} else if(frappe.datetime.get_diff(doc.due_date) < 0) {
-				return [__("Overdue"), "red", "outstanding_amount,>,0|due_date,<,Today"];
-			} else {
-				return [__("Unpaid"), "orange", "outstanding_amount,>,0|due,>=,Today"];
 			}
-		} else if(cint(doc.is_return)) {
-			return [__("Return"), "darkgrey", "is_return,=,Yes"];
-		} else if(flt(doc.outstanding_amount)==0 && doc.docstatus==1) {
-			return [__("Paid"), "green", "outstanding_amount,=,0"];
 		}
+		let status_color = {
+			"Return": "darkgrey",
+			"Paid": "green",
+			"Unpaid": "red",
+			"Debit Note Issued": "darkgrey",
+			"Overdue": "orange",
+		};
+		return [__(status), status_color[status], "status,=" + status];
 	}
 };

--- a/erpnext/controllers/status_updater.py
+++ b/erpnext/controllers/status_updater.py
@@ -47,10 +47,10 @@ status_map = {
 	"Purchase Invoice": [
 		["Draft", None],
 		["Submitted", "eval:self.docstatus==1"],
-		["Paid", "eval:self.outstanding_amount==0 and self.docstatus==1"],
+		["Paid", "is_paid_status"],
 		["Return", "eval:self.is_return==1 and self.docstatus==1"],
 		["Debit Note Issued",
-		 "eval:self.outstanding_amount <= 0 and self.docstatus==1 and self.is_return==0 and get_value('Purchase Invoice', {'is_return': 1, 'return_against': self.name, 'docstatus': 1})"],
+		 "has_debit_note_issued"],
 		["Unpaid", "eval:self.outstanding_amount > 0 and getdate(self.due_date) >= getdate(nowdate()) and self.docstatus==1"],
 		["Overdue", "eval:self.outstanding_amount > 0 and getdate(self.due_date) < getdate(nowdate()) and self.docstatus==1"],
 		["Cancelled", "eval:self.docstatus==2"],

--- a/erpnext/selling/doctype/customer/customer.js
+++ b/erpnext/selling/doctype/customer/customer.js
@@ -5,13 +5,13 @@ frappe.ui.form.on("Customer", {
 	setup: function(frm) {
 
 		frm.make_methods = {
-			'Quotation': () => erpnext.utils.create_new_doc('Quotation', {
-				'quotation_to': frm.doc.doctype,
-				'party_name': frm.doc.name
+			'Quotation': () => frappe.model.open_mapped_doc({
+				method: "erpnext.selling.doctype.customer.customer.make_quotation",
+				frm: cur_frm
 			}),
-			'Opportunity': () => erpnext.utils.create_new_doc('Opportunity', {
-				'opportunity_from': frm.doc.doctype,
-				'party_name': frm.doc.name
+			'Opportunity': () => frappe.model.open_mapped_doc({
+				method: "erpnext.selling.doctype.customer.customer.make_opportunity",
+				frm: cur_frm
 			})
 		}
 

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -12,6 +12,7 @@ from erpnext.utilities.transaction_base import TransactionBase
 from erpnext.accounts.party import validate_party_accounts, get_dashboard_info, get_timeline_data # keep this
 from frappe.contacts.address_and_contact import load_address_and_contact, delete_contact_and_address
 from frappe.model.rename_doc import update_linked_doctypes
+from frappe.model.mapper import get_mapped_doc
 
 class Customer(TransactionBase):
 	def get_feed(self):
@@ -237,6 +238,66 @@ def create_contact(contact, party_type, party, email):
 	contact.append('email_ids', dict(email_id=email, is_primary=1))
 	contact.append('links', dict(link_doctype=party_type, link_name=party))
 	contact.insert()
+
+@frappe.whitelist()
+def make_quotation(source_name, target_doc=None):
+
+	def set_missing_values(source, target):
+		_set_missing_values(source, target)
+
+	target_doc = get_mapped_doc("Customer", source_name,
+		{"Customer": {
+			"doctype": "Quotation",
+			"field_map": {
+				"name":"party_name"
+			}
+		}}, target_doc, set_missing_values)
+
+	target_doc.quotation_to = "Customer"
+	target_doc.run_method("set_missing_values")
+	target_doc.run_method("set_other_charges")
+	target_doc.run_method("calculate_taxes_and_totals")
+
+	price_list = frappe.get_value("Customer", source_name, 'default_price_list')
+	if price_list:
+		target_doc.selling_price_list = price_list
+
+	return target_doc
+
+@frappe.whitelist()
+def make_opportunity(source_name, target_doc=None):
+	def set_missing_values(source, target):
+		_set_missing_values(source, target)
+
+	target_doc = get_mapped_doc("Customer", source_name,
+		{"Customer": {
+			"doctype": "Opportunity",
+			"field_map": {
+				"name": "party_name",
+				"doctype": "opportunity_from",
+			}
+		}}, target_doc, set_missing_values)
+
+	return target_doc
+
+def _set_missing_values(source, target):
+	address = frappe.get_all('Dynamic Link', {
+			'link_doctype': source.doctype,
+			'link_name': source.name,
+			'parenttype': 'Address',
+		}, ['parent'], limit=1)
+
+	contact = frappe.get_all('Dynamic Link', {
+			'link_doctype': source.doctype,
+			'link_name': source.name,
+			'parenttype': 'Contact',
+		}, ['parent'], limit=1)
+
+	if address:
+		target.customer_address = address[0].parent
+
+	if contact:
+		target.contact_person = contact[0].parent
 
 @frappe.whitelist()
 def get_loyalty_programs(doc):


### PR DESCRIPTION
this fixes an issue caused by https://github.com/frappe/erpnext/pull/19388 where  sales invoices/purchase invoices with outstanding amount as 0 and a credit or debit note issued against them would show status as `[Debit/Credit] Note Issued`

Now, if the outstanding is zero, and there is note against the invoice, we will check if there is a payment entry made against the original invoice. If no payment entry is made it will get the status `[Debit/Credit] Note Issued` otherwise it will get the status of `Paid`