### PR TITLE
ci: comment about coverage after min. 3 builds

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -11,6 +11,7 @@ coverage:
 comment:
   layout: "diff, files"
   require_changes: true
-  
+  after_n_builds: 3
+
 ignore:
   - "erpnext/demo"


### PR DESCRIPTION
- Codecov is prematurely commenting with wrong/misleading coverage information.
- Comment only after 3 build results are received. 