### PR TITLE
fix(HR): show correct closing leave balance

### DIFF
--- a/erpnext/hr/report/employee_leave_balance/employee_leave_balance.py
+++ b/erpnext/hr/report/employee_leave_balance/employee_leave_balance.py
@@ -76,7 +76,7 @@ def get_data(filters, leave_types):
 				opening = get_leave_balance_on(employee.name, leave_type, filters.from_date)
 
 				# closing balance
-				closing = get_leave_balance_on(employee.name, leave_type, filters.to_date)
+				closing = max(opening - leaves_taken, 0)
 
 				row += [opening, leaves_taken, closing]
 


### PR DESCRIPTION
**Issue:** Incorrect closing leave balance is displayed when the filter to date is set as last day of the leave allocation period.