### PR TITLE
fix: Accounts Table not updating on changing Entry Type in Journal Entry Form.

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.js
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.js
@@ -120,6 +120,10 @@ frappe.ui.form.on("Journal Entry", {
 				}
 			}
 		});
+	},
+	voucher_type: function(frm) {
+		frm.fields_dict.accounts.frm.clear_table('accounts');
+		frm.fields_dict.accounts.frm.refresh_fields();
 	}
 });
 


### PR DESCRIPTION
Issue: [21210](https://github.com/frappe/erpnext/issues/21210)

Child table (Journal Entry Account) values were not updating
when Entry Type is changed.

Now child table is cleared on Entry Type value change, and
new values are showing.