### PR TITLE
fix: Total row in query-report

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -629,7 +629,10 @@ erpnext.utils.map_current_doc = function(opts) {
 }
 
 frappe.form.link_formatters['Item'] = function(value, doc) {
-	if(doc && doc.item_name && doc.item_name !== value) {
+	if(!value) {
+		return "Total";
+	}
+	else if(doc && doc.item_name && doc.item_name !== value) {
 		return value? value + ': ' + doc.item_name: doc.item_name;
 	} else {
 		return value;
@@ -637,7 +640,10 @@ frappe.form.link_formatters['Item'] = function(value, doc) {
 }
 
 frappe.form.link_formatters['Employee'] = function(value, doc) {
-	if(doc && doc.employee_name && doc.employee_name !== value) {
+	if(!value) {
+		return "Total";
+	}
+	else if(doc && doc.employee_name && doc.employee_name !== value) {
 		return value? value + ': ' + doc.employee_name: doc.employee_name;
 	} else {
 		return value;


### PR DESCRIPTION
**Before:**
![Screenshot 2020-04-03 at 8 48 26 PM](https://user-images.githubusercontent.com/25857446/78376546-20b9ca80-75ec-11ea-8f6c-8e1ef1e87344.png)

**After:**
![Screenshot 2020-04-03 at 8 43 02 PM](https://user-images.githubusercontent.com/25857446/78376569-257e7e80-75ec-11ea-910e-5994dab3eb9f.png)

- `query_report.py` prepares the total row of the report with the title 'Total Row', however, this row gets spliced in `query_report.js` (reason unknown)
![Screenshot 2020-04-03 at 8 51 13 PM](https://user-images.githubusercontent.com/25857446/78376797-742c1880-75ec-11ea-8047-517e11dce065.png)
- Datatable recalculates and makes the total row again from all the individual rows . This time the problematic cell has `null` value. Datatable then tries to format the cell.
- Currently the formatter in erpnext just sends null back if the value is `null`. If Datatable gets no value , it attaches the value from the first row in the report.
- Ideally any value coming into `frappe.form.link_formatters` function will not be `null` unless it is from the total row (i.e. this scenario). Hence, the fix.
