### PR TITLE
fix: deleting unused Stock Entry Type

### DIFF
--- a/erpnext/patches/v13_0/stock_entry_enhancements.py
+++ b/erpnext/patches/v13_0/stock_entry_enhancements.py
@@ -25,3 +25,7 @@ def execute():
             doc = frappe.new_doc('Warehouse Type')
             doc.name = 'Transit'
             doc.insert()
+
+        frappe.reload_doc("stock", "doctype", "stock_entry_type")
+        frappe.delete_doc_if_exists("Stock Entry Type", "Send to Warehouse")
+        frappe.delete_doc_if_exists("Stock Entry Type", "Receive at Warehouse")


### PR DESCRIPTION
Added code to delete **Send to Warehouse** and **Receive at Warehouse** from exiting site. (ref #22671)