### PR TITLE
fix(leave alloc): update ledger leaves after submit

### DIFF
--- a/erpnext/hr/doctype/leave_allocation/leave_allocation.py
+++ b/erpnext/hr/doctype/leave_allocation/leave_allocation.py
@@ -49,6 +49,9 @@ class LeaveAllocation(Document):
 		if self.carry_forward and allocation:
 			expire_allocation(allocation)
 
+	def on_update_after_submit(self):
+		update_ledger_leaves(self.name, self.total_leaves_allocated)
+
 	def on_cancel(self):
 		self.create_leave_ledger_entry(submit=False)
 		if self.carry_forward:
@@ -221,3 +224,9 @@ def get_unused_leaves(employee, leave_type, from_date, to_date):
 def validate_carry_forward(leave_type):
 	if not frappe.db.get_value("Leave Type", leave_type, "is_carry_forward"):
 		frappe.throw(_("Leave Type {0} cannot be carry-forwarded").format(leave_type))
+
+def update_ledger_leaves(name, total_leaves_allocated):
+	ledger = frappe.get_doc("Leave Ledger Entry", { 'transaction_name': name })
+	ledger.leaves = total_leaves_allocated
+	ledger.save()
+	frappe.db.commit()

--- a/erpnext/hr/doctype/leave_ledger_entry/leave_ledger_entry.json
+++ b/erpnext/hr/doctype/leave_ledger_entry/leave_ledger_entry.json
@@ -1,5 +1,4 @@
 {
- "actions": [],
  "creation": "2019-05-09 15:47:39.760406",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -64,10 +63,12 @@
    "options": "transaction_type"
   },
   {
+   "allow_on_submit": 1,
    "fieldname": "leaves",
    "fieldtype": "Float",
    "in_list_view": 1,
-   "label": "Leaves"
+   "label": "Leaves",
+   "read_only": 1
   },
   {
    "fieldname": "from_date",
@@ -110,8 +111,7 @@
  ],
  "in_create": 1,
  "is_submittable": 1,
- "links": [],
- "modified": "2020-02-27 14:40:10.502605",
+ "modified": "2020-08-10 05:19:11.024643",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Leave Ledger Entry",


### PR DESCRIPTION
Closes #20961

This fixes the issue wherein if the `Total Leaves Allocated ` of `Leave Allocation` is updated via `Add Unused Leaves from Previous Allocations` checkbox, it will **not** update the `Leaves` field in the `Leave Ledger Entry`

## FIX (Screenshots)
### Before update (Leave Allocation)
![image](https://user-images.githubusercontent.com/17470909/89749378-080d7400-dafa-11ea-8c8e-b01996fb138a.png)

### Before update (Leave Ledger Entry)
![image](https://user-images.githubusercontent.com/17470909/89749755-a9e19080-dafb-11ea-8a30-0793e5f59833.png)

### Before update (Leave Application Dashboard)
<img width="907" alt="New Leave Application 1 - New Leave Application 1 2020-08-10 11-37-21" src="https://user-images.githubusercontent.com/17470909/89750314-0b0a6380-dafe-11ea-950a-c282bd0bc8e0.png">

### After update (Leave Allocation)
By checking `Add Unused Leaves from Previous Allocations`
![image](https://user-images.githubusercontent.com/17470909/89749456-5fabdf80-dafa-11ea-9c37-e5835f81b5f1.png)

### After update (Leave Ledger Entry)
![image](https://user-images.githubusercontent.com/17470909/89749847-13619f00-dafc-11ea-8899-b4b1f452c75c.png)

### After update (Leave Application Dashboard)
<img width="924" alt="New Leave Application 1 - New Leave Application 1 2020-08-10 11-40-10" src="https://user-images.githubusercontent.com/17470909/89750378-502e9580-dafe-11ea-8b35-731ec8e4adf8.png">