### PR TITLE
fix: Autoname for customer and supplier

### DIFF
--- a/erpnext/buying/doctype/buying_settings/buying_settings.json
+++ b/erpnext/buying/doctype/buying_settings/buying_settings.json
@@ -28,7 +28,7 @@
    "fieldname": "supp_master_name",
    "fieldtype": "Select",
    "label": "Supplier Naming By",
-   "options": "Supplier Name\nNaming Series"
+   "options": "Supplier Name\nNaming Series\nAuto Name"
   },
   {
    "fieldname": "supplier_group",
@@ -123,7 +123,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2021-06-24 10:38:28.934525",
+ "modified": "2021-09-08 19:26:23.548837",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Buying Settings",

--- a/erpnext/buying/doctype/supplier/supplier.py
+++ b/erpnext/buying/doctype/supplier/supplier.py
@@ -10,7 +10,7 @@ from frappe.contacts.address_and_contact import (
 	delete_contact_and_address,
 	load_address_and_contact,
 )
-from frappe.model.naming import set_name_by_naming_series
+from frappe.model.naming import set_name_by_naming_series, set_name_from_naming_options
 
 from erpnext.accounts.party import get_dashboard_info, validate_party_accounts
 from erpnext.utilities.transaction_base import TransactionBase
@@ -40,8 +40,10 @@ class Supplier(TransactionBase):
 		supp_master_name = frappe.defaults.get_global_default('supp_master_name')
 		if supp_master_name == 'Supplier Name':
 			self.name = self.supplier_name
-		else:
+		elif supp_master_name == 'Naming Series':
 			set_name_by_naming_series(self)
+		else:
+			self.name = set_name_from_naming_options(frappe.get_meta(self.doctype).autoname, self)
 
 	def on_update(self):
 		if not self.naming_series:

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -14,7 +14,7 @@ from frappe.contacts.address_and_contact import (
 )
 from frappe.desk.reportview import build_match_conditions, get_filters_cond
 from frappe.model.mapper import get_mapped_doc
-from frappe.model.naming import set_name_by_naming_series
+from frappe.model.naming import set_name_by_naming_series, set_name_from_naming_options
 from frappe.model.rename_doc import update_linked_doctypes
 from frappe.utils import cint, cstr, flt, get_formatted_email, today
 from frappe.utils.user import get_users_with_role
@@ -40,8 +40,10 @@ class Customer(TransactionBase):
 		cust_master_name = frappe.defaults.get_global_default('cust_master_name')
 		if cust_master_name == 'Customer Name':
 			self.name = self.get_customer_name()
-		else:
+		elif cust_master_name == 'Naming Series':
 			set_name_by_naming_series(self)
+		else:
+			self.name = set_name_from_naming_options(frappe.get_meta(self.doctype).autoname, self)
 
 	def get_customer_name(self):
 

--- a/erpnext/selling/doctype/selling_settings/selling_settings.json
+++ b/erpnext/selling/doctype/selling_settings/selling_settings.json
@@ -41,14 +41,14 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Customer Naming By",
-   "options": "Customer Name\nNaming Series"
+   "options": "Customer Name\nNaming Series\nAuto Name"
   },
   {
    "fieldname": "campaign_naming_by",
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Campaign Naming By",
-   "options": "Campaign Name\nNaming Series"
+   "options": "Campaign Name\nNaming Series\nAuto Name"
   },
   {
    "fieldname": "customer_group",
@@ -204,7 +204,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2021-09-01 22:55:33.803624",
+ "modified": "2021-09-08 19:38:10.175989",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Selling Settings",


### PR DESCRIPTION
Introduced a new option "Auto Name" in Selling and Buying Settings

<img width="1343" alt="Screenshot 2021-09-15 at 10 18 18 AM" src="https://user-images.githubusercontent.com/42651287/133372417-f3b17bae-bd3f-426f-a720-50cf4536ff19.png">

There may be instances when the user wants to name the customer based on custom fields or using some other auto name logic

This PR allows users to use standard auto naming functionality for naming customers 