### PR TITLE
fix: half day leave date value reset

### DIFF
--- a/erpnext/hr/doctype/leave_application/leave_application.js
+++ b/erpnext/hr/doctype/leave_application/leave_application.js
@@ -113,7 +113,7 @@ frappe.ui.form.on("Leave Application", {
 			}
 		}
 		else {
-			frm.doc.half_day_date = "";
+			frm.set_value("half_day_date", "");
 		}
 		frm.trigger("calculate_total_days");
 	},

--- a/erpnext/hr/doctype/leave_application/leave_application.js
+++ b/erpnext/hr/doctype/leave_application/leave_application.js
@@ -104,11 +104,16 @@ frappe.ui.form.on("Leave Application", {
 	},
 
 	half_day: function(frm) {
-		if (frm.doc.from_date == frm.doc.to_date) {
-			frm.set_value("half_day_date", frm.doc.from_date);
+		if (frm.doc.half_day) {
+			if (frm.doc.from_date == frm.doc.to_date) {
+				frm.set_value("half_day_date", frm.doc.from_date);
+			}
+			else {
+				frm.trigger("half_day_datepicker");
+			}
 		}
 		else {
-			frm.trigger("half_day_datepicker");
+			frm.doc.half_day_date = "";
 		}
 		frm.trigger("calculate_total_days");
 	},


### PR DESCRIPTION
Changes made:
- Half Day Date in Doc cleared when the Half Day checkbox is deselected

Steps to test:
1. Create a leave application with half day set and save
1. Deselect the half day checkbox, save and submit
1. View the attendance record for that employee
1. The attendance should say "On Leave"
1. Repeat the same keeping the checkbox selected and submit
1. The attendance should say "Half Day"