### PR TITLE
fix: Stock Onboarding typo and reorder

### DIFF
--- a/erpnext/stock/doctype/stock_settings/stock_settings.js
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.js
@@ -20,7 +20,7 @@ frappe.tour['Stock Settings'] = [
 	{
 		fieldname: "item_naming_by",
 		title: __("Item Naming By"),
-		description: __("By default, the Item Name is set as per the Item Code entered. If you want Items to be named by a") + "<a href='https://docs.erpnext.com/docs/user/manual/en/setting-up/settings/naming-series' target='_blank'>Naming Series</a>" + __(" choose the 'Naming Series' option."),
+		description: __("By default, the Item Name is set as per the Item Code entered. If you want Items to be named by a ") + "<a href='https://docs.erpnext.com/docs/user/manual/en/setting-up/settings/naming-series' target='_blank'>Naming Series</a>" + __(" choose the 'Naming Series' option."),
 	},
 	{
 		fieldname: "default_warehouse",

--- a/erpnext/stock/module_onboarding/stock/stock.json
+++ b/erpnext/stock/module_onboarding/stock/stock.json
@@ -19,7 +19,7 @@
  "documentation_url": "https://docs.erpnext.com/docs/user/manual/en/stock",
  "idx": 0,
  "is_complete": 0,
- "modified": "2020-05-19 19:03:23.602423",
+ "modified": "2020-06-29 16:41:09.440378",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock",
@@ -32,13 +32,13 @@
    "step": "Create a Product"
   },
   {
+   "step": "Create a Supplier"
+  },
+  {
    "step": "Introduction to Stock Entry"
   },
   {
    "step": "Create a Stock Entry"
-  },
-  {
-   "step": "Create a Supplier"
   },
   {
    "step": "Create a Purchase Receipt"
@@ -49,6 +49,5 @@
  ],
  "subtitle": "Inventory, Warehouses, Analysis and more.",
  "success_message": "The Stock Module is all set up!",
- "title": "Let's Setup the Stock Module.",
- "user_can_dismiss": 1
+ "title": "Let's Set Up the Stock Module."
 }

--- a/erpnext/stock/onboarding_step/create_a_supplier/create_a_supplier.json
+++ b/erpnext/stock/onboarding_step/create_a_supplier/create_a_supplier.json
@@ -8,7 +8,7 @@
  "is_mandatory": 0,
  "is_single": 0,
  "is_skipped": 0,
- "modified": "2020-05-14 22:09:10.043554",
+ "modified": "2020-06-29 16:36:53.948242",
  "modified_by": "Administrator",
  "name": "Create a Supplier",
  "owner": "Administrator",


### PR DESCRIPTION
- Added Space before 'Naming Series' in form tour
- Reordered onboarding so that item,supplier,warehouse (all basics) are created first and exploration later
  ![Screenshot 2020-06-29 at 5 24 49 PM](https://user-images.githubusercontent.com/25857446/86001995-53c5fb80-ba2d-11ea-8b6b-bc90abf7bb38.png)

- **Setup** to **Set Up**
