### PR TITLE
fix: Serial no / batch no Popup is coming for the non serialized items

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -535,6 +535,12 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 								() => me.frm.script_manager.trigger("price_list_rate", cdt, cdn),
 								() => me.toggle_conversion_factor(item),
 								() => {
+									if (show_batch_dialog && !item.has_serial_no
+										&& !item.has_batch_no) {
+										show_batch_dialog = false;
+									}
+								},
+								() => {
 									if (show_batch_dialog)
 										return frappe.db.get_value("Item", item.item_code, ["has_batch_no", "has_serial_no"])
 											.then((r) => {


### PR DESCRIPTION
**Issue**
While making delivery note serial no popup is coming for non serialized items
![image](https://user-images.githubusercontent.com/8780500/85204912-6bb6c480-b335-11ea-90a6-da565df475b2.png)
