### PR TITLE
fix: table data deleted on submitted maintenance schedule

### DIFF
--- a/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.js
+++ b/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.js
@@ -18,7 +18,7 @@ frappe.ui.form.on('Maintenance Schedule', {
 	},
 	refresh: function (frm) {
 		setTimeout(() => {
-			frm.toggle_display('generate_schedule', !(frm.is_new()));
+			frm.toggle_display('generate_schedule', !(frm.is_new() || frm.doc.docstatus));
 			frm.toggle_display('schedule', !(frm.is_new()));
 		}, 10);
 	},

--- a/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py
+++ b/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py
@@ -16,9 +16,9 @@ from erpnext.utilities.transaction_base import TransactionBase, delete_events
 class MaintenanceSchedule(TransactionBase):
 	@frappe.whitelist()
 	def generate_schedule(self):
+		if self.docstatus != 0:
+			return
 		self.set('schedules', [])
-		frappe.db.sql("""delete from `tabMaintenance Schedule Detail`
-			where parent=%s""", (self.name))
 		count = 1
 		for d in self.get('items'):
 			self.validate_maintenance_detail()


### PR DESCRIPTION
### Issue
- Schedule data gets erased if "Generate Schedule" is triggered on a submitted schedule and refreshed.

![schedule_bug](https://user-images.githubusercontent.com/43572428/133424240-4552cf6d-dae8-4059-84b1-93ab4c46f38b.gif)


### Fix
- Disabled "Generate Schedule " button when document is in submitted state.
- Removed unnecessary query to delete rows.
