### PR TITLE
feat(projects): bill all hours by default

### DIFF
--- a/erpnext/projects/doctype/timesheet/timesheet.js
+++ b/erpnext/projects/doctype/timesheet/timesheet.js
@@ -206,9 +206,6 @@ frappe.ui.form.on("Timesheet Detail", {
 		update_billing_hours(frm, cdt, cdn);
 		update_time_rates(frm, cdt, cdn);
 		calculate_billing_costing_amount(frm, cdt, cdn);
-
-		// bill all `hours` by default
-		frappe.model.set_value(cdt, cdn, "billing_hours", locals[cdt][cdn].hours);
 	},
 
 	activity_type: function(frm, cdt, cdn) {
@@ -261,7 +258,12 @@ var calculate_end_time = function(frm, cdt, cdn) {
 
 var update_billing_hours = function(frm, cdt, cdn){
 	var child = locals[cdt][cdn];
-	if(!child.billable) frappe.model.set_value(cdt, cdn, 'billing_hours', 0.0);
+	if(!child.billable) {
+		frappe.model.set_value(cdt, cdn, 'billing_hours', 0.0);
+	} else {
+		// bill all hours by default
+		frappe.model.set_value(cdt, cdn, "billing_hours", child.hours);
+	}
 };
 
 var update_time_rates = function(frm, cdt, cdn){

--- a/erpnext/projects/doctype/timesheet/timesheet.js
+++ b/erpnext/projects/doctype/timesheet/timesheet.js
@@ -206,6 +206,9 @@ frappe.ui.form.on("Timesheet Detail", {
 		update_billing_hours(frm, cdt, cdn);
 		update_time_rates(frm, cdt, cdn);
 		calculate_billing_costing_amount(frm, cdt, cdn);
+
+		// bill all `hours` by default
+		frappe.model.set_value(cdt, cdn, "billing_hours", locals[cdt][cdn].hours);
 	},
 
 	activity_type: function(frm, cdt, cdn) {


### PR DESCRIPTION
### Problem
I frequently struggle with **Timesheet**. In the editable grid I can enter the time worked. For `billing_hours` I have to enter the **Timesheet Detail**, check `billable` and manually copy the working `hours` to `billing_hours`.

### Solution
With this PR, the `billing_hours` are equal to the `hours` worked by default. They can still be changed manually if required. This way it doesn't generate extra work if the values are different but saves some time when they are equal.