### PR TITLE
Stock Ageing TypeError: ‘<’ not supported between instances of ‘int’ …

### DIFF
--- a/erpnext/stock/report/stock_ageing/stock_ageing.py
+++ b/erpnext/stock/report/stock_ageing/stock_ageing.py
@@ -187,7 +187,7 @@ def get_fifo_queue(filters, sle=None):
 						transferred_item_details[(d.voucher_no, d.name)].append(fifo_queue.pop(0))
 					else:
 						# all from current batch
-						flt(batch[0]) -= qty_to_pop
+						batch[0] -= qty_to_pop
 						transferred_item_details[(d.voucher_no, d.name)].append([qty_to_pop, batch[1]])
 						qty_to_pop = 0
 

--- a/erpnext/stock/report/stock_ageing/stock_ageing.py
+++ b/erpnext/stock/report/stock_ageing/stock_ageing.py
@@ -180,14 +180,14 @@ def get_fifo_queue(filters, sle=None):
 				qty_to_pop = abs(d.actual_qty)
 				while qty_to_pop:
 					batch = fifo_queue[0] if fifo_queue else [0, None]
-					if 0 < cint(batch[0]) <= qty_to_pop:
+					if 0 < flt(batch[0]) <= qty_to_pop:
 						# if batch qty > 0
 						# not enough or exactly same qty in current batch, clear batch
-						qty_to_pop -= cint(batch[0])
+						qty_to_pop -= flt(batch[0])
 						transferred_item_details[(d.voucher_no, d.name)].append(fifo_queue.pop(0))
 					else:
 						# all from current batch
-						cint(batch[0]) -= qty_to_pop
+						flt(batch[0]) -= qty_to_pop
 						transferred_item_details[(d.voucher_no, d.name)].append([qty_to_pop, batch[1]])
 						qty_to_pop = 0
 

--- a/erpnext/stock/report/stock_ageing/stock_ageing.py
+++ b/erpnext/stock/report/stock_ageing/stock_ageing.py
@@ -180,14 +180,14 @@ def get_fifo_queue(filters, sle=None):
 				qty_to_pop = abs(d.actual_qty)
 				while qty_to_pop:
 					batch = fifo_queue[0] if fifo_queue else [0, None]
-					if 0 < batch[0] <= qty_to_pop:
+					if 0 < cint(batch[0]) <= qty_to_pop:
 						# if batch qty > 0
 						# not enough or exactly same qty in current batch, clear batch
-						qty_to_pop -= batch[0]
+						qty_to_pop -= cint(batch[0])
 						transferred_item_details[(d.voucher_no, d.name)].append(fifo_queue.pop(0))
 					else:
 						# all from current batch
-						batch[0] -= qty_to_pop
+						cint(batch[0]) -= qty_to_pop
 						transferred_item_details[(d.voucher_no, d.name)].append([qty_to_pop, batch[1]])
 						qty_to_pop = 0
 


### PR DESCRIPTION
…and ‘str’

Re this user report https://discuss.erpnext.com/t/stock-ageing-report-typeerror-not-supported-between-instances-of-int-and-str/62605

Notes: 

ASSUMPTION:  This error arises in current version-12 production?

WARNING: This proposed change has not been tested

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
