### PR TITLE
fix(patch): reload Expense Claim doctype

### DIFF
--- a/erpnext/patches/v12_0/set_correct_status_for_expense_claim.py
+++ b/erpnext/patches/v12_0/set_correct_status_for_expense_claim.py
@@ -4,6 +4,9 @@
 import frappe
 
 def execute():
+
+    frappe.reload_doc("hr", "doctype", "expense_claim")
+    
     frappe.db.sql("""
         update `tabExpense Claim`
         set status = 'Paid'


### PR DESCRIPTION
```
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/patches/v12_0/set_correct_status_for_expense_claim.py", line 11, in execute
    """)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/database.py", line 171, in sql
    self._cursor.execute(query)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/pymysql/cursors.py", line 170, in execute
    result = self._query(query)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/pymysql/cursors.py", line 328, in _query
    conn.query(q)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/pymysql/connections.py", line 517, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/pymysql/connections.py", line 732, in _read_query_result
    result.read()
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/pymysql/connections.py", line 1075, in read
    first_packet = self.connection._read_packet()
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/pymysql/connections.py", line 684, in _read_packet
    packet.check_error()
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/pymysql/protocol.py", line 220, in check_error
    err.raise_mysql_exception(self._data)
  File "/home/frappe/frappe-bench/env/local/lib/python2.7/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
    raise errorclass(errno, errval)
  pymysql.err.InternalError: (1054, u"Unknown column 'total_taxes_and_charges' in 'where clause'")
```