### PR TITLE
fix: total stock summary report not working

### DIFF
--- a/erpnext/stock/report/total_stock_summary/total_stock_summary.py
+++ b/erpnext/stock/report/total_stock_summary/total_stock_summary.py
@@ -51,7 +51,7 @@ def get_total_stock(filters):
 			INNER JOIN `tabWarehouse` warehouse
 				ON warehouse.name = ledger.warehouse
 			WHERE
-				actual_qty != 0 %s""" % (columns, conditions))
+				ledger.actual_qty != 0 %s""" % (columns, conditions))
 
 def validate_filters(filters):
 	if filters.get("group_by") == 'Company' and \


### PR DESCRIPTION
1. Add custom field actual qty in the item master
2. Check Total Stock Summary report, you will get below error
```
    packet.check_error()
  File "/home/frappe/benches/bench-version-12-2021-04-21/env/lib/python3.6/site-packages/pymysql/protocol.py", line 220, in check_error
    err.raise_mysql_exception(self._data)
  File "/home/frappe/benches/bench-version-12-2021-04-21/env/lib/python3.6/site-packages/pymysql/err.py", line 109, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.InternalError: (1052, "Column 'actual_qty' in where clause is ambiguous")
```