### PR TITLE
fix: Procurement Tracker report not working

### DIFF
--- a/erpnext/buying/report/procurement_tracker/procurement_tracker.py
+++ b/erpnext/buying/report/procurement_tracker/procurement_tracker.py
@@ -141,13 +141,13 @@ def get_conditions(filters):
 	conditions = ""
 
 	if filters.get("company"):
-		conditions += " AND company='%s'"% filters.get('company')
+		conditions += " AND company=%s"% frappe.db.escape(filters.get('company'))
 
 	if filters.get("cost_center") or filters.get("project"):
 		conditions += """
-			AND (cost_center='%s'
-			OR project='%s')
-			"""% (filters.get('cost_center'), filters.get('project'))
+			AND (cost_center=%s
+			OR project=%s)
+			"""% (frappe.db.escape(filters.get('cost_center')), frappe.db.escape(filters.get('project')))
 
 	if filters.get("from_date"):
 		conditions += " AND transaction_date>=%s"% filters.get('from_date')


### PR DESCRIPTION
If company name contain special character like single quote (')

<img width="1231" alt="Screenshot 2020-02-06 at 1 00 59 PM" src="https://user-images.githubusercontent.com/8780500/73921801-0d40fa80-48ee-11ea-897a-759ff35ce7b0.png">
