### PR TITLE
refactor: show form buttons only if permissions exist

### DIFF
--- a/erpnext/setup/doctype/company/company.js
+++ b/erpnext/setup/doctype/company/company.js
@@ -90,29 +90,41 @@ frappe.ui.form.on("Company", {
 			frm.toggle_enable("default_currency", (frm.doc.__onload &&
 				!frm.doc.__onload.transactions_exist));
 
-			frm.add_custom_button(__('Create Tax Template'), function() {
-				frm.trigger("make_default_tax_template");
-			});
+			if (frm.has_perm('write')) {
+				frm.add_custom_button(__('Create Tax Template'), function() {
+					frm.trigger("make_default_tax_template");
+				});
+			}
 
-			frm.add_custom_button(__('Cost Centers'), function() {
-				frappe.set_route('Tree', 'Cost Center', {'company': frm.doc.name})
-			}, __("View"));
+			if (frappe.perm.has_perm("Cost Ceter", 0, 'read')) {
+				frm.add_custom_button(__('Cost Centers'), function() {
+					frappe.set_route('Tree', 'Cost Center', {'company': frm.doc.name})
+				}, __("View"));
+			}
 
-			frm.add_custom_button(__('Chart of Accounts'), function() {
-				frappe.set_route('Tree', 'Account', {'company': frm.doc.name})
-			}, __("View"));
+			if (frappe.perm.has_perm("Accounts", 0, 'read')) {
+				frm.add_custom_button(__('Chart of Accounts'), function() {
+					frappe.set_route('Tree', 'Account', {'company': frm.doc.name})
+				}, __("View"));
+			}
 
-			frm.add_custom_button(__('Sales Tax Template'), function() {
-				frappe.set_route('List', 'Sales Taxes and Charges Template', {'company': frm.doc.name});
-			}, __("View"));
+			if (frappe.perm.has_perm("Sales Taxes and Charges Template", 0, 'read')) {
+				frm.add_custom_button(__('Sales Tax Template'), function() {
+					frappe.set_route('List', 'Sales Taxes and Charges Template', {'company': frm.doc.name});
+				}, __("View"));
+			}
 
-			frm.add_custom_button(__('Purchase Tax Template'), function() {
-				frappe.set_route('List', 'Purchase Taxes and Charges Template', {'company': frm.doc.name});
-			}, __("View"));
+			if (frappe.perm.has_perm("Purchase Taxes and Charges Template", 0, 'read')) {
+				frm.add_custom_button(__('Purchase Tax Template'), function() {
+					frappe.set_route('List', 'Purchase Taxes and Charges Template', {'company': frm.doc.name});
+				}, __("View"));
+			}
 
-			frm.add_custom_button(__('Default Tax Template'), function() {
-				frm.trigger("make_default_tax_template");
-			}, __('Create'));
+			if (frm.has_perm('write')) {
+				frm.add_custom_button(__('Default Tax Template'), function() {
+					frm.trigger("make_default_tax_template");
+				}, __('Create'));
+			}
 		}
 
 		erpnext.company.set_chart_of_accounts_options(frm.doc);

--- a/erpnext/setup/doctype/company/company.js
+++ b/erpnext/setup/doctype/company/company.js
@@ -98,13 +98,13 @@ frappe.ui.form.on("Company", {
 
 			if (frappe.perm.has_perm("Cost Ceter", 0, 'read')) {
 				frm.add_custom_button(__('Cost Centers'), function() {
-					frappe.set_route('Tree', 'Cost Center', {'company': frm.doc.name})
+					frappe.set_route('Tree', 'Cost Center', {'company': frm.doc.name});
 				}, __("View"));
 			}
 
 			if (frappe.perm.has_perm("Accounts", 0, 'read')) {
 				frm.add_custom_button(__('Chart of Accounts'), function() {
-					frappe.set_route('Tree', 'Account', {'company': frm.doc.name})
+					frappe.set_route('Tree', 'Account', {'company': frm.doc.name});
 				}, __("View"));
 			}
 

--- a/erpnext/setup/doctype/company/company.js
+++ b/erpnext/setup/doctype/company/company.js
@@ -96,13 +96,13 @@ frappe.ui.form.on("Company", {
 				});
 			}
 
-			if (frappe.perm.has_perm("Cost Ceter", 0, 'read')) {
+			if (frappe.perm.has_perm("Cost Center", 0, 'read')) {
 				frm.add_custom_button(__('Cost Centers'), function() {
 					frappe.set_route('Tree', 'Cost Center', {'company': frm.doc.name});
 				}, __("View"));
 			}
 
-			if (frappe.perm.has_perm("Accounts", 0, 'read')) {
+			if (frappe.perm.has_perm("Account", 0, 'read')) {
 				frm.add_custom_button(__('Chart of Accounts'), function() {
 					frappe.set_route('Tree', 'Account', {'company': frm.doc.name});
 				}, __("View"));


### PR DESCRIPTION
This PR adds permission checks before rendering buttons on the form toolbar

#### Administrator

<img width="1223" alt="Screen Shot 2020-11-06 at 2 35 42 PM" src="https://user-images.githubusercontent.com/18097732/98347450-6c7a9980-203d-11eb-87d8-d323db55fdf6.png">

#### User with limited perms

<img width="1217" alt="Screen Shot 2020-11-06 at 2 34 13 PM" src="https://user-images.githubusercontent.com/18097732/98347516-7f8d6980-203d-11eb-84ca-e922a75b4543.png">
