### PR TITLE
ci: get branch name from GITHUB_REF if GITHUB_BASE_REF not available

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -12,7 +12,7 @@ sudo apt install npm
 
 pip install frappe-bench
 
-git clone https://github.com/frappe/frappe --branch "${GITHUB_BASE_REF}" --depth 1
+git clone https://github.com/frappe/frappe --branch "${GITHUB_BASE_REF:-${GITHUB_REF##*/}}" --depth 1
 bench init --skip-assets --frappe-path ~/frappe --python "$(which python)" frappe-bench
 
 mkdir ~/frappe-bench/sites/test_site


### PR DESCRIPTION
The environment variable GITHUB_BASE_REF is only available for `pull_request` events. Consequently, `workflow_dispatch` and `push` events [fail during install](https://github.com/frappe/erpnext/actions/runs/659940318).

This PR gets the branch name from GITHUB_REF if GITHUB_BASE_REF is unavailable. This can work, as GITHUB_REF refers to the correct branches for `workflow_dispatch` and `push` events.

Further reading:
- https://docs.github.com/en/actions/reference/events-that-trigger-workflows
- https://docs.github.com/en/actions/reference/environment-variables
- https://stackoverflow.com/a/39296572
- https://stackoverflow.com/a/58034787

---

**Local Testing** (ASD available, ASDF not)

![Screenshot-2021-03-17-111816](https://user-images.githubusercontent.com/16315650/111421773-92aef500-8713-11eb-8111-bec6a3d1b48e.png)
