### PR TITLE
fix: item not showing in popup while making batch

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -165,6 +165,16 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 				return (doc.rule_applied) ? "green" : "red";
 			});
 		}
+
+		let batch_no_field = this.frm.get_docfield("items", "batch_no");
+		if (batch_no_field) {
+			batch_no_field.get_route_options_for_new_doc = function(row) {
+				return {
+					"item": row.doc.item_code
+				}
+			};
+		}
+
 	},
 	onload: function() {
 		var me = this;


### PR DESCRIPTION
**Issue**

While creating batch from purchase receipt the item showing as blank

<img width="696" alt="Screenshot 2020-03-27 at 12 54 29 PM" src="https://user-images.githubusercontent.com/8780500/77732108-321e3800-702a-11ea-8dcf-54e1c1dae286.png">


**After Fix**

<img width="766" alt="Screenshot 2020-03-27 at 12 53 40 PM" src="https://user-images.githubusercontent.com/8780500/77732151-44987180-702a-11ea-9d58-079c57cb55ca.png">
