### PR TITLE
fix: Add phone icon on read only phone fields

### DIFF
--- a/erpnext/public/js/telephony.js
+++ b/erpnext/public/js/telephony.js
@@ -1,13 +1,16 @@
 frappe.ui.form.ControlData = frappe.ui.form.ControlData.extend( {
 	make_input() {
-		this._super();
+		if(!this.df.read_only) {
+			this._super();
+		}
 		if (this.df.options == 'Phone') {
 			this.setup_phone();
 		}
 	},
 	setup_phone() {
 		if (frappe.phone_call.handler) {
-			this.$wrapper.find('.control-input')
+			let control = this.df.read_only ? '.control-value' : '.control-input';
+			this.$wrapper.find(control)
 				.append(`
 					<span class="phone-btn">
 						<a class="btn-open no-decoration" title="${__('Make a call')}">

--- a/erpnext/public/js/telephony.js
+++ b/erpnext/public/js/telephony.js
@@ -1,6 +1,6 @@
 frappe.ui.form.ControlData = frappe.ui.form.ControlData.extend( {
 	make_input() {
-		if(!this.df.read_only) {
+		if (!this.df.read_only) {
 			this._super();
 		}
 		if (this.df.options == 'Phone') {


### PR DESCRIPTION
Phone Icon is missing from read_only phone fields.
Before:
![image](https://user-images.githubusercontent.com/30859809/108673599-f6c20d00-7509-11eb-830f-5cde348507cf.png)

After:
![image](https://user-images.githubusercontent.com/30859809/108673912-77810900-750a-11eb-9522-41fd0b90fbd8.png)
