### PR TITLE
fix: remove cancelled entries from Stock and Account Value comparison report

### DIFF
--- a/erpnext/stock/report/stock_and_account_value_comparison/stock_and_account_value_comparison.py
+++ b/erpnext/stock/report/stock_and_account_value_comparison/stock_and_account_value_comparison.py
@@ -22,6 +22,7 @@ def get_data(report_filters):
 	data = []
 
 	filters = {
+		"is_cancelled": 0,
 		"company": report_filters.company,
 		"posting_date": ("<=", report_filters.as_on_date)
 	}
@@ -34,7 +35,7 @@ def get_data(report_filters):
 		key = (d.voucher_type, d.voucher_no)
 		gl_data = voucher_wise_gl_data.get(key) or {}
 		d.account_value = gl_data.get("account_value", 0)
-		d.difference_value = (d.stock_value - d.account_value)
+		d.difference_value = abs(d.stock_value - d.account_value)
 		if abs(d.difference_value) > 0.1:
 			data.append(d)
 


### PR DESCRIPTION
Don't consider the cancelled GL and SLE entries