### PR TITLE
fix(Healthcare): unhide company field in Sample Collection, add field in Rehab DocTypes

### DIFF
--- a/erpnext/healthcare/doctype/patient_assessment/patient_assessment.json
+++ b/erpnext/healthcare/doctype/patient_assessment/patient_assessment.json
@@ -11,6 +11,7 @@
   "patient",
   "assessment_template",
   "column_break_4",
+  "company",
   "healthcare_practitioner",
   "assessment_datetime",
   "assessment_description",
@@ -127,11 +128,18 @@
    "fieldname": "assessment_description",
    "fieldtype": "Small Text",
    "label": "Assessment Description"
+  },
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "in_standard_filter": 1,
+   "label": "Company",
+   "options": "Company"
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2020-04-21 13:23:09.815007",
+ "modified": "2020-05-25 14:38:38.302399",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Patient Assessment",

--- a/erpnext/healthcare/doctype/sample_collection/sample_collection.json
+++ b/erpnext/healthcare/doctype/sample_collection/sample_collection.json
@@ -85,11 +85,9 @@
   {
    "fieldname": "company",
    "fieldtype": "Link",
-   "hidden": 1,
+   "in_standard_filter": 1,
    "label": "Company",
-   "options": "Company",
-   "print_hide": 1,
-   "report_hide": 1
+   "options": "Company"
   },
   {
    "fieldname": "section_break_6",
@@ -167,7 +165,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2020-04-04 19:17:02.707203",
+ "modified": "2020-05-25 14:36:46.990469",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Sample Collection",

--- a/erpnext/healthcare/doctype/therapy_plan/therapy_plan.json
+++ b/erpnext/healthcare/doctype/therapy_plan/therapy_plan.json
@@ -10,6 +10,7 @@
   "patient",
   "patient_name",
   "column_break_4",
+  "company",
   "status",
   "start_date",
   "section_break_3",
@@ -98,10 +99,17 @@
    "label": "Status",
    "options": "Not Started\nIn Progress\nCompleted\nCancelled",
    "read_only": 1
+  },
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "in_standard_filter": 1,
+   "label": "Company",
+   "options": "Company"
   }
  ],
  "links": [],
- "modified": "2020-04-21 13:13:43.956014",
+ "modified": "2020-05-25 14:38:53.649315",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Therapy Plan",

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -688,7 +688,7 @@ erpnext.patches.v12_0.set_serial_no_status #2020-05-21
 erpnext.patches.v12_0.update_price_list_currency_in_bom
 execute:frappe.delete_doc_if_exists('Dashboard', 'Accounts')
 erpnext.patches.v13_0.update_actual_start_and_end_date_in_wo
-erpnext.patches.v13_0.set_company_field_in_healthcare_doctypes
+erpnext.patches.v13_0.set_company_field_in_healthcare_doctypes #2020-05-25
 erpnext.patches.v12_0.update_bom_in_so_mr
 execute:frappe.delete_doc("Report", "Department Analytics")
 execute:frappe.rename_doc("Desk Page", "Loan Management", "Loan", force=True)

--- a/erpnext/patches/v13_0/set_company_field_in_healthcare_doctypes.py
+++ b/erpnext/patches/v13_0/set_company_field_in_healthcare_doctypes.py
@@ -3,8 +3,8 @@ import frappe
 
 def execute():
 	company = frappe.db.get_single_value('Global Defaults', 'default_company')
-	doctypes = ['Clinical Procedure', 'Inpatient Record', 'Lab Test', 'Patient Appointment', 'Patient Encounter', 'Vital Signs']
+	doctypes = ['Clinical Procedure', 'Inpatient Record', 'Lab Test', 'Sample Collection' 'Patient Appointment', 'Patient Encounter', 'Vital Signs', 'Therapy Session', 'Therapy Plan', 'Patient Assessment']
 	for entry in doctypes:
 		if frappe.db.exists('DocType', entry):
-			frappe.reload_doc("Healthcare", "doctype", entry)
+			frappe.reload_doc('Healthcare', 'doctype', entry)
 			frappe.db.sql("update `tab{dt}` set company = '{company}' where ifnull(company, '') = ''".format(dt=entry, company=company))


### PR DESCRIPTION
The company field in Sample Collection was hidden. This PR unhides the field and also adds company fields in Rehab Module DocTypes. It re-runs the patch for setting the company field in existing documents.
