### PR TITLE
fix: Set default reference Id for "On Previous Row Amount" and "On Previous Row Total"

### DIFF
--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -329,6 +329,17 @@ erpnext.taxes_and_totals = erpnext.payments.extend({
 		var tax_rate = this._get_tax_rate(tax, item_tax_map);
 		var current_tax_amount = 0.0;
 
+		// To set row_id by default as previous row.
+		if(["On Previous Row Amount", "On Previous Row Total"].includes(tax.charge_type)) {
+			if (tax.idx == 1) {
+			frappe.throw(
+				__("Cannot select charge type as 'On Previous Row Amount' or 'On Previous Row Total' for first row"))
+			}
+			if (!tax.row_id) {
+				tax.row_id = tax.idx - 1;
+			}
+		}
+		
 		if(tax.charge_type == "Actual") {
 			// distribute the tax amount proportionally to each item row
 			var actual = flt(tax.tax_amount, precision("tax_amount", tax));

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -331,9 +331,9 @@ erpnext.taxes_and_totals = erpnext.payments.extend({
 
 		// To set row_id by default as previous row.
 		if(["On Previous Row Amount", "On Previous Row Total"].includes(tax.charge_type)) {
-			if (tax.idx == 1) {
-			frappe.throw(
-				__("Cannot select charge type as 'On Previous Row Amount' or 'On Previous Row Total' for first row"))
+			if (tax.idx === 1) {
+				frappe.throw(
+					__("Cannot select charge type as 'On Previous Row Amount' or 'On Previous Row Total' for first row"));
 			}
 			if (!tax.row_id) {
 				tax.row_id = tax.idx - 1;

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -339,7 +339,6 @@ erpnext.taxes_and_totals = erpnext.payments.extend({
 				tax.row_id = tax.idx - 1;
 			}
 		}
-		
 		if(tax.charge_type == "Actual") {
 			// distribute the tax amount proportionally to each item row
 			var actual = flt(tax.tax_amount, precision("tax_amount", tax));


### PR DESCRIPTION
- Added client-side validation for "On the Previous Row Amount" and "On Previous Row Total"

- On selecting "On Previous Row Amount" or "On Previous Row Total" in taxes table an error used to pop up in console which broke the script if reference row is not selected. And many times the user is not aware that the reference row field exists. So by default use previous row reference id

![85304068-ef54ea80-b4c8-11ea-9799-a024cf6f1bab (1)](https://user-images.githubusercontent.com/33727827/85312028-e7e70e80-b4d3-11ea-98ef-e667721183e0.png)

