### PR TITLE
Fixing Wrong calculations for Leave Balance in Leave Encashment

### DIFF
--- a/erpnext/hr/doctype/leave_allocation/leave_allocation.py
+++ b/erpnext/hr/doctype/leave_allocation/leave_allocation.py
@@ -210,8 +210,8 @@ def get_unused_leaves(employee, leave_type, from_date, to_date):
 	leaves = frappe.get_all("Leave Ledger Entry", filters={
 		'employee': employee,
 		'leave_type': leave_type,
-		'from_date': ('>=', from_date),
-		'to_date': ('<=', to_date)
+		'from_date': ('<=', from_date),
+		'to_date': ('>=', to_date)
 		}, or_filters={
 			'is_expired': 0,
 			'is_carry_forward': 1

--- a/erpnext/hr/doctype/leave_encashment/leave_encashment.py
+++ b/erpnext/hr/doctype/leave_encashment/leave_encashment.py
@@ -66,8 +66,8 @@ class LeaveEncashment(Document):
 		if not allocation:
 			frappe.throw(_("No Leaves Allocated to Employee: {0} for Leave Type: {1}").format(self.employee, self.leave_type))
 
-		self.leave_balance = allocation.total_leaves_allocated - allocation.carry_forwarded_leaves_count\
-			- get_unused_leaves(self.employee, self.leave_type, allocation.from_date, self.encashment_date)
+		self.leave_balance = get_unused_leaves(self.employee, self.leave_type, allocation.from_date, self.encashment_date) \
+			- allocation.carry_forwarded_leaves_count
 
 		encashable_days = self.leave_balance - frappe.db.get_value('Leave Type', self.leave_type, 'encashment_threshold_days')
 		self.encashable_days = encashable_days if encashable_days > 0 else 0
@@ -79,7 +79,7 @@ class LeaveEncashment(Document):
 		return True
 
 	def get_leave_allocation(self):
-		leave_allocation = frappe.db.sql("""select name, to_date, total_leaves_allocated, carry_forwarded_leaves_count from `tabLeave Allocation` where '{0}'
+		leave_allocation = frappe.db.sql("""select * from `tabLeave Allocation` where '{0}'
 		between from_date and to_date and docstatus=1 and leave_type='{1}'
 		and employee= '{2}'""".format(self.encashment_date or getdate(nowdate()), self.leave_type, self.employee), as_dict=1) #nosec
 


### PR DESCRIPTION
<h4>Fixing wrong calculations for Leave Balance in leave encashment.</h4>
Related Bug: https://github.com/frappe/erpnext/issues/23448
<br>
<br>

* BUG 1:
https://github.com/frappe/erpnext/blob/24e5a6172aaba2974d3097ea07758ec79ed3a953/erpnext/hr/doctype/leave_encashment/leave_encashment.py#L70
``allocation.from_date`` is calling an attribute that does not exist which always returns ``None``, where ``allocation = self.get_leave_allocation() ``. The query used to make this object does not contain ``from_date`` as shown below.
https://github.com/frappe/erpnext/blob/24e5a6172aaba2974d3097ea07758ec79ed3a953/erpnext/hr/doctype/leave_encashment/leave_encashment.py#L81-L86

<br>

* BUG 2:
``self.leave_balance`` calculation does not make sense, because it subtracts the unused leave balance from the total leave balance allocation which is not correct. It needs to be the unused leave balance only. For example, If an employee has 21 days leave allocated and did not take any vacations, the total unused days will also be 21 and the total balance at the end will be zero!!  
https://github.com/frappe/erpnext/blob/24e5a6172aaba2974d3097ea07758ec79ed3a953/erpnext/hr/doctype/leave_encashment/leave_encashment.py#L69-L70