### PR TITLE
fix: incorrect sales invoice status set if rounding adjustment is set

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -1469,7 +1469,11 @@ def is_overdue(doc):
 	if outstanding_amount <= 0:
 		return
 
-	grand_total = flt(doc.grand_total, doc.precision("grand_total"))
+	if doc.rounding_adjustment and doc.rounded_total:
+		invoice_total = flt(doc.rounded_total, doc.precision("rounded_total"))
+	else:
+		invoice_total = flt(doc.grand_total, doc.precision("grand_total"))
+
 	nowdate = getdate()
 	if doc.payment_schedule:
 		# calculate payable amount till date
@@ -1479,7 +1483,7 @@ def is_overdue(doc):
 			if getdate(payment.due_date) < nowdate
 		)
 
-		if (grand_total - outstanding_amount) < payable_amount:
+		if (invoice_total - outstanding_amount) < payable_amount:
 			return True
 
 	elif getdate(doc.due_date) < nowdate:


### PR DESCRIPTION
Introduced with #27625

Case:
`due_date = any_future_date`

`grand_total = 499.5`
`rounding_adjustment = 0.5`
`rounded_total = 500`
`oustanding_amount = 500`

with the above values, the status of the invoice is set as `Overdue` because,
`is_overdue` returns `True` since `grand_total - outstanding_amount` is negative