### PR TITLE
fix(ux): stock levels take time after item merge

### DIFF
--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -676,6 +676,8 @@ class Item(WebsiteGenerator):
 	def after_rename(self, old_name, new_name, merge):
 		if merge:
 			self.validate_duplicate_item_in_stock_reconciliation(old_name, new_name)
+			frappe.msgprint(_("It can take upto few hours for accurate stock values to be visible after merging items."),
+					indicator="orange", title="Note")
 
 		if self.route:
 			invalidate_cache_for_item(self)


### PR DESCRIPTION
Item merge creates a repost and it can take from 1 to n hours for it to finish. (depending upon queued up reposts)

Added message so users don't feel confused till this operation is finished.