### PR TITLE
fix: Missing method reset_issue_metrics added back to Issue doctype

### DIFF
--- a/erpnext/support/doctype/issue/issue.py
+++ b/erpnext/support/doctype/issue/issue.py
@@ -212,6 +212,10 @@ class Issue(Document):
 		}).insert(ignore_permissions=True)
 
 		return replicated_issue.name
+	
+	def reset_issue_metrics(self):
+		self.db_set("resolution_time", None)
+		self.db_set("user_resolution_time", None)
 
 	def before_insert(self):
 		if frappe.db.get_single_value("Support Settings", "track_service_level_agreement"):


### PR DESCRIPTION
v13 PR: https://github.com/frappe/erpnext/pull/26574

**Issue:**
Method reset_issue_metrics was removed earlier while still being used.

**Fix:**
It was added back again.