### PR TITLE
fix: Dialog variable assignment after definition in POS

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -22,6 +22,7 @@ erpnext.PointOfSale.Controller = class {
 	}
 
 	create_opening_voucher() {
+		debugger;
 		const me = this;
 		const table_fields = [
 			{
@@ -55,10 +56,6 @@ erpnext.PointOfSale.Controller = class {
 				});
 				dialog.fields_dict.balance_details.grid.refresh();
 			});
-		}
-		const pos_profile_query = {
-			query: 'erpnext.accounts.doctype.pos_profile.pos_profile.pos_profile_query',
-			filters: { company: dialog.fields_dict.company.get_value() }
 		}
 		const dialog = new frappe.ui.Dialog({
 			title: __('Create POS Opening Entry'),
@@ -105,6 +102,10 @@ erpnext.PointOfSale.Controller = class {
 			primary_action_label: __('Submit')
 		});
 		dialog.show();
+		const pos_profile_query = {
+			query: 'erpnext.accounts.doctype.pos_profile.pos_profile.pos_profile_query',
+			filters: { company: dialog.fields_dict.company.get_value() }
+		}
 	}
 
 	async prepare_app_defaults(data) {

--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -22,7 +22,6 @@ erpnext.PointOfSale.Controller = class {
 	}
 
 	create_opening_voucher() {
-		debugger;
 		const me = this;
 		const table_fields = [
 			{

--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -56,10 +56,6 @@ erpnext.PointOfSale.Controller = class {
 				dialog.fields_dict.balance_details.grid.refresh();
 			});
 		}
-		const pos_profile_query = {
-			query: 'erpnext.accounts.doctype.pos_profile.pos_profile.pos_profile_query',
-			filters: { company: dialog.fields_dict.company.get_value() }
-		}
 		const dialog = new frappe.ui.Dialog({
 			title: __('Create POS Opening Entry'),
 			static: true,
@@ -105,6 +101,10 @@ erpnext.PointOfSale.Controller = class {
 			primary_action_label: __('Submit')
 		});
 		dialog.show();
+		const pos_profile_query = {
+			query: 'erpnext.accounts.doctype.pos_profile.pos_profile.pos_profile_query',
+			filters: { company: dialog.fields_dict.company.get_value() }
+		};
 	}
 
 	async prepare_app_defaults(data) {


### PR DESCRIPTION
### Issue:

`dialog` variable was used before defining.

![image](https://user-images.githubusercontent.com/33727827/117966784-f33c6600-b341-11eb-9a8d-39ff267192c6.png)

![image](https://user-images.githubusercontent.com/33727827/117966840-ffc0be80-b341-11eb-817b-54d8b9d9c361.png)
