### PR TITLE
fix: Invoices not getting fetched during payment reconciliation

### DIFF
--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
@@ -114,7 +114,7 @@ class PaymentReconciliation(Document):
 				'party_type': self.party_type,
 				'voucher_type': voucher_type,
 				'account': self.receivable_payable_account
-			}, as_dict=1, debug=1)
+			}, as_dict=1)
 
 	def add_payment_entries(self, entries):
 		self.set('payments', [])


### PR DESCRIPTION
**Issue:** If debug flag is passed during a query it prints the query as an `errprint` which stops any further operations. Due to this outstanding invoices were not getting fetched during payment reconciliation

Removed the flag to fix this