### PR TITLE
fix: timeout error in the repost item valuation

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -332,7 +332,9 @@ scheduler_events = {
 		"erpnext.projects.doctype.project.project.collect_project_status",
 		"erpnext.hr.doctype.shift_type.shift_type.process_auto_attendance_for_all_shifts",
 		"erpnext.support.doctype.issue.issue.set_service_level_agreement_variance",
-		"erpnext.erpnext_integrations.connectors.shopify_connection.sync_old_orders",
+		"erpnext.erpnext_integrations.connectors.shopify_connection.sync_old_orders"
+	],
+	"hourly_long": [
 		"erpnext.stock.doctype.repost_item_valuation.repost_item_valuation.repost_entries"
 	],
 	"daily": [


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-13-2021-05-17/apps/erpnext/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py", line 58, in repost
    repost_sl_entries(doc)
  File "/home/frappe/benches/bench-version-13-2021-05-17/apps/erpnext/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py", line 81, in repost_sl_entries
    allow_negative_stock=doc.allow_negative_stock, via_landed_cost_voucher=doc.via_landed_cost_voucher)
  File "/home/frappe/benches/bench-version-13-2021-05-17/apps/erpnext/erpnext/stock/stock_ledger.py", line 126, in repost_future_sle
    }, allow_negative_stock=allow_negative_stock, via_landed_cost_voucher=via_landed_cost_voucher)
  File "/home/frappe/benches/bench-version-13-2021-05-17/apps/erpnext/erpnext/stock/stock_ledger.py", line 177, in __init__
    self.build()
  File "/home/frappe/benches/bench-version-13-2021-05-17/apps/erpnext/erpnext/stock/stock_ledger.py", line 255, in build
    self.process_sle(sle)
  File "/home/frappe/benches/bench-version-13-2021-05-17/apps/erpnext/erpnext/stock/stock_ledger.py", line 370, in process_sle
    self.update_outgoing_rate_on_transaction(sle)
  File "/home/frappe/benches/bench-version-13-2021-05-17/apps/erpnext/erpnext/stock/stock_ledger.py", line 440, in update_outgoing_rate_on_transaction
    self.update_rate_on_stock_entry(sle, outgoing_rate)
  File "/home/frappe/benches/bench-version-13-2021-05-17/apps/erpnext/erpnext/stock/stock_ledger.py", line 450, in update_rate_on_stock_entry
    stock_entry = frappe.get_doc("Stock Entry", sle.voucher_no, for_update=True)
  File "/home/frappe/benches/bench-version-13-2021-05-17/apps/frappe/frappe/__init__.py", line 851, in get_doc
    cache().hset('document_cache', key, doc.as_dict())
  File "/home/frappe/benches/bench-version-13-2021-05-17/apps/frappe/frappe/model/base_document.py", line 310, in as_dict
    doc[df.fieldname] = [d.as_dict(convert_dates_to_str=convert_dates_to_str, no_nulls=no_nulls) for d in children]
  File "/home/frappe/benches/bench-version-13-2021-05-17/apps/frappe/frappe/model/base_document.py", line 310, in <listcomp>
    doc[df.fieldname] = [d.as_dict(convert_dates_to_str=convert_dates_to_str, no_nulls=no_nulls) for d in children]
  File "/home/frappe/benches/bench-version-13-2021-05-17/apps/frappe/frappe/model/base_document.py", line 306, in as_dict
    doc = self.get_valid_dict(convert_dates_to_str=convert_dates_to_str)
  File "/home/frappe/benches/bench-version-13-2021-05-17/apps/frappe/frappe/model/base_document.py", line 243, in get_valid_dict
    d[fieldname] = self.get(fieldname)
  File "/home/frappe/benches/bench-version-13-2021-05-17/apps/frappe/frappe/model/base_document.py", line 146, in get
    and key in (d.fieldname for d in self.meta.get_table_fields()):
  File "/home/frappe/benches/bench-version-13-2021-05-17/apps/frappe/frappe/model/meta.py", line 160, in get_table_fields
    return self._table_fields
  File "/home/frappe/benches/bench-version-13-2021-05-17/env/lib/python3.6/site-packages/rq/timeouts.py", line 64, in handle_death_penalty
    '({0} seconds)'.format(self._timeout))
rq.timeouts.JobTimeoutException: Task exceeded maximum timeout value (300 seconds)
```