### PR TITLE
fix: patch for Healthcare Refactoring

### DIFF
--- a/erpnext/patches/v12_0/update_healthcare_refactored_changes.py
+++ b/erpnext/patches/v12_0/update_healthcare_refactored_changes.py
@@ -100,7 +100,7 @@ def execute():
 
 		for entry in encounter_details:
 			doc = frappe.get_doc('Patient Encounter', entry.name)
-			symptoms = entry.symptoms.split('\n')
+			symptoms = entry.symptoms.split('\n') if entry.symptoms else []
 			for symptom in symptoms:
 				if not frappe.db.exists('Complaint', symptom):
 					frappe.get_doc({
@@ -112,7 +112,7 @@ def execute():
 				})
 				row.db_update()
 
-			diagnosis = entry.diagnosis.split('\n')
+			diagnosis = entry.diagnosis.split('\n') if entry.diagnosis else []
 			for d in diagnosis:
 				if not frappe.db.exists('Diagnosis', d):
 					frappe.get_doc({


### PR DESCRIPTION
**Fix:** If Symptoms and Diagnoses are empty in Patient Encounters
```
Executing erpnext.patches.v12_0.update_healthcare_refactored_changes in test (_a94a8fe5ccb19ba6)
Traceback (most recent call last):
  File "/usr/local/Cellar/python/3.7.4_1/Frameworks/Python.framework/Versions/3.7/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/local/Cellar/python/3.7.4_1/Frameworks/Python.framework/Versions/3.7/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/Users/ruchamahabal/frappe-test-bench/apps/frappe/frappe/utils/bench_helper.py", line 97, in <module>
    main()
  File "/Users/ruchamahabal/frappe-test-bench/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/Users/ruchamahabal/frappe-test-bench/env/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/Users/ruchamahabal/frappe-test-bench/env/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/Users/ruchamahabal/frappe-test-bench/env/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/ruchamahabal/frappe-test-bench/env/lib/python3.7/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/ruchamahabal/frappe-test-bench/env/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/ruchamahabal/frappe-test-bench/env/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/Users/ruchamahabal/frappe-test-bench/env/lib/python3.7/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/ruchamahabal/frappe-test-bench/apps/frappe/frappe/commands/__init__.py", line 25, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/Users/ruchamahabal/frappe-test-bench/apps/frappe/frappe/commands/site.py", line 241, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website, skip_failing=skip_failing)
  File "/Users/ruchamahabal/frappe-test-bench/apps/frappe/frappe/migrate.py", line 49, in migrate
    frappe.modules.patch_handler.run_all(skip_failing)
  File "/Users/ruchamahabal/frappe-test-bench/apps/frappe/frappe/modules/patch_handler.py", line 41, in run_all
    run_patch(patch)
  File "/Users/ruchamahabal/frappe-test-bench/apps/frappe/frappe/modules/patch_handler.py", line 30, in run_patch
    if not run_single(patchmodule = patch):
  File "/Users/ruchamahabal/frappe-test-bench/apps/frappe/frappe/modules/patch_handler.py", line 71, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/Users/ruchamahabal/frappe-test-bench/apps/frappe/frappe/modules/patch_handler.py", line 91, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/Users/ruchamahabal/frappe-test-bench/apps/erpnext/erpnext/patches/v12_0/update_healthcare_refactored_changes.py", line 103, in execute
    symptoms = entry.symptoms.split('\n')
AttributeError: 'NoneType' object has no attribute 'split'
```