### PR TITLE
fix: timeout error while loading warehouse tree

### DIFF
--- a/erpnext/stock/doctype/warehouse/warehouse.py
+++ b/erpnext/stock/doctype/warehouse/warehouse.py
@@ -3,8 +3,9 @@
 
 from __future__ import unicode_literals
 import frappe, erpnext
-from frappe.utils import cint, nowdate
+from frappe.utils import cint, flt
 from frappe import throw, _
+from collections import defaultdict
 from frappe.utils.nestedset import NestedSet
 from erpnext.stock import get_warehouse_account
 from frappe.contacts.address_and_contact import load_address_and_contact
@@ -28,7 +29,6 @@ class Warehouse(NestedSet):
 			if account:
 				self.set_onload('account', account)
 		load_address_and_contact(self)
-
 
 	def on_update(self):
 		self.update_nsm_model()
@@ -140,8 +140,6 @@ class Warehouse(NestedSet):
 
 @frappe.whitelist()
 def get_children(doctype, parent=None, company=None, is_root=False):
-	from erpnext.stock.utils import get_stock_value_from_bin
-
 	if is_root:
 		parent = ""
 
@@ -154,12 +152,47 @@ def get_children(doctype, parent=None, company=None, is_root=False):
 
 	warehouses = frappe.get_list(doctype, fields=fields, filters=filters, order_by='name')
 
+	company_currency = ''
+	if company:
+		company_currency = frappe.get_cached_value('Company', company, 'default_currency')
+
+	warehouse_wise_value = get_warehouse_wise_stock_value(company)
+
 	# return warehouses
 	for wh in warehouses:
-		wh["balance"] = get_stock_value_from_bin(warehouse=wh.value)
-		if company:
-			wh["company_currency"] = frappe.db.get_value('Company', company, 'default_currency')
+		wh["balance"] = warehouse_wise_value.get(wh.value)
+		if company_currency:
+			wh["company_currency"] = company_currency
 	return warehouses
+
+def get_warehouse_wise_stock_value(company):
+	warehouses = frappe.get_all('Warehouse',
+		fields = ['name', 'parent_warehouse'], filters = {'company': company})
+	parent_warehouse = {d.name : d.parent_warehouse for d in warehouses}
+
+	filters = {'warehouse': ('in', [data.name for data in warehouses])}
+	bin_data = frappe.get_all('Bin', fields = ['sum(stock_value) as stock_value', 'warehouse'],
+		filters = filters, group_by = 'warehouse')
+
+	warehouse_wise_stock_value = defaultdict(float)
+	for row in bin_data:
+		if not row.stock_value:
+			continue
+
+		warehouse_wise_stock_value[row.warehouse] = row.stock_value
+		update_value_in_parent_warehouse(warehouse_wise_stock_value,
+			parent_warehouse, row.warehouse, row.stock_value)
+
+	return warehouse_wise_stock_value
+
+def update_value_in_parent_warehouse(warehouse_wise_stock_value, parent_warehouse_dict, warehouse, stock_value):
+	parent_warehouse = parent_warehouse_dict.get(warehouse)
+	if not parent_warehouse:
+		return
+
+	warehouse_wise_stock_value[parent_warehouse] += flt(stock_value)
+	update_value_in_parent_warehouse(warehouse_wise_stock_value, parent_warehouse_dict,
+		parent_warehouse, stock_value)
 
 @frappe.whitelist()
 def add_node():

--- a/erpnext/stock/doctype/warehouse/warehouse_tree.js
+++ b/erpnext/stock/doctype/warehouse/warehouse_tree.js
@@ -20,7 +20,7 @@ frappe.treeview_settings['Warehouse'] = {
 	onrender: function(node) {
 		if (node.data && node.data.balance!==undefined) {
 			$('<span class="balance-area pull-right text-muted small">'
-			+ format_currency(Math.abs(node.data.balance), node.data.company_currency)
+			+ format_currency((node.data.balance), node.data.company_currency)
 			+ '</span>').insertBefore(node.$ul);
 		}
 	}


### PR DESCRIPTION
**Issue**
Customer has 2500 warehouses and they wanted to see all the warehouses in the tree view. But system was not able to load all the warehouses within 3mins and thrown an error that "Request Time Out"

<img width="965" alt="Screenshot 2021-05-13 at 1 39 47 AM" src="https://user-images.githubusercontent.com/8780500/118037979-2ad00000-b38c-11eb-9fe9-661cb87ed867.png">

**Code Debug**
Using bench console did profiling and found that system taking more than 30 mins to load all the warehouses and the method  get_stock_value_from_bin which get the stock value from bin against the warehouse executes every time against each warehouse (even though warehouse is parent warehouse). So if customer has 2500 warehouses then this method was executing 2500 times.

Even check mysql processlist and found that the bottleneck is at the get_stock_value_from_bin query

<img width="1167" alt="Screenshot 2021-05-13 at 1 08 37 AM" src="https://user-images.githubusercontent.com/8780500/118039283-ca41c280-b38d-11eb-90a0-42e8f147484a.png">


**Solution**

Optimized the code and no of calls to database by adding new method. With few number of db call get all the child warehouses stock value data and using recursion method updated stock value in the parent warehouses.

**After Fix**

After the fix system has took 30 seconds to load all the warehouses

<img width="754" alt="Screenshot 2021-05-13 at 1 33 22 AM" src="https://user-images.githubusercontent.com/8780500/118038706-15a7a100-b38d-11eb-8dbb-c287001efa99.png">
