### PR TITLE
fix: item wise tax calculation

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -651,7 +651,7 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 					let child = frappe.model.add_child(me.frm.doc, "taxes");
 					child.charge_type = "On Net Total";
 					child.account_head = tax;
-					child.rate = rate;
+					child.rate = 0;
 				}
 			});
 		}


### PR DESCRIPTION
Problem:
- Make a Sales Invoice of 2 items
- Set tax template for 2nd item
- Tax set in the tax template will be calculated for both of the item
- Expected behavior is that tax should be calculated only for 2nd item with tax template