### PR TITLE
fix: check for warehouse in the woocommerce settings

### DIFF
--- a/erpnext/erpnext_integrations/connectors/woocommerce_connection.py
+++ b/erpnext/erpnext_integrations/connectors/woocommerce_connection.py
@@ -182,7 +182,8 @@ def set_items_in_sales_order(new_sales_order, woocommerce_settings, order, sys_l
 	company_abbr = frappe.db.get_value('Company', woocommerce_settings.company, 'abbr')
 
 	default_warehouse = _("Stores - {0}", sys_lang).format(company_abbr)
-	if not frappe.db.exists("Warehouse", default_warehouse):
+	if not frappe.db.exists("Warehouse", default_warehouse) \
+		and not woocommerce_settings.warehouse:
 		frappe.throw(_("Please set Warehouse in Woocommerce Settings"))
 
 	for item in order.get("line_items"):


### PR DESCRIPTION
- **Fixes:** ``` frappe.exceptions.ValidationError: Please set Warehouse in Woocommerce Settings ```
- **Issue:** If user adds a warehouse into warehouse settings and deletes the stores warehouse from the warehouse master. Validation breaks, since, it expects that default warehouse to exists.