### PR TITLE
fix: list index out of range error while setting POS payment mode

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -1619,22 +1619,23 @@ def update_multi_mode_option(doc, pos_profile):
 
 	for pos_payment_method in pos_profile.get('payments'):
 		pos_payment_method = pos_payment_method.as_dict()
-		
+
 		payment_mode = get_mode_of_payment_info(pos_payment_method.mode_of_payment, doc.company)
-		payment_mode[0].default = pos_payment_method.default
-		append_payment(payment_mode[0])
+		if payment_mode:
+			payment_mode[0].default = pos_payment_method.default
+			append_payment(payment_mode[0])
 
 def get_all_mode_of_payments(doc):
 	return frappe.db.sql("""
-		select mpa.default_account, mpa.parent, mp.type as type 
-		from `tabMode of Payment Account` mpa,`tabMode of Payment` mp 
+		select mpa.default_account, mpa.parent, mp.type as type
+		from `tabMode of Payment Account` mpa,`tabMode of Payment` mp
 		where mpa.parent = mp.name and mpa.company = %(company)s and mp.enabled = 1""",
 	{'company': doc.company}, as_dict=1)
 
 def get_mode_of_payment_info(mode_of_payment, company):
 	return frappe.db.sql("""
-		select mpa.default_account, mpa.parent, mp.type as type 
-		from `tabMode of Payment Account` mpa,`tabMode of Payment` mp 
+		select mpa.default_account, mpa.parent, mp.type as type
+		from `tabMode of Payment Account` mpa,`tabMode of Payment` mp
 		where mpa.parent = mp.name and mpa.company = %s and mp.enabled = 1 and mp.name = %s""",
 	(company, mode_of_payment), as_dict=1)
 


### PR DESCRIPTION
list index out of range error while setting POS payment mode if there are no payment accounts set.

```python
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-13-2020-08-06/apps/frappe/frappe/app.py", line 64, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-13-2020-08-06/apps/frappe/frappe/api.py", line 58, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-13-2020-08-06/apps/frappe/frappe/handler.py", line 30, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-13-2020-08-06/apps/frappe/frappe/handler.py", line 69, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-13-2020-08-06/apps/frappe/frappe/__init__.py", line 1086, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-13-2020-08-06/apps/frappe/frappe/handler.py", line 97, in runserverobj
    frappe.desk.form.run_method.runserverobj(method, docs=docs, dt=dt, dn=dn, arg=arg, args=args)
  File "/home/frappe/benches/bench-version-13-2020-08-06/apps/frappe/frappe/desk/form/run_method.py", line 46, in runserverobj
    r = doc.run_method(method, args)
  File "/home/frappe/benches/bench-version-13-2020-08-06/apps/frappe/frappe/model/document.py", line 827, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-version-13-2020-08-06/apps/frappe/frappe/model/document.py", line 1119, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-version-13-2020-08-06/apps/frappe/frappe/model/document.py", line 1102, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-version-13-2020-08-06/apps/frappe/frappe/model/document.py", line 821, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-version-13-2020-08-06/apps/erpnext/erpnext/accounts/doctype/pos_invoice/pos_invoice.py", line 287, in set_missing_values
    pos = self.set_pos_fields(for_validate)
  File "/home/frappe/benches/bench-version-13-2020-08-06/apps/erpnext/erpnext/accounts/doctype/pos_invoice/pos_invoice.py", line 228, in set_pos_fields
    update_multi_mode_option(self, pos)
  File "/home/frappe/benches/bench-version-13-2020-08-06/apps/erpnext/erpnext/accounts/doctype/sales_invoice/sales_invoice.py", line 1624, in update_multi_mode_option
    payment_mode[0].default = pos_payment_method.default
IndexError: list index out of range
```
