### PR TITLE
fix: Pass doc and other parameters to properly prefill information

### DIFF
--- a/erpnext/public/js/utils/customer_quick_entry.js
+++ b/erpnext/public/js/utils/customer_quick_entry.js
@@ -1,8 +1,8 @@
 frappe.provide('frappe.ui.form');
 
 frappe.ui.form.CustomerQuickEntryForm = class CustomerQuickEntryForm extends frappe.ui.form.QuickEntryForm {
-	constructor(doctype, after_insert) {
-		super(doctype, after_insert);
+	constructor(doctype, after_insert, init_callback, doc, force) {
+		super(doctype, after_insert, init_callback, doc, force);
 		this.skip_redirect_on_error = true;
 	}
 


### PR DESCRIPTION
**Issue:** Customer document was not getting auto-linked with the reference document while creating a custom from form dashboard.


**Before:**

https://user-images.githubusercontent.com/13928957/126263465-b56eb854-4882-4c12-b364-28a37ec2f3ce.mov

**After:**

https://user-images.githubusercontent.com/13928957/126263473-3c7c1961-04e1-4414-8283-8601d1661a5b.mov


