### PR TITLE
fix: auto update price list rate

### DIFF
--- a/erpnext/stock/doctype/stock_settings/stock_settings.json
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.json
@@ -294,6 +294,7 @@
   },
   {
    "default": "0",
+   "depends_on": "auto_insert_price_list_rate_if_missing",
    "fieldname": "update_existing_price_list_rate",
    "fieldtype": "Check",
    "label": "Update Existing Price List Rate"

--- a/erpnext/stock/doctype/stock_settings/stock_settings.json
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.json
@@ -21,6 +21,7 @@
   "mr_qty_allowance",
   "column_break_12",
   "auto_insert_price_list_rate_if_missing",
+  "update_existing_price_list_rate",
   "allow_negative_stock",
   "show_barcode_field",
   "clean_description_html",
@@ -290,6 +291,12 @@
    "fieldname": "mr_qty_allowance",
    "fieldtype": "Float",
    "label": "Over Transfer Allowance"
+  },
+  {
+   "default": "0",
+   "fieldname": "update_existing_price_list_rate",
+   "fieldtype": "Check",
+   "label": "Update Existing Price List Rate"
   }
  ],
  "icon": "icon-cog",
@@ -297,7 +304,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2021-06-28 17:02:26.683002",
+ "modified": "2021-11-06 19:40:02.183592",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Settings",

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -708,7 +708,7 @@ def insert_item_price(args):
 				{'item_code': args.item_code, 'price_list': args.price_list, 'currency': args.currency},
 				['name', 'price_list_rate'], as_dict=1)
 			if item_price and item_price.name:
-				if item_price.price_list_rate != price_list_rate:
+				if item_price.price_list_rate != price_list_rate and frappe.db.get_single_value('Stock Settings', 'update_existing_price_list_rate'):
 					frappe.db.set_value('Item Price', item_price.name, "price_list_rate", price_list_rate)
 					frappe.msgprint(_("Item Price updated for {0} in Price List {1}").format(args.item_code,
 						args.price_list), alert=True)


### PR DESCRIPTION
Add new check field "update_existing_price_list_rate" in "Stock Settings" DocType. Now the rate is only being updated if this field is checked.