### PR TITLE
fix: asset finance book depreciation posting date fix

### DIFF
--- a/erpnext/assets/doctype/asset_finance_book/asset_finance_book.json
+++ b/erpnext/assets/doctype/asset_finance_book/asset_finance_book.json
@@ -50,13 +50,11 @@
    "reqd": 1
   },
   {
-   "depends_on": "eval:parent.doctype == 'Asset'",
    "fieldname": "depreciation_start_date",
    "fieldtype": "Date",
    "in_list_view": 1,
    "label": "Depreciation Posting Date",
-   "mandatory_depends_on": "eval:parent.doctype == 'Asset'",
-   "reqd": 1
+   "mandatory_depends_on": "eval:parent.doctype == 'Asset'"
   },
   {
    "default": "0",
@@ -87,7 +85,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-10-30 15:22:29.119868",
+ "modified": "2020-11-05 16:30:09.213479",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset Finance Book",


### PR DESCRIPTION
Fixes: Depreciation Posting Date was mandatory while adding finance book. This date should be mandatory when creating Asset.
