### PR TITLE
fix: missing help links in navbar help dropdown

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -720,7 +720,7 @@ erpnext.patches.v13_0.delete_report_requested_items_to_order
 erpnext.patches.v12_0.update_item_tax_template_company
 erpnext.patches.v13_0.move_branch_code_to_bank_account
 erpnext.patches.v13_0.healthcare_lab_module_rename_doctypes
-erpnext.patches.v13_0.add_standard_navbar_items #4
+erpnext.patches.v13_0.add_standard_navbar_items #2021-03-24
 erpnext.patches.v13_0.stock_entry_enhancements
 erpnext.patches.v12_0.update_state_code_for_daman_and_diu
 erpnext.patches.v12_0.rename_lost_reason_detail

--- a/erpnext/public/js/help_links.js
+++ b/erpnext/public/js/help_links.js
@@ -1,526 +1,1051 @@
-frappe.provide('frappe.help.help_links');
+frappe.provide("frappe.help.help_links");
 
-const docsUrl = 'https://erpnext.com/docs/';
+const docsUrl = "https://erpnext.com/docs/";
 
-frappe.help.help_links['Form/Rename Tool'] = [
-	{ label: 'Bulk Rename', url: docsUrl + 'user/manual/en/setting-up/data/bulk-rename' },
-]
+frappe.help.help_links["Form/Rename Tool"] = [
+	{
+		label: "Bulk Rename",
+		url: docsUrl + "user/manual/en/setting-up/data/bulk-rename",
+	},
+];
 
 //Setup
 
-frappe.help.help_links['List/User'] = [
-	{ label: 'New User', url: docsUrl + 'user/manual/en/setting-up/users-and-permissions/adding-users' },
-	{ label: 'Rename User', url: docsUrl + 'user/manual/en/setting-up/articles/rename-user' },
-]
+frappe.help.help_links["List/User"] = [
+	{
+		label: "New User",
+		url:
+			docsUrl +
+			"user/manual/en/setting-up/users-and-permissions/adding-users",
+	},
+	{
+		label: "Rename User",
+		url: docsUrl + "user/manual/en/setting-up/articles/rename-user",
+	},
+];
 
-frappe.help.help_links['permission-manager'] = [
-	{ label: 'Role Permissions Manager', url: docsUrl + 'user/manual/en/setting-up/users-and-permissions/role-based-permissions' },
-	{ label: 'Managing Perm Level in Permissions Manager', url: docsUrl + 'user/manual/en/setting-up/articles/managing-perm-level' },
-	{ label: 'User Permissions', url: docsUrl + 'user/manual/en/setting-up/users-and-permissions/user-permissions' },
-	{ label: 'Sharing', url: docsUrl + 'user/manual/en/setting-up/users-and-permissions/sharing' },
-	{ label: 'Password', url: docsUrl + 'user/manual/en/setting-up/articles/change-password' },
-]
+frappe.help.help_links["permission-manager"] = [
+	{
+		label: "Role Permissions Manager",
+		url:
+			docsUrl +
+			"user/manual/en/setting-up/users-and-permissions/role-based-permissions",
+	},
+	{
+		label: "Managing Perm Level in Permissions Manager",
+		url: docsUrl + "user/manual/en/setting-up/articles/managing-perm-level",
+	},
+	{
+		label: "User Permissions",
+		url:
+			docsUrl +
+			"user/manual/en/setting-up/users-and-permissions/user-permissions",
+	},
+	{
+		label: "Sharing",
+		url:
+			docsUrl + "user/manual/en/setting-up/users-and-permissions/sharing",
+	},
+	{
+		label: "Password",
+		url: docsUrl + "user/manual/en/setting-up/articles/change-password",
+	},
+];
 
-frappe.help.help_links['Form/System Settings'] = [
-	{ label: 'Naming Series', url: docsUrl + 'user/manual/en/setting-up/settings/system-settings' },
-]
+frappe.help.help_links["Form/System Settings"] = [
+	{
+		label: "Naming Series",
+		url: docsUrl + "user/manual/en/setting-up/settings/system-settings",
+	},
+];
 
-frappe.help.help_links['data-import-tool'] = [
-	{ label: 'Importing and Exporting Data', url: docsUrl + 'user/manual/en/setting-up/data/data-import-tool' },
-	{ label: 'Overwriting Data from Data Import Tool', url: docsUrl + 'user/manual/en/setting-up/articles/overwriting-data-from-data-import-tool' },
-]
+frappe.help.help_links["data-import-tool"] = [
+	{
+		label: "Importing and Exporting Data",
+		url: docsUrl + "user/manual/en/setting-up/data/data-import-tool",
+	},
+	{
+		label: "Overwriting Data from Data Import Tool",
+		url:
+			docsUrl +
+			"user/manual/en/setting-up/articles/overwriting-data-from-data-import-tool",
+	},
+];
 
-frappe.help.help_links['module_setup'] = [
-	{ label: 'Role Permissions Manager', url: docsUrl + 'user/manual/en/setting-up/users-and-permissions/role-based-permissions' },
-]
+frappe.help.help_links["module_setup"] = [
+	{
+		label: "Role Permissions Manager",
+		url:
+			docsUrl +
+			"user/manual/en/setting-up/users-and-permissions/role-based-permissions",
+	},
+];
 
-frappe.help.help_links['Form/Naming Series'] = [
-	{ label: 'Naming Series', url: docsUrl + 'user/manual/en/setting-up/settings/naming-series' },
-	{ label: 'Setting the Current Value for Naming Series', url: docsUrl + 'user/manual/en/setting-up/articles/naming-series-current-value' },
-]
+frappe.help.help_links["Form/Naming Series"] = [
+	{
+		label: "Naming Series",
+		url: docsUrl + "user/manual/en/setting-up/settings/naming-series",
+	},
+	{
+		label: "Setting the Current Value for Naming Series",
+		url:
+			docsUrl +
+			"user/manual/en/setting-up/articles/naming-series-current-value",
+	},
+];
 
-frappe.help.help_links['Form/Global Defaults'] = [
-	{ label: 'Global Settings', url: docsUrl + 'user/manual/en/setting-up/settings/global-defaults' },
-]
+frappe.help.help_links["Form/Global Defaults"] = [
+	{
+		label: "Global Settings",
+		url: docsUrl + "user/manual/en/setting-up/settings/global-defaults",
+	},
+];
 
-frappe.help.help_links['Form/Email Digest'] = [
-	{ label: 'Email Digest', url: docsUrl + 'user/manual/en/setting-up/email/email-digest' },
-]
+frappe.help.help_links["Form/Email Digest"] = [
+	{
+		label: "Email Digest",
+		url: docsUrl + "user/manual/en/setting-up/email/email-digest",
+	},
+];
 
-frappe.help.help_links['List/Print Heading'] = [
-	{ label: 'Print Heading', url: docsUrl + 'user/manual/en/setting-up/print/print-headings' },
-]
+frappe.help.help_links["List/Print Heading"] = [
+	{
+		label: "Print Heading",
+		url: docsUrl + "user/manual/en/setting-up/print/print-headings",
+	},
+];
 
-frappe.help.help_links['List/Letter Head'] = [
-	{ label: 'Letter Head', url: docsUrl + 'user/manual/en/setting-up/print/letter-head' },
-]
+frappe.help.help_links["List/Letter Head"] = [
+	{
+		label: "Letter Head",
+		url: docsUrl + "user/manual/en/setting-up/print/letter-head",
+	},
+];
 
-frappe.help.help_links['List/Address Template'] = [
-	{ label: 'Address Template', url: docsUrl + 'user/manual/en/setting-up/print/address-template' },
-]
+frappe.help.help_links["List/Address Template"] = [
+	{
+		label: "Address Template",
+		url: docsUrl + "user/manual/en/setting-up/print/address-template",
+	},
+];
 
-frappe.help.help_links['List/Terms and Conditions'] = [
-	{ label: 'Terms and Conditions', url: docsUrl + 'user/manual/en/setting-up/print/terms-and-conditions' },
-]
+frappe.help.help_links["List/Terms and Conditions"] = [
+	{
+		label: "Terms and Conditions",
+		url: docsUrl + "user/manual/en/setting-up/print/terms-and-conditions",
+	},
+];
 
-frappe.help.help_links['List/Cheque Print Template'] = [
-	{ label: 'Cheque Print Template', url: docsUrl + 'user/manual/en/setting-up/print/cheque-print-template' },
-]
+frappe.help.help_links["List/Cheque Print Template"] = [
+	{
+		label: "Cheque Print Template",
+		url: docsUrl + "user/manual/en/setting-up/print/cheque-print-template",
+	},
+];
 
-frappe.help.help_links['List/Email Account'] = [
-	{ label: 'Email Account', url: docsUrl + 'user/manual/en/setting-up/email/email-account' },
-]
+frappe.help.help_links["List/Email Account"] = [
+	{
+		label: "Email Account",
+		url: docsUrl + "user/manual/en/setting-up/email/email-account",
+	},
+];
 
-frappe.help.help_links['List/Notification'] = [
-	{ label: 'Notification', url: docsUrl + 'user/manual/en/setting-up/email/notifications' },
-]
+frappe.help.help_links["List/Notification"] = [
+	{
+		label: "Notification",
+		url: docsUrl + "user/manual/en/setting-up/email/notifications",
+	},
+];
 
-frappe.help.help_links['Form/Notification'] = [
-	{ label: 'Notification', url: docsUrl + 'user/manual/en/setting-up/email/notifications' },
-]
+frappe.help.help_links["Form/Notification"] = [
+	{
+		label: "Notification",
+		url: docsUrl + "user/manual/en/setting-up/email/notifications",
+	},
+];
 
-frappe.help.help_links['List/Email Digest'] = [
-	{ label: 'Email Digest', url: docsUrl + 'user/manual/en/setting-up/email/email-digest' },
-]
+frappe.help.help_links["List/Email Digest"] = [
+	{
+		label: "Email Digest",
+		url: docsUrl + "user/manual/en/setting-up/email/email-digest",
+	},
+];
 
-frappe.help.help_links['List/Auto Email Report'] = [
-	{ label: 'Auto Email Reports', url: docsUrl + 'user/manual/en/setting-up/email/email-reports' },
-]
+frappe.help.help_links["List/Auto Email Report"] = [
+	{
+		label: "Auto Email Reports",
+		url: docsUrl + "user/manual/en/setting-up/email/email-reports",
+	},
+];
 
-frappe.help.help_links['Form/Print Settings'] = [
-	{ label: 'Print Settings', url: docsUrl + 'user/manual/en/setting-up/print/print-settings' },
-]
+frappe.help.help_links["Form/Print Settings"] = [
+	{
+		label: "Print Settings",
+		url: docsUrl + "user/manual/en/setting-up/print/print-settings",
+	},
+];
 
-frappe.help.help_links['print-format-builder'] = [
-	{ label: 'Print Format Builder', url: docsUrl + 'user/manual/en/setting-up/print/print-settings' },
-]
+frappe.help.help_links["print-format-builder"] = [
+	{
+		label: "Print Format Builder",
+		url: docsUrl + "user/manual/en/setting-up/print/print-settings",
+	},
+];
 
-frappe.help.help_links['List/Print Heading'] = [
-	{ label: 'Print Heading', url: docsUrl + 'user/manual/en/setting-up/print/print-headings' },
-]
+frappe.help.help_links["List/Print Heading"] = [
+	{
+		label: "Print Heading",
+		url: docsUrl + "user/manual/en/setting-up/print/print-headings",
+	},
+];
 
 //setup-integrations
 
-frappe.help.help_links['Form/PayPal Settings'] = [
-	{ label: 'PayPal Settings', url: docsUrl + 'user/manual/en/setting-up/integrations/paypal-integration' },
-]
+frappe.help.help_links["Form/PayPal Settings"] = [
+	{
+		label: "PayPal Settings",
+		url:
+			docsUrl +
+			"user/manual/en/setting-up/integrations/paypal-integration",
+	},
+];
 
-frappe.help.help_links['Form/Razorpay Settings'] = [
-	{ label: 'Razorpay Settings', url: docsUrl + 'user/manual/en/setting-up/integrations/razorpay-integration' },
-]
+frappe.help.help_links["Form/Razorpay Settings"] = [
+	{
+		label: "Razorpay Settings",
+		url:
+			docsUrl +
+			"user/manual/en/setting-up/integrations/razorpay-integration",
+	},
+];
 
-frappe.help.help_links['Form/Dropbox Settings'] = [
-	{ label: 'Dropbox Settings', url: docsUrl + 'user/manual/en/setting-up/integrations/dropbox-backup' },
-]
+frappe.help.help_links["Form/Dropbox Settings"] = [
+	{
+		label: "Dropbox Settings",
+		url: docsUrl + "user/manual/en/setting-up/integrations/dropbox-backup",
+	},
+];
 
-frappe.help.help_links['Form/LDAP Settings'] = [
-	{ label: 'LDAP Settings', url: docsUrl + 'user/manual/en/setting-up/integrations/ldap-integration' },
-]
+frappe.help.help_links["Form/LDAP Settings"] = [
+	{
+		label: "LDAP Settings",
+		url:
+			docsUrl + "user/manual/en/setting-up/integrations/ldap-integration",
+	},
+];
 
-frappe.help.help_links['Form/Stripe Settings'] = [
-	{ label: 'Stripe Settings', url: docsUrl + 'user/manual/en/setting-up/integrations/stripe-integration' },
-]
+frappe.help.help_links["Form/Stripe Settings"] = [
+	{
+		label: "Stripe Settings",
+		url:
+			docsUrl +
+			"user/manual/en/setting-up/integrations/stripe-integration",
+	},
+];
 
 //Sales
 
-frappe.help.help_links['Form/Quotation'] = [
-	{ label: 'Quotation', url: docsUrl + 'user/manual/en/selling/quotation' },
-	{ label: 'Applying Discount', url: docsUrl + 'user/manual/en/selling/articles/applying-discount' },
-	{ label: 'Sales Person', url: docsUrl + 'user/manual/en/selling/articles/sales-persons-in-the-sales-transactions' },
-	{ label: 'Applying Margin', url: docsUrl + 'user/manual/en/selling/articles/adding-margin' },
-]
+frappe.help.help_links["Form/Quotation"] = [
+	{ label: "Quotation", url: docsUrl + "user/manual/en/selling/quotation" },
+	{
+		label: "Applying Discount",
+		url: docsUrl + "user/manual/en/selling/articles/applying-discount",
+	},
+	{
+		label: "Sales Person",
+		url:
+			docsUrl +
+			"user/manual/en/selling/articles/sales-persons-in-the-sales-transactions",
+	},
+	{
+		label: "Applying Margin",
+		url: docsUrl + "user/manual/en/selling/articles/adding-margin",
+	},
+];
 
-frappe.help.help_links['List/Customer'] = [
-	{ label: 'Customer', url: docsUrl + 'user/manual/en/CRM/customer' },
-	{ label: 'Credit Limit', url: docsUrl + 'user/manual/en/accounts/credit-limit' },
-]
+frappe.help.help_links["List/Customer"] = [
+	{ label: "Customer", url: docsUrl + "user/manual/en/CRM/customer" },
+	{
+		label: "Credit Limit",
+		url: docsUrl + "user/manual/en/accounts/credit-limit",
+	},
+];
 
-frappe.help.help_links['Form/Customer'] = [
-	{ label: 'Customer', url: docsUrl + 'user/manual/en/CRM/customer' },
-	{ label: 'Credit Limit', url: docsUrl + 'user/manual/en/accounts/credit-limit' },
-]
+frappe.help.help_links["Form/Customer"] = [
+	{ label: "Customer", url: docsUrl + "user/manual/en/CRM/customer" },
+	{
+		label: "Credit Limit",
+		url: docsUrl + "user/manual/en/accounts/credit-limit",
+	},
+];
 
-frappe.help.help_links['List/Sales Taxes and Charges Template'] = [
-	{ label: 'Setting Up Taxes', url: docsUrl + 'user/manual/en/setting-up/setting-up-taxes' },
-]
+frappe.help.help_links["List/Sales Taxes and Charges Template"] = [
+	{
+		label: "Setting Up Taxes",
+		url: docsUrl + "user/manual/en/setting-up/setting-up-taxes",
+	},
+];
 
-frappe.help.help_links['Form/Sales Taxes and Charges Template'] = [
-	{ label: 'Setting Up Taxes', url: docsUrl + 'user/manual/en/setting-up/setting-up-taxes' },
-]
+frappe.help.help_links["Form/Sales Taxes and Charges Template"] = [
+	{
+		label: "Setting Up Taxes",
+		url: docsUrl + "user/manual/en/setting-up/setting-up-taxes",
+	},
+];
 
-frappe.help.help_links['List/Sales Order'] = [
-	{ label: 'Sales Order', url: docsUrl + 'user/manual/en/selling/sales-order' },
-	{ label: 'Recurring Sales Order', url: docsUrl + 'user/manual/en/accounts/recurring-orders-and-invoices' },
-	{ label: 'Applying Discount', url: docsUrl + 'user/manual/en/selling/articles/applying-discount' },
-]
+frappe.help.help_links["List/Sales Order"] = [
+	{
+		label: "Sales Order",
+		url: docsUrl + "user/manual/en/selling/sales-order",
+	},
+	{
+		label: "Recurring Sales Order",
+		url: docsUrl + "user/manual/en/accounts/recurring-orders-and-invoices",
+	},
+	{
+		label: "Applying Discount",
+		url: docsUrl + "user/manual/en/selling/articles/applying-discount",
+	},
+];
 
-frappe.help.help_links['Form/Sales Order'] = [
-	{ label: 'Sales Order', url: docsUrl + 'user/manual/en/selling/sales-order' },
-	{ label: 'Recurring Sales Order', url: docsUrl + 'user/manual/en/accounts/recurring-orders-and-invoices' },
-	{ label: 'Applying Discount', url: docsUrl + 'user/manual/en/selling/articles/applying-discount' },
-	{ label: 'Drop Shipping', url: docsUrl + 'user/manual/en/selling/articles/drop-shipping' },
-	{ label: 'Sales Person', url: docsUrl + 'user/manual/en/selling/articles/sales-persons-in-the-sales-transactions' },
-	{ label: 'Close Sales Order', url: docsUrl + 'user/manual/en/selling/articles/close-sales-order' },
-	{ label: 'Applying Margin', url: docsUrl + 'user/manual/en/selling/articles/adding-margin' },
-]
+frappe.help.help_links["Form/Sales Order"] = [
+	{
+		label: "Sales Order",
+		url: docsUrl + "user/manual/en/selling/sales-order",
+	},
+	{
+		label: "Recurring Sales Order",
+		url: docsUrl + "user/manual/en/accounts/recurring-orders-and-invoices",
+	},
+	{
+		label: "Applying Discount",
+		url: docsUrl + "user/manual/en/selling/articles/applying-discount",
+	},
+	{
+		label: "Drop Shipping",
+		url: docsUrl + "user/manual/en/selling/articles/drop-shipping",
+	},
+	{
+		label: "Sales Person",
+		url:
+			docsUrl +
+			"user/manual/en/selling/articles/sales-persons-in-the-sales-transactions",
+	},
+	{
+		label: "Close Sales Order",
+		url: docsUrl + "user/manual/en/selling/articles/close-sales-order",
+	},
+	{
+		label: "Applying Margin",
+		url: docsUrl + "user/manual/en/selling/articles/adding-margin",
+	},
+];
 
-frappe.help.help_links['Form/Product Bundle'] = [
-	{ label: 'Product Bundle', url: docsUrl + 'user/manual/en/selling/setup/product-bundle' },
-]
+frappe.help.help_links["Form/Product Bundle"] = [
+	{
+		label: "Product Bundle",
+		url: docsUrl + "user/manual/en/selling/setup/product-bundle",
+	},
+];
 
-frappe.help.help_links['Form/Selling Settings'] = [
-	{ label: 'Selling Settings', url: docsUrl + 'user/manual/en/selling/setup/selling-settings' },
-]
+frappe.help.help_links["Form/Selling Settings"] = [
+	{
+		label: "Selling Settings",
+		url: docsUrl + "user/manual/en/selling/setup/selling-settings",
+	},
+];
 
 //Buying
 
-frappe.help.help_links['List/Supplier'] = [
-	{ label: 'Supplier', url: docsUrl + 'user/manual/en/buying/supplier' },
-]
+frappe.help.help_links["List/Supplier"] = [
+	{ label: "Supplier", url: docsUrl + "user/manual/en/buying/supplier" },
+];
 
-frappe.help.help_links['Form/Supplier'] = [
-	{ label: 'Supplier', url: docsUrl + 'user/manual/en/buying/supplier' },
-]
+frappe.help.help_links["Form/Supplier"] = [
+	{ label: "Supplier", url: docsUrl + "user/manual/en/buying/supplier" },
+];
 
-frappe.help.help_links['Form/Request for Quotation'] = [
-	{ label: 'Request for Quotation', url: docsUrl + 'user/manual/en/buying/request-for-quotation' },
-	{ label: 'RFQ Video', url: docsUrl + 'user/videos/learn/request-for-quotation.html' },
-]
+frappe.help.help_links["Form/Request for Quotation"] = [
+	{
+		label: "Request for Quotation",
+		url: docsUrl + "user/manual/en/buying/request-for-quotation",
+	},
+	{
+		label: "RFQ Video",
+		url: docsUrl + "user/videos/learn/request-for-quotation.html",
+	},
+];
 
-frappe.help.help_links['Form/Supplier Quotation'] = [
-	{ label: 'Supplier Quotation', url: docsUrl + 'user/manual/en/buying/supplier-quotation' },
-]
+frappe.help.help_links["Form/Supplier Quotation"] = [
+	{
+		label: "Supplier Quotation",
+		url: docsUrl + "user/manual/en/buying/supplier-quotation",
+	},
+];
 
-frappe.help.help_links['Form/Buying Settings'] = [
-	{ label: 'Buying Settings', url: docsUrl + 'user/manual/en/buying/setup/buying-settings' },
-]
+frappe.help.help_links["Form/Buying Settings"] = [
+	{
+		label: "Buying Settings",
+		url: docsUrl + "user/manual/en/buying/setup/buying-settings",
+	},
+];
 
-frappe.help.help_links['List/Purchase Order'] = [
-	{ label: 'Purchase Order', url: docsUrl + 'user/manual/en/buying/purchase-order' },
-	{ label: 'Recurring Purchase Order', url: docsUrl + 'user/manual/en/accounts/recurring-orders-and-invoices' },
-]
+frappe.help.help_links["List/Purchase Order"] = [
+	{
+		label: "Purchase Order",
+		url: docsUrl + "user/manual/en/buying/purchase-order",
+	},
+	{
+		label: "Recurring Purchase Order",
+		url: docsUrl + "user/manual/en/accounts/recurring-orders-and-invoices",
+	},
+];
 
-frappe.help.help_links['Form/Purchase Order'] = [
-	{ label: 'Purchase Order', url: docsUrl + 'user/manual/en/buying/purchase-order' },
-	{ label: 'Item UoM', url: docsUrl + 'user/manual/en/buying/articles/purchasing-in-different-unit' },
-	{ label: 'Supplier Item Code', url: docsUrl + 'user/manual/en/buying/articles/maintaining-suppliers-part-no-in-item' },
-	{ label: 'Recurring Purchase Order', url: docsUrl + 'user/manual/en/accounts/recurring-orders-and-invoices' },
-	{ label: 'Subcontracting', url: docsUrl + 'user/manual/en/manufacturing/subcontracting' },
-]
+frappe.help.help_links["Form/Purchase Order"] = [
+	{
+		label: "Purchase Order",
+		url: docsUrl + "user/manual/en/buying/purchase-order",
+	},
+	{
+		label: "Item UoM",
+		url:
+			docsUrl +
+			"user/manual/en/buying/articles/purchasing-in-different-unit",
+	},
+	{
+		label: "Supplier Item Code",
+		url:
+			docsUrl +
+			"user/manual/en/buying/articles/maintaining-suppliers-part-no-in-item",
+	},
+	{
+		label: "Recurring Purchase Order",
+		url: docsUrl + "user/manual/en/accounts/recurring-orders-and-invoices",
+	},
+	{
+		label: "Subcontracting",
+		url: docsUrl + "user/manual/en/manufacturing/subcontracting",
+	},
+];
 
-frappe.help.help_links['List/Purchase Taxes and Charges Template'] = [
-	{ label: 'Setting Up Taxes', url: docsUrl + 'user/manual/en/setting-up/setting-up-taxes' },
-]
+frappe.help.help_links["List/Purchase Taxes and Charges Template"] = [
+	{
+		label: "Setting Up Taxes",
+		url: docsUrl + "user/manual/en/setting-up/setting-up-taxes",
+	},
+];
 
-frappe.help.help_links['List/POS Profile'] = [
-	{ label: 'POS Profile', url: docsUrl + 'user/manual/en/setting-up/pos-setting' },
-]
+frappe.help.help_links["List/POS Profile"] = [
+	{
+		label: "POS Profile",
+		url: docsUrl + "user/manual/en/setting-up/pos-setting",
+	},
+];
 
-frappe.help.help_links['List/Price List'] = [
-	{ label: 'Price List', url: docsUrl + 'user/manual/en/setting-up/price-lists' },
-]
+frappe.help.help_links["List/Price List"] = [
+	{
+		label: "Price List",
+		url: docsUrl + "user/manual/en/setting-up/price-lists",
+	},
+];
 
-frappe.help.help_links['List/Authorization Rule'] = [
-	{ label: 'Authorization Rule', url: docsUrl + 'user/manual/en/setting-up/authorization-rule' },
-]
+frappe.help.help_links["List/Authorization Rule"] = [
+	{
+		label: "Authorization Rule",
+		url: docsUrl + "user/manual/en/setting-up/authorization-rule",
+	},
+];
 
-frappe.help.help_links['Form/SMS Settings'] = [
-	{ label: 'SMS Settings', url: docsUrl + 'user/manual/en/setting-up/sms-setting' },
-]
+frappe.help.help_links["Form/SMS Settings"] = [
+	{
+		label: "SMS Settings",
+		url: docsUrl + "user/manual/en/setting-up/sms-setting",
+	},
+];
 
-frappe.help.help_links['List/Stock Reconciliation'] = [
-	{ label: 'Stock Reconciliation', url: docsUrl + 'user/manual/en/setting-up/stock-reconciliation-for-non-serialized-item' },
-]
+frappe.help.help_links["List/Stock Reconciliation"] = [
+	{
+		label: "Stock Reconciliation",
+		url:
+			docsUrl +
+			"user/manual/en/setting-up/stock-reconciliation-for-non-serialized-item",
+	},
+];
 
-frappe.help.help_links['Tree/Territory'] = [
-	{ label: 'Territory', url: docsUrl + 'user/manual/en/setting-up/territory' },
-]
+frappe.help.help_links["Tree/Territory"] = [
+	{
+		label: "Territory",
+		url: docsUrl + "user/manual/en/setting-up/territory",
+	},
+];
 
-frappe.help.help_links['Form/Dropbox Backup'] = [
-	{ label: 'Dropbox Backup', url: docsUrl + 'user/manual/en/setting-up/third-party-backups' },
-	{ label: 'Setting Up Dropbox Backup', url: docsUrl + 'user/manual/en/setting-up/articles/setting-up-dropbox-backups' },
-]
+frappe.help.help_links["Form/Dropbox Backup"] = [
+	{
+		label: "Dropbox Backup",
+		url: docsUrl + "user/manual/en/setting-up/third-party-backups",
+	},
+	{
+		label: "Setting Up Dropbox Backup",
+		url:
+			docsUrl +
+			"user/manual/en/setting-up/articles/setting-up-dropbox-backups",
+	},
+];
 
-frappe.help.help_links['List/Workflow'] = [
-	{ label: 'Workflow', url: docsUrl + 'user/manual/en/setting-up/workflows' },
-]
+frappe.help.help_links["List/Workflow"] = [
+	{ label: "Workflow", url: docsUrl + "user/manual/en/setting-up/workflows" },
+];
 
-frappe.help.help_links['List/Company'] = [
-	{ label: 'Company', url: docsUrl + 'user/manual/en/setting-up/company-setup' },
-	{ label: 'Managing Multiple Companies', url: docsUrl + 'user/manual/en/setting-up/articles/managing-multiple-companies' },
-	{ label: 'Delete All Related Transactions for a Company', url: docsUrl + 'user/manual/en/setting-up/articles/delete-a-company-and-all-related-transactions' },
-]
+frappe.help.help_links["List/Company"] = [
+	{
+		label: "Company",
+		url: docsUrl + "user/manual/en/setting-up/company-setup",
+	},
+	{
+		label: "Managing Multiple Companies",
+		url:
+			docsUrl +
+			"user/manual/en/setting-up/articles/managing-multiple-companies",
+	},
+	{
+		label: "Delete All Related Transactions for a Company",
+		url:
+			docsUrl +
+			"user/manual/en/setting-up/articles/delete-a-company-and-all-related-transactions",
+	},
+];
 
 //Accounts
 
-frappe.help.help_links['modules/Accounts'] = [
-	{ label: 'Introduction to Accounts', url: docsUrl + 'user/manual/en/accounts/' },
-	{ label: 'Chart of Accounts', url: docsUrl + 'user/manual/en/accounts/chart-of-accounts.html' },
-	{ label: 'Multi Currency Accounting', url: docsUrl + 'user/manual/en/accounts/multi-currency-accounting' },
-]
+frappe.help.help_links["modules/Accounts"] = [
+	{
+		label: "Introduction to Accounts",
+		url: docsUrl + "user/manual/en/accounts/",
+	},
+	{
+		label: "Chart of Accounts",
+		url: docsUrl + "user/manual/en/accounts/chart-of-accounts.html",
+	},
+	{
+		label: "Multi Currency Accounting",
+		url: docsUrl + "user/manual/en/accounts/multi-currency-accounting",
+	},
+];
 
-frappe.help.help_links['Tree/Account'] = [
-	{ label: 'Chart of Accounts', url: docsUrl + 'user/manual/en/accounts/chart-of-accounts' },
-	{ label: 'Managing Tree Mastes', url: docsUrl + 'user/manual/en/setting-up/articles/managing-tree-structure-masters' },
-]
+frappe.help.help_links["Tree/Account"] = [
+	{
+		label: "Chart of Accounts",
+		url: docsUrl + "user/manual/en/accounts/chart-of-accounts",
+	},
+	{
+		label: "Managing Tree Mastes",
+		url:
+			docsUrl +
+			"user/manual/en/setting-up/articles/managing-tree-structure-masters",
+	},
+];
 
-frappe.help.help_links['Form/Sales Invoice'] = [
-	{ label: 'Sales Invoice', url: docsUrl + 'user/manual/en/accounts/sales-invoice' },
-	{ label: 'Accounts Opening Balance', url: docsUrl + 'user/manual/en/accounts/opening-accounts' },
-	{ label: 'Sales Return', url: docsUrl + 'user/manual/en/stock/sales-return' },
-	{ label: 'Recurring Sales Invoice', url: docsUrl + 'user/manual/en/accounts/recurring-orders-and-invoices' },
-]
+frappe.help.help_links["Form/Sales Invoice"] = [
+	{
+		label: "Sales Invoice",
+		url: docsUrl + "user/manual/en/accounts/sales-invoice",
+	},
+	{
+		label: "Accounts Opening Balance",
+		url: docsUrl + "user/manual/en/accounts/opening-accounts",
+	},
+	{
+		label: "Sales Return",
+		url: docsUrl + "user/manual/en/stock/sales-return",
+	},
+	{
+		label: "Recurring Sales Invoice",
+		url: docsUrl + "user/manual/en/accounts/recurring-orders-and-invoices",
+	},
+];
 
-frappe.help.help_links['List/Sales Invoice'] = [
-	{ label: 'Sales Invoice', url: docsUrl + 'user/manual/en/accounts/sales-invoice' },
-	{ label: 'Accounts Opening Balance', url: docsUrl + 'user/manual/en/accounts/opening-accounts' },
-	{ label: 'Sales Return', url: docsUrl + 'user/manual/en/stock/sales-return' },
-	{ label: 'Recurring Sales Invoice', url: docsUrl + 'user/manual/en/accounts/recurring-orders-and-invoices' },
-]
+frappe.help.help_links["List/Sales Invoice"] = [
+	{
+		label: "Sales Invoice",
+		url: docsUrl + "user/manual/en/accounts/sales-invoice",
+	},
+	{
+		label: "Accounts Opening Balance",
+		url: docsUrl + "user/manual/en/accounts/opening-accounts",
+	},
+	{
+		label: "Sales Return",
+		url: docsUrl + "user/manual/en/stock/sales-return",
+	},
+	{
+		label: "Recurring Sales Invoice",
+		url: docsUrl + "user/manual/en/accounts/recurring-orders-and-invoices",
+	},
+];
 
-frappe.help.help_links['pos'] = [
-	{ label: 'Point of Sale Invoice', url: docsUrl + 'user/manual/en/accounts/point-of-sale-pos-invoice' },
-]
+frappe.help.help_links["pos"] = [
+	{
+		label: "Point of Sale Invoice",
+		url: docsUrl + "user/manual/en/accounts/point-of-sale-pos-invoice",
+	},
+];
 
-frappe.help.help_links['List/POS Profile'] = [
-	{ label: 'Point of Sale Profile', url: docsUrl + 'user/manual/en/setting-up/pos-setting' },
-]
+frappe.help.help_links["List/POS Profile"] = [
+	{
+		label: "Point of Sale Profile",
+		url: docsUrl + "user/manual/en/setting-up/pos-setting",
+	},
+];
 
-frappe.help.help_links['List/Purchase Invoice'] = [
-	{ label: 'Purchase Invoice', url: docsUrl + 'user/manual/en/accounts/purchase-invoice' },
-	{ label: 'Accounts Opening Balance', url: docsUrl + 'user/manual/en/accounts/opening-accounts' },
-	{ label: 'Recurring Purchase Invoice', url: docsUrl + 'user/manual/en/accounts/recurring-orders-and-invoices' },
-]
+frappe.help.help_links["List/Purchase Invoice"] = [
+	{
+		label: "Purchase Invoice",
+		url: docsUrl + "user/manual/en/accounts/purchase-invoice",
+	},
+	{
+		label: "Accounts Opening Balance",
+		url: docsUrl + "user/manual/en/accounts/opening-accounts",
+	},
+	{
+		label: "Recurring Purchase Invoice",
+		url: docsUrl + "user/manual/en/accounts/recurring-orders-and-invoices",
+	},
+];
 
-frappe.help.help_links['List/Journal Entry'] = [
-	{ label: 'Journal Entry', url: docsUrl + 'user/manual/en/accounts/journal-entry' },
-	{ label: 'Advance Payment Entry', url: docsUrl + 'user/manual/en/accounts/advance-payment-entry' },
-	{ label: 'Accounts Opening Balance', url: docsUrl + 'user/manual/en/accounts/opening-accounts' },
-]
+frappe.help.help_links["List/Journal Entry"] = [
+	{
+		label: "Journal Entry",
+		url: docsUrl + "user/manual/en/accounts/journal-entry",
+	},
+	{
+		label: "Advance Payment Entry",
+		url: docsUrl + "user/manual/en/accounts/advance-payment-entry",
+	},
+	{
+		label: "Accounts Opening Balance",
+		url: docsUrl + "user/manual/en/accounts/opening-accounts",
+	},
+];
 
-frappe.help.help_links['List/Payment Entry'] = [
-	{ label: 'Payment Entry', url: docsUrl + 'user/manual/en/accounts/payment-entry' },
-]
+frappe.help.help_links["List/Payment Entry"] = [
+	{
+		label: "Payment Entry",
+		url: docsUrl + "user/manual/en/accounts/payment-entry",
+	},
+];
 
-frappe.help.help_links['List/Payment Request'] = [
-	{ label: 'Payment Request', url: docsUrl + 'user/manual/en/accounts/payment-request' },
-]
+frappe.help.help_links["List/Payment Request"] = [
+	{
+		label: "Payment Request",
+		url: docsUrl + "user/manual/en/accounts/payment-request",
+	},
+];
 
-frappe.help.help_links['List/Asset'] = [
-	{ label: 'Managing Fixed Assets', url: docsUrl + 'user/manual/en/accounts/managing-fixed-assets' },
-]
+frappe.help.help_links["List/Asset"] = [
+	{
+		label: "Managing Fixed Assets",
+		url: docsUrl + "user/manual/en/accounts/managing-fixed-assets",
+	},
+];
 
-frappe.help.help_links['List/Asset Category'] = [
-	{ label: 'Asset Category', url: docsUrl + 'user/manual/en/accounts/managing-fixed-assets' },
-]
+frappe.help.help_links["List/Asset Category"] = [
+	{
+		label: "Asset Category",
+		url: docsUrl + "user/manual/en/accounts/managing-fixed-assets",
+	},
+];
 
-frappe.help.help_links['Tree/Cost Center'] = [
-	{ label: 'Budgeting', url: docsUrl + 'user/manual/en/accounts/budgeting' },
-]
+frappe.help.help_links["Tree/Cost Center"] = [
+	{ label: "Budgeting", url: docsUrl + "user/manual/en/accounts/budgeting" },
+];
 
-frappe.help.help_links['List/Item'] = [
-	{ label: 'Item', url: docsUrl + 'user/manual/en/stock/item' },
-	{ label: 'Item Price', url: docsUrl + 'user/manual/en/stock/item/item-price' },
-	{ label: 'Barcode', url: docsUrl + 'user/manual/en/stock/articles/track-items-using-barcode' },
-	{ label: 'Item Wise Taxation', url: docsUrl + 'user/manual/en/accounts/item-wise-taxation' },
-	{ label: 'Managing Fixed Assets', url: docsUrl + 'user/manual/en/accounts/managing-fixed-assets' },
-	{ label: 'Item Codification', url: docsUrl + 'user/manual/en/stock/item/item-codification' },
-	{ label: 'Item Variants', url: docsUrl + 'user/manual/en/stock/item/item-variants' },
-	{ label: 'Item Valuation', url: docsUrl + 'user/manual/en/stock/item/item-valuation-fifo-and-moving-average' },
-]
+frappe.help.help_links["List/Item"] = [
+	{ label: "Item", url: docsUrl + "user/manual/en/stock/item" },
+	{
+		label: "Item Price",
+		url: docsUrl + "user/manual/en/stock/item/item-price",
+	},
+	{
+		label: "Barcode",
+		url:
+			docsUrl + "user/manual/en/stock/articles/track-items-using-barcode",
+	},
+	{
+		label: "Item Wise Taxation",
+		url: docsUrl + "user/manual/en/accounts/item-wise-taxation",
+	},
+	{
+		label: "Managing Fixed Assets",
+		url: docsUrl + "user/manual/en/accounts/managing-fixed-assets",
+	},
+	{
+		label: "Item Codification",
+		url: docsUrl + "user/manual/en/stock/item/item-codification",
+	},
+	{
+		label: "Item Variants",
+		url: docsUrl + "user/manual/en/stock/item/item-variants",
+	},
+	{
+		label: "Item Valuation",
+		url:
+			docsUrl +
+			"user/manual/en/stock/item/item-valuation-fifo-and-moving-average",
+	},
+];
 
-frappe.help.help_links['Form/Item'] = [
-	{ label: 'Item', url: docsUrl + 'user/manual/en/stock/item' },
-	{ label: 'Item Price', url: docsUrl + 'user/manual/en/stock/item/item-price' },
-	{ label: 'Barcode', url: docsUrl + 'user/manual/en/stock/articles/track-items-using-barcode' },
-	{ label: 'Item Wise Taxation', url: docsUrl + 'user/manual/en/accounts/item-wise-taxation' },
-	{ label: 'Managing Fixed Assets', url: docsUrl + 'user/manual/en/accounts/managing-fixed-assets' },
-	{ label: 'Item Codification', url: docsUrl + 'user/manual/en/stock/item/item-codification' },
-	{ label: 'Item Variants', url: docsUrl + 'user/manual/en/stock/item/item-variants' },
-	{ label: 'Item Valuation', url: docsUrl + 'user/manual/en/stock/item/item-valuation-fifo-and-moving-average' },
-]
+frappe.help.help_links["Form/Item"] = [
+	{ label: "Item", url: docsUrl + "user/manual/en/stock/item" },
+	{
+		label: "Item Price",
+		url: docsUrl + "user/manual/en/stock/item/item-price",
+	},
+	{
+		label: "Barcode",
+		url:
+			docsUrl + "user/manual/en/stock/articles/track-items-using-barcode",
+	},
+	{
+		label: "Item Wise Taxation",
+		url: docsUrl + "user/manual/en/accounts/item-wise-taxation",
+	},
+	{
+		label: "Managing Fixed Assets",
+		url: docsUrl + "user/manual/en/accounts/managing-fixed-assets",
+	},
+	{
+		label: "Item Codification",
+		url: docsUrl + "user/manual/en/stock/item/item-codification",
+	},
+	{
+		label: "Item Variants",
+		url: docsUrl + "user/manual/en/stock/item/item-variants",
+	},
+	{
+		label: "Item Valuation",
+		url:
+			docsUrl +
+			"user/manual/en/stock/item/item-valuation-fifo-and-moving-average",
+	},
+];
 
-frappe.help.help_links['List/Purchase Receipt'] = [
-	{ label: 'Purchase Receipt', url: docsUrl + 'user/manual/en/stock/purchase-receipt' },
-	{ label: 'Barcode', url: docsUrl + 'user/manual/en/stock/articles/track-items-using-barcode' },
-]
+frappe.help.help_links["List/Purchase Receipt"] = [
+	{
+		label: "Purchase Receipt",
+		url: docsUrl + "user/manual/en/stock/purchase-receipt",
+	},
+	{
+		label: "Barcode",
+		url:
+			docsUrl + "user/manual/en/stock/articles/track-items-using-barcode",
+	},
+];
 
-frappe.help.help_links['List/Delivery Note'] = [
-	{ label: 'Delivery Note', url: docsUrl + 'user/manual/en/stock/delivery-note' },
-	{ label: 'Barcode', url: docsUrl + 'user/manual/en/stock/articles/track-items-using-barcode' },
-	{ label: 'Sales Return', url: docsUrl + 'user/manual/en/stock/sales-return' },
-]
+frappe.help.help_links["List/Delivery Note"] = [
+	{
+		label: "Delivery Note",
+		url: docsUrl + "user/manual/en/stock/delivery-note",
+	},
+	{
+		label: "Barcode",
+		url:
+			docsUrl + "user/manual/en/stock/articles/track-items-using-barcode",
+	},
+	{
+		label: "Sales Return",
+		url: docsUrl + "user/manual/en/stock/sales-return",
+	},
+];
 
-frappe.help.help_links['Form/Delivery Note'] = [
-	{ label: 'Delivery Note', url: docsUrl + 'user/manual/en/stock/delivery-note' },
-	{ label: 'Sales Return', url: docsUrl + 'user/manual/en/stock/sales-return' },
-	{ label: 'Barcode', url: docsUrl + 'user/manual/en/stock/articles/track-items-using-barcode' },
-	{ label: 'Subcontracting', url: docsUrl + 'user/manual/en/manufacturing/subcontracting' },
-]
+frappe.help.help_links["Form/Delivery Note"] = [
+	{
+		label: "Delivery Note",
+		url: docsUrl + "user/manual/en/stock/delivery-note",
+	},
+	{
+		label: "Sales Return",
+		url: docsUrl + "user/manual/en/stock/sales-return",
+	},
+	{
+		label: "Barcode",
+		url:
+			docsUrl + "user/manual/en/stock/articles/track-items-using-barcode",
+	},
+	{
+		label: "Subcontracting",
+		url: docsUrl + "user/manual/en/manufacturing/subcontracting",
+	},
+];
 
-frappe.help.help_links['List/Installation Note'] = [
-	{ label: 'Installation Note', url: docsUrl + 'user/manual/en/stock/installation-note' },
-]
+frappe.help.help_links["List/Installation Note"] = [
+	{
+		label: "Installation Note",
+		url: docsUrl + "user/manual/en/stock/installation-note",
+	},
+];
 
+frappe.help.help_links["Tree"] = [
+	{
+		label: "Managing Tree Structure Masters",
+		url:
+			docsUrl +
+			"user/manual/en/setting-up/articles/managing-tree-structure-masters",
+	},
+];
 
-frappe.help.help_links['Tree'] = [
-	{ label: 'Managing Tree Structure Masters', url: docsUrl + 'user/manual/en/setting-up/articles/managing-tree-structure-masters' },
-]
-
-frappe.help.help_links['List/Budget'] = [
-	{ label: 'Budgeting', url: docsUrl + 'user/manual/en/accounts/budgeting' },
-]
+frappe.help.help_links["List/Budget"] = [
+	{ label: "Budgeting", url: docsUrl + "user/manual/en/accounts/budgeting" },
+];
 
 //Stock
 
-frappe.help.help_links['List/Material Request'] = [
-	{ label: 'Material Request', url: docsUrl + 'user/manual/en/stock/material-request' },
-	{ label: 'Auto-creation of Material Request', url: docsUrl + 'user/manual/en/stock/articles/auto-creation-of-material-request' },
-]
+frappe.help.help_links["List/Material Request"] = [
+	{
+		label: "Material Request",
+		url: docsUrl + "user/manual/en/stock/material-request",
+	},
+	{
+		label: "Auto-creation of Material Request",
+		url:
+			docsUrl +
+			"user/manual/en/stock/articles/auto-creation-of-material-request",
+	},
+];
 
-frappe.help.help_links['Form/Material Request'] = [
-	{ label: 'Material Request', url: docsUrl + 'user/manual/en/stock/material-request' },
-	{ label: 'Auto-creation of Material Request', url: docsUrl + 'user/manual/en/stock/articles/auto-creation-of-material-request' },
-]
+frappe.help.help_links["Form/Material Request"] = [
+	{
+		label: "Material Request",
+		url: docsUrl + "user/manual/en/stock/material-request",
+	},
+	{
+		label: "Auto-creation of Material Request",
+		url:
+			docsUrl +
+			"user/manual/en/stock/articles/auto-creation-of-material-request",
+	},
+];
 
-frappe.help.help_links['Form/Stock Entry'] = [
-	{ label: 'Stock Entry', url: docsUrl + 'user/manual/en/stock/stock-entry' },
-	{ label: 'Stock Entry Types', url: docsUrl + 'user/manual/en/stock/articles/stock-entry-purpose' },
-	{ label: 'Repack Entry', url: docsUrl + 'user/manual/en/stock/articles/repack-entry' },
-	{ label: 'Opening Stock', url: docsUrl + 'user/manual/en/stock/opening-stock' },
-	{ label: 'Subcontracting', url: docsUrl + 'user/manual/en/manufacturing/subcontracting' },
-]
+frappe.help.help_links["Form/Stock Entry"] = [
+	{ label: "Stock Entry", url: docsUrl + "user/manual/en/stock/stock-entry" },
+	{
+		label: "Stock Entry Types",
+		url: docsUrl + "user/manual/en/stock/articles/stock-entry-purpose",
+	},
+	{
+		label: "Repack Entry",
+		url: docsUrl + "user/manual/en/stock/articles/repack-entry",
+	},
+	{
+		label: "Opening Stock",
+		url: docsUrl + "user/manual/en/stock/opening-stock",
+	},
+	{
+		label: "Subcontracting",
+		url: docsUrl + "user/manual/en/manufacturing/subcontracting",
+	},
+];
 
-frappe.help.help_links['List/Stock Entry'] = [
-	{ label: 'Stock Entry', url: docsUrl + 'user/manual/en/stock/stock-entry' },
-]
+frappe.help.help_links["List/Stock Entry"] = [
+	{ label: "Stock Entry", url: docsUrl + "user/manual/en/stock/stock-entry" },
+];
 
-frappe.help.help_links['Tree/Warehouse'] = [
-	{ label: 'Warehouse', url: docsUrl + 'user/manual/en/stock/warehouse' },
-]
+frappe.help.help_links["Tree/Warehouse"] = [
+	{ label: "Warehouse", url: docsUrl + "user/manual/en/stock/warehouse" },
+];
 
-frappe.help.help_links['List/Serial No'] = [
-	{ label: 'Serial No', url: docsUrl + 'user/manual/en/stock/serial-no' },
-]
+frappe.help.help_links["List/Serial No"] = [
+	{ label: "Serial No", url: docsUrl + "user/manual/en/stock/serial-no" },
+];
 
-frappe.help.help_links['Form/Serial No'] = [
-	{ label: 'Serial No', url: docsUrl + 'user/manual/en/stock/serial-no' },
-]
+frappe.help.help_links["Form/Serial No"] = [
+	{ label: "Serial No", url: docsUrl + "user/manual/en/stock/serial-no" },
+];
 
-frappe.help.help_links['Form/Batch'] = [
-	{ label: 'Batch', url: docsUrl + 'user/manual/en/stock/batch' },
-]
+frappe.help.help_links["Form/Batch"] = [
+	{ label: "Batch", url: docsUrl + "user/manual/en/stock/batch" },
+];
 
-frappe.help.help_links['Form/Packing Slip'] = [
-	{ label: 'Packing Slip', url: docsUrl + 'user/manual/en/stock/tools/packing-slip' },
-]
+frappe.help.help_links["Form/Packing Slip"] = [
+	{
+		label: "Packing Slip",
+		url: docsUrl + "user/manual/en/stock/tools/packing-slip",
+	},
+];
 
-frappe.help.help_links['Form/Quality Inspection'] = [
-	{ label: 'Quality Inspection', url: docsUrl + 'user/manual/en/stock/tools/quality-inspection' },
-]
+frappe.help.help_links["Form/Quality Inspection"] = [
+	{
+		label: "Quality Inspection",
+		url: docsUrl + "user/manual/en/stock/tools/quality-inspection",
+	},
+];
 
-frappe.help.help_links['Form/Landed Cost Voucher'] = [
-	{ label: 'Landed Cost Voucher', url: docsUrl + 'user/manual/en/stock/tools/landed-cost-voucher' },
-]
+frappe.help.help_links["Form/Landed Cost Voucher"] = [
+	{
+		label: "Landed Cost Voucher",
+		url: docsUrl + "user/manual/en/stock/tools/landed-cost-voucher",
+	},
+];
 
-frappe.help.help_links['Tree/Item Group'] = [
-	{ label: 'Item Group', url: docsUrl + 'user/manual/en/stock/setup/item-group' },
-]
+frappe.help.help_links["Tree/Item Group"] = [
+	{
+		label: "Item Group",
+		url: docsUrl + "user/manual/en/stock/setup/item-group",
+	},
+];
 
-frappe.help.help_links['Form/Item Attribute'] = [
-	{ label: 'Item Attribute', url: docsUrl + 'user/manual/en/stock/setup/item-attribute' },
-]
+frappe.help.help_links["Form/Item Attribute"] = [
+	{
+		label: "Item Attribute",
+		url: docsUrl + "user/manual/en/stock/setup/item-attribute",
+	},
+];
 
-frappe.help.help_links['Form/UOM'] = [
-	{ label: 'Fractions in UOM', url: docsUrl + 'user/manual/en/stock/articles/managing-fractions-in-uom' },
-]
+frappe.help.help_links["Form/UOM"] = [
+	{
+		label: "Fractions in UOM",
+		url:
+			docsUrl + "user/manual/en/stock/articles/managing-fractions-in-uom",
+	},
+];
 
-frappe.help.help_links['Form/Stock Reconciliation'] = [
-	{ label: 'Opening Stock Entry', url: docsUrl + 'user/manual/en/stock/opening-stock' },
-]
+frappe.help.help_links["Form/Stock Reconciliation"] = [
+	{
+		label: "Opening Stock Entry",
+		url: docsUrl + "user/manual/en/stock/opening-stock",
+	},
+];
 
 //CRM
 
-frappe.help.help_links['Form/Lead'] = [
-	{ label: 'Lead', url: docsUrl + 'user/manual/en/CRM/lead' },
-]
+frappe.help.help_links["Form/Lead"] = [
+	{ label: "Lead", url: docsUrl + "user/manual/en/CRM/lead" },
+];
 
-frappe.help.help_links['Form/Opportunity'] = [
-	{ label: 'Opportunity', url: docsUrl + 'user/manual/en/CRM/opportunity' },
-]
+frappe.help.help_links["Form/Opportunity"] = [
+	{ label: "Opportunity", url: docsUrl + "user/manual/en/CRM/opportunity" },
+];
 
-frappe.help.help_links['Form/Address'] = [
-	{ label: 'Address', url: docsUrl + 'user/manual/en/CRM/address' },
-]
+frappe.help.help_links["Form/Address"] = [
+	{ label: "Address", url: docsUrl + "user/manual/en/CRM/address" },
+];
 
-frappe.help.help_links['Form/Contact'] = [
-	{ label: 'Contact', url: docsUrl + 'user/manual/en/CRM/contact' },
-]
+frappe.help.help_links["Form/Contact"] = [
+	{ label: "Contact", url: docsUrl + "user/manual/en/CRM/contact" },
+];
 
-frappe.help.help_links['Form/Newsletter'] = [
-	{ label: 'Newsletter', url: docsUrl + 'user/manual/en/CRM/newsletter' },
-]
+frappe.help.help_links["Form/Newsletter"] = [
+	{ label: "Newsletter", url: docsUrl + "user/manual/en/CRM/newsletter" },
+];
 
-frappe.help.help_links['Form/Campaign'] = [
-	{ label: 'Campaign', url: docsUrl + 'user/manual/en/CRM/setup/campaign' },
-]
+frappe.help.help_links["Form/Campaign"] = [
+	{ label: "Campaign", url: docsUrl + "user/manual/en/CRM/setup/campaign" },
+];
 
-frappe.help.help_links['Tree/Sales Person'] = [
-	{ label: 'Sales Person', url: docsUrl + 'user/manual/en/CRM/setup/sales-person' },
-]
+frappe.help.help_links["Tree/Sales Person"] = [
+	{
+		label: "Sales Person",
+		url: docsUrl + "user/manual/en/CRM/setup/sales-person",
+	},
+];
 
-frappe.help.help_links['Form/Sales Person'] = [
-	{ label: 'Sales Person Target', url: docsUrl + 'user/manual/en/selling/setup/sales-person-target-allocation' },
-]
+frappe.help.help_links["Form/Sales Person"] = [
+	{
+		label: "Sales Person Target",
+		url:
+			docsUrl +
+			"user/manual/en/selling/setup/sales-person-target-allocation",
+	},
+];
 
 //Support
 
-frappe.help.help_links['List/Feedback Trigger'] = [
-	{ label: 'Feedback Trigger', url: docsUrl + 'user/manual/en/setting-up/feedback/setting-up-feedback' },
-]
+frappe.help.help_links["List/Feedback Trigger"] = [
+	{
+		label: "Feedback Trigger",
+		url: docsUrl + "user/manual/en/setting-up/feedback/setting-up-feedback",
+	},
+];
 
-frappe.help.help_links['List/Feedback Request'] = [
-	{ label: 'Feedback Request', url: docsUrl + 'user/manual/en/setting-up/feedback/submit-feedback' },
-]
+frappe.help.help_links["List/Feedback Request"] = [
+	{
+		label: "Feedback Request",
+		url: docsUrl + "user/manual/en/setting-up/feedback/submit-feedback",
+	},
+];
 
-frappe.help.help_links['List/Feedback Request'] = [
-	{ label: 'Feedback Request', url: docsUrl + 'user/manual/en/setting-up/feedback/submit-feedback' },
-]
+frappe.help.help_links["List/Feedback Request"] = [
+	{
+		label: "Feedback Request",
+		url: docsUrl + "user/manual/en/setting-up/feedback/submit-feedback",
+	},
+];
 
 //Manufacturing
 
-frappe.help.help_links['Form/BOM'] = [
-	{ label: 'Bill of Material', url: docsUrl + 'user/manual/en/manufacturing/bill-of-materials' },
-	{ label: 'Nested BOM Structure', url: docsUrl + 'user/manual/en/manufacturing/articles/nested-bom-structure' },
-]
+frappe.help.help_links["Form/BOM"] = [
+	{
+		label: "Bill of Material",
+		url: docsUrl + "user/manual/en/manufacturing/bill-of-materials",
+	},
+	{
+		label: "Nested BOM Structure",
+		url:
+			docsUrl +
+			"user/manual/en/manufacturing/articles/nested-bom-structure",
+	},
+];
 
-frappe.help.help_links['Form/Work Order'] = [
-	{ label: 'Work Order', url: docsUrl + 'user/manual/en/manufacturing/work-order' },
-]
+frappe.help.help_links["Form/Work Order"] = [
+	{
+		label: "Work Order",
+		url: docsUrl + "user/manual/en/manufacturing/work-order",
+	},
+];
 
-frappe.help.help_links['Form/Workstation'] = [
-	{ label: 'Workstation', url: docsUrl + 'user/manual/en/manufacturing/workstation' },
-]
+frappe.help.help_links["Form/Workstation"] = [
+	{
+		label: "Workstation",
+		url: docsUrl + "user/manual/en/manufacturing/workstation",
+	},
+];
 
-frappe.help.help_links['Form/Operation'] = [
-	{ label: 'Operation', url: docsUrl + 'user/manual/en/manufacturing/operation' },
-]
+frappe.help.help_links["Form/Operation"] = [
+	{
+		label: "Operation",
+		url: docsUrl + "user/manual/en/manufacturing/operation",
+	},
+];
 
-frappe.help.help_links['Form/BOM Update Tool'] = [
-	{ label: 'BOM Update Tool', url: docsUrl + 'user/manual/en/manufacturing/tools/bom-update-tool' },
-]
+frappe.help.help_links["Form/BOM Update Tool"] = [
+	{
+		label: "BOM Update Tool",
+		url: docsUrl + "user/manual/en/manufacturing/tools/bom-update-tool",
+	},
+];
 
 //Customize
 
-frappe.help.help_links['Form/Customize Form'] = [
-	{ label: 'Custom Field', url: docsUrl + 'user/manual/en/customize-erpnext/custom-field' },
-	{ label: 'Customize Field', url: docsUrl + 'user/manual/en/customize-erpnext/customize-form' },
-]
+frappe.help.help_links["Form/Customize Form"] = [
+	{
+		label: "Custom Field",
+		url: docsUrl + "user/manual/en/customize-erpnext/custom-field",
+	},
+	{
+		label: "Customize Field",
+		url: docsUrl + "user/manual/en/customize-erpnext/customize-form",
+	},
+];
 
-frappe.help.help_links['Form/Custom Field'] = [
-	{ label: 'Custom Field', url: docsUrl + 'user/manual/en/customize-erpnext/custom-field' },
-]
+frappe.help.help_links["Form/Custom Field"] = [
+	{
+		label: "Custom Field",
+		url: docsUrl + "user/manual/en/customize-erpnext/custom-field",
+	},
+];
 
-frappe.help.help_links['Form/Custom Field'] = [
-	{ label: 'Custom Field', url: docsUrl + 'user/manual/en/customize-erpnext/custom-field' },
-]
+frappe.help.help_links["Form/Custom Field"] = [
+	{
+		label: "Custom Field",
+		url: docsUrl + "user/manual/en/customize-erpnext/custom-field",
+	},
+];

--- a/erpnext/public/js/help_links.js
+++ b/erpnext/public/js/help_links.js
@@ -2,13 +2,13 @@ frappe.provide('frappe.help.help_links');
 
 const docsUrl = 'https://erpnext.com/docs/';
 
-frappe.help.help_links['rename tool'] = [
+frappe.help.help_links['Form/Rename Tool'] = [
 	{ label: 'Bulk Rename', url: docsUrl + 'user/manual/en/setting-up/data/bulk-rename' },
 ]
 
 //Setup
 
-frappe.help.help_links['user'] = [
+frappe.help.help_links['List/User'] = [
 	{ label: 'New User', url: docsUrl + 'user/manual/en/setting-up/users-and-permissions/adding-users' },
 	{ label: 'Rename User', url: docsUrl + 'user/manual/en/setting-up/articles/rename-user' },
 ]
@@ -21,7 +21,7 @@ frappe.help.help_links['permission-manager'] = [
 	{ label: 'Password', url: docsUrl + 'user/manual/en/setting-up/articles/change-password' },
 ]
 
-frappe.help.help_links['system-settings'] = [
+frappe.help.help_links['Form/System Settings'] = [
 	{ label: 'Naming Series', url: docsUrl + 'user/manual/en/setting-up/settings/system-settings' },
 ]
 
@@ -30,60 +30,64 @@ frappe.help.help_links['data-import-tool'] = [
 	{ label: 'Overwriting Data from Data Import Tool', url: docsUrl + 'user/manual/en/setting-up/articles/overwriting-data-from-data-import-tool' },
 ]
 
-frappe.help.help_links['naming-series'] = [
+frappe.help.help_links['module_setup'] = [
+	{ label: 'Role Permissions Manager', url: docsUrl + 'user/manual/en/setting-up/users-and-permissions/role-based-permissions' },
+]
+
+frappe.help.help_links['Form/Naming Series'] = [
 	{ label: 'Naming Series', url: docsUrl + 'user/manual/en/setting-up/settings/naming-series' },
 	{ label: 'Setting the Current Value for Naming Series', url: docsUrl + 'user/manual/en/setting-up/articles/naming-series-current-value' },
 ]
 
-frappe.help.help_links['global-defaults'] = [
+frappe.help.help_links['Form/Global Defaults'] = [
 	{ label: 'Global Settings', url: docsUrl + 'user/manual/en/setting-up/settings/global-defaults' },
 ]
 
-frappe.help.help_links['email-digest'] = [
+frappe.help.help_links['Form/Email Digest'] = [
 	{ label: 'Email Digest', url: docsUrl + 'user/manual/en/setting-up/email/email-digest' },
 ]
 
-frappe.help.help_links['print-heading'] = [
+frappe.help.help_links['List/Print Heading'] = [
 	{ label: 'Print Heading', url: docsUrl + 'user/manual/en/setting-up/print/print-headings' },
 ]
 
-frappe.help.help_links['letter-head'] = [
+frappe.help.help_links['List/Letter Head'] = [
 	{ label: 'Letter Head', url: docsUrl + 'user/manual/en/setting-up/print/letter-head' },
 ]
 
-frappe.help.help_links['address-template'] = [
+frappe.help.help_links['List/Address Template'] = [
 	{ label: 'Address Template', url: docsUrl + 'user/manual/en/setting-up/print/address-template' },
 ]
 
-frappe.help.help_links['terms-and-conditions'] = [
+frappe.help.help_links['List/Terms and Conditions'] = [
 	{ label: 'Terms and Conditions', url: docsUrl + 'user/manual/en/setting-up/print/terms-and-conditions' },
 ]
 
-frappe.help.help_links['cheque-print-template'] = [
+frappe.help.help_links['List/Cheque Print Template'] = [
 	{ label: 'Cheque Print Template', url: docsUrl + 'user/manual/en/setting-up/print/cheque-print-template' },
 ]
 
-frappe.help.help_links['email-account'] = [
+frappe.help.help_links['List/Email Account'] = [
 	{ label: 'Email Account', url: docsUrl + 'user/manual/en/setting-up/email/email-account' },
 ]
 
-frappe.help.help_links['notification'] = [
+frappe.help.help_links['List/Notification'] = [
 	{ label: 'Notification', url: docsUrl + 'user/manual/en/setting-up/email/notifications' },
 ]
 
-frappe.help.help_links['notification'] = [
+frappe.help.help_links['Form/Notification'] = [
 	{ label: 'Notification', url: docsUrl + 'user/manual/en/setting-up/email/notifications' },
 ]
 
-frappe.help.help_links['email-digest'] = [
+frappe.help.help_links['List/Email Digest'] = [
 	{ label: 'Email Digest', url: docsUrl + 'user/manual/en/setting-up/email/email-digest' },
 ]
 
-frappe.help.help_links['auto-email-report'] = [
+frappe.help.help_links['List/Auto Email Report'] = [
 	{ label: 'Auto Email Reports', url: docsUrl + 'user/manual/en/setting-up/email/email-reports' },
 ]
 
-frappe.help.help_links['print-settings'] = [
+frappe.help.help_links['Form/Print Settings'] = [
 	{ label: 'Print Settings', url: docsUrl + 'user/manual/en/setting-up/print/print-settings' },
 ]
 
@@ -91,60 +95,66 @@ frappe.help.help_links['print-format-builder'] = [
 	{ label: 'Print Format Builder', url: docsUrl + 'user/manual/en/setting-up/print/print-settings' },
 ]
 
-frappe.help.help_links['print-heading'] = [
+frappe.help.help_links['List/Print Heading'] = [
 	{ label: 'Print Heading', url: docsUrl + 'user/manual/en/setting-up/print/print-headings' },
 ]
 
 //setup-integrations
 
-frappe.help.help_links['paypal-settings'] = [
+frappe.help.help_links['Form/PayPal Settings'] = [
 	{ label: 'PayPal Settings', url: docsUrl + 'user/manual/en/setting-up/integrations/paypal-integration' },
 ]
 
-frappe.help.help_links['razorpay-settings'] = [
+frappe.help.help_links['Form/Razorpay Settings'] = [
 	{ label: 'Razorpay Settings', url: docsUrl + 'user/manual/en/setting-up/integrations/razorpay-integration' },
 ]
 
-frappe.help.help_links['dropbox-settings'] = [
+frappe.help.help_links['Form/Dropbox Settings'] = [
 	{ label: 'Dropbox Settings', url: docsUrl + 'user/manual/en/setting-up/integrations/dropbox-backup' },
 ]
 
-frappe.help.help_links['ldap-settings'] = [
+frappe.help.help_links['Form/LDAP Settings'] = [
 	{ label: 'LDAP Settings', url: docsUrl + 'user/manual/en/setting-up/integrations/ldap-integration' },
 ]
 
-frappe.help.help_links['stripe-settings'] = [
+frappe.help.help_links['Form/Stripe Settings'] = [
 	{ label: 'Stripe Settings', url: docsUrl + 'user/manual/en/setting-up/integrations/stripe-integration' },
 ]
 
 //Sales
 
-frappe.help.help_links['quotation'] = [
+frappe.help.help_links['Form/Quotation'] = [
 	{ label: 'Quotation', url: docsUrl + 'user/manual/en/selling/quotation' },
 	{ label: 'Applying Discount', url: docsUrl + 'user/manual/en/selling/articles/applying-discount' },
 	{ label: 'Sales Person', url: docsUrl + 'user/manual/en/selling/articles/sales-persons-in-the-sales-transactions' },
 	{ label: 'Applying Margin', url: docsUrl + 'user/manual/en/selling/articles/adding-margin' },
 ]
 
-frappe.help.help_links['customer'] = [
+frappe.help.help_links['List/Customer'] = [
 	{ label: 'Customer', url: docsUrl + 'user/manual/en/CRM/customer' },
 	{ label: 'Credit Limit', url: docsUrl + 'user/manual/en/accounts/credit-limit' },
 ]
 
-frappe.help.help_links['customer'] = [
+frappe.help.help_links['Form/Customer'] = [
 	{ label: 'Customer', url: docsUrl + 'user/manual/en/CRM/customer' },
 	{ label: 'Credit Limit', url: docsUrl + 'user/manual/en/accounts/credit-limit' },
 ]
 
-frappe.help.help_links['sales-taxes-and-charges-template'] = [
+frappe.help.help_links['List/Sales Taxes and Charges Template'] = [
 	{ label: 'Setting Up Taxes', url: docsUrl + 'user/manual/en/setting-up/setting-up-taxes' },
 ]
 
-frappe.help.help_links['sales-taxes-and-charges-template'] = [
+frappe.help.help_links['Form/Sales Taxes and Charges Template'] = [
 	{ label: 'Setting Up Taxes', url: docsUrl + 'user/manual/en/setting-up/setting-up-taxes' },
 ]
 
-frappe.help.help_links['sales-order'] = [
+frappe.help.help_links['List/Sales Order'] = [
+	{ label: 'Sales Order', url: docsUrl + 'user/manual/en/selling/sales-order' },
+	{ label: 'Recurring Sales Order', url: docsUrl + 'user/manual/en/accounts/recurring-orders-and-invoices' },
+	{ label: 'Applying Discount', url: docsUrl + 'user/manual/en/selling/articles/applying-discount' },
+]
+
+frappe.help.help_links['Form/Sales Order'] = [
 	{ label: 'Sales Order', url: docsUrl + 'user/manual/en/selling/sales-order' },
 	{ label: 'Recurring Sales Order', url: docsUrl + 'user/manual/en/accounts/recurring-orders-and-invoices' },
 	{ label: 'Applying Discount', url: docsUrl + 'user/manual/en/selling/articles/applying-discount' },
@@ -154,34 +164,43 @@ frappe.help.help_links['sales-order'] = [
 	{ label: 'Applying Margin', url: docsUrl + 'user/manual/en/selling/articles/adding-margin' },
 ]
 
-frappe.help.help_links['product-bundle'] = [
+frappe.help.help_links['Form/Product Bundle'] = [
 	{ label: 'Product Bundle', url: docsUrl + 'user/manual/en/selling/setup/product-bundle' },
 ]
 
-frappe.help.help_links['selling-settings'] = [
+frappe.help.help_links['Form/Selling Settings'] = [
 	{ label: 'Selling Settings', url: docsUrl + 'user/manual/en/selling/setup/selling-settings' },
 ]
 
 //Buying
 
-frappe.help.help_links['supplier'] = [
+frappe.help.help_links['List/Supplier'] = [
 	{ label: 'Supplier', url: docsUrl + 'user/manual/en/buying/supplier' },
 ]
 
-frappe.help.help_links['request-for-quotation'] = [
+frappe.help.help_links['Form/Supplier'] = [
+	{ label: 'Supplier', url: docsUrl + 'user/manual/en/buying/supplier' },
+]
+
+frappe.help.help_links['Form/Request for Quotation'] = [
 	{ label: 'Request for Quotation', url: docsUrl + 'user/manual/en/buying/request-for-quotation' },
 	{ label: 'RFQ Video', url: docsUrl + 'user/videos/learn/request-for-quotation.html' },
 ]
 
-frappe.help.help_links['supplier-quotation'] = [
+frappe.help.help_links['Form/Supplier Quotation'] = [
 	{ label: 'Supplier Quotation', url: docsUrl + 'user/manual/en/buying/supplier-quotation' },
 ]
 
-frappe.help.help_links['buying-settings'] = [
+frappe.help.help_links['Form/Buying Settings'] = [
 	{ label: 'Buying Settings', url: docsUrl + 'user/manual/en/buying/setup/buying-settings' },
 ]
 
-frappe.help.help_links['purchase-order'] = [
+frappe.help.help_links['List/Purchase Order'] = [
+	{ label: 'Purchase Order', url: docsUrl + 'user/manual/en/buying/purchase-order' },
+	{ label: 'Recurring Purchase Order', url: docsUrl + 'user/manual/en/accounts/recurring-orders-and-invoices' },
+]
+
+frappe.help.help_links['Form/Purchase Order'] = [
 	{ label: 'Purchase Order', url: docsUrl + 'user/manual/en/buying/purchase-order' },
 	{ label: 'Item UoM', url: docsUrl + 'user/manual/en/buying/articles/purchasing-in-different-unit' },
 	{ label: 'Supplier Item Code', url: docsUrl + 'user/manual/en/buying/articles/maintaining-suppliers-part-no-in-item' },
@@ -189,44 +208,44 @@ frappe.help.help_links['purchase-order'] = [
 	{ label: 'Subcontracting', url: docsUrl + 'user/manual/en/manufacturing/subcontracting' },
 ]
 
-frappe.help.help_links['purchase-taxes-and-charges-template'] = [
+frappe.help.help_links['List/Purchase Taxes and Charges Template'] = [
 	{ label: 'Setting Up Taxes', url: docsUrl + 'user/manual/en/setting-up/setting-up-taxes' },
 ]
 
-frappe.help.help_links['pos-profile'] = [
+frappe.help.help_links['List/POS Profile'] = [
 	{ label: 'POS Profile', url: docsUrl + 'user/manual/en/setting-up/pos-setting' },
 ]
 
-frappe.help.help_links['price-list'] = [
+frappe.help.help_links['List/Price List'] = [
 	{ label: 'Price List', url: docsUrl + 'user/manual/en/setting-up/price-lists' },
 ]
 
-frappe.help.help_links['authorization-rule'] = [
+frappe.help.help_links['List/Authorization Rule'] = [
 	{ label: 'Authorization Rule', url: docsUrl + 'user/manual/en/setting-up/authorization-rule' },
 ]
 
-frappe.help.help_links['sms-settings'] = [
+frappe.help.help_links['Form/SMS Settings'] = [
 	{ label: 'SMS Settings', url: docsUrl + 'user/manual/en/setting-up/sms-setting' },
 ]
 
-frappe.help.help_links['stock-reconciliation'] = [
+frappe.help.help_links['List/Stock Reconciliation'] = [
 	{ label: 'Stock Reconciliation', url: docsUrl + 'user/manual/en/setting-up/stock-reconciliation-for-non-serialized-item' },
 ]
 
-frappe.help.help_links['territory/view/tree'] = [
+frappe.help.help_links['Tree/Territory'] = [
 	{ label: 'Territory', url: docsUrl + 'user/manual/en/setting-up/territory' },
 ]
 
-frappe.help.help_links['dropbox-backup'] = [
+frappe.help.help_links['Form/Dropbox Backup'] = [
 	{ label: 'Dropbox Backup', url: docsUrl + 'user/manual/en/setting-up/third-party-backups' },
 	{ label: 'Setting Up Dropbox Backup', url: docsUrl + 'user/manual/en/setting-up/articles/setting-up-dropbox-backups' },
 ]
 
-frappe.help.help_links['workflow'] = [
+frappe.help.help_links['List/Workflow'] = [
 	{ label: 'Workflow', url: docsUrl + 'user/manual/en/setting-up/workflows' },
 ]
 
-frappe.help.help_links['company'] = [
+frappe.help.help_links['List/Company'] = [
 	{ label: 'Company', url: docsUrl + 'user/manual/en/setting-up/company-setup' },
 	{ label: 'Managing Multiple Companies', url: docsUrl + 'user/manual/en/setting-up/articles/managing-multiple-companies' },
 	{ label: 'Delete All Related Transactions for a Company', url: docsUrl + 'user/manual/en/setting-up/articles/delete-a-company-and-all-related-transactions' },
@@ -234,25 +253,25 @@ frappe.help.help_links['company'] = [
 
 //Accounts
 
-frappe.help.help_links['accounts'] = [
+frappe.help.help_links['modules/Accounts'] = [
 	{ label: 'Introduction to Accounts', url: docsUrl + 'user/manual/en/accounts/' },
 	{ label: 'Chart of Accounts', url: docsUrl + 'user/manual/en/accounts/chart-of-accounts.html' },
 	{ label: 'Multi Currency Accounting', url: docsUrl + 'user/manual/en/accounts/multi-currency-accounting' },
 ]
 
-frappe.help.help_links['account/view/tree'] = [
+frappe.help.help_links['Tree/Account'] = [
 	{ label: 'Chart of Accounts', url: docsUrl + 'user/manual/en/accounts/chart-of-accounts' },
 	{ label: 'Managing Tree Mastes', url: docsUrl + 'user/manual/en/setting-up/articles/managing-tree-structure-masters' },
 ]
 
-frappe.help.help_links['sales-invoice'] = [
+frappe.help.help_links['Form/Sales Invoice'] = [
 	{ label: 'Sales Invoice', url: docsUrl + 'user/manual/en/accounts/sales-invoice' },
 	{ label: 'Accounts Opening Balance', url: docsUrl + 'user/manual/en/accounts/opening-accounts' },
 	{ label: 'Sales Return', url: docsUrl + 'user/manual/en/stock/sales-return' },
 	{ label: 'Recurring Sales Invoice', url: docsUrl + 'user/manual/en/accounts/recurring-orders-and-invoices' },
 ]
 
-frappe.help.help_links['sales-invoice'] = [
+frappe.help.help_links['List/Sales Invoice'] = [
 	{ label: 'Sales Invoice', url: docsUrl + 'user/manual/en/accounts/sales-invoice' },
 	{ label: 'Accounts Opening Balance', url: docsUrl + 'user/manual/en/accounts/opening-accounts' },
 	{ label: 'Sales Return', url: docsUrl + 'user/manual/en/stock/sales-return' },
@@ -263,43 +282,43 @@ frappe.help.help_links['pos'] = [
 	{ label: 'Point of Sale Invoice', url: docsUrl + 'user/manual/en/accounts/point-of-sale-pos-invoice' },
 ]
 
-frappe.help.help_links['pos-profile'] = [
+frappe.help.help_links['List/POS Profile'] = [
 	{ label: 'Point of Sale Profile', url: docsUrl + 'user/manual/en/setting-up/pos-setting' },
 ]
 
-frappe.help.help_links['purchase-invoice'] = [
+frappe.help.help_links['List/Purchase Invoice'] = [
 	{ label: 'Purchase Invoice', url: docsUrl + 'user/manual/en/accounts/purchase-invoice' },
 	{ label: 'Accounts Opening Balance', url: docsUrl + 'user/manual/en/accounts/opening-accounts' },
 	{ label: 'Recurring Purchase Invoice', url: docsUrl + 'user/manual/en/accounts/recurring-orders-and-invoices' },
 ]
 
-frappe.help.help_links['journal-entry'] = [
+frappe.help.help_links['List/Journal Entry'] = [
 	{ label: 'Journal Entry', url: docsUrl + 'user/manual/en/accounts/journal-entry' },
 	{ label: 'Advance Payment Entry', url: docsUrl + 'user/manual/en/accounts/advance-payment-entry' },
 	{ label: 'Accounts Opening Balance', url: docsUrl + 'user/manual/en/accounts/opening-accounts' },
 ]
 
-frappe.help.help_links['payment-entry'] = [
+frappe.help.help_links['List/Payment Entry'] = [
 	{ label: 'Payment Entry', url: docsUrl + 'user/manual/en/accounts/payment-entry' },
 ]
 
-frappe.help.help_links['payment-request'] = [
+frappe.help.help_links['List/Payment Request'] = [
 	{ label: 'Payment Request', url: docsUrl + 'user/manual/en/accounts/payment-request' },
 ]
 
-frappe.help.help_links['asset'] = [
+frappe.help.help_links['List/Asset'] = [
 	{ label: 'Managing Fixed Assets', url: docsUrl + 'user/manual/en/accounts/managing-fixed-assets' },
 ]
 
-frappe.help.help_links['asset-category'] = [
+frappe.help.help_links['List/Asset Category'] = [
 	{ label: 'Asset Category', url: docsUrl + 'user/manual/en/accounts/managing-fixed-assets' },
 ]
 
-frappe.help.help_links['cost-center/view/tree'] = [
+frappe.help.help_links['Tree/Cost Center'] = [
 	{ label: 'Budgeting', url: docsUrl + 'user/manual/en/accounts/budgeting' },
 ]
 
-frappe.help.help_links['item'] = [
+frappe.help.help_links['List/Item'] = [
 	{ label: 'Item', url: docsUrl + 'user/manual/en/stock/item' },
 	{ label: 'Item Price', url: docsUrl + 'user/manual/en/stock/item/item-price' },
 	{ label: 'Barcode', url: docsUrl + 'user/manual/en/stock/articles/track-items-using-barcode' },
@@ -310,42 +329,61 @@ frappe.help.help_links['item'] = [
 	{ label: 'Item Valuation', url: docsUrl + 'user/manual/en/stock/item/item-valuation-fifo-and-moving-average' },
 ]
 
-frappe.help.help_links['purchase-receipt'] = [
+frappe.help.help_links['Form/Item'] = [
+	{ label: 'Item', url: docsUrl + 'user/manual/en/stock/item' },
+	{ label: 'Item Price', url: docsUrl + 'user/manual/en/stock/item/item-price' },
+	{ label: 'Barcode', url: docsUrl + 'user/manual/en/stock/articles/track-items-using-barcode' },
+	{ label: 'Item Wise Taxation', url: docsUrl + 'user/manual/en/accounts/item-wise-taxation' },
+	{ label: 'Managing Fixed Assets', url: docsUrl + 'user/manual/en/accounts/managing-fixed-assets' },
+	{ label: 'Item Codification', url: docsUrl + 'user/manual/en/stock/item/item-codification' },
+	{ label: 'Item Variants', url: docsUrl + 'user/manual/en/stock/item/item-variants' },
+	{ label: 'Item Valuation', url: docsUrl + 'user/manual/en/stock/item/item-valuation-fifo-and-moving-average' },
+]
+
+frappe.help.help_links['List/Purchase Receipt'] = [
 	{ label: 'Purchase Receipt', url: docsUrl + 'user/manual/en/stock/purchase-receipt' },
 	{ label: 'Barcode', url: docsUrl + 'user/manual/en/stock/articles/track-items-using-barcode' },
 ]
 
-frappe.help.help_links['delivery-note'] = [
+frappe.help.help_links['List/Delivery Note'] = [
 	{ label: 'Delivery Note', url: docsUrl + 'user/manual/en/stock/delivery-note' },
 	{ label: 'Barcode', url: docsUrl + 'user/manual/en/stock/articles/track-items-using-barcode' },
 	{ label: 'Sales Return', url: docsUrl + 'user/manual/en/stock/sales-return' },
 ]
 
-frappe.help.help_links['delivery-note'] = [
+frappe.help.help_links['Form/Delivery Note'] = [
 	{ label: 'Delivery Note', url: docsUrl + 'user/manual/en/stock/delivery-note' },
 	{ label: 'Sales Return', url: docsUrl + 'user/manual/en/stock/sales-return' },
 	{ label: 'Barcode', url: docsUrl + 'user/manual/en/stock/articles/track-items-using-barcode' },
 	{ label: 'Subcontracting', url: docsUrl + 'user/manual/en/manufacturing/subcontracting' },
 ]
 
-frappe.help.help_links['installation-note'] = [
+frappe.help.help_links['List/Installation Note'] = [
 	{ label: 'Installation Note', url: docsUrl + 'user/manual/en/stock/installation-note' },
 ]
 
 
+frappe.help.help_links['Tree'] = [
+	{ label: 'Managing Tree Structure Masters', url: docsUrl + 'user/manual/en/setting-up/articles/managing-tree-structure-masters' },
+]
 
-frappe.help.help_links['budget'] = [
+frappe.help.help_links['List/Budget'] = [
 	{ label: 'Budgeting', url: docsUrl + 'user/manual/en/accounts/budgeting' },
 ]
 
 //Stock
 
-frappe.help.help_links['material-request'] = [
+frappe.help.help_links['List/Material Request'] = [
 	{ label: 'Material Request', url: docsUrl + 'user/manual/en/stock/material-request' },
 	{ label: 'Auto-creation of Material Request', url: docsUrl + 'user/manual/en/stock/articles/auto-creation-of-material-request' },
 ]
 
-frappe.help.help_links['stock-entry'] = [
+frappe.help.help_links['Form/Material Request'] = [
+	{ label: 'Material Request', url: docsUrl + 'user/manual/en/stock/material-request' },
+	{ label: 'Auto-creation of Material Request', url: docsUrl + 'user/manual/en/stock/articles/auto-creation-of-material-request' },
+]
+
+frappe.help.help_links['Form/Stock Entry'] = [
 	{ label: 'Stock Entry', url: docsUrl + 'user/manual/en/stock/stock-entry' },
 	{ label: 'Stock Entry Types', url: docsUrl + 'user/manual/en/stock/articles/stock-entry-purpose' },
 	{ label: 'Repack Entry', url: docsUrl + 'user/manual/en/stock/articles/repack-entry' },
@@ -353,114 +391,136 @@ frappe.help.help_links['stock-entry'] = [
 	{ label: 'Subcontracting', url: docsUrl + 'user/manual/en/manufacturing/subcontracting' },
 ]
 
-frappe.help.help_links['warehouse/view/tree'] = [
+frappe.help.help_links['List/Stock Entry'] = [
+	{ label: 'Stock Entry', url: docsUrl + 'user/manual/en/stock/stock-entry' },
+]
+
+frappe.help.help_links['Tree/Warehouse'] = [
 	{ label: 'Warehouse', url: docsUrl + 'user/manual/en/stock/warehouse' },
 ]
 
-frappe.help.help_links['serial-no'] = [
+frappe.help.help_links['List/Serial No'] = [
 	{ label: 'Serial No', url: docsUrl + 'user/manual/en/stock/serial-no' },
 ]
 
-frappe.help.help_links['batch'] = [
+frappe.help.help_links['Form/Serial No'] = [
+	{ label: 'Serial No', url: docsUrl + 'user/manual/en/stock/serial-no' },
+]
+
+frappe.help.help_links['Form/Batch'] = [
 	{ label: 'Batch', url: docsUrl + 'user/manual/en/stock/batch' },
 ]
 
-frappe.help.help_links['packing-slip'] = [
+frappe.help.help_links['Form/Packing Slip'] = [
 	{ label: 'Packing Slip', url: docsUrl + 'user/manual/en/stock/tools/packing-slip' },
 ]
 
-frappe.help.help_links['quality-inspection'] = [
+frappe.help.help_links['Form/Quality Inspection'] = [
 	{ label: 'Quality Inspection', url: docsUrl + 'user/manual/en/stock/tools/quality-inspection' },
 ]
 
-frappe.help.help_links['landed-cost-voucher'] = [
+frappe.help.help_links['Form/Landed Cost Voucher'] = [
 	{ label: 'Landed Cost Voucher', url: docsUrl + 'user/manual/en/stock/tools/landed-cost-voucher' },
 ]
 
-frappe.help.help_links['item-group/view/tree'] = [
+frappe.help.help_links['Tree/Item Group'] = [
 	{ label: 'Item Group', url: docsUrl + 'user/manual/en/stock/setup/item-group' },
 ]
 
-frappe.help.help_links['item-attribute'] = [
+frappe.help.help_links['Form/Item Attribute'] = [
 	{ label: 'Item Attribute', url: docsUrl + 'user/manual/en/stock/setup/item-attribute' },
 ]
 
-frappe.help.help_links['uom'] = [
+frappe.help.help_links['Form/UOM'] = [
 	{ label: 'Fractions in UOM', url: docsUrl + 'user/manual/en/stock/articles/managing-fractions-in-uom' },
 ]
 
-frappe.help.help_links['stock-reconciliation'] = [
+frappe.help.help_links['Form/Stock Reconciliation'] = [
 	{ label: 'Opening Stock Entry', url: docsUrl + 'user/manual/en/stock/opening-stock' },
 ]
 
 //CRM
 
-frappe.help.help_links['lead'] = [
+frappe.help.help_links['Form/Lead'] = [
 	{ label: 'Lead', url: docsUrl + 'user/manual/en/CRM/lead' },
 ]
 
-frappe.help.help_links['opportunity'] = [
+frappe.help.help_links['Form/Opportunity'] = [
 	{ label: 'Opportunity', url: docsUrl + 'user/manual/en/CRM/opportunity' },
 ]
 
-frappe.help.help_links['address'] = [
+frappe.help.help_links['Form/Address'] = [
 	{ label: 'Address', url: docsUrl + 'user/manual/en/CRM/address' },
 ]
 
-frappe.help.help_links['contact'] = [
+frappe.help.help_links['Form/Contact'] = [
 	{ label: 'Contact', url: docsUrl + 'user/manual/en/CRM/contact' },
 ]
 
-frappe.help.help_links['newsletter'] = [
+frappe.help.help_links['Form/Newsletter'] = [
 	{ label: 'Newsletter', url: docsUrl + 'user/manual/en/CRM/newsletter' },
 ]
 
-frappe.help.help_links['campaign'] = [
+frappe.help.help_links['Form/Campaign'] = [
 	{ label: 'Campaign', url: docsUrl + 'user/manual/en/CRM/setup/campaign' },
 ]
 
-frappe.help.help_links['sales-person/view/tree'] = [
+frappe.help.help_links['Tree/Sales Person'] = [
 	{ label: 'Sales Person', url: docsUrl + 'user/manual/en/CRM/setup/sales-person' },
 ]
 
-frappe.help.help_links['sales-person'] = [
+frappe.help.help_links['Form/Sales Person'] = [
 	{ label: 'Sales Person Target', url: docsUrl + 'user/manual/en/selling/setup/sales-person-target-allocation' },
+]
+
+//Support
+
+frappe.help.help_links['List/Feedback Trigger'] = [
+	{ label: 'Feedback Trigger', url: docsUrl + 'user/manual/en/setting-up/feedback/setting-up-feedback' },
+]
+
+frappe.help.help_links['List/Feedback Request'] = [
+	{ label: 'Feedback Request', url: docsUrl + 'user/manual/en/setting-up/feedback/submit-feedback' },
+]
+
+frappe.help.help_links['List/Feedback Request'] = [
+	{ label: 'Feedback Request', url: docsUrl + 'user/manual/en/setting-up/feedback/submit-feedback' },
 ]
 
 //Manufacturing
 
-frappe.help.help_links['bom'] = [
+frappe.help.help_links['Form/BOM'] = [
 	{ label: 'Bill of Material', url: docsUrl + 'user/manual/en/manufacturing/bill-of-materials' },
 	{ label: 'Nested BOM Structure', url: docsUrl + 'user/manual/en/manufacturing/articles/nested-bom-structure' },
 ]
 
-frappe.help.help_links['work-order'] = [
+frappe.help.help_links['Form/Work Order'] = [
 	{ label: 'Work Order', url: docsUrl + 'user/manual/en/manufacturing/work-order' },
 ]
 
-frappe.help.help_links['workstation'] = [
+frappe.help.help_links['Form/Workstation'] = [
 	{ label: 'Workstation', url: docsUrl + 'user/manual/en/manufacturing/workstation' },
 ]
 
-frappe.help.help_links['operation'] = [
+frappe.help.help_links['Form/Operation'] = [
 	{ label: 'Operation', url: docsUrl + 'user/manual/en/manufacturing/operation' },
 ]
 
-frappe.help.help_links['bom-update-tool'] = [
+frappe.help.help_links['Form/BOM Update Tool'] = [
 	{ label: 'BOM Update Tool', url: docsUrl + 'user/manual/en/manufacturing/tools/bom-update-tool' },
 ]
 
 //Customize
 
-frappe.help.help_links['customize-form'] = [
+frappe.help.help_links['Form/Customize Form'] = [
 	{ label: 'Custom Field', url: docsUrl + 'user/manual/en/customize-erpnext/custom-field' },
 	{ label: 'Customize Field', url: docsUrl + 'user/manual/en/customize-erpnext/customize-form' },
 ]
 
-frappe.help.help_links['custom-field'] = [
+frappe.help.help_links['Form/Custom Field'] = [
 	{ label: 'Custom Field', url: docsUrl + 'user/manual/en/customize-erpnext/custom-field' },
 ]
 
-frappe.help.help_links['custom-field'] = [
+frappe.help.help_links['Form/Custom Field'] = [
 	{ label: 'Custom Field', url: docsUrl + 'user/manual/en/customize-erpnext/custom-field' },
 ]

--- a/erpnext/setup/install.py
+++ b/erpnext/setup/install.py
@@ -142,13 +142,15 @@ def add_standard_navbar_items():
 		}
 	]
 
-	current_nabvar_items = navbar_settings.help_dropdown
+	current_navbar_items = navbar_settings.help_dropdown
 	navbar_settings.set('help_dropdown', [])
 
 	for item in erpnext_navbar_items:
-		navbar_settings.append('help_dropdown', item)
+		current_labels = [item.get('item_label') for item in current_navbar_items]
+		if not item.get('item_label') in current_labels:
+			navbar_settings.append('help_dropdown', item)
 
-	for item in current_nabvar_items:
+	for item in current_navbar_items:
 		navbar_settings.append('help_dropdown', {
 			'item_label': item.item_label,
 			'item_type': item.item_type,


### PR DESCRIPTION
Help links weren't being rendered in the Help dropdown on the navbar.

**Before:**
<img width="1440" alt="Screenshot 2021-03-24 at 4 49 13 PM" src="https://user-images.githubusercontent.com/19775888/112302259-e3e55880-8cc0-11eb-8233-615c239a6c2f.png">


**After:**
<img width="1439" alt="Screenshot 2021-03-24 at 4 47 37 PM" src="https://user-images.githubusercontent.com/19775888/112302104-b4cee700-8cc0-11eb-89c1-5a629af53a7e.png">


`erpnext.patches.v13_0.add_standard_navbar_items` needs to be executed again. Added a check to prevent the duplicate items being appended to the dropdown.
