### PR TITLE
fix: linking party in calendar event of appointment

### DIFF
--- a/erpnext/crm/doctype/appointment/appointment.py
+++ b/erpnext/crm/doctype/appointment/appointment.py
@@ -174,7 +174,7 @@ class Appointment(Document):
 			'status': 'Open',
 			'type': 'Public',
 			'send_reminder': frappe.db.get_single_value('Appointment Booking Settings', 'email_reminders'),
-			'event_participants': [dict(reference_doctype='Lead', reference_docname=self.party)]
+			'event_participants': [dict(reference_doctype=self.appointment_with, reference_docname=self.party)]
 		})
 		employee = _get_employee_from_user(self._assign)
 		if employee:


### PR DESCRIPTION
Add link to calendar event participants based on `appointment_with` 