### PR TITLE
fix: Error handling in Upload Attendance 

### DIFF
--- a/erpnext/hr/doctype/upload_attendance/upload_attendance.js
+++ b/erpnext/hr/doctype/upload_attendance/upload_attendance.js
@@ -24,10 +24,10 @@ erpnext.hr.AttendanceControlPanel = frappe.ui.form.Controller.extend({
 		}
 		window.location.href = repl(frappe.request.url +
 			'?cmd=%(cmd)s&from_date=%(from_date)s&to_date=%(to_date)s', {
-				cmd: "erpnext.hr.doctype.upload_attendance.upload_attendance.get_template",
-				from_date: this.frm.doc.att_fr_date,
-				to_date: this.frm.doc.att_to_date,
-			});
+			cmd: "erpnext.hr.doctype.upload_attendance.upload_attendance.get_template",
+			from_date: this.frm.doc.att_fr_date,
+			to_date: this.frm.doc.att_to_date,
+		});
 	},
 
 	show_upload() {

--- a/erpnext/hr/doctype/upload_attendance/upload_attendance.py
+++ b/erpnext/hr/doctype/upload_attendance/upload_attendance.py
@@ -28,7 +28,12 @@ def get_template():
 	w = UnicodeWriter()
 	w = add_header(w)
 
-	w = add_data(w, args)
+	try:
+		w = add_data(w, args)
+	except Exception as e:
+		frappe.clear_messages()
+		frappe.respond_as_web_page("Holiday List Missing", html=e)
+		return
 
 	# write out response as a type csv
 	frappe.response['result'] = cstr(w.getvalue())


### PR DESCRIPTION
Error handling in Upload Attendance if the holiday list is missing.
Before:
![image](https://user-images.githubusercontent.com/32095923/99065697-c6dfa100-25cd-11eb-91e6-be60d37f8ad5.png)
Now:
![image](https://user-images.githubusercontent.com/32095923/99065803-f7273f80-25cd-11eb-902c-975bbd6b431a.png)
