### PR TITLE
feat: Exchange rate difference handling in procurement cycle

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -517,7 +517,7 @@ class PurchaseInvoice(BuyingController):
 			if d.category in ('Valuation', 'Total and Valuation')
 			and flt(d.base_tax_amount_after_discount_amount)]
 
-		purchase_receipt_details = self.get_purchase_receipt_details()
+		exchange_rate_map, net_rate_map = self.get_purchase_receipt_details()
 
 		for item in self.get("items"):
 			if flt(item.base_net_amount):
@@ -636,31 +636,33 @@ class PurchaseInvoice(BuyingController):
 								"project": item.project or self.project
 							}, account_currency, item=item))
 
-						if purchase_receipt_details[item.item_code]["conversion_rate"] and \
-							self.conversion_rate != purchase_receipt_details[item.item_code]["conversion_rate"] and \
-							item.net_rate == purchase_receipt_details[item.item_code]["net_rate"]:
+						# check if the exchange rate has changed
+						if item.get('purchase_receipt'):
+							if exchange_rate_map[item.purchase_receipt] and \
+								self.conversion_rate != exchange_rate_map[item.purchase_receipt] and \
+								item.net_rate == net_rate_map[item.item_code]:
 
-							discrepancy_caused_by_exchange_rate_difference = (item.qty * item.net_rate) * \
-								(purchase_receipt_details[item.item_code]["conversion_rate"] - self.conversion_rate)
+								discrepancy_caused_by_exchange_rate_difference = (item.qty * item.net_rate) * \
+									(exchange_rate_map[item.purchase_receipt] - self.conversion_rate)
 
-							gl_entries.append(
-								self.get_gl_dict({
-									"account": expense_account,
-									"against": self.supplier,
-									"debit": discrepancy_caused_by_exchange_rate_difference,
-									"cost_center": item.cost_center,
-									"project": item.project or self.project
-								}, account_currency, item=item)
-							)
-							gl_entries.append(
-								self.get_gl_dict({
-									"account": self.get_company_default("exchange_gain_loss_account"),		
-									"against": self.supplier,
-									"credit": discrepancy_caused_by_exchange_rate_difference,
-									"cost_center": item.cost_center,
-									"project": item.project or self.project
-								}, account_currency, item=item)
-							)
+								gl_entries.append(
+									self.get_gl_dict({
+										"account": expense_account,
+										"against": self.supplier,
+										"debit": discrepancy_caused_by_exchange_rate_difference,
+										"cost_center": item.cost_center,
+										"project": item.project or self.project
+									}, account_currency, item=item)
+								)
+								gl_entries.append(
+									self.get_gl_dict({
+										"account": self.get_company_default("exchange_gain_loss_account"),		
+										"against": self.supplier,
+										"credit": discrepancy_caused_by_exchange_rate_difference,
+										"cost_center": item.cost_center,
+										"project": item.project or self.project
+									}, account_currency, item=item)
+								)
 
 					# If asset is bought through this document and not linked to PR
 					if self.update_stock and item.landed_cost_voucher_amount:
@@ -716,21 +718,22 @@ class PurchaseInvoice(BuyingController):
 								item.precision("item_tax_amount"))
 
 	def get_purchase_receipt_details(self):
-		purchase_receipt_details = {}
-		for item in self.items:
-			if item.purchase_receipt:
-				purchase_receipt = frappe.get_doc('Purchase Receipt', item.purchase_receipt)
-				pr_item_details = {
-					"conversion_rate" : purchase_receipt.conversion_rate
-				}
-				
-				for pr_item in purchase_receipt.items:
-					if pr_item.item_code == item.item_code:
-						pr_item_details["net_rate"] = pr_item.net_rate
+		purchase_receipts = []
+		pr_items = []
 
-				purchase_receipt_details[item.item_code] = pr_item_details
+		for item in self.get('items'):
+			if item.get('purchase_receipt'):
+				purchase_receipts.append(item.purchase_receipt)
+			if item.get('pr_detail'):
+				pr_items.append(item.pr_detail)
+			
+		exchange_rate_map = frappe._dict(frappe.get_all('Purchase Receipt', filters={'name': ('in',
+			purchase_receipts)}, fields=['name', 'conversion_rate'], as_list=1))
 
-		return purchase_receipt_details
+		net_rate_map = frappe._dict(frappe.get_all('Purchase Receipt Item', filters={'name': ('in',
+			pr_items)}, fields=['item_code', 'net_rate'], as_list=1))
+
+		return exchange_rate_map, net_rate_map
 
 	def get_asset_gl_entry(self, gl_entries):
 		arbnb_account = self.get_company_default("asset_received_but_not_billed")

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -636,7 +636,7 @@ class PurchaseInvoice(BuyingController):
 
 						# check if the exchange rate has changed
 						purchase_receipt_conversion_rate = frappe.db.get_value('Purchase Receipt', {'name': item.purchase_receipt}, ['conversion_rate'])
-						if self.conversion_rate != purchase_receipt_conversion_rate:
+						if purchase_receipt_conversion_rate and self.conversion_rate != purchase_receipt_conversion_rate:
 							discrepancy_caused_by_exchange_rate_difference = (item.qty * item.rate) * (purchase_receipt_conversion_rate - self.conversion_rate)
 							gl_entries.append(
 								self.get_gl_dict({

--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -230,6 +230,23 @@ class TestPurchaseInvoice(unittest.TestCase):
 			self.assertEqual(expected_values[gle.account][1], gle.debit)
 			self.assertEqual(expected_values[gle.account][2], gle.credit)
 
+	def test_purchase_invoice_with_exchange_rate_difference(self):
+		set_gst_settings()
+		pr = make_purchase_receipt(currency = "USD", conversion_rate = 70)
+		pi = make_purchase_invoice(currency = "USD", conversion_rate = 80, do_not_save = "True")
+
+		for item in pi.items:
+			item.purchase_receipt = pr.name
+
+		pi.insert()
+		pi.submit()		
+
+		# fetching the latest GL Entry with 'Exchange Gain/Loss - _TC' account
+		gl_entries = frappe.get_all('GL Entry', filters = {'account': 'Exchange Gain/Loss - _TC'})
+		voucher_no = frappe.get_value('GL Entry', gl_entries[0]['name'], 'voucher_no')	
+
+		self.assertEqual(pi.name, voucher_no)
+
 	def test_purchase_invoice_change_naming_series(self):
 		pi = frappe.copy_doc(test_records[1])
 		pi.insert()
@@ -1050,6 +1067,24 @@ def update_tax_witholding_category(company, account, date):
 			'account': account
 		})
 		tds_category.save()
+def set_gst_settings():
+	gst_settings = frappe.get_doc("GST Settings")
+
+	gst_account = frappe.get_all(
+		"GST Account",
+		fields=["cgst_account", "sgst_account", "igst_account"],
+		filters = {"company": "_Test Company"}
+	)
+
+	if not gst_account:
+		gst_settings.append("gst_accounts", {
+			"company": "_Test Company",
+			"cgst_account": "CGST - _TC",
+			"sgst_account": "SGST - _TC",
+			"igst_account": "IGST - _TC",
+		})
+
+	gst_settings.save()
 
 def unlink_payment_on_cancel_of_invoice(enable=1):
 	accounts_settings = frappe.get_doc("Accounts Settings")

--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -231,12 +231,11 @@ class TestPurchaseInvoice(unittest.TestCase):
 			self.assertEqual(expected_values[gle.account][2], gle.credit)
 
 	def test_purchase_invoice_with_exchange_rate_difference(self):
-		set_gst_settings()
 		pr = make_purchase_receipt(currency = "USD", conversion_rate = 70)
 		pi = make_purchase_invoice(currency = "USD", conversion_rate = 80, do_not_save = "True")
 
-		for item in pi.items:
-			item.purchase_receipt = pr.name
+		pi.items[0].purchase_receipt = pr.name
+		pi.items[0].pr_detail = pr.items[0].name
 
 		pi.insert()
 		pi.submit()		
@@ -1072,24 +1071,6 @@ def update_tax_witholding_category(company, account, date):
 			'account': account
 		})
 		tds_category.save()
-def set_gst_settings():
-	gst_settings = frappe.get_doc("GST Settings")
-
-	gst_account = frappe.get_all(
-		"GST Account",
-		fields=["cgst_account", "sgst_account", "igst_account"],
-		filters = {"company": "_Test Company"}
-	)
-
-	if not gst_account:
-		gst_settings.append("gst_accounts", {
-			"company": "_Test Company",
-			"cgst_account": "CGST - _TC",
-			"sgst_account": "SGST - _TC",
-			"igst_account": "IGST - _TC",
-		})
-
-	gst_settings.save()
 
 def unlink_payment_on_cancel_of_invoice(enable=1):
 	accounts_settings = frappe.get_doc("Accounts Settings")

--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -247,6 +247,11 @@ class TestPurchaseInvoice(unittest.TestCase):
 
 		self.assertEqual(pi.name, voucher_no)
 
+		exchange_gain_loss_amount = frappe.get_value('GL Entry', gl_entries[0]['name'], 'debit')
+		discrepancy_caused_by_exchange_rate_diff = abs(pi.items[0].base_net_amount - pr.items[0].base_net_amount)
+
+		self.assertEqual(exchange_gain_loss_amount, discrepancy_caused_by_exchange_rate_diff)
+
 	def test_purchase_invoice_change_naming_series(self):
 		pi = frappe.copy_doc(test_records[1])
 		pi.insert()

--- a/erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/test_subcontracted_raw_materials_to_be_transferred.py
+++ b/erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/test_subcontracted_raw_materials_to_be_transferred.py
@@ -60,7 +60,6 @@ def transfer_subcontracted_raw_materials(po):
 	rm_item = [
 		{
 			'name': po.supplied_items[0].name,
-<<<<<<< HEAD
 			'item_code': item_1,
 			'rm_item_code': item_1,
 			'item_name': item_1,
@@ -68,20 +67,10 @@ def transfer_subcontracted_raw_materials(po):
 			'warehouse': '_Test Warehouse - _TC',
 			'rate': 100,
 			'amount': 100 * transfer_qty_map[item_1],
-=======
-			'item_code': '_Test Item Home Desktop 100',
-			'rm_item_code': '_Test Item Home Desktop 100',
-			'item_name': '_Test Item Home Desktop 100',
-			'qty': 2,
-			'warehouse': '_Test Warehouse - _TC',
-			'rate': 100,
-			'amount': 200,
->>>>>>> c4d851e45f (fix: Test)
 			'stock_uom': 'Nos'
 		},
 		{
 			'name': po.supplied_items[1].name,
-<<<<<<< HEAD
 			'item_code': item_2,
 			'rm_item_code': item_2,
 			'item_name': item_2,
@@ -89,15 +78,6 @@ def transfer_subcontracted_raw_materials(po):
 			'warehouse': '_Test Warehouse - _TC',
 			'rate': 100,
 			'amount': 100 * transfer_qty_map[item_2],
-=======
-			'item_code': '_Test Item',
-			'rm_item_code': '_Test Item',
-			'item_name': '_Test Item',
-			'qty': 1,
-			'warehouse': '_Test Warehouse - _TC',
-			'rate': 100,
-			'amount': 100,
->>>>>>> c4d851e45f (fix: Test)
 			'stock_uom': 'Nos'
 		}
 	]

--- a/erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/test_subcontracted_raw_materials_to_be_transferred.py
+++ b/erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/test_subcontracted_raw_materials_to_be_transferred.py
@@ -60,6 +60,7 @@ def transfer_subcontracted_raw_materials(po):
 	rm_item = [
 		{
 			'name': po.supplied_items[0].name,
+<<<<<<< HEAD
 			'item_code': item_1,
 			'rm_item_code': item_1,
 			'item_name': item_1,
@@ -67,10 +68,20 @@ def transfer_subcontracted_raw_materials(po):
 			'warehouse': '_Test Warehouse - _TC',
 			'rate': 100,
 			'amount': 100 * transfer_qty_map[item_1],
+=======
+			'item_code': '_Test Item Home Desktop 100',
+			'rm_item_code': '_Test Item Home Desktop 100',
+			'item_name': '_Test Item Home Desktop 100',
+			'qty': 2,
+			'warehouse': '_Test Warehouse - _TC',
+			'rate': 100,
+			'amount': 200,
+>>>>>>> c4d851e45f (fix: Test)
 			'stock_uom': 'Nos'
 		},
 		{
 			'name': po.supplied_items[1].name,
+<<<<<<< HEAD
 			'item_code': item_2,
 			'rm_item_code': item_2,
 			'item_name': item_2,
@@ -78,6 +89,15 @@ def transfer_subcontracted_raw_materials(po):
 			'warehouse': '_Test Warehouse - _TC',
 			'rate': 100,
 			'amount': 100 * transfer_qty_map[item_2],
+=======
+			'item_code': '_Test Item',
+			'rm_item_code': '_Test Item',
+			'item_name': '_Test Item',
+			'qty': 1,
+			'warehouse': '_Test Warehouse - _TC',
+			'rate': 100,
+			'amount': 100,
+>>>>>>> c4d851e45f (fix: Test)
 			'stock_uom': 'Nos'
 		}
 	]

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -254,7 +254,7 @@ class PurchaseReceipt(BuyingController):
 		return process_gl_map(gl_entries)
 
 	def make_item_gl_entries(self, gl_entries, warehouse_account=None):
-		from erpnext.accounts.doctype.purchase_invoice.purchase_invoice import get_pr_or_pi_details
+		from erpnext.accounts.doctype.purchase_invoice.purchase_invoice import get_purchase_document_details
 
 		stock_rbnb = self.get_company_default("stock_received_but_not_billed")
 		landed_cost_entries = get_item_account_wise_additional_cost(self.name)
@@ -264,7 +264,7 @@ class PurchaseReceipt(BuyingController):
 		warehouse_with_no_account = []
 		stock_items = self.get_stock_items()
 
-		exchange_rate_map, net_rate_map = get_pr_or_pi_details(self)
+		exchange_rate_map, net_rate_map = get_purchase_document_details(self)
 
 		for d in self.get("items"):
 			if d.item_code in stock_items and flt(d.valuation_rate) and flt(d.qty):
@@ -312,7 +312,7 @@ class PurchaseReceipt(BuyingController):
 						if d.get('purchase_invoice'):
 							if exchange_rate_map[d.purchase_invoice] and \
 								self.conversion_rate != exchange_rate_map[d.purchase_invoice] and \
-								d.net_rate == net_rate_map[d.item_code]:
+								d.net_rate == net_rate_map[d.purchase_invoice_item]:
 
 								discrepancy_caused_by_exchange_rate_difference = (d.qty * d.net_rate) * \
 									(exchange_rate_map[d.purchase_invoice] - self.conversion_rate)

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -287,11 +287,7 @@ class PurchaseReceipt(BuyingController):
 							continue
 
 					self.add_gl_entry(gl_entries, warehouse_account_name, d.cost_center, stock_value_diff, 0.0, remarks,
-						stock_rbnb, account_currency=warehouse_account_currency, item=d)
-					print("*"* 30)
-					print(1)
-					print("warehouse_account_name: ", warehouse_account_name)
-					print("")					
+						stock_rbnb, account_currency=warehouse_account_currency, item=d)					
 
 					# GL Entry for from warehouse or Stock Received but not billed
 					# Intentionally passed negative debit amount to avoid incorrect GL Entry validation

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -262,6 +262,8 @@ class PurchaseReceipt(BuyingController):
 		warehouse_with_no_account = []
 		stock_items = self.get_stock_items()
 
+		exchange_rate_map, net_rate_map = self.get_purchase_invoice_details()
+
 		for d in self.get("items"):
 			if d.item_code in stock_items and flt(d.valuation_rate) and flt(d.qty):
 				if warehouse_account.get(d.warehouse):
@@ -303,19 +305,23 @@ class PurchaseReceipt(BuyingController):
 						self.add_gl_entry(gl_entries, account, d.cost_center,
 							-1 * flt(d.base_net_amount, d.precision("base_net_amount")), 0.0, remarks, warehouse_account_name,
 							debit_in_account_currency=-1 * credit_amount, account_currency=credit_currency, item=d)
-						
+
 						# check if the exchange rate has changed
-						purchase_invoice_conversion_rate = frappe.db.get_value('Purchase Invoice', {'name': d.purchase_invoice}, ['conversion_rate'])
-						if purchase_invoice_conversion_rate and self.conversion_rate != purchase_invoice_conversion_rate:
-							discrepancy_caused_by_exchange_rate_difference = (d.qty * d.rate) * (purchase_invoice_conversion_rate - self.conversion_rate)
+						if d.get('purchase_invoice'):
+							if exchange_rate_map[d.purchase_invoice] and \
+								self.conversion_rate != exchange_rate_map[d.purchase_invoice] and \
+								d.net_rate == net_rate_map[d.item_code]:
 
-							self.add_gl_entry(gl_entries, account, d.cost_center, 0.0, discrepancy_caused_by_exchange_rate_difference,
-								remarks, self.supplier, debit_in_account_currency=-1 * discrepancy_caused_by_exchange_rate_difference, 
-								account_currency=credit_currency, item=d)
+								discrepancy_caused_by_exchange_rate_difference = (d.qty * d.net_rate) * \
+									(exchange_rate_map[d.purchase_invoice] - self.conversion_rate)
 
-							self.add_gl_entry(gl_entries, self.get_company_default("exchange_gain_loss_account"), d.cost_center, discrepancy_caused_by_exchange_rate_difference, 0.0, 
-								remarks, self.supplier, debit_in_account_currency=-1 * discrepancy_caused_by_exchange_rate_difference, 
-								account_currency=credit_currency, item=d)
+								self.add_gl_entry(gl_entries, account, d.cost_center, 0.0, discrepancy_caused_by_exchange_rate_difference,
+									remarks, self.supplier, debit_in_account_currency=-1 * discrepancy_caused_by_exchange_rate_difference, 
+									account_currency=credit_currency, item=d)
+
+								self.add_gl_entry(gl_entries, self.get_company_default("exchange_gain_loss_account"), d.cost_center, discrepancy_caused_by_exchange_rate_difference, 0.0, 
+									remarks, self.supplier, debit_in_account_currency=-1 * discrepancy_caused_by_exchange_rate_difference, 
+									account_currency=credit_currency, item=d)
 
 					# Amount added through landed-cos-voucher
 					if d.landed_cost_voucher_amount and landed_cost_entries:
@@ -494,6 +500,28 @@ class PurchaseReceipt(BuyingController):
 
 		self.add_gl_entry(gl_entries, asset_account, item.cost_center, 0.0, flt(item.landed_cost_voucher_amount),
 			remarks, expenses_included_in_asset_valuation, project=item.project, item=item)
+
+	def get_purchase_invoice_details(self):
+		purchase_invoices = []
+		pi_items = []
+
+		for item in self.get('items'):
+			if item.get('purchase_invoice'):
+				purchase_invoices.append(item.purchase_invoice)
+			if item.get('purchase_invoice_item'):
+				pi_items.append(item.purchase_invoice_item)
+			
+		exchange_rate_map = frappe._dict(frappe.get_all('Purchase Invoice', filters={'name': ('in',
+			purchase_invoices)}, fields=['name', 'conversion_rate'], as_list=1))
+		print("*"*50)
+		print("In get_purchase_invoice_details:")
+		print("exchange_rate_map: ", exchange_rate_map)
+
+		net_rate_map = frappe._dict(frappe.get_all('Purchase Invoice Item', filters={'name': ('in',
+			pi_items)}, fields=['item_code', 'net_rate'], as_list=1))
+		print("net_rate_map: ", net_rate_map)
+
+		return exchange_rate_map, net_rate_map
 
 	def update_assets(self, item, valuation_rate):
 		assets = frappe.db.get_all('Asset',

--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -1051,6 +1051,28 @@ class TestPurchaseReceipt(unittest.TestCase):
 		self.assertEqual(len(item_two_gl_entry), 1)
 
 		frappe.db.set_value('Company', company, 'enable_perpetual_inventory_for_non_stock_items', before_test_value)
+	def test_purchase_receipt_with_exchange_rate_difference(self):
+		from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice as create_purchase_invoice
+
+		pi = create_purchase_invoice(currency = "USD", conversion_rate = 70)
+
+		create_warehouse("_Test Warehouse for Valuation", company="_Test Company with perpetual inventory",
+			properties={"account": '_Test Account Stock In Hand - TCP1'})
+		pr = make_purchase_receipt(warehouse = '_Test Warehouse for Valuation - TCP1', 
+			company="_Test Company with perpetual inventory", currency = "USD", conversion_rate = 80, 
+			do_not_save = "True")
+
+		for item in pr.items:
+			item.purchase_invoice = pi.name
+
+		pr.insert()
+		pr.submit()	
+
+		# fetching the latest GL Entry with 'Exchange Gain/Loss - TCP1' account
+		gl_entries = frappe.get_all('GL Entry', filters = {'account': 'Exchange Gain/Loss - TCP1'})
+		voucher_no = frappe.get_value('GL Entry', gl_entries[0]['name'], 'voucher_no')	
+
+		self.assertEqual(pr.name, voucher_no)
 
 def get_sl_entries(voucher_type, voucher_no):
 	return frappe.db.sql(""" select actual_qty, warehouse, stock_value_difference

--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -1051,6 +1051,7 @@ class TestPurchaseReceipt(unittest.TestCase):
 		self.assertEqual(len(item_two_gl_entry), 1)
 
 		frappe.db.set_value('Company', company, 'enable_perpetual_inventory_for_non_stock_items', before_test_value)
+
 	def test_purchase_receipt_with_exchange_rate_difference(self):
 		from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice as create_purchase_invoice
 
@@ -1058,21 +1059,25 @@ class TestPurchaseReceipt(unittest.TestCase):
 
 		create_warehouse("_Test Warehouse for Valuation", company="_Test Company with perpetual inventory",
 			properties={"account": '_Test Account Stock In Hand - TCP1'})
+		
 		pr = make_purchase_receipt(warehouse = '_Test Warehouse for Valuation - TCP1', 
 			company="_Test Company with perpetual inventory", currency = "USD", conversion_rate = 80, 
 			do_not_save = "True")
 
-		for item in pr.items:
-			item.purchase_invoice = pi.name
+		pr.items[0].purchase_invoice = pi.name
+		pr.items[0].purchase_invoice_item = pi.items[0].name
 
 		pr.insert()
-		pr.submit()	
+		pr.submit()
 
 		# fetching the latest GL Entry with 'Exchange Gain/Loss - TCP1' account
 		gl_entries = frappe.get_all('GL Entry', filters = {'account': 'Exchange Gain/Loss - TCP1'})
-		voucher_no = frappe.get_value('GL Entry', gl_entries[0]['name'], 'voucher_no')	
-
+		voucher_no = frappe.get_value('GL Entry', gl_entries[0]['name'], 'voucher_no')
 		self.assertEqual(pr.name, voucher_no)
+
+		exchange_gain_loss_amount = frappe.get_value('GL Entry', gl_entries[0]['name'], 'debit')
+		discrepancy_caused_by_exchange_rate_diff = abs(pi.items[0].base_net_amount - pr.items[0].base_net_amount)
+		self.assertEqual(exchange_gain_loss_amount, discrepancy_caused_by_exchange_rate_diff)
 
 def get_sl_entries(voucher_type, voucher_no):
 	return frappe.db.sql(""" select actual_qty, warehouse, stock_value_difference


### PR DESCRIPTION
### _Issue:_
When a Purchase Invoice is created from a Purchase Receipt(or vice versa), if the exchange rate is different at the time of creation of the latter, the GL entries created for the Stock Received But Not Billed account will not be balanced.

![Screenshot 2021-04-29 at 4 15 18 AM](https://user-images.githubusercontent.com/25903035/116481984-e62f6980-a8a1-11eb-9b81-75aad0a19caf.png)

### _Fix:_
The amount for the _Stock Received But Not Billed_ account for the second transaction will be made equal to that of the first and the difference will be assigned to the _Exchange Gain/Loss_ account.

_Case 1:_ The Purchase Receipt is created first at a particular exchange rate, but the exchange rate at the time of creation of the Purchase Invoice is different.

<details>
<summary>Images</summary>

For the Purchase Receipt:

![Screenshot 2021-04-29 at 4 32 30 AM](https://user-images.githubusercontent.com/25903035/116483108-1d067f00-a8a4-11eb-9b91-5f61b3b4108b.png)

For the corresponding Purchase Invoice(created after the exchange rate was changed):

![Screenshot 2021-04-29 at 4 35 09 AM](https://user-images.githubusercontent.com/25903035/116483361-900ff580-a8a4-11eb-9369-50671c458296.png)

</details>

_Case 2:_ The Purchase Invoice is created first at a particular exchange rate, but the exchange rate at the time of creation of the Purchase Receipt is different.

<details>
<summary>Images</summary>

For the Purchase Invoice:

![Screenshot 2021-06-07 at 7 51 08 AM](https://user-images.githubusercontent.com/25903035/120950843-3fbe6a00-c765-11eb-85df-49947a50b374.png)

For the corresponding Purchase Receipt(created after the exchange rate was changed):

![Screenshot 2021-06-07 at 7 47 50 AM](https://user-images.githubusercontent.com/25903035/120950865-4816a500-c765-11eb-8463-cf870a809e36.png)

</details>

`no-docs`

