### PR TITLE
fix: Remove duplicate `create_internal_customer` utility

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -1832,7 +1832,8 @@ class TestSalesInvoice(unittest.TestCase):
 
 		create_internal_customer(
 			customer_name="_Test Internal Customer",
-			represents_company="_Test Company 1"
+			represents_company="_Test Company 1",
+			allowed_to_interact_with="Wind Power LLC"
 		)
 
 		if not frappe.db.exists("Supplier", "_Test Internal Supplier"):
@@ -1994,6 +1995,8 @@ class TestSalesInvoice(unittest.TestCase):
 
 	def test_internal_transfer_gl_entry(self):
 		## Create internal transfer account
+		from erpnext.selling.doctype.customer.test_customer import create_internal_customer
+
 		account = create_account(account_name="Unrealized Profit",
 			parent_account="Current Liabilities - TCP1", company="_Test Company with perpetual inventory")
 
@@ -2550,29 +2553,6 @@ def get_taxes_and_charges():
 	"rate": 2,
 	"row_id": 1
 	}]
-
-def create_internal_customer(customer_name, represents_company, allowed_to_interact_with):
-	if not frappe.db.exists("Customer", customer_name):
-		customer = frappe.get_doc({
-			"customer_group": "_Test Customer Group",
-			"customer_name": customer_name,
-			"customer_type": "Individual",
-			"doctype": "Customer",
-			"territory": "_Test Territory",
-			"is_internal_customer": 1,
-			"represents_company": represents_company
-		})
-
-		customer.append("companies", {
-			"company": allowed_to_interact_with
-		})
-
-		customer.insert()
-		customer_name = customer.name
-	else:
-		customer_name = frappe.db.get_value("Customer", customer_name)
-
-	return customer_name
 
 def create_internal_supplier(supplier_name, represents_company, allowed_to_interact_with):
 	if not frappe.db.exists("Supplier", supplier_name):

--- a/erpnext/selling/doctype/customer/test_customer.py
+++ b/erpnext/selling/doctype/customer/test_customer.py
@@ -353,27 +353,25 @@ def set_credit_limit(customer, company, credit_limit):
 		})
 		customer.credit_limits[-1].db_insert()
 
-def create_internal_customer(**args):
-	args = frappe._dict(args)
-
-	customer_name = args.get("customer_name") or "_Test Internal Customer"
-
+def create_internal_customer(customer_name, represents_company, allowed_to_interact_with):
 	if not frappe.db.exists("Customer", customer_name):
 		customer = frappe.get_doc({
 			"doctype": "Customer",
-			"customer_group": args.customer_group or "_Test Customer Group",
+			"customer_group": "_Test Customer Group",
 			"customer_name": customer_name,
-			"customer_type": args.customer_type or "Individual",
-			"territory": args.territory or "_Test Territory",
+			"customer_type": "Individual",
+			"territory": "_Test Territory",
 			"is_internal_customer": 1,
-			"represents_company": args.represents_company or "_Test Company with perpetual inventory"
+			"represents_company": represents_company
 		})
 
 		customer.append("companies", {
-			"company": args.allowed_company or "Wind Power LLC"
+			"company": allowed_to_interact_with
 		})
-		customer.insert()
 
-		return customer
+		customer.insert()
+		customer_name = customer.name
 	else:
-		return frappe.get_cached_doc("Customer", customer_name)
+		customer_name = frappe.db.get_value("Customer", customer_name)
+
+	return customer_name

--- a/erpnext/stock/doctype/delivery_note/test_delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/test_delivery_note.py
@@ -435,7 +435,8 @@ class TestDeliveryNote(unittest.TestCase):
 		company = frappe.db.get_value('Warehouse', 'Stores - TCP1', 'company')
 		customer = create_internal_customer(
 			customer_name="_Test Internal Customer 2",
-			allowed_company="_Test Company with perpetual inventory"
+			represents_company="_Test Company with perpetual inventory",
+			allowed_to_interact_with="_Test Company with perpetual inventory"
 		)
 
 		set_valuation_method("_Test Item", "FIFO")

--- a/erpnext/stock/doctype/delivery_note/test_delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/test_delivery_note.py
@@ -433,7 +433,7 @@ class TestDeliveryNote(unittest.TestCase):
 		from erpnext.selling.doctype.customer.test_customer import create_internal_customer
 
 		company = frappe.db.get_value('Warehouse', 'Stores - TCP1', 'company')
-		customer = create_internal_customer(
+		customer_name = create_internal_customer(
 			customer_name="_Test Internal Customer 2",
 			represents_company="_Test Company with perpetual inventory",
 			allowed_to_interact_with="_Test Company with perpetual inventory"
@@ -454,7 +454,7 @@ class TestDeliveryNote(unittest.TestCase):
 		dn = create_delivery_note(
 			item_code="_Test Product Bundle Item",
 			company="_Test Company with perpetual inventory",
-			customer=customer.name,
+			customer=customer_name,
 			cost_center = 'Main - TCP1',
 			expense_account = "Cost of Goods Sold - TCP1",
 			do_not_submit=True,


### PR DESCRIPTION
Introduced via https://github.com/frappe/erpnext/pull/27086

Already on version-13-hotfix via https://github.com/frappe/erpnext/pull/27166

