### PR TITLE
fix: (minor) Mandatory field missing to create address from lead

### DIFF
--- a/erpnext/crm/doctype/lead/lead.json
+++ b/erpnext/crm/doctype/lead/lead.json
@@ -1,12 +1,10 @@
 {
- "actions": [],
  "allow_events_in_timeline": 1,
  "allow_import": 1,
  "autoname": "naming_series:",
  "creation": "2013-04-10 11:45:37",
  "doctype": "DocType",
  "document_type": "Document",
- "email_append_to": 1,
  "engine": "InnoDB",
  "field_order": [
   "organization_lead",
@@ -34,6 +32,7 @@
   "notes",
   "address_info",
   "address_html",
+  "address_type",
   "address_title",
   "address_line1",
   "address_line2",
@@ -433,13 +432,20 @@
    "fieldname": "contact_section",
    "fieldtype": "Section Break",
    "label": "Contact"
+  },
+  {
+   "default": "Billing",
+   "depends_on": "eval: doc.__islocal",
+   "fieldname": "address_type",
+   "fieldtype": "Select",
+   "label": "Address Type",
+   "options": "Billing\nShipping\nOffice\nPersonal\nPlant\nPostal\nShop\nSubsidiary\nWarehouse\nCurrent\nPermanent\nOther"
   }
  ],
  "icon": "fa fa-user",
  "idx": 5,
  "image_field": "image",
- "links": [],
- "modified": "2020-01-13 16:16:48.885228",
+ "modified": "2020-04-06 20:26:11.687110",
  "modified_by": "Administrator",
  "module": "CRM",
  "name": "Lead",
@@ -508,7 +514,6 @@
   }
  ],
  "search_fields": "lead_name,lead_owner,status",
- "sender_field": "email_id",
  "show_name_in_global_search": 1,
  "sort_field": "modified",
  "sort_order": "DESC",

--- a/erpnext/crm/doctype/lead/lead.py
+++ b/erpnext/crm/doctype/lead/lead.py
@@ -126,7 +126,7 @@ class Lead(SellingController):
 			self.title = self.lead_name
 
 	def create_address(self):
-		address_fields = ["address_title", "address_line1", "address_line2",
+		address_fields = ["address_type", "address_title", "address_line1", "address_line2",
 			"city", "county", "state", "country", "pincode"]
 		info_fields = ["email_id", "phone", "fax"]
 
@@ -209,7 +209,7 @@ class Lead(SellingController):
 			self.contact_doc.save()
 
 	def flush_address_and_contact_fields(self):
-		fields = ['address_line1', 'address_line2', 'address_title',
+		fields = ['address_type', 'address_line1', 'address_line2', 'address_title',
 			'city', 'county', 'country', 'fax', 'pincode', 'state']
 
 		for field in fields:


### PR DESCRIPTION

In the new feature, which lets you create an address also automatically from the Lead. 
https://github.com/frappe/erpnext/pull/18715

It does not work because `Address Type` is a mandatory field that is always missing in this scenario and it always throws this warning.

<img width="439" alt="Screen Shot 2020-04-06 at 10 38 07 PM" src="https://user-images.githubusercontent.com/16913064/78585331-4bf42200-7857-11ea-8d50-b09ddfdb3a10.png">

Just added field to select the Address Type in Lead, works fine now.

<img width="915" alt="Screen Shot 2020-04-06 at 10 39 24 PM" src="https://user-images.githubusercontent.com/16913064/78585446-852c9200-7857-11ea-8d39-290986357af3.png">
