### PR TITLE
fix: delete Receive at Warehouse entry on cancellation of Send to War…

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -117,6 +117,7 @@ class StockEntry(StockController):
 		self.update_transferred_qty()
 		self.update_quality_inspection()
 		self.delete_auto_created_batches()
+		self.delete_linked_stock_entry()
 
 	def set_job_card_data(self):
 		if self.job_card and not self.work_order:
@@ -159,6 +160,12 @@ class StockEntry(StockController):
 		if self.job_card and self.purpose != 'Material Transfer for Manufacture':
 			frappe.throw(_("For job card {0}, you can only make the 'Material Transfer for Manufacture' type stock entry")
 				.format(self.job_card))
+
+	def delete_linked_stock_entry(self):
+		if self.purpose == "Send to Warehouse":
+			for d in frappe.get_all("Stock Entry", filters={"docstatus": 0,
+				"outgoing_stock_entry": self.name, "purpose": "Receive at Warehouse"}):
+				frappe.delete_doc("Stock Entry", d.name)
 
 	def set_transfer_qty(self):
 		for item in self.get("items"):


### PR DESCRIPTION
**Issue**

1. Create stock entry with type as "Send to Warehouse"

1. Create stock entry with type as "Receive at Warehouse" against the above stock entry

1. Now cancel the stock entry "Send to Warehouse", system should delete the "Receive at Warehouse" entries which are in Draft state.