### PR TITLE
fix: remove employee_name from job card summary and test all manufacturing reports

### DIFF
--- a/erpnext/manufacturing/report/job_card_summary/job_card_summary.py
+++ b/erpnext/manufacturing/report/job_card_summary/job_card_summary.py
@@ -45,7 +45,7 @@ def get_data(filters):
 	job_card_time_details = {}
 	for job_card_data in frappe.get_all("Job Card Time Log",
 		fields=["min(from_time) as from_time", "max(to_time) as to_time", "parent"],
-		filters=job_card_time_filter, group_by="parent", debug=1):
+		filters=job_card_time_filter, group_by="parent"):
 		job_card_time_details[job_card_data.parent] = job_card_data
 
 	res = []

--- a/erpnext/manufacturing/report/job_card_summary/job_card_summary.py
+++ b/erpnext/manufacturing/report/job_card_summary/job_card_summary.py
@@ -24,7 +24,7 @@ def get_data(filters):
 	}
 
 	fields = ["name", "status", "work_order", "production_item", "item_name", "posting_date",
-		"total_completed_qty", "workstation", "operation", "employee_name", "total_time_in_mins"]
+		"total_completed_qty", "workstation", "operation", "total_time_in_mins"]
 
 	for field in ["work_order", "workstation", "operation", "company"]:
 		if filters.get(field):
@@ -170,12 +170,6 @@ def get_columns(filters):
 			"fieldname": "operation",
 			"fieldtype": "Link",
 			"options": "Operation",
-			"width": 110
-		},
-		{
-			"label": _("Employee Name"),
-			"fieldname": "employee_name",
-			"fieldtype": "Data",
 			"width": 110
 		},
 		{

--- a/erpnext/manufacturing/report/test_reports.py
+++ b/erpnext/manufacturing/report/test_reports.py
@@ -1,0 +1,63 @@
+import unittest
+from typing import List, Tuple
+
+import frappe
+
+from erpnext.tests.utils import ReportFilters, ReportName, execute_script_report
+
+DEFAULT_FILTERS = {
+	"company": "_Test Company",
+	"from_date": "2010-01-01",
+	"to_date": "2030-01-01",
+	"warehouse": "_Test Warehouse - _TC",
+}
+
+
+REPORT_FILTER_TEST_CASES: List[Tuple[ReportName, ReportFilters]] = [
+	("BOM Explorer", {"bom": frappe.get_last_doc("BOM").name}),
+	("BOM Operations Time", {}),
+	("BOM Stock Calculated", {"bom": frappe.get_last_doc("BOM").name, "qty_to_make": 2}),
+	("BOM Stock Report", {"bom": frappe.get_last_doc("BOM").name, "qty_to_produce": 2}),
+	("Cost of Poor Quality Report", {}),
+	("Downtime Analysis", {}),
+	(
+		"Exponential Smoothing Forecasting",
+		{
+			"based_on_document": "Sales Order",
+			"based_on_field": "Qty",
+			"no_of_years": 3,
+			"periodicity": "Yearly",
+			"smoothing_constant": 0.3,
+		},
+	),
+	("Job Card Summary", {"fiscal_year": "2021-2022"}),
+	("Production Analytics", {"range": "Monthly"}),
+	("Quality Inspection Summary", {}),
+	("Work Order Stock Report", {}),
+	("Work Order Summary", {"fiscal_year": "2021-2022", "age": 0}),
+]
+
+
+if frappe.db.a_row_exists("Production Plan"):
+	REPORT_FILTER_TEST_CASES.append(
+		("Production Plan Summary", {"production_plan": frappe.get_last_doc("Production Plan").name})
+	)
+
+OPTIONAL_FILTERS = {
+	"warehouse": "_Test Warehouse - _TC",
+	"item": "_Test Item",
+	"item_group": "_Test Item Group",
+}
+
+
+class TestManufacturingReports(unittest.TestCase):
+	def test_execute_all_manufacturing_reports(self):
+		"""Test that all script report in manufacturing modules are executable with supported filters"""
+		for report, filter in REPORT_FILTER_TEST_CASES:
+			execute_script_report(
+				report_name=report,
+				module="Manufacturing",
+				filters=filter,
+				default_filters=DEFAULT_FILTERS,
+				optional_filters=OPTIONAL_FILTERS if filter.get("_optional") else None,
+			)

--- a/erpnext/stock/report/process_loss_report/process_loss_report.py
+++ b/erpnext/stock/report/process_loss_report/process_loss_report.py
@@ -111,7 +111,7 @@ def run_query(query_args: QueryArgs) -> Data:
 			{work_order_filter}
 		GROUP BY
 			se.work_order
-	""".format(**query_args), query_args, as_dict=1, debug=1)
+	""".format(**query_args), query_args, as_dict=1)
 
 def update_data_with_total_pl_value(data: Data) -> None:
 	for row in data:

--- a/erpnext/stock/report/test_reports.py
+++ b/erpnext/stock/report/test_reports.py
@@ -40,6 +40,7 @@ REPORT_FILTER_TEST_CASES: List[Tuple[ReportName, ReportFilters]] = [
 	("Item Variant Details", {"item": "_Test Variant Item",}),
 	("Total Stock Summary", {"group_by": "warehouse",}),
 	("Batch Item Expiry Status", {}),
+	("Process Loss Report", {}),
 	("Stock Ageing", {"range1": 30, "range2": 60, "range3": 90, "_optional": True}),
 ]
 


### PR DESCRIPTION
This field doesn't exist and it's moved on individual line-level logs.

closes https://github.com/frappe/erpnext/issues/28027 