### PR TITLE
fix: update lead if contact details are changed (v12)

### DIFF
--- a/erpnext/crm/utils.py
+++ b/erpnext/crm/utils.py
@@ -1,0 +1,24 @@
+import frappe
+
+
+def update_lead_phone_numbers(contact, method):
+	if contact.phone_nos:
+		contact_lead = contact.get_link_for("Lead")
+		if contact_lead:
+			phone = mobile_no = contact.phone_nos[0].phone
+
+			if len(contact.phone_nos) > 1:
+				# get the default phone number
+				primary_phones = [phone.phone for phone in contact.phone_nos if phone.is_primary_phone]
+				if primary_phones:
+					phone = primary_phones[0]
+
+				# get the default mobile number
+				primary_mobile_nos = [phone.phone for phone in contact.phone_nos if phone.is_primary_mobile_no]
+				if primary_mobile_nos:
+					mobile_no = primary_mobile_nos[0]
+
+			lead = frappe.get_doc("Lead", contact_lead)
+			lead.phone = phone
+			lead.mobile_no = mobile_no
+			lead.save()

--- a/erpnext/crm/utils.py
+++ b/erpnext/crm/utils.py
@@ -9,12 +9,12 @@ def update_lead_phone_numbers(contact, method):
 
 			if len(contact.phone_nos) > 1:
 				# get the default phone number
-				primary_phones = [phone.phone for phone in contact.phone_nos if phone.is_primary_phone]
+				primary_phones = [phone_doc.phone for phone_doc in contact.phone_nos if phone_doc.is_primary_phone]
 				if primary_phones:
 					phone = primary_phones[0]
 
 				# get the default mobile number
-				primary_mobile_nos = [phone.phone for phone in contact.phone_nos if phone.is_primary_mobile_no]
+				primary_mobile_nos = [phone_doc.phone for phone_doc in contact.phone_nos if phone_doc.is_primary_mobile_no]
 				if primary_mobile_nos:
 					mobile_no = primary_mobile_nos[0]
 

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -256,7 +256,8 @@ doc_events = {
 	},
 	"Contact": {
 		"on_trash": "erpnext.support.doctype.issue.issue.update_issue",
-		"after_insert": "erpnext.communication.doctype.call_log.call_log.set_caller_information"
+		"after_insert": "erpnext.communication.doctype.call_log.call_log.set_caller_information",
+		"validate": "erpnext.crm.utils.update_lead_phone_numbers"
 	},
 	"Lead": {
 		"after_insert": "erpnext.communication.doctype.call_log.call_log.set_caller_information"


### PR DESCRIPTION
**Problem:**

In the Lead DocType, we have fields to store its contact's phone information. After they're set, they become hidden, which can lead to outdated Lead reports.

**Solution:**

On saving a Contact linked with a Lead, update the info from Contact into the Lead.