### PR TITLE
fix: update variant qty in BOM, Create Work Order dialog

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.js
+++ b/erpnext/manufacturing/doctype/bom/bom.js
@@ -215,7 +215,32 @@ frappe.ui.form.on("BOM", {
 				label: __('Qty To Manufacture'),
 				fieldname: 'qty',
 				reqd: 1,
-				default: 1
+				default: 1,
+				onchange: () => {
+					const { quantity, items: rm } = frm.doc;
+					const variant_items_map = rm.reduce((acc, item) => {
+						acc[item.item_code] = item.qty;
+						return acc;
+					}, {});
+					const mf_qty = cur_dialog.fields_list.filter(
+						(f) => f.df.fieldname === "qty"
+					)[0]?.value;
+					const items = cur_dialog.fields.filter(
+						(f) => f.fieldname === "items"
+					)[0]?.data;
+
+					if (!items) {
+						return;
+					}
+
+					items.forEach((item) => {
+						item.qty =
+							(variant_items_map[item.item_code] * mf_qty) /
+							quantity;
+					});
+
+					cur_dialog.refresh();
+				}
 			});
 		}
 


### PR DESCRIPTION
### Description
- Create Work Order dialog doesn't update the qty of the variant item on updating fg qty.
- Now it does on clicking away from the fg qty field.

<details>
<summary>Before</summary>

https://user-images.githubusercontent.com/29507195/135069438-a544f9bf-8d80-452e-a2d1-47eb6bda2747.mov

</details>
<details>
<summary>After</summary>

https://user-images.githubusercontent.com/29507195/135069528-ff229423-350d-4cbd-8971-a59f0048ae8b.mov

</details>