### PR TITLE
fix: cannot cancel assets with repair pending

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -408,6 +408,8 @@ class Asset(AccountsController):
 					row.expected_value_after_useful_life = asset_value_after_full_schedule
 
 	def validate_cancellation(self):
+		if self.status in ("In Maintenance", "Out of Order"):
+			frappe.throw(_("You must cancel all the maintenance or repair documents before cancelling the asset."))
 		if self.status not in ("Submitted", "Partially Depreciated", "Fully Depreciated"):
 			frappe.throw(_("Asset cannot be cancelled, as it is already {0}").format(self.status))
 

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -409,7 +409,8 @@ class Asset(AccountsController):
 
 	def validate_cancellation(self):
 		if self.status in ("In Maintenance", "Out of Order"):
-			frappe.throw(_("You must cancel all the maintenance or repair documents before cancelling the asset."))
+			frappe.throw(_("There are active maintenance or repairs against the asset. You must complete \
+				all of them before cancelling the asset."))
 		if self.status not in ("Submitted", "Partially Depreciated", "Fully Depreciated"):
 			frappe.throw(_("Asset cannot be cancelled, as it is already {0}").format(self.status))
 

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -409,8 +409,7 @@ class Asset(AccountsController):
 
 	def validate_cancellation(self):
 		if self.status in ("In Maintenance", "Out of Order"):
-			frappe.throw(_("There are active maintenance or repairs against the asset. You must complete \
-				all of them before cancelling the asset."))
+			frappe.throw(_("There are active maintenance or repairs against the asset. You must complete all of them before cancelling the asset."))
 		if self.status not in ("Submitted", "Partially Depreciated", "Fully Depreciated"):
 			frappe.throw(_("Asset cannot be cancelled, as it is already {0}").format(self.status))
 


### PR DESCRIPTION
Problem:
Assets having pending repair documents or pending maintenance documents shows inappropriate error message

Changes:
Error message now suggests, If an asset has 'In Maintenance' or 'Out of Order' statuses, then user must complete/cancel all the active maintenance or repairs before cancelling the asset. 
