### PR TITLE
fix: Skipping total row for tree-view reports

### DIFF
--- a/erpnext/selling/report/sales_analytics/sales_analytics.json
+++ b/erpnext/selling/report/sales_analytics/sales_analytics.json
@@ -1,5 +1,5 @@
 {
- "add_total_row": 0,
+ "add_total_row": 1,
  "creation": "2018-09-21 12:46:29.451048",
  "disable_prepared_report": 0,
  "disabled": 0,
@@ -7,7 +7,7 @@
  "doctype": "Report",
  "idx": 0,
  "is_standard": "Yes",
- "modified": "2020-04-30 19:49:02.303320",
+ "modified": "2020-06-19 17:41:03.132101",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Analytics",

--- a/erpnext/selling/report/sales_analytics/sales_analytics.py
+++ b/erpnext/selling/report/sales_analytics/sales_analytics.py
@@ -23,7 +23,14 @@ class Analytics(object):
 		self.get_columns()
 		self.get_data()
 		self.get_chart_data()
-		return self.columns, self.data, None, self.chart
+
+		# Skiping total row for tree-view reports
+		skip_total_row = 0
+
+		if self.filters.tree_type in ["Supplier Group", "Item Group", "Customer Group", "Territory"]:
+			skip_total_row = 1
+
+		return self.columns, self.data, None, self.chart, None, skip_total_row
 
 	def get_columns(self):
 		self.columns = [{
@@ -194,9 +201,6 @@ class Analytics(object):
 	def get_rows(self):
 		self.data = []
 		self.get_periodic_data()
-		total_row = {
-			"entity": "Total",
-		}
 
 		for entity, period_data in iteritems(self.entity_periodic_data):
 			row = {
@@ -210,17 +214,12 @@ class Analytics(object):
 				row[scrub(period)] = amount
 				total += amount
 
-				if not total_row.get(scrub(period)): total_row[scrub(period)] = 0
-				total_row[scrub(period)] += amount
-
 			row["total"] = total
 
 			if self.filters.tree_type == "Item":
 				row["stock_uom"] = period_data.get("stock_uom")
 
 			self.data.append(row)
-
-		self.data.append(total_row)
 
 	def get_rows_by_group(self):
 		self.get_periodic_data()

--- a/erpnext/selling/report/sales_analytics/sales_analytics.py
+++ b/erpnext/selling/report/sales_analytics/sales_analytics.py
@@ -24,7 +24,7 @@ class Analytics(object):
 		self.get_data()
 		self.get_chart_data()
 
-		# Skiping total row for tree-view reports
+		# Skipping total row for tree-view reports
 		skip_total_row = 0
 
 		if self.filters.tree_type in ["Supplier Group", "Item Group", "Customer Group", "Territory"]:

--- a/erpnext/selling/report/sales_analytics/test_analytics.py
+++ b/erpnext/selling/report/sales_analytics/test_analytics.py
@@ -34,21 +34,6 @@ class TestAnalytics(unittest.TestCase):
 
 		expected_data = [
 			{
-				'entity': 'Total',
-				'apr_2017': 0.0,
-				'may_2017': 0.0,
-				'jun_2017': 2000.0,
-				'jul_2017': 1000.0,
-				'aug_2017': 0.0,
-				'sep_2017': 1500.0,
-				'oct_2017': 1000.0,
-				'nov_2017': 0.0,
-				'dec_2017': 0.0,
-				'jan_2018': 0.0,
-				'feb_2018': 2000.0,
-				'mar_2018': 0.0
-  			},
-			{
 				"entity": "_Test Customer 1",
 				"entity_name": "_Test Customer 1",
 				"apr_2017": 0.0,
@@ -149,21 +134,6 @@ class TestAnalytics(unittest.TestCase):
 		report = execute(filters)
 
 		expected_data = [
-			{
-				'entity': 'Total',
-				'apr_2017': 0.0,
-				'may_2017': 0.0,
-				'jun_2017': 20.0,
-				'jul_2017': 10.0,
-				'aug_2017': 0.0,
-				'sep_2017': 15.0,
-				'oct_2017': 10.0,
-				'nov_2017': 0.0,
-				'dec_2017': 0.0,
-				'jan_2018': 0.0,
-				'feb_2018': 20.0,
-				'mar_2018': 0.0
-  			},
 			{
 				"entity": "_Test Customer 1",
 				"entity_name": "_Test Customer 1",


### PR DESCRIPTION
Skipping Total row for tree view doctypes as Total Row shows inflated values for tree view reports