### PR TITLE
fix: expected amount in pos closing entry detail

### DIFF
--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.js
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.js
@@ -128,13 +128,13 @@ function refresh_payments(d, frm, remove) {
 	d.payments.forEach(p => {
 		const payment = frm.doc.payment_reconciliation.find(pay => pay.mode_of_payment === p.mode_of_payment);
 		if (payment) {
-			if (!remove) payment.expected_amount += flt(d.grand_total);
+			if (!remove) payment.expected_amount += flt(p.amount-d.change_amount);
 			else payment.expected_amount -= flt(p.amount);
 		} else {
 			frm.add_child("payment_reconciliation", {
 				mode_of_payment: p.mode_of_payment,
 				opening_amount: 0,
-				expected_amount: p.amount
+				expected_amount: p.amount-d.change_amount
 			})
 		}
 	})

--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.js
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.js
@@ -128,7 +128,7 @@ function refresh_payments(d, frm, remove) {
 	d.payments.forEach(p => {
 		const payment = frm.doc.payment_reconciliation.find(pay => pay.mode_of_payment === p.mode_of_payment);
 		if (payment) {
-			if (!remove) payment.expected_amount += flt(p.amount);
+			if (!remove) payment.expected_amount += flt(d.grand_total);
 			else payment.expected_amount -= flt(p.amount);
 		} else {
 			frm.add_child("payment_reconciliation", {

--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.py
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.py
@@ -113,12 +113,12 @@ def make_closing_entry_from_opening(opening_entry):
 		for p in d.payments:
 			existing_pay = [pay for pay in payments if pay.mode_of_payment == p.mode_of_payment]
 			if existing_pay:
-				existing_pay[0].expected_amount += flt(d.grand_total);
+				existing_pay[0].expected_amount += flt(p.amount-d.change_amount);
 			else:
 				payments.append(frappe._dict({
 					'mode_of_payment': p.mode_of_payment,
 					'opening_amount': 0,
-					'expected_amount': p.amount
+					'expected_amount': p.amount-d.change_amount
 				}))
 
 	closing_entry.set("pos_transactions", pos_transactions)

--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.py
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.py
@@ -113,7 +113,7 @@ def make_closing_entry_from_opening(opening_entry):
 		for p in d.payments:
 			existing_pay = [pay for pay in payments if pay.mode_of_payment == p.mode_of_payment]
 			if existing_pay:
-				existing_pay[0].expected_amount += flt(p.amount);
+				existing_pay[0].expected_amount += flt(d.grand_total);
 			else:
 				payments.append(frappe._dict({
 					'mode_of_payment': p.mode_of_payment,


### PR DESCRIPTION
expected amount in POS closing entry was equal to total cash received, not total amount in invoices as it should be
closes #23125
![image](https://user-images.githubusercontent.com/73298430/96891432-dc701800-14b2-11eb-8918-cfd4ed7cd37d.png)

