### PR TITLE
Update project.json

### DIFF
--- a/erpnext/projects/doctype/project/project.json
+++ b/erpnext/projects/doctype/project/project.json
@@ -83,7 +83,6 @@
    "oldfieldname": "status",
    "oldfieldtype": "Select",
    "options": "Open\nCompleted\nCancelled",
-   "reqd": 1,
    "search_index": 1
   },
   {


### PR DESCRIPTION
unnecessary requirement for project creation as this is a field of the Type select which will be pre-filled. When creating a project of list view it will also bring up this field as it has "reqd": 1. A new projekt will have the status set to open in most cases.
