### PR TITLE
fix: Replace company abbr

### DIFF
--- a/erpnext/setup/doctype/company/company.js
+++ b/erpnext/setup/doctype/company/company.js
@@ -202,8 +202,6 @@ cur_frm.cscript.change_abbr = function() {
 				if(r.exc) {
 					frappe.msgprint(__("There were errors."));
 					return;
-				} else {
-					cur_frm.set_value("abbr", args.new_abbr);
 				}
 				dialog.hide();
 				cur_frm.refresh();

--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -400,8 +400,6 @@ def replace_abbr(company, old, new):
 	for dt in ["Warehouse", "Account", "Cost Center", "Department",
 			"Sales Taxes and Charges Template", "Purchase Taxes and Charges Template"]:
 		_rename_records(dt)
-		frappe.db.commit()
-
 
 def get_name_with_abbr(name, company):
 	company_abbr = frappe.get_cached_value('Company',  company,  "abbr")


### PR DESCRIPTION
While replacing the abbr system renames all records of account, warehouse, etc where abbr added as a suffix. After renaming each document there was `commit`, which can cause partial update if it fails in a later stage. Removed commit.

Also in JS, removed `set_value` for the same reason. If it fails on the server side, it should not update abbr from js.