### PR TITLE
fix: Components formulated from additional salary not being fetched in Payroll Entry

### DIFF
--- a/erpnext/payroll/doctype/salary_slip/salary_slip.py
+++ b/erpnext/payroll/doctype/salary_slip/salary_slip.py
@@ -577,7 +577,7 @@ class SalarySlip(TransactionBase):
 					'default_amount': amount if not struct_row.get("is_additional_component") else 0,
 					'depends_on_payment_days' : struct_row.depends_on_payment_days,
 					'salary_component' : struct_row.salary_component,
-					'abbr' : struct_row.abbr,
+					'abbr' : struct_row.abbr or struct_row.get("salary_component_abbr"),
 					'additional_salary': additional_salary,
 					'do_not_include_in_total' : struct_row.do_not_include_in_total,
 					'is_tax_applicable': struct_row.is_tax_applicable,


### PR DESCRIPTION
**Problem:**

Consider the following Salary Structure where there is an Additional Salary Component and another component dependent on it by the formula:

![additional-salary](https://user-images.githubusercontent.com/24353136/103983402-2fe92c80-51ab-11eb-99bf-5eadf274aa4f.png)

While running the Payroll Entry, the additional salary component gets added to the Salary Slip. However, the component dependent on it (Overtime Allowance) is not added to the salary slip:

![salary-slip-dependent-comp](https://user-images.githubusercontent.com/24353136/103983581-7e96c680-51ab-11eb-8daf-1f68fe8838a0.gif)

**Fix:**

The amount for dependent components is calculated using abbreviations from the formula. However, the abbreviations for Additional Salary were not getting set. After fix:

![salary-slip-dependent-comp-after](https://user-images.githubusercontent.com/24353136/103983956-45128b00-51ac-11eb-8cdf-14ca0aa88a46.gif)

