### PR TITLE
fix(ux): misleading label for image fields

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.json
+++ b/erpnext/manufacturing/doctype/bom/bom.json
@@ -436,7 +436,7 @@
    "description": "Item Image (if not slideshow)",
    "fieldname": "website_image",
    "fieldtype": "Attach Image",
-   "label": "Image"
+   "label": "Website Image"
   },
   {
    "allow_on_submit": 1,
@@ -539,7 +539,7 @@
  "image_field": "image",
  "is_submittable": 1,
  "links": [],
- "modified": "2021-05-16 12:25:09.081968",
+ "modified": "2021-10-27 14:52:04.500251",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "BOM",


### PR DESCRIPTION
BOM doctype has two image fields with the same label "Image". This is confusing in some context. 


<img width="387" alt="Screenshot 2021-10-27 at 2 55 16 PM" src="https://user-images.githubusercontent.com/9079960/139038498-e5e502be-b195-4df5-8e71-09ecae76bd51.png">

