### PR TITLE
fix: added company filter while fetching loans

### DIFF
--- a/erpnext/loan_management/doctype/loan/loan.js
+++ b/erpnext/loan_management/doctype/loan/loan.js
@@ -28,7 +28,8 @@ frappe.ui.form.on('Loan', {
 		frm.set_query("loan_type", function () {
 			return {
 				"filters": {
-					"docstatus": 1
+					"docstatus": 1,
+					"company": frm.doc.company
 				}
 			};
 		});

--- a/erpnext/loan_management/doctype/loan_application/loan_application.js
+++ b/erpnext/loan_management/doctype/loan_application/loan_application.js
@@ -16,9 +16,16 @@ frappe.ui.form.on('Loan Application', {
 		frm.trigger("add_toolbar_buttons");
 	},
 	repayment_method: function(frm) {
-		frm.doc.repayment_amount = frm.doc.repayment_periods = ""
-		frm.trigger("toggle_fields")
-		frm.trigger("toggle_required")
+		frm.doc.repayment_amount = frm.doc.repayment_periods = "";
+		frm.trigger("toggle_fields");
+		frm.trigger("toggle_required");
+		frm.set_query('loan_type', () => {
+			return {
+				filters: {
+					company: frm.doc.company
+				}
+			};
+		});
 	},
 	toggle_fields: function(frm) {
 		frm.toggle_enable("repayment_amount", frm.doc.repayment_method=="Repay Fixed Amount per Period")

--- a/erpnext/loan_management/doctype/loan_application/loan_application.js
+++ b/erpnext/loan_management/doctype/loan_application/loan_application.js
@@ -14,11 +14,6 @@ frappe.ui.form.on('Loan Application', {
 	refresh: function(frm) {
 		frm.trigger("toggle_fields");
 		frm.trigger("add_toolbar_buttons");
-	},
-	repayment_method: function(frm) {
-		frm.doc.repayment_amount = frm.doc.repayment_periods = "";
-		frm.trigger("toggle_fields");
-		frm.trigger("toggle_required");
 		frm.set_query('loan_type', () => {
 			return {
 				filters: {
@@ -26,6 +21,11 @@ frappe.ui.form.on('Loan Application', {
 				}
 			};
 		});
+	},
+	repayment_method: function(frm) {
+		frm.doc.repayment_amount = frm.doc.repayment_periods = "";
+		frm.trigger("toggle_fields");
+		frm.trigger("toggle_required");
 	},
 	toggle_fields: function(frm) {
 		frm.toggle_enable("repayment_amount", frm.doc.repayment_method=="Repay Fixed Amount per Period")

--- a/erpnext/loan_management/doctype/loan_application/loan_application.js
+++ b/erpnext/loan_management/doctype/loan_application/loan_application.js
@@ -14,7 +14,7 @@ frappe.ui.form.on('Loan Application', {
 	refresh: function(frm) {
 		frm.trigger("toggle_fields");
 		frm.trigger("add_toolbar_buttons");
-		frm.set_query('loan_type', () => {
+		frm.set_query("loan_type", () => {
 			return {
 				filters: {
 					company: frm.doc.company

--- a/erpnext/payroll/doctype/salary_slip/salary_slip.py
+++ b/erpnext/payroll/doctype/salary_slip/salary_slip.py
@@ -1088,6 +1088,7 @@ class SalarySlip(TransactionBase):
 				"applicant": self.employee,
 				"docstatus": 1,
 				"repay_from_salary": 1,
+				"company": self.company
 			})
 
 	def make_loan_repayment_entry(self):

--- a/erpnext/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/erpnext/payroll/doctype/salary_slip/test_salary_slip.py
@@ -481,15 +481,19 @@ def make_employee_salary_slip(user, payroll_frequency, salary_structure=None):
 	if not salary_structure:
 		salary_structure = payroll_frequency + " Salary Structure Test for Salary Slip"
 
+	employee = frappe.db.get_value("Employee",
+					{
+						"user_id": user
+					},
+					["name", "company", "employee_name"],
+					as_dict=True)
 
-	employee = frappe.db.get_value("Employee", {"user_id": user})
-	salary_structure_doc = make_salary_structure(salary_structure, payroll_frequency, employee=employee)
+	salary_structure_doc = make_salary_structure(salary_structure, payroll_frequency, employee=employee.name, company=employee.company)
 	salary_slip_name = frappe.db.get_value("Salary Slip", {"employee": frappe.db.get_value("Employee", {"user_id": user})})
 
 	if not salary_slip_name:
-		salary_slip = make_salary_slip(salary_structure_doc.name, employee = employee)
-		salary_slip.employee_name = frappe.get_value("Employee",
-			{"name":frappe.db.get_value("Employee", {"user_id": user})}, "employee_name")
+		salary_slip = make_salary_slip(salary_structure_doc.name, employee = employee.name)
+		salary_slip.employee_name = employee.employee_name
 		salary_slip.payroll_frequency = payroll_frequency
 		salary_slip.posting_date = nowdate()
 		salary_slip.insert()

--- a/erpnext/payroll/doctype/salary_structure/test_salary_structure.py
+++ b/erpnext/payroll/doctype/salary_structure/test_salary_structure.py
@@ -119,26 +119,25 @@ def make_salary_structure(salary_structure, payroll_frequency, employee=None,
 	if test_tax:
 		frappe.db.sql("""delete from `tabSalary Structure` where name=%s""",(salary_structure))
 
-	if not frappe.db.exists('Salary Structure', salary_structure):
-		details = {
-			"doctype": "Salary Structure",
-			"name": salary_structure,
-			"company": company or erpnext.get_default_company(),
-			"earnings": make_earning_salary_component(setup=True,  test_tax=test_tax, company_list=["_Test Company"]),
-			"deductions": make_deduction_salary_component(setup=True, test_tax=test_tax, company_list=["_Test Company"]),
-			"payroll_frequency": payroll_frequency,
-			"payment_account": get_random("Account", filters={'account_currency': currency}),
-			"currency": currency
-		}
-		if other_details and isinstance(other_details, dict):
-			details.update(other_details)
-		salary_structure_doc = frappe.get_doc(details)
-		salary_structure_doc.insert()
-		if not dont_submit:
-			salary_structure_doc.submit()
+	if frappe.db.exists("Salary Structure", salary_structure):
+		frappe.db.delete("Salary Structure", salary_structure)
 
-	else:
-		salary_structure_doc = frappe.get_doc("Salary Structure", salary_structure)
+	details = {
+		"doctype": "Salary Structure",
+		"name": salary_structure,
+		"company": company or erpnext.get_default_company(),
+		"earnings": make_earning_salary_component(setup=True,  test_tax=test_tax, company_list=["_Test Company"]),
+		"deductions": make_deduction_salary_component(setup=True, test_tax=test_tax, company_list=["_Test Company"]),
+		"payroll_frequency": payroll_frequency,
+		"payment_account": get_random("Account", filters={"account_currency": currency}),
+		"currency": currency
+	}
+	if other_details and isinstance(other_details, dict):
+		details.update(other_details)
+	salary_structure_doc = frappe.get_doc(details)
+	salary_structure_doc.insert()
+	if not dont_submit:
+		salary_structure_doc.submit()
 
 	filters = {'employee':employee, 'docstatus': 1}
 	if not from_date and payroll_period:


### PR DESCRIPTION
**Company filter for Loan Type**

1. While creating a Loan or Loan Application, it should only display the loan types that fall under the company that's selected.

![Screenshot 2021-07-02 at 10 57 34 AM](https://user-images.githubusercontent.com/31363128/124235721-3b525a80-db33-11eb-8305-b077dc0d278b.png)

**Salary Slip**

1. When a salary slip is created it should only consider the loan that's taken from the company that's selected in the salary slip.