### PR TITLE
fix: Updating Standard Notification's channel field

### DIFF
--- a/erpnext/accounts/notification/notification_for_new_fiscal_year/notification_for_new_fiscal_year.json
+++ b/erpnext/accounts/notification/notification_for_new_fiscal_year/notification_for_new_fiscal_year.json
@@ -1,5 +1,6 @@
 {
  "attach_print": 0,
+ "channel": "Email",
  "condition": "doc.auto_created",
  "creation": "2018-04-25 14:19:05.440361",
  "days_in_advance": 0,

--- a/erpnext/hr/notification/training_feedback/training_feedback.json
+++ b/erpnext/hr/notification/training_feedback/training_feedback.json
@@ -1,5 +1,6 @@
 {
  "attach_print": 0,
+ "channel": "Email",
  "creation": "2017-08-11 03:17:11.769210",
  "days_in_advance": 0,
  "docstatus": 0,

--- a/erpnext/payroll/notification/retention_bonus/retention_bonus.json
+++ b/erpnext/payroll/notification/retention_bonus/retention_bonus.json
@@ -1,5 +1,6 @@
 {
  "attach_print": 0,
+ "channel": "Email",
  "condition": "doc.docstatus==1",
  "creation": "2018-05-15 18:52:36.362838",
  "date_changed": "bonus_payment_date",


### PR DESCRIPTION
Some Standard Notification does not have a `channel` field, since its a mandatory field we cannot edit those Notification
![channel](https://user-images.githubusercontent.com/30859809/116886722-0d41be80-ac47-11eb-90ce-9061f099cd96.gif)