### PR TITLE
fix: production plan incorrect work order qty

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
@@ -159,12 +159,11 @@ class TestProductionPlan(unittest.TestCase):
 		self.assertTrue(mr.customer, '_Test Customer')
 
 	def test_production_plan_with_multi_level_bom(self):
-		'''
-			Item Code				Qty
-			Test BOM 1	 			1
-				Test BOM 2			2
-					Test BOM 3		3
-		'''
+		#|Item Code			|	Qty	|
+		#|Test BOM 1	 		|	1	|
+		#|	Test BOM 2		|	2	|
+		#|		Test BOM 3	|	3	|
+
 		for item_code in ["Test BOM 1", "Test BOM 2", "Test BOM 3", "Test RM BOM 1"]:
 			create_item(item_code, is_stock_item=1)
 

--- a/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
@@ -158,6 +158,47 @@ class TestProductionPlan(unittest.TestCase):
 		self.assertTrue(mr.material_request_type, 'Customer Provided')
 		self.assertTrue(mr.customer, '_Test Customer')
 
+	def test_production_plan_with_multi_level_bom(self):
+		'''
+			Item Code				Qty
+			Test BOM 1	 			1
+				Test BOM 2			2
+					Test BOM 3		3
+		'''
+		for item_code in ["Test BOM 1", "Test BOM 2", "Test BOM 3", "Test RM BOM 1"]:
+			create_item(item_code, is_stock_item=1)
+
+		# created bom upto 3 level
+		if not frappe.db.get_value('BOM', {'item': "Test BOM 3"}):
+			make_bom(item = "Test BOM 3", raw_materials = ["Test RM BOM 1"], rm_qty=3)
+
+		if not frappe.db.get_value('BOM', {'item': "Test BOM 2"}):
+			make_bom(item = "Test BOM 2", raw_materials = ["Test BOM 3"], rm_qty=3)
+
+		if not frappe.db.get_value('BOM', {'item': "Test BOM 1"}):
+			make_bom(item = "Test BOM 1", raw_materials = ["Test BOM 2"], rm_qty=2)
+
+		item_code = "Test BOM 1"
+		pln = frappe.new_doc('Production Plan')
+		pln.company = "_Test Company"
+		pln.append("po_items", {
+			"item_code": item_code,
+			"bom_no": frappe.db.get_value('BOM', {'item': "Test BOM 1"}),
+			"planned_qty": 3,
+			"make_work_order_for_sub_assembly_items": 1
+		})
+
+		pln.submit()
+		pln.make_work_order()
+
+		#last level sub-assembly work order produce qty
+		to_produce_qty = frappe.db.get_value("Work Order",
+			{"production_plan": pln.name, "production_item": "Test BOM 3"}, "qty")
+
+		self.assertEqual(to_produce_qty, 18.0)
+		pln.cancel()
+		frappe.delete_doc("Production Plan", pln.name)
+
 def create_production_plan(**args):
 	args = frappe._dict(args)
 
@@ -205,7 +246,7 @@ def make_bom(**args):
 
 		bom.append('items', {
 			'item_code': item,
-			'qty': 1,
+			'qty': args.rm_qty or 1.0,
 			'uom': item_doc.stock_uom,
 			'stock_uom': item_doc.stock_uom,
 			'rate': item_doc.valuation_rate or args.rate,


### PR DESCRIPTION
**Issue**

1. Make multilevel(upto 3-4) Sub-assembly items with more than one quantity BOM

1. Create production plan and click on Make Work Order (make sure Make Work Order for Sub Assembly Items has enabled)

1. Then check system created work order's qty, the sub-assembly quantity has not correct (see attachment)
<img width="832" alt="Screenshot 2020-09-04 at 5 17 47 PM" src="https://user-images.githubusercontent.com/8780500/92236675-7d8b1b00-eed3-11ea-90d8-ea1683f2e842.png">


**After Fix**
<img width="659" alt="Screenshot 2020-09-04 at 5 12 58 PM" src="https://user-images.githubusercontent.com/8780500/92236689-84b22900-eed3-11ea-80ab-30825c50c882.png">
