### PR TITLE
feat(pick list): group items based on item code and warehouse before printing

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.json
+++ b/erpnext/stock/doctype/pick_list/pick_list.json
@@ -18,7 +18,9 @@
   "get_item_locations",
   "section_break_6",
   "locations",
-  "amended_from"
+  "amended_from",
+  "print_settings_section",
+  "group_same_items"
  ],
  "fields": [
   {
@@ -110,11 +112,24 @@
    "options": "STO-PICK-.YYYY.-",
    "reqd": 1,
    "set_only_once": 1
+  },
+  {
+   "fieldname": "print_settings_section",
+   "fieldtype": "Section Break",
+   "label": "Print Settings "
+  },
+  {
+   "allow_on_submit": 1,
+   "default": "0",
+   "fieldname": "group_same_items",
+   "fieldtype": "Check",
+   "label": "Group same items",
+   "print_hide": 1
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2020-03-17 11:38:41.932875",
+ "modified": "2021-10-04 19:13:38.629098",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Pick List",

--- a/erpnext/stock/doctype/pick_list/pick_list.json
+++ b/erpnext/stock/doctype/pick_list/pick_list.json
@@ -129,7 +129,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2021-10-04 19:13:38.629098",
+ "modified": "2021-10-05 11:09:55.696270",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Pick List",

--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -139,19 +139,18 @@ class PickList(Document):
 		count = 0
 
 		for item in self.locations:
-			group_item_qty[item.item_code] = group_item_qty.get(item.item_code, 0) + item.qty
-			group_picked_qty[item.item_code] = group_picked_qty.get(item.item_code, 0) + item.qty
-
+			group_item_qty[(item.item_code, item.warehouse)] = group_item_qty.get((item.item_code,item.warehouse), 0) + item.qty
+			group_picked_qty[(item.item_code, item.warehouse)] = group_picked_qty.get((item.item_code,item.warehouse), 0) + item.qty
 
 		duplicate_list = []
 		for item in self.locations:
-			if item.item_code in group_item_qty:
+			if (item.item_code, item.warehouse) in group_item_qty:
 				count += 1
-				item.qty = group_item_qty[item.item_code]
-				item.picked_qty = group_picked_qty[item.item_code]
-				item.stock_qty = group_item_qty[item.item_code]
+				item.qty = group_item_qty[(item.item_code, item.warehouse)]
+				item.picked_qty = group_picked_qty[(item.item_code, item.warehouse)]
+				item.stock_qty = group_item_qty[(item.item_code, item.warehouse)]
 				item.idx = count
-				del group_item_qty[item.item_code]
+				del group_item_qty[(item.item_code, item.warehouse)]
 			else:
 				duplicate_list.append(item)
 		for item in duplicate_list:

--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -140,7 +140,7 @@ class PickList(Document):
 
 		for item in self.locations:
 			group_item_qty[(item.item_code, item.warehouse)] = group_item_qty.get((item.item_code,item.warehouse), 0) + item.qty
-			group_picked_qty[(item.item_code, item.warehouse)] = group_picked_qty.get((item.item_code,item.warehouse), 0) + item.qty
+			group_picked_qty[(item.item_code, item.warehouse)] = group_picked_qty.get((item.item_code,item.warehouse), 0) + item.picked_qty
 
 		duplicate_list = []
 		for item in self.locations:


### PR DESCRIPTION
**Problem:**
 - Similar items on Pick List locations table aren't grouped before printing when fetched using "Get Items" button.
 
<img width="1158" alt="Screenshot 2021-10-05 at 2 40 49 PM" src="https://user-images.githubusercontent.com/13060550/135994916-7efac4f6-8db0-43b1-959b-985243a6ecae.png">

**Changes:**
- Added a setting called "Group Same Items" on Pick List under Printing Settings section.
- Grouped items based on item code and warehouse before printing.

Above items grouped based on item code and warehouse:
<img width="1185" alt="Screenshot 2021-10-05 at 2 41 10 PM" src="https://user-images.githubusercontent.com/13060550/135994932-70a58053-56b2-4930-abb9-f424125111ed.png">

Printing Settings:
<img width="595" alt="Screenshot 2021-10-05 at 2 16 34 PM" src="https://user-images.githubusercontent.com/13060550/135995255-a0ee8da9-7b1e-4d4c-9835-1fd64c453807.png">
