### PR TITLE
fix: only remove the selected Quotation item instead of all rows with the same item code

### DIFF
--- a/erpnext/public/js/shopping_cart.js
+++ b/erpnext/public/js/shopping_cart.js
@@ -134,11 +134,12 @@ $.extend(shopping_cart, {
 		}
 	},
 
-	shopping_cart_update: function({item_code, qty, cart_dropdown, additional_notes}) {
+	shopping_cart_update: function({item_code, qty, row, cart_dropdown, additional_notes}) {
 		frappe.freeze();
 		shopping_cart.update_cart({
 			item_code,
 			qty,
+			row,
 			additional_notes,
 			with_items: 1,
 			btn: this,
@@ -163,7 +164,7 @@ $.extend(shopping_cart, {
 				oldValue = input.val().trim(),
 				newVal = 0;
 
-			if (btn.attr('data-dir') == 'up') {
+			if (btn.data('dir') == 'up') {
 				newVal = parseInt(oldValue) + 1;
 			} else {
 				if (oldValue > 1) {
@@ -171,7 +172,7 @@ $.extend(shopping_cart, {
 				}
 			}
 			input.val(newVal);
-			var item_code = input.attr("data-item-code");
+			var item_code = input.data("item-code");
 			shopping_cart.shopping_cart_update({item_code, qty: newVal, cart_dropdown: true});
 			return false;
 		});

--- a/erpnext/public/js/shopping_cart.js
+++ b/erpnext/public/js/shopping_cart.js
@@ -86,6 +86,7 @@ $.extend(shopping_cart, {
 				args: {
 					item_code: opts.item_code,
 					qty: opts.qty,
+					row: opts.row,
 					additional_notes: opts.additional_notes !== undefined ? opts.additional_notes : undefined,
 					with_items: opts.with_items || 0
 				},

--- a/erpnext/shopping_cart/cart.py
+++ b/erpnext/shopping_cart/cart.py
@@ -100,18 +100,21 @@ def request_for_quotation():
 	return quotation.name
 
 @frappe.whitelist()
-def update_cart(item_code, qty, additional_notes=None, with_items=False):
+def update_cart(item_code, qty, row=None, additional_notes=None, with_items=False):
 	quotation = _get_cart_quotation()
 
 	empty_card = False
 	qty = flt(qty)
 	if qty == 0:
-		quotation_items = quotation.get("items", {"item_code": ["!=", item_code]})
+		if row is None:
+			quotation_items = quotation.get("items", {"item_code": ["!=", item_code]})
+		else:
+			quotation_items = quotation.get("items", {"name": ["!=", row]})
+
 		if quotation_items:
 			quotation.set("items", quotation_items)
 		else:
 			empty_card = True
-
 	else:
 		quotation_items = quotation.get("items", {"item_code": item_code})
 		if not quotation_items:

--- a/erpnext/templates/includes/cart.js
+++ b/erpnext/templates/includes/cart.js
@@ -26,8 +26,8 @@ $.extend(shopping_cart, {
 	bind_address_select: function() {
 		$(".cart-addresses").on('click', '.address-card', function(e) {
 			const $card = $(e.currentTarget);
-			const address_type = $card.closest('[data-address-type]').attr('data-address-type');
-			const address_name = $card.closest('[data-address-name]').attr('data-address-name');
+			const address_type = $card.closest('[data-address-type]').data('address-type');
+			const address_name = $card.closest('[data-address-name]').data('address-name');
 			return frappe.call({
 				type: "POST",
 				method: "erpnext.shopping_cart.cart.update_cart_address",
@@ -60,18 +60,19 @@ $.extend(shopping_cart, {
 	bind_change_qty: function() {
 		// bind update button
 		$(".cart-items").on("change", ".cart-qty", function() {
-			var item_code = $(this).attr("data-item-code");
-			var newVal = $(this).val();
-			shopping_cart.shopping_cart_update({item_code, qty: newVal});
+			let row = $(this).closest("tr").data("name");
+			let item_code = $(this).data("item-code");
+			let newVal = $(this).val();
+			shopping_cart.shopping_cart_update({item_code, qty: newVal, row: row});
 		});
 
 		$(".cart-items").on('click', '.number-spinner button', function () {
-			var btn = $(this),
+			let btn = $(this),
 				input = btn.closest('.number-spinner').find('input'),
 				oldValue = input.val().trim(),
 				newVal = 0;
 
-			if (btn.attr('data-dir') == 'up') {
+			if (btn.data('dir') == 'up') {
 				newVal = parseInt(oldValue) + 1;
 			} else {
 				if (oldValue > 1) {
@@ -79,7 +80,7 @@ $.extend(shopping_cart, {
 				}
 			}
 			input.val(newVal);
-			var item_code = input.attr("data-item-code");
+			let item_code = input.data("item-code");
 			shopping_cart.shopping_cart_update({item_code, qty: newVal});
 		});
 	},
@@ -87,7 +88,7 @@ $.extend(shopping_cart, {
 	bind_change_notes: function() {
 		$('.cart-items').on('change', 'textarea', function() {
 			const $textarea = $(this);
-			const item_code = $textarea.attr('data-item-code');
+			const item_code = $textarea.data('item-code');
 			const qty = $textarea.closest('tr').find('.cart-qty').val();
 			const notes = $textarea.val();
 			shopping_cart.shopping_cart_update({


### PR DESCRIPTION
**Problem:**

While updating an item in the cart, it may be possible that multiple instances of that item might exist in the Quotation. If you remove one instance of this item (set quantity to 0), the system removes all instances of that item code instead.

**Fix:**

Pass the active item row to modify instead