### PR TITLE
fix: Gives a 404 error when clicked on the Download Required Material…

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.js
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.js
@@ -218,6 +218,10 @@ frappe.ui.form.on('Production Plan', {
 	},
 
 	download_materials_required: function(frm) {
+		if(frm.is_new()) {
+			frappe.throw(__("Please save the document before downloading the material required."));
+			return;
+		}
 		let get_template_url = 'erpnext.manufacturing.doctype.production_plan.production_plan.download_raw_materials';
 		open_url_post(frappe.request.url, { cmd: get_template_url, production_plan: frm.doc.name });
 	},

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.js
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.js
@@ -218,10 +218,6 @@ frappe.ui.form.on('Production Plan', {
 	},
 
 	download_materials_required: function(frm) {
-		if(frm.is_new()) {
-			frappe.throw(__("Please save the document before downloading the material required."));
-			return;
-		}
 		let get_template_url = 'erpnext.manufacturing.doctype.production_plan.production_plan.download_raw_materials';
 		open_url_post(frappe.request.url, { cmd: get_template_url, production_plan: frm.doc.name });
 	},

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.json
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.json
@@ -225,6 +225,7 @@
    "options": "Warehouse"
   },
   {
+   "depends_on": "eval:!doc.__islocal",
    "fieldname": "download_materials_required",
    "fieldtype": "Button",
    "label": "Download Required Materials"
@@ -296,7 +297,7 @@
  "icon": "fa fa-calendar",
  "is_submittable": 1,
  "links": [],
- "modified": "2019-12-04 15:58:50.940460",
+ "modified": "2020-01-21 19:13:10.113854",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Production Plan",


### PR DESCRIPTION
Gives a 404 error when clicked on the Download Required Material button while the form is not saved. 
Fixes: #20355

When we create a new Production Plan and without saving if we click on the Download Required Material button it is showing 404 error (The resource you are looking for is not available.)

![ezgif-6-36540e8adc4a](https://user-images.githubusercontent.com/40858925/72753160-1a6da200-3bea-11ea-918a-fafbc9d9b11d.gif)
