### PR TITLE
fix: Download Required Materials not working for production plan

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.js
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.js
@@ -159,6 +159,7 @@ frappe.ui.form.on('Production Plan', {
 	get_sales_orders: function(frm) {
 		frappe.call({
 			method: "get_open_sales_orders",
+			freeze: true,
 			doc: frm.doc,
 			callback: function(r) {
 				refresh_field("sales_orders");
@@ -169,6 +170,7 @@ frappe.ui.form.on('Production Plan', {
 	get_material_request: function(frm) {
 		frappe.call({
 			method: "get_pending_material_requests",
+			freeze: true,
 			doc: frm.doc,
 			callback: function() {
 				refresh_field('material_requests');
@@ -188,7 +190,7 @@ frappe.ui.form.on('Production Plan', {
 	},
 
 	get_items_for_mr: function(frm) {
-		const set_fields = ['actual_qty', 'item_code','item_name', 'description', 'uom', 
+		const set_fields = ['actual_qty', 'item_code','item_name', 'description', 'uom',
 			'min_order_qty', 'quantity', 'sales_order', 'warehouse', 'projected_qty', 'material_request_type'];
 		frappe.call({
 			method: "erpnext.manufacturing.doctype.production_plan.production_plan.get_items_for_material_requests",
@@ -219,7 +221,7 @@ frappe.ui.form.on('Production Plan', {
 
 	download_materials_required: function(frm) {
 		let get_template_url = 'erpnext.manufacturing.doctype.production_plan.production_plan.download_raw_materials';
-		open_url_post(frappe.request.url, { cmd: get_template_url, production_plan: frm.doc.name });
+		open_url_post(frappe.request.url, { cmd: get_template_url, doc: frm.doc });
 	},
 
 	show_progress: function(frm) {

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -422,14 +422,13 @@ class ProductionPlan(Document):
 			msgprint(_("No material request created"))
 
 @frappe.whitelist()
-def download_raw_materials(production_plan):
-	doc = frappe.get_doc('Production Plan', production_plan)
-	doc.check_permission()
-
+def download_raw_materials(doc):
 	item_list = [['Item Code', 'Description', 'Stock UOM', 'Required Qty', 'Warehouse',
 		'projected Qty', 'Actual Qty']]
 
-	doc = doc.as_dict()
+	if isinstance(doc, string_types):
+		doc = frappe._dict(json.loads(doc))
+
 	for d in get_items_for_material_requests(doc, ignore_existing_ordered_qty=True):
 		item_list.append([d.get('item_code'), d.get('description'), d.get('stock_uom'), d.get('quantity'),
 			d.get('warehouse'), d.get('projected_qty'), d.get('actual_qty')])


### PR DESCRIPTION
### **Issue**
**Steps**

1. Go to Production plan

1. Add Sales Order

1. Select "Ignore Existing Projected Qty"

1. For Warehouse ---> select warehouse

1. Click on Download Required Materials,  you will get below error (404 not found)
<img width="515" alt="Screenshot 2020-09-22 at 7 48 31 PM" src="https://user-images.githubusercontent.com/8780500/93894885-dd275a00-fd0c-11ea-925b-a31b5e0938ad.png">
