### PR TITLE
fix: Sales Order Status Fix

### DIFF
--- a/erpnext/controllers/status_updater.py
+++ b/erpnext/controllers/status_updater.py
@@ -39,7 +39,7 @@ status_map = {
 		["To Deliver and Bill", "eval:self.per_delivered < 100 and self.per_billed < 100 and self.docstatus == 1"],
 		["To Bill", "eval:(self.per_delivered == 100 or self.skip_delivery_note) and self.per_billed < 100 and self.docstatus == 1"],
 		["To Deliver", "eval:self.per_delivered < 100 and self.per_billed == 100 and self.docstatus == 1 and not self.skip_delivery_note"],
-		["Completed", "eval:(self.per_delivered == 100 or self.skip_delivery_note) and self.per_billed == 100 and self.docstatus == 1"],
+		["Completed", "eval:(self.per_delivered == 100 or self.skip_delivery_note) and (self.per_billed == 100 or self.grand_total == 0) and self.docstatus == 1"],
 		["Cancelled", "eval:self.docstatus==2"],
 		["Closed", "eval:self.status=='Closed'"],
 		["On Hold", "eval:self.status=='On Hold'"],

--- a/erpnext/selling/doctype/sales_order/sales_order_list.js
+++ b/erpnext/selling/doctype/sales_order/sales_order_list.js
@@ -33,6 +33,8 @@ frappe.listview_settings['Sales Order'] = {
 			// to bill
 			return [__("To Bill"), "orange",
 				"per_delivered,=,100|per_billed,<,100|status,!=,Closed"];
+		} else if ((flt(doc.per_delivered, 6) === 100) && flt(doc.grand_total) === 0) {
+			return [__("Completed"), "green", "status,=,Completed"];
 		} else if (doc.skip_delivery_note && flt(doc.per_billed, 6) < 100){
 			return [__("To Bill"), "orange", "per_billed,<,100|status,!=,Closed"];
 		}


### PR DESCRIPTION
**Problem:**
Sometimes the Sales Order has 0 value as well when it is a free service or FOC item. Such Sales orders always show as `Submitted`, no relevant status. 

**Solution:**
Added the condition to Status Updater and Sales Order List.

<img width="932" alt="Screen Shot 2020-07-23 at 4 49 42 PM" src="https://user-images.githubusercontent.com/16913064/88281139-c82a4c80-cd04-11ea-94a4-821b95c4bb1e.png">
