### PR TITLE
fix: batch selection popup not coming for stock entry

### DIFF
--- a/erpnext/public/js/utils/serial_no_batch_selector.js
+++ b/erpnext/public/js/utils/serial_no_batch_selector.js
@@ -313,11 +313,15 @@ erpnext.SerialNoBatchSelector = Class.extend({
 								frappe.throw(__(`Batch ${val} already selected.`));
 								return;
 							}
+
+							let batch_number = me.item.batch_no ||
+								this.grid_row.on_grid_fields_dict.batch_no.get_value();
+
 							if (me.warehouse_details.name) {
 								frappe.call({
 									method: 'erpnext.stock.doctype.batch.batch.get_batch_qty',
 									args: {
-										batch_no: me.item.batch_no,
+										batch_no: batch_number,
 										warehouse: me.warehouse_details.name,
 										item_code: me.item_code
 									},

--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -60,7 +60,8 @@ frappe.ui.form.on('Stock Entry', {
 					}
 				}
 
-				if(item.s_warehouse) filters["warehouse"] = item.s_warehouse;
+				filters["warehouse"] = item.s_warehouse || item.t_warehouse;
+
 				return {
 					query : "erpnext.controllers.queries.get_batch_no",
 					filters: filters
@@ -886,7 +887,7 @@ erpnext.stock.select_batch_and_serial_no = (frm, item) => {
 		}
 	}
 
-	if(item && !item.has_serial_no && item.has_batch_no) return;
+	if(item && !item.has_serial_no && !item.has_batch_no) return;
 	if (frm.doc.purpose === 'Material Receipt') return;
 
 	frappe.require("assets/erpnext/js/utils/serial_no_batch_selector.js", function() {


### PR DESCRIPTION
**Issue**

1. Batch selection popup not coming for stock entry

1. Quantity not showing for the batch in the dropdown if the stock entry type is Material Receipt
<img width="869" alt="Screenshot 2020-03-24 at 11 35 08 AM" src="https://user-images.githubusercontent.com/8780500/77393774-bde25b00-6dc3-11ea-80df-b6970e67abfc.png">


**After Fix**

1. Batch selection popup
<img width="798" alt="Screenshot 2020-03-24 at 11 16 41 AM" src="https://user-images.githubusercontent.com/8780500/77393801-ccc90d80-6dc3-11ea-8775-4320f478205d.png">

1. Batch with quantity in dropdown 
<img width="873" alt="Screenshot 2020-03-24 at 11 33 35 AM" src="https://user-images.githubusercontent.com/8780500/77393846-ed916300-6dc3-11ea-9e0f-b6fe2079c688.png">
