### PR TITLE
fix: show uom in print formats instead of stock uom

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
+++ b/erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
@@ -63,7 +63,6 @@
   "warehouse_section",
   "warehouse",
   "rejected_warehouse",
-  "from_warehouse",
   "quality_inspection",
   "batch_no",
   "col_br_wh",
@@ -199,7 +198,6 @@
    "fieldtype": "Link",
    "label": "UOM",
    "options": "UOM",
-   "print_hide": 1,
    "reqd": 1
   },
   {
@@ -763,22 +761,16 @@
    "fetch_from": "item_code.asset_category",
    "fieldname": "asset_category",
    "fieldtype": "Data",
+   "in_preview": 1,
    "label": "Asset Category",
    "options": "Asset Category",
    "read_only": 1
-  },
-  {
-   "fieldname": "from_warehouse",
-   "fieldtype": "Link",
-   "ignore_user_permissions": 1,
-   "label": "Supplier Warehouse",
-   "options": "Warehouse"
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-01-13 16:04:14.200462",
+ "modified": "2020-03-05 14:20:17.297284",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Purchase Invoice Item",

--- a/erpnext/selling/doctype/quotation_item/quotation_item.json
+++ b/erpnext/selling/doctype/quotation_item/quotation_item.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "creation": "2013-03-07 11:42:57",
  "doctype": "DocType",
  "document_type": "Document",
@@ -163,6 +164,7 @@
    "oldfieldname": "stock_uom",
    "oldfieldtype": "Data",
    "options": "UOM",
+   "print_hide": 1,
    "print_width": "100px",
    "read_only": 1,
    "width": "100px"
@@ -176,7 +178,6 @@
    "fieldtype": "Link",
    "label": "UOM",
    "options": "UOM",
-   "print_hide": 1,
    "reqd": 1
   },
   {
@@ -382,6 +383,7 @@
    "read_only": 1
   },
   {
+   "default": "0",
    "fieldname": "is_free_item",
    "fieldtype": "Check",
    "label": "Is Free Item",
@@ -517,6 +519,7 @@
   },
   {
    "allow_on_submit": 1,
+   "default": "0",
    "fieldname": "page_break",
    "fieldtype": "Check",
    "label": "Page Break",
@@ -574,7 +577,8 @@
  ],
  "idx": 1,
  "istable": 1,
- "modified": "2019-05-01 17:39:14.228141",
+ "links": [],
+ "modified": "2020-03-05 14:18:58.783751",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Quotation Item",

--- a/erpnext/selling/doctype/sales_order_item/sales_order_item.json
+++ b/erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -212,7 +212,6 @@
    "fieldtype": "Link",
    "label": "UOM",
    "options": "UOM",
-   "print_hide": 1,
    "reqd": 1
   },
   {
@@ -770,7 +769,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-01-13 12:29:03.103797",
+ "modified": "2020-03-05 14:20:28.085117",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order Item",

--- a/erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
+++ b/erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "autoname": "hash",
  "creation": "2013-04-22 13:15:44",
  "doctype": "DocType",
@@ -180,6 +181,7 @@
    "oldfieldname": "stock_uom",
    "oldfieldtype": "Data",
    "options": "UOM",
+   "print_hide": 1,
    "print_width": "50px",
    "read_only": 1,
    "reqd": 1,
@@ -195,7 +197,6 @@
    "in_list_view": 1,
    "label": "UOM",
    "options": "UOM",
-   "print_hide": 1,
    "reqd": 1
   },
   {
@@ -702,7 +703,8 @@
  ],
  "idx": 1,
  "istable": 1,
- "modified": "2019-05-25 22:08:27.452734",
+ "links": [],
+ "modified": "2020-03-05 14:18:33.131672",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Note Item",

--- a/erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
+++ b/erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
@@ -68,7 +68,6 @@
   "warehouse_and_reference",
   "warehouse",
   "rejected_warehouse",
-  "from_warehouse",
   "purchase_order",
   "material_request",
   "column_break_40",
@@ -224,7 +223,6 @@
    "oldfieldname": "uom",
    "oldfieldtype": "Link",
    "options": "UOM",
-   "print_hide": 1,
    "print_width": "100px",
    "reqd": 1,
    "width": "100px"
@@ -817,23 +815,16 @@
    "fetch_from": "item_code.asset_category",
    "fieldname": "asset_category",
    "fieldtype": "Link",
+   "in_preview": 1,
    "label": "Asset Category",
    "options": "Asset Category",
    "read_only": 1
-  },
-  {
-   "fieldname": "from_warehouse",
-   "fieldtype": "Link",
-   "hidden": 1,
-   "ignore_user_permissions": 1,
-   "label": "Supplier Warehouse",
-   "options": "Warehouse"
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-01-13 16:03:34.879827",
+ "modified": "2020-03-05 14:19:48.799370",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Purchase Receipt Item",


### PR DESCRIPTION
Before:
<img width="1260" alt="Screenshot 2020-03-05 at 2 21 16 PM" src="https://user-images.githubusercontent.com/25369014/75965062-44ef9200-5eee-11ea-8ad0-943863dc67cb.png">

After:
<img width="1260" alt="Screenshot 2020-03-05 at 1 58 46 PM" src="https://user-images.githubusercontent.com/25369014/75965083-4c16a000-5eee-11ea-87af-bda1185c80d6.png">
