### PR TITLE
fix (patch): Healthcare lab module rename fields

### DIFF
--- a/erpnext/patches/v13_0/healthcare_lab_module_rename_doctypes.py
+++ b/erpnext/patches/v13_0/healthcare_lab_module_rename_doctypes.py
@@ -18,6 +18,7 @@ def execute():
 
 		for old_dt, new_dt in doctypes.items():
 			if not frappe.db.table_exists(new_dt) and frappe.db.table_exists(old_dt):
+				frappe.reload_doc('healthcare', 'doctype', frappe.scrub(old_dt))
 				frappe.rename_doc('DocType', old_dt, new_dt, force=True)
 				frappe.reload_doc('healthcare', 'doctype', frappe.scrub(new_dt))
 				frappe.delete_doc_if_exists('DocType', old_dt)
@@ -35,6 +36,18 @@ def execute():
 				UPDATE `tab{0}`
 				SET parentfield = %(parentfield)s
 			""".format(doctype), {'parentfield': parentfield})
+
+		# copy renamed child table fields (fields were already renamed in old doctype json, hence sql)
+		frappe.db.sql("""UPDATE `tabNormal Test Result` SET lab_test_name = test_name""")
+		frappe.db.sql("""UPDATE `tabNormal Test Result` SET lab_test_event = test_event""")
+		frappe.db.sql("""UPDATE `tabNormal Test Result` SET lab_test_uom = test_uom""")
+		frappe.db.sql("""UPDATE `tabNormal Test Result` SET lab_test_comment = test_comment""")
+		frappe.db.sql("""UPDATE `tabNormal Test Template` SET lab_test_event = test_event""")
+		frappe.db.sql("""UPDATE `tabNormal Test Template` SET lab_test_uom = test_uom""")
+		frappe.db.sql("""UPDATE `tabDescriptive Test Result` SET lab_test_particulars = test_particulars""")
+		frappe.db.sql("""UPDATE `tabLab Test Group Template` SET lab_test_template = test_template""")
+		frappe.db.sql("""UPDATE `tabLab Test Group Template` SET lab_test_description = test_description""")
+		frappe.db.sql("""UPDATE `tabLab Test Group Template` SET lab_test_rate = test_rate""")
 
 		# rename field
 		frappe.reload_doc('healthcare', 'doctype', 'lab_test')

--- a/erpnext/patches/v13_0/setup_patient_history_settings_for_standard_doctypes.py
+++ b/erpnext/patches/v13_0/setup_patient_history_settings_for_standard_doctypes.py
@@ -8,6 +8,7 @@ def execute():
 
 	frappe.reload_doc("healthcare", "doctype", "Therapy Session")
 	frappe.reload_doc("healthcare", "doctype", "Inpatient Medication Order")
+	frappe.reload_doc("healthcare", "doctype", "Clinical Procedure")
 	frappe.reload_doc("healthcare", "doctype", "Patient History Settings")
 	frappe.reload_doc("healthcare", "doctype", "Patient History Standard Document Type")
 	frappe.reload_doc("healthcare", "doctype", "Patient History Custom Document Type")


### PR DESCRIPTION
- SQL to copy renamed field values, as the patch didn't handle renamed child table fields
- reload_doc Clinical Procedure, failing when migrating from v11