### PR TITLE
feat(regional): limit field legth in DATEV Settings.

### DIFF
--- a/erpnext/regional/doctype/datev_settings/datev_settings.json
+++ b/erpnext/regional/doctype/datev_settings/datev_settings.json
@@ -28,7 +28,8 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Client ID",
-   "reqd": 1
+   "reqd": 1,
+   "length": 5
   },
   {
    "fieldname": "consultant",
@@ -42,7 +43,8 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Consultant ID",
-   "reqd": 1
+   "reqd": 1,
+   "length": 7
   },
   {
    "fieldname": "column_break_2",


### PR DESCRIPTION
- Consultant ID can be any value between 1001 and 9999999, so it's max. length is 7.
- Client ID can be any value between 1 and 99999, so it's max length is 5.