### PR TITLE
feat: Provision to set Default Item Manufacturer

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
+++ b/erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
@@ -754,8 +754,7 @@
   {
    "fieldname": "manufacturer_part_no",
    "fieldtype": "Data",
-   "label": "Manufacturer Part Number",
-   "read_only": 1
+   "label": "Manufacturer Part Number"
   },
   {
    "depends_on": "is_fixed_asset",
@@ -777,7 +776,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-04-01 14:20:17.297284",
+ "modified": "2020-04-07 18:34:35.104178",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Purchase Invoice Item",

--- a/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
+++ b/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
@@ -702,8 +702,7 @@
   {
    "fieldname": "manufacturer_part_no",
    "fieldtype": "Data",
-   "label": "Manufacturer Part Number",
-   "read_only": 1
+   "label": "Manufacturer Part Number"
   },
   {
    "default": "0",
@@ -723,7 +722,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2019-12-06 13:17:12.142799",
+ "modified": "2020-04-07 18:35:17.558928",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Purchase Order Item",

--- a/erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
+++ b/erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "autoname": "hash",
  "creation": "2013-05-22 12:43:10",
  "doctype": "DocType",
@@ -522,8 +523,7 @@
   {
    "fieldname": "manufacturer_part_no",
    "fieldtype": "Data",
-   "label": "Manufacturer Part Number",
-   "read_only": 1
+   "label": "Manufacturer Part Number"
   },
   {
    "fieldname": "column_break_15",
@@ -532,7 +532,8 @@
  ],
  "idx": 1,
  "istable": 1,
- "modified": "2019-06-02 05:32:46.019237",
+ "links": [],
+ "modified": "2020-04-07 18:35:51.175947",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Supplier Quotation Item",

--- a/erpnext/public/js/controllers/buying.js
+++ b/erpnext/public/js/controllers/buying.js
@@ -379,7 +379,31 @@ erpnext.buying.BuyingController = erpnext.TransactionController.extend({
 				}
 			});
 		}
-	}
+	},
+
+	manufacturer_part_no: function(doc, cdt, cdn) {
+		const row = locals[cdt][cdn];
+
+		if (row.manufacturer_part_no) {
+			frappe.model.get_value('Item Manufacturer',
+				{
+					'item_code': row.item_code,
+					'manufacturer': row.manufacturer,
+					'manufacturer_part_no': row.manufacturer_part_no
+				},
+				'name',
+				function(data) {
+					if (!data) {
+						let msg = {
+							message: __("Manufacturer Part Number <b>{0}</b> is invalid", [row.manufacturer_part_no]),
+							title: __("Invalid Part Number")
+						}
+						frappe.throw(msg);
+					}
+				});
+
+			}
+		}
 });
 
 cur_frm.add_fetch('project', 'cost_center', 'cost_center');

--- a/erpnext/stock/doctype/item/item.json
+++ b/erpnext/stock/doctype/item/item.json
@@ -114,6 +114,8 @@
   "is_sub_contracted_item",
   "column_break_74",
   "customer_code",
+  "default_item_manufacturer",
+  "default_manufacturer_part_no",
   "website_section",
   "show_in_website",
   "show_variant_in_website",
@@ -1038,6 +1040,18 @@
    "fieldname": "auto_create_assets",
    "fieldtype": "Check",
    "label": "Auto Create Assets on Purchase"
+  },
+  {
+   "fieldname": "default_item_manufacturer",
+   "fieldtype": "Data",
+   "label": "Default Item Manufacturer",
+   "read_only": 1
+  },
+  {
+   "fieldname": "default_manufacturer_part_no",
+   "fieldtype": "Data",
+   "label": "Default Manufacturer Part No",
+   "read_only": 1
   }
  ],
  "has_web_view": 1,
@@ -1046,7 +1060,7 @@
  "image_field": "image",
  "links": [],
  "max_attachments": 1,
- "modified": "2020-03-24 16:14:36.950677",
+ "modified": "2020-04-07 15:56:06.195722",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Item",

--- a/erpnext/stock/doctype/item_manufacturer/item_manufacturer.json
+++ b/erpnext/stock/doctype/item_manufacturer/item_manufacturer.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "allow_import": 1,
  "creation": "2019-06-02 04:41:37.332911",
  "doctype": "DocType",
@@ -10,7 +11,8 @@
   "manufacturer_part_no",
   "column_break_3",
   "item_name",
-  "description"
+  "description",
+  "is_default"
  ],
  "fields": [
   {
@@ -52,9 +54,17 @@
    "fieldtype": "Small Text",
    "label": "Description",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "is_default",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Is Default"
   }
  ],
- "modified": "2019-06-06 19:07:31.175919",
+ "links": [],
+ "modified": "2020-04-07 20:25:55.507905",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Item Manufacturer",

--- a/erpnext/stock/doctype/item_manufacturer/item_manufacturer.py
+++ b/erpnext/stock/doctype/item_manufacturer/item_manufacturer.py
@@ -11,6 +11,10 @@ from frappe.model.document import Document
 class ItemManufacturer(Document):
 	def validate(self):
 		self.validate_duplicate_entry()
+		self.manage_default_item_manufacturer()
+
+	def on_trash(self):
+		self.manage_default_item_manufacturer(delete=True)
 
 	def validate_duplicate_entry(self):
 		if self.is_new():
@@ -23,6 +27,40 @@ class ItemManufacturer(Document):
 			if frappe.db.exists("Item Manufacturer", filters):
 				frappe.throw(_("Duplicate entry against the item code {0} and manufacturer {1}")
 					.format(self.item_code, self.manufacturer))
+
+	def manage_default_item_manufacturer(self, delete=False):
+		from frappe.model.utils import set_default
+
+		item = frappe.get_doc("Item", self.item_code)
+		default_manufacturer = item.default_item_manufacturer
+		default_part_no = item.default_manufacturer_part_no
+
+		if not self.is_default:
+			# if unchecked and default in Item master, clear it.
+			if default_manufacturer == self.manufacturer and default_part_no == self.manufacturer_part_no:
+				frappe.db.set_value("Item", item.name,
+					{
+						"default_item_manufacturer": None,
+						"default_manufacturer_part_no": None
+					})
+
+		elif self.is_default:
+			set_default(self, "item_code")
+			manufacturer, manufacturer_part_no = default_manufacturer, default_part_no
+
+			if delete:
+				manufacturer, manufacturer_part_no = None, None
+
+			elif (default_manufacturer != self.manufacturer) or \
+				(default_manufacturer == self.manufacturer and default_part_no != self.manufacturer_part_no):
+				manufacturer = self.manufacturer
+				manufacturer_part_no = self.manufacturer_part_no
+
+			frappe.db.set_value("Item", item.name,
+					{
+						"default_item_manufacturer": manufacturer,
+						"default_manufacturer_part_no": manufacturer_part_no
+					})
 
 @frappe.whitelist()
 def get_item_manufacturer_part_no(item_code, manufacturer):

--- a/erpnext/stock/doctype/material_request_item/material_request_item.json
+++ b/erpnext/stock/doctype/material_request_item/material_request_item.json
@@ -404,14 +404,13 @@
   {
    "fieldname": "manufacturer_part_no",
    "fieldtype": "Data",
-   "label": "Manufacturer Part Number",
-   "read_only": 1
+   "label": "Manufacturer Part Number"
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-02-25 03:09:10.698967",
+ "modified": "2020-04-07 18:37:54.495112",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Material Request Item",

--- a/erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
+++ b/erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
@@ -801,8 +801,7 @@
   {
    "fieldname": "manufacturer_part_no",
    "fieldtype": "Data",
-   "label": "Manufacturer Part Number",
-   "read_only": 1
+   "label": "Manufacturer Part Number"
   },
   {
    "depends_on": "is_fixed_asset",
@@ -832,7 +831,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-03-11 14:19:48.799370",
+ "modified": "2020-04-07 18:38:21.141558",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Purchase Receipt Item",

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -341,6 +341,9 @@ def get_basic_details(args, item, overwrite_warehouse=True):
 		else:
 			out["manufacturer_part_no"] = None
 			out["manufacturer"] = None
+	else:
+		out["manufacturer"], out["manufacturer_part_no"] = frappe.get_value("Item", item.name,
+			["default_item_manufacturer", "default_manufacturer_part_no"] )
 
 	child_doctype = args.doctype + ' Item'
 	meta = frappe.get_meta(child_doctype)


### PR DESCRIPTION
- **Is Default** checkbox added in Item Manufacturer.
![Screenshot 2020-04-07 at 9 10 36 PM](https://user-images.githubusercontent.com/25857446/78690134-b323dc00-7914-11ea-8ff3-6d93bae74f61.png)


- **Default Item Manufacturer** and **Default Manufacturer Part** No fields added to Item Master
![Screenshot 2020-04-07 at 9 11 56 PM](https://user-images.githubusercontent.com/25857446/78690160-bb7c1700-7914-11ea-8998-d3e2e81abf33.png)

- **Manufacturer Part No** field is now editable in all child tables with validation ( if invalid Part Nos are added)
![ok](https://user-images.githubusercontent.com/25857446/79102539-8cd4c500-7d88-11ea-8134-da3e1da2f95d.png)

 
- Manufacturer and Part No auto fetched via `get_item_details` in child tables on setting item code.


**Minor Notes:**
- If is_default is unchecked and then saved , it will be cleared from Item Master if it was set there.
- If the default Item Manufacturer is deleted, it is again cleared from Item Master if it was set there.