### PR TITLE
chore: fix typo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,20 @@
 {
-  "devdependencies": {
+  "name": "erpnext",
+  "description": "Open Source ERP System powered by the Frappe Framework",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/frappe/erpnext.git"
+  },
+  "homepage": "https://erpnext.com",
+  "author": "Frappe Technologies Pvt. Ltd.",
+  "license": "GPL-3.0",
+  "bugs": {
+    "url": "https://github.com/frappe/erpnext/issues"
+  },
+  "devDependencies": {
     "snyk": "^1.290.1"
+  },
+  "dependencies": {
   },
   "scripts": {
     "snyk-protect": "snyk protect",


### PR DESCRIPTION
* fixed devDependencies typo which possibly caused https://discuss.erpnext.com/t/bin-sh-1-snyk-not-found-when-bench-update/58035 which was introduced in https://github.com/frappe/erpnext/pull/20563

* Added missing fields for package meta data

