### PR TITLE
fix: opportunity-quotation mapping order status

### DIFF
--- a/erpnext/crm/doctype/opportunity/opportunity.py
+++ b/erpnext/crm/doctype/opportunity/opportunity.py
@@ -248,7 +248,6 @@ def make_quotation(source_name, target_doc=None):
 			"doctype": "Quotation",
 			"field_map": {
 				"opportunity_from": "quotation_to",
-				"opportunity_type": "order_type",
 				"name": "enq_no",
 			}
 		},


### PR DESCRIPTION
**Issue-**
When the user trying to save a Quotation created from Opportunity, getting this error.
![image](https://user-images.githubusercontent.com/20715976/112425323-dfba4900-8d5b-11eb-884d-dfb6ee35e119.png)

**Issue Root Cause-** 
Opportunity Type(Link field in Opportunity) is mapped with Order Status(Select field Quotation). The system not getting the same values of Opportunity Type in Order Status then it throws the error.

**Fix-**
Removed Opportunity Type -> Order Type mapping.