### PR TITLE
fix(loyalty): loyalty point entry use wrong tier

### DIFF
--- a/erpnext/accounts/doctype/loyalty_program/loyalty_program.py
+++ b/erpnext/accounts/doctype/loyalty_program/loyalty_program.py
@@ -41,10 +41,16 @@ def get_loyalty_program_details_with_points(customer, loyalty_program=None, expi
 	loyalty_program = frappe.get_doc("Loyalty Program", loyalty_program)
 	lp_details.update(get_loyalty_details(customer, loyalty_program.name, expiry_date, company, include_expired_entry))
 
-	tier_spent_level = sorted([d.as_dict() for d in loyalty_program.collection_rules],
-		key=lambda rule:rule.min_spent, reverse=True)
+	# sort collection rule, first item on list will be lowest min_spent 
+	tier_spent_level = sorted(
+		[d.as_dict() for d in loyalty_program.collection_rules],
+		key=lambda rule: rule.min_spent, reverse=False,
+	)
+
+	# looping and apply tier from highest min_spent
 	for i, d in enumerate(tier_spent_level):
-		if i==0 or (lp_details.total_spent+current_transaction_amount) <= d.min_spent:
+		# if cumulative spend more than min_spent then continue to next tier
+		if (lp_details.total_spent + current_transaction_amount) >= d.min_spent:
 			lp_details.tier_name = d.tier_name
 			lp_details.collection_factor = d.collection_factor
 		else:

--- a/erpnext/accounts/doctype/loyalty_program/loyalty_program.py
+++ b/erpnext/accounts/doctype/loyalty_program/loyalty_program.py
@@ -47,7 +47,7 @@ def get_loyalty_program_details_with_points(customer, loyalty_program=None, expi
 		key=lambda rule: rule.min_spent, reverse=False,
 	)
 
-	# looping and apply tier from highest min_spent
+	# looping and apply tier from lowest min_spent
 	for i, d in enumerate(tier_spent_level):
 		# if cumulative spend more than min_spent then continue to next tier
 		if (lp_details.total_spent + current_transaction_amount) >= d.min_spent:


### PR DESCRIPTION
## Fix for > [Bug] V12 - Loyalty program: Loyalty Point Entry use wrong Tier #22167

This is incorrect because it loop from highest and see if cumulative amount is less than min tier spend but it won't work if min tier spend is at 0 (Which it can be since min tier spend is not mandatory field)
that might be why he add i == 0 to skip this error.

The new method loop from lowest and check if cumulative spend is more than min spend.