### PR TITLE
fix: Request URL for patch test db backup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ jobs:
   - name: "Python 3.6 Patch Test"
     python: 3.6
     before_script:
-      - wget http://build.erpnext.com/20171108_190013_955977f8_database.sql.gz
+      - wget http://build.erpnext.com/BACKUPS/20171108_190013_955977f8_database.sql.gz
       - bench --site test_site --force restore ~/frappe-bench/20171108_190013_955977f8_database.sql.gz
     script: bench --site test_site migrate
 


### PR DESCRIPTION
Directory change in backup file hosted on http://build.erpnext.com/ caused:
![Screenshot 2021-01-20 at 5 52 42 PM](https://user-images.githubusercontent.com/25857446/105173844-9bd27a00-5b47-11eb-9b62-e52f093b13b7.png)

Fixed the same