### PR TITLE
fix: reserved qty for production issue for partial completion of work…

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -429,15 +429,15 @@ class WorkOrder(Document):
 		update bin reserved_qty_for_production
 		called from Stock Entry for production, after submit, cancel
 		'''
+		# calculate consumed qty based on submitted stock entries
+		self.update_consumed_qty_for_required_items()
+
 		if self.docstatus==1:
 			# calculate transferred qty based on submitted stock entries
 			self.update_transaferred_qty_for_required_items()
 
 			# update in bin
 			self.update_reserved_qty_for_production()
-
-		# calculate consumed qty based on submitted stock entries
-		self.update_consumed_qty_for_required_items()
 
 	def update_reserved_qty_for_production(self, items=None):
 		'''update reserved_qty_for_production in bins'''

--- a/erpnext/stock/doctype/bin/bin.py
+++ b/erpnext/stock/doctype/bin/bin.py
@@ -69,15 +69,21 @@ class Bin(Document):
 		'''Update qty reserved for production from Production Item tables
 			in open work orders'''
 		self.reserved_qty_for_production = frappe.db.sql('''
-			select sum(item.required_qty - item.transferred_qty)
-			from `tabWork Order` pro, `tabWork Order Item` item
-			where
+			SELECT
+				CASE WHEN ifnull(skip_transfer, 0) = 0 THEN
+					SUM(item.required_qty - item.transferred_qty)
+				ELSE
+					SUM(item.required_qty - item.consumed_qty)
+				END
+			FROM `tabWork Order` pro, `tabWork Order Item` item
+			WHERE
 				item.item_code = %s
 				and item.parent = pro.name
 				and pro.docstatus = 1
 				and item.source_warehouse = %s
 				and pro.status not in ("Stopped", "Completed")
-				and item.required_qty > item.transferred_qty''', (self.item_code, self.warehouse))[0][0]
+				and (item.required_qty > item.transferred_qty or item.required_qty > item.consumed_qty)
+		''', (self.item_code, self.warehouse))[0][0]
 
 		self.set_projected_qty()
 


### PR DESCRIPTION
**Issue**

Steps to replicate issue

1. Created work order for 5 qty and enabled skip material transfer

1. Created manufacturing entry for the 2 items

1. Reserved qty for production in the BIN has not updated.

1. Created manufacturing entry for the 3 items then Reserved qty for production has updated as Zero.

So for partial completion the Reserved qty for production has not updated if skip material transfer has enabled in the work order 