### PR TITLE
fix: filter only submitted fees in student fee collection report

### DIFF
--- a/erpnext/education/report/student_fee_collection/student_fee_collection.json
+++ b/erpnext/education/report/student_fee_collection/student_fee_collection.json
@@ -1,5 +1,5 @@
 {
- "add_total_row": 0,
+ "add_total_row": 1,
  "creation": "2016-06-22 02:58:41.024538",
  "disable_prepared_report": 0,
  "disabled": 0,

--- a/erpnext/education/report/student_fee_collection/student_fee_collection.json
+++ b/erpnext/education/report/student_fee_collection/student_fee_collection.json
@@ -13,7 +13,7 @@
  "name": "Student Fee Collection",
  "owner": "Administrator",
  "prepared_report": 0,
- "query": "SELECT\n student as \"Student:Link/Student:200\",\n student_name as \"Student Name::200\",\n sum(grand_total) - sum(outstanding_amount) as \"Paid Amount:Currency:150\",\n sum(outstanding_amount) as \"Outstanding Amount:Currency:150\",\n sum(grand_total) as \"Grand Total:Currency:150\"\nFROM\n `tabFees` \nGROUP BY\n student",
+ "query": "SELECT\n student as \"Student:Link/Student:200\",\n student_name as \"Student Name::200\",\n sum(grand_total) - sum(outstanding_amount) as \"Paid Amount:Currency:150\",\n sum(outstanding_amount) as \"Outstanding Amount:Currency:150\",\n sum(grand_total) as \"Grand Total:Currency:150\"\nFROM\n `tabFees` \nWHERE\n docstatus=1 \nGROUP BY\n student",
  "ref_doctype": "Fees",
  "report_name": "Student Fee Collection",
  "report_type": "Query Report",


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

I am suggesting this fix to solve an issue with cancelled Fees documents reflecting in the paid column of the Student Fee Collection report, I noticed this while making test entries in V13 i.e ERPNext: v13.13.0 (version-13), Adding the total row was useful to see the total amount of all the fees documents

> Explain the **details** for making this change. What existing problem does the pull request solve?

Made changes to the student_fee_collection.json

To filter out and show only submitted documents added in "query" _WHERE docstatus=1_
To Show the Total Row added _"add_total_row": 1,_

> Screenshots/GIFs

**Before Fix**

![before_fix](https://user-images.githubusercontent.com/17405044/140798185-4621c4d6-92a8-460b-a2ed-c7f66b14c03a.PNG)


**After Fix**

![after_fix](https://user-images.githubusercontent.com/17405044/140798162-45b70dd8-999d-4271-af8e-00326c6cc342.PNG)
