### PR TITLE
fix: Back Update from QC based on Batch No

### DIFF
--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.py
@@ -70,8 +70,11 @@ class QualityInspection(Document):
 
 			if self.reference_type and self.reference_name:
 				conditions = ""
-				if self.batch_no:
+				if self.batch_no and self.docstatus == 1:
 					conditions += " and t1.batch_no = '%s'"%(self.batch_no)
+
+				if self.docstatus == 2: # if cancel, then remove qi link wherever same name
+					conditions += " and t1.quality_inspection = '%s'"%(self.name)
 
 				frappe.db.sql("""
 					UPDATE

--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.py
@@ -69,11 +69,21 @@ class QualityInspection(Document):
 				doctype = 'Stock Entry Detail'
 
 			if self.reference_type and self.reference_name:
+				conditions = ""
+				if self.batch_no:
+					conditions += " and t1.batch_no = '%s'"%(self.batch_no)
+
 				frappe.db.sql("""
-					UPDATE `tab{child_doc}` t1, `tab{parent_doc}` t2
-					SET t1.quality_inspection = %s, t2.modified = %s
-					WHERE t1.parent = %s and t1.item_code = %s and t1.parent = t2.name
-				""".format(parent_doc=self.reference_type, child_doc=doctype),
+					UPDATE
+						`tab{child_doc}` t1, `tab{parent_doc}` t2
+					SET
+						t1.quality_inspection = %s, t2.modified = %s
+					WHERE
+						t1.parent = %s
+						and t1.item_code = %s
+						and t1.parent = t2.name
+						{conditions}
+				""".format(parent_doc=self.reference_type, child_doc=doctype, conditions=conditions),
 					(quality_inspection, self.modified, self.reference_name, self.item_code))
 
 	def set_status_based_on_acceptance_formula(self):


### PR DESCRIPTION
**Issue:**
- On submission of QI for a certain Batch No, it back updates the Stock Entry Child table
- It added QI to all the rows having the same Item code irrespective of Batch, which shouldnt happen if QI is created for particular batch
![Screenshot 2021-01-08 at 9 43 28 AM](https://user-images.githubusercontent.com/25857446/103974615-35894700-5198-11eb-9b11-366e1b16af8f.png)
- Similar on cancellation, all rows having same item were cleared. The same item rows could have different QIs against eachother. Removing all QI links for this item in the table would not be correct.

**Fix:**
- pass Batch as a filter while updating on submit
![Screenshot 2021-01-08 at 9 55 24 AM](https://user-images.githubusercontent.com/25857446/103974628-3d48eb80-5198-11eb-9959-2d3d5e171566.png)

- While updating on QI cancellation, simply remove QI name from table row wherever name is present. 
(cancelled 004, so three rows having 004 are cleared, but row containing 005 is untouched)
![Screenshot 2021-01-08 at 6 39 42 PM](https://user-images.githubusercontent.com/25857446/104018751-5ecdc580-51e0-11eb-8266-585f9d729918.png)

ToDo:

- [x] check impact on cancellation