### PR TITLE
fix: retention filters

### DIFF
--- a/erpnext/payroll/doctype/retention_bonus/retention_bonus.js
+++ b/erpnext/payroll/doctype/retention_bonus/retention_bonus.js
@@ -4,9 +4,13 @@
 frappe.ui.form.on('Retention Bonus', {
 	setup: function(frm) {
 		frm.set_query("employee", function() {
+			if (!frm.doc.company) {
+				frappe.msgprint(__("Please Select Company First"))
+			}
 			return {
 				filters: {
-					"status": "Active"
+					"status": "Active",
+					"company": frm.doc.company
 				}
 			};
 		});

--- a/erpnext/payroll/doctype/retention_bonus/retention_bonus.js
+++ b/erpnext/payroll/doctype/retention_bonus/retention_bonus.js
@@ -5,7 +5,7 @@ frappe.ui.form.on('Retention Bonus', {
 	setup: function(frm) {
 		frm.set_query("employee", function() {
 			if (!frm.doc.company) {
-				frappe.msgprint(__("Please Select Company First"))
+				frappe.msgprint(__("Please Select Company First"));
 			}
 			return {
 				filters: {


### PR DESCRIPTION
While selecting an employee for a retention bonus the current filters are just on employee status being active. Hence even after selecting any company all the active employees even from other companies are visible in the drop-down for selection.

![Screenshot 2020-12-14 at 1 34 34 PM](https://user-images.githubusercontent.com/33727827/102056309-2f5eaf80-3e12-11eb-89ce-d402f45caa65.png)

After the fix-:
If the company is not selected:

![Screenshot 2020-12-14 at 1 43 09 PM](https://user-images.githubusercontent.com/33727827/102056396-50bf9b80-3e12-11eb-9fe2-820d0fd30321.png)

And the company filter for employees:

![Screenshot 2020-12-14 at 1 44 01 PM](https://user-images.githubusercontent.com/33727827/102056464-6e8d0080-3e12-11eb-8ba6-e453bfba1732.png)
