### PR TITLE
fix: SQL error on fetching RM in production plan

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -747,9 +747,8 @@ def get_bin_details(row, company, for_warehouse=None, all_warehouse=False):
 		group by item_code, warehouse
 	""".format(conditions=conditions), { "item_code": row['item_code'] }, as_dict=1)
 
-def get_warehouse_list(warehouses, warehouse_list=None):
-	if warehouse_list is not None:
-		warehouse_list = []
+def get_warehouse_list(warehouses):
+	warehouse_list = []
 
 	if isinstance(warehouses, str):
 		warehouses = json.loads(warehouses)
@@ -761,22 +760,18 @@ def get_warehouse_list(warehouses, warehouse_list=None):
 		else:
 			warehouse_list.append(row.get("warehouse"))
 
+	return warehouse_list
+
 @frappe.whitelist()
 def get_items_for_material_requests(doc, warehouses=None, get_parent_warehouse_data=None):
 	if isinstance(doc, str):
 		doc = frappe._dict(json.loads(doc))
 
-	warehouse_list = []
 	if warehouses:
-		get_warehouse_list(warehouses, warehouse_list)
-
-	if warehouse_list:
-		warehouses = list(set(warehouse_list))
+		warehouses = list(set(get_warehouse_list(warehouses)))
 
 		if doc.get("for_warehouse") and not get_parent_warehouse_data and doc.get("for_warehouse") in warehouses:
 			warehouses.remove(doc.get("for_warehouse"))
-
-		warehouse_list = None
 
 	doc['mr_items'] = []
 

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -748,7 +748,7 @@ def get_bin_details(row, company, for_warehouse=None, all_warehouse=False):
 	""".format(conditions=conditions), { "item_code": row['item_code'] }, as_dict=1)
 
 def get_warehouse_list(warehouses, warehouse_list=None):
-	if not warehouse_list:
+	if warehouse_list is not None:
 		warehouse_list = []
 
 	if isinstance(warehouses, str):

--- a/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
@@ -10,7 +10,7 @@ from erpnext.stock.doctype.item.test_item import create_item
 from erpnext.manufacturing.doctype.production_plan.production_plan import get_sales_orders
 from erpnext.stock.doctype.stock_reconciliation.test_stock_reconciliation import create_stock_reconciliation
 from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
-from erpnext.manufacturing.doctype.production_plan.production_plan import get_items_for_material_requests
+from erpnext.manufacturing.doctype.production_plan.production_plan import get_items_for_material_requests, get_warehouse_list
 
 class TestProductionPlan(unittest.TestCase):
 	def setUp(self):
@@ -250,6 +250,27 @@ class TestProductionPlan(unittest.TestCase):
 		self.assertEqual(to_produce_qty, 18.0)
 		pln.cancel()
 		frappe.delete_doc("Production Plan", pln.name)
+
+	def test_get_warehouse_list_group(self):
+		"""Check if required warehouses are returned"""
+		warehouse_json = '[{\"warehouse\":\"_Test Warehouse Group - _TC\"}]'
+
+		warehouses = set(get_warehouse_list(warehouse_json))
+		expected_warehouses = {"_Test Warehouse Group-C1 - _TC", "_Test Warehouse Group-C2 - _TC"}
+
+		missing_warehouse = expected_warehouses - warehouses
+
+		self.assertTrue(len(missing_warehouse) == 0,
+				msg=f"Following warehouses were expected {', '.join(missing_warehouse)}")
+
+	def test_get_warehouse_list_single(self):
+		warehouse_json = '[{\"warehouse\":\"_Test Scrap Warehouse - _TC\"}]'
+
+		warehouses = set(get_warehouse_list(warehouse_json))
+		expected_warehouses = {"_Test Scrap Warehouse - _TC", }
+
+		self.assertEqual(warehouses, expected_warehouses)
+
 
 def create_production_plan(**args):
 	args = frappe._dict(args)


### PR DESCRIPTION
Problem: 
sql error on fetching RM from production plan

Steps to reproduce:
- Create new production plan
- pick any item with BOM
- Add material request warehouse
- get RM > enter any warehouse (try a group warehouse-like ALL WH)

You'll get SQL error because the warehouse JSON is being sent to query instead of a parsed list. 



Root cause: 
The list is getting passed by reference and compared using `not` which would ignore the referenced list if it's empty and create new one instead. 
https://github.com/frappe/erpnext/blob/28d52c4a9521759625bb13e5ea0c50c9112e4fed/erpnext/manufacturing/doctype/production_plan/production_plan.py#L751-L752

Solution: 
~~check the passed reference for None, not for falseness.~~
refactor and avoid passing by reference / mutations. 