### PR TITLE
refactor: item-warehouse based reposting

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -17,7 +17,7 @@ from erpnext.accounts.general_ledger import (
 from erpnext.accounts.utils import get_fiscal_year
 from erpnext.controllers.accounts_controller import AccountsController
 from erpnext.stock import get_warehouse_account_map
-from erpnext.stock.stock_ledger import get_valuation_rate
+from erpnext.stock.stock_ledger import get_items_to_be_repost, get_valuation_rate
 
 
 class QualityInspectionRequiredError(frappe.ValidationError): pass
@@ -684,12 +684,8 @@ def create_repost_item_valuation_entry(args):
 def create_item_wise_repost_entries(voucher_type, voucher_no, allow_zero_rate=False):
 	"""Using a voucher create repost item valuation records for all item-warehouse pairs."""
 
-	stock_ledger_entries = frappe.db.get_all("Stock Ledger Entry",
-		filters={"voucher_type": voucher_type, "voucher_no": voucher_no},
-		fields=["item_code", "warehouse", "posting_date", "posting_time", "creation", "company"],
-		order_by="creation asc",
-		group_by="item_code, warehouse"
-	)
+	stock_ledger_entries = get_items_to_be_repost(voucher_type, voucher_no)
+
 	distinct_item_warehouses = set()
 	repost_entries = []
 

--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -711,6 +711,7 @@ def create_item_wise_repost_entries(voucher_type, voucher_no, allow_zero_rate=Fa
 		repost_entry.posting_time = sle.posting_time
 		repost_entry.allow_zero_rate = allow_zero_rate
 		repost_entry.flags.ignore_links = True
+		repost_entry.flags.ignore_permissions = True
 		repost_entry.submit()
 		repost_entries.append(repost_entry)
 

--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -691,7 +691,6 @@ def create_item_wise_repost_entries(voucher_type, voucher_no, allow_zero_rate=Fa
 		group_by="item_code, warehouse"
 	)
 	distinct_item_warehouses = set()
-
 	repost_entries = []
 
 	for sle in stock_ledger_entries:

--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -544,7 +544,12 @@ class StockController(AccountsController):
 			"company": self.company
 		})
 		if future_sle_exists(args):
-			create_item_wise_repost_entries(voucher_type=self.doctype, voucher_no=self.name)
+			item_based_reposting =  cint(frappe.db.get_single_value("Stock Reposting Settings", "item_based_reposting"))
+			if item_based_reposting:
+				create_item_wise_repost_entries(voucher_type=self.doctype, voucher_no=self.name)
+			else:
+				create_repost_item_valuation_entry(args)
+
 
 @frappe.whitelist()
 def make_quality_inspections(doctype, docname, items):

--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -544,7 +544,7 @@ class StockController(AccountsController):
 			"company": self.company
 		})
 		if future_sle_exists(args):
-			create_repost_item_valuation_entry(args)
+			create_item_wise_repost_entries(voucher_type=self.doctype, voucher_no=self.name)
 
 @frappe.whitelist()
 def make_quality_inspections(doctype, docname, items):
@@ -679,3 +679,39 @@ def create_repost_item_valuation_entry(args):
 	repost_entry.flags.ignore_permissions = True
 	repost_entry.save()
 	repost_entry.submit()
+
+
+def create_item_wise_repost_entries(voucher_type, voucher_no, allow_zero_rate=False):
+	"""Using a voucher create repost item valuation records for all item-warehouse pairs."""
+
+	stock_ledger_entries = frappe.db.get_all("Stock Ledger Entry",
+		filters={"voucher_type": voucher_type, "voucher_no": voucher_no},
+		fields=["item_code", "warehouse", "posting_date", "posting_time", "creation", "company"],
+		order_by="creation asc",
+		group_by="item_code, warehouse"
+	)
+	distinct_item_warehouses = set()
+
+	repost_entries = []
+
+	for sle in stock_ledger_entries:
+		item_wh = (sle.item_code, sle.warehouse)
+		if item_wh in distinct_item_warehouses:
+			continue
+		distinct_item_warehouses.add(item_wh)
+
+		repost_entry = frappe.new_doc("Repost Item Valuation")
+		repost_entry.based_on = "Item and Warehouse"
+		repost_entry.voucher_type = voucher_type
+		repost_entry.voucher_no = voucher_no
+
+		repost_entry.item_code = sle.item_code
+		repost_entry.warehouse = sle.warehouse
+		repost_entry.posting_date = sle.posting_date
+		repost_entry.posting_time = sle.posting_time
+		repost_entry.allow_zero_rate = allow_zero_rate
+		repost_entry.flags.ignore_links = True
+		repost_entry.submit()
+		repost_entries.append(repost_entry)
+
+	return repost_entries

--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
@@ -64,7 +64,7 @@
    "in_standard_filter": 1,
    "label": "Status",
    "no_copy": 1,
-   "options": "Queued\nIn Progress\nCompleted\nFailed",
+   "options": "Queued\nIn Progress\nCompleted\nSkipped\nFailed",
    "read_only": 1
   },
   {

--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
@@ -177,7 +177,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2021-11-18 02:18:10.524560",
+ "modified": "2021-11-24 02:18:10.524560",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Repost Item Valuation",

--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
@@ -59,7 +59,7 @@ class RepostItemValuation(Document):
 
 	def on_submit(self):
 		self.deduplicate_similar_repost()
-		if not frappe.flags.in_test:
+		if not frappe.flags.in_test or self.flags.dont_run_in_test:
 			return
 
 		frappe.enqueue(repost, timeout=1800, queue='long',

--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
@@ -58,6 +58,11 @@ class RepostItemValuation(Document):
 		frappe.enqueue(repost, timeout=1800, queue='long',
 			job_name='repost_sle', now=True, doc=self)
 
+
+def on_doctype_update():
+	frappe.db.add_index("Repost Item Valuation", ["warehouse", "item_code"], "item_warehouse")
+
+
 def repost(doc):
 	try:
 		if not frappe.db.exists("Repost Item Valuation", doc.name):

--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
@@ -27,15 +27,12 @@ class RepostItemValuation(Document):
 		if self.based_on == 'Transaction':
 			self.item_code = None
 			self.warehouse = None
-		else:
-			self.voucher_type = None
-			self.voucher_no = None
 
 		self.allow_negative_stock = self.allow_negative_stock or \
 				cint(frappe.db.get_single_value("Stock Settings", "allow_negative_stock"))
 
 	def set_company(self):
-		if self.voucher_type and self.voucher_no:
+		if self.based_on == "Transaction":
 			self.company = frappe.get_cached_value(self.voucher_type, self.voucher_no, "company")
 		elif self.warehouse:
 			self.company = frappe.get_cached_value("Warehouse", self.warehouse, "company")

--- a/erpnext/stock/doctype/repost_item_valuation/test_repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/test_repost_item_valuation.py
@@ -74,8 +74,11 @@ class TestRepostItemValuation(unittest.TestCase):
 			)
 
 	def test_create_item_wise_repost_item_valuation_entries(self):
-		pr = make_purchase_receipt(company="_Test Company with perpetual inventory",
-			warehouse = "Stores - TCP1", get_multiple_items = True)
+		pr = make_purchase_receipt(
+			company="_Test Company with perpetual inventory",
+			warehouse="Stores - TCP1",
+			get_multiple_items=True,
+		)
 
 		rivs = create_item_wise_repost_entries(pr.doctype, pr.name)
 		self.assertGreaterEqual(len(rivs), 2)
@@ -84,3 +87,51 @@ class TestRepostItemValuation(unittest.TestCase):
 		for riv in rivs:
 			self.assertEqual(riv.company, "_Test Company with perpetual inventory")
 			self.assertEqual(riv.warehouse, "Stores - TCP1")
+
+	def test_deduplication(self):
+		def _assert_status(doc, status):
+			doc.load_from_db()
+			self.assertEqual(doc.status, status)
+
+		riv_args = frappe._dict(
+			doctype="Repost Item Valuation",
+			item_code="_Test Item",
+			warehouse="_Test Warehouse - _TC",
+			based_on="Item and Warehouse",
+			voucher_type="Sales Invoice",
+			voucher_no="SI-1",
+			posting_date="2021-01-02",
+			posting_time="00:01:00",
+		)
+
+		# new repost without any duplicates
+		riv1 = frappe.get_doc(riv_args)
+		riv1.flags.dont_run_in_test = True
+		riv1.submit()
+		_assert_status(riv1, "Queued")
+		self.assertEqual(riv1.voucher_type, "Sales Invoice")  # traceability
+		self.assertEqual(riv1.voucher_no, "SI-1")
+
+		# newer than existing duplicate - riv1
+		riv2 = frappe.get_doc(riv_args.update({"posting_date": "2021-01-03"}))
+		riv2.flags.dont_run_in_test = True
+		riv2.submit()
+		_assert_status(riv2, "Skipped")
+
+		# older than exisitng duplicate - riv1
+		riv3 = frappe.get_doc(riv_args.update({"posting_date": "2021-01-01"}))
+		riv3.flags.dont_run_in_test = True
+		riv3.submit()
+		_assert_status(riv3, "Queued")
+		_assert_status(riv1, "Skipped")
+
+		# unrelated reposts, shouldn't do anything to others.
+		riv4 = frappe.get_doc(riv_args.update({"warehouse": "Stores - _TC"}))
+		riv4.flags.dont_run_in_test = True
+		riv4.submit()
+		_assert_status(riv4, "Queued")
+		_assert_status(riv3, "Queued")
+
+		# to avoid breaking other tests accidentaly
+		riv4.set_status("Skipped")
+		riv3.set_status("Skipped")

--- a/erpnext/stock/doctype/repost_item_valuation/test_repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/test_repost_item_valuation.py
@@ -116,12 +116,14 @@ class TestRepostItemValuation(unittest.TestCase):
 		riv2 = frappe.get_doc(riv_args.update({"posting_date": "2021-01-03"}))
 		riv2.flags.dont_run_in_test = True
 		riv2.submit()
+		riv1.deduplicate_similar_repost()
 		_assert_status(riv2, "Skipped")
 
 		# older than exisitng duplicate - riv1
 		riv3 = frappe.get_doc(riv_args.update({"posting_date": "2021-01-01"}))
 		riv3.flags.dont_run_in_test = True
 		riv3.submit()
+		riv3.deduplicate_similar_repost()
 		_assert_status(riv3, "Queued")
 		_assert_status(riv1, "Skipped")
 
@@ -129,6 +131,7 @@ class TestRepostItemValuation(unittest.TestCase):
 		riv4 = frappe.get_doc(riv_args.update({"warehouse": "Stores - _TC"}))
 		riv4.flags.dont_run_in_test = True
 		riv4.submit()
+		riv4.deduplicate_similar_repost()
 		_assert_status(riv4, "Queued")
 		_assert_status(riv3, "Queued")
 

--- a/erpnext/stock/doctype/repost_item_valuation/test_repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/test_repost_item_valuation.py
@@ -5,6 +5,8 @@ import unittest
 
 import frappe
 
+from erpnext.controllers.stock_controller import create_item_wise_repost_entries
+from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import make_purchase_receipt
 from erpnext.stock.doctype.repost_item_valuation.repost_item_valuation import (
 	in_configured_timeslot,
 )
@@ -70,3 +72,15 @@ class TestRepostItemValuation(unittest.TestCase):
 				in_configured_timeslot(repost_settings, case.get("current_time")),
 				msg=f"Exepcted false from : {case}",
 			)
+
+	def test_create_item_wise_repost_item_valuation_entries(self):
+		pr = make_purchase_receipt(company="_Test Company with perpetual inventory",
+			warehouse = "Stores - TCP1", get_multiple_items = True)
+
+		rivs = create_item_wise_repost_entries(pr.doctype, pr.name)
+		self.assertGreaterEqual(len(rivs), 2)
+		self.assertIn("_Test Item", [d.item_code for d in rivs])
+
+		for riv in rivs:
+			self.assertEqual(riv.company, "_Test Company with perpetual inventory")
+			self.assertEqual(riv.warehouse, "Stores - TCP1")

--- a/erpnext/stock/doctype/stock_reposting_settings/stock_reposting_settings.json
+++ b/erpnext/stock/doctype/stock_reposting_settings/stock_reposting_settings.json
@@ -1,6 +1,7 @@
 {
  "actions": [],
  "allow_rename": 1,
+ "beta": 1,
  "creation": "2021-10-01 10:56:30.814787",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -10,7 +11,8 @@
   "limit_reposting_timeslot",
   "start_time",
   "end_time",
-  "limits_dont_apply_on"
+  "limits_dont_apply_on",
+  "item_based_reposting"
  ],
  "fields": [
   {
@@ -44,12 +46,18 @@
    "fieldname": "limit_reposting_timeslot",
    "fieldtype": "Check",
    "label": "Limit timeslot for Stock Reposting"
+  },
+  {
+   "default": "0",
+   "fieldname": "item_based_reposting",
+   "fieldtype": "Check",
+   "label": "Use Item based reposting"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2021-10-01 11:27:28.981594",
+ "modified": "2021-11-02 01:22:45.155841",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Reposting Settings",


### PR DESCRIPTION
Motivations: 

1) When you're doing a series of backdated transactions, each transaction causes reposting and some of it is duplicate work.

Example backdated transactions:

| Transaction | Posting Time | Submission Time |
| --- | --- | --- |
| A | 0 | 5 |
| B | 1 | 6 |
| C | 2 | 7 |
| D | 3 | 8 |
| E | 4 | 9 |


Assuming all operating on the same set of items (or some shared items)

A causes reposting of A, B, C, D, E.
B causes reposting of B, C, D, E
C causes reposting of C, D and E, and so on... Ideally, the system should just figure out that reposting A is all that's required. 

2) During the last few months me, @rohitwaghchaure and @marination have experimented many times and found that item-warehouse based reposting on big sites is orders of magnitude faster. There are a few gotchas related to perf but those can be addressed separately. 

---




Changes:
- [x] Allow creating item-warehouse based reposting records instead of voucher-based.
- [x] Make this configurable via repost settings (will be dropped in future, this is internal API, hence not a breaking change.)
- [x] Enforce uniqueness of item-wh-queued state. New status "Skipped" added on Repost Item Valuation for reposts that are skipped because of this.
- [x] Multifield index on item-warehouse for speeding up deduplication query. 
- [x] Tests
    - [X] creation of item-wh reposts
    - [x] deduplication

--- 

WIP: Deferred to a separate PR


- [ ] batch GL reposting for a voucher. 
- [ ] Handle dependent SLE concept (FG, repack)





<details>
  <summary>Should I enable this?</summary>

No, if you don't understand how Stock Reposting works in ERPNext then avoid using any of this. These changes will become the default in the coming months anyway. 

</details>


<details>
  <summary></summary>
'tsa zoke
<details>
  <summary></summary>
<img src="https://user-images.githubusercontent.com/9079960/139850998-c99048cd-72b0-4e69-939b-8886725ec61b.png">
</details>
</details>


#### How to test:

1. go to stock reposting settings and enable "item based reposting"
2. Pick 2-3 items, create stock transactions for each of them (in/out etc)
3. Create 2-3 backdated transaction for each item-warehoue combination. 
4. Check "Repost Item Valuation". There should be a repost item valuation record for each combination of Item and warehouse in backdated transactions. 

##### Testing deduplication: 
1. Create a repost item valuation manually for an item-warehouse. 
2. Create another repost item valuation with same values but with future posting time.
3. go to "scheduled job" and trigger "repost_entries" scheduled job manually. 
4. check repost item valuations again, the one with newer posting date should be "Skipped". 
 