### PR TITLE
fix: show proper currency symbol in Taxes and Charges table

### DIFF
--- a/erpnext/accounts/doctype/purchase_taxes_and_charges/purchase_taxes_and_charges.json
+++ b/erpnext/accounts/doctype/purchase_taxes_and_charges/purchase_taxes_and_charges.json
@@ -22,7 +22,7 @@
   "cost_center",
   "dimension_col_break",
   "section_break_9",
-  "currency",
+  "account_currency",
   "tax_amount",
   "tax_amount_after_discount_amount",
   "total",
@@ -209,26 +209,26 @@
    "fieldtype": "Column Break"
   },
   {
-   "fetch_from": "account_head.account_currency",
-   "fieldname": "currency",
-   "fieldtype": "Link",
-   "label": "Account Currency",
-   "options": "Currency",
-   "read_only": 1
-  },
-  {
    "default": "0",
    "depends_on": "eval:['Purchase Taxes and Charges Template', 'Payment Entry'].includes(parent.doctype)",
    "description": "If checked, the tax amount will be considered as already included in the Paid Amount in Payment Entry",
    "fieldname": "included_in_paid_amount",
    "fieldtype": "Check",
    "label": "Considered In Paid Amount"
+  },
+  {
+   "fetch_from": "account_head.account_currency",
+   "fieldname": "account_currency",
+   "fieldtype": "Link",
+   "label": "Account Currency",
+   "options": "Currency",
+   "read_only": 1
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2021-06-14 01:43:50.750455",
+ "modified": "2021-08-05 20:04:36.618240",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Purchase Taxes and Charges",

--- a/erpnext/accounts/doctype/sales_taxes_and_charges/sales_taxes_and_charges.json
+++ b/erpnext/accounts/doctype/sales_taxes_and_charges/sales_taxes_and_charges.json
@@ -19,7 +19,7 @@
   "section_break_8",
   "rate",
   "section_break_9",
-  "currency",
+  "account_currency",
   "tax_amount",
   "total",
   "tax_amount_after_discount_amount",
@@ -187,14 +187,6 @@
    "fieldtype": "Column Break"
   },
   {
-   "fetch_from": "account_head.account_currency",
-   "fieldname": "currency",
-   "fieldtype": "Link",
-   "label": "Account Currency",
-   "options": "Currency",
-   "read_only": 1
-  },
-  {
    "default": "0",
    "depends_on": "eval:['Sales Taxes and Charges Template', 'Payment Entry'].includes(parent.doctype)",
    "description": "If checked, the tax amount will be considered as already included in the Paid Amount in Payment Entry",
@@ -210,13 +202,21 @@
    "label": "Dont Recompute tax",
    "print_hide": 1,
    "read_only": 1
+  },
+  {
+   "fetch_from": "account_head.account_currency",
+   "fieldname": "account_currency",
+   "fieldtype": "Link",
+   "label": "Account Currency",
+   "options": "Currency",
+   "read_only": 1
   }
  ],
  "idx": 1,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2021-07-27 12:40:59.051803",
+ "modified": "2021-08-05 20:04:01.726867",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Taxes and Charges",


### PR DESCRIPTION
Previously:
When creating a multi currency Sales or Purchase Invoice, as the table (Sales/Purchase) Taxes and Charges had a field name for Account Currency as currency the Amount and related fields used to pick the symbol of tables account currency and not the documents currency which was wrong as seen below:
![image](https://user-images.githubusercontent.com/33727827/128371163-398e24c8-765a-4166-abc5-6182d9c0498f.png)


Fix:
Changed the field name so that the Amount and related fields picks up documents currency.
![image](https://user-images.githubusercontent.com/33727827/128370655-8091e94f-26c5-46fa-bee8-4bbb4d4b58dc.png)
