### PR TITLE
fix: Added hidden GL column in general ledger

### DIFF
--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -131,7 +131,7 @@ def get_gl_entries(filters):
 	gl_entries = frappe.db.sql(
 		"""
 		select
-			posting_date, account, party_type, party,
+			name as gl_entry, posting_date, account, party_type, party,
 			voucher_type, voucher_no, cost_center, project,
 			against_voucher_type, against_voucher, account_currency,
 			remarks, against, is_opening {select_fields}
@@ -362,6 +362,12 @@ def get_columns(filters):
 			currency = get_company_currency(company)
 
 	columns = [
+		{
+			"fieldname": "gl_entry",
+			"fieldtype": "Link",
+			"options": "GL Entry",
+			"hidden": 1
+		},
 		{
 			"label": _("Posting Date"),
 			"fieldname": "posting_date",


### PR DESCRIPTION
Added a hidden GL Entry columns in General Ledger Report

**Issue:**
Currently the **Add Column** feature in reports only allow values to be added from the Parent Level and values from child doctypes cannot be added. So if an Accounting Dimension is created and added at Item Table in Sales Invoice or Account Table in Journal Entry these dimensions cannot be added or seen in **General Ledger** report.

**Solution:**
Since all the Accounting Dimensions are available at the GL Entry, added a hidden GL Entry column from which accounting dimensions can be easily added

<img width="1278" alt="Screenshot 2020-03-21 at 10 16 58 PM" src="https://user-images.githubusercontent.com/42651287/77232030-a8eba900-6bc4-11ea-824d-65bfffba2dba.png">
