### PR TITLE
fix: commit individual SLE rename for large datasets (v12)

### DIFF
--- a/erpnext/accounts/doctype/gl_entry/gl_entry.py
+++ b/erpnext/accounts/doctype/gl_entry/gl_entry.py
@@ -294,4 +294,8 @@ def rename_temporarily_named_docs(doctype):
 		oldname = doc.name
 		set_name_from_naming_options(frappe.get_meta(doctype).autoname, doc)
 		newname = doc.name
-		frappe.db.sql("""UPDATE `tab{}` SET name = %s, to_rename = 0 where name = %s""".format(doctype), (newname, oldname))
+		frappe.db.sql(
+			"UPDATE `tab{}` SET name = %s, to_rename = 0 where name = %s".format(doctype),
+			(newname, oldname),
+			auto_commit=True
+		)


### PR DESCRIPTION
Renaming a large number of SLEs would time out while processing. This commits every rename to the database, so that future calls (via the hourly hook) don't keep running on the same SLEs.