### PR TITLE
fix: choose correct Salary Structure Assignment when getting data for formula eval

### DIFF
--- a/erpnext/payroll/doctype/salary_slip/salary_slip.py
+++ b/erpnext/payroll/doctype/salary_slip/salary_slip.py
@@ -115,9 +115,22 @@ class SalarySlip(TransactionBase):
 			status = "Cancelled"
 		return status
 
-	def validate_dates(self):
+	def validate_dates(self, joining_date=None, relieving_date=None):
 		if date_diff(self.end_date, self.start_date) < 0:
 			frappe.throw(_("To date cannot be before From date"))
+
+		if not joining_date:
+			joining_date, relieving_date = frappe.get_cached_value(
+				"Employee",
+				self.employee,
+				("date_of_joining", "relieving_date")
+			)
+
+		if date_diff(self.end_date, joining_date) < 0:
+			frappe.throw(_("Cannot create Salary Slip for Employee joining after Payroll Period"))
+
+		if relieving_date and date_diff(relieving_date, self.start_date) < 0:
+			frappe.throw(_("Cannot create Salary Slip for Employee who has left before Payroll Period"))
 
 	def is_rounding_total_disabled(self):
 		return cint(frappe.db.get_single_value("Payroll Settings", "disable_rounded_total"))
@@ -154,9 +167,14 @@ class SalarySlip(TransactionBase):
 
 			if not self.salary_slip_based_on_timesheet:
 				self.get_date_details()
-			self.validate_dates()
-			joining_date, relieving_date = frappe.get_cached_value("Employee", self.employee,
-				["date_of_joining", "relieving_date"])
+
+			joining_date, relieving_date = frappe.get_cached_value(
+				"Employee",
+				self.employee,
+				("date_of_joining", "relieving_date")
+			)
+
+			self.validate_dates(joining_date, relieving_date)
 
 			#getin leave details
 			self.get_working_days_details(joining_date, relieving_date)
@@ -492,13 +510,21 @@ class SalarySlip(TransactionBase):
 	def get_data_for_eval(self):
 		'''Returns data for evaluating formula'''
 		data = frappe._dict()
+		employee = frappe.get_doc("Employee", self.employee).as_dict()
+
+		start_date = getdate(self.start_date)
+		date_to_validate = (
+			employee.date_of_joining
+			if employee.date_of_joining > start_date
+			else start_date
+		)
 
 		salary_structure_assignment = frappe.get_value(
 			"Salary Structure Assignment",
 			{
 				"employee": self.employee,
 				"salary_structure": self.salary_structure,
-				"from_date": ("<=", self.start_date),
+				"from_date": ("<=", date_to_validate),
 				"docstatus": 1,
 			},
 			order_by="from_date desc",
@@ -509,14 +535,14 @@ class SalarySlip(TransactionBase):
 				_("Please assign a Salary Structure for Employee {0} "
 				"applicable from or before {1} first").format(
 					frappe.bold(self.employee_name),
-					frappe.bold(self.start_date)
+					frappe.bold(formatdate(date_to_validate)),
 				)
 			)
 
 		data.update(frappe.get_doc("Salary Structure Assignment",
 			salary_structure_assignment).as_dict())
 
-		data.update(frappe.get_doc("Employee", self.employee).as_dict())
+		data.update(employee)
 		data.update(self.as_dict())
 
 		# set values for components

--- a/erpnext/payroll/doctype/salary_slip/salary_slip.py
+++ b/erpnext/payroll/doctype/salary_slip/salary_slip.py
@@ -493,8 +493,28 @@ class SalarySlip(TransactionBase):
 		'''Returns data for evaluating formula'''
 		data = frappe._dict()
 
+		salary_structure_assignment = frappe.get_value(
+			"Salary Structure Assignment",
+			{
+				"employee": self.employee,
+				"salary_structure": self.salary_structure,
+				"from_date": ("<=", self.start_date),
+				"docstatus": 1,
+			},
+			order_by="from_date desc",
+		)
+
+		if not salary_structure_assignment:
+			frappe.throw(
+				_("Please assign a Salary Structure for Employee {0} "
+				"applicable from or before {1} first").format(
+					frappe.bold(self.employee_name),
+					frappe.bold(self.start_date)
+				)
+			)
+
 		data.update(frappe.get_doc("Salary Structure Assignment",
-			{"employee": self.employee, "salary_structure": self.salary_structure}).as_dict())
+			salary_structure_assignment).as_dict())
 
 		data.update(frappe.get_doc("Employee", self.employee).as_dict())
 		data.update(self.as_dict())

--- a/erpnext/payroll/doctype/salary_slip/salary_slip.py
+++ b/erpnext/payroll/doctype/salary_slip/salary_slip.py
@@ -527,7 +527,9 @@ class SalarySlip(TransactionBase):
 				"from_date": ("<=", date_to_validate),
 				"docstatus": 1,
 			},
+			"*",
 			order_by="from_date desc",
+			as_dict=True,
 		)
 
 		if not salary_structure_assignment:
@@ -539,9 +541,7 @@ class SalarySlip(TransactionBase):
 				)
 			)
 
-		data.update(frappe.get_doc("Salary Structure Assignment",
-			salary_structure_assignment).as_dict())
-
+		data.update(salary_structure_assignment)
 		data.update(employee)
 		data.update(self.as_dict())
 

--- a/erpnext/payroll/doctype/salary_structure/test_salary_structure.py
+++ b/erpnext/payroll/doctype/salary_structure/test_salary_structure.py
@@ -6,7 +6,7 @@ import frappe
 import unittest
 import erpnext
 from frappe.utils.make_random import get_random
-from frappe.utils import nowdate, add_days, add_years, getdate, add_months
+from frappe.utils import nowdate, add_days, add_years, getdate, add_months, get_first_day, date_diff
 from erpnext.payroll.doctype.salary_structure.salary_structure import make_salary_slip
 from erpnext.payroll.doctype.salary_slip.test_salary_slip import make_earning_salary_component,\
 	make_deduction_salary_component, make_employee_salary_slip, create_tax_slab
@@ -113,8 +113,9 @@ class TestSalaryStructure(unittest.TestCase):
 		sal_struct = make_salary_structure("Salary Structure Multi Currency", "Monthly", currency='USD')
 		self.assertEqual(sal_struct.currency, 'USD')
 
-def make_salary_structure(salary_structure, payroll_frequency, employee=None, dont_submit=False, other_details=None,
-	test_tax=False, company=None, currency=erpnext.get_default_currency(), payroll_period=None):
+def make_salary_structure(salary_structure, payroll_frequency, employee=None,
+	from_date=None, dont_submit=False, other_details=None,test_tax=False,
+	company=None, currency=erpnext.get_default_currency(), payroll_period=None):
 	if test_tax:
 		frappe.db.sql("""delete from `tabSalary Structure` where name=%s""",(salary_structure))
 
@@ -139,10 +140,23 @@ def make_salary_structure(salary_structure, payroll_frequency, employee=None, do
 	else:
 		salary_structure_doc = frappe.get_doc("Salary Structure", salary_structure)
 
+	filters = {'employee':employee, 'docstatus': 1}
+	if not from_date and payroll_period:
+		from_date = payroll_period.start_date
+
+	if from_date:
+		filters['from_date'] = from_date
+
 	if employee and not frappe.db.get_value("Salary Structure Assignment",
-		{'employee':employee, 'docstatus': 1}) and salary_structure_doc.docstatus==1:
-			create_salary_structure_assignment(employee, salary_structure, company=company, currency=currency,
-			payroll_period=payroll_period)
+		filters) and salary_structure_doc.docstatus==1:
+		create_salary_structure_assignment(
+			employee,
+			salary_structure,
+			from_date=from_date,
+			company=company,
+			currency=currency,
+			payroll_period=payroll_period
+		)
 
 	return salary_structure_doc
 
@@ -165,12 +179,13 @@ def create_salary_structure_assignment(employee, salary_structure, from_date=Non
 	salary_structure_assignment.base = 50000
 	salary_structure_assignment.variable = 5000
 
-	if getdate(nowdate()).day == 1:
-		date = from_date or nowdate()
-	else:
-		date = from_date or add_days(nowdate(), -1)
+	if not from_date:
+		from_date = get_first_day(nowdate())
+		joining_date = frappe.get_cached_value("Employee", employee, "date_of_joining")
+		if date_diff(joining_date, from_date) > 0:
+			from_date = joining_date
 
-	salary_structure_assignment.from_date = date
+	salary_structure_assignment.from_date = from_date
 	salary_structure_assignment.salary_structure = salary_structure
 	salary_structure_assignment.currency = currency
 	salary_structure_assignment.payroll_payable_account = get_payable_account(company)

--- a/erpnext/payroll/doctype/salary_structure/test_salary_structure.py
+++ b/erpnext/payroll/doctype/salary_structure/test_salary_structure.py
@@ -6,7 +6,7 @@ import frappe
 import unittest
 import erpnext
 from frappe.utils.make_random import get_random
-from frappe.utils import nowdate, add_days, add_years, getdate, add_months, get_first_day, date_diff
+from frappe.utils import nowdate, add_years, get_first_day, date_diff
 from erpnext.payroll.doctype.salary_structure.salary_structure import make_salary_slip
 from erpnext.payroll.doctype.salary_slip.test_salary_slip import make_earning_salary_component,\
 	make_deduction_salary_component, make_employee_salary_slip, create_tax_slab


### PR DESCRIPTION
Resolves #24601 
Resolves #21307

## Changes Made
- Improved validation for Payroll Period to see if employee hasn't joined or has already left
- Choosing correct salary structure with following additional filters:
    - Salary Structure Assignment's **From Date** should be less than or equal to (Payroll Period Start Date or Employee Joining Date whichever is later)
    - Salary Structure Assignment should be submitted
- Gets the Salary Structure Assignment with From Date closest to Payroll Start Date / Employee Joining Date instead of choosing the one which was last modified (`order_by`)
- Error message if Salary Structure Assignment with above filters not found
