### PR TITLE
fix: from_warehouse getting set to None

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -1185,7 +1185,7 @@ class StockEntry(StockController):
 		wo = frappe.get_doc("Work Order", self.work_order)
 		wo_items = frappe.get_all('Work Order Item',
 			filters={'parent': self.work_order},
-			fields=["item_code", "required_qty", "consumed_qty", "transferred_qty"]
+			fields=["item_code", "source_warehouse", "required_qty", "consumed_qty", "transferred_qty"]
 			)
 
 		work_order_qty = wo.material_transferred_for_manufacturing or wo.qty
@@ -1205,7 +1205,7 @@ class StockEntry(StockController):
 			if qty > 0:
 				self.add_to_stock_entry_detail({
 					item.item_code: {
-						"from_warehouse": wo.wip_warehouse,
+						"from_warehouse": wo.wip_warehouse or item.source_warehouse,
 						"to_warehouse": "",
 						"qty": qty,
 						"item_name": item.item_name,


### PR DESCRIPTION
## Issue

### Manufacturing Settings
![image](https://user-images.githubusercontent.com/43572428/129185548-3c02ab4e-bec0-459f-94aa-0e75c4d6f24c.png)
- **"Allow Multiple Material Consumption"** is enabled.

### Work Order Settings
![image](https://user-images.githubusercontent.com/43572428/129185016-3760af4f-674e-47d5-85dc-4891ff6822a1.png)
- **"Skip Material Transfer to WIP Warehouse"** is enabled while creating the work order.
- When this setting is enabled, the WIP Warehouse field is not mandatory and can be left empty.
- When the WIP is empty, while clicking on **"Finish"** to create the stock entry, the source warehouses would get set to None since it wasn't handled.

![image](https://user-images.githubusercontent.com/43572428/129186144-366ae792-6b05-45fd-8285-f401e197ddf9.png)

## Fix

- If WIP Warehouse is empty, it would set the item's set source warehouse in the stock entry detail.

![image](https://user-images.githubusercontent.com/43572428/129186548-7afa8751-bb9d-497a-8be0-bec74f0ebb3f.png)



