### PR TITLE
fix: Accumulated depreciation

### DIFF
--- a/erpnext/assets/doctype/asset_category/asset_category.js
+++ b/erpnext/assets/doctype/asset_category/asset_category.js
@@ -3,8 +3,8 @@
 
 frappe.ui.form.on('Asset Category', {
 	onload: function(frm) {
-		frm.add_fetch('company_name', 'accumulated_depreciation_account', 'accumulated_depreciation_account');
-		frm.add_fetch('company_name', 'depreciation_expense_account', 'accumulated_depreciation_account');
+		frm.add_fetch('company_name','accumulated_depreciation_account','accumulated_depreciation_account');
+		frm.add_fetch('company_name','depreciation_expense_account','depreciation_expense_account');
 
 		frm.set_query('fixed_asset_account', 'accounts', function(doc, cdt, cdn) {
 			var d  = locals[cdt][cdn];

--- a/erpnext/assets/doctype/asset_category/asset_category.js
+++ b/erpnext/assets/doctype/asset_category/asset_category.js
@@ -3,8 +3,8 @@
 
 frappe.ui.form.on('Asset Category', {
 	onload: function(frm) {
-		frm.add_fetch('company_name','accumulated_depreciation_account','accumulated_depreciation_account');
-		frm.add_fetch('company_name','depreciation_expense_account','depreciation_expense_account');
+		frm.add_fetch('company_name', 'accumulated_depreciation_account', 'accumulated_depreciation_account');
+		frm.add_fetch('company_name', 'depreciation_expense_account', 'depreciation_expense_account');
 
 		frm.set_query('fixed_asset_account', 'accounts', function(doc, cdt, cdn) {
 			var d  = locals[cdt][cdn];


### PR DESCRIPTION
In asset category in accounts table in accumulated depreciation column, it is fetching depreciation and in depreciation column, it is fetching nothing, and later if we try submitting it will throw an error to change inside accumulated depreciation column to accumulated depreciation. So now both can be auto-fetched.
**Before fix:**
![assets](https://user-images.githubusercontent.com/37659765/118684295-baa7fb00-b81f-11eb-889c-69d14814451e.gif)

**After Fix:**
![assets_after](https://user-images.githubusercontent.com/37659765/118684386-cc899e00-b81f-11eb-98d6-3c8d457ed499.gif)
