### PR TITLE
fix: Translate weekday when getting weekly off dates

### DIFF
--- a/erpnext/hr/doctype/holiday_list/holiday_list.py
+++ b/erpnext/hr/doctype/holiday_list/holiday_list.py
@@ -23,7 +23,7 @@ class HolidayList(Document):
 		last_idx = max([cint(d.idx) for d in self.get("holidays")] or [0,])
 		for i, d in enumerate(date_list):
 			ch = self.append('holidays', {})
-			ch.description = self.weekly_off
+			ch.description = _(self.weekly_off)
 			ch.holiday_date = d
 			ch.weekly_off = 1
 			ch.idx = last_idx + i + 1


### PR DESCRIPTION
Translate weekday when adding holidays to holiday list based on a weekday

Before:
![bug](https://user-images.githubusercontent.com/21094671/118015029-73020a80-b319-11eb-9fa7-7ffe0bb4133a.gif)

After:
 
![Screen recording](https://user-images.githubusercontent.com/21094671/118015066-80b79000-b319-11eb-9f61-ede583f0edbb.gif)


Closes #25690 
