### PR TITLE
fix: delete old appointment analytics tree grid report

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -662,3 +662,4 @@ erpnext.patches.v12_0.set_updated_purpose_in_pick_list
 erpnext.patches.v12_0.repost_stock_ledger_entries_for_target_warehouse
 erpnext.patches.v12_0.update_end_date_and_status_in_email_campaign
 erpnext.patches.v13_0.move_tax_slabs_from_payroll_period_to_income_tax_slab #123
+execute:frappe.delete_doc_if_exists("Page", "appointment-analytic")


### PR DESCRIPTION
Remove old deprecated Appointment Analytics tree grid report.