### PR TITLE
fix: escape apostrophe in cost centre and project if exist

### DIFF
--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -268,9 +268,9 @@ class GrossProfitGenerator(object):
 	def get_last_purchase_rate(self, item_code, row):
 		condition = ''
 		if row.project:
-			condition += " AND a.project='%s'" % (row.project)
+			condition += " AND a.project=%s" % (frappe.db.escape(row.project))
 		elif row.cost_center:
-			condition += " AND a.cost_center='%s'" % (row.cost_center)
+			condition += " AND a.cost_center=%s" % (frappe.db.escape(row.cost_center))
 		if self.filters.to_date:
 			condition += " AND modified='%s'" % (self.filters.to_date)
 


### PR DESCRIPTION
When added condition to also include cost center or project in https://github.com/frappe/erpnext/pull/22616 missed to escape apostrophe if it existed in cost center or project.