### PR TITLE
fix: Loan disbursement amount validation

### DIFF
--- a/erpnext/loan_management/doctype/loan/loan.json
+++ b/erpnext/loan_management/doctype/loan/loan.json
@@ -332,6 +332,7 @@
    "read_only": 1
   },
   {
+   "depends_on": "eval:doc.is_secured_loan",
    "fetch_from": "loan_application.maximum_loan_amount",
    "fieldname": "maximum_loan_amount",
    "fieldtype": "Currency",
@@ -352,7 +353,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2020-11-05 10:04:00.762975",
+ "modified": "2020-11-24 12:27:23.208240",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan",


### PR DESCRIPTION
In real life scenarios there may a delay in actual Loan Disbursement from bank account and the Loan Disbursement entry being posted in the system.

Within this course of time the loan security prices may change which in turn changes the possible loan disbursal amount. This causes an issue while posting the Loan Disbursement entry if the disbursed amount is greater than the current loan disbursement amount (based on current loan security prices)

This PR fixes that issue 