### PR TITLE
fix: WIP do not merge - Early attempt to fix website_list_for_contact.py

### DIFF
--- a/erpnext/controllers/website_list_for_contact.py
+++ b/erpnext/controllers/website_list_for_contact.py
@@ -2,6 +2,7 @@
 # License: GNU General Public License v3. See license.txt
 
 from __future__ import unicode_literals
+import operator
 import json
 import frappe
 from frappe import _
@@ -19,42 +20,91 @@ def get_list_context(context=None):
 	}
 
 
-def get_transaction_list(doctype, txt=None, filters=None, limit_start=0, limit_page_length=20, order_by="modified"):
+def get_transaction_list(doctype, txt=None, filters=None, limit_start=0, limit_page_length=20, order_by="not_implemented"):
+	"""Returns a list of transactions for doctype 'doctype' based on contact-linked permissions.
+
+	Arguments:
+		doctype - DocType to query
+		txt - Optional search string
+		filters - Optional additional filters
+		limit_start - Starting index of item when using limit_page_length (default 0)
+		limit_page_length - Maximum number of items to return (default 20)
+		order_by - Not implemented
+	"""
 	user = frappe.session.user
 	ignore_permissions = False
 
-	if not filters: filters = []
+	if not filters:
+		filters = []
+	customer_filters = []
+	supplier_filters = []
 
 	if doctype in ['Supplier Quotation', 'Purchase Invoice']:
 		filters.append((doctype, 'docstatus', '<', 2))
 	else:
 		filters.append((doctype, 'docstatus', '=', 1))
 
-	if (user != 'Guest' and is_website_user()) or doctype == 'Request for Quotation':
-		parties_doctype = 'Request for Quotation Supplier' if doctype == 'Request for Quotation' else doctype
-		# find party for this contact
-		customers, suppliers = get_customers_suppliers(parties_doctype, user)
+	# If we have read access on this doctype, we return all results
+	if frappe.has_permission(doctype, 'read', user):
+		transactions = get_list_for_transactions(
+			doctype, txt, filters, limit_start, limit_page_length, fields='name',
+			ignore_permissions=True, order_by='modified desc')
+		return post_process(doctype, transactions)
 
-		if customers:
-			if doctype == 'Quotation':
-				filters.append(('quotation_to', '=', 'Customer'))
-				filters.append(('party_name', 'in', customers))
-			else:
-				filters.append(('customer', 'in', customers))
-		elif suppliers:
-			filters.append(('supplier', 'in', suppliers))
+	# Otherwise, we limit results to ones linked by contacts or suppliers
+	# Return empty list except for Request for Quotation
+	if (user == 'Guest') and (doctype != 'Request for Quotation'):
+		return []
+
+	parties_doctype = 'Request for Quotation Supplier' if doctype == 'Request for Quotation' else doctype
+	# find party for this contact
+	customers, suppliers = get_customers_suppliers(parties_doctype, user)
+
+	if not (customers or suppliers):
+		# No customers or suppliers linked, so return empty list
+		return []
+	if customers:
+		if doctype == 'Quotation':
+			customer_filters.append(('quotation_to', '=', 'Customer'))
+			customer_filters.append(('party_name', 'in', customers))
 		else:
-			return []
+			customer_filters.append(('customer', 'in', customers))
+	if suppliers:
+		supplier_filters.append(('supplier', 'in', suppliers))
 
-		if doctype == 'Request for Quotation':
-			parties = customers or suppliers
-			return rfq_transaction_list(parties_doctype, doctype, parties, limit_start, limit_page_length)
+	# TODO - make this bit make sense
+	if doctype == 'Request for Quotation':
+		parties = customers or suppliers
+		return rfq_transaction_list(parties, limit_start, limit_page_length)
 
-		# Since customers and supplier do not have direct access to internal doctypes
-		ignore_permissions = True
+	# Since customers and supplier do not have direct access to internal doctypes
+	ignore_permissions = True
 
-	transactions = get_list_for_transactions(doctype, txt, filters, limit_start, limit_page_length,
-		fields='name', ignore_permissions=ignore_permissions, order_by='modified desc')
+	transactions = []
+	customer_doc_names = set()
+	# If we are linked by customers or suppliers, then we search without getting permissions.
+	if customers:
+		# Get transactions linked by Customer
+		transactions = get_list_for_transactions(
+			doctype, txt, filters + customer_filters, limit_start, limit_page_length, fields='name',
+			ignore_permissions=True, order_by='modified desc')
+	if suppliers:
+		# Get transactions linked by Supplier
+		supplier_transactions = get_list_for_transactions(
+			doctype, txt, filters + supplier_filters, limit_start, limit_page_length,
+			fields='name', ignore_permissions=True, order_by='modified desc')
+	if customers and suppliers:
+		# Combine customer and supplier documents
+		customer_doc_names = {d.name for d in transactions}
+		# Filter to remove duplicates
+		for transaction in supplier_transactions:
+			if transaction.name not in customer_doc_names:
+				transactions.append(transaction)
+		# Sort by modified
+		transactions.sort(key=operator.attrgetter('modified'))
+	elif suppliers:
+		# No customers
+		transactions = supplier_transactions
 
 	return post_process(doctype, transactions)
 
@@ -66,10 +116,12 @@ def get_list_for_transactions(doctype, txt, filters, limit_start, limit_page_len
 	data = []
 	or_filters = []
 
-	for d in get_list(doctype, txt, filters=filters, fields="name", limit_start=limit_start,
-		limit_page_length=limit_page_length, ignore_permissions=ignore_permissions, order_by="modified desc"):
+	for d in get_list(doctype, txt, filters=filters, fields=["name", "modified"], limit_start=limit_start,
+		limit_page_length=limit_page_length, ignore_permissions=ignore_permissions, order_by=order_by):
 		data.append(d)
 
+	# TODO - remove the rest of this code if it doesn't actually do anything?
+	# What is it supposed to do?
 	if txt:
 		if meta.get_field('items'):
 			if meta.get_field('items').options:
@@ -79,19 +131,25 @@ def get_list_for_transactions(doctype, txt, filters, limit_start, limit_page_len
 					or_filters.append([doctype, "name", "=", child.parent])
 
 	if or_filters:
-		for r in frappe.get_list(doctype, fields=fields,filters=filters, or_filters=or_filters,
-			limit_start=limit_start, limit_page_length=limit_page_length,
-			ignore_permissions=ignore_permissions, order_by=order_by):
+		for r in frappe.get_list(doctype, fields=fields + ['modified'], filters=filters,
+				or_filters=or_filters, limit_start=limit_start,
+				limit_page_length=limit_page_length, ignore_permissions=ignore_permissions,
+				order_by=order_by):
 			data.append(r)
 
 	return data
 
-def rfq_transaction_list(parties_doctype, doctype, parties, limit_start, limit_page_length):
-	data = frappe.db.sql("""select distinct parent as name, supplier from `tab{doctype}`
-			where supplier = '{supplier}' and docstatus=1  order by modified desc limit {start}, {len}""".
-			format(doctype=parties_doctype, supplier=parties[0], start=limit_start, len = limit_page_length), as_dict=1)
+def rfq_transaction_list(parties, limit_start, limit_page_length):
+	# TODO - check all of this
+	data = frappe.db.sql(
+		"""select distinct parent as name, supplier from `tabRequest for Quotation Supplier`
+		where supplier = %(supplier)s and docstatus=1
+		order by modified desc limit %(start)s, %(len)s""",
+		{'supplier': parties[0], 'start': frappe.cint(limit_start),
+			'len': frappe.cint(limit_page_length)},
+		as_dict=1)
 
-	return post_process(doctype, data)
+	return post_process('Request for Quotation', data)
 
 def post_process(doctype, data):
 	result = []
@@ -119,50 +177,68 @@ def post_process(doctype, data):
 	return result
 
 def get_customers_suppliers(doctype, user):
+	"""Returns a list of customers and suppliers linked, by user->contact,
+	to documents of DocType 'doctype', for User 'user'.
+	"""
+	roles = frappe.get_roles(user)
 	customers = []
 	suppliers = []
 	meta = frappe.get_meta(doctype)
 
-	customer_field_name = get_customer_field_name(doctype)
+	has_customer_field = meta.has_field(get_customer_field_name(doctype))
+	has_supplier_field = meta.has_field(get_supplier_field_name(doctype))
 
-	has_customer_field = meta.has_field(customer_field_name)
-	has_supplier_field = meta.has_field('supplier')
-
-	if has_common(["Supplier", "Customer"], frappe.get_roles(user)):
+	customers = suppliers = None
+	# If the user has either the roles 'Supplier' or 'Customer', we search
+	# for contacts linked to them and linked to our target doctype
+	if has_common(["Supplier", "Customer"], roles):
 		contacts = frappe.db.sql("""
 			select
-				`tabContact`.email_id,
 				`tabDynamic Link`.link_doctype,
 				`tabDynamic Link`.link_name
 			from
 				`tabContact`, `tabDynamic Link`
 			where
-				`tabContact`.name=`tabDynamic Link`.parent and `tabContact`.email_id =%s
+				`tabContact`.name=`tabDynamic Link`.parent and `tabContact`.user = %s
 			""", user, as_dict=1)
-		customers = [c.link_name for c in contacts if c.link_doctype == 'Customer']
-		suppliers = [c.link_name for c in contacts if c.link_doctype == 'Supplier']
-	elif frappe.has_permission(doctype, 'read', user=user):
-		customer_list = frappe.get_list("Customer")
-		customers = suppliers = [customer.name for customer in customer_list]
+		# Return the list of customers and suppliers if the doctype
+		# has that field and the user has the relevant Role.
+		if has_customer_field and ("Customer" in roles):
+			customers = [c.link_name for c in contacts if c.link_doctype == 'Customer']
+		if has_supplier_field and ("Supplier" in roles):
+			suppliers = [c.link_name for c in contacts if c.link_doctype == 'Supplier']
 
-	return customers if has_customer_field else None, \
-		suppliers if has_supplier_field else None
+	return customers, suppliers
 
 def has_website_permission(doc, ptype, user, verbose=False):
+	"""Checks if the user 'user' has website permission for document 'doc'
+	based on role-based permissions or contact linking
+	permissions (for website users with either the Customer or Supplier
+	role).
+	WARNING - the 'ptype' argument is not used.
+	Returns either True, if permission given, or False, if permission denied.
+	"""
 	doctype = doc.doctype
-	customers, suppliers = get_customers_suppliers(doctype, user)
-	if customers:
-		return frappe.db.exists(doctype, get_customer_filter(doc, customers))
-	elif suppliers:
-		fieldname = 'suppliers' if doctype == 'Request for Quotation' else 'supplier'
-		return frappe.db.exists(doctype, filters={
-			'name': doc.name,
-			fieldname: ["in", suppliers]
-		})
-	else:
+	# Guest user never has permission
+	if user == 'Guest':
 		return False
+	# Check for standard permissions
+	if frappe.has_permission(doctype, 'read', user=user):
+		return True
+	# Check for linked contacts
+	customers, suppliers = get_customers_suppliers(doctype, user)
+
+	# Check if customers found
+	if customers and frappe.db.exists(doctype, get_customer_filter(doc, customers)):
+		return True
+	# Otherwise, check if suppliers found
+	if suppliers and frappe.db.exists(doctype, get_supplier_filter(doc, suppliers)):
+		return True
+	# Neither customers nor suppliers found
+	return False
 
 def get_customer_filter(doc, customers):
+	"""Return a filter dict for filtering by customer."""
 	doctype = doc.doctype
 	filters = frappe._dict()
 	filters.name = doc.name
@@ -172,7 +248,23 @@ def get_customer_filter(doc, customers):
 	return filters
 
 def get_customer_field_name(doctype):
+	"""Returns the 'Customer' field name for doctype 'doctype'."""
 	if doctype == 'Quotation':
 		return 'party_name'
 	else:
 		return 'customer'
+
+def get_supplier_filter(doc, suppliers):
+	"""Return a filter dict for filtering by supplier."""
+	doctype = doc.doctype
+	filters = frappe._dict()
+	filters.name = doc.name
+	filters[get_supplier_field_name(doctype)] = ['in', suppliers]
+
+def get_supplier_field_name(doctype):
+	"""Returns the 'Supplier' field name for doctype 'doctype'."""
+	if doctype == 'Request for Quotation':
+		# TODO - check this field
+		return 'suppliers'
+	else:
+		return 'supplier'


### PR DESCRIPTION
website_list_for_contact.py is a mess.

It's not clear what it should do, and where. It has a number of bugs*. This is an early WIP attempt at rewriting most of it. It hasn't been tested properly yet, and I haven't even looked at some of the documents it is used with (e.g. all the Quotations stuff is probably broken).
*example bugs: doesn't deal with a Supplier who is also a Customer, broken call fixed by https://github.com/frappe/erpnext/pull/21827

See this thread which started me off:
https://discuss.erpnext.com/t/restricting-website-access/61819/18

This is a _very important_ part of the code. Getting the security right here is important so that:
a) people can set sensible access control for website users and system users on the desk AND the website
b) website users see ONLY their documents in the list (unless they have been given role permissions to see all)
c) website users cannot view documents by directly typing in the URL unless they either have role permissions or are linked by a contact

I am also expecting that extra checks that the relevant portal for each doctype is actually enabled will be required to stop people seeing documents that they are linked to but the organization still doesn't want them to see. For example, there is NO CIRCUMSTANCE in which we want suppliers with accounts to be able to see POs, PINVs or PRECs, but there are other documents we _do_ want them to see. Currently I'm going to have to hack around this with extra has_website_permissions hooks.

At this point I'm just asking for comments on a) how it is _supposed_ to work and b) my approach.
For example, are you supposed to have things like read-only access to PREC on the Supplier role?