### PR TITLE
fix(accounting): Tax Withholding Category Description default

### DIFF
--- a/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
+++ b/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
@@ -58,7 +58,7 @@ def get_tax_withholding_details(tax_withholding_category, fiscal_year, company):
 				"rate": tax_rate_detail.tax_withholding_rate,
 				"threshold": tax_rate_detail.single_threshold,
 				"cumulative_threshold": tax_rate_detail.cumulative_threshold,
-				"description": tax_withholding.category_name
+				"description": tax_withholding.category_name.strip() if tax_withholding.category_name.strip() else tax_withholding_category
 			})
 
 def get_tax_withholding_rates(tax_withholding, fiscal_year):

--- a/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
+++ b/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
@@ -58,7 +58,7 @@ def get_tax_withholding_details(tax_withholding_category, fiscal_year, company):
 				"rate": tax_rate_detail.tax_withholding_rate,
 				"threshold": tax_rate_detail.single_threshold,
 				"cumulative_threshold": tax_rate_detail.cumulative_threshold,
-				"description": tax_withholding.category_name.strip() if tax_withholding.category_name.strip() else tax_withholding_category
+				"description": tax_withholding.category_name if tax_withholding.category_name else tax_withholding_category
 			})
 
 def get_tax_withholding_rates(tax_withholding, fiscal_year):


### PR DESCRIPTION
This pull request fixes a bug that happens when a Purchase Invoice uses a
Tax Withholding Category without a category_name. It throws the following error:

<img width="434" alt="Screen Shot 2020-05-08 at 5 55 07 PM" src="https://user-images.githubusercontent.com/16395892/81395362-12644e80-9156-11ea-9733-51d8a088c67f.png">

The category_name was used as the tax description which is a required field. I fixed it by using the Tax Withholding Category's name as the description if the category_name is empty.