### PR TITLE
fix: User is not able to change item tax template

### DIFF
--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -288,8 +288,8 @@ erpnext.taxes_and_totals = erpnext.payments.extend({
 					company: me.frm.doc.company,
 					tax_category: cstr(me.frm.doc.tax_category),
 					item_codes: item_codes,
-					item_tax_templates: item_tax_templates,
-					item_rates: item_rates
+					item_rates: item_rates,
+					item_tax_templates: item_tax_templates
 				},
 				callback: function(r) {
 					if (!r.exc) {

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -270,11 +270,14 @@ erpnext.taxes_and_totals = erpnext.payments.extend({
 		let me = this;
 		let item_codes = [];
 		let item_rates = {};
+		let item_tax_templates = {};
+
 		$.each(this.frm.doc.items || [], function(i, item) {
 			if (item.item_code) {
 				// Use combination of name and item code in case same item is added multiple times
 				item_codes.push([item.item_code, item.name]);
 				item_rates[item.name] = item.net_rate;
+				item_tax_templates[item.name] = item.item_tax_template
 			}
 		});
 
@@ -285,18 +288,16 @@ erpnext.taxes_and_totals = erpnext.payments.extend({
 					company: me.frm.doc.company,
 					tax_category: cstr(me.frm.doc.tax_category),
 					item_codes: item_codes,
+					item_tax_templates: item_tax_templates,
 					item_rates: item_rates
 				},
 				callback: function(r) {
 					if (!r.exc) {
 						$.each(me.frm.doc.items || [], function(i, item) {
-							if (item.name && r.message.hasOwnProperty(item.name)) {
+							if (item.name && r.message.hasOwnProperty(item.name) && r.message[item.name].item_tax_template) {
 								item.item_tax_template = r.message[item.name].item_tax_template;
 								item.item_tax_rate = r.message[item.name].item_tax_rate;
 								me.add_taxes_from_item_tax_template(item.item_tax_rate);
-							} else {
-								item.item_tax_template = "";
-								item.item_tax_rate = "{}";
 							}
 						});
 					}

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -277,7 +277,7 @@ erpnext.taxes_and_totals = erpnext.payments.extend({
 				// Use combination of name and item code in case same item is added multiple times
 				item_codes.push([item.item_code, item.name]);
 				item_rates[item.name] = item.net_rate;
-				item_tax_templates[item.name] = item.item_tax_template
+				item_tax_templates[item.name] = item.item_tax_template;
 			}
 		});
 

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -436,15 +436,15 @@ def get_barcode_data(items_list):
 	return itemwise_barcode
 
 @frappe.whitelist()
-def get_item_tax_info(company, tax_category, item_codes, item_tax_templates=None, item_rates=None):
+def get_item_tax_info(company, tax_category, item_codes, item_rates=None, item_tax_templates=None):
 	out = {}
-	if isinstance(item_codes, string_types):
+	if isinstance(item_codes, (str,)):
 		item_codes = json.loads(item_codes)
 
-	if isinstance(item_rates, string_types):
+	if isinstance(item_rates, (str,)):
 		item_rates = json.loads(item_rates)
 
-	if isinstance(item_tax_templates, string_types):
+	if isinstance(item_tax_templates, (str,)):
 		item_tax_templates = json.loads(item_tax_templates)
 
 	for item_code in item_codes:
@@ -514,7 +514,7 @@ def _get_item_tax_template(args, taxes, out=None, for_validate=False):
 		return None
 
 	# do not change if already a valid template
-	if args.get('item_tax_template') in [t.item_tax_template for t in taxes]:
+	if args.get('item_tax_template') in {t.item_tax_template for t in taxes}:
 		out["item_tax_template"] = args.get('item_tax_template')
 		return args.get('item_tax_template')
 

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -453,8 +453,10 @@ def get_item_tax_info(company, tax_category, item_codes, item_tax_templates=None
 
 		out[item_code[1]] = {}
 		item = frappe.get_cached_doc("Item", item_code[0])
-		args = {"company": company, "tax_category": tax_category, "net_rate": item_rates[item_code[1]],
-			"item_tax_template": item_tax_templates.get(item_code[1])}
+		args = {"company": company, "tax_category": tax_category, "net_rate": item_rates[item_code[1]]}
+
+		if item_tax_templates:
+			args.update({"item_tax_template": item_tax_templates.get(item_code[1])})
 
 		get_item_tax_template(args, item, out[item_code[1]])
 		out[item_code[1]]["item_tax_rate"] = get_item_tax_map(company, out[item_code[1]].get("item_tax_template"), as_json=True)

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -436,7 +436,7 @@ def get_barcode_data(items_list):
 	return itemwise_barcode
 
 @frappe.whitelist()
-def get_item_tax_info(company, tax_category, item_codes, item_tax_templates, item_rates=None):
+def get_item_tax_info(company, tax_category, item_codes, item_tax_templates=None, item_rates=None):
 	out = {}
 	if isinstance(item_codes, string_types):
 		item_codes = json.loads(item_codes)


### PR DESCRIPTION
Due to introduction of net rate based item taxes in the following PR users were unable to change Item Tax Templates manually
https://github.com/frappe/erpnext/pull/25961

This PR fixes that issue