### PR TITLE
fix: Serial No Rename does not affect  Stock Ledger Entry

### DIFF
--- a/erpnext/stock/doctype/serial_no/serial_no.json
+++ b/erpnext/stock/doctype/serial_no/serial_no.json
@@ -1,6 +1,7 @@
 {
  "actions": [],
  "allow_import": 1,
+ "allow_rename": 1,
  "autoname": "field:serial_no",
  "creation": "2013-05-16 10:59:15",
  "description": "Distinct unit of an Item",
@@ -426,7 +427,7 @@
  "icon": "fa fa-barcode",
  "idx": 1,
  "links": [],
- "modified": "2020-06-25 15:53:50.900855",
+ "modified": "2020-07-20 20:50:16.660433",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Serial No",

--- a/erpnext/stock/doctype/serial_no/serial_no.py
+++ b/erpnext/stock/doctype/serial_no/serial_no.py
@@ -197,7 +197,7 @@ class SerialNo(StockController):
 	def after_rename(self, old, new, merge=False):
 		"""rename serial_no text fields"""
 		for dt in frappe.db.sql("""select parent from tabDocField
-			where fieldname='serial_no' and fieldtype in ('Text', 'Small Text')"""):
+			where fieldname='serial_no' and fieldtype in ('Text', 'Small Text', 'Long Text')"""):
 
 			for item in frappe.db.sql("""select name, serial_no from `tab%s`
 				where serial_no like %s""" % (dt[0], frappe.db.escape('%' + old + '%'))):

--- a/erpnext/stock/doctype/serial_no/serial_no.py
+++ b/erpnext/stock/doctype/serial_no/serial_no.py
@@ -190,6 +190,23 @@ class SerialNo(StockController):
 		if sle_exists:
 			frappe.throw(_("Cannot delete Serial No {0}, as it is used in stock transactions").format(self.name))
 
+	def before_rename(self, old, new, merge=False):
+		if merge:
+			frappe.throw(_("Sorry, Serial Nos cannot be merged"))
+
+	def after_rename(self, old, new, merge=False):
+		"""rename serial_no text fields"""
+		for dt in frappe.db.sql("""select parent from tabDocField
+			where fieldname='serial_no' and fieldtype in ('Text', 'Small Text')"""):
+
+			for item in frappe.db.sql("""select name, serial_no from `tab%s`
+				where serial_no like %s""" % (dt[0], frappe.db.escape('%' + old + '%'))):
+
+				serial_nos = map(lambda i: new if i.upper()==old.upper() else i, item[1].split('\n'))
+				frappe.db.sql("""update `tab%s` set serial_no = %s
+					where name=%s""" % (dt[0], '%s', '%s'),
+					('\n'.join(list(serial_nos)), item[0]))
+
 	def update_serial_no_reference(self, serial_no=None):
 		last_sle = self.get_last_sle(serial_no)
 		self.set_purchase_details(last_sle.get("purchase_sle"))


### PR DESCRIPTION
- Rename of a Serial No did not reflect in Stock Ledger Entry due to change in serial no field type from _Small Text_ to _Long Text_ in Stock Ledger Entry's Serial No field
- Added Long Text in `after_rename` condition , and reverted https://github.com/frappe/erpnext/pull/22627