### PR TITLE
fix: Change fieldtype of Customer's PO in Sales Invoice

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
@@ -447,7 +447,7 @@
   {
    "allow_on_submit": 1,
    "fieldname": "po_no",
-   "fieldtype": "Small Text",
+   "fieldtype": "Data",
    "hide_days": 1,
    "hide_seconds": 1,
    "label": "Customer's Purchase Order",
@@ -1946,7 +1946,7 @@
  "idx": 181,
  "is_submittable": 1,
  "links": [],
- "modified": "2020-08-03 23:31:12.675040",
+ "modified": "2020-08-27 01:56:28.532140",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice",


### PR DESCRIPTION
**Before:**

![image](https://user-images.githubusercontent.com/50285544/91417093-e89e7700-e86d-11ea-84e1-fcb3d76e7cf9.png)


**After:**

![image](https://user-images.githubusercontent.com/50285544/91417138-f7852980-e86d-11ea-8bf0-c1e93c5fc97c.png)


Changed field type from small text to data to make it consistent with Purchase Invoice 