### PR TITLE
fix: make transaction date of the oldest transaction as the last integration date

### DIFF
--- a/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.py
+++ b/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.py
@@ -124,9 +124,8 @@ def add_account_subtype(account_subtype):
 
 @frappe.whitelist()
 def sync_transactions(bank, bank_account):
-	''' Sync transactions based on the last integration date as the start date, after sync is completed
-		add the transaction date of the oldest transaction as the last integration date '''
-
+	'''Sync transactions based on the last integration date as the start date, after the sync is completed
+		add the transaction date of the oldest transaction as the last integration date'''
 	last_transaction_date = frappe.db.get_value("Bank Account", bank_account, "last_integration_date")
 	if last_transaction_date:
 		start_date = formatdate(last_transaction_date, "YYYY-MM-dd")

--- a/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.py
+++ b/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.py
@@ -124,10 +124,12 @@ def add_account_subtype(account_subtype):
 
 @frappe.whitelist()
 def sync_transactions(bank, bank_account):
+	''' Sync transactions based on the last integration date as the start date, after sync is completed
+		add the transaction date of the oldest transaction as the last integration date '''
 
-	last_sync_date = frappe.db.get_value("Bank Account", bank_account, "last_integration_date")
-	if last_sync_date:
-		start_date = formatdate(last_sync_date, "YYYY-MM-dd")
+	last_transaction_date = frappe.db.get_value("Bank Account", bank_account, "last_integration_date")
+	if last_transaction_date:
+		start_date = formatdate(last_transaction_date, "YYYY-MM-dd")
 	else:
 		start_date = formatdate(add_months(today(), -12), "YYYY-MM-dd")
 	end_date = formatdate(today(), "YYYY-MM-dd")
@@ -139,12 +141,14 @@ def sync_transactions(bank, bank_account):
 		for transaction in reversed(transactions):
 			result += new_bank_transaction(transaction)
 
-		frappe.logger().info("Plaid added {} new Bank Transactions from '{}' between {} and {}".format(
-			len(result), bank_account, start_date, end_date))
+		if result:
+			end_date = frappe.db.get_value('Bank Transaction', result.pop(), 'date')
 
-		frappe.db.set_value("Bank Account", bank_account, "last_integration_date", getdate(end_date))
+			frappe.logger().info("Plaid added {} new Bank Transactions from '{}' between {} and {}".format(
+				len(result), bank_account, start_date, end_date))
 
-		return result
+		frappe.db.set_value("Bank Account", bank_account, "last_integration_date", end_date)
+
 	except Exception:
 		frappe.log_error(frappe.get_traceback(), _("Plaid transactions sync error"))
 


### PR DESCRIPTION
**Issue** 
- Currently, last integration date is decided by the date/timezone of the server. However, when transactions are synced over a defined period, it fetches all the transactions based on the transaction date. 
- Transaction date is defined by a financial institution without any timezone information. [source](https://support.plaid.com/hc/en-us/articles/360008271754-Transaction-dates)
- This causes those transactions to be missed which are not in the same timezone as the server. Suppose servers are in the Region A with timezone that is ahead of the date that are recorded in plaid. Those transactions will not be synced, since the last integration date has changed in the bank account server.

**Proposed Fix**
- set the transaction date of the oldest transaction in the sync as the last integration date. This will make sure the transactions are in sync with the date  that the financial institution is following.