### PR TITLE
fix: POS Opening Entry with empty balance detail rows

### DIFF
--- a/erpnext/accounts/doctype/pos_opening_entry/pos_opening_entry.py
+++ b/erpnext/accounts/doctype/pos_opening_entry/pos_opening_entry.py
@@ -20,15 +20,16 @@ class POSOpeningEntry(StatusUpdater):
 
 		if not cint(frappe.db.get_value("User", self.user, "enabled")):
 			frappe.throw(_("User {} is disabled. Please select valid user/cashier").format(self.user))
-	
+
 	def validate_payment_method_account(self):
 		invalid_modes = []
 		for d in self.balance_details:
-			account = frappe.db.get_value("Mode of Payment Account", 
-				{"parent": d.mode_of_payment, "company": self.company}, "default_account")
-			if not account:
-				invalid_modes.append(get_link_to_form("Mode of Payment", d.mode_of_payment))
-		
+			if d.mode_of_payment:
+				account = frappe.db.get_value("Mode of Payment Account",
+					{"parent": d.mode_of_payment, "company": self.company}, "default_account")
+				if not account:
+					invalid_modes.append(get_link_to_form("Mode of Payment", d.mode_of_payment))
+
 		if invalid_modes:
 			if invalid_modes == 1:
 				msg = _("Please set default Cash or Bank account in Mode of Payment {}")

--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -93,6 +93,10 @@ erpnext.PointOfSale.Controller = class {
 					})
 					return frappe.utils.play_sound("error");
 				}
+
+				// filter balance details for empty rows
+				balance_details = balance_details.filter(d => d.mode_of_payment);
+
 				const method = "erpnext.selling.page.point_of_sale.point_of_sale.create_opening_voucher";
 				const res = await frappe.call({ method, args: { pos_profile, company, balance_details }, freeze:true });
 				!res.exc && me.prepare_app_defaults(res.message);


### PR DESCRIPTION
**Issue:**
- Open POS, make sure there is not POS Opening Entry for this POS Profile and User
- In the POS Opening Entry Dialog add an empty row and click on submit
- Due to no mode of payment in the row, while validating `get_link_to_form("Mode of Payment", d.mode_of_payment)` breaks as tries to encode a `None` value
<img src="https://user-images.githubusercontent.com/25857446/111069182-ee9a3380-84f1-11eb-8e66-31718fb45a3d.png" width=45%>

```
File "/home/frappe/benches/bench-version-13-2021-02-11/apps/erpnext/erpnext/accounts/doctype/pos_opening_entry/pos_opening_entry.py", line 15, in validate
    self.validate_payment_method_account()
  File "/home/frappe/benches/bench-version-13-2021-02-11/apps/erpnext/erpnext/accounts/doctype/pos_opening_entry/pos_opening_entry.py", line 31, in validate_payment_method_account
    invalid_modes.append(get_link_to_form("Mode of Payment", d.mode_of_payment))
  File "/home/frappe/benches/bench-version-13-2021-02-11/apps/frappe/frappe/utils/data.py", line 1052, in get_link_to_form
    return """{1}""".format(get_url_to_form(doctype, name), label)
  File "/home/frappe/benches/bench-version-13-2021-02-11/apps/frappe/frappe/utils/data.py", line 1076, in get_url_to_form
    return get_url(uri = "desk#Form/{0}/{1}".format(quoted(doctype), quoted(name)))
  File "/home/frappe/benches/bench-version-13-2021-02-11/apps/frappe/frappe/utils/data.py", line 1277, in quoted
    return cstr(quote(encode(url), safe=b"~@#$&()*!+=:;,.?/'"))
  File "/usr/lib64/python3.6/urllib/parse.py", line 789, in quote
    return quote_from_bytes(string, safe)
  File "/usr/lib64/python3.6/urllib/parse.py", line 814, in quote_from_bytes
    raise TypeError("quote_from_bytes() expected bytes")
TypeError: quote_from_bytes() expected bytes
```

**Fix:**
- On the client side, filter out empty rows before calling the API and passing it the table data
- On the server side, validate the row only if the mode of payment exists