### PR TITLE
fix: rename breadcrumb for Brand DocType from Selling to Stock

### DIFF
--- a/erpnext/public/js/conf.js
+++ b/erpnext/public/js/conf.js
@@ -50,7 +50,7 @@ $.extend(frappe.breadcrumbs.preferred, {
 	"Territory": "Selling",
 	"Sales Person": "Selling",
 	"Sales Partner": "Selling",
-	"Brand": "Selling"
+	"Brand": "Stock"
 });
 
 $.extend(frappe.breadcrumbs.module_map, {


### PR DESCRIPTION
Changes made:
- Breadcrumb for Brand DocType renamed from Selling to Stock

Reason for change:
1. [ERPNext Documentation for Brand](https://erpnext.com/docs/user/manual/en/selling/brand) shows the Brand DocType to exist under Selling -> Sales
1. However, it can only be found under Stock -> Settings
![image](https://user-images.githubusercontent.com/33743873/73427609-2c271600-435d-11ea-9e56-50648db4b938.png)
1. Hence, the breadcrumb for it has been renamed to reflect the existing placement
![image](https://user-images.githubusercontent.com/33743873/73427616-2f220680-435d-11ea-9bb9-ea2da554670f.png)


The above mentioned documentation will have to be modified to reflect this change