### PR TITLE
fix(e-invoicing): cannot cancel invoice if IRN cancelled on portal (#26638)

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -686,3 +686,4 @@ erpnext.patches.v12_0.purchase_receipt_status
 erpnext.patches.v12_0.add_company_link_to_einvoice_settings
 erpnext.patches.v12_0.add_document_type_field_for_italy_einvoicing
 erpnext.patches.v12_0.create_taxable_value_field_in_purchase_invoice
+erpnext.patches.v12_0.show_einvoice_irn_cancelled_field

--- a/erpnext/patches/v12_0/show_einvoice_irn_cancelled_field.py
+++ b/erpnext/patches/v12_0/show_einvoice_irn_cancelled_field.py
@@ -1,0 +1,12 @@
+from __future__ import unicode_literals
+import frappe
+
+def execute():
+	company = frappe.get_all('Company', filters = {'country': 'India'})
+	if not company:
+		return
+
+	irn_cancelled_field = frappe.db.exists('Custom Field', {'dt': 'Sales Invoice', 'fieldname': 'irn_cancelled'})
+	if irn_cancelled_field:
+		frappe.db.set_value('Custom Field', irn_cancelled_field, 'depends_on', 'eval: doc.irn')
+		frappe.db.set_value('Custom Field', irn_cancelled_field, 'read_only', 0)

--- a/erpnext/regional/india/setup.py
+++ b/erpnext/regional/india/setup.py
@@ -414,7 +414,7 @@ def make_custom_fields(update=True):
 		dict(fieldname='ack_date', label='Ack. Date', fieldtype='Data', read_only=1, hidden=1, insert_after='ack_no', no_copy=1, print_hide=1),
 
 		dict(fieldname='irn_cancelled', label='IRN Cancelled', fieldtype='Check', no_copy=1, print_hide=1,
-			depends_on='eval:(doc.irn_cancelled === 1)', read_only=1, allow_on_submit=1, insert_after='customer'),
+			depends_on='eval: doc.irn', allow_on_submit=1, insert_after='customer'),
 
 		dict(fieldname='eway_bill_cancelled', label='E-Way Bill Cancelled', fieldtype='Check', no_copy=1, print_hide=1,
 			depends_on='eval:(doc.eway_bill_cancelled === 1)', read_only=1, allow_on_submit=1, insert_after='customer'),


### PR DESCRIPTION
Backports the following commits to version-12-hotfix:
 - fix(e-invoicing): cannot cancel invoice if IRN cancelled on portal (#26638)