### PR TITLE
fix: clear error message when approval not available

### DIFF
--- a/erpnext/hr/doctype/department_approver/department_approver.py
+++ b/erpnext/hr/doctype/department_approver/department_approver.py
@@ -20,7 +20,7 @@ def get_approvers(doctype, txt, searchfield, start, page_len, filters):
 	approvers = []
 	department_details = {}
 	department_list = []
-	employee = frappe.get_value("Employee", filters.get("employee"), ["department", "leave_approver", "expense_approver", "shift_request_approver"], as_dict=True)
+	employee = frappe.get_value("Employee", filters.get("employee"), ["employee_name","department", "leave_approver", "expense_approver", "shift_request_approver"], as_dict=True)
 
 	employee_department = filters.get("department") or employee.department
 	if employee_department:
@@ -59,11 +59,9 @@ def get_approvers(doctype, txt, searchfield, start, page_len, filters):
 				and approver.approver=user.name""",(d, "%" + txt + "%", parentfield), as_list=True)
 
 	if len(approvers) == 0:
-		frappe.throw(_("Please set {0} for the Employee or for Department: {1}").
-			format(
-				field_name, frappe.bold(employee_department),
-				frappe.bold(employee.name)
-			),
-			title=_(field_name + " Missing"))
+		error_msg = _("Please set {0} for the Employee: {1}").format(field_name, frappe.bold(employee.employee_name))
+		if department_list:
+			error_msg += _(" or for Department: {0}").format(frappe.bold(employee_department))
+		frappe.throw(error_msg, title=_(field_name + " Missing"))
 
 	return set(tuple(approver) for approver in approvers)


### PR DESCRIPTION
Steps:

Go to Leave Application, apply for leave
Make sure there is NO leave approver assigned at dept level or employee level.

You get the below error

![](https://frappe.io/files/6H2Nmo4.gif)

Unable to handle failed response
request.js:275 SyntaxError: Unexpected token < in JSON at position 0
  at JSON.parse (<anonymous>)
  at Object.frappe.request.report_error (erpnext_support.js:409)
  at 500 (request.js:188)
  at Object.<anonymous> (request.js:268)
  at i (jquery.min.js:2)
  at Object.fireWith [as rejectWith] (jquery.min.js:2)
  at z (jquery.min.js:4)
  at XMLHttpRequest.<anonymous> (jquery.min.js:4)
(anonymous) @ request.js:275
i @ jquery.min.js:2
fireWith @ jquery.min.js:2
z @ jquery.min.js:4
(anonymous) @ jquery.min.js:4
desk.js:151

Now it gives proper error message:
![Screenshot 2020-11-20 at 1 10 15 PM](https://user-images.githubusercontent.com/33727827/99774210-81722500-2b33-11eb-81a0-c4e4ea894cf0.png)
