### PR TITLE
fix: allow to select item code in batch naming

### DIFF
--- a/erpnext/stock/doctype/batch/batch.py
+++ b/erpnext/stock/doctype/batch/batch.py
@@ -93,7 +93,7 @@ class Batch(Document):
 
 			if create_new_batch:
 				if batch_number_series:
-					self.batch_id = make_autoname(batch_number_series)
+					self.batch_id = make_autoname(batch_number_series, doc=self)
 				elif batch_uses_naming_series():
 					self.batch_id = self.get_name_from_naming_series()
 				else:


### PR DESCRIPTION
<img width="598" alt="Screenshot 2021-03-01 at 11 33 19 AM" src="https://user-images.githubusercontent.com/8780500/109457998-f71a5500-7a81-11eb-871a-9fa190b20e11.png">


Output
<img width="258" alt="Screenshot 2021-03-01 at 11 32 47 AM" src="https://user-images.githubusercontent.com/8780500/109458049-0f8a6f80-7a82-11eb-9dd2-c87c3dfdf108.png">
