### PR TITLE
fix: Set Query on warehouse fields in Stock Settings

### DIFF
--- a/erpnext/stock/doctype/stock_settings/stock_settings.js
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.js
@@ -3,6 +3,15 @@
 
 frappe.ui.form.on('Stock Settings', {
 	refresh: function(frm) {
+		let filters = function() {
+			return {
+				 filters : {
+					is_group : 0
+				 }
+			};
+		}
 
+		frm.set_query("default_warehouse", filters);
+		frm.set_query("sample_retention_warehouse", filters);
 	}
 });

--- a/erpnext/stock/doctype/stock_settings/stock_settings.js
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.js
@@ -5,11 +5,11 @@ frappe.ui.form.on('Stock Settings', {
 	refresh: function(frm) {
 		let filters = function() {
 			return {
-				 filters : {
+				filters : {
 					is_group : 0
-				 }
+				}
 			};
-		}
+		};
 
 		frm.set_query("default_warehouse", filters);
 		frm.set_query("sample_retention_warehouse", filters);

--- a/erpnext/stock/doctype/stock_settings/stock_settings.py
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.py
@@ -30,8 +30,16 @@ class StockSettings(Document):
 			frappe.make_property_setter({'fieldname': name, 'property': 'hidden',
 				'value': 0 if self.show_barcode_field else 1})
 
+		self.validate_warehouses()
 		self.cant_change_valuation_method()
 		self.validate_clean_description_html()
+
+	def validate_warehouses(self):
+		warehouse_fields = ["default_warehouse", "sample_retention_warehouse"]
+		for field in warehouse_fields:
+			if frappe.db.get_value("Warehouse", self.get(field), "is_group"):
+				frappe.throw(_("Group Warehouses cannot be used in transactions. Please change the value of {0}") \
+					.format(frappe.bold(self.meta.get_field(field).label)), title =_("Incorrect Warehouse"))
 
 	def cant_change_valuation_method(self):
 		db_valuation_method = frappe.db.get_single_value("Stock Settings", "valuation_method")


### PR DESCRIPTION
- Group Warehouses can't be used for transactions, shouldn't be allowed as input in the first place.

**Fixes:**
- Client side query on warehouse Link fields
- Server Side validation
![Screenshot 2020-02-19 at 11 05 47 AM](https://user-images.githubusercontent.com/25857446/74804996-e8924d00-5307-11ea-8f44-cc3409e1a5be.png)

