### PR TITLE
fix: Display appropriate message for Payment Term discrepancies in Payment Entry

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -390,6 +390,9 @@ class PaymentEntry(AccountsController):
 						invoice_paid_amount_map[invoice_key]['discounted_amt'] = ref.total_amount * (term.discount / 100)
 
 		for key, allocated_amount in iteritems(invoice_payment_amount_map):
+			if not invoice_paid_amount_map.get(key):
+				frappe.throw(_('Payment term {0} not used in {1}').format(key[0], key[1]))
+
 			outstanding = flt(invoice_paid_amount_map.get(key, {}).get('outstanding'))
 			discounted_amt = flt(invoice_paid_amount_map.get(key, {}).get('discounted_amt'))
 


### PR DESCRIPTION
_Problem:_

When a Payment Entry is created for an Invoice, but the Payment Term in the Payment Entry does not correspond with the ones used in the Invoice, the following message is displayed:

![Screenshot 2021-10-02 at 8 50 37 PM](https://user-images.githubusercontent.com/25903035/135723137-35a32d87-9c7b-4cb1-b425-c0526f0cd4ee.png)

This doesn't give a clear indication of the problem, i.e. the mismatch in Payment Terms.

_Fix:_

Display the following message instead.

![Screenshot 2021-10-02 at 9 07 46 PM](https://user-images.githubusercontent.com/25903035/135723193-9d573f67-8c10-44ca-952e-687ad94a988b.png)

