### PR TITLE
fix: column 'outstanding_amount' cannot be null

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -1318,9 +1318,9 @@ def get_reference_details(reference_doctype, reference_name, party_account_curre
 
 	return frappe._dict({
 		"due_date": ref_doc.get("due_date"),
-		"total_amount": total_amount,
-		"outstanding_amount": outstanding_amount,
-		"exchange_rate": exchange_rate,
+		"total_amount": flt(total_amount),
+		"outstanding_amount": flt(outstanding_amount),
+		"exchange_rate": flt(exchange_rate),
 		"bill_no": bill_no
 	})
 


### PR DESCRIPTION
Fix a case, where if the Payment Entry Reference is Journal Entry with MultiCurrency enabled then the `outstanding_amount` is set as None which throws error on Payment Entry submission

<details>
<summary>Traceback</summary>

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-13-2021-06-18/apps/erpnext/erpnext/accounts/doctype/payment_entry/payment_entry.py", line 75, in on_submit
    self.update_outstanding_amounts()
  File "/home/frappe/benches/bench-version-13-2021-06-18/apps/erpnext/erpnext/accounts/doctype/payment_entry/payment_entry.py", line 99, in update_outstanding_amounts
    self.set_missing_ref_details(force=True)
  File "/home/frappe/benches/bench-version-13-2021-06-18/apps/erpnext/erpnext/accounts/doctype/payment_entry/payment_entry.py", line 187, in set_missing_ref_details
    d.db_set(field, value)
  File "/home/frappe/benches/bench-version-13-2021-06-18/apps/frappe/frappe/model/document.py", line 1071, in db_set
    self.modified, self.modified_by, update_modified=update_modified)
  File "/home/frappe/benches/bench-version-13-2021-06-18/apps/frappe/frappe/database/database.py", line 667, in set_value
    values, debug=debug)
  File "/home/frappe/benches/bench-version-13-2021-06-18/apps/frappe/frappe/database/database.py", line 146, in sql
    self._cursor.execute(query, values)
  File "/home/frappe/benches/bench-version-13-2021-06-18/env/lib/python3.6/site-packages/pymysql/cursors.py", line 148, in execute
    result = self._query(query)
  File "/home/frappe/benches/bench-version-13-2021-06-18/env/lib/python3.6/site-packages/pymysql/cursors.py", line 310, in _query
    conn.query(q)
  File "/home/frappe/benches/bench-version-13-2021-06-18/env/lib/python3.6/site-packages/pymysql/connections.py", line 548, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/home/frappe/benches/bench-version-13-2021-06-18/env/lib/python3.6/site-packages/pymysql/connections.py", line 775, in _read_query_result
    result.read()
  File "/home/frappe/benches/bench-version-13-2021-06-18/env/lib/python3.6/site-packages/pymysql/connections.py", line 1156, in read
    first_packet = self.connection._read_packet()
  File "/home/frappe/benches/bench-version-13-2021-06-18/env/lib/python3.6/site-packages/pymysql/connections.py", line 725, in _read_packet
    packet.raise_for_error()
  File "/home/frappe/benches/bench-version-13-2021-06-18/env/lib/python3.6/site-packages/pymysql/protocol.py", line 221, in raise_for_error
    err.raise_mysql_exception(self._data)
  File "/home/frappe/benches/bench-version-13-2021-06-18/env/lib/python3.6/site-packages/pymysql/err.py", line 143, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.IntegrityError: (1048, "Column 'outstanding_amount' cannot be null")
```
Ref. Issue: ISS-21-22-03540
</details>