### PR TITLE
fix: POS Closing Entry without linked invoices

### DIFF
--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
@@ -180,8 +180,7 @@
    "fieldname": "pos_transactions",
    "fieldtype": "Table",
    "label": "POS Transactions",
-   "options": "POS Invoice Reference",
-   "reqd": 1
+   "options": "POS Invoice Reference"
   },
   {
    "fieldname": "pos_opening_entry",
@@ -229,7 +228,7 @@
    "link_fieldname": "pos_closing_entry"
   }
  ],
- "modified": "2021-05-05 16:59:49.723261",
+ "modified": "2021-10-20 16:19:25.340565",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Closing Entry",

--- a/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
@@ -246,7 +246,10 @@ def get_invoice_customer_map(pos_invoices):
 	return pos_invoice_customer_map
 
 def consolidate_pos_invoices(pos_invoices=None, closing_entry=None):
-	invoices = pos_invoices or (closing_entry and closing_entry.get('pos_transactions')) or get_all_unconsolidated_invoices()
+	invoices = pos_invoices or (closing_entry and closing_entry.get('pos_transactions'))
+	if frappe.flags.in_test and not invoices:
+		invoices = get_all_unconsolidated_invoices()
+
 	invoice_by_customer = get_invoice_customer_map(invoices)
 
 	if len(invoices) >= 10 and closing_entry:


### PR DESCRIPTION
**Problem:**
Creating a POS Closing Entry without any invoices was not allowed earlier
<img src='https://user-images.githubusercontent.com/36098155/138134524-5fd955b1-790d-4fb4-b115-255c4296d1b3.gif' width='700'>


**Solution:**
Now it is allowed.
<img src='https://user-images.githubusercontent.com/36098155/138135048-1b9d22be-4616-46f5-8c21-50e2899c4289.gif' width='700'>

**Steps:**
1. Create an opening entry through POS or manually
2. Create a closing entry against the same
3. Submit and see if it allows you to do so

