### PR TITLE
fix: removed extra space from label "Rate"

### DIFF
--- a/erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
+++ b/erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
@@ -12,8 +12,6 @@
   "item_name",
   "column_break_3",
   "lead_time_days",
-  "expected_delivery_date",
-  "is_free_item",
   "section_break_5",
   "description",
   "item_group",
@@ -21,18 +19,20 @@
   "col_break1",
   "image",
   "image_view",
+  "manufacture_details",
+  "manufacturer",
+  "column_break_15",
+  "manufacturer_part_no",
   "quantity_and_rate",
   "qty",
   "stock_uom",
+  "price_list_rate",
+  "discount_percentage",
+  "discount_amount",
   "col_break2",
   "uom",
   "conversion_factor",
   "stock_qty",
-  "sec_break_price_list",
-  "price_list_rate",
-  "discount_percentage",
-  "discount_amount",
-  "col_break_price_list",
   "base_price_list_rate",
   "sec_break1",
   "rate",
@@ -42,6 +42,7 @@
   "base_rate",
   "base_amount",
   "pricing_rules",
+  "is_free_item",
   "section_break_24",
   "net_rate",
   "net_amount",
@@ -55,6 +56,7 @@
   "weight_uom",
   "warehouse_and_reference",
   "warehouse",
+  "project",
   "prevdoc_doctype",
   "material_request",
   "sales_order",
@@ -63,19 +65,13 @@
   "material_request_item",
   "request_for_quotation_item",
   "item_tax_rate",
-  "manufacture_details",
-  "manufacturer",
-  "column_break_15",
-  "manufacturer_part_no",
-  "ad_sec_break",
-  "project",
   "section_break_44",
   "page_break"
  ],
  "fields": [
   {
    "bold": 1,
-   "columns": 2,
+   "columns": 4,
    "fieldname": "item_code",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -111,7 +107,7 @@
   {
    "fieldname": "lead_time_days",
    "fieldtype": "Int",
-   "label": "Supplier Lead Time (days)"
+   "label": "Lead Time in days"
   },
   {
    "collapsible": 1,
@@ -166,6 +162,7 @@
   {
    "fieldname": "stock_uom",
    "fieldtype": "Link",
+   "in_list_view": 1,
    "label": "Stock UOM",
    "options": "UOM",
    "print_hide": 1,
@@ -199,7 +196,6 @@
   {
    "fieldname": "uom",
    "fieldtype": "Link",
-   "in_list_view": 1,
    "label": "UOM",
    "options": "UOM",
    "print_hide": 1,
@@ -241,7 +237,7 @@
    "fieldname": "rate",
    "fieldtype": "Currency",
    "in_list_view": 1,
-   "label": "Rate ",
+   "label": "Rate",
    "oldfieldname": "import_rate",
    "oldfieldtype": "Currency",
    "options": "currency"
@@ -526,41 +522,18 @@
    "fieldtype": "Column Break"
   },
   {
-   "fieldname": "sec_break_price_list",
-   "fieldtype": "Section Break"
-  },
-  {
-   "fieldname": "col_break_price_list",
-   "fieldtype": "Column Break"
-  },
-  {
-   "collapsible": 1,
-   "fieldname": "ad_sec_break",
-   "fieldtype": "Section Break",
-   "label": "Accounting Dimensions"
-  },
-  {
    "default": "0",
-   "depends_on": "is_free_item",
    "fieldname": "is_free_item",
    "fieldtype": "Check",
    "label": "Is Free Item",
    "print_hide": 1,
    "read_only": 1
-  },
-  {
-   "allow_on_submit": 1,
-   "bold": 1,
-   "fieldname": "expected_delivery_date",
-   "fieldtype": "Date",
-   "label": "Expected Delivery Date"
   }
  ],
  "idx": 1,
- "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-10-01 16:34:39.703033",
+ "modified": "2020-10-16 11:36:00.683431",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Supplier Quotation Item",


### PR DESCRIPTION
Due to this extra space in the label "Rate", when someone used to export the "Supplier Quotation" template from our Data Import the template used to have this extra space in the column name.
![Screenshot 2020-10-16 at 11 32 27 AM](https://user-images.githubusercontent.com/33727827/96219491-9263cf80-0fa4-11eb-9676-eecf78246099.png)

Which used to give an error when they used this template to import data.
![Screenshot 2020-10-16 at 11 35 44 AM](https://user-images.githubusercontent.com/33727827/96219523-a6a7cc80-0fa4-11eb-958c-c9e31d7ac786.png)
