### PR TITLE
fix: minor ui changes

### DIFF
--- a/erpnext/hr/doctype/employee_advance/employee_advance.js
+++ b/erpnext/hr/doctype/employee_advance/employee_advance.js
@@ -18,13 +18,18 @@ frappe.ui.form.on('Employee Advance', {
 			if (!frm.doc.employee) {
 				frappe.msgprint(__("Please select employee first"));
 			}
-			var company_currency = erpnext.get_currency(frm.doc.company);
+			let company_currency = erpnext.get_currency(frm.doc.company);
+			let currencies = [company_currency];
+			if (frm.doc.currency && (frm.doc.currency != company_currency)) {
+				currencies.push(frm.doc.currency)
+			}
+
 			return {
 				filters: {
 					"root_type": "Asset",
 					"is_group": 0,
 					"company": frm.doc.company,
-					"account_currency": ["in", [frm.doc.currency, company_currency]],
+					"account_currency": ["in", currencies],
 				}
 			};
 		});
@@ -181,21 +186,23 @@ frappe.ui.form.on('Employee Advance', {
 	},
 
 	currency: function(frm) {
-		var from_currency = frm.doc.currency;
-		var company_currency;
-		if (!frm.doc.company) {
-			company_currency = erpnext.get_currency(frappe.defaults.get_default("Company"));
-		} else {
-			company_currency = erpnext.get_currency(frm.doc.company);
+		if (frm.doc.currency) {
+			var from_currency = frm.doc.currency;
+			var company_currency;
+			if (!frm.doc.company) {
+				company_currency = erpnext.get_currency(frappe.defaults.get_default("Company"));
+			} else {
+				company_currency = erpnext.get_currency(frm.doc.company);
+			}
+			if (from_currency != company_currency) {
+				frm.events.set_exchange_rate(frm, from_currency, company_currency);
+			} else {
+				frm.set_value("exchange_rate", 1.0);
+				frm.set_df_property('exchange_rate', 'hidden', 1);
+				frm.set_df_property("exchange_rate", "description", "" );
+			}
+			frm.refresh_fields();
 		}
-		if (from_currency != company_currency) {
-			frm.events.set_exchange_rate(frm, from_currency, company_currency);
-		} else {
-			frm.set_value("exchange_rate", 1.0);
-			frm.set_df_property('exchange_rate', 'hidden', 1);
-			frm.set_df_property("exchange_rate", "description", "" );
-		}
-		frm.refresh_fields();
 	},
 
 	set_exchange_rate: function(frm, from_currency, company_currency) {

--- a/erpnext/hr/doctype/employee_advance/employee_advance.js
+++ b/erpnext/hr/doctype/employee_advance/employee_advance.js
@@ -21,7 +21,7 @@ frappe.ui.form.on('Employee Advance', {
 			let company_currency = erpnext.get_currency(frm.doc.company);
 			let currencies = [company_currency];
 			if (frm.doc.currency && (frm.doc.currency != company_currency)) {
-				currencies.push(frm.doc.currency)
+				currencies.push(frm.doc.currency);
 			}
 
 			return {

--- a/erpnext/payroll/doctype/employee_benefit_application/employee_benefit_application.json
+++ b/erpnext/payroll/doctype/employee_benefit_application/employee_benefit_application.json
@@ -23,6 +23,7 @@
   "employee_benefits",
   "totals",
   "total_amount",
+  "column_break",
   "pro_rata_dispensed_amount"
  ],
  "fields": [
@@ -139,11 +140,15 @@
    "label": "Company",
    "options": "Company",
    "reqd": 1
+  },
+  {
+   "fieldname": "column_break",
+   "fieldtype": "Column Break"
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2020-11-25 11:49:05.095101",
+ "modified": "2020-12-14 15:52:08.566418",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Employee Benefit Application",


### PR DESCRIPTION
While making a new employee advance when the Currency is set to company currency, company currency is shown twice.

![Screenshot 2020-12-14 at 1 53 33 PM](https://user-images.githubusercontent.com/33727827/102077070-ba4da300-3e2e-11eb-86b9-92aed66aa3f2.png)

After change:-
If Currency is company currency:

![Screenshot 2020-12-14 at 3 47 18 PM](https://user-images.githubusercontent.com/33727827/102077122-d2bdbd80-3e2e-11eb-8099-79520565281f.png)

If Currency is other than company currency:

![Screenshot 2020-12-14 at 3 48 34 PM](https://user-images.githubusercontent.com/33727827/102077178-e6692400-3e2e-11eb-94fa-ef49d52c4fa3.png)
________________________________________
In Employee Benefits Application for the total section, there are only 2 fields and both are set on the left side keeping a blank space on the right.
![Screenshot 2020-12-14 at 1 55 13 PM](https://user-images.githubusercontent.com/33727827/102077263-026cc580-3e2f-11eb-82d9-e94c702f8d89.png)

Changed to:
![Screenshot 2020-12-14 at 3 52 50 PM](https://user-images.githubusercontent.com/33727827/102077304-11ec0e80-3e2f-11eb-9543-8fe3683f3395.png)
