### PR TITLE
fix: removed extra space from label "Rate"

### DIFF
--- a/erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
+++ b/erpnext/buying/doctype/supplier_quotation_item/supplier_quotation_item.json
@@ -241,7 +241,7 @@
    "fieldname": "rate",
    "fieldtype": "Currency",
    "in_list_view": 1,
-   "label": "Rate ",
+   "label": "Rate",
    "oldfieldname": "import_rate",
    "oldfieldtype": "Currency",
    "options": "currency"
@@ -560,7 +560,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-10-01 16:34:39.703033",
+ "modified": "2020-10-19 12:36:26.913211",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Supplier Quotation Item",


### PR DESCRIPTION
Due to this extra space in the label "Rate", when someone used to export the "Supplier Quotation" template from our Data Import the template used to have this extra space in the column name.
![Screenshot 2020-10-16 at 11 32 27 AM](https://user-images.githubusercontent.com/33727827/96219491-9263cf80-0fa4-11eb-9676-eecf78246099.png)

Which used to give an error when they used this template to import data.
![Screenshot 2020-10-16 at 11 35 44 AM](https://user-images.githubusercontent.com/33727827/96219523-a6a7cc80-0fa4-11eb-958c-c9e31d7ac786.png)
