### PR TITLE
fix: BOM stock report

### DIFF
--- a/erpnext/manufacturing/report/bom_stock_report/bom_stock_report.py
+++ b/erpnext/manufacturing/report/bom_stock_report/bom_stock_report.py
@@ -18,10 +18,10 @@ def get_columns():
 	"""return columns"""
 	columns = [
 		_("Item") + ":Link/Item:150",
-		_("Description") + "::500",
-		_("Qty per BOM Line") + ":Float:100",
-		_("Required Qty") + ":Float:100",
-		_("In Stock Qty") + ":Float:100",
+		_("Description") + "::300",
+		_("BOM Qty") + ":Float:160",
+		_("Required Qty") + ":Float:120",
+		_("In Stock Qty") + ":Float:120",
 		_("Enough Parts to Build") + ":Float:200",
 	]
 
@@ -59,13 +59,14 @@ def get_bom_stock(filters):
 				bom_item.item_code,
 				bom_item.description ,
 				bom_item.{qty_field},
-				bom_item.{qty_field} * {qty_to_produce},
+				bom_item.{qty_field} * {qty_to_produce} / bom.quantity,
 				sum(ledger.actual_qty) as actual_qty,
-				sum(FLOOR(ledger.actual_qty / (bom_item.{qty_field} * {qty_to_produce})))
+				sum(FLOOR(ledger.actual_qty / (bom_item.{qty_field} * {qty_to_produce} / bom.quantity)))
 			FROM
-				{table} AS bom_item
+				`tabBOM` AS bom INNER JOIN {table} AS bom_item
+					ON bom.name = bom_item.parent
 				LEFT JOIN `tabBin` AS ledger
-				ON bom_item.item_code = ledger.item_code
+					ON bom_item.item_code = ledger.item_code
 				{conditions}
 			WHERE
 				bom_item.parent = '{bom}' and bom_item.parenttype='BOM'


### PR DESCRIPTION
**Issue**

Created BOM for Mixed Fruit Juice and added Quantity as 12
<img width="1197" alt="Screenshot 2020-04-23 at 1 40 27 AM" src="https://user-images.githubusercontent.com/8780500/80028901-89b5a380-8503-11ea-88a1-ead69a374aae.png">


In BOM Stock Report, required quantity is showing as per 1 quantity 
![image](https://user-images.githubusercontent.com/8780500/80028960-a356eb00-8503-11ea-89dd-836cacc3c9dc.png)


**After Fix**
![image](https://user-images.githubusercontent.com/8780500/80029051-caadb800-8503-11ea-89d6-7d4ea27d1467.png)

<img width="1179" alt="Screenshot 2020-04-22 at 11 09 10 PM" src="https://user-images.githubusercontent.com/8780500/80029085-da2d0100-8503-11ea-9df1-506319bbe16d.png">
