### PR TITLE
fix: unable to create asset depreciation entry when cost_center is mandatory

### DIFF
--- a/erpnext/assets/doctype/asset/depreciation.py
+++ b/erpnext/assets/doctype/asset/depreciation.py
@@ -59,7 +59,7 @@ def make_depreciation_entry(asset_name, date=None):
 				"credit_in_account_currency": d.depreciation_amount,
 				"reference_type": "Asset",
 				"reference_name": asset.name,
-				"cost_center": ""
+				"cost_center": depreciation_cost_center
 			}
 
 			debit_entry = {


### PR DESCRIPTION
Summary : unable to create manual / auto asset depreciation entry when cost_center is mandatory

Reason: Though we are calculating value for depreciation_cost_center, it is not passed in credit_entry(it is passed in debit_entry) and this prevents creation of manual / auto asset depreciation entry when cost_center is mandatory

Solution : pass already calculated depreciation_cost_center value in credit_entry (in line with, already done as in debit_entry)

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
