### PR TITLE
fix: Handle for custom field IFSC code in Bank remittance report.

### DIFF
--- a/erpnext/payroll/report/bank_remittance/bank_remittance.py
+++ b/erpnext/payroll/report/bank_remittance/bank_remittance.py
@@ -47,33 +47,39 @@ def execute(filters=None):
 			"fieldtype": "Int",
 			"fieldname": "employee_account_no",
 			"width": 50
-		},
-		{
+		}
+	]
+
+	if 'ifsc_code' in frappe.get_meta("Employee")._valid_columns:
+		columns.append({
 			"label": _("IFSC Code"),
 			"fieldtype": "Data",
 			"fieldname": "bank_code",
 			"width": 100
-		},
-		{
-			"label": _("Currency"),
-			"fieldtype": "Data",
-			"fieldname": "currency",
-			"width": 50
-		},
-		{
-			"label": _("Net Salary Amount"),
-			"fieldtype": "Currency",
-			"options": "currency",
-			"fieldname": "amount",
-			"width": 100
-		}
-	]
+		})
+
+	columns += [{
+		"label": _("Currency"),
+		"fieldtype": "Data",
+		"fieldname": "currency",
+		"width": 50
+	},
+	{
+		"label": _("Net Salary Amount"),
+		"fieldtype": "Currency",
+		"options": "currency",
+		"fieldname": "amount",
+		"width": 100
+	}]
+
 	data = []
 
 	accounts = get_bank_accounts()
 	payroll_entries = get_payroll_entries(accounts, filters)
 	salary_slips = get_salary_slips(payroll_entries)
-	get_emp_bank_ifsc_code(salary_slips)
+
+	if 'ifsc_code' in frappe.get_meta("Employee")._valid_columns:
+		get_emp_bank_ifsc_code(salary_slips)
 
 	for salary in salary_slips:
 		if salary.bank_name and salary.bank_account_no and salary.debit_acc_no and salary.status in ["Submitted", "Paid"]:

--- a/erpnext/payroll/report/bank_remittance/bank_remittance.py
+++ b/erpnext/payroll/report/bank_remittance/bank_remittance.py
@@ -50,7 +50,7 @@ def execute(filters=None):
 		}
 	]
 
-	if 'ifsc_code' in frappe.get_meta("Employee")._valid_columns:
+	if frappe.db.has_column('Employee', 'ifsc_code'):
 		columns.append({
 			"label": _("IFSC Code"),
 			"fieldtype": "Data",
@@ -78,7 +78,7 @@ def execute(filters=None):
 	payroll_entries = get_payroll_entries(accounts, filters)
 	salary_slips = get_salary_slips(payroll_entries)
 
-	if 'ifsc_code' in frappe.get_meta("Employee")._valid_columns:
+	if frappe.db.has_column('Employee', 'ifsc_code'):
 		get_emp_bank_ifsc_code(salary_slips)
 
 	for salary in salary_slips:


### PR DESCRIPTION
```
  File "/home/frappe/benches/bench-version-13-2020-11-10/env/lib/python3.6/site-packages/pymysql/connections.py", line 684, in _read_packet
    packet.check_error()
  File "/home/frappe/benches/bench-version-13-2020-11-10/env/lib/python3.6/site-packages/pymysql/protocol.py", line 220, in check_error
    err.raise_mysql_exception(self._data)
  File "/home/frappe/benches/bench-version-13-2020-11-10/env/lib/python3.6/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.InternalError: (1054, "Unknown column 'ifsc_code' in 'field list'")
```
Error  "Unknown column 'ifsc_code' in 'field list'" raised if the region is not India or ifsc field is not in employee master. on opening Bank remittance report.