### PR TITLE
fix: Update Ewaybill Tool Version

### DIFF
--- a/erpnext/regional/india/utils.py
+++ b/erpnext/regional/india/utils.py
@@ -473,7 +473,7 @@ def get_ewb_data(dt, dn):
 		ewaybills.append(data)
 
 	data = {
-		'version': '1.0.1118',
+		'version': '1.0.0621',
 		'billLists': ewaybills
 	}
 


### PR DESCRIPTION
As govt makes changes to excel tool, it changes version and old versions are withdrawn.

Changes to excel tool is not affecting our JSON file, and it's working with just change in version.

![image](https://user-images.githubusercontent.com/10496564/124346600-702ae400-dbfd-11eb-936e-718146b805b4.png)
