### PR TITLE
fix: extra transferred qty has not consumed against work order

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -1115,7 +1115,10 @@ class StockEntry(StockController):
 							else:
 								qty = (req_qty_each * flt(self.fg_completed_qty)) - remaining_qty
 					else:
-						qty = req_qty_each * flt(self.fg_completed_qty)
+						if self.flags.backflush_based_on == "Material Transferred for Manufacture":
+							qty = (item.qty/trans_qty) * flt(self.fg_completed_qty)
+						else:
+							qty = req_qty_each * flt(self.fg_completed_qty)
 
 			elif backflushed_materials.get(item.item_code):
 				for d in backflushed_materials.get(item.item_code):
@@ -1123,7 +1126,8 @@ class StockEntry(StockController):
 						if (qty > req_qty):
 							qty = (qty/trans_qty) * flt(self.fg_completed_qty)
 
-						if consumed_qty:
+						if consumed_qty and frappe.db.get_single_value("Manufacturing Settings",
+							"material_consumption"):
 							qty -= consumed_qty
 
 			if cint(frappe.get_cached_value('UOM', item.stock_uom, 'must_be_whole_number')):


### PR DESCRIPTION
**Issue**

1. Set backflush based on as "Material Transferred for Manufacture" and uncheck "Allow Multiple Material Consumption" in manufacturing settings.
2. Create work order for 10 quantity.
2. Transfer double quantity of the raw materials to the work in progress warehouse
3. Finish the work order for 5 quantity, you will come to know that the raw materials quantity has set as per BOM and not as per transferred materials.