### PR TITLE
fix: fix: replaced formatdate -> format_date

### DIFF
--- a/erpnext/accounts/print_format/journal_auditing_voucher/journal_auditing_voucher.html
+++ b/erpnext/accounts/print_format/journal_auditing_voucher/journal_auditing_voucher.html
@@ -17,7 +17,7 @@
             </div>
             <div class="col-xs-6">
                 <table>
-                    <tr><td><strong>Date: </strong></td><td>{{  frappe.utils.formatdate(doc.creation)  }}</td></tr>
+                    <tr><td><strong>Date: </strong></td><td>{{  frappe.utils.format_date(doc.creation)  }}</td></tr>
                 </table>
             </div>
     </div>

--- a/erpnext/accounts/print_format/payment_receipt_voucher/payment_receipt_voucher.html
+++ b/erpnext/accounts/print_format/payment_receipt_voucher/payment_receipt_voucher.html
@@ -5,7 +5,7 @@
     {{ add_header(0, 1, doc, letter_head, no_letterhead, print_settings) }}
 
     {%- for label, value in (
-        (_("Received On"), frappe.utils.formatdate(doc.voucher_date)),
+        (_("Received On"), frappe.utils.format_date(doc.voucher_date)),
         (_("Received From"), doc.pay_to_recd_from),
         (_("Amount"), "<strong>" + doc.get_formatted("total_amount") + "</strong><br>" + (doc.total_amount_in_words or "") + "<br>"),
         (_("Remarks"), doc.remark)

--- a/erpnext/accounts/print_format/purchase_auditing_voucher/purchase_auditing_voucher.html
+++ b/erpnext/accounts/print_format/purchase_auditing_voucher/purchase_auditing_voucher.html
@@ -8,7 +8,7 @@
         <div class="col-xs-6">
             <table>
             <tr><td><strong>Supplier Name: </strong></td><td>{{ doc.supplier }}</td></tr>
-            <tr><td><strong>Due Date: </strong></td><td>{{ frappe.utils.formatdate(doc.due_date) }}</td></tr>
+            <tr><td><strong>Due Date: </strong></td><td>{{ frappe.utils.format_date(doc.due_date) }}</td></tr>
             <tr><td><strong>Address: </strong></td><td>{{doc.address_display}}</td></tr>
             <tr><td><strong>Contact: </strong></td><td>{{doc.contact_display}}</td></tr>
             <tr><td><strong>Mobile no: </strong> </td><td>{{doc.contact_mobile}}</td></tr>
@@ -17,7 +17,7 @@
         <div class="col-xs-6">
             <table>
                 <tr><td><strong>Voucher No: </strong></td><td>{{ doc.name }}</td></tr>
-                <tr><td><strong>Date: </strong></td><td>{{ frappe.utils.formatdate(doc.creation) }}</td></tr>
+                <tr><td><strong>Date: </strong></td><td>{{ frappe.utils.format_date(doc.creation) }}</td></tr>
             </table>
         </div>
     </div>

--- a/erpnext/accounts/print_format/sales_auditing_voucher/sales_auditing_voucher.html
+++ b/erpnext/accounts/print_format/sales_auditing_voucher/sales_auditing_voucher.html
@@ -8,7 +8,7 @@
         <div class="col-xs-6">
             <table>
             <tr><td><strong>Customer Name: </strong></td><td>{{ doc.customer }}</td></tr>
-            <tr><td><strong>Due Date: </strong></td><td>{{ frappe.utils.formatdate(doc.due_date) }}</td></tr>
+            <tr><td><strong>Due Date: </strong></td><td>{{ frappe.utils.format_date(doc.due_date) }}</td></tr>
             <tr><td><strong>Address: </strong></td><td>{{doc.address_display}}</td></tr>
             <tr><td><strong>Contact: </strong></td><td>{{doc.contact_display}}</td></tr>
             <tr><td><strong>Mobile no: </strong> </td><td>{{doc.contact_mobile}}</td></tr>
@@ -17,7 +17,7 @@
         <div class="col-xs-6">
             <table>
                 <tr><td><strong>Voucher No: </strong></td><td>{{ doc.name }}</td></tr>
-                <tr><td><strong>Date: </strong></td><td>{{ frappe.utils.formatdate(doc.creation) }}</td></tr>
+                <tr><td><strong>Date: </strong></td><td>{{ frappe.utils.format_date(doc.creation) }}</td></tr>
             </table>
         </div>
     </div>

--- a/erpnext/templates/pages/material_request_info.html
+++ b/erpnext/templates/pages/material_request_info.html
@@ -25,7 +25,7 @@
 		</span>
 	</div>
 	<div class="col-xs-6 text-muted text-right small">
-		{{ frappe.utils.formatdate(doc.transaction_date, 'medium') }}
+		{{ frappe.utils.format_date(doc.transaction_date, 'medium') }}
 	</div>
 </div>
 

--- a/erpnext/templates/pages/order.html
+++ b/erpnext/templates/pages/order.html
@@ -42,10 +42,10 @@
 		</span>
 	</div>
 	<div class="col-6 text-muted text-right small">
-		{{ frappe.utils.formatdate(doc.transaction_date, 'medium') }}
+		{{ frappe.utils.format_date(doc.transaction_date, 'medium') }}
 		{% if doc.valid_till %}
 		<p>
-		{{ _("Valid Till") }}: {{ frappe.utils.formatdate(doc.valid_till, 'medium') }}
+		{{ _("Valid Till") }}: {{ frappe.utils.format_date(doc.valid_till, 'medium') }}
 		</p>
 		{% endif %}
 	</div>


### PR DESCRIPTION
formatdate is deprecated.
https://github.com/frappe/frappe/blob/develop/frappe/utils/safe_exec.py#L218