### PR TITLE
fix: make depreciation entries only if calculate depr is checked

### DIFF
--- a/erpnext/assets/doctype/asset/depreciation.py
+++ b/erpnext/assets/doctype/asset/depreciation.py
@@ -22,7 +22,7 @@ def post_depreciation_entries(date=None):
 def get_depreciable_assets(date):
 	return frappe.db.sql_list("""select a.name
 		from tabAsset a, `tabDepreciation Schedule` ds
-		where a.name = ds.parent and a.docstatus=1 and ds.schedule_date<=%s
+		where a.name = ds.parent and a.docstatus=1 and ds.schedule_date<=%s and a.calculate_depreciation = 1
 			and a.status in ('Submitted', 'Partially Depreciated')
 			and ifnull(ds.journal_entry, '')=''""", date)
 


### PR DESCRIPTION
Problem:
While scheduling auto journal entries for depreciation, if an asset is cancelled and amended then calculate depreciation is unchecked, finance books are removed from that asset but not schedules. This asset is catched in the `get_depreciable_assets` query because schedule is linked with asset. Now making journal entries against this asset throws error since no finance book is linked with it.

Hence no depreciation entries are made for other assets.
