### PR TITLE
fix: Wrong key sent to get_valuation_rate

### DIFF
--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -349,7 +349,7 @@ class BuyingController(StockController):
 			})
 
 			if not rm.rate:
-				rm.rate = get_valuation_rate(raw_material_data.item_code, self.supplier_warehouse,
+				rm.rate = get_valuation_rate(raw_material_data.rm_item_code, self.supplier_warehouse,
 					self.doctype, self.name, currency=self.company_currency, company=self.company)
 
 		rm.amount = qty * flt(rm.rate)


### PR DESCRIPTION
- `TypeError: quote_from_bytes() expected bytes` occurs while trying to get form link to raise valuation rate error message.
- item_code sent to `frappe.utils.get_link_to_form` was None, hence the issue