### PR TITLE
fix: use dictionary filter instead of list

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -76,9 +76,9 @@ frappe.ui.form.on("Work Order", {
 		frm.set_query("production_item", function() {
 			return {
 				query: "erpnext.controllers.queries.item_query",
-				filters:[
-					['is_stock_item', '=',1]
-				]
+				filters: {
+					"is_stock_item": 1,
+				}
 			};
 		});
 


### PR DESCRIPTION
Item query doesn't support list filter anymore. This is the only place list-based filters are used for item_query.

```
|   File "/Users/ankush/benches/v13hf/apps/erpnext/erpnext/controllers/queries.py", line 219, in item_query
|     if filters.get('supplier'):
| AttributeError: 'list' object has no attribute 'get'
```