### PR TITLE
fix: incorrect completed qty against operation in work order if workstation is different in job card

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -110,11 +110,10 @@ class JobCard(Document):
 		for_quantity, time_in_mins = 0, 0
 		from_time_list, to_time_list = [], []
 
-		field = "operation_id" if self.operation_id else "operation"
+		field = "operation_id"
 		data = frappe.get_all('Job Card',
 			fields = ["sum(total_time_in_mins) as time_in_mins", "sum(total_completed_qty) as completed_qty"],
-			filters = {"docstatus": 1, "work_order": self.work_order,
-				"workstation": self.workstation, field: self.get(field)})
+			filters = {"docstatus": 1, "work_order": self.work_order, field: self.get(field)})
 
 		if data and len(data) > 0:
 			for_quantity = data[0].completed_qty
@@ -127,14 +126,13 @@ class JobCard(Document):
 				FROM `tabJob Card` jc, `tabJob Card Time Log` jctl
 				WHERE
 					jctl.parent = jc.name and jc.work_order = %s
-					and jc.workstation = %s and jc.{0} = %s and jc.docstatus = 1
-			""".format(field), (self.work_order, self.workstation, self.get(field)), as_dict=1)
+					and jc.{0} = %s and jc.docstatus = 1
+			""".format(field), (self.work_order, self.get(field)), as_dict=1)
 
 			wo = frappe.get_doc('Work Order', self.work_order)
 
-			work_order_field = "name" if field == "operation_id" else field
 			for data in wo.operations:
-				if data.get(work_order_field) == self.get(field):
+				if data.get("name") == self.get(field):
 					data.completed_qty = for_quantity
 					data.actual_operation_time = time_in_mins
 					data.actual_start_time = time_data[0].start_time if time_data else None

--- a/erpnext/manufacturing/doctype/job_card/test_job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/test_job_card.py
@@ -5,6 +5,8 @@ from __future__ import unicode_literals
 
 import unittest
 import frappe
+from frappe.utils import random_string
+from erpnext.manufacturing.doctype.workstation.test_workstation import make_workstation
 from erpnext.manufacturing.doctype.work_order.test_work_order import make_wo_order_test_record
 from erpnext.manufacturing.doctype.job_card.job_card import OperationMismatchError
 
@@ -29,3 +31,37 @@ class TestJobCard(unittest.TestCase):
 				doc.operation_id = "Test Data"
 				self.assertRaises(OperationMismatchError, doc.save)
 
+	def test_job_card_with_different_work_station(self):
+		data = frappe.get_cached_value('BOM',
+			{'docstatus': 1, 'with_operations': 1, 'company': '_Test Company'}, ['name', 'item'])
+
+		if data:
+			bom, bom_item = data
+
+			work_order = make_wo_order_test_record(item=bom_item, qty=1, bom_no=bom)
+
+			job_card = frappe.get_all('Job Card',
+				filters = {'work_order': work_order.name},
+				fields = ["operation_id", "workstation", "name", "for_quantity"])[0]
+
+			if job_card:
+				workstation = frappe.db.get_value("Workstation",
+					{"name": ("not in", [job_card.workstation])}, "name")
+
+				if not workstation or job_card.workstation == workstation:
+					workstation = make_workstation(workstation_name=random_string(5)).name
+
+				doc = frappe.get_doc("Job Card", job_card.name)
+				doc.workstation = workstation
+				doc.append("time_logs", {
+					"from_time": "2009-01-01 12:06:25",
+					"to_time": "2009-01-01 12:37:25",
+					"time_in_mins": "31.00002",
+					"completed_qty": job_card.for_quantity
+				})
+				doc.submit()
+
+				completed_qty = frappe.db.get_value("Work Order Operation", job_card.operation_id, "completed_qty")
+				self.assertEqual(completed_qty, job_card.for_quantity)
+
+				doc.cancel()

--- a/erpnext/manufacturing/doctype/workstation/test_workstation.py
+++ b/erpnext/manufacturing/doctype/workstation/test_workstation.py
@@ -20,3 +20,18 @@ class TestWorkstation(unittest.TestCase):
 			"_Test Workstation 1", "Operation 1", "2013-02-02 05:00:00", "2013-02-02 20:00:00")
 		self.assertRaises(WorkstationHolidayError, check_if_within_operating_hours,
 			"_Test Workstation 1", "Operation 1", "2013-02-01 10:00:00", "2013-02-02 20:00:00")
+
+def make_workstation(**args):
+	args = frappe._dict(args)
+
+	try:
+		doc = frappe.get_doc({
+			"doctype": "Workstation",
+			"workstation_name": args.workstation_name
+		})
+
+		doc.insert()
+
+		return doc
+	except frappe.DuplicateEntryError:
+		return frappe.get_doc("Workstation", args.workstation_name)


### PR DESCRIPTION
**Issue**

1. Make work order with operations and submit it.

1. On submission of work order, system will auto create the Job Cards

1. Open first job card and submit it but before submit change the workstation

1. After that check the completed quantity against the operation in work order. You can see there is no update in the completed qty against the operation

**After Fix**

1. System will update the completed quantity in work order which has been set in the job card 