### PR TITLE
fix: Consistent capitalization

### DIFF
--- a/erpnext/setup/doctype/company/company.json
+++ b/erpnext/setup/doctype/company/company.json
@@ -242,7 +242,7 @@
   {
    "fieldname": "default_warehouse_for_sales_return",
    "fieldtype": "Link",
-   "label": "Default warehouse for Sales Return",
+   "label": "Default Warehouse for Sales Return",
    "options": "Warehouse"
   },
   {


### PR DESCRIPTION
Will replace "warehouse" with "Warehouse" in "Source warehouse for Sales Return"