### PR TITLE
fix: HSN/SAC Error while creating a new item and not selecting the fi…

### DIFF
--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -137,7 +137,7 @@ frappe.ui.form.on("Item", {
 	},
 
 	gst_hsn_code: function(frm) {
-		if(!frm.doc.taxes || !frm.doc.taxes.length) {
+		if((!frm.doc.taxes || !frm.doc.taxes.length) && frm.doc.gst_hsn_code) {
 			frappe.db.get_doc("GST HSN Code", frm.doc.gst_hsn_code).then(hsn_doc => {
 				$.each(hsn_doc.taxes || [], function(i, tax) {
 					let a = frappe.model.add_child(cur_frm.doc, 'Item Tax', 'taxes');


### PR DESCRIPTION
While creating an item if the user tries to enter the HSN/SAC code. And if a user doesn't enter and clicked outside the HSN/SAC box then the error "The resource you are looking for is not available" occurs.

This issue is resolved by checking if the HSN/SAC is entered or not. If there is no HSN/SAC then further DB call `frappe.db.get_doc("GST HSN Code"...)` can't be made.
