### PR TITLE
fix: Get invoice details only if invoice is selected

### DIFF
--- a/erpnext/accounts/doctype/c_form/c_form.js
+++ b/erpnext/accounts/doctype/c_form/c_form.js
@@ -32,10 +32,12 @@ frappe.ui.form.on('C-Form Invoice Detail', {
 	invoice_no(frm, cdt, cdn) {
 		let d = frappe.get_doc(cdt, cdn);
 
-		frm.call('get_invoice_details', {
-			invoice_no: d.invoice_no
-		}).then(r => {
-			frappe.model.set_value(cdt, cdn, r.message);
-		});
+		if (d.invoice_no) {
+			frm.call('get_invoice_details', {
+				invoice_no: d.invoice_no
+			}).then(r => {
+				frappe.model.set_value(cdt, cdn, r.message);
+			});
+		}
 	}
 });


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/Users/deepesh/frappe-bench/apps/frappe/frappe/app.py", line 60, in application
    response = frappe.api.handle()
  File "/Users/deepesh/frappe-bench/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/Users/deepesh/frappe-bench/apps/frappe/frappe/handler.py", line 24, in handle
    data = execute_cmd(cmd)
  File "/Users/deepesh/frappe-bench/apps/frappe/frappe/handler.py", line 63, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/deepesh/frappe-bench/apps/frappe/frappe/__init__.py", line 1068, in call
    return fn(*args, **newargs)
  File "/Users/deepesh/frappe-bench/apps/frappe/frappe/handler.py", line 91, in runserverobj
    frappe.desk.form.run_method.runserverobj(method, docs=docs, dt=dt, dn=dn, arg=arg, args=args)
  File "/Users/deepesh/frappe-bench/apps/frappe/frappe/desk/form/run_method.py", line 49, in runserverobj
    r = doc.run_method(method, **args)
  File "/Users/deepesh/frappe-bench/apps/frappe/frappe/model/document.py", line 803, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/Users/deepesh/frappe-bench/apps/frappe/frappe/model/document.py", line 1090, in composer
    return composed(self, method, *args, **kwargs)
  File "/Users/deepesh/frappe-bench/apps/frappe/frappe/model/document.py", line 1073, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/Users/deepesh/frappe-bench/apps/frappe/frappe/model/document.py", line 797, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
TypeError: get_invoice_details() missing 1 required positional argument: 'invoice_no'
```