### PR TITLE
fix: sql error on saving sales invoice without a sales order

### DIFF
--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -80,7 +80,7 @@ class SellingController(StockController):
 
 			party_details = _get_party_details(customer,
 				ignore_permissions=self.flags.ignore_permissions,
-				posting_date=self.posting_date if self.posting_date else None,
+				posting_date=self.posting_date if hasattr(self, 'posting_date') else None,
 				doctype=self.doctype, company=self.company,
 				fetch_payment_terms_template=fetch_payment_terms_template,
 				party_address=self.customer_address, shipping_address=self.shipping_address_name)

--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -80,6 +80,7 @@ class SellingController(StockController):
 
 			party_details = _get_party_details(customer,
 				ignore_permissions=self.flags.ignore_permissions,
+				posting_date=self.posting_date if self.posting_date else None,
 				doctype=self.doctype, company=self.company,
 				fetch_payment_terms_template=fetch_payment_terms_template,
 				party_address=self.customer_address, shipping_address=self.shipping_address_name)


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

- erpnext/controllers/selling_controller.py", line 85, in set_missing_lead_customer_details doesn't pass a value for posting_date
- erpnext/accounts/party.py, line 60, in _get_party_details requires posting_date or it defaults to None

Fix is if self.posting_date is set pass details to party._get_party_details, if not pass None - which is the default behaviour of party._get_party_details

closes #23276 

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
