### PR TITLE
fix(patch): use translated string while setting notification template

### DIFF
--- a/erpnext/patches/v11_0/set_default_email_template_in_hr.py
+++ b/erpnext/patches/v11_0/set_default_email_template_in_hr.py
@@ -1,8 +1,9 @@
 from __future__ import unicode_literals
+from frappe import _
 import frappe
 
 def execute():
 	hr_settings = frappe.get_single("HR Settings")
-	hr_settings.leave_approval_notification_template = "Leave Approval Notification"
-	hr_settings.leave_status_notification_template = "Leave Status Notification"
+	hr_settings.leave_approval_notification_template = _("Leave Approval Notification")
+	hr_settings.leave_status_notification_template = _("Leave Status Notification")
 	hr_settings.save()


### PR DESCRIPTION
backport of https://github.com/frappe/erpnext/pull/21679
when using language other than english

`frappe.exceptions.LinkValidationError: Could not find Leave Approval Notification Template: Leave Approval Notification, Leave Status Notification Template: Leave Status Notification`