### PR TITLE
fix: trigger docker build on release

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,7 +1,7 @@
 name: Trigger Docker build on release
 on:
   release:
-    types: [created]
+    types: [released]
 jobs:
   curl:
     runs-on: ubuntu-latest


### PR DESCRIPTION
release action type to released instead of created