### PR TITLE
fix: warehouse unset if an item doesn't have default warehouse

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -440,11 +440,12 @@ class SalesInvoice(SellingController):
 			if pos.get("company_address"):
 				self.company_address = pos.get("company_address")
 
-			customer_price_list, customer_group = frappe.get_value("Customer", self.customer, ['default_price_list', 'customer_group'])
-
-			customer_group_price_list = frappe.get_value("Customer Group", customer_group, 'default_price_list')
-
-			selling_price_list = customer_price_list or customer_group_price_list or pos.get('selling_price_list')
+			if self.customer:
+				customer_price_list, customer_group = frappe.get_value("Customer", self.customer, ['default_price_list', 'customer_group'])
+				customer_group_price_list = frappe.get_value("Customer Group", customer_group, 'default_price_list')
+				selling_price_list = customer_price_list or customer_group_price_list or pos.get('selling_price_list')
+			else:
+				selling_price_list = pos.get('selling_price_list')
 
 			if selling_price_list:
 				self.set('selling_price_list', selling_price_list)

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -436,6 +436,44 @@ erpnext.utils.update_child_items = function(opts) {
 	const cannot_add_row = (typeof opts.cannot_add_row === 'undefined') ? true : opts.cannot_add_row;
 	const child_docname = (typeof opts.cannot_add_row === 'undefined') ? "items" : opts.child_docname;
 	this.data = [];
+	const fields = [{
+		fieldtype:'Data',
+		fieldname:"docname",
+		read_only: 1,
+		hidden: 1,
+	}, {
+		fieldtype:'Link',
+		fieldname:"item_code",
+		options: 'Item',
+		in_list_view: 1,
+		read_only: 0,
+		disabled: 0,
+		label: __('Item Code')
+	}, {
+		fieldtype:'Float',
+		fieldname:"qty",
+		default: 0,
+		read_only: 0,
+		in_list_view: 1,
+		label: __('Qty')
+	}, {
+		fieldtype:'Currency',
+		fieldname:"rate",
+		default: 0,
+		read_only: 0,
+		in_list_view: 1,
+		label: __('Rate')
+	}];
+
+	if (frm.doc.doctype == 'Sales Order' || frm.doc.doctype == 'Purchase Order' ) {
+		fields.splice(2, 0, {
+			fieldtype: 'Date',
+			fieldname: frm.doc.doctype == 'Sales Order' ? "delivery_date" : "schedule_date",
+			in_list_view: 1,
+			label: frm.doc.doctype == 'Sales Order' ? __("Delivery Date") : __("Reqd by date")
+		})
+	}
+
 	const dialog = new frappe.ui.Dialog({
 		title: __("Update Items"),
 		fields: [
@@ -450,34 +488,7 @@ erpnext.utils.update_child_items = function(opts) {
 				get_data: () => {
 					return this.data;
 				},
-				fields: [{
-					fieldtype:'Data',
-					fieldname:"docname",
-					read_only: 1,
-					hidden: 1,
-				}, {
-					fieldtype:'Link',
-					fieldname:"item_code",
-					options: 'Item',
-					in_list_view: 1,
-					read_only: 0,
-					disabled: 0,
-					label: __('Item Code')
-				}, {
-					fieldtype:'Float',
-					fieldname:"qty",
-					default: 0,
-					read_only: 0,
-					in_list_view: 1,
-					label: __('Qty')
-				}, {
-					fieldtype:'Currency',
-					fieldname:"rate",
-					default: 0,
-					read_only: 0,
-					in_list_view: 1,
-					label: __('Rate')
-				}]
+				fields: fields
 			},
 		],
 		primary_action: function() {
@@ -506,6 +517,8 @@ erpnext.utils.update_child_items = function(opts) {
 			"docname": d.name,
 			"name": d.name,
 			"item_code": d.item_code,
+			"delivery_date": d.delivery_date,
+			"schedule_date": d.schedule_date,
 			"qty": d.qty,
 			"rate": d.rate,
 		});


### PR DESCRIPTION
Problem: 
If an item or item group or brand or stock settings doesn't have default warehouse, while updating items in sales order, item gets added without warehouse validation

Point of sale was unaccessible if customer is not set in pos profile