### PR TITLE
fix: Paging and Discount filter

### DIFF
--- a/erpnext/e_commerce/api.py
+++ b/erpnext/e_commerce/api.py
@@ -27,6 +27,7 @@ def get_product_filter_data(query_args=None):
 	if isinstance(query_args, str):
 		query_args = json.loads(query_args)
 
+	query_args = frappe._dict(query_args)
 	if query_args:
 		search = query_args.get("search")
 		field_filters = query_args.get("field_filters", {})

--- a/erpnext/e_commerce/product_data_engine/query.py
+++ b/erpnext/e_commerce/product_data_engine/query.py
@@ -287,7 +287,7 @@ class ProductQuery:
 	def filter_results_by_discount(self, fields, result):
 		if fields and fields.get("discount"):
 			discount_percent = frappe.utils.flt(fields["discount"][0])
-			result = [row for row in result if row.get("discount_percent") and row.discount_percent >= discount_percent]
+			result = [row for row in result if row.get("discount_percent") and row.discount_percent <= discount_percent]
 
 		if self.filter_with_discount:
 			# no limit was added to results while querying

--- a/erpnext/e_commerce/product_data_engine/test_product_data_engine.py
+++ b/erpnext/e_commerce/product_data_engine/test_product_data_engine.py
@@ -265,10 +265,9 @@ class TestProductDataEngine(unittest.TestCase):
 		)
 		items = result.get("items")
 
-		# check if only product with 10% and below discount are fetched in the right order
-		self.assertEqual(len(items), 2)
-		self.assertEqual(items[0].get("item_code"), "Test 13I Laptop")
-		self.assertEqual(items[1].get("item_code"), "Test 12I Laptop")
+		# check if only product with 10% and below discount are fetched
+		self.assertEqual(len(items), 1)
+		self.assertEqual(items[0].get("item_code"), "Test 12I Laptop")
 
 	def test_product_list_with_api(self):
 		"Test products listing using API."

--- a/erpnext/regional/report/gstr_1/gstr_1.py
+++ b/erpnext/regional/report/gstr_1/gstr_1.py
@@ -50,7 +50,7 @@ class Gstr1Report(object):
 			self.get_invoice_items()
 			self.get_items_based_on_tax_rate()
 			self.invoice_fields = [d["fieldname"] for d in self.invoice_columns]
-		
+
 		self.get_data()
 
 		return self.columns, self.data
@@ -709,7 +709,7 @@ class Gstr1Report(object):
 						"width": 100
 				}
 			]
-			
+
 		self.columns = self.invoice_columns + self.tax_columns + self.other_columns
 
 @frappe.whitelist()


### PR DESCRIPTION
**Issue:**
- Paging button breaks
- Due to change from `10% and above` to `10% and below`, filtering broke due to not changing filter behaviour in `api.py`

**Fix:**
- Convert incoming api args to frappe dict
- Change discount filter condition due to reversal of behaviour