### PR TITLE
fix: Add missing account settings link in accounts module

### DIFF
--- a/erpnext/config/accounts.py
+++ b/erpnext/config/accounts.py
@@ -391,6 +391,11 @@ def get_data():
 			"items": [
 				{
 					"type": "doctype",
+					"name": "Accounts Settings",
+					"description": _("Setup accounts module.")
+				},
+				{
+					"type": "doctype",
 					"name": "Payment Gateway Account",
 					"description": _("Setup Gateway accounts.")
 				},


### PR DESCRIPTION
Add missing accounts settings link in accounts and settings module which was only accessible through search before

![Anmerkung 2020-03-26 011256](https://user-images.githubusercontent.com/60393001/77598154-5df1ce80-6f01-11ea-87c9-bb4ff7fa029f.png)
