### PR TITLE
fix: Set Value of wrong Bank Account Field in Payment Entry

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -25,7 +25,7 @@ frappe.ui.form.on('Payment Entry', {
 		});
 		frm.set_query("party_type", function() {
 			return{
-				"filters": {
+				filters: {
 					"name": ["in", Object.keys(frappe.boot.party_account_types)],
 				}
 			}
@@ -33,14 +33,16 @@ frappe.ui.form.on('Payment Entry', {
 		frm.set_query("party_bank_account", function() {
 			return {
 				filters: {
-					"is_company_account":0
+					is_company_account: 0,
+					party_type: frm.doc.party_type,
+					party: frm.doc.party
 				}
 			}
 		});
 		frm.set_query("bank_account", function() {
 			return {
 				filters: {
-					"is_company_account":1
+					is_company_account: 1
 				}
 			}
 		});
@@ -326,7 +328,7 @@ frappe.ui.form.on('Payment Entry', {
 							() => {
 								frm.set_party_account_based_on_party = false;
 								if (r.message.bank_account) {
-									frm.set_value("party_bank_account", r.message.bank_account);
+									frm.set_value("bank_account", r.message.bank_account);
 								}
 							}
 						]);

--- a/erpnext/buying/doctype/supplier/supplier.json
+++ b/erpnext/buying/doctype/supplier/supplier.json
@@ -97,7 +97,7 @@
   {
    "fieldname": "default_bank_account",
    "fieldtype": "Link",
-   "label": "Default Bank Account",
+   "label": "Default Company Bank Account",
    "options": "Bank Account"
   },
   {
@@ -385,7 +385,7 @@
  "idx": 370,
  "image_field": "image",
  "links": [],
- "modified": "2020-03-17 09:48:30.578242",
+ "modified": "2020-06-17 23:28:30",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Supplier",


### PR DESCRIPTION
Company bank account was wrongly inserted into the field "Party Bank Account" in payment entry, instead of "Bank Account".

Adds filters for "Party Bank Account" based on selected Party (I forgot to create a PR for version-12 back in February, see PR #20653).

Also changes the label of "Default Bank Account" to "Default Company Bank Account", like suggested in PR #20632

#### Please Note
This is kind of a revert of PR #19390. However, it seems like the function "get_party_bank_account" in Bank Account doctype changed how it worked since it is clearly pulling the default company bank account.