### PR TITLE
fix: Do not throw error on migrate

### DIFF
--- a/erpnext/regional/india/utils.py
+++ b/erpnext/regional/india/utils.py
@@ -695,7 +695,7 @@ def get_gst_accounts(company=None, account_wise=False, only_reverse_charge=0, on
 		filters=filters,
 		fields=["cgst_account", "sgst_account", "igst_account", "cess_account"])
 
-	if not gst_settings_accounts and not frappe.flags.in_test:
+	if not gst_settings_accounts and not frappe.flags.in_test and not frappe.flags.in_migrate:
 		frappe.throw(_("Please set GST Accounts in GST Settings"))
 
 	for d in gst_settings_accounts:


### PR DESCRIPTION
Error on running `create_itc_reversal_custom_fields` patch if GST accounts are not set
```
Executing erpnext.patches.v12_0.create_itc_reversal_custom_fields in test-erpnext (_4b06722fbf1484c5)
Traceback (most recent call last):
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/runpy.py", line 193, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.8/lib/python3.8/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/Users/saqibansari/frappe/bench-v13/apps/frappe/frappe/utils/bench_helper.py", line 101, in <module>
    main()
  File "/Users/saqibansari/frappe/bench-v13/apps/frappe/frappe/utils/bench_helper.py", line 18, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/Users/saqibansari/frappe/frappe-env/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/Users/saqibansari/frappe/frappe-env/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/Users/saqibansari/frappe/frappe-env/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/saqibansari/frappe/frappe-env/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/saqibansari/frappe/frappe-env/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/saqibansari/frappe/frappe-env/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/Users/saqibansari/frappe/frappe-env/lib/python3.8/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/saqibansari/frappe/bench-v13/apps/frappe/frappe/commands/__init__.py", line 27, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/Users/saqibansari/frappe/bench-v13/apps/frappe/frappe/commands/site.py", line 306, in migrate
    migrate(
  File "/Users/saqibansari/frappe/bench-v13/apps/frappe/frappe/migrate.py", line 67, in migrate
    frappe.modules.patch_handler.run_all(skip_failing)
  File "/Users/saqibansari/frappe/bench-v13/apps/frappe/frappe/modules/patch_handler.py", line 41, in run_all
    run_patch(patch)
  File "/Users/saqibansari/frappe/bench-v13/apps/frappe/frappe/modules/patch_handler.py", line 30, in run_patch
    if not run_single(patchmodule = patch):
  File "/Users/saqibansari/frappe/bench-v13/apps/frappe/frappe/modules/patch_handler.py", line 71, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/Users/saqibansari/frappe/bench-v13/apps/frappe/frappe/modules/patch_handler.py", line 91, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/Users/saqibansari/frappe/bench-v13/apps/erpnext/erpnext/patches/v12_0/create_itc_reversal_custom_fields.py", line 53, in execute
    gst_accounts = get_gst_accounts(only_non_reverse_charge=1)
  File "/Users/saqibansari/frappe/bench-v13/apps/erpnext/erpnext/regional/india/utils.py", line 699, in get_gst_accounts
    frappe.throw(_("Please set GST Accounts in GST Settings"))
  File "/Users/saqibansari/frappe/bench-v13/apps/frappe/frappe/__init__.py", line 427, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red', is_minimizable=is_minimizable, wide=wide, as_list=as_list)
  File "/Users/saqibansari/frappe/bench-v13/apps/frappe/frappe/__init__.py", line 406, in msgprint
    _raise_exception()
  File "/Users/saqibansari/frappe/bench-v13/apps/frappe/frappe/__init__.py", line 360, in _raise_exception
    raise raise_exception(msg)
frappe.exceptions.ValidationError: Please set GST Accounts in GST Settings
```