### PR TITLE
fix: Exploded Item Rate in BOM

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -494,7 +494,7 @@ class BOM(WebsiteGenerator):
 					'image'			: d.image,
 					'stock_uom'		: d.stock_uom,
 					'stock_qty'		: flt(d.stock_qty),
-					'rate'			: d.base_rate,
+					'rate'			: flt(d.base_rate) / flt(d.conversion_factor),
 					'include_item_in_manufacturing': d.include_item_in_manufacturing
 				}))
 


### PR DESCRIPTION
**Issue:**
- Consider a BOM for Item **Shirt** with raw material **Linen Cloth**
- Stock UOM for raw material **Linen Cloth** is Meter and Purchase Rate per meter is Rs.1500
- In the BOM Items table, set UOM to Millimetre for raw material **Linen Cloth**, so the cost per millimetre will be Rs.1.5 (conversion factor 0.001)
- However exploded items are in Stock UOM only, so the system must assign a rate of Rs.1500 to the raw material in the exploded items table. But, it assigns the same rate as the Multi UOM item (Rs.1.5)

**Fix:**
- Set rate in exploded items always as per stock uom