### PR TITLE
fix: Skip Progress and Completed by fields on Task Duplication

### DIFF
--- a/erpnext/projects/doctype/task/task.json
+++ b/erpnext/projects/doctype/task/task.json
@@ -183,7 +183,8 @@
   {
    "fieldname": "progress",
    "fieldtype": "Percent",
-   "label": "% Progress"
+   "label": "% Progress",
+   "no_copy": 1
   },
   {
    "default": "0",
@@ -356,6 +357,7 @@
    "fieldname": "completed_by",
    "fieldtype": "Link",
    "label": "Completed By",
+   "no_copy": 1,
    "options": "User"
   }
  ],
@@ -364,7 +366,7 @@
  "is_tree": 1,
  "links": [],
  "max_attachments": 5,
- "modified": "2020-03-18 18:08:44.153211",
+ "modified": "2020-07-03 12:36:04.960457",
  "modified_by": "Administrator",
  "module": "Projects",
  "name": "Task",


### PR DESCRIPTION
**Issue:**
- % Progress was copied over on Task duplication, due to which, every new task on save was set to completed if the previous was completed

**Fix**
- Dont copy **%Progress** and **Completed By** on duplication