### PR TITLE
ci: use node action instead of apt

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -4,11 +4,7 @@ set -e
 
 cd ~ || exit
 
-sudo apt-get install redis-server
-
-sudo apt install nodejs
-
-sudo apt install npm
+sudo apt-get install redis-server libcups2-dev
 
 pip install frappe-bench
 
@@ -32,7 +28,6 @@ wget -O /tmp/wkhtmltox.tar.xz https://github.com/frappe/wkhtmltopdf/raw/master/w
 tar -xf /tmp/wkhtmltox.tar.xz -C /tmp
 sudo mv /tmp/wkhtmltox/bin/wkhtmltopdf /usr/local/bin/wkhtmltopdf
 sudo chmod o+x /usr/local/bin/wkhtmltopdf
-sudo apt-get install libcups2-dev
 
 cd ~/frappe-bench || exit
 

--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -31,7 +31,13 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: 3.7
+
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          check-latest: true
 
       - name: Add to Hosts
         run: echo "127.0.0.1 test_site" | sudo tee -a /etc/hosts

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -43,6 +43,12 @@ jobs:
         with:
           python-version: 3.7
 
+      - name: Setup Node
+        uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          check-latest: true
+
       - name: Add to Hosts
         run: echo "127.0.0.1 test_site" | sudo tee -a /etc/hosts
 


### PR DESCRIPTION
Replace manual node install in `install.sh` with https://github.com/actions/setup-node

