### PR TITLE
fix: double exception in payroll

### DIFF
--- a/erpnext/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/erpnext/payroll/doctype/payroll_entry/payroll_entry.py
@@ -289,7 +289,9 @@ class PayrollEntry(Document):
 				jv_name = journal_entry.name
 				self.update_salary_slip_status(jv_name = jv_name)
 			except Exception as e:
-				frappe.msgprint(e)
+				if type(e) in (str, list, tuple):
+					frappe.msgprint(e)
+				raise
 
 		return jv_name
 


### PR DESCRIPTION
 Steps:

- Keep salary component account and payroll payable account same. The user used to get the below error.
![Screen Recording 2020-12-07 at 7 09 44 PM](https://user-images.githubusercontent.com/33727827/101359349-21fd6e80-38c2-11eb-96d8-c1d0b0205585.gif)

The issue was that it was throwing the error while creating submitting journal entry and the catch exception block in payroll entry was catching the Exception of type Exception which was creating the issue.
Now it does not throw the 2nd error if the type is of error. 
![Screen Recording 2020-12-07 at 7 14 06 PM](https://user-images.githubusercontent.com/33727827/101359772-c1bafc80-38c2-11eb-9ccf-b72fdba9055b.gif)