### PR TITLE
fix: Only calculate first_respone_time if SLA is set

### DIFF
--- a/erpnext/support/doctype/issue/issue.py
+++ b/erpnext/support/doctype/issue/issue.py
@@ -228,7 +228,7 @@ def get_time_in_timedelta(time):
 def set_first_response_time(communication, method):
 	if communication.get('reference_doctype') == "Issue":
 		issue = get_parent_doc(communication)
-		if is_first_response(issue):
+		if is_first_response(issue) and issue.service_level_agreement:
 			first_response_time = calculate_first_response_time(issue, get_datetime(issue.first_responded_on))
 			issue.db_set("first_response_time", first_response_time)
 


### PR DESCRIPTION
_Issue:_

First responses aren't being sent on Issues if the SLA field is not set. The following error pops up:

![Screenshot 2021-10-05 at 10 57 18 AM](https://user-images.githubusercontent.com/25903035/135965466-521c52e6-95bd-4ff0-bae2-9c2d1ed93fcc.png)

_Fix:_

Only calculate `first_respone_time` if SLA is set. `first_response_time` calculation requires SLAs, to fetch the working hours, thereby causing this error when it's not set. 

