### PR TITLE
fix: only "Tax" type accounts should be shown for selection in GST Settings

### DIFF
--- a/erpnext/regional/doctype/gst_settings/gst_settings.js
+++ b/erpnext/regional/doctype/gst_settings/gst_settings.js
@@ -35,6 +35,7 @@ frappe.ui.form.on('GST Settings', {
 			return {
 				filters: {
 					company: row.company,
+					account_type: "Tax",
 					is_group: 0
 				}
 			};


### PR DESCRIPTION
Before all accounts of a company were allowed to be selected in GST Settings.
![Screenshot 2021-07-02 at 3 32 04 PM](https://user-images.githubusercontent.com/33727827/124258624-41eccc00-db4b-11eb-9c21-dc06d94d6636.png)

But only the accounts with "Account Type" as "Tax" should be allowed.
![Screenshot 2021-07-02 at 3 32 44 PM](https://user-images.githubusercontent.com/33727827/124258714-5761f600-db4b-11eb-956d-f3468e49e049.png)
