### PR TITLE
fix: breadcrumbs for company

### DIFF
--- a/erpnext/setup/doctype/company/company_list.js
+++ b/erpnext/setup/doctype/company/company_list.js
@@ -1,10 +1,5 @@
 frappe.listview_settings['Company'] = {
-    onload: () => {
-        frappe.breadcrumbs.add({
-            type: 'Custom',
-            module: __('Accounts'),
-            label: __('Accounts'),
-            route: '#modules/Accounts'
-        });
-    }
-}
+	onload() {
+		frappe.breadcrumbs.add('Accounts');
+	},
+};


### PR DESCRIPTION
### Issue
Breadcrumbs for Company were using an older route.

### Fix
Added Breadcrumbs to company of module Accounts

---


**Before**

![image](https://user-images.githubusercontent.com/38958184/110303498-75499f00-8020-11eb-8978-9734ee0f7b1b.png)
![image](https://user-images.githubusercontent.com/38958184/110303520-7bd81680-8020-11eb-81d8-c0feb1a1a187.png)

**After**

![image](https://user-images.githubusercontent.com/38958184/110303558-8692ab80-8020-11eb-824c-124cb7c71671.png)

