### PR TITLE
fix: Patient appointment invoicing

### DIFF
--- a/erpnext/healthcare/doctype/patient_appointment/patient_appointment.json
+++ b/erpnext/healthcare/doctype/patient_appointment/patient_appointment.json
@@ -134,6 +134,7 @@
    "set_only_once": 1
   },
   {
+   "depends_on": "eval:doc.practitioner;",
    "fieldname": "section_break_12",
    "fieldtype": "Section Break",
    "label": "Appointment Details"
@@ -349,7 +350,7 @@
   }
  ],
  "links": [],
- "modified": "2021-02-08 13:13:15.116833",
+ "modified": "2021-06-16 00:40:26.841794",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Patient Appointment",

--- a/erpnext/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/erpnext/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -135,8 +135,6 @@ def check_payment_fields_reqd(patient):
 			fee_validity = frappe.db.exists('Fee Validity', {'patient': patient, 'status': 'Pending'})
 			if fee_validity:
 				return {'fee_validity': fee_validity}
-			if check_is_new_patient(patient):
-				return False
 		return True
 	return False
 
@@ -150,8 +148,6 @@ def invoice_appointment(appointment_doc):
 			fee_validity = None
 		elif not fee_validity:
 			if frappe.db.exists('Fee Validity Reference', {'appointment': appointment_doc.name}):
-				return
-			if check_is_new_patient(appointment_doc.patient, appointment_doc.name):
 				return
 	else:
 		fee_validity = None


### PR DESCRIPTION
Fixes #26067 
The payment fields in the patient appointment with automated appointment
invoicing and enable free followups does not become mandatory for
patients with no previous appointments. This check for new patient to
enable invoicing is not required.

Signed-off-by: Syed Mujeer Hashmi <mujeerhashmi@4csolutions.in>

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
