### PR TITLE
fix: correct calculation for discount amount when margin is set

### DIFF
--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -113,10 +113,10 @@ class calculate_taxes_and_totals(object):
 					item.rate_with_margin, item.base_rate_with_margin = self.calculate_margin(item)
 					if flt(item.rate_with_margin) > 0:
 						item.rate = flt(item.rate_with_margin * (1.0 - (item.discount_percentage / 100.0)), item.precision("rate"))
-						if not item.discount_amount:
-							item.discount_amount = item.rate_with_margin - item.rate
-						elif not item.discount_percentage:
+						if item.discount_amount and not item.discount_percentage:
 							item.rate -= item.discount_amount
+						else:
+							item.discount_amount = item.rate_with_margin - item.rate
 					elif flt(item.price_list_rate) > 0:
 						item.discount_amount = item.price_list_rate - item.rate
 				elif flt(item.price_list_rate) > 0 and not item.discount_amount:


### PR DESCRIPTION
Discount amount needs to be re-calculated in cases where **Rate with Margin** AND **Discount Percentage** exist, as discount percentage is applicable on rate with margin and earlier discount amount calculated on rate without margin would be incorrect.

**Failing test:**
https://github.com/frappe/erpnext/runs/2259456987#step:11:384
### Before:

![image](https://user-images.githubusercontent.com/38958184/113479566-751cb200-94ad-11eb-8752-f1d99873d07c.png)

### After:

![image](https://user-images.githubusercontent.com/38958184/113479663-faa06200-94ad-11eb-843f-3f8a9d4f6914.png)
