### PR TITLE
fix: UOM fixes in Sales Order,Material Request & Production Plan

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -144,7 +144,7 @@ class ProductionPlan(Document):
 			item_condition = " and mr_item.item_code ={0}".format(frappe.db.escape(self.item_code))
 
 		items = frappe.db.sql("""select distinct parent, name, item_code, warehouse, description,
-			(qty - ordered_qty) as pending_qty
+			(qty - ordered_qty) * conversion_factor as pending_qty
 			from `tabMaterial Request Item` mr_item
 			where parent in (%s) and docstatus = 1 and qty > ordered_qty
 			and exists (select name from `tabBOM` bom where bom.item=mr_item.item_code

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -496,7 +496,7 @@ def close_or_unclose_sales_orders(names, status):
 
 def get_requested_item_qty(sales_order):
 	return frappe._dict(frappe.db.sql("""
-		select sales_order_item, sum(stock_qty)
+		select sales_order_item, sum(qty)
 		from `tabMaterial Request Item`
 		where docstatus = 1
 			and sales_order = %s
@@ -507,16 +507,12 @@ def get_requested_item_qty(sales_order):
 def make_material_request(source_name, target_doc=None):
 	requested_item_qty = get_requested_item_qty(source_name)
 
-	def postprocess(source, doc):
-		doc.material_request_type = "Purchase"
-
 	def update_item(source, target, source_parent):
 		# qty is for packed items, because packed items don't have stock_qty field
-		qty = source.get("stock_qty") or source.get("qty")
+		qty = source.get("qty")
 		target.project = source_parent.project
 		target.qty = qty - requested_item_qty.get(source.name, 0)
-		target.conversion_factor = 1
-		target.stock_qty = qty - requested_item_qty.get(source.name, 0)
+		target.stock_qty = flt(target.qty) * flt(target.conversion_factor)
 
 	doc = get_mapped_doc("Sales Order", source_name, {
 		"Sales Order": {
@@ -537,14 +533,12 @@ def make_material_request(source_name, target_doc=None):
 			"doctype": "Material Request Item",
 			"field_map": {
 				"name": "sales_order_item",
-				"parent": "sales_order",
-				"stock_uom": "uom",
-				"stock_qty": "qty"
+				"parent": "sales_order"
 			},
 			"condition": lambda doc: not frappe.db.exists('Product Bundle', doc.item_code) and doc.stock_qty > requested_item_qty.get(doc.name, 0),
 			"postprocess": update_item
 		}
-	}, target_doc, postprocess)
+	}, target_doc)
 
 	return doc
 

--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -501,7 +501,7 @@ def raise_work_orders(material_request):
 				wo_order = frappe.new_doc("Work Order")
 				wo_order.update({
 					"production_item": d.item_code,
-					"qty": d.qty - d.ordered_qty,
+					"qty": d.stock_qty - d.ordered_qty,
 					"fg_warehouse": d.warehouse,
 					"wip_warehouse": default_wip_warehouse,
 					"description": d.description,


### PR DESCRIPTION
1) In Production Plan
   - **Planned Qty** while fetching Items from Material Request must be the stock quantity (in case of different uom in MR)

1) Sales Order to Material Request 
   - Stock UOM and Qty was mapped even though UOM differed in Sales Order
   - On mapping Material Request type should be whatever is default and forcibly 'Purchase'
   - **After Fix:** Child table mapped to MR as it is with the UOM intact

2) Material Request to Work Order
   - 'Qty to Manufacture' in Work Order must be set as per Stock UOM
   - Completed Qty in Material Request Item was set as per UOM
   - **After Fix:** Completed Qty and Qty to Manufacture are set as per Stock UOM
