### PR TITLE
fix: total value difference due to Allow Multiple Material Consumption

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -513,7 +513,7 @@ class StockEntry(StockController):
 		scrap_items_cost = sum([flt(d.basic_amount) for d in self.get("items") if d.is_scrap_item])
 
 		# Get raw materials cost from BOM if multiple material consumption entries
-		if frappe.db.get_single_value("Manufacturing Settings", "material_consumption"):
+		if frappe.db.get_single_value("Manufacturing Settings", "material_consumption") and len(self.items) == 1:
 			bom_items = self.get_bom_raw_materials(finished_item_qty)
 			outgoing_items_cost = sum([flt(row.qty)*flt(row.rate) for row in bom_items.values()])
 


### PR DESCRIPTION
**Issue**

1. Set "Allow Multiple Material Consumption" in the manufacturing settings
2. Create BOM with 3 raw materials and make work order against it.
3. Make stock entry with type as "Material Transfer for Manufacture" against the above work order.
4. Then make manufacture stock entry and remove the one raw materials out of 3. After that check the value of the field "Total Value Difference (Out - In)".
<img width="1185" alt="Screenshot 2021-01-02 at 10 28 22 PM" src="https://user-images.githubusercontent.com/8780500/103462395-eb910300-4d4a-11eb-9941-6d170d56878d.png">


**After Fix**

<img width="1194" alt="Screenshot 2021-01-02 at 10 28 42 PM" src="https://user-images.githubusercontent.com/8780500/103462408-fb104c00-4d4a-11eb-9e33-1b664ac2bf75.png">

