### PR TITLE
fix:Ignore mandatory fields while creating payment reconciliation Journal Entry

### DIFF
--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
@@ -306,5 +306,5 @@ def reconcile_dr_cr_note(dr_cr_notes, company):
 				}
 			]
 		})
-
+		jv.flags.ignore_mandatory = True
 		jv.submit()


### PR DESCRIPTION
Ignore mandatory fields which prevents payment reconciliations from being created

PR : https://github.com/frappe/erpnext/pull/26550