### PR TITLE
feat: add tax category in pos profile

### DIFF
--- a/erpnext/accounts/doctype/pos_profile/pos_profile.json
+++ b/erpnext/accounts/doctype/pos_profile/pos_profile.json
@@ -3,6 +3,7 @@
  "autoname": "Prompt",
  "creation": "2013-05-24 12:15:51",
  "doctype": "DocType",
+ "engine": "InnoDB",
  "field_order": [
   "disabled",
   "section_break_2",
@@ -50,6 +51,7 @@
   "income_account",
   "expense_account",
   "taxes_and_charges",
+  "tax_category",
   "apply_discount_on",
   "accounting_dimensions_section",
   "cost_center",
@@ -381,11 +383,17 @@
   {
    "fieldname": "dimension_col_break",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "tax_category",
+   "fieldtype": "Link",
+   "label": "Tax Category",
+   "options": "Tax Category"
   }
  ],
  "icon": "icon-cog",
  "idx": 1,
- "modified": "2019-05-25 22:56:30.352693",
+ "modified": "2020-01-24 15:52:03.797701",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Profile",

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -420,7 +420,9 @@ class SalesInvoice(SellingController):
 
 		if pos:
 			self.allow_print_before_pay = pos.allow_print_before_pay
-			self.tax_category = pos.get("tax_category")
+			
+			if not for_validate:
+				self.tax_category = pos.get("tax_category")
 
 			if not for_validate and not self.customer:
 				self.customer = pos.customer

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -420,6 +420,7 @@ class SalesInvoice(SellingController):
 
 		if pos:
 			self.allow_print_before_pay = pos.allow_print_before_pay
+			self.tax_category = pos.get("tax_category")
 
 			if not for_validate and not self.customer:
 				self.customer = pos.customer


### PR DESCRIPTION
Added Tax Category field in POS Profile form.
While loading POS the tax category in Sales Invoice will be set to it. however on Customer/Address selection it may get overwritten.