### PR TITLE
fix: the status of repost item valuation showing In Progress since long time

### DIFF
--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
@@ -4,8 +4,9 @@
 
 from __future__ import unicode_literals
 import frappe, erpnext
+from rq.timeouts import JobTimeoutException
 from frappe.model.document import Document
-from frappe.utils import cint, get_link_to_form, add_to_date, now, today
+from frappe.utils import cint, get_link_to_form, add_to_date, now, today, time_diff_in_hours
 from erpnext.stock.stock_ledger import repost_future_sle
 from erpnext.accounts.utils import update_gl_entries_after, check_if_stock_and_account_balance_synced
 from frappe.utils.user import get_users_with_role
@@ -57,7 +58,8 @@ def repost(doc):
 		repost_gl_entries(doc)
 
 		doc.set_status('Completed')
-	except Exception:
+
+	except (Exception, JobTimeoutException):
 		frappe.db.rollback()
 		traceback = frappe.get_traceback()
 		frappe.log_error(traceback)
@@ -113,6 +115,12 @@ def notify_error_to_stock_managers(doc, traceback):
 	frappe.sendmail(recipients=recipients, subject=subject, message=message)
 
 def repost_entries():
+	job_log = frappe.get_all('Scheduled Job Log', fields = ['status', 'creation'],
+		filters = {'scheduled_job_type': 'repost_item_valuation.repost_entries'}, order_by='creation desc', limit=1)
+
+	if job_log and job_log[0]['status'] == 'Start' and time_diff_in_hours(now(), job_log[0]['creation']) < 2:
+		return
+
 	riv_entries = get_repost_item_valuation_entries()
 
 	for row in riv_entries:


### PR DESCRIPTION
Some repost item valuation required more than one hour to complete the task, if the scheduler is already running then skip the execution.