### PR TITLE
fix: update default KSA VAT rate for setup

### DIFF
--- a/erpnext/setup/setup_wizard/data/country_wise_tax.json
+++ b/erpnext/setup/setup_wizard/data/country_wise_tax.json
@@ -2116,9 +2116,9 @@
 	},
 
 	"Saudi Arabia": {
-		"KSA VAT 5%": {
-			"account_name": "VAT 5%",
-			"tax_rate": 5.00
+		"KSA VAT 15%": {
+			"account_name": "VAT 15%",
+			"tax_rate": 15.00
 		},
 		"KSA VAT Zero": {
 			"account_name": "VAT Zero",


### PR DESCRIPTION
VAT rate in KSA was updated by the government from 5% to 15%. ERPNext still sets it up at 5% to date.

source: 

https://taxsummaries.pwc.com/saudi-arabia/corporate/other-taxes

https://www2.deloitte.com/ly/en/pages/tax/articles/ksa-vat-rate-increase-15percent-1-july-2020.html

This PR updates the standard/default VAT to 15%. 

EDIT: can be backported to v13 and v12. 

no-docs