### PR TITLE
fix: Added Permissions for employee to book an appointment

### DIFF
--- a/erpnext/crm/doctype/appointment/appointment.json
+++ b/erpnext/crm/doctype/appointment/appointment.json
@@ -93,7 +93,7 @@
    "fieldtype": "Column Break"
   }
  ],
- "modified": "2019-10-14 15:23:54.630731",
+ "modified": "2021-06-28 16:27:53.235714",
  "modified_by": "Administrator",
  "module": "CRM",
  "name": "Appointment",
@@ -142,6 +142,18 @@
    "read": 1,
    "report": 1,
    "role": "Sales User",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Employee",
    "share": 1,
    "write": 1
   }


### PR DESCRIPTION
Backport: https://github.com/frappe/erpnext/pull/26266

Initially if user logged in with role as employee they did not had permissions for booking appointment in the CRM module so it would not show all the fields in the form thus throwing missing values error but after the fix all the fields are visible and form gets submitted 

<img width="1259" alt="Screenshot 2021-06-29 at 1 23 32 PM" src="https://user-images.githubusercontent.com/49878143/123759556-a30f6800-d8dd-11eb-92e5-27b172568a9f.png">
<img width="1264" alt="Screenshot 2021-06-29 at 1 25 17 PM" src="https://user-images.githubusercontent.com/49878143/123759576-a60a5880-d8dd-11eb-986a-7a6d5b2e6c7d.png">

