### PR TITLE
fix: Item Barcode stays the same after updating.

### DIFF
--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -572,6 +572,13 @@ class Item(WebsiteGenerator):
 							frappe.throw(_("Barcode {0} is not a valid {1} code").format(
 								item_barcode.barcode, item_barcode.barcode_type), InvalidBarcode)
 
+					if item_barcode.barcode != item_barcode.name:
+						# if barcode is getting updated , the row name has to reset.
+						# Delete previous old row doc and re-enter row as if new to reset name in db.
+						item_barcode.set("__islocal", True)
+						item_barcode.name = None
+						frappe.delete_doc("Item Barcode", item_barcode.name)
+
 	def validate_warehouse_for_reorder(self):
 		'''Validate Reorder level table for duplicate and conditional mandatory'''
 		warehouse = []


### PR DESCRIPTION
- Assume a Barcode **abc** is created by adding a row in the barcodes table of Item master.
- Due to Item Barcode's naming series being _'fieldname: barcode'_ it is stored in the db with **name:abc** and **barcode:abc**
- Update the same barcode row in Item master to **123** since **abc** was accidental.
- It is stored as **name:abc** and **barcode:123** in the db.
- Now if we wish to use barcode **'abc'** in another Item where it actually belonged, we get a `DuplicationError` because **name:abc** already exists.

**Fix:**
- Only on updation, if the row name and barcode differ, delete that doc from `tabItem Barcode` and re-enter this row as if new so that it's name is reset in the db and a new entry is made.
- Not problematic for new rows as they do not satisfy this condition.