### PR TITLE
fix: manufacturing dashboard and work order summary chart

### DIFF
--- a/erpnext/manufacturing/dashboard_fixtures.py
+++ b/erpnext/manufacturing/dashboard_fixtures.py
@@ -3,7 +3,7 @@
 
 import frappe, erpnext, json
 from frappe import _
-from frappe.utils import nowdate, get_date_str
+from frappe.utils import nowdate, get_first_day, get_last_day, add_months
 from erpnext.accounts.utils import get_fiscal_year
 
 def get_data():
@@ -28,10 +28,10 @@ def get_dashboards():
 			{ "chart": "Job Card Analysis", "width": "Full" }
 		],
 		"cards": [
-			{ "card": "Total Work Order" },
-			{ "card": "Completed Work Order" },
+			{ "card": "Monthly Total Work Order" },
+			{ "card": "Monthly Completed Work Order" },
 			{ "card": "Ongoing Job Card" },
-			{ "card": "Total Quality Inspection"}
+			{ "card": "Monthly Quality Inspection"}
 		]
 	}]
 
@@ -180,38 +180,37 @@ def get_charts():
 	}]
 
 def get_number_cards():
-	fiscal_year = get_fiscal_year(date=nowdate())
-	year_start_date = get_date_str(fiscal_year[1])
-	year_end_date = get_date_str(fiscal_year[2])
+	start_date = add_months(nowdate(), -1)
+	end_date = nowdate()
 
 	return [{
 		"doctype": "Number Card",
 		"document_type": "Work Order",
-		"name": "Total Work Order",
+		"name": "Monthly Total Work Order",
 		"filters_json": json.dumps([
 			['Work Order', 'docstatus', '=', 1],
-			['Work Order', 'creation', 'between', [year_start_date, year_end_date]]
+			['Work Order', 'creation', 'between', [start_date, end_date]]
 		]),
 		"function": "Count",
 		"is_public": 1,
-		"label": _("Total Work Order"),
+		"label": _("Monthly Total Work Order"),
 		"show_percentage_stats": 1,
-		"stats_time_interval": "Monthly"
+		"stats_time_interval": "Weekly"
 	},
 	{
 		"doctype": "Number Card",
 		"document_type": "Work Order",
-		"name": "Completed Work Order",
+		"name": "Monthly Completed Work Order",
 		"filters_json": json.dumps([
 			['Work Order', 'status', '=', 'Completed'],
 			['Work Order', 'docstatus', '=', 1],
-			['Work Order', 'creation', 'between', [year_start_date, year_end_date]]
+			['Work Order', 'creation', 'between', [start_date, end_date]]
 		]),
 		"function": "Count",
 		"is_public": 1,
-		"label": _("Completed Work Order"),
+		"label": _("Monthly Completed Work Order"),
 		"show_percentage_stats": 1,
-		"stats_time_interval": "Monthly"
+		"stats_time_interval": "Weekly"
 	},
 	{
 		"doctype": "Number Card",
@@ -225,16 +224,19 @@ def get_number_cards():
 		"is_public": 1,
 		"label": _("Ongoing Job Card"),
 		"show_percentage_stats": 1,
-		"stats_time_interval": "Monthly"
+		"stats_time_interval": "Weekly"
 	},
 	{
 		"doctype": "Number Card",
 		"document_type": "Quality Inspection",
-		"name": "Total Quality Inspection",
-		"filters_json": json.dumps([['Quality Inspection', 'docstatus', '=', 1]]),
+		"name": "Monthly Quality Inspection",
+		"filters_json": json.dumps([
+			['Quality Inspection', 'docstatus', '=', 1],
+			['Quality Inspection', 'creation', 'between', [start_date, end_date]]
+		]),
 		"function": "Count",
 		"is_public": 1,
-		"label": _("Total Quality Inspection"),
+		"label": _("Monthly Quality Inspection"),
 		"show_percentage_stats": 1,
-		"stats_time_interval": "Monthly"
+		"stats_time_interval": "Weekly"
 	}]

--- a/erpnext/manufacturing/doctype/downtime_entry/downtime_entry.json
+++ b/erpnext/manufacturing/doctype/downtime_entry/downtime_entry.json
@@ -1,11 +1,13 @@
 {
  "actions": [],
  "allow_import": 1,
+ "autoname": "naming_series:",
  "creation": "2020-04-18 04:50:46.187638",
  "doctype": "DocType",
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
+  "naming_series",
   "workstation",
   "operator",
   "column_break_4",
@@ -78,10 +80,17 @@
    "fieldname": "remarks",
    "fieldtype": "Text",
    "label": "Remarks"
+  },
+  {
+   "fieldname": "naming_series",
+   "fieldtype": "Select",
+   "label": "Naming Series",
+   "options": "DT-",
+   "reqd": 1
   }
  ],
  "links": [],
- "modified": "2020-05-19 12:59:37.358483",
+ "modified": "2020-05-26 22:14:54.479831",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Downtime Entry",

--- a/erpnext/manufacturing/report/downtime_analysis/downtime_analysis.py
+++ b/erpnext/manufacturing/report/downtime_analysis/downtime_analysis.py
@@ -24,7 +24,12 @@ def get_data(filters):
 	if filters.get("workstation"):
 		query_filters["workstation"] = filters.get("workstation")
 
-	return frappe.get_all("Downtime Entry", fields= fields, filters=query_filters)
+	data = frappe.get_all("Downtime Entry", fields= fields, filters=query_filters) or []
+	for d in data:
+		if d.downtime:
+			d.downtime = d.downtime / 60
+
+	return data
 
 def get_chart_data(data, columns):
 	labels = sorted(list(set([d.workstation for d in data])))
@@ -44,7 +49,7 @@ def get_chart_data(data, columns):
 		"data": {
 			"labels": labels,
 			"datasets": [
-				{"name": "Dataset 1", "values": datasets}
+				{"name": "Machine Downtime", "values": datasets}
 			]
 		},
 		"type": "bar"
@@ -88,7 +93,7 @@ def get_columns(filters):
 			"width": 160
 		},
 		{
-			"label": _("Downtime (In Mins)"),
+			"label": _("Downtime (In Hours)"),
 			"fieldname": "downtime",
 			"fieldtype": "Float",
 			"width": 150

--- a/erpnext/manufacturing/report/work_order_summary/work_order_summary.py
+++ b/erpnext/manufacturing/report/work_order_summary/work_order_summary.py
@@ -56,7 +56,7 @@ def get_chart_data(data, filters):
 		return get_chart_based_on_qty(data, filters)
 
 def get_chart_based_on_status(data):
-	labels = ["Not Started", "In Process", "Stopped", "Completed"]
+	labels = ["Completed", "In Process", "Stopped", "Not Started"]
 
 	status_wise_data = {
 		"Not Started": 0,
@@ -66,13 +66,10 @@ def get_chart_based_on_status(data):
 	}
 
 	for d in data:
-		if d.status == "In Process" and d.produced_qty:
-			status_wise_data["Completed"] += d.produced_qty
+		status_wise_data[d.status] += 1
 
-		status_wise_data[d.status] += d.qty
-
-	values = [status_wise_data["Not Started"], status_wise_data["In Process"],
-		status_wise_data["Stopped"], status_wise_data["Completed"]]
+	values = [status_wise_data["Completed"], status_wise_data["In Process"],
+		status_wise_data["Stopped"], status_wise_data["Not Started"]]
 
 	chart = {
 		"data": {


### PR DESCRIPTION
### Changed the label of number cards

![image](https://user-images.githubusercontent.com/8780500/82932296-d0386b00-9fa5-11ea-935d-8cb90b1453b4.png)

### Added naming series for downtime entry 
<img width="581" alt="Screenshot 2020-05-26 at 11 09 21 PM" src="https://user-images.githubusercontent.com/8780500/82932447-0fff5280-9fa6-11ea-82b2-7c2f920876b6.png">


### Fixed work order summary chart
<img width="1124" alt="Screenshot 2020-05-26 at 11 12 19 PM" src="https://user-images.githubusercontent.com/8780500/82932686-6f5d6280-9fa6-11ea-8aff-e47a2c2650b3.png">
