### PR TITLE
fix: subscription test case

### DIFF
--- a/erpnext/accounts/doctype/subscription/test_subscription.py
+++ b/erpnext/accounts/doctype/subscription/test_subscription.py
@@ -209,7 +209,7 @@ class TestSubscription(unittest.TestCase):
 		subscription = frappe.new_doc('Subscription')
 		subscription.customer = '_Test Customer'
 		subscription.append('plans', {'plan': '_Test Plan Name', 'qty': 1})
-		subscription.start = '2018-01-01'
+		subscription.start = add_days(nowdate(), -1000)
 		subscription.days_until_due = 1
 		subscription.insert()
 		subscription.process()		# generate first invoice


### PR DESCRIPTION
**Issue**

```
======================================================================
FAIL: test_subscription_is_past_due_doesnt_change_within_grace_period (erpnext.accounts.doctype.subscription.test_subscription.TestSubscription)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/frappe-bench/apps/erpnext/erpnext/accounts/doctype/subscription/test_subscription.py", line 221, in test_subscription_is_past_due_doesnt_change_within_grace_period
    self.assertEqual(subscription.status, 'Past Due Date')
AssertionError: u'Unpaid' != u'Past Due Date'
- Unpaid
+ Past Due Date
```

<img width="1440" alt="Screenshot 2020-10-29 at 3 52 05 PM" src="https://user-images.githubusercontent.com/8780500/97556152-0f5c6380-19ff-11eb-801e-17d0a42733d5.png">
