### PR TITLE
fix: use ERPNext in welcome email when default company is not set

### DIFF
--- a/erpnext/setup/utils.py
+++ b/erpnext/setup/utils.py
@@ -141,6 +141,6 @@ def insert_record(records):
 				raise
 
 def welcome_email():
-	site_name = get_default_company()
-	title = _("Welcome to {0}".format(site_name))
+	site_name = get_default_company() or "ERPNext"
+	title = _("Welcome to {0}").format(site_name)
 	return title


### PR DESCRIPTION
Issue:

![image](https://user-images.githubusercontent.com/11243138/75948748-3f805080-5eca-11ea-89b1-0324a558f708.png)

port of #20835 