### PR TITLE
fix: cancelled sales invoices are considered in billed qty calculation

### DIFF
--- a/erpnext/selling/report/sales_order_analysis/sales_order_analysis.py
+++ b/erpnext/selling/report/sales_order_analysis/sales_order_analysis.py
@@ -73,7 +73,7 @@ def get_data(conditions, filters):
 			`tabSales Order` so,
 			`tabSales Order Item` soi
 		LEFT JOIN `tabSales Invoice Item` sii
-			ON sii.so_detail = soi.name
+			ON sii.so_detail = soi.name and sii.docstatus = 1
 		WHERE
 			soi.parent = so.name
 			and so.status not in ('Stopped', 'Closed', 'On Hold')


### PR DESCRIPTION
In the Sales Order Analytics report, the billed quantity was calculated considering cancelled Sales Invoices. 

So, if there were 2 sales invoices created against a sales order and one of them was cancelled then the billed quantity showed invalid value.