### PR TITLE
fix: Added permission for employee to book appointment

### DIFF
--- a/erpnext/crm/doctype/appointment/appointment.json
+++ b/erpnext/crm/doctype/appointment/appointment.json
@@ -102,7 +102,7 @@
   }
  ],
  "links": [],
- "modified": "2020-01-28 16:16:45.447213",
+ "modified": "2021-06-30 12:09:14.228756",
  "modified_by": "Administrator",
  "module": "CRM",
  "name": "Appointment",
@@ -151,6 +151,18 @@
    "read": 1,
    "report": 1,
    "role": "Sales User",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Employee",
    "share": 1,
    "write": 1
   }


### PR DESCRIPTION
Initially when the user logged in as employee they did not had permissions to create an appointment so when the user saved the form it would throw missing values errors this fix would allow the employee to make an appointment

<img width="1440" alt="Screenshot 2021-06-30 at 12 24 46 PM" src="https://user-images.githubusercontent.com/49878143/123923971-234dd000-d9a7-11eb-9c0d-e5b20972700b.png">
<img width="1440" alt="Screenshot 2021-06-30 at 12 30 23 PM" src="https://user-images.githubusercontent.com/49878143/123923984-25b02a00-d9a7-11eb-94d4-4d60f049eb2c.png">
