### PR TITLE
fix: add error prompt for wrong date range

### DIFF
--- a/erpnext/selling/report/item_wise_sales_history/item_wise_sales_history.py
+++ b/erpnext/selling/report/item_wise_sales_history/item_wise_sales_history.py
@@ -9,6 +9,9 @@ from frappe.utils.nestedset import get_descendants_of
 
 def execute(filters=None):
 	filters = frappe._dict(filters or {})
+	if filters.from_date > filters.to_date:
+		frappe.throw(_('From Date cannot be greater than To Date'))
+	
 	columns = get_columns(filters)
 	data = get_data(filters)
 


### PR DESCRIPTION
For itemwise sales history report, there is no prompt or error when the from date is greater than to date:

![image](https://user-images.githubusercontent.com/33246109/85428975-9e61f680-b59b-11ea-8e6f-7ebe18613249.png)

After fix:

![itemwise_date_fix](https://user-images.githubusercontent.com/33246109/85429033-bb96c500-b59b-11ea-8063-c27a48b5a31e.gif)
