### PR TITLE
feat: Supplier Sourced Items in BOM and Purchase Order

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -27,7 +27,6 @@ frappe.ui.form.on("Purchase Order", {
 				filters: {'company': frm.doc.company}
 			}
 		});
-
 	},
 
 	onload: function(frm) {
@@ -38,6 +37,14 @@ frappe.ui.form.on("Purchase Order", {
 
 		erpnext.queries.setup_queries(frm, "Warehouse", function() {
 			return erpnext.queries.warehouse(frm.doc);
+		});
+	},
+
+	refresh: function(frm) {
+		// Set Supplier Sourced Item fields read only
+		let fields_read_only = ["item_code", "item_name", "operation", "description", "qty", "uom", "bom_no"];
+		fields_read_only.forEach(function(field) {
+			frappe.meta.get_docfield("Supplier Sourced Item", field, frm.doc.name).read_only = 1;
 		});
 	}
 });

--- a/erpnext/buying/doctype/purchase_order/purchase_order.json
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.json
@@ -69,6 +69,8 @@
   "raw_material_details",
   "set_reserve_warehouse",
   "supplied_items",
+  "supplier_sourced_item_section",
+  "supplier_sourced_items",
   "taxes_section",
   "tax_category",
   "column_break_50",
@@ -1078,13 +1080,26 @@
    "fieldtype": "Small Text",
    "label": "Billing Address",
    "read_only": 1
+  },
+  {
+   "fieldname": "supplier_sourced_items",
+   "fieldtype": "Table",
+   "label": "Supplier Sourced Items",
+   "options": "Supplier Sourced Item",
+   "read_only": 1
+  },
+  {
+   "collapsible_depends_on": "supplier_sourced_items",
+   "fieldname": "supplier_sourced_item_section",
+   "fieldtype": "Section Break",
+   "label": "Supplier Sourced Item"
   }
  ],
  "icon": "fa fa-file-text",
  "idx": 105,
  "is_submittable": 1,
  "links": [],
- "modified": "2020-09-14 14:36:12.418690",
+ "modified": "2020-10-05 21:57:55.657892",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Purchase Order",

--- a/erpnext/manufacturing/doctype/bom/bom.json
+++ b/erpnext/manufacturing/doctype/bom/bom.json
@@ -37,6 +37,8 @@
   "inspection_required",
   "quality_inspection_template",
   "items",
+  "has_supplier_sourced_items",
+  "supplier_sourced_items",
   "scrap_section",
   "scrap_items",
   "costing",
@@ -510,14 +512,28 @@
    "no_copy": 1,
    "print_hide": 1,
    "read_only": 1
+  },
+  {
+   "depends_on": "eval:doc.has_supplier_sourced_items",
+   "fieldname": "supplier_sourced_items",
+   "fieldtype": "Table",
+   "label": "Supplier Sourced Items",
+   "options": "Supplier Sourced Item"
+  },
+  {
+   "default": "0",
+   "fieldname": "has_supplier_sourced_items",
+   "fieldtype": "Check",
+   "label": "Has Supplier Sourced Items"
   }
  ],
  "icon": "fa fa-sitemap",
  "idx": 1,
  "image_field": "image",
+ "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2020-05-21 12:29:32.634952",
+ "modified": "2020-10-05 12:40:39.018004",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "BOM",

--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -992,3 +992,14 @@ def make_variant_bom(source_name, bom_no, item, variant_items, target_doc=None):
 	}, target_doc, postprocess)
 
 	return doc
+
+def get_supplier_sourced_items(bom, qty):
+	return frappe.db.sql("""
+			select
+				item_code, item_name, operation, description, idx,
+				(qty*%s) as qty, uom, parent as bom_no
+			from
+				`tabSupplier Sourced Item`
+			where
+				 parent = %s order by idx
+		""", (qty, bom), as_dict=1)

--- a/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
@@ -210,6 +210,14 @@ def make_bom(**args):
 			'stock_uom': item_doc.stock_uom,
 			'rate': item_doc.valuation_rate or args.rate,
 		})
+	if args.supplier_sourced_items:
+		bom.append('supplier_sourced_items', {
+			'item_code': item,
+			'qty': 1,
+			'uom': item_doc.stock_uom,
+			'stock_uom': item_doc.stock_uom,
+			'rate': item_doc.valuation_rate or args.rate,
+		})
 
 	bom.insert(ignore_permissions=True)
 	bom.submit()

--- a/erpnext/manufacturing/doctype/supplier_sourced_item/supplier_sourced_item.json
+++ b/erpnext/manufacturing/doctype/supplier_sourced_item/supplier_sourced_item.json
@@ -1,0 +1,141 @@
+{
+ "actions": [],
+ "creation": "2020-10-05 11:12:16.638869",
+ "doctype": "DocType",
+ "document_type": "Setup",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "item_code",
+  "item_name",
+  "operation",
+  "column_break_3",
+  "section_break_5",
+  "description",
+  "col_break1",
+  "image",
+  "image_view",
+  "quantity",
+  "qty",
+  "uom",
+  "section_break_13",
+  "bom_no"
+ ],
+ "fields": [
+  {
+   "columns": 3,
+   "fieldname": "item_code",
+   "fieldtype": "Link",
+   "in_filter": 1,
+   "in_list_view": 1,
+   "label": "Item Code",
+   "oldfieldname": "item_code",
+   "oldfieldtype": "Link",
+   "options": "Item",
+   "reqd": 1,
+   "search_index": 1
+  },
+  {
+   "columns": 3,
+   "fieldname": "item_name",
+   "fieldtype": "Data",
+   "label": "Item Name"
+  },
+  {
+   "depends_on": "eval:parent.with_operations == 1",
+   "fieldname": "operation",
+   "fieldtype": "Link",
+   "label": "Item operation",
+   "options": "Operation"
+  },
+  {
+   "fieldname": "column_break_3",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "bom_no",
+   "fieldtype": "Link",
+   "in_filter": 1,
+   "in_list_view": 1,
+   "label": "BOM No",
+   "oldfieldname": "bom_no",
+   "oldfieldtype": "Link",
+   "options": "BOM",
+   "print_width": "150px",
+   "search_index": 1,
+   "width": "150px"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "section_break_5",
+   "fieldtype": "Section Break",
+   "label": "Description"
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Text Editor",
+   "label": "Item Description",
+   "oldfieldname": "description",
+   "oldfieldtype": "Text",
+   "print_width": "250px",
+   "width": "250px"
+  },
+  {
+   "fieldname": "col_break1",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "image",
+   "fieldtype": "Attach",
+   "hidden": 1,
+   "label": "Image",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "image_view",
+   "fieldtype": "Image",
+   "label": "Image View",
+   "options": "image"
+  },
+  {
+   "fieldname": "quantity",
+   "fieldtype": "Section Break",
+   "label": "Quantity"
+  },
+  {
+   "columns": 2,
+   "fieldname": "qty",
+   "fieldtype": "Float",
+   "in_list_view": 1,
+   "label": "Quantity",
+   "oldfieldname": "qty",
+   "oldfieldtype": "Currency",
+   "reqd": 1
+  },
+  {
+   "columns": 1,
+   "fieldname": "uom",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "UOM",
+   "options": "UOM",
+   "print_hide": 1,
+   "reqd": 1
+  },
+  {
+   "fieldname": "section_break_13",
+   "fieldtype": "Section Break"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2020-10-06 16:28:49.972878",
+ "modified_by": "Administrator",
+ "module": "Manufacturing",
+ "name": "Supplier Sourced Item",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC"
+}

--- a/erpnext/manufacturing/doctype/supplier_sourced_item/supplier_sourced_item.py
+++ b/erpnext/manufacturing/doctype/supplier_sourced_item/supplier_sourced_item.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+from __future__ import unicode_literals
+# import frappe
+from frappe.model.document import Document
+
+class SupplierSourcedItem(Document):
+	pass


### PR DESCRIPTION
Minor and a basic feature required by Manufacturing companies.

While creating a BOM for Sub-Contracting, there might be raw material which Supplier will have to procure themselves, not always though hence we cannot put this flag in Item Master. 

Does not require any Stock Entries or Accounts-related stuff. Just the information which is very important to the user and they need to see on BOM and Purchase Order.

- Added a checkbox Has Supplier Sourced Items
- It will populate the Childtable with Item Code, Item Name, Description, Qty, UOM.
<img width="1195" alt="Screen Shot 2020-10-05 at 6 14 57 PM" src="https://user-images.githubusercontent.com/16913064/95106579-520b8280-0756-11eb-8ac0-5d4d87e54111.png">


<img width="1208" alt="Screen Shot 2020-10-05 at 6 15 52 PM" src="https://user-images.githubusercontent.com/16913064/95106593-55067300-0756-11eb-836c-8c082f108668.png">

- In Purchase Order on validate if BOM exists, it will pull the Supplier Sourced Items for reference to the Supplier and populate in the read only table with no effect on totals.
- The qty is calculated based on item qty multiplied by the required raw material qty in BOM.
![screencapture-kanchan-ch-8000-desk-2020-10-06-16_00_40](https://user-images.githubusercontent.com/16913064/95190619-3e5f2b00-07ed-11eb-84f3-d78280ee0202.png)

