### PR TITLE
fix: routing operations table is blank on pull of operations in BOM

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -113,7 +113,13 @@ class BOM(WebsiteGenerator):
 			self.set("operations", [])
 			for d in frappe.get_all("BOM Operation", fields = ["*"],
 				filters = {'parenttype': 'Routing', 'parent': self.routing}):
-				child = self.append('operations', d)
+				child = self.append('operations', {
+					"operation": d.operation,
+					"workstation": d.workstation,
+					"description": d.description,
+					"time_in_mins": d.time_in_mins,
+					"batch_size": d.batch_size
+				})
 				child.hour_rate = flt(d.hour_rate / self.conversion_rate, 2)
 
 	def set_bom_material_details(self):


### PR DESCRIPTION
**Issue**

Steps to replicate issue

- Make routing record and select the routing in the BOM and save

- After BOM save, go to routing and operations table will be blank

<img width="1199" alt="Screenshot 2020-05-29 at 1 25 42 PM" src="https://user-images.githubusercontent.com/8780500/83236290-e8300a80-a1b0-11ea-8717-47b62b574c5a.png">
