### PR TITLE
fix: batch no in POS

### DIFF
--- a/erpnext/stock/doctype/serial_no/serial_no.py
+++ b/erpnext/stock/doctype/serial_no/serial_no.py
@@ -554,7 +554,7 @@ def auto_fetch_serial_number(qty, item_code, warehouse, posting_date=None, batch
 
 	if batch_nos:
 		try:
-			filters["batch_no"] = json.loads(batch_nos)
+			filters["batch_no"] = [json.loads(batch_nos)]
 		except:
 			filters["batch_no"] = [batch_nos]
 

--- a/erpnext/stock/doctype/serial_no/serial_no.py
+++ b/erpnext/stock/doctype/serial_no/serial_no.py
@@ -554,7 +554,7 @@ def auto_fetch_serial_number(qty, item_code, warehouse, posting_date=None, batch
 
 	if batch_nos:
 		try:
-			filters["batch_no"] = [json.loads(batch_nos)]
+			filters["batch_no"] = json.loads(batch_nos) if (type(json.loads(batch_nos)) == list) else [json.loads(batch_nos)]
 		except:
 			filters["batch_no"] = [batch_nos]
 


### PR DESCRIPTION
Traceback:
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-13-2021-02-09/apps/frappe/frappe/app.py", line 67, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-13-2021-02-09/apps/frappe/frappe/api.py", line 58, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-13-2021-02-09/apps/frappe/frappe/handler.py", line 30, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-13-2021-02-09/apps/frappe/frappe/handler.py", line 70, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-13-2021-02-09/apps/frappe/frappe/__init__.py", line 1134, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-13-2021-02-09/apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py", line 567, in auto_fetch_serial_number
    serial_numbers = fetch_serial_numbers(filters, qty, do_not_include=reserved_sr_nos)
  File "/home/frappe/benches/bench-version-13-2021-02-09/apps/erpnext/erpnext/stock/doctype/serial_no/serial_no.py", line 601, in fetch_serial_numbers
    batch_no_condition = """and sr.batch_no in ({}) """.format(', '.join(["'%s'" % d for d in batch_nos]))
TypeError: 'int' object is not iterable
```

filters:
"args": {
  "qty": 2,
  "item_code": "abimol-extra-tab",
  "warehouse": "Stores - TP",
  "batch_nos": "1",
  "posting_date": "2021-02-28",
  "for_doctype": "POS Invoice"
	},