### PR TITLE
fix: Cashlfow mapper not showing data

### DIFF
--- a/erpnext/accounts/report/cash_flow/custom_cash_flow.py
+++ b/erpnext/accounts/report/cash_flow/custom_cash_flow.py
@@ -165,7 +165,7 @@ def add_data_for_operating_activities(
 	if profit_data:
 		profit_data.update({
 			"indent": 1,
-			"parent_account": get_mapper_for(light_mappers, position=0)['section_header']
+			"parent_account": get_mapper_for(light_mappers, position=1)['section_header']
 		})
 		data.append(profit_data)
 		section_data.append(profit_data)
@@ -312,10 +312,10 @@ def add_data_for_other_activities(
 def compute_data(filters, company_currency, profit_data, period_list, light_mappers, full_mapper):
 	data = []
 
-	operating_activities_mapper = get_mapper_for(light_mappers, position=0)
+	operating_activities_mapper = get_mapper_for(light_mappers, position=1)
 	other_mappers = [
-		get_mapper_for(light_mappers, position=1),
-		get_mapper_for(light_mappers, position=2)
+		get_mapper_for(light_mappers, position=2),
+		get_mapper_for(light_mappers, position=3)
 	]
 
 	if operating_activities_mapper:
@@ -396,7 +396,7 @@ def _get_account_type_based_data(filters, account_names, period_list, accumulate
 			gl_sum = frappe.db.sql_list("""
 				select sum(credit) - sum(debit)
 				from `tabGL Entry`
-				where company=%s and posting_date >= %s and posting_date <= %s 
+				where company=%s and posting_date >= %s and posting_date <= %s
 					and voucher_type != 'Period Closing Voucher'
 					and account in ( SELECT name FROM tabAccount WHERE name IN (%s)
 					OR parent_account IN (%s))
@@ -405,7 +405,7 @@ def _get_account_type_based_data(filters, account_names, period_list, accumulate
 			gl_sum = frappe.db.sql_list("""
 				select sum(credit) - sum(debit)
 				from `tabGL Entry`
-				where company=%s and posting_date >= %s and posting_date <= %s 
+				where company=%s and posting_date >= %s and posting_date <= %s
 					and voucher_type != 'Period Closing Voucher'
 					and account in ( SELECT name FROM tabAccount WHERE name IN (%s)
 					OR parent_account IN (%s))


### PR DESCRIPTION
In Cash Flow Mapper the `get_mapper_for` starts searching from `position` 0 but position is a mandatory field and doesn't allow user to save position as 0 due to which no data was fetched custom cashflow mapper report

Befor:
![image](https://user-images.githubusercontent.com/42651287/118586079-bba54200-b7b7-11eb-9a53-2f5fee45a96b.png)

After:
![image](https://user-images.githubusercontent.com/42651287/118586025-a4665480-b7b7-11eb-9343-c32dcd26620d.png)
