### PR TITLE
fix: incorrect job card status

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -502,13 +502,11 @@ class JobCard(Document):
 			self.status = 'Work In Progress'
 
 		if (self.docstatus == 1 and
-			(self.for_quantity <= self.transferred_qty or not self.items)):
-			# consider excess transfer
-			# completed qty is checked via separate validation
+			(self.for_quantity <= self.total_completed_qty or not self.items)):
 			self.status = 'Completed'
 
 		if self.status != 'Completed':
-			if self.for_quantity == self.transferred_qty:
+			if self.for_quantity <= self.transferred_qty:
 				self.status = 'Material Transferred'
 
 		if update_status:

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -303,6 +303,7 @@ erpnext.patches.v13_0.set_status_in_maintenance_schedule_table
 erpnext.patches.v13_0.add_default_interview_notification_templates
 erpnext.patches.v13_0.enable_scheduler_job_for_item_reposting
 erpnext.patches.v13_0.requeue_failed_reposts
+erpnext.patches.v13_0.update_job_card_status
 erpnext.patches.v12_0.update_production_plan_status
 erpnext.patches.v13_0.healthcare_deprecation_warning
 erpnext.patches.v14_0.delete_healthcare_doctypes

--- a/erpnext/patches/v13_0/update_job_card_status.py
+++ b/erpnext/patches/v13_0/update_job_card_status.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2021, Frappe and Contributors
+# License: GNU General Public License v3. See license.txt
+
+import frappe
+
+
+def execute():
+
+	job_card = frappe.qb.DocType("Job Card")
+	(frappe.qb
+		.update(job_card)
+		.set(job_card.status, "Completed")
+		.where(
+			(job_card.docstatus == 1)
+			& (job_card.for_quantity <= job_card.total_completed_qty)
+			& (job_card.status.isin(["Work In Progress", "Material Transferred"]))
+		)
+	).run()

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -1450,7 +1450,7 @@ class StockEntry(StockController):
 				item_dict[item]["qty"] = 0
 
 		# delete items with 0 qty
-		list_of_items = item_dict.keys()
+		list_of_items = list(item_dict.keys())
 		for item in list_of_items:
 			if not item_dict[item]["qty"]:
 				del item_dict[item]


### PR DESCRIPTION
- Fix incorrect job card status. use completed quantity instead of transfer qty for 'Completed' status
- unrelated fix: possible runtime error when modifying dict and its `keys()` iterators together. 