### PR TITLE
fix: Payment Entry created against a Payroll Entry should only consider Salary Slips in that Payroll Entry

### DIFF
--- a/erpnext/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/erpnext/payroll/doctype/payroll_entry/payroll_entry.py
@@ -312,8 +312,8 @@ class PayrollEntry(Document):
 
 		cond = self.get_filter_condition()
 		salary_slip_name_list = frappe.db.sql(""" select t1.name from `tabSalary Slip` t1
-			where t1.docstatus = 1 and start_date >= %s and end_date <= %s %s
-			""" % ('%s', '%s', cond), (self.start_date, self.end_date), as_list = True)
+			where t1.docstatus = 1 and t1.payroll_entry = %s and start_date >= %s and end_date <= %s %s
+			""" % ('%s', '%s', '%s', cond), (self.name, self.start_date, self.end_date), as_list = True)
 
 		if salary_slip_name_list and len(salary_slip_name_list) > 0:
 			salary_slip_total = 0
@@ -542,7 +542,7 @@ def create_salary_slips_for_employees(employees, args, publish_progress=True):
 					title = _("Creating Salary Slips..."))
 		else:
 			salary_slip_name = frappe.db.sql(
-				'''SELECT 
+				'''SELECT
 						name
 					FROM `tabSalary Slip`
 					WHERE company=%s

--- a/erpnext/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/erpnext/payroll/doctype/payroll_entry/payroll_entry.py
@@ -582,6 +582,7 @@ def submit_salary_slips_for_employees(payroll_entry, salary_slips, publish_progr
 		else:
 			try:
 				ss_obj.submit()
+				ss_obj.db_set("payroll_entry", payroll_entry.name)
 				submitted_ss.append(ss_obj)
 			except frappe.ValidationError:
 				not_submitted_ss.append(ss[0])


### PR DESCRIPTION
**Problem**: On clicking **Make Bank Entry** in Payroll Entry, the system is calculating the amount for salary slips for the whole period instead of calculating the salary slips related to that particular payroll entry.

**Fix**: Filter Salary Slips linked to the Payroll Entry while fetching Salary Slips for creating a Payment Entry.