### PR TITLE
fix: blank row added while adding multiple items on sales order(#20584)

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -75,6 +75,12 @@ frappe.ui.form.on("Sales Order", {
 		});
 
 		erpnext.queries.setup_warehouse_query(frm);
+
+		$('.grid-add-multiple-rows').click(function() {
+			$.each(frm.doc.items || [], function(i, d) {
+				if(!d.item_code) frm.doc.items = [];
+			});
+		});
 	},
 
 	delivery_date: function(frm) {


### PR DESCRIPTION
 frappe/frappe#18532 
first row was added blank while adding multiple items on sales order form.