### PR TITLE
fix: Reposition description in Warehouse

### DIFF
--- a/erpnext/stock/doctype/warehouse/warehouse.json
+++ b/erpnext/stock/doctype/warehouse/warehouse.json
@@ -85,6 +85,7 @@
    "fieldtype": "Column Break"
   },
   {
+   "description": "If blank, parent Warehouse Account or company default will be considered in transactions",
    "fieldname": "account",
    "fieldtype": "Link",
    "label": "Account",
@@ -235,7 +236,7 @@
  "idx": 1,
  "is_tree": 1,
  "links": [],
- "modified": "2020-08-03 11:19:35.943330",
+ "modified": "2020-08-03 18:41:52.442502",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Warehouse",


### PR DESCRIPTION
After removing description from under warehouse name in https://github.com/frappe/erpnext/pull/22877 , description was intended for Account field.
![Screenshot 2020-08-03 at 7 00 54 PM](https://user-images.githubusercontent.com/25857446/89187562-1966f580-d5bb-11ea-823f-4d2c0688227c.png)
