### PR TITLE
fix: Reset weight_per_unit on replacing Item

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -312,7 +312,7 @@ def get_basic_details(args, item, overwrite_warehouse=True):
 		"transaction_date": args.get("transaction_date"),
 		"against_blanket_order": args.get("against_blanket_order"),
 		"bom_no": item.get("default_bom"),
-		"weight_per_unit": args.get("weight_per_unit") or item.get("weight_per_unit"),
+		"weight_per_unit": item.get("weight_per_unit"),
 		"weight_uom": args.get("weight_uom") or item.get("weight_uom")
 	})
 

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -313,7 +313,7 @@ def get_basic_details(args, item, overwrite_warehouse=True):
 		"against_blanket_order": args.get("against_blanket_order"),
 		"bom_no": item.get("default_bom"),
 		"weight_per_unit": item.get("weight_per_unit"),
-		"weight_uom": args.get("weight_uom") or item.get("weight_uom")
+		"weight_uom": item.get("weight_uom")
 	})
 
 	if item.get("enable_deferred_revenue") or item.get("enable_deferred_expense"):


### PR DESCRIPTION
### Issue:

On changing an Item in a table, its weight_per_unit doesn't get reset.

<details>
<summary>Steps to replicate issue</summary>

- Create a new Sales Order.
- Enter an Item with a default weight_per_unit.
- Replace this Item with another Item.
- Check the weight_per_unit now. You'll find that it hasn't changed.
</details>

### Fix:

On replacing an Item, the weight_per_unit field gets reset to the new Item's default weight_per_unit(or zero, if it doesn't have one).
