### PR TITLE
fix: set disable rounded total if it is globally enabled

### DIFF
--- a/erpnext/setup/doctype/global_defaults/global_defaults.py
+++ b/erpnext/setup/doctype/global_defaults/global_defaults.py
@@ -59,12 +59,14 @@ class GlobalDefaults(Document):
 
 		# Make property setters to hide rounded total fields
 		for doctype in ("Quotation", "Sales Order", "Sales Invoice", "Delivery Note",
-			"Supplier Quotation", "Purchase Order", "Purchase Invoice"):
+			"Supplier Quotation", "Purchase Order", "Purchase Invoice", "Purchase Receipt"):
 			make_property_setter(doctype, "base_rounded_total", "hidden", self.disable_rounded_total, "Check", validate_fields_for_doctype=False)
 			make_property_setter(doctype, "base_rounded_total", "print_hide", 1, "Check", validate_fields_for_doctype=False)
 
 			make_property_setter(doctype, "rounded_total", "hidden", self.disable_rounded_total, "Check", validate_fields_for_doctype=False)
 			make_property_setter(doctype, "rounded_total", "print_hide", self.disable_rounded_total, "Check", validate_fields_for_doctype=False)
+
+			make_property_setter(doctype, "disable_rounded_total", "default", cint(self.disable_rounded_total), "Text", validate_fields_for_doctype=False)
 
 	def toggle_in_words(self):
 		self.disable_in_words = cint(self.disable_in_words)


### PR DESCRIPTION
Even if Disable Rounded Total is enabled in Global Defaults, the user still has to enable it in Sales Invoice & other forms to disable the rounding adjustment.

This PR checks the Disable Rounded Total of each form, if globally enabled. 