### PR TITLE
fix(pos): taxes amount in pos item cart

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_item_cart.js
+++ b/erpnext/selling/page/point_of_sale/pos_item_cart.js
@@ -472,12 +472,7 @@ erpnext.PointOfSale.ItemCart = class {
 		const grand_total = cint(frappe.sys_defaults.disable_rounded_total) ? frm.doc.grand_total : frm.doc.rounded_total;
 		this.render_grand_total(grand_total);
 
-		const taxes = frm.doc.taxes.map(t => {
-			return {
-				description: t.description, rate: t.rate
-			};
-		});
-		this.render_taxes(frm.doc.total_taxes_and_charges, taxes);
+		this.render_taxes(frm.doc.taxes);
 	}
 
 	render_net_total(value) {
@@ -502,14 +497,14 @@ erpnext.PointOfSale.ItemCart = class {
 		);
 	}
 
-	render_taxes(value, taxes) {
+	render_taxes(taxes) {
 		if (taxes.length) {
 			const currency = this.events.get_frm().doc.currency;
 			const taxes_html = taxes.map(t => {
 				const description = /[0-9]+/.test(t.description) ? t.description : `${t.description} @ ${t.rate}%`;
 				return `<div class="tax-row">
 					<div class="tax-label">${description}</div>
-					<div class="tax-value">${format_currency(value, currency)}</div>
+					<div class="tax-value">${format_currency(t.tax_amount_after_discount_amount, currency)}</div>
 				</div>`;
 			}).join('');
 			this.$totals_section.find('.taxes-container').css('display', 'flex').html(taxes_html);


### PR DESCRIPTION
- The taxes in the POS Item Cart are incorrectly displayed
  Before:
  <img width="429" alt="CleanShot 2021-07-09 at 17 03 23@2x" src="https://user-images.githubusercontent.com/25369014/125071953-9659f380-e0d7-11eb-883e-15458800993b.png">
  After:
  <img width="429" alt="CleanShot 2021-07-09 at 17 01 36@2x" src="https://user-images.githubusercontent.com/25369014/125071764-5c88ed00-e0d7-11eb-9750-7289c3c5b8fc.png">
