### PR TITLE
fix: Stock Quantity not calculated on client side in Material Request Items.

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -941,15 +941,19 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 	},
 
 	conversion_factor: function(doc, cdt, cdn, dont_fetch_price_list_rate) {
-		if(doc.doctype != 'Material Request' && frappe.meta.get_docfield(cdt, "stock_qty", cdn)) {
+		if(frappe.meta.get_docfield(cdt, "stock_qty", cdn)) {
 			var item = frappe.get_doc(cdt, cdn);
 			frappe.model.round_floats_in(item, ["qty", "conversion_factor"]);
 			item.stock_qty = flt(item.qty * item.conversion_factor, precision("stock_qty", item));
-			item.total_weight = flt(item.stock_qty * item.weight_per_unit);
 			refresh_field("stock_qty", item.name, item.parentfield);
-			refresh_field("total_weight", item.name, item.parentfield);
 			this.toggle_conversion_factor(item);
-			this.calculate_net_weight();
+
+			if(doc.doctype != "Material Request") {
+				item.total_weight = flt(item.stock_qty * item.weight_per_unit);
+				refresh_field("total_weight", item.name, item.parentfield);
+				this.calculate_net_weight();
+			}
+
 			if (!dont_fetch_price_list_rate &&
 				frappe.meta.has_field(doc.doctype, "price_list_currency")) {
 				this.apply_price_list(item, true);


### PR DESCRIPTION
- In Material Request Items, on changing UOM, Stock Qty was not calculated on Client Side.
- Hence, on save it was recalculated and  set from the server side.

Problem:
- On the client side it fetched 'conversion_factor', rounded it with the correct precision and then carried out multiplication. (**stock_qty = qty * conversion_factor**)
- On server side , whatever precision **'conversion_factor'** was stored in , is fetched and used as it is  causing incorrect stock_qty value.

Case: (In Material Request)
- Conversion Factor is **0.0274453** in Item Master, and precision (via Customise Form) for this field is 7.
- Global precision is 6.
- Client side calculations :  **0.027445** (precision 6) * 20 = 0.548900 (which was missed)
- Server side calculations:  **0.0274453** (precision 7) * 20 = 0.548906
- In Purchase Order, stock_qty = **0.027445** (precision 6) * 20 = 0.548900
- Causing mismatch in values and showing Material Request as pending even though already ordered.
