### PR TITLE
fix: filters as dictionary

### DIFF
--- a/erpnext/support/doctype/issue/issue.py
+++ b/erpnext/support/doctype/issue/issue.py
@@ -335,8 +335,13 @@ def get_issue_list(doctype, txt, filters, limit_start, limit_page_length=20, ord
 
 	ignore_permissions = False
 	if is_website_user():
-		if not filters: filters = []
-		filters.append(("Issue", "customer", "=", customer)) if customer else filters.append(("Issue", "raised_by", "=", user))
+		if not filters: filters = {}
+
+		if customer:
+			filters["customer"] = customer
+		else:
+			filters["raised_by"] = user
+
 		ignore_permissions = True
 
 	return get_list(doctype, txt, filters, limit_start, limit_page_length, ignore_permissions=ignore_permissions)


### PR DESCRIPTION
Filters are passed as dict from the website. However the get list would assume it to be a list and would append filters causing the following error

<img width="1071" alt="Screenshot 2020-04-19 at 12 50 18 PM" src="https://user-images.githubusercontent.com/18097732/79681988-5988af00-823c-11ea-9498-1e4ba4f7c81a.png">

This PR fixes this