### PR TITLE
fix: Default column width in Gross profit report

### DIFF
--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -55,27 +55,27 @@ def get_columns(group_wise_columns, filters):
 	columns = []
 	column_map = frappe._dict({
 		"parent": _("Sales Invoice") + ":Link/Sales Invoice:120",
-		"posting_date": _("Posting Date") + ":Date",
-		"posting_time": _("Posting Time"),
-		"item_code": _("Item Code") + ":Link/Item",
-		"item_name": _("Item Name"),
-		"item_group": _("Item Group") + ":Link/Item Group",
-		"brand": _("Brand"),
-		"description": _("Description"),
-		"warehouse": _("Warehouse") + ":Link/Warehouse",
-		"qty": _("Qty") + ":Float",
-		"base_rate": _("Avg. Selling Rate") + ":Currency/currency",
-		"buying_rate": _("Valuation Rate") + ":Currency/currency",
-		"base_amount": _("Selling Amount") + ":Currency/currency",
-		"buying_amount": _("Buying Amount") + ":Currency/currency",
-		"gross_profit": _("Gross Profit") + ":Currency/currency",
-		"gross_profit_percent": _("Gross Profit %") + ":Percent",
-		"project": _("Project") + ":Link/Project",
+		"posting_date": _("Posting Date") + ":Date:100",
+		"posting_time": _("Posting Time") + ":Data:100",
+		"item_code": _("Item Code") + ":Link/Item:100",
+		"item_name": _("Item Name") + ":Data:100",
+		"item_group": _("Item Group") + ":Link/Item Group:100",
+		"brand": _("Brand") + ":Link/Brand:100",
+		"description": _("Description") +":Data:100",
+		"warehouse": _("Warehouse") + ":Link/Warehouse:100",
+		"qty": _("Qty") + ":Float:80",
+		"base_rate": _("Avg. Selling Rate") + ":Currency/currency:100",
+		"buying_rate": _("Valuation Rate") + ":Currency/currency:100",
+		"base_amount": _("Selling Amount") + ":Currency/currency:100",
+		"buying_amount": _("Buying Amount") + ":Currency/currency:100",
+		"gross_profit": _("Gross Profit") + ":Currency/currency:100",
+		"gross_profit_percent": _("Gross Profit %") + ":Percent:100",
+		"project": _("Project") + ":Link/Project:100",
 		"sales_person": _("Sales person"),
-		"allocated_amount": _("Allocated Amount") + ":Currency/currency",
-		"customer": _("Customer") + ":Link/Customer",
-		"customer_group": _("Customer Group") + ":Link/Customer Group",
-		"territory": _("Territory") + ":Link/Territory"
+		"allocated_amount": _("Allocated Amount") + ":Currency/currency:100",
+		"customer": _("Customer") + ":Link/Customer:100",
+		"customer_group": _("Customer Group") + ":Link/Customer Group:100",
+		"territory": _("Territory") + ":Link/Territory:100"
 	})
 
 	for col in group_wise_columns.get(scrub(filters.group_by)):
@@ -85,7 +85,8 @@ def get_columns(group_wise_columns, filters):
 		"fieldname": "currency",
 		"label" : _("Currency"),
 		"fieldtype": "Link",
-		"options": "Currency"
+		"options": "Currency",
+		"hidden": 1
 	})
 
 	return columns
@@ -277,7 +278,7 @@ class GrossProfitGenerator(object):
 			from `tabPurchase Invoice Item` a
 			where a.item_code = %s and a.docstatus=1
 			and modified <= %s
-			order by a.modified desc limit 1""", (item_code,self.filters.to_date))
+			order by a.modified desc limit 1""", (item_code, self.filters.to_date))
 		else:
 			last_purchase_rate = frappe.db.sql("""
 			select (a.base_rate / a.conversion_factor)


### PR DESCRIPTION
Before:
<img width="1184" alt="Screenshot 2020-04-27 at 2 08 32 PM" src="https://user-images.githubusercontent.com/42651287/80452393-cfc79880-8943-11ea-8899-53317f585b96.png">

After:
![image](https://user-images.githubusercontent.com/42651287/80452550-23d27d00-8944-11ea-86f4-ea808f9c5691.png)
