### PR TITLE
fix: item stock levels displaying inconsistently

### DIFF
--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -477,11 +477,10 @@ $.extend(erpnext.item, {
 
 								let no_of_combinations = lengths.reduce((a, b) => a * b, 1);
 								let msg;
-								if (no_of_combinations === 1){
-									msg = __("Make {0} Variant").format(no_of_combinations);
-								}
-								else {
-									msg = __("Make {0} Variants").format(no_of_combinations);
+								if (no_of_combinations === 1) {
+									msg = __("Make {0} Variant", [no_of_combinations]);
+								} else {
+									msg = __("Make {0} Variants", [no_of_combinations]);
 								}
 								me.multiple_variant_dialog.get_primary_btn().html(msg);
 								me.multiple_variant_dialog.enable_primary_action();

--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -474,11 +474,16 @@ $.extend(erpnext.item, {
 								me.multiple_variant_dialog.get_primary_btn().html(__('Create Variants'));
 								me.multiple_variant_dialog.disable_primary_action();
 							} else {
+
 								let no_of_combinations = lengths.reduce((a, b) => a * b, 1);
-								me.multiple_variant_dialog.get_primary_btn()
-									.html(__(
-										`Make ${no_of_combinations} Variant${no_of_combinations === 1 ? '' : 's'}`
-									));
+								let msg;
+								if (no_of_combinations === 1){
+									msg = __("Make {0} Variant").format(no_of_combinations);
+								}
+								else {
+									msg = __("Make {0} Variants").format(no_of_combinations);
+								}
+								me.multiple_variant_dialog.get_primary_btn().html(msg);
 								me.multiple_variant_dialog.enable_primary_action();
 							}
 						}

--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -46,9 +46,6 @@ frappe.ui.form.on("Item", {
 			}, __("View"));
 		}
 
-		if (!frm.doc.is_fixed_asset) {
-			erpnext.item.make_dashboard(frm);
-		}
 
 		if (frm.doc.is_fixed_asset) {
 			frm.trigger('is_fixed_asset');
@@ -96,6 +93,10 @@ frappe.ui.form.on("Item", {
 
 		erpnext.item.edit_prices_button(frm);
 		erpnext.item.toggle_attributes(frm);
+		
+		if (!frm.doc.is_fixed_asset) {
+			erpnext.item.make_dashboard(frm);
+		}
 
 		frm.add_custom_button(__('Duplicate'), function() {
 			var new_item = frappe.model.copy_doc(frm.doc);


### PR DESCRIPTION
**Issue :**

- Opening Item the first time.
![image](https://user-images.githubusercontent.com/43572428/116417706-28808880-a859-11eb-8276-d3fb0ffdc360.png)
- Opening it the second time without refreshing.
![image](https://user-images.githubusercontent.com/43572428/116418308-a5abfd80-a859-11eb-99b4-84c423e28fdf.png)

**After FIx**
![dash_fix](https://user-images.githubusercontent.com/43572428/116418967-38e53300-a85a-11eb-95b7-7cb01af07a23.gif)
