### PR TITLE
fix: showing error for wrong filters.

### DIFF
--- a/erpnext/stock/report/stock_qty_vs_serial_no_count/stock_qty_vs_serial_no_count.py
+++ b/erpnext/stock/report/stock_qty_vs_serial_no_count/stock_qty_vs_serial_no_count.py
@@ -6,9 +6,16 @@ import frappe
 from frappe import _
 
 def execute(filters=None):
+	validate_warehouse(filters)
 	columns = get_columns()
 	data = get_data(filters.warehouse)
 	return columns, data
+
+def validate_warehouse(filters):
+	company = filters.company
+	warehouse = filters.warehouse
+	if not frappe.db.exists("Warehouse", {"name": warehouse, "company": company}):
+		frappe.throw(_("Warehouse: {0} does not belong to {1}".format(warehouse, company)))
 
 def get_columns():
 	columns = [

--- a/erpnext/stock/report/stock_qty_vs_serial_no_count/stock_qty_vs_serial_no_count.py
+++ b/erpnext/stock/report/stock_qty_vs_serial_no_count/stock_qty_vs_serial_no_count.py
@@ -15,7 +15,7 @@ def validate_warehouse(filters):
 	company = filters.company
 	warehouse = filters.warehouse
 	if not frappe.db.exists("Warehouse", {"name": warehouse, "company": company}):
-		frappe.throw(_("Warehouse: {0} does not belong to {1}".format(warehouse, company)))
+		frappe.throw(_("Warehouse: {0} does not belong to {1}").format(warehouse, company))
 
 def get_columns():
 	columns = [


### PR DESCRIPTION
In https://github.com/frappe/erpnext/pull/22669 if the company was changed, still the report showed values of the selected warehouse. Added validation for checking if the warehouse belongs to the selected company.

![Screenshot 2020-10-26 at 11 56 40 AM](https://user-images.githubusercontent.com/33727827/97141028-f1cf9580-1783-11eb-89f7-dd2640962e6e.png)
