### PR TITLE
fix: Student Admission accepting end date less than start date. #20625

### DIFF
--- a/erpnext/education/doctype/student_admission/student_admission.js
+++ b/erpnext/education/doctype/student_admission/student_admission.js
@@ -11,5 +11,12 @@ frappe.ui.form.on('Student Admission', {
 
 	academic_year: function(frm) {
 		frm.trigger("program");
+	},
+
+	admission_end_date: function(frm) {
+		if(frm.doc.admission_end_date && frm.doc.admission_end_date <= frm.doc.admission_start_date){
+			frm.set_value("admission_end_date", "");
+			frappe.throw(__("Admission End Date should be greater than Admission Start Date."));
+		}
 	}
 });


### PR DESCRIPTION
Steps to reproduce the issue:

Go to Student Admission form.
Select end date less than start date.
Save the form.
Description:
End date of admission should not be accepted less than start date.

Expected Result:
Throw a validation message or should not save the form.