### PR TITLE
fix: typo in error message in loan_security_pledge.py

### DIFF
--- a/erpnext/loan_management/doctype/loan_security_pledge/loan_security_pledge.py
+++ b/erpnext/loan_management/doctype/loan_security_pledge/loan_security_pledge.py
@@ -38,7 +38,7 @@ class LoanSecurityPledge(Document):
 		for pledge in self.securities:
 
 			if not pledge.qty and not pledge.amount:
-				frappe.throw(_("Qty or Amount is mandatroy for loan security"))
+				frappe.throw(_("Qty or Amount is mandatory for loan security!"))
 
 			if not (self.loan_application and pledge.loan_security_price):
 				pledge.loan_security_price = get_loan_security_price(pledge.loan_security)


### PR DESCRIPTION
![Screenshot 2020-05-12 at 7 10 30 PM](https://user-images.githubusercontent.com/15175501/81698902-41473100-9484-11ea-9150-7ed22d962ebb.png)
