### PR TITLE
fix: Payment Terms validation precision

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1354,8 +1354,8 @@ class AccountsController(TransactionBase):
 			total = 0
 			base_total = 0
 			for d in self.get("payment_schedule"):
-				total += flt(d.payment_amount)
-				base_total += flt(d.base_payment_amount)
+				total += flt(d.payment_amount, d.precision("payment_amount"))
+				base_total += flt(d.base_payment_amount, d.precision("base_payment_amount"))
 
 			base_grand_total = self.get("base_rounded_total") or self.base_grand_total
 			grand_total = self.get("rounded_total") or self.grand_total
@@ -1371,8 +1371,9 @@ class AccountsController(TransactionBase):
 				else:
 					grand_total -= self.get("total_advance")
 					base_grand_total = flt(grand_total * self.get("conversion_rate"), self.precision("base_grand_total"))
-			if total != flt(grand_total, self.precision("grand_total")) or \
-				base_total != flt(base_grand_total, self.precision("base_grand_total")):
+
+			if flt(total, self.precision("grand_total")) != flt(grand_total, self.precision("grand_total")) or \
+				flt(base_total, self.precision("base_grand_total")) != flt(base_grand_total, self.precision("base_grand_total")):
 				frappe.throw(_("Total Payment Amount in Payment Schedule must be equal to Grand / Rounded Total"))
 
 	def is_rounded_total_disabled(self):


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/42651287/139008957-061426d5-e07d-4035-94c5-7d413f7daacf.png)

Due to precision issues while validating payment terms user used to get the above error on saving a document

An example where this issue used to happen is as follows

1. Make a sales Invoice with net total amount of 232177.80 with no taxes and enable rounding
![image](https://user-images.githubusercontent.com/42651287/139009467-94b4dff0-5146-4826-b53c-a12fffc70553.png)

2. Add a payment terms template as follows with the following terms
![image](https://user-images.githubusercontent.com/42651287/139009597-fd81c499-5bbf-4913-b1a0-d9974a66dad5.png)

Try saving the order

