### PR TITLE
fix: Include search fields in Project Link field query

### DIFF
--- a/erpnext/projects/doctype/project/project.json
+++ b/erpnext/projects/doctype/project/project.json
@@ -458,7 +458,7 @@
  "index_web_pages_for_search": 1,
  "links": [],
  "max_attachments": 4,
- "modified": "2020-09-02 11:54:01.223620",
+ "modified": "2021-04-28 16:36:11.654632",
  "modified_by": "Administrator",
  "module": "Projects",
  "name": "Project",
@@ -495,7 +495,7 @@
   }
  ],
  "quick_entry": 1,
- "search_fields": "customer, status, priority, is_active",
+ "search_fields": "project_name,customer, status, priority, is_active",
  "show_name_in_global_search": 1,
  "sort_field": "modified",
  "sort_order": "DESC",


### PR DESCRIPTION
**Problem**:

Cannot search by Project Name in transactions, only naming series works. 

![project-search-before](https://user-images.githubusercontent.com/24353136/116399780-eb12ff80-a846-11eb-9c68-f87cca409fc4.gif)

**Fix**: 

- Include search fields in Project Link field query
- Add `project_name` to Project search fields

![project-search-after](https://user-images.githubusercontent.com/24353136/116399355-78098900-a846-11eb-8a88-117c4acea19a.gif)
