### PR TITLE
fix(ProdPlan): Get SubAssy Items does not work

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.js
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.js
@@ -242,6 +242,8 @@ frappe.ui.form.on('Production Plan', {
 	},
 
 	get_sub_assembly_items: function(frm) {
+		frm.dirty();
+
 		frappe.call({
 			method: "get_sub_assembly_items",
 			freeze: true,

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -561,8 +561,6 @@ class ProductionPlan(Document):
 			get_sub_assembly_items(row.bom_no, bom_data, row.planned_qty)
 			self.set_sub_assembly_items_based_on_level(row, bom_data, manufacturing_type)
 
-		self.save()
-
 	def set_sub_assembly_items_based_on_level(self, row, bom_data, manufacturing_type=None):
 		bom_data = sorted(bom_data, key = lambda i: i.bom_level)
 


### PR DESCRIPTION
- Get subassembly items button wasn't working unless the document was saved already.
- If clicked on that button it would save prodplan and new one will again get created on saving.

![Screenshot 2021-09-16 at 12 08 34 PM](https://user-images.githubusercontent.com/9079960/133562716-65978d88-c150-419b-8e0b-f8900dd6b0cd.png)


Root cause:
`self.save()` saved the document with a new name hence refresh_field can't work. 