### PR TITLE
fix: allow on submit for the delivery date field not working for sale…

### DIFF
--- a/erpnext/selling/doctype/sales_order_item/sales_order_item.json
+++ b/erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -150,6 +150,7 @@
    "width": "300px"
   },
   {
+   "allow_on_submit": 1,
    "columns": 2,
    "depends_on": "eval: !parent.skip_delivery_note",
    "fieldname": "delivery_date",
@@ -757,8 +758,7 @@
  ],
  "idx": 1,
  "istable": 1,
- "links": [],
- "modified": "2020-03-05 14:20:28.085117",
+ "modified": "2020-05-22 12:40:01.696076",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order Item",


### PR DESCRIPTION
Allow on submit property has enabled for the field Delivery Date in the sales order but not in the sales order item. Now when user change the delivery date on sales order after submission then system reset the delivery date based upon the date set in the child table