### PR TITLE
fix(work order): Actual start and end dates update

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -456,10 +456,10 @@ class WorkOrder(Document):
 
 			if data and len(data):
 				dates = [d.posting_datetime for d in data]
-				self.actual_start_date = min(dates)
+				self.db_set('actual_start_date', min(dates))
 
 				if self.status == "Completed":
-					self.actual_end_date = max(dates)
+					self.db_set('actual_end_date', max(dates))
 
 		self.set_lead_time()
 


### PR DESCRIPTION
**PROBLEM**
Currently, even when the Work Order (without Operations) is completed and Stock Entries are there, the Actual Start Date and Actual End Date is not updated. 
<img width="1109" alt="Screen Shot 2021-01-13 at 5 46 53 PM" src="https://user-images.githubusercontent.com/16913064/104452379-ef354d00-55c8-11eb-8068-ea4781ccbacb.png">

**SOLUTION**
For some reason need to db_set, then it updates the Actual Start Date and Actual End Date
<img width="1198" alt="Screen Shot 2021-01-13 at 5 46 33 PM" src="https://user-images.githubusercontent.com/16913064/104452387-f2c8d400-55c8-11eb-936e-df0196d57352.png">

