### PR TITLE
fix: NoneType has no len()

### DIFF
--- a/erpnext/regional/india/e_invoice/utils.py
+++ b/erpnext/regional/india/e_invoice/utils.py
@@ -23,7 +23,7 @@ def validate_einvoice_fields(doc):
 	invalid_doctype = doc.doctype != 'Sales Invoice'
 	invalid_supply_type = doc.get('gst_category') not in ['Registered Regular', 'SEZ', 'Overseas', 'Deemed Export']
 	company_transaction = doc.get('billing_address_gstin') == doc.get('company_gstin')
-	no_taxes_applied = len(doc.get('taxes')) == 0
+	no_taxes_applied = len(doc.get('taxes', [])) == 0
 
 	if not einvoicing_enabled or invalid_doctype or invalid_supply_type or company_transaction or no_taxes_applied:
 		return


### PR DESCRIPTION
Fix
```
 File "/home/frappe/frappe-io-bench/apps/frappe/frappe/model/document.py", line 320, in _save
    self.run_before_save_methods()
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/model/document.py", line 956, in run_before_save_methods
    self.run_method("before_cancel")
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/model/document.py", line 848, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/model/document.py", line 1135, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/model/document.py", line 1118, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/frappe-io-bench/apps/frappe/frappe/model/document.py", line 842, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/frappe-io-bench/apps/erpnext/erpnext/controllers/accounts_controller.py", line 137, in before_cancel
    validate_einvoice_fields(self)
  File "/home/frappe/frappe-io-bench/apps/erpnext/erpnext/__init__.py", line 129, in caller
    return frappe.get_attr(regional_overrides[region][fn_name])(*args, **kwargs)
  File "/home/frappe/frappe-io-bench/apps/erpnext/erpnext/regional/india/e_invoice/utils.py", line 26, in validate_einvoice_fields
    no_taxes_applied = len(doc.get('taxes')) == 0
TypeError: object of type 'NoneType' has no len()
```