### PR TITLE
fix: Website item group logic for product listing in Item Group pages

### DIFF
--- a/erpnext/portal/product_configurator/test_product_configurator.py
+++ b/erpnext/portal/product_configurator/test_product_configurator.py
@@ -43,6 +43,30 @@ class TestProductConfigurator(unittest.TestCase):
 				"show_variant_in_website": 1
 			}).insert()
 
+	def create_regular_web_item(self, name, item_group=None):
+		if not frappe.db.exists('Item', name):
+			doc = frappe.get_doc({
+				"description": name,
+				"item_code": name,
+				"item_name": name,
+				"doctype": "Item",
+				"is_stock_item": 1,
+				"item_group": item_group or "_Test Item Group",
+				"stock_uom": "_Test UOM",
+				"item_defaults": [{
+					"company": "_Test Company",
+					"default_warehouse": "_Test Warehouse - _TC",
+					"expense_account": "_Test Account Cost for Goods Sold - _TC",
+					"buying_cost_center": "_Test Cost Center - _TC",
+					"selling_cost_center": "_Test Cost Center - _TC",
+					"income_account": "Sales - _TC"
+				}],
+				"show_in_website": 1
+			}).insert()
+		else:
+			doc = frappe.get_doc("Item", name)
+		return doc
+
 	def test_product_list(self):
 		template_items = frappe.get_all('Item', {'show_in_website': 1})
 		variant_items = frappe.get_all('Item', {'show_variant_in_website': 1})
@@ -79,3 +103,42 @@ class TestProductConfigurator(unittest.TestCase):
 			'Test Size': ['2XL']
 		})
 		self.assertEqual(len(items), 1)
+
+	def test_products_in_multiple_item_groups(self):
+		"""Check if product is visible on multiple item group pages barring its own."""
+		from erpnext.shopping_cart.product_query import ProductQuery
+
+		if not frappe.db.exists("Item Group", {"name": "Tech Items"}):
+			item_group_doc = frappe.get_doc({
+				"doctype": "Item Group",
+				"item_group_name": "Tech Items",
+				"parent_item_group": "All Item Groups",
+				"show_in_website": 1
+			}).insert()
+		else:
+			item_group_doc = frappe.get_doc("Item Group", "Tech Items")
+
+		doc = self.create_regular_web_item("Portal Item", item_group="Tech Items")
+		if not frappe.db.exists("Website Item Group", {"parent": "Portal Item"}):
+			doc.append("website_item_groups", {
+				"item_group": "_Test Item Group Desktops"
+			})
+			doc.save()
+
+		# check if item is visible in its own Item Group's page
+		engine = ProductQuery()
+		items = engine.query({}, {"item_group": "Tech Items"}, None, start=0, item_group="Tech Items")
+		self.assertEqual(len(items), 1)
+		self.assertEqual(items[0].item_code, "Portal Item")
+
+		# check if item is visible in configured foreign Item Group's page
+		engine = ProductQuery()
+		items = engine.query({}, {"item_group": "_Test Item Group Desktops"}, None, start=0, item_group="_Test Item Group Desktops")
+		item_codes = [row.item_code for row in items]
+
+		self.assertIn(len(items), [2, 3])
+		self.assertIn("Portal Item", item_codes)
+
+		# teardown
+		doc.delete()
+		item_group_doc.delete()

--- a/erpnext/setup/doctype/item_group/item_group.py
+++ b/erpnext/setup/doctype/item_group/item_group.py
@@ -91,7 +91,7 @@ class ItemGroup(NestedSet, WebsiteGenerator):
 		field_filters['item_group'] = self.name
 
 		engine = ProductQuery()
-		context.items = engine.query(attribute_filters, field_filters, search, start)
+		context.items = engine.query(attribute_filters, field_filters, search, start, item_group=self.name)
 
 		filter_engine = ProductFiltersBuilder(self.name)
 

--- a/erpnext/shopping_cart/filters.py
+++ b/erpnext/shopping_cart/filters.py
@@ -22,12 +22,15 @@ class ProductFiltersBuilder:
 
 		filter_data = []
 		for df in fields:
-			filters = {}
+			filters, or_filters = {}, []
 			if df.fieldtype == "Link":
 				if self.item_group:
-					filters['item_group'] = self.item_group
+					or_filters.extend([
+						["item_group", "=", self.item_group],
+						["Website Item Group", "item_group", "=", self.item_group]
+					])
 
-				values =  frappe.get_all("Item", fields=[df.fieldname], filters=filters, distinct="True", pluck=df.fieldname)
+				values =  frappe.get_all("Item", fields=[df.fieldname], filters=filters, or_filters=or_filters, distinct="True", pluck=df.fieldname, debug=1)
 			else:
 				doctype = df.get_link_doctype()
 
@@ -44,7 +47,9 @@ class ProductFiltersBuilder:
 				values = [d.name for d in frappe.get_all(doctype, filters)]
 
 			# Remove None
-			values = values.remove(None) if None in values else values
+			if None in values:
+				values.remove(None)
+
 			if values:
 				filter_data.append([df, values])
 
@@ -61,14 +66,18 @@ class ProductFiltersBuilder:
 		for attr_doc in attribute_docs:
 			selected_attributes = []
 			for attr in attr_doc.item_attribute_values:
+				or_filters = []
 				filters= [
 					["Item Variant Attribute", "attribute", "=", attr.parent],
 					["Item Variant Attribute", "attribute_value", "=", attr.attribute_value]
 				]
 				if self.item_group:
-					filters.append(["item_group", "=", self.item_group])
+					or_filters.extend([
+						["item_group", "=", self.item_group],
+						["Website Item Group", "item_group", "=", self.item_group]
+					])
 
-				if frappe.db.get_all("Item", filters, limit=1):
+				if frappe.db.get_all("Item", filters, or_filters=or_filters, limit=1):
 					selected_attributes.append(attr)
 
 			if selected_attributes:

--- a/erpnext/shopping_cart/filters.py
+++ b/erpnext/shopping_cart/filters.py
@@ -30,7 +30,7 @@ class ProductFiltersBuilder:
 						["Website Item Group", "item_group", "=", self.item_group]
 					])
 
-				values = frappe.get_all("Item", fields=[df.fieldname], filters=filters, or_filters=or_filters, distinct="True", pluck=df.fieldname, debug=1)
+				values = frappe.get_all("Item", fields=[df.fieldname], filters=filters, or_filters=or_filters, distinct="True", pluck=df.fieldname)
 			else:
 				doctype = df.get_link_doctype()
 

--- a/erpnext/shopping_cart/filters.py
+++ b/erpnext/shopping_cart/filters.py
@@ -30,7 +30,7 @@ class ProductFiltersBuilder:
 						["Website Item Group", "item_group", "=", self.item_group]
 					])
 
-				values =  frappe.get_all("Item", fields=[df.fieldname], filters=filters, or_filters=or_filters, distinct="True", pluck=df.fieldname, debug=1)
+				values = frappe.get_all("Item", fields=[df.fieldname], filters=filters, or_filters=or_filters, distinct="True", pluck=df.fieldname, debug=1)
 			else:
 				doctype = df.get_link_doctype()
 

--- a/erpnext/shopping_cart/product_query.py
+++ b/erpnext/shopping_cart/product_query.py
@@ -115,6 +115,17 @@ class ProductQuery:
 			if not values:
 				continue
 
+			# handle multiselect fields in filter addition
+			meta = frappe.get_meta('Item', cached=True)
+			df = meta.get_field(field)
+			if df.fieldtype == 'Table MultiSelect':
+				child_doctype = df.options
+				child_meta = frappe.get_meta(child_doctype, cached=True)
+				fields = child_meta.get("fields", { "fieldtype": "Link", "in_list_view": 1 })
+				if fields:
+					self.filters.append([child_doctype, fields[0].fieldname, 'IN', values])
+				continue
+
 			if isinstance(values, list):
 				# If value is a list use `IN` query
 				self.filters.append([field, 'IN', values])

--- a/erpnext/shopping_cart/product_query.py
+++ b/erpnext/shopping_cart/product_query.py
@@ -22,13 +22,14 @@ class ProductQuery:
 		self.settings = frappe.get_doc("Products Settings")
 		self.cart_settings = frappe.get_doc("Shopping Cart Settings")
 		self.page_length = self.settings.products_per_page or 20
-		self.fields = ['name', 'item_name', 'item_code', 'website_image', 'variant_of', 'has_variants', 'item_group', 'image', 'web_long_description', 'description', 'route']
+		self.fields = ['name', 'item_name', 'item_code', 'website_image', 'variant_of', 'has_variants',
+			'item_group', 'image', 'web_long_description', 'description', 'route', 'weightage']
 		self.filters = []
 		self.or_filters = [['show_in_website', '=', 1]]
 		if not self.settings.get('hide_variants'):
 			self.or_filters.append(['show_variant_in_website', '=', 1])
 
-	def query(self, attributes=None, fields=None, search_term=None, start=0):
+	def query(self, attributes=None, fields=None, search_term=None, start=0, item_group=None):
 		"""Summary
 
 		Args:
@@ -44,6 +45,15 @@ class ProductQuery:
 		if search_term: self.build_search_filters(search_term)
 
 		result = []
+		website_item_groups = []
+
+		# if from item group page consider website item group table
+		if item_group:
+			website_item_groups = frappe.db.get_all(
+				"Item",
+				fields=self.fields + ["`tabWebsite Item Group`.parent as wig_parent"],
+				filters=[["Website Item Group", "item_group", "=", item_group]]
+			)
 
 		if attributes:
 			all_items = []
@@ -61,12 +71,10 @@ class ProductQuery:
 					],
 					or_filters=self.or_filters,
 					start=start,
-					limit=self.page_length,
-					order_by="weightage desc"
+					limit=self.page_length
 				)
 
 				items_dict = {item.name: item for item in items}
-				# TODO: Replace Variants by their parent templates
 
 				all_items.append(set(items_dict.keys()))
 
@@ -78,14 +86,22 @@ class ProductQuery:
 				filters=self.filters,
 				or_filters=self.or_filters,
 				start=start,
-				limit=self.page_length,
-				order_by="weightage desc"
+				limit=self.page_length
 			)
+
+		# Combine results having context of website item groups into item results
+		if item_group and website_item_groups:
+			items_list = {row.name for row in result}
+			for row in website_item_groups:
+				if row.wig_parent not in items_list:
+					result.append(row)
+
+		result = sorted(result, key=lambda x: x.get("weightage"), reverse=True)
 
 		for item in result:
 			product_info = get_product_info_for_website(item.item_code, skip_quotation_creation=True).get('product_info')
 			if product_info:
-				item.formatted_price = product_info['price'].get('formatted_price') if product_info['price'] else None
+				item.formatted_price = product_info.get('price', {}).get('formatted_price')
 
 		return result
 

--- a/erpnext/shopping_cart/product_query.py
+++ b/erpnext/shopping_cart/product_query.py
@@ -121,12 +121,10 @@ class ProductQuery:
 			if df.fieldtype == 'Table MultiSelect':
 				child_doctype = df.options
 				child_meta = frappe.get_meta(child_doctype, cached=True)
-				fields = child_meta.get("fields", { "fieldtype": "Link", "in_list_view": 1 })
+				fields = child_meta.get("fields")
 				if fields:
 					self.filters.append([child_doctype, fields[0].fieldname, 'IN', values])
-				continue
-
-			if isinstance(values, list):
+			elif isinstance(values, list):
 				# If value is a list use `IN` query
 				self.filters.append([field, 'IN', values])
 			else:

--- a/erpnext/shopping_cart/product_query.py
+++ b/erpnext/shopping_cart/product_query.py
@@ -101,7 +101,7 @@ class ProductQuery:
 		for item in result:
 			product_info = get_product_info_for_website(item.item_code, skip_quotation_creation=True).get('product_info')
 			if product_info:
-				item.formatted_price = product_info.get('price', {}).get('formatted_price')
+				item.formatted_price = (product_info.get('price') or {}).get('formatted_price')
 
 		return result
 


### PR DESCRIPTION
**Issue:**
- The Website Item Groups table was not considered while fetching items for the Item Group Page
- So if Item Iphone 11 belongs to Item Group Products but has **Services** in the Website Item Groups table, it should be viisble in the **Services** web page and the **Products** web page
- Filters werent considering  Website Item Groups either
- Filters that were of fieldtype **Table Multiselect** broke the product query

**Fix:**
- Passed an argument to query engine to know when query is for item group page
- If for item group page, get data with regards to website item group table
- This query is fast since there's one filter and that shortens the table beforehand
- This data is merged with the results from the Item master (results only considering item attributes and field filters)
- The combined data is then sorted as per weightage
- **For filters:** added condition to consider Website Item Group, handled **Table Multiselect** fieldtype filters too

**Consider the foll.g items:**
![Screenshot 2021-06-23 at 2 32 42 PM](https://user-images.githubusercontent.com/25857446/123068130-3d2f6600-d42f-11eb-98f3-f6ec4dc43c9f.png)

**On the Item Group Page:**
- Items that have _Item Group as Services_ **OR** Items with _Website Item Group as Services_ must be visible
  ![Screenshot 2021-06-23 at 4 04 38 PM](https://user-images.githubusercontent.com/25857446/123081900-13307080-d43c-11eb-96b2-84d106575798.png)
- Similarly, DTH plan that belogns to _Services_ has Website Item Group as _Products_ and is visible on **Products**
  ![Screenshot 2021-06-23 at 4 06 57 PM](https://user-images.githubusercontent.com/25857446/123082338-8afe9b00-d43c-11eb-90f7-4c5bdc5a03e3.png)

