### PR TITLE
Remove Campagin restrection

### DIFF
--- a/erpnext/crm/doctype/lead/lead.json
+++ b/erpnext/crm/doctype/lead/lead.json
@@ -171,7 +171,6 @@
    "options": "Customer"
   },
   {
-   "depends_on": "eval: doc.source==\"Campaign\"",
    "fieldname": "campaign_name",
    "fieldtype": "Link",
    "label": "Campaign Name",


### PR DESCRIPTION
Lead Source Now is an independent doctype.
forcing the user to add Campaign is not valid 
Solution
Show Campaign keeping it optional and keep the user to be free to add or remove data
