### PR TITLE
Production Plan | Get items from Sales Order not fetching grand total value

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -47,7 +47,7 @@ class ProductionPlan(Document):
 				'sales_order': data.name,
 				'sales_order_date': data.transaction_date,
 				'customer': data.customer,
-				'grand_total': data.grand_total
+				'grand_total': data.base_grand_total
 			})
 
 	def get_pending_material_requests(self):


### PR DESCRIPTION
- On production plan the Sales Order base grand total now fetching when users click on get sales order button.