### PR TITLE
fix: check for tax_rate

### DIFF
--- a/erpnext/regional/report/gstr_1/gstr_1.py
+++ b/erpnext/regional/report/gstr_1/gstr_1.py
@@ -255,15 +255,16 @@ class Gstr1Report(object):
 
 						for item_code, tax_amounts in item_wise_tax_detail.items():
 							tax_rate = tax_amounts[0]
-							if cgst_or_sgst:
-								tax_rate *= 2
-								if parent not in self.cgst_sgst_invoices:
-									self.cgst_sgst_invoices.append(parent)
+							if tax_rate:
+								if cgst_or_sgst:
+									tax_rate *= 2
+									if parent not in self.cgst_sgst_invoices:
+										self.cgst_sgst_invoices.append(parent)
 
-							rate_based_dict = self.items_based_on_tax_rate\
-								.setdefault(parent, {}).setdefault(tax_rate, [])
-							if item_code not in rate_based_dict:
-								rate_based_dict.append(item_code)
+								rate_based_dict = self.items_based_on_tax_rate\
+									.setdefault(parent, {}).setdefault(tax_rate, [])
+								if item_code not in rate_based_dict:
+									rate_based_dict.append(item_code)
 					except ValueError:
 						continue
 		if unidentified_gst_accounts:


### PR DESCRIPTION
**Issue:**

1. Create a Sales Invoice with multiple rows in Taxes and Charges, make sure to have a row with rate set and one with rate as 0.

![Screenshot 2021-01-12 at 1 53 30 PM](https://user-images.githubusercontent.com/31363128/104288386-bec4b480-54dd-11eb-8727-3402c59d42af.png)


2. GSTR-1 report shows double entries for such invoices.
2. Because of this, the total value of the report was also getting affected.
3. The report was considering tax rows with the rate 0 as well.

![Screenshot 2021-01-12 at 1 50 01 PM](https://user-images.githubusercontent.com/31363128/104288003-3d6d2200-54dd-11eb-9927-cbb3b97460f2.png)
