### PR TITLE
fix: Supplier invoice importer fix

### DIFF
--- a/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py
+++ b/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py
@@ -391,5 +391,5 @@ def set_default_accounts(company):
 	})
 
 	company.save()
-	install_country_fixtures(company.name)
+	install_country_fixtures(company.name, company.country)
 	company.create_default_tax_template()

--- a/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py
+++ b/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py
@@ -391,5 +391,5 @@ def set_default_accounts(company):
 	})
 
 	company.save()
-	install_country_fixtures(company.name, company.country)
+	install_country_fixtures(company.name)
 	company.create_default_tax_template()

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1112,8 +1112,11 @@ class AccountsController(TransactionBase):
 			for d in self.get("payment_schedule"):
 				if d.invoice_portion:
 					d.payment_amount = flt(grand_total * flt(d.invoice_portion / 100), d.precision('payment_amount'))
-					d.base_payment_amount = flt(base_grand_total * flt(d.invoice_portion / 100), d.precision('payment_amount'))
+					d.base_payment_amount = flt(base_grand_total * flt(d.invoice_portion / 100), d.precision('base_payment_amount'))
 					d.outstanding = d.payment_amount
+				elif not d.invoice_portion:
+					d.base_payment_amount = flt(base_grand_total * self.get("conversion_rate"), d.precision('base_payment_amount'))
+
 
 	def set_due_date(self):
 		due_dates = [d.due_date for d in self.get("payment_schedule") if d.due_date]


### PR DESCRIPTION
- This [PR](https://github.com/frappe/erpnext/pull/25292) recently added few variables including the 'base_payment_amount' to deal with multi currency invoices. 
- The Supplier Invoice Importer tool was generating purchase invoices without adding the **invoice portion** in Payment Schedule due to which  'base_payment_amount'  was never set (in set_payment_schedule method), causing validation error in the 'validate_payment_schedule_amount' method.
** validate_payment_schedule_amount, set_payment_schedule in accounts_controller.py

   <img src='https://user-images.githubusercontent.com/36098155/126809153-069f7446-8f74-4c34-84de-69c2e166df98.png' width='500px' height='200px'>

So in absence of invoice_portion, base_payment_amount is assigned same value as the payment_amount in the given payment schedule.

Steps:
1. Create a company based in Italy, currency as euros. Also create a Buying Price List for this new company.
2. Create a new entry in the Import Supplier Invoice, select the new company and buying price list, any item and tax account, supplier group as 'Services'.
3. Select the zip file containing the invoice XMLs to be imported and import.
4. check Error Log for any error like in the above screenshot.