### PR TITLE
fix: Precision issues while allocating advance amount

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
@@ -127,7 +127,6 @@
   "write_off_cost_center",
   "advances_section",
   "allocate_advances_automatically",
-  "adjust_advance_taxes",
   "get_advances",
   "advances",
   "payment_schedule_section",
@@ -1327,13 +1326,6 @@
    "options": "Project"
   },
   {
-   "default": "0",
-   "description": "Taxes paid while advance payment will be adjusted against this invoice",
-   "fieldname": "adjust_advance_taxes",
-   "fieldtype": "Check",
-   "label": "Adjust Advance Taxes"
-  },
-  {
    "depends_on": "eval:doc.is_internal_supplier",
    "description": "Unrealized Profit / Loss account for intra-company transfers",
    "fieldname": "unrealized_profit_loss_account",
@@ -1378,7 +1370,7 @@
  "idx": 204,
  "is_submittable": 1,
  "links": [],
- "modified": "2021-03-09 21:12:30.422084",
+ "modified": "2021-03-30 21:45:58.334107",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Purchase Invoice",

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -406,9 +406,10 @@ def check_if_advance_entry_modified(args):
 		throw(_("""Payment Entry has been modified after you pulled it. Please pull it again."""))
 
 def validate_allocated_amount(args):
+	precision = args.get('precision') or frappe.db.get_single_value("System Settings", "currency_precision")
 	if args.get("allocated_amount") < 0:
 		throw(_("Allocated amount cannot be negative"))
-	elif args.get("allocated_amount") > args.get("unadjusted_amount"):
+	elif flt(args.get("allocated_amount"), precision) > flt(args.get("unadjusted_amount"), precision):
 		throw(_("Allocated amount cannot be greater than unadjusted amount"))
 
 def update_reference_in_journal_entry(d, jv_obj):

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -656,6 +656,7 @@ class AccountsController(TransactionBase):
 					'dr_or_cr': dr_or_cr,
 					'unadjusted_amount': flt(d.advance_amount),
 					'allocated_amount': flt(d.allocated_amount),
+					'precision': d.precision('advance_amount'),
 					'exchange_rate': (self.conversion_rate
 						if self.party_account_currency != self.company_currency else 1),
 					'grand_total': (self.base_grand_total
@@ -1394,7 +1395,7 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 			)
 
 	def get_new_child_item(item_row):
-		child_doctype = "Sales Order Item" if parent_doctype == "Sales Order" else "Purchase Order Item" 
+		child_doctype = "Sales Order Item" if parent_doctype == "Sales Order" else "Purchase Order Item"
 		return set_order_defaults(parent_doctype, parent_doctype_name, child_doctype, child_docname, item_row)
 
 	def validate_quantity(child_item, d):


### PR DESCRIPTION
<img width="1392" alt="Screenshot 2021-04-05 at 9 03 06 PM" src="https://user-images.githubusercontent.com/42651287/113592584-fa8d9700-9652-11eb-9110-692ac812774e.png">

The advance amount and allocated amount precision had some differences due to exchange rate conversions which we causing issues while allocating payments. The PR ignores those precision differences
