### PR TITLE
fix: select sal comp while making sal struct

### DIFF
--- a/erpnext/payroll/doctype/salary_structure/salary_structure.js
+++ b/erpnext/payroll/doctype/salary_structure/salary_structure.js
@@ -70,6 +70,9 @@ frappe.ui.form.on('Salary Structure', {
 		});
 	},
 
+	company: function(frm) {
+		frm.trigger('set_earning_deduction_component');
+	},
 
 	currency: function(frm) {
 		calculate_totals(frm.doc);
@@ -117,6 +120,7 @@ frappe.ui.form.on('Salary Structure', {
 		fields_read_only.forEach(function(field) {
 			frappe.meta.get_docfield("Salary Detail", field, frm.doc.name).read_only = 1;
 		});
+		frm.trigger('set_earning_deduction_component');
 	},
 
 	assign_to_employees:function (frm) {

--- a/erpnext/payroll/doctype/salary_structure/salary_structure.py
+++ b/erpnext/payroll/doctype/salary_structure/salary_structure.py
@@ -216,7 +216,7 @@ def get_earning_deduction_components(doctype, txt, searchfield, start, page_len,
 	return frappe.db.sql("""
 		select t1.salary_component
 		from `tabSalary Component` t1, `tabSalary Component Account` t2
-		where t1.salary_component = t2.parent
+		where t1.name = t2.parent
 		and t1.type = %s 
 		and t2.company = %s
 		order by salary_component


### PR DESCRIPTION
While making salary structure salary components didn't use to fetch correctly. Changed the query for the same.