### PR TITLE
fix: the JSON object must be str, bytes or bytearray, not "list"

### DIFF
--- a/erpnext/accounts/doctype/bank_guarantee/bank_guarantee.py
+++ b/erpnext/accounts/doctype/bank_guarantee/bank_guarantee.py
@@ -27,4 +27,4 @@ def get_vouchar_detials(column_list, doctype, docname):
 	for col in column_list:
 		sanitize_searchfield(col) 
 	return frappe.db.sql(''' select {columns} from `tab{doctype}` where name=%s'''
-		.format(columns=", ".join(json.loads(column_list)), doctype=doctype), docname, as_dict=1)[0]
+		.format(columns=", ".join(column_list), doctype=doctype), docname, as_dict=1)[0]


### PR DESCRIPTION
This PR is in response to backport failing of https://github.com/frappe/erpnext/pull/23047