### PR TITLE
fix(Bank Reconciliation): Filter Bank Account drop-down list

### DIFF
--- a/erpnext/accounts/doctype/bank_reconciliation/bank_reconciliation.js
+++ b/erpnext/accounts/doctype/bank_reconciliation/bank_reconciliation.js
@@ -21,6 +21,14 @@ frappe.ui.form.on("Bank Reconciliation", {
 			};
 		});
 
+		frm.set_query("bank_account", function() {
+			return {
+				"filters": {
+					"is_company_account": 1
+				}
+			};
+		});
+
 		frm.set_value("from_date", frappe.datetime.month_start());
 		frm.set_value("to_date", frappe.datetime.month_end());
 	},


### PR DESCRIPTION
Issue: Bank Account drop-down list features all the bank accounts created, instead of just the company accounts

Fix: Added a filter that ensures that only company accounts show up on the Bank Account drop-down list

![Screenshot 2021-03-13 at 11 47 09 PM](https://user-images.githubusercontent.com/25903035/111039881-703c8380-8456-11eb-8c5c-d898191c9c66.png)

