### PR TITLE
fix: validation check for batch for stock reconciliation type in stock entry

### DIFF
--- a/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py
+++ b/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py
@@ -89,17 +89,16 @@ class StockLedgerEntry(Document):
 		if item_det.is_stock_item != 1:
 			frappe.throw(_("Item {0} must be a stock Item").format(self.item_code))
 
-		# check if batch number is required
-		if self.voucher_type != 'Stock Reconciliation':
-			if item_det.has_batch_no == 1:
-				batch_item = self.item_code if self.item_code == item_det.item_name else self.item_code + ":" +  item_det.item_name
-				if not self.batch_no:
-					frappe.throw(_("Batch number is mandatory for Item {0}").format(batch_item))
-				elif not frappe.db.get_value("Batch",{"item": self.item_code, "name": self.batch_no}):
-					frappe.throw(_("{0} is not a valid Batch Number for Item {1}").format(self.batch_no, batch_item))
+		# check if batch number is valid
+		if item_det.has_batch_no == 1:
+			batch_item = self.item_code if self.item_code == item_det.item_name else self.item_code + ":" + item_det.item_name
+			if not self.batch_no:
+				frappe.throw(_("Batch number is mandatory for Item {0}").format(batch_item))
+			elif not frappe.db.get_value("Batch",{"item": self.item_code, "name": self.batch_no}):
+				frappe.throw(_("{0} is not a valid Batch Number for Item {1}").format(self.batch_no, batch_item))
 
-			elif item_det.has_batch_no == 0 and self.batch_no and self.is_cancelled == 0:
-				frappe.throw(_("The Item {0} cannot have Batch").format(self.item_code))
+		elif item_det.has_batch_no == 0 and self.batch_no and self.is_cancelled == 0:
+			frappe.throw(_("The Item {0} cannot have Batch").format(self.item_code))
 
 		if item_det.has_variants:
 			frappe.throw(_("Stock cannot exist for Item {0} since has variants").format(self.item_code),

--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.js
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.js
@@ -17,6 +17,14 @@ frappe.ui.form.on("Stock Reconciliation", {
 				}
 			}
 		});
+		frm.set_query("batch_no", "items", function(doc, cdt, cdn) {
+			var item = locals[cdt][cdn];
+			return {
+				filters: {
+					'item': item.item_code
+				}
+			};
+		});
 
 		if (frm.doc.company) {
 			erpnext.queries.setup_queries(frm, "Warehouse", function() {

--- a/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
@@ -16,6 +16,7 @@ from erpnext.stock.utils import get_incoming_rate, get_stock_value_on, get_valua
 from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos
 from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import make_purchase_receipt
 
+
 class TestStockReconciliation(unittest.TestCase):
 	@classmethod
 	def setUpClass(self):
@@ -315,6 +316,26 @@ class TestStockReconciliation(unittest.TestCase):
 		sr3.cancel()
 		dn2.cancel()
 		pr1.cancel()
+
+	def test_valid_batch(self):
+		create_batch_item_with_batch("Testing Batch Item 1", "001")
+		create_batch_item_with_batch("Testing Batch Item 2", "002")
+		sr = create_stock_reconciliation(item_code="Testing Batch Item 1", qty=1, rate=100, batch_no="002"
+			, do_not_submit=True)
+		self.assertRaises(frappe.ValidationError, sr.submit)
+
+def create_batch_item_with_batch(item_name, batch_id):
+	batch_item_doc = create_item(item_name, is_stock_item=1)
+	if not batch_item_doc.has_batch_no:
+		batch_item_doc.has_batch_no = 1
+		batch_item_doc.create_new_batch = 1
+		batch_item_doc.save(ignore_permissions=True)
+
+	if not frappe.db.exists('Batch', batch_id):
+		b = frappe.new_doc('Batch')
+		b.item = item_name
+		b.batch_id = batch_id
+		b.save()
 
 def insert_existing_sle(warehouse):
 	from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry


### PR DESCRIPTION
**Issue:**
- There were no filters while selecting batch in stock reconciliation.
![image](https://user-images.githubusercontent.com/43572428/124743069-f9faea00-df3a-11eb-9fcd-38493521c10c.png)

- The check for valid batch no. was skipped if Voucher_Type = "Stock Reconciliation".

**Changes**
- Added Filters for batch no.
![image](https://user-images.githubusercontent.com/43572428/124743302-3c242b80-df3b-11eb-858a-9142ad189f03.png)

- Validation check for batch also validates if Voucher_type is "Stock Reconciliation"