### PR TITLE
fix: Address Card issues in e-commerce

### DIFF
--- a/erpnext/public/scss/shopping_cart.scss
+++ b/erpnext/public/scss/shopping_cart.scss
@@ -467,9 +467,13 @@ body.product-page {
 
 	.btn-change-address {
 		color: var(--blue-500);
-		box-shadow: none;
-		border: 1px solid var(--blue-500);
 	}
+}
+
+.btn-new-address:hover, .btn-change-address:hover {
+	box-shadow: none;
+	color: var(--blue-500) !important;
+	border: 1px solid var(--blue-500);
 }
 
 .modal .address-card {

--- a/erpnext/templates/includes/cart/cart_address.html
+++ b/erpnext/templates/includes/cart/cart_address.html
@@ -99,6 +99,7 @@ frappe.ready(() => {
 					fieldname: 'country',
 					fieldtype: 'Link',
 					options: 'Country',
+					only_select: true,
 					reqd: 1
 				},
 				{


### PR DESCRIPTION
**Issue:**
- Add Address modal in Shopping Cart, has a country field that kept auto clearing anything added to it. The styles are also missing for the same
- Hover styles on **Add Address** and **Change** buttons in address card
  ![hover-btn-add-address](https://user-images.githubusercontent.com/25857446/123213884-2e56bb00-d4e4-11eb-9783-767545532628.gif)

**Fix:**
- Country field retains data. Its style will be fixed in frappe.
  ![country-field-modal](https://user-images.githubusercontent.com/25857446/123213250-66a9c980-d4e3-11eb-8f05-e774c13b3f6c.gif)
- Hover state on address and change button
  ![Screenshot 2021-06-24 at 11 58 50 AM](https://user-images.githubusercontent.com/25857446/123213269-6e696e00-d4e3-11eb-8299-bad46a50a446.png)
