### PR TITLE
fix: Bank statement import

### DIFF
--- a/erpnext/accounts/doctype/bank_statement_import/bank_statement_import.py
+++ b/erpnext/accounts/doctype/bank_statement_import/bank_statement_import.py
@@ -51,7 +51,7 @@ class BankStatementImport(DataImport):
 			self.import_file, self.google_sheets_url
 		)
 
-		if 'Bank Account' not in json.dumps(preview):
+		if 'Bank Account' not in json.dumps(preview['columns']):
 			frappe.throw(_("Please add the Bank Account column"))
 
 		from frappe.core.page.background_jobs.background_jobs import get_info


### PR DESCRIPTION
Unable to import bank statement if the data has datetime values as datetime values are not JSON serializable

![image](https://user-images.githubusercontent.com/42651287/124133733-c124c600-da9f-11eb-85c7-971b06fdc570.png)

Changed the validation to just check for columns to check for bank account column