### PR TITLE
fix: stock ledger report not working if include uom selected in filter

### DIFF
--- a/erpnext/stock/report/stock_ledger/stock_ledger.py
+++ b/erpnext/stock/report/stock_ledger/stock_ledger.py
@@ -23,6 +23,7 @@ def execute(filters=None):
 	conversion_factors = []
 	if opening_row:
 		data.append(opening_row)
+		conversion_factors.append(0)
 
 	actual_qty = stock_value = 0
 


### PR DESCRIPTION
If user has selected Include UOM in the stock ledger report which has Opening Row then system didn't load the report and throw the below error

```
Traceback (most recent call last):
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/frappe/frappe/app.py", line 66, in application
    response = frappe.api.handle()
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/frappe/frappe/api.py", line 54, in handle
    return frappe.handler.handle()
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/frappe/frappe/handler.py", line 31, in handle
    data = execute_cmd(cmd)
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/frappe/frappe/handler.py", line 67, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/frappe/frappe/__init__.py", line 1179, in call
    return fn(*args, **newargs)
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/frappe/frappe/__init__.py", line 616, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 233, in run
    result = generate_report_result(report, filters, user, custom_columns)
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 75, in generate_report_result
    res = report.execute_script_report(filters)
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/frappe/frappe/core/doctype/report/report.py", line 122, in execute_script_report
    res = self.execute_module(filters)
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/frappe/frappe/core/doctype/report/report.py", line 139, in execute_module
    return frappe.get_attr(method_name)(frappe._dict(filters))
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/erpnext/erpnext/stock/report/stock_ledger/stock_ledger.py", line 61, in execute
    update_included_uom_in_report(columns, data, include_uom, conversion_factors)
  File "/Users/rohitwaghchaure/Documents/frappe_develop/frappe-bench/apps/erpnext/erpnext/stock/utils.py", line 320, in update_included_uom_in_report
    if not conversion_factors[row_idx]:
IndexError: list index out of range
```