### PR TITLE
fix: remove function to get earning deduction components

### DIFF
--- a/erpnext/payroll/doctype/additional_salary/additional_salary.js
+++ b/erpnext/payroll/doctype/additional_salary/additional_salary.js
@@ -53,7 +53,7 @@ frappe.ui.form.on('Additional Salary', {
 		if (!frm.doc.company) return;
 		frm.set_query("salary_component", function() {
 			return {
-				filters: {type: ["in",["earning", "deduction"]], company: frm.doc.company}
+				filters: {type: ["in", ["earning", "deduction"]], company: frm.doc.company}
 			};
 		});
 	},

--- a/erpnext/payroll/doctype/additional_salary/additional_salary.js
+++ b/erpnext/payroll/doctype/additional_salary/additional_salary.js
@@ -53,8 +53,7 @@ frappe.ui.form.on('Additional Salary', {
 		if (!frm.doc.company) return;
 		frm.set_query("salary_component", function() {
 			return {
-				query: "erpnext.payroll.doctype.salary_structure.salary_structure.get_earning_deduction_components",
-				filters: {type: "earning", company: frm.doc.company}
+				filters: {type: ["in",["earning", "deduction"]], company: frm.doc.company}
 			};
 		});
 	},

--- a/erpnext/payroll/doctype/employee_incentive/employee_incentive.js
+++ b/erpnext/payroll/doctype/employee_incentive/employee_incentive.js
@@ -44,7 +44,6 @@ frappe.ui.form.on('Employee Incentive', {
 	},
 
 	set_earning_component: function(frm) {
-		debugger;
 		if (!frm.doc.company) return;
 		frm.set_query("salary_component", function() {
 			return {

--- a/erpnext/payroll/doctype/employee_incentive/employee_incentive.js
+++ b/erpnext/payroll/doctype/employee_incentive/employee_incentive.js
@@ -10,15 +10,7 @@ frappe.ui.form.on('Employee Incentive', {
 				}
 			};
 		});
-
-		if (!frm.doc.company) return;
-		frm.set_query("salary_component", function() {
-			return {
-				query: "erpnext.payroll.doctype.salary_structure.salary_structure.get_earning_deduction_components",
-				filters: {type: "earning", company: frm.doc.company}
-			};
-		});
-
+		frm.trigger('set_earning_component');
 	},
 
 	employee: function(frm) {
@@ -45,8 +37,19 @@ frappe.ui.form.on('Employee Incentive', {
 			callback: function(data) {
 				if (data.message) {
 					frm.set_value("company", data.message.company);
+					frm.trigger('set_earning_component');
 				}
 			}
+		});
+	},
+
+	set_earning_component: function(frm) {
+		debugger;
+		if (!frm.doc.company) return;
+		frm.set_query("salary_component", function() {
+			return {
+				filters: {type: "earning", company: frm.doc.company}
+			};
 		});
 	},
 

--- a/erpnext/payroll/doctype/salary_structure/salary_structure.js
+++ b/erpnext/payroll/doctype/salary_structure/salary_structure.js
@@ -58,13 +58,11 @@ frappe.ui.form.on('Salary Structure', {
 		if(!frm.doc.company) return;
 		frm.set_query("salary_component", "earnings", function() {
 			return {
-				query : "erpnext.payroll.doctype.salary_structure.salary_structure.get_earning_deduction_components",
 				filters: {type: "earning", company: frm.doc.company}
 			};
 		});
 		frm.set_query("salary_component", "deductions", function() {
 			return {
-				query : "erpnext.payroll.doctype.salary_structure.salary_structure.get_earning_deduction_components",
 				filters: {type: "deduction", company: frm.doc.company}
 			};
 		});

--- a/erpnext/payroll/doctype/salary_structure/salary_structure.py
+++ b/erpnext/payroll/doctype/salary_structure/salary_structure.py
@@ -207,22 +207,3 @@ def get_employees(salary_structure):
 
 	return list(set([d.employee for d in employees]))
 
-@frappe.whitelist()
-@frappe.validate_and_sanitize_search_inputs
-def get_earning_deduction_components(doctype, txt, searchfield, start, page_len, filters):
-	if len(filters) < 2:
-		return {}
-
-	return frappe.db.sql("""
-		select t1.salary_component
-		from `tabSalary Component` t1, `tabSalary Component Account` t2
-		where (t1.name = t2.parent
-		and t1.type = %(type)s
-		and t2.company = %(company)s)
-		or (t1.type = %(type)s
-		and t1.statistical_component = 1)
-		order by salary_component
-	""",{
-		"type": filters['type'],
-		"company": filters['company']
-	})


### PR DESCRIPTION
Removed function to get earning deduction components as it was redundant and unnecessary.
