### PR TITLE
fix: Issues on qty trigger in Stock Entry Detail

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -312,10 +312,9 @@ frappe.ui.form.on('Stock Entry', {
 			callback: function(r) {
 				if (!r.exe && r.message){
 					frappe.model.set_value(cdt, cdn, "serial_no", r.message);
-
-					if (callback) {
-						callback();
-					}
+				}
+				if (callback) {
+					callback();
 				}
 			}
 		});
@@ -540,8 +539,9 @@ frappe.ui.form.on('Stock Entry', {
 
 frappe.ui.form.on('Stock Entry Detail', {
 	qty: function(frm, cdt, cdn) {
-		frm.events.set_basic_rate(frm, cdt, cdn);
- 		frm.events.set_serial_no(frm, cdt, cdn);
+		frm.events.set_serial_no(frm, cdt, cdn, () => {
+			frm.events.set_basic_rate(frm, cdt, cdn);
+		});
 	},
 
 	conversion_factor: function(frm, cdt, cdn) {

--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -511,9 +511,10 @@ frappe.ui.form.on('Stock Entry', {
 			item.amount = flt(item.basic_amount + flt(item.additional_cost),
 				precision("amount", item));
 
-			item.valuation_rate = flt(flt(item.basic_rate)
-				+ (flt(item.additional_cost) / flt(item.transfer_qty)),
-				precision("valuation_rate", item));
+			if (flt(item.transfer_qty)) {
+				item.valuation_rate = flt(flt(item.basic_rate) + (flt(item.additional_cost) / flt(item.transfer_qty)),
+					precision("valuation_rate", item));
+			}
 		}
 
 		refresh_field('items');
@@ -539,9 +540,8 @@ frappe.ui.form.on('Stock Entry', {
 
 frappe.ui.form.on('Stock Entry Detail', {
 	qty: function(frm, cdt, cdn) {
-		frm.events.set_serial_no(frm, cdt, cdn, () => {
-			frm.events.set_basic_rate(frm, cdt, cdn);
-		});
+		frm.events.set_basic_rate(frm, cdt, cdn);
+ 		frm.events.set_serial_no(frm, cdt, cdn);
 	},
 
 	conversion_factor: function(frm, cdt, cdn) {


### PR DESCRIPTION
**Issues and Fixes:**
1) On triggering Qty, Basic Amount and it's subsequent fields were not set. This is because `set_basic_rate` was within the `set_serial_no` callback. If no serial no was fetched nothing was set.
      <details><summary>GIF</summary>
     
      ![stock-entry-qty](https://user-images.githubusercontent.com/25857446/80113530-101fc300-85a0-11ea-8fe3-69db56a542a5.gif)
</details>

2)   _After fix:_
       <details><summary>GIF</summary>

       ![stock-entry-qty-fixed](https://user-images.githubusercontent.com/25857446/80113582-2037a280-85a0-11ea-8135-bbf167e21b8a.gif)
       </details>

3) Initially as Qty is 0, so is **Qty as per Stock UOM**. Qty as per Stock UOM is used to calculate valuation rate. Due to it's zero value, valuation rate was NaN
![Screenshot 2020-04-23 at 7 43 08 PM](https://user-images.githubusercontent.com/25857446/80114374-1f534080-85a1-11ea-84ff-a943a81057e6.png)

4) _After fix_
![Screenshot 2020-04-23 at 8 12 26 PM](https://user-images.githubusercontent.com/25857446/80114405-28441200-85a1-11ea-8612-6fb34d188405.png)
