### PR TITLE
fix(HR): hide "more" button from team updates

### DIFF
--- a/erpnext/hr/page/team_updates/team_updates.js
+++ b/erpnext/hr/page/team_updates/team_updates.js
@@ -36,7 +36,7 @@ frappe.team_updates = {
 				start: me.start
 			},
 			callback: function(r) {
-				if(r.message) {
+				if (r.message && r.message.length > 0) {
 					r.message.forEach(function(d) {
 						me.add_row(d);
 					});

--- a/erpnext/hr/page/team_updates/team_updates.js
+++ b/erpnext/hr/page/team_updates/team_updates.js
@@ -75,6 +75,6 @@ frappe.team_updates = {
 		}
 		me.last_feed_date = date;
 
-		$(frappe.render_template('team_update_row', data)).appendTo(me.body)
+		$(frappe.render_template('team_update_row', data)).appendTo(me.body);
 	}
 }


### PR DESCRIPTION
"More" button is meaningless when there's not content. The functionality to handle it was already there but not getting executed due to minor bug. 


Related issue: FR-ISS-214458