### PR TITLE
fix: value fetching for custom field in POS

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_payment.js
+++ b/erpnext/selling/page/point_of_sale/pos_payment.js
@@ -56,7 +56,7 @@ erpnext.PointOfSale.Payment = class {
 				);
 				let df_events = {
 					onchange: function() {
-						frm.set_value(this.df.fieldname, this.value);
+						frm.set_value(this.df.fieldname, this.get_value());
 					}
 				};
 				if (df.fieldtype == "Button") {


### PR DESCRIPTION
value for custom field was being fetched as undefined, fixed it by using this.get_value() method instead

port for: https://github.com/frappe/erpnext/pull/26366

Steps followed:
1. Added custom fields in POS Invoice, under the Payment section(`pos_payment.js`).
2. Realised the value of the custom fields were not getting fetched.
3. Replaced `this.value` by `this.get_value()` method and it started fetching correctly.