### PR TITLE
fix(India): Internal transfer check fix

### DIFF
--- a/erpnext/regional/india/utils.py
+++ b/erpnext/regional/india/utils.py
@@ -248,6 +248,9 @@ def is_internal_transfer(party_details, doctype):
 	elif doctype in ("Purchase Invoice", "Purchase Order", "Purchase Receipt"):
 		destination_gstin = party_details.supplier_gstin
 
+	if not destination_gstin or party_details.gstin:
+		return False
+
 	if party_details.gstin == destination_gstin:
 		return True
 	else:


### PR DESCRIPTION
If neither the Customer/Supplier nor the Company Address had a GSTIN added, then the transaction between these parties was wrongly considered an internal transaction.

Due to this when a PO was converted to Purchase Invoice, the taxes added in PO were removed when it got converted to Purchase Invoice

Steps to test:
1. Add a Company Address with no GSTIN
2. Add an address for a Supplier without GSTIN
3. Make a Purchase Order, with that company (company should have country as India) add some taxes in it
4. Using the menu option convert the Order to Invoice and make sure the same taxes from PO are copied in the invoice