### PR TITLE
fix: Return Qty in PR/DN for legacy data

### DIFF
--- a/erpnext/patches/v13_0/update_returned_qty_in_pr_dn.py
+++ b/erpnext/patches/v13_0/update_returned_qty_in_pr_dn.py
@@ -1,8 +1,7 @@
-# Copyright (c) 2019, Frappe and Contributors
+# Copyright (c) 2021, Frappe and Contributors
 # License: GNU General Public License v3. See license.txt
-
-from __future__ import unicode_literals
 import frappe
+from erpnext.controllers.status_updater import OverAllowanceError
 
 def execute():
 	frappe.reload_doc('stock', 'doctype', 'purchase_receipt')
@@ -14,9 +13,15 @@ def execute():
 		for return_doc in frappe.get_all(doctype, filters={'is_return' : 1, 'docstatus' : 1}):
 			# Update original receipt/delivery document from return
 			return_doc = frappe.get_cached_doc(doctype, return_doc.name)
-			return_doc.update_prevdoc_status()
+			try:
+				return_doc.update_prevdoc_status()
+			except OverAllowanceError:
+				frappe.db.rollback()
+				continue
+
 			return_against = frappe.get_doc(doctype, return_doc.return_against)
 			return_against.update_billing_status()
+			frappe.db.commit()
 
 	# Set received qty in stock uom in PR, as returned qty is checked against it
 	frappe.db.sql(""" update `tabPurchase Receipt Item`


### PR DESCRIPTION
**Case:**

**Legacy** PR with the following items:
Item: A  | Qty: 100  | **Row Name: abcde123**
Item: A  | Qty: 400 |  **Row Name: fghij567**

**Legacy** PR Return with the following items:
Item: A  | Qty: 300  | **Against PR Item Row Name: abcde123** [Over return against first row]

In version 12, since there was no back updation from Returned PR to its original PR, and no linking between the child rows, over return **against a row** was not an issue
 
Since version 13 we check returned qty against each row. So when this patch runs to back update the returned qty, for some legacy documents, it will break throwing `OverAllowanceError`

**Fix:**
- Ignore such legacy documents, they will not have `Returned %` updated that's it, since they are not compliant with the current row to row mapping.
- Commit after each doc finishes its back updation, and rollback in case of `OverAllowanceError`