### PR TITLE
fix: Missing backlink in dashboard

### DIFF
--- a/erpnext/crm/doctype/lead/lead_dashboard.py
+++ b/erpnext/crm/doctype/lead/lead_dashboard.py
@@ -13,7 +13,7 @@ def get_data():
 		},
 		'transactions': [
 			{
-				'items': ['Opportunity', 'Quotation']
+				'items': ['Opportunity', 'Quotation', 'Email Campaign']
 			},
 		]
 	}


### PR DESCRIPTION
Added Email Campaign Link to Dashboard. Placing should be discussed As there are no different sections for the moment.


