### PR TITLE
fix: Stock qty in HSN wise outward summary

### DIFF
--- a/erpnext/regional/report/hsn_wise_summary_of_outward_supplies/hsn_wise_summary_of_outward_supplies.py
+++ b/erpnext/regional/report/hsn_wise_summary_of_outward_supplies/hsn_wise_summary_of_outward_supplies.py
@@ -43,6 +43,12 @@ def _execute(filters=None):
 
 			data.append(row)
 			added_item.append((d.parent, d.item_code))
+		# gst is already added, just add qty and taxable value
+		else:
+			row = [d.gst_hsn_code, d.description, d.stock_uom, d.stock_qty, d.base_net_amount, d.base_net_amount]
+			for tax in tax_columns:
+				row += [0]
+			data.append(row)
 	if data:
 		data = get_merged_data(columns, data) # merge same hsn code data
 	return columns, data


### PR DESCRIPTION
**Issue:** Stock qty in GST Itemised sales register and HSN wise summary of outward supplies

Steps to check:
- Create a GST Sales Invoice with item having GST HSN code added in item master, add the same item twice in that invoice
- Check GST itemised sales register and HSN wise summary of outward supplies, the stock qty, tax amounts, total amount and taxable amount should match 