### PR TITLE
fix: remove check for exempt_from_sales_tax

### DIFF
--- a/erpnext/regional/germany/accounts_controller.py
+++ b/erpnext/regional/germany/accounts_controller.py
@@ -15,8 +15,7 @@ REQUIRED_FIELDS = {
 		},
 		{
 			"field_name": "taxes",
-			"regulation": "§ 14 Abs. 4 Nr. 8 UStG",
-			"condition": "not exempt_from_sales_tax"
+			"regulation": "§ 14 Abs. 4 Nr. 8 UStG"
 		},
 		{
 			"field_name": "customer_address",


### PR DESCRIPTION
Field `exempt_from_sales_tax` is now only available in the US. This led to the following error:

```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench-develop/apps/frappe/frappe/app.py", line 64, in application
    response = frappe.api.handle()
  File "/home/frappe/frappe-bench-develop/apps/frappe/frappe/api.py", line 58, in handle
    return frappe.handler.handle()
  File "/home/frappe/frappe-bench-develop/apps/frappe/frappe/handler.py", line 30, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/frappe-bench-develop/apps/frappe/frappe/handler.py", line 70, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-bench-develop/apps/frappe/frappe/__init__.py", line 1106, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench-develop/apps/frappe/frappe/desk/form/save.py", line 21, in savedocs
    doc.save()
  File "/home/frappe/frappe-bench-develop/apps/frappe/frappe/model/document.py", line 285, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/frappe-bench-develop/apps/frappe/frappe/model/document.py", line 307, in _save
    self.insert()
  File "/home/frappe/frappe-bench-develop/apps/frappe/frappe/model/document.py", line 238, in insert
    self.run_before_save_methods()
  File "/home/frappe/frappe-bench-develop/apps/frappe/frappe/model/document.py", line 947, in run_before_save_methods
    self.run_method("validate")
  File "/home/frappe/frappe-bench-develop/apps/frappe/frappe/model/document.py", line 848, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/frappe-bench-develop/apps/frappe/frappe/model/document.py", line 1133, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/frappe-bench-develop/apps/frappe/frappe/model/document.py", line 1116, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/frappe-bench-develop/apps/frappe/frappe/model/document.py", line 842, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/frappe-bench-develop/apps/erpnext/erpnext/accounts/doctype/sales_invoice/sales_invoice.py", line 71, in validate
    super(SalesInvoice, self).validate()
  File "/home/frappe/frappe-bench-develop/apps/erpnext/erpnext/controllers/selling_controller.py", line 40, in validate
    super(SellingController, self).validate()
  File "/home/frappe/frappe-bench-develop/apps/erpnext/erpnext/controllers/stock_controller.py", line 21, in validate
    super(StockController, self).validate()
  File "/home/frappe/frappe-bench-develop/apps/erpnext/erpnext/controllers/accounts_controller.py", line 108, in validate
    validate_regional(self)
  File "/home/frappe/frappe-bench-develop/apps/erpnext/erpnext/__init__.py", line 129, in caller
    return frappe.get_attr(regional_overrides[region][fn_name])(*args, **kwargs)
  File "/home/frappe/frappe-bench-develop/apps/erpnext/erpnext/regional/germany/accounts_controller.py", line 41, in validate_regional
    if condition and not frappe.safe_eval(condition, doc.as_dict()):
  File "/home/frappe/frappe-bench-develop/apps/frappe/frappe/__init__.py", line 1635, in safe_eval
    return eval(code, eval_globals, eval_locals)
  File "<string>", line 1, in <module>
NameError: name 'exempt_from_sales_tax' is not defined
```