### PR TITLE
fix: Do not fetch fully return issued purchase receipts

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -134,7 +134,7 @@ erpnext.accounts.PurchaseInvoice = class PurchaseInvoice extends erpnext.buying.
 					},
 					get_query_filters: {
 						docstatus: 1,
-						status: ["not in", ["Closed", "Completed"]],
+						status: ["not in", ["Closed", "Completed", "Return Issued"]],
 						company: me.frm.doc.company,
 						is_return: 0
 					}


### PR DESCRIPTION
Purchase Receipts for which the items are fully returned are also fetched while using the `Get Items` button in Purchase Invoice.

Add "Return Issues" status in the list of statues to ignore