### PR TITLE
fix: use set_value instead of sql

### DIFF
--- a/erpnext/regional/india/setup.py
+++ b/erpnext/regional/india/setup.py
@@ -105,8 +105,9 @@ def add_print_formats():
 	frappe.reload_doc("accounts", "print_format", "gst_pos_invoice")
 	frappe.reload_doc("accounts", "print_format", "GST E-Invoice")
 
-	frappe.db.sql(""" update `tabPrint Format` set disabled = 0 where
-		name in('GST POS Invoice', 'GST Tax Invoice', 'GST E-Invoice') """)
+	frappe.db.set_value("Print Format", "GST POS Invoice", "disabled", 0)
+	frappe.db.set_value("Print Format", "GST Tax Invoice", "disabled", 0)
+	frappe.db.set_value("Print Format", "GST E-Invoice", "disabled", 0)
 
 def make_custom_fields(update=True):
 	hsn_sac_field = dict(fieldname='gst_hsn_code', label='HSN/SAC',

--- a/erpnext/regional/italy/setup.py
+++ b/erpnext/regional/italy/setup.py
@@ -189,9 +189,7 @@ def make_custom_fields(update=True):
 
 def setup_report():
 	report_name = 'Electronic Invoice Register'
-
-	frappe.db.sql(""" update `tabReport` set disabled = 0 where
-		name = %s """, report_name)
+	frappe.db.set_value("Report", report_name, "disabled", 0)
 
 	if not frappe.db.get_value('Custom Role', dict(report=report_name)):
 		frappe.get_doc(dict(

--- a/erpnext/regional/united_states/setup.py
+++ b/erpnext/regional/united_states/setup.py
@@ -36,5 +36,4 @@ def make_custom_fields(update=True):
 
 def add_print_formats():
 	frappe.reload_doc("regional", "print_format", "irs_1099_form")
-	frappe.db.sql(""" update `tabPrint Format` set disabled = 0 where
-		name in('IRS 1099 Form') """)
+	frappe.db.set_value("Print Format", "IRS 1099 Form", "disabled", 0)


### PR DESCRIPTION
In the regional setup there are a lot of unnecessary SQL queries. Use `frappe.db.set_value` instead.

On a similar note, see [this discuss thread](https://discuss.erpnext.com/t/dos-and-donts-1-frappe-db-get-value/67773).