### PR TITLE
ci: use ubuntu 18 specifically

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Use ubuntu 18 instead of latest to ensure we get the exact same environment each time