### PR TITLE
feat: Naming series for Sales/Purchase Return

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
@@ -9,6 +9,7 @@
  "field_order": [
   "title",
   "naming_series",
+  "return_naming_series",
   "supplier",
   "supplier_name",
   "tax_id",
@@ -174,6 +175,7 @@
    "print_hide": 1
   },
   {
+   "depends_on": "eval: doc.is_return === 0",
    "fieldname": "naming_series",
    "fieldtype": "Select",
    "label": "Series",
@@ -1326,13 +1328,25 @@
    "fieldtype": "Link",
    "label": "Project",
    "options": "Project"
+  },
+  {
+   "bold": 1,
+   "depends_on": "eval: doc.is_return === 1",
+   "fieldname": "return_naming_series",
+   "fieldtype": "Select",
+   "label": "Return Series",
+   "no_copy": 1,
+   "options": "ACC-PINV-RET-.YYYY.-",
+   "print_hide": 1,
+   "reqd": 1,
+   "set_only_once": 1
   }
  ],
  "icon": "fa fa-file-text",
  "idx": 204,
  "is_submittable": 1,
  "links": [],
- "modified": "2020-07-24 09:46:40.405463",
+ "modified": "2020-08-03 00:17:38.634629",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Purchase Invoice",

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
@@ -1,7 +1,6 @@
 {
  "actions": [],
  "allow_import": 1,
- "allow_workflow": 1,
  "autoname": "naming_series:",
  "creation": "2013-05-24 19:29:05",
  "doctype": "DocType",
@@ -10,6 +9,7 @@
   "customer_section",
   "title",
   "naming_series",
+  "return_naming_series",
   "customer",
   "customer_name",
   "tax_id",
@@ -209,6 +209,7 @@
   },
   {
    "bold": 1,
+   "depends_on": "eval: doc.is_return === 0",
    "fieldname": "naming_series",
    "fieldtype": "Select",
    "hide_days": 1,
@@ -1941,13 +1942,25 @@
    "hide_seconds": 1,
    "label": "Is Internal Customer",
    "read_only": 1
+  },
+  {
+   "bold": 1,
+   "depends_on": "eval: doc.is_return === 1",
+   "fieldname": "return_naming_series",
+   "fieldtype": "Select",
+   "label": "Return Series",
+   "no_copy": 1,
+   "options": "ACC-SINV-RET-.YYYY.-",
+   "print_hide": 1,
+   "reqd": 1,
+   "set_only_once": 1
   }
  ],
  "icon": "fa fa-file-text",
  "idx": 181,
  "is_submittable": 1,
  "links": [],
- "modified": "2020-07-18 05:07:16.725974",
+ "modified": "2020-08-02 21:21:14.209766",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice",

--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -16,6 +16,7 @@ from frappe.contacts.doctype.address.address import get_address_display
 
 from erpnext.accounts.doctype.budget.budget import validate_expense_against_budget
 from erpnext.controllers.stock_controller import StockController
+from frappe.model.naming import make_autoname
 
 class BuyingController(StockController):
 	def __setup__(self):
@@ -816,6 +817,10 @@ class BuyingController(StockController):
 			validate_item_type(self, "is_sub_contracted_item", "subcontracted")
 		else:
 			validate_item_type(self, "is_purchase_item", "purchase")
+
+	def autoname(self):
+		if self.doctype in ['Purchase Receipt', 'Purchase Invoice'] and self.is_return:
+			self.name = make_autoname(self.return_naming_series)
 
 def get_items_from_bom(item_code, bom, exploded_item=1):
 	doctype = "BOM Item" if not exploded_item else "BOM Explosion Item"

--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -10,6 +10,7 @@ from erpnext.stock.utils import get_incoming_rate
 from erpnext.stock.get_item_details import get_conversion_factor
 from erpnext.stock.doctype.item.item import set_item_default
 from frappe.contacts.doctype.address.address import get_address_display
+from frappe.model.naming import make_autoname
 
 from erpnext.controllers.stock_controller import StockController
 
@@ -417,6 +418,10 @@ class SellingController(StockController):
 		# validate items to see if they have is_sales_item enabled
 		from erpnext.controllers.buying_controller import validate_item_type
 		validate_item_type(self, "is_sales_item", "sales")
+
+	def autoname(self):
+		if self.doctype in ['Sales Invoice', 'Delivery Note'] and self.is_return:
+			self.name = make_autoname(self.return_naming_series)
 
 def set_default_income_account_for_item(obj):
 	for d in obj.get("items"):

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -237,6 +237,9 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 	},
 
 	is_return: function() {
+		if(this.frm.doc.is_return) {
+			frm.fields_dict.naming_series = this.frm.doc.return_naming_series;
+		}
 		if(!this.frm.doc.is_return && this.frm.doc.return_against) {
 			this.frm.set_value('return_against', '');
 		}

--- a/erpnext/stock/doctype/delivery_note/delivery_note.json
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.json
@@ -11,6 +11,7 @@
   "column_break0",
   "title",
   "naming_series",
+  "return_naming_series",
   "customer",
   "customer_name",
   "column_break1",
@@ -101,6 +102,8 @@
   "terms_section_break",
   "tc_name",
   "terms",
+  "payment_terms_section",
+  "payment_schedule",
   "transporter_info",
   "transporter",
   "driver",
@@ -169,6 +172,7 @@
    "print_hide": 1
   },
   {
+   "depends_on": "eval: doc.is_return === 0",
    "fieldname": "naming_series",
    "fieldtype": "Select",
    "label": "Series",
@@ -1249,13 +1253,36 @@
    "fieldtype": "Link",
    "label": "Inter Company Reference",
    "options": "Purchase Receipt"
+  },
+  {
+   "bold": 1,
+   "depends_on": "eval: doc.is_return === 1",
+   "fieldname": "return_naming_series",
+   "fieldtype": "Select",
+   "label": "Return Series",
+   "no_copy": 1,
+   "options": "MAT-DN-RET-.YYYY.-",
+   "print_hide": 1,
+   "reqd": 1,
+   "set_only_once": 1
+  },
+  {
+   "fieldname": "payment_terms_section",
+   "fieldtype": "Section Break",
+   "label": "Payment Terms"
+  },
+  {
+   "fieldname": "payment_schedule",
+   "fieldtype": "Table",
+   "label": "Payment Schedule",
+   "options": "Payment Schedule"
   }
  ],
  "icon": "fa fa-truck",
  "idx": 146,
  "is_submittable": 1,
  "links": [],
- "modified": "2020-07-18 05:13:55.580420",
+ "modified": "2020-08-02 23:20:17.032352",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Note",

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.json
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.json
@@ -1,7 +1,6 @@
 {
  "actions": [],
  "allow_import": 1,
- "allow_workflow": 1,
  "autoname": "naming_series:",
  "creation": "2013-05-21 16:16:39",
  "doctype": "DocType",
@@ -13,6 +12,7 @@
   "column_break0",
   "title",
   "naming_series",
+  "return_naming_series",
   "supplier",
   "supplier_name",
   "supplier_delivery_note",
@@ -154,6 +154,7 @@
    "print_hide": 1
   },
   {
+   "depends_on": "eval: doc.is_return === 0",
    "fieldname": "naming_series",
    "fieldtype": "Select",
    "label": "Series",
@@ -1104,13 +1105,25 @@
    "fieldtype": "Small Text",
    "label": "Billing Address",
    "read_only": 1
+  },
+  {
+   "bold": 1,
+   "depends_on": "eval: doc.is_return === 1",
+   "fieldname": "return_naming_series",
+   "fieldtype": "Select",
+   "label": "Return Series",
+   "no_copy": 1,
+   "options": "MAT-PR-RET-.YYYY.-",
+   "print_hide": 1,
+   "reqd": 1,
+   "set_only_once": 1
   }
  ],
  "icon": "fa fa-truck",
  "idx": 261,
  "is_submittable": 1,
  "links": [],
- "modified": "2020-07-18 05:19:12.148115",
+ "modified": "2020-08-03 00:30:04.208217",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Purchase Receipt",


### PR DESCRIPTION
**Issue -** The naming series for Sales return is same as the Sales invoice. It should be distinguishing!

**Fix-**
Introduce a default naming series for return entries. So, in Sales Invoice, Delivery Note, Purchase Receipt, and Purchase Invoice, there will 2 series by default.

- Sales Invoice: ACC-SINV-RET-.YYYY.-
- Delivery Note: MAT-DN-RET-.YYYY.-
- Purchase Invoice:  ACC-PINV-RET-.YYYY.-
- Purchase Receipt: MAT-PR-RET-.YYYY.-