### PR TITLE
fix: Removed company filter for Loan Type

### DIFF
--- a/erpnext/hr/doctype/loan/loan.js
+++ b/erpnext/hr/doctype/loan/loan.js
@@ -15,15 +15,6 @@ frappe.ui.form.on('Loan', {
 			};
 		});
 
-		frm.set_query("loan_type", function () {
-			return {
-				"filters": {
-					"docstatus": 1,
-					"company": frm.doc.company
-				}
-			};
-		});
-
 		frm.set_query("interest_income_account", function () {
 			return {
 				"filters": {

--- a/erpnext/hr/doctype/loan_application/loan_application.js
+++ b/erpnext/hr/doctype/loan_application/loan_application.js
@@ -7,13 +7,6 @@ frappe.ui.form.on('Loan Application', {
 	refresh: function(frm) {
 		frm.trigger("toggle_fields");
 		frm.trigger("add_toolbar_buttons");
-		frm.set_query('loan_type', () => {
-			return {
-				filters: {
-					company: frm.doc.company
-				}
-			};
-		});
 	},
 	repayment_method: function(frm) {
 		frm.doc.repayment_amount = frm.doc.repayment_periods = ""


### PR DESCRIPTION
1. Version 12 does not have a company field for Loan Type.
2. Removed company filter for Loan Type from Loan and Loan Application doctype.

Fixes issue introduced by https://github.com/frappe/erpnext/pull/26296