### PR TITLE
fix: shipment pickup_to, pickup_from functionality.

### DIFF
--- a/erpnext/stock/doctype/shipment/shipment.js
+++ b/erpnext/stock/doctype/shipment/shipment.js
@@ -363,43 +363,6 @@ frappe.ui.form.on('Shipment', {
 		if (frm.doc.pickup_date < frappe.datetime.get_today()) {
 			frappe.throw(__("Pickup Date cannot be before this day"));
 		}
-		if (frm.doc.pickup_date == frappe.datetime.get_today()) {
-			var pickup_time = frm.events.get_pickup_time(frm);
-			frm.set_value("pickup_from", pickup_time);
-			frm.trigger('set_pickup_to_time');
-		}
-	},
-	pickup_from: function(frm) {
-		var pickup_time = frm.events.get_pickup_time(frm);
-		if (frm.doc.pickup_from && frm.doc.pickup_date == frappe.datetime.get_today()) {
-			let current_hour = pickup_time.split(':')[0];
-			let current_min = pickup_time.split(':')[1];
-			let pickup_hour = frm.doc.pickup_from.split(':')[0];
-			let pickup_min = frm.doc.pickup_from.split(':')[1];
-			if (pickup_hour < current_hour || (pickup_hour == current_hour && pickup_min < current_min)) {
-				frm.set_value("pickup_from", pickup_time);
-				frappe.throw(__("Pickup Time cannot be in the past"));
-			}
-		}
-		frm.trigger('set_pickup_to_time');
-	},
-	get_pickup_time: function() {
-		let current_hour = new Date().getHours();
-		let current_min = new Date().toLocaleString('en-US', {minute: 'numeric'});
-		if (current_min < 30) {
-			current_min = '30';
-		} else {
-			current_min = '00';
-			current_hour = Number(current_hour)+1;
-		}
-		let pickup_time = current_hour +':'+ current_min;
-		return pickup_time;
-	},
-	set_pickup_to_time: function(frm) {
-		let pickup_to_hour = Number(frm.doc.pickup_from.split(':')[0])+5;
-		let pickup_to_min = frm.doc.pickup_from.split(':')[1];
-		let pickup_to = pickup_to_hour +':'+ pickup_to_min;
-		frm.set_value("pickup_to", pickup_to);
 	},
 	clear_pickup_fields: function(frm) {
 		let fields = ["pickup_address_name", "pickup_contact_name", "pickup_address", "pickup_contact", "pickup_contact_email", "pickup_contact_person"];

--- a/erpnext/stock/doctype/shipment/shipment.json
+++ b/erpnext/stock/doctype/shipment/shipment.json
@@ -275,14 +275,16 @@
    "default": "09:00",
    "fieldname": "pickup_from",
    "fieldtype": "Time",
-   "label": "Pickup from"
+   "label": "Pickup from",
+   "reqd": 1
   },
   {
    "allow_on_submit": 1,
    "default": "17:00",
    "fieldname": "pickup_to",
    "fieldtype": "Time",
-   "label": "Pickup to"
+   "label": "Pickup to",
+   "reqd": 1
   },
   {
    "fieldname": "column_break_36",
@@ -431,7 +433,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2020-12-25 15:02:34.891976",
+ "modified": "2021-04-13 17:14:18.181818",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Shipment",


### PR DESCRIPTION
### Description
- Removes auto entry of **Pickup to** and **Pickup from** fields in the **Shipment** DocType.
- Both fields have been made mandatory to force manual entry of values.


### Behaviour Before PR
**Pickup to** is auto set.
![before](https://user-images.githubusercontent.com/29507195/114554058-efa2ba00-9c83-11eb-878d-10e466536200.gif)

Setting **Pickup from** auto sets **Pickup to** 5 hours ahead, this leads to invalid values which breaks validation in controller.
![Screen Shot 2021-04-13 at 18 03 34](https://user-images.githubusercontent.com/29507195/114552801-98e8b080-9c82-11eb-8095-41f9b0f32c22.png)

### Behaviour After PR
**Pickup to** has to be manually set.
![after](https://user-images.githubusercontent.com/29507195/114554912-d3534d00-9c84-11eb-8f3c-8e5f6be7eb45.gif)

