### PR TITLE
fix: Reverse SLE not created for fraction qty or qty less than 1

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -31,7 +31,7 @@ def make_sl_entries(sl_entries, allow_negative_stock=False, via_landed_cost_vouc
 				sle['posting_time'] = now_datetime().strftime('%H:%M:%S.%f')
 
 				if cancel:
-					sle['actual_qty'] = -flt(sle.get('actual_qty'), 0)
+					sle['actual_qty'] = -flt(sle.get('actual_qty'))
 
 					if sle['actual_qty'] < 0 and not sle.get('outgoing_rate'):
 						sle['outgoing_rate'] = get_incoming_outgoing_rate_for_cancel(sle.item_code,


### PR DESCRIPTION
Reverse SLE was not created on cancel when qty is less than 1

Before:
<img width="1149" alt="Screenshot 2020-08-23 at 9 25 36 PM" src="https://user-images.githubusercontent.com/42651287/90982786-3aea4a00-e587-11ea-89c2-b8669422ef56.png">

After:
<img width="1144" alt="Screenshot 2020-08-23 at 9 24 13 PM" src="https://user-images.githubusercontent.com/42651287/90982788-3faefe00-e587-11ea-925b-99b03d838c96.png">
