### PR TITLE
fix: Fixed Budget Variance Graph color from all black to default

### DIFF
--- a/erpnext/accounts/report/budget_variance_report/budget_variance_report.py
+++ b/erpnext/accounts/report/budget_variance_report/budget_variance_report.py
@@ -397,6 +397,7 @@ def get_chart_data(filters, columns, data):
 				{'name': 'Budget', 'chartType': 'bar', 'values': budget_values},
 				{'name': 'Actual Expense', 'chartType': 'bar', 'values': actual_values}
 			]
-		}
+		},
+		'type' : 'bar'
 	}
 


### PR DESCRIPTION
Budget Variance report had an all black graph due to an issue, fixed back to its default colors(pink,blue,..)
port for : https://github.com/frappe/erpnext/pull/26289
Before:
<img height='400' width='500' src='https://user-images.githubusercontent.com/36098155/124736413-9c639f00-df34-11eb-8f31-ee24e1504b3a.png'>

After:
<img height='400' width='500' src='https://user-images.githubusercontent.com/36098155/124736437-a1c0e980-df34-11eb-898f-4a2c33038794.png'>
