### PR TITLE
fix: added checkbox show remarks in the filters for AR & AP reports

### DIFF
--- a/erpnext/accounts/report/accounts_payable/accounts_payable.js
+++ b/erpnext/accounts/report/accounts_payable/accounts_payable.js
@@ -4,7 +4,7 @@
 frappe.query_reports["Accounts Payable"] = {
 	"filters": [
 		{
-			"fieldname":"company",
+			"fieldname": "company",
 			"label": __("Company"),
 			"fieldtype": "Link",
 			"options": "Company",
@@ -12,19 +12,19 @@ frappe.query_reports["Accounts Payable"] = {
 			"default": frappe.defaults.get_user_default("Company")
 		},
 		{
-			"fieldname":"report_date",
+			"fieldname": "report_date",
 			"label": __("Posting Date"),
 			"fieldtype": "Date",
 			"default": frappe.datetime.get_today()
 		},
 		{
-			"fieldname":"finance_book",
+			"fieldname": "finance_book",
 			"label": __("Finance Book"),
 			"fieldtype": "Link",
 			"options": "Finance Book"
 		},
 		{
-			"fieldname":"cost_center",
+			"fieldname": "cost_center",
 			"label": __("Cost Center"),
 			"fieldtype": "Link",
 			"options": "Cost Center",
@@ -38,7 +38,7 @@ frappe.query_reports["Accounts Payable"] = {
 			}
 		},
 		{
-			"fieldname":"supplier",
+			"fieldname": "supplier",
 			"label": __("Supplier"),
 			"fieldtype": "Link",
 			"options": "Supplier",
@@ -54,48 +54,48 @@ frappe.query_reports["Accounts Payable"] = {
 			}
 		},
 		{
-			"fieldname":"ageing_based_on",
+			"fieldname": "ageing_based_on",
 			"label": __("Ageing Based On"),
 			"fieldtype": "Select",
 			"options": 'Posting Date\nDue Date\nSupplier Invoice Date',
 			"default": "Due Date"
 		},
 		{
-			"fieldname":"range1",
+			"fieldname": "range1",
 			"label": __("Ageing Range 1"),
 			"fieldtype": "Int",
 			"default": "30",
 			"reqd": 1
 		},
 		{
-			"fieldname":"range2",
+			"fieldname": "range2",
 			"label": __("Ageing Range 2"),
 			"fieldtype": "Int",
 			"default": "60",
 			"reqd": 1
 		},
 		{
-			"fieldname":"range3",
+			"fieldname": "range3",
 			"label": __("Ageing Range 3"),
 			"fieldtype": "Int",
 			"default": "90",
 			"reqd": 1
 		},
 		{
-			"fieldname":"range4",
+			"fieldname": "range4",
 			"label": __("Ageing Range 4"),
 			"fieldtype": "Int",
 			"default": "120",
 			"reqd": 1
 		},
 		{
-			"fieldname":"payment_terms_template",
+			"fieldname": "payment_terms_template",
 			"label": __("Payment Terms Template"),
 			"fieldtype": "Link",
 			"options": "Payment Terms Template"
 		},
 		{
-			"fieldname":"supplier_group",
+			"fieldname": "supplier_group",
 			"label": __("Supplier Group"),
 			"fieldtype": "Link",
 			"options": "Supplier Group"
@@ -106,17 +106,17 @@ frappe.query_reports["Accounts Payable"] = {
 			"fieldtype": "Check"
 		},
 		{
-			"fieldname":"based_on_payment_terms",
+			"fieldname": "based_on_payment_terms",
 			"label": __("Based On Payment Terms"),
 			"fieldtype": "Check",
 		},
 		{
-			"fieldname":"show_remarks",
+			"fieldname": "show_remarks",
 			"label": __("Show Remarks"),
 			"fieldtype": "Check",
 		},
 		{
-			"fieldname":"tax_id",
+			"fieldname": "tax_id",
 			"label": __("Tax Id"),
 			"fieldtype": "Data",
 			"hidden": 1

--- a/erpnext/accounts/report/accounts_payable/accounts_payable.js
+++ b/erpnext/accounts/report/accounts_payable/accounts_payable.js
@@ -111,6 +111,11 @@ frappe.query_reports["Accounts Payable"] = {
 			"fieldtype": "Check",
 		},
 		{
+			"fieldname":"show_remarks",
+			"label": __("Show Remarks"),
+			"fieldtype": "Check",
+		},
+		{
 			"fieldname":"tax_id",
 			"label": __("Tax Id"),
 			"fieldtype": "Data",

--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.js
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.js
@@ -4,7 +4,7 @@
 frappe.query_reports["Accounts Receivable"] = {
 	"filters": [
 		{
-			"fieldname":"company",
+			"fieldname": "company",
 			"label": __("Company"),
 			"fieldtype": "Link",
 			"options": "Company",
@@ -12,19 +12,19 @@ frappe.query_reports["Accounts Receivable"] = {
 			"default": frappe.defaults.get_user_default("Company")
 		},
 		{
-			"fieldname":"report_date",
+			"fieldname": "report_date",
 			"label": __("Posting Date"),
 			"fieldtype": "Date",
 			"default": frappe.datetime.get_today()
 		},
 		{
-			"fieldname":"finance_book",
+			"fieldname": "finance_book",
 			"label": __("Finance Book"),
 			"fieldtype": "Link",
 			"options": "Finance Book"
 		},
 		{
-			"fieldname":"cost_center",
+			"fieldname": "cost_center",
 			"label": __("Cost Center"),
 			"fieldtype": "Link",
 			"options": "Cost Center",
@@ -38,7 +38,7 @@ frappe.query_reports["Accounts Receivable"] = {
 			}
 		},
 		{
-			"fieldname":"customer",
+			"fieldname": "customer",
 			"label": __("Customer"),
 			"fieldtype": "Link",
 			"options": "Customer",
@@ -67,66 +67,66 @@ frappe.query_reports["Accounts Receivable"] = {
 			}
 		},
 		{
-			"fieldname":"ageing_based_on",
+			"fieldname": "ageing_based_on",
 			"label": __("Ageing Based On"),
 			"fieldtype": "Select",
 			"options": 'Posting Date\nDue Date',
 			"default": "Due Date"
 		},
 		{
-			"fieldname":"range1",
+			"fieldname": "range1",
 			"label": __("Ageing Range 1"),
 			"fieldtype": "Int",
 			"default": "30",
 			"reqd": 1
 		},
 		{
-			"fieldname":"range2",
+			"fieldname": "range2",
 			"label": __("Ageing Range 2"),
 			"fieldtype": "Int",
 			"default": "60",
 			"reqd": 1
 		},
 		{
-			"fieldname":"range3",
+			"fieldname": "range3",
 			"label": __("Ageing Range 3"),
 			"fieldtype": "Int",
 			"default": "90",
 			"reqd": 1
 		},
 		{
-			"fieldname":"range4",
+			"fieldname": "range4",
 			"label": __("Ageing Range 4"),
 			"fieldtype": "Int",
 			"default": "120",
 			"reqd": 1
 		},
 		{
-			"fieldname":"customer_group",
+			"fieldname": "customer_group",
 			"label": __("Customer Group"),
 			"fieldtype": "Link",
 			"options": "Customer Group"
 		},
 		{
-			"fieldname":"payment_terms_template",
+			"fieldname": "payment_terms_template",
 			"label": __("Payment Terms Template"),
 			"fieldtype": "Link",
 			"options": "Payment Terms Template"
 		},
 		{
-			"fieldname":"sales_partner",
+			"fieldname": "sales_partner",
 			"label": __("Sales Partner"),
 			"fieldtype": "Link",
 			"options": "Sales Partner"
 		},
 		{
-			"fieldname":"sales_person",
+			"fieldname": "sales_person",
 			"label": __("Sales Person"),
 			"fieldtype": "Link",
 			"options": "Sales Person"
 		},
 		{
-			"fieldname":"territory",
+			"fieldname": "territory",
 			"label": __("Territory"),
 			"fieldtype": "Link",
 			"options": "Territory"
@@ -137,50 +137,50 @@ frappe.query_reports["Accounts Receivable"] = {
 			"fieldtype": "Check"
 		},
 		{
-			"fieldname":"based_on_payment_terms",
+			"fieldname": "based_on_payment_terms",
 			"label": __("Based On Payment Terms"),
 			"fieldtype": "Check",
 		},
 		{
-			"fieldname":"show_future_payments",
+			"fieldname": "show_future_payments",
 			"label": __("Show Future Payments"),
 			"fieldtype": "Check",
 		},
 		{
-			"fieldname":"show_delivery_notes",
+			"fieldname": "show_delivery_notes",
 			"label": __("Show Linked Delivery Notes"),
 			"fieldtype": "Check",
 		},
 		{
-			"fieldname":"show_sales_person",
+			"fieldname": "show_sales_person",
 			"label": __("Show Sales Person"),
 			"fieldtype": "Check",
 		},
 		{
-			"fieldname":"show_remarks",
+			"fieldname": "show_remarks",
 			"label": __("Show Remarks"),
 			"fieldtype": "Check",
 		},
 		{
-			"fieldname":"tax_id",
+			"fieldname": "tax_id",
 			"label": __("Tax Id"),
 			"fieldtype": "Data",
 			"hidden": 1
 		},
 		{
-			"fieldname":"customer_name",
+			"fieldname": "customer_name",
 			"label": __("Customer Name"),
 			"fieldtype": "Data",
 			"hidden": 1
 		},
 		{
-			"fieldname":"payment_terms",
+			"fieldname": "payment_terms",
 			"label": __("Payment Tems"),
 			"fieldtype": "Data",
 			"hidden": 1
 		},
 		{
-			"fieldname":"credit_limit",
+			"fieldname": "credit_limit",
 			"label": __("Credit Limit"),
 			"fieldtype": "Currency",
 			"hidden": 1

--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.js
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.js
@@ -157,6 +157,11 @@ frappe.query_reports["Accounts Receivable"] = {
 			"fieldtype": "Check",
 		},
 		{
+			"fieldname":"show_remarks",
+			"label": __("Show Remarks"),
+			"fieldtype": "Check",
+		},
+		{
 			"fieldname":"tax_id",
 			"label": __("Tax Id"),
 			"fieldtype": "Data",

--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -106,6 +106,7 @@ class ReceivablePayableReport(object):
 					party = gle.party,
 					posting_date = gle.posting_date,
 					account_currency = gle.account_currency,
+					remarks = gle.remarks,
 					invoiced = 0.0,
 					paid = 0.0,
 					credit_note = 0.0,
@@ -586,7 +587,7 @@ class ReceivablePayableReport(object):
 		self.gl_entries = frappe.db.sql("""
 			select
 				name, posting_date, account, party_type, party, voucher_type, voucher_no, cost_center,
-				against_voucher_type, against_voucher, account_currency, {0}
+				against_voucher_type, against_voucher, account_currency, remarks, {0}
 			from
 				`tabGL Entry`
 			where
@@ -754,6 +755,7 @@ class ReceivablePayableReport(object):
 		self.add_column(label=_('Voucher Type'), fieldname='voucher_type', fieldtype='Data')
 		self.add_column(label=_('Voucher No'), fieldname='voucher_no', fieldtype='Dynamic Link',
 			options='voucher_type', width=180)
+		self.add_column(label=_('Remarks'), fieldname='remarks', fieldtype='Text', width=200),
 		self.add_column(label='Due Date', fieldtype='Date')
 
 		if self.party_type == "Supplier":

--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -106,7 +106,7 @@ class ReceivablePayableReport(object):
 					party = gle.party,
 					posting_date = gle.posting_date,
 					account_currency = gle.account_currency,
-					remarks = gle.remarks,
+					remarks = gle.remarks if self.filters.get("show_remarks") else None,
 					invoiced = 0.0,
 					paid = 0.0,
 					credit_note = 0.0,
@@ -584,10 +584,12 @@ class ReceivablePayableReport(object):
 		else:
 			select_fields = "debit, credit"
 
+		remarks = ", remarks" if self.filters.get("show_remarks") else ""
+
 		self.gl_entries = frappe.db.sql("""
 			select
 				name, posting_date, account, party_type, party, voucher_type, voucher_no, cost_center,
-				against_voucher_type, against_voucher, account_currency, remarks, {0}
+				against_voucher_type, against_voucher, account_currency, {0} {remarks}
 			from
 				`tabGL Entry`
 			where
@@ -596,7 +598,7 @@ class ReceivablePayableReport(object):
 				and party_type=%s
 				and (party is not null and party != '')
 				{1} {2} {3}"""
-			.format(select_fields, date_condition, conditions, order_by), values, as_dict=True)
+			.format(select_fields, date_condition, conditions, order_by, remarks=remarks), values, as_dict=True)
 
 	def get_sales_invoices_or_customers_based_on_sales_person(self):
 		if self.filters.get("sales_person"):
@@ -755,7 +757,10 @@ class ReceivablePayableReport(object):
 		self.add_column(label=_('Voucher Type'), fieldname='voucher_type', fieldtype='Data')
 		self.add_column(label=_('Voucher No'), fieldname='voucher_no', fieldtype='Dynamic Link',
 			options='voucher_type', width=180)
-		self.add_column(label=_('Remarks'), fieldname='remarks', fieldtype='Text', width=200),
+
+		if self.filters.show_remarks:
+			self.add_column(label=_('Remarks'), fieldname='remarks', fieldtype='Text', width=200),
+
 		self.add_column(label='Due Date', fieldtype='Date')
 
 		if self.party_type == "Supplier":


### PR DESCRIPTION
Added checkbox 'Show Remarks' in the filters to add column 'Remarks' whenever required in the reports Accounts Receivable & Accounts Payable.

![ezgif com-gif-maker (4)](https://user-images.githubusercontent.com/60467153/132516291-5a2a84fc-036b-4ebd-bb8b-cd2c93f23447.gif)

