### PR TITLE
fix: spacing for slideshow

### DIFF
--- a/erpnext/public/less/website.less
+++ b/erpnext/public/less/website.less
@@ -297,6 +297,10 @@
 	margin-top: 30px;
 }
 
+.item-group-slideshow {
+	margin-bottom: 1rem;
+}
+
 .product-image-img {
 	border: 1px solid @light-border-color;
 	border-radius: 3px;

--- a/erpnext/templates/generators/item_group.html
+++ b/erpnext/templates/generators/item_group.html
@@ -4,7 +4,7 @@
 
 {% block page_content %}
 <div class="item-group-content" itemscope itemtype="http://schema.org/Product">
-	<div>
+	<div class="item-group-slideshow">
 		{% if slideshow %}<!-- slideshow -->
 		{% include "templates/includes/slideshow.html" %}
 		{% endif %}


### PR DESCRIPTION
Fix spacing below slideshow in item group page

### Before Fix
<img width="400" alt="Screen Shot 2020-08-11 at 3 08 24 PM" src="https://user-images.githubusercontent.com/18097732/89882678-c7d6f000-dbe4-11ea-99c2-ac07e30ef289.png">

### After Fix
<img width="400" alt="Screen Shot 2020-08-11 at 3 08 12 PM" src="https://user-images.githubusercontent.com/18097732/89882695-cdccd100-dbe4-11ea-9f7b-ff6a722abc7a.png">
