### PR TITLE
fix: stock move dialog duplicate submit actions

### DIFF
--- a/erpnext/stock/dashboard/item_dashboard.js
+++ b/erpnext/stock/dashboard/item_dashboard.js
@@ -156,7 +156,7 @@ erpnext.stock.move_item = function(item, source, target, actual_qty, rate, callb
 				fieldtype: 'Float', description: __('Available {0}', [actual_qty]) },
 			{fieldname: 'rate', label: __('Rate'), fieldtype: 'Currency', hidden: 1 },
 		],
-	})
+	});
 	var submitted = false;
 	dialog.show();
 	dialog.get_field('item_code').set_input(item);
@@ -181,7 +181,7 @@ erpnext.stock.move_item = function(item, source, target, actual_qty, rate, callb
 	}
 
 	dialog.set_primary_action(__('Submit'), function() {
-	    if(submitted) return;
+		if(submitted) return;
 		var values = dialog.get_values();
 		if(!values) {
 			return;
@@ -194,7 +194,7 @@ erpnext.stock.move_item = function(item, source, target, actual_qty, rate, callb
 			frappe.msgprint(__('Source and target warehouse must be different'));
 		}
 
-        submitted = true;
+		submitted = true;
 		frappe.call({
 			method: 'erpnext.stock.doctype.stock_entry.stock_entry_utils.make_stock_entry',
 			args: values,

--- a/erpnext/stock/dashboard/item_dashboard.js
+++ b/erpnext/stock/dashboard/item_dashboard.js
@@ -157,6 +157,7 @@ erpnext.stock.move_item = function(item, source, target, actual_qty, rate, callb
 			{fieldname: 'rate', label: __('Rate'), fieldtype: 'Currency', hidden: 1 },
 		],
 	})
+	var submitted = false;
 	dialog.show();
 	dialog.get_field('item_code').set_input(item);
 
@@ -180,6 +181,7 @@ erpnext.stock.move_item = function(item, source, target, actual_qty, rate, callb
 	}
 
 	dialog.set_primary_action(__('Submit'), function() {
+	    if(submitted) return;
 		var values = dialog.get_values();
 		if(!values) {
 			return;
@@ -192,6 +194,7 @@ erpnext.stock.move_item = function(item, source, target, actual_qty, rate, callb
 			frappe.msgprint(__('Source and target warehouse must be different'));
 		}
 
+        submitted = true;
 		frappe.call({
 			method: 'erpnext.stock.doctype.stock_entry.stock_entry_utils.make_stock_entry',
 			args: values,


### PR DESCRIPTION
As shown in #24841 these duplications are caused by the dialog not having a safe guard against duplicate submission.

I think a more permanent solution would be to integrate a safe guarding mechanism directly into frappe dialogs so it can be prevented from happening again.
