### PR TITLE
fix: Add method for regional round off account back

### DIFF
--- a/erpnext/regional/india/utils.py
+++ b/erpnext/regional/india/utils.py
@@ -808,3 +808,24 @@ def get_gst_tax_amount(doc):
 			gst_tax += tax.tax_amount_after_discount_amount
 
 	return gst_tax, base_gst_tax
+
+@frappe.whitelist()
+def get_regional_round_off_accounts(company, account_list):
+	country = frappe.get_cached_value('Company', company, 'country')
+
+	if country != 'India':
+		return
+
+	if isinstance(account_list, string_types):
+		account_list = json.loads(account_list)
+
+	if not frappe.db.get_single_value('GST Settings', 'round_off_gst_values'):
+		return
+
+	gst_accounts = get_gst_accounts(company)
+	gst_account_list = gst_accounts.get('cgst_account') + gst_accounts.get('sgst_account') \
+		+ gst_accounts.get('igst_account')
+
+	account_list.extend(gst_account_list)
+
+	return account_list


### PR DESCRIPTION
This method got removed in a merge conflict which caused the following issue.  Adding it back in this PR

```
AttributeError: module 'erpnext.regional.india.utils' has no attribute 'get_regional_round_off_accounts'
```