### PR TITLE
fix: fetching of item tax from hsn code

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -438,7 +438,8 @@ regional_overrides = {
 		'erpnext.hr.utils.calculate_annual_eligible_hra_exemption': 'erpnext.regional.india.utils.calculate_annual_eligible_hra_exemption',
 		'erpnext.hr.utils.calculate_hra_exemption_for_period': 'erpnext.regional.india.utils.calculate_hra_exemption_for_period',
 		'erpnext.controllers.accounts_controller.validate_einvoice_fields': 'erpnext.regional.india.e_invoice.utils.validate_einvoice_fields',
-		'erpnext.assets.doctype.asset.asset.get_depreciation_amount': 'erpnext.regional.india.utils.get_depreciation_amount'
+		'erpnext.assets.doctype.asset.asset.get_depreciation_amount': 'erpnext.regional.india.utils.get_depreciation_amount',
+		'erpnext.stock.doctype.item.item.set_item_tax_from_hsn_code': 'erpnext.regional.india.utils.set_item_tax_from_hsn_code'
 	},
 	'United Arab Emirates': {
 		'erpnext.controllers.taxes_and_totals.update_itemised_tax_data': 'erpnext.regional.united_arab_emirates.utils.update_itemised_tax_data',

--- a/erpnext/regional/india/utils.py
+++ b/erpnext/regional/india/utils.py
@@ -860,3 +860,14 @@ def get_depreciation_amount(asset, depreciable_value, row):
 		depreciation_amount = flt(depreciable_value * (flt(rate_of_depreciation) / 100))
 
 	return depreciation_amount
+
+def set_item_tax_from_hsn_code(item):
+	if not item.taxes and item.gst_hsn_code: 
+		hsn_doc = frappe.get_doc("GST HSN Code", item.gst_hsn_code)
+
+		for tax in hsn_doc.taxes:
+			item.append('taxes', {
+				'item_tax_template': tax.item_tax_template,
+				'tax_category': tax.tax_category,
+				'valid_from': tax.valid_from
+			})

--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -138,20 +138,6 @@ frappe.ui.form.on("Item", {
 		frm.toggle_reqd('customer', frm.doc.is_customer_provided_item ? 1:0);
 	},
 
-	gst_hsn_code: function(frm) {
-		if((!frm.doc.taxes || !frm.doc.taxes.length) && frm.doc.gst_hsn_code) {
-			frappe.db.get_doc("GST HSN Code", frm.doc.gst_hsn_code).then(hsn_doc => {
-				$.each(hsn_doc.taxes || [], function(i, tax) {
-					let a = frappe.model.add_child(cur_frm.doc, 'Item Tax', 'taxes');
-					a.item_tax_template = tax.item_tax_template;
-					a.tax_category = tax.tax_category;
-					a.valid_from = tax.valid_from;
-					frm.refresh_field('taxes');
-				});
-			});
-		}
-	},
-
 	is_fixed_asset: function(frm) {
 		// set serial no to false & toggles its visibility
 		frm.set_value('has_serial_no', 0);

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -123,6 +123,7 @@ class Item(WebsiteGenerator):
 		self.cant_change()
 		self.update_show_in_website()
 		self.validate_item_tax_net_rate_range()
+		set_item_tax_from_hsn_code(self)
 
 		if not self.is_new():
 			self.old_item_group = frappe.db.get_value(self.doctype, self.name, "item_group")
@@ -1305,3 +1306,7 @@ def update_variants(variants, template, publish_progress=True):
 def on_doctype_update():
 	# since route is a Text column, it needs a length for indexing
 	frappe.db.add_index("Item", ["route(500)"])
+
+@erpnext.allow_regional
+def set_item_tax_from_hsn_code(item):
+	pass

--- a/erpnext/stock/doctype/item/regional/india.js
+++ b/erpnext/stock/doctype/item/regional/india.js
@@ -1,6 +1,6 @@
 frappe.ui.form.on('Item', {
 	gst_hsn_code: function(frm) {
-		if((!frm.doc.taxes || !frm.doc.taxes.length) && frm.doc.gst_hsn_code) {
+		if ((!frm.doc.taxes || !frm.doc.taxes.length) && frm.doc.gst_hsn_code) {
 			frappe.db.get_doc("GST HSN Code", frm.doc.gst_hsn_code).then(hsn_doc => {
 				$.each(hsn_doc.taxes || [], function(i, tax) {
 					let a = frappe.model.add_child(cur_frm.doc, 'Item Tax', 'taxes');
@@ -12,5 +12,4 @@ frappe.ui.form.on('Item', {
 			});
 		}
 	},
-})
-
+});

--- a/erpnext/stock/doctype/item/regional/india.js
+++ b/erpnext/stock/doctype/item/regional/india.js
@@ -1,0 +1,16 @@
+frappe.ui.form.on('Item', {
+	gst_hsn_code: function(frm) {
+		if((!frm.doc.taxes || !frm.doc.taxes.length) && frm.doc.gst_hsn_code) {
+			frappe.db.get_doc("GST HSN Code", frm.doc.gst_hsn_code).then(hsn_doc => {
+				$.each(hsn_doc.taxes || [], function(i, tax) {
+					let a = frappe.model.add_child(cur_frm.doc, 'Item Tax', 'taxes');
+					a.item_tax_template = tax.item_tax_template;
+					a.tax_category = tax.tax_category;
+					a.valid_from = tax.valid_from;
+					frm.refresh_field('taxes');
+				});
+			});
+		}
+	},
+})
+


### PR DESCRIPTION
Issues fixed:
- Item tax was fetched from GST HSN Code even if there is no Indian company exists
- Item tax was not fetched if items were imported using Data Import

To test the fix:
- Modify a GST HSN Code record and add an Item Tax Template in the child table
- Copy the HSN code and import an Item using Data Import. Make sure the HSN code field & value is present in the Data Import template
- Check the imported Item if the Item Tax table has a proper Item Tax Template set.