### PR TITLE
fix: patch to delete appointment reminder scheduler job with wrong path

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -661,3 +661,4 @@ erpnext.patches.v12_0.set_updated_purpose_in_pick_list
 erpnext.patches.v12_0.repost_stock_ledger_entries_for_target_warehouse
 erpnext.patches.v12_0.update_end_date_and_status_in_email_campaign
 erpnext.patches.v13_0.move_tax_slabs_from_payroll_period_to_income_tax_slab #123
+erpnext.patches.v12_0.delete_appointment_reminder_scheduler_entry

--- a/erpnext/patches/v12_0/delete_appointment_reminder_scheduler_entry.py
+++ b/erpnext/patches/v12_0/delete_appointment_reminder_scheduler_entry.py
@@ -1,0 +1,4 @@
+import frappe
+
+def execute():
+    frappe.delete_doc_if_exists('Scheduled Job Type', 'patient_appointment.send_appointment_reminder')


### PR DESCRIPTION
Patch added to delete the erroneous scheduler job added earlier

Update error reported on [discuss](https://discuss.erpnext.com/t/error-while-update-1062-duplicate-entry-patient-appointment-send-appointment-reminder-for-key-primary/60830)