### PR TITLE
fix: fail migration due to None type during v13_0.update_returned_qty_in_pr_dn

### DIFF
--- a/erpnext/patches/v13_0/update_returned_qty_in_pr_dn.py
+++ b/erpnext/patches/v13_0/update_returned_qty_in_pr_dn.py
@@ -13,7 +13,7 @@ def execute():
 	frappe.reload_doc('stock', 'doctype', 'stock_settings')
 
 	def update_from_return_docs(doctype):
-		for return_doc in frappe.get_all(doctype, filters={'is_return' : 1, 'docstatus' : 1, 'return_against': 'IS NOT NULL'}):
+		for return_doc in frappe.get_all(doctype, filters={'is_return' : 1, 'docstatus' : 1, 'return_against': ('!=', '')}):
 			# Update original receipt/delivery document from return
 			return_doc = frappe.get_cached_doc(doctype, return_doc.name)
 			try:

--- a/erpnext/patches/v13_0/update_returned_qty_in_pr_dn.py
+++ b/erpnext/patches/v13_0/update_returned_qty_in_pr_dn.py
@@ -13,7 +13,7 @@ def execute():
 	frappe.reload_doc('stock', 'doctype', 'stock_settings')
 
 	def update_from_return_docs(doctype):
-		for return_doc in frappe.get_all(doctype, filters={'is_return' : 1, 'docstatus' : 1}):
+		for return_doc in frappe.get_all(doctype, filters={'is_return' : 1, 'docstatus' : 1, 'return_against': 'IS NOT NULL'}):
 			# Update original receipt/delivery document from return
 			return_doc = frappe.get_cached_doc(doctype, return_doc.name)
 			try:


### PR DESCRIPTION
If there is a Delivery Note or Purchase Receipt is_return =1 and does not contain an original document the patch fails.
I think most case when this fails is from Data Import when migrating from an older system.
[https://discuss.erpnext.com/t/issue-while-migrating-update/79336/2](https://discuss.erpnext.com/t/issue-while-migrating-update/79336/2)
