### PR TITLE
fix: currency symbol in update items

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -513,6 +513,7 @@ erpnext.utils.update_child_items = function(opts) {
 	}, {
 		fieldtype:'Currency',
 		fieldname:"rate",
+		options: "currency",
 		default: 0,
 		read_only: 0,
 		in_list_view: 1,


### PR DESCRIPTION
When you choose update items on a submitted purchase order the currency symbol is set to company default. it should be set to supplier/ purchase order default.

The numbers look correct, it is just the symbol. Very confusing for operators.

Before:
![Screenshot 2021-02-24 at 2 33 48 PM](https://user-images.githubusercontent.com/33727827/108977186-4c371f00-76ae-11eb-9361-180b20a73cb4.png)

After fix:
![Screenshot 2021-02-24 at 2 35 15 PM](https://user-images.githubusercontent.com/33727827/108977254-5bb66800-76ae-11eb-99d2-875c165f8a2c.png)
