### PR TITLE
fix: Ignore customer and supplier while deleting company transactions

### DIFF
--- a/erpnext/setup/doctype/company/delete_company_transactions.py
+++ b/erpnext/setup/doctype/company/delete_company_transactions.py
@@ -26,7 +26,8 @@ def delete_company_transactions(company_name):
 		tabDocField where fieldtype='Link' and options='Company'"""):
 		if doctype not in ("Account", "Cost Center", "Warehouse", "Budget",
 			"Party Account", "Employee", "Sales Taxes and Charges Template",
-			"Purchase Taxes and Charges Template", "POS Profile", 'BOM'):
+			"Purchase Taxes and Charges Template", "POS Profile", 'BOM', 
+			"Item default", "Customer", "Supplier"):
 				delete_for_doctype(doctype, company_name)
 
 	# reset company values


### PR DESCRIPTION
Issue: Customer and Supplier was getting deleted while deleting company transactions because of newly introduced "Represents company" field