### PR TITLE
fix: filter serial no based on batch no

### DIFF
--- a/erpnext/public/js/utils/serial_no_batch_selector.js
+++ b/erpnext/public/js/utils/serial_no_batch_selector.js
@@ -90,7 +90,8 @@ erpnext.SerialNoBatchSelector = Class.extend({
 						args: {
 							qty: qty,
 							item_code: me.item_code,
-							warehouse: me.warehouse_details.name
+							warehouse: me.warehouse_details.name,
+							batch_no: me.item.batch_no || null
 						}
 					});
 
@@ -392,7 +393,7 @@ erpnext.SerialNoBatchSelector = Class.extend({
 			delivery_document_no: ""
 		}
 
-		if (this.has_batch) {
+		if (this.item.batch_no) {
 			serial_no_filters["batch_no"] = this.item.batch_no;
 		}
 

--- a/erpnext/stock/doctype/serial_no/serial_no.py
+++ b/erpnext/stock/doctype/serial_no/serial_no.py
@@ -397,7 +397,6 @@ def make_serial_no(serial_no, args):
 	sr.via_stock_ledger = args.get('via_stock_ledger') or True
 	sr.asset = args.get('asset')
 	sr.location = args.get('location')
-	
 
 	if args.get('purchase_document_type'):
 		sr.purchase_document_type = args.get('purchase_document_type')
@@ -474,10 +473,11 @@ def get_delivery_note_serial_no(item_code, qty, delivery_note):
 	return serial_nos
 
 @frappe.whitelist()
-def auto_fetch_serial_number(qty, item_code, warehouse):
+def auto_fetch_serial_number(qty, item_code, warehouse, batch_no=None):
 	serial_numbers = frappe.get_list("Serial No", filters={
 		"item_code": item_code,
 		"warehouse": warehouse,
+		"batch_no": batch_no,
 		"delivery_document_no": "",
 		"sales_invoice": ""
 	}, limit=qty, order_by="creation")


### PR DESCRIPTION
As a user , while creating delivery note in the system is showing all the serial numbers, If i select particular batch.
problem occures when particular item has more than one batch. so its need to filter based on batch selected

Before: 
![serial_no_filter_batch_before](https://user-images.githubusercontent.com/6947417/74214927-5960b600-4cc5-11ea-9f8f-6513a33b4cbf.gif)

After:
![serial_no_filter_batch_after](https://user-images.githubusercontent.com/6947417/74214933-5d8cd380-4cc5-11ea-92dc-965b833bd629.gif)
