### PR TITLE
fix: Typo in Accounts Settings

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -104,7 +104,7 @@
    "default": "1",
    "fieldname": "unlink_advance_payment_on_cancelation_of_order",
    "fieldtype": "Check",
-   "label": "Unlink Advance Payment on Cancelation of Order"
+   "label": "Unlink Advance Payment on Cancellation of Order"
   },
   {
    "default": "1",
@@ -223,9 +223,10 @@
  ],
  "icon": "icon-cog",
  "idx": 1,
+ "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2020-08-03 20:13:26.043092",
+ "modified": "2020-10-07 14:58:50.325577",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounts Settings",


### PR DESCRIPTION
Changed "Cancelation" to "Cancellation"

**Before:**

![image](https://user-images.githubusercontent.com/50285544/95315401-12f14480-08b0-11eb-8d62-43bcf2cf8008.png)



**After:**

![image](https://user-images.githubusercontent.com/50285544/95315371-066cec00-08b0-11eb-8d0e-11799d9d4e2e.png)
