### PR TITLE
chore: Drop Python2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
-dist: trusty
-
 language: python
+dist: trusty
 
 git:
   depth: 1
@@ -14,20 +13,9 @@ addons:
 
 jobs:
   include:
-  - name: "Python 2.7 Server Side Test"
-    python: 2.7
-    script: bench --site test_site run-tests --app erpnext --coverage
-
   - name: "Python 3.6 Server Side Test"
     python: 3.6
     script: bench --site test_site run-tests --app erpnext --coverage
-
-  - name: "Python 2.7 Patch Test"
-    python: 2.7
-    before_script:
-      - wget http://build.erpnext.com/20171108_190013_955977f8_database.sql.gz
-      - bench --site test_site --force restore ~/frappe-bench/20171108_190013_955977f8_database.sql.gz
-    script: bench --site test_site migrate
 
   - name: "Python 3.6 Patch Test"
     python: 3.6
@@ -40,8 +28,7 @@ install:
   - cd ~
   - nvm install 10
 
-  - git clone https://github.com/frappe/bench --depth 1
-  - pip install -e ./bench
+  - pip install frappe-bench
 
   - git clone https://github.com/frappe/frappe --branch $TRAVIS_BRANCH --depth 1
   - bench init --skip-assets --frappe-path ~/frappe --python $(which python) frappe-bench

--- a/erpnext/setup/doctype/company/test_company.py
+++ b/erpnext/setup/doctype/company/test_company.py
@@ -47,9 +47,7 @@ class TestCompany(unittest.TestCase):
 		frappe.delete_doc("Company", "COA from Existing Company")
 
 	def test_coa_based_on_country_template(self):
-		countries = ["India", "Brazil", "United Arab Emirates", "Canada", "Germany", "France",
-			"Guatemala", "Indonesia", "Italy", "Mexico", "Nicaragua", "Netherlands", "Singapore",
-			"Brazil", "Argentina", "Hungary", "Taiwan"]
+		countries = ["Canada", "Germany", "France"]
 
 		for country in countries:
 			templates = get_charts_for_country(country)


### PR DESCRIPTION
- Drop Python2 support.
https://discuss.erpnext.com/t/dropping-python-2-support-for-frappe-framework/61159

- Make tests faster by removing test redundancy.

**Before:**
<img width="996" alt="Screenshot 2020-05-12 at 9 34 49 PM" src="https://user-images.githubusercontent.com/13928957/81718517-7316c280-9499-11ea-8dea-eaa1ebed3fde.png">

**After:**
<img width="981" alt="Screenshot 2020-05-12 at 9 49 32 PM" src="https://user-images.githubusercontent.com/13928957/81719348-968e3d00-949a-11ea-8fbb-9cea3e9659da.png">
