### PR TITLE
fix: taxes not set correctly when items pulled from PO to PI

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.js
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.js
@@ -22,7 +22,7 @@ frappe.ui.form.on("Purchase Receipt", {
 				frappe.set_route("Form", lcv.doctype, lcv.name);
 			},
 		}
-		
+
 		frm.custom_make_buttons = {
 			'Stock Entry': 'Return',
 			'Purchase Invoice': 'Purchase Invoice'
@@ -34,7 +34,7 @@ frappe.ui.form.on("Purchase Receipt", {
 				filters: {'company': frm.doc.company }
 			}
 		});
-		
+
 	},
 	onload: function(frm) {
 		erpnext.queries.setup_queries(frm, "Warehouse", function() {
@@ -107,6 +107,8 @@ erpnext.stock.PurchaseReceiptController = erpnext.buying.BuyingController.extend
 								message: __("Please Select a Supplier")
 							});
 						}
+
+						me.frm.doc.taxes = [];
 						erpnext.utils.map_current_doc({
 							method: "erpnext.buying.doctype.purchase_order.purchase_order.make_purchase_receipt",
 							source_doctype: "Purchase Order",


### PR DESCRIPTION
**Issue**

1. Make purchase order with taxes
2. Goto Purchase Receipt > New> add supplier (same as above purchase order) > Get items from > Purchase Order > select the above PO
3. System fetch all the details from PO to PI, except taxes.

