### PR TITLE
fix: empty "against account" in Purchase Receipt GLE

### DIFF
--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -966,7 +966,7 @@ def compare_existing_and_expected_gle(existing_gle, expected_gle, precision):
 		for e in existing_gle:
 			if entry.account == e.account:
 				account_existed = True
-			if (entry.account == e.account and entry.against_account == e.against_account
+			if (entry.account == e.account
 					and (not entry.cost_center or not e.cost_center or entry.cost_center == e.cost_center)
 					and ( flt(entry.debit, precision) != flt(e.debit, precision) or
 						flt(entry.credit, precision) != flt(e.credit, precision))):

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -436,7 +436,7 @@ class PurchaseReceipt(BuyingController):
 			"cost_center": cost_center,
 			"debit": debit,
 			"credit": credit,
-			"against_account": against_account,
+			"against": against_account,
 			"remarks": remarks,
 		}
 


### PR DESCRIPTION
Problem(s):
1. against account field is empty on PR GLEs. introduced via https://github.com/frappe/erpnext/pull/25379 
2. During reposting of PR, GLEs are not updated in line with SLE. This was due to faulty conditions for comparing new and old GLEs.

Solution:
1. Correct field name
2. Remove faulty condition. 