### PR TITLE
feat: linking supplier with an item group for filtering items

### DIFF
--- a/erpnext/buying/doctype/supplier/supplier.json
+++ b/erpnext/buying/doctype/supplier/supplier.json
@@ -383,8 +383,14 @@
  "icon": "fa fa-user",
  "idx": 370,
  "image_field": "image",
- "links": [],
- "modified": "2021-01-06 19:51:40.939087",
+ "links": [
+  {
+   "group": "Item Group",
+   "link_doctype": "Supplier Item Group",
+   "link_fieldname": "supplier"
+  }
+ ],
+ "modified": "2021-05-18 15:10:11.087191",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Supplier",

--- a/erpnext/buying/doctype/supplier_item_group/supplier_item_group.js
+++ b/erpnext/buying/doctype/supplier_item_group/supplier_item_group.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('Supplier Item Group', {
+	// refresh: function(frm) {
+
+	// }
+});

--- a/erpnext/buying/doctype/supplier_item_group/supplier_item_group.json
+++ b/erpnext/buying/doctype/supplier_item_group/supplier_item_group.json
@@ -1,0 +1,51 @@
+{
+ "actions": [],
+ "creation": "2021-05-07 18:16:40.621421",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "supplier",
+  "item_group"
+ ],
+ "fields": [
+  {
+   "fieldname": "supplier",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Supplier",
+   "options": "Supplier"
+  },
+  {
+   "fieldname": "item_group",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Item Group",
+   "options": "Item Group"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2021-05-07 18:16:40.621421",
+ "modified_by": "Administrator",
+ "module": "Buying",
+ "name": "Supplier Item Group",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "track_changes": 1
+}

--- a/erpnext/buying/doctype/supplier_item_group/supplier_item_group.json
+++ b/erpnext/buying/doctype/supplier_item_group/supplier_item_group.json
@@ -14,19 +14,21 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Supplier",
-   "options": "Supplier"
+   "options": "Supplier",
+   "reqd": 1
   },
   {
    "fieldname": "item_group",
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Item Group",
-   "options": "Item Group"
+   "options": "Item Group",
+   "reqd": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2021-05-07 18:16:40.621421",
+ "modified": "2021-05-19 13:48:16.742303",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Supplier Item Group",
@@ -41,6 +43,30 @@
    "read": 1,
    "report": 1,
    "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Purchase User",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Purchase Manager",
    "share": 1,
    "write": 1
   }

--- a/erpnext/buying/doctype/supplier_item_group/supplier_item_group.py
+++ b/erpnext/buying/doctype/supplier_item_group/supplier_item_group.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+from __future__ import unicode_literals
+# import frappe
+from frappe.model.document import Document
+
+class SupplierItemGroup(Document):
+	pass

--- a/erpnext/buying/doctype/supplier_item_group/supplier_item_group.py
+++ b/erpnext/buying/doctype/supplier_item_group/supplier_item_group.py
@@ -3,8 +3,16 @@
 # For license information, please see license.txt
 
 from __future__ import unicode_literals
-# import frappe
+import frappe
+from frappe import _
 from frappe.model.document import Document
 
 class SupplierItemGroup(Document):
-	pass
+	def validate(self):
+		exists = frappe.db.exists({
+			'doctype': 'Supplier Item Group',
+			'supplier': self.supplier,
+			'item_group': self.item_group
+		})
+		if exists:
+			frappe.throw(_("Item Group has already been linked to this supplier."))

--- a/erpnext/buying/doctype/supplier_item_group/test_supplier_item_group.py
+++ b/erpnext/buying/doctype/supplier_item_group/test_supplier_item_group.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+from __future__ import unicode_literals
+
+# import frappe
+import unittest
+
+class TestSupplierItemGroup(unittest.TestCase):
+	pass

--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -204,7 +204,7 @@ def item_query(doctype, txt, searchfield, start, page_len, filters, as_dict=Fals
 
 	if "description" in searchfields:
 		searchfields.remove("description")
-
+	
 	columns = ''
 	extra_searchfields = [field for field in searchfields
 		if not field in ["name", "item_group", "description"]]
@@ -216,11 +216,22 @@ def item_query(doctype, txt, searchfield, start, page_len, filters, as_dict=Fals
 		if not field in searchfields]
 	searchfields = " or ".join([field + " like %(txt)s" for field in searchfields])
 
+	if filters.get('supplier'):
+		item_group_list = frappe.get_list('Supplier Item Group', filters = {'supplier': filters.get('supplier')}, fields = ['item_group'])
+		
+		item_groups = []
+		for i in item_group_list:
+			item_groups.append(i.item_group)
+
+		del filters['supplier']
+
+		if item_groups:
+			filters['item_group'] = ['in', item_groups]
+		
 	description_cond = ''
 	if frappe.db.count('Item', cache=True) < 50000:
 		# scan description only if items are less than 50000
 		description_cond = 'or tabItem.description LIKE %(txt)s'
-
 	return frappe.db.sql("""select tabItem.name,
 		if(length(tabItem.item_name) > 40,
 			concat(substr(tabItem.item_name, 1, 40), "..."), item_name) as item_name,

--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -217,7 +217,7 @@ def item_query(doctype, txt, searchfield, start, page_len, filters, as_dict=Fals
 	searchfields = " or ".join([field + " like %(txt)s" for field in searchfields])
 
 	if filters.get('supplier'):
-		item_group_list = frappe.get_list('Supplier Item Group', filters = {'supplier': filters.get('supplier')}, fields = ['item_group'])
+		item_group_list = frappe.get_all('Supplier Item Group', filters = {'supplier': filters.get('supplier')}, fields = ['item_group'])
 		
 		item_groups = []
 		for i in item_group_list:

--- a/erpnext/public/js/controllers/buying.js
+++ b/erpnext/public/js/controllers/buying.js
@@ -84,13 +84,13 @@ erpnext.buying.BuyingController = erpnext.TransactionController.extend({
 			if (me.frm.doc.is_subcontracted == "Yes") {
 				return{
 					query: "erpnext.controllers.queries.item_query",
-					filters:{ 'is_sub_contracted_item': 1 }
+					filters:{ 'supplier': me.frm.doc.supplier, 'is_sub_contracted_item': 1 }
 				}
 			}
 			else {
 				return{
 					query: "erpnext.controllers.queries.item_query",
-					filters: {'is_purchase_item': 1}
+					filters: { 'supplier': me.frm.doc.supplier, 'is_purchase_item': 1 }
 				}
 			}
 		});


### PR DESCRIPTION
**Changes:**

- Created a doctype to create links between supplier and item_groups.

![image](https://user-images.githubusercontent.com/43572428/117969184-baea5700-b344-11eb-98aa-ca2e214d81ea.png)

- Updated filters for buying module if any item groups are linked to the supplier.
![item_group](https://user-images.githubusercontent.com/43572428/117975519-61862600-b34c-11eb-820c-b43907c73d94.gif)
(If no item groups are linked to the supplier it does not apply the filter)

-  Added Supplier Item Group in Supplier dashboard.
![image](https://user-images.githubusercontent.com/43572428/118630270-017bfd80-b7ec-11eb-883a-55e5ef650cc6.png)

- **[Docs](https://github.com/frappe/erpnext_documentation/pull/333)**

