### PR TITLE
fix: also update employee field when renamed

### DIFF
--- a/erpnext/hr/doctype/employee/employee.py
+++ b/erpnext/hr/doctype/employee/employee.py
@@ -56,6 +56,9 @@ class Employee(NestedSet):
 			if existing_user_id:
 				remove_user_permission(
 					"Employee", self.name, existing_user_id)
+	
+	def after_rename(self, old, new, merge):
+		self.db_set("employee", new)
 
 	def set_employee_name(self):
 		self.employee_name = ' '.join(filter(lambda x: x, [self.first_name, self.middle_name, self.last_name]))


### PR DESCRIPTION
Fixes #16148. Although originally this issue was found in v10, subsequent versions continue to have this behaviour.

