### PR TITLE
fix: incorrect required qty for subcontracting purchase receipt

### DIFF
--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -708,8 +708,102 @@ class TestPurchaseOrder(unittest.TestCase):
 		# To test if the PO does NOT have a Blanket Order
 		self.assertEqual(po_doc.items[0].blanket_order, None)
 
+	def test_subcontracted_items_with_same_raw_material(self):
+		from erpnext.manufacturing.doctype.production_plan.test_production_plan import make_bom
+		update_backflush_based_on("Material Transferred for Subcontract")
 
+		if not frappe.db.exists("Item", "Sub-Contract-Same Raw Material"):
+			make_item("Sub-Contract-Same Raw Material", {
+				"is_stock_item": 1,
+			})
 
+		make_stock_entry(target="_Test Warehouse - _TC", item_code="Sub-Contract-Same Raw Material",
+			qty=80, basic_rate=100, purpose="Material Receipt")
+
+		for item_code in ["Sub-Contract-Same-RM Item 1", "Sub-Contract-Same-RM Item 2",
+			"Sub-Contract-Same-RM Item 3"]:
+			if not frappe.db.exists("Item", item_code):
+				make_item(item_code, {
+					"is_stock_item": 1,
+					"is_sub_contracted_item": 1
+				})
+
+			if not frappe.db.exists("BOM", {"item": item_code}):
+				make_bom(item = item_code, quantity = 7,
+					raw_materials = ['Sub-Contract-Same Raw Material'])
+
+		po = create_purchase_order(item_code= "Sub-Contract-Same-RM Item 1", qty = 77,
+			is_subcontracted = "Yes", do_not_save=True)
+
+		for item_code, qty in {"Sub-Contract-Same-RM Item 2": 140, "Sub-Contract-Same-RM Item 3": 343}.items():
+			po.append("items", {
+				"item_code": item_code,
+				"warehouse": "_Test Warehouse - _TC",
+				"qty": qty
+			})
+
+		po.supplier_warehouse = "_Test Warehouse 1 - _TC"
+		po.set_missing_values()
+		po.submit()
+
+		rm_item = [
+			{
+				"item_code": "Sub-Contract-Same-RM Item 1",
+				"rm_item_code": "Sub-Contract-Same Raw Material",
+				"item_name": "Sub-Contract-Same Raw Material",
+				"qty": 11,
+				"warehouse": "_Test Warehouse - _TC",
+				"rate": 100,
+				"amount": 600,
+				"stock_uom": "Nos",
+				"name": po.supplied_items[0].name
+			},
+			{
+				"item_code": "Sub-Contract-Same-RM Item 2",
+				"rm_item_code": "Sub-Contract-Same Raw Material",
+				"item_name": "Sub-Contract-Same Raw Material",
+				"qty": 20,
+				"warehouse": "_Test Warehouse - _TC",
+				"rate": 100,
+				"amount": 600,
+				"stock_uom": "Nos",
+				"name": po.supplied_items[1].name
+			},
+			{
+				"item_code": "Sub-Contract-Same-RM Item 3",
+				"rm_item_code": "Sub-Contract-Same Raw Material",
+				"item_name": "Sub-Contract-Same Raw Material",
+				"qty": 49,
+				"warehouse": "_Test Warehouse - _TC",
+				"rate": 100,
+				"amount": 600,
+				"stock_uom": "Nos",
+				"name": po.supplied_items[2].name
+			},
+		]
+
+		# to transfer materials from store to supplier's warehouse
+		rm_item_string = json.dumps(rm_item)
+		se1 = frappe.get_doc(make_subcontract_transfer_entry(po.name, rm_item_string))
+		se1.to_warehouse = "_Test Warehouse 1 - _TC"
+		se1.submit()
+
+		pr = make_purchase_receipt(po.name)
+		pr.get("items")[0].qty = 21
+		pr.get("items")[1].qty = 56
+		pr.get("items")[2].qty = 259
+		pr.set_missing_values()
+		pr.submit()
+
+		po.load_from_db()
+		pr = make_purchase_receipt(po.name)
+		pr.insert()
+
+		self.assertEquals(pr.supplied_items[0].required_qty, 8)
+		self.assertEquals(pr.supplied_items[1].required_qty, 12)
+		self.assertEquals(pr.supplied_items[2].required_qty, 12)
+
+		update_backflush_based_on("BOM")
 
 def make_pr_against_po(po, received_qty=0):
 	pr = make_purchase_receipt(po)

--- a/erpnext/buying/doctype/purchase_receipt_item_supplied/purchase_receipt_item_supplied.json
+++ b/erpnext/buying/doctype/purchase_receipt_item_supplied/purchase_receipt_item_supplied.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "creation": "2013-02-22 01:27:42",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -18,7 +19,8 @@
   "conversion_factor",
   "current_stock",
   "reference_name",
-  "bom_detail_no"
+  "bom_detail_no",
+  "extra_item"
  ],
  "fields": [
   {
@@ -152,11 +154,22 @@
    "oldfieldname": "bom_detail_no",
    "oldfieldtype": "Data",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "extra_item",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Extra Item",
+   "no_copy": 1,
+   "print_hide": 1,
+   "read_only": 1
   }
  ],
  "idx": 1,
  "istable": 1,
- "modified": "2019-11-21 16:25:29.909112",
+ "links": [],
+ "modified": "2020-01-28 12:55:45.767903",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Purchase Receipt Item Supplied",

--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -270,7 +270,7 @@ class BuyingController(StockController):
 
 			non_stock_items = get_non_stock_items(item.purchase_order, item.item_code)
 
-			item_key = '{}{}'.format(item.item_code, item.purchase_order)
+			item_key = '{}{}{}'.format(item.item_code, item.purchase_order, item.purchase_order_item)
 
 			fg_yet_to_be_received = qty_to_be_received_map.get(item_key)
 
@@ -278,7 +278,9 @@ class BuyingController(StockController):
 			backflushed_batch_qty_map = get_backflushed_batch_qty_map(item.purchase_order, item.item_code)
 
 			for raw_material in transferred_raw_materials + non_stock_items:
-				rm_item_key = '{}{}'.format(raw_material.rm_item_code, item.purchase_order)
+				rm_item_key = '{}{}{}'.format(raw_material.rm_item_code,
+					item.purchase_order, item.purchase_order_item)
+
 				raw_material_data = backflushed_raw_materials_map.get(rm_item_key, {})
 
 				consumed_qty = raw_material_data.get('qty', 0)
@@ -843,7 +845,7 @@ def get_subcontracted_raw_materials_from_se(purchase_order, fg_item):
 def get_backflushed_subcontracted_raw_materials(purchase_orders):
 	common_query = """
 		SELECT
-			CONCAT(prsi.rm_item_code, pri.purchase_order) AS item_key,
+			CONCAT(prsi.rm_item_code, pri.purchase_order, pri.purchase_order_item) AS item_key,
 			SUM(prsi.consumed_qty) AS qty,
 			{serial_no_concat_syntax} AS serial_nos,
 			{batch_no_concat_syntax} AS batch_nos
@@ -854,7 +856,7 @@ def get_backflushed_subcontracted_raw_materials(purchase_orders):
 			AND pri.purchase_order IN %s
 			AND pri.item_code = prsi.main_item_code
 			AND pr.docstatus = 1
-		GROUP BY prsi.rm_item_code, pri.purchase_order
+		GROUP BY prsi.rm_item_code, pri.purchase_order, pri.purchase_order_item
 	"""
 
 	backflushed_raw_materials = frappe.db.multisql({
@@ -908,7 +910,7 @@ def validate_item_type(doc, fieldname, message):
 
 def get_qty_to_be_received(purchase_orders):
 	return frappe._dict(frappe.db.sql("""
-		SELECT CONCAT(poi.`item_code`, poi.`parent`) AS item_key,
+		SELECT CONCAT(poi.`item_code`, poi.`parent`, poi.`name`) AS item_key,
 		SUM(poi.`qty`) - SUM(poi.`received_qty`) AS qty_to_be_received
 		FROM `tabPurchase Order Item` poi
 		WHERE

--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -532,3 +532,17 @@ def get_tax_template(doctype, txt, searchfield, start, page_len, filters):
 
 		taxes = _get_item_tax_template(args, taxes, for_validate=True)
 		return [(d,) for d in set(taxes)]
+
+@frappe.whitelist()
+def get_subcontracted_items(doctype, txt, searchfield, start, page_len, filters):
+	if txt:
+		filters.update({
+			"main_item_code": ("like", "%{0}%".format(txt))
+		})
+
+	return frappe.get_all("Purchase Order Item Supplied",
+		fields = ["distinct main_item_code as name"],
+		filters = filters,
+		limit_start = start,
+		limit_page_length = page_len
+	, as_list=1)

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -658,3 +658,4 @@ erpnext.patches.v12_0.set_permission_einvoicing
 erpnext.patches.v12_0.set_published_in_hub_tracked_item
 erpnext.patches.v12_0.set_job_offer_applicant_email
 erpnext.patches.v12_0.create_irs_1099_field_united_states
+erpnext.patches.v12_0.update_reference_for_subcontracting_purchase_receipt #12sssswks

--- a/erpnext/patches/v12_0/update_reference_for_subcontracting_purchase_receipt.py
+++ b/erpnext/patches/v12_0/update_reference_for_subcontracting_purchase_receipt.py
@@ -1,0 +1,40 @@
+# Copyright (c) 2017, Frappe and Contributors
+# License: GNU General Public License v3. See license.txt
+
+from __future__ import unicode_literals
+import frappe
+from six import iteritems
+from erpnext.controllers.buying_controller import get_subcontracted_raw_materials_from_se
+
+def execute():
+	frappe.reload_doc("stock", "doctype", "purchase_receipt")
+	frappe.reload_doc("stock", "doctype", "purchase_receipt_item")
+	frappe.reload_doc("buying", "doctype", "purchase_receipt_item_supplied")
+
+	purchase_receipts = frappe.db.sql(""" SELECT distinct `tabPurchase Receipt`.name
+		FROM 
+			`tabPurchase Receipt`, `tabPurchase Receipt Item Supplied`
+		WHERE
+			`tabPurchase Receipt Item Supplied`.parent = `tabPurchase Receipt`.name 
+			AND (`tabPurchase Receipt Item Supplied`.reference_name is null 
+				OR `tabPurchase Receipt Item Supplied`.reference_name = '')
+			AND `tabPurchase Receipt`.docstatus = 1
+			AND `tabPurchase Receipt`.is_subcontracted = 'Yes' """, as_dict=1)
+
+	for purchase_receipt in purchase_receipts:
+		pr_doc = frappe.get_doc("Purchase Receipt", purchase_receipt.name)
+
+		for item in pr_doc.items:
+			#Get transferred materials against the purchase order
+			raw_materials = get_subcontracted_raw_materials_from_se(item.purchase_order,
+				item.purchase_order_item, item.item_code)
+
+			total_count = len(raw_materials)
+			for data in raw_materials:
+				for supplied_item in pr_doc.supplied_items:
+					if (total_count > 0 and data.main_item_code == supplied_item.main_item_code
+						and data.rm_item_code == supplied_item.rm_item_code
+						and not supplied_item.reference_name):
+						supplied_item.reference_name = item.name
+						total_count -= 1
+						supplied_item.db_set("reference_name", item.name)

--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -68,6 +68,15 @@ frappe.ui.form.on('Stock Entry', {
 			}
 		});
 
+		frm.set_query("subcontracted_item", 'items', function(doc, cdt, cdn) {
+			let filters = { parent: doc.purchase_order }
+
+			return {
+				query : "erpnext.controllers.queries.get_subcontracted_items",
+				filters: filters
+			}
+		});
+
 		frm.set_query("expense_account", "additional_costs", function() {
 			return {
 				query: "erpnext.controllers.queries.tax_account_query",

--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -68,12 +68,12 @@ frappe.ui.form.on('Stock Entry', {
 			}
 		});
 
-		frm.set_query("subcontracted_item", 'items', function(doc, cdt, cdn) {
-			let filters = { parent: doc.purchase_order }
-
+		frm.set_query("subcontracted_item", 'items', function(doc) {
 			return {
 				query : "erpnext.controllers.queries.get_subcontracted_items",
-				filters: filters
+				filters: {
+					parent: doc.purchase_order
+				}
 			}
 		});
 

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -78,6 +78,7 @@ class StockEntry(StockController):
 		self.validate_serialized_batch()
 		self.set_actual_qty()
 		self.calculate_rate_and_amount(update_finished_item_rate=False)
+		self.set_subcontracted_item()
 
 	def on_submit(self):
 
@@ -422,6 +423,21 @@ class StockEntry(StockController):
 		self.update_valuation_rate()
 		self.set_total_incoming_outgoing_value()
 		self.set_total_amount()
+
+	def set_subcontracted_item(self):
+		if self.purpose != 'Send to Subcontractor': return
+
+		subcontracted_items = [d.subcontracted_item for d in self.items if d.subcontracted_item]
+		if len(subcontracted_items) == len(self.items): return
+
+		for row in self.items:
+			if row.subcontracted_item: continue
+
+			if len(set(subcontracted_items)) == 1:
+				row.subcontracted_item = subcontracted_items[0]
+			else:
+				frappe.throw(_("Row {0}: select subcontracted item for the raw material {1}")
+					.format(row.idx, row.item_code))
 
 	def set_basic_rate(self, force=False, update_finished_item_rate=True, raise_error_if_no_rate=True):
 		"""get stock and incoming rate on posting date"""


### PR DESCRIPTION
**Issue**

![image](https://user-images.githubusercontent.com/8780500/72334284-1110a100-36e3-11ea-9ad0-903b5d28a5a7.png)


**After Fix**
![image](https://user-images.githubusercontent.com/8780500/72334315-1ff75380-36e3-11ea-82f5-467abb536d91.png)


Steps to replicate issue

1. Create 4 boms for different items and add same raw materials in all 4 boms

1. Create subcontracted PO against that 4 items

1. Do stock entry transfer

1. Create purchase receipt entries against PO partially 

1. First entry will calculate the correct required qty where as second will shows the incorrect qty