### PR TITLE
fix: Added Project Field in Purchase Receipt for Stock Ledger Tagging

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.json
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.json
@@ -102,6 +102,7 @@
   "bill_no",
   "bill_date",
   "more_info",
+  "project",
   "status",
   "amended_from",
   "range",
@@ -1059,13 +1060,20 @@
    "fieldname": "scan_barcode",
    "fieldtype": "Data",
    "label": "Scan Barcode"
+  },
+  {
+   "description": "Track this Purchase Receipt against any Project",
+   "fieldname": "project",
+   "fieldtype": "Link",
+   "label": "Project",
+   "options": "Project"
   }
  ],
  "icon": "fa fa-truck",
  "idx": 261,
  "is_submittable": 1,
  "links": [],
- "modified": "2020-04-17 13:06:26.970288",
+ "modified": "2020-07-15 12:49:42.095297",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Purchase Receipt",


### PR DESCRIPTION
Port of https://github.com/frappe/erpnext/pull/22666
Due to https://github.com/frappe/erpnext/pull/22689 checked for duplicate field, not present in version-12
