### PR TITLE
fix(CRM): Change Opportunity to 'Converted' when Sales Order is created

### DIFF
--- a/erpnext/crm/doctype/opportunity/opportunity.py
+++ b/erpnext/crm/doctype/opportunity/opportunity.py
@@ -119,11 +119,19 @@ class Opportunity(TransactionBase):
 				and q.status not in ('Lost', 'Closed')""", self.name)
 
 	def has_ordered_quotation(self):
-		return frappe.db.sql("""
-			select q.name
-			from `tabQuotation` q, `tabQuotation Item` qi
-			where q.name = qi.parent and q.docstatus=1 and qi.prevdoc_docname =%s
-			and q.status = 'Ordered'""", self.name)
+		if not self.with_items:
+			return frappe.get_all('Quotation',
+				{
+					'opportunity': self.name,
+					'status': 'Ordered',
+					'docstatus': 1
+				}, 'name')
+		else:
+			return frappe.db.sql("""
+				select q.name
+				from `tabQuotation` q, `tabQuotation Item` qi
+				where q.name = qi.parent and q.docstatus=1 and qi.prevdoc_docname =%s
+				and q.status = 'Ordered'""", self.name)
 
 	def has_lost_quotation(self):
 		lost_quotation = frappe.db.sql("""


### PR DESCRIPTION
Issue:

- Opportunity is created
- When Opportunity is converted into Quotation, the status of Opportunity changes to "Quotation"
- When Quotation is converted into "Sales Order", Status of Opportunity should convert to "Converted".

Solution:

This was happening when Items are not added from the Opportunity itself, due to which the linking in the 
Quotation Item table was not happening properly.

Notice the last entry, the field for linking is not set as items were not added from Opportunity using "With Items".

![image](https://user-images.githubusercontent.com/15175501/89884405-23a27880-dbe7-11ea-86af-b08ffe6fcc26.png)

This fix adds a provision to find the opportunity linked to a Quotation with different logic when items are not selected
in the Opportunity.