### PR TITLE
fix: Sort website products by weightage mentioned in Item master

### DIFF
--- a/erpnext/shopping_cart/product_query.py
+++ b/erpnext/shopping_cart/product_query.py
@@ -61,7 +61,8 @@ class ProductQuery:
 					],
 					or_filters=self.or_filters,
 					start=start,
-					limit=self.page_length
+					limit=self.page_length,
+					order_by="weightage desc"
 				)
 
 				items_dict = {item.name: item for item in items}
@@ -71,7 +72,15 @@ class ProductQuery:
 
 			result = [items_dict.get(item) for item in list(set.intersection(*all_items))]
 		else:
-			result = frappe.get_all("Item", fields=self.fields, filters=self.filters, or_filters=self.or_filters, start=start, limit=self.page_length)
+			result = frappe.get_all(
+				"Item",
+				fields=self.fields,
+				filters=self.filters,
+				or_filters=self.or_filters,
+				start=start,
+				limit=self.page_length,
+				order_by="weightage desc"
+			)
 
 		for item in result:
 			product_info = get_product_info_for_website(item.item_code, skip_quotation_creation=True).get('product_info')


### PR DESCRIPTION
Make sure items are sorted and shown by their weightage on the website product listing

![Screenshot 2021-06-21 at 7 40 37 PM](https://user-images.githubusercontent.com/25857446/122775896-3a663100-d2c8-11eb-9593-e1f02d6d7308.png)
![Screenshot 2021-06-21 at 7 42 48 PM](https://user-images.githubusercontent.com/25857446/122775903-3c2ff480-d2c8-11eb-8c89-34eaad16f19f.png)
