### PR TITLE
fix: Make Reference fields mandatory in Quality Inspection (ux)

### DIFF
--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.json
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.json
@@ -73,7 +73,8 @@
    "fieldname": "reference_type",
    "fieldtype": "Select",
    "label": "Reference Type",
-   "options": "\nPurchase Receipt\nPurchase Invoice\nDelivery Note\nSales Invoice\nStock Entry"
+   "options": "\nPurchase Receipt\nPurchase Invoice\nDelivery Note\nSales Invoice\nStock Entry",
+   "reqd": 1
   },
   {
    "fieldname": "reference_name",
@@ -84,7 +85,8 @@
    "label": "Reference Name",
    "oldfieldname": "purchase_receipt_no",
    "oldfieldtype": "Link",
-   "options": "reference_type"
+   "options": "reference_type",
+   "reqd": 1
   },
   {
    "fieldname": "section_break_7",
@@ -231,9 +233,10 @@
  ],
  "icon": "fa fa-search",
  "idx": 1,
+ "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2020-04-26 17:50:25.068222",
+ "modified": "2020-09-12 16:11:31.910508",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Quality Inspection",


### PR DESCRIPTION
**Issue:**
- On creating a PR(or any doc that checks QI), if QI is required an error is thrown asking to set Quality Inspection for a certain item
- Ideally the user should go to the Item's row in the Items table and click on **Create New Quality Inspection** from the QI field dropdown and then create a QI. This way the reference name and type is set
- Although if a user goes to Quality Inspection List and creates a new entry, and doesn't set Reference name and type as it isn't mandatory, user wont know how to Link the QI and Purchase Receipt
- Since theres no reference the QI wont appear in the options in the Purchase Receipt

**Fix:**
- Make Reference Type and  Reference Name mandatory as a Quality Inspection against nothing makes no sense.
 ![Screenshot 2020-09-12 at 4 25 31 PM](https://user-images.githubusercontent.com/25857446/92994052-94092600-f514-11ea-8202-bea860a05dcf.png)
