### PR TITLE
fix: [pos] customer group filter resets on syncing offline invoices

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/pos.py
+++ b/erpnext/accounts/doctype/sales_invoice/pos.py
@@ -207,7 +207,7 @@ def get_customers_list(pos_profile={}):
 	if pos_profile.get('customer_groups'):
 		# Get customers based on the customer groups defined in the POS profile
 		for d in pos_profile.get('customer_groups'):
-			customer_groups.extend([d.name for d in get_child_nodes('Customer Group', d.customer_group)])
+			customer_groups.extend([d.get('name') for d in get_child_nodes('Customer Group', d.get('customer_group'))])
 		cond = "customer_group in (%s)" % (', '.join(['%s'] * len(customer_groups)))
 
 	return frappe.db.sql(""" select name, customer_name, customer_group,
@@ -387,7 +387,9 @@ def get_pricing_rule_data(doc):
 
 
 @frappe.whitelist()
-def make_invoice(doc_list={}, email_queue_list={}, customers_list={}):
+def make_invoice(pos_profile, doc_list={}, email_queue_list={}, customers_list={}):
+	import json
+
 	if isinstance(doc_list, string_types):
 		doc_list = json.loads(doc_list)
 
@@ -421,7 +423,8 @@ def make_invoice(doc_list={}, email_queue_list={}, customers_list={}):
 				name_list.append(name)
 
 	email_queue = make_email_queue(email_queue_list)
-	customers = get_customers_list()
+	pos_profile = json.loads(pos_profile)
+	customers = get_customers_list(pos_profile)
 	return {
 		'invoice': name_list,
 		'email_queue': email_queue,

--- a/erpnext/accounts/page/pos/pos.js
+++ b/erpnext/accounts/page/pos/pos.js
@@ -1769,6 +1769,7 @@ erpnext.pos.PointOfSale = erpnext.taxes_and_totals.extend({
 				method: "erpnext.accounts.doctype.sales_invoice.pos.make_invoice",
 				freeze: true,
 				args: {
+					pos_profile: me.pos_profile_data,
 					doc_list: me.si_docs,
 					email_queue_list: me.email_queue_list,
 					customers_list: me.customers_list


### PR DESCRIPTION
Problem: Setting a customer group in pos profile filters out customers, however on pos offline screen if sync invoices action is performed, the filter resets and all group's customer is shown.