### PR TITLE
fix: lead date comparison issue

### DIFF
--- a/erpnext/crm/doctype/lead/lead.py
+++ b/erpnext/crm/doctype/lead/lead.py
@@ -62,7 +62,8 @@ class Lead(SellingController):
 		if self.contact_date and getdate(self.contact_date) < getdate(nowdate()):
 			frappe.throw(_("Next Contact Date cannot be in the past"))
 
-		if self.ends_on and self.contact_date and (self.ends_on < self.contact_date):
+		if (self.ends_on and self.contact_date and
+			(getdate(self.ends_on) < getdate(self.contact_date))):
 			frappe.throw(_("Ends On date cannot be before Next Contact Date."))
 
 	def on_update(self):


### PR DESCRIPTION
**Issue**

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2020-01-16/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-2020-01-16/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-2020-01-16/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2020-01-16/apps/frappe/frappe/handler.py", line 61, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2020-01-16/apps/frappe/frappe/__init__.py", line 1042, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2020-01-16/apps/frappe/frappe/client.py", line 128, in set_value
    doc.save()
  File "/home/frappe/benches/bench-2020-01-16/apps/frappe/frappe/model/document.py", line 272, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-2020-01-16/apps/frappe/frappe/model/document.py", line 308, in _save
    self.run_before_save_methods()
  File "/home/frappe/benches/bench-2020-01-16/apps/frappe/frappe/model/document.py", line 888, in run_before_save_methods
    self.run_method("validate")
  File "/home/frappe/benches/bench-2020-01-16/apps/frappe/frappe/model/document.py", line 787, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-2020-01-16/apps/frappe/frappe/model/document.py", line 1058, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-2020-01-16/apps/frappe/frappe/model/document.py", line 1041, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-2020-01-16/apps/frappe/frappe/model/document.py", line 781, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-2020-01-16/apps/erpnext/erpnext/crm/doctype/lead/lead.py", line 57, in validate
    (self.ends_on < self.contact_date):
TypeError: '<' not supported between instances of 'datetime.datetime' and 'str'
```