### PR TITLE
fix: Changes done to get valid customer and employee list on payment entry form(#20498)

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -253,6 +253,19 @@ frappe.ui.form.on('Payment Entry', {
 			frappe.throw(__("Party can only be one of "+ party_types.join(", ")));
 		}
 
+		frm.set_query("party", function() {
+			if(frm.doc.party_type == 'Employee'){
+				return {
+					query: "erpnext.controllers.queries.employee_query"
+				}
+			}
+			else if(frm.doc.party_type == 'Customer'){
+				return {
+					query: "erpnext.controllers.queries.customer_query"
+				}
+			}
+		});
+
 		if(frm.doc.party) {
 			$.each(["party", "party_balance", "paid_from", "paid_to",
 				"paid_from_account_currency", "paid_from_account_balance",

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.js
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.js
@@ -297,7 +297,7 @@ frappe.ui.form.on("Material Request Plan Item", {
 	}
 });
 
-cur_frm.fields_dict['sales_orders'].grid.get_field("sales_order").get_query = function(doc) {
+cur_frm.fields_dict['sales_orders'].grid.get_field("sales_order").get_query = function() {
 	return{
 		filters: [
 			['Sales Order','docstatus', '=' ,1]

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.js
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.js
@@ -296,3 +296,11 @@ frappe.ui.form.on("Material Request Plan Item", {
 		}
 	}
 });
+
+cur_frm.fields_dict['sales_orders'].grid.get_field("sales_order").get_query = function(doc, cdt, cdn) {
+	return{
+		filters: [
+			['Sales Order','docstatus', '=' ,1]
+		]
+	}
+};

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.js
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.js
@@ -297,7 +297,7 @@ frappe.ui.form.on("Material Request Plan Item", {
 	}
 });
 
-cur_frm.fields_dict['sales_orders'].grid.get_field("sales_order").get_query = function(doc, cdt, cdn) {
+cur_frm.fields_dict['sales_orders'].grid.get_field("sales_order").get_query = function(doc) {
 	return{
 		filters: [
 			['Sales Order','docstatus', '=' ,1]


### PR DESCRIPTION
Issue Id : #20498
On payment entry form when we choose party type as employee then in party link employee with status left also listed. Same thing happen when i choose customer as party type then in party link customer with disabled status are listed.
Changes done to get valid customer and employee list on payment entry form. Please find the screen shots for resolved issue.
1. Employee List
![employee_list](https://user-images.githubusercontent.com/53554836/74583177-58dc5e00-4fea-11ea-9661-f1e1685af8dc.png)
2. Wrong employee list on payment entry form
![wrong_employee_list](https://user-images.githubusercontent.com/53554836/74583182-6c87c480-4fea-11ea-97fd-aec6edb85b3b.png)
3. Valid employee list on payment entry form
![image](https://user-images.githubusercontent.com/53554836/74583207-c4263000-4fea-11ea-94b3-7d747c6a34be.png)

4. Customer List
![customer_list](https://user-images.githubusercontent.com/53554836/74583213-d4d6a600-4fea-11ea-9e9b-57b704653043.png)
5. Wrong customer list on payment entry form
![wrong_customer_list](https://user-images.githubusercontent.com/53554836/74583222-eae46680-4fea-11ea-90aa-fcd8571d0e39.png)
6. Valid customer list on payment entry form
![correct_customer_list](https://user-images.githubusercontent.com/53554836/74583229-fcc60980-4fea-11ea-9a81-1666dbd966d6.png)

Issue Id : #20609
On production plan form if you select get items from sales order then all sales order with valid bom and docstatus = 1 listed in sales order child table.
But if try to add row manually in sales order child table then sales order of status draft, submit and cancel all are getting listed which is invalid.
Changes done to get valid sales order list in ce1f6a7 commit please find following screen shots for the same:
1. Sales order list
![sales_order_list](https://user-images.githubusercontent.com/53554836/74586827-7bce3880-5011-11ea-8635-dfe8853709bb.png)
2. Sales orders with status draft, submit and cancel getting listed on production plan form.
![wrong_sales_order_list](https://user-images.githubusercontent.com/53554836/74586841-99030700-5011-11ea-9b5f-cd612955074d.png)
3. Production plan with valid sales order list
![correct_sales_order_list](https://user-images.githubusercontent.com/53554836/74586847-a7512300-5011-11ea-8237-23dfc6945738.png)
