### PR TITLE
fix: asset finance book posting date fix

### DIFF
--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -232,7 +232,7 @@ frappe.ui.form.on('Asset', {
 
 
 	item_code: function(frm) {
-		if(frm.doc.item_code) {
+		if(frm.doc.item_code && frm.doc.calculate_depreciation) {
 			frm.trigger('set_finance_book');
 		}
 	},
@@ -323,6 +323,7 @@ frappe.ui.form.on('Asset', {
 
 	calculate_depreciation: function(frm) {
 		frm.toggle_reqd("finance_books", frm.doc.calculate_depreciation);
+		frm.trigger('set_finance_book');
 	},
 
 	gross_purchase_amount: function(frm) {

--- a/erpnext/assets/doctype/asset_finance_book/asset_finance_book.json
+++ b/erpnext/assets/doctype/asset_finance_book/asset_finance_book.json
@@ -55,6 +55,7 @@
    "fieldtype": "Date",
    "in_list_view": 1,
    "label": "Depreciation Posting Date",
+   "mandatory_depends_on": "eval:parent.doctype == 'Asset'",
    "reqd": 1
   },
   {
@@ -86,7 +87,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-09-16 12:11:30.631788",
+ "modified": "2020-10-30 15:22:29.119868",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset Finance Book",


### PR DESCRIPTION
Problem:
- Set finance book in Asset Category
- Making an asset of this Category will fetch finance books even if calculate depreciation is unchecked
- Saving the asset throws error.

Depends on: https://github.com/frappe/frappe/pull/11834