### PR TITLE
test(perf): eliminate repeat creation of HSN codes

### DIFF
--- a/erpnext/regional/india/setup.py
+++ b/erpnext/regional/india/setup.py
@@ -27,6 +27,9 @@ def setup_company_independent_fixtures(patch=False):
 	add_print_formats()
 
 def add_hsn_sac_codes():
+	if frappe.flags.in_test and frappe.flags.created_hsn_codes:
+		return
+
 	# HSN codes
 	with open(os.path.join(os.path.dirname(__file__), 'hsn_code_data.json'), 'r') as f:
 		hsn_codes = json.loads(f.read())
@@ -37,6 +40,9 @@ def add_hsn_sac_codes():
 	with open(os.path.join(os.path.dirname(__file__), 'sac_code_data.json'), 'r') as f:
 		sac_codes = json.loads(f.read())
 	create_hsn_codes(sac_codes, code_field="sac_code")
+
+	if frappe.flags.in_test:
+		frappe.flags.created_hsn_codes = True
 
 def create_hsn_codes(data, code_field):
 	for d in data:


### PR DESCRIPTION
In tests, we have 5 Indian companies and all of them trigger the creation of HSN code. 

Adding a flag in tests to ignore repeat creation of HSN codes saves ~1.5-2 minutes. (in all test runners)