### PR TITLE
fix: stock reconciliation, incorrect serial nos fetched in the current serial no field

### DIFF
--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -165,8 +165,11 @@ class StockReconciliation(StockController):
 			validate_is_stock_item(item_code, item.is_stock_item, verbose=0)
 
 			# item should not be serialized
-			if item.has_serial_no and not row.serial_no and not item.serial_no_series:
+			if item.has_serial_no and not row.serial_no and not item.serial_no_series and flt(row.qty) > 0:
 				raise frappe.ValidationError(_("Serial no(s) required for serialized item {0}").format(item_code))
+
+			if flt(row.qty) == 0 and row.serial_no:
+				row.serial_no = ''
 
 			# item managed batch-wise not allowed
 			if item.has_batch_no and not row.batch_no and not item.create_new_batch:
@@ -235,7 +238,7 @@ class StockReconciliation(StockController):
 			sl_entries = self.merge_similar_item_serial_nos(sl_entries)
 
 	def issue_existing_serial_and_batch(self, sl_entries):
-		from erpnext.stock.stock_ledger import get_previous_sle
+		from erpnext.stock.stock_ledger import get_stock_ledger_entries
 
 		for row in self.items:
 			serial_nos = get_serial_nos(row.serial_no) or []
@@ -261,12 +264,14 @@ class StockReconciliation(StockController):
 			for serial_no in serial_nos:
 				args = self.get_sle_for_items(row, [serial_no])
 
-				previous_sle = get_previous_sle({
+				previous_sle = get_stock_ledger_entries({
 					"item_code": row.item_code,
 					"posting_date": self.posting_date,
 					"posting_time": self.posting_time,
 					"serial_no": serial_no
-				})
+				}, "<", "desc", "limit 1")
+
+				previous_sle = previous_sle and previous_sle[0] or {}
 
 				if previous_sle and row.warehouse != previous_sle.get("warehouse"):
 					# If serial no exists in different warehouse

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -460,7 +460,13 @@ def get_stock_ledger_entries(previous_sle, operator=None,
 		conditions += " and " + previous_sle.get("warehouse_condition")
 
 	if check_serial_no and previous_sle.get("serial_no"):
-		conditions += " and serial_no like {}".format(frappe.db.escape('%{0}%'.format(previous_sle.get("serial_no"))))
+		serial_no = previous_sle.get("serial_no")
+		conditions += """ and (
+				serial_no = '{0}'
+				OR serial_no like '{0}\n%%'
+				OR serial_no like '%%\n{0}'
+				OR serial_no like '%%\n{0}\n%%'
+			) and actual_qty > 0""".format(serial_no)
 
 	if not previous_sle.get("posting_date"):
 		previous_sle["posting_date"] = "1900-01-01"

--- a/erpnext/stock/utils.py
+++ b/erpnext/stock/utils.py
@@ -96,11 +96,7 @@ def get_stock_balance(item_code, warehouse, posting_date=None, posting_time=None
 
 	if with_valuation_rate:
 		if with_serial_no:
-			serial_nos = last_entry.get("serial_no")
-
-			if (serial_nos and
-				len(get_serial_nos_data(serial_nos)) < last_entry.qty_after_transaction):
-				serial_nos = get_serial_nos_data_after_transactions(args)
+			serial_nos = get_serial_nos_data_after_transactions(args)
 
 			return ((last_entry.qty_after_transaction, last_entry.valuation_rate, serial_nos)
 				if last_entry else (0.0, 0.0, 0.0))


### PR DESCRIPTION
### **Issue**

1. Create new item "Surface Disinfectant" with has serial no and set "Serial Number Series" as "SD.#####"

1. Create and submit the purchase receipt with item as "Surface Disinfectant" and quantity as 5, so system will create the serial no as SD00001, SD00002, SD00003, SD00004, SD00005

1. Create and submit delivery note for the item "Surface Disinfectant" with quantity as 3 and serial no as "SD00001", "SD00002", "SD00004"

1. The create the stock reconciliation for the item "Surface Disinfectant", system pulls the incorrect serial no in the current serial no field

<img width="888" alt="Screenshot 2020-09-21 at 1 05 18 AM" src="https://user-images.githubusercontent.com/8780500/93720939-290dbe00-fbaa-11ea-91fd-a42c0f9ad7a4.png">


### **After Fix**
<img width="859" alt="Screenshot 2020-09-21 at 1 31 13 AM" src="https://user-images.githubusercontent.com/8780500/93720951-37f47080-fbaa-11ea-8585-0e873aaf5717.png">

