### PR TITLE
fix: unbound error in product configurator 61b9727

### DIFF
--- a/erpnext/portal/product_configurator/utils.py
+++ b/erpnext/portal/product_configurator/utils.py
@@ -261,12 +261,14 @@ def get_next_attribute_and_values(item_code, selected_attributes):
 	if exact_match:
 		data = get_product_info_for_website(exact_match[0])
 		product_info = data.product_info
+		if product_info:
+			product_info["allow_items_not_in_stock"] = cint(data.cart_settings.allow_items_not_in_stock)
 		if not data.cart_settings.show_price:
 			product_info = None
 	else:
 		product_info = None
 
-	product_info["allow_items_not_in_stock"] = cint(data.cart_settings.allow_items_not_in_stock)
+
 
 	return {
 		'next_attribute': next_attribute,


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 61, in application
    response = frappe.handler.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 24, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 63, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1054, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/portal/product_configurator/utils.py", line 269, in get_next_attribute_and_values
    product_info["allow_items_not_in_stock"] = cint(data.cart_settings.allow_items_not_in_stock)
UnboundLocalError: local variable 'data' referenced before assignment
```