### PR TITLE
fix: purchase receipt to purchase invoice bill date mapping

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -536,7 +536,8 @@ def make_purchase_invoice(source_name, target_doc=None):
 			"doctype": "Purchase Invoice",
 			"field_map": {
 				"supplier_warehouse":"supplier_warehouse",
-				"is_return": "is_return"
+				"is_return": "is_return",
+				"bill_date": "bill_date"
 			},
 			"validation": {
 				"docstatus": ["=", 1],


### PR DESCRIPTION
**Issue:**

On creating a Purchase Invoice from a Purchase Receipt, the Bill Date field of Purchase Receipt was not getting mapped to Supplier Invoice Date field of Purchase Invoice.

![bill date mapping issue](https://user-images.githubusercontent.com/31363128/99765013-37ce0e00-2b24-11eb-9455-ef2b00ce465b.png)

