### PR TITLE
fix: payment terms on Sales Order when Invoice Portion field is empty

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1211,7 +1211,7 @@ class AccountsController(TransactionBase):
 				d.base_payment_amount = flt(base_grand_total * flt(d.invoice_portion / 100), d.precision('base_payment_amount'))
 				d.outstanding = d.payment_amount
 			elif not d.invoice_portion:
-				d.base_payment_amount = flt(base_grand_total * self.get("conversion_rate"), d.precision('base_payment_amount'))
+				d.base_payment_amount = flt(d.payment_amount * self.get("conversion_rate"), d.precision('base_payment_amount'))
 
 
 	def get_order_details(self):


### PR DESCRIPTION
closes #27208

This fix is intended to fix the the validation of the Payment Schedule child table. In v12, it was possible to enter Payment Amounts directly in this field without a % recorded in the Invoice Portion field. This functionality broke in v13.

In our case we can't enter the payment terms by percentages, because they are values determined arbitrarily by the contract; leaving the % at 0% should allow us to enter arbitrary amounts into the payment schedule to get around this limitation.

I believe this functionality was broken (recently) by commit cd980f5e6b1853b4cf2af02d5592cb5da7ae1f8a.