### PR TITLE
fix(accounting): Allow 0 threshold in Tax Withholding Category

### DIFF
--- a/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
+++ b/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
@@ -162,8 +162,7 @@ def get_tds_amount(suppliers, net_total, company, tax_details, fiscal_year_detai
 		debit_note_amount = get_debit_note_amount(suppliers, year_start_date, year_end_date)
 		supplier_credit_amount -= debit_note_amount
 
-		if ((tax_details.get('threshold', 0) and supplier_credit_amount >= tax_details.threshold)
-			or (tax_details.get('cumulative_threshold', 0) and supplier_credit_amount >= tax_details.cumulative_threshold)):
+		if supplier_credit_amount >= tax_details.get('threshold', 0) or supplier_credit_amount >= tax_details.get('cumulative_threshold', 0):
 
 			if ldc and is_valid_certificate(ldc.valid_from, ldc.valid_upto, posting_date, tds_deducted, net_total,
 				ldc.certificate_limit):


### PR DESCRIPTION
This fixes a bug in Tax Withholding Category where if it has a threshold
of 0, it doesn't get applied to Purchase Invoices. The bug was fixed by
updating the condition.

**Before:** If the threshold is 0, no tax amount will appear in Purchase Invoices. The user will have to set the threshold to -1 or 1.
**After**: It will now work even with 0 threshold.
