### PR TITLE
fix: cancelling of asset value adjustement

### DIFF
--- a/erpnext/assets/doctype/asset_value_adjustment/asset_value_adjustment.py
+++ b/erpnext/assets/doctype/asset_value_adjustment/asset_value_adjustment.py
@@ -21,9 +21,6 @@ class AssetValueAdjustment(Document):
 		self.reschedule_depreciations(self.new_asset_value)
 
 	def on_cancel(self):
-		if self.journal_entry:
-			frappe.throw(_("Cancel the journal entry {0} first").format(self.journal_entry))
-
 		self.reschedule_depreciations(self.current_asset_value)
 
 	def validate_date(self):


### PR DESCRIPTION
Asset Value Adjustment cannot be cancelled if submitted Journal Entry is linked to it. But to cancel Journal Entry, Asset Value Adjustment has to be cancelled first. Hence it is impossible to cancel them.

<img width="1212" alt="Screenshot 2020-12-23 at 11 55 55 AM" src="https://user-images.githubusercontent.com/25369014/102966396-d24fb180-4515-11eb-845d-3889e26d22de.png">

<img width="1212" alt="Screenshot 2020-12-23 at 11 55 36 AM" src="https://user-images.githubusercontent.com/25369014/102966402-d4b20b80-4515-11eb-999a-227f24d69e17.png">
