### PR TITLE
fix: Item GL entries for purchase invoice

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -400,8 +400,6 @@ class PurchaseInvoice(BuyingController):
 		update_linked_doc(self.doctype, self.name, self.inter_company_invoice_reference)
 
 	def make_gl_entries(self, gl_entries=None):
-		if not self.grand_total:
-			return
 		if not gl_entries:
 			gl_entries = self.get_gl_entries()
 


### PR DESCRIPTION
Currently for a Purchase Invoice with zero grand total no accounting entries are posted and the invoice is completely off the books since no GL entries are posted.

Consider the below scenario:

<img width="1210" alt="Screenshot 2020-08-13 at 8 45 09 PM" src="https://user-images.githubusercontent.com/42651287/90153631-dd941300-dda6-11ea-8a4b-5af2e25d8ef5.png">

First row has the actual item and the second row has a service item which is used to allocate the downpayment, so the grand total of the invoice is zero.

Even though expense head for both the rows are different no accounting entry is passed.
<img width="1184" alt="Screenshot 2020-08-13 at 8 45 22 PM" src="https://user-images.githubusercontent.com/42651287/90160105-f43e6800-ddae-11ea-849b-f6918f922558.png">

<img width="1225" alt="Screenshot 2020-08-13 at 8 45 36 PM" src="https://user-images.githubusercontent.com/42651287/90160115-f9031c00-ddae-11ea-87c5-58e7f78e93dc.png">
