### PR TITLE
fix: Add future in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+future==0.18.2
 # frappe   # https://github.com/frappe/frappe is installed during bench-init
 gocardless-pro~=1.22.0
 googlemaps  # used in ERPNext, but dependency is defined in Frappe


### PR DESCRIPTION
Since future is removed from frappe, adding it as a dependency here

PR to test if https://github.com/frappe/erpnext/pull/25850's CI failures are reproducible on current Frappe develop