### PR TITLE
fix: Add bold rounded total

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
@@ -3232,7 +3232,7 @@
    "allow_bulk_edit": 0,
    "allow_in_quick_entry": 0,
    "allow_on_submit": 0,
-   "bold": 0,
+   "bold": 1,
    "collapsible": 0,
    "columns": 0,
    "depends_on": "eval:!doc.disable_rounded_total",


### PR DESCRIPTION
I'm working with Monogramm to develop a New design for print format and noticed that 
rounded total inside `Sales Invoice` is bold field, but inside `Purchase Invoice` - not a bold field.
It gives impact when you have custom `.important` selector inside Print Format:
Print format inside Sales Invoice:
```
...
<div class="row important data-field" data-fieldname="rounded_total" data-fieldtype="Currency">
...
```

Print format inside Purchase Invoice:
```
...
<div class="row data-field" data-fieldname="rounded_total" data-fieldtype="Currency">
...
```
![image](https://user-images.githubusercontent.com/32329685/85710984-7e434c00-b6ef-11ea-8efd-ead2e7034b2a.png)
