### PR TITLE
fix: calculation of remaining_sub_periods if relieving date before mo…

### DIFF
--- a/erpnext/payroll/doctype/payroll_period/payroll_period.py
+++ b/erpnext/payroll/doctype/payroll_period/payroll_period.py
@@ -5,7 +5,7 @@
 from __future__ import unicode_literals
 import frappe
 from frappe import _
-from frappe.utils import date_diff, getdate, formatdate, cint, month_diff, flt
+from frappe.utils import date_diff, getdate, formatdate, cint, month_diff, flt, add_months
 from frappe.model.document import Document
 from erpnext.hr.utils import get_holidays_for_employee
 
@@ -88,6 +88,8 @@ def get_period_factor(employee, start_date, end_date, payroll_frequency, payroll
 		period_start = joining_date
 	if relieving_date and getdate(relieving_date) < getdate(period_end):
 		period_end = relieving_date
+		if month_diff(period_end, start_date) > 1:
+			start_date = add_months(start_date, - (month_diff(period_end, start_date)+1))
 
 	total_sub_periods, remaining_sub_periods = 0.0, 0.0
 


### PR DESCRIPTION
![photo_2021-01-01_14-59-25](https://user-images.githubusercontent.com/33727827/103860859-6c048a80-50e2-11eb-846c-00cd57012502.jpg)

The above error would occur when suppose the employee was relieved in December but we are trying to submit the document in later months let's say January.

This would occur because as the employee was relieved in December the end date is considered that but as we are trying to save or submit the document in January the start date is considered to be of January and hence the difference is 0

Now we decrease the start date to the month they were relieved.