### PR TITLE
fix: verification for razorpay hooks

### DIFF
--- a/erpnext/non_profit/doctype/member/member.py
+++ b/erpnext/non_profit/doctype/member/member.py
@@ -92,6 +92,10 @@ def create_customer(user_details):
 		})
 
 		contact.insert()
+
+	except frappe.DuplicateEntryError:
+		return customer.name
+
 	except Exception as e:
 		frappe.log_error(frappe.get_traceback(), _("Contact Creation Failed"))
 		pass

--- a/erpnext/non_profit/doctype/member/member.py
+++ b/erpnext/non_profit/doctype/member/member.py
@@ -77,6 +77,7 @@ def create_customer(user_details):
 	customer = frappe.new_doc("Customer")
 	customer.customer_name = user_details.fullname
 	customer.customer_type = "Individual"
+	customer.flags.ignore_mandatory = True
 	customer.insert(ignore_permissions=True)
 
 	try:
@@ -91,7 +92,7 @@ def create_customer(user_details):
 			"link_name": customer.name
 		})
 
-		contact.insert()
+		contact.save()
 
 	except frappe.DuplicateEntryError:
 		return customer.name

--- a/erpnext/non_profit/doctype/membership/membership.py
+++ b/erpnext/non_profit/doctype/membership/membership.py
@@ -62,7 +62,10 @@ def get_member_based_on_subscription(subscription_id, email):
 					'subscription_id': subscription_id,
 					'email_id': email
 				}, order_by="creation desc")
-	return frappe.get_doc("Member", members[0]['name'])
+	try:
+		return frappe.get_doc("Member", members[0]['name'])
+	except:
+		return None
 
 def verify_signature(data):
 	signature = frappe.request.headers.get('X-Razorpay-Signature')
@@ -96,7 +99,10 @@ def trigger_razorpay_subscription(*args, **kwargs):
 	except Exception as e:
 		error_log = frappe.log_error(frappe.get_traceback() + '\n' + data_json , _("Membership Webhook Failed"))
 		notify_failure(error_log)
-		raise e
+		return False
+
+	if not member:
+		return False
 
 	if data.event == "subscription.activated":
 		member.customer_id = payment.customer_id

--- a/erpnext/non_profit/doctype/membership/membership.py
+++ b/erpnext/non_profit/doctype/membership/membership.py
@@ -77,7 +77,7 @@ def verify_signature(data):
 
 @frappe.whitelist(allow_guest=True)
 def trigger_razorpay_subscription(*args, **kwargs):
-	data = frappe.request.get_data()
+	data = frappe.request.get_data(as_text=True)
 	verify_signature(data)
 
 	if isinstance(data, six.string_types):


### PR DESCRIPTION
This PR has the following changes

* fix: use string to verify webhook instead of dict
* handle null state for member explicityl
* check duplicate contact explicitly
* ignore mandatory for customer 