### PR TITLE
fix: cannot delete a project if linked with sales order

### DIFF
--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -86,6 +86,10 @@ class Project(Document):
 		if self.sales_order:
 			frappe.db.set_value("Sales Order", self.sales_order, "project", self.name)
 
+	def on_trash(self):
+		for so in frappe.get_all("Sales Order", {"project": self.name}, ["name"], as_dict=1):
+			frappe.db.set_value("Sales Order", so.name, "project", "")
+
 	def update_percent_complete(self):
 		if self.percent_complete_method == "Manual":
 			if self.status == "Completed":

--- a/erpnext/projects/doctype/project/test_project.py
+++ b/erpnext/projects/doctype/project/test_project.py
@@ -48,7 +48,7 @@ class TestProject(unittest.TestCase):
 		so.reload()
 		self.assertFalse(so.project)
 
-def get_project(name, template):
+def get_project(name):
 	template = get_project_template()
 
 	project = frappe.get_doc(dict(

--- a/erpnext/projects/doctype/project/test_project.py
+++ b/erpnext/projects/doctype/project/test_project.py
@@ -8,7 +8,8 @@ test_records = frappe.get_test_records('Project')
 test_ignore = ["Sales Order"]
 
 from erpnext.projects.doctype.project_template.test_project_template import get_project_template, make_project_template
-from erpnext.projects.doctype.project.project import set_project_status
+from erpnext.selling.doctype.sales_order.sales_order import make_project as make_project_from_so
+from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
 
 from frappe.utils import getdate
 
@@ -32,7 +33,22 @@ class TestProject(unittest.TestCase):
 		self.assertEqual(task4.subject, 'Task 4')
 		self.assertEqual(getdate(task4.exp_end_date), getdate('2019-01-06'))
 
-def get_project(name):
+	def test_project_linking_with_sales_order(self):
+		so = make_sales_order()
+		project = make_project_from_so(so.name)
+
+		project.save()
+		self.assertEqual(project.sales_order, so.name)
+
+		so.reload()
+		self.assertEqual(so.project, project.name)
+
+		project.delete()
+
+		so.reload()
+		self.assertFalse(so.project)
+
+def get_project(name, template):
 	template = get_project_template()
 
 	project = frappe.get_doc(dict(


### PR DESCRIPTION
Backport of #27689