### PR TITLE
fix: Changed profitability analysis report width

### DIFF
--- a/erpnext/accounts/report/profitability_analysis/profitability_analysis.py
+++ b/erpnext/accounts/report/profitability_analysis/profitability_analysis.py
@@ -168,21 +168,24 @@ def get_columns(filters):
 			"label": _("Income"),
 			"fieldtype": "Currency",
 			"options": "currency",
-			"width": 120
+			"width": 305
+
 		},
 		{
 			"fieldname": "expense",
 			"label": _("Expense"),
 			"fieldtype": "Currency",
 			"options": "currency",
-			"width": 120
+			"width": 305
+
 		},
 		{
 			"fieldname": "gross_profit_loss",
 			"label": _("Gross Profit / Loss"),
 			"fieldtype": "Currency",
 			"options": "currency",
-			"width": 120
+			"width": 307
+
 		}
 	]
 


### PR DESCRIPTION
Adjusted the width of Profitability Analysis Report to fit the screen and reduce white space

**Before**
![image](https://user-images.githubusercontent.com/36098155/122954178-da8d8a00-d39c-11eb-9e90-966b86854639.png)

**After**
![image](https://user-images.githubusercontent.com/36098155/122954024-b6ca4400-d39c-11eb-80b3-8826949a8956.png)
