### PR TITLE
Fix leave ledger patch

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -635,7 +635,7 @@ execute:frappe.reload_doc('desk', 'doctype', 'dashboard_chart')
 execute:frappe.reload_doc('desk', 'doctype', 'dashboard_chart_field')
 erpnext.patches.v12_0.add_default_dashboards
 erpnext.patches.v12_0.remove_bank_remittance_custom_fields
-erpnext.patches.v12_0.generate_leave_ledger_entries #27-08-2020
+erpnext.patches.v12_0.generate_leave_ledger_entries #04-11-2020
 erpnext.patches.v12_0.move_credit_limit_to_customer_credit_limit
 erpnext.patches.v12_0.add_variant_of_in_item_attribute_table
 erpnext.patches.v12_0.rename_bank_account_field_in_journal_entry_account

--- a/erpnext/patches/v12_0/generate_leave_ledger_entries.py
+++ b/erpnext/patches/v12_0/generate_leave_ledger_entries.py
@@ -11,8 +11,6 @@ def execute():
 	frappe.reload_doc("HR", "doctype", "Leave Ledger Entry")
 	frappe.reload_doc("HR", "doctype", "Leave Encashment")
 	frappe.reload_doc("HR", "doctype", "Leave Type")
-	if frappe.db.a_row_exists("Leave Ledger Entry"):
-		return
 
 	if not frappe.get_meta("Leave Allocation").has_field("unused_leaves"):
 		frappe.reload_doc("HR", "doctype", "Leave Allocation")


### PR DESCRIPTION
While running the patch if there was any existing entry in the Leave Ledger Entry List, the patch wasn't executed further. Hence not creating missing Leave Ledger entries.