### PR TITLE
fix: updated item filters for material request

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -433,12 +433,20 @@ erpnext.buying.MaterialRequestController = erpnext.buying.BuyingController.exten
 			if (doc.material_request_type == "Customer Provided") {
 				return{
 					query: "erpnext.controllers.queries.item_query",
-					filters:{ 'customer': me.frm.doc.customer }
+					filters:{ 
+						'customer': me.frm.doc.customer,
+						'is_stock_item':1
+					}
 				}
-			} else if (doc.material_request_type != "Manufacture") {
+			} else if (doc.material_request_type == "Purchase") {
 				return{
 					query: "erpnext.controllers.queries.item_query",
 					filters: {'is_purchase_item': 1}
+				}
+			} else {
+				return{
+					query: "erpnext.controllers.queries.item_query",
+					filters: {'is_stock_item': 1}
 				}
 			}
 		});


### PR DESCRIPTION
**Issue:**

- When creating a Material Request of the Purpose 'Material Transfer', the system does not allow you to select any Items which do not have 'Is Purchase Item' checked on Item master.
- This does not allow any intermediate manufacturing materials, such as Semi Finished Goods to be internally transferred

![image](https://user-images.githubusercontent.com/9079960/116693779-0105f900-a9dc-11eb-84b0-a52e1363af9a.png)


**Fix:**

- Uses filter is_purchase_item only when purpose has "Purchase" selected, else it filters with is_stock_item.
![filter_fix](https://user-images.githubusercontent.com/43572428/116683984-f93f5800-a9cd-11eb-8501-2c797cfb0d23.gif)
