### PR TITLE
Fixes the rounding off 3 decimal digits to 2 in Accounting Ledger

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -79,7 +79,7 @@ class StockController(AccountsController):
 							"against": item_row.expense_account,
 							"cost_center": item_row.cost_center,
 							"remarks": self.get("remarks") or "Accounting Entry for Stock",
-							"debit": flt(sle.stock_value_difference, 2),
+							"debit": flt(sle.stock_value_difference, precision),
 							"is_opening": item_row.get("is_opening") or self.get("is_opening") or "No",
 						}, warehouse_account[sle.warehouse]["account_currency"]))
 
@@ -89,7 +89,7 @@ class StockController(AccountsController):
 							"against": warehouse_account[sle.warehouse]["account"],
 							"cost_center": item_row.cost_center,
 							"remarks": self.get("remarks") or "Accounting Entry for Stock",
-							"credit": flt(sle.stock_value_difference, 2),
+							"credit": flt(sle.stock_value_difference, precision),
 							"project": item_row.get("project") or self.get("project"),
 							"is_opening": item_row.get("is_opening") or self.get("is_opening") or "No"
 						}))


### PR DESCRIPTION
Due to error in code 3 decimal digits were being rounded off to 2 decimal digits in Accounting Ledger. Difference amount is loaded in Stock Adjustments. This is important change for countries with 3 decimal digit currencies.

Before the change. Rounded to 2 decimal digits leading to entry in stock adjustment.
![image](https://user-images.githubusercontent.com/16674535/88930441-2cf52200-d284-11ea-9dfe-56f2d742ace2.png)

After the change. 3 decimal digits work fine.

![image](https://user-images.githubusercontent.com/16674535/88930232-de478800-d283-11ea-84c6-da01cddf38b0.png)
