### PR TITLE
fix: get formatted value in 'taxes' print template

### DIFF
--- a/erpnext/templates/print_formats/includes/taxes.html
+++ b/erpnext/templates/print_formats/includes/taxes.html
@@ -20,10 +20,10 @@
 			{%- if (charge.tax_amount or doc.flags.print_taxes_with_zero_amount) and (not charge.included_in_print_rate or doc.flags.show_inclusive_tax_in_print) -%}
 			<div class="row">
 				<div class="col-xs-5 {%- if doc.align_labels_right %} text-right{%- endif -%}">
-					<label>{{ charge.get_formatted("description") }}</label></div>
+					<label>{{ charge.get_formatted("description") }}</label>
+				</div>
 				<div class="col-xs-7 text-right">
-					{{ frappe.format_value(frappe.utils.flt(charge.tax_amount),
-						table_meta.get_field("tax_amount"), doc, currency=doc.currency) }}
+					{{ charge.get_formatted('tax_amount', doc) }}
 				</div>
 			</div>
 			{%- endif -%}


### PR DESCRIPTION
Use `document.get_formatted` instead of `frappe.format_value` to show absolute value (if set in print format)

Depends on: https://github.com/frappe/frappe/pull/12019