### PR TITLE
fix(minor): Filters and validations in Tax Withholding Category

### DIFF
--- a/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.js
+++ b/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.js
@@ -8,7 +8,8 @@ frappe.ui.form.on('Tax Withholding Category', {
 			if (child.company) {
 				return {
 					filters: {
-						'company': child.company
+						'company': child.company,
+						'root_type': ['in', ['Asset', 'Liability']]
 					}
 				};
 			}

--- a/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
+++ b/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
@@ -13,6 +13,7 @@ from frappe.utils import cint, getdate
 class TaxWithholdingCategory(Document):
 	def validate(self):
 		self.validate_dates()
+		self.validate_accounts()
 		self.validate_thresholds()
 
 	def validate_dates(self):
@@ -24,6 +25,14 @@ class TaxWithholdingCategory(Document):
 			# validate overlapping of dates
 			if last_date and getdate(d.to_date) < getdate(last_date):
 				frappe.throw(_("Row #{0}: Dates overlapping with other row").format(d.idx))
+
+	def validate_accounts(self):
+		existing_accounts = []
+		for d in self.get('accounts'):
+			if d.get('account') in existing_accounts:
+				frappe.throw(_("Account {0} added multiple times").format(frappe.bold(d.get('account'))))
+
+			existing_accounts.append(d.get('account'))
 
 	def validate_thresholds(self):
 		for d in self.get('rates'):


### PR DESCRIPTION
Duplicate accounts were allowed to be added in Tax Withholding Category, added validation for that

![image](https://user-images.githubusercontent.com/42651287/138909922-0d7cfee6-fd89-4f78-afde-b74c04e201f2.png)
