### PR TITLE
fix: Multiple fixes for Partly Paid status in Sales Invoice and Purchase Invoice

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -1183,6 +1183,11 @@ class PurchaseInvoice(BuyingController):
 			return
 
 		outstanding_amount = flt(self.outstanding_amount, self.precision("outstanding_amount"))
+		total = (
+			flt(self.base_grand_total, self.precision("base_grand_total"))
+			if self.disable_rounded_total
+			else flt(self.base_rounded_total, self.precision("base_rounded_total"))
+		)
 
 		if not status:
 			if self.docstatus == 2:
@@ -1192,7 +1197,7 @@ class PurchaseInvoice(BuyingController):
 					self.status = 'Internal Transfer'
 				elif is_overdue(self):
 					self.status = "Overdue"
-				elif 0 < abs(outstanding_amount) < abs(flt(self.base_grand_total, self.precision("base_grand_total"))):
+				elif 0 < abs(outstanding_amount) < abs(total):
 					self.status = "Partly Paid"
 				elif outstanding_amount > 0 and getdate(self.due_date) >= getdate():
 					self.status = "Unpaid"

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -1183,8 +1183,12 @@ class PurchaseInvoice(BuyingController):
 			return
 
 		outstanding_amount = flt(self.outstanding_amount, self.precision("outstanding_amount"))
-		total = "base_grand_total" if self.disable_rounded_total else "base_rounded_total"
-		total = flt(self.get(total), self.precision(total))
+		total_fieldname = (
+			"base_grand_total"
+			if self.disable_rounded_total
+			else "base_rounded_total"
+		)
+		total = flt(self.get(total_fieldname), self.precision(total_fieldname))
 
 		if not status:
 			if self.docstatus == 2:
@@ -1194,7 +1198,7 @@ class PurchaseInvoice(BuyingController):
 					self.status = 'Internal Transfer'
 				elif is_overdue(self, total):
 					self.status = "Overdue"
-				elif 0 < abs(outstanding_amount) < abs(total):
+				elif 0 < outstanding_amount < total:
 					self.status = "Partly Paid"
 				elif outstanding_amount > 0 and getdate(self.due_date) >= getdate():
 					self.status = "Unpaid"

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -1183,11 +1183,8 @@ class PurchaseInvoice(BuyingController):
 			return
 
 		outstanding_amount = flt(self.outstanding_amount, self.precision("outstanding_amount"))
-		total = (
-			flt(self.base_grand_total, self.precision("base_grand_total"))
-			if self.disable_rounded_total
-			else flt(self.base_rounded_total, self.precision("base_rounded_total"))
-		)
+		total = "base_grand_total" if self.disable_rounded_total else "base_rounded_total"
+		total = flt(self.get(total), self.precision(total))
 
 		if not status:
 			if self.docstatus == 2:
@@ -1195,7 +1192,7 @@ class PurchaseInvoice(BuyingController):
 			elif self.docstatus == 1:
 				if self.is_internal_transfer():
 					self.status = 'Internal Transfer'
-				elif is_overdue(self):
+				elif is_overdue(self, total):
 					self.status = "Overdue"
 				elif 0 < abs(outstanding_amount) < abs(total):
 					self.status = "Partly Paid"

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -1192,7 +1192,7 @@ class PurchaseInvoice(BuyingController):
 					self.status = 'Internal Transfer'
 				elif is_overdue(self):
 					self.status = "Overdue"
-				elif 0 < outstanding_amount < flt(self.grand_total, self.precision("grand_total")):
+				elif 0 < abs(outstanding_amount) < abs(flt(self.base_grand_total, self.precision("base_grand_total"))):
 					self.status = "Partly Paid"
 				elif outstanding_amount > 0 and getdate(self.due_date) >= getdate():
 					self.status = "Unpaid"

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -1419,6 +1419,11 @@ class SalesInvoice(SellingController):
 			return
 
 		outstanding_amount = flt(self.outstanding_amount, self.precision("outstanding_amount"))
+		total = (
+			flt(self.base_grand_total, self.precision("base_grand_total"))
+			if self.disable_rounded_total
+			else flt(self.base_rounded_total, self.precision("base_rounded_total"))
+		)
 
 		if not status:
 			if self.docstatus == 2:
@@ -1428,7 +1433,7 @@ class SalesInvoice(SellingController):
 					self.status = 'Internal Transfer'
 				elif is_overdue(self):
 					self.status = "Overdue"
-				elif 0 < abs(outstanding_amount) < abs(flt(self.base_grand_total, self.precision("base_grand_total"))):
+				elif 0 < abs(outstanding_amount) < abs(total):
 					self.status = "Partly Paid"
 				elif outstanding_amount > 0 and getdate(self.due_date) >= getdate():
 					self.status = "Unpaid"
@@ -1457,7 +1462,7 @@ class SalesInvoice(SellingController):
 
 def is_overdue(doc):
 	nowdate = getdate()
-	if doc.is_pos or doc.is_return or not doc.payment_schedule:
+	if doc.get('is_pos') or doc.get('is_return') or not doc.get('payment_schedule'):
 		return getdate(doc.due_date) < nowdate
 
 	outstanding_amount = flt(doc.outstanding_amount, doc.precision("outstanding_amount"))

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1698,7 +1698,7 @@ def update_invoice_status():
 						or (
 							dt.outstanding_amount > 0
 							and (dt.base_grand_total - dt.outstanding_amount) <
-								(select sum(payment_amount) from `tabPayment Schedule` as ps
+								(select sum(base_payment_amount) from `tabPayment Schedule` as ps
 									where ps.parent = dt.name and ps.due_date < %s)
 						)
 					)

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1686,17 +1686,23 @@ def get_advance_payment_entries(party_type, party, party_account, order_doctype,
 
 def update_invoice_status():
 	"""Updates status as Overdue for applicable invoices. Runs daily."""
-
+	nowdate = getdate()
 	for doctype in ("Sales Invoice", "Purchase Invoice"):
 		frappe.db.sql("""
 			update `tab{}` as dt set dt.status = 'Overdue'
-			where dt.docstatus = 1
+			where
+				dt.docstatus = 1
 				and dt.status != 'Overdue'
-				and dt.outstanding_amount > 0
-				and (dt.grand_total - dt.outstanding_amount) <
-					(select sum(payment_amount) from `tabPayment Schedule` as ps
-						where ps.parent = dt.name and ps.due_date < %s)
-		""".format(doctype), getdate())
+				and (
+						((dt.is_pos or dt_is_return) and dt.due_date < %s)
+						or (
+							dt.outstanding_amount > 0
+							and (dt.base_grand_total - dt.outstanding_amount) <
+								(select sum(payment_amount) from `tabPayment Schedule` as ps
+									where ps.parent = dt.name and ps.due_date < %s)
+						)
+					)
+		""".format(doctype), nowdate, nowdate)
 
 @frappe.whitelist()
 def get_payment_terms(terms_template, posting_date=None, grand_total=None, base_grand_total=None, bill_date=None):

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1694,7 +1694,7 @@ def update_invoice_status():
 				dt.docstatus = 1
 				and dt.status != 'Overdue'
 				and (
-						((dt.is_pos or dt_is_return) and dt.due_date < %s)
+						((dt.is_pos or dt.is_return) and dt.due_date < %s)
 						or (
 							dt.outstanding_amount > 0
 							and (dt.base_grand_total - dt.outstanding_amount) <

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -303,3 +303,4 @@ erpnext.patches.v13_0.modify_invalid_gain_loss_gl_entries #2
 erpnext.patches.v13_0.fix_additional_cost_in_mfg_stock_entry
 erpnext.patches.v13_0.set_status_in_maintenance_schedule_table
 erpnext.patches.v13_0.add_default_interview_notification_templates
+erpnext.patches.v13_0.fix_invoice_statuses

--- a/erpnext/patches/v13_0/fix_invoice_statuses.py
+++ b/erpnext/patches/v13_0/fix_invoice_statuses.py
@@ -1,0 +1,31 @@
+import frappe
+from frappe.utils import add_months, getdate
+
+
+def execute():
+	# This fix is not related to Party Specific Item,
+	# but it is needed for code introduced around that time
+	# If your DB doesn't have this doctype yet, you should be fine
+	if not frappe.db.exists("DocType", "Party Specific Item"):
+		return
+
+	for doctype in ("Purchase Invoice", "Sales Invoice"):
+		# invoices to update = overdue + mod 6 months ago (1 apr 2021)
+		# OR modified after PR date (25 sept 2021) + overdue or partly paid or overdue and discounted or partly paid and discounted
+		frappe.db.query("""
+			SELECT name
+			FROM `tab{}`
+			WHERE (
+					docstatus = `Overdue`
+					AND modified > %s
+				)
+				OR (
+					docstatus IN (`Overdue`, `Partly Paid`, `Overdue and Discounted`, `Partly Paid and Discounted`)
+					AND modified > %s
+				)
+		""".format(doctype),(add_months(getdate(), -6), getdate("2021-09-25")))
+		# for docname in get_all:
+		# 	doc = frappe.get_doc(doctype, docname)
+		# 	doc.set_status()
+
+		# create dict of docs, update in one go


### PR DESCRIPTION
## Issues
- When `base_grand_total` and `grand_total` are not same, status is being wrongly set.

## Changes made
 - Compare `outstanding_amount` with `base_grand_total` instead of `grand_total` since it will always be in base currency.
 - Improve `is_overdue` and `update_invoice_status`.
 - Consider `rounded_total` when it is not disabled.
