### PR TITLE
fix: issue in project custom status

### DIFF
--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -179,9 +179,6 @@ class Project(Document):
 		if self.percent_complete == 100:
 			self.status = "Completed"
 
-		else:
-			self.status = "Open"
-
 	def update_costing(self):
 		from_time_sheet = frappe.db.sql("""select
 			sum(costing_amount) as costing_amount,


### PR DESCRIPTION
**Issue:**

https://user-images.githubusercontent.com/31363128/115819583-c40a9700-a41c-11eb-9624-617611dcca44.mp4

**Steps to Replicate:**
1. Customise the Project Doctype. Add custom Status. Save.
2. Create a new project. Change the Status as the custom status. Save.

**Actual Result:**
The status changes to Open after Save.

**Expected Result:**
The status should not change to Open after Save.

**Fix:**
Removed the else condition that was forcefully setting the status to Open.