### PR TITLE
fix: Show total row in print format of financial statement

### DIFF
--- a/erpnext/accounts/report/financial_statements.html
+++ b/erpnext/accounts/report/financial_statements.html
@@ -44,7 +44,7 @@
 		</tr>
 	</thead>
 	<tbody>
-		{% for(let j=0, k=data.length-1; j<k; j++) { %}
+		{% for(let j=0, k=data.length; j<k; j++) { %}
 			{%
 				var row = data[j];
 				var row_class = data[j].parent_account ? "" : "financial-statements-important";


### PR DESCRIPTION
**Before:**
<img width="1013" alt="Screenshot 2020-07-15 at 4 38 42 PM" src="https://user-images.githubusercontent.com/13928957/87538348-b23fda80-c6b9-11ea-8ba8-1c0156508007.png">
<img width="992" alt="Screenshot 2020-07-15 at 4 38 25 PM" src="https://user-images.githubusercontent.com/13928957/87538418-ca175e80-c6b9-11ea-8cb3-fe31b52f079d.png">

---

**After:**
<img width="1013" alt="Screenshot 2020-07-15 at 4 38 42 PM" src="https://user-images.githubusercontent.com/13928957/87538375-bc61d900-c6b9-11ea-87e4-03da0790cc3f.png">
<img width="990" alt="Screenshot 2020-07-15 at 4 34 17 PM" src="https://user-images.githubusercontent.com/13928957/87538382-bec43300-c6b9-11ea-8b87-ab60511c36e7.png">

