### PR TITLE
fix: Student form joining date accepting a future date #20587

### DIFF
--- a/erpnext/education/doctype/quiz/quiz.js
+++ b/erpnext/education/doctype/quiz/quiz.js
@@ -4,5 +4,18 @@
 frappe.ui.form.on('Quiz', {
 	refresh: function(frm) {
 
+	},
+	validate: function(frm){
+		frm.events.check_duplicate_question(frm.doc.question);
+	},
+	check_duplicate_question: function(questions_data){
+		var questions = []
+		questions_data.forEach(function(q){
+			questions.push(q.question_link)
+		})
+		var questions_set = new Set(questions)
+		if (questions.length != questions_set.size) {
+			frappe.throw(__("The question cannot be duplicate"))
+		}
 	}
 });

--- a/erpnext/education/doctype/student/student.js
+++ b/erpnext/education/doctype/student/student.js
@@ -25,7 +25,13 @@ frappe.ui.form.on('Student', {
 					{party_type:'Student', party:frm.doc.name});
 			});
 		}
-	}
+	},
+	validate: function (frm) {
+		console.log("test")
+		if (frappe.datetime.get_today() < frm.doc.joining_date) {
+			frappe.throw("Joining date cannot be greater than today")
+		}
+	},
 });
 
 frappe.ui.form.on('Student Guardian', {

--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -137,7 +137,7 @@ frappe.ui.form.on("Item", {
 	},
 
 	gst_hsn_code: function(frm) {
-		if(!frm.doc.taxes || !frm.doc.taxes.length) {
+		if((!frm.doc.taxes || !frm.doc.taxes.length) && frm.doc.gst_hsn_code) {
 			frappe.db.get_doc("GST HSN Code", frm.doc.gst_hsn_code).then(hsn_doc => {
 				$.each(hsn_doc.taxes || [], function(i, tax) {
 					let a = frappe.model.add_child(cur_frm.doc, 'Item Tax', 'taxes');

--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -145,6 +145,7 @@ frappe.ui.form.on('Material Request', {
 	},
 
 	get_item_data: function(frm, item) {
+		if (!item.item_code) return
 		frm.call({
 			method: "erpnext.stock.get_item_details.get_item_details",
 			child: item,


### PR DESCRIPTION
On student form by default, the date is selected as today's date but if the user changes the date to future date it was acceptable. Now added validation for joining date to not accept a future date.