### PR TITLE
fix: incorrect available_qty being set

### DIFF
--- a/erpnext/public/js/utils/serial_no_batch_selector.js
+++ b/erpnext/public/js/utils/serial_no_batch_selector.js
@@ -333,8 +333,8 @@ erpnext.SerialNoBatchSelector = Class.extend({
 							};
 						},
 						change: function () {
-							let val = this.get_value();
-							if (val.length === 0) {
+							const batch_no = this.get_value();
+							if (!batch_no) {
 								this.grid_row.on_grid_fields_dict
 									.available_qty.set_value(0);
 								return;
@@ -358,7 +358,7 @@ erpnext.SerialNoBatchSelector = Class.extend({
 								frappe.call({
 									method: 'erpnext.stock.doctype.batch.batch.get_batch_qty',
 									args: {
-										batch_no: val,
+										batch_no,
 										warehouse: me.warehouse_details.name,
 										item_code: me.item_code
 									},

--- a/erpnext/public/js/utils/serial_no_batch_selector.js
+++ b/erpnext/public/js/utils/serial_no_batch_selector.js
@@ -354,14 +354,11 @@ erpnext.SerialNoBatchSelector = Class.extend({
 								return;
 							}
 
-							let batch_number = me.item.batch_no ||
-								this.grid_row.on_grid_fields_dict.batch_no.get_value();
-
 							if (me.warehouse_details.name) {
 								frappe.call({
 									method: 'erpnext.stock.doctype.batch.batch.get_batch_qty',
 									args: {
-										batch_no: batch_number,
+										batch_no: val,
 										warehouse: me.warehouse_details.name,
 										item_code: me.item_code
 									},


### PR DESCRIPTION
The issue was that selecting a batch in the `SerialNoBatchSelector` does not always set the correct `available_qty` in the modal child table.

The reason was because the variable `batch_number`, used to fetch the batch qty for `available_qty`, below, will always be set to `me.item.batch_no` if the `batch_no` is already set in the page's `frm.doc.items` child doc context.

https://github.com/frappe/erpnext/blob/25b6c5d55aced74a83606d49a1800d3747389d3f/erpnext/public/js/utils/serial_no_batch_selector.js#L357-L358


The solution was to query batch qty for the currently selected batch with `val` that's already defined at the beginning of the _change_ listener irrespective of the value in the page's `frm.doc.items`.

https://github.com/frappe/erpnext/blob/25b6c5d55aced74a83606d49a1800d3747389d3f/erpnext/public/js/utils/serial_no_batch_selector.js#L336

