### PR TITLE
fix: titles and order of Healthcare Onboarding steps

### DIFF
--- a/erpnext/healthcare/doctype/healthcare_settings/healthcare_settings.js
+++ b/erpnext/healthcare/doctype/healthcare_settings/healthcare_settings.js
@@ -57,19 +57,19 @@ frappe.tour['Healthcare Settings'] = [
 		description: __('Checking this will automatically create a Sales Invoice whenever an appointment is booked for a Patient.')
 	},
 	{
-		fieldname: 'healthcare_service_items',
+		fieldname: 'inpatient_visit_charge_item',
 		title: __('Healthcare Service Items'),
-		description: __('Set up the Healthcare Service Items for billing. Click ') + "<a href='https://docs.erpnext.com/docs/user/manual/en/healthcare/healthcare_settings#2-default-healthcare-service-items' target='_blank'>here</a>" + __(' to know more')
+		description: __('You can create a service item for Inpatient Visit Charge and set it here. Similarly, you can set up other Healthcare Service Items for billing in this section. Click ') + "<a href='https://docs.erpnext.com/docs/user/manual/en/healthcare/healthcare_settings#2-default-healthcare-service-items' target='_blank'>here</a>" + __(' to know more')
 	},
 	{
-		fieldname: 'sb_in_ac',
+		fieldname: 'income_account',
 		title: __('Set up default Accounts for the Healthcare Facility'),
 		description: __('If you wish to override default accounts settings and configure the Income and Receivable accounts for Healthcare, you can do so here.')
 
 	},
 	{
-		fieldname: 'out_patient_sms_alerts',
+		fieldname: 'send_registration_msg',
 		title: __('Out Patient SMS alerts'),
-		description: __('You can set up Out Patient SMS alerts here. Click ') + "<a href='https://docs.erpnext.com/docs/user/manual/en/healthcare/healthcare_settings#4-out-patient-sms-alerts' target='_blank'>here</a>" + __(' to know more')
+		description: __('If you want to send SMS alert on Patient Registration, you can enable this option. Similary, you can set up Out Patient SMS alerts for other functionalities in this section. Click ') + "<a href='https://docs.erpnext.com/docs/user/manual/en/healthcare/healthcare_settings#4-out-patient-sms-alerts' target='_blank'>here</a>" + __(' to know more')
 	}
 ];

--- a/erpnext/healthcare/module_onboarding/healthcare/healthcare.json
+++ b/erpnext/healthcare/module_onboarding/healthcare/healthcare.json
@@ -10,7 +10,7 @@
  "documentation_url": "https://docs.erpnext.com/docs/user/manual/en/healthcare",
  "idx": 0,
  "is_complete": 0,
- "modified": "2020-05-19 12:52:09.757729",
+ "modified": "2020-05-26 22:07:19.746314",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Healthcare",
@@ -20,13 +20,13 @@
    "step": "Create Patient"
   },
   {
-   "step": "Create Practitioner"
-  },
-  {
    "step": "Create Practitioner Schedule"
   },
   {
-   "step": "Setup Schedule and Employee for Healthcare Practitioner"
+   "step": "Introduction to Healthcare Practitioner"
+  },
+  {
+   "step": "Create Practitioner"
   },
   {
    "step": "Explore Healthcare Settings"

--- a/erpnext/healthcare/module_onboarding/healthcare/healthcare.json
+++ b/erpnext/healthcare/module_onboarding/healthcare/healthcare.json
@@ -10,7 +10,7 @@
  "documentation_url": "https://docs.erpnext.com/docs/user/manual/en/healthcare",
  "idx": 0,
  "is_complete": 0,
- "modified": "2020-05-26 22:07:19.746314",
+ "modified": "2020-05-26 23:16:37.603361",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Healthcare",
@@ -26,7 +26,7 @@
    "step": "Introduction to Healthcare Practitioner"
   },
   {
-   "step": "Create Practitioner"
+   "step": "Create Healthcare Practitioner"
   },
   {
    "step": "Explore Healthcare Settings"

--- a/erpnext/healthcare/onboarding_step/create_healthcare_practitioner/create_healthcare_practitioner.json
+++ b/erpnext/healthcare/onboarding_step/create_healthcare_practitioner/create_healthcare_practitioner.json
@@ -1,6 +1,6 @@
 {
  "action": "Create Entry",
- "creation": "2020-05-19 10:39:55.728057",
+ "creation": "2020-05-19 10:39:55.728058",
  "docstatus": 0,
  "doctype": "Onboarding Step",
  "idx": 0,
@@ -8,12 +8,12 @@
  "is_mandatory": 1,
  "is_single": 0,
  "is_skipped": 0,
- "modified": "2020-05-19 12:27:39.851375",
+ "modified": "2020-05-26 23:16:31.965521",
  "modified_by": "Administrator",
- "name": "Create Practitioner",
+ "name": "Create Healthcare Practitioner",
  "owner": "Administrator",
  "reference_document": "Healthcare Practitioner",
  "show_full_form": 1,
- "title": "Create Practitioner",
+ "title": "Create Healthcare Practitioner",
  "validate_action": 1
 }

--- a/erpnext/healthcare/onboarding_step/explore_clinical_procedure_templates/explore_clinical_procedure_templates.json
+++ b/erpnext/healthcare/onboarding_step/explore_clinical_procedure_templates/explore_clinical_procedure_templates.json
@@ -8,7 +8,7 @@
  "is_mandatory": 0,
  "is_single": 0,
  "is_skipped": 0,
- "modified": "2020-05-19 11:46:35.085270",
+ "modified": "2020-05-26 22:07:07.487210",
  "modified_by": "Administrator",
  "name": "Explore Clinical Procedure Templates",
  "owner": "Administrator",

--- a/erpnext/healthcare/onboarding_step/explore_clinical_procedure_templates/explore_clinical_procedure_templates.json
+++ b/erpnext/healthcare/onboarding_step/explore_clinical_procedure_templates/explore_clinical_procedure_templates.json
@@ -8,7 +8,7 @@
  "is_mandatory": 0,
  "is_single": 0,
  "is_skipped": 0,
- "modified": "2020-05-26 22:07:07.487210",
+ "modified": "2020-05-26 23:10:24.504030",
  "modified_by": "Administrator",
  "name": "Explore Clinical Procedure Templates",
  "owner": "Administrator",

--- a/erpnext/healthcare/onboarding_step/explore_healthcare_settings/explore_healthcare_settings.json
+++ b/erpnext/healthcare/onboarding_step/explore_healthcare_settings/explore_healthcare_settings.json
@@ -8,7 +8,7 @@
  "is_mandatory": 1,
  "is_single": 1,
  "is_skipped": 0,
- "modified": "2020-05-26 22:07:07.481952",
+ "modified": "2020-05-26 23:10:24.507648",
  "modified_by": "Administrator",
  "name": "Explore Healthcare Settings",
  "owner": "Administrator",

--- a/erpnext/healthcare/onboarding_step/explore_healthcare_settings/explore_healthcare_settings.json
+++ b/erpnext/healthcare/onboarding_step/explore_healthcare_settings/explore_healthcare_settings.json
@@ -8,7 +8,7 @@
  "is_mandatory": 1,
  "is_single": 1,
  "is_skipped": 0,
- "modified": "2020-05-19 12:26:48.682673",
+ "modified": "2020-05-26 22:07:07.481952",
  "modified_by": "Administrator",
  "name": "Explore Healthcare Settings",
  "owner": "Administrator",

--- a/erpnext/healthcare/onboarding_step/introduction_to_healthcare_practitioner/introduction_to_healthcare_practitioner.json
+++ b/erpnext/healthcare/onboarding_step/introduction_to_healthcare_practitioner/introduction_to_healthcare_practitioner.json
@@ -9,12 +9,12 @@
  "is_mandatory": 1,
  "is_single": 0,
  "is_skipped": 0,
- "modified": "2020-05-19 12:26:42.492734",
+ "modified": "2020-05-26 22:07:07.482530",
  "modified_by": "Administrator",
- "name": "Setup Schedule and Employee for Healthcare Practitioner",
+ "name": "Introduction to Healthcare Practitioner",
  "owner": "Administrator",
  "reference_document": "Healthcare Practitioner",
  "show_full_form": 0,
- "title": "Setup Schedule and Employee for Healthcare Practitioner",
+ "title": "Introduction to Healthcare Practitioner",
  "validate_action": 0
 }


### PR DESCRIPTION
- Shorter and better titles for Onboarding Steps. 
    - "Setup Schedule and Employee for Healthcare Practitioner" > "Introduction to Healthcare Practitioner"
    - "Create Practitioner" > "Create Healthcare Practitioner"
- Rearranged the steps for better context
- Refactor Onboarding Tour for Healthcare Settings

**Before:**

![image](https://user-images.githubusercontent.com/24353136/82927276-11c51800-9f9e-11ea-80cb-a61db68870b6.png)

**After:**

![module-onboard-after](https://user-images.githubusercontent.com/24353136/82933295-543f2280-9fa7-11ea-9266-d7859a8b0c8e.png)
