### PR TITLE
refactor: enabled no copy property for Supplier Invoice Date to avoid…

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
@@ -356,6 +356,7 @@
    "fieldname": "bill_date",
    "fieldtype": "Date",
    "label": "Supplier Invoice Date",
+   "no_copy": 1,
    "oldfieldname": "bill_date",
    "oldfieldtype": "Date",
    "print_hide": 1
@@ -1307,7 +1308,7 @@
  "icon": "fa fa-file-text",
  "idx": 204,
  "is_submittable": 1,
- "modified": "2020-08-20 11:08:19.611710",
+ "modified": "2020-09-21 12:22:09.164068",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Purchase Invoice",


### PR DESCRIPTION
**Issue**

1. Make invoice and set the Supplier Invoice date

1. Create auto repeat record against the same purchase invoice

1. On next schedule date, system not generate the auto purchase invoice because system set the due date same as old purchase invoice due date based on the old "Supplier Invoice date" and got below error.

Due date set as per next schedule date where as Supplier Invoice date has set as per old invoice.

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2020-08-24/apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py", line 136, in create_documents
    new_doc = self.make_new_document()
  File "/home/frappe/benches/bench-version-12-2020-08-24/apps/frappe/frappe/automation/doctype/auto_repeat/auto_repeat.py", line 151, in make_new_document
    new_doc.insert(ignore_permissions = True)
  File "/home/frappe/benches/bench-version-12-2020-08-24/apps/frappe/frappe/model/document.py", line 230, in insert
    self.run_before_save_methods()
  File "/home/frappe/benches/bench-version-12-2020-08-24/apps/frappe/frappe/model/document.py", line 896, in run_before_save_methods
    self.run_method("validate")
  File "/home/frappe/benches/bench-version-12-2020-08-24/apps/frappe/frappe/model/document.py", line 797, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2020-08-24/apps/frappe/frappe/model/document.py", line 1073, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2020-08-24/apps/frappe/frappe/model/document.py", line 1056, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-version-12-2020-08-24/apps/frappe/frappe/model/document.py", line 791, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2020-08-24/apps/erpnext/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py", line 69, in validate
    super(PurchaseInvoice, self).validate()
  File "/home/frappe/benches/bench-version-12-2020-08-24/apps/erpnext/erpnext/controllers/buying_controller.py", line 38, in validate
    super(BuyingController, self).validate()
  File "/home/frappe/benches/bench-version-12-2020-08-24/apps/erpnext/erpnext/controllers/stock_controller.py", line 21, in validate
    super(StockController, self).validate()
  File "/home/frappe/benches/bench-version-12-2020-08-24/apps/erpnext/erpnext/controllers/accounts_controller.py", line 85, in validate
    self.validate_all_documents_schedule()
  File "/home/frappe/benches/bench-version-12-2020-08-24/apps/erpnext/erpnext/controllers/accounts_controller.py", line 136, in validate_all_documents_schedule
    self.validate_invoice_documents_schedule()
  File "/home/frappe/benches/bench-version-12-2020-08-24/apps/erpnext/erpnext/controllers/accounts_controller.py", line 126, in validate_invoice_documents_schedule
    self.validate_due_date()
  File "/home/frappe/benches/bench-version-12-2020-08-24/apps/erpnext/erpnext/controllers/accounts_controller.py", line 210, in validate_due_date
    "Supplier", self.supplier, self.company, self.bill_date, self.payment_terms_template)
  File "/home/frappe/benches/bench-version-12-2020-08-24/apps/erpnext/erpnext/accounts/party.py", line 358, in validate_due_date
    frappe.throw(_("Due Date cannot be before Posting / Supplier Invoice Date"))
  File "/home/frappe/benches/bench-version-12-2020-08-24/apps/frappe/frappe/__init__.py", line 376, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red', is_minimizable=is_minimizable)
  File "/home/frappe/benches/bench-version-12-2020-08-24/apps/frappe/frappe/__init__.py", line 355, in msgprint
    _raise_exception()
  File "/home/frappe/benches/bench-version-12-2020-08-24/apps/frappe/frappe/__init__.py", line 315, in _raise_exception
    raise raise_exception(msg)
frappe.exceptions.ValidationError: Due Date cannot be before Posting / Supplier Invoice Date
```