### PR TITLE
fix: Convert dates to datetime.date before comparing in Holiday List

### DIFF
--- a/erpnext/hr/doctype/holiday_list/holiday_list.py
+++ b/erpnext/hr/doctype/holiday_list/holiday_list.py
@@ -1,3 +1,4 @@
+
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
 
@@ -32,7 +33,7 @@ class HolidayList(Document):
 
 
 	def validate_days(self):
-		if self.from_date > self.to_date:
+		if getdate(self.from_date) > getdate(self.to_date):
 			throw(_("To Date cannot be before From Date"))
 
 		for day in self.get("holidays"):


### PR DESCRIPTION
On setting from/to date in Holiday List Entry via Report Builder:
 ```
          if self.from_date > self.to_date:
     TypeError: '>' not supported between instances of 'str' and 'datetime.date'
```
This PR fixes that