### PR TITLE
fix(Bank Reconciliation Tool): Filter Bank Account drop-down list

### DIFF
--- a/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.js
+++ b/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.js
@@ -8,6 +8,7 @@ frappe.ui.form.on("Bank Reconciliation Tool", {
 			return {
 				filters: {
 					company: ["in", frm.doc.company],
+					'is_company_account': 1
 				},
 			};
 		});


### PR DESCRIPTION
Issue: Bank Account drop-down list features all the bank accounts created, instead of just the company accounts

Fix: Added a filter that ensures that only company accounts show up on the Bank Account drop-down list

![Screenshot 2021-03-13 at 10 26 59 PM](https://user-images.githubusercontent.com/25903035/111037684-3e71ef80-844b-11eb-8a88-469cd654b081.png)
