### PR TITLE
ci: auto backport squashed commits based on labels

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,16 +1,25 @@
 name: Backport
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
       - labeled
 
 jobs:
-  backport:
-    runs-on: ubuntu-18.04
-    name: Backport
+  main:
+    runs-on: ubuntu-latest
     steps:
-      - name: Backport
-        uses: tibdex/backport@v1
+      - name: Checkout Actions
+        uses: actions/checkout@v2
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          repository: "ankush/backport"
+          path: ./actions
+          ref: develop
+      - name: Install Actions
+        run: npm install --production --prefix ./actions
+      - name: Run backport
+        uses: ./actions/backport
+        with:
+          token: ${{secrets.BACKPORT_BOT_TOKEN}}
+          labelsToAdd: "backport"
+          title: "{{originalTitle}}"


### PR DESCRIPTION
Workflow to auto backport `squashed` PR merges. 

Use this label scheme for creating backports:  `backport <branchname>`

Example : `backport version-13-hotfix`



---
Credit:

This is based on work of https://github.com/tibdex/backport with subsequent modification from https://github.com/grafana/grafana-github-actions (which in turn is based on https://github.com/microsoft/vscode-github-triage-actions)

All repos are licensed under MIT License.