### PR TITLE
fix: Quality Feedback and Template (minor)

### DIFF
--- a/erpnext/quality_management/doctype/quality_feedback/quality_feedback.js
+++ b/erpnext/quality_management/doctype/quality_feedback/quality_feedback.js
@@ -5,21 +5,28 @@ frappe.ui.form.on('Quality Feedback', {
 	refresh: function(frm) {
 		frm.set_value("date", frappe.datetime.get_today());
 	},
-	template: function(frm){
-		frappe.call({
-			"method": "frappe.client.get",
-			args: {
-				doctype: "Quality Feedback Template",
-				name: frm.doc.template
-			},
-			callback: function(data){
-				frm.fields_dict.parameters.grid.remove_all();
-				for (var i in data.message.parameters){
-					frm.add_child("parameters");
-					frm.fields_dict.parameters.get_value()[i].parameter = data.message.parameters[i].parameter;
+
+	template: function(frm) {
+		if (frm.doc.template) {
+			frappe.call({
+				"method": "frappe.client.get",
+				args: {
+					doctype: "Quality Feedback Template",
+					name: frm.doc.template
+				},
+				callback: function(data) {
+					if (data && data.message) {
+						frm.fields_dict.parameters.grid.remove_all();
+
+						// fetch parameters from template and autofill
+						for (let template_parameter of data.message.parameters) {
+							let row = frm.add_child("parameters");
+							row.parameter = template_parameter.parameter;
+						}
+						frm.refresh();
+					}
 				}
-				frm.refresh();
-			}
-		});
+			});
+		}
 	}
 });

--- a/erpnext/quality_management/doctype/quality_feedback/quality_feedback.json
+++ b/erpnext/quality_management/doctype/quality_feedback/quality_feedback.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "autoname": "format:FDBK-{#####}",
  "creation": "2019-05-26 21:23:05.308379",
  "doctype": "DocType",
@@ -53,12 +54,13 @@
   {
    "fieldname": "document_name",
    "fieldtype": "Dynamic Link",
-   "label": "Name",
+   "label": "Feedback By",
    "options": "document_type",
    "reqd": 1
   }
  ],
- "modified": "2019-05-28 15:16:01.161662",
+ "links": [],
+ "modified": "2020-07-03 15:50:58.589302",
  "modified_by": "Administrator",
  "module": "Quality Management",
  "name": "Quality Feedback",

--- a/erpnext/quality_management/doctype/quality_feedback_template/quality_feedback_template.json
+++ b/erpnext/quality_management/doctype/quality_feedback_template/quality_feedback_template.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "autoname": "format:TMPL-{template}",
  "creation": "2019-05-26 21:17:24.283061",
  "doctype": "DocType",
@@ -30,10 +31,12 @@
    "fieldname": "parameters",
    "fieldtype": "Table",
    "label": "Parameters",
-   "options": "Quality Feedback Template Parameter"
+   "options": "Quality Feedback Template Parameter",
+   "reqd": 1
   }
  ],
- "modified": "2019-05-26 21:48:47.770610",
+ "links": [],
+ "modified": "2020-07-03 16:06:03.749415",
  "modified_by": "Administrator",
  "module": "Quality Management",
  "name": "Quality Feedback Template",


### PR DESCRIPTION
**Issue:**
![image](https://user-images.githubusercontent.com/25857446/86463254-c515ef00-bd4a-11ea-9980-a8b3bf9c92f9.png)

**Fixes:**
- Check if template field is populated before fetching template to populate table
- Minor code cleanup
- Change 'Name' to 'Feedback By' in Quality Feedback
- Make Parameter table mandatory in Quality Feedback Template. Don't allow saving empty templates