### PR TITLE
fix: Salary component account filter

### DIFF
--- a/erpnext/payroll/doctype/salary_component/salary_component.js
+++ b/erpnext/payroll/doctype/salary_component/salary_component.js
@@ -4,9 +4,9 @@
 frappe.ui.form.on('Salary Component', {
 	setup: function(frm) {
 		frm.set_query("account", "accounts", function(doc, cdt, cdn) {
-			var d = locals[cdt][cdn];
+			let d = frappe.get_doc(cdt, cdn);
 
-			var root_type = "Liability";
+			let root_type = "Liability";
 			if (frm.doc.type == "Deduction") {
 				root_type = "Expense";
 			}

--- a/erpnext/payroll/doctype/salary_component/salary_component.js
+++ b/erpnext/payroll/doctype/salary_component/salary_component.js
@@ -5,10 +5,17 @@ frappe.ui.form.on('Salary Component', {
 	setup: function(frm) {
 		frm.set_query("account", "accounts", function(doc, cdt, cdn) {
 			var d = locals[cdt][cdn];
+
+			var root_type = "Liability";
+			if (frm.doc.type == "Deduction") {
+				root_type = "Expense";
+			}
+
 			return {
 				filters: {
 					"is_group": 0,
-					"company": d.company
+					"company": d.company,
+					"root_type": root_type
 				}
 			};
 		});


### PR DESCRIPTION
1. When creating a salary component, we select an account in the Accounts table.
2. For salary component type Earning, only Liability accounts are needed, and for salary component deduction only Expense accounts are needed.
3. Based on these conditions, added filters when selecting an account.

![Screenshot 2021-07-23 at 12 43 24 PM](https://user-images.githubusercontent.com/31363128/126749501-4eb99d98-2ac8-45e4-9c16-995ea277bee6.png)
