### PR TITLE
fix: hide alt tag if item is not shown in website

### DIFF
--- a/erpnext/stock/doctype/item/item.json
+++ b/erpnext/stock/doctype/item/item.json
@@ -1054,6 +1054,7 @@
    "read_only": 1
   },
   {
+   "depends_on": "eval: doc.show_in_website || doc.show_variant_in_website",
    "fieldname": "website_image_alt",
    "fieldtype": "Data",
    "label": "Image Description"
@@ -1066,7 +1067,7 @@
  "index_web_pages_for_search": 1,
  "links": [],
  "max_attachments": 1,
- "modified": "2021-03-15 13:41:04.108932",
+ "modified": "2021-03-18 14:04:38.575519",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Item",


### PR DESCRIPTION
The alt tag/image description field like others should be hidden by default unless "show on website" is checked.

Before:
![image](https://user-images.githubusercontent.com/9079960/111597112-e264ed80-87f3-11eb-9eec-4ff45d14bf5a.png)

After:
![image](https://user-images.githubusercontent.com/9079960/111597518-3ff93a00-87f4-11eb-9653-9561b1a8e8f6.png)
