### PR TITLE
fix: Ignore Customer Group Perm on All Products page

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/utils.py
+++ b/erpnext/accounts/doctype/pricing_rule/utils.py
@@ -173,7 +173,7 @@ def _get_tree_conditions(args, parenttype, table, allow_blank=True):
 		if parenttype in ["Customer Group", "Item Group", "Territory"]:
 			parent_field = "parent_{0}".format(frappe.scrub(parenttype))
 			root_name = frappe.db.get_list(parenttype,
-				{"is_group": 1, parent_field: ("is", "not set")}, "name", as_list=1)
+				{"is_group": 1, parent_field: ("is", "not set")}, "name", as_list=1, ignore_permissions=True)
 
 			if root_name and root_name[0][0]:
 				parent_groups.append(root_name[0][0])


### PR DESCRIPTION
**Issue**:
- While not logged in, if a user tries to go to the `/all-products` page it throws a permission error on Customer Group
- This happens precisely due to `frappe.db.get_list` that is used to just fetch the root customer group while getting pricing rules, nothing critical.
- It checks for permissions. Everywhere else we haven't used ORM which isn't interfering with fetching basic things
![cart-perm-issue](https://user-images.githubusercontent.com/25857446/115263923-76a7d480-a153-11eb-9925-06bbbe8ac9ea.gif)

**Fix:**
-  `frappe.db.get_list` is used due to the nature of the query (checking where `parent_field` is not set, more convenient with ORM)
- Let that be, `ignore_permissions` in it
- Product listing will be visible, while trying to add to cart user is redirected to login page
![cart-perm-fix](https://user-images.githubusercontent.com/25857446/115263679-3f392800-a153-11eb-879a-0e8bb477849b.gif)
