### PR TITLE
fix: Product Page non-stock item status

### DIFF
--- a/erpnext/shopping_cart/product_info.py
+++ b/erpnext/shopping_cart/product_info.py
@@ -7,7 +7,7 @@ import frappe
 from erpnext.shopping_cart.cart import _get_cart_quotation
 from erpnext.shopping_cart.doctype.shopping_cart_settings.shopping_cart_settings \
 	import get_shopping_cart_settings, show_quantity_in_website
-from erpnext.utilities.product import get_price, get_qty_in_stock
+from erpnext.utilities.product import get_price, get_qty_in_stock, get_non_stock_item_status
 
 @frappe.whitelist(allow_guest=True)
 def get_product_info_for_website(item_code):
@@ -31,7 +31,7 @@ def get_product_info_for_website(item_code):
 	product_info = {
 		"price": price,
 		"stock_qty": stock_status.stock_qty,
-		"in_stock": stock_status.in_stock if stock_status.is_stock_item else 1,
+		"in_stock": stock_status.in_stock if stock_status.is_stock_item else get_non_stock_item_status(item_code, "website_warehouse"),
 		"qty": 0,
 		"uom": frappe.db.get_value("Item", item_code, "stock_uom"),
 		"show_stock_qty": show_quantity_in_website(),

--- a/erpnext/utilities/product.py
+++ b/erpnext/utilities/product.py
@@ -124,3 +124,11 @@ def get_price(item_code, price_list, customer_group, company, qty=1):
 					price_obj["formatted_price"] = ""
 
 			return price_obj
+
+def get_non_stock_item_status(item_code, item_warehouse_field):
+#if item belongs to product bundle, check if bundle items are in stock
+	if frappe.db.exists("Product Bundle", item_code):
+		items = frappe.get_doc("Product Bundle", item_code).get_all_children()
+		return all([ get_qty_in_stock(d.item_code, item_warehouse_field).in_stock for d in items ])
+	else:
+		return 1


### PR DESCRIPTION
If the Item is a non-stock item the following scenario for setting it's status was not considered:
- Item is a Product Bundle template item and one of it's bundle items is out of stock

**After fix:**
- If non-stock item, check if it is a Product Bundle Item
- If yes, it will show In Stock only if **ALL** bundle items are in stock 