### PR TITLE
fix: Enable auto commiting in Repost Item Valuation

### DIFF
--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
@@ -51,6 +51,7 @@ class RepostItemValuation(Document):
 
 def repost(doc):
 	try:
+		frappe.db.auto_commit_on_many_writes = 1
 		if not frappe.db.exists("Repost Item Valuation", doc.name):
 			return
 
@@ -77,6 +78,7 @@ def repost(doc):
 		raise
 	finally:
 		frappe.db.commit()
+		frappe.db.auto_commit_on_many_writes = 0
 
 def repost_sl_entries(doc):
 	if doc.based_on == 'Transaction':


### PR DESCRIPTION
**Issue:**
------
During **Repost Item Valuation**:
![Screenshot 2021-06-22 at 11 12 15 AM](https://user-images.githubusercontent.com/25857446/122869586-1cd9ab80-d34a-11eb-8363-41b17608ceaf.png)

**Fix:**
-------
- Enable `auto_commit_on_many_writes`
- Even if the job is prematurely terminated due to whatever reason and half the reposting is done it wont be an issue since it will have to run again.