### PR TITLE
fix: reorder material request not created if doctype has custom manda…

### DIFF
--- a/erpnext/stock/reorder_item.py
+++ b/erpnext/stock/reorder_item.py
@@ -116,6 +116,8 @@ def create_material_request(material_requests):
 		else:
 			exceptions_list.append(frappe.get_traceback())
 
+		frappe.log_error(frappe.get_traceback())
+
 	for request_type in material_requests:
 		for company in material_requests[request_type]:
 			try:
@@ -158,6 +160,7 @@ def create_material_request(material_requests):
 
 				schedule_dates = [d.schedule_date for d in mr.items]
 				mr.schedule_date = max(schedule_dates or [nowdate()])
+				mr.flags.ignore_mandatory = True
 				mr.insert()
 				mr.submit()
 				mr_list.append(mr)


### PR DESCRIPTION
**Issue**
Added custom field Project Custom and enabled mandatory property for that field.

While making the material request against the reorder qty, got the below error
![image](https://user-images.githubusercontent.com/8780500/75229087-3eb73280-57d7-11ea-80e2-295a0ce748a5.png)
