### PR TITLE
fix: Correct South Africa VAT Rate (Updated)

### DIFF
--- a/erpnext/setup/setup_wizard/data/country_wise_tax.json
+++ b/erpnext/setup/setup_wizard/data/country_wise_tax.json
@@ -1519,7 +1519,7 @@
 	"South Africa": {
 		"South Africa Tax": {
 			"account_name": "VAT",
-			"tax_rate": 14.00
+			"tax_rate": 15.00
 		}
 	},
 


### PR DESCRIPTION
On 1 April 2018 South Africa increased the VAT rate from 14% to 15%, this proposed change seeks to update the default parameters for a fresh ERPNext installation.
Previously created pull request #25892 which has now been closed and recreated under correct branch due to issue with rebasing.
This pull request replaces pull request #25892 
