### PR TITLE
fix: patch for creating irs_1099 custom field (United States)

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -648,3 +648,4 @@ erpnext.patches.v12_0.update_owner_fields_in_acc_dimension_custom_fields
 erpnext.patches.v12_0.remove_denied_leaves_from_leave_ledger
 erpnext.patches.v12_0.update_price_or_product_discount
 erpnext.patches.v12_0.add_export_type_field_in_party_master
+erpnext.patches.v12_0.create_irs_1099_field_united_states

--- a/erpnext/patches/v12_0/create_irs_1099_field_united_states.py
+++ b/erpnext/patches/v12_0/create_irs_1099_field_united_states.py
@@ -1,0 +1,10 @@
+from __future__ import unicode_literals
+import frappe
+from erpnext.regional.united_states.setup import make_custom_fields
+
+def execute():
+    company = frappe.get_all('Company', filters = {'country': 'United States'})
+    if not company:
+        return
+
+    make_custom_fields()


### PR DESCRIPTION
Backport of: https://github.com/frappe/erpnext/pull/20553/

Added missing patch for creating custom field irs_1099 in US regional data introduced in the PR: https://github.com/frappe/erpnext/pull/16421

**Before**:

![irs_missing](https://user-images.githubusercontent.com/24353136/74108165-75693800-4b9d-11ea-887e-9a8013d05b98.png)

**After**:

![irs_field](https://user-images.githubusercontent.com/24353136/74108169-7ac68280-4b9d-11ea-8e6d-30107e33b1cf.png)
