### PR TITLE
fix: incorrect status creating PR from PO after creating PI

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -368,7 +368,6 @@ def make_purchase_receipt(source_name, target_doc=None):
 		"Purchase Order": {
 			"doctype": "Purchase Receipt",
 			"field_map": {
-				"per_billed": "per_billed",
 				"supplier_warehouse":"supplier_warehouse"
 			},
 			"validation": {

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -763,3 +763,4 @@ erpnext.patches.v13_0.setup_gratuity_rule_for_india_and_uae
 erpnext.patches.v13_0.setup_uae_vat_fields
 execute:frappe.db.set_value('System Settings', None, 'app_name', 'ERPNext')
 erpnext.patches.v13_0.rename_discharge_date_in_ip_record
+erpnext.patches.v12_0.purchase_receipt_status

--- a/erpnext/patches/v12_0/purchase_receipt_status.py
+++ b/erpnext/patches/v12_0/purchase_receipt_status.py
@@ -1,0 +1,30 @@
+""" This patch fixes old purchase receipts (PR) where even after submitting
+	the PR, the `status` remains "Draft". `per_billed` field was copied over from previous
+	doc (PO), hence it is recalculated for setting new correct status of PR.
+"""
+
+import frappe
+
+logger = frappe.logger("patch", allow_site=True, file_count=50)
+
+def execute():
+	affected_purchase_receipts = frappe.db.sql(
+		"""select name from `tabPurchase Receipt`
+		where status = 'Draft' and per_billed = 100 and docstatus = 1"""
+	)
+
+	if not affected_purchase_receipts:
+		return
+
+	logger.info("purchase_receipt_status: begin patch, PR count: {}"
+				.format(len(affected_purchase_receipts)))
+
+
+	for pr in affected_purchase_receipts:
+		pr_name = pr[0]
+		logger.info("purchase_receipt_status: patching PR - {}".format(pr_name))
+
+		pr_doc = frappe.get_doc("Purchase Receipt", pr_name)
+
+		pr_doc.update_billing_status(update_modified=False)
+		pr_doc.set_status(update=True, update_modified=False)

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -176,7 +176,7 @@ class PurchaseReceipt(BuyingController):
 		if flt(self.per_billed) < 100:
 			self.update_billing_status()
 		else:
-			self.status = "Completed"
+			self.db_set("status", "Completed")
 
 
 		# Updating stock ledger should always be called after updating prevdoc status,


### PR DESCRIPTION
Steps to reproduce:

1. Create a PO
2. Create PI from the PO with 100% qty.
3. Create PR from PO with 100% qty.
4. Refresh the PR page 1-2 times. (important) 
5. Check "More info" section of PR. It will have "Draft" status but 100% billed.

Unexpected behaviour: 
1. New PR has 100% billed percentage. (gets copied from PO it was created with, which is incorrect in case of partial / mix PRs)
2. Because of 100% status icon shows Completed however `doc.status` is still in draft. 

ToDo:

- [x] Add tests for reproducing both issues
- [x] Fix updation of status if 100% completed
- [x] Do not copy percentage billed
- [x] Write patch for existing records


Closes #23489
Related issues: ISS-20-21-10948, ISS-20-21-10868