### PR TITLE
fix: Avoid validation of group cost center on repost

### DIFF
--- a/erpnext/accounts/doctype/gl_entry/gl_entry.py
+++ b/erpnext/accounts/doctype/gl_entry/gl_entry.py
@@ -138,7 +138,7 @@ class GLEntry(Document):
 			frappe.throw(_("{0} {1}: Cost Center {2} does not belong to Company {3}")
 				.format(self.voucher_type, self.voucher_no, self.cost_center, self.company))
 
-		if self.cost_center and _check_is_group():
+		if not self.flags.from_repost and self.cost_center and _check_is_group():
 			frappe.throw(_("""{0} {1}: Cost Center {2} is a group cost center and group cost centers cannot
 				be used in transactions""").format(self.voucher_type, self.voucher_no, frappe.bold(self.cost_center)))
 


### PR DESCRIPTION
- On cancelling a backdated submitted entry, when dealing with old data, it throws:  **Cost Center <name> is a group cost center and group cost centers cannot be used in transactions**
- Here, since the system reposts GL entries of future transactions that already are submitted. If these have a group cost center too, user cant cancel this transaction.
- Neither can user change the cost center

**Fix:**
- While validating group cost center check if its via reposting or not. If via reposting, don't validate
- Essentially only validate this condition for newly created transactions