### PR TITLE
fix: address template with upper filter throws jinja error

### DIFF
--- a/erpnext/regional/address_template/templates/united_states.html
+++ b/erpnext/regional/address_template/templates/united_states.html
@@ -1,4 +1,4 @@
 {{ address_line1 }}<br>
 {% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
 {{ city }}, {% if state %}{{ state }}{% endif -%}{% if pincode %} {{ pincode }}<br>{% endif -%}
-{% if country != "United States" %}{{ country|upper }}{% endif -%}
+{% if country != "United States" %}{{ country }}{% endif -%}


### PR DESCRIPTION
Fix:

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-13-2021-05-17/env/lib64/python3.6/warnings.py", line 99, in _showwarnmsg
    msg.file, msg.line)
  File "/home/frappe/benches/bench-version-13-2021-05-17/env/lib/python3.6/site-packages/PyPDF2/pdf.py", line 1069, in _showwarning
    file.write(formatWarning(message, category, filename, lineno, line))
  File "/home/frappe/benches/bench-version-13-2021-05-17/env/lib/python3.6/site-packages/PyPDF2/utils.py", line 69, in formatWarning
    file = filename.replace("/", "\\").rsplit("\\", 1)[1] # find the file name
IndexError: list index out of range

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-13-2021-05-17/apps/frappe/frappe/app.py", line 68, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-13-2021-05-17/apps/frappe/frappe/api.py", line 54, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-13-2021-05-17/apps/frappe/frappe/handler.py", line 31, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-13-2021-05-17/apps/frappe/frappe/handler.py", line 67, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-13-2021-05-17/apps/frappe/frappe/__init__.py", line 1169, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-13-2021-05-17/apps/erpnext/erpnext/accounts/party.py", line 34, in get_party_details
    fetch_payment_terms_template, party_address, company_address, shipping_address, pos_profile)
  File "/home/frappe/benches/bench-version-13-2021-05-17/apps/erpnext/erpnext/accounts/party.py", line 48, in _get_party_details
    party_address, shipping_address = set_address_details(party_details, party, party_type, doctype, company, party_address, company_address, shipping_address)
  File "/home/frappe/benches/bench-version-13-2021-05-17/apps/erpnext/erpnext/accounts/party.py", line 87, in set_address_details
    party_details.address_display = get_address_display(party_details[billing_address_field])
  File "/home/frappe/benches/bench-version-13-2021-05-17/apps/frappe/frappe/contacts/doctype/address/address.py", line 134, in get_address_display
    return frappe.render_template(template, address_dict)
  File "/home/frappe/benches/bench-version-13-2021-05-17/apps/frappe/frappe/utils/jinja.py", line 85, in render_template
    return get_jenv().from_string(template).render(context)
  File "/home/frappe/benches/bench-version-13-2021-05-17/env/lib/python3.6/site-packages/jinja2/environment.py", line 1090, in render
    self.environment.handle_exception()
  File "/home/frappe/benches/bench-version-13-2021-05-17/env/lib/python3.6/site-packages/jinja2/environment.py", line 832, in handle_exception
    reraise(*rewrite_traceback_stack(source=source))
  File "/home/frappe/benches/bench-version-13-2021-05-17/env/lib/python3.6/site-packages/jinja2/_compat.py", line 28, in reraise
    raise value.with_traceback(tb)
  File "<template>", line 4, in top-level template code
  File "/home/frappe/benches/bench-version-13-2021-05-17/env/lib/python3.6/site-packages/jinja2/filters.py", line 200, in do_upper
    return soft_unicode(s).upper()
SystemError: <built-in function soft_unicode> returned a result with an error set
```
