### PR TITLE
feat: Scan Barcode in Purchase Receipt

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -473,6 +473,7 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 							item_code: item.item_code,
 							barcode: item.barcode,
 							serial_no: item.serial_no,
+							batch_no: item.batch_no,
 							set_warehouse: me.frm.doc.set_warehouse,
 							warehouse: item.warehouse,
 							customer: me.frm.doc.customer || me.frm.doc.party_name,
@@ -637,6 +638,7 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 
 				// Add the new list to the serial no. field in grid with each in new line
 				item.serial_no = valid_serial_nos.join('\n');
+				item.conversion_factor = item.conversion_factor || 1;
 
 				refresh_field("serial_no", item.name, item.parentfield);
 				if(!doc.is_return && cint(user_defaults.set_qty_in_transactions_based_on_serial_no_input)) {

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.json
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.json
@@ -47,6 +47,7 @@
   "is_subcontracted",
   "supplier_warehouse",
   "items_section",
+  "scan_barcode",
   "items",
   "pricing_rule_details",
   "pricing_rules",
@@ -1070,13 +1071,18 @@
    "label": "Inter Company Reference",
    "options": "Delivery Note",
    "read_only": 1
+  },
+  {
+   "fieldname": "scan_barcode",
+   "fieldtype": "Data",
+   "label": "Scan Barcode"
   }
  ],
  "icon": "fa fa-truck",
  "idx": 261,
  "is_submittable": 1,
  "links": [],
- "modified": "2019-12-30 19:12:49.709711",
+ "modified": "2020-04-06 16:31:37.444891",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Purchase Receipt",

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -245,7 +245,7 @@ def get_basic_details(args, item, overwrite_warehouse=True):
 		'item_group_defaults': item_group_defaults,
 		'brand_defaults': brand_defaults
 	})
-	
+
 	warehouse = get_item_warehouse(item, args, overwrite_warehouse, defaults)
 
 	if args.get('doctype') == "Material Request" and not args.get('material_request_type'):
@@ -279,7 +279,7 @@ def get_basic_details(args, item, overwrite_warehouse=True):
 		"cost_center": get_default_cost_center(args, item_defaults, item_group_defaults, brand_defaults),
 		'has_serial_no': item.has_serial_no,
 		'has_batch_no': item.has_batch_no,
-		"batch_no": None,
+		"batch_no": args.get("batch_no"),
 		"uom": args.uom,
 		"min_order_qty": flt(item.min_order_qty) if args.doctype == "Material Request" else "",
 		"qty": flt(args.qty) or 1.0,
@@ -377,7 +377,7 @@ def get_item_warehouse(item, args, overwrite_warehouse, defaults={}):
 
 	else:
 		warehouse = args.get('warehouse')
-	
+
 	return warehouse
 
 def update_barcode_value(out):


### PR DESCRIPTION
- Added Scan Barcode field in Purchase Receipt
- Minor bug fixes:
  - If `item.conversion_factor` is not set assume it is 1. 
Since `get_item_details` sets `item.conversion_factor` later, initially via `scan_barcode` its value is 0. This value is used in the `serial_no` trigger to set qty. Since `qty = serial_no length / item.conversion_factor`,  `qty =Infinity`. This is propagated to `received_qty` as well.
  - If batch_no is already set, consider it.

**Working:**

![barcode](https://user-images.githubusercontent.com/25857446/78587115-1e5ca800-785a-11ea-87b4-4fc35386ce20.gif)

- [Documentation](https://github.com/frappe/erpnext_documentation/pull/28)