### PR TITLE
fix: Get Items from Product Bundle in Purchase Order

### DIFF
--- a/erpnext/public/js/controllers/buying.js
+++ b/erpnext/public/js/controllers/buying.js
@@ -508,7 +508,7 @@ erpnext.buying.get_items_from_product_bundle = function(frm) {
 						var d = frm.add_child("items");
 						var item = r.message[i];
 						for ( var key in  item) {
-							if ( !is_null(item[key]) ) {
+							if ( !is_null(item[key]) && key !== "doctype" ) {
 								d[key] = item[key];
 							}
 						}


### PR DESCRIPTION
Port of https://github.com/frappe/erpnext/pull/22821
**Before:**
![v-12-prod-bundle-before](https://user-images.githubusercontent.com/25857446/91835007-6e536580-ec66-11ea-8bd0-810238b74b44.gif)

**After:**
![v-12-prod-bundle-after](https://user-images.githubusercontent.com/25857446/91835173-a65aa880-ec66-11ea-93f7-bc26b716bd99.gif)
