### PR TITLE
fix: Move related fields together in Selling Settings

### DIFF
--- a/erpnext/selling/doctype/selling_settings/selling_settings.json
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.json
@@ -18,17 +18,18 @@
   "close_opportunity_after_days",
   "item_price_settings_section",
   "selling_price_list",
+  "maintain_same_rate_action",
+  "role_to_override_stop_action",
   "column_break_15",
   "maintain_same_sales_rate",
-  "maintain_same_rate_action",
   "editable_price_list_rate",
   "validate_selling_price",
+  "editable_bundle_item_rates",
   "sales_transactions_settings_section",
   "so_required",
   "dn_required",
   "sales_update_frequency",
   "column_break_5",
-  "role_to_override_stop_action",
   "allow_multiple_items",
   "allow_against_multiple_purchase_orders",
   "hide_tax_id"
@@ -191,6 +192,12 @@
    "fieldname": "sales_transactions_settings_section",
    "fieldtype": "Section Break",
    "label": "Transaction Settings"
+  },
+  {
+   "default": "0",
+   "fieldname": "editable_bundle_item_rates",
+   "fieldtype": "Check",
+   "label": "Calculate Product Bundle Price based on Child Items' Rates"
   }
  ],
  "icon": "fa fa-cog",
@@ -198,7 +205,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2021-08-06 22:25:50.119458",
+ "modified": "2021-09-01 22:47:24.298970",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Selling Settings",

--- a/erpnext/selling/doctype/selling_settings/selling_settings.json
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.json
@@ -154,7 +154,7 @@
    "options": "Stop\nWarn"
   },
   {
-   "depends_on": "eval: doc.maintain_same_rate_action == 'Stop'",
+   "depends_on": "eval: doc.maintain_same_sales_rate && doc.maintain_same_rate_action == 'Stop'",
    "fieldname": "role_to_override_stop_action",
    "fieldtype": "Link",
    "label": "Role Allowed to Override Stop Action",
@@ -204,7 +204,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2021-09-01 22:48:30.860203",
+ "modified": "2021-09-01 22:53:53.394444",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Selling Settings",

--- a/erpnext/selling/doctype/selling_settings/selling_settings.json
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.json
@@ -149,7 +149,7 @@
    "depends_on": "maintain_same_sales_rate",
    "fieldname": "maintain_same_rate_action",
    "fieldtype": "Select",
-   "label": "Action if Same Rate is Not Maintained",
+   "label": "Action if Same Rate is Not Maintained Throughout Sales Cycle",
    "mandatory_depends_on": "maintain_same_sales_rate",
    "options": "Stop\nWarn"
   },
@@ -204,7 +204,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2021-09-01 22:53:53.394444",
+ "modified": "2021-09-01 22:55:33.803624",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Selling Settings",

--- a/erpnext/selling/doctype/selling_settings/selling_settings.json
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.json
@@ -147,7 +147,6 @@
   {
    "default": "Stop",
    "depends_on": "maintain_same_sales_rate",
-   "description": "Configure the action to stop the transaction or just warn if the same rate is not maintained.",
    "fieldname": "maintain_same_rate_action",
    "fieldtype": "Select",
    "label": "Action if Same Rate is Not Maintained",
@@ -205,7 +204,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2021-09-01 22:47:24.298970",
+ "modified": "2021-09-01 22:48:30.860203",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Selling Settings",


### PR DESCRIPTION
### Before:

- Related fields are in different sections.

![Screenshot 2021-09-01 at 10 44 32 PM](https://user-images.githubusercontent.com/25903035/131716515-835e9024-0508-44d5-87d0-cfb8b943ce48.png)

- Unchecking 'Maintain Same Rate Throughout Sales Cycle' makes 'Action if Same Rate is Not Maintained' disappear, but not 'Role Allowed to Override Stop Action', which is dependant on 'Action if Same Rate is Not Maintained'.

![Screenshot 2021-09-01 at 10 45 25 PM](https://user-images.githubusercontent.com/25903035/131716827-433ef4a0-0fcb-4f08-bf5e-788bb0aa4bf0.png)

- Redundant description.

![Screenshot 2021-09-01 at 10 46 04 PM](https://user-images.githubusercontent.com/25903035/131716877-413d8704-f1eb-4a4e-923f-15c2537bbdc4.png)

### After:

- Move all related fields to the same section.

![Screenshot 2021-09-01 at 11 02 27 PM](https://user-images.githubusercontent.com/25903035/131717259-595babfc-7b54-4e58-a4cf-95669ab74e87.png)

- Make display for both 'Action if Same Rate is Not Maintained Throughout Sales Cycle' and 'Role Allowed to Override Stop Action' depend on 'Maintain Same Rate Throughout Sales Cycle'.

_When unchecked:_

![Screenshot 2021-09-01 at 11 05 58 PM](https://user-images.githubusercontent.com/25903035/131717632-1f0844a4-a93f-40dd-b267-2323e7d7a2c1.png)

_When checked:_

![Screenshot 2021-09-01 at 11 02 27 PM](https://user-images.githubusercontent.com/25903035/131717259-595babfc-7b54-4e58-a4cf-95669ab74e87.png)

- Rename 'Action if Same Rate is Not Maintained' to 'Action if Same Rate is Not Maintained Throughout Sales Cycle' and remove redundant description.

![Screenshot 2021-09-01 at 11 06 53 PM](https://user-images.githubusercontent.com/25903035/131717830-a79ce422-f436-46ed-8596-c0bea57be23a.png)
