### PR TITLE
fix: test fails due to improper gain loss account set (#26482)

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -954,8 +954,17 @@ class TestPurchaseInvoice(unittest.TestCase):
 		acc_settings.save()
 
 	def test_gain_loss_with_advance_entry(self):
-		unlink_enabled = frappe.db.get_value("Accounts Settings", "Accounts Settings", "unlink_payment_on_cancel_of_invoice")
-		frappe.db.set_value("Accounts Settings", "Accounts Settings", "unlink_payment_on_cancel_of_invoice", 1)
+		unlink_enabled = frappe.db.get_value(
+			"Accounts Settings", "Accounts Settings",
+			"unlink_payment_on_cancel_of_invoice")
+		
+		frappe.db.set_value(
+			"Accounts Settings", "Accounts Settings",
+			"unlink_payment_on_cancel_of_invoice", 1)
+
+		original_account = frappe.db.get_value("Company", "_Test Company", "exchange_gain_loss_account")
+		frappe.db.set_value("Company", "_Test Company", "exchange_gain_loss_account", "Exchange Gain/Loss - _TC")
+
 		pay = frappe.get_doc({
 			'doctype': 'Payment Entry',
 			'company': '_Test Company',
@@ -995,7 +1004,8 @@ class TestPurchaseInvoice(unittest.TestCase):
 		gl_entries = frappe.db.sql("""
 			select account, sum(debit - credit) as balance from `tabGL Entry`
 			where voucher_no=%s
-			group by account order by account asc""", (pi.name), as_dict=1)
+			group by account
+			order by account asc""", (pi.name), as_dict=1)
 		
 		for i, gle in enumerate(gl_entries):
 			self.assertEqual(expected_gle[i][0], gle.account)
@@ -1055,6 +1065,7 @@ class TestPurchaseInvoice(unittest.TestCase):
 		pay.cancel()
 
 		frappe.db.set_value("Accounts Settings", "Accounts Settings", "unlink_payment_on_cancel_of_invoice", unlink_enabled)
+		frappe.db.set_value("Company", "_Test Company", "exchange_gain_loss_account", original_account)
 
 	def test_purchase_invoice_advance_taxes(self):
 		from erpnext.buying.doctype.purchase_order.test_purchase_order import create_purchase_order


### PR DESCRIPTION
Backports the following commits to version-13-hotfix:
 - fix: test fails due to improper gain loss account set (#26482)