### PR TITLE
fix: HSN code no visible in GST itemised sales register

### DIFF
--- a/erpnext/regional/report/gst_itemised_sales_register/gst_itemised_sales_register.py
+++ b/erpnext/regional/report/gst_itemised_sales_register/gst_itemised_sales_register.py
@@ -15,7 +15,7 @@ def execute(filters=None):
 		dict(fieldtype='Data', label='GST Category', fieldname="gst_category", width=120),
 		dict(fieldtype='Data', label='Export Type', fieldname="export_type", width=120),
 		dict(fieldtype='Data', label='E-Commerce GSTIN', fieldname="ecommerce_gstin", width=130),
-		dict(fieldtype='Data', label='HSN Code', fieldname="hsn_code", width=120)
+		dict(fieldtype='Data', label='HSN Code', fieldname="gst_hsn_code", width=120)
 	], additional_query_columns=[
 		'customer_gstin',
 		'billing_address_gstin',


### PR DESCRIPTION
HSN code not visible in GST itemised sales register because of fieldname and column name mismatch 