### PR TITLE
fix(Work Order): added freeze when trying to stop work order

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -705,6 +705,7 @@ erpnext.work_order = {
 		frappe.call({
 			method: "erpnext.manufacturing.doctype.work_order.work_order.stop_unstop",
 			freeze: true,
+			freeze_message: __("Updating Work Order status"),
 			args: {
 				work_order: frm.doc.name,
 				status: status

--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -704,6 +704,7 @@ erpnext.work_order = {
 	stop_work_order: function(frm, status) {
 		frappe.call({
 			method: "erpnext.manufacturing.doctype.work_order.work_order.stop_unstop",
+			freeze: true,
 			args: {
 				work_order: frm.doc.name,
 				status: status


### PR DESCRIPTION
**Issue:**
- Status of the _Work Order_ would sometimes not get updated and throw an error while trying to do a db_set.(Lock Wait Timeout)

**Potential Fix:**
- Added freeze parameter to prevent multiple calls.