### PR TITLE
feat(General Ledger): Implement multi-account selection

### DIFF
--- a/erpnext/accounts/report/general_ledger/general_ledger.js
+++ b/erpnext/accounts/report/general_ledger/general_ledger.js
@@ -39,7 +39,6 @@ frappe.query_reports["General Ledger"] = {
 			"fieldtype": "MultiSelectList",
 			"options": "Account",
 			get_data: function(txt) {
-				console.log("txt = ", txt)
 				return frappe.db.get_link_options('Account', txt, {
 					company: frappe.query_report.get_filter_value("company")
 				});

--- a/erpnext/accounts/report/general_ledger/general_ledger.js
+++ b/erpnext/accounts/report/general_ledger/general_ledger.js
@@ -36,16 +36,13 @@ frappe.query_reports["General Ledger"] = {
 		{
 			"fieldname":"account",
 			"label": __("Account"),
-			"fieldtype": "Link",
+			"fieldtype": "MultiSelectList",
 			"options": "Account",
-			"get_query": function() {
-				var company = frappe.query_report.get_filter_value('company');
-				return {
-					"doctype": "Account",
-					"filters": {
-						"company": company,
-					}
-				}
+			get_data: function(txt) {
+				console.log("txt = ", txt)
+				return frappe.db.get_link_options('Account', txt, {
+					company: frappe.query_report.get_filter_value("company")
+				});
 			}
 		},
 		{

--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -211,15 +211,16 @@ def get_conditions(filters):
 	conditions = []
 
 	if filters.get("account") and not filters.get("include_dimensions"):
-		account_conditions = ""
+		account_conditions = "account in (select name from tabAccount where"
 		for account in filters["account"]:
 			lft, rgt = frappe.db.get_value("Account", account, ["lft", "rgt"])
-			account_conditions += """account in (select name from tabAccount
-				where lft>=%s and rgt<=%s and docstatus<2)""" % (lft, rgt)
+			account_conditions += """ (lft>=%s and rgt<=%s) """ % (lft, rgt)
 
 			# so that the OR doesn't get added to the last account condition
 			if account != filters["account"][-1]:
-				account_conditions += " OR "
+				account_conditions += "OR"
+		
+		account_conditions += "and docstatus<2)"
 		conditions.append(account_conditions)
 
 	if filters.get("cost_center"):

--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -91,7 +91,19 @@ def set_account_currency(filters):
 		account_currency = None
 
 		if filters.get("account"):
-			account_currency = get_account_currency(filters.account[0])
+			if len(filters.get("account")) == 1:	
+				account_currency = get_account_currency(filters.account[0])
+			else:
+				currency = get_account_currency(filters.account[0])
+				is_same_account_currency = True
+				for account in filters.get("account"):
+					if get_account_currency(account) != currency:
+						is_same_account_currency = False
+						break
+
+				if is_same_account_currency:
+					account_currency = currency
+
 		elif filters.get("party"):
 			gle_currency = frappe.db.get_value(
 				"GL Entry", {


### PR DESCRIPTION
- Allow the user to select more than one Account at a time while generating a General Ledger report.

![Screenshot 2021-06-14 at 1 25 23 PM](https://user-images.githubusercontent.com/25903035/121858194-fbf2d400-cd13-11eb-8f65-54398adfc626.png)

<details>
<summary> Testing Info </summary>

_Steps to re-create:_

- Create and submit invoices/journal entries. This will generate GL Entries associated with multiple accounts.
- Open General Ledger report.
- Try setting more than one value in the Account filter as shown in the image.

</details>

`no-docs`