### PR TITLE
fix: Auto Statewise gst tax template

### DIFF
--- a/erpnext/regional/india/utils.py
+++ b/erpnext/regional/india/utils.py
@@ -236,7 +236,7 @@ def get_tax_template(master_doctype, company, is_inter_state, state_code):
 		if tax_category.gst_state == number_state_mapping[state_code] or \
 	 		(not default_tax and not tax_category.gst_state):
 			default_tax = frappe.db.get_value(master_doctype,
-				{'disabled': 0, 'tax_category': tax_category.name}, 'name')
+				{'company': company, 'disabled': 0, 'tax_category': tax_category.name}, 'name')
 	return default_tax
 
 def get_tax_template_for_sez(party_details, master_doctype, company, party_type):


### PR DESCRIPTION
**Issue:** In a multi-company setup appropriate company's tax template was not fetched even if automatic tax template fetching was configured.
  
Steps to replicate/test:
1. Add Address and Part GSTIN for the parties (Company, Customer, Supplier)
2. Create In State and Out State Tax Categories for a state 
3. Create In State and Out State tax templates (Sales Or Purchase) for two companies and assign respective tax categories in them
4. Now create a Sales or Purchase Invoice and and select the GST address for the company selected in the Invoice (For eg Company A). Tax Template for Company A should be auto fetched
5. Now create a Sales or Purchase Invoice and and select the GST address for the other company (For eg Company B). Tax Template for Company B should be auto fetched

The above results were not achieved earlier and tax template for the same company (Company A) was fetched in both the steps 4 and 5. This PR fixes that issue.