### PR TITLE
fix: Change FieldType from Text to Text Editor in Non-Conformance DocType

### DIFF
--- a/erpnext/quality_management/doctype/non_conformance/non_conformance.json
+++ b/erpnext/quality_management/doctype/non_conformance/non_conformance.json
@@ -81,7 +81,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2020-10-26 15:27:47.247814",
+ "modified": "2021-02-26 15:27:47.247814",
  "modified_by": "Administrator",
  "module": "Quality Management",
  "name": "Non Conformance",

--- a/erpnext/quality_management/doctype/non_conformance/non_conformance.json
+++ b/erpnext/quality_management/doctype/non_conformance/non_conformance.json
@@ -70,12 +70,12 @@
   },
   {
    "fieldname": "corrective_action",
-   "fieldtype": "Text",
+   "fieldtype": "Text Editor",
    "label": "Corrective Action"
   },
   {
    "fieldname": "preventive_action",
-   "fieldtype": "Text",
+   "fieldtype": "Text Editor",
    "label": "Preventive Action"
   }
  ],


### PR DESCRIPTION
Enable rich Text Editors for Corrective Action and Preventive Action fields. Closes #24759