### PR TITLE
fix: name 'patient' is not defined

### DIFF
--- a/erpnext/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/erpnext/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -352,7 +352,7 @@ def send_message(doc, message):
 
 		# jinja to string convertion happens here
 		message = frappe.render_template(message, context)
-		number = [patient.mobile]
+		number = [patient_mobile]
 		send_sms(number, message)
 
 


### PR DESCRIPTION
possible escape while refactoring, fixed in develop added here.

Reported via -
https://discuss.erpnext.com/t/healthcare-outpatient-sms-alert-error/60812
