### PR TITLE
fix: Order Items by weightage in the web items query

### DIFF
--- a/erpnext/shopping_cart/product_query.py
+++ b/erpnext/shopping_cart/product_query.py
@@ -71,7 +71,8 @@ class ProductQuery:
 					],
 					or_filters=self.or_filters,
 					start=start,
-					limit=self.page_length
+					limit=self.page_length,
+					order_by="weightage desc"
 				)
 
 				items_dict = {item.name: item for item in items}
@@ -86,7 +87,8 @@ class ProductQuery:
 				filters=self.filters,
 				or_filters=self.or_filters,
 				start=start,
-				limit=self.page_length
+				limit=self.page_length,
+				order_by="weightage desc"
 			)
 
 		# Combine results having context of website item groups into item results


### PR DESCRIPTION
**Issue:**
- Query engine first queried items in **any order**, with a page limit and then sorted the results by weightage
- So items having much higher weightage , which were modified long back, and are ay down the items list don't come up

**Fix:**
- order items in query and then again  after including website item groups

**To Test**:
- Have 10 Items with show in website enabled. Set weightage in each.
- Make sure the highest weightage item is has the oldest modified time (in the Item List on Desk it should be somewhere at the bottom)
- Set Products per Page to 5 in Product Settings.
- Check if this item shows up on the first page of the website product listing