### PR TITLE
fix(Healthcare): remove hardcoded UOM during Item creation for templates

### DIFF
--- a/erpnext/healthcare/doctype/clinical_procedure_template/clinical_procedure_template.py
+++ b/erpnext/healthcare/doctype/clinical_procedure_template/clinical_procedure_template.py
@@ -78,6 +78,8 @@ def create_item_from_template(doc):
 	if doc.is_billable:
 		disabled = 0
 
+	uom = frappe.db.exists('UOM', 'Unit') or frappe.db.get_single_value('Stock Settings', 'stock_uom')
+
 	#insert item
 	item =  frappe.get_doc({
 		'doctype': 'Item',
@@ -92,7 +94,7 @@ def create_item_from_template(doc):
 		'show_in_website': 0,
 		'is_pro_applicable': 0,
 		'disabled': disabled,
-		'stock_uom': 'Unit'
+		'stock_uom': uom
 	}).insert(ignore_permissions=True)
 
 	#insert item price


### PR DESCRIPTION
Back Port: https://github.com/frappe/erpnext/pull/21350

Issue: https://discuss.erpnext.com/t/cant-create-clinical-procedure-template/61145

The "Unit" UOM was hardcoded while creating Items for Templates in Healthcare. This created a problem if it is not present in the system and also in translation:

![image](https://user-images.githubusercontent.com/24353136/79835542-7c49cd80-83cc-11ea-8f1a-139d7646a030.png)

Now it checks if the "Unit" UOM is present, else picks up the default UOM set in Stock Settings
