### PR TITLE
fix: Order Items by weightage in the web items query

### DIFF
--- a/erpnext/shopping_cart/product_query.py
+++ b/erpnext/shopping_cart/product_query.py
@@ -87,7 +87,8 @@ class ProductQuery:
 				filters=self.filters,
 				or_filters=self.or_filters,
 				start=start,
-				limit=self.page_length
+				limit=self.page_length,
+				order_by="weightage desc"
 			)
 
 		# Combine results having context of website item groups into item results


### PR DESCRIPTION
Port of https://github.com/frappe/erpnext/pull/26284

`order_by` clause was accidentally removed in https://github.com/frappe/erpnext/commit/5b462ad11a4b5e426cecd868907e9fa2f9c445f2