### PR TITLE
fix: 'Last Purchase Rate' taking wrong on BOM. #20228

### DIFF
--- a/erpnext/buying/utils.py
+++ b/erpnext/buying/utils.py
@@ -12,7 +12,6 @@ from erpnext.stock.doctype.item.item import validate_end_of_life
 
 def update_last_purchase_rate(doc, is_submit):
 	"""updates last_purchase_rate in item table for each item"""
-
 	import frappe.utils
 	this_purchase_date = frappe.utils.getdate(doc.get('posting_date') or doc.get('transaction_date'))
 
@@ -23,7 +22,7 @@ def update_last_purchase_rate(doc, is_submit):
 		# compare last purchase date and this transaction's date
 		last_purchase_rate = None
 		if last_purchase_details and \
-				(last_purchase_details.purchase_date > this_purchase_date):
+				(doc.get('docstatus') == 2 or last_purchase_details.purchase_date > this_purchase_date):
 			last_purchase_rate = last_purchase_details['base_net_rate']
 		elif is_submit == 1:
 			# even if this transaction is the latest one, it should be submitted

--- a/erpnext/selling/doctype/quotation/quotation.py
+++ b/erpnext/selling/doctype/quotation/quotation.py
@@ -68,18 +68,23 @@ class Quotation(SellingController):
 
 	def declare_enquiry_lost(self, lost_reasons_list, detailed_reason=None):
 		if not self.has_sales_order():
+			get_lost_reasons = frappe.get_list('Opportunity Lost Reason',
+			fields = ["name"])
+			lost_reasons_lst = [reason.get('name') for reason in get_lost_reasons]
 			frappe.db.set(self, 'status', 'Lost')
 
 			if detailed_reason:
 				frappe.db.set(self, 'order_lost_reason', detailed_reason)
 
 			for reason in lost_reasons_list:
-				self.append('lost_reasons', reason)
+				if reason.get('lost_reason') in lost_reasons_lst:
+					self.append('lost_reasons', reason)
+				else:
+					frappe.throw(_("Invalid lost reason <b>{0}</b>, please create a new lost reason".format(reason.get('lost_reason'))))
 
 			self.update_opportunity()
 			self.update_lead()
 			self.save()
-
 		else:
 			frappe.throw(_("Cannot set as Lost as Sales Order is made."))
 

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -979,6 +979,7 @@ def _msgprint(msg, verbose):
 def get_last_purchase_details(item_code, doc_name=None, conversion_rate=1.0):
 	"""returns last purchase details in stock uom"""
 	# get last purchase order item details
+
 	last_purchase_order = frappe.db.sql("""\
 		select po.name, po.transaction_date, po.conversion_rate,
 			po_item.conversion_factor, po_item.base_price_list_rate,
@@ -988,6 +989,7 @@ def get_last_purchase_details(item_code, doc_name=None, conversion_rate=1.0):
 			po.name = po_item.parent
 		order by po.transaction_date desc, po.name desc
 		limit 1""", (item_code, cstr(doc_name)), as_dict=1)
+
 
 	# get last purchase receipt item details
 	last_purchase_receipt = frappe.db.sql("""\
@@ -1000,14 +1002,17 @@ def get_last_purchase_details(item_code, doc_name=None, conversion_rate=1.0):
 		order by pr.posting_date desc, pr.posting_time desc, pr.name desc
 		limit 1""", (item_code, cstr(doc_name)), as_dict=1)
 
+	
+	
 	purchase_order_date = getdate(last_purchase_order and last_purchase_order[0].transaction_date
 							   or "1900-01-01")
 	purchase_receipt_date = getdate(last_purchase_receipt and
 								 last_purchase_receipt[0].posting_date or "1900-01-01")
 
-	if (purchase_order_date > purchase_receipt_date) or \
+	if (purchase_order_date >= purchase_receipt_date) or \
 				(last_purchase_order and not last_purchase_receipt):
 		# use purchase order
+		
 		last_purchase = last_purchase_order[0]
 		purchase_date = purchase_order_date
 
@@ -1024,10 +1029,11 @@ def get_last_purchase_details(item_code, doc_name=None, conversion_rate=1.0):
 	out = frappe._dict({
 		"base_price_list_rate": flt(last_purchase.base_price_list_rate) / conversion_factor,
 		"base_rate": flt(last_purchase.base_rate) / conversion_factor,
-		"base_net_rate": flt(last_purchase.net_rate) / conversion_factor,
+		"base_net_rate": flt(last_purchase.base_net_rate) / conversion_factor,
 		"discount_percentage": flt(last_purchase.discount_percentage),
 		"purchase_date": purchase_date
 	})
+	
 
 	conversion_rate = flt(conversion_rate) or 1.0
 	out.update({


### PR DESCRIPTION
On BOM after selecting last purchase rate, it is fetching wrong rate on selection of item.

1.Create new Item
2.Create new Purchase order(PO1) for 20 rs
3.Create Purchase receipt for (PR1) 20 rs
4.Item Price got created for 20 rs
5.Now, Create again create PO2 for same item with rs 25.
6.Create new PR2 for 25 rs.
7.Deleted PO2 and PR2 (which is of rs 25)
7.Create new BOM for same item
8.Select 'Rate of materials based on'= Last Purchase Rate
9.select item
10. on BOM, rate is taking 25 for that item (which has been deleted)