### PR TITLE
fix: Add Hold status column in the Issue Summary Report

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -781,3 +781,4 @@ erpnext.patches.v13_0.germany_fill_debtor_creditor_number
 erpnext.patches.v13_0.set_pos_closing_as_failed
 erpnext.patches.v13_0.update_timesheet_changes
 erpnext.patches.v13_0.set_training_event_attendance
+erpnext.patches.v13_0.rename_issue_status_hold_to_on_hold

--- a/erpnext/patches/v13_0/rename_issue_status_hold_to_on_hold.py
+++ b/erpnext/patches/v13_0/rename_issue_status_hold_to_on_hold.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2020, Frappe and Contributors
+# License: GNU General Public License v3. See license.txt
+
+from __future__ import unicode_literals
+import frappe
+
+def execute():
+	if frappe.db.exists('DocType', 'Issue'):
+        frappe.reload_doc("support", "doctype", "issue")
+	    rename_status()
+
+def rename_status():
+	frappe.db.sql("""
+		UPDATE
+            `tabIssue`
+		SET
+            status = 'On Hold'
+        WHERE
+            status = 'Hold'
+	""")

--- a/erpnext/patches/v13_0/rename_issue_status_hold_to_on_hold.py
+++ b/erpnext/patches/v13_0/rename_issue_status_hold_to_on_hold.py
@@ -6,15 +6,15 @@ import frappe
 
 def execute():
 	if frappe.db.exists('DocType', 'Issue'):
-        frappe.reload_doc("support", "doctype", "issue")
-	    rename_status()
+		frappe.reload_doc("support", "doctype", "issue")
+		rename_status()
 
 def rename_status():
 	frappe.db.sql("""
 		UPDATE
-            `tabIssue`
+			`tabIssue`
 		SET
-            status = 'On Hold'
-        WHERE
-            status = 'Hold'
+			status = 'On Hold'
+		WHERE
+			status = 'Hold'
 	""")

--- a/erpnext/support/doctype/issue/issue.json
+++ b/erpnext/support/doctype/issue/issue.json
@@ -119,7 +119,7 @@
    "no_copy": 1,
    "oldfieldname": "status",
    "oldfieldtype": "Select",
-   "options": "Open\nReplied\nHold\nResolved\nClosed",
+   "options": "Open\nReplied\nOn Hold\nResolved\nClosed",
    "search_index": 1
   },
   {
@@ -410,7 +410,7 @@
  "icon": "fa fa-ticket",
  "idx": 7,
  "links": [],
- "modified": "2020-08-11 18:49:07.574769",
+ "modified": "2021-05-26 10:49:07.574769",
  "modified_by": "Administrator",
  "module": "Support",
  "name": "Issue",

--- a/erpnext/support/report/issue_summary/issue_summary.js
+++ b/erpnext/support/report/issue_summary/issue_summary.js
@@ -42,6 +42,7 @@ frappe.query_reports["Issue Summary"] = {
 				"",
 				{label: __('Open'), value: 'Open'},
 				{label: __('Replied'), value: 'Replied'},
+				{label: __('Hold'), value: 'Hold'},
 				{label: __('Resolved'), value: 'Resolved'},
 				{label: __('Closed'), value: 'Closed'}
 			]

--- a/erpnext/support/report/issue_summary/issue_summary.js
+++ b/erpnext/support/report/issue_summary/issue_summary.js
@@ -42,7 +42,7 @@ frappe.query_reports["Issue Summary"] = {
 				"",
 				{label: __('Open'), value: 'Open'},
 				{label: __('Replied'), value: 'Replied'},
-				{label: __('Hold'), value: 'Hold'},
+				{label: __('On Hold'), value: 'On Hold'},
 				{label: __('Resolved'), value: 'Resolved'},
 				{label: __('Closed'), value: 'Closed'}
 			]

--- a/erpnext/support/report/issue_summary/issue_summary.py
+++ b/erpnext/support/report/issue_summary/issue_summary.py
@@ -62,7 +62,7 @@ class IssueSummary(object):
 				'width': 200
 			})
 
-		self.statuses = ['Open', 'Replied', 'Hold', 'Resolved', 'Closed']
+		self.statuses = ['Open', 'Replied', 'On Hold', 'Resolved', 'Closed']
 		for status in self.statuses:
 			self.columns.append({
 				'label': _(status),
@@ -265,7 +265,7 @@ class IssueSummary(object):
 		labels = []
 		open_issues = []
 		replied_issues = []
-		hold_issues = []
+		on_hold_issues = []
 		resolved_issues = []
 		closed_issues = []
 
@@ -278,7 +278,7 @@ class IssueSummary(object):
 			labels.append(entry.get(entity_field))
 			open_issues.append(entry.get('open'))
 			replied_issues.append(entry.get('replied'))
-			hold_issues.append(entry.get('hold'))
+			on_hold_issues.append(entry.get('on_hold'))
 			resolved_issues.append(entry.get('resolved'))
 			closed_issues.append(entry.get('closed'))
 
@@ -295,8 +295,8 @@ class IssueSummary(object):
 						'values': replied_issues[:30]
 					},
 					{
-						'name': 'Hold',
-						'values': hold_issues[:30]
+						'name': 'On Hold',
+						'values': on_hold_issues[:30]
 					},
 					{
 						'name': 'Resolved',
@@ -319,14 +319,14 @@ class IssueSummary(object):
 
 		open_issues = 0
 		replied = 0
-		hold = 0
+		on_hold = 0
 		resolved = 0
 		closed = 0
 
 		for entry in self.data:
 			open_issues += entry.get('open')
 			replied += entry.get('replied')
-			hold += entry.get('hold')
+			on_hold += entry.get('on_hold')
 			resolved += entry.get('resolved')
 			closed += entry.get('closed')
 
@@ -344,9 +344,9 @@ class IssueSummary(object):
 				'datatype': 'Int',
 			},
 			{
-				'value': hold,
+				'value': on_hold,
 				'indicator': 'Grey',
-				'label': _('Hold'),
+				'label': _('On Hold'),
 				'datatype': 'Int',
 			},
 			{

--- a/erpnext/support/report/issue_summary/issue_summary.py
+++ b/erpnext/support/report/issue_summary/issue_summary.py
@@ -62,7 +62,7 @@ class IssueSummary(object):
 				'width': 200
 			})
 
-		self.statuses = ['Open', 'Replied', 'Resolved', 'Closed']
+		self.statuses = ['Open', 'Replied', 'Hold', 'Resolved', 'Closed']
 		for status in self.statuses:
 			self.columns.append({
 				'label': _(status),
@@ -265,6 +265,7 @@ class IssueSummary(object):
 		labels = []
 		open_issues = []
 		replied_issues = []
+		hold_issues = []
 		resolved_issues = []
 		closed_issues = []
 
@@ -277,6 +278,7 @@ class IssueSummary(object):
 			labels.append(entry.get(entity_field))
 			open_issues.append(entry.get('open'))
 			replied_issues.append(entry.get('replied'))
+			hold_issues.append(entry.get('hold'))
 			resolved_issues.append(entry.get('resolved'))
 			closed_issues.append(entry.get('closed'))
 
@@ -291,6 +293,10 @@ class IssueSummary(object):
 					{
 						'name': 'Replied',
 						'values': replied_issues[:30]
+					},
+					{
+						'name': 'Hold',
+						'values': hold_issues[:30]
 					},
 					{
 						'name': 'Resolved',
@@ -313,12 +319,14 @@ class IssueSummary(object):
 
 		open_issues = 0
 		replied = 0
+		hold = 0
 		resolved = 0
 		closed = 0
 
 		for entry in self.data:
 			open_issues += entry.get('open')
 			replied += entry.get('replied')
+			hold += entry.get('hold')
 			resolved += entry.get('resolved')
 			closed += entry.get('closed')
 
@@ -333,6 +341,12 @@ class IssueSummary(object):
 				'value': replied,
 				'indicator': 'Grey',
 				'label': _('Replied'),
+				'datatype': 'Int',
+			},
+			{
+				'value': hold,
+				'indicator': 'Grey',
+				'label': _('Hold'),
 				'datatype': 'Int',
 			},
 			{


### PR DESCRIPTION
On Hold (status) column is added in the Issue Summary report

![Screenshot 2021-05-26 at 11 22 01 AM](https://user-images.githubusercontent.com/60467153/119609400-250afd80-be15-11eb-90b5-84473363dccf.png)

