### PR TITLE
fix: incorrect bom no. added for non-variant items on variant boms (bp #26320)

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -1100,6 +1100,8 @@ def make_variant_bom(source_name, bom_no, item, variant_items, target_doc=None):
 		},
 		'BOM Item': {
 			'doctype': 'BOM Item',
+			# stop get_mapped_doc copying parent bom_no to children
+			'field_no_map': ['bom_no'],
 			'condition': lambda doc: doc.has_variants == 0
 		},
 	}, target_doc, postprocess)


### PR DESCRIPTION
Backports the following commits to develop:
 - fix: incorrect bom no. added for non-variant items on variant boms (#26320)