### PR TITLE
fix: batch_no not mapped from PR to Stock Entry

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -842,7 +842,8 @@ def make_stock_entry(source_name,target_doc=None):
 			"doctype": "Stock Entry Detail",
 			"field_map": {
 				"warehouse": "s_warehouse",
-				"parent": "reference_purchase_receipt"
+				"parent": "reference_purchase_receipt",
+				"batch_no": "batch_no"
 			},
 		},
 	}, target_doc, set_missing_values)


### PR DESCRIPTION
### Issue
- Batch number isn't getting mapped when trying to create a stock entry from Purchase Receipt.

![batch_map](https://user-images.githubusercontent.com/43572428/135974767-2fe04016-464a-4e38-bb16-eb87b0ad44b4.gif)

### After Fix

![batch_map_fix](https://user-images.githubusercontent.com/43572428/135974927-4ecd6aa5-daf5-41a8-b3b4-8fe44cb67642.gif)

