### PR TITLE
perf(cache): fix active SLA doctype caching

### DIFF
--- a/erpnext/support/doctype/service_level_agreement/service_level_agreement.py
+++ b/erpnext/support/doctype/service_level_agreement/service_level_agreement.py
@@ -281,15 +281,18 @@ def get_repeated(values):
 
 
 def get_documents_with_active_service_level_agreement():
-	if not frappe.cache().hget("service_level_agreement", "active"):
-		set_documents_with_active_service_level_agreement()
+	sla_doctypes = frappe.cache().hget("service_level_agreement", "active")
 
-	return frappe.cache().hget("service_level_agreement", "active")
+	if sla_doctypes is None:
+		return set_documents_with_active_service_level_agreement()
+
+	return sla_doctypes
 
 
 def set_documents_with_active_service_level_agreement():
 	active = [sla.document_type for sla in frappe.get_all("Service Level Agreement", fields=["document_type"])]
 	frappe.cache().hset("service_level_agreement", "active", active)
+	return active
 
 
 def apply(doc, method=None):


### PR DESCRIPTION
![Screenshot 2021-08-09 at 11 30 36 AM](https://user-images.githubusercontent.com/9079960/128691687-027136d2-ca52-40f9-8dc9-41608c97b9e7.png)


If no SLA is configured then this query runs on EVERY `validate` call.

Root cause: if no active SLA doctypes exist then `not []` evaluates to `True` and causes query to run again.
