### PR TITLE
chore: remove frappe from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-frappe
+# frappe   # https://github.com/frappe/frappe is installed during bench-init
 gocardless-pro~=1.22.0
 googlemaps  # used in ERPNext, but dependency is defined in Frappe
 pandas~=1.1.5


### PR DESCRIPTION
Due to recent changes in pip dependency resolver, in some random cases, pip thinks frappe is not installed and tries to fetch it from pypi, which results in errors like #25496

Until a better solution is available, frappe should not be part of requirements.txt

`frappe` in requirements.txt does nothing other than indicating dependency to the reader.

Alternatives:
- use relative path and editable install `-e '../frappe'`. Con: hardcoding path, might cause reinstall. Pros: will never fetch from pypi.
- use `git:` url in requirements.txt. Con: This will cause unnecessary re-fetching of the package, will have to deal with versioning separately. 
- use old dependency resolver and older pip (this is removed in latest pip) `--use-deprecated=legacy-resolver` 