### PR TITLE
refactor: update cost updates operation time and hour rates in BOM

### DIFF
--- a/erpnext/manufacturing/doctype/bom/test_bom.py
+++ b/erpnext/manufacturing/doctype/bom/test_bom.py
@@ -122,7 +122,7 @@ class TestBOM(unittest.TestCase):
 		bom.items[0].conversion_factor = 5
 		bom.insert()
 
-		bom.update_cost()
+		bom.update_cost(update_hour_rate = False)
 
 		# test amounts in selected currency
 		self.assertEqual(bom.items[0].rate, 300)

--- a/erpnext/manufacturing/doctype/routing/routing.py
+++ b/erpnext/manufacturing/doctype/routing/routing.py
@@ -4,13 +4,23 @@
 
 from __future__ import unicode_literals
 import frappe
-from frappe.utils import cint
+from frappe.utils import cint, flt
 from frappe import _
 from frappe.model.document import Document
 
 class Routing(Document):
 	def validate(self):
+		self.calculate_operating_cost()
 		self.set_routing_id()
+
+	def on_update(self):
+		self.calculate_operating_cost()
+
+	def calculate_operating_cost(self):
+		for operation in self.operations:
+			if not operation.hour_rate:
+				operation.hour_rate = frappe.db.get_value("Workstation", operation.workstation, 'hour_rate')
+			operation.operating_cost = flt(flt(operation.hour_rate) * flt(operation.time_in_mins) / 60, 2)
 
 	def set_routing_id(self):
 		sequence_id = 0

--- a/erpnext/manufacturing/doctype/workstation/workstation.py
+++ b/erpnext/manufacturing/doctype/workstation/workstation.py
@@ -39,7 +39,8 @@ class Workstation(Document):
 
 	def update_bom_operation(self):
 		bom_list = frappe.db.sql("""select DISTINCT parent from `tabBOM Operation`
-			where workstation = %s""", self.name)
+			where workstation = %s and parenttype = 'routing' """, self.name)
+
 		for bom_no in bom_list:
 			frappe.db.sql("""update `tabBOM Operation` set hour_rate = %s
 				where parent = %s and workstation = %s""",
@@ -71,7 +72,7 @@ def check_if_within_operating_hours(workstation, operation, from_datetime, to_da
 def is_within_operating_hours(workstation, operation, from_datetime, to_datetime):
 	operation_length = time_diff_in_seconds(to_datetime, from_datetime)
 	workstation = frappe.get_doc("Workstation", workstation)
-	
+
 	if not workstation.working_hours:
 		return
 


### PR DESCRIPTION
**Changes:**
**Workstation**
- Hour rates are no longer updated directly in the BOM when rates are changed in the workstations.

**Update Cost (BOM)**
- Update cost now fetches latest rates from workstation and routing(if linked).

_Operation Time_
![routing](https://user-images.githubusercontent.com/43572428/121032622-0f101c00-c7c9-11eb-9482-d7cc7228be48.gif)

_Hour Rates_
![routing_work](https://user-images.githubusercontent.com/43572428/121032625-11727600-c7c9-11eb-90a6-3320e6656c7d.gif)


- Added test cases.
- **[Docs](https://github.com/frappe/erpnext_documentation/pull/345)**