### PR TITLE
fix: Refactor dashboard links in leave policy

### DIFF
--- a/erpnext/hr/doctype/leave_policy/leave_policy_dashboard.py
+++ b/erpnext/hr/doctype/leave_policy/leave_policy_dashboard.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from frappe import _
 
 def get_data():
 	return {
@@ -8,11 +9,11 @@ def get_data():
 		},
 		'transactions': [
 			{
-				'label': ('Employees'),
+				'label': _('Employees'),
 				'items': ['Employee', 'Employee Grade']
 			},
 			{
-				'label': ('Leaves'),
+				'label': _('Leaves'),
 				'items': ['Leave Allocation']
 			},
 		]

--- a/erpnext/hr/doctype/leave_policy/leave_policy_dashboard.py
+++ b/erpnext/hr/doctype/leave_policy/leave_policy_dashboard.py
@@ -8,13 +8,7 @@ def get_data():
 		},
 		'transactions': [
 			{
-				'items': ['Employee']
-			},
-			{
-				'items': ['Employee Grade']
-			},
-			{
-				'items': ['Leave Allocation']
+				'items': ['Employee','Employee Grade', 'Leave Allocation' ]
 			},
 		]
 	}

--- a/erpnext/hr/doctype/leave_policy/leave_policy_dashboard.py
+++ b/erpnext/hr/doctype/leave_policy/leave_policy_dashboard.py
@@ -8,7 +8,7 @@ def get_data():
 		},
 		'transactions': [
 			{
-				'items': ['Employee','Employee Grade', 'Leave Allocation' ]
+				'items': ['Employee','Employee Grade', 'Leave Allocation']
 			},
 		]
 	}

--- a/erpnext/hr/doctype/leave_policy/leave_policy_dashboard.py
+++ b/erpnext/hr/doctype/leave_policy/leave_policy_dashboard.py
@@ -8,7 +8,17 @@ def get_data():
 		},
 		'transactions': [
 			{
-				'items': ['Employee','Employee Grade', 'Leave Allocation']
+				'label': ('Employees'),
+				'items': ['Employee', 'Employee Grade']
+			},
+			{
+				'label': ('Leaves'),
+				'items': ['Leave Allocation']
 			},
 		]
 	}
+
+
+
+
+	


### PR DESCRIPTION
Changed placement of dashboard links in Leave Policy to make it more consistent and remove unwanted spacing.

**Before:**

![image](https://user-images.githubusercontent.com/50285544/86088513-237d6c00-bac4-11ea-8f1d-a5372fd1a362.png)


**After:**

![image](https://user-images.githubusercontent.com/50285544/86125850-fac49900-bafa-11ea-819f-9e15606b99d3.png)
