### PR TITLE
fix: permission error after submitting exchange rate revaluation

### DIFF
--- a/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.js
+++ b/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.js
@@ -21,21 +21,17 @@ frappe.ui.form.on('Exchange Rate Revaluation', {
 
 	refresh: function(frm) {
 		if(frm.doc.docstatus==1) {
-			frappe.db.get_value("Journal Entry Account", {
-				'reference_type': 'Exchange Rate Revaluation',
-				'reference_name': frm.doc.name,
-				'docstatus': 1
-			}, "sum(debit) as sum", (r) =>{
-				let total_amt = 0;
-				frm.doc.accounts.forEach(d=> {
-					total_amt = total_amt + d['new_balance_in_base_currency'];
-				});
-				if(total_amt !== r.sum) {
-					frm.add_custom_button(__('Journal Entry'), function() {
-						return frm.events.make_jv(frm);
-					}, __('Create'));
+			frappe.call({
+				method: 'check_journal_entry_condition',
+				doc: frm.doc,
+				callback: function(r) {
+					if (r.message) {
+						frm.add_custom_button(__('Journal Entry'), function() {
+							return frm.events.make_jv(frm);
+						}, __('Create'));
+					}
 				}
-			}, 'Journal Entry');
+			});			
 		}
 	},
 

--- a/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py
+++ b/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py
@@ -28,6 +28,23 @@ class ExchangeRateRevaluation(Document):
 			frappe.throw(_("Please select Company and Posting Date to getting entries"))
 
 	@frappe.whitelist()
+	def check_journal_entry_condition(self):
+		total_debit = frappe.db.get_value("Journal Entry Account", {
+			'reference_type': 'Exchange Rate Revaluation',
+			'reference_name': self.name,
+			'docstatus': 1
+		}, "sum(debit) as sum")
+
+		total_amt = 0
+		for d in self.accounts:
+			total_amt = total_amt + d.new_balance_in_base_currency
+
+		if total_amt != total_debit:
+			return True
+		
+		return False
+
+	@frappe.whitelist()
 	def get_accounts_data(self, account=None):
 		accounts = []
 		self.validate_mandatory()


### PR DESCRIPTION
To replicate the issue:
- Login with a user having only Account User role
- Create Exchange Rate Revaluation & Submit it
- Refresh the page.
- Permission error should pop up while trying to query Journal Entry Account