### PR TITLE
fix: production plan not fetching sales order of a variant

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -118,16 +118,20 @@ class ProductionPlan(Document):
 
 		item_condition = ""
 		if self.item_code:
+			if frappe.db.exists('Item', self.item_code):
+				is_variant = frappe.db.get_value('Item', self.item_code, ['variant_of'])
+			if is_variant:
+				variant_of = is_variant
 			item_condition = ' and so_item.item_code = {0}'.format(frappe.db.escape(self.item_code))
-
+		
 		items = frappe.db.sql("""select distinct parent, item_code, warehouse,
 			(qty - work_order_qty) * conversion_factor as pending_qty, description, name
 			from `tabSales Order Item` so_item
 			where parent in (%s) and docstatus = 1 and qty > work_order_qty
-			and exists (select name from `tabBOM` bom where bom.item=so_item.item_code
+			and exists (select name from `tabBOM` bom where bom.item= "%s"
 					and bom.is_active = 1) %s""" % \
-			(", ".join(["%s"] * len(so_list)), item_condition), tuple(so_list), as_dict=1)
-
+			(", ".join(["%s"] * len(so_list)), variant_of or "so_items.item_code", item_condition), tuple(so_list), as_dict=1)
+			
 		if self.item_code:
 			item_condition = ' and so_item.item_code = {0}'.format(frappe.db.escape(self.item_code))
 
@@ -695,6 +699,10 @@ def get_sales_orders(self):
 		so_filter += "and so.status = %(sales_order_status)s"
 
 	if self.item_code:
+		if frappe.db.exists('Item', self.item_code):
+			is_variant = frappe.db.get_value('Item', self.item_code, ['variant_of'])
+			if is_variant:
+				variant_of = is_variant
 		item_filter += " and so_item.item_code = %(item)s"
 
 	open_so = frappe.db.sql("""
@@ -704,7 +712,7 @@ def get_sales_orders(self):
 			and so.docstatus = 1 and so.status not in ("Stopped", "Closed")
 			and so.company = %(company)s
 			and so_item.qty > so_item.work_order_qty {0} {1}
-			and (exists (select name from `tabBOM` bom where bom.item=so_item.item_code
+			and (exists (select name from `tabBOM` bom where bom.item=%(item_code)s
 					and bom.is_active = 1)
 				or exists (select name from `tabPacked Item` pi
 					where pi.parent = so.name and pi.parent_item = so_item.item_code
@@ -715,6 +723,7 @@ def get_sales_orders(self):
 			"to_date": self.to_date,
 			"customer": self.customer,
 			"project": self.project,
+			"item_code": variant_of or "so_item.item_code",
 			"item": self.item_code,
 			"company": self.company,
 			"sales_order_status": self.sales_order_status

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -131,15 +131,22 @@ class ProductionPlan(Document):
 			bom_item = self.get_bom_item() or bom_item
 			item_condition = ' and so_item.item_code = {0}'.format(frappe.db.escape(self.item_code))
 
-		items = frappe.db.sql("""select distinct parent, item_code, warehouse,
-				(qty - work_order_qty) * conversion_factor as pending_qty, description, name
-				from `tabSales Order Item` so_item
-			where 
+		items = frappe.db.sql("""
+			select
+				distinct parent, item_code, warehouse,
+				(qty - work_order_qty) * conversion_factor as pending_qty,
+				description, name
+			from
+				`tabSales Order Item` so_item
+			where
 				parent in (%s) and docstatus = 1 and qty > work_order_qty
 				and exists (select name from `tabBOM` bom where %s
-						and bom.is_active = 1) %s""" % \
-			(", ".join(["%s"] * len(so_list)), bom_item, item_condition), tuple(so_list), as_dict=1)
-			
+				and bom.is_active = 1) %s""" %
+			(", ".join(["%s"] * len(so_list)),
+			bom_item,
+			item_condition),
+			tuple(so_list), as_dict=1)
+
 		if self.item_code:
 			item_condition = ' and so_item.item_code = {0}'.format(frappe.db.escape(self.item_code))
 

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -109,6 +109,15 @@ class ProductionPlan(Document):
 		so_mr_list = [d.get(field) for d in self.get(table) if d.get(field)]
 		return so_mr_list
 
+	def get_bom_item(self):
+		"""Check if Item or if its Template has a BOM."""
+		bom_item = None
+		has_bom = frappe.db.exists({'doctype': 'BOM', 'item': self.item_code, 'docstatus': 1})
+		if not has_bom:
+			template_item = frappe.db.get_value('Item', self.item_code, ['variant_of'])
+			bom_item = "bom.item = {0}".format(frappe.db.escape(template_item)) if template_item else bom_item
+		return bom_item
+
 	def get_so_items(self):
 		# Check for empty table or empty rows
 		if not self.get("sales_orders") or not self.get_so_mr_list("sales_order", "sales_orders"):
@@ -116,21 +125,20 @@ class ProductionPlan(Document):
 
 		so_list = self.get_so_mr_list("sales_order", "sales_orders")
 
-		item_condition = variant_of_bom = ""
-		if self.item_code:
-			if frappe.db.exists('Item', self.item_code):
-				has_variant_bom = frappe.db.exists({'doctype': 'BOM', 'item': self.item_code})
-				if not has_variant_bom:
-					variant_of_bom = "'%s'" % frappe.db.get_value('Item', self.item_code, ['variant_of'])
+		item_condition = ""
+		bom_item = "bom.item = so_item.item_code"
+		if self.item_code and frappe.db.exists('Item', self.item_code):
+			bom_item = self.get_bom_item() or bom_item
 			item_condition = ' and so_item.item_code = {0}'.format(frappe.db.escape(self.item_code))
 
 		items = frappe.db.sql("""select distinct parent, item_code, warehouse,
-			(qty - work_order_qty) * conversion_factor as pending_qty, description, name
-			from `tabSales Order Item` so_item
-			where parent in (%s) and docstatus = 1 and qty > work_order_qty
-			and exists (select name from `tabBOM` bom where bom.item= %s
-					and bom.is_active = 1) %s""" % \
-			(", ".join(["%s"] * len(so_list)), variant_of_bom or "so_item.item_code", item_condition), tuple(so_list), as_dict=1)
+				(qty - work_order_qty) * conversion_factor as pending_qty, description, name
+				from `tabSales Order Item` so_item
+			where 
+				parent in (%s) and docstatus = 1 and qty > work_order_qty
+				and exists (select name from `tabBOM` bom where %s
+						and bom.is_active = 1) %s""" % \
+			(", ".join(["%s"] * len(so_list)), bom_item, item_condition), tuple(so_list), as_dict=1)
 			
 		if self.item_code:
 			item_condition = ' and so_item.item_code = {0}'.format(frappe.db.escape(self.item_code))
@@ -686,7 +694,8 @@ def get_material_request_items(row, sales_order, company,
 		}
 
 def get_sales_orders(self):
-	so_filter = item_filter = variant_of_bom = ""
+	so_filter = item_filter = ""
+	bom_item = "bom.item = so_item.item_code"
 	if self.from_date:
 		so_filter += " and so.transaction_date >= %(from_date)s"
 	if self.to_date:
@@ -698,11 +707,8 @@ def get_sales_orders(self):
 	if self.sales_order_status:
 		so_filter += "and so.status = %(sales_order_status)s"
 
-	if self.item_code:
-		if frappe.db.exists('Item', self.item_code):
-			has_variant_bom = frappe.db.exists({'doctype': 'BOM', 'item': self.item_code})
-			if not has_variant_bom:
-				variant_of_bom = "'%s'" % frappe.db.get_value('Item', self.item_code, ['variant_of'])
+	if self.item_code and frappe.db.exists('Item', self.item_code):
+		bom_item = self.get_bom_item() or bom_item
 		item_filter += " and so_item.item_code = %(item)s"
 
 	open_so = frappe.db.sql("""
@@ -712,13 +718,13 @@ def get_sales_orders(self):
 			and so.docstatus = 1 and so.status not in ("Stopped", "Closed")
 			and so.company = %(company)s
 			and so_item.qty > so_item.work_order_qty {0} {1}
-			and (exists (select name from `tabBOM` bom where bom.item= {2}
+			and (exists (select name from `tabBOM` bom where {2}
 					and bom.is_active = 1)
 				or exists (select name from `tabPacked Item` pi
 					where pi.parent = so.name and pi.parent_item = so_item.item_code
 						and exists (select name from `tabBOM` bom where bom.item=pi.item_code
 							and bom.is_active = 1)))
-		""".format(so_filter, item_filter, variant_of_bom or "so_item.item_code"), {
+		""".format(so_filter, item_filter, bom_item), {
 			"from_date": self.from_date,
 			"to_date": self.to_date,
 			"customer": self.customer,


### PR DESCRIPTION
**Current Issue:**
- Created a Sales Order for an item variant.(The parent item has a BOM)
![so_1](https://user-images.githubusercontent.com/43572428/119668790-1a705880-be55-11eb-94dd-cdd31acbb771.png)

- On creating a Production Plan and trying to fetch in this Sales Order using Item Code, it doesn't get fetched.

![so_2](https://user-images.githubusercontent.com/43572428/119668983-47bd0680-be55-11eb-97aa-144bebc33c53.png)

**Reason:**
- No condition in SQL query when item variant BOM does not exist.

**Solution:**
- The query must fetch the parent item's BOM if the item variant does not have a BOM.

**After Fix**:
- Updated Query.
- Parent item BOM.

![image](https://user-images.githubusercontent.com/43572428/119671069-147b7700-be57-11eb-881e-0236600d35d1.png)

- When item variant has a BOM.

![variant_with](https://user-images.githubusercontent.com/43572428/119671104-1d6c4880-be57-11eb-8874-0cabeae2fde2.gif)

- When item variant doesn't have a BOM. (Fetches parent BOM)

![variant_without](https://user-images.githubusercontent.com/43572428/119671213-396fea00-be57-11eb-834c-e6e691ea70dc.gif)




