### PR TITLE
fix: include item_code in items result to allow adding product info in custom templates

### DIFF
--- a/erpnext/portal/product_configurator/utils.py
+++ b/erpnext/portal/product_configurator/utils.py
@@ -375,7 +375,7 @@ def get_items(filters=None, search=None):
 
 	results = frappe.db.sql('''
 		SELECT
-			`tabItem`.`name`, `tabItem`.`item_name`,
+			`tabItem`.`name`, `tabItem`.`item_name`, `tabItem`.`item_code`,
 			`tabItem`.`website_image`, `tabItem`.`image`,
 			`tabItem`.`web_long_description`, `tabItem`.`description`,
 			`tabItem`.`route`


### PR DESCRIPTION
In some cases, users/developers may want to display prices on product list page by creating custom page templates. The method erpnext.shopping_cart.product_info.set_product_info_for_website can add product info to items in the page context.
set_product_info_for_website relies on item_code to fetch product info. Including item_code in the query result will make it possible. 
This PR has been based on version-12-hotfix branch. 