### PR TITLE
fix: filters for quality_procedure tree

### DIFF
--- a/erpnext/quality_management/doctype/quality_procedure/quality_procedure_tree.js
+++ b/erpnext/quality_management/doctype/quality_procedure/quality_procedure_tree.js
@@ -4,7 +4,7 @@ frappe.treeview_settings["Quality Procedure"] = {
 	add_tree_node: 'erpnext.quality_management.doctype.quality_procedure.quality_procedure.add_node',
 	filters: [
 		{
-			fieldname: "quality_procedure",
+			fieldname: "parent_quality_procedure",
 			fieldtype: "Link",
 			options: "Quality Procedure",
 			label: __("Quality Procedure"),


### PR DESCRIPTION
Port of https://github.com/frappe/erpnext/pull/20633

---

For the tree view of quality procedure, if the filter is set, or even manually set to blank value (i.e. `""`) it would cause a type error.

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2020-02-05/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-12-2020-02-05/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-12-2020-02-05/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-12-2020-02-05/apps/frappe/frappe/handler.py", line 61, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-12-2020-02-05/apps/frappe/frappe/__init__.py", line 1042, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-12-2020-02-05/apps/frappe/frappe/desk/treeview.py", line 22, in get_all_nodes
    data = tree_method(doctype, parent, **filters)
TypeError: get_children() got an unexpected keyword argument 'quality_procedure'
```

This PR fixes that