### PR TITLE
fix: Make shelf life mandatory in Batched Item if it has expiry date

### DIFF
--- a/erpnext/stock/doctype/batch/batch.py
+++ b/erpnext/stock/doctype/batch/batch.py
@@ -122,8 +122,11 @@ class Batch(Document):
 			self.expiry_date = add_days(self.manufacturing_date, shelf_life_in_days)
 
 		if has_expiry_date and not self.expiry_date:
-			frappe.msgprint(_('Expiry date is mandatory for selected item.'))
-			frappe.throw(_("Set item's shelf life in days, to set expiry based on manufacturing date plus shelf-life."))
+			frappe.throw(msg=_("Please set {0} for Batched Item {1}, which is used to set {2} on Submit.") \
+				.format(frappe.bold("Shelf Life in Days"),
+					frappe.utils.get_link_to_form("Item", self.item),
+					frappe.bold("Batch Expiry Date")),
+				title=_("Expiry Date Mandatory"))
 
 	def get_name_from_naming_series(self):
 		"""

--- a/erpnext/stock/doctype/item/item.json
+++ b/erpnext/stock/doctype/item/item.json
@@ -343,7 +343,8 @@
   {
    "fieldname": "shelf_life_in_days",
    "fieldtype": "Int",
-   "label": "Shelf Life In Days"
+   "label": "Shelf Life In Days",
+   "mandatory_depends_on": "eval:doc.has_batch_no && doc.has_expiry_date"
   },
   {
    "default": "2099-12-31",
@@ -1045,7 +1046,7 @@
  "image_field": "image",
  "links": [],
  "max_attachments": 1,
- "modified": "2020-01-02 19:13:59.295963",
+ "modified": "2020-03-24 16:14:36.950677",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Item",


### PR DESCRIPTION
- Improved Error message
**Before:**
![Screenshot 2020-03-24 at 4 31 22 PM](https://user-images.githubusercontent.com/25857446/77418313-bb482b80-6dec-11ea-8dea-f21c401c68f2.png)
**After:**
![Screenshot 2020-03-24 at 4 27 00 PM](https://user-images.githubusercontent.com/25857446/77418321-be431c00-6dec-11ea-92c8-1e9152b7f8de.png)

- Shelf Life in Days is mandatory if it is a batched item and if it has expiry date