### PR TITLE
fix: subscription prepaid date validation

### DIFF
--- a/erpnext/accounts/doctype/subscription/subscription.py
+++ b/erpnext/accounts/doctype/subscription/subscription.py
@@ -333,7 +333,7 @@ class Subscription(Document):
 		if not self.generate_invoice_at_period_start:
 			return False
 
-		if self.is_new_subscription():
+		if self.is_new_subscription() and getdate(nowdate()) >= getdate(self.current_invoice_start):
 			return True
 
 		# Check invoice dates and make sure it doesn't have outstanding invoices


### PR DESCRIPTION
**Issue:**

1. Subscription Invoice got generated on the wrong date.
2. The subscription start date is 15-01-2021.

![image](https://user-images.githubusercontent.com/31363128/104409629-b37c9200-558c-11eb-84dc-e6f97310ca00.png)

3. The invoice got created before 15-01-2021

![image](https://user-images.githubusercontent.com/31363128/104409689-da3ac880-558c-11eb-89da-2dde60968baa.png)

4. The subscription had Generate Invoice At Beginning Of Period checked, this didn't behave as expected.
