### PR TITLE
fix: stock entry with putaway rule not working

### DIFF
--- a/erpnext/stock/doctype/putaway_rule/putaway_rule.py
+++ b/erpnext/stock/doctype/putaway_rule/putaway_rule.py
@@ -97,7 +97,7 @@ def apply_putaway_rule(doctype, items, company, sync=None, purpose=None):
 		at_capacity, rules = get_ordered_putaway_rules(item_code, company, source_warehouse=source_warehouse)
 
 		if not rules:
-			warehouse = source_warehouse or item.warehouse
+			warehouse = source_warehouse or item.get('warehouse')
 			if at_capacity:
 				# rules available, but no free space
 				items_not_accomodated.append([item_code, pending_qty])


### PR DESCRIPTION
**Issue**

1. Make stock entry with type as 'Material Receipt'
2. Enabled Putaway Rule checkbox and select item against which Putaway Rule has not made
3. Try to save stock entry you will get below error

```
Traceback (most recent call last):
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/frappe/frappe/app.py", line 68, in application
    response = frappe.api.handle()
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/frappe/frappe/handler.py", line 31, in handle
    data = execute_cmd(cmd)
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/frappe/frappe/handler.py", line 67, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/frappe/frappe/__init__.py", line 1172, in call
    return fn(*args, **newargs)
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/frappe/frappe/desk/form/save.py", line 21, in savedocs
    doc.save()
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/frappe/frappe/model/document.py", line 285, in save
    return self._save(*args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/frappe/frappe/model/document.py", line 320, in _save
    self.run_before_save_methods()
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/frappe/frappe/model/document.py", line 955, in run_before_save_methods
    self.run_method("before_validate")
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/frappe/frappe/model/document.py", line 859, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/frappe/frappe/model/document.py", line 1148, in composer
    return composed(self, method, *args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/frappe/frappe/model/document.py", line 1131, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/frappe/frappe/model/document.py", line 853, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.py", line 52, in before_validate
    purpose=self.purpose)
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/erpnext/erpnext/stock/doctype/putaway_rule/putaway_rule.py", line 101, in apply_putaway_rule
    warehouse = source_warehouse or item.warehouse
AttributeError: 'StockEntryDetail' object has no attribute 'warehouse'
```