### PR TITLE
fix: Do not cancel reference document on Quality Inspection cancellation

### DIFF
--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.js
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.js
@@ -4,6 +4,11 @@
 cur_frm.cscript.refresh = cur_frm.cscript.inspection_type;
 
 frappe.ui.form.on("Quality Inspection", {
+	refresh: function(frm) {
+		// Ignore cancellation of reference doctype on cancel all.
+		frm.ignore_doctypes_on_cancel_all = [frm.doc.reference_type];
+	},
+
 	item_code: function(frm) {
 		if (frm.doc.item_code) {
 			return frm.call({


### PR DESCRIPTION
**Problem**:

On Cancelling Quality Inspection, the link to the reference document is already handled by delinking the reference. The reference document should be ignored while canceling all related documents.

![image](https://user-images.githubusercontent.com/24353136/102987959-36d03800-4539-11eb-8ddd-469386b9d172.png)

![image](https://user-images.githubusercontent.com/24353136/102988217-9d555600-4539-11eb-88ce-3b2b12e83723.png)

**Fix**:

Ignore reference doctype during the cancellation by setting `ignore_doctypes_on_cancel_all`.