### PR TITLE
fix: chart not visible for First Response Time reports

### DIFF
--- a/erpnext/crm/report/first_response_time_for_opportunity/first_response_time_for_opportunity.js
+++ b/erpnext/crm/report/first_response_time_for_opportunity/first_response_time_for_opportunity.js
@@ -22,10 +22,10 @@ frappe.query_reports["First Response Time for Opportunity"] = {
 	get_chart_data: function (_columns, result) {
 		return {
 			data: {
-				labels: result.map(d => d[0]),
+				labels: result.map(d => d.creation_date),
 				datasets: [{
 					name: "First Response Time",
-					values: result.map(d => d[1])
+					values: result.map(d => d.first_response_time)
 				}]
 			},
 			type: "line",
@@ -35,8 +35,7 @@ frappe.query_reports["First Response Time for Opportunity"] = {
 						hide_days: 0,
 						hide_seconds: 0
 					};
-					value = frappe.utils.get_formatted_duration(d, duration_options);
-					return value;
+					return frappe.utils.get_formatted_duration(d, duration_options);
 				}
 			}
 		}

--- a/erpnext/support/report/first_response_time_for_issues/first_response_time_for_issues.js
+++ b/erpnext/support/report/first_response_time_for_issues/first_response_time_for_issues.js
@@ -22,10 +22,10 @@ frappe.query_reports["First Response Time for Issues"] = {
 	get_chart_data: function(_columns, result) {
 		return {
 			data: {
-				labels: result.map(d => d[0]),
+				labels: result.map(d => d.creation_date),
 				datasets: [{
 					name: 'First Response Time',
-					values: result.map(d => d[1])
+					values: result.map(d => d.first_response_time)
 				}]
 			},
 			type: "line",
@@ -35,8 +35,7 @@ frappe.query_reports["First Response Time for Issues"] = {
 						hide_days: 0,
 						hide_seconds: 0
 					};
-					value = frappe.utils.get_formatted_duration(d, duration_options);
-					return value;
+					return frappe.utils.get_formatted_duration(d, duration_options);
 				}
 			}
 		}


### PR DESCRIPTION
Backport: https://github.com/frappe/erpnext/pull/26032

### First Response Time for Opportunity

**Before**:

![First Response Time for Opportunity](https://user-images.githubusercontent.com/24353136/121771785-34b57080-cb8f-11eb-8f17-71e5dbc364c3.png)

**After**:

![image](https://user-images.githubusercontent.com/24353136/121771815-62021e80-cb8f-11eb-896f-6b496ca8fe2b.png)

### First Response Time for Issues

**Before**:

![Pasted Graphic 3](https://user-images.githubusercontent.com/24353136/121771793-40a13280-cb8f-11eb-803d-1eda6ee784ca.png)

**After**:

![image](https://user-images.githubusercontent.com/24353136/121771827-7514ee80-cb8f-11eb-8da6-7ca05afeb772.png)


