### PR TITLE
fix: Ignore Permission for Leave Ledger Entry

### DIFF
--- a/erpnext/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
+++ b/erpnext/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
@@ -52,7 +52,9 @@ def create_leave_ledger_entry(ref_doc, args, submit=True):
 	ledger.update(args)
 
 	if submit:
-		frappe.get_doc(ledger).submit()
+		doc = frappe.get_doc(ledger)
+		doc.flags.ignore_permissions = 1
+		doc.submit()
 	else:
 		delete_ledger_entry(ledger)
 


### PR DESCRIPTION
Leave Ledger Entry being an internal document created by the system and not any user, should not require explicit permissions for creation. This PR adds a flag to ignore permissions on Leave Ledger Entry.