### PR TITLE
chore: do not allow future transactions

### DIFF
--- a/erpnext/utilities/transaction_base.py
+++ b/erpnext/utilities/transaction_base.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 import frappe
 import frappe.share
 from frappe import _
-from frappe.utils import cstr, now_datetime, cint, flt, get_time, get_datetime, get_link_to_form
+from frappe.utils import cstr, now_datetime, cint, flt, get_time, get_datetime, get_link_to_form, date_diff, nowdate
 from erpnext.controllers.status_updater import StatusUpdater
 from erpnext.accounts.utils import get_fiscal_year
 
@@ -29,7 +29,13 @@ class TransactionBase(StatusUpdater):
 			except ValueError:
 				frappe.throw(_('Invalid Posting Time'))
 
+		self.validate_future_posting()
 		self.validate_with_last_transaction_posting_time()
+	
+	def validate_future_posting(self):
+		if getattr(self, 'set_posting_time', None) and date_diff(self.posting_date, nowdate()) > 0:
+			msg = _("Posting future transactions are not allowed due to Immutable Ledger")
+			frappe.throw(msg, title=_("Future Posting Not Allowed"))
 
 	def add_calendar_event(self, opts, force=False):
 		if cstr(self.contact_by) != cstr(self._prev.contact_by) or \


### PR DESCRIPTION
Problem:
- If a future transaction is posted then user is unable to create transactions on until that particular future date.
- Only option is to delete the stock ledger entry associated with that future transaction after cancelling.

<img width="464" alt="Screenshot 2020-10-09 at 2 31 55 PM" src="https://user-images.githubusercontent.com/25369014/95571140-955f3d00-0a45-11eb-80ea-bf4f30f1b770.png">


Fix:
- Not allow future posting until immutable ledger is stable
<img width="464" alt="Screenshot 2020-10-09 at 3 34 27 PM" src="https://user-images.githubusercontent.com/25369014/95570921-43b6b280-0a45-11eb-87e1-30ba8b25b8f8.png">
