### PR TITLE
fix: on click of duplicate button system has not copied the difference account

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -986,7 +986,10 @@ erpnext.stock.StockEntry = erpnext.stock.StockController.extend({
 
 	items_add: function(doc, cdt, cdn) {
 		var row = frappe.get_doc(cdt, cdn);
-		this.frm.script_manager.copy_from_first_row("items", row, ["expense_account", "cost_center"]);
+
+		if (!(row.expense_account && row.cost_center)) {
+			this.frm.script_manager.copy_from_first_row("items", row, ["expense_account", "cost_center"]);
+		}
 
 		if(!row.s_warehouse) row.s_warehouse = this.frm.doc.from_warehouse;
 		if(!row.t_warehouse) row.t_warehouse = this.frm.doc.to_warehouse;


### PR DESCRIPTION
1. Make stock entry with two items and set separate Difference Account in each row
2. Expand the second row and click on Duplicate button
3. System will create Third row but it will not use the Second row's Difference Account
4. It will user the First row's Difference Account

**After Fix**
System will user the Difference Account of the duplicated row 