### PR TITLE
fix: add Scheduler Event for sending appointment reminders in v12

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -268,7 +268,8 @@ doc_events = {
 
 scheduler_events = {
 	"all": [
-		"erpnext.projects.doctype.project.project.project_status_update_reminder"
+		"erpnext.projects.doctype.project.project.project_status_update_reminder",
+		"erpnext.healthcare.doctype.patient_appointment.patient_appointment.set_appointment_reminder"
 	],
 	"hourly": [
 		'erpnext.hr.doctype.daily_work_summary_group.daily_work_summary_group.trigger_emails',


### PR DESCRIPTION
Added Scheduler Event for Patient Appointment Reminders in v12. This had been fixed in the healthcare refactored PR for develop branch.