### PR TITLE
fix(minor): Employee filter in Unpaid Expense Claims report

### DIFF
--- a/erpnext/accounts/report/unpaid_expense_claim/unpaid_expense_claim.js
+++ b/erpnext/accounts/report/unpaid_expense_claim/unpaid_expense_claim.js
@@ -4,9 +4,10 @@
 frappe.query_reports["Unpaid Expense Claim"] = {
 	"filters": [
 		{
-			"fieldname":"employee",
+			"fieldname": "employee",
 			"label": __("Employee"),
-			"fieldtype": "Link"
+			"fieldtype": "Link",
+			"options": "Employee"
 		}
 	]
 }


### PR DESCRIPTION
Link Option missing in Employee filter in Unpaid Expense Claim report 