### PR TITLE
perf: don't query unless required

### DIFF
--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -99,9 +99,10 @@ def validate_returned_items(doc):
 								frappe.throw(_("Row # {0}: Serial No {1} does not match with {2} {3}")
 									.format(d.idx, s, doc.doctype, doc.return_against))
 
-				if warehouse_mandatory and frappe.db.get_value("Item", d.item_code, "is_stock_item") \
-					and not d.get("warehouse"):
-						frappe.throw(_("Warehouse is mandatory"))
+				if (warehouse_mandatory and not d.get("warehouse") and
+					frappe.db.get_value("Item", d.item_code, "is_stock_item")
+				):
+					frappe.throw(_("Warehouse is mandatory"))
 
 			items_returned = True
 

--- a/erpnext/stock/doctype/batch/batch.py
+++ b/erpnext/stock/doctype/batch/batch.py
@@ -230,9 +230,8 @@ def set_batch_nos(doc, warehouse_field, throw=False):
 	"""Automatically select `batch_no` for outgoing items in item table"""
 	for d in doc.items:
 		qty = d.get('stock_qty') or d.get('transfer_qty') or d.get('qty') or 0
-		has_batch_no = frappe.db.get_value('Item', d.item_code, 'has_batch_no')
 		warehouse = d.get(warehouse_field, None)
-		if has_batch_no and warehouse and qty > 0:
+		if warehouse and qty > 0 and frappe.db.get_value('Item', d.item_code, 'has_batch_no'):
 			if not d.batch_no:
 				d.batch_no = get_batch_no(d.item_code, warehouse, qty, throw, d.serial_no)
 			else:

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -181,9 +181,8 @@ class DeliveryNote(SellingController):
 		super(DeliveryNote, self).validate_warehouse()
 
 		for d in self.get_item_list():
-			if frappe.db.get_value("Item", d['item_code'], "is_stock_item") == 1:
-				if not d['warehouse']:
-					frappe.throw(_("Warehouse required for stock Item {0}").format(d["item_code"]))
+			if not d['warehouse'] and frappe.db.get_value("Item", d['item_code'], "is_stock_item") == 1:
+				frappe.throw(_("Warehouse required for stock Item {0}").format(d["item_code"]))
 
 
 	def update_current_stock(self):

--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -189,7 +189,7 @@ class MaterialRequest(BuyingController):
 		item_wh_list = []
 		for d in self.get("items"):
 			if (not mr_item_rows or d.name in mr_item_rows) and [d.item_code, d.warehouse] not in item_wh_list \
-					and frappe.db.get_value("Item", d.item_code, "is_stock_item") == 1 and d.warehouse:
+					and d.warehouse and frappe.db.get_value("Item", d.item_code, "is_stock_item") == 1 :
 				item_wh_list.append([d.item_code, d.warehouse])
 
 		for item_code, warehouse in item_wh_list:


### PR DESCRIPTION
Reordering conditionals so queries are not performed unless absolutely required.

Essentially, both options below are semantically the same but one will always hit the DB before evaluating to `False`.

- `False and frappe.db.sql("select * from tabItem")`

- `frappe.db.sql("select * from tabItem") and False`
