### PR TITLE
fix: add Email option to contact email field 

### DIFF
--- a/erpnext/support/doctype/warranty_claim/warranty_claim.json
+++ b/erpnext/support/doctype/warranty_claim/warranty_claim.json
@@ -362,7 +362,7 @@
  ],
  "icon": "fa fa-bug",
  "idx": 1,
- "modified": "2020-09-18 17:26:09.703215",
+ "modified": "2021-11-09 17:26:09.703215",
  "modified_by": "Administrator",
  "module": "Support",
  "name": "Warranty Claim",

--- a/erpnext/support/doctype/warranty_claim/warranty_claim.json
+++ b/erpnext/support/doctype/warranty_claim/warranty_claim.json
@@ -256,6 +256,7 @@
    "fieldname": "contact_email",
    "fieldtype": "Data",
    "label": "Contact Email",
+   "options": "Email",
    "read_only": 1
   },
   {


### PR DESCRIPTION
Added the Email in option field of Contact Email so you are able to create a notification (Doctype) mapping to this field as reciever.