### PR TITLE
fix: Include Stock Reco logic in `update_qty_in_future_sle`

### DIFF
--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -357,6 +357,7 @@ class StockReconciliation(StockController):
 			if row.current_qty:
 				data.actual_qty = -1 * row.current_qty
 				data.qty_after_transaction = flt(row.current_qty)
+				data.previous_qty_after_transaction = flt(row.qty)
 				data.valuation_rate = flt(row.current_valuation_rate)
 				data.stock_value = data.qty_after_transaction * data.valuation_rate
 				data.stock_value_difference = -1 * flt(row.amount_difference)

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -875,8 +875,6 @@ def get_valuation_rate(item_code, warehouse, voucher_type, voucher_no,
 def update_qty_in_future_sle(args, allow_negative_stock=None):
 	"""Recalculate Qty after Transaction in future SLEs based on current SLE."""
 	datetime_limit_condition = ""
-	last_balance = None
-
 	qty_shift = args.actual_qty
 
 	# find difference/shift in qty caused by stock reconciliation
@@ -937,7 +935,7 @@ def get_next_stock_reco(args):
 		select
 			name, posting_date, posting_time, creation, voucher_no
 		from
-			 `tabStock Ledger Entry`
+			`tabStock Ledger Entry`
 		where
 			item_code = %(item_code)s
 			and warehouse = %(warehouse)s
@@ -954,8 +952,6 @@ def get_next_stock_reco(args):
 	""", args, as_dict=1)
 
 def get_datetime_limit_condition(detail):
-	if not detail: return None
-
 	return f"""
 		and
 		(timestamp(posting_date, posting_time) < timestamp('{detail.posting_date}', '{detail.posting_time}')


### PR DESCRIPTION
Port of https://github.com/frappe/erpnext/pull/26158

**Issue:**
--------------------
- On creating a backdated stock reconciliation, future quantity was not reposted due to incorrect logic in `update_qty_in_future_sle` and a missing case for stock reconciliations
   ![Screenshot 2021-06-22 at 9 38 18 PM](https://user-images.githubusercontent.com/25857446/122960966-92249b00-d3a1-11eb-82cf-47f025b5cf7a.png)
- The **actual_qty** was used to adjust future SLEs, which is always 0 in stock reco SLEs
- This allowed submission of Stock Recos that created insufficient stock for the future. It should have been blocked on submit

**Fix:**
-----------------------------
- Consider shift in qty i.e. **difference between previous SLE and current Stock Reco SLE**, for Stock Reconciliation while updating future SLEs
- Add all future SLEs' Qty after Transaction by this shift in qty
- Validate negative stock for Stock Reco too

### **Cases**
Consider:
<table>
 <th>No.</th>
  <th>Document</th>
  <th>Date</th>
  <th>Qty</th>
  <th>Balance Qty</th>
  <tr>
    <td>1</td>
    <td>PR</td>
    <td>2nd June</td>
    <td>10</td>
   <td>10</td>
  </tr>
  <tr>
    <td>2</td>
    <td>DN</td>
    <td>3rd June</td>
    <td>-1</td>
   <td>9</td>
  </tr>
  <tr>
    <td>3</td>
    <td>PR</td>
    <td>5th June</td>
    <td>1</td>
   <td>10</td>
  </tr>
</table>

- Post a backdated reco 1 on the 1st for qty 8. The shift in qty is 8 since there is no transaction before this reco. The future SLE balances are shifted by **8**.
   <table>
     <th>No.</th>
     <th>Document</th>
     <th>Date</th>
     <th>Qty</th>
     <th>Balance Qty</th>
     <th>Balance after Reco 1</th>
     <tr>
       <td>4</td>
      <td> <b>Reco 1</b> </td>
      <td>1st June</td>
      <td>0</td>
      <td>8</td>
      <td>8</td>
    </tr>
    <tr>
      <td>1</td>
      <td>PR</td>
      <td>2nd June</td>
      <td>10</td>
     <td><strike>10</strike></td>
     <td>18</td>
    </tr>
    <tr>
      <td>2</td>
      <td>DN</td>
      <td>3rd June</td>
      <td>-1</td>
      <td><strike>9</strike></td>
      <td>17</td>
    </tr>
    <tr>
      <td>3</td>
      <td>PR</td>
      <td>5th June</td>
      <td>1</td>
      <td><strike>10</strike></td>
      <td>18</td>
    </tr>
  </table>

- Post a backdated reco 2 on the 4th for qty 6. The shift in qty =  **current balance after reco 2** - **previous balance before reco 2** = **6** - **9** = **-3**. The future SLE balances are shifted by **-3**

   <table>
     <th>No.</th>
     <th>Document</th>
     <th>Date</th>
     <th>Qty</th>
     <th>Balance Qty</th>
     <th>Balance after Reco 2</th>
    <tr>
      <td>1</td>
      <td>PR</td>
      <td>2nd June</td>
      <td>10</td>
     <td>10</td>
     <td></td>
    </tr>
    <tr>
      <td>2</td>
      <td>DN</td>
      <td>3rd June</td>
      <td>-1</td>
      <td>9</td>
      <td></td>
    </tr>
    <tr>
      <td>4</td>
      <td> <b>Reco 2</b> </td>
      <td>4th June</td>
      <td>0</td>
      <td>6</td>
      <td>6</td>
    </tr>
    <tr>
      <td>3</td>
      <td>PR</td>
      <td>5th June</td>
      <td>1</td>
      <td><strike>10</strike></td>
      <td>7</td>
    </tr>
  </table>

- If a reco (Reco 1) is posted on 4th (as previously seen) and then another reco (Reco 2) on the 1st, the qty recalculation after submitting **Reco 2** must happen only till the 3rd (**any time before Reco 1**)

  <table>
     <th>No.</th>
     <th>Document</th>
     <th>Date</th>
     <th>Qty</th>
     <th>Balance Qty</th>
     <th>Balance after Reco 2</th>
     <tr>
      <td>5</td>
      <td> <b>Reco 2</b> </td>
      <td>1st June</td>
      <td>0</td>
     <td>8</td>
     <td>8</td>
    </tr>
    <tr>
      <td>1</td>
      <td>PR</td>
      <td>2nd June</td>
      <td>10</td>
     <td><strike>10</strike></td>
     <td>18</td>
    </tr>
    <tr>
      <td>2</td>
      <td>DN</td>
      <td>3rd June</td>
      <td>-1</td>
      <td><strike>9</strike></td>
      <td>17</td>
    </tr>
    <tr>
      <td>4</td>
      <td> <b>Reco 1</b> </td>
      <td>4th June</td>
      <td>0</td>
      <td>6</td>
      <td></td>
    </tr>
    <tr>
      <td>3</td>
      <td>PR</td>
      <td>5th June</td>
      <td>1</td>
      <td>7</td>
      <td></td>
    </tr>
  </table>
 
- Posting a backdated reco that causes future negative stock should be stopped

   <table>
     <th>No.</th>
     <th>Document</th>
     <th>Date</th>
     <th>Qty</th>
     <th>Balance Qty</th>
     <th>Balance after Reco 1</th>
    <tr>
      <td>1</td>
      <td>PR</td>
      <td>2nd June</td>
      <td>10</td>
     <td>10</td>
     <td></td>
    </tr>
    <tr>
       <td>4</td>
      <td> <b>Reco 1</b> </td>
      <td>3rd June 8am</td>
      <td>0</td>
      <td>0</td>
      <td>NA due to blocked Reco</td>
    </tr>
    <tr>
      <td>2</td>
      <td>DN</td>
      <td>3rd June 10 am</td>
      <td>-1</td>
      <td>9</td>
      <td></td>
    </tr>
    <tr>
      <td>3</td>
      <td>PR</td>
      <td>5th June</td>
      <td>1</td>
      <td>10</td>
      <td></td>
    </tr>
  </table>