### PR TITLE
fix: 'StockEntry' object has no attribute 'set_incoming_rate'

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -378,9 +378,8 @@ def create_stock_entry(pick_list):
 	else:
 		stock_entry = update_stock_entry_items_with_no_reference(pick_list, stock_entry)
 
-	stock_entry.set_incoming_rate()
 	stock_entry.set_actual_qty()
-	stock_entry.calculate_rate_and_amount(update_finished_item_rate=False)
+	stock_entry.calculate_rate_and_amount()
 
 	return stock_entry.as_dict()
 


### PR DESCRIPTION
While creating the stock entry from pick list user getting the below error

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-13-2021-03-31/apps/frappe/frappe/app.py", line 67, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-13-2021-03-31/apps/frappe/frappe/api.py", line 58, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-13-2021-03-31/apps/frappe/frappe/handler.py", line 30, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-13-2021-03-31/apps/frappe/frappe/handler.py", line 70, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-13-2021-03-31/apps/frappe/frappe/__init__.py", line 1134, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-13-2021-03-31/apps/erpnext/erpnext/stock/doctype/pick_list/pick_list.py", line 381, in create_stock_entry
    stock_entry.set_incoming_rate()
AttributeError: 'StockEntry' object has no attribute 'set_incoming_rate'
```