### PR TITLE
fix: fetch depreciation amount only if depr entry is made

### DIFF
--- a/erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py
+++ b/erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py
@@ -111,7 +111,7 @@ def get_assets(filters):
 								   0
 							  end), 0) as depreciation_amount_during_the_period
 			from `tabAsset` a, `tabDepreciation Schedule` ds
-			where a.docstatus=1 and a.company=%(company)s and a.purchase_date <= %(to_date)s and a.name = ds.parent
+			where a.docstatus=1 and a.company=%(company)s and a.purchase_date <= %(to_date)s and a.name = ds.parent and ifnull(ds.journal_entry, '') != ''
 			group by a.asset_category
 			union
 			SELECT a.asset_category,


### PR DESCRIPTION
Problem: Asset Depreciation and Balances report was fetching "Depreciation Amount during the Period" incorrect. The value was inflated by un-depreciated amount set in the schedule table of assets.
Eg. Asset having 12 number of depr, out if which 5 has been depreciated as of 22-05-2020. Now the amount to be depreciated in the coming months was also included in the "Depreciation Amount during the Period"