### PR TITLE
 fix: Applied query on PO Supplier popup field in Material Request.

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -222,7 +222,13 @@ frappe.ui.form.on('Material Request', {
 				fieldname:'default_supplier',
 				fieldtype: 'Link',
 				options: 'Supplier',
-				description: __('Selected Supplier must be the Default Supplier of one of the items below.'),
+				description: __('Select a Supplier from the Default Supplier List of the items below.'),
+				get_query: () => {
+					return {
+						query: "erpnext.stock.doctype.material_request.material_request.get_default_supplier_query",
+						filters: {'doc': frm.doc.name}
+					}
+				}
 			},
 			(values) => {
 				frappe.model.open_mapped_doc({

--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -371,6 +371,18 @@ def get_material_requests_based_on_supplier(supplier):
 		material_requests = []
 	return material_requests, supplier_items
 
+def get_default_supplier_query(doctype, txt, searchfield, start, page_len, filters):
+	doc = frappe.get_doc("Material Request", filters.get("doc"))
+	item_list = []
+	for d in doc.items:
+		item_list.append(d.item_code)
+
+	return frappe.db.sql("""select default_supplier
+		from `tabItem Default`
+		where parent in ({0}) and
+		default_supplier IS NOT NULL
+		""".format(', '.join(['%s']*len(item_list))),tuple(item_list))
+
 @frappe.whitelist()
 def make_supplier_quotation(source_name, target_doc=None):
 	def postprocess(source, target_doc):


### PR DESCRIPTION
Port of https://github.com/frappe/erpnext/pull/20231
Enhancement on https://github.com/frappe/erpnext/pull/20179
- Link field in popup will only suggest default suppliers of items in child table
- Improved description to give context
![Screenshot 2020-01-10 at 11 28 08 AM](https://user-images.githubusercontent.com/25857446/72129464-5314ac80-339c-11ea-9c51-cfb056724314.png)


**Working:**

![POPup2](https://user-images.githubusercontent.com/25857446/72129384-134dc500-339c-11ea-8b6e-4883f797861f.gif)
