### PR TITLE
chore: Add Filter Group to dialogs

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -480,7 +480,7 @@ erpnext.utils.update_child_items = function(opts) {
 				callback: r => {
 					if(!r.exc) {
 						if (this.doc.conversion_factor == r.message.conversion_factor) return;
-						
+
 						const docname = this.doc.docname;
 						dialog.fields_dict.trans_items.df.data.some(doc => {
 							if (doc.docname == docname) {
@@ -677,6 +677,7 @@ erpnext.utils.map_current_doc = function(opts) {
 			date_field: opts.date_field || undefined,
 			setters: opts.setters,
 			get_query: opts.get_query,
+			add_filters_group: 1,
 			action: function(selections, args) {
 				let values = selections;
 				if(values.length === 0){


### PR DESCRIPTION
- Added Filter Group to all Dialogs created via `erpnext.utils.map_current_doc`
  <img src="https://user-images.githubusercontent.com/25857446/94116315-820a7a00-fe68-11ea-8d65-81b9e08b67c5.png" width=55%>

**Affects Dialogs in the following documents:**
- Payment Order
- Purchase Invoice
- Sales Invoice
- Purchase Order
- RFQ
- Supplier Quotation
- Opportunity
- Appraisal
- Maintenance Schedule
- Maintenance Visit
- Employee Tax Exemption Proof
- Installation Note
- Quotation
- Sales Order
- Delivery Note
- Delivery Trip
- Material Request
- Pick List
- Purchase Receipt
- Stock Entry