### PR TITLE
feat: do not allow gl entry submission after period closing

### DIFF
--- a/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.json
+++ b/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.json
@@ -7,6 +7,7 @@
  "field_order": [
   "transaction_date",
   "posting_date",
+  "year_start_date",
   "fiscal_year",
   "amended_from",
   "company",
@@ -90,13 +91,20 @@
    "fieldname": "cost_center_wise_pnl",
    "fieldtype": "Check",
    "label": "Book Cost Center Wise Profit/Loss"
+  },
+  {
+   "fieldname": "year_start_date",
+   "fieldtype": "Date",
+   "hidden": 1,
+   "label": "Year Start Date",
+   "read_only": 1
   }
  ],
  "icon": "fa fa-file-text",
  "idx": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2021-05-20 15:27:37.210458",
+ "modified": "2021-08-30 20:15:25.639122",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Period Closing Voucher",

--- a/erpnext/accounts/general_ledger.py
+++ b/erpnext/accounts/general_ledger.py
@@ -55,7 +55,7 @@ def validate_period_closing(gl_map):
 
 	if period_closing:
 		msg = _("You cannot create or cancel any accounting entries within a closed fiscal year.") + '<br><br>'
-		msg += _("You must cancel Period Closing Voucher {} to proceed with entries submission.").format(
+		msg += _("You must cancel Period Closing Voucher {} to proceed with submission/cancellation.").format(
 			frappe.bold(period_closing[0].name))
 
 		frappe.throw(msg, title=_("Fiscal Year Closed"), exc=ClosedAccountingPeriod)

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -301,3 +301,4 @@ erpnext.patches.v13_0.einvoicing_deprecation_warning
 erpnext.patches.v14_0.delete_einvoicing_doctypes
 erpnext.patches.v13_0.set_operation_time_based_on_operating_cost
 erpnext.patches.v13_0.validate_options_for_data_field
+erpnext.patches.v13_0.update_year_start_date_in_pcv

--- a/erpnext/patches/v13_0/update_year_start_date_in_pcv.py
+++ b/erpnext/patches/v13_0/update_year_start_date_in_pcv.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2021, Frappe and Contributors
+# License: GNU General Public License v3. See license.txt
+
+from __future__ import unicode_literals
+import frappe
+
+def execute():
+	pcvs = frappe.db.get_all(
+		doctype='Period Closing Voucher',
+		filters={'docstatus': 1},
+		fields=['name', 'posting_date', 'fiscal_year', 'company']
+	)
+	if pcvs:
+		from erpnext.accounts.utils import get_fiscal_year
+		frappe.reload_doc('accounts', 'doctype', 'period_closing_voucher')
+
+		for pcv in pcvs:
+			year_start_date = get_fiscal_year(pcv.posting_date, pcv.fiscal_year, company=pcv.company)[1]
+			frappe.db.set_value('Period Closing Voucher', pcv.name, 'year_start_date', year_start_date)


### PR DESCRIPTION
Problem:
After creating a Period Closing Voucher for a fiscal year, if there happens to be a backdated entry submission/cancellation then it affects the closed balance sheet

Proposed Solution:
Do not allow gl entry submission/cancellation between closed fiscal years. User will have to cancel the period closing voucher to proceed with the accounting transaction

`no-docs`