### PR TITLE
fix: rate not able to change in purchase order

### DIFF
--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -658,7 +658,13 @@ class calculate_taxes_and_totals(object):
 					item.margin_type = None
 					item.margin_rate_or_amount = 0.0
 
-			if item.margin_type and item.margin_rate_or_amount:
+			if not item.pricing_rules and flt(item.rate) > flt(item.price_list_rate):
+				item.margin_type = "Amount"
+				item.margin_rate_or_amount = flt(item.rate - item.price_list_rate,
+						item.precision("margin_rate_or_amount"))
+				item.rate_with_margin = item.rate
+
+			elif item.margin_type and item.margin_rate_or_amount:
 				margin_value = item.margin_rate_or_amount if item.margin_type == 'Amount' else flt(item.price_list_rate) * flt(item.margin_rate_or_amount) / 100
 				rate_with_margin = flt(item.price_list_rate) + flt(margin_value)
 				base_rate_with_margin = flt(rate_with_margin) * flt(self.doc.conversion_rate)


### PR DESCRIPTION
**Issue**

If the purchase order has Margin without pricing rules then system not allowing to change the Rate of the Item. In the below example I'm trying to change the item's rate from 2200 to 2100
![not-able-to-change-rate](https://user-images.githubusercontent.com/8780500/122685915-0b01e680-d22c-11eb-9cb1-866e77ae904d.gif)

**After Fix**

<img width="1308" alt="Screenshot 2021-06-21 at 12 58 12 AM" src="https://user-images.githubusercontent.com/8780500/122685923-1d7c2000-d22c-11eb-8a51-6b8b1965bf08.png">

