### PR TITLE
fix: PO/PINV -  Check if doctype has company_address field before setting the value

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -864,7 +864,8 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 						if (r.message) {
 							me.frm.set_value("billing_address", r.message);
 						} else {
-							me.frm.set_value("company_address", "");
+							if(frappe.meta.get_docfield(me.frm.doctype, 'company_address'))				
+								me.frm.set_value("company_address", "");						
 						}
 					}
 				});

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -864,7 +864,7 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 						if (r.message) {
 							me.frm.set_value("billing_address", r.message);
 						} else {
-							if (frappe.meta.get_docfield(me.frm.doctype, 'company_address')){
+							if (frappe.meta.get_docfield(me.frm.doctype, 'company_address')) {
 								me.frm.set_value("company_address", "");
 							}
 						}

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -864,8 +864,9 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 						if (r.message) {
 							me.frm.set_value("billing_address", r.message);
 						} else {
-							if(frappe.meta.get_docfield(me.frm.doctype, 'company_address'))				
-								me.frm.set_value("company_address", "");						
+							if(frappe.meta.get_docfield(me.frm.doctype, 'company_address')){			
+								me.frm.set_value("company_address", "");
+							}						
 						}
 					}
 				});

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -864,9 +864,9 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 						if (r.message) {
 							me.frm.set_value("billing_address", r.message);
 						} else {
-							if(frappe.meta.get_docfield(me.frm.doctype, 'company_address')){			
+							if (frappe.meta.get_docfield(me.frm.doctype, 'company_address')){
 								me.frm.set_value("company_address", "");
-							}						
+							}
 						}
 					}
 				});


### PR DESCRIPTION
closes #27419

Upon creating a new Purchase Order, or a Purchase Invoice, an error pops up indicating that the field "company_address" is not found

This is happening because doctypes like Purchase Order/ PINV doesn't have field "company_address".
After adding a "if" condition before setting the value will solve the issue.
 