### PR TITLE
fix: expense account error message in DN

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -226,7 +226,7 @@ class StockController(AccountsController):
 
 	def check_expense_account(self, item):
 		if not item.get("expense_account"):
-			frappe.throw(_("Expense or Difference account is mandatory for Item {0} as it impacts overall stock value").format(item.item_code))
+			frappe.throw(_("Expense Account not set for Item {0}. Please set an Expense Account for the item in the Items table").format(item.item_code))
 
 		else:
 			is_expense_account = frappe.db.get_value("Account",


### PR DESCRIPTION
Changed error message if expense account not set for item in Delivery Note.
**Earlier:** Expense or Difference account is mandatory for Item IT - 6 as it impacts overall stock value
**After fix:** Expense Account not set for Item IT - 6. Please set an Expense Account for the item in the Items table

Note: Item - 6 is an example