### PR TITLE
fix: sql syntax error in accounting dimensions

### DIFF
--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -202,7 +202,7 @@ def get_conditions(filters):
 				if frappe.get_cached_value('DocType', dimension.document_type, 'is_tree'):
 					filters[dimension.fieldname] = get_dimension_with_children(dimension.document_type,
 						filters.get(dimension.fieldname))
-				conditions.append("{0} in %({0})s".format(dimension.fieldname))
+				conditions.append("{0} in (%({0})s)".format(dimension.fieldname))
 
 	return "and {}".format(" and ".join(conditions)) if conditions else ""
 


### PR DESCRIPTION
Bug introduced in https://github.com/frappe/erpnext/pull/20860

![Screenshot 2020-04-07 at 2 06 42 PM](https://user-images.githubusercontent.com/36654812/78648027-0841fc80-78d9-11ea-8c6e-cf6c93691698.png)
