### PR TITLE
fix: Salary Structure object has no attribute set_totals

### DIFF
--- a/erpnext/payroll/doctype/salary_slip/salary_slip.js
+++ b/erpnext/payroll/doctype/salary_slip/salary_slip.js
@@ -216,7 +216,7 @@ frappe.ui.form.on('Salary Slip Timesheet', {
 });
 
 var set_totals = function(frm) {
-	if (frm.doc.docstatus === 0) {
+	if (frm.doc.docstatus === 0 && frm.doc.doctype === "Salary Slip") {
 		if (frm.doc.earnings || frm.doc.deductions) {
 			frappe.call({
 				method: "set_totals",


### PR DESCRIPTION
Backport: https://github.com/frappe/erpnext/pull/25113

**Problem (Not always replicated)**:

While settings components in the Salary Detail table in the Salary Structure, this error was thrown. The reason being, the same Salary Detail table is used in Salary Structure and Salary Slip, so it tries to call `set_totals` in Salary Structure.

![bug-salary-structure](https://user-images.githubusercontent.com/24353136/113247229-3a155580-92d8-11eb-965d-2951d8572a77.png)

**Fix**:  Check whether the parent doctype is Salary Slip