### PR TITLE
fix: incorrect incoming rate for the sales return

### DIFF
--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -310,12 +310,27 @@ class SellingController(StockController):
 				if flt(d.conversion_factor)==0.0:
 					d.conversion_factor = get_conversion_factor(d.item_code, d.uom).get("conversion_factor") or 1.0
 				return_rate = 0
-				if cint(self.is_return) and self.return_against and self.docstatus==1:
-					against_document_no = (d.get("sales_invoice_item")
-						if self.doctype == "Sales Invoice" else d.get("delivery_note_item"))
+				if cint(self.is_return) and self.docstatus==1:
+					if self.return_against:
+						against_document_no = (d.get("sales_invoice_item")
+							if self.doctype == "Sales Invoice" else d.get("delivery_note_item"))
 
-					return_rate = self.get_incoming_rate_for_sales_return(d.item_code,
-						self.return_against, against_document_no)
+						return_rate = self.get_incoming_rate_for_sales_return(d.item_code,
+							self.return_against, against_document_no)
+					else:
+						# For standalone credit note
+						args = frappe._dict({
+							"item_code": d.item_code,
+							"warehouse": d.warehouse,
+							"posting_date": self.posting_date,
+							"posting_time": self.posting_time,
+							"qty": flt(d.qty),
+							"serial_no": d.serial_no,
+							"company": d.company,
+							"allow_zero_valuation": d.allow_zero_valuation
+						})
+
+						return_rate = get_incoming_rate(args)
 
 				# On cancellation or if return entry submission, make stock ledger entry for
 				# target warehouse first, to update serial no values properly


### PR DESCRIPTION
**Issue**

Make standalone sales invoice return entry with update stock and submit it. After submit check the stock ledger entry, you will found that the incoming rate has set as zero in the stock ledger entry. Due to zero incoming rate system has calculated incorrect valuation rate for the future entries.

<img width="205" alt="Screenshot 2021-02-12 at 1 18 34 PM" src="https://user-images.githubusercontent.com/8780500/107742626-6cbdbb80-6d35-11eb-96e2-24bc84fd38bb.png">


**After Fix**

<img width="271" alt="Screenshot 2021-02-12 at 1 20 25 PM" src="https://user-images.githubusercontent.com/8780500/107742686-88c15d00-6d35-11eb-8bf5-9c11cc8ed8f4.png">
