### PR TITLE
fix: Change wrong format_date to formatdate

### DIFF
--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
@@ -11,7 +11,7 @@ from frappe.core.doctype.communication.email import make
 
 from frappe.utils.print_format import report_to_pdf
 from frappe.utils.pdf import get_pdf
-from frappe.utils import today, add_days, add_months, getdate, format_date
+from frappe.utils import today, add_days, add_months, getdate, formatdate
 from frappe.utils.jinja import validate_template
 
 import copy
@@ -149,8 +149,8 @@ def get_recipients_and_cc(customer, doc):
 def get_context(customer, doc):
 	template_doc = copy.deepcopy(doc)
 	del template_doc.customers
-	template_doc.from_date = format_date(template_doc.from_date)
-	template_doc.to_date = format_date(template_doc.to_date)
+	template_doc.from_date = formatdate(template_doc.from_date)
+	template_doc.to_date = formatdate(template_doc.to_date)
 	return {
 		'doc': template_doc,
 		'customer': frappe.get_doc('Customer', customer),
@@ -265,7 +265,7 @@ def send_emails(document_name, from_scheduler=False):
 
 @frappe.whitelist()
 def send_auto_email():
-	selected = frappe.get_list('Process Statement Of Accounts', filters={'to_date': format_date(today()), 'enable_auto_email': 1})
+	selected = frappe.get_list('Process Statement Of Accounts', filters={'to_date': formatdate(today()), 'enable_auto_email': 1})
 	for entry in selected:
 		send_emails(entry.name, from_scheduler=True)
 	return True


### PR DESCRIPTION
Installing erpnext...
Updating DocTypes for erpnext       : [===                                     ]An error occurred while installing erpnext:
Module import failed for Process Statement Of Accounts (erpnext.accounts.doctype.process_statement_of_accounts.process_statement_of_accounts Error: cannot import name 'format_date' from 'frappe.utils' (/home/erpfrappe/frappe-bench/apps/frappe/frappe/utils/__init__.py))

This is caused by wrong format_date name. The correct name is formatdate. (Author is probably confused with format_datetime)

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
