### PR TITLE
fix: Consolidated Financial Report throws error for empty equity data list

### DIFF
--- a/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py
+++ b/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py
@@ -114,8 +114,9 @@ def prepare_companywise_opening_balance(asset_data, liability_data, equity_data,
 
 		# opening_value = Aseet - liability - equity
 		for data in [asset_data, liability_data, equity_data]:
-			account_name = get_root_account_name(data[0].root_type, company)
-			opening_value += (get_opening_balance(account_name, data, company) or 0.0)
+			if data:
+				account_name = get_root_account_name(data[0].root_type, company)
+				opening_value += (get_opening_balance(account_name, data, company) or 0.0)
 
 		opening_balance[company] = opening_value
 


### PR DESCRIPTION
**Problem:**
Consolidated Financial Report throws index out of range error, on my instance it was because the `equity_data` list was empty and that caused an issue in `prepare_companywise_opening_balance` method where it directly fetched for the first elements of asset_data, liability_data, equity_data

<img src='https://user-images.githubusercontent.com/36098155/139211436-16e49f01-8d83-47b1-ab0f-9fd246ea4cc4.png' width='700' >

**Solution:**
If the list is empty, skip it in the `prepare_companywise_opening_balance`
