### PR TITLE
fix: asset category name disappear

### DIFF
--- a/erpnext/assets/doctype/asset_category/asset_category.json
+++ b/erpnext/assets/doctype/asset_category/asset_category.json
@@ -19,7 +19,6 @@
  ],
  "fields": [
   {
-   "depends_on": "eval:!doc.asset_category_name",
    "fieldname": "asset_category_name",
    "fieldtype": "Data",
    "in_list_view": 1,
@@ -67,7 +66,7 @@
   }
  ],
  "links": [],
- "modified": "2021-01-22 12:31:14.425319",
+ "modified": "2021-02-24 15:05:38.621803",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset Category",


### PR DESCRIPTION
The asset category name is anyway mandatory hence any condition on display wasn't required.
Before:
![Screen Recording 2021-02-24 at 2 29 01 PM](https://user-images.githubusercontent.com/33727827/108982391-c4ecaa00-76b3-11eb-8909-25e65f4af30f.gif)

After:
![Screen Recording 2021-02-24 at 3 15 06 PM](https://user-images.githubusercontent.com/33727827/108982310-a7b7db80-76b3-11eb-94c8-c43ae64352e3.gif)
