### PR TITLE
fix: accounts payable shows advance amount of other company

### DIFF
--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -600,10 +600,12 @@ def get_party_shipping_address(doctype, name):
 	else:
 		return ''
 
-def get_partywise_advanced_payment_amount(party_type, posting_date = None):
+def get_partywise_advanced_payment_amount(party_type, posting_date = None, company=None):
 	cond = "1=1"
 	if posting_date:
 		cond = "posting_date <= '{0}'".format(posting_date)
+	if company:
+		cond += "and company = '{0}'".format(company)
 
 	data = frappe.db.sql(""" SELECT party, sum({0}) as amount
 		FROM `tabGL Entry`

--- a/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py
+++ b/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py
@@ -33,7 +33,7 @@ class AccountsReceivableSummary(ReceivablePayableReport):
 		self.get_party_total(args)
 
 		party_advance_amount = get_partywise_advanced_payment_amount(self.party_type,
-			self.filters.report_date) or {}
+			self.filters.report_date, self.filters.company) or {}
 
 		for party, party_dict in iteritems(self.party_total):
 			if party_dict.outstanding == 0:


### PR DESCRIPTION
Problem: 
If a supplier has advance amount in one company and also has transactions in other company then the accounts payable summary report shows advance amount in both company's report.