### PR TITLE
fix: get existing payment req amount only from unpaid req

### DIFF
--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -373,6 +373,7 @@ def get_existing_payment_request_amount(ref_dt, ref_dn):
 			reference_doctype = %s
 			and reference_name = %s
 			and docstatus = 1
+			and status != 'Paid'
 	""", (ref_dt, ref_dn))
 	return flt(existing_payment_request_amount[0][0]) if existing_payment_request_amount else 0
 


### PR DESCRIPTION
A Payment Request (1200 INR) is created to pay advance against a Sales Order (4000 INR) and then it is Paid. Now Sales Order has Advance Paid as 1200 INR. 
Now again creating Payment Entry against Sales Order fetches Payable Amount as 
(4000 - 1200 - 1200) 
i.e 
(SO Grand Total - Advance Paid - Existing Payment Entry Amount)