### PR TITLE
fix: Place of Supply fix in Sales Invoices

### DIFF
--- a/erpnext/regional/india/utils.py
+++ b/erpnext/regional/india/utils.py
@@ -139,7 +139,7 @@ def get_place_of_supply(party_details, doctype):
 	if not frappe.get_meta('Address').has_field('gst_state'): return
 
 	if doctype in ("Sales Invoice", "Delivery Note", "Sales Order"):
-		address_name = party_details.customer_address or party_details.shipping_address
+		address_name = party_details.customer_address or party_details.shipping_address_name
 	elif doctype in ("Purchase Invoice", "Purchase Order", "Purchase Receipt"):
 		address_name = party_details.shipping_address or party_details.supplier_address
 

--- a/erpnext/regional/india/utils.py
+++ b/erpnext/regional/india/utils.py
@@ -139,7 +139,7 @@ def get_place_of_supply(party_details, doctype):
 	if not frappe.get_meta('Address').has_field('gst_state'): return
 
 	if doctype in ("Sales Invoice", "Delivery Note", "Sales Order"):
-		address_name = party_details.shipping_address_name or party_details.customer_address
+		address_name = party_details.customer_address or party_details.shipping_address
 	elif doctype in ("Purchase Invoice", "Purchase Order", "Purchase Receipt"):
 		address_name = party_details.shipping_address or party_details.supplier_address
 


### PR DESCRIPTION
Back Port Of: https://github.com/frappe/erpnext/pull/23785

For Bill To - Ship To Sales Transaction (where billing and shipping address are different) Place Of Supply that is reported is determined based on the Bill To address's state (Customer Address). Currently the Ship To address (Shipping Address) is given preference. This PR fixes that behaviour.