### PR TITLE
fix: Payment amount in payment terms showing negative amount

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -805,7 +805,7 @@ class AccountsController(TransactionBase):
 		posting_date = self.get("bill_date") or self.get("posting_date") or self.get("transaction_date")
 		date = self.get("due_date")
 		due_date = date or posting_date
-		grand_total = self.get("rounded_total") or self.grand_total
+		grand_total = self.get("base_rounded_total") or self.base_grand_total
 		if self.doctype in ("Sales Invoice", "Purchase Invoice"):
 			grand_total = grand_total - flt(self.write_off_amount)
 
@@ -854,15 +854,15 @@ class AccountsController(TransactionBase):
 			total = 0
 			for d in self.get("payment_schedule"):
 				total += flt(d.payment_amount)
-			total = flt(total, self.precision("grand_total"))
+			total = flt(total, self.precision("base_grand_total"))
 
-			grand_total = flt(self.get("rounded_total") or self.grand_total, self.precision('grand_total'))
+			grand_total = flt(self.get("base_rounded_total") or self.base_grand_total, self.precision('base_grand_total'))
 			if self.get("total_advance"):
 				grand_total -= self.get("total_advance")
 
 			if self.doctype in ("Sales Invoice", "Purchase Invoice"):
 				grand_total = grand_total - flt(self.write_off_amount)
-			if total != flt(grand_total, self.precision("grand_total")):
+			if total != flt(grand_total, self.precision("base_grand_total")):
 				frappe.throw(_("Total Payment Amount in Payment Schedule must be equal to Grand / Rounded Total"))
 
 	def is_rounded_total_disabled(self):


### PR DESCRIPTION
Payment Amount in Payment Terms is shown as negative if advance is allocated against a multicurrency Purchase Invoice

Befor:
<img width="1253" alt="Screenshot 2020-06-25 at 5 59 47 PM" src="https://user-images.githubusercontent.com/42651287/85724594-fae72200-b711-11ea-9a17-54ada88e1e7c.png">

After:
<img width="1267" alt="Screenshot 2020-06-25 at 6 10 59 PM" src="https://user-images.githubusercontent.com/42651287/85724618-01759980-b712-11ea-8e8d-90bb28ed6b40.png">
