### PR TITLE
feat: Production Plan: make the item_code filter into a 'like' search rather than a link field

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.js
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.js
@@ -41,7 +41,7 @@ frappe.ui.form.on('Production Plan', {
 				filters:{
 					'is_stock_item': 1,
 				}
-			}
+			};
 		};
 
 		frm.fields_dict['po_items'].grid.get_field('bom_no').get_query = function(doc, cdt, cdn) {
@@ -50,17 +50,17 @@ frappe.ui.form.on('Production Plan', {
 				return {
 					query: "erpnext.controllers.queries.bom",
 					filters:{'item': cstr(d.item_code)}
-				}
+				};
 			} else frappe.msgprint(__("Please enter Item first"));
-		};
+		}
 
 		frm.fields_dict['mr_items'].grid.get_field('warehouse').get_query = function(doc) {
 			return {
 				filters: {
 					company: doc.company
 				}
-			}
-		};
+			};
+		}
 	},
 
 	refresh: function(frm) {

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.js
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.js
@@ -42,7 +42,7 @@ frappe.ui.form.on('Production Plan', {
 					'is_stock_item': 1,
 				}
 			}
-		}
+		};
 
 		frm.fields_dict['po_items'].grid.get_field('bom_no').get_query = function(doc, cdt, cdn) {
 			var d = locals[cdt][cdn];
@@ -52,7 +52,7 @@ frappe.ui.form.on('Production Plan', {
 					filters:{'item': cstr(d.item_code)}
 				}
 			} else frappe.msgprint(__("Please enter Item first"));
-		}
+		};
 
 		frm.fields_dict['mr_items'].grid.get_field('warehouse').get_query = function(doc) {
 			return {
@@ -60,7 +60,7 @@ frappe.ui.form.on('Production Plan', {
 					company: doc.company
 				}
 			}
-		}
+		};
 	},
 
 	refresh: function(frm) {

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.json
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.json
@@ -194,6 +194,7 @@
   {
    "fieldname": "po_items",
    "fieldtype": "Table",
+   "label": "Work Order Items",
    "no_copy": 1,
    "options": "Production Plan Item",
    "reqd": 1
@@ -332,12 +333,12 @@
   },
   {
    "fieldname": "section_break_25",
-   "fieldtype": "Section Break"
+   "fieldtype": "Section Break",
+   "hidden": 1
   },
   {
    "fieldname": "prod_plan_references",
    "fieldtype": "Table",
-   "hidden": 1,
    "label": "Production Plan Item Reference",
    "options": "Production Plan Item Reference"
   },

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.json
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.json
@@ -98,11 +98,10 @@
    "label": "Filters"
   },
   {
+   "description": "Searches for item codes like this string",
    "fieldname": "item_code",
-   "fieldtype": "Link",
-   "in_list_view": 1,
-   "label": "Item Code",
-   "options": "Item"
+   "fieldtype": "Data",
+   "label": "Item Code"
   },
   {
    "depends_on": "eval: doc.get_items_from == \"Sales Order\"",
@@ -364,7 +363,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2021-06-28 20:00:33.905114",
+ "modified": "2021-07-20 17:55:37.164051",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Production Plan",

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.json
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.json
@@ -93,12 +93,13 @@
    "collapsible": 1,
    "collapsible_depends_on": "eval: doc.__islocal",
    "depends_on": "eval: doc.get_items_from",
+   "description": "These filters are used in searches triggered by the buttons below",
    "fieldname": "filters",
    "fieldtype": "Section Break",
    "label": "Filters"
   },
   {
-   "description": "Searches for item codes like this string",
+   "description": "Look for item codes like this text",
    "fieldname": "item_code",
    "fieldtype": "Data",
    "label": "Item Code"

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -78,7 +78,7 @@ class ProductionPlan(Document):
 				"from_date": self.from_date,
 				"to_date": self.to_date,
 				"warehouse": self.warehouse,
-				"item": '%' + self.item_code + '%',
+				"item": f'%{self.item_code}%',
 				"company": self.company
 			}, as_dict=1)
 
@@ -117,7 +117,7 @@ class ProductionPlan(Document):
 
 		item_condition = ""
 		if self.item_code:
-			item_condition = ' and so_item.item_code like {0}'.format(frappe.db.escape('%'+ self.item_code +'%'))
+			item_condition = ' and so_item.item_code like {0}'.format(frappe.db.escape(f'%{self.item_code}%'))
 
 		items = frappe.db.sql("""select distinct parent, item_code, warehouse,
 			(qty - work_order_qty) * conversion_factor as pending_qty, description, name
@@ -150,7 +150,7 @@ class ProductionPlan(Document):
 
 		item_condition = ""
 		if self.item_code:
-			item_condition = " and mr_item.item_code like {0}".format(frappe.db.escape('%'+ self.item_code +'%'))
+			item_condition = " and mr_item.item_code like {0}".format(frappe.db.escape(f'%{self.item_code}%'))
 
 		items = frappe.db.sql("""select distinct parent, name, item_code, warehouse, description,
 			(qty - ordered_qty) * conversion_factor as pending_qty
@@ -710,7 +710,7 @@ def get_sales_orders(self):
 			"to_date": self.to_date,
 			"customer": self.customer,
 			"project": self.project,
-			"item": '%' + self.item_code + '%',
+			"item": f'%{self.item_code}%',
 			"company": self.company,
 			"sales_order_status": self.sales_order_status
 		}, as_dict=1)


### PR DESCRIPTION
Allows you to add multiple items with similar item_codes to the same production plan rather than the strict single item according to a link field

Consider a realistic scenario: a clothes printing shop is much more likely to want to make all t-shirts, or all medium t-shirts, or all white t-shirts, or all t-shirt sizes with a single design (new behaviour) than they are to make a single t-shirt design, in a single size, in a single colour (existing behaviour).

no-docs