### PR TITLE
fix: payment entry multi-currency issue

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -401,6 +401,8 @@ frappe.ui.form.on('Payment Entry', {
 
 	set_account_currency_and_balance: function(frm, account, currency_field,
 			balance_field, callback_function) {
+
+		var company_currency = frappe.get_doc(":Company", frm.doc.company).default_currency;
 		if (frm.doc.posting_date && account) {
 			frappe.call({
 				method: "erpnext.accounts.doctype.payment_entry.payment_entry.get_account_details",
@@ -427,6 +429,14 @@ frappe.ui.form.on('Payment Entry', {
 
 									if(!frm.doc.paid_amount && frm.doc.received_amount)
 										frm.events.received_amount(frm);
+
+									if (frm.doc.paid_from_account_currency == frm.doc.paid_to_account_currency
+										&& frm.doc.paid_amount != frm.doc.received_amount) {
+											if (company_currency != frm.doc.paid_from_account_currency &&
+												frm.doc.payment_type == "Pay") {
+													frm.doc.paid_amount = frm.doc.received_amount;
+												}
+										}
 								}
 							},
 							() => {


### PR DESCRIPTION
Steps to replicate issue

1. Company currency set as INR
2. Make supplier and set default payable account in the USD
3. Make Purchase invoice against the above supplier with currency as USD
4. Make payment entry against the purchase invoice and set the mode of payment for the USD currency
5. System will change the Paid Amount from INR to USD but amount will remain same
6. Due to this extra unallocated amount set in the payment entry which is wrong.

**After Fix**
System set the Paid Amount in the USD and not same as INR
