### PR TITLE
fix: not able to add employee in the job card

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -192,11 +192,11 @@ class JobCard(Document):
 						"completed_qty": args.get("completed_qty") or 0.0
 					})
 		elif args.get("start_time"):
-			new_args = {
+			new_args = frappe._dict({
 				"from_time": get_datetime(args.get("start_time")),
 				"operation": args.get("sub_operation"),
 				"completed_qty": 0.0
-			}
+			})
 
 			if employees:
 				for name in employees:


### PR DESCRIPTION
**Issue**

1. Click on start button and select the employee in the Popup, you will get below error 

```
Traceback (most recent call last):
  File "/home/frappe/version13/apps/frappe/frappe/app.py", line 68, in application
    response = frappe.api.handle()
  File "/home/frappe/version13/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/home/frappe/version13/apps/frappe/frappe/handler.py", line 31, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/version13/apps/frappe/frappe/handler.py", line 67, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/version13/apps/frappe/frappe/__init__.py", line 1172, in call
    return fn(*args, **newargs)
  File "/home/frappe/version13/apps/erpnext/erpnext/manufacturing/doctype/job_card/job_card.py", line 540, in make_time_log
    doc.add_time_log(args)
  File "/home/frappe/version13/apps/erpnext/erpnext/manufacturing/doctype/job_card/job_card.py", line 203, in add_time_log
    new_args.employee = name.get('employee')
AttributeError: 'dict' object has no attribute 'employee'
```