### PR TITLE
fix(patch): Reload GSTR 3B report

### DIFF
--- a/erpnext/patches/v11_0/add_permissions_in_gst_settings.py
+++ b/erpnext/patches/v11_0/add_permissions_in_gst_settings.py
@@ -7,4 +7,5 @@ def execute():
 		return
 
 	frappe.reload_doc("regional", "doctype", "lower_deduction_certificate")
+	frappe.reload_doc("regional", "doctype", "gstr_3b_report")
 	add_permissions()


### PR DESCRIPTION
backport of https://github.com/frappe/erpnext/pull/21583
```
File "/home/frappe/frappe-bench/apps/erpnext/erpnext/patches/v11_0/add_permissions_in_gst_settings.py", line 9, in execute
    add_permissions()
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/regional/india/setup.py", line 81, in add_permissions
    add_permission(doctype, 'All', 0)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/permissions.py", line 494, in add_permission
    validate_permissions_for_doctype(doctype)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/doctype/doctype.py", line 988, in validate_permissions_for_doctype
    doctype = frappe.get_doc("DocType", doctype)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 753, in get_doc
    doc = frappe.model.document.get_doc(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 71, in get_doc
    return controller(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 106, in __init__
    self.load_from_db()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 149, in load_from_db
    frappe.throw(_("{0} {1} not found").format(_(self.doctype), self.name), frappe.DoesNotExistError)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 377, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red', is_minimizable=is_minimizable)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 356, in msgprint
    _raise_exception()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 316, in _raise_exception
    raise raise_exception(msg)
frappe.exceptions.DoesNotExistError: DocType GSTR 3B Report not found
```