### PR TITLE
fix: don't override po_no

### DIFF
--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -372,6 +372,9 @@ class SellingController(StockController):
 
 	def set_pos_for_sales_invoice(self):
 		po_nos = []
+		if self.po_no:
+			po_nos.append(self.po_no)
+			
 		self.get_po_nos('Sales Order', 'sales_order', po_nos)
 		self.get_po_nos('Delivery Note', 'delivery_note', po_nos)
 		self.po_no = ', '.join(list(set(x.strip() for x in ','.join(po_nos).split(','))))


### PR DESCRIPTION
## Steps to replicate

1. Set `po_no` field in Sales Invoice as mandatory, from customize form
1. Fill the values and try to save the document, the customer/items should not have any pending transactions.
1. You'll get a mandatory server error.

## Problem

The following piece in `selling_controller` run in `validate` resets the `po_no`

https://github.com/frappe/erpnext/blob/755b773616cb7e037e2034d2bc0e396f36580a3f/erpnext/controllers/selling_controller.py#L379-L383

This also means that if we do not set the field as mandatory, the value will just be reset blindly

## The Fix

The fix appends the generated values to existing values. The other option is to see if any value is present, if it is then we don't override that value.

Frappe Issue List: [ISS-20-21-07185](https://frappe.io/desk#Form/Issue/ISS-20-21-07185)