### PR TITLE
fix(patch): lab module patch fix

### DIFF
--- a/erpnext/patches/v13_0/healthcare_lab_module_rename_doctypes.py
+++ b/erpnext/patches/v13_0/healthcare_lab_module_rename_doctypes.py
@@ -47,8 +47,8 @@ def execute():
 
 		for new, old in rename_fields.items():
 			if frappe.db.has_column('Normal Test Result', old):
-				frappe.db.sql("""UPDATE `tabNormal Test Result` SET %(new)s = %(old)s""", {
-					'new': new, 'old': old})
+				frappe.db.sql("""UPDATE `tabNormal Test Result` SET {} = {}"""
+					.format(old, new))
 
 		if frappe.db.has_column('Normal Test Template', 'test_event'):
 			frappe.db.sql("""UPDATE `tabNormal Test Template` SET lab_test_event = test_event""")
@@ -67,8 +67,8 @@ def execute():
 
 		for new, old in rename_fields.items():
 			if frappe.db.has_column('Lab Test Group Template', old):
-				frappe.db.sql("""UPDATE `tabLab Test Group Template` SET %(new)s = %(old)s""", {
-					'new': new, 'old': old})
+				frappe.db.sql("""UPDATE `tabLab Test Group Template` SET {} = {}"""
+					.format(old, new))
 
 		# rename field
 		frappe.reload_doc('healthcare', 'doctype', 'lab_test')

--- a/erpnext/patches/v13_0/healthcare_lab_module_rename_doctypes.py
+++ b/erpnext/patches/v13_0/healthcare_lab_module_rename_doctypes.py
@@ -48,7 +48,7 @@ def execute():
 		for new, old in rename_fields.items():
 			if frappe.db.has_column('Normal Test Result', old):
 				frappe.db.sql("""UPDATE `tabNormal Test Result` SET {} = {}"""
-					.format(old, new))
+					.format(new, old))
 
 		if frappe.db.has_column('Normal Test Template', 'test_event'):
 			frappe.db.sql("""UPDATE `tabNormal Test Template` SET lab_test_event = test_event""")
@@ -68,7 +68,7 @@ def execute():
 		for new, old in rename_fields.items():
 			if frappe.db.has_column('Lab Test Group Template', old):
 				frappe.db.sql("""UPDATE `tabLab Test Group Template` SET {} = {}"""
-					.format(old, new))
+					.format(new, old))
 
 		# rename field
 		frappe.reload_doc('healthcare', 'doctype', 'lab_test')


### PR DESCRIPTION
Fix, when migrating from old schema -

`ProgrammingError: (1064, "You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ''lab_test_name' = 'test_name'' at line 1")```