### PR TITLE
fix: update Allocated amount after Paid Amount is changed in PE

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -561,7 +561,7 @@ frappe.ui.form.on('Payment Entry', {
 			flt(frm.doc.received_amount) * flt(frm.doc.target_exchange_rate));
 
 		if(frm.doc.payment_type == "Pay")
-			frm.events.allocate_party_amount_against_ref_docs(frm, frm.doc.received_amount);
+			frm.events.allocate_party_amount_against_ref_docs(frm, frm.doc.received_amount, 1);
 		else
 			frm.events.set_unallocated_amount(frm);
 


### PR DESCRIPTION
**Issue:** Allocated Amount doesn't get updated after the Paid amount is changed in Payment Entry. (for Purchase Invoice/Order/Return)

**Steps to Replicate:**

- Create a Payment Entry against Purchase Invoice/Order/Return.
- Change Paid Amount After the Outstanding Invoices are fetched.

**Reference:** https://github.com/frappe/erpnext/pull/25460