### PR TITLE
fix: Create a new item on Material Request showing error Item None not fou…

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -145,6 +145,7 @@ frappe.ui.form.on('Material Request', {
 	},
 
 	get_item_data: function(frm, item) {
+		if (!item.item_code) return;
 		frm.call({
 			method: "erpnext.stock.get_item_details.get_item_details",
 			child: item,


### PR DESCRIPTION
**ISSUE:** While creating Material Request if a user creates a new item in Material Request child table it throwing unexpected error `"Item None not found"` "The resource you are looking for is not available".

_- Handled this issue on Material Request if the item is not available and if the user clicks outside without creating the item restricted the frappe call with return statement._