### PR TITLE
fix: ignore random periodicity in validations

### DIFF
--- a/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py
+++ b/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py
@@ -47,7 +47,7 @@ class MaintenanceSchedule(TransactionBase):
 			"Yearly": 365
 		}
 		for item in self.items:
-			if item.periodicity and item.start_date:
+			if item.periodicity and item.periodicity != "Random" and item.start_date:
 				if not item.end_date:
 					if item.no_of_visits:
 						item.end_date = add_days(item.start_date, item.no_of_visits * days_in_period[item.periodicity])


### PR DESCRIPTION
"Random" periodicity doesn't have a mapping in days_to_period dictionary. 


```
Error ReportTraceback (most recent call last):
 File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/form/save.py", line 21, in savedocs
  doc.save()
 File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 285, in save
  return self._save(*args, **kwargs)
 File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 320, in _save
  self.run_before_save_methods()
 File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 968, in run_before_save_methods
  self.run_method("validate")
 File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 860, in run_method
  out = Document.hook(fn)(self, *args, **kwargs)
 File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1158, in composer
  return composed(self, method, *args, **kwargs)
 File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1141, in runner
  add_to_return_value(self, fn(self, *args, **kwargs))
 File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 854, in 
  fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
 File "/home/frappe/frappe-bench/apps/erpnext/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py", line 202, in validate
  self.validate_end_date_visits()
 File "/home/frappe/frappe-bench/apps/erpnext/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py", line 57, in validate_end_date_visits
  no_of_visits = cint(diff / days_in_period[item.periodicity])
KeyError: 'Random'
```