### PR TITLE
fix: Retain space inside Serial no string while cleaning serial nos

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -85,7 +85,7 @@ class StockController(AccountsController):
 				# strip preceeding and succeeding spaces for each SN
 				# (SN could have valid spaces in between e.g. SN - 123 - 2021)
 				serial_no_list = row.serial_no.split("\n")
-				serial_no_list = [sn.lstrip().rstrip() for sn in serial_no_list]
+				serial_no_list = [sn.strip() for sn in serial_no_list]
 
 				row.serial_no = "\n".join(serial_no_list)
 

--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -79,8 +79,15 @@ class StockController(AccountsController):
 	def clean_serial_nos(self):
 		for row in self.get("items"):
 			if hasattr(row, "serial_no") and row.serial_no:
-				# replace commas by linefeed and remove all spaces in string
-				row.serial_no = row.serial_no.replace(",", "\n").replace(" ", "")
+				# replace commas by linefeed
+				row.serial_no = row.serial_no.replace(",", "\n")
+
+				# strip preceeding and succeeding spaces for each SN
+				# (SN could have valid spaces in between e.g. SN - 123 - 2021)
+				serial_no_list = row.serial_no.split("\n")
+				serial_no_list = [sn.lstrip().rstrip() for sn in serial_no_list]
+
+				row.serial_no = "\n".join(serial_no_list)
 
 	def get_gl_entries(self, warehouse_account=None, default_expense_account=None,
 			default_cost_center=None):

--- a/erpnext/stock/doctype/serial_no/test_serial_no.py
+++ b/erpnext/stock/doctype/serial_no/test_serial_no.py
@@ -184,14 +184,14 @@ class TestSerialNo(ERPNextTestCase):
 
 		se = frappe.copy_doc(test_records[0])
 		se.get("items")[0].item_code = item_code
-		se.get("items")[0].qty = 3
-		se.get("items")[0].serial_no = " _TS1, _TS2 , _TS3  "
-		se.get("items")[0].transfer_qty = 3
+		se.get("items")[0].qty = 4
+		se.get("items")[0].serial_no = " _TS1, _TS2 , _TS3  , _TS4 - 2021"
+		se.get("items")[0].transfer_qty = 4
 		se.set_stock_entry_type()
 		se.insert()
 		se.submit()
 
-		self.assertEqual(se.get("items")[0].serial_no, "_TS1\n_TS2\n_TS3")
+		self.assertEqual(se.get("items")[0].serial_no, "_TS1\n_TS2\n_TS3\n_TS4 - 2021")
 
 		frappe.db.rollback()
 


### PR DESCRIPTION
A missing case https://github.com/frappe/erpnext/pull/26596 did not consider

**Issue:**
- Consider Serial No string `SN - 123 - 2021\n  SN - 124 - 2021\n `
- The individual serial no is `SN - 123 - 2021` with spaces in it. The previous fix removed all spaces in the string. So            
 `SN - 123 - 2021\n` becomes `SN-123-2021\n` 
- This caused serial no mismatch issues in some sales invoices created from legacy delivery notes

**Fix:**
- String `SN - 123 - 2021\n   SN - 124 - 2021\n  `  is cleaned to become `SN - 123 - 2021\nSN - 124 - 2021\n` without trailing and leading spaces i.e. **spaces surrounding the serial no removed**