### PR TITLE
fix:  In employee leave balance summary report change get_all to get_list to hide descendants when hide descendants is selected in user permissions

### DIFF
--- a/erpnext/hr/report/employee_leave_balance_summary/employee_leave_balance_summary.py
+++ b/erpnext/hr/report/employee_leave_balance_summary/employee_leave_balance_summary.py
@@ -47,7 +47,7 @@ def get_data(filters, leave_types):
 	user = frappe.session.user
 	conditions = get_conditions(filters)
 
-	active_employees = frappe.get_all("Employee",
+	active_employees = frappe.get_list("Employee",
 		filters=conditions,
 		fields=["name", "employee_name", "department", "user_id", "leave_approver"])
 


### PR DESCRIPTION
This PR fixes the issue mentioned [here](https://github.com/frappe/frappe/issues/12990)

Since `get_all` is same as `get_list` but without applying permissions, change get_all to get_list in employee leave balance summary report to hide descendants when hide descendants is selected in user permissions.


