### PR TITLE
fix: don't overwrite patient appointment duration if already specified

### DIFF
--- a/erpnext/healthcare/doctype/patient_appointment/patient_appointment.js
+++ b/erpnext/healthcare/doctype/patient_appointment/patient_appointment.js
@@ -226,7 +226,9 @@ let check_and_set_availability = function(frm) {
 			primary_action_label: __('Book'),
 			primary_action: function() {
 				frm.set_value('appointment_time', selected_slot);
-				frm.set_value('duration', duration);
+				if (!frm.doc.duration) {
+					frm.set_value('duration', duration);
+				}
 				frm.set_value('practitioner', d.get_value('practitioner'));
 				frm.set_value('department', d.get_value('department'));
 				frm.set_value('appointment_date', d.get_value('appointment_date'));


### PR DESCRIPTION
**Before:**

While booking a patient appointment, if the time slot in Practitioner Schedule is of 15 mins (for example), then in-spite of setting the duration as 45 mins, it overwrites the duration to time slot default 

![duration-app-before](https://user-images.githubusercontent.com/24353136/91287582-88e09700-e7ad-11ea-941f-37fe520ccbda.gif)


**After:**

Don't overwrite duration if already specified

![duration-app-after](https://user-images.githubusercontent.com/24353136/91287411-56369e80-e7ad-11ea-906d-0cda1a359fd7.gif)
