### PR TITLE
fix(POS): do not fetch items until POS Profile is set

### DIFF
--- a/erpnext/selling/page/point_of_sale/point_of_sale.js
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.js
@@ -1515,6 +1515,9 @@ class POSItems {
 	}
 
 	get_items({start = 0, page_length = 40, search_value='', item_group=this.parent_item_group}={}) {
+		if (!this.frm.doc.pos_profile)
+			return;
+
 		const price_list = this.frm.doc.selling_price_list;
 		return new Promise(res => {
 			frappe.call({


### PR DESCRIPTION
**Problem**: (v12) POS tries to fetch items before POS Profile is set

![pos-before](https://user-images.githubusercontent.com/24353136/101343859-a17f4380-38aa-11eb-991f-7f8d19bb2373.gif)

**Fix**: Do not fetch items until the POS Profile is set

![pos-after](https://user-images.githubusercontent.com/24353136/101343873-a7752480-38aa-11eb-92a3-a76d88bd84be.gif)
