### PR TITLE
fix: stock_ageing.py report SyntaxError: can’t assign to function call

### DIFF
--- a/erpnext/stock/report/stock_ageing/stock_ageing.py
+++ b/erpnext/stock/report/stock_ageing/stock_ageing.py
@@ -187,7 +187,7 @@ def get_fifo_queue(filters, sle=None):
 						transferred_item_details[(d.voucher_no, d.name)].append(fifo_queue.pop(0))
 					else:
 						# all from current batch
-						batch[0] -= qty_to_pop
+						batch[0] = flt(batch[0]) - qty_to_pop
 						transferred_item_details[(d.voucher_no, d.name)].append([qty_to_pop, batch[1]])
 						qty_to_pop = 0
 


### PR DESCRIPTION
Following this Stock Ageing report error reported in version-12
https://discuss.erpnext.com/t/stock-ageing-report-typeerror-not-supported-between-instances-of-int-and-str/62605/4

This PR below to fix that subsequently introduced this current **can’t assign to function SyntaxError**: https://github.com/frappe/erpnext/pull/22206/files/677978dd00e92533d7897dec041a901c0e3cbba9

This PR should fix the SyntaxError that @marination kindly flagged thanks!