### PR TITLE
perf: Fetching exchange rate on every line item slows down PO

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1103,6 +1103,8 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 				to_currency: to_currency,
 				args: args
 			},
+			freeze: true,
+			freeze_message: __("Fetching exchange rates ..."),
 			callback: function(r) {
 				callback(flt(r.message));
 			}

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -611,8 +611,12 @@ def get_price_list_rate(args, item_doc, out):
 	meta = frappe.get_meta(args.parenttype or args.doctype)
 
 	if meta.get_field("currency") or args.get('currency'):
-		pl_details = get_price_list_currency_and_exchange_rate(args)
-		args.update(pl_details)
+		if not args.get("price_list_currency") or not args.get("plc_conversion_rate"):
+			# if currency and plc_conversion_rate exist then
+			# `get_price_list_currency_and_exchange_rate` has already been called
+			pl_details = get_price_list_currency_and_exchange_rate(args)
+			args.update(pl_details)
+
 		if meta.get_field("currency"):
 			validate_conversion_rate(args, meta)
 
@@ -993,6 +997,8 @@ def apply_price_list(args, as_doc=False):
 	args = process_args(args)
 
 	parent = get_price_list_currency_and_exchange_rate(args)
+	args.update(parent)
+
 	children = []
 
 	if "items" in args:

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -1057,7 +1057,7 @@ def get_price_list_currency_and_exchange_rate(args):
 	return frappe._dict({
 		"price_list_currency": price_list_currency,
 		"price_list_uom_dependant": price_list_uom_dependant,
-		"plc_conversion_rate": plc_conversion_rate
+		"plc_conversion_rate": plc_conversion_rate or 1
 	})
 
 @frappe.whitelist()


### PR DESCRIPTION
**Issue:**
- Set default currency as USD, create a company with default currency as USD
- Create two price lists for AED and USD, Create Item prices with currency AED and USD .
- Create an MR with more than one line item that have item prices created
- Create a PO from it
- change the currency to AED. It will throw multiple errors for not having exchange rate
- set the price list to an AED price list, it will again throw multiple errors for not having exchange rate, one for the parent form and one for each line item. This slows the system down in case there are 80 line items and freezes the page sometimes.
- This is all due to multi currency with a currency that is not supported by the frankfurter API.

> The error is not avoidable and is not wrong but the performance and unnecessary function calls can be better.

**Fix:**
- `get_price_list_currency_and_exchange_rate` is called once when the currency in the parent changes, and **n** times for each row while setting their rates (`rate*plc_conversion_rate`)
- at least while applying price list rate, if no price list currency conversion rate was found, default to 1
- it eventually multiplies each row's rate by 1 even if its 0 (not found) so just default to 1 in the first exchange rate fetch (parent), so that we don't call the api to fetch exchange rates on each row. Eliminates `get_exchange_rate` call here.
- Additionally in `get_price_list_rate` check if `price_list_currency` and `plc_conversion_rate` exist. If they do then `get_price_list_currency_and_exchange_rate` has been called before and need not be called again. Eliminate another function call here. 
- The error message will be visible once
------

> **Considered 41 Items for load testing. Each having an Item Price**
<h2>Performance Earlier:</h2>

- When either **conversion_rate** or **price list** or **plc_conversion_rate** is triggered `apply_price_list` is called that calls `get_price_list_currency_and_exchange_rate`, etc.
- It took 1.1 minute and displayed 42 errors. Also error log was flooded, due to error thrown for each row
![Screenshot 2021-04-15 at 3 52 14 PM](https://user-images.githubusercontent.com/25857446/114864570-c7939200-9e0e-11eb-80b4-8885ecbffcee.png)
- Min of 56.6 seconds on just triggering **conversion_rate**
 ![Screenshot 2021-04-15 at 3 57 35 PM](https://user-images.githubusercontent.com/25857446/114865081-691ae380-9e0f-11eb-8f27-250f99795d26.png)

<h2>Performance Now:</h2>

- Min of 1.91 seconds on just triggering **conversion_rate**
 ![Screenshot 2021-04-15 at 5 08 41 PM](https://user-images.githubusercontent.com/25857446/114865238-96679180-9e0f-11eb-86a6-728e03197cd1.png)
- Observed a **maximum** of 4.82 seconds on changing price list to price list with different currency whose conversion is missing. **Error thrown only once**. Price List Conversion Rate set to 1 after error, user can change the same.
![Screenshot 2021-04-15 at 4 06 45 PM](https://user-images.githubusercontent.com/25857446/114865655-32919880-9e10-11eb-815a-f1236b45afdb.png)
- Average times were approx 2.65 seconds - 4.85 seconds