### PR TITLE
fix(General Ledger): Filter Cost Center and Project drop-down lists by Company

### DIFF
--- a/erpnext/accounts/report/general_ledger/general_ledger.js
+++ b/erpnext/accounts/report/general_ledger/general_ledger.js
@@ -145,7 +145,9 @@ frappe.query_reports["General Ledger"] = {
 			"label": __("Project"),
 			"fieldtype": "MultiSelectList",
 			get_data: function(txt) {
-				return frappe.db.get_link_options('Project', txt);
+				return frappe.db.get_link_options('Project', txt, {
+					company: frappe.query_report.get_filter_value("company")
+				});
 			}
 		},
 		{

--- a/erpnext/accounts/report/general_ledger/general_ledger.js
+++ b/erpnext/accounts/report/general_ledger/general_ledger.js
@@ -135,7 +135,9 @@ frappe.query_reports["General Ledger"] = {
 			"label": __("Cost Center"),
 			"fieldtype": "MultiSelectList",
 			get_data: function(txt) {
-				return frappe.db.get_link_options('Cost Center', txt);
+				return frappe.db.get_link_options('Cost Center', txt, {
+					company: frappe.query_report.get_filter_value("company")
+				});
 			}
 		},
 		{


### PR DESCRIPTION
**_Issue:_**

The drop-down lists for the _Cost Center_ and _Project_ filters in the _General Ledger_ report contain the names of all the Cost Centers and Projects in that database, even the ones not associated with the specified _Company_.

![Screenshot 2021-06-14 at 4 37 17 PM](https://user-images.githubusercontent.com/25903035/121883922-f1dece80-cd2f-11eb-8e4f-14dcbdec8f1f.png)

_**Fix:**_

Filter the drop-down lists for _Cost Center_ and _Project_ by the specified _Company_.

![Screenshot 2021-06-14 at 4 39 14 PM](https://user-images.githubusercontent.com/25903035/121883929-f4412880-cd2f-11eb-957c-a918b9754ff8.png)

<details>
<summary>Testing Info</summary>

Steps to replicate:
- Create a new Company, if more than one company is not present already.
- Create Projects associated with the different Companies(the Cost Centers will be created automatically).
- Open General Ledger report.
- Select a Company.
- Check the drop-down lists for Cost Center and Project to confirm that all the values are associated with the specified Company.

</details>