### PR TITLE
fix: Account filter not working with accounting dimension filter

### DIFF
--- a/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.py
+++ b/erpnext/accounts/doctype/accounting_dimension/accounting_dimension.py
@@ -19,7 +19,7 @@ class AccountingDimension(Document):
 
 	def validate(self):
 		if self.document_type in core_doctypes_list + ('Accounting Dimension', 'Project',
-				'Cost Center', 'Accounting Dimension Detail', 'Company') :
+				'Cost Center', 'Accounting Dimension Detail', 'Company', 'Account') :
 
 			msg = _("Not allowed to create accounting dimension for {0}").format(self.document_type)
 			frappe.throw(msg)

--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -211,7 +211,7 @@ def get_gl_entries(filters, accounting_dimensions):
 			dimension_fields=dimension_fields, select_fields=select_fields, conditions=get_conditions(filters), distributed_cost_center_query=distributed_cost_center_query,
 			order_by_statement=order_by_statement
 		),
-		filters, as_dict=1)
+		filters, as_dict=1, debug=1)
 
 	if filters.get('presentation_currency'):
 		return convert_to_presentation_currency(gl_entries, currency_map, filters.get('company'))
@@ -222,7 +222,7 @@ def get_gl_entries(filters, accounting_dimensions):
 def get_conditions(filters):
 	conditions = []
 
-	if filters.get("account") and not filters.get("include_dimensions"):
+	if filters.get("account"):
 		filters.account = get_accounts_with_children(filters.account)
 		conditions.append("account in %(account)s")
 

--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -211,7 +211,7 @@ def get_gl_entries(filters, accounting_dimensions):
 			dimension_fields=dimension_fields, select_fields=select_fields, conditions=get_conditions(filters), distributed_cost_center_query=distributed_cost_center_query,
 			order_by_statement=order_by_statement
 		),
-		filters, as_dict=1, debug=1)
+		filters, as_dict=1)
 
 	if filters.get('presentation_currency'):
 		return convert_to_presentation_currency(gl_entries, currency_map, filters.get('company'))


### PR DESCRIPTION
Bug introduced in PR: https://github.com/frappe/erpnext/pull/24770

Account filter was not working with "Consider Accounting Dimension" filter due to bug introduced in the above PR to avoid another potential error

Added proper solution for this to avoid creation of Accounting Dimension using Account doctype