### PR TITLE
fix: Breaking cost center validation

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -368,6 +368,11 @@ class AccountsController(TransactionBase):
 					if self.doctype in ["Purchase Invoice", "Sales Invoice"] and item.meta.get_field('is_fixed_asset'):
 						item.set('is_fixed_asset', ret.get('is_fixed_asset', 0))
 
+					# Double check for cost center
+					# Items add via promotional scheme may not have cost center set
+					if hasattr(item, 'cost_center') and not item.get('cost_center'):
+						item.set('cost_center', self.get('cost_center') or erpnext.get_default_cost_center(self.company))
+
 					if ret.get("pricing_rules"):
 						self.apply_pricing_rule_on_items(item, ret)
 						self.set_pricing_rule_details(item, ret)


### PR DESCRIPTION
Method `validate_item_cost_centers` in sales invoice breaks in the following scenario

<img width="1328" alt="Screenshot 2021-05-11 at 4 51 58 PM" src="https://user-images.githubusercontent.com/42651287/117808280-4d71f400-b27a-11eb-92a3-869daa0148de.png">

Suppose product discount is applied for an item and the user removes the free or discounted item manually and doesn't check `Ignore Pricing Rule` then the system tries to add the free or discounted item again on save but the cost center is missing for those items and hence the above mentioned validation in sales invoice breaks and user is not able to understand the error or what's the reason for it

To avoid this added a double check to add missing cost center in items table