### PR TITLE
fix: update tax template name for 18% GST

### DIFF
--- a/erpnext/setup/setup_wizard/data/country_wise_tax.json
+++ b/erpnext/setup/setup_wizard/data/country_wise_tax.json
@@ -1195,7 +1195,7 @@
 			"*": {
 				"item_tax_templates": [
 					{
-						"title": "GST 9%",
+						"title": "GST 18%",
 						"taxes": [
 							{
 								"tax_type": {


### PR DESCRIPTION
In the default item tax templates, when setting up for India, a template is created for 5%, 9%, 12%, and 28%. There is no 9% GST but 18%

![image](https://user-images.githubusercontent.com/33246109/139524751-437edfe4-d4d5-4046-b61a-4228009c6b89.png)

no-docs