### PR TITLE
fix: previous_sle() fetched incorrect sle for batched items

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -426,6 +426,7 @@ class StockEntry(StockController):
 			previous_sle = get_previous_sle({
 				"item_code": d.item_code,
 				"warehouse": d.s_warehouse or d.t_warehouse,
+				"batch_no": d.batch_no or "",
 				"posting_date": self.posting_date,
 				"posting_time": self.posting_time
 			})

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -855,9 +855,11 @@ def get_previous_sle(args, for_update=False):
 			"posting_date": "2012-12-12",
 			"posting_time": "12:00",
 			"sle": "name of reference Stock Ledger Entry"
+			"batch_no": "Batch 1"
 		}
 	"""
 	args["name"] = args.get("sle", None) or ""
+	args["batch_no"] = args.get("batch_no", None) or ""
 	sle = get_stock_ledger_entries(args, "<=", "desc", "limit 1", for_update=for_update)
 	return sle and sle[0] or {}
 
@@ -869,6 +871,9 @@ def get_stock_ledger_entries(previous_sle, operator=None,
 		conditions += " and warehouse = %(warehouse)s"
 	elif previous_sle.get("warehouse_condition"):
 		conditions += " and " + previous_sle.get("warehouse_condition")
+
+	if previous_sle.get("batch_no"):
+		conditions += "and batch_no = %(batch_no)s"
 
 	if check_serial_no and previous_sle.get("serial_no"):
 		# conditions += " and serial_no like {}".format(frappe.db.escape('%{0}%'.format(previous_sle.get("serial_no"))))


### PR DESCRIPTION
## Issue

### For Example
Let's consider Item **"Batch Item 1"** with batch **"NSJ0001"** and "Allow Negative Stock" is disabled.
![image](https://user-images.githubusercontent.com/43572428/134126793-e362598f-4e01-47c4-bf9f-7ad80085f629.png)

Now if we try to make a back-dated stock entry for Batch **"NSJ0001"**, it does not throw a negative stock error.
![sle](https://user-images.githubusercontent.com/43572428/134127799-26816088-a401-4b93-9c69-3bca791f2dcd.gif)

## Reason
- `previous_sle()` did not consider batch_no while fetching the last SLE. It used to fetch only on t he basis of item_code and warehouse.
- This would fetch wrong actual_qty for batch items since there could be other batch's stock entries before the original batch date. 

## Fix

- `previous_sle()` now fetches last SLE based on batch_no for batched items.