### PR TITLE
fix: validated GST state

### DIFF
--- a/erpnext/regional/india/utils.py
+++ b/erpnext/regional/india/utils.py
@@ -48,6 +48,9 @@ def validate_gstin_for_india(doc, method):
 		validate_gstin_check_digit(doc.gstin)
 		set_gst_state_and_state_number(doc)
 
+		if not doc.gst_state:
+			frappe.throw(_("Please Enter GST state"))
+
 		if doc.gst_state_number != doc.gstin[:2]:
 			frappe.throw(_("Invalid GSTIN! First 2 digits of GSTIN should match with State number {0}.")
 				.format(doc.gst_state_number))


### PR DESCRIPTION
While Adding an Address, when we enter the GSTIN and try to save, this is the error gets. 

![image](https://user-images.githubusercontent.com/32095923/104426603-29dabd80-55a8-11eb-8df1-34ddc48ca8ee.png)

After reading the traceback we understood that the GST State has to be entered as well, but, it never prompted as a Mandatory field, how are we supposed to understand this?
