### PR TITLE
fix: Do not copy Item Tax template from SO to PO

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -868,7 +868,8 @@ def make_purchase_order(source_name, for_supplier=None, selected_items=[], targe
 			 		],
 					"field_no_map": [
 						"rate",
-						"price_list_rate"
+						"price_list_rate",
+						"item_tax_template"
 					],
 					"postprocess": update_item,
 					"condition": lambda doc: doc.ordered_qty < doc.qty and doc.supplier == supplier and doc.item_code in selected_items


### PR DESCRIPTION
Taxes in Sales Order should not be copied in PO

Taxes and Charges is already there in no field map, Added item tax template in that list as well.