### PR TITLE
chore: add timeout to GHA workflows

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout Actions
         uses: actions/checkout@v2

--- a/.github/workflows/docs-checker.yml
+++ b/.github/workflows/docs-checker.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
 
     steps:
       - name: 'Setup Environment'

--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -5,6 +5,7 @@ on: [pull_request, workflow_dispatch]
 jobs:
   test:
     runs-on: ubuntu-18.04
+    timeout-minutes: 60
 
     name: Patch Test
 

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-18.04
+    timeout-minutes: 60
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-18.04
+    timeout-minutes: 60
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
If a workflow is stuck for whatever reason, it won't stop until the default limit of 6 hours is hit, wasting resources. 

Limited most workflows to a maximum of 60 minutes. (which is 2-3x our current max running time)