### PR TITLE
fix: Validate Serial No/Batch No against unserialized Item in Stock Reconciliation

### DIFF
--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -190,6 +190,9 @@ class StockReconciliation(StockController):
 				has_serial_no = True
 				self.get_sle_for_serialized_items(row, sl_entries)
 			else:
+				if row.serial_no or row.batch_no:
+					frappe.throw(_("Row #{0}: Item {1} is not a Serialized/Batched Item. It cannot have a Serial No/Batch No against it.") \
+						.format(row.idx, frappe.bold(row.item_code)))
 				previous_sle = get_previous_sle({
 					"item_code": row.item_code,
 					"warehouse": row.warehouse,


### PR DESCRIPTION
- On adding Serial No against Item with Has Serial No=0 :
   ```
  bench/apps/erpnext/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py", line 
  373, in merge_similar_item_serial_nos
     if not d.serial_no or d.actual_qty < 0:
  TypeError: '<' not supported between instances of 'NoneType' and 'int'
  ```
- Where it broke:
   ```python
    if item.has_serial_no or item.has_batch_no:
	   has_serial_no = True
	   self.get_sle_for_serialized_items(row, sl_entries)
    ```
    Since it didn't satisfy the condition , the item sle did not have any `actual_qty` against it

- **After Fix:**
  ![Screenshot 2020-03-06 at 2 16 43 PM](https://user-images.githubusercontent.com/25857446/76069156-70d74a00-5fb8-11ea-8ff0-eb29a0822232.png)
