### PR TITLE
feat: provision to make auto journal entry if there is difference between stock and account value

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -28,6 +28,8 @@
   "column_break_18",
   "book_deferred_entries_via_journal_entry",
   "submit_journal_entries",
+  "values_out_of_sync_section",
+  "make_auto_journal_entry_on_values_out_of_sync",
   "print_settings",
   "show_inclusive_tax_in_print",
   "column_break_12",
@@ -226,6 +228,18 @@
    "fieldname": "delete_linked_ledger_entries",
    "fieldtype": "Check",
    "label": "Delete Accounting and Stock Ledger Entries on deletion of Transaction"
+  },
+  {
+   "fieldname": "values_out_of_sync_section",
+   "fieldtype": "Section Break",
+   "label": "Values Out Of Sync"
+  },
+  {
+   "default": "1",
+   "description": "If stock value and account value is not same then system will create the adjustment journal entry",
+   "fieldname": "make_auto_journal_entry_on_values_out_of_sync",
+   "fieldtype": "Check",
+   "label": "Make Auto Journal Entry On Values Out Of Sync"
   }
  ],
  "icon": "icon-cog",
@@ -233,7 +247,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2021-01-05 13:04:00.118892",
+ "modified": "2021-03-12 12:02:48.682509",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounts Settings",

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -851,6 +851,20 @@ def get_payment_entry(ref_doc, args):
 
 	return je if args.get("journal_entry") else je.as_dict()
 
+def make_journal_entry(**args):
+	args = frappe._dict(args)
+
+	jv = frappe.new_doc("Journal Entry")
+	jv.update(args)
+
+	jv.accounts = []
+	for row in args.accounts:
+		if isinstance(row, dict):
+			row = frappe._dict(row)
+
+		jv.append('accounts', row)
+
+	jv.submit()
 
 @frappe.whitelist()
 def get_opening_accounts(company):

--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
@@ -5,7 +5,7 @@
 from __future__ import unicode_literals
 import frappe, erpnext
 from frappe.model.document import Document
-from frappe.utils import cint, get_link_to_form
+from frappe.utils import cint, get_link_to_form, today
 from erpnext.stock.stock_ledger import repost_future_sle
 from erpnext.accounts.utils import update_gl_entries_after, check_if_stock_and_account_balance_synced
 from frappe.utils.user import get_users_with_role
@@ -29,7 +29,7 @@ class RepostItemValuation(Document):
 			self.company = frappe.get_cached_value(self.voucher_type, self.voucher_no, "company")
 		elif self.warehouse:
 			self.company = frappe.get_cached_value("Warehouse", self.warehouse, "company")
-	
+
 	def set_status(self, status=None):
 		if not status:
 			status = 'Queued'
@@ -54,7 +54,7 @@ def repost(doc):
 
 		repost_sl_entries(doc)
 		repost_gl_entries(doc)
-		check_if_stock_and_account_balance_synced(doc.posting_date, doc.company)
+		check_if_stock_and_account_balance_synced(today(), doc.company)
 
 		doc.set_status('Completed')
 	except Exception:
@@ -103,7 +103,7 @@ def notify_error_to_stock_managers(doc, traceback):
 	recipients = get_users_with_role("Stock Manager")
 	if not recipients:
 		get_users_with_role("System Manager")
-	
+
 	subject = _("Error while reposting item valuation")
 	message = (_("Hi,") + "<br>"
 		+ _("An error has been appeared while reposting item valuation via {0}")

--- a/erpnext/stock/report/incorrect_stock_value_report/incorrect_stock_value_report.js
+++ b/erpnext/stock/report/incorrect_stock_value_report/incorrect_stock_value_report.js
@@ -1,0 +1,36 @@
+// Copyright (c) 2016, Frappe Technologies Pvt. Ltd. and contributors
+// For license information, please see license.txt
+/* eslint-disable */
+
+frappe.query_reports["Incorrect Stock Value Report"] = {
+	"filters": [
+		{
+			"label": __("Company"),
+			"fieldname": "company",
+			"fieldtype": "Link",
+			"options": "Company",
+			"reqd": 1,
+			"default": frappe.defaults.get_user_default("Company")
+		},
+		{
+			"label": __("Account"),
+			"fieldname": "account",
+			"fieldtype": "Link",
+			"options": "Account",
+			get_query: function() {
+				var company = frappe.query_report.get_filter_value('company');
+				return {
+					filters: {
+						"account_type": "Stock",
+						"company": company
+					}
+				}
+			}
+		},
+		{
+			"label": __("From Date"),
+			"fieldname": "from_date",
+			"fieldtype": "Date"
+		},
+	]
+};

--- a/erpnext/stock/report/incorrect_stock_value_report/incorrect_stock_value_report.json
+++ b/erpnext/stock/report/incorrect_stock_value_report/incorrect_stock_value_report.json
@@ -1,0 +1,29 @@
+{
+ "add_total_row": 0,
+ "columns": [],
+ "creation": "2021-03-10 17:54:07.341365",
+ "disable_prepared_report": 0,
+ "disabled": 0,
+ "docstatus": 0,
+ "doctype": "Report",
+ "filters": [],
+ "idx": 0,
+ "is_standard": "Yes",
+ "modified": "2021-03-10 17:54:07.341365",
+ "modified_by": "Administrator",
+ "module": "Stock",
+ "name": "Incorrect Stock Value Report",
+ "owner": "Administrator",
+ "prepared_report": 0,
+ "ref_doctype": "Stock Ledger Entry",
+ "report_name": "Incorrect Stock Value Report",
+ "report_type": "Script Report",
+ "roles": [
+  {
+   "role": "Stock User"
+  },
+  {
+   "role": "Accounts Manager"
+  }
+ ]
+}

--- a/erpnext/stock/report/incorrect_stock_value_report/incorrect_stock_value_report.py
+++ b/erpnext/stock/report/incorrect_stock_value_report/incorrect_stock_value_report.py
@@ -1,0 +1,140 @@
+# Copyright (c) 2013, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+from __future__ import unicode_literals
+import frappe, erpnext
+from frappe import _
+from six import iteritems
+from frappe.utils import add_days, today, getdate
+from erpnext.stock.utils import get_stock_value_on
+from erpnext.accounts.utils import get_stock_and_account_balance
+
+def execute(filters=None):
+	if not erpnext.is_perpetual_inventory_enabled(filters.company):
+		frappe.throw(_("Perpetual inventory required for the company {0} to view this report.")
+			.format(filters.company))
+
+	data = get_data(filters)
+	columns = get_columns(filters)
+
+	return columns, data
+
+def get_unsync_date(filters):
+	date = frappe.db.sql(""" SELECT min(posting_date) from `tabStock Ledger Entry`""")
+	if not date: return
+
+	date = date[0][0]
+
+	while getdate(date) < getdate(today()):
+		account_bal, stock_bal, warehouse_list = get_stock_and_account_balance(posting_date=date,
+			company=filters.company, account = filters.account)
+
+		if abs(account_bal - stock_bal) > 0.1:
+			return date
+
+		date = add_days(date, 1)
+
+def get_data(report_filters):
+	from_date = report_filters.get("from_date")
+
+	if not from_date:
+		from_date = get_unsync_date(report_filters)
+
+	if not from_date:
+		return []
+
+	result = []
+
+	voucher_wise_dict = {}
+	data = frappe.db.sql('''
+			SELECT
+				name, posting_date, posting_time, voucher_type, voucher_no,
+				stock_value_difference, stock_value, warehouse, item_code
+			FROM
+				`tabStock Ledger Entry`
+			WHERE
+				posting_date
+				= %s and company = %s
+				and is_cancelled = 0
+			ORDER BY timestamp(posting_date, posting_time) asc, creation asc
+		''', (from_date, report_filters.company), as_dict=1)
+
+	for d in data:
+		voucher_wise_dict.setdefault((d.item_code, d.warehouse), []).append(d)
+
+	closing_date = add_days(from_date, -1)
+	for key, stock_data in iteritems(voucher_wise_dict):
+		prev_stock_value = get_stock_value_on(posting_date = closing_date, item_code=key[0], warehouse =key[1])
+		for data in stock_data:
+			expected_stock_value = prev_stock_value + data.stock_value_difference
+			if abs(data.stock_value - expected_stock_value) > 0.1:
+				data.difference_value = abs(data.stock_value - expected_stock_value)
+				data.expected_stock_value = expected_stock_value
+				result.append(data)
+
+	return result
+
+def get_columns(filters):
+	return [
+		{
+			"label": _("Stock Ledger ID"),
+			"fieldname": "name",
+			"fieldtype": "Link",
+			"options": "Stock Ledger Entry",
+			"width": "80"
+		},
+		{
+			"label": _("Posting Date"),
+			"fieldname": "posting_date",
+			"fieldtype": "Date"
+		},
+		{
+			"label": _("Posting Time"),
+			"fieldname": "posting_time",
+			"fieldtype": "Time"
+		},
+		{
+			"label": _("Voucher Type"),
+			"fieldname": "voucher_type",
+			"width": "110"
+		},
+		{
+			"label": _("Voucher No"),
+			"fieldname": "voucher_no",
+			"fieldtype": "Dynamic Link",
+			"options": "voucher_type",
+			"width": "110"
+		},
+		{
+			"label": _("Item Code"),
+			"fieldname": "item_code",
+			"fieldtype": "Link",
+			"options": "Item",
+			"width": "110"
+		},
+		{
+			"label": _("Warehouse"),
+			"fieldname": "warehouse",
+			"fieldtype": "Link",
+			"options": "Warehouse",
+			"width": "110"
+		},
+		{
+			"label": _("Expected Stock Value"),
+			"fieldname": "expected_stock_value",
+			"fieldtype": "Currency",
+			"width": "150"
+		},
+		{
+			"label": _("Stock Value"),
+			"fieldname": "stock_value",
+			"fieldtype": "Currency",
+			"width": "120"
+		},
+		{
+			"label": _("Difference Value"),
+			"fieldname": "difference_value",
+			"fieldtype": "Currency",
+			"width": "150"
+		}
+	]


### PR DESCRIPTION
**Issue**

<img width="658" alt="Screenshot 2021-03-12 at 12 04 01 PM" src="https://user-images.githubusercontent.com/8780500/110902617-31121380-832c-11eb-8ddb-db6000d179a6.png">


If the stock and account value has the difference then system throws the above validation and force user to make the journal entry. Once user create the Journal Entry then system allow user to complete the transaction. With the new changes we have added provision to make the JV automatically if there is difference between stock and account value.

<img width="832" alt="Screenshot 2021-03-12 at 12 08 52 PM" src="https://user-images.githubusercontent.com/8780500/110902351-c660d800-832b-11eb-85a3-a30c1c6c62fb.png">

**Report**

Added report to know which are the incorrect stock value transactions

<img width="1317" alt="Screenshot 2021-03-12 at 12 10 25 PM" src="https://user-images.githubusercontent.com/8780500/110902515-04f69280-832c-11eb-89df-a579d45792bc.png">

