### PR TITLE
fix: made paid amount field read only

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
@@ -985,7 +985,8 @@
    "label": "Paid Amount",
    "no_copy": 1,
    "options": "currency",
-   "print_hide": 1
+   "print_hide": 1,
+   "read_only": 1
   },
   {
    "fieldname": "base_paid_amount",
@@ -1334,7 +1335,7 @@
  "idx": 204,
  "is_submittable": 1,
  "links": [],
- "modified": "2020-08-03 23:20:04.466153",
+ "modified": "2020-09-15 15:43:25.644444",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Purchase Invoice",


### PR DESCRIPTION
Made 'paid amount' read-only because it not to be entered by the user. If, it 'is paid' is checked it means it is fully paid. and the paid amount is calculated in backend on save .
