### PR TITLE
fix: partial serial no return issue

### DIFF
--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -205,19 +205,21 @@ def get_already_returned_items(doc):
 
 def get_returned_qty_map_for_row(row_name, doctype):
 	child_doctype = doctype + " Item"
-	reference_field = frappe.scrub(child_doctype) if doctype == "Purchase Receipt" else "dn_detail"
+	reference_field = "dn_detail" if doctype == "Delivery Note" else frappe.scrub(child_doctype)
 
 	fields = [
 		"sum(abs(`tab{0}`.qty)) as qty".format(child_doctype),
 		"sum(abs(`tab{0}`.stock_qty)) as stock_qty".format(child_doctype)
 	]
 
-	if doctype == "Purchase Receipt":
+	if doctype in ("Purchase Receipt", "Purchase Invoice"):
 		fields += [
 			"sum(abs(`tab{0}`.rejected_qty)) as rejected_qty".format(child_doctype),
-			"sum(abs(`tab{0}`.received_qty)) as received_qty".format(child_doctype),
-			"sum(abs(`tab{0}`.received_stock_qty)) as received_stock_qty".format(child_doctype)
+			"sum(abs(`tab{0}`.received_qty)) as received_qty".format(child_doctype)
 		]
+
+		if doctype == "Purchase Receipt":
+			fields += ["sum(abs(`tab{0}`.received_stock_qty)) as received_stock_qty".format(child_doctype)]
 
 	data = frappe.db.get_list(doctype,
 		fields = fields,
@@ -231,6 +233,7 @@ def get_returned_qty_map_for_row(row_name, doctype):
 
 def make_return_doc(doctype, source_name, target_doc=None):
 	from frappe.model.mapper import get_mapped_doc
+	from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos
 	company = frappe.db.get_value("Delivery Note", source_name, "company")
 	default_warehouse_for_sales_return = frappe.db.get_value("Company", company, "default_warehouse_for_sales_return")
 
@@ -290,6 +293,12 @@ def make_return_doc(doctype, source_name, target_doc=None):
 	def update_item(source_doc, target_doc, source_parent):
 		target_doc.qty = -1 * source_doc.qty
 
+		if source_doc.serial_no:
+			returned_serial_nos = get_returned_serial_nos(source_doc, source_parent)
+			serial_nos = list(set(get_serial_nos(source_doc.serial_no)) - set(returned_serial_nos))
+			if serial_nos:
+				target_doc.serial_no = '\n'.join(serial_nos)
+
 		if doctype == "Purchase Receipt":
 			returned_qty_map = get_returned_qty_map_for_row(source_doc.name, doctype)
 			target_doc.received_qty = -1 * flt(source_doc.received_qty - (returned_qty_map.get('received_qty') or 0))
@@ -305,10 +314,12 @@ def make_return_doc(doctype, source_name, target_doc=None):
 			target_doc.purchase_receipt_item = source_doc.name
 
 		elif doctype == "Purchase Invoice":
-			target_doc.received_qty = -1 * source_doc.received_qty
-			target_doc.rejected_qty = -1 * source_doc.rejected_qty
-			target_doc.qty = -1* source_doc.qty
-			target_doc.stock_qty = -1 * source_doc.stock_qty
+			returned_qty_map = get_returned_qty_map_for_row(source_doc.name, doctype)
+			target_doc.received_qty = -1 * flt(source_doc.received_qty - (returned_qty_map.get('received_qty') or 0))
+			target_doc.rejected_qty = -1 * flt(source_doc.rejected_qty - (returned_qty_map.get('rejected_qty') or 0))
+			target_doc.qty = -1 * flt(source_doc.qty - (returned_qty_map.get('qty') or 0))
+
+			target_doc.stock_qty = -1 * flt(source_doc.stock_qty - (returned_qty_map.get('stock_qty') or 0))
 			target_doc.purchase_order = source_doc.purchase_order
 			target_doc.purchase_receipt = source_doc.purchase_receipt
 			target_doc.rejected_warehouse = source_doc.rejected_warehouse
@@ -330,6 +341,10 @@ def make_return_doc(doctype, source_name, target_doc=None):
 			if default_warehouse_for_sales_return:
 				target_doc.warehouse = default_warehouse_for_sales_return
 		elif doctype == "Sales Invoice" or doctype == "POS Invoice":
+			returned_qty_map = get_returned_qty_map_for_row(source_doc.name, doctype)
+			target_doc.qty = -1 * flt(source_doc.qty - (returned_qty_map.get('qty') or 0))
+			target_doc.stock_qty = -1 * flt(source_doc.stock_qty - (returned_qty_map.get('stock_qty') or 0))
+
 			target_doc.sales_order = source_doc.sales_order
 			target_doc.delivery_note = source_doc.delivery_note
 			target_doc.so_detail = source_doc.so_detail
@@ -407,3 +422,21 @@ def get_filters(voucher_type, voucher_no, voucher_detail_no, return_against, ite
 		filters["voucher_detail_no"] = reference_voucher_detail_no
 
 	return filters
+
+def get_returned_serial_nos(child_doc, parent_doc):
+	from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos
+	return_ref_field = frappe.scrub(child_doc.doctype)
+	if child_doc.doctype == "Delivery Note Item":
+		return_ref_field = "dn_detail"
+
+	serial_nos = []
+
+	fields = ["`{0}`.`serial_no`".format("tab" + child_doc.doctype)]
+
+	filters = [[parent_doc.doctype, "return_against", "=", parent_doc.name], [parent_doc.doctype, "is_return", "=", 1],
+		[child_doc.doctype, return_ref_field, "=", child_doc.name], [parent_doc.doctype, "docstatus", "=", 1]]
+
+	for row in frappe.get_all(parent_doc.doctype, fields = fields, filters=filters):
+		serial_nos.extend(get_serial_nos(row.serial_no))
+
+	return serial_nos


### PR DESCRIPTION
**1st Issue**

1. Create Delivery Note for 10 items with serial no

1. Create Return for 1 item with 1 serial no

1. Create another delivery note, qty changes to 9 but the serial numbers auto fetched are all 10. 

**2nd Issue**

Replicated for the document Sales Invoice and Purchase Invoice

1. Make sales invoice for 10 quantity 
2. Make sales return for 6 quantity
3. Make one more sales return for remaining quantity, ideally system should show remaining quantity as 4 but it shows the quantity as 10.

