### PR TITLE
fix: reload doc for possible future schema changes

### DIFF
--- a/erpnext/patches/v12_0/purchase_receipt_status.py
+++ b/erpnext/patches/v12_0/purchase_receipt_status.py
@@ -19,6 +19,9 @@ def execute():
 	logger.info("purchase_receipt_status: begin patch, PR count: {}"
 				.format(len(affected_purchase_receipts)))
 
+	frappe.reload_doc("stock", "doctype", "Purchase Receipt")
+	frappe.reload_doc("stock", "doctype", "Purchase Receipt Item")
+
 
 	for pr in affected_purchase_receipts:
 		pr_name = pr[0]


### PR DESCRIPTION
Problem: the patch for fixing the Purchase Receipt status could fail as the function being run now relies on additional fields introduced later. 

Solution: migrate schema for doctype and child table before running patch.

Root cause of https://github.com/frappe/erpnext/pull/25902
