### PR TITLE
ci: fix docs checker for wiki based docs

### DIFF
--- a/.github/helper/documentation.py
+++ b/.github/helper/documentation.py
@@ -24,6 +24,8 @@ def docs_link_exists(body):
 					parts = parsed_url.path.split('/')
 					if len(parts) == 5 and parts[1] == "frappe" and parts[2] in docs_repos:
 						return True
+				elif parsed_url.netloc == "docs.erpnext.com":
+					return True
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

Problem: Links to new wiki based documents don't pass the docs check in CI


New docs: https://docs.erpnext.com/docs/v13/user/manual/en/introduction 


(note: "feat" in pr title is just for demonstration, will change it later)