### PR TITLE
fix: selecting salary component

### DIFF
--- a/erpnext/payroll/doctype/additional_salary/additional_salary.js
+++ b/erpnext/payroll/doctype/additional_salary/additional_salary.js
@@ -12,14 +12,6 @@ frappe.ui.form.on('Additional Salary', {
 				}
 			};
 		});
-
-		if (!frm.doc.currency) return;
-		frm.set_query("salary_component", function() {
-			return {
-				query: "erpnext.payroll.doctype.salary_structure.salary_structure.get_earning_deduction_components",
-				filters: {currency: frm.doc.currency, company: frm.doc.company}
-			};
-		});
 	},
 
 	employee: function(frm) {

--- a/erpnext/payroll/doctype/employee_incentive/employee_incentive.js
+++ b/erpnext/payroll/doctype/employee_incentive/employee_incentive.js
@@ -11,11 +11,11 @@ frappe.ui.form.on('Employee Incentive', {
 			};
 		});
 
-		if (!frm.doc.currency) return;
+		if (!frm.doc.company) return;
 		frm.set_query("salary_component", function() {
 			return {
 				query: "erpnext.payroll.doctype.salary_structure.salary_structure.get_earning_deduction_components",
-				filters: {type: "earning", currency: frm.doc.currency, company: frm.doc.company}
+				filters: {type: "earning", company: frm.doc.company}
 			};
 		});
 

--- a/erpnext/payroll/doctype/salary_structure/salary_structure.js
+++ b/erpnext/payroll/doctype/salary_structure/salary_structure.js
@@ -55,17 +55,17 @@ frappe.ui.form.on('Salary Structure', {
 	},
 
 	set_earning_deduction_component: function(frm) {
-		if(!frm.doc.currency && !frm.doc.company) return;
+		if(!frm.doc.company) return;
 		frm.set_query("salary_component", "earnings", function() {
 			return {
 				query : "erpnext.payroll.doctype.salary_structure.salary_structure.get_earning_deduction_components",
-				filters: {type: "earning", currency: frm.doc.currency, company: frm.doc.company}
+				filters: {type: "earning", company: frm.doc.company}
 			};
 		});
 		frm.set_query("salary_component", "deductions", function() {
 			return {
 				query : "erpnext.payroll.doctype.salary_structure.salary_structure.get_earning_deduction_components",
-				filters: {type: "deduction", currency: frm.doc.currency, company: frm.doc.company}
+				filters: {type: "deduction", company: frm.doc.company}
 			};
 		});
 	},
@@ -74,7 +74,6 @@ frappe.ui.form.on('Salary Structure', {
 	currency: function(frm) {
 		calculate_totals(frm.doc);
 		frm.trigger("set_dynamic_labels")
-		frm.trigger('set_earning_deduction_component');
 		frm.refresh()
 	},
 

--- a/erpnext/payroll/doctype/salary_structure/salary_structure.py
+++ b/erpnext/payroll/doctype/salary_structure/salary_structure.py
@@ -210,7 +210,7 @@ def get_employees(salary_structure):
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
 def get_earning_deduction_components(doctype, txt, searchfield, start, page_len, filters):
-	if len(filters) < 3:
+	if len(filters) < 2:
 		return {}
 
 	return frappe.db.sql("""


### PR DESCRIPTION
While making an additional salary, salary structure, or employee incentive if the currency was set anything other than company currency the salary component was not available for selection, because it was considered that the salary component should also have an account in the selected currency. But this is not true anymore, hence removing currency filters.