### PR TITLE
fixed special character recognition on bar-code scan in pos window.

### DIFF
--- a/erpnext/accounts/doctype/pos_settings/pos_settings.json
+++ b/erpnext/accounts/doctype/pos_settings/pos_settings.json
@@ -5,7 +5,8 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "invoice_fields"
+  "invoice_fields",
+  "over_ride_barcode_decode"
  ],
  "fields": [
   {
@@ -13,11 +14,17 @@
    "fieldtype": "Table",
    "label": "POS Field",
    "options": "POS Field"
+  },
+  {
+   "default": "0",
+   "fieldname": "over_ride_barcode_decode",
+   "fieldtype": "Check",
+   "label": "Allow Special Char On Scan"
   }
  ],
  "issingle": 1,
  "links": [],
- "modified": "2020-06-01 15:46:41.478928",
+ "modified": "2021-04-12 16:43:40.281959",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Settings",

--- a/erpnext/selling/page/point_of_sale/point_of_sale.py
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.py
@@ -258,3 +258,7 @@ def set_customer_info(fieldname, customer, value=""):
 		contact_doc.set('phone_nos', [{ 'phone': value, 'is_primary_mobile_no': 1}])
 		frappe.db.set_value('Customer', customer, 'mobile_no', value)
 	contact_doc.save()
+
+@frappe.whitelist()
+def get_pos_settings():
+	return frappe.get_single('POS Settings')


### PR DESCRIPTION
When a bar-code with a special characters like "-", "$" "_" etc is scanned in POS search field, the special characters are filtered out. 

this commit fixes #25293

Actual output: 
![Screenshot from 2021-04-12 15-59-16](https://user-images.githubusercontent.com/36509967/114380749-0c69bf80-9ba8-11eb-99c5-57e708b01c64.png)



Required Output: 
![Screenshot from 2021-04-12 15-55-44](https://user-images.githubusercontent.com/36509967/114380768-11c70a00-9ba8-11eb-8ea8-736d608a57fd.png)



