### PR TITLE
fix: Incorrect GL Entry validation

### DIFF
--- a/erpnext/accounts/general_ledger.py
+++ b/erpnext/accounts/general_ledger.py
@@ -18,7 +18,8 @@ def make_gl_entries(gl_map, cancel=False, adv_adj=False, merge_entries=True, upd
 			gl_map = process_gl_map(gl_map, merge_entries)
 			if gl_map and len(gl_map) > 1:
 				save_entries(gl_map, adv_adj, update_outstanding, from_repost)
-			else:
+			# Post GL Map proccess there may no be any GL Entries
+			elif gl_map:
 				frappe.throw(_("Incorrect number of General Ledger Entries found. You might have selected a wrong Account in the transaction."))
 		else:
 			make_reverse_gl_entries(gl_map, adv_adj=adv_adj, update_outstanding=update_outstanding)

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -242,19 +242,15 @@ class AccountsController(TransactionBase):
 		if self.doctype == 'Sales Invoice':
 			party_account_field = 'debit_to'
 			item_field = 'income_account'
-			party_account_label = 'Debit To'
-			item_field_label = 'Income Account'
 		else:
 			party_account_field = 'credit_to'
 			item_field = 'expense_account'
-			party_account_label = 'Credit To'
-			item_field_label = 'Expense Account'
 
 		for item in self.get('items'):
 			if item.get(item_field) == self.get(party_account_field):
 				frappe.throw(_("Row {0}: {1} {2} cannot be same as {3} (Party Account) {4}").format(item.idx,
-					frappe.bold(item_field_label), item.get(item_field), frappe.bold(party_account_label),
-					self.get(party_account_field)))
+					frappe.bold(frappe.unscrub(item_field)), item.get(item_field),
+					frappe.bold(frappe.unscrub(party_account_field)), self.get(party_account_field)))
 
 	def validate_inter_company_reference(self):
 		if self.doctype not in ('Purchase Invoice', 'Purchase Receipt', 'Purchase Order'):

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -259,7 +259,7 @@ class AccountsController(TransactionBase):
 		if self.is_internal_transfer():
 			if not (self.get('inter_company_reference') or self.get('inter_company_invoice_reference')
 				or self.get('inter_company_order_reference')):
-				msg = _("Internal Sale or Delivery Reference missing. ")
+				msg = _("Internal Sale or Delivery Reference missing.")
 				msg += _("Please create purchase from internal sale or delivery document itself")
 				frappe.throw(msg, title=_("Internal Sales Reference Missing"))
 

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -90,6 +90,8 @@ class AccountsController(TransactionBase):
 		self.ensure_supplier_is_not_blocked()
 
 		self.validate_date_with_fiscal_year()
+		self.validate_party_accounts()
+
 		self.validate_inter_company_reference()
 
 		self.set_incoming_rate()
@@ -232,6 +234,27 @@ class AccountsController(TransactionBase):
 			if date_field and self.get(date_field):
 				validate_fiscal_year(self.get(date_field), self.fiscal_year, self.company,
 									 self.meta.get_label(date_field), self)
+
+	def validate_party_accounts(self):
+		if self.doctype not in ('Sales Invoice', 'Purchase Invoice'):
+			return
+
+		if self.doctype == 'Sales Invoice':
+			party_account_field = 'debit_to'
+			item_field = 'income_account'
+			party_account_label = 'Debit To'
+			item_field_label = 'Income Account'
+		else:
+			party_account_field = 'credit_to'
+			item_field = 'expense_account'
+			party_account_label = 'Credit To'
+			item_field_label = 'Expense Account'
+
+		for item in self.get('items'):
+			if item.get(item_field) == self.get(party_account_field):
+				frappe.throw(_("Row {0}: {1} {2} cannot be same as {3} (Party Account) {4}").format(item.idx,
+					frappe.bold(item_field_label), item.get(item_field), frappe.bold(party_account_label),
+					self.get(party_account_field)))
 
 	def validate_inter_company_reference(self):
 		if self.doctype not in ('Purchase Invoice', 'Purchase Receipt', 'Purchase Order'):


### PR DESCRIPTION
Do not throw validation error for incorrect GL entry if no GL entries exists

There may be cases that post GL Entry processing there is no GL entry to post, total debit might be equal to total credit, hence post-processing no GL Entry is there to post, in this case system gives incorrect GL entry validation if there is no GL Entry