### PR TITLE
fix: query for contact person

### DIFF
--- a/erpnext/selling/doctype/quotation/quotation.js
+++ b/erpnext/selling/doctype/quotation/quotation.js
@@ -147,6 +147,7 @@ erpnext.selling.QuotationController = erpnext.selling.SellingController.extend({
 		this.frm.toggle_reqd("party_name", this.frm.doc.quotation_to);
 		this.frm.set_query('customer_address', this.address_query);
 		this.frm.set_query('shipping_address_name', this.address_query);
+		this.frm.set_query('contact_person', this.contact_query);
 	},
 
 	tc_name: function() {
@@ -156,6 +157,15 @@ erpnext.selling.QuotationController = erpnext.selling.SellingController.extend({
 	address_query: function(doc) {
 		return {
 			query: 'frappe.contacts.doctype.address.address.address_query',
+			filters: {
+				link_doctype: frappe.dynamic_link.doctype,
+				link_name: doc.party_name
+			}
+		};
+	},
+
+	contact_query: function(doc) {
+		return {
 			filters: {
 				link_doctype: frappe.dynamic_link.doctype,
 				link_name: doc.party_name


### PR DESCRIPTION
Before if you remove the contact person in quotation to change it the filter didn't use to works:
![Screenshot 2020-08-26 at 4 25 48 PM](https://user-images.githubusercontent.com/33727827/91295637-01992080-e7b9-11ea-9d3d-659708bb2884.png)

After the change, the values get fetch correctly:
![Screenshot 2020-08-26 at 4 24 40 PM](https://user-images.githubusercontent.com/33727827/91295701-1a093b00-e7b9-11ea-9ecc-407c5c3bd8e5.png)
