### PR TITLE
feat(e-invoicing): auto calculate distance for e-way bill generations

### DIFF
--- a/erpnext/regional/india/e_invoice/einvoice.js
+++ b/erpnext/regional/india/e_invoice/einvoice.js
@@ -115,17 +115,19 @@ erpnext.setup_einvoice_actions = (doctype) => {
 					message += '<br><br>';
 					message += __('You must first use the portal to cancel the e-way bill and then update the cancelled status in the ERPNext system.');
 
-					frappe.msgprint({
+					const dialog = frappe.msgprint({
 						title: __('Update E-Way Bill Cancelled Status?'),
 						message: message,
 						indicator: 'orange',
-						primary_action: function() {
-							frappe.call({
-								method: 'erpnext.regional.india.e_invoice.utils.cancel_eway_bill',
-								args: { doctype, docname: name },
-								freeze: true,
-								callback: () => frm.reload_doc()
-							});
+						primary_action: {
+							action: function() {
+								frappe.call({
+									method: 'erpnext.regional.india.e_invoice.utils.cancel_eway_bill',
+									args: { doctype, docname: name },
+									freeze: true,
+									callback: () => frm.reload_doc() || dialog.hide()
+								});
+							}
 						},
 						primary_action_label: __('Yes')
 					});

--- a/erpnext/regional/india/e_invoice/utils.py
+++ b/erpnext/regional/india/e_invoice/utils.py
@@ -339,9 +339,7 @@ def get_eway_bill_details(invoice):
 	if invoice.is_return:
 		frappe.throw(_('E-Way Bill cannot be generated for Credit Notes & Debit Notes. Please clear fields in the Transporter Section of the invoice.'),
 			title=_('Invalid Fields'))
-	
-	if not invoice.distance:
-		frappe.throw(_('Distance is mandatory for generating e-way bill for an e-invoice.'), title=_('Missing Field'))
+
 
 	mode_of_transport = { '': '', 'Road': '1', 'Air': '2', 'Rail': '3', 'Ship': '4' }
 	vehicle_type = { 'Regular': 'R', 'Over Dimensional Cargo (ODC)': 'O' }
@@ -450,7 +448,7 @@ def make_einvoice(invoice):
 	if invoice.is_return:
 		prev_doc_details = get_return_doc_reference(invoice)
 
-	if invoice.transporter and flt(invoice.distance) and not invoice.is_return:
+	if invoice.transporter and not invoice.is_return:
 		eway_bill_details = get_eway_bill_details(invoice)
 
 	# not yet implemented
@@ -1027,12 +1025,12 @@ def generate_eway_bill(doctype, docname, **kwargs):
 	gsp_connector.generate_eway_bill(**kwargs)
 
 @frappe.whitelist()
-def cancel_eway_bill(doctype, docname, eway_bill, reason, remark):
+def cancel_eway_bill(doctype, docname):
 	# TODO: uncomment when eway_bill api from Adequare is enabled
 	# gsp_connector = GSPConnector(doctype, docname)
 	# gsp_connector.cancel_eway_bill(eway_bill, reason, remark)
 
-	# update cancelled status only, to be able to cancel irn next
+	frappe.db.set_value(doctype, docname, 'ewaybill', '')
 	frappe.db.set_value(doctype, docname, 'eway_bill_cancelled', 1)
 
 @frappe.whitelist()


### PR DESCRIPTION
While generating IRNs, If the distance is set as zero and other transporter details are set properly, then the system auto-calculates the distance (in the background) and generates e-way bill no.

<img width="864" alt="Screenshot 2021-04-26 at 5 10 13 PM" src="https://user-images.githubusercontent.com/25369014/116076797-55df0200-a6b2-11eb-9aa1-fe3e913f1463.png">
