### PR TITLE
fix: shipping charges not sync from shopify

### DIFF
--- a/erpnext/erpnext_integrations/connectors/shopify_connection.py
+++ b/erpnext/erpnext_integrations/connectors/shopify_connection.py
@@ -244,6 +244,15 @@ def update_taxes_with_shipping_lines(taxes, shipping_lines, shopify_settings):
 	"""Shipping lines represents the shipping details,
 		each such shipping detail consists of a list of tax_lines"""
 	for shipping_charge in shipping_lines:
+		if shipping_charge.get("price"):
+			taxes.append({
+				"charge_type": _("Actual"),
+				"account_head": get_tax_account_head(shipping_charge),
+				"description": shipping_charge["title"],
+				"tax_amount": shipping_charge["price"],
+				"cost_center": shopify_settings.cost_center
+			})
+
 		for tax in shipping_charge.get("tax_lines"):
 			taxes.append({
 				"charge_type": _("Actual"),


### PR DESCRIPTION
If shipping charges added in the Shopify then while syncing orders with erpnext the rates are not added