### PR TITLE
fix: displaying mandatory address field in Lead form

### DIFF
--- a/erpnext/crm/doctype/lead/lead.json
+++ b/erpnext/crm/doctype/lead/lead.json
@@ -241,6 +241,7 @@
   },
   {
    "depends_on": "eval: doc.__islocal",
+   "description": "Home, Work, etc.",
    "fieldname": "address_title",
    "fieldtype": "Data",
    "label": "Address Title"
@@ -249,7 +250,8 @@
    "depends_on": "eval: doc.__islocal",
    "fieldname": "address_line1",
    "fieldtype": "Data",
-   "label": "Address Line 1"
+   "label": "Address Line 1",
+   "mandatory_depends_on": "eval: doc.address_title && doc.address_type"
   },
   {
    "depends_on": "eval: doc.__islocal",
@@ -261,7 +263,8 @@
    "depends_on": "eval: doc.__islocal",
    "fieldname": "city",
    "fieldtype": "Data",
-   "label": "City/Town"
+   "label": "City/Town",
+   "mandatory_depends_on": "eval: doc.address_title && doc.address_type"
   },
   {
    "depends_on": "eval: doc.__islocal",
@@ -280,6 +283,7 @@
    "fieldname": "country",
    "fieldtype": "Link",
    "label": "Country",
+   "mandatory_depends_on": "eval: doc.address_title && doc.address_type",
    "options": "Country"
   },
   {
@@ -449,7 +453,7 @@
  "idx": 5,
  "image_field": "image",
  "links": [],
- "modified": "2020-06-18 14:39:41.835416",
+ "modified": "2020-10-13 15:24:00.094811",
  "modified_by": "Administrator",
  "module": "CRM",
  "name": "Lead",

--- a/erpnext/crm/doctype/lead/lead.py
+++ b/erpnext/crm/doctype/lead/lead.py
@@ -22,7 +22,7 @@ class Lead(SellingController):
 		load_address_and_contact(self)
 
 	def before_insert(self):
-		if self.address_type and self.address_title and self.address_line1 and self.city and self.country:
+		if self.address_title and self.address_type:
 			self.address_doc = self.create_address()
 		self.contact_doc = self.create_contact()
 

--- a/erpnext/crm/doctype/lead/lead.py
+++ b/erpnext/crm/doctype/lead/lead.py
@@ -22,7 +22,8 @@ class Lead(SellingController):
 		load_address_and_contact(self)
 
 	def before_insert(self):
-		self.address_doc = self.create_address()
+		if self.address_type and self.address_title and self.address_line1 and self.city and self.country:
+			self.address_doc = self.create_address()
 		self.contact_doc = self.create_contact()
 
 	def after_insert(self):
@@ -133,15 +134,6 @@ class Lead(SellingController):
 		# skipping country since the system auto-sets it from system defaults
 		address = frappe.new_doc("Address")
 
-		mandatory_fields = [ df.fieldname for df in address.meta.fields if df.reqd ]
-
-		if not all([self.get(field) for field in mandatory_fields]):
-			frappe.msgprint(_('Missing mandatory fields in address. \
-				{0} to create address' ).format("<a href='desk#Form/Address/New Address 1' \
-				> Click here </a>"),
-				alert=True, indicator='yellow')
-			return
-
 		address.update({addr_field: self.get(addr_field) for addr_field in address_fields})
 		address.update({info_field: self.get(info_field) for info_field in info_fields})
 		address.insert()
@@ -190,7 +182,7 @@ class Lead(SellingController):
 
 	def update_links(self):
 		# update address links
-		if self.address_doc:
+		if hasattr(self, 'address_doc'):
 			self.address_doc.append("links", {
 				"link_doctype": "Lead",
 				"link_name": self.name,


### PR DESCRIPTION
**Issue -** In the New Lead form, when entering a new Address, no mandatory red fields are shown and if you don't fill the proper fields it does not save the Lead's Address section (and Address master) and gives notification on the side (screenshots below)
![image](https://user-images.githubusercontent.com/20715976/95847390-4594b480-0d6a-11eb-9aed-3341953136c2.png)

**After fix -** Now address field mandatory depends on Address Type and Address Title. 
![lead](https://user-images.githubusercontent.com/20715976/95847539-77a61680-0d6a-11eb-8a11-25907bf1f9f0.gif)


