### PR TITLE
fix: editable price list rate field in sales transactions

### DIFF
--- a/erpnext/selling/sales_common.js
+++ b/erpnext/selling/sales_common.js
@@ -247,7 +247,12 @@ erpnext.selling.SellingController = class SellingController extends erpnext.Tran
 		var editable_price_list_rate = cint(frappe.defaults.get_default("editable_price_list_rate"));
 
 		if(df && editable_price_list_rate) {
-			df.read_only = 0;
+			const parent_field = frappe.meta.get_parentfield(this.frm.doc.doctype, this.frm.doc.doctype + " Item");
+			if (!this.frm.fields_dict[parent_field]) return;
+
+			this.frm.fields_dict[parent_field].grid.update_docfield_property(
+				'price_list_rate', 'read_only', 0
+			);
 		}
 	}
 


### PR DESCRIPTION
The `price_list_rate` field in Sales Transactions wasn't editable even after setting "Allow User to Edit Price List Rate in Transactions"