### PR TITLE
fix: operation time auto set to zero

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -498,16 +498,20 @@ class BOM(WebsiteGenerator):
 	def update_rate_and_time(self, row, update_hour_rate = False):
 		if not row.hour_rate or update_hour_rate:
 			hour_rate = flt(frappe.get_cached_value("Workstation", row.workstation, "hour_rate"))
-			row.hour_rate = (hour_rate / flt(self.conversion_rate)
-				if self.conversion_rate and hour_rate else hour_rate)
+
+			if hour_rate:
+				row.hour_rate = (hour_rate / flt(self.conversion_rate)
+					if self.conversion_rate and hour_rate else hour_rate)
 
 			if self.routing:
-				row.time_in_mins = flt(frappe.db.get_value("BOM Operation", {
+				time_in_mins = flt(frappe.db.get_value("BOM Operation", {
 						"workstation": row.workstation,
 						"operation": row.operation,
-						"sequence_id": row.sequence_id,
 						"parent": self.routing
 				}, ["time_in_mins"]))
+
+				if time_in_mins:
+					row.time_in_mins = time_in_mins
 
 		if row.hour_rate and row.time_in_mins:
 			row.base_hour_rate = flt(row.hour_rate) * flt(self.conversion_rate)

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -296,3 +296,4 @@ erpnext.patches.v13_0.update_recipient_email_digest
 erpnext.patches.v13_0.shopify_deprecation_warning
 erpnext.patches.v13_0.einvoicing_deprecation_warning
 erpnext.patches.v14_0.delete_einvoicing_doctypes
+erpnext.patches.v13_0.set_operation_time_based_on_operating_cost

--- a/erpnext/patches/v13_0/set_operation_time_based_on_operating_cost.py
+++ b/erpnext/patches/v13_0/set_operation_time_based_on_operating_cost.py
@@ -1,0 +1,15 @@
+import frappe
+
+def execute():
+	frappe.reload_doc('manufacturing', 'doctype', 'bom')
+	frappe.reload_doc('manufacturing', 'doctype', 'bom_operation')
+
+	frappe.db.sql('''
+		UPDATE
+			`tabBOM Operation`
+		SET
+			time_in_mins = (operating_cost * 60) / hour_rate
+		WHERE
+			time_in_mins = 0 AND operating_cost > 0
+			AND hour_rate > 0 AND docstatus = 1 AND parenttype = "BOM"
+	''')


### PR DESCRIPTION
If the operations in the BOM and routing is different then system auto reset the Time In Mins to Zero in the BOM

<img width="1092" alt="Screenshot 2021-08-27 at 1 45 08 AM" src="https://user-images.githubusercontent.com/8780500/131030662-ec24ba13-94d1-46b0-9a18-46fcf2bdf07f.png">


**After Fix**

<img width="1072" alt="Screenshot 2021-08-27 at 1 51 07 AM" src="https://user-images.githubusercontent.com/8780500/131030682-3254f6ff-6ce4-44f0-a61a-793bd338bade.png">

