### PR TITLE
fix: incorrect required qty for subcontracting purchase receipt

### DIFF
--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -261,7 +261,7 @@ class BuyingController(StockController):
 
 			non_stock_items = get_non_stock_items(item.purchase_order, item.item_code)
 
-			item_key = '{}{}'.format(item.item_code, item.purchase_order)
+			item_key = '{}{}{}'.format(item.item_code, item.purchase_order, item.purchase_order_item)
 
 			fg_yet_to_be_received = qty_to_be_received_map.get(item_key)
 
@@ -269,7 +269,9 @@ class BuyingController(StockController):
 			backflushed_batch_qty_map = get_backflushed_batch_qty_map(item.purchase_order, item.item_code)
 
 			for raw_material in transferred_raw_materials + non_stock_items:
-				rm_item_key = '{}{}'.format(raw_material.rm_item_code, item.purchase_order)
+				rm_item_key = '{}{}{}'.format(raw_material.rm_item_code,
+					item.purchase_order, item.purchase_order_item)
+
 				raw_material_data = backflushed_raw_materials_map.get(rm_item_key, {})
 
 				consumed_qty = raw_material_data.get('qty', 0)
@@ -815,7 +817,7 @@ def get_subcontracted_raw_materials_from_se(purchase_order, fg_item):
 def get_backflushed_subcontracted_raw_materials(purchase_orders):
 	common_query = """
 		SELECT
-			CONCAT(prsi.rm_item_code, pri.purchase_order) AS item_key,
+			CONCAT(prsi.rm_item_code, pri.purchase_order, pri.purchase_order_item) AS item_key,
 			SUM(prsi.consumed_qty) AS qty,
 			{serial_no_concat_syntax} AS serial_nos,
 			{batch_no_concat_syntax} AS batch_nos
@@ -826,7 +828,7 @@ def get_backflushed_subcontracted_raw_materials(purchase_orders):
 			AND pri.purchase_order IN %s
 			AND pri.item_code = prsi.main_item_code
 			AND pr.docstatus = 1
-		GROUP BY prsi.rm_item_code, pri.purchase_order
+		GROUP BY prsi.rm_item_code, pri.purchase_order, pri.purchase_order_item
 	"""
 
 	backflushed_raw_materials = frappe.db.multisql({
@@ -880,7 +882,7 @@ def validate_item_type(doc, fieldname, message):
 
 def get_qty_to_be_received(purchase_orders):
 	return frappe._dict(frappe.db.sql("""
-		SELECT CONCAT(poi.`item_code`, poi.`parent`) AS item_key,
+		SELECT CONCAT(poi.`item_code`, poi.`parent`, poi.`name`) AS item_key,
 		SUM(poi.`qty`) - SUM(poi.`received_qty`) AS qty_to_be_received
 		FROM `tabPurchase Order Item` poi
 		WHERE


### PR DESCRIPTION
**Issue**

![image](https://user-images.githubusercontent.com/8780500/72334284-1110a100-36e3-11ea-9ad0-903b5d28a5a7.png)


**After Fix**
![image](https://user-images.githubusercontent.com/8780500/72334315-1ff75380-36e3-11ea-82f5-467abb536d91.png)


Steps to replicate issue

1. Create 4 boms for different items and add same raw materials in all 4 boms

1. Create subcontracted PO against that 4 items

1. Do stock entry transfer

1. Create purchase receipt entries against PO partially 

1. First entry will calculate the correct required qty where as second will shows the incorrect qty