### PR TITLE
fix(Education): descriptions not copied while creating Fees from Fee Structure

### DIFF
--- a/erpnext/education/api.py
+++ b/erpnext/education/api.py
@@ -151,7 +151,7 @@ def get_fee_components(fee_structure):
 	:param fee_structure: Fee Structure.
 	"""
 	if fee_structure:
-		fs = frappe.get_list("Fee Component", fields=["fees_category", "amount"] , filters={"parent": fee_structure}, order_by= "idx")
+		fs = frappe.get_list("Fee Component", fields=["fees_category", "description", "amount"] , filters={"parent": fee_structure}, order_by= "idx")
 		return fs
 
 
@@ -363,9 +363,9 @@ def get_current_enrollment(student, academic_year=None):
 		select
 			name as program_enrollment, student_name, program, student_batch_name as student_batch,
 			student_category, academic_term, academic_year
-		from 
+		from
 			`tabProgram Enrollment`
-		where 
+		where
 			student = %s and academic_year = %s
 		order by creation''', (student, current_academic_year), as_dict=1)
 

--- a/erpnext/education/doctype/fees/fees.js
+++ b/erpnext/education/doctype/fees/fees.js
@@ -161,6 +161,7 @@ frappe.ui.form.on("Fees", {
 						$.each(r.message, function(i, d) {
 							var row = frappe.model.add_child(frm.doc, "Fee Component", "components");
 							row.fees_category = d.fees_category;
+							row.description = d.description;
 							row.amount = d.amount;
 						});
 					}


### PR DESCRIPTION
Backport: https://github.com/frappe/erpnext/pull/22792

While creating Fees from Fees Structure the descriptions for fee components are not copied.

**Before:**

![desc-not-copied](https://user-images.githubusercontent.com/24353136/88297665-d173e300-cd1d-11ea-86b3-443c601d15cb.gif)

**After:**

![desc-copied](https://user-images.githubusercontent.com/24353136/88297678-d8025a80-cd1d-11ea-8e21-d93ce7a1a352.gif)
