### PR TITLE
fix: Delete linked Transaction Deletion Record docs on deleting company

### DIFF
--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -388,6 +388,7 @@ class Company(NestedSet):
 		frappe.db.sql("delete from tabEmployee where company=%s", self.name)
 		frappe.db.sql("delete from tabDepartment where company=%s", self.name)
 		frappe.db.sql("delete from `tabTax Withholding Account` where company=%s", self.name)
+		frappe.db.sql("delete from `tabTransaction Deletion Record` where company=%s", self.name)
 
 		# delete tax templates
 		frappe.db.sql("delete from `tabSales Taxes and Charges Template` where company=%s", self.name)


### PR DESCRIPTION
_Issue:_

Users are unable to delete Companies with linked Transaction Deletion Record docs.

![Screenshot 2021-10-05 at 10 16 25 AM](https://user-images.githubusercontent.com/25903035/135961657-8fb4eaa3-3e01-4f80-9a60-f50934df6d76.png)

_Fix:_

Delete all Transaction Deletion Record docs associated with a company on deleting it.