### PR TITLE
fix: plc conversion rate set infinitely

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.js
+++ b/erpnext/manufacturing/doctype/bom/bom.js
@@ -265,7 +265,7 @@ erpnext.bom.BomController = erpnext.TransactionController.extend({
 
 	plc_conversion_rate: function(doc) {
 		if (!this.in_apply_price_list) {
-			this.apply_price_list();
+			this.apply_price_list(null, true);
 		}
 	},
 


### PR DESCRIPTION
- `plc_conversion_rate` calls `apply_price_list` which calls `plc_conversion_rate in a loop`.