### PR TITLE
ci: Use codecov for coverage reporting

### DIFF
--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -99,34 +99,10 @@ jobs:
           CI_BUILD_ID: ${{ github.run_id }}
           ORCHESTRATOR_URL: http://test-orchestrator.frappe.io
 
-      - name: Upload Coverage Data
-        run: |
-          cp ~/frappe-bench/sites/.coverage ${GITHUB_WORKSPACE}
-          cd ${GITHUB_WORKSPACE}
-          pip3 install coverage==5.5
-          pip3 install coveralls==3.0.1
-          coveralls
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
-          COVERALLS_FLAG_NAME: run-${{ matrix.container }}
-          COVERALLS_SERVICE_NAME: ${{ github.event_name == 'pull_request' && 'github' || 'github-actions' }}
-          COVERALLS_PARALLEL: true
-
-  coveralls:
-    name: Coverage Wrap Up
-    needs: test
-    container: python:3-slim
-    runs-on: ubuntu-latest
-    steps:
-      - name: Clone
-        uses: actions/checkout@v2
-
-      - name: Coveralls Finished
-        run: |
-          cd ${GITHUB_WORKSPACE}
-          pip3 install coverage==5.5
-          pip3 install coveralls==3.0.1
-          coveralls --finish
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload coverage data
+        uses: codecov/codecov-action@v2
+        with:
+          name: MariaDB
+          fail_ci_if_error: true
+          files: /home/runner/frappe-bench/sites/coverage.xml
+          verbose: true

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 [![CI](https://github.com/frappe/erpnext/actions/workflows/server-tests.yml/badge.svg?branch=develop)](https://github.com/frappe/erpnext/actions/workflows/server-tests.yml)
 [![Open Source Helpers](https://www.codetriage.com/frappe/erpnext/badges/users.svg)](https://www.codetriage.com/frappe/erpnext)
-[![Coverage Status](https://coveralls.io/repos/github/frappe/erpnext/badge.svg?branch=develop)](https://coveralls.io/github/frappe/erpnext?branch=develop)
+[![codecov](https://codecov.io/gh/frappe/erpnext/branch/develop/graph/badge.svg?token=0TwvyUg3I5)](https://codecov.io/gh/frappe/erpnext)
 
 [https://erpnext.com](https://erpnext.com)
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,13 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0.5%
+
+comment:
+  layout: "diff, files"
+  require_changes: true


### PR DESCRIPTION
Why [codecov](https://about.codecov.io/)?
- Coveralls had login issues (too many requests/redirect) and we were not able to view files to find the actual uncovered lines
- Codecov has better reporting (status checks & [commit diff](https://codecov.io/gh/surajshetty3416/frappe/commit/55f37971bee920a2ae2682e5fb0c7e9c5664571d)), UX ([better folder/file navigation](https://codecov.io/gh/surajshetty3416/frappe/tree/55f37971bee920a2ae2682e5fb0c7e9c5664571d/frappe), faster page loads), [browser extension](https://docs.codecov.com/docs/browser-extension) and [graphs](https://codecov.io/gh/surajshetty3416/frappe/commit/55f37971bee920a2ae2682e5fb0c7e9c5664571d/graphs).
- Codecov will not require the additional step of coverage wrap-up for parallel builds ([it manages internally](https://docs.codecov.com/docs/merging-reports))

same as: https://github.com/frappe/frappe/pull/14105