### PR TITLE
Update transaction.js

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -3,6 +3,7 @@
 
 erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 	setup: function() {
+		frappe.flags.hide_serial_batch_dialog = true
 		this._super();
 		frappe.ui.form.on(this.frm.doctype + " Item", "rate", function(frm, cdt, cdn) {
 			var item = frappe.get_doc(cdt, cdn);


### PR DESCRIPTION
Added frappe.flags.hide_serial_batch_dialog = true that was missing in version-12

This causes the dialog to appear even for non-serial items as the default is left as undefined and falls under the criteria to show the dialog.

In version-13 the flag is correctly set