### PR TITLE
fix: minor issues

### DIFF
--- a/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py
+++ b/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py
@@ -97,7 +97,7 @@ def build_forest(data):
 				return [parent_account]
 			elif account_name == child:
 				parent_account_list = return_parent(data, parent_account)
-				if not parent_account_list:
+				if not parent_account_list and parent_account:
 					frappe.throw(_("The parent account {0} does not exists")
 						.format(parent_account))
 				return [child] + parent_account_list

--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
@@ -4,6 +4,7 @@
  "description": "This tool helps you to update or fix the quantity and valuation of stock in the system. It is typically used to synchronise the system values and what actually exists in your warehouses.",
  "doctype": "DocType",
  "document_type": "Document",
+ "engine": "InnoDB",
  "field_order": [
   "naming_series",
   "company",
@@ -44,11 +45,11 @@
    "reqd": 1
   },
   {
-   "default": "Stock Reconciliation",
    "fieldname": "purpose",
    "fieldtype": "Select",
    "label": "Purpose",
-   "options": "Opening Stock\nStock Reconciliation"
+   "options": "\nOpening Stock\nStock Reconciliation",
+   "reqd": 1
   },
   {
    "fieldname": "col1",
@@ -153,7 +154,7 @@
  "idx": 1,
  "is_submittable": 1,
  "max_attachments": 1,
- "modified": "2019-05-26 09:03:09.542141",
+ "modified": "2020-04-08 17:02:47.196206",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Reconciliation",


### PR DESCRIPTION
1. 
```
  File "/home/frappe/benches/bench-version-12-2020-03-19/apps/erpnext/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py", line 63, in get_coa
    forest = build_forest(generate_data_from_csv(file_name))
  File "/home/frappe/benches/bench-version-12-2020-03-19/apps/erpnext/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py", line 121, in build_forest
    path = return_parent(data, account_name)[::-1]
  File "/home/frappe/benches/bench-version-12-2020-03-19/apps/erpnext/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py", line 101, in return_parent
    frappe.throw(_("The parent account {0} does not exists")
TypeError: 'str' object is not callable
```

2. While creating a Stock Reconciliation, by default the option chosen for Purpose field is Stock Reconciliation. Since, a person might not even know there exists an option for Opening Entry. To fix this issue now onward, the purpose field will be blank and user has to select the purpose manually.  