### PR TITLE
fix: auto cancel if movement exists

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -132,9 +132,10 @@ class Asset(AccountsController):
 		if len(movements) > 1:
 			frappe.throw(_('Asset has multiple Asset Movement Entries which has to be \
 				cancelled manually to cancel this asset.'))
-		movement = frappe.get_doc('Asset Movement', movements[0].get('name'))
-		movement.flags.ignore_validate = True
-		movement.cancel()
+		if movements:
+			movement = frappe.get_doc('Asset Movement', movements[0].get('name'))
+			movement.flags.ignore_validate = True
+			movement.cancel()
 
 	def make_asset_movement(self):
 		reference_doctype = 'Purchase Receipt' if self.purchase_receipt else 'Purchase Invoice'


### PR DESCRIPTION
If there are no movements created for an asset, the system won't let it to be cancelled. 
Case of no movement existing occurs for asset created before refactoring changes were merged.