### PR TITLE
fix: prevent spurious defaults for items when making prec from dnote

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -1762,7 +1762,8 @@ def get_delivery_note_details(internal_reference):
 		filters={'parent': internal_reference})
 
 	for d in si_item_details:
-		so_item_map.setdefault(d.name, d.so_detail)
+		if d.so_detail:
+			so_item_map.setdefault(d.name, d.so_detail)
 
 	return so_item_map
 


### PR DESCRIPTION
Backported from [#25559 ](https://github.com/frappe/erpnext/pull/25559)