### PR TITLE
fix: Added parent task expected end date validation

### DIFF
--- a/erpnext/projects/doctype/project/test_project.py
+++ b/erpnext/projects/doctype/project/test_project.py
@@ -37,7 +37,7 @@ class TestProject(unittest.TestCase):
 
 		task1 = task_exists("Test Template Task Parent")
 		if not task1:
-			task1 = create_task(subject="Test Template Task Parent", is_group=1, is_template=1, begin=1, duration=1)
+			task1 = create_task(subject="Test Template Task Parent", is_group=1, is_template=1, begin=1, duration=4)
 
 		task2 = task_exists("Test Template Task Child 1")
 		if not task2:
@@ -52,7 +52,7 @@ class TestProject(unittest.TestCase):
 		tasks = frappe.get_all('Task', ['subject','exp_end_date','depends_on_tasks', 'name', 'parent_task'], dict(project=project.name), order_by='creation asc')
 
 		self.assertEqual(tasks[0].subject, 'Test Template Task Parent')
-		self.assertEqual(getdate(tasks[0].exp_end_date), calculate_end_date(project, 1, 1))
+		self.assertEqual(getdate(tasks[0].exp_end_date), calculate_end_date(project, 1, 4))
 
 		self.assertEqual(tasks[1].subject, 'Test Template Task Child 1')
 		self.assertEqual(getdate(tasks[1].exp_end_date), calculate_end_date(project, 1, 3))

--- a/erpnext/projects/doctype/task/task.py
+++ b/erpnext/projects/doctype/task/task.py
@@ -30,7 +30,7 @@ class Task(NestedSet):
 
     def validate(self):
         self.validate_dates()
-		self.validate_parent_expected_end_date()
+        self.validate_parent_expected_end_date()
         self.validate_parent_project_dates()
         self.validate_progress()
         self.validate_status()
@@ -46,11 +46,11 @@ class Task(NestedSet):
             frappe.throw(_("{0} can not be greater than {1}").format(frappe.bold("Actual Start Date"), \
                 frappe.bold("Actual End Date")))
 
-	def validate_parent_expected_end_date(self):
-		if self.parent_task:
-			parent_exp_end_date = frappe.db.get_value("Task", self.parent_task, "exp_end_date")
-			if getdate(self.get('exp_end_date')) > getdate(parent_exp_end_date):
-				frappe.throw(_("Expected End Date should be less than or equal to parents task's Expected End Date {0}.").format(getdate(parent_exp_end_date)))
+    def validate_parent_expected_end_date(self):
+        if self.parent_task:
+            parent_exp_end_date = frappe.db.get_value("Task", self.parent_task, "exp_end_date")
+            if parent_exp_end_date and getdate(self.get("exp_end_date")) > getdate(parent_exp_end_date):
+                frappe.throw(_("Expected End Date should be less than or equal to parent task's Expected End Date {0}.").format(getdate(parent_exp_end_date)))
 
     def validate_parent_project_dates(self):
         if not self.project or frappe.flags.in_test:

--- a/erpnext/projects/doctype/task/task.py
+++ b/erpnext/projects/doctype/task/task.py
@@ -30,6 +30,7 @@ class Task(NestedSet):
 
     def validate(self):
         self.validate_dates()
+		self.validate_parent_expected_end_date()
         self.validate_parent_project_dates()
         self.validate_progress()
         self.validate_status()
@@ -44,6 +45,12 @@ class Task(NestedSet):
         if self.act_start_date and self.act_end_date and getdate(self.act_start_date) > getdate(self.act_end_date):
             frappe.throw(_("{0} can not be greater than {1}").format(frappe.bold("Actual Start Date"), \
                 frappe.bold("Actual End Date")))
+
+	def validate_parent_expected_end_date(self):
+		if self.parent_task:
+			parent_exp_end_date = frappe.db.get_value("Task", self.parent_task, "exp_end_date")
+			if getdate(self.get('exp_end_date')) > getdate(parent_exp_end_date):
+				frappe.throw(_("Expected End Date should be less than or equal to parents task's Expected End Date {0}.").format(getdate(parent_exp_end_date)))
 
     def validate_parent_project_dates(self):
         if not self.project or frappe.flags.in_test:


### PR DESCRIPTION
Currently, a Task's Expected Date can be set as a later date and the system accepts it without validating the Expected End of the Parent Task, that shouldn't be the case, because we don't allow Parent Task to get completed before the Child Task