### PR TITLE
feat: shopping portal changes

### DIFF
--- a/erpnext/shopping_cart/cart.py
+++ b/erpnext/shopping_cart/cart.py
@@ -180,6 +180,13 @@ def create_lead_for_item_inquiry(lead, subject, message):
 	lead_doc.update(lead)
 	lead_doc.set('lead_owner', '')
 
+	if not frappe.db.exists('Lead Source', 'Product Inquiry'):
+		frappe.get_doc({
+			'doctype': 'Lead Source',
+			'source_name' : 'Product Inquiry'
+		}).insert(ignore_permissions=True)
+	lead_doc.set('source', 'Product Inquiry')
+
 	try:
 		lead_doc.save(ignore_permissions=True)
 	except frappe.exceptions.DuplicateEntryError:

--- a/erpnext/templates/pages/cart.html
+++ b/erpnext/templates/pages/cart.html
@@ -47,7 +47,7 @@
 
 	{% if doc.items %}
 		<div class="place-order-container">
-			<a class="btn btn-primary-light" href="/all-products">
+			<a class="btn btn-primary-light mr-2" href="/all-products">
 				{{ _("Add More") }}
 			</a>
 			{% if cart_settings.enable_checkout %}

--- a/erpnext/templates/pages/cart.html
+++ b/erpnext/templates/pages/cart.html
@@ -48,7 +48,7 @@
 	{% if doc.items %}
 		<div class="place-order-container">
 			<a class="btn btn-primary-light mr-2" href="/all-products">
-				{{ _("Add More") }}
+				{{ _("Continue Shopping") }}
 			</a>
 			{% if cart_settings.enable_checkout %}
 				<button class="btn btn-primary btn-place-order" type="button">

--- a/erpnext/templates/pages/cart.html
+++ b/erpnext/templates/pages/cart.html
@@ -47,6 +47,9 @@
 
 	{% if doc.items %}
 		<div class="place-order-container">
+			<a class="btn btn-primary-light" href="/all-products">
+				{{ _("Add More") }}
+			</a>
 			{% if cart_settings.enable_checkout %}
 				<button class="btn btn-primary btn-place-order" type="button">
 					{{ _("Place Order") }}


### PR DESCRIPTION
- Capturing Lead source(**Product Inquiry**) when a lead is created from the product detail page's 'Contact Us' button.
- Added **Continue Shopping** button on cart page with redirects to the all-products page.
![sc-changes](https://user-images.githubusercontent.com/20715976/105450192-fc74ca80-5c9f-11eb-94f5-a503bdd7b7a3.gif)
