### PR TITLE
fix: import taxjar globally in the taxjar_integration module

### DIFF
--- a/erpnext/erpnext_integrations/taxjar_integration.py
+++ b/erpnext/erpnext_integrations/taxjar_integration.py
@@ -1,5 +1,7 @@
 import traceback
 
+import taxjar
+
 import frappe
 from erpnext import get_default_company
 from frappe import _
@@ -29,7 +31,6 @@ def get_client():
 
 
 def create_transaction(doc, method):
-	import taxjar
 	"""Create an order transaction in TaxJar"""
 
 	if not TAXJAR_CREATE_TRANSACTIONS:


### PR DESCRIPTION
`taxjar` was earlier imported specifically in one function, which caused other functions using it to break

Refer #22863 