### PR TITLE
fix: backflush raw material based on - Material Transferred for Manufacture

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -1054,7 +1054,7 @@ class StockEntry(StockController):
 			req_qty_each = flt(req_qty / manufacturing_qty)
 			consumed_qty = flt(req_items[0].consumed_qty)
 
-			if trans_qty and manufacturing_qty >= (produced_qty + flt(self.fg_completed_qty)):
+			if trans_qty and manufacturing_qty > (produced_qty + flt(self.fg_completed_qty)):
 				if qty >= req_qty:
 					qty = (req_qty/trans_qty) * flt(self.fg_completed_qty)
 				else:


### PR DESCRIPTION
Hi @nabinhait ,
 
Issue : Manufacturing setting > Backflush Raw Material Based on “Material Transferred for Manufacture” doesn't fetch the actual raw material transferred qty. It fetches qty based on "BOM"

The issue is because @creamdory in PR #https://github.com/frappe/erpnext/pull/13384
commit : https://github.com/frappe/erpnext/pull/13384/files#diff-91f0ed661ef4b6e1f167fc7961b1a79b
she 
```
changed from: if trans_qty and manufacturing_qty > (produced_qty + flt(self.fg_completed_qty)):
to : if trans_qty and manufacturing_qty >= (produced_qty + flt(self.fg_completed_qty)):
```
**'='** was added by her in the condition, which was not there before her commit.
Kindly except the fix for the issue.


https://github.com/frappe/erpnext/blob/develop/erpnext/stock/doctype/stock_entry/stock_entry.py#L1057

https://github.com/frappe/erpnext/pull/13384

https://github.com/frappe/erpnext/pull/13384/files#diff-91f0ed661ef4b6e1f167fc7961b1a79b

**before fix gif** :  Stock Entry = Manufacture shows raw material quantity as per BOM.

![FetchTransQtyError](https://user-images.githubusercontent.com/29812965/74123824-ffdd8600-4bf5-11ea-8873-95de24a7ef09.gif)

**after fix gi**f :  Stock Entry = "Manufacture" shows raw material quantity as per "Material Transfer for Manufacture".

![FetchTransQtyFix](https://user-images.githubusercontent.com/29812965/74123836-0c61de80-4bf6-11ea-86fb-d9619fd9b02b.gif)
