### PR TITLE
fix: Handle `is_search_module_loaded` for redis version < 4.0.0

### DIFF
--- a/erpnext/e_commerce/redisearch.py
+++ b/erpnext/e_commerce/redisearch.py
@@ -20,14 +20,16 @@ def get_indexable_web_fields():
 	return [df.fieldname for df in valid_fields]
 
 def is_search_module_loaded():
-	cache = frappe.cache()
-	out = cache.execute_command('MODULE LIST')
+	try:
+		cache = frappe.cache()
+		out = cache.execute_command('MODULE LIST')
 
-	parsed_output = " ".join(
-		(" ".join([s.decode() for s in o if not isinstance(s, int)]) for o in out)
-	)
-
-	return "search" in parsed_output
+		parsed_output = " ".join(
+			(" ".join([s.decode() for s in o if not isinstance(s, int)]) for o in out)
+		)
+		return "search" in parsed_output
+	except Exception:
+		return False
 
 def if_redisearch_loaded(function):
 	"Decorator to check if Redisearch is loaded."


### PR DESCRIPTION
**Issue:**
- For E-commerce , stray methods in `redisearch.py` are run to create search indexes. 
- These are only run if redisearch is installed
- To check this `is_search_module_loaded` uses the redis command `MODULE LIST`
- However this command works only with redis > 4.0.0 (https://redis.io/commands/module-list). A lot of setups still run on older redis versions.
- The check breaks for them causing:
   ```py
     from erpnext.e_commerce.redisearch import (
  File "/home/frappe/benches/bench-version-13-2021-09-16/apps/erpnext/erpnext/e_commerce/redisearch.py", line 207, in <module>
    define_autocomplete_dictionary()
  File "/home/frappe/benches/bench-version-13-2021-09-16/apps/erpnext/erpnext/e_commerce/redisearch.py", line 35, in wrapper
    if is_search_module_loaded():
  File "/home/frappe/benches/bench-version-13-2021-09-16/apps/erpnext/erpnext/e_commerce/redisearch.py", line 24, in is_search_module_loaded
    out = cache.execute_command('MODULE LIST')
  File "/home/frappe/benches/bench-version-13-2021-09-16/env/lib/python3.6/site-packages/redis/client.py", line 901, in execute_command
    return self.parse_response(conn, command_name, **options)
  File "/home/frappe/benches/bench-version-13-2021-09-16/env/lib/python3.6/site-packages/redis/client.py", line 915, in parse_response
    response = connection.read_response()
  File "/home/frappe/benches/bench-version-13-2021-09-16/env/lib/python3.6/site-packages/redis/connection.py", line 756, in read_response
    raise response
  
   redis.exceptions.ResponseError: unknown command 'MODULE'
    ```
**Fix:**
- Return False on exceptions (most likely going to be this exception)
- If redis version is older then `is_search_module_loaded` will return False