### PR TITLE
fix: can not create item variants

### DIFF
--- a/erpnext/controllers/item_variant.py
+++ b/erpnext/controllers/item_variant.py
@@ -262,7 +262,8 @@ def copy_attributes_to_variant(item, variant):
 	# copy non no-copy fields
 
 	exclude_fields = ["naming_series", "item_code", "item_name", "show_in_website",
-		"show_variant_in_website", "opening_stock", "variant_of", "valuation_rate"]
+		"show_variant_in_website", "opening_stock", "variant_of", "valuation_rate",
+		"has_variants", "attributes"]
 
 	if item.variant_based_on=='Manufacturer':
 		# don't copy manufacturer values if based on part no

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -773,3 +773,4 @@ erpnext.patches.v13_0.fix_non_unique_represents_company
 erpnext.patches.v12_0.add_document_type_field_for_italy_einvoicing
 erpnext.patches.v13_0.make_non_standard_user_type #13-04-2021
 erpnext.patches.v13_0.update_shipment_status
+erpnext.patches.v13_0.remove_attribute_field_from_item_variant_setting

--- a/erpnext/patches/v13_0/remove_attribute_field_from_item_variant_setting.py
+++ b/erpnext/patches/v13_0/remove_attribute_field_from_item_variant_setting.py
@@ -1,0 +1,8 @@
+import frappe
+
+def execute():
+	"""Remove has_variants and attribute fields from item variant settings."""
+	frappe.reload_doc("stock", "doctype", "Item Variant Settings")
+
+	frappe.db.sql("""delete from `tabVariant Field`
+			where field_name in ('attributes', 'has_variants')""")

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -63,7 +63,7 @@ class Item(WebsiteGenerator):
 			if self.variant_of:
 				if not self.item_code:
 					template_item_name = frappe.db.get_value("Item", self.variant_of, "item_name")
-					self.item_code = make_variant_item_code(self.variant_of, template_item_name, self)
+					make_variant_item_code(self.variant_of, template_item_name, self)
 			else:
 				from frappe.model.naming import set_name_by_naming_series
 				set_name_by_naming_series(self)

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -674,10 +674,10 @@ class Item(WebsiteGenerator):
 		if not records: return
 		document = _("Stock Reconciliation") if len(records) == 1 else _("Stock Reconciliations")
 
-		msg = _("The items {0} and {1} are present in the following {2} : ").format(
+		msg = _("The items {0} and {1} are present in the following {2} :").format(
 			frappe.bold(old_name), frappe.bold(new_name), document)
 
-		msg += '<br>'
+		msg += ' <br>'
 		msg += ', '.join([get_link_to_form("Stock Reconciliation", d.parent) for d in records]) + "<br><br>"
 
 		msg += _("Note: To merge the items, create a separate Stock Reconciliation for the old item {0}").format(

--- a/erpnext/stock/doctype/item_variant_settings/item_variant_settings.py
+++ b/erpnext/stock/doctype/item_variant_settings/item_variant_settings.py
@@ -13,10 +13,11 @@ class ItemVariantSettings(Document):
 	def set_default_fields(self):
 		self.fields = []
 		fields = frappe.get_meta('Item').fields
-		exclude_fields = ["naming_series", "item_code", "item_name", "show_in_website",
+		exclude_fields = {"naming_series", "item_code", "item_name", "show_in_website",
 			"show_variant_in_website", "standard_rate", "opening_stock", "image", "description",
 			"variant_of", "valuation_rate", "description", "barcodes",
-			"website_image", "thumbnail", "website_specifiations", "web_long_description"]
+			"website_image", "thumbnail", "website_specifiations", "web_long_description",
+			"has_variants", "attributes"}
 
 		for d in fields:
 			if not d.no_copy and d.fieldname not in exclude_fields and \


### PR DESCRIPTION
- Ignore two fields causing problem while creating variant.
- Also fix the setting of item_code to `None` while using naming series.


Closes #25037
Closes #25423