### PR TITLE
feat: set default project and customer if only one found in Timesheet

### DIFF
--- a/erpnext/projects/doctype/timesheet/timesheet.py
+++ b/erpnext/projects/doctype/timesheet/timesheet.py
@@ -247,7 +247,7 @@ def get_timesheet_data(name, project):
 	}
 
 @frappe.whitelist()
-def make_sales_invoice(source_name, item_code=None, customer=None):
+def make_sales_invoice(source_name, item_code=None, customer=None, project=None):
 	target = frappe.new_doc("Sales Invoice")
 	timesheet = frappe.get_doc('Timesheet', source_name)
 
@@ -264,6 +264,9 @@ def make_sales_invoice(source_name, item_code=None, customer=None):
 	target.company = timesheet.company
 	if customer:
 		target.customer = customer
+
+	if project:
+		target.project = project
 
 	if item_code:
 		target.append('items', {


### PR DESCRIPTION
**Changes:**

- Add a new "Project" option in the "Create Sales Invoice" dialog box in Timesheet
- If only one customer or project needs to be billed, they're automatically fetched into the dialog box, otherwise none are selected

<hr>

**Screenshots / GIFs:**

![timesheet-customer-project](https://user-images.githubusercontent.com/13396535/86244450-9b7f8b00-bbc5-11ea-9274-d524aff6a1be.gif)