### PR TITLE
fix: bom stock report color showing always red

### DIFF
--- a/erpnext/manufacturing/report/bom_stock_report/bom_stock_report.js
+++ b/erpnext/manufacturing/report/bom_stock_report/bom_stock_report.js
@@ -25,8 +25,8 @@ frappe.query_reports["BOM Stock Report"] = {
 	],
 	"formatter": function(value, row, column, data, default_formatter) {
 		value = default_formatter(value, row, column, data);
-		if (column.id == "item"){
-			if (data["Enough Parts to Build"] > 0){
+		if (column.id == "item") {
+			if (data["enough_parts_to_build"] > 0) {
 				value = `<a style='color:green' href="#Form/Item/${data['item']}" data-doctype="Item">${data['item']}</a>`;
 			} else {
 				value = `<a style='color:red' href="#Form/Item/${data['item']}" data-doctype="Item">${data['item']}</a>`;


### PR DESCRIPTION
**Issue**

Stock available still showing in the red color

<img width="948" alt="Screenshot 2020-11-24 at 4 53 51 PM" src="https://user-images.githubusercontent.com/8780500/100088495-37ac7600-2e76-11eb-86f8-9a0aa8416b9b.png">


**After Fix**

<img width="963" alt="Screenshot 2020-11-24 at 4 55 37 PM" src="https://user-images.githubusercontent.com/8780500/100088530-45fa9200-2e76-11eb-858d-5fc64a548630.png">
