### PR TITLE
fix: Parent condition in pricing rules

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/utils.py
+++ b/erpnext/accounts/doctype/pricing_rule/utils.py
@@ -168,7 +168,7 @@ def _get_tree_conditions(args, parenttype, table, allow_blank=True):
 			frappe.throw(_("Invalid {0}").format(args.get(field)))
 
 		parent_groups = frappe.db.sql_list("""select name from `tab%s`
-			where lft>=%s and rgt<=%s""" % (parenttype, '%s', '%s'), (lft, rgt))
+			where lft<=%s and rgt>=%s""" % (parenttype, '%s', '%s'), (lft, rgt))
 
 		if parenttype in ["Customer Group", "Item Group", "Territory"]:
 			parent_field = "parent_{0}".format(frappe.scrub(parenttype))


### PR DESCRIPTION
Let's say a pricing Rule is created for the item Group "Component" 

![image](https://user-images.githubusercontent.com/42651287/127499318-255d4c46-281a-4ffc-9563-767dd1666ddb.png)

And the tree structure is as follows
![image](https://user-images.githubusercontent.com/42651287/127499471-a0361985-d3cc-4aa1-b6a3-65845601d1f6.png)

Pricing rule was not getting applied for items under this group due to incorrect condition

