### PR TITLE
fix: force https for shopify webhook registration

### DIFF
--- a/erpnext/erpnext_integrations/doctype/shopify_settings/shopify_settings.py
+++ b/erpnext/erpnext_integrations/doctype/shopify_settings/shopify_settings.py
@@ -37,7 +37,7 @@ class ShopifySettings(Document):
 				res = session.post(url, data=json.dumps({
 					"webhook": {
 						"topic": method,
-						"address": get_webhook_address(connector_name='shopify_connection', method='store_request_data'),
+						"address": get_webhook_address(connector_name='shopify_connection', method='store_request_data', force_https=True),
 						"format": "json"
 						}
 					}), headers=get_header(self))

--- a/erpnext/erpnext_integrations/utils.py
+++ b/erpnext/erpnext_integrations/utils.py
@@ -28,7 +28,7 @@ def validate_webhooks_request(doctype,  hmac_key, secret_key='secret'):
 
 	return innerfn
 
-def get_webhook_address(connector_name, method, exclude_uri=False):
+def get_webhook_address(connector_name, method, exclude_uri=False, force_https=False):
 	endpoint = "erpnext.erpnext_integrations.connectors.{0}.{1}".format(connector_name, method)
 
 	if exclude_uri:
@@ -39,7 +39,11 @@ def get_webhook_address(connector_name, method, exclude_uri=False):
 	except RuntimeError:
 		url = "http://localhost:8000"
 
-	server_url = '{uri.scheme}://{uri.netloc}/api/method/{endpoint}'.format(uri=urlparse(url), endpoint=endpoint)
+	url_data = urlparse(url)
+	scheme = "https" if force_https else url_data.scheme
+	netloc = url_data.netloc
+
+	server_url = f"{scheme}://{netloc}/api/method/{endpoint}"
 
 	return server_url
 


### PR DESCRIPTION
Problem: Shopify does not suport HTTP as webhook URLs: https://shopify.dev/tutorials/authenticate-a-private-app-with-shopify-admin#make-authenticated-requests. the scheme is picked up from the request URL, which could be `http` while accessing ERPNext. 

Solution: force `https` for webhook URLs. Added kwarg for backward compatibility. 


closes #25510 