### PR TITLE
fix(stock): add/remove links in dashboard

### DIFF
--- a/erpnext/config/stock.py
+++ b/erpnext/config/stock.py
@@ -173,7 +173,7 @@ def get_data():
 				},
 				{
 					"type": "doctype",
-					"name": "Item Variant Settings",
+					"name": "Customs Tariff Number",
 				},
 			]
 		},


### PR DESCRIPTION
Under the Items and Pricing section in Stock module's dashboard:
Added: Customs Tariff Number
Removed: Item Variant Settings (its already under Settings section in the same dashboard)
