### PR TITLE
fix: consider reverted expired leaves entry

### DIFF
--- a/erpnext/hr/doctype/leave_application/leave_application.py
+++ b/erpnext/hr/doctype/leave_application/leave_application.py
@@ -575,19 +575,22 @@ def get_leaves_for_period(employee, leave_type, from_date, to_date):
 	return leave_days
 
 def skip_expiry_leaves(leave_entry, date):
-	''' Checks whether the expired leaves coincide with the to_date of leave balance check '''
+	''' Checks whether the expired leaves coincide with the to_date of leave balance check.
+		This allows backdated leave entry creation for non carry forwarded allocation '''
 	end_date = frappe.db.get_value("Leave Allocation", {'name': leave_entry.transaction_name}, ['to_date'])
 	return True if end_date == date and not leave_entry.is_carry_forward else False
 
 def get_leave_entries(employee, leave_type, from_date, to_date):
-	''' Returns leave entries between from_date and to_date '''
+	''' Returns leave entries between from_date and to_date. '''
 	return frappe.db.sql("""
 		SELECT
 			employee, leave_type, from_date, to_date, leaves, transaction_name, transaction_type, holiday_list,
 			is_carry_forward, is_expired
 		FROM `tabLeave Ledger Entry`
 		WHERE employee=%(employee)s AND leave_type=%(leave_type)s
-			AND docstatus=1 AND leaves<0
+			AND docstatus=1 
+			AND (leaves<0
+				OR is_expired=1)
 			AND (from_date between %(from_date)s AND %(to_date)s
 				OR to_date between %(from_date)s AND %(to_date)s
 				OR (from_date < %(from_date)s AND to_date > %(to_date)s))

--- a/erpnext/hr/doctype/leave_encashment/leave_encashment.py
+++ b/erpnext/hr/doctype/leave_encashment/leave_encashment.py
@@ -8,7 +8,6 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.utils import getdate, nowdate, flt
 from erpnext.hr.utils import set_employee_name
-from erpnext.hr.doctype.leave_application.leave_application import get_leave_balance_on
 from erpnext.hr.doctype.salary_structure_assignment.salary_structure_assignment import get_assigned_salary_structure
 from erpnext.hr.doctype.leave_ledger_entry.leave_ledger_entry import create_leave_ledger_entry
 from erpnext.hr.doctype.leave_allocation.leave_allocation import get_unused_leaves

--- a/erpnext/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
+++ b/erpnext/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
@@ -141,6 +141,7 @@ def expire_allocation(allocation, expiry_date=None):
 	leaves = get_remaining_leaves(allocation)
 	expiry_date = expiry_date if expiry_date else allocation.to_date
 
+	# allows expired leaves entry to be created/reverted
 	if leaves:
 		args = dict(
 			leaves=flt(leaves) * -1,
@@ -160,6 +161,8 @@ def expire_carried_forward_allocation(allocation):
 	from erpnext.hr.doctype.leave_application.leave_application import get_leaves_for_period
 	leaves_taken = get_leaves_for_period(allocation.employee, allocation.leave_type, allocation.from_date, allocation.to_date)
 	leaves = flt(allocation.leaves) + flt(leaves_taken)
+
+	# allow expired leaves entry to be created
 	if leaves > 0:
 		args = frappe._dict(
 			transaction_name=allocation.name,

--- a/erpnext/hr/report/employee_leave_balance/employee_leave_balance.py
+++ b/erpnext/hr/report/employee_leave_balance/employee_leave_balance.py
@@ -76,7 +76,7 @@ def get_data(filters, leave_types):
 				opening = get_leave_balance_on(employee.name, leave_type, filters.from_date)
 
 				# closing balance
-				closing = get_leave_balance_on(employee.name, leave_type, filters.to_date)
+				closing = max(opening - leaves_taken, 0)
 
 				row += [opening, leaves_taken, closing]
 


### PR DESCRIPTION
- Consider reverted entries to cancel out expired leave entries which were reverted
- Add more descriptive comments to the existing functions
- do not allow leave balance to be less than 0 for closing balance in employee leave balance report