### PR TITLE
fix: Prematurely referenced variable in buying controller for subcontracting

### DIFF
--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -983,11 +983,11 @@ def get_non_stock_items(purchase_order, fg_item_code):
 def set_serial_nos(raw_material, consumed_serial_nos, qty):
 	consumed_serial_nos_list = []
 
-	if isinstance(consumed_serial_nos, list):
+	if consumed_serial_nos and isinstance(consumed_serial_nos, list):
 		for row in consumed_serial_nos:
 			consumed_serial_nos_list.extend(get_serial_nos(row))
-	else:
-		consumed_serial_nos_list = get_serial_nos(row)
+	elif consumed_serial_nos:
+		consumed_serial_nos_list = get_serial_nos(consumed_serial_nos)
 
 	serial_nos = set(get_serial_nos(raw_material.serial_nos)) - set(consumed_serial_nos_list)
 


### PR DESCRIPTION
**Issue:**
Introduced via https://github.com/frappe/erpnext/pull/26423
```py
File ".../apps/erpnext/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py", line 74, in validate
    super(PurchaseReceipt, self).validate()
  File ".../apps/erpnext/erpnext/controllers/buying_controller.py", line 61, in validate
    self.create_raw_materials_supplied("supplied_items")
  File ".../erpnext/erpnext/controllers/buying_controller.py", line 239, in create_raw_materials_supplied
    self.update_raw_materials_supplied_based_on_stock_entries()
  File ".../apps/erpnext/erpnext/controllers/buying_controller.py", line 325, in update_raw_materials_supplied_based_on_stock_entries
    set_serial_nos(raw_material, consumed_serial_nos, qty)
  File ".../apps/erpnext/erpnext/controllers/buying_controller.py", line 990, in set_serial_nos
    consumed_serial_nos_list = get_serial_nos(row)
UnboundLocalError: local variable 'row' referenced before assignment
```

**Fix**:
- Pass `consumed_serial_nos` to `get_serial_nos`
- Check if `consumed_serial_nos` is truthy