### PR TITLE
fix: specify fields to be set in Lead

### DIFF
--- a/erpnext/shopping_cart/cart.py
+++ b/erpnext/shopping_cart/cart.py
@@ -194,7 +194,9 @@ def add_new_address(doc):
 def create_lead_for_item_inquiry(lead, subject, message):
 	lead = frappe.parse_json(lead)
 	lead_doc = frappe.new_doc('Lead')
-	lead_doc.update(lead)
+	for fieldname in ("lead_name", "company_name", "email_id", "phone"):
+		lead_doc.set(fieldname, lead.get(fieldname))
+
 	lead_doc.set('lead_owner', '')
 
 	if not frappe.db.exists('Lead Source', 'Product Inquiry'):
@@ -202,6 +204,7 @@ def create_lead_for_item_inquiry(lead, subject, message):
 			'doctype': 'Lead Source',
 			'source_name' : 'Product Inquiry'
 		}).insert(ignore_permissions=True)
+
 	lead_doc.set('source', 'Product Inquiry')
 
 	try:


### PR DESCRIPTION
Restricts fields that can be set to the fields being displayed in the dialog box [here](https://github.com/frappe/erpnext/blob/develop/erpnext/templates/generators/item/item_inquiry.js).