### PR TITLE
fix: consider rounded_total in returns

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -572,7 +572,8 @@ class SalesInvoice(SellingController):
 
 	def validate_pos(self):
 		if self.is_return:
-			if flt(self.paid_amount) + flt(self.write_off_amount) - flt(self.grand_total) > \
+			invoice_total = self.rounded_total or self.grand_total
+			if flt(self.paid_amount) + flt(self.write_off_amount) - flt(invoice_total) > \
 				1.0/(10.0**(self.precision("grand_total") + 1.0)):
 					frappe.throw(_("Paid amount + Write Off Amount can not be greater than Grand Total"))
 


### PR DESCRIPTION
A "_Paid amount + Write Off Amount can not be greater than Grand Total_" exception was thrown during **Sales Invoice** validation for cases where the total had been rounded down.

eg. considering a few valid cases below -

| | no rounding | rounded up | rounded down |
|-|-:|-:|-:|
| `grand_total` | -17.00 | -17.82 | -17.32 |
| `rounded_total` | -17.00 | -18.00 | -17.00 |
| `paid_amount` | -17.00 | -18.00 | -17.00 |
| `write_off_amount` | 0.00 | 0.00 | 0.00 |
| `paid_amount - grand_total > 0` | ❌ | ❌ | ✔️ |

