### PR TITLE
fix: remove bad defaults from selling settings

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -278,6 +278,7 @@ erpnext.patches.v13_0.update_tds_check_field #3
 erpnext.patches.v13_0.add_custom_field_for_south_africa #2
 erpnext.patches.v13_0.update_recipient_email_digest
 erpnext.patches.v13_0.shopify_deprecation_warning
+erpnext.patches.v13_0.remove_bad_selling_defaults
 erpnext.patches.v13_0.migrate_stripe_api
 erpnext.patches.v13_0.reset_clearance_date_for_intracompany_payment_entries
 erpnext.patches.v13_0.einvoicing_deprecation_warning

--- a/erpnext/patches/v13_0/remove_bad_selling_defaults.py
+++ b/erpnext/patches/v13_0/remove_bad_selling_defaults.py
@@ -1,0 +1,15 @@
+import frappe
+from frappe import _
+
+
+def execute():
+	selling_settings = frappe.get_single("Selling Settings")
+
+	if selling_settings.customer_group in (_("All Customer Groups"), "All Customer Groups"):
+		selling_settings.customer_group = None
+
+	if selling_settings.territory in (_("All Territories"), "All Territories"):
+		selling_settings.territory = None
+
+	selling_settings.flags.ignore_mandatory=True
+	selling_settings.save(ignore_permissions=True)

--- a/erpnext/selling/doctype/selling_settings/selling_settings.py
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.py
@@ -8,7 +8,6 @@ import frappe
 from frappe.custom.doctype.property_setter.property_setter import make_property_setter
 from frappe.model.document import Document
 from frappe.utils import cint
-from frappe.utils.nestedset import get_root_of
 
 
 class SellingSettings(Document):
@@ -37,9 +36,3 @@ class SellingSettings(Document):
 		editable_bundle_item_rates = cint(self.editable_bundle_item_rates)
 
 		make_property_setter("Packed Item", "rate", "read_only", not(editable_bundle_item_rates), "Check", validate_fields_for_doctype=False)
-
-	def set_default_customer_group_and_territory(self):
-		if not self.customer_group:
-			self.customer_group = get_root_of('Customer Group')
-		if not self.territory:
-			self.territory = get_root_of('Territory')

--- a/erpnext/setup/setup_wizard/operations/install_fixtures.py
+++ b/erpnext/setup/setup_wizard/operations/install_fixtures.py
@@ -303,7 +303,6 @@ def set_more_defaults():
 
 def update_selling_defaults():
 	selling_settings = frappe.get_doc("Selling Settings")
-	selling_settings.set_default_customer_group_and_territory()
 	selling_settings.cust_master_name = "Customer Name"
 	selling_settings.so_required = "No"
 	selling_settings.dn_required = "No"

--- a/erpnext/setup/utils.py
+++ b/erpnext/setup/utils.py
@@ -53,6 +53,7 @@ def before_tests():
 
 	frappe.db.set_value("Stock Settings", None, "auto_insert_price_list_rate_if_missing", 0)
 	enable_all_roles_and_domains()
+	set_defaults_for_tests()
 
 	frappe.db.commit()
 
@@ -126,6 +127,14 @@ def enable_all_roles_and_domains():
 	frappe.get_single('Domain Settings').set_active_domains(\
 		[d.name for d in domains])
 	add_all_roles_to('Administrator')
+
+def set_defaults_for_tests():
+	from frappe.utils.nestedset import get_root_of
+
+	selling_settings = frappe.get_single("Selling Settings")
+	selling_settings.customer_group = get_root_of("Customer Group")
+	selling_settings.territory = get_root_of("Territory")
+	selling_settings.save()
 
 
 def insert_record(records):


### PR DESCRIPTION
Problem: 
Users can't change these default filters. Even if they change it, it will get overwritten on refresh. This is particularly bad because these filters don't work "as expected". Ideally "All customer" implies => "No filtering" however here, it's all customers who have Customer group set to "All customer groups". This is done by setting it default during setup, IMO this is a bad default.

![Screenshot 2021-05-25 at 11 57 20 PM](https://user-images.githubusercontent.com/9079960/119549553-f4937700-bdb4-11eb-937f-c4643e42b794.png)


We already have "descendent of" filtering but that doesn't consider the parent itself, so that's not intuitive either. If goal is to have "all customers" shown by default then the best option is just to remove the filter.


Change:
1. don't set these defaults during setup.
2. Erase existing defaults.
3. Keep these defaults in test (where they don't matter much)


Reported issues:
https://discuss.erpnext.com/t/how-to-disable-the-default-filter/54829/3
https://discuss.erpnext.com/t/how-to-change-the-default-value-for-filters-list-views/52004/6
https://discuss.erpnext.com/t/customers-under-specific-groups-not-showing-under-all-customer-groups/58782
closes https://github.com/frappe/erpnext/issues/22742
closes https://github.com/frappe/erpnext/issues/21363
closes https://github.com/frappe/erpnext/issues/18813

