### PR TITLE
fix(Payroll Entry): Set cost center for payroll payable account

### DIFF
--- a/erpnext/hr/doctype/payroll_entry/payroll_entry.py
+++ b/erpnext/hr/doctype/payroll_entry/payroll_entry.py
@@ -290,6 +290,7 @@ class PayrollEntry(Document):
 				"account": default_payroll_payable_account,
 				"credit_in_account_currency": flt(payable_amount, precision),
 				"party_type": '',
+				"cost_center": self.cost_center
 			})
 
 			journal_entry.set("accounts", accounts)


### PR DESCRIPTION
**Problem:**

While submitting salary slips, if the default company is not the same as the company in the salary slip, the accrual Journal Entry picks up the cost center of the default company instead of the cost center set in the transaction thereby showing this validation:

![image](https://user-images.githubusercontent.com/24353136/91731450-78248c80-ebc4-11ea-83c9-1eae78026971.png)

**Fix:** Set the cost center for Payroll Payable Account while making accrual Journal Entry