### PR TITLE
fix: Item Wise report query fix

### DIFF
--- a/erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py
+++ b/erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py
@@ -306,10 +306,6 @@ def get_conditions(filters):
 
 def get_items(filters, additional_query_columns):
 	conditions = get_conditions(filters)
-	match_conditions = frappe.build_match_conditions("Purchase Invoice")
-
-	if match_conditions:
-		match_conditions = " and {0} ".format(match_conditions)
 
 	if additional_query_columns:
 		additional_query_columns = ', ' + ', '.join(additional_query_columns)
@@ -327,8 +323,8 @@ def get_items(filters, additional_query_columns):
 			`tabPurchase Invoice`.supplier_name, `tabPurchase Invoice`.mode_of_payment {0}
 		from `tabPurchase Invoice`, `tabPurchase Invoice Item`
 		where `tabPurchase Invoice`.name = `tabPurchase Invoice Item`.`parent` and
-		`tabPurchase Invoice`.docstatus = 1 %s %s
-	""".format(additional_query_columns) % (conditions, match_conditions), filters, as_dict=1)
+		`tabPurchase Invoice`.docstatus = 1 %s
+	""".format(additional_query_columns) % (conditions), filters, as_dict=1)
 
 def get_aii_accounts():
 	return dict(frappe.db.sql("select name, stock_received_but_not_billed from tabCompany"))

--- a/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py
+++ b/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py
@@ -119,7 +119,7 @@ def _execute(filters=None, additional_table_columns=None, additional_query_colum
 		add_sub_total_row(total_row, total_row_map, 'total_row', tax_columns)
 		data.append(total_row_map.get('total_row'))
 		skip_total_row = 1
-	
+
 	return columns, data, None, None, None, skip_total_row
 
 def get_columns(additional_table_columns, filters):
@@ -370,10 +370,6 @@ def get_group_by_conditions(filters, doctype):
 
 def get_items(filters, additional_query_columns):
 	conditions = get_conditions(filters)
-	match_conditions = frappe.build_match_conditions("Sales Invoice")
-
-	if match_conditions:
-		match_conditions = " and {0} ".format(match_conditions)
 
 	if additional_query_columns:
 		additional_query_columns = ', ' + ', '.join(additional_query_columns)
@@ -394,8 +390,8 @@ def get_items(filters, additional_query_columns):
 			`tabSales Invoice`.update_stock, `tabSales Invoice Item`.uom, `tabSales Invoice Item`.qty {0}
 		from `tabSales Invoice`, `tabSales Invoice Item`
 		where `tabSales Invoice`.name = `tabSales Invoice Item`.parent
-			and `tabSales Invoice`.docstatus = 1 {1} {2}
-		""".format(additional_query_columns or '', conditions, match_conditions), filters, as_dict=1) #nosec
+			and `tabSales Invoice`.docstatus = 1 {1}
+		""".format(additional_query_columns or '', conditions), filters, as_dict=1) #nosec
 
 def get_delivery_notes_against_sales_order(item_list):
 	so_dn_map = frappe._dict()


### PR DESCRIPTION
Due to recent changes in query building order for item wise reports the following mysql error was encountered if user permission is applied

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2020-02-24/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-12-2020-02-24/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-12-2020-02-24/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-12-2020-02-24/apps/frappe/frappe/handler.py", line 61, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-12-2020-02-24/apps/frappe/frappe/__init__.py", line 1051, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-12-2020-02-24/apps/frappe/frappe/__init__.py", line 524, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "/home/frappe/benches/bench-version-12-2020-02-24/apps/frappe/frappe/desk/query_report.py", line 186, in run
    result = generate_report_result(report, filters, user)
  File "/home/frappe/benches/bench-version-12-2020-02-24/apps/frappe/frappe/desk/query_report.py", line 68, in generate_report_result
    res = report.execute_script_report(filters)
  File "/home/frappe/benches/bench-version-12-2020-02-24/apps/frappe/frappe/core/doctype/report/report.py", line 104, in execute_script_report
    res = self.execute_module(filters)
  File "/home/frappe/benches/bench-version-12-2020-02-24/apps/frappe/frappe/core/doctype/report/report.py", line 121, in execute_module
    return frappe.get_attr(method_name)(frappe._dict(filters))
  File "/home/frappe/benches/bench-version-12-2020-02-24/apps/erpnext/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py", line 13, in execute
    return _execute(filters)
  File "/home/frappe/benches/bench-version-12-2020-02-24/apps/erpnext/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py", line 22, in _execute
    item_list = get_items(filters, additional_query_columns)
  File "/home/frappe/benches/bench-version-12-2020-02-24/apps/erpnext/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py", line 398, in get_items
    """.format(additional_query_columns or '', conditions, match_conditions), filters, as_dict=1) #nosec
  File "/home/frappe/benches/bench-version-12-2020-02-24/apps/frappe/frappe/database/database.py", line 156, in sql
    self._cursor.execute(query, values)
  File "/home/frappe/benches/bench-version-12-2020-02-24/env/lib/python3.6/site-packages/pymysql/cursors.py", line 170, in execute
    result = self._query(query)
  File "/home/frappe/benches/bench-version-12-2020-02-24/env/lib/python3.6/site-packages/pymysql/cursors.py", line 328, in _query
    conn.query(q)
  File "/home/frappe/benches/bench-version-12-2020-02-24/env/lib/python3.6/site-packages/pymysql/connections.py", line 517, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/home/frappe/benches/bench-version-12-2020-02-24/env/lib/python3.6/site-packages/pymysql/connections.py", line 732, in _read_query_result
    result.read()
  File "/home/frappe/benches/bench-version-12-2020-02-24/env/lib/python3.6/site-packages/pymysql/connections.py", line 1075, in read
    first_packet = self.connection._read_packet()
  File "/home/frappe/benches/bench-version-12-2020-02-24/env/lib/python3.6/site-packages/pymysql/connections.py", line 684, in _read_packet
    packet.check_error()
  File "/home/frappe/benches/bench-version-12-2020-02-24/env/lib/python3.6/site-packages/pymysql/protocol.py", line 220, in check_error
    err.raise_mysql_exception(self._data)
  File "/home/frappe/benches/bench-version-12-2020-02-24/env/lib/python3.6/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.ProgrammingError: (1064, "You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'and (((coalesce(`tabSales Invoice`.`company`, '')='' or `tabSales Invoice`.`comp' at line 16")

```

**Solution**
Removed matched conditions as build_match_conditions is called in `query_report.py` for relevant doctypes. No need to call it separately in reports