### PR TITLE
fix: Picked Qty conversion from Stock Qty to Qty while creating DN from Pick List

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -345,7 +345,7 @@ def create_delivery_note(source_name, target_doc=None):
 
 		if dn_item:
 			dn_item.warehouse = location.warehouse
-			dn_item.qty = location.picked_qty
+			dn_item.qty = location.picked_qty / location.conversion_factor
 			dn_item.batch_no = location.batch_no
 			dn_item.serial_no = location.serial_no
 

--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -345,7 +345,7 @@ def create_delivery_note(source_name, target_doc=None):
 
 		if dn_item:
 			dn_item.warehouse = location.warehouse
-			dn_item.qty = location.picked_qty / location.conversion_factor
+			dn_item.qty = flt(location.picked_qty) / (flt(location.conversion_factor) or 1)
 			dn_item.batch_no = location.batch_no
 			dn_item.serial_no = location.serial_no
 

--- a/erpnext/stock/doctype/pick_list/test_pick_list.py
+++ b/erpnext/stock/doctype/pick_list/test_pick_list.py
@@ -304,8 +304,7 @@ class TestPickList(unittest.TestCase):
 					'qty': 1,
 					'conversion_factor': 5,
 					'delivery_date': frappe.utils.today()
-				},
-				{
+				}, {
 					'item_code': '_Test Item',
 					'qty': 1,
 					'conversion_factor': 1,
@@ -326,8 +325,7 @@ class TestPickList(unittest.TestCase):
 				'conversion_factor': 5,
 				'sales_order': sales_order.name,
 				'sales_order_item': sales_order.items[0].name ,
-			},
-			{
+			}, {
 				'item_code': '_Test Item',
 				'qty': 1,
 				'stock_qty': 1,

--- a/erpnext/stock/doctype/pick_list/test_pick_list.py
+++ b/erpnext/stock/doctype/pick_list/test_pick_list.py
@@ -9,6 +9,7 @@ test_dependencies = ['Item', 'Sales Invoice', 'Stock Entry', 'Batch']
 
 from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import make_purchase_receipt
 from erpnext.stock.doctype.item.test_item import create_item
+from erpnext.stock.doctype.pick_list.pick_list import create_delivery_note
 from erpnext.stock.doctype.stock_reconciliation.stock_reconciliation \
 		import EmptyStockReconciliationItemsError
 


### PR DESCRIPTION
Fixes #24970

**Issue occurs while creating a Delivery Note from a Pick List