### PR TITLE
fix: use ceil in case of whole uoms for reorder qty

### DIFF
--- a/erpnext/stock/reorder_item.py
+++ b/erpnext/stock/reorder_item.py
@@ -150,7 +150,7 @@ def create_material_request(material_requests):
 							conversion_factor = frappe.db.get_value("UOM Conversion Detail",
 								{'parent': item.name, 'uom': uom}, 'conversion_factor') or 1.0
 
-					must_be_whole_number = frappe.get_value("UOM", uom, "must_be_whole_number")
+					must_be_whole_number = frappe.db.get_value("UOM", uom, "must_be_whole_number", cache=True)
 					qty = d.reorder_qty / conversion_factor
 					if must_be_whole_number:
 						qty = ceil(qty)

--- a/erpnext/stock/reorder_item.py
+++ b/erpnext/stock/reorder_item.py
@@ -4,6 +4,7 @@
 from __future__ import unicode_literals
 
 import json
+from math import ceil
 
 import frappe
 from frappe import _
@@ -149,11 +150,16 @@ def create_material_request(material_requests):
 							conversion_factor = frappe.db.get_value("UOM Conversion Detail",
 								{'parent': item.name, 'uom': uom}, 'conversion_factor') or 1.0
 
+					must_be_whole_number = frappe.get_value("UOM", uom, "must_be_whole_number")
+					qty = d.reorder_qty / conversion_factor
+					if must_be_whole_number:
+						qty = ceil(qty)
+
 					mr.append("items", {
 						"doctype": "Material Request Item",
 						"item_code": d.item_code,
 						"schedule_date": add_days(nowdate(),cint(item.lead_time_days)),
-						"qty": d.reorder_qty / conversion_factor,
+						"qty": qty,
 						"uom": uom,
 						"stock_uom": item.stock_uom,
 						"warehouse": d.warehouse,


### PR DESCRIPTION
### Description
- Reorder qty is calculated from stock projected qty.
- The UOM used here may be different say _Nos_ as compared to Purchase UOM say _Pack of 10_ (conversion factor will be 10).
- So if shortage is of 7 (_Nos_) this will cause a reorder of 0.7 (_Pack of 10_).
- This pr will cause `ceil(0.7)` i.e. `1` if the Purchase UOM should be a whole number.

(Internal ref: ISS-21-22-07039)