### PR TITLE
fix: Validate Payment Gateway only if it exists in Payment Request.

### DIFF
--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -69,7 +69,7 @@ class PaymentRequest(Document):
 		elif self.payment_request_type == 'Inward':
 			self.db_set('status', 'Requested')
 
-		send_mail = self.payment_gateway_validation()
+		send_mail = self.payment_gateway_validation() if self.payment_gateway else None
 		ref_doc = frappe.get_doc(self.reference_doctype, self.reference_name)
 
 		if (hasattr(ref_doc, "order_type") and getattr(ref_doc, "order_type") == "Shopping Cart") \


### PR DESCRIPTION
- On submitting Payment Request if Payment Gateway Account was left blank, this appeared:
![Screenshot 2020-05-20 at 3 05 28 PM](https://user-images.githubusercontent.com/25857446/82430655-4111eb80-9aab-11ea-8e81-77c63b9266cf.png)

**After Fix:**
- Only validate Payment Gateway Account if it exists in the Payment Request.