### PR TITLE
fix: fetching employee in payroll entry

### DIFF
--- a/erpnext/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/erpnext/payroll/doctype/payroll_entry/payroll_entry.py
@@ -680,6 +680,10 @@ def employee_query(doctype, txt, searchfield, start, page_len, filters):
 	conditions = []
 	include_employees = []
 	emp_cond = ''
+
+	if not filters.payroll_frequency:
+		frappe.throw(_('Select Payroll Frequency.'))
+
 	if filters.start_date and filters.end_date:
 		employee_list = get_employee_list(filters)
 		emp = filters.get('employees')


### PR DESCRIPTION
**Issue:** After clicking on the employee field, the error pop-up still appears.
![image](https://user-images.githubusercontent.com/20715976/123955459-438d8700-d9c7-11eb-82ff-5fb0e2783b82.png)
