### PR TITLE
fix: UOM length unit in global setup list is empty

### DIFF
--- a/erpnext/setup/doctype/global_defaults/global_defaults.js
+++ b/erpnext/setup/doctype/global_defaults/global_defaults.js
@@ -17,7 +17,7 @@ frappe.ui.form.on('Global Defaults', {
 			method: "frappe.client.get_list",
 			args: {
 				doctype: "UOM Conversion Factor",
-				filters: { "category": "Length" },
+				filters: { "category": __("Length") },
 				fields: ["to_uom"],
 				limit_page_length: 500
 			},

--- a/erpnext/setup/doctype/global_defaults/global_defaults.js
+++ b/erpnext/setup/doctype/global_defaults/global_defaults.js
@@ -17,7 +17,7 @@ frappe.ui.form.on('Global Defaults', {
 			method: "frappe.client.get_list",
 			args: {
 				doctype: "UOM Conversion Factor",
-				filters: { "category": __("Length") },
+				filters: { "category": __("Length")  },
 				fields: ["to_uom"],
 				limit_page_length: 500
 			},

--- a/erpnext/setup/doctype/global_defaults/global_defaults.js
+++ b/erpnext/setup/doctype/global_defaults/global_defaults.js
@@ -17,7 +17,7 @@ frappe.ui.form.on('Global Defaults', {
 			method: "frappe.client.get_list",
 			args: {
 				doctype: "UOM Conversion Factor",
-				filters: { "category": __("Length")  },
+				filters: { "category": __("Length") },
 				fields: ["to_uom"],
 				limit_page_length: 500
 			},


### PR DESCRIPTION
From #24749

When ERPNext is installed in French for exemple, in the table "tabUOM Conversion Factor" the category column is filled with translated value Length=>Longueur (Length in french)
In the Global Defaults form, the field "Default length unit" is filtered by category "Length" without translation, so the possible default UOM list is empty