### PR TITLE
fix: creating salary slip from timesheet

### DIFF
--- a/erpnext/projects/doctype/timesheet/timesheet.py
+++ b/erpnext/projects/doctype/timesheet/timesheet.py
@@ -288,7 +288,7 @@ def make_sales_invoice(source_name, item_code=None, customer=None):
 def make_salary_slip(source_name, target_doc=None):
 	target = frappe.new_doc("Salary Slip")
 	set_missing_values(source_name, target)
-	target.run_method("get_emp_and_leave_details")
+	target.run_method("get_emp_and_working_day_details")
 
 	return target
 


### PR DESCRIPTION
While making salary slip from the timesheet this error gets pop up.

![image](https://user-images.githubusercontent.com/33727827/106725353-490cbe00-662f-11eb-95ec-761f1838b59b.png)

This occurs because the salary structure should have been set by itself but it doesn't because the call function name was changed in https://github.com/frappe/erpnext/pull/21258 and was missed from here.