### PR TITLE
fix: Calculate taxes post submit only for orders

### DIFF
--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -25,7 +25,7 @@ class calculate_taxes_and_totals(object):
 
 		self.discount_amount_applied = False
 
-		if self.docstatus == 0 or self.flags.ignore_validate_update_after_submit
+		if self.doc.docstatus == 0 or self.doc.flags.ignore_validate_update_after_submit
 			self._calculate()
 
 			if self.doc.meta.get_field("discount_amount"):

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -25,7 +25,7 @@ class calculate_taxes_and_totals(object):
 
 		self.discount_amount_applied = False
 
-		if self.doc.docstatus == 0 or self.doc.flags.ignore_validate_update_after_submit
+		if self.doc.docstatus == 0 or self.doc.flags.ignore_validate_update_after_submit:
 			self._calculate()
 
 			if self.doc.meta.get_field("discount_amount"):

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -24,11 +24,13 @@ class calculate_taxes_and_totals(object):
 			return
 
 		self.discount_amount_applied = False
-		self._calculate()
 
-		if self.doc.meta.get_field("discount_amount"):
-			self.set_discount_amount()
-			self.apply_discount_amount()
+		if self.docstatus == 0 or self.flags.ignore_validate_update_after_submit
+			self._calculate()
+
+			if self.doc.meta.get_field("discount_amount"):
+				self.set_discount_amount()
+				self.apply_discount_amount()
 
 		if self.doc.doctype in ["Sales Invoice", "Purchase Invoice"]:
 			self.calculate_total_advance()


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 68, in application
    response = frappe.api.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/api.py", line 95, in handle
    "data": doc.save().as_dict()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 285, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 326, in _save
    self.validate_update_after_submit()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 782, in validate_update_after_submit
    self._validate_update_after_submit()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/base_document.py", line 760, in _validate_update_after_submit
    frappe.UpdateAfterSubmitError)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 432, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red', is_minimizable=is_minimizable, wide=wide, as_list=as_list)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 411, in msgprint
    _raise_exception()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 365, in _raise_exception
    raise raise_exception(msg)
frappe.exceptions.UpdateAfterSubmitError: Not allowed to change Taxes and Charges Calculation after submission
```