### PR TITLE
fix: incorrect stock valuation for repack entry

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -363,6 +363,9 @@ class StockEntry(StockController):
 					+ self.work_order + ":" + ", ".join(other_ste), DuplicateEntryForWorkOrderError)
 
 	def set_incoming_rate(self):
+		if self.purpose == "Repack":
+			self.set_basic_rate_for_finished_goods()
+
 		for d in self.items:
 			if d.s_warehouse:
 				args = self.get_args_for_incoming_rate(d)
@@ -475,20 +478,31 @@ class StockEntry(StockController):
 			"allow_zero_valuation": item.allow_zero_valuation_rate,
 		})
 
-	def set_basic_rate_for_finished_goods(self, raw_material_cost, scrap_material_cost):
+	def set_basic_rate_for_finished_goods(self, raw_material_cost=0, scrap_material_cost=0):
+		total_fg_qty = 0
+		if not raw_material_cost and self.get("items"):
+			raw_material_cost = sum([flt(row.basic_amount) for row in self.items
+				if row.s_warehouse and not row.t_warehouse])
+
+			total_fg_qty = sum([flt(row.qty) for row in self.items
+				if row.t_warehouse and not row.s_warehouse])
+
 		if self.purpose in ["Manufacture", "Repack"]:
 			for d in self.get("items"):
 				if (d.transfer_qty and (d.bom_no or d.t_warehouse)
 					and (getattr(self, "pro_doc", frappe._dict()).scrap_warehouse != d.t_warehouse)):
 
-					if self.work_order \
-						and frappe.db.get_single_value("Manufacturing Settings", "material_consumption"):
+					if (self.work_order and self.purpose == "Manufacture"
+						and frappe.db.get_single_value("Manufacturing Settings", "material_consumption")):
 						bom_items = self.get_bom_raw_materials(d.transfer_qty)
 						raw_material_cost = sum([flt(row.qty)*flt(row.rate) for row in bom_items.values()])
 
-					if raw_material_cost:
+					if raw_material_cost and self.purpose == "Manufacture":
 						d.basic_rate = flt((raw_material_cost - scrap_material_cost) / flt(d.transfer_qty), d.precision("basic_rate"))
 						d.basic_amount = flt((raw_material_cost - scrap_material_cost), d.precision("basic_amount"))
+					elif self.purpose == "Repack" and total_fg_qty:
+						d.basic_rate = flt(raw_material_cost) / flt(total_fg_qty)
+						d.basic_amount = d.basic_rate * d.qty
 
 	def distribute_additional_costs(self):
 		if self.purpose == "Material Issue":


### PR DESCRIPTION
**Issue**

Example, I bought 2 dates fruits harvest from 2 farms 1000 KG @ USD 2.5 and 1000 KG @ 3 USD and Carton 5KG Boxes at 0.50 USD and used these to sort my dates fruits and repackage 3 new items Dates Quality 1 - 5KG Boxes (1200KG), Dates Quality 2 - 5 KG Boxes (500 KG), Dates Quality 3 - 5 KG Boxes (300KG).

Ideally the system shall have an out going value = (1000 X 2.5) + (1000X3) + (400X0.50)= USD 5700 which is done correctly in the system.

The incoming value must be 5700USD/2000KG=USD2.85/KG and thus I will have three incoming items as follows:
Quality 1 = 1200 X 2.85 = 3420
Quality 2 = 500 X 2.85 = 1425
Quality 3 = 300 X 2.85 = 855
Total = 5700 with no stock value difference.

But the system instead works out each line item to equal the total of 5700
Quality 1 = 1200 X 4.75 = 5700
Quality 2 = 500 X 11.4 = 5700
Quality 3 = 300 X 19 = 5700
Total incoming = 17100 with stock difference =11400

**After Fix**

Equally divided raw materials cost among the finished goods
