### PR TITLE
fix: add check for allowing access to european region

### DIFF
--- a/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_connector.py
+++ b/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_connector.py
@@ -31,6 +31,7 @@ class PlaidConnector():
 		return access_token
 
 	def get_link_token(self):
+		country_codes = ["US", "CA", "FR", "IE", "NL", "ES", "GB"] if self.settings.enable_european_access else ["US", "CA"]
 		token_request = {
 			"client_name": self.client_name,
 			"client_id": self.settings.plaid_client_id,
@@ -38,7 +39,7 @@ class PlaidConnector():
 			"products": self.products,
 			# only allow Plaid-supported languages and countries (LAST: Sep-19-2020)
 			"language": frappe.local.lang if frappe.local.lang in ["en", "fr", "es", "nl"] else "en",
-			"country_codes": ["US", "CA", "FR", "IE", "NL", "ES", "GB"],
+			"country_codes": country_codes,
 			"user": {
 				"client_user_id": frappe.generate_hash(frappe.session.user, length=32)
 			}

--- a/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.json
+++ b/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "creation": "2018-10-25 10:02:48.656165",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -11,7 +12,8 @@
   "plaid_client_id",
   "plaid_secret",
   "column_break_7",
-  "plaid_env"
+  "plaid_env",
+  "enable_european_access"
  ],
  "fields": [
   {
@@ -58,10 +60,17 @@
   {
    "fieldname": "column_break_7",
    "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "enable_european_access",
+   "fieldtype": "Check",
+   "label": "Enable European Access"
   }
  ],
  "issingle": 1,
- "modified": "2020-09-12 02:31:44.542385",
+ "links": [],
+ "modified": "2020-10-29 20:24:56.916104",
  "modified_by": "Administrator",
  "module": "ERPNext Integrations",
  "name": "Plaid Settings",


### PR DESCRIPTION
- **Issue:** Europe/UK region is not enabled for everyone, this causes the plaid integration to fail for accounts without european access
- **Fix:** Added a check that explicitly allows users to enable european access. Country codes related to the europe will be fetched dynamically.
- From plaid support, in order to get the european access:
 ``` Your team would need to complete an additional onboarding/compliance application to get access to UK/EU geos. There are, generally speaking, not per-country requirements and upon completion of the application form you should be able access all countries (however it is all case-by-case and depends on how you intend to use Plaid). ```