### PR TITLE
fix: Cancel Subscription

### DIFF
--- a/erpnext/accounts/doctype/subscription/subscription.py
+++ b/erpnext/accounts/doctype/subscription/subscription.py
@@ -419,7 +419,7 @@ class Subscription(Document):
 		but it will not affect already created invoices.
 		"""
 		if self.status != 'Cancelled':
-			to_generate_invoice = True if self.status == 'Active' else False
+			to_generate_invoice = True if self.status == 'Active' and not self.generate_invoice_at_period_start else False
 			to_prorate = frappe.db.get_single_value('Subscription Settings', 'prorate')
 			self.status = 'Cancelled'
 			self.cancelation_date = nowdate()

--- a/erpnext/accounts/doctype/subscription_settings/subscription_settings.json
+++ b/erpnext/accounts/doctype/subscription_settings/subscription_settings.json
@@ -61,7 +61,7 @@
    "in_global_search": 0, 
    "in_list_view": 0, 
    "in_standard_filter": 0, 
-   "label": "Cancel Invoice After Grace Period", 
+   "label": "Cancel Subscription After Grace Period", 
    "length": 0, 
    "no_copy": 0, 
    "permlevel": 0, 


### PR DESCRIPTION
Do not generate invoice when cancelling subscription if invoice is
already created at the beginning of the period.

Fix label in subscription setting.

Signed-off-by: Syed Mujeer Hashmi <mujeerhashmi@4csolutions.in>