### PR TITLE
fix: user not able to view product

### DIFF
--- a/erpnext/shopping_cart/product_info.py
+++ b/erpnext/shopping_cart/product_info.py
@@ -10,14 +10,16 @@ from erpnext.shopping_cart.doctype.shopping_cart_settings.shopping_cart_settings
 from erpnext.utilities.product import get_price, get_qty_in_stock, get_non_stock_item_status
 
 @frappe.whitelist(allow_guest=True)
-def get_product_info_for_website(item_code):
+def get_product_info_for_website(item_code, skip_quotation_creation=False):
 	"""get product price / stock info for website"""
 
 	cart_settings = get_shopping_cart_settings()
 	if not cart_settings.enabled:
 		return frappe._dict()
 
-	cart_quotation = _get_cart_quotation()
+	cart_quotation = frappe._dict()
+	if not skip_quotation_creation:
+		cart_quotation = _get_cart_quotation()
 
 	price = get_price(
 		item_code,
@@ -51,7 +53,7 @@ def get_product_info_for_website(item_code):
 
 def set_product_info_for_website(item):
 	"""set product price uom for website"""
-	product_info = get_product_info_for_website(item.item_code)
+	product_info = get_product_info_for_website(item.item_code, skip_quotation_creation=True)
 
 	if product_info:
 		item.update(product_info)

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -467,7 +467,7 @@ class Item(WebsiteGenerator):
 
 	def set_shopping_cart_data(self, context):
 		from erpnext.shopping_cart.product_info import get_product_info_for_website
-		context.shopping_cart = get_product_info_for_website(self.name)
+		context.shopping_cart = get_product_info_for_website(self.name, skip_quotation_creation=True)
 
 	def add_default_uom_in_conversion_factor_table(self):
 		uom_conv_list = [d.uom for d in self.get("uoms")]


### PR DESCRIPTION
**Issue**

When user is trying to view the product in website view, system throwing the below error

![image](https://user-images.githubusercontent.com/8780500/81652575-9584ed80-9451-11ea-8679-0c08338f9b1a.png)

After debugging the issue, came to know about below issue

1. User has set the paypal as payment gateway in the Shopping Cart Settings, which has currency USD

1. If not logged in then system tries to fetch the debtor account in USD currency and if the account not found then system creates the new debtor account. But as the user has not logged in yet, system tries to create the new account and failed due to insufficient permission.

**Fix**
1) Should use company currency to fetch the debtor account and not payment gateway account
1) Also skip quotation creation while searching products