### PR TITLE
fix: incoming rate for credit note

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -946,7 +946,6 @@ class SalesInvoice(SellingController):
 						gl_entries.append(self.get_gl_dict(gle, item=item))
 
 					self.set_asset_status(asset)
-
 				else:
 					# Do not book income for transfer within same company
 					if not self.is_internal_transfer():

--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -397,17 +397,24 @@ def get_rate_for_return(voucher_type, voucher_no, item_code, return_against=None
 		return_against = frappe.get_cached_value(voucher_type, voucher_no, "return_against")
 
 	if not return_against and voucher_type == 'Sales Invoice' and sle:
-		return get_incoming_rate({
-			"item_code": sle.item_code,
-			"warehouse": sle.warehouse,
-			"posting_date": sle.get('posting_date'),
-			"posting_time": sle.get('posting_time'),
-			"qty": sle.actual_qty,
-			"serial_no": sle.get('serial_no'),
-			"company": sle.company,
-			"voucher_type": sle.voucher_type,
-			"voucher_no": sle.voucher_no
-		}, raise_error_if_no_rate=False)
+		incoming_rate = 0.0
+		if voucher_detail_no:
+			incoming_rate = frappe.get_cached_value('Sales Invoice Item', voucher_detail_no, 'incoming_rate')
+
+		if not incoming_rate:
+			incoming_rate = get_incoming_rate({
+				"item_code": sle.item_code,
+				"warehouse": sle.warehouse,
+				"posting_date": sle.get('posting_date'),
+				"posting_time": sle.get('posting_time'),
+				"qty": sle.actual_qty,
+				"serial_no": sle.get('serial_no'),
+				"company": sle.company,
+				"voucher_type": sle.voucher_type,
+				"voucher_no": sle.voucher_no
+			}, raise_error_if_no_rate=False)
+
+		return incoming_rate
 
 	return_against_item_field = get_return_against_item_fields(voucher_type)
 

--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -315,18 +315,22 @@ class SellingController(StockController):
 				# Get incoming rate based on original item cost based on valuation method
 				qty = flt(d.get('stock_qty') or d.get('actual_qty'))
 
-				d.incoming_rate = get_incoming_rate({
-					"item_code": d.item_code,
-					"warehouse": d.warehouse,
-					"posting_date": self.get('posting_date') or self.get('transaction_date'),
-					"posting_time": self.get('posting_time') or nowtime(),
-					"qty": qty if cint(self.get("is_return")) else (-1 * qty),
-					"serial_no": d.get('serial_no'),
-					"company": self.company,
-					"voucher_type": self.doctype,
-					"voucher_no": self.name,
-					"allow_zero_valuation": d.get("allow_zero_valuation")
-				}, raise_error_if_no_rate=False)
+				if self.get('is_return'):
+					d.incoming_rate = d.base_net_rate
+
+				if not d.get('incoming_rate') or not self.get('is_return'):
+					d.incoming_rate = get_incoming_rate({
+						"item_code": d.item_code,
+						"warehouse": d.warehouse,
+						"posting_date": self.get('posting_date') or self.get('transaction_date'),
+						"posting_time": self.get('posting_time') or nowtime(),
+						"qty": qty if cint(self.get("is_return")) else (-1 * qty),
+						"serial_no": d.get('serial_no'),
+						"company": self.company,
+						"voucher_type": self.doctype,
+						"voucher_no": self.name,
+						"allow_zero_valuation": d.get("allow_zero_valuation")
+					}, raise_error_if_no_rate=False)
 
 				# For internal transfers use incoming rate as the valuation rate
 				if self.is_internal_transfer():


### PR DESCRIPTION
Set incoming rate for credit not based on the rate defined in the sales invoice by the user and not based on the previous transactions

**Issue**

1. Created purchase receipt with incoming rate as 100
2. Created Standalone credit note with rate as 1800 but system has set incoming rate as 100 (see below image)

<img width="1321" alt="Screenshot 2021-08-09 at 11 06 59 AM" src="https://user-images.githubusercontent.com/8780500/128670183-d83c4835-0b77-426e-970c-af312de3d48e.png">


**After Fix**

<img width="1290" alt="Screenshot 2021-08-09 at 12 09 37 PM" src="https://user-images.githubusercontent.com/8780500/128670206-05681cbd-65d5-4352-a65d-3b7f328f571b.png">
