### PR TITLE
fix(Work Order): added freeze when trying to stop work order (#26192)

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -704,6 +704,8 @@ erpnext.work_order = {
 	stop_work_order: function(frm, status) {
 		frappe.call({
 			method: "erpnext.manufacturing.doctype.work_order.work_order.stop_unstop",
+			freeze: true,
+			freeze_message: __("Updating Work Order status"),
 			args: {
 				work_order: frm.doc.name,
 				status: status


### PR DESCRIPTION
Backports the following commits to version-13-hotfix:
 - fix(Work Order): added freeze when trying to stop work order (#26192)