### PR TITLE
fix: stock ageing should not take cancelled stock entries.

### DIFF
--- a/erpnext/stock/report/stock_ageing/stock_ageing.py
+++ b/erpnext/stock/report/stock_ageing/stock_ageing.py
@@ -233,7 +233,8 @@ def get_stock_ledger_entries(filters):
 				from `tabItem` {item_conditions}) item
 		where item_code = item.name and
 			company = %(company)s and
-			posting_date <= %(to_date)s
+			posting_date <= %(to_date)s and
+			is_cancelled != 1
 			{sle_conditions}
 			order by posting_date, posting_time, sle.creation, actual_qty""" #nosec
 		.format(item_conditions=get_item_conditions(filters),


### PR DESCRIPTION
### stock ageing should not take cancelled stock entries.

Issue: A stock ageing report showing incorrect stock
In the stock ledger report, there is no stock available for Item '0104-Spindle Assembly Double Pulley (In House)'
![image](https://user-images.githubusercontent.com/33727827/105353936-e3273c00-5c15-11eb-9af7-bb1869e5e7bb.png)



Stock showing in Stock Ageing Report in 91-above days
![image](https://user-images.githubusercontent.com/33727827/105353950-e7535980-5c15-11eb-9761-4bef2836c9c1.png)


