### PR TITLE
fix: Lock stock ledger entries that are being reposted.

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -429,7 +429,7 @@ def get_future_stock_vouchers(posting_date, posting_time, for_warehouses=None, f
 	for d in frappe.db.sql("""select distinct sle.voucher_type, sle.voucher_no
 		from `tabStock Ledger Entry` sle
 		where timestamp(sle.posting_date, sle.posting_time) >= timestamp(%s, %s) {condition}
-		order by timestamp(sle.posting_date, sle.posting_time) asc, creation asc""".format(condition=condition),
+		order by timestamp(sle.posting_date, sle.posting_time) asc, creation asc for update""".format(condition=condition),
 		tuple([posting_date, posting_time] + values), as_dict=True):
 			future_stock_vouchers.append([d.voucher_type, d.voucher_no])
 


### PR DESCRIPTION
**Case:**
- Stock Ledger Entry was being reposted and Stock Entry was being cancelled at the same time.
- Stock Entry got cancelled, but this particular Stock Ledger Entry associated to it stayed (due to reposting).

**Fix:**
- During Reposting, don't let any other transaction utilise this Stock Ledger Entry
- In this case, only after the repost is completed cancel the Stock Ledger Entry.