### PR TITLE
chore: Set Stock Entry Form Indicators in setup

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -9,7 +9,7 @@ frappe.ui.form.on('Stock Entry', {
 			if (!doc.s_warehouse) {
 				return 'blue';
 			} else {
-				return (doc.qty<=doc.actual_qty) ? 'green' : 'orange'
+				return (doc.qty<=doc.actual_qty) ? 'green' : 'orange';
 			}
 		});
 

--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -5,6 +5,14 @@ frappe.provide("erpnext.accounts.dimensions");
 
 frappe.ui.form.on('Stock Entry', {
 	setup: function(frm) {
+		frm.set_indicator_formatter('item_code', function(doc) {
+			if (!doc.s_warehouse) {
+				return 'blue';
+			} else {
+				return (doc.qty<=doc.actual_qty) ? 'green' : 'orange'
+			}
+		});
+
 		frm.set_query('work_order', function() {
 			return {
 				filters: [
@@ -778,15 +786,6 @@ erpnext.stock.StockEntry = erpnext.stock.StockController.extend({
 				}
 			}
 		}
-
-		this.frm.set_indicator_formatter('item_code',
-			function(doc) {
-				if (!doc.s_warehouse) {
-					return 'blue';
-				} else {
-					return (doc.qty<=doc.actual_qty) ? "green" : "orange"
-				}
-			})
 
 		this.frm.add_fetch("purchase_order", "supplier", "supplier");
 


### PR DESCRIPTION
- Moved `set_indicator_formatter` from extended stock controller `setup` to form setup
- Style consistency with other forms (DN, PO, etc.) that set indicator in `setup` as well
- Makes it easier to customise
- No UI impact, it will look just as it used to