### PR TITLE
fix: condition for SLA status banner

### DIFF
--- a/erpnext/support/doctype/issue/issue.js
+++ b/erpnext/support/doctype/issue/issue.js
@@ -48,44 +48,62 @@ frappe.ui.form.on("Issue", {
 		}
 	},
 
-	refresh: function (frm) {
-		if (frm.doc.status !== "Closed") {
-			if (frm.doc.service_level_agreement && frm.doc.agreement_status === "Ongoing") {
-				frappe.call({
-					"method": "frappe.client.get",
-					args: {
-						doctype: "Service Level Agreement",
-						name: frm.doc.service_level_agreement
-					},
-					callback: function(data) {
-						let statuses = data.message.pause_sla_on;
-						const hold_statuses = [];
-						$.each(statuses, (_i, entry) => {
-							hold_statuses.push(entry.status);
-						});
-						if (hold_statuses.includes(frm.doc.status)) {
-							frm.dashboard.clear_headline();
-							let message = {"indicator": "orange", "msg": __("SLA is on hold since {0}", [moment(frm.doc.on_hold_since).fromNow(true)])};
-							frm.dashboard.set_headline_alert(
-								'<div class="row">' +
-									'<div class="col-xs-12">' +
-										'<span class="indicator whitespace-nowrap '+ message.indicator +'"><span>'+ message.msg +'</span></span> ' +
-									'</div>' +
-								'</div>'
-							);
-						} else {
-							set_time_to_resolve_and_response(frm);
-						}
-					}
-				});
-			}
+	refresh: function(frm) {
 
-			frm.add_custom_button(__("Close"), function () {
+		// alert messages
+		if (frm.doc.status !== "Closed" && frm.doc.service_level_agreement
+			&& frm.doc.agreement_status === "Ongoing") {
+			frappe.call({
+				"method": "frappe.client.get",
+				args: {
+					doctype: "Service Level Agreement",
+					name: frm.doc.service_level_agreement
+				},
+				callback: function(data) {
+					let statuses = data.message.pause_sla_on;
+					const hold_statuses = [];
+					$.each(statuses, (_i, entry) => {
+						hold_statuses.push(entry.status);
+					});
+					if (hold_statuses.includes(frm.doc.status)) {
+						frm.dashboard.clear_headline();
+						let message = { "indicator": "orange", "msg": __("SLA is on hold since {0}", [moment(frm.doc.on_hold_since).fromNow(true)]) };
+						frm.dashboard.set_headline_alert(
+							'<div class="row">' +
+							'<div class="col-xs-12">' +
+							'<span class="indicator whitespace-nowrap ' + message.indicator + '"><span>' + message.msg + '</span></span> ' +
+							'</div>' +
+							'</div>'
+						);
+					} else {
+						set_time_to_resolve_and_response(frm);
+					}
+				}
+			});
+		} else if (frm.doc.service_level_agreement) {
+			frm.dashboard.clear_headline();
+
+			let agreement_status = (frm.doc.agreement_status == "Fulfilled") ?
+				{ "indicator": "green", "msg": "Service Level Agreement has been fulfilled" } :
+				{ "indicator": "red", "msg": "Service Level Agreement Failed" };
+
+			frm.dashboard.set_headline_alert(
+				'<div class="row">' +
+				'<div class="col-xs-12">' +
+				'<span class="indicator whitespace-nowrap ' + agreement_status.indicator + '"><span class="hidden-xs">' + agreement_status.msg + '</span></span> ' +
+				'</div>' +
+				'</div>'
+			);
+		}
+
+		// buttons
+		if (frm.doc.status !== "Closed") {
+			frm.add_custom_button(__("Close"), function() {
 				frm.set_value("status", "Closed");
 				frm.save();
 			});
 
-			frm.add_custom_button(__("Task"), function () {
+			frm.add_custom_button(__("Task"), function() {
 				frappe.model.open_mapped_doc({
 					method: "erpnext.support.doctype.issue.issue.make_task",
 					frm: frm
@@ -93,23 +111,7 @@ frappe.ui.form.on("Issue", {
 			}, __("Create"));
 
 		} else {
-			if (frm.doc.service_level_agreement) {
-				frm.dashboard.clear_headline();
-
-				let agreement_status = (frm.doc.agreement_status == "Fulfilled") ?
-					{"indicator": "green", "msg": "Service Level Agreement has been fulfilled"} :
-					{"indicator": "red", "msg": "Service Level Agreement Failed"};
-
-				frm.dashboard.set_headline_alert(
-					'<div class="row">' +
-						'<div class="col-xs-12">' +
-							'<span class="indicator whitespace-nowrap '+ agreement_status.indicator +'"><span class="hidden-xs">'+ agreement_status.msg +'</span></span> ' +
-						'</div>' +
-					'</div>'
-				);
-			}
-
-			frm.add_custom_button(__("Reopen"), function () {
+			frm.add_custom_button(__("Reopen"), function() {
 				frm.set_value("status", "Open");
 				frm.save();
 			});


### PR DESCRIPTION
If the document is NOT in the closed state and fulfilled then there won't be any banner. This bug was introduced while fixing a bug related to buttons, so separated out code for showing buttons and showing banners.