### PR TITLE
feat: Added popup to 'Get Items from Open Material Requests' in Purchase Order

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -180,7 +180,19 @@ erpnext.buying.PurchaseOrderController = erpnext.buying.BuyingController.extend(
 	get_items_from_open_material_requests: function() {
 		erpnext.utils.map_current_doc({
 			method: "erpnext.stock.doctype.material_request.material_request.make_purchase_order_based_on_supplier",
+			args: {
+				supplier: this.frm.doc.supplier
+			},
+			source_doctype: "Material Request",
 			source_name: this.frm.doc.supplier,
+			query_method: "erpnext.stock.doctype.material_request.material_request.get_material_requests_based_on_supplier" ,
+			query_method_args: {
+				supplier: this.frm.doc.supplier
+			},
+			target: this.frm,
+			setters: {
+				company: me.frm.doc.company
+			},
 			get_query_filters: {
 				docstatus: ["!=", 2],
 			}

--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -185,17 +185,15 @@ erpnext.buying.PurchaseOrderController = erpnext.buying.BuyingController.extend(
 			},
 			source_doctype: "Material Request",
 			source_name: this.frm.doc.supplier,
-			query_method: "erpnext.stock.doctype.material_request.material_request.get_material_requests_based_on_supplier" ,
-			query_method_args: {
-				supplier: this.frm.doc.supplier
-			},
 			target: this.frm,
 			setters: {
 				company: me.frm.doc.company
 			},
 			get_query_filters: {
 				docstatus: ["!=", 2],
-			}
+				supplier: this.frm.doc.supplier
+			},
+			get_query_method: "erpnext.stock.doctype.material_request.material_request.get_material_requests_based_on_supplier"
 		});
 	},
 

--- a/erpnext/buying/doctype/purchase_order/purchase_order.json
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.json
@@ -12,8 +12,8 @@
   "supplier",
   "get_items_from_open_material_requests",
   "supplier_name",
-  "company",
   "column_break1",
+  "company",
   "transaction_date",
   "schedule_date",
   "order_confirmation_no",
@@ -171,6 +171,7 @@
   },
   {
    "depends_on": "eval:doc.supplier && doc.docstatus===0 && (!(doc.items && doc.items.length) || (doc.items.length==1 && !doc.items[0].item_code))",
+   "description": "Based on Supplier.",
    "fieldname": "get_items_from_open_material_requests",
    "fieldtype": "Button",
    "label": "Get Items from Open Material Requests"

--- a/erpnext/buying/doctype/purchase_order/purchase_order.json
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.json
@@ -170,8 +170,8 @@
    "search_index": 1
   },
   {
+   "description": "Fetch items based on Default Supplier.",
    "depends_on": "eval:doc.supplier && doc.docstatus===0 && (!(doc.items && doc.items.length) || (doc.items.length==1 && !doc.items[0].item_code))",
-   "description": "Based on Supplier.",
    "fieldname": "get_items_from_open_material_requests",
    "fieldtype": "Button",
    "label": "Get Items from Open Material Requests"

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -582,7 +582,7 @@ erpnext.utils.map_current_doc = function(opts) {
 				"method": opts.method,
 				"source_names": opts.source_name,
 				"target_doc": cur_frm.doc,
-				'args': opts.args
+				"args": opts.args
 			},
 			callback: function(r) {
 				if(!r.exc) {
@@ -600,6 +600,8 @@ erpnext.utils.map_current_doc = function(opts) {
 			date_field: opts.date_field || undefined,
 			setters: opts.setters,
 			get_query: opts.get_query,
+			method: opts.query_method,
+			method_args: opts.query_method_args,
 			action: function(selections, args) {
 				let values = selections;
 				if(values.length === 0){

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -514,9 +514,18 @@ erpnext.utils.update_child_items = function(opts) {
 }
 
 erpnext.utils.map_current_doc = function(opts) {
-	if(opts.get_query_filters) {
-		opts.get_query = function() {
-			return {filters: opts.get_query_filters};
+	let query_args = {};
+	if (opts.get_query_filters) {
+		query_args.filters = opts.get_query_filters;
+	}
+
+	if (opts.get_query_method) {
+		query_args.query = opts.get_query_method;
+	}
+
+	if (query_args.filters || query_args.query) {
+		opts.get_query = () => {
+			return query_args;
 		}
 	}
 	var _map = function() {
@@ -600,8 +609,6 @@ erpnext.utils.map_current_doc = function(opts) {
 			date_field: opts.date_field || undefined,
 			setters: opts.setters,
 			get_query: opts.get_query,
-			method: opts.query_method,
-			method_args: opts.query_method_args,
 			action: function(selections, args) {
 				let values = selections;
 				if(values.length === 0){


### PR DESCRIPTION
Depends on https://github.com/frappe/frappe/pull/9384 (UX) and https://github.com/frappe/frappe/pull/9334

- 'Get Items from Open Material Requests' directly fetched and mapped all Material Requests from the supplier.
- Often it timed out for large number of Material Requests

**After change:**
- Popup with filtered Material Requests based on Supplier on button click.
- Only 20 MRs shown initially and then incrementally on clicking 'More'.

![_idk](https://user-images.githubusercontent.com/25857446/73686010-37779a00-46ed-11ea-8a4b-78da6fe239e7.gif)

- [Documentation](https://github.com/frappe/erpnext_documentation/pull/29)
 