### PR TITLE
fix: added job_card_item link in material request

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -605,7 +605,8 @@ def make_material_request(source_name, target_doc=None):
 			"doctype": "Material Request Item",
 			"field_map": {
 				"required_qty": "qty",
-				"uom": "stock_uom"
+				"uom": "stock_uom",
+				"name": "job_card_item"
 			},
 			"postprocess": update_item,
 		}

--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -502,7 +502,8 @@ def make_stock_entry(source_name, target_doc=None):
 			"field_map": {
 				"name": "material_request_item",
 				"parent": "material_request",
-				"uom": "stock_uom"
+				"uom": "stock_uom",
+				"job_card_item": "job_card_item"
 			},
 			"postprocess": update_item,
 			"condition": lambda doc: doc.ordered_qty < doc.stock_qty

--- a/erpnext/stock/doctype/material_request_item/material_request_item.json
+++ b/erpnext/stock/doctype/material_request_item/material_request_item.json
@@ -450,6 +450,8 @@
    "fieldname": "job_card_item",
    "fieldtype": "Data",
    "hidden": 1,
+   "no_copy": 1,
+   "print_hide": 1,
    "label": "Job Card Item"
   }
  ],

--- a/erpnext/stock/doctype/material_request_item/material_request_item.json
+++ b/erpnext/stock/doctype/material_request_item/material_request_item.json
@@ -52,6 +52,7 @@
   "sales_order_item",
   "production_plan",
   "material_request_plan_item",
+  "job_card_item",
   "col_break4",
   "expense_account",
   "section_break_46",
@@ -444,16 +445,23 @@
   {
    "fieldname": "qty_info_col_break",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "job_card_item",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Job Card Item"
   }
  ],
  "idx": 1,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-10-02 11:44:36.553064",
+ "modified": "2021-11-03 14:40:24.409826",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Material Request Item",
+ "naming_rule": "Random",
  "owner": "Administrator",
  "permissions": [],
  "sort_field": "modified",


### PR DESCRIPTION
### Issue

- When trying to create a **Material Transfer** using the workflow Job Card > Material Request > Material Transfer, the  
**"Transferred Qty"** is not updated in the Job Card Item.
- Material Request does not have any field that can store the **Job Card Item** reference. Hence when creating the **Material Transfer** via **Material Request** the reference is empty.

![job_card_item_before](https://user-images.githubusercontent.com/43572428/140038253-aae593d4-dd58-4b75-a9e9-a943f922044d.gif)

### Changes
- Added a Job Card Item reference in Material Request Item too.
- Updated mapping for Job Card > Material Request & Material Request > Material Transfer.

![job_card_item_after](https://user-images.githubusercontent.com/43572428/140039609-428d5143-48b3-408e-a607-5ceaab2d8c8a.gif)


