### PR TITLE
fix: item name is missing into job card

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.json
+++ b/erpnext/manufacturing/doctype/job_card/job_card.json
@@ -275,7 +275,7 @@
    "read_only": 1
   },
   {
-   "fetch_from": "work_order.production_item.item_name",
+   "fetch_from": "work_order.item_name",
    "fieldname": "item_name",
    "fieldtype": "Read Only",
    "label": "Item Name"
@@ -296,7 +296,7 @@
   }
  ],
  "is_submittable": 1,
- "modified": "2021-08-16 15:21:21.398267",
+ "modified": "2020-08-24 15:21:21.398267",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Job Card",

--- a/erpnext/manufacturing/doctype/job_card/job_card.json
+++ b/erpnext/manufacturing/doctype/job_card/job_card.json
@@ -270,7 +270,7 @@
   },
   {
    "fieldname": "barcode",
-   "fieldtype": "Barcode",
+   "fieldtype": "Barcode", 
    "label": "Barcode",
    "read_only": 1
   },

--- a/erpnext/manufacturing/doctype/job_card/job_card.json
+++ b/erpnext/manufacturing/doctype/job_card/job_card.json
@@ -275,7 +275,7 @@
    "read_only": 1
   },
   {
-   "fetch_from": "work_order.item_name",
+   "fetch_from": "work_order.production_item.item_name",
    "fieldname": "item_name",
    "fieldtype": "Read Only",
    "label": "Item Name"

--- a/erpnext/manufacturing/doctype/job_card/job_card.json
+++ b/erpnext/manufacturing/doctype/job_card/job_card.json
@@ -275,7 +275,7 @@
    "read_only": 1
   },
   {
-   "fetch_from": "work_order.item_name",
+   "fetch_from": "work_order.production_item.item_name",
    "fieldname": "item_name",
    "fieldtype": "Read Only",
    "label": "Item Name"
@@ -296,7 +296,7 @@
   }
  ],
  "is_submittable": 1,
- "modified": "2020-08-24 15:21:21.398267",
+ "modified": "2021-08-16 15:21:21.398267",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Job Card",

--- a/erpnext/manufacturing/doctype/job_card/job_card.json
+++ b/erpnext/manufacturing/doctype/job_card/job_card.json
@@ -270,7 +270,7 @@
   },
   {
    "fieldname": "barcode",
-   "fieldtype": "Barcode", 
+   "fieldtype": "Barcode",
    "label": "Barcode",
    "read_only": 1
   },

--- a/erpnext/manufacturing/doctype/job_card/job_card.json
+++ b/erpnext/manufacturing/doctype/job_card/job_card.json
@@ -275,7 +275,7 @@
    "read_only": 1
   },
   {
-   "fetch_from": "work_order.production_item.item_name",
+   "fetch_from": "work_order.item_name",
    "fieldname": "item_name",
    "fieldtype": "Read Only",
    "label": "Item Name"

--- a/erpnext/manufacturing/doctype/work_order/work_order.json
+++ b/erpnext/manufacturing/doctype/work_order/work_order.json
@@ -472,7 +472,7 @@
  "image_field": "image",
  "is_submittable": 1,
  "links": [],
- "modified": "2019-12-04 11:20:04.695123",
+ "modified": "2021-08-16 11:20:04.695123",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Work Order",

--- a/erpnext/manufacturing/doctype/work_order/work_order.json
+++ b/erpnext/manufacturing/doctype/work_order/work_order.json
@@ -107,6 +107,8 @@
   },
   {
    "depends_on": "eval:doc.production_item",
+   "fetch_from": "production_item.item_name",
+   "fetch_if_empty": 1,
    "fieldname": "item_name",
    "fieldtype": "Data",
    "label": "Item Name",


### PR DESCRIPTION
fix #26954


This fix must not be merge into upper version because in version-13 and develop the field production_item is a typefield link and readonly:1


Could be related to #26386