### PR TITLE
docs: Added change log for v12.4.0

### DIFF
--- a/erpnext/change_log/v12/v12_4_0.md
+++ b/erpnext/change_log/v12/v12_4_0.md
@@ -1,0 +1,89 @@
+# Version 12.4.0 Release Note
+
+### Accounts
+
+- Validity of item tax. [#20135](https://github.com/frappe/erpnext/pull/20135)
+
+- Dynamic filters for dimensions in the budget variance report. [#19973](https://github.com/frappe/erpnext/pull/19973)
+
+- Purchase Receipt and Purchase Invoice is not mandatory for an existing asset. [19980](https://github.com/frappe/erpnext/pull/19980)
+
+- Allowed multiple Landed Cost Vouchers against a Purchase Receipt / Purchase Invoice. [#20058](https://github.com/frappe/erpnext/pull/20058)
+
+- Rounding adjustment while both inclusive tax and additional discount amount are applied. [#20078](https://github.com/frappe/erpnext/pull/20078)
+
+- Fixed an error while doing payment reconciliation for party type Employee. [#20088](https://github.com/frappe/erpnext/pull/20088)
+
+- Show Closing row in General Ledger print. [#20161](https://github.com/frappe/erpnext/pull/20161)
+
+- New report - Stock and Account Balance Comparison. [#20226](https://github.com/frappe/erpnext/pull/20226)
+
+- Paid amount should not be over-written on clicking "Get Outstanding Invoices" button in Payment Entry. [#20050](https://github.com/frappe/erpnext/pull/20050)
+
+- Currency symbol in Sales / Purchase Register report
+
+- Currency symbol in "Bank and Cash Payment Voucher" print format.
+
+
+### Human Resource
+
+- Fixed leave allocation on the compensatory leave request submission. [#19961](https://github.com/frappe/erpnext/pull/19961)
+
+- Create Payment Entry against Employee Advance to return any unclaimed amount and update returned amount in Employee Advance. [#19955](https://github.com/frappe/erpnext/pull/19955)
+
+- Set Party against loan accounts in an accrual journal entry for salary. [#20022](https://github.com/frappe/erpnext/pull/20022)
+
+- Editable loan repayment schedule after submission [#20122](https://github.com/frappe/erpnext/pull/20112)
+
+- Update the paid amount and status of a loan after processing salary slip against it. [#20023](https://github.com/frappe/erpnext/pull/20023)
+
+- Settings to disable rounded total in salary slip via HR Settings. [#20150](https://github.com/frappe/erpnext/pull/20150)
+
+- Submit Salary button was not showing after creating salary slip in payroll entry. [#19753](https://github.com/frappe/erpnext/pull/19753)
+
+- Payment Entry against payroll entry should deduct loan amount (if there are any loan deductions in salary slip). [#20194](https://github.com/frappe/erpnext/pull/20194)
+
+- Show only relevant "Job Offer" in Employee Onboarding based on Job Applicant
+
+- Added dashboard in Employee Advance
+
+
+### Manufacturing
+
+- Fixed backflushed qty for partial receipt against a subcontracted purchase order. [#20026](https://github.com/frappe/erpnext/pull/20026)
+
+- Added "Set Reserve Warehouse" field in sub-contracted Purchase Order. [19992](https://github.com/frappe/erpnext/pull/19992)
+   - Only shows if the supplied items table is not empty
+   - On entering a warehouse in the field, it sets / overwrites reserve warehouse in Supplied Raw Materials table.
+
+- In Backflush Stock Entry against Work Order, additional cost for service items (defined in BOM) should come proportionately based on finished goods qty. [#20105](https://github.com/frappe/erpnext/pull/20105)
+
+- Hide transfer button in a subcontracted PO if full qty is already transferred. [#20155](https://github.com/frappe/erpnext/pull/20155)
+
+- Set correct valuation rate of finished goods item in case of multiple material consumptions. [#20165](https://github.com/frappe/erpnext/pull/20165)
+
+- Job Card creation from Work Order dashboard
+
+
+### Stock
+
+- Fixed ambiguous column name in the Batch query. Test by searching in any Batch link field.
+
+- Fixed incorrect reorder level in Stock balance report
+
+- Validate Batch for serialized items
+
+- Get the outgoing rate of serial no from SLE if serial no already transferred to another company. [#20171](https://github.com/frappe/erpnext/pull/20171)
+
+- Deliver Note creation from Sales Order dashboard. [#20199](https://github.com/frappe/erpnext/pull/20199)
+
+
+### Others
+
+- Addition and deletion of items in submitted Sales Order / Purchase Order. [#19911](https://github.com/frappe/erpnext/pull/19911)
+
+- Get item price based on price list considering minimum qty. [#20206](https://github.com/frappe/erpnext/pull/20206)
+
+- Product Bundle item should not appear in dialog on click of "Create Material Request" button. [#20216](https://github.com/frappe/erpnext/pull/20216)
+
+- Delete linked communications on the deletion of company transactions. [#19928](https://github.com/frappe/erpnext/pull/19928)


### PR DESCRIPTION
# Version 12.4.0 Release Note

### Accounts

- Validity of item tax. [#20135](https://github.com/frappe/erpnext/pull/20135)

- Dynamic filters for dimensions in the budget variance report. [#19973](https://github.com/frappe/erpnext/pull/19973)

- Purchase Receipt and Purchase Invoice is not mandatory for an existing asset. [19980](https://github.com/frappe/erpnext/pull/19980)

- Allowed multiple Landed Cost Vouchers against a Purchase Receipt / Purchase Invoice. [#20058](https://github.com/frappe/erpnext/pull/20058)

- Rounding adjustment while both inclusive tax and additional discount amount are applied. [#20078](https://github.com/frappe/erpnext/pull/20078)

- Fixed an error while doing payment reconciliation for party type Employee. [#20088](https://github.com/frappe/erpnext/pull/20088)

- Show Closing row in General Ledger print. [#20161](https://github.com/frappe/erpnext/pull/20161)

- New report - Stock and Account Balance Comparison. [#20226](https://github.com/frappe/erpnext/pull/20226)

- Paid amount should not be over-written on clicking "Get Outstanding Invoices" button in Payment Entry. [#20050](https://github.com/frappe/erpnext/pull/20050)

- Currency symbol in Sales / Purchase Register report

- Currency symbol in "Bank and Cash Payment Voucher" print format.


### Human Resource

- Fixed leave allocation on the compensatory leave request submission. [#19961](https://github.com/frappe/erpnext/pull/19961)

- Create Payment Entry against Employee Advance to return any unclaimed amount and update returned amount in Employee Advance. [#19955](https://github.com/frappe/erpnext/pull/19955)

- Set Party against loan accounts in an accrual journal entry for salary. [#20022](https://github.com/frappe/erpnext/pull/20022)

- Editable loan repayment schedule after submission [#20122](https://github.com/frappe/erpnext/pull/20112)

- Update the paid amount and status of a loan after processing salary slip against it. [#20023](https://github.com/frappe/erpnext/pull/20023)

- Settings to disable rounded total in salary slip via HR Settings. [#20150](https://github.com/frappe/erpnext/pull/20150)

- Submit Salary button was not showing after creating salary slip in payroll entry. [#19753](https://github.com/frappe/erpnext/pull/19753)

- Payment Entry against payroll entry should deduct loan amount (if there are any loan deductions in salary slip). [#20194](https://github.com/frappe/erpnext/pull/20194)

- Show only relevant "Job Offer" in Employee Onboarding based on Job Applicant

- Added dashboard in Employee Advance


### Manufacturing

- Fixed backflushed qty for partial receipt against a subcontracted purchase order. [#20026](https://github.com/frappe/erpnext/pull/20026)

- Added "Set Reserve Warehouse" field in sub-contracted Purchase Order. [19992](https://github.com/frappe/erpnext/pull/19992)
   - Only shows if the supplied items table is not empty
   - On entering a warehouse in the field, it sets / overwrites reserve warehouse in Supplied Raw Materials table.

- In Backflush Stock Entry against Work Order, additional cost for service items (defined in BOM) should come proportionately based on finished goods qty. [#20105](https://github.com/frappe/erpnext/pull/20105)

- Hide transfer button in a subcontracted PO if full qty is already transferred. [#20155](https://github.com/frappe/erpnext/pull/20155)

- Set correct valuation rate of finished goods item in case of multiple material consumptions. [#20165](https://github.com/frappe/erpnext/pull/20165)

- Job Card creation from Work Order dashboard


### Stock

- Fixed ambiguous column name in the Batch query. Test by searching in any Batch link field.

- Fixed incorrect reorder level in Stock balance report

- Validate Batch for serialized items

- Get the outgoing rate of serial no from SLE if serial no already transferred to another company. [#20171](https://github.com/frappe/erpnext/pull/20171)

- Deliver Note creation from Sales Order dashboard. [#20199](https://github.com/frappe/erpnext/pull/20199)


### Others

- Addition and deletion of items in submitted Sales Order / Purchase Order. [#19911](https://github.com/frappe/erpnext/pull/19911)

- Get item price based on price list considering minimum qty. [#20206](https://github.com/frappe/erpnext/pull/20206)

- Product Bundle item should not appear in dialog on click of "Create Material Request" button. [#20216](https://github.com/frappe/erpnext/pull/20216)

- Delete linked communications on the deletion of company transactions. [#19928](https://github.com/frappe/erpnext/pull/19928)