### PR TITLE
fix: overproduction, not allowed to transfer extra materials

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -838,6 +838,8 @@ class StockEntry(StockController):
 			frappe.throw(_("Posting date and posting time is mandatory"))
 
 		self.set_work_order_details()
+		self.flags.backflush_based_on = frappe.db.get_single_value("Manufacturing Settings",
+			"backflush_raw_materials_based_on")
 
 		if self.bom_no:
 
@@ -851,14 +853,14 @@ class StockEntry(StockController):
 							item["to_warehouse"] = self.pro_doc.wip_warehouse
 					self.add_to_stock_entry_detail(item_dict)
 
-				elif (self.work_order and (self.purpose == "Manufacture" or self.purpose == "Material Consumption for Manufacture")
-					and not self.pro_doc.skip_transfer and frappe.db.get_single_value("Manufacturing Settings",
-					"backflush_raw_materials_based_on")== "Material Transferred for Manufacture"):
+				elif (self.work_order and (self.purpose == "Manufacture"
+						or self.purpose == "Material Consumption for Manufacture") and not self.pro_doc.skip_transfer
+					and self.flags.backflush_based_on == "Material Transferred for Manufacture"):
 					self.get_transfered_raw_materials()
 
-				elif self.work_order and (self.purpose == "Manufacture" or self.purpose == "Material Consumption for Manufacture") and \
-					frappe.db.get_single_value("Manufacturing Settings", "backflush_raw_materials_based_on")== "BOM" and \
-					frappe.db.get_single_value("Manufacturing Settings", "material_consumption")== 1:
+				elif (self.work_order and (self.purpose == "Manufacture" or
+					self.purpose == "Material Consumption for Manufacture") and self.flags.backflush_based_on== "BOM"
+					and frappe.db.get_single_value("Manufacturing Settings", "material_consumption")== 1):
 					self.get_unconsumed_raw_materials()
 				else:
 					if not self.fg_completed_qty:
@@ -1102,7 +1104,6 @@ class StockEntry(StockController):
 				for d in backflushed_materials.get(item.item_code):
 					if d.get(item.warehouse):
 						if (qty > req_qty):
-							qty = req_qty
 							qty-= d.get(item.warehouse)
 
 			if qty > 0:
@@ -1127,11 +1128,22 @@ class StockEntry(StockController):
 		"""
 		item_dict = self.get_pro_order_required_items()
 		max_qty = flt(self.pro_doc.qty)
+
+		allow_overproduction = False
+		overproduction_percentage = flt(frappe.db.get_single_value("Manufacturing Settings",
+			"overproduction_percentage_for_work_order"))
+
+		to_transfer_qty = flt(self.pro_doc.material_transferred_for_manufacturing) + flt(self.fg_completed_qty)
+		transfer_limit_qty = max_qty + ((max_qty * overproduction_percentage) / 100)
+
+		if transfer_limit_qty >= to_transfer_qty:
+			allow_overproduction = True
+
 		for item, item_details in iteritems(item_dict):
 			pending_to_issue = flt(item_details.required_qty) - flt(item_details.transferred_qty)
 			desire_to_transfer = flt(self.fg_completed_qty) * flt(item_details.required_qty) / max_qty
 
-			if desire_to_transfer <= pending_to_issue:
+			if desire_to_transfer <= pending_to_issue or allow_overproduction:
 				item_dict[item]["qty"] = desire_to_transfer
 			elif pending_to_issue > 0:
 				item_dict[item]["qty"] = pending_to_issue


### PR DESCRIPTION
### 1) Issue
In Material transfer. As per the BOM, raw-material to FG ration is 1:1. In order to over-produce, I tried to over-transfer. But even if I said transfer for 120 FG, it transferred the raw-material for 100 only.


<img width="979" alt="Screenshot 2020-10-15 at 3 48 01 PM" src="https://user-images.githubusercontent.com/8780500/96110841-0a2aef00-0efe-11eb-9656-d13b835783ba.png">

**After Fix**

<img width="925" alt="Screenshot 2020-10-15 at 3 48 28 PM" src="https://user-images.githubusercontent.com/8780500/96110971-3a728d80-0efe-11eb-9678-5ec38331df94.png">

### 2) Issue

Created two manufacture entry, one for 80 (worked fine) and another for 40. But in the second Manufacture Entry, it fetched only 20 Qty of raw-material. Even though When I mentioned 40 as FG item.

<img width="1028" alt="Screenshot 2020-10-15 at 6 36 27 PM" src="https://user-images.githubusercontent.com/8780500/96132408-02784400-0f18-11eb-838c-817da8ffe0f5.png">

**After Fix**
<img width="939" alt="Screenshot 2020-10-15 at 6 53 35 PM" src="https://user-images.githubusercontent.com/8780500/96132445-0b691580-0f18-11eb-8e68-b50725d0bfc5.png">
