### PR TITLE
fix: Args missing error on changing Price List currency with cart enabled

### DIFF
--- a/erpnext/e_commerce/doctype/e_commerce_settings/e_commerce_settings.py
+++ b/erpnext/e_commerce/doctype/e_commerce_settings/e_commerce_settings.py
@@ -127,7 +127,7 @@ class ECommerceSettings(Document):
 			if not (new_fields == old_fields):
 				create_website_items_index()
 
-def validate_cart_settings(doc, method):
+def validate_cart_settings(doc=None, method=None):
 	frappe.get_doc("E Commerce Settings", "E Commerce Settings").run_method("validate")
 
 def get_shopping_cart_settings():


### PR DESCRIPTION
After E-commerce Refactor due to merge conflicts, keyword args introduced via https://github.com/frappe/erpnext/pull/27050 became positional args.
This caused the error below on calling `validate_cart_settings()` within function `check_impact_on_shopping_cart` in `price_list.py` :

![image](https://user-images.githubusercontent.com/25857446/133258601-773eae3c-7514-4879-baaa-e11e08f374cd.png)
