### PR TITLE
fix: employee Name Standard filter not working

### DIFF
--- a/erpnext/hr/doctype/attendance/attendance.json
+++ b/erpnext/hr/doctype/attendance/attendance.json
@@ -57,11 +57,12 @@
   {
    "fetch_from": "employee.employee_name",
    "fieldname": "employee_name",
-   "fieldtype": "Read Only",
+   "fieldtype": "Data",
    "in_global_search": 1,
    "label": "Employee Name",
    "oldfieldname": "employee_name",
-   "oldfieldtype": "Data"
+   "oldfieldtype": "Data",
+   "read_only": 1
   },
   {
    "default": "Present",
@@ -173,7 +174,7 @@
  "icon": "fa fa-ok",
  "idx": 1,
  "is_submittable": 1,
- "modified": "2019-07-29 20:35:40.845422",
+ "modified": "2020-02-19 14:25:32.945842",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Attendance",


### PR DESCRIPTION
The employee field is disabled due to the field type. in case of confusion ask me.
![image](https://user-images.githubusercontent.com/32095923/74818760-3bc6c880-5325-11ea-9370-7f67f504270e.png)
