### PR TITLE
fix: Depreciation Posting Date is mandatory even if Calculate Depreci…

### DIFF
--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -323,7 +323,10 @@ frappe.ui.form.on('Asset', {
 
 	calculate_depreciation: function(frm) {
 		frm.toggle_reqd("finance_books", frm.doc.calculate_depreciation);
-		frm.trigger('set_finance_book');
+
+		if (frm.doc.calculate_depreciation) {
+			frm.trigger('set_finance_book');
+		}
 	},
 
 	gross_purchase_amount: function(frm) {


### PR DESCRIPTION
**Issue**
Create an asset record and disable "Calculate Depreciation" checkbox and save it. You will get the below error

![image](https://user-images.githubusercontent.com/8780500/100607769-6a9cb100-3331-11eb-8f23-e1bc6cace97d.png)
