### PR TITLE
fix: invalid comparison between NoneType & float

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/utils.py
+++ b/erpnext/accounts/doctype/pricing_rule/utils.py
@@ -471,7 +471,7 @@ def apply_pricing_rule_on_transaction(doc):
 
 					if not d.get(pr_field): continue
 
-					if d.validate_applied_rule and doc.get(field) < d.get(pr_field):
+					if d.validate_applied_rule and doc.get(field, 0) < d.get(pr_field):
 						frappe.msgprint(_("User has not applied rule on the invoice {0}")
 							.format(doc.name))
 					else:


### PR DESCRIPTION
fix: TypeError: '<' not supported between instances of 'NoneType' and 'float'