### PR TITLE
fix: Quotation list view blank if quotation_to field not set as a standard filter

### DIFF
--- a/erpnext/selling/doctype/quotation/quotation_list.js
+++ b/erpnext/selling/doctype/quotation/quotation_list.js
@@ -3,7 +3,7 @@ frappe.listview_settings['Quotation'] = {
 		"company", "currency", 'valid_till'],
 
 	onload: function(listview) {
-		if(listview.page.fields_dict.quotation_to){
+		if (listview.page.fields_dict.quotation_to) {
 			listview.page.fields_dict.quotation_to.get_query = function() {
 				return {
 					"filters": {

--- a/erpnext/selling/doctype/quotation/quotation_list.js
+++ b/erpnext/selling/doctype/quotation/quotation_list.js
@@ -3,13 +3,15 @@ frappe.listview_settings['Quotation'] = {
 		"company", "currency", 'valid_till'],
 
 	onload: function(listview) {
-		listview.page.fields_dict.quotation_to.get_query = function() {
-			return {
-				"filters": {
-					"name": ["in", ["Customer", "Lead"]],
-				}
+		if(listview.page.fields_dict.quotation_to){
+			listview.page.fields_dict.quotation_to.get_query = function() {
+				return {
+					"filters": {
+						"name": ["in", ["Customer", "Lead"]],
+					}
+				};
 			};
-		};
+		}
 	},
 
 	get_indicator: function(doc) {


### PR DESCRIPTION
**Issue**
Quotation list view blank if quotation_to field not set as a standard filter

Backport `version-11` for #22659