### PR TITLE
fix: excluding unidentified accounts from gstr-1

### DIFF
--- a/erpnext/regional/report/gstr_1/gstr_1.py
+++ b/erpnext/regional/report/gstr_1/gstr_1.py
@@ -236,6 +236,7 @@ class Gstr1Report(object):
 		self.cgst_sgst_invoices = []
 
 		unidentified_gst_accounts = []
+		unidentified_gst_accounts_invoice = []
 		for parent, account, item_wise_tax_detail, tax_amount in self.tax_details:
 			if account in self.gst_accounts.cess_account:
 				self.invoice_cess.setdefault(parent, tax_amount)
@@ -251,6 +252,7 @@ class Gstr1Report(object):
 						if not (cgst_or_sgst or account in self.gst_accounts.igst_account):
 							if "gst" in account.lower() and account not in unidentified_gst_accounts:
 								unidentified_gst_accounts.append(account)
+								unidentified_gst_accounts_invoice.append(parent)
 							continue
 
 						for item_code, tax_amounts in item_wise_tax_detail.items():
@@ -273,7 +275,7 @@ class Gstr1Report(object):
 
 		# Build itemised tax for export invoices where tax table is blank
 		for invoice, items in iteritems(self.invoice_items):
-			if invoice not in self.items_based_on_tax_rate \
+			if invoice not in self.items_based_on_tax_rate and invoice not in unidentified_gst_accounts_invoice \
 				and frappe.db.get_value(self.doctype, invoice, "export_type") == "Without Payment of Tax":
 					self.items_based_on_tax_rate.setdefault(invoice, {}).setdefault(0, items.keys())
 


### PR DESCRIPTION
**Issue:**

1. Invoices with Unidentified Accounts (Accounts not added in GST Settings) were reflecting in GSTR-1.

**Steps to Replicate:**

1. Create Sales Invoice and add such GST accounts in the Sales Taxes and Charges table that are not present in GST settings.

**GST Settings**
![Screenshot 2021-02-18 at 7 18 39 PM](https://user-images.githubusercontent.com/31363128/108366271-304efb80-721e-11eb-98d9-1a9c43fe3251.png)


**Sales Taxes and Charges in Sales Invoice**
![Screenshot 2021-02-18 at 7 19 01 PM](https://user-images.githubusercontent.com/31363128/108366288-33e28280-721e-11eb-9aea-13613f877430.png)

2. Keep the Sales invoice amount less than the B2C Limit of GST settings and submit the invoice.
3. Go to GSTR-1 Report and select B2C Small as Type of Business. 
4. The invoice amount should not reflect in the report.

**Before the fix:**
![Screenshot 2021-02-18 at 7 17 26 PM](https://user-images.githubusercontent.com/31363128/108366168-11506980-721e-11eb-986c-1b1bdcda110e.png)

**After the fix:**
![Screenshot 2021-02-18 at 7 22 34 PM](https://user-images.githubusercontent.com/31363128/108366710-ad7a7080-721e-11eb-8af6-3013c93b5826.png)
