### PR TITLE
fix: Account filter in Process Deferred Accounting doctype

### DIFF
--- a/erpnext/accounts/doctype/process_deferred_accounting/process_deferred_accounting.js
+++ b/erpnext/accounts/doctype/process_deferred_accounting/process_deferred_accounting.js
@@ -10,13 +10,15 @@ frappe.ui.form.on('Process Deferred Accounting', {
 				}
 			};
 		});
+	},
 
-		if (frm.doc.company) {
+	type: function(frm) {
+		if (frm.doc.company && frm.doc.type) {
 			frm.set_query("account", function() {
 				return {
 					filters: {
 						'company': frm.doc.company,
-						'root_type': 'Liability',
+						'root_type': frm.doc.type === 'Income' ? 'Liability' : 'Asset',
 						'is_group': 0
 					}
 				};

--- a/erpnext/accounts/doctype/process_deferred_accounting/process_deferred_accounting.json
+++ b/erpnext/accounts/doctype/process_deferred_accounting/process_deferred_accounting.json
@@ -60,6 +60,7 @@
    "reqd": 1
   },
   {
+   "depends_on": "eval: doc.type",
    "fieldname": "account",
    "fieldtype": "Link",
    "label": "Account",
@@ -73,9 +74,10 @@
    "reqd": 1
   }
  ],
+ "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2020-02-06 18:18:09.852844",
+ "modified": "2020-09-03 18:07:02.463754",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Process Deferred Accounting",


### PR DESCRIPTION
In case of type as "Income" liability accounts should be visible:
<img width="1229" alt="Screenshot 2020-09-03 at 6 32 50 PM" src="https://user-images.githubusercontent.com/42651287/92118416-15c1cb00-ee14-11ea-9705-c64ef74912ee.png">

In case of type as "Expense" asset accounts should be visible:
<img width="1212" alt="Screenshot 2020-09-03 at 6 32 39 PM" src="https://user-images.githubusercontent.com/42651287/92118437-1a867f00-ee14-11ea-9c75-a1c345850ac2.png">
 