### PR TITLE
fix(India): create property setters for shorter naming series on setup

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/test_records.json
+++ b/erpnext/accounts/doctype/sales_invoice/test_records.json
@@ -31,7 +31,7 @@
   "base_grand_total": 561.8,
   "grand_total": 561.8,
   "is_pos": 0,
-  "naming_series": "_T-Sales Invoice-",
+  "naming_series": "T-SINV-",
   "base_net_total": 500.0,
   "taxes": [
    {
@@ -104,7 +104,7 @@
   "base_grand_total": 630.0,
   "grand_total": 630.0,
   "is_pos": 0,
-  "naming_series": "_T-Sales Invoice-",
+  "naming_series": "T-SINV-",
   "base_net_total": 500.0,
   "taxes": [
    {
@@ -175,7 +175,7 @@
   ],
   "grand_total": 0,
   "is_pos": 0,
-  "naming_series": "_T-Sales Invoice-",
+  "naming_series": "T-SINV-",
   "taxes": [
    {
     "account_head": "_Test Account Shipping Charges - _TC",
@@ -301,7 +301,7 @@
   ],
   "grand_total": 0,
   "is_pos": 0,
-  "naming_series": "_T-Sales Invoice-",
+  "naming_series": "T-SINV-",
   "taxes": [
    {
     "account_head": "_Test Account Excise Duty - _TC",

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -2115,6 +2115,7 @@ def create_sales_invoice(**args):
 	si.return_against = args.return_against
 	si.currency=args.currency or "INR"
 	si.conversion_rate = args.conversion_rate or 1
+	si.naming_series = args.naming_series or "T-SINV-"
 
 	si.append("items", {
 		"item_code": args.item or args.item_code or "_Test Item",

--- a/erpnext/regional/india/setup.py
+++ b/erpnext/regional/india/setup.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 
 import frappe, os, json
 from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+from frappe.custom.doctype.property_setter.property_setter import make_property_setter
 from frappe.permissions import add_permission, update_permission_property
 from erpnext.regional.india import states
 from erpnext.accounts.utils import get_fiscal_year, FiscalYearError
@@ -18,6 +19,7 @@ def setup(company=None, patch=True):
 # TODO: for all countries
 def setup_company_independent_fixtures():
 	make_custom_fields()
+	make_property_setters()
 	add_permissions()
 	add_custom_roles_for_reports()
 	frappe.enqueue('erpnext.regional.india.setup.add_hsn_sac_codes', now=frappe.flags.in_test)
@@ -109,6 +111,11 @@ def add_print_formats():
 	frappe.db.set_value("Print Format", "GST POS Invoice", "disabled", 0)
 	frappe.db.set_value("Print Format", "GST Tax Invoice", "disabled", 0)
 	frappe.db.set_value("Print Format", "GST E-Invoice", "disabled", 0)
+
+def make_property_setters():
+	# GST rules do not allow for an invoice no. bigger than 16 characters
+	make_property_setter('Sales Invoice', 'naming_series', 'options', 'SINV-.YY.-\nSRET-.YY.-', '')
+	make_property_setter('Purchase Invoice', 'naming_series', 'options', 'PINV-.YY.-\nPRET-.YY.-', '')
 
 def make_custom_fields(update=True):
 	hsn_sac_field = dict(fieldname='gst_hsn_code', label='HSN/SAC',


### PR DESCRIPTION
- This is in compliance with GST Rules and is being done to avoid ValidationError.
- FIxed relevant tests as well.