### PR TITLE
fix: removed show cancelled entries checkbox from the stock ledger report

### DIFF
--- a/erpnext/stock/report/stock_ledger/stock_ledger.js
+++ b/erpnext/stock/report/stock_ledger/stock_ledger.js
@@ -82,11 +82,6 @@ frappe.query_reports["Stock Ledger"] = {
 			"label": __("Include UOM"),
 			"fieldtype": "Link",
 			"options": "UOM"
-		},
-		{
-			"fieldname": "show_cancelled_entries",
-			"label": __("Show Cancelled Entries"),
-			"fieldtype": "Check"
 		}
 	],
 	"formatter": function (value, row, column, data, default_formatter) {

--- a/erpnext/stock/report/stock_ledger/stock_ledger.py
+++ b/erpnext/stock/report/stock_ledger/stock_ledger.py
@@ -138,7 +138,7 @@ def get_stock_ledger_entries(filters, items):
 			`tabStock Ledger Entry` sle
 		WHERE
 			company = %(company)s
-				AND posting_date BETWEEN %(from_date)s AND %(to_date)s
+				AND is_cancelled = 0 AND posting_date BETWEEN %(from_date)s AND %(to_date)s
 				{sle_conditions}
 				{item_conditions_sql}
 		ORDER BY
@@ -208,9 +208,6 @@ def get_sle_conditions(filters):
 		conditions.append("batch_no=%(batch_no)s")
 	if filters.get("project"):
 		conditions.append("project=%(project)s")
-
-	if not filters.get("show_cancelled_entries"):
-		conditions.append("is_cancelled = 0")
 
 	return "and {}".format(" and ".join(conditions)) if conditions else ""
 


### PR DESCRIPTION
As we are allowing to do backdated entries, removing the checkbox "show cancelled entries" from the stock ledger report 

<img width="936" alt="Screenshot 2021-03-09 at 9 16 16 PM" src="https://user-images.githubusercontent.com/8780500/110497771-c5a62700-811c-11eb-91aa-b3ca4143f3f1.png">
