### PR TITLE
fix: work order creation message against material request

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -299,6 +299,7 @@ frappe.ui.form.on('Material Request', {
 			args: {
 				"material_request": frm.doc.name
 			},
+			freeze: true,
 			callback: function(r) {
 				if(r.message.length) {
 					frm.reload_doc();

--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -8,7 +8,7 @@ from __future__ import unicode_literals
 import frappe
 import json
 
-from frappe.utils import cstr, flt, getdate, new_line_sep, nowdate, add_days
+from frappe.utils import cstr, flt, getdate, new_line_sep, nowdate, add_days, get_link_to_form
 from frappe import msgprint, _
 from frappe.model.mapper import get_mapped_doc
 from erpnext.stock.stock_balance import update_bin_qty, get_indented_qty
@@ -522,15 +522,22 @@ def raise_work_orders(material_request):
 
 				work_orders.append(wo_order.name)
 			else:
-				errors.append(_("Row {0}: Bill of Materials not found for the Item {1}").format(d.idx, d.item_code))
+				errors.append(_("Row {0}: Bill of Materials not found for the Item {1}")
+					.format(d.idx, get_link_to_form("Item", d.item_code)))
 
 	if work_orders:
-		message = ["""<a href="#Form/Work Order/%s" target="_blank">%s</a>""" % \
-			(p, p) for p in work_orders]
-		msgprint(_("The following Work Orders were created:") + '\n' + new_line_sep(message))
+		work_orders_list = [get_link_to_form("Work Order", d) for d in work_orders]
+
+		if len(work_orders) > 1:
+			msgprint(_("The following {0} were created: {1}")
+				.format(frappe.bold(_("Work Orders")), '<br>' + ', '.join(work_orders_list)))
+		else:
+			msgprint(_("The {0} {1} created sucessfully")
+				.format(frappe.bold(_("Work Order")), work_orders_list[0]))
 
 	if errors:
-		frappe.throw(_("Work Order cannot be created for following reason:") + '\n' + new_line_sep(errors))
+		frappe.throw(_("Work Order cannot be created for following reason: <br> {0}")
+			.format(new_line_sep(errors)))
 
 	return work_orders
 


### PR DESCRIPTION
## **Issue**
Message that is displayed when One Work Order is created: "Work orders were created" (plural) even if single WO was created.
![image](https://user-images.githubusercontent.com/8780500/80279200-97dd0d00-8719-11ea-9624-86497f312738.png)

## **After Fix**
**Singular**
![image](https://user-images.githubusercontent.com/8780500/80281149-c1506580-8726-11ea-8b68-157a6090bee2.png)


**Plural**

![image](https://user-images.githubusercontent.com/8780500/80281159-dd540700-8726-11ea-8c9a-8b00c5b1f4dd.png)
