### PR TITLE
fix: delete old appointment analytics tree grid report

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -680,3 +680,4 @@ erpnext.patches.v12_0.fix_quotation_expired_status
 erpnext.patches.v12_0.update_appointment_reminder_scheduler_entry
 erpnext.patches.v12_0.retain_permission_rules_for_video_doctype
 erpnext.patches.v13_0.patch_to_fix_reverse_linking_in_additional_salary_encashment_and_incentive
+execute:frappe.delete_doc_if_exists("Page", "appointment-analytic")


### PR DESCRIPTION
Remove old deprecated Appointment Analytics tree grid report as it has been replaced with Script Report in v13.