### PR TITLE
fix: Bulk Salary Structure Assignment

### DIFF
--- a/erpnext/payroll/doctype/salary_structure/salary_structure.js
+++ b/erpnext/payroll/doctype/salary_structure/salary_structure.js
@@ -133,8 +133,6 @@ frappe.ui.form.on('Salary Structure', {
 			title: __("Assign to Employees"),
 			fields: [
 				{fieldname: "sec_break", fieldtype: "Section Break", label: __("Filter Employees By (Optional)")},
-				{fieldname: "company", fieldtype: "Link", options: "Company", label: __("Company"), default: frm.doc.company, read_only:1},
-				{fieldname: "currency", fieldtype: "Link", options: "Currency", label: __("Currency"), default: frm.doc.currency, read_only:1},
 				{fieldname: "grade", fieldtype: "Link", options: "Employee Grade", label: __("Employee Grade")},
 				{fieldname:'department', fieldtype:'Link', options: 'Department', label: __('Department')},
 				{fieldname:'designation', fieldtype:'Link', options: 'Designation', label: __('Designation')},

--- a/erpnext/payroll/doctype/salary_structure/salary_structure.py
+++ b/erpnext/payroll/doctype/salary_structure/salary_structure.py
@@ -88,7 +88,7 @@ class SalaryStructure(Document):
 		return employees
 
 	@frappe.whitelist()
-	def assign_salary_structure(self, grade=None, department=None, designation=None,employee=None,
+	def assign_salary_structure(self, grade=None, department=None, designation=None, employee=None,
 			payroll_payable_account=None, from_date=None, base=None, variable=None, income_tax_slab=None):
 		employees = self.get_employees(company= self.company, grade= grade,department= department,designation= designation,name=employee)
 


### PR DESCRIPTION
While assigning Salary Structure in bulk using the **Assign to Employees** button even company and currency arguments are passed although the server-side function `assign_salary_structure` does not accept them as arguments.

We don't need to pass these arguments nor do we need filters for Company or Currency in the dialog since that is fetched from the Salary Structure document itself.

**Note**: The issue is not always replicated

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-13-2021-03-26/apps/frappe/frappe/app.py", line 67, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-13-2021-03-26/apps/frappe/frappe/api.py", line 58, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-13-2021-03-26/apps/frappe/frappe/handler.py", line 30, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-13-2021-03-26/apps/frappe/frappe/handler.py", line 70, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-13-2021-03-26/apps/frappe/frappe/__init__.py", line 1134, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-13-2021-03-26/apps/frappe/frappe/handler.py", line 101, in runserverobj
    frappe.desk.form.run_method.runserverobj(method, docs=docs, dt=dt, dn=dn, arg=arg, args=args)
  File "/home/frappe/benches/bench-version-13-2021-03-26/apps/frappe/frappe/desk/form/run_method.py", line 49, in runserverobj
    r = doc.run_method(method, **args)
  File "/home/frappe/benches/bench-version-13-2021-03-26/apps/frappe/frappe/model/document.py", line 848, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-version-13-2021-03-26/apps/frappe/frappe/model/document.py", line 1137, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-version-13-2021-03-26/apps/frappe/frappe/model/document.py", line 1120, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-version-13-2021-03-26/apps/frappe/frappe/model/document.py", line 842, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
TypeError: assign_salary_structure() got an unexpected keyword argument 'company'
```