### PR TITLE
fix: Validation for journal entry with 0 debit and credit values

### DIFF
--- a/erpnext/accounts/doctype/invoice_discounting/invoice_discounting.py
+++ b/erpnext/accounts/doctype/invoice_discounting/invoice_discounting.py
@@ -137,11 +137,12 @@ class InvoiceDiscounting(AccountsController):
 			"cost_center": erpnext.get_default_cost_center(self.company)
 		})
 
-		je.append("accounts", {
-			"account": self.bank_charges_account,
-			"debit_in_account_currency": flt(self.bank_charges),
-			"cost_center": erpnext.get_default_cost_center(self.company)
-		})
+		if self.bank_charges:
+			je.append("accounts", {
+				"account": self.bank_charges_account,
+				"debit_in_account_currency": flt(self.bank_charges),
+				"cost_center": erpnext.get_default_cost_center(self.company)
+			})
 
 		je.append("accounts", {
 			"account": self.short_term_loan,

--- a/erpnext/accounts/doctype/invoice_discounting/test_invoice_discounting.py
+++ b/erpnext/accounts/doctype/invoice_discounting/test_invoice_discounting.py
@@ -80,6 +80,7 @@ class TestInvoiceDiscounting(unittest.TestCase):
 			short_term_loan=self.short_term_loan,
 			bank_charges_account=self.bank_charges_account,
 			bank_account=self.bank_account,
+			bank_charges=100
 			)
 
 		je = inv_disc.create_disbursement_entry()
@@ -289,6 +290,7 @@ def create_invoice_discounting(invoices, **args):
 	inv_disc.bank_account=args.bank_account
 	inv_disc.loan_start_date = args.start or nowdate()
 	inv_disc.loan_period = args.period or 30
+	inv_disc.bank_charges = flt(args.bank_charges)
 
 	for d in invoices:
 		inv_disc.append("invoices", {

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -34,6 +34,7 @@ class JournalEntry(AccountsController):
 		self.validate_entries_for_advance()
 		self.validate_multi_currency()
 		self.set_amounts_in_company_currency()
+		self.validate_debit_credit_amount()
 		self.validate_total_debit_and_credit()
 		self.validate_against_jv()
 		self.validate_reference_doc()
@@ -368,6 +369,11 @@ class JournalEntry(AccountsController):
 		for d in self.get("accounts"):
 			if flt(d.debit > 0): d.against_account = ", ".join(list(set(accounts_credited)))
 			if flt(d.credit > 0): d.against_account = ", ".join(list(set(accounts_debited)))
+
+	def validate_debit_credit_amount(self):
+		for d in self.get('accounts'):
+			if not flt(d.debit) and not flt(d.credit):
+				frappe.throw(_("Row {0}: Both Debit and Credit values cannot be zero").format(d.idx))
 
 	def validate_total_debit_and_credit(self):
 		self.set_total_debit_credit()


### PR DESCRIPTION
Journal Entry with absolutely 0 debit and credit values was allowed to created.

<img width="1213" alt="Screenshot 2020-11-21 at 12 07 47 PM" src="https://user-images.githubusercontent.com/42651287/99869618-a4afd980-2bf2-11eb-90e1-764661e656c6.png">

This PR adds a validation for it
<img width="1224" alt="Screenshot 2020-11-21 at 12 07 39 PM" src="https://user-images.githubusercontent.com/42651287/99869633-b4c7b900-2bf2-11eb-8f75-4ce57637332a.png">

