### PR TITLE
fix: move `gst_category` to address from customer and supplier

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -2490,6 +2490,7 @@ def make_test_address_for_ewaybill():
 			"gstin": "27AAECE4835E1ZR",
 			"gst_state": "Maharashtra",
 			"gst_state_number": "27",
+			"gst_category": "Registered Regular",
 			"pincode": "401108"
 		}).insert()
 
@@ -2515,6 +2516,7 @@ def make_test_address_for_ewaybill():
 			"gstin": "27AACCM7806M1Z3",
 			"gst_state": "Maharashtra",
 			"gst_state_number": "27",
+			"gst_category": "Registered Regular",
 			"pincode": "410038"
 		}).insert()
 
@@ -2562,6 +2564,7 @@ def make_test_address_for_ewaybill():
 			"is_primary_address": 0,
 			"phone": "+910000000000",
 			"gstin": "07AAACC1206D1ZI",
+			"gst_category": "Registered Regular",
 			"gst_state": "Delhi",
 			"gst_state_number": "07",
 			"pincode": "1100101"

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -85,63 +85,72 @@ website_context = {
 
 website_route_rules = [
 	{"from_route": "/orders", "to_route": "Sales Order"},
-	{"from_route": "/orders/<path:name>", "to_route": "order",
+	{
+		"from_route": "/orders/<path:name>", "to_route": "order",
 		"defaults": {
 			"doctype": "Sales Order",
 			"parents": [{"label": _("Orders"), "route": "orders"}]
 		}
 	},
 	{"from_route": "/invoices", "to_route": "Sales Invoice"},
-	{"from_route": "/invoices/<path:name>", "to_route": "order",
+	{
+		"from_route": "/invoices/<path:name>", "to_route": "order",
 		"defaults": {
 			"doctype": "Sales Invoice",
 			"parents": [{"label": _("Invoices"), "route": "invoices"}]
 		}
 	},
 	{"from_route": "/supplier-quotations", "to_route": "Supplier Quotation"},
-	{"from_route": "/supplier-quotations/<path:name>", "to_route": "order",
+	{
+		"from_route": "/supplier-quotations/<path:name>", "to_route": "order",
 		"defaults": {
 			"doctype": "Supplier Quotation",
 			"parents": [{"label": _("Supplier Quotation"), "route": "supplier-quotations"}]
 		}
 	},
 	{"from_route": "/purchase-orders", "to_route": "Purchase Order"},
-	{"from_route": "/purchase-orders/<path:name>", "to_route": "order",
+	{
+		"from_route": "/purchase-orders/<path:name>", "to_route": "order",
 		"defaults": {
 			"doctype": "Purchase Order",
 			"parents": [{"label": _("Purchase Order"), "route": "purchase-orders"}]
 		}
 	},
 	{"from_route": "/purchase-invoices", "to_route": "Purchase Invoice"},
-	{"from_route": "/purchase-invoices/<path:name>", "to_route": "order",
+	{
+		"from_route": "/purchase-invoices/<path:name>", "to_route": "order",
 		"defaults": {
 			"doctype": "Purchase Invoice",
 			"parents": [{"label": _("Purchase Invoice"), "route": "purchase-invoices"}]
 		}
 	},
 	{"from_route": "/quotations", "to_route": "Quotation"},
-	{"from_route": "/quotations/<path:name>", "to_route": "order",
+	{
+		"from_route": "/quotations/<path:name>", "to_route": "order",
 		"defaults": {
 			"doctype": "Quotation",
 			"parents": [{"label": _("Quotations"), "route": "quotations"}]
 		}
 	},
 	{"from_route": "/shipments", "to_route": "Delivery Note"},
-	{"from_route": "/shipments/<path:name>", "to_route": "order",
+	{
+		"from_route": "/shipments/<path:name>", "to_route": "order",
 		"defaults": {
 			"doctype": "Delivery Note",
 			"parents": [{"label": _("Shipments"), "route": "shipments"}]
 		}
 	},
 	{"from_route": "/rfq", "to_route": "Request for Quotation"},
-	{"from_route": "/rfq/<path:name>", "to_route": "rfq",
+	{
+		"from_route": "/rfq/<path:name>", "to_route": "rfq",
 		"defaults": {
 			"doctype": "Request for Quotation",
 			"parents": [{"label": _("Request for Quotation"), "route": "rfq"}]
 		}
 	},
 	{"from_route": "/addresses", "to_route": "Address"},
-	{"from_route": "/addresses/<path:name>", "to_route": "addresses",
+	{
+		"from_route": "/addresses/<path:name>", "to_route": "addresses",
 		"defaults": {
 			"doctype": "Address",
 			"parents": [{"label": _("Addresses"), "route": "addresses"}]
@@ -152,7 +161,8 @@ website_route_rules = [
 	{"from_route": "/boms", "to_route": "BOM"},
 	{"from_route": "/timesheets", "to_route": "Timesheet"},
 	{"from_route": "/material-requests", "to_route": "Material Request"},
-	{"from_route": "/material-requests/<path:name>", "to_route": "material_request_info",
+	{
+		"from_route": "/material-requests/<path:name>", "to_route": "material_request_info",
 		"defaults": {
 			"doctype": "Material Request",
 			"parents": [{"label": _("Material Request"), "route": "material-requests"}]
@@ -423,7 +433,8 @@ payment_gateway_enabled = "erpnext.accounts.utils.create_payment_gateway_account
 
 communication_doctypes = ["Customer", "Supplier"]
 
-accounting_dimension_doctypes = ["GL Entry", "Sales Invoice", "Purchase Invoice", "Payment Entry", "Asset",
+accounting_dimension_doctypes = [
+	"GL Entry", "Sales Invoice", "Purchase Invoice", "Payment Entry", "Asset",
 	"Expense Claim", "Expense Claim Detail", "Expense Taxes and Charges", "Stock Entry", "Budget", "Payroll Entry", "Delivery Note",
 	"Sales Invoice Item", "Purchase Invoice Item", "Purchase Order Item", "Journal Entry Account", "Material Request Item", "Delivery Note Item",
 	"Purchase Receipt Item", "Stock Entry Detail", "Payment Entry Deduction", "Sales Taxes and Charges", "Purchase Taxes and Charges", "Shipping Rule",

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -286,7 +286,6 @@ doc_events = {
 		'validate': [
 			'erpnext.regional.india.utils.validate_gstin_for_india',
 			'erpnext.regional.italy.utils.set_state_code',
-			'erpnext.regional.india.utils.update_gst_category',
 		],
 	},
 	'Supplier': {

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -318,3 +318,4 @@ erpnext.patches.v14_0.migrate_crm_settings
 erpnext.patches.v13_0.rename_ksa_qr_field
 erpnext.patches.v13_0.disable_ksa_print_format_for_others # 16-12-2021
 erpnext.patches.v14_0.add_default_exit_questionnaire_notification_template
+erpnext.patches.v13_0.update_custom_fields_for_india

--- a/erpnext/patches/v13_0/update_custom_fields_for_india.py
+++ b/erpnext/patches/v13_0/update_custom_fields_for_india.py
@@ -52,7 +52,6 @@ def execute():
             'gst_category': addr.gst_category,
             'export_type': addr.export_type
         })
-    frappe.db.commit()
 
     # delete custom fields
     cf = frappe.qb.DocType('Custom Field')

--- a/erpnext/patches/v13_0/update_custom_fields_for_india.py
+++ b/erpnext/patches/v13_0/update_custom_fields_for_india.py
@@ -35,16 +35,14 @@ def execute():
         .on(link.link_name == cust.name)
         .select(link.parent, cust.gst_category, cust.export_type)
         .where(link.parenttype == 'Address')
-        .where(link.link_doctype == 'Customer')
-        .limit(3)).run(as_dict = True)
+        .where(link.link_doctype == 'Customer')).run(as_dict = True)
 
     supp_addr = (frappe.qb.from_(link)
         .join(supp)
         .on(link.link_name == supp.name)
         .select(link.parent, supp.gst_category, supp.export_type)
         .where(link.parenttype == 'Address')
-        .where(link.link_doctype == 'Supplier')
-        .limit(3)).run(as_dict = True)
+        .where(link.link_doctype == 'Supplier')).run(as_dict = True)
 
     address = cust_addr + supp_addr
 

--- a/erpnext/patches/v13_0/update_custom_fields_for_india.py
+++ b/erpnext/patches/v13_0/update_custom_fields_for_india.py
@@ -34,7 +34,7 @@ def execute():
         .join(cust)
         .on(link.link_name == cust.name)
         .select(link.parent, cust.gst_category, cust.export_type)
-        .where(link.parenttype == 'Address' )
+        .where(link.parenttype == 'Address')
         .where(link.link_doctype == 'Customer')
         .limit(3)).run(as_dict = True)
 
@@ -42,7 +42,7 @@ def execute():
         .join(supp)
         .on(link.link_name == supp.name)
         .select(link.parent, supp.gst_category, supp.export_type)
-        .where(link.parenttype == 'Address' )
+        .where(link.parenttype == 'Address')
         .where(link.link_doctype == 'Supplier')
         .limit(3)).run(as_dict = True)
 
@@ -62,7 +62,7 @@ def execute():
         .select(cf.name, cf.dt, cf.fieldname)
         .where((cf.dt == 'Customer') | (cf.dt == 'Supplier'))
         .where((cf.fieldname == 'export_type') | (cf.fieldname == 'gst_category'))
-        ).run(as_dict = True)
+    ).run(as_dict = True)
 
     for field in field_to_delete:
         frappe.delete_doc('Custom Field', field.name)

--- a/erpnext/patches/v13_0/update_custom_fields_for_india.py
+++ b/erpnext/patches/v13_0/update_custom_fields_for_india.py
@@ -1,7 +1,7 @@
 import frappe
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 
 from erpnext.regional.india import states
-from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 
 
 def execute():

--- a/erpnext/patches/v13_0/update_custom_fields_for_india.py
+++ b/erpnext/patches/v13_0/update_custom_fields_for_india.py
@@ -1,0 +1,69 @@
+import frappe
+
+from erpnext.regional.india import states
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+
+
+def execute():
+    company = frappe.get_all('Company', filters = {'country': 'India'})
+    if not company:
+        return
+
+    # create custom fields
+    custom_fields = {
+        'Address': [
+            dict(fieldname='gst_category',label='GST Category',fieldtype='Select', insert_after='gstin',
+                options='Registered Regular\nRegistered Composition\nUnregistered\nSEZ\nOverseas\nConsumer\nDeemed Export\nUIN Holders',
+                default='Unregistered'),
+            dict(fieldname='export_type', label='Export Type', fieldtype='Select', insert_after='gst_category',
+                depends_on='eval:in_list(["SEZ", "Overseas", "Deemed Export"], doc.gst_category)',
+                options='\nWith Payment of Tax\nWithout Payment of Tax',
+                mandatory_depends_on='eval:in_list(["SEZ", "Overseas", "Deemed Export"], doc.gst_category)'),
+            dict(fieldname='gst_state', label='GST State', fieldtype='Select',
+                options='\n'.join(states), insert_after='export_type'),
+        ]
+    }
+    create_custom_fields(custom_fields, update=True)
+
+    #patch fields created
+    link = frappe.qb.DocType('Dynamic Link')
+    cust = frappe.qb.DocType('Customer')
+    supp = frappe.qb.DocType('Supplier')
+
+    cust_addr = (frappe.qb.from_(link)
+        .join(cust)
+        .on(link.link_name == cust.name)
+        .select(link.parent, cust.gst_category, cust.export_type)
+        .where(link.parenttype == 'Address' )
+        .where(link.link_doctype == 'Customer')
+        .limit(3)).run(as_dict = True)
+
+    supp_addr = (frappe.qb.from_(link)
+        .join(supp)
+        .on(link.link_name == supp.name)
+        .select(link.parent, supp.gst_category, supp.export_type)
+        .where(link.parenttype == 'Address' )
+        .where(link.link_doctype == 'Supplier')
+        .limit(3)).run(as_dict = True)
+
+    address = cust_addr + supp_addr
+
+
+    for addr in address:
+        frappe.db.set_value('Address', addr.parent, {
+            'gst_category': addr.gst_category,
+            'export_type': addr.export_type
+        })
+    frappe.db.commit()
+
+    # delete custom fields
+    cf = frappe.qb.DocType('Custom Field')
+    field_to_delete = (frappe.qb.from_(cf)
+        .select(cf.name, cf.dt, cf.fieldname)
+        .where((cf.dt == 'Customer') | (cf.dt == 'Supplier'))
+        .where((cf.fieldname == 'export_type') | (cf.fieldname == 'gst_category'))
+        ).run(as_dict = True)
+
+    for field in field_to_delete:
+        frappe.delete_doc('Custom Field', field.name)
+    frappe.db.commit()

--- a/erpnext/regional/doctype/gstr_3b_report/gstr_3b_report.py
+++ b/erpnext/regional/doctype/gstr_3b_report/gstr_3b_report.py
@@ -397,22 +397,14 @@ class GSTR3BReport(Document):
 
 		for doctype in ["Sales Invoice", "Purchase Invoice"]:
 
-			if doctype == "Sales Invoice":
-				party_type = 'Customer'
-				party = 'customer'
-			else:
-				party_type = 'Supplier'
-				party = 'supplier'
-
 			docnames = frappe.db.sql(
 			"""
-				SELECT t1.name FROM `tab{doctype}` t1, `tab{party_type}` t2
-				WHERE t1.docstatus = 1 and t1.is_opening = 'No'
-				and month(t1.posting_date) = %s and year(t1.posting_date) = %s
-				and t1.company = %s and t1.place_of_supply IS NULL and t1.{party} = t2.name and
-				t2.gst_category != 'Overseas'
-			""".format(doctype = doctype, party_type = party_type,
-				party=party) ,(self.month_no, self.year, self.company), as_dict=1) #nosec
+				SELECT name FROM `tab{doctype}`
+				WHERE docstatus = 1 and is_opening = 'No'
+				and month(posting_date) = %s and year(posting_date) = %s
+				and company = %s and place_of_supply IS NULL and
+				gst_category != 'Overseas'
+			""".format(doctype = doctype) ,(self.month_no, self.year, self.company), as_dict=1) # nosec
 
 			for d in docnames:
 				missing_field_invoices.append(d.name)

--- a/erpnext/regional/doctype/gstr_3b_report/test_gstr_3b_report.py
+++ b/erpnext/regional/doctype/gstr_3b_report/test_gstr_3b_report.py
@@ -103,44 +103,6 @@ class TestGSTR3BReport(unittest.TestCase):
 		gst_settings.round_off_gst_values = 1
 		gst_settings.save()
 
-	def test_gst_category_auto_update(self):
-		if not frappe.db.exists("Customer", "_Test GST Customer With GSTIN"):
-			customer = frappe.get_doc({
-				"customer_group": "_Test Customer Group",
-				"customer_name": "_Test GST Customer With GSTIN",
-				"customer_type": "Individual",
-				"doctype": "Customer",
-				"territory": "_Test Territory"
-			}).insert()
-
-			self.assertEqual(customer.gst_category, 'Unregistered')
-
-		if not frappe.db.exists('Address', '_Test GST Category-1-Billing'):
-			address = frappe.get_doc({
-				"address_line1": "_Test Address Line 1",
-				"address_title": "_Test GST Category-1",
-				"address_type": "Billing",
-				"city": "_Test City",
-				"state": "Test State",
-				"country": "India",
-				"doctype": "Address",
-				"is_primary_address": 1,
-				"phone": "+91 0000000000",
-				"gstin": "29AZWPS7135H1ZG",
-				"gst_state": "Karnataka",
-				"gst_state_number": "29"
-			}).insert()
-
-			address.append("links", {
-				"link_doctype": "Customer",
-				"link_name": "_Test GST Customer With GSTIN"
-			})
-
-			address.save()
-
-		customer.load_from_db()
-		self.assertEqual(customer.gst_category, 'Registered Regular')
-
 
 def make_sales_invoice():
 	si = create_sales_invoice(company="_Test Company GST",
@@ -284,7 +246,6 @@ def make_suppliers():
 		frappe.get_doc({
 			"supplier_group": "_Test Supplier Group",
 			"supplier_name": "_Test Registered Supplier",
-			"gst_category": "Registered Regular",
 			"supplier_type": "Individual",
 			"doctype": "Supplier",
 		}).insert()
@@ -293,7 +254,6 @@ def make_suppliers():
 		frappe.get_doc({
 			"supplier_group": "_Test Supplier Group",
 			"supplier_name": "_Test Unregistered Supplier",
-			"gst_category": "Unregistered",
 			"supplier_type": "Individual",
 			"doctype": "Supplier",
 		}).insert()
@@ -311,6 +271,7 @@ def make_suppliers():
 			"phone": "+91 0000000000",
 			"gstin": "29AACCV0498C1Z9",
 			"gst_state": "Karnataka",
+			"gst_category": "Registered Regular",
 		}).insert()
 
 		address.append("links", {
@@ -337,7 +298,8 @@ def make_suppliers():
 
 		address.append("links", {
 			"link_doctype": "Supplier",
-			"link_name": "_Test Unregistered Supplier"
+			"link_name": "_Test Unregistered Supplier",
+			"gst_category": "Unregistered",
 		})
 
 		address.save()
@@ -347,7 +309,6 @@ def make_customers():
 		frappe.get_doc({
 			"customer_group": "_Test Customer Group",
 			"customer_name": "_Test GST Customer",
-			"gst_category": "Registered Regular",
 			"customer_type": "Individual",
 			"doctype": "Customer",
 			"territory": "_Test Territory"
@@ -357,7 +318,6 @@ def make_customers():
 		frappe.get_doc({
 			"customer_group": "_Test Customer Group",
 			"customer_name": "_Test GST SEZ Customer",
-			"gst_category": "SEZ",
 			"customer_type": "Individual",
 			"doctype": "Customer",
 			"territory": "_Test Territory"
@@ -367,7 +327,6 @@ def make_customers():
 		frappe.get_doc({
 			"customer_group": "_Test Customer Group",
 			"customer_name": "_Test Unregistered Customer",
-			"gst_category": "Unregistered",
 			"customer_type": "Individual",
 			"doctype": "Customer",
 			"territory": "_Test Territory"
@@ -386,7 +345,8 @@ def make_customers():
 			"phone": "+91 0000000000",
 			"gstin": "29AZWPS7135H1ZG",
 			"gst_state": "Karnataka",
-			"gst_state_number": "29"
+			"gst_state_number": "29",
+			"gst_category": "Registered Regular",
 		}).insert()
 
 		address.append("links", {
@@ -408,6 +368,8 @@ def make_customers():
 			"is_primary_address": 1,
 			"phone": "+91 0000000000",
 			"gst_state": "Haryana",
+			"gst_category": "Unregistered",
+			"gstin": "URP",
 		}).insert()
 
 		address.append("links", {
@@ -429,6 +391,7 @@ def make_customers():
 			"is_primary_address": 1,
 			"phone": "+91 0000000000",
 			"gst_state": "Gujarat",
+			"gst_category": "SEZ",
 		}).insert()
 
 		address.append("links", {
@@ -462,7 +425,8 @@ def make_company():
 			"phone": "+91 0000000000",
 			"gstin": "27AAECE4835E1ZR",
 			"gst_state": "Maharashtra",
-			"gst_state_number": "27"
+			"gst_state_number": "27",
+			"gst_category": "Registered Regular",
 		}).insert()
 
 		address.append("links", {

--- a/erpnext/regional/india/setup.py
+++ b/erpnext/regional/india/setup.py
@@ -2,7 +2,9 @@
 # License: GNU General Public License v3. See license.txt
 
 
-import frappe, os, json
+import frappe
+import os
+import json
 from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 from frappe.custom.doctype.property_setter.property_setter import make_property_setter
 from frappe.permissions import add_permission, update_permission_property
@@ -335,12 +337,12 @@ def get_custom_fields():
 	si_ewaybill_fields = [
 		{
 			'fieldname': 'transporter_info',
- 			'label': 'Transporter Info',
- 			'fieldtype': 'Section Break',
- 			'insert_after': 'terms',
- 			'collapsible': 1,
- 			'collapsible_depends_on': 'transporter',
- 			'print_hide': 1
+			'label': 'Transporter Info',
+			'fieldtype': 'Section Break',
+			'insert_after': 'terms',
+			'collapsible': 1,
+			'collapsible_depends_on': 'transporter',
+			'print_hide': 1
 		},
 		{
 			'fieldname': 'transporter',
@@ -524,31 +526,33 @@ def get_custom_fields():
 		'Purchase Invoice Item': [hsn_sac_field, nil_rated_exempt, is_non_gst, taxable_value],
 		'Material Request Item': [hsn_sac_field, nil_rated_exempt, is_non_gst],
 		'Salary Component': [
-			dict(fieldname=  'component_type',
+			dict(
+				fieldname= 'component_type',
 				label= 'Component Type',
-				fieldtype=  'Select',
+				fieldtype= 'Select',
 				insert_after= 'description',
 				options= "\nProvident Fund\nAdditional Provident Fund\nProvident Fund Loan\nProfessional Tax",
 				depends_on = 'eval:doc.type == "Deduction"'
 			)
 		],
 		'Employee': [
-			dict(fieldname='ifsc_code',
+			dict(
+				fieldname='ifsc_code',
 				label='IFSC Code',
 				fieldtype='Data',
 				insert_after='bank_ac_no',
 				print_hide=1,
 				depends_on='eval:doc.salary_mode == "Bank"'
-				),
+			),
 			dict(
-				fieldname =  'pan_number',
+				fieldname = 'pan_number',
 				label = 'PAN Number',
 				fieldtype = 'Data',
 				insert_after = 'payroll_cost_center',
 				print_hide = 1
 			),
 			dict(
-				fieldname =  'micr_code',
+				fieldname = 'micr_code',
 				label = 'MICR Code',
 				fieldtype = 'Data',
 				insert_after = 'ifsc_code',
@@ -785,7 +789,7 @@ def set_tax_withholding_category(company):
 
 			if fiscal_year_details:
 				# if fiscal year don't match with any of the already entered data, append rate row
-				fy_exist = [k for k in doc.get('rates') if k.get('from_date') <= fiscal_year_details[1] \
+				fy_exist = [k for k in doc.get('rates') if k.get('from_date') <= fiscal_year_details[1]
 					and k.get('to_date') >= fiscal_year_details[2]]
 				if not fy_exist:
 					doc.append("rates", d.get('rates')[0])

--- a/erpnext/regional/india/setup.py
+++ b/erpnext/regional/india/setup.py
@@ -170,7 +170,7 @@ def get_custom_fields():
 		dict(fieldname='gst_category', label='GST Category',
 			fieldtype='Select', insert_after='gst_section', print_hide=1,
 			options='\nRegistered Regular\nRegistered Composition\nUnregistered\nSEZ\nOverseas\nConsumer\nDeemed Export\nUIN Holders',
-			fetch_from='customer.gst_category', fetch_if_empty=1, length=25),
+			fetch_from='customer_address.gst_category', fetch_if_empty=1, length=25),
 		dict(fieldname='export_type', label='Export Type',
 			fieldtype='Select', insert_after='gst_category', print_hide=1,
 			depends_on='eval:in_list(["SEZ", "Overseas", "Deemed Export"], doc.gst_category)',

--- a/erpnext/regional/india/setup.py
+++ b/erpnext/regional/india/setup.py
@@ -154,11 +154,11 @@ def get_custom_fields():
 		dict(fieldname='gst_category', label='GST Category',
 			fieldtype='Select', insert_after='gst_section', print_hide=1,
 			options='\nRegistered Regular\nRegistered Composition\nUnregistered\nSEZ\nOverseas\nUIN Holders',
-			fetch_from='supplier.gst_category', fetch_if_empty=1),
+			fetch_from='supplier_address.gst_category', fetch_if_empty=1),
 		dict(fieldname='export_type', label='Export Type',
 			fieldtype='Select', insert_after='gst_category', print_hide=1,
 			depends_on='eval:in_list(["SEZ", "Overseas"], doc.gst_category)',
-			options='\nWith Payment of Tax\nWithout Payment of Tax', fetch_from='supplier.export_type',
+			options='\nWith Payment of Tax\nWithout Payment of Tax', fetch_from='supplier_address.export_type',
 			fetch_if_empty=1),
 	]
 
@@ -172,7 +172,7 @@ def get_custom_fields():
 		dict(fieldname='export_type', label='Export Type',
 			fieldtype='Select', insert_after='gst_category', print_hide=1,
 			depends_on='eval:in_list(["SEZ", "Overseas", "Deemed Export"], doc.gst_category)',
-			options='\nWith Payment of Tax\nWithout Payment of Tax', fetch_from='customer.export_type',
+			options='\nWith Payment of Tax\nWithout Payment of Tax', fetch_from='customer_address.export_type',
 			fetch_if_empty=1, length=25),
 	]
 
@@ -180,7 +180,7 @@ def get_custom_fields():
 		dict(fieldname='gst_category', label='GST Category',
 			fieldtype='Select', insert_after='gst_vehicle_type', print_hide=1,
 			options='\nRegistered Regular\nRegistered Composition\nUnregistered\nSEZ\nOverseas\nConsumer\nDeemed Export\nUIN Holders',
-			fetch_from='customer.gst_category', fetch_if_empty=1),
+			fetch_from='customer_address.gst_category', fetch_if_empty=1),
 	]
 
 	invoice_gst_fields = [
@@ -483,8 +483,15 @@ def get_custom_fields():
 		'Address': [
 			dict(fieldname='gstin', label='Party GSTIN', fieldtype='Data',
 				insert_after='fax'),
+			dict(fieldname='gst_category',label='GST Category',fieldtype='Select', insert_after='gstin',
+				options='Registered Regular\nRegistered Composition\nUnregistered\nSEZ\nOverseas\nConsumer\nDeemed Export\nUIN Holders',
+				default='Unregistered'),
+			dict(fieldname='export_type', label='Export Type', fieldtype='Select', insert_after='gst_category',
+				depends_on='eval:in_list(["SEZ", "Overseas", "Deemed Export"], doc.gst_category)',
+				options='\nWith Payment of Tax\nWithout Payment of Tax',
+				mandatory_depends_on='eval:in_list(["SEZ", "Overseas", "Deemed Export"], doc.gst_category)'),
 			dict(fieldname='gst_state', label='GST State', fieldtype='Select',
-				options='\n'.join(states), insert_after='gstin'),
+				options='\n'.join(states), insert_after='export_type'),
 			dict(fieldname='gst_state_number', label='GST State Number',
 				fieldtype='Data', insert_after='gst_state', read_only=1),
 		],
@@ -625,23 +632,6 @@ def get_custom_fields():
 				'fieldtype': 'Data',
 				'insert_after': 'pan',
 				'depends_on': 'eval:doc.is_transporter'
-			},
-			{
-				'fieldname': 'gst_category',
-				'label': 'GST Category',
-				'fieldtype': 'Select',
-				'insert_after': 'gst_transporter_id',
-				'options': 'Registered Regular\nRegistered Composition\nUnregistered\nSEZ\nOverseas\nUIN Holders',
-				'default': 'Unregistered'
-			},
-			{
-				'fieldname': 'export_type',
-				'label': 'Export Type',
-				'fieldtype': 'Select',
-				'insert_after': 'gst_category',
-				'depends_on':'eval:in_list(["SEZ", "Overseas"], doc.gst_category)',
-				'options': '\nWith Payment of Tax\nWithout Payment of Tax',
-				'mandatory_depends_on': 'eval:in_list(["SEZ", "Overseas"], doc.gst_category)'
 			}
 		],
 		'Customer': [
@@ -650,23 +640,6 @@ def get_custom_fields():
 				'label': 'PAN',
 				'fieldtype': 'Data',
 				'insert_after': 'customer_type'
-			},
-			{
-				'fieldname': 'gst_category',
-				'label': 'GST Category',
-				'fieldtype': 'Select',
-				'insert_after': 'pan',
-				'options': 'Registered Regular\nRegistered Composition\nUnregistered\nSEZ\nOverseas\nConsumer\nDeemed Export\nUIN Holders',
-				'default': 'Unregistered'
-			},
-			{
-				'fieldname': 'export_type',
-				'label': 'Export Type',
-				'fieldtype': 'Select',
-				'insert_after': 'gst_category',
-				'depends_on':'eval:in_list(["SEZ", "Overseas", "Deemed Export"], doc.gst_category)',
-				'options': '\nWith Payment of Tax\nWithout Payment of Tax',
-				'mandatory_depends_on': 'eval:in_list(["SEZ", "Overseas", "Deemed Export"], doc.gst_category)'
 			}
 		],
 		'Member': [

--- a/erpnext/regional/india/utils.py
+++ b/erpnext/regional/india/utils.py
@@ -12,7 +12,8 @@ from erpnext.hr.utils import get_salary_assignment
 from erpnext.payroll.doctype.salary_structure.salary_structure import make_salary_slip
 from erpnext.regional.india import number_state_mapping, state_numbers, states
 
-GST_INVOICE_NUMBER_FORMAT = re.compile(r"^[a-zA-Z0-9\-/]+$")   #alphanumeric and - /
+#alphanumeric and - /
+GST_INVOICE_NUMBER_FORMAT = re.compile(r"^[a-zA-Z0-9\-/]+$")   
 GSTIN_FORMAT = re.compile("^[0-9]{2}[A-Z]{4}[0-9A-Z]{1}[0-9]{4}[A-Z]{1}[1-9A-Z]{1}[1-9A-Z]{1}[0-9A-Z]{1}$")
 GSTIN_UIN_FORMAT = re.compile("^[0-9]{4}[A-Z]{3}[0-9]{5}[0-9A-Z]{3}")
 PAN_NUMBER_FORMAT = re.compile("[A-Z]{5}[0-9]{4}[A-Z]{1}")
@@ -169,7 +170,8 @@ def test_method():
 	return 'overridden'
 
 def get_place_of_supply(party_details, doctype):
-	if not frappe.get_meta('Address').has_field('gst_state'): return
+	if not frappe.get_meta('Address').has_field('gst_state'):
+		return
 
 	if doctype in ("Sales Invoice", "Delivery Note", "Sales Order"):
 		address_name = party_details.customer_address or party_details.shipping_address_name
@@ -209,8 +211,11 @@ def get_regional_address_details(party_details, doctype, company):
 		party_details['taxes_and_charges'] = tax_template_by_category
 		return
 
-	if not party_details.place_of_supply: return party_details
-	if not party_details.company_gstin: return party_details
+	if not party_details.place_of_supply: 
+		return party_details
+
+	if not party_details.company_gstin: 
+		return party_details
 
 	if ((doctype in ("Sales Invoice", "Delivery Note", "Sales Order") and party_details.company_gstin
 		and party_details.company_gstin[:2] != party_details.place_of_supply[:2]) or (doctype in ("Purchase Invoice",
@@ -263,7 +268,7 @@ def get_tax_template(master_doctype, company, is_inter_state, state_code):
 
 	for tax_category in tax_categories:
 		if tax_category.gst_state == number_state_mapping[state_code] or \
-	 		(not default_tax and not tax_category.gst_state):
+			(not default_tax and not tax_category.gst_state):
 			default_tax = frappe.db.get_value(master_doctype,
 				{'company': company, 'disabled': 0, 'tax_category': tax_category.name}, 'name')
 	return default_tax

--- a/erpnext/regional/india/utils.py
+++ b/erpnext/regional/india/utils.py
@@ -13,7 +13,7 @@ from erpnext.payroll.doctype.salary_structure.salary_structure import make_salar
 from erpnext.regional.india import number_state_mapping, state_numbers, states
 
 #alphanumeric and - /
-GST_INVOICE_NUMBER_FORMAT = re.compile(r"^[a-zA-Z0-9\-/]+$")   
+GST_INVOICE_NUMBER_FORMAT = re.compile(r"^[a-zA-Z0-9\-/]+$")
 GSTIN_FORMAT = re.compile("^[0-9]{2}[A-Z]{4}[0-9A-Z]{1}[0-9]{4}[A-Z]{1}[1-9A-Z]{1}[1-9A-Z]{1}[0-9A-Z]{1}$")
 GSTIN_UIN_FORMAT = re.compile("^[0-9]{4}[A-Z]{3}[0-9]{5}[0-9A-Z]{3}")
 PAN_NUMBER_FORMAT = re.compile("[A-Z]{5}[0-9]{4}[A-Z]{1}")
@@ -57,8 +57,8 @@ def validate_gstin_for_india(doc, method):
 
 def validate_gst_category(doc, valid_gst_category):
 	if doc.gst_category not in valid_gst_category:
-		frappe.throw(_("GST Category can be one of {}."
-			.format(', '.join(valid_gst_category))), title=_("Invalid GST Category"))
+		frappe.throw(_("GST Category can be one of {0}.")
+			.format(', '.join(valid_gst_category)), title=_("Invalid GST Category"))
 
 def validate_pan_for_india(doc, method):
 	if doc.get('country') != 'India' or not doc.get('pan'):
@@ -211,10 +211,10 @@ def get_regional_address_details(party_details, doctype, company):
 		party_details['taxes_and_charges'] = tax_template_by_category
 		return
 
-	if not party_details.place_of_supply: 
+	if not party_details.place_of_supply:
 		return party_details
 
-	if not party_details.company_gstin: 
+	if not party_details.company_gstin:
 		return party_details
 
 	if ((doctype in ("Sales Invoice", "Delivery Note", "Sales Order") and party_details.company_gstin

--- a/erpnext/stock/doctype/shipment/test_shipment.py
+++ b/erpnext/stock/doctype/shipment/test_shipment.py
@@ -13,7 +13,7 @@ class TestShipment(ERPNextTestCase):
 	def test_shipment_from_delivery_note(self):
 		delivery_note = create_test_delivery_note()
 		delivery_note.submit()
-		shipment = create_test_shipment([ delivery_note ])
+		shipment = create_test_shipment([delivery_note])
 		shipment.submit()
 		second_shipment = make_shipment(delivery_note.name)
 		self.assertEqual(second_shipment.value_of_goods, delivery_note.grand_total)

--- a/erpnext/stock/doctype/shipment/test_shipment.py
+++ b/erpnext/stock/doctype/shipment/test_shipment.py
@@ -148,6 +148,7 @@ def create_shipment_address(address_title, company_name, postal_code):
 	address.city = 'Random City'
 	address.postal_code = postal_code
 	address.country = 'Germany'
+	address.gst_category = 'Unregistered'
 	address.insert()
 	return address
 
@@ -182,7 +183,6 @@ def create_shipment_customer(customer_name):
 	customer.customer_type = 'Company'
 	customer.customer_group = 'All Customer Groups'
 	customer.territory = 'All Territories'
-	customer.gst_category = 'Unregistered'
 	customer.insert()
 	return customer
 


### PR DESCRIPTION
Issue: #27880 

This commit includes
1. Move GST Category to Address
2. Validate GST Category based on GSTIN. GST Category depends on GST Number.
3. Allow `URP` in GSTIN (used by govt in ewaybill website to mean Unregistered Persons)
4. Minor fixes to Validate GSTIN.

Screenshots.

GST Category Validation
![image](https://user-images.githubusercontent.com/10496564/137064641-268e0853-f956-4d2e-9555-b282686b5954.png)

UIN Holders
Auto-Update if format matches
![image](https://user-images.githubusercontent.com/10496564/137064920-ee7a92a9-6d91-4921-bea1-d01bb0fa784d.png)

The way forward
Going ahead, we can fetch GST Category and address info from GST Number using API's
