### PR TITLE
feat: link Bank Account in Employee and Salary Slip

### DIFF
--- a/erpnext/accounts/doctype/bank_account/bank_account.py
+++ b/erpnext/accounts/doctype/bank_account/bank_account.py
@@ -35,26 +35,36 @@ class BankAccount(Document):
 		if not self.iban:
 			return
 
-		def encode_char(c):
-			# Position in the alphabet (A=1, B=2, ...) plus nine
-			return str(9 + ord(c) - 64)
-
-		# remove whitespaces, upper case to get the right number from ord()
-		iban = ''.join(self.iban.split(' ')).upper()
-
-		# Move country code and checksum from the start to the end
-		flipped = iban[4:] + iban[:4]
-
-		# Encode characters as numbers
-		encoded = [encode_char(c) if ord(c) >= 65 and ord(c) <= 90 else c for c in flipped]
-
-		try:
-			to_check = int(''.join(encoded))
-		except ValueError:
+		if not is_valid_iban(self.iban):
 			frappe.throw(_('IBAN is not valid'))
 
-		if to_check % 97 != 1:
-			frappe.throw(_('IBAN is not valid'))
+
+def is_valid_iban(iban):
+	'''
+	Algorithm: https://en.wikipedia.org/wiki/International_Bank_Account_Number#Validating_the_IBAN
+	'''
+	def encode_char(c):
+		# Position in the alphabet (A=1, B=2, ...) plus nine
+		return str(9 + ord(c) - 64)
+
+	# remove whitespaces, upper case to get the right number from ord()
+	iban = ''.join(iban.split(' ')).upper()
+
+	# Move country code and checksum from the start to the end
+	flipped = iban[4:] + iban[:4]
+
+	# Encode characters as numbers
+	encoded = [encode_char(c) if ord(c) >= 65 and ord(c) <= 90 else c for c in flipped]
+
+	try:
+		to_check = int(''.join(encoded))
+	except ValueError:
+		return False
+
+	if to_check % 97 != 1:
+		return False
+
+	return True
 
 
 @frappe.whitelist()

--- a/erpnext/accounts/doctype/bank_account/bank_account_dashboard.py
+++ b/erpnext/accounts/doctype/bank_account/bank_account_dashboard.py
@@ -13,11 +13,15 @@ def get_data():
 		'transactions': [
 			{
 				'label': _('Payments'),
-				'items': ['Payment Entry', 'Payment Request', 'Payment Order', 'Payroll Entry']
+				'items': ['Payment Entry', 'Payment Request', 'Payment Order']
 			},
 			{
 				'label': _('Party'),
-				'items': ['Customer', 'Supplier']
+				'items': ['Customer', 'Supplier', 'Employee']
+			},
+			{
+				'label': _('Payroll'),
+				'items': ['Payroll Entry', 'Salary Slip']
 			},
 			{
 				'items': ['Bank Guarantee']

--- a/erpnext/hr/doctype/employee/employee.json
+++ b/erpnext/hr/doctype/employee/employee.json
@@ -65,8 +65,7 @@
   "salary_mode",
   "payroll_cost_center",
   "column_break_52",
-  "bank_name",
-  "bank_ac_no",
+  "bank_account",
   "health_insurance_section",
   "health_insurance_provider",
   "health_insurance_no",
@@ -437,22 +436,6 @@
    "options": "\nBank\nCash\nCheque"
   },
   {
-   "depends_on": "eval:doc.salary_mode == 'Bank'",
-   "fieldname": "bank_name",
-   "fieldtype": "Data",
-   "label": "Bank Name",
-   "oldfieldname": "bank_name",
-   "oldfieldtype": "Link"
-  },
-  {
-   "depends_on": "eval:doc.salary_mode == 'Bank'",
-   "fieldname": "bank_ac_no",
-   "fieldtype": "Data",
-   "label": "Bank A/C No.",
-   "oldfieldname": "bank_ac_no",
-   "oldfieldtype": "Data"
-  },
-  {
    "collapsible": 1,
    "fieldname": "health_insurance_section",
    "fieldtype": "Section Break",
@@ -807,13 +790,20 @@
    "fieldtype": "Link",
    "label": "Shift Request Approver",
    "options": "User"
+  },
+  {
+   "depends_on": "eval:doc.salary_mode == 'Bank'",
+   "fieldname": "bank_account",
+   "fieldtype": "Link",
+   "label": "Bank Account",
+   "options": "Bank Account"
   }
  ],
  "icon": "fa fa-user",
  "idx": 24,
  "image_field": "image",
  "links": [],
- "modified": "2021-06-17 11:31:37.730760",
+ "modified": "2021-08-29 18:24:53.875953",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Employee",

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -307,3 +307,4 @@ erpnext.patches.v13_0.migrate_stripe_api
 erpnext.patches.v13_0.reset_clearance_date_for_intracompany_payment_entries
 erpnext.patches.v13_0.set_operation_time_based_on_operating_cost
 erpnext.patches.v13_0.employee_bank_account
+erpnext.patches.v13_0.salary_slip_bank_account

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -306,3 +306,4 @@ erpnext.patches.v13_0.rename_discharge_ordered_date_in_ip_record
 erpnext.patches.v13_0.migrate_stripe_api
 erpnext.patches.v13_0.reset_clearance_date_for_intracompany_payment_entries
 erpnext.patches.v13_0.set_operation_time_based_on_operating_cost
+erpnext.patches.v13_0.employee_bank_account

--- a/erpnext/patches/v13_0/employee_bank_account.py
+++ b/erpnext/patches/v13_0/employee_bank_account.py
@@ -1,0 +1,55 @@
+import frappe
+
+from erpnext import get_region
+from erpnext.accounts.doctype.bank_account.bank_account import is_valid_iban
+
+
+def execute():
+	"""
+	Create Banks and Bank Accounts from bank details in Employee.
+	"""
+	frappe.reload_doctype("Employee")
+	employees = frappe.get_all("Employee",
+		fields=["name", "bank_name", "bank_ac_no"],
+		filters={"bank_ac_no": ("is", "set"), "bank_name": ("is", "set")}
+	)
+
+	for employee in employees:
+		existing_accounts = frappe.get_list("Bank Account", 
+			filters={
+				"bank": employee.bank_name
+			},
+			or_filters={
+				"bank_account_no": employee.bank_ac_no,
+				"iban": employee.bank_ac_no
+			}
+		)
+
+		if existing_accounts:
+			bank_account = existing_accounts[0].name
+		else:
+			if not frappe.db.exists("Bank", employee.bank_name):
+				new_bank = frappe.new_doc("Bank")
+				new_bank.bank_name = employee.bank_name
+				new_bank.save()
+
+			new_bank_account = frappe.new_doc("Bank Account")
+			new_bank_account.account_name = employee.bank_ac_no
+
+			if is_valid_iban(employee.bank_ac_no):
+				new_bank_account.iban = employee.bank_ac_no
+			else:
+				new_bank_account.bank_account_no = employee.bank_ac_no
+
+			new_bank_account.bank = employee.bank_name
+			new_bank_account.party_type = "Employee"
+			new_bank_account.party = employee.name
+
+			if get_region() == "India":
+				new_bank_account.ifsc_code = employee.ifsc_code
+				new_bank_account.micr_code = employee.micr_code
+
+			new_bank_account.save()
+			bank_account = new_bank_account.name
+
+		frappe.set_value("Employee", employee.name, "bank_account", bank_account)

--- a/erpnext/patches/v13_0/salary_slip_bank_account.py
+++ b/erpnext/patches/v13_0/salary_slip_bank_account.py
@@ -1,0 +1,50 @@
+import frappe
+from erpnext.accounts.doctype.bank_account.bank_account import is_valid_iban
+
+
+def execute():
+	"""
+	Create Banks and Bank Accounts from bank details in Salary Slip.
+	"""
+	frappe.reload_doctype("Salary Slip")
+	salary_slips = frappe.get_all("Salary Slip",
+		fields=["name", "employee", "bank_account_no", "bank_name"]
+	)
+
+	for salary_slip in salary_slips:
+		if not (salary_slip.bank_account_no and salary_slip.bank_name):
+			continue
+
+		existing_accounts = frappe.get_list("Bank Account",
+			filters={
+				"bank": salary_slip.bank_name
+			},
+			or_filters={
+				"bank_account_no": salary_slip.bank_account_no,
+				"iban": salary_slip.bank_account_no
+			}
+		)
+
+		if existing_accounts:
+			bank_account = existing_accounts[0].name
+		else:
+			if not frappe.db.exists("Bank", salary_slip.bank_name):
+				new_bank = frappe.new_doc("Bank")
+				new_bank.bank_name = salary_slip.bank_name
+				new_bank.save()
+
+			new_bank_account = frappe.new_doc("Bank Account")
+			new_bank_account.account_name = salary_slip.bank_account_no
+
+			if is_valid_iban(salary_slip.bank_account_no):
+				new_bank_account.iban = salary_slip.bank_account_no
+			else:
+				new_bank_account.bank_account_no = salary_slip.bank_account_no
+
+			new_bank_account.bank = salary_slip.bank_name
+			new_bank_account.party_type = "Employee"
+			new_bank_account.party = salary_slip.employee
+			new_bank_account.save()
+			bank_account = new_bank_account.name
+
+		frappe.set_value("Salary Slip", salary_slip.name, "bank_account", bank_account)

--- a/erpnext/payroll/doctype/salary_slip/salary_slip.json
+++ b/erpnext/payroll/doctype/salary_slip/salary_slip.json
@@ -42,8 +42,7 @@
   "hour_rate",
   "base_hour_rate",
   "section_break_26",
-  "bank_name",
-  "bank_account_no",
+  "bank_account",
   "mode_of_payment",
   "section_break_32",
   "deduct_tax_for_unclaimed_employee_benefits",
@@ -291,22 +290,6 @@
   {
    "fieldname": "section_break_26",
    "fieldtype": "Section Break"
-  },
-  {
-   "fieldname": "bank_name",
-   "fieldtype": "Data",
-   "label": "Bank Name",
-   "oldfieldname": "bank_name",
-   "oldfieldtype": "Data",
-   "read_only": 1
-  },
-  {
-   "fieldname": "bank_account_no",
-   "fieldtype": "Data",
-   "label": "Bank Account No.",
-   "oldfieldname": "bank_account_no",
-   "oldfieldtype": "Data",
-   "read_only": 1
   },
   {
    "fieldname": "section_break_32",
@@ -625,13 +608,20 @@
    "label": "Leave Details",
    "options": "Salary Slip Leave",
    "read_only": 1
+  },
+  {
+   "fieldname": "bank_account",
+   "fieldtype": "Link",
+   "label": "Bank Account",
+   "options": "Bank Account",
+   "read_only": 1
   }
  ],
  "icon": "fa fa-file-text",
  "idx": 9,
  "is_submittable": 1,
  "links": [],
- "modified": "2021-03-31 22:44:09.772331",
+ "modified": "2021-08-29 18:18:12.647762",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Salary Slip",

--- a/erpnext/payroll/doctype/salary_slip/salary_slip.py
+++ b/erpnext/payroll/doctype/salary_slip/salary_slip.py
@@ -1150,7 +1150,6 @@ class SalarySlip(TransactionBase):
 			status = self.get_status()
 		self.db_set("status", status)
 
-
 	def process_salary_structure(self, for_preview=0):
 		'''Calculate salary after salary structure details have been updated'''
 		if not self.salary_slip_based_on_timesheet:
@@ -1160,11 +1159,10 @@ class SalarySlip(TransactionBase):
 		self.calculate_net_pay()
 
 	def pull_emp_details(self):
-		emp = frappe.db.get_value("Employee", self.employee, ["bank_name", "bank_ac_no", "salary_mode"], as_dict=1)
+		emp = frappe.db.get_value("Employee", self.employee, ["bank_account", "salary_mode"], as_dict=1)
 		if emp:
 			self.mode_of_payment = emp.salary_mode
-			self.bank_name = emp.bank_name
-			self.bank_account_no = emp.bank_ac_no
+			self.bank_account = emp.bank_account
 
 	@frappe.whitelist()
 	def process_salary_based_on_working_days(self):

--- a/erpnext/regional/india/setup.py
+++ b/erpnext/regional/india/setup.py
@@ -535,14 +535,21 @@ def make_custom_fields(update=True):
 				depends_on = 'eval:doc.type == "Deduction"'
 			)
 		],
-		'Employee': [
-			dict(fieldname='ifsc_code',
+		'Bank Account': [
+			dict(
+				fieldname='ifsc_code',
 				label='IFSC Code',
 				fieldtype='Data',
-				insert_after='bank_ac_no',
-				print_hide=1,
-				depends_on='eval:doc.salary_mode == "Bank"'
-				),
+				insert_after='branch_code'
+			),
+			dict(
+				fieldname =  'micr_code',
+				label = 'MICR Code',
+				fieldtype = 'Data',
+				insert_after = 'ifsc_code'
+			)
+		],
+		'Employee': [
 			dict(
 				fieldname =  'pan_number',
 				label = 'PAN Number',
@@ -551,20 +558,11 @@ def make_custom_fields(update=True):
 				print_hide = 1
 			),
 			dict(
-				fieldname =  'micr_code',
-				label = 'MICR Code',
-				fieldtype = 'Data',
-				insert_after = 'ifsc_code',
-				print_hide = 1,
-				depends_on='eval:doc.salary_mode == "Bank"'
-			),
-			dict(
 				fieldname = 'provident_fund_account',
 				label = 'Provident Fund Account',
 				fieldtype = 'Data',
 				insert_after = 'pan_number'
 			)
-
 		],
 		'Company': [
 			dict(fieldname='hra_section', label='HRA Settings',

--- a/erpnext/regional/india/setup.py
+++ b/erpnext/regional/india/setup.py
@@ -543,10 +543,10 @@ def make_custom_fields(update=True):
 				insert_after='branch_code'
 			),
 			dict(
-				fieldname =  'micr_code',
-				label = 'MICR Code',
-				fieldtype = 'Data',
-				insert_after = 'ifsc_code'
+				fieldname='micr_code',
+				label='MICR Code',
+				fieldtype='Data',
+				insert_after='ifsc_code'
 			)
 		],
 		'Employee': [


### PR DESCRIPTION
Previously, bank details were stored directly in **Employee** and **Salary Slip**. This PR replaces these fields with a link to **Bank Account**.

Related Issue: #17685