### PR TITLE
fix(utils): pass stock_qty to get_pricing_rule_for_item

### DIFF
--- a/erpnext/utilities/product.py
+++ b/erpnext/utilities/product.py
@@ -82,6 +82,7 @@ def get_price(item_code, price_list, customer_group, company, qty=1):
 			pricing_rule = get_pricing_rule_for_item(frappe._dict({
 				"item_code": item_code,
 				"qty": qty,
+				"stock_qty": qty,
 				"transaction_type": "selling",
 				"price_list": price_list,
 				"customer_group": customer_group,


### PR DESCRIPTION
The get_pricing_rule_for_item function uses the _stock_qty_ and _qty_ arguments to filter pricing rules on.

The get_price function in erpnext/utilities/product.py is used by, for example the shopping cart. It is only passing the _qty_ argument, which breaks the functionality to apply pricing rules based on quantity.

Reference to get_pricing_rule_for_item where stock_qty is used: https://github.com/frappe/erpnext/blob/develop/erpnext/accounts/doctype/pricing_rule/utils.py#L175

This PR makes get_price also pass the _stock_qty_ argument.
