### PR TITLE
Bug While fetching Conversation Factor

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -309,8 +309,7 @@ def get_basic_details(args, item, overwrite_warehouse=True):
 	if item.stock_uom == args.uom:
 		out.conversion_factor = 1.0
 	else:
-		out.conversion_factor = args.conversion_factor or \
-			get_conversion_factor(item.name, args.uom).get("conversion_factor")
+		out.conversion_factor = get_conversion_factor(item.name, args.uom).get("conversion_factor")
 
 	args.conversion_factor = out.conversion_factor
 	out.stock_qty = out.qty * out.conversion_factor


### PR DESCRIPTION
Bug:
In Sales Order's Item Table
we select abc item with conversation factor 20
so it will fetch correct data for conversation factor
now suppose you reselect another item in same row from abc to xyz with conversation factor 30
still it will fetch conversation factor to 20 only
because this api pass current conversation factor and backend will send it back without checking for new item