### PR TITLE
fix: incorrect amount in work order required items table. 

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -774,7 +774,7 @@ def get_bom_items_as_dict(bom, company, qty=1, fetch_exploded=1, fetch_scrap_ite
 				item.image,
 				bom.project,
 				bom_item.rate,
-				bom_item.amount,
+				sum(bom_item.{qty_field}/ifnull(bom.quantity, 1)) * bom_item.rate * %(qty)s as amount,
 				item.stock_uom,
 				item.item_group,
 				item.allow_alternative_item,

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -656,7 +656,7 @@ class WorkOrder(Document):
 				for item in sorted(item_dict.values(), key=lambda d: d['idx'] or 9999):
 					self.append('required_items', {
 						'rate': item.rate,
-						'amount': item.amount,
+						'amount': item.rate * item.qty,
 						'operation': item.operation or operation,
 						'item_code': item.item_code,
 						'item_name': item.item_name,

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -296,3 +296,4 @@ erpnext.patches.v13_0.update_job_card_details
 erpnext.patches.v13_0.update_level_in_bom #1234sswef
 erpnext.patches.v13_0.add_missing_fg_item_for_stock_entry
 erpnext.patches.v13_0.update_subscription_status_in_memberships
+erpnext.patches.v13_0.update_amt_in_work_order_required_items

--- a/erpnext/patches/v13_0/update_amt_in_work_order_required_items.py
+++ b/erpnext/patches/v13_0/update_amt_in_work_order_required_items.py
@@ -1,0 +1,10 @@
+import frappe
+
+def execute():
+	""" Correct amount in child table of required items table."""
+
+	frappe.reload_doc("manufacturing", "doctype", "work_order")
+	frappe.reload_doc("manufacturing", "doctype", "work_order_item")
+
+	frappe.db.sql("""UPDATE `tabWork Order Item` SET amount = rate * required_qty""")
+


### PR DESCRIPTION
Problem: function used in BOM wasn't computing amount as per `qty` parameter. 
Steps to reproduce:
- Create a BOM
- Create Work Order with more than 1 qty
- Amount won't be correct in Work Order required items table. 

![Screenshot 2021-07-21 at 4 33 41 PM](https://user-images.githubusercontent.com/9079960/126498084-1659057b-f05b-498b-bdee-30f1f96021af.png)


This has no impact on stock/accounting. It's just shown there for reference. 