### PR TITLE
fix: reset homepage to home after unchecking products page

### DIFF
--- a/erpnext/portal/doctype/products_settings/products_settings.py
+++ b/erpnext/portal/doctype/products_settings/products_settings.py
@@ -12,7 +12,7 @@ class ProductsSettings(Document):
 	def validate(self):
 		if self.home_page_is_products:
 			frappe.db.set_value("Website Settings", "home_page", "products")
-		elif frappe.get_single_value("Website Settings", "home_page") == 'products':
+		elif frappe.db.get_single_value("Website Settings", "home_page") == 'products':
 			frappe.db.set_value("Website Settings", "home_page", "home")
 
 		self.validate_field_filters()

--- a/erpnext/portal/doctype/products_settings/products_settings.py
+++ b/erpnext/portal/doctype/products_settings/products_settings.py
@@ -11,9 +11,9 @@ from frappe.model.document import Document
 class ProductsSettings(Document):
 	def validate(self):
 		if self.home_page_is_products:
-			website_settings = frappe.get_doc('Website Settings')
-			website_settings.home_page = 'products'
-			website_settings.save()
+			frappe.db.set_value("Website Settings", "home_page", "products")
+		elif frappe.get_single_value("Website Settings", "home_page") == 'products':
+			frappe.db.set_value("Website Settings", "home_page", "home")
 
 		self.validate_field_filters()
 		self.validate_attribute_filters()
@@ -40,4 +40,5 @@ def home_page_is_products(doc, method):
 	home_page_is_products = cint(frappe.db.get_single_value('Products Settings', 'home_page_is_products'))
 	if home_page_is_products:
 		doc.home_page = 'products'
-
+	elif doc.home_page == "products":
+		doc.home_page = 'home'

--- a/erpnext/portal/doctype/products_settings/products_settings.py
+++ b/erpnext/portal/doctype/products_settings/products_settings.py
@@ -40,5 +40,3 @@ def home_page_is_products(doc, method):
 	home_page_is_products = cint(frappe.db.get_single_value('Products Settings', 'home_page_is_products'))
 	if home_page_is_products:
 		doc.home_page = 'products'
-	elif doc.home_page == "products":
-		doc.home_page = 'home'


### PR DESCRIPTION
resets homepage back to home when "home page is products" is unchecked

fixes: #22733 