### PR TITLE
fix: Dont overwrite default warehouse in Material Request

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -180,9 +180,8 @@ frappe.ui.form.on('Material Request', {
 		});
 	},
 
-	get_item_data: function(frm, item) {
+	get_item_data: function(frm, item, overwrite_warehouse=false) {
 		if (item && !item.item_code) { return; }
-
 		frm.call({
 			method: "erpnext.stock.get_item_details.get_item_details",
 			child: item,
@@ -203,7 +202,8 @@ frappe.ui.form.on('Material Request', {
 					plc_conversion_rate: 1,
 					rate: item.rate,
 					conversion_factor: item.conversion_factor
-				}
+				},
+				overwrite_warehouse: overwrite_warehouse
 			},
 			callback: function(r) {
 				const d = item;
@@ -354,29 +354,29 @@ frappe.ui.form.on("Material Request Item", {
 		}
 
 		const item = locals[doctype][name];
-		frm.events.get_item_data(frm, item);
+		frm.events.get_item_data(frm, item, false);
 	},
 
 	from_warehouse: function(frm, doctype, name) {
 		const item = locals[doctype][name];
-		frm.events.get_item_data(frm, item);
+		frm.events.get_item_data(frm, item, false);
 	},
 
 	warehouse: function(frm, doctype, name) {
 		const item = locals[doctype][name];
-		frm.events.get_item_data(frm, item);
+		frm.events.get_item_data(frm, item, false);
 	},
 
 	rate: function(frm, doctype, name) {
 		const item = locals[doctype][name];
-		frm.events.get_item_data(frm, item);
+		frm.events.get_item_data(frm, item, false);
 	},
 
 	item_code: function(frm, doctype, name) {
 		const item = locals[doctype][name];
 		item.rate = 0;
 		set_schedule_date(frm);
-		frm.events.get_item_data(frm, item);
+		frm.events.get_item_data(frm, item, true);
 	},
 
 	schedule_date: function(frm, cdt, cdn) {

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -47,6 +47,8 @@ def get_item_details(args, doc=None, for_validate=False, overwrite_warehouse=Tru
 	"""
 
 	args = process_args(args)
+	for_validate = process_string_args(for_validate)
+	overwrite_warehouse = process_string_args(overwrite_warehouse)
 	item = frappe.get_cached_doc("Item", args.item_code)
 	validate_item_details(args, item)
 
@@ -166,6 +168,10 @@ def process_args(args):
 	set_transaction_type(args)
 	return args
 
+def process_string_args(args):
+	if isinstance(args, string_types):
+		args = json.loads(args)
+	return args
 
 @frappe.whitelist()
 def get_item_code(barcode=None, serial_no=None):


### PR DESCRIPTION
**Issue:**
- On setting default warehouse at item level, `get_item_data` fetched default warehouse every single time it was triggered, overwriting what was already set
![mr-warehouse-issue](https://user-images.githubusercontent.com/25857446/87421063-fa94c500-c5f3-11ea-8f08-171a2fe33b58.gif)

**Fix:**
- overwrite warehouse only on item code change, otherwise don't fetch default warehouse on rate,qty,warehouse,etc trigger
![mr-warehouse-fix](https://user-images.githubusercontent.com/25857446/87421080-fff20f80-c5f3-11ea-8f3a-804488698c5f.gif)
