### PR TITLE
fix: Add total rows in Report Purchase Order Items to be Received or Billed

### DIFF
--- a/erpnext/stock/report/purchase_order_items_to_be_received_or_billed/purchase_order_items_to_be_received_or_billed.json
+++ b/erpnext/stock/report/purchase_order_items_to_be_received_or_billed/purchase_order_items_to_be_received_or_billed.json
@@ -1,5 +1,5 @@
 {
- "add_total_row": 0,
+ "add_total_row": 1,
  "creation": "2019-09-16 14:10:33.102865",
  "disable_prepared_report": 0,
  "disabled": 0,
@@ -7,7 +7,7 @@
  "doctype": "Report",
  "idx": 0,
  "is_standard": "Yes",
- "modified": "2019-09-21 15:19:55.710578",
+ "modified": "2020-05-13 15:27:45.228418",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Purchase Order Items To Be Received or Billed",


### PR DESCRIPTION
Added only on hotfix as this report is replaced on developed.

![Screenshot 2020-05-13 at 3 30 12 PM](https://user-images.githubusercontent.com/25857446/81799814-82484f80-952f-11ea-95b4-53c5bf7e278b.png)
