### PR TITLE
fix: variable declaration

### DIFF
--- a/erpnext/selling/doctype/quotation/quotation.js
+++ b/erpnext/selling/doctype/quotation/quotation.js
@@ -53,8 +53,11 @@ erpnext.selling.QuotationController = class QuotationController extends erpnext.
 	}
 	refresh(doc, dt, dn) {
 		super.refresh(doc, dt, dn);
-		doctype = doc.quotation_to == 'Customer' ? 'Customer':'Lead';
-		frappe.dynamic_link = {doc: this.frm.doc, fieldname: 'party_name', doctype: doctype}
+		frappe.dynamic_link = {
+			doc: this.frm.doc,
+			fieldname: 'party_name',
+			doctype: doc.quotation_to == 'Customer' ? 'Customer' : 'Lead',
+		};
 
 		var me = this;
 


### PR DESCRIPTION
```
quotation__js:863 Uncaught (in promise) TypeError: Assignment to constant variable.
    at FormController.refresh (quotation__js:863)
    at runner (script_manager.js:105)
    at script_manager.js:135
```
![image](https://user-images.githubusercontent.com/38958184/121184837-1b58af80-c883-11eb-99a9-a86963ad7a7c.png)
