### PR TITLE
fix: 'Set Basic Rate Manually' field is now available for Manufacture type stock entry

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -460,7 +460,7 @@ class StockEntry(StockController):
 					scrap_material_cost += flt(d.basic_amount)
 
 		number_of_fg_items = len([t.t_warehouse for t in self.get("items") if t.t_warehouse])
-		if (fg_basic_rate == 0.0 and number_of_fg_items == 1) or update_finished_item_rate:
+		if number_of_fg_items == 1 or update_finished_item_rate:
 			self.set_basic_rate_for_finished_goods(raw_material_cost, scrap_material_cost)
 
 	def get_args_for_incoming_rate(self, item):
@@ -488,6 +488,8 @@ class StockEntry(StockController):
 
 		if self.purpose in ["Manufacture", "Repack"]:
 			for d in self.get("items"):
+				if d.set_basic_rate_manually: continue
+
 				if (d.transfer_qty and (d.bom_no or d.t_warehouse)
 					and (getattr(self, "pro_doc", frappe._dict()).scrap_warehouse != d.t_warehouse)):
 
@@ -499,7 +501,7 @@ class StockEntry(StockController):
 					if raw_material_cost and self.purpose == "Manufacture":
 						d.basic_rate = flt((raw_material_cost - scrap_material_cost) / flt(d.transfer_qty), d.precision("basic_rate"))
 						d.basic_amount = flt((raw_material_cost - scrap_material_cost), d.precision("basic_amount"))
-					elif self.purpose == "Repack" and total_fg_qty and not d.set_basic_rate_manually:
+					elif self.purpose == "Repack" and total_fg_qty:
 						d.basic_rate = flt(raw_material_cost) / flt(total_fg_qty)
 						d.basic_amount = d.basic_rate * flt(d.qty)
 

--- a/erpnext/stock/doctype/stock_entry_detail/stock_entry_detail.json
+++ b/erpnext/stock/doctype/stock_entry_detail/stock_entry_detail.json
@@ -494,7 +494,7 @@
   },
   {
    "default": "0",
-   "depends_on": "eval:parent.purpose===\"Repack\" && doc.t_warehouse",
+   "depends_on": "eval:in_list([\"Repack\", \"Manufacture\"], parent.purpose) && doc.t_warehouse",
    "fieldname": "set_basic_rate_manually",
    "fieldtype": "Check",
    "label": "Set Basic Rate Manually"
@@ -502,7 +502,7 @@
  ],
  "idx": 1,
  "istable": 1,
- "modified": "2020-09-04 12:12:35.668198",
+ "modified": "2021-01-05 15:05:04.891447",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Entry Detail",


### PR DESCRIPTION
The field Set Basic Rate Manually can be visible even if the Stock Entry Type is Manufacture 

![image](https://user-images.githubusercontent.com/8780500/103630833-3f2c6800-4f68-11eb-89d5-393b332932f5.png)
