### PR TITLE
fix: not able to submit stock entry with 350 items

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -407,7 +407,8 @@ class update_entries_after(object):
 				return
 
 		# Get dynamic incoming/outgoing rate
-		self.get_dynamic_incoming_outgoing_rate(sle)
+		if not self.args.get("sle_id"):
+			self.get_dynamic_incoming_outgoing_rate(sle)
 
 		if sle.serial_no:
 			self.get_serialized_values(sle)
@@ -447,7 +448,8 @@ class update_entries_after(object):
 		sle.doctype="Stock Ledger Entry"
 		frappe.get_doc(sle).db_update()
 
-		self.update_outgoing_rate_on_transaction(sle)
+		if not self.args.get("sle_id"):
+			self.update_outgoing_rate_on_transaction(sle)
 
 	def validate_negative_stock(self, sle):
 		"""


### PR DESCRIPTION
**Issue**

User was trying to submit the stock entry with 350 items but not able to submit it and got a "Timeout Error"

### Profiling

After profiling came to know that system was calling the method recalculate_amounts_in_stock_entry, 350 times for the same stock entry. Ideally this function should call in case of reposting and not in case of normal Stock Ledger posting.

<img width="790" alt="Screenshot 2021-09-15 at 6 46 04 PM" src="https://user-images.githubusercontent.com/8780500/133447356-17eb5a2a-8086-4f63-b758-2404c69d4df9.png">


### After Fix

<img width="634" alt="Screenshot 2021-09-15 at 7 10 31 PM" src="https://user-images.githubusercontent.com/8780500/133447741-aa381afc-51d6-456a-ad8c-02e677ce6c50.png">
