### PR TITLE
fix: don't map set warehouse from delivery note to purchase receipt

### DIFF
--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -732,7 +732,8 @@ def make_inter_company_transaction(doctype, source_name, target_doc=None):
 			"doctype": target_doctype,
 			"postprocess": update_details,
 			"field_no_map": [
-				"taxes_and_charges"
+				"taxes_and_charges",
+				"set_warehouse"
 			]
 		},
 		doctype +" Item": {


### PR DESCRIPTION
**Issue**

While making purchase receipt from delivery note system copy the set warehouse from delivery note (Set Source Warehouse) to purchase receipt (Accepted Warehouse).

