### PR TITLE
fix: incorrect source warehouse in stock entry

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -1010,7 +1010,7 @@ class StockEntry(StockController):
 		wo = frappe.get_doc("Work Order", self.work_order)
 		wo_items = frappe.get_all('Work Order Item',
 			filters={'parent': self.work_order},
-			fields=["item_code", "required_qty", "consumed_qty", "transferred_qty"]
+			fields=["item_code", "required_qty", "consumed_qty", "transferred_qty", "source_warehouse"]
 			)
 
 		work_order_qty = wo.material_transferred_for_manufacturing or wo.qty
@@ -1028,9 +1028,13 @@ class StockEntry(StockController):
 			qty = req_qty_each * flt(self.fg_completed_qty)
 
 			if qty > 0:
+				from_warehouse = wo.wip_warehouse
+				if wo.skip_transfer and not wo.from_wip_warehouse:
+					from_warehouse = item.source_warehouse
+
 				self.add_to_stock_entry_detail({
 					item.item_code: {
-						"from_warehouse": wo.wip_warehouse,
+						"from_warehouse": from_warehouse,
 						"to_warehouse": "",
 						"qty": qty,
 						"item_name": item.item_name,


### PR DESCRIPTION
Steps to replicate the issue

1. Enable "Allow Multiple Material Consumption" and set the backflush based on as "BOM" in the manufacturing settings.
2. Create work order and enable "Skip Material Transfer to WIP Warehouse" and disable " Backflush Raw Materials From Work-in-Progress Warehouse"
3. Submit the work order and click on Finish button
4. System will open the stock entry with Source Warehouse as Work In progress warehouse and not the Source warehouse.

**After Fix**

System has set the Source Warehouse in the stock entry child table from the work order item table.