### PR TITLE
fix: Show accounts in financial statements upto level 20

### DIFF
--- a/erpnext/accounts/report/financial_statements.py
+++ b/erpnext/accounts/report/financial_statements.py
@@ -307,7 +307,7 @@ def get_accounts(company, root_type):
 		where company=%s and root_type=%s order by lft""", (company, root_type), as_dict=True)
 
 
-def filter_accounts(accounts, depth=10):
+def filter_accounts(accounts, depth=20):
 	parent_children_map = {}
 	accounts_by_name = {}
 	for d in accounts:


### PR DESCRIPTION
Issue: Due to restriction up to level 10, some accounts are not showing in financial statements.