### PR TITLE
fix: apply filters in all transactions

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -159,6 +159,26 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 				};
 			});
 		}
+		if (this.frm.fields_dict["items"].grid.get_field("cost_center")) {
+   			this.frm.set_query("cost_center", "items", function(doc) {
+    				return {
+     					filters: {
+						"company": doc.company,
+      				        	"is_group": 0
+    					}
+   				};
+   			});
+ 		 }
+
+  		if (this.frm.fields_dict["items"].grid.get_field("expense_account")) {
+   			this.frm.set_query("expense_account", "items", function(doc) {
+    				return {
+     					filters: {
+      						"company": doc.company
+     					}
+    				};
+   			});
+  		}	
 
 		if(frappe.meta.get_docfield(this.frm.doc.doctype, "pricing_rules")) {
 			this.frm.set_indicator_formatter('pricing_rule', function(doc) {


### PR DESCRIPTION
Apply cost center and expense account filter in all transactions.

For eg, Added cost center filter and expense account filter in Material Request Item table which shows dropdown of accounts and cost centers belonging to the selected company.

**Before:**

All cost centers of all companies including root nodes were shown. Same for Expense account (accounts of all companies shown).

![image](https://user-images.githubusercontent.com/50285544/85844249-098c1280-b7c0-11ea-816f-031ab04dbc21.png)

![image](https://user-images.githubusercontent.com/50285544/85844261-0f81f380-b7c0-11ea-915b-48ffb83fb98b.png)


**After:**

Filter on selected company and child nodes.

![image](https://user-images.githubusercontent.com/50285544/85844284-190b5b80-b7c0-11ea-9a57-7a608b3f3b9f.png)

![image](https://user-images.githubusercontent.com/50285544/85844292-1d377900-b7c0-11ea-8380-ca098011c4c0.png)

