### PR TITLE
fix: Better error feedback on creating SO from Quotation

### DIFF
--- a/erpnext/selling/doctype/quotation/quotation.py
+++ b/erpnext/selling/doctype/quotation/quotation.py
@@ -285,9 +285,17 @@ def _make_customer(source_name, ignore_permissions=False):
 						return customer
 					else:
 						raise
-				except frappe.MandatoryError:
+				except frappe.MandatoryError as e:
+					mandatory_fields = e.args[0].split(':')[1].split(',')
+					mandatory_fields = [customer.meta.get_label(field.strip()) for field in mandatory_fields]
+
 					frappe.local.message_log = []
-					frappe.throw(_("Please create Customer from Lead {0}").format(lead_name))
+					lead_link = frappe.utils.get_link_to_form("Lead", lead_name)
+					message = _("Could not auto create Customer due to the following missing mandatory field(s):") + "<br>"
+					message += "<br><ul><li>" + "</li><li>".join(mandatory_fields) + "</li></ul>"
+					message += _("Please create Customer from Lead {0}.").format(lead_link)
+
+					frappe.throw(message, title=_("Mandatory Missing"))
 			else:
 				return customer_name
 		else:


### PR DESCRIPTION
**Issue:**
- Manually create a Lead (without Territory set)
- (Optional): Remove Default Customer Group form Selling Settings
- Create Quotation from this Lead
- Create Sales Order from this quotation, you will see:
 ![ss](https://user-images.githubusercontent.com/25857446/91663100-6380bf80-eb04-11ea-9c38-b9bec060e1c3.png)
- The problem here is that a Mandatory fields 'Territory' and 'Customer Group' were missing in the auto created Customer, and the message is misleading

**Fix:**
-  Added specifics, formatting and title to error message
 ![Screenshot 2020-08-30 at 9 00 30 PM](https://user-images.githubusercontent.com/25857446/91663147-ab074b80-eb04-11ea-9625-18e88ddb5e55.png)
