### PR TITLE
fix: TDS round off not working from second transaction

### DIFF
--- a/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
+++ b/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
@@ -191,6 +191,9 @@ def get_tax_amount(party_type, parties, inv, tax_details, posting_date, pan_no=N
 				tax_amount = get_tds_amount_from_ldc(ldc, parties, pan_no, tax_details, posting_date, net_total)
 			else:
 				tax_amount = net_total * tax_details.rate / 100 if net_total > 0 else 0
+
+			if cint(tax_details.round_off_tax_amount):
+				tax_amount = round(tax_amount)
 		else:
 			tax_amount = get_tds_amount(ldc, parties, inv, tax_details, tax_deducted, vouchers)
 

--- a/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
+++ b/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
@@ -191,9 +191,6 @@ def get_tax_amount(party_type, parties, inv, tax_details, posting_date, pan_no=N
 				tax_amount = get_tds_amount_from_ldc(ldc, parties, pan_no, tax_details, posting_date, net_total)
 			else:
 				tax_amount = net_total * tax_details.rate / 100 if net_total > 0 else 0
-
-			if cint(tax_details.round_off_tax_amount):
-				tax_amount = round(tax_amount)
 		else:
 			tax_amount = get_tds_amount(ldc, parties, inv, tax_details, tax_deducted, vouchers)
 
@@ -205,6 +202,9 @@ def get_tax_amount(party_type, parties, inv, tax_details, posting_date, pan_no=N
 			#  if no TCS has been charged in FY,
 			# then chargeable value is "prev invoices + advances" value which cross the threshold
 			tax_amount = get_tcs_amount(parties, inv, tax_details, vouchers, advance_vouchers)
+
+	if cint(tax_details.round_off_tax_amount):
+		tax_amount = round(tax_amount)
 
 	return tax_amount, tax_deducted
 
@@ -324,9 +324,6 @@ def get_tds_amount(ldc, parties, inv, tax_details, tax_deducted, vouchers):
 			tds_amount = get_ltds_amount(supp_credit_amt, 0, ldc.certificate_limit, ldc.rate, tax_details)
 		else:
 			tds_amount = supp_credit_amt * tax_details.rate / 100 if supp_credit_amt > 0 else 0
-
-	if cint(tax_details.round_off_tax_amount):
-		tds_amount = round(tds_amount)
 
 	return tds_amount
 


### PR DESCRIPTION
Tax Withholding Round Off amount check was done only in the code block where the TDS for the very first transaction was calculated.

So for the subsequent transactions let's say second and so on the TDS amount was not getting rounded to the nearest integer

Moved the check to the code block where the final tax amount is returned so that the tax amount is rounded off for all types (TDS  and TCS both) and all transactions