### PR TITLE
fix: Spelling correction in throw message on stock entry(#20337)

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -614,7 +614,7 @@ class StockEntry(StockController):
 		if self.work_order and self.purpose == "Manufacture":
 			allowed_qty = wo_qty + (allowance_percentage/100 * wo_qty)
 			if self.fg_completed_qty > allowed_qty:
-				frappe.throw(_("For quantity {0} should not be grater than work order quantity {1}")
+				frappe.throw(_("For quantity {0} should not be greater than work order quantity {1}")
 					.format(flt(self.fg_completed_qty), wo_qty))
 
 			if production_item not in items_with_target_warehouse:


### PR DESCRIPTION
Spelling of greater changed in one throw message of stock entry.
Before change check following screenshot:
![image](https://user-images.githubusercontent.com/53554836/72728949-7f0e0a00-3bb4-11ea-81f3-4ec6fa7ff258.png)


After change check following screenshot:
![image](https://user-images.githubusercontent.com/53554836/72729018-a1a02300-3bb4-11ea-889f-4817147ccab3.png)
