### PR TITLE
fix: Stock Reconciliation Invalid Quantity for Batched Item

### DIFF
--- a/erpnext/stock/doctype/batch/batch.py
+++ b/erpnext/stock/doctype/batch/batch.py
@@ -143,7 +143,7 @@ class Batch(Document):
 
 
 @frappe.whitelist()
-def get_batch_qty(batch_no=None, warehouse=None, item_code=None):
+def get_batch_qty(batch_no=None, warehouse=None, item_code=None, posting_date=None, posting_time=None):
 	"""Returns batch actual qty if warehouse is passed,
 		or returns dict of qty by warehouse if warehouse is None
 
@@ -155,9 +155,14 @@ def get_batch_qty(batch_no=None, warehouse=None, item_code=None):
 
 	out = 0
 	if batch_no and warehouse:
+		cond = ""
+		if posting_date and posting_time:
+			cond = " and timestamp(posting_date, posting_time) <= timestamp('{0}', '{1}')".format(posting_date,
+				posting_time)
+
 		out = float(frappe.db.sql("""select sum(actual_qty)
 			from `tabStock Ledger Entry`
-			where warehouse=%s and batch_no=%s""",
+			where warehouse=%s and batch_no=%s {0}""".format(cond),
 			(warehouse, batch_no))[0][0] or 0)
 
 	if batch_no and not warehouse:

--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.js
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.js
@@ -74,6 +74,20 @@ frappe.ui.form.on("Stock Reconciliation", {
 		, __("Get Items"), __("Update"));
 	},
 
+	posting_date: function(frm) {
+		frm.trigger("set_valuation_rate_and_qty_for_all_items");
+	},
+
+	posting_time: function(frm) {
+		frm.trigger("set_valuation_rate_and_qty_for_all_items");
+	},
+
+	set_valuation_rate_and_qty_for_all_items: function(frm) {
+		frm.doc.items.forEach(row => {
+			frm.events.set_valuation_rate_and_qty(frm, row.doctype, row.name);
+		});
+	},
+
 	set_valuation_rate_and_qty: function(frm, cdt, cdn) {
 		var d = frappe.model.get_doc(cdt, cdn);
 

--- a/erpnext/stock/report/stock_ledger/stock_ledger.py
+++ b/erpnext/stock/report/stock_ledger/stock_ledger.py
@@ -33,7 +33,7 @@ def execute(filters=None):
 			actual_qty += flt(sle.actual_qty, precision)
 			stock_value += sle.stock_value_difference
 
-			if sle.voucher_type == 'Stock Reconciliation':
+			if sle.voucher_type == 'Stock Reconciliation' and not sle.actual_qty:
 				actual_qty = sle.qty_after_transaction
 				stock_value = sle.stock_value
 


### PR DESCRIPTION
**Issue**

For the past dated Stock Reconciliation, the batched item is showing the quantity as per current date instead of quantity as per posting date

<img width="921" alt="Screenshot 2020-07-16 at 10 24 28 PM" src="https://user-images.githubusercontent.com/8780500/87700103-725d1e00-c7b3-11ea-9e56-50b0725bc653.png">


**After Fix**
<img width="932" alt="Screenshot 2020-07-16 at 10 14 01 PM" src="https://user-images.githubusercontent.com/8780500/87699645-c9162800-c7b2-11ea-958c-b626108a6c69.png">
