### PR TITLE
Fix (Regional - UAE): Unknown fieldnames

### DIFF
--- a/erpnext/regional/united_arab_emirates/utils.py
+++ b/erpnext/regional/united_arab_emirates/utils.py
@@ -26,9 +26,9 @@ def update_itemised_tax_data(doc):
 		elif row.item_code and itemised_tax.get(row.item_code):
 			tax_rate = sum([tax.get('tax_rate', 0) for d, tax in itemised_tax.get(row.item_code).items()])
 
-		row.tax_rate = flt(tax_rate, row.precision("tax_rate"))
+		row.item_tax_rate = flt(tax_rate, row.precision("item_tax_rate"))
 		row.tax_amount = flt((row.net_amount * tax_rate) / 100, row.precision("net_amount"))
-		row.total_amount = flt((row.net_amount + row.tax_amount), row.precision("total_amount"))
+		row.net_amount = flt((row.net_amount + row.tax_amount), row.precision("net_amount"))
 
 def get_account_currency(account):
 	"""Helper function to get account currency."""


### PR DESCRIPTION
Updated wrong field names. Please update at the earliest.
Throws error when creating important documents like PO, PI etc.