### PR TITLE
fix(Project): get correct holiday list when calculating dates; test fixes

### DIFF
--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -81,12 +81,18 @@ class Project(Document):
 
 	def calculate_start_date(self, task_details):
 		self.start_date = add_days(self.expected_start_date, task_details.start)
-		self.start_date = update_if_holiday(self.holiday_list, self.start_date)
+		self.start_date = self.update_if_holiday(self.start_date)
 		return self.start_date
 
 	def calculate_end_date(self, task_details):
 		self.end_date = add_days(self.start_date, task_details.duration)
-		return update_if_holiday(self.holiday_list, self.end_date)
+		return self.update_if_holiday(self.end_date)
+
+	def update_if_holiday(self, date):
+		holiday_list = self.holiday_list or get_holiday_list(self.company)
+		while is_holiday(holiday_list, date):
+			date = add_days(date, 1)
+		return date
 
 	def dependency_mapping(self, template_tasks, project_tasks):
 		for template_task in template_tasks:
@@ -541,9 +547,3 @@ def set_project_status(project, status):
 
 	project.status = status
 	project.save()
-
-def update_if_holiday(holiday_list, date):
-	holiday_list = holiday_list or get_holiday_list()
-	while is_holiday(holiday_list, date):
-		date = add_days(date, 1)
-	return date

--- a/erpnext/projects/doctype/project/test_project.py
+++ b/erpnext/projects/doctype/project/test_project.py
@@ -8,7 +8,6 @@ test_records = frappe.get_test_records('Project')
 test_ignore = ["Sales Order"]
 
 from erpnext.projects.doctype.project_template.test_project_template import make_project_template
-from erpnext.projects.doctype.project.project import update_if_holiday
 from erpnext.projects.doctype.task.test_task import create_task
 from frappe.utils import getdate, nowdate, add_days
 
@@ -97,7 +96,8 @@ def get_project(name, template):
 		project_name = name,
 		status = 'Open',
 		project_template = template.name,
-		expected_start_date = nowdate()
+		expected_start_date = nowdate(),
+		company="_Test Company"
 	)).insert()
 
 	return project
@@ -131,7 +131,7 @@ def task_exists(subject):
 
 def calculate_end_date(project, start, duration):
 	start = add_days(project.expected_start_date, start)
-	start = update_if_holiday(project.holiday_list, start)
+	start = project.update_if_holiday(start)
 	end = add_days(start, duration)
-	end = update_if_holiday(project.holiday_list, end)
+	end = project.update_if_holiday(end)
 	return getdate(end)


### PR DESCRIPTION
- Previously, the Default Holiday List of the default Company used to be fetched instead of the project's company.
- Made `update_if_holiday` a method, not being used elsewhere.
- Use `_Test Company` in tests as `Wind Power LLC` (the default company) doesn't have a default holiday list.