### PR TITLE
fix: Assignment Rule Unassign Condition doesn't work

### DIFF
--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -114,7 +114,9 @@ class Customer(TransactionBase):
 		'''If Customer created from Lead, update lead status to "Converted"
 		update Customer link in Quotation, Opportunity'''
 		if self.lead_name:
-			frappe.db.set_value('Lead', self.lead_name, 'status', 'Converted', update_modified=False)
+			lead = frappe.get_doc('Lead', self.lead_name)
+			lead.status = 'Converted'
+			lead.save()
 
 	def create_lead_address_contact(self):
 		if self.lead_name:


### PR DESCRIPTION
backport of fix: Assignment Rule Unassign Condition doesn't work #24551

The customer has created an Assignment Rule for Lead Doctype which basically removes the assigned person when the status of the Lead changes to 'Converted'.

This Assignment Rule is working if we manually change the status to 'Converted', but if a user creates a 'Customer' from Lead which basically changes the status of Lead to 'Converted' in the background then Assignment Rule is not getting triggered.