### PR TITLE
fix: Item Price and Add to Cart not showing on Website

### DIFF
--- a/erpnext/shopping_cart/cart.py
+++ b/erpnext/shopping_cart/cart.py
@@ -319,7 +319,7 @@ def apply_cart_settings(party=None, quotation=None):
 def set_price_list_and_rate(quotation, cart_settings):
 	"""set price list based on billing territory"""
 
-	_set_price_list(quotation, cart_settings)
+	_set_price_list(cart_settings, quotation)
 
 	# reset values
 	quotation.price_list_currency = quotation.currency = \
@@ -334,23 +334,28 @@ def set_price_list_and_rate(quotation, cart_settings):
 		# set it in cookies for using in product page
 		frappe.local.cookie_manager.set_cookie("selling_price_list", quotation.selling_price_list)
 
-def _set_price_list(quotation, cart_settings):
+def _set_price_list(cart_settings, quotation={}):
 	"""Set price list based on customer or shopping cart default"""
 	from erpnext.accounts.party import get_default_price_list
 
 	# check if customer price list exists
 	selling_price_list = None
-	if quotation.party_name:
-		selling_price_list = frappe.db.get_value('Customer', quotation.party_name, 'default_price_list')
+	if quotation and quotation.get("party_name"):
+		selling_price_list = frappe.db.get_value('Customer', quotation.get("party_name"), 'default_price_list')
 
 	# else check for territory based price list
 	if not selling_price_list:
 		selling_price_list = cart_settings.price_list
 
-	if not selling_price_list and quotation.party_name:
-		selling_price_list = get_default_price_list(frappe.get_doc("Customer", quotation.party_name))
+	party_name = quotation.get("party_name") if quotation else get_party().get("name")
 
-	quotation.selling_price_list = selling_price_list
+	if not selling_price_list and party_name:
+		selling_price_list = get_default_price_list(frappe.get_doc("Customer", party_name))
+
+	if quotation:
+		quotation.selling_price_list = selling_price_list
+
+	return selling_price_list
 
 def set_taxes(quotation, cart_settings):
 	"""set taxes based on billing territory"""

--- a/erpnext/shopping_cart/cart.py
+++ b/erpnext/shopping_cart/cart.py
@@ -334,7 +334,7 @@ def set_price_list_and_rate(quotation, cart_settings):
 		# set it in cookies for using in product page
 		frappe.local.cookie_manager.set_cookie("selling_price_list", quotation.selling_price_list)
 
-def _set_price_list(cart_settings, quotation={}):
+def _set_price_list(cart_settings, quotation=None):
 	"""Set price list based on customer or shopping cart default"""
 	from erpnext.accounts.party import get_default_price_list
 

--- a/erpnext/shopping_cart/product_info.py
+++ b/erpnext/shopping_cart/product_info.py
@@ -4,7 +4,7 @@
 from __future__ import unicode_literals
 
 import frappe
-from erpnext.shopping_cart.cart import _get_cart_quotation
+from erpnext.shopping_cart.cart import _get_cart_quotation, _set_price_list
 from erpnext.shopping_cart.doctype.shopping_cart_settings.shopping_cart_settings \
 	import get_shopping_cart_settings, show_quantity_in_website
 from erpnext.utilities.product import get_price, get_qty_in_stock, get_non_stock_item_status
@@ -21,9 +21,11 @@ def get_product_info_for_website(item_code, skip_quotation_creation=False):
 	if not skip_quotation_creation:
 		cart_quotation = _get_cart_quotation()
 
+	selling_price_list = cart_quotation.get("selling_price_list") if cart_quotation else _set_price_list(cart_settings, None)
+
 	price = get_price(
 		item_code,
-		cart_quotation.selling_price_list,
+		selling_price_list,
 		cart_settings.default_customer_group,
 		cart_settings.company
 	)
@@ -42,7 +44,7 @@ def get_product_info_for_website(item_code, skip_quotation_creation=False):
 
 	if product_info["price"]:
 		if frappe.session.user != "Guest":
-			item = cart_quotation.get({"item_code": item_code})
+			item = cart_quotation.get({"item_code": item_code}) if cart_quotation else None
 			if item:
 				product_info["qty"] = item[0].qty
 


### PR DESCRIPTION
- Item info is fetched with `skip_quotation_creation=True`
- Price list (required to fetch item price) was attempted to be fetched from cart_quotation, which is blank if `skip_quotation_creation=True`
**Solution:** Fetch price list again via `_set_price_list` and make `_set_price_list` handle fetching price list without quotation data

**Before:**
![Screenshot 2020-05-25 at 2 20 52 PM](https://user-images.githubusercontent.com/25857446/82796164-b9552400-9e92-11ea-9e02-1f2f0bdb3327.png)

**After:**
![Screenshot 2020-05-25 at 2 20 28 PM](https://user-images.githubusercontent.com/25857446/82796173-bd814180-9e92-11ea-844e-8126235bb5a5.png)
