### PR TITLE
fix: Parent Item of Product Bundle should not appear in dialog

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -376,6 +376,9 @@ class SalesOrder(SellingController):
 	def get_work_order_items(self, for_raw_material_request=0):
 		'''Returns items with BOM that already do not have a linked work order'''
 		items = []
+		item_codes = [i.item_code for i in self.items]
+		product_bundle_parents = [pb.new_item_code for pb in frappe.get_all("Product Bundle", {"new_item_code": ["in", item_codes]}, ["new_item_code"])]
+
 		for table in [self.items, self.packed_items]:
 			for i in table:
 				bom = get_default_bom_item(i.item_code)
@@ -387,7 +390,7 @@ class SalesOrder(SellingController):
 				else:
 					pending_qty = stock_qty
 
-				if pending_qty:
+				if pending_qty and i.item_code not in product_bundle_parents:
 					if bom:
 						items.append(dict(
 							name= i.name,


### PR DESCRIPTION
In dialog for creating work order or request for raw material from Sales Order.

Before:
OPB is the parent item of Product Bundle: Oneplus Bundle
<img width="1280" alt="Screenshot 2020-01-07 at 3 47 23 PM" src="https://user-images.githubusercontent.com/6195660/71887917-fc5a6900-3136-11ea-9ddb-12a895ceec30.png">

<img width="1280" alt="after" src="https://user-images.githubusercontent.com/6195660/71887722-966de180-3136-11ea-8a67-5615e1372226.png">
