### PR TITLE
fix: Validate or Set Loan Amount first

### DIFF
--- a/erpnext/loan_management/doctype/loan_application/loan_application.py
+++ b/erpnext/loan_management/doctype/loan_application/loan_application.py
@@ -16,6 +16,7 @@ from six import string_types
 
 class LoanApplication(Document):
 	def validate(self):
+		self.set_pledge_amount()
 		self.set_loan_amount()
 		self.validate_loan_amount()
 
@@ -24,7 +25,6 @@ class LoanApplication(Document):
 				self.repayment_periods, self.is_term_loan)
 
 		self.validate_loan_type()
-		self.set_pledge_amount()
 
 		self.get_repayment_details()
 		self.check_sanctioned_amount_limit()
@@ -108,7 +108,7 @@ class LoanApplication(Document):
 		if self.is_secured_loan and self.proposed_pledges:
 			self.maximum_loan_amount = 0
 			for security in self.proposed_pledges:
-				self.maximum_loan_amount += security.post_haircut_amount
+				self.maximum_loan_amount += flt(security.post_haircut_amount)
 
 		if not self.loan_amount and self.is_secured_loan and self.proposed_pledges:
 			self.loan_amount = self.maximum_loan_amount

--- a/erpnext/loan_management/doctype/loan_application/loan_application.py
+++ b/erpnext/loan_management/doctype/loan_application/loan_application.py
@@ -19,8 +19,9 @@ class LoanApplication(Document):
 		self.set_loan_amount()
 		self.validate_loan_amount()
 
-		validate_repayment_method(self.repayment_method, self.loan_amount, self.repayment_amount,
-			self.repayment_periods, self.is_term_loan)
+		if self.is_term_loan:
+			validate_repayment_method(self.repayment_method, self.loan_amount, self.repayment_amount,
+				self.repayment_periods, self.is_term_loan)
 
 		self.validate_loan_type()
 		self.set_pledge_amount()

--- a/erpnext/loan_management/doctype/loan_application/loan_application.py
+++ b/erpnext/loan_management/doctype/loan_application/loan_application.py
@@ -16,14 +16,15 @@ from six import string_types
 
 class LoanApplication(Document):
 	def validate(self):
+		self.set_loan_amount()
+		self.validate_loan_amount()
 
 		validate_repayment_method(self.repayment_method, self.loan_amount, self.repayment_amount,
 			self.repayment_periods, self.is_term_loan)
 
 		self.validate_loan_type()
 		self.set_pledge_amount()
-		self.set_loan_amount()
-		self.validate_loan_amount()
+
 		self.get_repayment_details()
 		self.check_sanctioned_amount_limit()
 


### PR DESCRIPTION
- Loan Amount field is not mandatory in Loan Application (it can be set via the backend if it is a secured loan with proposed pledges)
- **validate_repayment_method** would break if loan amount was blank
    ```
         if monthly_repayment_amount > loan_amount:
        TypeError: '>' not supported between instances of 'int' and 'NoneType'
     ```
**Fix:**
- Set loan amount first if secured loan else user must set the amount, then validate if loan amount is set
- Validation for repayment method after that only (if Term Loan)