### PR TITLE
fix: do not generate multiple invoices

### DIFF
--- a/erpnext/accounts/doctype/subscription/subscription.py
+++ b/erpnext/accounts/doctype/subscription/subscription.py
@@ -502,9 +502,11 @@ class Subscription(Document):
 		# Check invoice dates and make sure it doesn't have outstanding invoices
 		return getdate() >= getdate(self.current_invoice_start)
 
-	def is_current_invoice_generated(self):
+	def is_current_invoice_generated(self, _current_start_date=None, _current_end_date=None):
 		invoice = self.get_current_invoice()
-		_current_start_date, _current_end_date = self.update_subscription_period(date=add_days(self.current_invoice_end, 1), return_date=True)
+
+		if not (_current_start_date and _current_end_date):
+			_current_start_date, _current_end_date = self.update_subscription_period(date=add_days(self.current_invoice_end, 1), return_date=True)
 
 		if invoice and getdate(_current_start_date) <= getdate(invoice.posting_date) <= getdate(_current_end_date):
 			return True
@@ -523,7 +525,9 @@ class Subscription(Document):
 		if getdate() > getdate(self.current_invoice_end) and self.is_prepaid_to_invoice():
 			self.update_subscription_period(add_days(self.current_invoice_end, 1))
 
-		if not self.is_current_invoice_generated() and (self.is_postpaid_to_invoice() or self.is_prepaid_to_invoice()):
+		if not self.is_current_invoice_generated(self.current_invoice_start, self.current_invoice_end) \
+			and (self.is_postpaid_to_invoice() or self.is_prepaid_to_invoice()):
+
 			prorate = frappe.db.get_single_value('Subscription Settings', 'prorate')
 			self.generate_invoice(prorate)
 
@@ -560,8 +564,10 @@ class Subscription(Document):
 				self.set_status_grace_period()
 
 			# Generate invoices periodically even if current invoice are unpaid
-			if self.generate_new_invoices_past_due_date and not self.is_current_invoice_generated() and (self.is_postpaid_to_invoice()
-				or self.is_prepaid_to_invoice()):
+			if self.generate_new_invoices_past_due_date and not \
+				self.is_current_invoice_generated(self.current_invoice_start, self.current_invoice_end) \
+				and (self.is_postpaid_to_invoice() or self.is_prepaid_to_invoice()):
+
 				prorate = frappe.db.get_single_value('Subscription Settings', 'prorate')
 				self.generate_invoice(prorate)
 


### PR DESCRIPTION
- fixes [#28179](https://github.com/frappe/erpnext/issues/28179)
- checks if the invoice date is between the current invoice period.
- the invoice date was always smaller than invoice period hence there were multiple invoices being created.
