### PR TITLE
fix(report): fix messed up alignment in script report that extends financial_statements.js

### DIFF
--- a/erpnext/public/js/financial_statements.js
+++ b/erpnext/public/js/financial_statements.js
@@ -3,7 +3,7 @@ frappe.provide("erpnext.financial_statements");
 erpnext.financial_statements = {
 	"filters": get_filters(),
 	"formatter": function(value, row, column, data, default_formatter) {
-		if (column.fieldname=="account") {
+		if (data && column.fieldname=="account") {
 			value = data.account_name || value;
 
 			column.link_onclick =
@@ -13,7 +13,7 @@ erpnext.financial_statements = {
 
 		value = default_formatter(value, row, column, data);
 
-		if (!data.parent_account) {
+		if (data && !data.parent_account) {
 			value = $(`<span>${value}</span>`);
 
 			var $value = $(value).css("font-weight", "bold");


### PR DESCRIPTION
**Problem:**

I have a script report that is extending the file `apps/erpnext/erpnext/public/js/financial_statements.js`. So all the columns and everything in my report is quite messed up and **it doesn't get changed from the python file of my report**.

This is how the report looks:

![Screenshot from 2020-07-09 13-17-22](https://user-images.githubusercontent.com/13060550/87424756-22872700-c5fa-11ea-94d2-9d62fa9935fd.png)

I figured out that it was the `formatter` function in the file `financial_statements.js`.

In the case of my report, the `formatter` function on line 5 is also receiving `undefined` value for the parameter called `data` at some point. Hence it is giving javascript console errors at the line 7 at `data.account_name` and at the line 16 at `!data.parent_account`.

**Changes:**

Making those conditions a little bit robust by checking for the existence of `data` like so `data && column.fieldname=="account"` at line 6 for example and also on line 16 is solving the problem.

And the report looks good:

![Screenshot from 2020-07-09 13-18-12](https://user-images.githubusercontent.com/13060550/87441577-dd222400-c610-11ea-84a0-a4f8a1395002.png)
