### PR TITLE
fix: Unable to submit landed cost voucher

### DIFF
--- a/erpnext/stock/doctype/landed_cost_voucher/test_landed_cost_voucher.py
+++ b/erpnext/stock/doctype/landed_cost_voucher/test_landed_cost_voucher.py
@@ -162,6 +162,76 @@ class TestLandedCostVoucher(unittest.TestCase):
 		self.assertEqual(lcv.items[0].applicable_charges, 41.07)
 		self.assertEqual(lcv.items[2].applicable_charges, 41.08)
 
+	def test_multiple_landed_cost_voucher_against_pr(self):
+		pr = make_purchase_receipt(company="_Test Company with perpetual inventory", warehouse = "Stores - TCP1", 
+			supplier_warehouse = "Stores - TCP1", do_not_save=True)
+
+		pr.append("items", {
+			"item_code": "_Test Item",
+			"warehouse": "Stores - TCP1",
+			"cost_center": "Main - TCP1",
+			"qty": 5,
+			"rate": 100
+		})
+
+		pr.submit()
+
+		lcv1 = make_landed_cost_voucher(receipt_document_type = 'Purchase Receipt', 
+			receipt_document=pr.name, charges=100, do_not_save=True)
+
+		lcv1.insert()
+		lcv1.set('items', [
+			lcv1.get('items')[0]
+		])
+		distribute_landed_cost_on_items(lcv1)
+
+		lcv1.submit()
+
+		lcv2 = make_landed_cost_voucher(receipt_document_type = 'Purchase Receipt', 
+			receipt_document=pr.name, charges=100, do_not_save=True)
+
+		lcv2.insert()
+		lcv2.set('items', [
+			lcv2.get('items')[1]
+		])
+		distribute_landed_cost_on_items(lcv2)
+
+		lcv2.submit()
+
+		pr.load_from_db()
+
+		self.assertEqual(pr.items[0].landed_cost_voucher_amount, 100)
+		self.assertEqual(pr.items[0].landed_cost_voucher_amount, 100)
+
+def make_landed_cost_voucher(** args):
+	args = frappe._dict(args)
+	ref_doc = frappe.get_doc(args.receipt_document_type, args.receipt_document)
+
+	lcv = frappe.new_doc('Landed Cost Voucher')
+	lcv.company = '_Test Company'
+	lcv.distribute_charges_based_on = 'Amount'
+
+	lcv.set('purchase_receipts', [{
+		"receipt_document_type": args.receipt_document_type,
+		"receipt_document": args.receipt_document,
+		"supplier": ref_doc.supplier,
+		"posting_date": ref_doc.posting_date,
+		"grand_total": ref_doc.grand_total
+	}])
+
+	lcv.set("taxes", [{
+		"description": "Shipping Charges",
+		"expense_account": "Expenses Included In Valuation - TCP1",
+		"amount": args.charges
+	}])
+
+	if not args.do_not_save:
+		lcv.insert()
+		if not args.do_not_submit:
+			lcv.submit()
+
+	return lcv
+
 
 def submit_landed_cost_voucher(receipt_document_type, receipt_document, charges=50):
 	ref_doc = frappe.get_doc(receipt_document_type, receipt_document)

--- a/erpnext/stock/doctype/landed_cost_voucher/test_landed_cost_voucher.py
+++ b/erpnext/stock/doctype/landed_cost_voucher/test_landed_cost_voucher.py
@@ -201,7 +201,7 @@ class TestLandedCostVoucher(unittest.TestCase):
 		pr.load_from_db()
 
 		self.assertEqual(pr.items[0].landed_cost_voucher_amount, 100)
-		self.assertEqual(pr.items[0].landed_cost_voucher_amount, 100)
+		self.assertEqual(pr.items[1].landed_cost_voucher_amount, 100)
 
 def make_landed_cost_voucher(** args):
 	args = frappe._dict(args)

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -349,7 +349,7 @@ class PurchaseReceipt(BuyingController):
 		if warehouse_with_no_account:
 			frappe.msgprint(_("No accounting entries for the following warehouses") + ": \n" +
 				"\n".join(warehouse_with_no_account))
-
+		
 		return process_gl_map(gl_entries)
 
 	def get_asset_gl_entry(self, gl_entries):
@@ -616,23 +616,16 @@ def get_item_account_wise_additional_cost(purchase_document):
 
 	if not landed_cost_vouchers:
 		return
-
-	total_item_cost = 0
+	
 	item_account_wise_cost = {}
-	item_cost_allocated = []
 
 	for lcv in landed_cost_vouchers:
 		landed_cost_voucher_doc = frappe.get_cached_doc("Landed Cost Voucher", lcv.parent)
 		based_on_field = frappe.scrub(landed_cost_voucher_doc.distribute_charges_based_on)
+		total_item_cost = 0
 
 		for item in landed_cost_voucher_doc.items:
-			if item.purchase_receipt_item not in item_cost_allocated:
-				total_item_cost += item.get(based_on_field)
-				item_cost_allocated.append(item.purchase_receipt_item)
-
-	for lcv in landed_cost_vouchers:
-		landed_cost_voucher_doc = frappe.get_cached_doc("Landed Cost Voucher", lcv.parent)
-		based_on_field = frappe.scrub(landed_cost_voucher_doc.distribute_charges_based_on)
+			total_item_cost += item.get(based_on_field)
 
 		for item in landed_cost_voucher_doc.items:
 			if item.receipt_document == purchase_document:

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -620,7 +620,7 @@ def get_item_account_wise_additional_cost(purchase_document):
 	item_account_wise_cost = {}
 
 	for lcv in landed_cost_vouchers:
-		landed_cost_voucher_doc = frappe.get_cached_doc("Landed Cost Voucher", lcv.parent)
+		landed_cost_voucher_doc = frappe.get_doc("Landed Cost Voucher", lcv.parent)
 		based_on_field = frappe.scrub(landed_cost_voucher_doc.distribute_charges_based_on)
 		total_item_cost = 0
 


### PR DESCRIPTION
Issue:

While submitting subsequent landed cost vouchers against a purchase document the  `total_cost` was considered for all the items in all the Landed Cost Vouchers even though some LCVs might not have all those items which was causing unequal debit and credit issue while submitting landed cost vouchers.  