### PR TITLE
fix: stock ledger entry was not created against stock reco

### DIFF
--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -216,7 +216,7 @@ class StockReconciliation(StockController):
 				if row.qty and not row.valuation_rate:
 					frappe.throw(_("Valuation Rate required for Item {0} at row {1}").format(row.item_code, row.idx))
 
-				if ((previous_sle and row.qty == previous_sle.get("qty_after_transaction")
+				if (not item.has_batch_no and (previous_sle and row.qty == previous_sle.get("qty_after_transaction")
 					and (row.valuation_rate == previous_sle.get("valuation_rate") or row.qty == 0))
 					or (not previous_sle and not row.qty)):
 						continue

--- a/erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.js
+++ b/erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.js
@@ -61,9 +61,11 @@ frappe.query_reports["Batch-Wise Balance History"] = {
 			"options": "Batch",
 			"get_query": function() {
 				let item_code = frappe.query_report.get_filter_value('item_code');
-				return {
-					filters: {
-						"item": item_code
+				if (item_code) {
+					return {
+						filters: {
+							"item": item_code
+						}
 					}
 				}
 			}


### PR DESCRIPTION
1. Create purchase receipt for batch item with 2 quantity in warehouse A
2. Create one more purchase receipt for 1 quantity in warehouse A with different batch and same incoming rate.
3. Make delivery note for the batch item with 1 qty (use 1st in-warded batch) 
4. After that make stock reco for the batch item with warehouse A and update the qty from 1 to 2 for the 1st batch
5. On submission of stock reco check the stock ledger, you can't see the stock ledger entries against it.