### PR TITLE
fix: bom comparison issue

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -823,6 +823,10 @@ def add_operations_cost(stock_entry, work_order=None, expense_account=None):
 def get_bom_diff(bom1, bom2):
 	from frappe.model import table_fields
 
+	if bom1 == bom2:
+		frappe.throw(_("BOM 1 {0} and BOM 2 {1} should not be same")
+			.format(frappe.bold(bom1), frappe.bold(bom2)))
+
 	doc1 = frappe.get_doc('BOM', bom1)
 	doc2 = frappe.get_doc('BOM', bom2)
 

--- a/erpnext/manufacturing/page/bom_comparison_tool/bom_comparison_tool.js
+++ b/erpnext/manufacturing/page/bom_comparison_tool/bom_comparison_tool.js
@@ -22,7 +22,14 @@ erpnext.BOMComparisonTool = class BOMComparisonTool {
 					fieldname: 'name1',
 					fieldtype: 'Link',
 					options: 'BOM',
-					change: () => this.fetch_and_render()
+					change: () => this.fetch_and_render(),
+					get_query: () => {
+						return {
+							filters: {
+								"name": ["not in", [this.form.get_value("name2") || ""]]
+							}
+						}
+					}
 				},
 				{
 					fieldtype: 'Column Break'
@@ -32,7 +39,14 @@ erpnext.BOMComparisonTool = class BOMComparisonTool {
 					fieldname: 'name2',
 					fieldtype: 'Link',
 					options: 'BOM',
-					change: () => this.fetch_and_render()
+					change: () => this.fetch_and_render(),
+					get_query: () => {
+						return {
+							filters: {
+								"name": ["not in", [this.form.get_value("name1") || ""]]
+							}
+						}
+					}
 				},
 				{
 					fieldtype: 'Section Break'


### PR DESCRIPTION
**Issue**
If bom 1 and bom 2 are same then system throwing below error

<img width="1193" alt="Screenshot 2020-03-19 at 9 41 46 AM" src="https://user-images.githubusercontent.com/8780500/77031934-0ddaaf80-69c9-11ea-85ba-14d7e0d22d08.png">


**After Fix**
User not able to select the same BOM in BOM 1 and BOM 2
![image](https://user-images.githubusercontent.com/8780500/77031965-25199d00-69c9-11ea-8a31-c51d4ef32b5d.png)
