### PR TITLE
fix: unsupported operand type(s) for += 'int' and 'NoneType'

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -74,13 +74,13 @@ class PickList(Document):
 
 			if item_map.get(key):
 				item_map[key].qty += item.qty
-				item_map[key].stock_qty += item.stock_qty
+				item_map[key].stock_qty += flt(item.stock_qty)
 			else:
 				item_map[key] = item
 
 			# maintain count of each item (useful to limit get query)
 			self.item_count_map.setdefault(item_code, 0)
-			self.item_count_map[item_code] += item.stock_qty
+			self.item_count_map[item_code] += flt(item.stock_qty)
 
 		return item_map.values()
 


### PR DESCRIPTION
**Issue**

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2020-01-16/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-2020-01-16/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-2020-01-16/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2020-01-16/apps/frappe/frappe/handler.py", line 61, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2020-01-16/apps/frappe/frappe/__init__.py", line 1042, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2020-01-16/apps/frappe/frappe/handler.py", line 89, in runserverobj
    frappe.desk.form.run_method.runserverobj(method, docs=docs, dt=dt, dn=dn, arg=arg, args=args)
  File "/home/frappe/benches/bench-2020-01-16/apps/frappe/frappe/desk/form/run_method.py", line 43, in runserverobj
    r = doc.run_method(method)
  File "/home/frappe/benches/bench-2020-01-16/apps/frappe/frappe/model/document.py", line 787, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-2020-01-16/apps/frappe/frappe/model/document.py", line 1058, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-2020-01-16/apps/frappe/frappe/model/document.py", line 1041, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-2020-01-16/apps/frappe/frappe/model/document.py", line 781, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-2020-01-16/apps/erpnext/erpnext/stock/doctype/pick_list/pick_list.py", line 33, in set_item_locations
    items = self.aggregate_item_qty()
  File "/home/frappe/benches/bench-2020-01-16/apps/erpnext/erpnext/stock/doctype/pick_list/pick_list.py", line 83, in aggregate_item_qty
    self.item_count_map[item_code] += item.stock_qty
TypeError: unsupported operand type(s) for +=: 'int' and 'NoneType'
```