### PR TITLE
fix: Correct price list rate field value in return Sales Invoice

### DIFF
--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -329,7 +329,6 @@ def make_return_doc(doctype, source_name, target_doc=None):
 			target_doc.po_detail = source_doc.po_detail
 			target_doc.pr_detail = source_doc.pr_detail
 			target_doc.purchase_invoice_item = source_doc.name
-			target_doc.price_list_rate = 0
 
 		elif doctype == "Delivery Note":
 			returned_qty_map = get_returned_qty_map_for_row(source_doc.name, doctype)
@@ -360,7 +359,6 @@ def make_return_doc(doctype, source_name, target_doc=None):
 			else:
 				target_doc.pos_invoice_item = source_doc.name
 
-			target_doc.price_list_rate = 0
 			if default_warehouse_for_sales_return:
 				target_doc.warehouse = default_warehouse_for_sales_return
 


### PR DESCRIPTION
**Problem:**
Submit a sales invoice with a different price list. Create a return credit for this submitted invoice and on expanding the item row in the items table the **price list rate** field will display 0 instead of the actual price list rate.
<img src='https://user-images.githubusercontent.com/36098155/130580332-24def6d5-d8ad-4b3b-8723-28cdb31f4ebc.png' width='500'>

**Solution:**
the `update_item` method was setting the field to 0 in an earlier [PR](https://github.com/frappe/erpnext/commit/1f591ab02e40ab884899059ae95f7d86315da83b), removed that part.

**Steps:**
1. Create a new price list rate
2. Create an item price list rate under the new price list
3. Create a Sales Invoice with this price list applied and submit.
4. From the submitted invoice, create a return credit note and expand the item row and check the price list rate field.