### PR TITLE
fix(deps): pin plaid-python to 7.2.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 braintree==3.57.1
-frappe
+# frappe   # https://github.com/frappe/frappe is installed during bench-init
 gocardless-pro==1.11.0
 googlemaps==3.1.1
 pandas==0.24.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ frappe
 gocardless-pro==1.11.0
 googlemaps==3.1.1
 pandas==0.24.2
-plaid-python>=7.0.0
+plaid-python~=7.2.1
 PyGithub==1.44.1
 python-stdnum==1.12
 Unidecode==1.1.1


### PR DESCRIPTION
Old requirement.txt was allowing next major version which has breaking
changes and causes failure in installation.

closes https://github.com/frappe/erpnext/issues/26991