### PR TITLE
fix: employee checkin doctype time permissions

### DIFF
--- a/erpnext/hr/doctype/employee_checkin/employee_checkin.js
+++ b/erpnext/hr/doctype/employee_checkin/employee_checkin.js
@@ -2,7 +2,9 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Employee Checkin', {
-	// refresh: function(frm) {
-
-	// }
+	setup: (frm) => {
+		if(!frm.doc.time) {
+			frm.set_value("time", frappe.datetime.now_datetime());
+		}
+	}
 });

--- a/erpnext/hr/doctype/employee_checkin/employee_checkin.json
+++ b/erpnext/hr/doctype/employee_checkin/employee_checkin.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "allow_import": 1,
  "autoname": "EMP-CKIN-.MM.-.YYYY.-.######",
  "creation": "2019-06-10 11:56:34.536413",
@@ -23,7 +24,6 @@
   {
    "fieldname": "employee",
    "fieldtype": "Link",
-   "in_list_view": 1,
    "label": "Employee",
    "options": "Employee",
    "reqd": 1
@@ -32,14 +32,17 @@
    "fetch_from": "employee.employee_name",
    "fieldname": "employee_name",
    "fieldtype": "Data",
+   "in_list_view": 1,
    "label": "Employee Name",
    "read_only": 1
   },
   {
    "fieldname": "log_type",
    "fieldtype": "Select",
+   "in_list_view": 1,
    "label": "Log Type",
-   "options": "\nIN\nOUT"
+   "options": "\nIN\nOUT",
+   "reqd": 1
   },
   {
    "fieldname": "shift",
@@ -58,6 +61,7 @@
    "fieldtype": "Datetime",
    "in_list_view": 1,
    "label": "Time",
+   "permlevel": 1,
    "reqd": 1
   },
   {
@@ -103,7 +107,8 @@
    "label": "Shift Actual End"
   }
  ],
- "modified": "2019-07-23 23:47:33.975263",
+ "links": [],
+ "modified": "2020-01-23 04:57:42.551355",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Employee Checkin",
@@ -147,9 +152,58 @@
    "role": "HR User",
    "share": 1,
    "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "read": 1,
+   "role": "Employee",
+   "write": 1
+  },
+  {
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "permlevel": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "permlevel": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "HR Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "permlevel": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "HR User",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "permlevel": 1,
+   "read": 1,
+   "role": "Employee"
   }
  ],
  "sort_field": "modified",
  "sort_order": "ASC",
+ "title_field": "employee_name",
  "track_changes": 1
 }


### PR DESCRIPTION
Changes made:
- Employee Checkin list view modified to show Employee Name, Log Type and Time.
- Time field in Employee Checkin Doctype is set to current time automatically if not set.
- Time field in DocType can only be set / changed by HR Manager, HR User and System Manager.
- Employee cannot set/edit Time field in Employee Checkin DocType.
- Log Type field made mandatory.

Steps to test:
1. Create a checkin/checkout as a User with only Employee permissions
1. Time field should not be visible or editable
1. Open the same document as an HR Manager, HR User or System Manager
1. Datetime field should be visible and editable
1. Doc cannot be saved without setting Log Type