### PR TITLE
chore: Added change log

### DIFF
--- a/erpnext/change_log/v12/v12_7_0.md
+++ b/erpnext/change_log/v12/v12_7_0.md
@@ -1,0 +1,63 @@
+## ERPNext v12.7.0 Release Note
+
+### Enhancements
+
+- Allow Purchase/Sales Invoice without Purchase/Sales Order against a specific Supplier/Customer [#20865](https://github.com/frappe/erpnext/pull/20865)
+- The address is now mandatory to place an order from Shopping Cart [#20922](https://github.com/frappe/erpnext/pull/20922)
+- Target Warehouse for finished goods in Manufacture type Stock Entry now can be different from Work Order [#21002](https://github.com/frappe/erpnext/pull/21002)
+- Qty in Stock Entry must always be positive [#21004](https://github.com/frappe/erpnext/pull/21004)
+- Enhanced UX for Manufacturing module [#19802](https://github.com/frappe/erpnext/pull/19802)
+    - Default calendar for Job Card
+    - Changed Timer Position, Added Pause, Resume Button
+    - Progress Bar for Work Order Operations
+    - Create Multiple Job Cards from Work Order
+    - Removed Projected Quantity Formula Section from Production Plan and Added Doc Link Next to Field
+    - Grouped relevant fields
+- Allowed customized Order Type in Sales Order [#18096](https://github.com/frappe/erpnext/pull/18096)
+- Added Serial No Status field for the filter in List and Report view [#21201](https://github.com/frappe/erpnext/pull/21201)
+- Enabled new regions (UAE, BR, MX) to amazon MWS connector [#21195](https://github.com/frappe/erpnext/pull/21195)
+- Added Scan Barcode field in Purchase Receipt [#21181](https://github.com/frappe/erpnext/pull/21181)
+- Added Cost Center, Warehouse and Item Group filters in Purchase Register report [#21177](https://github.com/frappe/erpnext/pull/21177)
+- Show filtered items in Material Request based on Request Type [#21173](https://github.com/frappe/erpnext/pull/21173)
+- Set Qty To Manufacture field as non-mandatory in job card [#21080](https://github.com/frappe/erpnext/pull/21080)
+- Fetch batch no automatically from serial no, if the item has both serial and batch no [#20757](https://github.com/frappe/erpnext/pull/20757)
+
+### Fixes:
+- The payment status of Expense Claim considering Employee Advance amount
+- Fixes in BOM Comparison Tool [#20992](https://github.com/frappe/erpnext/pull/20992)
+- UOM fixes in Sales Order, Material Request and Production Plan [#21015](https://github.com/frappe/erpnext/pull/21015)
+- Passive Italian e-Invoicing [#19334](https://github.com/frappe/erpnext/issues/19334)
+- Batch selection popup not coming for stock entry [#21036](https://github.com/frappe/erpnext/pull/21036)
+- Place of supply validation in GSTR-1 report (for India) [#21057](https://github.com/frappe/erpnext/pull/21057)
+- On changing qty, the free item was not removing [#21250](https://github.com/frappe/erpnext/pull/21250)
+- If Lead name has leading white space, Contact's first name was set to blank [#21247](https://github.com/frappe/erpnext/pull/21247)
+- Make Message field mandatory in Project, if Collect Progress is checked [#21208](https://github.com/frappe/erpnext/pull/21208)
+- Show base received amount only when base paid amount defers from base received amount [#21193](https://github.com/frappe/erpnext/pull/21193)
+- Consider reverted entries to cancel out expired leave entries which were reverted [#21256](https://github.com/frappe/erpnext/pull/21256)
+- The tax amount after discount amount should be considered for tax calculation in GSTR-3B report [#21241](https://github.com/frappe/erpnext/pull/21241)
+- Replace newlines with spaces before evaluation of condition and formula [#21166](https://github.com/frappe/erpnext/pull/21166)
+- Get serial nos qty in Stock Reconciliation based on posting date and time [#21169](https://github.com/frappe/erpnext/pull/21169)
+- Validate Serial/Batch No naming series in Item itself [#21167](https://github.com/frappe/erpnext/pull/21167)
+- When shipping tax is set it does not clear cart and gives error [#21035](https://github.com/frappe/erpnext/pull/21035)
+- While creating Sales Invoice from the shopping cart, enable auto allocation of advances [#20878](https://github.com/frappe/erpnext/pull/20878)
+- Payment Request status fixes [#21100](https://github.com/frappe/erpnext/pull/21100)
+- Add permissions on GSTR-3B report only for India [#21163](https://github.com/frappe/erpnext/pull/21163)
+- Since a Customer Provided Item does not have a valuation rate, expenses should not be booked in Stock Entry [#21156](https://github.com/frappe/erpnext/pull/21156)
+- Update Received Qty in Material Request as per Stock UOM [#21055](https://github.com/frappe/erpnext/pull/21054)
+- Cannot set warehouse while deleting all items from submitted sales order and then adding new items [#21078](https://github.com/frappe/erpnext/pull/21078)
+- Serial no scan was not adding the serial nos in stock entry [#21082](https://github.com/frappe/erpnext/pull/21082)
+- Healthcare Domain Issues [#21112](https://github.com/frappe/erpnext/pull/21112)
+    - Appointment Reminders not working
+    - Disabled Patient, Practitioner Schedule, Clinical Procedure Template showed as enabled in ListView.
+    - Batch not getting fetched in Clinical Procedure Item.
+    - Lab Test Template Item creation error
+    - Lab Test Template error while creating a Patient Medical Record
+- Party details not set in Payment Request in case of payment failed from shopping cart [#21085](https://github.com/frappe/erpnext/pull/21085)
+- Allowed Expense accounts with only base currency in Landed Cost voucher [#21074](https://github.com/frappe/erpnext/pull/21074)
+- Price list mentioned in Customer Group should get priority over POS Profile [#21117](https://github.com/frappe/erpnext/pull/21117)
+- Show proper currency symbol in Total row in Accounts Receivable/Payable report [#21090](https://github.com/frappe/erpnext/pull/21090)
+- Add item defaults based on global settings only if default company and warehouse is mentioned [#21088](https://github.com/frappe/erpnext/pull/21088)
+- If "Display Items In Stock" enabled, show only available items in POS [#21071](https://github.com/frappe/erpnext/pull/21071)
+- Update Requested Qty in Bin based on Material Request Type [#21065](https://github.com/frappe/erpnext/pull/21065)
+- Ignored user permission for parent_company and existing_company field in Company [#21010](https://github.com/frappe/erpnext/pull/21010)
+- Wrong calculation of depreciation eliminated in Asset Depreciation and Balances report [#21032](https://github.com/frappe/erpnext/pull/21032)


### PR DESCRIPTION
## Version 12.7.0 Release Note

### Enhancements

- Allow Purchase/Sales Invoice without Purchase/Sales Order against a specific Supplier/Customer [#20865](https://github.com/frappe/erpnext/pull/20865)
- The address is now mandatory to place an order from Shopping Cart [#20922](https://github.com/frappe/erpnext/pull/20922)
- Target Warehouse for finished goods in Manufacture type Stock Entry now can be different from Work Order [#21002](https://github.com/frappe/erpnext/pull/21002)
- Qty in Stock Entry must always be positive [#21004](https://github.com/frappe/erpnext/pull/21004)
- Enhanced UX for Manufacturing module [#19802](https://github.com/frappe/erpnext/pull/19802)
    - Default calendar for Job Card
    - Changed Timer Position, Added Pause, Resume Button
    - Progress Bar for Work Order Operations
    - Create Multiple Job Cards from Work Order
    - Removed Projected Quantity Formula Section from Production Plan and Added Doc Link Next to Field
    - Grouped relevant fields
- Allowed customized Order Type in Sales Order [#18096](https://github.com/frappe/erpnext/pull/18096)
- Added Serial No Status field for the filter in List and Report view [#21201](https://github.com/frappe/erpnext/pull/21201)
- Enabled new regions (UAE, BR, MX) to amazon MWS connector [#21195](https://github.com/frappe/erpnext/pull/21195)
- Added Scan Barcode field in Purchase Receipt [#21181](https://github.com/frappe/erpnext/pull/21181)
- Added Cost Center, Warehouse and Item Group filters in Purchase Register report [#21177](https://github.com/frappe/erpnext/pull/21177)
- Show filtered items in Material Request based on Request Type [#21173](https://github.com/frappe/erpnext/pull/21173)
- Set Qty To Manufacture field as non-mandatory in job card [#21080](https://github.com/frappe/erpnext/pull/21080)
- Fetch batch no automatically from serial no, if the item has both serial and batch no [#20757](https://github.com/frappe/erpnext/pull/20757)

### Fixes:
- The payment status of Expense Claim considering Employee Advance amount
- Fixes in BOM Comparison Tool [#20992](https://github.com/frappe/erpnext/pull/20992)
- UOM fixes in Sales Order, Material Request and Production Plan [#21015](https://github.com/frappe/erpnext/pull/21015)
- Passive Italian e-Invoicing [#19334](https://github.com/frappe/erpnext/issues/19334)
- Batch selection popup not coming for stock entry [#21036](https://github.com/frappe/erpnext/pull/21036)
- Place of supply validation in GSTR-1 report (for India) [#21057](https://github.com/frappe/erpnext/pull/21057)
- On changing qty, the free item was not removing [#21250](https://github.com/frappe/erpnext/pull/21250)
- If Lead name has leading white space, Contact's first name was set to blank [#21247](https://github.com/frappe/erpnext/pull/21247)
- Make Message field mandatory in Project, if Collect Progress is checked [#21208](https://github.com/frappe/erpnext/pull/21208)
- Show base received amount only when base paid amount defers from base received amount [#21193](https://github.com/frappe/erpnext/pull/21193)
- Consider reverted entries to cancel out expired leave entries which were reverted [#21256](https://github.com/frappe/erpnext/pull/21256)
- The tax amount after discount amount should be considered for tax calculation in GSTR-3B report [#21241](https://github.com/frappe/erpnext/pull/21241)
- Replace newlines with spaces before evaluation of condition and formula [#21166](https://github.com/frappe/erpnext/pull/21166)
- Get serial nos qty in Stock Reconciliation based on posting date and time [#21169](https://github.com/frappe/erpnext/pull/21169)
- Validate Serial/Batch No naming series in Item itself [#21167](https://github.com/frappe/erpnext/pull/21167)
- When shipping tax is set it does not clear cart and gives error [#21035](https://github.com/frappe/erpnext/pull/21035)
- While creating Sales Invoice from the shopping cart, enable auto allocation of advances [#20878](https://github.com/frappe/erpnext/pull/20878)
- Payment Request status fixes [#21100](https://github.com/frappe/erpnext/pull/21100)
- Add permissions on GSTR-3B report only for India [#21163](https://github.com/frappe/erpnext/pull/21163)
- Since a Customer Provided Item does not have a valuation rate, expenses should not be booked in Stock Entry [#21156](https://github.com/frappe/erpnext/pull/21156)
- Update Received Qty in Material Request as per Stock UOM [#21055](https://github.com/frappe/erpnext/pull/21054)
- Cannot set warehouse while deleting all items from submitted sales order and then adding new items [#21078](https://github.com/frappe/erpnext/pull/21078)
- Serial no scan was not adding the serial nos in stock entry [#21082](https://github.com/frappe/erpnext/pull/21082)
- Healthcare Domain Issues [#21112](https://github.com/frappe/erpnext/pull/21112)
    - Appointment Reminders not working
    - Disabled Patient, Practitioner Schedule, Clinical Procedure Template showed as enabled in ListView.
    - Batch not getting fetched in Clinical Procedure Item.
    - Lab Test Template Item creation error
    - Lab Test Template error while creating a Patient Medical Record
- Party details not set in Payment Request in case of payment failed from shopping cart [#21085](https://github.com/frappe/erpnext/pull/21085)
- Allowed Expense accounts with only base currency in Landed Cost voucher [#21074](https://github.com/frappe/erpnext/pull/21074)
- Price list mentioned in Customer Group should get priority over POS Profile [#21117](https://github.com/frappe/erpnext/pull/21117)
- Show proper currency symbol in Total row in Accounts Receivable/Payable report [#21090](https://github.com/frappe/erpnext/pull/21090)
- Add item defaults based on global settings only if default company and warehouse is mentioned [#21088](https://github.com/frappe/erpnext/pull/21088)
- If "Display Items In Stock" enabled, show only available items in POS [#21071](https://github.com/frappe/erpnext/pull/21071)
- Update Requested Qty in Bin based on Material Request Type [#21065](https://github.com/frappe/erpnext/pull/21065)
- Ignored user permission for parent_company and existing_company field in Company [#21010](https://github.com/frappe/erpnext/pull/21010)
- Wrong calculation of depreciation eliminated in Asset Depreciation and Balances report [#21032](https://github.com/frappe/erpnext/pull/21032)