### PR TITLE
fix: Move Issue List actions under 'Actions' dropdown (ux)

### DIFF
--- a/erpnext/support/doctype/issue/issue_list.js
+++ b/erpnext/support/doctype/issue/issue_list.js
@@ -8,11 +8,11 @@ frappe.listview_settings['Issue'] = {
 
 		var method = "erpnext.support.doctype.issue.issue.set_multiple_status";
 
-		listview.page.add_menu_item(__("Set as Open"), function() {
+		listview.page.add_action_item(__("Set as Open"), function() {
 			listview.call_for_selected_items(method, {"status": "Open"});
 		});
 
-		listview.page.add_menu_item(__("Set as Closed"), function() {
+		listview.page.add_action_item(__("Set as Closed"), function() {
 			listview.call_for_selected_items(method, {"status": "Closed"});
 		});
 	},


### PR DESCRIPTION
**Before:**
- Actions such as Set as Open/Set as Closed are applied on checked items in list view. Its better that these are visible after selecting items in list view i.e. via **Actions** dropdown, not Menu dropdown
![Screenshot 2020-07-16 at 3 43 06 PM](https://user-images.githubusercontent.com/25857446/87659219-dc0d0600-c77a-11ea-8999-d62a46750beb.png)

**After:**
- Move Issue List actions under 'Actions' dropdown
 ![Screenshot 2020-07-16 at 3 45 13 PM](https://user-images.githubusercontent.com/25857446/87659241-e62f0480-c77a-11ea-9b1e-72b99f3d34f3.png)
