### PR TITLE
ci: Use only compatible version of bench CLI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,7 @@ install:
   - cd ~
   - nvm install 10
 
-  - git clone https://github.com/frappe/bench --depth 1
-  - pip install -e ./bench
+  - pip install -U frappe-bench --only-binary='all'
 
   - git clone https://github.com/frappe/frappe --branch $TRAVIS_BRANCH --depth 1
   - bench init --skip-assets --frappe-path ~/frappe --python $(which python) frappe-bench


### PR DESCRIPTION
bench CLI has dropped support for < `PY3.6` (ref: https://github.com/frappe/bench/pull/1170). With the --only-binary option, we can tell pip to install only the latest compatible version of bench CLI