### PR TITLE
fix: added shipment link in delivery note dashboard

### DIFF
--- a/erpnext/stock/doctype/delivery_note/delivery_note.js
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.js
@@ -15,6 +15,7 @@ frappe.ui.form.on("Delivery Note", {
 			'Installation Note': 'Installation Note',
 			'Sales Invoice': 'Invoice',
 			'Stock Entry': 'Return',
+			'Shipment': 'Shipment'
 		},
 		frm.set_indicator_formatter('item_code',
 			function(doc) {

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -598,6 +598,9 @@ def make_shipment(source_name, target_doc=None):
 				pickup_contact_display += '<br>' + user.mobile_no
 		target.pickup_contact = pickup_contact_display
 
+		# As we are using session user details in the pickup_contact then pickup_contact_person will be session user
+		target.pickup_contact_person = frappe.session.user
+
 		contact = frappe.db.get_value("Contact", source.contact_person, ['email_id', 'phone', 'mobile_no'], as_dict=1)
 		delivery_contact_display = '{}'.format(source.contact_display)
 		if contact:
@@ -609,6 +612,13 @@ def make_shipment(source_name, target_doc=None):
 				delivery_contact_display += '<br>' + contact.mobile_no
 		target.delivery_contact = delivery_contact_display
 
+		if source.shipping_address_name:
+			target.delivery_address_name = source.shipping_address_name
+			target.delivery_address = source.shipping_address
+		elif source.customer_address:
+			target.delivery_address_name = source.customer_address
+			target.delivery_address = source.address_display
+
 	doclist = get_mapped_doc("Delivery Note", source_name, 	{
 		"Delivery Note": {
 			"doctype": "Shipment",
@@ -617,9 +627,7 @@ def make_shipment(source_name, target_doc=None):
 				"company": "pickup_company",
 				"company_address": "pickup_address_name",
 				"company_address_display": "pickup_address",
-				"address_display": "delivery_address",
 				"customer": "delivery_customer",
-				"shipping_address_name": "delivery_address_name",
 				"contact_person": "delivery_contact_name",
 				"contact_email": "delivery_contact_email"
 			},
@@ -637,7 +645,7 @@ def make_shipment(source_name, target_doc=None):
 			}
 		}
 	}, target_doc, postprocess)
-	
+
 	return doclist
 
 @frappe.whitelist()

--- a/erpnext/stock/doctype/delivery_note/delivery_note_dashboard.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note_dashboard.py
@@ -19,7 +19,7 @@ def get_data():
 			},
 			{
 				'label': _('Reference'),
-				'items': ['Sales Order', 'Quality Inspection']
+				'items': ['Sales Order', 'Shipment', 'Quality Inspection']
 			},
 			{
 				'label': _('Returns'),

--- a/erpnext/stock/doctype/shipment/shipment.json
+++ b/erpnext/stock/doctype/shipment/shipment.json
@@ -345,7 +345,8 @@
    "label": "Status",
    "no_copy": 1,
    "options": "Draft\nSubmitted\nBooked\nCancelled\nCompleted",
-   "print_hide": 1
+   "print_hide": 1,
+   "read_only": 1
   },
   {
    "fieldname": "tracking_url",
@@ -430,7 +431,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2020-12-02 15:43:44.607039",
+ "modified": "2020-12-25 15:02:34.891976",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Shipment",

--- a/erpnext/stock/doctype/shipment/shipment.py
+++ b/erpnext/stock/doctype/shipment/shipment.py
@@ -5,7 +5,7 @@
 from __future__ import unicode_literals
 import frappe
 from frappe import _
-from frappe.utils import flt
+from frappe.utils import flt, get_time, to_timedelta
 from frappe.model.document import Document
 from erpnext.accounts.party import get_party_shipping_address
 from frappe.contacts.doctype.contact.contact import get_default_contact
@@ -13,6 +13,7 @@ from frappe.contacts.doctype.contact.contact import get_default_contact
 class Shipment(Document):
 	def validate(self):
 		self.validate_weight()
+		self.validate_pickup_time()
 		self.set_value_of_goods()
 		if self.docstatus == 0:
 			self.status = 'Draft'
@@ -31,6 +32,10 @@ class Shipment(Document):
 		for parcel in self.shipment_parcel:
 			if flt(parcel.weight) <= 0:
 				frappe.throw(_('Parcel weight cannot be 0'))
+
+	def validate_pickup_time(self):
+		if self.pickup_from and self.pickup_to and get_time(self.pickup_to) < get_time(self.pickup_from):
+			frappe.throw(_("Pickup To time should be greater than Pickup From time"))
 
 	def set_value_of_goods(self):
 		value_of_goods = 0

--- a/erpnext/stock/doctype/shipment/shipment.py
+++ b/erpnext/stock/doctype/shipment/shipment.py
@@ -5,7 +5,7 @@
 from __future__ import unicode_literals
 import frappe
 from frappe import _
-from frappe.utils import flt, get_time, to_timedelta
+from frappe.utils import flt, get_time
 from frappe.model.document import Document
 from erpnext.accounts.party import get_party_shipping_address
 from frappe.contacts.doctype.contact.contact import get_default_contact


### PR DESCRIPTION
1) Added shipment in the dashboard of the delivery note

<img width="1224" alt="Screenshot 2020-12-25 at 1 48 06 PM" src="https://user-images.githubusercontent.com/8780500/103129536-32ce2280-46bf-11eb-8c60-8ce0f81adade.png">

2) Added validation that Pickup to time should be greater than Pickup from time
3) Fixed address and contact person mapping from delivery note to shipment
4) Enabled read only property for the status field