### PR TITLE
fix: email digest user not found

### DIFF
--- a/erpnext/setup/doctype/email_digest/email_digest.py
+++ b/erpnext/setup/doctype/email_digest/email_digest.py
@@ -48,12 +48,8 @@ class EmailDigest(Document):
 		recipients = list(filter(lambda r: r in valid_users,
 			self.recipient_list.split("\n")))
 
-		original_user = frappe.session.user
-
 		if recipients:
 			for user_id in recipients:
-				frappe.set_user(user_id)
-				frappe.set_user_lang(user_id)
 				msg_for_this_recipient = self.get_msg_html()
 				if msg_for_this_recipient:
 					frappe.sendmail(
@@ -63,9 +59,6 @@ class EmailDigest(Document):
 						reference_doctype = self.doctype,
 						reference_name = self.name,
 						unsubscribe_message = _("Unsubscribe from this Email Digest"))
-
-		frappe.set_user(original_user)
-		frappe.set_user_lang(original_user)
 
 	def get_msg_html(self):
 		"""Build email digest content"""


### PR DESCRIPTION
**Issue:**
1. In an Email Digest, after clicking Send Now, the whole site used to become inaccessible and an error used to appear.

![user not found](https://user-images.githubusercontent.com/31363128/99530903-f3c5f680-29c7-11eb-80be-0dfae35a3cc8.png)

2. This used to happen because on clicking Send Now, the code was setting the recipient of email as the session user, send the email, and then reset the original user as session user.
3. For all this frappe.set_user function was used and this function clears the session after the user gets set. Hence the error.

**Fix:** Not changing the session user before sending the email.
