### PR TITLE
fix: incorrect delink serial no and batch

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -247,16 +247,17 @@ class StockController(AccountsController):
 		for d in self.items:
 			if not d.batch_no: continue
 
+			serial_nos = [sr.name for sr in frappe.get_all("Serial No",
+				{'batch_no': d.batch_no, 'status': 'Inactive'})]
+
+			if serial_nos:
+				frappe.db.set_value("Serial No", { 'name': ['in', serial_nos] }, "batch_no", None)
+
 			d.batch_no = None
 			d.db_set("batch_no", None)
 
 		for data in frappe.get_all("Batch",
 			{'reference_name': self.name, 'reference_doctype': self.doctype}):
-
-			serial_nos = [sr.name for sr in frappe.get_all("Serial No", {'batch_no': data.name})]
-			if serial_nos:
-				frappe.db.set_value("Serial No", { 'name': ['in', serial_nos] }, "batch_no", None)
-
 			frappe.delete_doc("Batch", data.name)
 
 	def get_sl_entries(self, d, args):


### PR DESCRIPTION
**Issue**

1. Create a new item "Test Serial and Batch No" and enable Has Serial No and Has Batch No checkbox

1. Make purchase receipt with qty as 5

1. Make work order with raw materials as "Test Serial and Batch No" and make manufacture entry with 5 qty.

1. Cancel and amend the Manufacture stock entry, while saving again you will get the below error.

<img width="648" alt="Screenshot 2020-11-18 at 5 58 45 PM" src="https://user-images.githubusercontent.com/8780500/99531021-1fe17780-29c8-11eb-84c0-add14965fb9d.png">


System delink the batch and serial no even if the batch was not created first time against the Manufacture stock entry

