### PR TITLE
fix: pos item cart dom updates

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_item_cart.js
+++ b/erpnext/selling/page/point_of_sale/pos_item_cart.js
@@ -965,8 +965,23 @@ erpnext.PointOfSale.ItemCart = class {
 		});
 	}
 
+	attach_refresh_field_event(frm) {
+		$(frm.wrapper).off('refresh-fields');
+		$(frm.wrapper).on('refresh-fields', () => {
+			if (frm.doc.items.length) {
+				frm.doc.items.forEach(item => {
+					this.update_item_html(item);
+				});
+			}
+			this.update_totals_section(frm);
+		});
+	}
+
 	load_invoice() {
 		const frm = this.events.get_frm();
+		
+		this.attach_refresh_field_event(frm);
+
 		this.fetch_customer_details(frm.doc.customer).then(() => {
 			this.events.customer_details_updated(this.customer_info);
 			this.update_customer_section();


### PR DESCRIPTION
Problem:
- Changing discount from POS screen, doesn't update the Grand Total, Net Total etc

Why?
- If `discount` is applied on the invoice, `grand_total`, `net_total` and other fields on the pos invoice are changed.
- Those change doesn't trigger an event. For eg. `frm.doc.grand_total = 600` doesn't triggers `grand_total` event on the `form`
- Hence it not possible to listen for these updates to change the Cart dom.

Fix:
- On any field change of the POS Invoice, the `frm.refresh_field` event is manually triggered almost in every case.
- Hence, listening for that event and triggering cart refresh solves the issue.