### PR TITLE
fix: free item quantity issue

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1396,6 +1396,8 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 			for (let key in free_item_data) {
 				row_to_modify[key] = free_item_data[key];
 			}
+		} if (items && items.length && free_item_data) {
+			items[0].qty = free_item_data.qty
 		}
 	},
 


### PR DESCRIPTION
Free item quantity not updated as per new pricing rule
Example:
If customer buys item A for quantity between 4 to 9 then they receive 1 free Item B.

if customer buys item A for quantity more than 10 then they receive 3 free Item B.

**Issue**

If Item A with 10 qty added then free item added with 3 quantity, but if Item A qty reduce to 5 then free item qty not updated to 1.