### PR TITLE
fix: Wrong Ordered-Status Indicator for Material Request Items

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -18,7 +18,7 @@ frappe.ui.form.on('Material Request', {
 
 		// formatter for material request item
 		frm.set_indicator_formatter('item_code',
-			function(doc) { return (doc.qty<=doc.ordered_qty) ? "green" : "orange"; });
+			function(doc) { return (doc.stock_qty<=doc.ordered_qty) ? "green" : "orange"; });
 
 		frm.set_query("item_code", "items", function() {
 			return {


### PR DESCRIPTION
The indicator displaying if a material request item has been ordered or not (green/orange) used the wrong quantity field for determining the status.
The qty field used in the code is not in stock uom while the ordered_qty field is.
Now, the stock_qty field is used for correct comparison with ordered_qty.