### PR TITLE
chore: remove pytlint config

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,1 +1,0 @@
-disable=access-member-before-definition


### PR DESCRIPTION
- We have flake8 config and it also runs in Sider. Flake8 and pylint have huge overlap, so no point in using both tools.
- The config is not valid pylint config. So it's useless anyway.
