### PR TITLE
fix: Remove trailing spaces in translatable strings

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -439,7 +439,7 @@ class AccountsController(TransactionBase):
 
 		if account_currency not in valid_currency:
 			frappe.throw(_("Account {0} is invalid. Account Currency must be {1}")
-						 .format(account, _(" or ").join(valid_currency)))
+				.format(account, (' ' + _("or") + ' ').join(valid_currency)))
 
 	def clear_unallocated_advances(self, childtype, parentfield):
 		self.set(parentfield, self.get(parentfield, {"allocated_amount": ["not in", [0, None, ""]]}))

--- a/erpnext/education/report/student_and_guardian_contact_details/student_and_guardian_contact_details.py
+++ b/erpnext/education/report/student_and_guardian_contact_details/student_and_guardian_contact_details.py
@@ -14,7 +14,7 @@ def execute(filters=None):
 	student_batch_name = filters.get("student_batch_name")
 
 	columns = get_columns()
-	
+
 	program_enrollments = frappe.get_list("Program Enrollment", fields=["student", "student_name"],
 		filters={"academic_year": academic_year, "program": program, "student_batch_name": student_batch_name})
 
@@ -46,9 +46,9 @@ def execute(filters=None):
 
 def get_columns():
 	columns = [
-		_(" Group Roll No") + "::60",  
-		_("Student ID") + ":Link/Student:90", 
-		_("Student Name") + "::150", 
+		_("Group Roll No") + "::60",
+		_("Student ID") + ":Link/Student:90",
+		_("Student Name") + "::150",
 		_("Student Mobile No.") + "::110",
 		_("Student Email ID") + "::125",
 		_("Student Address") + "::175",
@@ -84,10 +84,10 @@ def get_guardian_map(student_list):
 
 	guardian_list = list(set([g.guardian for g in guardian_details])) or ['']
 
-	guardian_mobile_no = dict(frappe.db.sql("""select name, mobile_number from `tabGuardian` 
+	guardian_mobile_no = dict(frappe.db.sql("""select name, mobile_number from `tabGuardian`
 			where name in (%s)""" % ", ".join(['%s']*len(guardian_list)), tuple(guardian_list)))
 
-	guardian_email_id = dict(frappe.db.sql("""select name, email_address from `tabGuardian` 
+	guardian_email_id = dict(frappe.db.sql("""select name, email_address from `tabGuardian`
 			where name in (%s)""" % ", ".join(['%s']*len(guardian_list)), tuple(guardian_list)))
 
 	for guardian in guardian_details:

--- a/erpnext/hr/doctype/leave_application/leave_application.py
+++ b/erpnext/hr/doctype/leave_application/leave_application.py
@@ -687,8 +687,7 @@ def add_leaves(events, start, end, filter_conditions=None):
 			"to_date": d.to_date,
 			"docstatus": d.docstatus,
 			"color": d.color,
-			"title": cstr(d.employee_name) + \
-				(d.half_day and _(" (Half Day)") or ""),
+			"title": cstr(d.employee_name) + (' ' + _('(Half Day)') if d.half_day else ''),
 		}
 		if e not in events:
 			events.append(e)

--- a/erpnext/projects/report/billing_summary.py
+++ b/erpnext/projects/report/billing_summary.py
@@ -53,7 +53,7 @@ def get_columns():
 def get_data(filters):
 	data = []
 	if(filters.from_date > filters.to_date):
-		frappe.msgprint(_(" From Date can not be greater than To Date"))
+		frappe.msgprint(_("From Date can not be greater than To Date"))
 		return data
 
 	timesheets = get_timesheets(filters)

--- a/erpnext/stock/dashboard/item_dashboard.js
+++ b/erpnext/stock/dashboard/item_dashboard.js
@@ -108,8 +108,8 @@ erpnext.stock.ItemDashboard = Class.extend({
 		if (context.data.length > 0) {
 			$(frappe.render_template('item_dashboard_list', context)).appendTo(this.result);
 		} else {
-			var message = __(" Currently no stock available in any warehouse")
-			$("<span class='text-muted small'>"+message+"</span>").appendTo(this.result);
+			var message = __("Currently no stock available in any warehouse");
+			$(`<span class='text-muted small'>  ${message} </span>`).appendTo(this.result);
 		}
 	},
 	get_item_dashboard_data: function(data, max_count, show_item) {

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -308,7 +308,7 @@ class Item(WebsiteGenerator):
 		if self.retain_sample and not frappe.db.get_single_value('Stock Settings', 'sample_retention_warehouse'):
 			frappe.throw(_("Please select Sample Retention Warehouse in Stock Settings first"))
 		if self.retain_sample and not self.has_batch_no:
-			frappe.throw(_(" {0} Retain Sample is based on batch, please check Has Batch No to retain sample of item").format(
+			frappe.throw(_("{0} Retain Sample is based on batch, please check Has Batch No to retain sample of item").format(
 				self.item_code))
 
 	def get_context(self, context):


### PR DESCRIPTION
Trailing spaces in the translatable string are invalid.

docs: https://github.com/frappe/frappe_io/pull/277