### PR TITLE
chore: change log for v12.25.0

### DIFF
--- a/erpnext/change_log/v12/v12_25_0.md
+++ b/erpnext/change_log/v12/v12_25_0.md
@@ -1,0 +1,10 @@
+## Version 12.25.0 Release Notes
+
+### Fixes & Enhancements
+- Multiple price rules margin. ([#24844](https://github.com/frappe/erpnext/pull/24844))
+- Document naming rule not working for subscription invoices ([#27394](https://github.com/frappe/erpnext/pull/27394))
+- Prematurely referenced variable in buying controller for subcontracting ([#27333](https://github.com/frappe/erpnext/pull/27333))
+- Calculation of gross profit percentage in Gross Profit Report ([#26713](https://github.com/frappe/erpnext/pull/27045))
+- Price list rate not fetched for return sales invoice fixed ([#26593](https://github.com/frappe/erpnext/pull/26593))
+- Set production plan to completed even on over production ([#27027](https://github.com/frappe/erpnext/pull/27027))
+- Add `total_billing_hours` to Sales Invoice ([#26652](https://github.com/frappe/erpnext/pull/26652))


### PR DESCRIPTION
## Version 12.25.0 Release Notes

### Fixes & Enhancements
- Multiple price rules margin. ([#24844](https://github.com/frappe/erpnext/pull/24844))
- Document naming rule not working for subscription invoices ([#27394](https://github.com/frappe/erpnext/pull/27394))
- Prematurely referenced variable in buying controller for subcontracting ([#27333](https://github.com/frappe/erpnext/pull/27333))
- Calculation of gross profit percentage in Gross Profit Report ([#26713](https://github.com/frappe/erpnext/pull/27045))
- Price list rate not fetched for return sales invoice fixed ([#26593](https://github.com/frappe/erpnext/pull/26593))
- Set production plan to completed even on over production ([#27027](https://github.com/frappe/erpnext/pull/27027))
- Add `total_billing_hours` to Sales Invoice ([#26652](https://github.com/frappe/erpnext/pull/26652))