### PR TITLE
feat: add `total_billing_hours` to Sales Invoice

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
@@ -69,6 +69,7 @@
   "time_sheet_list",
   "timesheets",
   "total_billing_amount",
+  "total_billing_hours",
   "section_break_30",
   "total_qty",
   "base_total",
@@ -1564,12 +1565,20 @@
   {
    "fieldname": "dimension_col_break",
    "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "total_billing_hours",
+   "fieldtype": "Float",
+   "label": "Total Billing Hours",
+   "print_hide": 1,
+   "read_only": 1
   }
  ],
  "icon": "fa fa-file-text",
  "idx": 181,
  "is_submittable": 1,
- "modified": "2020-07-01 12:41:29.484813",
+ "modified": "2021-07-26 14:01:34.605644",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice",

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -683,12 +683,10 @@ class SalesInvoice(SellingController):
 			self.calculate_billing_amount_for_timesheet()
 
 	def calculate_billing_amount_for_timesheet(self):
-		total_billing_amount = 0.0
-		for data in self.timesheets:
-			if data.billing_amount:
-				total_billing_amount += data.billing_amount
+		timesheet_sum = lambda field: sum((ts.get(field) or 0.0 )for ts in self.timesheets)
 
-		self.total_billing_amount = total_billing_amount
+		self.total_billing_amount = timesheet_sum('billing_amount')
+		self.total_billing_hours = timesheet_sum('billing_hours')
 
 	def get_warehouse(self):
 		user_pos_profile = frappe.db.sql("""select name, warehouse from `tabPOS Profile`

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -683,7 +683,8 @@ class SalesInvoice(SellingController):
 			self.calculate_billing_amount_for_timesheet()
 
 	def calculate_billing_amount_for_timesheet(self):
-		timesheet_sum = lambda field: sum((ts.get(field) or 0.0 )for ts in self.timesheets)
+		def timesheet_sum(field):
+			return sum((ts.get(field) or 0.0) for ts in self.timesheets)
 
 		self.total_billing_amount = timesheet_sum('billing_amount')
 		self.total_billing_hours = timesheet_sum('billing_hours')

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -686,8 +686,8 @@ class SalesInvoice(SellingController):
 		def timesheet_sum(field):
 			return sum((ts.get(field) or 0.0) for ts in self.timesheets)
 
-		self.total_billing_amount = timesheet_sum('billing_amount')
-		self.total_billing_hours = timesheet_sum('billing_hours')
+		self.total_billing_amount = timesheet_sum("billing_amount")
+		self.total_billing_hours = timesheet_sum("billing_hours")
 
 	def get_warehouse(self):
 		user_pos_profile = frappe.db.sql("""select name, warehouse from `tabPOS Profile`


### PR DESCRIPTION
### Problem

Timesheets get fetched into a sales invoice. Currently we calculate only the total billing amount. This makes it hard to add a position "Consulting, 30 hours @ 50 USD". We have to divide the total by our rate or sum the hours manually.

### Solution

Add a field `total_billing_hours`, next to `total_billing_amount`.

### Demo


https://user-images.githubusercontent.com/14891507/127000697-109ce1d9-b579-4631-9478-b30f8ac7f0b9.mov

