### PR TITLE
fix: add deduct functionality added for selling cycle

### DIFF
--- a/erpnext/accounts/doctype/sales_taxes_and_charges/sales_taxes_and_charges.json
+++ b/erpnext/accounts/doctype/sales_taxes_and_charges/sales_taxes_and_charges.json
@@ -1,9 +1,13 @@
 {
+ "actions": [],
  "creation": "2013-04-24 11:39:32",
  "doctype": "DocType",
  "document_type": "Setup",
  "editable_grid": 1,
+ "engine": "InnoDB",
  "field_order": [
+  "category",
+  "add_deduct_tax",
   "charge_type",
   "row_id",
   "account_head",
@@ -23,8 +27,7 @@
   "base_tax_amount",
   "base_total",
   "base_tax_amount_after_discount_amount",
-  "item_wise_tax_detail",
-  "parenttype"
+  "item_wise_tax_detail"
  ],
  "fields": [
   {
@@ -174,17 +177,6 @@
    "read_only": 1
   },
   {
-   "fieldname": "parenttype",
-   "fieldtype": "Data",
-   "hidden": 1,
-   "in_filter": 1,
-   "label": "Parenttype",
-   "oldfieldname": "parenttype",
-   "oldfieldtype": "Data",
-   "print_hide": 1,
-   "search_index": 1
-  },
-  {
    "fieldname": "accounting_dimensions_section",
    "fieldtype": "Section Break",
    "label": "Accounting Dimensions"
@@ -192,15 +184,31 @@
   {
    "fieldname": "dimension_col_break",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "category",
+   "fieldtype": "Select",
+   "label": "Consider Tax or Charge for",
+   "options": "Valuation and Total\nValuation\nTotal",
+   "reqd": 1
+  },
+  {
+   "fieldname": "add_deduct_tax",
+   "fieldtype": "Select",
+   "label": "Add or Deduct",
+   "options": "Add\nDeduct",
+   "reqd": 1
   }
  ],
  "idx": 1,
  "istable": 1,
- "modified": "2019-05-25 22:59:38.740883",
+ "links": [],
+ "modified": "2020-05-06 05:29:01.321515",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Taxes and Charges",
  "owner": "Administrator",
  "permissions": [],
+ "sort_field": "modified",
  "sort_order": "ASC"
 }

--- a/erpnext/accounts/doctype/sales_taxes_and_charges_template/sales_taxes_and_charges_template.js
+++ b/erpnext/accounts/doctype/sales_taxes_and_charges_template/sales_taxes_and_charges_template.js
@@ -5,3 +5,26 @@ cur_frm.cscript.tax_table = "Sales Taxes and Charges";
 
 {% include "erpnext/public/js/controllers/accounts.js" %}
 
+frappe.ui.form.on("Sales Taxes and Charges", "add_deduct_tax", function(doc, cdt, cdn) {
+	var d = locals[cdt][cdn];
+
+	if(!d.category && d.add_deduct_tax) {
+		frappe.msgprint(__("Please select Category first"));
+		d.add_deduct_tax = '';
+	}
+	else if(d.category != 'Total' && d.add_deduct_tax == 'Deduct') {
+		frappe.msgprint(__("Cannot deduct when category is for 'Valuation' or 'Valuation and Total'"));
+		d.add_deduct_tax = '';
+	}
+	refresh_field('add_deduct_tax', d.name, 'taxes');
+});
+
+frappe.ui.form.on("Sales Taxes and Charges", "category", function(doc, cdt, cdn) {
+	var d = locals[cdt][cdn];
+
+	if (d.category != 'Total' && d.add_deduct_tax == 'Deduct') {
+		frappe.msgprint(__("Cannot deduct when category is for 'Valuation' or 'Vaulation and Total'"));
+		d.add_deduct_tax = '';
+	}
+	refresh_field('add_deduct_tax', d.name, 'taxes');
+});

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -289,7 +289,7 @@ class calculate_taxes_and_totals(object):
 		# if tax/charges is for deduction, multiply by -1
 		if getattr(tax, "category", None):
 			tax_amount = 0.0 if (tax.category == "Valuation") else tax_amount
-			if self.doc.doctype in ["Purchase Order", "Purchase Invoice", "Purchase Receipt", "Supplier Quotation"]:
+			if self.doc.doctype in ["Purchase Order", "Purchase Invoice", "Purchase Receipt", "Supplier Quotation", "Quotation", "Sales Order", "Sales Invoice", "Delivery Note"]:
 				tax_amount *= -1.0 if (tax.add_deduct_tax == "Deduct") else 1.0
 		return tax_amount
 

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -669,3 +669,5 @@ erpnext.patches.v12_0.set_serial_no_status #2020-05-21
 erpnext.patches.v12_0.update_price_list_currency_in_bom
 erpnext.patches.v12_0.update_uom_conversion_factor
 erpnext.patches.v12_0.set_italian_import_supplier_invoice_permissions
+execute:frappe.delete_doc_if_exists("Page", "appointment-analytic")
+execute:erpnext.patches.v12_0.update_sales_taxes_and_charges_template

--- a/erpnext/patches/v12_0/update_sales_taxes_and_charges_template.py
+++ b/erpnext/patches/v12_0/update_sales_taxes_and_charges_template.py
@@ -1,0 +1,13 @@
+from __future__ import unicode_literals
+import frappe
+
+def execute():
+	frappe.reload_doc("accounts", "doctype", "sales_taxes_and_charges_template")
+	
+	# set add_deduct_tax in Sales Taxes And Charges Templates
+	if frappe.db.has_column("Sales Taxes and Charges", "category") and\
+		frappe.db.has_column("Sales Taxes and Charges", "add_deduct_tax"):
+		frappe.db.sql('''update `tabSales Taxes and Charges`
+			set category = 'Total',
+			add_deduct_tax = 'Add'
+		''')

--- a/erpnext/selling/sales_common.js
+++ b/erpnext/selling/sales_common.js
@@ -225,6 +225,17 @@ erpnext.selling.SellingController = erpnext.TransactionController.extend({
 		refresh_field("incentives",row.name,row.parentfield);
 	},
 
+	category: function(doc, cdt, cdn) {
+		// should be the category field of tax table
+		if(cdt != doc.doctype) {
+			this.calculate_taxes_and_totals();
+		}
+	},
+
+	add_deduct_tax: function(doc, cdt, cdn) {
+		this.calculate_taxes_and_totals();
+	},
+
 	warehouse: function(doc, cdt, cdn) {
 		var me = this;
 		var item = frappe.get_doc(cdt, cdn);


### PR DESCRIPTION
We have use case where we need to deduct tax in selling cycle

![WheelHouse_Cannabis_Dispensary_ACC_SINV_2020_00897](https://user-images.githubusercontent.com/6947417/81280924-d1493d00-9076-11ea-90e7-af68489ab66b.png)

we added add and deduct functionality for selling cycle
![WheelHouse_Cannabis_Dispensary_ACC_SINV_2020_00897 (1)](https://user-images.githubusercontent.com/6947417/81281252-37ce5b00-9077-11ea-9225-fee97315ea94.png)
