### PR TITLE
fix: COGS validation in the purchase receipt

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -207,7 +207,6 @@ class PurchaseReceipt(BuyingController):
 		from erpnext.accounts.general_ledger import process_gl_map
 
 		stock_rbnb = self.get_company_default("stock_received_but_not_billed")
-		cogs_account = self.get_company_default("default_expense_account")
 		landed_cost_entries = get_item_account_wise_additional_cost(self.name)
 		expenses_included_in_valuation = self.get_company_default("expenses_included_in_valuation")
 
@@ -289,6 +288,7 @@ class PurchaseReceipt(BuyingController):
 						if self.is_return or flt(d.item_tax_amount):
 							loss_account = expenses_included_in_valuation
 						else:
+							cogs_account = self.get_company_default("default_expense_account")
 							loss_account = cogs_account
 
 						gl_entries.append(self.get_gl_dict({


### PR DESCRIPTION
If no COGS set in the company then getting the below error, even if there is no negative stock balance
<img width="672" alt="Screenshot 2020-10-07 at 7 05 45 PM" src="https://user-images.githubusercontent.com/8780500/95338185-4b087f80-08d0-11eb-9e4b-f95820782035.png">
