### PR TITLE
fix: (ux) Remove warehouse filter on Batch field for Material Receipt

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -88,7 +88,9 @@ frappe.ui.form.on('Stock Entry', {
 					}
 				}
 
-				filters["warehouse"] = item.s_warehouse || item.t_warehouse;
+				if (frm.doc.purpose != "Material Receipt") {
+					filters["warehouse"] = item.s_warehouse || item.t_warehouse;
+				}
 
 				return {
 					query : "erpnext.controllers.queries.get_batch_no",

--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -88,6 +88,8 @@ frappe.ui.form.on('Stock Entry', {
 					}
 				}
 
+				// User could want to select a manually created empty batch (no warehouse)
+				// or a pre-existing batch
 				if (frm.doc.purpose != "Material Receipt") {
 					filters["warehouse"] = item.s_warehouse || item.t_warehouse;
 				}


### PR DESCRIPTION
**Issue:**
- Consider a Batch that is manually created, and has no warehouse against it and is empty
- Create a Stock Entry (Material Receipt), add a target warehouse, add a row for the batched item. Try to add manually created batch in Batch No field
- You cannot, since there is a warehouse filter.
![photo_2021-11-02 15 52 45](https://user-images.githubusercontent.com/25857446/139829277-81458339-e5d4-4b82-ac66-12d51e98dd84.jpeg)

**Fix:**
- **Only for Material Receipt**, avoid adding warehouse filter
- User should be able to select a **new empty batch** or a **pre-existing batch** (for adjustment and return purposes) in this Receipt
  <img width="477" alt="Screenshot 2021-11-02 at 3 54 51 PM" src="https://user-images.githubusercontent.com/25857446/139829513-60fd4de7-619a-4a08-a07c-d55db360a019.png">
