### PR TITLE
fix: fetch email id from dialog box

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_past_order_summary.js
+++ b/erpnext/selling/page/point_of_sale/pos_past_order_summary.js
@@ -241,7 +241,7 @@ erpnext.PointOfSale.PastOrderSummary = class {
 
 	send_email() {
 		const frm = this.events.get_frm();
-		const recipients = this.email_dialog.get_values().recipients;
+		const recipients = this.email_dialog.get_values().email_id;
 		const doc = this.doc || frm.doc;
 		const print_format = frm.pos_print_format;
 


### PR DESCRIPTION
fixed fetching email id from the dialog box in POS Past order summary.