### PR TITLE
fix(Leave Application): List view fix

### DIFF
--- a/erpnext/hr/doctype/leave_application/leave_application_list.js
+++ b/erpnext/hr/doctype/leave_application/leave_application_list.js
@@ -1,5 +1,6 @@
 frappe.listview_settings['Leave Application'] = {
 	add_fields: ["leave_type", "employee", "employee_name", "total_leave_days", "from_date", "to_date"],
+	has_indicator_for_draft: 1,
 	get_indicator: function (doc) {
 		if (doc.status === "Approved") {
 			return [__("Approved"), "green", "status,=,Approved"];


### PR DESCRIPTION
Currently, the Leave Application shows Status as Draft in the document and in the list view. But according to the default Workflow, it should show as Open.

<img width="578" alt="Screen Shot 2021-02-04 at 6 42 26 PM" src="https://user-images.githubusercontent.com/16913064/106898266-f956f100-6719-11eb-82d6-225915e730c1.png">

Very minor fix, just added has_indicator_for_draft in the listview setting.

<img width="832" alt="Screen Shot 2021-02-04 at 6 53 05 PM" src="https://user-images.githubusercontent.com/16913064/106898501-476bf480-671a-11eb-890c-336e4ef121fc.png">
