### PR TITLE
fix: add company in list fields to fetch for Expense Claim

### DIFF
--- a/erpnext/hr/doctype/expense_claim/expense_claim_list.js
+++ b/erpnext/hr/doctype/expense_claim/expense_claim_list.js
@@ -1,5 +1,5 @@
 frappe.listview_settings['Expense Claim'] = {
-	add_fields: ["total_claimed_amount", "docstatus"],
+	add_fields: ["total_claimed_amount", "docstatus", "company"],
 	get_indicator: function(doc) {
 		if(doc.status == "Paid") {
 			return [__("Paid"), "green", "status,=,Paid"];


### PR DESCRIPTION
Fixes:
![expense claim currency fix](https://user-images.githubusercontent.com/19775888/89981297-438e7680-dc91-11ea-83a7-5e66a5ba7da9.gif)


The issue occurs because the doc passed to `format` in list view doesn't contain the company field. Because of this code - https://github.com/frappe/frappe/blob/5549efa87a99e909c50f2ab9fe0375c2e2debc3c/frappe/public/js/frappe/model/meta.js#L236-L242,
since the form object exists, docname is the same for all the list rows (the company set in the form object).