### PR TITLE
fix: Correct company address not getting copied from Purchase Order to Invoice

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -871,20 +871,19 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 			});
 
 			// Get default company billing address in Purchase Invoice, Order and Receipt
-			if (frm.doc.company && frappe.meta.get_docfield(this.frm.doctype, "billing_address")) {
+			if (this.frm.doc.company && frappe.meta.get_docfield(this.frm.doctype, "billing_address")) {
 				frappe.call({
 					method: "erpnext.setup.doctype.company.company.get_default_company_address",
-					args: {name:this.frm.doc.company, existing_address: this.frm.doc.billing_address || ""},
+					args: {name: this.frm.doc.company, existing_address: this.frm.doc.billing_address || ""},
 					debounce: 2000,
 					callback: function(r) {
 						if (r.message) {
-							me.frm.set_value("billing_address",r.message)
-						}
-						else {
-							ke.frm.set_value("company_address","")
+							me.frm.set_value("billing_address", r.message);
+						} else {
+							me.frm.set_value("company_address", "");
 						}
 					}
-				})
+				});
 			}
 
 		} else {

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -866,21 +866,26 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 
 		if (frappe.meta.get_docfield(this.frm.doctype, "shipping_address") &&
 			in_list(['Purchase Order', 'Purchase Receipt', 'Purchase Invoice'], this.frm.doctype)) {
-			erpnext.utils.get_shipping_address(this.frm, function(){
+			erpnext.utils.get_shipping_address(this.frm, function() {
 				set_party_account(set_pricing);
 			});
 
 			// Get default company billing address in Purchase Invoice, Order and Receipt
-			frappe.call({
-				'method': 'frappe.contacts.doctype.address.address.get_default_address',
-				'args': {
-					'doctype': 'Company',
-					'name': this.frm.doc.company
-				},
-				'callback': function(r) {
-					me.frm.set_value('billing_address', r.message);
-				}
-			});
+			if (frm.doc.company && frappe.meta.get_docfield(this.frm.doctype, "billing_address")) {
+				frappe.call({
+					method: "erpnext.setup.doctype.company.company.get_default_company_address",
+					args: {name:this.frm.doc.company, existing_address: this.frm.doc.billing_address || ""},
+					debounce: 2000,
+					callback: function(r) {
+						if (r.message) {
+							me.frm.set_value("billing_address",r.message)
+						}
+						else {
+							ke.frm.set_value("company_address","")
+						}
+					}
+				})
+			}
 
 		} else {
 			set_party_account(set_pricing);

--- a/erpnext/public/js/utils/party.js
+++ b/erpnext/public/js/utils/party.js
@@ -289,8 +289,8 @@ erpnext.utils.get_shipping_address = function(frm, callback) {
 				company: frm.doc.company,
 				address: frm.doc.shipping_address
 			},
-			callback: function(r){
-				if (r.message){
+			callback: function(r) {
+				if (r.message) {
 					frm.set_value("shipping_address", r.message[0]) //Address title or name
 					frm.set_value("shipping_address_display", r.message[1]) //Address to be displayed on the page
 				}


### PR DESCRIPTION
If a user updated the company address in Purchase Order other than the preferred billing address it was not getting copied from Purchase Order to Purchase Invoice

Steps to test
1. Create two addresses for a company, For Eg: Maharashtra-Billing and Goa-Billing, and mark Maharashtra-Billing as the preferred billing address
2. Create a Purchase Order and update the company address from the default one (Maharashtra-Billing) to another one (Goa-Billing) and save and submit the PO
3. Now create a Purchase Invoice from the same PO using the "Create Purchase Invoice" button and check, the company billing address should be same as the one in Purchase Order