### PR TITLE
fix: POS Item Cart non-stop scroll issue

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_item_cart.js
+++ b/erpnext/selling/page/point_of_sale/pos_item_cart.js
@@ -564,7 +564,6 @@ erpnext.PointOfSale.ItemCart = class {
 		)
 
 		set_dynamic_rate_header_width();
-		this.scroll_to_item($item_to_update);
 
 		function set_dynamic_rate_header_width() {
 			const rate_cols = Array.from(me.$cart_items_wrapper.find(".item-rate-amount"));
@@ -637,12 +636,6 @@ erpnext.PointOfSale.ItemCart = class {
 	handle_broken_image($img) {
 		const item_abbr = $($img).attr('alt');
 		$($img).parent().replaceWith(`<div class="item-image item-abbr">${item_abbr}</div>`);
-	}
-
-	scroll_to_item($item) {
-		if ($item.length === 0) return;
-		const scrollTop = $item.offset().top - this.$cart_items_wrapper.offset().top + this.$cart_items_wrapper.scrollTop();
-		this.$cart_items_wrapper.animate({ scrollTop });
 	}
 
 	update_selector_value_in_cart_item(selector, value, item) {


### PR DESCRIPTION
**Issue :**
The item cart in POS would continuously scroll up and down when many items are added

**Reference Support Issue:**
https://frappe.io/app/issue/ISS-21-22-04311

**Fix :**
Removed the auto scroll function that was run on cart updation