### PR TITLE
feat: (minor) Display more informative message when work order can't be created

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -422,7 +422,7 @@ class WorkOrder(Document):
 	def validate_operation_time(self):
 		for d in self.operations:
 			if not d.time_in_mins > 0:
-				frappe.throw(_("Operation Time must be greater than 0 for Operation {0}".format(d.operation)))
+				frappe.throw(_("Operation Time must be greater than 0 for Operation {0} (Item: {1}, BOM: {2}).".format(d.operation, self.production_item, self.bom_no)))
 
 	def update_required_items(self):
 		'''


### PR DESCRIPTION
ERPNext was showing just Operation Name when work order can't be created. With this PR, it also shows item's name and bom name. (When creating more than 10 work orders via production planning, operation name is not sufficient)

Old Way:
![image](https://user-images.githubusercontent.com/710051/79893317-94d9d800-840c-11ea-9cb1-846a14d62bda.png)

When Updated:
![image](https://user-images.githubusercontent.com/710051/79893370-a4592100-840c-11ea-800c-e63e93206737.png)


<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
