### PR TITLE
fix: Missing method reset_issue_metrics added back to Issue doctype

### DIFF
--- a/erpnext/support/doctype/issue/issue.py
+++ b/erpnext/support/doctype/issue/issue.py
@@ -116,6 +116,10 @@ class Issue(Document):
 		}).insert(ignore_permissions=True)
 
 		return replicated_issue.name
+	
+	def reset_issue_metrics(self):
+		self.db_set("resolution_time", None)
+		self.db_set("user_resolution_time", None)
 
 def get_list_context(context=None):
 	return {


### PR DESCRIPTION
Method reset_issue_metrics was removed earlier while still being used, added back again.