### PR TITLE
feat(accounting): show actual quantity for warehouse in sales invoice

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -32,6 +32,7 @@ erpnext.accounts.SalesInvoiceController = erpnext.selling.SellingController.exte
 			me.frm.script_manager.trigger("is_pos");
 			me.frm.refresh_fields();
 		}
+		erpnext.queries.setup_warehouse_query(this.frm);
 	},
 
 	refresh: function(doc, dt, dn) {


### PR DESCRIPTION
**Problem:**

- It doesn't display actual quantity for warehouse in Sales Invoice as it does for Sales Order:

![Screenshot from 2020-04-23 22-48-34](https://user-images.githubusercontent.com/13060550/80133294-a4971f00-85ba-11ea-956f-1c3942018432.png)

**Change in action:**

![Screenshot from 2020-04-23 22-51-36](https://user-images.githubusercontent.com/13060550/80133304-a7920f80-85ba-11ea-8da3-48e42034569a.png)
