### PR TITLE
fix(tests): flaky SLA test and precision in Payment Entry test

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
@@ -589,9 +589,9 @@ class TestPaymentEntry(unittest.TestCase):
 		party_account_balance = get_balance_on(account=pe.paid_from, cost_center=pe.cost_center)
 
 		self.assertEqual(pe.cost_center, si.cost_center)
-		self.assertEqual(expected_account_balance, account_balance)
-		self.assertEqual(expected_party_balance, party_balance)
-		self.assertEqual(expected_party_account_balance, party_account_balance)
+		self.assertEqual(flt(expected_account_balance), account_balance)
+		self.assertEqual(flt(expected_party_balance), party_balance)
+		self.assertEqual(flt(expected_party_account_balance), party_account_balance)
 
 def create_payment_terms_template():
 

--- a/erpnext/support/doctype/service_level_agreement/service_level_agreement.json
+++ b/erpnext/support/doctype/service_level_agreement/service_level_agreement.json
@@ -150,7 +150,8 @@
    "fieldtype": "Link",
    "label": "Document Type",
    "options": "DocType",
-   "reqd": 1
+   "reqd": 1,
+   "set_only_once": 1
   },
   {
    "default": "1",
@@ -178,7 +179,7 @@
   }
  ],
  "links": [],
- "modified": "2021-05-29 13:35:41.956849",
+ "modified": "2021-07-08 12:28:46.283334",
  "modified_by": "Administrator",
  "module": "Support",
  "name": "Service Level Agreement",

--- a/erpnext/support/doctype/service_level_agreement/test_service_level_agreement.py
+++ b/erpnext/support/doctype/service_level_agreement/test_service_level_agreement.py
@@ -328,16 +328,11 @@ def create_service_level_agreement(default_service_level_agreement, holiday_list
 			"entity": entity
 		})
 
-	service_level_agreement_exists = frappe.db.exists("Service Level Agreement", filters)
+	sla = frappe.db.exists("Service Level Agreement", filters)
+	if sla:
+		frappe.delete_doc("Service Level Agreement", sla, force=1)
 
-	if not service_level_agreement_exists:
-		doc = frappe.get_doc(service_level_agreement).insert(ignore_permissions=True)
-	else:
-		doc = frappe.get_doc("Service Level Agreement", service_level_agreement_exists)
-		doc.update(service_level_agreement)
-		doc.save()
-
-	return doc
+	return frappe.get_doc(service_level_agreement).insert(ignore_permissions=True)
 
 
 def create_customer():


### PR DESCRIPTION
SLA test still failing randomly even after https://github.com/frappe/erpnext/pull/26347

- Enable `set_only_once` for document type field since all the custom / docfield creation happens only on the `before_insert` event
- Recreate SLA for tests if it already exists