### PR TITLE
fix: document naming rule not working for subscription invoices

### DIFF
--- a/erpnext/accounts/doctype/subscription/subscription.py
+++ b/erpnext/accounts/doctype/subscription/subscription.py
@@ -400,6 +400,7 @@ class Subscription(Document):
 
 		invoice.flags.ignore_mandatory = True
 
+		invoice.set_missing_values()
 		invoice.save()
 
 		if self.submit_invoice:


### PR DESCRIPTION
Document Naming Rule on Sales Invoice

<img width="1180" alt="CleanShot 2021-09-08 at 13 46 37@2x" src="https://user-images.githubusercontent.com/25369014/132472632-d3ad6a5e-df41-4dba-bcea-868bc2f66749.png">

Created a Subscription for the Company associated with that Company GSTIN

Now clicking on Fetch Subscription Updates on the Subscription document creates a Sales Invoice with default naming instead of following the Document Naming Rule.

This is because the Company GSTIN is set in the `validate` method of Sales Invoice while the naming is set before `validate`, hence while setting the name, the Company GSTIN condition is `false`
