### PR TITLE
fix: broken link to shopping cart docs

### DIFF
--- a/erpnext/shopping_cart/doctype/shopping_cart_settings/shopping_cart_settings.js
+++ b/erpnext/shopping_cart/doctype/shopping_cart_settings/shopping_cart_settings.js
@@ -16,9 +16,9 @@ frappe.ui.form.on("Shopping Cart Settings", {
 		if (frm.doc.enabled) {
 			frm.get_field('store_page_docs').$wrapper.removeClass('hide-control').html(
 				`<div>${__("Follow these steps to create a landing page for your store")}:
-					<a href="https://docs.erpnext.com/docs/user/manual/en/website/store-landing-page"
+					<a href="https://docs.erpnext.com/docs/user/manual/en/website/shopping-cart"
 						style="color: var(--gray-600)">
-						docs/store-landing-page
+						docs/shopping-cart
 					</a>
 				</div>`
 			);


### PR DESCRIPTION
Changed link to correct link to shopping cart settings: https://docs.erpnext.com/docs/user/manual/en/website/shopping-cart 