### PR TITLE
fix: Move branch code back to bank account

### DIFF
--- a/erpnext/accounts/doctype/bank/bank.json
+++ b/erpnext/accounts/doctype/bank/bank.json
@@ -13,7 +13,6 @@
   "bank_name",
   "swift_number",
   "column_break_1",
-  "branch_code",
   "website",
   "address_and_contact",
   "address_html",
@@ -50,15 +49,6 @@
    "fieldname": "column_break_1",
    "fieldtype": "Column Break",
    "search_index": 1
-  },
-  {
-   "allow_in_quick_entry": 1,
-   "fieldname": "branch_code",
-   "fieldtype": "Data",
-   "in_list_view": 1,
-   "in_standard_filter": 1,
-   "label": "Branch Code",
-   "unique": 1
   },
   {
    "fieldname": "address_and_contact",
@@ -111,7 +101,7 @@
   }
  ],
  "links": [],
- "modified": "2020-03-25 21:22:33.496264",
+ "modified": "2020-07-17 14:00:13.105433",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Bank",

--- a/erpnext/accounts/doctype/bank_account/bank_account.json
+++ b/erpnext/accounts/doctype/bank_account/bank_account.json
@@ -23,6 +23,7 @@
   "account_details_section",
   "iban",
   "column_break_12",
+  "branch_code",
   "bank_account_no",
   "address_and_contact",
   "address_html",
@@ -197,10 +198,16 @@
    "fieldtype": "Data",
    "label": "Mask",
    "read_only": 1
+  },
+  {
+   "fieldname": "branch_code",
+   "fieldtype": "Data",
+   "in_global_search": 1,
+   "label": "Branch Code"
   }
  ],
  "links": [],
- "modified": "2020-04-06 21:00:45.379804",
+ "modified": "2020-07-17 13:59:50.795412",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Bank Account",

--- a/erpnext/accounts/doctype/bank_guarantee/bank_guarantee.js
+++ b/erpnext/accounts/doctype/bank_guarantee/bank_guarantee.js
@@ -4,7 +4,7 @@
 cur_frm.add_fetch('bank_account','account','account');
 cur_frm.add_fetch('bank_account','bank_account_no','bank_account_no');
 cur_frm.add_fetch('bank_account','iban','iban');
-cur_frm.add_fetch('bank','branch_code','branch_code');
+cur_frm.add_fetch('bank_account','branch_code','branch_code');
 cur_frm.add_fetch('bank','swift_number','swift_number');
 
 frappe.ui.form.on('Bank Guarantee', {

--- a/erpnext/accounts/doctype/payment_request/payment_request.json
+++ b/erpnext/accounts/doctype/payment_request/payment_request.json
@@ -211,7 +211,7 @@
    "label": "IBAN"
   },
   {
-   "fetch_from": "bank.branch_code",
+   "fetch_from": "bank_account.branch_code",
    "fetch_if_empty": 1,
    "fieldname": "branch_code",
    "fieldtype": "Read Only",
@@ -352,7 +352,7 @@
  "in_create": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2020-05-29 17:38:49.392713",
+ "modified": "2020-07-17 14:06:42.185763",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Request",

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -709,3 +709,4 @@ erpnext.patches.v13_0.move_payroll_setting_separately_from_hr_settings #22-06-20
 erpnext.patches.v13_0.check_is_income_tax_component #22-06-2020
 erpnext.patches.v12_0.add_taxjar_integration_field
 erpnext.patches.v12_0.update_item_tax_template_company
+erpnext.patches.v13_0.move_branch_code_to_bank_account

--- a/erpnext/patches/v12_0/move_bank_account_swift_number_to_bank.py
+++ b/erpnext/patches/v12_0/move_bank_account_swift_number_to_bank.py
@@ -7,8 +7,7 @@ def execute():
 	if frappe.db.table_exists('Bank') and frappe.db.table_exists('Bank Account') and frappe.db.has_column('Bank Account', 'swift_number'):
 		frappe.db.sql("""
 			UPDATE `tabBank` b, `tabBank Account` ba
-			SET b.swift_number = ba.swift_number, b.branch_code = ba.branch_code
-			WHERE b.name = ba.bank
+			SET b.swift_number = ba.swift_number WHERE b.name = ba.bank
 		""")
 
 	frappe.reload_doc('accounts', 'doctype', 'bank_account')

--- a/erpnext/patches/v13_0/move_branch_code_to_bank_account.py
+++ b/erpnext/patches/v13_0/move_branch_code_to_bank_account.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2019, Frappe and Contributors
+# License: GNU General Public License v3. See license.txt
+
+from __future__ import unicode_literals
+
+import frappe
+
+def execute():
+
+	frappe.reload_doc('accounts', 'doctype', 'bank_account')
+	frappe.reload_doc('accounts', 'doctype', 'bank')
+
+	if frappe.db.has_column('Bank', 'branch_code') and frappe.db.has_column('Bank Account', 'branch_code'):
+		frappe.db.sql("""UPDATE `tabBank` b, `tabBank Account` ba
+			SET ba.branch_code = b.branch_code
+			WHERE b.branch_code IS NOT NULL and ba.branch_code IS NULL""")

--- a/erpnext/patches/v13_0/move_branch_code_to_bank_account.py
+++ b/erpnext/patches/v13_0/move_branch_code_to_bank_account.py
@@ -13,4 +13,5 @@ def execute():
 	if frappe.db.has_column('Bank', 'branch_code') and frappe.db.has_column('Bank Account', 'branch_code'):
 		frappe.db.sql("""UPDATE `tabBank` b, `tabBank Account` ba
 			SET ba.branch_code = b.branch_code
-			WHERE b.branch_code IS NOT NULL and ba.branch_code IS NULL""")
+			WHERE ba.bank = b.name AND
+			ifnull(b.branch_code, '') != '' AND ifnull(ba.branch_code, '') = ''""")


### PR DESCRIPTION
Branch Code was moved from Bank Account to Bank Recently in this [PR](https://github.com/frappe/erpnext/pull/20653)

Moving branch code back to Bank Account as there can be multiple Bank Accounts with same bank but with different branches, so branch_code field makes more sense there.