### PR TITLE
fix: object referencing the same address issue

### DIFF
--- a/erpnext/regional/india/e_invoice/utils.py
+++ b/erpnext/regional/india/e_invoice/utils.py
@@ -397,7 +397,7 @@ def safe_json_load(json_string):
 		frappe.throw(_("Error in input data. Please check for any special characters near following input: <br> {}").format(snippet))
 
 def validate_einvoice(validations, einvoice, errors=None):
-	if not errors:
+	if errors is None:
 		errors = []
 	for fieldname, field_validation in validations.items():
 		value = einvoice.get(fieldname, None)
@@ -412,12 +412,12 @@ def validate_einvoice(validations, einvoice, errors=None):
 
 			if isinstance(value, list):
 				for d in value:
-					errors = validate_einvoice(child_validations, d, errors)
+					validate_einvoice(child_validations, d, errors)
 					if not d:
 						# remove empty dicts
 						einvoice.pop(fieldname, None)
 			else:
-				errors = validate_einvoice(child_validations, value, errors)
+				validate_einvoice(child_validations, value, errors)
 				if not value:
 					# remove empty dicts
 					einvoice.pop(fieldname, None)

--- a/erpnext/regional/india/e_invoice/utils.py
+++ b/erpnext/regional/india/e_invoice/utils.py
@@ -372,7 +372,7 @@ def make_einvoice(invoice):
 	einvoice = safe_json_load(einvoice)
 
 	validations = json.loads(read_json('einv_validation'))
-	errors = validate_einvoice(validations, einvoice)
+	errors = validate_einvoice(validations, einvoice, [])
 	if errors:
 		message = "\n".join([
 			"E Invoice: ", json.dumps(einvoice, indent=4),
@@ -396,7 +396,7 @@ def safe_json_load(json_string):
 		snippet = json_string[start:end]
 		frappe.throw(_("Error in input data. Please check for any special characters near following input: <br> {}").format(snippet))
 
-def validate_einvoice(validations, einvoice, errors=[]):
+def validate_einvoice(validations, einvoice, errors):
 	for fieldname, field_validation in validations.items():
 		value = einvoice.get(fieldname, None)
 		if not value or value == "None":

--- a/erpnext/regional/india/e_invoice/utils.py
+++ b/erpnext/regional/india/e_invoice/utils.py
@@ -372,7 +372,7 @@ def make_einvoice(invoice):
 	einvoice = safe_json_load(einvoice)
 
 	validations = json.loads(read_json('einv_validation'))
-	errors = validate_einvoice(validations, einvoice, [])
+	errors = validate_einvoice(validations, einvoice)
 	if errors:
 		message = "\n".join([
 			"E Invoice: ", json.dumps(einvoice, indent=4),
@@ -396,7 +396,9 @@ def safe_json_load(json_string):
 		snippet = json_string[start:end]
 		frappe.throw(_("Error in input data. Please check for any special characters near following input: <br> {}").format(snippet))
 
-def validate_einvoice(validations, einvoice, errors):
+def validate_einvoice(validations, einvoice, errors=None):
+	if not errors:
+		errors = []
 	for fieldname, field_validation in validations.items():
 		value = einvoice.get(fieldname, None)
 		if not value or value == "None":
@@ -410,12 +412,12 @@ def validate_einvoice(validations, einvoice, errors):
 
 			if isinstance(value, list):
 				for d in value:
-					validate_einvoice(child_validations, d, errors)
+					errors = validate_einvoice(child_validations, d, errors)
 					if not d:
 						# remove empty dicts
 						einvoice.pop(fieldname, None)
 			else:
-				validate_einvoice(child_validations, value, errors)
+				errors = validate_einvoice(child_validations, value, errors)
 				if not value:
 					# remove empty dicts
 					einvoice.pop(fieldname, None)


### PR DESCRIPTION
Scenario:

While generating IRN, the validation error is not refreshing on every click. It gets append to the previous log due to the error log object referring to the same memory address.

Before fix:

![error](https://user-images.githubusercontent.com/36359901/113423011-5f46b880-93eb-11eb-91ed-81198248af34.gif)

After fix:

![fix](https://user-images.githubusercontent.com/36359901/113423025-6372d600-93eb-11eb-995b-3cc926f206d1.gif)
