### PR TITLE
fix: Set Root as Parent if no parent in new tree view node

### DIFF
--- a/erpnext/setup/doctype/customer_group/customer_group.py
+++ b/erpnext/setup/doctype/customer_group/customer_group.py
@@ -6,9 +6,12 @@ import frappe
 from frappe import _
 
 
-from frappe.utils.nestedset import NestedSet
+from frappe.utils.nestedset import NestedSet, get_root_of
 class CustomerGroup(NestedSet):
 	nsm_parent_field = 'parent_customer_group'
+	def validate(self):
+		if not self.parent_customer_group:
+			self.parent_customer_group = get_root_of("Customer Group")
 
 	def on_update(self):
 		self.validate_name_with_customer()

--- a/erpnext/setup/doctype/sales_person/sales_person.py
+++ b/erpnext/setup/doctype/sales_person/sales_person.py
@@ -5,13 +5,16 @@ from __future__ import unicode_literals
 import frappe
 from frappe import _
 from frappe.utils import flt
-from frappe.utils.nestedset import NestedSet
+from frappe.utils.nestedset import NestedSet, get_root_of
 from erpnext import get_default_currency
 
 class SalesPerson(NestedSet):
 	nsm_parent_field = 'parent_sales_person'
 
 	def validate(self):
+		if not self.parent_sales_person:
+			self.parent_sales_person = get_root_of("Sales Person")
+
 		for d in self.get('targets') or []:
 			if not flt(d.target_qty) and not flt(d.target_amount):
 				frappe.throw(_("Either target qty or target amount is mandatory."))

--- a/erpnext/setup/doctype/territory/territory.py
+++ b/erpnext/setup/doctype/territory/territory.py
@@ -6,12 +6,14 @@ import frappe
 from frappe.utils import flt
 from frappe import _
 
-from frappe.utils.nestedset import NestedSet
+from frappe.utils.nestedset import NestedSet, get_root_of
 
 class Territory(NestedSet):
 	nsm_parent_field = 'parent_territory'
 
 	def validate(self):
+		if not self.parent_territory:
+			self.parent_territory = get_root_of("Territory")
 
 		for d in self.get('targets') or []:
 			if not flt(d.target_qty) and not flt(d.target_amount):


### PR DESCRIPTION
**Issue:**
- No parent even after save if no parent is set
  ![image](https://user-images.githubusercontent.com/25857446/85999636-0bf1a500-ba2a-11ea-87a9-c461e51244dc.png)

**Fix:**
- While creating a new Customer Group/ Territory / Sales Person from List View, if no Parent is filled, fetch root node as parent, just like Supplier Group