### PR TITLE
fix: auto fetch sr nos with modifed conversion factor

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -132,15 +132,19 @@ class POSInvoice(SalesInvoice):
 
 			msg = ""
 			item_code = frappe.bold(d.item_code)
+			serial_nos = get_serial_nos(d.serial_no)
 			if serialized and batched and (no_batch_selected or no_serial_selected):
 				msg = (_('Row #{}: Please select a serial no and batch against item: {} or remove it to complete transaction.')
 							.format(d.idx, item_code))
-			if serialized and no_serial_selected:
+			elif serialized and no_serial_selected:
 				msg = (_('Row #{}: No serial number selected against item: {}. Please select one or remove it to complete transaction.')
 							.format(d.idx, item_code))
-			if batched and no_batch_selected:
+			elif batched and no_batch_selected:
 				msg = (_('Row #{}: No batch selected against item: {}. Please select a batch or remove it to complete transaction.')
 							.format(d.idx, item_code))
+			elif serialized and not no_serial_selected and len(serial_nos) != d.qty:
+				msg = (_("Row #{}: You must select {} serial numbers for item {}.").format(d.idx, frappe.bold(cint(d.qty)), item_code))
+
 			if msg:
 				error_msg.append(msg)
 

--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -555,6 +555,8 @@ erpnext.PointOfSale.Controller = class {
 					frappe.utils.play_sound("error");
 					return;
 				}
+				if (!item_code) return;
+
 				item_selected_from_selector && (value = flt(value))
 
 				const args = { item_code, batch_no, [field]: value };

--- a/erpnext/selling/page/point_of_sale/pos_item_details.js
+++ b/erpnext/selling/page/point_of_sale/pos_item_details.js
@@ -372,12 +372,13 @@ erpnext.PointOfSale.ItemDetails = class {
 		this.$form_container.on('click', '.auto-fetch-btn', () => {
 			this.batch_no_control && this.batch_no_control.set_value('');
 			let qty = this.qty_control.get_value();
+			let conversion_factor = this.conversion_factor_control.get_value();
 			let expiry_date = this.item_row.has_batch_no ? this.events.get_frm().doc.posting_date : "";
 
 			let numbers = frappe.call({
 				method: "erpnext.stock.doctype.serial_no.serial_no.auto_fetch_serial_number",
 				args: {
-					qty,
+					qty: qty * conversion_factor,
 					item_code: this.current_item.item_code,
 					warehouse: this.warehouse_control.get_value() || '',
 					batch_nos: this.current_item.batch_no || '',


### PR DESCRIPTION
Problem:
- Select a serialized item in Point of Sale
- Change UOM and Conversion Factor
- Click on Auto Fetch Serial Numbers
- Only 1 serial number will be fetched, while `qty * conversion_factor` sr.nos. should have been fetched