### PR TITLE
feat(regional): toggle for reduced depreciation rate as per IT Act

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -394,10 +394,6 @@ class Asset(AccountsController):
 			if cint(self.number_of_depreciations_booked) > cint(row.total_number_of_depreciations):
 				frappe.throw(_("Number of Depreciations Booked cannot be greater than Total Number of Depreciations"))
 
-		if row.depreciation_start_date and getdate(row.depreciation_start_date) < getdate(nowdate()):
-			frappe.msgprint(_("Depreciation Row {0}: Depreciation Start Date is entered as past date")
-				.format(row.idx), title=_('Warning'), indicator='red')
-
 		if row.depreciation_start_date and getdate(row.depreciation_start_date) < getdate(self.purchase_date):
 			frappe.throw(_("Depreciation Row {0}: Next Depreciation Date cannot be before Purchase Date")
 				.format(row.idx))

--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -645,12 +645,18 @@ class TestAsset(unittest.TestCase):
 		pr = make_purchase_receipt(item_code="Macbook Pro",
 			qty=1, rate=8000.0, location="Test Location")
 
+		finance_book = frappe.new_doc('Finance Book')
+		finance_book.finance_book_name = 'Income Tax'
+		finance_book.for_income_tax = 1
+		finance_book.insert(ignore_if_duplicate=1)
+
 		asset_name = frappe.db.get_value("Asset", {"purchase_receipt": pr.name}, 'name')
 		asset = frappe.get_doc('Asset', asset_name)
 		asset.calculate_depreciation = 1
 		asset.available_for_use_date = '2030-07-12'
 		asset.purchase_date = '2030-01-01'
 		asset.append("finance_books", {
+			"finance_book": finance_book.name,
 			"expected_value_after_useful_life": 1000,
 			"depreciation_method": "Written Down Value",
 			"total_number_of_depreciations": 3,

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -309,3 +309,4 @@ erpnext.patches.v13_0.update_dates_in_tax_withholding_category
 erpnext.patches.v14_0.update_opportunity_currency_fields
 erpnext.patches.v13_0.gst_fields_for_pos_invoice
 erpnext.patches.v13_0.create_accounting_dimensions_in_pos_doctypes
+erpnext.patches.v13_0.create_custom_field_for_finance_book

--- a/erpnext/patches/v13_0/create_custom_field_for_finance_book.py
+++ b/erpnext/patches/v13_0/create_custom_field_for_finance_book.py
@@ -1,0 +1,21 @@
+import frappe
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+
+
+def execute():
+	company = frappe.get_all('Company', filters = {'country': 'India'})
+	if not company:
+		return
+
+	custom_field = {
+		'Finance Book': [
+			{
+				'fieldname': 'for_income_tax',
+				'label': 'For Income Tax',
+				'fieldtype': 'Check',
+				'insert_after': 'finance_book_name',
+				'description': 'If the asset is put to use for less than 180 days, the first Depreciation Rate will be reduced by 50%.'
+			}
+		]
+	}
+	create_custom_fields(custom_field, update=1)

--- a/erpnext/regional/india/setup.py
+++ b/erpnext/regional/india/setup.py
@@ -663,6 +663,15 @@ def make_custom_fields(update=True):
 				'fieldtype': 'Data',
 				'insert_after': 'email'
 			}
+		],
+		'Finance Book': [
+			{
+				'fieldname': 'for_income_tax',
+				'label': 'For Income Tax',
+				'fieldtype': 'Check',
+				'insert_after': 'finance_book_name',
+				'description': 'If the asset is put to use for less than 180 days, the first Depreciation Rate will be reduced by 50%.'
+			}
 		]
 	}
 	create_custom_fields(custom_fields, update=update)

--- a/erpnext/regional/india/utils.py
+++ b/erpnext/regional/india/utils.py
@@ -860,12 +860,13 @@ def get_depreciation_amount(asset, depreciable_value, row):
 		rate_of_depreciation = row.rate_of_depreciation
 		# if its the first depreciation
 		if depreciable_value == asset.gross_purchase_amount:
-			# as per IT act, if the asset is purchased in the 2nd half of fiscal year, then rate is divided by 2
-			diff = date_diff(row.depreciation_start_date, asset.available_for_use_date)
-			if diff <= 180:
-				rate_of_depreciation = rate_of_depreciation / 2
-				frappe.msgprint(
-					_('As per IT Act, the rate of depreciation for the first depreciation entry is reduced by 50%.'))
+			if row.finance_book and frappe.db.get_value('Finance Book', row.finance_book, 'for_income_tax'):
+				# as per IT act, if the asset is purchased in the 2nd half of fiscal year, then rate is divided by 2
+				diff = date_diff(row.depreciation_start_date, asset.available_for_use_date)
+				if diff <= 180:
+					rate_of_depreciation = rate_of_depreciation / 2
+					frappe.msgprint(
+						_('As per IT Act, the rate of depreciation for the first depreciation entry is reduced by 50%.'))
 
 		depreciation_amount = flt(depreciable_value * (flt(rate_of_depreciation) / 100))
 


### PR DESCRIPTION
The rate of depreciation should only be reduced if a company maintains a depreciation schedule as per the income tax act.

The rate shouldn't be reduced for the depreciation schedules which the company maintains in their books.

Added a toggle in the Finance Book to enable/disable the automatic reduction in the depreciation rate.

<img width="547" alt="CleanShot 2021-09-20 at 16 26 49@2x" src="https://user-images.githubusercontent.com/25369014/133991424-b9c9a185-b17e-48c9-82ee-a735ca2c2462.png">
