### PR TITLE
fix: fixed rounding off ordered percent to 100 in condition

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -101,7 +101,8 @@ frappe.ui.form.on('Material Request', {
 		}
 
 		if (frm.doc.docstatus == 1 && frm.doc.status != 'Stopped') {
-			if (flt(frm.doc.per_ordered, 2) < 100) {
+			let precision = frappe.defaults.get_default("float_precision");
+			if (flt(frm.doc.per_ordered, precision) < 100) {
 				let add_create_pick_list_button = () => {
 					frm.add_custom_button(__('Pick List'),
 						() => frm.events.create_pick_list(frm), __('Create'));


### PR DESCRIPTION
**Issue:**
- Buttons were disabled when ordered percent was < 100 (99.998).
<img width="1287" alt="Screenshot 2021-06-22 at 3 47 11 PM" src="https://user-images.githubusercontent.com/43572428/122908818-2ecf4480-d372-11eb-9354-1ec8fcbe6677.png">

- Condition to make the custom buttons (create, stop, etc) rounded the value to 100 because of precision set to 2.
`if (flt(frm.doc.per_ordered, 2) < 100) `

**After Fix:**
![image](https://user-images.githubusercontent.com/43572428/122909771-275c6b00-d373-11eb-8804-e26e3d0350dd.png)

**Related Fix** - [*PR #24019*](https://github.com/frappe/erpnext/pull/24019)