### PR TITLE
fix: stock entry qty must be positive

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -177,6 +177,10 @@ class StockEntry(StockController):
 		stock_items = self.get_stock_items()
 		serialized_items = self.get_serialized_items()
 		for item in self.get("items"):
+			if item.qty and item.qty < 0:
+				frappe.throw(_("Row {0}: The item {1}, quantity must be positive number")
+					.format(item.idx, frappe.bold(item.item_code)))
+
 			if item.item_code not in stock_items:
 				frappe.throw(_("{0} is not a stock Item").format(item.item_code))
 


### PR DESCRIPTION
**Issue**

User was facing the problem that stock qty was zero still stock balance column was showing the positive amount in the stock balance report.

<img width="1277" alt="Screenshot 2020-03-19 at 2 30 25 PM" src="https://user-images.githubusercontent.com/8780500/77050877-670a0980-69f0-11ea-9ee3-2b523d3d4d9f.png">

Then after debug we came to know that user has created stock entry with purpose as "Material Issue" and set negative qty. But as the purpose was set as "Material Issue" system has changed the negative qty to positive and treat as the Inward Entry. But we keep the incoming rate as Zero for Material Issue type entries. System has used zero value as a incoming rate for the inward entry and due to this stock balance qty was set as zero but value was still showing in the stock balance column.

**Stock Entry**
<img width="928" alt="Screenshot 2020-03-19 at 2 40 02 PM" src="https://user-images.githubusercontent.com/8780500/77051369-2ced3780-69f1-11ea-9942-36bcfa63040f.png">

**Stock Ledger Entry**
<img width="658" alt="Screenshot 2020-03-19 at 2 40 48 PM" src="https://user-images.githubusercontent.com/8780500/77050858-607b9200-69f0-11ea-8d50-e2017f3fb376.png">

Solution: added validation to don't create stock entry with negative qty