### PR TITLE
fix: pos loyalty card alignment

### DIFF
--- a/erpnext/public/scss/point-of-sale.scss
+++ b/erpnext/public/scss/point-of-sale.scss
@@ -806,6 +806,9 @@
 						display: none;
 						float: right;
 						font-weight: 700;
+						white-space: nowrap;
+						overflow: hidden;
+						text-overflow: ellipsis;
 					}
 
 					> .cash-shortcuts {
@@ -828,6 +831,11 @@
 							}
 						}
 					}
+				}
+
+				> .loyalty-card {
+					display: flex;
+					flex-direction: column;
 				}
 			}
 		}

--- a/erpnext/selling/page/point_of_sale/pos_payment.js
+++ b/erpnext/selling/page/point_of_sale/pos_payment.js
@@ -481,7 +481,7 @@ erpnext.PointOfSale.Payment = class {
 		const amount = doc.loyalty_amount > 0 ? format_currency(doc.loyalty_amount, doc.currency) : '';
 		this.$payment_modes.append(
 			`<div class="payment-mode-wrapper">
-				<div class="mode-of-payment" data-mode="loyalty-amount" data-payment-type="loyalty-amount">
+				<div class="mode-of-payment loyalty-card" data-mode="loyalty-amount" data-payment-type="loyalty-amount">
 					Redeem Loyalty Points
 					<div class="loyalty-amount-amount pay-amount">${amount}</div>
 					<div class="loyalty-amount-name">${loyalty_program}</div>


### PR DESCRIPTION
Before if the name of the Loyalty Program was big it used to mess up with the design.
![Screenshot 2021-06-14 at 5 59 02 PM](https://user-images.githubusercontent.com/33727827/121893538-b2b67a80-cd3b-11eb-8200-0c6e3548224f.png)

Fixed it
![Screenshot 2021-06-14 at 5 57 51 PM](https://user-images.githubusercontent.com/33727827/121893585-bfd36980-cd3b-11eb-8735-1c334ce1c8c1.png)

