### PR TITLE
fix: show date in the message for already marked attendance

### DIFF
--- a/erpnext/hr/doctype/attendance/attendance.py
+++ b/erpnext/hr/doctype/attendance/attendance.py
@@ -35,13 +35,14 @@ class Attendance(Document):
 				and docstatus != 2
 		""", (self.employee, getdate(self.attendance_date), self.name))
 		if res:
-			frappe.throw(_("Attendance for employee {0} is already marked").format(self.employee))
+			frappe.throw(_("Attendance for employee {0} is already marked for the date {1}").format(
+				frappe.bold(self.employee), frappe.bold(self.attendance_date)))
 
 	def check_leave_record(self):
 		leave_record = frappe.db.sql("""
 			select leave_type, half_day, half_day_date
 			from `tabLeave Application`
-			where employee = %s 
+			where employee = %s
 				and %s between from_date and to_date
 				and status = 'Approved'
 				and docstatus = 1


### PR DESCRIPTION
When marking Attendance from Attendance Request DocType if attendance has already been marked for some date it shows this message and the document is not submitted:

**Before:**

![attendance-mark](https://user-images.githubusercontent.com/24353136/80343924-5ddc4a00-8884-11ea-8273-6fd924ac18a4.png)

Since attendance is marked in bulk from this form, adding the exact attendance date would be feasible?

**After:**

![attendance-message](https://user-images.githubusercontent.com/24353136/80348405-62583100-888b-11ea-9beb-d235d21ba609.png)

