### PR TITLE
fix: option name for the field 'Role Allowed to Create/Edit Back-dated Transactions'

### DIFF
--- a/erpnext/stock/doctype/stock_settings/stock_settings.json
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.json
@@ -217,7 +217,7 @@
    "fieldname": "role_allowed_to_create_edit_back_dated_transactions",
    "fieldtype": "Link",
    "label": "Role Allowed to Create/Edit Back-dated Transactions",
-   "options": "User"
+   "options": "Role"
   },
   {
    "fieldname": "column_break_26",
@@ -234,7 +234,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2020-11-23 22:26:54.225608",
+ "modified": "2020-12-29 12:53:31.162247",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Settings",


### PR DESCRIPTION
**Issue**

In stock settings, the users list showing in the dropdown for the field "Role Allowed to Create/Edit Back-dated Transactions"

<img width="719" alt="Screenshot 2020-12-29 at 4 24 43 PM" src="https://user-images.githubusercontent.com/8780500/103278937-ab501e80-49f2-11eb-8d9e-bff2b29cee8f.png">


**After Fix**

Roles showing in the dropdown

<img width="790" alt="Screenshot 2020-12-29 at 4 23 50 PM" src="https://user-images.githubusercontent.com/8780500/103278945-b1de9600-49f2-11eb-9052-5a116e7a554a.png">
