### PR TITLE
fix: Create POS Invoice for Product Bundles

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -471,13 +471,14 @@ def get_bundle_availability(bundle_item_code, warehouse):
 	bundle_bin_qty = 1000000
 	for item in product_bundle.items:
 		item_bin_qty = get_bin_qty(item.item_code, warehouse)
+		item_pos_reserved_qty = get_pos_reserved_qty(item.item_code, warehouse)
+		available_qty = item_bin_qty - item_pos_reserved_qty
 
-		max_num_of_bundles = item_bin_qty / item.qty
-		if bundle_bin_qty > max_num_of_bundles:
-			bundle_bin_qty = max_num_of_bundles
+		max_available_bundles = available_qty / item.qty
+		if bundle_bin_qty > max_available_bundles:
+			bundle_bin_qty = max_available_bundles
 
 	pos_sales_qty = get_pos_reserved_qty(bundle_item_code, warehouse)
-
 	return bundle_bin_qty - pos_sales_qty
 
 def get_bin_qty(item_code, warehouse):

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -215,7 +215,7 @@ class POSInvoice(SalesInvoice):
 			is_stock_item = frappe.get_cached_value("Item", d.get("item_code"), "is_stock_item")
 			if not is_stock_item:
 				if not frappe.db.exists('Product Bundle', d.item_code):
-					frappe.throw(_("Row #{}: Item {} is a non stock item. You can only include stock items in a POS Invoice. ")
+					frappe.throw(_("Row #{}: Item {} is a non stock item. You can only include stock items in a POS Invoice.")
 						.format(d.idx, frappe.bold(d.item_code)), title=_("Invalid Item"))
 
 	def validate_mode_of_payment(self):

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -218,8 +218,9 @@ class POSInvoice(SalesInvoice):
 		for d in self.get("items"):
 			is_stock_item = frappe.get_cached_value("Item", d.get("item_code"), "is_stock_item")
 			if not is_stock_item:
-				frappe.throw(_("Row #{}: Item {} is a non stock item. You can only include stock items in a POS Invoice. ")
-					.format(d.idx, frappe.bold(d.item_code)), title=_("Invalid Item"))
+				if not frappe.db.exists('Product Bundle', d.item_code):
+					frappe.throw(_("Row #{}: Item {} is a non stock item. You can only include stock items in a POS Invoice. ")
+						.format(d.idx, frappe.bold(d.item_code)), title=_("Invalid Item"))
 
 	def validate_mode_of_payment(self):
 		if len(self.payments) == 0:
@@ -472,7 +473,7 @@ def get_bundle_availability(bundle_item_code, warehouse):
 	for item in product_bundle.items:
 		item_bin_qty = get_bin_qty(item.item_code, warehouse)
 
-		max_num_of_bundles = item_bin_qty / item.qty	# max number of bundles that can be created using the item_bin_qty
+		max_num_of_bundles = item_bin_qty / item.qty
 		if bundle_bin_qty > max_num_of_bundles:
 			bundle_bin_qty = max_num_of_bundles
 


### PR DESCRIPTION
_Issue:_
Users are unable to create POS Invoices for Product Bundles, as their item_codes correspond to non-stock Items.

_Fix:_
- Check if non-stock items are Product Bundles.
- If so, check stock availability of included Items.