### PR TITLE
ci: concurrency control for CI jobs

### DIFF
--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -7,6 +7,9 @@ on:
       - '**.md'
   workflow_dispatch:
 
+concurrency:
+  group: patch-develop-${{ github.event.number }}
+  cancel-in-progress: true
 
 jobs:
   test:

--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -12,6 +12,10 @@ on:
       - '**.js'
       - '**.md'
 
+concurrency:
+  group: server-develop-${{ github.event.number }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-18.04

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -6,6 +6,10 @@ on:
       - '**.md'
   workflow_dispatch:
 
+concurrency:
+  group: ui-develop-${{ github.event.number }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
similar to https://github.com/frappe/frappe/pull/14061

This will ensure that only one instance of the following tests run per PR and cancel previous running/queued jobs when new commits are pushed. 

- Server / unit tests
- UI tests
- Patch test