### PR TITLE
fix: Consider company fiscal year for getting balance

### DIFF
--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -133,7 +133,7 @@ def get_balance_on(account=None, date=None, party_type=None, party=None, company
 		acc = frappe.get_doc("Account", account)
 
 	try:
-		year_start_date = get_fiscal_year(date, verbose=0)[1]
+		year_start_date = get_fiscal_year(date, company=company, verbose=0)[1]
 	except FiscalYearError:
 		if getdate(date) > getdate(nowdate()):
 			# if fiscal year not found and the date is greater than today
@@ -787,10 +787,10 @@ def get_children(doctype, parent, company, is_root=False):
 		company_currency = frappe.get_cached_value('Company',  company,  "default_currency")
 		for each in acc:
 			each["company_currency"] = company_currency
-			each["balance"] = flt(get_balance_on(each.get("value"), in_account_currency=False))
+			each["balance"] = flt(get_balance_on(each.get("value"), in_account_currency=False, company=company))
 
 			if each.account_currency != company_currency:
-				each["balance_in_account_currency"] = flt(get_balance_on(each.get("value")))
+				each["balance_in_account_currency"] = flt(get_balance_on(each.get("value"), company=company))
 
 	return acc
 


### PR DESCRIPTION
Suppose in a Multi-Company setup there are two companies one based in India and one based in USA.

Now fiscal years for both these companies will obviously be different, one will be from Apr-March and one will be from Jan-Dec

While getting balances it gets the default fiscal year based on current date for both the companies either in India or USA, so if you view the Profit and Loss Report, it will show you the correct amount based on the fiscal year selected but the if you view the balance in COA if will consider the default fiscal year and the balance visible there may be different

Solution: First give preference to Company Fiscal year and then default fiscal year
