### PR TITLE
fix: unlink references from batch on cancellation of stock transactions

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -866,7 +866,7 @@ class PurchaseInvoice(BuyingController):
 		# because updating ordered qty in bin depends upon updated ordered qty in PO
 		if self.update_stock == 1:
 			self.update_stock_ledger()
-			self.unlink_reference_from_batch()
+			self.delete_auto_created_batches()
 
 		self.make_gl_entries_on_cancel()
 		self.update_project()

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -866,6 +866,7 @@ class PurchaseInvoice(BuyingController):
 		# because updating ordered qty in bin depends upon updated ordered qty in PO
 		if self.update_stock == 1:
 			self.update_stock_ledger()
+			self.unlink_reference_from_batch()
 
 		self.make_gl_entries_on_cancel()
 		self.update_project()

--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -235,12 +235,16 @@ class StockController(AccountsController):
 				frappe.throw(_("{0} {1}: Cost Center is mandatory for Item {2}").format(
 					_(self.doctype), self.name, item.get("item_code")))
 
-	def unlink_reference_from_batch(self):
-		frappe.db.sql(""" UPDATE `tabBatch`
-			SET reference_doctype = NULL, reference_name = NULL
-			WHERE
-				reference_doctype = %s and reference_name = %s
-		""", (self.doctype, self.name))
+	def delete_auto_created_batches(self):
+		for d in self.items:
+			if not d.batch_no: continue
+
+			d.batch_no = None
+			d.db_set("batch_no", None)
+
+		for data in frappe.get_all("Batch",
+			{'reference_name': self.name, 'reference_doctype': self.doctype}):
+			frappe.delete_doc("Batch", data.name)
 
 	def get_sl_entries(self, d, args):
 		sl_dict = frappe._dict({

--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -235,6 +235,13 @@ class StockController(AccountsController):
 				frappe.throw(_("{0} {1}: Cost Center is mandatory for Item {2}").format(
 					_(self.doctype), self.name, item.get("item_code")))
 
+	def unlink_reference_from_batch(self):
+		frappe.db.sql(""" UPDATE `tabBatch`
+			SET reference_doctype = NULL, reference_name = NULL
+			WHERE
+				reference_doctype = %s and reference_name = %s
+		""", (self.doctype, self.name))
+
 	def get_sl_entries(self, d, args):
 		sl_dict = frappe._dict({
 			"item_code": d.get("item_code", None),

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -195,6 +195,7 @@ class PurchaseReceipt(BuyingController):
 		# because updating ordered qty in bin depends upon updated ordered qty in PO
 		self.update_stock_ledger()
 		self.make_gl_entries_on_cancel()
+		self.unlink_reference_from_batch()
 
 	def get_current_stock(self):
 		for d in self.get('supplied_items'):

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -195,7 +195,7 @@ class PurchaseReceipt(BuyingController):
 		# because updating ordered qty in bin depends upon updated ordered qty in PO
 		self.update_stock_ledger()
 		self.make_gl_entries_on_cancel()
-		self.unlink_reference_from_batch()
+		self.delete_auto_created_batches()
 
 	def get_current_stock(self):
 		for d in self.get('supplied_items'):

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -110,6 +110,7 @@ class StockEntry(StockController):
 		self.update_cost_in_project()
 		self.update_transferred_qty()
 		self.update_quality_inspection()
+		self.unlink_reference_from_batch()
 
 	def set_job_card_data(self):
 		if self.job_card and not self.work_order:

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -110,7 +110,7 @@ class StockEntry(StockController):
 		self.update_cost_in_project()
 		self.update_transferred_qty()
 		self.update_quality_inspection()
-		self.unlink_reference_from_batch()
+		self.delete_auto_created_batches()
 
 	def set_job_card_data(self):
 		if self.job_card and not self.work_order:


### PR DESCRIPTION
While deleting the batch getting an error that "Batch is linked with stock entry" even if stock entry has been cancelled. If tries to delete cancelled stock entry then getting an error that "stock entry linked with batch"