### PR TITLE
fix: sales order payment terms date is same as quotation

### DIFF
--- a/erpnext/selling/doctype/quotation/quotation.py
+++ b/erpnext/selling/doctype/quotation/quotation.py
@@ -183,10 +183,6 @@ def _make_sales_order(source_name, target_doc=None, ignore_permissions=False):
 			"Sales Team": {
 				"doctype": "Sales Team",
 				"add_if_empty": True
-			},
-			"Payment Schedule": {
-				"doctype": "Payment Schedule",
-				"add_if_empty": True
 			}
 		}, target_doc, set_missing_values, ignore_permissions=ignore_permissions)
 


### PR DESCRIPTION
Problem Fixed:
- Create Sales Order from Quotation
- The due dates in payment terms are as per the quotation date. 
- It should be calculated as x days after Sales Order posting date. X is Credit Days set in the Payment terms master.