### PR TITLE
fix: Flaky test for Report Subcontracted Raw materials to be transferred

### DIFF
--- a/erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/test_subcontracted_raw_materials_to_be_transferred.py
+++ b/erpnext/buying/report/subcontracted_raw_materials_to_be_transferred/test_subcontracted_raw_materials_to_be_transferred.py
@@ -30,42 +30,54 @@ class TestSubcontractedItemToBeTransferred(unittest.TestCase):
 		po.reload()
 
 		po_data = [row for row in data if row.get('purchase_order') == po.name]
+		# Alphabetically sort to be certain of order
+		po_data = sorted(po_data, key = lambda i: i['rm_item_code'])
 
 		self.assertEqual(len(po_data), 2)
-		self.assertIn(po_data[0]['rm_item_code'], ['_Test Item', '_Test Item Home Desktop 100'])
-		self.assertIn(po_data[0]['p_qty'], [9, 18])
-		self.assertIn(po_data[0]['transferred_qty'], [1, 2])
+		self.assertEqual(po_data[0]['purchase_order'], po.name)
 
-		self.assertEqual(data[1]['purchase_order'], po.name)
-		self.assertIn(data[1]['rm_item_code'], ['_Test Item', '_Test Item Home Desktop 100'])
-		self.assertIn(data[1]['p_qty'], [9, 18])
-		self.assertIn(data[1]['transferred_qty'], [1, 2])
+		self.assertEqual(po_data[0]['rm_item_code'], '_Test Item')
+		self.assertEqual(po_data[0]['p_qty'], 8)
+		self.assertEqual(po_data[0]['transferred_qty'], 2)
+
+		self.assertEqual(po_data[1]['rm_item_code'], '_Test Item Home Desktop 100')
+		self.assertEqual(po_data[1]['p_qty'], 19)
+		self.assertEqual(po_data[1]['transferred_qty'], 1)
 
 		se.cancel()
 		po.cancel()
 
 def transfer_subcontracted_raw_materials(po):
+	# Order of supplied items fetched in PO is flaky
+	transfer_qty_map = {
+		'_Test Item': 2,
+		'_Test Item Home Desktop 100': 1
+	}
+
+	item_1 = po.supplied_items[0].rm_item_code
+	item_2 = po.supplied_items[1].rm_item_code
+
 	rm_item = [
 		{
 			'name': po.supplied_items[0].name,
-			'item_code': '_Test Item Home Desktop 100',
-			'rm_item_code': '_Test Item Home Desktop 100',
-			'item_name': '_Test Item Home Desktop 100',
-			'qty': 2,
+			'item_code': item_1,
+			'rm_item_code': item_1,
+			'item_name': item_1,
+			'qty': transfer_qty_map[item_1],
 			'warehouse': '_Test Warehouse - _TC',
 			'rate': 100,
-			'amount': 200,
+			'amount': 100 * transfer_qty_map[item_1],
 			'stock_uom': 'Nos'
 		},
 		{
 			'name': po.supplied_items[1].name,
-			'item_code': '_Test Item',
-			'rm_item_code': '_Test Item',
-			'item_name': '_Test Item',
-			'qty': 1,
+			'item_code': item_2,
+			'rm_item_code': item_2,
+			'item_name': item_2,
+			'qty': transfer_qty_map[item_2],
 			'warehouse': '_Test Warehouse - _TC',
 			'rate': 100,
-			'amount': 100,
+			'amount': 100 * transfer_qty_map[item_2],
 			'stock_uom': 'Nos'
 		}
 	]


### PR DESCRIPTION
Due to https://github.com/frappe/erpnext/pull/26011

**Issue:**
- test for Report Subcontracted Raw materials to be transferred randomly failed purely due to ordering of rows in supplied items table
- In PO the supplied items table sometimes had Item 1 then Item 2 and sometimes vice versa, due to which allotting a definite transfer qty was not happening
- While getting data from the report too, the order of item rows was flaky

**Fixed:**
- Created a transfer qty map that makes sure that 1 qty is transferred against Item 1 irrespective of which row it is on
- Alphabetically sorted Report data returned, to be certain of asserting value