### PR TITLE
fix: total time calc for job card

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -40,7 +40,7 @@ class JobCard(Document):
 					frappe.throw(_("Row {0}: From Time and To Time of {1} is overlapping with {2}")
 						.format(d.idx, self.name, data.name), OverlapError)
 
-				if d.from_time and d.to_time:
+				if d.from_time and d.to_time and d.completed_qty > 0:
 					d.time_in_mins = time_diff_in_hours(d.to_time, d.from_time) * 60
 					self.total_time_in_mins += d.time_in_mins
 


### PR DESCRIPTION
### Description
Adds to total time only if completed qty is more than 0.

### Before
![Screen Shot 2021-05-14 at 17 03 55](https://user-images.githubusercontent.com/29507195/118265332-a6d65f00-b4d6-11eb-85df-609f2c8e8725.png)

### After
![Screen Shot 2021-05-14 at 17 02 00](https://user-images.githubusercontent.com/29507195/118265345-ac33a980-b4d6-11eb-87d1-3c0d3a505ef3.png)

