### PR TITLE
fix(Subscription): reorder updation of end date

### DIFF
--- a/erpnext/accounts/doctype/subscription/subscription.py
+++ b/erpnext/accounts/doctype/subscription/subscription.py
@@ -290,7 +290,7 @@ class Subscription(Document):
 		invoice.flags.ignore_mandatory = True
 		invoice.set_missing_values()
 		invoice.save()
-		
+
 		if self.submit_invoice:
 			invoice.submit()
 
@@ -412,14 +412,16 @@ class Subscription(Document):
 			else:
 				self.set_status_grace_period()
 
-			if getdate() > getdate(self.current_invoice_end):
-				self.update_subscription_period(add_days(self.current_invoice_end, 1))
+			update_subscription = True if getdate() > getdate(self.current_invoice_end) else False
 
 			# Generate invoices periodically even if current invoice are unpaid
 			if self.generate_new_invoices_past_due_date and not self.is_current_invoice_generated() and (self.is_postpaid_to_invoice()
 				or self.is_prepaid_to_invoice()):
 				prorate = frappe.db.get_single_value('Subscription Settings', 'prorate')
 				self.generate_invoice(prorate)
+
+			if update_subscription:
+				self.update_subscription_period(add_days(self.current_invoice_end, 1))
 
 	@staticmethod
 	def is_not_outstanding(invoice):


### PR DESCRIPTION
- closes [issue/#27521](https://github.com/frappe/erpnext/issues/27521)
- This issue persists since the current end date is updated before `is_postpaid_to_invoice` and `is_prepaid_to_invoice` is run, and both end up returning `False` as `nowdate` will always be smaller than `current_invoice_end`.