### PR TITLE
fix: Misleading description in Warehouse

### DIFF
--- a/erpnext/stock/doctype/warehouse/warehouse.json
+++ b/erpnext/stock/doctype/warehouse/warehouse.json
@@ -45,7 +45,6 @@
    "oldfieldtype": "Section Break"
   },
   {
-   "description": "If blank, parent Warehouse Account or company default will be considered",
    "fieldname": "warehouse_name",
    "fieldtype": "Data",
    "label": "Warehouse Name",
@@ -236,7 +235,7 @@
  "idx": 1,
  "is_tree": 1,
  "links": [],
- "modified": "2020-07-16 15:43:50.653256",
+ "modified": "2020-08-03 11:19:35.943330",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Warehouse",


### PR DESCRIPTION
- Removed this description as it was misleading. Warehouse Name has to be unique
 ![Screenshot 2020-08-03 at 11 22 13 AM](https://user-images.githubusercontent.com/25857446/89149785-f3b9fc00-d57a-11ea-98b2-7358c9191849.png)
