### PR TITLE
fix: Stock Analytics Report must consider warehouse during calculation

### DIFF
--- a/erpnext/stock/report/stock_analytics/stock_analytics.py
+++ b/erpnext/stock/report/stock_analytics/stock_analytics.py
@@ -114,14 +114,41 @@ def get_period(posting_date, filters):
 
 
 def get_periodic_data(entry, filters):
+	"""Structured as:
+		Item 1
+			- Balance (updated and carried forward):
+					- Warehouse A : bal_qty/value
+					- Warehouse B : bal_qty/value
+			- Jun 2021 (sum of warehouse quantities used in report)
+					- Warehouse A : bal_qty/value
+					- Warehouse B : bal_qty/value
+			- Jul 2021 (sum of warehouse quantities used in report)
+					- Warehouse A : bal_qty/value
+					- Warehouse B : bal_qty/value
+		Item 2
+			- Balance (updated and carried forward):
+					- Warehouse A : bal_qty/value
+					- Warehouse B : bal_qty/value
+			- Jun 2021 (sum of warehouse quantities used in report)
+					- Warehouse A : bal_qty/value
+					- Warehouse B : bal_qty/value
+			- Jul 2021 (sum of warehouse quantities used in report)
+					- Warehouse A : bal_qty/value
+					- Warehouse B : bal_qty/value
+	"""
 	periodic_data = {}
 	for d in entry:
 		period = get_period(d.posting_date, filters)
 		bal_qty = 0
 
+		# if period against item does not exist yet, instantiate it
+		# insert existing balance dict against period, and add/subtract to it
+		if periodic_data.get(d.item_code) and not periodic_data.get(d.item_code).get(period):
+			periodic_data[d.item_code][period] = periodic_data[d.item_code]['balance']
+
 		if d.voucher_type == "Stock Reconciliation":
-			if periodic_data.get(d.item_code):
-				bal_qty = periodic_data[d.item_code]["balance"]
+			if periodic_data.get(d.item_code) and periodic_data.get(d.item_code).get('balance').get(d.warehouse):
+				bal_qty = periodic_data[d.item_code]['balance'][d.warehouse]
 
 			qty_diff = d.qty_after_transaction - bal_qty
 		else:
@@ -132,12 +159,12 @@ def get_periodic_data(entry, filters):
 		else:
 			value = d.stock_value_difference
 
-		periodic_data.setdefault(d.item_code, {}).setdefault(period, 0.0)
-		periodic_data.setdefault(d.item_code, {}).setdefault("balance", 0.0)
+		# period-warehouse wise balance
+		periodic_data.setdefault(d.item_code, {}).setdefault('balance', {}).setdefault(d.warehouse, 0.0)
+		periodic_data.setdefault(d.item_code, {}).setdefault(period, {}).setdefault(d.warehouse, 0.0)
 
-		periodic_data[d.item_code]["balance"] += value
-		periodic_data[d.item_code][period] = periodic_data[d.item_code]["balance"]
-
+		periodic_data[d.item_code]['balance'][d.warehouse] += value
+		periodic_data[d.item_code][period][d.warehouse] = periodic_data[d.item_code]['balance'][d.warehouse]
 
 	return periodic_data
 
@@ -160,7 +187,8 @@ def get_data(filters):
 		total = 0
 		for dummy, end_date in ranges:
 			period = get_period(end_date, filters)
-			amount = flt(periodic_data.get(item_data.name, {}).get(period))
+			period_data = periodic_data.get(item_data.name, {}).get(period)
+			amount = sum(period_data.values()) if period_data else 0
 			row[scrub(period)] = amount
 			total += amount
 		row["total"] = total

--- a/erpnext/stock/report/stock_balance/stock_balance.py
+++ b/erpnext/stock/report/stock_balance/stock_balance.py
@@ -235,12 +235,15 @@ def filter_items_with_no_transactions(iwb_map, float_precision):
 	return iwb_map
 
 def get_items(filters):
+	"Get items based on item code, item group or brand."
 	conditions = []
 	if filters.get("item_code"):
 		conditions.append("item.name=%(item_code)s")
 	else:
 		if filters.get("item_group"):
 			conditions.append(get_item_group_condition(filters.get("item_group")))
+		if filters.get("brand"): # used in stock analytics report
+			conditions.append("item.brand=%(brand)s")
 
 	items = []
 	if conditions:


### PR DESCRIPTION
**Consider the following:**
- Here are SLEs for Item **Bottle** for the month of June. 
- The total quantity in June should be (balance qty in **Work In Progress - GP** + balance qty in **Stores - GP**) = **11 + 6** = **17**
   ![Screenshot 2021-08-11 at 10 44 07 AM](https://user-images.githubusercontent.com/25857446/128973439-1fcb5950-98c1-4465-a834-9b90e3a01aef.png)

**Issue:**
- ![Screenshot 2021-08-10 at 8 52 42 PM](https://user-images.githubusercontent.com/25857446/128972655-7ed47339-e983-4e97-9b9f-98305a3524fc.png)
- Stock Analytics Report haphazardly added `actual_qty` from SLEs **irrespective of warehouse** to generate the total qty in a month
- This gave out faulty values because while accounting for Stock Recos, considering warehouse is very important.
- It just added balance of SLEs in **Work In Progress - GP** to that of SLEs in **Stores - GP**, and so the balance shows as **11**, which is just the balance of **Stores - GP**. 
- Due to the stock reco on **15-06-2021**, the first SLE in **Work In Progress - GP** is reset or ignored.

**Fix:**
- Maintain period and warehouse wise balances
- Add the all warehouse balances in a certain period, to get its actual total qty
- The total quantity in June is (balance qty in **Work In Progress - GP** + balance qty in **Stores - GP**) = **11 + 6** = **17**
   ![Screenshot 2021-08-10 at 8 51 18 PM](https://user-images.githubusercontent.com/25857446/128973886-69f12cb5-d12b-4c09-8ec5-7ede2b74ce0a.png)
- Fixed brand filter which was not working

> This can be tested using Quick Stock balance too. All the balances until the end of a month of each warehouse should add up to the value in the report

**To test:**
- create an item and create stock transactions in different warehouses
- in one warehouse's transactions, add a stock reco
- check values in stock analytics, month/week/quarter wise