### PR TITLE
fix: broken URL in supplier portal

### DIFF
--- a/erpnext/templates/includes/rfq/rfq_items.html
+++ b/erpnext/templates/includes/rfq/rfq_items.html
@@ -1,4 +1,4 @@
-{% from "erpnext/templates/includes/rfq/rfq_macros.html" import item_name_and_description %}
+{% from "templates/includes/rfq/rfq_macros.html" import item_name_and_description %}
 
 {% for d in doc.items %}
 <div class="rfq-item">

--- a/erpnext/templates/pages/rfq.html
+++ b/erpnext/templates/pages/rfq.html
@@ -86,7 +86,7 @@
 										<span class="small gray">{{d.transaction_date}}</span>
 									</div>
 								</div>
-								<a class="transaction-item-link" href="/quotations/{{d.name}}">Link</a>
+								<a class="transaction-item-link" href="/supplier-quotations/{{d.name}}">Link</a>
 							</div>
 						{% endfor %}
 					</div>
@@ -95,6 +95,4 @@
 		</div>
     </div>
 </div>
-
-
 {% endblock %}


### PR DESCRIPTION
The quotations in RFQ portal are supplier quotations, not sales quotation.
#no-docs