### PR TITLE
fix: apply url encoding to project names (v12)

### DIFF
--- a/erpnext/templates/includes/projects/project_row.html
+++ b/erpnext/templates/includes/projects/project_row.html
@@ -1,6 +1,6 @@
 {% if doc.status=="Open" %}
 <div class="web-list-item">
-	<a class="no-decoration" href="/projects?project={{ doc.name }}">
+	<a class="no-decoration" href="/projects?project={{ doc.name | urlencode }}">
 		<div class="row">
 			<div class="col-xs-6">
 


### PR DESCRIPTION
**Problem:**

If a project's name contained special URL characters, the page would fail to render on the portal properly (for example, "Frappe & ERPNext" would resolve to just "Frappe").