### PR TITLE
fix: only set to none auto created batches

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -243,11 +243,11 @@ class StockController(AccountsController):
 
 	def delete_auto_created_batches(self):
 		from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos
-  
 		def set_auto_created_batch_to_none(batch_no):
-			item = list(filter(lambda x: x.batch_no == batch_no, self.items))
-			item.batch_no = None
-			item.db_set("batch_no", None)
+  
+			for item in filter(lambda x: x.batch_no == batch_no, self.items):
+				item.batch_no = None
+				item.db_set("batch_no", None)
 
 		for d in self.items:
 			if not d.batch_no: continue

--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -243,6 +243,12 @@ class StockController(AccountsController):
 
 	def delete_auto_created_batches(self):
 		from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos
+  
+		def set_auto_created_batch_to_none(batch_no):
+			item = list(filter(lambda x: x.batch_no == batch_no, self.items))
+			item.batch_no = None
+			item.db_set("batch_no", None)
+
 		for d in self.items:
 			if not d.batch_no: continue
 
@@ -250,12 +256,11 @@ class StockController(AccountsController):
 			if serial_nos:
 				frappe.db.set_value("Serial No", { 'name': ['in', serial_nos] }, "batch_no", None)
 
-			d.batch_no = None
-			d.db_set("batch_no", None)
-
 		for data in frappe.get_all("Batch",
 			{'reference_name': self.name, 'reference_doctype': self.doctype}):
 			frappe.delete_doc("Batch", data.name)
+   
+			set_auto_created_batch_to_none(data.name)
 
 	def get_sl_entries(self, d, args):
 		sl_dict = frappe._dict({

--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -243,8 +243,8 @@ class StockController(AccountsController):
 
 	def delete_auto_created_batches(self):
 		from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos
-		def set_auto_created_batch_to_none(batch_no):
   
+		def set_auto_created_batch_to_none(batch_no):
 			for item in filter(lambda x: x.batch_no == batch_no, self.items):
 				item.batch_no = None
 				item.db_set("batch_no", None)


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

In Stock Reconciliation, only auto-created batches should be set to None, if we set to None all of them, it becomes difficult when trying only to amend the Stock Reconciliation, last behavior was that we have to set all (batch, qty and valuation rate)

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
