### PR TITLE
fix: null fields being set in Integration Request

### DIFF
--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -126,12 +126,12 @@ class PaymentRequest(Document):
 
 		return controller.get_payment_url(**{
 			"amount": flt(self.grand_total, self.precision("grand_total")),
-			"title": data.company.encode("utf-8"),
-			"description": self.subject.encode("utf-8"),
+			"title": frappe.as_unicode(data.company),
+			"description": frappe.as_unicode(self.subject),
 			"reference_doctype": "Payment Request",
 			"reference_docname": self.name,
 			"payer_email": self.email_to or frappe.session.user,
-			"payer_name": frappe.safe_encode(data.customer_name),
+			"payer_name": frappe.as_unicode(data.customer_name),
 			"order_id": self.name,
 			"currency": self.currency
 		})


### PR DESCRIPTION
In py3, `string.encode("utf-8")` results in strings of type **bytestrings** instead of the expected **unicode** as in py2. And py3 throws _TypeError_ when `json.dumps` is called on any object containing bytestrings.

Therefore the `json.dumps` called on the _kwargs_ during **Integration Request** creation fails. However this happens silently and some of the fields in the **Integration Request**._data_ json ends up with _null_.

This PR should prevent this from happening in py3 environments while leaving the behavior in py2 unchanged.