### PR TITLE
ci: update badge in README and add push event trigger

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -1,8 +1,6 @@
 name: CI
 
-on:
-  pull_request:
-  workflow_dispatch:
+on: [pull_request, workflow_dispatch, push]
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
         <p>ERP made simple</p>
     </p>
 
-[![Build Status](https://api.travis-ci.com/frappe/erpnext.svg?branch=develop)](https://travis-ci.com/frappe/erpnext)
+[![CI](https://github.com/frappe/erpnext/actions/workflows/ci-tests.yml/badge.svg?branch=develop)](https://github.com/frappe/erpnext/actions/workflows/ci-tests.yml)
 [![Open Source Helpers](https://www.codetriage.com/frappe/erpnext/badges/users.svg)](https://www.codetriage.com/frappe/erpnext)
 [![Coverage Status](https://coveralls.io/repos/github/frappe/erpnext/badge.svg?branch=develop)](https://coveralls.io/github/frappe/erpnext?branch=develop)
 


### PR DESCRIPTION
Refer https://github.com/frappe/frappe/pull/12592 for more info.

The badge currently looks like this:

![Badge](https://github.com/frappe/erpnext/actions/workflows/ci-tests.yml/badge.svg?branch=develop)
