### PR TITLE
fix: Deferred Revenue Section should be collapsible only if its not enabled

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
+++ b/erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
@@ -501,6 +501,7 @@
   },
   {
    "collapsible": 1,
+   "collapsible_depends_on": "enable_deferred_expense",
    "fieldname": "deferred_expense_section",
    "fieldtype": "Section Break",
    "label": "Deferred Expense"
@@ -854,7 +855,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2021-06-16 19:43:51.099386",
+ "modified": "2021-08-12 20:14:45.506639",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Purchase Invoice Item",

--- a/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
+++ b/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
@@ -473,6 +473,7 @@
   },
   {
    "collapsible": 1,
+   "collapsible_depends_on": "enable_deferred_revenue",
    "fieldname": "deferred_revenue",
    "fieldtype": "Section Break",
    "label": "Deferred Revenue"
@@ -825,7 +826,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2021-06-21 23:03:11.599901",
+ "modified": "2021-08-12 20:15:42.668399",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice Item",


### PR DESCRIPTION
In Purchase Invoice and Sales Invoice. For the Items table, the Deferred Revenue Section should not be in collapsible state if Enable Deferred Revenue is checked.

This change aims to improved that UX.