### PR TITLE
fix: escape company field

### DIFF
--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -611,7 +611,7 @@ def get_partywise_advanced_payment_amount(party_type, posting_date = None, futur
 			cond = "posting_date <= '{0}'".format(posting_date)
 
 	if company:
-		cond += "and company = '{0}'".format(company)
+		cond += "and company = '{0}'".format(frappe.db.escape(company))
 
 	data = frappe.db.sql(""" SELECT party, sum({0}) as amount
 		FROM `tabGL Entry`


### PR DESCRIPTION
Traceback:

```python
Syntax error in query:
 SELECT party, sum(debit) as amount
		FROM `tabGL Entry`
		WHERE
			party_type = %s and against_voucher is null
			and posting_date <= '2020-08-07'and company = 'Nature's Legacy' GROUP BY party
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-13-2020-07-03/apps/frappe/frappe/app.py", line 64, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-13-2020-07-03/apps/frappe/frappe/api.py", line 58, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-13-2020-07-03/apps/frappe/frappe/handler.py", line 30, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-13-2020-07-03/apps/frappe/frappe/handler.py", line 69, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-13-2020-07-03/apps/frappe/frappe/__init__.py", line 1085, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-13-2020-07-03/apps/frappe/frappe/__init__.py", line 545, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "/home/frappe/benches/bench-version-13-2020-07-03/apps/frappe/frappe/desk/query_report.py", line 183, in run
    result = generate_report_result(report, filters, user, custom_columns)
  File "/home/frappe/benches/bench-version-13-2020-07-03/apps/frappe/frappe/desk/query_report.py", line 59, in generate_report_result
    res = report.execute_script_report(filters)
  File "/home/frappe/benches/bench-version-13-2020-07-03/apps/frappe/frappe/core/doctype/report/report.py", line 116, in execute_script_report
    res = self.execute_module(filters)
  File "/home/frappe/benches/bench-version-13-2020-07-03/apps/frappe/frappe/core/doctype/report/report.py", line 133, in execute_module
    return frappe.get_attr(method_name)(frappe._dict(filters))
  File "/home/frappe/benches/bench-version-13-2020-07-03/apps/erpnext/erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.py", line 14, in execute
    return AccountsReceivableSummary(filters).run(args)
  File "/home/frappe/benches/bench-version-13-2020-07-03/apps/erpnext/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py", line 25, in run
    self.get_data(args)
  File "/home/frappe/benches/bench-version-13-2020-07-03/apps/erpnext/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py", line 36, in get_data
    self.filters.report_date, self.filters.show_future_payments, self.filters.company) or {}
  File "/home/frappe/benches/bench-version-13-2020-07-03/apps/erpnext/erpnext/accounts/party.py", line 621, in get_partywise_advanced_payment_amount
    .format(("credit") if party_type == "Customer" else "debit", cond) , party_type)
  File "/home/frappe/benches/bench-version-13-2020-07-03/apps/frappe/frappe/database/database.py", line 158, in sql
    self._cursor.execute(query, values)
  File "/home/frappe/benches/bench-version-13-2020-07-03/env/lib/python3.6/site-packages/pymysql/cursors.py", line 170, in execute
    result = self._query(query)
  File "/home/frappe/benches/bench-version-13-2020-07-03/env/lib/python3.6/site-packages/pymysql/cursors.py", line 328, in _query
    conn.query(q)
  File "/home/frappe/benches/bench-version-13-2020-07-03/env/lib/python3.6/site-packages/pymysql/connections.py", line 517, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/home/frappe/benches/bench-version-13-2020-07-03/env/lib/python3.6/site-packages/pymysql/connections.py", line 732, in _read_query_result
    result.read()
  File "/home/frappe/benches/bench-version-13-2020-07-03/env/lib/python3.6/site-packages/pymysql/connections.py", line 1075, in read
    first_packet = self.connection._read_packet()
  File "/home/frappe/benches/bench-version-13-2020-07-03/env/lib/python3.6/site-packages/pymysql/connections.py", line 684, in _read_packet
    packet.check_error()
  File "/home/frappe/benches/bench-version-13-2020-07-03/env/lib/python3.6/site-packages/pymysql/protocol.py", line 220, in check_error
    err.raise_mysql_exception(self._data)
  File "/home/frappe/benches/bench-version-13-2020-07-03/env/lib/python3.6/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.ProgrammingError: (1064, "You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 's Legacy' GROUP BY party' at line 5")
```