### PR TITLE
fix: GSTR B2C report

### DIFF
--- a/erpnext/regional/report/gstr_1/gstr_1.py
+++ b/erpnext/regional/report/gstr_1/gstr_1.py
@@ -78,7 +78,7 @@ class Gstr1Report(object):
 				place_of_supply = invoice_details.get("place_of_supply")
 				ecommerce_gstin =  invoice_details.get("ecommerce_gstin")
 
-				b2cs_output.setdefault((rate, place_of_supply, ecommerce_gstin),{
+				b2cs_output.setdefault((rate, place_of_supply, ecommerce_gstin, inv),{
 					"place_of_supply": "",
 					"ecommerce_gstin": "",
 					"rate": "",
@@ -90,7 +90,7 @@ class Gstr1Report(object):
 					"invoice_value": invoice_details.get("base_grand_total"),
 				})
 
-				row = b2cs_output.get((rate, place_of_supply, ecommerce_gstin))
+				row = b2cs_output.get((rate, place_of_supply, ecommerce_gstin, inv))
 				row["place_of_supply"] = place_of_supply
 				row["ecommerce_gstin"] = ecommerce_gstin
 				row["rate"] = rate


### PR DESCRIPTION
**Issue**
Two invoices should be show in the report, but only one invoice is showing

<img width="965" alt="Screenshot 2020-11-30 at 10 10 38 PM" src="https://user-images.githubusercontent.com/8780500/100714869-611c5300-33dc-11eb-8d86-f913fb16828a.png">


**After Fix**
<img width="941" alt="Screenshot 2020-11-30 at 10 11 32 PM" src="https://user-images.githubusercontent.com/8780500/100714923-74c7b980-33dc-11eb-8431-5e8d2b0b1b1a.png">


