### PR TITLE
fix: Price list rate not fetched for return sales invoice fixed

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -74,9 +74,8 @@ def get_item_details(args, doc=None, for_validate=False, overwrite_warehouse=Tru
 
 	update_party_blanket_order(args, out)
 
-	if not doc or cint(doc.get('is_return')) == 0:
-		# get price list rate only if the invoice is not a credit or debit note
-		get_price_list_rate(args, item, out)
+	
+	get_price_list_rate(args, item, out)
 
 	if args.customer and cint(args.is_pos):
 		out.update(get_pos_profile_item_details(args.company, args, update_data=True))


### PR DESCRIPTION
When a sales invoice is created with 'Is Return' checked and a price list is selected(other than standard), the items added to the child table wouldn't auto fetch the price list rate. Fixed it by removing the condition that prevented it.

Steps:
1. create sales invoice with Is Return checked
2. select a custom price list
3. add items and check its rate