### PR TITLE
fix(test): first check for org chart always fails

### DIFF
--- a/cypress/integration/test_organizational_chart_desktop.js
+++ b/cypress/integration/test_organizational_chart_desktop.js
@@ -2,8 +2,11 @@ context('Organizational Chart', () => {
 	before(() => {
 		cy.login();
 		cy.visit('/app/website');
+	});
+
+	it('navigates to org chart', () => {
+		cy.visit('/app');
 		cy.awesomebar('Organizational Chart');
-		cy.wait(500);
 		cy.url().should('include', '/organizational-chart');
 
 		cy.window().its('frappe.csrf_token').then(csrf_token => {

--- a/cypress/integration/test_organizational_chart_mobile.js
+++ b/cypress/integration/test_organizational_chart_mobile.js
@@ -1,9 +1,14 @@
 context('Organizational Chart Mobile', () => {
 	before(() => {
 		cy.login();
-		cy.viewport(375, 667);
 		cy.visit('/app/website');
+	});
+
+	it('navigates to org chart', () => {
+		cy.viewport(375, 667);
+		cy.visit('/app');
 		cy.awesomebar('Organizational Chart');
+		cy.url().should('include', '/organizational-chart');
 
 		cy.window().its('frappe.csrf_token').then(csrf_token => {
 			return cy.request({


### PR DESCRIPTION
**Problem**: The first check always fails for the Org Chart test (passes on local). And the test is not retried since it fails in the _before_ hook. Also, all the tests post that are skipped.

![image](https://user-images.githubusercontent.com/24353136/131459305-1b6a50f9-455a-44c2-a3cc-0e1b78b5551b.png)

**Fix**: move all assertions to a separate test.
