### PR TITLE
fix: Add homepage to sitemap

### DIFF
--- a/erpnext/templates/pages/home.py
+++ b/erpnext/templates/pages/home.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 import frappe
 
 no_cache = 1
+sitemap = 1
 
 def get_context(context):
 	homepage = frappe.get_doc('Homepage')


### PR DESCRIPTION
Fixes the puzzling omission of the homepage from the sitemap
Crawlers should resolve the canonical path of the page if there are duplicates:
`['', 'home']`
`<link rel="canonical" href="http://v13:8002">`
[https://moz.com/learn/seo/canonicalization](https://moz.com/learn/seo/canonicalization)

Related frappe/frappe#10613

@netchampfaris 
@Mergifyio backport version-12-hotfix