### PR TITLE
fix: disabled cancellation for sales order if linked to drafted sales invoice

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -233,7 +233,7 @@ class SalesOrder(SellingController):
 		# Checks Sales Invoice
 		submit_rv = frappe.db.sql_list("""select t1.name
 			from `tabSales Invoice` t1,`tabSales Invoice Item` t2
-			where t1.name = t2.parent and t2.sales_order = %s and t1.docstatus = 1""",
+			where t1.name = t2.parent and t2.sales_order = %s and t1.docstatus < 2""",
 			self.name)
 
 		if submit_rv:

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -1219,8 +1219,8 @@ class TestSalesOrder(unittest.TestCase):
 
 	def test_so_cancellation_when_si_drafted(self):
 		"""
-			Test to check if Sales Order gets submitted if Sales Invoice is in Draft state
-			Expected result: sales order should not get submitted 
+			Test to check if Sales Order gets cancelled if Sales Invoice is in Draft state
+			Expected result: sales order should not get cancelled 
 		"""
 		so = make_sales_order()
 		so.submit()

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -1217,6 +1217,19 @@ class TestSalesOrder(unittest.TestCase):
 		# To test if the SO does NOT have a Blanket Order
 		self.assertEqual(so_doc.items[0].blanket_order, None)
 
+	def test_so_cancellation_when_si_drafted(self):
+        """
+            Test to check if Sales Order gets submitted if Sales Invoice is in Draft state
+            Expected result: sales order should not get submitted 
+        """
+        so = make_sales_order()
+        so.submit()
+        si = make_sales_invoice(so.name)
+        si.save()
+
+        self.assertRaises(frappe.ValidationError, so.cancel)
+
+
 
 def make_sales_order(**args):
 	so = frappe.new_doc("Sales Order")

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -1219,15 +1219,15 @@ class TestSalesOrder(unittest.TestCase):
 
 	def test_so_cancellation_when_si_drafted(self):
 		"""
-            Test to check if Sales Order gets submitted if Sales Invoice is in Draft state
-            Expected result: sales order should not get submitted 
+			Test to check if Sales Order gets submitted if Sales Invoice is in Draft state
+			Expected result: sales order should not get submitted 
 		"""
-        so = make_sales_order()
-        so.submit()
-        si = make_sales_invoice(so.name)
-        si.save()
+		so = make_sales_order()
+		so.submit()
+		si = make_sales_invoice(so.name)
+		si.save()
 
-        self.assertRaises(frappe.ValidationError, so.cancel)
+		self.assertRaises(frappe.ValidationError, so.cancel)
 
 
 

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -1218,10 +1218,10 @@ class TestSalesOrder(unittest.TestCase):
 		self.assertEqual(so_doc.items[0].blanket_order, None)
 
 	def test_so_cancellation_when_si_drafted(self):
-        """
+		"""
             Test to check if Sales Order gets submitted if Sales Invoice is in Draft state
             Expected result: sales order should not get submitted 
-        """
+		"""
         so = make_sales_order()
         so.submit()
         si = make_sales_invoice(so.name)


### PR DESCRIPTION
Backport of #26104 