### PR TITLE
fix: Quality procedure fixes

### DIFF
--- a/erpnext/quality_management/doctype/quality_procedure/quality_procedure.js
+++ b/erpnext/quality_management/doctype/quality_procedure/quality_procedure.js
@@ -8,7 +8,7 @@ frappe.ui.form.on('Quality Procedure', {
 				filters: {
 					name: ["not in", [frm.parent_quality_procedure, frm.name]]
 				}
-			}
-		})
+			};
+		});
 	}
 });

--- a/erpnext/quality_management/doctype/quality_procedure/quality_procedure.js
+++ b/erpnext/quality_management/doctype/quality_procedure/quality_procedure.js
@@ -2,4 +2,13 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Quality Procedure', {
+	refresh: function(frm) {
+		frm.set_query("procedure","processes", (frm) =>{
+			return {
+				filters: {
+					name: ["not in", [frm.parent_quality_procedure, frm.name]]
+				}
+			}
+		})
+	}
 });

--- a/erpnext/quality_management/doctype/quality_procedure/quality_procedure.json
+++ b/erpnext/quality_management/doctype/quality_procedure/quality_procedure.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_rename": 1,
  "autoname": "format:PRC-{quality_procedure_name}",
  "creation": "2018-10-06 00:06:29.756804",
  "doctype": "DocType",
@@ -72,7 +73,7 @@
  ],
  "is_tree": 1,
  "links": [],
- "modified": "2020-03-18 18:26:05.511984",
+ "modified": "2020-06-17 17:25:03.434953",
  "modified_by": "Administrator",
  "module": "Quality Management",
  "name": "Quality Procedure",

--- a/erpnext/quality_management/doctype/quality_procedure/quality_procedure.py
+++ b/erpnext/quality_management/doctype/quality_procedure/quality_procedure.py
@@ -46,9 +46,7 @@ class QualityProcedure(NestedSet):
 			# Set parent for only those children who don't have a parent
 			parent_quality_procedure = frappe.db.get_value("Quality Procedure", process.procedure, "parent_quality_procedure")
 			if not parent_quality_procedure and process.procedure:
-				doc = frappe.get_doc("Quality Procedure", process.procedure)
-				doc.parent_quality_procedure = self.name
-				doc.save(ignore_permissions=True)
+				frappe.db.set_value(self.doctype, process.procedure, "parent_quality_procedure", self.name)
 
 	def check_for_incorrect_child(self):
 		for process in self.processes:

--- a/erpnext/quality_management/doctype/quality_procedure/quality_procedure.py
+++ b/erpnext/quality_management/doctype/quality_procedure/quality_procedure.py
@@ -10,13 +10,8 @@ from frappe import _
 class QualityProcedure(NestedSet):
 	nsm_parent_field = 'parent_quality_procedure'
 
-	def on_save(self):
-		for process in self.processes:
-			if process.procedure:
-				doc = frappe.get_doc("Quality Procedure", process.procedure)
-				if doc.parent_quality_procedure:
-					frappe.throw(_("{0} already has a Parent Procedure {1}.".format(process.procedure, doc.parent_quality_procedure)))
-				self.is_group = 1
+	def before_save(self):
+		self.check_for_incorrect_child()
 
 	def on_update(self):
 		self.set_parent()
@@ -48,10 +43,22 @@ class QualityProcedure(NestedSet):
 
 	def set_parent(self):
 		for process in self.processes:
-			if process.procedure:
+			# Set parent for only those children who don't have a parent
+			parent_quality_procedure = frappe.db.get_value("Quality Procedure", process.procedure, "parent_quality_procedure")
+			if not parent_quality_procedure and process.procedure:
 				doc = frappe.get_doc("Quality Procedure", process.procedure)
 				doc.parent_quality_procedure = self.name
 				doc.save(ignore_permissions=True)
+
+	def check_for_incorrect_child(self):
+		for process in self.processes:
+			if process.procedure:
+				# Check if any child process belongs to another parent.
+				parent_quality_procedure = frappe.db.get_value("Quality Procedure", process.procedure, "parent_quality_procedure")
+				if parent_quality_procedure and parent_quality_procedure != self.name:
+					frappe.throw(_("{0} already has a Parent Procedure {1}.".format(frappe.bold(process.procedure), frappe.bold(parent_quality_procedure))),
+						title=_("Invalid Child Procedure"))
+				self.is_group = 1
 
 @frappe.whitelist()
 def get_children(doctype, parent=None, parent_quality_procedure=None, is_root=False):

--- a/erpnext/quality_management/doctype/quality_procedure/quality_procedure_tree.js
+++ b/erpnext/quality_management/doctype/quality_procedure/quality_procedure_tree.js
@@ -16,6 +16,7 @@ frappe.treeview_settings["Quality Procedure"] = {
 		},
 	],
 	breadcrumb: "Setup",
+	disable_add_node: true,
 	root_label: "All Quality Procedures",
 	get_tree_root: false,
 	menu_items: [

--- a/erpnext/quality_management/doctype/quality_procedure_process/quality_procedure_process.json
+++ b/erpnext/quality_management/doctype/quality_procedure_process/quality_procedure_process.json
@@ -1,6 +1,8 @@
 {
+ "actions": [],
  "creation": "2019-05-26 00:10:00.248885",
  "doctype": "DocType",
+ "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
   "process_description",
@@ -23,7 +25,8 @@
   }
  ],
  "istable": 1,
- "modified": "2019-05-26 22:05:49.007189",
+ "links": [],
+ "modified": "2020-06-17 15:44:38.937915",
  "modified_by": "Administrator",
  "module": "Quality Management",
  "name": "Quality Procedure Process",


### PR DESCRIPTION
- Check if any child procedure belongs to another parent. If yes:
  ![Screenshot 2020-06-17 at 5 58 26 PM](https://user-images.githubusercontent.com/25857446/84899795-c991a500-b0c6-11ea-81e6-87c34da93574.png)

- On saving, parent is set in child processes. Set parent only for those children without a parent. Used `frappe.db.get_value` to reduce `get_doc` time and also to avoid triggering save for each child (which will run validations for all the children until it reaches a leaf node)  

- Filter child procedure field. 
  ![Screenshot 2020-06-17 at 5 34 35 PM](https://user-images.githubusercontent.com/25857446/84895786-7b79a300-b0c0-11ea-9d86-67e4d98f29d9.png)

   Don't let users select :
   * The same process as the current document (Process cant be its own child)
   * The parent of the current document (Its parent cant be its child)

- Allow Renaming
- Disable New button in tree view (UX)
- Editable grid for Quality Procedure Process table (UX)

