### PR TITLE
fix: Expense claim outstanding while making payment entry

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -907,7 +907,7 @@ def get_reference_details(reference_doctype, reference_name, party_account_curre
 	elif reference_doctype != "Journal Entry":
 		if party_account_currency == company_currency:
 			if ref_doc.doctype == "Expense Claim":
-				total_amount = ref_doc.total_sanctioned_amount
+				total_amount = flt(ref_doc.total_sanctioned_amount) + flt(ref_doc.total_taxes_and_charges)
 			elif ref_doc.doctype == "Employee Advance":
 				total_amount = ref_doc.advance_amount
 			else:
@@ -925,8 +925,8 @@ def get_reference_details(reference_doctype, reference_name, party_account_curre
 			outstanding_amount = ref_doc.get("outstanding_amount")
 			bill_no = ref_doc.get("bill_no")
 		elif reference_doctype == "Expense Claim":
-			outstanding_amount = flt(ref_doc.get("total_sanctioned_amount")) \
-				- flt(ref_doc.get("total_amount+reimbursed")) - flt(ref_doc.get("total_advance_amount"))
+			outstanding_amount = flt(ref_doc.get("total_sanctioned_amount")) + flt(ref_doc.get("total_taxes_and_charges"))\
+				- flt(ref_doc.get("total_amount_reimbursed")) - flt(ref_doc.get("total_advance_amount"))
 		elif reference_doctype == "Employee Advance":
 			outstanding_amount = ref_doc.advance_amount - flt(ref_doc.paid_amount)
 		else:


### PR DESCRIPTION
While manually selecting Expense Claim in Payment Entry references only sanctioned amount is fetched and taxes and charges are ignored

Expense Claim:
<img width="1223" alt="Screenshot 2020-07-18 at 9 07 21 PM" src="https://user-images.githubusercontent.com/42651287/87856420-ab74ca00-c93c-11ea-9fdf-c55894d2b12d.png">

Before:
<img width="1277" alt="Screenshot 2020-07-18 at 9 21 22 PM" src="https://user-images.githubusercontent.com/42651287/87856421-b0397e00-c93c-11ea-9edf-77322c777ad3.png">

After:
<img width="1254" alt="Screenshot 2020-07-18 at 9 08 11 PM" src="https://user-images.githubusercontent.com/42651287/87856424-b4659b80-c93c-11ea-91f2-c8dd000fa80a.png">
