### PR TITLE
fix: warehouse address filtered based on warehouse

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -23,6 +23,24 @@ frappe.ui.form.on('Stock Entry', {
 			}
 		});
 
+		frm.set_query('source_warehouse_address', function() {
+			return {
+				filters: {
+					link_doctype: 'Warehouse',
+					link_name: frm.doc.from_warehouse
+				}
+			}
+		});
+
+		frm.set_query('target_warehouse_address', function() {
+			return {
+				filters: {
+					link_doctype: 'Warehouse',
+					link_name: frm.doc.to_warehouse
+				}
+			}
+		});
+
 		frappe.db.get_value('Stock Settings', {name: 'Stock Settings'}, 'sample_retention_warehouse', (r) => {
 			if (r.sample_retention_warehouse) {
 				var filters = [
@@ -80,6 +98,9 @@ frappe.ui.form.on('Stock Entry', {
 
 		frm.add_fetch("bom_no", "inspection_required", "inspection_required");
 	},
+
+
+
 
 	setup_quality_inspection: function(frm) {
 		if (!frm.doc.inspection_required) {

--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -99,9 +99,6 @@ frappe.ui.form.on('Stock Entry', {
 		frm.add_fetch("bom_no", "inspection_required", "inspection_required");
 	},
 
-
-
-
 	setup_quality_inspection: function(frm) {
 		if (!frm.doc.inspection_required) {
 			return;


### PR DESCRIPTION
The warehouse address should be filtered based on the warehouse selected. Shouldn't show all available warehouse.

Previous:
![Screenshot 2020-09-17 at 12 52 44 PM](https://user-images.githubusercontent.com/33727827/93434352-a81ea000-f8e5-11ea-912b-460388b556a4.png)

After changes:
![Screenshot 2020-09-17 at 12 53 11 PM](https://user-images.githubusercontent.com/33727827/93434394-b7055280-f8e5-11ea-9aa4-b4b02839eb0e.png)
