### PR TITLE
fix: tax id is not fetched when creating sales order from quotation

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.json
+++ b/erpnext/selling/doctype/sales_order/sales_order.json
@@ -282,6 +282,7 @@
    "width": "100px"
   },
   {
+   "fetch_from": "customer.tax_id",
    "fieldname": "tax_id",
    "fieldtype": "Data",
    "label": "Tax Id",
@@ -1196,7 +1197,7 @@
  "idx": 105,
  "is_submittable": 1,
  "links": [],
- "modified": "2020-04-17 12:50:39.640534",
+ "modified": "2020-05-19 21:36:57.437325",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order",


### PR DESCRIPTION
Issue -
![A0xVW0w](https://user-images.githubusercontent.com/20715976/82330467-83cab980-9a00-11ea-9e6a-30ad40c0652f.gif)
