### PR TITLE
fix: Error on any new doc from Shipping Rule.

### DIFF
--- a/erpnext/accounts/doctype/shipping_rule/shipping_rule.py
+++ b/erpnext/accounts/doctype/shipping_rule/shipping_rule.py
@@ -82,7 +82,7 @@ class ShippingRule(Document):
 			if not shipping_country:
 				frappe.throw(_('Shipping Address does not have country, which is required for this Shipping Rule'))
 			if shipping_country not in [d.country for d in self.countries]:
-				frappe.throw(_('Shipping rule not applicable for country {0}').format(shipping_country))
+				frappe.throw(_('Shipping rule not applicable for country {0} in Shipping Address').format(shipping_country))
 
 	def add_shipping_rule_to_tax_table(self, doc, shipping_amount):
 		shipping_charge = {

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -894,7 +894,7 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 
 	shipping_rule: function() {
 		var me = this;
-		if(this.frm.doc.shipping_rule) {
+		if(this.frm.doc.shipping_rule && this.frm.doc.shipping_address) {
 			return this.frm.call({
 				doc: this.frm.doc,
 				method: "apply_shipping_rule",


### PR DESCRIPTION
**Issue:**
Even though the country is appropriate. From **Shipping Rule** to Purchase Order (or any doc)

![shipping-rule](https://user-images.githubusercontent.com/25857446/78799663-0c087880-79d8-11ea-9dc9-eb00f78174d2.png)

**Fix:**
- Error because `shipping_rule` is set before `shipping_address`. While applying `shipping` rule on `shipping_rule` trigger, it gets `None` as the `shipping_address`.
- Don't apply Shipping Rule unless `shipping_address` and `shipping_rule` are both there.
- `shipping_rule` gets triggered on setting item in the child table again, so it will get set eventually.
