### PR TITLE
fix: rate gets overwritten when pricing rule is set

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -237,6 +237,7 @@ def get_pricing_rule_for_item(args, price_list_rate=0, doc=None, for_validate=Fa
 			if pricing_rule.mixed_conditions or pricing_rule.apply_rule_on_other:
 				item_details.update({
 					'apply_rule_on_other_items': json.dumps(pricing_rule.apply_rule_on_other_items),
+					'price_or_product_discount': pricing_rule.price_or_product_discount,
 					'apply_rule_on': (frappe.scrub(pricing_rule.apply_rule_on_other)
 						if pricing_rule.apply_rule_on_other else frappe.scrub(pricing_rule.get('apply_on')))
 				})

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1407,12 +1407,12 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 
 		for(var k in args) {
 			let data = args[k];
-
+			debugger;
 			if (data && data.apply_rule_on_other_items) {
 				me.frm.doc.items.forEach(d => {
 					if (in_list(data.apply_rule_on_other_items, d[data.apply_rule_on])) {
 						for(var k in data) {
-							if (in_list(fields, k) && data[k]) {
+							if (in_list(fields, k) && data[k] && (data.price_or_product_discount === 'price' || k === 'pricing_rules')) {
 								frappe.model.set_value(d.doctype, d.name, k, data[k]);
 							}
 						}

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1407,7 +1407,7 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 
 		for(var k in args) {
 			let data = args[k];
-			debugger;
+
 			if (data && data.apply_rule_on_other_items) {
 				me.frm.doc.items.forEach(d => {
 					if (in_list(data.apply_rule_on_other_items, d[data.apply_rule_on])) {


### PR DESCRIPTION
### Problem: 

Promotional scheme configured for below case.

Case : Buy any of these 3 items and get additional coke free.
Coke
Aloo Tiki Burger
Veg Burger

min qty 3 to max qty 5 - > 1 Coke free
10+ qty - > 3 coke free

-------------------------
Please follow the exact steps below to reproduce the bug

Attached is the gif explaining the scenario.
Step 1 : Go to Sales Invoice.
Step 2 : Add Aloo Tiki Burger - 1 qty
Step 3 : Add Veg Burger - 3 qty , this will fetch free item coke. fine till now
Step 4: Add new Row , Select Coke , **the rate of all items will change to 20.0**