### PR TITLE
fix: WIP needs to be set before submit on skip_transfer

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -239,7 +239,7 @@ class WorkOrder(Document):
 		self.create_serial_no_batch_no()
 
 	def on_submit(self):
-		if not self.wip_warehouse:
+		if not self.wip_warehouse and not self.skip_transfer:
 			frappe.throw(_("Work-in-Progress Warehouse is required before Submit"))
 		if not self.fg_warehouse:
 			frappe.throw(_("For Warehouse is required before Submit"))


### PR DESCRIPTION
**Issue:**
- System throws error on submit if WIP Warehouse field is empty even if "Skip Material Transfer to WIP Warehouse" is checked.
![image](https://user-images.githubusercontent.com/43572428/125649744-398eb84a-f0c9-4ced-8ed8-bba1666408af.png)

**Expected:**
- User should be able to leave the WIP Warehouse field empty if "Skip Material Transfer to WIP Warehouse" is enabled, since WIP field is marked non-mandatory on enabling the option and should fetch source warehouses in stock entry as per item source warehouses


