### PR TITLE
fix: Bank Clearance of POS purchase invoice

### DIFF
--- a/erpnext/accounts/doctype/bank_clearance/bank_clearance.py
+++ b/erpnext/accounts/doctype/bank_clearance/bank_clearance.py
@@ -60,12 +60,12 @@ class BankClearance(Document):
 		""".format(condition=condition), {"account": self.account, "from":self.from_date,
 				"to": self.to_date, "bank_account": self.bank_account}, as_dict=1)
 
-		pos_entries = []
+		pos_sales_invoices, pos_purchase_invoices = [], []
 		if self.include_pos_transactions:
-			pos_entries = frappe.db.sql("""
+			pos_sales_invoices = frappe.db.sql("""
 				select
 					"Sales Invoice Payment" as payment_document, sip.name as payment_entry, sip.amount as debit,
-					si.posting_date, si.debit_to as against_account, sip.clearance_date,
+					si.posting_date, si.customer as against_account, sip.clearance_date,
 					account.account_currency, 0 as credit
 				from `tabSales Invoice Payment` sip, `tabSales Invoice` si, `tabAccount` account
 				where
@@ -75,7 +75,20 @@ class BankClearance(Document):
 					si.posting_date ASC, si.name DESC
 			""", {"account":self.account, "from":self.from_date, "to":self.to_date}, as_dict=1)
 
-		entries = sorted(list(payment_entries)+list(journal_entries+list(pos_entries)),
+			pos_purchase_invoices = frappe.db.sql("""
+				select
+					"Purchase Invoice" as payment_document, pi.name as payment_entry, pi.paid_amount as credit,
+					pi.posting_date, pi.supplier as against_account, pi.clearance_date,
+					account.account_currency, 0 as debit
+				from `tabPurchase Invoice` pi, `tabAccount` account
+				where
+					pi.cash_bank_account=%(account)s and pi.docstatus=1 and account.name = pi.cash_bank_account
+					and pi.posting_date >= %(from)s and pi.posting_date <= %(to)s
+				order by
+					pi.posting_date ASC, pi.name DESC
+			""", {"account": self.account, "from": self.from_date, "to": self.to_date}, as_dict=1)
+
+		entries = sorted(list(payment_entries) + list(journal_entries + list(pos_sales_invoices) + list(pos_purchase_invoices)),
 			key=lambda k: k['posting_date'] or getdate(nowdate()))
 
 		self.set('payment_entries', [])

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
@@ -969,8 +969,10 @@
   {
    "fieldname": "clearance_date",
    "fieldtype": "Date",
-   "hidden": 1,
-   "label": "Clearance Date"
+   "label": "Clearance Date",
+   "no_copy": 1,
+   "print_hide": 1,
+   "read_only": 1
   },
   {
    "fieldname": "col_br_payments",
@@ -1332,7 +1334,7 @@
  "idx": 204,
  "is_submittable": 1,
  "links": [],
- "modified": "2020-07-24 09:46:40.405463",
+ "modified": "2020-08-03 12:46:01.411074",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Purchase Invoice",

--- a/erpnext/accounts/doctype/sales_invoice_payment/sales_invoice_payment.json
+++ b/erpnext/accounts/doctype/sales_invoice_payment/sales_invoice_payment.json
@@ -64,6 +64,7 @@
    "fieldname": "clearance_date",
    "fieldtype": "Date",
    "label": "Clearance Date",
+   "no_copy": 1,
    "print_hide": 1,
    "read_only": 1
   },
@@ -78,7 +79,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2020-05-05 16:51:20.091441",
+ "modified": "2020-08-03 12:45:39.986598",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice Payment",


### PR DESCRIPTION
POS Purchase Invoice was not getting fetched in the Bank Clearance form for updating the clearance date.