### PR TITLE
feat: Validation of the Swiss chart of accounts and addition of the abbreviated chart of accounts then addition of a custom script for the region of Switzerland for use with the erpnextswiss plugin

### DIFF
--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/ch_l10nch_abbreviated_chart_template.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/ch_l10nch_abbreviated_chart_template.json
@@ -1,0 +1,677 @@
+{
+    "country_code": "ch",
+    "name": "Switzerland - Plan comptable STERCHI Abr\u00e9g\u00e9",
+    "tree": {
+        "Actif": {
+          "Actifs circulants": {
+              "Tr\u00e9sorerie": {
+                  "Caisse": {
+                      "Caisse principale": {
+                          "account_type": "Cash",
+                          "account_number": "1001"
+                      },
+                      "Caisse auxiliaire": {
+                          "account_type": "Cash",
+                          "account_number": "1002"
+                      },
+                      "account_number": "1000"
+                  },
+                  "Compte postal": {
+                      "Compte postal Suisse": {
+                          "account_type": "Bank",
+                          "account_number": "1011"
+                      },
+                      "account_number": "1010"
+                  },
+                  "Banques": {
+                      "Compte courant CHF": {
+                          "account_type": "Bank",
+                          "account_number": "1021"
+                      },
+                      "Compte d'\u00e9pargne CHF": {
+                          "account_type": "Bank",
+                          "account_number": "1022"
+                      },
+                      "Compte courant EUR": {
+                          "account_type": "Bank",
+                          "account_number": "1024"
+                      },
+                      "Compte courant USD": {
+                          "account_type": "Bank",
+                          "account_number": "1025"
+                      },
+                      "is_group": 1,
+                      "account_number": "1020"
+                  },
+                  "account_number": "100"
+              },
+              "Actifs cot\u00e9s en bourse d\u00e9tenus \u00e0 court terme": {
+                  "Titres \u00e0 court terme": {
+                    "account_number": "1060"
+                  },
+                  "Corrections de la valeur des titres": {
+                    "account_number": "1069"
+                  },
+                  "account_number": "106"
+              },
+              "Comptes d'attente": {
+                  "Compte de transfert": {
+                    "account_number": "1090"
+                  },
+                  "Compte d'attente pour salaires": {
+                    "account_number": "1091"
+                  },
+                  "Compte d'attente pour montants \u00e0 clarifier": {
+                    "account_number": "1092"
+                  },
+                  "account_number": "109"
+              },
+              "Cr\u00e9ances r\u00e9sultant de la vente de biens et de prestations de services": {
+                  "Cr\u00e9ances suisse en CHF": {
+                    "account_type": "Receivable",
+                    "account_number": "1100"
+                  },
+                  "Cr\u00e9ances \u00e9trang\u00e8res en CHF": {
+                    "account_type": "Receivable",
+                    "account_number": "1101"
+                  },
+                  "Cr\u00e9ances \u00e9trang\u00e8res en monnaie \u00e9trang\u00e8re EUR": {
+                    "account_type": "Receivable",
+                    "account_number": "1102"
+                  },
+                  "Cr\u00e9ances \u00e9trang\u00e8res en monnaie \u00e9trang\u00e8re USD": {
+                    "account_type": "Receivable",
+                    "account_number": "1103"
+                  },
+                  "Corrections de la valeur des ventes de biens et de prestations de services \u00e0 des tiers (inclus ducroire)": {
+                    "account_type": "Receivable",
+                    "account_number": "1109"
+                  },
+                  "Cr\u00e9ances r\u00e9sultant de la vente de biens et de prestations de services envers des participations": {
+                    "account_type": "Receivable",
+                    "account_number": "1110"
+                  },
+                  "is_group": 1,
+                  "account_type": "Receivable",
+                  "account_number": "110"
+              },
+              "Autres cr\u00e9ances \u00e0 court terme": {
+                  "Pr\u00eats": {
+                    "account_number": "1140"
+                  },
+                  "Corrections de la valeur des avances et des pr\u00eats envers des tiers": {
+                    "account_number": "1149"
+                  },
+                  "Imp\u00f4t pr\u00e9alable : TVA s/mat\u00e9riel, marchandises, prestations et \u00e9nergie": {
+                    "account_type": "Tax",
+                    "account_number": "1170"
+                  },
+                  "Imp\u00f4t pr\u00e9alable : TVA s/investissements et autres charges d’exploitation": {
+                    "account_type": "Tax",
+                    "account_number": "1171"
+                  },
+                  "R\u00e9conciliation de l'imp\u00f4t pr\u00e9alable lors de changement de m\u00e9thode": {
+                    "account_number": "1172"
+                  },
+                  "R\u00e9duction de l'imp\u00f4t pr\u00e9alable": {
+                    "account_number": "1173"
+                  },
+                  "Correction de l'imp\u00f4t pr\u00e9alable": {
+                    "account_number": "1174"
+                  },
+                  "D\u00e9compte TVA": {
+                    "account_type": "Tax",
+                    "account_number": "1175"
+                  },
+                  "Imp\u00f4t anticip\u00e9 \u00e0 r\u00e9cup\u00e9rer": {
+                    "account_number": "1176"
+                  },
+                  "Cr\u00e9ances envers l'administration des douanes": {
+                    "account_number": "1177"
+                  },
+                  "Compte courant AVS, AI, APG, AC": {
+                    "account_number": "1180"
+                  },
+                  "Compte courant Caisse d'allocations familiales (CAF)": {
+                    "account_number": "1181"
+                  },
+                  "Compte courant Institutions de pr\u00e9voyance professionnelle": {
+                    "account_number": "1182"
+                  },
+                  "Compte courant Assurance-accidents": {
+                    "account_number": "1183"
+                  },
+                  "Compte courant Assurance maladie (indemnit\u00e9 journali\u00e8re maladie)": {
+                    "account_number": "1184"
+                  },
+                  "Compte courant Imp\u00f4t \u00e0 la source": {
+                    "account_number": "1188"
+                  },
+                  "Cr\u00e9ances (WIR)": {
+                    "account_number": "1190"
+                  },
+                  "Cautionnements": {
+                    "account_number": "1191"
+                  },
+                  "Acomptes pay\u00e9s": {
+                    "account_number": "1192"
+                  },
+                  "D\u00e9p\u00f4t de garantie de loyer": {
+                    "account_number": "1193"
+                  },
+                  "Corrections de la valeur des cr\u00e9ances \u00e0 court terme": {
+                    "account_number": "1199"
+                  },
+                  "account_number": "114"
+              },
+              "Stocks et prestations non factur\u00e9es": {
+                  "Stocks de marchandises commerciales": {
+                      "account_type": "Stock",
+                      "account_number": "1200"
+                  },
+                  "Stocks de mati\u00e8res premi\u00e8res": {
+                      "account_type": "Stock",
+                      "account_number": "1210"
+                  },
+                  "Stocks de mati\u00e8res auxiliaires": {
+                      "account_type": "Stock",
+                      "account_number": "1220"
+                  },
+                  "Stocks de mati\u00e8res auxiliaires": {
+                      "account_type": "Stock",
+                      "account_number": "1230"
+                  },
+                  "Stocks Obligatoires": {
+                      "account_type": "Stock",
+                      "account_number": "1240"
+                  },
+                  "Marchandises en consignation": {
+                      "account_number": "1250"
+                  },
+                  "Stocks de produits finis": {
+                      "account_type": "Stock",
+                      "account_number": "1260"
+                  },
+                  "Stocks de produits semi-ouvr\u00e9s": {
+                      "account_type": "Stock",
+                      "account_number": "1270"
+                  },
+                  "Travaux en cours": {
+                      "account_number": "1280"
+                  },
+                  "account_number": "120"
+              },
+              "Actifs de r\u00e9gularisation (actifs transitoires)": {
+                  "Charges pay\u00e9es d'avance": {
+                    "account_number": "1300"
+                  },
+                  "Produits \u00e0 recevoir": {
+                    "account_number": "1301"
+                  },
+                  "R\u00e9serve de contributions de l'employeur": {
+                    "account_number": "1302"
+                  },
+                  "Remise de dettes": {
+                    "account_number": "1303"
+                  },
+                  "account_number": "130"
+              },
+              "account_number": "10"
+          },
+          "Actifs immobilis\u00e9s": {
+              "Immobilisations financi\u00e8res": {
+                  "Titres \u00e0 long terme": {
+                      "account_number": "1400"
+                  },
+                  "Corrections de la valeur des titres": {
+                      "account_number": "1409"
+                  },
+                  "Autres placements \u00e0 long terme": {
+                      "account_number": "1410"
+                  },
+                  "Pr\u00eats": {
+                      "account_number": "1440"
+                  },
+                  "Hypoth\u00e8ques": {
+                      "account_number": "1441"
+                  },
+                  "Corrections de la valeur des cr\u00e9ances \u00e0 long terme envers des tiers": {
+                      "account_number": "1449"
+                  },
+                  "account_number": "140"
+              },
+              "Participations": {
+                  "Participations": {
+                      "account_number": "1480"
+                  },
+                  "Corrections de la valeur des participations": {
+                      "account_number": "1489"
+                  },
+                  "account_number": "148"
+              },
+              "Immobilisation corporelle meubles": {
+                  "Machines et appareils": {
+                      "account_number": "1500"
+                  },
+                  "Amortissements et corrections de la valeur des machines et appareils": {
+                      "account_number": "1509"
+                  },
+                  "Mobilier et installations": {
+                      "account_number": "1510"
+                  },
+                  "Amortissements et corrections de la valeur du mobilier et installations": {
+                      "account_number": "1519"
+                  },
+                  "Machines de bureau, informatique, syst\u00e8mes de communication": {
+                      "account_number": "1520"
+                  },
+                  "Amortissements et corrections de la valeur des machines de bureau, informatique, syst\u00e8mes de communication": {
+                      "account_number": "1529"
+                  },
+                  "V\u00e9hicules": {
+                      "account_number": "1530"
+                  },
+                  "Amortissements et corrections de la valeur des v\u00e9hicules": {
+                      "account_number": "1539"
+                  },
+                  "Outillages et appareils": {
+                      "account_number": "1540"
+                  },
+                  "Amortissements et corrections de la valeur de l’outillage et appareils": {
+                      "account_number": "1549"
+                  },
+                  "account_number": "150"
+              },
+              "Immobilisation corporelle immeubles": {
+                  "Immeubles d’exploitation": {
+                      "account_number": "1600"
+                  },
+                  "Amortissements et corrections de la valeur des immeubles d’exploitation": {
+                      "account_number": "1609"
+                  },
+                  "account_number": "160"
+              },
+              "Immobilisations incorporelles": {
+                  "Brevets, know-how, processus de fabrication": {
+                      "account_number": "1700"
+                  },
+                  "Amortissements et corrections de la valeur des immeubles d’exploitation": {
+                      "account_number": "1709"
+                  },
+                  "Goodwill": {
+                      "account_number": "1770"
+                  },
+                  "Amortissements et corrections de la valeur du goodwill": {
+                      "account_number": "1779"
+                  },
+                  "account_number": "170"
+              },
+              "Capital social (ou capital de fondation) non lib\u00e9r\u00e9": {
+                  "Capital social non lib\u00e9r\u00e9": {
+                    "account_number": "1850"
+                  },
+                  "Capital participation non lib\u00e9r\u00e9": {
+                    "account_number": "1851"
+                  },
+                  "account_number": "180"
+              },
+              "account_number": "14"
+          },
+          "root_type": "Asset",
+          "account_number": "1"
+        },
+        "Passif": {
+          "Capitaux \u00e9trangers \u00e0 court terme": {
+              "Dettes \u00e0 court terme r\u00e9sultant de l’achat de biens et de prestations de services": {
+                  "Dettes r\u00e9sultant d’achats de mati\u00e8res et de marchandises": {
+                      "account_type": "Payable",
+                      "account_number": "2000"
+                  },
+                  "Dettes r\u00e9sultant de prestations de services de tiers": {
+                      "account_type": "Payable",
+                      "account_number": "2001"
+                  },
+                  "Dettes r\u00e9sultant de charges de personnel": {
+                      "account_type": "Payable",
+                      "account_number": "2002"
+                  },
+                  "Dettes r\u00e9sultant d'autres charges d'exploitation": {
+                      "account_type": "Payable",
+                      "account_number": "2004"
+                  },
+                  "Acomptes re\u00e7us de tiers": {
+                      "account_type": "Payable",
+                      "account_number": "2030"
+                  },
+                  "Dettes r\u00e9sultant de livraisons et de prestations \u00e0 des participations": {
+                      "account_type": "Payable",
+                      "account_number": "2050"
+                  },
+                  "is_group": 1,
+                  "account_type": "Payable",
+                  "account_number": "200"
+              },
+              "Dettes \u00e0 court terme portant int\u00e9r\u00eat": {
+                  "Compte courant CHF": {
+                      "account_number": "2100"
+                  },
+                  "Emprunts CHF": {
+                      "account_number": "2107"
+                  },
+                  "Hypoth\u00e8que CHF": {
+                      "account_number": "2109"
+                  },
+                  "Engagements de financement par leasing": {
+                      "account_number": "2120"
+                  },
+                  "Autres dettes financi\u00e8res \u00e0 court terme envers des tiers": {
+                      "account_number": "2140"
+                  },
+                  "account_number": "210"
+              },
+              "Autres dettes \u00e0 court terme": {
+                  "TVA due": {
+                      "account_type": "Tax",
+                      "account_number": "2200"
+                  },
+                  "D\u00e9compte TVA": {
+                      "account_type": "Tax",
+                      "account_number": "2201"
+                  },
+                  "Imp\u00f4t sur les acquisitions": {
+                      "account_number": "2203"
+                  },
+                  "Imp\u00f4t anticip\u00e9 \u00e0 payer": {
+                      "account_number": "2206"
+                  },
+                  "Droit de timbre": {
+                      "account_number": "2207"
+                  },
+                  "Imp\u00f4t directs": {
+                      "account_number": "2208"
+                  },
+                  "Autres dettes \u00e0 court terme envers des tiers (sans int\u00e9r\u00eats)": {
+                      "account_number": "2210"
+                  },
+                  "Autres dettes financi\u00e8res \u00e0 court terme envers les parties prenantes et les organes (sans int\u00e9r\u00eats)": {
+                      "account_number": "2260"
+                  },
+                  "Dividendes": {
+                      "account_number": "2261"
+                  },
+                  "Autres dettes \u00e0 court terme relatives aux charges salariales (sans int\u00e9r\u00eats)": {
+                      "account_number": "2270"
+                  },
+                  "Compte courant Imp\u00f4t \u00e0 la source": {
+                      "account_number": "2279"
+                  },
+                  "account_number": "220"
+              },
+              "Passifs de r\u00e9gularisation (passifs transitoires) et provisions \u00e0 court terme": {
+                  "Charges \u00e0 payer": {
+                      "account_number": "2300"
+                  },
+                  "Produits encaiss\u00e9s d’avance": {
+                      "account_number": "2301"
+                  },
+                  "Provisions \u00e0 court terme": {
+                      "account_number": "2330"
+                  },
+                  "account_number": "230"
+              },
+              "account_number": "20"
+          },
+          "Capitaux \u00e9trangers \u00e0 long terme": {
+              "Dettes \u00e0 long terme portant int\u00e9r\u00eat": {
+                  "Dettes bancaires \u00e0 long terme": {
+                      "account_number": "2400"
+                  },
+                  "Engagements de financement par leasing": {
+                      "account_number": "2420"
+                  },
+                  "Emprunts obligataires": {
+                      "account_number": "2430"
+                  },
+                  "Emprunts": {
+                      "account_number": "2450"
+                  },
+                  "Hypoth\u00e8ques": {
+                      "account_number": "2451"
+                  },
+                  "account_number": "240"
+              },
+              "Autres dettes \u00e0 long terme": {
+                  "Autres dettes \u00e0 long terme": {
+                      "account_number": "2500"
+                  },
+                  "account_number": "250"
+              },
+              "Provisions et postes analogues pr\u00e9vus par la loi": {
+                  "Autres provisions \u00e0 long terme": {
+                      "account_number": "2691"
+                  },
+                  "account_number": "260"
+              },
+              "account_number": "24"
+          },
+          "Capitaux propres (personnes morales)": {
+              "Capital social (capital-actions, capital de fondation, capital propre)": {
+                  "Capital social de la S.\u00e0.r.l": {
+                      "account_type": "Equity",
+                      "account_number": "2800"
+                  },
+                  "account_number": "280"
+              },
+              "R\u00e9serves et b\u00e9n\u00e9fice report\u00e9 ou perte report\u00e9e": {
+                  "R\u00e9serve l\u00e9gale issue du capital": {
+                      "account_type": "Equity",
+                      "account_number": "2900"
+                  },
+                  "R\u00e9serves d‘\u00e9valuation": {
+                      "account_type": "Equity",
+                      "account_number": "2940"
+                  },
+                  "R\u00e9serve l\u00e9gale issue du b\u00e9n\u00e9fice": {
+                      "account_type": "Equity",
+                      "account_number": "2950"
+                  },
+                  "R\u00e9serves facultatives issues du b\u00e9n\u00e9fice": {
+                      "account_type": "Equity",
+                      "account_number": "2960"
+                  },
+                  "B\u00e9n\u00e9fice ou perte report\u00e9e": {
+                      "account_type": "Equity",
+                      "account_number": "2970"
+                  },
+                  "B\u00e9n\u00e9fice ou perte de l’exercice": {
+                      "account_type": "Equity",
+                      "account_number": "2979"
+                  },
+                  "Propres actions, parts sociales, droits de participations (poste n\u00e9gatif)": {
+                      "account_type": "Equity",
+                      "account_number": "2980"
+                  },
+                  "account_number": "290"
+              },
+              "account_number": "28"
+          },
+          "root_type": "Liability",
+          "account_number": "2"
+        },
+        "Produits nets des ventes de biens et de prestations de services": {
+          "Ventes de produits fabriqu\u00e9s": {
+              "account_number": "3000"
+          },
+          "Ventes de produits fabriqu\u00e9s": {
+              "account_number": "3000"
+          },
+          "Ventes de marchandise": {
+              "account_number": "3200"
+          },
+          "Ventes de prestations": {
+              "account_number": "3400"
+          },
+          "Produits annexes r\u00e9sultant de livraisons et de prestations de services": {
+              "account_number": "3600"
+          },
+          "Prestations propres": {
+              "account_number": "3700"
+          },
+          "Propres consommations": {
+              "account_number": "3710"
+          },
+          "D\u00e9ductions sur ventes (escomptes, rabais, ristournes, ...)": {
+              "account_number": "3800"
+          },
+          "Pertes sur clients, variation du ducroire": {
+              "account_number": "3805"
+          },
+          "Variation des stocks de produits semi-finis": {
+              "account_number": "3900"
+          },
+          "Variation de stocks de produits finis": {
+              "account_number": "3901"
+          },
+          "Variation de la valeur des prestations non factur\u00e9es": {
+              "account_number": "3940"
+          },
+          "root_type": "Income",
+          "account_number": "3"
+        },
+        "Charges de mat\u00e9riel, de marchandises, de prestations de tiers et d’\u00e9nergie": {
+          "Charges de mat\u00e9riel": {
+              "account_number": "4000"
+          },
+          "Charges de marchandises destin\u00e9es \u00e0 la revente": {
+              "account_number": "4200"
+          },
+          "Charges de prestations de tiers": {
+              "account_number": "4400"
+          },
+          "Charges d’\u00e9nergie pour l’exploitation": {
+              "account_number": "4500"
+          },
+          "D\u00e9ductions sur les charges (escomptes, rabais, , ...)": {
+              "account_number": "4900"
+          },
+          "root_type": "Expense",
+          "account_number": "4"
+        },
+        "Charges de personnel": {
+          "Charge salaires": {
+              "account_number": "5200"
+          },
+          "Charges sociales": {
+              "account_number": "5270"
+          },
+          "Autres charges de personnel": {
+              "account_number": "5800"
+          },
+          "Prestations de tiers/temporaires": {
+              "account_number": "5900"
+          },
+          "root_type": "Expense",
+          "account_number": "5"
+        },
+        "Autres charges d’exploitation, amortissements et corrections de valeur, r\u00e9sultat financier": {
+          "Charges de locaux": {
+              "account_number": "6000"
+          },
+          "Entretien, r\u00e9parations, remplacements (ERR)": {
+              "account_number": "6100"
+          },
+          "Charges de leasing": {
+              "account_number": "6150"
+          },
+          "Charges de v\u00e9hicules et de transport": {
+              "account_number": "6200"
+          },
+          "V\u00e9hicules en leasing": {
+              "account_number": "6260"
+          },
+          "Assurances-choses, droits, taxes, autorisations": {
+              "account_number": "6300"
+          },
+          "Charges d’\u00e9nergie et \u00e9vacuation des d\u00e9chets": {
+              "account_number": "6400"
+          },
+          "Charges d’administration": {
+              "account_number": "6500"
+          },
+          "Frais informatiques": {
+              "account_number": "6570"
+          },
+          "Charges de publicit\u00e9": {
+              "account_number": "6600"
+          },
+          "Autres charges d’exploitation": {
+              "account_number": "6700"
+          },
+          "Amortissements et corrections de la valeur des immobilisations": {
+              "account_number": "6800"
+          },
+          "Charges financi\u00e8res": {
+              "account_number": "6900"
+          },
+          "Produits financiers": {
+              "account_number": "6950"
+          },
+          "root_type": "Expense",
+          "account_number": "6"
+        },
+        "R\u00e9sultat des activit\u00e9s annexes d’exploitation": {
+          "Produits accessoires": {
+              "account_number": "7000"
+          },
+          "Charges accessoires": {
+              "account_number": "7010"
+          },
+          "Produits des immeubles d’exploitation": {
+              "account_number": "7500"
+          },
+          "Charges des immeubles d’exploitation": {
+              "account_number": "7510"
+          },
+          "root_type": "Expense",
+          "account_number": "7"
+        },
+        "R\u00e9sultats exceptionnels et hors exploitation": {
+          "Charges hors exploitation": {
+              "account_number": "8000"
+          },
+          "Produits hors exploitation": {
+              "account_number": "8100"
+          },
+          "Charges extraordinaires, exceptionnelles ou hors p\u00e9riode": {
+              "account_number": "8500"
+          },
+          "Produits extraordinaires, exceptionnels ou hors p\u00e9riode": {
+              "account_number": "8510"
+          },
+          "Imp\u00f4ts directs": {
+              "Imp\u00f4ts sur le b\u00e9n\u00e9fice/Imp\u00f4ts cantonaux et communaux": {
+                  "account_number": "8900"
+              },
+              "Imp\u00f4ts sur le capital/Imp\u00f4t f\u00e9d\u00e9raux": {
+                  "account_number": "8901"
+              },
+              "Imp\u00f4ts directs hors p\u00e9riode": {
+                  "account_number": "8902"
+              },
+              "account_number": "89"
+          },
+          "root_type": "Expense",
+          "account_number": "8"
+        },
+        "Cl\u00f4ture": {
+          "Utilisation du b\u00e9n\u00e9fice": {
+              "B\u00e9n\u00e9fice ou perte de l'exercice": {
+                  "account_number": "9200"
+              },
+              "account_number": "92"
+          },
+          "root_type": "Equity",
+          "account_number": "9"
+        }
+    }
+}

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/ch_l10nch_complet_chart_template.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/ch_l10nch_complet_chart_template.json
@@ -1,0 +1,3305 @@
+{
+    "country_code": "ch",
+    "name": "Switzerland - Plan comptable STERCHI",
+    "tree": {
+        "Actif": {
+          "Actifs circulants": {
+              "Tr\u00e9sorerie": {
+                  "Caisse": {
+                      "Caisse principale": {
+                          "account_type": "Cash",
+                          "account_number": "1001"
+                      },
+                      "Caisse auxiliaire": {
+                          "account_type": "Cash",
+                          "account_number": "1002"
+                      },
+                      "account_number": "1000"
+                  },
+                  "Compte postal": {
+                      "Compte postal Suisse": {
+                          "account_type": "Bank",
+                          "account_number": "1011"
+                      },
+                      "account_number": "1010"
+                  },
+                  "Banques": {
+                      "Compte courant CHF": {
+                          "account_type": "Bank",
+                          "account_number": "1021"
+                      },
+                      "Compte d'\u00e9pargne CHF": {
+                          "account_type": "Bank",
+                          "account_number": "1022"
+                      },
+                      "Compte courant EUR": {
+                          "account_type": "Bank",
+                          "account_number": "1024"
+                      },
+                      "Compte courant USD": {
+                          "account_type": "Bank",
+                          "account_number": "1025"
+                      },
+                      "is_group": 1,
+                      "account_number": "1020"
+                  },
+                  "account_number": "100"
+              },
+              "Actifs cot\u00e9s en bourse d\u00e9tenus \u00e0 court terme": {
+                  "Actions \u00e0 court terme": {
+                    "account_number": "1060"
+                  },
+                  "Bons de participation \u00e0 court terme": {
+                    "account_number": "1061"
+                  },
+                  "Parts de fonds de placement \u00e0 court terme": {
+                    "account_number": "1062"
+                  },
+                  "Obligations \u00e0 court terme": {
+                    "account_number": "1063"
+                  },
+                  "R\u00e9serves de fluctuation de valeur sur titres \u00e0 court terme": {
+                    "account_number": "1068"
+                  },
+                  "Corrections de la valeur des titres": {
+                    "account_number": "1069"
+                  },
+                  "Autres placements \u00e0 court terme": {
+                    "account_number": "1070"
+                  },
+                  "R\u00e9serves de fluctuation de valeur sur autres placements \u00e0 court terme": {
+                    "account_number": "1078"
+                  },
+                  "Corrections de la valeur des autres placements \u00e0 court terme": {
+                    "account_number": "1079"
+                  },
+                  "account_number": "106"
+              },
+              "Comptes d'attente": {
+                  "Compte de transfert": {
+                    "account_number": "1090"
+                  },
+                  "Compte d'attente pour salaires": {
+                    "account_number": "1091"
+                  },
+                  "Compte d'attente pour montants \u00e0 clarifier": {
+                    "account_number": "1099"
+                  },
+                  "account_number": "109"
+              },
+              "Cr\u00e9ances r\u00e9sultant de la vente de biens et de prestations de services": {
+                  "Cr\u00e9ances suisse en CHF": {
+                    "account_type": "Receivable",
+                    "account_number": "1100"
+                  },
+                  "Cr\u00e9ances \u00e9trang\u00e8res en CHF": {
+                    "account_type": "Receivable",
+                    "account_number": "1101"
+                  },
+                  "Cr\u00e9ances \u00e9trang\u00e8res en monnaie \u00e9trang\u00e8re EUR": {
+                    "account_type": "Receivable",
+                    "account_number": "1102"
+                  },
+                  "Cr\u00e9ances \u00e9trang\u00e8res en monnaie \u00e9trang\u00e8re USD": {
+                    "account_type": "Receivable",
+                    "account_number": "1103"
+                  },
+                  "Corrections de la valeur des ventes de biens et de prestations de services \u00e0 des tiers (inclus ducroire)": {
+                    "account_type": "Receivable",
+                    "account_number": "1109"
+                  },
+                  "Cr\u00e9ances r\u00e9sultant de la vente de biens et de prestations de services envers des participations": {
+                    "account_type": "Receivable",
+                    "account_number": "1110"
+                  },
+                  "Corrections de la valeur des ventes des cr\u00e9ances envers des participations": {
+                    "account_type": "Receivable",
+                    "account_number": "1119"
+                  },
+                  "Cr\u00e9ances envers les actionnaires": {
+                    "account_type": "Receivable",
+                    "account_number": "1120"
+                  },
+                  "Cr\u00e9ances envers les administrateurs": {
+                    "account_type": "Receivable",
+                    "account_number": "1122"
+                  },
+                  "Cr\u00e9ances envers les membres de la direction": {
+                    "account_type": "Receivable",
+                    "account_number": "1124"
+                  },
+                  "Cr\u00e9ances envers l'organe de r\u00e9vision": {
+                    "account_type": "Receivable",
+                    "account_number": "1128"
+                  },
+                  "Corrections de la valeur de la vente de bien et de prestations de services envers les parties prenantes et les organes": {
+                    "account_type": "Receivable",
+                    "account_number": "1129"
+                  },
+                  "is_group": 1,
+                  "account_type": "Receivable",
+                  "account_number": "110"
+              },
+              "Autres cr\u00e9ances \u00e0 court terme": {
+                  "Pr\u00eats \u00e0 court terme": {
+                    "account_number": "1140"
+                  },
+                  "Corrections de la valeur des avances et des pr\u00eats envers des tiers": {
+                    "account_number": "1149"
+                  },
+                  "Pr\u00eats \u00e0 court terme envers les participations": {
+                    "account_number": "1150"
+                  },
+                  "Corrections de la valeur des autres cr\u00e9ances \u00e0 court terme envers des participations": {
+                    "account_number": "1159"
+                  },
+                  "Pr\u00eats \u00e0 court terme envers les actionnaires": {
+                    "account_number": "1160"
+                  },
+                  "Pr\u00eats \u00e0 court terme envers les administrateurs": {
+                    "account_number": "1162"
+                  },
+                  "Pr\u00eats \u00e0 court terme envers les membres de la direction": {
+                    "account_number": "1164"
+                  },
+                  "Corrections de la valeur des autres cr\u00e9ances \u00e0 envers des envers les parties prenantes et les organes": {
+                    "account_number": "1169"
+                  },
+                  "Imp\u00f4t pr\u00e9alable : TVA s/mat\u00e9riel, marchandises, prestations et \u00e9nergie": {
+                    "account_type": "Tax",
+                    "account_number": "1170"
+                  },
+                  "Imp\u00f4t pr\u00e9alable : TVA s/investissements et autres charges d’exploitation": {
+                    "account_type": "Tax",
+                    "account_number": "1171"
+                  },
+                  "R\u00e9conciliation de l'imp\u00f4t pr\u00e9alable lors de changement de m\u00e9thode": {
+                    "account_number": "1172"
+                  },
+                  "R\u00e9duction de l'imp\u00f4t pr\u00e9alable": {
+                    "account_number": "1173"
+                  },
+                  "Correction de l'imp\u00f4t pr\u00e9alable": {
+                    "account_number": "1174"
+                  },
+                  "D\u00e9compte TVA": {
+                    "account_type": "Tax",
+                    "account_number": "1175"
+                  },
+                  "Imp\u00f4t anticip\u00e9 \u00e0 r\u00e9cup\u00e9rer": {
+                    "account_number": "1176"
+                  },
+                  "Cr\u00e9ances envers l'administration des douanes": {
+                    "account_number": "1177"
+                  },
+                  "Compte courant AVS, AI, APG, AC": {
+                    "account_number": "1180"
+                  },
+                  "Compte courant Caisse d'allocations familiales (CAF)": {
+                    "account_number": "1181"
+                  },
+                  "Compte courant Institutions de pr\u00e9voyance professionnelle": {
+                    "account_number": "1182"
+                  },
+                  "Compte courant Assurance-accidents": {
+                    "account_number": "1183"
+                  },
+                  "Compte courant Assurance maladie (indemnit\u00e9 journali\u00e8re maladie)": {
+                    "account_number": "1184"
+                  },
+                  "Compte courant Imp\u00f4t \u00e0 la source": {
+                    "account_number": "1188"
+                  },
+                  "Cr\u00e9ances (WIR)": {
+                    "account_number": "1190"
+                  },
+                  "Cautionnements": {
+                    "account_number": "1191"
+                  },
+                  "Acomptes pay\u00e9s": {
+                    "account_number": "1192"
+                  },
+                  "D\u00e9p\u00f4t de garantie de loyer": {
+                    "account_number": "1193"
+                  },
+                  "Corrections de la valeur des cr\u00e9ances \u00e0 court terme": {
+                    "account_number": "1199"
+                  },
+                  "account_number": "114"
+              },
+              "Stocks et prestations non factur\u00e9es": {
+                  "Stocks de marchandises commerciales": {
+                      "account_type": "Stock",
+                      "account_number": "1200"
+                  },
+                  "Variation des stocks de marchandises": {
+                      "account_type": "Stock",
+                      "account_number": "1207"
+                  },
+                  "Acomptes sur les marchandises commerciales": {
+                      "account_type": "Stock",
+                      "account_number": "1208"
+                  },
+                  "Correction de la valeur des marchandises commerciales": {
+                      "account_type": "Stock",
+                      "account_number": "1209"
+                  },
+                  "Stocks de mati\u00e8res premi\u00e8res": {
+                      "account_type": "Stock",
+                      "account_number": "1210"
+                  },
+                  "Variation des stocks de mati\u00e8res premi\u00e8res": {
+                      "account_type": "Stock",
+                      "account_number": "1217"
+                  },
+                  "Acomptes sur mati\u00e8res premi\u00e8res": {
+                      "account_type": "Stock",
+                      "account_number": "1218"
+                  },
+                  "Correction de la valeur des mati\u00e8res premi\u00e8res": {
+                      "account_type": "Stock",
+                      "account_number": "1219"
+                  },
+                  "Stocks de pi\u00e8ces termin\u00e9es": {
+                      "account_type": "Stock",
+                      "account_number": "1220"
+                  },
+                  "Stocks de pi\u00e8ces semi-ouvr\u00e9es": {
+                      "account_type": "Stock",
+                      "account_number": "1221"
+                  },
+                  "Variation du stock de mati\u00e8res": {
+                      "account_type": "Stock",
+                      "account_number": "1227"
+                  },
+                  "Acompte sur mati\u00e8res": {
+                      "account_type": "Stock",
+                      "account_number": "1228"
+                  },
+                  "Correction de la valeur des stocks de mati\u00e8res": {
+                      "account_type": "Stock",
+                      "account_number": "1229"
+                  },
+                  "Stocks de mati\u00e8res auxiliaires": {
+                      "account_type": "Stock",
+                      "account_number": "1230"
+                  },
+                  "Stocks de mati\u00e8res consommables": {
+                      "account_type": "Stock",
+                      "account_number": "1231"
+                  },
+                  "Stocks de mat\u00e9riel d'emballages": {
+                      "account_type": "Stock",
+                      "account_number": "1232"
+                  },
+                  "Variation des stocks de mati\u00e8res auxiliaires et de mati\u00e8res consommables": {
+                      "account_type": "Stock",
+                      "account_number": "1237"
+                  },
+                  "Acompte sur mati\u00e8res auxiliaires et mati\u00e8res consommables": {
+                      "account_type": "Stock",
+                      "account_number": "1238"
+                  },
+                  "Correction de la valeur des mati\u00e8res auxiliaires et de mati\u00e8res consommables": {
+                      "account_type": "Stock",
+                      "account_number": "1239"
+                  },
+                  "Stocks obligatoires": {
+                      "account_type": "Stock",
+                      "account_number": "1240"
+                  },
+                  "Variation des stocks obligatoires": {
+                      "account_type": "Stock",
+                      "account_number": "1247"
+                  },
+                  "Correction de la valeur des stocks obligatoires": {
+                      "account_type": "Stock",
+                      "account_number": "1249"
+                  },
+                  "Marchandises en consignation": {
+                      "account_number": "1250"
+                  },
+                  "Variation des stocks de marchandises en consignation": {
+                      "account_type": "Stock",
+                      "account_number": "1257"
+                  },
+                  "Correction de la valeur sur stocks de marchandises en consignation": {
+                      "account_type": "Stock",
+                      "account_number": "1259"
+                  },
+                  "Stocks de produits finis": {
+                      "account_type": "Stock",
+                      "account_number": "1260"
+                  },
+                  "Variation des stocks de produits finis": {
+                      "account_type": "Stock",
+                      "account_number": "1267"
+                  },
+                  "Correction de la valeur des produits finis": {
+                      "account_type": "Stock",
+                      "account_number": "1269"
+                  },
+                  "Stocks de produits semi-ouvr\u00e9s": {
+                      "account_type": "Stock",
+                      "account_number": "1270"
+                  },
+                  "Variation des stocks de produits semi-ouvr\u00e9s": {
+                      "account_type": "Stock",
+                      "account_number": "1277"
+                  },
+                  "Correction de la valeur des produits semi-ouvr\u00e9s": {
+                      "account_type": "Stock",
+                      "account_number": "1279"
+                  },
+                  "Travaux en cours": {
+                      "account_number": "1280"
+                  },
+                  "Variation des travaux en cours": {
+                      "account_type": "Stock",
+                      "account_number": "1287"
+                  },
+                  "Correction de la valeur des travaux en cours": {
+                      "account_type": "Stock",
+                      "account_number": "1289"
+                  },
+                  "account_number": "120"
+              },
+              "Actifs de r\u00e9gularisation (actifs transitoires)": {
+                  "Charges pay\u00e9es d'avance": {
+                    "account_number": "1300"
+                  },
+                  "Produits \u00e0 recevoir": {
+                    "account_number": "1301"
+                  },
+                  "R\u00e9serve de contributions de l'employeur": {
+                    "account_number": "1302"
+                  },
+                  "Remise de dettes": {
+                    "account_number": "1303"
+                  },
+                  "account_number": "130"
+              },
+              "account_number": "10"
+          },
+          "Actifs immobilis\u00e9s": {
+              "Immobilisations financi\u00e8res": {
+                  "Actions \u00e0 long terme": {
+                      "account_number": "1400"
+                  },
+                  "Bons de participation \u00e0 long terme": {
+                      "account_number": "1401"
+                  },
+                  "Parts de fonds de placement \u00e0 long terme": {
+                      "account_number": "1402"
+                  },
+                  "Obligations \u00e0 long terme": {
+                      "account_number": "1403"
+                  },
+                  "R\u00e9serve de fluctuation de valeur des immobilisations financi\u00e8res \u00e0 long terme": {
+                      "account_number": "1408"
+                  },
+                  "Corrections de la valeur des titres \u00e0 long terme": {
+                      "account_number": "1409"
+                  },
+                  "Comptes de placement": {
+                      "account_number": "1410"
+                  },
+                  "D\u00e9p\u00f4t de garantie de loyer": {
+                      "account_number": "1411"
+                  },
+                  "Corrections de la valeur des autres placements \u00e0 long terme": {
+                      "account_number": "1419"
+                  },
+                  "Pr\u00eats \u00e0 long terme": {
+                      "account_number": "1440"
+                  },
+                  "Hypoth\u00e8ques": {
+                      "account_number": "1441"
+                  },
+                  "Corrections de la valeur des cr\u00e9ances \u00e0 long terme envers des tiers": {
+                      "account_number": "1449"
+                  },
+                  "Pr\u00eats \u00e0 long terme envers les participations": {
+                      "account_number": "1450"
+                  },
+                  "Pr\u00eats hypoth\u00e9caires envers les participations": {
+                      "account_number": "1451"
+                  },
+                  "Corrections de la valeur des cr\u00e9ances \u00e0 long terme envers des participations": {
+                      "account_number": "1459"
+                  },
+                  "Pr\u00eats \u00e0 long terme envers les actionnaires": {
+                      "account_number": "1460"
+                  },
+                  "Pr\u00eats hypoth\u00e9caires envers les actionnaires": {
+                      "account_number": "1461"
+                  },
+                  "Pr\u00eats \u00e0 long terme envers les administrateurs": {
+                      "account_number": "1462"
+                  },
+                  "Pr\u00eats hypoth\u00e9caires envers les administrateurs": {
+                      "account_number": "1463"
+                  },
+                  "Pr\u00eats \u00e0 long terme envers les membres de la direction": {
+                      "account_number": "1464"
+                  },
+                  "Pr\u00eats hypoth\u00e9caires envers les membres de la direction": {
+                      "account_number": "1465"
+                  },
+                  "Corrections de la valeur des cr\u00e9ances \u00e0 long terme envers les parties prenantes et les organes": {
+                      "account_number": "1469"
+                  },
+                  "R\u00e9serve de contributions de l'employeur": {
+                      "account_number": "1470"
+                  },
+                  "account_number": "140"
+              },
+              "Participations": {
+                  "Participations": {
+                      "account_number": "1480"
+                  },
+                  "Corrections de la valeur des participations": {
+                      "account_number": "1489"
+                  },
+                  "account_number": "148"
+              },
+              "Immobilisation corporelle meubles": {
+                  "Machines et appareils": {
+                      "account_number": "1500"
+                  },
+                  "Chaines de production": {
+                      "account_number": "1501"
+                  },
+                  "Machines et appareils en leasing": {
+                      "account_number": "1507"
+                  },
+                  "Acomptes vers\u00e9s sur machines et appareils": {
+                      "account_number": "1508"
+                  },
+                  "Amortissements et corrections de la valeur des machines et appareils": {
+                      "account_number": "1509"
+                  },
+                  "Mobilier et installations": {
+                      "account_number": "1510"
+                  },
+                  "Installations/\u00e9quipements d'ateliers": {
+                      "account_number": "1511"
+                  },
+                  "Installations/\u00e9quipements de magasins": {
+                      "account_number": "1512"
+                  },
+                  "Mobilier de bureau": {
+                      "account_number": "1513"
+                  },
+                  "Mobilier et installations en leasing": {
+                      "account_number": "1517"
+                  },
+                  "Acomptes vers\u00e9s sur mobilier et installations": {
+                      "account_number": "1518"
+                  },
+                  "Amortissements et corrections de la valeur du mobilier et installations": {
+                      "account_number": "1519"
+                  },
+                  "Machines de bureau": {
+                      "account_number": "1520"
+                  },
+                  "Informatique": {
+                      "account_number": "1521"
+                  },
+                  "Syst\u00e8me de communication": {
+                      "account_number": "1522"
+                  },
+                  "Machines de bureau, informatique et syst\u00e8me de communication en leasing": {
+                      "account_number": "1527"
+                  },
+                  "Acomptes vers\u00e9s sur machines de bureau, informatique et syst\u00e8me de communication": {
+                      "account_number": "1528"
+                  },
+                  "Amortissements et corrections de la valeur des machines de bureau, informatique, syst\u00e8mes de communication": {
+                      "account_number": "1529"
+                  },
+                  "V\u00e9hicules": {
+                      "account_number": "1530"
+                  },
+                  "V\u00e9hicules en leasing": {
+                      "account_number": "1537"
+                  },
+                  "Acomptes sur v\u00e9hicules": {
+                      "account_number": "1538"
+                  },
+                  "Amortissements et corrections de la valeur des v\u00e9hicules": {
+                      "account_number": "1539"
+                  },
+                  "Outillages et appareils": {
+                      "account_number": "1540"
+                  },
+                  "Outillages et appareils en leasing": {
+                      "account_number": "1547"
+                  },
+                  "Acomptes sur outillages et appareils": {
+                      "account_number": "1548"
+                  },
+                  "Amortissements et corrections de la valeur de l’outillage et appareils": {
+                      "account_number": "1549"
+                  },
+                  "Installations de stockage": {
+                      "account_number": "1550"
+                  },
+                  "Installations de stockage en leasing": {
+                      "account_number": "1557"
+                  },
+                  "Acomptes sur installations de stockage": {
+                      "account_number": "1558"
+                  },
+                  "Amortissements et corrections de la valeur des installations de stockage": {
+                      "account_number": "1559"
+                  },
+                  "Equipements": {
+                      "account_number": "1570"
+                  },
+                  "Installations": {
+                      "account_number": "1571"
+                  },
+                  "\u00e9quipements et installations en leasing": {
+                      "account_number": "1577"
+                  },
+                  "Acomptes sur \u00e9quipements et installations": {
+                      "account_number": "1578"
+                  },
+                  "Amortissements et corrections de la valeur des \u00e9quipements et installations": {
+                      "account_number": "1579"
+                  },
+                  "Lingerie et habits de travail": {
+                      "account_number": "1590"
+                  },
+                  "Mod\u00e8les, empreintes, gabarits, moulages": {
+                      "account_number": "1591"
+                  },
+                  "Autres immobilisations corporelles meubles en leasing": {
+                      "account_number": "1597"
+                  },
+                  "Acomptes sur autres immobilisations corporelles meubles": {
+                      "account_number": "1598"
+                  },
+                  "Amortissements et corrections de la valeur des autres immobilisations corporelles meubles": {
+                      "account_number": "1599"
+                  },
+                  "account_number": "150"
+              },
+              "Immobilisation corporelle immeubles": {
+                  "Immeubles d’exploitation": {
+                      "account_number": "1600"
+                  },
+                  "Transformation d'immeubles d'exploitation": {
+                      "account_number": "1606"
+                  },
+                  "Immeubles d'exploitation en leasing": {
+                      "account_number": "1607"
+                  },
+                  "Acomptes sur immeubles d'exploitation": {
+                      "account_number": "1608"
+                  },
+                  "Amortissements et corrections de la valeur des immeubles d’exploitation": {
+                      "account_number": "1609"
+                  },
+                  "Usines": {
+                      "account_number": "1610"
+                  },
+                  "Usines en leasing": {
+                      "account_number": "1617"
+                  },
+                  "Acomptes sur usines": {
+                      "account_number": "1618"
+                  },
+                  "Amortissements et corrections de la valeur des usines": {
+                      "account_number": "1619"
+                  },
+                  "Ateliers": {
+                      "account_number": "1620"
+                  },
+                  "Ateliers en leasing": {
+                      "account_number": "1627"
+                  },
+                  "Acomptes sur ateliers": {
+                      "account_number": "1628"
+                  },
+                  "Amortissements et corrections de la valeur des ateliers": {
+                      "account_number": "1629"
+                  },
+                  "Entrep\u00f4ts": {
+                      "account_number": "1630"
+                  },
+                  "Entrep\u00f4ts en leasing": {
+                      "account_number": "1637"
+                  },
+                  "Acomptes sur entrep\u00f4ts": {
+                      "account_number": "1638"
+                  },
+                  "Amortissements et corrections de la valeur des entrep\u00f4ts": {
+                      "account_number": "1639"
+                  },
+                  "Halles d'exploitation": {
+                      "account_number": "1640"
+                  },
+                  "Halles de vente": {
+                      "account_number": "1641"
+                  },
+                  "Halles d'exploitation et de vente en leasing": {
+                      "account_number": "1647"
+                  },
+                  "Acomptes sur immeubles d'exploitation et de vente": {
+                      "account_number": "1648"
+                  },
+                  "Amortissements et corrections de la valeur des immeubles d'exploitation et de vente": {
+                      "account_number": "1649"
+                  },
+                  "Immeubles administratifs": {
+                      "account_number": "1650"
+                  },
+                  "Immeubles administratifs en leasing": {
+                      "account_number": "1657"
+                  },
+                  "Acomptes sur immeubles administratifs": {
+                      "account_number": "1658"
+                  },
+                  "Amortissements et corrections de la valeur des immeubles administratifs": {
+                      "account_number": "1659"
+                  },
+                  "Immeubles d'habitation du personnel": {
+                      "account_number": "1660"
+                  },
+                  "Autres immeubles d'habitation": {
+                      "account_number": "1661"
+                  },
+                  "Immeubles d'habitation en leasing": {
+                      "account_number": "1667"
+                  },
+                  "Acomptes sur immeubles d'habitation": {
+                      "account_number": "1668"
+                  },
+                  "Amortissements et corrections de la valeur des immeubles d'habitation": {
+                      "account_number": "1669"
+                  },
+                  "Bien-fonds non bâtis": {
+                      "account_number": "1680"
+                  },
+                  "Bien-fonds non bâtis en leasing": {
+                      "account_number": "1687"
+                  },
+                  "Acomptes sur bien-fonds non bâtis": {
+                      "account_number": "1688"
+                  },
+                  "Amortissements et corrections de la valeur des biens-fonds non bâtis": {
+                      "account_number": "1689"
+                  },
+                  "account_number": "160"
+              },
+              "Immobilisations incorporelles": {
+                  "Brevets": {
+                      "account_number": "1700"
+                  },
+                  "Know-how": {
+                      "account_number": "1701"
+                  },
+                  "Processus de fabrication": {
+                      "account_number": "1702"
+                  },
+                  "Amortissements et corrections de la valeur des brevets, know-how, processus de fabrication": {
+                      "account_number": "1709"
+                  },
+                  "Marques commerciales": {
+                      "account_number": "1710"
+                  },
+                  "Echantillons": {
+                      "account_number": "1711"
+                  },
+                  "Mod\u00e8les": {
+                      "account_number": "1712"
+                  },
+                  "Plans": {
+                      "account_number": "1713"
+                  },
+                  "Amortissements et corrections de la valeur des marques commerciales, \u00e9chantillons, mod\u00e8les, plans": {
+                      "account_number": "1719"
+                  },
+                  "Droit de licences": {
+                      "account_number": "1720"
+                  },
+                  "Concessions": {
+                      "account_number": "1721"
+                  },
+                  "Droits de jouissance": {
+                      "account_number": "1722"
+                  },
+                  "Droit des soci\u00e9t\u00e9s": {
+                      "account_number": "1723"
+                  },
+                  "Amortissements et corrections de la valeur sur droit de licences, concessions, droits de jouissance, raisons de commerce": {
+                      "account_number": "1729"
+                  },
+                  "Droits de propri\u00e9t\u00e9 intellectuelle": {
+                      "account_number": "1730"
+                  },
+                  "Droit d'\u00e9dition": {
+                      "account_number": "1731"
+                  },
+                  "Droits conventionnels": {
+                      "account_number": "1732"
+                  },
+                  "Amortissements et corrections de la valeur des droits de propri\u00e9t\u00e9 intellectuelle, droit d'\u00e9dition, droit conventionnels": {
+                      "account_number": "1739"
+                  },
+                  "Logiciels d\u00e9velopp\u00e9s en interne": {
+                      "account_number": "1740"
+                  },
+                  "Logiciels achet\u00e9s": {
+                      "account_number": "1741"
+                  },
+                  "Amortissements et corrections de la valeur des logiciels": {
+                      "account_number": "1749"
+                  },
+                  "D\u00e9veloppements sp\u00e9cifiques internes (co\u00fbts activ\u00e9s)": {
+                      "account_number": "1750"
+                  },
+                  "D\u00e9veloppements sp\u00e9cifiques acquis": {
+                      "account_number": "1751"
+                  },
+                  "Amortissements et corrections de la valeur sur d\u00e9veloppements sp\u00e9cifiques": {
+                      "account_number": "1759"
+                  },
+                  "Goodwill": {
+                      "account_number": "1770"
+                  },
+                  "Amortissements et corrections de la valeur du goodwill": {
+                      "account_number": "1779"
+                  },
+                  "Autres immobilisations incorporelles": {
+                      "account_number": "1790"
+                  },
+                  "Amortissements et corrections de la valeur des autres immobilisations incorporelles": {
+                      "account_number": "1799"
+                  },
+                  "account_number": "170"
+              },
+              "Capital social (ou capital de fondation) non lib\u00e9r\u00e9": {
+                  "Capital social non lib\u00e9r\u00e9": {
+                    "account_number": "1850"
+                  },
+                  "Capital participation non lib\u00e9r\u00e9": {
+                    "account_number": "1851"
+                  },
+                  "account_number": "180"
+              },
+              "account_number": "14"
+          },
+          "root_type": "Asset",
+          "account_number": "1"
+        },
+        "Passif": {
+          "Capitaux \u00e9trangers \u00e0 court terme": {
+              "Dettes \u00e0 court terme r\u00e9sultant de l’achat de biens et de prestations de services": {
+                  "Dettes r\u00e9sultant d’achats de mati\u00e8res et de marchandises": {
+                      "account_type": "Payable",
+                      "account_number": "2000"
+                  },
+                  "Dettes r\u00e9sultant de prestations de services de tiers": {
+                      "account_type": "Payable",
+                      "account_number": "2001"
+                  },
+                  "Dettes r\u00e9sultant de charges de personnel": {
+                      "account_type": "Payable",
+                      "account_number": "2002"
+                  },
+                  "Dettes r\u00e9sultant d'autres charges d'exploitation": {
+                      "account_type": "Payable",
+                      "account_number": "2004"
+                  },
+                  "Acomptes re\u00e7us de tiers": {
+                      "account_type": "Payable",
+                      "account_number": "2030"
+                  },
+                  "Dettes r\u00e9sultant de livraisons et de prestations \u00e0 des participations": {
+                      "account_type": "Payable",
+                      "account_number": "2050"
+                  },
+                  "Dettes r\u00e9sultant d'achats et de prestations de services envers les actionnaires": {
+                      "account_type": "Payable",
+                      "account_number": "2060"
+                  },
+                  "Dettes r\u00e9sultant d'achats et de prestations de services envers les administrateurs": {
+                      "account_type": "Payable",
+                      "account_number": "2062"
+                  },
+                  "Dettes r\u00e9sultant d'achats et de prestations de services envers les membres de la direction": {
+                      "account_type": "Payable",
+                      "account_number": "2064"
+                  },
+                  "Dettes r\u00e9sultant d'achats et de prestations de services envers l'organe de r\u00e9vision": {
+                      "account_type": "Payable",
+                      "account_number": "2068"
+                  },
+                  "is_group": 1,
+                  "account_type": "Payable",
+                  "account_number": "200"
+              },
+              "Dettes \u00e0 court terme portant int\u00e9r\u00eat": {
+                  "Compte courant CHF \u00e0 court terme": {
+                      "account_number": "2100"
+                  },
+                  "Emprunts bancaires CHF \u00e0 court terme": {
+                      "account_number": "2107"
+                  },
+                  "Hypoth\u00e8que bancaire CHF \u00e0 court terme": {
+                      "account_number": "2109"
+                  },
+                  "Dettes envers les soci\u00e9t\u00e9s de virement (WIR)": {
+                      "account_number": "2111"
+                  },
+                  "Engagements \u00e0 court terme de financement par leasing": {
+                      "account_number": "2120"
+                  },
+                  "Emprunts obligatoires \u00e0 court terme": {
+                      "account_number": "2130"
+                  },
+                  "Autres dettes financi\u00e8res \u00e0 court terme envers des tiers": {
+                      "account_number": "2140"
+                  },
+                  "Dettes financi\u00e8res envers des participations": {
+                      "account_number": "2150"
+                  },
+                  "Dettes financi\u00e8res envers les actionnaires": {
+                      "account_number": "2160"
+                  },
+                  "Dettes financi\u00e8res envers les administrateurs": {
+                      "account_number": "2162"
+                  },
+                  "Dettes financi\u00e8res envers les membres de la direction": {
+                      "account_number": "2164"
+                  },
+                  "Dettes financi\u00e8res envers des institutions de pr\u00e9voyance": {
+                      "account_number": "2170"
+                  },
+                  "account_number": "210"
+              },
+              "Autres dettes \u00e0 court terme": {
+                  "TVA due": {
+                      "account_type": "Tax",
+                      "account_number": "2200"
+                  },
+                  "D\u00e9compte TVA": {
+                      "account_type": "Tax",
+                      "account_number": "2201"
+                  },
+                  "R\u00e9conciliation du chiffre d'affaires suite \u00e0 un changement de m\u00e9thode": {
+                      "account_number": "2202"
+                  },
+                  "Imp\u00f4t sur les acquisitions": {
+                      "account_number": "2203"
+                  },
+                  "Imp\u00f4t anticip\u00e9 \u00e0 payer": {
+                      "account_number": "2206"
+                  },
+                  "Droit de timbre": {
+                      "account_number": "2207"
+                  },
+                  "Imp\u00f4t directs": {
+                      "account_number": "2208"
+                  },
+                  "Autres dettes \u00e0 court terme envers des tiers (sans int\u00e9r\u00eats)": {
+                      "account_number": "2210"
+                  },
+                  "Autres dettes financi\u00e8res \u00e0 court terme envers les actionnaires(sans int\u00e9r\u00eats)": {
+                      "account_number": "2260"
+                  },
+                  "Dividendes": {
+                      "account_number": "2261"
+                  },
+                  "Autres dettes financi\u00e8res \u00e0 court terme envers les administrateurs(sans int\u00e9r\u00eats)": {
+                      "account_number": "2262"
+                  },
+                  "Autres dettes financi\u00e8res \u00e0 court terme envers les membres de la direction (sans int\u00e9r\u00eats)": {
+                      "account_number": "2264"
+                  },
+                  "Autres dettes financi\u00e8res \u00e0 court terme envers l'organe de r\u00e9vision (sans int\u00e9r\u00eats)": {
+                      "account_number": "2268"
+                  },
+                  "Compte courant Institutions de pr\u00e9voyance professionnelle": {
+                      "account_number": "2270"
+                  },
+                  "Compte courant AVS, AI, APG, AC": {
+                      "account_number": "2271"
+                  },
+                  "Compte courant Caisse d'allocations familiales (CAF)": {
+                      "account_number": "2272"
+                  },
+                  "Compte courant Assurance-accidents": {
+                      "account_number": "2273"
+                  },
+                  "Compte courant Assurance maladie (indemnit\u00e9 journali\u00e8re maladie)": {
+                      "account_number": "2274"
+                  },
+                  "Compte courant Imp\u00f4t \u00e0 la source": {
+                      "account_number": "2279"
+                  },
+                  "account_number": "220"
+              },
+              "Passifs de r\u00e9gularisation (passifs transitoires) et provisions \u00e0 court terme": {
+                  "Charges \u00e0 payer": {
+                      "account_number": "2300"
+                  },
+                  "Produits encaiss\u00e9s d’avance": {
+                      "account_number": "2301"
+                  },
+                  "Provisions pour travaux de garantie \u00e0 court terme": {
+                      "account_number": "2330"
+                  },
+                  "Provisions pour risques li\u00e9s aux engagements d\u00e9coulant d'obligations de prendre livraison \u00e0 court terme": {
+                      "account_number": "2331"
+                  },
+                  "Provisions pour imp\u00f4ts directs \u00e0 court terme": {
+                      "account_number": "2340"
+                  },
+                  "Provisions pour imp\u00f4ts indirects \u00e0 court terme": {
+                      "account_number": "2341"
+                  },
+                  "Provisions pour r\u00e9paration et entretien \u00e0 court terme": {
+                      "account_number": "2350"
+                  },
+                  "Provisions pour r\u00e9novation des immobilisations \u00e0 court terme": {
+                      "account_number": "2351"
+                  },
+                  "Provisions pour recherche \u00e0 court terme": {
+                      "account_number": "2352"
+                  },
+                  "Provisions pour d\u00e9veloppement \u00e0 court terme": {
+                      "account_number": "2353"
+                  },
+                  "Provisions pour restructuration \u00e0 court terme": {
+                      "account_number": "2354"
+                  },
+                  "Provisions pour protection de l'environnement \u00e0 court terme": {
+                      "account_number": "2355"
+                  },
+                  "Provisions pour pertes futures": {
+                      "account_number": "2360"
+                  },
+                  "Provisions pour engagements envers l'institution de pr\u00e9voyance professionnelle \u00e0 court terme": {
+                      "account_number": "2370"
+                  },
+                  "Provisions pour charges salariales \u00e0 court terme": {
+                      "account_number": "2371"
+                  },
+                  "Provisions pour engagements envers participations \u00e0 court terme": {
+                      "account_number": "2380"
+                  },
+                  "Provisions pour engagements envers les parties prenantes et les organes \u00e0 court terme": {
+                      "account_number": "2381"
+                  },
+                  "Provisions pour assurer la prosp\u00e9rit\u00e9 durable de l'entreprise \u00e0 court terme": {
+                      "account_number": "2390"
+                  },
+                  "Autres provisions \u00e0 court terme": {
+                      "account_number": "2391"
+                  },
+                  "account_number": "230"
+              },
+              "account_number": "20"
+          },
+          "Capitaux \u00e9trangers \u00e0 long terme": {
+              "Dettes \u00e0 long terme portant int\u00e9r\u00eat": {
+                  "Emprunts bancaires en CHF \u00e0 long terme": {
+                      "account_number": "2400"
+                  },
+                  "Hypoth\u00e8ques bancaires en CHF \u00e0 long terme": {
+                      "account_number": "2401"
+                  },
+                  "Engagements \u00e0 long terme de financement par leasing": {
+                      "account_number": "2420"
+                  },
+                  "Emprunts obligataires \u00e0 long terme": {
+                      "account_number": "2430"
+                  },
+                  "Emprunts \u00e0 long terme \u00e0 l'\u00e9gard de tiers portant int\u00e9r\u00eat": {
+                      "account_number": "2450"
+                  },
+                  "Hypoth\u00e8ques \u00e0 long terme \u00e0 l'\u00e9gard de tiers portant int\u00e9r\u00eat": {
+                      "account_number": "2451"
+                  },
+                  "Emprunts \u00e0 long terme aupr\u00e8s des participations": {
+                      "account_number": "2470"
+                  },
+                  "Emprunts hypoth\u00e8ques \u00e0 long terme aupr\u00e8s des participations": {
+                      "account_number": "2471"
+                  },
+                  "Emprunts aupr\u00e8s des actionnaires": {
+                      "account_number": "2480"
+                  },
+                  "Emprunts hypoth\u00e8ques aupr\u00e8s des actionnaires": {
+                      "account_number": "2481"
+                  },
+                  "Emprunts aupr\u00e8s des administrateurs": {
+                      "account_number": "2482"
+                  },
+                  "Emprunts hypoth\u00e8ques aupr\u00e8s des administrateurs": {
+                      "account_number": "2483"
+                  },
+                  "Emprunts aupr\u00e8s des membres de la direction": {
+                      "account_number": "2484"
+                  },
+                  "Emprunts hypoth\u00e8ques aupr\u00e8s des membres de la direction": {
+                      "account_number": "2485"
+                  },
+                  "Emprunts aupr\u00e8s des institutions de pr\u00e9voyance professionnelle": {
+                      "account_number": "2490"
+                  },
+                  "Dettes hypoth\u00e8ques aupr\u00e8s des institutions de pr\u00e9voyance professionnelle": {
+                      "account_number": "2491"
+                  },
+                  "account_number": "240"
+              },
+              "Autres dettes \u00e0 long terme": {
+                  "Autres dettes \u00e0 long terme \u00e0 l'\u00e9gard de tiers (sans int\u00e9r\u00eats)": {
+                      "account_number": "2500"
+                  },
+                  "Autres dettes \u00e0 long terme envers des participations (sans int\u00e9r\u00eats)": {
+                      "account_number": "2550"
+                  },
+                  "Autres dettes envers les actionnaires \u00e0 long terme (sans int\u00e9r\u00eats)": {
+                      "account_number": "2560"
+                  },
+                  "Autres dettes envers les administrateurs \u00e0 long terme (sans int\u00e9r\u00eats)": {
+                      "account_number": "2562"
+                  },
+                  "Autres dettes envers les membres de la direction \u00e0 long terme (sans int\u00e9r\u00eats)": {
+                      "account_number": "2564"
+                  },
+                  "Autres dettes envers des institutions de pr\u00e9voyance professionnelle": {
+                      "account_number": "2570"
+                  },
+                  "account_number": "250"
+              },
+              "Provisions et postes analogues pr\u00e9vus par la loi": {
+                "Provisions pour travaux de garantie \u00e0 long terme": {
+                    "account_number": "2630"
+                },
+                "Provisions pour risques li\u00e9s aux engagements d\u00e9coulant d'obligations de prendre livraison \u00e0 long terme": {
+                    "account_number": "2631"
+                },
+                "Provisions pour imp\u00f4ts directs \u00e0 long terme": {
+                    "account_number": "2640"
+                },
+                "Provisions pour imp\u00f4ts indirects \u00e0 long terme": {
+                    "account_number": "2641"
+                },
+                "Provisions pour r\u00e9paration et entretien \u00e0 long terme": {
+                    "account_number": "2650"
+                },
+                "Provisions pour r\u00e9novation des immobilisations \u00e0 long terme": {
+                    "account_number": "2651"
+                },
+                "Provisions pour recherche \u00e0 long terme": {
+                    "account_number": "2652"
+                },
+                "Provisions pour d\u00e9veloppement \u00e0 long terme": {
+                    "account_number": "2653"
+                },
+                "Provisions pour restructuration \u00e0 long terme": {
+                    "account_number": "2654"
+                },
+                "Provisions pour protection de l'environnement \u00e0 long terme": {
+                    "account_number": "2655"
+                },
+                "Provisions pour affaires en cours": {
+                    "account_number": "2660"
+                },
+                "Provisions pour engagements envers l'institution de pr\u00e9voyance professionnelle \u00e0 long terme": {
+                    "account_number": "2670"
+                },
+                "Provisions pour charges salariales \u00e0 long terme": {
+                    "account_number": "2671"
+                },
+                "Provisions pour engagements envers participations \u00e0 long terme": {
+                    "account_number": "2680"
+                },
+                "Provisions pour engagements envers les parties prenantes et les organes \u00e0 long terme": {
+                    "account_number": "2681"
+                },
+                "Provisions pour assurer la prosp\u00e9rit\u00e9 durable de l'entreprise \u00e0 long terme": {
+                    "account_number": "2690"
+                },
+                "Autres provisions \u00e0 long terme": {
+                    "account_number": "2691"
+                },
+                "R\u00e9serve pour fluctuation de valeur": {
+                    "account_number": "2695"
+                },
+                  "account_number": "260"
+              },
+              "account_number": "24"
+          },
+          "Capitaux propres (personnes morales)": {
+              "Capital social (capital-actions, capital de fondation, capital propre)": {
+                  "Capital social de la S.\u00e0.r.l": {
+                      "account_type": "Equity",
+                      "account_number": "2800"
+                  },
+                  "account_number": "280"
+              },
+              "R\u00e9serves et b\u00e9n\u00e9fice report\u00e9 ou perte report\u00e9e": {
+                  "Agio \u00e0 la fondation ou lors d'augmentations de capital": {
+                      "account_type": "Equity",
+                      "account_number": "2900"
+                  },
+                  "Autres apports,primes et contributions": {
+                      "account_type": "Equity",
+                      "account_number": "2901"
+                  },
+                  "Agio lors de fusion, de scission ou de cession d'actifs": {
+                      "account_type": "Equity",
+                      "account_number": "2902"
+                  },
+                  "Gain lors de r\u00e9duction du capital": {
+                      "account_type": "Equity",
+                      "account_number": "2903"
+                  },
+                  "R\u00e9serves d‘\u00e9valuation": {
+                      "account_type": "Equity",
+                      "account_number": "2940"
+                  },
+                  "R\u00e9serve l\u00e9gale issue du b\u00e9n\u00e9fice": {
+                      "account_type": "Equity",
+                      "account_number": "2950"
+                  },
+                  "R\u00e9serves facultatives issues du b\u00e9n\u00e9fice": {
+                      "account_type": "Equity",
+                      "account_number": "2960"
+                  },
+                  "B\u00e9n\u00e9fice ou perte report\u00e9e": {
+                      "account_type": "Equity",
+                      "account_number": "2970"
+                  },
+                  "B\u00e9n\u00e9fice ou perte de l’exercice": {
+                      "account_type": "Equity",
+                      "account_number": "2979"
+                  },
+                  "Propres actions, parts sociales": {
+                      "account_type": "Equity",
+                      "account_number": "2980"
+                  },
+                  "Commandite propre": {
+                      "account_type": "Equity",
+                      "account_number": "2985"
+                  },
+                  "account_number": "290"
+              },
+              "account_number": "28"
+          },
+          "root_type": "Liability",
+          "account_number": "2"
+        },
+        "Produits nets des ventes de biens et de prestations de services": {
+          "Chiffre d'affaires de la production vendue": {
+              "Vente de produits fabriqu\u00e9s": {
+                  "Ventes de produits fabriqu\u00e9s comptant": {
+                      "account_number": "3000"
+                  },
+                  "Ventes de produits fabriqu\u00e9s au d\u00e9tail \u00e0 cr\u00e9dit": {
+                      "account_number": "3001"
+                  },
+                  "Ventes de produits fabriqu\u00e9s en gros \u00e0 cr\u00e9dit": {
+                      "account_number": "3002"
+                  },
+                  "Ventes de produits fabriqu\u00e9s r\u00e9sultant de prestations annexes (port et emballage)": {
+                      "account_number": "3007"
+                  },
+                  "Variation des cr\u00e9ances/d\u00e9biteurs": {
+                      "account_number": "3008"
+                  },
+                  "D\u00e9ductions sur ventes": {
+                      "account_number": "3009"
+                  },
+                  "account_number": "300"
+              },
+              "D\u00e9ductions sur vente de produits fabriqu\u00e9s": {
+                  "Escomptes": {
+                      "account_number": "3090"
+                  },
+                  "Rabais et r\u00e9ductions de prix": {
+                      "account_number": "3091"
+                  },
+                  "Ristournes": {
+                      "account_number": "3092"
+                  },
+                  "Commissions de tiers": {
+                      "account_number": "3093"
+                  },
+                  "Frais d'encaissement": {
+                      "account_number": "3094"
+                  },
+                  "Pertes sur clients, variation de prix": {
+                      "account_number": "3095"
+                  },
+                  "Diff\u00e9rences de change": {
+                      "account_number": "3096"
+                  },
+                  "Frais de ports": {
+                      "account_number": "3097"
+                  },
+                  "account_number": "309"
+              },
+              "account_number": "30"
+          },
+          "Ventes de marchandises": {
+              "Ventes de marchandises": {
+                  "Ventes de marchandises au comptant": {
+                      "account_number": "3200"
+                  },
+                  "Ventes de marchandises au d\u00e9tail \u00e0 cr\u00e9dit": {
+                      "account_number": "3201"
+                  },
+                  "Ventes de marchandises en gros \u00e0 cr\u00e9dit": {
+                      "account_number": "3202"
+                  },
+                  "Ventes de marchandises de prestations annexes (port et emballage)": {
+                      "account_number": "3207"
+                  },
+                  "Variation des cr\u00e9ances/d\u00e9biteurs": {
+                      "account_number": "3208"
+                  },
+                  "D\u00e9ductions sur ventes": {
+                      "account_number": "3209"
+                  },
+                  "account_number": "320"
+              },
+              "D\u00e9ductions sur vente de marchandises": {
+                  "Escomptes": {
+                      "account_number": "3290"
+                  },
+                  "Rabais et r\u00e9ductions de prix": {
+                      "account_number": "3291"
+                  },
+                  "Ristournes": {
+                      "account_number": "3292"
+                  },
+                  "Commissions de tiers": {
+                      "account_number": "3293"
+                  },
+                  "Frais d'encaissement": {
+                      "account_number": "3294"
+                  },
+                  "Pertes sur clients, variation de prix": {
+                      "account_number": "3295"
+                  },
+                  "Diff\u00e9rences de change": {
+                      "account_number": "3296"
+                  },
+                  "Frais de ports": {
+                      "account_number": "3297"
+                  },
+                  "account_number": "329"
+              },
+              "account_number": "32"
+          },
+          "Vente de prestations": {
+              "Ventes de prestations": {
+                  "Ventes de prestations au comptant": {
+                      "account_number": "3400"
+                  },
+                  "Ventes de prestations \u00e0 cr\u00e9dit": {
+                      "account_number": "3401"
+                  },
+                  "Ventes de prestations annexes d'exploitation": {
+                      "account_number": "3407"
+                  },
+                  "Variation des cr\u00e9ances/d\u00e9biteurs": {
+                      "account_number": "3408"
+                  },
+                  "D\u00e9ductions sur ventes de prestations": {
+                      "account_number": "3409"
+                  },
+                  "account_number": "340"
+              },
+              "D\u00e9ductions sur vente de prestations": {
+                  "Escomptes": {
+                      "account_number": "3490"
+                  },
+                  "Rabais et r\u00e9ductions de prix": {
+                      "account_number": "3491"
+                  },
+                  "Ristournes": {
+                      "account_number": "3492"
+                  },
+                  "Commissions de tiers": {
+                      "account_number": "3493"
+                  },
+                  "Frais d'encaissement": {
+                      "account_number": "3494"
+                  },
+                  "Pertes sur clients, variation de prix": {
+                      "account_number": "3495"
+                  },
+                  "Diff\u00e9rences de change": {
+                      "account_number": "3496"
+                  },
+                  "Frais de ports": {
+                      "account_number": "3497"
+                  },
+                  "account_number": "349"
+              },
+              "account_number": "34"
+          },
+          "Produits annexes r\u00e9sultants de la vente de biens et de prestations de services": {
+              "Produits annexes r\u00e9sultant de livraisons et de prestations de services": {
+                  "Ventes de mati\u00e8res premi\u00e8res": {
+                      "account_number": "3600"
+                  },
+                  "Ventes de mati\u00e8res auxiliaires": {
+                      "account_number": "3601"
+                  },
+                  "Ventes de d\u00e9chets": {
+                      "account_number": "3602"
+                  },
+                  "Ventes de prestations annexes": {
+                      "account_number": "3607"
+                  },
+                  "Variation des cr\u00e9ances/d\u00e9biteurs": {
+                      "account_number": "3608"
+                  },
+                  "D\u00e9ductions sur les produits accessoires": {
+                      "account_number": "3609"
+                  },
+                  "account_number": "360"
+              },
+              "Produits de licences, berverts, etc.": {
+                  "Produits de licences pour produit": {
+                      "account_number": "3610"
+                  },
+                  "D\u00e9ductions sur les produits des licences, des brevets, etc.": {
+                      "account_number": "3619"
+                  },
+                  "account_number": "361"
+              },
+              "Produits r\u00e9sultant de la mise \u00e0 disposition du personnel": {
+                  "Produits r\u00e9sultant de la mise \u00e0 disposition du personnel": {
+                      "account_number": "3670"
+                  },
+                  "account_number": "367"
+              },
+              "Autres Produits": {
+                  "Autres Produits": {
+                      "account_number": "3680"
+                  },
+                  "account_number": "368"
+              },
+              "D\u00e9ductions sur les autres ventes et les prestations de services": {
+                  "Escomptes": {
+                      "account_number": "3690"
+                  },
+                  "Rabais et r\u00e9ductions de prix": {
+                      "account_number": "3691"
+                  },
+                  "account_number": "369"
+              },
+              "account_number": "36"
+          },
+          "Propres prestations et propres consommations": {
+              "Prestations propres": {
+                  "Propre production d'immobilisations corporelles meubles": {
+                      "account_number": "3700"
+                  },
+                  "Propre production d'immobilisations corporelles immeubles": {
+                      "account_number": "3701"
+                  },
+                  "Propre reproduction d'immobilisations corporelles meubles": {
+                      "account_number": "3702"
+                  },
+                  "Propre reproduction d'immobilisations corporelles immeubles": {
+                      "account_number": "3703"
+                  },
+                  "account_number": "370"
+              },
+              "Propres consommations": {
+                  "Propres consommations produites": {
+                      "account_number": "3710"
+                  },
+                  "account_number": "371"
+              },
+              "Propres consommations de marchandises": {
+                  "Propres consommations de marchandises": {
+                      "account_number": "3720"
+                  },
+                  "account_number": "372"
+              },
+              "Propres consommations de services": {
+                  "Propres consommations de services": {
+                      "account_number": "3740"
+                  },
+                  "account_number": "374"
+              },
+              "Pr\u00e9l\u00e8vements en nature": {
+                  "Pr\u00e9l\u00e8vements en nature": {
+                      "account_number": "3790"
+                  },
+                  "account_number": "379"
+              },
+              "account_number": "37"
+          },
+          "D\u00e9ductions sur ventes": {
+              "D\u00e9ductions sur ventes": {
+                  "Escomptes": {
+                      "account_number": "3800"
+                  },
+                  "Rabais et r\u00e9ductions de prix": {
+                      "account_number": "3801"
+                  },
+                  "Ristournes": {
+                      "account_number": "3802"
+                  },
+                  "Commissions de tiers": {
+                      "account_number": "3803"
+                  },
+                  "Frais d'encaissement": {
+                      "account_number": "3804"
+                  },
+                  "Pertes sur clients, variation du ducroire": {
+                      "account_number": "3805"
+                  },
+                  "Diff\u00e9rences de change": {
+                      "account_number": "3806"
+                  },
+                  "Frais d'exp\u00e9dition": {
+                      "account_number": "3807"
+                  },
+                  "TVA - Taux de la dette nette": {
+                      "account_number": "3808"
+                  },
+                  "account_number": "380"
+              },
+              "account_number": "38"
+          },
+          "Variation des stocks de produits finis et semi-finis et variation des prestations de services non factur\u00e9s": {
+              "Variation des stocks de produits semi-finis et finis": {
+                  "Variation des stocks de produits semis-finis": {
+                      "account_number": "3900"
+                  },
+                  "Variation des stocks de produits finis": {
+                      "account_number": "3901"
+                  },
+                  "account_number": "390"
+              },
+              "Variation de la valeur des prestations non factur\u00e9es": {
+                  "Variation de la valeur des prestations non factur\u00e9es": {
+                      "account_number": "3940"
+                  },
+                  "Variation des stocks de produits finis": {
+                      "account_number": "3941"
+                  },
+                  "account_number": "394"
+              },
+              "account_number": "39"
+          },
+          "root_type": "Income",
+          "account_number": "3"
+        },
+        "Charges de mat\u00e9riel, de marchandises, de prestations de tiers et d’\u00e9nergie": {
+          "Charges de mat\u00e9riel": {
+              "Charges de mat\u00e9riel Production": {
+                  "Achats d'appareils": {
+                      "account_number": "4000"
+                  },
+                  "Achats de composants": {
+                      "account_number": "4001"
+                  },
+                  "Achats d'accessoires": {
+                      "account_number": "4002"
+                  },
+                  "Achats d'autres mati\u00e8res": {
+                      "account_number": "4003"
+                  },
+                  "Achats d'autres auxiliaires et de fournitures d'exploitation": {
+                      "account_number": "4004"
+                  },
+                  "Achats de mat\u00e9riel d'emballage": {
+                      "account_number": "4005"
+                  },
+                  "Travaux de tiers": {
+                      "account_number": "4006"
+                  },
+                  "Charges directes d'achats": {
+                      "account_number": "4007"
+                  },
+                  "Variations de stocks": {
+                      "account_number": "4008"
+                  },
+                  "D\u00e9ductions obtenues": {
+                      "account_number": "4009"
+                  },
+                  "account_number": "400"
+              },
+              "Travaux de tiers": {
+                  "Travaux de tiers": {
+                      "account_number": "4060"
+                  },
+                  "account_number": "406"
+              },
+              "Charge directe d'achat Production": {
+                  "Frais \u00e0 l'achat": {
+                      "account_number": "4070"
+                  },
+                  "Droits de douane \u00e0 l'importation": {
+                      "account_number": "4071"
+                  },
+                  "Frais de transport \u00e0 l'achat": {
+                      "account_number": "4072"
+                  },
+                  "account_number": "407"
+              },
+              "Variation des stocks et pertes de mati\u00e8res": {
+                  "Variations de stocks": {
+                      "account_number": "4080"
+                  },
+                  "Pertes de mati\u00e8res": {
+                      "account_number": "4086"
+                  },
+                  "account_number": "408"
+              },
+              "D\u00e9ductions obtenues sur achats Production": {
+                  "Escomptes sur achats": {
+                      "account_number": "4090"
+                  },
+                  "Rabais et r\u00e9ductions de prix": {
+                      "account_number": "4091"
+                  },
+                  "Ristournes sur achats": {
+                      "account_number": "4092"
+                  },
+                  "Commissions obtenues": {
+                      "account_number": "4093"
+                  },
+                  "Diff\u00e9rences de change": {
+                      "account_number": "4096"
+                  },
+                  "account_number": "409"
+              },
+              "account_number": "40"
+          },
+          "Charges de marchandises": {
+              "Charge de marchandises destin\u00e9es \u00e0 la revente": {
+                  "Achats de marchandises": {
+                      "account_number": "4200"
+                  },
+                  "Achats de mat\u00e9riel d'emballage": {
+                      "account_number": "4205"
+                  },
+                  "Charges directes d'achats": {
+                      "account_number": "4207"
+                  },
+                  "Variations de stocks": {
+                      "account_number": "4208"
+                  },
+                  "D\u00e9ductions obtenues sur achats": {
+                      "account_number": "4209"
+                  },
+                  "account_number": "420"
+              },
+              "Charge directe d'achat Commerce": {
+                  "Frais \u00e0 l'achat": {
+                      "account_number": "4270"
+                  },
+                  "Droits de douane \u00e0 l'importation": {
+                      "account_number": "4271"
+                  },
+                  "Frais de transport \u00e0 l'achat": {
+                      "account_number": "4272"
+                  },
+                  "account_number": "427"
+              },
+              "Variation des stocks et pertes de marchandises": {
+                  "Variations de stocks": {
+                      "account_number": "4280"
+                  },
+                  "Pertes de marchandises": {
+                      "account_number": "4286"
+                  },
+                  "account_number": "428"
+              },
+              "D\u00e9ductions obtenues sur achats Commerce": {
+                  "Escomptes": {
+                      "account_number": "4290"
+                  },
+                  "Rabais et r\u00e9ductions de prix": {
+                      "account_number": "4291"
+                  },
+                  "Ristournes": {
+                      "account_number": "4292"
+                  },
+                  "Commissions obtenues sur achats": {
+                      "account_number": "4293"
+                  },
+                  "Diff\u00e9rences de change": {
+                      "account_number": "4296"
+                  },
+                  "account_number": "429"
+              },
+              "account_number": "42"
+          },
+          "Prestations et travaux de tiers": {
+              "Charges de prestations de tiers": {
+                  "Charges pour prestations de services": {
+                      "account_number": "4400"
+                  },
+                  "Charges directes d'achat": {
+                      "account_number": "4407"
+                  },
+                  "D\u00e9ductions obtenues sur achats": {
+                      "account_number": "4409"
+                  },
+                  "account_number": "440"
+              },
+              "Charges directes d'achat sur prestations de tiers": {
+                  "Charges directes d'achat sur prestations de tiers": {
+                      "account_number": "4470"
+                  },
+                  "account_number": "447"
+              },
+              "D\u00e9ductions obtenues sur prestations de service de tiers": {
+                  "Escomptes": {
+                      "account_number": "4490"
+                  },
+                  "Rabais et r\u00e9ductions de prix": {
+                      "account_number": "4491"
+                  },
+                  "Ristournes": {
+                      "account_number": "4492"
+                  },
+                  "Commissions obtenues sur achats": {
+                      "account_number": "4493"
+                  },
+                  "Diff\u00e9rences de change": {
+                      "account_number": "4496"
+                  },
+                  "account_number": "449"
+              },
+              "account_number": "44"
+          },
+          "Charges d’\u00e9nergie pour l’exploitation": {
+              "Electricit\u00e9": {
+                  "Courant faible": {
+                      "account_number": "4500"
+                  },
+                  "Courant fort": {
+                      "account_number": "4501"
+                  },
+                  "account_number": "450"
+              },
+              "Gaz": {
+                  "Gaz naturel": {
+                      "account_number": "4510"
+                  },
+                  "Gaz liquide en bonbonnes": {
+                      "account_number": "4511"
+                  },
+                  "account_number": "451"
+              },
+              "Combustibles": {
+                  "Mazout": {
+                      "account_number": "4520"
+                  },
+                  "Charbon, briquettes, bois": {
+                      "account_number": "4521"
+                  },
+                  "account_number": "452"
+              },
+              "Carburants": {
+                  "Essence": {
+                      "account_number": "4530"
+                  },
+                  "Diesel": {
+                      "account_number": "4531"
+                  },
+                  "Huile": {
+                      "account_number": "4532"
+                  },
+                  "account_number": "453"
+              },
+              "Eau": {
+                  "Eau": {
+                      "account_number": "4540"
+                  },
+                  "account_number": "454"
+              },
+              "account_number": "45"
+          },
+          "Autres charges pour mat\u00e9riel, marchandises et prestations de tiers": {
+              "Autres charges de mati\u00e8res Production": {
+                  "Autres charges de mati\u00e8res Production": {
+                      "account_number": "4600"
+                  },
+                  "account_number": "460"
+              },
+              "Autres charges de marchandises": {
+                  "Autres charges de marchandises": {
+                      "account_number": "4620"
+                  },
+                  "account_number": "462"
+              },
+              "Autres charges pour prestations de tiers": {
+                  "Autres charges de marchandises": {
+                      "account_number": "4640"
+                  },
+                  "account_number": "464"
+              },
+              "Autres charges d'emballage": {
+                  "Autres charges d'emballage": {
+                      "account_number": "4650"
+                  },
+                  "account_number": "465"
+              },
+              "Variation des provisions pour garantie": {
+                  "Variation des provisions pour garantie": {
+                      "account_number": "4660"
+                  },
+                  "account_number": "466"
+              },
+              "account_number": "46"
+          },
+          "Charges directes d'achats": {
+              "frais \u00e0 l'achat": {
+                  "account_number": "4700"
+              },
+              "Droit de douane": {
+                  "account_number": "4701"
+              },
+              "Frais de transport \u00e0 l'achat": {
+                  "account_number": "4702"
+              },
+              "account_number": "47"
+          },
+          "Variation des stocks, pertes de mati\u00e8res et de marchandises": {
+              "Variation des stocks de mati\u00e8res et marchandises": {
+                  "Variation des stocks de marchandises": {
+                      "account_number": "4800"
+                  },
+                  "Variation des stocks de mati\u00e8res premi\u00e8res": {
+                      "account_number": "4801"
+                  },
+                  "Variation des stocks de mati\u00e8res": {
+                      "account_number": "4802"
+                  },
+                  "Variation des stocks de fournitures d'exploitation": {
+                      "account_number": "4803"
+                  },
+                  "Variation des stocks obligatoires": {
+                      "account_number": "4804"
+                  },
+                  "Variation des stocks de marchandises en consignation": {
+                      "account_number": "4805"
+                  },
+                  "account_number": "480"
+              },
+              "pertes de mati\u00e8res et de marchandises": {
+                  "Pertes de mati\u00e8res": {
+                      "account_number": "4880"
+                  },
+                  "Pertes de marchandises": {
+                      "account_number": "4886"
+                  },
+                  "account_number": "488"
+              },
+              "account_number": "48"
+          },
+          "D\u00e9ductions  obtenues sur achats": {
+              "Escomptes": {
+                  "account_number": "4900"
+              },
+              "Rabais et r\u00e9ductions de prix": {
+                  "account_number": "4901"
+              },
+              "Ristournes": {
+                  "account_number": "4902"
+              },
+              "Commissions obtenues sur achats": {
+                  "account_number": "4903"
+              },
+              "Diff\u00e9rences de change": {
+                  "account_number": "4906"
+              },
+              "account_number": "49"
+          },
+          "root_type": "Expense",
+          "account_number": "4"
+        },
+        "Charges de personnel": {
+          "Charges de personnel Production": {
+              "Charges salariales Production": {
+                  "Salaires": {
+                      "account_number": "5000"
+                  },
+                  "Indemnit\u00e9s": {
+                      "account_number": "5001"
+                  },
+                  "Participations au b\u00e9n\u00e9fice": {
+                      "account_number": "5002"
+                  },
+                  "Commissions": {
+                      "account_number": "5003"
+                  },
+                  "Prestations des assurances sociales": {
+                      "account_number": "5005"
+                  },
+                  "Mise \u00e0 disposition de personnel": {
+                      "account_number": "5006"
+                  },
+                  "Charges sociales": {
+                      "account_number": "5007"
+                  },
+                  "Autres charges de personnel": {
+                      "account_number": "5008"
+                  },
+                  "prestations de tiers": {
+                      "account_number": "5009"
+                  },
+                  "account_number": "500"
+              },
+              "Charges sociales Production": {
+                  "AVS, AI, APG, AC": {
+                      "account_number": "5070"
+                  },
+                  "Caisse d'allocations familiales (CAF)": {
+                      "account_number": "5071"
+                  },
+                  "Pr\u00e9voyance professionnelle": {
+                      "account_number": "5072"
+                  },
+                  "Assurances-accidents": {
+                      "account_number": "5073"
+                  },
+                  "Assurances maladie (indemnit\u00e9 journali\u00e8re maladie)": {
+                      "account_number": "5074"
+                  },
+                  "Imp\u00f4ts \u00e0 la source": {
+                      "account_number": "5079"
+                  },
+                  "account_number": "507"
+              },
+              "Autres charges de personnel Production": {
+                  "Recherche de personnel": {
+                      "account_number": "5080"
+                  },
+                  "Formation et formation continue": {
+                      "account_number": "5081"
+                  },
+                  "Indemnit\u00e9s effectives": {
+                      "account_number": "5082"
+                  },
+                  "Indemnit\u00e9s forfaitaires": {
+                      "account_number": "5083"
+                  },
+                  "Autres charges de personnel": {
+                      "account_number": "5089"
+                  },
+                  "account_number": "508"
+              },
+              "account_number": "50"
+          },
+          "Charges de personnel Commerce": {
+              "Charges salariales Commerce": {
+                  "Salaires": {
+                      "account_number": "5200"
+                  },
+                  "Indemnit\u00e9s": {
+                      "account_number": "5201"
+                  },
+                  "Participations au b\u00e9n\u00e9fice": {
+                      "account_number": "5202"
+                  },
+                  "Commissions": {
+                      "account_number": "5203"
+                  },
+                  "Prestations des assurances sociales": {
+                      "account_number": "5205"
+                  },
+                  "Mise \u00e0 disposition de personnel": {
+                      "account_number": "5206"
+                  },
+                  "Charges sociales": {
+                      "account_number": "5207"
+                  },
+                  "Autres charges de personnel": {
+                      "account_number": "5208"
+                  },
+                  "prestations de tiers": {
+                      "account_number": "5209"
+                  },
+                  "account_number": "520"
+              },
+              "Charges sociales Production": {
+                  "AVS, AI, APG, AC": {
+                      "account_number": "5270"
+                  },
+                  "Caisse d'allocations familiales (CAF)": {
+                      "account_number": "5271"
+                  },
+                  "Pr\u00e9voyance professionnelle": {
+                      "account_number": "5272"
+                  },
+                  "Assurances-accidents": {
+                      "account_number": "5273"
+                  },
+                  "Assurances maladie (indemnit\u00e9 journali\u00e8re maladie)": {
+                      "account_number": "5274"
+                  },
+                  "Imp\u00f4ts \u00e0 la source": {
+                      "account_number": "5279"
+                  },
+                  "account_number": "527"
+              },
+              "Autres charges de personnel Commerce": {
+                  "Recherche de personnel": {
+                      "account_number": "5280"
+                  },
+                  "Formation et formation continue": {
+                      "account_number": "5281"
+                  },
+                  "Indemnit\u00e9s effectives": {
+                      "account_number": "5282"
+                  },
+                  "Indemnit\u00e9s forfaitaires": {
+                      "account_number": "5283"
+                  },
+                  "Autres charges de personnel": {
+                      "account_number": "5289"
+                  },
+                  "account_number": "528"
+              },
+              "Prestations de tiers Commerce": {
+                  "Employ\u00e9s temporaires": {
+                      "account_number": "5290"
+                  },
+                  "account_number": "529"
+              },
+              "account_number": "52"
+          },
+          "Charges de personnel Prestations de services": {
+              "Charges salariales Prestations de services": {
+                  "Salaires": {
+                      "account_number": "5400"
+                  },
+                  "Indemnit\u00e9s": {
+                      "account_number": "5401"
+                  },
+                  "Participations au b\u00e9n\u00e9fice": {
+                      "account_number": "5402"
+                  },
+                  "Commissions": {
+                      "account_number": "5403"
+                  },
+                  "Prestations des assurances sociales": {
+                      "account_number": "5405"
+                  },
+                  "Mise \u00e0 disposition de personnel": {
+                      "account_number": "5406"
+                  },
+                  "Charges sociales": {
+                      "account_number": "5407"
+                  },
+                  "Autres charges de personnel": {
+                      "account_number": "5408"
+                  },
+                  "prestations de tiers": {
+                      "account_number": "5409"
+                  },
+                  "account_number": "540"
+              },
+              "Charges sociales Prestations de services": {
+                  "AVS, AI, APG, AC": {
+                      "account_number": "5470"
+                  },
+                  "Caisse d'allocations familiales (CAF)": {
+                      "account_number": "5471"
+                  },
+                  "Pr\u00e9voyance professionnelle": {
+                      "account_number": "5472"
+                  },
+                  "Assurances-accidents": {
+                      "account_number": "5473"
+                  },
+                  "Assurances maladie (indemnit\u00e9 journali\u00e8re maladie)": {
+                      "account_number": "5474"
+                  },
+                  "Imp\u00f4ts \u00e0 la source": {
+                      "account_number": "5479"
+                  },
+                  "account_number": "547"
+              },
+              "Autres charges de personnel Prestations de services": {
+                  "Recherche de personnel": {
+                      "account_number": "5480"
+                  },
+                  "Formation et formation continue": {
+                      "account_number": "5481"
+                  },
+                  "Indemnit\u00e9s effectives": {
+                      "account_number": "5482"
+                  },
+                  "Indemnit\u00e9s forfaitaires": {
+                      "account_number": "5483"
+                  },
+                  "Autres charges de personnel": {
+                      "account_number": "5489"
+                  },
+                  "account_number": "548"
+              },
+              "Prestations de tiers Prestations de services": {
+                  "Employ\u00e9s temporaires": {
+                      "account_number": "5490"
+                  },
+                  "account_number": "549"
+              },
+              "account_number": "54"
+          },
+          "Charges de personnel Administration": {
+              "Charges salariales Administration": {
+                  "Salaires": {
+                      "account_number": "5600"
+                  },
+                  "Indemnit\u00e9s": {
+                      "account_number": "5601"
+                  },
+                  "Participations au b\u00e9n\u00e9fice": {
+                      "account_number": "5602"
+                  },
+                  "Salaires des membres de la direction de l'entreprise": {
+                      "account_number": "5603"
+                  },
+                  "Salaires/indemnit\u00e9s des membres du conseil d'administration": {
+                      "account_number": "5604"
+                  },
+                  "Prestations des assurances sociales": {
+                      "account_number": "5605"
+                  },
+                  "Mise \u00e0 disposition de personnel": {
+                      "account_number": "5606"
+                  },
+                  "Charges sociales": {
+                      "account_number": "5607"
+                  },
+                  "Autres charges de personnel": {
+                      "account_number": "5608"
+                  },
+                  "prestations de tiers": {
+                      "account_number": "5609"
+                  },
+                  "account_number": "560"
+              },
+              "Charges sociales Administration": {
+                  "AVS, AI, APG, AC": {
+                      "account_number": "5670"
+                  },
+                  "Caisse d'allocations familiales (CAF)": {
+                      "account_number": "5671"
+                  },
+                  "Pr\u00e9voyance professionnelle": {
+                      "account_number": "5672"
+                  },
+                  "Assurances-accidents": {
+                      "account_number": "5673"
+                  },
+                  "Assurances maladie (indemnit\u00e9 journali\u00e8re maladie)": {
+                      "account_number": "5674"
+                  },
+                  "Imp\u00f4ts \u00e0 la source": {
+                      "account_number": "5679"
+                  },
+                  "account_number": "567"
+              },
+              "Autres charges de personnel Administration": {
+                  "Recherche de personnel": {
+                      "account_number": "5680"
+                  },
+                  "Formation et formation continue": {
+                      "account_number": "5681"
+                  },
+                  "Indemnit\u00e9s effectives": {
+                      "account_number": "5682"
+                  },
+                  "Indemnit\u00e9s forfaitaires": {
+                      "account_number": "5683"
+                  },
+                  "Autres charges de personnel": {
+                      "account_number": "5689"
+                  },
+                  "account_number": "568"
+              },
+              "Prestations de tiers Administration": {
+                  "Employ\u00e9s temporaires": {
+                      "account_number": "5690"
+                  },
+                  "account_number": "569"
+              },
+              "account_number": "56"
+          },
+          "Charges de personnel Administration": {
+              "Charges sociales": {
+                  "AVS, AI, APG, AC": {
+                      "account_number": "5770"
+                  },
+                  "Caisse d'allocations familiales (CAF)": {
+                      "account_number": "5771"
+                  },
+                  "Pr\u00e9voyance professionnelle": {
+                      "account_number": "5772"
+                  },
+                  "Assurances-accidents": {
+                      "account_number": "5773"
+                  },
+                  "Assurances maladie (indemnit\u00e9 journali\u00e8re maladie)": {
+                      "account_number": "5774"
+                  },
+                  "Imp\u00f4ts \u00e0 la source": {
+                      "account_number": "5779"
+                  },
+                  "account_number": "577"
+              },
+              "account_number": "57"
+          },
+          "Autres charges de personnel": {
+              "Recherche de personnel": {
+                  "Annonces pour recherche de personnel": {
+                      "account_number": "5800"
+                  },
+                  "Commissions pour recherche de personnel": {
+                      "account_number": "5801"
+                  },
+                  "account_number": "580"
+              },
+              "Formation et formation continue": {
+                  "Formation obligatoire": {
+                      "account_number": "5810"
+                  },
+                  "Formation continue/perfectionnement": {
+                      "account_number": "5811"
+                  },
+                  "account_number": "581"
+              },
+              "Indemnit\u00e9s effectives": {
+                  "Frais de voyages": {
+                      "account_number": "5820"
+                  },
+                  "Frais de repas": {
+                      "account_number": "5821"
+                  },
+                  "Frais de logement": {
+                      "account_number": "5822"
+                  },
+                  "account_number": "582"
+              },
+              "Indemnit\u00e9s forfaitaires": {
+                  "Indemnit\u00e9s forfaitaires pour les cadres": {
+                      "account_number": "5830"
+                  },
+                  "Indemnit\u00e9s forfaitaires pour les membres de la direction de l'entreprise": {
+                      "account_number": "5831"
+                  },
+                  "Indemnit\u00e9s forfaitaires pour les membres du conseil d'administration": {
+                      "account_number": "5832"
+                  },
+                  "account_number": "583"
+              },
+              "Restaurant d'entreprise/cantine": {
+                  "Repas au restaurant d'entreprise": {
+                      "account_number": "5840"
+                  },
+                  "Boissons au restaurant d'entreprise": {
+                      "account_number": "5841"
+                  },
+                  "Produits des repas (comme diminution de charges)": {
+                      "account_number": "5845"
+                  },
+                  "Produits des boissons (comme diminution de charges)": {
+                      "account_number": "5846"
+                  },
+                  "account_number": "584"
+              },
+              "Autres charges de personnel": {
+                  "Manifestations en faveur du personnel": {
+                      "account_number": "5880"
+                  },
+                  "Frais li\u00e9s \u00e0 des activit\u00e9s sportives": {
+                      "account_number": "5881"
+                  },
+                  "account_number": "588"
+              },
+              "Parts priv\u00e9es sur charges de personnel": {
+                  "Parts priv\u00e9es sur charges de personnel": {
+                      "account_number": "5890"
+                  },
+                  "account_number": "589"
+              },
+              "account_number": "58"
+          },
+          "Prestations de tiers/temporaires": {
+              "Prestations de tiers": {
+                  "account_number": "5900"
+              },
+              "Employ\u00e9s temporaires": {
+                  "account_number": "5901"
+              },
+              "account_number": "59"
+          },
+          "root_type": "Expense",
+          "account_number": "5"
+        },
+        "Autres charges d’exploitation, amortissements et corrections de valeur, r\u00e9sultat financier": {
+          "Charges de locaux": {
+              "Loyers pour locaux de tiers": {
+                  "Loyer des usines": {
+                      "account_number": "6000"
+                  },
+                  "Loyer des ateliers": {
+                      "account_number": "6001"
+                  },
+                  "Loyer des entrep\u00f4ts": {
+                      "account_number": "6002"
+                  },
+                  "Loyer des bâtiments d'exposition et de vente": {
+                      "account_number": "6003"
+                  },
+                  "Loyer des bâtiments de bureau et d'administration": {
+                      "account_number": "6004"
+                  },
+                  "Loyer des locaux du personnel": {
+                      "account_number": "6005"
+                  },
+                  "Loyer du garage, du parking": {
+                      "account_number": "6006"
+                  },
+                  "account_number": "600"
+              },
+              "Loyers pour propres locaux": {
+                  "Valeur locative des usines": {
+                      "account_number": "6010"
+                  },
+                  "Valeur locative des ateliers": {
+                      "account_number": "6011"
+                  },
+                  "Valeur locative des entrep\u00f4ts": {
+                      "account_number": "6012"
+                  },
+                  "Valeur locative des bâtiments d'exposition et de vente": {
+                      "account_number": "6013"
+                  },
+                  "Valeur locative des bâtiments de bureau et d'administration": {
+                      "account_number": "6014"
+                  },
+                  "Valeur locative des locaux du personnel": {
+                      "account_number": "6015"
+                  },
+                  "Valeur locative du garage, du parking": {
+                      "account_number": "6016"
+                  },
+                  "account_number": "601"
+              },
+              "Charges accessoires": {
+                  "Charges accessoires de chauffage": {
+                      "account_number": "6030"
+                  },
+                  "Charges accessoires d'\u00e9lectricit\u00e9, de gaz, d'eau": {
+                      "account_number": "6031"
+                  },
+                  "Charges accessoires de conciergerie": {
+                      "account_number": "6032"
+                  },
+                  "Charges accessoires des bâtiments d'exposition et de vente": {
+                      "account_number": "6033"
+                  },
+                  "Charges accessoires des bâtiments de bureau et d'administration": {
+                      "account_number": "6034"
+                  },
+                  "Charges accessoires des locaux du personnel": {
+                      "account_number": "6035"
+                  },
+                  "Charges accessoires du garage": {
+                      "account_number": "6036"
+                  },
+                  "account_number": "603"
+              },
+              "Nettoyage": {
+                  "Personnel de nettoyage": {
+                      "account_number": "6040"
+                  },
+                  "Nettoyage effectu\u00e9 par des tiers": {
+                      "account_number": "6041"
+                  },
+                  "Mat\u00e9riel de nettoyage": {
+                      "account_number": "6042"
+                  },
+                  "Nettoyage des bâtiments d'exposition et de vente": {
+                      "account_number": "6043"
+                  },
+                  "Nettoyage des bâtiments de bureau et d'administration": {
+                      "account_number": "6044"
+                  },
+                  "Nettoyage des locaux du personnel": {
+                      "account_number": "6045"
+                  },
+                  "account_number": "604"
+              },
+              "Charges d'entretien des locaux": {
+                  "R\u00e9paration": {
+                      "account_number": "6050"
+                  },
+                  "Investissements de moindre importance": {
+                      "account_number": "6051"
+                  },
+                  "Abonnements d'entretien": {
+                      "account_number": "6052"
+                  },
+                  "Nettoyage des bâtiments d'exposition et de vente": {
+                      "account_number": "6053"
+                  },
+                  "Nettoyage des bâtiments de bureau et d'administration": {
+                      "account_number": "6054"
+                  },
+                  "Nettoyage des locaux du personnel": {
+                      "account_number": "6055"
+                  },
+                  "Entretien du garage": {
+                      "account_number": "6056"
+                  },
+                  "account_number": "605"
+              },
+              "Immobilisations en leasing": {
+                  "Usine en leasing": {
+                      "account_number": "6060"
+                  },
+                  "Atelier en leasing": {
+                      "account_number": "6061"
+                  },
+                  "Entrep\u00f4t en leasing": {
+                      "account_number": "6062"
+                  },
+                  "Bâtiments d'exposition et de vente en leasing": {
+                      "account_number": "6063"
+                  },
+                  "Bâtiments de bureau et d'administration en leasing": {
+                      "account_number": "6064"
+                  },
+                  "Locaux de personnel en leasing": {
+                      "account_number": "6065"
+                  },
+                  "Garage en leasing": {
+                      "account_number": "6066"
+                  },
+                  "account_number": "606"
+              },
+              "Parts priv\u00e9es sur charges de locaux": {
+                  "Parts priv\u00e9es sur charges de chauffage, d'\u00e9clairage, de nettoyage": {
+                      "account_number": "6090"
+                  },
+                  "account_number": "609"
+              },
+              "account_number": "60"
+          },
+          "Entretien, r\u00e9parations, remplacements (ERR); leasing immobilisations corporelles": {
+              "ERR machines et appareils de production": {
+                  "account_number": "6100"
+              },
+              "ERR mobilier et installations": {
+                  "account_number": "6101"
+              },
+              "ERR outils et mat\u00e9riel": {
+                  "account_number": "6102"
+              },
+              "Leasing \u00e9quipement de production": {
+                  "account_number": "6105"
+              },
+              "ERR installations des magasins": {
+                  "account_number": "6110"
+              },
+              "ERR installations de locaux d'exposition": {
+                  "account_number": "6111"
+              },
+              "Leasing du mobilier de vente": {
+                  "account_number": "6115"
+              },
+              "ERR d\u00e9p\u00f4t central": {
+                  "account_number": "6120"
+              },
+              "Leasing d'\u00e9quipements de d\u00e9p\u00f4ts": {
+                  "account_number": "6125"
+              },
+              "ERR mobilier de bureau": {
+                  "account_number": "6130"
+              },
+              "ERR machines de bureau": {
+                  "account_number": "6131"
+              },
+              "ERR informatique": {
+                  "account_number": "6132"
+              },
+              "ERR technologies de communication": {
+                  "account_number": "6133"
+              },
+              "Leasing d'installations de bureau": {
+                  "account_number": "6135"
+              },
+              "ERR mobilier du restaurant du personnel": {
+                  "account_number": "6141"
+              },
+              "Leasing des installations du personnel": {
+                  "account_number": "6145"
+              },
+              "account_number": "61"
+          },
+          "Charge de v\u00e9hicules et de transport": {
+              "Charges de v\u00e9hicules": {
+                  "R\u00e9paration": {
+                      "account_number": "6200"
+                  },
+                  "Service": {
+                      "account_number": "6201"
+                  },
+                  "Nettoyage": {
+                      "account_number": "6202"
+                  },
+                  "Essence": {
+                      "account_number": "6210"
+                  },
+                  "Diesel": {
+                      "account_number": "6211"
+                  },
+                  "Huile": {
+                      "account_number": "6212"
+                  },
+                  "Assurance responsabilit\u00e9 civile": {
+                      "account_number": "6220"
+                  },
+                  "Assurance casco": {
+                      "account_number": "6221"
+                  },
+                  "Assurance protection juridique": {
+                      "account_number": "6222"
+                  },
+                  "Assurance incendie": {
+                      "account_number": "6223"
+                  },
+                  "Taxes de circulation": {
+                      "account_number": "6230"
+                  },
+                  "Cotisations": {
+                      "account_number": "6231"
+                  },
+                  "Taxes": {
+                      "account_number": "6232"
+                  },
+                  "V\u00e9hicules en leasing": {
+                      "account_number": "6260"
+                  },
+                  "Location de v\u00e9hicules": {
+                      "account_number": "6264"
+                  },
+                  "Parts priv\u00e9es sur charges de v\u00e9hicules": {
+                      "account_number": "6270"
+                  },
+                  "account_number": "620"
+              },
+              "Charges de v\u00e9hicules": {
+                  "Frais": {
+                      "account_number": "6280"
+                  },
+                  "Frais de transport": {
+                      "account_number": "6281"
+                  },
+                  "Cargo domicile": {
+                      "account_number": "6282"
+                  },
+                  "account_number": "628"
+              },
+              "account_number": "62"
+          },
+          "Assurances-choses, droits, taxes, autorisations": {
+              "Assurances-choses": {
+                  "Assurance pour dommages naturels": {
+                      "account_number": "6300"
+                  },
+                  "Assurances pour bris de glace": {
+                      "account_number": "6301"
+                  },
+                  "Assurance vols": {
+                      "account_number": "6302"
+                  },
+                  "Assurance responsabilit\u00e9 civile": {
+                      "account_number": "6310"
+                  },
+                  "Assurance garantie": {
+                      "account_number": "6311"
+                  },
+                  "Assurance protection juridique": {
+                      "account_number": "6312"
+                  },
+                  "Assurance pour pertes d'exploitation": {
+                      "account_number": "6320"
+                  },
+                  "Primes pour assurance-vie": {
+                      "account_number": "6330"
+                  },
+                  "Primes pour cautionnement": {
+                      "account_number": "6331"
+                  },
+                  "account_number": "630"
+              },
+              "Droits, taxes et autorisations": {
+                  "Droits": {
+                      "account_number": "6360"
+                  },
+                  "Taxes": {
+                      "account_number": "6361"
+                  },
+                  "Autorisations": {
+                      "account_number": "6370"
+                  },
+                  "Patentes": {
+                      "account_number": "6371"
+                  },
+                  "account_number": "636"
+              },
+              "account_number": "63"
+          },
+          "Charges d’\u00e9nergie et \u00e9vacuation des d\u00e9chets": {
+              "Charges d'\u00e9nergie": {
+                  "Courant fort": {
+                      "account_number": "6400"
+                  },
+                  "Courant faible": {
+                      "account_number": "6401"
+                  },
+                  "Eclairage": {
+                      "account_number": "6402"
+                  },
+                  "Gaz naturel": {
+                      "account_number": "6410"
+                  },
+                  "Gaz liquide en bonbonnes": {
+                      "account_number": "6411"
+                  },
+                  "Mazout": {
+                      "account_number": "6420"
+                  },
+                  "Charbon, briquettes, bois": {
+                      "account_number": "6421"
+                  },
+                  "Eau": {
+                      "account_number": "6430"
+                  },
+                  "account_number": "640"
+              },
+              "Evacuation des d\u00e9chets": {
+                  "Evacuation de d\u00e9chets": {
+                      "account_number": "6460"
+                  },
+                  "Evacuation de d\u00e9chets sp\u00e9ciaux": {
+                      "account_number": "6461"
+                  },
+                  "Eaux us\u00e9es": {
+                      "account_number": "6462"
+                  },
+                  "account_number": "646"
+              },
+              "account_number": "64"
+          },
+          "Charges d’administration et d'informatique": {
+              "Charges d'administration": {
+                  "Mat\u00e9riel de bureau": {
+                      "account_number": "6500"
+                  },
+                  "Imprim\u00e9s": {
+                      "account_number": "6501"
+                  },
+                  "Photocopies": {
+                      "account_number": "6502"
+                  },
+                  "Litt\u00e9rature sp\u00e9cialis\u00e9e, journaux, magazines": {
+                      "account_number": "6503"
+                  },
+                  "T\u00e9l\u00e9phone": {
+                      "account_number": "6510"
+                  },
+                  "Internet": {
+                      "account_number": "6512"
+                  },
+                  "Frais de port": {
+                      "account_number": "6513"
+                  },
+                  "Cotisations": {
+                      "account_number": "6520"
+                  },
+                  "Dons et cadeaux": {
+                      "account_number": "6521"
+                  },
+                  "Pourboires": {
+                      "account_number": "6522"
+                  },
+                  "Honoraires pour la tenue de la comptabilit\u00e9": {
+                      "account_number": "6530"
+                  },
+                  "Honoraires pour conseil en gestion d'entreprise": {
+                      "account_number": "6531"
+                  },
+                  "Honoraires pour conseil juridique": {
+                      "account_number": "6532"
+                  },
+                  "Charges du conseil d'administration": {
+                      "account_number": "6540"
+                  },
+                  "Charges de l'assembl\u00e9e g\u00e9n\u00e9rale": {
+                      "account_number": "6541"
+                  },
+                  "Charges de l'organe de r\u00e9vision": {
+                      "account_number": "6542"
+                  },
+                  "Frais de fondation, d'augmentation de capital et d'organisation": {
+                      "account_number": "6550"
+                  },
+                  "Frais de recouvrement": {
+                      "account_number": "6551"
+                  },
+                  "Autres frais d'administration": {
+                      "account_number": "6559"
+                  },
+                  "account_number": "650"
+              },
+              "Frais informatiques": {
+                  "Leasing Hardware": {
+                      "account_number": "6570"
+                  },
+                  "Leasing Software": {
+                      "account_number": "6571"
+                  },
+                  "Location de mat\u00e9riel": {
+                      "account_number": "6572"
+                  },
+                  "Charges de licences et de mise \u00e0 jour": {
+                      "account_number": "6580"
+                  },
+                  "Maintenance/Hotline hardware": {
+                      "account_number": "6581"
+                  },
+                  "Maintenance/Hotline software": {
+                      "account_number": "6582"
+                  },
+                  "Consommables": {
+                      "account_number": "6583"
+                  },
+                  "Frais de r\u00e9seau informatique": {
+                      "account_number": "6585"
+                  },
+                  "Conseils en d\u00e9veloppement de strat\u00e9gie": {
+                      "account_number": "6590"
+                  },
+                  "D\u00e9veloppement individualis\u00e9, adaptation individualis\u00e9e": {
+                      "account_number": "6591"
+                  },
+                  "Charges d'installation": {
+                      "account_number": "6592"
+                  },
+                  "account_number": "657"
+              },
+              "account_number": "65"
+          },
+          "Charges de publicit\u00e9": {
+              "Publicit\u00e9, m\u00e9dia \u00e9lectronique": {
+                  "Publicit\u00e9 dans les journaux": {
+                      "account_number": "6600"
+                  },
+                  "Publicit\u00e9 \u00e0 la radio": {
+                      "account_number": "6601"
+                  },
+                  "Publicit\u00e9 \u00e0 la t\u00e9l\u00e9vision": {
+                      "account_number": "6602"
+                  },
+                  "Publicit\u00e9 sur internet": {
+                      "account_number": "6604"
+                  },
+                  "account_number": "660"
+              },
+              "Imprim\u00e9s publicitaires, mat\u00e9riel de publicit\u00e9, articles de publicit\u00e9, \u00e9chantillons": {
+                  "Imprim\u00e9s publicitaires, mat\u00e9riel de publicit\u00e9": {
+                      "account_number": "6610"
+                  },
+                  "Articles de publicit\u00e9, \u00e9chantillons": {
+                      "account_number": "6611"
+                  },
+                  "account_number": "661"
+              },
+              "Vitrines, d\u00e9coration, foires, expositions": {
+                  "Vitrines, d\u00e9coration": {
+                      "account_number": "6620"
+                  },
+                  "Foires, expositions": {
+                      "account_number": "6621"
+                  },
+                  "account_number": "662"
+              },
+              "Frais de d\u00e9placement, service \u00e0 la client\u00e8le": {
+                  "Frais de d\u00e9placement": {
+                      "account_number": "6640"
+                  },
+                  "Service \u00e0 la client\u00e8le": {
+                      "account_number": "6641"
+                  },
+                  "Cadeaux \u00e0 la client\u00e8le": {
+                      "account_number": "6642"
+                  },
+                  "account_number": "664"
+              },
+              "Publicit\u00e9, sponsoring": {
+                  "Annonces publicitaires": {
+                      "account_number": "6660"
+                  },
+                  "Sponsoring": {
+                      "account_number": "6661"
+                  },
+                  "account_number": "666"
+              },
+              "Relations publiques": {
+                  "Manifestations en faveur de la client\u00e8le": {
+                      "account_number": "6670"
+                  },
+                  "Contacts avec les m\u00e9dias": {
+                      "account_number": "6671"
+                  },
+                  "Anniversaire de l'entreprise": {
+                      "account_number": "6672"
+                  },
+                  "account_number": "667"
+              },
+              "Conseils en publicit\u00e9, \u00e9tudes de march\u00e9": {
+                  "Conseils en publicit\u00e9": {
+                      "account_number": "6680"
+                  },
+                  "Etudes de march\u00e9": {
+                      "account_number": "6681"
+                  },
+                  "account_number": "668"
+              },
+              "Charge de publicit\u00e9 comme pr\u00e9l\u00e8vements \u00e0 titre priv\u00e9": {
+                  "Charge de publicit\u00e9 comme pr\u00e9l\u00e8vements \u00e0 titre priv\u00e9": {
+                      "account_number": "6690"
+                  },
+                  "account_number": "669"
+              },
+              "account_number": "66"
+          },
+          "Autres charges d’exploitation": {
+              "Informations \u00e9conomiques, poursuites": {
+                  "Informations \u00e9conomiques": {
+                      "account_number": "6700"
+                  },
+                  "Poursuites": {
+                      "account_number": "6701"
+                  },
+                  "account_number": "670"
+              },
+              "S\u00e9curit\u00e9 et surveillance": {
+                  "S\u00e9curit\u00e9": {
+                      "account_number": "6710"
+                  },
+                  "Surveillance": {
+                      "account_number": "6711"
+                  },
+                  "account_number": "671"
+              },
+              "Recherche et d\u00e9veloppement": {
+                  "Recherche": {
+                      "account_number": "6720"
+                  },
+                  "D\u00e9veloppement": {
+                      "account_number": "6721"
+                  },
+                  "account_number": "672"
+              },
+              "Correction de l'imp\u00f4t pr\u00e9alable (lors d'utilisation mixte)": {
+                  "Correction de l'imp\u00f4t pr\u00e9alable (lors d'utilisation mixte)": {
+                      "account_number": "6740"
+                  },
+                  "account_number": "674"
+              },
+              "Autres charges d'exploitation et pr\u00e9l\u00e8vements \u00e0 titre priv\u00e9": {
+                  "Autres charges d'exploitation": {
+                      "account_number": "6790"
+                  },
+                  "Pr\u00e9l\u00e8vements \u00e0 titre priv\u00e9": {
+                      "account_number": "6791"
+                  },
+                  "account_number": "679"
+              },
+              "account_number": "67"
+          },
+          "Amortissements et corrections de la valeur des actifs immobilis\u00e9s": {
+              "Ajustement de la valeur des immobilisations financi\u00e8res": {
+                  "Ajustement de la valeur des titres des actifs immobilis\u00e9s": {
+                      "account_number": "6800"
+                  },
+                  "Ajustement de la valeur des autres immobilisations financi\u00e8res": {
+                      "account_number": "6801"
+                  },
+                  "Ajustement de la valeur des cr\u00e9ances \u00e0 long terme envers des tiers": {
+                      "account_number": "6804"
+                  },
+                  "Ajustement de la valeur des cr\u00e9ances \u00e0 long terme envers des participations": {
+                      "account_number": "6805"
+                  },
+                  "Ajustement de la valeur des cr\u00e9ances \u00e0 long terme envers les parties prenantes et les organes": {
+                      "account_number": "6806"
+                  },
+                  "account_number": "680"
+              },
+              "Ajustement de la valeur des participations": {
+                  "Ajustement de la valeur de la participation": {
+                      "account_number": "6810"
+                  },
+                  "account_number": "681"
+              },
+              "Amortissement et ajustement de la valeur sur actifs meubles": {
+                  "Amortissement et ajustement de la valeur des machines et appareils": {
+                      "account_number": "6820"
+                  },
+                  "Amortissement et ajustement de la valeur du mobilier et des installations": {
+                      "account_number": "6821"
+                  },
+                  "Amortissement et ajustement de la valeur des machines de bureau, informatique et syst\u00e8me de communication": {
+                      "account_number": "6822"
+                  },
+                  "Amortissement et ajustement de la valeur des v\u00e9hicules": {
+                      "account_number": "6823"
+                  },
+                  "Amortissement et ajustement de la valeur des ateliers et \u00e9quipements": {
+                      "account_number": "6824"
+                  },
+                  "Amortissement et ajustement de la valeur \u00e9quipements d'entrep\u00f4ts": {
+                      "account_number": "6825"
+                  },
+                  "Amortissement et ajustement de la valeur des installations fixes et \u00e9quipements": {
+                      "account_number": "6827"
+                  },
+                  "Amortissement et ajustement de la valeur des autres \u00e9quipements": {
+                      "account_number": "6829"
+                  },
+                  "account_number": "682"
+              },
+              "Amortissement et ajustement de la valeur des immobilisations corporelles immeubles": {
+                  "Amortissement et ajustement de la valeur des immeubles d'exploitation": {
+                      "account_number": "6830"
+                  },
+                  "Amortissement et ajustement de la valeur des usines": {
+                      "account_number": "6831"
+                  },
+                  "Amortissement et ajustement de la valeur des ateliers et \u00e9quipements": {
+                      "account_number": "6832"
+                  },
+                  "Amortissement et ajustement de la valeur des entrep\u00f4ts": {
+                      "account_number": "6833"
+                  },
+                  "Amortissement et ajustement de la valeur des bâtiments d'exposition et de vente": {
+                      "account_number": "6834"
+                  },
+                  "Amortissement et ajustement de la valeur des bâtiments administratifs": {
+                      "account_number": "6835"
+                  },
+                  "Amortissement et ajustement de la valeur des immeubles d'habitation": {
+                      "account_number": "6836"
+                  },
+                  "Correction de la valeur des biens-fonds non bâtis": {
+                      "account_number": "6879"
+                  },
+                  "account_number": "683"
+              },
+              "Amortissement et ajustement de la valeur des immobilisations incorporelles": {
+                  "Amortissement et ajustement de la valeur des brevets, know-how, recettes de fabrication": {
+                      "account_number": "6840"
+                  },
+                  "Amortissement et ajustement de la valeur des marques commerciales, \u00e9chantillons, mod\u00e8les, plans": {
+                      "account_number": "6841"
+                  },
+                  "Amortissement et ajustement de la valeur des droits de licences, concessions, droits de jouissance, raisons de commerce": {
+                      "account_number": "6842"
+                  },
+                  "Amortissement et ajustement de la valeur des droits de propri\u00e9t\u00e9 intellectuelle, droits d'\u00e9dition, droits conventionnels": {
+                      "account_number": "6843"
+                  },
+                  "Amortissement et ajustement de la valeur des d\u00e9veloppements sp\u00e9cifiques": {
+                      "account_number": "6845"
+                  },
+                  "Amortissement et ajustement de la valeur du goodwill": {
+                      "account_number": "6847"
+                  },
+                  "Amortissement et ajustement de la valeur des autres immobilisations incorporelles": {
+                      "account_number": "6849"
+                  },
+                  "account_number": "684"
+              },
+              "account_number": "68"
+          },
+          "Charges et produits financiers": {
+              "Charges financi\u00e8res": {
+                  "Int\u00e9r\u00eats d\u00e9biteurs sur cr\u00e9dit bancaire": {
+                      "account_number": "6900"
+                  },
+                  "Int\u00e9r\u00eats d\u00e9biteurs sur emprunts": {
+                      "account_number": "6901"
+                  },
+                  "Int\u00e9r\u00eats hypoth\u00e9caires": {
+                      "account_number": "6902"
+                  },
+                  "Int\u00e9r\u00eats moratoires": {
+                      "account_number": "6903"
+                  },
+                  "Charge d'int\u00e9r\u00eats pour acomptes de clients": {
+                      "account_number": "6904"
+                  },
+                  "Charge d'int\u00e9r\u00eats sur leasing financier": {
+                      "account_number": "6905"
+                  },
+                  "Charge d'int\u00e9r\u00eats sur compte courant envers les actionnaires": {
+                      "account_number": "6920"
+                  },
+                  "Charge d'int\u00e9r\u00eats sur pr\u00eat envers les actionnaires": {
+                      "account_number": "6921"
+                  },
+                  "Charge d'int\u00e9r\u00eats sur compte courant envers les administrateurs": {
+                      "account_number": "6922"
+                  },
+                  "Charge d'int\u00e9r\u00eats sur pr\u00eat envers les administrateurs": {
+                      "account_number": "6923"
+                  },
+                  "Charge d'int\u00e9r\u00eats sur compte courant envers les membres de la direction": {
+                      "account_number": "6924"
+                  },
+                  "Charge d'int\u00e9r\u00eats sur pr\u00eat envers les membres de la direction": {
+                      "account_number": "6925"
+                  },
+                  "Charge d'int\u00e9r\u00eats sur emprunts aupr\u00e8s d'institutions de pr\u00e9voyance professionnelle": {
+                      "account_number": "6930"
+                  },
+                  "Frais bancaires": {
+                      "account_number": "6940"
+                  },
+                  "Droit de garde": {
+                      "account_number": "6941"
+                  },
+                  "Pertes sur tr\u00e9sorerie et titre avec cours boursier": {
+                      "account_number": "6942"
+                  },
+                  "Pertes sur immobilisations financi\u00e8res": {
+                      "account_number": "6943"
+                  },
+                  "Escomptes accord\u00e9s aux clients": {
+                      "account_number": "6945"
+                  },
+                  "Pertes de change": {
+                      "account_number": "6949"
+                  },
+                  "account_number": "690"
+              },
+              "Produits Financiers": {
+                  "Produits financiers sur avoir en banque": {
+                      "account_number": "6950"
+                  },
+                  "Produits financiers sur avoir \u00e0 court terme": {
+                      "account_number": "6951"
+                  },
+                  "Produits financiers sur titres r\u00e9alisables \u00e0 court terme": {
+                      "account_number": "6952"
+                  },
+                  "Produits financiers sur autres placements \u00e0 court terme": {
+                      "account_number": "6953"
+                  },
+                  "Produits financiers sur titre": {
+                      "account_number": "6960"
+                  },
+                  "Produits financiers sur autres immobilisations financi\u00e8res": {
+                      "account_number": "6961"
+                  },
+                  "Produits financiers sur participations": {
+                      "account_number": "6962"
+                  },
+                  "Produits financiers sur cr\u00e9ances \u00e0 long terme envers des tiers": {
+                      "account_number": "6963"
+                  },
+                  "Produits du compte courant envers les actionnaires": {
+                      "account_number": "6980"
+                  },
+                  "Produits des pr\u00eats envers les actionnaires": {
+                      "account_number": "6981"
+                  },
+                  "Produits du compte courant envers les administrateurs": {
+                      "account_number": "6982"
+                  },
+                  "Produits des pr\u00eats envers les administrateurs": {
+                      "account_number": "6983"
+                  },
+                  "Produits du compte courant envers les membres de la direction": {
+                      "account_number": "6984"
+                  },
+                  "Produits des pr\u00eats envers les membres de la direction": {
+                      "account_number": "6985"
+                  },
+                  "Produits financiers r\u00e9sultant d'int\u00e9r\u00eats moratoires et d'escomptes": {
+                      "account_number": "6990"
+                  },
+                  "Produits financiers sur acomptes vers\u00e9s": {
+                      "account_number": "6991"
+                  },
+                  "Gains sur titres d\u00e9tenus \u00e0 court terme cot\u00e9s en bourse": {
+                      "account_number": "6992"
+                  },
+                  "Gains sur immobilisations financi\u00e8res": {
+                      "account_number": "6994"
+                  },
+                  "Remises de fournisseurs": {
+                      "account_number": "6995"
+                  },
+                  "Gains de change": {
+                      "account_number": "6999"
+                  },
+                  "account_number": "695"
+              },
+          "account_number": "69"
+          },
+          "root_type": "Expense",
+          "account_number": "6"
+        },
+        "R\u00e9sultat des activit\u00e9s annexes d’exploitation": {
+          "Produits accessoires": {
+              "Produits accessoires": {
+                  "Produits bruts": {
+                      "account_number": "7000"
+                  },
+                  "Diminutions de produits": {
+                      "account_number": "7009"
+                  },
+                  "Charges de mati\u00e8re": {
+                      "account_number": "7010"
+                  },
+                  "Charges de personnel": {
+                      "account_number": "7011"
+                  },
+                  "Charges de locaux": {
+                      "account_number": "7012"
+                  },
+                  "Charges d'entretien, de r\u00e9parations, de remplacements, leasing": {
+                      "account_number": "7013"
+                  },
+                  "Charge de v\u00e9hicules et de transport": {
+                      "account_number": "7014"
+                  },
+                  "Assurances-choses, droits, taxes, autorisations et patentes": {
+                      "account_number": "7015"
+                  },
+                  "Charges d'\u00e9nergie et \u00e9vacuation des d\u00e9chets": {
+                      "account_number": "7016"
+                  },
+                  "Charges d'administration et d'informatique": {
+                      "account_number": "7017"
+                  },
+                  "Charges de publicit\u00e9": {
+                      "account_number": "7018"
+                  },
+                  "Autres charges": {
+                      "account_number": "7019"
+                  },
+                  "account_number": "700"
+              },
+              "account_number": "70"
+          },
+          "R\u00e9sultat d'immeubles": {
+              "Produits des immeubles d'exploitation": {
+                  "Valeur locative pour locaux d'exploitation": {
+                      "account_number": "7500"
+                  },
+                  "Valeur locative pour locaux d'habitation": {
+                      "account_number": "7501"
+                  },
+                  "Loyers de locaux d'exploitation": {
+                      "account_number": "7502"
+                  },
+                  "Loyers des appartements": {
+                      "account_number": "7503"
+                  },
+                  "Loyers des garages": {
+                      "account_number": "7504"
+                  },
+                  "Loyers (impos\u00e9s par option)": {
+                      "account_number": "7505"
+                  },
+                  "Participation aux frais de chauffage et d'\u00e9clairage": {
+                      "account_number": "7508"
+                  },
+                  "Autres revenus d'immeubles": {
+                      "account_number": "7509"
+                  },
+                  "Int\u00e9r\u00eats hypoth\u00e9caires": {
+                      "account_number": "7510"
+                  },
+                  "Entretien de l'immeuble": {
+                      "account_number": "7511"
+                  },
+                  "Droits, taxes, imp\u00f4ts fonciers": {
+                      "account_number": "7512"
+                  },
+                  "Primes d'assurance": {
+                      "account_number": "7513"
+                  },
+                  "Eau": {
+                      "account_number": "7514"
+                  },
+                  "Ordures, \u00e9vacuation des d\u00e9chets": {
+                      "account_number": "7515"
+                  },
+                  "Charges d'administration": {
+                      "account_number": "7516"
+                  },
+                  "Chauffage et \u00e9clairage": {
+                      "account_number": "7517"
+                  },
+                  "Amortissements et corrections de la valeur": {
+                      "account_number": "7518"
+                  },
+                  "Autres charges d'immeubles": {
+                      "account_number": "7519"
+                  },
+                  "account_number": "750"
+              },
+              "account_number": "75"
+          },
+          "root_type": "Expense",
+          "account_number": "7"
+        },
+        "R\u00e9sultats exceptionnels et hors exploitation": {
+          "R\u00e9sultats hors exploitation": {
+              "Charges hors exploitation": {
+                  "Charges hors exploitation": {
+                      "account_number": "8000"
+                  },
+                  "account_number": "800"
+              },
+              "Produits hors exploitation": {
+                  "Produits hors exploitation": {
+                      "account_number": "8100"
+                  },
+                  "account_number": "810"
+              },
+              "account_number": "80"
+          },
+          "Charges et produits exceptionnels, uniques ou hors p\u00e9riode": {
+              "Charges et produits exceptionnels": {
+                  "Dotations exceptionnelles aux r\u00e9serves": {
+                      "account_number": "8500"
+                  },
+                  "Provisions exceptionnelles": {
+                      "account_number": "8501"
+                  },
+                  "Amortissements et corrections exceptionnelles de la valeur": {
+                      "account_number": "8502"
+                  },
+                  "Pertes de change exceptionnelles": {
+                      "account_number": "8503"
+                  },
+                  "Pertes exceptionnelles sur ali\u00e9nations d'actifs immobilis\u00e9s": {
+                      "account_number": "8504"
+                  },
+                  "Pertes exceptionnelles sur d\u00e9biteurs": {
+                      "account_number": "8505"
+                  },
+                  "Indemnit\u00e9s pour pr\u00e9judices": {
+                      "account_number": "8506"
+                  },
+                  "Dissolutions de r\u00e9serves": {
+                      "account_number": "8510"
+                  },
+                  "Dissolutions exceptionnelles de provisions superflues": {
+                      "account_number": "8511"
+                  },
+                  "Gains de change exceptionnels": {
+                      "account_number": "8513"
+                  },
+                  "B\u00e9n\u00e9fices exceptionnels sur ali\u00e9nations d'actifs immobilis\u00e9s": {
+                      "account_number": "8514"
+                  },
+                  "Subvention re\u00e7ue (avec TVA)": {
+                      "account_number": "8515"
+                  },
+                  "Subvention re\u00e7ue (sans TVA)": {
+                      "account_number": "8516"
+                  },
+                  "Indemnit\u00e9s re\u00e7ues pour pr\u00e9judices": {
+                      "account_number": "8517"
+                  },
+                  "account_number": "850"
+              },
+              "Charges et produits uniques": {
+                  "Charges uniques": {
+                      "account_number": "8600"
+                  },
+                  "Produits uniques": {
+                      "account_number": "8610"
+                  },
+                  "account_number": "860"
+              },
+              "Charges et produits hors p\u00e9riode": {
+                  "Dotations \u00e0 la r\u00e9serve de contributions de l'employeur": {
+                      "account_number": "8704"
+                  },
+                  "Franchise": {
+                      "account_number": "8705"
+                  },
+                  "Autres charges hors p\u00e9riode": {
+                      "account_number": "8709"
+                  },
+                  "Produits de prestations d'assurance ou dommages-int\u00e9r\u00eats": {
+                      "account_number": "8710"
+                  },
+                  "Produits de ristournes": {
+                      "account_number": "8711"
+                  },
+                  "Produits de remboursements": {
+                      "account_number": "8712"
+                  },
+                  "Dissolutions de la r\u00e9serve de contributions de l'employeur": {
+                      "account_number": "8714"
+                  },
+                  "Autres produits hors p\u00e9riode": {
+                      "account_number": "8719"
+                  },
+                  "account_number": "870"
+              },
+              "account_number": "85"
+          },
+          "Imp\u00f4ts directs": {
+              "Imp\u00f4ts sur le b\u00e9n\u00e9fice/Imp\u00f4ts cantonaux et communaux": {
+                  "account_number": "8900"
+              },
+              "Imp\u00f4ts sur le capital/Imp\u00f4t f\u00e9d\u00e9raux": {
+                  "account_number": "8901"
+              },
+              "Imp\u00f4ts directs hors p\u00e9riode": {
+                  "account_number": "8902"
+              },
+              "account_number": "89"
+          },
+          "root_type": "Expense",
+          "account_number": "8"
+        },
+        "Cl\u00f4ture": {
+          "Utilisation du b\u00e9n\u00e9fice": {
+              "B\u00e9n\u00e9fice ou perte de l'exercice": {
+                  "account_number": "9200"
+              },
+              "account_number": "92"
+          },
+          "root_type": "Equity",
+          "account_number": "9"
+        }
+    }
+}

--- a/erpnext/regional/switzerland/setup.py
+++ b/erpnext/regional/switzerland/setup.py
@@ -1,0 +1,31 @@
+# Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
+# License: GNU General Public License v3. See license.txt
+
+from __future__ import unicode_literals
+
+import frappe
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+
+def setup(company=None, patch=True):
+    make_custom_fields()
+    make_client_script()
+
+def make_custom_fields():
+    custom_fields = {
+            'Sales Invoice': [
+                dict(fieldname='reference_number', label='Reference Number',
+                    fieldtype='Data', insert_after='naming_series', length='25', unique='1', translatable='0'),
+                dict(fieldname='reference_number_full', label='Reference Number Full',
+                    fieldtype='Data', insert_after='reference_number', length='25', unique='1', translatable='0', hidden='1')
+            ]
+    }
+    create_custom_fields(custom_fields)
+
+def make_client_script():
+    doc = frappe.get_doc({
+        'doctype': 'Client Script',
+        'dt': 'Sales Invoice',
+        'enabled': '1',
+        'script': "frappe.ui.form.on('Sales Invoice',{onload(frm){'use strict';const CHARCODE_A='A'.charCodeAt(0);const CHARCODE_0='0'.charCodeAt(0);const FORMAT=/^[0-9A-Z]{1,}$/;const FORMAT_RF=/^RF[0-9]{2}[A-Z0-9]{1,21}$/;const FORMAT_RF_BODY=/^[A-Z0-9]{1,21}$/;const FORMAT_RF_HEAD='RF';function mod97(value){var buffer=0;var charCode;for(var i=0;i<value.length;i+=1){charCode=value.charCodeAt(i);buffer=charCode+(charCode>=CHARCODE_A?buffer*100-CHARCODE_A+10:buffer*10-CHARCODE_0);if(buffer>1000000){buffer%=97}}return buffer%97}function stringifyInput(rawValue){if(rawValue===null||rawValue===undefined){throw new Error('Expecting \\'rawValue\\' of type \\'string\\', found: \\''+rawValue+'\\'')}if(typeof rawValue!=='string'){throw new Error('Expecting \\'rawValue\\' of type \\'string\\', found: \\''+(typeof rawValue)+'\\'')}return rawValue}var iso7064={compute:function(rawValue){const value=stringifyInput(rawValue);if(!value.match(FORMAT)){throw new Error('Invalid data format; expecting: \\''+FORMAT+'\\', found: \\''+value+'\\'')}return mod97(value)},computeWithoutCheck:function(rawValue){return mod97(rawValue)}};var iso11649={generate:function(rawValue){const value=stringifyInput(rawValue);if(!value.match(FORMAT_RF_BODY)){throw new Error('Invalid Creditor Reference format; expecting: \\''+FORMAT_RF_BODY+'\\', found: \\''+value+'\\'')}return FORMAT_RF_HEAD+('0'+(98-iso7064.computeWithoutCheck(value+FORMAT_RF_HEAD+'00'))).slice(-2)+value},validate:function(rawValue){const value=stringifyInput(rawValue);if(!value.match(FORMAT_RF)){throw new Error('Invalid Creditor Reference format; expecting: \\''+FORMAT_RF+'\\', found: \\''+value+'\\'')}return iso7064.computeWithoutCheck(value.substring(4,value.length)+value.substring(0,4))===1}};function stringifyInput(rawValue,valueName='rawValue'){if(rawValue!==null&&rawValue!==undefined){switch(typeof rawValue){case 'string':return rawValue.toUpperCase().replace(/[^0-9A-Z]/g,'');default:throw new Error('Expecting '+valueName+' of type \\'string\\', found: \\''+(typeof rawValue)+'\\'')}}throw new Error('Expecting '+valueName+' of type \\'string\\', found: \\''+rawValue+'\\'')}var random=Math.floor(Math.random()*999999999999);var generatorRF=iso11649.generate(`'${ random }'`);var generatorRFStr=generatorRF.replace(/(.{4})(?=.)/g,'$1 ');if(frm.is_new()){frm.set_value('reference_number',generatorRFStr);frm.set_value('reference_number_full',generatorRF);}}});"
+    })
+    doc.insert()


### PR DESCRIPTION
Swiss chart of accounts validated: 
![image](https://user-images.githubusercontent.com/24554787/116566724-49071c00-a907-11eb-94d3-dcd13c2b0dc9.png)

Add scripts and reference fields:
![image](https://user-images.githubusercontent.com/24554787/116566948-794eba80-a907-11eb-8280-3bf5c3361c91.png)

![image](https://user-images.githubusercontent.com/24554787/116567034-91263e80-a907-11eb-8d20-ea770fc71ef2.png)

This works for the erpnext swiss plugin for generating a unique ISO11649 reference number
https://www.iso.org/obp/ui/#iso:std:iso:11649:ed-1:v1:en