### PR TITLE
fix: Perform Item Attribute Value Validation on Variants Only

### DIFF
--- a/erpnext/stock/doctype/item_attribute/item_attribute.py
+++ b/erpnext/stock/doctype/item_attribute/item_attribute.py
@@ -29,9 +29,18 @@ class ItemAttribute(Document):
 		'''Validate that if there are existing items with attributes, they are valid'''
 		attributes_list = [d.attribute_value for d in self.item_attribute_values]
 
-		for item in frappe.db.sql('''select i.name, iva.attribute_value as value
-			from `tabItem Variant Attribute` iva, `tabItem` i where iva.attribute = %s
-			and iva.parent = i.name and i.has_variants = 0''', self.name, as_dict=1):
+		# Get Item Variant Attribute details of variant items
+		items = frappe.db.sql("""
+			select
+				i.name, iva.attribute_value as value
+			from
+				`tabItem Variant Attribute` iva, `tabItem` i
+			where
+				iva.attribute = %(attribute)s
+				and iva.parent = i.name and
+				i.variant_of is not null and i.variant_of != ''""", {"attribute" : self.name}, as_dict=1)
+
+		for item in items:
 			if self.numeric_values:
 				validate_is_incremental(self, self.name, item.value, item.name)
 			else:


### PR DESCRIPTION
**Issue:**
- While adding or editing an attribute value in **Item Attribute**, a validation is done to see whether any attribute value is removed that exists in a Variant.
- Item attribute **values** exist in Variants while they are blank in Item Templates
- This validation checked attribute value of any Item having `has_variants = 0`, assuming that it is a variant

**Case encountered**:
 Normal Item A (not template or variant), with `has_variants = 0` but populated Item Attributes table with an attribute **Color** and value **None** since its not a variant
If you try adding a value to Item Attribute: **Color**, it will thow _"The value **None** is already assigned to an existing Item A"_

**Fix:**
- While fetching items to check their attribute values, filter based on `variant_of` instead of `has_variants`
- This way we will only get variant item attributes who will have a non empty attribute value