### PR TITLE
fix: Cashier Closing Type Issue

### DIFF
--- a/erpnext/accounts/doctype/cashier_closing/cashier_closing.py
+++ b/erpnext/accounts/doctype/cashier_closing/cashier_closing.py
@@ -23,13 +23,13 @@ class CashierClosing(Document):
 			where posting_date=%s and posting_time>=%s and posting_time<=%s and owner=%s
 		""", (self.date, self.from_time, self.time, self.user))
 		self.outstanding_amount = flt(values[0][0] if values else 0)
-			
+
 	def make_calculations(self):
 		total = 0.00
 		for i in self.payments:
 			total += flt(i.amount)
 
-		self.net_amount = total + self.outstanding_amount + self.expense - self.custody + self.returns
+		self.net_amount = total + self.outstanding_amount + flt(self.expense) - flt(self.custody) + flt(self.returns)
 
 	def validate_time(self):
 		if self.from_time >= self.time:


### PR DESCRIPTION
- Convert to **flt** before performing arithmetic operations
- `total` and `self.outstanding_amount` are already of type flt