### PR TITLE
fix: Due to decimal issue make purchase receipt button not showing in the purchase order

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -123,14 +123,14 @@ erpnext.buying.PurchaseOrderController = erpnext.buying.BuyingController.extend(
 			}
 			if(doc.status != "Closed") {
 				if (doc.status != "On Hold") {
-					if(flt(doc.per_received, 2) < 100 && allow_receipt) {
+					if(flt(doc.per_received) < 100 && allow_receipt) {
 						cur_frm.add_custom_button(__('Receipt'), this.make_purchase_receipt, __('Create'));
 						if(doc.is_subcontracted==="Yes" && me.has_unsupplied_items()) {
 							cur_frm.add_custom_button(__('Material to Supplier'),
 								function() { me.make_stock_entry(); }, __("Transfer"));
 						}
 					}
-					if(flt(doc.per_billed, 2) < 100)
+					if(flt(doc.per_billed) < 100)
 						cur_frm.add_custom_button(__('Invoice'),
 							this.make_purchase_invoice, __('Create'));
 


### PR DESCRIPTION
**Issue**

User not able to view purchase receipt / purchase invoice button from the dropdown

<img width="672" alt="Screenshot 2020-07-09 at 6 16 36 PM" src="https://user-images.githubusercontent.com/8780500/87041992-ab741c00-c210-11ea-8ef4-ddebac2b470c.png">

After debug the issue came to know that system rounding the per_received to 100 and therefore the Purchase Receipt was not displaying 
<img width="266" alt="Screenshot 2020-07-09 at 6 12 40 PM" src="https://user-images.githubusercontent.com/8780500/87042037-b9c23800-c210-11ea-8444-8bd27c3531ca.png">


**After Fix**

<img width="520" alt="Screenshot 2020-07-09 at 6 12 27 PM" src="https://user-images.githubusercontent.com/8780500/87042134-dc545100-c210-11ea-9786-307a927e4350.png">
