### PR TITLE
fix: partial rename while replacing abbreviation

### DIFF
--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -419,11 +419,11 @@ def replace_abbr(company, old, new):
 			_rename_record(d)
 	try:
 		frappe.db.auto_commit_on_many_writes = 1
-		frappe.db.set_value("Company", company, "abbr", new)
 		for dt in ["Warehouse", "Account", "Cost Center", "Department",
 				"Sales Taxes and Charges Template", "Purchase Taxes and Charges Template"]:
 			_rename_records(dt)
 			frappe.db.commit()
+		frappe.db.set_value("Company", company, "abbr", new)
 
 	except Exception:
 		frappe.log_error(title=_('Abbreviation Rename Error'))


### PR DESCRIPTION
Problem:
- A user renames company abbreviation from ABC to XYZ
- The process starts in a background job and before renaming any warehouse or account and other records, the company's `abbr` is set as XYZ (new value)
- If the background process fails, the company's abbr is changed but cost-center/account/warehouse some of these records are not renamed completely
- If the user tries to rename the abbreviation again, the renaming process now starts assuming the old abbreviation as XYZ

Proposed Change:
- Set company doc's `abbr` to the new value only when all the records have been renamed.