### PR TITLE
fix: Render timesheet template on timer field

### DIFF
--- a/erpnext/projects/doctype/timesheet/timesheet.js
+++ b/erpnext/projects/doctype/timesheet/timesheet.js
@@ -174,9 +174,10 @@ frappe.ui.form.on("Timesheet Detail", {
 
 		var $trigger_again = $('.form-grid').find('.grid-row').find('.btn-open-row');
 		$trigger_again.on('click', () => {
-			$('.form-grid')
-				.find('[data-fieldname="timer"]')
-				.append(frappe.render_template("timesheet"));
+			let $timer = $('.form-grid').find('[data-fieldname="timer"]')
+			if ($timer.get(0)) {
+				$timer.append(frappe.render_template("timesheet"));
+			}
 			frm.trigger("control_timer");
 		});
 	},

--- a/erpnext/projects/doctype/timesheet/timesheet.js
+++ b/erpnext/projects/doctype/timesheet/timesheet.js
@@ -174,7 +174,7 @@ frappe.ui.form.on("Timesheet Detail", {
 
 		var $trigger_again = $('.form-grid').find('.grid-row').find('.btn-open-row');
 		$trigger_again.on('click', () => {
-			let $timer = $('.form-grid').find('[data-fieldname="timer"]')
+			let $timer = $('.form-grid').find('[data-fieldname="timer"]');
 			if ($timer.get(0)) {
 				$timer.append(frappe.render_template("timesheet"));
 			}


### PR DESCRIPTION
When a user creates a new timesheet, a new row will be already added. Delete that row, add the row and expand it you get this error
![image](https://user-images.githubusercontent.com/30859809/116964252-afee5180-acc8-11eb-8613-d43809a8bf44.png)