### PR TITLE
fix: prevent spurious defaults for items when making prec from dnote

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -1761,7 +1761,8 @@ def get_delivery_note_details(internal_reference):
 		filters={'parent': internal_reference})
 
 	for d in si_item_details:
-		so_item_map.setdefault(d.name, d.so_detail)
+		if d.so_detail:
+			so_item_map.setdefault(d.name, d.so_detail)
 
 	return so_item_map
 

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -1755,16 +1755,10 @@ def update_pr_items(doc, sales_item_map, purchase_item_map, parent_child_map, wa
 		item.purchase_order = parent_child_map.get(sales_item_map.get(item.delivery_note_item))
 
 def get_delivery_note_details(internal_reference):
-	so_item_map = {}
-
 	si_item_details = frappe.get_all('Delivery Note Item', fields=['name', 'so_detail'],
 		filters={'parent': internal_reference})
 
-	for d in si_item_details:
-		if d.so_detail:
-			so_item_map.setdefault(d.name, d.so_detail)
-
-	return so_item_map
+	return {d.name: d.so_detail for d in si_item_details if d.so_detail}
 
 def get_sales_invoice_details(internal_reference):
 	dn_item_map = {}


### PR DESCRIPTION
### Description
Adds conditional that prevents spurious values from **Purchase Order** to be added to **Sales Order Item** map in the absence of sales order detail in the map.

This was preventing **Internal Purchase Receipt**s from being created from **Delivery Note**s.

(fix by @rohitwaghchaure)