### PR TITLE
fix: Insert Supplier Group via List View

### DIFF
--- a/erpnext/setup/doctype/customer_group/customer_group.js
+++ b/erpnext/setup/doctype/customer_group/customer_group.js
@@ -8,7 +8,7 @@ cur_frm.cscript.refresh = function(doc, cdt, cdn) {
 
 cur_frm.cscript.set_root_readonly = function(doc) {
 	// read-only for root customer group
-	if(!doc.parent_customer_group) {
+	if(!doc.parent_customer_group && !doc.__islocal) {
 		cur_frm.set_read_only();
 		cur_frm.set_intro(__("This is a root customer group and cannot be edited."));
 	} else {
@@ -20,7 +20,8 @@ cur_frm.cscript.set_root_readonly = function(doc) {
 cur_frm.fields_dict['parent_customer_group'].get_query = function(doc,cdt,cdn) {
 	return {
 		filters: {
-			'is_group': 1
+			'is_group': 1,
+			'name': ['!=', cur_frm.doc.customer_group_name]
 		}
 	}
 }

--- a/erpnext/setup/doctype/item_group/item_group.js
+++ b/erpnext/setup/doctype/item_group/item_group.js
@@ -66,7 +66,7 @@ frappe.ui.form.on("Item Group", {
 	set_root_readonly: function(frm) {
 		// read-only for root item group
 		frm.set_intro("");
-		if(!frm.doc.parent_item_group) {
+		if(!frm.doc.parent_item_group && !frm.doc.__islocal) {
 			frm.set_read_only();
 			frm.set_intro(__("This is a root item group and cannot be edited."), true);
 		}

--- a/erpnext/setup/doctype/sales_person/sales_person.js
+++ b/erpnext/setup/doctype/sales_person/sales_person.js
@@ -19,7 +19,7 @@ frappe.ui.form.on('Sales Person', {
 				}
 			}
 		};
-	
+
 		frm.make_methods = {
 			'Sales Order': () => frappe.new_doc("Sales Order")
 				.then(() => frm.add_child("sales_team", {"sales_person": frm.doc.name}))
@@ -33,7 +33,7 @@ cur_frm.cscript.refresh = function(doc, cdt, cdn) {
 
 cur_frm.cscript.set_root_readonly = function(doc) {
 	// read-only for root
-	if(!doc.parent_sales_person) {
+	if(!doc.parent_sales_person && !doc.__islocal) {
 		cur_frm.set_read_only();
 		cur_frm.set_intro(__("This is a root sales person and cannot be edited."));
 	} else {

--- a/erpnext/setup/doctype/supplier_group/supplier_group.js
+++ b/erpnext/setup/doctype/supplier_group/supplier_group.js
@@ -8,7 +8,7 @@ cur_frm.cscript.refresh = function(doc) {
 
 cur_frm.cscript.set_root_readonly = function(doc) {
 	// read-only for root customer group
-	if(!doc.parent_supplier_group) {
+	if(!doc.parent_supplier_group && !doc.__islocal) {
 		cur_frm.set_read_only();
 		cur_frm.set_intro(__("This is a root supplier group and cannot be edited."));
 	} else {
@@ -20,7 +20,8 @@ cur_frm.cscript.set_root_readonly = function(doc) {
 cur_frm.fields_dict['parent_supplier_group'].get_query = function() {
 	return {
 		filters: {
-			'is_group': 1
+			'is_group': 1,
+			'name': ['!=', cur_frm.doc.supplier_group_name]
 		}
 	};
 };

--- a/erpnext/setup/doctype/territory/territory.js
+++ b/erpnext/setup/doctype/territory/territory.js
@@ -20,7 +20,7 @@ cur_frm.cscript.refresh = function(doc, cdt, cdn) {
 
 cur_frm.cscript.set_root_readonly = function(doc) {
 	// read-only for root territory
-	if(!doc.parent_territory) {
+	if(!doc.parent_territory && !doc.__islocal) {
 		cur_frm.set_read_only();
 		cur_frm.set_intro(__("This is a root territory and cannot be edited."));
 	} else {


### PR DESCRIPTION
**Issue:**
- While trying to Insert a Supplier Group via List View, the form was **Read Only** , even though a root node already existed. Every attempt to create an entry was taken as creation of root node.
 ![Screenshot 2020-06-23 at 4 53 38 PM](https://user-images.githubusercontent.com/25857446/85399198-0a306900-b574-11ea-9ea7-76d5c4d6af5e.png)

**Fix:**
- Since every Tree already has a Root Node instantiated, Check if current form has parent and if it is a new form.
- If it is not a new form(already saved without parent), it probably is the root node. Else, allow editing.
- Added filter in Parent Link field to avoid selecting Itself as parent
- Changes applied on Customer Group, Item group, Sales Person & Territory.