### PR TITLE
fix: patches were breaking while migrating

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -214,6 +214,7 @@ erpnext.patches.v13_0.delete_old_sales_reports
 execute:frappe.delete_doc_if_exists("DocType", "Bank Reconciliation")
 erpnext.patches.v13_0.move_doctype_reports_and_notification_from_hr_to_payroll #22-06-2020
 erpnext.patches.v13_0.move_payroll_setting_separately_from_hr_settings #22-06-2020
+erpnext.patches.v12_0.create_itc_reversal_custom_fields
 erpnext.patches.v13_0.check_is_income_tax_component #22-06-2020
 erpnext.patches.v13_0.loyalty_points_entry_for_pos_invoice #22-07-2020
 erpnext.patches.v12_0.add_taxjar_integration_field
@@ -266,7 +267,6 @@ erpnext.patches.v13_0.rename_discharge_date_in_ip_record
 erpnext.patches.v12_0.create_taxable_value_field
 erpnext.patches.v12_0.add_gst_category_in_delivery_note
 erpnext.patches.v12_0.purchase_receipt_status
-erpnext.patches.v12_0.create_itc_reversal_custom_fields
 erpnext.patches.v13_0.fix_non_unique_represents_company
 erpnext.patches.v12_0.add_document_type_field_for_italy_einvoicing
 erpnext.patches.v13_0.make_non_standard_user_type #13-04-2021

--- a/erpnext/patches/v13_0/check_is_income_tax_component.py
+++ b/erpnext/patches/v13_0/check_is_income_tax_component.py
@@ -19,10 +19,10 @@ def execute():
 	]
 
 	for doctype in doctypes:
-		frappe.reload_doc('Payroll', 'doctype', doctype)
+		frappe.reload_doc('Payroll', 'doctype', doctype, force=True)
 
 
-	reports = ['Professional Tax Deductions', 'Provident Fund Deductions']
+	reports = ['Professional Tax Deductions', 'Provident Fund Deductions', 'E-Invoice Summary']
 	for report in reports:
 		frappe.reload_doc('Regional', 'Report', report)
 		frappe.reload_doc('Regional', 'Report', report)

--- a/erpnext/patches/v13_0/delete_old_purchase_reports.py
+++ b/erpnext/patches/v13_0/delete_old_purchase_reports.py
@@ -13,6 +13,7 @@ def execute():
 	for report in reports_to_delete:
 		if frappe.db.exists("Report", report):
 			delete_auto_email_reports(report)
+			check_linked_reports(report)
 
 			frappe.delete_doc("Report", report)
 
@@ -21,3 +22,13 @@ def delete_auto_email_reports(report):
 	auto_email_reports = frappe.db.get_values("Auto Email Report", {"report": report}, ["name"])
 	for auto_email_report in auto_email_reports:
 		frappe.delete_doc("Auto Email Report", auto_email_report[0])
+
+def check_linked_reports(report):
+	""" Check if reports are referenced in Desktop Icon """
+	icons = frappe.get_all("Desktop Icon",
+						fields = ['name'],
+						filters = {
+							"_report": report
+						})
+	if icons:
+		frappe.delete_doc("Desktop Icon", icons)

--- a/erpnext/patches/v13_0/delete_old_sales_reports.py
+++ b/erpnext/patches/v13_0/delete_old_sales_reports.py
@@ -11,6 +11,7 @@ def execute():
 	for report in reports_to_delete:
 		if frappe.db.exists("Report", report):
 			delete_auto_email_reports(report)
+			check_linked_reports(report)
 
 			frappe.delete_doc("Report", report)
 
@@ -19,3 +20,13 @@ def delete_auto_email_reports(report):
 	auto_email_reports = frappe.db.get_values("Auto Email Report", {"report": report}, ["name"])
 	for auto_email_report in auto_email_reports:
 		frappe.delete_doc("Auto Email Report", auto_email_report[0])
+
+def check_linked_reports(report):
+	""" Check if reports are referenced in Desktop Icon """
+	icons = frappe.get_all("Desktop Icon",
+						fields = ['name'],
+						filters = {
+							"_report": report
+						})
+	if icons:
+		frappe.delete_doc("Desktop Icon", icons)

--- a/erpnext/patches/v13_0/delete_old_sales_reports.py
+++ b/erpnext/patches/v13_0/delete_old_sales_reports.py
@@ -4,6 +4,7 @@
 from __future__ import unicode_literals
 
 import frappe
+from erpnext.patches.v13_0.delete_old_purchase_reports import check_linked_reports
 
 def execute():
 	reports_to_delete = ["Ordered Items To Be Delivered", "Ordered Items To Be Billed"]
@@ -20,13 +21,3 @@ def delete_auto_email_reports(report):
 	auto_email_reports = frappe.db.get_values("Auto Email Report", {"report": report}, ["name"])
 	for auto_email_report in auto_email_reports:
 		frappe.delete_doc("Auto Email Report", auto_email_report[0])
-
-def check_linked_reports(report):
-	""" Check if reports are referenced in Desktop Icon """
-	icons = frappe.get_all("Desktop Icon",
-						fields = ['name'],
-						filters = {
-							"_report": report
-						})
-	if icons:
-		frappe.delete_doc("Desktop Icon", icons)

--- a/erpnext/patches/v13_0/rename_issue_doctype_fields.py
+++ b/erpnext/patches/v13_0/rename_issue_doctype_fields.py
@@ -41,6 +41,7 @@ def execute():
 		rename_field('Opportunity', 'mins_to_first_response', 'first_response_time')
 
 		# change fieldtype to duration
+		frappe.reload_doc('crm', 'doctype', 'opportunity', force=True)
 		count = 0
 		for entry in opportunities:
 			mins_to_first_response = convert_to_seconds(entry.mins_to_first_response, 'Minutes')
@@ -58,6 +59,8 @@ def execute():
 
 def convert_to_seconds(value, unit):
 	seconds = 0
+	if value == 0:
+		return seconds
 	if unit == 'Hours':
 		seconds = value * 3600
 	if unit == 'Minutes':

--- a/erpnext/patches/v13_0/update_returned_qty_in_pr_dn.py
+++ b/erpnext/patches/v13_0/update_returned_qty_in_pr_dn.py
@@ -8,6 +8,7 @@ def execute():
 	frappe.reload_doc('stock', 'doctype', 'purchase_receipt_item')
 	frappe.reload_doc('stock', 'doctype', 'delivery_note')
 	frappe.reload_doc('stock', 'doctype', 'delivery_note_item')
+	frappe.reload_doc('stock', 'doctype', 'stock_settings')
 
 	def update_from_return_docs(doctype):
 		for return_doc in frappe.get_all(doctype, filters={'is_return' : 1, 'docstatus' : 1}):


### PR DESCRIPTION
Fixes for the following errors occurred while migrating:

- frappe.exceptions.ValidationError: Fieldtype cannot be changed from Data to Currency
- frappe.exceptions.LinkValidationError: Could not find Report: E-Invoice Summary
- pymysql.err.OperationalError: (1054, "Unknown column 'first_response_time' in 'field list'")
- TypeError: unsupported operand type(s) for *: 'NoneType' and 'int'
- frappe.exceptions.LinkExistsError: Cannot delete or cancel because Report "A" is linked with Desktop Icon "B" 
- frappe.database.database.InvalidColumnName: Invalid field name