### PR TITLE
fix: sort product by item_group and price

### DIFF
--- a/erpnext/portal/product_configurator/utils.py
+++ b/erpnext/portal/product_configurator/utils.py
@@ -372,6 +372,7 @@ def get_items(filters=None, search=None):
 			left_joins.append(f[0])
 
 	left_join = ' '.join(['LEFT JOIN `tab{0}` on (`tab{0}`.parent = `tabItem`.name)'.format(l) for l in left_joins])
+	left_join = left_join.join('LEFT JOIN `tabItem Price` ON `tabItem`.`name` = `tabItem Price`.`item_code`')
 
 	results = frappe.db.sql('''
 		SELECT
@@ -387,7 +388,9 @@ def get_items(filters=None, search=None):
 		GROUP BY
 			`tabItem`.`name`
 		ORDER BY
-			`tabItem`.`weightage` DESC
+			`tabItem`.`weightage` DESC,
+			`tabItem`.`item_group` DESC,
+			`tabItem Price`.`price_list_rate` DESC
 		LIMIT
 			{page_length}
 		OFFSET


### PR DESCRIPTION
Sort product by item_group and price
![Screenshot from 2020-06-30 17-53-39](https://user-images.githubusercontent.com/6947417/86125672-afaa8600-bafa-11ea-840a-d54f5a5db093.png)
