### PR TITLE
fix: not able to do overproduction

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -611,7 +611,7 @@ erpnext.work_order = {
 				description: __('Max: {0}', [max]),
 				default: max
 			}, data => {
-				max += (max * (frm.doc.__onload.overproduction_percentage || 0.0)) / 100;
+				max += (frm.doc.qty * (frm.doc.__onload.overproduction_percentage || 0.0)) / 100;
 
 				if (data.qty > max) {
 					frappe.msgprint(__('Quantity must not be more than {0}', [max]));


### PR DESCRIPTION
**Issue**

1. Set overproduction as 30% in the manufacturing settings

1. Created work order with qty as 100, completed partial 80 qty

1. When trying to finished 30 quantity (10 extra), system throwing below error
<img width="713" alt="Screenshot 2020-10-12 at 2 46 50 PM" src="https://user-images.githubusercontent.com/8780500/95729915-309d2000-0c9b-11eb-8ab3-baa46ba70924.png">
