### PR TITLE
fix: change start and end field values in Job Card calendar settings

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card_calendar.js
+++ b/erpnext/manufacturing/doctype/job_card/job_card_calendar.js
@@ -1,7 +1,7 @@
 frappe.views.calendar["Job Card"] = {
 	field_map: {
-		"start": "from_time",
-		"end": "to_time",
+		"start": "started_time",
+		"end": "started_time",
 		"id": "name",
 		"title": "subject",
 		"color": "color",


### PR DESCRIPTION
`from_time` and `to_time` are child table fields which breaks Gantt view, causing:
<img width="1440" alt="Screenshot 2020-09-09 at 3 37 39 PM" src="https://user-images.githubusercontent.com/19775888/92585316-6e7ce200-f2b2-11ea-8235-b553413640cf.png">
