### PR TITLE
fix: Avoid automatic customer creation on website user login

### DIFF
--- a/erpnext/shopping_cart/utils.py
+++ b/erpnext/shopping_cart/utils.py
@@ -1,8 +1,5 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
-
-from __future__ import unicode_literals
-
 import frappe
 
 from erpnext.shopping_cart.doctype.shopping_cart_settings.shopping_cart_settings import (
@@ -18,10 +15,17 @@ def show_cart_count():
 	return False
 
 def set_cart_count(login_manager):
-	role, parties = check_customer_or_supplier()
-	if role == 'Supplier': return
+	# since this is run only on hooks login event
+	# make sure user is already a customer
+	# before trying to set cart count
+	user_is_customer = is_customer()
+	if not user_is_customer: return
+
 	if show_cart_count():
 		from erpnext.shopping_cart.cart import set_cart_count
+		# set_cart_count will try to fetch existing cart quotation
+		# or create one if non existent (and create a customer too)
+		# cart count is calculated from this quotation's items
 		set_cart_count()
 
 def clear_cart_count(login_manager):
@@ -32,13 +36,13 @@ def update_website_context(context):
 	cart_enabled = is_cart_enabled()
 	context["shopping_cart_enabled"] = cart_enabled
 
-def check_customer_or_supplier():
-	if frappe.session.user:
+def is_customer():
+	if frappe.session.user and frappe.session.user != "Guest":
 		contact_name = frappe.get_value("Contact", {"email_id": frappe.session.user})
 		if contact_name:
 			contact = frappe.get_doc('Contact', contact_name)
 			for link in contact.links:
-				if link.link_doctype in ('Customer', 'Supplier'):
-					return link.link_doctype, link.link_name
+				if link.link_doctype == 'Customer':
+					return True
 
-		return 'Customer', None
+		return False

--- a/erpnext/shopping_cart/utils.py
+++ b/erpnext/shopping_cart/utils.py
@@ -19,10 +19,12 @@ def set_cart_count(login_manager):
 	# make sure user is already a customer
 	# before trying to set cart count
 	user_is_customer = is_customer()
-	if not user_is_customer: return
+	if not user_is_customer:
+		return
 
 	if show_cart_count():
 		from erpnext.shopping_cart.cart import set_cart_count
+
 		# set_cart_count will try to fetch existing cart quotation
 		# or create one if non existent (and create a customer too)
 		# cart count is calculated from this quotation's items


### PR DESCRIPTION
**Issue:**
> TLDR: When a website user logs in, if they are not a customer and if cart is enabled, a customer was automatically created
- This user could have been created for blogs, or for other purposes, and not e-commerce.
- **This happens because:** on login, hooks triggers an event that sets the cart count. For this it tries to fetch the current users shopping cart (cart quotation). If it cannot find a quotation it creates a new one against this user. While doing this, it creates a customer if non-existent.
- If a quotation is found then its items count becomes the cart count, else an empty quotation(cart) is initialised.
- If a logged in user has ever added anything to cart, they are made a customer in the backend. So if this user is not a customer, we don't need to refresh the cart at all, it will be empty or non-existent.

**Fix:**
- Setting of cart count (refreshing the cart count) must happen only if the user logging in is a valid customer in the system. Otherwise the user has no business with the cart.
- Changed `check_customer_or_supplier` to `is_customer`. If supplier we were exiting the function anyway so why return it.

**To test:**
- Create a new website user (do not use this user for e-commerce)
- login as this user
- Check if customer was auto created after login