### PR TITLE
fix: salary slip working hours increment

### DIFF
--- a/erpnext/payroll/doctype/salary_slip/salary_slip.py
+++ b/erpnext/payroll/doctype/salary_slip/salary_slip.py
@@ -1123,6 +1123,7 @@ class SalarySlip(TransactionBase):
 	#calculate total working hours, earnings based on hourly wages and totals
 	def calculate_total_for_salary_slip_based_on_timesheet(self):
 		if self.timesheets:
+			self.total_working_hours = 0
 			for timesheet in self.timesheets:
 				if timesheet.working_hours:
 					self.total_working_hours += timesheet.working_hours


### PR DESCRIPTION
**Issue:**

1. Adding and removing Earnings and Deductions to a Salary Slip that's based on Timesheet increments the Total Working hours on each step.

Steps to Replicate:

1. Create a Salary Slip based on Timesheet.
2. Note the Total Working Hours.
3. Add/Remove an Earning or Deduction.
4. The Total Working hours doubles after each step.