### PR TITLE
fix: Authorization Control Customer String Format

### DIFF
--- a/erpnext/setup/doctype/authorization_control/authorization_control.py
+++ b/erpnext/setup/doctype/authorization_control/authorization_control.py
@@ -85,7 +85,7 @@ class AuthorizationControl(TransactionBase):
 			if doc_obj:
 				if doc_obj.doctype == 'Sales Invoice': customer = doc_obj.customer
 				else: customer = doc_obj.customer_name
-				add_cond = " and master_name = '"+ frappe.db.escape(customer) +"'"
+				add_cond = " and master_name = "+ frappe.db.escape(customer) +""
 		if based_on == 'Itemwise Discount':
 			if doc_obj:
 				for t in doc_obj.get("items"):


### PR DESCRIPTION
Enhancement on https://github.com/frappe/erpnext/pull/20202
```
pymysql.err.ProgrammingError: (1064, "You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'Apple''' at line 3")
```
Caused due to:
```
and master_name = ''Apple'' 
```

Works on names with "%" (successful submission)
![Screenshot 2020-01-11 at 4 02 56 PM](https://user-images.githubusercontent.com/25857446/72202972-db25af80-348b-11ea-8bee-bd9568325283.png)
