### PR TITLE
fix: item attributes not editable until refresh

### DIFF
--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -85,7 +85,7 @@ frappe.ui.form.on("Item", {
 		}
 		if (frm.doc.variant_of) {
 			frm.set_intro(__('This Item is a Variant of {0} (Template).',
-				[`<a href="#Form/Item/${frm.doc.variant_of}">${frm.doc.variant_of}</a>`]), true);
+				[`<a href="/app/item/${frm.doc.variant_of}" onclick="location.reload()">${frm.doc.variant_of}</a>`]), true);
 		}
 
 		if (frappe.defaults.get_default("item_naming_by")!="Naming Series" || frm.doc.variant_of) {


### PR DESCRIPTION
backport of fix: item attributes not editable until refresh #24701

The item attributes under Item master at first are not editable, but after refresh they are editable

Steps to reproduce:

Go to item list
Search for a product either through a filter or manually which is a variant
Open that variant item
On the top, most of the page the Item template product will be mentioned- Open that
Go to system attributes, it will not allow editing
Refresh the page and check the item attributes will be now editable.