### PR TITLE
feat: request for work from home marked in attendance

### DIFF
--- a/erpnext/hr/doctype/attendance_request/attendance_request.py
+++ b/erpnext/hr/doctype/attendance_request/attendance_request.py
@@ -38,6 +38,8 @@ class AttendanceRequest(Document):
 				attendance.employee_name = self.employee_name
 				if self.half_day and date_diff(getdate(self.half_day_date), getdate(attendance_date)) == 0:
 					attendance.status = "Half Day"
+				elif self.reason == "Work From Home":
+					attendance.status = "Work From Home"
 				else:
 					attendance.status = "Present"
 				attendance.attendance_date = attendance_date

--- a/erpnext/hr/doctype/attendance_request/test_attendance_request.py
+++ b/erpnext/hr/doctype/attendance_request/test_attendance_request.py
@@ -13,7 +13,28 @@ class TestAttendanceRequest(unittest.TestCase):
 		for doctype in ["Attendance Request", "Attendance"]:
 			frappe.db.sql("delete from `tab{doctype}`".format(doctype=doctype))
 
-	def test_attendance_request(self):
+	def test_on_duty_attendance_request(self):
+		today = nowdate()
+		employee = get_employee()
+		attendance_request = frappe.new_doc("Attendance Request")
+		attendance_request.employee = employee.name
+		attendance_request.from_date = date(date.today().year, 1, 1)
+		attendance_request.to_date = date(date.today().year, 1, 2)
+		attendance_request.reason = "On Duty"
+		attendance_request.company = "_Test Company"
+		attendance_request.insert()
+		attendance_request.submit()
+		attendance = frappe.get_doc('Attendance', {
+			'employee': employee.name,
+			'attendance_date': date(date.today().year, 1, 1),
+			'docstatus': 1
+		})
+		self.assertEqual(attendance.status, 'Present')
+		attendance_request.cancel()
+		attendance.reload()
+		self.assertEqual(attendance.docstatus, 2)
+
+	def test_work_from_home_attendance_request(self):
 		today = nowdate()
 		employee = get_employee()
 		attendance_request = frappe.new_doc("Attendance Request")
@@ -29,7 +50,7 @@ class TestAttendanceRequest(unittest.TestCase):
 			'attendance_date': date(date.today().year, 1, 1),
 			'docstatus': 1
 		})
-		self.assertEqual(attendance.status, 'Present')
+		self.assertEqual(attendance.status, 'Work From Home')
 		attendance_request.cancel()
 		attendance.reload()
 		self.assertEqual(attendance.docstatus, 2)


### PR DESCRIPTION
Changes made:
- Attendance is marked as Work From Home (WFH) in Attendance when an Attendance Request for WFH is made

![image](https://user-images.githubusercontent.com/33743873/73429793-7ced3d80-4362-11ea-98d0-a42bf4a57792.png)

- Test changed to test Attendance Request with Reason being "On Duty"
- Test added for Attendance Request with Reason "Work From Home"

Steps to test:
1. Make an Attendance Request with the reason set to "Work From Home"
1. Check the Attendance List in Attendance to see if the record has been created
1. Status should be "Work From Home"