### PR TITLE
fix: incorrect balance qty in stock ledger report

### DIFF
--- a/erpnext/stock/report/stock_ledger/stock_ledger.py
+++ b/erpnext/stock/report/stock_ledger/stock_ledger.py
@@ -4,9 +4,9 @@
 from __future__ import unicode_literals
 
 import frappe
+from frappe.utils import cint, flt
 from erpnext.stock.utils import update_included_uom_in_report
 from frappe import _
-
 
 def execute(filters=None):
 	include_uom = filters.get("include_uom")
@@ -15,6 +15,7 @@ def execute(filters=None):
 	sl_entries = get_stock_ledger_entries(filters, items)
 	item_details = get_item_details(items, sl_entries, include_uom)
 	opening_row = get_opening_balance(filters, columns)
+	precision = cint(frappe.db.get_single_value("System Settings", "float_precision"))
 
 	data = []
 	conversion_factors = []
@@ -29,7 +30,7 @@ def execute(filters=None):
 		sle.update(item_detail)
 
 		if filters.get("batch_no"):
-			actual_qty += sle.actual_qty
+			actual_qty += flt(sle.actual_qty, precision)
 			stock_value += sle.stock_value_difference
 
 			if sle.voucher_type == 'Stock Reconciliation':


### PR DESCRIPTION
Cherry-pick https://github.com/frappe/erpnext/pull/22649

**Issue**

in stock ledger, user has put the batch filter and balance quantity is not matching with the balance quantity in the report Batch wise Balance History

**Stock Ledger Report**
<img width="1261" alt="Screenshot 2020-07-10 at 6 00 48 PM" src="https://user-images.githubusercontent.com/8780500/87155692-083b0980-c2d9-11ea-8063-26cfc02efae2.png">


**Batch wise Balance History Report**
<img width="1226" alt="Screenshot 2020-07-10 at 6 01 39 PM" src="https://user-images.githubusercontent.com/8780500/87155750-23a61480-c2d9-11ea-84d2-ea8df59fb301.png">


**After Fix**
<img width="1214" alt="Screenshot 2020-07-10 at 6 04 35 PM" src="https://user-images.githubusercontent.com/8780500/87155821-46d0c400-c2d9-11ea-8752-7ba74f84b1dc.png">
