### PR TITLE
fix: missing plus button in request for quotaion for supplier quotation

### DIFF
--- a/erpnext/buying/doctype/request_for_quotation/request_for_quotation.js
+++ b/erpnext/buying/doctype/request_for_quotation/request_for_quotation.js
@@ -9,7 +9,7 @@ cur_frm.add_fetch('contact', 'email_id', 'email_id')
 frappe.ui.form.on("Request for Quotation",{
 	setup: function(frm) {
 		frm.custom_make_buttons = {
-			'Supplier Quotation': 'Supplier Quotation'
+			'Supplier Quotation': 'Create'
 		}
 
 		frm.fields_dict["suppliers"].grid.get_field("contact").get_query = function(doc, cdt, cdn) {


### PR DESCRIPTION
After creating a RFQ and submitting it - Supplier Quotation in the dashboard does not have a plus sign to create a quotation directly from there.

before:
<img width="1280" alt="Screenshot 2020-01-29 at 9 39 13 AM" src="https://user-images.githubusercontent.com/6195660/73327272-2510e280-424d-11ea-884e-bf743dcbdb7b.png">
after:
<img width="1280" alt="Screenshot 2020-01-29 at 9 38 45 AM" src="https://user-images.githubusercontent.com/6195660/73327282-2d691d80-424d-11ea-988e-637f93c63ca5.png">
