### PR TITLE
fix(ux): clean invalid fields from variant setting

### DIFF
--- a/erpnext/stock/doctype/item_variant_settings/item_variant_settings.js
+++ b/erpnext/stock/doctype/item_variant_settings/item_variant_settings.js
@@ -2,18 +2,31 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Item Variant Settings', {
-	setup: function(frm) {
+	refresh: function(frm) {
 		const allow_fields = [];
-		const exclude_fields = ["naming_series", "item_code", "item_name", "show_in_website",
-		"show_variant_in_website", "opening_stock", "variant_of", "valuation_rate"];
+
+		const existing_fields = frm.doc.fields.map(row => row.field_name);
+		const exclude_fields = [...existing_fields, "naming_series", "item_code", "item_name",
+			"show_in_website", "show_variant_in_website", "standard_rate", "opening_stock", "image",
+			"variant_of", "valuation_rate", "barcodes", "website_image", "thumbnail",
+			"website_specifiations", "web_long_description", "has_variants", "attributes"];
+
+		const exclude_field_types = ['HTML', 'Section Break', 'Column Break', 'Button', 'Read Only'];
 
 		frappe.model.with_doctype('Item', () => {
 			frappe.get_meta('Item').fields.forEach(d => {
-				if(!in_list(['HTML', 'Section Break', 'Column Break', 'Button', 'Read Only'], d.fieldtype)
+				if (!in_list(exclude_field_types, d.fieldtype)
 					&& !d.no_copy && !in_list(exclude_fields, d.fieldname)) {
 					allow_fields.push(d.fieldname);
 				}
 			});
+
+			if (allow_fields.length == 0) {
+				allow_fields.push({
+					label: __("No additional fields available"),
+					value: "",
+				});
+			}
 
 			frm.fields_dict.fields.grid.update_docfield_property(
 				'field_name', 'options', allow_fields


### PR DESCRIPTION
- Remove fields that are already existing from options
- Add a message for case when no additional fields can be added.


before:
ALL fields are shown, even the ones that are already added. 
![Screenshot 2021-09-09 at 6 40 52 PM](https://user-images.githubusercontent.com/9079960/132691971-0eadbb3d-0494-46b0-ad59-0c6884816f27.png)


after:
![Screenshot 2021-09-09 at 6 40 04 PM](https://user-images.githubusercontent.com/9079960/132691847-48390e2b-1a59-4f2e-9c9a-f46c8eb31805.png)

![Screenshot 2021-09-09 at 6 38 16 PM](https://user-images.githubusercontent.com/9079960/132691767-cf1b626b-b899-41dd-a5e5-46a0816636ec.png)
