### PR TITLE
fix: patch failing because of incorrect gl entries

### DIFF
--- a/erpnext/patches/v13_0/item_reposting_for_incorrect_sl_and_gl.py
+++ b/erpnext/patches/v13_0/item_reposting_for_incorrect_sl_and_gl.py
@@ -1,5 +1,6 @@
 import frappe
 from frappe import _
+from frappe.utils import getdate, get_time
 from erpnext.stock.stock_ledger import update_entries_after
 from erpnext.accounts.utils import update_gl_entries_after
 
@@ -40,7 +41,10 @@ def execute():
 
 
 	print("Reposting General Ledger Entries...")
+	posting_date = getdate(reposting_project_deployed_on)
+	posting_time = get_time(reposting_project_deployed_on)
+
 	for row in frappe.get_all('Company', filters= {'enable_perpetual_inventory': 1}):
-		update_gl_entries_after('2020-12-25', '01:58:55', company=row.name)
+		update_gl_entries_after(posting_date, posting_time, company=row.name)
 
 	frappe.db.auto_commit_on_many_writes = 0

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -295,7 +295,8 @@ class PurchaseReceipt(BuyingController):
 								"against": warehouse_account[d.warehouse]["account"],
 								"cost_center": d.cost_center,
 								"remarks": self.get("remarks") or _("Accounting Entry for Stock"),
-								"credit": flt(amount["base_amount"]),
+								"credit": (flt(amount["base_amount"]) if (amount["base_amount"] or
+									account_currency!=self.company_currency) else flt(amount["amount"])),
 								"credit_in_account_currency": flt(amount["amount"]),
 								"project": d.project
 							}, item=d))


### PR DESCRIPTION
In the [PR](https://github.com/frappe/erpnext/pull/24127) we have introduced base_amount field which has value zero and due to that system throwing below error during reposting
```
frappe.exceptions.ValidationError: Debit and Credit not equal for Purchase Receipt #MAT-PRE-2021-00004. Difference is 3381.02.
```

Other fixes:

1. Removed hard coded date and time
2. Fixed compare_existing_and_expected_gle method