### PR TITLE
fix: local variable 'lft' referenced before assignment

### DIFF
--- a/erpnext/stock/doctype/warehouse/warehouse.py
+++ b/erpnext/stock/doctype/warehouse/warehouse.py
@@ -177,7 +177,7 @@ def convert_to_group_or_ledger():
 	return frappe.get_doc("Warehouse", args.docname).convert_to_group_or_ledger()
 
 def get_child_warehouses(warehouse):
-	lft, rgt = frappe.get_cached_value("Warehouse", warehouse, [lft, rgt])
+	lft, rgt = frappe.get_cached_value("Warehouse", warehouse, ["lft", "rgt"])
 
 	return frappe.db.sql_list("""select name from `tabWarehouse`
 		where lft >= %s and rgt <= %s""", (lft, rgt))


### PR DESCRIPTION
**Issue**

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/frappe/frappe/api.py", line 56, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/frappe/frappe/handler.py", line 22, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/frappe/frappe/handler.py", line 61, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/frappe/frappe/__init__.py", line 1055, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/frappe/frappe/__init__.py", line 527, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/frappe/frappe/desk/query_report.py", line 175, in run
    result = generate_report_result(report, filters, user, custom_columns)
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/frappe/frappe/desk/query_report.py", line 59, in generate_report_result
    res = report.execute_script_report(filters)
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/frappe/frappe/core/doctype/report/report.py", line 116, in execute_script_report
    res = self.execute_module(filters)
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/frappe/frappe/core/doctype/report/report.py", line 133, in execute_module
    return frappe.get_attr(method_name)(frappe._dict(filters))
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/erpnext/erpnext/stock/report/stock_and_account_value_comparison/stock_and_account_value_comparison.py", line 16, in execute
    data = get_data(filters)
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/erpnext/erpnext/stock/report/stock_and_account_value_comparison/stock_and_account_value_comparison.py", line 30, in get_data
    stock_ledger_entries = get_stock_ledger_data(report_filters, filters)
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/erpnext/erpnext/stock/report/stock_and_account_value_comparison/stock_and_account_value_comparison.py", line 46, in get_stock_ledger_data
    report_filters.company)
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/erpnext/erpnext/stock/doctype/warehouse/warehouse.py", line 190, in get_warehouses_based_on_account
    warehouses.extend(get_child_warehouses(d.name))
  File "/home/frappe/benches/bench-version-12-2020-04-23/apps/erpnext/erpnext/stock/doctype/warehouse/warehouse.py", line 180, in get_child_warehouses
    lft, rgt = frappe.get_cached_value("Warehouse", warehouse, [lft, rgt])
UnboundLocalError: local variable 'lft' referenced before assignment
```