### PR TITLE
fix: pass labels through translation function

### DIFF
--- a/erpnext/stock/report/process_loss_report/process_loss_report.py
+++ b/erpnext/stock/report/process_loss_report/process_loss_report.py
@@ -2,6 +2,7 @@
 # For license information, please see license.txt
 
 import frappe
+from frappe import _
 from typing import Dict, List, Tuple
 
 Filters = frappe._dict
@@ -24,57 +25,57 @@ def get_data(filters: Filters) -> Data:
 def get_columns() -> Columns:
 	return [
 		{
-			'label': 'Work Order',
+			'label': _('Work Order'),
 			'fieldname': 'name',
 			'fieldtype': 'Link',
 			'options': 'Work Order',
 			'width': '200'
 		},
 		{
-			'label': 'Item',
+			'label': _('Item'),
 			'fieldname': 'production_item',
 			'fieldtype': 'Link',
 			'options': 'Item',
 			'width': '100'
 		},
 		{
-			'label': 'Status',
+			'label': _('Status'),
 			'fieldname': 'status',
 			'fieldtype': 'Data',
 			'width': '100'
 		},
 		{
-			'label': 'Manufactured Qty',
+			'label': _('Manufactured Qty'),
 			'fieldname': 'produced_qty',
 			'fieldtype': 'Float',
 			'width': '150'
 		},
 		{
-			'label': 'Loss Qty',
+			'label': _('Loss Qty'),
 			'fieldname': 'process_loss_qty',
 			'fieldtype': 'Float',
 			'width': '150'
 		},
 		{
-			'label': 'Actual Manufactured Qty',
+			'label': _('Actual Manufactured Qty'),
 			'fieldname': 'actual_produced_qty',
 			'fieldtype': 'Float',
 			'width': '150'
 		},
 		{
-			'label': 'Loss Value',
+			'label': _('Loss Value'),
 			'fieldname': 'total_pl_value',
 			'fieldtype': 'Float',
 			'width': '150'
 		},
 		{
-			'label': 'FG Value',
+			'label': _('FG Value'),
 			'fieldname': 'total_fg_value',
 			'fieldtype': 'Float',
 			'width': '150'
 		},
 		{
-			'label': 'Raw Material Value',
+			'label': _('Raw Material Value'),
 			'fieldname': 'total_rm_value',
 			'fieldtype': 'Float',
 			'width': '150'


### PR DESCRIPTION
### Description
Some noob forgot to call `_` on the labels in the Process Loss Report. Hence added them.