### PR TITLE
fix(pricing_rule): clear discount amount

### DIFF
--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -18,8 +18,12 @@ erpnext.taxes_and_totals = erpnext.payments.extend({
 
 		item.rate = flt(item.rate_with_margin , precision("rate", item));
 
-		if(item.discount_percentage){
+		if (item.discount_percentage) {
 			item.discount_amount = flt(item.rate_with_margin) * flt(item.discount_percentage) / 100;
+		} else if (item.discount_percentage === 0) {
+			// there are some case that discount_amount has been set
+			// by previous item and doesn't got clear when change item
+			item.discount_amount = 0;
 		}
 
 		if (item.discount_amount) {


### PR DESCRIPTION
Discount amount on previous selected item won't get clear when new item have 0% discount pricing rule.

**Step to replicate:**
(We'll use discount on Item and discount on brand since discount on all item and brand won't work according to #22328)
- Create pricing rule A and B
- Go to Sales Invoice
- Select Item A (Which have price discount 10%)
- Change Item B (Which have price discount 0%)
- Item B will get discount amount from Item A

**Expected result:**
When changing from item A to item B discount will get clear according to pricing rule of Item B

**Use case:**
Create promotion which have discount 10% on all item exclude brand A

Pricing rule A (Discount 10% on Item A):
![image](https://user-images.githubusercontent.com/24489363/85115432-d983c300-b245-11ea-913c-ecfa85e33b10.png)

Pricing rule B (Discount 10% on Brand 001):
![image](https://user-images.githubusercontent.com/24489363/85115491-f15b4700-b245-11ea-9bb2-4f933447a112.png)

