### PR TITLE
fix(DocTypes): Reset "owner" values in DocTypes to Administrator

### DIFF
--- a/erpnext/accounts/doctype/item_tax_template/item_tax_template.json
+++ b/erpnext/accounts/doctype/item_tax_template/item_tax_template.json
@@ -38,7 +38,7 @@
    "reqd": 1
   }
  ],
- "modified": "2020-06-18 20:27:42.615842",
+ "modified": "2020-09-18 17:26:09.703215",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Item Tax Template",

--- a/erpnext/accounts/doctype/item_tax_template/item_tax_template.json
+++ b/erpnext/accounts/doctype/item_tax_template/item_tax_template.json
@@ -39,7 +39,7 @@
   }
  ],
  "modified": "2020-06-18 20:27:42.615842",
- "modified_by": "ahmad@havenir.com",
+ "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Item Tax Template",
  "owner": "Administrator",

--- a/erpnext/accounts/doctype/mode_of_payment/mode_of_payment.json
+++ b/erpnext/accounts/doctype/mode_of_payment/mode_of_payment.json
@@ -49,7 +49,7 @@
  "modified_by": "sammish.thundiyil@gmail.com",
  "module": "Accounts",
  "name": "Mode of Payment",
- "owner": "harshada@webnotestech.com",
+ "owner": "Administrator",
  "permissions": [
   {
    "create": 1,

--- a/erpnext/accounts/doctype/mode_of_payment/mode_of_payment.json
+++ b/erpnext/accounts/doctype/mode_of_payment/mode_of_payment.json
@@ -45,7 +45,7 @@
  ],
  "icon": "fa fa-credit-card",
  "idx": 1,
- "modified": "2019-08-14 14:58:42.079115",
+ "modified": "2020-09-18 17:26:09.703215",
  "modified_by": "sammish.thundiyil@gmail.com",
  "module": "Accounts",
  "name": "Mode of Payment",

--- a/erpnext/accounts/doctype/mode_of_payment/mode_of_payment.json
+++ b/erpnext/accounts/doctype/mode_of_payment/mode_of_payment.json
@@ -46,7 +46,7 @@
  "icon": "fa fa-credit-card",
  "idx": 1,
  "modified": "2020-09-18 17:26:09.703215",
- "modified_by": "sammish.thundiyil@gmail.com",
+ "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Mode of Payment",
  "owner": "Administrator",

--- a/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.json
+++ b/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.json
@@ -291,7 +291,7 @@
  "issingle": 0, 
  "istable": 0, 
  "max_attachments": 0, 
- "modified": "2018-08-21 16:15:49.089450", 
+ "modified": "2020-09-18 17:26:09.703215", 
  "modified_by": "Administrator", 
  "module": "Accounts", 
  "name": "Period Closing Voucher", 

--- a/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.json
+++ b/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.json
@@ -295,7 +295,7 @@
  "modified_by": "Administrator", 
  "module": "Accounts", 
  "name": "Period Closing Voucher", 
- "owner": "jai@webnotestech.com", 
+ "owner": "Administrator", 
  "permissions": [
   {
    "amend": 1, 

--- a/erpnext/accounts/doctype/purchase_taxes_and_charges/purchase_taxes_and_charges.json
+++ b/erpnext/accounts/doctype/purchase_taxes_and_charges/purchase_taxes_and_charges.json
@@ -210,7 +210,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-03-12 14:53:47.679439",
+ "modified": "2020-09-18 17:26:09.703215",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Purchase Taxes and Charges",

--- a/erpnext/accounts/doctype/purchase_taxes_and_charges_template/purchase_taxes_and_charges_template.json
+++ b/erpnext/accounts/doctype/purchase_taxes_and_charges_template/purchase_taxes_and_charges_template.json
@@ -78,7 +78,7 @@
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Purchase Taxes and Charges Template",
- "owner": "wasim@webnotestech.com",
+ "owner": "Administrator",
  "permissions": [
   {
    "email": 1,

--- a/erpnext/buying/doctype/purchase_order_item_supplied/purchase_order_item_supplied.json
+++ b/erpnext/buying/doctype/purchase_order_item_supplied/purchase_order_item_supplied.json
@@ -152,7 +152,7 @@
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Purchase Order Item Supplied",
- "owner": "dhanalekshmi@webnotestech.com",
+ "owner": "Administrator",
  "permissions": [],
  "sort_field": "modified",
  "sort_order": "DESC"

--- a/erpnext/buying/doctype/purchase_order_item_supplied/purchase_order_item_supplied.json
+++ b/erpnext/buying/doctype/purchase_order_item_supplied/purchase_order_item_supplied.json
@@ -148,7 +148,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-03-12 15:43:53.862897",
+ "modified": "2020-09-18 17:26:09.703215",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Purchase Order Item Supplied",

--- a/erpnext/buying/doctype/purchase_receipt_item_supplied/purchase_receipt_item_supplied.json
+++ b/erpnext/buying/doctype/purchase_receipt_item_supplied/purchase_receipt_item_supplied.json
@@ -192,7 +192,7 @@
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Purchase Receipt Item Supplied",
- "owner": "wasim@webnotestech.com",
+ "owner": "Administrator",
  "permissions": [],
  "sort_field": "modified",
  "sort_order": "DESC",

--- a/erpnext/buying/doctype/purchase_receipt_item_supplied/purchase_receipt_item_supplied.json
+++ b/erpnext/buying/doctype/purchase_receipt_item_supplied/purchase_receipt_item_supplied.json
@@ -188,7 +188,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-04-10 18:09:33.997618",
+ "modified": "2020-09-18 17:26:09.703215",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Purchase Receipt Item Supplied",

--- a/erpnext/erpnext_integrations/doctype/shopify_settings/shopify_settings.json
+++ b/erpnext/erpnext_integrations/doctype/shopify_settings/shopify_settings.json
@@ -259,7 +259,7 @@
  ],
  "issingle": 1,
  "modified": "2020-05-28 12:32:11.384757",
- "modified_by": "umair@erpnext.com",
+ "modified_by": "Administrator",
  "module": "ERPNext Integrations",
  "name": "Shopify Settings",
  "owner": "Administrator",

--- a/erpnext/erpnext_integrations/doctype/shopify_settings/shopify_settings.json
+++ b/erpnext/erpnext_integrations/doctype/shopify_settings/shopify_settings.json
@@ -258,7 +258,7 @@
   }
  ],
  "issingle": 1,
- "modified": "2020-05-28 12:32:11.384757",
+ "modified": "2020-09-18 17:26:09.703215",
  "modified_by": "Administrator",
  "module": "ERPNext Integrations",
  "name": "Shopify Settings",

--- a/erpnext/healthcare/doctype/healthcare_schedule_time_slot/healthcare_schedule_time_slot.json
+++ b/erpnext/healthcare/doctype/healthcare_schedule_time_slot/healthcare_schedule_time_slot.json
@@ -117,7 +117,7 @@
  "issingle": 0, 
  "istable": 1, 
  "max_attachments": 0, 
- "modified": "2018-05-08 13:45:57.226530", 
+ "modified": "2020-09-18 17:26:09.703215", 
  "modified_by": "Administrator", 
  "module": "Healthcare", 
  "name": "Healthcare Schedule Time Slot", 

--- a/erpnext/healthcare/doctype/healthcare_schedule_time_slot/healthcare_schedule_time_slot.json
+++ b/erpnext/healthcare/doctype/healthcare_schedule_time_slot/healthcare_schedule_time_slot.json
@@ -122,7 +122,7 @@
  "module": "Healthcare", 
  "name": "Healthcare Schedule Time Slot", 
  "name_case": "", 
- "owner": "rmehta@gmail.com", 
+ "owner": "Administrator", 
  "permissions": [], 
  "quick_entry": 1, 
  "read_only": 0, 

--- a/erpnext/healthcare/doctype/practitioner_schedule/practitioner_schedule.json
+++ b/erpnext/healthcare/doctype/practitioner_schedule/practitioner_schedule.json
@@ -44,7 +44,7 @@
   }
  ],
  "links": [],
- "modified": "2020-01-31 12:21:45.975488",
+ "modified": "2020-09-18 17:26:09.703215",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Practitioner Schedule",

--- a/erpnext/healthcare/doctype/practitioner_schedule/practitioner_schedule.json
+++ b/erpnext/healthcare/doctype/practitioner_schedule/practitioner_schedule.json
@@ -48,7 +48,7 @@
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Practitioner Schedule",
- "owner": "rmehta@gmail.com",
+ "owner": "Administrator",
  "permissions": [
   {
    "create": 1,

--- a/erpnext/hr/doctype/appraisal/appraisal.json
+++ b/erpnext/hr/doctype/appraisal/appraisal.json
@@ -700,7 +700,7 @@
  "modified_by": "Administrator", 
  "module": "HR", 
  "name": "Appraisal", 
- "owner": "ashwini@webnotestech.com", 
+ "owner": "Administrator", 
  "permissions": [
   {
    "amend": 0, 

--- a/erpnext/hr/doctype/appraisal/appraisal.json
+++ b/erpnext/hr/doctype/appraisal/appraisal.json
@@ -696,7 +696,7 @@
  "issingle": 0, 
  "istable": 0, 
  "max_attachments": 0, 
- "modified": "2019-01-30 11:28:08.401459", 
+ "modified": "2020-09-18 17:26:09.703215", 
  "modified_by": "Administrator", 
  "module": "HR", 
  "name": "Appraisal", 

--- a/erpnext/hr/doctype/appraisal_goal/appraisal_goal.json
+++ b/erpnext/hr/doctype/appraisal_goal/appraisal_goal.json
@@ -207,7 +207,7 @@
  "issingle": 0, 
  "istable": 1, 
  "max_attachments": 0, 
- "modified": "2016-07-11 03:27:57.897071", 
+ "modified": "2020-09-18 17:26:09.703215", 
  "modified_by": "Administrator", 
  "module": "HR", 
  "name": "Appraisal Goal", 

--- a/erpnext/hr/doctype/appraisal_goal/appraisal_goal.json
+++ b/erpnext/hr/doctype/appraisal_goal/appraisal_goal.json
@@ -211,7 +211,7 @@
  "modified_by": "Administrator", 
  "module": "HR", 
  "name": "Appraisal Goal", 
- "owner": "ashwini@webnotestech.com", 
+ "owner": "Administrator", 
  "permissions": [], 
  "quick_entry": 0, 
  "read_only": 0, 

--- a/erpnext/hr/doctype/appraisal_template/appraisal_template.json
+++ b/erpnext/hr/doctype/appraisal_template/appraisal_template.json
@@ -117,7 +117,7 @@
  "modified_by": "Administrator", 
  "module": "HR", 
  "name": "Appraisal Template", 
- "owner": "ashwini@webnotestech.com", 
+ "owner": "Administrator", 
  "permissions": [
   {
    "amend": 0, 

--- a/erpnext/hr/doctype/appraisal_template/appraisal_template.json
+++ b/erpnext/hr/doctype/appraisal_template/appraisal_template.json
@@ -113,7 +113,7 @@
  "issingle": 0, 
  "istable": 0, 
  "max_attachments": 0, 
- "modified": "2016-12-13 12:37:56.937023", 
+ "modified": "2020-09-18 17:26:09.703215", 
  "modified_by": "Administrator", 
  "module": "HR", 
  "name": "Appraisal Template", 

--- a/erpnext/hr/doctype/appraisal_template_goal/appraisal_template_goal.json
+++ b/erpnext/hr/doctype/appraisal_template_goal/appraisal_template_goal.json
@@ -78,7 +78,7 @@
  "issingle": 0, 
  "istable": 1, 
  "max_attachments": 0, 
- "modified": "2016-07-11 03:27:57.979215", 
+ "modified": "2020-09-18 17:26:09.703215", 
  "modified_by": "Administrator", 
  "module": "HR", 
  "name": "Appraisal Template Goal", 

--- a/erpnext/hr/doctype/appraisal_template_goal/appraisal_template_goal.json
+++ b/erpnext/hr/doctype/appraisal_template_goal/appraisal_template_goal.json
@@ -82,7 +82,7 @@
  "modified_by": "Administrator", 
  "module": "HR", 
  "name": "Appraisal Template Goal", 
- "owner": "ashwini@webnotestech.com", 
+ "owner": "Administrator", 
  "permissions": [], 
  "quick_entry": 0, 
  "read_only": 0, 

--- a/erpnext/hr/doctype/attendance/attendance.json
+++ b/erpnext/hr/doctype/attendance/attendance.json
@@ -209,7 +209,7 @@
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Attendance",
- "owner": "ashwini@webnotestech.com",
+ "owner": "Administrator",
  "permissions": [
   {
    "cancel": 1,

--- a/erpnext/hr/doctype/attendance/attendance.json
+++ b/erpnext/hr/doctype/attendance/attendance.json
@@ -205,7 +205,7 @@
  "idx": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2020-05-29 13:51:37.177231",
+ "modified": "2020-09-18 17:26:09.703215",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Attendance",

--- a/erpnext/hr/doctype/expense_claim/expense_claim.json
+++ b/erpnext/hr/doctype/expense_claim/expense_claim.json
@@ -371,7 +371,7 @@
  "idx": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2020-06-15 12:43:04.099803",
+ "modified": "2020-09-18 17:26:09.703215",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Expense Claim",

--- a/erpnext/hr/doctype/expense_claim/expense_claim.json
+++ b/erpnext/hr/doctype/expense_claim/expense_claim.json
@@ -376,7 +376,7 @@
  "module": "HR",
  "name": "Expense Claim",
  "name_case": "Title Case",
- "owner": "harshada@webnotestech.com",
+ "owner": "Administrator",
  "permissions": [
   {
    "amend": 1,

--- a/erpnext/hr/doctype/expense_claim_detail/expense_claim_detail.json
+++ b/erpnext/hr/doctype/expense_claim_detail/expense_claim_detail.json
@@ -120,7 +120,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-05-11 18:54:35.601592",
+ "modified": "2020-09-18 17:26:09.703215",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Expense Claim Detail",

--- a/erpnext/hr/doctype/expense_claim_detail/expense_claim_detail.json
+++ b/erpnext/hr/doctype/expense_claim_detail/expense_claim_detail.json
@@ -124,7 +124,7 @@
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Expense Claim Detail",
- "owner": "harshada@webnotestech.com",
+ "owner": "Administrator",
  "permissions": [],
  "sort_field": "modified",
  "sort_order": "DESC"

--- a/erpnext/hr/doctype/expense_claim_type/expense_claim_type.json
+++ b/erpnext/hr/doctype/expense_claim_type/expense_claim_type.json
@@ -48,7 +48,7 @@
  "icon": "fa fa-flag",
  "idx": 1,
  "links": [],
- "modified": "2019-12-11 13:38:59.534034",
+ "modified": "2020-09-18 17:26:09.703215",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Expense Claim Type",

--- a/erpnext/hr/doctype/expense_claim_type/expense_claim_type.json
+++ b/erpnext/hr/doctype/expense_claim_type/expense_claim_type.json
@@ -52,7 +52,7 @@
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Expense Claim Type",
- "owner": "harshada@webnotestech.com",
+ "owner": "Administrator",
  "permissions": [
   {
    "create": 1,

--- a/erpnext/hr/doctype/upload_attendance/upload_attendance.json
+++ b/erpnext/hr/doctype/upload_attendance/upload_attendance.json
@@ -233,7 +233,7 @@
  "modified_by": "Administrator", 
  "module": "HR", 
  "name": "Upload Attendance", 
- "owner": "harshada@webnotestech.com", 
+ "owner": "Administrator", 
  "permissions": [
   {
    "amend": 0, 

--- a/erpnext/hr/doctype/upload_attendance/upload_attendance.json
+++ b/erpnext/hr/doctype/upload_attendance/upload_attendance.json
@@ -229,7 +229,7 @@
  "issingle": 1, 
  "istable": 0, 
  "max_attachments": 1, 
- "modified": "2017-11-14 12:51:34.980103", 
+ "modified": "2020-09-18 17:26:09.703215", 
  "modified_by": "Administrator", 
  "module": "HR", 
  "name": "Upload Attendance", 

--- a/erpnext/hub_node/data_migration_mapping/company_to_hub_company/company_to_hub_company.json
+++ b/erpnext/hub_node/data_migration_mapping/company_to_hub_company/company_to_hub_company.json
@@ -41,7 +41,7 @@
  "mapping_type": "Push",
  "migration_id_field": "hub_sync_id",
  "modified": "2018-02-14 15:57:05.571142",
- "modified_by": "achilles@erpnext.com",
+ "modified_by": "Administrator",
  "name": "Company to Hub Company",
  "owner": "Administrator",
  "page_length": 10,

--- a/erpnext/hub_node/data_migration_mapping/company_to_hub_company/company_to_hub_company.json
+++ b/erpnext/hub_node/data_migration_mapping/company_to_hub_company/company_to_hub_company.json
@@ -40,7 +40,7 @@
  "mapping_name": "Company to Hub Company",
  "mapping_type": "Push",
  "migration_id_field": "hub_sync_id",
- "modified": "2018-02-14 15:57:05.571142",
+ "modified": "2020-09-18 17:26:09.703215",
  "modified_by": "Administrator",
  "name": "Company to Hub Company",
  "owner": "Administrator",

--- a/erpnext/hub_node/data_migration_mapping/hub_message_to_lead/hub_message_to_lead.json
+++ b/erpnext/hub_node/data_migration_mapping/hub_message_to_lead/hub_message_to_lead.json
@@ -22,7 +22,7 @@
  "mapping_type": "Pull",
  "migration_id_field": "hub_sync_id",
  "modified": "2020-09-18 17:26:09.703215",
- "modified_by": "achilles@erpnext.com",
+ "modified_by": "Administrator",
  "name": "Hub Message to Lead",
  "owner": "Administrator",
  "page_length": 10,

--- a/erpnext/hub_node/data_migration_mapping/hub_message_to_lead/hub_message_to_lead.json
+++ b/erpnext/hub_node/data_migration_mapping/hub_message_to_lead/hub_message_to_lead.json
@@ -24,7 +24,7 @@
  "modified": "2018-02-14 15:57:05.606597",
  "modified_by": "achilles@erpnext.com",
  "name": "Hub Message to Lead",
- "owner": "frappetest@gmail.com",
+ "owner": "Administrator",
  "page_length": 10,
  "remote_objectname": "Hub Message",
  "remote_primary_key": "name"

--- a/erpnext/hub_node/data_migration_mapping/hub_message_to_lead/hub_message_to_lead.json
+++ b/erpnext/hub_node/data_migration_mapping/hub_message_to_lead/hub_message_to_lead.json
@@ -21,7 +21,7 @@
  "mapping_name": "Hub Message to Lead",
  "mapping_type": "Pull",
  "migration_id_field": "hub_sync_id",
- "modified": "2018-02-14 15:57:05.606597",
+ "modified": "2020-09-18 17:26:09.703215",
  "modified_by": "achilles@erpnext.com",
  "name": "Hub Message to Lead",
  "owner": "Administrator",

--- a/erpnext/hub_node/doctype/hub_user/hub_user.json
+++ b/erpnext/hub_node/doctype/hub_user/hub_user.json
@@ -121,7 +121,7 @@
  "issingle": 0, 
  "istable": 1, 
  "max_attachments": 0, 
- "modified": "2018-09-01 13:56:07.816894", 
+ "modified": "2020-09-18 17:26:09.703215", 
  "modified_by": "netchamp@rawcoderz.com", 
  "module": "Hub Node", 
  "name": "Hub User", 

--- a/erpnext/hub_node/doctype/hub_user/hub_user.json
+++ b/erpnext/hub_node/doctype/hub_user/hub_user.json
@@ -122,7 +122,7 @@
  "istable": 1, 
  "max_attachments": 0, 
  "modified": "2020-09-18 17:26:09.703215", 
- "modified_by": "netchamp@rawcoderz.com", 
+ "modified_by": "Administrator", 
  "module": "Hub Node", 
  "name": "Hub User", 
  "name_case": "", 

--- a/erpnext/hub_node/doctype/hub_users/hub_users.json
+++ b/erpnext/hub_node/doctype/hub_users/hub_users.json
@@ -59,7 +59,7 @@
  "module": "Hub Node", 
  "name": "Hub Users", 
  "name_case": "", 
- "owner": "test1@example.com", 
+ "owner": "Administrator", 
  "permissions": [], 
  "quick_entry": 1, 
  "read_only": 0, 

--- a/erpnext/hub_node/doctype/hub_users/hub_users.json
+++ b/erpnext/hub_node/doctype/hub_users/hub_users.json
@@ -54,7 +54,7 @@
  "issingle": 0, 
  "istable": 1, 
  "max_attachments": 0, 
- "modified": "2018-03-06 04:41:17.916243", 
+ "modified": "2020-09-18 17:26:09.703215", 
  "modified_by": "Administrator", 
  "module": "Hub Node", 
  "name": "Hub Users", 

--- a/erpnext/hub_node/doctype/marketplace_settings/marketplace_settings.json
+++ b/erpnext/hub_node/doctype/marketplace_settings/marketplace_settings.json
@@ -352,7 +352,7 @@
  "issingle": 1, 
  "istable": 0, 
  "max_attachments": 0, 
- "modified": "2019-02-01 14:21:16.729848", 
+ "modified": "2020-09-18 17:26:09.703215", 
  "modified_by": "Administrator", 
  "module": "Hub Node", 
  "name": "Marketplace Settings", 

--- a/erpnext/hub_node/doctype/marketplace_settings/marketplace_settings.json
+++ b/erpnext/hub_node/doctype/marketplace_settings/marketplace_settings.json
@@ -357,7 +357,7 @@
  "module": "Hub Node", 
  "name": "Marketplace Settings", 
  "name_case": "", 
- "owner": "netchamp@rawcoderz.com", 
+ "owner": "Administrator", 
  "permissions": [
   {
    "amend": 0, 

--- a/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.json
+++ b/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.json
@@ -813,7 +813,7 @@
  "issingle": 0, 
  "istable": 0, 
  "max_attachments": 0, 
- "modified": "2018-08-21 14:44:33.670332", 
+ "modified": "2020-09-18 17:26:09.703215", 
  "modified_by": "Administrator", 
  "module": "Maintenance", 
  "name": "Maintenance Schedule", 

--- a/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.json
+++ b/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.json
@@ -1005,7 +1005,7 @@
  "modified_by": "Administrator", 
  "module": "Maintenance", 
  "name": "Maintenance Visit", 
- "owner": "ashwini@webnotestech.com", 
+ "owner": "Administrator", 
  "permissions": [
   {
    "amend": 1, 

--- a/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.json
+++ b/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.json
@@ -1001,7 +1001,7 @@
  "issingle": 0, 
  "istable": 0, 
  "max_attachments": 0, 
- "modified": "2020-07-15 14:44:44.911402", 
+ "modified": "2020-09-18 17:26:09.703215", 
  "modified_by": "Administrator", 
  "module": "Maintenance", 
  "name": "Maintenance Visit", 

--- a/erpnext/maintenance/doctype/maintenance_visit_purpose/maintenance_visit_purpose.json
+++ b/erpnext/maintenance/doctype/maintenance_visit_purpose/maintenance_visit_purpose.json
@@ -125,7 +125,7 @@
  ],
  "idx": 1,
  "istable": 1,
- "modified": "2019-10-03 14:55:52.786805",
+ "modified": "2020-09-18 17:26:09.703215",
  "modified_by": "Administrator",
  "module": "Maintenance",
  "name": "Maintenance Visit Purpose",

--- a/erpnext/maintenance/doctype/maintenance_visit_purpose/maintenance_visit_purpose.json
+++ b/erpnext/maintenance/doctype/maintenance_visit_purpose/maintenance_visit_purpose.json
@@ -129,7 +129,7 @@
  "modified_by": "Administrator",
  "module": "Maintenance",
  "name": "Maintenance Visit Purpose",
- "owner": "ashwini@webnotestech.com",
+ "owner": "Administrator",
  "permissions": [],
  "sort_field": "modified",
  "sort_order": "DESC",

--- a/erpnext/projects/doctype/dependent_task/dependent_task.json
+++ b/erpnext/projects/doctype/dependent_task/dependent_task.json
@@ -48,7 +48,7 @@
  "issingle": 0, 
  "istable": 1, 
  "max_attachments": 0, 
- "modified": "2016-10-26 17:37:25.638190", 
+ "modified": "2020-09-18 17:26:09.703215", 
  "modified_by": "Administrator", 
  "module": "Projects", 
  "name": "Dependent Task", 

--- a/erpnext/projects/doctype/dependent_task/dependent_task.json
+++ b/erpnext/projects/doctype/dependent_task/dependent_task.json
@@ -49,7 +49,7 @@
  "istable": 1, 
  "max_attachments": 0, 
  "modified": "2016-10-26 17:37:25.638190", 
- "modified_by": "rohitw1991@gmail.com", 
+ "modified_by": "Administrator", 
  "module": "Projects", 
  "name": "Dependent Task", 
  "name_case": "", 

--- a/erpnext/selling/doctype/industry_type/industry_type.json
+++ b/erpnext/selling/doctype/industry_type/industry_type.json
@@ -53,7 +53,7 @@
  "modified_by": "Administrator", 
  "module": "Selling", 
  "name": "Industry Type", 
- "owner": "harshada@webnotestech.com", 
+ "owner": "Administrator", 
  "permissions": [
   {
    "amend": 0, 

--- a/erpnext/selling/doctype/industry_type/industry_type.json
+++ b/erpnext/selling/doctype/industry_type/industry_type.json
@@ -49,7 +49,7 @@
  "issingle": 0, 
  "istable": 0, 
  "max_attachments": 0, 
- "modified": "2016-07-25 05:24:25.881361", 
+ "modified": "2020-09-18 17:26:09.703215", 
  "modified_by": "Administrator", 
  "module": "Selling", 
  "name": "Industry Type", 

--- a/erpnext/selling/doctype/product_bundle/product_bundle.json
+++ b/erpnext/selling/doctype/product_bundle/product_bundle.json
@@ -239,7 +239,7 @@
  "istable": 0, 
  "max_attachments": 0, 
  "modified": "2017-10-18 14:23:06.538568", 
- "modified_by": "tundebabzy@gmail.com", 
+ "modified_by": "Administrator", 
  "module": "Selling", 
  "name": "Product Bundle", 
  "owner": "Administrator", 

--- a/erpnext/selling/doctype/product_bundle/product_bundle.json
+++ b/erpnext/selling/doctype/product_bundle/product_bundle.json
@@ -238,7 +238,7 @@
  "issingle": 0, 
  "istable": 0, 
  "max_attachments": 0, 
- "modified": "2017-10-18 14:23:06.538568", 
+ "modified": "2020-09-18 17:26:09.703215", 
  "modified_by": "Administrator", 
  "module": "Selling", 
  "name": "Product Bundle", 

--- a/erpnext/stock/doctype/batch/batch.json
+++ b/erpnext/stock/doctype/batch/batch.json
@@ -170,7 +170,7 @@
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Batch",
- "owner": "harshada@webnotestech.com",
+ "owner": "Administrator",
  "permissions": [
   {
    "create": 1,

--- a/erpnext/stock/doctype/batch/batch.json
+++ b/erpnext/stock/doctype/batch/batch.json
@@ -166,7 +166,7 @@
  "idx": 1,
  "image_field": "image",
  "max_attachments": 5,
- "modified": "2019-10-03 22:38:45.104056",
+ "modified": "2020-09-18 17:26:09.703215",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Batch",

--- a/erpnext/stock/doctype/landed_cost_item/landed_cost_item.json
+++ b/erpnext/stock/doctype/landed_cost_item/landed_cost_item.json
@@ -133,7 +133,7 @@
  ],
  "idx": 1,
  "istable": 1,
- "modified": "2019-11-12 15:41:21.053462",
+ "modified": "2020-09-18 17:26:09.703215",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Landed Cost Item",

--- a/erpnext/stock/doctype/landed_cost_item/landed_cost_item.json
+++ b/erpnext/stock/doctype/landed_cost_item/landed_cost_item.json
@@ -137,7 +137,7 @@
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Landed Cost Item",
- "owner": "wasim@webnotestech.com",
+ "owner": "Administrator",
  "permissions": [],
  "sort_field": "modified",
  "sort_order": "DESC"

--- a/erpnext/stock/doctype/landed_cost_purchase_receipt/landed_cost_purchase_receipt.json
+++ b/erpnext/stock/doctype/landed_cost_purchase_receipt/landed_cost_purchase_receipt.json
@@ -173,7 +173,7 @@
  "issingle": 0, 
  "istable": 1, 
  "max_attachments": 0, 
- "modified": "2016-07-20 10:49:34.228751", 
+ "modified": "2020-09-18 17:26:09.703215", 
  "modified_by": "Administrator", 
  "module": "Stock", 
  "name": "Landed Cost Purchase Receipt", 

--- a/erpnext/stock/doctype/landed_cost_purchase_receipt/landed_cost_purchase_receipt.json
+++ b/erpnext/stock/doctype/landed_cost_purchase_receipt/landed_cost_purchase_receipt.json
@@ -177,7 +177,7 @@
  "modified_by": "Administrator", 
  "module": "Stock", 
  "name": "Landed Cost Purchase Receipt", 
- "owner": "wasim@webnotestech.com", 
+ "owner": "Administrator", 
  "permissions": [], 
  "quick_entry": 0, 
  "read_only": 0, 

--- a/erpnext/support/doctype/warranty_claim/warranty_claim.json
+++ b/erpnext/support/doctype/warranty_claim/warranty_claim.json
@@ -365,7 +365,7 @@
  "modified_by": "Administrator",
  "module": "Support",
  "name": "Warranty Claim",
- "owner": "harshada@webnotestech.com",
+ "owner": "Administrator",
  "permissions": [
   {
    "create": 1,

--- a/erpnext/support/doctype/warranty_claim/warranty_claim.json
+++ b/erpnext/support/doctype/warranty_claim/warranty_claim.json
@@ -361,7 +361,7 @@
  ],
  "icon": "fa fa-bug",
  "idx": 1,
- "modified": "2019-05-24 10:56:30.626200",
+ "modified": "2020-09-18 17:26:09.703215",
  "modified_by": "Administrator",
  "module": "Support",
  "name": "Warranty Claim",


### PR DESCRIPTION
Presently there are contributor email ids as owner set in many doctype (26) json files.

This can be seen when you edit doctypes like below:
![image](https://user-images.githubusercontent.com/15175501/93471801-78858d00-f911-11ea-801a-67d944296d30.png)
![image](https://user-images.githubusercontent.com/15175501/93471815-7cb1aa80-f911-11ea-9b25-0a16ba0891a7.png)

This could cause confusion to the end user as he/she wont be aware of who's name that is.