### PR TITLE
fix: make contract template editable

### DIFF
--- a/erpnext/crm/doctype/contract_template/contract_template.json
+++ b/erpnext/crm/doctype/contract_template/contract_template.json
@@ -23,8 +23,7 @@
   {
    "fieldname": "contract_terms",
    "fieldtype": "Text Editor",
-   "label": "Contract Terms and Conditions",
-   "read_only": 1
+   "label": "Contract Terms and Conditions"
   },
   {
    "fieldname": "sb_fulfilment",
@@ -45,7 +44,7 @@
   }
  ],
  "links": [],
- "modified": "2020-06-03 00:24:58.179816",
+ "modified": "2020-11-11 17:49:44.879363",
  "modified_by": "Administrator",
  "module": "CRM",
  "name": "Contract Template",


### PR DESCRIPTION
The text editor field in Contract Template was weirdly set to read-only rendering the whole thing useless. 

This should fix https://github.com/frappe/erpnext/issues/23857

![contrac-template](https://user-images.githubusercontent.com/33246109/98811664-36775400-2447-11eb-99e4-62b1a4ee4617.gif)
