### PR TITLE
fix: Dont validate warehouse values between MR to Stock Entry

### DIFF
--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -427,6 +427,7 @@ class TestMaterialRequest(unittest.TestCase):
 			"basic_rate": 1.0
 		})
 		se_doc.get("items")[1].update({
+			"item_code": "_Test Item Home Desktop 100",
 			"qty": 3.0,
 			"transfer_qty": 3.0,
 			"s_warehouse": "_Test Warehouse 1 - _TC",
@@ -537,7 +538,7 @@ class TestMaterialRequest(unittest.TestCase):
 
 		mr = make_material_request(item_code='_Test FG Item', material_request_type='Manufacture',
 			uom="_Test UOM 1", conversion_factor=12)
-		
+
 		requested_qty = self._get_requested_qty('_Test FG Item', '_Test Warehouse - _TC')
 
 		self.assertEqual(requested_qty, existing_requested_qty + 120)

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -1241,9 +1241,8 @@ class StockEntry(StockController):
 				mreq_item = frappe.db.get_value("Material Request Item",
 					{"name": item.material_request_item, "parent": item.material_request},
 					["item_code", "warehouse", "idx"], as_dict=True)
-				if mreq_item.item_code != item.item_code or \
-				mreq_item.warehouse != (item.s_warehouse if self.purpose== "Material Issue" else item.t_warehouse):
-					frappe.throw(_("Item or Warehouse for row {0} does not match Material Request").format(item.idx),
+				if mreq_item.item_code != item.item_code:
+					frappe.throw(_("Item for row {0} does not match Material Request").format(item.idx),
 						frappe.MappingMismatchError)
 
 	def validate_batch(self):


### PR DESCRIPTION
Port of https://github.com/frappe/erpnext/pull/24294

- Remove validation that checks if _**warehouse** in Stock Entry is the same as that in the Material Request that it was pulled from_.
  ![Screenshot 2021-01-04 at 6 51 19 PM](https://user-images.githubusercontent.com/25857446/103538965-32066f00-4ebd-11eb-8677-47d8e2f3881a.png)
- The warehouse could change from a Material Request to Stock Entry often as different user roles raise Material Requests and different user roles stock up warehouses.
- Also at the time of creating MR, it is possible that a purchase user wants to issue/receive an Item but does not know from /to which warehouse. Later the stock user will select a warehouse according to stock levels. In such cases also the warehouse will change.
- Material Requests are usually subject to a lot of changes in the real world, so keeping it flexible would be better.
