### PR TITLE
fix: move to hooks

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -345,6 +345,8 @@ get_site_info = 'erpnext.utilities.get_site_info'
 
 payment_gateway_enabled = "erpnext.accounts.utils.create_payment_gateway_account"
 
+communication_doctypes = ["Customer", "Supplier"]
+
 regional_overrides = {
 	'France': {
 		'erpnext.tests.test_regional.test_method': 'erpnext.regional.france.utils.test_method'


### PR DESCRIPTION
- Move Customer and Supplier to hooks in ERPNext.
- Framework should be independent of any ERPNext related stuff
- Frappe PR [#9874](https://github.com/frappe/frappe/pull/9874)