### PR TITLE
fix: allow on submit for the delivery date field

### DIFF
--- a/erpnext/selling/doctype/sales_order_item/sales_order_item.json
+++ b/erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "autoname": "hash",
  "creation": "2013-03-07 11:42:58",
  "doctype": "DocType",
@@ -151,6 +152,7 @@
    "width": "300px"
   },
   {
+   "allow_on_submit": 1,
    "columns": 2,
    "depends_on": "eval: !parent.skip_delivery_note",
    "fieldname": "delivery_date",
@@ -767,7 +769,8 @@
  ],
  "idx": 1,
  "istable": 1,
- "modified": "2019-12-12 18:06:26.238169",
+ "links": [],
+ "modified": "2020-01-13 12:29:03.103797",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order Item",


### PR DESCRIPTION
Allow on submit property has enabled for the field Delivery Date in the sales order but not in the sales order item. Now when user change the delivery date on sales order after submission then system reset the delivery date based upon the date set in the child table