### PR TITLE
feat: Unlink Sales Order from Project and minor Project UX

### DIFF
--- a/erpnext/projects/doctype/project/project.js
+++ b/erpnext/projects/doctype/project/project.js
@@ -64,10 +64,6 @@ frappe.ui.form.on("Project", {
 
 	set_buttons: function(frm) {
 		if (!frm.is_new()) {
-			frm.add_custom_button(__('Duplicate Project with Tasks'), () => {
-				frm.events.create_duplicate(frm);
-			});
-
 			frm.add_custom_button(__('Completed'), () => {
 				frm.events.set_status(frm, 'Completed');
 			}, __('Set Status'));
@@ -75,6 +71,15 @@ frappe.ui.form.on("Project", {
 			frm.add_custom_button(__('Cancelled'), () => {
 				frm.events.set_status(frm, 'Cancelled');
 			}, __('Set Status'));
+
+			frm.add_custom_button(__('Duplicate Project with Tasks'), () => {
+				frm.events.create_duplicate(frm);
+			}, __('Tools'));
+
+			frm.add_custom_button(__('Unlink Sales Order'), () => {
+				frm.events.unlink_sales_order(frm);
+			}, __('Tools'));
+
 		}
 
 		if (frappe.model.can_read("Task")) {
@@ -83,7 +88,7 @@ frappe.ui.form.on("Project", {
 					"project": frm.doc.name
 				};
 				frappe.set_route("List", "Task", "Gantt");
-			});
+			}, __("Views"));
 
 			frm.add_custom_button(__("Kanban Board"), () => {
 				frappe.call('erpnext.projects.doctype.project.project.create_kanban_board_if_not_exists', {
@@ -91,8 +96,9 @@ frappe.ui.form.on("Project", {
 				}).then(() => {
 					frappe.set_route('List', 'Task', 'Kanban', frm.doc.project_name);
 				});
-			});
+			}, __("Views"));
 		}
+		frm.page.set_inner_btn_group_as_primary(__('Set Status'));
 	},
 
 	create_duplicate: function(frm) {
@@ -117,6 +123,27 @@ frappe.ui.form.on("Project", {
 				{project: frm.doc.name, status: status}).then(() => { /* page will auto reload */ });
 		});
 	},
+
+	unlink_sales_order: (frm) => {
+		frappe.call('erpnext.projects.doctype.project.project.unlink_sales_order', {
+			project_name: frm.doc.name
+		}).then((r) => {
+			if (r && r.message) {
+				frappe.show_alert({
+						message: __("Unlinked Sales Order {0}",
+							['<a href="#Form/Sales Order/'+r.message+'">' + r.message + '</a>']),
+						indicator: 'green'
+					});
+			}
+			else {
+				frappe.show_alert({
+					message: __("Nothing to Unlink"),
+					indicator: 'blue'
+				});
+			}
+			frm.reload_doc();
+		});
+	}
 
 });
 

--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -493,3 +493,18 @@ def set_project_status(project, status):
 
 	project.status = status
 	project.save()
+
+@frappe.whitelist()
+def unlink_sales_order(project_name):
+	# If project belongs to / is created from a specfic Sales Order
+	# unlink SO
+	project = frappe.get_doc("Project", project_name)
+
+	if frappe.db.exists("Sales Order", project_name) and frappe.db.get_value("Sales Order", project_name, "project"):
+		frappe.db.set_value("Sales Order", project_name, "project", '')
+
+		project.sales_order, project.customer = '', ''
+		project.save()
+		return project_name
+
+	return


### PR DESCRIPTION
## **Issue:**
- Create a Sales Order, lets say SAL-ORD-001
- Create a Project from this Sales Order, the Project gets the name SAL-ORD-001. The Project gets linked in the Sales Order (read only field), and the Sales Order gets linked in the Project
- Great we already have a circular dependency
- Try deleting the Project, because you don't want it anymore:
  ![Screenshot 2020-10-21 at 4 19 07 PM](https://user-images.githubusercontent.com/25857446/96709893-eca3cc80-13b8-11eb-914c-73248f9190c4.png)
- There is also no way to unlink the Sales order from the project, removing Sales Order from the project doesn't help. There is a link in the Sales Order too

## **Fix:**
- Added an **Unlink Sales Order** tool, that will unlink the Sales Order that this Project was created for and from
   ![Screenshot 2020-10-21 at 4 22 30 PM](https://user-images.githubusercontent.com/25857446/96710265-705db900-13b9-11eb-913c-788f106bffc6.png)
- It will remove the project link from the Sales Order and vice versa.
- It will also recalculate the Sales Costs in the Project
  ![project-so-link](https://user-images.githubusercontent.com/25857446/96711031-891a9e80-13ba-11eb-84b1-1d888ba5e1a3.gif)
- The Estimated Cost is left untouched as it could have been manually set too and it is just an estimate
- If there's nothing to unlink, feedback is given:
 ![Screenshot 2020-10-21 at 4 32 23 PM](https://user-images.githubusercontent.com/25857446/96711253-e4e52780-13ba-11eb-903c-57bd635e8a2a.png)-
- Users can unlink and keep the project if used against a Sales Invoice or any other document

## **Minor Enhancement:**
**Before:**
![Screenshot 2020-10-21 at 4 38 32 PM](https://user-images.githubusercontent.com/25857446/96711727-a4d27480-13bb-11eb-9dbf-c348a031eaba.png)

**After:**
![Screenshot 2020-10-21 at 4 39 27 PM](https://user-images.githubusercontent.com/25857446/96711780-ba479e80-13bb-11eb-9d2d-0f3bff6ae5bd.png)

**Duplicate Project with Tasks** and **Unlink Sales Order** is Shifted under Tools
  ![Screenshot 2020-10-21 at 4 36 00 PM](https://user-images.githubusercontent.com/25857446/96711574-663cba00-13bb-11eb-894d-6ebeff9bfb8c.png)
**Kanban Board** and **Gantt Chart** are shifted under **Views**
  ![Screenshot 2020-10-21 at 4 36 07 PM](https://user-images.githubusercontent.com/25857446/96711583-68067d80-13bb-11eb-8378-1ad5b31a3acb.png)
**Set Status** is the primary button group



