### PR TITLE
fix: Parent company defaulting on creation of new company

### DIFF
--- a/erpnext/hr/doctype/staffing_plan/test_staffing_plan.py
+++ b/erpnext/hr/doctype/staffing_plan/test_staffing_plan.py
@@ -14,7 +14,7 @@ test_dependencies = ["Designation"]
 class TestStaffingPlan(unittest.TestCase):
 	def test_staffing_plan(self):
 		_set_up()
-		frappe.db.set_value("Company", "_Test Company", "is_group", 1)
+		frappe.db.set_value("Company", "_Test Company 3", "is_group", 1)
 		if frappe.db.exists("Staffing Plan", "Test"):
 			return
 		staffing_plan = frappe.new_doc("Staffing Plan")
@@ -36,7 +36,7 @@ class TestStaffingPlan(unittest.TestCase):
 		if frappe.db.exists("Staffing Plan", "Test 1"):
 			return
 		staffing_plan = frappe.new_doc("Staffing Plan")
-		staffing_plan.company = "_Test Company"
+		staffing_plan.company = "_Test Company 3"
 		staffing_plan.name = "Test 1"
 		staffing_plan.from_date = nowdate()
 		staffing_plan.to_date = add_days(nowdate(), 10)
@@ -52,7 +52,7 @@ class TestStaffingPlan(unittest.TestCase):
 		if frappe.db.exists("Staffing Plan", "Test"):
 			return
 		staffing_plan = frappe.new_doc("Staffing Plan")
-		staffing_plan.company = "_Test Company"
+		staffing_plan.company = "_Test Company 3"
 		staffing_plan.name = "Test"
 		staffing_plan.from_date = nowdate()
 		staffing_plan.to_date = add_days(nowdate(), 10)
@@ -88,11 +88,10 @@ def make_company():
 	if frappe.db.exists("Company", "_Test Company 10"):
 		return
 
-	frappe.db.set_value("Company", "_Test Company", "is_group", 1)
 	company = frappe.new_doc("Company")
 	company.company_name = "_Test Company 10"
 	company.abbr = "_TC10"
-	company.parent_company = "_Test Company 1"
+	company.parent_company = "_Test Company 3"
 	company.default_currency = "INR"
 	company.country = "Pakistan"
 	company.insert()

--- a/erpnext/hr/doctype/staffing_plan/test_staffing_plan.py
+++ b/erpnext/hr/doctype/staffing_plan/test_staffing_plan.py
@@ -87,10 +87,12 @@ def _set_up():
 def make_company():
 	if frappe.db.exists("Company", "_Test Company 10"):
 		return
+
+	frappe.db.set_value("Company", "_Test Company", "is_group", 1)
 	company = frappe.new_doc("Company")
 	company.company_name = "_Test Company 10"
 	company.abbr = "_TC10"
-	company.parent_company = "_Test Company 3"
+	company.parent_company = "_Test Company 1"
 	company.default_currency = "INR"
 	company.country = "Pakistan"
 	company.insert()

--- a/erpnext/hr/doctype/staffing_plan/test_staffing_plan.py
+++ b/erpnext/hr/doctype/staffing_plan/test_staffing_plan.py
@@ -90,7 +90,7 @@ def make_company():
 	company = frappe.new_doc("Company")
 	company.company_name = "_Test Company 10"
 	company.abbr = "_TC10"
-	company.parent_company = "_Test Company"
+	company.parent_company = "_Test Company 3"
 	company.default_currency = "INR"
 	company.country = "Pakistan"
 	company.insert()

--- a/erpnext/setup/doctype/company/company.js
+++ b/erpnext/setup/doctype/company/company.js
@@ -4,6 +4,15 @@
 frappe.provide("erpnext.company");
 
 frappe.ui.form.on("Company", {
+	onload: function(frm) {
+		if (frm.doc.__islocal && frm.doc.parent_company) {
+			frappe.db.get_value('Company', frm.doc.parent_company, 'is_group', (r) => {
+				if (!r.is_group) {
+					frm.set_value('parent_company', '')
+				}
+			});
+		}
+	},
 	setup: function(frm) {
 		erpnext.company.setup_queries(frm);
 		frm.set_query("hra_component", function(){

--- a/erpnext/setup/doctype/company/company.js
+++ b/erpnext/setup/doctype/company/company.js
@@ -8,7 +8,7 @@ frappe.ui.form.on("Company", {
 		if (frm.doc.__islocal && frm.doc.parent_company) {
 			frappe.db.get_value('Company', frm.doc.parent_company, 'is_group', (r) => {
 				if (!r.is_group) {
-					frm.set_value('parent_company', '')
+					frm.set_value('parent_company', '');
 				}
 			});
 		}

--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -47,6 +47,7 @@ class Company(NestedSet):
 		self.validate_perpetual_inventory()
 		self.check_country_change()
 		self.set_chart_of_accounts()
+		self.validate_parent_company()
 
 	def validate_abbr(self):
 		if not self.abbr:
@@ -188,6 +189,13 @@ class Company(NestedSet):
 		if self.parent_company:
 			self.create_chart_of_accounts_based_on = "Existing Company"
 			self.existing_company = self.parent_company
+
+	def validate_parent_company(self):
+		if self.parent_company:
+			is_group = frappe.get_value('Company', self.parent_company, 'is_group')
+
+			if not is_group:
+				frappe.throw(_("Parent Company must be a group company"))
 
 	def set_default_accounts(self):
 		default_accounts = {


### PR DESCRIPTION
On creation of a new company the parent company is fetched from the Global defaults irrespective if it is a group company or not