### PR TITLE
fix: filter by accounts with group by accounts

### DIFF
--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -55,9 +55,10 @@ def validate_filters(filters, account_details):
 			if not account_details.get(account):
 				frappe.throw(_("Account {0} does not exists").format(account))
 
-	if (filters.get("account") and filters.get("group_by") == _('Group by Account')
-		and account_details[filters.account].is_group == 0):
-		frappe.throw(_("Can not filter based on Account, if grouped by Account"))
+	if (filters.get("account") and filters.get("group_by") == _('Group by Account')):
+		for account in filters.account:
+			if account_details[account].is_group == 0:
+				frappe.throw(_("Can not filter based on Child Account, if grouped by Account"))
 
 	if (filters.get("voucher_no")
 		and filters.get("group_by") in [_('Group by Voucher')]):

--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -56,6 +56,7 @@ def validate_filters(filters, account_details):
 				frappe.throw(_("Account {0} does not exists").format(account))
 
 	if (filters.get("account") and filters.get("group_by") == _('Group by Account')):
+		filters.account = frappe.parse_json(filters.get('account'))
 		for account in filters.account:
 			if account_details[account].is_group == 0:
 				frappe.throw(_("Can not filter based on Child Account, if grouped by Account"))


### PR DESCRIPTION
Bug introduced in https://github.com/frappe/erpnext/pull/26044
Steps to reproduce:
1. Select "Group by Accounts" for Group by filter.
2. Select any account that is not a group.

Following error was thrown:

```
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-13-2021-07-02/apps/frappe/frappe/app.py", line 68, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-13-2021-07-02/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-13-2021-07-02/apps/frappe/frappe/handler.py", line 31, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-13-2021-07-02/apps/frappe/frappe/handler.py", line 67, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-13-2021-07-02/apps/frappe/frappe/__init__.py", line 1172, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-13-2021-07-02/apps/frappe/frappe/__init__.py", line 609, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "/home/frappe/benches/bench-version-13-2021-07-02/apps/frappe/frappe/desk/query_report.py", line 234, in run
    result = generate_report_result(report, filters, user, custom_columns)
  File "/home/frappe/benches/bench-version-13-2021-07-02/apps/frappe/frappe/desk/query_report.py", line 78, in generate_report_result
    res = report.execute_script_report(filters)
  File "/home/frappe/benches/bench-version-13-2021-07-02/apps/frappe/frappe/core/doctype/report/report.py", line 125, in execute_script_report
    res = self.execute_module(filters)
  File "/home/frappe/benches/bench-version-13-2021-07-02/apps/frappe/frappe/core/doctype/report/report.py", line 142, in execute_module
    return frappe.get_attr(method_name)(frappe._dict(filters))
  File "/home/frappe/benches/bench-version-13-2021-07-02/apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py", line 32, in execute
    validate_filters(filters, account_details)
  File "/home/frappe/benches/bench-version-13-2021-07-02/apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py", line 60, in validate_filters
    and account_details[filters.account].is_group == 0):
TypeError: unhashable type: 'list' 
```