### PR TITLE
feat: Exchange rate difference handling in procurement cycle

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -568,7 +568,7 @@ class PurchaseInvoice(BuyingController):
 							print("*" * 100)
 							print("2")
 
-					else:			# delete comment later - add condition and change GL entries here? $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
+					else:
 						if not self.is_internal_transfer():
 							gl_entries.append(
 								self.get_gl_dict({
@@ -637,8 +637,7 @@ class PurchaseInvoice(BuyingController):
 								expense_account = service_received_but_not_billed_account
 
 					if not self.is_internal_transfer():
-						# check exchange rate difference
-						# purchase_receipt_name = self.as_dict()['items'][0]['purchase_receipt']
+						# check if the exchange rate has changed
 						purchase_receipt_name = item.purchase_receipt
 						purchase_receipt = frappe.get_doc('Purchase Receipt', purchase_receipt_name)
 						if self.conversion_rate == purchase_receipt.conversion_rate:
@@ -651,12 +650,10 @@ class PurchaseInvoice(BuyingController):
 								}, account_currency, item=item))
 		
 						else:
-							# Purchase Invoice: item.expense_account - Stock Received But Not Billed 
 							gle = frappe.get_all('GL Entry')
 							for gl_entry_name in gle:
 								gl_entry = frappe.get_doc('GL Entry', gl_entry_name)
 								if gl_entry.voucher_no == purchase_receipt.name:
-									# if gl_entry.account == self.as_dict()['items'][0]['expense_account']:
 									if gl_entry.account == item.expense_account:
 										debit_at_old_exchange_rate = gl_entry.credit
 										break

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -499,8 +499,6 @@ class PurchaseInvoice(BuyingController):
 						"cost_center": self.cost_center
 					}, self.party_account_currency, item=self)
 				)
-				print("*" * 100)
-				print("Supplier GL Entry")
 
 	def make_item_gl_entries(self, gl_entries):
 		# item gl entries

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -102,6 +102,13 @@ class PurchaseInvoice(BuyingController):
 		self.set_status()
 		self.validate_purchase_receipt_if_update_stock()
 		validate_inter_company_party(self.doctype, self.supplier, self.company, self.inter_company_invoice_reference)
+		self.check_exchange_rate_difference()
+
+	def check_exchange_rate_difference(self):
+		purchase_receipt_name = self.as_dict()['items'][0]['purchase_receipt']
+		purchase_receipt = frappe.get_doc('Purchase Receipt', purchase_receipt_name)
+		if self.conversion_rate != purchase_receipt.conversion_rate:
+			print("*" * 100)
 
 	def validate_release_date(self):
 		if self.release_date and getdate(nowdate()) >= getdate(self.release_date):

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -642,7 +642,7 @@ class PurchaseInvoice(BuyingController):
 								self.get_gl_dict({
 									"account": expense_account,
 									"against": self.supplier,
-									"debit": debit_at_old_exchange_rate,
+									"debit": item.qty * item.rate * purchase_receipt_conversion_rate,
 									"cost_center": item.cost_center,
 									"project": item.project or self.project
 								}, account_currency, item=item)

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -638,21 +638,21 @@ class PurchaseInvoice(BuyingController):
 						# check if the exchange rate has changed
 						purchase_receipt_conversion_rate = frappe.db.get_value('Purchase Receipt', {'name': item.purchase_receipt}, ['conversion_rate'])
 						if self.conversion_rate != purchase_receipt_conversion_rate:
+							discrepancy_caused_by_exchange_rate_difference = (item.qty * item.rate) * (purchase_receipt_conversion_rate - self.conversion_rate)
 							gl_entries.append(
 								self.get_gl_dict({
 									"account": expense_account,
 									"against": self.supplier,
-									"debit": item.qty * item.rate * purchase_receipt_conversion_rate,
+									"debit": discrepancy_caused_by_exchange_rate_difference,
 									"cost_center": item.cost_center,
 									"project": item.project or self.project
 								}, account_currency, item=item)
 							)
-							discrepancy_caused_by_exchange_rate_difference = (item.qty * item.rate) * (purchase_receipt_conversion_rate - self.conversion_rate)
 							gl_entries.append(
 								self.get_gl_dict({
 									"account": self.get_company_default("exchange_gain_loss_account"),		
 									"against": self.supplier,
-									"debit": discrepancy_caused_by_exchange_rate_difference,
+									"credit": discrepancy_caused_by_exchange_rate_difference,
 									"cost_center": item.cost_center,
 									"project": item.project or self.project
 								}, account_currency, item=item)


### PR DESCRIPTION
**_Issue:_**
When a Purchase Invoice is created from a Purchase Receipt(or vice versa), if the exchange rate is different at the time of creation of the latter, the GL entries created for the _Stock Received But Not Billed_ account will not be balanced.

![Screenshot 2021-04-29 at 4 15 18 AM](https://user-images.githubusercontent.com/25903035/116481984-e62f6980-a8a1-11eb-9b81-75aad0a19caf.png)

**_Fix:_**
The amount for the _Stock Received But Not Billed_ account for the second transaction will be made equal to that of the first and the difference will be assigned to the _Exchange Gain/Loss_ account.

For the Purchase Receipt:

![Screenshot 2021-04-29 at 4 32 30 AM](https://user-images.githubusercontent.com/25903035/116483108-1d067f00-a8a4-11eb-9b91-5f61b3b4108b.png)

For the corresponding Purchase Invoice(created after the exchange rate was changed):

![Screenshot 2021-04-29 at 4 35 09 AM](https://user-images.githubusercontent.com/25903035/116483361-900ff580-a8a4-11eb-9369-50671c458296.png)

