### PR TITLE
fix: handle exception if sending Appointment Confirmation message fails

### DIFF
--- a/erpnext/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/erpnext/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -325,7 +325,11 @@ def update_status(appointment_id, status):
 def send_confirmation_msg(doc):
 	if frappe.db.get_single_value('Healthcare Settings', 'send_appointment_confirmation'):
 		message = frappe.db.get_single_value('Healthcare Settings', 'appointment_confirmation_msg')
-		send_message(doc, message)
+		try:
+			send_message(doc, message)
+		except Exception:
+			frappe.log_error(frappe.get_traceback(), _('Appointment Confirmation Message Not Sent'))
+			frappe.msgprint(_('Appointment Confirmation Message Not Sent'), indicator='orange')
 
 
 @frappe.whitelist()


### PR DESCRIPTION
Frontport: https://github.com/frappe/erpnext/pull/21568

**Fix for:** https://discuss.erpnext.com/t/cannot-save-patient-appointment-when-confirmation-sms-fails/61054

Handle exception if sending Patient Appointment confirmation message fails:

![confirmation-not-sent](https://user-images.githubusercontent.com/24353136/80871918-452cc380-8ccc-11ea-84e0-6d677b595d23.png)

Create an error log for the same
![confirmation-msg-error-log](https://user-images.githubusercontent.com/24353136/80871915-42ca6980-8ccc-11ea-8f4a-52f38c27edc9.png)