### PR TITLE
fix: last purchase rate not updating when voucher cancelled if only one voucher is present

### DIFF
--- a/erpnext/buying/utils.py
+++ b/erpnext/buying/utils.py
@@ -35,8 +35,10 @@ def update_last_purchase_rate(doc, is_submit):
 				frappe.throw(_("UOM Conversion factor is required in row {0}").format(d.idx))
 
 		# update last purchsae rate
-		frappe.db.sql("""update `tabItem` set last_purchase_rate = %s where name = %s""",
-			(flt(last_purchase_rate), d.item_code))
+		frappe.db.set_value('Item', d.item_code, 'last_purchase_rate', flt(last_purchase_rate))
+
+
+
 
 def validate_for_items(doc):
 	items = []

--- a/erpnext/buying/utils.py
+++ b/erpnext/buying/utils.py
@@ -35,9 +35,8 @@ def update_last_purchase_rate(doc, is_submit):
 				frappe.throw(_("UOM Conversion factor is required in row {0}").format(d.idx))
 
 		# update last purchsae rate
-		if last_purchase_rate:
-			frappe.db.sql("""update `tabItem` set last_purchase_rate = %s where name = %s""",
-				(flt(last_purchase_rate), d.item_code))
+		frappe.db.sql("""update `tabItem` set last_purchase_rate = %s where name = %s""",
+			(flt(last_purchase_rate), d.item_code))
 
 def validate_for_items(doc):
 	items = []


### PR DESCRIPTION
Solves the problem when the cancelled Purchase Order/ Receipt did not update the item's last purchase if there are no other vouchers

Steps to Reproduce the issue:
- Create an item
- Create a Purchase Order with this item
- Check the item's last purchase rate is updated
- Now Cancel the Purchase Order
- The item's s last purchase rate is not made 0


