### PR TITLE
fix: added separate table to track scheduled time logs in job card

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.json
+++ b/erpnext/manufacturing/doctype/job_card/job_card.json
@@ -27,12 +27,20 @@
   "employee_name",
   "status",
   "project",
+  "scheduled_time_section",
+  "scheduled_time_logs",
+  "section_break_24",
+  "expected_start_time",
+  "column_break_26",
+  "expected_end_time",
   "timing_detail",
   "time_logs",
   "section_break_13",
   "total_completed_qty",
   "total_time_in_mins",
   "column_break_15",
+  "actual_start_time",
+  "actual_end_time",
   "section_break_8",
   "items",
   "more_information",
@@ -115,7 +123,7 @@
   {
    "fieldname": "timing_detail",
    "fieldtype": "Section Break",
-   "label": "Timing Detail"
+   "label": "Actual Time"
   },
   {
    "fieldname": "employee",
@@ -314,11 +322,67 @@
    "label": "Quality Inspection",
    "no_copy": 1,
    "options": "Quality Inspection"
+  },
+  {
+   "fieldname": "scheduled_time_logs",
+   "fieldtype": "Table",
+   "label": "Scheduled Time Logs",
+   "no_copy": 1,
+   "options": "Job Card Schedule Time",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "scheduled_time_section",
+   "fieldtype": "Section Break",
+   "label": "Scheduled Time"
+  },
+  {
+   "fieldname": "section_break_24",
+   "fieldtype": "Section Break",
+   "hide_border": 1
+  },
+  {
+   "fieldname": "expected_start_time",
+   "fieldtype": "Datetime",
+   "label": "Expected Start Time",
+   "no_copy": 1,
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_26",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "expected_end_time",
+   "fieldtype": "Datetime",
+   "label": "Expected End Time",
+   "no_copy": 1,
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "actual_start_time",
+   "fieldtype": "Datetime",
+   "label": "Actual Start Time",
+   "no_copy": 1,
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "actual_end_time",
+   "fieldtype": "Datetime",
+   "label": "Actual End Time",
+   "no_copy": 1,
+   "print_hide": 1,
+   "read_only": 1
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2020-11-19 18:26:50.531664",
+ "modified": "2021-05-31 13:40:17.067179",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Job Card",

--- a/erpnext/manufacturing/doctype/job_card_schedule_time/job_card_schedule_time.json
+++ b/erpnext/manufacturing/doctype/job_card_schedule_time/job_card_schedule_time.json
@@ -1,0 +1,47 @@
+{
+ "actions": [],
+ "creation": "2020-08-31 16:20:48.058083",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "from_time",
+  "to_time",
+  "time_in_mins"
+ ],
+ "fields": [
+  {
+   "fieldname": "from_time",
+   "fieldtype": "Datetime",
+   "in_list_view": 1,
+   "label": "From Time",
+   "read_only": 1
+  },
+  {
+   "fieldname": "to_time",
+   "fieldtype": "Datetime",
+   "in_list_view": 1,
+   "label": "To Time",
+   "read_only": 1
+  },
+  {
+   "fieldname": "time_in_mins",
+   "fieldtype": "Float",
+   "in_list_view": 1,
+   "label": "Time In Mins"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2021-05-31 14:12:28.631949",
+ "modified_by": "Administrator",
+ "module": "Manufacturing",
+ "name": "Job Card Schedule Time",
+ "owner": "Administrator",
+ "permissions": [],
+ "quick_entry": 1,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "track_changes": 1
+}

--- a/erpnext/manufacturing/doctype/job_card_schedule_time/job_card_schedule_time.py
+++ b/erpnext/manufacturing/doctype/job_card_schedule_time/job_card_schedule_time.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+class JobCardScheduleTime(Document):
+	pass

--- a/erpnext/manufacturing/doctype/routing/test_routing.py
+++ b/erpnext/manufacturing/doctype/routing/test_routing.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 
 import unittest
 import frappe
+from frappe.utils import now
 from frappe.test_runner import make_test_records
 from erpnext.stock.doctype.item.test_item import make_item
 from erpnext.manufacturing.doctype.operation.test_operation import make_operation
@@ -38,6 +39,11 @@ class TestRouting(unittest.TestCase):
 		for data in frappe.get_all("Job Card",
 			filters={"work_order": wo_doc.name}, order_by="sequence_id desc"):
 			job_card_doc = frappe.get_doc("Job Card", data.name)
+			job_card_doc.append('time_logs', {
+				'completed_qty': 10,
+				'from_time': now(),
+				'time_in_mins': 20
+			})
 			job_card_doc.time_logs[0].completed_qty = 10
 			if job_card_doc.sequence_id != 1:
 				self.assertRaises(OperationSequenceError, job_card_doc.save)

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -277,8 +277,8 @@ class WorkOrder(Document):
 				enable_capacity_planning=enable_capacity_planning, auto_create=True)
 
 			if enable_capacity_planning and job_card_doc:
-				row.planned_start_time = job_card_doc.time_logs[-1].from_time
-				row.planned_end_time = job_card_doc.time_logs[-1].to_time
+				row.planned_start_time = job_card_doc.scheduled_time_logs[-1].from_time
+				row.planned_end_time = job_card_doc.scheduled_time_logs[-1].to_time
 
 				if date_diff(row.planned_start_time, original_start_time) > plan_days:
 					frappe.message_log.pop()


### PR DESCRIPTION
**Issue**

System auto set the time logs in the job card even though job has not started
<img width="1302" alt="Screenshot 2021-05-31 at 5 42 30 PM" src="https://user-images.githubusercontent.com/8780500/120191544-b1635900-c237-11eb-9988-871b064d0e0a.png">


**After Fix**
Added separate tables to track scheduled time logs and actual time logs

<img width="1294" alt="Screenshot 2021-05-31 at 5 41 51 PM" src="https://user-images.githubusercontent.com/8780500/120191679-dbb51680-c237-11eb-8b47-0f7c66c1a17e.png">

