### PR TITLE
fix: filter issue for the stock and account value comparison report

### DIFF
--- a/erpnext/stock/report/stock_and_account_value_comparison/stock_and_account_value_comparison.py
+++ b/erpnext/stock/report/stock_and_account_value_comparison/stock_and_account_value_comparison.py
@@ -43,7 +43,7 @@ def get_data(report_filters):
 def get_stock_ledger_data(report_filters, filters):
 	if report_filters.account:
 		warehouses = get_warehouses_based_on_account(report_filters.account,
-			report_filters.warehouse)
+			report_filters.company)
 
 		filters["warehouse"] = ("in", warehouses)
 


### PR DESCRIPTION

<img width="1207" alt="Screenshot 2020-01-13 at 12 32 52 PM" src="https://user-images.githubusercontent.com/910238/72237568-f2d27480-3600-11ea-8fb6-9aba14aeefa3.png">

Though validation is right, but since we set Stock In Hand as a default Account, it should query all the Warehouses in this case and show us the update.
