### PR TITLE
fix: PO/SO view title

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.json
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.json
@@ -1084,7 +1084,7 @@
  "idx": 105,
  "is_submittable": 1,
  "links": [],
- "modified": "2020-07-18 05:09:33.800633",
+ "modified": "2020-07-31 14:13:44.610190",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Purchase Order",
@@ -1135,5 +1135,5 @@
  "sort_field": "modified",
  "sort_order": "DESC",
  "timeline_field": "supplier",
- "title_field": "title"
+ "title_field": "supplier"
 }

--- a/erpnext/selling/doctype/sales_order/sales_order.json
+++ b/erpnext/selling/doctype/sales_order/sales_order.json
@@ -1,7 +1,6 @@
 {
  "actions": [],
  "allow_import": 1,
- "allow_workflow": 1,
  "autoname": "naming_series:",
  "creation": "2013-06-18 12:39:59",
  "doctype": "DocType",
@@ -1461,7 +1460,7 @@
  "idx": 105,
  "is_submittable": 1,
  "links": [],
- "modified": "2020-07-18 05:13:06.680696",
+ "modified": "2020-07-31 14:13:17.962015",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order",
@@ -1535,7 +1534,7 @@
  "sort_field": "modified",
  "sort_order": "DESC",
  "timeline_field": "customer",
- "title_field": "title",
+ "title_field": "customer",
  "track_changes": 1,
  "track_seen": 1
 }


### PR DESCRIPTION
- The title of a form (based on view settings) gets set on updation of form
- If the title field is based 'title' it gets set once on save and never changes again as value of title for the current form is what was first set
- So, if a customer is changed in SO after saving , this happens (title and customer field have different values):
 ![Screenshot 2020-07-31 at 2 06 23 PM](https://user-images.githubusercontent.com/25857446/89017450-f547b200-d337-11ea-8838-d7cc59fe53b1.png)

**After Fix:**
   - ![Screenshot 2020-07-31 at 2 21 20 PM](https://user-images.githubusercontent.com/25857446/89017801-83239d00-d338-11ea-94eb-bc59f7c85ffd.png)

