### PR TITLE
fix: only "Tax" type accounts should be shown for selection in GST Settings

### DIFF
--- a/erpnext/regional/doctype/gst_settings/gst_settings.js
+++ b/erpnext/regional/doctype/gst_settings/gst_settings.js
@@ -35,6 +35,7 @@ frappe.ui.form.on('GST Settings', {
 			return {
 				filters: {
 					company: row.company,
+					account_type: "Tax",
 					is_group: 0
 				}
 			};


### PR DESCRIPTION
Backport of https://github.com/frappe/erpnext/pull/26299