### PR TITLE
fix: show salary component with zero amount

### DIFF
--- a/erpnext/payroll/doctype/salary_slip/salary_slip.py
+++ b/erpnext/payroll/doctype/salary_slip/salary_slip.py
@@ -504,7 +504,7 @@ class SalarySlip(TransactionBase):
 		data = self.get_data_for_eval()
 		for struct_row in self._salary_structure_doc.get(component_type):
 			amount = self.eval_condition_and_formula(struct_row, data)
-			if amount and struct_row.statistical_component == 0:
+			if struct_row.statistical_component == 0:
 				self.update_component_row(struct_row, amount, component_type)
 
 	def get_data_for_eval(self):
@@ -662,8 +662,6 @@ class SalarySlip(TransactionBase):
 			])
 
 		if not component_row:
-			if not amount:
-				return
 
 			component_row = self.append(component_type)
 			for attr in (


### PR DESCRIPTION

Show the component with 0 value if it is part of your salary structure assignment
![image](https://user-images.githubusercontent.com/32095923/123064949-58e53d00-d42c-11eb-9fcf-ba302658ce01.png)
