### PR TITLE
fix: Laboratory Module patch

### DIFF
--- a/erpnext/patches/v13_0/healthcare_lab_module_rename_doctypes.py
+++ b/erpnext/patches/v13_0/healthcare_lab_module_rename_doctypes.py
@@ -38,16 +38,37 @@ def execute():
 			""".format(doctype), {'parentfield': parentfield})
 
 		# copy renamed child table fields (fields were already renamed in old doctype json, hence sql)
-		frappe.db.sql("""UPDATE `tabNormal Test Result` SET lab_test_name = test_name""")
-		frappe.db.sql("""UPDATE `tabNormal Test Result` SET lab_test_event = test_event""")
-		frappe.db.sql("""UPDATE `tabNormal Test Result` SET lab_test_uom = test_uom""")
-		frappe.db.sql("""UPDATE `tabNormal Test Result` SET lab_test_comment = test_comment""")
-		frappe.db.sql("""UPDATE `tabNormal Test Template` SET lab_test_event = test_event""")
-		frappe.db.sql("""UPDATE `tabNormal Test Template` SET lab_test_uom = test_uom""")
-		frappe.db.sql("""UPDATE `tabDescriptive Test Result` SET lab_test_particulars = test_particulars""")
-		frappe.db.sql("""UPDATE `tabLab Test Group Template` SET lab_test_template = test_template""")
-		frappe.db.sql("""UPDATE `tabLab Test Group Template` SET lab_test_description = test_description""")
-		frappe.db.sql("""UPDATE `tabLab Test Group Template` SET lab_test_rate = test_rate""")
+		rename_fields = {
+			'lab_test_name': 'test_name',
+			'lab_test_event': 'test_event',
+			'lab_test_uom': 'test_uom',
+			'lab_test_comment': 'test_comment'
+		}
+
+		for new, old in rename_fields.items():
+			if frappe.db.has_column('Normal Test Result', old):
+				frappe.db.sql("""UPDATE `tabNormal Test Result` SET %(new)s = %(old)s""", {
+					'new': new, 'old': old})
+
+		if frappe.db.has_column('Normal Test Template', 'test_event'):
+			frappe.db.sql("""UPDATE `tabNormal Test Template` SET lab_test_event = test_event""")
+
+		if frappe.db.has_column('Normal Test Template', 'test_uom'):
+			frappe.db.sql("""UPDATE `tabNormal Test Template` SET lab_test_uom = test_uom""")
+
+		if frappe.db.has_column('Descriptive Test Result', 'test_particulars'):
+			frappe.db.sql("""UPDATE `tabDescriptive Test Result` SET lab_test_particulars = test_particulars""")
+
+		rename_fields = {
+			'lab_test_template': 'test_template',
+			'lab_test_description': 'test_description',
+			'lab_test_rate': 'test_rate'
+		}
+
+		for new, old in rename_fields.items():
+			if frappe.db.has_column('Lab Test Group Template', old):
+				frappe.db.sql("""UPDATE `tabLab Test Group Template` SET %(new)s = %(old)s""", {
+					'new': new, 'old': old})
 
 		# rename field
 		frappe.reload_doc('healthcare', 'doctype', 'lab_test')


### PR DESCRIPTION
Backport of: https://github.com/frappe/erpnext/pull/25431

Lab module patch breaking: https://github.com/frappe/erpnext/pull/25276
Check if the column exists before renaming.
```python
Executing erpnext.patches.v13_0.healthcare_lab_module_rename_doctypes in site1.local (_4bc010a720c49300)
Traceback (most recent call last):
File “/usr/lib/python3.6/runpy.py”, line 193, in _run_module_as_main
“main”, mod_spec)
File “/usr/lib/python3.6/runpy.py”, line 85, in _run_code
exec(code, run_globals)
File “/home/v13/frappe-bench/apps/frappe/frappe/utils/bench_helper.py”, line 101, in
main()
File “/home/v13/frappe-bench/apps/frappe/frappe/utils/bench_helper.py”, line 18, in main
click.Group(commands=commands)(prog_name=‘bench’)
File “/home/v13/frappe-bench/env/lib/python3.6/site-packages/click/core.py”, line 764, in call
return self.main(*args, **kwargs)
File “/home/v13/frappe-bench/env/lib/python3.6/site-packages/click/core.py”, line 717, in main
rv = self.invoke(ctx)
File “/home/v13/frappe-bench/env/lib/python3.6/site-packages/click/core.py”, line 1137, in invoke
return _process_result(sub_ctx.command.invoke(sub_ctx))
File “/home/v13/frappe-bench/env/lib/python3.6/site-packages/click/core.py”, line 1137, in invoke
return _process_result(sub_ctx.command.invoke(sub_ctx))
File “/home/v13/frappe-bench/env/lib/python3.6/site-packages/click/core.py”, line 956, in invoke
return ctx.invoke(self.callback, **ctx.params)
File “/home/v13/frappe-bench/env/lib/python3.6/site-packages/click/core.py”, line 555, in invoke
return callback(*args, **kwargs)
File “/home/v13/frappe-bench/env/lib/python3.6/site-packages/click/decorators.py”, line 17, in new_func
return f(get_current_context(), *args, **kwargs)
File “/home/v13/frappe-bench/apps/frappe/frappe/commands/init.py”, line 27, in _func
ret = f(frappe._dict(ctx.obj), *args, **kwargs)
File “/home/v13/frappe-bench/apps/frappe/frappe/commands/site.py”, line 300, in migrate
skip_search_index=skip_search_index
File “/home/v13/frappe-bench/apps/frappe/frappe/migrate.py”, line 67, in migrate
frappe.modules.patch_handler.run_all(skip_failing)
File “/home/v13/frappe-bench/apps/frappe/frappe/modules/patch_handler.py”, line 41, in run_all
run_patch(patch)
File “/home/v13/frappe-bench/apps/frappe/frappe/modules/patch_handler.py”, line 30, in run_patch
if not run_single(patchmodule = patch):
File “/home/v13/frappe-bench/apps/frappe/frappe/modules/patch_handler.py”, line 71, in run_single
return execute_patch(patchmodule, method, methodargs)
File “/home/v13/frappe-bench/apps/frappe/frappe/modules/patch_handler.py”, line 91, in execute_patch
frappe.get_attr(patchmodule.split()[0] + “.execute”)()
File “/home/v13/frappe-bench/apps/erpnext/erpnext/patches/v13_0/healthcare_lab_module_rename_doctypes.py”, line 41, in execute
frappe.db.sql(""“UPDATE tabNormal Test Result SET lab_test_name = test_name”"")
File “/home/v13/frappe-bench/apps/frappe/frappe/database/database.py”, line 152, in sql
self._cursor.execute(query)
File “/home/v13/frappe-bench/env/lib/python3.6/site-packages/pymysql/cursors.py”, line 170, in execute
result = self._query(query)
File “/home/v13/frappe-bench/env/lib/python3.6/site-packages/pymysql/cursors.py”, line 328, in _query
conn.query(q)
File “/home/v13/frappe-bench/env/lib/python3.6/site-packages/pymysql/connections.py”, line 517, in query
self._affected_rows = self._read_query_result(unbuffered=unbuffered)
File “/home/v13/frappe-bench/env/lib/python3.6/site-packages/pymysql/connections.py”, line 732, in _read_query_result
result.read()
File “/home/v13/frappe-bench/env/lib/python3.6/site-packages/pymysql/connections.py”, line 1075, in read
first_packet = self.connection._read_packet()
File “/home/v13/frappe-bench/env/lib/python3.6/site-packages/pymysql/connections.py”, line 684, in _read_packet
packet.check_error()
File “/home/v13/frappe-bench/env/lib/python3.6/site-packages/pymysql/protocol.py”, line 220, in check_error
err.raise_mysql_exception(self._data)
File “/home/v13/frappe-bench/env/lib/python3.6/site-packages/pymysql/err.py”, line 109, in raise_mysql_exception
raise errorclass(errno, errval)
pymysql.err.InternalError: (1054, “Unknown column ‘test_name’ in ‘field list’”)
```