### PR TITLE
fix: wrong company selected when marking attendance for all employees

### DIFF
--- a/erpnext/hr/doctype/employee_attendance_tool/employee_attendance_tool.py
+++ b/erpnext/hr/doctype/employee_attendance_tool/employee_attendance_tool.py
@@ -55,7 +55,7 @@ def mark_employee_attendance(employee_list, status, date, leave_type=None, compa
 		else:
 			leave_type = None
 
-		company = frappe.db.get_value("Employee", employee['employee'], "Company")
+		company = frappe.db.get_value("Employee", employee['employee'], "Company", cache=True)
 
 		attendance=frappe.get_doc(dict(
 			doctype='Attendance',

--- a/erpnext/hr/doctype/employee_attendance_tool/employee_attendance_tool.py
+++ b/erpnext/hr/doctype/employee_attendance_tool/employee_attendance_tool.py
@@ -55,8 +55,7 @@ def mark_employee_attendance(employee_list, status, date, leave_type=None, compa
 		else:
 			leave_type = None
 
-		if not company:
-			company = frappe.db.get_value("Employee", employee['employee'], "Company")
+		company = frappe.db.get_value("Employee", employee['employee'], "Company")
 
 		attendance=frappe.get_doc(dict(
 			doctype='Attendance',


### PR DESCRIPTION
Before this fix the employee attendance tool would set wrong company for an employee if attendance for all employees was marked at the same time.

After this fix appropriate company is set for each of the employee when the attendance is marked for all employees.

Employee 1 Company
<img width="1359" alt="Screenshot 2021-09-28 at 2 10 25 PM" src="https://user-images.githubusercontent.com/49878143/135055414-2f301be8-c8f5-4159-adaf-9200ddff0c8d.png">

Employee 2 Company
<img width="1348" alt="Screenshot 2021-09-28 at 2 11 23 PM" src="https://user-images.githubusercontent.com/49878143/135055442-73a14cb6-d47b-4907-a379-d4050737936b.png">

Before fix 
<img width="1350" alt="Screenshot 2021-09-28 at 2 18 40 PM" src="https://user-images.githubusercontent.com/49878143/135055715-0230f420-d706-4aa4-b7f0-b6a584997be0.png">

<img width="1345" alt="Screenshot 2021-09-28 at 2 14 16 PM" src="https://user-images.githubusercontent.com/49878143/135055751-87a40950-f096-4904-b4c3-fa18ec27712f.png">

After fix

<img width="1370" alt="Screenshot 2021-09-28 at 2 13 17 PM" src="https://user-images.githubusercontent.com/49878143/135055904-9e08e2f0-7a2e-4c70-8671-be98d34d643a.png">
<img width="1348" alt="Screenshot 2021-09-28 at 2 11 23 PM" src="https://user-images.githubusercontent.com/49878143/135055913-eefa4a93-19b4-4227-8731-8fb3bbc9634d.png">


