### PR TITLE
fix: timeout while cancelling stock reconciliation

### DIFF
--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -473,6 +473,13 @@ class StockReconciliation(StockController):
 		else:
 			self._submit()
 
+	def cancel(self):
+		if len(self.items) > 100:
+			msgprint(_("The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Submitted stage"))
+			self.queue_action('cancel', timeout=2000)
+		else:
+			self._cancel()
+
 @frappe.whitelist()
 def get_items(warehouse, posting_date, posting_time, company):
 	lft, rgt = frappe.db.get_value("Warehouse", warehouse, ["lft", "rgt"])


### PR DESCRIPTION
**Issue**

Getting time-out error while cancelling stock reconciliation with 3200 item rows

**Solution**

Enqueue cancel action for stock reconciliation

Develop PR https://github.com/frappe/erpnext/pull/26098