### PR TITLE
fix: use setup from Supplier Quotation Controller

### DIFF
--- a/erpnext/buying/doctype/supplier_quotation/supplier_quotation.js
+++ b/erpnext/buying/doctype/supplier_quotation/supplier_quotation.js
@@ -4,15 +4,17 @@
 // attach required files
 {% include 'erpnext/public/js/controllers/buying.js' %};
 
-frappe.ui.form.on('Suppier Quotation', {
-	setup: function(frm) {
-		frm.custom_make_buttons = {
-			'Purchase Order': 'Purchase Order'
-		}
-	}
-});
-
 erpnext.buying.SupplierQuotationController = erpnext.buying.BuyingController.extend({
+	setup: function() {
+		this.frm.custom_make_buttons = {
+			'Purchase Order': 'Purchase Order',
+			'Quotation': 'Quotation',
+			'Subscription': 'Subscription'
+		}
+
+		this._super();
+	},
+
 	refresh: function() {
 		var me = this;
 		this._super();


### PR DESCRIPTION
## Bug
Click the `+` button from dashboard in Supplier quotation for Purchase order. This would redirect to the PO form, however the events are not triggered correctly (Framework issue, will be resolved in a different PR)

This would result in `refresh` being called twice which would create the custom make buttons twice (screenshot below)

<img width="239" alt="image" src="https://user-images.githubusercontent.com/18097732/77773778-150c5800-7070-11ea-8bee-541aed857193.png">

## How the button works
The button would trigger `make_new` function in `form.js`

```javascript
make_new(doctype) {
		// make new doctype from the current form
		// will handover to `make_methods` if defined
		// or will create and match link fields
		var me = this;
		if(this.make_methods && this.make_methods[doctype]) {
			return this.make_methods[doctype](this);
		} else if(this.custom_make_buttons && this.custom_make_buttons[doctype]) {
			this.custom_buttons[__(this.custom_make_buttons[doctype])].trigger('click');
		} else {
			frappe.model.with_doctype(doctype, function() {
				var new_doc = frappe.model.get_new_doc(doctype);

				// set link fields (if found)
				frappe.get_meta(doctype).fields.forEach(function(df) {
					if(df.fieldtype==='Link' && df.options===me.doctype) {
						new_doc[df.fieldname] = me.doc.name;
					} else if (['Link', 'Dynamic Link'].includes(df.fieldtype) && me.doc[df.fieldname]) {
						new_doc[df.fieldname] = me.doc[df.fieldname];
					}
				});

				frappe.ui.form.make_quick_entry(doctype, null, null, new_doc);
				// frappe.set_route('Form', doctype, new_doc.name);
			});
		}
	}
```

[link](https://github.com/frappe/frappe/blob/4198fc3b4dd8f6da2251c3fc49699b4b6671374c/frappe/public/js/frappe/form/form.js#L1481-L1507)

Ideally the second condition `this.custom_make_buttons && this.custom_make_buttons[doctype])` should be triggered for supplier quotation, however it is not triggered because events from `frappe.ui.form.on('Supplier Quotation')` would never be called.

The fix was to move the code to the supplier quotation controller.

### The Frappe Problem
When the second condition is not satisfied, the fallback method is called in the `else`.
This is the root problem, which will be solved in a separate PR.