### PR TITLE
fix: escape % in customer name

### DIFF
--- a/erpnext/setup/doctype/authorization_control/authorization_control.py
+++ b/erpnext/setup/doctype/authorization_control/authorization_control.py
@@ -76,7 +76,7 @@ class AuthorizationControl(TransactionBase):
 		add_cond = ''
 		auth_value = av_dis
 
-		if val == 1: add_cond += " and system_user = '"+session['user'].replace("'", "\\'")+"'"
+		if val == 1: add_cond += " and system_user = '"+ frappe.db.escape(session['user'])+"'"
 		elif val == 2: add_cond += " and system_role IN %s" % ("('"+"','".join(frappe.get_roles())+"')")
 		else: add_cond += " and ifnull(system_user,'') = '' and ifnull(system_role,'') = ''"
 
@@ -85,7 +85,7 @@ class AuthorizationControl(TransactionBase):
 			if doc_obj:
 				if doc_obj.doctype == 'Sales Invoice': customer = doc_obj.customer
 				else: customer = doc_obj.customer_name
-				add_cond = " and master_name = '"+cstr(customer).replace("'", "\\'")+"'"
+				add_cond = " and master_name = '"+ frappe.db.escape(customer) +"'"
 		if based_on == 'Itemwise Discount':
 			if doc_obj:
 				for t in doc_obj.get("items"):


### PR DESCRIPTION
issue: authorization_control.py would raise `TypeError: not enough arguments for format string` if customer name contained a "%" sign