### PR TITLE
fix(Issue): Remove response_by and resolution_by if sla is removed

### DIFF
--- a/erpnext/support/doctype/issue/issue.json
+++ b/erpnext/support/doctype/issue/issue.json
@@ -166,7 +166,7 @@
    "options": "Service Level Agreement"
   },
   {
-   "depends_on": "eval: doc.status != 'Replied';",
+   "depends_on": "eval: doc.status != 'Replied' && doc.service_level_agreement;",
    "fieldname": "response_by",
    "fieldtype": "Datetime",
    "label": "Response By",
@@ -180,7 +180,7 @@
    "read_only": 1
   },
   {
-   "depends_on": "eval: doc.status != 'Replied';",
+   "depends_on": "eval: doc.status != 'Replied' && doc.service_level_agreement;",
    "fieldname": "resolution_by",
    "fieldtype": "Datetime",
    "label": "Resolution By",
@@ -410,7 +410,7 @@
  "icon": "fa fa-ticket",
  "idx": 7,
  "links": [],
- "modified": "2021-05-26 10:49:07.574769",
+ "modified": "2021-06-10 03:22:27.098898",
  "modified_by": "Administrator",
  "module": "Support",
  "name": "Issue",

--- a/erpnext/support/doctype/issue/issue.py
+++ b/erpnext/support/doctype/issue/issue.py
@@ -29,6 +29,9 @@ class Issue(Document):
 		self.update_status()
 		self.set_lead_contact(self.raised_by)
 
+		if not self.service_level_agreement:
+			self.reset_associated_fields()
+
 	def on_update(self):
 		# Add a communication in the issue timeline
 		if self.flags.create_communication and self.via_customer_portal:
@@ -53,6 +56,13 @@ class Issue(Document):
 			if not self.company:
 				self.company = frappe.db.get_value("Lead", self.lead, "company") or \
 					frappe.db.get_default("Company")
+
+	def reset_associated_fields(self):
+		self.agreement_status = ""
+		self.response_by = ""
+		self.resolution_by = ""
+		self.response_by_variance = 0
+		self.resolution_by_variance = 0
 
 	def update_status(self):
 		status = frappe.db.get_value("Issue", self.name, "status")

--- a/erpnext/support/doctype/issue/issue.py
+++ b/erpnext/support/doctype/issue/issue.py
@@ -30,7 +30,7 @@ class Issue(Document):
 		self.set_lead_contact(self.raised_by)
 
 		if not self.service_level_agreement:
-			self.reset_associated_fields()
+			self.reset_sla_fields()
 
 	def on_update(self):
 		# Add a communication in the issue timeline
@@ -57,7 +57,7 @@ class Issue(Document):
 				self.company = frappe.db.get_value("Lead", self.lead, "company") or \
 					frappe.db.get_default("Company")
 
-	def reset_associated_fields(self):
+	def reset_sla_fields(self):
 		self.agreement_status = ""
 		self.response_by = ""
 		self.resolution_by = ""


### PR DESCRIPTION
**_Issue:_**
The _Response By_ and _Resolution By_ fields continue to be visible even after SLA is removed.

_**Fix:**_
Make the display for the two fields depend on the _Service Level Agreement_ field.

<details>
<summary> Images </summary>

Before Removing SLA:

![Screenshot 2021-06-10 at 3 29 55 AM](https://user-images.githubusercontent.com/25903035/121435226-24896f80-c99c-11eb-9631-8188b3f31fda.png)

After Removing SLA:

![Screenshot 2021-06-10 at 3 31 12 AM](https://user-images.githubusercontent.com/25903035/121435331-51d61d80-c99c-11eb-8d92-3e956bd5cb25.png)

</details>

