### PR TITLE
feat: consider min and max qty for recursive pricing rule

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -120,6 +120,9 @@ class PricingRule(Document):
 		for other_field in cleanup_other_fields:
 			self.set(other_field, None)
 
+		if self.price_or_product_discount == 'Price' and self.is_recursive:
+			self.is_recursive = 0
+
 	def validate_rate_or_discount(self):
 		for field in ["Rate"]:
 			if flt(self.get(frappe.scrub(field))) < 0:


### PR DESCRIPTION
<img width="1093" alt="Screenshot 2021-04-19 at 5 33 06 PM" src="https://user-images.githubusercontent.com/8780500/115234183-5cabc900-a136-11eb-9a49-935740348264.png">

As min qty is 20 and max qty is 60 in above pricing rule with "Is Recursive"
On purchase of 65 qty system will increase the free item's qty to 2

<img width="286" alt="Screenshot 2021-04-19 at 6 07 32 PM" src="https://user-images.githubusercontent.com/8780500/115237400-2708df00-a13a-11eb-98c8-b3a0d2fd9605.png">
