### PR TITLE
fix: Prevent resetting of Product Bundles' rates on saving

### DIFF
--- a/erpnext/stock/doctype/packed_item/packed_item.py
+++ b/erpnext/stock/doctype/packed_item/packed_item.py
@@ -44,8 +44,10 @@ def update_packing_list_item(doc, packing_item_code, qty, main_item_row, descrip
 	# check if exists
 	exists = 0
 	for d in doc.get("packed_items"):
-		if d.parent_item == main_item_row.item_code and d.item_code == packing_item_code and\
-				d.parent_detail_docname == main_item_row.name:
+		if d.parent_item == main_item_row.item_code and d.item_code == packing_item_code:
+			if d.parent_detail_docname != main_item_row.name:
+				d.parent_detail_docname = main_item_row.name
+
 			pi, exists = d, 1
 			break
 


### PR DESCRIPTION
_Problem:_ 

On saving a Sales Order that was created from a Quotation which had a Product Bundle whose rate was dependant on its child items, the rates of all the Packed Items as well as the Product Bundle get reset to zero.
 
<details>
<summary>Steps to replicate issue</summary>

1. Open Selling Settings.
2. Enable _Calculate Product Bundle Price based on Child Items' Rates_.
3. Create a new Quotation.
4. Add a Product Bundle to its Items table.
5. Set Rates for its child items.
6. Save and Submit.
7. Create > Sales Order.
8. Save.

On hitting Save, the rates of the Packed Items as well as the Product Bundle will get reset to zero.

</details>

<details>
<summary>Images</summary>

_Before save:_

![telegram-cloud-photo-size-5-6197229022186941599-y](https://user-images.githubusercontent.com/25903035/133790937-ed445c42-ae53-4499-806b-1b3a7a21fe7f.jpg)

_After save:_

![telegram-cloud-photo-size-5-6197229022186941601-y](https://user-images.githubusercontent.com/25903035/133790975-0fb70078-8b5e-4a3f-86cd-55d647b6cf88.jpg)


</details>

_Fix:_

The rates of the Packed Items are being reset because the Packed Items that aren't linked with the Product Bundle row's name, are being overwritten. This fix links the Packed Items with their Parent Item's row, thereby preventing the overwriting(and hence, the rate being reset).