### PR TITLE
feat: allow draft pos invoices even if no stock available

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -127,7 +127,7 @@ class POSInvoice(SalesInvoice):
 						.format(item.idx, bold_delivered_serial_nos), title=_("Item Unavailable"))
 
 	def validate_stock_availablility(self):
-		if self.is_return:
+		if self.is_return or self.docstatus != 1:
 			return
 
 		allow_negative_stock = frappe.db.get_single_value('Stock Settings', 'allow_negative_stock')


### PR DESCRIPTION
In POS, users wish to add the items and create a Draft Sales Invoice, even if stocks are not there in the system

Let's say there is one item 'A' now, stocks in the system are zero but in the actual store, they have 100 quantities of the item. so now they want the system should create a SI in the draft and later they can add the stocks and submit POS invoices.

Currently, the system doesn't allow creating POS invoices for unavailable items.
Earlier, there was a bug and the system was allowing saving POS (in draft ) for unavailable quantities. Supposedly, users considered it as a feature.

`no-docs`