### PR TITLE
feat: separate equity tree in CoA SKR04

### DIFF
--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/de_kontenplan_SKR04_with_account_number.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/de_kontenplan_SKR04_with_account_number.json
@@ -910,75 +910,8 @@
             },
             "is_group": 1
         },
-        "Passiva": {
+        "Passiva - Verbindlichkeiten": {
             "root_type": "Liability",
-            "A - Eigenkapital": {
-                "account_type": "Equity",
-                "is_group": 1,
-                "I - Gezeichnetes Kapital": {
-                    "account_type": "Equity",
-                    "is_group": 1
-                },
-                "II - Kapitalr\u00fccklage": {
-                    "account_type": "Equity",
-                    "is_group": 1
-                },
-                "III - Gewinnr\u00fccklagen": {
-                    "account_type": "Equity",
-                    "1 - gesetzliche R\u00fccklage": {
-                        "account_type": "Equity",
-                        "is_group": 1
-                    },
-                    "2 - R\u00fccklage f. Anteile an einem herrschenden oder mehrheitlich beteiligten Unternehmen": {
-                        "account_type": "Equity",
-                        "is_group": 1
-                    },
-                    "3 - satzungsm\u00e4\u00dfige R\u00fccklagen": {
-                        "account_type": "Equity",
-                        "is_group": 1
-                    },
-                    "4 - andere Gewinnr\u00fccklagen": {
-                        "account_type": "Equity",
-                        "is_group": 1,
-                        "Gewinnr\u00fccklagen aus den \u00dcbergangsvorschriften BilMoG": {
-                            "is_group": 1,
-                            "Gewinnr\u00fccklagen (BilMoG)": {
-                                "account_number": "2963"
-                            },
-                            "Gewinnr\u00fccklagen aus Zuschreibung Sachanlageverm\u00f6gen (BilMoG)": {
-                                "account_number": "2964"
-                            },
-                            "Gewinnr\u00fccklagen aus Zuschreibung Finanzanlageverm\u00f6gen (BilMoG)": {
-                                "account_number": "2965"
-                            },
-                            "Gewinnr\u00fccklagen aus Aufl\u00f6sung der Sonderposten mit R\u00fccklageanteil (BilMoG)": {
-                                "account_number": "2966"
-                            }
-                        },
-                        "Latente Steuern (Gewinnr\u00fccklage Haben) aus erfolgsneutralen Verrechnungen": {
-                            "account_number": "2967"
-                        },
-                        "Latente Steuern (Gewinnr\u00fccklage Soll) aus erfolgsneutralen Verrechnungen": {
-                            "account_number": "2968"
-                        },
-                        "Rechnungsabgrenzungsposten (Gewinnr\u00fccklage Soll) aus erfolgsneutralen Verrechnungen": {
-                            "account_number": "2969"
-                        }
-                    },
-                    "is_group": 1
-                },
-                "IV - Gewinnvortrag/Verlustvortrag": {
-                    "account_type": "Equity",
-                    "is_group": 1
-                },
-                "V - Jahres\u00fcberschu\u00df/Jahresfehlbetrag": {
-                    "account_type": "Equity",
-                    "is_group": 1
-                },
-                "Einlagen stiller Gesellschafter": {
-                    "account_number": "9295"
-                }
-            },
             "B - R\u00fcckstellungen": {
                 "is_group": 1,
                 "1 - R\u00fcckstellungen f. Pensionen und \u00e4hnliche Verplicht.": {
@@ -1594,6 +1527,143 @@
                 }
             },
             "is_group": 1
+        },
+        "Passiva - Eigenkapital": {
+            "root_type": "Equity",
+            "A - Eigenkapital": {
+                "account_type": "Equity",
+                "is_group": 1,
+                "I - Gezeichnetes Kapital": {
+                    "account_type": "Equity",
+                    "is_group": 1,
+                    "Gezeichnetes Kapital": {
+                        "account_number": "2900",
+                        "account_type": "Equity"
+                    },
+                    "Gesch\u00e4ftsguthaben der verbleibenden Mitglieder": {
+                        "account_number": "2901"
+                    },
+                    "Gesch\u00e4ftsguthaben der ausscheidenden Mitglieder": {
+                        "account_number": "2902"
+                    },
+                    "Gesch\u00e4ftsguthaben aus gek\u00fcndigten Gesch\u00e4ftsanteilen": {
+                        "account_number": "2903"
+                    },
+                    "R\u00fcckst\u00e4ndige f\u00e4llige Einzahlungen auf Gesch\u00e4ftsanteile, vermerkt": {
+                        "account_number": "2906"
+                    },
+                    "Gegenkonto R\u00fcckst\u00e4ndige f\u00e4llige Einzahlungen auf Gesch\u00e4ftsanteile, vermerkt": {
+                        "account_number": "2907"
+                    },
+                    "Kapitalerh\u00f6hung aus Gesellschaftsmitteln": {
+                        "account_number": "2908"
+                    },
+                    "Ausstehende Einlagen auf das gezeichnete Kapital, nicht eingefordert": {
+                        "account_number": "2910"
+                    }
+                },
+                "II - Kapitalr\u00fccklage": {
+                    "account_type": "Equity",
+                    "is_group": 1,
+                    "Kapitalr\u00fccklage": {
+                        "account_number": "2920"
+                    },
+                    "Kapitalr\u00fccklage durch Ausgabe von Anteilen \u00fcber Nennbetrag": {
+                        "account_number": "2925"
+                    },
+                    "Kapitalr\u00fccklage durch Ausgabe von Schuldverschreibungen": {
+                        "account_number": "2926"
+                    },
+                    "Kapitalr\u00fccklage durch Zuzahlungen gegen Gew\u00e4hrung eines Vorzugs": {
+                        "account_number": "2927"
+                    },
+                    "Kapitalr\u00fccklage durch Zuzahlungen in das Eigenkapital": {
+                        "account_number": "2928"
+                    },
+                    "Nachschusskapital (Gegenkonto 1299)": {
+                        "account_number": "2929"
+                    }
+                },
+                "III - Gewinnr\u00fccklagen": {
+                    "account_type": "Equity",
+                    "1 - gesetzliche R\u00fccklage": {
+                        "account_type": "Equity",
+                        "is_group": 1,
+                        "Gesetzliche R\u00fccklage": {
+                            "account_number": "2930"
+                        }
+                    },
+                    "2 - R\u00fccklage f. Anteile an einem herrschenden oder mehrheitlich beteiligten Unternehmen": {
+                        "account_type": "Equity",
+                        "is_group": 1,
+                        "R\u00fccklage f. Anteile an einem herrschenden oder mehrheitlich beteiligten Unternehmen": {
+                            "account_number": "2935"
+                        }
+                    },
+                    "3 - satzungsm\u00e4\u00dfige R\u00fccklagen": {
+                        "account_type": "Equity",
+                        "is_group": 1,
+                        "Satzungsm\u00e4\u00dfige R\u00fccklagen": {
+                            "account_number": "2950"
+                        }
+                    },
+                    "4 - andere Gewinnr\u00fccklagen": {
+                        "account_type": "Equity",
+                        "is_group": 1,
+                        "Andere Gewinnr\u00fccklagen": {
+                            "account_number": "2960"
+                        },
+                        "Andere Gewinnr\u00fccklagen aus dem Erwerb eigener Anteile": {
+                            "account_number": "2961"
+                        },
+                        "Eigenkapitalanteil von Wertaufholungen": {
+                            "account_number": "2962"
+                        },
+                        "Gewinnr\u00fccklagen aus den \u00dcbergangsvorschriften BilMoG": {
+                            "is_group": 1,
+                            "Gewinnr\u00fccklagen (BilMoG)": {
+                                "account_number": "2963"
+                            },
+                            "Gewinnr\u00fccklagen aus Zuschreibung Sachanlageverm\u00f6gen (BilMoG)": {
+                                "account_number": "2964"
+                            },
+                            "Gewinnr\u00fccklagen aus Zuschreibung Finanzanlageverm\u00f6gen (BilMoG)": {
+                                "account_number": "2965"
+                            },
+                            "Gewinnr\u00fccklagen aus Aufl\u00f6sung der Sonderposten mit R\u00fccklageanteil (BilMoG)": {
+                                "account_number": "2966"
+                            }
+                        },
+                        "Latente Steuern (Gewinnr\u00fccklage Haben) aus erfolgsneutralen Verrechnungen": {
+                            "account_number": "2967"
+                        },
+                        "Latente Steuern (Gewinnr\u00fccklage Soll) aus erfolgsneutralen Verrechnungen": {
+                            "account_number": "2968"
+                        },
+                        "Rechnungsabgrenzungsposten (Gewinnr\u00fccklage Soll) aus erfolgsneutralen Verrechnungen": {
+                            "account_number": "2969"
+                        }
+                    },
+                    "is_group": 1
+                },
+                "IV - Gewinnvortrag/Verlustvortrag": {
+                    "account_type": "Equity",
+                    "is_group": 1,
+                    "Gewinnvortrag vor Verwendung": {
+                        "account_number": "2970"
+                    },
+                    "Verlustvortrag vor Verwendung": {
+                        "account_number": "2978"
+                    }
+                },
+                "V - Jahres\u00fcberschu\u00df/Jahresfehlbetrag": {
+                    "account_type": "Equity",
+                    "is_group": 1
+                },
+                "Einlagen stiller Gesellschafter": {
+                    "account_number": "9295"
+                }
+            }
         },
         "1 - Umsatzerl\u00f6se": {
             "root_type": "Income",


### PR DESCRIPTION
Previously, there were only very few equity accounts, located in the liabilities tree.

This PR gives Equity its own root and adds the missing equity account.

`develop`: #24095