### PR TITLE
fix: Create Opportunity without Default Company from Email

### DIFF
--- a/erpnext/crm/doctype/opportunity/opportunity.py
+++ b/erpnext/crm/doctype/opportunity/opportunity.py
@@ -335,8 +335,14 @@ def make_opportunity_from_communication(communication, ignore_communication_link
 
 	opportunity_from = "Lead"
 
+	if frappe.db.get_default("Company"):
+		company = frappe.db.get_default("Company")
+	else:
+		company =  frappe.get_list("Company")[0].name
+
 	opportunity = frappe.get_doc({
 		"doctype": "Opportunity",
+		"company": company,
 		"opportunity_from": opportunity_from,
 		"party_name": lead
 	}).insert(ignore_permissions=True)

--- a/erpnext/crm/doctype/opportunity/opportunity.py
+++ b/erpnext/crm/doctype/opportunity/opportunity.py
@@ -325,7 +325,7 @@ def auto_close_opportunity():
 		doc.save()
 
 @frappe.whitelist()
-def make_opportunity_from_communication(communication, ignore_communication_links=False):
+def make_opportunity_from_communication(communication, company, ignore_communication_links=False):
 	from erpnext.crm.doctype.lead.lead import make_lead_from_communication
 	doc = frappe.get_doc("Communication", communication)
 
@@ -334,11 +334,6 @@ def make_opportunity_from_communication(communication, ignore_communication_link
 		lead = make_lead_from_communication(communication, ignore_communication_links=True)
 
 	opportunity_from = "Lead"
-
-	if frappe.db.get_default("Company"):
-		company = frappe.db.get_default("Company")
-	else:
-		company =  frappe.get_list("Company")[0].name
 
 	opportunity = frappe.get_doc({
 		"doctype": "Opportunity",

--- a/erpnext/public/js/communication.js
+++ b/erpnext/public/js/communication.js
@@ -70,7 +70,12 @@ frappe.ui.form.on("Communication", {
 			freeze: true,
 			callback: (r) => {
 				if(r.message) {
-					frm.reload_doc()
+					frm.reload_doc();
+					frappe.show_alert({
+						message: __("Opportunity {0} created",
+							['<a href="#Form/Opportunity/'+r.message+'">' + r.message + '</a>']),
+						indicator: 'green'
+					});
 				}
 			}
 		})

--- a/erpnext/public/js/communication.js
+++ b/erpnext/public/js/communication.js
@@ -7,7 +7,7 @@ frappe.ui.form.on("Communication", {
 	},
 
 	setup_custom_buttons: (frm) => {
-		let confirm_msg = "Are you sure you want to create {0} from this email ?";
+		let confirm_msg = "Are you sure you want to create {0} from this email?";
 		if(frm.doc.reference_doctype !== "Issue") {
 			frm.add_custom_button(__("Issue"), () => {
 				frappe.confirm(__(confirm_msg, [__("Issue")]), () => {

--- a/erpnext/public/js/communication.js
+++ b/erpnext/public/js/communication.js
@@ -7,7 +7,7 @@ frappe.ui.form.on("Communication", {
 	},
 
 	setup_custom_buttons: (frm) => {
-		let confirm_msg = "Are you sure you want to create {0} from this email";
+		let confirm_msg = "Are you sure you want to create {0} from this email ?";
 		if(frm.doc.reference_doctype !== "Issue") {
 			frm.add_custom_button(__("Issue"), () => {
 				frappe.confirm(__(confirm_msg, [__("Issue")]), () => {
@@ -62,22 +62,36 @@ frappe.ui.form.on("Communication", {
 	},
 
 	make_opportunity_from_communication: (frm) => {
-		return frappe.call({
-			method: "erpnext.crm.doctype.opportunity.opportunity.make_opportunity_from_communication",
-			args: {
-				communication: frm.doc.name
-			},
-			freeze: true,
-			callback: (r) => {
-				if(r.message) {
-					frm.reload_doc();
-					frappe.show_alert({
-						message: __("Opportunity {0} created",
-							['<a href="#Form/Opportunity/'+r.message+'">' + r.message + '</a>']),
-						indicator: 'green'
-					});
+		const fields = [{
+			fieldtype: 'Link',
+			label: __('Select a Company'),
+			fieldname: 'company',
+			options: 'Company',
+			reqd: 1,
+			default: frappe.defaults.get_user_default("Company")
+		}];
+
+		frappe.prompt(fields, data => {
+			frappe.call({
+				method: "erpnext.crm.doctype.opportunity.opportunity.make_opportunity_from_communication",
+				args: {
+					communication: frm.doc.name,
+					company: data.company
+				},
+				freeze: true,
+				callback: (r) => {
+					if(r.message) {
+						frm.reload_doc();
+						frappe.show_alert({
+							message: __("Opportunity {0} created",
+								['<a href="#Form/Opportunity/'+r.message+'">' + r.message + '</a>']),
+							indicator: 'green'
+						});
+					}
 				}
-			}
-		})
+			});
+		},
+		'Create an Opportunity',
+		'Create');
 	}
 });


### PR DESCRIPTION
**Issue:**
- If no Default Company in Global Defaults, error on creating Opportunity from Communication (Email):
  ![image](https://user-images.githubusercontent.com/25857446/90735697-28ec7b00-e2eb-11ea-8b33-7c0db9403e90.png)

**Fix:**
- Prompt to select company if no default found
  ![opp2](https://user-images.githubusercontent.com/25857446/90754555-a5855680-e2f7-11ea-8383-f609d93f097a.gif)

- If default exists prompt is auto-populated with default company
  ![default](https://user-images.githubusercontent.com/25857446/90754577-acac6480-e2f7-11ea-84cf-5b9f769aea98.gif)

- Feedback on Opportunity Creation
 ![Screenshot 2020-08-20 at 1 42 55 PM](https://user-images.githubusercontent.com/25857446/90736071-3f92d200-e2eb-11ea-9bfc-1fd873371680.png)
