### PR TITLE
fix: Opening Journal Entry via Data Import

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -22,8 +22,12 @@ class JournalEntry(AccountsController):
 		return self.voucher_type
 
 	def validate(self):
+		if self.voucher_type == 'Opening Entry':
+			self.is_opening = 'Yes'
+
 		if not self.is_opening:
 			self.is_opening='No'
+
 		self.clearance_date = None
 
 		self.validate_party()


### PR DESCRIPTION
While importing Opening Entry JVs via Data Import user enters the `voucher_type` type  field as 'Open Entry' and is under the impression that opening entries are being entered but might not be aware of the `is_opening` select field which also has to be updated as 'Yes'

Current the trigger for this only exists on client side hence while importing opening JVs via Data Import its not auto updated and causes issues while viewing ledgers and posting other entries


**Solution:** Added server side handling for this. On selecting `voucher_type` as Opening Entry is opening will be updated as "Yes"