### PR TITLE
fix: Production Plan: traverse all BOM levels looking for manufactured items not in stock

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
@@ -239,6 +239,10 @@ class TestProductionPlan(unittest.TestCase):
 			"planned_qty": 3
 		})
 
+		mr_items = get_items_for_material_requests(pln.as_dict())
+		for d in mr_items:
+			pln.append('mr_items', d)
+
 		pln.get_sub_assembly_items('In House')
 		pln.submit()
 		pln.make_work_order()


### PR DESCRIPTION
Currently (v13.6) the production plan can either deal with 2-level BOMs (non-exploded option) or BOMs that are always made directly from the base materials (exploded items imported from the BOM).

So it does not support, for example, 3-level BOMs where there may be stock of intermediate manufactured parts.

This is a fix that enables any level of nested BOMs and checks stock at each level so you only need to manufacture the correct number of parts at each BOM level.

fixes: #26563