### PR TITLE
fix: cannot save asset category without depr posting date

### DIFF
--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -136,6 +136,8 @@ frappe.ui.form.on('Asset', {
 
 		if (frm.doc.docstatus == 0) {
 			frm.toggle_reqd("finance_books", frm.doc.calculate_depreciation);
+			frm.set_df_property('depreciation_start_date', 'reqd', 1, frm.doc.name, 'finance_books');
+			frm.refresh_field('finance_books');
 		}
 	},
 

--- a/erpnext/assets/doctype/asset_category/asset_category.js
+++ b/erpnext/assets/doctype/asset_category/asset_category.js
@@ -50,6 +50,5 @@ frappe.ui.form.on('Asset Category', {
 				}
 			};
 		});
-
 	}
 });

--- a/erpnext/assets/doctype/asset_finance_book/asset_finance_book.json
+++ b/erpnext/assets/doctype/asset_finance_book/asset_finance_book.json
@@ -1,5 +1,4 @@
 {
- "actions": [],
  "creation": "2018-05-08 14:44:37.095570",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -54,9 +53,7 @@
    "fieldname": "depreciation_start_date",
    "fieldtype": "Date",
    "in_list_view": 1,
-   "label": "Depreciation Posting Date",
-   "mandatory_depends_on": "eval:parent.doctype == 'Asset'",
-   "reqd": 1
+   "label": "Depreciation Posting Date"
   },
   {
    "default": "0",
@@ -84,10 +81,8 @@
    "label": "Rate of Depreciation"
   }
  ],
- "index_web_pages_for_search": 1,
  "istable": 1,
- "links": [],
- "modified": "2020-10-30 15:22:29.119868",
+ "modified": "2020-12-30 15:43:03.188256",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset Finance Book",


### PR DESCRIPTION
Fix: depreciation posting date was mandatory while saving asset category.
This happened due to recent backport from version 13 beta where depreciation posting date was set as required based on `mandatory_depends_on` which doesn't work in v12