### PR TITLE
fix: Project field in Stock Entry Detail should be editable

### DIFF
--- a/erpnext/stock/doctype/stock_entry_detail/stock_entry_detail.json
+++ b/erpnext/stock/doctype/stock_entry_detail/stock_entry_detail.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "autoname": "hash",
  "creation": "2013-03-29 18:22:12",
  "doctype": "DocType",
@@ -479,8 +480,7 @@
    "fieldname": "project",
    "fieldtype": "Link",
    "label": "Project",
-   "options": "Project",
-   "read_only": 1
+   "options": "Project"
   },
   {
    "fieldname": "po_detail",
@@ -494,7 +494,8 @@
  ],
  "idx": 1,
  "istable": 1,
- "modified": "2019-08-20 14:01:02.319754",
+ "links": [],
+ "modified": "2020-03-19 12:34:09.836295",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Entry Detail",


### PR DESCRIPTION
- It doesn't get fetched from anywhere and neither can it be set.
- Removed 'read_only'.

**After Fix:**
![Screenshot 2020-03-19 at 12 55 00 PM](https://user-images.githubusercontent.com/25857446/77041842-9f095080-69e0-11ea-82be-9c43a32486d3.png)
