### PR TITLE
fix: Plaid Withdrawals and Deposits are recorded incorrectly

### DIFF
--- a/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.py
+++ b/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.py
@@ -183,11 +183,11 @@ def new_bank_transaction(transaction):
 	bank_account = frappe.db.get_value("Bank Account", dict(integration_id=transaction["account_id"]))
 
 	if float(transaction["amount"]) >= 0:
-		debit = float(transaction["amount"])
-		credit = 0
-	else:
 		debit = 0
-		credit = abs(float(transaction["amount"]))
+		credit = float(transaction["amount"])
+	else:
+		debit = abs(float(transaction["amount"]))
+		credit = 0
 
 	status = "Pending" if transaction["pending"] == "True" else "Settled"
 


### PR DESCRIPTION
That's odd that this issue was not noticed before but it seems like the only logical explanation. Deposit/Withdrawl columns are switched around. Money out recorded as deposits and money in recorded as withdrawals.

Plaid API shows that negative values mean money comes into the account (credit) and positive means money goes OUT (debit):
https://plaid.com/docs/api/products/#transactions-get-response-amount (see “amount”)