### PR TITLE
fix: cannot find accounting module while rendering breadcrumb

### DIFF
--- a/erpnext/accounts/doctype/account/account_tree.js
+++ b/erpnext/accounts/doctype/account/account_tree.js
@@ -1,7 +1,7 @@
 frappe.provide("frappe.treeview_settings")
 
 frappe.treeview_settings["Account"] = {
-	breadcrumbs: "Accounts",
+	breadcrumb: "Accounts",
 	title: __("Chart Of Accounts"),
 	get_tree_root: false,
 	filters: [

--- a/erpnext/accounts/doctype/cost_center/cost_center_tree.js
+++ b/erpnext/accounts/doctype/cost_center/cost_center_tree.js
@@ -1,5 +1,5 @@
 frappe.treeview_settings["Cost Center"] = {
-	breadcrumbs: "Accounts",
+	breadcrumb: "Accounts",
 	get_tree_root: false,
 	filters: [{
 		fieldname: "company",

--- a/erpnext/public/js/conf.js
+++ b/erpnext/public/js/conf.js
@@ -43,7 +43,6 @@ $.extend(frappe.breadcrumbs.preferred, {
 $.extend(frappe.breadcrumbs.module_map, {
 	'ERPNext Integrations': 'Integrations',
 	'Geo': 'Settings',
-	'Accounts': 'Accounting',
 	'Portal': 'Website',
 	'Utilities': 'Settings',
 	'Shopping Cart': 'Website',


### PR DESCRIPTION
Problem:
```
frappe.breadcrumbs.module_map = {
...
'Accounts': 'Accounting'
...
}
```

breadcrumb.js
```
// breadcrumbs.module = 'Accounts'

if (frappe.breadcrumbs.module_map[breadcrumbs.module]) {
	breadcrumbs.module = frappe.breadcrumbs.module_map[breadcrumbs.module];

        // Now breadcrumbs.module = 'Accounts'
}

if(frappe.get_module(breadcrumbs.module)) {    // cannot find module named 'Accounting'
....
}
```