### PR TITLE
fix: Nest `.level` class style under `.hierarchy` class

### DIFF
--- a/erpnext/public/scss/hierarchy_chart.scss
+++ b/erpnext/public/scss/hierarchy_chart.scss
@@ -206,10 +206,12 @@
 	margin: 0px 0px 16px 0px;
 }
 
-.level {
-	margin-right: 8px;
-	align-items: flex-start;
-	flex-direction: column;
+.hierarchy, .hierarchy-mobile {
+	.level {
+		margin-right: 8px;
+		align-items: flex-start;
+		flex-direction: column;
+	}
 }
 
 #arrows {


### PR DESCRIPTION
Changes in [this PR](https://github.com/frappe/erpnext/pull/26261) were breaking all list views since it was overriding `.level` class that is used in list rows.

**Solution:**

Nest `.level` class inside `.hierarchy & .hierarchy-mobile`

---

**Before:**
![Screenshot 2021-08-11 at 2 39 24 PM](https://user-images.githubusercontent.com/13928957/129002387-8de1e080-f732-4ae2-9693-0d3380314345.png)


**After:**
![Screenshot 2021-08-11 at 2 41 10 PM](https://user-images.githubusercontent.com/13928957/129003188-c068357a-79b1-4ed3-9f16-cccc3660d69b.png)

