### PR TITLE
fix(payroll): allow duplicate additional salaries

### DIFF
--- a/erpnext/payroll/doctype/additional_salary/additional_salary.py
+++ b/erpnext/payroll/doctype/additional_salary/additional_salary.py
@@ -9,16 +9,9 @@ from frappe import _, bold
 from frappe.utils import getdate, date_diff, comma_and, formatdate
 
 class AdditionalSalary(Document):
-
 	def on_submit(self):
 		if self.ref_doctype == "Employee Advance" and self.ref_docname:
 			frappe.db.set_value("Employee Advance", self.ref_docname, "return_amount", self.amount)
-
-	def before_insert(self):
-		if frappe.db.exists("Additional Salary", {"employee": self.employee, "salary_component": self.salary_component,
-			"amount": self.amount, "payroll_date": self.payroll_date, "company": self.company, "docstatus": 1}):
-
-			frappe.throw(_("Additional Salary Component Exists."))
 
 	def validate(self):
 		self.validate_dates()


### PR DESCRIPTION
As discussed in #24824, it can be useful to have multiple additional salaries created separately:

> Take **Deadline Incentive** for example. It may be desirable to show the same component with possibly the same amount multiple times in the Salary Slip. One for each deadline achieved.

---
In any case, this logic shouldn't be in the `before_insert` method as one can easily circumvent it by saving with a different amount initially and then re-saving with the desired amount.