### PR TITLE
fix: serial no changed after saving stock reconciliation

### DIFF
--- a/erpnext/projects/report/project_profitability/project_profitability.py
+++ b/erpnext/projects/report/project_profitability/project_profitability.py
@@ -4,6 +4,7 @@
 from __future__ import unicode_literals
 import frappe
 from frappe import _
+from frappe.utils import flt
 
 def execute(filters=None):
 	columns, data = [], []
@@ -52,8 +53,8 @@ def get_rows(filters):
 
 def calculate_cost_and_profit(data):
 	for row in data:
-		row.fractional_cost = row.base_gross_pay * row.utilization
-		row.profit = row.base_grand_total - row.base_gross_pay * row.utilization
+		row.fractional_cost = flt(row.base_gross_pay) * flt(row.utilization)
+		row.profit = flt(row.base_grand_total) - flt(row.base_gross_pay) * flt(row.utilization)
 	return data
 
 def get_conditions(filters):

--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -72,7 +72,7 @@ class StockReconciliation(StockController):
 
 				if item_dict.get("serial_nos"):
 					item.current_serial_no = item_dict.get("serial_nos")
-					if self.purpose == "Stock Reconciliation" and not item.serial_no::
+					if self.purpose == "Stock Reconciliation" and not item.serial_no:
 						item.serial_no = item.current_serial_no
 
 				item.current_qty = item_dict.get("qty")

--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -72,7 +72,7 @@ class StockReconciliation(StockController):
 
 				if item_dict.get("serial_nos"):
 					item.current_serial_no = item_dict.get("serial_nos")
-					if self.purpose == "Stock Reconciliation":
+					if self.purpose == "Stock Reconciliation" and not item.serial_no::
 						item.serial_no = item.current_serial_no
 
 				item.current_qty = item_dict.get("qty")


### PR DESCRIPTION
Issue:
1. Create stock reconciliation against the serialized items
2. Changed the current qty and serial no and save it
3. After save, you will notice that system has changed the manually added serial nos to the current serial nos