### PR TITLE
fix: Supplier Leaderboard

### DIFF
--- a/erpnext/startup/leaderboard.py
+++ b/erpnext/startup/leaderboard.py
@@ -123,7 +123,8 @@ def get_all_suppliers(date_range, company, field, limit = None):
 	if field == "outstanding_amount":
 		filters = [['docstatus', '=', '1'], ['company', '=', company]]
 		if date_range:
-			filters.append(['posting_date', 'between' [date_range[0], date_range[1]]])
+			date_range = frappe.parse_json(date_range)
+			filters.append(['posting_date', 'between', [date_range[0], date_range[1]]])
 		return frappe.db.get_all('Purchase Invoice',
 			fields = ['supplier as name', 'sum(outstanding_amount) as value'],
 			filters = filters,


### PR DESCRIPTION
Fixes https://github.com/frappe/erpnext/issues/22906

- On accessing **Supplier** Leaderboard with Date Range
 ![Screenshot 2020-09-03 at 7 04 16 PM](https://user-images.githubusercontent.com/25857446/92126687-1d866d00-ee1e-11ea-87dd-509f55d16018.png)

- Added missing comma in filters and parsed from string before list indexing