### PR TITLE
fix: get_route_options_for_new_doc for Project

### DIFF
--- a/erpnext/projects/doctype/project/project.js
+++ b/erpnext/projects/doctype/project/project.js
@@ -18,8 +18,8 @@ frappe.ui.form.on("Project", {
 		};
 	},
 	onload: function (frm) {
-		var so = frappe.meta.get_docfield("Project", "sales_order");
-		so.get_route_options_for_new_doc = function (field) {
+		const so = frm.get_docfield("sales_order");
+		so.get_route_options_for_new_doc = () => {
 			if (frm.is_new()) return;
 			return {
 				"customer": frm.doc.customer,


### PR DESCRIPTION
**Issue:** Previously, `get_route_options_for_new_doc` was not working while creating Sales Order from Project due to which `Customer` & `Project Name` were not getting auto-populated. This was happening because we were setting `get_route_options_for_new_doc in wrong` `df`.
**Solution:**
Use `get_docfield` in `frm` which gets the right `df`

port-of: https://github.com/frappe/erpnext/pull/25141