### PR TITLE
feat: add address template for luxembourg

### DIFF
--- a/erpnext/regional/address_template/templates/luxembourg.html
+++ b/erpnext/regional/address_template/templates/luxembourg.html
@@ -1,0 +1,4 @@
+{% if address_line1 %}{{ address_line1 }}<br>{% endif -%}
+{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
+{% if pincode %}L-{{ pincode }}{% endif -%}{% if city %} {{ city }}{% endif %}<br>
+{% if country %}{{ country | upper }}{% endif %}


### PR DESCRIPTION
Add an **Address Template** for Luxembourg.

Reference: https://www.upu.int/UPU/media/upu/PostalEntitiesFiles/addressingUnit/luxEn.pdf