### PR TITLE
fix: Check for Company before trying to fetch party details

### DIFF
--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -388,7 +388,7 @@ def set_taxes(party, party_type, posting_date, company, customer_group=None, sup
 	from erpnext.accounts.doctype.tax_rule.tax_rule import get_tax_template, get_party_details
 	args = {
 		party_type.lower(): party,
-		"company":			company
+		"company": company
 	}
 
 	if tax_category:

--- a/erpnext/public/js/utils/party.js
+++ b/erpnext/public/js/utils/party.js
@@ -4,7 +4,7 @@
 frappe.provide("erpnext.utils");
 
 erpnext.utils.get_party_details = function(frm, method, args, callback) {
-	if(!method) {
+	if (!method) {
 		method = "erpnext.accounts.party.get_party_details";
 	}
 
@@ -22,12 +22,12 @@ erpnext.utils.get_party_details = function(frm, method, args, callback) {
 		}
 	}
 
-	if(!args) {
-		if((frm.doctype != "Purchase Order" && frm.doc.customer)
+	if (!args) {
+		if ((frm.doctype != "Purchase Order" && frm.doc.customer)
 			|| (frm.doc.party_name && in_list(['Quotation', 'Opportunity'], frm.doc.doctype))) {
 
 			let party_type = "Customer";
-			if(frm.doc.quotation_to && frm.doc.quotation_to === "Lead") {
+			if (frm.doc.quotation_to && frm.doc.quotation_to === "Lead") {
 				party_type = "Lead";
 			}
 
@@ -36,7 +36,7 @@ erpnext.utils.get_party_details = function(frm, method, args, callback) {
 				party_type: party_type,
 				price_list: frm.doc.selling_price_list
 			};
-		} else if(frm.doc.supplier) {
+		} else if (frm.doc.supplier) {
 			args = {
 				party: frm.doc.supplier,
 				party_type: "Supplier",
@@ -78,11 +78,15 @@ erpnext.utils.get_party_details = function(frm, method, args, callback) {
 			args.posting_date = frm.doc.posting_date || frm.doc.transaction_date;
 		}
 	}
-	if(!args || !args.party) return;
+	if (!args || !args.party) return;
 
-	if(frappe.meta.get_docfield(frm.doc.doctype, "taxes")) {
-		if(!erpnext.utils.validate_mandatory(frm, "Posting/Transaction Date",
+	if (frappe.meta.get_docfield(frm.doc.doctype, "taxes")) {
+		if (!erpnext.utils.validate_mandatory(frm, "Posting / Transaction Date",
 			args.posting_date, args.party_type=="Customer" ? "customer": "supplier")) return;
+	}
+
+	if (!erpnext.utils.validate_mandatory(frm, "Company", frm.doc.company, args.party_type=="Customer" ? "customer": "supplier")) {
+		return;
 	}
 
 	args.currency = frm.doc.currency;
@@ -92,14 +96,14 @@ erpnext.utils.get_party_details = function(frm, method, args, callback) {
 		method: method,
 		args: args,
 		callback: function(r) {
-			if(r.message) {
+			if (r.message) {
 				frm.supplier_tds = r.message.supplier_tds;
 				frm.updating_party_details = true;
 				frappe.run_serially([
 					() => frm.set_value(r.message),
 					() => {
 						frm.updating_party_details = false;
-						if(callback) callback();
+						if (callback) callback();
 						frm.refresh();
 						erpnext.utils.add_item(frm);
 					}
@@ -110,9 +114,9 @@ erpnext.utils.get_party_details = function(frm, method, args, callback) {
 }
 
 erpnext.utils.add_item = function(frm) {
-	if(frm.is_new()) {
+	if (frm.is_new()) {
 		var prev_route = frappe.get_prev_route();
-		if(prev_route[1]==='Item' && !(frm.doc.items && frm.doc.items.length)) {
+		if (prev_route[1]==='Item' && !(frm.doc.items && frm.doc.items.length)) {
 			// add row
 			var item = frm.add_child('items');
 			frm.refresh_field('items');
@@ -124,23 +128,23 @@ erpnext.utils.add_item = function(frm) {
 }
 
 erpnext.utils.get_address_display = function(frm, address_field, display_field, is_your_company_address) {
-	if(frm.updating_party_details) return;
+	if (frm.updating_party_details) return;
 
-	if(!address_field) {
-		if(frm.doctype != "Purchase Order" && frm.doc.customer) {
+	if (!address_field) {
+		if (frm.doctype != "Purchase Order" && frm.doc.customer) {
 			address_field = "customer_address";
-		} else if(frm.doc.supplier) {
+		} else if (frm.doc.supplier) {
 			address_field = "supplier_address";
 		} else return;
 	}
 
-	if(!display_field) display_field = "address_display";
-	if(frm.doc[address_field]) {
+	if (!display_field) display_field = "address_display";
+	if (frm.doc[address_field]) {
 		frappe.call({
 			method: "frappe.contacts.doctype.address.address.get_address_display",
 			args: {"address_dict": frm.doc[address_field] },
 			callback: function(r) {
-				if(r.message) {
+				if (r.message) {
 					frm.set_value(display_field, r.message)
 				}
 			}
@@ -151,15 +155,15 @@ erpnext.utils.get_address_display = function(frm, address_field, display_field, 
 };
 
 erpnext.utils.set_taxes_from_address = function(frm, triggered_from_field, billing_address_field, shipping_address_field) {
-	if(frm.updating_party_details) return;
+	if (frm.updating_party_details) return;
 
-	if(frappe.meta.get_docfield(frm.doc.doctype, "taxes")) {
-		if(!erpnext.utils.validate_mandatory(frm, "Lead/Customer/Supplier",
+	if (frappe.meta.get_docfield(frm.doc.doctype, "taxes")) {
+		if (!erpnext.utils.validate_mandatory(frm, "Lead / Customer / Supplier",
 			frm.doc.customer || frm.doc.supplier || frm.doc.lead || frm.doc.party_name, triggered_from_field)) {
 			return;
 		}
 
-		if(!erpnext.utils.validate_mandatory(frm, "Posting/Transaction Date",
+		if (!erpnext.utils.validate_mandatory(frm, "Posting / Transaction Date",
 			frm.doc.posting_date || frm.doc.transaction_date, triggered_from_field)) {
 			return;
 		}
@@ -175,8 +179,8 @@ erpnext.utils.set_taxes_from_address = function(frm, triggered_from_field, billi
 			"shipping_address": frm.doc[shipping_address_field]
 		},
 		callback: function(r) {
-			if(!r.exc){
-				if(frm.doc.tax_category != r.message) {
+			if (!r.exc){
+				if (frm.doc.tax_category != r.message) {
 					frm.set_value("tax_category", r.message);
 				} else {
 					erpnext.utils.set_taxes(frm, triggered_from_field);
@@ -187,13 +191,17 @@ erpnext.utils.set_taxes_from_address = function(frm, triggered_from_field, billi
 };
 
 erpnext.utils.set_taxes = function(frm, triggered_from_field) {
-	if(frappe.meta.get_docfield(frm.doc.doctype, "taxes")) {
-		if(!erpnext.utils.validate_mandatory(frm, "Lead/Customer/Supplier",
+	if (frappe.meta.get_docfield(frm.doc.doctype, "taxes")) {
+		if (!erpnext.utils.validate_mandatory(frm, "Company", frm.doc.company, triggered_from_field)) {
+			return;
+		}
+
+		if (!erpnext.utils.validate_mandatory(frm, "Lead / Customer / Supplier",
 			frm.doc.customer || frm.doc.supplier || frm.doc.lead || frm.doc.party_name, triggered_from_field)) {
 			return;
 		}
 
-		if(!erpnext.utils.validate_mandatory(frm, "Posting/Transaction Date",
+		if (!erpnext.utils.validate_mandatory(frm, "Posting / Transaction Date",
 			frm.doc.posting_date || frm.doc.transaction_date, triggered_from_field)) {
 			return;
 		}
@@ -230,7 +238,7 @@ erpnext.utils.set_taxes = function(frm, triggered_from_field) {
 			"shipping_address": frm.doc.shipping_address_name
 		},
 		callback: function(r) {
-			if(r.message){
+			if (r.message){
 				frm.set_value("taxes_and_charges", r.message)
 			}
 		}
@@ -238,14 +246,14 @@ erpnext.utils.set_taxes = function(frm, triggered_from_field) {
 };
 
 erpnext.utils.get_contact_details = function(frm) {
-	if(frm.updating_party_details) return;
+	if (frm.updating_party_details) return;
 
-	if(frm.doc["contact_person"]) {
+	if (frm.doc["contact_person"]) {
 		frappe.call({
 			method: "frappe.contacts.doctype.contact.contact.get_contact_details",
 			args: {contact: frm.doc.contact_person },
 			callback: function(r) {
-				if(r.message)
+				if (r.message)
 					frm.set_value(r.message);
 			}
 		})
@@ -253,10 +261,10 @@ erpnext.utils.get_contact_details = function(frm) {
 }
 
 erpnext.utils.validate_mandatory = function(frm, label, value, trigger_on) {
-	if(!value) {
+	if (!value) {
 		frm.doc[trigger_on] = "";
 		refresh_field(trigger_on);
-		frappe.msgprint(__("Please enter {0} first", [label]));
+		frappe.throw({message:__("Please enter {0} first", [label]), title:__("Mandatory")});
 		return false;
 	}
 	return true;
@@ -271,12 +279,12 @@ erpnext.utils.get_shipping_address = function(frm, callback){
 				address: frm.doc.shipping_address
 			},
 			callback: function(r){
-				if(r.message){
+				if (r.message){
 					frm.set_value("shipping_address", r.message[0]) //Address title or name
 					frm.set_value("shipping_address_display", r.message[1]) //Address to be displayed on the page
 				}
 
-				if(callback){
+				if (callback){
 					return callback();
 				}
 			}


### PR DESCRIPTION
**Issue:**
- On a document without company (Sales or Purchase)
  ![_error](https://user-images.githubusercontent.com/25857446/86486454-f0afce00-bd78-11ea-91c6-fa9f6ee1568c.png)

**Fix:**
- Company check in `get_party_details`
   ![Screenshot 2020-07-03 at 10 08 15 PM](https://user-images.githubusercontent.com/25857446/86486571-3d93a480-bd79-11ea-8c87-6fcc9695d660.png)
- Use frappe.throw instead of msgprint
- Style consistency fixes
