### PR TITLE
feat(queries): sort warehouses based on item quantity in descending manner

### DIFF
--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -468,24 +468,18 @@ def warehouse_query(doctype, txt, searchfield, start, page_len, filters):
 	conditions, bin_conditions = [], []
 	filter_dict = get_doctype_wise_filters(filters)
 
-	sub_query = """ select round(`tabBin`.actual_qty, 2) from `tabBin`
-		where `tabBin`.warehouse = `tabWarehouse`.name
-		{bin_conditions} """.format(
-		bin_conditions=get_filters_cond(doctype, filter_dict.get("Bin"),
-			bin_conditions, ignore_permissions=True))
-
 	query = """select `tabWarehouse`.name,
-		CONCAT_WS(" : ", "Actual Qty", ifnull( ({sub_query}), 0) ) as actual_qty
-		from `tabWarehouse`
+		CONCAT_WS(" : ", "Actual Qty", ifnull(round(`tabBin`.actual_qty, 2), 0 )) actual_qty
+		from `tabWarehouse` left join `tabBin`
+		on `tabBin`.warehouse = `tabWarehouse`.name {bin_conditions}
 		where
-		   `tabWarehouse`.`{key}` like {txt}
+			`tabWarehouse`.`{key}` like {txt}
 			{fcond} {mcond}
-		order by
-			`tabWarehouse`.name desc
+		order by ifnull(`tabBin`.actual_qty, 0) desc
 		limit
 			{start}, {page_len}
 		""".format(
-			sub_query=sub_query,
+			bin_conditions=get_filters_cond(doctype, filter_dict.get("Bin"),bin_conditions, ignore_permissions=True),
 			key=searchfield,
 			fcond=get_filters_cond(doctype, filter_dict.get("Warehouse"), conditions),
 			mcond=get_match_cond(doctype),


### PR DESCRIPTION
**Existing system -**

The query set for warehouse dropdown sorts the warehouses by their names in descending order. This can sometimes get not easy to select a warehouse that has quantity in it for the chosen item as the warehouses that have the quantity can be at a lower position in the dropdown menu.

![Screenshot from 2020-08-19 01-12-59](https://user-images.githubusercontent.com/13060550/90558127-30ac0280-e1b9-11ea-9aa4-3b619ce7b1fe.png)

**New system -**

Sorted the warehouses based on the item quantity in them in descending order.

![Screenshot from 2020-08-19 01-12-23](https://user-images.githubusercontent.com/13060550/90558155-3a356a80-e1b9-11ea-9180-fff2b46c5813.png)

