### PR TITLE
fix: status indicator for delivery notes

### DIFF
--- a/erpnext/stock/doctype/delivery_note/delivery_note_list.js
+++ b/erpnext/stock/doctype/delivery_note/delivery_note_list.js
@@ -6,8 +6,8 @@ frappe.listview_settings['Delivery Note'] = {
 			return [__("Return"), "gray", "is_return,=,Yes"];
 		} else if (doc.status === "Closed") {
 			return [__("Closed"), "green", "status,=,Closed"];
-		} else if (flt(doc.per_returned, 2) === 100) {
-			return [__("Return Issued"), "grey", "per_returned,=,100"];
+		} else if (doc.status === "Return Issued") {
+			return [__("Return Issued"), "grey", "status,=,Return Issued"];
 		} else if (flt(doc.per_billed, 2) < 100) {
 			return [__("To Bill"), "orange", "per_billed,<,100"];
 		} else if (flt(doc.per_billed, 2) === 100) {


### PR DESCRIPTION
Problem: list view and form view show different indicator:

![Screenshot 2021-06-15 at 7 53 51 PM](https://user-images.githubusercontent.com/9079960/122072948-a999dc00-ce15-11eb-9412-d22d087fd98e.png)


On list view, `per_returned` isn't fetched i.e. `undefined` which become 0 hence the list view indicator is false.
![Screenshot 2021-06-15 at 8 02 02 PM](https://user-images.githubusercontent.com/9079960/122072917-a0107400-ce15-11eb-92b5-0d954d98ae06.png)



Solution: This "computation" is already done by the status updater, so relying on `doc.status` is better than redefining it.



