### PR TITLE
fix: validation for membership

### DIFF
--- a/erpnext/non_profit/doctype/membership/membership.py
+++ b/erpnext/non_profit/doctype/membership/membership.py
@@ -70,7 +70,7 @@ class Membership(Document):
 		settings = frappe.get_doc("Membership Settings")
 
 		if not member.customer:
-			frappe.throw(_("No customer linked to member {}", [member.name]))
+			frappe.throw(_("No customer linked to member {0}").format(frappe.bold(self.member)))
 
 		if not settings.debit_account:
 			frappe.throw(_("You need to set <b>Debit Account</b> in Membership Settings"))


### PR DESCRIPTION
```
  File "/home/frappe/benches/bench-version-13-2020-11-10/apps/frappe/frappe/model/document.py", line 1099, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-version-13-2020-11-10/apps/frappe/frappe/model/document.py", line 825, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-version-13-2020-11-10/apps/erpnext/erpnext/non_profit/doctype/membership/membership.py", line 73, in generate_invoice
    frappe.throw(_("No customer linked to member {}", [member.name]))
  File "/home/frappe/benches/bench-version-13-2020-11-10/apps/frappe/frappe/__init__.py", line 81, in _
    translated_string = get_full_dict(lang).get(msg)
  File "/home/frappe/benches/bench-version-13-2020-11-10/apps/frappe/frappe/translate.py", line 190, in get_full_dict
    frappe.local.lang_full_dict = load_lang(lang)
  File "/home/frappe/benches/bench-version-13-2020-11-10/apps/frappe/frappe/translate.py", line 209, in load_lang
    out = frappe.cache().hget("lang_full_dict", lang, shared=True)
  File "/home/frappe/benches/bench-version-13-2020-11-10/apps/frappe/frappe/utils/redis_wrapper.py", line 178, in hget
    if key in frappe.local.cache[_name]:
TypeError: unhashable type: 'list'
```