### PR TITLE
fix: cast nowdate string to datetime

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -453,7 +453,7 @@ class Asset(AccountsController):
 
 		if ((self.purchase_receipt \
 			or (self.purchase_invoice and frappe.db.get_value('Purchase Invoice', self.purchase_invoice, 'update_stock')))
-			and self.purchase_receipt_amount and self.available_for_use_date <= nowdate()):
+			and self.purchase_receipt_amount and getdate(self.available_for_use_date) <= nowdate()):
 			fixed_asset_account = get_asset_category_account('fixed_asset_account', asset=self.name,
 					asset_category = self.asset_category, company = self.company)
 


### PR DESCRIPTION
String to be converted to dateformat

To resolve the error message :
{'method_name': 'erpnext.assets.doctype.asset.asset.make_post_gl_entry', 
Traceback (most recent call last):
  File "/home/gsn/frappe-bench/apps/frappe/frappe/utils/background_jobs.py", line 99, in execute_job
    method(**kwargs)
  File "/home/gsn/frappe-bench/apps/erpnext/erpnext/assets/doctype/asset/asset.py", line 434, in make_post_gl_entry
    doc.make_gl_entries()
  File "/home/gsn/frappe-bench/apps/erpnext/erpnext/assets/doctype/asset/asset.py", line 361, in make_gl_entries
    and self.purchase_receipt_amount and self.available_for_use_date <= nowdate()):
TypeError: '<=' not supported between instances of 'datetime.date' and 'str'
