### PR TITLE
fix: Use extend_cscript function to properly extend class methods to cscript

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -151,6 +151,7 @@
 		"context": true,
 		"before": true,
 		"beforeEach": true,
-		"onScan": true
+		"onScan": true,
+		"extend_cscript": true
 	}
 }

--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.js
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.js
@@ -262,4 +262,4 @@ erpnext.accounts.PaymentReconciliationController = class PaymentReconciliationCo
 
 };
 
-$.extend(cur_frm.cscript, new erpnext.accounts.PaymentReconciliationController({frm: cur_frm}));
+extend_cscript(cur_frm.cscript, new erpnext.accounts.PaymentReconciliationController({frm: cur_frm}));

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.js
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.js
@@ -135,7 +135,7 @@ erpnext.selling.POSInvoiceController = class POSInvoiceController extends erpnex
 	}
 }
 
-$.extend(cur_frm.cscript, new erpnext.selling.POSInvoiceController({ frm: cur_frm }))
+extend_cscript(cur_frm.cscript, new erpnext.selling.POSInvoiceController({ frm: cur_frm }))
 
 frappe.ui.form.on('POS Invoice', {
 	redeem_loyalty_points: function(frm) {

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -450,11 +450,8 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends e
 	}
 };
 
-console.log('innn')
 // for backward compatibility: combine new and previous states
-let controller_instance = new erpnext.accounts.SalesInvoiceController({frm: cur_frm})
-extend_cscript(cur_frm.cscript, controller_instance);
-extend_cscript(cur_frm.cscript.__proto_, controller_instance.__proto__);
+extend_cscript(cur_frm.cscript, new erpnext.accounts.SalesInvoiceController({frm: cur_frm}));
 
 cur_frm.cscript['Make Delivery Note'] = function() {
 	frappe.model.open_mapped_doc({

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -450,8 +450,11 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends e
 	}
 };
 
+console.log('innn')
 // for backward compatibility: combine new and previous states
-$.extend(cur_frm.cscript, new erpnext.accounts.SalesInvoiceController({frm: cur_frm}));
+let controller_instance = new erpnext.accounts.SalesInvoiceController({frm: cur_frm})
+extend_cscript(cur_frm.cscript, controller_instance);
+extend_cscript(cur_frm.cscript.__proto_, controller_instance.__proto__);
 
 cur_frm.cscript['Make Delivery Note'] = function() {
 	frappe.model.open_mapped_doc({

--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -547,7 +547,7 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends e
 };
 
 // for backward compatibility: combine new and previous states
-$.extend(cur_frm.cscript, new erpnext.buying.PurchaseOrderController({frm: cur_frm}));
+extend_cscript(cur_frm.cscript, new erpnext.buying.PurchaseOrderController({frm: cur_frm}));
 
 cur_frm.cscript.update_status= function(label, status){
 	frappe.call({

--- a/erpnext/buying/doctype/request_for_quotation/request_for_quotation.js
+++ b/erpnext/buying/doctype/request_for_quotation/request_for_quotation.js
@@ -414,4 +414,4 @@ erpnext.buying.RequestforQuotationController = class RequestforQuotationControll
 };
 
 // for backward compatibility: combine new and previous states
-$.extend(cur_frm.cscript, new erpnext.buying.RequestforQuotationController({frm: cur_frm}));
+extend_cscript(cur_frm.cscript, new erpnext.buying.RequestforQuotationController({frm: cur_frm}));

--- a/erpnext/buying/doctype/supplier_quotation/supplier_quotation.js
+++ b/erpnext/buying/doctype/supplier_quotation/supplier_quotation.js
@@ -95,7 +95,7 @@ erpnext.buying.SupplierQuotationController = class SupplierQuotationController e
 };
 
 // for backward compatibility: combine new and previous states
-$.extend(cur_frm.cscript, new erpnext.buying.SupplierQuotationController({frm: cur_frm}));
+extend_cscript(cur_frm.cscript, new erpnext.buying.SupplierQuotationController({frm: cur_frm}));
 
 cur_frm.fields_dict['items'].grid.get_field('project').get_query =
 	function(doc, cdt, cdn) {

--- a/erpnext/crm/doctype/lead/lead.js
+++ b/erpnext/crm/doctype/lead/lead.js
@@ -88,4 +88,4 @@ erpnext.LeadController = class LeadController extends frappe.ui.form.Controller 
 	}
 };
 
-$.extend(cur_frm.cscript, new erpnext.LeadController({ frm: cur_frm }));
+extend_cscript(cur_frm.cscript, new erpnext.LeadController({ frm: cur_frm }));

--- a/erpnext/crm/doctype/opportunity/opportunity.js
+++ b/erpnext/crm/doctype/opportunity/opportunity.js
@@ -195,7 +195,7 @@ erpnext.crm.Opportunity = class Opportunity extends frappe.ui.form.Controller {
 	}
 };
 
-$.extend(cur_frm.cscript, new erpnext.crm.Opportunity({frm: cur_frm}));
+extend_cscript(cur_frm.cscript, new erpnext.crm.Opportunity({frm: cur_frm}));
 
 cur_frm.cscript.item_code = function(doc, cdt, cdn) {
 	var d = locals[cdt][cdn];

--- a/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.js
+++ b/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.js
@@ -115,5 +115,5 @@ erpnext.maintenance.MaintenanceSchedule = class MaintenanceSchedule extends frap
 	}
 };
 
-$.extend(cur_frm.cscript, new erpnext.maintenance.MaintenanceSchedule({frm: cur_frm}));
+extend_cscript(cur_frm.cscript, new erpnext.maintenance.MaintenanceSchedule({frm: cur_frm}));
 

--- a/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.js
+++ b/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.js
@@ -99,4 +99,4 @@ erpnext.maintenance.MaintenanceVisit = class MaintenanceVisit extends frappe.ui.
 	}
 };
 
-$.extend(cur_frm.cscript, new erpnext.maintenance.MaintenanceVisit({frm: cur_frm}));
+extend_cscript(cur_frm.cscript, new erpnext.maintenance.MaintenanceVisit({frm: cur_frm}));

--- a/erpnext/manufacturing/doctype/bom/bom.js
+++ b/erpnext/manufacturing/doctype/bom/bom.js
@@ -405,7 +405,7 @@ erpnext.bom.BomController = class BomController extends erpnext.TransactionContr
 	}
 };
 
-$.extend(cur_frm.cscript, new erpnext.bom.BomController({frm: cur_frm}));
+extend_cscript(cur_frm.cscript, new erpnext.bom.BomController({frm: cur_frm}));
 
 cur_frm.cscript.hour_rate = function(doc) {
 	erpnext.bom.calculate_op_cost(doc);

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -166,7 +166,9 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 					"account_list": frappe.flags.round_off_applicable_accounts
 				},
 				callback(r) {
-					frappe.flags.round_off_applicable_accounts.push(...r.message);
+					if (r.message) {
+						frappe.flags.round_off_applicable_accounts.push(...r.message);
+					}
 				}
 			});
 		}

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -5,7 +5,7 @@ frappe.provide('erpnext.accounts.dimensions');
 
 erpnext.TransactionController = class TransactionController extends erpnext.taxes_and_totals {
 	setup() {
-		this._super();
+		super.setup();
 		frappe.flags.hide_serial_batch_dialog = true;
 		frappe.ui.form.on(this.frm.doctype + " Item", "rate", function(frm, cdt, cdn) {
 			var item = frappe.get_doc(cdt, cdn);

--- a/erpnext/selling/doctype/installation_note/installation_note.js
+++ b/erpnext/selling/doctype/installation_note/installation_note.js
@@ -57,4 +57,4 @@ erpnext.selling.InstallationNote = class InstallationNote extends frappe.ui.form
 	}
 };
 
-$.extend(cur_frm.cscript, new erpnext.selling.InstallationNote({frm: cur_frm}));
+extend_cscript(cur_frm.cscript, new erpnext.selling.InstallationNote({frm: cur_frm}));

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -104,7 +104,7 @@ frappe.ui.form.on("Sales Order Item", {
 
 erpnext.selling.SalesOrderController = class SalesOrderController extends erpnext.selling.SellingController {
 	onload(doc, dt, dn) {
-		super.onload();
+		super.onload(doc, dt, dn);
 	}
 
 	refresh(doc, dt, dn) {
@@ -744,4 +744,5 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 		});
 	}
 };
-$.extend(cur_frm.cscript, new erpnext.selling.SalesOrderController({frm: cur_frm}));
+
+extend_cscript(cur_frm.cscript, new erpnext.selling.SalesOrderController({frm: cur_frm}));

--- a/erpnext/selling/doctype/sms_center/sms_center.js
+++ b/erpnext/selling/doctype/sms_center/sms_center.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 // License: GNU General Public License v3. See license.txt
 
-$.extend(cur_frm.cscript, {
+extend_cscript(cur_frm.cscript, {
 	message: function () {
 		var total_characters = this.frm.doc.message.length;
 		var total_msg = 1;

--- a/erpnext/setup/doctype/currency_exchange/currency_exchange.js
+++ b/erpnext/setup/doctype/currency_exchange/currency_exchange.js
@@ -1,29 +1,29 @@
 // Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 // License: GNU General Public License v3. See license.txt
 
-$.extend(cur_frm.cscript, {
+extend_cscript(cur_frm.cscript, {
 	onload: function() {
 		if(cur_frm.doc.__islocal) {
 			cur_frm.set_value("to_currency", frappe.defaults.get_global_default("currency"));
 		}
 	},
-	
+
 	refresh: function() {
 		cur_frm.cscript.set_exchange_rate_label();
 	},
-	
+
 	from_currency: function() {
 		cur_frm.cscript.set_exchange_rate_label();
 	},
-	
+
 	to_currency: function() {
 		cur_frm.cscript.set_exchange_rate_label();
 	},
-	
+
 	set_exchange_rate_label: function() {
 		if(cur_frm.doc.from_currency && cur_frm.doc.to_currency) {
 			var default_label = __(frappe.meta.docfield_map[cur_frm.doctype]["exchange_rate"].label);
-			cur_frm.fields_dict.exchange_rate.set_label(default_label + 
+			cur_frm.fields_dict.exchange_rate.set_label(default_label +
 				repl(" (1 %(from_currency)s = [?] %(to_currency)s)", cur_frm.doc));
 		}
 	}

--- a/erpnext/stock/doctype/delivery_note/delivery_note.js
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.js
@@ -305,7 +305,7 @@ erpnext.stock.DeliveryNoteController = class DeliveryNoteController extends erpn
 	}
 };
 
-$.extend(cur_frm.cscript, new erpnext.stock.DeliveryNoteController({frm: cur_frm}));
+extend_cscript(cur_frm.cscript, new erpnext.stock.DeliveryNoteController({frm: cur_frm}));
 
 frappe.ui.form.on('Delivery Note', {
 	setup: function(frm) {

--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -433,7 +433,7 @@ erpnext.buying.MaterialRequestController = class MaterialRequestController exten
 			if (doc.material_request_type == "Customer Provided") {
 				return{
 					query: "erpnext.controllers.queries.item_query",
-					filters:{ 
+					filters:{
 						'customer': me.frm.doc.customer,
 						'is_stock_item':1
 					}
@@ -472,7 +472,7 @@ erpnext.buying.MaterialRequestController = class MaterialRequestController exten
 };
 
 // for backward compatibility: combine new and previous states
-$.extend(cur_frm.cscript, new erpnext.buying.MaterialRequestController({frm: cur_frm}));
+extend_cscript(cur_frm.cscript, new erpnext.buying.MaterialRequestController({frm: cur_frm}));
 
 function set_schedule_date(frm) {
 	if(frm.doc.schedule_date){

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.js
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.js
@@ -251,7 +251,7 @@ erpnext.stock.PurchaseReceiptController = class PurchaseReceiptController extend
 };
 
 // for backward compatibility: combine new and previous states
-$.extend(cur_frm.cscript, new erpnext.stock.PurchaseReceiptController({frm: cur_frm}));
+extend_cscript(cur_frm.cscript, new erpnext.stock.PurchaseReceiptController({frm: cur_frm}));
 
 cur_frm.cscript.update_status = function(status) {
 	frappe.ui.form.is_saving = true;

--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -1064,4 +1064,4 @@ erpnext.stock.select_batch_and_serial_no = (frm, item) => {
 
 }
 
-$.extend(cur_frm.cscript, new erpnext.stock.StockEntry({frm: cur_frm}));
+extend_cscript(cur_frm.cscript, new erpnext.stock.StockEntry({frm: cur_frm}));

--- a/erpnext/support/doctype/warranty_claim/warranty_claim.js
+++ b/erpnext/support/doctype/warranty_claim/warranty_claim.js
@@ -55,7 +55,7 @@ erpnext.support.WarrantyClaim = class WarrantyClaim extends frappe.ui.form.Contr
 	}
 };
 
-$.extend(cur_frm.cscript, new erpnext.support.WarrantyClaim({frm: cur_frm}));
+extend_cscript(cur_frm.cscript, new erpnext.support.WarrantyClaim({frm: cur_frm}));
 
 cur_frm.fields_dict['serial_no'].get_query = function(doc, cdt, cdn) {
 	var cond = [];


### PR DESCRIPTION
Dependent on https://github.com/frappe/frappe/pull/13300

**Case:**
Class instance to be extended
<img width="917" alt="Screenshot 2021-05-23 at 1 17 09 PM" src="https://user-images.githubusercontent.com/13928957/119252464-0c5ad780-bbca-11eb-8f62-1f704bb5b351.png">


with `$.extend`: amount and other inherited functions are not extended
<img width="1027" alt="Screenshot 2021-05-23 at 1 20 36 PM" src="https://user-images.githubusercontent.com/13928957/119252422-c998ff80-bbc9-11eb-8ef0-920a42b3633c.png">

with `extend_cscript`: amount and other inherited functions are extended properly
<img width="660" alt="Screenshot 2021-05-23 at 1 19 43 PM" src="https://user-images.githubusercontent.com/13928957/119252447-efbe9f80-bbc9-11eb-89ec-51c054e98e7e.png">


> Note: this is a quick fix to make breaking functionalities work after the [new build system change](https://github.com/frappe/erpnext/pull/25623)
