### PR TITLE
fix: half day to be accounted in its leave type

### DIFF
--- a/erpnext/hr/doctype/attendance/attendance.json
+++ b/erpnext/hr/doctype/attendance/attendance.json
@@ -78,7 +78,7 @@
    "search_index": 1
   },
   {
-   "depends_on": "eval:doc.status==\"On Leave\"",
+   "depends_on": "eval:doc.status==\"On Leave\" || doc.status==\"Half Day\"",
    "fieldname": "leave_type",
    "fieldtype": "Link",
    "in_standard_filter": 1,
@@ -174,7 +174,7 @@
  "icon": "fa fa-ok",
  "idx": 1,
  "is_submittable": 1,
- "modified": "2020-02-19 14:25:32.945842",
+ "modified": "2021-06-30 14:42:39.162146",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Attendance",


### PR DESCRIPTION
Initially when user marked attendance as half day it would not account in its leave type such as (Sick Leave, Leave without pay etc) but after this fix it is accounting in the leave type

<img width="1034" alt="Screenshot 2021-06-30 at 2 54 26 PM" src="https://user-images.githubusercontent.com/49878143/123937120-79c10b80-d9b3-11eb-95dd-705800c0ce22.png">


