### PR TITLE
fix: Lock row in subquery while setting delivered qty

### DIFF
--- a/erpnext/controllers/status_updater.py
+++ b/erpnext/controllers/status_updater.py
@@ -249,7 +249,7 @@ class StatusUpdater(Document):
 				args['second_source_condition'] = """ + ifnull((select sum(%(second_source_field)s)
 					from `tab%(second_source_dt)s`
 					where `%(second_join_field)s`="%(detail_id)s"
-					and (`tab%(second_source_dt)s`.docstatus=1) %(second_source_extra_cond)s), 0) """ % args
+					and (`tab%(second_source_dt)s`.docstatus=1) %(second_source_extra_cond)s FOR UPDATE), 0) """ % args
 
 			if args['detail_id']:
 				if not args.get("extra_cond"): args["extra_cond"] = ""


### PR DESCRIPTION
Backport: https://github.com/frappe/erpnext/pull/23100

**Problem**: Lock wait Timeout Exceeded on submitting Delivery Note when updating the delivered qty in the previous doc.

**Traceback:**

```python
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2020-07-22/apps/frappe/frappe/desk/form/save.py", line 19, in savedocs
    doc.submit()
  File "/home/frappe/benches/bench-version-12-2020-07-22/apps/frappe/frappe/model/document.py", line 867, in submit
    self._submit()
  File "/home/frappe/benches/bench-version-12-2020-07-22/apps/frappe/frappe/model/document.py", line 856, in _submit
    self.save()
  File "/home/frappe/benches/bench-version-12-2020-07-22/apps/frappe/frappe/model/document.py", line 273, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2020-07-22/apps/frappe/frappe/model/document.py", line 303, in _save
    self.check_if_latest()
  File "/home/frappe/benches/bench-version-12-2020-07-22/apps/frappe/frappe/model/document.py", line 648, in check_if_latest
    where name = %s for update""".format(self.doctype), self.name, as_dict=True)
  File "/home/frappe/benches/bench-version-12-2020-07-22/apps/frappe/frappe/database/database.py", line 156, in sql
    self._cursor.execute(query, values)
  File "/home/frappe/benches/bench-version-12-2020-07-22/env/lib/python3.6/site-packages/pymysql/cursors.py", line 170, in execute
    result = self._query(query)
  File "/home/frappe/benches/bench-version-12-2020-07-22/env/lib/python3.6/site-packages/pymysql/cursors.py", line 328, in _query
    conn.query(q)
  File "/home/frappe/benches/bench-version-12-2020-07-22/env/lib/python3.6/site-packages/pymysql/connections.py", line 517, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/home/frappe/benches/bench-version-12-2020-07-22/env/lib/python3.6/site-packages/pymysql/connections.py", line 732, in _read_query_result
    result.read()
  File "/home/frappe/benches/bench-version-12-2020-07-22/env/lib/python3.6/site-packages/pymysql/connections.py", line 1075, in read
    first_packet = self.connection._read_packet()
  File "/home/frappe/benches/bench-version-12-2020-07-22/env/lib/python3.6/site-packages/pymysql/connections.py", line 684, in _read_packet
    packet.check_error()
  File "/home/frappe/benches/bench-version-12-2020-07-22/env/lib/python3.6/site-packages/pymysql/protocol.py", line 220, in check_error
    err.raise_mysql_exception(self._data)
  File "/home/frappe/benches/bench-version-12-2020-07-22/env/lib/python3.6/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.InternalError: (1205, 'Lock wait timeout exceeded; try restarting transaction')
```
**Engine status:**

```
------------------------
LATEST DETECTED DEADLOCK
------------------------
2020-08-17 10:08:28 7f65cc1a6700
*** (1) TRANSACTION:
TRANSACTION 3893403066, ACTIVE 16 sec starting index read
mysql tables in use 4, locked 4
LOCK WAIT 19 lock struct(s), heap size 2936, 11 row lock(s), undo log entries 10
MySQL thread id 104074469, OS thread handle 0x7f76ff7be700, query id 2848209243 localhost ::1 3245628434e4e27c updating
update `tabSales Order Item`
					set delivered_qty = (
						(select coalesce(sum(qty), 0)
							from `tabDelivery Note Item` where `so_detail`="3b3d5b4f46"
							and (docstatus=1  or parent="KEPL/DN/RET/20-21/00172") )
						 + coalesce((select sum(qty)
					from `tabSales Invoice Item`
					where `so_detail`="3b3d5b4f46"
					and (`tabSales Invoice Item`.docstatus=1)  and exists(select name from `tabSales Invoice`
				where name=`tabSales Invoice Item`.parent and update_stock = 1)), 0)
					)
					, modified = now(), modified_by = 'raju@skola.toys'
					where name='3b3d5b4f46'
*** (1) WAITING FOR THIS LOCK TO BE GRANTED:
RECORD LOCKS space id 2679250 page no 6718 n bits 88 index `PRIMARY` of table `3245628434e4e27c`.`tabSales Order Item` trx table locks 9 total table locks 2  trx id 3893403066 lock_mode X locks rec but not gap waiting lock hold time 1 wait time before grant 0
*** (2) TRANSACTION:
TRANSACTION 3893403117, ACTIVE 11 sec fetching rows
mysql tables in use 2, locked 2
19818 lock struct(s), heap size 2094632, 277110 row lock(s), undo log entries 19
MySQL thread id 104074519, OS thread handle 0x7f65cc1a6700, query id 2848209315 localhost ::1 3245628434e4e27c Sending data
update `tabSales Invoice Item`
					set delivered_qty = (
						(select coalesce(sum(qty), 0)
							from `tabDelivery Note Item` where `si_detail`="a474f2bae0"
							and (docstatus=1  or parent="KEPL/DN/RET/20-21/00171") )

					)
					, modified = now(), modified_by = 'raju@skola.toys'
					where name='a474f2bae0'
*** (2) HOLDS THE LOCK(S):
RECORD LOCKS space id 2679250 page no 6718 n bits 88 index `PRIMARY` of table `3245628434e4e27c`.`tabSales Order Item` trx table locks 13 total table locks 2  trx id 3893403117 lock mode S locks rec but not gap lock hold time 1 wait time before grant 0
*** (2) WAITING FOR THIS LOCK TO BE GRANTED:
RECORD LOCKS space id 2689064 page no 10388 n bits 80 index `PRIMARY` of table `3245628434e4e27c`.`tabDelivery Note Item` trx table locks 13 total table locks 2  trx id 3893403117 lock mode S waiting lock hold time 0 wait time before grant 0
*** WE ROLL BACK TRANSACTION (1)
```

**Fix**: On submitting a delivery note, it updates the delivered_qty in the previous doc, for example, Sales Order. While doing so, in the update query there is a subquery for selecting sum(qty) from Sales Invoice Item. At the same time, another query is trying to update the Sales Invoice Item table as seen in transaction 2. Though the first transaction is an update query, the lock is not on the table in the subquery but only in the main query. So, this PR locks the row in subquery explicitly.