### PR TITLE
fix: Don't prompt for Quality Inspection on Return Documents.

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -19,7 +19,7 @@ class QualityInspectionNotSubmittedError(frappe.ValidationError): pass
 class StockController(AccountsController):
 	def validate(self):
 		super(StockController, self).validate()
-		if not self.is_return:
+		if not self.get('is_return'):
 			self.validate_inspection()
 		self.validate_serialized_batch()
 		self.validate_customer_provided_item()

--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -19,7 +19,8 @@ class QualityInspectionNotSubmittedError(frappe.ValidationError): pass
 class StockController(AccountsController):
 	def validate(self):
 		super(StockController, self).validate()
-		self.validate_inspection()
+		if not self.is_return:
+			self.validate_inspection()
 		self.validate_serialized_batch()
 		self.validate_customer_provided_item()
 


### PR DESCRIPTION
- Once QI is done on Receipt, don't prompt again on Return.