### PR TITLE
Filters for tax templates

### DIFF
--- a/erpnext/accounts/doctype/pos_profile/pos_profile.js
+++ b/erpnext/accounts/doctype/pos_profile/pos_profile.js
@@ -35,6 +35,15 @@ frappe.ui.form.on('POS Profile', {
 			};
 		});
 
+		frm.set_query("taxes_and_charges", function() {
+			return {
+				filters: [
+					['Sales Taxes and Charges Template', 'company', '=', frm.doc.company],
+					['Sales Taxes and Charges Template', 'docstatus', '!=', 2]
+				]
+			};
+		});
+
 		frm.set_query('company_address', function(doc) {
 			if(!doc.company) {
 				frappe.throw(__('Please set Company'));

--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -28,6 +28,15 @@ frappe.ui.form.on("Purchase Order", {
 			}
 		});
 
+		frm.set_query("taxes_and_charges", function() {
+			return {
+				filters: [
+					['Sales Taxes and Charges Template', 'company', '=', frm.doc.company],
+					['Sales Taxes and Charges Template', 'docstatus', '!=', 2]
+				]
+			};
+		});
+
 	},
 
 	onload: function(frm) {

--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -28,15 +28,6 @@ frappe.ui.form.on("Purchase Order", {
 			}
 		});
 
-		frm.set_query("taxes_and_charges", function() {
-			return {
-				filters: [
-					['Sales Taxes and Charges Template', 'company', '=', frm.doc.company],
-					['Sales Taxes and Charges Template', 'docstatus', '!=', 2]
-				]
-			};
-		});
-
 	},
 
 	onload: function(frm) {

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -213,8 +213,8 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 			this.frm.set_query("taxes_and_charges", function() {
 				return {
 					filters: [
-						['Sales Taxes and Charges Template', 'company', '=', me.frm.doc.company],
-						['Sales Taxes and Charges Template', 'docstatus', '!=', 2]
+						['company', '=', me.frm.doc.company],
+						['docstatus', '!=', 2]
 					]
 				};
 			});

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -209,6 +209,17 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 			});
 		}
 
+		if(this.frm.fields_dict.taxes_and_charges) {
+			this.frm.set_query("taxes_and_charges", function() {
+				return {
+					filters: [
+						['Sales Taxes and Charges Template', 'company', '=', me.frm.doc.company],
+						['Sales Taxes and Charges Template', 'docstatus', '!=', 2]
+					]
+				}
+			});
+		}
+
 	},
 	onload: function() {
 		var me = this;

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -209,14 +209,14 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 			});
 		}
 
-		if(this.frm.fields_dict.taxes_and_charges) {
+		if (this.frm.fields_dict.taxes_and_charges) {
 			this.frm.set_query("taxes_and_charges", function() {
 				return {
 					filters: [
 						['Sales Taxes and Charges Template', 'company', '=', me.frm.doc.company],
 						['Sales Taxes and Charges Template', 'docstatus', '!=', 2]
 					]
-				}
+				};
 			});
 		}
 

--- a/erpnext/selling/sales_common.js
+++ b/erpnext/selling/sales_common.js
@@ -42,16 +42,6 @@ erpnext.selling.SellingController = erpnext.TransactionController.extend({
 		me.frm.set_query('customer_address', erpnext.queries.address_query);
 		me.frm.set_query('shipping_address_name', erpnext.queries.address_query);
 
-		if(this.frm.fields_dict.taxes_and_charges) {
-			this.frm.set_query("taxes_and_charges", function() {
-				return {
-					filters: [
-						['Sales Taxes and Charges Template', 'company', '=', me.frm.doc.company],
-						['Sales Taxes and Charges Template', 'docstatus', '!=', 2]
-					]
-				}
-			});
-		}
 
 		if(this.frm.fields_dict.selling_price_list) {
 			this.frm.set_query("selling_price_list", function() {

--- a/erpnext/selling/sales_common.js
+++ b/erpnext/selling/sales_common.js
@@ -469,7 +469,7 @@ frappe.ui.form.on(cur_frm.doctype,"project", function(frm) {
 						$.each(frm.doc["items"] || [], function(i, row) {
 							if(r.message) {
 								frappe.model.set_value(row.doctype, row.name, "cost_center", r.message);
-								frappe.msgprint(__("Cost Center For Item with Item Code '"+row.item_name+"' has been Changed to "+ r.message));
+								frappe.msgprint(__("Cost Center For Item with Item Code {0} has been Changed to {1}", [row.item_name, r.message]));
 							}
 						})
 					}


### PR DESCRIPTION
This PR elevates the application of "company filter" on "taxes and charges templates" from SellingController to TransactionController and also on POS profile

Previously only on doctypes that extended SellingController like SO used to get the filter now all doctypes that extend TranactionController(PO, PI, etc) will get it.

This solves the issue when the user selects the wrong template (usually of another company) and then gets the error on save(very common)

Improves usability since there can be lots of templates defined.

