### PR TITLE
fix: Query values incorrectly escaped while back updating Quality Inspection

### DIFF
--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.py
@@ -64,17 +64,21 @@ class QualityInspection(Document):
 					(quality_inspection, self.modified, self.reference_name, self.item_code))
 
 		else:
+			args = [quality_inspection, self.modified, self.reference_name, self.item_code]
 			doctype = self.reference_type + ' Item'
+
 			if self.reference_type == 'Stock Entry':
 				doctype = 'Stock Entry Detail'
 
 			if self.reference_type and self.reference_name:
 				conditions = ""
 				if self.batch_no and self.docstatus == 1:
-					conditions += " and t1.batch_no = '%s'"%(self.batch_no)
+					conditions += " and t1.batch_no = %s"
+					args.append(self.batch_no)
 
 				if self.docstatus == 2: # if cancel, then remove qi link wherever same name
-					conditions += " and t1.quality_inspection = '%s'"%(self.name)
+					conditions += " and t1.quality_inspection = %s"
+					args.append(self.name)
 
 				frappe.db.sql("""
 					UPDATE
@@ -87,7 +91,7 @@ class QualityInspection(Document):
 						and t1.parent = t2.name
 						{conditions}
 				""".format(parent_doc=self.reference_type, child_doc=doctype, conditions=conditions),
-					(quality_inspection, self.modified, self.reference_name, self.item_code))
+					args)
 
 	def inspect_and_set_status(self):
 		for reading in self.readings:


### PR DESCRIPTION
**Issue:**
- On submission, the QI back updates the transaction it was made against
- Here on line **75**, in the  `batch_no` condition , if the batch no had a '%' sign the cursor raised an error
![Screenshot 2021-04-01 at 12 05 43 PM](https://user-images.githubusercontent.com/25857446/113258639-d2680600-92e9-11eb-8364-b858cd792c41.png)
- Even though the no. of arguments were enough, the unescaped '%' sign made the cursor ignore that `t1.batch_no` value, making it seem like there was one less argument.

**Fix:**
- args passed via `frappe.db.sql` are automatically escaped. So pass all args, conditional and static, via `frappe.db.sql`
- Avoid string formatting unless you want to manually escape each conditional argument