### PR TITLE
fix(HR): Permission error while adding weekly holidays

### DIFF
--- a/erpnext/hr/doctype/holiday_list/holiday_list.py
+++ b/erpnext/hr/doctype/holiday_list/holiday_list.py
@@ -16,6 +16,7 @@ class HolidayList(Document):
 		self.validate_days()
 		self.total_holidays = len(self.holidays)
 
+	@frappe.whitelist()
 	def get_weekly_off_dates(self):
 		self.validate_values()
 		date_list = self.get_weekly_off_date_list(self.from_date, self.to_date)


### PR DESCRIPTION
Fixes: https://github.com/frappe/erpnext/issues/25442

**Before**:

Permission error when trying to add weekly holidays using the **Add to Holidays** button

![image](https://user-images.githubusercontent.com/24353136/115759737-3730f080-a3be-11eb-9278-aa727eebaaa5.png)

**After**:

![holiday_list](https://user-images.githubusercontent.com/24353136/115760891-5aa86b00-a3bf-11eb-8c37-3ee3982b1b04.gif)

