### PR TITLE
fix: Validate if item exists on uploading items in stock reco

### DIFF
--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -621,8 +621,8 @@ def get_stock_balance_for(item_code, warehouse,
 
 	if not item_dict:
 		# In cases of data upload to Items table
-		msg = f"Item {item_code} does not exist."
-		frappe.throw(msg=_(msg), title=_("Missing"))
+		msg = _("Item {} does not exist.").format(item_code)
+		frappe.throw(msg, title=_("Missing"))
 
 	serial_nos = ""
 	with_serial_no = True if item_dict.get("has_serial_no") else False

--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -619,6 +619,11 @@ def get_stock_balance_for(item_code, warehouse,
 	item_dict = frappe.db.get_value("Item", item_code,
 		["has_serial_no", "has_batch_no"], as_dict=1)
 
+	if not item_dict:
+		# In cases of data upload to Items table
+		msg = f"Item {item_code} does not exist."
+		frappe.throw(msg=_(msg), title=_("Missing"))
+
 	serial_nos = ""
 	with_serial_no = True if item_dict.get("has_serial_no") else False
 	data = get_stock_balance(item_code, warehouse, posting_date, posting_time,


### PR DESCRIPTION
**Issue:**
Uploading (via Upload button) **non existent item** in stock reco and then changing warehouse or batch  (trigger JS action) gave an error:
```py
  File ".../stock_reconciliation/stock_reconciliation.py", line 590, in get_stock_balance_for
    with_serial_no = True if item_dict.get("has_serial_no") else False

  AttributeError: 'NoneType' object has no attribute 'get'
```

>PS: Maybe some basic checks can be added during data upload itself to not manually check these. Will check framework

