### PR TITLE
fix: Report Issue Summary fix for zero issues

### DIFF
--- a/erpnext/support/report/issue_summary/issue_summary.py
+++ b/erpnext/support/report/issue_summary/issue_summary.py
@@ -260,8 +260,7 @@ class IssueSummary(object):
 					self.issue_summary_data[value]['avg_user_resolution_time'] = entry.get('avg_user_resolution_time') or 0.0
 
 	def get_chart_data(self):
-		if not self.data:
-			return None
+		self.chart = []
 
 		labels = []
 		open_issues = []
@@ -310,8 +309,7 @@ class IssueSummary(object):
 		}
 
 	def get_report_summary(self):
-		if not self.data:
-			return None
+		self.report_summary = []
 
 		open_issues = 0
 		replied = 0


### PR DESCRIPTION
Issue: When there is no data (issues), the report throws the following error.

Before:

![Screenshot 2021-03-18 at 10 37 42 AM](https://user-images.githubusercontent.com/60467153/111576322-4d073080-87d6-11eb-9a3f-56342b4beda9.png)

After: 

![Screenshot 2021-03-18 at 10 34 45 AM](https://user-images.githubusercontent.com/60467153/111576369-64461e00-87d6-11eb-89eb-65b7bd153c5a.png)


