### PR TITLE
fix: website_list_for_contact, fix changed frappe.db.exist keyword argument

### DIFF
--- a/erpnext/controllers/website_list_for_contact.py
+++ b/erpnext/controllers/website_list_for_contact.py
@@ -155,7 +155,7 @@ def has_website_permission(doc, ptype, user, verbose=False):
 		return frappe.db.exists(doctype, get_customer_filter(doc, customers))
 	elif suppliers:
 		fieldname = 'suppliers' if doctype == 'Request for Quotation' else 'supplier'
-		return frappe.db.exists(doctype, filters={
+		return frappe.db.exists(doctype, {
 			'name': doc.name,
 			fieldname: ["in", suppliers]
 		})


### PR DESCRIPTION
frappe.db.exists takes two arguments 'dt' and 'dn'. It no longer takes an argument 'filters'. This broken call in website_list_for_contact.py causes an exception which (somehow) causes authentication success instead of failure when viewing documents through the portal.

There are additional issues with this function, but those need additional thought and consideration and this part should be fixed ASAP.