### PR TITLE
fix: (revert) Add Delivery Note Count in Sales Invoice Dashboard

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice_dashboard.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice_dashboard.py
@@ -13,8 +13,7 @@ def get_data():
 			'Auto Repeat': 'reference_document',
 		},
 		'internal_links': {
-			'Sales Order': ['items', 'sales_order'],
-			'Delivery Note': ['items', 'delivery_note']
+			'Sales Order': ['items', 'sales_order']
 		},
 		'transactions': [
 			{


### PR DESCRIPTION
Problem:
- Sales Invoice is linked with Delivery note with 2 fields, `delivery_note` and `against_sales_invoice` found in Sales Invoice Item and Delivery Note Item respectively
- #23161 fixed an issue where the DN linked with SI with fieldname `delivery_note` were not shown in SI Dashboard
- This fix broke the DN count shown in SI Dashboard where SI was linked with fieldname `against_sales_invoice`

Fix:
- Right now reverting back to show `against_sales_invoice` links
- Framework doesn't have provision to merge both of these links and show in dashboard