### PR TITLE
chore: drop python 2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,20 +14,9 @@ addons:
 
 jobs:
   include:
-  - name: "Python 2.7 Server Side Test"
-    python: 2.7
-    script: bench --site test_site run-tests --app erpnext --coverage
-
   - name: "Python 3.6 Server Side Test"
     python: 3.6
     script: bench --site test_site run-tests --app erpnext --coverage
-
-  - name: "Python 2.7 Patch Test"
-    python: 2.7
-    before_script:
-      - wget http://build.erpnext.com/20171108_190013_955977f8_database.sql.gz
-      - bench --site test_site --force restore ~/frappe-bench/20171108_190013_955977f8_database.sql.gz
-    script: bench --site test_site migrate
 
   - name: "Python 3.6 Patch Test"
     python: 3.6


### PR DESCRIPTION
drop Python2 support
https://discuss.erpnext.com/t/dropping-python-2-support-for-frappe-framework/61159