### PR TITLE
fix: manually set serial nos override with current available serial nos

### DIFF
--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.js
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.js
@@ -110,7 +110,7 @@ frappe.ui.form.on("Stock Reconciliation", {
 					frappe.model.set_value(cdt, cdn, "amount", r.message.rate * r.message.qty);
 					frappe.model.set_value(cdt, cdn, "current_serial_no", r.message.serial_nos);
 
-					if (frm.doc.purpose == "Stock Reconciliation") {
+					if (frm.doc.purpose == "Stock Reconciliation" && !d.serial_no) {
 						frappe.model.set_value(cdt, cdn, "serial_no", r.message.serial_nos);
 					}
 				}
@@ -185,6 +185,11 @@ frappe.ui.form.on("Stock Reconciliation Item", {
 		var child = locals[cdt][cdn];
 		if (child.batch_no) {
 			frappe.model.set_value(cdt, cdn, "batch_no", "");
+		}
+
+		if (child.serial_no) {
+			frappe.model.set_value(cdt, cdn, "serial_no", "");
+			frappe.model.set_value(cdt, cdn, "current_serial_no", "");
 		}
 
 		frm.events.set_valuation_rate_and_qty(frm, cdt, cdn);

--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -68,7 +68,7 @@ class StockReconciliation(StockController):
 
 				if item_dict.get("serial_nos"):
 					item.current_serial_no = item_dict.get("serial_nos")
-					if self.purpose == "Stock Reconciliation":
+					if self.purpose == "Stock Reconciliation" and not item.serial_no:
 						item.serial_no = item.current_serial_no
 
 				item.current_qty = item_dict.get("qty")


### PR DESCRIPTION
**Issue**
Steps to replicate the issue

1. Serialized item with quantity as 2 and serial nos are A, B

1. Created stock reco and wants to change serial nos From A,B to C with qty as 1

1. On save, system has override the serial no C with A and B

**Expected Behaviour**
Don't override the manually set serial nos in the stock reconciliation.