### PR TITLE
fix: Update item_tax_template_dashboard.py

### DIFF
--- a/erpnext/accounts/doctype/item_tax_template/item_tax_template_dashboard.py
+++ b/erpnext/accounts/doctype/item_tax_template/item_tax_template_dashboard.py
@@ -20,7 +20,8 @@ def get_data():
 				'items': ['Purchase Invoice', 'Purchase Order', 'Purchase Receipt']
 			},
 			{
-				'items': ['Item']
+				'label': _('Stock'),
+				'items': ['Item Groups', 'Item']
 			}
 		]
 	}


### PR DESCRIPTION
added missing backlink and label. 

In Item Groups I can set Item Tax Temple in Table taxes.

![image](https://user-images.githubusercontent.com/22279621/103680433-76117680-4f86-11eb-96ef-018343ee7901.png)

For example in Item I can also set Item Tax Temple inside a Table called taxes:
![image](https://user-images.githubusercontent.com/22279621/103680688-d2749600-4f86-11eb-926d-bc62205787f5.png)
