### PR TITLE
fix(pos): unsupported operand type -= for 'float' and 'NoneType'

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -257,9 +257,10 @@
   },
   {
    "default": "1",
+   "description": "If enabled, ledger entries will be posted for change amount in POS transactions",
    "fieldname": "post_change_gl_entries",
    "fieldtype": "Check",
-   "label": "Post Ledger Entries for Given Change"
+   "label": "Create Ledger Entries for Change Amount"
   }
  ],
  "icon": "icon-cog",
@@ -267,7 +268,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2021-05-25 12:34:05.858669",
+ "modified": "2021-06-17 20:26:03.721202",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounts Settings",

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -989,7 +989,7 @@ class SalesInvoice(SellingController):
 
 			for payment_mode in self.payments:
 				if skip_change_gl_entries and payment_mode.account == self.account_for_change_amount:
-					payment_mode.base_amount -= self.change_amount
+					payment_mode.base_amount -= flt(self.change_amount)
 
 				if payment_mode.amount:
 					# POS, make payment entries

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -387,7 +387,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 
 		if(this.frm.doc.scan_barcode) {
 			frappe.call({
-				method: "erpnext.selling.page.point_of_sale.point_of_sale.search_serial_or_batch_or_barcode_number",
+				method: "erpnext.selling.page.point_of_sale.point_of_sale.search_for_serial_or_batch_or_barcode_number",
 				args: { search_value: this.frm.doc.scan_barcode }
 			}).then(r => {
 				const data = r && r.message;


### PR DESCRIPTION
Fix:
```
File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/doctype/sales_invoice/sales_invoice.py", line 214, in on_submit
    self.make_gl_entries()
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/doctype/sales_invoice/sales_invoice.py", line 814, in make_gl_entries
    gl_entries = self.get_gl_entries()
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/doctype/sales_invoice/sales_invoice.py", line 853, in get_gl_entries
    self.make_pos_gl_entries(gl_entries)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/doctype/sales_invoice/sales_invoice.py", line 992, in make_pos_gl_entries
    payment_mode.base_amount -= self.change_amount
TypeError: unsupported operand type(s) for -=: 'float' and 'NoneType'
```