### PR TITLE
fix: po_not retaining on save

### DIFF
--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -375,7 +375,7 @@ class SellingController(StockController):
 			self.set_pos_for_delivery_note()
 
 	def set_pos_for_sales_invoice(self):
-		po_nos = []
+		po_nos = [self.po_no] if self.po_no else []
 		if self.po_no:
 			po_nos.append(self.po_no)
 		self.get_po_nos('Sales Order', 'sales_order', po_nos)

--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -383,7 +383,7 @@ class SellingController(StockController):
 		self.po_no = ', '.join(list(set(x.strip() for x in ','.join(po_nos).split(','))))
 
 	def set_pos_for_delivery_note(self):
-		po_nos = []
+		po_nos = [self.po_no] if self.po_no else []
 		if self.po_no:
 			po_nos.append(self.po_no)
 		self.get_po_nos('Sales Order', 'against_sales_order', po_nos)


### PR DESCRIPTION
Issue:
In sales invoice if the user enters a Customer PO number it gets removed on save
There was a line in validate cleaning it up

Solution:
Append instead of assign