### PR TITLE
fix: unable to enter score in Assessment Result details grid

### DIFF
--- a/erpnext/education/doctype/assessment_result/assessment_result.js
+++ b/erpnext/education/doctype/assessment_result/assessment_result.js
@@ -6,7 +6,8 @@ frappe.ui.form.on('Assessment Result', {
 		if (!frm.doc.__islocal) {
 			frm.trigger('setup_chart');
 		}
-		frm.set_df_property('details', 'read_only', 1);
+
+		frm.get_field('details').grid.cannot_add_rows = true;
 
 		frm.set_query('course', function() {
 			return {


### PR DESCRIPTION
Backport of: https://github.com/frappe/erpnext/pull/25945

fixes: https://github.com/frappe/erpnext/issues/25723

**Problem**:

- The Result child table in Assessment Result doctype was marked read-only.
- Earlier marking the table as read-only had different behavior. It used to allow editing fields in the table but not allow adding or removing rows. 
- That is why the assessment result child table was set as read-only to only allow entering the score for parameters auto-fetched from the Assessment Plan and not adding new parameters.
- This grid behavior changed with https://github.com/frappe/frappe/pull/11912 where now it doesn't allow editing anything in a grid.
- So the Assessment Result child table no more allows adding scores.

**Fix**:

Don't set the table as read-only and only disable adding new rows.

![image](https://user-images.githubusercontent.com/24353136/120654594-79f6e580-c49f-11eb-95aa-33b6a1580df1.png)
