### PR TITLE
feat: Show net values in Party Accounts

### DIFF
--- a/erpnext/accounts/report/general_ledger/general_ledger.js
+++ b/erpnext/accounts/report/general_ledger/general_ledger.js
@@ -166,6 +166,11 @@ frappe.query_reports["General Ledger"] = {
 			"fieldname": "show_cancelled_entries",
 			"label": __("Show Cancelled Entries"),
 			"fieldtype": "Check"
+		},
+		{
+			"fieldname": "show_net_values_in_party_account",
+			"label": __("Show Net Values in Party Account"),
+			"fieldtype": "Check"
 		}
 	]
 }


### PR DESCRIPTION
Consider the following scenario where both payment and credit note is allocated against invoices.

![image](https://user-images.githubusercontent.com/42651287/118279853-3a189000-b4e9-11eb-9343-11705dc85605.png)

The statement of account for that customer in this scenario is shown as follows:
![image](https://user-images.githubusercontent.com/42651287/118282051-7ea52b00-b4eb-11eb-80cf-0a28c47efe08.png)

Many times this credit/debit note allocation is internal to the user of the system and want to show only net values to external entities like Auditors, Customers and Suppliers.

For this added a check in General Ledger to show net values for party accounts when viewing consolidated view grouped by voucher

<img width="1320" alt="Screenshot 2021-05-14 at 7 35 29 PM" src="https://user-images.githubusercontent.com/42651287/118282765-42be9580-b4ec-11eb-90f2-34b4185ca19b.png">

SOA post enabling net values
![image](https://user-images.githubusercontent.com/42651287/118282166-9da3bd00-b4eb-11eb-8bdb-6172c01cad05.png)