### PR TITLE
fix(Production Planning Report): incorrect required_qty

### DIFF
--- a/erpnext/manufacturing/report/production_planning_report/production_planning_report.py
+++ b/erpnext/manufacturing/report/production_planning_report/production_planning_report.py
@@ -124,7 +124,7 @@ class ProductionPlanReport(object):
 				if self.filters.include_subassembly_raw_materials else "(bom_item.qty / bom.quantity)")
 
 			raw_materials = frappe.db.sql(""" SELECT bom_item.parent, bom_item.item_code,
-					bom_item.item_name as raw_material_name, {0} as required_qty
+					bom_item.item_name as raw_material_name, {0} as required_qty_per_unit
 				FROM
 					`tabBOM` as bom, `tab{1}` as bom_item
 				WHERE
@@ -208,7 +208,7 @@ class ProductionPlanReport(object):
 		warehouses = self.mrp_warehouses or []
 		for d in self.raw_materials_dict.get(key):
 			if self.filters.based_on != "Work Order":
-				d.required_qty = d.required_qty * data.qty_to_manufacture
+				d.required_qty = d.required_qty_per_unit * data.qty_to_manufacture
 
 			if not warehouses:
 				warehouses = [data.warehouse]


### PR DESCRIPTION
Production Planning report required_qty column displaying multiplied values.
the product requires 2 qty of raw material.
In sales order 1 the qty is 2 so 4 (2*2) reqd qty is correct.
but In sales order 2 the qty is 3 so 12 reqd qty is incorrect it should be  6 (3*2).

![image](https://user-images.githubusercontent.com/28212972/101318184-ea70d100-3885-11eb-9d86-f66704823750.png)

After Fix
![image](https://user-images.githubusercontent.com/28212972/101318565-8f8ba980-3886-11eb-9d23-1a035300403f.png)
