### PR TITLE
fix: handle custom statuses for the pause SLA configuration

### DIFF
--- a/erpnext/support/doctype/issue/issue.py
+++ b/erpnext/support/doctype/issue/issue.py
@@ -85,42 +85,46 @@ class Issue(Document):
 			hold_statuses = [entry.status for entry in pause_sla_on]
 			update_values = {}
 
-			if self.status in hold_statuses and status not in hold_statuses:
-				update_values['on_hold_since'] = frappe.flags.current_time or now_datetime()
-				if not self.first_responded_on:
-					update_values['response_by'] = None
-					update_values['response_by_variance'] = 0
-				update_values['resolution_by'] = None
-				update_values['resolution_by_variance'] = 0
+			if hold_statuses:
+				if self.status in hold_statuses and status not in hold_statuses:
+					update_values['on_hold_since'] = frappe.flags.current_time or now_datetime()
+					if not self.first_responded_on:
+						update_values['response_by'] = None
+						update_values['response_by_variance'] = 0
+					update_values['resolution_by'] = None
+					update_values['resolution_by_variance'] = 0
 
-			# calculate hold time when status is changed from any hold status to any non-hold status
-			if self.status not in hold_statuses and status in hold_statuses:
-				hold_time = self.total_hold_time if self.total_hold_time else 0
-				now_time = frappe.flags.current_time or now_datetime()
-				update_values['total_hold_time'] = hold_time + time_diff_in_seconds(now_time, self.on_hold_since)
+				# calculate hold time when status is changed from any hold status to any non-hold status
+				if self.status not in hold_statuses and status in hold_statuses:
+					hold_time = self.total_hold_time if self.total_hold_time else 0
+					now_time = frappe.flags.current_time or now_datetime()
+					last_hold_time = 0
+					if self.on_hold_since:
+						# last_hold_time will be added to the sla variables
+						last_hold_time = time_diff_in_seconds(now_time, self.on_hold_since)
+						update_values['total_hold_time'] = hold_time + last_hold_time
 
-				# re-calculate SLA variables after issue changes from any hold status to any non-hold status
-				# add hold time to SLA variables
-				start_date_time = get_datetime(self.service_level_agreement_creation)
-				priority = get_priority(self)
-				now_time = frappe.flags.current_time or now_datetime()
-				hold_time = time_diff_in_seconds(now_time, self.on_hold_since)
+					# re-calculate SLA variables after issue changes from any hold status to any non-hold status
+					# add hold time to SLA variables
+					start_date_time = get_datetime(self.service_level_agreement_creation)
+					priority = get_priority(self)
+					now_time = frappe.flags.current_time or now_datetime()
 
-				if not self.first_responded_on:
-					response_by = get_expected_time_for(parameter="response", service_level=priority, start_date_time=start_date_time)
-					response_by = add_to_date(response_by, seconds=round(hold_time))
-					response_by_variance = round(time_diff_in_hours(response_by, now_time))
-					update_values['response_by'] = response_by
-					update_values['response_by_variance'] = response_by_variance + (hold_time // 3600)
+					if not self.first_responded_on:
+						response_by = get_expected_time_for(parameter="response", service_level=priority, start_date_time=start_date_time)
+						response_by = add_to_date(response_by, seconds=round(last_hold_time))
+						response_by_variance = round(time_diff_in_hours(response_by, now_time))
+						update_values['response_by'] = response_by
+						update_values['response_by_variance'] = response_by_variance + (last_hold_time // 3600)
 
-				resolution_by = get_expected_time_for(parameter="resolution", service_level=priority, start_date_time=start_date_time)
-				resolution_by = add_to_date(resolution_by, seconds=round(hold_time))
-				resolution_by_variance = round(time_diff_in_hours(resolution_by, now_time))
-				update_values['resolution_by'] = resolution_by
-				update_values['resolution_by_variance'] = resolution_by_variance + (hold_time // 3600)
-				update_values['on_hold_since'] = None
+					resolution_by = get_expected_time_for(parameter="resolution", service_level=priority, start_date_time=start_date_time)
+					resolution_by = add_to_date(resolution_by, seconds=round(last_hold_time))
+					resolution_by_variance = round(time_diff_in_hours(resolution_by, now_time))
+					update_values['resolution_by'] = resolution_by
+					update_values['resolution_by_variance'] = resolution_by_variance + (last_hold_time // 3600)
+					update_values['on_hold_since'] = None
 
-			self.db_set(update_values)
+				self.db_set(update_values)
 
 	def update_agreement_status(self):
 		if self.service_level_agreement and self.agreement_fulfilled == "Ongoing":

--- a/erpnext/support/doctype/issue/issue.py
+++ b/erpnext/support/doctype/issue/issue.py
@@ -79,7 +79,7 @@ class Issue(Document):
 
 	def handle_hold_time(self, status):
 		if self.service_level_agreement:
-			# set response and resolution variance as None as the issue is on Hold for status as Replied
+			# set response and resolution variance as None as the issue is on Hold
 			pause_sla_on = frappe.db.get_all("Pause SLA On Status", fields=["status"],
 				filters={"parent": self.service_level_agreement})
 			hold_statuses = [entry.status for entry in pause_sla_on]
@@ -93,15 +93,14 @@ class Issue(Document):
 				update_values['resolution_by'] = None
 				update_values['resolution_by_variance'] = 0
 
-			# calculate hold time when status is changed from Replied to any other status
+			# calculate hold time when status is changed from any hold status to any non-hold status
 			if self.status not in hold_statuses and status in hold_statuses:
 				hold_time = self.total_hold_time if self.total_hold_time else 0
 				now_time = frappe.flags.current_time or now_datetime()
 				update_values['total_hold_time'] = hold_time + time_diff_in_seconds(now_time, self.on_hold_since)
 
-			# re-calculate SLA variables after issue changes from Replied to Open
-			# add hold time to SLA variables
-			if self.status == "Open" and status in hold_statuses:
+				# re-calculate SLA variables after issue changes from any hold status to any non-hold status
+				# add hold time to SLA variables
 				start_date_time = get_datetime(self.service_level_agreement_creation)
 				priority = get_priority(self)
 				now_time = frappe.flags.current_time or now_datetime()
@@ -109,13 +108,15 @@ class Issue(Document):
 
 				if not self.first_responded_on:
 					response_by = get_expected_time_for(parameter="response", service_level=priority, start_date_time=start_date_time)
-					update_values['response_by'] = add_to_date(response_by, seconds=round(hold_time))
-					response_by_variance = round(time_diff_in_hours(self.response_by, now_time))
+					response_by = add_to_date(response_by, seconds=round(hold_time))
+					response_by_variance = round(time_diff_in_hours(response_by, now_time))
+					update_values['response_by'] = response_by
 					update_values['response_by_variance'] = response_by_variance + (hold_time // 3600)
 
 				resolution_by = get_expected_time_for(parameter="resolution", service_level=priority, start_date_time=start_date_time)
-				update_values['resolution_by'] = add_to_date(resolution_by, seconds=round(hold_time))
-				resolution_by_variance = round(time_diff_in_hours(self.resolution_by, now_time))
+				resolution_by = add_to_date(resolution_by, seconds=round(hold_time))
+				resolution_by_variance = round(time_diff_in_hours(resolution_by, now_time))
+				update_values['resolution_by'] = resolution_by
 				update_values['resolution_by_variance'] = resolution_by_variance + (hold_time // 3600)
 				update_values['on_hold_since'] = None
 


### PR DESCRIPTION
Backport: https://github.com/frappe/erpnext/pull/22349

Fixes for two issues:

- The response and resolution variables are unset on statuses configured for Hold and reset when the issue changes from a status configured for Hold to "Open" by adding the hold time. However, it should do so for any status which is not configured for hold otherwise the SLA fails for custom statuses as response and resolution variance fields are unset.

- The total hold time field should only be set if on_hold_since is captured and hold configurations are enabled in the SLA document.