### PR TITLE
fix: set default posting_date value to None

### DIFF
--- a/erpnext/accounts/deferred_revenue.py
+++ b/erpnext/accounts/deferred_revenue.py
@@ -199,9 +199,12 @@ def book_deferred_income_or_expense(doc, deferred_process, posting_date=None):
 		if item.get(enable_check):
 			_book_deferred_revenue_or_expense(item)
 
-def process_deferred_accounting(posting_date=today()):
+def process_deferred_accounting(posting_date=None):
 	''' Converts deferred income/expense into income/expense
 		Executed via background jobs on every month end '''
+
+	if not posting_date:
+		posting_date = today()
 
 	if not cint(frappe.db.get_singles_value('Accounts Settings', 'automatically_process_deferred_accounting_entry')):
 		return


### PR DESCRIPTION
using mutable python defaults, and especially function calls, inside function definitions causes bugs that can be really hard to debug sometimes (eg. webhooks in #21754 broke in this particular instance). please refrain from using such defaults.

instead, using `None` is almost always a sane default. the values can then be manipulated inside the function instead.

fixes: #21754 
introduced in: #19658 