### PR TITLE
fix: Totals row incorrect value in GL Entry

### DIFF
--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -421,8 +421,6 @@ def get_accountwise_gle(filters, accounting_dimensions, gl_entries, gle_map):
 			update_value_in_dict(totals, 'closing', gle)
 
 		elif gle.posting_date <= to_date:
-			update_value_in_dict(gle_map[gle.get(group_by)].totals, 'total', gle)
-			update_value_in_dict(totals, 'total', gle)
 			if filters.get("group_by") != 'Group by Voucher (Consolidated)':
 				gle_map[gle.get(group_by)].entries.append(gle)
 			elif filters.get("group_by") == 'Group by Voucher (Consolidated)':
@@ -436,8 +434,11 @@ def get_accountwise_gle(filters, accounting_dimensions, gl_entries, gle_map):
 				else:
 					update_value_in_dict(consolidated_gle, key, gle)
 
-			update_value_in_dict(gle_map[gle.get(group_by)].totals, 'closing', gle)
-			update_value_in_dict(totals, 'closing', gle)
+	for key, gle_entry in consolidated_gle.items():
+		update_value_in_dict(gle_map[gle.get(group_by)].totals, 'total', gle_entry)
+		update_value_in_dict(totals, 'total', gle_entry)
+		update_value_in_dict(gle_map[gle_entry.get(group_by)].totals, 'closing', gle_entry)
+		update_value_in_dict(totals, 'closing', gle_entry)
 
 	for key, value in consolidated_gle.items():
 		entries.append(value)

--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -434,13 +434,11 @@ def get_accountwise_gle(filters, accounting_dimensions, gl_entries, gle_map):
 				else:
 					update_value_in_dict(consolidated_gle, key, gle)
 
-	for key, gle_entry in consolidated_gle.items():
-		update_value_in_dict(gle_map[gle.get(group_by)].totals, 'total', gle_entry)
-		update_value_in_dict(totals, 'total', gle_entry)
-		update_value_in_dict(gle_map[gle_entry.get(group_by)].totals, 'closing', gle_entry)
-		update_value_in_dict(totals, 'closing', gle_entry)
-
 	for key, value in consolidated_gle.items():
+		update_value_in_dict(gle_map[value.get(group_by)].totals, 'total', value)
+		update_value_in_dict(totals, 'total', value)
+		update_value_in_dict(gle_map[value.get(group_by)].totals, 'closing', value)
+		update_value_in_dict(totals, 'closing', value)
 		entries.append(value)
 
 	return totals, entries


### PR DESCRIPTION
Totals and Closing row in General Ledger shows incorrect amount if "Show Net Values in Party Account" filter is enabled

Before:
![image](https://user-images.githubusercontent.com/42651287/137668891-49666cb1-5478-4c91-9c47-4172ce62753a.png)

After:
<img width="1323" alt="Screenshot 2021-10-18 at 9 46 38 AM" src="https://user-images.githubusercontent.com/42651287/137668539-b9332518-6f52-4e65-86c5-723b76a1109c.png">