### PR TITLE
chore: Delete Bank Reco doctype

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -700,3 +700,4 @@ erpnext.patches.v12_0.set_italian_import_supplier_invoice_permissions
 erpnext.patches.v13_0.update_sla_enhancements
 erpnext.patches.v12_0.update_address_template_for_india
 erpnext.patches.v12_0.set_multi_uom_in_rfq
+execute:frappe.delete_doc_if_exists("DocType", "Bank Reconciliation")


### PR DESCRIPTION
Bank Reconciliation was recently rename in this PR https://github.com/frappe/erpnext/pull/21171

But the doc still exists and when user searches it from Awesome Bar following error pops up on selection

![image](https://user-images.githubusercontent.com/42651287/85103965-40dd4b00-b225-11ea-951d-f7ae01c8ca19.png)
