### PR TITLE
fix: job card error handling for operations field

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -353,17 +353,19 @@ def get_operation_details(work_order, operation):
 
 @frappe.whitelist()
 def get_operations(doctype, txt, searchfield, start, page_len, filters):
-	if filters.get("work_order"):
-		args = {"parent": filters.get("work_order")}
-		if txt:
-			args["operation"] = ("like", "%{0}%".format(txt))
+	if not filters.get("work_order"):
+		frappe.msgprint(_("Please select a Work Order first."))
+		return []
+	args = {"parent": filters.get("work_order")}
+	if txt:
+		args["operation"] = ("like", "%{0}%".format(txt))
 
-		return frappe.get_all("Work Order Operation",
-			filters = args,
-			fields = ["distinct operation as operation"],
-			limit_start = start,
-			limit_page_length = page_len,
-			order_by="idx asc", as_list=1)
+	return frappe.get_all("Work Order Operation",
+		filters = args,
+		fields = ["distinct operation as operation"],
+		limit_start = start,
+		limit_page_length = page_len,
+		order_by="idx asc", as_list=1)
 
 @frappe.whitelist()
 def make_material_request(source_name, target_doc=None):


### PR DESCRIPTION
**Issue:**

1. In a Job Card, the Operation field has a filter based on the Work Order selected.
2. So when the user clicks on the Operation field without selecting a Work Order, an error appears.


![Screenshot 2020-11-24 at 3 44 19 PM](https://user-images.githubusercontent.com/31363128/100080576-0169f900-2e6c-11eb-8ab1-4550abe1c17b.png)

**Fix:**

1. Error handling for the scenario where the Operation field is clicked before selecting Work Order.
2. Message is displayed to the user asking them to select a Work Order in this scenario.

![Screenshot 2020-11-24 at 3 40 58 PM](https://user-images.githubusercontent.com/31363128/100080331-b5b74f80-2e6b-11eb-827c-6b02fba73118.png)



