### PR TITLE
fix: show custom button for saved projects

### DIFF
--- a/erpnext/projects/doctype/project/project.js
+++ b/erpnext/projects/doctype/project/project.js
@@ -75,24 +75,27 @@ frappe.ui.form.on("Project", {
 			frm.add_custom_button(__('Cancelled'), () => {
 				frm.events.set_status(frm, 'Cancelled');
 			}, __('Set Status'));
+
+
+			if (frappe.model.can_read("Task")) {
+					frm.add_custom_button(__("Gantt Chart"), function () {
+						frappe.route_options = {
+							"project": frm.doc.name
+						};
+						frappe.set_route("List", "Task", "Gantt");
+					});
+
+					frm.add_custom_button(__("Kanban Board"), () => {
+						frappe.call('erpnext.projects.doctype.project.project.create_kanban_board_if_not_exists', {
+							project: frm.doc.project_name
+						}).then(() => {
+							frappe.set_route('List', 'Task', 'Kanban', frm.doc.project_name);
+						});
+					});
+			}
 		}
 
-		if (frappe.model.can_read("Task")) {
-			frm.add_custom_button(__("Gantt Chart"), function () {
-				frappe.route_options = {
-					"project": frm.doc.name
-				};
-				frappe.set_route("List", "Task", "Gantt");
-			});
 
-			frm.add_custom_button(__("Kanban Board"), () => {
-				frappe.call('erpnext.projects.doctype.project.project.create_kanban_board_if_not_exists', {
-					project: frm.doc.project_name
-				}).then(() => {
-					frappe.set_route('List', 'Task', 'Kanban', frm.doc.project_name);
-				});
-			});
-		}
 	},
 
 	create_duplicate: function(frm) {

--- a/erpnext/projects/doctype/project/project.js
+++ b/erpnext/projects/doctype/project/project.js
@@ -78,20 +78,20 @@ frappe.ui.form.on("Project", {
 
 
 			if (frappe.model.can_read("Task")) {
-					frm.add_custom_button(__("Gantt Chart"), function () {
-						frappe.route_options = {
-							"project": frm.doc.name
-						};
-						frappe.set_route("List", "Task", "Gantt");
-					});
+				frm.add_custom_button(__("Gantt Chart"), function () {
+					frappe.route_options = {
+						"project": frm.doc.name
+					};
+					frappe.set_route("List", "Task", "Gantt");
+				});
 
-					frm.add_custom_button(__("Kanban Board"), () => {
-						frappe.call('erpnext.projects.doctype.project.project.create_kanban_board_if_not_exists', {
-							project: frm.doc.project_name
-						}).then(() => {
-							frappe.set_route('List', 'Task', 'Kanban', frm.doc.project_name);
-						});
+				frm.add_custom_button(__("Kanban Board"), () => {
+					frappe.call('erpnext.projects.doctype.project.project.create_kanban_board_if_not_exists', {
+						project: frm.doc.project_name
+					}).then(() => {
+						frappe.set_route('List', 'Task', 'Kanban', frm.doc.project_name);
 					});
+				});
 			}
 		}
 


### PR DESCRIPTION
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-13-2021-02-08/apps/frappe/frappe/app.py", line 67, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-13-2021-02-08/apps/frappe/frappe/api.py", line 58, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-13-2021-02-08/apps/frappe/frappe/handler.py", line 30, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-13-2021-02-08/apps/frappe/frappe/handler.py", line 70, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-13-2021-02-08/apps/frappe/frappe/__init__.py", line 1134, in call
    return fn(*args, **newargs)
TypeError: create_kanban_board_if_not_exists() missing 1 required positional argument: 'project'

This is because the button to view kanban is visible for the new doc as well.

![Screenshot 2021-02-24 at 3 41 38 PM](https://user-images.githubusercontent.com/33727827/108987180-ff0c7a80-76b8-11eb-8945-88734b1380c4.png)

Error pop up:
![Screenshot 2021-02-24 at 3 42 10 PM](https://user-images.githubusercontent.com/33727827/108987234-0d5a9680-76b9-11eb-899d-0e7907aacf79.png)

After the fix:
![Screenshot 2021-02-24 at 3 42 57 PM](https://user-images.githubusercontent.com/33727827/108987278-19deef00-76b9-11eb-830f-a3a1263e5c94.png)
