### PR TITLE
fix: sales invoice add button from sales order dashboard

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -8,7 +8,7 @@ frappe.ui.form.on("Sales Order", {
 		frm.custom_make_buttons = {
 			'Delivery Note': 'Delivery Note',
 			'Pick List': 'Pick List',
-			'Sales Invoice': 'Invoice',
+			'Sales Invoice': 'Sales Invoice',
 			'Material Request': 'Material Request',
 			'Purchase Order': 'Purchase Order',
 			'Project': 'Project',


### PR DESCRIPTION
**Issue:**

1. Sales Invoice + button was missing from the Sales Order Dashboard

![image](https://user-images.githubusercontent.com/31363128/101346905-47cd4800-38af-11eb-895e-0bc71571dac2.png)
