### PR TITLE
fix: currency symbol in bank transaction list view

### DIFF
--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.json
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.json
@@ -175,22 +175,24 @@
   },
   {
    "fieldname": "deposit",
-   "oldfieldname": "debit",
    "fieldtype": "Currency",
    "in_list_view": 1,
-   "label": "Deposit"
+   "label": "Deposit",
+   "oldfieldname": "debit",
+   "options": "currency"
   },
   {
    "fieldname": "withdrawal",
-   "oldfieldname": "credit",
    "fieldtype": "Currency",
    "in_list_view": 1,
-   "label": "Withdrawal"
+   "label": "Withdrawal",
+   "oldfieldname": "credit",
+   "options": "currency"
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2020-12-30 19:40:54.221070",
+ "modified": "2021-04-14 17:31:58.963529",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Bank Transaction",


### PR DESCRIPTION
Error: The representation of the Currency in Bank Transaction ListView is incorrect - 

![image](https://user-images.githubusercontent.com/25369014/114707699-28a46280-9d48-11eb-95d3-4b630053c64d.png)

![image](https://user-images.githubusercontent.com/25369014/114707771-3bb73280-9d48-11eb-87b4-27ff326d9b3a.png)
