### PR TITLE
fix: Add accidentally removed function

### DIFF
--- a/erpnext/accounts/dashboard_fixtures.py
+++ b/erpnext/accounts/dashboard_fixtures.py
@@ -107,6 +107,10 @@ def get_charts():
 			}
 		]
 
+def get_account(account_type, company):
+	accounts = frappe.get_list("Account", filters={"account_type": account_type, "company": company})
+	if accounts:
+		return accounts[0].name
 
 def get_company_for_dashboards():
 	company = frappe.defaults.get_defaults().company


### PR DESCRIPTION
fixes: 

```
File "/Users/sps/benches/develop/apps/erpnext/erpnext/setup/utils.py", line 45, in before_tests
    "domains"			: ["Manufacturing"],
  File "/Users/sps/benches/develop/apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.py", line 77, in setup_complete
    run_setup_success(args)
  File "/Users/sps/benches/develop/apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.py", line 99, in run_setup_success
    install_fixtures.install()
  File "/Users/sps/benches/develop/apps/frappe/frappe/desk/page/setup_wizard/install_fixtures.py", line 16, in install
    sync_dashboards()
  File "/Users/sps/benches/develop/apps/frappe/frappe/utils/dashboard.py", line 86, in sync_dashboards
    config = get_config(app_name, module_name)
  File "/Users/sps/benches/develop/apps/frappe/frappe/utils/dashboard.py", line 110, in get_config
    return frappe._dict(module_dashboards.get_data())
  File "/Users/sps/benches/develop/apps/erpnext/erpnext/accounts/dashboard_fixtures.py", line 11, in get_data
    "charts": get_charts(),
  File "/Users/sps/benches/develop/apps/erpnext/erpnext/accounts/dashboard_fixtures.py", line 31, in get_charts
    bank_account = company.default_bank_account or get_account("Bank", company.name)
NameError: name 'get_account' is not defined
```

The issue was introduced through https://github.com/frappe/erpnext/pull/21618