### PR TITLE
fix: Typo (Enchashment > Encashment)

### DIFF
--- a/erpnext/patches/v12_0/generate_leave_ledger_entries.py
+++ b/erpnext/patches/v12_0/generate_leave_ledger_entries.py
@@ -51,7 +51,7 @@ def generate_encashment_leave_ledger_entries():
 
 	for encashment in leave_encashments:
 		if not frappe.db.exists("Leave Ledger Entry", {'transaction_type': 'Leave Encashment', 'transaction_name': encashment.name}):
-			frappe.get_doc("Leave Enchashment", encashment).create_leave_ledger_entry()
+			frappe.get_doc("Leave Encashment", encashment).create_leave_ledger_entry()
 
 def generate_expiry_allocation_ledger_entries():
 	''' fix ledger entries for missing leave allocation transaction '''


### PR DESCRIPTION
Fixes following error while migration
```
File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/site.py", line 287, in migrate
    migrate(context.verbose, rebuild_website=rebuild_website, skip_failing=skip_failing)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py", line 48, in migrate
    frappe.modules.patch_handler.run_all(skip_failing)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 41, in run_all
    run_patch(patch)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 30, in run_patch
    if not run_single(patchmodule = patch):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 71, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 91, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/patches/v12_0/generate_leave_ledger_entries.py", line 21, in execute
    generate_encashment_leave_ledger_entries()
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/patches/v12_0/generate_leave_ledger_entries.py", line 54, in generate_encashment_leave_ledger_entries
    frappe.get_doc("Leave Enchashment", encashment).create_leave_ledger_entry()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 762, in get_doc
    doc = frappe.model.document.get_doc(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 69, in get_doc
    controller = get_controller(doctype)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/base_document.py", line 48, in get_controller
    module = load_doctype_module(doctype, module_name)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/utils.py", line 206, in load_doctype_module
    raise ImportError('Module import failed for {0} ({1})'.format(doctype, module_name + ' Error: ' + str(e)))
ImportError: Module import failed for Leave Enchashment (frappe.core.doctype.leave_enchashment.leave_enchashment Error: No module named 'frappe.core.doctype.leave_enchashment')
```