### PR TITLE
fix: avoid resetting employee on amending timesheets

### DIFF
--- a/erpnext/projects/doctype/timesheet/timesheet.js
+++ b/erpnext/projects/doctype/timesheet/timesheet.js
@@ -32,12 +32,12 @@ frappe.ui.form.on("Timesheet", {
 		};
 	},
 
-	onload: function(frm){
+	onload: function(frm) {
 		if (frm.doc.__islocal && frm.doc.time_logs) {
 			calculate_time_and_amount(frm);
 		}
 
-		if (frm.is_new()) {
+		if (frm.is_new() && !frm.doc.employee) {
 			set_employee_and_company(frm);
 		}
 	},


### PR DESCRIPTION
**Before Fix**:

If a timesheet with employee field set is amended, it resets employee details and since it is a non-mandatory field user can miss this, save and submit the timesheet without setting the employee again. This is because the timesheet tries to set the employee from session user on load.

![timesheet-employee-reset](https://user-images.githubusercontent.com/24353136/138082128-e2f8960c-bb18-494a-9fb9-ed70904369f2.gif)

**After Fix:**

Don't reset employee details if already set

![employee-reset-fix](https://user-images.githubusercontent.com/24353136/138082153-a23bb5d3-f053-4de4-ba93-11416ba385b1.gif)

