### PR TITLE
fix: filter for Indian workspace card

### DIFF
--- a/erpnext/accounts/workspace/accounting/accounting.json
+++ b/erpnext/accounts/workspace/accounting/accounting.json
@@ -684,6 +684,7 @@
    "is_query_report": 0,
    "label": "Goods and Services Tax (GST India)",
    "onboard": 0,
+   "only_for": "India",
    "type": "Card Break"
   },
   {


### PR DESCRIPTION
Filter out whole Indian section

Requires frappe/frappe#13220