### PR TITLE
fix: ageing error in PSOA

### DIFF
--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
@@ -94,7 +94,7 @@ def get_report_pdf(doc, consolidated=True):
 			continue
 
 		html = frappe.render_template(template_path, \
-			{"filters": filters, "data": res, "ageing": ageing[0] if doc.include_ageing else None,
+			{"filters": filters, "data": res, "ageing": ageing[0] if (doc.include_ageing and ageing) else None,
 				"letter_head": letter_head if doc.letter_head else None,
 				"terms_and_conditions": frappe.db.get_value('Terms and Conditions', doc.terms_and_conditions, 'terms')
 					if doc.terms_and_conditions else None})


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/Users/anuja-frappe/Dev/frappe/frappe-bench2/apps/frappe/frappe/app.py", line 68, in application
    response = frappe.api.handle()
  File "/Users/anuja-frappe/Dev/frappe/frappe-bench2/apps/frappe/frappe/api.py", line 54, in handle
    return frappe.handler.handle()
  File "/Users/anuja-frappe/Dev/frappe/frappe-bench2/apps/frappe/frappe/handler.py", line 31, in handle
    data = execute_cmd(cmd)
  File "/Users/anuja-frappe/Dev/frappe/frappe-bench2/apps/frappe/frappe/handler.py", line 67, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/anuja-frappe/Dev/frappe/frappe-bench2/apps/frappe/frappe/__init__.py", line 1169, in call
    return fn(*args, **newargs)
  File "/Users/anuja-frappe/Dev/frappe/frappe-bench2/apps/erpnext/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py", line 231, in download_statements
    report = get_report_pdf(doc)
  File "/Users/anuja-frappe/Dev/frappe/frappe-bench2/apps/erpnext/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py", line 97, in get_report_pdf
    {"filters": filters, "data": res, "ageing": ageing[0] if doc.include_ageing else None,
IndexError: list index out of range
```