### PR TITLE
refactor: zip_and_download

### DIFF
--- a/erpnext/regional/germany/utils/datev/datev_csv.py
+++ b/erpnext/regional/germany/utils/datev/datev_csv.py
@@ -155,20 +155,22 @@ def get_header(filters, csv_class):
 	return header
 
 
-def download_csv_files_as_zip(csv_data_list):
+def zip_and_download(zip_filename, csv_files):
 	"""
 	Put CSV files in a zip archive and send that to the client.
 
 	Params:
-	csv_data_list -- list of dicts [{'file_name': 'EXTF_Buchunsstapel.zip', 'csv_data': get_datev_csv()}]
+	zip_filename	Name of the zip file
+	csv_files		list of dicts [{'file_name': 'my_file.csv', 'csv_data': 'comma,separated,values'}]
 	"""
 	zip_buffer = BytesIO()
 
-	datev_zip = zipfile.ZipFile(zip_buffer, mode='w', compression=zipfile.ZIP_DEFLATED)
-	for csv_file in csv_data_list:
-		datev_zip.writestr(csv_file.get('file_name'), csv_file.get('csv_data'))
-	datev_zip.close()
+	zip_file = zipfile.ZipFile(zip_buffer, mode='w', compression=zipfile.ZIP_DEFLATED)
+	for csv_file in csv_files:
+		zip_file.writestr(csv_file.get('file_name'), csv_file.get('csv_data'))
+
+	zip_file.close()
 
 	frappe.response['filecontent'] = zip_buffer.getvalue()
-	frappe.response['filename'] = 'DATEV.zip'
+	frappe.response['filename'] = zip_filename
 	frappe.response['type'] = 'binary'

--- a/erpnext/regional/report/datev/datev.py
+++ b/erpnext/regional/report/datev/datev.py
@@ -11,9 +11,10 @@ from __future__ import unicode_literals
 
 import json
 import frappe
-from frappe import _
 from six import string_types
-from erpnext.regional.germany.utils.datev.datev_csv import download_csv_files_as_zip, get_datev_csv
+
+from frappe import _
+from erpnext.regional.germany.utils.datev.datev_csv import zip_and_download, get_datev_csv
 from erpnext.regional.germany.utils.datev.datev_constants import Transactions, DebtorsCreditors, AccountNames
 
 COLUMNS = [
@@ -327,7 +328,8 @@ def download_datev_csv(filters):
 	customers = get_customers(filters)
 	suppliers = get_suppliers(filters)
 
-	download_csv_files_as_zip([
+	zip_name = '{} DATEV.zip'.format(frappe.utils.datetime.date.today())
+	zip_and_download(zip_name, [
 		{
 			'file_name': 'EXTF_Buchungsstapel.csv',
 			'csv_data': get_datev_csv(transactions, filters, csv_class=Transactions)


### PR DESCRIPTION
- Rename badly named method (`download_csv_files_as_zip` ->`zip_and_download`).
- Rename badly named variable (`datev_zip` -> `zip_file`).
- Make `zip_filename` a parameter instead of hardcoding it.
- Include current date in the name of the zip file.