### PR TITLE
fix: designation insufficient permission on lead doctype.

### DIFF
--- a/erpnext/hr/doctype/designation/designation.json
+++ b/erpnext/hr/doctype/designation/designation.json
@@ -182,6 +182,10 @@
    "share": 1,
    "submit": 0,
    "write": 1
+  },
+  {
+   "read": 1,
+   "role": "Sales User"
   }
  ],
  "quick_entry": 1,


### PR DESCRIPTION
At present for v13 stable, Designation doctype's permissions is limited to 'HR User'.

At creating lead, Designation field is linked with Designation. In some use-cases, for generating leads, only Sales User or Sales Manager permissions are assigned. Hence, Insufficient permission validations appears.
Refer: https://discuss.erpnext.com/t/insufficient-permission-for-designation-new-lead-doctype/73963

For more details: https://github.com/frappe/erpnext/issues/25327