### PR TITLE
fix: Ignore group cost center validation for period closing voucher

### DIFF
--- a/erpnext/accounts/doctype/gl_entry/gl_entry.py
+++ b/erpnext/accounts/doctype/gl_entry/gl_entry.py
@@ -138,7 +138,8 @@ class GLEntry(Document):
 			frappe.throw(_("{0} {1}: Cost Center {2} does not belong to Company {3}")
 				.format(self.voucher_type, self.voucher_no, self.cost_center, self.company))
 
-		if not self.flags.from_repost and self.cost_center and _check_is_group():
+		if not self.flags.from_repost and not self.voucher_type == 'Period Closing Voucher' \
+			and self.cost_center and _check_is_group():
 			frappe.throw(_("""{0} {1}: Cost Center {2} is a group cost center and group cost centers cannot
 				be used in transactions""").format(self.voucher_type, self.voucher_no, frappe.bold(self.cost_center)))
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/42651287/104586650-c0cc7600-568b-11eb-822c-d3fe9b66c837.png)

Group Cost Center validation was introduced recently which started causing issues while posting period closing voucher
Add a flag to ignore that validation