### PR TITLE
fix: consolidated report issue

### DIFF
--- a/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py
+++ b/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py
@@ -115,7 +115,7 @@ def prepare_companywise_opening_balance(asset_data, liability_data, equity_data,
 		# opening_value = Aseet - liability - equity
 		for data in [asset_data, liability_data, equity_data]:
 			account_name = get_root_account_name(data[0].root_type, company)
-			opening_value += get_opening_balance(account_name, data, company)
+			opening_value += (get_opening_balance(account_name, data, company) or 0.0)
 
 		opening_balance[company] = opening_value
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/app.py", line 66, in application
    response = frappe.api.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/api.py", line 54, in handle
    return frappe.handler.handle()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 31, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/handler.py", line 67, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 1205, in call
    return fn(*args, **newargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 621, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 233, in run
    result = generate_report_result(report, filters, user, custom_columns)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/desk/query_report.py", line 75, in generate_report_result
    res = report.execute_script_report(filters)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/report/report.py", line 122, in execute_script_report
    res = self.execute_module(filters)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/core/doctype/report/report.py", line 139, in execute_module
    return frappe.get_attr(method_name)(frappe._dict(filters))
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py", line 50, in execute
    data, message, chart, report_summary = get_balance_sheet_data(fiscal_year, companies, columns, filters)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py", line 78, in get_balance_sheet_data
    message, opening_balance = prepare_companywise_opening_balance(asset, liability, equity, companies)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py", line 118, in prepare_companywise_opening_balance
    opening_value += get_opening_balance(account_name, data, company)
TypeError: unsupported operand type(s) for +=: 'int' and 'NoneType'
```