### PR TITLE
fix: wrong operation time in Work Order

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -487,8 +487,8 @@ class WorkOrder(Document):
 			return
 
 		operations = []
+		bom_qty = frappe.get_cached_value("BOM", self.bom_no, "quantity")
 		if not self.use_multi_level_bom:
-			bom_qty = frappe.db.get_value("BOM", self.bom_no, "quantity")
 			operations.extend(_get_operations(self.bom_no, qty=1.0/bom_qty))
 		else:
 			bom_tree = frappe.get_doc("BOM", self.bom_no).get_tree_representation()
@@ -497,7 +497,7 @@ class WorkOrder(Document):
 
 			for d in bom_traversal:
 				if d.is_bom:
-					operations.extend(_get_operations(d.name, qty=d.exploded_qty))
+					operations.extend(_get_operations(d.name, qty=d.exploded_qty/bom_qty))
 
 			for correct_index, operation in enumerate(operations, start=1):
 				operation.idx = correct_index

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -487,8 +487,8 @@ class WorkOrder(Document):
 			return
 
 		operations = []
-		bom_qty = frappe.get_cached_value("BOM", self.bom_no, "quantity")
 		if not self.use_multi_level_bom:
+			bom_qty = frappe.db.get_value("BOM", self.bom_no, "quantity")
 			operations.extend(_get_operations(self.bom_no, qty=1.0/bom_qty))
 		else:
 			bom_tree = frappe.get_doc("BOM", self.bom_no).get_tree_representation()
@@ -497,7 +497,7 @@ class WorkOrder(Document):
 
 			for d in bom_traversal:
 				if d.is_bom:
-					operations.extend(_get_operations(d.name, qty=d.exploded_qty/bom_qty))
+					operations.extend(_get_operations(d.name, qty=d.exploded_qty))
 
 			for correct_index, operation in enumerate(operations, start=1):
 				operation.idx = correct_index


### PR DESCRIPTION
**Issue**
Created BOM 100 Qty with operation time as 100
<img width="1183" alt="Screenshot 2021-07-23 at 4 44 45 PM" src="https://user-images.githubusercontent.com/8780500/126780243-14820b8c-bed5-4315-b8d9-211e422ff43d.png">


Then created work order against the BOM and system has calculated incorrect operation time
<img width="1051" alt="Screenshot 2021-07-23 at 4 44 12 PM" src="https://user-images.githubusercontent.com/8780500/126780258-94e1e499-20a7-4503-9bbc-0d486f5ac759.png">



**After Fix**

<img width="1104" alt="Screenshot 2021-07-23 at 4 43 38 PM" src="https://user-images.githubusercontent.com/8780500/126780299-46a9743c-98ba-44ee-9d9b-b638eee7c7f7.png">

