### PR TITLE
fix: add cost center filter in MR item

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -31,6 +31,15 @@ frappe.ui.form.on('Material Request', {
 				filters: {'company': doc.company}
 			};
 		});
+		
+		frm.set_query("cost_center", "items", function(doc) {
+				return {
+					filters: {'company': doc.company,
+					"is_group": 0
+					}
+						
+				};
+			});
 
 		frm.set_query("bom_no", "items", function(doc, cdt, cdn) {
 			var row = locals[cdt][cdn];


### PR DESCRIPTION
Added cost center filter in Material Request Item table.

**Before:**

All cost centers of all companies including root nodes were shown.

![Screenshot 2020-06-26 at 8 59 24 AM](https://user-images.githubusercontent.com/50285544/85817560-ec3d5100-b78b-11ea-9c66-7902bcb617a2.png)


**After:**

Filter on selected company and child nodes.

 
![Screenshot 2020-06-26 at 8 59 55 AM](https://user-images.githubusercontent.com/50285544/85817565-ee9fab00-b78b-11ea-9551-8a636888c10e.png)


