### PR TITLE
fix: whitelist all query functions for search widget

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -840,6 +840,7 @@ def get_opening_accounts(company):
 	return [{"account": a, "balance": get_balance_on(a)} for a in accounts]
 
 
+@frappe.whitelist()
 def get_against_jv(doctype, txt, searchfield, start, page_len, filters):
 	return frappe.db.sql("""select jv.name, jv.posting_date, jv.user_remark
 		from `tabJournal Entry` jv, `tabJournal Entry Account` jv_detail

--- a/erpnext/accounts/doctype/payment_order/payment_order.py
+++ b/erpnext/accounts/doctype/payment_order/payment_order.py
@@ -26,6 +26,7 @@ class PaymentOrder(Document):
 		for d in self.references:
 			frappe.db.set_value(self.payment_order_type, d.get(frappe.scrub(self.payment_order_type)), ref_field, status)
 
+@frappe.whitelist()
 def get_mop_query(doctype, txt, searchfield, start, page_len, filters):
 	return frappe.db.sql(""" select mode_of_payment from `tabPayment Order Reference`
 		where parent = %(parent)s and mode_of_payment like %(txt)s
@@ -36,6 +37,7 @@ def get_mop_query(doctype, txt, searchfield, start, page_len, filters):
 			'txt': "%%%s%%" % txt
 		})
 
+@frappe.whitelist()
 def get_supplier_query(doctype, txt, searchfield, start, page_len, filters):
 	return frappe.db.sql(""" select supplier from `tabPayment Order Reference`
 		where parent = %(parent)s and supplier like %(txt)s and

--- a/erpnext/accounts/doctype/pos_profile/pos_profile.py
+++ b/erpnext/accounts/doctype/pos_profile/pos_profile.py
@@ -115,6 +115,7 @@ def get_item_groups(pos_profile):
 def get_series():
 	return frappe.get_meta("Sales Invoice").get_field("naming_series").options or ""
 
+@frappe.whitelist()
 def pos_profile_query(doctype, txt, searchfield, start, page_len, filters):
 	user = frappe.session['user']
 	company = filters.get('company') or frappe.defaults.get_user_default('company')

--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -432,6 +432,7 @@ def make_pricing_rule(doctype, docname):
 
 	return doc
 
+@frappe.whitelist()
 def get_item_uoms(doctype, txt, searchfield, start, page_len, filters):
 	items = [filters.get('value')]
 	if filters.get('apply_on') != 'Item Code':

--- a/erpnext/accounts/page/bank_reconciliation/bank_reconciliation.py
+++ b/erpnext/accounts/page/bank_reconciliation/bank_reconciliation.py
@@ -21,7 +21,7 @@ def reconcile(bank_transaction, payment_doctype, payment_name):
 	if payment_doctype == "Payment Entry" and payment_entry.unallocated_amount > transaction.unallocated_amount:
 		frappe.throw(_("The unallocated amount of Payment Entry {0} \
 			is greater than the Bank Transaction's unallocated amount").format(payment_name))
-		
+
 	if transaction.unallocated_amount == 0:
 		frappe.throw(_("This bank transaction is already fully reconciled"))
 
@@ -289,6 +289,7 @@ def get_matching_transactions_payments(description_matching):
 	else:
 		return []
 
+@frappe.whitelist()
 def payment_entry_query(doctype, txt, searchfield, start, page_len, filters):
 	account = frappe.db.get_value("Bank Account", filters.get("bank_account"), "account")
 	if not account:
@@ -317,6 +318,7 @@ def payment_entry_query(doctype, txt, searchfield, start, page_len, filters):
 		}
 	)
 
+@frappe.whitelist()
 def journal_entry_query(doctype, txt, searchfield, start, page_len, filters):
 	account = frappe.db.get_value("Bank Account", filters.get("bank_account"), "account")
 
@@ -352,6 +354,7 @@ def journal_entry_query(doctype, txt, searchfield, start, page_len, filters):
 		}
 	)
 
+@frappe.whitelist()
 def sales_invoices_query(doctype, txt, searchfield, start, page_len, filters):
 	return frappe.db.sql("""
 		SELECT

--- a/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
+++ b/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
@@ -206,6 +206,7 @@ def get_list_context(context=None):
 	})
 	return list_context
 
+@frappe.whitelist()
 def get_supplier_contacts(doctype, txt, searchfield, start, page_len, filters):
 	return frappe.db.sql("""select `tabContact`.name from `tabContact`, `tabDynamic Link`
 		where `tabDynamic Link`.link_doctype = 'Supplier' and (`tabDynamic Link`.link_name=%(name)s

--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -10,7 +10,8 @@ from collections import defaultdict
 from erpnext.stock.get_item_details import _get_item_tax_template
 from frappe.utils import unique
 
- # searches for active employees
+# searches for active employees
+@frappe.whitelist()
 def employee_query(doctype, txt, searchfield, start, page_len, filters):
 	conditions = []
 	fields = get_fields("Employee", ["name", "employee_name"])
@@ -40,6 +41,7 @@ def employee_query(doctype, txt, searchfield, start, page_len, filters):
 
 
 # searches for leads which are not converted
+@frappe.whitelist()
 def lead_query(doctype, txt, searchfield, start, page_len, filters):
 	fields = get_fields("Lead", ["name", "lead_name", "company_name"])
 
@@ -69,6 +71,7 @@ def lead_query(doctype, txt, searchfield, start, page_len, filters):
 
 
  # searches for customer
+@frappe.whitelist()
 def customer_query(doctype, txt, searchfield, start, page_len, filters):
 	conditions = []
 	cust_master_name = frappe.defaults.get_user_default("cust_master_name")
@@ -106,6 +109,7 @@ def customer_query(doctype, txt, searchfield, start, page_len, filters):
 
 
 # searches for supplier
+@frappe.whitelist()
 def supplier_query(doctype, txt, searchfield, start, page_len, filters):
 	supp_master_name = frappe.defaults.get_user_default("supp_master_name")
 	if supp_master_name == "Supplier Name":
@@ -137,6 +141,7 @@ def supplier_query(doctype, txt, searchfield, start, page_len, filters):
 		})
 
 
+@frappe.whitelist()
 def tax_account_query(doctype, txt, searchfield, start, page_len, filters):
 	company_currency = erpnext.get_company_currency(filters.get('company'))
 
@@ -162,6 +167,7 @@ def tax_account_query(doctype, txt, searchfield, start, page_len, filters):
 	return tax_accounts
 
 
+@frappe.whitelist()
 def item_query(doctype, txt, searchfield, start, page_len, filters, as_dict=False):
 	conditions = []
 
@@ -224,6 +230,7 @@ def item_query(doctype, txt, searchfield, start, page_len, filters, as_dict=Fals
 			}, as_dict=as_dict)
 
 
+@frappe.whitelist()
 def bom(doctype, txt, searchfield, start, page_len, filters):
 	conditions = []
 	fields = get_fields("BOM", ["name", "item"])
@@ -250,6 +257,7 @@ def bom(doctype, txt, searchfield, start, page_len, filters):
 		})
 
 
+@frappe.whitelist()
 def get_project_name(doctype, txt, searchfield, start, page_len, filters):
 	cond = ''
 	if filters.get('customer'):
@@ -276,6 +284,7 @@ def get_project_name(doctype, txt, searchfield, start, page_len, filters):
 			})
 
 
+@frappe.whitelist()
 def get_delivery_notes_to_be_billed(doctype, txt, searchfield, start, page_len, filters, as_dict):
 	fields = get_fields("Delivery Note", ["name", "customer", "posting_date"])
 
@@ -305,6 +314,7 @@ def get_delivery_notes_to_be_billed(doctype, txt, searchfield, start, page_len, 
 	}, {"txt": ("%%%s%%" % txt)}, as_dict=as_dict)
 
 
+@frappe.whitelist()
 def get_batch_no(doctype, txt, searchfield, start, page_len, filters):
 	cond = ""
 	if filters.get("posting_date"):
@@ -362,6 +372,7 @@ def get_batch_no(doctype, txt, searchfield, start, page_len, filters):
 			limit %(start)s, %(page_len)s""".format(cond, match_conditions=get_match_cond(doctype)), args)
 
 
+@frappe.whitelist()
 def get_account_list(doctype, txt, searchfield, start, page_len, filters):
 	filter_list = []
 
@@ -385,6 +396,7 @@ def get_account_list(doctype, txt, searchfield, start, page_len, filters):
 		limit_start=start, limit_page_length=page_len, as_list=True)
 
 
+@frappe.whitelist()
 def get_blanket_orders(doctype, txt, searchfield, start, page_len, filters):
 	return frappe.db.sql("""select distinct bo.name, bo.blanket_order_type, bo.to_date
 		from `tabBlanket Order` bo, `tabBlanket Order Item` boi

--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -910,6 +910,7 @@ def get_bom_diff(bom1, bom2):
 
 	return out
 
+@frappe.whitelist()
 def item_query(doctype, txt, searchfield, start, page_len, filters):
 	meta = frappe.get_meta("Item", cached=True)
 	searchfields = meta.get_search_fields()

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -631,6 +631,7 @@ class WorkOrder(Document):
 		bom.set_bom_material_details()
 		return bom
 
+@frappe.whitelist()
 def get_bom_operations(doctype, txt, searchfield, start, page_len, filters):
 	if txt:
 		filters['operation'] = ('like', '%%%s%%' % txt)

--- a/erpnext/manufacturing/report/bom_variance_report/bom_variance_report.py
+++ b/erpnext/manufacturing/report/bom_variance_report/bom_variance_report.py
@@ -19,7 +19,7 @@ def get_columns(filters):
 			"options": "Work Order",
 			"width": 120
 		}]
-	
+
 	if not filters.get('bom_no'):
 		columns.extend([
 			{

--- a/erpnext/payroll/doctype/employee_benefit_application/employee_benefit_application.py
+++ b/erpnext/payroll/doctype/employee_benefit_application/employee_benefit_application.py
@@ -222,7 +222,7 @@ def get_benefit_amount_based_on_pro_rata(sal_struct, component_max_benefit):
 
 	return benefit_amount
 
-
+@frappe.whitelist()
 def get_earning_components(doctype, txt, searchfield, start, page_len, filters):
 	if len(filters) < 2:
 		return {}

--- a/erpnext/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/erpnext/payroll/doctype/payroll_entry/payroll_entry.py
@@ -539,6 +539,7 @@ def submit_salary_slips_for_employees(payroll_entry, salary_slips, publish_progr
 	if not_submitted_ss:
 		frappe.msgprint(_("Could not submit some Salary Slips"))
 
+@frappe.whitelist()
 def get_payroll_entries_for_jv(doctype, txt, searchfield, start, page_len, filters):
 	return frappe.db.sql("""
 		select name from `tabPayroll Entry`

--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -238,6 +238,7 @@ def get_list_context(context=None):
 		"row_template": "templates/includes/projects/project_row.html"
 	}
 
+@frappe.whitelist()
 def get_users_for_project(doctype, txt, searchfield, start, page_len, filters):
 	conditions = []
 	return frappe.db.sql("""select name, concat_ws(' ', first_name, middle_name, last_name)

--- a/erpnext/projects/doctype/task/task.py
+++ b/erpnext/projects/doctype/task/task.py
@@ -188,6 +188,7 @@ def check_if_child_exists(name):
 	return child_tasks
 
 
+@frappe.whitelist()
 def get_project(doctype, txt, searchfield, start, page_len, filters):
 	from erpnext.controllers.queries import get_match_cond
 	return frappe.db.sql(""" select name from `tabProject`

--- a/erpnext/restaurant/doctype/restaurant_order_entry/restaurant_order_entry.py
+++ b/erpnext/restaurant/doctype/restaurant_order_entry/restaurant_order_entry.py
@@ -65,6 +65,7 @@ def make_invoice(table, customer, mode_of_payment):
 
 	return invoice.name
 
+@frappe.whitelist()
 def item_query_restaurant(doctype='Item', txt='', searchfield='name', start=0, page_len=20, filters=None, as_dict=False):
 	'''Return items that are selected in active menu of the restaurant'''
 	restaurant, menu = get_restaurant_and_menu_name(filters['table'])

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -542,6 +542,7 @@ def make_address(args, is_primary_address=1):
 
 	return address
 
+@frappe.whitelist()
 def get_customer_primary_contact(doctype, txt, searchfield, start, page_len, filters):
 	customer = filters.get('customer')
 	return frappe.db.sql("""

--- a/erpnext/selling/doctype/product_bundle/product_bundle.py
+++ b/erpnext/selling/doctype/product_bundle/product_bundle.py
@@ -22,12 +22,13 @@ class ProductBundle(Document):
 		"""Validates, main Item is not a stock item"""
 		if frappe.db.get_value("Item", self.new_item_code, "is_stock_item"):
 			frappe.throw(_("Parent Item {0} must not be a Stock Item").format(self.new_item_code))
-			
+
 	def validate_child_items(self):
 		for item in self.items:
 			if frappe.db.exists("Product Bundle", item.item_code):
 				frappe.throw(_("Child Item should not be a Product Bundle. Please remove item `{0}` and save").format(item.item_code))
-				
+
+@frappe.whitelist()
 def get_new_item_code(doctype, txt, searchfield, start, page_len, filters):
 	from erpnext.controllers.queries import get_match_cond
 

--- a/erpnext/selling/page/point_of_sale/point_of_sale.py
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.py
@@ -167,6 +167,7 @@ def get_item_group_condition(pos_profile):
 
 	return cond % tuple(item_groups)
 
+@frappe.whitelist()
 def item_group_query(doctype, txt, searchfield, start, page_len, filters):
 	item_groups = []
 	cond = "1=1"

--- a/erpnext/stock/doctype/item_alternative/item_alternative.py
+++ b/erpnext/stock/doctype/item_alternative/item_alternative.py
@@ -42,6 +42,7 @@ class ItemAlternative(Document):
 			'alternative_item_code': self.alternative_item_code, 'name': ('!=', self.name)}):
 			frappe.throw(_("Already record exists for the item {0}").format(self.item_code))
 
+@frappe.whitelist()
 def get_alternative_items(doctype, txt, searchfield, start, page_len, filters):
 	return frappe.db.sql(""" (select alternative_item_code from `tabItem Alternative`
 			where item_code = %(item_code)s and alternative_item_code like %(txt)s)

--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -402,6 +402,7 @@ def get_material_requests_based_on_supplier(doctype, txt, searchfield, start, pa
 
 	return material_requests
 
+@frappe.whitelist()
 def get_default_supplier_query(doctype, txt, searchfield, start, page_len, filters):
 	doc = frappe.get_doc("Material Request", filters.get("doc"))
 	item_list = []

--- a/erpnext/stock/doctype/packing_slip/packing_slip.py
+++ b/erpnext/stock/doctype/packing_slip/packing_slip.py
@@ -175,6 +175,7 @@ class PackingSlip(Document):
 
 		self.update_item_details()
 
+@frappe.whitelist()
 def item_details(doctype, txt, searchfield, start, page_len, filters):
 	from erpnext.controllers.queries import get_match_cond
 	return frappe.db.sql("""select name, item_name, description from `tabItem`

--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.py
@@ -58,6 +58,7 @@ class QualityInspection(Document):
 				.format(parent_doc=self.reference_type, child_doc=doctype),
 				(quality_inspection, self.modified, self.reference_name, self.item_code))
 
+@frappe.whitelist()
 def item_query(doctype, txt, searchfield, start, page_len, filters):
 	if filters.get("from"):
 		from frappe.desk.reportview import get_match_cond

--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.py
@@ -87,6 +87,7 @@ def item_query(doctype, txt, searchfield, start, page_len, filters):
 			page_len = page_len, qi_condition = qi_condition),
 			{'parent': filters.get('parent'), 'txt': "%%%s%%" % txt})
 
+@frappe.whitelist()
 def quality_inspection_query(doctype, txt, searchfield, start, page_len, filters):
 	return frappe.get_all('Quality Inspection',
 		limit_start=start,


### PR DESCRIPTION
add whitelist to methods that are being called through link fields, since search_widget has now been limited to only whitelisted methods with frappe/frappe#10492

whitelist is necessary for the link fields to work, which was breaking in the latest develop and has been fixed with frappe/frappe#10893