### PR TITLE
chore: Use sql to set naming series in older projects

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -749,4 +749,4 @@ erpnext.patches.v13_0.update_project_template_tasks
 erpnext.patches.v13_0.set_company_in_leave_ledger_entry
 erpnext.patches.v13_0.convert_qi_parameter_to_link_field
 erpnext.patches.v13_0.setup_patient_history_settings_for_standard_doctypes
-erpnext.patches.v13_0.add_naming_series_to_old_projects
+erpnext.patches.v13_0.add_naming_series_to_old_projects # 1-02-2021

--- a/erpnext/patches/v13_0/add_naming_series_to_old_projects.py
+++ b/erpnext/patches/v13_0/add_naming_series_to_old_projects.py
@@ -4,23 +4,11 @@ from frappe.custom.doctype.property_setter.property_setter import make_property_
 
 def execute():
 	frappe.reload_doc("projects", "doctype", "project")
-	projects = frappe.db.get_all("Project",
-		fields=["name", "naming_series", "modified"],
-		filters={
-			"naming_series": ["is", "not set"]
-		},
-		order_by="timestamp(modified) asc")
 
-	# disable set only once as the old docs must be saved
-	# (to bypass 'Cant change naming series' validation on save)
-	make_property_setter("Project", "naming_series", "set_only_once", 0, "Check")
+	frappe.db.sql("""UPDATE `tabProject`
+		SET
+			naming_series = 'PROJ-.####'
+		WHERE
+			naming_series is NULL""")
 
-	for entry in projects:
-		# need to save the doc so that users can edit old projects
-		doc = frappe.get_doc("Project", entry.name)
-		if not doc.naming_series:
-			doc.naming_series = "PROJ-.####"
-			doc.save()
-
-	delete_property_setter("Project", "set_only_once", "naming_series")
 	frappe.db.commit()

--- a/erpnext/patches/v13_0/add_naming_series_to_old_projects.py
+++ b/erpnext/patches/v13_0/add_naming_series_to_old_projects.py
@@ -11,4 +11,3 @@ def execute():
 		WHERE
 			naming_series is NULL""")
 
-	frappe.db.commit()


### PR DESCRIPTION
https://github.com/frappe/erpnext/pull/23210/ caused some issues on saving older projects.
Custom Select fields with outdated values (options changed) would throw errors.

Fix:
- Set the naming series in the db directly

**To test (devs only):**
- Uncheck mandatory in Naming series field of Project Doctype. Empty the options
- Set autoname to `field:project_name`
- Create some projects. Their names will be set by `project_name`
- Now check mandatory in Naming series field of Project. Add the options (`PROJ-.####`) [reverse first point]
- Try to edit newly created projects. It will throw Mandatory Error.
- Run the patch.
- Try to edit the same projects. Should work.
