### PR TITLE
fix: tds calculation, skip invoices with "Apply Tax Withholding Amount" has disabled

### DIFF
--- a/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
+++ b/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
@@ -139,9 +139,9 @@ def get_tds_amount(suppliers, net_total, company, tax_details, fiscal_year_detai
 		else:
 			tds_amount = _get_tds(net_total, tax_details.rate)
 	else:
-		supplier_credit_amount = frappe.get_all('Purchase Invoice Item',
-			fields = ['sum(net_amount)'],
-			filters = {'parent': ('in', vouchers), 'docstatus': 1}, as_list=1)
+		supplier_credit_amount = frappe.get_all('Purchase Invoice',
+			fields = ['sum(net_total)'],
+			filters = {'name': ('in', vouchers), 'docstatus': 1, "apply_tds": 1}, as_list=1)
 
 		supplier_credit_amount = (supplier_credit_amount[0][0]
 			if supplier_credit_amount and supplier_credit_amount[0][0] else 0)


### PR DESCRIPTION
**Issue**

Three invoices against supplier A is as follows -

1) 8,688 (Apply TDS - yes)
2) 48,244 (Apply TDS - no)
3) 822 (Apply TDS - yes) -> System has applied tds by considering the amount of second invoice

TDS invoices amount = 9510 and TDS should not be deduct from the 3rd invoice but system has deducted
