### PR TITLE
fix: do not setup charts if not setup_complete or no company found

### DIFF
--- a/erpnext/accounts/dashboard_fixtures.py
+++ b/erpnext/accounts/dashboard_fixtures.py
@@ -7,10 +7,16 @@ import json
 
 
 def get_data():
-	return frappe._dict({
-		"dashboards": get_dashboards(),
-		"charts": get_charts(),
+	data = frappe._dict({
+		"dashboards": [],
+		"charts": []
 	})
+	company = get_company_for_dashboards()
+	if company:
+		company_doc = frappe.get_doc("Company", company)
+		data.dashboards = get_dashboards()
+		data.charts = get_charts(company_doc)
+	return data
 
 def get_dashboards():
 	return [{
@@ -25,16 +31,12 @@ def get_dashboards():
 		]
 	}]
 
-def get_charts():
-	charts = []
-	company_name = get_company_for_dashboards()
-	if company_name:
-		company = frappe.get_doc("Company", company_name)
-		income_account = company.default_income_account or get_account("Income Account", company.name)
-		expense_account = company.default_expense_account or get_account("Expense Account", company.name)
-		bank_account = company.default_bank_account or get_account("Bank", company.name)
+def get_charts(company):
+	income_account = company.default_income_account or get_account("Income Account", company.name)
+	expense_account = company.default_expense_account or get_account("Expense Account", company.name)
+	bank_account = company.default_bank_account or get_account("Bank", company.name)
 
-	charts = [
+	return [
 		{
 			"doctype": "Dashboard Chart",
 			"time_interval": "Quarterly",
@@ -110,8 +112,6 @@ def get_charts():
 			"type": "Bar"
 		}
 	]
-
-	return charts
 
 def get_account(account_type, company):
 	accounts = frappe.get_list("Account", filters={"account_type": account_type, "company": company})

--- a/erpnext/accounts/dashboard_fixtures.py
+++ b/erpnext/accounts/dashboard_fixtures.py
@@ -1,5 +1,7 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
+from erpnext import get_default_company
+from frappe.utils import cint
 
 import frappe
 import json
@@ -25,87 +27,93 @@ def get_dashboards():
 	}]
 
 def get_charts():
-	company = frappe.get_doc("Company", get_company_for_dashboards())
-	income_account = company.default_income_account or get_account("Income Account", company.name)
-	expense_account = company.default_expense_account or get_account("Expense Account", company.name)
-	bank_account = company.default_bank_account or get_account("Bank", company.name)
+	charts = []
+	if cint(frappe.db.get_single_value('System Settings', 'setup_complete')):
+		company_name = get_company_for_dashboards()
+		if company_name:
+			company = frappe.get_doc("Company", company_name)
+			income_account = company.default_income_account or get_account("Income Account", company.name)
+			expense_account = company.default_expense_account or get_account("Expense Account", company.name)
+			bank_account = company.default_bank_account or get_account("Bank", company.name)
 
-	return [
-			{
-				"doctype": "Dashboard Chart",
-				"time_interval": "Quarterly",
-				"name": "Income",
-				"chart_name": "Income",
-				"timespan": "Last Year",
-				"color": None,
-				"filters_json": json.dumps({"company": company.name, "account": income_account}),
-				"source": "Account Balance Timeline",
-				"chart_type": "Custom",
-				"timeseries": 1,
-				"owner": "Administrator",
-				"type": "Line"
-			},
-			{
-				"doctype": "Dashboard Chart",
-				"time_interval": "Quarterly",
-				"name": "Expenses",
-				"chart_name": "Expenses",
-				"timespan": "Last Year",
-				"color": None,
-				"filters_json": json.dumps({"company": company.name, "account": expense_account}),
-				"source": "Account Balance Timeline",
-				"chart_type": "Custom",
-				"timeseries": 1,
-				"owner": "Administrator",
-				"type": "Line"
-			},
-			{
-				"doctype": "Dashboard Chart",
-				"time_interval": "Quarterly",
-				"name": "Bank Balance",
-				"chart_name": "Bank Balance",
-				"timespan": "Last Year",
-				"color": "#ffb868",
-				"filters_json": json.dumps({"company": company.name, "account": bank_account}),
-				"source": "Account Balance Timeline",
-				"chart_type": "Custom",
-				"timeseries": 1,
-				"owner": "Administrator",
-				"type": "Line"
-			},
-			{
-				"doctype": "Dashboard Chart",
-				"time_interval": "Monthly",
-				"name": "Incoming Bills (Purchase Invoice)",
-				"chart_name": "Incoming Bills (Purchase Invoice)",
-				"timespan": "Last Year",
-				"color": "#a83333",
-				"value_based_on": "base_grand_total",
-				"filters_json": json.dumps({}),
-				"chart_type": "Sum",
-				"timeseries": 1,
-				"based_on": "posting_date",
-				"owner": "Administrator",
-				"document_type": "Purchase Invoice",
-				"type": "Bar"
-			},
-			{
-				"doctype": "Dashboard Chart",
-				"time_interval": "Monthly",
-				"name": "Outgoing Bills (Sales Invoice)",
-				"chart_name": "Outgoing Bills (Sales Invoice)",
-				"timespan": "Last Year",
-				"color": "#7b933d",
-				"value_based_on": "base_grand_total",
-				"filters_json": json.dumps({}),
-				"chart_type": "Sum",
-				"timeseries": 1,
-				"based_on": "posting_date",
-				"owner": "Administrator",
-				"document_type": "Sales Invoice",
-				"type": "Bar"
-			}
-		]
+			charts = [
+				{
+					"doctype": "Dashboard Chart",
+					"time_interval": "Quarterly",
+					"name": "Income",
+					"chart_name": "Income",
+					"timespan": "Last Year",
+					"color": None,
+					"filters_json": json.dumps({"company": company.name, "account": income_account}),
+					"source": "Account Balance Timeline",
+					"chart_type": "Custom",
+					"timeseries": 1,
+					"owner": "Administrator",
+					"type": "Line"
+				},
+				{
+					"doctype": "Dashboard Chart",
+					"time_interval": "Quarterly",
+					"name": "Expenses",
+					"chart_name": "Expenses",
+					"timespan": "Last Year",
+					"color": None,
+					"filters_json": json.dumps({"company": company.name, "account": expense_account}),
+					"source": "Account Balance Timeline",
+					"chart_type": "Custom",
+					"timeseries": 1,
+					"owner": "Administrator",
+					"type": "Line"
+				},
+				{
+					"doctype": "Dashboard Chart",
+					"time_interval": "Quarterly",
+					"name": "Bank Balance",
+					"chart_name": "Bank Balance",
+					"timespan": "Last Year",
+					"color": "#ffb868",
+					"filters_json": json.dumps({"company": company.name, "account": bank_account}),
+					"source": "Account Balance Timeline",
+					"chart_type": "Custom",
+					"timeseries": 1,
+					"owner": "Administrator",
+					"type": "Line"
+				},
+				{
+					"doctype": "Dashboard Chart",
+					"time_interval": "Monthly",
+					"name": "Incoming Bills (Purchase Invoice)",
+					"chart_name": "Incoming Bills (Purchase Invoice)",
+					"timespan": "Last Year",
+					"color": "#a83333",
+					"value_based_on": "base_grand_total",
+					"filters_json": json.dumps({}),
+					"chart_type": "Sum",
+					"timeseries": 1,
+					"based_on": "posting_date",
+					"owner": "Administrator",
+					"document_type": "Purchase Invoice",
+					"type": "Bar"
+				},
+				{
+					"doctype": "Dashboard Chart",
+					"time_interval": "Monthly",
+					"name": "Outgoing Bills (Sales Invoice)",
+					"chart_name": "Outgoing Bills (Sales Invoice)",
+					"timespan": "Last Year",
+					"color": "#7b933d",
+					"value_based_on": "base_grand_total",
+					"filters_json": json.dumps({}),
+					"chart_type": "Sum",
+					"timeseries": 1,
+					"based_on": "posting_date",
+					"owner": "Administrator",
+					"document_type": "Sales Invoice",
+					"type": "Bar"
+				}
+			]
+
+	return charts
 
 def get_account(account_type, company):
 	accounts = frappe.get_list("Account", filters={"account_type": account_type, "company": company})
@@ -113,11 +121,9 @@ def get_account(account_type, company):
 		return accounts[0].name
 
 def get_company_for_dashboards():
-	company = frappe.defaults.get_defaults().company
-	if company:
-		return company
-	else:
+	company = get_default_company()
+	if not company:
 		company_list = frappe.get_list("Company")
 		if company_list:
-			return company_list[0].name
-	return None
+			company = company_list[0].name
+	return company

--- a/erpnext/accounts/dashboard_fixtures.py
+++ b/erpnext/accounts/dashboard_fixtures.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
 from erpnext import get_default_company
-from frappe.utils import cint
 
 import frappe
 import json
@@ -28,90 +27,89 @@ def get_dashboards():
 
 def get_charts():
 	charts = []
-	if cint(frappe.db.get_single_value('System Settings', 'setup_complete')):
-		company_name = get_company_for_dashboards()
-		if company_name:
-			company = frappe.get_doc("Company", company_name)
-			income_account = company.default_income_account or get_account("Income Account", company.name)
-			expense_account = company.default_expense_account or get_account("Expense Account", company.name)
-			bank_account = company.default_bank_account or get_account("Bank", company.name)
+	company_name = get_company_for_dashboards()
+	if company_name:
+		company = frappe.get_doc("Company", company_name)
+		income_account = company.default_income_account or get_account("Income Account", company.name)
+		expense_account = company.default_expense_account or get_account("Expense Account", company.name)
+		bank_account = company.default_bank_account or get_account("Bank", company.name)
 
-			charts = [
-				{
-					"doctype": "Dashboard Chart",
-					"time_interval": "Quarterly",
-					"name": "Income",
-					"chart_name": "Income",
-					"timespan": "Last Year",
-					"color": None,
-					"filters_json": json.dumps({"company": company.name, "account": income_account}),
-					"source": "Account Balance Timeline",
-					"chart_type": "Custom",
-					"timeseries": 1,
-					"owner": "Administrator",
-					"type": "Line"
-				},
-				{
-					"doctype": "Dashboard Chart",
-					"time_interval": "Quarterly",
-					"name": "Expenses",
-					"chart_name": "Expenses",
-					"timespan": "Last Year",
-					"color": None,
-					"filters_json": json.dumps({"company": company.name, "account": expense_account}),
-					"source": "Account Balance Timeline",
-					"chart_type": "Custom",
-					"timeseries": 1,
-					"owner": "Administrator",
-					"type": "Line"
-				},
-				{
-					"doctype": "Dashboard Chart",
-					"time_interval": "Quarterly",
-					"name": "Bank Balance",
-					"chart_name": "Bank Balance",
-					"timespan": "Last Year",
-					"color": "#ffb868",
-					"filters_json": json.dumps({"company": company.name, "account": bank_account}),
-					"source": "Account Balance Timeline",
-					"chart_type": "Custom",
-					"timeseries": 1,
-					"owner": "Administrator",
-					"type": "Line"
-				},
-				{
-					"doctype": "Dashboard Chart",
-					"time_interval": "Monthly",
-					"name": "Incoming Bills (Purchase Invoice)",
-					"chart_name": "Incoming Bills (Purchase Invoice)",
-					"timespan": "Last Year",
-					"color": "#a83333",
-					"value_based_on": "base_grand_total",
-					"filters_json": json.dumps({}),
-					"chart_type": "Sum",
-					"timeseries": 1,
-					"based_on": "posting_date",
-					"owner": "Administrator",
-					"document_type": "Purchase Invoice",
-					"type": "Bar"
-				},
-				{
-					"doctype": "Dashboard Chart",
-					"time_interval": "Monthly",
-					"name": "Outgoing Bills (Sales Invoice)",
-					"chart_name": "Outgoing Bills (Sales Invoice)",
-					"timespan": "Last Year",
-					"color": "#7b933d",
-					"value_based_on": "base_grand_total",
-					"filters_json": json.dumps({}),
-					"chart_type": "Sum",
-					"timeseries": 1,
-					"based_on": "posting_date",
-					"owner": "Administrator",
-					"document_type": "Sales Invoice",
-					"type": "Bar"
-				}
-			]
+	charts = [
+		{
+			"doctype": "Dashboard Chart",
+			"time_interval": "Quarterly",
+			"name": "Income",
+			"chart_name": "Income",
+			"timespan": "Last Year",
+			"color": None,
+			"filters_json": json.dumps({"company": company.name, "account": income_account}),
+			"source": "Account Balance Timeline",
+			"chart_type": "Custom",
+			"timeseries": 1,
+			"owner": "Administrator",
+			"type": "Line"
+		},
+		{
+			"doctype": "Dashboard Chart",
+			"time_interval": "Quarterly",
+			"name": "Expenses",
+			"chart_name": "Expenses",
+			"timespan": "Last Year",
+			"color": None,
+			"filters_json": json.dumps({"company": company.name, "account": expense_account}),
+			"source": "Account Balance Timeline",
+			"chart_type": "Custom",
+			"timeseries": 1,
+			"owner": "Administrator",
+			"type": "Line"
+		},
+		{
+			"doctype": "Dashboard Chart",
+			"time_interval": "Quarterly",
+			"name": "Bank Balance",
+			"chart_name": "Bank Balance",
+			"timespan": "Last Year",
+			"color": "#ffb868",
+			"filters_json": json.dumps({"company": company.name, "account": bank_account}),
+			"source": "Account Balance Timeline",
+			"chart_type": "Custom",
+			"timeseries": 1,
+			"owner": "Administrator",
+			"type": "Line"
+		},
+		{
+			"doctype": "Dashboard Chart",
+			"time_interval": "Monthly",
+			"name": "Incoming Bills (Purchase Invoice)",
+			"chart_name": "Incoming Bills (Purchase Invoice)",
+			"timespan": "Last Year",
+			"color": "#a83333",
+			"value_based_on": "base_grand_total",
+			"filters_json": json.dumps({}),
+			"chart_type": "Sum",
+			"timeseries": 1,
+			"based_on": "posting_date",
+			"owner": "Administrator",
+			"document_type": "Purchase Invoice",
+			"type": "Bar"
+		},
+		{
+			"doctype": "Dashboard Chart",
+			"time_interval": "Monthly",
+			"name": "Outgoing Bills (Sales Invoice)",
+			"chart_name": "Outgoing Bills (Sales Invoice)",
+			"timespan": "Last Year",
+			"color": "#7b933d",
+			"value_based_on": "base_grand_total",
+			"filters_json": json.dumps({}),
+			"chart_type": "Sum",
+			"timeseries": 1,
+			"based_on": "posting_date",
+			"owner": "Administrator",
+			"document_type": "Sales Invoice",
+			"type": "Bar"
+		}
+	]
 
 	return charts
 


### PR DESCRIPTION
system tries to setup dashboard on fresh install and fails because company is not set.

fixes: #21669 