### PR TITLE
fix: removing payment_field from loan repayment closure

### DIFF
--- a/erpnext/loan_management/report/loan_repayment_and_closure/loan_repayment_and_closure.py
+++ b/erpnext/loan_management/report/loan_repayment_and_closure/loan_repayment_and_closure.py
@@ -103,7 +103,7 @@ def get_data(filters):
 
 	loan_repayments = frappe.get_all("Loan Repayment",
 		filters = query_filters,
-		fields=["posting_date", "applicant", "name", "against_loan", "payment_type", "payable_amount",
+		fields=["posting_date", "applicant", "name", "against_loan", "payable_amount",
 			"pending_principal_amount", "interest_payable", "penalty_amount", "amount_paid"]
 	)
 


### PR DESCRIPTION
**Issue-** 
When open the Loan Repayment and Closure report it pops up this error.
![image](https://user-images.githubusercontent.com/20715976/103534192-70e3f700-4eb4-11eb-8df3-693a90945d59.png)
