### PR TITLE
fix: rename breadcrumb for brand doctype to stock

### DIFF
--- a/erpnext/public/js/conf.js
+++ b/erpnext/public/js/conf.js
@@ -50,7 +50,7 @@ $.extend(frappe.breadcrumbs.preferred, {
 	"Territory": "Selling",
 	"Sales Person": "Selling",
 	"Sales Partner": "Selling",
-	"Brand": "Selling"
+	"Brand": "Stock"
 });
 
 $.extend(frappe.breadcrumbs.module_map, {


### PR DESCRIPTION
Changes made:
- Breadcrumb for Brand DocType renamed from Selling to Stock

Reason for change:
- [ERPNext Documentation for Brand](https://erpnext.com/docs/user/manual/en/selling/brand) shows the Brand DocType to exist under Selling -> Sales
- However, it can only be found under Stock -> Settings
![image](https://user-images.githubusercontent.com/33743873/73426495-7f4b9980-435a-11ea-9e89-5799d6eacde9.png)
- Hence, the breadcrumb for it has been renamed to reflect the existing placement
![image](https://user-images.githubusercontent.com/33743873/73426580-bb7efa00-435a-11ea-99eb-58e3e58633bd.png)

The above mentioned documentation will have to be modified to reflect this change

