### PR TITLE
fix: Removed Finished Product and Finished Qty columns from Stock Ledger Report

### DIFF
--- a/erpnext/stock/report/stock_ledger/stock_ledger.py
+++ b/erpnext/stock/report/stock_ledger/stock_ledger.py
@@ -46,19 +46,6 @@ def execute(filters=None):
 			"out_qty": min(sle.actual_qty, 0)
 		})
 
-		# get the name of the item that was produced using this item
-		if sle.voucher_type == "Stock Entry":
-			purpose, work_order, fg_completed_qty = frappe.db.get_value(sle.voucher_type, sle.voucher_no, ["purpose", "work_order", "fg_completed_qty"])
-
-			if purpose == "Manufacture" and work_order:
-				finished_product = frappe.db.get_value("Work Order", work_order, "item_name")
-				finished_qty = fg_completed_qty
-
-				sle.update({
-					"finished_product": finished_product,
-					"finished_qty": finished_qty,
-				})
-
 		data.append(sle)
 
 		if include_uom:
@@ -77,8 +64,6 @@ def get_columns():
 		{"label": _("In Qty"), "fieldname": "in_qty", "fieldtype": "Float", "width": 80, "convertible": "qty"},
 		{"label": _("Out Qty"), "fieldname": "out_qty", "fieldtype": "Float", "width": 80, "convertible": "qty"},
 		{"label": _("Balance Qty"), "fieldname": "qty_after_transaction", "fieldtype": "Float", "width": 100, "convertible": "qty"},
-		{"label": _("Finished Product"), "fieldname": "finished_product", "width": 100},
-		{"label": _("Finished Qty"), "fieldname": "finished_qty", "fieldtype": "Float", "width": 100, "convertible": "qty"},
 		{"label": _("Voucher #"), "fieldname": "voucher_no", "fieldtype": "Dynamic Link", "options": "voucher_type", "width": 150},
 		{"label": _("Warehouse"), "fieldname": "warehouse", "fieldtype": "Link", "options": "Warehouse", "width": 150},
 		{"label": _("Item Group"), "fieldname": "item_group", "fieldtype": "Link", "options": "Item Group", "width": 100},


### PR DESCRIPTION
Columns **Finished Product** and **Finished Qty** were introduced via https://github.com/frappe/erpnext/pull/19708. These columns would serve better in a work order related report (WIP).

They only fetch values if :
- Voucher type in the row is Stock entry
- Stock Entry is of type Manufacture
- Stock Entry has work order against it.

In most cases they will be empty.

**Before:**
![Screenshot 2020-04-28 at 9 25 50 PM](https://user-images.githubusercontent.com/25857446/80509934-aafd1080-8997-11ea-8b5d-36055312ebbe.png)

**After:**
![Screenshot 2020-04-28 at 9 26 58 PM](https://user-images.githubusercontent.com/25857446/80509949-afc1c480-8997-11ea-9813-2addc3144715.png)
