### PR TITLE
feat: HSN based tax breakup table check in GST Settings 

### DIFF
--- a/erpnext/regional/doctype/gst_settings/gst_settings.json
+++ b/erpnext/regional/doctype/gst_settings/gst_settings.json
@@ -8,6 +8,7 @@
   "gst_summary",
   "column_break_2",
   "round_off_gst_values",
+  "hsn_wise_tax_breakup",
   "gstin_email_sent_on",
   "section_break_4",
   "gst_accounts",
@@ -17,37 +18,27 @@
   {
    "fieldname": "gst_summary",
    "fieldtype": "HTML",
-   "label": "GST Summary",
-   "show_days": 1,
-   "show_seconds": 1
+   "label": "GST Summary"
   },
   {
    "fieldname": "column_break_2",
-   "fieldtype": "Column Break",
-   "show_days": 1,
-   "show_seconds": 1
+   "fieldtype": "Column Break"
   },
   {
    "fieldname": "gstin_email_sent_on",
    "fieldtype": "Date",
    "label": "GSTIN Email Sent On",
-   "read_only": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "read_only": 1
   },
   {
    "fieldname": "section_break_4",
-   "fieldtype": "Section Break",
-   "show_days": 1,
-   "show_seconds": 1
+   "fieldtype": "Section Break"
   },
   {
    "fieldname": "gst_accounts",
    "fieldtype": "Table",
    "label": "GST Accounts",
-   "options": "GST Account",
-   "show_days": 1,
-   "show_seconds": 1
+   "options": "GST Account"
   },
   {
    "default": "250000",
@@ -56,24 +47,26 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "B2C Limit",
-   "reqd": 1,
-   "show_days": 1,
-   "show_seconds": 1
+   "reqd": 1
   },
   {
    "default": "0",
    "description": "Enabling this option will round off individual GST components in all the Invoices",
    "fieldname": "round_off_gst_values",
    "fieldtype": "Check",
-   "label": "Round Off GST Values",
-   "show_days": 1,
-   "show_seconds": 1
+   "label": "Round Off GST Values"
+  },
+  {
+   "default": "0",
+   "fieldname": "hsn_wise_tax_breakup",
+   "fieldtype": "Check",
+   "label": "HSN Wise Tax Breakup "
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2021-01-28 17:19:47.969260",
+ "modified": "2021-10-11 15:52:05.250159",
  "modified_by": "Administrator",
  "module": "Regional",
  "name": "GST Settings",
@@ -83,4 +76,4 @@
  "sort_field": "modified",
  "sort_order": "DESC",
  "track_changes": 1
-   }
+}

--- a/erpnext/regional/doctype/gst_settings/gst_settings.json
+++ b/erpnext/regional/doctype/gst_settings/gst_settings.json
@@ -6,8 +6,9 @@
  "engine": "InnoDB",
  "field_order": [
   "gst_summary",
-  "column_break_2",
+  "gst_tax_settings_section",
   "round_off_gst_values",
+  "column_break_4",
   "hsn_wise_tax_breakup",
   "gstin_email_sent_on",
   "section_break_4",
@@ -19,10 +20,6 @@
    "fieldname": "gst_summary",
    "fieldtype": "HTML",
    "label": "GST Summary"
-  },
-  {
-   "fieldname": "column_break_2",
-   "fieldtype": "Column Break"
   },
   {
    "fieldname": "gstin_email_sent_on",
@@ -60,13 +57,22 @@
    "default": "0",
    "fieldname": "hsn_wise_tax_breakup",
    "fieldtype": "Check",
-   "label": "HSN Wise Tax Breakup "
+   "label": "Tax Breakup Table Based On HSN Code"
+  },
+  {
+   "fieldname": "gst_tax_settings_section",
+   "fieldtype": "Section Break",
+   "label": "GST Tax Settings"
+  },
+  {
+   "fieldname": "column_break_4",
+   "fieldtype": "Column Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2021-10-11 15:52:05.250159",
+ "modified": "2021-10-11 18:10:14.242614",
  "modified_by": "Administrator",
  "module": "Regional",
  "name": "GST Settings",


### PR DESCRIPTION
#### Due to changes introduced by this [PR](https://github.com/frappe/erpnext/pull/27524), **Tax Breakup** table was displaying tax based only on items instead of HSN Code.
---
This feat adds a check in the GST Settings page that lets you choose HSN wise breakup or Item wise breakup.
Created a new section ***GST Tax Settings*** for the Round Off check and Tax Breakup check. 

   <img src='https://user-images.githubusercontent.com/36098155/136793073-409754a8-95ab-4c69-bd43-5c7b7e672f2f.png' width='700'>

<details open>
<summary><b>Item wise tax breakup</b></summary>
<img src='https://user-images.githubusercontent.com/36098155/136973240-65368fc2-9637-446f-a880-3b1c7db7dbda.png' width='700'>
</details>

<details open>
<summary><b>HSN wise tax breakup</b></summary>
<img src='https://user-images.githubusercontent.com/36098155/136974398-d4ea8f9b-6fa7-483c-8f1c-16656e2687b1.png' width='700'>
</details>

**In the above example, 2 items had same HSN code so they were grouped together in the HSN wise breakup table.**

<details>
<summary><b>GST Settings page before changes</b></summary>
<img src='https://user-images.githubusercontent.com/36098155/136793597-39c1b9d3-7e54-4dc5-996a-2e8ad4a6c478.png' width='700'>
</details>


  
`no-docs`