### PR TITLE
fix: set_taxes() missing 1 required positional argument: 'company'

### DIFF
--- a/erpnext/public/js/utils/party.js
+++ b/erpnext/public/js/utils/party.js
@@ -224,6 +224,10 @@ erpnext.utils.set_taxes = function(frm, triggered_from_field) {
 		party = frm.doc.party_name;
 	}
 
+	if (!frm.doc.company) {
+		frappe.throw(_("Kindly select the company first"));
+	}
+
 	frappe.call({
 		method: "erpnext.accounts.party.set_taxes",
 		args: {


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2020-08-24/apps/frappe/frappe/app.py", line 64, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-12-2020-08-24/apps/frappe/frappe/api.py", line 59, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-12-2020-08-24/apps/frappe/frappe/handler.py", line 24, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-12-2020-08-24/apps/frappe/frappe/handler.py", line 63, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-12-2020-08-24/apps/frappe/frappe/__init__.py", line 1055, in call
    return fn(*args, **newargs)
TypeError: set_taxes() missing 1 required positional argument: 'company'
```