### PR TITLE
fix: Invoice generation for Unpaid subscriptions

### DIFF
--- a/erpnext/accounts/doctype/subscription/subscription.json
+++ b/erpnext/accounts/doctype/subscription/subscription.json
@@ -13,6 +13,7 @@
   "cancelation_date",
   "trial_period_start",
   "trial_period_end",
+  "generate_new_invoices_past_due_date",
   "column_break_11",
   "current_invoice_start",
   "current_invoice_end",
@@ -183,8 +184,7 @@
    "fieldname": "invoices",
    "fieldtype": "Table",
    "label": "Invoices",
-   "options": "Subscription Invoice",
-   "read_only": 1
+   "options": "Subscription Invoice"
   },
   {
    "collapsible": 1,
@@ -195,9 +195,16 @@
   {
    "fieldname": "dimension_col_break",
    "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "description": "New invoices will be generated as per schedule even if current invoices are unpaid or past due date",
+   "fieldname": "generate_new_invoices_past_due_date",
+   "fieldtype": "Check",
+   "label": "Generate New Invoices Past Due Date"
   }
  ],
- "modified": "2020-08-27 23:30:02.504042",
+ "modified": "2020-11-29 22:46:14.879289",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Subscription",

--- a/erpnext/accounts/doctype/subscription/subscription.py
+++ b/erpnext/accounts/doctype/subscription/subscription.py
@@ -412,7 +412,7 @@ class Subscription(Document):
 				self.update_subscription_period(add_days(self.current_invoice_end, 1))
 
 			# Generate invoices periodically even if current invoice are unpaid
-			if not self.is_current_invoice_generated() and (self.is_postpaid_to_invoice()
+			if self.generate_new_invoices_past_due_date and not self.is_current_invoice_generated() and (self.is_postpaid_to_invoice()
 				or self.is_prepaid_to_invoice()):
 				prorate = frappe.db.get_single_value('Subscription Settings', 'prorate')
 				self.generate_invoice(prorate)

--- a/erpnext/accounts/doctype/subscription/subscription.py
+++ b/erpnext/accounts/doctype/subscription/subscription.py
@@ -408,6 +408,15 @@ class Subscription(Document):
 			else:
 				self.set_status_grace_period()
 
+			if getdate() > getdate(self.current_invoice_end):
+				self.update_subscription_period(add_days(self.current_invoice_end, 1))
+
+			# Generate invoices periodically even if current invoice are unpaid
+			if not self.is_current_invoice_generated() and (self.is_postpaid_to_invoice()
+				or self.is_prepaid_to_invoice()):
+				prorate = frappe.db.get_single_value('Subscription Settings', 'prorate')
+				self.generate_invoice(prorate)
+
 	@staticmethod
 	def is_not_outstanding(invoice):
 		"""


### PR DESCRIPTION
Backported check to generate new invoice past due date for the PR https://github.com/frappe/erpnext/pull/22263

<img width="1223" alt="Screenshot 2020-12-02 at 1 39 46 PM" src="https://user-images.githubusercontent.com/42651287/100845924-e9196000-34a3-11eb-946a-c30ff3d5d7b4.png">
