### PR TITLE
fix: handle error handling (v12)

### DIFF
--- a/erpnext/stock/doctype/delivery_trip/delivery_trip.py
+++ b/erpnext/stock/doctype/delivery_trip/delivery_trip.py
@@ -238,7 +238,7 @@ class DeliveryTrip(Document):
 		try:
 			directions = maps_client.directions(**directions_data)
 		except Exception as e:
-			frappe.throw(_(e))
+			frappe.throw(_(str(e)))
 
 		return directions[0] if directions else False
 


### PR DESCRIPTION
**Problem:**

When processing delivery routes, if there's bad inputs in the address, then the system fails trying to handle the error.

```python
TypeError: Expected a lat/lng dict or tuple, but got NoneType

During handling of the above exception, another exception occurred:

TypeError: Object of type 'TypeError' is not JSON serializable
```