### PR TITLE
fix: reference variable in pricing rule

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -136,7 +136,7 @@ class PricingRule(Document):
 			for d in self.items:
 				max_discount = frappe.get_cached_value("Item", d.item_code, "max_discount")
 				if max_discount and flt(self.discount_percentage) > flt(max_discount):
-					throw(_("Max discount allowed for item: {0} is {1}%").format(self.item_code, max_discount))
+					throw(_("Max discount allowed for item: {0} is {1}%").format(d.item_code, max_discount))
 
 	def validate_price_list_with_currency(self):
 		if self.currency and self.for_price_list:


### PR DESCRIPTION
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-13-2021-02-02/apps/frappe/frappe/desk/form/save.py", line 21, in savedocs
    doc.save()
  File "/home/frappe/benches/bench-version-13-2021-02-02/apps/frappe/frappe/model/document.py", line 285, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-version-13-2021-02-02/apps/frappe/frappe/model/document.py", line 320, in _save
    self.run_before_save_methods()
  File "/home/frappe/benches/bench-version-13-2021-02-02/apps/frappe/frappe/model/document.py", line 950, in run_before_save_methods
    self.run_method("validate")
  File "/home/frappe/benches/bench-version-13-2021-02-02/apps/frappe/frappe/model/document.py", line 848, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-version-13-2021-02-02/apps/frappe/frappe/model/document.py", line 1135, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-version-13-2021-02-02/apps/frappe/frappe/model/document.py", line 1118, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-version-13-2021-02-02/apps/frappe/frappe/model/document.py", line 842, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-version-13-2021-02-02/apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py", line 31, in validate
    self.validate_max_discount()
  File "/home/frappe/benches/bench-version-13-2021-02-02/apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py", line 139, in validate_max_discount
    throw(_("Max discount allowed for item: {0} is {1}%").format(self.item_code, max_discount))
AttributeError: 'PricingRule' object has no attribute 'item_code'

Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-13-2021-02-02/apps/frappe/frappe/app.py", line 67, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-13-2021-02-02/apps/frappe/frappe/api.py", line 58, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-13-2021-02-02/apps/frappe/frappe/handler.py", line 30, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-13-2021-02-02/apps/frappe/frappe/handler.py", line 70, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-13-2021-02-02/apps/frappe/frappe/__init__.py", line 1134, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-13-2021-02-02/apps/frappe/frappe/desk/form/save.py", line 21, in savedocs
    doc.save()
  File "/home/frappe/benches/bench-version-13-2021-02-02/apps/frappe/frappe/model/document.py", line 285, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-version-13-2021-02-02/apps/frappe/frappe/model/document.py", line 320, in _save
    self.run_before_save_methods()
  File "/home/frappe/benches/bench-version-13-2021-02-02/apps/frappe/frappe/model/document.py", line 950, in run_before_save_methods
    self.run_method("validate")
  File "/home/frappe/benches/bench-version-13-2021-02-02/apps/frappe/frappe/model/document.py", line 848, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-version-13-2021-02-02/apps/frappe/frappe/model/document.py", line 1135, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-version-13-2021-02-02/apps/frappe/frappe/model/document.py", line 1118, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-version-13-2021-02-02/apps/frappe/frappe/model/document.py", line 842, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-version-13-2021-02-02/apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py", line 31, in validate
    self.validate_max_discount()
  File "/home/frappe/benches/bench-version-13-2021-02-02/apps/erpnext/erpnext/accounts/doctype/pricing_rule/pricing_rule.py", line 139, in validate_max_discount
    throw(_("Max discount allowed for item: {0} is {1}%").format(self.item_code, max_discount))
AttributeError: 'PricingRule' object has no attribute 'item_code'