### PR TITLE
fix: incorrect incoming rate for the sales return

### DIFF
--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 import frappe, erpnext
 from frappe import _
 from frappe.model.meta import get_field_precision
+from erpnext.stock.utils import get_incoming_rate
 from frappe.utils import flt, get_datetime, format_datetime
 
 class StockOverReturnError(frappe.ValidationError): pass
@@ -386,9 +387,23 @@ def make_return_doc(doctype, source_name, target_doc=None):
 
 	return doclist
 
-def get_rate_for_return(voucher_type, voucher_no, item_code, return_against=None, item_row=None, voucher_detail_no=None):
+def get_rate_for_return(voucher_type, voucher_no, item_code, return_against=None,
+	item_row=None, voucher_detail_no=None, sle=None):
 	if not return_against:
 		return_against = frappe.get_cached_value(voucher_type, voucher_no, "return_against")
+
+	if not return_against and voucher_type == 'Sales Invoice' and sle:
+		return get_incoming_rate({
+			"item_code": sle.item_code,
+			"warehouse": sle.warehouse,
+			"posting_date": sle.get('posting_date'),
+			"posting_time": sle.get('posting_time'),
+			"qty": sle.actual_qty,
+			"serial_no": sle.get('serial_no'),
+			"company": sle.company,
+			"voucher_type": sle.voucher_type,
+			"voucher_no": sle.voucher_no
+		}, raise_error_if_no_rate=False)
 
 	return_against_item_field = get_return_against_item_fields(voucher_type)
 

--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -316,14 +316,16 @@ class SellingController(StockController):
 
 		items = self.get("items") + (self.get("packed_items") or [])
 		for d in items:
-			if not cint(self.get("is_return")):
+			if not self.get("return_against"):
 				# Get incoming rate based on original item cost based on valuation method
+				qty = flt(d.get('stock_qty') or d.get('actual_qty'))
+
 				d.incoming_rate = get_incoming_rate({
 					"item_code": d.item_code,
 					"warehouse": d.warehouse,
 					"posting_date": self.get('posting_date') or self.get('transaction_date'),
 					"posting_time": self.get('posting_time') or nowtime(),
-					"qty": -1 * flt(d.get('stock_qty') or d.get('actual_qty')),
+					"qty": qty if cint(self.get("is_return")) else (-1 * qty),
 					"serial_no": d.get('serial_no'),
 					"company": self.company,
 					"voucher_type": self.doctype,

--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
@@ -126,7 +126,7 @@ def repost_entries():
 		check_if_stock_and_account_balance_synced(today(), d.name)
 
 def get_repost_item_valuation_entries():
-	date = add_to_date(today(), hours=-12)
+	date = add_to_date(today(), hours=-4)
 
 	return frappe.db.sql(""" SELECT name from `tabRepost Item Valuation`
 		WHERE status != 'Completed' and creation <= %s and docstatus = 1

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -372,7 +372,8 @@ class update_entries_after(object):
 		elif sle.voucher_type in ("Purchase Receipt", "Purchase Invoice", "Delivery Note", "Sales Invoice"):
 			if frappe.get_cached_value(sle.voucher_type, sle.voucher_no, "is_return"):
 				from erpnext.controllers.sales_and_purchase_return import get_rate_for_return # don't move this import to top
-				rate = get_rate_for_return(sle.voucher_type, sle.voucher_no, sle.item_code, voucher_detail_no=sle.voucher_detail_no)
+				rate = get_rate_for_return(sle.voucher_type, sle.voucher_no, sle.item_code,
+					voucher_detail_no=sle.voucher_detail_no, sle = sle)
 			else:
 				if sle.voucher_type in ("Purchase Receipt", "Purchase Invoice"):
 					rate_field = "valuation_rate"


### PR DESCRIPTION
**Issue**

Make standalone sales invoice return entry with update stock and submit it. After submit check the stock ledger entry, you will found that the incoming rate has set as zero in the stock ledger entry. Due to zero incoming rate system has calculated incorrect valuation rate for the future entries.

<img width="205" alt="Screenshot 2021-02-12 at 1 18 34 PM" src="https://user-images.githubusercontent.com/8780500/107742626-6cbdbb80-6d35-11eb-96e2-24bc84fd38bb.png">


**After Fix**

<img width="271" alt="Screenshot 2021-02-12 at 1 20 25 PM" src="https://user-images.githubusercontent.com/8780500/107742686-88c15d00-6d35-11eb-8bf5-9c11cc8ed8f4.png">
