### PR TITLE
fix: no rounded_total in Payment Request

### DIFF
--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -396,7 +396,7 @@ def get_amount(ref_doc, payment_account=None):
 	"""get amount based on doctype"""
 	dt = ref_doc.doctype
 	if dt in ["Sales Order", "Purchase Order"]:
-		grand_total = flt(ref_doc.grand_total) - flt(ref_doc.advance_paid)
+		grand_total = flt(ref_doc.rounded_total or ref_doc.grand_total) - flt(ref_doc.advance_paid)
 
 	elif dt in ["Sales Invoice", "Purchase Invoice"]:
 		if ref_doc.party_account_currency == ref_doc.currency:


### PR DESCRIPTION
While creating **Payment Request** from a **Sales Order**, `rounded_total` is not considered. This causes **Payment Request**s to be made with decimal amounts.

This fix uses `rounded_total` first and then falls back to `grand_total` if rounding has been disabled in **ERPNext Settings**.
