### PR TITLE
fix: employee advance return through multiple additional salaries

### DIFF
--- a/erpnext/hr/doctype/employee_advance/employee_advance.js
+++ b/erpnext/hr/doctype/employee_advance/employee_advance.js
@@ -73,7 +73,7 @@ frappe.ui.form.on('Employee Advance', {
 					frm.trigger('make_return_entry');
 				}, __('Create'));
 			} else if (frm.doc.repay_unclaimed_amount_from_salary == 1 && frappe.model.can_create("Additional Salary")) {
-				frm.add_custom_button(__("Deduction from salary"), function() {
+				frm.add_custom_button(__("Deduction from Salary"), function() {
 					frm.events.make_deduction_via_additional_salary(frm);
 				}, __('Create'));
 			}

--- a/erpnext/hr/doctype/employee_advance/employee_advance.json
+++ b/erpnext/hr/doctype/employee_advance/employee_advance.json
@@ -170,7 +170,7 @@
    "default": "0",
    "fieldname": "repay_unclaimed_amount_from_salary",
    "fieldtype": "Check",
-   "label": "Repay unclaimed amount from salary"
+   "label": "Repay Unclaimed Amount from Salary"
   },
   {
    "depends_on": "eval:cur_frm.doc.employee",
@@ -200,10 +200,11 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2021-03-31 22:31:53.746659",
+ "modified": "2021-09-11 18:38:38.617478",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Employee Advance",
+ "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
  "permissions": [
   {

--- a/erpnext/hr/doctype/employee_advance/employee_advance.py
+++ b/erpnext/hr/doctype/employee_advance/employee_advance.py
@@ -172,7 +172,10 @@ def get_paying_amount_paying_exchange_rate(payment_account, doc):
 @frappe.whitelist()
 def create_return_through_additional_salary(doc):
 	import json
-	doc = frappe._dict(json.loads(doc))
+
+	if isinstance(doc, str):
+		doc = frappe._dict(json.loads(doc))
+
 	additional_salary = frappe.new_doc('Additional Salary')
 	additional_salary.employee = doc.employee
 	additional_salary.currency = doc.currency

--- a/erpnext/hr/doctype/employee_advance/test_employee_advance.py
+++ b/erpnext/hr/doctype/employee_advance/test_employee_advance.py
@@ -12,8 +12,8 @@ import erpnext
 from erpnext.hr.doctype.employee.test_employee import make_employee
 from erpnext.hr.doctype.employee_advance.employee_advance import (
 	EmployeeAdvanceOverPayment,
-	make_bank_entry,
 	create_return_through_additional_salary,
+	make_bank_entry,
 )
 from erpnext.payroll.doctype.salary_component.test_salary_component import create_salary_component
 from erpnext.payroll.doctype.salary_structure.test_salary_structure import make_salary_structure

--- a/erpnext/hr/doctype/employee_advance/test_employee_advance.py
+++ b/erpnext/hr/doctype/employee_advance/test_employee_advance.py
@@ -13,7 +13,10 @@ from erpnext.hr.doctype.employee.test_employee import make_employee
 from erpnext.hr.doctype.employee_advance.employee_advance import (
 	EmployeeAdvanceOverPayment,
 	make_bank_entry,
+	create_return_through_additional_salary,
 )
+from erpnext.payroll.doctype.salary_component.test_salary_component import create_salary_component
+from erpnext.payroll.doctype.salary_structure.test_salary_structure import make_salary_structure
 
 
 class TestEmployeeAdvance(unittest.TestCase):
@@ -33,6 +36,46 @@ class TestEmployeeAdvance(unittest.TestCase):
 		journal_entry1 = make_payment_entry(advance)
 		self.assertRaises(EmployeeAdvanceOverPayment, journal_entry1.submit)
 
+	def test_repay_unclaimed_amount_from_salary(self):
+		employee_name = make_employee("_T@employe.advance")
+		advance = make_employee_advance(employee_name, {"repay_unclaimed_amount_from_salary": 1})
+
+		args = {"type": "Deduction"}
+		create_salary_component("Advance Salary - Deduction", **args)
+		make_salary_structure("Test Additional Salary for Advance Return", "Monthly", employee=employee_name)
+
+		# additional salary for 700 first
+		advance.reload()
+		additional_salary = create_return_through_additional_salary(advance)
+		additional_salary.salary_component = "Advance Salary - Deduction"
+		additional_salary.payroll_date = nowdate()
+		additional_salary.amount = 700
+		additional_salary.insert()
+		additional_salary.submit()
+
+		advance.reload()
+		self.assertEqual(advance.return_amount, 700)
+
+		# additional salary for remaining 300
+		additional_salary = create_return_through_additional_salary(advance)
+		additional_salary.salary_component = "Advance Salary - Deduction"
+		additional_salary.payroll_date = nowdate()
+		additional_salary.amount = 300
+		additional_salary.insert()
+		additional_salary.submit()
+
+		advance.reload()
+		self.assertEqual(advance.return_amount, 1000)
+
+		# update advance return amount on additional salary cancellation
+		additional_salary.cancel()
+		advance.reload()
+		self.assertEqual(advance.return_amount, 700)
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+
 def make_payment_entry(advance):
 	journal_entry = frappe.get_doc(make_bank_entry("Employee Advance", advance.name))
 	journal_entry.cheque_no = "123123"
@@ -41,7 +84,7 @@ def make_payment_entry(advance):
 
 	return journal_entry
 
-def make_employee_advance(employee_name):
+def make_employee_advance(employee_name, args=None):
 	doc = frappe.new_doc("Employee Advance")
 	doc.employee = employee_name
 	doc.company  = "_Test company"
@@ -51,6 +94,10 @@ def make_employee_advance(employee_name):
 	doc.advance_amount = 1000
 	doc.posting_date = nowdate()
 	doc.advance_account = "_Test Employee Advance - _TC"
+
+	if args:
+		doc.update(args)
+
 	doc.insert()
 	doc.submit()
 

--- a/erpnext/payroll/doctype/additional_salary/additional_salary.py
+++ b/erpnext/payroll/doctype/additional_salary/additional_salary.py
@@ -14,12 +14,11 @@ from erpnext.hr.utils import validate_active_employee
 
 class AdditionalSalary(Document):
 	def on_submit(self):
-		if self.ref_doctype == "Employee Advance" and self.ref_docname:
-			frappe.db.set_value("Employee Advance", self.ref_docname, "return_amount", self.amount)
-
+		self.update_return_amount_in_employee_advance()
 		self.update_employee_referral()
 
 	def on_cancel(self):
+		self.update_return_amount_in_employee_advance()
 		self.update_employee_referral(cancel=True)
 
 	def validate(self):
@@ -97,6 +96,17 @@ class AdditionalSalary(Document):
 			if referral_details.status != "Accepted":
 				frappe.throw(_("Additional Salary for referral bonus can only be created against Employee Referral with status {0}").format(
 					frappe.bold("Accepted")))
+
+	def update_return_amount_in_employee_advance(self):
+		if self.ref_doctype == "Employee Advance" and self.ref_docname:
+			return_amount = frappe.db.get_value("Employee Advance", self.ref_docname, "return_amount")
+
+			if self.docstatus == 2:
+				return_amount -= self.amount
+			else:
+				return_amount += self.amount
+
+			frappe.db.set_value("Employee Advance", self.ref_docname, "return_amount", return_amount)
 
 	def update_employee_referral(self, cancel=False):
 		if self.ref_doctype == "Employee Referral":


### PR DESCRIPTION
## Problems

### 1. Employee advance return does not work through multiple additional salaries

- Create an Employee Advance (eg: Rs. 5000) with **Repay Unclaimed Amount** from Salary enabled
    
    ![image](https://user-images.githubusercontent.com/24353136/132950607-47531b46-7c5c-41dd-af38-685bfcba6a50.png)

- Create Deduction from Salary against the Employee Advance of Rs. 2000. The return amount in Employee Advance gets updated to 2000.

   ![image](https://user-images.githubusercontent.com/24353136/132950632-d2bd08ba-3792-4725-9ac9-9b39970cad0e.png)

- Now create another additional salary from Employee Advance of Rs. 2000.
    
    ![image](https://user-images.githubusercontent.com/24353136/132950652-5afea0b2-dc33-42bb-97ff-3f7b85ecf273.png)

- The return amount in Employee Advance only gets updated with 1 additional salary document's amount:

    ![image](https://user-images.githubusercontent.com/24353136/132950692-f81152ce-7421-4ee0-a4b9-3079e8180a4f.png)

### 2. Additional Salary cancelation does not update the return amount in Employee Advance

### 3. Inconsistent cases in the field and button labeling:

<img width="1313" alt="employee-advance" src="https://user-images.githubusercontent.com/24353136/132950845-bdbb17b9-e883-46b1-b1b0-d772b8242cd9.png">

## Solution:

1. `return_amount` in Employee Advance was only updated with the latest linked additional salary's amount on submit. No handling on cancelation. Added a method `update_return_amount_in_employee_advance` called on Additional Salary submission and cancellation to add/deduct the return amount respectively to the existing return amount value in Employee Advance.
2. Fixed form and button labels.
3. Added a test for the same.