### PR TITLE
fix: stock level dashboard disappearing after refresh

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -42,6 +42,6 @@ sed -i 's/socketio:/# socketio:/g' Procfile
 sed -i 's/redis_socketio:/# redis_socketio:/g' Procfile
 
 bench get-app erpnext "${GITHUB_WORKSPACE}"
-bench start &
+bench start &> bench_run_logs.txt &
 bench --site test_site reinstall --yes
 bench build --app frappe

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -102,3 +102,7 @@ jobs:
         run: cd ~/frappe-bench/ && bench --site test_site run-ui-tests erpnext --headless
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+
+      - name: Show bench console if tests failed
+        if: ${{ failure() }}
+        run: cat ~/frappe-bench/bench_run_logs.txt

--- a/cypress/integration/test_item.js
+++ b/cypress/integration/test_item.js
@@ -1,0 +1,44 @@
+describe("Test Item Dashboard", () => {
+	before(() => {
+		cy.login();
+		cy.visit("/app/item");
+		cy.insert_doc(
+			"Item",
+			{
+				item_code: "e2e_test_item",
+				item_group: "All Item Groups",
+				opening_stock: 42,
+				valuation_rate: 100,
+			},
+			true
+		);
+		cy.go_to_doc("item", "e2e_test_item");
+	});
+
+	it("should show dashboard with correct data on first load", () => {
+		cy.get(".stock-levels").contains("Stock Levels").should("be.visible");
+		cy.get(".stock-levels").contains("e2e_test_item").should("exist");
+
+		// reserved and available qty
+		cy.get(".stock-levels .inline-graph-count")
+			.eq(0)
+			.contains("0")
+			.should("exist");
+		cy.get(".stock-levels .inline-graph-count")
+			.eq(1)
+			.contains("42")
+			.should("exist");
+	});
+
+	it("should persist on field change", () => {
+		cy.get('input[data-fieldname="disabled"]').check();
+		cy.wait(500);
+		cy.get(".stock-levels").contains("Stock Levels").should("be.visible");
+		cy.get(".stock-levels").should("have.length", 1);
+	});
+
+	it("should persist on reload", () => {
+		cy.reload();
+		cy.get(".stock-levels").contains("Stock Levels").should("be.visible");
+	});
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -23,3 +23,9 @@
 //
 // -- This is will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... });
+
+const slug = (name) => name.toLowerCase().replace(" ", "-");
+
+Cypress.Commands.add("go_to_doc", (doctype, name) => {
+	cy.visit(`/app/${slug(doctype)}/${encodeURIComponent(name)}`);
+});

--- a/erpnext/setup/utils.py
+++ b/erpnext/setup/utils.py
@@ -28,21 +28,21 @@ def before_tests():
 	from frappe.desk.page.setup_wizard.setup_wizard import setup_complete
 	if not frappe.get_list("Company"):
 		setup_complete({
-			"currency"			:"USD",
-			"full_name"			:"Test User",
-			"company_name"		:"Wind Power LLC",
-			"timezone"			:"America/New_York",
-			"company_abbr"		:"WP",
-			"industry"			:"Manufacturing",
-			"country"			:"United States",
-			"fy_start_date"		:"2011-01-01",
-			"fy_end_date"		:"2011-12-31",
-			"language"			:"english",
-			"company_tagline"	:"Testing",
-			"email"				:"test@erpnext.com",
-			"password"			:"test",
+			"currency"          :"USD",
+			"full_name"         :"Test User",
+			"company_name"      :"Wind Power LLC",
+			"timezone"          :"America/New_York",
+			"company_abbr"      :"WP",
+			"industry"          :"Manufacturing",
+			"country"           :"United States",
+			"fy_start_date"     :"2021-01-01",
+			"fy_end_date"       :"2021-12-31",
+			"language"          :"english",
+			"company_tagline"   :"Testing",
+			"email"             :"test@erpnext.com",
+			"password"          :"test",
 			"chart_of_accounts" : "Standard",
-			"domains"			: ["Manufacturing"],
+			"domains"           : ["Manufacturing"],
 		})
 
 	frappe.db.sql("delete from `tabLeave Allocation`")

--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -93,7 +93,7 @@ frappe.ui.form.on("Item", {
 
 		erpnext.item.edit_prices_button(frm);
 		erpnext.item.toggle_attributes(frm);
-		
+
 		if (!frm.doc.is_fixed_asset) {
 			erpnext.item.make_dashboard(frm);
 		}
@@ -381,7 +381,8 @@ $.extend(erpnext.item, {
 		// Show Stock Levels only if is_stock_item
 		if (frm.doc.is_stock_item) {
 			frappe.require('item-dashboard.bundle.js', function() {
-				const section = frm.dashboard.add_section('', __("Stock Levels"));
+				frm.dashboard.parent.find('.stock-levels').remove();
+				const section = frm.dashboard.add_section('', __("Stock Levels"), 'stock-levels');
 				erpnext.item.item_dashboard = new erpnext.stock.ItemDashboard({
 					parent: section,
 					item_code: frm.doc.name,


### PR DESCRIPTION
Problem: When `refresh_section` is called, all `.custom` class dashboards are removed, this makes the stock dashboard go away. Earlier this was fixed by reordering execution in https://github.com/frappe/erpnext/pull/25506 but now refresh section gets called after each field change due to https://github.com/frappe/frappe/pull/13355


Solution: use `stock-levels` as a class instead of the default `custom` that's removed. This also means we need to manually clear it before creating a new one to avoid duplicates. 

Also added UI test, so this doesn't break again. 

PS: To test you need to disable developer mode (as that disables caching.)


closes: https://github.com/frappe/erpnext/issues/26260
