### PR TITLE
fix: Let all System Managers be able to delete Company transactions

### DIFF
--- a/erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py
+++ b/erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py
@@ -11,8 +11,15 @@ from frappe.desk.notifications import clear_notifications
 
 class TransactionDeletionRecord(Document):
 	def validate(self):
-		frappe.only_for('System Manager')
+		self.validate_user()
 		self.validate_doctypes_to_be_ignored()
+
+	def validate_user(self):
+		frappe.only_for('System Manager')
+
+		if not frappe.has_permission("Transaction Deletion Record", "submit"):
+			if 'System Manager' in frappe.get_roles(frappe.session.user):
+				self.flags.ignore_permissions = 1
 
 	def validate_doctypes_to_be_ignored(self):
 		doctypes_to_be_ignored_list = get_doctypes_to_be_ignored()


### PR DESCRIPTION
_Issue:_
- Users without the 'submit' permission for Transaction Deletion Record are unable to delete Company transactions.

![Screenshot 2021-07-23 at 5 14 38 AM](https://user-images.githubusercontent.com/25903035/126722296-23ead296-1092-428d-a027-a52221a97b97.png)

_Fix:_
- If the User is a System Manager, subsequent permissions for the doc will be ignored.