### PR TITLE
fix(Asset): set current asset value before calculating difference amount

### DIFF
--- a/erpnext/assets/doctype/asset_value_adjustment/asset_value_adjustment.py
+++ b/erpnext/assets/doctype/asset_value_adjustment/asset_value_adjustment.py
@@ -13,8 +13,8 @@ from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import g
 class AssetValueAdjustment(Document):
 	def validate(self):
 		self.validate_date()
-		self.set_difference_amount()
 		self.set_current_asset_value()
+		self.set_difference_amount()
 
 	def on_submit(self):
 		self.make_depreciation_entry()
@@ -25,7 +25,7 @@ class AssetValueAdjustment(Document):
 			frappe.throw(_("Cancel the journal entry {0} first").format(self.journal_entry))
 
 		self.reschedule_depreciations(self.current_asset_value)
-	
+
 	def validate_date(self):
 		asset_purchase_date = frappe.db.get_value('Asset', self.asset, 'purchase_date')
 		if getdate(self.date) < getdate(asset_purchase_date):
@@ -78,7 +78,7 @@ class AssetValueAdjustment(Document):
 				debit_entry.update({
 					dimension['fieldname']: self.get(dimension['fieldname']) or dimension.get('default_dimension')
 				})
-		
+
 		je.append("accounts", credit_entry)
 		je.append("accounts", debit_entry)
 


### PR DESCRIPTION
**Issue**: In Asset Value Adjustment, if the Current Asset Value is not set and the system tries to calculate the difference amount it breaks:

```python
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-13-2020-11-11/apps/frappe/frappe/app.py", line 64, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-13-2020-11-11/apps/frappe/frappe/api.py", line 58, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-13-2020-11-11/apps/frappe/frappe/handler.py", line 30, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-13-2020-11-11/apps/frappe/frappe/handler.py", line 70, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-13-2020-11-11/apps/frappe/frappe/__init__.py", line 1107, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-13-2020-11-11/apps/frappe/frappe/client.py", line 198, in save
    doc.save()
  File "/home/frappe/benches/bench-version-13-2020-11-11/apps/frappe/frappe/model/document.py", line 285, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-version-13-2020-11-11/apps/frappe/frappe/model/document.py", line 307, in _save
    self.insert()
  File "/home/frappe/benches/bench-version-13-2020-11-11/apps/frappe/frappe/model/document.py", line 238, in insert
    self.run_before_save_methods()
  File "/home/frappe/benches/bench-version-13-2020-11-11/apps/frappe/frappe/model/document.py", line 930, in run_before_save_methods
    self.run_method("validate")
  File "/home/frappe/benches/bench-version-13-2020-11-11/apps/frappe/frappe/model/document.py", line 831, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-version-13-2020-11-11/apps/frappe/frappe/model/document.py", line 1116, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-version-13-2020-11-11/apps/frappe/frappe/model/document.py", line 1099, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-version-13-2020-11-11/apps/frappe/frappe/model/document.py", line 825, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-version-13-2020-11-11/apps/erpnext/erpnext/assets/doctype/asset_value_adjustment/asset_value_adjustment.py", line 16, in validate
    self.set_difference_amount()
  File "/home/frappe/benches/bench-version-13-2020-11-11/apps/erpnext/erpnext/assets/doctype/asset_value_adjustment/asset_value_adjustment.py", line 36, in set_difference_amount
    self.difference_amount = flt(self.current_asset_value - self.new_asset_value)
TypeError: unsupported operand type(s) for -: 'NoneType' and 'int'
```

**Fix**: Set current asset value before calculating the difference amount.