### PR TITLE
fix: Update tax template on supplier address change

### DIFF
--- a/erpnext/regional/india/taxes.js
+++ b/erpnext/regional/india/taxes.js
@@ -6,6 +6,9 @@ erpnext.setup_auto_gst_taxation = (doctype) => {
 		shipping_address: function(frm) {
 			frm.trigger('get_tax_template');
 		},
+		supplier_address: function(frm) {
+			frm.trigger('get_tax_template');
+		},
 		tax_category: function(frm) {
 			frm.trigger('get_tax_template');
 		},


### PR DESCRIPTION
A single supplier can have address in multiple states for example Maharashtra and Gujarat

On changing supplier address tax template was not update based on tax category assigned
For example on selecting address of Maharashtra  CGST, SGST should be fetched and on selecting Gujarat's address IGST should be auto pulled

![GST fix](https://user-images.githubusercontent.com/42651287/91841340-ccd11180-ec6f-11ea-845c-1ae4a253e0e2.gif)
  