### PR TITLE
fix: Additional salary can be created only for active employee

### DIFF
--- a/erpnext/hr/doctype/additional_salary/additional_salary.js
+++ b/erpnext/hr/doctype/additional_salary/additional_salary.js
@@ -8,7 +8,8 @@ frappe.ui.form.on('Additional Salary', {
 		frm.set_query("employee", function() {
 			return {
 				filters: {
-					company: frm.doc.company
+					company: frm.doc.company,
+					status:  "Active"
 				}
 			};
 		});


### PR DESCRIPTION
Before users are also allowed to create an additional salary for an employee who left. 
Now, the only employees with active status are allowed in additional salary.
  #20687