### PR TITLE
fix: Accounting Dimension filters not honouring user permissions

### DIFF
--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -566,7 +566,7 @@ def get_filtered_dimensions(doctype, txt, searchfield, start, page_len, filters)
 
 		query_filters.append(['name', query_selector, dimensions])
 
-	output = frappe.get_all(doctype, filters=query_filters)
+	output = frappe.get_list(doctype, filters=query_filters)
 	result = [d.name for d in output]
 
 	return [(d,) for d in set(result)]


### PR DESCRIPTION
Accounting Dimensions uses a custom query for filtering the records in fields
`get_all` was used to get the records that don't considers user permissions
Replace `get_all` ORM method with `get_list` which also considers user permission 
