### PR TITLE
fix: optimized reposting code to improve performance

### DIFF
--- a/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.json
+++ b/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.json
@@ -142,6 +142,7 @@
    "oldfieldtype": "Data",
    "print_width": "150px",
    "read_only": 1,
+   "search_index": 1,
    "width": "150px"
   },
   {
@@ -316,7 +317,7 @@
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2020-09-07 11:10:35.318872",
+ "modified": "2021-07-05 16:56:18.957206",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Ledger Entry",


### PR DESCRIPTION
**Issue**

While doing reposting for Repost Item Valuation system took more than 2 hours and even the reposting was not completed after 2 hours. After debug the codeI found that for the Manufacture type of stock entry, system does the reposting multiple times (as per number of raw materials used in the stock entry). For example in the below Manufacture stock entry, 10 raw materials were used to produce finished goods. 

<img width="1020" alt="Screenshot 2021-07-05 at 4 43 10 PM" src="https://user-images.githubusercontent.com/8780500/124463371-6d242500-ddb0-11eb-90fb-da05a705788d.png">



During repost if out of 10 the 5 materials has been reposted then system was reposting finished good sle 5 times and due to which system was taking a lot of time to repost the transactions and remain in the In Progress state.


**After Fix**
System will do reposting of finished goods only once after completion of raw materials reposting. After change in the code system took 2 mins to complete reposting. Also added index on the column voucher_detail_no field in the table `tabStock Ledger Entry`

![image](https://user-images.githubusercontent.com/8780500/124462454-503b2200-ddaf-11eb-9ffc-ad87fdef6aaf.png)
