### PR TITLE
fix: show_dashboard + button depends on status

### DIFF
--- a/erpnext/hr/doctype/expense_claim/expense_claim.js
+++ b/erpnext/hr/doctype/expense_claim/expense_claim.js
@@ -211,6 +211,17 @@ frappe.ui.form.on("Expense Claim", {
 	},
 
 	refresh: function(frm) {
+
+		if (!frm.doc.__islocal){
+			// toggle '+' button from dashboard depends upon status.
+			if (frm.doc.status === "Paid" || frm.doc.status === "Rejected"){
+				$('[data-doctype="Payment Entry"]').find("button").hide();
+				$('[data-doctype="Journal Entry"]').find("button").hide();
+			}else if (frm.doc.status === "Unpaid"){
+				$('[data-doctype="Payment Entry"]').find("button").show();
+				$('[data-doctype="Journal Entry"]').find("button").show();
+			}
+		}
 		frm.trigger("toggle_fields");
 
 		if(frm.doc.docstatus === 1 && frm.doc.approval_status !== "Rejected") {


### PR DESCRIPTION
In Expense Claim doctype when the status is Paid, payment Entry and Journal Entry links (In dashboard) should be disabled.

![image](https://user-images.githubusercontent.com/32095923/85679910-767fa980-b6e7-11ea-8ef0-d40ded1c6000.png)
