### PR TITLE
fix: allow to make job card without employee

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -192,21 +192,29 @@ class JobCard(Document):
 						"completed_qty": args.get("completed_qty") or 0.0
 					})
 		elif args.get("start_time"):
-			for name in employees:
-				self.append("time_logs", {
-					"from_time": get_datetime(args.get("start_time")),
-					"employee": name.get('employee'),
-					"operation": args.get("sub_operation"),
-					"completed_qty": 0.0
-				})
+			new_args = {
+				"from_time": get_datetime(args.get("start_time")),
+				"operation": args.get("sub_operation"),
+				"completed_qty": 0.0
+			}
 
-		if not self.employee:
+			if employees:
+				for name in employees:
+					new_args.employee = name.get('employee')
+					self.add_start_time_log(new_args)
+			else:
+				self.add_start_time_log(new_args)
+
+		if not self.employee and employees:
 			self.set_employees(employees)
 
 		if self.status == "On Hold":
 			self.current_time = time_diff_in_seconds(last_row.to_time, last_row.from_time)
 
 		self.save()
+
+	def add_start_time_log(self, args):
+		self.append("time_logs", args)
 
 	def set_employees(self, employees):
 		for name in employees:


### PR DESCRIPTION
**Issue**

Goto Job Card > Click on start button > don't select employee > click on Submit button > You will get below Error

```
Traceback (most recent call last):
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/frappe/frappe/app.py", line 68, in application
    response = frappe.api.handle()
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/frappe/frappe/handler.py", line 31, in handle
    data = execute_cmd(cmd)
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/frappe/frappe/handler.py", line 67, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/frappe/frappe/__init__.py", line 1172, in call
    return fn(*args, **newargs)
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/erpnext/erpnext/manufacturing/doctype/job_card/job_card.py", line 532, in make_time_log
    doc.add_time_log(args)
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/erpnext/erpnext/manufacturing/doctype/job_card/job_card.py", line 195, in add_time_log
    for name in employees:
TypeError: 'NoneType' object is not iterable
```