### PR TITLE
fix: incorrect delivered qty in Supplier-Wise Sales Analytics

### DIFF
--- a/erpnext/stock/report/supplier_wise_sales_analytics/supplier_wise_sales_analytics.py
+++ b/erpnext/stock/report/supplier_wise_sales_analytics/supplier_wise_sales_analytics.py
@@ -21,7 +21,7 @@ def execute(filters=None):
 			for cd in consumed_details.get(item_code):
 
 				if (cd.voucher_no not in material_transfer_vouchers):
-					if cd.voucher_type=="Delivery Note":
+					if cd.voucher_type in ["Delivery Note", "Sales Invoice"]:
 						delivered_qty += abs(flt(cd.actual_qty))
 						delivered_amount += abs(flt(cd.stock_value_difference))
 					elif cd.voucher_type!="Delivery Note":


### PR DESCRIPTION
**Issue**
Sales Invoice with update stock enabled was not considered

<img width="1223" alt="Screenshot 2020-07-09 at 6 40 03 PM" src="https://user-images.githubusercontent.com/8780500/87044254-e9bf0a80-c213-11ea-9664-da8cc54c4e1c.png">



**After Fix**
<img width="1282" alt="Screenshot 2020-07-09 at 6 39 37 PM" src="https://user-images.githubusercontent.com/8780500/87044244-e62b8380-c213-11ea-9f00-880662ee43b8.png">
