### PR TITLE
fix: Asset status after maintenance or repair

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -131,7 +131,7 @@ class Asset(AccountsController):
 
 	def validate_gross_and_purchase_amount(self):
 		if self.is_existing_asset: return
-		
+
 		if self.gross_purchase_amount and self.gross_purchase_amount != self.purchase_receipt_amount:
 			frappe.throw(_("Gross Purchase Amount should be {} to purchase amount of one single Asset. {}\
 				Please do not book expense of multiple assets against one single Asset.")
@@ -561,14 +561,18 @@ class Asset(AccountsController):
 			return 100 * (1 - flt(depreciation_rate, float_precision))
 
 def update_maintenance_status():
-	assets = frappe.get_all('Asset', filters = {'docstatus': 1, 'maintenance_required': 1})
+	assets = frappe.get_all(
+		"Asset", filters={"docstatus": 1, "maintenance_required": 1}
+	)
 
 	for asset in assets:
 		asset = frappe.get_doc("Asset", asset.name)
-		if frappe.db.exists('Asset Maintenance Task', {'parent': asset.name, 'next_due_date': today()}):
-			asset.set_status('In Maintenance')
-		if frappe.db.exists('Asset Repair', {'asset_name': asset.name, 'repair_status': 'Pending'}):
-			asset.set_status('Out of Order')
+		if frappe.db.exists("Asset Repair", {"asset_name": asset.name, "repair_status": "Pending"}):
+			asset.set_status("Out of Order")
+		elif frappe.db.exists("Asset Maintenance Task", {"parent": asset.name, "next_due_date": today()}):
+			asset.set_status("In Maintenance")
+		else:
+			asset.set_status()
 
 def make_post_gl_entry():
 


### PR DESCRIPTION
Fix a bug in the **Asset** DocType where their statuses are not being reverted to their original status after a repair or maintenance when being processed by the `update_maintenance_status()` function. This was fixed by adding a call to `set_status()` in the `update_maintenance_status()` function if there is no **Asset Maintenance Task** or **Asset Repair**.