### PR TITLE
fix: replace newline in remarks (DATEV report)

### DIFF
--- a/erpnext/regional/report/datev/datev.py
+++ b/erpnext/regional/report/datev/datev.py
@@ -351,7 +351,7 @@ def run_query(filters, extra_fields, extra_joins, extra_filters, as_dict=1):
 
 			gl.posting_date as 'Belegdatum',
 			gl.voucher_no as 'Belegfeld 1',
-			LEFT(gl.remarks, 60) as 'Buchungstext',
+			REPLACE(LEFT(gl.remarks, 60), '\n', ' ') as 'Buchungstext',
 			gl.voucher_type as 'Beleginfo - Art 1',
 			gl.voucher_no as 'Beleginfo - Inhalt 1',
 			gl.against_voucher_type as 'Beleginfo - Art 2',


### PR DESCRIPTION
Remarks can contain newline ("\n"). This causes problems when exported to CSV.

Therefore we replace "\n" with " ".