### PR TITLE
fix: allow target warehouses to be changed for work order stock entries (develop)

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -294,13 +294,8 @@ class StockEntry(StockController):
 				if validate_for_manufacture:
 					if d.bom_no:
 						d.s_warehouse = None
-
 						if not d.t_warehouse:
 							frappe.throw(_("Target warehouse is mandatory for row {0}").format(d.idx))
-
-						elif self.pro_doc and (cstr(d.t_warehouse) != self.pro_doc.fg_warehouse and cstr(d.t_warehouse) != self.pro_doc.scrap_warehouse):
-							frappe.throw(_("Target warehouse in row {0} must be same as Work Order").format(d.idx))
-
 					else:
 						d.t_warehouse = None
 						if not d.s_warehouse:


### PR DESCRIPTION
**Problem:**

The system throws a validation if you try to change the target warehouse for a Stock Entry that's linked to a Work Order, even though there might be cases where you'd need an alternate warehouse.

CC: @rohitwaghchaure 

<hr>

**Screenshots / GIFs:**

![image](https://user-images.githubusercontent.com/13396535/77043620-ee9d4b80-69e3-11ea-9855-5dd5a6ab8b95.png)