### PR TITLE
fix: Required by date validation in Purchase Order

### DIFF
--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -838,7 +838,7 @@ class BuyingController(StockController):
 		if not self.get("items"):
 			return
 
-		earliest_schedule_date = min([d.schedule_date for d in self.get("items")])
+		earliest_schedule_date = min([d.schedule_date for d in self.get("items") if d.schedule_date])
 		if earliest_schedule_date:
 			self.schedule_date = earliest_schedule_date
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2021-04-21/apps/frappe/frappe/desk/form/save.py", line 21, in savedocs
    doc.save()
  File "/home/frappe/benches/bench-version-12-2021-04-21/apps/frappe/frappe/model/document.py", line 273, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2021-04-21/apps/frappe/frappe/model/document.py", line 296, in _save
    self.insert()
  File "/home/frappe/benches/bench-version-12-2021-04-21/apps/frappe/frappe/model/document.py", line 230, in insert
    self.run_before_save_methods()
  File "/home/frappe/benches/bench-version-12-2021-04-21/apps/frappe/frappe/model/document.py", line 896, in run_before_save_methods
    self.run_method("validate")
  File "/home/frappe/benches/bench-version-12-2021-04-21/apps/frappe/frappe/model/document.py", line 797, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2021-04-21/apps/frappe/frappe/model/document.py", line 1073, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2021-04-21/apps/frappe/frappe/model/document.py", line 1056, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-version-12-2021-04-21/apps/frappe/frappe/model/document.py", line 791, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2021-04-21/apps/erpnext/erpnext/buying/doctype/purchase_order/purchase_order.py", line 48, in validate
    self.validate_schedule_date()
  File "/home/frappe/benches/bench-version-12-2021-04-21/apps/erpnext/erpnext/controllers/buying_controller.py", line 796, in validate_schedule_date
    earliest_schedule_date = min([d.schedule_date for d in self.get("items")])
TypeError: '<' not supported between instances of 'NoneType' and 'NoneType'

```