### PR TITLE
fix(Payroll): component amount calculation based on formula with abbr not working

### DIFF
--- a/erpnext/payroll/doctype/salary_slip/salary_slip.py
+++ b/erpnext/payroll/doctype/salary_slip/salary_slip.py
@@ -618,12 +618,15 @@ class SalarySlip(TransactionBase):
 
 			component_row = self.append(component_type)
 			for attr in (
-				'depends_on_payment_days', 'salary_component', 'abbr'
+				'depends_on_payment_days', 'salary_component',
 				'do_not_include_in_total', 'is_tax_applicable',
 				'is_flexible_benefit', 'variable_based_on_taxable_salary',
 				'exempted_from_income_tax'
 			):
 				component_row.set(attr, component_data.get(attr))
+
+			abbr = component_data.get('abbr') or component_data.get('salary_component_abbr')
+			component_row.set('abbr', abbr)
 
 		if additional_salary:
 			component_row.default_amount = 0

--- a/erpnext/payroll/doctype/salary_structure/salary_structure.py
+++ b/erpnext/payroll/doctype/salary_structure/salary_structure.py
@@ -100,7 +100,7 @@ class SalaryStructure(Document):
 					from_date=from_date, base=base, variable=variable, income_tax_slab=income_tax_slab)
 			else:
 				assign_salary_structure_for_employees(employees, self,
-					payroll_payable_account=payroll_payable_account, 
+					payroll_payable_account=payroll_payable_account,
 					from_date=from_date, base=base, variable=variable, income_tax_slab=income_tax_slab)
 		else:
 			frappe.msgprint(_("No Employee Found"))


### PR DESCRIPTION
Fixes: https://github.com/frappe/erpnext/issues/25036

### Problem

Component amount calculation based on a formula with abbreviation not working 

### Steps to replicate

Create the following documents:

**Salary Structure:**

![image](https://user-images.githubusercontent.com/24353136/113248630-f839de80-92da-11eb-88ea-9f485943a102.png)

**Salary Structure Assignment:**

![image](https://user-images.githubusercontent.com/24353136/113248684-0be54500-92db-11eb-9826-4c403ccae916.png)

**Salary Slip created from Payroll Entry:**

![salary-comp-abbr-before](https://user-images.githubusercontent.com/24353136/113258340-73a28c80-92e9-11eb-87e2-eaba86b17166.gif)

### After Fix

![salary-comp-abbr-after](https://user-images.githubusercontent.com/24353136/113258019-03940680-92e9-11eb-8f8e-9ce533d2d371.gif)

