### PR TITLE
fix: can't save item price after adding child table 

### DIFF
--- a/erpnext/stock/doctype/item_price/item_price.py
+++ b/erpnext/stock/doctype/item_price/item_price.py
@@ -50,16 +50,18 @@ class ItemPrice(Document):
 
 	def check_duplicates(self):
 		conditions = "where item_code=%(item_code)s and price_list=%(price_list)s and name != %(name)s"
+		condition_data_dict = dict(item_code=self.item_code, price_list=self.price_list, name=self.name)
 
 		for field in ['uom', 'valid_from',
 			'valid_upto', 'packing_unit', 'customer', 'supplier']:
 			if self.get(field):
 				conditions += " and {0} = %({1})s".format(field, field)
+				condition_data_dict[field] = self.get(field)
 
 		price_list_rate = frappe.db.sql("""
 			SELECT price_list_rate
 			FROM `tabItem Price`
-			  {conditions} """.format(conditions=conditions), self.as_dict())
+			  {conditions} """.format(conditions=conditions), condition_data_dict)
 
 		if price_list_rate :
 			frappe.throw(_("Item Price appears multiple times based on Price List, Supplier/Customer, Currency, Item, UOM, Qty and Dates."), ItemPriceDuplicateItem)


### PR DESCRIPTION
**Issue-** After adding child table in item price, we can't save form if child table has data.
![item_price](https://user-images.githubusercontent.com/20715976/95731261-eb79ed80-0c9c-11eb-9135-5e3e4717c0c1.gif)
