### PR TITLE
fix: escape fields for Payroll Entry

### DIFF
--- a/erpnext/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/erpnext/payroll/doctype/payroll_entry/payroll_entry.py
@@ -90,7 +90,7 @@ class PayrollEntry(Document):
 		cond = ''
 		for f in ['company', 'branch', 'department', 'designation']:
 			if self.get(f):
-				cond += " and t1." + f + " = '" + self.get(f).replace("'", "\'") + "'"
+				cond += " and t1." + f + " = " + frappe.db.escape(self.get(f))
 
 		return cond
 


### PR DESCRIPTION
```python
Syntax error in query:
request.js:356 
				select
					distinct t1.name as employee, t1.employee_name, t1.department, t1.designation
				from
					`tabEmployee` t1, `tabSalary Structure Assignment` t2
				where
					t1.name = t2.employee
					and t2.docstatus = 1
			 and t1.company = 'Nature's Legacy'
			and coalesce(t1.date_of_joining, '0000-00-00') <= '2020-07-15'
			and coalesce(t1.relieving_date, '2199-12-31') >= '2020-07-01'
		and t2.salary_structure IN %(sal_struct)s and %(from_date)s >= t2.from_date order by t2.from_date desc
			
request.js:356 Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-13-2020-08-07/apps/frappe/frappe/app.py", line 64, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-13-2020-08-07/apps/frappe/frappe/api.py", line 58, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-13-2020-08-07/apps/frappe/frappe/handler.py", line 30, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-13-2020-08-07/apps/frappe/frappe/handler.py", line 69, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-13-2020-08-07/apps/frappe/frappe/__init__.py", line 1086, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-13-2020-08-07/apps/frappe/frappe/handler.py", line 97, in runserverobj
    frappe.desk.form.run_method.runserverobj(method, docs=docs, dt=dt, dn=dn, arg=arg, args=args)
  File "/home/frappe/benches/bench-version-13-2020-08-07/apps/frappe/frappe/desk/form/run_method.py", line 43, in runserverobj
    r = doc.run_method(method)
  File "/home/frappe/benches/bench-version-13-2020-08-07/apps/frappe/frappe/model/document.py", line 827, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-version-13-2020-08-07/apps/frappe/frappe/model/document.py", line 1119, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-version-13-2020-08-07/apps/frappe/frappe/model/document.py", line 1102, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-version-13-2020-08-07/apps/frappe/frappe/model/document.py", line 821, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-version-13-2020-08-07/apps/erpnext/erpnext/payroll/doctype/payroll_entry/payroll_entry.py", line 76, in fill_employee_details
    employees = self.get_emp_list()
  File "/home/frappe/benches/bench-version-13-2020-08-07/apps/erpnext/erpnext/payroll/doctype/payroll_entry/payroll_entry.py", line 71, in get_emp_list
    """ % cond, {"sal_struct": tuple(sal_struct), "from_date": self.end_date}, as_dict=True)
  File "/home/frappe/benches/bench-version-13-2020-08-07/apps/frappe/frappe/database/database.py", line 158, in sql
    self._cursor.execute(query, values)
  File "/home/frappe/benches/bench-version-13-2020-08-07/env/lib/python3.6/site-packages/pymysql/cursors.py", line 170, in execute
    result = self._query(query)
  File "/home/frappe/benches/bench-version-13-2020-08-07/env/lib/python3.6/site-packages/pymysql/cursors.py", line 328, in _query
    conn.query(q)
  File "/home/frappe/benches/bench-version-13-2020-08-07/env/lib/python3.6/site-packages/pymysql/connections.py", line 517, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/home/frappe/benches/bench-version-13-2020-08-07/env/lib/python3.6/site-packages/pymysql/connections.py", line 732, in _read_query_result
    result.read()
  File "/home/frappe/benches/bench-version-13-2020-08-07/env/lib/python3.6/site-packages/pymysql/connections.py", line 1075, in read
    first_packet = self.connection._read_packet()
  File "/home/frappe/benches/bench-version-13-2020-08-07/env/lib/python3.6/site-packages/pymysql/connections.py", line 684, in _read_packet
    packet.check_error()
  File "/home/frappe/benches/bench-version-13-2020-08-07/env/lib/python3.6/site-packages/pymysql/protocol.py", line 220, in check_error
    err.raise_mysql_exception(self._data)
  File "/home/frappe/benches/bench-version-13-2020-08-07/env/lib/python3.6/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.ProgrammingError: (1064, "You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 's Legacy'\n\t\t\tand coalesce(t1.date_of_joining, '0000-00-00') <= '2020-07-15'\n\t\t\ta' at line 8")
```
