### PR TITLE
fix: Unable to create batched item

### DIFF
--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -883,7 +883,12 @@ class Item(WebsiteGenerator):
 			linked_doctypes += ["Sales Order Item", "Purchase Order Item", "Material Request Item"]
 
 		for doctype in linked_doctypes:
-			if frappe.db.get_value(doctype, filters={"item_code": self.name, "docstatus": 1}) or \
+			if doctype in ("Purchase Invoice Item", "Sales Invoice Item",):
+				# If Invoice has Stock impact, only then consider it.
+				if self.stock_ledger_created():
+					return True
+
+			elif frappe.db.get_value(doctype, filters={"item_code": self.name, "docstatus": 1}) or \
 				frappe.db.get_value("Production Order",
 					filters={"production_item": self.name, "docstatus": 1}):
 				return True


### PR DESCRIPTION
- Consider an Item without any Stock Transactions against it and just a Purchase Invoice **without** Update Stock against it.
- Try changing value of **Has Batch No** or  **Has Serial No**
- It prompts "As there are existing transactions...you can not change the value of Has Serial No" even though there is only a Purchase Invoice against it that has no stock effect.

**Fix:**
- For Sales/Purchase Invoices against item , check if any invoice has impact on Stock Ledger. If not, allow to edit.