### PR TITLE
fix: link to navigate to item template from variant

### DIFF
--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -85,7 +85,7 @@ frappe.ui.form.on("Item", {
 		}
 		if (frm.doc.variant_of) {
 			frm.set_intro(__('This Item is a Variant of {0} (Template).',
-				[`<a href="/app/item/${frm.doc.variant_of}" onclick="location.reload()">${frm.doc.variant_of}</a>`]), true);
+				[`<a href="#Form/Item/${frm.doc.variant_of}" target="_blank">${frm.doc.variant_of}</a>`]), true);
 		}
 
 		if (frappe.defaults.get_default("item_naming_by")!="Naming Series" || frm.doc.variant_of) {


### PR DESCRIPTION
Link to navigate to Item Template from Variant broken as v12 still uses `/desk#Form/DoctypeName` for routing and not `/app/doctypename`

   ![image](https://user-images.githubusercontent.com/24353136/132954442-a2add353-7dbd-4976-9af7-b341251970ae.png)

   ![image](https://user-images.githubusercontent.com/24353136/132954469-1aa1fbcd-d581-4707-b261-1d7c4d0a0332.png)

Fix not needed for v13