### PR TITLE
refactor(asset maintenance log): streamline asset maintenance log fields

### DIFF
--- a/erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log.json
+++ b/erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log.json
@@ -25,6 +25,7 @@
   "assign_to_name",
   "due_date",
   "completion_date",
+  "section_break_7",
   "description",
   "column_break_9",
   "actions_performed",
@@ -138,7 +139,7 @@
   {
    "fetch_from": "task.description",
    "fieldname": "description",
-   "fieldtype": "Read Only",
+   "fieldtype": "Text",
    "label": "Description",
    "read_only": 1
   },
@@ -147,7 +148,8 @@
    "fieldtype": "Section Break"
   },
   {
-   "allow_on_submit": 1,
+   "fetch_from": "task.description",
+   "fetch_if_empty": 1,
    "fieldname": "actions_performed",
    "fieldtype": "Text Editor",
    "label": "Actions performed"
@@ -168,12 +170,18 @@
    "in_preview": 1,
    "label": "Task Name",
    "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "section_break_7",
+   "fieldtype": "Section Break",
+   "label": "Description"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2021-01-22 12:33:45.888124",
+ "modified": "2021-05-25 09:33:36.889087",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset Maintenance Log",


### PR DESCRIPTION
Rationale: Streamline the Asset Maintenance Log.

- Separate Description to another section and make it collapsible (Default is collapsed.) This is beneficial for longer descriptions. Old behavior had the description on a column break.
Old:
![Screenshot from 2021-05-26 18-50-49](https://user-images.githubusercontent.com/13974728/119647974-7fc34a00-be53-11eb-89c7-0d24c568cba8.png)
New:
![](https://user-images.githubusercontent.com/13974728/119458110-fa666980-bd6e-11eb-8e07-35f6d0ed634b.png)

- Prefill "Actions Performed" with the Asset Maintenance Task Description. Actions to be taken might be described in the Task Description anyway. (Only fetch if the field is empty, to prevent overwriting.)
![](https://user-images.githubusercontent.com/13974728/119458429-53ce9880-bd6f-11eb-8225-00446f3e47f5.gif)

- Set "Actions Performed" as read only after submit.
![](https://user-images.githubusercontent.com/13974728/119458977-dce5cf80-bd6f-11eb-95b5-d5f8f1ade4df.gif)

This changes doesn't need updates to the docs. Will also not need new tests.