### PR TITLE
fix(plaid): do not send null list in account ids

### DIFF
--- a/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_connector.py
+++ b/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_connector.py
@@ -72,10 +72,16 @@ class PlaidConnector():
 
 	def get_transactions(self, start_date, end_date, account_id=None):
 		self.auth()
-		account_ids = list(account_id) if account_id else None
+		kwargs = dict(
+			access_token=self.access_token,
+			start_date=start_date,
+			end_date=end_date
+		)
+		if account_id:
+			kwargs.update(dict(account_ids=[account_id]))
 
 		try:
-			response = self.client.Transactions.get(self.access_token, start_date=start_date, end_date=end_date, account_ids=account_ids)
+			response = self.client.Transactions.get(**kwargs)
 			transactions = response["transactions"]
 			while len(transactions) < response["total_transactions"]:
 				response = self.client.Transactions.get(self.access_token, start_date=start_date, end_date=end_date, offset=len(transactions))


### PR DESCRIPTION
**Issue:**

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2020-08-24/apps/erpnext/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_connector.py", line 78, in get_transactions
    response = self.client.Transactions.get(self.access_token, start_date=start_date, end_date=end_date, account_ids=account_ids)
  File "/home/frappe/benches/bench-version-12-2020-08-24/env/lib/python3.6/site-packages/plaid/api/transactions.py", line 49, in get
    'options': options,
  File "/home/frappe/benches/bench-version-12-2020-08-24/env/lib/python3.6/site-packages/plaid/client.py", line 103, in post
    return self._post(path, post_data, is_json)
  File "/home/frappe/benches/bench-version-12-2020-08-24/env/lib/python3.6/site-packages/plaid/client.py", line 120, in _post
    headers=headers,
  File "/home/frappe/benches/bench-version-12-2020-08-24/env/lib/python3.6/site-packages/plaid/internal/requester.py", line 68, in _http_request
    raise PlaidError.from_response(response_body)
plaid.errors.InvalidRequestError: options.account_ids must be a non-empty array of valid account ids
```