### PR TITLE
Correct state code for 'Other Territory'

### DIFF
--- a/erpnext/regional/india/__init__.py
+++ b/erpnext/regional/india/__init__.py
@@ -69,7 +69,7 @@ state_numbers = {
  "Mizoram": "15",
  "Nagaland": "13",
  "Odisha": "21",
- "Other Territory": "98",
+ "Other Territory": "97",
  "Pondicherry": "34",
  "Punjab": "03",
  "Rajasthan": "08",


### PR DESCRIPTION
Corrects state code for 'Other Territory' to match e-invoicing state codes list. Attempts to fix #24992