### PR TITLE
fix(ux): item description should fall back to name (#26339)

### DIFF
--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -100,10 +100,11 @@ frappe.ui.form.on("Item", {
 
 		frm.add_custom_button(__('Duplicate'), function() {
 			var new_item = frappe.model.copy_doc(frm.doc);
-			if(new_item.item_name===new_item.item_code) {
+			// Duplicate item could have different name, causing "copy paste" error.
+			if (new_item.item_name===new_item.item_code) {
 				new_item.item_name = null;
 			}
-			if(new_item.description===new_item.description) {
+			if (new_item.item_code===new_item.description || new_item.item_code===new_item.description) {
 				new_item.description = null;
 			}
 			frappe.set_route('Form', 'Item', new_item.name);
@@ -186,8 +187,6 @@ frappe.ui.form.on("Item", {
 	item_code: function(frm) {
 		if(!frm.doc.item_name)
 			frm.set_value("item_name", frm.doc.item_code);
-		if(!frm.doc.description)
-			frm.set_value("description", frm.doc.item_code);
 	},
 
 	is_stock_item: function(frm) {


### PR DESCRIPTION
Backports the following commits to version-13-hotfix:
 - fix(ux): item description should fall back to name (#26339)