### PR TITLE
fix: set stock UOM in item while creating material request from stock entry

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -139,6 +139,7 @@ frappe.ui.form.on('Stock Entry', {
 						mr_item.item_code = item.item_code;
 						mr_item.item_name = item.item_name;
 						mr_item.uom = item.uom;
+						mr_item.stock_uom = item.stock_uom;
 						mr_item.conversion_factor = item.conversion_factor;
 						mr_item.item_group = item.item_group;
 						mr_item.description = item.description;


### PR DESCRIPTION
Stock UOM wasn't fetched from Stock Entry item while creating a Material Request from a Stock Entry.