### PR TITLE
fix: function call to update payment schedule labels

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1379,7 +1379,7 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 
 	update_payment_schedule_grid_labels: function(company_currency) {
 		const me = this;
-		if (this.frm.doc.payment_schedule.length > 0) {
+		if (this.frm.doc.payment_schedule && this.frm.doc.payment_schedule.length > 0) {
 			this.frm.set_currency_labels(["base_payment_amount", "base_outstanding", "base_paid_amount"],
 				company_currency, "payment_schedule");
 			this.frm.set_currency_labels(["payment_amount", "outstanding", "paid_amount"],

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1384,7 +1384,7 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 				company_currency, "payment_schedule");
 			this.frm.set_currency_labels(["payment_amount", "outstanding", "paid_amount"],
 				this.frm.doc.currency, "payment_schedule");
-			
+
 			var schedule_grid = this.frm.fields_dict["payment_schedule"].grid;
 			$.each(["base_payment_amount", "base_outstanding", "base_paid_amount"], function(i, fname) {
 				if (frappe.meta.get_docfield(schedule_grid.doctype, fname))
@@ -2034,7 +2034,7 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 					if(r.message && !r.exc) {
 						me.frm.set_value("payment_schedule", r.message);
 						const company_currency = me.get_company_currency();
-						this.update_payment_schedule_grid_labels(company_currency);
+						me.update_payment_schedule_grid_labels(company_currency);
 					}
 				}
 			})

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1379,7 +1379,7 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 
 	update_payment_schedule_grid_labels: function(company_currency) {
 		const me = this;
-		if (this.frm.fields_dict["payment_schedule"]) {
+		if (this.frm.doc.payment_schedule.length > 0) {
 			this.frm.set_currency_labels(["base_payment_amount", "base_outstanding", "base_paid_amount"],
 				company_currency, "payment_schedule");
 			this.frm.set_currency_labels(["payment_amount", "outstanding", "paid_amount"],


### PR DESCRIPTION
```
TypeError: this.update_payment_schedule_grid_labels is not a function
    at Object.callback (transaction.js:2037)
    at Object.success [as success_callback] (request.js:78)
    at 200 (request.js:122)
    at Object.<anonymous> (request.js:247)
    at i (jquery.min.js:2)
    at Object.fireWith [as resolveWith] (jquery.min.js:2)
    at z (jquery.min.js:4)
    at XMLHttpRequest.<anonymous> (jquery.min.js:4)
```

```
Uncaught (in promise) TypeError: Cannot read property 'length' of undefined
    at Grid.update_docfield_property (control.min.js?ver=1620007033.7552323:sourcemap:1)
    at String.<anonymous> (form.js:1206)
    at Function.each (jquery.min.js:2)
    at frappe.ui.form.Form.set_currency_labels (form.js:1204)
    at init.update_payment_schedule_grid_labels (erpnext.min.js?ver=1620007033.7552323:sourcemap:1)
    at init.change_grid_labels (erpnext.min.js?ver=1620007033.7552323:sourcemap:1)
    at init.set_dynamic_labels [as _super] (erpnext.min.js?ver=1620007033.7552323:sourcemap:1)
    at init.set_dynamic_labels (sales_invoice__js:633)
    at init.<anonymous> (class.js:53)
    at init.set_dynamic_labels (sales_invoice__js:1160)
```
