### PR TITLE
fix:User allowed to set student DOB can not be greater than Joining Date #20628

### DIFF
--- a/erpnext/education/doctype/student/student.py
+++ b/erpnext/education/doctype/student/student.py
@@ -25,6 +25,9 @@ class Student(Document):
 		if self.date_of_birth and getdate(self.date_of_birth) >= getdate(today()):
 			frappe.throw(_("Date of Birth cannot be greater than today."))
 
+		if self.date_of_birth and getdate(self.date_of_birth) >= getdate(self.joining_date):
+			frappe.throw(_("Date of Birth cannot be greater than Joining Date."))
+
 		if self.joining_date and self.date_of_leaving and getdate(self.joining_date) > getdate(self.date_of_leaving):
 			frappe.throw(_("Joining Date can not be greater than Leaving Date"))
 


### PR DESCRIPTION
**Description of the issue**
User Allowed to create student with invalide real time scenrio DOB and Joining Date

**Context information (for bug reports)
Output of bench version**

erpnext 12.x.x-develop
frappe 12.x.x-develop

**Steps to reproduce the issue**

1. Go to Student Form
2. Enter other mandatory Details
3. Select joining Date as 01st Feb 2020
4. Select Date of Birth as 14th Feb 2020
5. And Student form gets submitted.

**Observed result**
User allowed to save student form

**Expected result**
Some Validation Message need to show on form for Joining Date and DOB

**Stacktrace / full error messageTraceback (most recent call last):**

**Additional information**
OS Details:

Ubuntu 16.04 LTS

**Installation Steps:**

virtualenv -p /usr/bin/python3 .
source ./bin/activate
git clone bench-repo
bench init
bench get-app erpnext