### PR TITLE
fix: Missing if condition in Customer Default Bank Account Validation.

### DIFF
--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -76,7 +76,8 @@ class Customer(TransactionBase):
 	def validate_default_bank_account(self):
 		if self.default_bank_account:
 			is_company_account = frappe.db.get_value('Bank Account', self.default_bank_account, 'is_company_account')
-			frappe.throw(_("{0} is not a company bank account").format(frappe.bold(self.default_bank_account)))
+			if not is_company_account:
+				frappe.throw(_("{0} is not a company bank account").format(frappe.bold(self.default_bank_account)))
 
 	def on_update(self):
 		self.validate_name_with_customer_group()


### PR DESCRIPTION
Throws error even if Account is a Company Bank Account.