### PR TITLE
fix: Batch  Balance Qty fixes in Stock Ledger Report,etc.

### DIFF
--- a/erpnext/stock/doctype/batch/batch.py
+++ b/erpnext/stock/doctype/batch/batch.py
@@ -179,6 +179,35 @@ def get_batch_qty(batch_no=None, warehouse=None, item_code=None, posting_date=No
 
 	return out
 
+@frappe.whitelist()
+def get_batch_balance_on(batch_no, posting_date=None, warehouse=None):
+	"""Returns balance qty of batch before and on the date specified,
+	   if no date, it will return the entire balance qty irrespective
+
+	User must pass batch_no or batch_no + date
+
+	:param batch_no: Mandatory - give balance qty for this batch no
+	:param posting_date: Optional - give balance qty till this date
+	:param warehouse: Optional - give balance qty for this warehouse"""
+	balance = 0
+	float_precision = cint(frappe.db.get_default("float_precision")) or 3
+
+	if not batch_no:
+		return balance
+
+	cond = ""
+	if posting_date:
+		cond += " and posting_date <= '{0}'".format(posting_date)
+	if warehouse:
+		cond += " and warehouse = {0}".format(frappe.db.escape(warehouse))
+
+	balance = float(frappe.db.sql("""select sum(round(actual_qty, {0}))
+			from `tabStock Ledger Entry`
+			where batch_no=%s
+			{1}""".format(float_precision, cond),
+			(batch_no))[0][0] or 0)
+
+	return balance
 
 @frappe.whitelist()
 def get_batches_by_oldest(item_code, warehouse):

--- a/erpnext/stock/report/stock_ledger/stock_ledger.py
+++ b/erpnext/stock/report/stock_ledger/stock_ledger.py
@@ -35,7 +35,7 @@ def execute(filters=None):
 		sle.update(item_detail)
 
 		if filters.get("batch_no"):
-			actual_qty += flt(sle.actual_qty, precision)
+			actual_qty = flt(actual_qty, precision) + flt(sle.actual_qty, precision)
 			stock_value += sle.stock_value_difference
 
 			if sle.voucher_type == 'Stock Reconciliation' and not sle.actual_qty:


### PR DESCRIPTION
## Stock Ledger 
Consider a batch with balance qty 1 on **31st May 2020**
- After https://github.com/frappe/erpnext/pull/19479, batch balance qty was calculated from only among the entries **visible**, completely **ignoring** any past balance qty. The opening balance wasn't batch oriented either.
![Screenshot 2020-08-14 at 12 43 54 PM](https://user-images.githubusercontent.com/25857446/90223577-f561aa80-de2b-11ea-80b1-fd06fd84bdfd.png)

**Fix:**
- Fetch batch's total balance qty before **from date** as opening balance, and calculate future balances from here
- Round each actual_qty as per global precision then add for precision accuracy, while fetching batch balance qty
![Screenshot 2020-08-14 at 12 42 40 PM](https://user-images.githubusercontent.com/25857446/90223590-f98dc800-de2b-11ea-892f-c7a9397af80c.png)

**note:** Unsure what the balance value should be , fetching the actual stock value form the ledger causes inconsistency. But altering it according to batch is also incorrect as we don't track batch wise stock value as of now

## Batch Precision
- for consistency, round the number as per precision then add the number (difference if added without precision and rounded at the end only)
- This to maintain consistency between balance in Batch Wise Balance History Report and Stock Ledger Report
- Also due to a difference between mariadb's rounding and python's rounding, used python for consistency