### PR TITLE
fix: Allow PR/DN without PO/SO if set in Supplier/Customer Master

### DIFF
--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -100,6 +100,9 @@ class DeliveryNote(SellingController):
 	def so_required(self):
 		"""check in manage account if sales order required or not"""
 		if frappe.db.get_value("Selling Settings", None, 'so_required') == 'Yes':
+			if frappe.get_value('Customer', self.customer, 'so_required'):
+				return
+
 			for d in self.get('items'):
 				if not d.against_sales_order:
 					frappe.throw(_("Sales Order required for Item {0}").format(d.item_code))

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -118,6 +118,9 @@ class PurchaseReceipt(BuyingController):
 
 	def po_required(self):
 		if frappe.db.get_value("Buying Settings", None, "po_required") == 'Yes':
+			if frappe.get_value('Supplier', self.supplier, 'allow_purchase_invoice_creation_without_purchase_order'):
+				return
+				
 			for d in self.get('items'):
 				if not d.purchase_order:
 					frappe.throw(_("Purchase Order number required for Item {0}").format(d.item_code))


### PR DESCRIPTION
#### Description
Allows creation of Purchase Receipt without Purchase Order if "Allow Purchase Invoice Creation Without Purchase Order" in the Supplier Master is ticked.
The same also applies for the corresponding option in Customer Master.

#### Details
PR #20864 added the option to overwrite the default behaviour of requiring a Purchase Order or a Sales Order for the creation of an Invoice based on the Supplier/Customer. However, this new logic has only been implemented in Purchase/Sales Invoice, but not in Purchase Receipt and Delivery Note.
Because the procurement process in ERPNext is _Purchase Order -> Purchase Receipt -> Purchase Invoice_ this logic should also apply for Purchase Receipt and Delivery Note.