### PR TITLE
fix(healthcare): Availability slots display, disabled Practitioner Schedule

### DIFF
--- a/erpnext/healthcare/doctype/patient_appointment/patient_appointment.js
+++ b/erpnext/healthcare/doctype/patient_appointment/patient_appointment.js
@@ -433,11 +433,12 @@ let check_and_set_availability = function(frm) {
 				slot_html += `<br><span> <b> ${__('Maximum Capacity:')} </b> ${slot_info.service_unit_capacity} </span>`;
 			}
 
-			slot_html += '</div><br><br>';
+			slot_html += '</div><br>';
 
 			slot_html += slot_info.avail_slot.map(slot => {
 				appointment_count = 0;
 				disabled = false;
+				count_class = tool_tip = '';
 				start_str = slot.from_time;
 				slot_start_time = moment(slot.from_time, 'HH:mm:ss');
 				slot_end_time = moment(slot.to_time, 'HH:mm:ss');
@@ -486,10 +487,11 @@ let check_and_set_availability = function(frm) {
 						data-duration=${interval}
 						data-service-unit="${slot_info.service_unit || ''}"
 						style="margin: 0 10px 10px 0; width: auto;" ${disabled ? 'disabled="disabled"' : ""}
-						data-toggle="tooltip" title="${tool_tip}">
-						${start_str.substring(0, start_str.length - 3)}<br>
-						<span class='badge ${count_class}'> ${count} </span>
+						data-toggle="tooltip" title="${tool_tip || ''}">
+						${start_str.substring(0, start_str.length - 3)}
+						${slot_info.service_unit_capacity ? `<br><span class='badge ${count_class}'> ${count} </span>` : ''}
 					</button>`;
+
 			}).join("");
 
 			if (slot_info.service_unit_capacity) {

--- a/erpnext/healthcare/doctype/patient_appointment/patient_appointment.py
+++ b/erpnext/healthcare/doctype/patient_appointment/patient_appointment.py
@@ -354,7 +354,7 @@ def get_available_slots(practitioner_doc, date):
 		validate_practitioner_schedules(schedule_entry, practitioner)
 		practitioner_schedule = frappe.get_doc('Practitioner Schedule', schedule_entry.schedule)
 
-		if practitioner_schedule:
+		if practitioner_schedule and not practitioner_schedule.disabled:
 			available_slots = []
 			for time_slot in practitioner_schedule.time_slots:
 				if weekday == time_slot.day:


### PR DESCRIPTION
1 - Appointment slots for service units without overlap, badge and tooltip shows undefined

![Screen Shot 2021-10-04 at 7 21 07 PM](https://user-images.githubusercontent.com/3326959/135999968-42d9ac99-c316-4751-86a7-785c9aeace83.png)

Fix: conditionally show badge and tooltip

![Screen Shot 2021-10-04 at 7 22 43 PM](https://user-images.githubusercontent.com/3326959/136000003-8cdc6bba-8589-40f2-85cc-2b2dc033ff75.png)


2 - Practitioner Schedule if disabled shouldn't show up in Availability dialog, and wont be available for appointment booking