### PR TITLE
fix(ux): warn when overbilling allowance was bypassed due to role

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -993,8 +993,8 @@ class AccountsController(TransactionBase):
 				item.get(item_ref_dn), based_on), self.precision(based_on, item))
 			if not ref_amt:
 				frappe.msgprint(
-					_("Warning: System will not check overbilling since amount for Item {0} in {1} is zero")
-						.format(item.item_code, ref_dt))
+					_("System will not check overbilling since amount for Item {0} in {1} is zero")
+						.format(item.item_code, ref_dt), title=_("Warning"), indicator="orange")
 				continue
 
 			already_billed = frappe.db.sql("""
@@ -1002,7 +1002,7 @@ class AccountsController(TransactionBase):
 				from `tab%s`
 				where %s=%s and docstatus=1 and parent != %s
 			""" % (based_on, self.doctype + " Item", item_ref_dn, '%s', '%s'),
-			   (item.get(item_ref_dn), self.name))[0][0]
+				(item.get(item_ref_dn), self.name))[0][0]
 
 			total_billed_amt = flt(flt(already_billed) + flt(item.get(based_on)),
 				self.precision(based_on, item))
@@ -1027,8 +1027,8 @@ class AccountsController(TransactionBase):
 					self.throw_overbill_exception(item, max_allowed_amt)
 
 		if role_allowed_to_over_bill in user_roles and total_overbilled_amt > 0.1:
-			frappe.msgprint(_("INFO: Overbilling of {} ignored because you have {} role.")
-					.format(total_overbilled_amt, role_allowed_to_over_bill))
+			frappe.msgprint(_("Overbilling of {} ignored because you have {} role.")
+					.format(total_overbilled_amt, role_allowed_to_over_bill), title=_("Warning"), indicator="orange")
 
 	def throw_overbill_exception(self, item, max_allowed_amt):
 		frappe.throw(_("Cannot overbill for Item {0} in row {1} more than {2}. To allow over-billing, please set allowance in Accounts Settings")

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -980,6 +980,9 @@ class AccountsController(TransactionBase):
 		item_allowance = {}
 		global_qty_allowance, global_amount_allowance = None, None
 
+		role_allowed_to_over_bill = frappe.db.get_single_value('Accounts Settings', 'role_allowed_to_over_bill')
+		user_roles = frappe.get_roles()
+
 		for item in self.get("items"):
 			if item.get(item_ref_dn):
 				ref_amt = flt(frappe.db.get_value(ref_dt + " Item",
@@ -1009,9 +1012,7 @@ class AccountsController(TransactionBase):
 						total_billed_amt = abs(total_billed_amt)
 						max_allowed_amt = abs(max_allowed_amt)
 
-					role_allowed_to_over_bill = frappe.db.get_single_value('Accounts Settings', 'role_allowed_to_over_bill')
-
-					if total_billed_amt - max_allowed_amt > 0.01 and role_allowed_to_over_bill not in frappe.get_roles():
+					if total_billed_amt - max_allowed_amt > 0.01 and role_allowed_to_over_bill not in user_roles:
 						if self.doctype != "Purchase Invoice":
 							self.throw_overbill_exception(item, max_allowed_amt)
 						elif not cint(frappe.db.get_single_value("Buying Settings", "bill_for_rejected_quantity_in_purchase_invoice")):


### PR DESCRIPTION
Change:
- Show message when user has overbilled but system ignored it due to their role. 
- Refactor code (excessive indentation)
- minor perf changes - extract loop invariants like global settings and user's roles. 

![Screenshot 2021-09-20 at 4 30 47 PM](https://user-images.githubusercontent.com/9079960/133993358-ba74f95f-f4a0-4c65-8204-328f64b2c255.png)
