### PR TITLE
fix: Changed profitability analysis report width

### DIFF
--- a/erpnext/accounts/report/profitability_analysis/profitability_analysis.py
+++ b/erpnext/accounts/report/profitability_analysis/profitability_analysis.py
@@ -168,21 +168,24 @@ def get_columns(filters):
 			"label": _("Income"),
 			"fieldtype": "Currency",
 			"options": "currency",
-			"width": 120
+			"width": 305
+
 		},
 		{
 			"fieldname": "expense",
 			"label": _("Expense"),
 			"fieldtype": "Currency",
 			"options": "currency",
-			"width": 120
+			"width": 305
+
 		},
 		{
 			"fieldname": "gross_profit_loss",
 			"label": _("Gross Profit / Loss"),
 			"fieldtype": "Currency",
 			"options": "currency",
-			"width": 120
+			"width": 307
+
 		}
 	]
 


### PR DESCRIPTION
Backport of #26150

Adjusted the width of Profitability Analysis Report to fit the screen and reduce white space

Before
![image](https://user-images.githubusercontent.com/36098155/123046846-377b5580-d41a-11eb-9866-768d6f9b2bd2.png)

After
![image](https://user-images.githubusercontent.com/36098155/123046879-3f3afa00-d41a-11eb-9da0-38ba1c3f06d6.png)
