### PR TITLE
fix: set account for change amount even if pos profile not found

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -478,6 +478,9 @@ class SalesInvoice(SellingController):
 		if cint(self.is_pos) != 1:
 			return
 
+		if not self.account_for_change_amount:
+			self.account_for_change_amount = frappe.get_cached_value('Company',  self.company,  'default_cash_account')
+
 		from erpnext.stock.get_item_details import get_pos_profile_item_details, get_pos_profile
 		if not self.pos_profile:
 			pos_profile = get_pos_profile(self.company) or {}
@@ -491,9 +494,6 @@ class SalesInvoice(SellingController):
 
 		if not self.get('payments') and not for_validate:
 			update_multi_mode_option(self, pos)
-
-		if not self.account_for_change_amount:
-			self.account_for_change_amount = frappe.get_cached_value('Company',  self.company,  'default_cash_account')
 
 		if pos:
 			if not for_validate:


### PR DESCRIPTION
Introduced in https://github.com/frappe/erpnext/pull/26853 
If `POS Profile` was not found we weren't executing the code where `account_for_change_amount` was being set.
Moved it above so this gets executed and `account_for_change_amount` gets set.