### PR TITLE
fix: make target warehouse field mandatory while saving the work order

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -346,6 +346,7 @@ class ProductionPlan(Document):
 		if not wo.fg_warehouse:
 			wo.fg_warehouse = warehouse.get('fg_warehouse')
 		try:
+			wo.flags.ignore_mandatory = True
 			wo.insert()
 			return wo.name
 		except OverProductionError:

--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -313,7 +313,7 @@ frappe.ui.form.on("Work Order", {
 				"Work in Progress": "progress-bar-warning",
 				"Completed": "progress-bar-success"
 			};
-	
+
 			let bars = [];
 			let message = '';
 			let title = '';
@@ -404,7 +404,6 @@ frappe.ui.form.on("Work Order", {
 	},
 
 	before_submit: function(frm) {
-		frm.toggle_reqd(["fg_warehouse", "wip_warehouse"], true);
 		frm.fields_dict.required_items.grid.toggle_reqd("source_warehouse", true);
 		frm.toggle_reqd("transfer_material_against",
 			frm.doc.operations && frm.doc.operations.length > 0);

--- a/erpnext/manufacturing/doctype/work_order/work_order.json
+++ b/erpnext/manufacturing/doctype/work_order/work_order.json
@@ -231,6 +231,7 @@
    "fieldname": "wip_warehouse",
    "fieldtype": "Link",
    "label": "Work-in-Progress Warehouse",
+   "mandatory_depends_on": "eval:!doc.skip_transfer || doc.from_wip_warehouse",
    "options": "Warehouse"
   },
   {
@@ -238,7 +239,8 @@
    "fieldname": "fg_warehouse",
    "fieldtype": "Link",
    "label": "Target Warehouse",
-   "options": "Warehouse"
+   "options": "Warehouse",
+   "reqd": 1
   },
   {
    "fieldname": "column_break_12",
@@ -481,7 +483,7 @@
  "image_field": "image",
  "is_submittable": 1,
  "links": [],
- "modified": "2020-01-31 12:46:23.636033",
+ "modified": "2020-04-24 19:32:43.323054",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Work Order",


### PR DESCRIPTION
**Issue**
While creating Work order, the field target warehouse is not marked mandatory, later when you try to submit the work order, error as missing field pops-up.

**Fixed**

![image](https://user-images.githubusercontent.com/8780500/80244911-67e52980-8687-11ea-9138-361cc6346dc7.png)
