### PR TITLE
fix: Unable to submit reverse charge invoice

### DIFF
--- a/erpnext/regional/india/utils.py
+++ b/erpnext/regional/india/utils.py
@@ -711,9 +711,6 @@ def make_regional_gl_entries(gl_entries, doc):
 	if country != 'India':
 		return gl_entries
 
-	if not doc.total_taxes_and_charges:
-		return gl_entries
-
 	if doc.reverse_charge == 'Y':
 		gst_accounts = get_gst_accounts(doc.company)
 		gst_account_list = gst_accounts.get('cgst_account') + gst_accounts.get('sgst_account') \
@@ -723,6 +720,7 @@ def make_regional_gl_entries(gl_entries, doc):
 			if tax.category not in ("Total", "Valuation and Total"):
 				continue
 
+			dr_or_cr = "credit" if tax.add_deduct_tax == "Add" else "debit"
 			if flt(tax.base_tax_amount_after_discount_amount) and tax.account_head in gst_account_list:
 				account_currency = get_account_currency(tax.account_head)
 
@@ -732,8 +730,8 @@ def make_regional_gl_entries(gl_entries, doc):
 						"cost_center": tax.cost_center,
 						"posting_date": doc.posting_date,
 						"against": doc.supplier,
-						"credit": tax.base_tax_amount_after_discount_amount,
-						"credits_in_account_currency": tax.base_tax_amount_after_discount_amount \
+						dr_or_cr: tax.base_tax_amount_after_discount_amount,
+						dr_or_cr + "_in_account_currency": tax.base_tax_amount_after_discount_amount \
 							if account_currency==doc.company_currency \
 							else tax.tax_amount_after_discount_amount
 					}, account_currency, item=tax)


### PR DESCRIPTION
Unable to submit reverse charge invoice since no GL entry for tax deduction is passed in case of 0 total taxes and charges and total debit doesn't match total credit

![image](https://user-images.githubusercontent.com/42651287/90763064-ade38e80-e303-11ea-8ce9-818b005c58fd.png)
