### PR TITLE
fix: failing Fees test

### DIFF
--- a/erpnext/education/doctype/fees/test_fees.py
+++ b/erpnext/education/doctype/fees/test_fees.py
@@ -7,7 +7,7 @@ import frappe
 import unittest
 from frappe.utils import nowdate
 from frappe.utils.make_random import get_random
-
+from erpnext.education.doctype.program.test_program import make_program_and_linked_courses
 
 # test_records = frappe.get_test_records('Fees')
 
@@ -15,6 +15,7 @@ class TestFees(unittest.TestCase):
 
 	def test_fees(self):
 		student = get_random("Student")
+		program = make_program_and_linked_courses("_Test Program 1", ["_Test Course 1", "_Test Course 2"])
 		fee = frappe.new_doc("Fees")
 		fee.posting_date = nowdate()
 		fee.due_date = nowdate()
@@ -23,6 +24,7 @@ class TestFees(unittest.TestCase):
 		fee.income_account = "Sales - _TC"
 		fee.cost_center = "_Test Cost Center - _TC"
 		fee.company = "_Test Company"
+		fee.program = program.name
 
 		fee.extend("components", [
 			{


### PR DESCRIPTION
**Failing test:**

```python
ERROR: test_fees (erpnext.education.doctype.fees.test_fees.TestFees)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/frappe-bench/apps/erpnext/erpnext/education/doctype/fees/test_fees.py", line 36, in test_fees
    fee.save()
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 281, in save
    return self._save(*args, **kwargs)
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 303, in _save
    self.insert()
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 232, in insert
    self._validate()
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 489, in _validate
    self._validate_mandatory()
  File "/home/travis/frappe-bench/apps/frappe/frappe/model/document.py", line 780, in _validate_mandatory
    name=self.name))
frappe.exceptions.MandatoryError: [Fees, EDU-FEE-2020-00001]: program
```

**After:**

![fix-fees](https://user-images.githubusercontent.com/24353136/89757544-35125480-db03-11ea-8ac2-0464fefe94d9.png)

