### PR TITLE
fix: incorrect mandatory error message for warehouse

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -317,9 +317,6 @@ class StockEntry(StockController):
 				d.s_warehouse = self.from_warehouse
 				d.t_warehouse = self.to_warehouse
 
-			if not (d.s_warehouse or d.t_warehouse):
-				frappe.throw(_("Atleast one warehouse is mandatory"))
-
 			if self.purpose in source_mandatory and not d.s_warehouse:
 				if self.from_warehouse:
 					d.s_warehouse = self.from_warehouse
@@ -331,6 +328,7 @@ class StockEntry(StockController):
 					d.t_warehouse = self.to_warehouse
 				else:
 					frappe.throw(_("Target warehouse is mandatory for row {0}").format(d.idx))
+
 
 			if self.purpose == "Manufacture":
 				if validate_for_manufacture:
@@ -345,6 +343,9 @@ class StockEntry(StockController):
 
 			if cstr(d.s_warehouse) == cstr(d.t_warehouse) and not self.purpose == "Material Transfer for Manufacture":
 				frappe.throw(_("Source and target warehouse cannot be same for row {0}").format(d.idx))
+
+			if not (d.s_warehouse or d.t_warehouse):
+				frappe.throw(_("Atleast one warehouse is mandatory"))
 
 	def validate_work_order(self):
 		if self.purpose in ("Manufacture", "Material Transfer for Manufacture", "Material Consumption for Manufacture"):


### PR DESCRIPTION
## Before 
### Material Issue
- Message should mention that "Source Warehouse" is mandatory.

<img width="1420" alt="Screenshot 2021-08-19 at 3 33 32 PM" src="https://user-images.githubusercontent.com/43572428/130050342-af26872a-7db5-49c1-a1b2-89f2422bfa65.png">


### Material Receipt
- Message should mention that "Target Warehouse" is mandatory.
<img width="1406" alt="Screenshot 2021-08-19 at 3 34 51 PM" src="https://user-images.githubusercontent.com/43572428/130050370-b0b08fed-4e9b-433b-b63b-30f019dc44cc.png">

- The validation was skipped since the validation of empty warehouse fields was checked first.

## Fix
- Moved the check for empty source and target warehouse fields after the mandatory checks.

![image](https://user-images.githubusercontent.com/43572428/130049543-bca922d4-6a69-4928-b571-79e7792ae48d.png)

