### PR TITLE
fix: allow creating stock entry based on work order for customer provided items

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -458,7 +458,7 @@ class StockEntry(StockController):
 			Set rate for outgoing, scrapped and finished items
 		"""
 		# Set rate for outgoing items
-		outgoing_items_cost = self.set_rate_for_outgoing_items(reset_outgoing_rate)
+		outgoing_items_cost = self.set_rate_for_outgoing_items(reset_outgoing_rate, raise_error_if_no_rate)
 		finished_item_qty = sum([d.transfer_qty for d in self.items if d.is_finished_item])
 
 		# Set basic rate for incoming items
@@ -482,13 +482,13 @@ class StockEntry(StockController):
 			d.basic_rate = flt(d.basic_rate, d.precision("basic_rate"))
 			d.basic_amount = flt(flt(d.transfer_qty) * flt(d.basic_rate), d.precision("basic_amount"))
 
-	def set_rate_for_outgoing_items(self, reset_outgoing_rate=True):
+	def set_rate_for_outgoing_items(self, reset_outgoing_rate=True, raise_error_if_no_rate=True):
 		outgoing_items_cost = 0.0
 		for d in self.get('items'):
 			if d.s_warehouse:
 				if reset_outgoing_rate:
 					args = self.get_args_for_incoming_rate(d)
-					rate = get_incoming_rate(args)
+					rate = get_incoming_rate(args, raise_error_if_no_rate)
 					if rate > 0:
 						d.basic_rate = rate
 


### PR DESCRIPTION
Allows creation of Stock Entry based on Work Order if items are customer provided (valuation rate is zero).
This used to work previously, but since #24031 it throws below traceback:

```
Traceback (most recent call last):
  File "/home/walstan/Work/develop/apps/frappe/frappe/app.py", line 67, in application
    response = frappe.api.handle()
  File "/home/walstan/Work/develop/apps/frappe/frappe/api.py", line 58, in handle
    return frappe.handler.handle()
  File "/home/walstan/Work/develop/apps/frappe/frappe/handler.py", line 30, in handle
    data = execute_cmd(cmd)
  File "/home/walstan/Work/develop/apps/frappe/frappe/handler.py", line 70, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/walstan/Work/develop/apps/frappe/frappe/__init__.py", line 1136, in call
    return fn(*args, **newargs)
  File "/home/walstan/Work/develop/apps/erpnext/erpnext/manufacturing/doctype/work_order/work_order.py", line 790, in make_stock_entry
    stock_entry.get_items()
  File "/home/walstan/Work/develop/apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.py", line 1013, in get_items
    self.calculate_rate_and_amount(raise_error_if_no_rate=False)
  File "/home/walstan/Work/develop/apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.py", line 449, in calculate_rate_and_amount
    self.set_basic_rate(reset_outgoing_rate, raise_error_if_no_rate)
  File "/home/walstan/Work/develop/apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.py", line 461, in set_basic_rate
    outgoing_items_cost = self.set_rate_for_outgoing_items(reset_outgoing_rate)
  File "/home/walstan/Work/develop/apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.py", line 491, in set_rate_for_outgoing_items
    rate = get_incoming_rate(args)
  File "/home/walstan/Work/develop/apps/erpnext/erpnext/stock/utils.py", line 210, in get_incoming_rate
    in_rate = get_valuation_rate(args.get('item_code'), args.get('warehouse'),
  File "/home/walstan/Work/develop/apps/erpnext/erpnext/stock/stock_ledger.py", line 805, in get_valuation_rate
    frappe.throw(msg=msg, title=_("Valuation Rate Missing"))
  File "/home/walstan/Work/develop/apps/frappe/frappe/__init__.py", line 416, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red', is_minimizable=is_minimizable, wide=wide, as_list=as_list)
  File "/home/walstan/Work/develop/apps/frappe/frappe/__init__.py", line 395, in msgprint
    _raise_exception()
  File "/home/walstan/Work/develop/apps/frappe/frappe/__init__.py", line 349, in _raise_exception
    raise raise_exception(msg)
frappe.exceptions.ValidationError: Valuation Rate for the Item <a href="http://127.0.0.1:8010/app/item/Test%20Item">Test Item</a>, is required to do accounting entries for Stock Entry .<br><br> Here are the options to proceed:<li>If the item is transacting as a Zero Valuation Rate item in this entry, please enable 'Allow Zero Valuation Rate' in the Stock Entry Item table.</li><li>If not, you can Cancel / Submit this entry <b>after</b> performing either one below:</li><ul><li>Create an incoming stock transaction for the Item.</li><li>Mention Valuation Rate in the Item master.</li></ul></li>
```
![image](https://user-images.githubusercontent.com/38958184/109288801-5b070880-784b-11eb-84fd-00ec58c49c87.png)

___

Solved by passing the `raise_error_if_no_rate` flag to the `set_rate_for_outgoing_items` function.

Alternatively, the `validate_customer_provided_item` method which sets the **Allow Zero Valuation Rate** field can be run before `calculate_rate_and_amount` is called.