### PR TITLE
fix: get_students not respecting the program

### DIFF
--- a/erpnext/education/doctype/fee_schedule/fee_schedule.py
+++ b/erpnext/education/doctype/fee_schedule/fee_schedule.py
@@ -123,9 +123,11 @@ def get_students(student_group, academic_year, academic_term=None, student_categ
 
 	students = frappe.db.sql("""
 		select pe.student, pe.student_name, pe.program, pe.student_batch_name
-		from `tabStudent Group Student` sgs, `tabProgram Enrollment` pe
+		from `tabStudent Group Student` sgs, `tabProgram Enrollment` pe, `tabStudent Group` sg
 		where
 			pe.student = sgs.student and pe.academic_year = %s
+			and sg.program = pe.program
+			and sg.name = sgs.parent
 			and sgs.parent = %s and sgs.active = 1
 			{conditions}
 		""".format(conditions=conditions), (academic_year, student_group), as_dict=1)


### PR DESCRIPTION
The get_students function is not taking into account the program for which the fee needs to be created. If a student is enrolled for multiple programs then the fee schedule pull up the wrong count of students.

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
