### PR TITLE
fix: shopify error message on failure of sales order creation

### DIFF
--- a/erpnext/erpnext_integrations/connectors/shopify_connection.py
+++ b/erpnext/erpnext_integrations/connectors/shopify_connection.py
@@ -95,10 +95,10 @@ def create_sales_order(shopify_order, shopify_settings, company=None):
 		items = get_order_items(shopify_order.get("line_items"), shopify_settings)
 
 		if not items:
-			message = 'Following items are exists in order but relevant record not found in Product master'
+			message = 'Following items exists in the shopify order but relevant records were not found in the shopify Product master'
 			message += "\n" + ", ".join(product_not_exists)
 
-			make_shopify_log(status="Error", exception=e, rollback=True)
+			make_shopify_log(status="Error", exception=message, rollback=True)
 
 			return ''
 


### PR DESCRIPTION
Fixes:
``` Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2020-05-22/apps/erpnext/erpnext/erpnext_integrations/connectors/shopify_connection.py", line 30, in sync_sales_order
    create_order(order, shopify_settings)
  File "/home/frappe/benches/bench-version-12-2020-05-22/apps/erpnext/erpnext/erpnext_integrations/connectors/shopify_connection.py", line 81, in create_order
    so = create_sales_order(order, shopify_settings, company)
  File "/home/frappe/benches/bench-version-12-2020-05-22/apps/erpnext/erpnext/erpnext_integrations/connectors/shopify_connection.py", line 101, in create_sales_order
    make_shopify_log(status="Error", exception=e, rollback=True)
NameError: name 'e' is not defined ```