### PR TITLE
fix(product-listing): Check if customer exists

### DIFF
--- a/erpnext/shopping_cart/cart.py
+++ b/erpnext/shopping_cart/cart.py
@@ -345,7 +345,7 @@ def _set_price_list(cart_settings, quotation=None):
 	selling_price_list = None
 
 	# check if default customer price list exists
-	if party_name:
+	if party_name and frappe.db.exists("Customer", party_name):
 		selling_price_list = get_default_price_list(frappe.get_doc("Customer", party_name))
 
 	# check default price list in shopping cart


### PR DESCRIPTION
- It might happen that party_name might not always be Customer
(it might be a Supplier as well)

- Due to this, when a user (who's not a customer) navigates to a product page, it used to show "Not Found - 404" page.

- This 404 page was getting cached and was affecting other customers as well.

**Note:** There's a "Page Not Found" handling issue which needs to be fixed as well... currently, it shows "Page Not Found" even for document not found exception because we raise the same `frappe.DoesNotExistError` in both the cases.

---

Steps to replicate:
- Clear website cache
- Enable Shopping Cart
- Login via Supplier account.
- Navigate to any listed item which has available stock. 