### PR TITLE
fix: not able to add equity account in the chart of accounts

### DIFF
--- a/erpnext/accounts/doctype/account/account.py
+++ b/erpnext/accounts/doctype/account/account.py
@@ -102,15 +102,15 @@ class Account(NestedSet):
 			if not frappe.db.get_value("Account",
 				{'account_name': self.account_name, 'company': ancestors[0]}, 'name'):
 				frappe.throw(_("Please add the account to root level Company - %s" % ancestors[0]))
-		else:
+		elif self.parent_account:
 			descendants = get_descendants_of('Company', self.company)
 			if not descendants: return
 			parent_acc_name_map = {}
 			parent_acc_name, parent_acc_number = frappe.db.get_value('Account', self.parent_account, \
 				["account_name", "account_number"])
-			filters = { 
+			filters = {
 				"company": ["in", descendants],
-				"account_name": parent_acc_name, 
+				"account_name": parent_acc_name,
 			}
 			if parent_acc_number:
 				filters["account_number"] = parent_acc_number


### PR DESCRIPTION
**Issue**

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2020-03-19/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-12-2020-03-19/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-12-2020-03-19/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-12-2020-03-19/apps/frappe/frappe/handler.py", line 61, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-12-2020-03-19/apps/frappe/frappe/__init__.py", line 1054, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-12-2020-03-19/apps/erpnext/erpnext/accounts/utils.py", line 291, in add_ac
    ac.insert()
  File "/home/frappe/benches/bench-version-12-2020-03-19/apps/frappe/frappe/model/document.py", line 230, in insert
    self.run_before_save_methods()
  File "/home/frappe/benches/bench-version-12-2020-03-19/apps/frappe/frappe/model/document.py", line 895, in run_before_save_methods
    self.run_method("validate")
  File "/home/frappe/benches/bench-version-12-2020-03-19/apps/frappe/frappe/model/document.py", line 794, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2020-03-19/apps/frappe/frappe/model/document.py", line 1065, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2020-03-19/apps/frappe/frappe/model/document.py", line 1048, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-version-12-2020-03-19/apps/frappe/frappe/model/document.py", line 788, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2020-03-19/apps/erpnext/erpnext/accounts/doctype/account/account.py", line 44, in validate
    self.validate_root_company_and_sync_account_to_children()
  File "/home/frappe/benches/bench-version-12-2020-03-19/apps/erpnext/erpnext/accounts/doctype/account/account.py", line 110, in validate_root_company_and_sync_account_to_children
    ["account_name", "account_number"])
TypeError: 'NoneType' object is not iterable
```