### PR TITLE
feat: add Bank Account to dashboards

### DIFF
--- a/erpnext/buying/doctype/supplier/supplier_dashboard.py
+++ b/erpnext/buying/doctype/supplier/supplier_dashboard.py
@@ -23,11 +23,7 @@ def get_data():
 			},
 			{
 				'label': _('Payments'),
-				'items': ['Payment Entry']
-			},
-			{
-				'label': _('Bank'),
-				'items': ['Bank Account']
+				'items': ['Payment Entry', 'Bank Account']
 			},
 			{
 				'label': _('Pricing'),

--- a/erpnext/education/doctype/student/student_dashboard.py
+++ b/erpnext/education/doctype/student/student_dashboard.py
@@ -6,6 +6,9 @@ def get_data():
 		'heatmap': True,
 		'heatmap_message': _('This is based on the attendance of this Student'),
 		'fieldname': 'student',
+		'non_standard_fieldnames': {
+			'Bank Account': 'party'
+		},
 		'transactions': [
 			{
 				'label': _('Admission'),
@@ -29,7 +32,7 @@ def get_data():
 			},
 			{
 				'label': _('Fee'),
-				'items': ['Fees']
+				'items': ['Fees', 'Bank Account']
 			}
 		]
 	}

--- a/erpnext/hr/doctype/employee/employee_dashboard.py
+++ b/erpnext/hr/doctype/employee/employee_dashboard.py
@@ -6,6 +6,9 @@ def get_data():
 		'heatmap': True,
 		'heatmap_message': _('This is based on the attendance of this Employee'),
 		'fieldname': 'employee',
+		'non_standard_fieldnames': {
+			'Bank Account': 'party'
+		},
 		'transactions': [
 			{
 				'label': _('Leave and Attendance'),
@@ -33,7 +36,7 @@ def get_data():
 			},
 			{
 				'label': _('Payroll'),
-				'items': ['Salary Structure Assignment', 'Salary Slip', 'Additional Salary', 'Timesheet','Employee Incentive', 'Retention Bonus']
+				'items': ['Salary Structure Assignment', 'Salary Slip', 'Additional Salary', 'Timesheet','Employee Incentive', 'Retention Bonus', 'Bank Account']
 			},
 			{
 				'label': _('Training'),

--- a/erpnext/non_profit/doctype/member/member_dashboard.py
+++ b/erpnext/non_profit/doctype/member/member_dashboard.py
@@ -6,10 +6,17 @@ def get_data():
 		'heatmap': True,
 		'heatmap_message': _('Member Activity'),
 		'fieldname': 'member',
+		'non_standard_fieldnames': {
+			'Bank Account': 'party'
+		},
 		'transactions': [
 			{
 				'label': _('Membership Details'),
 				'items': ['Membership']
+			},
+			{
+				'label': _('Fee'),
+				'items': ['Bank Account']
 			}
 		]
 	}

--- a/erpnext/selling/doctype/customer/customer_dashboard.py
+++ b/erpnext/selling/doctype/customer/customer_dashboard.py
@@ -11,7 +11,8 @@ def get_data():
 		'non_standard_fieldnames': {
 			'Payment Entry': 'party',
 			'Quotation': 'party_name',
-			'Opportunity': 'party_name'
+			'Opportunity': 'party_name',
+			'Bank Account': 'party'
 		},
 		'dynamic_links': {
 			'party_name': ['Customer', 'quotation_to']
@@ -27,7 +28,7 @@ def get_data():
 			},
 			{
 				'label': _('Payments'),
-				'items': ['Payment Entry']
+				'items': ['Payment Entry', 'Bank Account']
 			},
 			{
 				'label': _('Support'),


### PR DESCRIPTION
### Current Situation

- In **Bank Account**, we can link to the related party, the "owner" of the account.
- In the parties we cannot see the related **Bank Account**.

### What?

This PR adds **Bank Account** entries to the dashboards of all parties available in **Bank Account**:

- Supplier (already existed)
- Customer
- Employee
- Student
- Member

### Why?

- Increase the visibility of **Bank Account**. 
- Make it comfortable to use in relation to external parties. 