### PR TITLE
fix: Inpatient Medication Orders report test

### DIFF
--- a/erpnext/healthcare/doctype/inpatient_record/test_inpatient_record.py
+++ b/erpnext/healthcare/doctype/inpatient_record/test_inpatient_record.py
@@ -145,7 +145,7 @@ def create_inpatient(patient):
 
 def get_healthcare_service_unit(unit_name=None):
 	if not unit_name:
-		service_unit = get_random("Healthcare Service Unit", filters={"inpatient_occupancy": 1})
+		service_unit = get_random("Healthcare Service Unit", filters={"inpatient_occupancy": 1, "company": "_Test Company"})
 	else:
 		service_unit = frappe.db.exists("Healthcare Service Unit", {"healthcare_service_unit_name": unit_name})
 

--- a/erpnext/healthcare/report/inpatient_medication_orders/test_inpatient_medication_orders.py
+++ b/erpnext/healthcare/report/inpatient_medication_orders/test_inpatient_medication_orders.py
@@ -119,7 +119,7 @@ def create_records(patient):
 	ip_record.expected_length_of_stay = 0
 	ip_record.save()
 	ip_record.reload()
-	service_unit = get_healthcare_service_unit()
+	service_unit = get_healthcare_service_unit('Test Service Unit Ip Occupancy')
 	admit_patient(ip_record, service_unit, now_datetime())
 
 	ipmo = create_ipmo(patient)


### PR DESCRIPTION
```
FAIL: test_inpatient_medication_orders_report (erpnext.healthcare.report.inpatient_medication_orders.test_inpatient_medication_orders.TestInpatientMedicationOrders)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/travis/frappe-bench/apps/erpnext/erpnext/healthcare/report/inpatient_medication_orders/test_inpatient_medication_orders.py", line 75, in test_inpatient_medication_orders_report
    self.assertEqual(expected_data, report[1])
AssertionError: Lists differ: [{'patient': '_Test IPD Patient', 'inpatie[1027 chars]TC'}] != []
First list contains 3 additional elements.
First extra element 0:
{'patient': '_Test IPD Patient', 'inpatient_record': 'HLC-INP-2021-00015', 'practitioner': None, 'drug': 'Dextromethorphan', 'drug_name': 'Dextromethorphan', 'dosage': 1.0, 'dosage_form': 'Tablet', 'date': datetime.date(2021, 2, 9), 'time': datetime.timedelta(0, 32400), 'is_completed': 0, 'healthcare_service_unit': 'Test Service Unit Ip Occupancy - _TC'}
Diff is 1208 characters long. Set self.maxDiff to None to see it.
```