### PR TITLE
[Hot Fix] Fieldname column_break_5 appears multiple times in rows 5, 14

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice_timesheet/sales_invoice_timesheet.json
+++ b/erpnext/accounts/doctype/sales_invoice_timesheet/sales_invoice_timesheet.json
@@ -17,7 +17,6 @@
   "billing_amount",
   "section_break_11",
   "timesheet_detail",
-  "column_break_5",
   "time_sheet",
   "project_name"
  ],
@@ -91,7 +90,6 @@
    "fieldtype": "Column Break"
   },
   {
-
    "fieldname": "section_break_7",
    "fieldtype": "Section Break",
    "label": "Totals"
@@ -114,7 +112,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2021-08-15 18:37:08.084930",
+ "modified": "2021-10-19 23:14:24.411870",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice Timesheet",


### PR DESCRIPTION
 - `closes #28009`