### PR TITLE
fix: Customers 'primary_address' not updated automatically (#26798)

### DIFF
--- a/erpnext/accounts/custom/address.py
+++ b/erpnext/accounts/custom/address.py
@@ -1,7 +1,7 @@
 import frappe
 from frappe import _
 from frappe.contacts.doctype.address.address import Address
-from frappe.contacts.doctype.address.address import get_address_templates
+from frappe.contacts.doctype.address.address import get_address_templates, get_address_display
 
 class ERPNextAddress(Address):
 	def validate(self):
@@ -22,6 +22,18 @@ class ERPNextAddress(Address):
 			frappe.throw(_("Address needs to be linked to a Company. Please add a row for Company in the Links table."),
 				title=_("Company Not Linked"))
 
+	def on_update(self):
+		"""
+		After Address is updated, update the related 'Primary Address' on Customer.
+		"""
+		address_display = get_address_display(self.as_dict())
+		filters = { "customer_primary_address": self.name }
+		customers = frappe.db.get_all("Customer", filters=filters, as_list=True)
+		for customer_name in customers:
+			doc_customer = frappe.get_doc("Customer", customer_name[0])
+			doc_customer.primary_address = address_display
+			doc_customer.save()
+			
 @frappe.whitelist()
 def get_shipping_address(company, address = None):
 	filters = [

--- a/erpnext/accounts/custom/address.py
+++ b/erpnext/accounts/custom/address.py
@@ -30,9 +30,7 @@ class ERPNextAddress(Address):
 		filters = { "customer_primary_address": self.name }
 		customers = frappe.db.get_all("Customer", filters=filters, as_list=True)
 		for customer_name in customers:
-			doc_customer = frappe.get_doc("Customer", customer_name[0])
-			doc_customer.primary_address = address_display
-			doc_customer.save()
+			frappe.db.set_value("Customer", customer_name[0], "primary_address", address_display)
 			
 @frappe.whitelist()
 def get_shipping_address(company, address = None):


### PR DESCRIPTION
Closes #26798

TLDR:  When an Address is updated, and that Address is a Customer's Primary Address, update the Read Only field `customer.primary_address`