### PR TITLE
feat: payment automation for invoicing

### DIFF
--- a/erpnext/non_profit/doctype/membership_settings/membership_settings.js
+++ b/erpnext/non_profit/doctype/membership_settings/membership_settings.js
@@ -37,6 +37,16 @@ frappe.ui.form.on("Membership Settings", {
 			};
 		});
 
+		frm.set_query('payment_account', function(doc) {
+			return {
+				filters: {
+					'account_type': ['in', ['Bank', 'Cash']],
+					'is_group': 0,
+					'company': frm.doc.company
+				}
+			};
+		});
+
 		let docs_url = "https://docs.erpnext.com/docs/user/manual/en/non_profit/membership";
 
 		frm.set_intro(__("You can learn more about memberships in the manual. ") + `<a href='${docs_url}'>${__('ERPNext Docs')}</a>`, true);

--- a/erpnext/non_profit/doctype/membership_settings/membership_settings.json
+++ b/erpnext/non_profit/doctype/membership_settings/membership_settings.json
@@ -11,9 +11,11 @@
   "billing_frequency",
   "webhook_secret",
   "column_break_6",
-  "enable_auto_invoicing",
+  "enable_invoicing",
+  "make_payment_entry",
   "company",
   "debit_account",
+  "payment_account",
   "column_break_9",
   "send_email",
   "send_invoice",
@@ -58,14 +60,7 @@
    "label": "Invoicing"
   },
   {
-   "default": "0",
-   "fieldname": "enable_auto_invoicing",
-   "fieldtype": "Check",
-   "label": "Enable Auto Invoicing",
-   "mandatory_depends_on": "eval:doc.send_invoice"
-  },
-  {
-   "depends_on": "eval:doc.enable_auto_invoicing",
+   "depends_on": "eval:doc.enable_invoicing",
    "fieldname": "debit_account",
    "fieldtype": "Link",
    "label": "Debit Account",
@@ -77,7 +72,7 @@
    "fieldtype": "Column Break"
   },
   {
-   "depends_on": "eval:doc.enable_auto_invoicing",
+   "depends_on": "eval:doc.enable_invoicing",
    "fieldname": "company",
    "fieldtype": "Link",
    "label": "Company",
@@ -86,7 +81,7 @@
   },
   {
    "default": "0",
-   "depends_on": "eval:doc.enable_auto_invoicing && doc.send_email",
+   "depends_on": "eval:doc.enable_invoicing && doc.send_email",
    "fieldname": "send_invoice",
    "fieldtype": "Check",
    "label": "Send Invoice with Email"
@@ -119,11 +114,34 @@
    "label": "Email Template",
    "mandatory_depends_on": "eval:doc.send_email",
    "options": "Email Template"
+  },
+  {
+   "default": "0",
+   "fieldname": "enable_invoicing",
+   "fieldtype": "Check",
+   "label": "Enable Invoicing",
+   "mandatory_depends_on": "eval:doc.send_invoice || doc.make_payment_entry"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.enable_invoicing",
+   "fieldname": "make_payment_entry",
+   "fieldtype": "Check",
+   "label": "Make Payment Entry"
+  },
+  {
+   "depends_on": "eval:doc.make_payment_entry",
+   "fieldname": "payment_account",
+   "fieldtype": "Link",
+   "label": "Payment To",
+   "mandatory_depends_on": "eval:doc.make_payment_entry",
+   "options": "Account"
   }
  ],
+ "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2020-08-05 17:26:37.287395",
+ "modified": "2020-11-04 19:51:21.990595",
  "modified_by": "Administrator",
  "module": "Non Profit",
  "name": "Membership Settings",

--- a/erpnext/non_profit/doctype/membership_settings/membership_settings.json
+++ b/erpnext/non_profit/doctype/membership_settings/membership_settings.json
@@ -12,6 +12,7 @@
   "webhook_secret",
   "column_break_6",
   "enable_invoicing",
+  "create_for_web_forms",
   "make_payment_entry",
   "company",
   "debit_account",
@@ -136,12 +137,19 @@
    "label": "Payment To",
    "mandatory_depends_on": "eval:doc.make_payment_entry",
    "options": "Account"
+  },
+  {
+   "depends_on": "eval:doc.enable_invoicing",
+   "description": "Automatically create an invoice when payment is authorized from a web form entry",
+   "fieldname": "create_for_web_forms",
+   "fieldtype": "Data",
+   "label": "Auto Create Invoice for Web Forms"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2020-11-04 19:51:21.990595",
+ "modified": "2020-11-04 20:19:55.163749",
  "modified_by": "Administrator",
  "module": "Non Profit",
  "name": "Membership Settings",

--- a/erpnext/non_profit/doctype/membership_type/membership_type.js
+++ b/erpnext/non_profit/doctype/membership_type/membership_type.js
@@ -2,12 +2,12 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Membership Type', {
-	refresh: function(frm) {
+	refresh: function (frm) {
 		frappe.db.get_single_value("Membership Settings", "enable_razorpay").then(val => {
 			if (val) frm.set_df_property('razorpay_plan_id', 'hidden', false);
 		});
 
-		frappe.db.get_single_value("Membership Settings", "enable_auto_invoicing").then(val => {
+		frappe.db.get_single_value("Membership Settings", "enable_invoicing").then(val => {
 			if (val) frm.set_df_property('linked_item', 'hidden', false);
 		});
 	}


### PR DESCRIPTION
This PR adds the following

1. Remove `email` field and use `email_id` only
1. Auto creation of payment entries
1. Auto invoicing when payment is authorized via web forms


## Pending

- [ ] Portal View for logged in users 
- [ ] Tests
- [ ] Documentation