### PR TITLE
fix(pos): return case for item with available qty equal to one

### DIFF
--- a/erpnext/accounts/doctype/pos_closing_entry_detail/pos_closing_entry_detail.json
+++ b/erpnext/accounts/doctype/pos_closing_entry_detail/pos_closing_entry_detail.json
@@ -46,6 +46,7 @@
    "reqd": 1
   },
   {
+   "default": "0",
    "fieldname": "closing_amount",
    "fieldtype": "Currency",
    "in_list_view": 1,
@@ -57,7 +58,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-10-23 16:45:43.662034",
+ "modified": "2021-05-19 20:08:44.523861",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Closing Entry Detail",

--- a/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
@@ -56,11 +56,11 @@ class POSInvoiceMergeLog(Document):
 		sales = [d for d in pos_invoice_docs if d.get('is_return') == 0]
 
 		sales_invoice, credit_note = "", ""
-		if sales:
-			sales_invoice = self.process_merging_into_sales_invoice(sales)
-
 		if returns:
 			credit_note = self.process_merging_into_credit_note(returns)
+
+		if sales:
+			sales_invoice = self.process_merging_into_sales_invoice(sales)
 
 		self.save() # save consolidated_sales_invoice & consolidated_credit_note ref in merge log
 


### PR DESCRIPTION
Problem:
- Only one qty of Item A is available
- POS Invoice created for Item A
- Stock Qty is zero
- POS Invoice return created for Item A
- Stock Qty should be one
- Creating POS Invoice for Item A throws an error - insufficient quantity

Also fixes a case, where a unique stock ledger entry cannot be found.
For eg., there are instances where 2 stock ledger entries having different `actual_qty_after_transaction` with same `posting_date` & `posting_time` are found. In that case, the `actual_qty_after_transaction` could be wrong. 