### PR TITLE
fix: cannot set custom label for 'total' field in print format

### DIFF
--- a/erpnext/templates/print_formats/includes/total.html
+++ b/erpnext/templates/print_formats/includes/total.html
@@ -7,7 +7,7 @@
 		</div>
 	{% else %}
 		<div class="col-xs-5 {%- if doc.align_labels_right %} text-right{%- endif -%}">
-			<label>{{ _(doc.meta.get_label('total')) }}</label></div>
+			<label>{{ _(df.label) }}</label></div>
 		<div class="col-xs-7 text-right">
 			{{ doc.get_formatted("total", doc) }}
 		</div>


### PR DESCRIPTION
The 'Total' field is rendered with a custom template in Sales Invoice print formats.

The template fetches the label from meta, which required users to change the label from the Customize Form to change the label in print format

To test the fix:
- Open any custom print format of Sales Invoice
- Using Print Format Builder, change the label of Total field
- Check if the label is changed in any document's print preview.

