### PR TITLE
fix: disposed asset creates inconsistencies in asset depr report

### DIFF
--- a/erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py
+++ b/erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py
@@ -93,7 +93,7 @@ def get_assets(filters):
 			   sum(results.depreciation_eliminated_during_the_period) as depreciation_eliminated_during_the_period,
 			   sum(results.depreciation_amount_during_the_period) as depreciation_amount_during_the_period
 		from (SELECT a.asset_category,
-				   ifnull(sum(case when ds.schedule_date < %(from_date)s then
+				   ifnull(sum(case when ds.schedule_date < %(from_date)s and (ifnull(a.disposal_date, 0) = 0 or a.disposal_date >= %(from_date)s) then
 								   ds.depreciation_amount
 							  else
 								   0
@@ -115,9 +115,7 @@ def get_assets(filters):
 			group by a.asset_category
 			union
 			SELECT a.asset_category,
-				   ifnull(sum(case when ifnull(a.disposal_date, 0) != 0
-										and (a.disposal_date < %(from_date)s or a.disposal_date > %(to_date)s) 
-										then
+				   ifnull(sum(case when ifnull(a.disposal_date, 0) != 0 and (a.disposal_date < %(from_date)s or a.disposal_date > %(to_date)s) then
 									0
 							   else
 									a.opening_accumulated_depreciation


### PR DESCRIPTION
Net Asset value from previous period was incorrectly carried onto next period.

Net asset value after 31-01-2019 is 76k
<img width="1218" alt="Screenshot 2020-05-28 at 7 53 48 PM" src="https://user-images.githubusercontent.com/25369014/83154115-5f1bc380-a11d-11ea-8341-eda494c1d082.png">

Net asset value before 01-01-2020 is 75k
<img width="1218" alt="Screenshot 2020-05-28 at 7 53 44 PM" src="https://user-images.githubusercontent.com/25369014/83154099-5aefa600-a11d-11ea-838c-fe0fae80e197.png">
