### PR TITLE
fix: UnboundLocalError when setting product_info

### DIFF
--- a/erpnext/portal/product_configurator/utils.py
+++ b/erpnext/portal/product_configurator/utils.py
@@ -239,12 +239,11 @@ def get_next_attribute_and_values(item_code, selected_attributes):
 	if exact_match:
 		data = get_product_info_for_website(exact_match[0])
 		product_info = data.product_info
+		product_info["allow_items_not_in_stock"] = cint(data.cart_settings.allow_items_not_in_stock)
 		if not data.cart_settings.show_price:
 			product_info = None
 	else:
 		product_info = None
-
-	product_info["allow_items_not_in_stock"] = cint(data.cart_settings.allow_items_not_in_stock)
 
 	return {
 		'next_attribute': next_attribute,


### PR DESCRIPTION
The `data` variable is not available when `exact_match` is `False`. As a result the moved line throws the following error when selecting variants until an exact match is found.
```
UnboundLocalError: local variable 'data' referenced before assignment
```

The solution moves the offending line under the `exact_match` conditional and leaves `product_info` as `None` when the condition is false.
