### PR TITLE
fix: POS payment modes displayed wrong total

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_payment.js
+++ b/erpnext/selling/page/point_of_sale/pos_payment.js
@@ -198,6 +198,7 @@ erpnext.PointOfSale.Payment = class {
 			const is_cash_shortcuts_invisible = !this.$payment_modes.find('.cash-shortcuts').is(':visible');
 			this.attach_cash_shortcuts(frm.doc);
 			!is_cash_shortcuts_invisible && this.$payment_modes.find('.cash-shortcuts').css('display', 'grid');
+			this.render_payment_mode_dom();
 		});
 
 		frappe.ui.form.on('POS Invoice', 'loyalty_amount', (frm) => {


### PR DESCRIPTION
**Problem:**
On applying additional discount, the total displayed on the payment mode doesn't update.
  <img width="600" alt="Screenshot 2021-07-29 at 2 22 38 PM" src="https://user-images.githubusercontent.com/36098155/127462612-0c9e0d91-801a-427b-92b3-3758cacfc3db.png">

**Fix:**
Re-rendered the payment modes

Ref: **[ISSUE](https://frappe.io/app/issue/ISS-21-22-04311)**