### PR TITLE
fix: Mode of payment getting overwritten by default mode of payment for returns

### DIFF
--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -629,22 +629,29 @@ class calculate_taxes_and_totals(object):
 		self.doc.other_charges_calculation = get_itemised_tax_breakup_html(self.doc)
 
 	def update_paid_amount_for_return(self, total_amount_to_pay):
-		default_mode_of_payment = frappe.db.get_value('Sales Invoice Payment',
-			{'parent': self.doc.pos_profile, 'default': 1},
-			['mode_of_payment', 'type', 'account'], as_dict=1)
+		existing_amount = 0
 
-		self.doc.payments = []
+		for payment in self.doc.payments:
+			existing_amount += payment.amount
 
-		if default_mode_of_payment:
-			self.doc.append('payments', {
-				'mode_of_payment': default_mode_of_payment.mode_of_payment,
-				'type': default_mode_of_payment.type,
-				'account': default_mode_of_payment.account,
-				'amount': total_amount_to_pay
-			})
-		else:
-			self.doc.is_pos = 0
-			self.doc.pos_profile = ''
+		# do not override user entered amount if equal to total_amount_to_pay
+		if existing_amount != total_amount_to_pay:
+			default_mode_of_payment = frappe.db.get_value('Sales Invoice Payment',
+				{'parent': self.doc.pos_profile, 'default': 1},
+				['mode_of_payment', 'type', 'account'], as_dict=1)
+
+			self.doc.payments = []
+
+			if default_mode_of_payment:
+				self.doc.append('payments', {
+					'mode_of_payment': default_mode_of_payment.mode_of_payment,
+					'type': default_mode_of_payment.type,
+					'account': default_mode_of_payment.account,
+					'amount': total_amount_to_pay
+				})
+			else:
+				self.doc.is_pos = 0
+				self.doc.pos_profile = ''
 
 		self.calculate_paid_amount()
 

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -594,7 +594,7 @@ erpnext.taxes_and_totals = erpnext.payments.extend({
 			$.each(actual_taxes_dict, function(key, value) {
 				if (value) total_actual_tax += value;
 			});
-			
+
 			return flt(this.frm.doc.grand_total - total_actual_tax, precision("grand_total"));
 		}
 	},
@@ -672,25 +672,33 @@ erpnext.taxes_and_totals = erpnext.payments.extend({
 			);
 		}
 
-		frappe.db.get_value('Sales Invoice Payment', {'parent': this.frm.doc.pos_profile, 'default': 1},
-			['mode_of_payment', 'account', 'type'], (value) => {
-				if (this.frm.is_dirty()) {
-					frappe.model.clear_table(this.frm.doc, 'payments');
-					if (value) {
-						let row = frappe.model.add_child(this.frm.doc, 'Sales Invoice Payment', 'payments');
-						row.mode_of_payment = value.mode_of_payment;
-						row.type = value.type;
-						row.account = value.account;
-						row.default = 1;
-						row.amount = total_amount_to_pay;
-					} else {
-						this.frm.set_value('is_pos', 1);
-					}
-					this.frm.refresh_fields();
-				}
-			}, 'Sales Invoice');
+		let existing_amount = 0
+		$.each(this.frm.doc.payments || [], function(i, row) {
+			existing_amount += row.amount;
+		})
 
-		this.calculate_paid_amount();
+		if (existing_amount != total_amount_to_pay) {
+			frappe.db.get_value('Sales Invoice Payment', {'parent': this.frm.doc.pos_profile, 'default': 1},
+				['mode_of_payment', 'account', 'type'], (value) => {
+					if (this.frm.is_dirty()) {
+						frappe.model.clear_table(this.frm.doc, 'payments');
+						if (value) {
+							let row = frappe.model.add_child(this.frm.doc, 'Sales Invoice Payment', 'payments');
+							row.mode_of_payment = value.mode_of_payment;
+							row.type = value.type;
+							row.account = value.account;
+							row.default = 1;
+							row.amount = total_amount_to_pay;
+						} else {
+							this.frm.set_value('is_pos', 1);
+						}
+						this.frm.refresh_fields();
+						this.calculate_paid_amount();
+					}
+				}, 'Sales Invoice');
+		} else {
+			this.calculate_paid_amount();
+		}
 	},
 
 	set_default_payment: function(total_amount_to_pay, update_paid_amount) {


### PR DESCRIPTION
User entered Mode Of Payments gets overwritten by default mode of payment in POS profile while making POS returns

**Solution**: Do not override user entered mode of payment if user entered amount is equal to return amount