### PR TITLE
fix: Set Quotation expired if not Ordered or Lost

### DIFF
--- a/erpnext/selling/doctype/quotation/quotation.py
+++ b/erpnext/selling/doctype/quotation/quotation.py
@@ -182,8 +182,12 @@ def _make_sales_order(source_name, target_doc=None, ignore_permissions=False):
 	return doclist
 
 def set_expired_status():
-	frappe.db.sql("""UPDATE `tabQuotation` SET `status` = 'Expired'
-		WHERE `status` != "Expired" AND `valid_till` < %s""", (nowdate()))
+	frappe.db.sql("""
+		UPDATE
+			`tabQuotation` SET `status` = 'Expired'
+		WHERE
+			`status` not in ('Ordered', 'Expired', 'Lost', 'Cancelled') AND `valid_till` < %s
+		""", (nowdate()))
 
 @frappe.whitelist()
 def make_sales_invoice(source_name, target_doc=None):


### PR DESCRIPTION
Problem:
Currently, all the Quotations are set to `Expired` if it is past its validity. This has caused a problem because now Quotations have lost its status which was earlier `Lost` or `Ordered`. There is no way to revert it now since changes are on database. I believe many users might have lost this data if they want a report like how many Quotations were ordered and how many were lost.

<img width="532" alt="Screen Shot 2020-01-20 at 8 23 21 PM" src="https://user-images.githubusercontent.com/16913064/72735921-c56a6580-3bc2-11ea-80b5-2009ade96e1e.png">

Solution:
The Quotation which is already set as `Lost` or `Ordered` or `Cancelled` should not be set as `Expired`.
