### PR TITLE
fix (tests): module import error for Dashboard Chart Field 

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -626,10 +626,11 @@ erpnext.patches.v12_0.update_ewaybill_field_position
 erpnext.patches.v12_0.create_accounting_dimensions_in_missing_doctypes
 erpnext.patches.v11_1.set_status_for_material_request_type_manufacture
 erpnext.patches.v12_0.move_plaid_settings_to_doctype
-execute:frappe.reload_doc('desk', 'doctype','dashboard_chart_link')
-execute:frappe.reload_doc('desk', 'doctype','dashboard')
-execute:frappe.reload_doc('desk', 'doctype','dashboard_chart_source')
-execute:frappe.reload_doc('desk', 'doctype','dashboard_chart')
+execute:frappe.reload_doc('desk', 'doctype', 'dashboard_chart_link')
+execute:frappe.reload_doc('desk', 'doctype', 'dashboard')
+execute:frappe.reload_doc('desk', 'doctype', 'dashboard_chart_source')
+execute:frappe.reload_doc('desk', 'doctype', 'dashboard_chart')
+execute:frappe.reload_doc('desk', 'doctype', 'dashboard_chart_field')
 erpnext.patches.v12_0.add_default_dashboards
 erpnext.patches.v12_0.remove_bank_remittance_custom_fields
 erpnext.patches.v12_0.generate_leave_ledger_entries


### PR DESCRIPTION
Fixes Module Import error in patch while creating dashboards

```
Traceback (most recent call last):
  File "/home/travis/frappe-bench/apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.py", line 393, in make_records
    doc.insert(ignore_permissions=True)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 220, in insert
    self._set_defaults()
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 631, in _set_defaults
    new_doc = frappe.new_doc(df.options, as_dict=True)
  File "/home/travis/frappe-bench/apps/frappe/frappe/__init__.py", line 693, in new_doc
    return get_new_doc(doctype, parent_doc, parentfield, as_dict=as_dict)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/create_new.py", line 21, in get_new_doc
    frappe.local.new_doc_templates[doctype] = make_new_doc(doctype)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/create_new.py", line 39, in make_new_doc
    "docstatus": 0
  File "/home/travis/frappe-bench/apps/frappe/frappe/__init__.py", line 759, in get_doc
    doc = frappe.model.document.get_doc(*args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 69, in get_doc
    controller = get_controller(doctype)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/base_document.py", line 49, in get_controller
    module = load_doctype_module(doctype, module_name)
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/utils.py", line 206, in load_doctype_module
    raise ImportError('Module import failed for {0} ({1})'.format(doctype, module_name + ' Error: ' + str(e)))

ImportError: Module import failed for Dashboard Chart Field (frappe.core.doctype.dashboard_chart_field.dashboard_chart_field Error: No module named dashboard_chart_field.dashboard_chart_field)
```

