### PR TITLE
fix: Removed set_status after cancel from Expense Claim and Employee Advance

### DIFF
--- a/erpnext/hr/doctype/employee_advance/employee_advance.py
+++ b/erpnext/hr/doctype/employee_advance/employee_advance.py
@@ -22,7 +22,6 @@ class EmployeeAdvance(Document):
 
 	def on_cancel(self):
 		self.ignore_linked_doctypes = ('GL Entry')
-		self.set_status()
 
 	def set_status(self):
 		if self.docstatus == 0:
@@ -183,9 +182,9 @@ def make_return_entry(employee, company, employee_advance_name, return_amount,  
 	bank_cash_account = get_default_bank_cash_account(company, account_type='Cash', mode_of_payment = mode_of_payment)
 	if not bank_cash_account:
 		frappe.throw(_("Please set a Default Cash Account in Company defaults"))
-	
+
 	advance_account_currency = frappe.db.get_value('Account', advance_account, 'account_currency')
-	
+
 	je = frappe.new_doc('Journal Entry')
 	je.posting_date = nowdate()
 	je.voucher_type = get_voucher_type(mode_of_payment)

--- a/erpnext/hr/doctype/expense_claim/expense_claim.py
+++ b/erpnext/hr/doctype/expense_claim/expense_claim.py
@@ -44,10 +44,9 @@ class ExpenseClaim(AccountsController):
 
 		paid_amount = flt(self.total_amount_reimbursed) + flt(self.total_advance_amount)
 		precision = self.precision("grand_total")
-		if (self.is_paid or (flt(self.total_sanctioned_amount) > 0
-			and flt(self.grand_total, precision) ==  flt(paid_amount, precision))) \
-			and self.docstatus == 1 and self.approval_status == 'Approved':
-				status = "Paid"
+		if (self.is_paid or (flt(self.total_sanctioned_amount) > 0 and self.docstatus == 1
+			and flt(self.grand_total, precision) ==  flt(paid_amount, precision))) and self.approval_status == 'Approved':
+			status = "Paid"
 		elif flt(self.total_sanctioned_amount) > 0 and self.docstatus == 1 and self.approval_status == 'Approved':
 			status = "Unpaid"
 		elif self.docstatus == 1 and self.approval_status == 'Rejected':

--- a/erpnext/hr/doctype/expense_claim/expense_claim.py
+++ b/erpnext/hr/doctype/expense_claim/expense_claim.py
@@ -86,7 +86,6 @@ class ExpenseClaim(AccountsController):
 		if self.is_paid:
 			update_reimbursed_amount(self)
 
-		self.set_status()
 		self.update_claimed_amount_in_employee_advance()
 
 	def update_claimed_amount_in_employee_advance(self):

--- a/erpnext/hr/doctype/expense_claim/expense_claim.py
+++ b/erpnext/hr/doctype/expense_claim/expense_claim.py
@@ -36,7 +36,7 @@ class ExpenseClaim(AccountsController):
 			self.project = frappe.db.get_value("Task", self.task, "project")
 
 	def set_status(self):
-		self.status = {
+		status = {
 			"0": "Draft",
 			"1": "Submitted",
 			"2": "Cancelled"
@@ -47,11 +47,12 @@ class ExpenseClaim(AccountsController):
 		if (self.is_paid or (flt(self.total_sanctioned_amount) > 0
 			and flt(self.grand_total, precision) ==  flt(paid_amount, precision))) \
 			and self.docstatus == 1 and self.approval_status == 'Approved':
-				self.status = "Paid"
+				status = "Paid"
 		elif flt(self.total_sanctioned_amount) > 0 and self.docstatus == 1 and self.approval_status == 'Approved':
-			self.status = "Unpaid"
+			status = "Unpaid"
 		elif self.docstatus == 1 and self.approval_status == 'Rejected':
-			self.status = 'Rejected'
+			status = 'Rejected'
+		self.db_set("status", status)
 
 	def on_update(self):
 		share_doc_with_approver(self, self.expense_approver)

--- a/erpnext/hr/doctype/expense_claim/expense_claim.py
+++ b/erpnext/hr/doctype/expense_claim/expense_claim.py
@@ -45,7 +45,7 @@ class ExpenseClaim(AccountsController):
 		paid_amount = flt(self.total_amount_reimbursed) + flt(self.total_advance_amount)
 		precision = self.precision("grand_total")
 		if (self.is_paid or (flt(self.total_sanctioned_amount) > 0 and self.docstatus == 1
-			and flt(self.grand_total, precision) ==  flt(paid_amount, precision))) and self.approval_status == 'Approved':
+			and flt(self.grand_total, precision) == flt(paid_amount, precision))) and self.approval_status == 'Approved':
 			status = "Paid"
 		elif flt(self.total_sanctioned_amount) > 0 and self.docstatus == 1 and self.approval_status == 'Approved':
 			status = "Unpaid"

--- a/erpnext/hr/doctype/expense_claim/expense_claim.py
+++ b/erpnext/hr/doctype/expense_claim/expense_claim.py
@@ -35,7 +35,7 @@ class ExpenseClaim(AccountsController):
 		if self.task and not self.project:
 			self.project = frappe.db.get_value("Task", self.task, "project")
 
-	def set_status(self):
+	def set_status(self, update=False):
 		status = {
 			"0": "Draft",
 			"1": "Submitted",
@@ -51,7 +51,11 @@ class ExpenseClaim(AccountsController):
 			status = "Unpaid"
 		elif self.docstatus == 1 and self.approval_status == 'Rejected':
 			status = 'Rejected'
-		self.db_set("status", status)
+
+		if update:
+			self.db_set("status", status)
+		else:
+			self.status = status
 
 	def on_update(self):
 		share_doc_with_approver(self, self.expense_approver)
@@ -74,7 +78,7 @@ class ExpenseClaim(AccountsController):
 		if self.is_paid:
 			update_reimbursed_amount(self)
 
-		self.set_status()
+		self.set_status(update=True)
 		self.update_claimed_amount_in_employee_advance()
 
 	def on_cancel(self):


### PR DESCRIPTION
### Issue
1. From Expense Claim and Employee Advance, the set_status function is called explicitly.
2. This is not needed as the Status gets updated to Cancelled even without calling these functions on cancel.