### PR TITLE
fix: Do not ignore validate methods on GL entry submit

### DIFF
--- a/erpnext/accounts/general_ledger.py
+++ b/erpnext/accounts/general_ledger.py
@@ -140,10 +140,8 @@ def make_entry(args, adv_adj, update_outstanding):
 	gle = frappe.new_doc("GL Entry")
 	gle.update(args)
 	gle.flags.ignore_permissions = 1
-	gle.validate()
 	gle.db_insert()
 	gle.run_method("on_update_with_args", adv_adj, update_outstanding)
-	gle.flags.ignore_validate = True
 	gle.submit()
 
 	# check against budget

--- a/erpnext/accounts/general_ledger.py
+++ b/erpnext/accounts/general_ledger.py
@@ -140,7 +140,7 @@ def make_entry(args, adv_adj, update_outstanding):
 	gle = frappe.new_doc("GL Entry")
 	gle.update(args)
 	gle.flags.ignore_permissions = 1
-	gle.db_insert()
+	gle.insert()
 	gle.run_method("on_update_with_args", adv_adj, update_outstanding)
 	gle.submit()
 


### PR DESCRIPTION
Do not ignore validations as no `before_save` methods written in Server Script or hooks are executed if validations are ignored 