### PR TITLE
fix: Delivery note not able to create sales return

### DIFF
--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -436,7 +436,7 @@ def make_sales_invoice(source_name, target_doc=None):
 	def update_item(source_doc, target_doc, source_parent):
 		target_doc.qty = to_make_invoice_qty_map[source_doc.name]
 
-		if source_doc.serial_no and source_parent.per_billed > 0:
+		if source_doc.serial_no and source_parent.per_billed > 0 and not source_parent.is_return:
 			target_doc.serial_no = get_delivery_note_serial_no(source_doc.item_code,
 				target_doc.qty, source_parent.name)
 


### PR DESCRIPTION
before:
![before_sales_return](https://user-images.githubusercontent.com/6947417/72237060-3330f300-35ff-11ea-8e85-df0aafe5e2f6.gif)


after: 
![after_sales_return](https://user-images.githubusercontent.com/6947417/72236933-b3a32400-35fe-11ea-8d28-8399f7f48a04.gif)
