### PR TITLE
fix: show allow zero valuation only when auto checked

### DIFF
--- a/erpnext/stock/doctype/stock_reconciliation_item/stock_reconciliation_item.json
+++ b/erpnext/stock/doctype/stock_reconciliation_item/stock_reconciliation_item.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "creation": "2015-02-17 01:06:05.072764",
  "doctype": "DocType",
  "document_type": "Other",
@@ -170,6 +171,7 @@
   },
   {
    "default": "0",
+   "depends_on": "allow_zero_valuation_rate",
    "fieldname": "allow_zero_valuation_rate",
    "fieldtype": "Check",
    "label": "Allow Zero Valuation Rate",
@@ -179,7 +181,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2021-03-23 11:09:44.407157",
+ "modified": "2021-05-21 12:13:33.041266",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Reconciliation Item",


### PR DESCRIPTION
### Description
Allow Zero Valuation is an auto set field, read only.
It will now display only if it is set.