### PR TITLE
fix: Creating opportunity from email

### DIFF
--- a/erpnext/crm/doctype/opportunity/opportunity.py
+++ b/erpnext/crm/doctype/opportunity/opportunity.py
@@ -330,7 +330,7 @@ def make_opportunity_from_communication(communication, ignore_communication_link
 	opportunity = frappe.get_doc({
 		"doctype": "Opportunity",
 		"opportunity_from": opportunity_from,
-		"lead": lead
+		"party_name": lead
 	}).insert(ignore_permissions=True)
 
 	link_communication_to_document(doc, "Opportunity", opportunity.name, ignore_communication_links)

--- a/erpnext/public/js/communication.js
+++ b/erpnext/public/js/communication.js
@@ -13,7 +13,7 @@ frappe.ui.form.on("Communication", {
 				frappe.confirm(__(confirm_msg, [__("Issue")]), () => {
 					frm.trigger('make_issue_from_communication');
 				})
-			}, "Make");
+			}, "Create");
 		}
 
 		if(!in_list(["Lead", "Opportunity"], frm.doc.reference_doctype)) {


### PR DESCRIPTION
**Issue:**
- On trying to create an Opportunity from a Communication
  ![email](https://user-images.githubusercontent.com/25857446/89759196-3e052500-db07-11ea-80ce-559359683ff2.png)

**Fix**
- Lead name should be populated in field **party_name** on creating oportunity
- Added **Issue** from under **Make** button to **Create** to reduce redundant buttons