### PR TITLE
fix: Update .pylintrc

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,1 +1,5 @@
+[MESSAGES CONTROL]
 disable=access-member-before-definition
+
+[FORMAT]
+indent-string='\t'


### PR DESCRIPTION
pylint fails without headers. This adds the needed headers and allows tabs instead of spaces
