### PR TITLE
fix(UAE): Incorrect VAT rate display in Sales Invoice

### DIFF
--- a/erpnext/regional/united_arab_emirates/utils.py
+++ b/erpnext/regional/united_arab_emirates/utils.py
@@ -1,6 +1,8 @@
 from __future__ import unicode_literals
+import frappe
 from frappe.utils import flt
 from erpnext.controllers.taxes_and_totals import get_itemised_tax
+from six import iteritems
 
 def update_itemised_tax_data(doc):
 	if not doc.taxes: return
@@ -9,7 +11,14 @@ def update_itemised_tax_data(doc):
 
 	for row in doc.items:
 		tax_rate = 0.0
-		if itemised_tax.get(row.item_code):
+		item_tax_rate = frappe.parse_json(row.item_tax_rate)
+
+		# First check if tax rate is present
+		# If not then look up in item_wise_tax_detail
+		if item_tax_rate:
+			for account, rate in iteritems(item_tax_rate):
+				tax_rate += rate
+		elif itemised_tax.get(row.item_code):
 			tax_rate = sum([tax.get('tax_rate', 0) for d, tax in itemised_tax.get(row.item_code).items()])
 
 		row.tax_rate = flt(tax_rate, row.precision("tax_rate"))


### PR DESCRIPTION
If same item has different `Item Tax Template` in a single Sales Invoice then same VAT rate is displayed for both items in Sales Invoice

**Solution:**
First give preference to `item_tax_rate` to get rate and then get from `item_wise_tax_detail`

Before:
![image](https://user-images.githubusercontent.com/42651287/82676697-6f86f680-9c64-11ea-8b25-6f5e10bfde66.png)

After:
![image](https://user-images.githubusercontent.com/42651287/82676739-7f9ed600-9c64-11ea-8a89-cce35f97b130.png)
