### PR TITLE
refactor(Fiscal Year): to avoid using SQL query to get fiscal year dates

### DIFF
--- a/erpnext/accounts/doctype/fiscal_year/fiscal_year.py
+++ b/erpnext/accounts/doctype/fiscal_year/fiscal_year.py
@@ -116,12 +116,8 @@ def auto_create_fiscal_year():
 			pass
 
 def get_from_and_to_date(fiscal_year):
-	from_and_to_date_tuple = frappe.db.sql("""select year_start_date, year_end_date
-		from `tabFiscal Year` where name=%s""", (fiscal_year))[0]
-
-	from_and_to_date = {
-		"from_date": from_and_to_date_tuple[0],
-		"to_date": from_and_to_date_tuple[1]
-	}
-
-	return from_and_to_date
+	fields = [
+		"year_start_date as from_date",
+		"year_end_date as to_date"
+	]
+	return frappe.db.get_value("Fiscal Year", fiscal_year, fields, as_dict=1)


### PR DESCRIPTION
Changed frappe.db.sql() to frappe.db.get_value() to get 'from_date' and 'to_date' values from Fiscal Year