### PR TITLE
feat: add Maintenance Visit link in Customer and Sales Order dashboards

### DIFF
--- a/erpnext/selling/doctype/customer/customer_dashboard.py
+++ b/erpnext/selling/doctype/customer/customer_dashboard.py
@@ -33,7 +33,7 @@ def get_data():
 			},
 			{
 				'label': _('Support'),
-				'items': ['Issue']
+				'items': ['Issue', 'Maintenance Visit']
 			},
 			{
 				'label': _('Projects'),

--- a/erpnext/selling/doctype/sales_order/sales_order_dashboard.py
+++ b/erpnext/selling/doctype/sales_order/sales_order_dashboard.py
@@ -10,6 +10,7 @@ def get_data():
 			'Payment Entry': 'reference_name',
 			'Payment Request': 'reference_name',
 			'Auto Repeat': 'reference_document',
+			'Maintenance Visit': 'prevdoc_docname'
 		},
 		'internal_links': {
 			'Quotation': ['items', 'prevdoc_docname']
@@ -17,7 +18,7 @@ def get_data():
 		'transactions': [
 			{
 				'label': _('Fulfillment'),
-				'items': ['Sales Invoice', 'Pick List', 'Delivery Note']
+				'items': ['Sales Invoice', 'Pick List', 'Delivery Note', 'Maintenance Visit']
 			},
 			{
 				'label': _('Purchasing'),


### PR DESCRIPTION
Added Maintenance Visit link in the Customer and Sales Order dashboard

![link-1](https://user-images.githubusercontent.com/24353136/91176616-29787d80-e700-11ea-9a81-6ed3246447e0.png)

![so](https://user-images.githubusercontent.com/24353136/91180945-ee794880-e705-11ea-987a-e70f7c8bdcee.png)


Feature Request in Issue: [ISS-20-21-04457](https://frappe.io/desk#Form/Issue/ISS-20-21-04457)