### PR TITLE
fix: add validation for 'for_qty' else throws errors

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.json
+++ b/erpnext/stock/doctype/pick_list/pick_list.json
@@ -71,8 +71,7 @@
    "description": "Qty of raw materials will be decided based on the qty of the Finished Goods Item",
    "fieldname": "for_qty",
    "fieldtype": "Float",
-   "label": "Qty of Finished Goods Item",
-   "read_only": 1
+   "label": "Qty of Finished Goods Item"
   },
   {
    "fieldname": "amended_from",
@@ -114,7 +113,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2020-03-17 11:38:41.932875",
+ "modified": "2021-05-25 16:51:37.210932",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Pick List",

--- a/erpnext/stock/doctype/pick_list/pick_list.json
+++ b/erpnext/stock/doctype/pick_list/pick_list.json
@@ -71,7 +71,8 @@
    "description": "Qty of raw materials will be decided based on the qty of the Finished Goods Item",
    "fieldname": "for_qty",
    "fieldtype": "Float",
-   "label": "Qty of Finished Goods Item"
+   "label": "Qty of Finished Goods Item",
+   "read_only": 1
   },
   {
    "fieldname": "amended_from",

--- a/erpnext/stock/doctype/pick_list/pick_list.json
+++ b/erpnext/stock/doctype/pick_list/pick_list.json
@@ -114,7 +114,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2021-05-25 16:51:37.210932",
+ "modified": "2020-03-17 11:38:41.932875",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Pick List",

--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -112,9 +112,9 @@ class PickList(Document):
 		return item_map.values()
 
 	def validate_for_qty(self):
-		if self.for_qty is not None and self.for_qty > 0:
-			return
-		frappe.throw(_("Qty of Finished Goods Item should be greater than 0."))
+		if self.purpose == "Material Transfer for Manufacture" \
+				and (self.for_qty is None or self.for_qty == 0):
+			frappe.throw(_("Qty of Finished Goods Item should be greater than 0."))
 
 
 def validate_item_locations(pick_list):

--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -112,7 +112,7 @@ class PickList(Document):
 		return item_map.values()
 
 	def validate_for_qty(self):
-		if self.for_qty > 0:
+		if self.for_qty is not None and self.for_qty > 0:
 			return
 		frappe.throw(_("Qty of Finished Goods Item should be greater than 0."))
 

--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -17,6 +17,9 @@ from erpnext.selling.doctype.sales_order.sales_order import make_delivery_note a
 # TODO: Prioritize SO or WO group warehouse
 
 class PickList(Document):
+	def validate(self):
+		self.validate_for_qty()
+
 	def before_save(self):
 		self.set_item_locations()
 
@@ -35,6 +38,7 @@ class PickList(Document):
 
 	@frappe.whitelist()
 	def set_item_locations(self, save=False):
+		self.validate_for_qty()
 		items = self.aggregate_item_qty()
 		self.item_location_map = frappe._dict()
 
@@ -106,6 +110,11 @@ class PickList(Document):
 			self.item_count_map[item_code] += item.stock_qty
 
 		return item_map.values()
+
+	def validate_for_qty(self):
+		if self.for_qty > 0:
+			return
+		frappe.throw(_("Qty of Finished Goods Item should be greater than 0."))
 
 
 def validate_item_locations(pick_list):

--- a/erpnext/stock/doctype/pick_list/test_pick_list.py
+++ b/erpnext/stock/doctype/pick_list/test_pick_list.py
@@ -37,6 +37,7 @@ class TestPickList(unittest.TestCase):
 			'company': '_Test Company',
 			'customer': '_Test Customer',
 			'items_based_on': 'Sales Order',
+			'purpose': 'Delivery',
 			'locations': [{
 				'item_code': '_Test Item',
 				'qty': 5,
@@ -90,6 +91,7 @@ class TestPickList(unittest.TestCase):
 			'company': '_Test Company',
 			'customer': '_Test Customer',
 			'items_based_on': 'Sales Order',
+			'purpose': 'Delivery',
 			'locations': [{
 				'item_code': '_Test Item Warehouse Group Wise Reorder',
 				'qty': 1000,
@@ -135,6 +137,7 @@ class TestPickList(unittest.TestCase):
 			'company': '_Test Company',
 			'customer': '_Test Customer',
 			'items_based_on': 'Sales Order',
+			'purpose': 'Delivery',
 			'locations': [{
 				'item_code': '_Test Serialized Item',
 				'qty': 1000,
@@ -264,6 +267,7 @@ class TestPickList(unittest.TestCase):
 			'company': '_Test Company',
 			'customer': '_Test Customer',
 			'items_based_on': 'Sales Order',
+			'purpose': 'Delivery',
 			'locations': [{
 				'item_code': '_Test Item',
 				'qty': 5,
@@ -319,6 +323,7 @@ class TestPickList(unittest.TestCase):
 			'company': '_Test Company',
 			'customer': '_Test Customer',
 			'items_based_on': 'Sales Order',
+			'purpose': 'Delivery',
 			'locations': [{
 				'item_code': '_Test Item',
 				'qty': 1,


### PR DESCRIPTION
### Description
- Add validation for **Pick List**'s `for_qty`, because setting this value to 0 throws errors, and `for_qty = 0` doesn't have a use case.
- Removed `read_only` because the value is set in a dialog which can't be retriggered unless the **Work Order** is set again.