### PR TITLE
fix(Payment Reconciliation): reference row added in allocation table

### DIFF
--- a/erpnext/accounts/doctype/payment_reconciliation_allocation/payment_reconciliation_allocation.json
+++ b/erpnext/accounts/doctype/payment_reconciliation_allocation/payment_reconciliation_allocation.json
@@ -7,6 +7,7 @@
  "field_order": [
   "reference_type",
   "reference_name",
+  "reference_row",
   "column_break_3",
   "invoice_type",
   "invoice_number",
@@ -121,11 +122,17 @@
    "label": "Amount",
    "options": "Currency",
    "read_only": 1
+  },
+  {
+   "fieldname": "reference_row",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Reference Row"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2021-08-30 10:58:42.665107",
+ "modified": "2021-09-20 17:23:09.455803",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Reconciliation Allocation",


### PR DESCRIPTION
Added Reference Row field in Payment Reconciliation Allocation table.
Fixes this [issue](https://discuss.erpnext.com/t/bug-in-payment-reconciliation-v13-11-0/80407).

Try reconciling a sales invoice with journal entry to replicate the issue.