### PR TITLE
fix: Backward compatibility for GSTR-1 report

### DIFF
--- a/erpnext/regional/report/gstr_1/gstr_1.py
+++ b/erpnext/regional/report/gstr_1/gstr_1.py
@@ -199,7 +199,7 @@ class Gstr1Report(object):
 		self.item_tax_rate = frappe._dict()
 
 		items = frappe.db.sql("""
-			select item_code, parent, taxable_value, item_tax_rate
+			select item_code, parent, taxable_value, base_net_amount, item_tax_rate
 			from `tab%s Item`
 			where parent in (%s)
 		""" % (self.doctype, ', '.join(['%s']*len(self.invoices))), tuple(self.invoices), as_dict=1)
@@ -207,7 +207,7 @@ class Gstr1Report(object):
 		for d in items:
 			if d.item_code not in self.invoice_items.get(d.parent, {}):
 				self.invoice_items.setdefault(d.parent, {}).setdefault(d.item_code,
-					sum(i.get('taxable_value', 0) for i in items
+					sum((i.get('taxable_value', 0) or i.get('base_net_amount', 0)) for i in items
 						if i.item_code == d.item_code and i.parent == d.parent))
 
 				item_tax_rate = {}


### PR DESCRIPTION
Use base_net_amount as a fallback value for old invoices if taxable value is 0 for GSTR-1 report