### PR TITLE
fix: remove unknown field employee_name from query

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -677,7 +677,7 @@ def get_job_details(start, end, filters=None):
 	conditions = get_filters_cond("Job Card", filters, [])
 
 	job_cards = frappe.db.sql(""" SELECT `tabJob Card`.name, `tabJob Card`.work_order,
-			`tabJob Card`.employee_name, `tabJob Card`.status, ifnull(`tabJob Card`.remarks, ''),
+			`tabJob Card`.status, ifnull(`tabJob Card`.remarks, ''),
 			min(`tabJob Card Time Log`.from_time) as from_time,
 			max(`tabJob Card Time Log`.to_time) as to_time
 		FROM `tabJob Card` , `tabJob Card Time Log`

--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -687,7 +687,7 @@ def get_job_details(start, end, filters=None):
 
 	for d in job_cards:
 			subject_data = []
-			for field in ["name", "work_order", "remarks", "employee_name"]:
+			for field in ["name", "work_order", "remarks"]:
 				if not d.get(field): continue
 
 				subject_data.append(d.get(field))


### PR DESCRIPTION


> we access Job Card, Calendar View, we have this error:
Unknown column 'tabJob Card.employee_name

This PR removes that obsolete field from the query.