### PR TITLE
fix: mapping for company name lead->contact

### DIFF
--- a/erpnext/crm/doctype/lead/lead.py
+++ b/erpnext/crm/doctype/lead/lead.py
@@ -157,6 +157,7 @@ class Lead(SellingController):
 			"salutation": self.salutation,
 			"gender": self.gender,
 			"designation": self.designation,
+			"company_name": self.company_name,
 		})
 
 		if self.email_id:


### PR DESCRIPTION
Issue - Company name is not fetched in Contact doc which is created along with a Lead doc.