### PR TITLE
fix: item-wise sales history report

### DIFF
--- a/erpnext/selling/report/item_wise_sales_history/item_wise_sales_history.py
+++ b/erpnext/selling/report/item_wise_sales_history/item_wise_sales_history.py
@@ -191,7 +191,7 @@ def get_conditions(filters):
 		conditions += "AND so_item.item_code = '%s'" %frappe.db.escape(filters.item_code)
 
 	if filters.get("customer"):
-		conditions += "AND so.customer = '%s'" %frappe.db.escape(filters.customer)
+		conditions += "AND so.customer = %s" %frappe.db.escape(filters.customer)
 
 	return conditions
 


### PR DESCRIPTION
**Issue-**
When we apply customer filter in Item-Wise Sales History report it throws an SQL query error.
![item-wise-b](https://user-images.githubusercontent.com/20715976/88175732-e67c4380-cc43-11ea-8439-f91ea38c2047.gif)

**After Fix-**
![item-wise-a](https://user-images.githubusercontent.com/20715976/88175562-a5842f00-cc43-11ea-8f99-13eee2c6a74a.gif)
