### PR TITLE
fix(HR) : Filter Leave Type based on allocation for a particular employee

### DIFF
--- a/erpnext/hr/doctype/leave_application/leave_application.js
+++ b/erpnext/hr/doctype/leave_application/leave_application.js
@@ -67,6 +67,13 @@ frappe.ui.form.on("Leave Application", {
 				})
 			);
 			frm.dashboard.show();
+			frm.set_query('leave_type', function(){
+				return {
+					filters : [
+						['leave_type_name', 'in', Object.keys(leave_details)]
+					]
+				}
+			});
 		}
 	},
 

--- a/erpnext/hr/doctype/leave_application/leave_application_dashboard.html
+++ b/erpnext/hr/doctype/leave_application/leave_application_dashboard.html
@@ -1,5 +1,5 @@
 
-{% if data %}
+{% if not jQuery.isEmptyObject(data) %}
 <h5 style="margin-top: 20px;"> {{ __("Allocated Leaves") }} </h5>
 <table class="table table-bordered small">
 	<thead>
@@ -10,7 +10,6 @@
 			<th style="width: 20%" class="text-right">{{ __("Pending Leaves") }}</th>
 			<th style="width: 20%" class="text-right">{{ __("Available Leaves") }}</th>
 		</tr>
-
 	</thead>
 	<tbody>
 		{% for(const [key, value] of Object.entries(data)) { %}
@@ -24,6 +23,6 @@
 		{% } %}
 	</tbody>
 </table>
-{% } else { %}
+{% else %}
 <p style="margin-top: 30px;"> No Leaves have been allocated. </p>
-{% } %}
+{% endif %}


### PR DESCRIPTION
All leave types showing erroneously for every employee
and to/from dates.

Added filters for showing only allocated leave types.

Also the dashboard table was showing even if there is
no leave allocation, fixed template code.


Before:
![image](https://user-images.githubusercontent.com/15175501/83297423-2d375980-a210-11ea-9751-d86a90531b9e.png)

After:
![image](https://user-images.githubusercontent.com/15175501/83297735-bc447180-a210-11ea-9d05-da4ec545266f.png)

![image](https://user-images.githubusercontent.com/15175501/83297621-843d2e80-a210-11ea-90e9-b2bb19031614.png)

