### PR TITLE
fix: make tax and total debited on deduct in sales invoice on gl_ledger Creation

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -798,13 +798,15 @@ class SalesInvoice(SellingController):
 		for tax in self.get("taxes"):
 			if flt(tax.base_tax_amount_after_discount_amount):
 				account_currency = get_account_currency(tax.account_head)
+				dr_or_cr = "credit" if tax.add_deduct_tax == "Add" else "debit"
+
 				gl_entries.append(
 					self.get_gl_dict({
 						"account": tax.account_head,
 						"against": self.customer,
-						"credit": flt(tax.base_tax_amount_after_discount_amount,
+						dr_or_cr: flt(tax.base_tax_amount_after_discount_amount,
 							tax.precision("tax_amount_after_discount_amount")),
-						"credit_in_account_currency": (flt(tax.base_tax_amount_after_discount_amount,
+						dr_or_cr + "_in_account_currency": (flt(tax.base_tax_amount_after_discount_amount,
 							tax.precision("base_tax_amount_after_discount_amount")) if account_currency==self.company_currency else
 							flt(tax.tax_amount_after_discount_amount, tax.precision("tax_amount_after_discount_amount"))),
 						"cost_center": tax.cost_center

--- a/erpnext/accounts/doctype/sales_taxes_and_charges/sales_taxes_and_charges.json
+++ b/erpnext/accounts/doctype/sales_taxes_and_charges/sales_taxes_and_charges.json
@@ -192,11 +192,26 @@
   {
    "fieldname": "dimension_col_break",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "category",
+   "fieldtype": "Select",
+   "label": "Consider Tax or Charge for",
+   "options": "Total",
+   "reqd": 1
+  },
+  {
+   "fieldname": "add_deduct_tax",
+   "fieldtype": "Select",
+   "label": "Add or Deduct",
+   "options": "Add\nDeduct",
+   "reqd": 1
   }
  ],
  "idx": 1,
  "istable": 1,
- "modified": "2019-05-25 22:59:38.740883",
+ "links": [],
+ "modified": "2020-05-19 03:31:26.950640",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Taxes and Charges",


### PR DESCRIPTION
 PR  Depends on https://github.com/frappe/erpnext/pull/21636

Problem : on Add_deduct_tax == "Deduct". It try to create gl_ledger. in round off function debit-credit should be zero. but when we deduct it give debit-credit give not zero result.

solve:
Added on Add we credit the amount and on deduct we debit the amount. that logic wrote in sales invoice.

before:
![Peek 2020-05-19 18-49](https://user-images.githubusercontent.com/6947417/82331296-8ed21980-9a01-11ea-9bbf-abf6bd0dfec3.gif)

after:
![Peek 2020-05-19 18-47](https://user-images.githubusercontent.com/6947417/82331287-8b3e9280-9a01-11ea-92bf-6a2f1fad0bf0.gif)
