### PR TITLE
fix: 'NoneType' object is not iterable

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -342,8 +342,14 @@ def get_basic_details(args, item, overwrite_warehouse=True):
 			out["manufacturer_part_no"] = None
 			out["manufacturer"] = None
 	else:
-		out["manufacturer"], out["manufacturer_part_no"] = frappe.get_value("Item", item.name,
-			["default_item_manufacturer", "default_manufacturer_part_no"] )
+		data = frappe.get_value("Item", item.name,
+			["default_item_manufacturer", "default_manufacturer_part_no"] , as_dict=1)
+
+		if data:
+			out.update({
+				"manufacturer": data.default_item_manufacturer,
+				"manufacturer_part_no": data.default_manufacturer_part_no
+			})
 
 	child_doctype = args.doctype + ' Item'
 	meta = frappe.get_meta(child_doctype)


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/frappe/frappe/desk/form/save.py", line 22, in savedocs
    doc.save()
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/frappe/frappe/model/document.py", line 273, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/frappe/frappe/model/document.py", line 296, in _save
    self.insert()
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/frappe/frappe/model/document.py", line 230, in insert
    self.run_before_save_methods()
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/frappe/frappe/model/document.py", line 893, in run_before_save_methods
    self.run_method("validate")
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/frappe/frappe/model/document.py", line 794, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/frappe/frappe/model/document.py", line 1064, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/frappe/frappe/model/document.py", line 1047, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/frappe/frappe/model/document.py", line 788, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/erpnext/erpnext/buying/doctype/purchase_order/purchase_order.py", line 43, in validate
    super(PurchaseOrder, self).validate()
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/erpnext/erpnext/controllers/buying_controller.py", line 38, in validate
    super(BuyingController, self).validate()
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/erpnext/erpnext/controllers/stock_controller.py", line 21, in validate
    super(StockController, self).validate()
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/erpnext/erpnext/controllers/accounts_controller.py", line 69, in validate
    self.set_missing_values(for_validate=True)
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/erpnext/erpnext/controllers/buying_controller.py", line 77, in set_missing_values
    self.set_missing_item_details(for_validate)
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/erpnext/erpnext/controllers/accounts_controller.py", line 279, in set_missing_item_details
    ret = get_item_details(args, self, for_validate=True, overwrite_warehouse=False)
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/erpnext/erpnext/stock/get_item_details.py", line 53, in get_item_details
    out = get_basic_details(args, item, overwrite_warehouse)
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/erpnext/erpnext/stock/get_item_details.py", line 344, in get_basic_details
    ["default_item_manufacturer", "default_manufacturer_part_no"] )
TypeError: 'NoneType' object is not iterable
```