### PR TITLE
fix: serial no trim issue

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -744,7 +744,7 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 				serialnos = item.serial_no.split("\n");
 				for (var i = 0; i < serialnos.length; i++) {
 					if (serialnos[i] != "") {
-						valid_serial_nos.push(serialnos[i])
+						valid_serial_nos.push(serialnos[i]);
 					}
 				}
 				item.conversion_factor = item.conversion_factor || 1;

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -738,9 +738,15 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 			}
 			else {
 				var valid_serial_nos = [];
-
+				var serialnos = [];
 				// Replacing all occurences of comma with carriage return
 				item.serial_no = item.serial_no.replace(/,/g, '\n');
+				serialnos = item.serial_no.split("\n");
+				for (var i = 0; i < serialnos.length; i++) {
+					if (serialnos[i] != "") {
+						valid_serial_nos.push(serialnos[i])
+					}
+				}
 				item.conversion_factor = item.conversion_factor || 1;
 
 				refresh_field("serial_no", item.name, item.parentfield);

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -740,19 +740,7 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 				var valid_serial_nos = [];
 
 				// Replacing all occurences of comma with carriage return
-				var serial_nos = item.serial_no.trim().replace(/,/g, '\n');
-
-				serial_nos = serial_nos.trim().split('\n');
-
-				// Trim each string and push unique string to new list
-				for (var x=0; x<=serial_nos.length - 1; x++) {
-					if (serial_nos[x].trim() != "" && valid_serial_nos.indexOf(serial_nos[x].trim()) == -1) {
-						valid_serial_nos.push(serial_nos[x].trim());
-					}
-				}
-
-				// Add the new list to the serial no. field in grid with each in new line
-				item.serial_no = valid_serial_nos.join('\n');
+				item.serial_no = item.serial_no.replace(/,/g, '\n');
 				item.conversion_factor = item.conversion_factor || 1;
 
 				refresh_field("serial_no", item.name, item.parentfield);


### PR DESCRIPTION
**Issue:**

1. Serial No field for transaction doctypes was causing issues with manual entry as well as entry through a barcode reader.
2. The unnecessary trim code was causing the cursor to go back to the previous line.

![Screen Recording 2021-03-18 at 6 29 58 PM (1)](https://user-images.githubusercontent.com/31363128/111740551-f586c480-88aa-11eb-9597-63fbbaba5367.gif)

**Steps to replicate:**

1. Create any new transaction document (e.g. Purchase Receipt)
2.  Enter an item and open the item row.
3. In the Serial no field, enter the serial number. 
4. Then press enter to go to the next line.
5. The cursor should stay on the new line and should not go back to the previous line.




