### PR TITLE
fix: Disable Renaming in Serial No

### DIFF
--- a/erpnext/stock/doctype/serial_no/serial_no.json
+++ b/erpnext/stock/doctype/serial_no/serial_no.json
@@ -1,7 +1,6 @@
 {
  "actions": [],
  "allow_import": 1,
- "allow_rename": 1,
  "autoname": "field:serial_no",
  "creation": "2013-05-16 10:59:15",
  "description": "Distinct unit of an Item",
@@ -427,7 +426,7 @@
  "icon": "fa fa-barcode",
  "idx": 1,
  "links": [],
- "modified": "2020-05-21 19:29:58.517772",
+ "modified": "2020-06-25 15:53:50.900855",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Serial No",


### PR DESCRIPTION
- Disabled Serial No Renaming as the serial no fields are just text fields in transactions. 
- Renaming does not rename the values in those fields, causing chaotic data. 