### PR TITLE
fix: Maintain same rate in Stock Ledger until stock become positive

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -673,11 +673,15 @@ class update_entries_after(object):
 			if self.wh_data.stock_queue[-1][1]==incoming_rate:
 				self.wh_data.stock_queue[-1][0] += actual_qty
 			else:
+				# Item has a positive balance qty, add new entry
 				if self.wh_data.stock_queue[-1][0] > 0:
 					self.wh_data.stock_queue.append([actual_qty, incoming_rate])
-				else:
+				else: # negative balance qty
 					qty = self.wh_data.stock_queue[-1][0] + actual_qty
-					self.wh_data.stock_queue[-1][0] = qty
+					if qty > 0: # new balance qty is positive
+						self.wh_data.stock_queue[-1] = [qty, incoming_rate]
+					else: # new balance qty is still negative, maintain same rate
+						self.wh_data.stock_queue[-1][0] = qty
 		else:
 			qty_to_pop = abs(actual_qty)
 			while qty_to_pop:

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -677,7 +677,7 @@ class update_entries_after(object):
 					self.wh_data.stock_queue.append([actual_qty, incoming_rate])
 				else:
 					qty = self.wh_data.stock_queue[-1][0] + actual_qty
-					self.wh_data.stock_queue[-1] = [qty, incoming_rate]
+					self.wh_data.stock_queue[-1][0] = qty
 		else:
 			qty_to_pop = abs(actual_qty)
 			while qty_to_pop:


### PR DESCRIPTION
Problem:
Let's say, the stock for an item is negative (-10 qty).
And we make an incoming entry of +2 qty, after which stock is still in negative. In this case, the system should maintain the same rate in the FIFO queue. Otherwise, it will lead to wrong GL entry and COGS will not be booked properly.
Solution:
Maintain the same rate in Stock Ledger until stock becomes positive