### PR TITLE
fix: (revert) Add Delivery Note Count in Sales Invoice Dashboard

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice_dashboard.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice_dashboard.py
@@ -13,8 +13,7 @@ def get_data():
 			'Auto Repeat': 'reference_document',
 		},
 		'internal_links': {
-			'Sales Order': ['items', 'sales_order'],
-			'Delivery Note': ['items', 'delivery_note']
+			'Sales Order': ['items', 'sales_order']
 		},
 		'transactions': [
 			{


### PR DESCRIPTION
BackPort of #23570 