### PR TITLE
Fix: Wrong filter for supplier default bank account

### DIFF
--- a/erpnext/buying/doctype/supplier/supplier.js
+++ b/erpnext/buying/doctype/supplier/supplier.js
@@ -17,10 +17,11 @@ frappe.ui.form.on("Supplier", {
 				}
 			}
 		});
-		frm.set_query("default_bank_account", function() {
+		frm.set_query("default_bank_account", function(doc, cdt, cdn) {
 			return {
 				filters: {
-					"is_company_account":1
+					"is_company_account":0,
+					"party":doc.name
 				}
 			}
 		});


### PR DESCRIPTION
The query for default bank account field in the supplier master only allowed company bank accounts. With this fix it's now possible to one of the supplier bank accounts as default bank account.