### PR TITLE
fix: Remove Production Order reference from Item Validation

### DIFF
--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -984,9 +984,7 @@ class Item(WebsiteGenerator):
 				if self.stock_ledger_created():
 					return True
 
-			elif frappe.db.get_value(doctype, filters={"item_code": self.name, "docstatus": 1}) or \
-				frappe.db.get_value("Production Order",
-					filters={"production_item": self.name, "docstatus": 1}):
+			elif frappe.db.get_value(doctype, filters={"item_code": self.name, "docstatus": 1}):
 				return True
 
 	def validate_auto_reorder_enabled_in_stock_settings(self):


### PR DESCRIPTION
- Production Order has been removed almost 2 years or so back, and Production Plan is in action as of now
- Removed check on Production Order in item's `check_if_linked_document_exists` function