### PR TITLE
fix: Notify assignee on reopening resolved issue

### DIFF
--- a/erpnext/support/doctype/issue/issue.py
+++ b/erpnext/support/doctype/issue/issue.py
@@ -46,12 +46,14 @@ class Issue(Document):
 			'document_type': self.doctype,
 			'subject': subject,
 			'document_name': self.name,
-			'from_user': frappe.session.user,
-			'for_user': self.owner
+			'from_user': frappe.session.user
 			# 'email_content': description_html
 		}
 
-		enqueue_create_notification(frappe.session.user, notification_doc)
+		assigned_to = frappe.db.get_value(self.doctype, self.name, '_assign')
+		assigned_to = frappe.parse_json(assigned_to)
+
+		enqueue_create_notification(assigned_to, notification_doc)
 
 	def on_update(self):
 		# Add a communication in the issue timeline


### PR DESCRIPTION
### Proposed Change:

Assignees will be notified if an Issue that was marked as Resolved is reopened by anyone else.

![Screenshot 2021-07-26 at 10 29 57 PM](https://user-images.githubusercontent.com/25903035/127029092-27eccb73-4734-4146-bf21-a55295f8e296.png)

_Note:_
https://github.com/frappe/frappe/pull/13782 needs to be merged first.

