### PR TITLE
fix: Use remove_all from file_manager

### DIFF
--- a/erpnext/regional/italy/utils.py
+++ b/erpnext/regional/italy/utils.py
@@ -6,7 +6,7 @@ import frappe
 from frappe.utils import flt, cstr
 from erpnext.controllers.taxes_and_totals import get_itemised_tax
 from frappe import _
-from frappe.core.doctype.file.file import remove_file
+from frappe.utils.file_manager import remove_file
 from six import string_types
 from frappe.desk.form.load import get_attachments
 from erpnext.regional.italy import state_codes


### PR DESCRIPTION
Use `remove_all` from `file_manager.py`

redundant `remove_all` was removed via https://github.com/frappe/frappe/pull/13996