### PR TITLE
fix(Desk Page): Number of Open Leads not visible on Shortcut Card

### DIFF
--- a/erpnext/crm/desk_page/crm/crm.json
+++ b/erpnext/crm/desk_page/crm/crm.json
@@ -33,7 +33,7 @@
  "idx": 0,
  "is_standard": 1,
  "label": "CRM",
- "modified": "2020-04-01 11:28:51.219999",
+ "modified": "2020-04-26 22:31:15.865799",
  "modified_by": "Administrator",
  "module": "CRM",
  "name": "CRM",
@@ -42,7 +42,7 @@
  "pin_to_top": 0,
  "shortcuts": [
   {
-   "format": "Open",
+   "format": "{} Open",
    "label": "Lead",
    "link_to": "Lead",
    "stats_filter": "{\"status\":\"Open\"}",

--- a/erpnext/selling/desk_page/retail/retail.json
+++ b/erpnext/selling/desk_page/retail/retail.json
@@ -17,7 +17,7 @@
  "idx": 0,
  "is_standard": 1,
  "label": "Retail",
- "modified": "2020-04-01 11:28:50.966145",
+ "modified": "2020-04-26 22:42:39.346750",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Retail",


### PR DESCRIPTION
Missing "Open" lead count on the Lead shortcut card on the CRM Desk Page

**Before:**

![lead-count-missing](https://user-images.githubusercontent.com/24353136/80316038-0bb20f00-8819-11ea-9f91-56ef993024ea.png)

**After:**

![lead-after-fix](https://user-images.githubusercontent.com/24353136/80315957-97776b80-8818-11ea-9629-326ff7eb8d79.png)