### PR TITLE
fix: asset movement date for backdated asset entry

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -146,7 +146,7 @@ class Asset(AccountsController):
 			'assets': assets,
 			'purpose': 'Receipt',
 			'company': self.company,
-			'transaction_date': getdate(nowdate()),
+			'transaction_date': getdate(self.purchase_date),
 			'reference_doctype': reference_doctype,
 			'reference_name': reference_docname
 		}).insert()


### PR DESCRIPTION
Problem: First asset movement was made based on the time of submitting asset. For an asset which was purchased earlier but the record is submitted today had its auto generated asset movement's transaction date as today.