### PR TITLE
feat: Merge POS invoices based on customer group

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.js
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.js
@@ -4,7 +4,7 @@
 frappe.ui.form.on('POS Invoice Merge Log', {
 	setup: function(frm) {
 		frm.set_query("pos_invoice", "pos_invoices", doc => {
-			return{
+			return {
 				filters: {
 					'docstatus': 1,
 					'customer': doc.customer,
@@ -12,5 +12,10 @@ frappe.ui.form.on('POS Invoice Merge Log', {
 				}
 			}
 		});
+	},
+
+	merger_invoices_based_on: function(frm) {
+		frm.set_value('customer', '');
+		frm.set_value('customer_group', '');
 	}
 });

--- a/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.js
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.js
@@ -14,7 +14,7 @@ frappe.ui.form.on('POS Invoice Merge Log', {
 		});
 	},
 
-	merger_invoices_based_on: function(frm) {
+	merge_invoices_based_on: function(frm) {
 		frm.set_value('customer', '');
 		frm.set_value('customer_group', '');
 	}

--- a/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.json
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.json
@@ -6,9 +6,11 @@
  "engine": "InnoDB",
  "field_order": [
   "posting_date",
-  "customer",
+  "merge_invoices_based_on",
   "column_break_3",
   "pos_closing_entry",
+  "customer",
+  "customer_group",
   "section_break_3",
   "pos_invoices",
   "references_section",
@@ -88,12 +90,27 @@
    "fieldtype": "Link",
    "label": "POS Closing Entry",
    "options": "POS Closing Entry"
+  },
+  {
+   "fieldname": "merge_invoices_based_on",
+   "fieldtype": "Select",
+   "label": "Merge Invoices Based On",
+   "options": "Customer\nCustomer Group",
+   "reqd": 1
+  },
+  {
+   "depends_on": "eval:doc.merge_invoices_based_on == 'Customer Group'",
+   "fieldname": "customer_group",
+   "fieldtype": "Link",
+   "label": "Customer Group",
+   "mandatory_depends_on": "eval:doc.merge_invoices_based_on == 'Customer Group'",
+   "options": "Customer Group"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2020-12-01 11:53:57.267579",
+ "modified": "2021-09-14 11:17:19.001142",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Invoice Merge Log",

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -499,7 +499,7 @@ class SalesInvoice(SellingController):
 			self.account_for_change_amount = frappe.get_cached_value('Company',  self.company,  'default_cash_account')
 
 		from erpnext.stock.get_item_details import get_pos_profile, get_pos_profile_item_details
-		if not self.pos_profile:
+		if not self.pos_profile and not self.flags.ignore_pos_profile:
 			pos_profile = get_pos_profile(self.company) or {}
 			if not pos_profile:
 				return

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -441,7 +441,7 @@ accounting_dimension_doctypes = ["GL Entry", "Sales Invoice", "Purchase Invoice"
 	"Purchase Receipt Item", "Stock Entry Detail", "Payment Entry Deduction", "Sales Taxes and Charges", "Purchase Taxes and Charges", "Shipping Rule",
 	"Landed Cost Item", "Asset Value Adjustment", "Loyalty Program", "Fee Schedule", "Fee Structure", "Stock Reconciliation",
 	"Travel Request", "Fees", "POS Profile", "Opening Invoice Creation Tool", "Opening Invoice Creation Tool Item", "Subscription",
-	"Subscription Plan"
+	"Subscription Plan", "POS Invoice", "POS Invoice Item"
 ]
 
 regional_overrides = {

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -306,3 +306,4 @@ erpnext.patches.v13_0.create_gst_payment_entry_fields
 erpnext.patches.v14_0.delete_shopify_doctypes
 erpnext.patches.v13_0.update_dates_in_tax_withholding_category
 erpnext.patches.v14_0.update_opportunity_currency_fields
+erpnext.patches.v13_0.create_accounting_dimensions_in_pos_doctypes

--- a/erpnext/patches/v13_0/create_accounting_dimensions_in_pos_doctypes.py
+++ b/erpnext/patches/v13_0/create_accounting_dimensions_in_pos_doctypes.py
@@ -13,7 +13,7 @@ def execute():
 	count = 1
 	for d in accounting_dimensions:
 
-		if count%2 == 0:
+		if count % 2 == 0:
 			insert_after_field = 'dimension_col_break'
 		else:
 			insert_after_field = 'accounting_dimensions_section'

--- a/erpnext/patches/v13_0/create_accounting_dimensions_in_pos_doctypes.py
+++ b/erpnext/patches/v13_0/create_accounting_dimensions_in_pos_doctypes.py
@@ -1,0 +1,42 @@
+import frappe
+from frappe.custom.doctype.custom_field.custom_field import create_custom_field
+
+
+def execute():
+	frappe.reload_doc('accounts', 'doctype', 'accounting_dimension')
+	accounting_dimensions = frappe.db.sql("""select fieldname, label, document_type, disabled from
+		`tabAccounting Dimension`""", as_dict=1)
+
+	if not accounting_dimensions:
+		return
+
+	count = 1
+	for d in accounting_dimensions:
+
+		if count%2 == 0:
+			insert_after_field = 'dimension_col_break'
+		else:
+			insert_after_field = 'accounting_dimensions_section'
+
+		for doctype in ["POS Invoice", "POS Invoice Item"]:
+
+			field = frappe.db.get_value("Custom Field", {"dt": doctype, "fieldname": d.fieldname})
+
+			if field:
+				continue
+			meta = frappe.get_meta(doctype, cached=False)
+			fieldnames = [d.fieldname for d in meta.get("fields")]
+
+			df = {
+				"fieldname": d.fieldname,
+				"label": d.label,
+				"fieldtype": "Link",
+				"options": d.document_type,
+				"insert_after": insert_after_field
+			}
+
+			if df['fieldname'] not in fieldnames:
+				create_custom_field(doctype, df)
+				frappe.clear_cache(doctype=doctype)
+
+		count += 1


### PR DESCRIPTION
Customers can now be merged based on customer group. 

1. Select the "Merge Invoice Based On" customer group. If this option is selected the customer invoice validation will be ignored
2. Select the Group Customer based on which the invoices have to be merged.  

<img width="1345" alt="Screenshot 2021-09-16 at 7 27 57 PM" src="https://user-images.githubusercontent.com/42651287/133625766-43ff1d8e-172a-431a-b730-0ce993f3f688.png">

`no-docs`