### PR TITLE
fix: set conversion factor while creating RFQ from Opportunity

### DIFF
--- a/erpnext/buying/doctype/request_for_quotation/test_request_for_quotation.py
+++ b/erpnext/buying/doctype/request_for_quotation/test_request_for_quotation.py
@@ -11,6 +11,8 @@ from erpnext.stock.doctype.item.test_item import make_item
 from erpnext.templates.pages.rfq import check_supplier_has_docname_access
 from erpnext.buying.doctype.request_for_quotation.request_for_quotation import make_supplier_quotation
 from erpnext.buying.doctype.request_for_quotation.request_for_quotation import create_supplier_quotation
+from erpnext.crm.doctype.opportunity.test_opportunity import make_opportunity
+from erpnext.crm.doctype.opportunity.opportunity import make_request_for_quotation as make_rfq
 
 class TestRequestforQuotation(unittest.TestCase):
 	def test_quote_status(self):
@@ -109,6 +111,23 @@ class TestRequestforQuotation(unittest.TestCase):
 
 		self.assertEqual(supplier_quotation.items[0].qty, 5)
 		self.assertEqual(supplier_quotation.items[0].stock_qty, 10)
+
+	def test_make_rfq_from_opportunity(self):
+		opportunity = make_opportunity(with_items=1)
+		supplier_data = get_supplier_data()
+		rfq = make_rfq(opportunity.name)
+
+		self.assertEqual(len(rfq.get("items")), len(opportunity.get("items")))
+		rfq.message_for_supplier = 'Please supply the specified items at the best possible rates.'
+
+		for item in rfq.items:
+			item.warehouse = "_Test Warehouse - _TC"
+
+		for data in supplier_data:
+			rfq.append('suppliers', data)
+
+		rfq.status = 'Draft'
+		rfq.submit()
 
 def make_request_for_quotation(**args):
 	"""

--- a/erpnext/crm/doctype/opportunity/opportunity.py
+++ b/erpnext/crm/doctype/opportunity/opportunity.py
@@ -267,6 +267,12 @@ def make_quotation(source_name, target_doc=None):
 
 @frappe.whitelist()
 def make_request_for_quotation(source_name, target_doc=None):
+	def set_missing_values(source, target):
+		rfq = frappe.get_doc(target)
+		for item in rfq.items:
+			# opportunity item is not multi-uom
+			item.conversion_factor = 1.0
+
 	doclist = get_mapped_doc("Opportunity", source_name, {
 		"Opportunity": {
 			"doctype": "Request for Quotation"
@@ -279,7 +285,7 @@ def make_request_for_quotation(source_name, target_doc=None):
 				["uom", "uom"]
 			]
 		}
-	}, target_doc)
+	}, target_doc, set_missing_values)
 
 	return doclist
 

--- a/erpnext/crm/doctype/opportunity/opportunity.py
+++ b/erpnext/crm/doctype/opportunity/opportunity.py
@@ -267,11 +267,8 @@ def make_quotation(source_name, target_doc=None):
 
 @frappe.whitelist()
 def make_request_for_quotation(source_name, target_doc=None):
-	def set_missing_values(source, target):
-		rfq = frappe.get_doc(target)
-		for item in rfq.items:
-			# opportunity item is not multi-uom
-			item.conversion_factor = 1.0
+	def update_item(obj, target, source_parent):
+		target.conversion_factor = 1.0
 
 	doclist = get_mapped_doc("Opportunity", source_name, {
 		"Opportunity": {
@@ -283,9 +280,10 @@ def make_request_for_quotation(source_name, target_doc=None):
 				["name", "opportunity_item"],
 				["parent", "opportunity"],
 				["uom", "uom"]
-			]
+			],
+			"postprocess": update_item
 		}
-	}, target_doc, set_missing_values)
+	}, target_doc)
 
 	return doclist
 

--- a/erpnext/crm/doctype/opportunity/test_opportunity.py
+++ b/erpnext/crm/doctype/opportunity/test_opportunity.py
@@ -82,7 +82,8 @@ def make_opportunity(**args):
 	if args.with_items:
 		opp_doc.append('items', {
 			"item_code": args.item_code or "_Test Item",
-			"qty": args.qty or 1
+			"qty": args.qty or 1,
+			"uom": "_Test UOM"
 		})
 
 	opp_doc.insert()


### PR DESCRIPTION
**Steps to replicate:**

1. Created Opportunity.
2. Select items in opportunity, with default UOM only
3. Create new RFQ
4. Select Opportunity in RFQ using **Get Items** option
5. Item is fetched in RFQ. Warehouse is selected
6. When saving RFQ, it throws the mandatory validation: conversion factor is 0.

Though it fetched default UoM correctly, but conversion factor was not set as 1

![gif](https://user-images.githubusercontent.com/24353136/91943994-0b6fd600-ed1b-11ea-820e-3a8dc3bad479.gif)
