### PR TITLE
fix: salary structure assignment filter employee based on company

### DIFF
--- a/erpnext/hr/doctype/salary_structure/salary_structure.js
+++ b/erpnext/hr/doctype/salary_structure/salary_structure.js
@@ -88,7 +88,6 @@ frappe.ui.form.on('Salary Structure', {
 			],
 			primary_action: function() {
 				var data = d.get_values();
-				console.log("data", data)
 				frappe.call({
 					doc: frm.doc,
 					method: "assign_salary_structure",

--- a/erpnext/hr/doctype/salary_structure/salary_structure.js
+++ b/erpnext/hr/doctype/salary_structure/salary_structure.js
@@ -46,7 +46,7 @@ frappe.ui.form.on('Salary Structure', {
 		frm.trigger("toggle_fields");
 		frm.fields_dict['earnings'].grid.set_column_disp("default_amount", false);
 		frm.fields_dict['deductions'].grid.set_column_disp("default_amount", false);
-		
+
 		if(frm.doc.docstatus === 1) {
 			frm.add_custom_button(__("Preview Salary Slip"), function() {
 				frm.trigger('preview_salary_slip');
@@ -75,6 +75,7 @@ frappe.ui.form.on('Salary Structure', {
 			title: __("Assign to Employees"),
 			fields: [
 				{fieldname: "sec_break", fieldtype: "Section Break", label: __("Filter Employees By (Optional)")},
+				{fieldname: "company", fieldtype: "Link", options: "Company", label: __("Company"), default: frm.doc.company, read_only:1},
 				{fieldname: "grade", fieldtype: "Link", options: "Employee Grade", label: __("Employee Grade")},
 				{fieldname:'department', fieldtype:'Link', options: 'Department', label: __('Department')},
 				{fieldname:'designation', fieldtype:'Link', options: 'Designation', label: __('Designation')},
@@ -87,7 +88,7 @@ frappe.ui.form.on('Salary Structure', {
 			],
 			primary_action: function() {
 				var data = d.get_values();
-
+				console.log("data", data)
 				frappe.call({
 					doc: frm.doc,
 					method: "assign_salary_structure",

--- a/erpnext/hr/doctype/salary_structure/salary_structure.py
+++ b/erpnext/hr/doctype/salary_structure/salary_structure.py
@@ -117,6 +117,7 @@ def create_salary_structures_assignment(employee, salary_structure, from_date, b
 	assignment = frappe.new_doc("Salary Structure Assignment")
 	assignment.employee = employee
 	assignment.salary_structure = salary_structure.name
+	assignment.company = salary_structure.company
 	assignment.from_date = from_date
 	assignment.base = base
 	assignment.variable = variable

--- a/erpnext/hr/doctype/salary_structure/salary_structure.py
+++ b/erpnext/hr/doctype/salary_structure/salary_structure.py
@@ -88,24 +88,24 @@ class SalaryStructure(Document):
 		if employees:
 			if len(employees) > 20:
 				frappe.enqueue(assign_salary_structure_for_employees, timeout=600,
-					employees=employees, company= company, salary_structure=self,from_date=from_date, base=base,variable=variable)
+					employees=employees, salary_structure=self,from_date=from_date, base=base,variable=variable)
 			else:
-				assign_salary_structure_for_employees(employees, company, self, from_date=from_date, base=base,variable=variable)
+				assign_salary_structure_for_employees(employees, self, from_date=from_date, base=base,variable=variable)
 		else:
 			frappe.msgprint(_("No Employee Found"))
 
 
 
-def assign_salary_structure_for_employees(employees, company, salary_structure, from_date=None, base=None,variable=None):
+def assign_salary_structure_for_employees(employees, salary_structure, from_date=None, base=None,variable=None):
 	salary_structures_assignments = []
-	existing_assignments_for = get_existing_assignments(employees, company, salary_structure.name, from_date)
+	existing_assignments_for = get_existing_assignments(employees, salary_structure, from_date)
 	count=0
 	for employee in employees:
 		if employee in existing_assignments_for:
 			continue
 		count +=1
 
-		salary_structures_assignment = create_salary_structures_assignment(employee, company, salary_structure, from_date, base, variable)
+		salary_structures_assignment = create_salary_structures_assignment(employee, salary_structure, from_date, base, variable)
 		salary_structures_assignments.append(salary_structures_assignment)
 		frappe.publish_progress(count*100/len(set(employees) - set(existing_assignments_for)), title = _("Assigning Structures..."))
 
@@ -113,11 +113,10 @@ def assign_salary_structure_for_employees(employees, company, salary_structure, 
 		frappe.msgprint(_("Structures have been assigned successfully"))
 
 
-def create_salary_structures_assignment(employee, company, salary_structure, from_date, base, variable):
+def create_salary_structures_assignment(employee, salary_structure, from_date, base, variable):
 	assignment = frappe.new_doc("Salary Structure Assignment")
 	assignment.employee = employee
 	assignment.salary_structure = salary_structure.name
-	assignment.company = company
 	assignment.from_date = from_date
 	assignment.base = base
 	assignment.variable = variable
@@ -126,12 +125,12 @@ def create_salary_structures_assignment(employee, company, salary_structure, fro
 	return assignment.name
 
 
-def get_existing_assignments(employees, company, salary_structure,from_date):
+def get_existing_assignments(employees, salary_structure, from_date):
 	salary_structures_assignments = frappe.db.sql_list("""
 		select distinct employee from `tabSalary Structure Assignment`
 		where salary_structure=%s and employee in (%s)
 		and from_date=%s  and company= %s and docstatus=1
-	""" % ('%s', ', '.join(['%s']*len(employees)),'%s', '%s'), [salary_structure] + employees+[from_date]+[company])
+	""" % ('%s', ', '.join(['%s']*len(employees)),'%s', '%s'), [salary_structure.name] + employees+[from_date]+[salary_structure.company])
 	if salary_structures_assignments:
 		frappe.msgprint(_("Skipping Salary Structure Assignment for the following employees, as Salary Structure Assignment records already exists against them. {0}")
 			.format("\n".join(salary_structures_assignments)))

--- a/erpnext/hr/doctype/salary_structure/salary_structure.py
+++ b/erpnext/hr/doctype/salary_structure/salary_structure.py
@@ -117,6 +117,7 @@ def create_salary_structures_assignment(employee, salary_structure, from_date, b
 	assignment = frappe.new_doc("Salary Structure Assignment")
 	assignment.employee = employee
 	assignment.salary_structure = salary_structure.name
+	assignment.company = salary_structure.company
 	assignment.from_date = from_date
 	assignment.base = base
 	assignment.variable = variable
@@ -170,7 +171,7 @@ def make_salary_slip(source_name, target_doc = None, employee = None, as_print =
 def get_employees(salary_structure):
 	employees = frappe.get_list('Salary Structure Assignment',
 		filters={'salary_structure': salary_structure, 'docstatus': 1}, fields=['employee'])
-	
+
 	if not employees:
 		frappe.throw(_("There's no Employee with Salary Structure: {0}. \
 			Assign {1} to an Employee to preview Salary Slip").format(salary_structure, salary_structure))

--- a/erpnext/hr/doctype/salary_structure/salary_structure.py
+++ b/erpnext/hr/doctype/salary_structure/salary_structure.py
@@ -117,7 +117,7 @@ def create_salary_structures_assignment(employee, salary_structure, from_date, b
 	assignment = frappe.new_doc("Salary Structure Assignment")
 	assignment.employee = employee
 	assignment.salary_structure = salary_structure.name
-	assignment.company = salary_structure.company
+	assignment.company = frappe.db.get_value("Employee", employee , "company")
 	assignment.from_date = from_date
 	assignment.base = base
 	assignment.variable = variable

--- a/erpnext/hr/doctype/salary_structure/salary_structure.py
+++ b/erpnext/hr/doctype/salary_structure/salary_structure.py
@@ -117,7 +117,7 @@ def create_salary_structures_assignment(employee, salary_structure, from_date, b
 	assignment = frappe.new_doc("Salary Structure Assignment")
 	assignment.employee = employee
 	assignment.salary_structure = salary_structure.name
-	assignment.company = salary_structure.company
+	assignment.company = frappe.db.get_value("Employee", employee, "company")
 	assignment.from_date = from_date
 	assignment.base = base
 	assignment.variable = variable

--- a/erpnext/hr/doctype/salary_structure/salary_structure.py
+++ b/erpnext/hr/doctype/salary_structure/salary_structure.py
@@ -117,7 +117,7 @@ def create_salary_structures_assignment(employee, salary_structure, from_date, b
 	assignment = frappe.new_doc("Salary Structure Assignment")
 	assignment.employee = employee
 	assignment.salary_structure = salary_structure.name
-	assignment.company = frappe.db.get_value("Employee", employee , "company")
+	assignment.company = salary_structure.company
 	assignment.from_date = from_date
 	assignment.base = base
 	assignment.variable = variable


### PR DESCRIPTION
As an HR, when I try to assign Salary Structure to Employees with 'ASSIGN TO EMPLOYEES' option in Salary Structure with Company Name: ABC (Child Comapny) , the Salary structure gets assigned in salary strucutre assignment with Parent company (XYZ) default. because there is no filtering based on company.