### PR TITLE
feat: Add company and correct filter in bank statement reconciliation report filters

### DIFF
--- a/erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.js
+++ b/erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.js
@@ -4,6 +4,14 @@
 frappe.query_reports["Bank Reconciliation Statement"] = {
 	"filters": [
 		{
+			"fieldname":"company",
+			"label": __("Company"),
+			"fieldtype": "Link",
+			"options": "Company",
+			"reqd": 1,
+			"default": frappe.defaults.get_user_default("Company")
+		},
+		{
 			"fieldname":"account",
 			"label": __("Bank Account"),
 			"fieldtype": "Link",
@@ -12,11 +20,14 @@ frappe.query_reports["Bank Reconciliation Statement"] = {
 				locals[":Company"][frappe.defaults.get_user_default("Company")]["default_bank_account"]: "",
 			"reqd": 1,
 			"get_query": function() {
+				var company = frappe.query_report.get_filter_value('company')
 				return {
 					"query": "erpnext.controllers.queries.get_account_list",
 					"filters": [
 						['Account', 'account_type', 'in', 'Bank, Cash'],
 						['Account', 'is_group', '=', 0],
+						['Account', 'disabled', '=', 0],
+						['Account', 'company', '=', company],
 					]
 				}
 			}


### PR DESCRIPTION
If you have multi company scenario and many bank accounts that are no longer active, then it becomes difficult in bank statement reconciliation report to filter the account to reconcile and it also shows disabled accounts so futher confusion is created.

https://github.com/frappe/erpnext/issues/23613

![image](https://user-images.githubusercontent.com/35020381/95829250-ad350a80-0d3e-11eb-8e68-ca3e2d358c3f.png)
