### PR TITLE
fix: remove stale doctypes and add msg for ecommerce refactor

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -317,3 +317,4 @@ erpnext.patches.v13_0.replace_supplier_item_group_with_party_specific_item
 erpnext.patches.v13_0.create_accounting_dimensions_in_pos_doctypes
 erpnext.patches.v13_0.create_custom_field_for_finance_book
 erpnext.patches.v13_0.modify_invalid_gain_loss_gl_entries
+erpnext.patches.v13_0.shopping_cart_to_ecommerce

--- a/erpnext/patches/v13_0/shopping_cart_to_ecommerce.py
+++ b/erpnext/patches/v13_0/shopping_cart_to_ecommerce.py
@@ -1,0 +1,29 @@
+import click
+import frappe
+
+
+def execute():
+
+	frappe.delete_doc("DocType", "Shopping Cart Settings", ignore_missing=True)
+	frappe.delete_doc("DocType", "Products Settings", ignore_missing=True)
+	frappe.delete_doc("DocType", "Supplier Item Group", ignore_missing=True)
+
+	if frappe.db.get_single_value("E Commerce Settings", "enabled"):
+		notify_users()
+
+
+def notify_users():
+
+	click.secho(
+		"Shopping cart and Product settings are merged into E-commerce settings.\n"
+		"Checkout the documentation to learn more:"
+		"https://docs.erpnext.com/docs/v13/user/manual/en/e_commerce/set_up_e_commerce",
+		fg="yellow",
+	)
+
+	note = frappe.new_doc("Note")
+	note.title = "New E-Commerce Module"
+	note.public = 1
+	note.notify_on_login = 1
+	note.content = """<div class="ql-editor read-mode"><p>You are seeing this message because Shopping Cart is enabled on your site. </p><p><br></p><p>Shopping Cart Settings and Products settings are now merged into "E Commerce Settings". </p><p><br></p><p>You can learn about new and improved E-Commerce features in the official documentation.</p><ol><li data-list="bullet"><span class="ql-ui" contenteditable="false"></span><a href="https://docs.erpnext.com/docs/v13/user/manual/en/e_commerce/set_up_e_commerce" rel="noopener noreferrer">https://docs.erpnext.com/docs/v13/user/manual/en/e_commerce/set_up_e_commerce</a></li></ol><p><br></p></div>"""
+	note.save()


### PR DESCRIPTION
Closes https://github.com/frappe/erpnext/issues/27550 & ISS-21-22-06573

- delete stale doctypes and leave a message for all users when logging in. (only on sites where E commerce is enabled)

![Screenshot 2021-09-29 at 11 13 34 PM](https://user-images.githubusercontent.com/9079960/135322464-5bdba58e-f09c-4e08-97a6-8cc8a73af37f.png)
