### PR TITLE
fix: Fixed Budget Variance Graph color from all black to default

### DIFF
--- a/erpnext/accounts/report/budget_variance_report/budget_variance_report.py
+++ b/erpnext/accounts/report/budget_variance_report/budget_variance_report.py
@@ -397,6 +397,7 @@ def get_chart_data(filters, columns, data):
 				{'name': 'Budget', 'chartType': 'bar', 'values': budget_values},
 				{'name': 'Actual Expense', 'chartType': 'bar', 'values': actual_values}
 			]
-		}
+		},
+		'type' : 'bar'
 	}
 


### PR DESCRIPTION
Budget Variance report had an all black graph due to an issue, fixed back to its default colors(pink,blue,..)

**Before:**
<img src="https://user-images.githubusercontent.com/36098155/124162436-0e169580-dabc-11eb-8323-302fafee2c1d.png" width='500px' height='400px'>

**After:**
<img src="https://user-images.githubusercontent.com/36098155/124162099-c42daf80-dabb-11eb-97e4-978c29a99076.png" width='500px' height='400px'>


