### PR TITLE
fix: last purchase rate in item prices report

### DIFF
--- a/erpnext/stock/report/item_prices/item_prices.py
+++ b/erpnext/stock/report/item_prices/item_prices.py
@@ -80,35 +80,10 @@ def get_last_purchase_rate():
 
 	item_last_purchase_rate_map = {}
 
-	query = """select * from (select
-					result.item_code,
-					result.base_rate
-					from (
-						(select
-							po_item.item_code,
-							po_item.item_name,
-							po.transaction_date as posting_date,
-							po_item.base_price_list_rate,
-							po_item.discount_percentage,
-							po_item.base_rate
-						from `tabPurchase Order` po, `tabPurchase Order Item` po_item
-						where po.name = po_item.parent and po.docstatus = 1)
-						union
-						(select
-							pr_item.item_code,
-							pr_item.item_name,
-							pr.posting_date,
-							pr_item.base_price_list_rate,
-							pr_item.discount_percentage,
-							pr_item.base_rate
-						from `tabPurchase Receipt` pr, `tabPurchase Receipt Item` pr_item
-						where pr.name = pr_item.parent and pr.docstatus = 1)
-				) result
-				order by result.item_code asc, result.posting_date desc) result_wrapper
-				group by item_code"""
+	query = """select item_code, last_purchase_rate from `tabItem`"""
 
 	for d in frappe.db.sql(query, as_dict=1):
-		item_last_purchase_rate_map.setdefault(d.item_code, d.base_rate)
+		item_last_purchase_rate_map.setdefault(d.item_code, d.last_purchase_rate)
 
 	return item_last_purchase_rate_map
 

--- a/erpnext/stock/report/item_prices/item_prices.py
+++ b/erpnext/stock/report/item_prices/item_prices.py
@@ -77,39 +77,26 @@ def get_price_list():
 	return item_rate_map
 
 def get_last_purchase_rate():
-
 	item_last_purchase_rate_map = {}
 
-	query = """select * from (select
-					result.item_code,
-					result.base_net_rate
-					from (
-						(select
-							po_item.item_code,
-							po_item.base_net_rate
-						from `tabPurchase Order` po, `tabPurchase Order Item` po_item
-						where po.name = po_item.parent and po.docstatus = 1
-						order by po.transaction_date desc, po.name desc limit 1)
-						union
-						(select
-							pr_item.item_code,
-							pr_item.base_net_rate
-						from `tabPurchase Receipt` pr, `tabPurchase Receipt Item` pr_item
-						where pr.name = pr_item.parent and pr.docstatus = 1
-						order by pr.posting_date desc, pr.posting_time desc, pr.name desc limit 1)
-						union
-						(select
-							pi_item.item_code,
-							pi_item.base_net_rate
-						from `tabPurchase Invoice` pi, `tabPurchase Invoice Item` pi_item
-						where pi.name = pi_item.parent and pi.docstatus = 1 and pi.update_stock = 1
-						order by pi.posting_date desc, pi.posting_time desc, pi.name desc limit 1)
-				) result
-				order by result.item_code asc) result_wrapper
-				group by item_code"""
+	query = """select * from (
+				(select
+					po_item.item_code,
+					po.transaction_date as posting_date,
+					po_item.base_rate
+				from `tabPurchase Order` po, `tabPurchase Order Item` po_item
+					where po.name = po_item.parent and po.docstatus = 1)
+				union
+				(select
+					pr_item.item_code,
+					pr.posting_date,
+					pr_item.base_rate
+				from `tabPurchase Receipt` pr, `tabPurchase Receipt Item` pr_item
+					where pr.name = pr_item.parent and pr.docstatus = 1)
+				) result order by result.item_code asc, result.posting_date asc"""
 
 	for d in frappe.db.sql(query, as_dict=1):
-		item_last_purchase_rate_map.setdefault(d.item_code, d.base_net_rate)
+		item_last_purchase_rate_map[d.item_code] = d.base_rate
 
 	return item_last_purchase_rate_map
 

--- a/erpnext/stock/report/item_prices/item_prices.py
+++ b/erpnext/stock/report/item_prices/item_prices.py
@@ -93,6 +93,13 @@ def get_last_purchase_rate():
 					pr_item.base_rate
 				from `tabPurchase Receipt` pr, `tabPurchase Receipt Item` pr_item
 					where pr.name = pr_item.parent and pr.docstatus = 1)
+				union
+				(select
+					pi_item.item_code,
+					pi.posting_date,
+					pi_item.base_rate
+				from `tabPurchase Invoice` pi, `tabPurchase Invoice Item` pi_item
+					where pi.name = pi_item.parent and pi.docstatus = 1 and pi.update_stock = 1)
 				) result order by result.item_code asc, result.posting_date asc"""
 
 	for d in frappe.db.sql(query, as_dict=1):

--- a/erpnext/stock/report/item_prices/item_prices.py
+++ b/erpnext/stock/report/item_prices/item_prices.py
@@ -80,10 +80,36 @@ def get_last_purchase_rate():
 
 	item_last_purchase_rate_map = {}
 
-	query = """select item_code, last_purchase_rate from `tabItem`"""
+	query = """select * from (select
+					result.item_code,
+					result.base_net_rate
+					from (
+						(select
+							po_item.item_code,
+							po_item.base_net_rate
+						from `tabPurchase Order` po, `tabPurchase Order Item` po_item
+						where po.name = po_item.parent and po.docstatus = 1
+						order by po.transaction_date desc, po.name desc limit 1)
+						union
+						(select
+							pr_item.item_code,
+							pr_item.base_net_rate
+						from `tabPurchase Receipt` pr, `tabPurchase Receipt Item` pr_item
+						where pr.name = pr_item.parent and pr.docstatus = 1
+						order by pr.posting_date desc, pr.posting_time desc, pr.name desc limit 1)
+						union
+						(select
+							pi_item.item_code,
+							pi_item.base_net_rate
+						from `tabPurchase Invoice` pi, `tabPurchase Invoice Item` pi_item
+						where pi.name = pi_item.parent and pi.docstatus = 1 and pi.update_stock = 1
+						order by pi.posting_date desc, pi.posting_time desc, pi.name desc limit 1)
+				) result
+				order by result.item_code asc) result_wrapper
+				group by item_code"""
 
 	for d in frappe.db.sql(query, as_dict=1):
-		item_last_purchase_rate_map.setdefault(d.item_code, d.last_purchase_rate)
+		item_last_purchase_rate_map.setdefault(d.item_code, d.base_net_rate)
 
 	return item_last_purchase_rate_map
 


### PR DESCRIPTION
**Issue:** 
- Below query fetches 466 results. On removing `group by` fetches 1900+ results. So rows were being grouped into one row per item resulting in loss of ordered data.
```
select * from (
	(select
		po_item.item_code,
		po.transaction_date as posting_date,
		po_item.base_rate
        from `tabPurchase Order` po, `tabPurchase Order Item` po_item
	where po.name = po_item.parent and po.docstatus = 1)
	union
	(select
		pr_item.item_code,
		pr.posting_date,
		pr_item.base_rate
	from `tabPurchase Receipt` pr, `tabPurchase Receipt Item` pr_item
        where pr.name = pr_item.parent and pr.docstatus = 1)
) result 
group by result.item_code
order by result.item_code asc, result.posting_date desc
```

- Last Purchase Rate of item were fetched from Purchase Orders and Receipts. Invoices with update stock were not considered.

Fix:
- Remove `group by` to get all the Purchase Order/Receipt/Invoice Item's rate