### PR TITLE
fix: Check for Company before rendering tree in Account Tree

### DIFF
--- a/erpnext/accounts/doctype/account/account_tree.js
+++ b/erpnext/accounts/doctype/account/account_tree.js
@@ -14,6 +14,9 @@ frappe.treeview_settings["Account"] = {
 			on_change: function() {
 				var me = frappe.treeview_settings['Account'].treeview;
 				var company = me.page.fields_dict.company.get_value();
+				if (!company) {
+					frappe.throw(__("Please set a Company"));
+				}
 				frappe.call({
 					method: "erpnext.accounts.doctype.account.account.get_root_company",
 					args: {


### PR DESCRIPTION
- This occurs sometimes in Account Tree
   `lft, rgt = frappe.db.get_value(doctype, name, ["lft", "rgt"])`
    `TypeError: 'NoneType' object is not iterable`
- This is due to company going as `null` from the filter. `get_tree_default` gets a null value somehow that get's set and even triggers `on_change`
- The root cause has something to do with permissions, it's hard to say exactly what as its not possible to replicate.
- Till then, some defensive code to avoid server side call if company is null.