### PR TITLE
ci: rule to fail PRs that add a new manual commit

### DIFF
--- a/.github/helper/semgrep_rules/frappe_correctness.yml
+++ b/.github/helper/semgrep_rules/frappe_correctness.yml
@@ -131,3 +131,21 @@ rules:
       key `$X` is uselessly assigned twice. This could be a potential bug.
   languages: [python]
   severity: ERROR
+
+
+- id: frappe-manual-commit
+  patterns:
+    - pattern: frappe.db.commit()
+    - pattern-not-inside: |
+        try:
+          ...
+        except ...:
+          ...
+  message: |
+    Manually commiting a transaction is highly discouraged. Read about the transaction model implemented by Frappe Framework before adding manual commits: https://frappeframework.com/docs/user/en/api/database#database-transaction-model If you think manual commit is required then add a comment explaining why and `// nosemgrep` on the same line.
+  paths:
+      exclude:
+        - "**/patches/**"
+        - "**/demo/**"
+  languages: [python]
+  severity: ERROR


### PR DESCRIPTION
Manual commits are a frequent source of bugs, confusion or undefined behaviour. 

All new manual commits should be explicitly ignored with an explanation of why it's added. This will only fail for new additions. Existing ones need to be cleaned up manually.


These are not required in most cases, ref: https://frappeframework.com/docs/user/en/api/database#database-transaction-model 