### PR TITLE
fix: Unable to cancel employee advance

### DIFF
--- a/erpnext/hr/doctype/employee_advance/employee_advance.py
+++ b/erpnext/hr/doctype/employee_advance/employee_advance.py
@@ -22,6 +22,7 @@ class EmployeeAdvance(Document):
 		self.validate_employee_advance_account()
 
 	def on_cancel(self):
+		self.ignore_linked_doctypes = ('GL Entry')
 		self.set_status()
 
 	def set_status(self):


### PR DESCRIPTION
Ignore links to GL Entry while cancelling Employee Advance