### PR TITLE
fix: Pricing Rule breaks if no item_code

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/utils.py
+++ b/erpnext/accounts/doctype/pricing_rule/utils.py
@@ -319,7 +319,9 @@ def apply_internal_priority(pricing_rules, field_set, args):
 	filtered_rules = []
 	for field in field_set:
 		if args.get(field):
-			filtered_rules = filter(lambda x: x[field]==args[field], pricing_rules)
+			# filter function always returns a filter object even if empty
+			# list conversion is necessary to check for an empty result
+			filtered_rules = list(filter(lambda x: x.get(field)==args.get(field), pricing_rules))
 			if filtered_rules: break
 
 	return filtered_rules or pricing_rules


### PR DESCRIPTION
**Issue:**
- Assume an Item _Box_ with Item Group **_Home Items_** (parent group _All Item Groups_)
- Create selling pricing Rule for a particular customer on Item Group **_Home Items_** 
- Create another selling pricing Rule for the same customer on Item Group **_All Item Groups_**
- Use any Item belonging to  Item Group **_Home Items_** in Delivery Note or Sales Invoice:
  ```filtered_rules = filter(lambda x: x[field]==args[field], pricing_rules)```
   ```KeyError: 'item_code'```
- Problem here is since we have two pricing rules of equal importance (difference is Item group, one is parent of the other), it tries to set a rule via **`apply_internal_priority`**
- Here `item_code` did not exist in the pricing rule (since it was based on item group), hence **`x['item_code']`** broke in the filter function

**Fix:**
- Use `get()` instead of using keys as the keys may or may not exist
- list() wrapping filter() function as filter function always returns a filter object even if empty, checking this object for availability of results will **always** return True