### PR TITLE
chore: replace assertEquals with alias assertEqual

### DIFF
--- a/erpnext/accounts/doctype/dunning/test_dunning.py
+++ b/erpnext/accounts/doctype/dunning/test_dunning.py
@@ -42,9 +42,9 @@ class TestDunning(unittest.TestCase):
 			['Sales - _TC',  0.0, 20.44]
 		])
 		for gle in gl_entries:
-			self.assertEquals(expected_values[gle.account][0], gle.account)
-			self.assertEquals(expected_values[gle.account][1], gle.debit)
-			self.assertEquals(expected_values[gle.account][2], gle.credit)
+			self.assertEqual(expected_values[gle.account][0], gle.account)
+			self.assertEqual(expected_values[gle.account][1], gle.debit)
+			self.assertEqual(expected_values[gle.account][2], gle.credit)
 
 	def test_payment_entry(self):
 		dunning = create_dunning()

--- a/erpnext/accounts/doctype/gl_entry/test_gl_entry.py
+++ b/erpnext/accounts/doctype/gl_entry/test_gl_entry.py
@@ -54,4 +54,4 @@ class TestGLEntry(unittest.TestCase):
 		self.assertTrue(all(new.name != old.name for new, old in zip(gl_entries, new_gl_entries)))
 
 		new_naming_series_current_value = frappe.db.sql("SELECT current from tabSeries where name = %s", naming_series)[0][0]
-		self.assertEquals(old_naming_series_current_value + 2, new_naming_series_current_value)
+		self.assertEqual(old_naming_series_current_value + 2, new_naming_series_current_value)

--- a/erpnext/accounts/doctype/payment_order/test_payment_order.py
+++ b/erpnext/accounts/doctype/payment_order/test_payment_order.py
@@ -31,10 +31,10 @@ class TestPaymentOrder(unittest.TestCase):
 
 		doc = create_payment_order_against_payment_entry(payment_entry, "Payment Entry")
 		reference_doc = doc.get("references")[0]
-		self.assertEquals(reference_doc.reference_name, payment_entry.name)
-		self.assertEquals(reference_doc.reference_doctype, "Payment Entry")
-		self.assertEquals(reference_doc.supplier, "_Test Supplier")
-		self.assertEquals(reference_doc.amount, 250)
+		self.assertEqual(reference_doc.reference_name, payment_entry.name)
+		self.assertEqual(reference_doc.reference_doctype, "Payment Entry")
+		self.assertEqual(reference_doc.supplier, "_Test Supplier")
+		self.assertEqual(reference_doc.amount, 250)
 
 def create_payment_order_against_payment_entry(ref_doc, order_type):
 	payment_order = frappe.get_doc(dict(

--- a/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
@@ -99,7 +99,7 @@ class TestPricingRule(unittest.TestCase):
 
 		args.item_code = "_Test Item 2"
 		details = get_item_details(args)
-		self.assertEquals(details.get("discount_percentage"), 15)
+		self.assertEqual(details.get("discount_percentage"), 15)
 
 	def test_pricing_rule_for_margin(self):
 		from erpnext.stock.get_item_details import get_item_details
@@ -145,8 +145,8 @@ class TestPricingRule(unittest.TestCase):
 			"name": None
 		})
 		details = get_item_details(args)
-		self.assertEquals(details.get("margin_type"), "Percentage")
-		self.assertEquals(details.get("margin_rate_or_amount"), 10)
+		self.assertEqual(details.get("margin_type"), "Percentage")
+		self.assertEqual(details.get("margin_rate_or_amount"), 10)
 
 	def test_mixed_conditions_for_item_group(self):
 		for item in ["Mixed Cond Item 1", "Mixed Cond Item 2"]:
@@ -192,7 +192,7 @@ class TestPricingRule(unittest.TestCase):
 			"name": None
 		})
 		details = get_item_details(args)
-		self.assertEquals(details.get("discount_percentage"), 10)
+		self.assertEqual(details.get("discount_percentage"), 10)
 
 	def test_pricing_rule_for_variants(self):
 		from erpnext.stock.get_item_details import get_item_details
@@ -322,11 +322,11 @@ class TestPricingRule(unittest.TestCase):
 		si.insert(ignore_permissions=True)
 
 		item = si.items[0]
-		self.assertEquals(item.margin_rate_or_amount, 10)
-		self.assertEquals(item.rate_with_margin, 1100)
+		self.assertEqual(item.margin_rate_or_amount, 10)
+		self.assertEqual(item.rate_with_margin, 1100)
 		self.assertEqual(item.discount_percentage, 10)
-		self.assertEquals(item.discount_amount, 110)
-		self.assertEquals(item.rate, 990)
+		self.assertEqual(item.discount_amount, 110)
+		self.assertEqual(item.rate, 990)
 
 	def test_pricing_rule_with_margin_and_discount_amount(self):
 		frappe.delete_doc_if_exists('Pricing Rule', '_Test Pricing Rule')
@@ -338,10 +338,10 @@ class TestPricingRule(unittest.TestCase):
 		si.insert(ignore_permissions=True)
 
 		item = si.items[0]
-		self.assertEquals(item.margin_rate_or_amount, 10)
-		self.assertEquals(item.rate_with_margin, 1100)
-		self.assertEquals(item.discount_amount, 110)
-		self.assertEquals(item.rate, 990)
+		self.assertEqual(item.margin_rate_or_amount, 10)
+		self.assertEqual(item.rate_with_margin, 1100)
+		self.assertEqual(item.discount_amount, 110)
+		self.assertEqual(item.rate, 990)
 
 	def test_pricing_rule_for_product_discount_on_same_item(self):
 		frappe.delete_doc_if_exists('Pricing Rule', '_Test Pricing Rule')
@@ -458,21 +458,21 @@ class TestPricingRule(unittest.TestCase):
 		si.items[0].price_list_rate = 1000
 		si.submit()
 		item = si.items[0]
-		self.assertEquals(item.rate, 100)
+		self.assertEqual(item.rate, 100)
 
 		# Correct Customer and Incorrect is_return value
 		si = create_sales_invoice(do_not_submit=True, customer="_Test Customer 1", is_return=1, qty=-1)
 		si.items[0].price_list_rate = 1000
 		si.submit()
 		item = si.items[0]
-		self.assertEquals(item.rate, 100)
+		self.assertEqual(item.rate, 100)
 
 		# Correct Customer and correct is_return value
 		si = create_sales_invoice(do_not_submit=True, customer="_Test Customer 1", is_return=0)
 		si.items[0].price_list_rate = 1000
 		si.submit()
 		item = si.items[0]
-		self.assertEquals(item.rate, 900)
+		self.assertEqual(item.rate, 900)
 
 	def test_multiple_pricing_rules(self):
 		make_pricing_rule(discount_percentage=20, selling=1, priority=1, apply_multiple_pricing_rules=1,
@@ -545,11 +545,11 @@ class TestPricingRule(unittest.TestCase):
 			apply_on="Transaction", free_item="Water Flask 1", free_qty=1, free_item_rate=10)
 
 		si = create_sales_invoice(qty=5, do_not_submit=True)
-		self.assertEquals(len(si.items), 2)
-		self.assertEquals(si.items[1].rate, 10)
+		self.assertEqual(len(si.items), 2)
+		self.assertEqual(si.items[1].rate, 10)
 
 		si1 = create_sales_invoice(qty=2, do_not_submit=True)
-		self.assertEquals(len(si1.items), 1)
+		self.assertEqual(len(si1.items), 1)
 
 		for doc in [si, si1]:
 			doc.delete()

--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -78,7 +78,7 @@ class TestAsset(unittest.TestCase):
 		})
 
 		doc.set_missing_values()
-		self.assertEquals(doc.items[0].is_fixed_asset, 1)
+		self.assertEqual(doc.items[0].is_fixed_asset, 1)
 
 	def test_schedule_for_straight_line_method(self):
 		pr = make_purchase_receipt(item_code="Macbook Pro",
@@ -565,7 +565,7 @@ class TestAsset(unittest.TestCase):
 
 		doc = make_invoice(pr.name)
 
-		self.assertEquals('Asset Received But Not Billed - _TC', doc.items[0].expense_account)
+		self.assertEqual('Asset Received But Not Billed - _TC', doc.items[0].expense_account)
 	
 	def test_asset_cwip_toggling_cases(self):
 		cwip = frappe.db.get_value("Asset Category", "Computers", "enable_cwip_accounting")

--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -187,7 +187,7 @@ class TestPurchaseOrder(unittest.TestCase):
 		update_child_qty_rate('Purchase Order', trans_item, po.name)
 
 		po.reload()
-		self.assertEquals(len(po.get('items')), 2)
+		self.assertEqual(len(po.get('items')), 2)
 		self.assertEqual(po.status, 'To Receive and Bill')
 		# ordered qty should increase on row addition
 		self.assertEqual(get_ordered_qty(), existing_ordered_qty + 7)
@@ -234,7 +234,7 @@ class TestPurchaseOrder(unittest.TestCase):
 		update_child_qty_rate('Purchase Order', trans_item, po.name)
 
 		po.reload()
-		self.assertEquals(len(po.get('items')), 1)
+		self.assertEqual(len(po.get('items')), 1)
 		self.assertEqual(po.status, 'To Receive and Bill')
 
 		# ordered qty should decrease (back to initial) on row deletion
@@ -448,13 +448,13 @@ class TestPurchaseOrder(unittest.TestCase):
 
 		pi.load_from_db()
 
-		self.assertEquals(pi.per_received, 100.00)
-		self.assertEquals(pi.items[0].qty, pi.items[0].received_qty)
+		self.assertEqual(pi.per_received, 100.00)
+		self.assertEqual(pi.items[0].qty, pi.items[0].received_qty)
 
 		po.load_from_db()
 
-		self.assertEquals(po.per_received, 100.00)
-		self.assertEquals(po.per_billed, 100.00)
+		self.assertEqual(po.per_received, 100.00)
+		self.assertEqual(po.per_billed, 100.00)
 
 		pr.cancel()
 
@@ -674,8 +674,8 @@ class TestPurchaseOrder(unittest.TestCase):
 			filters={"warehouse": "_Test Warehouse - _TC", "item_code": "_Test Item"},
 			fieldname=["reserved_qty_for_sub_contract", "projected_qty"], as_dict=1)
 
-		self.assertEquals(bin2.reserved_qty_for_sub_contract, bin1.reserved_qty_for_sub_contract + 10)
-		self.assertEquals(bin2.projected_qty, bin1.projected_qty - 10)
+		self.assertEqual(bin2.reserved_qty_for_sub_contract, bin1.reserved_qty_for_sub_contract + 10)
+		self.assertEqual(bin2.projected_qty, bin1.projected_qty - 10)
 
 		# Create stock transfer
 		rm_item = [{"item_code":"_Test FG Item","rm_item_code":"_Test Item","item_name":"_Test Item",
@@ -690,7 +690,7 @@ class TestPurchaseOrder(unittest.TestCase):
 			filters={"warehouse": "_Test Warehouse - _TC", "item_code": "_Test Item"},
 			fieldname="reserved_qty_for_sub_contract", as_dict=1)
 
-		self.assertEquals(bin3.reserved_qty_for_sub_contract, bin2.reserved_qty_for_sub_contract - 6)
+		self.assertEqual(bin3.reserved_qty_for_sub_contract, bin2.reserved_qty_for_sub_contract - 6)
 
 		# close PO
 		po.update_status("Closed")
@@ -698,7 +698,7 @@ class TestPurchaseOrder(unittest.TestCase):
 			filters={"warehouse": "_Test Warehouse - _TC", "item_code": "_Test Item"},
 			fieldname="reserved_qty_for_sub_contract", as_dict=1)
 
-		self.assertEquals(bin4.reserved_qty_for_sub_contract, bin1.reserved_qty_for_sub_contract)
+		self.assertEqual(bin4.reserved_qty_for_sub_contract, bin1.reserved_qty_for_sub_contract)
 
 		# Re-open PO
 		po.update_status("Submitted")
@@ -706,7 +706,7 @@ class TestPurchaseOrder(unittest.TestCase):
 			filters={"warehouse": "_Test Warehouse - _TC", "item_code": "_Test Item"},
 			fieldname="reserved_qty_for_sub_contract", as_dict=1)
 
-		self.assertEquals(bin5.reserved_qty_for_sub_contract, bin2.reserved_qty_for_sub_contract - 6)
+		self.assertEqual(bin5.reserved_qty_for_sub_contract, bin2.reserved_qty_for_sub_contract - 6)
 
 		make_stock_entry(target="_Test Warehouse 1 - _TC", item_code="_Test Item",
 			qty=40, basic_rate=100)
@@ -723,7 +723,7 @@ class TestPurchaseOrder(unittest.TestCase):
 			filters={"warehouse": "_Test Warehouse - _TC", "item_code": "_Test Item"},
 			fieldname="reserved_qty_for_sub_contract", as_dict=1)
 
-		self.assertEquals(bin6.reserved_qty_for_sub_contract, bin1.reserved_qty_for_sub_contract)
+		self.assertEqual(bin6.reserved_qty_for_sub_contract, bin1.reserved_qty_for_sub_contract)
 
 		# Cancel PR
 		pr.cancel()
@@ -731,7 +731,7 @@ class TestPurchaseOrder(unittest.TestCase):
 			filters={"warehouse": "_Test Warehouse - _TC", "item_code": "_Test Item"},
 			fieldname="reserved_qty_for_sub_contract", as_dict=1)
 
-		self.assertEquals(bin7.reserved_qty_for_sub_contract, bin2.reserved_qty_for_sub_contract - 6)
+		self.assertEqual(bin7.reserved_qty_for_sub_contract, bin2.reserved_qty_for_sub_contract - 6)
 
 		# Make Purchase Invoice
 		pi = make_pi_from_po(po.name)
@@ -743,7 +743,7 @@ class TestPurchaseOrder(unittest.TestCase):
 			filters={"warehouse": "_Test Warehouse - _TC", "item_code": "_Test Item"},
 			fieldname="reserved_qty_for_sub_contract", as_dict=1)
 
-		self.assertEquals(bin8.reserved_qty_for_sub_contract, bin1.reserved_qty_for_sub_contract)
+		self.assertEqual(bin8.reserved_qty_for_sub_contract, bin1.reserved_qty_for_sub_contract)
 
 		# Cancel PR
 		pi.cancel()
@@ -751,7 +751,7 @@ class TestPurchaseOrder(unittest.TestCase):
 			filters={"warehouse": "_Test Warehouse - _TC", "item_code": "_Test Item"},
 			fieldname="reserved_qty_for_sub_contract", as_dict=1)
 
-		self.assertEquals(bin9.reserved_qty_for_sub_contract, bin2.reserved_qty_for_sub_contract - 6)
+		self.assertEqual(bin9.reserved_qty_for_sub_contract, bin2.reserved_qty_for_sub_contract - 6)
 
 		# Cancel Stock Entry
 		se.cancel()
@@ -759,7 +759,7 @@ class TestPurchaseOrder(unittest.TestCase):
 			filters={"warehouse": "_Test Warehouse - _TC", "item_code": "_Test Item"},
 			fieldname="reserved_qty_for_sub_contract", as_dict=1)
 
-		self.assertEquals(bin10.reserved_qty_for_sub_contract, bin1.reserved_qty_for_sub_contract + 10)
+		self.assertEqual(bin10.reserved_qty_for_sub_contract, bin1.reserved_qty_for_sub_contract + 10)
 
 		# Cancel PO
 		po.reload()
@@ -768,7 +768,7 @@ class TestPurchaseOrder(unittest.TestCase):
 			filters={"warehouse": "_Test Warehouse - _TC", "item_code": "_Test Item"},
 			fieldname="reserved_qty_for_sub_contract", as_dict=1)
 
-		self.assertEquals(bin11.reserved_qty_for_sub_contract, bin1.reserved_qty_for_sub_contract)
+		self.assertEqual(bin11.reserved_qty_for_sub_contract, bin1.reserved_qty_for_sub_contract)
 
 	def test_exploded_items_in_subcontracted(self):
 		item_code = "_Test Subcontracted FG Item 1"
@@ -782,7 +782,7 @@ class TestPurchaseOrder(unittest.TestCase):
 
 		exploded_items = sorted([d.item_code for d in bom.exploded_items if not d.get('sourced_by_supplier')])
 		supplied_items = sorted([d.rm_item_code for d in po.supplied_items])
-		self.assertEquals(exploded_items, supplied_items)
+		self.assertEqual(exploded_items, supplied_items)
 
 		po1 = create_purchase_order(item_code=item_code, qty=1,
 			is_subcontracted="Yes", supplier_warehouse="_Test Warehouse 1 - _TC", include_exploded_items=0)
@@ -790,7 +790,7 @@ class TestPurchaseOrder(unittest.TestCase):
 		supplied_items1 = sorted([d.rm_item_code for d in po1.supplied_items])
 		bom_items = sorted([d.item_code for d in bom.items if not d.get('sourced_by_supplier')])
 
-		self.assertEquals(supplied_items1, bom_items)
+		self.assertEqual(supplied_items1, bom_items)
 
 	def test_backflush_based_on_stock_entry(self):
 		item_code = "_Test Subcontracted FG Item 1"
@@ -840,8 +840,8 @@ class TestPurchaseOrder(unittest.TestCase):
 		transferred_items = sorted([d.item_code for d in se.get('items') if se.purchase_order == po.name])
 		issued_items = sorted([d.rm_item_code for d in pr.get('supplied_items')])
 
-		self.assertEquals(transferred_items, issued_items)
-		self.assertEquals(pr.get('items')[0].rm_supp_cost, 2000)
+		self.assertEqual(transferred_items, issued_items)
+		self.assertEqual(pr.get('items')[0].rm_supp_cost, 2000)
 
 
 		transferred_rm_map = frappe._dict()

--- a/erpnext/erpnext_integrations/doctype/mpesa_settings/test_mpesa_settings.py
+++ b/erpnext/erpnext_integrations/doctype/mpesa_settings/test_mpesa_settings.py
@@ -19,7 +19,7 @@ class TestMpesaSettings(unittest.TestCase):
 		mode_of_payment = frappe.get_doc("Mode of Payment", "Mpesa-_Test")
 		self.assertTrue(frappe.db.exists("Payment Gateway Account", {'payment_gateway': "Mpesa-_Test"}))
 		self.assertTrue(mode_of_payment.name)
-		self.assertEquals(mode_of_payment.type, "Phone")
+		self.assertEqual(mode_of_payment.type, "Phone")
 
 	def test_processing_of_account_balance(self):
 		mpesa_doc = create_mpesa_settings(payment_gateway_name="_Account Balance")
@@ -31,11 +31,11 @@ class TestMpesaSettings(unittest.TestCase):
 
 		# test integration request creation and successful update of the status on receiving callback response
 		self.assertTrue(integration_request)
-		self.assertEquals(integration_request.status, "Completed")
+		self.assertEqual(integration_request.status, "Completed")
 
 		# test formatting of account balance received as string to json with appropriate currency symbol
 		mpesa_doc.reload()
-		self.assertEquals(mpesa_doc.account_balance, dumps({
+		self.assertEqual(mpesa_doc.account_balance, dumps({
 			"Working Account": {
 				"current_balance": "Sh 481,000.00",
 				"available_balance": "Sh 481,000.00",
@@ -60,7 +60,7 @@ class TestMpesaSettings(unittest.TestCase):
 
 		pr = pos_invoice.create_payment_request()
 		# test payment request creation
-		self.assertEquals(pr.payment_gateway, "Mpesa-Payment")
+		self.assertEqual(pr.payment_gateway, "Mpesa-Payment")
 
 		# submitting payment request creates integration requests with random id
 		integration_req_ids = frappe.get_all("Integration Request", filters={
@@ -75,12 +75,12 @@ class TestMpesaSettings(unittest.TestCase):
 
 		# test integration request creation and successful update of the status on receiving callback response
 		self.assertTrue(integration_request)
-		self.assertEquals(integration_request.status, "Completed")
+		self.assertEqual(integration_request.status, "Completed")
 
 		pos_invoice.reload()
 		integration_request.reload()
-		self.assertEquals(pos_invoice.mpesa_receipt_number, "LGR7OWQX0R")
-		self.assertEquals(integration_request.status, "Completed")
+		self.assertEqual(pos_invoice.mpesa_receipt_number, "LGR7OWQX0R")
+		self.assertEqual(integration_request.status, "Completed")
 		
 		frappe.db.set_value("Customer", "_Test Customer", "default_currency", "")
 		integration_request.delete()
@@ -104,7 +104,7 @@ class TestMpesaSettings(unittest.TestCase):
 
 		pr = pos_invoice.create_payment_request()
 		# test payment request creation
-		self.assertEquals(pr.payment_gateway, "Mpesa-Payment")
+		self.assertEqual(pr.payment_gateway, "Mpesa-Payment")
 
 		# submitting payment request creates integration requests with random id
 		integration_req_ids = frappe.get_all("Integration Request", filters={
@@ -126,12 +126,12 @@ class TestMpesaSettings(unittest.TestCase):
 			verify_transaction(**callback_response)
 			# test completion of integration request
 			integration_request = frappe.get_doc("Integration Request", integration_req_ids[i])
-			self.assertEquals(integration_request.status, "Completed")
+			self.assertEqual(integration_request.status, "Completed")
 			integration_requests.append(integration_request)
 
 		# check receipt number once all the integration requests are completed
 		pos_invoice.reload()
-		self.assertEquals(pos_invoice.mpesa_receipt_number, ', '.join(mpesa_receipt_numbers))
+		self.assertEqual(pos_invoice.mpesa_receipt_number, ', '.join(mpesa_receipt_numbers))
 
 		frappe.db.set_value("Customer", "_Test Customer", "default_currency", "")
 		[d.delete() for d in integration_requests]
@@ -155,7 +155,7 @@ class TestMpesaSettings(unittest.TestCase):
 
 		pr = pos_invoice.create_payment_request()
 		# test payment request creation
-		self.assertEquals(pr.payment_gateway, "Mpesa-Payment")
+		self.assertEqual(pr.payment_gateway, "Mpesa-Payment")
 
 		# submitting payment request creates integration requests with random id
 		integration_req_ids = frappe.get_all("Integration Request", filters={
@@ -175,7 +175,7 @@ class TestMpesaSettings(unittest.TestCase):
 		verify_transaction(**callback_response)
 		# test completion of integration request
 		integration_request = frappe.get_doc("Integration Request", integration_req_ids[0])
-		self.assertEquals(integration_request.status, "Completed")
+		self.assertEqual(integration_request.status, "Completed")
 
 		# now one request is completed
 		# second integration request fails
@@ -187,7 +187,7 @@ class TestMpesaSettings(unittest.TestCase):
 			'name': ['not in', integration_req_ids]
 		}, pluck="name")
 
-		self.assertEquals(len(new_integration_req_ids), 1)
+		self.assertEqual(len(new_integration_req_ids), 1)
 
 		frappe.db.set_value("Customer", "_Test Customer", "default_currency", "")
 		frappe.db.sql("delete from `tabIntegration Request` where integration_request_service = 'Mpesa'")

--- a/erpnext/healthcare/doctype/clinical_procedure/test_clinical_procedure.py
+++ b/erpnext/healthcare/doctype/clinical_procedure/test_clinical_procedure.py
@@ -17,7 +17,7 @@ class TestClinicalProcedure(unittest.TestCase):
 
 		procedure_template.disabled = 1
 		procedure_template.save()
-		self.assertEquals(frappe.db.get_value('Item', procedure_template.item, 'disabled'), 1)
+		self.assertEqual(frappe.db.get_value('Item', procedure_template.item, 'disabled'), 1)
 
 	def test_consumables(self):
 		patient, medical_department, practitioner = create_healthcare_docs()

--- a/erpnext/healthcare/doctype/lab_test/test_lab_test.py
+++ b/erpnext/healthcare/doctype/lab_test/test_lab_test.py
@@ -18,7 +18,7 @@ class TestLabTest(unittest.TestCase):
 
 		lab_template.disabled = 1
 		lab_template.save()
-		self.assertEquals(frappe.db.get_value('Item', lab_template.item, 'disabled'), 1)
+		self.assertEqual(frappe.db.get_value('Item', lab_template.item, 'disabled'), 1)
 
 		lab_template.reload()
 
@@ -57,7 +57,7 @@ class TestLabTest(unittest.TestCase):
 
 		# sample collection should not be created
 		lab_test.reload()
-		self.assertEquals(lab_test.sample, None)
+		self.assertEqual(lab_test.sample, None)
 
 	def test_create_lab_tests_from_sales_invoice(self):
 		sales_invoice = create_sales_invoice()

--- a/erpnext/healthcare/doctype/patient_appointment/test_patient_appointment.py
+++ b/erpnext/healthcare/doctype/patient_appointment/test_patient_appointment.py
@@ -20,13 +20,13 @@ class TestPatientAppointment(unittest.TestCase):
 		patient, medical_department, practitioner = create_healthcare_docs()
 		frappe.db.set_value('Healthcare Settings', None, 'automate_appointment_invoicing', 0)
 		appointment = create_appointment(patient, practitioner, nowdate())
-		self.assertEquals(appointment.status, 'Open')
+		self.assertEqual(appointment.status, 'Open')
 		appointment = create_appointment(patient, practitioner, add_days(nowdate(), 2))
-		self.assertEquals(appointment.status, 'Scheduled')
+		self.assertEqual(appointment.status, 'Scheduled')
 		encounter = create_encounter(appointment)
-		self.assertEquals(frappe.db.get_value('Patient Appointment', appointment.name, 'status'), 'Closed')
+		self.assertEqual(frappe.db.get_value('Patient Appointment', appointment.name, 'status'), 'Closed')
 		encounter.cancel()
-		self.assertEquals(frappe.db.get_value('Patient Appointment', appointment.name, 'status'), 'Open')
+		self.assertEqual(frappe.db.get_value('Patient Appointment', appointment.name, 'status'), 'Open')
 
 	def test_start_encounter(self):
 		patient, medical_department, practitioner = create_healthcare_docs()

--- a/erpnext/healthcare/doctype/therapy_plan/test_therapy_plan.py
+++ b/erpnext/healthcare/doctype/therapy_plan/test_therapy_plan.py
@@ -18,24 +18,24 @@ class TestTherapyPlan(unittest.TestCase):
 
 	def test_status(self):
 		plan = create_therapy_plan()
-		self.assertEquals(plan.status, 'Not Started')
+		self.assertEqual(plan.status, 'Not Started')
 
 		session = make_therapy_session(plan.name, plan.patient, 'Basic Rehab', '_Test Company')
 		frappe.get_doc(session).submit()
-		self.assertEquals(frappe.db.get_value('Therapy Plan', plan.name, 'status'), 'In Progress')
+		self.assertEqual(frappe.db.get_value('Therapy Plan', plan.name, 'status'), 'In Progress')
 
 		session = make_therapy_session(plan.name, plan.patient, 'Basic Rehab', '_Test Company')
 		frappe.get_doc(session).submit()
-		self.assertEquals(frappe.db.get_value('Therapy Plan', plan.name, 'status'), 'Completed')
+		self.assertEqual(frappe.db.get_value('Therapy Plan', plan.name, 'status'), 'Completed')
 
 		patient, medical_department, practitioner = create_healthcare_docs()
 		appointment = create_appointment(patient, practitioner, nowdate())		
 		session = make_therapy_session(plan.name, plan.patient, 'Basic Rehab', '_Test Company', appointment.name)
 		session = frappe.get_doc(session)
 		session.submit()
-		self.assertEquals(frappe.db.get_value('Patient Appointment', appointment.name, 'status'), 'Closed')
+		self.assertEqual(frappe.db.get_value('Patient Appointment', appointment.name, 'status'), 'Closed')
 		session.cancel()
-		self.assertEquals(frappe.db.get_value('Patient Appointment', appointment.name, 'status'), 'Open')
+		self.assertEqual(frappe.db.get_value('Patient Appointment', appointment.name, 'status'), 'Open')
 
 	def test_therapy_plan_from_template(self):
 		patient = create_patient()
@@ -49,7 +49,7 @@ class TestTherapyPlan(unittest.TestCase):
 		si.save()
 
 		therapy_plan_template_amt = frappe.db.get_value('Therapy Plan Template', template, 'total_amount')
-		self.assertEquals(si.items[0].amount, therapy_plan_template_amt)
+		self.assertEqual(si.items[0].amount, therapy_plan_template_amt)
 
 
 def create_therapy_plan(template=None):

--- a/erpnext/healthcare/doctype/therapy_type/test_therapy_type.py
+++ b/erpnext/healthcare/doctype/therapy_type/test_therapy_type.py
@@ -13,7 +13,7 @@ class TestTherapyType(unittest.TestCase):
 
 		therapy_type.disabled = 1
 		therapy_type.save()
-		self.assertEquals(frappe.db.get_value('Item', therapy_type.item, 'disabled'), 1)
+		self.assertEqual(frappe.db.get_value('Item', therapy_type.item, 'disabled'), 1)
 
 def create_therapy_type():
 	exercise = create_exercise_type()

--- a/erpnext/hr/doctype/compensatory_leave_request/test_compensatory_leave_request.py
+++ b/erpnext/hr/doctype/compensatory_leave_request/test_compensatory_leave_request.py
@@ -68,19 +68,19 @@ class TestCompensatoryLeaveRequest(unittest.TestCase):
 		filters = dict(transaction_name=compensatory_leave_request.leave_allocation)
 		leave_ledger_entry = frappe.get_all('Leave Ledger Entry', fields='*', filters=filters)
 
-		self.assertEquals(len(leave_ledger_entry), 1)
-		self.assertEquals(leave_ledger_entry[0].employee, compensatory_leave_request.employee)
-		self.assertEquals(leave_ledger_entry[0].leave_type, compensatory_leave_request.leave_type)
-		self.assertEquals(leave_ledger_entry[0].leaves, 1)
+		self.assertEqual(len(leave_ledger_entry), 1)
+		self.assertEqual(leave_ledger_entry[0].employee, compensatory_leave_request.employee)
+		self.assertEqual(leave_ledger_entry[0].leave_type, compensatory_leave_request.leave_type)
+		self.assertEqual(leave_ledger_entry[0].leaves, 1)
 
 		# check reverse leave ledger entry on cancellation
 		compensatory_leave_request.cancel()
 		leave_ledger_entry = frappe.get_all('Leave Ledger Entry', fields='*', filters=filters, order_by = 'creation desc')
 
-		self.assertEquals(len(leave_ledger_entry), 2)
-		self.assertEquals(leave_ledger_entry[0].employee, compensatory_leave_request.employee)
-		self.assertEquals(leave_ledger_entry[0].leave_type, compensatory_leave_request.leave_type)
-		self.assertEquals(leave_ledger_entry[0].leaves, -1)
+		self.assertEqual(len(leave_ledger_entry), 2)
+		self.assertEqual(leave_ledger_entry[0].employee, compensatory_leave_request.employee)
+		self.assertEqual(leave_ledger_entry[0].leave_type, compensatory_leave_request.leave_type)
+		self.assertEqual(leave_ledger_entry[0].leaves, -1)
 
 def get_compensatory_leave_request(employee, leave_date=today()):
 	prev_comp_leave_req = frappe.db.get_value('Compensatory Leave Request',

--- a/erpnext/hr/doctype/expense_claim/test_expense_claim.py
+++ b/erpnext/hr/doctype/expense_claim/test_expense_claim.py
@@ -88,9 +88,9 @@ class TestExpenseClaim(unittest.TestCase):
 		])
 
 		for gle in gl_entries:
-			self.assertEquals(expected_values[gle.account][0], gle.account)
-			self.assertEquals(expected_values[gle.account][1], gle.debit)
-			self.assertEquals(expected_values[gle.account][2], gle.credit)
+			self.assertEqual(expected_values[gle.account][0], gle.account)
+			self.assertEqual(expected_values[gle.account][1], gle.debit)
+			self.assertEqual(expected_values[gle.account][2], gle.credit)
 
 	def test_rejected_expense_claim(self):
 		payable_account = get_payable_account(company_name)
@@ -104,11 +104,11 @@ class TestExpenseClaim(unittest.TestCase):
 		})
 		expense_claim.submit()
 
-		self.assertEquals(expense_claim.status, 'Rejected')
-		self.assertEquals(expense_claim.total_sanctioned_amount, 0.0)
+		self.assertEqual(expense_claim.status, 'Rejected')
+		self.assertEqual(expense_claim.total_sanctioned_amount, 0.0)
 
 		gl_entry = frappe.get_all('GL Entry', {'voucher_type': 'Expense Claim', 'voucher_no': expense_claim.name})
-		self.assertEquals(len(gl_entry), 0)
+		self.assertEqual(len(gl_entry), 0)
 
 	def test_expense_approver_perms(self):
 		user = "test_approver_perm_emp@example.com"

--- a/erpnext/hr/doctype/job_offer/test_job_offer.py
+++ b/erpnext/hr/doctype/job_offer/test_job_offer.py
@@ -35,13 +35,13 @@ class TestJobOffer(unittest.TestCase):
 		job_offer = create_job_offer(job_applicant=job_applicant.name)
 		job_offer.submit()
 		job_applicant.reload()
-		self.assertEquals(job_applicant.status, "Accepted")
+		self.assertEqual(job_applicant.status, "Accepted")
 
 		# status update after rejection
 		job_offer.status = "Rejected"
 		job_offer.submit()
 		job_applicant.reload()
-		self.assertEquals(job_applicant.status, "Rejected")
+		self.assertEqual(job_applicant.status, "Rejected")
 
 def create_job_offer(**args):
 	args = frappe._dict(args)

--- a/erpnext/hr/doctype/leave_allocation/test_leave_allocation.py
+++ b/erpnext/hr/doctype/leave_allocation/test_leave_allocation.py
@@ -96,7 +96,7 @@ class TestLeaveAllocation(unittest.TestCase):
 			carry_forward=1)
 		leave_allocation_1.submit()
 
-		self.assertEquals(leave_allocation_1.unused_leaves, 10)
+		self.assertEqual(leave_allocation_1.unused_leaves, 10)
 
 		leave_allocation_1.cancel()
 
@@ -108,7 +108,7 @@ class TestLeaveAllocation(unittest.TestCase):
 			new_leaves_allocated=25)
 		leave_allocation_2.submit()
 
-		self.assertEquals(leave_allocation_2.unused_leaves, 5)
+		self.assertEqual(leave_allocation_2.unused_leaves, 5)
 
 	def test_carry_forward_leaves_expiry(self):
 		frappe.db.sql("delete from `tabLeave Allocation`")
@@ -145,7 +145,7 @@ class TestLeaveAllocation(unittest.TestCase):
 			to_date=add_months(nowdate(), 12))
 		leave_allocation_1.submit()
 
-		self.assertEquals(leave_allocation_1.unused_leaves, leave_allocation.new_leaves_allocated)
+		self.assertEqual(leave_allocation_1.unused_leaves, leave_allocation.new_leaves_allocated)
 
 	def test_creation_of_leave_ledger_entry_on_submit(self):
 		frappe.db.sql("delete from `tabLeave Allocation`")
@@ -155,10 +155,10 @@ class TestLeaveAllocation(unittest.TestCase):
 
 		leave_ledger_entry = frappe.get_all('Leave Ledger Entry', fields='*', filters=dict(transaction_name=leave_allocation.name))
 
-		self.assertEquals(len(leave_ledger_entry), 1)
-		self.assertEquals(leave_ledger_entry[0].employee, leave_allocation.employee)
-		self.assertEquals(leave_ledger_entry[0].leave_type, leave_allocation.leave_type)
-		self.assertEquals(leave_ledger_entry[0].leaves, leave_allocation.new_leaves_allocated)
+		self.assertEqual(len(leave_ledger_entry), 1)
+		self.assertEqual(leave_ledger_entry[0].employee, leave_allocation.employee)
+		self.assertEqual(leave_ledger_entry[0].leave_type, leave_allocation.leave_type)
+		self.assertEqual(leave_ledger_entry[0].leaves, leave_allocation.new_leaves_allocated)
 
 		# check if leave ledger entry is deleted on cancellation
 		leave_allocation.cancel()

--- a/erpnext/hr/doctype/leave_application/test_leave_application.py
+++ b/erpnext/hr/doctype/leave_application/test_leave_application.py
@@ -16,36 +16,36 @@ from erpnext.hr.doctype.employee.test_employee import make_employee
 test_dependencies = ["Leave Allocation", "Leave Block List", "Employee"]
 
 _test_records = [
- {
-  "company": "_Test Company",
-  "doctype": "Leave Application",
-  "employee": "_T-Employee-00001",
-  "from_date": "2013-05-01",
-  "description": "_Test Reason",
-  "leave_type": "_Test Leave Type",
-  "posting_date": "2013-01-02",
-  "to_date": "2013-05-05"
- },
- {
-  "company": "_Test Company",
-  "doctype": "Leave Application",
-  "employee": "_T-Employee-00002",
-  "from_date": "2013-05-01",
-  "description": "_Test Reason",
-  "leave_type": "_Test Leave Type",
-  "posting_date": "2013-01-02",
-  "to_date": "2013-05-05"
- },
- {
-  "company": "_Test Company",
-  "doctype": "Leave Application",
-  "employee": "_T-Employee-00001",
-  "from_date": "2013-01-15",
-  "description": "_Test Reason",
-  "leave_type": "_Test Leave Type LWP",
-  "posting_date": "2013-01-02",
-  "to_date": "2013-01-15"
- }
+	{
+		"company": "_Test Company",
+		"doctype": "Leave Application",
+		"employee": "_T-Employee-00001",
+		"from_date": "2013-05-01",
+		"description": "_Test Reason",
+		"leave_type": "_Test Leave Type",
+		"posting_date": "2013-01-02",
+		"to_date": "2013-05-05"
+	},
+	{
+		"company": "_Test Company",
+		"doctype": "Leave Application",
+		"employee": "_T-Employee-00002",
+		"from_date": "2013-05-01",
+		"description": "_Test Reason",
+		"leave_type": "_Test Leave Type",
+		"posting_date": "2013-01-02",
+		"to_date": "2013-05-05"
+	},
+	{
+		"company": "_Test Company",
+		"doctype": "Leave Application",
+		"employee": "_T-Employee-00001",
+		"from_date": "2013-01-15",
+		"description": "_Test Reason",
+		"leave_type": "_Test Leave Type LWP",
+		"posting_date": "2013-01-02",
+		"to_date": "2013-01-15"
+	}
 ]
 
 

--- a/erpnext/hr/doctype/leave_application/test_leave_application.py
+++ b/erpnext/hr/doctype/leave_application/test_leave_application.py
@@ -516,9 +516,9 @@ class TestLeaveApplication(unittest.TestCase):
 		leave_application.submit()
 		leave_ledger_entry = frappe.get_all('Leave Ledger Entry', fields='*', filters=dict(transaction_name=leave_application.name))
 
-		self.assertEquals(leave_ledger_entry[0].employee, leave_application.employee)
-		self.assertEquals(leave_ledger_entry[0].leave_type, leave_application.leave_type)
-		self.assertEquals(leave_ledger_entry[0].leaves, leave_application.total_leave_days * -1)
+		self.assertEqual(leave_ledger_entry[0].employee, leave_application.employee)
+		self.assertEqual(leave_ledger_entry[0].leave_type, leave_application.leave_type)
+		self.assertEqual(leave_ledger_entry[0].leaves, leave_application.total_leave_days * -1)
 
 		# check if leave ledger entry is deleted on cancellation
 		leave_application.cancel()
@@ -549,11 +549,11 @@ class TestLeaveApplication(unittest.TestCase):
 
 		leave_ledger_entry = frappe.get_all('Leave Ledger Entry', '*', filters=dict(transaction_name=leave_application.name))
 
-		self.assertEquals(len(leave_ledger_entry), 2)
-		self.assertEquals(leave_ledger_entry[0].employee, leave_application.employee)
-		self.assertEquals(leave_ledger_entry[0].leave_type, leave_application.leave_type)
-		self.assertEquals(leave_ledger_entry[0].leaves, -9)
-		self.assertEquals(leave_ledger_entry[1].leaves, -2)
+		self.assertEqual(len(leave_ledger_entry), 2)
+		self.assertEqual(leave_ledger_entry[0].employee, leave_application.employee)
+		self.assertEqual(leave_ledger_entry[0].leave_type, leave_application.leave_type)
+		self.assertEqual(leave_ledger_entry[0].leaves, -9)
+		self.assertEqual(leave_ledger_entry[1].leaves, -2)
 
 	def test_leave_application_creation_after_expiry(self):
 		# test leave balance for carry forwarded allocation
@@ -566,7 +566,7 @@ class TestLeaveApplication(unittest.TestCase):
 
 		create_carry_forwarded_allocation(employee, leave_type)
 
-		self.assertEquals(get_leave_balance_on(employee.name, leave_type.name, add_days(nowdate(), -85), add_days(nowdate(), -84)), 0)
+		self.assertEqual(get_leave_balance_on(employee.name, leave_type.name, add_days(nowdate(), -85), add_days(nowdate(), -84)), 0)
 
 	def test_leave_approver_perms(self):
 		employee = get_employee()

--- a/erpnext/hr/doctype/leave_encashment/test_leave_encashment.py
+++ b/erpnext/hr/doctype/leave_encashment/test_leave_encashment.py
@@ -88,10 +88,10 @@ class TestLeaveEncashment(unittest.TestCase):
 
 		leave_ledger_entry = frappe.get_all('Leave Ledger Entry', fields='*', filters=dict(transaction_name=leave_encashment.name))
 
-		self.assertEquals(len(leave_ledger_entry), 1)
-		self.assertEquals(leave_ledger_entry[0].employee, leave_encashment.employee)
-		self.assertEquals(leave_ledger_entry[0].leave_type, leave_encashment.leave_type)
-		self.assertEquals(leave_ledger_entry[0].leaves, leave_encashment.encashable_days *  -1)
+		self.assertEqual(len(leave_ledger_entry), 1)
+		self.assertEqual(leave_ledger_entry[0].employee, leave_encashment.employee)
+		self.assertEqual(leave_ledger_entry[0].leave_type, leave_encashment.leave_type)
+		self.assertEqual(leave_ledger_entry[0].leaves, leave_encashment.encashable_days *  -1)
 
 		# check if leave ledger entry is deleted on cancellation
 

--- a/erpnext/hr/doctype/leave_encashment/test_leave_encashment.py
+++ b/erpnext/hr/doctype/leave_encashment/test_leave_encashment.py
@@ -91,7 +91,7 @@ class TestLeaveEncashment(unittest.TestCase):
 		self.assertEqual(len(leave_ledger_entry), 1)
 		self.assertEqual(leave_ledger_entry[0].employee, leave_encashment.employee)
 		self.assertEqual(leave_ledger_entry[0].leave_type, leave_encashment.leave_type)
-		self.assertEqual(leave_ledger_entry[0].leaves, leave_encashment.encashable_days *  -1)
+		self.assertEqual(leave_ledger_entry[0].leaves, leave_encashment.encashable_days * -1)
 
 		# check if leave ledger entry is deleted on cancellation
 

--- a/erpnext/loan_management/doctype/loan/test_loan.py
+++ b/erpnext/loan_management/doctype/loan/test_loan.py
@@ -55,9 +55,9 @@ class TestLoan(unittest.TestCase):
 
 	def test_loan(self):
 		loan = frappe.get_doc("Loan", {"applicant":self.applicant1})
-		self.assertEquals(loan.monthly_repayment_amount, 15052)
-		self.assertEquals(flt(loan.total_interest_payable, 0), 21034)
-		self.assertEquals(flt(loan.total_payment, 0), 301034)
+		self.assertEqual(loan.monthly_repayment_amount, 15052)
+		self.assertEqual(flt(loan.total_interest_payable, 0), 21034)
+		self.assertEqual(flt(loan.total_payment, 0), 301034)
 
 		schedule = loan.repayment_schedule
 
@@ -72,9 +72,9 @@ class TestLoan(unittest.TestCase):
 		loan.monthly_repayment_amount = 14000
 		loan.save()
 
-		self.assertEquals(len(loan.repayment_schedule), 22)
-		self.assertEquals(flt(loan.total_interest_payable, 0), 22712)
-		self.assertEquals(flt(loan.total_payment, 0), 302712)
+		self.assertEqual(len(loan.repayment_schedule), 22)
+		self.assertEqual(flt(loan.total_interest_payable, 0), 22712)
+		self.assertEqual(flt(loan.total_payment, 0), 302712)
 
 	def test_loan_with_security(self):
 
@@ -89,7 +89,7 @@ class TestLoan(unittest.TestCase):
 
 		loan = create_loan_with_security(self.applicant2, "Stock Loan", "Repay Over Number of Periods",
 			12, loan_application)
-		self.assertEquals(loan.loan_amount, 1000000)
+		self.assertEqual(loan.loan_amount, 1000000)
 
 	def test_loan_disbursement(self):
 		pledge = [{
@@ -102,7 +102,7 @@ class TestLoan(unittest.TestCase):
 		create_pledge(loan_application)
 
 		loan = create_loan_with_security(self.applicant2, "Stock Loan", "Repay Over Number of Periods", 12, loan_application)
-		self.assertEquals(loan.loan_amount, 1000000)
+		self.assertEqual(loan.loan_amount, 1000000)
 
 		loan.submit()
 
@@ -120,8 +120,8 @@ class TestLoan(unittest.TestCase):
 			filters = {'voucher_type': 'Loan Disbursement', 'voucher_no': loan_disbursement_entry2.name}
 		)
 
-		self.assertEquals(loan.status, "Disbursed")
-		self.assertEquals(loan.disbursed_amount, 1000000)
+		self.assertEqual(loan.status, "Disbursed")
+		self.assertEqual(loan.disbursed_amount, 1000000)
 		self.assertTrue(gl_entries1)
 		self.assertTrue(gl_entries2)
 
@@ -137,7 +137,7 @@ class TestLoan(unittest.TestCase):
 		loan = create_demand_loan(self.applicant2, "Demand Loan", loan_application, posting_date='2019-10-01')
 		loan.submit()
 
-		self.assertEquals(loan.loan_amount, 1000000)
+		self.assertEqual(loan.loan_amount, 1000000)
 
 		first_date = '2019-10-01'
 		last_date = '2019-10-30'
@@ -156,15 +156,15 @@ class TestLoan(unittest.TestCase):
 		repayment_entry.submit()
 
 		penalty_amount = (accrued_interest_amount * 5 * 25) / 100
-		self.assertEquals(flt(repayment_entry.penalty_amount,0), flt(penalty_amount, 0))
+		self.assertEqual(flt(repayment_entry.penalty_amount,0), flt(penalty_amount, 0))
 
 		amounts = frappe.db.get_all('Loan Interest Accrual', {'loan': loan.name}, ['paid_interest_amount'])
 
 		loan.load_from_db()
 
 		total_interest_paid = amounts[0]['paid_interest_amount'] + amounts[1]['paid_interest_amount']
-		self.assertEquals(amounts[1]['paid_interest_amount'], repayment_entry.interest_payable)
-		self.assertEquals(flt(loan.total_principal_paid, 0), flt(repayment_entry.amount_paid -
+		self.assertEqual(amounts[1]['paid_interest_amount'], repayment_entry.interest_payable)
+		self.assertEqual(flt(loan.total_principal_paid, 0), flt(repayment_entry.amount_paid -
 			 penalty_amount - total_interest_paid, 0))
 
 	def test_loan_closure(self):
@@ -179,7 +179,7 @@ class TestLoan(unittest.TestCase):
 		loan = create_demand_loan(self.applicant2, "Demand Loan", loan_application, posting_date='2019-10-01')
 		loan.submit()
 
-		self.assertEquals(loan.loan_amount, 1000000)
+		self.assertEqual(loan.loan_amount, 1000000)
 
 		first_date = '2019-10-01'
 		last_date = '2019-10-30'
@@ -204,12 +204,12 @@ class TestLoan(unittest.TestCase):
 
 		amount = frappe.db.get_value('Loan Interest Accrual', {'loan': loan.name}, ['sum(paid_interest_amount)'])
 
-		self.assertEquals(flt(amount, 0),flt(accrued_interest_amount, 0))
-		self.assertEquals(flt(repayment_entry.penalty_amount, 5), 0)
+		self.assertEqual(flt(amount, 0),flt(accrued_interest_amount, 0))
+		self.assertEqual(flt(repayment_entry.penalty_amount, 5), 0)
 
 		request_loan_closure(loan.name)
 		loan.load_from_db()
-		self.assertEquals(loan.status, "Loan Closure Requested")
+		self.assertEqual(loan.status, "Loan Closure Requested")
 
 	def test_loan_repayment_for_term_loan(self):
 		pledges = [{
@@ -241,8 +241,8 @@ class TestLoan(unittest.TestCase):
 		amounts = frappe.db.get_value('Loan Interest Accrual', {'loan': loan.name}, ['paid_interest_amount',
 			'paid_principal_amount'])
 
-		self.assertEquals(amounts[0], 11250.00)
-		self.assertEquals(amounts[1], 78303.00)
+		self.assertEqual(amounts[0], 11250.00)
+		self.assertEqual(amounts[1], 78303.00)
 
 	def test_security_shortfall(self):
 		pledges = [{
@@ -268,17 +268,17 @@ class TestLoan(unittest.TestCase):
 		loan_security_shortfall = frappe.get_doc("Loan Security Shortfall", {"loan": loan.name})
 		self.assertTrue(loan_security_shortfall)
 
-		self.assertEquals(loan_security_shortfall.loan_amount, 1000000.00)
-		self.assertEquals(loan_security_shortfall.security_value, 800000.00)
-		self.assertEquals(loan_security_shortfall.shortfall_amount, 600000.00)
+		self.assertEqual(loan_security_shortfall.loan_amount, 1000000.00)
+		self.assertEqual(loan_security_shortfall.security_value, 800000.00)
+		self.assertEqual(loan_security_shortfall.shortfall_amount, 600000.00)
 
 		frappe.db.sql(""" UPDATE `tabLoan Security Price` SET loan_security_price = 250
 			where loan_security='Test Security 2'""")
 
 		create_process_loan_security_shortfall()
 		loan_security_shortfall = frappe.get_doc("Loan Security Shortfall", {"loan": loan.name})
-		self.assertEquals(loan_security_shortfall.status, "Completed")
-		self.assertEquals(loan_security_shortfall.shortfall_amount, 0)
+		self.assertEqual(loan_security_shortfall.status, "Completed")
+		self.assertEqual(loan_security_shortfall.shortfall_amount, 0)
 
 	def test_loan_security_unpledge(self):
 		pledge = [{
@@ -292,7 +292,7 @@ class TestLoan(unittest.TestCase):
 		loan = create_demand_loan(self.applicant2, "Demand Loan", loan_application, posting_date='2019-10-01')
 		loan.submit()
 
-		self.assertEquals(loan.loan_amount, 1000000)
+		self.assertEqual(loan.loan_amount, 1000000)
 
 		first_date = '2019-10-01'
 		last_date = '2019-10-30'
@@ -312,7 +312,7 @@ class TestLoan(unittest.TestCase):
 
 		request_loan_closure(loan.name)
 		loan.load_from_db()
-		self.assertEquals(loan.status, "Loan Closure Requested")
+		self.assertEqual(loan.status, "Loan Closure Requested")
 
 		unpledge_request = unpledge_security(loan=loan.name, save=1)
 		unpledge_request.submit()
@@ -323,11 +323,11 @@ class TestLoan(unittest.TestCase):
 		pledged_qty = get_pledged_security_qty(loan.name)
 
 		self.assertEqual(loan.status, 'Closed')
-		self.assertEquals(sum(pledged_qty.values()), 0)
+		self.assertEqual(sum(pledged_qty.values()), 0)
 
 		amounts = amounts = calculate_amounts(loan.name, add_days(last_date, 5))
 		self.assertEqual(amounts['pending_principal_amount'], 0)
-		self.assertEquals(amounts['payable_principal_amount'], 0.0)
+		self.assertEqual(amounts['payable_principal_amount'], 0.0)
 		self.assertEqual(amounts['interest_amount'], 0)
 
 	def test_partial_loan_security_unpledge(self):
@@ -346,7 +346,7 @@ class TestLoan(unittest.TestCase):
 		loan = create_demand_loan(self.applicant2, "Demand Loan", loan_application, posting_date='2019-10-01')
 		loan.submit()
 
-		self.assertEquals(loan.loan_amount, 1000000)
+		self.assertEqual(loan.loan_amount, 1000000)
 
 		first_date = '2019-10-01'
 		last_date = '2019-10-30'
@@ -379,7 +379,7 @@ class TestLoan(unittest.TestCase):
 		loan = create_demand_loan(self.applicant2, "Demand Loan", loan_application, posting_date='2019-10-01')
 		loan.submit()
 
-		self.assertEquals(loan.loan_amount, 1000000)
+		self.assertEqual(loan.loan_amount, 1000000)
 
 		unpledge_map = {'Test Security 1': 4000}
 		unpledge_request = unpledge_security(loan=loan.name, security_map = unpledge_map, save=1)
@@ -450,7 +450,7 @@ class TestLoan(unittest.TestCase):
 		loan = create_demand_loan(self.applicant2, "Demand Loan", loan_application, posting_date='2019-10-01')
 		loan.submit()
 
-		self.assertEquals(loan.loan_amount, 1000000)
+		self.assertEqual(loan.loan_amount, 1000000)
 
 		first_date = '2019-10-01'
 		last_date = '2019-10-30'
@@ -475,7 +475,7 @@ class TestLoan(unittest.TestCase):
 
 		request_loan_closure(loan.name)
 		loan.load_from_db()
-		self.assertEquals(loan.status, "Loan Closure Requested")
+		self.assertEqual(loan.status, "Loan Closure Requested")
 
 		amounts = calculate_amounts(loan.name, add_days(last_date, 5))
 		self.assertEqual(amounts['pending_principal_amount'], 0.0)
@@ -492,7 +492,7 @@ class TestLoan(unittest.TestCase):
 		loan = create_demand_loan(self.applicant2, "Demand Loan", loan_application, posting_date='2019-10-01')
 		loan.submit()
 
-		self.assertEquals(loan.loan_amount, 1000000)
+		self.assertEqual(loan.loan_amount, 1000000)
 
 		first_date = '2019-10-01'
 		last_date = '2019-10-30'
@@ -533,8 +533,8 @@ class TestLoan(unittest.TestCase):
 		calculated_penalty_amount = frappe.db.get_value('Loan Interest Accrual',
 			{'process_loan_interest_accrual': process, 'loan': loan.name}, 'penalty_amount')
 
-		self.assertEquals(loan.loan_amount, 1000000)
-		self.assertEquals(calculated_penalty_amount, penalty_amount)
+		self.assertEqual(loan.loan_amount, 1000000)
+		self.assertEqual(calculated_penalty_amount, penalty_amount)
 
 	def test_penalty_repayment(self):
 		loan, dummy = create_loan_scenario_for_penalty(self)
@@ -547,13 +547,13 @@ class TestLoan(unittest.TestCase):
 		repayment_entry.submit()
 
 		amounts = calculate_amounts(loan.name, '2019-11-30 00:00:01')
-		self.assertEquals(amounts['penalty_amount'], second_penalty)
+		self.assertEqual(amounts['penalty_amount'], second_penalty)
 
 		repayment_entry = create_repayment_entry(loan.name, self.applicant2, '2019-11-30 00:00:01', second_penalty)
 		repayment_entry.submit()
 
 		amounts = calculate_amounts(loan.name, '2019-11-30 00:00:02')
-		self.assertEquals(amounts['penalty_amount'], 0)
+		self.assertEqual(amounts['penalty_amount'], 0)
 
 	def test_loan_write_off_limit(self):
 		pledge = [{
@@ -567,7 +567,7 @@ class TestLoan(unittest.TestCase):
 		loan = create_demand_loan(self.applicant2, "Demand Loan", loan_application, posting_date='2019-10-01')
 		loan.submit()
 
-		self.assertEquals(loan.loan_amount, 1000000)
+		self.assertEqual(loan.loan_amount, 1000000)
 
 		first_date = '2019-10-01'
 		last_date = '2019-10-30'
@@ -589,15 +589,15 @@ class TestLoan(unittest.TestCase):
 
 		amount = frappe.db.get_value('Loan Interest Accrual', {'loan': loan.name}, ['sum(paid_interest_amount)'])
 
-		self.assertEquals(flt(amount, 0),flt(accrued_interest_amount, 0))
-		self.assertEquals(flt(repayment_entry.penalty_amount, 5), 0)
+		self.assertEqual(flt(amount, 0),flt(accrued_interest_amount, 0))
+		self.assertEqual(flt(repayment_entry.penalty_amount, 5), 0)
 
 		amounts = calculate_amounts(loan.name, add_days(last_date, 5))
-		self.assertEquals(flt(amounts['pending_principal_amount'], 0), 50)
+		self.assertEqual(flt(amounts['pending_principal_amount'], 0), 50)
 
 		request_loan_closure(loan.name)
 		loan.load_from_db()
-		self.assertEquals(loan.status, "Loan Closure Requested")
+		self.assertEqual(loan.status, "Loan Closure Requested")
 
 	def test_loan_amount_write_off(self):
 		pledge = [{
@@ -611,7 +611,7 @@ class TestLoan(unittest.TestCase):
 		loan = create_demand_loan(self.applicant2, "Demand Loan", loan_application, posting_date='2019-10-01')
 		loan.submit()
 
-		self.assertEquals(loan.loan_amount, 1000000)
+		self.assertEqual(loan.loan_amount, 1000000)
 
 		first_date = '2019-10-01'
 		last_date = '2019-10-30'
@@ -633,17 +633,17 @@ class TestLoan(unittest.TestCase):
 
 		amount = frappe.db.get_value('Loan Interest Accrual', {'loan': loan.name}, ['sum(paid_interest_amount)'])
 
-		self.assertEquals(flt(amount, 0),flt(accrued_interest_amount, 0))
-		self.assertEquals(flt(repayment_entry.penalty_amount, 5), 0)
+		self.assertEqual(flt(amount, 0),flt(accrued_interest_amount, 0))
+		self.assertEqual(flt(repayment_entry.penalty_amount, 5), 0)
 
 		amounts = calculate_amounts(loan.name, add_days(last_date, 5))
-		self.assertEquals(flt(amounts['pending_principal_amount'], 0), 100)
+		self.assertEqual(flt(amounts['pending_principal_amount'], 0), 100)
 
 		we = make_loan_write_off(loan.name, amount=amounts['pending_principal_amount'])
 		we.submit()
 
 		amounts = calculate_amounts(loan.name, add_days(last_date, 5))
-		self.assertEquals(flt(amounts['pending_principal_amount'], 0), 0)
+		self.assertEqual(flt(amounts['pending_principal_amount'], 0), 0)
 
 def create_loan_scenario_for_penalty(doc):
 	pledge = [{

--- a/erpnext/loan_management/doctype/loan_disbursement/test_loan_disbursement.py
+++ b/erpnext/loan_management/doctype/loan_disbursement/test_loan_disbursement.py
@@ -87,7 +87,7 @@ class TestLoanDisbursement(unittest.TestCase):
 		loan = create_demand_loan(self.applicant, "Demand Loan", loan_application, posting_date='2019-10-01')
 		loan.submit()
 
-		self.assertEquals(loan.loan_amount, 1000000)
+		self.assertEqual(loan.loan_amount, 1000000)
 
 		first_date = '2019-10-01'
 		last_date = '2019-10-30'
@@ -114,5 +114,5 @@ class TestLoanDisbursement(unittest.TestCase):
 		per_day_interest = get_per_day_interest(1500000, 13.5, '2019-10-30')
 		interest = per_day_interest * 15
 
-		self.assertEquals(amounts['pending_principal_amount'], 1500000)
-		self.assertEquals(amounts['interest_amount'], flt(interest + previous_interest, 2))
+		self.assertEqual(amounts['pending_principal_amount'], 1500000)
+		self.assertEqual(amounts['interest_amount'], flt(interest + previous_interest, 2))

--- a/erpnext/loan_management/doctype/loan_interest_accrual/test_loan_interest_accrual.py
+++ b/erpnext/loan_management/doctype/loan_interest_accrual/test_loan_interest_accrual.py
@@ -52,7 +52,7 @@ class TestLoanInterestAccrual(unittest.TestCase):
 		process_loan_interest_accrual_for_demand_loans(posting_date=last_date)
 		loan_interest_accural = frappe.get_doc("Loan Interest Accrual", {'loan': loan.name})
 
-		self.assertEquals(flt(loan_interest_accural.interest_amount, 0), flt(accrued_interest_amount, 0))
+		self.assertEqual(flt(loan_interest_accural.interest_amount, 0), flt(accrued_interest_amount, 0))
 
 	def test_accumulated_amounts(self):
 		pledge = [{
@@ -76,7 +76,7 @@ class TestLoanInterestAccrual(unittest.TestCase):
 		process_loan_interest_accrual_for_demand_loans(posting_date=last_date)
 		loan_interest_accrual = frappe.get_doc("Loan Interest Accrual", {'loan': loan.name})
 
-		self.assertEquals(flt(loan_interest_accrual.interest_amount, 0), flt(accrued_interest_amount, 0))
+		self.assertEqual(flt(loan_interest_accrual.interest_amount, 0), flt(accrued_interest_amount, 0))
 
 		next_start_date = '2019-10-31'
 		next_end_date = '2019-11-29'
@@ -90,4 +90,4 @@ class TestLoanInterestAccrual(unittest.TestCase):
 
 		loan_interest_accrual = frappe.get_doc("Loan Interest Accrual", {'loan': loan.name,
 			'process_loan_interest_accrual': process})
-		self.assertEquals(flt(loan_interest_accrual.total_pending_interest_amount, 0), total_pending_interest_amount)
+		self.assertEqual(flt(loan_interest_accrual.total_pending_interest_amount, 0), total_pending_interest_amount)

--- a/erpnext/manufacturing/doctype/bom/test_bom.py
+++ b/erpnext/manufacturing/doctype/bom/test_bom.py
@@ -223,7 +223,7 @@ class TestBOM(unittest.TestCase):
 			is_subcontracted="Yes", supplier_warehouse="_Test Warehouse 1 - _TC")
 		bom_items = sorted([d.item_code for d in bom.items if d.sourced_by_supplier != 1])
 		supplied_items = sorted([d.rm_item_code for d in po.supplied_items])
-		self.assertEquals(bom_items, supplied_items)
+		self.assertEqual(bom_items, supplied_items)
 
 def get_default_bom(item_code="_Test FG Item 2"):
 	return frappe.db.get_value("BOM", {"item": item_code, "is_active": 1, "is_default": 1})

--- a/erpnext/manufacturing/doctype/bom_update_tool/test_bom_update_tool.py
+++ b/erpnext/manufacturing/doctype/bom_update_tool/test_bom_update_tool.py
@@ -45,16 +45,16 @@ class TestBOMUpdateTool(unittest.TestCase):
 		else:
 			doc = frappe.get_doc("BOM", bom_no)
 
-		self.assertEquals(doc.total_cost, 200)
+		self.assertEqual(doc.total_cost, 200)
 
 		frappe.db.set_value("Item", "BOM Cost Test Item 2", "valuation_rate", 200)
 		update_cost()
 
 		doc.load_from_db()
-		self.assertEquals(doc.total_cost, 300)
+		self.assertEqual(doc.total_cost, 300)
 
 		frappe.db.set_value("Item", "BOM Cost Test Item 2", "valuation_rate", 100)
 		update_cost()
 
 		doc.load_from_db()
-		self.assertEquals(doc.total_cost, 200)
+		self.assertEqual(doc.total_cost, 200)

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -473,7 +473,7 @@ class TestWorkOrder(unittest.TestCase):
 	def test_cost_center_for_manufacture(self):
 		wo_order = make_wo_order_test_record()
 		ste = make_stock_entry(wo_order.name, "Material Transfer for Manufacture", wo_order.qty)
-		self.assertEquals(ste.get("items")[0].get("cost_center"), "_Test Cost Center - _TC")
+		self.assertEqual(ste.get("items")[0].get("cost_center"), "_Test Cost Center - _TC")
 
 	def test_operation_time_with_batch_size(self):
 		fg_item = "Test Batch Size Item For BOM"
@@ -539,11 +539,11 @@ class TestWorkOrder(unittest.TestCase):
 		ste_cancel_list.append(ste1)
 
 		ste3 = frappe.get_doc(make_stock_entry(wo_order.name, "Material Consumption for Manufacture", 2))
-		self.assertEquals(ste3.fg_completed_qty, 2)
+		self.assertEqual(ste3.fg_completed_qty, 2)
 
 		expected_qty = {"_Test Item": 2, "_Test Item Home Desktop 100": 4}
 		for row in ste3.items:
-			self.assertEquals(row.qty, expected_qty.get(row.item_code))
+			self.assertEqual(row.qty, expected_qty.get(row.item_code))
 		ste_cancel_list.reverse()
 		for ste_doc in ste_cancel_list:
 			ste_doc.cancel()
@@ -577,7 +577,7 @@ class TestWorkOrder(unittest.TestCase):
 		ste3 = frappe.get_doc(make_stock_entry(wo_order.name, "Manufacture", 2))
 		for ste_row in ste3.items:
 			if itemwise_qty.get(ste_row.item_code) and ste_row.s_warehouse:
-				self.assertEquals(ste_row.qty, itemwise_qty.get(ste_row.item_code) / 2)
+				self.assertEqual(ste_row.qty, itemwise_qty.get(ste_row.item_code) / 2)
 
 		ste3.submit()
 		ste_cancel_list.append(ste3)
@@ -585,7 +585,7 @@ class TestWorkOrder(unittest.TestCase):
 		ste2 = frappe.get_doc(make_stock_entry(wo_order.name, "Manufacture", 2))
 		for ste_row in ste2.items:
 			if itemwise_qty.get(ste_row.item_code) and ste_row.s_warehouse:
-				self.assertEquals(ste_row.qty, itemwise_qty.get(ste_row.item_code) / 2)
+				self.assertEqual(ste_row.qty, itemwise_qty.get(ste_row.item_code) / 2)
 		ste_cancel_list.reverse()
 		for ste_doc in ste_cancel_list:
 			ste_doc.cancel()

--- a/erpnext/non_profit/doctype/donation/test_donation.py
+++ b/erpnext/non_profit/doctype/donation/test_donation.py
@@ -39,7 +39,7 @@ class TestDonation(unittest.TestCase):
 		donation.on_payment_authorized()
 		donation.reload()
 
-		self.assertEquals(donation.paid, 1)
+		self.assertEqual(donation.paid, 1)
 		self.assertTrue(frappe.db.exists('Payment Entry', {'reference_no': donation.name}))
 
 

--- a/erpnext/portal/doctype/homepage/test_homepage.py
+++ b/erpnext/portal/doctype/homepage/test_homepage.py
@@ -13,7 +13,7 @@ class TestHomepage(unittest.TestCase):
 		set_request(method='GET', path='home')
 		response = render()
 
-		self.assertEquals(response.status_code, 200)
+		self.assertEqual(response.status_code, 200)
 
 		html = frappe.safe_decode(response.get_data())
 		self.assertTrue('<section class="hero-section' in html)

--- a/erpnext/portal/doctype/homepage_section/test_homepage_section.py
+++ b/erpnext/portal/doctype/homepage_section/test_homepage_section.py
@@ -28,7 +28,7 @@ class TestHomepageSection(unittest.TestCase):
 		set_request(method='GET', path='home')
 		response = render()
 
-		self.assertEquals(response.status_code, 200)
+		self.assertEqual(response.status_code, 200)
 
 		html = frappe.safe_decode(response.get_data())
 
@@ -61,7 +61,7 @@ class TestHomepageSection(unittest.TestCase):
 		set_request(method='GET', path='home')
 		response = render()
 
-		self.assertEquals(response.status_code, 200)
+		self.assertEqual(response.status_code, 200)
 
 		html = frappe.safe_decode(response.get_data())
 

--- a/erpnext/regional/doctype/tax_exemption_80g_certificate/test_tax_exemption_80g_certificate.py
+++ b/erpnext/regional/doctype/tax_exemption_80g_certificate/test_tax_exemption_80g_certificate.py
@@ -49,11 +49,11 @@ class TestTaxExemption80GCertificate(unittest.TestCase):
 		certificate.insert()
 
 		# check company details
-		self.assertEquals(certificate.company_pan_number, 'BBBTI3374C')
-		self.assertEquals(certificate.company_80g_number, 'NQ.CIT(E)I2018-19/DEL-IE28615-27062018/10087')
+		self.assertEqual(certificate.company_pan_number, 'BBBTI3374C')
+		self.assertEqual(certificate.company_80g_number, 'NQ.CIT(E)I2018-19/DEL-IE28615-27062018/10087')
 
 		# check donation details
-		self.assertEquals(certificate.amount, donation.amount)
+		self.assertEqual(certificate.amount, donation.amount)
 
 		duplicate_certificate = create_80g_certificate(args)
 		# duplicate validation
@@ -83,9 +83,9 @@ class TestTaxExemption80GCertificate(unittest.TestCase):
 		certificate.get_payments()
 		certificate.insert()
 
-		self.assertEquals(len(certificate.payments), 1)
-		self.assertEquals(certificate.payments[0].amount, membership.amount)
-		self.assertEquals(certificate.payments[0].invoice_id, invoice.name)
+		self.assertEqual(len(certificate.payments), 1)
+		self.assertEqual(certificate.payments[0].amount, membership.amount)
+		self.assertEqual(certificate.payments[0].invoice_id, invoice.name)
 
 
 def create_80g_certificate(args):

--- a/erpnext/selling/doctype/quotation/test_quotation.py
+++ b/erpnext/selling/doctype/quotation/test_quotation.py
@@ -48,7 +48,7 @@ class TestQuotation(unittest.TestCase):
 		sales_order.transaction_date = nowdate()
 		sales_order.insert()
 
-		self.assertEquals(sales_order.currency, "USD")
+		self.assertEqual(sales_order.currency, "USD")
 		self.assertNotEqual(sales_order.currency, quotation.currency)
 
 	def test_make_sales_order(self):

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -85,7 +85,7 @@ class TestSalesOrder(unittest.TestCase):
 		si1.update_billed_amount_in_sales_order = 1
 		si1.submit()
 		so.load_from_db()
-		self.assertEquals(so.per_billed, 0)
+		self.assertEqual(so.per_billed, 0)
 
 	def test_make_sales_invoice_with_terms(self):
 		so = make_sales_order(do_not_submit=True)
@@ -996,7 +996,7 @@ class TestSalesOrder(unittest.TestCase):
 		# Check if Work Orders were raised
 		for item in so_item_name:
 			wo_qty = frappe.db.sql("select sum(qty) from `tabWork Order` where sales_order=%s and sales_order_item=%s", (so.name, item))
-			self.assertEquals(wo_qty[0][0], so_item_name.get(item))
+			self.assertEqual(wo_qty[0][0], so_item_name.get(item))
 
 	def test_serial_no_based_delivery(self):
 		frappe.set_value("Stock Settings", None, "automatically_set_serial_nos_based_on_fifo", 1)

--- a/erpnext/stock/doctype/delivery_note/test_delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/test_delivery_note.py
@@ -710,7 +710,7 @@ class TestDeliveryNote(unittest.TestCase):
 		dn1.submit()
 
 		si = make_sales_invoice(dn.name)
-		self.assertEquals(si.items[0].qty, 1)
+		self.assertEqual(si.items[0].qty, 1)
 
 	def test_make_sales_invoice_from_dn_with_returned_qty_duplicate_items(self):
 		from erpnext.stock.doctype.delivery_note.delivery_note import make_sales_invoice
@@ -738,8 +738,8 @@ class TestDeliveryNote(unittest.TestCase):
 		dn1.submit()
 
 		si2 = make_sales_invoice(dn.name)
-		self.assertEquals(si2.items[0].qty, 2)
-		self.assertEquals(si2.items[1].qty, 1)
+		self.assertEqual(si2.items[0].qty, 2)
+		self.assertEqual(si2.items[1].qty, 1)
 
 def create_delivery_note(**args):
 	dn = frappe.new_doc("Delivery Note")

--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -620,10 +620,10 @@ class TestPurchaseReceipt(unittest.TestCase):
 		pr = make_purchase_receipt(item_code=asset_item, qty=3)
 		assets = frappe.db.get_all('Asset', filters={'purchase_receipt': pr.name})
 
-		self.assertEquals(len(assets), 3)
+		self.assertEqual(len(assets), 3)
 
 		location = frappe.db.get_value('Asset', assets[0].name, 'location')
-		self.assertEquals(location, "Test Location")
+		self.assertEqual(location, "Test Location")
 
 		pr.cancel()
 
@@ -728,7 +728,7 @@ class TestPurchaseReceipt(unittest.TestCase):
 		pr1.submit()
 
 		pi = make_purchase_invoice(pr.name)
-		self.assertEquals(pi.items[0].qty, 3)
+		self.assertEqual(pi.items[0].qty, 3)
 
 		pr1.cancel()
 		pr.reload()
@@ -759,8 +759,8 @@ class TestPurchaseReceipt(unittest.TestCase):
 		pr2.submit()
 
 		pi2 = make_purchase_invoice(pr1.name)
-		self.assertEquals(pi2.items[0].qty, 2)
-		self.assertEquals(pi2.items[1].qty, 1)
+		self.assertEqual(pi2.items[0].qty, 2)
+		self.assertEqual(pi2.items[1].qty, 1)
 
 		pr2.cancel()
 		pi1.cancel()

--- a/erpnext/support/doctype/issue/test_issue.py
+++ b/erpnext/support/doctype/issue/test_issue.py
@@ -22,50 +22,50 @@ class TestIssue(unittest.TestCase):
 		customer = create_customer("_Test Customer", "__Test SLA Customer Group", "__Test SLA Territory")
 		issue = make_issue(creation, "_Test Customer", 1)
 
-		self.assertEquals(issue.response_by, datetime.datetime(2019, 3, 4, 14, 0))
-		self.assertEquals(issue.resolution_by, datetime.datetime(2019, 3, 4, 15, 0))
+		self.assertEqual(issue.response_by, datetime.datetime(2019, 3, 4, 14, 0))
+		self.assertEqual(issue.resolution_by, datetime.datetime(2019, 3, 4, 15, 0))
 
 		# make issue with customer_group specific SLA
 		customer = create_customer("__Test Customer", "_Test SLA Customer Group", "__Test SLA Territory")
 		issue = make_issue(creation, "__Test Customer", 2)
 
-		self.assertEquals(issue.response_by, datetime.datetime(2019, 3, 4, 14, 0))
-		self.assertEquals(issue.resolution_by, datetime.datetime(2019, 3, 4, 15, 0))
+		self.assertEqual(issue.response_by, datetime.datetime(2019, 3, 4, 14, 0))
+		self.assertEqual(issue.resolution_by, datetime.datetime(2019, 3, 4, 15, 0))
 
 
 		# make issue with territory specific SLA
 		customer = create_customer("___Test Customer", "__Test SLA Customer Group", "_Test SLA Territory")
 		issue = make_issue(creation, "___Test Customer", 3)
 
-		self.assertEquals(issue.response_by, datetime.datetime(2019, 3, 4, 14, 0))
-		self.assertEquals(issue.resolution_by, datetime.datetime(2019, 3, 4, 15, 0))
+		self.assertEqual(issue.response_by, datetime.datetime(2019, 3, 4, 14, 0))
+		self.assertEqual(issue.resolution_by, datetime.datetime(2019, 3, 4, 15, 0))
 
 		# make issue with default SLA
 		issue = make_issue(creation=creation, index=4)
 
-		self.assertEquals(issue.response_by, datetime.datetime(2019, 3, 4, 16, 0))
-		self.assertEquals(issue.resolution_by, datetime.datetime(2019, 3, 4, 18, 0))
+		self.assertEqual(issue.response_by, datetime.datetime(2019, 3, 4, 16, 0))
+		self.assertEqual(issue.resolution_by, datetime.datetime(2019, 3, 4, 18, 0))
 
 		# make issue with default SLA before working hours
 		creation = datetime.datetime(2019, 3, 4, 7, 0)
 		issue = make_issue(creation=creation, index=5)
 
-		self.assertEquals(issue.response_by, datetime.datetime(2019, 3, 4, 14, 0))
-		self.assertEquals(issue.resolution_by, datetime.datetime(2019, 3, 4, 16, 0))
+		self.assertEqual(issue.response_by, datetime.datetime(2019, 3, 4, 14, 0))
+		self.assertEqual(issue.resolution_by, datetime.datetime(2019, 3, 4, 16, 0))
 
 		# make issue with default SLA after working hours
 		creation = datetime.datetime(2019, 3, 4, 20, 0)
 		issue = make_issue(creation, index=6)
 
-		self.assertEquals(issue.response_by, datetime.datetime(2019, 3, 6, 14, 0))
-		self.assertEquals(issue.resolution_by, datetime.datetime(2019, 3, 6, 16, 0))
+		self.assertEqual(issue.response_by, datetime.datetime(2019, 3, 6, 14, 0))
+		self.assertEqual(issue.resolution_by, datetime.datetime(2019, 3, 6, 16, 0))
 
 		# make issue with default SLA next day
 		creation = datetime.datetime(2019, 3, 4, 14, 0)
 		issue = make_issue(creation=creation, index=7)
 
-		self.assertEquals(issue.response_by, datetime.datetime(2019, 3, 4, 18, 0))
-		self.assertEquals(issue.resolution_by, datetime.datetime(2019, 3, 6, 12, 0))
+		self.assertEqual(issue.response_by, datetime.datetime(2019, 3, 4, 18, 0))
+		self.assertEqual(issue.resolution_by, datetime.datetime(2019, 3, 6, 12, 0))
 
 		frappe.flags.current_time = datetime.datetime(2019, 3, 4, 15, 0)
 


### PR DESCRIPTION
`assertEquals` has been deprecated, while not fully removed it will still keep giving warnings in tests / CI.

ref: https://docs.python.org/3/library/unittest.html#deprecated-aliases