### PR TITLE
fix: presentation currency in statement of accounts

### DIFF
--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.html
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.html
@@ -38,22 +38,22 @@
 					{% endif %}
 					</td>
 					<td style="text-align: right">
-						{{ frappe.utils.fmt_money(row.debit, filters.presentation_currency) }}</td>
+						{{ frappe.utils.fmt_money(row.debit, currency=filters.presentation_currency) }}</td>
 					<td style="text-align: right">
-						{{ frappe.utils.fmt_money(row.credit, filters.presentation_currency) }}</td>
+						{{ frappe.utils.fmt_money(row.credit, currency=filters.presentation_currency) }}</td>
 			{% else %}
 				<td></td>
 				<td></td>
 				<td><b>{{ frappe.format(row.account, {fieldtype: "Link"}) or "&nbsp;" }}</b></td>
 				<td style="text-align: right">
-					{{ row.account and frappe.utils.fmt_money(row.debit, filters.presentation_currency) }}
+					{{ row.account and frappe.utils.fmt_money(row.debit, currency=filters.presentation_currency) }}
 				</td>
 				<td style="text-align: right">
-					{{ row.account and frappe.utils.fmt_money(row.credit, filters.presentation_currency) }}
+					{{ row.account and frappe.utils.fmt_money(row.credit, currency=filters.presentation_currency) }}
 				</td>
 			{% endif %}
 				<td style="text-align: right">
-					{{ frappe.utils.fmt_money(row.balance, filters.presentation_currency) }}
+					{{ frappe.utils.fmt_money(row.balance, currency=filters.presentation_currency) }}
 				</td>
 			</tr>
 		{% endfor %}


### PR DESCRIPTION
Precision was passed as 'USD' which throws TypeError: 'str' object cannot be interpreted as an integer