### PR TITLE
fix: update employee field on renaming employee

### DIFF
--- a/erpnext/hr/doctype/employee/employee.py
+++ b/erpnext/hr/doctype/employee/employee.py
@@ -57,6 +57,9 @@ class Employee(NestedSet):
 				remove_user_permission(
 					"Employee", self.name, existing_user_id)
 
+	def after_rename(self, old, new, merge):
+		self.db_set("employee", new)
+
 	def set_employee_name(self):
 		self.employee_name = ' '.join(filter(lambda x: x, [self.first_name, self.middle_name, self.last_name]))
 


### PR DESCRIPTION
**Steps to replicate**:

1. Create an Employee, say, **EMP-0001**
2. Mark attendance for the Employee using Employee Attendance Tool
3. Rename Employee to **EMP-0002**
4. Mark attendance again using the Employee Attendance Tool. The Attendance still gets marked with **EMP-0001** and not **EMP-0002**

That's because the Employee Attendance Tool picks up employees based on the `employee` field in Employee doctype and not the `name`. This employee field is not changed when you rename the doc.

https://user-images.githubusercontent.com/24353136/120778292-cd227400-c543-11eb-8004-bcf8c2f97fb4.mp4

**Fix**:

Update `employee` field in Employee on `after_rename` method. 

https://user-images.githubusercontent.com/24353136/120779055-4f129d00-c544-11eb-81b6-98b7935cfae4.mp4

P.S. Why do we have this redundant field? 🤔