### PR TITLE
fix: Party validation for inter-warehouse transaction

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -1450,10 +1450,16 @@ def get_inter_company_details(doc, doctype):
 		parties = frappe.db.get_all("Supplier", fields=["name"], filters={"disabled": 0, "is_internal_supplier": 1, "represents_company": doc.company})
 		company = frappe.get_cached_value("Customer", doc.customer, "represents_company")
 
+		if not parties:
+			frappe.throw(_('No Supplier found for Inter Company Transactions which represents company {0}').format(frappe.bold(doc.company)))
+
 		party = get_internal_party(parties, "Supplier", doc)
 	else:
 		parties = frappe.db.get_all("Customer", fields=["name"], filters={"disabled": 0, "is_internal_customer": 1, "represents_company": doc.company})
 		company = frappe.get_cached_value("Supplier", doc.supplier, "represents_company")
+
+		if not parties:
+			frappe.throw(_('No Customer found for Inter Company Transactions which represents company {0}').format(frappe.bold(doc.company)))
 
 		party = get_internal_party(parties, "Customer", doc)
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-2020-01-15/apps/frappe/frappe/app.py", line 62, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-2020-01-15/apps/frappe/frappe/api.py", line 58, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-2020-01-15/apps/frappe/frappe/handler.py", line 24, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-2020-01-15/apps/frappe/frappe/handler.py", line 63, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-2020-01-15/apps/frappe/frappe/__init__.py", line 1074, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-2020-01-15/apps/frappe/frappe/model/mapper.py", line 30, in make_mapped_doc
    return method(source_name)
  File "/home/frappe/benches/bench-2020-01-15/apps/erpnext/erpnext/accounts/doctype/sales_invoice/sales_invoice.py", line 1505, in make_inter_company_purchase_invoice
    return make_inter_company_transaction("Sales Invoice", source_name, target_doc)
  File "/home/frappe/benches/bench-2020-01-15/apps/erpnext/erpnext/accounts/doctype/sales_invoice/sales_invoice.py", line 1515, in make_inter_company_transaction
    validate_inter_company_transaction(source_doc, doctype)
  File "/home/frappe/benches/bench-2020-01-15/apps/erpnext/erpnext/accounts/doctype/sales_invoice/sales_invoice.py", line 1485, in validate_inter_company_transaction
    details = get_inter_company_details(doc, doctype)
  File "/home/frappe/benches/bench-2020-01-15/apps/erpnext/erpnext/accounts/doctype/sales_invoice/sales_invoice.py", line 1455, in get_inter_company_details
    party = get_internal_party(parties, "Supplier", doc)
  File "/home/frappe/benches/bench-2020-01-15/apps/erpnext/erpnext/accounts/doctype/sales_invoice/sales_invoice.py", line 1479, in get_internal_party
    party = parties[0].name
IndexError: list index out of range
```