### PR TITLE
fix: error popup for submitted doc

### DIFF
--- a/erpnext/payroll/doctype/salary_slip/salary_slip.js
+++ b/erpnext/payroll/doctype/salary_slip/salary_slip.js
@@ -214,14 +214,16 @@ frappe.ui.form.on('Salary Slip Timesheet', {
 });
 
 var calculate_totals = function(frm) {
-	if (frm.doc.earnings || frm.doc.deductions) {
-		frappe.call({
-			method: "set_totals",
-			doc: frm.doc,
-			callback: function() {
-				frm.refresh_fields();
-			}
-		});
+	if (frm.doc.docstatus === 0) {
+		if (frm.doc.earnings || frm.doc.deductions) {
+			frappe.call({
+				method: "set_totals",
+				doc: frm.doc,
+				callback: function() {
+					frm.refresh_fields();
+				}
+			});
+		}
 	}
 };
 


### PR DESCRIPTION
We have added calculate_totals in salary_slip.js. This method also triggers on_refresh event.

When a user, with employee role access the submitted salary slip, the system throws error Insufficient permissions for Salary Slip.

Reason:
Employee role does not have a submit permission on salary slip.
calculate_total run server-side method
As salary slip is already submitted, `runserverobj` check validate submit permissions


![](https://frappe.io/files/qU51AUE.png)

Now if the document is submitted it doesn't call the server-side method.