### PR TITLE
fix: set status to object instead of variable

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
@@ -149,6 +149,49 @@ class TestPaymentEntry(unittest.TestCase):
 		outstanding_amount = flt(frappe.db.get_value("Sales Invoice", pi.name, "outstanding_amount"))
 		self.assertEqual(outstanding_amount, 0)
 
+
+	def test_payment_against_sales_invoice_to_check_status(self):
+		si = create_sales_invoice(customer="_Test Customer USD", debit_to="_Test Receivable USD - _TC",
+			currency="USD", conversion_rate=50)
+
+		pe = get_payment_entry("Sales Invoice", si.name, bank_account="_Test Bank USD - _TC")
+		pe.reference_no = "1"
+		pe.reference_date = "2016-01-01"
+		pe.target_exchange_rate = 50
+		pe.insert()
+		pe.submit()
+
+		outstanding_amount = flt(frappe.db.get_value("Sales Invoice", si.name, "outstanding_amount"))
+		self.assertEqual(outstanding_amount, 0)
+		self.assertEqual(si.status, 'Paid')
+
+		pe.cancel()
+
+		outstanding_amount = flt(frappe.db.get_value("Sales Invoice", si.name, "outstanding_amount"))
+		self.assertEqual(outstanding_amount, 100)
+		self.assertEqual(si.status, 'Unpaid')
+
+	def test_payment_against_purchase_invoice_to_check_status(self):
+		pi = make_purchase_invoice(supplier="_Test Supplier USD", debit_to="_Test Payable USD - _TC",
+			currency="USD", conversion_rate=50)
+
+		pe = get_payment_entry("Purchase Invoice", pi.name, bank_account="_Test Bank USD - _TC")
+		pe.reference_no = "1"
+		pe.reference_date = "2016-01-01"
+		pe.source_exchange_rate = 50
+		pe.insert()
+		pe.submit()
+
+		outstanding_amount = flt(frappe.db.get_value("Purchase Invoice", pi.name, "outstanding_amount"))
+		self.assertEqual(outstanding_amount, 0)
+		self.assertEqual(pi.status, 'Paid')
+
+		pe.cancel()
+
+		outstanding_amount = flt(frappe.db.get_value("Purchase Invoice", pi.name, "outstanding_amount"))
+		self.assertEqual(outstanding_amount, 100)
+		self.assertEqual(pi.status, 'Unpaid')
+
 	def test_payment_entry_against_ec(self):
 
 		payable = frappe.get_cached_value('Company',  "_Test Company",  'default_payable_account')

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -136,15 +136,15 @@ class PurchaseInvoice(BuyingController):
 			args = [
 				self.name,
 				self.outstanding_amount,
-				self.is_return, 
-				self.due_date, 
+				self.is_return,
+				self.due_date,
 				self.docstatus,
 				precision
 			]
-			status = get_status(args)
+			self.status = get_status(args)
 
 		if update:
-			self.db_set('status', status, update_modified = update_modified)
+			self.db_set('status', self.status, update_modified = update_modified)
 
 	def set_missing_values(self, for_validate=False):
 		if not self.credit_to:
@@ -1053,7 +1053,7 @@ def get_status(*args):
 			status = "Submitted"
 	else:
 		status = "Draft"
-	
+
 	return status
 
 def get_list_context(context=None):

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -1228,16 +1228,16 @@ class SalesInvoice(SellingController):
 			args = [
 				self.name,
 				self.outstanding_amount,
-				self.is_discounted, 
-				self.is_return, 
-				self.due_date, 
+				self.is_discounted,
+				self.is_return,
+				self.due_date,
 				self.docstatus,
 				precision,
 			]
-			status = get_status(args)
+			self.status = get_status(args)
 
 		if update:
-			self.db_set('status', status, update_modified = update_modified)
+			self.db_set('status', self.status, update_modified = update_modified)
 
 def get_discounting_status(sales_invoice):
 	status = None
@@ -1261,7 +1261,7 @@ def get_discounting_status(sales_invoice):
 
 def get_status(*args):
 	sales_invoice, outstanding_amount, is_discounted, is_return, due_date, docstatus, precision = args[0]
-	
+
 	discounting_status = None
 	if is_discounted:
 		discounting_status = get_discounting_status(sales_invoice)
@@ -1292,7 +1292,7 @@ def get_status(*args):
 			status = "Submitted"
 	else:
 		status = "Draft"
-	
+
 	return status
 
 def validate_inter_company_party(doctype, party, company, inter_company_reference):
@@ -1465,7 +1465,7 @@ def get_inter_company_details(doc, doctype):
 		"party": party,
 		"company": company
 	}
-  
+
 def get_internal_party(parties, link_doctype, doc):
 	if len(parties) == 1:
 			party = parties[0].name


### PR DESCRIPTION
## Issue : Though the outstanding amount is zero, the status remains unpaid. 

<img width="1163" alt="Screenshot 2020-03-02 at 11 45 21 AM" src="https://user-images.githubusercontent.com/3784093/75656016-115ffe00-5c89-11ea-8990-d53e54932c0b.png">

<img width="1197" alt="Screenshot 2020-03-02 at 11 45 03 AM" src="https://user-images.githubusercontent.com/3784093/75656026-158c1b80-5c89-11ea-9d6f-4b7ff08bd7b6.png">

#### Reason: while calling get_status method, we do not set the returned status to object

