### PR TITLE
fix: Fee Validity fixes

### DIFF
--- a/erpnext/healthcare/doctype/fee_validity/fee_validity.json
+++ b/erpnext/healthcare/doctype/fee_validity/fee_validity.json
@@ -46,13 +46,13 @@
   {
    "fieldname": "visited",
    "fieldtype": "Int",
-   "label": "Visited yet",
+   "label": "Visits Completed",
    "read_only": 1
   },
   {
    "fieldname": "valid_till",
    "fieldtype": "Date",
-   "label": "Valid till",
+   "label": "Valid Till",
    "read_only": 1
   },
   {
@@ -106,7 +106,7 @@
  ],
  "in_create": 1,
  "links": [],
- "modified": "2020-03-17 20:25:06.487418",
+ "modified": "2021-08-26 10:51:05.609349",
  "modified_by": "Administrator",
  "module": "Healthcare",
  "name": "Fee Validity",

--- a/erpnext/healthcare/doctype/fee_validity/fee_validity.py
+++ b/erpnext/healthcare/doctype/fee_validity/fee_validity.py
@@ -11,20 +11,12 @@ import datetime
 class FeeValidity(Document):
 	def validate(self):
 		self.update_status()
-		self.set_start_date()
 
 	def update_status(self):
 		if self.visited >= self.max_visits:
 			self.status = 'Completed'
 		else:
 			self.status = 'Pending'
-
-	def set_start_date(self):
-		self.start_date = getdate()
-		for appointment in self.ref_appointments:
-			appointment_date = frappe.db.get_value('Patient Appointment', appointment.appointment, 'appointment_date')
-			if getdate(appointment_date) < self.start_date:
-				self.start_date = getdate(appointment_date)
 
 
 def create_fee_validity(appointment):
@@ -36,11 +28,9 @@ def create_fee_validity(appointment):
 	fee_validity.patient = appointment.patient
 	fee_validity.max_visits = frappe.db.get_single_value('Healthcare Settings', 'max_visits') or 1
 	valid_days = frappe.db.get_single_value('Healthcare Settings', 'valid_days') or 1
-	fee_validity.visited = 1
+	fee_validity.visited = 0
+	fee_validity.start_date = getdate(appointment.appointment_date)
 	fee_validity.valid_till = getdate(appointment.appointment_date) + datetime.timedelta(days=int(valid_days))
-	fee_validity.append('ref_appointments', {
-		'appointment': appointment.name
-	})
 	fee_validity.save(ignore_permissions=True)
 	return fee_validity
 

--- a/erpnext/healthcare/doctype/fee_validity/test_fee_validity.py
+++ b/erpnext/healthcare/doctype/fee_validity/test_fee_validity.py
@@ -22,14 +22,14 @@ class TestFeeValidity(unittest.TestCase):
 		item = create_healthcare_service_items()
 		healthcare_settings = frappe.get_single("Healthcare Settings")
 		healthcare_settings.enable_free_follow_ups = 1
-		healthcare_settings.max_visits = 2
+		healthcare_settings.max_visits = 1
 		healthcare_settings.valid_days = 7
 		healthcare_settings.automate_appointment_invoicing = 1
 		healthcare_settings.op_consulting_charge_item = item
 		healthcare_settings.save(ignore_permissions=True)
 		patient, medical_department, practitioner = create_healthcare_docs()
 
-		# For first appointment, invoice is generated
+		# For first appointment, invoice is generated. First appointment not considered in fee validity
 		appointment = create_appointment(patient, practitioner, nowdate())
 		invoiced = frappe.db.get_value("Patient Appointment", appointment.name, "invoiced")
 		self.assertEqual(invoiced, 1)

--- a/erpnext/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/erpnext/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -109,9 +109,13 @@ class PatientAppointment(Document):
 					frappe.db.set_value('Patient Appointment', self.name, 'notes', comments)
 
 	def update_fee_validity(self):
+		if not frappe.db.get_single_value('Healthcare Settings', 'enable_free_follow_ups'):
+			return
+
 		fee_validity = manage_fee_validity(self)
 		if fee_validity:
-			frappe.msgprint(_('{0} has fee validity till {1}').format(self.patient, fee_validity.valid_till))
+			frappe.msgprint(_('{0}: {1} has fee validity till {2}').format(self.patient,
+				frappe.bold(self.patient_name), fee_validity.valid_till))
 
 	@frappe.whitelist()
 	def get_therapy_types(self):

--- a/erpnext/healthcare/doctype/patient_appointment/test_patient_appointment.py
+++ b/erpnext/healthcare/doctype/patient_appointment/test_patient_appointment.py
@@ -107,14 +107,17 @@ class TestPatientAppointment(unittest.TestCase):
 		patient, medical_department, practitioner = create_healthcare_docs()
 		frappe.db.set_value('Healthcare Settings', None, 'enable_free_follow_ups', 1)
 		appointment = create_appointment(patient, practitioner, nowdate())
-		fee_validity = frappe.db.get_value('Fee Validity Reference', {'appointment': appointment.name}, 'parent')
+		fee_validity = frappe.db.get_value('Fee Validity', {'patient': patient, 'practitioner': practitioner})
 		# fee validity created
 		self.assertTrue(fee_validity)
 
-		visited = frappe.db.get_value('Fee Validity', fee_validity, 'visited')
+		# first follow up appointment
+		appointment = create_appointment(patient, practitioner, nowdate())
+		self.assertEqual(frappe.db.get_value('Fee Validity', fee_validity, 'visited'), 1)
+
 		update_status(appointment.name, 'Cancelled')
 		# check fee validity updated
-		self.assertEqual(frappe.db.get_value('Fee Validity', fee_validity, 'visited'), visited - 1)
+		self.assertEqual(frappe.db.get_value('Fee Validity', fee_validity, 'visited'), 0)
 
 		frappe.db.set_value('Healthcare Settings', None, 'enable_free_follow_ups', 0)
 		frappe.db.set_value('Healthcare Settings', None, 'automate_appointment_invoicing', 1)


### PR DESCRIPTION
- Since the Healthcare configuration is "Enable Free **Follow-ups**", the first appointment should not be linked to Fee Validity.
- Start Date for Fee Validity should be considered as the Appointment Date for the First Appointment and not the current date.
- Fixed tests
- Changed form labels