### PR TITLE
fix: map fields in opportunity server side

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -140,11 +140,6 @@ class Asset(AccountsController):
 		if self.is_existing_asset:
 			return
 
-		docname = self.purchase_receipt or self.purchase_invoice
-		if docname:
-			doctype = 'Purchase Receipt' if self.purchase_receipt else 'Purchase Invoice'
-			date = frappe.db.get_value(doctype, docname, 'posting_date')
-
 		if self.available_for_use_date and getdate(self.available_for_use_date) < getdate(self.purchase_date):
 			frappe.throw(_("Available-for-use Date should be after purchase date"))
 
@@ -440,9 +435,10 @@ class Asset(AccountsController):
 			if accumulated_depreciation_after_full_schedule:
 				accumulated_depreciation_after_full_schedule = max(accumulated_depreciation_after_full_schedule)
 
-				asset_value_after_full_schedule = flt(flt(self.gross_purchase_amount) -
-					flt(accumulated_depreciation_after_full_schedule),
-					self.precision('gross_purchase_amount'))
+				asset_value_after_full_schedule = flt(
+					flt(self.gross_purchase_amount) -
+					flt(self.opening_accumulated_depreciation) -
+					flt(accumulated_depreciation_after_full_schedule), self.precision('gross_purchase_amount'))
 
 				if (row.expected_value_after_useful_life and
 					row.expected_value_after_useful_life < asset_value_after_full_schedule):

--- a/erpnext/crm/doctype/opportunity/opportunity.py
+++ b/erpnext/crm/doctype/opportunity/opportunity.py
@@ -10,6 +10,7 @@ from frappe import _
 from frappe.email.inbox import link_communication_to_document
 from frappe.model.mapper import get_mapped_doc
 from frappe.utils import cint, cstr, flt, get_fullname
+from erpnext.regional.india.setup import get_custom_fields
 
 from erpnext.setup.utils import get_exchange_rate
 from erpnext.utilities.transaction_base import TransactionBase
@@ -33,6 +34,7 @@ class Opportunity(TransactionBase):
 		self.validate_item_details()
 		self.validate_uom_is_integer("uom", "qty")
 		self.validate_cust_name()
+		self.map_fields()
 
 		if not self.title:
 			self.title = self.customer_name
@@ -105,6 +107,21 @@ class Opportunity(TransactionBase):
 
 			self.opportunity_from = "Lead"
 			self.party_name = lead_name
+
+	def map_fields(self):
+		print("called")
+		for field in self.meta.fields:
+			print(field.fieldname, "in here")
+			print(hasattr(self, field.fieldname), self.get(field.fieldname))
+			if not self.get(field.fieldname):
+				print("in if")
+				try:
+					print(field.fieldname)
+					value = frappe.db.get_value(self.opportunity_from, self.party_name, field.fieldname)
+					print(value, field.fieldname)
+					frappe.db.set(self, field.fieldname, value)
+				except Exception:
+					continue
 
 	@frappe.whitelist()
 	def declare_enquiry_lost(self, lost_reasons_list, detailed_reason=None):

--- a/erpnext/crm/doctype/opportunity/opportunity.py
+++ b/erpnext/crm/doctype/opportunity/opportunity.py
@@ -109,16 +109,10 @@ class Opportunity(TransactionBase):
 			self.party_name = lead_name
 
 	def map_fields(self):
-		print("called")
 		for field in self.meta.fields:
-			print(field.fieldname, "in here")
-			print(hasattr(self, field.fieldname), self.get(field.fieldname))
 			if not self.get(field.fieldname):
-				print("in if")
 				try:
-					print(field.fieldname)
 					value = frappe.db.get_value(self.opportunity_from, self.party_name, field.fieldname)
-					print(value, field.fieldname)
 					frappe.db.set(self, field.fieldname, value)
 				except Exception:
 					continue


### PR DESCRIPTION
Issue:

1. When we create an Opportunity from Lead manually, the Opportunity picks the value of similar fields from Lead doctype.
2. The same does not happen when Opportunity is created from Lead using data import.

Fix:
1. Added logic on the server-side, which checks if a field in opportunity does not have a value and this field is present in Lead/Customer doctype then it fetches that value and adds it to the field in Opportunity.