### PR TITLE
fix: docfield of sales_order is not fetching route options for new doc

### DIFF
--- a/erpnext/projects/doctype/project/project.js
+++ b/erpnext/projects/doctype/project/project.js
@@ -18,7 +18,7 @@ frappe.ui.form.on("Project", {
 		};
 	},
 	onload: function (frm) {
-		var so = frappe.meta.get_docfield("Project", "sales_order");
+		var so = frm.get_docfield("Project", "sales_order");
 		so.get_route_options_for_new_doc = function (field) {
 			if (frm.is_new()) return;
 			return {


### PR DESCRIPTION


<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

I found that when clicking 'new doc' in the link field, the new doc form is not fetching the route options predefined.

The source code is using the wrong method to get `so` as docfield.
`frappe.meta.get_docfield` is not referring to the same docfield compared with `frm.get_docfield` in the doctype form.

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

I saw other places where using get_route_options_for_new_doc, docfield is using `frm.get_docfield` instead of `frappe.meta.get_docfield` otherwise the `get_route_options_for_new_doc` is not attached in that 'so' docfield.

[Reference: transaction.js](https://github.com/frappe/erpnext/blob/develop/erpnext/public/js/controllers/transaction.js#L169)

