### PR TITLE
fix: Avoid changing Ref. Doctype in Accounting Dimension after creation

### DIFF
--- a/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.js
+++ b/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.js
@@ -42,7 +42,7 @@ frappe.ui.form.on('Accounting Dimension', {
 			});
 		}
 
-		frm.toggle_enable('document_type', doc.__islocal);
+		frm.toggle_enable('document_type', frm.doc.__islocal);
 	},
 
 	document_type: function(frm) {

--- a/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.js
+++ b/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.js
@@ -41,6 +41,8 @@ frappe.ui.form.on('Accounting Dimension', {
 				});
 			});
 		}
+
+		frm.toggle_enable('document_type', doc.__islocal);
 	},
 
 	document_type: function(frm) {

--- a/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.py
+++ b/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.py
@@ -29,6 +29,16 @@ class AccountingDimension(Document):
 		if exists and self.is_new():
 			frappe.throw("Document Type already used as a dimension")
 
+		if not self.is_new():
+			self.validate_document_type_change()
+
+	def validate_document_type_change(self):
+		doctype_before_save = frappe.db.get_value("Accounting Dimension", self.name, "document_type")
+		if doctype_before_save != self.document_type:
+			message = _("Cannot change Reference Document Type.")
+			message += _("Please create a new Accounting Dimension if required.")
+			frappe.throw(message)
+
 	def after_insert(self):
 		if frappe.flags.in_test:
 			make_dimension_in_accounting_doctypes(doc=self)


### PR DESCRIPTION
Port of https://github.com/frappe/erpnext/pull/24578

<h2>Issue:</h2>

- On creating an Accounting Dimension, `fieldname` is set and custom fields are created 
- For e.g. Acc. Dimension **Branch** is created, `fieldname` is set as `branch`. Custom fields `branch` are created in doctypes that affect accounting ledgers
- Now a user changes the **Reference Document Type** to **Territory** from **Branch** and Saves this record
- Custom field creation does not run again as it runs only once on record creation. Hence, the doctype field change has no affect on the Accounting Dimension whatsoever
- Now if you go to **General Ledger Report**, the filter field will show **Territory** and will try to search for results in custom field `territory`, which does not exist. `branch` exists.
  ```
       Unknown column 'territory' in where clause
   ```
- Deleting Dimension **Territory** does not delete custom fields `branch`

<h2>Fix:</h2>

- Made **Reference Document Type** a read only field **after first save**
- Don't let users change this field as they are not aware custom fields are created based on it.
- If a dimension was wrongly created, they must delete it , so that custom fields are deleted. And then create the appropriate one.
- Validation for the same on server side for API manipulations.