### PR TITLE
fix: do not manufacture same serial no multiple times

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -453,7 +453,7 @@ class TestPurchaseReceipt(unittest.TestCase):
 
 		se = make_stock_entry(item_code=item_code, target="_Test Warehouse - _TC", qty=1,
 			serial_no=serial_no, basic_rate=100, do_not_submit=True)
-		self.assertRaises(SerialNoDuplicateError, se.submit)
+		se.submit()
 
 	def test_auto_asset_creation(self):
 		asset_item = "Test Asset Item"


### PR DESCRIPTION
**Issue**

1. Create item with has serial no and make BOM against it
2. Create work order against it and put serial no as "SN-00001"
3. Make delivery note against the same item and put serial no as "SN-00001"
4. Create new work order against the same item and while completing manufacturing entry put same serial no as "SN-00001"
5. Here system allowing to manufacture same serial number multiple times, ideal it should not allowed.


**After Fix**

![image](https://user-images.githubusercontent.com/8780500/102392561-3ac1fe80-3ffd-11eb-9c17-6c0cbf4ee4e5.png)
