### PR TITLE
fix: Received/Delivered Items to Be Billed Logic

### DIFF
--- a/erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py
+++ b/erpnext/accounts/report/delivered_items_to_be_billed/delivered_items_to_be_billed.py
@@ -14,11 +14,19 @@ def execute(filters=None):
 
 def get_column():
 	return [
-		_("Delivery Note") + ":Link/Delivery Note:120", _("Status") + "::120", _("Date") + ":Date:100",
-		_("Suplier") + ":Link/Customer:120", _("Customer Name") + "::120",
-		_("Project") + ":Link/Project:120", _("Item Code") + ":Link/Item:120",
-		_("Amount") + ":Currency:100", _("Billed Amount") + ":Currency:100", _("Pending Amount") + ":Currency:100",
-		_("Item Name") + "::120", _("Description") + "::120", _("Company") + ":Link/Company:120",
+		_("Delivery Note") + ":Link/Delivery Note:160",
+		_("Date") + ":Date:100",
+		_("Customer") + ":Link/Customer:120",
+		_("Customer Name") + "::120",
+		_("Item Code") + ":Link/Item:120",
+		_("Amount") + ":Currency:100",
+		_("Billed Amount") + ":Currency:100",
+		_("Returned Amount") + ":Currency:120",
+		_("Pending Amount") + ":Currency:100",
+		_("Item Name") + "::120",
+		_("Description") + "::120",
+		_("Project") + ":Link/Project:120",
+		_("Company") + ":Link/Company:120",
 	]
 
 def get_args():

--- a/erpnext/accounts/report/non_billed_report.py
+++ b/erpnext/accounts/report/non_billed_report.py
@@ -17,18 +17,26 @@ def get_ordered_to_be_billed_data(args):
 
 	return frappe.db.sql("""
 		Select
-			`{parent_tab}`.name, `{parent_tab}`.status, `{parent_tab}`.{date_field}, `{parent_tab}`.{party}, `{parent_tab}`.{party}_name,
-			{project_field}, `{child_tab}`.item_code, `{child_tab}`.base_amount,
+			`{parent_tab}`.name, `{parent_tab}`.{date_field},
+			`{parent_tab}`.{party}, `{parent_tab}`.{party}_name,
+			`{child_tab}`.item_code,
+			`{child_tab}`.base_amount,
 			(`{child_tab}`.billed_amt * ifnull(`{parent_tab}`.conversion_rate, 1)),
-			(`{child_tab}`.base_amount - (`{child_tab}`.billed_amt * ifnull(`{parent_tab}`.conversion_rate, 1))),
-			`{child_tab}`.item_name, `{child_tab}`.description, `{parent_tab}`.company
+			(`{child_tab}`.base_rate * ifnull(`{child_tab}`.returned_qty, 0)),
+			(`{child_tab}`.base_amount -
+			(`{child_tab}`.billed_amt * ifnull(`{parent_tab}`.conversion_rate, 1)) -
+			(`{child_tab}`.base_rate * ifnull(`{child_tab}`.returned_qty, 0))),
+			`{child_tab}`.item_name, `{child_tab}`.description,
+			{project_field}, `{parent_tab}`.company
 		from
 			`{parent_tab}`, `{child_tab}`
 		where
 			`{parent_tab}`.name = `{child_tab}`.parent and `{parent_tab}`.docstatus = 1
 			and `{parent_tab}`.status not in ('Closed', 'Completed')
-			and `{child_tab}`.amount > 0 and round(`{child_tab}`.billed_amt *
-			ifnull(`{parent_tab}`.conversion_rate, 1), {precision}) < `{child_tab}`.base_amount
+			and `{child_tab}`.amount > 0
+			and (`{child_tab}`.base_amount -
+			round(`{child_tab}`.billed_amt * ifnull(`{parent_tab}`.conversion_rate, 1), {precision}) -
+			(`{child_tab}`.base_rate * ifnull(`{child_tab}`.returned_qty, 0))) > 0
 		order by
 			`{parent_tab}`.{order} {order_by}
 		""".format(parent_tab = 'tab' + doctype, child_tab = 'tab' + child_tab, precision= precision, party = party,

--- a/erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py
+++ b/erpnext/accounts/report/received_items_to_be_billed/received_items_to_be_billed.py
@@ -14,11 +14,19 @@ def execute(filters=None):
 
 def get_column():
 	return [
-		_("Purchase Receipt") + ":Link/Purchase Receipt:120", _("Status") + "::120", _("Date") + ":Date:100",
-		_("Supplier") + ":Link/Supplier:120", _("Supplier Name") + "::120",
-		_("Project") + ":Link/Project:120", _("Item Code") + ":Link/Item:120",
-		_("Amount") + ":Currency:100", _("Billed Amount") + ":Currency:100", _("Amount to Bill") + ":Currency:100",
-		_("Item Name") + "::120", _("Description") + "::120", _("Company") + ":Link/Company:120",
+		_("Purchase Receipt") + ":Link/Purchase Receipt:160",
+		_("Date") + ":Date:100",
+		_("Supplier") + ":Link/Supplier:120",
+		_("Supplier Name") + "::120",
+		_("Item Code") + ":Link/Item:120",
+		_("Amount") + ":Currency:100",
+		_("Billed Amount") + ":Currency:100",
+		_("Returned Amount") + ":Currency:120",
+		_("Pending Amount") + ":Currency:120",
+		_("Item Name") + "::120",
+		_("Description") + "::120",
+		_("Project") + ":Link/Project:120",
+		_("Company") + ":Link/Company:120",
 	]
 
 def get_args():


### PR DESCRIPTION
Cherry Picked fix from https://github.com/frappe/erpnext/pull/22859
- Added Returned Amount to **Delivered** and **Purchased** Items to be Billed Reports.
- **Pending Amount = Total Amount - Billed Amount  - Returned Amount**. Essentially only non-returned items should be counted as pending
- If **Pending Amount** > 0, only then will the item be visible in the Report. So if a PR is 50 % Billed and 50% Returned, it won't be visible in the Report.

![Screenshot 2020-09-10 at 6 48 42 PM](https://user-images.githubusercontent.com/25857446/92734685-626a5080-f396-11ea-8425-7259dae95e51.png)
