### PR TITLE
fix: Braintree payment processed twice

### DIFF
--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -550,5 +550,3 @@ def validate_payment(doc, method=""):
 	status = frappe.db.get_value(doc.reference_doctype, doc.reference_docname, 'status')
 	if status == 'Paid':
 		frappe.throw(_("The Payment Request {0} is already paid, cannot process payment twice").format(doc.reference_docname))
-	else:
-		return

--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -543,14 +543,12 @@ def make_payment_order(source_name, target_doc=None):
 
 	return doclist
 
+def validate_payment(doc, method=""):
+	if not frappe.db.has_column(doc.reference_doctype, 'status'):
+		return
 
-def validate_payment(doc, method):
 	status = frappe.db.get_value(doc.reference_doctype, doc.reference_docname, 'status')
 	if status == 'Paid':
-		frappe.log_error("The Payment Request {0} is already paid, cannot process payment twice".format(doc.reference_docname))
-		return{
-			"redirect_to": frappe.redirect_to_message(_('Server Error'), _("The Payment Request {0} is already paid, cannot process payment twice").format(doc.reference_docname)),
-			"status": 401
-		}
+		frappe.throw(_("The Payment Request {0} is already paid, cannot process payment twice").format(doc.reference_docname))
 	else:
 		return

--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -549,7 +549,7 @@ def validate_payment(doc, method):
 	if status == 'Paid':
 		frappe.log_error("The Payment Request {0} is already paid, cannot process payment twice".format(doc.reference_docname))
 		return{
-			"redirect_to": frappe.redirect_to_message(_('Server Error'), _("The Payment Request {0} is already paid, cannot process payment twice".format(doc.reference_docname))),
+			"redirect_to": frappe.redirect_to_message(_('Server Error'), _("The Payment Request {0} is already paid, cannot process payment twice").format(doc.reference_docname)),
 			"status": 401
 		}
 	else:

--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -542,3 +542,15 @@ def make_payment_order(source_name, target_doc=None):
 	}, target_doc, set_missing_values)
 
 	return doclist
+
+
+def validate_payment(doc, method):
+	status = frappe.db.get_value(doc.reference_doctype, doc.reference_docname, 'status')
+	if status == 'Paid':
+		frappe.log_error("The Payment Request {0} is already paid, cannot process payment twice".format(doc.reference_docname))
+		return{
+			"redirect_to": frappe.redirect_to_message(_('Server Error'), _("The Payment Request {0} is already paid, cannot process payment twice".format(doc.reference_docname))),
+			"status": 401
+		}
+	else:
+		return

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -316,6 +316,9 @@ doc_events = {
 	},
 	"Company": {
 		"on_trash": "erpnext.regional.india.utils.delete_gst_settings_for_company"
+	},
+	"Integration Request": {
+		"validate": "erpnext.accounts.doctype.payment_request.payment_request.validate_payment"
 	}
 }
 


### PR DESCRIPTION
**Problem:**
Paid twice by clicking on the same payment link, creates a second integration request for the exact same payment request as before and no payment entry is created for the second payment

**Solution:**
Added a validation method to check if the Payment Request is already paid

**Ref Issue:** ISS-21-22-05023