### PR TITLE
fix: ignore permission while creating Supplier Scorecard Period in Supplier Scorecard

### DIFF
--- a/erpnext/buying/doctype/supplier_scorecard/supplier_scorecard.py
+++ b/erpnext/buying/doctype/supplier_scorecard/supplier_scorecard.py
@@ -178,6 +178,7 @@ def make_all_scorecards(docname):
 			period_card = make_supplier_scorecard(docname, None)
 			period_card.start_date = start_date
 			period_card.end_date = end_date
+			period_card.insert(ignore_permissions=True)
 			period_card.submit()
 			scp_count = scp_count + 1
 			if start_date < first_start_date:

--- a/erpnext/buying/doctype/supplier_scorecard_period/supplier_scorecard_period.py
+++ b/erpnext/buying/doctype/supplier_scorecard_period/supplier_scorecard_period.py
@@ -106,7 +106,7 @@ def make_supplier_scorecard(source_name, target_doc=None):
 			"doctype": "Supplier Scorecard Scoring Criteria",
 			"postprocess": update_criteria_fields,
 		}
-	}, target_doc, post_process)
+	}, target_doc, post_process, ignore_permissions=True)
 
 	return doc
 


### PR DESCRIPTION
**Issue:**
Supplier Scorecard Period is created by the system so it has **User Cannot Create** set. Due to this no role other than System Manager can create a Supplier Scorecard (Supplier Scorecard Period is created when Supplier Scorecard is created), even if they have `create` permission for Supplier Scorecard.


**Fix:**
Ignore permissions while inserting Supplier Scorecard Period.


Ref Issue: ISS-20-21-04965