### PR TITLE
fix: footer powered template

### DIFF
--- a/erpnext/templates/includes/footer/footer_powered.html
+++ b/erpnext/templates/includes/footer/footer_powered.html
@@ -12,8 +12,8 @@
 } %}
 
 {% set link = '' %}
-{% set label = domains[0].domain %}
 {% if domains %}
+	{% set label = domains[0].domain %}
 	{% set link = links[label] %}
 {% endif %}
 


### PR DESCRIPTION
check if domains list exists

Fixes following error caused because no domain exists before running setup wizard.
Caused on fresh site with ERPNext installed

```
b'Traceback (most recent call last):\n  File "/home/revant/frappe-bench/apps/frappe/frappe/website/render.py", line 50, in render\n    data = render_page_by_language(path)\n  File "/home/revant/frappe-bench/apps/frappe/frappe/website/render.py", line 177, in render_page_by_language\n    return render_page(path)\n  File "/home/revant/frappe-bench/apps/frappe/frappe/website/render.py", line 193, in render_page\n    return build(path)\n  File "/home/revant/frappe-bench/apps/frappe/frappe/website/render.py", line 200, in build\n    return build_page(path)\n  File "/home/revant/frappe-bench/apps/frappe/frappe/website/render.py", line 223, in build_page\n    html = frappe.get_template(context.template).render(context)\n  File "/home/revant/frappe-bench/env/lib/python3.8/site-packages/jinja2/environment.py", line 1090, in render\n    self.environment.handle_exception()\n  File "/home/revant/frappe-bench/env/lib/python3.8/site-packages/jinja2/environment.py", line 832, in handle_exception\n    reraise(*rewrite_traceback_stack(source=source))\n  File "/home/revant/frappe-bench/env/lib/python3.8/site-packages/jinja2/_compat.py", line 28, in reraise\n    raise value.with_traceback(tb)\n  File "/home/revant/frappe-bench/apps/frappe/frappe/./www/login.html", line 1, in top-level template code\n    {% extends "templates/web.html" %}\n  File "/home/revant/frappe-bench/apps/frappe/frappe/./templates/web.html", line 1, in top-level template code\n    {% extends base_template_path %}\n  File "/home/revant/frappe-bench/apps/frappe/frappe/./templates/base.html", line 60, in top-level template code\n  File "/home/revant/frappe-bench/apps/frappe/frappe/./templates/base.html", line 61, in block "footer"\n    {% if banner_html -%}\n  File "/home/revant/frappe-bench/apps/frappe/frappe/./templates/includes/footer/footer.html", line 37, in top-level template code\n    {# powered #}\n  File "/home/revant/frappe-bench/apps/frappe/frappe/./templates/includes/footer/footer.html", line 38, in block "powered"\n    <div class="footer-col-right col-sm-6 col-12 footer-powered">\n  File "/home/revant/frappe-bench/apps/erpnext/erpnext/./templates/includes/footer/footer_powered.html", line 15, in top-level template code\n    {% set label = domains[0].domain %}\n  File "/home/revant/frappe-bench/env/lib/python3.8/site-packages/jinja2/sandbox.py", line 407, in getattr\n    value = getattr(obj, attribute)\njinja2.exceptions.UndefinedError: list object has no element 0\n'
```