### PR TITLE
fix: (ux) Use subassembly schedule date while making WO from Prod Plan

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -457,7 +457,8 @@ class ProductionPlan(Document):
 
 	def prepare_args_for_sub_assembly_items(self, row, args):
 		for field in ["production_item", "item_name", "qty", "fg_warehouse",
-			"description", "bom_no", "stock_uom", "bom_level", "production_plan_item"]:
+			"description", "bom_no", "stock_uom", "bom_level",
+			"production_plan_item", "schedule_date"]:
 			args[field] = row.get(field)
 
 		args.update({


### PR DESCRIPTION
**Issue:**
- Consider the following Production Plan with Subassembly items. Notice the different **Planned Start Date** in the first table and the different **Schedule Date** in the lower subassembly items table
  ![Screenshot 2021-09-21 at 2 22 49 PM](https://user-images.githubusercontent.com/25857446/134142273-a46b1eba-b9a1-424e-9593-7f15df46b751.png)
- Submit the Production plan and create Work orders from it. 
- The **Planned Start Date** in the new Work Order does not respect the **Schedule Date** for the **subassembly items**
  ![Screenshot 2021-09-21 at 2 21 31 PM](https://user-images.githubusercontent.com/25857446/134142468-15b3758a-b38b-494f-b5b7-0d14fcce3c2d.png)

 **After fix:**
![Screenshot 2021-09-21 at 2 22 21 PM](https://user-images.githubusercontent.com/25857446/134142551-bc28aded-9af0-49cc-b951-c62d02148bae.png)


**To test:**
- Create a multi-level BOM
- Create two sales orders against this BOM's top most Item
- Create a Production Plan pull these Sales Orders and items in
- Change the Items to Manufacture's **Planned Start Date**
- Click on Get Sub Assembly Items, their schedule dates should be pulled according to the date change
- Submit Production Plan
- Create Work orders. Observe the sub assembly Work Order's **Planned Start Date**