### PR TITLE
fix: get_item_price not working properly

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -968,7 +968,7 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 
 	qty: function(doc, cdt, cdn) {
 		let item = frappe.get_doc(cdt, cdn);
-		this.conversion_factor(doc, cdt, cdn, true);
+		this.conversion_factor(doc, cdt, cdn, false);
 		this.apply_pricing_rule(item, true);
 	},
 

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -571,7 +571,7 @@ def get_item_price(args, item_code, ignore_party=False):
 
 	return frappe.db.sql(""" select name, price_list_rate, uom
 		from `tabItem Price` {conditions}
-		order by uom desc, min_qty desc """.format(conditions=conditions), args)
+		order by uom desc, min_qty desc, valid_from desc """.format(conditions=conditions), args)
 
 def get_price_list_rate_for(args, item_code):
 	"""
@@ -604,10 +604,15 @@ def get_price_list_rate_for(args, item_code):
 		if desired_qty and check_packing_list(price_list_rate[0][0], desired_qty, item_code):
 			item_price_data = price_list_rate
 	else:
-		for field in ["customer", "supplier", "min_qty"]:
+		for field in ["customer", "supplier"]:
 			del item_price_args[field]
 
 		general_price_list_rate = get_item_price(item_price_args, item_code, ignore_party=args.get("ignore_party"))
+
+		if not general_price_list_rate:
+			del item_price_args["min_qty"]
+			general_price_list_rate = get_item_price(item_price_args, item_code, ignore_party=args.get("ignore_party"))
+
 		if not general_price_list_rate and args.get("uom") != args.get("stock_uom"):
 			item_price_args["uom"] = args.get("stock_uom")
 			general_price_list_rate = get_item_price(item_price_args, item_code, ignore_party=args.get("ignore_party"))


### PR DESCRIPTION
This PR solves two problems:
1.- min_qty was not being used to select the correct price for an item. It was only used when the transaction party had an assigned item price.

2.- When you have more than one valid item price (valid = when the transaction date is between valid_from and valid_upto), the code choose one of them randomly (the first that sql returns), now, it choose the one with the higher valid_from.
**Example**:
Original:
![Captura de Pantalla 2020-01-06 a la(s) 10 16 09](https://user-images.githubusercontent.com/46027152/71820394-b5ed0780-306d-11ea-8d6f-a55ca7b18825.png)

New:
![Captura de Pantalla 2020-01-06 a la(s) 10 16 30](https://user-images.githubusercontent.com/46027152/71820404-bd141580-306d-11ea-83ce-eca963cd4544.png)
