### PR TITLE
fix: migration v12 to13 problem opportunity

### DIFF
--- a/erpnext/crm/doctype/opportunity/opportunity.json
+++ b/erpnext/crm/doctype/opportunity/opportunity.json
@@ -430,7 +430,7 @@
  "icon": "fa fa-info-sign",
  "idx": 195,
  "links": [],
- "modified": "2021-06-04 10:11:22.831139",
+ "modified": "2021-06-05 10:11:22.831139",
  "modified_by": "Administrator",
  "module": "CRM",
  "name": "Opportunity",


### PR DESCRIPTION
fix: #26321
into erpnext/crm/doctype/opportunity/opportunity.json the attribut modified is the same in v12.22.0 as in v13.7.0
The result is on apps/erpnext/erpnext/patches/v13_0/rename_issue_doctype_fields.py on
frappe.reload_doc('crm', 'doctype', 'opportunity')
it return false, and the tabOpporunity is not altered with ALTER TABLE xxx MODIFY