### PR TITLE
feat(selling): added sales target to customer

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -19,6 +19,7 @@ from erpnext.assets.doctype.asset.depreciation \
 from erpnext.stock.doctype.batch.batch import set_batch_nos
 from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos, get_delivery_note_serial_no
 from erpnext.setup.doctype.company.company import update_company_current_month_sales
+from erpnext.selling.doctype.customer.customer import update_customer_current_month_sales
 from erpnext.accounts.general_ledger import get_round_off_account_and_cost_center
 from erpnext.accounts.doctype.loyalty_program.loyalty_program import \
 	get_loyalty_program_details_with_points, get_loyalty_details, validate_loyalty_points
@@ -196,6 +197,7 @@ class SalesInvoice(SellingController):
 
 		if frappe.db.get_single_value('Selling Settings', 'sales_update_frequency') == "Each Transaction":
 			update_company_current_month_sales(self.company)
+			update_customer_current_month_sales(self.customer)
 			self.update_project()
 		update_linked_doc(self.doctype, self.name, self.inter_company_invoice_reference)
 
@@ -264,6 +266,7 @@ class SalesInvoice(SellingController):
 
 		if frappe.db.get_single_value('Selling Settings', 'sales_update_frequency') == "Each Transaction":
 			update_company_current_month_sales(self.company)
+			update_customer_current_month_sales(self.customer)
 			self.update_project()
 		if not self.is_return and self.loyalty_program:
 			self.delete_loyalty_point_entry()

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -332,6 +332,9 @@ scheduler_events = {
 		"erpnext.loan_management.doctype.loan_security_shortfall.loan_security_shortfall.create_process_loan_security_shortfall",
 		"erpnext.loan_management.doctype.loan_interest_accrual.loan_interest_accrual.process_loan_interest_accrual_for_term_loans"
 	],
+	"monthly": [
+		"erpnext.selling.doctype.customer.customer.set_total_monthly_sales_to_zero"
+	],
 	"monthly_long": [
 		"erpnext.accounts.deferred_revenue.process_deferred_accounting",
 		"erpnext.hr.utils.allocate_earned_leaves",

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -707,3 +707,6 @@ erpnext.patches.v13_0.move_doctype_reports_and_notification_from_hr_to_payroll #
 erpnext.patches.v13_0.move_payroll_setting_separately_from_hr_settings #22-06-2020
 erpnext.patches.v13_0.check_is_income_tax_component #22-06-2020
 erpnext.patches.v12_0.add_taxjar_integration_field
+erpnext.patches.v12_0.update_sales_taxes_and_charges_template
+erpnext.patches.v13_0.update_customer_total_sales
+erpnext.patches.v13_0.setup_remove_assignment_on_task

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -707,6 +707,4 @@ erpnext.patches.v13_0.move_doctype_reports_and_notification_from_hr_to_payroll #
 erpnext.patches.v13_0.move_payroll_setting_separately_from_hr_settings #22-06-2020
 erpnext.patches.v13_0.check_is_income_tax_component #22-06-2020
 erpnext.patches.v12_0.add_taxjar_integration_field
-erpnext.patches.v12_0.update_sales_taxes_and_charges_template
 erpnext.patches.v13_0.update_customer_total_sales
-erpnext.patches.v13_0.setup_remove_assignment_on_task

--- a/erpnext/patches/v13_0/update_customer_total_sales.py
+++ b/erpnext/patches/v13_0/update_customer_total_sales.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2017, Frappe and Contributors
+# License: GNU General Public License v3. See license.txt
+
+from __future__ import unicode_literals
+import frappe
+from erpnext.selling.doctype.customer.customer import update_customer_current_month_sales
+
+def execute():
+	'''Update customer monthly sales history based on sales invoices'''
+	frappe.reload_doctype("Customer")
+	customers = [d['name'] for d in frappe.get_list("Customer")]
+
+	for customer in customers:
+		update_customer_current_month_sales(customer)

--- a/erpnext/selling/doctype/customer/customer.json
+++ b/erpnext/selling/doctype/customer/customer.json
@@ -51,6 +51,14 @@
   "primary_address",
   "default_receivable_accounts",
   "accounts",
+  "sales_target_sb",
+  "monthly_sales_target",
+  "column_break_41",
+  "total_monthly_sales",
+  "delivery_window",
+  "delivery_start_time",
+  "column_break_42",
+  "delivery_end_time",
   "credit_limit_section",
   "payment_terms",
   "credit_limits",
@@ -479,13 +487,40 @@
    "fieldname": "dn_required",
    "fieldtype": "Check",
    "label": "Allow Sales Invoice Creation Without Delivery Note"
+  },
+  {
+   "fieldname": "column_break_42",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "monthly_sales_target",
+   "fieldtype": "Currency",
+   "label": "Monthly Sales Target",
+   "options": "default_currency"
+  },
+  {
+   "fieldname": "total_monthly_sales",
+   "fieldtype": "Currency",
+   "label": "Total Monthly Sales",
+   "options": "default_currency",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_41",
+   "fieldtype": "Column Break"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "sales_target_sb",
+   "fieldtype": "Section Break",
+   "label": "Sales Target"
   }
  ],
  "icon": "fa fa-user",
  "idx": 363,
  "image_field": "image",
  "links": [],
- "modified": "2020-03-17 11:03:42.706907",
+ "modified": "2020-06-30 22:24:37.691545",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Customer",


### PR DESCRIPTION
added sales target to the customer and displayed Monthly Sales Target and Total Monthly Sales as progress in Customer Dashboard

Sales Target Fields
![sales_target](https://user-images.githubusercontent.com/53251406/86563165-874edb80-bf81-11ea-9f76-f4eee75ee02d.png)


Sales Target Dashboard
![sales_target_dashboard](https://user-images.githubusercontent.com/53251406/86563128-769e6580-bf81-11ea-841d-1e6bf7a85dcf.png)