### PR TITLE
fix: precision rate for packed items in internal transfers

### DIFF
--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -330,9 +330,15 @@ class SellingController(StockController):
 
 				# For internal transfers use incoming rate as the valuation rate
 				if self.is_internal_transfer():
-					rate = flt(d.incoming_rate * d.conversion_factor, d.precision('rate'))
-					if d.rate != rate:
-						d.rate = rate
+					if d.doctype == "Packed Item":
+						incoming_rate = flt(d.incoming_rate * d.conversion_factor, d.precision('incoming_rate'))
+						if d.incoming_rate != incoming_rate:
+							d.incoming_rate = incoming_rate
+					else:
+						rate = flt(d.incoming_rate * d.conversion_factor, d.precision('rate'))
+						if d.rate != rate:
+							d.rate = rate
+
 						d.discount_percentage = 0
 						d.discount_amount = 0
 						frappe.msgprint(_("Row {0}: Item rate has been updated as per valuation rate since its an internal stock transfer")


### PR DESCRIPTION
**Issue:**
![image](https://user-images.githubusercontent.com/43572428/121886785-7aab3980-cd33-11eb-84b9-c5829db056cb.png)
- While trying to create an internal transfer in a delivery note with packed items, the above error was thrown.

**Reason:**
- There is no "rate" field for packed items.
- No condition to check if doctype is a _Packed Item_ or a _Delivery Note Item_.

**Fix:**
- Checks if the doctype is a packed item and tries to fetch the respective field's precision, i.e _"incoming_rate"_ for Packed Items.
