### PR TITLE
fix: can't multiply sequence by non-int of type 'float'

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -110,7 +110,7 @@ def get_item_details(args, doc=None, for_validate=False, overwrite_warehouse=Tru
 	get_gross_profit(out)
 	if args.doctype == 'Material Request':
 		out.rate = args.rate or out.price_list_rate
-		out.amount = flt(args.qty * out.rate)
+		out.amount = flt(args.qty) * flt(out.rate)
 
 	return out
 


### PR DESCRIPTION
**Issue**

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-13-2021-03-10-a/apps/frappe/frappe/app.py", line 67, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-13-2021-03-10-a/apps/frappe/frappe/api.py", line 58, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-13-2021-03-10-a/apps/frappe/frappe/handler.py", line 30, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-13-2021-03-10-a/apps/frappe/frappe/handler.py", line 70, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-13-2021-03-10-a/apps/frappe/frappe/__init__.py", line 1134, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-13-2021-03-10-a/apps/erpnext/erpnext/stock/get_item_details.py", line 113, in get_item_details
    out.amount = flt(args.qty * out.rate)
TypeError: can't multiply sequence by non-int of type 'float'
```