### PR TITLE
feat: deleting account & stock entries on deletion of transaction

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -21,7 +21,7 @@
   "book_asset_depreciation_entry_automatically",
   "add_taxes_from_item_tax_template",
   "automatically_fetch_payment_terms",
-  "delete_linked_entries",
+  "delete_linked_ledger_entries",
   "deferred_accounting_settings_section",
   "automatically_process_deferred_accounting_entry",
   "book_deferred_entries_based_on",
@@ -223,9 +223,9 @@
   },
   {
    "default": "0",
-   "fieldname": "delete_linked_entries",
+   "fieldname": "delete_linked_ledger_entries",
    "fieldtype": "Check",
-   "label": "Delete Accounting and Stock Entries on deletion of Transaction"
+   "label": "Delete Accounting and Stock Ledger Entries on deletion of Transaction"
   }
  ],
  "icon": "icon-cog",

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -21,6 +21,7 @@
   "book_asset_depreciation_entry_automatically",
   "add_taxes_from_item_tax_template",
   "automatically_fetch_payment_terms",
+  "delete_linked_entries",
   "deferred_accounting_settings_section",
   "automatically_process_deferred_accounting_entry",
   "book_deferred_entries_based_on",
@@ -219,6 +220,12 @@
    "fieldtype": "Select",
    "label": "Book Deferred Entries Based On",
    "options": "Days\nMonths"
+  },
+  {
+   "default": "0",
+   "fieldname": "delete_linked_entries",
+   "fieldtype": "Check",
+   "label": "Delete Accounting and Stock Entries on deletion of Transaction"
   }
  ],
  "icon": "icon-cog",
@@ -226,7 +233,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2020-10-13 11:32:52.268826",
+ "modified": "2021-01-05 13:04:00.118892",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounts Settings",

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -118,6 +118,12 @@ class AccountsController(TransactionBase):
 	
 	def before_cancel(self):
 		validate_einvoice_fields(self)
+	
+	def on_trash(self):
+		# delete sl and gl entries on deletion of transaction
+		if frappe.db.get_single_value('Accounts Settings', 'delete_linked_entries'):
+			frappe.db.sql("delete from `tabGL Entry` where voucher_type=%s and voucher_no=%s", (self.doctype, self.name))
+			frappe.db.sql("delete from `tabStock Ledger Entry` where voucher_type=%s and voucher_no=%s", (self.doctype, self.name))
 
 	def validate_deferred_start_and_end_date(self):
 		for d in self.items:

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -121,7 +121,7 @@ class AccountsController(TransactionBase):
 	
 	def on_trash(self):
 		# delete sl and gl entries on deletion of transaction
-		if frappe.db.get_single_value('Accounts Settings', 'delete_linked_entries'):
+		if frappe.db.get_single_value('Accounts Settings', 'delete_linked_ledger_entries'):
 			frappe.db.sql("delete from `tabGL Entry` where voucher_type=%s and voucher_no=%s", (self.doctype, self.name))
 			frappe.db.sql("delete from `tabStock Ledger Entry` where voucher_type=%s and voucher_no=%s", (self.doctype, self.name))
 


### PR DESCRIPTION
Added a checkbox in Accounts Settings to allow deletion of linked GL and SL entries on deletion of invoice / receipt
<img width="416" alt="Screenshot 2021-01-05 at 1 11 00 PM" src="https://user-images.githubusercontent.com/25369014/103619360-970ea300-4f57-11eb-9f34-b0856096dcbc.png">

This is done for user who doesn't wants to lose the document id after cancelling the document. They can now cancel and delete the document to get the same document id again.
