### PR TITLE
fix: change format string to percent string interpolation

### DIFF
--- a/erpnext/patches/v13_0/add_missing_fg_item_for_stock_entry.py
+++ b/erpnext/patches/v13_0/add_missing_fg_item_for_stock_entry.py
@@ -30,19 +30,20 @@ def execute():
 		return
 
 	repost_stock_entries = []
+
 	stock_entries = frappe.db.sql_list('''
 		SELECT
 			se.name
 		FROM
 			`tabStock Entry` se
 		WHERE
-			se.purpose = 'Manufacture' and se.docstatus < 2 and se.work_order in {work_orders}
+			se.purpose = 'Manufacture' and se.docstatus < 2 and se.work_order in %s
 			and not exists(
 				select name from `tabStock Entry Detail` sed where sed.parent = se.name and sed.is_finished_item = 1
 			)
-		Order BY
+		ORDER BY
 			se.posting_date, se.posting_time
-	'''.format(work_orders=tuple(work_orders)))
+	''',  (work_orders,))
 
 	if stock_entries:
 		print('Length of stock entries', len(stock_entries))


### PR DESCRIPTION
Format string causes syntax error when there is a single item in the list due to trailing comma in `str(tuple(some_list))`.