### PR TITLE
Bug Related Setting Batch Number in Item Table

### DIFF
--- a/erpnext/selling/sales_common.js
+++ b/erpnext/selling/sales_common.js
@@ -388,7 +388,7 @@ erpnext.selling.SellingController = class SellingController extends erpnext.Tran
 	*/
 	set_batch_number(cdt, cdn) {
 		const doc = frappe.get_doc(cdt, cdn);
-		if (doc && doc.has_batch_no && doc.warehouse) {
+		if (doc && doc.has_batch_no && doc.warehouse && !doc.batch_no) {
 			this._set_batch_number(doc);
 		}
 	}


### PR DESCRIPTION
Bug While Scanning Batch number in **Scan Barcode Field**

Issue: When we scan batch numbers in the scan barcode field the item gets fetched and also the batch number, this fetched batch number is overwritten by the set_batch_number function.

Resolution:
Whenever we scan batch numbers in the scan barcode table, the set_batch_number should check whether the batch number is there or not, if not then only get the batch numbers via FIFO allocation.
