### PR TITLE
fix: Skip empty rows while updating unsaved BOM cost

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -307,6 +307,9 @@ class BOM(WebsiteGenerator):
 		existing_bom_cost = self.total_cost
 
 		for d in self.get("items"):
+			if not d.item_code:
+				continue
+
 			rate = self.get_rm_rate({
 				"company": self.company,
 				"item_code": d.item_code,
@@ -599,7 +602,7 @@ class BOM(WebsiteGenerator):
 		for d in self.get('items'):
 			if d.bom_no:
 				self.get_child_exploded_items(d.bom_no, d.stock_qty)
-			else:
+			elif d.item_code:
 				self.add_to_cur_exploded_items(frappe._dict({
 					'item_code'		: d.item_code,
 					'item_name'		: d.item_name,


### PR DESCRIPTION
**Issue:**
```py
    File ".../apps/erpnext/erpnext/manufacturing/doctype/bom/bom.py", line 267, in update_cost
      self.update_exploded_items()
    File ".../apps/erpnext/erpnext/manufacturing/doctype/bom/bom.py", line 540, in update_exploded_items
      self.add_exploded_items()
    File ".../apps/erpnext/erpnext/manufacturing/doctype/bom/bom.py", line 611, in add_exploded_items
      for d in sorted(self.cur_exploded_items, key=itemgetter(0)):
TypeError: 'NoneType' object is not subscriptable
```
- This happens when empty rows are added to an unsaved BOM, and the user changes the UOM in any row.
- `update_cost` is triggered which tries to add exploded items and get rates for all rows
- Rows without item codes or empty rows cause this error

**Fix:**
- Skip fetching exploded items or valuation rate if row is empty