### PR TITLE
fix: Typo in Accounts Settings

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -97,7 +97,7 @@
    "default": "1",
    "fieldname": "unlink_advance_payment_on_cancelation_of_order",
    "fieldtype": "Check",
-   "label": "Unlink Advance Payment on Cancelation of Order"
+   "label": "Unlink Advance Payment on Cancellation of Order"
   },
   {
    "default": "1",
@@ -179,7 +179,7 @@
  "icon": "icon-cog",
  "idx": 1,
  "issingle": 1,
- "modified": "2020-03-11 13:09:26.235848",
+ "modified": "2020-10-08 09:40:12.121145",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounts Settings",


### PR DESCRIPTION
backport of https://github.com/frappe/erpnext/pull/23529

Changed "Cancelation" to "Cancellation"

**Before:**

![image](https://user-images.githubusercontent.com/50285544/95315401-12f14480-08b0-11eb-8d62-43bcf2cf8008.png)



**After:**

![image](https://user-images.githubusercontent.com/50285544/95315371-066cec00-08b0-11eb-8d0e-11799d9d4e2e.png)
