### PR TITLE
fix: handle default value for batch size in BOM operation (develop)

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -588,7 +588,7 @@ class BOM(WebsiteGenerator):
 			for d in self.operations:
 				if not d.description:
 					d.description = frappe.db.get_value('Operation', d.operation, 'description')
-				if not d.batch_size > 0:
+				if not d.batch_size or d.batch_size <= 0:
 					d.batch_size = 1
 
 def get_list_context(context):


### PR DESCRIPTION
```diff
TypeError: unorderable types: NoneType() > int()
  File "frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "frappe/handler.py", line 61, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "__init__.py", line 1041, in call
    return fn(*args, **newargs)
  File "frappe/desk/form/save.py", line 22, in savedocs
    doc.save()
  File "frappe/model/document.py", line 272, in save
    return self._save(*args, **kwargs)
  File "frappe/model/document.py", line 308, in _save
    self.run_before_save_methods()
  File "frappe/model/document.py", line 888, in run_before_save_methods
    self.run_method("validate")
  File "frappe/model/document.py", line 787, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "frappe/model/document.py", line 1058, in composer
    return composed(self, method, *args, **kwargs)
  File "frappe/model/document.py", line 1041, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "frappe/model/document.py", line 781, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "erpnext/manufacturing/doctype/bom/bom.py", line 61, in validate
    self.validate_operations()
  File "erpnext/manufacturing/doctype/bom/bom.py", line 591, in validate_operations
    if not d.batch_size > 0:
```