### PR TITLE
fix(stock): added link for customs tariff number

### DIFF
--- a/erpnext/config/stock.py
+++ b/erpnext/config/stock.py
@@ -173,6 +173,10 @@ def get_data():
 				},
 				{
 					"type": "doctype",
+					"name": "Customs Tariff Number",
+				},
+				{
+					"type": "doctype",
 					"name": "Item Variant Settings",
 				},
 			]


### PR DESCRIPTION
added a link in the stock module's dashboard for Customs Tariff Number under the Items and Pricing section

