### PR TITLE
fix: don't set asset maintenance log status as Overdue when Completed or Cancelled

### DIFF
--- a/erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log.py
+++ b/erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log.py
@@ -11,7 +11,7 @@ from erpnext.assets.doctype.asset_maintenance.asset_maintenance import calculate
 
 class AssetMaintenanceLog(Document):
 	def validate(self):
-		if getdate(self.due_date) < getdate(nowdate()):
+		if getdate(self.due_date) < getdate(nowdate()) and self.maintenance_status not in ["Completed", "Cancelled"]:
 			self.maintenance_status = "Overdue"
 
 		if self.maintenance_status == "Completed" and not self.completion_date:

--- a/erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log_list.js
+++ b/erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log_list.js
@@ -1,14 +1,15 @@
 frappe.listview_settings['Asset Maintenance Log'] = {
 	add_fields: ["maintenance_status"],
+	has_indicator_for_draft: 1,
 	get_indicator: function(doc) {
-		if(doc.maintenance_status=="Pending") {
-			return [__("Pending"), "orange"];
-		} else if(doc.maintenance_status=="Completed") {
-			return [__("Completed"), "green"];
-		} else if(doc.maintenance_status=="Cancelled") {
-			return [__("Cancelled"), "red"];
-		} else if(doc.maintenance_status=="Overdue") {
-			return [__("Overdue"), "red"];
+		if (doc.maintenance_status=="Planned") {
+			return [__(doc.maintenance_status), "orange", "status,=," + doc.maintenance_status];
+		} else if (doc.maintenance_status=="Completed") {
+			return [__(doc.maintenance_status), "green", "status,=," + doc.maintenance_status];
+		} else if (doc.maintenance_status=="Cancelled") {
+			return [__(doc.maintenance_status), "red", "status,=," + doc.maintenance_status];
+		} else if (doc.maintenance_status=="Overdue") {
+			return [__(doc.maintenance_status), "red", "status,=," + doc.maintenance_status];
 		}
 	}
 };


### PR DESCRIPTION
Backport of: https://github.com/frappe/erpnext/pull/23011

**Before:**

Asset Maintenance Log document doesn't let you set status as Completed when the due date has passed as it sets the status as Overdue on validate and throws this message:

![asset_maintenance](https://user-images.githubusercontent.com/24353136/90016114-296f8b00-dcc7-11ea-84aa-7fd8e4e71d24.png)

List View would only show status as Completed / Draft

![list-1](https://user-images.githubusercontent.com/24353136/90016661-f974b780-dcc7-11ea-92ec-f264906f081e.png)

**After:**

Don't set status as Overdue on validate if the status is Completed / Cancelled

![completed](https://user-images.githubusercontent.com/24353136/90016419-93883000-dcc7-11ea-9a43-79829a4e46f4.png)

Also, added `has_indicator_for_draft` flag to show correct status in List View:

![list](https://user-images.githubusercontent.com/24353136/90016559-cc280980-dcc7-11ea-8250-1121e2148f7a.png)
