### PR TITLE
fix: events not deleted on cancelling maintenance schedule

### DIFF
--- a/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py
+++ b/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py
@@ -54,7 +54,7 @@ class MaintenanceSchedule(TransactionBase):
 					email_map[d.sales_person] = sp.get_email_id()
 				except frappe.ValidationError:
 					no_email_sp.append(d.sales_person)
-					
+
 			if no_email_sp:
 				frappe.msgprint(
 					frappe._("Setting Events to {0}, since the Employee attached to the below Sales Persons does not have a User ID{1}").format(
@@ -66,17 +66,17 @@ class MaintenanceSchedule(TransactionBase):
 				parent=%s""", (d.sales_person, d.item_code, self.name), as_dict=1)
 
 			for key in scheduled_date:
-				description =frappe._("Reference: {0}, Item Code: {1} and Customer: {2}").format(self.name, d.item_code, self.customer)	
-				frappe.get_doc({
+				description =frappe._("Reference: {0}, Item Code: {1} and Customer: {2}").format(self.name, d.item_code, self.customer)
+				event = frappe.get_doc({
 					"doctype": "Event",
 					"owner": email_map.get(d.sales_person, self.owner),
 					"subject": description,
 					"description": description,
 					"starts_on": cstr(key["scheduled_date"]) + " 10:00:00",
 					"event_type": "Private",
-					"ref_type": self.doctype,
-					"ref_name": self.name
-				}).insert(ignore_permissions=1)
+				})
+				event.add_participant(self.doctype, self.name)
+				event.insert(ignore_permissions=1)
 
 		frappe.db.set(self, 'status', 'Submitted')
 

--- a/erpnext/maintenance/doctype/maintenance_schedule/test_maintenance_schedule.py
+++ b/erpnext/maintenance/doctype/maintenance_schedule/test_maintenance_schedule.py
@@ -2,6 +2,7 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 from __future__ import unicode_literals
+from frappe.utils.data import get_datetime, add_days
 
 import frappe
 import unittest
@@ -9,4 +10,39 @@ import unittest
 # test_records = frappe.get_test_records('Maintenance Schedule')
 
 class TestMaintenanceSchedule(unittest.TestCase):
-	pass
+	def events_should_be_created_and_deleted(self):
+		ms = make_maintenance_schedule()
+		ms.generate_schedule()
+		ms.submit()
+
+		all_events = get_events(ms)
+		self.assertTrue(len(all_events) > 0)
+
+		ms.cancel()
+		events_after_cancel = get_events(ms)
+		self.assertTrue(len(events_after_cancel) == 0)
+
+def get_events(ms):
+	return frappe.get_all("Event Participants", filters={
+			"reference_doctype": ms.doctype,
+			"reference_docname": ms.name,
+			"parenttype": "Event"
+		})
+
+def make_maintenance_schedule():
+	ms = frappe.new_doc("Maintenance Schedule")
+	ms.company = "_Test Company"
+	ms.customer = "_Test Customer"
+	ms.transaction_date = get_datetime()
+
+	ms.append("items", {
+		"item_code": "_Test Item",
+		"start_date": get_datetime(),
+		"end_date": add_days(get_datetime(), 32),
+		"periodicity": "Weekly",
+		"no_of_visits": 4,
+		"sales_person": "Sales Team",
+	})
+	ms.insert(ignore_permissions=True)
+
+	return ms

--- a/erpnext/maintenance/doctype/maintenance_schedule/test_maintenance_schedule.py
+++ b/erpnext/maintenance/doctype/maintenance_schedule/test_maintenance_schedule.py
@@ -10,7 +10,7 @@ import unittest
 # test_records = frappe.get_test_records('Maintenance Schedule')
 
 class TestMaintenanceSchedule(unittest.TestCase):
-	def events_should_be_created_and_deleted(self):
+	def test_events_should_be_created_and_deleted(self):
 		ms = make_maintenance_schedule()
 		ms.generate_schedule()
 		ms.submit()


### PR DESCRIPTION
Backport of https://github.com/frappe/erpnext/pull/22954

---

When cancelling a maintenance schedule, associated events would not be deleted. This was because they were not created properly in the first place. 

This PR fixes that

Depends On: https://github.com/frappe/frappe/pull/11221 [Merged]