### PR TITLE
feat: apply item-wise pricing rules

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -206,7 +206,7 @@ def get_pricing_rule_for_item(args, price_list_rate=0, doc=None, for_validate=Fa
 		"discount_amount_on_rate": []
 	})
 
-	if args.ignore_pricing_rule or not args.item_code:
+	if args.ignore_pricing_rule or args.item_ignore_pricing_rule or not args.item_code:
 		if frappe.db.exists(args.doctype, args.name) and args.get("pricing_rules"):
 			item_details = remove_pricing_rule_for_item(args.get("pricing_rules"),
 				item_details, args.get('item_code'))

--- a/erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
+++ b/erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
@@ -40,6 +40,7 @@
   "base_rate",
   "base_amount",
   "pricing_rules",
+  "item_ignore_pricing_rule",
   "is_free_item",
   "section_break_22",
   "net_rate",
@@ -769,12 +770,18 @@
    "collapsible": 1,
    "fieldname": "col_break7",
    "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "item_ignore_pricing_rule",
+   "fieldtype": "Check",
+   "label": "Ignore Pricing Rule"
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-04-22 10:37:35.103176",
+ "modified": "2020-05-08 06:11:08.386919",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Purchase Invoice Item",

--- a/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
+++ b/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
@@ -45,6 +45,7 @@
   "base_rate",
   "base_amount",
   "pricing_rules",
+  "item_ignore_pricing_rule",
   "is_free_item",
   "section_break_21",
   "net_rate",
@@ -783,12 +784,18 @@
    "fieldtype": "Link",
    "label": "Finance Book",
    "options": "Finance Book"
+  },
+  {
+   "default": "0",
+   "fieldname": "item_ignore_pricing_rule",
+   "fieldtype": "Check",
+   "label": "Ignore Pricing Rule"
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2019-12-04 12:22:38.517710",
+ "modified": "2020-05-08 06:11:38.569638",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice Item",

--- a/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
+++ b/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
@@ -39,6 +39,7 @@
   "base_rate",
   "base_amount",
   "pricing_rules",
+  "item_ignore_pricing_rule",
   "is_free_item",
   "section_break_29",
   "net_rate",
@@ -725,18 +726,23 @@
    "fieldname": "more_info_section_break",
    "fieldtype": "Section Break",
    "label": "More Information"
+  },
+  {
+   "default": "0",
+   "fieldname": "item_ignore_pricing_rule",
+   "fieldtype": "Check",
+   "label": "Ignore Pricing Rule"
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-04-21 11:55:58.643393",
+ "modified": "2020-05-08 06:12:04.769939",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Purchase Order Item",
  "owner": "Administrator",
  "permissions": [],
- "quick_entry": 1,
  "search_fields": "item_name",
  "sort_field": "modified",
  "sort_order": "DESC",

--- a/erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
+++ b/erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
@@ -42,6 +42,7 @@
   "base_rate",
   "base_amount",
   "pricing_rules",
+  "item_ignore_pricing_rule",
   "is_free_item",
   "section_break_24",
   "net_rate",
@@ -528,12 +529,18 @@
   {
    "fieldname": "column_break_15",
    "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "item_ignore_pricing_rule",
+   "fieldtype": "Check",
+   "label": "Ignore Pricing Rule"
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-04-07 18:35:51.175947",
+ "modified": "2020-05-08 06:12:32.611668",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Supplier Quotation Item",

--- a/erpnext/selling/doctype/quotation_item/quotation_item.json
+++ b/erpnext/selling/doctype/quotation_item/quotation_item.json
@@ -47,6 +47,7 @@
   "base_amount",
   "base_net_amount",
   "pricing_rules",
+  "item_ignore_pricing_rule",
   "is_free_item",
   "item_weight_details",
   "weight_per_unit",
@@ -602,12 +603,18 @@
    "label": "Against Blanket Order",
    "no_copy": 1,
    "print_hide": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "item_ignore_pricing_rule",
+   "fieldtype": "Check",
+   "label": "Ignore Pricing Rule"
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-03-30 18:40:28.782720",
+ "modified": "2020-05-08 05:10:57.215538",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Quotation Item",

--- a/erpnext/selling/doctype/sales_order_item/sales_order_item.json
+++ b/erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -46,6 +46,7 @@
   "base_rate",
   "base_amount",
   "pricing_rules",
+  "item_ignore_pricing_rule",
   "is_free_item",
   "section_break_24",
   "net_rate",
@@ -764,12 +765,17 @@
    "fieldname": "against_blanket_order",
    "fieldtype": "Check",
    "label": "Against Blanket Order"
+  },
+  {
+   "fieldname": "item_ignore_pricing_rule",
+   "fieldtype": "Check",
+   "label": "Ignore Pricing Rule"
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-03-05 14:20:28.085117",
+ "modified": "2020-05-08 06:08:58.616432",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order Item",

--- a/erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
+++ b/erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -44,6 +44,7 @@
   "base_rate",
   "base_amount",
   "pricing_rules",
+  "item_ignore_pricing_rule",
   "is_free_item",
   "section_break_25",
   "net_rate",
@@ -709,12 +710,18 @@
    "no_copy": 1,
    "print_hide": 1,
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "item_ignore_pricing_rule",
+   "fieldtype": "Check",
+   "label": "Ignore Pricing Rule"
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-03-05 14:18:33.131672",
+ "modified": "2020-05-08 06:09:38.276790",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Note Item",

--- a/erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
+++ b/erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
@@ -44,6 +44,7 @@
   "base_rate",
   "base_amount",
   "pricing_rules",
+  "item_ignore_pricing_rule",
   "is_free_item",
   "section_break_29",
   "net_rate",
@@ -834,18 +835,23 @@
    "collapsible": 1,
    "fieldname": "image_column",
    "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "item_ignore_pricing_rule",
+   "fieldtype": "Check",
+   "label": "Ignore Pricing Rule"
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-04-28 19:01:21.154963",
+ "modified": "2020-05-08 06:10:10.448848",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Purchase Receipt Item",
  "owner": "Administrator",
  "permissions": [],
- "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "DESC"
 }


### PR DESCRIPTION
**Changes:**

- Add "Ignore Pricing Rule" checkbox in all Buying and Selling transactions that apply pricing rules.
- Re-map pricing rule triggers to pick up item toggles instead of the parent toggle.

<hr>

**Screenshots / GIFs:**

![item-pricing-rule](https://user-images.githubusercontent.com/13396535/81396521-2d799300-9143-11ea-9b64-9085cba946d5.gif)