### PR TITLE
fix: Cashier query in POS Opening/Closing Entry

### DIFF
--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.py
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.py
@@ -89,8 +89,8 @@ class POSClosingEntry(StatusUpdater):
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
 def get_cashiers(doctype, txt, searchfield, start, page_len, filters):
-	cashiers_list = frappe.get_all("POS Profile User", filters=filters, fields=['user'])
-	return [c['user'] for c in cashiers_list]
+	cashiers_list = frappe.get_all("POS Profile User", filters=filters, fields=['user'], as_list=1)
+	return [c for c in cashiers_list]
 
 @frappe.whitelist()
 def get_pos_invoices(start, end, pos_profile, user):


### PR DESCRIPTION
**Issue**:
Custom query gave back list of strings `["a", "b"]`, that caused :
![Screenshot 2021-04-19 at 9 58 56 PM](https://user-images.githubusercontent.com/25857446/115270643-26804080-a15a-11eb-8398-2493ce1df25a.png)


**Fix:**
Custom link query must return an iterable of iterables `[["a"], ["b"]]` or `(("a",), ("b",))`, as it searches for title and subtitle in dropdown. Hence it assumes each result is an iterable.
![Screenshot 2021-04-19 at 9 56 48 PM](https://user-images.githubusercontent.com/25857446/115270453-f173ee00-a159-11eb-9f5a-be8e910dfb80.png)
