### PR TITLE
feat(Non Profit): API Endpoint to update halted Razorpay subscriptions

### DIFF
--- a/erpnext/non_profit/doctype/member/member.json
+++ b/erpnext/non_profit/doctype/member/member.json
@@ -26,7 +26,7 @@
   "razorpay_details_section",
   "subscription_id",
   "customer_id",
-  "subscription_activated",
+  "subscription_status",
   "column_break_21",
   "subscription_start",
   "subscription_end"
@@ -152,12 +152,6 @@
    "fieldtype": "Column Break"
   },
   {
-   "default": "0",
-   "fieldname": "subscription_activated",
-   "fieldtype": "Check",
-   "label": "Subscription Activated"
-  },
-  {
    "fieldname": "subscription_start",
    "fieldtype": "Date",
    "label": "Subscription Start "
@@ -166,11 +160,17 @@
    "fieldname": "subscription_end",
    "fieldtype": "Date",
    "label": "Subscription End"
+  },
+  {
+   "fieldname": "subscription_status",
+   "fieldtype": "Select",
+   "label": "Subscription Status",
+   "options": "\nActive\nHalted"
   }
  ],
  "image_field": "image",
  "links": [],
- "modified": "2020-11-09 12:12:10.174647",
+ "modified": "2021-07-11 14:27:26.368039",
  "modified_by": "Administrator",
  "module": "Non Profit",
  "name": "Member",

--- a/erpnext/non_profit/doctype/member/member.py
+++ b/erpnext/non_profit/doctype/member/member.py
@@ -84,7 +84,9 @@ def create_member(user_details):
 		"email_id": user_details.email,
 		"pan_number": user_details.pan or None,
 		"membership_type": user_details.plan_id,
-		"subscription_id": user_details.subscription_id or None
+		"customer_id": user_details.customer_id or None,
+		"subscription_id": user_details.subscription_id or None,
+		"subscription_status": user_details.subscription_status or ""
 	})
 
 	member.insert(ignore_permissions=True)

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -292,3 +292,4 @@ erpnext.patches.v13_0.bill_for_rejected_quantity_in_purchase_invoice
 erpnext.patches.v13_0.update_job_card_details
 erpnext.patches.v13_0.update_level_in_bom #1234sswef
 erpnext.patches.v13_0.add_missing_fg_item_for_stock_entry
+erpnext.patches.v13_0.update_subscription_status_in_memberships

--- a/erpnext/patches/v13_0/update_subscription_status_in_memberships.py
+++ b/erpnext/patches/v13_0/update_subscription_status_in_memberships.py
@@ -1,0 +1,9 @@
+import frappe
+
+def execute():
+	if frappe.db.exists('DocType', 'Member'):
+		frappe.reload_doc('Non Profit', 'doctype', 'Member')
+
+		if frappe.db.has_column('Member', 'subscription_activated'):
+			frappe.db.sql('UPDATE `tabMember` SET subscription_status = "Active" WHERE subscription_activated = 1')
+			frappe.db.sql_ddl('ALTER table `tabMember` DROP COLUMN subscription_activated')


### PR DESCRIPTION
Backport: https://github.com/frappe/erpnext/pull/26427

When all payment retries have been exhausted, Razorpay moves the subscription to the halted state. The customer has to manually retry the charge or change the card linked to the subscription for the subscription to move back to the active state.

Sample payload for halted subscription: https://razorpay.com/docs/webhooks/payloads/#subscription-halted

- Changed Subscription Activated checkbox to Subscription Status field. Added a patch for the same.
- Added an API endpoint to update Razorpay subscription as halted. Razorpay webhook can be used to update this:
 
https://user-images.githubusercontent.com/24353136/125204114-27c49380-e299-11eb-9a03-d56a9cc89bb0.mp4

Documentation PR: https://github.com/frappe/erpnext_documentation/pull/366