### PR TITLE
fix: Remove obsolete section titles from Quality Meeting doctype

### DIFF
--- a/erpnext/quality_management/doctype/quality_meeting/quality_meeting.json
+++ b/erpnext/quality_management/doctype/quality_meeting/quality_meeting.json
@@ -33,8 +33,7 @@
   },
   {
    "fieldname": "sb_00",
-   "fieldtype": "Section Break",
-   "label": "Agenda"
+   "fieldtype": "Section Break"
   },
   {
    "fieldname": "agenda",
@@ -44,13 +43,12 @@
   },
   {
    "fieldname": "sb_01",
-   "fieldtype": "Section Break",
-   "label": "Minutes"
+   "fieldtype": "Section Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2020-10-27 16:36:45.657883",
+ "modified": "2021-02-26 16:36:45.657883",
  "modified_by": "Administrator",
  "module": "Quality Management",
  "name": "Quality Meeting",

--- a/erpnext/quality_management/doctype/quality_meeting/quality_meeting.json
+++ b/erpnext/quality_management/doctype/quality_meeting/quality_meeting.json
@@ -48,7 +48,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2021-02-26 16:36:45.657883",
+ "modified": "2021-02-27 16:36:45.657883",
  "modified_by": "Administrator",
  "module": "Quality Management",
  "name": "Quality Meeting",


### PR DESCRIPTION
Removes the obsolete labels from the section breaks that the tables already provide.

![image](https://user-images.githubusercontent.com/7112040/109373935-6112de80-7877-11eb-990c-38d5db4a9fc0.png)

becomes

![image](https://user-images.githubusercontent.com/7112040/109373921-51939580-7877-11eb-81c7-6353f62de9f4.png)
