### PR TITLE
fix: Finance book filtering in financial statements

### DIFF
--- a/erpnext/accounts/report/balance_sheet/balance_sheet.js
+++ b/erpnext/accounts/report/balance_sheet/balance_sheet.js
@@ -14,6 +14,7 @@ frappe.require("assets/erpnext/js/financial_statements.js", function() {
 	frappe.query_reports["Balance Sheet"]["filters"].push({
 		"fieldname": "include_default_book_entries",
 		"label": __("Include Default Book Entries"),
-		"fieldtype": "Check"
+		"fieldtype": "Check",
+		"default": 1
 	});
 });

--- a/erpnext/accounts/report/cash_flow/cash_flow.js
+++ b/erpnext/accounts/report/cash_flow/cash_flow.js
@@ -20,7 +20,8 @@ frappe.require("assets/erpnext/js/financial_statements.js", function() {
 		{
 			"fieldname": "include_default_book_entries",
 			"label": __("Include Default Book Entries"),
-			"fieldtype": "Check"
+			"fieldtype": "Check",
+			"default": 1
 		}
 	);
 });

--- a/erpnext/accounts/report/cash_flow/cash_flow.py
+++ b/erpnext/accounts/report/cash_flow/cash_flow.py
@@ -130,11 +130,11 @@ def get_account_type_based_gl_data(company, start_date, end_date, account_type, 
 	filters = frappe._dict(filters)
 
 	if filters.finance_book:
-		cond = " and finance_book = %s" %(frappe.db.escape(filters.finance_book))
+		cond = " AND (finance_book in (%s, '') OR finance_book IS NULL)" %(frappe.db.escape(filters.finance_book))
 		if filters.include_default_book_entries:
 			company_fb = frappe.db.get_value("Company", company, 'default_finance_book')
 
-			cond = """ and ifnull(finance_book, '') in (%s, %s, '')
+			cond = """ AND (finance_book in (%s, %s, '') OR finance_book IS NULL)
 				""" %(frappe.db.escape(filters.finance_book), frappe.db.escape(company_fb))
 
 	gl_sum = frappe.db.sql_list("""

--- a/erpnext/accounts/report/cash_flow/cash_flow.py
+++ b/erpnext/accounts/report/cash_flow/cash_flow.py
@@ -134,7 +134,7 @@ def get_account_type_based_gl_data(company, start_date, end_date, account_type, 
 		if filters.include_default_book_entries:
 			company_fb = frappe.db.get_value("Company", company, 'default_finance_book')
 
-			cond = """ and finance_book in (%s, %s)
+			cond = """ and ifnull(finance_book, '') in (%s, %s, '')
 				""" %(frappe.db.escape(filters.finance_book), frappe.db.escape(company_fb))
 
 	gl_sum = frappe.db.sql_list("""

--- a/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js
+++ b/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js
@@ -58,7 +58,8 @@ frappe.query_reports["Consolidated Financial Statement"] = {
 		{
 			"fieldname": "include_default_book_entries",
 			"label": __("Include Default Book Entries"),
-			"fieldtype": "Check"
+			"fieldtype": "Check",
+			"default": 1
 		}
 	]
 }

--- a/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py
+++ b/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py
@@ -389,9 +389,9 @@ def get_additional_conditions(from_date, ignore_closing_entries, filters):
 
 	if filters.get("finance_book"):
 		if filters.get("include_default_book_entries"):
-			additional_conditions.append("finance_book in (%(finance_book)s, %(company_fb)s)")
+			additional_conditions.append("ifnull(finance_book) in (%(finance_book)s, %(company_fb)s, '')")
 		else:
-			additional_conditions.append("finance_book in (%(finance_book)s)")
+			additional_conditions.append("ifnull(finance_book) in (%(finance_book)s, '')")
 
 	return " and {}".format(" and ".join(additional_conditions)) if additional_conditions else ""
 

--- a/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py
+++ b/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py
@@ -389,9 +389,9 @@ def get_additional_conditions(from_date, ignore_closing_entries, filters):
 
 	if filters.get("finance_book"):
 		if filters.get("include_default_book_entries"):
-			additional_conditions.append("ifnull(finance_book) in (%(finance_book)s, %(company_fb)s, '')")
+			additional_conditions.append("(finance_book in (%(finance_book)s, %(company_fb)s, '') OR finance_book IS NULL)")
 		else:
-			additional_conditions.append("ifnull(finance_book) in (%(finance_book)s, '')")
+			additional_conditions.append("(finance_book in (%(finance_book)s, '') OR finance_book IS NULL)")
 
 	return " and {}".format(" and ".join(additional_conditions)) if additional_conditions else ""
 

--- a/erpnext/accounts/report/financial_statements.py
+++ b/erpnext/accounts/report/financial_statements.py
@@ -408,9 +408,9 @@ def get_additional_conditions(from_date, ignore_closing_entries, filters):
 
 		if filters.get("finance_book"):
 			if filters.get("include_default_book_entries"):
-				additional_conditions.append("ifnull(finance_book, '') in (%(finance_book)s, %(company_fb)s, '')")
+				additional_conditions.append("(finance_book in (%(finance_book)s, %(company_fb)s, '') OR finance_book IS NULL)")
 			else:
-				additional_conditions.append("ifnull(finance_book, '') in (%(finance_book)s, '')")
+				additional_conditions.append("(finance_book in (%(finance_book)s, '') OR finance_book IS NULL)")
 
 	if accounting_dimensions:
 		for dimension in accounting_dimensions:

--- a/erpnext/accounts/report/financial_statements.py
+++ b/erpnext/accounts/report/financial_statements.py
@@ -408,9 +408,9 @@ def get_additional_conditions(from_date, ignore_closing_entries, filters):
 
 		if filters.get("finance_book"):
 			if filters.get("include_default_book_entries"):
-				additional_conditions.append("finance_book in (%(finance_book)s, %(company_fb)s)")
+				additional_conditions.append("ifnull(finance_book, '') in (%(finance_book)s, %(company_fb)s, '')")
 			else:
-				additional_conditions.append("finance_book in (%(finance_book)s)")
+				additional_conditions.append("ifnull(finance_book, '') in (%(finance_book)s, '')")
 
 	if accounting_dimensions:
 		for dimension in accounting_dimensions:

--- a/erpnext/accounts/report/general_ledger/general_ledger.js
+++ b/erpnext/accounts/report/general_ledger/general_ledger.js
@@ -154,7 +154,8 @@ frappe.query_reports["General Ledger"] = {
 		{
 			"fieldname": "include_default_book_entries",
 			"label": __("Include Default Book Entries"),
-			"fieldtype": "Check"
+			"fieldtype": "Check",
+			"default": 1
 		}
 	]
 }

--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -184,7 +184,7 @@ def get_conditions(filters):
 
 	if filters.get("finance_book"):
 		if filters.get("include_default_book_entries"):
-			conditions.append("finance_book in (%(finance_book)s, %(company_fb)s)")
+			conditions.append("(finance_book in (%(finance_book)s, %(company_fb)s, '') OR finance_book IS NULL)")
 		else:
 			conditions.append("finance_book in (%(finance_book)s)")
 

--- a/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.js
+++ b/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.js
@@ -23,7 +23,8 @@ frappe.require("assets/erpnext/js/financial_statements.js", function() {
 		{
 			"fieldname": "include_default_book_entries",
 			"label": __("Include Default Book Entries"),
-			"fieldtype": "Check"
+			"fieldtype": "Check",
+			"default": 1
 		}
 	);
 });

--- a/erpnext/accounts/report/trial_balance/trial_balance.js
+++ b/erpnext/accounts/report/trial_balance/trial_balance.js
@@ -85,7 +85,8 @@ frappe.require("assets/erpnext/js/financial_statements.js", function() {
 			{
 				"fieldname": "include_default_book_entries",
 				"label": __("Include Default Book Entries"),
-				"fieldtype": "Check"
+				"fieldtype": "Check",
+				"default": 1
 			}
 		],
 		"formatter": erpnext.financial_statements.formatter,

--- a/erpnext/accounts/report/trial_balance/trial_balance.py
+++ b/erpnext/accounts/report/trial_balance/trial_balance.py
@@ -103,9 +103,9 @@ def get_rootwise_opening_balances(filters, report_type):
 			where lft >= %s and rgt <= %s)""" % (lft, rgt)
 
 	if filters.finance_book:
-		fb_conditions = " and finance_book = %(finance_book)s"
+		fb_conditions = " AND finance_book = %(finance_book)s"
 		if filters.include_default_book_entries:
-			fb_conditions = " and (finance_book in (%(finance_book)s, %(company_fb)s))"
+			fb_conditions = " AND (finance_book in (%(finance_book)s, %(company_fb)s, '') OR finance_book IS NULL)"
 
 		additional_conditions += fb_conditions
 


### PR DESCRIPTION
**Problem:**
While applying a filter on finance book in financial statements the records with only financial book set are displayed

**Solution:**
After this fix on application of finance book filter records with no finance book will also be seen along with the filtered finance book records.