### PR TITLE
feat: ignore permission when deleting linked emails

### DIFF
--- a/erpnext/setup/doctype/company/delete_company_transactions.py
+++ b/erpnext/setup/doctype/company/delete_company_transactions.py
@@ -15,9 +15,9 @@ def delete_company_transactions(company_name):
 	frappe.only_for("System Manager")
 	doc = frappe.get_doc("Company", company_name)
 
-	if frappe.session.user != doc.owner:
-		frappe.throw(_("Transactions can only be deleted by the creator of the Company"),
-			frappe.PermissionError)
+	# if frappe.session.user != doc.owner:
+	# 	frappe.throw(_("Transactions can only be deleted by the creator of the Company"),
+	# 		frappe.PermissionError)
 
 	delete_bins(company_name)
 	delete_lead_addresses(company_name)
@@ -108,8 +108,8 @@ def delete_lead_addresses(company_name):
 def delete_communications(doctype, company_name, company_fieldname):
 		reference_docs = frappe.get_all(doctype, filters={company_fieldname:company_name})
 		reference_doc_names = [r.name for r in reference_docs]
-		
+
 		communications = frappe.get_all("Communication", filters={"reference_doctype":doctype,"reference_name":["in", reference_doc_names]})
 		communication_names = [c.name for c in communications]
 
-		frappe.delete_doc("Communication", communication_names)
+		frappe.delete_doc("Communication", communication_names, ignore_permissions=True)

--- a/erpnext/setup/doctype/company/delete_company_transactions.py
+++ b/erpnext/setup/doctype/company/delete_company_transactions.py
@@ -15,9 +15,9 @@ def delete_company_transactions(company_name):
 	frappe.only_for("System Manager")
 	doc = frappe.get_doc("Company", company_name)
 
-	# if frappe.session.user != doc.owner:
-	# 	frappe.throw(_("Transactions can only be deleted by the creator of the Company"),
-	# 		frappe.PermissionError)
+	if frappe.session.user != doc.owner:
+		frappe.throw(_("Transactions can only be deleted by the creator of the Company"),
+			frappe.PermissionError)
 
 	delete_bins(company_name)
 	delete_lead_addresses(company_name)


### PR DESCRIPTION
Only Administrators could delete company transactions because email queue had the permissions applied. This PR ignores permissions when deleting email queue.