### PR TITLE
fix: unecessary keyword args were passed in mapper functions

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -714,12 +714,15 @@ erpnext.utils.map_current_doc = function(opts) {
 			child_columns: opts.child_columns,
 			action: function(selections, args) {
 				let values = selections;
-				if(values.length === 0){
+				if (values.length === 0) {
 					frappe.msgprint(__("Please select {0}", [opts.source_doctype]))
 					return;
 				}
 				opts.source_name = values;
-				opts.args = args;
+				if (opts.allow_child_item_selection) {
+					// args contains filtered child docnames
+					opts.args = args;
+				}
 				d.dialog.hide();
 				_map();
 			},

--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -272,8 +272,9 @@ def update_status(name, status):
 	material_request.update_status(status)
 
 @frappe.whitelist()
-def make_purchase_order(source_name, target_doc=None, args={}):
-
+def make_purchase_order(source_name, target_doc=None, args=None):
+	if args is None:
+		args = {}
 	if isinstance(args, string_types):
 		args = json.loads(args)
 


### PR DESCRIPTION
Problem:
With #27449, unexpected `args` were being passed to all the `method` used in `get_items_from` action. So if the `method` didn't expect those keyword args, then..

![image](https://user-images.githubusercontent.com/25369014/133739809-d88ea807-4354-41d2-96e1-7c9f23864448.png)

Fix:
Only pass `args` if child item selection is enabled
