### PR TITLE
chore: Show Toast alert feedback on Scanning Barcode

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -352,9 +352,15 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 
 		let show_description = function(idx, exist = null) {
 			if (exist) {
-				scan_barcode_field.set_new_description(__('Row #{0}: Qty increased by 1', [idx]));
+				frappe.show_alert({
+					message: __('Row #{0}: Qty increased by 1', [idx]),
+					indicator: 'green'
+				});
 			} else {
-				scan_barcode_field.set_new_description(__('Row #{0}: Item added', [idx]));
+				frappe.show_alert({
+					message: __('Row #{0}: Item added', [idx]),
+					indicator: 'green'
+				});
 			}
 		}
 
@@ -365,7 +371,10 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 			}).then(r => {
 				const data = r && r.message;
 				if (!data || Object.keys(data).length === 0) {
-					scan_barcode_field.set_new_description(__('Cannot find Item with this barcode'));
+					frappe.show_alert({
+						message: __('Cannot find Item with this Barcode'),
+						indicator: 'red'
+					});
 					return;
 				}
 


### PR DESCRIPTION
In Place alerts weren't grabbing the users attention due to being muted and hardly standing out
![Screenshot 2020-10-29 at 2 36 20 PM](https://user-images.githubusercontent.com/25857446/97547494-e1255680-19f3-11eb-833e-024ec83998c4.png)

Added Toast alerts to give more eye-catching feedback. It is also standard in the redesign.
![scan_barcode_alert_final](https://user-images.githubusercontent.com/25857446/97547572-f69a8080-19f3-11eb-80fe-f6bfce81cc9d.gif)
