### PR TITLE
fix: Creating Lead from email

### DIFF
--- a/erpnext/crm/doctype/lead/lead.py
+++ b/erpnext/crm/doctype/lead/lead.py
@@ -114,10 +114,12 @@ class Lead(SellingController):
 	def set_lead_name(self):
 		if not self.lead_name:
 			# Check for leads being created through data import
-			if not self.company_name and not self.flags.ignore_mandatory:
+			if not self.company_name and not self.email_id and not self.flags.ignore_mandatory:
 				frappe.throw(_("A Lead requires either a person's name or an organization's name"))
-
-			self.lead_name = self.company_name
+			elif self.company_name:
+				self.lead_name = self.company_name
+			else:
+				self.lead_name = self.email_id.split("@")[0]
 
 	def set_title(self):
 		if self.organization_lead:


### PR DESCRIPTION
**Issue -** Lead is not creating from email since it didn't found either lead_name or company name.

**Fix -** Added check to extract a part of the email for lead_name. If lead_name or company not found.