### PR TITLE
fix: incorrect incoming rate in stock reconciliation

### DIFF
--- a/erpnext/stock/doctype/serial_no/serial_no.py
+++ b/erpnext/stock/doctype/serial_no/serial_no.py
@@ -328,7 +328,8 @@ def validate_serial_no(sle, item_det):
 	elif serial_nos:
 		# SLE is being cancelled and has serial nos
 		for serial_no in serial_nos:
-			check_serial_no_validity_on_cancel(serial_no, sle)
+			if sle.actual_qty < 0:
+				check_serial_no_validity_on_cancel(serial_no, sle)
 
 def check_serial_no_validity_on_cancel(serial_no, sle):
 	sr = frappe.db.get_value("Serial No", serial_no, ["name", "warehouse", "company", "status"], as_dict=1)

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -291,6 +291,7 @@ class update_entries_after(object):
 			where
 				item_code = %(item_code)s
 				and warehouse = %(warehouse)s
+				and is_cancelled = 0
 				and timestamp(posting_date, time_format(posting_time, %(time_format)s)) = timestamp(%(posting_date)s, time_format(%(posting_time)s, %(time_format)s))
 
 			order by


### PR DESCRIPTION
**Issue**

Create stock reco and add same item and warehouse 4 times with same valuation rate for the **Serialized Items**

<img width="1305" alt="Screenshot 2021-06-24 at 6 59 40 PM" src="https://user-images.githubusercontent.com/8780500/123271909-e903af00-d51e-11eb-8a0c-7607155452ae.png">

Check SL entries

System has merged the similar item and calculated incorrect Incoming rate
<img width="537" alt="Screenshot 2021-06-24 at 7 22 58 PM" src="https://user-images.githubusercontent.com/8780500/123275075-aa232880-d521-11eb-9940-e5a254382dc9.png">

**After Fix**

Check SL entries

<img width="853" alt="Screenshot 2021-06-24 at 6 58 29 PM" src="https://user-images.githubusercontent.com/8780500/123275251-c9ba5100-d521-11eb-8f15-299776a45bc6.png">

