### PR TITLE
fix: Default period start date and period end date for financial statements

### DIFF
--- a/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js
+++ b/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js
@@ -33,7 +33,6 @@ frappe.query_reports["Consolidated Financial Statement"] = {
 			"fieldname":"period_start_date",
 			"label": __("Start Date"),
 			"fieldtype": "Date",
-			"default": frappe.datetime.nowdate(),
 			"hidden": 1,
 			"reqd": 1
 		},
@@ -41,7 +40,6 @@ frappe.query_reports["Consolidated Financial Statement"] = {
 			"fieldname":"period_end_date",
 			"label": __("End Date"),
 			"fieldtype": "Date",
-			"default": frappe.datetime.add_months(frappe.datetime.nowdate(), 12),
 			"hidden": 1,
 			"reqd": 1
 		},
@@ -106,5 +104,16 @@ frappe.query_reports["Consolidated Financial Statement"] = {
 			value = $value.wrap("<p></p>").parent().html();
 		}
 		return value;
+	},
+	onload: function() {
+		let fiscal_year = frappe.defaults.get_user_default("fiscal_year")
+
+		frappe.model.with_doc("Fiscal Year", fiscal_year, function(r) {
+			var fy = frappe.model.get_doc("Fiscal Year", fiscal_year);
+			frappe.query_report.set_filter_value({
+				period_start_date: fy.year_start_date,
+				period_end_date: fy.year_end_date
+			});
+		});
 	}
 }

--- a/erpnext/public/js/financial_statements.js
+++ b/erpnext/public/js/financial_statements.js
@@ -47,6 +47,16 @@ erpnext.financial_statements = {
 		// dropdown for links to other financial statements
 		erpnext.financial_statements.filters = get_filters()
 
+		let fiscal_year = frappe.defaults.get_user_default("fiscal_year")
+
+		frappe.model.with_doc("Fiscal Year", fiscal_year, function(r) {
+			var fy = frappe.model.get_doc("Fiscal Year", fiscal_year);
+			frappe.query_report.set_filter_value({
+				period_start_date: fy.year_start_date,
+				period_end_date: fy.year_end_date
+			});
+		});
+
 		report.page.add_inner_button(__("Balance Sheet"), function() {
 			var filters = report.get_values();
 			frappe.set_route('query-report', 'Balance Sheet', {company: filters.company});
@@ -99,7 +109,6 @@ function get_filters() {
 			"fieldname":"period_start_date",
 			"label": __("Start Date"),
 			"fieldtype": "Date",
-			"default": frappe.datetime.nowdate(),
 			"hidden": 1,
 			"reqd": 1
 		},
@@ -107,7 +116,6 @@ function get_filters() {
 			"fieldname":"period_end_date",
 			"label": __("End Date"),
 			"fieldtype": "Date",
-			"default": frappe.datetime.add_months(frappe.datetime.nowdate(), 12),
 			"hidden": 1,
 			"reqd": 1
 		},


### PR DESCRIPTION
On selecting the "Date Range" filter for the first time user gets a "Date not in any active fiscal year" error if "To Date" is not in any active fiscal year