### PR TITLE
fix: Supplier trigger onload

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -28,7 +28,7 @@ erpnext.accounts.PurchaseInvoice = erpnext.buying.BuyingController.extend({
 
 		// Trigger supplier event on load if supplier is available
 		// The reason for this is PI can be created from PR or PO and supplier is pre populated
-		if (this.frm.doc.supplier) {
+		if (this.frm.doc.supplier && this.frm.doc.__islocal) {
 			this.frm.trigger('supplier');
 		}
 	},


### PR DESCRIPTION
This PR fixes an issue introduced in https://github.com/frappe/erpnext/pull/23282

Supplier event should be triggered onload only for local docs and not submitted or saved documents