### PR TITLE
fix(ewb): remove checksum validation for TRANSIN

### DIFF
--- a/erpnext/regional/india/utils.py
+++ b/erpnext/regional/india/utils.py
@@ -615,8 +615,9 @@ def get_transport_details(data, doc):
 		data.transDocDate = frappe.utils.formatdate(doc.lr_date, 'dd/mm/yyyy')
 
 	if doc.gst_transporter_id:
-		validate_gstin_check_digit(doc.gst_transporter_id, label='GST Transporter ID')
-		data.transporterId  = doc.gst_transporter_id
+		if doc.gst_transporter_id[0:2] != "88":
+			validate_gstin_check_digit(doc.gst_transporter_id, label='GST Transporter ID')
+		data.transporterId = doc.gst_transporter_id
 
 	return data
 


### PR DESCRIPTION
This PR is added to avoid doing checksum validation on Transporter ID if it is a "TRANSIN".

**current issue:**
![Transporter_id_error_demo_erpnext](https://user-images.githubusercontent.com/4847317/83328952-56092e80-a2a4-11ea-9fac-98174cf161c5.gif)

**using the same transporter ID on e-waybill web app:**
![Transporter_id_demo_ewb_site](https://user-images.githubusercontent.com/4847317/83328986-720cd000-a2a4-11ea-82a9-b5a69babb0cf.gif)


**after the fix:**
![Transporter_id_fix_demo_erpnext](https://user-images.githubusercontent.com/4847317/83330241-61138d00-a2ab-11ea-81c2-efeacb95f87d.gif)


<details>
 <summary>More Background information</summary>
 
Examples of TRANSIN that do not pass the checksum validation but is a valid Transporter ID:
1. 88AAAFS5961L2ZQ
2. 88AABFG1694H1ZP
3. 88AACCD7104K1ZZ
4. 88AACCG4006F2Z1

There is no publicly available information on how to do checksum validation on TRANSIN. But, it turns out that they just swap out the first to digits "state code" with 88, which is not a valid state code. Also, they don't update the checksum after changing the state code.

For example: 
The GSTIN `21AABFG1694H1ZP` is a valid GSTIN(and would pass the checksum) that belongs to a transporter `GREAT INDIA ROADWAYS`, But their TRANSIN `88AABFG1694H1ZP` has been generated just by swapping the 21 with 88. Notice that they have not updated the last character with an updated checksum, hence there is no way to verify the validity of this TRANSIN just by using a checksum.


</details>

