### PR TITLE
fix: send emails on rfq submit

### DIFF
--- a/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
+++ b/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
@@ -62,6 +62,7 @@ class RequestforQuotation(BuyingController):
 		for supplier in self.suppliers:
 			supplier.email_sent = 0
 			supplier.quote_status = 'Pending'
+		self.send_to_supplier()
 
 	def on_cancel(self):
 		frappe.db.set(self, 'status', 'Cancelled')

--- a/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
+++ b/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
@@ -82,7 +82,7 @@ class RequestforQuotation(BuyingController):
 	def send_to_supplier(self):
 		"""Sends RFQ mail to involved suppliers."""
 		for rfq_supplier in self.suppliers:
-			if rfq_supplier.send_email:
+			if rfq_supplier.email_id is not None and rfq_supplier.send_email:
 				self.validate_email_id(rfq_supplier)
 
 				# make new user if required


### PR DESCRIPTION
### Before
Emails are not sent even if the send email option is selected.

### After
Emails get sent `on_submit` if send email is selected.