### PR TITLE
fix: Tax calculation for Recurring additional salary

### DIFF
--- a/erpnext/payroll/doctype/additional_salary/additional_salary.py
+++ b/erpnext/payroll/doctype/additional_salary/additional_salary.py
@@ -110,11 +110,11 @@ class AdditionalSalary(Document):
 		no_of_days = date_diff(getdate(end_date), getdate(start_date)) + 1
 		return amount_per_day * no_of_days
 
-def get_additional_salaries(employee, start_date, end_date, component_type):
+@frappe.whitelist()
+def get_additional_salary_component(employee, start_date, end_date, component_type):
 	additional_salary_list = frappe.db.sql("""
-		select name, salary_component as component, type, amount,
-		overwrite_salary_structure_amount as overwrite,
-		deduct_full_tax_on_selected_payroll_date
+		select name, salary_component as component, type, amount, overwrite_salary_structure_amount as overwrite,
+		deduct_full_tax_on_selected_payroll_date, is_recurring
 		from `tabAdditional Salary`
 		where employee=%(employee)s
 			and docstatus = 1

--- a/erpnext/payroll/doctype/additional_salary/additional_salary.py
+++ b/erpnext/payroll/doctype/additional_salary/additional_salary.py
@@ -111,7 +111,7 @@ class AdditionalSalary(Document):
 		return amount_per_day * no_of_days
 
 @frappe.whitelist()
-def get_additional_salary_component(employee, start_date, end_date, component_type):
+def get_additional_salaries(employee, start_date, end_date, component_type):
 	additional_salary_list = frappe.db.sql("""
 		select name, salary_component as component, type, amount, overwrite_salary_structure_amount as overwrite,
 		deduct_full_tax_on_selected_payroll_date, is_recurring

--- a/erpnext/payroll/doctype/salary_detail/salary_detail.json
+++ b/erpnext/payroll/doctype/salary_detail/salary_detail.json
@@ -12,6 +12,7 @@
   "year_to_date",
   "section_break_5",
   "additional_salary",
+  "is_recurring_additional_salary",
   "statistical_component",
   "depends_on_payment_days",
   "exempted_from_income_tax",
@@ -235,11 +236,19 @@
    "label": "Year To Date",
    "options": "currency",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.parenttype=='Salary Slip' && doc.parentfield=='earnings' && doc.additional_salary",
+   "fieldname": "is_recurring_additional_salary",
+   "fieldtype": "Check",
+   "label": "Is Recurring Additional Salary",
+   "read_only": 1
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2021-01-14 13:39:15.847158",
+ "modified": "2021-03-14 13:39:15.847158",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Salary Detail",

--- a/erpnext/payroll/doctype/salary_slip/salary_slip.py
+++ b/erpnext/payroll/doctype/salary_slip/salary_slip.py
@@ -711,6 +711,7 @@ class SalarySlip(TransactionBase):
 		# get remaining numbers of sub-period (period for which one salary is processed)
 		remaining_sub_periods = get_period_factor(self.employee,
 			self.start_date, self.end_date, self.payroll_frequency, payroll_period)[1]
+
 		# get taxable_earnings, paid_taxes for previous period
 		previous_taxable_earnings = self.get_taxable_earnings_for_prev_period(payroll_period.start_date,
 			self.start_date, tax_slab.allow_tax_exemption)
@@ -870,8 +871,16 @@ class SalarySlip(TransactionBase):
 
 			if earning.is_tax_applicable:
 				if additional_amount:
-					taxable_earnings += (amount - additional_amount)
-					additional_income += additional_amount
+					if not earning.is_recurring_additional_salary:
+						taxable_earnings += (amount - additional_amount)
+						additional_income += additional_amount
+					else:
+						to_date = frappe.db.get_value("Additional Salary", earning.additional_salary, 'to_date')
+						period = (getdate(to_date).month - getdate(self.start_date).month) + 1
+						if period > 0:
+							taxable_earnings += (amount - additional_amount) * period
+							additional_income += additional_amount * period
+
 					if earning.deduct_full_tax_on_selected_payroll_date:
 						additional_income_with_full_tax += additional_amount
 					continue


### PR DESCRIPTION
Before: Tax calculation of Recurring Additional Salary was calculated on monthly basis.
Suppose, There is a Recurring Additional salary for three months, then every month the amount(monthly) is contributed to yearly taxable earning. then according to tax slabs, it calculate TDS/Income tax

Now: The whole Amount for three months is taken at once and contributed to yearly Taxables earning and tax is calculated accordingly. As taxes are on CTC.
 