### PR TITLE
ci: ignore js files in unittests

### DIFF
--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -1,6 +1,11 @@
 name: Patch
 
-on: [pull_request, workflow_dispatch]
+on:
+  pull_request:
+    paths-ignore:
+      - '**.js'
+  workflow_dispatch:
+
 
 jobs:
   test:

--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths-ignore:
       - '**.js'
+      - '**.md'
   workflow_dispatch:
 
 

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -4,11 +4,13 @@ on:
   pull_request:
     paths-ignore:
       - '**.js'
+      - '**.md'
   workflow_dispatch:
   push:
     branches: [ develop ]
     paths-ignore:
       - '**.js'
+      - '**.md'
 
 jobs:
   test:

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -2,9 +2,13 @@ name: Server
 
 on:
   pull_request:
+    paths-ignore:
+      - '**.js'
   workflow_dispatch:
   push:
     branches: [ develop ]
+    paths-ignore:
+      - '**.js'
 
 jobs:
   test:

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -2,6 +2,8 @@ name: UI
 
 on:
   pull_request:
+    paths-ignore:
+      - '**.md'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
- Avoid running python unittests on PRs that ONLY change JS files.
- Saves resources and reduces concurrent builds. 