### PR TITLE
chore: remove woocommerce package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,3 @@ python-youtube~=0.8.0
 taxjar~=1.9.2
 tweepy~=3.10.0
 Unidecode~=1.2.0
-WooCommerce~=3.0.0


### PR DESCRIPTION
This is not used anywhere. It was added in this commit https://github.com/frappe/erpnext/commit/df83148d7ccb15ba18b59c7d9b761a3651bb1dec even there it isn't being used.


The package name is "woocommerce", you can `grep` the full codebase to be sure. 