### PR TITLE
fix: unsetting of payment if no pos profile found

### DIFF
--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -679,17 +679,13 @@ class calculate_taxes_and_totals(object):
 		default_mode_of_payment = frappe.db.get_value('POS Payment Method',
 			{'parent': self.doc.pos_profile, 'default': 1}, ['mode_of_payment'], as_dict=1)
 
-		self.doc.payments = []
-
 		if default_mode_of_payment:
+			self.doc.payments = []
 			self.doc.append('payments', {
 				'mode_of_payment': default_mode_of_payment.mode_of_payment,
 				'amount': total_amount_to_pay,
 				'default': 1
 			})
-		else:
-			self.doc.is_pos = 0
-			self.doc.pos_profile = ''
 
 		self.calculate_paid_amount()
 


### PR DESCRIPTION
In https://github.com/frappe/erpnext/pull/26853 we removed the need for having a POS Profile for POS Sales Invoice. 

This PR fix the problem where in Sales Invoice if `is_pos` is checked and `is_return` is checked this piece of code re-sets payments table to empty if `POS Profile` is not mentioned or `Default Mode of Payment` of that POS Profile doesn't exist.
