### PR TITLE
fix: Post Dated unallocated amount not considered in Advance Amount in AR/AP summary

### DIFF
--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -602,10 +602,14 @@ def get_party_shipping_address(doctype, name):
 	else:
 		return ''
 
-def get_partywise_advanced_payment_amount(party_type, posting_date = None, company=None):
+def get_partywise_advanced_payment_amount(party_type, posting_date = None, future_payment=0, company=None):
 	cond = "1=1"
 	if posting_date:
-		cond = "posting_date <= '{0}'".format(posting_date)
+		if future_payment:
+			cond = "DATE(creation) <= '{0}'".format(posting_date)
+		else:
+			cond = "posting_date <= '{0}'".format(posting_date)
+
 	if company:
 		cond += "and company = '{0}'".format(company)
 

--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -618,7 +618,7 @@ def get_partywise_advanced_payment_amount(party_type, posting_date = None, futur
 		WHERE
 			party_type = %s and against_voucher is null
 			and {1} GROUP BY party"""
-		.format(("credit") if party_type == "Customer" else "debit", cond) , party_type, debug=1)
+		.format(("credit") if party_type == "Customer" else "debit", cond) , party_type)
 
 	if data:
 		return frappe._dict(data)

--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -606,7 +606,7 @@ def get_partywise_advanced_payment_amount(party_type, posting_date = None, futur
 	cond = "1=1"
 	if posting_date:
 		if future_payment:
-			cond = "DATE(creation) <= '{0}'".format(posting_date)
+			cond = "posting_date <= '{0}' OR DATE(creation) <= '{0}' """.format(posting_date)
 		else:
 			cond = "posting_date <= '{0}'".format(posting_date)
 
@@ -618,7 +618,7 @@ def get_partywise_advanced_payment_amount(party_type, posting_date = None, futur
 		WHERE
 			party_type = %s and against_voucher is null
 			and {1} GROUP BY party"""
-		.format(("credit") if party_type == "Customer" else "debit", cond) , party_type)
+		.format(("credit") if party_type == "Customer" else "debit", cond) , party_type, debug=1)
 
 	if data:
 		return frappe._dict(data)

--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -583,7 +583,7 @@ class ReceivablePayableReport(object):
 				and (party is not null and party != '')
 				and posting_date <= %s
 				{1} {2} {3}"""
-			.format(select_fields, conditions, future_payment_condition, order_by), values, as_dict=True, debug=1)
+			.format(select_fields, conditions, future_payment_condition, order_by), values, as_dict=True)
 
 	def get_sales_invoices_or_customers_based_on_sales_person(self):
 		if self.filters.get("sales_person"):

--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -559,12 +559,13 @@ class ReceivablePayableReport(object):
 		conditions, values = self.prepare_conditions()
 		order_by = self.get_order_by_condition()
 
-		future_payment_condition = ''
 		if self.filters.show_future_payments:
-			values.extend([self.party_type, self.filters.report_date, self.filters.report_date])
+			values.insert(2, self.filters.report_date)
 
-			future_payment_condition = """ OR (docstatus < 2 and party_type = %s
-			AND against_voucher IS NULL AND posting_date > %s and DATE(creation) <= %s)"""
+			date_condition = """AND (posting_date <= %s
+				OR (against_voucher IS NULL AND DATE(creation) <= %s))"""
+		else:
+			date_condition = "AND posting_date <=%s"
 
 		if self.filters.get(scrub(self.party_type)):
 			select_fields = "debit_in_account_currency as debit, credit_in_account_currency as credit"
@@ -581,9 +582,8 @@ class ReceivablePayableReport(object):
 				docstatus < 2
 				and party_type=%s
 				and (party is not null and party != '')
-				and posting_date <= %s
 				{1} {2} {3}"""
-			.format(select_fields, conditions, future_payment_condition, order_by), values, as_dict=True)
+			.format(select_fields, date_condition, conditions, order_by), values, as_dict=True)
 
 	def get_sales_invoices_or_customers_based_on_sales_person(self):
 		if self.filters.get("sales_person"):

--- a/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js
+++ b/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js
@@ -111,7 +111,12 @@ frappe.query_reports["Accounts Receivable Summary"] = {
 			"fieldname":"based_on_payment_terms",
 			"label": __("Based On Payment Terms"),
 			"fieldtype": "Check",
-		}
+		},
+		{
+			"fieldname":"show_future_payments",
+			"label": __("Show Future Payments"),
+			"fieldtype": "Check",
+		},
 	],
 
 	onload: function(report) {

--- a/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py
+++ b/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py
@@ -33,7 +33,7 @@ class AccountsReceivableSummary(ReceivablePayableReport):
 		self.get_party_total(args)
 
 		party_advance_amount = get_partywise_advanced_payment_amount(self.party_type,
-			company=self.filters.company) or {}
+			self.filters.report_date, self.filters.show_future_payments, self.filters.company) or {}
 
 		for party, party_dict in iteritems(self.party_total):
 			if party_dict.outstanding == 0:

--- a/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py
+++ b/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py
@@ -33,7 +33,7 @@ class AccountsReceivableSummary(ReceivablePayableReport):
 		self.get_party_total(args)
 
 		party_advance_amount = get_partywise_advanced_payment_amount(self.party_type,
-			self.filters.report_date, self.filters.company) or {}
+			company=self.filters.company) or {}
 
 		for party, party_dict in iteritems(self.party_total):
 			if party_dict.outstanding == 0:


### PR DESCRIPTION
If Advance Payment Entry date is after report date then that amount is not captured as Advance Amount in AR/AP summary