### PR TITLE
fix: date as reference_date from bank transactions

### DIFF
--- a/erpnext/public/js/bank_reconciliation_tool/dialog_manager.js
+++ b/erpnext/public/js/bank_reconciliation_tool/dialog_manager.js
@@ -16,7 +16,7 @@ erpnext.accounts.bank_reconciliation.DialogManager = class DialogManager {
 				doctype: "Bank Transaction",
 				filters: { name: this.bank_transaction_name },
 				fieldname: [
-					"date",
+					"date as reference_date",
 					"deposit",
 					"withdrawal",
 					"currency",


### PR DESCRIPTION
- Fetches `date` as `reference_date` from Bank Transactions since the fieldname is `reference_date` in vouchers.
- Fixes autofill for Create Voucher.

#### Before:

![image](https://user-images.githubusercontent.com/38958184/127296073-60ed394b-c24c-4e41-9ade-e8dec3150de4.png)

#### After:

![image](https://user-images.githubusercontent.com/38958184/127295560-38503c86-8722-4638-9e76-daa5d9a58462.png)


