### PR TITLE
fix: payment entry can be created against on hold PI

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -167,8 +167,15 @@ erpnext.accounts.PurchaseInvoice = erpnext.buying.BuyingController.extend({
 	make_comment_dialog_and_block_invoice: function(){
 		const me = this;
 
-		const title = __('Add Comment');
+		const title = __('Block Invoice');
 		const fields = [
+			{
+				fieldname: 'release_date',
+				read_only: 0,
+				fieldtype:'Date',
+				label: __('Release Date'),
+				default: me.frm.doc.release_date
+			},
 			{
 				fieldname: 'hold_comment',
 				read_only: 0,
@@ -187,7 +194,11 @@ erpnext.accounts.PurchaseInvoice = erpnext.buying.BuyingController.extend({
 			const dialog_data = me.dialog.get_values();
 			frappe.call({
 				'method': 'erpnext.accounts.doctype.purchase_invoice.purchase_invoice.block_invoice',
-				'args': {'name': me.frm.doc.name, 'hold_comment': dialog_data.hold_comment},
+				'args': {
+					'name': me.frm.doc.name,
+					'hold_comment': dialog_data.hold_comment,
+					'release_date': dialog_data.release_date
+				},
 				'callback': (r) => me.frm.reload_doc()
 			});
 			me.dialog.hide();

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -927,9 +927,10 @@ class PurchaseInvoice(BuyingController):
 	def on_recurring(self, reference_doc, auto_repeat_doc):
 		self.due_date = None
 
-	def block_invoice(self, hold_comment=None):
+	def block_invoice(self, hold_comment=None, release_date=None):
 		self.db_set('on_hold', 1)
 		self.db_set('hold_comment', cstr(hold_comment))
+		self.db_set('release_date', release_date)
 
 	def unblock_invoice(self):
 		self.db_set('on_hold', 0)
@@ -1013,10 +1014,10 @@ def unblock_invoice(name):
 
 
 @frappe.whitelist()
-def block_invoice(name, hold_comment):
+def block_invoice(name, hold_comment, release_date):
 	if frappe.db.exists('Purchase Invoice', name):
 		pi = frappe.get_doc('Purchase Invoice', name)
-		pi.block_invoice(hold_comment)
+		pi.block_invoice(hold_comment, release_date)
 
 @frappe.whitelist()
 def make_inter_company_sales_invoice(source_name, target_doc=None):


### PR DESCRIPTION
![Hold Invoice Issue](https://user-images.githubusercontent.com/25369014/72255275-51f9ae80-362c-11ea-9ffe-9a0723885cf3.gif)

Problem:
An on hold purchase invoice created. 
Then it was unblocked. (Removes invoice release date)
Now it is blocked. (Doesn't lets us set release date)
Payment Entry 'Get Outstanding Invoices' button fetches this blocked invoice because no release date is set.