### PR TITLE
fix: validation message of quality inspection in purchase receipt

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -379,8 +379,7 @@ class StockController(AccountsController):
 					link = frappe.utils.get_link_to_form('Quality Inspection', d.quality_inspection)
 					frappe.throw(_("Quality Inspection: {0} is not submitted for the item: {1} in row {2}").format(link, d.item_code, d.idx), QualityInspectionNotSubmittedError)
 
-				qa_failed = any([r.status=="Rejected" for r in qa_doc.readings])
-				if qa_failed:
+				if qa_doc.status != 'Accepted':
 					frappe.throw(_("Row {0}: Quality Inspection rejected for item {1}")
 						.format(d.idx, d.item_code), QualityInspectionRejectedError)
 			elif qa_required :

--- a/erpnext/stock/doctype/quality_inspection/test_quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/test_quality_inspection.py
@@ -27,10 +27,11 @@ class TestQualityInspection(unittest.TestCase):
 		dn.reload()
 		self.assertRaises(QualityInspectionRejectedError, dn.submit)
 
-		frappe.db.set_value("Quality Inspection Reading", {"parent": qa.name}, "status", "Accepted")
+		frappe.db.set_value("Quality Inspection", qa.name, "status", "Accepted")
 		dn.reload()
 		dn.submit()
 
+		qa.reload()
 		qa.cancel()
 		dn.reload()
 		dn.cancel()


### PR DESCRIPTION
**Issue**

1. Create quality inspection with status as "Accepted" at parent level and "Rejected" at child table for one of the quality inspection parameter against the purchase receipt.
2. Then try to submit the purchase receipt, system will throw the below error
<img width="767" alt="Screenshot 2021-05-11 at 9 35 28 PM" src="https://user-images.githubusercontent.com/8780500/117848612-15ca7280-b2a1-11eb-895b-d1a697e42abf.png">


Solution

Alway check parent level status and not quality inspection parameter status