### PR TITLE
fix: add order_by explicitly for holiday list

### DIFF
--- a/erpnext/hr/doctype/holiday_list/holiday_list_calendar.js
+++ b/erpnext/hr/doctype/holiday_list/holiday_list_calendar.js
@@ -9,6 +9,7 @@ frappe.views.calendar["Holiday List"] = {
 		"title": "description",
 		"allDay": "allDay"
 	},
+	order_by: `from_date`,
 	get_events_method: "erpnext.hr.doctype.holiday_list.holiday_list.get_events",
 	filters: [
 		{


### PR DESCRIPTION
Gantt view of Holiday List would break because with the following traceback

```python
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-13-2020-07-03/apps/frappe/frappe/app.py", line 64, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-13-2020-07-03/apps/frappe/frappe/api.py", line 58, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-13-2020-07-03/apps/frappe/frappe/handler.py", line 30, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-13-2020-07-03/apps/frappe/frappe/handler.py", line 69, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-13-2020-07-03/apps/frappe/frappe/__init__.py", line 1085, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-13-2020-07-03/apps/frappe/frappe/__init__.py", line 545, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "/home/frappe/benches/bench-version-13-2020-07-03/apps/frappe/frappe/desk/reportview.py", line 22, in get
    data = compress(execute(**args), args = args)
  File "/home/frappe/benches/bench-version-13-2020-07-03/apps/frappe/frappe/desk/reportview.py", line 27, in execute
    return DatabaseQuery(doctype).execute(*args, **kwargs)
  File "/home/frappe/benches/bench-version-13-2020-07-03/apps/frappe/frappe/model/db_query.py", line 96, in execute
    result = self.build_and_run()
  File "/home/frappe/benches/bench-version-13-2020-07-03/apps/frappe/frappe/model/db_query.py", line 130, in build_and_run
    return frappe.db.sql(query, as_dict=not self.as_list, debug=self.debug, update=self.update)
  File "/home/frappe/benches/bench-version-13-2020-07-03/apps/frappe/frappe/database/database.py", line 173, in sql
    self._cursor.execute(query)
  File "/home/frappe/benches/bench-version-13-2020-07-03/env/lib/python3.6/site-packages/pymysql/cursors.py", line 170, in execute
    result = self._query(query)
  File "/home/frappe/benches/bench-version-13-2020-07-03/env/lib/python3.6/site-packages/pymysql/cursors.py", line 328, in _query
    conn.query(q)
  File "/home/frappe/benches/bench-version-13-2020-07-03/env/lib/python3.6/site-packages/pymysql/connections.py", line 517, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/home/frappe/benches/bench-version-13-2020-07-03/env/lib/python3.6/site-packages/pymysql/connections.py", line 732, in _read_query_result
    result.read()
  File "/home/frappe/benches/bench-version-13-2020-07-03/env/lib/python3.6/site-packages/pymysql/connections.py", line 1075, in read
    first_packet = self.connection._read_packet()
  File "/home/frappe/benches/bench-version-13-2020-07-03/env/lib/python3.6/site-packages/pymysql/connections.py", line 684, in _read_packet
    packet.check_error()
  File "/home/frappe/benches/bench-version-13-2020-07-03/env/lib/python3.6/site-packages/pymysql/protocol.py", line 220, in check_error
    err.raise_mysql_exception(self._data)
  File "/home/frappe/benches/bench-version-13-2020-07-03/env/lib/python3.6/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.InternalError: (1054, "Unknown column 'tabHoliday List.holiday_date' in 'order clause'")
```

This PR fixes it by explicitly setting order-by