### PR TITLE
fix: List invoices in Payment Reconciliation Payment

### DIFF
--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.js
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.js
@@ -234,7 +234,7 @@ erpnext.accounts.PaymentReconciliationController = frappe.ui.form.Controller.ext
 		});
 
 		if (invoices) {
-			this.frm.fields_dict.payment.grid.update_docfield_property(
+			this.frm.fields_dict.payments.grid.update_docfield_property(
 				'invoice_number', 'options', "\n" + invoices.join("\n")
 			);
 


### PR DESCRIPTION
Invoices are not listed in the Payment Reconciliation Payment child table due to a typo in the code.

Fixes #25309, #25291, #25497, #25525