### PR TITLE
fix(india): escape for special characters in JSON

### DIFF
--- a/erpnext/regional/india/e_invoice/utils.py
+++ b/erpnext/regional/india/e_invoice/utils.py
@@ -160,7 +160,7 @@ def get_item_list(invoice):
 		item.update(d.as_dict())
 
 		item.sr_no = d.idx
-		item.description = d.item_name.replace('"', '\\"')
+		item.description = json.dumps(d.item_name)[1:-1]
 
 		item.qty = abs(item.qty)
 		item.discount_amount = 0


### PR DESCRIPTION
JSON does not accept special whitespace characters like tab, carriage return, line feed.

JSON.dumps escapes json specific characters.

Ref: https://www.ecma-international.org/wp-content/uploads/ECMA-404_2nd_edition_december_2017.pdf

Related issue: ISS-20-21-09811