### PR TITLE
feat: adds item filter in buying doctypes on selected supplier

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
@@ -63,6 +63,7 @@
   "supplier_warehouse",
   "items_section",
   "update_stock",
+  "filter_items_by_supplier",
   "scan_barcode",
   "items",
   "pricing_rule_details",
@@ -1291,10 +1292,10 @@
    "fieldtype": "Column Break"
   },
   {
-    "fieldname": "project",
-    "fieldtype": "Link",
-    "label": "Project",
-    "options": "Project"
+   "fieldname": "project",
+   "fieldtype": "Link",
+   "label": "Project",
+   "options": "Project"
   },
   {
    "fieldname": "tax_withholding_category",
@@ -1303,12 +1304,19 @@
    "label": "Tax Withholding Category",
    "options": "Tax Withholding Category",
    "print_hide": 1
+  },
+  {
+   "default": "0",
+   "depends_on": "eval: doc.supplier",
+   "fieldname": "filter_items_by_supplier",
+   "fieldtype": "Check",
+   "label": "Filter Items by Supplier"
   }
  ],
  "icon": "fa fa-file-text",
  "idx": 204,
  "is_submittable": 1,
- "modified": "2020-09-21 12:22:09.164068",
+ "modified": "2020-11-26 01:06:57.308440",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Purchase Invoice",

--- a/erpnext/buying/doctype/purchase_order/purchase_order.json
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.json
@@ -51,6 +51,7 @@
   "is_subcontracted",
   "supplier_warehouse",
   "items_section",
+  "filter_items_by_supplier",
   "scan_barcode",
   "items",
   "section_break_48",
@@ -1050,13 +1051,19 @@
    "fieldtype": "Link",
    "label": "Set Reserve Warehouse",
    "options": "Warehouse"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval: doc.supplier",
+   "fieldname": "filter_items_by_supplier",
+   "fieldtype": "Check",
+   "label": "Filter Items by Supplier"
   }
  ],
  "icon": "fa fa-file-text",
  "idx": 105,
  "is_submittable": 1,
- "links": [],
- "modified": "2020-09-14 14:36:12.418690",
+ "modified": "2020-11-26 01:06:33.139484",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Purchase Order",

--- a/erpnext/buying/doctype/supplier_quotation/supplier_quotation.json
+++ b/erpnext/buying/doctype/supplier_quotation/supplier_quotation.json
@@ -1,5 +1,4 @@
 {
- "actions": [],
  "allow_import": 1,
  "autoname": "naming_series:",
  "creation": "2013-05-21 16:16:45",
@@ -32,6 +31,7 @@
   "plc_conversion_rate",
   "ignore_pricing_rule",
   "items_section",
+  "filter_items_by_supplier",
   "items",
   "link_to_mrs",
   "pricing_rule_details",
@@ -791,13 +791,19 @@
    "options": "Opportunity",
    "print_hide": 1,
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "depends_on": "eval: doc.supplier",
+   "fieldname": "filter_items_by_supplier",
+   "fieldtype": "Check",
+   "label": "Filter Items by Supplier"
   }
  ],
  "icon": "fa fa-shopping-cart",
  "idx": 29,
  "is_submittable": 1,
- "links": [],
- "modified": "2019-12-30 19:17:28.208693",
+ "modified": "2020-11-26 01:02:42.652295",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Supplier Quotation",

--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -638,7 +638,7 @@ def get_fields(doctype, fields=[]):
 
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
-def item_supplier_query(doctype, txt, searchfield, start, page_len, filters):
+def supplier_item_query(doctype, txt, searchfield, start, page_len, filters):
 	item_suppliers = frappe.get_all('Item Supplier',
 		filters={'supplier': filters.get('supplier')},
 		fields=['parent'],
@@ -652,12 +652,17 @@ def item_supplier_query(doctype, txt, searchfield, start, page_len, filters):
 	supplier_item_codes = item_suppliers + item_defaults
 	supplier_item_codes = [supplier.parent for supplier in supplier_item_codes]
 
-	supplier_items = frappe.get_all('Item',
-		filters={
-			'item_code': ['in', supplier_item_codes],
-			'is_purchase_item': filters.get('is_purchase_item')
-		},
+	item_filters = [
+		[searchfield, 'like', '%' + txt + '%'],
+		['item_code', 'in', supplier_item_codes],
+		['is_purchase_item', '=', filters.get('is_purchase_item')]
+	]
+
+	supplier_items = frappe.get_all(doctype,
+		filters=item_filters,
 		fields=["name", "item_name", "item_group", "description"],
+		limit_start=start,
+		limit_page_length=page_len,
 		distinct=True,
 		as_list=True
 	)

--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -634,3 +634,31 @@ def get_fields(doctype, fields=[]):
 		fields.insert(1, meta.title_field.strip())
 
 	return unique(fields)
+
+
+@frappe.whitelist()
+@frappe.validate_and_sanitize_search_inputs
+def item_supplier_query(doctype, txt, searchfield, start, page_len, filters):
+	item_suppliers = frappe.get_all('Item Supplier',
+		filters={'supplier': filters.get('supplier')},
+		fields=['parent'],
+		distinct=True)
+
+	item_defaults = frappe.get_all('Item Default',
+		filters={'default_supplier': filters.get('supplier')},
+		fields=['parent'],
+		distinct=True)
+
+	supplier_item_codes = item_suppliers + item_defaults
+	supplier_item_codes = [supplier.parent for supplier in supplier_item_codes]
+
+	supplier_items = frappe.get_all('Item',
+		filters={
+			'item_code': ['in', supplier_item_codes],
+			'is_purchase_item': filters.get('is_purchase_item')
+		},
+		fields=["name", "item_name", "item_group", "description"],
+		distinct=True,
+		as_list=True
+	)
+	return supplier_items

--- a/erpnext/public/js/controllers/buying.js
+++ b/erpnext/public/js/controllers/buying.js
@@ -208,7 +208,7 @@ erpnext.buying.BuyingController = erpnext.TransactionController.extend({
 	get_item_query: function (doc) {
 		if (doc.supplier && doc.filter_items_by_supplier) {
 			return {
-				query: "erpnext.controllers.queries.item_supplier_query",
+				query: "erpnext.controllers.queries.supplier_item_query",
 				filters: {
 					'supplier': doc.supplier,
 					'is_purchase_item': 1

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.json
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.json
@@ -46,6 +46,7 @@
   "is_subcontracted",
   "supplier_warehouse",
   "items_section",
+  "filter_items_by_supplier",
   "scan_barcode",
   "items",
   "pricing_rule_details",
@@ -1066,13 +1067,19 @@
    "fieldtype": "Link",
    "label": "Project",
    "options": "Project"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval: doc.supplier",
+   "fieldname": "filter_items_by_supplier",
+   "fieldtype": "Check",
+   "label": "Filter Items by Supplier"
   }
  ],
  "icon": "fa fa-truck",
  "idx": 261,
  "is_submittable": 1,
- "links": [],
- "modified": "2020-07-15 12:49:42.095297",
+ "modified": "2020-11-26 01:07:24.815762",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Purchase Receipt",


### PR DESCRIPTION
Changes made:
- Add 'Filter by Supplier' checkbox to each of the Buying doctypes (Purchase Order, Purchase Receipt, Purchase Invoice, Supplier Quotation)
- Filter checkbox is only displayed if a supplier is selected
- Add supplier items query to ERPNext `queries.py` to get all items where that supplier is listed either as default supplier or in supplier details child table
- Add filter logic to `buying.js` so that it applies to all buying doctypes

Function
- Allow a user to select only items from a specific supplier
- Filter only applied if a supplier is selected and checkbox is active
- Filter is triggered on the checkbox and hence does not affect buying doctypes that do not have the field

Steps to Test
- Ensure one or more items are active and have a supplier listed either as default or in the supplier details child table
- Open any of the buying doctypes as listed above and create a new one
- Set the supplier
- Items should still show all purchasable items in the table dropdown or in select multiple popup box
- Select the checkbox
- Items should filter only to those with that supplier

Screenshots

- Items with supplier set

![image](https://user-images.githubusercontent.com/33743873/100453764-8c9ff480-30e1-11eb-8e1a-af5ef9e40378.png)


- Purchase order with supplier set but checkbox not set

![image](https://user-images.githubusercontent.com/33743873/100454174-6169d500-30e2-11eb-90d4-7ab107a07cf0.png)

![image](https://user-images.githubusercontent.com/33743873/100454207-76deff00-30e2-11eb-9fa4-4396272ee37f.png)


- Purchase order with supplier and checkbox set

![image](https://user-images.githubusercontent.com/33743873/100454242-852d1b00-30e2-11eb-809d-0bce4430b2d1.png)

![image](https://user-images.githubusercontent.com/33743873/100454261-8eb68300-30e2-11eb-97fa-44865e2fb9c7.png)