### PR TITLE
fix: validation msg for TransDocNo e-invoicing

### DIFF
--- a/erpnext/regional/india/e_invoice/einv_validation.json
+++ b/erpnext/regional/india/e_invoice/einv_validation.json
@@ -919,7 +919,8 @@
         "minLength": 1,
         "maxLength": 15,
         "pattern": "^([0-9A-Z/-]){1,15}$",
-        "description": "Tranport Document Number"
+        "description": "Tranport Document Number",
+        "validationMsg": "Transport Receipt No is invalid"
       },
       "TransDocDt": {
         "type": "string",


### PR DESCRIPTION
If in Sales Invoice, an invalid value was entered for Transport Receipt No following error used to occur. 

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2021-03-24/apps/frappe/frappe/app.py", line 67, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-12-2021-03-24/apps/frappe/frappe/api.py", line 59, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-12-2021-03-24/apps/frappe/frappe/handler.py", line 24, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-12-2021-03-24/apps/frappe/frappe/handler.py", line 64, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-12-2021-03-24/apps/frappe/frappe/__init__.py", line 1074, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-12-2021-03-24/apps/erpnext/erpnext/regional/india/e_invoice/utils.py", line 813, in get_einvoice
    return make_einvoice(invoice)
  File "/home/frappe/benches/bench-version-12-2021-03-24/apps/erpnext/erpnext/regional/india/e_invoice/utils.py", line 372, in make_einvoice
    throw_error_list(errors, _('E Invoice Validation Failed'))
  File "/home/frappe/benches/bench-version-12-2021-03-24/apps/erpnext/erpnext/regional/india/e_invoice/utils.py", line 378, in throw_error_list
    li = ['
'+ d +'
' for d in errors]
  File "/home/frappe/benches/bench-version-12-2021-03-24/apps/erpnext/erpnext/regional/india/e_invoice/utils.py", line 378, in 
    li = ['
'+ d +'
' for d in errors]
TypeError: must be str, not NoneType
```