### PR TITLE
refactor: show service instead of services

### DIFF
--- a/erpnext/templates/includes/footer/footer_powered.html
+++ b/erpnext/templates/includes/footer/footer_powered.html
@@ -10,9 +10,17 @@
 	'Agriculture': '/agriculture',
 	'Hospitality': ''
 } %}
+
 {% set link = '' %}
+{% set label = domains[0].domain %}
 {% if domains %}
-	{% set link = links[domains[0].domain] %}
+	{% set link = links[label] %}
 {% endif %}
 
-<a href="https://erpnext.com{{ link }}?source=website_footer" target="_blank" class="text-muted">Powered by ERPNext - {{ '' if domains else 'Open Source' }} ERP Software {{ ('for ' + domains[0].domain + ' Companies') if domains else '' }}</a>
+{% if label == "Services" %}
+	{% set label = "Service" %}
+{% endif %}
+
+
+
+<a href="https://erpnext.com{{ link }}?source=website_footer" target="_blank" class="text-muted">Powered by ERPNext - {{ '' if domains else 'Open Source' }} ERP Software {{ ('for ' + label + ' Companies') if domains else '' }}</a>


### PR DESCRIPTION
Fix grammar, rename "Services" to "Service" when rendering in footer

![image](https://user-images.githubusercontent.com/18097732/85032017-f44e2d00-b19c-11ea-92fc-c8a718c6795c.png)
