### PR TITLE
fix: allow to cancel loan with cancelled repayment entry

### DIFF
--- a/erpnext/loan_management/doctype/loan/loan.py
+++ b/erpnext/loan_management/doctype/loan/loan.py
@@ -44,6 +44,7 @@ class Loan(AccountsController):
 
 	def on_cancel(self):
 		self.unlink_loan_security_pledge()
+		self.ignore_linked_doctypes = ['GL Entry']
 
 	def set_missing_fields(self):
 		if not self.company:


### PR DESCRIPTION
**On canceling the loan we get this validation**
![image](https://user-images.githubusercontent.com/33727827/116425564-01798500-a860-11eb-8678-47d5e75452a4.png)


**On opening the linked GL Entry, as you can see the checkbox 'Is canceled' is checked. So the GL is canceled but the validation is not allowing the loan to be canceled.**
![image](https://user-images.githubusercontent.com/33727827/116425680-181fdc00-a860-11eb-8542-f9a2f54689b8.png)

Steps to Reproduce:

Open a loan with repayment done
Try to cancel and click ok for canceling all linked document
We get this validation