### PR TITLE
fix: incorrect serial no in the subcontracted purchase receipt

### DIFF
--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -336,7 +336,7 @@ class BuyingController(StockController):
 				raw_material_data = backflushed_raw_materials_map.get(rm_item_key, {})
 
 				consumed_qty = raw_material_data.get('qty', 0)
-				consumed_serial_nos = raw_material_data.get('serial_nos', '')
+				consumed_serial_nos = raw_material_data.get('serial_no', '')
 				consumed_batch_nos = raw_material_data.get('batch_nos', '')
 
 				transferred_qty = raw_material.qty


### PR DESCRIPTION
backport https://github.com/frappe/erpnext/pull/24353

1. Make subcontracted PO and send 2 serialized raw materials to the supplier warehouse
2. Make two purchase receipts against the above PO
3. In the second purchase receipt system fetch the same serial no which has been fetched in the 1st purchase receipt