### PR TITLE
feat: GST naming series - inform users about two extra chars on amending

### DIFF
--- a/erpnext/regional/india/utils.py
+++ b/erpnext/regional/india/utils.py
@@ -163,7 +163,8 @@ def validate_document_name(doc, method=None):
 		return
 
 	if len(doc.name) > 16:
-		frappe.throw(_("Maximum length of document number should be 16 characters as per GST rules. Please change the naming series."))
+		frappe.throw(_("Maximum length of document number should be 16 characters as per GST rules. Please change the naming series. \
+		Keep in mind that submittable documents will add \"-n\" to the end of document name upon on amending. Limit naming series to 14 characters in that case."))
 
 	if not GST_INVOICE_NUMBER_FORMAT.match(doc.name):
 		frappe.throw(_("Document name should only contain alphanumeric values, dash(-) and slash(/) characters as per GST rules. Please change the naming series."))


### PR DESCRIPTION
GST rules mandates 16 as the upper limit of number of characters. Users therefore might unknowingly set 15/16 chars in the naming series which will cause issue upon amending(extra 2 chars). The mess it can create in the middle of a financial year is huge considering the fact that we have immutable ledgers.

This PR informs users to limit it to 14 in case of submittable documents.
![image](https://user-images.githubusercontent.com/52111700/124911133-0dc15180-e00a-11eb-8f11-36a64c90c4e4.png)
