### PR TITLE
fix: incorrect bom name

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.js
+++ b/erpnext/manufacturing/doctype/bom/bom.js
@@ -83,7 +83,7 @@ frappe.ui.form.on("BOM", {
 
 		if (!frm.doc.__islocal && frm.doc.docstatus<2) {
 			frm.add_custom_button(__("Update Cost"), function() {
-				frm.events.update_cost(frm);
+				frm.events.update_cost(frm, true);
 			});
 			frm.add_custom_button(__("Browse BOM"), function() {
 				frappe.route_options = {
@@ -318,14 +318,15 @@ frappe.ui.form.on("BOM", {
 		})
 	},
 
-	update_cost: function(frm) {
+	update_cost: function(frm, save_doc=false) {
 		return frappe.call({
 			doc: frm.doc,
 			method: "update_cost",
 			freeze: true,
 			args: {
 				update_parent: true,
-				from_child_bom:false
+				save: save_doc,
+				from_child_bom: false
 			},
 			callback: function(r) {
 				refresh_field("items");

--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -330,7 +330,7 @@ class BOM(WebsiteGenerator):
 				frappe.get_doc("BOM", bom).update_cost(from_child_bom=True)
 
 		if not from_child_bom:
-			frappe.msgprint(_("Cost Updated"))
+			frappe.msgprint(_("Cost Updated"), alert=True)
 
 	def update_parent_cost(self):
 		if self.total_cost:


### PR DESCRIPTION
**Issue**

<img width="1093" alt="Screenshot 2021-07-22 at 3 38 34 PM" src="https://user-images.githubusercontent.com/8780500/126623158-3c37c54b-d4e2-45c1-bbb0-6921f48375bf.png">

Steps to replicate issue

1. Make new bom > select item > change conversion factor manually in the BOM Item (child table)
2. Save the BOM, you will see the incorrect name

Resolves: https://frappe.io/app/issue/ISS-21-22-03745