### PR TITLE
fix: Do not update total for RCM invvoices if net taxes are zero

### DIFF
--- a/erpnext/regional/india/utils.py
+++ b/erpnext/regional/india/utils.py
@@ -659,6 +659,9 @@ def update_grand_total_for_rcm(doc, method):
 	if country != 'India':
 		return
 
+	if not doc.total_taxes_and_charges:
+		return
+
 	if doc.reverse_charge == 'Y':
 		gst_accounts = get_gst_accounts(doc.company)
 		gst_account_list = gst_accounts.get('cgst_account') + gst_accounts.get('sgst_account') \
@@ -706,7 +709,10 @@ def make_regional_gl_entries(gl_entries, doc):
 	country = frappe.get_cached_value('Company', doc.company, 'country')
 
 	if country != 'India':
-		return
+		return gl_entries
+
+	if not doc.total_taxes_and_charges:
+		return gl_entries
 
 	if doc.reverse_charge == 'Y':
 		gst_accounts = get_gst_accounts(doc.company)


### PR DESCRIPTION
In many cases the way user handles the RCM scenarios is they Add and Deduct the same tax amount in the same invoice at the same time.

The new RCM was not allowing to do so anymore. This PR fixes that Issue