### PR TITLE
fix: no selling_price_list returning null

### DIFF
--- a/erpnext/shopping_cart/product_info.py
+++ b/erpnext/shopping_cart/product_info.py
@@ -17,13 +17,16 @@ def get_product_info_for_website(item_code, skip_quotation_creation=False):
 	if not cart_settings.enabled:
 		return frappe._dict()
 
+	selling_price_list = cart_settings.price_list
+
 	cart_quotation = frappe._dict()
 	if not skip_quotation_creation:
 		cart_quotation = _get_cart_quotation()
+		selling_price_list = cart_quotation.selling_price_list
 
 	price = get_price(
 		item_code,
-		cart_quotation.selling_price_list,
+		selling_price_list,
 		cart_settings.default_customer_group,
 		cart_settings.company
 	)


### PR DESCRIPTION
Fixes bug introduced in https://github.com/frappe/erpnext/pull/21740

In `get_product_info_for_website` in case quotation is not created we use an empty dict, however the price list is not specified here.
https://github.com/frappe/erpnext/blob/28d1d6c91f0c02efeb05e23fc83ab9158daaee90/erpnext/shopping_cart/product_info.py#L12-L29

If no `price_list` is specified, the price would return as null
https://github.com/frappe/erpnext/blob/28d1d6c91f0c02efeb05e23fc83ab9158daaee90/erpnext/utilities/product.py#L70-L76

This would mean the `price` info would be null and Add to Cart button would never be rendered
https://github.com/frappe/erpnext/blob/28d1d6c91f0c02efeb05e23fc83ab9158daaee90/erpnext/templates/generators/item/item_add_to_cart.html#L30-L46