### PR TITLE
fix(Immutable Ledger): Item wise backdated stock entry posting

### DIFF
--- a/erpnext/utilities/transaction_base.py
+++ b/erpnext/utilities/transaction_base.py
@@ -161,19 +161,22 @@ class TransactionBase(StatusUpdater):
 			if not (self.get("update_stock") or self.get("is_pos")):
 				return
 
-		fiscal_year = get_fiscal_year(self.get('posting_date'), as_dict=True).name
+		for item in self.get('items'):
+			fiscal_year = get_fiscal_year(self.get('posting_date'), as_dict=True).name
 
-		last_transaction_time = frappe.db.sql("""
-			select MAX(timestamp(posting_date, posting_time)) as posting_time
-			from `tabStock Ledger Entry`
-			where docstatus = 1""")[0][0]
+			last_transaction_time = frappe.db.sql("""
+				select MAX(timestamp(posting_date, posting_time)) as posting_time
+				from `tabStock Ledger Entry`
+				where docstatus = 1 and item_code = %s """, (item.item_code))[0][0]
 
-		cur_doc_posting_datetime = "%s %s" % (self.posting_date, self.get("posting_time") or "00:00:00")
+			cur_doc_posting_datetime = "%s %s" % (self.posting_date, self.get("posting_time") or "00:00:00")
 
-		if last_transaction_time and get_datetime(cur_doc_posting_datetime) < get_datetime(last_transaction_time):
-			frappe.throw(_("""Posting timestamp of current transaction
-				must be after last Stock transaction's timestamp which is {0}""").format(frappe.bold(last_transaction_time)),
-				title=_("Backdated Stock Entry"))
+			if last_transaction_time and get_datetime(cur_doc_posting_datetime) < get_datetime(last_transaction_time):
+				frappe.throw(_("""Last Stock Transaction for item {0} was on {1}.
+					Stock Transactions for Item {2} cannot be posted before this time.
+					Please remove this item and try to submit again or update the posting time""").format(
+					frappe.bold(item.item_code), frappe.bold(last_transaction_time), frappe.bold(item.item_code)),
+					title=_("Backdated Stock Entry"))
 
 def delete_events(ref_type, ref_name):
 	events = frappe.db.sql_list(""" SELECT

--- a/erpnext/utilities/transaction_base.py
+++ b/erpnext/utilities/transaction_base.py
@@ -162,8 +162,6 @@ class TransactionBase(StatusUpdater):
 				return
 
 		for item in self.get('items'):
-			fiscal_year = get_fiscal_year(self.get('posting_date'), as_dict=True).name
-
 			last_transaction_time = frappe.db.sql("""
 				select MAX(timestamp(posting_date, posting_time)) as posting_time
 				from `tabStock Ledger Entry`

--- a/erpnext/utilities/transaction_base.py
+++ b/erpnext/utilities/transaction_base.py
@@ -170,11 +170,10 @@ class TransactionBase(StatusUpdater):
 			cur_doc_posting_datetime = "%s %s" % (self.posting_date, self.get("posting_time") or "00:00:00")
 
 			if last_transaction_time and get_datetime(cur_doc_posting_datetime) < get_datetime(last_transaction_time):
-				frappe.throw(_("""Last Stock Transaction for item {0} was on {1}.
-					Stock Transactions for Item {2} cannot be posted before this time.
-					Please remove this item and try to submit again or update the posting time""").format(
-					frappe.bold(item.item_code), frappe.bold(last_transaction_time), frappe.bold(item.item_code)),
-					title=_("Backdated Stock Entry"))
+				msg = _("Last Stock Transaction for item {0} was on {1}.").format(frappe.bold(item.item_code), frappe.bold(last_transaction_time))
+				msg += "<br><br>" + _("Stock Transactions for Item {0} cannot be posted before this time.").format(frappe.bold(item.item_code))
+				msg += "<br><br>" + _("Please remove this item and try to submit again or update the posting time.")
+				frappe.throw(msg, title=_("Backdated Stock Entry"))
 
 def delete_events(ref_type, ref_name):
 	events = frappe.db.sql_list(""" SELECT


### PR DESCRIPTION
Currently System won't allow backdated entry for any Item before the last stock transaction.

After this fix Item Wise Backdated will be checked

For Eg: If Stock Transaction is posted for Item A is made at 21 June 2020
Then Stock Transaction for Item B can still be made at 20 June 2020