### PR TITLE
fix(patch): delete stale shopify doctypes

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -302,3 +302,4 @@ erpnext.patches.v13_0.custom_fields_for_taxjar_integration
 erpnext.patches.v14_0.delete_einvoicing_doctypes
 erpnext.patches.v13_0.set_operation_time_based_on_operating_cost
 erpnext.patches.v13_0.validate_options_for_data_field
+erpnext.patches.v14_0.delete_shopify_doctypes

--- a/erpnext/patches/v14_0/delete_shopify_doctypes.py
+++ b/erpnext/patches/v14_0/delete_shopify_doctypes.py
@@ -1,0 +1,5 @@
+import frappe
+
+def execute():
+	frappe.delete_doc("DocType", "Shopify Settings", ignore_missing=True)
+	frappe.delete_doc("DocType", "Shopify Log", ignore_missing=True)


### PR DESCRIPTION
- Add a patch to remove Shopify doctypes. 

missed out in https://github.com/frappe/erpnext/pull/26700