### PR TITLE
fix: Hide serial and batch selector in Stock Entry

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -100,6 +100,13 @@ frappe.ui.form.on('Stock Entry', {
 
 		frm.add_fetch("bom_no", "inspection_required", "inspection_required");
 		erpnext.accounts.dimensions.setup_dimension_filters(frm, frm.doctype);
+
+		frappe.db.get_single_value('Stock Settings', 'disable_serial_no_and_batch_selector')
+		.then((value) => {
+			if (value) {
+				frappe.flags.hide_serial_batch_dialog = true;
+			}
+		});
 	},
 
 	setup_quality_inspection: function(frm) {
@@ -721,7 +728,8 @@ frappe.ui.form.on('Stock Entry Detail', {
 							no_batch_serial_number_value = !d.batch_no;
 						}
 
-						if (no_batch_serial_number_value) {
+						console.log(frappe.flags.hide_serial_batch_dialog, "$#$#$#");
+						if (no_batch_serial_number_value && !frappe.flags.hide_serial_batch_dialog) {
 							erpnext.stock.select_batch_and_serial_no(frm, d);
 						}
 					}

--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -728,7 +728,6 @@ frappe.ui.form.on('Stock Entry Detail', {
 							no_batch_serial_number_value = !d.batch_no;
 						}
 
-						console.log(frappe.flags.hide_serial_batch_dialog, "$#$#$#");
 						if (no_batch_serial_number_value && !frappe.flags.hide_serial_batch_dialog) {
 							erpnext.stock.select_batch_and_serial_no(frm, d);
 						}


### PR DESCRIPTION
<img width="1323" alt="Screenshot 2021-03-31 at 8 16 53 PM" src="https://user-images.githubusercontent.com/42651287/113163868-32b16600-925e-11eb-95eb-bbf202f5c9ac.png">

Disabling Serial No and Batch Selector didn't disabled it in stock entry as batch selector for stock entry was implemented separately, the PR applied that disabling setting in Stock Entry