### PR TITLE
fix: force reload custom field doctype

### DIFF
--- a/erpnext/patches/v13_0/update_vehicle_no_reqd_condition.py
+++ b/erpnext/patches/v13_0/update_vehicle_no_reqd_condition.py
@@ -2,7 +2,7 @@ import frappe
 
 
 def execute():
-	frappe.reload_doc('custom', 'doctype', 'custom_field')
+	frappe.reload_doc('custom', 'doctype', 'custom_field', force=True)
 	company = frappe.get_all('Company', filters = {'country': 'India'})
 	if not company:
 		return


### PR DESCRIPTION
custom_field.json has the same modified key in both versions but not the same content. 

This can happen again if something is backported, safe solution is to force reload.

closes https://github.com/frappe/frappe/issues/14335 