### PR TITLE
fix: sync_jobs fails

### DIFF
--- a/erpnext/support/doctype/service_level_agreement/service_level_agreement.json
+++ b/erpnext/support/doctype/service_level_agreement/service_level_agreement.json
@@ -203,10 +203,11 @@
   }
  ],
  "links": [],
- "modified": "2021-07-27 11:16:45.596579",
+ "modified": "2021-10-02 11:32:55.556024",
  "modified_by": "Administrator",
  "module": "Support",
  "name": "Service Level Agreement",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {

--- a/erpnext/support/doctype/service_level_agreement/service_level_agreement.py
+++ b/erpnext/support/doctype/service_level_agreement/service_level_agreement.py
@@ -339,7 +339,7 @@ def set_documents_with_active_service_level_agreement():
 
 def apply(doc, method=None):
 	# Applies SLA to document on validate
-	if frappe.flags.in_patch or frappe.flags.in_install or frappe.flags.in_setup_wizard or \
+	if frappe.flags.in_patch or frappe.flags.in_migrate or frappe.flags.in_install or frappe.flags.in_setup_wizard or \
 		doc.doctype not in get_documents_with_active_service_level_agreement():
 		return
 


### PR DESCRIPTION
Fixes:

```
  File "/Users/saqibansari/frappe/bench-v13/apps/frappe/frappe/commands/site.py", line 306, in migrate
    migrate(
  File "/Users/saqibansari/frappe/bench-v13/apps/frappe/frappe/migrate.py", line 70, in migrate
    sync_jobs()
  File "/Users/saqibansari/frappe/bench-v13/apps/frappe/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py", line 134, in sync_jobs
    all_events = insert_events(scheduler_events)
  File "/Users/saqibansari/frappe/bench-v13/apps/frappe/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py", line 146, in insert_events
    event_jobs += insert_event_jobs(events, event_type)
  File "/Users/saqibansari/frappe/bench-v13/apps/frappe/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py", line 164, in insert_event_jobs
    insert_single_event(frequency, event)
  File "/Users/saqibansari/frappe/bench-v13/apps/frappe/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py", line 183, in insert_single_event
    doc.insert()
  File "/Users/saqibansari/frappe/bench-v13/apps/frappe/frappe/model/document.py", line 235, in insert
    self.run_before_save_methods()
  File "/Users/saqibansari/frappe/bench-v13/apps/frappe/frappe/model/document.py", line 965, in run_before_save_methods
    self.run_method("validate")
  File "/Users/saqibansari/frappe/bench-v13/apps/frappe/frappe/model/document.py", line 859, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/Users/saqibansari/frappe/bench-v13/apps/frappe/frappe/model/document.py", line 1155, in composer
    return composed(self, method, *args, **kwargs)
  File "/Users/saqibansari/frappe/bench-v13/apps/frappe/frappe/model/document.py", line 1140, in runner
    add_to_return_value(self, f(self, method, *args, **kwargs))
  File "/Users/saqibansari/frappe/bench-v13/apps/erpnext/erpnext/support/doctype/service_level_agreement/service_level_agreement.py", line 343, in apply
    doc.doctype not in get_documents_with_active_service_level_agreement():
  File "/Users/saqibansari/frappe/bench-v13/apps/erpnext/erpnext/support/doctype/service_level_agreement/service_level_agreement.py", line 329, in get_documents_with_active_service_level_agreement
    return set_documents_with_active_service_level_agreement()
  File "/Users/saqibansari/frappe/bench-v13/apps/erpnext/erpnext/support/doctype/service_level_agreement/service_level_agreement.py", line 335, in set_documents_with_active_service_level_agreement
    active = [sla.document_type for sla in frappe.get_all("Service Level Agreement", fields=["document_type"])]
  File "/Users/saqibansari/frappe/bench-v13/apps/frappe/frappe/__init__.py", line 1464, in get_all
    return get_list(doctype, *args, **kwargs)
  File "/Users/saqibansari/frappe/bench-v13/apps/frappe/frappe/__init__.py", line 1437, in get_list
    return frappe.model.db_query.DatabaseQuery(doctype).execute(*args, **kwargs)
  File "/Users/saqibansari/frappe/bench-v13/apps/frappe/frappe/model/db_query.py", line 105, in execute
    result = self.build_and_run()
  File "/Users/saqibansari/frappe/bench-v13/apps/frappe/frappe/model/db_query.py", line 142, in build_and_run
    return frappe.db.sql(query, as_dict=not self.as_list, debug=self.debug,
  File "/Users/saqibansari/frappe/bench-v13/apps/frappe/frappe/database/database.py", line 144, in sql
    self._cursor.execute(query)
  File "/Users/saqibansari/frappe/frappe-env/lib/python3.8/site-packages/pymysql/cursors.py", line 148, in execute
    result = self._query(query)
  File "/Users/saqibansari/frappe/frappe-env/lib/python3.8/site-packages/pymysql/cursors.py", line 310, in _query
    conn.query(q)
  File "/Users/saqibansari/frappe/frappe-env/lib/python3.8/site-packages/pymysql/connections.py", line 548, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/Users/saqibansari/frappe/frappe-env/lib/python3.8/site-packages/pymysql/connections.py", line 775, in _read_query_result
    result.read()
  File "/Users/saqibansari/frappe/frappe-env/lib/python3.8/site-packages/pymysql/connections.py", line 1156, in read
    first_packet = self.connection._read_packet()
  File "/Users/saqibansari/frappe/frappe-env/lib/python3.8/site-packages/pymysql/connections.py", line 725, in _read_packet
    packet.raise_for_error()
  File "/Users/saqibansari/frappe/frappe-env/lib/python3.8/site-packages/pymysql/protocol.py", line 221, in raise_for_error
    err.raise_mysql_exception(self._data)
  File "/Users/saqibansari/frappe/frappe-env/lib/python3.8/site-packages/pymysql/err.py", line 143, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.OperationalError: (1054, "Unknown column 'document_type' in 'field list'")
```