### PR TITLE
chore: remove oldfieldtype from purchase invoice item

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
+++ b/erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
@@ -563,9 +563,6 @@
    "fieldname": "item_group",
    "fieldtype": "Data",
    "label": "Item Group",
-   "oldfieldname": "item_group",
-   "oldfieldtype": "Link",
-   "options": "Item Group",
    "print_hide": 1,
    "read_only": 1
   },
@@ -777,7 +774,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-04-07 18:34:35.104178",
+ "modified": "2020-04-22 10:37:35.103176",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Purchase Invoice Item",


### PR DESCRIPTION
fixes issue where framework expects data field type to be validated with options either set to "Email" or "Phone".

removing oldfieldtype works for now, should be fixed inside framework

closes: #21364 