### PR TITLE
fix: shorter title for onboarding step

### DIFF
--- a/erpnext/stock/onboarding_step/introduction_to_stock_entry/introduction_to_stock_entry.json
+++ b/erpnext/stock/onboarding_step/introduction_to_stock_entry/introduction_to_stock_entry.json
@@ -8,12 +8,12 @@
  "is_mandatory": 0,
  "is_single": 0,
  "is_skipped": 0,
- "modified": "2020-05-19 18:55:41.457289",
+ "modified": "2020-05-26 15:55:41.457289",
  "modified_by": "Administrator",
  "name": "Introduction to Stock Entry",
  "owner": "Administrator",
  "show_full_form": 0,
- "title": "Introduction to the multi-purpose stock transaction",
+ "title": "Introduction to Stock Entry",
  "validate_action": 1,
  "video_url": "https://www.youtube.com/watch?v=Njt107hlY3I"
 }


### PR DESCRIPTION
Long title would break the layout on onboarding

## Broken

![image](https://user-images.githubusercontent.com/18097732/82890819-68186380-9f6a-11ea-89ff-7a9ba096e3f1.png)


## Fixed

![image](https://user-images.githubusercontent.com/18097732/82890800-5cc53800-9f6a-11ea-8237-d5ec841fbede.png)
