### PR TITLE
fix: filter in material request item

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -31,6 +31,21 @@ frappe.ui.form.on('Material Request', {
 				filters: {'company': doc.company}
 			};
 		});
+		
+		frm.set_query("cost_center", "items", function(doc) {
+				return {
+					filters: {'company': doc.company,
+					"is_group": 0
+					}
+						
+				};
+			});
+		
+		frm.set_query("expense_account", "items", function(doc) {
+				return {
+					filters: {'company': doc.company}	
+				};
+			});
 
 		frm.set_query("bom_no", "items", function(doc, cdt, cdn) {
 			var row = locals[cdt][cdn];


### PR DESCRIPTION
Added cost center filter in Material Request Item table.

**Before:**

All cost centers of all companies including root nodes were shown. Same for Expense account (accounts of all companies shown).

![Screenshot 2020-06-26 at 8 59 24 AM](https://user-images.githubusercontent.com/50285544/85817560-ec3d5100-b78b-11ea-9c66-7902bcb617a2.png)

![Screenshot 2020-06-26 at 9 13 28 AM](https://user-images.githubusercontent.com/50285544/85818079-5c98a200-b78d-11ea-9546-0f3c863a85b9.png)



**After:**

Filter on selected company and child nodes.

 
![Screenshot 2020-06-26 at 8 59 55 AM](https://user-images.githubusercontent.com/50285544/85817565-ee9fab00-b78b-11ea-9551-8a636888c10e.png)

![Screenshot 2020-06-26 at 9 13 11 AM](https://user-images.githubusercontent.com/50285544/85818084-5f939280-b78d-11ea-9dcf-79a9de652b5e.png)

