### PR TITLE
fix: profit and loss report not working

### DIFF
--- a/erpnext/accounts/report/financial_statements.py
+++ b/erpnext/accounts/report/financial_statements.py
@@ -14,7 +14,7 @@ import frappe, erpnext
 from erpnext.accounts.report.utils import get_currency, convert_to_presentation_currency
 from erpnext.accounts.utils import get_fiscal_year
 from frappe import _
-from frappe.utils import (flt, getdate, get_first_day, add_months, add_days, formatdate, cstr)
+from frappe.utils import (flt, getdate, get_first_day, add_months, add_days, formatdate, cstr, cint)
 
 from six import itervalues
 from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import get_accounting_dimensions, get_dimension_with_children
@@ -46,7 +46,7 @@ def get_period_list(from_fiscal_year, to_fiscal_year, period_start_date, period_
 	start_date = year_start_date
 	months = get_months(year_start_date, year_end_date)
 
-	for i in range(math.ceil(months / months_to_add)):
+	for i in range(cint(math.ceil(months / months_to_add))):
 		period = frappe._dict({
 			"from_date": start_date
 		})


### PR DESCRIPTION
**Issue**


<img width="645" alt="Screenshot 2020-08-18 at 4 04 30 PM" src="https://user-images.githubusercontent.com/8780500/90503752-94a8d980-e16d-11ea-92e7-75e97c5e9243.png">

```
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 182, in run
    result = generate_report_result(report, filters, user, custom_columns)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 59, in generate_report_result
    res = report.execute_script_report(filters)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/core/doctype/report/report.py", line 116, in execute_script_report
    res = self.execute_module(filters)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/frappe/frappe/core/doctype/report/report.py", line 133, in execute_module
    return frappe.get_attr(method_name)(frappe._dict(filters))
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/erpnext/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.py", line 13, in execute
    company=filters.company)
  File "/Users/rohitwaghchaure/Documents/erpnext_new/frappe-bench/apps/erpnext/erpnext/accounts/report/financial_statements.py", line 49, in get_period_list
    for i in range(math.ceil(months / months_to_add)):
TypeError: range() integer end argument expected, got float.
```