### PR TITLE
fix: Customer Ledger Summary report not working on python 3

### DIFF
--- a/erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py
+++ b/erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py
@@ -286,14 +286,14 @@ class PartyLedgerSummaryReport(object):
 
 			if parties and accounts:
 				if len(parties) == 1:
-					party = parties.keys()[0]
+					party = list(parties.keys())[0]
 					for account, amount in iteritems(accounts):
 						self.party_adjustment_accounts.add(account)
 						self.party_adjustment_details.setdefault(party, {})
 						self.party_adjustment_details[party].setdefault(account, 0)
 						self.party_adjustment_details[party][account] += amount
 				elif len(accounts) == 1 and not has_irrelevant_entry:
-					account = accounts.keys()[0]
+					account = list(accounts.keys())[0]
 					self.party_adjustment_accounts.add(account)
 					for party, amount in iteritems(parties):
 						self.party_adjustment_details.setdefault(party, {})


### PR DESCRIPTION
**Issue**

In Python 3, keys() returns a dict_keys object and not a list
```
  File "/home/frappe/benches/bench-2019-09-16/apps/erpnext/erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py", line 289, in get_party_adjustment_amounts
    party = parties.keys()[0]
TypeError: 'dict_keys' object does not support indexing
```

Backport `version-11` for #19092