### PR TITLE
fix: Fetch thumbnail from Item master instead of regenerating

### DIFF
--- a/erpnext/e_commerce/doctype/website_item/website_item.py
+++ b/erpnext/e_commerce/doctype/website_item/website_item.py
@@ -147,7 +147,7 @@ class WebsiteItem(WebsiteGenerator):
 
 	def make_thumbnail(self):
 		"""Make a thumbnail of `website_image`"""
-		if frappe.flags.in_import:
+		if frappe.flags.in_import or frappe.flags.in_migrate:
 			return
 
 		import requests.exceptions

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -309,7 +309,7 @@ erpnext.patches.v13_0.reset_clearance_date_for_intracompany_payment_entries
 erpnext.patches.v13_0.custom_fields_for_taxjar_integration
 erpnext.patches.v13_0.set_operation_time_based_on_operating_cost
 erpnext.patches.v13_0.validate_options_for_data_field
-erpnext.patches.v13_0.create_website_items #19-10-2021
+erpnext.patches.v13_0.create_website_items #30-09-2021
 erpnext.patches.v13_0.populate_e_commerce_settings
 erpnext.patches.v13_0.make_homepage_products_website_items
 erpnext.patches.v13_0.update_dates_in_tax_withholding_category
@@ -324,3 +324,4 @@ erpnext.patches.v13_0.set_status_in_maintenance_schedule_table
 erpnext.patches.v13_0.add_default_interview_notification_templates
 erpnext.patches.v13_0.trim_sales_invoice_custom_field_length
 erpnext.patches.v13_0.requeue_failed_reposts
+erpnext.patches.v13_0.fetch_thumbnail_in_website_items

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -309,7 +309,7 @@ erpnext.patches.v13_0.reset_clearance_date_for_intracompany_payment_entries
 erpnext.patches.v13_0.custom_fields_for_taxjar_integration
 erpnext.patches.v13_0.set_operation_time_based_on_operating_cost
 erpnext.patches.v13_0.validate_options_for_data_field
-erpnext.patches.v13_0.create_website_items #30-09-2021
+erpnext.patches.v13_0.create_website_items #19-10-2021
 erpnext.patches.v13_0.populate_e_commerce_settings
 erpnext.patches.v13_0.make_homepage_products_website_items
 erpnext.patches.v13_0.update_dates_in_tax_withholding_category

--- a/erpnext/patches/v13_0/create_website_items.py
+++ b/erpnext/patches/v13_0/create_website_items.py
@@ -16,6 +16,7 @@ def execute():
 	web_fields_to_map = ["route", "slideshow", "website_image_alt",
 		"website_warehouse", "web_long_description", "website_content", "thumbnail"]
 
+	# get all valid columns (fields) from Item master DB schema
 	item_table_fields = frappe.db.sql("desc `tabItem`", as_dict=1)
 	item_table_fields = [d.get('Field') for d in item_table_fields]
 
@@ -45,7 +46,10 @@ def execute():
 
 	count = 0
 	for item in items:
-		if frappe.db.exists("Website Item", {"item_code": item.item_code}):
+		web_item_exists = frappe.db.exists("Website Item", {"item_code": item.item_code})
+		thumbnail_column_exists = "thumbnail" in item_table_fields
+
+		if web_item_exists and thumbnail_column_exists:
 			# if website item already exists check for empty thumbnail
 			# if empty, fetch thumbnail from Item master
 			web_item_doc = frappe.db.get_values(

--- a/erpnext/patches/v13_0/create_website_items.py
+++ b/erpnext/patches/v13_0/create_website_items.py
@@ -43,51 +43,30 @@ def execute():
 		fields=item_fields,
 		or_filters=or_filters
 	)
+	total_count = len(items)
 
-	count = 0
-	for item in items:
-		web_item_exists = frappe.db.exists("Website Item", {"item_code": item.item_code})
-		thumbnail_column_exists = "thumbnail" in item_table_fields
+	for count, item in enumerate(items, start=1):
+		if frappe.db.exists("Website Item", {"item_code": item.item_code}):
+			continue
 
-		if web_item_exists and thumbnail_column_exists:
-			# if website item already exists check for empty thumbnail
-			# if empty, fetch thumbnail from Item master
-			web_item_doc = frappe.db.get_values(
-				"Website Item",
-				filters={
-					"item_code": item.item_code
-				},
-				fieldname=["website_image", "thumbnail", "name"],
-				as_dict=True
-			)[0]
+		# make new website item from item (publish item)
+		website_item = make_website_item(item, save=False)
+		website_item.ranking = item.get("weightage")
 
-			if web_item_doc.get("website_image") and not web_item_doc.get("thumbnail"):
-				thumbnail = frappe.db.get_value("Item", item.item_code, "thumbnail")
-				frappe.db.set_value("Website Item", web_item_doc.name, "thumbnail", thumbnail)
-		else:
-			# else make new website item from item (publish item)
-			website_item = make_website_item(item, save=False)
-			website_item.ranking = item.get("weightage")
+		for field in web_fields_to_map:
+			website_item.update({field: item.get(field)})
 
-			for field in web_fields_to_map:
-				website_item.update({field: item.get(field)})
+		website_item.save()
 
-			website_item.save()
+		# move Website Item Group & Website Specification table to Website Item
+		for doctype in ("Website Item Group", "Item Website Specification"):
+			frappe.db.set_value(
+				doctype,
+				{"parenttype": "Item", "parent": item.item_code}, # filters
+				{"parenttype": "Website Item", "parent": website_item.name} # value dict
+			)
 
-			# move Website Item Group & Website Specification table to Website Item
-			for doctype in ("Website Item Group", "Item Website Specification"):
-				web_item, item_code = website_item.name, item.item_code
-				frappe.db.sql(f"""
-					Update
-						`tab{doctype}`
-					set
-						parenttype = 'Website Item',
-						parent = '{web_item}'
-					where
-						parenttype = 'Item'
-						and parent = '{item_code}'
-					""")
-
-		count += 1
 		if count % 20 == 0: # commit after every 20 items
 			frappe.db.commit()
+
+		frappe.utils.update_progress_bar('Creating Website Items', count, total_count)

--- a/erpnext/patches/v13_0/create_website_items.py
+++ b/erpnext/patches/v13_0/create_website_items.py
@@ -53,7 +53,8 @@ def execute():
 				filters={
 					"item_code": item.item_code
 				},
-				fieldname=["website_image", "thumbnail", "name"]
+				fieldname=["website_image", "thumbnail", "name"],
+				as_dict=True
 			)[0]
 
 			if web_item_doc.get("website_image") and not web_item_doc.get("thumbnail"):

--- a/erpnext/patches/v13_0/fetch_thumbnail_in_website_items.py
+++ b/erpnext/patches/v13_0/fetch_thumbnail_in_website_items.py
@@ -1,0 +1,16 @@
+import frappe
+
+
+def execute():
+    if frappe.db.has_column("Item", "thumbnail"):
+        website_item = frappe.qb.DocType("Website Item").as_("wi")
+        item = frappe.qb.DocType("Item")
+
+        frappe.qb.update(website_item).inner_join(item).on(
+            website_item.item_code == item.item_code
+        ).set(
+            website_item.thumbnail, item.thumbnail
+        ).where(
+            website_item.website_image.notnull()
+            & website_item.thumbnail.isnull()
+        ).run()


### PR DESCRIPTION
**Issue:**
- Due to thumbnail generation in patch, patch slowed down a lot. File is created , etc. which slows things down

**Fix:**
- Separate patch to update thumbnail field of website item from item master
- In `create_website_items`, only make web items, nothing else. If web item exists, skip the item.
- Added a progress bar to `create_website_items`