### PR TITLE
fix: fix options of currency fieldtype in Expense Taxes and Charges

### DIFF
--- a/erpnext/hr/doctype/expense_taxes_and_charges/expense_taxes_and_charges.json
+++ b/erpnext/hr/doctype/expense_taxes_and_charges/expense_taxes_and_charges.json
@@ -71,7 +71,7 @@
    "label": "Amount",
    "oldfieldname": "tax_amount",
    "oldfieldtype": "Currency",
-   "options": "currency"
+   "options": "Company:company:default_currency"
   },
   {
    "columns": 2,
@@ -81,7 +81,7 @@
    "label": "Total",
    "oldfieldname": "total",
    "oldfieldtype": "Currency",
-   "options": "currency",
+   "options": "Company:company:default_currency",
    "read_only": 1
   },
   {
@@ -95,7 +95,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2019-12-11 13:50:02.883328",
+ "modified": "2020-03-11 13:25:06.721917",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Expense Taxes and Charges",


### PR DESCRIPTION
Fixes:
<img width="1199" alt="Screenshot 2020-03-11 at 1 32 09 PM" src="https://user-images.githubusercontent.com/19775888/76395190-c044be00-639c-11ea-9db6-8cdd334fa5c8.png">

