### PR TITLE
fix: (ui) Empty State text font weight in Item Dashboard

### DIFF
--- a/erpnext/stock/dashboard/item_dashboard.js
+++ b/erpnext/stock/dashboard/item_dashboard.js
@@ -132,7 +132,7 @@ erpnext.stock.ItemDashboard = Class.extend({
 			var message = __("No Stock Available Currently");
 			this.content.find('.result').css('text-align', 'center');
 
-			$(`<div class='text-muted' style='margin: 20px 5px; font-weight: lighter;'>
+			$(`<div class='text-muted' style='margin: 20px 5px;'>
 				${message} </div>`).appendTo(this.result);
 		}
 	},


### PR DESCRIPTION
**Before:**
![Screenshot 2021-02-05 at 11 22 48 PM](https://user-images.githubusercontent.com/25857446/107153508-f36c4480-6993-11eb-881e-d4908f8183fb.png)


**After:**
![Screenshot 2021-02-05 at 11 24 28 PM](https://user-images.githubusercontent.com/25857446/107153513-f6ffcb80-6993-11eb-9701-5179d4dc9414.png)
