### PR TITLE
fix: Make status filter in Fixed Asset Register optional

### DIFF
--- a/erpnext/assets/report/fixed_asset_register/fixed_asset_register.js
+++ b/erpnext/assets/report/fixed_asset_register/fixed_asset_register.js
@@ -16,9 +16,8 @@ frappe.query_reports["Fixed Asset Register"] = {
 			fieldname:"status",
 			label: __("Status"),
 			fieldtype: "Select",
-			options: "In Location\nDisposed",
-			default: 'In Location',
-			reqd: 1
+			options: "\nIn Location\nDisposed",
+			default: 'In Location'
 		},
 		{
 			"fieldname":"filter_based_on",

--- a/erpnext/assets/report/fixed_asset_register/fixed_asset_register.py
+++ b/erpnext/assets/report/fixed_asset_register/fixed_asset_register.py
@@ -45,12 +45,13 @@ def get_conditions(filters):
 	if filters.get('cost_center'):
 		conditions["cost_center"] = filters.get('cost_center')
 
-	# In Store assets are those that are not sold or scrapped
-	operand = 'not in'
-	if status not in 'In Location':
-		operand = 'in'
+	if status:
+		# In Store assets are those that are not sold or scrapped
+		operand = 'not in'
+		if status not in 'In Location':
+			operand = 'in'
 
-	conditions['status'] = (operand, ['Sold', 'Scrapped'])
+		conditions['status'] = (operand, ['Sold', 'Scrapped'])
 
 	return conditions
 


### PR DESCRIPTION
_Problem:_

Users only have the option of selecting Assets that are In Location or those that have been Disposed, not both at once.

_Fix:_

Make the Status filter optional and add an empty option, which when picked, selects both Assets that are in Location and those that have been Disposed.

![Screenshot 2021-10-28 at 4 22 16 AM](https://user-images.githubusercontent.com/25903035/139158707-f21cac72-2774-49b2-bd55-3c6207a19dbe.png)
