### PR TITLE
fix: TypeError while concatenating account number and name in COA

### DIFF
--- a/erpnext/accounts/doctype/account/chart_of_accounts/chart_of_accounts.py
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/chart_of_accounts.py
@@ -225,7 +225,7 @@ def build_tree_from_json(chart_template, chart_data=None):
 
 			account['parent_account'] = parent
 			account['expandable'] = True if identify_is_group(child) else False
-			account['value'] = (child.get('account_number') + ' - ' + account_name) \
+			account['value'] = (cstr(child.get('account_number')).strip() + ' - ' + account_name) \
 				if child.get('account_number') else account_name
 			accounts.append(account)
 			_import_accounts(child, account['value'])


### PR DESCRIPTION
Backport: https://github.com/frappe/erpnext/pull/22885

TypeError while concatenating account number and name in COA:

```python
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-13-2020-07-03/apps/frappe/frappe/app.py", line 64, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-13-2020-07-03/apps/frappe/frappe/api.py", line 58, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-13-2020-07-03/apps/frappe/frappe/handler.py", line 30, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-13-2020-07-03/apps/frappe/frappe/handler.py", line 69, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-13-2020-07-03/apps/frappe/frappe/__init__.py", line 1085, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-13-2020-07-03/apps/erpnext/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py", line 117, in get_coa
    accounts = build_tree_from_json("", chart_data=forest) # returns alist of dict in a tree render-able form
  File "/home/frappe/benches/bench-version-13-2020-07-03/apps/erpnext/erpnext/accounts/doctype/account/chart_of_accounts/chart_of_accounts.py", line 233, in build_tree_from_json
    _import_accounts(chart, None)
  File "/home/frappe/benches/bench-version-13-2020-07-03/apps/erpnext/erpnext/accounts/doctype/account/chart_of_accounts/chart_of_accounts.py", line 229, in _import_accounts
    if child.get('account_number') else account_name
TypeError: unsupported operand type(s) for +: 'int' and 'str'
```