### PR TITLE
fix: restore inadvertently removed function `calculate_total_billing_amount`

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -1004,6 +1004,18 @@ frappe.ui.form.on("Sales Invoice Timesheet", {
 	}
 });
 
+var calculate_total_billing_amount =  function(frm) {
+	var doc = frm.doc;
+
+	doc.total_billing_amount = 0.0
+	if (doc.timesheets) {
+		doc.timesheets.forEach((d) => {
+			doc.total_billing_amount += flt(d.billing_amount)
+		});
+	}
+
+	refresh_field('total_billing_amount')
+}
 
 var set_timesheet_detail_rate = function(cdt, cdn, currency, timelog) {
 	frappe.call({


### PR DESCRIPTION
`calculate_total_billing_amount` was inadvertently removed [here](https://github.com/frappe/erpnext/commit/8547cb5448f5a38e59f5f6800615957a2081b1e7#diff-bb9310f10e3db773b4664e5f5fd681670d41beca380c1a967fcfc44acea8b2cdL972), although it is still being used whenever the `currency` event is triggered.

---

![image](https://user-images.githubusercontent.com/16315650/135225623-ced81eba-4210-4864-82e0-6d0da752b1c5.png)