### PR TITLE
fix(Payment Entry): Incorrect allocated amount

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -413,8 +413,12 @@ class PaymentEntry(AccountsController):
 				base_total_allocated_amount += flt(flt(d.allocated_amount) * flt(d.exchange_rate),
 					self.precision("base_paid_amount"))
 
-		self.total_allocated_amount = abs(total_allocated_amount)
-		self.base_total_allocated_amount = abs(base_total_allocated_amount)
+		if total_allocated_amount > 0:
+			self.total_allocated_amount = total_allocated_amount
+			self.base_total_allocated_amount = base_total_allocated_amount
+		else:
+			self.total_allocated_amount = 0
+			self.base_total_allocated_amount = 0
 
 	def set_unallocated_amount(self):
 		self.unallocated_amount = 0

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -124,6 +124,7 @@ class AccountsController(TransactionBase):
 
 			if self.is_return:
 				self.validate_qty()
+				self.validate_rate()
 			else:
 				self.validate_deferred_start_and_end_date()
 

--- a/erpnext/controllers/status_updater.py
+++ b/erpnext/controllers/status_updater.py
@@ -118,6 +118,7 @@ class StatusUpdater(Document):
 	def update_prevdoc_status(self):
 		self.update_qty()
 		self.validate_qty()
+		self.validate_rate()
 
 	def set_status(self, update=False, status=None, update_modified=True):
 		if self.is_new():
@@ -151,6 +152,17 @@ class StatusUpdater(Document):
 
 			if update:
 				self.db_set('status', self.status, update_modified = update_modified)
+
+	def validate_rate(self):
+		for args in self.status_updater:
+			if "target_ref_field" not in args:
+				# if target_ref_field is not specified, the programmer does not need to validate rate
+				continue
+
+			# get unique transactions to update
+			for d in self.get_all_children():
+				if hasattr(d, 'rate') and d.rate < 0:
+					frappe.throw(_("For item {0}, rate must be a positive number.").format(d.item_code))
 
 	def validate_qty(self):
 		"""Validates qty at row level"""


### PR DESCRIPTION
_Issues:_
- Amount is positive for return Sales Invoices when rate is negative.

![Screenshot 2021-05-28 at 5 33 15 AM](https://user-images.githubusercontent.com/25903035/119911044-37507d00-bf76-11eb-8131-85d7d89236b6.png)

- Total Allocated Amount is positive for Payment Entries that contain only return Invoices(which have negative values for allocated_amount).

_Fix:_
- Throw an error when negative rate is entered for return Sales Invoices.
- Set Total Allocated Amount as zero if sum of allocated_amount for all invoices is negative.

![Screenshot 2021-05-28 at 5 39 49 AM](https://user-images.githubusercontent.com/25903035/119911568-281dff00-bf77-11eb-8c4e-2b1756a80cb3.png)
