### PR TITLE
fix: skip earned leaves check for max leaves set to zero or less

### DIFF
--- a/erpnext/hr/doctype/leave_application/test_leave_application.py
+++ b/erpnext/hr/doctype/leave_application/test_leave_application.py
@@ -409,7 +409,7 @@ class TestLeaveApplication(unittest.TestCase):
 
 		self.assertEqual(get_leave_balance_on(employee.name, leave_type.name, nowdate(), add_days(nowdate(), 8)), 21)
 
-	def test_earned_leave(self):
+	def test_earned_leaves_creation(self):
 		leave_period = get_leave_period()
 		employee = get_employee()
 		leave_type = 'Test Earned Leave Type'
@@ -436,6 +436,14 @@ class TestLeaveApplication(unittest.TestCase):
 			allocate_earned_leaves()
 			i += 1
 		self.assertEqual(get_leave_balance_on(employee.name, leave_type, nowdate()), 6)
+
+		# validate earned leaves creation without maximum leaves
+		frappe.db.set_value('Leave Type', leave_type, 'max_leaves_allowed', 0)
+		i = 0
+		while(i<6):
+			allocate_earned_leaves()
+			i += 1
+		self.assertEqual(get_leave_balance_on(employee.name, leave_type, nowdate()), 9)
 
 	# test to not consider current leave in leave balance while submitting
 	def test_current_leave_on_submit(self):

--- a/erpnext/hr/utils.py
+++ b/erpnext/hr/utils.py
@@ -316,7 +316,9 @@ def allocate_earned_leaves():
 
 				allocation = frappe.get_doc('Leave Allocation', allocation.name)
 				new_allocation = flt(allocation.total_leaves_allocated) + flt(earned_leaves)
-				new_allocation = new_allocation if new_allocation <= e_leave_type.max_leaves_allowed else e_leave_type.max_leaves_allowed
+
+				if new_allocation > e_leave_type.max_leaves_allowed and e_leave_type.max_leaves_allowed > 0:
+					new_allocation = e_leave_type.max_leaves_allowed
 
 				if new_allocation == allocation.total_leaves_allocated:
 					continue


### PR DESCRIPTION
backport of #20535 
