### PR TITLE
fix: Make sure Supplier/Customer is selected before fetching Items(ux)

### DIFF
--- a/erpnext/stock/doctype/delivery_note/delivery_note.js
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.js
@@ -130,12 +130,18 @@ erpnext.stock.DeliveryNoteController = erpnext.selling.SellingController.extend(
 			if (this.frm.doc.docstatus===0) {
 				this.frm.add_custom_button(__('Sales Order'),
 					function() {
+						if (!me.frm.doc.customer) {
+							frappe.throw({
+								title: __("Mandatory"),
+								message: __("Please Select a Customer")
+							});
+						}
 						erpnext.utils.map_current_doc({
 							method: "erpnext.selling.doctype.sales_order.sales_order.make_delivery_note",
 							source_doctype: "Sales Order",
 							target: me.frm,
 							setters: {
-								customer: me.frm.doc.customer || undefined,
+								customer: me.frm.doc.customer,
 							},
 							get_query_filters: {
 								docstatus: 1,

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.js
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.js
@@ -116,12 +116,18 @@ erpnext.stock.PurchaseReceiptController = erpnext.buying.BuyingController.extend
 			if (this.frm.doc.docstatus == 0) {
 				this.frm.add_custom_button(__('Purchase Order'),
 					function () {
+						if (!me.frm.doc.supplier) {
+							frappe.throw({
+								title: __("Mandatory"),
+								message: __("Please Select a Supplier")
+							});
+						}
 						erpnext.utils.map_current_doc({
 							method: "erpnext.buying.doctype.purchase_order.purchase_order.make_purchase_receipt",
 							source_doctype: "Purchase Order",
 							target: me.frm,
 							setters: {
-								supplier: me.frm.doc.supplier || undefined,
+								supplier: me.frm.doc.supplier,
 							},
 							get_query_filters: {
 								docstatus: 1,


### PR DESCRIPTION
**Issue:**
- On Leaving the Supplier/Customer blank in PR/DN, and fetching items via Get Items From, it permitted fetching items from PO/SO against _any_ supplier/customer
 ![image](https://user-images.githubusercontent.com/25857446/92993431-18f14100-f50f-11ea-8368-7d7ab5b544d6.png)

- On fetching and saving such a PR/DN, it throws an error as there are references in the items table, to POs/SOs belong to different suppliers/customers:
 ![Screenshot 2020-09-12 at 3 42 46 PM](https://user-images.githubusercontent.com/25857446/92993354-8ea8dd00-f50e-11ea-95c0-9a7bdc3df953.png)

**Fix:**
- Check if Supplier/Customer is populated first
 ![Screenshot 2020-09-12 at 3 13 35 PM](https://user-images.githubusercontent.com/25857446/92993385-c3b52f80-f50e-11ea-8c28-416e66a4d8af.png)
