### PR TITLE
chore: change log for v13.13.0

### DIFF
--- a/erpnext/change_log/v13/v13_13_0.md
+++ b/erpnext/change_log/v13/v13_13_0.md
@@ -1,0 +1,29 @@
+# Version 13.13.0 Release Notes
+
+### Features & Enhancements
+
+- HR Module onboarding ([#25741](https://github.com/frappe/erpnext/pull/25741))
+- Tracking multiple rounds for the interview ([#25482](https://github.com/frappe/erpnext/pull/25482))
+- HSN based tax breakup table check in GST Settings (India Localization) ([#27907](https://github.com/frappe/erpnext/pull/27907))
+
+### Fixes
+
+- To improve stock transactions added indexes in stock queries and speed up bin updation ([#27758](https://github.com/frappe/erpnext/pull/27758))
+- Interstate internal transfer invoices not visible in GSTR-1 ([#27970](https://github.com/frappe/erpnext/pull/27970))
+- Account number and name incorrectly imported using COA importer ([#27967](https://github.com/frappe/erpnext/pull/27967))
+- Multiple fixes to timesheets ([#27775](https://github.com/frappe/erpnext/pull/27742))
+- Totals row incorrect value in GL Entry ([#27867](https://github.com/frappe/erpnext/pull/27867))
+- Sales Order delivery Date not getting set via data import ([#27862](https://github.com/frappe/erpnext/pull/27862))
+- Add cost center in gl entry for advance payment entry ([#27840](https://github.com/frappe/erpnext/pull/27840))
+- Item Variant selection empty popup on website ([#27924](https://github.com/frappe/erpnext/pull/27924))
+- Improve performance of fetching account balance in chart of accounts ([#27661](https://github.com/frappe/erpnext/pull/27661))
+- Chart Of Accounts import button not visible ([#27748](https://github.com/frappe/erpnext/pull/27748))
+- Website Items with same Item name unhandled, thumbnails missing ([#27720](https://github.com/frappe/erpnext/pull/27720))
+- Delete linked Transaction Deletion Record docs on deleting company ([#27785](https://github.com/frappe/erpnext/pull/27785))
+- Display appropriate message for Payment Term discrepancies in Payment Entry ([#27749](https://github.com/frappe/erpnext/pull/27749))
+- Updated buying onboarding tours. ([#27800](https://github.com/frappe/erpnext/pull/27800))
+- Fixed variant qty in BOM while making work order ([#27686](https://github.com/frappe/erpnext/pull/27686))
+- Availability slots display, disabled Practitioner Schedule ([#27812](https://github.com/frappe/erpnext/pull/27812))
+- Consolidated report not consider company currency ([#27863](https://github.com/frappe/erpnext/pull/27863))
+- Batch Number not copied from Purchase Receipt to Stock Entry ([#27794](https://github.com/frappe/erpnext/pull/27794))
+- Employee Leave Balance report should only consider ledgers of transaction type Leave Allocation ([#27728](https://github.com/frappe/erpnext/pull/27728))


### PR DESCRIPTION
# Version 13.13.0 Release Notes

### Features & Enhancements

- HR Module onboarding ([#25741](https://github.com/frappe/erpnext/pull/25741))
- Tracking multiple rounds for the interview ([#25482](https://github.com/frappe/erpnext/pull/25482))
- HSN based tax breakup table check in GST Settings (India Localization) ([#27907](https://github.com/frappe/erpnext/pull/27907))

### Fixes

- To improve stock transactions added indexes in stock queries and speed up bin updation ([#27758](https://github.com/frappe/erpnext/pull/27758))
- Interstate internal transfer invoices not visible in GSTR-1 ([#27970](https://github.com/frappe/erpnext/pull/27970))
- Account number and name incorrectly imported using COA importer ([#27967](https://github.com/frappe/erpnext/pull/27967))
- Multiple fixes to timesheets ([#27775](https://github.com/frappe/erpnext/pull/27742))
- Totals row incorrect value in GL Entry ([#27867](https://github.com/frappe/erpnext/pull/27867))
- Sales Order delivery Date not getting set via data import ([#27862](https://github.com/frappe/erpnext/pull/27862))
- Add cost center in gl entry for advance payment entry ([#27840](https://github.com/frappe/erpnext/pull/27840))
- Item Variant selection empty popup on website ([#27924](https://github.com/frappe/erpnext/pull/27924))
- Improve performance of fetching account balance in chart of accounts ([#27661](https://github.com/frappe/erpnext/pull/27661))
- Chart Of Accounts import button not visible ([#27748](https://github.com/frappe/erpnext/pull/27748))
- Website Items with same Item name unhandled, thumbnails missing ([#27720](https://github.com/frappe/erpnext/pull/27720))
- Delete linked Transaction Deletion Record docs on deleting company ([#27785](https://github.com/frappe/erpnext/pull/27785))
- Display appropriate message for Payment Term discrepancies in Payment Entry ([#27749](https://github.com/frappe/erpnext/pull/27749))
- Updated buying onboarding tours. ([#27800](https://github.com/frappe/erpnext/pull/27800))
- Fixed variant qty in BOM while making work order ([#27686](https://github.com/frappe/erpnext/pull/27686))
- Availability slots display, disabled Practitioner Schedule ([#27812](https://github.com/frappe/erpnext/pull/27812))
- Consolidated report not consider company currency ([#27863](https://github.com/frappe/erpnext/pull/27863))
- Batch Number not copied from Purchase Receipt to Stock Entry ([#27794](https://github.com/frappe/erpnext/pull/27794))
- Employee Leave Balance report should only consider ledgers of transaction type Leave Allocation ([#27728](https://github.com/frappe/erpnext/pull/27728))
