### PR TITLE
fix: Rearrange buttons for Company DocType

### DIFF
--- a/erpnext/setup/doctype/company/company.js
+++ b/erpnext/setup/doctype/company/company.js
@@ -119,13 +119,17 @@ frappe.ui.form.on("Company", {
 					frm.trigger("make_default_tax_template");
 				}, __('Manage'));
 			}
+
+			if (frappe.user.has_role('System Manager')){
+				if (frm.has_perm('write')) {
+					frm.add_custom_button(__('Delete Transactions'), function() {
+						frm.trigger("delete_company_transactions");
+					}, __('Manage'));
+				}
+			}
 		}
 
 		erpnext.company.set_chart_of_accounts_options(frm.doc);
-
-		if (!frappe.user.has_role('System Manager')) {
-			frm.get_field("delete_company_transactions").hide();
-		}
 	},
 
 	make_default_tax_template: function(frm) {
@@ -137,11 +141,6 @@ frappe.ui.form.on("Company", {
 				frappe.msgprint(__("Default tax templates for sales, purchase and items are created."));
 			}
 		})
-	},
-
-	onload_post_render: function(frm) {
-		if(frm.get_field("delete_company_transactions").$input)
-			frm.get_field("delete_company_transactions").$input.addClass("btn-danger");
 	},
 
 	country: function(frm) {

--- a/erpnext/setup/doctype/company/company.js
+++ b/erpnext/setup/doctype/company/company.js
@@ -117,7 +117,7 @@ frappe.ui.form.on("Company", {
 			if (frm.has_perm('write')) {
 				frm.add_custom_button(__('Default Tax Template'), function() {
 					frm.trigger("make_default_tax_template");
-				}, __('Create'));
+				}, __('Manage'));
 			}
 		}
 

--- a/erpnext/setup/doctype/company/company.js
+++ b/erpnext/setup/doctype/company/company.js
@@ -115,7 +115,7 @@ frappe.ui.form.on("Company", {
 			}
 
 			if (frm.has_perm('write')) {
-				frm.add_custom_button(__('Default Tax Template'), function() {
+				frm.add_custom_button(__('Create Tax Template'), function() {
 					frm.trigger("make_default_tax_template");
 				}, __('Manage'));
 			}

--- a/erpnext/setup/doctype/company/company.js
+++ b/erpnext/setup/doctype/company/company.js
@@ -120,7 +120,7 @@ frappe.ui.form.on("Company", {
 				}, __('Manage'));
 			}
 
-			if (frappe.user.has_role('System Manager')){
+			if (frappe.user.has_role('System Manager')) {
 				if (frm.has_perm('write')) {
 					frm.add_custom_button(__('Delete Transactions'), function() {
 						frm.trigger("delete_company_transactions");

--- a/erpnext/setup/doctype/company/company.js
+++ b/erpnext/setup/doctype/company/company.js
@@ -90,12 +90,6 @@ frappe.ui.form.on("Company", {
 			frm.toggle_enable("default_currency", (frm.doc.__onload &&
 				!frm.doc.__onload.transactions_exist));
 
-			if (frm.has_perm('write')) {
-				frm.add_custom_button(__('Create Tax Template'), function() {
-					frm.trigger("make_default_tax_template");
-				});
-			}
-
 			if (frappe.perm.has_perm("Cost Center", 0, 'read')) {
 				frm.add_custom_button(__('Cost Centers'), function() {
 					frappe.set_route('Tree', 'Cost Center', {'company': frm.doc.name});

--- a/erpnext/setup/doctype/company/company.json
+++ b/erpnext/setup/doctype/company/company.json
@@ -99,7 +99,6 @@
   "company_description",
   "registration_info",
   "registration_details",
-  "delete_company_transactions",
   "lft",
   "rgt",
   "old_parent"
@@ -667,11 +666,6 @@
    "oldfieldtype": "Code"
   },
   {
-   "fieldname": "delete_company_transactions",
-   "fieldtype": "Button",
-   "label": "Delete Company Transactions"
-  },
-  {
    "fieldname": "lft",
    "fieldtype": "Int",
    "hidden": 1,
@@ -747,7 +741,7 @@
  "image_field": "company_logo",
  "is_tree": 1,
  "links": [],
- "modified": "2021-02-16 15:53:37.167589",
+ "modified": "2021-05-07 03:11:28.189740",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Company",


### PR DESCRIPTION
### _Proposed Changes:_

- Change 'Create' button to 'Manage'
- Move 'Delete Company Transactions' under 'Manage'
- Remove redundant 'Create Tax Template' button
- Rename 'Default Tax Template' to 'Create Tax Template'

![Screenshot 2021-05-07 at 3 19 49 AM](https://user-images.githubusercontent.com/25903035/117369810-18187f80-aee3-11eb-8518-5c9ba097df31.png)

