### PR TITLE
fix: add filter for cost center in expense table

### DIFF
--- a/erpnext/hr/doctype/expense_claim/expense_claim.js
+++ b/erpnext/hr/doctype/expense_claim/expense_claim.js
@@ -154,6 +154,14 @@ frappe.ui.form.on("Expense Claim", {
 				}
 			};
 		});
+		frm.set_query("cost_center", "expenses", function() {
+			return {
+				filters: {
+					"company": frm.doc.company,
+					"is_group": 0
+				}
+			};
+		});
 		frm.set_query("account_head", "taxes", function(doc) {
 			return {
 				filters: [


### PR DESCRIPTION
Added filter for cost center in expense table (company and group_node filter)

Before: Cost centers of all company shown including root nodes 
![image](https://user-images.githubusercontent.com/50285544/84467775-ba5fc100-ac9a-11ea-832b-6a04ec9e2969.png)
