### PR TITLE
fix: Numeric/Non-numeric QI UX

### DIFF
--- a/erpnext/stock/doctype/item_quality_inspection_parameter/item_quality_inspection_parameter.json
+++ b/erpnext/stock/doctype/item_quality_inspection_parameter/item_quality_inspection_parameter.json
@@ -8,7 +8,7 @@
  "field_order": [
   "specification",
   "value",
-  "non_numeric",
+  "numeric",
   "column_break_3",
   "min_value",
   "max_value",
@@ -29,7 +29,7 @@
    "width": "100px"
   },
   {
-   "depends_on": "eval:(!doc.formula_based_criteria && doc.non_numeric)",
+   "depends_on": "eval:(!doc.formula_based_criteria && !doc.numeric)",
    "fieldname": "value",
    "fieldtype": "Data",
    "in_list_view": 1,
@@ -55,32 +55,32 @@
    "label": "Formula Based Criteria"
   },
   {
-   "depends_on": "eval:(!doc.formula_based_criteria && !doc.non_numeric)",
+   "depends_on": "eval:(!doc.formula_based_criteria && doc.numeric)",
    "fieldname": "min_value",
    "fieldtype": "Float",
    "in_list_view": 1,
    "label": "Minimum Value"
   },
   {
-   "depends_on": "eval:(!doc.formula_based_criteria && !doc.non_numeric)",
+   "depends_on": "eval:(!doc.formula_based_criteria && doc.numeric)",
    "fieldname": "max_value",
    "fieldtype": "Float",
    "in_list_view": 1,
    "label": "Maximum Value"
   },
   {
-   "default": "0",
-   "fieldname": "non_numeric",
+   "default": "1",
+   "fieldname": "numeric",
    "fieldtype": "Check",
    "in_list_view": 1,
-   "label": "Non-Numeric",
+   "label": "Numeric",
    "width": "80px"
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2021-01-07 21:32:49.866439",
+ "modified": "2021-02-01 19:18:46.924399",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Item Quality Inspection Parameter",

--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.py
@@ -97,7 +97,7 @@ class QualityInspection(Document):
 					self.set_status_based_on_acceptance_values(reading)
 
 	def set_status_based_on_acceptance_values(self, reading):
-		if cint(reading.non_numeric):
+		if not cint(reading.numeric):
 			result = reading.get("reading_value") == reading.get("value")
 		else:
 			# numeric readings
@@ -136,7 +136,7 @@ class QualityInspection(Document):
 
 	def get_formula_evaluation_data(self, reading):
 		data = {}
-		if cint(reading.non_numeric):
+		if not cint(reading.numeric):
 			data = {"reading_value": reading.get("reading_value")}
 		else:
 			# numeric readings

--- a/erpnext/stock/doctype/quality_inspection/test_quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/test_quality_inspection.py
@@ -55,7 +55,7 @@ class TestQualityInspection(unittest.TestCase):
 		},
 		{
 			"specification": "Particle Inspection Needed", # non-numeric reading
-			"non_numeric": 1,
+			"numeric": 0,
 			"value": "Yes",
 			"reading_value": "Yes"
 		}]
@@ -96,7 +96,7 @@ class TestQualityInspection(unittest.TestCase):
 		{
 			"specification": "Calcium Content", # non-numeric reading
 			"formula_based_criteria": 1,
-			"non_numeric": 1,
+			"numeric": 0,
 			"acceptance_formula": "reading_value in ('Grade A', 'Grade B', 'Grade C')",
 			"reading_value": "Grade B"
 		}]

--- a/erpnext/stock/doctype/quality_inspection_reading/quality_inspection_reading.json
+++ b/erpnext/stock/doctype/quality_inspection_reading/quality_inspection_reading.json
@@ -54,7 +54,7 @@
    "oldfieldtype": "Data"
   },
   {
-   "columns": 1,
+   "columns": 2,
    "fieldname": "reading_1",
    "fieldtype": "Data",
    "in_list_view": 1,
@@ -66,7 +66,6 @@
    "columns": 1,
    "fieldname": "reading_2",
    "fieldtype": "Data",
-   "in_list_view": 1,
    "label": "Reading 2",
    "oldfieldname": "reading_2",
    "oldfieldtype": "Data"
@@ -185,6 +184,7 @@
    "label": "Maximum Value"
   },
   {
+   "columns": 2,
    "depends_on": "non_numeric",
    "fieldname": "reading_value",
    "fieldtype": "Data",
@@ -215,7 +215,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2021-01-07 22:16:53.978410",
+ "modified": "2021-02-01 18:59:33.629441",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Quality Inspection Reading",

--- a/erpnext/stock/doctype/quality_inspection_reading/quality_inspection_reading.json
+++ b/erpnext/stock/doctype/quality_inspection_reading/quality_inspection_reading.json
@@ -9,7 +9,7 @@
   "specification",
   "status",
   "value",
-  "non_numeric",
+  "numeric",
   "manual_inspection",
   "column_break_4",
   "min_value",
@@ -46,7 +46,7 @@
   },
   {
    "columns": 2,
-   "depends_on": "eval:(!doc.formula_based_criteria && doc.non_numeric)",
+   "depends_on": "eval:(!doc.formula_based_criteria && !doc.numeric)",
    "fieldname": "value",
    "fieldtype": "Data",
    "label": "Acceptance Criteria Value",
@@ -139,7 +139,7 @@
    "options": "\nAccepted\nRejected"
   },
   {
-   "depends_on": "non_numeric",
+   "depends_on": "eval:!doc.numeric",
    "fieldname": "section_break_3",
    "fieldtype": "Section Break",
    "label": "Value Based Inspection"
@@ -170,14 +170,14 @@
    "label": "Formula Based Criteria"
   },
   {
-   "depends_on": "eval:(!doc.formula_based_criteria && !doc.non_numeric)",
+   "depends_on": "eval:(!doc.formula_based_criteria && doc.numeric)",
    "description": "Applied on each reading.",
    "fieldname": "min_value",
    "fieldtype": "Float",
    "label": "Minimum Value"
   },
   {
-   "depends_on": "eval:(!doc.formula_based_criteria && !doc.non_numeric)",
+   "depends_on": "eval:(!doc.formula_based_criteria && doc.numeric)",
    "description": "Applied on each reading.",
    "fieldname": "max_value",
    "fieldtype": "Float",
@@ -185,24 +185,17 @@
   },
   {
    "columns": 2,
-   "depends_on": "non_numeric",
+   "depends_on": "eval:!doc.numeric",
    "fieldname": "reading_value",
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Reading Value"
   },
   {
-   "depends_on": "eval:!doc.non_numeric",
+   "depends_on": "numeric",
    "fieldname": "section_break_14",
    "fieldtype": "Section Break",
    "label": "Numeric Inspection"
-  },
-  {
-   "default": "0",
-   "fieldname": "non_numeric",
-   "fieldtype": "Check",
-   "in_list_view": 1,
-   "label": "Non-Numeric"
   },
   {
    "default": "0",
@@ -210,12 +203,19 @@
    "fieldname": "manual_inspection",
    "fieldtype": "Check",
    "label": "Manual Inspection"
+  },
+  {
+   "default": "1",
+   "fieldname": "numeric",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Numeric"
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2021-02-01 18:59:33.629441",
+ "modified": "2021-02-01 19:46:22.138018",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Quality Inspection Reading",

--- a/erpnext/stock/doctype/quality_inspection_template/quality_inspection_template.py
+++ b/erpnext/stock/doctype/quality_inspection_template/quality_inspection_template.py
@@ -14,6 +14,6 @@ def get_template_details(template):
 
 	return frappe.get_all('Item Quality Inspection Parameter',
 		fields=["specification", "value", "acceptance_formula",
-			"non_numeric", "formula_based_criteria", "min_value", "max_value"],
+			"numeric", "formula_based_criteria", "min_value", "max_value"],
 		filters={'parenttype': 'Quality Inspection Template', 'parent': template},
 		order_by="idx")


### PR DESCRIPTION
- Removed `Reading 2` column and adjusted columns to make it more clear that one is a numeric reading field and the other is not.
  ![Screenshot 2021-02-01 at 7 57 01 PM](https://user-images.githubusercontent.com/25857446/106470739-dc76af80-64c6-11eb-9f36-3dfa31f7a854.png)
- Changed "Non-numeric" checkbox to "Numeric" which will be checked by default. Works as it used to. Reduced cognitive load. Done in template and transaction table.
 ![Screenshot 2021-02-01 at 7 41 05 PM](https://user-images.githubusercontent.com/25857446/106471174-61fa5f80-64c7-11eb-8b8e-20e2fbd87a72.png)
