### PR TITLE
fix: salary structure assign to employee

### DIFF
--- a/erpnext/payroll/doctype/salary_structure/salary_structure.js
+++ b/erpnext/payroll/doctype/salary_structure/salary_structure.js
@@ -145,7 +145,10 @@ frappe.ui.form.on('Salary Structure', {
 				frappe.call({
 					doc: frm.doc,
 					method: "assign_salary_structure",
-					args: data,
+					args: {
+						"employee": data.employee,
+						"from_date": data.from_date
+					},
 					callback: function(r) {
 						if(!r.exc) {
 							d.hide();

--- a/erpnext/payroll/doctype/salary_structure/salary_structure.js
+++ b/erpnext/payroll/doctype/salary_structure/salary_structure.js
@@ -142,13 +142,12 @@ frappe.ui.form.on('Salary Structure', {
 			],
 			primary_action: function() {
 				var data = d.get_values();
+				delete data.company
+				delete data.currency
 				frappe.call({
 					doc: frm.doc,
 					method: "assign_salary_structure",
-					args: {
-						"employee": data.employee,
-						"from_date": data.from_date
-					},
+					args: data,
 					callback: function(r) {
 						if(!r.exc) {
 							d.hide();


### PR DESCRIPTION
Issue:

1. Create a Salary Structure.
2. From the top menu click on Assign to Employees.
3. Select an Employee and enter From Date.
4. Click on Assign. An error appears.

![Screenshot 2021-03-04 at 11 20 36 AM](https://user-images.githubusercontent.com/31363128/109918526-1cef6600-7cdd-11eb-9414-1c7a994aae19.png)
