### PR TITLE
fix: fetch tax lines within the shipping lines

### DIFF
--- a/erpnext/erpnext_integrations/connectors/shopify_connection.py
+++ b/erpnext/erpnext_integrations/connectors/shopify_connection.py
@@ -241,14 +241,17 @@ def get_order_taxes(shopify_order, shopify_settings):
 	return taxes
 
 def update_taxes_with_shipping_lines(taxes, shipping_lines, shopify_settings):
+	"""Shipping lines represents the shipping details,
+		each such shipping detail consists of a list of tax_lines"""
 	for shipping_charge in shipping_lines:
-		taxes.append({
-			"charge_type": _("Actual"),
-			"account_head": get_tax_account_head(shipping_charge),
-			"description": shipping_charge["title"],
-			"tax_amount": shipping_charge["price"],
-			"cost_center": shopify_settings.cost_center
-		})
+		for tax in shipping_charge.get("tax_lines"):
+			taxes.append({
+				"charge_type": _("Actual"),
+				"account_head": get_tax_account_head(tax),
+				"description": tax["title"],
+				"tax_amount": tax["price"],
+				"cost_center": shopify_settings.cost_center
+			})
 
 	return taxes
 


### PR DESCRIPTION
- Tax lines are part of the individual shipping lines record, currently it tries to use the shipping line detail(not the tax line) as a reference for creating taxes. 
- This fix fetches the correct tax line from within the shipping line.