### PR TITLE
fix: setting correct account for sal struct assignment if not specified.

### DIFF
--- a/erpnext/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py
+++ b/erpnext/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py
@@ -43,7 +43,7 @@ class SalaryStructureAssignment(Document):
 
 	def set_payroll_payable_account(self):
 		if not self.payroll_payable_account:
-			payroll_payable_account = frappe.db.get_value('Company', self.company, 'default_payable_account')
+			payroll_payable_account = frappe.db.get_value('Company', self.company, 'default_payroll_payable_account')
 			if not payroll_payable_account:
 				payroll_payable_account = frappe.db.get_value(
 					"Account", {


### PR DESCRIPTION
Setting "Default Payroll Payable" account as "Payable Account" instead of "Default Payable" account for salary structure assignment.