### PR TITLE
Revert "fix: Tax calculation for Recurring additional salary"

### DIFF
--- a/erpnext/payroll/doctype/additional_salary/additional_salary.py
+++ b/erpnext/payroll/doctype/additional_salary/additional_salary.py
@@ -112,11 +112,11 @@ class AdditionalSalary(Document):
 		no_of_days = date_diff(getdate(end_date), getdate(start_date)) + 1
 		return amount_per_day * no_of_days
 
-@frappe.whitelist()
 def get_additional_salaries(employee, start_date, end_date, component_type):
 	additional_salary_list = frappe.db.sql("""
-		select name, salary_component as component, type, amount, overwrite_salary_structure_amount as overwrite,
-		deduct_full_tax_on_selected_payroll_date, is_recurring
+		select name, salary_component as component, type, amount,
+		overwrite_salary_structure_amount as overwrite,
+		deduct_full_tax_on_selected_payroll_date
 		from `tabAdditional Salary`
 		where employee=%(employee)s
 			and docstatus = 1

--- a/erpnext/payroll/doctype/salary_detail/salary_detail.json
+++ b/erpnext/payroll/doctype/salary_detail/salary_detail.json
@@ -12,7 +12,6 @@
   "year_to_date",
   "section_break_5",
   "additional_salary",
-  "is_recurring_additional_salary",
   "statistical_component",
   "depends_on_payment_days",
   "exempted_from_income_tax",
@@ -236,19 +235,11 @@
    "label": "Year To Date",
    "options": "currency",
    "read_only": 1
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:doc.parenttype=='Salary Slip' && doc.parentfield=='earnings' && doc.additional_salary",
-   "fieldname": "is_recurring_additional_salary",
-   "fieldtype": "Check",
-   "label": "Is Recurring Additional Salary",
-   "read_only": 1
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2021-03-14 13:39:15.847158",
+ "modified": "2021-01-14 13:39:15.847158",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Salary Detail",


### PR DESCRIPTION
Reverts frappe/erpnext#24206

Reverting this because it does not calculate taxable income properly in case of overwritten additional salary