### PR TITLE
fix: profitability test

### DIFF
--- a/erpnext/projects/report/project_profitability/test_project_profitability.py
+++ b/erpnext/projects/report/project_profitability/test_project_profitability.py
@@ -43,7 +43,6 @@ class TestProjectProfitability(unittest.TestCase):
 		self.assertEqual(self.salary_slip.total_working_days, row.total_working_days)
 
 		standard_working_hours = frappe.db.get_single_value("HR Settings", "standard_working_hours")
-		print("standard_working_hours", standard_working_hours)
 		utilization = timesheet.total_billed_hours/(self.salary_slip.total_working_days * standard_working_hours)
 		self.assertEqual(utilization, row.utilization)
 

--- a/erpnext/projects/report/project_profitability/test_project_profitability.py
+++ b/erpnext/projects/report/project_profitability/test_project_profitability.py
@@ -8,8 +8,8 @@ from erpnext.projects.doctype.timesheet.timesheet import make_salary_slip, make_
 from erpnext.projects.report.project_profitability.project_profitability import execute
 
 class TestProjectProfitability(unittest.TestCase):
-	@classmethod
-	def setUpClass(self):
+
+	def setUp(self):
 		emp = make_employee('test_employee_9@salary.com', company='_Test Company')
 		if not frappe.db.exists('Salary Component', 'Timesheet Component'):
 			frappe.get_doc({'doctype': 'Salary Component', 'salary_component': 'Timesheet Component'}).insert()
@@ -53,8 +53,7 @@ class TestProjectProfitability(unittest.TestCase):
 		fractional_cost = self.salary_slip.base_gross_pay * utilization
 		self.assertEqual(fractional_cost, row.fractional_cost)
 
-	@classmethod
-	def tearDownClass(self):
+	def tearDown(self):
 		frappe.get_doc("Sales Invoice", self.sales_invoice.name).cancel()
 		frappe.get_doc("Salary Slip", self.salary_slip.name).cancel()
 		frappe.get_doc("Timesheet", self.timesheet.name).cancel()

--- a/erpnext/projects/report/project_profitability/test_project_profitability.py
+++ b/erpnext/projects/report/project_profitability/test_project_profitability.py
@@ -9,7 +9,7 @@ from erpnext.projects.report.project_profitability.project_profitability import 
 
 class TestProjectProfitability(unittest.TestCase):
 	@classmethod
-	def setUp(self):
+	def setUpClass(self):
 		emp = make_employee('test_employee_9@salary.com', company='_Test Company')
 		if not frappe.db.exists('Salary Component', 'Timesheet Component'):
 			frappe.get_doc({'doctype': 'Salary Component', 'salary_component': 'Timesheet Component'}).insert()
@@ -21,7 +21,7 @@ class TestProjectProfitability(unittest.TestCase):
 		self.sales_invoice.due_date = nowdate()
 		self.sales_invoice.submit()
 
-		frappe.db.set_value("HR Settings", "HR Settings", "standard_working_hours", 8)
+		frappe.db.set_value('HR Settings', None, 'standard_working_hours', 8)
 
 	def test_project_profitability(self):
 		filters = {
@@ -43,6 +43,7 @@ class TestProjectProfitability(unittest.TestCase):
 		self.assertEqual(self.salary_slip.total_working_days, row.total_working_days)
 
 		standard_working_hours = frappe.db.get_single_value("HR Settings", "standard_working_hours")
+		print("standard_working_hours", standard_working_hours)
 		utilization = timesheet.total_billed_hours/(self.salary_slip.total_working_days * standard_working_hours)
 		self.assertEqual(utilization, row.utilization)
 
@@ -52,7 +53,8 @@ class TestProjectProfitability(unittest.TestCase):
 		fractional_cost = self.salary_slip.base_gross_pay * utilization
 		self.assertEqual(fractional_cost, row.fractional_cost)
 
-	def tearDown(self):
+	@classmethod
+	def tearDownClass(self):
 		frappe.get_doc("Sales Invoice", self.sales_invoice.name).cancel()
 		frappe.get_doc("Salary Slip", self.salary_slip.name).cancel()
 		frappe.get_doc("Timesheet", self.timesheet.name).cancel()


### PR DESCRIPTION
Fix failing test

```
ERROR: test_project_profitability (erpnext.projects.report.project_profitability.test_project_profitability.TestProjectProfitability)
----------------------------------------------------------------------
1000.0 1000.0
Traceback (most recent call last):
5000.0 5000.0
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/projects/report/project_profitability/test_project_profitability.py", line 46, in test_project_profitability
5000.0 5000.0
    utilization = timesheet.total_billed_hours/(self.salary_slip.total_working_days * standard_working_hours)
1000.0 1000.0
ZeroDivisionError: float division by zero
```