### PR TITLE
fix: po_detail field has no value for subcontracted stock entry

### DIFF
--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -876,7 +876,7 @@ class TestPurchaseOrder(unittest.TestCase):
 			},
 			{
 				"item_code":item_code,"rm_item_code":"Sub Contracted Raw Material 4","item_name":"_Test Item",
-				"qty":250,"warehouse":"_Test Warehouse - _TC", "stock_uom":"Nos", "name": po.supplied_items[1].name
+				"qty":250,"warehouse":"_Test Warehouse - _TC", "stock_uom":"Nos"
 			},
 		]
 
@@ -884,6 +884,10 @@ class TestPurchaseOrder(unittest.TestCase):
 		rm_item_string = json.dumps(rm_items)
 		se = frappe.get_doc(make_subcontract_transfer_entry(po.name, rm_item_string))
 		se.submit()
+
+		# Test po_detail field has value or not
+		for item_row in se.items:
+			self.assertEqual(item_row.po_detail, po.supplied_items[item_row.idx - 1].name)
 
 		po_doc = frappe.get_doc("Purchase Order", po.name)
 		for row in po_doc.supplied_items:

--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -301,7 +301,7 @@ class BuyingController(StockController):
 			# backflushed_batch_qty_map = get_backflushed_batch_qty_map(item.purchase_order, item.item_code)
 
 			for raw_material in transferred_raw_materials + non_stock_items:
-				rm_item_key = (raw_material.rm_item_code, item.purchase_order)
+				rm_item_key = (raw_material.rm_item_code, item.item_code, item.purchase_order)
 				raw_material_data = backflushed_raw_materials_map.get(rm_item_key, {})
 
 				consumed_qty = raw_material_data.get('qty', 0)
@@ -910,7 +910,7 @@ def get_backflushed_subcontracted_raw_materials(purchase_orders):
 		purchase_receipt_supplied_items = get_supplied_items(args[1], args[2], references)
 
 		for data in purchase_receipt_supplied_items:
-			pr_key = (data.rm_item_code, args[0])
+			pr_key = (data.rm_item_code, data.main_item_code, args[0])
 			if pr_key not in backflushed_raw_materials_map:
 				backflushed_raw_materials_map.setdefault(pr_key, frappe._dict({
 					"qty": 0.0,
@@ -936,7 +936,7 @@ def get_backflushed_subcontracted_raw_materials(purchase_orders):
 
 def get_supplied_items(item_code, purchase_receipt, references):
 	return frappe.get_all("Purchase Receipt Item Supplied",
-		fields=["rm_item_code", "consumed_qty", "serial_no", "batch_no"],
+		fields=["rm_item_code", "main_item_code", "consumed_qty", "serial_no", "batch_no"],
 		filters={"main_item_code": item_code, "parent": purchase_receipt, "reference_name": ("in", references)})
 
 def get_asset_item_details(asset_items):

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -615,6 +615,15 @@ class StockEntry(StockController):
 				if not row.subcontracted_item:
 					frappe.throw(_("Row {0}: Subcontracted Item is mandatory for the raw material {1}")
 						.format(row.idx, frappe.bold(row.item_code)))
+				elif not row.po_detail:
+					filters = {
+						"parent": self.purchase_order, "docstatus": 1,
+						"rm_item_code": row.item_code, "main_item_code": row.subcontracted_item
+					}
+
+					po_detail = frappe.db.get_value("Purchase Order Item Supplied", filters, "name")
+					if po_detail:
+						row.db_set("po_detail", po_detail)
 
 	def validate_bom(self):
 		for d in self.get('items'):


### PR DESCRIPTION
**Issue**

1. po_detail field is hidden which used to link the Purchase Order Supplied Items with the subcontracted Stock Entry.

1. If user has manually added row in the subcontracted Stock Entry then po_detail field has set as blank

**After Fix**
If user has manually added row in the subcontracted Stock Entry then automatically system will set the value for the field po_detail.