### PR TITLE
fix: incorrect outstanding amount for multicurrency with Reverse Charge

### DIFF
--- a/erpnext/regional/india/utils.py
+++ b/erpnext/regional/india/utils.py
@@ -4,7 +4,7 @@ from frappe import _
 import erpnext
 from frappe.utils import cstr, flt, date_diff, nowdate, round_based_on_smallest_currency_fraction, money_in_words
 from erpnext.regional.india import states, state_numbers
-from erpnext.controllers.taxes_and_totals import get_itemised_tax, get_itemised_taxable_amount
+from erpnext.controllers.taxes_and_totals import get_itemised_tax, get_itemised_taxable_amount, calculate_outstanding_amount
 from erpnext.controllers.accounts_controller import get_taxes_and_charges
 from erpnext.hr.utils import get_salary_assignment
 from erpnext.hr.doctype.salary_structure.salary_structure import make_salary_slip
@@ -689,16 +689,14 @@ def update_totals(gst_tax, base_gst_tax, doc):
 	doc.grand_total -= gst_tax
 
 	if doc.meta.get_field("rounded_total"):
-		if doc.is_rounded_total_disabled():
-			doc.outstanding_amount = doc.grand_total
-		else:
+		if not doc.is_rounded_total_disabled():
 			doc.rounded_total = round_based_on_smallest_currency_fraction(doc.grand_total,
 				doc.currency, doc.precision("rounded_total"))
 
 			doc.rounding_adjustment += flt(doc.rounded_total - doc.grand_total,
 				doc.precision("rounding_adjustment"))
 
-			doc.outstanding_amount = doc.rounded_total or doc.grand_total
+		calculate_outstanding_amount(doc)
 
 	doc.in_words = money_in_words(doc.grand_total, doc.currency)
 	doc.base_in_words = money_in_words(doc.base_grand_total, erpnext.get_company_currency(doc.company))


### PR DESCRIPTION
**Issue**

1. Make purchase invoice with company currency as INR, transaction currency as USD and USD rate as 100$ (make sure country is India)

1. Set Reverse Charge as "Yes" and save

1. After save, outstanding amount is showing as 100 INR which is incorrect

<img width="956" alt="Screenshot 2020-11-09 at 1 33 58 PM" src="https://user-images.githubusercontent.com/8780500/98515641-59f89e00-2291-11eb-9fc2-b766ae8107db.png">


**After Fix**
<img width="752" alt="Screenshot 2020-11-09 at 1 35 31 PM" src="https://user-images.githubusercontent.com/8780500/98515654-5fee7f00-2291-11eb-864a-cb09c7f3b99b.png">
