### PR TITLE
fix: make round off GLE always non-opening (bp #24723)

### DIFF
--- a/erpnext/accounts/general_ledger.py
+++ b/erpnext/accounts/general_ledger.py
@@ -252,7 +252,7 @@ def make_round_off_gle(gl_map, debit_credit_diff, precision):
 
 	if not round_off_gle:
 		for k in ["voucher_type", "voucher_no", "company",
-			"posting_date", "remarks", "is_opening"]:
+			"posting_date", "remarks"]:
 				round_off_gle[k] = gl_map[0][k]
 
 	round_off_gle.update({
@@ -264,6 +264,7 @@ def make_round_off_gle(gl_map, debit_credit_diff, precision):
 		"cost_center": round_off_cost_center,
 		"party_type": None,
 		"party": None,
+		"is_opening": "No",
 		"against_voucher_type": None,
 		"against_voucher": None
 	})


### PR DESCRIPTION
Opening GL entries can not be for profit and loss accounts. Round off accounts are by default P&L account. Hence when making opening entry, make round off entries as non-opening.

Backport of #24723 

Related issue: ISS-20-21-09677