### PR TITLE
fix: POS consolidated invoice rounded total issue

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
@@ -114,6 +114,8 @@ class POSInvoiceMergeLog(Document):
 	def merge_pos_invoice_into(self, invoice, data):
 		items, payments, taxes = [], [], []
 		loyalty_amount_sum, loyalty_points_sum = 0, 0
+		rounding_adjustment, base_rounding_adjustment = 0, 0
+		rounded_total, base_rounded_total = 0, 0
 		for doc in data:
 			map_doc(doc, invoice, table_map={ "doctype": invoice.doctype })
 
@@ -162,6 +164,11 @@ class POSInvoiceMergeLog(Document):
 						found = True
 				if not found:
 					payments.append(payment)
+			rounding_adjustment += doc.rounding_adjustment
+			rounded_total += doc.rounded_total
+			base_rounding_adjustment += doc.rounding_adjustment
+			base_rounded_total += doc.rounded_total
+
 
 		if loyalty_points_sum:
 			invoice.redeem_loyalty_points = 1
@@ -171,6 +178,10 @@ class POSInvoiceMergeLog(Document):
 		invoice.set('items', items)
 		invoice.set('payments', payments)
 		invoice.set('taxes', taxes)
+		invoice.set('rounding_adjustment',rounding_adjustment)
+		invoice.set('rounding_adjustment',base_rounding_adjustment)
+		invoice.set('base_rounded_total',base_rounded_total)
+		invoice.set('rounded_total',rounded_total)
 		invoice.additional_discount_percentage = 0
 		invoice.discount_amount = 0.0
 		invoice.taxes_and_charges = None

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -409,8 +409,6 @@ class calculate_taxes_and_totals(object):
 				self.doc.rounding_adjustment = diff
 
 	def calculate_totals(self):
-		print('BEFORE CALCULATE TAXES AND CHARGES', 'taxes:::', 'rounding adjustment:::',self.doc.rounding_adjustment, 'net total', self.doc.net_total)
-
 		if self.doc.get("taxes"):
 			self.doc.grand_total = flt(self.doc.get("taxes")[-1].total) + flt(self.doc.rounding_adjustment)
 		else:
@@ -421,8 +419,6 @@ class calculate_taxes_and_totals(object):
 			- flt(self.doc.rounding_adjustment), self.doc.precision("total_taxes_and_charges"))
 		else:
 			self.doc.total_taxes_and_charges = 0.0
-		print('AFTER assigning TAXES AND CHARGES', self.doc.grand_total, self.doc.net_total, self.doc.rounding_adjustment)
-		# frappe.throw('calculate_totals')
 
 		self._set_in_company_currency(self.doc, ["total_taxes_and_charges", "rounding_adjustment"])
 

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -260,7 +260,9 @@ class calculate_taxes_and_totals(object):
 		self.doc.round_floats_in(self.doc, ["total", "base_total", "net_total", "base_net_total"])
 
 	def calculate_taxes(self):
-		self.doc.rounding_adjustment = 0
+		if not self.doc.get('is_consolidated'):
+			self.doc.rounding_adjustment = 0
+
 		# maintain actual tax rate based on idx
 		actual_tax_dict = dict([[tax.idx, flt(tax.tax_amount, tax.precision("tax_amount"))]
 			for tax in self.doc.get("taxes") if tax.charge_type == "Actual"])
@@ -312,7 +314,9 @@ class calculate_taxes_and_totals(object):
 
 					# adjust Discount Amount loss in last tax iteration
 					if i == (len(self.doc.get("taxes")) - 1) and self.discount_amount_applied \
-						and self.doc.discount_amount and self.doc.apply_discount_on == "Grand Total":
+						and self.doc.discount_amount \
+						and self.doc.apply_discount_on == "Grand Total" \
+						and not self.doc.get('is_consolidated'):
 							self.doc.rounding_adjustment = flt(self.doc.grand_total
 								- flt(self.doc.discount_amount) - tax.total,
 								self.doc.precision("rounding_adjustment"))
@@ -405,11 +409,20 @@ class calculate_taxes_and_totals(object):
 				self.doc.rounding_adjustment = diff
 
 	def calculate_totals(self):
-		self.doc.grand_total = flt(self.doc.get("taxes")[-1].total) + flt(self.doc.rounding_adjustment) \
-			if self.doc.get("taxes") else flt(self.doc.net_total)
+		print('BEFORE CALCULATE TAXES AND CHARGES', 'taxes:::', 'rounding adjustment:::',self.doc.rounding_adjustment, 'net total', self.doc.net_total)
 
-		self.doc.total_taxes_and_charges = flt(self.doc.grand_total - self.doc.net_total
+		if self.doc.get("taxes"):
+			self.doc.grand_total = flt(self.doc.get("taxes")[-1].total) + flt(self.doc.rounding_adjustment)
+		else:
+			self.doc.grand_total = flt(self.doc.net_total)
+
+		if self.doc.get("taxes"):
+			self.doc.total_taxes_and_charges = flt(self.doc.grand_total - self.doc.net_total
 			- flt(self.doc.rounding_adjustment), self.doc.precision("total_taxes_and_charges"))
+		else:
+			self.doc.total_taxes_and_charges = 0.0
+		print('AFTER assigning TAXES AND CHARGES', self.doc.grand_total, self.doc.net_total, self.doc.rounding_adjustment)
+		# frappe.throw('calculate_totals')
 
 		self._set_in_company_currency(self.doc, ["total_taxes_and_charges", "rounding_adjustment"])
 
@@ -446,19 +459,20 @@ class calculate_taxes_and_totals(object):
 					self.doc.total_net_weight += d.total_weight
 
 	def set_rounded_total(self):
-		if self.doc.meta.get_field("rounded_total"):
-			if self.doc.is_rounded_total_disabled():
-				self.doc.rounded_total = self.doc.base_rounded_total = 0
-				return
+		if not self.doc.get('is_consolidated'):
+			if self.doc.meta.get_field("rounded_total"):
+				if self.doc.is_rounded_total_disabled():
+					self.doc.rounded_total = self.doc.base_rounded_total = 0
+					return
 
-			self.doc.rounded_total = round_based_on_smallest_currency_fraction(self.doc.grand_total,
-				self.doc.currency, self.doc.precision("rounded_total"))
+				self.doc.rounded_total = round_based_on_smallest_currency_fraction(self.doc.grand_total,
+					self.doc.currency, self.doc.precision("rounded_total"))
 
-			#if print_in_rate is set, we would have already calculated rounding adjustment
-			self.doc.rounding_adjustment += flt(self.doc.rounded_total - self.doc.grand_total,
-				self.doc.precision("rounding_adjustment"))
+				#if print_in_rate is set, we would have already calculated rounding adjustment
+				self.doc.rounding_adjustment += flt(self.doc.rounded_total - self.doc.grand_total,
+					self.doc.precision("rounding_adjustment"))
 
-			self._set_in_company_currency(self.doc, ["rounding_adjustment", "rounded_total"])
+				self._set_in_company_currency(self.doc, ["rounding_adjustment", "rounded_total"])
 
 	def _cleanup(self):
 		if not self.doc.get('is_consolidated'):


### PR DESCRIPTION
Ref issue: ISS-21-22-06296


**Problem:**
Consider the following 2 POS Invoices:
 <details>
<summary><b>invoice 1:</b></summary>
<img src='https://user-images.githubusercontent.com/36098155/137941265-c8908831-2049-47b5-ad36-849b03b609a4.png' width='700'>
<img src='https://user-images.githubusercontent.com/36098155/137943101-2eaf4b16-b390-4ec2-badf-b60870dd20e6.png' width='700'>
</details>

<details>
<summary><b>Invoice 2:</b></summary>
<img src='https://user-images.githubusercontent.com/36098155/137941420-940c5b6f-9fa7-4a95-a3e1-82baf8ad0de6.png' width='700'>
<img src='https://user-images.githubusercontent.com/36098155/137943306-9bc17b8d-23d9-4472-bcac-78680317b2b0.png' width='700'>
</details>

<details>
<summary><b>Consolidated Invoice of the above two:</b></summary>
<img src='![solved_consoltd_invoice](https://user-images.githubusercontent.com/36098155/137948250-919f8141-234b-4c92-b332-5d68962d9848.gif)' width='700'>
</details>



- The total gets rounded in both the invoices and _0.50_ is deducted from the total of both invoices
- So the effect totals and the amount paid in both the invoices now are:  ***250 and 50***
- On consolidating these 2 invoices, the total becomes:
   ***250.5 + 50.5 = 301***
- The effective amount actually paid is ***250+50 = 300***, since the totals of individual invoices were rounded off
- In the consolidated invoice, the paid amount is calculated by adding paid amounts from individual pos invoices
- The  amount to be paid in the consolidated sales invoice gets recalculated as **301** after merging the two POS invoices
- Since only 300 was paid and the sales invoice has 301 as the amount to be paid, the consolidated invoice would remain in unpaid state and there would be an outstanding amount of ***Re. 1***


**Solution:**
<details>
<summary><b>Fixed Consolidated Invoice of the above two:</b></summary>
<img src='https://user-images.githubusercontent.com/36098155/137948326-904b6a6a-3273-40da-b3a3-d50a799b7f82.gif' width='700'>
</details>

- Adding the `Rounding Adjustment` and `Rounded Total` of the individual POS invoices while merging to calculate the same for Consolidated Invoice
- In `calculate_taxes` method, rounding adjustment was being overriden so bypassed that for consolidated invoices
- In `calculate_totals` method, total_taxes_and_charges was being calculated even when there were no taxes applied, so added a condition for the same 


