### PR TITLE
fix: Message Formatting for missing Expense Account

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -225,7 +225,9 @@ class StockController(AccountsController):
 
 	def check_expense_account(self, item):
 		if not item.get("expense_account"):
-			frappe.throw(_("Expense Account not set for Item {0}. Please set an Expense Account for the item in the Items table").format(item.item_code))
+			frappe.throw(_("Row #{0}: Expense Account not set for Item {1}. Please set an Expense \
+				Account in the Items table").format(item.idx, frappe.bold(item.item_code)),
+				title=_("Expense Account Missing"))
 
 		else:
 			is_expense_account = frappe.db.get_value("Account",


### PR DESCRIPTION
Added Row ID and minor formatting to message 
![Screenshot 2020-06-17 at 1 45 42 PM](https://user-images.githubusercontent.com/25857446/84873458-e5825000-b0a0-11ea-95cc-4dfff01be6b2.png)

**How to replicate:**
Unset expense account in any Stock transaction's child table. You could also remove default COGS account from company