### PR TITLE
fix(Delivery Note): Assign Product Bundle's conversion_factor to Pack…

### DIFF
--- a/erpnext/stock/doctype/packed_item/packed_item.json
+++ b/erpnext/stock/doctype/packed_item/packed_item.json
@@ -13,6 +13,7 @@
   "section_break_6",
   "warehouse",
   "target_warehouse",
+  "conversion_factor",
   "column_break_9",
   "qty",
   "uom",
@@ -209,13 +210,18 @@
    "no_copy": 1,
    "print_hide": 1,
    "read_only": 1
+  },
+  {
+   "fieldname": "conversion_factor",
+   "fieldtype": "Float",
+   "label": "Conversion Factor"
   }
  ],
  "idx": 1,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-09-24 09:25:13.050151",
+ "modified": "2021-05-26 07:08:05.111385",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Packed Item",

--- a/erpnext/stock/doctype/packed_item/packed_item.py
+++ b/erpnext/stock/doctype/packed_item/packed_item.py
@@ -53,6 +53,7 @@ def update_packing_list_item(doc, packing_item_code, qty, main_item_row, descrip
 	pi.parent_detail_docname = main_item_row.name
 	pi.uom = item.stock_uom
 	pi.qty = flt(qty)
+	pi.conversion_factor = main_item_row.conversion_factor
 	if description and not pi.description:
 		pi.description = description
 	if not pi.warehouse and not doc.amended_from:


### PR DESCRIPTION
_Issue:_ 
The following error gets raised if a user tries to save a Delivery Note of type Internal Transfer which has a list of Packed Items.

![Screenshot 2021-05-26 at 7 33 18 AM](https://user-images.githubusercontent.com/25903035/119591675-ab631780-bdf4-11eb-8d60-86cccedf71c6.png)

_Fix:_
Add a field called Conversion Factor whose value is fetched from the Items table row containing the Product Bundle.

![Screenshot 2021-05-26 at 7 38 50 AM](https://user-images.githubusercontent.com/25903035/119592122-7f946180-bdf5-11eb-9b88-f289bfbbe51e.png)

