### PR TITLE
fix: Ignore rounding diff while importing JV using data import

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -29,7 +29,11 @@ class JournalEntry(AccountsController):
 		self.validate_entries_for_advance()
 		self.validate_multi_currency()
 		self.set_amounts_in_company_currency()
-		self.validate_total_debit_and_credit()
+
+		# Do not validate while importing via data import
+		if not frappe.flags.in_import:
+			self.validate_total_debit_and_credit()
+
 		self.validate_against_jv()
 		self.validate_reference_doc()
 		self.set_against_account()
@@ -1047,4 +1051,4 @@ def make_reverse_journal_entry(source_name, target_doc=None):
 		},
 	}, target_doc)
 
-	return doclist 
+	return doclist


### PR DESCRIPTION
Due to floating point arithmetic addition in python there may be cases where there is minor difference in total debit and total credit even though sum of debit and credit values is equal. Due to this user is unable to import JVs using data import.

Ignored total debit and credit validation while importing JVs

If "Submit After Import" is checked in Data Import then the JV will be submitted via Data import if diff is within permissible value else GL Entry validation for unequal debit and credit will be triggered.

If "Submit After Import" then the user can simply import the entry, fix the diff amount manually and submit