### PR TITLE
fix: Pass doc and other parameters to properly prefill information

### DIFF
--- a/erpnext/public/js/utils/customer_quick_entry.js
+++ b/erpnext/public/js/utils/customer_quick_entry.js
@@ -1,9 +1,9 @@
 frappe.provide('frappe.ui.form');
 
 frappe.ui.form.CustomerQuickEntryForm = frappe.ui.form.QuickEntryForm.extend({
-	init: function(doctype, after_insert) {
+	init: function(doctype, after_insert, init_callback, doc, force) {
+		this._super(doctype, after_insert, init_callback, doc, force);
 		this.skip_redirect_on_error = true;
-		this._super(doctype, after_insert);
 	},
 
 	render_dialog: function() {


### PR DESCRIPTION
**Issue:** Customer document was not getting auto-linked with the reference document while creating a custom from form dashboard.


**Before:**

https://user-images.githubusercontent.com/13928957/126263465-b56eb854-4882-4c12-b364-28a37ec2f3ce.mov

**After:**

https://user-images.githubusercontent.com/13928957/126263473-3c7c1961-04e1-4414-8283-8601d1661a5b.mov



port-of: https://github.com/frappe/erpnext/pull/26554