### PR TITLE
fix: Make relationship between Is Existing Asset and Purchase Details clearer

### DIFF
--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -150,6 +150,8 @@ frappe.ui.form.on('Asset', {
 		else if (frm.doc.is_existing_asset) {
 			frm.toggle_reqd('purchase_receipt', 0);
 			frm.toggle_reqd('purchase_invoice', 0);
+			frm.toggle_display('purchase_receipt', 0);
+ 			frm.toggle_display('purchase_invoice', 0);
 		}
 		else if (frm.doc.purchase_receipt) {
 			// if purchase receipt link is set then set PI disabled
@@ -164,8 +166,10 @@ frappe.ui.form.on('Asset', {
 		else {
 			frm.toggle_reqd('purchase_receipt', 1);
 			frm.set_df_property('purchase_receipt', 'read_only', 0);
+			frm.toggle_display('purchase_receipt', 1);
 			frm.toggle_reqd('purchase_invoice', 1);
 			frm.set_df_property('purchase_invoice', 'read_only', 0);
+			frm.toggle_display('purchase_invoice', 1);
 		}
 	},
 

--- a/erpnext/assets/doctype/asset/asset.json
+++ b/erpnext/assets/doctype/asset/asset.json
@@ -233,6 +233,7 @@
   },
   {
    "default": "0",
+   "description": "If unchecked, Purchase Receipt/Invoice needs to be entered in the Purchase Details section",
    "fieldname": "is_existing_asset",
    "fieldtype": "Check",
    "label": "Is Existing Asset"
@@ -502,10 +503,11 @@
    "link_fieldname": "asset"
   }
  ],
- "modified": "2021-06-24 14:58:51.097908",
+ "modified": "2021-10-28 18:58:37.276357",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset",
+ "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
  "permissions": [
   {


### PR DESCRIPTION
_Problem:_

The Purchase Invoice and Purchase Receipt fields are mandatory for Assets, unless Is Existing Asset is checked. However, this isn't evident to the users at all, unless they've read the docs.

_Fix:_

- Add description for Is Existing Asset.

   ![Screenshot 2021-10-28 at 3 39 50 AM](https://user-images.githubusercontent.com/25903035/139154563-73dc58a9-eea2-4b11-9628-5369ccf7caee.png)

- Hide PR and PI fields if Is Existing Asset is checked.

<details>
<summary>Before</summary>

When unchecked:

![Screenshot 2021-10-28 at 3 43 20 AM](https://user-images.githubusercontent.com/25903035/139154945-fd78d7e7-8137-49e7-8d9f-75007f68c40a.png)

When checked:

![Screenshot 2021-10-28 at 3 44 11 AM](https://user-images.githubusercontent.com/25903035/139154975-502f65b7-9e4c-4500-a260-67d2e4dc7676.png)

</details>

<details>
<summary>After</summary>

When unchecked:

![Screenshot 2021-10-28 at 3 38 45 AM](https://user-images.githubusercontent.com/25903035/139154444-6a24b54f-0575-45b8-a17a-136ce60a8c27.png)

When checked:

![Screenshot 2021-10-28 at 3 39 06 AM](https://user-images.githubusercontent.com/25903035/139154490-88da1b7d-a303-482f-99b6-2077ef80b918.png)

</details>