### PR TITLE
fix: Serial Nos not set in the row after scanning in popup

### DIFF
--- a/erpnext/selling/sales_common.js
+++ b/erpnext/selling/sales_common.js
@@ -206,8 +206,10 @@ erpnext.selling.SellingController = class SellingController extends erpnext.Tran
 		var me = this;
 		var item = frappe.get_doc(cdt, cdn);
 
-		if (item.serial_no && item.qty === item.serial_no.split(`\n`).length) {
-			return;
+		// check if serial nos entered are as much as qty in row
+		if (item.serial_no) {
+			let serial_nos = item.serial_no.split(`\n`).filter(sn => sn.trim()); // filter out whitespaces
+			if (item.qty === serial_nos.length) return;
 		}
 
 		if (item.serial_no && !item.batch_no) {


### PR DESCRIPTION
**Issue:**
- In Delivery Note/Sales Invoice with update stock, etc. don't add warehouse (parent field)
- Add a serialised item code. Popup appears
- Add serial nos simulating a scanner. At the end press enter (go to next line), then click insert
- Serial nos are not set in the Item row
-  The issue actually occurs on warehouse trigger. 
- In this case since warehouse is not set in the row beforehand, warehouse is set from the popup after clicking on **Insert**
-   In this trigger if the length of the serial nos in the popup text box != the qty, it clears the serial nos field
- **Umm why was the length not equal?** Remember this => `At the end press enter (go to next line` ? The culprit.
- This causes `serial_nos = ['123', '456', '']`. Ideally the length here is 2, but the extra string makes the length 3. Hence not equal to length, hence empty field
  ![2021-11-02 20 06 55](https://user-images.githubusercontent.com/25857446/139868476-6e57aa94-b6d5-495f-be0a-521909c5decf.gif)

**Fix:**
- Filter out empty strings and whitespaces to get the exact length of serial nos
- **This issue happens even if extra line is added in serial no text box (not in popup) and warehouse is changed**, so handled it at warehouse trigger.
  ![2021-11-02 20 05 13](https://user-images.githubusercontent.com/25857446/139868163-20ea4a1b-4117-4836-9876-ed66fe5af730.gif)
