### PR TITLE
fix: Period list fixes in financial statements

### DIFF
--- a/erpnext/accounts/report/financial_statements.py
+++ b/erpnext/accounts/report/financial_statements.py
@@ -8,6 +8,7 @@ from __future__ import unicode_literals
 import re
 from past.builtins import cmp
 import functools
+import math
 
 import frappe, erpnext
 from erpnext.accounts.report.utils import get_currency, convert_to_presentation_currency
@@ -42,7 +43,7 @@ def get_period_list(from_fiscal_year, to_fiscal_year, periodicity, accumulated_v
 	start_date = year_start_date
 	months = get_months(year_start_date, year_end_date)
 
-	for i in range(months // months_to_add):
+	for i in range(math.ceil(months / months_to_add)):
 		period = frappe._dict({
 			"from_date": start_date
 		})


### PR DESCRIPTION
Consider a fiscal year for less than 12 months, For Eg from `2019-05-01` to `2019-12-31`

Now if Balance Sheet is viewed for 'Yearly' Periodicity for this fiscal year the below error appears

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2020-07-02/apps/frappe/frappe/app.py", line 64, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-12-2020-07-02/apps/frappe/frappe/api.py", line 59, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-12-2020-07-02/apps/frappe/frappe/handler.py", line 24, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-12-2020-07-02/apps/frappe/frappe/handler.py", line 63, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-12-2020-07-02/apps/frappe/frappe/__init__.py", line 1054, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-12-2020-07-02/apps/frappe/frappe/__init__.py", line 526, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "/home/frappe/benches/bench-version-12-2020-07-02/apps/frappe/frappe/desk/query_report.py", line 183, in run
    result = generate_report_result(report, filters, user, custom_columns)
  File "/home/frappe/benches/bench-version-12-2020-07-02/apps/frappe/frappe/desk/query_report.py", line 59, in generate_report_result
    res = report.execute_script_report(filters)
  File "/home/frappe/benches/bench-version-12-2020-07-02/apps/frappe/frappe/core/doctype/report/report.py", line 116, in execute_script_report
    res = self.execute_module(filters)
  File "/home/frappe/benches/bench-version-12-2020-07-02/apps/frappe/frappe/core/doctype/report/report.py", line 133, in execute_module
    return frappe.get_attr(method_name)(frappe._dict(filters))
  File "/home/frappe/benches/bench-version-12-2020-07-02/apps/erpnext/erpnext/accounts/report/balance_sheet/balance_sheet.py", line 18, in execute
    accumulated_values=filters.accumulated_values)
  File "/home/frappe/benches/bench-version-12-2020-07-02/apps/erpnext/erpnext/accounts/report/financial_statements.py", line 146, in get_data
    period_list[-1]["to_date"],
IndexError: list index out of range
```

Also if the report is viewed with 'Quarterly' periodicity report only for first six months can be view

This PR fixes the issue