### PR TITLE
feat: open lead status on next contact date

### DIFF
--- a/erpnext/crm/doctype/lead/lead.py
+++ b/erpnext/crm/doctype/lead/lead.py
@@ -365,3 +365,8 @@ def get_lead_with_phone_number(number):
 	lead = leads[0].name if leads else None
 
 	return lead
+
+def daily_open_lead():
+	leads = frappe.get_all("Lead", filters = [["contact_date", "Between", [nowdate(), nowdate()]]])
+	for lead in leads:
+		frappe.db.set_value("Lead", lead.name, "status", "Open")

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -336,7 +336,8 @@ scheduler_events = {
 		"erpnext.hr.doctype.leave_ledger_entry.leave_ledger_entry.process_expired_allocation",
 		"erpnext.hr.utils.generate_leave_encashment",
 		"erpnext.loan_management.doctype.loan_security_shortfall.loan_security_shortfall.create_process_loan_security_shortfall",
-		"erpnext.loan_management.doctype.loan_interest_accrual.loan_interest_accrual.process_loan_interest_accrual_for_term_loans"
+		"erpnext.loan_management.doctype.loan_interest_accrual.loan_interest_accrual.process_loan_interest_accrual_for_term_loans",
+		"erpnext.crm.doctype.lead.lead.daily_open_lead"
 	],
 	"monthly_long": [
 		"erpnext.accounts.deferred_revenue.process_deferred_accounting",


### PR DESCRIPTION
- Open the lead status on the next contact date similar to opportunity.
- Only Leads having contact date as today must be set as open, so that sales users know which leads to give priority
- The leads having future dates as contact dates will be dealt with on their respective contact dates