### PR TITLE
fix: Incorrect discount amount on amended document

### DIFF
--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -67,6 +67,8 @@ erpnext.taxes_and_totals = erpnext.payments.extend({
 
 	calculate_discount_amount: function(){
 		if (frappe.meta.get_docfield(this.frm.doc.doctype, "discount_amount")) {
+			this.calculate_item_values();
+			this.calculate_net_total();
 			this.set_discount_amount();
 			this.apply_discount_amount();
 		}


### PR DESCRIPTION
**Steps to replicate the issue**
- Make a Purchase Order with some additional discount applied
- Cancel the doc
- Now amend the doc and do not save, the calculated discount amount and net total will be incorrect. This is due to async nature of javascript, the discount is calculated on the already discounted values in the canceled doc before the base values are recalculated to get the right discount amount

**Solution:** Calculate item values and net total before calculating discount 