### PR TITLE
fix: customer po no not copy from SI to DI and DI to SI

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -1395,6 +1395,7 @@ def make_delivery_note(source_name, target_doc=None):
 	def set_missing_values(source, target):
 		target.ignore_pricing_rule = 1
 		target.run_method("set_missing_values")
+		target.run_method("set_po_nos")
 		target.run_method("calculate_taxes_and_totals")
 
 	def update_item(source_doc, target_doc, source_parent):

--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -370,8 +370,19 @@ class SellingController(StockController):
 			sales_orders = list(set([d.get(ref_fieldname) for d in self.items if d.get(ref_fieldname)]))
 			if sales_orders:
 				po_nos = frappe.get_all('Sales Order', 'po_no', filters = {'name': ('in', sales_orders)})
-				if po_nos and po_nos[0].get('po_no'):
-					self.po_no = ', '.join(list(set([d.po_no for d in po_nos if d.po_no])))
+
+			elif not sales_orders and self.doctype  == "Sales Invoice":
+				dns = list(set([d.get("delivery_note") for d in self.items if d.get("delivery_note")]))
+				if dns:
+					po_nos = frappe.get_all('Delivery Note', 'po_no', filters = {'name': ('in', dns)})
+
+			elif not sales_orders and self.doctype  == "Delivery Note":
+				invoices = list(set([d.get("against_sales_invoice") for d in self.items if d.get("against_sales_invoice")]))
+				if invoices:
+					po_nos = frappe.get_all('Sales Invoice', 'po_no', filters = {'name': ('in', invoices)})
+
+			if po_nos and po_nos[0].get('po_no'):
+				self.po_no = ', '.join(list(set([d.po_no for d in po_nos if d.po_no])))
 
 	def set_gross_profit(self):
 		if self.doctype == "Sales Order":


### PR DESCRIPTION
1. Make Sales Invoice without sales order and put customer PO number.

1. Make delivery note against the above sales invoice and check customer PO number field in the sales invoice

1. The customer PO number field has no value