### PR TITLE
fix(ux): set default operation time to 0 

### DIFF
--- a/erpnext/manufacturing/doctype/sub_operation/sub_operation.json
+++ b/erpnext/manufacturing/doctype/sub_operation/sub_operation.json
@@ -19,6 +19,7 @@
    "options": "Operation"
   },
   {
+   "default": "0",
    "description": "Time in mins",
    "fieldname": "time_in_mins",
    "fieldtype": "Float",
@@ -38,7 +39,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-12-07 18:09:18.005578",
+ "modified": "2021-07-15 16:39:41.635362",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Sub Operation",


### PR DESCRIPTION
**Before:**
- Threw an error if operation time was left empty.
- No default value.
![image](https://user-images.githubusercontent.com/43572428/125775802-9b30ee3f-2ecb-4ce3-b9ec-bd2e36c54edb.png)

**Changes:**
- Default value for sub operation time is set to 0.