### PR TITLE
fix: incorrect delink serial no and batch

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -229,9 +229,9 @@ class StockController(AccountsController):
 
 	def check_expense_account(self, item):
 		if not item.get("expense_account"):
-			frappe.throw(_("Row #{0}: Expense Account not set for Item {1}. Please set an Expense \
-				Account in the Items table").format(item.idx, frappe.bold(item.item_code)),
-				title=_("Expense Account Missing"))
+			msg = _("Please set an Expense Account in the Items table")
+			frappe.throw(_("Row #{0}: Expense Account not set for the Item {1}. {2}")
+				.format(item.idx, frappe.bold(item.item_code), msg), title=_("Expense Account Missing"))
 
 		else:
 			is_expense_account = frappe.db.get_value("Account",
@@ -247,7 +247,9 @@ class StockController(AccountsController):
 		for d in self.items:
 			if not d.batch_no: continue
 
-			serial_nos = [sr.name for sr in frappe.get_all("Serial No", {'batch_no': d.batch_no})]
+			serial_nos = [sr.name for sr in frappe.get_all("Serial No",
+				{'batch_no': d.batch_no, 'status': 'Inactive'})]
+
 			if serial_nos:
 				frappe.db.set_value("Serial No", { 'name': ['in', serial_nos] }, "batch_no", None)
 


### PR DESCRIPTION
**Issue**

1. Create a new item "Test Serial and Batch No" and enable Has Serial No and Has Batch No checkbox

1. Make purchase receipt with qty as 5

1. Make work order with raw materials as "Test Serial and Batch No" and make manufacture entry with 5 qty.

1. Cancel and amend the Manufacture stock entry, while saving again you will get the below error.

<img width="648" alt="Screenshot 2020-11-18 at 5 58 45 PM" src="https://user-images.githubusercontent.com/8780500/99531021-1fe17780-29c8-11eb-84c0-add14965fb9d.png">


System delink the batch and serial no even if the batch was not created first time against the Manufacture stock entry

