### PR TITLE
fix: Export invoices not visible in GSTR-1 report

### DIFF
--- a/erpnext/regional/report/gstr_1/gstr_1.py
+++ b/erpnext/regional/report/gstr_1/gstr_1.py
@@ -201,7 +201,7 @@ class Gstr1Report(object):
 		elif self.filters.get("type_of_business") ==  "EXPORT":
 			conditions += """ AND is_return !=1 and gst_category = 'Overseas' """
 
-		conditions += " AND billing_address_gstin NOT IN %(company_gstins)s"
+		conditions += " AND IFNULL(billing_address_gstin, '') NOT IN %(company_gstins)s"
 
 		return conditions
 


### PR DESCRIPTION
Many Overseas Invoice (Export) might not have billing address GSTIN added in them
Due to this the Export section in GSTR-1 Report was showing no data

Updated the condition to fix this