### PR TITLE
fix: incorrect batch picked in subcontracted purchase receipt

### DIFF
--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -6,6 +6,7 @@ import frappe
 from frappe import _, msgprint
 from frappe.utils import flt,cint, cstr, getdate
 from six import iteritems
+from collections import OrderedDict
 from erpnext.accounts.party import get_party_details
 from erpnext.stock.get_item_details import get_conversion_factor
 from erpnext.buying.utils import validate_for_items, update_last_purchase_rate
@@ -325,10 +326,12 @@ class BuyingController(StockController):
 
 					batches_qty = get_batches_with_qty(raw_material.rm_item_code, raw_material.main_item_code,
 						qty, transferred_batch_qty_map, backflushed_batch_qty_map, item.purchase_order)
+
 					for batch_data in batches_qty:
 						qty = batch_data['qty']
 						raw_material.batch_no = batch_data['batch']
-						self.append_raw_material_to_be_backflushed(item, raw_material, qty)
+						if qty > 0:
+							self.append_raw_material_to_be_backflushed(item, raw_material, qty)
 				else:
 					self.append_raw_material_to_be_backflushed(item, raw_material, qty)
 
@@ -1009,7 +1012,7 @@ def get_transferred_batch_qty_map(purchase_order, fg_item):
 	for batch_data in transferred_batches:
 		key = ((batch_data.item_code, fg_item)
 			if batch_data.subcontracted_item else (batch_data.item_code, purchase_order))
-		transferred_batch_qty_map.setdefault(key, {})
+		transferred_batch_qty_map.setdefault(key, OrderedDict())
 		transferred_batch_qty_map[key][batch_data.batch_no] = batch_data.qty
 
 	return transferred_batch_qty_map
@@ -1062,8 +1065,14 @@ def get_batches_with_qty(item_code, fg_item, required_qty, transferred_batch_qty
 		if available_qty >= required_qty:
 			available_batches.append({'batch': batch, 'qty': required_qty})
 			break
-		else:
+		elif available_qty != 0:
 			available_batches.append({'batch': batch, 'qty': available_qty})
 			required_qty -= available_qty
+
+	for row in available_batches:
+		if backflushed_batches.get(row.get('batch'), 0) > 0:
+			backflushed_batches[row.get('batch')] += row.get('qty')
+		else:
+			backflushed_batches[row.get('batch')] = row.get('qty')
 
 	return available_batches


### PR DESCRIPTION
**Issue**

1. Create subcontracted purchase order for batched items 
2. Transferred 2 batches of same raw material to the supplier
3. Create partial purchase receipt, while creating second purchase receipt you will get below error message

![image](https://user-images.githubusercontent.com/8780500/113473602-142eb300-9488-11eb-97ee-b1c68f7e1603.png)

Check support ticket ISS-21-22-00046
