### PR TITLE
feat: [production_plan -> fetching delivery_date, schedule_date, shipping_address_name] enhance production plan

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.json
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.json
@@ -19,6 +19,8 @@
   "column_break2",
   "from_date",
   "to_date",
+  "from_delivery_date",
+  "to_delivery_date",
   "sales_orders_detail",
   "get_sales_orders",
   "sales_orders",
@@ -51,7 +53,9 @@
    "fieldtype": "Select",
    "label": "Naming Series",
    "options": "MFG-PP-.YYYY.-",
-   "reqd": 1
+   "reqd": 1,
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "company",
@@ -59,18 +63,24 @@
    "in_list_view": 1,
    "label": "Company",
    "options": "Company",
-   "reqd": 1
+   "reqd": 1,
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "get_items_from",
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Get Items From",
-   "options": "\nSales Order\nMaterial Request"
+   "options": "\nSales Order\nMaterial Request",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "column_break1",
-   "fieldtype": "Column Break"
+   "fieldtype": "Column Break",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "default": "Today",
@@ -78,7 +88,9 @@
    "fieldtype": "Date",
    "in_list_view": 1,
    "label": "Posting Date",
-   "reqd": 1
+   "reqd": 1,
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "collapsible": 1,
@@ -86,14 +98,18 @@
    "depends_on": "eval: doc.get_items_from",
    "fieldname": "filters",
    "fieldtype": "Section Break",
-   "label": "Filters"
+   "label": "Filters",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "item_code",
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Item Code",
-   "options": "Item"
+   "options": "Item",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "depends_on": "eval: doc.get_items_from == \"Sales Order\"",
@@ -101,36 +117,48 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Customer",
-   "options": "Customer"
+   "options": "Customer",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "depends_on": "eval: doc.get_items_from == \"Material Request\"",
    "fieldname": "warehouse",
    "fieldtype": "Link",
    "label": "Warehouse",
-   "options": "Warehouse"
+   "options": "Warehouse",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "depends_on": "eval: doc.get_items_from == \"Sales Order\"",
    "fieldname": "project",
    "fieldtype": "Link",
    "label": "Project",
-   "options": "Project"
+   "options": "Project",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "column_break2",
    "fieldtype": "Column Break",
+   "show_days": 1,
+   "show_seconds": 1,
    "width": "50%"
   },
   {
    "fieldname": "from_date",
    "fieldtype": "Date",
-   "label": "From Date"
+   "label": "From Date",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "to_date",
    "fieldtype": "Date",
-   "label": "To Date"
+   "label": "To Date",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "collapsible": 1,
@@ -138,19 +166,25 @@
    "depends_on": "eval: doc.get_items_from == \"Sales Order\"",
    "fieldname": "sales_orders_detail",
    "fieldtype": "Section Break",
-   "label": "Sales Orders"
+   "label": "Sales Orders",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "get_sales_orders",
    "fieldtype": "Button",
-   "label": "Get Sales Orders"
+   "label": "Get Sales Orders",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "sales_orders",
    "fieldtype": "Table",
    "label": "Sales Orders",
    "no_copy": 1,
-   "options": "Production Plan Sales Order"
+   "options": "Production Plan Sales Order",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "collapsible": 1,
@@ -158,98 +192,132 @@
    "depends_on": "eval: doc.get_items_from == \"Material Request\"",
    "fieldname": "material_request_detail",
    "fieldtype": "Section Break",
-   "label": "Material Request Detail"
+   "label": "Material Request Detail",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "get_material_request",
    "fieldtype": "Button",
-   "label": "Get Material Request"
+   "label": "Get Material Request",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "material_requests",
    "fieldtype": "Table",
    "label": "Material Requests",
    "no_copy": 1,
-   "options": "Production Plan Material Request"
+   "options": "Production Plan Material Request",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "select_items_to_manufacture_section",
    "fieldtype": "Section Break",
-   "label": "Select Items to Manufacture"
+   "label": "Select Items to Manufacture",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "depends_on": "get_items_from",
    "fieldname": "get_items",
    "fieldtype": "Button",
-   "label": "Get Items For Work Order"
+   "label": "Get Items For Work Order",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "po_items",
    "fieldtype": "Table",
    "no_copy": 1,
    "options": "Production Plan Item",
-   "reqd": 1
+   "reqd": 1,
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "material_request_planning",
    "fieldtype": "Section Break",
-   "label": "Material Request Planning"
+   "label": "Material Request Planning",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "default": "1",
    "fieldname": "include_non_stock_items",
    "fieldtype": "Check",
-   "label": "Include Non Stock Items"
+   "label": "Include Non Stock Items",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "default": "1",
    "fieldname": "include_subcontracted_items",
    "fieldtype": "Check",
-   "label": "Include Subcontracted Items"
+   "label": "Include Subcontracted Items",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "default": "0",
    "description": "To know more about projected quantity, <a href=\"https://erpnext.com/docs/user/manual/en/stock/projected-quantity\" style=\"text-decoration: underline;\" target=\"_blank\">click here</a>.",
    "fieldname": "ignore_existing_ordered_qty",
    "fieldtype": "Check",
-   "label": "Ignore Existing Projected Quantity"
+   "label": "Ignore Existing Projected Quantity",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "column_break_25",
-   "fieldtype": "Column Break"
+   "fieldtype": "Column Break",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "for_warehouse",
    "fieldtype": "Link",
    "label": "For Warehouse",
-   "options": "Warehouse"
+   "options": "Warehouse",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "download_materials_required",
    "fieldtype": "Button",
-   "label": "Download Required Materials"
+   "label": "Download Required Materials",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "get_items_for_mr",
    "fieldtype": "Button",
-   "label": "Get Raw Materials For Production"
+   "label": "Get Raw Materials For Production",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "section_break_27",
-   "fieldtype": "Section Break"
+   "fieldtype": "Section Break",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "mr_items",
    "fieldtype": "Table",
    "label": "Material Request Plan Item",
    "no_copy": 1,
-   "options": "Material Request Plan Item"
+   "options": "Material Request Plan Item",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "collapsible": 1,
    "fieldname": "other_details",
    "fieldtype": "Section Break",
-   "label": "Other Details"
+   "label": "Other Details",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "default": "0",
@@ -258,7 +326,9 @@
    "label": "Total Planned Qty",
    "no_copy": 1,
    "print_hide": 1,
-   "read_only": 1
+   "read_only": 1,
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "default": "0",
@@ -267,11 +337,15 @@
    "label": "Total Produced Qty",
    "no_copy": 1,
    "print_hide": 1,
-   "read_only": 1
+   "read_only": 1,
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "column_break_32",
-   "fieldtype": "Column Break"
+   "fieldtype": "Column Break",
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "default": "Draft",
@@ -281,7 +355,9 @@
    "no_copy": 1,
    "options": "\nDraft\nSubmitted\nNot Started\nIn Process\nCompleted\nStopped\nCancelled\nMaterial Requested",
    "print_hide": 1,
-   "read_only": 1
+   "read_only": 1,
+   "show_days": 1,
+   "show_seconds": 1
   },
   {
    "fieldname": "amended_from",
@@ -290,14 +366,30 @@
    "no_copy": 1,
    "options": "Production Plan",
    "print_hide": 1,
-   "read_only": 1
+   "read_only": 1,
+   "show_days": 1,
+   "show_seconds": 1
+  },
+  {
+   "fieldname": "from_delivery_date",
+   "fieldtype": "Date",
+   "label": "From Delivery Date",
+   "show_days": 1,
+   "show_seconds": 1
+  },
+  {
+   "fieldname": "to_delivery_date",
+   "fieldtype": "Date",
+   "label": "To Delivery Date",
+   "show_days": 1,
+   "show_seconds": 1
   }
  ],
  "icon": "fa fa-calendar",
  "is_submittable": 1,
  "links": [],
- "modified": "2019-12-04 15:58:50.940460",
- "modified_by": "Administrator",
+ "modified": "2020-06-26 09:43:57.077036",
+ "modified_by": "m.morez@mh-receptions.com",
  "module": "Manufacturing",
  "name": "Production Plan",
  "owner": "Administrator",


### PR DESCRIPTION
Reopen https://github.com/frappe/erpnext/pull/22531
#22479
#19593

The goal is to be able to sort orders by delivery date / material requests by schedule date (from_delivery_date and to_delivery_date are used)

Hope it will work this time...

Thanks in advance,
Sincerely yours,
Martin