### PR TITLE
fix: SLA not applied automatically when priority is missing

### DIFF
--- a/erpnext/support/doctype/issue/issue.py
+++ b/erpnext/support/doctype/issue/issue.py
@@ -214,7 +214,7 @@ class Issue(Document):
 
 	def before_insert(self):
 		if frappe.db.get_single_value("Support Settings", "track_service_level_agreement"):
-			self.set_response_and_resolution_time(priority=self.priority, service_level_agreement=self.service_level_agreement)
+			self.set_response_and_resolution_time()
 
 	def set_response_and_resolution_time(self, priority=None, service_level_agreement=None):
 		service_level_agreement = get_active_service_level_agreement_for(priority=priority,


### PR DESCRIPTION
SLA not getting applied automatically when priority is missing. The priority might not be set during issue creation so it should not be used as a filter in `before_insert` event.