### PR TITLE
fix: error in bulk attendance

### DIFF
--- a/erpnext/hr/doctype/attendance/attendance.py
+++ b/erpnext/hr/doctype/attendance/attendance.py
@@ -131,6 +131,10 @@ def mark_bulk_attendance(data):
 		data = json.loads(data)
 	data = frappe._dict(data)
 	company = frappe.get_value('Employee', data.employee, 'company')
+	if not data.unmarked_days:
+		frappe.throw(_("Please select a date."))
+		return
+
 	for date in data.unmarked_days:
 		doc_dict = {
 			'doctype': 'Attendance',

--- a/erpnext/hr/doctype/attendance/attendance_list.js
+++ b/erpnext/hr/doctype/attendance/attendance_list.js
@@ -12,7 +12,7 @@ frappe.listview_settings['Attendance'] = {
 	onload: function(list_view) {
 		let me = this;
 		const months = moment.months()
-		list_view.page.add_inner_button( __("Mark Attendance"), function(){
+		list_view.page.add_inner_button( __("Mark Attendance"), function() {
 			let dialog = new frappe.ui.Dialog({
 				title: __("Mark Attendance"),
 				fields: [
@@ -22,7 +22,7 @@ frappe.listview_settings['Attendance'] = {
 						fieldtype: 'Link',
 						options: 'Employee',
 						reqd: 1,
-						onchange: function(){
+						onchange: function() {
 							dialog.set_df_property("unmarked_days", "hidden", 1);
 							dialog.set_df_property("status", "hidden", 1);
 							dialog.set_df_property("month", "value", '');
@@ -36,7 +36,7 @@ frappe.listview_settings['Attendance'] = {
 						fieldname: "month",
 						options: months,
 						reqd: 1,
-						onchange: function(){
+						onchange: function() {
 							if(dialog.fields_dict.employee.value && dialog.fields_dict.month.value) {
 								dialog.set_df_property("status", "hidden", 0);
 								dialog.set_df_property("unmarked_days", "options", []);
@@ -44,9 +44,8 @@ frappe.listview_settings['Attendance'] = {
 								me.get_multi_select_options(dialog.fields_dict.employee.value, dialog.fields_dict.month.value).then(options =>{
 									if (options.length > 0) {
 										dialog.set_df_property("unmarked_days", "hidden", 0);
-										dialog.set_df_property("unmarked_days", "options", options)
-									}
-									else {
+										dialog.set_df_property("unmarked_days", "options", options);
+									} else {
 										dialog.no_unmarked_days_left = true;
 									}
 								});
@@ -71,20 +70,19 @@ frappe.listview_settings['Attendance'] = {
 						hidden: 1
 					},
 				],
-				primary_action(data){
-					if(cur_dialog.no_unmarked_days_left){
-						frappe.msgprint(__("Attendance for the month of " + dialog.fields_dict.month.value + " , has already been marked for the Employee " + dialog.fields_dict.employee.value));
-					}
-					else{
-						frappe.confirm(__('Mark attendance as <b>' + data.status + '</b> for <b>' + data.month +'</b>' + ' on selected dates?'), () => {
+				primary_action(data)  {
+					if (cur_dialog.no_unmarked_days_left) {
+						frappe.msgprint(__("Attendance for the month of {0} , has already been marked for the Employee {1}",[dialog.fields_dict.month.value, dialog.fields_dict.employee.value]));
+					} else {
+						frappe.confirm(__('Mark attendance as {0} for {1} on selected dates?', [data.status,data.month]), () => {
 							frappe.call({
 								method: "erpnext.hr.doctype.attendance.attendance.mark_bulk_attendance",
 								args: {
-									data : data
+									data: data
 								},
 								callback: function(r) {
-									if(r.message === 1) {
-										frappe.show_alert({message:__("Attendance Marked"), indicator:'blue'});
+									if (r.message === 1) {
+										frappe.show_alert({message: __("Attendance Marked"), indicator: 'blue'});
 										cur_dialog.hide();
 									}
 								}

--- a/erpnext/hr/doctype/attendance/attendance_list.js
+++ b/erpnext/hr/doctype/attendance/attendance_list.js
@@ -40,8 +40,13 @@ frappe.listview_settings['Attendance'] = {
 								dialog.set_df_property("status", "hidden", 0);
 								dialog.set_df_property("unmarked_days", "options", []);
 								me.get_multi_select_options(dialog.fields_dict.employee.value, dialog.fields_dict.month.value).then(options =>{
-									dialog.set_df_property("unmarked_days", "hidden", 0);
-									dialog.set_df_property("unmarked_days", "options", options);
+									if (options.length > 0) {
+										dialog.set_df_property("unmarked_days", "hidden", 0);
+										dialog.set_df_property("unmarked_days", "options", options)
+									}
+									else {
+										dialog.no_unmarked_days_left = true;
+									}
 								});
 							}
 						}
@@ -65,20 +70,25 @@ frappe.listview_settings['Attendance'] = {
 					},
 				],
 				primary_action(data){
-					frappe.confirm(__('Mark attendance as <b>' + data.status + '</b> for <b>' + data.month +'</b>' + ' on selected dates?'), () => {
-						frappe.call({
-							method: "erpnext.hr.doctype.attendance.attendance.mark_bulk_attendance",
-							args: {
-								data : data
-							},
-							callback: function(r) {
-								if(r.message === 1) {
-									frappe.show_alert({message:__("Attendance Marked"), indicator:'blue'});
-									cur_dialog.hide();
+					if(cur_dialog.no_unmarked_days_left){
+						frappe.msgprint(__("Attendance for the month of " + dialog.fields_dict.month.value + " , has already been marked for the Employee " + dialog.fields_dict.employee.value));
+					}
+					else{
+						frappe.confirm(__('Mark attendance as <b>' + data.status + '</b> for <b>' + data.month +'</b>' + ' on selected dates?'), () => {
+							frappe.call({
+								method: "erpnext.hr.doctype.attendance.attendance.mark_bulk_attendance",
+								args: {
+									data : data
+								},
+								callback: function(r) {
+									if(r.message === 1) {
+										frappe.show_alert({message:__("Attendance Marked"), indicator:'blue'});
+										cur_dialog.hide();
+									}
 								}
-							}
+							});
 						});
-					});
+					}
 					dialog.hide();
 					list_view.refresh();
 				},

--- a/erpnext/hr/doctype/attendance/attendance_list.js
+++ b/erpnext/hr/doctype/attendance/attendance_list.js
@@ -27,6 +27,7 @@ frappe.listview_settings['Attendance'] = {
 							dialog.set_df_property("status", "hidden", 1);
 							dialog.set_df_property("month", "value", '');
 							dialog.set_df_property("unmarked_days", "options", []);
+							dialog.no_unmarked_days_left = false;
 						}
 					},
 					{
@@ -39,6 +40,7 @@ frappe.listview_settings['Attendance'] = {
 							if(dialog.fields_dict.employee.value && dialog.fields_dict.month.value) {
 								dialog.set_df_property("status", "hidden", 0);
 								dialog.set_df_property("unmarked_days", "options", []);
+								dialog.no_unmarked_days_left = false;
 								me.get_multi_select_options(dialog.fields_dict.employee.value, dialog.fields_dict.month.value).then(options =>{
 									if (options.length > 0) {
 										dialog.set_df_property("unmarked_days", "hidden", 0);


### PR DESCRIPTION
**Issue:**
1. Error occurs on Attendance List view while marking Bulk Attendance.

![Screenshot 2021-03-05 at 4 29 00 PM](https://user-images.githubusercontent.com/31363128/110108049-b304b880-7dd1-11eb-89bb-d7800a617530.png)

**Scenario 1:**
1. From the attendance list view, click on the **Mark Attendance** button and select any employee and a month. Mark the attendance for that entire month.
2. After marking the attendance, verify the attendance in the list view.
3. Then again click on the Mark Attendance button. Select the same employee and same month. There will not be any dates to select from. Submit the dialog.
4. The above-mentioned error will appear.

**Fix:**

1. If the attendance for a particular month has already been marked then a message will be displayed to the user on submitting the dialog.

![Screenshot 2021-03-05 at 4 28 29 PM](https://user-images.githubusercontent.com/31363128/110108215-e5aeb100-7dd1-11eb-8ec6-e8fdb61b288c.png)

**Scenario 2:**

1. From the Attendance List view, click on the Mark Attendance button. Select an employee and a month for which attendance hasn't been marked.
2. List of unmarked days appear. Uncheck all the dates. Submit the dialog.
3. The above-mentioned error will appear.

**Fix:**

1. A message will be displayed to the user asking them to select dates.

![Screenshot 2021-03-05 at 5 34 11 PM](https://user-images.githubusercontent.com/31363128/110113503-35dd4180-7dd9-11eb-8165-64cbe8d95b1e.png)

