### PR TITLE
fix: improving UX for additional discount field

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_item_cart.js
+++ b/erpnext/selling/page/point_of_sale/pos_item_cart.js
@@ -367,15 +367,16 @@ erpnext.PointOfSale.ItemCart = class {
 			`<div class="add-discount-field"></div>`
 		);
 		const me = this;
+		const frm = me.events.get_frm();
+		let discount = frm.doc.additional_discount_percentage;
 
 		this.discount_field = frappe.ui.form.make_control({
 			df: {
 				label: __('Discount'),
 				fieldtype: 'Data',
-				placeholder: __('Enter discount percentage.'),
+				placeholder: ( discount ? discount + '%' :  __('Enter discount percentage.') ),
 				input_class: 'input-xs',
 				onchange: function() {
-					const frm = me.events.get_frm();
 					if (flt(this.value) != 0) {
 						frappe.model.set_value(frm.doc.doctype, frm.doc.name, 'additional_discount_percentage', flt(this.value));
 						me.hide_discount_control(this.value);


### PR DESCRIPTION
Previously as you can see in the gif below
Adding "Additional Discounts" changes the "Totals" but when you click on the field again the placeholder says "Enter the Discount Percentage" and the totals stays same as with the discount applied. This confuses user.
![1](https://user-images.githubusercontent.com/33727827/125627241-9957dde2-7891-4155-bc26-a56d6d6b7bc5.gif)

Now as you can see in the gif below
Clicking again will show the applied discount in place of "Placeholder" if any discount was applied. And user can now change the value to new discount if user wish to do so.
![2](https://user-images.githubusercontent.com/33727827/125627485-2079bd01-31d6-4d45-a5ab-3624b4f13fc0.gif)
