### PR TITLE
fix(ux): removed rate from grid view

### DIFF
--- a/erpnext/accounts/doctype/promotional_scheme_price_discount/promotional_scheme_price_discount.json
+++ b/erpnext/accounts/doctype/promotional_scheme_price_discount/promotional_scheme_price_discount.json
@@ -106,7 +106,6 @@
    "depends_on": "eval:doc.rate_or_discount==\"Rate\"",
    "fieldname": "rate",
    "fieldtype": "Currency",
-   "in_list_view": 1,
    "label": "Rate"
   },
   {
@@ -170,7 +169,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2021-03-07 11:56:23.424137",
+ "modified": "2021-08-19 15:49:29.598727",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Promotional Scheme Price Discount",


### PR DESCRIPTION
## Before

![image](https://user-images.githubusercontent.com/43572428/130053843-20a663a1-219f-4aed-a5ef-0adef17b8dd1.png)

## Changes

- Removed 'Rate' from the grid view.

![image](https://user-images.githubusercontent.com/43572428/130053177-dac177c3-c5c0-4952-a23d-3fd4e5ca3435.png)

- The Rate field is only applicable if the discount type was selected as 'Rate' else would be uneditable.

![rate](https://user-images.githubusercontent.com/43572428/130053571-9c9bb3ae-5fe3-4c27-aeb6-e28468b125c0.gif)
