### PR TITLE
fix: Check only Read and Write Permission in Update Items

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1242,7 +1242,7 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 		try:
 			doc.check_permission(perm_type)
 		except frappe.PermissionError:
-			actions = { 'create': 'add', 'write': 'update', 'cancel': 'remove' }
+			actions = { 'create': 'add', 'write': 'update'}
 
 			frappe.throw(_("You do not have permissions to {} items in a {}.")
 				.format(actions[perm_type], parent_doctype), title=_("Insufficient Permissions"))
@@ -1285,7 +1285,7 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 	sales_doctypes = ['Sales Order', 'Sales Invoice', 'Delivery Note', 'Quotation']
 	parent = frappe.get_doc(parent_doctype, parent_doctype_name)
 
-	check_doc_permissions(parent, 'cancel')
+	check_doc_permissions(parent, 'write')
 	validate_and_delete_children(parent, data)
 
 	for d in data:


### PR DESCRIPTION
**Issue:**
- On updation of child row , cancel permission was checked in Update Items
- It was intended to be checked if rows are deleted, hence misplaced.
- Also row deletion in a doc, should only need write permission. The permission check is on the parent doc anyway, hence incorrect
- This obstructed users without cancel permission to even update the rows

**Fix:**
- Check only if user has write(update) permission before proceeding at all