### PR TITLE
fix: Account number and name incorrectly imported using COA importer

### DIFF
--- a/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py
+++ b/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py
@@ -69,7 +69,7 @@ def import_coa(file_name, company):
 
 	frappe.local.flags.ignore_root_company_validation = True
 	forest = build_forest(data)
-	create_charts(company, custom_chart=forest)
+	create_charts(company, custom_chart=forest, from_coa_importer=True)
 
 	# trigger on_update for company to reset default accounts
 	set_default_accounts(company)
@@ -148,7 +148,7 @@ def get_coa(doctype, parent, is_root=False, file_name=None, for_validate=0):
 
 	if not for_validate:
 		forest = build_forest(data)
-		accounts = build_tree_from_json("", chart_data=forest) # returns a list of dict in a tree render-able form
+		accounts = build_tree_from_json("", chart_data=forest, from_coa_importer=True) # returns a list of dict in a tree render-able form
 
 		# filter out to show data for the selected node only
 		accounts = [d for d in accounts if d['parent_account']==parent]
@@ -212,11 +212,14 @@ def build_forest(data):
 		if not account_name:
 			error_messages.append("Row {0}: Please enter Account Name".format(line_no))
 
+		name = account_name
 		if account_number:
 			account_number = cstr(account_number).strip()
 			account_name = "{} - {}".format(account_number, account_name)
 
 		charts_map[account_name] = {}
+		charts_map[account_name]['account_name'] = name
+		if account_number: charts_map[account_name]["account_number"] = account_number
 		if cint(is_group) == 1: charts_map[account_name]["is_group"] = is_group
 		if account_type: charts_map[account_name]["account_type"] = account_type
 		if root_type: charts_map[account_name]["root_type"] = root_type


### PR DESCRIPTION
Account name and number were not correctly updated in the Account master when accounts were imported using the chart of accounts importer tool

For Eg: If an `account name`  is `Test Account` and `account number` is `1234` the account numbers is imported as blank and the `account name` is imported as `1234 - Test Account`

This PR fixes that issue 