### PR TITLE
refactor: update customs_tariff_number.json

### DIFF
--- a/erpnext/stock/doctype/customs_tariff_number/customs_tariff_number.json
+++ b/erpnext/stock/doctype/customs_tariff_number/customs_tariff_number.json
@@ -88,7 +88,7 @@
  "issingle": 0, 
  "istable": 0, 
  "max_attachments": 0, 
- "modified": "2018-09-12 09:30:03.951743", 
+ "modified": "2020-06-26 09:30:03.951743", 
  "modified_by": "Administrator", 
  "module": "Stock", 
  "name": "Customs Tariff Number", 

--- a/erpnext/stock/doctype/customs_tariff_number/customs_tariff_number.json
+++ b/erpnext/stock/doctype/customs_tariff_number/customs_tariff_number.json
@@ -71,7 +71,7 @@
    "read_only": 0, 
    "remember_last_selected_value": 0, 
    "report_hide": 0, 
-   "reqd": 1, 
+   "reqd": 0, 
    "search_index": 0, 
    "set_only_once": 0, 
    "translatable": 0, 


### PR DESCRIPTION
Main information of tariff numbers are the number. A description is more or less double information as this is mostly the number. Thus a description should not be mandetory.

