### PR TITLE
fix: Incorrect `modified` time in documents that inherit from `StatusUpdater`

### DIFF
--- a/erpnext/controllers/status_updater.py
+++ b/erpnext/controllers/status_updater.py
@@ -3,7 +3,7 @@
 
 from __future__ import unicode_literals
 import frappe
-from frappe.utils import flt, comma_or, nowdate, getdate
+from frappe.utils import flt, comma_or, nowdate, getdate, now
 from frappe import _
 from frappe.model.document import Document
 
@@ -336,10 +336,14 @@ class StatusUpdater(Document):
 				target.notify_update()
 
 	def _update_modified(self, args, update_modified):
-		args['update_modified'] = ''
-		if update_modified:
-			args['update_modified'] = ', modified = now(), modified_by = {0}'\
-				.format(frappe.db.escape(frappe.session.user))
+		if not update_modified:
+			args['update_modified'] = ''
+			return
+
+		args['update_modified'] = ', modified = {0}, modified_by = {1}'.format(
+			frappe.db.escape(now()),
+			frappe.db.escape(frappe.session.user)
+		)
 
 	def update_billing_status_for_zero_amount_refdoc(self, ref_dt):
 		ref_fieldname = frappe.scrub(ref_dt)


### PR DESCRIPTION
## Issue

Previously, the `modified` column was being set to the value of the `now()` MariaDB function. This results in the server time being set. The server time may be different from the timezone defined in the Frappe site. For example, if the server is used in Tanzania (GMT + 3), but hosted in Germany (GMT + 2)

## Change Made
Set `modified` to the return value of `frappe.utils.now()` which returns the correct time based on the timezone specified in the Frappe site.

**Special Thanks to @aakvatech** 