### PR TITLE
fix: retrieve proper value from HR Settings (v12)

### DIFF
--- a/erpnext/hr/doctype/hr_settings/hr_settings.py
+++ b/erpnext/hr/doctype/hr_settings/hr_settings.py
@@ -24,12 +24,12 @@ class HRSettings(Document):
 		if self.email_salary_slip_to_employee and self.encrypt_salary_slips_in_emails:
 			if not self.password_policy:
 				frappe.throw(_("Password policy for Salary Slips is not set"))
-	
+
 	def on_update(self):
 		self.toggle_rounded_total()
 		frappe.clear_cache()
 
 	def toggle_rounded_total(self):
-		self.disable_rounded_total = cint(self.disable_rounded_total)
+		self.disable_rounded_total = cint(self.get("disable_rounded_total"))
 		make_property_setter("Salary Slip", "rounded_total", "hidden", self.disable_rounded_total, "Check")
 		make_property_setter("Salary Slip", "rounded_total", "print_hide", self.disable_rounded_total, "Check")


### PR DESCRIPTION
Traceback:
```
	'HRSettings' has no attribute 'disable_rounded_total'
```

Migrate breaks at trying to retrieve value while running a v12 patch, but the column doesn't yet exist for existing sites