### PR TITLE
fix: order and time of operations in multilevel BOM work order (fp #25886)

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -1,7 +1,8 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
 
-from __future__ import unicode_literals
+from typing import List
+from collections import deque
 import frappe, erpnext
 from frappe.utils import cint, cstr, flt, today
 from frappe import _
@@ -16,13 +17,84 @@ from frappe.model.mapper import get_mapped_doc
 
 import functools
 
-from six import string_types
-
 from operator import itemgetter
 
 form_grid_templates = {
 	"items": "templates/form_grid/item_grid.html"
 }
+
+
+class BOMTree:
+	"""Full tree representation of a BOM"""
+
+	# specifying the attributes to save resources
+	# ref: https://docs.python.org/3/reference/datamodel.html#slots
+	__slots__ = ["name", "child_items", "is_bom", "item_code", "exploded_qty", "qty"]
+
+	def __init__(self, name: str, is_bom: bool = True, exploded_qty: float = 1.0, qty: float = 1) -> None:
+		self.name = name  # name of node, BOM number if is_bom else item_code
+		self.child_items: List["BOMTree"] = []  # list of child items
+		self.is_bom = is_bom   # true if the node is a BOM and not a leaf item
+		self.item_code: str = None  # item_code associated with node
+		self.qty = qty  # required unit quantity to make one unit of parent item.
+		self.exploded_qty = exploded_qty  # total exploded qty required for making root of tree.
+		if not self.is_bom:
+			self.item_code = self.name
+		else:
+			self.__create_tree()
+
+	def __create_tree(self):
+		bom = frappe.get_cached_doc("BOM", self.name)
+		self.item_code = bom.item
+
+		for item in bom.get("items", []):
+			qty = item.qty / bom.quantity  # quantity per unit
+			exploded_qty = self.exploded_qty * qty
+			if item.bom_no:
+				child = BOMTree(item.bom_no, exploded_qty=exploded_qty, qty=qty)
+				self.child_items.append(child)
+			else:
+				self.child_items.append(
+					BOMTree(item.item_code, is_bom=False, exploded_qty=exploded_qty, qty=qty)
+				)
+
+	def level_order_traversal(self) -> List["BOMTree"]:
+		"""Get level order traversal of tree.
+		E.g. for following tree the traversal will return list of nodes in order from top to bottom.
+		BOM:
+			- SubAssy1
+				- item1
+				- item2
+			- SubAssy2
+				- item3
+			- item4
+
+		returns = [SubAssy1, item1, item2, SubAssy2, item3, item4]
+		"""
+		traversal = []
+		q = deque()
+		q.append(self)
+
+		while q:
+			node = q.popleft()
+
+			for child in node.child_items:
+				traversal.append(child)
+				q.append(child)
+
+		return traversal
+
+	def __str__(self) -> str:
+		return (
+			f"{self.item_code}{' - ' + self.name if self.is_bom else ''} qty(per unit): {self.qty}"
+			f" exploded_qty: {self.exploded_qty}"
+		)
+
+	def __repr__(self, level: int = 0) -> str:
+		rep = "┃  " * (level - 1) + "┣━ " * (level > 0) + str(self) + "\n"
+		for child in self.child_items:
+			rep += child.__repr__(level=level + 1)
+		return rep
 
 class BOM(WebsiteGenerator):
 	website = frappe._dict(
@@ -152,7 +224,7 @@ class BOM(WebsiteGenerator):
 		if not args:
 			args = frappe.form_dict.get('args')
 
-		if isinstance(args, string_types):
+		if isinstance(args, str):
 			import json
 			args = json.loads(args)
 
@@ -599,6 +671,11 @@ class BOM(WebsiteGenerator):
 					d.description = frappe.db.get_value('Operation', d.operation, 'description')
 				if not d.batch_size or d.batch_size <= 0:
 					d.batch_size = 1
+
+	def get_tree_representation(self) -> BOMTree:
+		"""Get a complete tree representation preserving order of child items."""
+		return BOMTree(self.name)
+
 
 def get_bom_item_rate(args, bom_doc):
 	if bom_doc.rm_cost_as_per == 'Valuation Rate':

--- a/erpnext/manufacturing/doctype/bom/test_bom.py
+++ b/erpnext/manufacturing/doctype/bom/test_bom.py
@@ -2,14 +2,13 @@
 # License: GNU General Public License v3. See license.txt
 
 
-from __future__ import unicode_literals
+from collections import deque
 import unittest
 import frappe
 from frappe.utils import cstr, flt
 from frappe.test_runner import make_test_records
 from erpnext.stock.doctype.stock_reconciliation.test_stock_reconciliation import create_stock_reconciliation
 from erpnext.manufacturing.doctype.bom_update_tool.bom_update_tool import update_cost
-from six import string_types
 from erpnext.stock.doctype.item.test_item import make_item
 from erpnext.buying.doctype.purchase_order.test_purchase_order import create_purchase_order
 from erpnext.tests.test_subcontracting import set_backflush_based_on
@@ -227,11 +226,88 @@ class TestBOM(unittest.TestCase):
 		supplied_items = sorted([d.rm_item_code for d in po.supplied_items])
 		self.assertEqual(bom_items, supplied_items)
 
+	def test_bom_tree_representation(self):
+		bom_tree = {
+			"Assembly": {
+				"SubAssembly1": {"ChildPart1": {}, "ChildPart2": {},},
+				"SubAssembly2": {"ChildPart3": {}},
+				"SubAssembly3": {"SubSubAssy1": {"ChildPart4": {}}},
+				"ChildPart5": {},
+				"ChildPart6": {},
+				"SubAssembly4": {"SubSubAssy2": {"ChildPart7": {}}},
+			}
+		}
+		parent_bom = create_nested_bom(bom_tree, prefix="")
+		created_tree = parent_bom.get_tree_representation()
+
+		reqd_order = level_order_traversal(bom_tree)[1:] # skip first item
+		created_order = created_tree.level_order_traversal()
+
+		self.assertEqual(len(reqd_order), len(created_order))
+
+		for reqd_item, created_item in zip(reqd_order, created_order):
+			self.assertEqual(reqd_item, created_item.item_code)
+
+
 def get_default_bom(item_code="_Test FG Item 2"):
 	return frappe.db.get_value("BOM", {"item": item_code, "is_active": 1, "is_default": 1})
 
+
+
+
+def level_order_traversal(node):
+	traversal = []
+	q = deque()
+	q.append(node)
+
+	while q:
+		node = q.popleft()
+
+		for node_name, subtree in node.items():
+			traversal.append(node_name)
+			q.append(subtree)
+
+	return traversal
+
+def create_nested_bom(tree, prefix="_Test bom "):
+	""" Helper function to create a simple nested bom from tree describing item names. (along with required items)
+	"""
+
+	def create_items(bom_tree):
+		for item_code, subtree in bom_tree.items():
+			bom_item_code = prefix + item_code
+			if not frappe.db.exists("Item", bom_item_code):
+				frappe.get_doc(doctype="Item", item_code=bom_item_code, item_group="_Test Item Group").insert()
+			create_items(subtree)
+	create_items(tree)
+
+	def dfs(tree, node):
+		"""naive implementation for searching right subtree"""
+		for node_name, subtree in tree.items():
+			if node_name == node:
+				return subtree
+			else:
+				result = dfs(subtree, node)
+				if result is not None:
+					return result
+
+	order_of_creating_bom = reversed(level_order_traversal(tree))
+
+	for item in order_of_creating_bom:
+		child_items = dfs(tree, item)
+		if child_items:
+			bom_item_code = prefix + item
+			bom = frappe.get_doc(doctype="BOM", item=bom_item_code)
+			for child_item in child_items.keys():
+				bom.append("items", {"item_code": prefix + child_item})
+			bom.insert()
+			bom.submit()
+
+	return bom  # parent bom is last bom
+
+
 def reset_item_valuation_rate(item_code, warehouse_list=None, qty=None, rate=None):
-	if warehouse_list and isinstance(warehouse_list, string_types):
+	if warehouse_list and isinstance(warehouse_list, str):
 		warehouse_list = [warehouse_list]
 
 	if not warehouse_list:

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -1,7 +1,6 @@
-# Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
+# Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
 
-from __future__ import unicode_literals
 import frappe
 import json
 import math
@@ -28,9 +27,6 @@ class ItemHasVariantError(frappe.ValidationError): pass
 
 from six import string_types
 
-form_grid_templates = {
-	"operations": "templates/form_grid/work_order_grid.html"
-}
 
 class WorkOrder(Document):
 	def onload(self):

--- a/erpnext/manufacturing/doctype/work_order_operation/work_order_operation.json
+++ b/erpnext/manufacturing/doctype/work_order_operation/work_order_operation.json
@@ -2,7 +2,6 @@
  "actions": [],
  "creation": "2014-10-16 14:35:41.950175",
  "doctype": "DocType",
- "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
   "details",
@@ -48,6 +47,7 @@
   {
    "fieldname": "bom",
    "fieldtype": "Link",
+   "in_list_view": 1,
    "label": "BOM",
    "no_copy": 1,
    "options": "BOM",
@@ -67,6 +67,7 @@
    "fieldtype": "Column Break"
   },
   {
+   "columns": 1,
    "description": "Operation completed for how many finished goods?",
    "fieldname": "completed_qty",
    "fieldtype": "Float",
@@ -76,6 +77,7 @@
    "read_only": 1
   },
   {
+   "columns": 1,
    "default": "Pending",
    "fieldname": "status",
    "fieldtype": "Select",
@@ -118,6 +120,7 @@
    "fieldtype": "Column Break"
   },
   {
+   "columns": 1,
    "description": "in Minutes",
    "fieldname": "time_in_mins",
    "fieldtype": "Float",
@@ -200,7 +203,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-10-14 12:58:49.241252",
+ "modified": "2021-06-24 14:36:12.835543",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Work Order Operation",


### PR DESCRIPTION
Backports the following commits to develop:
 - chore: remove dead and py2 compatibility code (ff4aadc6)
 - fix(ux): show bom in operations child table (6ec88754)
 - fix: order and time of operations for multilevel bom (9e43445f)