### PR TITLE
fix: update_child_qty_rate() missing argument

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -439,12 +439,13 @@ erpnext.utils.update_child_items = function(opts) {
 	const dialog = new frappe.ui.Dialog({
 		title: __("Update Items"),
 		fields: [
-			{fieldtype:'Section Break', label: __('Items')},
 			{
 				fieldname: "trans_items",
 				fieldtype: "Table",
+				label: "Items",
 				cannot_add_rows: cannot_add_row,
 				in_place_edit: true,
+				reqd: 1,
 				data: this.data,
 				get_data: () => {
 					return this.data;


### PR DESCRIPTION
**Issue**:
- `update_child_qty_rate() missing 1 required positional argument: 'trans_items' ` 

**After Fix:**
- Made Items table field mandatory
![Screenshot 2020-03-05 at 10 34 28 AM](https://user-images.githubusercontent.com/25857446/75949567-a3a41400-5ecc-11ea-9b1d-d8f92ba9184a.png)

- Removed Section Break and Added Label to Items table
![Screenshot 2020-03-05 at 10 32 34 AM](https://user-images.githubusercontent.com/25857446/75949473-6049a580-5ecc-11ea-9cc9-778efe09e1d3.png)
