### PR TITLE
fix: Validation of Purchase Order against Material Request missing

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -71,6 +71,15 @@ class PurchaseOrder(BuyingController):
 				"compare_fields": [["project", "="], ["item_code", "="],
 					["uom", "="], ["conversion_factor", "="]],
 				"is_child_table": True
+			},
+			"Material Request": {
+				"ref_dn_field": "material_request",
+				"compare_fields": [["company", "="]],
+			},
+			"Material Request Item": {
+				"ref_dn_field": "material_request_item",
+				"compare_fields": [["project", "="], ["item_code", "="]],
+				"is_child_table": True
 			}
 		})
 


### PR DESCRIPTION
Validation of Purchase Order and Purchase Order Item against the linked Material Request Item was missing.
This way, it was possible to exchange items while making a purchase order and still fulfill the material request, even though the items did not match.