### PR TITLE
fix: Education | Quiz accepting duplicate question #20622

### DIFF
--- a/erpnext/education/doctype/quiz/quiz.js
+++ b/erpnext/education/doctype/quiz/quiz.js
@@ -4,5 +4,18 @@
 frappe.ui.form.on('Quiz', {
 	refresh: function(frm) {
 
+	},
+	validate: function(frm){
+		frm.events.check_duplicate_question(frm.doc.question);
+	},
+	check_duplicate_question: function(questions_data){
+		var questions = [];
+		questions_data.forEach(function(q){
+			questions.push(q.question_link);
+		});
+		var questions_set = new Set(questions);
+		if (questions.length != questions_set.size) {
+			frappe.throw(__("The question cannot be duplicate"));
+		}
 	}
 });


### PR DESCRIPTION
**## Description of the issue**

If the user enters the same question in a question child table of a Quiz form then it still accepting.

**### Solution**

Added validation, now it is not allowed to save Quiz with duplicate questions.