### PR TITLE
fix: Item Link Formatter Behaviour

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -703,9 +703,13 @@ erpnext.utils.map_current_doc = function(opts) {
 }
 
 frappe.form.link_formatters['Item'] = function(value, doc) {
-	if(doc && doc.item_name && doc.item_name !== value) {
-		return value? value + ': ' + doc.item_name: doc.item_name;
+	if (doc && value && doc.item_name && doc.item_name !== value) {
+		return value + ': ' + doc.item_name;
+	} else if (!value && doc.doctype && doc.item_name) {
+		// format blank value in child table
+		return doc.item_name;
 	} else {
+		// if value is blank in report view or item code and name are the same, return as is
 		return value;
 	}
 }


### PR DESCRIPTION
### **Issue:**
Item shows value in **Variant of** field, which are blank in the db, due to link formatter returning some value even though the actual value is blank.
Such Links were broken as well
![Screenshot 2020-10-12 at 8 32 56 PM](https://user-images.githubusercontent.com/25857446/95761417-eb441700-0cc9-11eb-9fa5-fee3ac7e1558.png)


### **Fix:**
- Link formatter is used to format Item value in **Reports** , **Child Table Grids**, and really any item link on a form 

In  **Reports**:
-  it should format the value as `item_code : item_name`, **_if there is value_** and **_if the value(item_code) differs from the item name_**
- If the value in the cell is blank , like in the first screenshot, return the same blank value back
  ![Screenshot 2020-10-12 at 8 27 13 PM](https://user-images.githubusercontent.com/25857446/95760843-209c3500-0cc9-11eb-9c42-8ebb06cf25c8.png)

In **Child table grids**:
- it should format the value as `item_code : item_name`, **_if there is value_** and **_if the value(item_code) differs from the item name_**
- If there's no value,`[ e.g. in an opening sales  invoice , item code is blank as item name is 'Opening Invoice Item' (dummy item)]`, then return item_name back for grid display
