### PR TITLE
fix:Stock Report - Projected qty unescaped % characters

### DIFF
--- a/erpnext/stock/report/stock_projected_qty/stock_projected_qty.py
+++ b/erpnext/stock/report/stock_projected_qty/stock_projected_qty.py
@@ -109,7 +109,7 @@ def get_item_map(item_code, include_uom):
 
 	condition = ""
 	if item_code:
-		condition = 'and item_code = {0}'.format(frappe.db.escape(item_code, percent=False))
+		condition = 'and item_code = {0}'.format(frappe.db.escape(item_code))
 
 	cf_field = cf_join = ""
 	if include_uom:
@@ -130,7 +130,7 @@ def get_item_map(item_code, include_uom):
 
 	condition = ""
 	if item_code:
-		condition = 'where parent={0}'.format(frappe.db.escape(item_code, percent=False))
+		condition = 'where parent={0}'.format(frappe.db.escape(item_code))
 
 	reorder_levels = frappe._dict()
 	for ir in frappe.db.sql("""select * from `tabItem Reorder` {condition}""".format(condition=condition), as_dict=1):


### PR DESCRIPTION
Problem: Item code can include % characters. Stock Projected qty is throwing a sql error when an item code with % character is entered

Fix: let frappe.db.escape percent args be true. 