### PR TITLE
refactor: using default precision in query

### DIFF
--- a/erpnext/controllers/status_updater.py
+++ b/erpnext/controllers/status_updater.py
@@ -313,6 +313,7 @@ class StatusUpdater(Document):
 	def _update_percent_field(self, args, update_modified=True):
 		"""Update percent field in parent transaction"""
 
+		args['precision'] = frappe.db.get_single_value('System Settings', 'float_precision') or 6
 		self._update_modified(args, update_modified)
 
 		if args.get('target_parent_field'):
@@ -321,7 +322,7 @@ class StatusUpdater(Document):
 					ifnull((select
 						ifnull(sum(if(abs(%(target_ref_field)s) > abs(%(target_field)s), abs(%(target_field)s), abs(%(target_ref_field)s))), 0)
 						/ sum(abs(%(target_ref_field)s)) * 100
-					from `tab%(target_dt)s` where parent="%(name)s" having sum(abs(%(target_ref_field)s)) > 0), 0), 6)
+					from `tab%(target_dt)s` where parent="%(name)s" having sum(abs(%(target_ref_field)s)) > 0), 0), %(precision)s)
 					%(update_modified)s
 				where name='%(name)s'""" % args)
 


### PR DESCRIPTION
### Issue
Here the Status has not updated to transferred.

![image](https://user-images.githubusercontent.com/43572428/135448148-0dcf21b0-047a-4583-9c8d-ebfd7259fcda.png)

Since the value has precision of 6, the value does not pass the condition.

![image](https://user-images.githubusercontent.com/43572428/135448238-5c2cda5b-7762-459a-850a-ffc3b099569b.png)




### Changes

- Fetching precision set in "System Settings" instead of 6.