### PR TITLE
fix(e-invoicing): missing QR code in auto email attachment

### DIFF
--- a/erpnext/regional/india/e_invoice/utils.py
+++ b/erpnext/regional/india/e_invoice/utils.py
@@ -969,7 +969,7 @@ class GSPConnector():
 			"attached_to_doctype": doctype,
 			"attached_to_name": docname,
 			"attached_to_field": "qrcode_image",
-			"is_private": 1,
+			"is_private": 0,
 			"content": qr_image.getvalue()})
 		_file.save()
 		frappe.db.commit()


### PR DESCRIPTION
QR Code was missing in the auto generated email pdf attachment for Sales Invoice, fixed now with the change.