### PR TITLE
fix: trigger lost reason dialog when status is changed to lost

### DIFF
--- a/erpnext/crm/doctype/opportunity/opportunity.js
+++ b/erpnext/crm/doctype/opportunity/opportunity.js
@@ -53,6 +53,13 @@ frappe.ui.form.on("Opportunity", {
 		frm.get_field("items").grid.set_multiple_add("item_code", "qty");
 	},
 
+	status:function(frm){
+		if (frm.doc.status == "Lost"){
+			frm.trigger('set_as_lost_dialog');
+		}
+	
+	},
+
 	customer_address: function(frm, cdt, cdn) {
 		erpnext.utils.get_address_display(frm, 'customer_address', 'address_display', false);
 	},
@@ -91,11 +98,6 @@ frappe.ui.form.on("Opportunity", {
 			frm.add_custom_button(__('Quotation'),
 				cur_frm.cscript.create_quotation, __('Create'));
 
-			if(doc.status!=="Quotation") {
-				frm.add_custom_button(__('Lost'), () => {
-					frm.trigger('set_as_lost_dialog');
-				});
-			}
 		}
 
 		if(!frm.doc.__islocal && frm.perm[0].write && frm.doc.docstatus==0) {


### PR DESCRIPTION
Before this fix lost reason dialog box was only triggered when clicked on the button and not when the status was changed to lost so this ended up in reason not being filled when the marked lost by selecting in dropdown.
After the fix when the status is changed in the drop down it triggers the lost reason dialog 
![lost_fix](https://user-images.githubusercontent.com/49878143/128168169-a62829c3-e1e3-464d-bcf7-2042e2b174b6.gif)
