### PR TITLE
fix: Incorrect billed qty in Sales Order analytics

### DIFF
--- a/erpnext/selling/report/sales_order_analysis/sales_order_analysis.py
+++ b/erpnext/selling/report/sales_order_analysis/sales_order_analysis.py
@@ -59,7 +59,7 @@ def get_data(conditions, filters):
 			IF(so.status in ('Completed','To Bill'), 0, (SELECT delay_days)) as delay,
 			soi.qty, soi.delivered_qty,
 			(soi.qty - soi.delivered_qty) AS pending_qty,
-			IFNULL(sii.qty, 0) as billed_qty,
+			IFNULL(SUM(sii.qty), 0) as billed_qty,
 			soi.base_amount as amount,
 			(soi.delivered_qty * soi.base_rate) as delivered_qty_amount,
 			(soi.billed_amt * IFNULL(so.conversion_rate, 1)) as billed_amount,


### PR DESCRIPTION
Billed qty is incorrectly visible in cases where multiple Sales Invoices are made against a Sales Order in Sales Order analytics report as the query did a group by on Sales Order number

In the example below Sales Order has item qty as 50 against which two Invoices are made having qty 3 and 10

Before:
<img width="1360" alt="Screenshot 2021-06-17 at 8 11 23 PM" src="https://user-images.githubusercontent.com/42651287/122419189-5f952f80-cfa8-11eb-9418-60d1582630f3.png">

After:
<img width="1263" alt="Screenshot 2021-06-17 at 8 07 35 PM" src="https://user-images.githubusercontent.com/42651287/122418441-d3830800-cfa7-11eb-92ee-70635aa72f00.png">
