### PR TITLE
fix: job card overlap unknown column `jc.employee` 

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -91,7 +91,7 @@ class JobCard(Document):
 		if args.get("employee"):
 			# override capacity for employee
 			production_capacity = 1
-			validate_overlap_for = " and jc.employee = %(employee)s "
+			validate_overlap_for = " and jctl.employee = %(employee)s "
 
 		extra_cond = ''
 		if check_next_available_slot:

--- a/erpnext/manufacturing/doctype/job_card/test_job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/test_job_card.py
@@ -19,67 +19,52 @@ class TestJobCard(unittest.TestCase):
 		self.work_order = make_wo_order_test_record(item="_Test FG Item 2", qty=2)
 
 	def tearDown(self):
-		self.work_order.cancel()
+		frappe.db.rollback()
 
 	def test_job_card(self):
-		data = frappe.get_cached_value('BOM',
-			{'docstatus': 1, 'with_operations': 1, 'company': '_Test Company'}, ['name', 'item'])
 
-		if data:
-			bom, bom_item = data
+		job_cards = frappe.get_all('Job Card',
+			filters = {'work_order': self.work_order.name}, fields = ["operation_id", "name"])
 
-			work_order = make_wo_order_test_record(item=bom_item, qty=1, bom_no=bom)
+		if job_cards:
+			job_card = job_cards[0]
+			frappe.db.set_value("Job Card", job_card.name, "operation_row_number", job_card.operation_id)
 
-			job_cards = frappe.get_all('Job Card',
-				filters = {'work_order': work_order.name}, fields = ["operation_id", "name"])
+			doc = frappe.get_doc("Job Card", job_card.name)
+			doc.operation_id = "Test Data"
+			self.assertRaises(OperationMismatchError, doc.save)
 
-			if job_cards:
-				job_card = job_cards[0]
-				frappe.db.set_value("Job Card", job_card.name, "operation_row_number", job_card.operation_id)
-
-				doc = frappe.get_doc("Job Card", job_card.name)
-				doc.operation_id = "Test Data"
-				self.assertRaises(OperationMismatchError, doc.save)
-
-			for d in job_cards:
-				frappe.delete_doc("Job Card", d.name)
+		for d in job_cards:
+			frappe.delete_doc("Job Card", d.name)
 
 	def test_job_card_with_different_work_station(self):
-		data = frappe.get_cached_value('BOM',
-			{'docstatus': 1, 'with_operations': 1, 'company': '_Test Company'}, ['name', 'item'])
+		job_cards = frappe.get_all('Job Card',
+			filters = {'work_order': self.work_order.name},
+			fields = ["operation_id", "workstation", "name", "for_quantity"])
 
-		if data:
-			bom, bom_item = data
+		job_card = job_cards[0]
 
-			work_order = make_wo_order_test_record(item=bom_item, qty=1, bom_no=bom)
+		if job_card:
+			workstation = frappe.db.get_value("Workstation",
+				{"name": ("not in", [job_card.workstation])}, "name")
 
-			job_cards = frappe.get_all('Job Card',
-				filters = {'work_order': work_order.name},
-				fields = ["operation_id", "workstation", "name", "for_quantity"])
+			if not workstation or job_card.workstation == workstation:
+				workstation = make_workstation(workstation_name=random_string(5)).name
 
-			job_card = job_cards[0]
+			doc = frappe.get_doc("Job Card", job_card.name)
+			doc.workstation = workstation
+			doc.append("time_logs", {
+				"from_time": "2009-01-01 12:06:25",
+				"to_time": "2009-01-01 12:37:25",
+				"time_in_mins": "31.00002",
+				"completed_qty": job_card.for_quantity
+			})
+			doc.submit()
 
-			if job_card:
-				workstation = frappe.db.get_value("Workstation",
-					{"name": ("not in", [job_card.workstation])}, "name")
+			completed_qty = frappe.db.get_value("Work Order Operation", job_card.operation_id, "completed_qty")
+			self.assertEqual(completed_qty, job_card.for_quantity)
 
-				if not workstation or job_card.workstation == workstation:
-					workstation = make_workstation(workstation_name=random_string(5)).name
-
-				doc = frappe.get_doc("Job Card", job_card.name)
-				doc.workstation = workstation
-				doc.append("time_logs", {
-					"from_time": "2009-01-01 12:06:25",
-					"to_time": "2009-01-01 12:37:25",
-					"time_in_mins": "31.00002",
-					"completed_qty": job_card.for_quantity
-				})
-				doc.submit()
-
-				completed_qty = frappe.db.get_value("Work Order Operation", job_card.operation_id, "completed_qty")
-				self.assertEqual(completed_qty, job_card.for_quantity)
-
-				doc.cancel()
+			doc.cancel()
 
 			for d in job_cards:
 				frappe.delete_doc("Job Card", d.name)
@@ -111,4 +96,3 @@ class TestJobCard(unittest.TestCase):
 			"employee": employee,
 		})
 		self.assertRaises(OverlapError, jc2.save)
-		frappe.db.rollback()


### PR DESCRIPTION
Steps to reproduce:

1. Trim tables on job card table / fresh install.
2. Create two job cards somehow (Work order with operations > submit)
3. In two separate job cards add same employee in overlapping time. 

Observed: SQL error.
Expected: overlap error.

closes https://github.com/frappe/erpnext/issues/27399
closes https://github.com/frappe/erpnext/issues/27064