### PR TITLE
fix: 'In Qty' and 'Out Qty' columns in Report Stock Ledger

### DIFF
--- a/erpnext/stock/report/stock_ledger/stock_ledger.js
+++ b/erpnext/stock/report/stock_ledger/stock_ledger.js
@@ -83,6 +83,9 @@ frappe.query_reports["Stock Ledger"] = {
 		if (column.fieldname == "out_qty" && data.out_qty < 0) {
 			value = "<span style='color:red'>" + value + "</span>";
 		}
+		else if (column.fieldname == "in_qty" && data.in_qty > 0) {
+			value = "<span style='color:green'>" + value + "</span>";
+		}
 
 		return value;
 	},

--- a/erpnext/stock/report/stock_ledger/stock_ledger.py
+++ b/erpnext/stock/report/stock_ledger/stock_ledger.py
@@ -38,7 +38,7 @@ def execute(filters=None):
 
 			sle.update({
 				"qty_after_transaction": actual_qty,
-				"stock_value": stock_value,
+				"stock_value": stock_value
 			})
 
 		sle.update({

--- a/erpnext/stock/report/stock_ledger/stock_ledger.py
+++ b/erpnext/stock/report/stock_ledger/stock_ledger.py
@@ -39,9 +39,12 @@ def execute(filters=None):
 			sle.update({
 				"qty_after_transaction": actual_qty,
 				"stock_value": stock_value,
-				"in_qty": max(sle.actual_qty, 0),
-				"out_qty": min(sle.actual_qty, 0)
 			})
+
+		sle.update({
+			"in_qty": max(sle.actual_qty, 0),
+			"out_qty": min(sle.actual_qty, 0)
+		})
 
 		# get the name of the item that was produced using this item
 		if sle.voucher_type == "Stock Entry":


### PR DESCRIPTION
Minor Enhancement on https://github.com/frappe/erpnext/pull/19708

**Before Fix:**
- **In Qty** and **Out Qty** columns showed data only if Batch filter was populated
![Screenshot 2020-01-28 at 4 14 48 PM](https://user-images.githubusercontent.com/25857446/73257194-50fa7c80-41e9-11ea-9b8a-1a2d059ae929.png)

**After Fix:**
- **In Qty** and **Out Qty** columns will show data for all rows irrespective
- Added colour for quick distinguishing
![Screenshot 2020-01-28 at 4 03 56 PM](https://user-images.githubusercontent.com/25857446/73256815-a5512c80-41e8-11ea-812b-54cf4bb24c1d.png)
