### PR TITLE
fix: Check if list view standard filter exists in Payment Entry

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry_list.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry_list.js
@@ -1,12 +1,14 @@
 frappe.listview_settings['Payment Entry'] = {
 
 	onload: function(listview) {
-		listview.page.fields_dict.party_type.get_query = function() {
-			return {
-				"filters": {
-					"name": ["in", Object.keys(frappe.boot.party_account_types)],
-				}
+		if (listview.page.fields_dict.party_type) {
+			listview.page.fields_dict.party_type.get_query = function() {
+				return {
+					"filters": {
+						"name": ["in", Object.keys(frappe.boot.party_account_types)],
+					}
+				};
 			};
-		};
+		}
 	}
 };


### PR DESCRIPTION
- If party type standard filter did not exist in List view, filters were not set while routing from Sales Invoice dashboard to Payment Entry
- This PR fixes that. It checks if the standard filter exists before assigning a `get_query`