### PR TITLE
fix: use method name as title in error log

### DIFF
--- a/erpnext/erpnext_integrations/doctype/amazon_mws_settings/amazon_methods.py
+++ b/erpnext/erpnext_integrations/doctype/amazon_mws_settings/amazon_methods.py
@@ -117,7 +117,7 @@ def call_mws_method(mws_method, *args, **kwargs):
 			return response
 		except Exception as e:
 			delay = math.pow(4, x) * 125
-			frappe.log_error(message=e, title=str(mws_method))
+			frappe.log_error(message=e, title="Method {} failed".format(mws_method.__name__))
 			time.sleep(delay)
 			continue
 


### PR DESCRIPTION
port-of: https://github.com/frappe/erpnext/pull/24383