### PR TITLE
fix(Bank Reconciliation): Clear Bank Transactions against Journal Entry Account

### DIFF
--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.js
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.js
@@ -2,14 +2,42 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Bank Transaction', {
-	onload(frm) {
+	onload: function(frm) {
 		frm.set_query('payment_document', 'payment_entries', function() {
 			return {
 				"filters": {
-					"name": ["in", ["Payment Entry", "Journal Entry", "Sales Invoice", "Purchase Invoice", "Expense Claim"]]
+					"name": ["in", ["Payment Entry", "Journal Entry Account", "Sales Invoice Payment", "Purchase Invoice"]]
 				}
 			};
 		});
+	},
+	refresh: function(frm) {
+		if (frm.doc.payment_entries.length > 0) {
+			frm.doc.payment_entries.forEach(entry => {
+				let parent_type = "";
+				if (entry.payment_document === "Journal Entry Account") {
+					parent_type = "Journal Entry";
+				}
+				if (entry.payment_document === "Sales Invoice Payment") {
+					parent_type = "Sales Invoice";
+				}
+				if (parent_type) {
+					frappe.db.get_value(entry.payment_document, {'name': entry.payment_entry}, 'parent', msg => {
+						frm.add_custom_button(entry.payment_document + __(" for ") + entry.allocated_amount,
+							function() {
+								frappe.set_route("Form", parent_type, msg.parent);
+							}, __('View Reconciled Payment...')
+						);
+					}, parent_type);
+				} else {
+					frm.add_custom_button(entry.payment_document + __(" for ") + String(entry.allocated_amount),
+						function() {
+							frappe.set_route("Form", entry.payment_document, entry.payment_entry);
+						}, __('View Reconciled Payment...')
+					);
+				}
+			});
+		}
 	}
 });
 
@@ -24,8 +52,11 @@ const update_clearance_date = (frm, cdt, cdn) => {
 		frappe.xcall('erpnext.accounts.doctype.bank_transaction.bank_transaction.unclear_reference_payment',
 			{doctype: cdt, docname: cdn})
 			.then(e => {
-				if (e == "success") {
-					frappe.show_alert({message:__("Document {0} successfully uncleared", [e]), indicator:'green'});
+				if (e.status == "success") {
+					frappe.show_alert({
+						message: __("Document {0} successfully uncleared", [e.entry]),
+						indicator: 'green'
+					});
 				}
 			});
 	}

--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
@@ -45,24 +45,115 @@ class BankTransaction(StatusUpdater):
 	def clear_linked_payment_entries(self):
 		for payment_entry in self.payment_entries:
 			allocated_amount = get_total_allocated_amount(payment_entry)
-			paid_amount = get_paid_amount(payment_entry, self.currency)
+			paid_amount = self.get_paid_amount(payment_entry.payment_document,
+				payment_entry.payment_entry, self.currency)
 
 			if paid_amount and allocated_amount:
 				if  flt(allocated_amount[0]["allocated_amount"]) > flt(paid_amount):
-					frappe.throw(_("The total allocated amount ({0}) is greated than the paid amount ({1}).").format(flt(allocated_amount[0]["allocated_amount"]), flt(paid_amount)))
+					frappe.throw(_("The total allocated amount ({0}) is greater than the paid amount ({1}).").format(flt(allocated_amount[0]["allocated_amount"]), flt(paid_amount)))
 				else:
-					if payment_entry.payment_document in ["Payment Entry", "Journal Entry", "Purchase Invoice", "Expense Claim"]:
-						self.clear_simple_entry(payment_entry)
+					# LEGACY: it is still possible that there are
+					# Bank Transaction records out there in old
+					# databases with Journal Entry or Sales Invoice
+					# payment entries. So to be on the safe side,
+					# handle clearing them even though new entries
+					# like that cannot be created.
+					if payment_entry.payment_document in ["Sales Invoice", "Journal Entry"]:
+						return self.clear_legacy_entry(payment_entry)
+					self.clear_simple_entry(payment_entry.payment_document,
+						payment_entry.payment_entry)
 
-					elif payment_entry.payment_document == "Sales Invoice":
-						self.clear_sales_invoice(payment_entry)
+	def clear_simple_entry(self, entry_type, entry_name):
+		frappe.db.set_value(entry_type, entry_name, "clearance_date", self.date)
+		if entry_type == "Journal Entry Account":
+			frappe.db.set_value("Journal Entry Account", entry_name,
+				"reconciled_with", self.name)
 
-	def clear_simple_entry(self, payment_entry):
-		frappe.db.set_value(payment_entry.payment_document, payment_entry.payment_entry, "clearance_date", self.date)
+	def clear_legacy_entry(self, payment_entry):
+		if payment_entry.payment_document == "Sales Invoice":
+			frappe.db.set_value("Sales Invoice Payment",
+				dict(parenttype=payment_entry.payment_document,
+					parent=payment_entry.payment_entry
+				), "clearance_date", self.date
+			)
+		else:  # Journal Entry
+			je = frappe.get_doc("Journal Entry", payment_entry.payment_entry);
+			account = frappe.db.get_value("Bank Account", self.bank_account,
+				"account")
+			for jea in je.accounts:
+				if jea.account == account:
+					self.clear_simple_entry("Journal Entry Account",
+						jea.name)
 
-	def clear_sales_invoice(self, payment_entry):
-		frappe.db.set_value("Sales Invoice Payment", dict(parenttype=payment_entry.payment_document,
-			parent=payment_entry.payment_entry), "clearance_date", self.date)
+	def get_paid_amount(self, entry_type, entry_name, currency):
+		company_currency = frappe.db.get_value("Company", self.company, "default_currency")
+		# First deal with the currently-used types of payment documents:
+		if entry_type in ["Payment Entry", "Purchase Invoice"]:
+			paid_amount_field = "paid_amount"
+			if entry_type == 'Payment Entry':
+				account = frappe.db.get_value("Bank Account", self.bank_account, "account")
+				doc = frappe.get_doc("Payment Entry", entry_name)
+				if doc.paid_from == account:
+					if doc.paid_from_account_currency == currency:
+						paid_amount_field = "paid_amount"
+					elif company_currency == currency:
+						paid_amount_field = "base_paid_amount"
+					else:
+						frappe.throw(_("Unable to determine amount of {0} {1} in {2}").format(entry_type, entry_name, currency))
+				elif doc.paid_to == account:
+					if doc.paid_to_account_currency == currency:
+						paid_amount_field = "received_amount"
+					elif company_currency == currency:
+						paid_amount_field = "base_received_amount"
+					else:
+						frappe.throw(_("Unable to determine amount of {0} {1} in {2}").format(entry_type, currency))
+				else:
+					frappe.throw(_("Payment Entry {0} does not match Bank Account of {1}").format(entry_name, self.name))
+			else:
+				if doc.currency == currency:
+					paid_amount_field = "paid_amount"
+				elif company_currency == currency:
+					paid_amount_field = "base_paid_amount"
+				else:
+					frappe.throw(_("Unable to determine amount of {0} {1} in {2}").format(entry_type, currency))
+			return frappe.db.get_value(entry_type, entry_name, paid_amount_field)
+
+		elif entry_type == "Sales Invoice Payment":
+			doc = frappe.get_doc("Sales Invoice Payment", entry_name)
+			if frappe.db.get_value("Sales Invoice", doc.parent, "currency") == currency:
+				paid_amount_field = "amount"
+			elif company_currency == currency:
+				paid_amount_field = "base_amount"
+			else:
+				frappe.throw(_("Unable to determine amount of {0} {1} in {2}").format(entry_type, currency))
+			return doc.get(paid_amount_field)
+		elif entry_type == "Journal Entry Account":
+			doc = frappe.get_doc("Journal Entry Account", entry_name)
+			if currency == doc.account_currency:
+				return doc.debit_in_account_currency + doc.credit_in_account_currency
+			elif currency == company_currency:
+				return doc.debit + doc.credit
+			else:
+				frappe.throw(_("Unable to determine amount of {0} {1} in {2}").format(entry_type, currency))
+
+		# LEGACY: deal with possible remaining instances of older reconciliation types
+		elif entry_type == "Expense Claim":
+			return frappe.db.get_value("Expense Claim", entry_name, "total_amount_reimbursed")
+
+		elif entry_type == "Sales Invoice" or entry_type == "Journal Entry":
+			account = frappe.db.get_value("Bank Account", self.bank_account,
+				"account")
+			child_type = ("Sales Invoice Payment" if entry_type == "Sales Invoice"
+				else "Journal Invoice Account")
+			table_name = "payments" if entry_type == "Sales Invoice" else "accounts"
+
+			doc = frappe.get_doc(entry_type, entry_name)
+			return sum(self.get_paid_amount(child_type, child.name, currency)
+				for child in doc.get(table_name) if child.account == account)
+
+		else:
+			frappe.throw("Please reconcile {0}: {1} manually".format(entry_type, entry_name))
+
 
 def get_total_allocated_amount(payment_entry):
 	return frappe.db.sql("""
@@ -80,35 +171,38 @@ def get_total_allocated_amount(payment_entry):
 		AND
 			bt.docstatus = 1""", (payment_entry.payment_document, payment_entry.payment_entry), as_dict=True)
 
-def get_paid_amount(payment_entry, currency):
-	if payment_entry.payment_document in ["Payment Entry", "Sales Invoice", "Purchase Invoice"]:
-
-		paid_amount_field = "paid_amount"
-		if payment_entry.payment_document == 'Payment Entry':
-			doc = frappe.get_doc("Payment Entry", payment_entry.payment_entry)
-			paid_amount_field = ("base_paid_amount"
-				if doc.paid_to_account_currency == currency else "paid_amount")
-
-		return frappe.db.get_value(payment_entry.payment_document,
-			payment_entry.payment_entry, paid_amount_field)
-
-	elif payment_entry.payment_document == "Journal Entry":
-		return frappe.db.get_value(payment_entry.payment_document, payment_entry.payment_entry, "total_credit")
-
-	elif payment_entry.payment_document == "Expense Claim":
-		return frappe.db.get_value(payment_entry.payment_document, payment_entry.payment_entry, "total_amount_reimbursed")
-
-	else:
-		frappe.throw("Please reconcile {0}: {1} manually".format(payment_entry.payment_document, payment_entry.payment_entry))
-
 @frappe.whitelist()
 def unclear_reference_payment(doctype, docname):
-	if frappe.db.exists(doctype, docname):
-		doc = frappe.get_doc(doctype, docname)
-		if doctype == "Sales Invoice":
-			frappe.db.set_value("Sales Invoice Payment", dict(parenttype=doc.payment_document,
-				parent=doc.payment_entry), "clearance_date", None)
-		else:
-			frappe.db.set_value(doc.payment_document, doc.payment_entry, "clearance_date", None)
+	# Note that the doc passed in here will always be a
+	# Bank Tranaction Payments entry and we have to go from it to the
+	# actual payment document to unclear:
+	if doctype != "Bank Transaction Payments" or not frappe.db.exists("Bank Transaction Payments", docname):
+		frappe.throw(f"Inconsistent Bank Transaction payment_entries record: {doctype} named {docname}")
+	doc = frappe.get_doc("Bank Transaction Payments", docname)
+	if not frappe.db.exists(doc.payment_document, doc.payment_entry):
+		frappe.throw(f"Error: no payment entry {doc.payment_document} named {doc.payment_entry}")
 
-		return doc.payment_entry
+	# LEGACY: Deal with older types of payment documents no longer used:
+	if doc.payment_document == "Sales Invoice":
+		frappe.db.set_value("Sales Invoice Payment",
+			dict(parenttype=doc.payment_document, parent=doc.payment_entry),
+			"clearance_date", None)
+	if doc.payment_document == "Journal Entry":
+		frappe.db.set_value(doc.payment_document, doc.payment_entry,
+			"clearance_date", None)
+		account = frappe.db.get_value("Bank Account",
+			frappe.db.get_value("Bank Transaction", doc.parent,
+				"bank_account"),
+			"account")
+		je = frappe.get_doc("Journal Entry", doc.payment_entry)
+		for jea in je.accounts:
+			if jea.account == account and jea.reconciled_with == doc.parent:
+				unclear_reference_payment("Journal Entry Account", jea.name)
+	# Deal with all of the current types of payment documents:
+	else:
+		frappe.db.set_value(doc.payment_document, doc.payment_entry,
+			"clearance_date", None)
+		if doc.payment_document == "Journal Entry Account":
+			frappe.db.set_value("Journal Entry Account", doc.payment_entry,
+				"reconciled_with", None)
+	return dict(status="success", entry=doc.payment_entry)

--- a/erpnext/accounts/doctype/bank_transaction/test_bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/test_bank_transaction.py
@@ -20,7 +20,7 @@ class TestBankTransaction(unittest.TestCase):
 		add_payments()
 
 	def tearDown(self):
-		for bt in frappe.get_all("Bank Transaction"):
+		for bt in frappe.get_all("Bank Transaction", filters=[{"company": "_Test Company"}]):
 			doc = frappe.get_doc("Bank Transaction", bt.name)
 			doc.cancel()
 			doc.delete()
@@ -110,7 +110,8 @@ def create_bank_account(bank_name="Citi Bank", account_name="_Test Bank - _TC"):
 			"doctype": "Bank Account",
 			"account_name":"Checking Account",
 			"bank": bank_name,
-			"account": account_name
+			"account": account_name,
+			"company": "_Test Company"
 		}).insert()
 	except frappe.DuplicateEntryError:
 		pass
@@ -128,6 +129,7 @@ def add_transactions():
 		"date": "2018-10-23",
 		"debit": 1200,
 		"currency": "INR",
+		"company": "_Test Company",
 		"bank_account": "Checking Account - Citi Bank"
 	}).insert()
 	doc.submit()
@@ -138,6 +140,7 @@ def add_transactions():
 		"date": "2018-10-23",
 		"debit": 1700,
 		"currency": "INR",
+		"company": "_Test Company",
 		"bank_account": "Checking Account - Citi Bank"
 	}).insert()
 	doc.submit()
@@ -148,6 +151,7 @@ def add_transactions():
 		"date": "2018-10-26",
 		"debit": 690,
 		"currency": "INR",
+		"company": "_Test Company",
 		"bank_account": "Checking Account - Citi Bank"
 	}).insert()
 	doc.submit()
@@ -158,6 +162,7 @@ def add_transactions():
 		"date": "2018-10-27",
 		"debit": 3900,
 		"currency": "INR",
+		"company": "_Test Company",
 		"bank_account": "Checking Account - Citi Bank"
 	}).insert()
 	doc.submit()
@@ -168,6 +173,7 @@ def add_transactions():
 		"date": "2018-10-27",
 		"credit": 109080,
 		"currency": "INR",
+		"company": "_Test Company",
 		"bank_account": "Checking Account - Citi Bank"
 	}).insert()
 	doc.submit()

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.json
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.json
@@ -33,7 +33,6 @@
   "total_amount",
   "total_amount_in_words",
   "reference",
-  "clearance_date",
   "remark",
   "paid_loan",
   "inter_company_journal_entry_reference",
@@ -277,16 +276,6 @@
    "fieldtype": "Section Break",
    "label": "Reference",
    "options": "fa fa-pushpin"
-  },
-  {
-   "fieldname": "clearance_date",
-   "fieldtype": "Date",
-   "label": "Clearance Date",
-   "no_copy": 1,
-   "oldfieldname": "clearance_date",
-   "oldfieldtype": "Date",
-   "read_only": 1,
-   "search_index": 1
   },
   {
    "fieldname": "remark",

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -28,8 +28,6 @@ class JournalEntry(AccountsController):
 		if not self.is_opening:
 			self.is_opening='No'
 
-		self.clearance_date = None
-
 		self.validate_party()
 		self.validate_entries_for_advance()
 		self.validate_multi_currency()
@@ -340,7 +338,10 @@ class JournalEntry(AccountsController):
 						currency=account_currency)
 
 				if flt(voucher_total) < (flt(order.advance_paid) + total):
-					frappe.throw(_("Advance paid against {0} {1} cannot be greater than Grand Total {2}").format(reference_type, reference_name, formatted_voucher_total))
+					frappe.throw(_("Advance paid against {0} {1} cannot be greater than Grand Total {2}").format(
+						reference_type, reference_name,
+						formatted_voucher_total
+					))
 
 	def validate_invoices(self):
 		"""Validate totals and docstatus for invoices"""

--- a/erpnext/accounts/doctype/journal_entry_account/journal_entry_account.json
+++ b/erpnext/accounts/doctype/journal_entry_account/journal_entry_account.json
@@ -37,7 +37,11 @@
   "col_break3",
   "is_advance",
   "user_remark",
-  "against_account"
+  "against_account",
+  "clear_sec",
+  "clearance_date",
+  "clear_col",
+  "reconciled_with"
  ],
  "fields": [
   {
@@ -194,6 +198,31 @@
    "read_only": 1
   },
   {
+    "fieldname": "clear_sec",
+    "fieldtype": "Section Break",
+    "label": "Clearance Information"
+  },
+  {
+    "fieldname": "clearance_date",
+    "fieldtype": "Date",
+    "label": "Clearance Date",
+    "no_copy": 1,
+    "read_only": 1,
+    "search_index": 1
+  },
+  {
+    "fieldname": "clear_col",
+    "fieldtype": "Column Break"
+  },
+  {
+    "fieldname": "reconciled_with",
+    "fieldtype": "Link",
+    "label": "Reconciled With",
+    "options": "Bank Transaction",
+    "read_only": 1,
+    "no_copy": 1
+  },
+  {
    "fieldname": "reference",
    "fieldtype": "Section Break",
    "label": "Reference"
@@ -280,7 +309,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-06-24 14:06:54.833738",
+ "modified": "2020-10-20 13:05:53.722627",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Journal Entry Account",

--- a/erpnext/accounts/page/bank_reconciliation/bank_reconciliation.py
+++ b/erpnext/accounts/page/bank_reconciliation/bank_reconciliation.py
@@ -10,19 +10,156 @@ from frappe.utils import flt
 from six import iteritems
 from erpnext import get_company_currency
 
+# The Bank Reconciliation process has clearly gone through a series of developments over
+# a significant span of time, occasionally with only a portion of the system being
+# updated at one time. These comments are intended to marshal what the components of
+# that system are and what the process is, as a sort of central checklist to guide
+# future development of this bookkeeping-critical facility.
+
+# As of ERPNext V13, 2020 Oct, it appears that ideally Bank Reconciliation works as
+# follows:
+# (A) Only accounting documents that directly yield General Ledger entries with Account
+#     field equal to the Account of the Bank Account being reconciled are actually used
+#     at the database level to reconcile Bank Transactions.
+# (B) The reconciliation mechanism is to set a field called "Clearance Date" in those
+#     accounting documents to show that they have been reconciled against a bank
+#     transaction, and to create a Bank Transaction Payment entry in the Payments table
+#     of the Bank Transaction to list the accounting documents against which it has
+#     been reconciled.
+# (C) The only such accounting document types at the moment are: (1) Payment Entry;
+#     (2) Journal Entry Account records (entries in the Accounts field of a
+#     Journal Entry); (3) "cash" or "pos" Purchase Invoice documents - ones that have
+#     a value for Cash/Bank Account and corresponding value for Paid Amount (note that
+#     these denote just a single payment in full); and (4) Sales Invoice Payment
+#     records (entries in the Sales Invoice Payment table of a Sales Invoice).
+# (D) In the case of Journal Entry Account records, a Reconciled With field is also
+#     set to the Bank Transaction entry to allow easy user traversal back to the
+#     associated Bank Transaction. In the future, such backreferences could be expanded
+#     to the other document types used in direct reconciliation.
+# (E) For convenience, the user is also allowed to "reconcile" against a
+#     "non-pos" Purchase Invoice, Sales Invoice, Expense Claim, or Journal Entry.
+#     In each of these cases, the documents do not directly correspond to GL Entries
+#     hitting the bank Account, but they all have associated entries of doctypes from
+#     item (C) that do.
+#     So "reconciling" against one of these document types is simply a shorthand for
+#     (simultaneously) reconciling all of the associated documents of types from (C)
+#     that relate to the bank Account being reconciled.
+
+# Here is a list of pieces of the Bank Reconciliation system, all of which have
+# been hopefully harmonized with the above view of reconciliation, and which should
+# be maintained through future updates.
+# (1) The document types listed in item (C) above. They must have the Clearance Date
+#     field used to record reconciliations; the other document types do not have to
+#     have this field.
+# (2) The (single) Bank Clearance doc which implements the "manual" mode of
+#     reconciliation, providing a form in which individual documents from (1) can
+#     have their Clearance Date fields set without any associated Bank Transaction
+#     records to be reconciled against. (In this way, it is possible to perform a
+#     bank reconciliation without importing any Bank Transactions.)
+# (2) The Bank Transaction doctype, which stores the records from a bank that need to
+#     be reconciled; their Bank Transaction Payment records (in the Payments table)
+#     must link to the doctypes from (1).
+# (4) The Bank Clearance Summary report, which shows all of the documents from (1)
+#     associated with a particular Bank Account against which it might reconcile,
+#     and whether (and on what date) they have cleared.
+# (5) The Bank Reconciliation Statement report, which shows the official bank balance
+#     which should correspond to the accounting records in ERPNext based on what
+#     documents have been reconciled or not.
+# (6) The Bank Reconciliation page, defined in this directory, which provides the main
+#     user interface to upload bank transactions and reconcile them with payment
+#     documents in ERPNext of all types in both items (C) and (E) above.
+
 @frappe.whitelist()
 def reconcile(bank_transaction, payment_doctype, payment_name):
 	transaction = frappe.get_doc("Bank Transaction", bank_transaction)
 	payment_entry = frappe.get_doc(payment_doctype, payment_name)
+	if hasattr(payment_entry, 'clearance_date') and payment_entry.clearance_date:
+		frappe.throw(_("This payment document is already cleared"))
+
+	# As per the above discussion, certain doctypes are cleared directly:
+	if payment_doctype in ["Journal Entry Account", "Payment Entry", "Sales Invoice Payment"]:
+		return direct_reconcile(transaction, payment_doctype, payment_entry)
 
 	account = frappe.db.get_value("Bank Account", transaction.bank_account, "account")
-	gl_entry = frappe.get_doc("GL Entry", dict(account=account, voucher_type=payment_doctype, voucher_no=payment_name))
+	if payment_doctype == "Purchase Invoice" and payment_entry.cash_bank_account == account:
+		return direct_reconcile(transaction, "Purchase Invoice", payment_entry, account)
 
-	if payment_doctype == "Payment Entry" and payment_entry.unallocated_amount > transaction.unallocated_amount:
-		frappe.throw(_("The unallocated amount of Payment Entry {0} is greater than the Bank Transaction's unallocated amount").format(payment_name))
+	# No other doctypes are cleared directly
+	n_recd = 0
+	n_tried = 0
 
+	if payment_doctype == "Journal Entry":
+		for jea in payment_entry.accounts:
+			if jea.account == account and not jea.clearance_date:
+				n_tried += 1
+				if direct_reconcile(transaction,
+						"Journal Entry Account", jea, account):
+					n_recd += 1
+
+	elif payment_doctype == "Sales Invoice" and payment_entry.payments:
+		for sip in payment_entry.payments:
+			if sip.account == account and not sip.clearance_date:
+				n_tried += 1
+				if direct_reconcile(transaction,
+						"Sales Invoice Payment", sip,
+						account) == 'reconciled':
+					n_recd += 1
+
+	# Everything else is just reconciled in terms of associated Payment Entry
+	# documents:
+	else:
+		pe_list = frappe.db.get_list("Payment Entry",
+			filters=dict(reference_name=payment_entry.name))
+		for result in pe_list:
+			pe = frappe.get_doc("Payment Entry", result["name"])
+			if not pe.clearance_date and (pe.paid_to == account or pe.paid_from == account):
+				n_tried += 1
+				if direct_reconcile(transaction, "Payment Entry",
+						pe, account) == 'reconciled':
+					n_recd += 1
+
+	return 'reconciled' if n_recd > 0 and n_recd == n_tried else 'failure'
+
+def direct_reconcile(transaction, payment_doctype, payment_entry, account = None):
 	if transaction.unallocated_amount == 0:
 		frappe.throw(_("This bank transaction is already fully reconciled"))
+
+	account = account or frappe.db.get_value("Bank Account", transaction.bank_account, "account")
+
+	gl_entry = None
+	gl_count = 0
+	if payment_doctype == "Journal Entry Account":
+		gl_entry = frappe.get_doc("GL Entry", dict(account=account,
+			voucher_type="Journal Entry",
+			voucher_no=payment_entry.parent,
+			credit_in_account_currency=payment_entry.credit_in_account_currency,
+			debit_in_account_currency=payment_entry.debit_in_account_currency
+		))
+		# There could still be multiple matches (maybe equal payments
+		# to two different cost centers) but since we only use the
+		# credit and debit amounts from the GL Entry and we don't
+		# modify the GL Entry in any way, it won't matter if it is the
+		# "wrong" one.
+	else:
+		# On the other hand, if there are multiple GL matches in other
+		# circumstances, we had best be cautious:
+		selector = dict(account=account, voucher_type=payment_doctype,
+				voucher_no=payment_entry.name)
+		gl_count = frappe.db.count("GL Entry", selector)
+		if gl_count == 1:
+			gl_entry = frappe.get_doc("GL Entry", selector)
+		elif gl_count == 0 and payment_doctype == "Sales Invoice Payment":
+			selector['voucher_type'] = "Sales Invoice"
+			selector['voucher_no'] = payment_entry.parent
+			gl_count = frappe.db.count("GL Entry", selector)
+			if gl_count == 1:
+				gl_entry = frappe.get_doc("GL Entry", selector)
+	if not gl_entry:
+		frappe.throw(_("There are {0} General Ledger entries associated with {1}: {2}").format(gl_count, payment_doctype, payment_entry.name))
+
+	payment_amount = gl_entry.credit_in_account_currency + gl_entry.debit_in_account_currency
+	if payment_amount > transaction.unallocated_amount:
+		frappe.throw(_("The paid amount of {0} {1} is greater than the Bank Transaction's unallocated amount").format(payment_doctype, payment_entry.name))
 
 	if transaction.credit > 0 and gl_entry.credit > 0:
 		frappe.throw(_("The selected payment entry should be linked with a debtor bank transaction"))
@@ -72,22 +209,48 @@ def get_linked_payments(bank_transaction):
 
 def check_matching_amount(bank_account, company, transaction):
 	payments = []
-	amount = transaction.credit if transaction.credit > 0 else transaction.debit
+	amount = transaction.unallocated_amount
+	company_currency = get_company_currency(company)
 
 	payment_type = "Receive" if transaction.credit > 0 else "Pay"
 	account_from_to = "paid_to" if transaction.credit > 0 else "paid_from"
-	currency_field = "paid_to_account_currency as currency" if transaction.credit > 0 else "paid_from_account_currency as currency"
+	currency_field = "paid_to_account_currency" if transaction.credit > 0 else "paid_from_account_currency"
+	pymt_amount_field = "received_amount as pymt_amount" if transaction.credit > 0 else "paid_amount as pymt_amount"
+	compare_amount = "received_amount" if transaction.credit > 0 else "paid_amount"
+	currency_filter = []
+	if transaction.currency == company_currency:
+		compare_amount = "base_received_amount" if transaction.credit > 0 else "base_paid_amount"
+	else:
+		currency_filter = [[currency_field, "=",
+			'"' + transaction.currency + '"'
+		]]
 
-	payment_entries = frappe.get_all("Payment Entry", fields=["'Payment Entry' as doctype", "name", "paid_amount", "payment_type", "reference_no", "reference_date",
-		"party", "party_type", "posting_date", "{0}".format(currency_field)], filters=[["paid_amount", "like", "{0}%".format(amount)],
-		["docstatus", "=", "1"], ["payment_type", "=", [payment_type, "Internal Transfer"]], ["ifnull(clearance_date, '')", "=", ""], ["{0}".format(account_from_to), "=", "{0}".format(bank_account)]])
+	payment_entries = frappe.get_all("Payment Entry",
+		fields=["'Payment Entry' as doctype", "name", "name as display_name",
+			pymt_amount_field, "payment_type", "reference_no",
+			"reference_date", "party", "party_type", "posting_date",
+			currency_field + " as currency"
+		], filters=currency_filter + [
+			[compare_amount, "like", "{0}%".format(amount)],
+			["docstatus", "=", "1"],
+			["payment_type", "=", [payment_type, "Internal Transfer"]],
+			["ifnull(clearance_date, '')", "=", ""],
+			[account_from_to, "=", bank_account]
+		])
 
 	jea_side = "debit" if transaction.credit > 0 else "credit"
-	journal_entries = frappe.db.sql(f"""
+	compare_amount = "jea." + jea_side;
+	currency_condition = ""
+	if company_currency != transaction.currency:
+		compare_amount += "_in_account_currency"
+		currency_condition = 'AND jea.account_currency = "' + transaction.currency + '"'
+	# This query produces individual Journal Entry Account lines that match the
+	# desired total.
+	journal_entry_accounts = frappe.db.sql(f"""
 		SELECT
-			'Journal Entry' as doctype, je.name, je.posting_date, je.cheque_no as reference_no,
+			'Journal Entry Account' as doctype, jea.name, je.name as display_name, je.posting_date, je.cheque_no as reference_no,
 			jea.account_currency as currency, je.pay_to_recd_from as party, je.cheque_date as reference_date,
-			jea.{jea_side}_in_account_currency as paid_amount
+			jea.{jea_side}_in_account_currency as pymt_amount
 		FROM
 			`tabJournal Entry Account` as jea
 		JOIN
@@ -95,11 +258,11 @@ def check_matching_amount(bank_account, company, transaction):
 		ON
 			jea.parent = je.name
 		WHERE
-			(je.clearance_date is null or je.clearance_date='0000-00-00')
+			(jea.clearance_date is null or jea.clearance_date='0000-00-00')
 		AND
 			jea.account = %(bank_account)s
 		AND
-			jea.{jea_side}_in_account_currency like %(txt)s
+			{compare_amount} like %(txt)s {currency_condition}
 		AND
 			je.docstatus = 1
 	""", {
@@ -107,11 +270,71 @@ def check_matching_amount(bank_account, company, transaction):
 		'txt': '%%%s%%' % amount
 	}, as_dict=True)
 
-	if transaction.credit > 0:
-		sales_invoices = frappe.db.sql("""
+	# However, if the transaction happens to be in company currency, we can also
+	# look for Journal Entry documents where the total of all of the relevant
+	# account lines equals the desired amount:
+	journal_entries = []
+	if transaction.currency == company_currency:
+		signed_amount = amount if transaction.credit > 0 else -amount
+		journal_entries = frappe.db.sql("""
 			SELECT
-				'Sales Invoice' as doctype, si.name, si.customer as party,
-				si.posting_date, sip.amount as paid_amount
+				"Journal Entry" as doctype, je.name,
+				je.name as display_name, je.posting_date,
+				je.cheque_no as reference_no,
+				je.pay_to_recd_from as party, je.cheque_date,
+				%(amount)s as pymt_amount
+			FROM
+				`tabJournal Entry Account` as jea
+			JOIN
+				`tabJournal Entry` as je
+			ON
+				jea.parent = je.name
+			WHERE
+				(jea.clearance_date is null or jea.clearance_date='0000-00-00')
+			AND
+				jea.account = %(bank_account)s
+			AND
+				je.docstatus = 1
+			GROUP BY
+				je.name
+			HAVING
+				count(*) > 1
+			AND
+				sum(jea.debit)-sum(jea.credit) = %(signed_amount)s
+			""", dict(amount=amount, signed_amount=signed_amount,
+			bank_account=bank_account, company_currency=company_currency),
+			as_dict=True)
+		for je in journal_entries:
+			je.currency = company_currency
+			doc = frappe.get_doc("Journal Entry", je.name)
+			je.subentries = []
+			for jea in doc.accounts:
+				if jea.clearance_date or jea.account != bank_account:
+					continue
+				sub = jea.as_dict();
+				sub.update(dict(display_name=jea.name,
+					posting_date=doc.posting_date,
+					reference_no=doc.cheque_no,
+					currency=company_currency,
+					reference_date=doc.cheque_date,
+					party=doc.pay_to_recd_from,
+					pymt_amount=jea.debit-jea.credit
+				))
+				if transaction.debit > 0:
+					sub['pymt_amount'] = jea.credit - jea.debit
+				je.subentries.append(sub)
+
+	if transaction.credit > 0:
+		compare_amount = "sip.base_amount"
+		currency_condition = ""
+		if (company_currency != transaction.currency):
+			compare_amount = "sip.amount"
+			currency_condition = 'AND si.currency = "' + transaction.currency + '"'
+		query = f"""SELECT
+				'Sales Invoice Payment' as doctype, sip.name,
+				si.name as display_name, si.customer as party,
+				si.posting_date, sip.amount as pymt_amount,
+				si.currency
 			FROM
 				`tabSales Invoice Payment` as sip
 			JOIN
@@ -121,20 +344,29 @@ def check_matching_amount(bank_account, company, transaction):
 			WHERE
 				(sip.clearance_date is null or sip.clearance_date='0000-00-00')
 			AND
-				sip.account = %s
+				sip.account = '{bank_account}'
 			AND
-				sip.amount like %s
+				{compare_amount} like {amount} {currency_condition}
 			AND
 				si.docstatus = 1
-		""", (bank_account, amount), as_dict=True)
+		"""
+		sales_invoices = frappe.db.sql(query, dict(), as_dict=True)
 	else:
 		sales_invoices = []
 
 	if transaction.debit > 0:
+		compare_amount = "base_paid_amount"
+		currency_condition = []
+		if (company_currency != transaction.currency):
+			compare_amount = "paid_amount"
+			currency_condition = [["currency", "=", '"' + transaction.currency + '"']]
+
 		purchase_invoices = frappe.get_all("Purchase Invoice",
-			fields = ["'Purchase Invoice' as doctype", "name", "paid_amount", "supplier as party", "posting_date", "currency"],
-			filters=[
-				["paid_amount", "like", "{0}%".format(amount)],
+			fields = ["'Purchase Invoice' as doctype", "name",
+				"name as display_name", "paid_amount as pymt_amount",
+				"supplier as party", "posting_date", "currency"],
+			filters=currency_condition + [
+				[compare_amount, "like", "{0}%".format(amount)],
 				["docstatus", "=", "1"],
 				["is_paid", "=", "1"],
 				["ifnull(clearance_date, '')", "=", ""],
@@ -142,26 +374,26 @@ def check_matching_amount(bank_account, company, transaction):
 			]
 		)
 
-		mode_of_payments = [x["parent"] for x in frappe.db.get_list("Mode of Payment Account",
-			filters={"default_account": bank_account}, fields=["parent"])]
+		expense_claims = []
+		if transaction.currency == company_currency:
+			mode_of_payments = [x["parent"] for x in frappe.db.get_list("Mode of Payment Account",
+				filters={"default_account": bank_account}, fields=["parent"])]
 
-		company_currency = get_company_currency(company)
-
-		expense_claims = frappe.get_all("Expense Claim",
-			fields=["'Expense Claim' as doctype", "name", "total_sanctioned_amount as paid_amount",
-				"employee as party", "posting_date", "'{0}' as currency".format(company_currency)],
-			filters=[
-				["total_sanctioned_amount", "like", "{0}%".format(amount)],
-				["docstatus", "=", "1"],
-				["is_paid", "=", "1"],
-				["ifnull(clearance_date, '')", "=", ""],
-				["mode_of_payment", "in", "{0}".format(tuple(mode_of_payments))]
-			]
-		)
+			expense_claims = frappe.get_all("Expense Claim",
+				fields=["'Expense Claim' as doctype", "name", "name as display_name", "total_sanctioned_amount as pymt_amount",
+					"employee as party", "posting_date", "'{0}' as currency".format(company_currency)],
+				filters=[
+					["total_sanctioned_amount", "like", "{0}%".format(amount)],
+					["docstatus", "=", "1"],
+					["is_paid", "=", "1"],
+					["ifnull(clearance_date, '')", "=", ""],
+					["mode_of_payment", "in", "{0}".format(tuple(mode_of_payments))]
+				]
+			)
 	else:
 		purchase_invoices = expense_claims = []
 
-	for data in [payment_entries, journal_entries, sales_invoices, purchase_invoices, expense_claims]:
+	for data in [payment_entries, journal_entry_accounts, journal_entries, sales_invoices, purchase_invoices, expense_claims]:
 		if data:
 			payments.extend(data)
 
@@ -208,23 +440,50 @@ def get_matching_descriptions_data(company, transaction):
 		if key == "Payment Entry":
 			data.extend(frappe.get_all("Payment Entry", filters=[["name", "in", value]],
 				fields=["'Payment Entry' as doctype", "posting_date", "party", "reference_no",
-					"reference_date", "paid_amount", "paid_to_account_currency as currency", "clearance_date"]))
-		if key == "Journal Entry":
-			journal_entries = frappe.get_all("Journal Entry", filters=[["name", "in", value]],
-				fields=["name", "'Journal Entry' as doctype", "posting_date",
-					"pay_to_recd_from as party", "cheque_no as reference_no", "cheque_date as reference_date",
-					"total_credit as paid_amount", "clearance_date"])
-			for journal_entry in journal_entries:
-				journal_entry_accounts = frappe.get_all("Journal Entry Account", filters={"parenttype": journal_entry["doctype"], "parent": journal_entry["name"]}, fields=["account_currency"])
-				journal_entry["currency"] = journal_entry_accounts[0]["account_currency"] if journal_entry_accounts else company_currency
-			data.extend(journal_entries)
+					"reference_date", "paid_amount as pymt_amount", "paid_to_account_currency as currency", "clearance_date"]))
+		if key == "Journal Entry Account":
+			journal_entry_accounts = frappe.get_all("Journal Entry Account", filters=[["name", "in", value]],
+				fields=["name", "'Journal Entry Account' as doctype", "parent", "debit", "credit", "account_currency as currency", "clearance_date"])
+			for jea in journal_entry_accounts:
+				jea["pymt_amount"] = jea["debit"] + jea["credit"]
+				journal_entry = frappe.get_doc("Journal Entry", jea["parent"])
+				jea["posting_date"] = journal_entry.posting_date;
+				jea["party"] = journal_entry.pay_to_recd_from;
+				jea["reference_no"] = journal_entry.cheque_no;
+				jea["reference_date"] = journal_entry.cheque_date;
+			data.extend(journal_entry_accounts)
 		if key == "Sales Invoice":
-			data.extend(frappe.get_all("Sales Invoice", filters=[["name", "in", value]], fields=["'Sales Invoice' as doctype", "posting_date", "customer_name as party", "paid_amount", "currency"]))
+			data.extend(frappe.get_all("Sales Invoice",
+				filters=[["name", "in", value]],
+				fields=[
+					"'Sales Invoice' as doctype",
+					"posting_date",
+					"customer_name as party",
+					"paid_amount as pymt_amount",
+					"currency"
+				]
+			))
 		if key == "Purchase Invoice":
-			data.extend(frappe.get_all("Purchase Invoice", filters=[["name", "in", value]], fields=["'Purchase Invoice' as doctype", "posting_date", "supplier_name as party", "paid_amount", "currency"]))
+			data.extend(frappe.get_all("Purchase Invoice",
+				filters=[["name", "in", value]],
+				fields=[
+					"'Purchase Invoice' as doctype",
+					"posting_date",
+					"supplier_name as party",
+					"paid_amount as pymt_amount",
+					"currency"
+				]
+			))
 		if key == "Expense Claim":
-			expense_claims = frappe.get_all("Expense Claim", filters=[["name", "in", value]], fields=["'Expense Claim' as doctype", "posting_date", "employee_name as party", "total_amount_reimbursed as paid_amount"])
-			data.extend([dict(x,**{"currency": company_currency}) for x in expense_claims])
+			expense_claims = frappe.get_all("Expense Claim",
+				filters=[["name", "in", value]],
+				fields=["'Expense Claim' as doctype",
+					"posting_date",
+					"employee_name as party",
+					"total_amount_reimbursed as pymt_amount"
+				]
+			)
+			data.extend([dict(x,currency=company_currency) for x in expense_claims])
 
 	return data
 
@@ -264,7 +523,7 @@ def get_matching_transactions_payments(description_matching):
 	payment_by_ratio = {x["payment_entry"]: x["ratio"] for x in description_matching}
 
 	if payments:
-		reference_payment_list = frappe.get_all("Payment Entry", fields=["name", "paid_amount", "payment_type", "reference_no", "reference_date",
+		reference_payment_list = frappe.get_all("Payment Entry", fields=["name", "paid_amount as pymt_amount", "payment_type", "reference_no", "reference_date",
 			"party", "party_type", "posting_date", "paid_to_account_currency"], filters=[["name", "in", payments]])
 
 		return sorted(reference_payment_list, key=lambda x: payment_by_ratio[x["name"]])
@@ -318,7 +577,7 @@ def journal_entry_query(doctype, txt, searchfield, start, page_len, filters):
 		ON
 			jea.parent = je.name
 		WHERE
-			(je.clearance_date is null or je.clearance_date='0000-00-00')
+			(jea.clearance_date is null or jea.clearance_date='0000-00-00')
 		AND
 			jea.account = %(account)s
 		AND
@@ -342,6 +601,7 @@ def journal_entry_query(doctype, txt, searchfield, start, page_len, filters):
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
 def sales_invoices_query(doctype, txt, searchfield, start, page_len, filters):
+	account = frappe.db.get_value("Bank Account", filters.get("bank_account"), "account")
 	return frappe.db.sql("""
 		SELECT
 			sip.parent, si.customer, sip.amount, sip.mode_of_payment
@@ -355,6 +615,8 @@ def sales_invoices_query(doctype, txt, searchfield, start, page_len, filters):
 			(sip.clearance_date is null or sip.clearance_date='0000-00-00')
 		AND
 			(sip.parent like %(txt)s or si.customer like %(txt)s)
+		AND
+			sip.account = %(account)s
 		ORDER BY
 			if(locate(%(_txt)s, sip.parent), locate(%(_txt)s, sip.parent), 99999),
 			sip.parent
@@ -364,6 +626,7 @@ def sales_invoices_query(doctype, txt, searchfield, start, page_len, filters):
 			'txt': "%%%s%%" % txt,
 			'_txt': txt.replace("%", ""),
 			'start': start,
-			'page_len': page_len
+			'page_len': page_len,
+			'account': account
 		}
 	)

--- a/erpnext/accounts/page/bank_reconciliation/bank_transaction_header.html
+++ b/erpnext/accounts/page/bank_reconciliation/bank_transaction_header.html
@@ -3,19 +3,16 @@
 		<div class="col-sm-2 ellipsis hidden-xs">
 			{{ __("Date") }}
 		</div>
-		<div class="col-xs-11 col-sm-4 ellipsis list-subject">
+		<div class="col-xs-7 col-sm-5 ellipsis list-subject">
 			{{ __("Description") }}
 		</div>
-		<div class="col-sm-2 ellipsis hidden-xs">
-			{{ __("Debit") }}
-		</div>
-		<div class="col-sm-2 ellipsis hidden-xs">
-			{{ __("Credit") }}
+		<div class="col-xs-3 ellipsis">
+			{{ __("Amount; (Unallocated)") }}
 		</div>
 		<div class="col-sm-1 ellipsis hidden-xs">
 			{{ __("Currency") }}
 		</div>
-		<div class="col-sm-1 ellipsis">
+		<div class="col-xs-2 col-sm-1 ellipsis">
 		</div>
 	</div>
 </div>

--- a/erpnext/accounts/page/bank_reconciliation/bank_transaction_row.html
+++ b/erpnext/accounts/page/bank_reconciliation/bank_transaction_row.html
@@ -4,20 +4,17 @@
 			<div class="col-sm-2 ellipsis hidden-xs">
 				{%= frappe.datetime.str_to_user(date) %}
 			</div>
-			<div class="col-xs-8 col-sm-4 ellipsis list-subject">
+			<div class="col-xs-7 col-sm-5 ellipsis list-subject">
 				{{ description }}
 			</div>
-			<div class="col-sm-2 ellipsis hidden-xs">
-				{%= format_currency(debit, currency) %}
-			</div>
-			<div class="col-sm-2 ellipsis hidden-xs">
-				{%= format_currency(credit, currency) %}
+			<div class="col-xs-3 ellipsis">
+				{{ amount_described }}
 			</div>
 			<div class="col-sm-1 ellipsis hidden-xs">
 				{{ currency }}
 			</div>
 		</div>
-		<div class="col-xs-3 col-sm-1">
+		<div class="col-xs-2 col-sm-1">
 			<div class="btn-group">
 				<a class="dropdown-toggle btn btn-default btn-xs" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
 					<span>Actions </span>

--- a/erpnext/accounts/page/bank_reconciliation/linked_payment_row.html
+++ b/erpnext/accounts/page/bank_reconciliation/linked_payment_row.html
@@ -1,7 +1,7 @@
 <div class="list-row">
 	<div>
 		<div class="col-xs-3 col-sm-2 ellipsis">
-			{{ name }}
+			{{ display_name }}
 		</div>
 		<div class="col-xs-3 col-sm-2 ellipsis">
 			{% if (typeof reference_date !== "undefined") %}
@@ -13,7 +13,7 @@
 			{% endif %}
 		</div>
 		<div class="col-sm-2 ellipsis hidden-xs">
-			{{ format_currency(paid_amount, currency) }}
+			{{ format_currency(pymt_amount, currency) }}
 		</div>
 		<div class="col-sm-2 ellipsis hidden-xs">
 			{% if (typeof party !== "undefined") %}
@@ -29,7 +29,7 @@
 		</div>
 		<div class="col-xs-2 col-sm-2">
 			<div class="text-right margin-bottom">
-				<button class="btn btn-primary btn-xs reconciliation-btn" data-doctype="{{ doctype }}" data-name="{{ name }}">{{ __("Reconcile") }}</button>
+				<button class="btn {{btn_class}} btn-xs reconciliation-btn" data-doctype="{{ doctype }}" data-name="{{ name }}">{{ __("Reconcile") }}</button>
 			</div>
 		</div>
 	</div>

--- a/erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py
+++ b/erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py
@@ -14,15 +14,23 @@ def execute(filters=None):
 
 	return columns, data
 
+def qc(fn, label, w, ft="Data", opt=None):
+	col = { "fieldname": fn, "label": label, "fieldtype": ft, "width": w }
+	if opt is not None:
+		col["options"] = opt
+	return col
+
 def get_columns():
 	return [
-		_("Payment Document") + "::130",
-		_("Payment Entry") + ":Dynamic Link/"+_("Payment Document")+":110",
-		_("Posting Date") + ":Date:100",
-		_("Cheque/Reference No") + "::120",
-		_("Clearance Date") + ":Date:100",
-		_("Against Account") + ":Link/Account:170",
-		_("Amount") + ":Currency:120"
+		qc("payment_document", _("Payment DocType"),     130),
+		qc("from_document",    _("From Document"),       110, "Dynamic Link", "from_doc_type"),
+		qc("posting_date",     _("Posting Date"),        100, "Date"),
+		qc("ref_no",           _("Cheque/Reference No"), 120),
+		qc("clearance_date",   _("Clearance Date"),      100, "Date"),
+		qc("against_account",  _("Against Account"),     170, "Link",         "Account"),
+		qc("amount",           _("Amount"),              120, "Currency"),
+		qc("from_doc_type",    _("From DocType"),        120),
+		qc("payment_entry",    _("Payment Entry"),       110, "Dynamic Link", "payment_document")
 	]
 
 def get_conditions(filters):
@@ -35,22 +43,64 @@ def get_conditions(filters):
 
 def get_entries(filters):
 	conditions = get_conditions(filters)
-	journal_entries =  frappe.db.sql("""SELECT
-			"Journal Entry", jv.name, jv.posting_date, jv.cheque_no,
-			jv.clearance_date, jvd.against_account, jvd.debit - jvd.credit
-		FROM 
+	# We have four payment document types that could contribute reconciled payments:
+	# (1) Journal Entry Account
+	query = """SELECT
+			"Journal Entry Account" as payment_document, jvd.name as payment_entry, jv.posting_date, jv.cheque_no as ref_no,
+			jvd.clearance_date, jvd.against_account, jvd.debit - jvd.credit as amount, "Journal Entry" as from_doc_type, jv.name as from_document
+		FROM
 			`tabJournal Entry Account` jvd, `tabJournal Entry` jv
-		WHERE 
-			jvd.parent = jv.name and jv.docstatus=1 and jvd.account = %(account)s {0}
-			order by posting_date DESC, jv.name DESC""".format(conditions), filters, as_list=1)
+		WHERE
+			jvd.parent = jv.name and jv.docstatus=1 and jvd.account = %(account)s
+	"""
+	query += conditions
+	query += 'ORDER BY jv.name DESC'
 
-	payment_entries =  frappe.db.sql("""SELECT
-			"Payment Entry", name, posting_date, reference_no, clearance_date, party, 
-			if(paid_from=%(account)s, paid_amount * -1, received_amount)
+	jea_payments =  frappe.db.sql(query, filters, as_dict=1)
+
+	# (2) Payment Entry
+	query =  """SELECT
+			"Payment Entry" as payment_document, name as payment_entry, posting_date, reference_no as ref_no, clearance_date, party as against_account,
+			if(paid_from=%(account)s, paid_amount * -1, received_amount) as amount, "Payment Entry" as from_doc_type, name as from_document
 		FROM 
 			`tabPayment Entry`
-		WHERE 
-			docstatus=1 and (paid_from = %(account)s or paid_to = %(account)s) {0}
-			order by posting_date DESC, name DESC""".format(conditions), filters, as_list=1)
+		WHERE
+			docstatus=1 and (paid_from = %(account)s or paid_to = %(account)s)
+	"""
+	query += conditions
+	query += 'ORDER BY name DESC'
 
-	return sorted(journal_entries + payment_entries, key=lambda k: k[2] or getdate(nowdate()))
+	pe_payments = frappe.db.sql(query, filters, as_dict=1)
+
+	# (3) Sales Invoice Payment
+	query = """SELECT
+			"Sales Invoice Payment" as payment_document, sip.name as payment_entry, si.posting_date, si.remarks as ref_no, sip.clearance_date, customer_name as against_account,
+			sip.amount, "Sales Invoice" as from_doc_type, si.name as from_document
+		FROM
+			`tabSales Invoice Payment` sip
+		JOIN
+			`tabSales Invoice` as si ON sip.parent = si.name
+		WHERE
+			si.docstatus = 1 and sip.account = %(account)s
+	"""
+	query += conditions
+	query += 'ORDER BY si.name DESC'
+
+	sip_payments = frappe.db.sql(query, filters, as_dict=1)
+
+	# (4) Purchase Invoice documents with Cash/Bank Account
+	query = """SELECT
+			"Purchase Invoice" as payment_document, name as payment_entry, posting_date, bill_no as ref_no, clearance_date, supplier_name as against_account,
+			paid_amount as amount, "Purchase Invoice" as from_doc_type, name as from_document
+		FROM
+			`tabPurchase Invoice`
+		WHERE
+			docstatus = 1 and cash_bank_account = %(account)s
+	"""
+	query += conditions
+	query += 'ORDER BY name DESC'
+
+	pi_payments = frappe.db.sql(query, filters, as_dict=1)
+
+	return sorted(jea_payments + pe_payments + sip_payments + pi_payments,
+		key=lambda k: k["posting_date"] or getdate(nowdate()))

--- a/erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py
+++ b/erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py
@@ -3,7 +3,7 @@
 
 from __future__ import unicode_literals
 import frappe
-from frappe.utils import flt, getdate, nowdate
+from frappe.utils import flt, getdate, add_to_date, nowdate
 from frappe import _
 
 def execute(filters=None):
@@ -15,6 +15,8 @@ def execute(filters=None):
 
 	account_currency = frappe.db.get_value("Account", filters.account, "account_currency")
 
+	if "report_date" in filters:
+		filters["later_date"] = add_to_date(filters["report_date"], years=1)
 	data = get_entries(filters)
 
 	from erpnext.accounts.utils import get_balance_on
@@ -34,7 +36,7 @@ def execute(filters=None):
 		get_balance_row(_("Bank Statement balance as per General Ledger"), balance_as_per_system, account_currency),
 		{},
 		{
-			"payment_entry": _("Outstanding Cheques and Deposits to clear"),
+			"from_document": _("Outstanding Cheques and Deposits to clear"),
 			"debit": total_debit,
 			"credit": total_credit,
 			"account_currency": account_currency
@@ -62,10 +64,10 @@ def get_columns():
 			"width": 220
 		},
 		{
-			"fieldname": "payment_entry",
-			"label": _("Payment Document"),
+			"fieldname": "from_document",
+			"label": _("From Document"),
 			"fieldtype": "Dynamic Link",
-			"options": "payment_document",
+			"options": "from_document_type",
 			"width": 220
 		},
 		{
@@ -113,62 +115,93 @@ def get_columns():
 			"fieldtype": "Link",
 			"options": "Currency",
 			"width": 100
-		}
+		},
+		{
+			"fieldname": "payment_entry",
+			"label": _("Payment Document"),
+			"fieldtype": "Dynamic Link",
+			"options": "payment_document",
+			"width": 150
+		},
+		{
+			"fieldname": "from_document_type",
+			"label": _("From Type of Document"),
+			"fieldtype": "Data",
+			"width": 150
+		},
 	]
 
 def get_entries(filters):
-	journal_entries = frappe.db.sql("""
-		select "Journal Entry" as payment_document, jv.posting_date,
-			jv.name as payment_entry, jvd.debit_in_account_currency as debit,
+	jea_payments = frappe.db.sql("""
+		select "Journal Entry Account" as payment_document, jv.posting_date,
+			jvd.name as payment_entry, jvd.debit_in_account_currency as debit,
 			jvd.credit_in_account_currency as credit, jvd.against_account,
-			jv.cheque_no as reference_no, jv.cheque_date as ref_date, jv.clearance_date, jvd.account_currency
+			jv.cheque_no as reference_no, jv.cheque_date as ref_date, jvd.clearance_date,
+			jvd.account_currency, jv.name as from_document, "Journal Entry" as from_document_type
 		from
 			`tabJournal Entry Account` jvd, `tabJournal Entry` jv
 		where jvd.parent = jv.name and jv.docstatus=1
 			and jvd.account = %(account)s and jv.posting_date <= %(report_date)s
-			and ifnull(jv.clearance_date, '4000-01-01') > %(report_date)s
+			and ifnull(jvd.clearance_date, %(later_date)s) > %(report_date)s
 			and ifnull(jv.is_opening, 'No') = 'No'""", filters, as_dict=1)
 
-	payment_entries = frappe.db.sql("""
+	pe_payments = frappe.db.sql("""
 		select
 			"Payment Entry" as payment_document, name as payment_entry,
 			reference_no, reference_date as ref_date,
 			if(paid_to=%(account)s, received_amount, 0) as debit,
 			if(paid_from=%(account)s, paid_amount, 0) as credit,
 			posting_date, ifnull(party,if(paid_from=%(account)s,paid_to,paid_from)) as against_account, clearance_date,
-			if(paid_to=%(account)s, paid_to_account_currency, paid_from_account_currency) as account_currency
+			if(paid_to=%(account)s, paid_to_account_currency, paid_from_account_currency) as account_currency,
+			name as from_document, "Payment Entry" as from_document_type
 		from `tabPayment Entry`
 		where
 			(paid_from=%(account)s or paid_to=%(account)s) and docstatus=1
 			and posting_date <= %(report_date)s
-			and ifnull(clearance_date, '4000-01-01') > %(report_date)s
+			and ifnull(clearance_date, %(later_date)s) > %(report_date)s
 	""", filters, as_dict=1)
 
-	pos_entries = []
+	sip_payments = []
+	pi_payments = []
 	if filters.include_pos_transactions:
-		pos_entries = frappe.db.sql("""
+		sip_payments = frappe.db.sql("""
 			select
 				"Sales Invoice Payment" as payment_document, sip.name as payment_entry, sip.amount as debit,
-				si.posting_date, si.debit_to as against_account, sip.clearance_date,
-				account.account_currency, 0 as credit
+				si.posting_date, si.debit_to as against_account, sip.clearance_date, si.remarks as reference_no,
+				account.account_currency, 0 as credit, sip.name as from_document,
+				"Sales Invoice Payment" as from_document_type
 			from `tabSales Invoice Payment` sip, `tabSales Invoice` si, `tabAccount` account
 			where
 				sip.account=%(account)s and si.docstatus=1 and sip.parent = si.name
 				and account.name = sip.account and si.posting_date <= %(report_date)s and
-				ifnull(sip.clearance_date, '4000-01-01') > %(report_date)s
-			order by
-				si.posting_date ASC, si.name DESC
+				ifnull(sip.clearance_date, %(later_date)s) > %(report_date)s
+			order by si.name DESC
 		""", filters, as_dict=1)
 
-	return sorted(list(payment_entries)+list(journal_entries+list(pos_entries)),
-			key=lambda k: k['posting_date'] or getdate(nowdate()))
+
+		pi_query = """
+			SELECT
+				"Purchase Invoice" as payment_document, name as payment_entry, paid_amount as credit, 0 as debit,
+				posting_date, supplier_name as against_account, clearance_date, bill_no as reference_no,
+				currency as account_currency, name as from_document, "Purchase Invoice" as from_document_type
+			FROM `tabPurchase Invoice`
+			WHERE
+				cash_bank_account=%(account)s and docstatus=1
+				and posting_date <= %(report_date)s
+				and ifnull(clearance_date, %(later_date)s) > %(report_date)s
+			ORDER BY name
+		"""
+		pi_payments = frappe.db.sql(pi_query, filters, as_dict=1)
+
+	return sorted(jea_payments + pe_payments + sip_payments + pi_payments,
+		key=lambda k: k['posting_date'] or getdate(nowdate()))
 
 def get_amounts_not_reflected_in_system(filters):
 	je_amount = frappe.db.sql("""
 		select sum(jvd.debit_in_account_currency - jvd.credit_in_account_currency)
 		from `tabJournal Entry Account` jvd, `tabJournal Entry` jv
 		where jvd.parent = jv.name and jv.docstatus=1 and jvd.account=%(account)s
-		and jv.posting_date > %(report_date)s and jv.clearance_date <= %(report_date)s
+		and jv.posting_date > %(report_date)s and jvd.clearance_date <= %(report_date)s
 		and ifnull(jv.is_opening, 'No') = 'No' """, filters)
 
 	je_amount = flt(je_amount[0][0]) if je_amount else 0.0
@@ -181,19 +214,43 @@ def get_amounts_not_reflected_in_system(filters):
 
 	pe_amount = flt(pe_amount[0][0]) if pe_amount else 0.0
 
-	return je_amount + pe_amount
+	sip_amount = 0.0
+	pi_amount = 0.0
+	if filters.include_pos_transactions:
+		sip_amount = frappe.db.sql("""
+			SELECT sum(sip.amount)
+			FROM `tabSales Invoice Payment` sip, `tabSales Invoice` si
+			WHERE sip.parent = si.name and si.docstatus=1
+			and sip.account=%(account)s
+			and si.posting_date > %(report_date)s
+			and sip.clearance_date <= %(report_date)s
+		""", filters)
+		if sip_amount:
+			sip_amount = flt(sip_amount[0][0])
+
+		pi_amount = frappe.db.sql("""
+			SELECT sum(paid_amount)
+			FROM `tabPurchase Invoice`
+			WHERE docstatus=1 and cash_bank_account=%(account)s
+			and posting_date > %(report_date)s
+			and clearance_date <=  %(report_date)s
+		""", filters)
+		if pi_amount:
+			pi_amount = -flt(pi_amount[0][0])
+
+	return je_amount + pe_amount + sip_amount + pi_amount
 
 def get_balance_row(label, amount, account_currency):
 	if amount > 0:
 		return {
-			"payment_entry": label,
+			"from_document": label,
 			"debit": amount,
 			"credit": 0,
 			"account_currency": account_currency
 		}
 	else:
 		return {
-			"payment_entry": label,
+			"from_document": label,
 			"debit": 0,
 			"credit": abs(amount),
 			"account_currency": account_currency

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -740,3 +740,4 @@ erpnext.patches.v13_0.updates_for_multi_currency_payroll
 erpnext.patches.v13_0.create_leave_policy_assignment_based_on_employee_current_leave_policy
 erpnext.patches.v13_0.add_po_to_global_search
 erpnext.patches.v13_0.update_returned_qty_in_pr_dn
+erpnext.patches.v13_0.migrate_clearances_to_journal_entry_account

--- a/erpnext/patches/v13_0/migrate_clearances_to_journal_entry_account.py
+++ b/erpnext/patches/v13_0/migrate_clearances_to_journal_entry_account.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2020, Frappe and Contributors
+# License: GNU General Public License v3. See license.txt
+
+from __future__ import unicode_literals
+import frappe
+
+def execute():
+	affected_transactions = 0
+	affected_payments = 0
+	new_payments = 0
+	frappe.reload_doc("accounts", "doctype", "Journal Entry Account")
+	for btname in frappe.db.get_all("Bank Transaction",
+					filters = { 'allocated_amount': ('>', 0) }):
+		bank_trans = frappe.get_doc("Bank Transaction", btname)
+		account = frappe.db.get_value("Bank Account",
+			bank_trans.bank_account, "account")
+		need_side = "credit" if bank_trans.debit > 0 else "debit"
+		to_replace = []
+		for payment in bank_trans.payment_entries:
+			if payment.payment_document != "Journal Entry":
+				continue
+			entry = frappe.get_doc("Journal Entry", payment.payment_entry)
+			je_total = sum(jea.get(need_side) for jea in entry.accounts if jea.account == account)
+			if je_total == payment.allocated_amount:
+				# OK, we will plan to replace the Journal
+				# Entry payment with payments for all of the
+				# Journal Entry Account records for that
+				# bank account on the correct side:
+				to_replace.append((payment, entry))
+			else:
+				print(f"Warning: For bank transaction {bank_trans.name}:\n",
+					f"keeping Journal Entry payment from {payment.payment_entry} because\n",
+					f"it does not match the sum of the Journal Entry Account records for Account {account}."
+				)
+		if len(to_replace) > 0:
+			affected_transactions += 1
+		for (oldpay, oldentry) in to_replace:
+			affected_payments += 1
+			bank_trans.remove(oldpay)
+			for jea in oldentry.accounts:
+				if jea.account == account and jea.get(need_side) > 0:
+					new_payments += 1
+					bank_trans.append("payment_entries", dict(
+						payment_document = "Journal Entry Account",
+						payment_entry = jea.name,
+						allocated_amount = jea.get(need_side),
+						clearance_date = bank_trans.date
+					))
+					frappe.db.set_value("Journal Entry Account", jea.name, "clearance_date", bank_trans.date);
+					frappe.db.set_value("Journal Entry Account", jea.name, "reconciled_with", bank_trans.name);
+		bank_trans.save()
+	print(f"Updated {affected_transactions} bank transactions by replacing {affected_payments} Journal Entry payments with {new_payments} Journal Entry Account payments.")
+


### PR DESCRIPTION
  Prior to this change, a Bank Transaction would reconcile against an entire
  Journal Entry. But a single Journal Entry (for example a transfer) could
  have individual Journal Entry Accounts lines for multiple different bank
  accounts. Thus, if the Bank Transactions from the statement of one Bank
  Account had already been reconciled, the corresponding Journal Entry would
  be marked as entirely cleared. Then when one later attempts to reconcile the
  Bank Transactions from the other Bank Account on the other side of the
  transfer, there is nothing "left" for the other side of the transfer to
  reconcile with.

  This commit improves the situation by moving the clearance_date field from
  Journal Entry to Journal Entry Account, and reconciling Bank Transactions
  against individual Journal Entry Account lines. This is a more realistic
  representation of what is going on, allows for different clearance_date
  values for the two different sides of non-same-day transfers, and alleviates
  the problem of only being able to reconcile one side of a transfer.

  Along the way, it also fixes several other issues: with a small parallel
  change to frappe.ui.Page in a separate PR in that project, the accumulation
  of "extra" field boxes on the top bar of a Bank Reconciliation if you click
  on "Reconcile This Account" multiple times is eliminated; also with that
  same change to frappe.ui.Page, this commit immediately filters the
  Bank Transactions in a Bank Reconciliation to just those matching the
  Bank Account of the Reconciliation; makes the payment amount information
  in the Reconciliation Tool more compact so that it can be displayed even
  on narrow screens; properly objects if the amount of the payment is larger
  than the Bank Transaction being reconciled; when searching for a payment,
  produces all associated Payment Entries for any specified Purchase Invoice
  or Expense Claim; correctly unclears payment entries when a payment row of a
  Bank Transaction is deleted; and allows for easy traversal from a reconciled
  Bank Transaction to the Journal Entry documents it is reconciled against,
  and vice versa.

Resolves #23660

Note that in my analysis of that issue, I inquired whether this (relatively minor) architectural change, of reconciling bank transactions with Journal Entry Accounts rather than with entire Journal Entry documents, would meet with the approval of ERPNext developers. Having no response and needing to proceed with our institution's bookkeeping, I thought I would go ahead and make the changes and offer them as a pull request. I think this PR offers a number of advantages over the previous state of Bank Reconciliation, and I hope that the developers find it to be helpful. Thank you for all of the effort you have put into ERPNext.