### PR TITLE
ci(Mergify): configuration update

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,58 @@
+pull_request_rules:
+  - name: Auto-close PRs on stable branch
+    conditions:
+      - and:
+        - and:
+          - author!=surajshetty3416
+          - author!=gavindsouza
+          - author!=rohitwaghchaure
+          - author!=nabinhait
+        - or:
+          - base=version-13
+          - base=version-12
+    actions:
+      close:
+      comment:
+          message: |
+            @{{author}}, thanks for the contribution, but we do not accept pull requests on a stable branch. Please raise PR on an appropriate hotfix branch. 
+            https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist#which-branch
+
+  - name: backport to version-13-hotfix
+    conditions:
+      - label="backport version-13-hotfix"
+    actions:
+      backport:
+        branches:
+          - version-13-hotfix
+        assignees:
+          - "{{ author }}"
+
+  - name: backport to version-13-pre-release
+    conditions:
+      - label="backport version-13-pre-release"
+    actions:
+      backport:
+        branches:
+          - version-13-pre-release
+        assignees:
+          - "{{ author }}"
+
+  - name: backport to version-12-hotfix
+    conditions:
+      - label="backport version-12-hotfix"
+    actions:
+      backport:
+        branches:
+          - version-12-hotfix
+        assignees:
+          - "{{ author }}"
+
+  - name: backport to version-12-pre-release
+    conditions:
+      - label="backport version-12-pre-release"
+    actions:
+      backport:
+        branches:
+          - version-12-pre-release
+        assignees:
+          - "{{ author }}"


### PR DESCRIPTION
- Auto close PRs on stable branch
- Also use old labels for backporting (for backward compatibility with previous github action) 