### PR TITLE
fix: set production plan to completed even on over production

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -297,7 +297,7 @@ class ProductionPlan(Document):
 
 		if self.total_produced_qty > 0:
 			self.status = "In Process"
-			if self.total_produced_qty == self.total_planned_qty:
+			if self.total_produced_qty >= self.total_planned_qty:
 				self.status = "Completed"
 
 		if self.status != 'Completed':


### PR DESCRIPTION
fix for issue [#26822](https://github.com/frappe/erpnext/issues/26822)

Fixes production plan showing incorrect status (on overproduction).