### PR TITLE
fix: keyerror while validating coa file

### DIFF
--- a/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py
+++ b/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py
@@ -293,6 +293,11 @@ def validate_accounts(file_name):
 	accounts_dict = {}
 	for account in accounts:
 		accounts_dict.setdefault(account["account_name"], account)
+		if not hasattr(account, "parent_account"):
+			msg = _("Please make sure the file you are using has 'Parent Account' column present in the header.")
+			msg += "<br><br>"
+			msg += _("Alternatively, you can download the template and fill your data in.")
+			frappe.throw(msg)
 		if account["parent_account"] and accounts_dict.get(account["parent_account"]):
 			accounts_dict[account["parent_account"]]["is_group"] = 1
 

--- a/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py
+++ b/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py
@@ -297,7 +297,7 @@ def validate_accounts(file_name):
 			msg = _("Please make sure the file you are using has 'Parent Account' column present in the header.")
 			msg += "<br><br>"
 			msg += _("Alternatively, you can download the template and fill your data in.")
-			frappe.throw(msg)
+			frappe.throw(msg, title=_("Parent Account Missing"))
 		if account["parent_account"] and accounts_dict.get(account["parent_account"]):
 			accounts_dict[account["parent_account"]]["is_group"] = 1
 


### PR DESCRIPTION
If a file with no parent account column is used for importing COA, then validating accounts throws `KeyError: 'parent_account'`

Note: This happens only if a new column for eg. an account number column is added to the template & the parent account column is removed. Such that total columns remain the same. 

Ref Issue. ISS-21-22-00193