### PR TITLE
fix: SE quantity data type issue

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -513,7 +513,7 @@ class StockEntry(StockController):
 						d.basic_amount = flt((raw_material_cost - scrap_material_cost), d.precision("basic_amount"))
 					elif self.purpose == "Repack" and total_fg_qty and not d.set_basic_rate_manually:
 						d.basic_rate = flt(raw_material_cost) / flt(total_fg_qty)
-						d.basic_amount = d.basic_rate * d.qty
+						d.basic_amount = d.basic_rate * flt(d.qty)
 
 	def distribute_additional_costs(self):
 		if self.purpose == "Material Issue":


### PR DESCRIPTION
Issue - getting quantity as string format

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2020-08-26/apps/frappe/frappe/desk/form/save.py", line 21, in savedocs
    doc.save()
  File "/home/frappe/benches/bench-version-12-2020-08-26/apps/frappe/frappe/model/document.py", line 273, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2020-08-26/apps/frappe/frappe/model/document.py", line 296, in _save
    self.insert()
  File "/home/frappe/benches/bench-version-12-2020-08-26/apps/frappe/frappe/model/document.py", line 230, in insert
    self.run_before_save_methods()
  File "/home/frappe/benches/bench-version-12-2020-08-26/apps/frappe/frappe/model/document.py", line 896, in run_before_save_methods
    self.run_method("validate")
  File "/home/frappe/benches/bench-version-12-2020-08-26/apps/frappe/frappe/model/document.py", line 797, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2020-08-26/apps/frappe/frappe/model/document.py", line 1073, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2020-08-26/apps/frappe/frappe/model/document.py", line 1056, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-version-12-2020-08-26/apps/frappe/frappe/model/document.py", line 791, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2020-08-26/apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.py", line 78, in validate
    self.set_incoming_rate()
  File "/home/frappe/benches/bench-version-12-2020-08-26/apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.py", line 365, in set_incoming_rate
    self.set_basic_rate_for_finished_goods()
  File "/home/frappe/benches/bench-version-12-2020-08-26/apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.py", line 503, in set_basic_rate_for_finished_goods
    d.basic_amount = d.basic_rate * d.qty
TypeError: can't multiply sequence by non-int of type 'float'
```