### PR TITLE
fix: Other taxes and charges check

### DIFF
--- a/erpnext/hr/doctype/salary_slip/salary_slip.py
+++ b/erpnext/hr/doctype/salary_slip/salary_slip.py
@@ -776,10 +776,10 @@ class SalarySlip(TransactionBase):
 
 		# other taxes and charges on income tax
 		for d in tax_slab.other_taxes_and_charges:
-			if flt(d.min_taxable_income) and flt(d.min_taxable_income) > tax_amount:
+			if flt(d.min_taxable_income) and flt(d.min_taxable_income) > annual_taxable_earning:
 				continue
 
-			if flt(d.max_taxable_income) and flt(d.max_taxable_income) < tax_amount:
+			if flt(d.max_taxable_income) and flt(d.max_taxable_income) < annual_taxable_earning:
 				continue
 			
 			tax_amount += tax_amount * flt(d.percent) / 100


### PR DESCRIPTION
Currently other taxes and charges check is being done based on the tax_amount value which is incorrect. The correct check should be based on annual_taxable_earning value. The use case is when Surcharge needs to be levied on employees with annual_taxable_earning more than 50,000,000.

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
