### PR TITLE
fix: Show Project under Create button in SO

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -181,7 +181,7 @@ erpnext.selling.SalesOrderController = erpnext.selling.SellingController.extend(
 					}
 
 					// project
-					if(flt(doc.per_delivered, 2) < 100 && (order_is_a_sale || order_is_a_custom_sale) && allow_delivery) {
+					if(flt(doc.per_delivered, 2) < 100) {
 							this.frm.add_custom_button(__('Project'), () => this.make_project(), __('Create'));
 					}
 


### PR DESCRIPTION
**Issue:**
- Under the **Create** dropdown in Sales order, **Project** was only visible if sales order type was one of Sales, Maintenance or Shopping Cart, and, if Sales order was deliverable(had atleast one item with delivered by supplier unchecked)
- These conditions seem pointless on Project creation from Sales Order, which should be allowed as long as the order isnt fully complete

**Fix:**
- **Project** to be visible only if Sales order isn't fully delivered (because making a project then is of no use)