### PR TITLE
fix: Lead Contact with blank first name via Customer

### DIFF
--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -150,7 +150,7 @@ class Customer(TransactionBase):
 						contact.save()
 
 			else:
-				lead.lead_name = lead.lead_name.split(" ")
+				lead.lead_name = lead.lead_name.lstrip().split(" ")
 				lead.first_name = lead.lead_name[0]
 				lead.last_name = " ".join(lead.lead_name[1:])
 


### PR DESCRIPTION
- On saving a Customer that has a Lead attached, system creates a Lead contact
- If Lead name has leading white space, Contact's first name is set to blank. ( due to split(" ") ) 
  ![issue](https://user-images.githubusercontent.com/25857446/79112351-fca07b00-7d9b-11ea-8005-ac98f739ba41.png)

**Fix:**
- strip leading white space before splitting