### PR TITLE
fix(Healthcare): remove hardcoded UOM during Item creation for Templates

### DIFF
--- a/erpnext/healthcare/doctype/clinical_procedure_template/clinical_procedure_template.py
+++ b/erpnext/healthcare/doctype/clinical_procedure_template/clinical_procedure_template.py
@@ -79,6 +79,7 @@ def create_item_from_template(doc):
 	if doc.is_billable and not doc.disabled:
 		disabled = 0
 
+	uom = frappe.db.exists('UOM', 'Unit') or frappe.db.get_single_value('Stock Settings', 'stock_uom')
 	item = frappe.get_doc({
 		'doctype': 'Item',
 		'item_code': doc.template,
@@ -92,7 +93,7 @@ def create_item_from_template(doc):
 		'show_in_website': 0,
 		'is_pro_applicable': 0,
 		'disabled': disabled,
-		'stock_uom': 'Unit'
+		'stock_uom': uom
 	}).insert(ignore_permissions=True, ignore_mandatory=True)
 
 	make_item_price(item.name, doc.rate)

--- a/erpnext/healthcare/doctype/lab_test_template/lab_test_template.py
+++ b/erpnext/healthcare/doctype/lab_test_template/lab_test_template.py
@@ -74,26 +74,27 @@ class LabTestTemplate(Document):
 
 
 def create_item_from_template(doc):
-	if doc.is_billable:
+	disabled = doc.disabled
+	if doc.is_billable and not doc.disabled:
 		disabled = 0
-	else:
-		disabled = 1
+
+	uom = frappe.db.exists('UOM', 'Unit') or frappe.db.get_single_value('Stock Settings', 'stock_uom')
 	# insert item
 	item =  frappe.get_doc({
-	"doctype": "Item",
-	"item_code": doc.lab_test_code,
-	"item_name":doc.lab_test_name,
-	"item_group": doc.lab_test_group,
-	"description":doc.lab_test_description,
-	"is_sales_item": 1,
-	"is_service_item": 1,
-	"is_purchase_item": 0,
-	"is_stock_item": 0,
-	"show_in_website": 0,
-	"is_pro_applicable": 0,
-	"disabled": disabled,
-	"stock_uom": "Unit"
-	}).insert(ignore_permissions=True)
+		"doctype": "Item",
+		"item_code": doc.lab_test_code,
+		"item_name":doc.lab_test_name,
+		"item_group": doc.lab_test_group,
+		"description":doc.lab_test_description,
+		"is_sales_item": 1,
+		"is_service_item": 1,
+		"is_purchase_item": 0,
+		"is_stock_item": 0,
+		"show_in_website": 0,
+		"is_pro_applicable": 0,
+		"disabled": disabled,
+		"stock_uom": uom
+	}).insert(ignore_permissions=True, ignore_mandatory=True)
 
 	# insert item price
 	# get item price list to insert item price


### PR DESCRIPTION
Issue: https://github.com/frappe/erpnext/issues/20218

The "Unit" UOM was hardcoded while creating Items for Templates in Healthcare. This created a problem if it is not present in the system and also in translation:

![image](https://user-images.githubusercontent.com/24353136/79835542-7c49cd80-83cc-11ea-8f1a-139d7646a030.png)

Now it checks if the "Unit" UOM is present, else picks up the default UOM set in Stock Settings
