### PR TITLE
fix: Hide Ex-Employees from Employee Tree and minor message UX

### DIFF
--- a/erpnext/hr/doctype/employee/employee.py
+++ b/erpnext/hr/doctype/employee/employee.py
@@ -218,7 +218,7 @@ class Employee(NestedSet):
 
 	def validate_preferred_email(self):
 		if self.prefered_contact_email and not self.get(scrub(self.prefered_contact_email)):
-			frappe.msgprint(_("Please enter " + self.prefered_contact_email))
+			frappe.msgprint(_("Please enter {0}").format(self.prefered_contact_email))
 
 	def validate_onboarding_process(self):
 		employee_onboarding = frappe.get_all("Employee Onboarding",


### PR DESCRIPTION
## **Issue:**
<details>
<summary>
Employees that have "Left" are still visible in Tree View

</summary>

 ![Screenshot 2020-10-23 at 2 14 33 PM](https://user-images.githubusercontent.com/25857446/96976816-e8eb8380-1539-11eb-908c-2364d8b4881f.png)
   ![Screenshot 2020-10-23 at 2 13 51 PM](https://user-images.githubusercontent.com/25857446/96976806-e557fc80-1539-11eb-885b-a81f6767ac88.png)
</details>

## **Fix:**
<details>
<summary>
Only Active employees visible
</summary>

  ![Screenshot 2020-10-23 at 2 16 17 PM](https://user-images.githubusercontent.com/25857446/96976968-12a4aa80-153a-11eb-938a-c64b38500885.png)

</details>

<details>
<summary>
Formatted Error message to rectify junior employees when a senior leaves
</summary>

  ![Screenshot 2020-10-23 at 2 09 33 PM](https://user-images.githubusercontent.com/25857446/96977063-32d46980-153a-11eb-9681-bb9a5da1a2cd.png)
</details>
