### PR TITLE
chore: added missing field-name

### DIFF
--- a/erpnext/support/doctype/service_level_agreement/service_level_agreement.json
+++ b/erpnext/support/doctype/service_level_agreement/service_level_agreement.json
@@ -183,6 +183,7 @@
   },
   {
    "label": "Pause SLA On",
+   "fieldname": "pause_sla_on",
    "options": "Pause SLA On Status"
   },
   {


### PR DESCRIPTION
**Issue**

While migrating bench getting below error

```
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/env/lib/python3.7/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 26, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/frappe/frappe/commands/site.py", line 309, in migrate
    skip_search_index=skip_search_index
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/frappe/frappe/migrate.py", line 68, in migrate
    frappe.model.sync.sync_all(verbose=verbose)
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/frappe/frappe/model/sync.py", line 17, in sync_all
    sync_for(app, force, verbose=verbose, reset_permissions=reset_permissions)
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/frappe/frappe/model/sync.py", line 68, in sync_for
    reset_permissions=reset_permissions, for_sync=True)
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/frappe/frappe/modules/import_file.py", line 67, in import_file_by_path
    ignore_version=ignore_version, reset_permissions=reset_permissions)
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/frappe/frappe/modules/import_file.py", line 103, in import_doc
    controller.prepare_for_import(docdict)
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/frappe/frappe/core/doctype/doctype/doctype.py", line 531, in prepare_for_import
    remaining_field_names = [f['fieldname'] for f in docdict.get('fields', [])]
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/frappe/frappe/core/doctype/doctype/doctype.py", line 531, in <listcomp>
    remaining_field_names = [f['fieldname'] for f in docdict.get('fields', [])]
KeyError: 'fieldname'
```