### PR TITLE
feat: Allow creation of PL for multiple Customers

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.js
+++ b/erpnext/stock/doctype/pick_list/pick_list.js
@@ -146,10 +146,6 @@ frappe.ui.form.on('Pick List', {
 			customer: frm.doc.customer
 		};
 		frm.get_items_btn = frm.add_custom_button(__('Get Items'), () => {
-			if (!frm.doc.customer) {
-				frappe.msgprint(__('Please select Customer first'));
-				return;
-			}
 			erpnext.utils.map_current_doc({
 				method: 'erpnext.selling.doctype.sales_order.sales_order.create_pick_list',
 				source_doctype: 'Sales Order',

--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -30,6 +30,8 @@ class PickList(Document):
 
 	def before_submit(self):
 		for item in self.locations:
+			# set picked_qty to stock_qty, before submit
+			item.picked_qty = item.stock_qty
 			if not frappe.get_cached_value('Item', item.item_code, 'has_serial_no'):
 				continue
 			if not item.serial_no:
@@ -68,9 +70,10 @@ class PickList(Document):
 			item_doc.name = None
 
 			for row in locations:
-				row.update({
-					'picked_qty': row.stock_qty
-				})
+# Avoid setting picked qty on initial save. It will be set to stock_qty on submit
+#				row.update({
+#					'picked_qty': row.stock_qty
+#				})
 
 				location = item_doc.as_dict()
 				location.update(row)


### PR DESCRIPTION
1. To allow creation of PL from multiple customers, removed mandate of customer. On click of 'Get Items', user can now select Sales Orders from several customers into a single pick list.

<img width="1080" alt="Screenshot 2021-09-20 at 11 57 24 AM" src="https://user-images.githubusercontent.com/12999179/133963558-a03a4cd6-43b3-4425-9f84-c95783d7ca4e.png">

2. Set picked_qty to 0 on selection of Sales Orders. It will be set to stock_qty, on submit.
<img width="1080" alt="Screenshot 2021-09-20 at 12 01 30 PM" src="https://user-images.githubusercontent.com/12999179/133963794-26870b7a-355f-4a58-b6bb-6bad2871d2ec.png">

 
