### PR TITLE
refactor: .doc missing and empty row on new doc

### DIFF
--- a/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.js
+++ b/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.js
@@ -31,8 +31,8 @@ frappe.ui.form.on('Maintenance Visit', {
 	},
 	onload: function (frm, cdt, cdn) {
 		let item = locals[cdt][cdn];
-		if (frm.maintenance_type == 'Scheduled') {
-			let schedule_id = item.purposes[0].prevdoc_detail_docname;
+		if (frm.doc.maintenance_type === "Scheduled") {
+			let schedule_id = item.purposes[0].prevdoc_detail_docname || frm.doc.maintenance_schedule_detail;
 			frappe.call({
 				method: "erpnext.maintenance.doctype.maintenance_schedule.maintenance_schedule.update_serial_nos",
 				args: {
@@ -42,6 +42,9 @@ frappe.ui.form.on('Maintenance Visit', {
 					serial_nos = r.message;
 				}
 			});
+		}
+		else {
+			frm.clear_table("purposes");
 		}
 
 		if (!frm.doc.status) {

--- a/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.js
+++ b/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.js
@@ -32,7 +32,7 @@ frappe.ui.form.on('Maintenance Visit', {
 	onload: function (frm, cdt, cdn) {
 		let item = locals[cdt][cdn];
 		if (frm.doc.maintenance_type === "Scheduled") {
-			let schedule_id = item.purposes[0].prevdoc_detail_docname || frm.doc.maintenance_schedule_detail;
+			const schedule_id = item.purposes[0].prevdoc_detail_docname || frm.doc.maintenance_schedule_detail;
 			frappe.call({
 				method: "erpnext.maintenance.doctype.maintenance_schedule.maintenance_schedule.update_serial_nos",
 				args: {


### PR DESCRIPTION
### Changes
- Added missing `.doc` in `frm.maintenance_type`.
- Clearing empty table row on creating a new visit.

![table](https://user-images.githubusercontent.com/43572428/132647304-8121cc04-b21f-4bb0-a592-73e239bc1ade.gif)

### After Changes
![table_fix](https://user-images.githubusercontent.com/43572428/132646360-389fac4d-c3d4-4e33-a247-6b83b9bfed70.gif)
