### PR TITLE
fix: not authorized to update entries after freezing accounts

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -2357,6 +2357,18 @@ class TestSalesInvoice(unittest.TestCase):
 		si.reload()
 		self.assertEqual(si.status, "Paid")
 
+	def test_sales_invoice_submission_post_account_freezing_date(self):
+		frappe.db.set_value('Accounts Settings', None, 'acc_frozen_upto', add_days(getdate(), 1))
+		si = create_sales_invoice(do_not_save=True)
+		si.posting_date = add_days(getdate(), 1)
+		si.save()
+
+		self.assertRaises(frappe.ValidationError, si.submit)
+		si.posting_date = getdate()
+		si.submit()
+
+		frappe.db.set_value('Accounts Settings', None, 'acc_frozen_upto', None)
+
 def get_sales_invoice_for_e_invoice():
 	si = make_sales_invoice_for_ewaybill()
 	si.naming_series = 'INV-2020-.#####'

--- a/erpnext/accounts/general_ledger.py
+++ b/erpnext/accounts/general_ledger.py
@@ -293,7 +293,7 @@ def check_freezing_date(posting_date, adv_adj=False):
 		if acc_frozen_upto:
 			frozen_accounts_modifier = frappe.db.get_value( 'Accounts Settings', None,'frozen_accounts_modifier')
 			if getdate(posting_date) <= getdate(acc_frozen_upto) \
-					and (not frozen_accounts_modifier in frappe.get_roles() or frappe.session.user == 'Administrator'):
+					and (frozen_accounts_modifier not in frappe.get_roles() or frappe.session.user == 'Administrator'):
 				frappe.throw(_("You are not authorized to add or update entries before {0}").format(formatdate(acc_frozen_upto)))
 
 def set_as_cancel(voucher_type, voucher_no):

--- a/erpnext/accounts/general_ledger.py
+++ b/erpnext/accounts/general_ledger.py
@@ -293,7 +293,7 @@ def check_freezing_date(posting_date, adv_adj=False):
 		if acc_frozen_upto:
 			frozen_accounts_modifier = frappe.db.get_value( 'Accounts Settings', None,'frozen_accounts_modifier')
 			if getdate(posting_date) <= getdate(acc_frozen_upto) \
-					and not frozen_accounts_modifier in frappe.get_roles() or frappe.session.user == 'Administrator':
+					and (not frozen_accounts_modifier in frappe.get_roles() or frappe.session.user == 'Administrator'):
 				frappe.throw(_("You are not authorized to add or update entries before {0}").format(formatdate(acc_frozen_upto)))
 
 def set_as_cancel(voucher_type, voucher_no):

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -303,3 +303,4 @@ erpnext.patches.v13_0.modify_invalid_gain_loss_gl_entries
 erpnext.patches.v13_0.fix_additional_cost_in_mfg_stock_entry
 erpnext.patches.v13_0.set_status_in_maintenance_schedule_table
 erpnext.patches.v13_0.add_default_interview_notification_templates
+erpnext.patches.v13_0.requeue_failed_reposts

--- a/erpnext/patches/v13_0/requeue_failed_reposts.py
+++ b/erpnext/patches/v13_0/requeue_failed_reposts.py
@@ -1,0 +1,14 @@
+import frappe
+from frappe.utils import cstr
+
+def execute():
+
+	reposts = frappe.get_all("Repost Item Valuation",
+		{"status": "Failed", "modified": [">", "2021-10-6"] },
+		["name", "modified", "error_log"])
+
+	for repost in reposts:
+		if "check_freezing_date" in cstr(repost.error_log):
+			frappe.db.set_value("Repost Item Valuation", repost.name, "status", "Queued")
+
+	frappe.db.commit()

--- a/erpnext/patches/v13_0/requeue_failed_reposts.py
+++ b/erpnext/patches/v13_0/requeue_failed_reposts.py
@@ -1,14 +1,13 @@
 import frappe
 from frappe.utils import cstr
 
+
 def execute():
 
 	reposts = frappe.get_all("Repost Item Valuation",
-		{"status": "Failed", "modified": [">", "2021-10-6"] },
+		{"status": "Failed", "modified": [">", "2021-10-05"] },
 		["name", "modified", "error_log"])
 
 	for repost in reposts:
 		if "check_freezing_date" in cstr(repost.error_log):
 			frappe.db.set_value("Repost Item Valuation", repost.name, "status", "Queued")
-
-	frappe.db.commit()


### PR DESCRIPTION
### Issue
- Freezing date is set in the **"Accounts Settings"**.

![image](https://user-images.githubusercontent.com/43572428/137090603-c6764c43-60b0-47e7-9afa-0003d07d42fa.png)

- When trying to make any entry which needs to update the GL, it throws the following error.
- For Example, while trying to submit a Delivery Note after the freezing date, the error is still thrown.

![image](https://user-images.githubusercontent.com/43572428/137090461-4ac1b7d7-3f5d-45a5-b802-bf5fadb242ec.png)

- Reposts fail even if posting date is greater than the freezing date.

![image](https://user-images.githubusercontent.com/43572428/137093111-f372a8a8-e173-4f13-aca5-9c5fc0a69bc6.png)


### Fix
- The condition that throws the error passes when the user is "Administrator" which is always the case when reposting or while updating entries. 
- Fixed the condition. 

