### PR TITLE
fix: remove nonexistent method from pick list

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -379,7 +379,6 @@ def create_stock_entry(pick_list):
 	else:
 		stock_entry = update_stock_entry_items_with_no_reference(pick_list, stock_entry)
 
-	stock_entry.set_incoming_rate()
 	stock_entry.set_actual_qty()
 	stock_entry.calculate_rate_and_amount()
 


### PR DESCRIPTION
This method is merged in calculate_rate_and_amount() during repost item valuation refactoring.

Ref:
https://github.com/nabinhait/erpnext/commit/e10f0a5a6cd344b0e2ea2b65a992b37e9a4594d6#diff-a160e3a8907dcdf28ce7728bb7dd45914ad8ab033489ea3de4c80fb1c4ca7fe9 