### PR TITLE
fix: Additional Salary component amount not getting set

### DIFF
--- a/erpnext/payroll/doctype/salary_slip/salary_slip.py
+++ b/erpnext/payroll/doctype/salary_slip/salary_slip.py
@@ -633,6 +633,8 @@ class SalarySlip(TransactionBase):
 
 		if additional_salary:
 			component_row.default_amount = 0
+			component_row.additional_amount = amount
+			component_row.additional_salary = additional_salary.name
 			component_row.deduct_full_tax_on_selected_payroll_date = \
 				additional_salary.deduct_full_tax_on_selected_payroll_date
 		else:


### PR DESCRIPTION
**Problem:**

Additional Salary with amount 5000 created:

![image](https://user-images.githubusercontent.com/24353136/114866027-b0ee3a80-9e10-11eb-8412-6deb337a5388.png)

Amount is still 0 in Salary Slip:

![additional-salary](https://user-images.githubusercontent.com/24353136/114866198-e6932380-9e10-11eb-9820-b6727c73e31f.png)

**After Fix:**

![additional-salary-after-fix](https://user-images.githubusercontent.com/24353136/114866357-12aea480-9e11-11eb-8cc2-97964387af97.png)

Problem caught due to failing tests:

![photo_2021-04-15 17 37 03](https://user-images.githubusercontent.com/24353136/114866473-3d006200-9e11-11eb-8368-f989d887f6a9.jpeg)
