### PR TITLE
fix: E-Way bill error message

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/regional/india.js
+++ b/erpnext/accounts/doctype/sales_invoice/regional/india.js
@@ -26,16 +26,24 @@ frappe.ui.form.on("Sales Invoice", {
 			&& !frm.doc.is_return && !frm.doc.ewaybill) {
 
 			frm.add_custom_button('E-Way Bill JSON', () => {
-				var w = window.open(
-					frappe.urllib.get_full_url(
-						"/api/method/erpnext.regional.india.utils.generate_ewb_json?"
-						+ "dt=" + encodeURIComponent(frm.doc.doctype)
-						+ "&dn=" + encodeURIComponent(frm.doc.name)
-					)
-				);
-				if (!w) {
-					frappe.msgprint(__("Please enable pop-ups")); return;
-				}
+				frappe.call({
+					method: 'erpnext.regional.india.utils.generate_ewb_json',
+					args: {
+						'dt': frm.doc.doctype,
+						'dn': [frm.doc.name]
+					},
+					callback: function(r) {
+						if (r.message) {
+							const args = {
+								cmd: 'erpnext.regional.india.utils.download_ewb_json',
+								data: r.message,
+								docname: frm.doc.name
+							};
+							open_url_post(frappe.request.url, args);
+						}
+					}
+				});
+
 			}, __("Create"));
 		}
 	}

--- a/erpnext/accounts/doctype/sales_invoice/regional/india_list.js
+++ b/erpnext/accounts/doctype/sales_invoice/regional/india_list.js
@@ -16,17 +16,23 @@ frappe.listview_settings['Sales Invoice'].onload = function (doclist) {
 			}
 		}
 
-		var w = window.open(
-			frappe.urllib.get_full_url(
-				"/api/method/erpnext.regional.india.utils.generate_ewb_json?"
-				+ "dt=" + encodeURIComponent(doclist.doctype)
-				+ "&dn=" + encodeURIComponent(docnames)
-			)
-		);
-		if (!w) {
-			frappe.msgprint(__("Please enable pop-ups")); return;
-		}
-
+		frappe.call({
+			method: 'erpnext.regional.india.utils.generate_ewb_json',
+			args: {
+				'dt': doclist.doctype,
+				'dn': docnames
+			},
+			callback: function(r) {
+				if (r.message) {
+					const args = {
+						cmd: 'erpnext.regional.india.utils.download_ewb_json',
+						data: r.message,
+						docname: docnames
+					};
+					open_url_post(frappe.request.url, args);
+				}
+			}
+		});
 	};
 
 	doclist.page.add_actions_menu_item(__('Generate E-Way Bill JSON'), action, false);

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -1892,7 +1892,7 @@ class TestSalesInvoice(unittest.TestCase):
 
 		si.submit()
 
-		data = get_ewb_data("Sales Invoice", si.name)
+		data = get_ewb_data("Sales Invoice", [si.name])
 
 		self.assertEqual(data['version'], '1.0.1118')
 		self.assertEqual(data['billLists'][0]['fromGstin'], '27AAECE4835E1ZR')

--- a/erpnext/regional/india/utils.py
+++ b/erpnext/regional/india/utils.py
@@ -469,7 +469,7 @@ def download_ewb_json():
 	else:
 		doc_name = data['docname']
 
-	frappe.local.response.filename = '{0}_e-WayBill_Data_{1}.json'.format(data['docname'], frappe.utils.random_string(5))
+	frappe.local.response.filename = '{0}_e-WayBill_Data_{1}.json'.format(doc_name, frappe.utils.random_string(5))
 
 @frappe.whitelist()
 def get_gstins_for_company(company):

--- a/erpnext/regional/india/utils.py
+++ b/erpnext/regional/india/utils.py
@@ -372,7 +372,6 @@ def calculate_hra_exemption_for_period(doc):
 		return exemptions
 
 def get_ewb_data(dt, dn):
-	dn = dn.split(',')
 
 	ewaybills = []
 	for doc_name in dn:
@@ -453,18 +452,24 @@ def get_ewb_data(dt, dn):
 
 @frappe.whitelist()
 def generate_ewb_json(dt, dn):
+	dn = json.loads(dn)
+	return get_ewb_data(dt, dn)
 
-	data = get_ewb_data(dt, dn)
+@frappe.whitelist()
+def download_ewb_json():
+	data = frappe._dict(frappe.local.form_dict)
 
-	frappe.local.response.filecontent = json.dumps(data, indent=4, sort_keys=True)
+	frappe.local.response.filecontent = json.dumps(data['data'], indent=4, sort_keys=True)
 	frappe.local.response.type = 'download'
 
-	if len(data['billLists']) > 1:
+	billList = json.loads(data['data'])['billLists']
+
+	if len(billList) > 1:
 		doc_name = 'Bulk'
 	else:
-		doc_name = dn
+		doc_name = data['docname']
 
-	frappe.local.response.filename = '{0}_e-WayBill_Data_{1}.json'.format(doc_name, frappe.utils.random_string(5))
+	frappe.local.response.filename = '{0}_e-WayBill_Data_{1}.json'.format(data['docname'], frappe.utils.random_string(5))
 
 @frappe.whitelist()
 def get_gstins_for_company(company):

--- a/erpnext/stock/doctype/delivery_note/regional/india.js
+++ b/erpnext/stock/doctype/delivery_note/regional/india.js
@@ -3,21 +3,28 @@
 erpnext.setup_auto_gst_taxation('Delivery Note');
 
 frappe.ui.form.on('Delivery Note', {
-    refresh: function(frm) {
-        if(frm.doc.docstatus == 1 && !frm.is_dirty() && !frm.doc.ewaybill) {
+	refresh: function(frm) {
+		if(frm.doc.docstatus == 1 && !frm.is_dirty() && !frm.doc.ewaybill) {
 			frm.add_custom_button('E-Way Bill JSON', () => {
-				var w = window.open(
-					frappe.urllib.get_full_url(
-						"/api/method/erpnext.regional.india.utils.generate_ewb_json?"
-						+ "dt=" + encodeURIComponent(frm.doc.doctype)
-						+ "&dn=" + encodeURIComponent(frm.doc.name)
-					)
-				);
-				if (!w) {
-					frappe.msgprint(__("Please enable pop-ups")); return;
-				}
+				frappe.call({
+					method: 'erpnext.regional.india.utils.generate_ewb_json',
+					args: {
+						'dt': frm.doc.doctype,
+						'dn': [frm.doc.name]
+					},
+					callback: function(r) {
+						if (r.message) {
+							const args = {
+								cmd: 'erpnext.regional.india.utils.download_ewb_json',
+								data: r.message,
+								docname: frm.doc.name
+							};
+							open_url_post(frappe.request.url, args);
+						}
+					}
+				});
 			}, __("Create"));
 		}
-    }
+	}
 })
 


### PR DESCRIPTION
Currently if there is any error in data while generating E-Way bill entire traceback is shown instead of Validation message

Before:
![image](https://user-images.githubusercontent.com/42651287/80337259-13080580-8877-11ea-9618-25f2ad096df0.png)

After:
![image](https://user-images.githubusercontent.com/42651287/80337347-3e8af000-8877-11ea-84ce-d5df799d1c91.png)
