### PR TITLE
fix(item_attribute): Handle whitespace issue in item attribute value and abbr.

### DIFF
--- a/erpnext/controllers/item_variant.py
+++ b/erpnext/controllers/item_variant.py
@@ -315,7 +315,7 @@ def make_variant_item_code(template_item_code, template_item_name, variant):
 			# 	exc=InvalidItemAttributeValueError)
 
 		abbr_or_value = cstr(attr.attribute_value) if item_attribute[0].numeric_values else item_attribute[0].abbr
-		abbreviations.append(abbr_or_value)
+		abbreviations.append(abbr_or_value.strip())
 
 	if abbreviations:
 		variant.item_code = "{0}-{1}".format(template_item_code, "-".join(abbreviations))

--- a/erpnext/controllers/item_variant.py
+++ b/erpnext/controllers/item_variant.py
@@ -315,7 +315,7 @@ def make_variant_item_code(template_item_code, template_item_name, variant):
 			# 	exc=InvalidItemAttributeValueError)
 
 		abbr_or_value = cstr(attr.attribute_value) if item_attribute[0].numeric_values else item_attribute[0].abbr
-		abbreviations.append(abbr_or_value.strip())
+		abbreviations.append(abbr_or_value)
 
 	if abbreviations:
 		variant.item_code = "{0}-{1}".format(template_item_code, "-".join(abbreviations))

--- a/erpnext/stock/doctype/item_attribute/item_attribute.py
+++ b/erpnext/stock/doctype/item_attribute/item_attribute.py
@@ -18,9 +18,11 @@ class ItemAttribute(Document):
 
 	def validate(self):
 		frappe.flags.attribute_values = None
+		if not self.numeric_values:
+			self.validate_attribute_value_and_abbr()
 		self.validate_numeric()
 		self.validate_duplication()
-
+		
 	def on_update(self):
 		self.validate_exising_items()
 
@@ -61,3 +63,10 @@ class ItemAttribute(Document):
 			if d.abbr in abbrs:
 				frappe.throw(_("{0} must appear only once").format(d.abbr))
 			abbrs.append(d.abbr)
+
+	def validate_attribute_value_and_abbr(self):
+		for value in self.item_attribute_values:
+			if value.abbr.startswith(' ',0,-1) or value.attribute_value.startswith(' ',0,-1):
+				value.abbr = value.abbr.strip()
+				value.attribute_value = value.attribute_value.strip()
+


### PR DESCRIPTION
This PR fixes the whitespace issues in the item attribute value and abbreviation.

## Issue
The item attribute value created mistakenly with white spaces at the beginning and end:

- In this case, if the user creates a new variant from the UI, it creates the item name with the whitespaces as in the item attribute value. 
- But in some other doctype, when the item attribute acts as a link field [stripping of values are handled], it displays the attribute values without whitespaces. Here, if we call the ```get_variant```  function of item_variant, it returns ```None``` but the variant with the same attribute value exists in the item list.

Eg: Attribute - "Colour", Attribute value -  " White"
      Item created - "T-Shirt- White"
      But if we look for "T-Shirt-White" in ```get_variant```  it returns None.
      
## Before Fix
![Peek 2020-06-04 23-02](https://user-images.githubusercontent.com/36359901/83838929-30eb4480-a718-11ea-869a-6cb6fac843f4.gif)
## After Fix
![Peek 2020-06-05 10-21](https://user-images.githubusercontent.com/36359901/83838952-3b0d4300-a718-11ea-8644-79dd9718fee8.gif)