### PR TITLE
fix: change PR on submit dialog title if serial no being created

### DIFF
--- a/erpnext/stock/doctype/serial_no/serial_no.py
+++ b/erpnext/stock/doctype/serial_no/serial_no.py
@@ -446,7 +446,7 @@ def auto_make_serial_nos(args):
 		docstatus = 0
 		voucher_no = args.get('voucher_no')
 		if voucher_no:
-			docstatus = frappe.db.get_value(voucher_type, voucher_no, "docstatus")
+			docstatus = frappe.db.get_cached_value(voucher_type, voucher_no, "docstatus")
 
 		multiple_title = singular_title = _("{0} Created").format(voucher_type)
 		if docstatus:

--- a/erpnext/stock/doctype/serial_no/serial_no.py
+++ b/erpnext/stock/doctype/serial_no/serial_no.py
@@ -443,7 +443,14 @@ def auto_make_serial_nos(args):
 	multiple_title = _("Serial Numbers Created")
 
 	if voucher_type:
+		docstatus = 0
+		voucher_no = args.get('voucher_no')
+		if voucher_no:
+			docstatus = frappe.db.get_value(voucher_type, voucher_no, "docstatus")
+
 		multiple_title = singular_title = _("{0} Created").format(voucher_type)
+		if docstatus:
+			multiple_title = singular_title = _("{0} Submitted").format(voucher_type)
 
 	if len(form_links) == 1:
 		frappe.msgprint(_("Serial No {0} Created").format(form_links[0]), singular_title)


### PR DESCRIPTION
### Description
Initially, if _Serial Nos_ are created on _Purchase Receipt_ submit the dialog title says _"Purchase Receipt Created"_ which is a lie because _Serial Nos_ are created on PR submit not save.

## After
- It now says _"Purchase Receipt Submitted"_
- Note this applies to all docs where the submission causes the creation of serial numbers.  

![Screen Shot 2021-06-28 at 16 42 11](https://user-images.githubusercontent.com/29507195/123628730-0becd680-d831-11eb-9c44-501c27b9c91f.png)

_Note: This is a (tentative) hack fix_
![Screen Shot 2021-06-28 at 16 40 16](https://user-images.githubusercontent.com/29507195/123628848-2e7eef80-d831-11eb-87ab-40d6881e4b02.png)
- In the SS above, the title and the second message are a lie, nothing was created or submitted due to the error/issue mentioned in the last line of the dialog.
- Fixing this requires changes to how dialogs function at the FF level, this is in the design stage.