### PR TITLE
fix: Customer Group label in Item-wise Sales History report

### DIFF
--- a/erpnext/selling/report/item_wise_sales_history/item_wise_sales_history.py
+++ b/erpnext/selling/report/item_wise_sales_history/item_wise_sales_history.py
@@ -96,7 +96,7 @@ def get_columns(filters):
 			"label": _("Customer Group"),
 			"fieldtype": "Link",
 			"fieldname": "customer_group",
-			"options": "customer Group",
+			"options": "Customer Group",
 			"width": 120
 		},
 		{


### PR DESCRIPTION
In the report, the Customer Group label was written as customer Group. This at times didn't fetch the fields correctly.

Before fix:
![image](https://user-images.githubusercontent.com/33246109/85055507-4900a080-b1bb-11ea-851d-3d6872ea3658.png)

After fix:
![Screenshot 2020-06-18 at 11 22 24 PM](https://user-images.githubusercontent.com/33246109/85055468-3ab28480-b1bb-11ea-962d-81a54d5ea5f7.png)

