### PR TITLE
fix: serial no refresh issue

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -737,26 +737,32 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 				this.frm.trigger("item_code", cdt, cdn);
 			}
 			else {
-				var valid_serial_nos = [];
-				var serialnos = [];
 				// Replacing all occurences of comma with carriage return
 				item.serial_no = item.serial_no.replace(/,/g, '\n');
-				serialnos = item.serial_no.split("\n");
-				for (var i = 0; i < serialnos.length; i++) {
-					if (serialnos[i] != "") {
-						valid_serial_nos.push(serialnos[i]);
-					}
-				}
 				item.conversion_factor = item.conversion_factor || 1;
-
 				refresh_field("serial_no", item.name, item.parentfield);
-				if(!doc.is_return && cint(user_defaults.set_qty_in_transactions_based_on_serial_no_input)) {
-					frappe.model.set_value(item.doctype, item.name,
-						"qty", valid_serial_nos.length / item.conversion_factor);
-					frappe.model.set_value(item.doctype, item.name, "stock_qty", valid_serial_nos.length);
+				if(!doc.is_return && cint(frappe.user_defaults.set_qty_in_transactions_based_on_serial_no_input)) {
+					setTimeout(() => {
+						me.update_qty(cdt, cdn)
+					}, 10000)
 				}
 			}
 		}
+	},
+
+	update_qty: function(cdt, cdn){
+		var valid_serial_nos = [];
+		var serialnos = [];
+		var item = frappe.get_doc(cdt, cdn);
+		serialnos = item.serial_no.split("\n");
+		for (var i = 0; i < serialnos.length; i++) {
+			if (serialnos[i] != "") {
+				valid_serial_nos.push(serialnos[i]);
+			}
+		}
+		frappe.model.set_value(item.doctype, item.name,
+			"qty", valid_serial_nos.length / item.conversion_factor);
+		frappe.model.set_value(item.doctype, item.name, "stock_qty", valid_serial_nos.length);
 	},
 
 	validate: function() {

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -741,16 +741,16 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 				item.serial_no = item.serial_no.replace(/,/g, '\n');
 				item.conversion_factor = item.conversion_factor || 1;
 				refresh_field("serial_no", item.name, item.parentfield);
-				if(!doc.is_return && cint(frappe.user_defaults.set_qty_in_transactions_based_on_serial_no_input)) {
+				if (!doc.is_return && cint(frappe.user_defaults.set_qty_in_transactions_based_on_serial_no_input)) {
 					setTimeout(() => {
-						me.update_qty(cdt, cdn)
-					}, 10000)
+						me.update_qty(cdt, cdn);
+					}, 10000);
 				}
 			}
 		}
 	},
 
-	update_qty: function(cdt, cdn){
+	update_qty: function(cdt, cdn) {
 		var valid_serial_nos = [];
 		var serialnos = [];
 		var item = frappe.get_doc(cdt, cdn);


### PR DESCRIPTION
**Issue:**

1. While scanning serial numbers in transaction documents like Purchase Receipt, some serial numbers used to disappear.
2. This was happening because the call chain that triggers after entering the serial number wasn't as fast as the next input entry.

![Purcahse receipt scanning](https://user-images.githubusercontent.com/31363128/113276156-2defbf00-92fd-11eb-84b9-369a65d7b4e4.gif)


**Fix:** 
1. The call chain has been throttled so that it doesn't trigger after every serial number entered.