### PR TITLE
fix: the JSON object must be str, bytes or bytearray, not "list"

### DIFF
--- a/erpnext/accounts/doctype/bank_guarantee/bank_guarantee.py
+++ b/erpnext/accounts/doctype/bank_guarantee/bank_guarantee.py
@@ -27,4 +27,4 @@ def get_vouchar_detials(column_list, doctype, docname):
 	for col in column_list:
 		sanitize_searchfield(col) 
 	return frappe.db.sql(''' select {columns} from `tab{doctype}` where name=%s'''
-		.format(columns=", ".join(json.loads(column_list)), doctype=doctype), docname, as_dict=1)[0]
+		.format(columns=", ".join(column_list), doctype=doctype), docname, as_dict=1)[0]


### PR DESCRIPTION
json.loads was already used before sanitize_searchfield hence using it again was giving the following error.

Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2020-07-22/apps/frappe/frappe/app.py", line 64, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-12-2020-07-22/apps/frappe/frappe/api.py", line 59, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-12-2020-07-22/apps/frappe/frappe/handler.py", line 24, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-12-2020-07-22/apps/frappe/frappe/handler.py", line 63, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-12-2020-07-22/apps/frappe/frappe/__init__.py", line 1054, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-12-2020-07-22/apps/erpnext/erpnext/accounts/doctype/bank_guarantee/bank_guarantee.py", line 30, in get_vouchar_detials
    .format(columns=", ".join(json.loads(column_list)), doctype=doctype), docname, as_dict=1)[0]
  File "/usr/lib64/python3.6/json/__init__.py", line 348, in loads
    'not {!r}'.format(s.__class__.__name__))
TypeError: the JSON object must be str, bytes or bytearray, not 'list'