### PR TITLE
fix: Zero division error while fetching unconsumed materials

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -1200,10 +1200,10 @@ class StockEntry(StockController):
 
 			wo_item_qty = item.transferred_qty or item.required_qty
 
-			req_qty_each = (
-				(flt(wo_item_qty) - flt(item.consumed_qty)) /
-					(flt(work_order_qty) - flt(wo.produced_qty))
-			)
+			wo_qty_consumed = flt(wo_item_qty) - flt(item.consumed_qty)
+			wo_qty_to_produce = flt(work_order_qty) - flt(wo.produced_qty)
+
+			req_qty_each = (wo_qty_consumed) / (wo_qty_to_produce or 1)
 
 			qty = req_qty_each * flt(self.fg_completed_qty)
 
@@ -1582,7 +1582,7 @@ class StockEntry(StockController):
 			if material_request and material_request not in material_requests:
 				material_requests.append(material_request)
 				frappe.db.set_value('Material Request', material_request, 'transfer_status', status)
-				
+
 	def update_items_for_process_loss(self):
 		process_loss_dict = {}
 		for d in self.get("items"):


### PR DESCRIPTION
**Issue:**
```py
 File ".../apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.py", line 1003, in get_items
    self.get_unconsumed_raw_materials()
  File ".../apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.py", line 1200, in get_unconsumed_raw_materials
    (flt(work_order_qty) - flt(wo.produced_qty))
ZeroDivisionError: float division by zero
```