### PR TITLE
fix: replaced "=" with "in" for multiple statuses in query

### DIFF
--- a/erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py
+++ b/erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py
@@ -41,9 +41,12 @@ def get_conditions(filters):
 	if filters.get("from_date") and filters.get("to_date"):
 		conditions += " and po.transaction_date between %(from_date)s and %(to_date)s"
 
-	for field in ['company', 'name', 'status']:
+	for field in ['company', 'name']:
 		if filters.get(field):
 			conditions += f" and po.{field} = %({field})s"
+
+	if filters.get('status'):
+		conditions += " and po.status in %(status)s"
 
 	if filters.get('project'):
 		conditions += " and poi.project = %(project)s"


### PR DESCRIPTION
### Issue
- When trying to select more than one status in the filters, it throws the below error.

![poa_bug](https://user-images.githubusercontent.com/43572428/139801258-b9d11f73-3125-48f0-bb59-01e0b24ee4e4.gif)

### Fix
- Replaced "=" with "in" when checking for status in query.
