### PR TITLE
fix: val is not defined

### DIFF
--- a/erpnext/public/js/utils/serial_no_batch_selector.js
+++ b/erpnext/public/js/utils/serial_no_batch_selector.js
@@ -348,9 +348,9 @@ erpnext.SerialNoBatchSelector = Class.extend({
 									return row.on_grid_fields_dict.batch_no.get_value();
 								}
 							});
-							if (selected_batches.includes(val)) {
+							if (selected_batches.includes(batch_no)) {
 								this.set_value("");
-								frappe.throw(__(`Batch ${val} already selected.`));
+								frappe.throw(__(`Batch ${batch_no} already selected.`));
 								return;
 							}
 


### PR DESCRIPTION
`val` was renamed as `batch_no` in #22541