### PR TITLE
fix: force user to set basic rate in case of Material Receipt stock entry

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -422,7 +422,7 @@ frappe.ui.form.on('Stock Entry', {
 			'allow_zero_valuation': 1,
 		};
 
-		if (item.item_code || item.serial_no) {
+		if ((item.item_code || item.serial_no) && frm.doc.purpose !== 'Material Receipt') {
 			frappe.call({
 				method: "erpnext.stock.utils.get_incoming_rate",
 				args: {
@@ -453,6 +453,7 @@ frappe.ui.form.on('Stock Entry', {
 						'company': frm.doc.company,
 						'voucher_type': frm.doc.doctype,
 						'voucher_no': child.name,
+						'purpose': frm.doc.purpose,
 						'allow_zero_valuation': 1
 					}
 				},
@@ -821,10 +822,6 @@ erpnext.stock.StockEntry = erpnext.stock.StockController.extend({
 				}
 			};
 		});
-
-		if(me.frm.doc.company && erpnext.is_perpetual_inventory_enabled(me.frm.doc.company)) {
-			this.frm.add_fetch("company", "stock_adjustment_account", "expense_account");
-		}
 
 		this.frm.fields_dict.items.grid.get_field('expense_account').get_query = function() {
 			if (erpnext.is_perpetual_inventory_enabled(me.frm.doc.company)) {

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -754,6 +754,20 @@ class TestStockEntry(unittest.TestCase):
 			filters={"voucher_type": "Stock Entry", "voucher_no": mr.name}, fieldname="is_opening")
 		self.assertEqual(is_opening, "Yes")
 
+	def test_material_receipt_entry_basic_rate_validate(self):
+		se_doc = make_stock_entry(item_code="_Test Item", target="Stores - TCP1",
+			company="_Test Company with perpetual inventory", qty=1, basic_rate=0,
+			expense_account="Stock Adjustment - TCP1", purpose="Material Receipt", do_not_save=True)
+
+		self.assertRaises(frappe.ValidationError, se_doc.save)
+
+		se_doc.items[0].basic_rate = 10
+		se_doc.save()
+
+		self.assertEqual(se_doc.items[0].amount, 10)
+		self.assertEqual(se_doc.items[0].basic_amount, 10)
+		self.assertEqual(se_doc.items[0].basic_rate, 10)
+
 	def test_total_basic_amount_zero(self):
 		se = frappe.get_doc({"doctype":"Stock Entry",
 			"purpose":"Material Receipt",


### PR DESCRIPTION
This change did to handle the reposting issue in case of Material Receipt.
Earlier we are fetching the valuation rate from the past transactions in case of Material Receipt but we found some cases where valuation rate in the past transactions is wrong because the Reposting Item Valuation entries are not completed. After completion of Reposting Item Valuation system never repost the valuation rate for the type 'Material Receipt' because for system it's difficult to identify whether the rate was set manually or by the system. So to fix this issue we are forcing users to set the basic rate for the Material Receipt stock entry.

If stock entry type is Material Receipt and user has not set the basic rate manually and allow zero valuation rate field is disabled then system will throw below error.

<img width="1013" alt="Screenshot 2021-06-11 at 10 33 42 AM" src="https://user-images.githubusercontent.com/8780500/121634369-0ad25000-caa2-11eb-9530-5cdd66f84ea9.png">