### PR TITLE
refactor: book loss amount in the COGS instead of stock received but not billed

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -207,6 +207,7 @@ class PurchaseReceipt(BuyingController):
 		from erpnext.accounts.general_ledger import process_gl_map
 
 		stock_rbnb = self.get_company_default("stock_received_but_not_billed")
+		cogs_account = self.get_company_default("default_expense_account")
 		landed_cost_entries = get_item_account_wise_additional_cost(self.name)
 		expenses_included_in_valuation = self.get_company_default("expenses_included_in_valuation")
 
@@ -288,7 +289,7 @@ class PurchaseReceipt(BuyingController):
 						if self.is_return or flt(d.item_tax_amount):
 							loss_account = expenses_included_in_valuation
 						else:
-							loss_account = stock_rbnb
+							loss_account = cogs_account
 
 						gl_entries.append(self.get_gl_dict({
 							"account": loss_account,


### PR DESCRIPTION
**Issue**

1. Enable allow negative stock in stock settings

1. Create the test item with valuation rate as 200 and then create delivery note two times with 1 quantity

1. The create the purchase receipt with quantity as 2 and incoming rate as 500 (see below image)
<img width="1202" alt="Screenshot 2020-09-23 at 7 25 24 PM" src="https://user-images.githubusercontent.com/8780500/94023987-7cfbeb00-fdd4-11ea-8836-2b29ce0b3dc4.png">

Check GL entry and you can see the loss amount(600) has been booked under Stock Received But Not Billed account

<img width="884" alt="Screenshot 2020-09-23 at 7 19 15 PM" src="https://user-images.githubusercontent.com/8780500/94024251-d06e3900-fdd4-11ea-8a8d-524d36935086.png">

As while making delivery note user has used the valuation rate as "200" therefore while making inward entry system has used the same rate and not the incoming rate 500. So the difference amount 1000 - 400 = 600 needs to be booked under COGS but as system booking it under Stock Received but not billed account, there is always balance remained in the Stock Received but not billed account which is incorrect

**After Fix**

<img width="938" alt="Screenshot 2020-09-23 at 7 24 39 PM" src="https://user-images.githubusercontent.com/8780500/94024522-27740e00-fdd5-11ea-83f4-1622e0b44d63.png">
