### PR TITLE
fix: rate and amount in material request copying from sales order

### DIFF
--- a/erpnext/stock/doctype/material_request_item/material_request_item.json
+++ b/erpnext/stock/doctype/material_request_item/material_request_item.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "autoname": "hash",
  "creation": "2013-02-22 01:28:02",
  "doctype": "DocType",
@@ -185,12 +186,14 @@
   {
    "fieldname": "rate",
    "fieldtype": "Currency",
-   "label": "Rate"
+   "label": "Rate",
+   "no_copy": 1
   },
   {
    "fieldname": "amount",
    "fieldtype": "Currency",
    "label": "Amount",
+   "no_copy": 1,
    "read_only": 1
   },
   {
@@ -407,7 +410,8 @@
  ],
  "idx": 1,
  "istable": 1,
- "modified": "2019-06-02 06:49:36.493957",
+ "links": [],
+ "modified": "2020-02-25 03:09:10.698967",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Material Request Item",


### PR DESCRIPTION
**Issue**

Rate and amount in the material request item is for budget purpose. When use create the material request from the sales order system copies the rate and amount from the sales order to the material request. If sales order has different currency than company currency then material request shows the rate in the company currency which is incorrect.

**Fix**

Enabled no copy property for rate and amount field in the material request item