### PR TITLE
fix: Updated timestamp for pos invoice json

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.json
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.json
@@ -1564,7 +1564,7 @@
  "icon": "fa fa-file-text",
  "is_submittable": 1,
  "links": [],
- "modified": "2021-08-18 16:13:52.080543",
+ "modified": "2021-08-24 18:19:20.728433",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Invoice",


### PR DESCRIPTION
Modifying the timestamp, it wasn't modified in old [PR](https://github.com/frappe/erpnext/pull/27004), while resolving merge conflicts.