### PR TITLE
fix: better validation for Integration Request

### DIFF
--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -550,10 +550,14 @@ def make_payment_order(source_name, target_doc=None):
 
 	return doclist
 
-def validate_payment(doc, method=""):
-	if not frappe.db.has_column(doc.reference_doctype, 'status'):
+def validate_payment(doc, method=None):
+	if doc.reference_doctype != "Payment Request" or (
+		frappe.db.get_value(doc.reference_doctype, doc.reference_docname, 'status')
+		!= "Paid"
+	):
 		return
 
-	status = frappe.db.get_value(doc.reference_doctype, doc.reference_docname, 'status')
-	if status == 'Paid':
-		frappe.throw(_("The Payment Request {0} is already paid, cannot process payment twice").format(doc.reference_docname))
+	frappe.throw(
+		_("The Payment Request {0} is already paid, cannot process payment twice")
+		.format(doc.reference_docname)
+	)


### PR DESCRIPTION
This code used to earlier interfere with Integration Requests linked to other DocTypes, like Sales Invoice. Changed it so that it checks for the **Payment Request** DocType instead of the `status` column.