### PR TITLE
fix: Inpatient Medication Order and Entry fixes

### DIFF
--- a/erpnext/healthcare/doctype/inpatient_medication_entry/inpatient_medication_entry.js
+++ b/erpnext/healthcare/doctype/inpatient_medication_entry/inpatient_medication_entry.js
@@ -21,6 +21,19 @@ frappe.ui.form.on('Inpatient Medication Entry', {
 				}
 			};
 		});
+
+		frm.set_query('warehouse', () => {
+			return {
+				filters: {
+					company: frm.doc.company
+				}
+			};
+		});
+	},
+
+	patient: function(frm) {
+		if (frm.doc.patient)
+			frm.set_value('service_unit', '');
 	},
 
 	get_medication_orders: function(frm) {

--- a/erpnext/healthcare/doctype/inpatient_medication_entry/inpatient_medication_entry.json
+++ b/erpnext/healthcare/doctype/inpatient_medication_entry/inpatient_medication_entry.json
@@ -67,6 +67,7 @@
   },
   {
    "collapsible": 1,
+   "collapsible_depends_on": "eval: doc.__islocal",
    "fieldname": "filters_section",
    "fieldtype": "Section Break",
    "label": "Filters"
@@ -93,6 +94,7 @@
    "options": "Patient"
   },
   {
+   "depends_on": "eval:!doc.patient",
    "fieldname": "service_unit",
    "fieldtype": "Link",
    "label": "Healthcare Service Unit",
@@ -178,7 +180,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2020-09-30 23:40:45.528715",
+ "modified": "2020-11-03 13:22:37.820707",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Inpatient Medication Entry",

--- a/erpnext/healthcare/doctype/inpatient_medication_entry/inpatient_medication_entry.py
+++ b/erpnext/healthcare/doctype/inpatient_medication_entry/inpatient_medication_entry.py
@@ -199,6 +199,7 @@ class InpatientMedicationEntry(Document):
 
 def get_pending_medication_orders(entry):
 	filters, values = get_filters(entry)
+	to_remove = []
 
 	data = frappe.db.sql("""
 		SELECT
@@ -225,7 +226,10 @@ def get_pending_medication_orders(entry):
 		doc['service_unit'] = get_current_healthcare_service_unit(inpatient_record)
 
 		if entry.service_unit and doc.service_unit != entry.service_unit:
-			data.remove(doc)
+			to_remove.append(doc)
+
+	for doc in to_remove:
+		data.remove(doc)
 
 	return data
 

--- a/erpnext/healthcare/doctype/inpatient_medication_order/inpatient_medication_order.js
+++ b/erpnext/healthcare/doctype/inpatient_medication_order/inpatient_medication_order.js
@@ -12,7 +12,8 @@ frappe.ui.form.on('Inpatient Medication Order', {
 		frm.set_query('patient', () => {
 			return {
 				filters: {
-					'inpatient_record': ['!=', '']
+					'inpatient_record': ['!=', ''],
+					'inpatient_status': 'Admitted'
 				}
 			};
 		});


### PR DESCRIPTION
Pre Release Testing fixes:

## Inpatient Medication Entry
- Added filter for the company in the warehouse field.

  ![warehouse](https://user-images.githubusercontent.com/24353136/97962631-9cc2fd80-1ddb-11eb-8ac8-92d7ff464156.png)

- Show filters section when the doc is unsaved since it will be used extensively.

- Healthcare Service Unit filter not functioning properly. If it was applied then medication orders were being fetched without the service unit. Fixed that.

  ![image](https://user-images.githubusercontent.com/24353136/97962726-c5e38e00-1ddb-11eb-89a5-15766eb424ed.png)

## Inpatient Medication Order
- Inpatient Medication Order should allow selecting patients only with status as **Admitted** since it has to fetch the Healthcare Service Unit details.

  ![status](https://user-images.githubusercontent.com/24353136/97962859-06430c00-1ddc-11eb-9d24-64045a7994a8.png)
