### PR TITLE
fix: discard empty rows from update items

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1841,6 +1841,11 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 
 	for d in data:
 		new_child_flag = False
+
+		if not d.get("item_code"):
+			# ignore empty rows
+			continue
+
 		if not d.get("docname"):
 			new_child_flag = True
 			check_doc_permissions(parent, 'create')

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -563,7 +563,7 @@ erpnext.utils.update_child_items = function(opts) {
 			},
 		],
 		primary_action: function() {
-			const trans_items = this.get_values()["trans_items"];
+			const trans_items = this.get_values()["trans_items"].filter((item) => !!item.item_code);
 			frappe.call({
 				method: 'erpnext.controllers.accounts_controller.update_child_qty_rate',
 				freeze: true,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9079960/130024057-08054589-fe28-4d01-9428-3a6057966a39.png)


If you leave empty rows while using "Update items", you'll see a weird error like "Item None not found" or


![image](https://user-images.githubusercontent.com/9079960/130024077-91a0c864-1bf9-4593-8438-d687020b9e3d.png)


Solution: discard rows that don't have item code. 