### PR TITLE
fix: total row in AR/AP summary report

### DIFF
--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.html
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.html
@@ -258,7 +258,7 @@
 					{% } %}
 				{% } else { %}
 					{% if(data[i]["party"]|| "&nbsp;") { %}
-						{% if((data[i]["party"]) != __("'Total'")) { %}
+						{% if(!data[i]["is_total_row"]) { %}
 							<td>
 								{% if(!(filters.customer || filters.supplier)) { %}
 									{%= data[i]["party"] %}


### PR DESCRIPTION
Currently, the condition for checking total row in AR/AP summary is incorrect, because of which the total row gets created as shown in screenshot below:
![ARS_Before](https://user-images.githubusercontent.com/41088003/109915378-2a9bf000-7ccb-11eb-9e95-c090858c7da0.jpg)

In the fix, the condition of the total row is checked by `is_total_row` key in the row data, which ensures the total row is correctly created as shown in screenshot below:
![ARS_After](https://user-images.githubusercontent.com/41088003/109915557-78b0f380-7ccb-11eb-95dd-36c67ee2fc68.jpg)
