### PR TITLE
fix: reload Manufacturing Settings in patch

### DIFF
--- a/erpnext/patches/v13_0/add_missing_fg_item_for_stock_entry.py
+++ b/erpnext/patches/v13_0/add_missing_fg_item_for_stock_entry.py
@@ -10,6 +10,7 @@ def execute():
 	if not frappe.db.has_column('Work Order', 'has_batch_no'):
 		return
 
+	frappe.reload_doctype('Manufacturing Settings')
 	if cint(frappe.db.get_single_value('Manufacturing Settings', 'make_serial_no_batch_from_work_order')):
 		return
 


### PR DESCRIPTION
### Reproduce

Restore a v12 backup into a v13 bench and run `bench migrate`.

### Error

```
InvalidColumnName: Invalid Fieldname: <b>make_serial_no_batch_from_work_order</b>
```

### Fix

Reload **Manufacturing Settings** doctype