### PR TITLE
fix: '>=' not supported between instances of 'str' and 'int'

### DIFF
--- a/erpnext/stock/utils.py
+++ b/erpnext/stock/utils.py
@@ -230,12 +230,12 @@ def get_valuation_method(item_code):
 
 def get_fifo_rate(previous_stock_queue, qty):
 	"""get FIFO (average) Rate from Queue"""
-	if qty >= 0:
+	if flt(qty) >= 0:
 		total = sum(f[0] for f in previous_stock_queue)
 		return sum(flt(f[0]) * flt(f[1]) for f in previous_stock_queue) / flt(total) if total else 0.0
 	else:
 		available_qty_for_outgoing, outgoing_cost = 0, 0
-		qty_to_pop = abs(qty)
+		qty_to_pop = abs(flt(qty))
 		while qty_to_pop and previous_stock_queue:
 			batch = previous_stock_queue[0]
 			if 0 < batch[0] <= qty_to_pop:


### PR DESCRIPTION
Protect our data types :(