### PR TITLE
fix(ux): fix unstranslated text in msgprint/throw

### DIFF
--- a/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.py
+++ b/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.py
@@ -27,7 +27,7 @@ class AccountingDimension(Document):
 		exists = frappe.db.get_value("Accounting Dimension", {'document_type': self.document_type}, ['name'])
 
 		if exists and self.is_new():
-			frappe.throw("Document Type already used as a dimension")
+			frappe.throw(_("Document Type already used as a dimension"))
 
 		if not self.is_new():
 			self.validate_document_type_change()

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
@@ -5,6 +5,7 @@
 
 from __future__ import unicode_literals
 import frappe
+from frappe import _
 from frappe.utils import cint
 from frappe.model.document import Document
 from frappe.custom.doctype.property_setter.property_setter import make_property_setter
@@ -24,7 +25,7 @@ class AccountsSettings(Document):
 	def validate_stale_days(self):
 		if not self.allow_stale and cint(self.stale_days) <= 0:
 			frappe.msgprint(
-				"Stale Days should start from 1.", title='Error', indicator='red',
+				_("Stale Days should start from 1."), title='Error', indicator='red',
 				raise_exception=1)
 
 	def enable_payment_schedule_in_print(self):

--- a/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py
+++ b/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py
@@ -22,7 +22,7 @@ def validate_company(company):
 		'allow_account_creation_against_child_company'])
 
 	if parent_company and (not allow_account_creation_against_child_company):
-		msg = _("{} is a child company. ").format(frappe.bold(company))
+		msg = _("{} is a child company.").format(frappe.bold(company)) + " "
 		msg += _("Please import accounts against parent company or enable {} in company master.").format(
 			frappe.bold('Allow Account Creation Against Child Company'))
 		frappe.throw(msg, title=_('Wrong Company'))
@@ -56,7 +56,7 @@ def get_file(file_name):
 	extension = extension.lstrip(".")
 
 	if extension not in ('csv',  'xlsx', 'xls'):
-		frappe.throw("Only CSV and Excel files can be used to for importing data. Please check the file format you are trying to upload")
+		frappe.throw(_("Only CSV and Excel files can be used to for importing data. Please check the file format you are trying to upload"))
 
 	return  file_doc, extension
 

--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.js
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.js
@@ -19,7 +19,7 @@ frappe.ui.form.on('Process Statement Of Accounts', {
 							frappe.show_alert({message: __('Emails Queued'), indicator: 'blue'});
 						}
 						else{
-							frappe.msgprint('No Records for these settings.')
+							frappe.msgprint(__('No Records for these settings.'))
 						}
 					}
 				});
@@ -33,7 +33,7 @@ frappe.ui.form.on('Process Statement Of Accounts', {
 					type: 'GET',
 					success: function(result) {
 						if(jQuery.isEmptyObject(result)){
-							frappe.msgprint('No Records for these settings.');
+							frappe.msgprint(__('No Records for these settings.'));
 						}
 						else{
 							window.location = url;
@@ -92,7 +92,7 @@ frappe.ui.form.on('Process Statement Of Accounts', {
 							frm.refresh_field('customers');
 						}
 						else{
-							frappe.throw('No Customers found with selected options.');
+							frappe.throw(__('No Customers found with selected options.'));
 						}
 					}
 				}

--- a/erpnext/crm/doctype/appointment/appointment.py
+++ b/erpnext/crm/doctype/appointment/appointment.py
@@ -38,7 +38,7 @@ class Appointment(Document):
 		number_of_agents = frappe.db.get_single_value('Appointment Booking Settings', 'number_of_agents')
 		if not number_of_agents == 0:
 			if (number_of_appointments_in_same_slot >= number_of_agents):
-				frappe.throw('Time slot is not available')
+				frappe.throw(_('Time slot is not available'))
 		# Link lead
 		if not self.party:
 			lead = self.find_lead_by_email()
@@ -75,10 +75,10 @@ class Appointment(Document):
 						subject=_('Appointment Confirmation'))
 		if frappe.session.user == "Guest":
 			frappe.msgprint(
-				'Please check your email to confirm the appointment')
+				_('Please check your email to confirm the appointment'))
 		else :
 			frappe.msgprint(
-				'Appointment was created. But no lead was found. Please check the email to confirm')
+				_('Appointment was created. But no lead was found. Please check the email to confirm'))
 
 	def on_change(self):
 		# Sync Calendar
@@ -91,7 +91,7 @@ class Appointment(Document):
 
 	def set_verified(self, email):
 		if not email == self.customer_email:
-			frappe.throw('Email verification failed.')
+			frappe.throw(_('Email verification failed.'))
 		# Create new lead
 		self.create_lead_and_link()
 		# Remove unverified status
@@ -184,7 +184,7 @@ class Appointment(Document):
 		appointment_event.insert(ignore_permissions=True)
 		self.calendar_event = appointment_event.name
 		self.save(ignore_permissions=True)
-	
+
 	def _get_verify_url(self):
 		verify_route = '/book_appointment/verify'
 		params = {

--- a/erpnext/education/doctype/course_scheduling_tool/course_scheduling_tool.py
+++ b/erpnext/education/doctype/course_scheduling_tool/course_scheduling_tool.py
@@ -75,7 +75,7 @@ class CourseSchedulingTool(Document):
 		"""Validates if Course Start Date is greater than Course End Date"""
 		if self.course_start_date > self.course_end_date:
 			frappe.throw(
-				"Course Start Date cannot be greater than Course End Date.")
+				_("Course Start Date cannot be greater than Course End Date."))
 
 	def delete_course_schedule(self, rescheduled, reschedule_errors):
 		"""Delete all course schedule within the Date range and specified filters"""

--- a/erpnext/loan_management/doctype/loan/loan.py
+++ b/erpnext/loan_management/doctype/loan/loan.py
@@ -264,7 +264,7 @@ def make_loan_write_off(loan, company=None, posting_date=None, amount=0, as_dict
 	pending_amount = amounts['pending_principal_amount']
 
 	if amount and (amount > pending_amount):
-		frappe.throw('Write Off amount cannot be greater than pending loan amount')
+		frappe.throw(_('Write Off amount cannot be greater than pending loan amount'))
 
 	if not amount:
 		amount = pending_amount

--- a/erpnext/non_profit/doctype/member/member.py
+++ b/erpnext/non_profit/doctype/member/member.py
@@ -28,7 +28,7 @@ class Member(Document):
 	def setup_subscription(self):
 		non_profit_settings = frappe.get_doc('Non Profit Settings')
 		if not non_profit_settings.enable_razorpay_for_memberships:
-			frappe.throw('Please check Enable Razorpay for Memberships in {0} to setup subscription').format(
+			frappe.throw(_('Please check Enable Razorpay for Memberships in {0} to setup subscription')).format(
 				get_link_to_form('Non Profit Settings', 'Non Profit Settings'))
 
 		controller = get_payment_gateway_controller("Razorpay")

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -953,15 +953,15 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 				(this.frm.doc.payment_schedule && this.frm.doc.payment_schedule.length)) {
 				var message1 = "";
 				var message2 = "";
-				var final_message = "Please clear the ";
+				var final_message = __("Please clear the") + " ";
 
 				if (this.frm.doc.payment_terms_template) {
-					message1 = "selected Payment Terms Template";
+					message1 = __("selected Payment Terms Template");
 					final_message = final_message + message1;
 				}
 
 				if ((this.frm.doc.payment_schedule || []).length) {
-					message2 = "Payment Schedule Table";
+					message2 = __("Payment Schedule Table");
 					if (message1.length !== 0) message2 = " and " + message2;
 					final_message = final_message + message2;
 				}

--- a/erpnext/setup/install.py
+++ b/erpnext/setup/install.py
@@ -39,7 +39,7 @@ def check_setup_wizard_not_completed():
 	if cint(frappe.db.get_single_value('System Settings', 'setup_complete') or 0):
 		message = """ERPNext can only be installed on a fresh site where the setup wizard is not completed.
 You can reinstall this site (after saving your data) using: bench --site [sitename] reinstall"""
-		frappe.throw(message)
+		frappe.throw(message)   # nosemgrep
 
 
 def set_single_defaults():

--- a/erpnext/www/book_appointment/index.js
+++ b/erpnext/www/book_appointment/index.js
@@ -48,7 +48,7 @@ function setup_date_picker() {
 function hide_next_button() {
     let next_button = document.getElementById('next-button');
     next_button.disabled = true;
-    next_button.onclick = () => frappe.msgprint("Please select a date and time");
+    next_button.onclick = () => frappe.msgprint(__("Please select a date and time"));
 }
 
 function show_next_button() {
@@ -63,7 +63,7 @@ function on_date_or_timezone_select() {
     if (date_picker.value === '') {
         clear_time_slots();
         hide_next_button();
-        frappe.throw('Please select a date');
+        frappe.throw(__('Please select a date'));
     }
     window.selected_date = date_picker.value;
     window.selected_timezone = timezone.value;


### PR DESCRIPTION
Added missing translate function in msgprint / throw.

This is to avoid CI failures from this rule for existing issues. ref: https://github.com/frappe/erpnext/blob/version-13-hotfix/.github/helper/semgrep_rules/ux.yml