### PR TITLE
chore: change log for v13_12_0

### DIFF
--- a/erpnext/change_log/v13/v13_12_0.md
+++ b/erpnext/change_log/v13/v13_12_0.md
@@ -1,0 +1,43 @@
+# Version 13.12.0 Release Notes
+
+### Features & Enhancements
+- Merge POS invoices based on customer group ([#27471](https://github.com/frappe/erpnext/pull/27471))
+
+- Get items from material request in purchase order ([#24725](https://github.com/frappe/erpnext/pull/24725))
+    - Earlier system was fetching all the items from material request to purchase order
+    - Now user can fetch the specific items from material request to purchase order
+
+- Validity dates in Tax Withholding Rates ([#27258](https://github.com/frappe/erpnext/pull/27258))
+    - Replaced fiscal year with From Date and To Date, to start the TDS effect from the mid of the fiscal year.
+
+- Toggle for reduced depreciation rate as per IT Act ([#27600](https://github.com/frappe/erpnext/pull/27600))
+    - Added a toggle in the Finance Book to enable/disable the automatic reduction in the depreciation rate.
+
+- Deduct the TDS using Journal Entry ([#27451](https://github.com/frappe/erpnext/pull/27451))
+    - Refactored TDS payable monthly report to show the TDS data which was created using Journal Entry.
+
+- Party specific item ([#27281](https://github.com/frappe/erpnext/pull/27281))
+    - User can set the specific items to the supplier
+    - While making purchase transactions, user can see the items which are linked to the respective supplier.
+
+- Provision to add scrap items in job card ([#27483](https://github.com/frappe/erpnext/pull/27483))
+
+### Fixes
+
+- Maintain same rate in Stock Ledger until stock become positive ([#27227](https://github.com/frappe/erpnext/pull/27227))
+- Duplicate Contact error on add Patient ([#27427](https://github.com/frappe/erpnext/pull/27427))
+- Distribution of additional costs in Manufacture Stock Entry ([#27629](https://github.com/frappe/erpnext/pull/27629))
+- Website Items with same Item name unhandled, thumbnails missing ([#27720](https://github.com/frappe/erpnext/pull/27720))
+- Delivery Note for transfer w/o internal customer ([#27798](https://github.com/frappe/erpnext/pull/27798))
+- Setting of gain/loss if party account is in company currency ([#27659](https://github.com/frappe/erpnext/pull/27659))
+- Check if doctype has company_address field before setting the value ([#27441](https://github.com/frappe/erpnext/pull/27441))
+- Removed b2c limit check from CDNR Invoices ([#27516](https://github.com/frappe/erpnext/pull/27516))
+- Cannot delete a project if linked with sales order ([#27536](https://github.com/frappe/erpnext/pull/27536))
+- Employee advance return through multiple additional salaries ([#27438](https://github.com/frappe/erpnext/pull/27438))
+- Improvements in COA Importer ([#27584](https://github.com/frappe/erpnext/pull/27584))
+- Validate if item exists on uploading items in stock reco ([#27543](https://github.com/frappe/erpnext/pull/27543))
+- Handle Excess/Multiple Item Transfer against Job Card ([#27486](https://github.com/frappe/erpnext/pull/27486))
+- Values with same account name and different account number in consolidated balance sheet report ([#27493](https://github.com/frappe/erpnext/pull/27493))
+- Added project name in the purchase order analysis ([#27701](https://github.com/frappe/erpnext/pull/27701))
+- Shopping Cart and Variant Selection ([#27508](https://github.com/frappe/erpnext/pull/27508))
+


### PR DESCRIPTION
# Version 13.12.0 Release Notes

### Features & Enhancements
- Merge POS invoices based on customer group ([#27471](https://github.com/frappe/erpnext/pull/27471))

- Get items from material request in purchase order ([#24725](https://github.com/frappe/erpnext/pull/24725))
    - Earlier system was fetching all the items from material request to purchase order
    - Now user can fetch the specific items from material request to purchase order

- Validity dates in Tax Withholding Rates ([#27258](https://github.com/frappe/erpnext/pull/27258))
    - Replaced fiscal year with From Date and To Date, to start the TDS effect from the mid of the fiscal year.

- Toggle for reduced depreciation rate as per IT Act ([#27600](https://github.com/frappe/erpnext/pull/27600))
    - Added a toggle in the Finance Book to enable/disable the automatic reduction in the depreciation rate.

- Deduct the TDS using Journal Entry ([#27451](https://github.com/frappe/erpnext/pull/27451))
    - Refactored TDS payable monthly report to show the TDS data which was created using Journal Entry.

- Party specific item ([#27281](https://github.com/frappe/erpnext/pull/27281))
    - User can set the specific items to the supplier
    - While making purchase transactions, user can see the items which are linked to the respective supplier.

- Provision to add scrap items in job card ([#27483](https://github.com/frappe/erpnext/pull/27483))

### Fixes

- Maintain same rate in Stock Ledger until stock become positive ([#27227](https://github.com/frappe/erpnext/pull/27227))
- Duplicate Contact error on add Patient ([#27427](https://github.com/frappe/erpnext/pull/27427))
- Distribution of additional costs in Manufacture Stock Entry ([#27629](https://github.com/frappe/erpnext/pull/27629))
- Website Items with same Item name unhandled, thumbnails missing ([#27720](https://github.com/frappe/erpnext/pull/27720))
- Delivery Note for transfer w/o internal customer ([#27798](https://github.com/frappe/erpnext/pull/27798))
- Setting of gain/loss if party account is in company currency ([#27659](https://github.com/frappe/erpnext/pull/27659))
- Check if doctype has company_address field before setting the value ([#27441](https://github.com/frappe/erpnext/pull/27441))
- Removed b2c limit check from CDNR Invoices ([#27516](https://github.com/frappe/erpnext/pull/27516))
- Cannot delete a project if linked with sales order ([#27536](https://github.com/frappe/erpnext/pull/27536))
- Employee advance return through multiple additional salaries ([#27438](https://github.com/frappe/erpnext/pull/27438))
- Improvements in COA Importer ([#27584](https://github.com/frappe/erpnext/pull/27584))
- Validate if item exists on uploading items in stock reco ([#27543](https://github.com/frappe/erpnext/pull/27543))
- Handle Excess/Multiple Item Transfer against Job Card ([#27486](https://github.com/frappe/erpnext/pull/27486))
- Values with same account name and different account number in consolidated balance sheet report ([#27493](https://github.com/frappe/erpnext/pull/27493))
- Added project name in the purchase order analysis ([#27701](https://github.com/frappe/erpnext/pull/27701))
- Shopping Cart and Variant Selection ([#27508](https://github.com/frappe/erpnext/pull/27508))

