### PR TITLE
fix: cannot change customer fields if credit exhausted

### DIFF
--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -184,6 +184,14 @@ class Customer(TransactionBase):
 	def validate_credit_limit_on_change(self):
 		if self.get("__islocal") or not self.credit_limits:
 			return
+		
+		last_credit_limits = [d.credit_limit
+			for d in frappe.db.get_all("Customer Credit Limit", filters={'parent': self.name}, fields=["credit_limit"], order_by="idx")]
+		
+		current_credit_limits = [d.credit_limit for d in self.credit_limits]
+
+		if last_credit_limits == current_credit_limits:
+			return
 
 		company_record = []
 		for limit in self.credit_limits:

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -185,12 +185,12 @@ class Customer(TransactionBase):
 		if self.get("__islocal") or not self.credit_limits:
 			return
 		
-		last_credit_limits = [d.credit_limit
-			for d in frappe.db.get_all("Customer Credit Limit", filters={'parent': self.name}, fields=["credit_limit"], order_by="idx")]
+		past_credit_limits = [d.credit_limit
+			for d in frappe.db.get_all("Customer Credit Limit", filters={'parent': self.name}, fields=["credit_limit"], order_by="company")]
 		
 		current_credit_limits = [d.credit_limit for d in self.credit_limits]
 
-		if last_credit_limits == current_credit_limits:
+		if past_credit_limits == current_credit_limits:
 			return
 
 		company_record = []

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -188,7 +188,7 @@ class Customer(TransactionBase):
 		past_credit_limits = [d.credit_limit
 			for d in frappe.db.get_all("Customer Credit Limit", filters={'parent': self.name}, fields=["credit_limit"], order_by="company")]
 		
-		current_credit_limits = [d.credit_limit for d in sorted(self.credit_limits, key=lambda k: k['company'])]
+		current_credit_limits = [d.credit_limit for d in sorted(self.credit_limits, key=lambda k: k.company)]
 
 		if past_credit_limits == current_credit_limits:
 			return

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -188,7 +188,7 @@ class Customer(TransactionBase):
 		past_credit_limits = [d.credit_limit
 			for d in frappe.db.get_all("Customer Credit Limit", filters={'parent': self.name}, fields=["credit_limit"], order_by="company")]
 		
-		current_credit_limits = [d.credit_limit for d in self.credit_limits]
+		current_credit_limits = [d.credit_limit for d in sorted(self.credit_limits, key=lambda k: k['company'])]
 
 		if past_credit_limits == current_credit_limits:
 			return


### PR DESCRIPTION
To replicate:
- Set a credit limit for a customer
- Set Administrator or any other user as Credit Controller in Accounts Setting
- Make sales invoice greater than the credit limit for the customer
- Now system won't allow changing Tax ID or any other field for that customer. 
 ![Screenshot 2020-08-20 at 11 27 17 AM](https://user-images.githubusercontent.com/25857446/90721902-69da9480-e2d7-11ea-8c1f-df8883ff7945.png)
