### PR TITLE
fix: therapy plan and session fixes

### DIFF
--- a/erpnext/healthcare/doctype/exercise/exercise.json
+++ b/erpnext/healthcare/doctype/exercise/exercise.json
@@ -37,7 +37,8 @@
    "depends_on": "eval:doc.parenttype==\"Therapy\";",
    "fieldname": "counts_completed",
    "fieldtype": "Int",
-   "label": "Counts Completed"
+   "label": "Counts Completed",
+   "no_copy": 1
   },
   {
    "fieldname": "assistance_level",
@@ -48,7 +49,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2020-04-10 13:41:06.662351",
+ "modified": "2020-11-04 18:20:25.583491",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Exercise",

--- a/erpnext/healthcare/doctype/therapy_plan/therapy_plan.js
+++ b/erpnext/healthcare/doctype/therapy_plan/therapy_plan.js
@@ -14,7 +14,7 @@ frappe.ui.form.on('Therapy Plan', {
 		if (!frm.doc.__islocal) {
 			frm.trigger('show_progress_for_therapies');
 			if (frm.doc.status != 'Completed') {
-				let therapy_types = (frm.doc.therapy_plan_details || []).map(function(d){ return d.therapy_type });
+				let therapy_types = (frm.doc.therapy_plan_details || []).map(function(d){ return d.therapy_type; });
 				const fields = [{
 					fieldtype: 'Link',
 					label: __('Therapy Type'),
@@ -24,7 +24,7 @@ frappe.ui.form.on('Therapy Plan', {
 					get_query: function() {
 						return {
 							filters: { 'therapy_type': ['in', therapy_types]}
-						}
+						};
 					}
 				}];
 

--- a/erpnext/healthcare/doctype/therapy_plan/therapy_plan.js
+++ b/erpnext/healthcare/doctype/therapy_plan/therapy_plan.js
@@ -13,43 +13,42 @@ frappe.ui.form.on('Therapy Plan', {
 	refresh: function(frm) {
 		if (!frm.doc.__islocal) {
 			frm.trigger('show_progress_for_therapies');
-		}
-
-		if (!frm.doc.__islocal && frm.doc.status != 'Completed') {
-			let therapy_types = (frm.doc.therapy_plan_details || []).map(function(d){ return d.therapy_type });
-			const fields = [{
-				fieldtype: 'Link',
-				label: __('Therapy Type'),
-				fieldname: 'therapy_type',
-				options: 'Therapy Type',
-				reqd: 1,
-				get_query: function() {
-					return {
-						filters: { 'therapy_type': ['in', therapy_types]}
-					}
-				}
-			}];
-
-			frm.add_custom_button(__('Therapy Session'), function() {
-				frappe.prompt(fields, data => {
-					frappe.call({
-						method: 'erpnext.healthcare.doctype.therapy_plan.therapy_plan.make_therapy_session',
-						args: {
-							therapy_plan: frm.doc.name,
-							patient: frm.doc.patient,
-							therapy_type: data.therapy_type,
-							company: frm.doc.company
-						},
-						freeze: true,
-						callback: function(r) {
-							if (r.message) {
-								frappe.model.sync(r.message);
-								frappe.set_route('Form', r.message.doctype, r.message.name);
-							}
+			if (frm.doc.status != 'Completed') {
+				let therapy_types = (frm.doc.therapy_plan_details || []).map(function(d){ return d.therapy_type });
+				const fields = [{
+					fieldtype: 'Link',
+					label: __('Therapy Type'),
+					fieldname: 'therapy_type',
+					options: 'Therapy Type',
+					reqd: 1,
+					get_query: function() {
+						return {
+							filters: { 'therapy_type': ['in', therapy_types]}
 						}
-					});
-				}, __('Select Therapy Type'), __('Create'));
-			}, __('Create'));
+					}
+				}];
+
+				frm.add_custom_button(__('Therapy Session'), function() {
+					frappe.prompt(fields, data => {
+						frappe.call({
+							method: 'erpnext.healthcare.doctype.therapy_plan.therapy_plan.make_therapy_session',
+							args: {
+								therapy_plan: frm.doc.name,
+								patient: frm.doc.patient,
+								therapy_type: data.therapy_type,
+								company: frm.doc.company
+							},
+							freeze: true,
+							callback: function(r) {
+								if (r.message) {
+									frappe.model.sync(r.message);
+									frappe.set_route('Form', r.message.doctype, r.message.name);
+								}
+							}
+						});
+					}, __('Select Therapy Type'), __('Create'));
+				}, __('Create'));
+			}
 
 			if (frm.doc.therapy_plan_template && !frm.doc.invoiced) {
 				frm.add_custom_button(__('Sales Invoice'), function() {

--- a/erpnext/healthcare/doctype/therapy_plan/therapy_plan.json
+++ b/erpnext/healthcare/doctype/therapy_plan/therapy_plan.json
@@ -115,7 +115,8 @@
    "fieldname": "therapy_plan_template",
    "fieldtype": "Link",
    "label": "Therapy Plan Template",
-   "options": "Therapy Plan Template"
+   "options": "Therapy Plan Template",
+   "set_only_once": 1
   },
   {
    "default": "0",
@@ -128,7 +129,7 @@
   }
  ],
  "links": [],
- "modified": "2020-10-23 01:27:42.128855",
+ "modified": "2020-11-04 18:13:13.564999",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Therapy Plan",

--- a/erpnext/healthcare/doctype/therapy_plan_detail/therapy_plan_detail.json
+++ b/erpnext/healthcare/doctype/therapy_plan_detail/therapy_plan_detail.json
@@ -30,12 +30,13 @@
    "fieldname": "sessions_completed",
    "fieldtype": "Int",
    "label": "Sessions Completed",
+   "no_copy": 1,
    "read_only": 1
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2020-10-08 01:17:34.778028",
+ "modified": "2020-11-04 18:15:52.173450",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Therapy Plan Detail",

--- a/erpnext/healthcare/doctype/therapy_session/therapy_session.js
+++ b/erpnext/healthcare/doctype/therapy_session/therapy_session.js
@@ -46,7 +46,7 @@ frappe.ui.form.on('Therapy Session', {
 						frappe.model.open_mapped_doc({
 							method: 'erpnext.healthcare.doctype.therapy_session.therapy_session.invoice_therapy_session',
 							frm: frm,
-						})
+						});
 					}, 'Create');
 				}
 			});
@@ -67,7 +67,7 @@ frappe.ui.form.on('Therapy Session', {
 				name: frm.doc.therapy_plan
 			},
 			callback: function(data) {
-				let therapy_types = (data.message.therapy_plan_details || []).map(function(d){ return d.therapy_type });
+				let therapy_types = (data.message.therapy_plan_details || []).map(function(d){ return d.therapy_type; });
 				frm.set_query('therapy_type', function() {
 					return {
 						filters: { 'therapy_type': ['in', therapy_types]}

--- a/erpnext/healthcare/doctype/therapy_session/therapy_session.js
+++ b/erpnext/healthcare/doctype/therapy_session/therapy_session.js
@@ -22,6 +22,10 @@ frappe.ui.form.on('Therapy Session', {
 	},
 
 	refresh: function(frm) {
+		if (frm.doc.therapy_plan) {
+			frm.trigger('filter_therapy_types');
+		}
+
 		if (!frm.doc.__islocal) {
 			frm.dashboard.add_indicator(__('Counts Targeted: {0}', [frm.doc.total_counts_targeted]), 'blue');
 			frm.dashboard.add_indicator(__('Counts Completed: {0}', [frm.doc.total_counts_completed]),
@@ -36,13 +40,41 @@ frappe.ui.form.on('Therapy Session', {
 				})
 			}, 'Create');
 
-			frm.add_custom_button(__('Sales Invoice'), function() {
-				frappe.model.open_mapped_doc({
-					method: 'erpnext.healthcare.doctype.therapy_session.therapy_session.invoice_therapy_session',
-					frm: frm,
-				})
-			}, 'Create');
+			frappe.db.get_value('Therapy Plan', {'name': frm.doc.therapy_plan}, 'therapy_plan_template', (r) => {
+				if (r && !r.therapy_plan_template) {
+					frm.add_custom_button(__('Sales Invoice'), function() {
+						frappe.model.open_mapped_doc({
+							method: 'erpnext.healthcare.doctype.therapy_session.therapy_session.invoice_therapy_session',
+							frm: frm,
+						})
+					}, 'Create');
+				}
+			});
 		}
+	},
+
+	therapy_plan: function(frm) {
+		if (frm.doc.therapy_plan) {
+			frm.trigger('filter_therapy_types');
+		}
+	},
+
+	filter_therapy_types: function(frm) {
+		frappe.call({
+			'method': 'frappe.client.get',
+			args: {
+				doctype: 'Therapy Plan',
+				name: frm.doc.therapy_plan
+			},
+			callback: function(data) {
+				let therapy_types = (data.message.therapy_plan_details || []).map(function(d){ return d.therapy_type });
+				frm.set_query('therapy_type', function() {
+					return {
+						filters: { 'therapy_type': ['in', therapy_types]}
+					};
+				});
+			}
+		});
 	},
 
 	patient: function(frm) {
@@ -98,19 +130,6 @@ frappe.ui.form.on('Therapy Session', {
 					frm.set_value(values);
 				}
 			});
-		} else {
-			let values = {
-				'patient': '',
-				'therapy_type': '',
-				'therapy_plan': '',
-				'practitioner': '',
-				'department': '',
-				'start_date': '',
-				'start_time': '',
-				'service_unit': '',
-				'duration': ''
-			};
-			frm.set_value(values);
 		}
 	},
 

--- a/erpnext/healthcare/doctype/therapy_session/therapy_session.json
+++ b/erpnext/healthcare/doctype/therapy_session/therapy_session.json
@@ -194,6 +194,7 @@
    "fieldname": "total_counts_completed",
    "fieldtype": "Int",
    "label": "Total Counts Completed",
+   "no_copy": 1,
    "read_only": 1
   },
   {
@@ -222,7 +223,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2020-10-22 23:10:21.178644",
+ "modified": "2020-11-04 18:14:25.999939",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Therapy Session",


### PR DESCRIPTION
Back port of: https://github.com/frappe/erpnext/pull/23817

Pre Release Testing fixes:

- Enable `no_copy` for:
   - **Counts Completed** field in Exercises child table (Therapy Session)
   - **Total Counts Completed** field in Therapy Session

- Button to create Sales Invoice from Therapy Plan (created from therapy plan template) gets hidden when the status is set as Completed

- Hide sales invoice creation button from Therapy session if created via template since such sessions should be billed as a package.

- Filter Therapy Types according to the selected Therapy Plan in Therapy Session form

  ![filter](https://user-images.githubusercontent.com/24353136/98124976-ded26900-1ed9-11eb-8c89-36e8499ba600.png)
