### PR TITLE
fix: Add project filter in parent task field

### DIFF
--- a/erpnext/projects/doctype/task/task.js
+++ b/erpnext/projects/doctype/task/task.js
@@ -29,10 +29,20 @@ frappe.ui.form.on("Task", {
 				filters: filters
 			};
 		})
+
+		frm.set_query("parent_task", function () {
+			let filters = {
+				"is_group": 1
+			};
+			if (frm.doc.project) filters["project"] = frm.doc.project;
+			return {
+				filters: filters
+			}
+		});
 	},
 
 	refresh: function (frm) {
-		frm.set_query("parent_task", { "is_group": 1 });
+		// frm.set_query("parent_task", { "is_group": 1 });
 	},
 
 	is_group: function (frm) {

--- a/erpnext/projects/doctype/task/task.js
+++ b/erpnext/projects/doctype/task/task.js
@@ -41,10 +41,6 @@ frappe.ui.form.on("Task", {
 		});
 	},
 
-	refresh: function (frm) {
-		// frm.set_query("parent_task", { "is_group": 1 });
-	},
-
 	is_group: function (frm) {
 		frappe.call({
 			method: "erpnext.projects.doctype.task.task.check_if_child_exists",


### PR DESCRIPTION
If the project field is not empty the option for parent task will consider project also while filtering.