### PR TITLE
fix: unknown attribute "string_types"

### DIFF
--- a/erpnext/hr/doctype/attendance/attendance.py
+++ b/erpnext/hr/doctype/attendance/attendance.py
@@ -135,7 +135,7 @@ def mark_attendance(employee, attendance_date, status, shift=None, leave_type=No
 def mark_bulk_attendance(data):
 	import json
 	from pprint import pprint
-	if isinstance(data, frappe.string_types):
+	if isinstance(data, str):
 		data = json.loads(data)
 	data = frappe._dict(data)
 	company = frappe.get_value('Employee', data.employee, 'company')


### PR DESCRIPTION
`frappe/__init__.py` imports string_types from `six`. Removed this transitive dependency.

Also checked, we don't use `frappe.string_types` anywhere else. 

closes https://github.com/frappe/erpnext/issues/26911 