### PR TITLE
fix: only check for payment_account on bank entry

### DIFF
--- a/erpnext/hr/doctype/payroll_entry/payroll_entry.js
+++ b/erpnext/hr/doctype/payroll_entry/payroll_entry.js
@@ -263,7 +263,7 @@ let make_bank_entry = function (frm) {
 		});
 	} else {
 		frappe.msgprint(__("Payment Account is mandatory"));
-		cur_frm.scroll_to_field('payment_account');
+		frm.scroll_to_field('payment_account');
 	}
 };
 

--- a/erpnext/hr/doctype/payroll_entry/payroll_entry.js
+++ b/erpnext/hr/doctype/payroll_entry/payroll_entry.js
@@ -249,7 +249,7 @@ const submit_salary_slip = function (frm) {
 
 let make_bank_entry = function (frm) {
 	var doc = frm.doc;
-	if (doc.company && doc.start_date && doc.end_date && doc.payment_account) {
+	if (doc.payment_account) {
 		return frappe.call({
 			doc: cur_frm.doc,
 			method: "make_payment_entry",
@@ -262,7 +262,8 @@ let make_bank_entry = function (frm) {
 			freeze_message: __("Creating Payment Entries......")
 		});
 	} else {
-		frappe.msgprint(__("Company, Payment Account, From Date and To Date is mandatory"));
+		frappe.msgprint(__("Payment Account is mandatory"));
+		cur_frm.scroll_to_field('payment_account');
 	}
 };
 


### PR DESCRIPTION
While clicking on Make Bank Entry, the system also checks for other mandatory fields which are already set (they become read-only).

![image](https://user-images.githubusercontent.com/50285544/80360822-891f6300-889d-11ea-8a9c-98aa8a8a4a70.png)

Since all the fields (company, start and end date are mandatory before form submission, there is no need to check for them again after submission.

