### PR TITLE
fix: Added permission for employee to book appointment

### DIFF
--- a/erpnext/crm/doctype/appointment/appointment.json
+++ b/erpnext/crm/doctype/appointment/appointment.json
@@ -102,7 +102,7 @@
   }
  ],
  "links": [],
- "modified": "2020-01-28 16:16:45.447213",
+ "modified": "2021-06-29 18:27:02.832979",
  "modified_by": "Administrator",
  "module": "CRM",
  "name": "Appointment",
@@ -151,6 +151,18 @@
    "read": 1,
    "report": 1,
    "role": "Sales User",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Employee",
    "share": 1,
    "write": 1
   }


### PR DESCRIPTION
Backport: https://github.com/frappe/erpnext/pull/26266

Initially when the user logged in as employee they did not had permissions to create an appointment so when the user saved the form it would throw missing values errors this fix would allow the employee to make an appointment 

<img width="1440" alt="Screenshot 2021-06-29 at 6 57 29 PM" src="https://user-images.githubusercontent.com/49878143/123808322-44aead80-d90e-11eb-8fa5-dcbf644c7e5f.png">
<img width="1440" alt="Screenshot 2021-06-29 at 7 13 50 PM" src="https://user-images.githubusercontent.com/49878143/123808349-4b3d2500-d90e-11eb-95b8-846d3e11762a.png">

