### PR TITLE
fix(regional): set proper state code in ewaybill JSON when gst_category is SEZ

### DIFF
--- a/erpnext/regional/india/utils.py
+++ b/erpnext/regional/india/utils.py
@@ -502,6 +502,9 @@ def get_address_details(data, doc, company_address, billing_address):
 		data.actualToStateCode = data.toStateCode
 		shipping_address = billing_address
 
+	if doc.gst_category == 'SEZ':
+		data.toStateCode = 99
+
 	return data
 
 def get_item_list(data, doc):


### PR DESCRIPTION
E-waybill website screenshot - Required Bill to State is `Other Countries` with state code `99` for SEZ.

![E-WayBill for SEZ](https://user-images.githubusercontent.com/10496564/99507572-8e630d00-29a9-11eb-9e41-f58b38f1a501.png)

E-waybill upload works after bill to state is given code `99`.

![EwayBill](https://user-images.githubusercontent.com/10496564/99507982-13e6bd00-29aa-11eb-8237-82e95b24d911.png)
