### PR TITLE
fix: Data not appearing properly for some fiscal_year in financial statements

### DIFF
--- a/erpnext/accounts/report/financial_statements.py
+++ b/erpnext/accounts/report/financial_statements.py
@@ -50,9 +50,8 @@ def get_period_list(from_fiscal_year, to_fiscal_year, periodicity, accumulated_v
 		to_date = add_months(start_date, months_to_add)
 		start_date = to_date
 
-		if to_date == get_first_day(to_date):
-			# if to_date is the first day, get the last day of previous month
-			to_date = add_days(to_date, -1)
+		# Subtract one day from to_date, as it may be first day in next fiscal year or month
+		to_date = add_days(to_date, -1)
 
 		if to_date <= year_end_date:
 			# the normal case


### PR DESCRIPTION
To Date in period list should be subtracted by one day even if the start and end date of fiscal years is not the start or end date of the month as the end date may overlap with next fiscal years start date 