### PR TITLE
fix: show full item name in search widget

### DIFF
--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -210,12 +210,15 @@ def item_query(doctype, txt, searchfield, start, page_len, filters, as_dict=Fals
 	meta = frappe.get_meta("Item", cached=True)
 	searchfields = meta.get_search_fields()
 
-	if "description" in searchfields:
-		searchfields.remove("description")
+	# these are handled separately
+	ignored_search_fields = ("item_name", "description")
+	for ignored_field in ignored_search_fields:
+		if ignored_field in searchfields:
+			searchfields.remove(ignored_field)
 
 	columns = ''
 	extra_searchfields = [field for field in searchfields
-		if not field in ["name", "item_group", "description"]]
+		if not field in ["name", "item_group", "description", "item_name"]]
 
 	if extra_searchfields:
 		columns = ", " + ", ".join(extra_searchfields)
@@ -252,10 +255,8 @@ def item_query(doctype, txt, searchfield, start, page_len, filters, as_dict=Fals
 	if frappe.db.count('Item', cache=True) < 50000:
 		# scan description only if items are less than 50000
 		description_cond = 'or tabItem.description LIKE %(txt)s'
-	return frappe.db.sql("""select tabItem.name,
-		if(length(tabItem.item_name) > 40,
-			concat(substr(tabItem.item_name, 1, 40), "..."), item_name) as item_name,
-		tabItem.item_group,
+	return frappe.db.sql("""select
+			tabItem.name, tabItem.item_name, tabItem.item_group,
 		if(length(tabItem.description) > 40, \
 			concat(substr(tabItem.description, 1, 40), "..."), description) as description
 		{columns}


### PR DESCRIPTION
In item auto-complete query, `item_name` is automatically stripped to 40 characters. `item_name` is supposed to be human readable description of the item hence this shouldn't be stripped. 

Search widget shows full item name now:
<img width="580" alt="Screenshot 2021-11-09 at 10 57 42 AM" src="https://user-images.githubusercontent.com/9079960/140868142-fe857ede-3c48-4fc6-8d43-402219a29f72.png">


Completion in table almost looks the same because of `ellipsis` class:

![telegram-cloud-photo-size-5-6075918035983643300-y](https://user-images.githubusercontent.com/9079960/140869845-3d8ef8f7-fa62-4d9a-9804-c9bb1e9953a2.jpg)
