### PR TITLE
fix: make quick entry for Tax Category work

### DIFF
--- a/erpnext/accounts/doctype/tax_category/tax_category.json
+++ b/erpnext/accounts/doctype/tax_category/tax_category.json
@@ -11,15 +11,18 @@
  ],
  "fields": [
   {
+   "allow_in_quick_entry": 1,
    "fieldname": "title",
    "fieldtype": "Data",
+   "in_list_view": 1,
    "label": "Title",
+   "reqd": 1,
    "unique": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2020-08-30 19:41:25.783852",
+ "modified": "2021-03-03 11:50:38.748872",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Tax Category",


### PR DESCRIPTION
### Problem
Quick Entry was already enabled for Tax Category. However, the only field "Title" did not have "Mandatory" or "Allow in Quick Entry" checked. Therefore the Quick Entry was skipped and the user redirected to the form view.

### Solution
Because Title is the only field and the name depends on it, the field should indeed be mandatory. With this setting in place, Quick Entry works as expected. This results in a much smoother UX.