### PR TITLE
fix: remove redundant label in salary slip

### DIFF
--- a/erpnext/payroll/doctype/salary_slip/salary_slip.json
+++ b/erpnext/payroll/doctype/salary_slip/salary_slip.json
@@ -381,7 +381,6 @@
   {
    "fieldname": "earning",
    "fieldtype": "Column Break",
-   "label": "Earning",
    "oldfieldtype": "Column Break",
    "show_days": 1,
    "show_seconds": 1,
@@ -400,7 +399,6 @@
   {
    "fieldname": "deduction",
    "fieldtype": "Column Break",
-   "label": "Deduction",
    "oldfieldtype": "Column Break",
    "show_days": 1,
    "show_seconds": 1,
@@ -616,7 +614,7 @@
  "idx": 9,
  "is_submittable": 1,
  "links": [],
- "modified": "2020-06-22 14:42:43.921828",
+ "modified": "2020-06-25 14:42:43.921828",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Salary Slip",


### PR DESCRIPTION
**Before:**

![image](https://user-images.githubusercontent.com/50285544/85866462-0bb49800-b7e5-11ea-9685-c2075fc2459a.png)


**After:**

![image](https://user-images.githubusercontent.com/50285544/85866493-1838f080-b7e5-11ea-94b9-38c4f62f8d99.png)
