### PR TITLE
fix: reload doc and make custom field for regional setup

### DIFF
--- a/erpnext/patches/v13_0/check_is_income_tax_component.py
+++ b/erpnext/patches/v13_0/check_is_income_tax_component.py
@@ -18,6 +18,14 @@ def execute():
         frappe.db.set_value("Salary Component", component.name, "is_income_tax_component", 1)
 
     if erpnext.get_region() == "India":
+        from erpnext.regional.india.setup import make_custom_fields
+
+        for doctype in ("Employee Tax Exemption Declaration", "Employee Tax Exemption Proof Submission",
+                        "Employee Tax Exemption Declaration Category", "Employee Tax Exemption Proof Submission Detail"):
+            frappe.reload_doc("Payroll", "doctype", doctype)
+
+        make_custom_fields()
+
         if frappe.db.exists("Salary Component", "Provident Fund"):
             frappe.db.set_value("Salary Component", "Provident Fund", "component_type", "Provident Fund")
         if frappe.db.exists("Salary Component", "Professional Tax"):

--- a/erpnext/patches/v13_0/check_is_income_tax_component.py
+++ b/erpnext/patches/v13_0/check_is_income_tax_component.py
@@ -7,6 +7,7 @@ import frappe, erpnext
 
 def execute():
     frappe.reload_doc('Payroll', 'doctype', 'salary_structure')
+    frappe.reload_doc('Payroll', 'doctype', 'salary_component')
 
     if frappe.db.exists("Salary Component", "Income Tax"):
         frappe.db.set_value("Salary Component", "Income Tax", "is_income_tax_component", 1)


### PR DESCRIPTION
patch failed to run on existing setups with region set to India since the custom field "component_type" was not setup

ref: #21990 