### PR TITLE
fix: capture advance payments in payment order

### DIFF
--- a/erpnext/accounts/doctype/bank_transaction/test_bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/test_bank_transaction.py
@@ -101,7 +101,7 @@ def create_bank_account(bank_name="Citi Bank", account_name="_Test Bank - _TC"):
 		pass
 
 	try:
-		doc = frappe.get_doc({
+		frappe.get_doc({
 			"doctype": "Bank Account",
 			"account_name":"Checking Account",
 			"bank": bank_name,

--- a/erpnext/accounts/doctype/bank_transaction/test_bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/test_bank_transaction.py
@@ -91,28 +91,31 @@ class TestBankTransaction(unittest.TestCase):
 		self.assertEqual(frappe.db.get_value("Bank Transaction", bank_transaction.name, "unallocated_amount"), 0)
 		self.assertTrue(frappe.db.get_value("Sales Invoice Payment", dict(parent=payment.name), "clearance_date") is not None)
 
+def create_bank_account(bank_name="Citi Bank", account_name="_Test Bank - _TC"):
+	try:
+		frappe.get_doc({
+			"doctype": "Bank",
+			"bank_name":bank_name,
+		}).insert()
+	except frappe.DuplicateEntryError:
+		pass
+
+	try:
+		doc = frappe.get_doc({
+			"doctype": "Bank Account",
+			"account_name":"Checking Account",
+			"bank": bank_name,
+			"account": account_name
+		}).insert()
+	except frappe.DuplicateEntryError:
+		pass
+
 def add_transactions():
 	if frappe.flags.test_bank_transactions_created:
 		return
 
 	frappe.set_user("Administrator")
-	try:
-		frappe.get_doc({
-			"doctype": "Bank",
-			"bank_name":"Citi Bank",
-		}).insert()
-	except frappe.DuplicateEntryError:
-		pass
-
-	try:
-		frappe.get_doc({
-			"doctype": "Bank Account",
-			"account_name":"Checking Account",
-			"bank": "Citi Bank",
-			"account": "_Test Bank - _TC"
-		}).insert()
-	except frappe.DuplicateEntryError:
-		pass
+	create_bank_account()
 
 	doc = frappe.get_doc({
 		"doctype": "Bank Transaction",

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -1172,30 +1172,23 @@ def make_payment_order(source_name, target_doc=None):
 	from frappe.model.mapper import get_mapped_doc
 	def set_missing_values(source, target):
 		target.payment_order_type = "Payment Entry"
+		target.append('references', dict(
+			reference_doctype="Payment Entry",
+			reference_name=source.name,
+			bank_account=source.party_bank_account,
+			amount=source.paid_amount,
+			account=source.paid_to,
+			supplier=source.party,
+			mode_of_payment=source.mode_of_payment,
+		))
 
-	def update_item(source_doc, target_doc, source_parent):
-		target_doc.bank_account = source_parent.party_bank_account
-		target_doc.amount = source_doc.allocated_amount
-		target_doc.account = source_parent.paid_to
-		target_doc.payment_entry = source_parent.name
-		target_doc.supplier = source_parent.party
-		target_doc.mode_of_payment = source_parent.mode_of_payment
-
-
-	doclist = get_mapped_doc("Payment Entry", source_name,	{
+	doclist = get_mapped_doc("Payment Entry", source_name, {
 		"Payment Entry": {
 			"doctype": "Payment Order",
 			"validation": {
 				"docstatus": ["=", 1]
-			}
-		},
-		"Payment Entry Reference": {
-			"doctype": "Payment Order Reference",
-			"validation": {
-				"docstatus": ["=", 1]
 			},
-			"postprocess": update_item
-		},
+		}
 
 	}, target_doc, set_missing_values)
 

--- a/erpnext/accounts/doctype/payment_order/payment_order.py
+++ b/erpnext/accounts/doctype/payment_order/payment_order.py
@@ -21,10 +21,15 @@ class PaymentOrder(Document):
 		if cancel:
 			status = 'Initiated'
 
-		ref_field = "status" if self.payment_order_type == "Payment Request" else "payment_order_status"
+		if self.payment_order_type == "Payment Request":
+			ref_field = "status"
+			ref_doc_field = frappe.scrub(self.payment_order_type)
+		else:
+			ref_field = "payment_order_status"
+			ref_doc_field = "reference_name"
 
 		for d in self.references:
-			frappe.db.set_value(self.payment_order_type, d.get(frappe.scrub(self.payment_order_type)), ref_field, status)
+			frappe.db.set_value(self.payment_order_type, d.get(ref_doc_field), ref_field, status)
 
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs

--- a/erpnext/accounts/doctype/payment_order/test_payment_order.py
+++ b/erpnext/accounts/doctype/payment_order/test_payment_order.py
@@ -7,8 +7,8 @@ import frappe
 import unittest
 from frappe.utils import getdate
 from erpnext.accounts.doctype.bank_transaction.test_bank_transaction import create_bank_account
-from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry, InvalidPaymentEntry, make_payment_order
-from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice, make_purchase_invoice_against_cost_center
+from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry, make_payment_order
+from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice
 
 class TestPaymentOrder(unittest.TestCase):
 	def setUp(self):

--- a/erpnext/accounts/doctype/payment_order/test_payment_order.py
+++ b/erpnext/accounts/doctype/payment_order/test_payment_order.py
@@ -5,6 +5,39 @@ from __future__ import unicode_literals
 
 import frappe
 import unittest
+from frappe.utils import getdate
+from erpnext.accounts.doctype.bank_transaction.test_bank_transaction import create_bank_account
+from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry, InvalidPaymentEntry, make_payment_order
+from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice, make_purchase_invoice_against_cost_center
 
 class TestPaymentOrder(unittest.TestCase):
-	pass
+	def setUp(self):
+		create_bank_account()
+
+	def test_payment_order_creation_against_payment_entry(self):
+		purchase_invoice = make_purchase_invoice()
+		payment_entry = get_payment_entry("Purchase Invoice", purchase_invoice.name, bank_account="_Test Bank - _TC")
+		payment_entry.reference_no = "_Test_Payment_Order"
+		payment_entry.reference_date = getdate()
+		payment_entry.party_bank_account = "Checking Account - Citi Bank"
+		payment_entry.insert()
+		payment_entry.submit()
+
+		doc = create_payment_order_against_payment_entry(payment_entry, "Payment Entry")
+		reference_doc = doc.get("references")[0]
+		self.assertEquals(reference_doc.reference_name, payment_entry.name)
+		self.assertEquals(reference_doc.reference_doctype, "Payment Entry")
+		self.assertEquals(reference_doc.supplier, "_Test Supplier")
+		self.assertEquals(reference_doc.amount, 250)
+
+def create_payment_order_against_payment_entry(ref_doc, order_type):
+	payment_order = frappe.get_doc(dict(
+		doctype="Payment Order",
+		company="_Test Company",
+		payment_order_type=order_type,
+		company_bank_account="Checking Account - Citi Bank"
+	))
+	doc = make_payment_order(ref_doc.name, payment_order)
+	doc.save()
+	doc.submit()
+	return doc

--- a/erpnext/accounts/doctype/payment_order/test_payment_order.py
+++ b/erpnext/accounts/doctype/payment_order/test_payment_order.py
@@ -14,6 +14,12 @@ class TestPaymentOrder(unittest.TestCase):
 	def setUp(self):
 		create_bank_account()
 
+	def tearDown(self):
+		for bt in frappe.get_all("Payment Order"):
+			doc = frappe.get_doc("Payment Order", bt.name)
+			doc.cancel()
+			doc.delete()
+
 	def test_payment_order_creation_against_payment_entry(self):
 		purchase_invoice = make_purchase_invoice()
 		payment_entry = get_payment_entry("Purchase Invoice", purchase_invoice.name, bank_account="_Test Bank - _TC")

--- a/erpnext/accounts/doctype/payment_order_reference/payment_order_reference.json
+++ b/erpnext/accounts/doctype/payment_order_reference/payment_order_reference.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "creation": "2018-07-20 16:38:06.630813",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -10,7 +11,6 @@
   "column_break_4",
   "supplier",
   "payment_request",
-  "payment_entry",
   "mode_of_payment",
   "bank_account_details",
   "bank_account",
@@ -103,17 +103,12 @@
    "no_copy": 1,
    "print_hide": 1,
    "read_only": 1
-  },
-  {
-   "fieldname": "payment_entry",
-   "fieldtype": "Link",
-   "label": "Payment Entry",
-   "options": "Payment Entry",
-   "read_only": 1
   }
  ],
+ "index_web_pages_for_search": 1,
  "istable": 1,
- "modified": "2019-05-08 13:56:25.724557",
+ "links": [],
+ "modified": "2020-09-04 08:29:51.014390",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Order Reference",


### PR DESCRIPTION
- **Issue:** Currently, advance payments are not fetched in payment entry, payment order that is suppose to be submitted as a report for payments should have all these details too. Also, if payment order shouldn't split a single payment entry into multiple invoices.
- **Proposed Fix:** Fetch a single entry in payment order reference against a payment entry with amount equal to paid amount.
![Kapture 2020-09-04 at 12 22 43](https://user-images.githubusercontent.com/14824451/92210298-160da500-eeac-11ea-883d-00b7d56c704b.gif)

