### PR TITLE
fix: Let all System Managers be able to delete Company transactions

### DIFF
--- a/erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.json
+++ b/erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.json
@@ -54,7 +54,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2021-05-08 23:13:48.049879",
+ "modified": "2021-08-04 20:15:59.071493",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Transaction Deletion Record",
@@ -70,6 +70,7 @@
    "report": 1,
    "role": "System Manager",
    "share": 1,
+   "submit": 1,
    "write": 1
   }
  ],


### PR DESCRIPTION
_Issue:_
- Users without the 'submit' permission for Transaction Deletion Record are unable to delete Company transactions.

![Screenshot 2021-07-23 at 5 14 38 AM](https://user-images.githubusercontent.com/25903035/126722296-23ead296-1092-428d-a027-a52221a97b97.png)

_Fix:_
- Grant Submit permission for all System Managers.