### PR TITLE
fix: add company filter in email digest

### DIFF
--- a/erpnext/setup/doctype/email_digest/email_digest.py
+++ b/erpnext/setup/doctype/email_digest/email_digest.py
@@ -405,8 +405,8 @@ class EmailDigest(Document):
 
 		value, count = frappe.db.sql("""select ifnull((sum(grand_total)) - (sum(grand_total*per_billed/100)),0),
                     count(*) from `tabSales Order`
-					where (transaction_date <= %(to_date)s) and billing_status != "Fully Billed"
-					and status not in ('Closed','Cancelled', 'Completed') """, {"to_date": self.future_to_date})[0]
+					where (transaction_date <= %(to_date)s) and billing_status != "Fully Billed" and company = %(company)s
+					and status not in ('Closed','Cancelled', 'Completed') """, {"to_date": self.future_to_date, "company": self.company})[0]
 
 		label = get_link_to_report('Sales Order', label=self.meta.get_label("sales_orders_to_bill"),
 			report_type="Report Builder",
@@ -430,8 +430,8 @@ class EmailDigest(Document):
 
 		value, count = frappe.db.sql("""select ifnull((sum(grand_total)) - (sum(grand_total*per_delivered/100)),0),
 					count(*) from `tabSales Order`
-					where (transaction_date <= %(to_date)s) and delivery_status != "Fully Delivered"
-					and status not in ('Closed','Cancelled', 'Completed') """, {"to_date": self.future_to_date})[0]
+					where (transaction_date <= %(to_date)s) and delivery_status != "Fully Delivered" and company = %(company)s
+					and status not in ('Closed','Cancelled', 'Completed') """, {"to_date": self.future_to_date, "company": self.company})[0]
 
 		label = get_link_to_report('Sales Order', label=self.meta.get_label("sales_orders_to_deliver"),
 			report_type="Report Builder",
@@ -455,8 +455,8 @@ class EmailDigest(Document):
 
 		value, count = frappe.db.sql("""select ifnull((sum(grand_total))-(sum(grand_total*per_received/100)),0),
                     count(*) from `tabPurchase Order`
-					where (transaction_date <= %(to_date)s) and per_received < 100
-					and status not in ('Closed','Cancelled', 'Completed') """, {"to_date": self.future_to_date})[0]
+					where (transaction_date <= %(to_date)s) and per_received < 100 and company = %(company)s
+					and status not in ('Closed','Cancelled', 'Completed') """, {"to_date": self.future_to_date, "company": self.company})[0]
 
 		label = get_link_to_report('Purchase Order', label=self.meta.get_label("purchase_orders_to_receive"),
 			report_type="Report Builder",
@@ -480,8 +480,8 @@ class EmailDigest(Document):
 
 		value, count = frappe.db.sql("""select ifnull((sum(grand_total)) - (sum(grand_total*per_billed/100)),0),
                     count(*) from `tabPurchase Order`
-					where (transaction_date <= %(to_date)s) and per_billed < 100
-					and status not in ('Closed','Cancelled', 'Completed') """, {"to_date": self.future_to_date})[0]
+					where (transaction_date <= %(to_date)s) and per_billed < 100 and company = %(company)s
+					and status not in ('Closed','Cancelled', 'Completed') """, {"to_date": self.future_to_date, "company": self.company})[0]
 
 		label = get_link_to_report('Purchase Order', label=self.meta.get_label("purchase_orders_to_bill"),
 			report_type="Report Builder",


### PR DESCRIPTION
Email digest would not filter sales order by company. This PR fixes it.

Frappe Issue: ISS-20-21-02736