### PR TITLE
ci: fail build if asset bundling fails

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -104,6 +104,8 @@ jobs:
 
       - name: Build Assets
         run: cd ~/frappe-bench/ && bench build
+        env:
+          CI: Yes
 
       - name: UI Tests
         run: cd ~/frappe-bench/ && bench --site test_site run-ui-tests erpnext --headless


### PR DESCRIPTION
depends on https://github.com/frappe/frappe/pull/14364

ref: https://github.com/frappe/frappe/pull/14318 