### PR TITLE
fix: Item Variant selection empty popup on website

### DIFF
--- a/erpnext/templates/generators/item/item_configure.html
+++ b/erpnext/templates/generators/item/item_configure.html
@@ -4,8 +4,8 @@
 <div class="mt-5 mb-6">
 	{% if cart_settings.enable_variants | int %}
 	<button class="btn btn-primary-light btn-configure font-md mr-2"
-		data-item-code="{{ doc.name }}"
-		data-item-name="{{ doc.item_name }}"
+		data-item-code="{{ doc.item_code }}"
+		data-item-name="{{ doc.web_item_name }}"
 	>
 		{{ _('Select Variant') }}
 	</button>


### PR DESCRIPTION
**Issue:**
- <img width="556" alt="Screenshot 2021-10-12 at 7 59 26 PM" src="https://user-images.githubusercontent.com/25857446/136975516-aacc996f-e92e-4b3c-80d0-c1a04d673f04.png">
- This was tested earlier with items that happened to have the same name as the website item
- Website Item naming is now changed to naming series based. So this was missed.

**Fix:**
- Store `item_code` instead of website item name in `Select Variant` buttons data attribute
- It is used in `get_attributes_and_values` which was taking the website item name earlier and giving back a blank result.
<img width="577" alt="Screenshot 2021-10-12 at 7 58 44 PM" src="https://user-images.githubusercontent.com/25857446/136975379-3ef94167-41d3-4680-97e6-bb3ee2777fab.png">

