### PR TITLE
fix: Quotation list view blank if quotation_to field not set as a standard filter

### DIFF
--- a/erpnext/selling/doctype/quotation/quotation_list.js
+++ b/erpnext/selling/doctype/quotation/quotation_list.js
@@ -3,7 +3,7 @@ frappe.listview_settings['Quotation'] = {
 		"company", "currency", 'valid_till'],
 
 	onload: function(listview) {
-		if(listview.page.fields_dict.quotation_to){
+		if (listview.page.fields_dict.quotation_to) {
 			listview.page.fields_dict.quotation_to.get_query = function() {
 				return {
 					"filters": {

--- a/erpnext/selling/doctype/quotation/quotation_list.js
+++ b/erpnext/selling/doctype/quotation/quotation_list.js
@@ -3,13 +3,15 @@ frappe.listview_settings['Quotation'] = {
 		"company", "currency", 'valid_till'],
 
 	onload: function(listview) {
-		listview.page.fields_dict.quotation_to.get_query = function() {
-			return {
-				"filters": {
-					"name": ["in", ["Customer", "Lead"]],
-				}
+		if(listview.page.fields_dict.quotation_to){
+			listview.page.fields_dict.quotation_to.get_query = function() {
+				return {
+					"filters": {
+						"name": ["in", ["Customer", "Lead"]],
+					}
+				};
 			};
-		};
+		}
 	},
 
 	get_indicator: function(doc) {


### PR DESCRIPTION
…andard filter

fix: Quotation list view  blank if quotation_to field not set as a standard filter

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
