### PR TITLE
fix(report): iterate on accounts only when accounts exist

### DIFF
--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -48,13 +48,12 @@ def validate_filters(filters, account_details):
 
 	if not filters.get("from_date") and not filters.get("to_date"):
 		frappe.throw(_("{0} and {1} are mandatory").format(frappe.bold(_("From Date")), frappe.bold(_("To Date"))))
-
-	for account in filters.account:
-		if not account_details.get(account):
-			frappe.throw(_("Account {0} does not exists").format(account))
 			
 	if filters.get('account'):
 		filters.account = frappe.parse_json(filters.get('account'))
+		for account in filters.account:
+			if not account_details.get(account):
+				frappe.throw(_("Account {0} does not exists").format(account))
 
 	if (filters.get("account") and filters.get("group_by") == _('Group by Account')
 		and account_details[filters.account].is_group == 0):


### PR DESCRIPTION

### Steps to Replicate:
1. **Create Process Statements of Accounts without selecting any account like below:**

![Screenshot 2021-07-08 at 5 56 29 PM](https://user-images.githubusercontent.com/33727827/124921283-dbb5ec80-e015-11eb-84b9-fa0c47824283.png)

2. **Now when you try to download it following error occurs.**
 **Traceback:**
```exc: "[\"Traceback (most recent call last):\\n  File \\\"/home/frappe/benches/bench-version-13-2021-07-02/apps/frappe/frappe/app.py\\\", line 68, in application\\n    response = frappe.api.handle()\\n  File \\\"/home/frappe/benches/bench-version-13-2021-07-02/apps/frappe/frappe/api.py\\\", line 55, in handle\\n    return frappe.handler.handle()\\n  File \\\"/home/frappe/benches/bench-version-13-2021-07-02/apps/frappe/frappe/handler.py\\\", line 31, in handle\\n    data = execute_cmd(cmd)\\n  File \\\"/home/frappe/benches/bench-version-13-2021-07-02/apps/frappe/frappe/handler.py\\\", line 67, in execute_cmd\\n    return frappe.call(method, **frappe.form_dict)\\n  File \\\"/home/frappe/benches/bench-version-13-2021-07-02/apps/frappe/frappe/__init__.py\\\", line 1172, in call\\n    return fn(*args, **newargs)\\n  File \\\"/home/frappe/benches/bench-version-13-2021-07-02/apps/erpnext/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py\\\", line 232, in download_statements\\n    report = get_report_pdf(doc)\\n  File \\\"/home/frappe/benches/bench-version-13-2021-07-02/apps/erpnext/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py\\\", line 88, in get_report_pdf\\n    col, res = get_soa(filters)\\n  File \\\"/home/frappe/benches/bench-version-13-2021-07-02/apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py\\\", line 32, in execute\\n    validate_filters(filters, account_details)\\n  File \\\"/home/frappe/benches/bench-version-13-2021-07-02/apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py\\\", line 52, in validate_filters\\n    for account in filters.account:\\nTypeError: 'NoneType' object is not iterable\\n\"]"```
