### PR TITLE
fix: remove make_purchase_invoice from demo script

### DIFF
--- a/erpnext/demo/user/fixed_asset.py
+++ b/erpnext/demo/user/fixed_asset.py
@@ -6,46 +6,28 @@ from __future__ import unicode_literals
 
 import frappe
 from frappe.utils.make_random import get_random
-from erpnext.assets.doctype.asset.asset import make_purchase_invoice, make_sales_invoice
+from erpnext.assets.doctype.asset.asset import make_sales_invoice
 from erpnext.assets.doctype.asset.depreciation import post_depreciation_entries, scrap_asset
+
 
 def work():
 	frappe.set_user(frappe.db.get_global('demo_accounts_user'))
 
-	asset_list = make_asset_purchase_entry()
-
-	if not asset_list:
-		# fixed_asset.work() already run
-		return
-		
 	# Enable booking asset depreciation entry automatically
 	frappe.db.set_value("Accounts Settings", None, "book_asset_depreciation_entry_automatically", 1)
-		
+
 	# post depreciation entries as on today
 	post_depreciation_entries()
-	
+
 	# scrap a random asset
 	frappe.db.set_value("Company", "Wind Power LLC", "disposal_account", "Gain/Loss on Asset Disposal - WPL")
-	
+
 	asset = get_random_asset()
 	scrap_asset(asset.name)
-	
-	# Sell a random asset
-	sell_an_asset()	
 
-def make_asset_purchase_entry():
-	asset_list = frappe.get_all("Asset", filters={"purchase_invoice": ["in", ("", None)]}, 
-		fields=["name", "item_code", "gross_purchase_amount", "company", "purchase_date"])
-				
-	# make purchase invoice
-	for asset in asset_list:
-		pi = make_purchase_invoice(asset.name, asset.item_code, asset.gross_purchase_amount, 
-			asset.company, asset.purchase_date)
-		pi.supplier = get_random("Supplier")
-		pi.save()
-		pi.submit()
-		
-	return asset_list
+	# Sell a random asset
+	sell_an_asset()
+
 
 def sell_an_asset():
 	asset = get_random_asset()
@@ -55,8 +37,9 @@ def sell_an_asset():
 		if asset.value_after_depreciation else asset.gross_purchase_amount * 0.9
 	si.save()
 	si.submit()
-	
+
+
 def get_random_asset():
 	return frappe.db.sql(""" select name, item_code, value_after_depreciation, gross_purchase_amount
-		from `tabAsset` 
+		from `tabAsset`
 		where docstatus=1 and status not in ("Scrapped", "Sold") order by rand() limit 1""", as_dict=1)[0]


### PR DESCRIPTION
currently demo fails with the following error:

```python-traceback
frappe@bf54a9834cfe:/workspace/development/frappe-bench$ bench --site test1.localhost execute erpnext.demo.demo.make
Traceback (most recent call last):
  File "/usr/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/workspace/development/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 97, in <module>
    main()
  File "/workspace/development/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/workspace/development/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/workspace/development/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/workspace/development/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/workspace/development/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/workspace/development/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/workspace/development/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/workspace/development/frappe-bench/env/lib/python3.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/workspace/development/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 25, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/workspace/development/frappe-bench/apps/frappe/frappe/commands/utils.py", line 145, in execute
    ret = frappe.get_attr(method)(*args, **kwargs)
  File "/workspace/development/frappe-bench/apps/frappe/frappe/__init__.py", line 1042, in get_attr
    return getattr(get_module(modulename), methodname)
  File "/workspace/development/frappe-bench/apps/frappe/frappe/__init__.py", line 823, in get_module
    return importlib.import_module(modulename)
  File "/workspace/development/frappe-bench/env/lib/python3.7/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1006, in _gcd_import
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 967, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 728, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/workspace/development/frappe-bench/apps/erpnext/erpnext/demo/demo.py", line 6, in <module>
    from erpnext.demo.user import hr, sales, purchase, manufacturing, stock, accounts, projects, fixed_asset
  File "/workspace/development/frappe-bench/apps/erpnext/erpnext/demo/user/fixed_asset.py", line 9, in <module>
    from erpnext.assets.doctype.asset.asset import make_purchase_invoice, make_sales_invoice
ImportError: cannot import name 'make_purchase_invoice' from 'erpnext.assets.doctype.asset.asset' (/workspace/development/frappe-bench/apps/erpnext/erpnext/assets/doctype/asset/asset.py)
```