### PR TITLE
feat: Create Journal Entry from Bank Transaction, requires frappe bugfix - V12

### DIFF
--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
@@ -8,6 +8,7 @@ from erpnext.controllers.status_updater import StatusUpdater
 from frappe.utils import flt
 from six.moves import reduce
 from frappe import _
+from frappe.model.mapper import get_mapped_doc
 
 class BankTransaction(StatusUpdater):
 	def after_insert(self):
@@ -112,3 +113,58 @@ def unclear_reference_payment(doctype, docname):
 			frappe.db.set_value(doc.payment_document, doc.payment_entry, "clearance_date", None)
 
 		return doc.payment_entry
+
+@frappe.whitelist()
+def make_journal_entry(source_name, target_doc=None,
+	opposite_account=None, party={'type': None, 'name': None}, reference={'type': None, 'name': None}):
+
+	doc = get_mapped_doc('Bank Transaction', source_name, {
+		'Bank Transaction': {
+			'doctype': 'Journal Entry',
+			# From Bank Transaction -> Journal Entry
+			'field_map': {
+				"company": "company",
+				"date": "cheque_date",
+				"transaction_id": "cheque_no",
+				"description": "user_remark"
+			},
+			'field_no_map': ['accounts'],
+			'validation': {
+				'docstatus': ['=', 1]
+			}
+		}
+	}, target_doc)
+	doc.voucher_type = 'Bank Entry'
+
+	bank_trans = frappe.get_cached_doc('Bank Transaction', source_name)
+	bank_ac = frappe.get_value('Bank Account', bank_trans.bank_account, 'account')
+
+	credit_row = frappe.new_doc('Journal Entry Account', doc, 'accounts')
+	doc.append('accounts', credit_row)
+	debit_row = frappe.new_doc('Journal Entry Account', doc, 'accounts')
+	doc.append('accounts', debit_row)
+
+	if bank_trans.credit > 0:
+		# They paid us
+		amount = bank_trans.credit
+		opp_row = credit_row
+		bank_row = debit_row
+	else:
+		# We paid them
+		amount = bank_trans.debit
+		opp_row = debit_row
+		bank_row = credit_row
+
+	bank_row.account = bank_ac
+	bank_row.bank_account = bank_trans.bank_account
+
+	opp_row.account = opposite_account
+	opp_row.party_type = party['type']
+	opp_row.party = party['name']
+	opp_row.reference_type = reference['type']
+	opp_row.reference_name = reference['name']
+
+	credit_row.credit_in_account_currency = amount
+	debit_row.debit_in_account_currency = amount
+
+	return doc

--- a/erpnext/accounts/page/bank_reconciliation/bank_reconciliation.js
+++ b/erpnext/accounts/page/bank_reconciliation/bank_reconciliation.js
@@ -335,32 +335,32 @@ erpnext.accounts.ReconciliationRow = class ReconciliationRow {
 		$(me.row).on('click', '.clickable-section', function() {
 			me.bank_entry = $(this).attr("data-name");
 			me.show_dialog($(this).attr("data-name"));
-		})
+		});
 
 		$(me.row).on('click', '.new-reconciliation', function() {
 			me.bank_entry = $(this).attr("data-name");
 			me.show_dialog($(this).attr("data-name"));
-		})
+		});
 
 		$(me.row).on('click', '.new-payment', function() {
 			me.bank_entry = $(this).attr("data-name");
 			me.new_payment();
-		})
+		});
 
 		$(me.row).on('click', '.new-invoice', function() {
 			me.bank_entry = $(this).attr("data-name");
 			me.new_invoice();
-		})
+		});
 
 		$(me.row).on('click', '.new-expense', function() {
 			me.bank_entry = $(this).attr("data-name");
 			me.new_expense();
-		})
+		});
 
 		$(me.row).on('click', '.new-journal', function() {
 			me.bank_entry = $(this).attr("data-name");
 			me.new_journal();
-		})
+		});
 
 	}
 
@@ -389,7 +389,7 @@ erpnext.accounts.ReconciliationRow = class ReconciliationRow {
 		frappe.model.open_mapped_doc({
 			method: "erpnext.accounts.doctype.bank_transaction.bank_transaction.make_journal_entry",
 			source_name: this.bank_entry
-		})
+		});
 	}
 
 	show_dialog(data) {

--- a/erpnext/accounts/page/bank_reconciliation/bank_reconciliation.js
+++ b/erpnext/accounts/page/bank_reconciliation/bank_reconciliation.js
@@ -356,6 +356,12 @@ erpnext.accounts.ReconciliationRow = class ReconciliationRow {
 			me.bank_entry = $(this).attr("data-name");
 			me.new_expense();
 		})
+
+		$(me.row).on('click', '.new-journal', function() {
+			me.bank_entry = $(this).attr("data-name");
+			me.new_journal();
+		})
+
 	}
 
 	new_payment() {
@@ -379,6 +385,12 @@ erpnext.accounts.ReconciliationRow = class ReconciliationRow {
 		frappe.new_doc("Expense Claim")
 	}
 
+	new_journal() {
+		frappe.model.open_mapped_doc({
+			method: "erpnext.accounts.doctype.bank_transaction.bank_transaction.make_journal_entry",
+			source_name: this.bank_entry
+		})
+	}
 
 	show_dialog(data) {
 		const me = this;

--- a/erpnext/accounts/page/bank_reconciliation/bank_transaction_row.html
+++ b/erpnext/accounts/page/bank_reconciliation/bank_transaction_row.html
@@ -29,6 +29,7 @@
 					<li><a class="new-payment" data-name={{ name }}>{{ __("New Payment") }}</a></li>
 					<li><a class="new-invoice" data-name={{ name }}>{{ __("New Invoice") }}</a></li>
 					<li><a class="new-expense" data-name={{ name }}>{{ __("New Expense") }}</a></li>
+					<li><a class="new-journal" data-name={{ name }}>{{ __("New Journal") }}</a></li>
 				</ul>
 			</div>
 		</div>


### PR DESCRIPTION
Add to the list of options given when reconciling bank transactions.
Hopefully one of many PRs on the way to automating bank transaction journals using Plaid.

Related to frappe/frappe#12280