### PR TITLE
fix(Shopping Cart): allow add to cart for any item if allow_items_not_in_stock is enabled

### DIFF
--- a/erpnext/portal/product_configurator/utils.py
+++ b/erpnext/portal/product_configurator/utils.py
@@ -249,6 +249,7 @@ def get_next_attribute_and_values(item_code, selected_attributes):
 
 	optional_attributes = item_cache.get_optional_attributes()
 	exact_match = []
+	allow_items_not_in_stock = False
 	# search for exact match if all selected attributes are required attributes
 	if len(selected_attributes.keys()) >= (len(attribute_list) - len(optional_attributes)):
 		item_attribute_value_map = item_cache.get_item_attribute_value_map()
@@ -263,7 +264,7 @@ def get_next_attribute_and_values(item_code, selected_attributes):
 	if exact_match:
 		data = get_product_info_for_website(exact_match[0])
 		product_info = data.product_info
-		product_info["allow_items_not_in_stock"] = cint(data.cart_settings.allow_items_not_in_stock)
+		allow_items_not_in_stock = cint(data.cart_settings.allow_items_not_in_stock)
 		if not data.cart_settings.show_price:
 			product_info = None
 	else:
@@ -275,6 +276,7 @@ def get_next_attribute_and_values(item_code, selected_attributes):
 		'filtered_items_count': filtered_items_count,
 		'filtered_items': filtered_items if filtered_items_count < 10 else [],
 		'exact_match': exact_match,
+		'allow_items_not_in_stock': allow_items_not_in_stock,
 		'product_info': product_info
 	}
 

--- a/erpnext/templates/generators/item/item_configure.js
+++ b/erpnext/templates/generators/item/item_configure.js
@@ -186,7 +186,7 @@ class ItemConfigure {
 		this.dialog.$status_area.empty();
 	}
 
-	get_html_for_item_found({ filtered_items_count, filtered_items, exact_match, product_info }) {
+	get_html_for_item_found({ filtered_items_count, filtered_items, exact_match, product_info, allow_items_not_in_stock }) {
 		const exact_match_message = __('1 exact match.');
 		const one_item = exact_match.length === 1 ?
 			exact_match[0] :
@@ -194,7 +194,7 @@ class ItemConfigure {
 				filtered_items[0] : '';
 
 		// Allow Add to Cart if adding out of stock items enabled in Shopping Cart else check stock.
-		const in_stock = product_info.allow_items_not_in_stock ? 1 : product_info.in_stock;
+		const in_stock = allow_items_not_in_stock ? 1 : product_info && product_info.in_stock;
 		const add_to_cart = `<a href data-action="btn_add_to_cart" data-item-code="${one_item}">${__('Add to cart')}</a>`;
 		const product_action =  in_stock ? add_to_cart : `<a style="color:#74808b;">${__('Not in Stock')}</a>`;
 


### PR DESCRIPTION
**Issue:**
Add to Cart button doesn't show up in the Item Configurator dialog even if **Allow items not in stock to be added to cart** is enabled (this occurs when `product_info` is `null`).

**Fix:**
Use a separate key for `allow_items_not_in_stock`, which doesn't depend on the value of `product_info`.