### PR TITLE
fix: Change Error Message in Work Order

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -434,7 +434,7 @@ class WorkOrder(Document):
 			elif flt(d.completed_qty) <= max_allowed_qty_for_wo:
 				d.status = "Completed"
 			else:
-				frappe.throw(_("Completed Qty can not be greater than 'Qty to Manufacture'"))
+				frappe.throw(_("Completed Qty cannot be greater than 'Qty to Manufacture'"))
 
 	def set_actual_dates(self):
 		if self.get("operations"):


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/50285544/94526499-39c9ce00-0253-11eb-889a-bf5c4d378dc8.png)


After:

Changed message to: **Completed Qty cannot be greater than 'Qty to Manufacture'**
