### PR TITLE
fix: incorrect consumed qty if raw material with batch

### DIFF
--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -289,7 +289,7 @@ class BuyingController(StockController):
 					title=_("Limit Crossed"))
 
 			transferred_batch_qty_map = get_transferred_batch_qty_map(item.purchase_order, item.item_code)
-			backflushed_batch_qty_map = get_backflushed_batch_qty_map(item.purchase_order, item.item_code)
+			# backflushed_batch_qty_map = get_backflushed_batch_qty_map(item.purchase_order, item.item_code)
 
 			for raw_material in transferred_raw_materials + non_stock_items:
 				rm_item_key = (raw_material.rm_item_code, item.purchase_order)
@@ -321,6 +321,8 @@ class BuyingController(StockController):
 					set_serial_nos(raw_material, consumed_serial_nos, qty)
 
 				if raw_material.batch_nos:
+					backflushed_batch_qty_map = raw_material_data.get('consumed_batch', {})
+
 					batches_qty = get_batches_with_qty(raw_material.rm_item_code, raw_material.main_item_code,
 						qty, transferred_batch_qty_map, backflushed_batch_qty_map, item.purchase_order)
 					for batch_data in batches_qty:
@@ -884,7 +886,8 @@ def get_backflushed_subcontracted_raw_materials(purchase_orders):
 				backflushed_raw_materials_map.setdefault(pr_key, frappe._dict({
 					"qty": 0.0,
 					"serial_no": [],
-					"batch_no": []
+					"batch_no": [],
+					"consumed_batch": {}
 				}))
 
 			row = backflushed_raw_materials_map.get(pr_key)
@@ -893,6 +896,12 @@ def get_backflushed_subcontracted_raw_materials(purchase_orders):
 			for field in ["serial_no", "batch_no"]:
 				if data.get(field):
 					row[field].append(data.get(field))
+
+			if data.get("batch_no"):
+				if data.get("batch_no") in row.consumed_batch:
+					row.consumed_batch[data.get("batch_no")] += data.consumed_qty
+				else:
+					row.consumed_batch[data.get("batch_no")] = data.consumed_qty
 
 	return backflushed_raw_materials_map
 
@@ -1038,13 +1047,11 @@ def get_backflushed_batch_qty_map(purchase_order, fg_item):
 
 	return backflushed_batch_qty_map
 
-def get_batches_with_qty(item_code, fg_item, required_qty, transferred_batch_qty_map, backflushed_batch_qty_map, po):
+def get_batches_with_qty(item_code, fg_item, required_qty, transferred_batch_qty_map, backflushed_batches, po):
 	# Returns available batches to be backflushed based on requirements
 	transferred_batches = transferred_batch_qty_map.get((item_code, fg_item), {})
 	if not transferred_batches:
 		transferred_batches = transferred_batch_qty_map.get((item_code, po), {})
-
-	backflushed_batches = backflushed_batch_qty_map.get((item_code, fg_item), {})
 
 	available_batches = []
 


### PR DESCRIPTION
### **Issue**
**Steps**

1. Set "Backflush Raw Materials of Subcontract Based On" as "Material Transferred for Subcontract" in buying settings.

1. Create subcontracted item SB1 and enable has batch no, also create raw material RM1 for subcontracted item with has batch no

1. Make BOM for the subcontracted item SB1 with raw material RM1

1. Create purchase order for the subcontracted item SB1 with qty as 500 and then transferred the raw material RM1 from store to supplier's warehouse with qty as 552

1. Create and submit single purchase receipt with quantity as 30, 40, 70, 60 in multiple rows (use duplicate button so that reference of purchase order will be copied in the purchase receipt)

1. Create one more purchase receipt for the remaining quantity 300, you will notice that the consumed qty has calculated incorrectly.

<img width="989" alt="Screenshot 2020-09-21 at 7 40 47 PM" src="https://user-images.githubusercontent.com/8780500/93845820-d7efee00-fcbf-11ea-8ef8-c30bfcbbabd6.png">

### **After Fix**

<img width="936" alt="Screenshot 2020-09-22 at 10 42 36 AM" src="https://user-images.githubusercontent.com/8780500/93846016-6fedd780-fcc0-11ea-8dca-ee4db7b1423e.png">