### PR TITLE
fix: tax rate being overridden in case of 0.00

### DIFF
--- a/erpnext/hr/doctype/expense_claim/test_expense_claim.py
+++ b/erpnext/hr/doctype/expense_claim/test_expense_claim.py
@@ -176,7 +176,7 @@ def generate_taxes():
 	account = create_account(company=company_name, account_name="Output Tax CGST", account_type="Tax", parent_account=parent_account)
 	return {'taxes':[{
 		"account_head": account,
-		"rate": 0,
+		"rate": 9,
 		"description": "CGST",
 		"tax_amount": 10,
 		"total": 210

--- a/erpnext/hr/doctype/expense_taxes_and_charges/expense_taxes_and_charges.json
+++ b/erpnext/hr/doctype/expense_taxes_and_charges/expense_taxes_and_charges.json
@@ -56,8 +56,6 @@
   },
   {
    "columns": 2,
-   "fetch_from": "account_head.tax_rate",
-   "fetch_if_empty": 1,
    "fieldname": "rate",
    "fieldtype": "Float",
    "in_list_view": 1,


### PR DESCRIPTION
In expense claim, tax rate could be different for different expenses.Therefore, rate is kept as 0.00 and tax amount entered manually in the tax table.
But fetch functionality overrides the tax rate (upon saving) and mess up the amount.

This PR removes the fetch functionality of the rate column.
#no-docs Please backport to v13 and v12 as well.