### PR TITLE
fix: Item-wise Sales History Report Error

### DIFF
--- a/erpnext/selling/report/item_wise_sales_history/item_wise_sales_history.py
+++ b/erpnext/selling/report/item_wise_sales_history/item_wise_sales_history.py
@@ -188,7 +188,7 @@ def get_conditions(filters):
 		conditions += "AND so.transaction_date <= '%s'" %filters.to_date
 
 	if filters.get("item_code"):
-		conditions += "AND so_item.item_code = '%s'" %frappe.db.escape(filters.item_code)
+		conditions += "AND so_item.item_code = %s" %frappe.db.escape(filters.item_code)
 
 	if filters.get("customer"):
 		conditions += "AND so.customer = %s" %frappe.db.escape(filters.customer)


### PR DESCRIPTION
When you apply a filter on Item, you get the following error:

**Before:**

![image](https://user-images.githubusercontent.com/50285544/93454747-03a65900-f8f9-11ea-8b23-96e5622b05a2.png)


**After:**

![image](https://user-images.githubusercontent.com/50285544/93454895-3ea88c80-f8f9-11ea-84d2-60297076001f.png)
