### PR TITLE
fix: commit  changes to shipment status in database

### DIFF
--- a/.github/helper/semgrep_rules/frappe_correctness.yml
+++ b/.github/helper/semgrep_rules/frappe_correctness.yml
@@ -7,8 +7,26 @@ rules:
     - pattern-inside: |
         def on_submit(self, ...):
           ...
+    - metavariable-regex:
+        metavariable: '$ATTR'
+        # this is negative look-ahead, add more attrs to ignore like (ignore|ignore_this_too|ignore_me)
+        regex: '^(?!status_updater)(.*)$'
   message: |
     Doctype modified after submission. Please check if modification of self.$ATTR is commited to database.
+  languages: [python]
+  severity: ERROR
+
+- id: frappe-modifying-after-cancel
+  patterns:
+    - pattern: self.$ATTR = ...
+    - pattern-inside: |
+        def on_cancel(self, ...):
+          ...
+    - metavariable-regex:
+        metavariable: '$ATTR'
+        regex: '^(?!ignore_linked_doctypes|status_updater)(.*)$'
+  message: |
+    Doctype modified after cancellation. Please check if modification of self.$ATTR is commited to database.
   languages: [python]
   severity: ERROR
 

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -772,3 +772,4 @@ erpnext.patches.v12_0.purchase_receipt_status
 erpnext.patches.v13_0.fix_non_unique_represents_company
 erpnext.patches.v12_0.add_document_type_field_for_italy_einvoicing
 erpnext.patches.v13_0.make_non_standard_user_type #13-04-2021
+erpnext.patches.v13_0.update_shipment_status

--- a/erpnext/patches/v13_0/update_shipment_status.py
+++ b/erpnext/patches/v13_0/update_shipment_status.py
@@ -1,0 +1,14 @@
+import frappe
+
+def execute():
+	frappe.reload_doc("stock", "doctype", "shipment")
+
+	# update submitted status
+	frappe.db.sql("""UPDATE `tabShipment`
+					SET status = "Submitted"
+					WHERE status = "Draft" AND docstatus = 1""")
+
+	# update cancelled status
+	frappe.db.sql("""UPDATE `tabShipment`
+					SET status = "Cancelled"
+					WHERE status = "Draft" AND docstatus = 2""")

--- a/erpnext/stock/doctype/shipment/shipment.py
+++ b/erpnext/stock/doctype/shipment/shipment.py
@@ -23,10 +23,10 @@ class Shipment(Document):
 			frappe.throw(_('Please enter Shipment Parcel information'))
 		if self.value_of_goods == 0:
 			frappe.throw(_('Value of goods cannot be 0'))
-		self.status = 'Submitted'
+		self.db_set('status', 'Submitted')
 
 	def on_cancel(self):
-		self.status = 'Cancelled'
+		self.db_set('status', 'Cancelled')
 
 	def validate_weight(self):
 		for parcel in self.shipment_parcel:


### PR DESCRIPTION
Problem: The status change is not committed to the database. 
Steps to reproduce: 
- Create any shipment. 
- Submit it.
- Refresh page (important)
- Problem 1: Staus will be Draft but the indicator will show correctly as shown in the screenshot.
- Cancel shipment.
- Refresh page (important)
- Problem 2: status will still be in draft but the indicator will show cancelled.

Solution:
- use `db_set` to commit the change.
- Add patch to fix existing records
- add CI rule to catch similar errors for `on_cancel`

![image](https://user-images.githubusercontent.com/9079960/115110650-16b9fe00-9f9a-11eb-85e1-a91dbcdfa7c0.png)
