### PR TITLE
fix: insufficient permission for Dunning error

### DIFF
--- a/erpnext/accounts/doctype/dunning/dunning.py
+++ b/erpnext/accounts/doctype/dunning/dunning.py
@@ -86,17 +86,17 @@ def resolve_dunning(doc, state):
 	for reference in doc.references:
 		if reference.reference_doctype == 'Sales Invoice' and reference.outstanding_amount <= 0:
 			dunnings = frappe.get_list('Dunning', filters={
-				'sales_invoice': reference.reference_name, 'status': ('!=', 'Resolved')})
+				'sales_invoice': reference.reference_name, 'status': ('!=', 'Resolved')}, ignore_permissions=True)
 
 			for dunning in dunnings:
-				frappe.db.set_value("Dunning", dunning.name, "status", 'Resolved')
+				frappe.db.set_value("Dunning", dunning.name, "status", 'Resolved', ignore_permissions=True)
 
 def calculate_interest_and_amount(posting_date, outstanding_amount, rate_of_interest, dunning_fee, overdue_days):
 	interest_amount = 0
 	grand_total = 0
 	if rate_of_interest:
 		interest_per_year = flt(outstanding_amount) * flt(rate_of_interest) / 100
-		interest_amount = (interest_per_year * cint(overdue_days)) / 365 
+		interest_amount = (interest_per_year * cint(overdue_days)) / 365
 		grand_total = flt(outstanding_amount) + flt(interest_amount) + flt(dunning_fee)
 	dunning_amount = flt(interest_amount) + flt(dunning_fee)
 	return {

--- a/erpnext/accounts/doctype/dunning/dunning.py
+++ b/erpnext/accounts/doctype/dunning/dunning.py
@@ -89,7 +89,7 @@ def resolve_dunning(doc, state):
 				'sales_invoice': reference.reference_name, 'status': ('!=', 'Resolved')}, ignore_permissions=True)
 
 			for dunning in dunnings:
-				frappe.db.set_value("Dunning", dunning.name, "status", 'Resolved', ignore_permissions=True)
+				frappe.db.set_value("Dunning", dunning.name, "status", 'Resolved')
 
 def calculate_interest_and_amount(posting_date, outstanding_amount, rate_of_interest, dunning_fee, overdue_days):
 	interest_amount = 0


### PR DESCRIPTION
**Issue**: 
When a user with no permission for Dunning tries to submit a Payment Entry,
**Insufficient Permission for Dunning** error is raised (even though that payment entry has nothing to do with dunning),
because `resolve_dunning()` is called from `Hooks.py` on submitting the Payment Entry.

![Screenshot 2021-06-17 at 7 10 19 PM](https://user-images.githubusercontent.com/60467153/122408116-bfd3a380-cf9f-11eb-907a-dd9a29c609a7.png)

Setting `ignore_permissions = True` for this.