### PR TITLE
fix(buying): fetch received qty on purchase receipt items

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -357,6 +357,7 @@ def set_missing_values(source, target):
 def make_purchase_receipt(source_name, target_doc=None):
 	def update_item(obj, target, source_parent):
 		target.qty = flt(obj.qty) - flt(obj.received_qty)
+		target.received_qty = target.qty
 		target.stock_qty = (flt(obj.qty) - flt(obj.received_qty)) * flt(obj.conversion_factor)
 		target.amount = (flt(obj.qty) - flt(obj.received_qty)) * flt(obj.rate)
 		target.base_amount = (flt(obj.qty) - flt(obj.received_qty)) * \


### PR DESCRIPTION
**Problem:**
It doesn't fetch the received qty on Purchase Receipt items when created from a Purchase Order or when used the button "Get item from" a Purchase Order.

![PO-PR](https://user-images.githubusercontent.com/13060550/91873606-d91c9500-ec96-11ea-8afc-2482b2897f02.gif)

![get-items-from-PO](https://user-images.githubusercontent.com/13060550/91873616-dc178580-ec96-11ea-87c6-46232e2d2981.gif)

**With the changes suggested:**

![PO-PR-fix](https://user-images.githubusercontent.com/13060550/91874526-f56d0180-ec97-11ea-9c7e-da333e22a901.gif)


![get-items-PR-fix](https://user-images.githubusercontent.com/13060550/91874209-90b1a700-ec97-11ea-8024-e1f016fb3f35.gif)

