### PR TITLE
fix: Set batch no in Manufacturing Stock Entry as per transferred raw materials

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -398,16 +398,13 @@ class StockEntry(StockController):
 						frappe.bold(d.transfer_qty)),
 					NegativeStockError, title=_('Insufficient Stock'))
 
-	def set_serial_nos(self, work_order):
+	def set_serial_batch_nos(self, work_order):
 		previous_se = frappe.db.get_value("Stock Entry", {"work_order": work_order,
 				"purpose": "Material Transfer for Manufacture"}, "name")
 
 		for d in self.get('items'):
-			transferred_serial_no = frappe.db.get_value("Stock Entry Detail",{"parent": previous_se,
-				"item_code": d.item_code}, "serial_no")
-			
-			transferred_batch_no = frappe.db.get_value("Stock Entry Detail",{"parent": previous_se,
-				"item_code": d.item_code}, "batch_no")
+			transferred_serial_no, transferred_batch_no= frappe.db.get_value("Stock Entry Detail",{"parent": previous_se,
+				"item_code": d.item_code}, ["serial_no", "batch_no"])
 
 			if transferred_serial_no:
 				d.serial_no = transferred_serial_no
@@ -885,7 +882,7 @@ class StockEntry(StockController):
 
 			# fetch the serial_no of the first stock entry for the second stock entry
 			if self.work_order and self.purpose == "Manufacture":
-				self.set_serial_nos(self.work_order)
+				self.set_serial_batch_nos(self.work_order)
 				work_order = frappe.get_doc('Work Order', self.work_order)
 				add_additional_cost(self, work_order)
 

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -405,10 +405,16 @@ class StockEntry(StockController):
 		for d in self.get('items'):
 			transferred_serial_no = frappe.db.get_value("Stock Entry Detail",{"parent": previous_se,
 				"item_code": d.item_code}, "serial_no")
+			
+			transferred_batch_no = frappe.db.get_value("Stock Entry Detail",{"parent": previous_se,
+				"item_code": d.item_code}, "batch_no")
 
 			if transferred_serial_no:
 				d.serial_no = transferred_serial_no
-
+			
+			if transferred_batch_no:
+				d.batch_no = transferred_batch_no
+			
 	def get_stock_and_rate(self):
 		self.set_work_order_details()
 		self.set_transfer_qty()


### PR DESCRIPTION
Fetched batch number in stock_entry.py and applied to item

Before:
![Batch_no_Task](https://user-images.githubusercontent.com/56826544/75663537-fd22fd80-5c96-11ea-94e7-e09b4048b76a.gif)


After:
![batch_number_fix](https://user-images.githubusercontent.com/56826544/75663550-044a0b80-5c97-11ea-80f4-fd96daaa4b8b.gif)
