### PR TITLE
fix: list index out of range

### DIFF
--- a/erpnext/stock/doctype/batch/batch.py
+++ b/erpnext/stock/doctype/batch/batch.py
@@ -7,7 +7,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.model.naming import make_autoname, revert_series_if_last
-from frappe.utils import flt, cint
+from frappe.utils import flt, cint, get_link_to_form
 from frappe.utils.jinja import render_template
 from frappe.utils.data import add_days
 from six import string_types
@@ -124,7 +124,7 @@ class Batch(Document):
 		if has_expiry_date and not self.expiry_date:
 			frappe.throw(msg=_("Please set {0} for Batched Item {1}, which is used to set {2} on Submit.") \
 				.format(frappe.bold("Shelf Life in Days"),
-					frappe.utils.get_link_to_form("Item", self.item),
+					get_link_to_form("Item", self.item),
 					frappe.bold("Batch Expiry Date")),
 				title=_("Expiry Date Mandatory"))
 
@@ -264,15 +264,19 @@ def get_batch_no(item_code, warehouse, qty=1, throw=False, serial_no=None):
 def get_batches(item_code, warehouse, qty=1, throw=False, serial_no=None):
 	from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos
 	cond = ''
-	if serial_no:
+	if serial_no and frappe.get_cached_value('Item', item_code, 'has_batch_no'):
+		serial_nos = get_serial_nos(serial_no)
 		batch = frappe.get_all("Serial No",
 			fields = ["distinct batch_no"],
 			filters= {
 				"item_code": item_code,
 				"warehouse": warehouse,
-				"name": ("in", get_serial_nos(serial_no))
+				"name": ("in", serial_nos)
 			}
 		)
+
+		if not batch:
+			validate_serial_no_with_batch(serial_nos, item_code)
 
 		if batch and len(batch) > 1:
 			return []
@@ -289,3 +293,14 @@ def get_batches(item_code, warehouse, qty=1, throw=False, serial_no=None):
 		group by batch_id
 		order by `tabBatch`.expiry_date ASC, `tabBatch`.creation ASC
 	""".format(cond), (item_code, warehouse), as_dict=True)
+
+def validate_serial_no_with_batch(serial_nos, item_code):
+	if frappe.get_cached_value("Serial No", serial_nos[0], "item_code") != item_code:
+		frappe.throw(_("The serial no {0} does not belong to item {1}")
+			.format(get_link_to_form("Serial No", serial_nos[0]), get_link_to_form("Item", item_code)))
+
+	serial_no_link = ','.join([get_link_to_form("Serial No", sn) for sn in serial_nos])
+
+	message = "Serial Nos" if len(serial_nos) > 1 else "Serial No"
+	frappe.throw(_("There is no batch found against the {0}: {1}")
+		.format(message, serial_no_link))


### PR DESCRIPTION
**Issue**

User has selected the serial no which is not belongs to the respective item and due to which system has broken 
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/frappe/frappe/api.py", line 56, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/frappe/frappe/handler.py", line 61, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/frappe/frappe/__init__.py", line 1055, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/frappe/frappe/desk/form/save.py", line 22, in savedocs
    doc.save()
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/frappe/frappe/model/document.py", line 273, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/frappe/frappe/model/document.py", line 296, in _save
    self.insert()
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/frappe/frappe/model/document.py", line 230, in insert
    self.run_before_save_methods()
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/frappe/frappe/model/document.py", line 893, in run_before_save_methods
    self.run_method("validate")
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/frappe/frappe/model/document.py", line 794, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/frappe/frappe/model/document.py", line 1064, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/frappe/frappe/model/document.py", line 1047, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/frappe/frappe/model/document.py", line 788, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.py", line 76, in validate
    set_batch_nos(self, 's_warehouse')
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/erpnext/erpnext/stock/doctype/batch/batch.py", line 232, in set_batch_nos
    d.batch_no = get_batch_no(d.item_code, warehouse, qty, throw, d.serial_no)
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/erpnext/erpnext/stock/doctype/batch/batch.py", line 249, in get_batch_no
    batches = get_batches(item_code, warehouse, qty, throw, serial_no)
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/erpnext/erpnext/stock/doctype/batch/batch.py", line 280, in get_batches
    cond = " and `tabBatch`.name = %s" %(frappe.db.escape(batch[0].batch_no))
IndexError: list index out of range
```