### PR TITLE
fix: Autoemail report not showing dynamic report filters

### DIFF
--- a/erpnext/public/js/financial_statements.js
+++ b/erpnext/public/js/financial_statements.js
@@ -113,15 +113,15 @@ function get_filters() {
 			"fieldname":"period_start_date",
 			"label": __("Start Date"),
 			"fieldtype": "Date",
-			"hidden": 1,
-			"reqd": 1
+			"reqd": 1,
+			"depends_on": "eval:doc.filter_based_on == 'Date Range'"
 		},
 		{
 			"fieldname":"period_end_date",
 			"label": __("End Date"),
 			"fieldtype": "Date",
-			"hidden": 1,
-			"reqd": 1
+			"reqd": 1,
+			"depends_on": "eval:doc.filter_based_on == 'Date Range'"
 		},
 		{
 			"fieldname":"from_fiscal_year",
@@ -129,7 +129,8 @@ function get_filters() {
 			"fieldtype": "Link",
 			"options": "Fiscal Year",
 			"default": frappe.defaults.get_user_default("fiscal_year"),
-			"reqd": 1
+			"reqd": 1,
+			"depends_on": "eval:doc.filter_based_on == 'Fiscal Year'"
 		},
 		{
 			"fieldname":"to_fiscal_year",
@@ -137,7 +138,8 @@ function get_filters() {
 			"fieldtype": "Link",
 			"options": "Fiscal Year",
 			"default": frappe.defaults.get_user_default("fiscal_year"),
-			"reqd": 1
+			"reqd": 1,
+			"depends_on": "eval:doc.filter_based_on == 'Fiscal Year'"
 		},
 		{
 			"fieldname": "periodicity",


### PR DESCRIPTION
Financial reports have dynamic date filters which toggle base on the value selected in `Filter Based On` filter.
If the value is this filter is `Fiscal Year` than From and To Fiscal year filters show up else if value is `Date Range` than From Date and To Date filters show.

This was not working in auto email report filters. Added `depends_on` condition and remove hidden property to resolve this

<img width="1311" alt="Screenshot 2021-10-27 at 7 38 5 PM" src="https://user-images.githubusercontent.com/42651287/139084921-596832a9-847d-4a91-9f54-f2ae3ede2f17.png">
