### PR TITLE
fix: Fixed clearing issue of payment references on setting cost center

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -1041,18 +1041,10 @@ frappe.ui.form.on('Payment Entry', {
 				},
 				callback: function(r, rt) {
 					if(r.message) {
-						frappe.run_serially([
-							() => {
+						
 								frm.set_value("paid_from_account_balance", r.message.paid_from_account_balance);
 								frm.set_value("paid_to_account_balance", r.message.paid_to_account_balance);
 								frm.set_value("party_balance", r.message.party_balance);
-							},
-							() => {
-								if(frm.doc.payment_type != "Internal") {
-									frm.clear_table("references");
-								}
-							}
-						]);
 
 					}
 				}


### PR DESCRIPTION
While creating Payment Entry (via Employee Advance in the issue), on setting the cost center the reference documents in the 'Payment References' child table would be cleared automatically.
Removed the part where it clears it.

Steps:
1. create payment entry through an Employee Advance entry
2. set a cost center
3. see if the reference documents get cleared or not