### PR TITLE
fix: cannot merge pos invoices with inclusive tax

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
@@ -331,7 +331,6 @@ class TestPOSInvoice(unittest.TestCase):
 		pos_inv.submit()
 
 		pos_inv2 = create_pos_invoice(rate=300, qty=2, do_not_submit=1)
-		pos_inv2.apply_discount_on = 'Net Total'
 		pos_inv2.additional_discount_percentage = 10
 		pos_inv2.append('payments', {
 			'mode_of_payment': 'Cash', 'account': 'Cash - _TC', 'amount': 540

--- a/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
@@ -98,23 +98,26 @@ class POSInvoiceMergeLog(Document):
 			for item in doc.get('items'):
 				found = False
 				for i in items:
-					if i.item_code == item.item_code and i.uom == item.uom and i.rate == item.rate:
+					if (i.item_code == item.item_code and not i.serial_no and not i.batch_no and
+						i.uom == item.uom and i.net_rate == item.net_rate):
 						found = True
 						i.qty = i.qty + item.qty
-						i.rate = (i.net_amount + item.net_amount) / i.qty
 				if not found:
+					item.rate = item.net_rate
 					items.append(item)
 			
 			for tax in doc.get('taxes'):
 				found = False
 				for t in taxes:
-					if t.account_head == tax.account_head and t.cost_center == tax.cost_center and t.rate == tax.rate:
-						t.tax_amount = flt(t.tax_amount) + flt(tax.tax_amount)
-						t.base_tax_amount = flt(t.base_tax_amount) + flt(tax.base_tax_amount)
+					if t.account_head == tax.account_head and t.cost_center == tax.cost_center:
+						t.tax_amount = flt(t.tax_amount) + flt(tax.tax_amount_after_discount_amount)
+						t.base_tax_amount = flt(t.base_tax_amount) + flt(tax.base_tax_amount_after_discount_amount)
 						found = True
 				if not found:
 					tax.charge_type = 'Actual'
 					tax.included_in_print_rate = 0
+					tax.tax_amount = tax.tax_amount_after_discount_amount
+					tax.base_tax_amount = tax.base_tax_amount_after_discount_amount
 					taxes.append(tax)
 
 			for payment in doc.get('payments'):

--- a/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
@@ -96,7 +96,14 @@ class POSInvoiceMergeLog(Document):
 				loyalty_amount_sum += doc.loyalty_amount
 			
 			for item in doc.get('items'):
-				items.append(item)
+				found = False
+				for i in items:
+					if i.item_code == item.item_code and i.uom == item.uom and i.rate == item.rate:
+						found = True
+						i.qty = i.qty + item.qty
+						i.rate = (i.net_amount + item.net_amount) / i.qty
+				if not found:
+					items.append(item)
 			
 			for tax in doc.get('taxes'):
 				found = False
@@ -107,6 +114,7 @@ class POSInvoiceMergeLog(Document):
 						found = True
 				if not found:
 					tax.charge_type = 'Actual'
+					tax.included_in_print_rate = 0
 					taxes.append(tax)
 
 			for payment in doc.get('payments'):
@@ -127,6 +135,8 @@ class POSInvoiceMergeLog(Document):
 		invoice.set('items', items)
 		invoice.set('payments', payments)
 		invoice.set('taxes', taxes)
+		invoice.additional_discount_percentage = 0
+		invoice.discount_amount = 0.0
 
 		return invoice
 	


### PR DESCRIPTION
Problem:
- Merging into sales invoice converts all type of taxes to Actual
- If POS Invoice has item with inclusive tax then submitting of sales invoice with actual inclusive tax throws error

Fix:
- Recalculate item rate to based on POS Invoice Item net rate
- Recalculated rate will be used to calculate tax again to adjust and give proper grand total
- For eg. If Item 1 in POS Invoice has tax inclusive rate of 300Rs with 10% tax i.e 30Rs. Then while merging into Sales Invoice, the rate will be set as 270Rs with 30Rs actual tax amount.