### PR TITLE
fix: Set barcode field empty only if it has value

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -288,7 +288,7 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 		this.setup_sms();
 		this.setup_quality_inspection();
 		let scan_barcode_field = this.frm.get_field('scan_barcode');
-		if (scan_barcode_field) {
+		if (scan_barcode_field && scan_barcode_field.get_value()) {
 			scan_barcode_field.set_value("");
 			scan_barcode_field.set_new_description("");
 


### PR DESCRIPTION
- Set barcode field empty only if it has value to avoid unnecessary form dirty trigger

**Issue:** Form was getting dirty even though the user has not changed any value.

![unnecessary_not_saved](https://user-images.githubusercontent.com/13928957/80313289-a275d000-8807-11ea-8f0d-286b6753dad0.gif)

**After fix:**
![unnecessary_not_saved_fix](https://user-images.githubusercontent.com/13928957/80313341-026c7680-8808-11ea-9804-53669715e83c.gif)
