### PR TITLE
fix: override field_map for job card gantt

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card_calendar.js
+++ b/erpnext/manufacturing/doctype/job_card/job_card_calendar.js
@@ -8,7 +8,17 @@ frappe.views.calendar["Job Card"] = {
 		"allDay": "allDay",
 		"progress": "progress"
 	},
-	gantt: true,
+	gantt: {
+		field_map: {
+			"start": "started_time",
+			"end": "started_time",
+			"id": "name",
+			"title": "subject",
+			"color": "color",
+			"allDay": "allDay",
+			"progress": "progress"
+		}
+	},
 	filters: [
 		{
 			"fieldtype": "Link",


### PR DESCRIPTION
`from_time` and `to_time` are child table fields which breaks Gantt view, causing:
![image](https://user-images.githubusercontent.com/19775888/97396656-8285ad00-190d-11eb-823a-4cd2a94efe7c.png)

Depends on: https://github.com/frappe/frappe/pull/11807