### PR TITLE
fix: status indicator for delivery notes (#26062)

### DIFF
--- a/erpnext/stock/doctype/delivery_note/delivery_note_list.js
+++ b/erpnext/stock/doctype/delivery_note/delivery_note_list.js
@@ -6,8 +6,8 @@ frappe.listview_settings['Delivery Note'] = {
 			return [__("Return"), "gray", "is_return,=,Yes"];
 		} else if (doc.status === "Closed") {
 			return [__("Closed"), "green", "status,=,Closed"];
-		} else if (flt(doc.per_returned, 2) === 100) {
-			return [__("Return Issued"), "grey", "per_returned,=,100"];
+		} else if (doc.status === "Return Issued") {
+			return [__("Return Issued"), "grey", "status,=,Return Issued"];
 		} else if (flt(doc.per_billed, 2) < 100) {
 			return [__("To Bill"), "orange", "per_billed,<,100"];
 		} else if (flt(doc.per_billed, 2) === 100) {


### PR DESCRIPTION
Backports the following commits to develop:
 - fix: status indicator for delivery notes (#26062)