### PR TITLE
refactor(payroll): simplified logic for additional salary

### DIFF
--- a/erpnext/payroll/doctype/salary_slip/salary_slip.py
+++ b/erpnext/payroll/doctype/salary_slip/salary_slip.py
@@ -13,7 +13,7 @@ from erpnext.payroll.doctype.payroll_entry.payroll_entry import get_start_end_da
 from erpnext.hr.doctype.employee.employee import get_holiday_list_for_employee
 from erpnext.utilities.transaction_base import TransactionBase
 from frappe.utils.background_jobs import enqueue
-from erpnext.payroll.doctype.additional_salary.additional_salary import get_additional_salary_component
+from erpnext.payroll.doctype.additional_salary.additional_salary import get_additional_salaries
 from erpnext.payroll.doctype.payroll_period.payroll_period import get_period_factor, get_payroll_period
 from erpnext.payroll.doctype.employee_benefit_application.employee_benefit_application import get_benefit_component_amount
 from erpnext.payroll.doctype.employee_benefit_claim.employee_benefit_claim import get_benefit_claim_amount, get_last_payroll_period_benefits
@@ -524,7 +524,7 @@ class SalarySlip(TransactionBase):
 
 		except NameError as err:
 			frappe.throw(_("{0} <br> This error can be due to missing or deleted field.").format(err),
-			    title=_("Name error"))
+				title=_("Name error"))
 		except SyntaxError as err:
 			frappe.throw(_("Syntax error in formula or condition: {0}").format(err))
 		except Exception as e:
@@ -558,15 +558,16 @@ class SalarySlip(TransactionBase):
 						self.update_component_row(frappe._dict(last_benefit.struct_row), amount, "earnings")
 
 	def add_additional_salary_components(self, component_type):
-		salary_components_details, additional_salary_details = get_additional_salary_component(self.employee,
+		additional_salaries = get_additional_salaries(self.employee,
 			self.start_date, self.end_date, component_type)
-		if salary_components_details and additional_salary_details:
-			for additional_salary in additional_salary_details:
-				additional_salary =frappe._dict(additional_salary)
-				amount = additional_salary.amount
-				overwrite = additional_salary.overwrite
-				self.update_component_row(frappe._dict(salary_components_details[additional_salary.component]), amount,
-					component_type, overwrite=overwrite, additional_salary=additional_salary.name)
+
+		for additional_salary in additional_salaries:
+			self.update_component_row(
+				get_salary_component_data(additional_salary.component),
+				additional_salary.amount,
+				component_type,
+				additional_salary
+			)
 
 	def add_tax_components(self, payroll_period):
 		# Calculate variable_based_on_taxable_salary after all components updated in salary slip
@@ -583,47 +584,59 @@ class SalarySlip(TransactionBase):
 
 		for d in tax_components:
 			tax_amount = self.calculate_variable_based_on_taxable_salary(d, payroll_period)
-			tax_row = self.get_salary_slip_row(d)
+			tax_row = get_salary_component_data(d)
 			self.update_component_row(tax_row, tax_amount, "deductions")
 
-	def update_component_row(self, struct_row, amount, key, overwrite=1, additional_salary = ''):
+	def update_component_row(self, component_data, amount, component_type, additional_salary=None):
 		component_row = None
-		for d in self.get(key):
-			if d.salary_component == struct_row.salary_component:
+		for d in self.get(component_type):
+			if d.salary_component != component_data.salary_component:
+				continue
+
+			if (
+				not d.additional_salary
+				and (not additional_salary or additional_salary.overwrite)
+				or additional_salary
+				and additional_salary.name == d.additional_salary
+			):
 				component_row = d
+				break
 
-		if not component_row or (struct_row.get("is_additional_component") and not overwrite):
-			if amount:
-				self.append(key, {
-					'amount': amount,
-					'default_amount': amount if not struct_row.get("is_additional_component") else 0,
-					'depends_on_payment_days' : struct_row.depends_on_payment_days,
-					'salary_component' : struct_row.salary_component,
-					'abbr' : struct_row.abbr or struct_row.get("salary_component_abbr"),
-					'additional_salary': additional_salary,
-					'do_not_include_in_total' : struct_row.do_not_include_in_total,
-					'is_tax_applicable': struct_row.is_tax_applicable,
-					'is_flexible_benefit': struct_row.is_flexible_benefit,
-					'variable_based_on_taxable_salary': struct_row.variable_based_on_taxable_salary,
-					'deduct_full_tax_on_selected_payroll_date': struct_row.deduct_full_tax_on_selected_payroll_date,
-					'additional_amount': amount if struct_row.get("is_additional_component") else 0,
-					'exempted_from_income_tax': struct_row.exempted_from_income_tax
-				})
+		if additional_salary and additional_salary.overwrite:
+			# Additional Salary with overwrite checked, remove default rows of same component
+			self.set(component_type, [
+				d for d in self.get(component_type)
+				if d.salary_component != component_data.salary_component
+				or d.additional_salary and additional_salary.name != d.additional_salary
+				or d == component_row
+			])
+
+		if not component_row:
+			if not amount:
+				return
+
+			component_row = self.append(component_type)
+			for attr in (
+				'depends_on_payment_days', 'salary_component', 'abbr'
+				'do_not_include_in_total', 'is_tax_applicable',
+				'is_flexible_benefit', 'variable_based_on_taxable_salary',
+				'exempted_from_income_tax'
+			):
+				component_row.set(attr, component_data.get(attr))
+
+		if additional_salary:
+			component_row.default_amount = 0
+			component_row.additional_amount = amount
+			component_row.additional_salary = additional_salary.name
+			component_row.deduct_full_tax_on_selected_payroll_date = \
+				additional_salary.deduct_full_tax_on_selected_payroll_date
 		else:
-			if struct_row.get("is_additional_component"):
-				if overwrite:
-					component_row.additional_amount = amount - component_row.get("default_amount", 0)
-					component_row.additional_salary = additional_salary
-				else:
-					component_row.additional_amount = amount
+			component_row.default_amount = amount
+			component_row.additional_amount = 0
+			component_row.deduct_full_tax_on_selected_payroll_date = \
+				component_data.deduct_full_tax_on_selected_payroll_date
 
-				if not overwrite and component_row.default_amount:
-					amount += component_row.default_amount
-			else:
-				component_row.default_amount = amount
-
-			component_row.amount = amount
-			component_row.deduct_full_tax_on_selected_payroll_date = struct_row.deduct_full_tax_on_selected_payroll_date
+		component_row.amount = amount
 
 	def calculate_variable_based_on_taxable_salary(self, tax_component, payroll_period):
 		if not payroll_period:
@@ -950,25 +963,12 @@ class SalarySlip(TransactionBase):
 				return frappe.safe_eval(condition, self.whitelisted_globals, data)
 		except NameError as err:
 			frappe.throw(_("{0} <br> This error can be due to missing or deleted field.").format(err),
-			    title=_("Name error"))
+				title=_("Name error"))
 		except SyntaxError as err:
 			frappe.throw(_("Syntax error in condition: {0}").format(err))
 		except Exception as e:
 			frappe.throw(_("Error in formula or condition: {0}").format(e))
 			raise
-
-	def get_salary_slip_row(self, salary_component):
-		component = frappe.get_doc("Salary Component", salary_component)
-		# Data for update_component_row
-		struct_row = frappe._dict()
-		struct_row['depends_on_payment_days'] = component.depends_on_payment_days
-		struct_row['salary_component'] = component.name
-		struct_row['abbr'] = component.salary_component_abbr
-		struct_row['do_not_include_in_total'] = component.do_not_include_in_total
-		struct_row['is_tax_applicable'] = component.is_tax_applicable
-		struct_row['is_flexible_benefit'] = component.is_flexible_benefit
-		struct_row['variable_based_on_taxable_salary'] = component.variable_based_on_taxable_salary
-		return struct_row
 
 	def get_component_totals(self, component_type, depends_on_payment_days=0):
 		joining_date, relieving_date = frappe.get_cached_value("Employee", self.employee,
@@ -1032,7 +1032,6 @@ class SalarySlip(TransactionBase):
 			self.total_loan_repayment += payment.total_payment
 
 	def get_loan_details(self):
-
 		return frappe.get_all("Loan",
 			fields=["name", "interest_income_account", "loan_account", "loan_type"],
 			filters = {
@@ -1263,3 +1262,19 @@ def unlink_ref_doc_from_salary_slip(ref_no):
 def generate_password_for_pdf(policy_template, employee):
 	employee = frappe.get_doc("Employee", employee)
 	return policy_template.format(**employee.as_dict())
+
+def get_salary_component_data(component):
+	return frappe.get_value(
+		"Salary Component",
+		component,
+		[
+			"name as salary_component",
+			"depends_on_payment_days",
+			"salary_component_abbr as abbr",
+			"do_not_include_in_total",
+			"is_tax_applicable",
+			"is_flexible_benefit",
+			"variable_based_on_taxable_salary",
+		],
+		as_dict=1,
+	)

--- a/erpnext/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/erpnext/payroll/doctype/salary_slip/test_salary_slip.py
@@ -246,7 +246,7 @@ class TestSalarySlip(unittest.TestCase):
 		make_salary_structure("Test Loan Repayment Salary Structure", "Monthly", employee=applicant, currency='INR',
 			payroll_period=payroll_period)
 
-		frappe.db.sql("""delete from `tabLoan""")
+		frappe.db.sql("delete from tabLoan")
 		loan = create_loan(applicant, "Car Loan", 11000, "Repay Over Number of Periods", 20, posting_date=add_months(nowdate(), -1))
 		loan.repay_from_salary = 1
 		loan.submit()


### PR DESCRIPTION
### Issue Fixed
Duplicate rows were being added to the `earnings` table on saving Salary Slip if the additional salary had the field **Overwrite Salary Structure Amount** unchecked. Resolves #24684.

### New Behavior
Additional salaries are now treated separately from _default_ salaries, although they may refer to the same salary component. 
For example: if there is a fixed transit allowance and an additional allowance for transit is applicable for the current payroll period, the same will reflect as an additional row in Salary Slip `earnings` table. This is useful to differentiate properly. 

It is also a standard practice to sometimes have multiple additional salaries referring to the same component (e.g. deadline incentive). The new change allows for each of these incentives to be shown separately. The new change also allows proper linking of each earnings row with their `Additional Salary` document. 

In a future release, the fields `default_amount` and `additional_amount` can be deprecated as they will now always equal `amount`. 

An exception to this behaviour is Additional Salaries with  **Overwrite Salary Structure Amount** checked. If these exist, all _default_ rows of the same component will be removed.

Note that existing Salary Slips will remain as-is.

### Changes Made
#### additional_salary.py

`get_additional_salaries` function: 
- Renamed from earlier name: `get_additional_salary_component`
- No longer whitelisted, as it wasn't being accessed from frontend.
- No longer returns `salary_components_details`, this is now being fetched in `salary_slip.py`.

**salary_slip.py**
- Replaced spaces with tabs.
- `add_additional_salary_components` updated for changes made in other functions.
- `get_salary_slip_row` renamed to `get_salary_component_data`, optimised to use `frappe.get_value` instead of `frappe.get_doc`.

`update component_row` function:
- Changed parameter names to be more logical.
- Removed overwrite parameter as `additional_salary` parameter now gets a `dict` object containing relevant data.
- Updated logic to find `component_row`.
- If an Additional Salary with `overwrite` checked is being updated, _default_ rows of the same component get removed.
- Removed condition that caused a new row to be added incorrectly to Salary Slip every time it was re-saved.
- Cleaner updation / creation of component row.

### TL;DR
- Additional salary components now have their own row.
- Incorrect duplication of rows on <kbd>Save</kbd> fixed.
- Code refactored to make it simpler to understand.

---

**Before**

![Peek 2021-03-02 14-04](https://user-images.githubusercontent.com/38958184/109621974-99f5d080-7b61-11eb-8498-92f6274d061a.gif)

**After**

![salary slip after](https://user-images.githubusercontent.com/16315650/110635764-78d05800-81d1-11eb-84aa-94f013af3937.gif)


Also tested for other cases mentioned here: https://github.com/frappe/erpnext/pull/24785#issuecomment-792621048