### PR TITLE
fix: Do not allow Company as accounting dimension

### DIFF
--- a/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.js
+++ b/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.js
@@ -7,7 +7,7 @@ frappe.ui.form.on('Accounting Dimension', {
 		frm.set_query('document_type', () => {
 			let invalid_doctypes = frappe.model.core_doctypes_list;
 			invalid_doctypes.push('Accounting Dimension', 'Project',
-				'Cost Center', 'Accounting Dimension Detail');
+				'Cost Center', 'Accounting Dimension Detail', 'Company');
 
 			return {
 				filters: {

--- a/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.py
+++ b/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.py
@@ -19,7 +19,7 @@ class AccountingDimension(Document):
 
 	def validate(self):
 		if self.document_type in core_doctypes_list + ('Accounting Dimension', 'Project',
-				'Cost Center', 'Accounting Dimension Detail') :
+				'Cost Center', 'Accounting Dimension Detail', 'Company') :
 
 			msg = _("Not allowed to create accounting dimension for {0}").format(self.document_type)
 			frappe.throw(msg)


### PR DESCRIPTION
Company doctype should not be allowed as an accounting dimension as Company is already linked with every GL Entry so it doesn't make sense making it as an accounting dimension.

Also making company as a dimension breaks some accounting reports as company is used as keys in many queries for filtering

For Eg:
`
frappe.db.sql("""
		select
			name as gl_entry, posting_date, account, party_type, party,
			voucher_type, voucher_no, {dimension_fields}
			cost_center, project,
			against_voucher_type, against_voucher, account_currency,
			remarks, against, is_opening, creation {select_fields}
		from tabGL Entry
		where company=%(company)s {conditions}
		{distributed_cost_center_query}
		{order_by_statement}
		""".format(dimension_fields=dimension_fields, select_fields=select_fields, conditions=get_conditions(filters), distributed_cost_center_query=distributed_cost_center_query,order_by_statement=order_by_statement),ilters, as_dict=1)
` 

![image](https://user-images.githubusercontent.com/42651287/97437895-22612c00-194a-11eb-99ca-5424e16d36d9.png)

