### PR TITLE
fix: get_regional_address_details missing positional arg 'company'

### DIFF
--- a/erpnext/regional/india/taxes.js
+++ b/erpnext/regional/india/taxes.js
@@ -10,6 +10,8 @@ erpnext.setup_auto_gst_taxation = (doctype) => {
 			frm.trigger('get_tax_template');
 		},
 		get_tax_template: function(frm) {
+			if (!frm.doc.company) return;
+
 			let party_details = {
 				'shipping_address': frm.doc.shipping_address || '',
 				'shipping_address_name': frm.doc.shipping_address_name || '',


### PR DESCRIPTION
**Issue:**
If no company Purchase Order and you try to set a tax category, this happens:
```Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2020-07-22/apps/frappe/frappe/app.py", line 64, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-12-2020-07-22/apps/frappe/frappe/api.py", line 59, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-12-2020-07-22/apps/frappe/frappe/handler.py", line 24, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-12-2020-07-22/apps/frappe/frappe/handler.py", line 63, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-12-2020-07-22/apps/frappe/frappe/__init__.py", line 1054, in call
    return fn(*args, **newargs)
TypeError: get_regional_address_details() missing 1 required positional argument: 'company'```