### PR TITLE
fix(regional): byte strings in DATEV Report

### DIFF
--- a/erpnext/regional/report/datev/datev.py
+++ b/erpnext/regional/report/datev/datev.py
@@ -160,7 +160,7 @@ def get_gl_entries(filters, as_dict):
 		where gl.company = %(company)s 
 		and DATE(gl.posting_date) >= %(from_date)s
 		and DATE(gl.posting_date) <= %(to_date)s
-		order by 'Belegdatum', gl.voucher_no""", filters, as_dict=as_dict, as_utf8=1)
+		order by 'Belegdatum', gl.voucher_no""", filters, as_dict=as_dict)
 
 	return gl_entries
 


### PR DESCRIPTION
Remove `as_utf8=True`from `frappe.db.sql` query.

![image](https://user-images.githubusercontent.com/14891507/73405443-2ea15580-42f4-11ea-9301-535c4ad880cf.png)

fix #20469