### PR TITLE
fix: condition for checking reference details for Payment Entry

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -897,7 +897,7 @@ def get_reference_details(reference_doctype, reference_name, party_account_curre
 		total_amount = ref_doc.get("grand_total")
 		exchange_rate = 1
 		outstanding_amount = ref_doc.get("outstanding_amount")
-	if reference_doctype == "Dunning":
+	elif reference_doctype == "Dunning":
 		total_amount = ref_doc.get("dunning_amount")
 		exchange_rate = 1
 		outstanding_amount = ref_doc.get("dunning_amount")
@@ -1101,7 +1101,7 @@ def get_payment_entry(dt, dn, party_amount=None, bank_account=None, bank_amount=
 					'outstanding_amount': doc.get('dunning_amount'),
 					'allocated_amount': doc.get('dunning_amount')
 				})
-			else:	
+			else:
 				pe.append("references", {
 					'reference_doctype': dt,
 					'reference_name': dn,


### PR DESCRIPTION
**Before:**

`get_reference_details` failing for payment entry of Fees

```python
Traceback (most recent call last):
  File "/Users/ruchamahabal/dev-bench/apps/frappe/frappe/app.py", line 64, in application
    response = frappe.api.handle()
  File "/Users/ruchamahabal/dev-bench/apps/frappe/frappe/api.py", line 58, in handle
    return frappe.handler.handle()
  File "/Users/ruchamahabal/dev-bench/apps/frappe/frappe/handler.py", line 30, in handle
    data = execute_cmd(cmd)
  File "/Users/ruchamahabal/dev-bench/apps/frappe/frappe/handler.py", line 69, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/ruchamahabal/dev-bench/apps/frappe/frappe/__init__.py", line 1086, in call
    return fn(*args, **newargs)
  File "/Users/ruchamahabal/dev-bench/apps/erpnext/erpnext/accounts/doctype/payment_entry/payment_entry.py", line 1116, in get_payment_entry
    pe.set_missing_values()
  File "/Users/ruchamahabal/dev-bench/apps/erpnext/erpnext/accounts/doctype/payment_entry/payment_entry.py", line 168, in set_missing_values
    self.set_missing_ref_details()
  File "/Users/ruchamahabal/dev-bench/apps/erpnext/erpnext/accounts/doctype/payment_entry/payment_entry.py", line 174, in set_missing_ref_details
    d.reference_name, self.party_account_currency)
  File "/Users/ruchamahabal/dev-bench/apps/erpnext/erpnext/accounts/doctype/payment_entry/payment_entry.py", line 918, in get_reference_details
    total_amount = ref_doc.base_grand_total
AttributeError: 'Fees' object has no attribute 'base_grand_total'
```

**After:**

![fees](https://user-images.githubusercontent.com/24353136/89414730-83f96c00-d748-11ea-9bc7-e44402106834.gif)
