### PR TITLE
fix: ams integration breaks when error raised

### DIFF
--- a/erpnext/erpnext_integrations/doctype/amazon_mws_settings/amazon_methods.py
+++ b/erpnext/erpnext_integrations/doctype/amazon_mws_settings/amazon_methods.py
@@ -117,7 +117,7 @@ def call_mws_method(mws_method, *args, **kwargs):
 			return response
 		except Exception as e:
 			delay = math.pow(4, x) * 125
-			frappe.log_error(message=e, title=str(mws_method))
+			frappe.log_error(message=e, title=f'Method "{mws_method.__name__}" failed')
 			time.sleep(delay)
 			continue
 


### PR DESCRIPTION
Logging breaks because title greater than 140 chars
`Error Log 1b41e6594b: 'Title' (<bound method Orders.list_orders of <erpnext.erpnext_integrations.doctype.amazon_mws_settings.amazon_mws_api.Orders object at 0x7f2bedbc1438>>) will get truncated, as max characters allowed is 140`

Add the method name instead of trying to convert the function object to a string