### PR TITLE
fix: don't reset rates in Timesheet Detail when Activity Type is cleared

### DIFF
--- a/erpnext/projects/doctype/timesheet/timesheet.js
+++ b/erpnext/projects/doctype/timesheet/timesheet.js
@@ -283,22 +283,24 @@ frappe.ui.form.on("Timesheet Detail", {
 		calculate_time_and_amount(frm);
 	},
 
-	activity_type: function(frm, cdt, cdn) {
-		frappe.call({
-			method: "erpnext.projects.doctype.timesheet.timesheet.get_activity_cost",
-			args: {
-				employee: frm.doc.employee,
-				activity_type: frm.selected_doc.activity_type,
-				currency: frm.doc.currency
-			},
-			callback: function(r){
-				if(r.message){
-					frappe.model.set_value(cdt, cdn, 'billing_rate', r.message['billing_rate']);
-					frappe.model.set_value(cdt, cdn, 'costing_rate', r.message['costing_rate']);
-					calculate_billing_costing_amount(frm, cdt, cdn);
+	activity_type: function (frm, cdt, cdn) {
+		if (locals[cdt][cdn].activity_type) {
+			frappe.call({
+				method: "erpnext.projects.doctype.timesheet.timesheet.get_activity_cost",
+				args: {
+					employee: frm.doc.employee,
+					activity_type: frm.selected_doc.activity_type,
+					currency: frm.doc.currency
+				},
+				callback: function (r){
+					if(r.message){
+						frappe.model.set_value(cdt, cdn, "billing_rate", r.message["billing_rate"]);
+						frappe.model.set_value(cdt, cdn, "costing_rate", r.message["costing_rate"]);
+						calculate_billing_costing_amount(frm, cdt, cdn);
+					}
 				}
-			}
-		});
+			});
+		}
 	}
 });
 

--- a/erpnext/projects/doctype/timesheet/timesheet.js
+++ b/erpnext/projects/doctype/timesheet/timesheet.js
@@ -293,7 +293,7 @@ frappe.ui.form.on("Timesheet Detail", {
 				activity_type: frm.selected_doc.activity_type,
 				currency: frm.doc.currency
 			},
-			callback: function (r){
+			callback: function (r) {
 				if (r.message) {
 					frappe.model.set_value(cdt, cdn, "billing_rate", r.message["billing_rate"]);
 					frappe.model.set_value(cdt, cdn, "costing_rate", r.message["costing_rate"]);

--- a/erpnext/projects/doctype/timesheet/timesheet.js
+++ b/erpnext/projects/doctype/timesheet/timesheet.js
@@ -285,22 +285,22 @@ frappe.ui.form.on("Timesheet Detail", {
 
 	activity_type: function (frm, cdt, cdn) {
 		if (!frappe.get_doc(cdt, cdn).activity_type) return;
-			frappe.call({
-				method: "erpnext.projects.doctype.timesheet.timesheet.get_activity_cost",
-				args: {
-					employee: frm.doc.employee,
-					activity_type: frm.selected_doc.activity_type,
-					currency: frm.doc.currency
-				},
-				callback: function (r){
-					if(r.message){
-						frappe.model.set_value(cdt, cdn, "billing_rate", r.message["billing_rate"]);
-						frappe.model.set_value(cdt, cdn, "costing_rate", r.message["costing_rate"]);
-						calculate_billing_costing_amount(frm, cdt, cdn);
-					}
+
+		frappe.call({
+			method: "erpnext.projects.doctype.timesheet.timesheet.get_activity_cost",
+			args: {
+				employee: frm.doc.employee,
+				activity_type: frm.selected_doc.activity_type,
+				currency: frm.doc.currency
+			},
+			callback: function (r){
+				if(r.message){
+					frappe.model.set_value(cdt, cdn, "billing_rate", r.message["billing_rate"]);
+					frappe.model.set_value(cdt, cdn, "costing_rate", r.message["costing_rate"]);
+					calculate_billing_costing_amount(frm, cdt, cdn);
 				}
-			});
-		}
+			}
+		});
 	}
 });
 

--- a/erpnext/projects/doctype/timesheet/timesheet.js
+++ b/erpnext/projects/doctype/timesheet/timesheet.js
@@ -294,7 +294,7 @@ frappe.ui.form.on("Timesheet Detail", {
 				currency: frm.doc.currency
 			},
 			callback: function (r){
-				if(r.message){
+				if (r.message) {
 					frappe.model.set_value(cdt, cdn, "billing_rate", r.message["billing_rate"]);
 					frappe.model.set_value(cdt, cdn, "costing_rate", r.message["costing_rate"]);
 					calculate_billing_costing_amount(frm, cdt, cdn);

--- a/erpnext/projects/doctype/timesheet/timesheet.js
+++ b/erpnext/projects/doctype/timesheet/timesheet.js
@@ -284,7 +284,7 @@ frappe.ui.form.on("Timesheet Detail", {
 	},
 
 	activity_type: function (frm, cdt, cdn) {
-		if (locals[cdt][cdn].activity_type) {
+		if (!frappe.get_doc(cdt, cdn).activity_type) return;
 			frappe.call({
 				method: "erpnext.projects.doctype.timesheet.timesheet.get_activity_cost",
 				args: {


### PR DESCRIPTION
**Current:** Assume a Timesheet Detail with correct billing and costing rate exists. If you now clear the Activity Type, the system will nevertheless try to fetch the Activity Cost, which doesn't exist, and reset the billing and costing rate to 0.00.

**New:** With this PR, the Activity Cost will only be fetched if any Activity Type is selected. This way we can avoid the useless overwrite of correct data.