### PR TITLE
feat(Healthcare Settings): Do Not Bill Patient Encounters for Inpatients

### DIFF
--- a/erpnext/healthcare/doctype/healthcare_settings/healthcare_settings.json
+++ b/erpnext/healthcare/doctype/healthcare_settings/healthcare_settings.json
@@ -19,6 +19,7 @@
   "valid_days",
   "inpatient_settings_section",
   "allow_discharge_despite_unbilled_services",
+  "do_not_bill_inpatient_encounters",
   "healthcare_service_items",
   "inpatient_visit_charge_item",
   "op_consulting_charge_item",
@@ -315,11 +316,17 @@
    "fieldname": "allow_discharge_despite_unbilled_services",
    "fieldtype": "Check",
    "label": "Allow Discharge Despite Unbilled Healthcare Services"
+  },
+  {
+   "default": "0",
+   "fieldname": "do_not_bill_inpatient_encounters",
+   "fieldtype": "Check",
+   "label": "Do Not Bill Patient Encounters for Inpatients"
   }
  ],
  "issingle": 1,
  "links": [],
- "modified": "2021-01-04 10:19:22.329272",
+ "modified": "2021-01-13 09:04:35.877700",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Healthcare Settings",

--- a/erpnext/healthcare/utils.py
+++ b/erpnext/healthcare/utils.py
@@ -77,11 +77,13 @@ def get_appointments_to_invoice(patient, company):
 
 
 def get_encounters_to_invoice(patient, company):
+	if not isinstance(patient, str):
+		patient = patient.name
 	encounters_to_invoice = []
 	encounters = frappe.get_list(
 		'Patient Encounter',
 		fields=['*'],
-		filters={'patient': patient.name, 'company': company, 'invoiced': False, 'docstatus': 1}
+		filters={'patient': patient, 'company': company, 'invoiced': False, 'docstatus': 1}
 	)
 	if encounters:
 		for encounter in encounters:

--- a/erpnext/healthcare/utils.py
+++ b/erpnext/healthcare/utils.py
@@ -90,6 +90,10 @@ def get_encounters_to_invoice(patient, company):
 				income_account = None
 				service_item = None
 				if encounter.practitioner:
+					if encounter.inpatient_record and \
+						frappe.db.get_single_value('Healthcare Settings', 'do_not_bill_inpatient_encounters'):
+						continue
+
 					service_item, practitioner_charge = get_service_item_and_practitioner_charge(encounter)
 					income_account = get_income_account(encounter.practitioner, encounter.company)
 


### PR DESCRIPTION
Some healthcare facilities do not bill Inpatients for Patient Encounters separately. Made this configurable via Healthcare Settings:

![image](https://user-images.githubusercontent.com/24353136/104406676-d8213b80-5585-11eb-8ff1-1d2cdaf651f6.png)

**Effect**: While doing **Get Items from > Healthcare Services** in Sales Invoice, the system will not fetch patient encounters for Inpatients if this is checked.

Documentation PR: https://github.com/frappe/erpnext_documentation/pull/231