### PR TITLE
fix: removed method reference not in version-12

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -268,9 +268,7 @@ doc_events = {
 
 scheduler_events = {
 	"all": [
-		"erpnext.projects.doctype.project.project.project_status_update_reminder",
-		"erpnext.healthcare_healthcare.doctype.patient_appointment.patient_appointment.send_appointment_reminder"
-
+		"erpnext.projects.doctype.project.project.project_status_update_reminder"
 	],
 	"hourly": [
 		'erpnext.hr.doctype.daily_work_summary_group.daily_work_summary_group.trigger_emails',


### PR DESCRIPTION
Removed scheduler event incorrectly added in this version, method not yet merged to version-12

as reported via this [discuss post](https://discuss.erpnext.com/t/internal-server-error-and-healthcare-module-missing/60479/6)