### PR TITLE
fix(patch): escape special characters in company field

### DIFF
--- a/erpnext/patches/v13_0/set_company_field_in_healthcare_doctypes.py
+++ b/erpnext/patches/v13_0/set_company_field_in_healthcare_doctypes.py
@@ -7,4 +7,4 @@ def execute():
 	for entry in doctypes:
 		if frappe.db.exists('DocType', entry):
 			frappe.reload_doc('Healthcare', 'doctype', entry)
-			frappe.db.sql("update `tab{dt}` set company = '{company}' where ifnull(company, '') = ''".format(dt=entry, company=company))
+			frappe.db.sql("update `tab{dt}` set company = {company} where ifnull(company, '') = ''".format(dt=entry, company=frappe.db.escape(company)))


### PR DESCRIPTION
`pymysql.err.ProgrammingError: (1064, "You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 's Repair Shop BV' where coalesce(company, '') = ''' at line 1")`