### PR TITLE
fix: change label of Global Defaults

### DIFF
--- a/erpnext/config/settings.py
+++ b/erpnext/config/settings.py
@@ -11,7 +11,7 @@ def get_data():
 				{
 					"type": "doctype",
 					"name": "Global Defaults",
-					"label": _("ERPNext Settings"),
+					"label": _("Global Defaults"),
 					"description": _("Set Default Values like Company, Currency, Current Fiscal Year, etc."),
 					"hide_count": True,
 					"settings": 1,


### PR DESCRIPTION
Fix:
Changed label of ERPNext Settings to Global Defaults.

![Screenshot 2020-04-27 at 8 01 15 PM](https://user-images.githubusercontent.com/50285544/80384003-f3e29580-88c1-11ea-9f66-3b51cc07d4f7.png)

ERPNext Settings open the Global Defaults Page

![Screenshot 2020-04-27 at 8 01 30 PM](https://user-images.githubusercontent.com/50285544/80384057-05c43880-88c2-11ea-930c-106f655f9b86.png)


