### PR TITLE
chore: Add description field & enable quick entry

### DIFF
--- a/erpnext/hr/doctype/skill/skill.json
+++ b/erpnext/hr/doctype/skill/skill.json
@@ -46,6 +46,11 @@
    "set_only_once": 0,
    "translatable": 0,
    "unique": 1
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Text",
+   "label": "Description"
   }
  ],
  "has_web_view": 0,
@@ -56,7 +61,7 @@
  "issingle": 0,
  "istable": 0,
  "max_attachments": 0,
- "modified": "2021-02-24 09:55:00.536328",
+ "modified": "2021-02-26 09:55:00.536328",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Skill",

--- a/erpnext/hr/doctype/skill/skill.json
+++ b/erpnext/hr/doctype/skill/skill.json
@@ -16,7 +16,7 @@
  "fields": [
   {
    "allow_bulk_edit": 0,
-   "allow_in_quick_entry": 0,
+   "allow_in_quick_entry": 1,
    "allow_on_submit": 0,
    "bold": 0,
    "collapsible": 0,
@@ -48,6 +48,7 @@
    "unique": 1
   },
   {
+   "allow_in_quick_entry": 1,
    "fieldname": "description",
    "fieldtype": "Text",
    "label": "Description"
@@ -61,7 +62,7 @@
  "issingle": 0,
  "istable": 0,
  "max_attachments": 0,
- "modified": "2021-02-26 09:55:00.536328",
+ "modified": "2021-02-26 10:55:00.536328",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Skill",


### PR DESCRIPTION
Lets us describe a skill past just the title. Closes #23592

the name and label "Description" were chosen to match Designation and so was the Text field type