### PR TITLE
fix(regional): remove shipping address GSTIN validation for e-invoice

### DIFF
--- a/erpnext/regional/india/e_invoice/utils.py
+++ b/erpnext/regional/india/e_invoice/utils.py
@@ -86,10 +86,10 @@ def get_doc_details(invoice):
 		invoice_date=invoice_date
 	))
 
-def get_party_details(address_name):
+def get_party_details(address_name, company_address=None, billing_address=None, shipping_address=None):
 	d = frappe.get_all('Address', filters={'name': address_name}, fields=['*'])[0]
 
-	if (not d.gstin
+	if ((not d.gstin and not shipping_address)
 		or not d.city
 		or not d.pincode
 		or not d.address_title
@@ -107,13 +107,16 @@ def get_party_details(address_name):
 		# according to einvoice standard
 		pincode = 999999
 
-	return frappe._dict(dict(
-		gstin=d.gstin, legal_name=d.address_title,
+	address_details = frappe._dict(dict(
+		legal_name=d.address_title,
 		location=d.city, pincode=d.pincode,
 		state_code=d.gst_state_number,
 		address_line1=d.address_line1,
 		address_line2=d.address_line2
 	))
+	if d.gstin:
+		address_details.gstin = d.gstin
+	return address_details
 
 def get_gstin_details(gstin):
 	if not hasattr(frappe.local, 'gstin_cache'):
@@ -322,12 +325,12 @@ def make_einvoice(invoice):
 	item_list = get_item_list(invoice)
 	doc_details = get_doc_details(invoice)
 	invoice_value_details = get_invoice_value_details(invoice)
-	seller_details = get_party_details(invoice.company_address)
+	seller_details = get_party_details(invoice.company_address, company_address=1)
 
 	if invoice.gst_category == 'Overseas':
 		buyer_details = get_overseas_address_details(invoice.customer_address)
 	else:
-		buyer_details = get_party_details(invoice.customer_address)
+		buyer_details = get_party_details(invoice.customer_address, billing_address=1)
 		place_of_supply = get_place_of_supply(invoice, invoice.doctype) or invoice.billing_address_gstin
 		place_of_supply = place_of_supply[:2]
 		buyer_details.update(dict(place_of_supply=place_of_supply))
@@ -337,7 +340,7 @@ def make_einvoice(invoice):
 		if invoice.gst_category == 'Overseas':
 			shipping_details = get_overseas_address_details(invoice.shipping_address_name)
 		else:
-			shipping_details = get_party_details(invoice.shipping_address_name)
+			shipping_details = get_party_details(invoice.shipping_address_name, shipping_address=1)
 	
 	if invoice.is_pos and invoice.base_paid_amount:
 		payment_details = get_payment_details(invoice)

--- a/erpnext/regional/india/e_invoice/utils.py
+++ b/erpnext/regional/india/e_invoice/utils.py
@@ -107,7 +107,7 @@ def get_party_details(address_name, company_address=None, billing_address=None, 
 		# according to einvoice standard
 		pincode = 999999
 
-	address_details = frappe._dict(dict(
+	party_address_details = frappe._dict(dict(
 		legal_name=d.address_title,
 		location=d.city, pincode=d.pincode,
 		state_code=d.gst_state_number,
@@ -115,8 +115,8 @@ def get_party_details(address_name, company_address=None, billing_address=None, 
 		address_line2=d.address_line2
 	))
 	if d.gstin:
-		address_details.gstin = d.gstin
-	return address_details
+		party_address_details.gstin = d.gstin
+	return party_address_details
 
 def get_gstin_details(gstin):
 	if not hasattr(frappe.local, 'gstin_cache'):


### PR DESCRIPTION
We have one case in which the billing address has GSTIN but the shipping address has no GSTIN. I checked Adaequare API and that also has no validation on this for the shipping address.