### PR TITLE
fix(e-invoicing): service item check

### DIFF
--- a/erpnext/regional/india/e_invoice/utils.py
+++ b/erpnext/regional/india/e_invoice/utils.py
@@ -199,7 +199,7 @@ def get_item_list(invoice):
 
 		item.batch_expiry_date = frappe.db.get_value('Batch', d.batch_no, 'expiry_date') if d.batch_no else None
 		item.batch_expiry_date = format_date(item.batch_expiry_date, 'dd/mm/yyyy') if item.batch_expiry_date else None
-		item.is_service_item = 'N' if frappe.db.get_value('Item', d.item_code, 'is_stock_item') else 'Y'
+		item.is_service_item = 'Y' if item.gst_hsn_code[:2] == "99" else 'N'
 		item.serial_no = ""
 
 		item = update_item_taxes(invoice, item)


### PR DESCRIPTION
Currently, the service item is decided if the item master has 'maintain stock' unchecked, which creates a problem for some users who don't maintain stock against some items which belongs to goods

Solution: Defined service item based on HSN code, If the HSN code starts with 99 then it belongs to services. 