### PR TITLE
fix: Payment Schedule not mapped from Purchase Order to Invoice.

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -443,6 +443,9 @@ def get_mapped_purchase_invoice(source_name, target_doc=None, ignore_permissions
 			"doctype": "Purchase Taxes and Charges",
 			"add_if_empty": True
 		},
+		"Payment Schedule": {
+			"doctype": "Payment Schedule"
+		}
 	}
 
 	if frappe.get_single("Accounts Settings").automatically_fetch_payment_terms == 1:


### PR DESCRIPTION
- **Before Fix:**
![_payment_schedu_before](https://user-images.githubusercontent.com/25857446/73631864-2fcddc00-4680-11ea-8f67-42b5eee4bb5f.gif)


- **After Fix:**
![_pay_sched_after](https://user-images.githubusercontent.com/25857446/73631978-77546800-4680-11ea-92b1-7e65854a0348.gif)
