### PR TITLE
fix: list index out of range bug

### DIFF
--- a/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.py
+++ b/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.py
@@ -55,6 +55,9 @@ def get_report_summary(columns, income, expense, net_profit_loss, period_list, p
 		income_label = _("Total Income")
 		expense_label = _("Total Expense")
 
+	if not (len(net_profit) and len(income_data) and len(expense_data)):
+		return None
+
 	return [
 		{
 			"value": net_profit[-1],


### PR DESCRIPTION
`net_profit[-1]` would throw an error if no values were present. This PR fixes that.