### PR TITLE
fix: timeout error while loading warehouse tree

### DIFF
--- a/erpnext/stock/doctype/warehouse/warehouse_tree.js
+++ b/erpnext/stock/doctype/warehouse/warehouse_tree.js
@@ -20,7 +20,7 @@ frappe.treeview_settings['Warehouse'] = {
 	onrender: function(node) {
 		if (node.data && node.data.balance!==undefined) {
 			$('<span class="balance-area pull-right">'
-			+ format_currency(Math.abs(node.data.balance), node.data.company_currency)
+			+ format_currency((node.data.balance), node.data.company_currency)
 			+ '</span>').insertBefore(node.$ul);
 		}
 	}


### PR DESCRIPTION
backport https://github.com/frappe/erpnext/pull/25693
**Issue**
Customer has 2500 warehouses and they wanted to see all the warehouses in the tree view. But system was not able to load all the warehouses within 3mins and thrown an error that "Request Time Out"

<img width="965" alt="Screenshot 2021-05-13 at 1 39 47 AM" src="https://user-images.githubusercontent.com/8780500/118037979-2ad00000-b38c-11eb-9fe9-661cb87ed867.png">

**Code Debug**
Using bench console did profiling and found that system taking more than 30 mins to load all the warehouses and the method  get_stock_value_from_bin which get the stock value from bin against the warehouse executes every time against each warehouse (even though warehouse is parent warehouse). So if customer has 2500 warehouses then this method was executing 2500 times.

Even check mysql processlist and found that the bottleneck is at the get_stock_value_from_bin query

<img width="1167" alt="Screenshot 2021-05-13 at 1 08 37 AM" src="https://user-images.githubusercontent.com/8780500/118039283-ca41c280-b38d-11eb-90a0-42e8f147484a.png">


**Solution**

Optimized the code and no of calls to database by adding new method. With few number of db call get all the child warehouses stock value data and using recursion method updated stock value in the parent warehouses.

**After Fix**

After the fix system has took 30 seconds to load all the warehouses

<img width="754" alt="Screenshot 2021-05-13 at 1 33 22 AM" src="https://user-images.githubusercontent.com/8780500/118038706-15a7a100-b38d-11eb-8dbb-c287001efa99.png">
