### PR TITLE
fix: stock & account balance difference in fraction

### DIFF
--- a/erpnext/accounts/general_ledger.py
+++ b/erpnext/accounts/general_ledger.py
@@ -171,7 +171,7 @@ def validate_account_for_perpetual_inventory(gl_map):
 					frappe.throw(_("Account: {0} can only be updated via Stock Transactions")
 						.format(account), StockAccountInvalidTransaction)
 
-			elif account_bal != stock_bal:
+			elif abs(account_bal - stock_bal) > 0.1:
 				precision = get_field_precision(frappe.get_meta("GL Entry").get_field("debit"),
 					currency=frappe.get_cached_value('Company',  gl_map[0].company,  "default_currency"))
 


### PR DESCRIPTION
Problem:
- There's 0.01 difference in balance which is preventing any stock transactions to be submitted

![image](https://user-images.githubusercontent.com/25369014/95955745-f3f83280-0e1a-11eb-8efb-b541bad2183b.png)

Fix:
- Ignore 0.1 difference in stock and account balance