### PR TITLE
fix: Add Delivery Note Count in Sales Invoice Dashboard

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice_dashboard.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice_dashboard.py
@@ -13,7 +13,8 @@ def get_data():
 			'Auto Repeat': 'reference_document',
 		},
 		'internal_links': {
-			'Sales Order': ['items', 'sales_order']
+			'Sales Order': ['items', 'sales_order'],
+			'Delivery Note': ['items', 'delivery_note']
 		},
 		'transactions': [
 			{


### PR DESCRIPTION
**Steps:**

1. Create a Sales Invoice
2. From "Get Items", pull in the DN
3. Issue: DN is not updated in the Sales Invoice dashboard.


![Screenshot 2020-08-25 at 7 49 51 PM](https://user-images.githubusercontent.com/50285544/91186567-d527ca80-e70c-11ea-8a57-0bea5373084d.png)


**Fix:**

Based on the Delivery Note pulled, update the Sales Invoice Dashboard

![Screenshot 2020-08-25 at 7 50 49 PM](https://user-images.githubusercontent.com/50285544/91186616-e40e7d00-e70c-11ea-955f-8d6cc2f6e321.png)
