### PR TITLE
fix: missing default Sales Taxes And Charges Template when frm.doc.taxes is []

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -417,7 +417,7 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 		var taxes_and_charges_field = frappe.meta.get_docfield(me.frm.doc.doctype, "taxes_and_charges",
 			me.frm.doc.name);
 
-		if (!this.frm.doc.taxes_and_charges && this.frm.doc.taxes) {
+		if (!this.frm.doc.taxes_and_charges && this.frm.doc.taxes && this.frm.doc.taxes.length > 0) {
 			return;
 		}
 


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

When create Sales Order from Quotation, default sales tax template won't autoload.

> Explain the **details** for making this change. What existing problem does the pull request solve?

For Javascript, empty array `[]` evaluates to true in conditional structures. 
If `frm.doc.taxes` is empty still need to load default Sales Taxes And Charges Template.
