### PR TITLE
fix: Payment reco error in multi-company setup

### DIFF
--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
@@ -101,10 +101,10 @@ class PaymentReconciliation(Document):
 			Having
 				amount > 0
 		""".format(
-			doc=voucher_type, 
-			dr_or_cr=dr_or_cr, 
-			reconciled_dr_or_cr=reconciled_dr_or_cr, 
-			party_type_field=frappe.scrub(self.party_type)), 
+			doc=voucher_type,
+			dr_or_cr=dr_or_cr,
+			reconciled_dr_or_cr=reconciled_dr_or_cr,
+			party_type_field=frappe.scrub(self.party_type)),
 			{
 				'party': self.party,
 				'party_type': self.party_type,
@@ -170,7 +170,7 @@ class PaymentReconciliation(Document):
 			reconcile_against_document(lst)
 
 		if dr_or_cr_notes:
-			reconcile_dr_cr_note(dr_or_cr_notes)
+			reconcile_dr_cr_note(dr_or_cr_notes, self.receivable_payable_account)
 
 		msgprint(_("Successfully Reconciled"))
 		self.get_unreconciled_entries()
@@ -261,7 +261,8 @@ class PaymentReconciliation(Document):
 
 		return cond
 
-def reconcile_dr_cr_note(dr_cr_notes):
+def reconcile_dr_cr_note(dr_cr_notes, receivable_payable_account):
+	company = frappe.db.get_value('Account', receivable_payable_account, 'company')
 	for d in dr_cr_notes:
 		voucher_type = ('Credit Note'
 			if d.voucher_type == 'Sales Invoice' else 'Debit Note')
@@ -273,6 +274,7 @@ def reconcile_dr_cr_note(dr_cr_notes):
 			"doctype": "Journal Entry",
 			"voucher_type": voucher_type,
 			"posting_date": today(),
+			"company": company,
 			"accounts": [
 				{
 					'account': d.account,

--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
@@ -170,7 +170,7 @@ class PaymentReconciliation(Document):
 			reconcile_against_document(lst)
 
 		if dr_or_cr_notes:
-			reconcile_dr_cr_note(dr_or_cr_notes, self.receivable_payable_account)
+			reconcile_dr_cr_note(dr_or_cr_notes, self.company)
 
 		msgprint(_("Successfully Reconciled"))
 		self.get_unreconciled_entries()
@@ -261,8 +261,7 @@ class PaymentReconciliation(Document):
 
 		return cond
 
-def reconcile_dr_cr_note(dr_cr_notes, receivable_payable_account):
-	company = frappe.db.get_value('Account', receivable_payable_account, 'company')
+def reconcile_dr_cr_note(dr_cr_notes, company):
 	for d in dr_cr_notes:
 		voucher_type = ('Credit Note'
 			if d.voucher_type == 'Sales Invoice' else 'Debit Note')


### PR DESCRIPTION
<img width="1218" alt="Screenshot 2020-07-07 at 2 10 10 PM" src="https://user-images.githubusercontent.com/42651287/86751508-555e7780-c05c-11ea-996a-54052fb98d2d.png">

While doing payment reconciliation in a multi-company  setup for any other company than default company the above error is encountered since the company in JV created to reconcile is always the default.