### PR TITLE
fix: StopIteration error when e-invoice not enabled

### DIFF
--- a/erpnext/regional/india/e_invoice/utils.py
+++ b/erpnext/regional/india/e_invoice/utils.py
@@ -444,6 +444,8 @@ class GSPConnector():
 	def get_credentials(self):
 		if self.invoice:
 			gstin = self.get_seller_gstin()
+			if not self.e_invoice_settings.enable:
+				frappe.throw(_("{} isn't enabled. Please enable it.").format(get_link_to_form("E Invoice Settings", "E Invoice Settings")))
 			credentials = next(d for d in self.e_invoice_settings.credentials if d.gstin == gstin)
 		else:
 			credentials = self.e_invoice_settings.credentials[0] if self.e_invoice_settings.credentials else None

--- a/erpnext/regional/india/e_invoice/utils.py
+++ b/erpnext/regional/india/e_invoice/utils.py
@@ -445,7 +445,7 @@ class GSPConnector():
 		if self.invoice:
 			gstin = self.get_seller_gstin()
 			if not self.e_invoice_settings.enable:
-				frappe.throw(_("{} isn't enabled. Please enable it.").format(get_link_to_form("E Invoice Settings", "E Invoice Settings")))
+				frappe.throw(_("E-Invoicing is disabled. Please enable it from {} to generate e-invoices.").format(get_link_to_form("E Invoice Settings", "E Invoice Settings")))
 			credentials = next(d for d in self.e_invoice_settings.credentials if d.gstin == gstin)
 		else:
 			credentials = self.e_invoice_settings.credentials[0] if self.e_invoice_settings.credentials else None


### PR DESCRIPTION
When E Invoice Settings in not enabled ever, following error occurs:

Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2021-01-28/apps/frappe/frappe/app.py", line 67, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-12-2021-01-28/apps/frappe/frappe/api.py", line 59, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-12-2021-01-28/apps/frappe/frappe/handler.py", line 24, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-12-2021-01-28/apps/frappe/frappe/handler.py", line 64, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-12-2021-01-28/apps/frappe/frappe/__init__.py", line 1064, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-12-2021-01-28/apps/erpnext/erpnext/regional/india/e_invoice/utils.py", line 805, in generate_irn
    gsp_connector = GSPConnector(doctype, docname)
  File "/home/frappe/benches/bench-version-12-2021-01-28/apps/erpnext/erpnext/regional/india/e_invoice/utils.py", line 433, in __init__
    self.credentials = self.get_credentials()
  File "/home/frappe/benches/bench-version-12-2021-01-28/apps/erpnext/erpnext/regional/india/e_invoice/utils.py", line 449, in get_credentials
    credentials = next(d for d in self.e_invoice_settings.credentials if d.gstin == gstin)
StopIteration

This happens because there isn't any value in the credentials table.

Having a check if the setting is enabled or not will stop this error as if it is enabled user has to add at least one value in the table.