### PR TITLE
fix: General Ledger translation issues

### DIFF
--- a/.github/helper/semgrep_rules/report.yml
+++ b/.github/helper/semgrep_rules/report.yml
@@ -19,3 +19,16 @@ rules:
   languages: [python]
   severity: ERROR
 
+- id: frappe-translated-values-in-business-logic
+  paths:
+    include:
+    - "**/report"
+  patterns:
+    - pattern-inside: |
+        {..., filters: [...], ...}
+    - pattern: |
+        {..., options: [..., __("..."), ...], ...}
+  message: |
+      Using translated values in options field will require you to translate the values while comparing in business logic. Instead of passing translated labels provide objects that contain both label and value. e.g. { label: __("Option value"), value: "Option value"}
+  languages: [javascript]
+  severity: ERROR

--- a/erpnext/accounts/report/general_ledger/general_ledger.js
+++ b/erpnext/accounts/report/general_ledger/general_ledger.js
@@ -110,9 +110,9 @@ frappe.query_reports["General Ledger"] = {
 			"fieldname":"group_by",
 			"label": __("Group by"),
 			"fieldtype": "Select",
-			"options": ["", __("Group by Voucher"), __("Group by Voucher (Consolidated)"),
-				__("Group by Account"), __("Group by Party")],
-			"default": __("Group by Voucher (Consolidated)")
+			"options": ["", "Group by Voucher", "Group by Voucher (Consolidated)",
+				"Group by Account", "Group by Party"],
+			"default": "Group by Voucher (Consolidated)"
 		},
 		{
 			"fieldname":"tax_id",

--- a/erpnext/accounts/report/general_ledger/general_ledger.js
+++ b/erpnext/accounts/report/general_ledger/general_ledger.js
@@ -110,8 +110,25 @@ frappe.query_reports["General Ledger"] = {
 			"fieldname":"group_by",
 			"label": __("Group by"),
 			"fieldtype": "Select",
-			"options": ["", "Group by Voucher", "Group by Voucher (Consolidated)",
-				"Group by Account", "Group by Party"],
+			"options": [
+				"",
+				{
+					label: __("Group by Voucher"),
+					value: "Group by Voucher",
+				},
+				{
+					label: __("Group by Voucher (Consolidated)"),
+					value: "Group by Voucher (Consolidated)",
+				},
+				{
+					label: __("Group by Account"),
+					value: "Group by Account",
+				},
+				{
+					label: __("Group by Party"),
+					value: "Group by Party",
+				},
+			],
 			"default": "Group by Voucher (Consolidated)"
 		},
 		{

--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -62,14 +62,14 @@ def validate_filters(filters, account_details):
 			if not account_details.get(account):
 				frappe.throw(_("Account {0} does not exists").format(account))
 
-	if (filters.get("account") and filters.get("group_by") == _('Group by Account')):
+	if (filters.get("account") and filters.get("group_by") == 'Group by Account'):
 		filters.account = frappe.parse_json(filters.get('account'))
 		for account in filters.account:
 			if account_details[account].is_group == 0:
 				frappe.throw(_("Can not filter based on Child Account, if grouped by Account"))
 
 	if (filters.get("voucher_no")
-		and filters.get("group_by") in [_('Group by Voucher')]):
+		and filters.get("group_by") in ['Group by Voucher']):
 		frappe.throw(_("Can not filter based on Voucher No, if grouped by Voucher"))
 
 	if filters.from_date > filters.to_date:
@@ -153,7 +153,7 @@ def get_gl_entries(filters, accounting_dimensions):
 	if filters.get("include_dimensions"):
 		order_by_statement = "order by posting_date, creation"
 
-	if filters.get("group_by") == _("Group by Voucher"):
+	if filters.get("group_by") == "Group by Voucher":
 		order_by_statement = "order by posting_date, voucher_type, voucher_no"
 
 	if filters.get("include_default_book_entries"):
@@ -312,13 +312,13 @@ def get_data_with_opening_closing(filters, account_details, accounting_dimension
 	# Opening for filtered account
 	data.append(totals.opening)
 
-	if filters.get("group_by") != _('Group by Voucher (Consolidated)'):
+	if filters.get("group_by") != 'Group by Voucher (Consolidated)':
 		for acc, acc_dict in iteritems(gle_map):
 			# acc
 			if acc_dict.entries:
 				# opening
 				data.append({})
-				if filters.get("group_by") != _("Group by Voucher"):
+				if filters.get("group_by") != "Group by Voucher":
 					data.append(acc_dict.totals.opening)
 
 				data += acc_dict.entries
@@ -327,7 +327,7 @@ def get_data_with_opening_closing(filters, account_details, accounting_dimension
 				data.append(acc_dict.totals.total)
 
 				# closing
-				if filters.get("group_by") != _("Group by Voucher"):
+				if filters.get("group_by") != "Group by Voucher":
 					data.append(acc_dict.totals.closing)
 		data.append({})
 	else:
@@ -357,9 +357,9 @@ def get_totals_dict():
 	)
 
 def group_by_field(group_by):
-	if group_by == _('Group by Party'):
+	if group_by == 'Group by Party':
 		return 'party'
-	elif group_by in [_('Group by Voucher (Consolidated)'), _('Group by Account')]:
+	elif group_by in ['Group by Voucher (Consolidated)', 'Group by Account']:
 		return 'account'
 	else:
 		return 'voucher_no'
@@ -423,9 +423,9 @@ def get_accountwise_gle(filters, accounting_dimensions, gl_entries, gle_map):
 		elif gle.posting_date <= to_date:
 			update_value_in_dict(gle_map[gle.get(group_by)].totals, 'total', gle)
 			update_value_in_dict(totals, 'total', gle)
-			if filters.get("group_by") != _('Group by Voucher (Consolidated)'):
+			if filters.get("group_by") != 'Group by Voucher (Consolidated)':
 				gle_map[gle.get(group_by)].entries.append(gle)
-			elif filters.get("group_by") == _('Group by Voucher (Consolidated)'):
+			elif filters.get("group_by") == 'Group by Voucher (Consolidated)':
 				keylist = [gle.get("voucher_type"), gle.get("voucher_no"), gle.get("account")]
 				for dim in accounting_dimensions:
 					keylist.append(gle.get(dim))


### PR DESCRIPTION
Options of group_by filter are translated. Assertions were made against English sentences and hence would always return false in cases where English isn't the system language.

Solution: don't translate options server side. Only displayed labels are translated client side. 

closes #27277 
