### PR TITLE
fix: call get_round_off_applicable_accounts() function when arguments available

### DIFF
--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -158,16 +158,18 @@ erpnext.taxes_and_totals = erpnext.payments.extend({
 		let me = this;
 		frappe.flags.round_off_applicable_accounts = [];
 
-		return frappe.call({
-			"method": "erpnext.controllers.taxes_and_totals.get_round_off_applicable_accounts",
-			"args": {
-				"company": me.frm.doc.company,
-				"account_list": frappe.flags.round_off_applicable_accounts
-			},
-			callback: function(r) {
-				frappe.flags.round_off_applicable_accounts.push(...r.message);
-			}
-		});
+		if (me.frm.doc.company) {
+			return frappe.call({
+				"method": "erpnext.controllers.taxes_and_totals.get_round_off_applicable_accounts",
+				"args": {
+					"company": me.frm.doc.company,
+					"account_list": frappe.flags.round_off_applicable_accounts
+				},
+				callback: function(r) {
+					frappe.flags.round_off_applicable_accounts.push(...r.message);
+				}
+			});
+		}
 	},
 
 	determine_exclusive_rate: function() {


### PR DESCRIPTION
![Screenshot 2021-03-08 at 6 17 54 PM](https://user-images.githubusercontent.com/33727827/110323774-134a6300-803b-11eb-992f-03b42ce26455.png)

Traceback (most recent call last):
  File "/Users/afshan/Dev/frappe/frappe-bench3/apps/frappe/frappe/app.py", line 67, in application
    response = frappe.api.handle()
  File "/Users/afshan/Dev/frappe/frappe-bench3/apps/frappe/frappe/api.py", line 58, in handle
    return frappe.handler.handle()
  File "/Users/afshan/Dev/frappe/frappe-bench3/apps/frappe/frappe/handler.py", line 30, in handle
    data = execute_cmd(cmd)
  File "/Users/afshan/Dev/frappe/frappe-bench3/apps/frappe/frappe/handler.py", line 70, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/afshan/Dev/frappe/frappe-bench3/apps/frappe/frappe/__init__.py", line 1138, in call
    return fn(*args, **newargs)
TypeError: get_round_off_applicable_accounts() missing 1 required positional argument: 'company'