### PR TITLE
fix: GL Entries for AP/AR Summary

### DIFF
--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -606,20 +606,19 @@ def get_partywise_advanced_payment_amount(party_type, posting_date = None, futur
 	cond = "1=1"
 	if posting_date:
 		if future_payment:
-			cond = "gle.posting_date <= '{0}' OR DATE(creation) <= '{0}' """.format(posting_date)
+			cond = "posting_date <= '{0}' OR DATE(creation) <= '{0}' """.format(posting_date)
 		else:
-			cond = "gle.posting_date <= '{0}'".format(posting_date)
+			cond = "posting_date <= '{0}'".format(posting_date)
 
 	if company:
-		cond += "and gle.company = {0}".format(frappe.db.escape(company))
+		cond += "and company = {0}".format(frappe.db.escape(company))
 
-	data = frappe.db.sql(""" SELECT gle.party, sum(gle.{0}) as amount
-		FROM `tabGL Entry` gle
-		INNER JOIN `tabPayment Entry` pe ON pe.name = gle.voucher_no
+	data = frappe.db.sql(""" SELECT party, sum({0}) as amount
+		FROM `tabGL Entry`
 		WHERE
-			gle.party_type = %s and gle.against_voucher is null
-            and pe.docstatus = 1
-			and {1} GROUP BY gle.party"""
+			party_type = %s and against_voucher is null
+			and is_cancelled = 0
+			and {1} GROUP BY party"""
 		.format(("credit") if party_type == "Customer" else "debit", cond) , party_type)
 
 	if data:

--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -606,18 +606,20 @@ def get_partywise_advanced_payment_amount(party_type, posting_date = None, futur
 	cond = "1=1"
 	if posting_date:
 		if future_payment:
-			cond = "posting_date <= '{0}' OR DATE(creation) <= '{0}' """.format(posting_date)
+			cond = "gle.posting_date <= '{0}' OR DATE(creation) <= '{0}' """.format(posting_date)
 		else:
-			cond = "posting_date <= '{0}'".format(posting_date)
+			cond = "gle.posting_date <= '{0}'".format(posting_date)
 
 	if company:
-		cond += "and company = {0}".format(frappe.db.escape(company))
+		cond += "and gle.company = {0}".format(frappe.db.escape(company))
 
-	data = frappe.db.sql(""" SELECT party, sum({0}) as amount
-		FROM `tabGL Entry`
+	data = frappe.db.sql(""" SELECT gle.party, sum(gle.{0}) as amount
+		FROM `tabGL Entry` gle
+		INNER JOIN `tabPayment Entry` pe ON pe.name = gle.voucher_no
 		WHERE
-			party_type = %s and against_voucher is null
-			and {1} GROUP BY party"""
+			gle.party_type = %s and gle.against_voucher is null
+            and pe.docstatus = 1
+			and {1} GROUP BY gle.party"""
 		.format(("credit") if party_type == "Customer" else "debit", cond) , party_type)
 
 	if data:


### PR DESCRIPTION
SQL query modified to fetch only those GL Entries for Accounts Payable Summary and Accounts Receivable Summary reports where the corresponding payment entry is in submitted state.

Issue:
Currently the AP and AR Summary report calculates the advance amount from payment entries. However, the filter to check whether the payment entry is in submitted state is not present.

Steps to reproduce:
1. Create a payment entry for a certain supplier which is not linked to any payment invoice. This will add the amount paid in the payment entry to the advance payment column in the accounts payable report.
2. Cancel the above payment entry. The advance payment column in the accounts payable report still reflects this amount and the paid amount column is adjusted to tally the outstanding amount. However, these numbers do not make sense against the Accounts Payable report and the calculated paid amount is incorrect.

Closes #22846