### PR TITLE
fix: Dont consider 0 as min qty while setting avg transferred qty from Job Card in Work Order

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -484,7 +484,8 @@ class JobCard(Document):
 						'docstatus': ('!=', 2)}, fields = 'sum(transferred_qty) as qty', group_by='operation_id')
 
 					if job_cards:
-						qty = min(d.qty for d in job_cards)
+						transferred_qtys = [d.qty for d in job_cards if d.qty > 0]
+						qty = min(transferred_qtys) if transferred_qtys else 0
 
 			doc.db_set('material_transferred_for_manufacturing', qty)
 


### PR DESCRIPTION
**Issue:**
- Consider Work Order having Material Transfer against set as Job Card
- Against the Job cards, some job cards have 0 qty transferred against them , some have 1, some have 2
- While back updating the Work Order's **Material Transferred for Manufacturing**, we sum all the Job cards qtys (grouped by operation id) and find the minimum qty
- So assume :
  Operation A has Job cards with transfer quantities: [1,3]. **Total= 4**
  Operation B has Job cards with transfer quantities: [0,0]. **Total= 0**
  Operation C has Job cards with transfer quantities: [1,0]. **Total= 1**
- The minimum here is 0. But realistically it should be 1, since some qty has been transferred. We just want the smallest qty that was transferred.

**Fix:**
- Considered only totals > 0. In this case 1 and 4. Take min from these and set in Work Order.
- If no totals are > 0, then default to 0, because nothing was truly transferred.