### PR TITLE
fix: Taxjar customer_address fix, currency fix

### DIFF
--- a/erpnext/erpnext_integrations/doctype/taxjar_settings/taxjar_settings.js
+++ b/erpnext/erpnext_integrations/doctype/taxjar_settings/taxjar_settings.js
@@ -7,6 +7,23 @@ frappe.ui.form.on('TaxJar Settings', {
 		frm.toggle_reqd("sandbox_api_key", frm.doc.is_sandbox);
 	},
 
+	on_load: (frm) => {
+		frm.set_query('shipping_account_head', function() {
+			return {
+				filters: {
+					'company': frm.doc.current_company
+				}
+			};
+		});
+		frm.set_query('tax_account_head', function() {
+			return {
+				filters: {
+					'company': frm.doc.current_company
+				}
+			};
+		});
+	},
+
 	refresh: (frm) => {
 		frm.add_custom_button(__('Update Nexus List'), function() {
 			frm.call({

--- a/erpnext/erpnext_integrations/doctype/taxjar_settings/taxjar_settings.js
+++ b/erpnext/erpnext_integrations/doctype/taxjar_settings/taxjar_settings.js
@@ -11,14 +11,14 @@ frappe.ui.form.on('TaxJar Settings', {
 		frm.set_query('shipping_account_head', function() {
 			return {
 				filters: {
-					'company': frm.doc.current_company
+					'company': frm.doc.company
 				}
 			};
 		});
 		frm.set_query('tax_account_head', function() {
 			return {
 				filters: {
-					'company': frm.doc.current_company
+					'company': frm.doc.company
 				}
 			};
 		});

--- a/erpnext/erpnext_integrations/doctype/taxjar_settings/taxjar_settings.json
+++ b/erpnext/erpnext_integrations/doctype/taxjar_settings/taxjar_settings.json
@@ -14,6 +14,8 @@
   "cb_keys",
   "sandbox_api_key",
   "configuration",
+  "current_company",
+  "column_break_10",
   "tax_account_head",
   "configuration_cb",
   "shipping_account_head",
@@ -68,10 +70,6 @@
    "label": "Sandbox API Key"
   },
   {
-   "fieldname": "configuration_cb",
-   "fieldtype": "Column Break"
-  },
-  {
    "default": "0",
    "depends_on": "taxjar_calculate_tax",
    "fieldname": "taxjar_create_transactions",
@@ -104,11 +102,25 @@
    "label": "Nexus",
    "options": "TaxJar Nexus",
    "read_only": 1
+  },
+  {
+   "fieldname": "current_company",
+   "fieldtype": "Link",
+   "label": "Company",
+   "options": "Company"
+  },
+  {
+   "fieldname": "configuration_cb",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_10",
+   "fieldtype": "Column Break"
   }
  ],
  "issingle": 1,
  "links": [],
- "modified": "2021-10-06 10:59:13.475442",
+ "modified": "2021-11-08 14:40:15.684224",
  "modified_by": "Administrator",
  "module": "ERPNext Integrations",
  "name": "TaxJar Settings",

--- a/erpnext/erpnext_integrations/doctype/taxjar_settings/taxjar_settings.json
+++ b/erpnext/erpnext_integrations/doctype/taxjar_settings/taxjar_settings.json
@@ -14,7 +14,6 @@
   "cb_keys",
   "sandbox_api_key",
   "configuration",
-  "current_company",
   "column_break_10",
   "tax_account_head",
   "configuration_cb",
@@ -104,12 +103,6 @@
    "read_only": 1
   },
   {
-   "fieldname": "current_company",
-   "fieldtype": "Link",
-   "label": "Company",
-   "options": "Company"
-  },
-  {
    "fieldname": "configuration_cb",
    "fieldtype": "Column Break"
   },
@@ -120,7 +113,7 @@
  ],
  "issingle": 1,
  "links": [],
- "modified": "2021-11-08 14:40:15.684224",
+ "modified": "2021-11-08 17:57:17.323275",
  "modified_by": "Administrator",
  "module": "ERPNext Integrations",
  "name": "TaxJar Settings",

--- a/erpnext/erpnext_integrations/doctype/taxjar_settings/taxjar_settings.json
+++ b/erpnext/erpnext_integrations/doctype/taxjar_settings/taxjar_settings.json
@@ -14,6 +14,7 @@
   "cb_keys",
   "sandbox_api_key",
   "configuration",
+  "company",
   "column_break_10",
   "tax_account_head",
   "configuration_cb",
@@ -109,11 +110,17 @@
   {
    "fieldname": "column_break_10",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "company",
+   "fieldtype": "Link",
+   "label": "Company",
+   "options": "Company"
   }
  ],
  "issingle": 1,
  "links": [],
- "modified": "2021-11-08 17:57:17.323275",
+ "modified": "2021-11-08 18:02:29.232090",
  "modified_by": "Administrator",
  "module": "ERPNext Integrations",
  "name": "TaxJar Settings",

--- a/erpnext/erpnext_integrations/doctype/taxjar_settings/taxjar_settings.py
+++ b/erpnext/erpnext_integrations/doctype/taxjar_settings/taxjar_settings.py
@@ -82,9 +82,9 @@ def make_custom_fields(update=True):
 			dict(fieldname='product_tax_category', fieldtype='Link', insert_after='description', options='Product Tax Category',
 				label='Product Tax Category', fetch_from='item_code.product_tax_category'),
 			dict(fieldname='tax_collectable', fieldtype='Currency', insert_after='net_amount',
-				label='Tax Collectable', read_only=1),
+				label='Tax Collectable', read_only=1, options='currency'),
 			dict(fieldname='taxable_amount', fieldtype='Currency', insert_after='tax_collectable',
-				label='Taxable Amount', read_only=1)
+				label='Taxable Amount', read_only=1, options='currency')
 		],
 		'Item': [
 			dict(fieldname='product_tax_category', fieldtype='Link', insert_after='item_group', options='Product Tax Category',

--- a/erpnext/erpnext_integrations/taxjar_integration.py
+++ b/erpnext/erpnext_integrations/taxjar_integration.py
@@ -262,7 +262,7 @@ def get_shipping_address_details(doc):
 	if doc.shipping_address_name:
 		shipping_address = frappe.get_doc("Address", doc.shipping_address_name)
 	elif doc.customer_address:
-		shipping_address = frappe.get_doc("Address", doc.customer_address_name)
+		shipping_address = frappe.get_doc("Address", doc.customer_address)
 	else:
 		shipping_address = get_company_address_details(doc)
 

--- a/erpnext/erpnext_integrations/taxjar_integration.py
+++ b/erpnext/erpnext_integrations/taxjar_integration.py
@@ -6,7 +6,7 @@ from frappe import _
 from frappe.contacts.doctype.address.address import get_company_address
 from frappe.utils import cint, flt
 
-from erpnext import get_default_company
+from erpnext import get_default_company, get_region
 
 TAX_ACCOUNT_HEAD = frappe.db.get_single_value("TaxJar Settings", "tax_account_head")
 SHIP_ACCOUNT_HEAD = frappe.db.get_single_value("TaxJar Settings", "shipping_account_head")
@@ -19,7 +19,6 @@ SUPPORTED_STATE_CODES = ['AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT', 'DE', 'DC', '
 	'IN', 'IA', 'KS', 'KY', 'LA', 'ME', 'MD', 'MA', 'MI', 'MN', 'MS', 'MO', 'MT', 'NE',
 	'NV', 'NH', 'NJ', 'NM', 'NY', 'NC', 'ND', 'OH', 'OK', 'OR', 'PA', 'RI', 'SC', 'SD',
 	'TN', 'TX', 'UT', 'VT', 'VA', 'WA', 'WV', 'WI', 'WY']
-USA_COMPANIES = frappe.get_all('Company', filters = {'country': 'United States'}, fields=['name'], pluck='name')
 
 
 
@@ -160,8 +159,7 @@ def set_sales_tax(doc, method):
 	if not TAXJAR_CALCULATE_TAX:
 		return
 
-	taxjar_settings_company = frappe.db.get_single_value('TaxJar Settings','current_company')
-	if taxjar_settings_company not in USA_COMPANIES:
+	if get_region(doc.company):
 		return
 
 	if not doc.items:

--- a/erpnext/erpnext_integrations/taxjar_integration.py
+++ b/erpnext/erpnext_integrations/taxjar_integration.py
@@ -159,7 +159,7 @@ def set_sales_tax(doc, method):
 	if not TAXJAR_CALCULATE_TAX:
 		return
 
-	if get_region(doc.company):
+	if get_region(doc.company) != 'United States':
 		return
 
 	if not doc.items:

--- a/erpnext/erpnext_integrations/taxjar_integration.py
+++ b/erpnext/erpnext_integrations/taxjar_integration.py
@@ -19,6 +19,8 @@ SUPPORTED_STATE_CODES = ['AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT', 'DE', 'DC', '
 	'IN', 'IA', 'KS', 'KY', 'LA', 'ME', 'MD', 'MA', 'MI', 'MN', 'MS', 'MO', 'MT', 'NE',
 	'NV', 'NH', 'NJ', 'NM', 'NY', 'NC', 'ND', 'OH', 'OK', 'OR', 'PA', 'RI', 'SC', 'SD',
 	'TN', 'TX', 'UT', 'VT', 'VA', 'WA', 'WV', 'WI', 'WY']
+USA_COMPANIES = frappe.get_all('Company', filters = {'country': 'United States'}, fields=['name'], pluck='name')
+
 
 
 def get_client():
@@ -156,6 +158,10 @@ def get_line_item_dict(item, docstatus):
 
 def set_sales_tax(doc, method):
 	if not TAXJAR_CALCULATE_TAX:
+		return
+
+	taxjar_settings_company = frappe.db.get_single_value('TaxJar Settings','current_company')
+	if taxjar_settings_company not in USA_COMPANIES:
 		return
 
 	if not doc.items:

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -308,7 +308,7 @@ erpnext.patches.v13_0.migrate_stripe_api
 erpnext.patches.v13_0.reset_clearance_date_for_intracompany_payment_entries
 execute:frappe.reload_doc("erpnext_integrations", "doctype", "TaxJar Settings")
 execute:frappe.reload_doc("erpnext_integrations", "doctype", "Product Tax Category")
-erpnext.patches.v13_0.custom_fields_for_taxjar_integration
+erpnext.patches.v13_0.custom_fields_for_taxjar_integration          #08-11-2021
 erpnext.patches.v13_0.set_operation_time_based_on_operating_cost
 erpnext.patches.v13_0.validate_options_for_data_field
 erpnext.patches.v13_0.create_website_items #30-09-2021

--- a/erpnext/patches/v13_0/custom_fields_for_taxjar_integration.py
+++ b/erpnext/patches/v13_0/custom_fields_for_taxjar_integration.py
@@ -23,9 +23,9 @@ def execute():
 			dict(fieldname='product_tax_category', fieldtype='Link', insert_after='description', options='Product Tax Category',
 				label='Product Tax Category', fetch_from='item_code.product_tax_category'),
 			dict(fieldname='tax_collectable', fieldtype='Currency', insert_after='net_amount',
-				label='Tax Collectable', read_only=1),
+				label='Tax Collectable', read_only=1, options='currency'),
 			dict(fieldname='taxable_amount', fieldtype='Currency', insert_after='tax_collectable',
-				label='Taxable Amount', read_only=1)
+				label='Taxable Amount', read_only=1, options='currency')
 		],
 		'Item': [
 			dict(fieldname='product_tax_category', fieldtype='Link', insert_after='item_group', options='Product Tax Category',

--- a/erpnext/patches/v13_0/custom_fields_for_taxjar_integration.py
+++ b/erpnext/patches/v13_0/custom_fields_for_taxjar_integration.py
@@ -32,7 +32,7 @@ def execute():
 				label='Product Tax Category')
 		],
 		'TaxJar Settings': [
-			dict(fieldname='current_company', fieldtype='Link', insert_after='configuration', options='Company',
+			dict(fieldname='company', fieldtype='Link', insert_after='configuration', options='Company',
 				label='Company')
 		]
 	}

--- a/erpnext/patches/v13_0/custom_fields_for_taxjar_integration.py
+++ b/erpnext/patches/v13_0/custom_fields_for_taxjar_integration.py
@@ -30,6 +30,10 @@ def execute():
 		'Item': [
 			dict(fieldname='product_tax_category', fieldtype='Link', insert_after='item_group', options='Product Tax Category',
 				label='Product Tax Category')
+		],
+		'TaxJar Settings': [
+			dict(fieldname='current_company', fieldtype='Link', insert_after='configuration', options='Company',
+				label='Company')
 		]
 	}
 	create_custom_fields(custom_fields, update=True)


### PR DESCRIPTION
**Problems:**
- `customer_address_name` was wrong variable, corrected it to `customer_address`
- Sales invoice item table had fields showing wrong currency, added `currency` to 'options' of **Tax Collectable** and **Taxable Amount** fields
-  In case of multiple companies, make api call only if invoice is from US 