### PR TITLE
fix: BOM Update Tool failing due to Too Many Writes error

### DIFF
--- a/erpnext/manufacturing/doctype/bom_update_tool/bom_update_tool.py
+++ b/erpnext/manufacturing/doctype/bom_update_tool/bom_update_tool.py
@@ -90,12 +90,15 @@ def update_latest_price_in_all_boms():
 		update_cost()
 
 def replace_bom(args):
+	frappe.db.auto_commit_on_many_writes = 1
 	args = frappe._dict(args)
 
 	doc = frappe.get_doc("BOM Update Tool")
 	doc.current_bom = args.current_bom
 	doc.new_bom = args.new_bom
 	doc.replace_bom()
+
+	frappe.db.auto_commit_on_many_writes = 0
 
 def update_cost():
 	frappe.db.auto_commit_on_many_writes = 1


### PR DESCRIPTION
BOM Update tool replacing fails when there are too many BOMs to be updated:

![items](https://user-images.githubusercontent.com/24353136/91448042-059b7000-e897-11ea-8c9f-832d26e7fdd6.png)

**Error Log:**

![error-log](https://user-images.githubusercontent.com/24353136/91447971-ef8daf80-e896-11ea-9153-f79ab87e60d1.png)

**Fix**: Enable Auto Commit on many writes