### PR TITLE
fix: Zero amount completed delivery notes being shown in Sales Invoice get items

### DIFF
--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -325,7 +325,7 @@ def get_delivery_notes_to_be_billed(doctype, txt, searchfield, start, page_len, 
 			and status not in ("Stopped", "Closed") %(fcond)s
 			and (
 				(`tabDelivery Note`.is_return = 0 and `tabDelivery Note`.per_billed < 100)
-				or `tabDelivery Note`.grand_total = 0
+				or (`tabDelivery Note`.grand_total = 0 and `tabDelivery Note`.per_billed < 100)
 				or (
 					`tabDelivery Note`.is_return = 1
 					and return_against in (select name from `tabDelivery Note` where per_billed < 100)


### PR DESCRIPTION
Zero amount completely billed Delivery Notes still getting pulled in "Get Items From" Dialog in Sales Invoice

<img width="1316" alt="Screenshot 2021-04-13 at 6 38 33 PM" src="https://user-images.githubusercontent.com/42651287/114558310-2a0e5600-9c88-11eb-974e-58121dd6fee2.png">

<img width="1336" alt="Screenshot 2021-04-13 at 6 39 17 PM" src="https://user-images.githubusercontent.com/42651287/114558328-2e3a7380-9c88-11eb-95ad-d32679bc63f3.png">
