### PR TITLE
fix(regional): add permissions for VAT Audit report

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -296,5 +296,5 @@ erpnext.patches.v13_0.update_subscription_status_in_memberships
 erpnext.patches.v13_0.update_amt_in_work_order_required_items
 erpnext.patches.v13_0.update_export_type_for_gst
 erpnext.patches.v13_0.update_tds_check_field #3
-erpnext.patches.v13_0.add_custom_field_for_south_africa
+erpnext.patches.v13_0.add_custom_field_for_south_africa #2
 erpnext.patches.v13_0.shopify_deprecation_warning

--- a/erpnext/patches/v13_0/add_custom_field_for_south_africa.py
+++ b/erpnext/patches/v13_0/add_custom_field_for_south_africa.py
@@ -3,7 +3,7 @@
 
 from __future__ import unicode_literals
 import frappe
-from erpnext.regional.south_africa.setup import make_custom_fields
+from erpnext.regional.south_africa.setup import make_custom_fields, add_permissions
 
 def execute():
 	company = frappe.get_all('Company', filters = {'country': 'South Africa'})
@@ -11,3 +11,4 @@ def execute():
 		return
 
 	make_custom_fields()
+	add_permissions()

--- a/erpnext/regional/report/vat_audit_report/vat_audit_report.json
+++ b/erpnext/regional/report/vat_audit_report/vat_audit_report.json
@@ -18,15 +18,5 @@
  "ref_doctype": "GL Entry",
  "report_name": "VAT Audit Report",
  "report_type": "Script Report",
- "roles": [
-  {
-   "role": "Accounts User"
-  },
-  {
-   "role": "Accounts Manager"
-  },
-  {
-   "role": "Auditor"
-  }
- ]
+ "roles": []
 }

--- a/erpnext/regional/report/vat_audit_report/vat_audit_report.py
+++ b/erpnext/regional/report/vat_audit_report/vat_audit_report.py
@@ -189,6 +189,8 @@ class VATAuditReport(object):
 						row["posting_date"] = formatdate(inv_data.get("posting_date"), "dd-mm-yyyy")
 						row["voucher_type"] = doctype
 						row["voucher_no"] = inv
+						row["party_type"] = "Customer" if doctype == "Sales Invoice" else "Supplier" 
+						row["party"] = inv_data.get("party")
 						row["remarks"] = inv_data.get("remarks")
 						row["gross_amount"]= item_details[0].get("gross_amount")
 						row["tax_amount"]= item_details[0].get("tax_amount")
@@ -227,6 +229,20 @@ class VATAuditReport(object):
 				"width": 150
 			},
 			{
+				"fieldname": "party_type",
+				"label": "Party Type",
+				"fieldtype": "Data",
+				"width": 140,
+				"hidden": 1
+			},
+			{
+				"fieldname": "party",
+				"label": "Party",
+				"fieldtype": "Dynamic Link",
+				"options": "party_type",
+				"width": 150
+			},
+			{
 				"fieldname": "remarks",
 				"label": "Details",
 				"fieldtype": "Data",
@@ -236,18 +252,18 @@ class VATAuditReport(object):
 				"fieldname": "net_amount",
 				"label": "Net Amount",
 				"fieldtype": "Currency",
-				"width": 150
+				"width": 130
 			},
 			{
 				"fieldname": "tax_amount",
 				"label": "Tax Amount",
 				"fieldtype": "Currency",
-				"width": 150
+				"width": 130
 			},
 			{
 				"fieldname": "gross_amount",
 				"label": "Gross Amount",
 				"fieldtype": "Currency",
-				"width": 150
+				"width": 130
 			},
 		]

--- a/erpnext/regional/south_africa/setup.py
+++ b/erpnext/regional/south_africa/setup.py
@@ -3,11 +3,12 @@
 
 from __future__ import unicode_literals
 
-# import frappe, os, json
+import frappe
 from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 from frappe.permissions import add_permission, update_permission_property
 
 def setup(company=None, patch=True):
+	make_custom_fields()
 	add_permissions()
 
 def make_custom_fields(update=True):
@@ -27,10 +28,23 @@ def make_custom_fields(update=True):
 	create_custom_fields(custom_fields, update=update)
 
 def add_permissions():
-	"""Add Permissions for South Africa VAT Settings and South Africa VAT Account"""
+	"""Add Permissions for South Africa VAT Settings and South Africa VAT Account
+		and VAT Audit Report"""
 	for doctype in ('South Africa VAT Settings', 'South Africa VAT Account'):
 		add_permission(doctype, 'All', 0)
 		for role in ('Accounts Manager', 'Accounts User', 'System Manager'):
 			add_permission(doctype, role, 0)
 			update_permission_property(doctype, role, 0, 'write', 1)
 			update_permission_property(doctype, role, 0, 'create', 1)
+	
+
+	# if not frappe.db.get_value('Custom Role', dict(report="VAT Audit Report")):
+	# 	frappe.get_doc(dict(
+	# 		doctype='Custom Role',
+	# 		report="VAT Audit Report",
+	# 		roles= [
+	# 			dict(role='Accounts User'),
+	# 			dict(role='Accounts Manager'),
+	# 			dict(role='Auditor')
+	# 		]
+	# 	)).insert()

--- a/erpnext/regional/south_africa/setup.py
+++ b/erpnext/regional/south_africa/setup.py
@@ -38,13 +38,13 @@ def add_permissions():
 			update_permission_property(doctype, role, 0, 'create', 1)
 	
 
-	# if not frappe.db.get_value('Custom Role', dict(report="VAT Audit Report")):
-	# 	frappe.get_doc(dict(
-	# 		doctype='Custom Role',
-	# 		report="VAT Audit Report",
-	# 		roles= [
-	# 			dict(role='Accounts User'),
-	# 			dict(role='Accounts Manager'),
-	# 			dict(role='Auditor')
-	# 		]
-	# 	)).insert()
+	if not frappe.db.get_value('Custom Role', dict(report="VAT Audit Report")):
+		frappe.get_doc(dict(
+			doctype='Custom Role',
+			report="VAT Audit Report",
+			roles= [
+				dict(role='Accounts User'),
+				dict(role='Accounts Manager'),
+				dict(role='Auditor')
+			]
+		)).insert()


### PR DESCRIPTION
Reference: https://github.com/frappe/erpnext/pull/26480

- Added permissions for specific roles in setup.py itself  (South Africa)
- Added party column in the VAT Audit Report