### PR TITLE
fix(regional): vehicle no is mandatory for ewaybill generation

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -754,3 +754,4 @@ erpnext.patches.v13_0.setup_patient_history_settings_for_standard_doctypes
 erpnext.patches.v13_0.add_naming_series_to_old_projects # 1-02-2021
 erpnext.patches.v12_0.add_state_code_for_ladakh
 erpnext.patches.v13_0.item_reposting_for_incorrect_sl_and_gl
+erpnext.patches.v13_0.update_vehicle_no_reqd_condition

--- a/erpnext/patches/v13_0/update_vehicle_no_reqd_condition.py
+++ b/erpnext/patches/v13_0/update_vehicle_no_reqd_condition.py
@@ -1,0 +1,9 @@
+import frappe
+
+def execute():
+    company = frappe.get_all('Company', filters = {'country': 'India'})
+	if not company:
+		return
+
+    if frappe.db.exists('Custom Field', { 'fieldname': 'vehicle_no' }):
+        frappe.db.set_value('Custom Field', { 'fieldname': 'vehicle_no' }, 'mandatory_depends_on', '')

--- a/erpnext/regional/india/e_invoice/einvoice.js
+++ b/erpnext/regional/india/e_invoice/einvoice.js
@@ -188,7 +188,6 @@ const get_ewaybill_fields = (frm) => {
 			'fieldname': 'vehicle_no',
 			'label': 'Vehicle No',
 			'fieldtype': 'Data',
-			'depends_on': 'eval:(doc.mode_of_transport === "Road")',
 			'default': frm.doc.vehicle_no
 		},
 		{


### PR DESCRIPTION
Vehicle No. is decided by the transporter at the time of actual shipping. So it should not be mandatory while generating eway-bills from Sales Invoices