### PR TITLE
fix: recipients list for customer credit limit exceeded email

### DIFF
--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -184,10 +184,10 @@ class Customer(TransactionBase):
 	def validate_credit_limit_on_change(self):
 		if self.get("__islocal") or not self.credit_limits:
 			return
-		
+
 		past_credit_limits = [d.credit_limit
 			for d in frappe.db.get_all("Customer Credit Limit", filters={'parent': self.name}, fields=["credit_limit"], order_by="company")]
-		
+
 		current_credit_limits = [d.credit_limit for d in sorted(self.credit_limits, key=lambda k: k.company)]
 
 		if past_credit_limits == current_credit_limits:
@@ -427,7 +427,7 @@ def send_emails(args):
 	subject = (_("Credit limit reached for customer {0}").format(args.get('customer')))
 	message = (_("Credit limit has been crossed for customer {0} ({1}/{2})")
 			.format(args.get('customer'), args.get('customer_outstanding'), args.get('credit_limit')))
-	frappe.sendmail(recipients=[args.get('credit_controller_users_list')], subject=subject, message=message)
+	frappe.sendmail(recipients=args.get('credit_controller_users_list'), subject=subject, message=message)
 
 def get_customer_outstanding(customer, company, ignore_outstanding_sales_order=False, cost_center=None):
 	# Outstanding based on GL Entries


### PR DESCRIPTION
**Problem:**

If a sales order which is exceeding the credit limit set for the customer is being submitted by a user who does not have a credit controller / sales manager role, on submit, system has to send emails to users with those roles. Following error shows up when Send Email button is clicked:

`TypeError: unhashable type: 'list'` error while sending customer credit limit exceeded email

![customer-credit-limit](https://user-images.githubusercontent.com/24353136/90129657-aa418c00-dd86-11ea-98f5-8df6e6de6381.gif)

**Traceback:**

```python
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-13-2020-08-07/apps/frappe/frappe/app.py", line 64, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-13-2020-08-07/apps/frappe/frappe/api.py", line 58, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-13-2020-08-07/apps/frappe/frappe/handler.py", line 30, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-13-2020-08-07/apps/frappe/frappe/handler.py", line 69, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-13-2020-08-07/apps/frappe/frappe/__init__.py", line 1086, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-13-2020-08-07/apps/erpnext/erpnext/selling/doctype/customer/customer.py", line 422, in send_emails
    frappe.sendmail(recipients=[args.get('credit_controller_users_list')], subject=subject, message=message)
  File "/home/frappe/benches/bench-version-13-2020-08-07/apps/frappe/frappe/__init__.py", line 507, in sendmail
    inline_images=inline_images, header=header, print_letterhead=print_letterhead)
  File "/home/frappe/benches/bench-version-13-2020-08-07/apps/frappe/frappe/email/queue.py", line 85, in send
    recipients = list(set(recipients))
TypeError: unhashable type: 'list'
```

**Fix:**

The `credit_controller_users_list` is already a list so it should not be passed as an argument inside another list. 

![customer-credit-limit-works](https://user-images.githubusercontent.com/24353136/90131011-086f6e80-dd89-11ea-9b50-ab60ab37e07b.gif)
