### PR TITLE
Chart of account importer fix and UK verified COA

### DIFF
--- a/erpnext/accounts/doctype/account/account_tree.js
+++ b/erpnext/accounts/doctype/account/account_tree.js
@@ -51,6 +51,15 @@ frappe.treeview_settings["Account"] = {
 			label: __('New Company'),
 			action: function() { frappe.new_doc("Company", true) },
 			condition: 'frappe.boot.user.can_create.indexOf("Company") !== -1'
+		},
+		{
+			label: __('Export Fixture'),
+			action: () => {
+				frappe.call({
+					method: 'erpnext.accounts.doctype.account.chart_of_accounts.chart_of_accounts.export_coa_to_json',
+					args: {company: frappe.treeview_settings['Account'].treeview.page.fields_dict.company.get_value()}
+				})},
+			condition: 'frappe.boot.developer_mode === 1 && frappe.boot.user.roles.indexOf("System Manager") !== -1'
 		}
 	],
 	fields: [

--- a/erpnext/accounts/doctype/account/account_tree.js
+++ b/erpnext/accounts/doctype/account/account_tree.js
@@ -58,7 +58,8 @@ frappe.treeview_settings["Account"] = {
 				frappe.call({
 					method: 'erpnext.accounts.doctype.account.chart_of_accounts.chart_of_accounts.export_coa_to_json',
 					args: {company: frappe.treeview_settings['Account'].treeview.page.fields_dict.company.get_value()}
-				})},
+				});
+			},
 			condition: 'frappe.boot.developer_mode === 1 && frappe.boot.user.roles.indexOf("System Manager") !== -1'
 		}
 	],

--- a/erpnext/accounts/doctype/account/chart_of_accounts/chart_of_accounts.py
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/chart_of_accounts.py
@@ -232,3 +232,22 @@ def build_tree_from_json(chart_template, chart_data=None):
 
 	_import_accounts(chart, None)
 	return accounts
+
+@frappe.whitelist()
+def export_coa_to_json(company):
+	"Export a company coa as a verified json chart template"
+	frappe.only_for('System Manager')
+	tree = get_chart(None, existing_company=company)
+	db_co = frappe.get_doc('Company', company)
+	country = db_co.country
+	country_code = frappe.get_value('Country', country, 'code')
+
+	data = {
+		'country_code': country_code,
+		'name': country + ' - Chart of Accounts',
+		'tree': tree
+	}
+
+	path = os.path.join(os.path.dirname(__file__), 'verified', country_code + '_chart_of_accounts.json')
+	with open(path, 'w') as fp:
+		json.dump(data, fp, indent=4)

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/gb_chart_of_accounts.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/gb_chart_of_accounts.json
@@ -1,0 +1,270 @@
+{
+    "country_code": "gb",
+    "name": "United Kingdom - Chart of Accounts",
+    "tree": {
+        "Assets": {
+            "root_type": "Asset",
+            "Current Assets": {
+                "Accounts Receivable": {
+                    "Debtors": {
+                        "account_type": "Receivable"
+                    }
+                },
+                "Cash at Bank and In Hand": {
+                    "account_type": "Cash",
+                    "Bank Accounts": {
+                        "account_type": "Bank",
+                        "Default Bank": {
+                            "account_type": "Bank"
+                        }
+                    },
+                    "Cash": {
+                        "account_type": "Cash"
+                    }
+                },
+                "Loans and Advances": {
+                    "Director Loans": {
+                        "is_group": 1,
+                        "account_number": ""
+                    },
+                    "Employee Advances": {
+                        "account_type": "Receivable"
+                    }
+                },
+                "Stocks": {
+                    "account_type": "Stock",
+                    "Stock": {
+                        "account_type": "Stock"
+                    }
+                },
+                "Tax Assets": {
+                    "VAT on Purchases": {
+                        "account_type": "Tax"
+                    }
+                }
+            },
+            "Fixed Assets": {
+                "Intangible Assets": {
+                    "Amortisation": {
+                        "account_type": "Fixed Asset"
+                    }
+                },
+                "Tangible Assets": {
+                    "Accumulated Depreciation": {
+                        "account_type": "Accumulated Depreciation"
+                    }
+                }
+            }
+        },
+        "Equity": {
+            "root_type": "Equity",
+            "Called Up Share Capital": {
+                "account_type": "Equity"
+            },
+            "Dividends Paid": {
+                "account_type": "Equity"
+            },
+            "Retained Profit": {
+                "account_type": "Equity"
+            },
+            "Revaluation Reserve": {
+                "account_type": "Equity"
+            }
+        },
+        "Expenditure": {
+            "root_type": "Expense",
+            "Accommodation Costs": {
+                "Light, Heat and Power": {
+                    "account_type": "Expense Account"
+                },
+                "Rent and Rates": {
+                    "account_type": "Expense Account"
+                },
+                "Repairs, Renewals and Maintenance": {
+                    "account_type": "Expense Account"
+                }
+            },
+            "Administrative Expenses": {
+                "Advertising and Promotions": {
+                    "account_type": "Expense Account"
+                },
+                "Bad Debts": {
+                    "account_type": "Expense Account"
+                },
+                "Banking and Financial Charges": {
+                    "account_type": "Expense Account"
+                },
+                "Depreciation": {
+                    "account_type": "Depreciation"
+                },
+                "Donations": {
+                    "Charities": {
+                        "account_type": "Expense Account"
+                    },
+                    "Grassroots Sports": {
+                        "account_type": "Expense Account"
+                    }
+                },
+                "Entertaining": {
+                    "Allowable Entertaining": {
+                        "account_type": "Expense Account"
+                    },
+                    "Disallowable Entertaining": {
+                        "account_type": "Expense Account"
+                    }
+                },
+                "Insurance": {
+                    "account_type": "Expense Account"
+                },
+                "Interest Paid": {
+                    "account_type": "Expense Account"
+                },
+                "Internet and Telephone": {
+                    "account_type": "Expense Account"
+                },
+                "Loss on Asset Disposal": {
+                    "account_type": "Expense Account"
+                },
+                "Penalties and Fines": {
+                    "account_type": "Expense Account"
+                },
+                "Post, Print & Stationery": {
+                    "account_type": "Expense Account"
+                },
+                "Sundry Expenses": {
+                    "Exchange Gain/Loss": {
+                        "account_type": "Expense Account"
+                    },
+                    "Rounding": {
+                        "account_type": "Round Off"
+                    },
+                    "Small Miscellaneous Expenses": {
+                        "account_type": "Expense Account"
+                    }
+                },
+                "Travel and Subsistence": {
+                    "account_type": "Expense Account"
+                },
+                "Vehicle Expenses": {
+                    "account_type": "Expense Account"
+                }
+            },
+            "Cost of Sales": {
+                "Cost of Goods Sold": {
+                    "account_type": "Cost of Goods Sold"
+                },
+                "Expenses Included In Valuation": {
+                    "account_type": "Expenses Included In Valuation"
+                },
+                "Stock Adjustment": {
+                    "account_type": "Stock Adjustment"
+                }
+            },
+            "Distribution Costs": {
+                "account_type": "Expense Account"
+            },
+            "Employment": {
+                "Accountancy and Audit": {
+                    "account_type": "Expense Account"
+                },
+                "Commission": {
+                    "account_type": "Expense Account"
+                },
+                "Consultancy": {
+                    "account_type": "Expense Account"
+                },
+                "Director Pensions": {
+                    "account_type": "Expense Account"
+                },
+                "Director Remuneration": {
+                    "account_type": "Expense Account"
+                },
+                "Legal and Professional Fees": {
+                    "account_type": "Expense Account"
+                },
+                "Salaries and Wages": {
+                    "account_type": "Expense Account"
+                },
+                "Subcontractors' Payments (CIS)": {
+                    "account_type": "Expense Account"
+                }
+            },
+            "Property Income Expenses": {
+                "Allowable Property Expenses": {
+                    "account_type": "Expense Account"
+                },
+                "Disallowable Property Expenses": {
+                    "account_type": "Expense Account"
+                }
+            },
+            "Trading Losses": {
+                "Losses from a Later Period Brought Back": {
+                    "account_type": "Expense Account"
+                },
+                "Losses from an Earlier Period Carried Forward": {
+                    "account_type": "Expense Account"
+                }
+            }
+        },
+        "Income": {
+            "root_type": "Income",
+            "Ancillary Income": {
+                "account_type": "Income Account"
+            },
+            "Income from Property": {
+                "account_type": "Income Account"
+            },
+            "Interest Received": {
+                "Non-trade Interest": {
+                    "account_type": "Income Account"
+                },
+                "Trade Interest": {
+                    "account_type": "Income Account"
+                }
+            },
+            "Turnover": {
+                "Sales": {
+                    "account_type": "Income Account"
+                }
+            }
+        },
+        "Liabilities": {
+            "root_type": "Liability",
+            "Current Liabilities": {
+                "Accounts Payable": {
+                    "Credit Cards": {
+                        "Default Credit Card": {
+                            "account_type": "Bank"
+                        }
+                    },
+                    "Creditors": {
+                        "account_type": "Payable"
+                    },
+                    "Payroll": {
+                        "Remuneration due after 9 months": {},
+                        "Remuneration due within 9 months": {}
+                    }
+                },
+                "Duty & Tax Liabilities": {
+                    "Corporation Tax Liability": {
+                        "account_type": "Tax"
+                    },
+                    "VAT Liability": {
+                        "account_type": "Tax"
+                    },
+                    "VAT on Sales": {
+                        "account_type": "Tax"
+                    }
+                },
+                "Stock Received But Not Billed": {
+                    "account_type": "Stock Received But Not Billed"
+                }
+            },
+            "Long-term Liabilities": {
+                "Liability Provision": {
+                    "account_type": "Payable"
+                }
+            }
+        }
+    }
+}

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/gb_chart_of_accounts.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/gb_chart_of_accounts.json
@@ -35,6 +35,9 @@
                     "account_type": "Stock",
                     "Stock": {
                         "account_type": "Stock"
+                    },
+                    "Capital Work In Progress": {
+                        "account_type": "Capital Work in Progress"
                     }
                 },
                 "Tax Assets": {
@@ -132,13 +135,13 @@
                     "account_type": "Expense Account"
                 },
                 "Sundry Expenses": {
-                    "Exchange Gain/Loss": {
-                        "account_type": "Expense Account"
-                    },
                     "Rounding": {
                         "account_type": "Round Off"
                     },
                     "Small Miscellaneous Expenses": {
+                        "account_type": "Expense Account"
+                    },
+                    "Exchange Loss": {
                         "account_type": "Expense Account"
                     }
                 },
@@ -158,6 +161,9 @@
                 },
                 "Stock Adjustment": {
                     "account_type": "Stock Adjustment"
+                },
+                "Expenses Included In Asset Valuation": {
+                    "account_type": "Expenses Included In Asset Valuation"
                 }
             },
             "Distribution Costs": {
@@ -204,6 +210,12 @@
                 "Losses from an Earlier Period Carried Forward": {
                     "account_type": "Expense Account"
                 }
+            },
+            "Deferred Expense": {
+                "account_type": "Expense Account"
+            },
+            "Unrealised Loss": {
+                "account_type": "Expense Account"
             }
         },
         "Income": {
@@ -226,6 +238,9 @@
                 "Sales": {
                     "account_type": "Income Account"
                 }
+            },
+            "Deferred Revenue": {
+                "account_type": "Income Account"
             }
         },
         "Liabilities": {
@@ -256,14 +271,23 @@
                         "account_type": "Tax"
                     }
                 },
-                "Stock Received But Not Billed": {
-                    "account_type": "Stock Received But Not Billed"
+                "Received But Not Billed": {
+                    "Service Received But Not Billed": {
+                        "account_type": "Service Received But Not Billed"
+                    },
+                    "Stock Received But Not Billed": {
+                        "account_type": "Stock Received But Not Billed"
+                    },
+                    "Asset Received But Not Billed": {
+                        "account_type": "Asset Received But Not Billed"
+                    }
                 }
             },
             "Long-term Liabilities": {
                 "Liability Provision": {
                     "account_type": "Payable"
-                }
+                },
+                "Unrealised Liability": {}
             }
         }
     }

--- a/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py
+++ b/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py
@@ -293,7 +293,7 @@ def validate_accounts(file_name):
 	accounts_dict = {}
 	for account in accounts:
 		accounts_dict.setdefault(account["account_name"], account)
-		if not hasattr(account, "parent_account"):
+		if not account.get("parent_account", "") and (not account.get("is_group", 0) or not account.get("root_type", "")):
 			msg = _("Please make sure the file you are using has 'Parent Account' column present in the header.")
 			msg += "<br><br>"
 			msg += _("Alternatively, you can download the template and fill your data in.")


### PR DESCRIPTION
**feat**: uk / gb chart of accounts
**feat**: add function and button for exporting chart of accounts for submission to github

![Screen Shot 2021-04-14 at 07 33 44](https://user-images.githubusercontent.com/64409021/114664568-cde11b80-9cf3-11eb-8813-d7d2c790ee6a.png)


**fix**: bug causing import failure on root accounts

![Screen Shot 2021-04-14 at 07 46 55](https://user-images.githubusercontent.com/64409021/114666017-a55a2100-9cf5-11eb-8b33-40f48b419de3.png)


```
Traceback (most recent call last):
  File "/home/frappe/erpnextv13/apps/frappe/frappe/app.py", line 67, in application
    response = frappe.api.handle()
  File "/home/frappe/erpnextv13/apps/frappe/frappe/api.py", line 58, in handle
    return frappe.handler.handle()
  File "/home/frappe/erpnextv13/apps/frappe/frappe/handler.py", line 32, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/erpnextv13/apps/frappe/frappe/handler.py", line 68, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/erpnextv13/apps/frappe/frappe/__init__.py", line 1165, in call
    return fn(*args, **newargs)
  File "/home/frappe/erpnextv13/apps/erpnext/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py", line 300, in validate_accounts
    frappe.throw(msg, title=_("Parent Account Missing"))
  File "/home/frappe/erpnextv13/apps/frappe/frappe/__init__.py", line 423, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red', is_minimizable=is_minimizable, wide=wide, as_list=as_list)
  File "/home/frappe/erpnextv13/apps/frappe/frappe/__init__.py", line 402, in msgprint
    _raise_exception()
  File "/home/frappe/erpnextv13/apps/frappe/frappe/__init__.py", line 356, in _raise_exception
    raise raise_exception(msg)
frappe.exceptions.ValidationError: Please make sure the file you are using has 'Parent Account' column present in the header.<br><br>Alternatively, you can download the template and fill your data in.
```