### PR TITLE
fix: Presentation currency conversion in reports

### DIFF
--- a/erpnext/accounts/report/utils.py
+++ b/erpnext/accounts/report/utils.py
@@ -98,15 +98,15 @@ def convert_to_presentation_currency(gl_entries, currency_info, company):
 			if entry.get('credit'):
 				entry['credit'] = credit_in_account_currency
 		else:
-			value = debit or credit
 			date = currency_info['report_date']
-			converted_value = convert(value, presentation_currency, company_currency, date)
+			converted_debit_value = convert(debit, presentation_currency, company_currency, date)
+			converted_credit_value = convert(credit, presentation_currency, company_currency, date)
 
 			if entry.get('debit'):
-				entry['debit'] = converted_value
+				entry['debit'] = converted_debit_value
 
 			if entry.get('credit'):
-				entry['credit'] = converted_value
+				entry['credit'] = converted_credit_value
 
 		converted_gl_list.append(entry)
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/42651287/131847446-2124250f-1bbe-4bef-b119-b7ae3840f28a.png)

As shown in the image above there could be cases where a single GL might have both Debit and Credit values

Currently, the function used to convert values to presentation currency assumed that one GL Entry will either have debit or credit value while led to wrong values in the reports when a presentation currency was selected
