### PR TITLE
fix: Employee Inactive status implications

### DIFF
--- a/erpnext/hr/doctype/attendance/attendance.js
+++ b/erpnext/hr/doctype/attendance/attendance.js
@@ -11,5 +11,5 @@ cur_frm.cscript.onload = function(doc, cdt, cdn) {
 cur_frm.fields_dict.employee.get_query = function(doc,cdt,cdn) {
 	return{
 		query: "erpnext.controllers.queries.employee_query"
-	}	
+	}
 }

--- a/erpnext/hr/doctype/attendance/attendance.py
+++ b/erpnext/hr/doctype/attendance/attendance.py
@@ -15,6 +15,7 @@ class Attendance(Document):
 		validate_status(self.status, ["Present", "Absent", "On Leave", "Half Day", "Work From Home"])
 		self.validate_attendance_date()
 		self.validate_duplicate_record()
+		self.validate_employee_status()
 		self.check_leave_record()
 
 	def validate_attendance_date(self):
@@ -37,6 +38,10 @@ class Attendance(Document):
 		if res:
 			frappe.throw(_("Attendance for employee {0} is already marked for the date {1}").format(
 				frappe.bold(self.employee), frappe.bold(self.attendance_date)))
+
+	def validate_employee_status(self):
+		if frappe.db.get_value("Employee", self.employee, "status") == "Inactive":
+			frappe.throw(_("Cannot mark attendance for an Inactive employee {0}").format(self.employee))
 
 	def check_leave_record(self):
 		leave_record = frappe.db.sql("""

--- a/erpnext/hr/doctype/attendance/attendance_list.js
+++ b/erpnext/hr/doctype/attendance/attendance_list.js
@@ -21,6 +21,9 @@ frappe.listview_settings['Attendance'] = {
 						label: __('For Employee'),
 						fieldtype: 'Link',
 						options: 'Employee',
+						get_query: () => {
+							return {query: "erpnext.controllers.queries.employee_query"}
+						},
 						reqd: 1,
 						onchange: function() {
 							dialog.set_df_property("unmarked_days", "hidden", 1);

--- a/erpnext/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/erpnext/payroll/doctype/payroll_entry/payroll_entry.py
@@ -459,6 +459,7 @@ def get_emp_list(sal_struct, cond, end_date, payroll_payable_account):
 			where
 				t1.name = t2.employee
 				and t2.docstatus = 1
+				and t1.status != 'Inactive'
 		%s order by t2.from_date desc
 		""" % cond, {"sal_struct": tuple(sal_struct), "from_date": end_date, "payroll_payable_account": payroll_payable_account}, as_dict=True)
 


### PR DESCRIPTION
**Fixes**:

1. Don't fetch Inactive employees for Payroll
2. Set employee query while marking attendance in bulk from Attendance listview
3. Validate employee status while marking attendance