### PR TITLE
fix: remove VM from installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,6 @@ The Easy Way: our install script for bench will install all dependencies (e.g. M
 
 New passwords will be created for the ERPNext "Administrator" user, the MariaDB root user, and the frappe user (the script displays the passwords and saves them to ~/frappe_passwords.txt).
 
-### Virtual Image
-
-You can download a virtual image to run ERPNext in a virtual machine on your local system.
-
-- [ERPNext Download](http://erpnext.com/download)
-
-System and user credentials are listed on the download page.
-
 ---
 
 ## License


### PR DESCRIPTION
Remove the reference to VM installation and images since the same has not been maintained in a long time:

![image](https://user-images.githubusercontent.com/33246109/138593507-d4f04980-cd8f-4e0c-b7a4-ed855455d2e9.png)
