### PR TITLE
fix: missing Asset Id in the Fixed Asset Register Report

### DIFF
--- a/erpnext/assets/report/fixed_asset_register/fixed_asset_register.py
+++ b/erpnext/assets/report/fixed_asset_register/fixed_asset_register.py
@@ -141,7 +141,7 @@ def get_data(filters):
 
 	assets_record = frappe.db.get_all("Asset",
 		filters=conditions,
-		fields=["name", "asset_name", "department", "cost_center", "purchase_receipt",
+		fields=["name as asset_id", "asset_name", "department", "cost_center", "purchase_receipt",
 			"asset_category", "purchase_date", "gross_purchase_amount", "location",
 			"available_for_use_date", "status", "purchase_invoice", "opening_accumulated_depreciation"])
 


### PR DESCRIPTION
Issue: Asset Id was missing in the Report Fixed Asset Register.

Before:
![Screenshot 2021-01-18 at 11 47 02 AM](https://user-images.githubusercontent.com/60467153/104879608-2e2a2080-5984-11eb-8b89-265917edd68a.png)

After:
![Screenshot 2021-01-18 at 11 50 16 AM](https://user-images.githubusercontent.com/60467153/104879677-544fc080-5984-11eb-9a33-b8376caf31ee.png)


