### PR TITLE
fix: for 'leave_type', field should be 'based_on_date_of_joining' 

### DIFF
--- a/erpnext/hr/utils.py
+++ b/erpnext/hr/utils.py
@@ -326,10 +326,10 @@ def allocate_earned_leaves():
 
 			from_date=allocation.from_date
 
-			if e_leave_type.based_on_date_of_joining_date:
+			if e_leave_type.based_on_date_of_joining:
 				from_date  = frappe.db.get_value("Employee", allocation.employee, "date_of_joining")
 
-			if check_effective_date(from_date, today, e_leave_type.earned_leave_frequency, e_leave_type.based_on_date_of_joining_date):
+			if check_effective_date(from_date, today, e_leave_type.earned_leave_frequency, e_leave_type.based_on_date_of_joining):
 				update_previous_leave_allocation(allocation, annual_allocation, e_leave_type)
 
 def update_previous_leave_allocation(allocation, annual_allocation, e_leave_type):


### PR DESCRIPTION
fix: for 'leave_type', field 'based_on_date_of_joining' is reference as 'based_on_date_of_joining_date'

**summary**: correct field name is '**based_on_date_of_joining**' , whereas it is referenced as '**based_on_date_of_joining_date**' (**extra '_date' at end**)
due to which the **earned_leaves calculation for leave_type based on date of joining gives incorrect result**

steps: 
[1]go to 'Leave Type' doctype http://localhost:8001/app/doctype/Leave%20Type
[2]check field name for label 'Based On Date Of Joining' (field no 26)
Note, the field's name it is 'based_on_date_of_joining'

Actual:
erpnext/erpnext/hr/utils.py --> def allocate_earned_leaves
field is refereed as based_on_date_of_joining_date'

Expected:
erpnext/erpnext/hr/utils.py --> def allocate_earned_leaves
field should be  refereed as based_on_date_of_joining'

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
