### PR TITLE
fix: Remove loan security field from loan

### DIFF
--- a/erpnext/loan_management/doctype/loan/loan.js
+++ b/erpnext/loan_management/doctype/loan/loan.js
@@ -45,15 +45,6 @@ frappe.ui.form.on('Loan', {
 			});
 		})
 
-		frm.set_query('loan_security_pledge', function(doc, cdt, cdn) {
-			return {
-				filters: {
-					applicant: frm.doc.applicant,
-					docstatus: 1,
-					loan_application: frm.doc.loan_application || ''
-				}
-			};
-		});
 	},
 
 	refresh: function (frm) {
@@ -86,9 +77,6 @@ frappe.ui.form.on('Loan', {
 		frm.toggle_display("repayment_periods", s1 - frm.doc.is_term_loan);
 	},
 
-	is_secured_loan: function(frm) {
-		frm.toggle_reqd("loan_security_pledge", frm.doc.is_secured_loan);
-	},
 
 	make_loan_disbursement: function (frm) {
 		frappe.call({

--- a/erpnext/loan_management/doctype/loan/loan.json
+++ b/erpnext/loan_management/doctype/loan/loan.json
@@ -25,15 +25,12 @@
   "disbursement_date",
   "disbursed_amount",
   "column_break_11",
+  "maximum_loan_amount",
   "is_term_loan",
   "repayment_method",
   "repayment_periods",
   "monthly_repayment_amount",
   "repayment_start_date",
-  "loan_security_details_section",
-  "loan_security_pledge",
-  "column_break_25",
-  "maximum_loan_value",
   "account_info",
   "mode_of_payment",
   "payment_account",
@@ -292,13 +289,8 @@
    "default": "0",
    "fieldname": "is_secured_loan",
    "fieldtype": "Check",
-   "label": "Is Secured Loan"
-  },
-  {
-   "depends_on": "is_secured_loan",
-   "fieldname": "loan_security_details_section",
-   "fieldtype": "Section Break",
-   "label": "Loan Security Details"
+   "label": "Is Secured Loan",
+   "read_only": 1
   },
   {
    "default": "0",
@@ -325,12 +317,6 @@
    "read_only": 1
   },
   {
-   "fieldname": "loan_security_pledge",
-   "fieldtype": "Link",
-   "label": "Loan Security Pledge",
-   "options": "Loan Security Pledge"
-  },
-  {
    "fieldname": "disbursed_amount",
    "fieldtype": "Currency",
    "label": "Disbursed Amount",
@@ -338,21 +324,17 @@
    "read_only": 1
   },
   {
-   "fetch_from": "loan_security_pledge.maximum_loan_value",
-   "fieldname": "maximum_loan_value",
+   "fetch_from": "loan_application.maximum_loan_amount",
+   "fieldname": "maximum_loan_amount",
    "fieldtype": "Currency",
-   "label": "Maximum Loan Value",
+   "label": "Maximum Loan Amount",
    "options": "Company:company:default_currency",
    "read_only": 1
-  },
-  {
-   "fieldname": "column_break_25",
-   "fieldtype": "Column Break"
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2020-04-13 13:16:10.192624",
+ "modified": "2020-07-02 20:46:40.128142",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan",

--- a/erpnext/loan_management/doctype/loan/test_loan.py
+++ b/erpnext/loan_management/doctype/loan/test_loan.py
@@ -16,6 +16,7 @@ from erpnext.loan_management.doctype.loan_interest_accrual.loan_interest_accrual
 from erpnext.loan_management.doctype.process_loan_security_shortfall.process_loan_security_shortfall import create_process_loan_security_shortfall
 from erpnext.loan_management.doctype.loan.loan import create_loan_security_unpledge
 from erpnext.loan_management.doctype.loan_security_unpledge.loan_security_unpledge import get_pledged_security_qty
+from erpnext.loan_management.doctype.loan_application.loan_application import create_pledge
 
 class TestLoan(unittest.TestCase):
 	def setUp(self):
@@ -72,31 +73,28 @@ class TestLoan(unittest.TestCase):
 		self.assertEquals(loan.total_payment, 302712)
 
 	def test_loan_with_security(self):
-		pledges = []
-		pledges.append({
+
+		pledge = [{
 			"loan_security": "Test Security 1",
 			"qty": 4000.00,
-			"haircut": 50,
-			"loan_security_price": 500.00
-		})
+		}]
 
-		loan_security_pledge = create_loan_security_pledge(self.applicant2, pledges)
+		loan_application = create_loan_application('_Test Company', self.applicant2, 'Stock Loan', pledge, "Repay Over Number of Periods", 12)
+		create_pledge(loan_application)
 
-		loan = create_loan_with_security(self.applicant2, "Stock Loan", "Repay Over Number of Periods", 12, loan_security_pledge.name)
-
+		loan = create_loan_with_security(self.applicant2, "Stock Loan", "Repay Over Number of Periods", 12, loan_application)
 		self.assertEquals(loan.loan_amount, 1000000)
 
 	def test_loan_disbursement(self):
-		pledges = []
-		pledges.append({
+		pledge = [{
 			"loan_security": "Test Security 1",
-			"qty": 4000.00,
-			"haircut": 50
-		})
+			"qty": 4000.00
+		}]
 
-		loan_security_pledge = create_loan_security_pledge(self.applicant2, pledges)
+		loan_application = create_loan_application('_Test Company', self.applicant2, 'Stock Loan', pledge, "Repay Over Number of Periods", 12)
+		create_pledge(loan_application)
 
-		loan = create_loan_with_security(self.applicant2, "Stock Loan", "Repay Over Number of Periods", 12, loan_security_pledge.name)
+		loan = create_loan_with_security(self.applicant2, "Stock Loan", "Repay Over Number of Periods", 12, loan_application)
 		self.assertEquals(loan.loan_amount, 1000000)
 
 		loan.submit()
@@ -121,18 +119,15 @@ class TestLoan(unittest.TestCase):
 		self.assertTrue(gl_entries2)
 
 	def test_regular_loan_repayment(self):
-		pledges = []
-		pledges.append({
+		pledge = [{
 			"loan_security": "Test Security 1",
-			"qty": 4000.00,
-			"haircut": 50
-		})
+			"qty": 4000.00
+		}]
 
-		loan_security_pledge = create_loan_security_pledge(self.applicant2, pledges)
+		loan_application = create_loan_application('_Test Company', self.applicant2, 'Demand Loan', pledge)
+		create_pledge(loan_application)
 
-		loan = create_demand_loan(self.applicant2, "Demand Loan", loan_security_pledge.name,
-			posting_date=get_first_day(nowdate()))
-
+		loan = create_demand_loan(self.applicant2, "Demand Loan", loan_application, posting_date=get_first_day(nowdate()))
 		loan.submit()
 
 		self.assertEquals(loan.loan_amount, 1000000)
@@ -166,16 +161,15 @@ class TestLoan(unittest.TestCase):
 			 penalty_amount - amounts[0], 2))
 
 	def test_loan_closure_repayment(self):
-		pledges = []
-		pledges.append({
+		pledge = [{
 			"loan_security": "Test Security 1",
-			"qty": 4000.00,
-			"haircut": 50
-		})
+			"qty": 4000.00
+		}]
 
-		loan_security_pledge = create_loan_security_pledge(self.applicant2, pledges)
-		loan = create_demand_loan(self.applicant2, "Demand Loan", loan_security_pledge.name,
-			posting_date=get_first_day(nowdate()))
+		loan_application = create_loan_application('_Test Company', self.applicant2, 'Demand Loan', pledge)
+		create_pledge(loan_application)
+
+		loan = create_demand_loan(self.applicant2, "Demand Loan", loan_application, posting_date=get_first_day(nowdate()))
 		loan.submit()
 
 		self.assertEquals(loan.loan_amount, 1000000)
@@ -214,23 +208,20 @@ class TestLoan(unittest.TestCase):
 		self.assertEquals(loan.status, "Loan Closure Requested")
 
 	def test_loan_repayment_for_term_loan(self):
-		pledges = []
-		pledges.append({
+		pledges = [{
 			"loan_security": "Test Security 2",
-			"qty": 4000.00,
-			"haircut": 50
-		})
-
-		pledges.append({
+			"qty": 4000.00
+		},
+		{
 			"loan_security": "Test Security 1",
-			"qty": 2000.00,
-			"haircut": 50
-		})
+			"qty": 2000.00
+		}]
 
-		loan_security_pledge = create_loan_security_pledge(self.applicant2, pledges)
+		loan_application = create_loan_application('_Test Company', self.applicant2, 'Stock Loan', pledges)
+		create_pledge(loan_application)
 
-		loan = create_loan_with_security(self.applicant2, "Stock Loan", "Repay Over Number of Periods", 12,
-			loan_security_pledge.name, posting_date=add_months(nowdate(), -1))
+		loan = create_loan_with_security(self.applicant2, "Stock Loan", "Repay Over Number of Periods", 12, loan_application,
+			posting_date=add_months(nowdate(), -1))
 
 		loan.submit()
 
@@ -250,16 +241,16 @@ class TestLoan(unittest.TestCase):
 		self.assertEquals(amounts[1], 78303.00)
 
 	def test_security_shortfall(self):
-		pledges = []
-		pledges.append({
+		pledges = [{
 			"loan_security": "Test Security 2",
 			"qty": 8000.00,
 			"haircut": 50,
-		})
+		}]
 
-		loan_security_pledge = create_loan_security_pledge(self.applicant2, pledges)
+		loan_application = create_loan_application('_Test Company', self.applicant2, 'Stock Loan', pledges)
+		create_pledge(loan_application)
 
-		loan = create_loan_with_security(self.applicant2, "Stock Loan", "Repay Over Number of Periods", 12, loan_security_pledge.name)
+		loan = create_loan_with_security(self.applicant2, "Stock Loan", "Repay Over Number of Periods", 12, loan_application)
 		loan.submit()
 
 		make_loan_disbursement_entry(loan.name, loan.loan_amount)
@@ -279,16 +270,15 @@ class TestLoan(unittest.TestCase):
 			where loan_security='Test Security 2'""")
 
 	def test_loan_security_unpledge(self):
-		pledges = []
-		pledges.append({
+		pledge = [{
 			"loan_security": "Test Security 1",
-			"qty": 4000.00,
-			"haircut": 50
-		})
+			"qty": 4000.00
+		}]
 
-		loan_security_pledge = create_loan_security_pledge(self.applicant2, pledges)
-		loan = create_demand_loan(self.applicant2, "Demand Loan", loan_security_pledge.name,
-			posting_date=get_first_day(nowdate()))
+		loan_application = create_loan_application('_Test Company', self.applicant2, 'Demand Loan', pledge)
+		create_pledge(loan_application)
+
+		loan = create_demand_loan(self.applicant2, "Demand Loan", loan_application, posting_date=get_first_day(nowdate()))
 		loan.submit()
 
 		self.assertEquals(loan.loan_amount, 1000000)
@@ -446,12 +436,13 @@ def create_loan_security():
 			"haircut": 50.00,
 		}).insert(ignore_permissions=True)
 
-def create_loan_security_pledge(applicant, pledges):
+def create_loan_security_pledge(applicant, pledges, loan_application):
 
 	lsp = frappe.new_doc("Loan Security Pledge")
 	lsp.applicant_type = 'Customer'
 	lsp.applicant = applicant
 	lsp.company = "_Test Company"
+	lsp.loan_application = loan_application
 
 	for pledge in pledges:
 		lsp.append('securities', {
@@ -510,6 +501,31 @@ def create_repayment_entry(loan, applicant, posting_date, payment_type, paid_amo
 
 	return lr
 
+def create_loan_application(company, applicant, loan_type, proposed_pledges, repayment_method=None,
+	repayment_periods=None, posting_date=None):
+	loan_application = frappe.new_doc('Loan Application')
+	loan_application.applicant_type = 'Customer'
+	loan_application.company = company
+	loan_application.applicant = applicant
+	loan_application.loan_type = loan_type
+	loan_application.posting_date = posting_date or nowdate()
+	loan_application.is_secured_loan = 1
+
+	if repayment_method:
+		loan_application.repayment_method = repayment_method
+		loan_application.repayment_periods = repayment_periods
+
+	for pledge in proposed_pledges:
+		loan_application.append('proposed_pledges', pledge)
+
+	loan_application.save()
+	loan_application.submit()
+
+	loan_application.status = 'Approved'
+	loan_application.save()
+
+	return loan_application.name
+
 
 def create_loan(applicant, loan_type, loan_amount, repayment_method, repayment_periods,
 	repayment_start_date=None, posting_date=None):
@@ -531,14 +547,13 @@ def create_loan(applicant, loan_type, loan_amount, repayment_method, repayment_p
 	loan.save()
 	return loan
 
-def create_loan_with_security(applicant, loan_type, repayment_method, repayment_periods, loan_security_pledge,
-	posting_date=None, repayment_start_date=None):
-
+def create_loan_with_security(applicant, loan_type, repayment_method, repayment_periods, loan_application, posting_date=None, repayment_start_date=None):
 	loan = frappe.get_doc({
 		"doctype": "Loan",
 		"company": "_Test Company",
 		"applicant_type": "Customer",
 		"posting_date": posting_date or nowdate(),
+		"loan_application": loan_application,
 		"applicant": applicant,
 		"loan_type": loan_type,
 		"is_term_loan": 1,
@@ -547,7 +562,6 @@ def create_loan_with_security(applicant, loan_type, repayment_method, repayment_
 		"repayment_periods": repayment_periods,
 		"repayment_start_date": repayment_start_date or nowdate(),
 		"mode_of_payment": frappe.db.get_value('Mode of Payment', {'type': 'Cash'}, 'name'),
-		"loan_security_pledge": loan_security_pledge,
 		"payment_account": 'Payment Account - _TC',
 		"loan_account": 'Loan Account - _TC',
 		"interest_income_account": 'Interest Income Account - _TC',
@@ -558,19 +572,19 @@ def create_loan_with_security(applicant, loan_type, repayment_method, repayment_
 
 	return loan
 
-def create_demand_loan(applicant, loan_type, loan_security_pledge, posting_date=None):
+def create_demand_loan(applicant, loan_type, loan_application, posting_date=None):
 
 	loan = frappe.get_doc({
 		"doctype": "Loan",
 		"company": "_Test Company",
 		"applicant_type": "Customer",
 		"posting_date": posting_date or nowdate(),
+		'loan_application': loan_application,
 		"applicant": applicant,
 		"loan_type": loan_type,
 		"is_term_loan": 0,
 		"is_secured_loan": 1,
 		"mode_of_payment": frappe.db.get_value('Mode of Payment', {'type': 'Cash'}, 'name'),
-		"loan_security_pledge": loan_security_pledge,
 		"payment_account": 'Payment Account - _TC',
 		"loan_account": 'Loan Account - _TC',
 		"interest_income_account": 'Interest Income Account - _TC',

--- a/erpnext/loan_management/doctype/loan_disbursement/test_loan_disbursement.py
+++ b/erpnext/loan_management/doctype/loan_disbursement/test_loan_disbursement.py
@@ -5,11 +5,12 @@ from __future__ import unicode_literals
 import frappe
 import unittest
 from frappe.utils import (nowdate, add_days, get_datetime, get_first_day, get_last_day, date_diff, flt, add_to_date)
-from erpnext.loan_management.doctype.loan.test_loan import (create_loan_type, create_loan_security_pledge, create_repayment_entry,
+from erpnext.loan_management.doctype.loan.test_loan import (create_loan_type, create_loan_security_pledge, create_repayment_entry, create_loan_application,
 	make_loan_disbursement_entry, create_loan_accounts, create_loan_security_type, create_loan_security, create_demand_loan, create_loan_security_price)
 from erpnext.loan_management.doctype.process_loan_interest_accrual.process_loan_interest_accrual import process_loan_interest_accrual_for_demand_loans
 from erpnext.loan_management.doctype.loan_interest_accrual.loan_interest_accrual import days_in_year
 from erpnext.selling.doctype.customer.test_customer import get_customer_dict
+from erpnext.loan_management.doctype.loan_application.loan_application import create_pledge
 
 class TestLoanDisbursement(unittest.TestCase):
 
@@ -31,18 +32,15 @@ class TestLoanDisbursement(unittest.TestCase):
 		self.applicant = frappe.db.get_value("Customer", {'name': '_Test Loan Customer'}, 'name')
 
 	def test_loan_topup(self):
-		pledges = []
-		pledges.append({
+		pledge = [{
 			"loan_security": "Test Security 1",
-			"qty": 4000.00,
-			"haircut": 50,
-			"loan_security_price": 500.00
-		})
+			"qty": 4000.00
+		}]
 
-		loan_security_pledge = create_loan_security_pledge(self.applicant, pledges)
+		loan_application = create_loan_application('_Test Company', self.applicant, 'Demand Loan', pledge)
+		create_pledge(loan_application)
 
-		loan = create_demand_loan(self.applicant, "Demand Loan", loan_security_pledge.name,
-			posting_date=get_first_day(nowdate()))
+		loan = create_demand_loan(self.applicant, "Demand Loan", loan_application, posting_date=get_first_day(nowdate()))
 
 		loan.submit()
 

--- a/erpnext/loan_management/doctype/loan_interest_accrual/test_loan_interest_accrual.py
+++ b/erpnext/loan_management/doctype/loan_interest_accrual/test_loan_interest_accrual.py
@@ -6,10 +6,11 @@ import frappe
 import unittest
 from frappe.utils import (nowdate, add_days, get_datetime, get_first_day, get_last_day, date_diff, flt, add_to_date)
 from erpnext.loan_management.doctype.loan.test_loan import (create_loan_type, create_loan_security_pledge, create_loan_security_price,
-	make_loan_disbursement_entry, create_loan_accounts, create_loan_security_type, create_loan_security, create_demand_loan)
+	make_loan_disbursement_entry, create_loan_accounts, create_loan_security_type, create_loan_security, create_demand_loan, create_loan_application)
 from erpnext.loan_management.doctype.process_loan_interest_accrual.process_loan_interest_accrual import process_loan_interest_accrual_for_demand_loans
 from erpnext.loan_management.doctype.loan_interest_accrual.loan_interest_accrual import days_in_year
 from erpnext.selling.doctype.customer.test_customer import get_customer_dict
+from erpnext.loan_management.doctype.loan_application.loan_application import create_pledge
 
 class TestLoanInterestAccrual(unittest.TestCase):
 	def setUp(self):
@@ -29,17 +30,15 @@ class TestLoanInterestAccrual(unittest.TestCase):
 		self.applicant = frappe.db.get_value("Customer", {'name': '_Test Loan Customer'}, 'name')
 
 	def test_loan_interest_accural(self):
-		pledges = []
-		pledges.append({
+		pledge = [{
 			"loan_security": "Test Security 1",
-			"qty": 4000.00,
-			"haircut": 50,
-			"loan_security_price": 500.00
-		})
+			"qty": 4000.00
+		}]
 
-		loan_security_pledge = create_loan_security_pledge(self.applicant, pledges)
+		loan_application = create_loan_application('_Test Company', self.applicant, 'Demand Loan', pledge)
+		create_pledge(loan_application)
 
-		loan = create_demand_loan(self.applicant, "Demand Loan", loan_security_pledge.name,
+		loan = create_demand_loan(self.applicant, "Demand Loan", loan_application,
 			posting_date=get_first_day(nowdate()))
 
 		loan.submit()

--- a/erpnext/loan_management/doctype/loan_security_pledge/loan_security_pledge.json
+++ b/erpnext/loan_management/doctype/loan_security_pledge/loan_security_pledge.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "autoname": "LS-.{applicant}.-.#####",
  "creation": "2019-08-29 18:48:51.371674",
  "doctype": "DocType",
@@ -6,10 +7,10 @@
  "engine": "InnoDB",
  "field_order": [
   "loan_details_section",
-  "loan_application",
-  "loan",
   "applicant_type",
   "applicant",
+  "loan",
+  "loan_application",
   "column_break_3",
   "company",
   "pledge_time",
@@ -55,15 +56,13 @@
    "fieldname": "loan",
    "fieldtype": "Link",
    "label": "Loan",
-   "options": "Loan",
-   "read_only": 1
+   "options": "Loan"
   },
   {
    "fieldname": "loan_application",
    "fieldtype": "Link",
    "label": "Loan Application",
-   "options": "Loan Application",
-   "read_only": 1
+   "options": "Loan Application"
   },
   {
    "fieldname": "total_security_value",
@@ -133,7 +132,8 @@
   }
  ],
  "is_submittable": 1,
- "modified": "2019-10-10 13:22:53.297519",
+ "links": [],
+ "modified": "2020-07-02 23:38:24.002382",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Security Pledge",


### PR DESCRIPTION
Removed Loan Security from field from Loan Doc which was there to add initial loan security pledges as it was causing unnecessary condition