### PR TITLE
fix: sales pipeline graph issue

### DIFF
--- a/erpnext/selling/page/sales_funnel/sales_funnel.css
+++ b/erpnext/selling/page/sales_funnel/sales_funnel.css
@@ -1,3 +1,4 @@
 .funnel-wrapper {
 	margin: 15px;
+	width: 100%;
 }


### PR DESCRIPTION
Issue - Sales Funnel report doesn't load any graph when 'Chart' is set to 'Sales Pipeline' or 'Opportunities by lead source'.
