### PR TITLE
fix: update cost center in the item table fetched from POS Profile

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -79,7 +79,7 @@ def get_item_details(args, doc=None, for_validate=False, overwrite_warehouse=Tru
 		get_price_list_rate(args, item, out)
 
 	if args.customer and cint(args.is_pos):
-		out.update(get_pos_profile_item_details(args.company, args))
+		out.update(get_pos_profile_item_details(args.company, args, update_data=True))
 
 	if (args.get("doctype") == "Material Request" and
 		args.get("material_request_type") == "Material Transfer"):
@@ -935,8 +935,8 @@ def get_bin_details(item_code, warehouse, company=None):
 	return bin_details
 
 def get_company_total_stock(item_code, company):
-	return frappe.db.sql("""SELECT sum(actual_qty) from 
-		(`tabBin` INNER JOIN `tabWarehouse` ON `tabBin`.warehouse = `tabWarehouse`.name) 
+	return frappe.db.sql("""SELECT sum(actual_qty) from
+		(`tabBin` INNER JOIN `tabWarehouse` ON `tabBin`.warehouse = `tabWarehouse`.name)
 		WHERE `tabWarehouse`.company = %s and `tabBin`.item_code = %s""",
 		(company, item_code))[0][0]
 


### PR DESCRIPTION
**Issue:** A Cost Center from a POS Profile doesn't get updated in the item table while creating Sales Invoice using POS Profile, it updates the Cost Center of the invoice (whereas the company's default Cost Center is fetched for the item)

**Steps to replicate:**

1. Create a POS Profile
2. Create a Sales Invoice using the POS Profile, check if the Cost Center from the POS Profile is fetched properly both in the invoice and the item.

**Before:**
![before_cc](https://user-images.githubusercontent.com/60467153/117295805-e925ed80-ae91-11eb-9019-6fdac0e91c47.gif)


**After:**
![after_cc](https://user-images.githubusercontent.com/60467153/117294692-8e3fc680-ae90-11eb-8a65-763384540f87.gif)
