### PR TITLE
fix: Item-wise sales and purchase register export

### DIFF
--- a/erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py
+++ b/erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py
@@ -265,13 +265,6 @@ def get_columns(additional_table_columns, filters):
 			'fieldtype': 'Currency',
 			'options': 'currency',
 			'width': 100
-		},
-		{
-			'fieldname': 'currency',
-			'label': _('Currency'),
-			'fieldtype': 'Currency',
-			'width': 80,
-			'hidden': 1
 		}
 	]
 

--- a/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py
+++ b/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py
@@ -223,7 +223,7 @@ def get_columns(additional_table_columns, filters):
 		}
 	]
 
-	if filters.get('group_by') != 'Terriotory':
+	if filters.get('group_by') != 'Territory':
 		columns.extend([
 			{
 				'label': _("Territory"),
@@ -304,13 +304,6 @@ def get_columns(additional_table_columns, filters):
 			'fieldtype': 'Currency',
 			'options': 'currency',
 			'width': 100
-		},
-		{
-			'fieldname': 'currency',
-			'label': _('Currency'),
-			'fieldtype': 'Currency',
-			'width': 80,
-			'hidden': 1
 		}
 	]
 
@@ -536,6 +529,13 @@ def get_tax_accounts(item_list, columns, company_currency,
 			'fieldtype': 'Currency',
 			'options': 'currency',
 			'width': 100
+		},
+		{
+			'fieldname': 'currency',
+			'label': _('Currency'),
+			'fieldtype': 'Currency',
+			'width': 80,
+			'hidden': 1
 		}
 	]
 


### PR DESCRIPTION
Due to hidden columns data in export was not export in  correct order
Temporary solution: Moved hidden column at the end

Before:
<img width="907" alt="Screenshot 2020-06-10 at 6 20 02 PM" src="https://user-images.githubusercontent.com/42651287/84271453-bff9c180-ab49-11ea-9297-c34cd36a2a58.png">

After:
<img width="882" alt="Screenshot 2020-06-10 at 6 23 51 PM" src="https://user-images.githubusercontent.com/42651287/84271472-c4be7580-ab49-11ea-8ce8-ee12274bc689.png">
