### PR TITLE
fix: Payment Order not allowing to create Payment Entry

### DIFF
--- a/erpnext/accounts/doctype/payment_order/payment_order.py
+++ b/erpnext/accounts/doctype/payment_order/payment_order.py
@@ -80,7 +80,7 @@ def make_journal_entry(doc, supplier, mode_of_payment=None):
 			paid_amt += d.amount
 
 	je.append('accounts', {
-		'account': doc.references[0].account,
+		'account': doc.account,
 		'credit_in_account_currency': paid_amt
 	})
 


### PR DESCRIPTION
**Issue-** After submitting, when clicking the Create Payment Entries button, this error is thrown. Note: Mode of Payment in Payment Request should be Bank Draft.
![image](https://user-images.githubusercontent.com/20715976/81344504-7c3c1400-90d4-11ea-8a5c-1632172155cc.png)

