### PR TITLE
chore: change log for v12.26.0

### DIFF
--- a/erpnext/change_log/v12/v12_26_0.md
+++ b/erpnext/change_log/v12/v12_26_0.md
@@ -1,0 +1,8 @@
+## Version 12.26.0 Release Notes
+
+### Fixes & Enhancements
+- Make Gross Profit Report more readable ([#27124](https://github.com/frappe/erpnext/pull/27124))
+- Set item uom as stock_uom if it isn't set ([#27623](https://github.com/frappe/erpnext/pull/27623))
+- Adding empty row on new maintenance visit ([#27626](https://github.com/frappe/erpnext/pull/27626))
+- Employee Leave Balance report should only consider ledgers of transaction type Leave Allocation ([#28017](https://github.com/frappe/erpnext/pull/28017))
+- Validate if item exists on uploading items in stock reco ([#27538](https://github.com/frappe/erpnext/pull/27538))


### PR DESCRIPTION
## Version 12.26.0 Release Notes

### Fixes & Enhancements
- Make Gross Profit Report more readable ([#27124](https://github.com/frappe/erpnext/pull/27124))
- Set item uom as stock_uom if it isn't set ([#27623](https://github.com/frappe/erpnext/pull/27623))
- Adding empty row on new maintenance visit ([#27626](https://github.com/frappe/erpnext/pull/27626))
- Employee Leave Balance report should only consider ledgers of transaction type Leave Allocation ([#28017](https://github.com/frappe/erpnext/pull/28017))
- Validate if item exists on uploading items in stock reco ([#27538](https://github.com/frappe/erpnext/pull/27538))