### PR TITLE
fix: duplication of earnings row on saving Salary Slip

### DIFF
--- a/erpnext/payroll/doctype/salary_slip/salary_slip.py
+++ b/erpnext/payroll/doctype/salary_slip/salary_slip.py
@@ -571,7 +571,7 @@ class SalarySlip(TransactionBase):
 		for d in self.get(key):
 			if d.salary_component == struct_row.salary_component:
 				component_row = d
-		if not component_row or (struct_row.get("is_additional_component") and not overwrite):
+		if not component_row:
 			if amount:
 				self.append(key, {
 					'amount': amount,


### PR DESCRIPTION
**Issue:** 
Duplicate rows were being added to the Earnings table on saving Salary Slip if the additional salary component had the field **Overwrite Salary Structure Amount** unchecked. See linked issue for more details.

Resolves #24684 

![Peek 2021-03-02 14-04](https://user-images.githubusercontent.com/38958184/109621974-99f5d080-7b61-11eb-8498-92f6274d061a.gif)


**Fix:**
Removed condition that caused a new row to be added incorrectly to Salary Slip every time it was re-saved. Due to this condition, following code in `else` block was always unreachable:

```python
if overwrite:
# ---
else:
	component_row.additional_amount = amount

if not overwrite and component_row.default_amount:
	amount += component_row.default_amount
```

