### PR TITLE
docs: frappe school link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,12 @@ The ERPNext code is licensed as GNU General Public License (v3) and the Document
 
 ---
 
+## Learning
+
+1. [Frappe School](https://frappe.school) - Learn Frappe Framework and ERPNext from the various courses by the maintainers or from the community.
+
+---
+
 ## Logo and Trademark
 
 The brand name ERPNext and the logo are trademarks of Frappe Technologies Pvt. Ltd.


### PR DESCRIPTION
1. Added Frappe School link in ReadMe.

![Screenshot 2021-10-05 at 12 57 09 PM](https://user-images.githubusercontent.com/31363128/135978925-6cea92cc-af0a-4660-9381-7aadceba0688.png)


