### PR TITLE
fix(auto attendance): bug in marking absent

### DIFF
--- a/erpnext/hr/doctype/shift_type/shift_type.py
+++ b/erpnext/hr/doctype/shift_type/shift_type.py
@@ -75,7 +75,7 @@ class ShiftType(Document):
 		for date in dates:
 			shift_details = get_employee_shift(employee, date, True)
 			if shift_details and shift_details.shift_type.name == self.name:
-				mark_attendance(employee, date, self.name, 'Absent')
+				mark_attendance(employee, date, 'Absent', self.name)
 
 	def get_assigned_employee(self, from_date=None, consider_default_shift=False):
 		filters = {'date':('>=', from_date), 'shift_type': self.name, 'docstatus': '1'}


### PR DESCRIPTION
This bug was introduces in the commit bd6e8b9cec5414f81c67468030ec174030845720

i.e. The mark_absent function was renamed to mark_attendance, but there is a miss-match in the order of the parameters.

Note: This change is present only on the develop branch. Hence, no PR required for hotfix branches.