### PR TITLE
fix(Healthcare): set company in healthcare service unit setup

### DIFF
--- a/erpnext/healthcare/setup.py
+++ b/erpnext/healthcare/setup.py
@@ -195,10 +195,21 @@ def create_sensitivity():
 
 def add_healthcare_service_unit_tree_root():
 	record = [
-	 {
-	  "doctype": "Healthcare Service Unit",
-	  "healthcare_service_unit_name": "All Healthcare Service Units",
-	  "is_group": 1
-	 }
+		{
+			"doctype": "Healthcare Service Unit",
+			"healthcare_service_unit_name": "All Healthcare Service Units",
+			"is_group": 1,
+			"company": get_company()
+	 	}
 	]
 	insert_record(record)
+
+def get_company():
+	company = frappe.defaults.get_defaults().company
+	if company:
+		return company
+	else:
+		company = frappe.get_list("Company", limit=1)
+		if company:
+			return company[0].name
+	return None


### PR DESCRIPTION
Set the company field while creating healthcare service unit in `setup.py`

```
  File "/Users/ruchamahabal/frappe-test-bench/apps/frappe/frappe/core/doctype/domain_settings/domain_settings.py", line 27, in on_update
    domain.setup_domain()
  File "/Users/ruchamahabal/frappe-test-bench/apps/frappe/frappe/core/doctype/domain/domain.py", line 32, in setup_domain
    frappe.get_attr(self.data.on_setup)()
  File "/Users/ruchamahabal/frappe-test-bench/apps/erpnext/erpnext/healthcare/setup.py", line 18, in setup_healthcare
    add_healthcare_service_unit_tree_root()
  File "/Users/ruchamahabal/frappe-test-bench/apps/erpnext/erpnext/healthcare/setup.py", line 204, in add_healthcare_service_unit_tree_root
    insert_record(record)
  File "/Users/ruchamahabal/frappe-test-bench/apps/erpnext/erpnext/setup/utils.py", line 135, in insert_record
    doc.insert(ignore_permissions=True)
  File "/Users/ruchamahabal/frappe-test-bench/apps/frappe/frappe/model/document.py", line 232, in insert
    self._validate()
  File "/Users/ruchamahabal/frappe-test-bench/apps/frappe/frappe/model/document.py", line 477, in _validate
    self._validate_mandatory()
  File "/Users/ruchamahabal/frappe-test-bench/apps/frappe/frappe/model/document.py", line 768, in _validate_mandatory
    name=self.name))
frappe.exceptions.MandatoryError: [Healthcare Service Unit, All Healthcare Service Units]: company
```