### PR TITLE
chore: Added change log for version 13.14.0

### DIFF
--- a/erpnext/change_log/v13/v13_14_0.md
+++ b/erpnext/change_log/v13/v13_14_0.md
@@ -1,0 +1,42 @@
+# Version 13.14.0 Release Notes
+
+### Features & Enhancements
+
+- KSA E-Invoicing and VAT Report ([#27369](https://github.com/frappe/erpnext/pull/27369))
+    - Added KSA VAT settings to setup KSA VAT accounts
+    - New report KSA VAT to check the vat amounts
+    - Print format for KSA VAT Invoice ([#28166](https://github.com/frappe/erpnext/pull/28166))
+
+- Provision to setup tax for recurring additional salary in Salary Slip ([#27459](https://github.com/frappe/erpnext/pull/27459))
+- Add dispatch address in E-invoicing for India localization ([#28084](https://github.com/frappe/erpnext/pull/28084))
+- Employee initial work history updated when transfer is performed ([#27768](https://github.com/frappe/erpnext/pull/27768))
+- Provision to setup quality inspection teamplte in the operation which will be use in the Job Card([#28219](https://github.com/frappe/erpnext/pull/28219))
+- Improved sales invoice submission performance ([#27916](https://github.com/frappe/erpnext/pull/27916))
+
+
+### Fixes
+
+- Splitting outstanding rows as per payment terms ([#27946](https://github.com/frappe/erpnext/pull/27946))
+
+- Make status filter in Fixed Asset Register optional ([#28126](https://github.com/frappe/erpnext/pull/28126))
+- Skip empty rows while updating unsaved BOM cost ([#28136](https://github.com/frappe/erpnext/pull/28136))
+- TDS round off not working from second transaction ([#27934](https://github.com/frappe/erpnext/pull/27934))
+- Update receivable/payable account on company change in the Sales / Purchase Invoice ([#28057](https://github.com/frappe/erpnext/pull/28057))
+- Changes in Maintenance Schedule gets overwritten on save ([#27990](https://github.com/frappe/erpnext/pull/27990))
+- Fetch thumbnail from Item master instead of regenerating ([#28005](https://github.com/frappe/erpnext/pull/28005))
+- Serial Nos not set in the row after scanning in popup ([#28202](https://github.com/frappe/erpnext/pull/28202))
+- Taxjar customer_address fix, currency fix ([#28262](https://github.com/frappe/erpnext/pull/28262))
+- TaxJar update - added nexus list, making api call only for nexus ([#27497](https://github.com/frappe/erpnext/pull/27497))
+- Don't reset rates in Timesheet Detail when Activity Type is cleared ([#28056](https://github.com/frappe/erpnext/pull/28056))
+- Show full item name in search widget ([#28283](https://github.com/frappe/erpnext/pull/28283))
+- Avoid automatic customer creation on website user login ([#27914](https://github.com/frappe/erpnext/pull/27914))
+- POS Closing Entry without linked invoices ([#28042](https://github.com/frappe/erpnext/pull/28042))
+- Added patch to fix production plan status ([#27567](https://github.com/frappe/erpnext/pull/27567))
+- Interstate internal transfer invoices was not displying in the GSTR-1 report ([#27970](https://github.com/frappe/erpnext/pull/27970))
+- Shows opening balance from filtered from date in the stock balance and stock ledger report ([#26877](https://github.com/frappe/erpnext/pull/26877))
+- Employee filter in YTD and MTD in salary slip ([#27997](https://github.com/frappe/erpnext/pull/27997))
+- Removed warehouse filter on Batch field for Material Receipt ([#28195](https://github.com/frappe/erpnext/pull/28195))
+- Account number and name incorrectly imported using COA importer ([#27967](https://github.com/frappe/erpnext/pull/27967))
+- Autoemail report not showing dynamic report filters ([#28114](https://github.com/frappe/erpnext/pull/28114))
+- Incorrect VAT Amount in UAE VAT 201 report ([#27994](https://github.com/frappe/erpnext/pull/27994))
+- Employee Leave Balance report should only consider ledgers of transaction type Leave Allocation([#27728](https://github.com/frappe/erpnext/pull/27728))


### PR DESCRIPTION
# Version 13.14.0 Release Notes

### Features & Enhancements

- KSA E-Invoicing and VAT Report ([#27369](https://github.com/frappe/erpnext/pull/27369))
    - Added KSA VAT settings to setup KSA VAT accounts
    - New report KSA VAT to check the vat amounts
    - Print format for KSA VAT Invoice ([#28166](https://github.com/frappe/erpnext/pull/28166))

- Provision to setup tax for recurring additional salary in Salary Slip ([#27459](https://github.com/frappe/erpnext/pull/27459))
- Add dispatch address in E-invoicing for India localization ([#28084](https://github.com/frappe/erpnext/pull/28084))
- Employee initial work history updated when transfer is performed ([#27768](https://github.com/frappe/erpnext/pull/27768))
- Provision to setup quality inspection teamplte in the operation which will be use in the Job Card([#28219](https://github.com/frappe/erpnext/pull/28219))
- Improved sales invoice submission performance ([#27916](https://github.com/frappe/erpnext/pull/27916))


### Fixes

- Splitting outstanding rows as per payment terms ([#27946](https://github.com/frappe/erpnext/pull/27946))

- Make status filter in Fixed Asset Register optional ([#28126](https://github.com/frappe/erpnext/pull/28126))
- Skip empty rows while updating unsaved BOM cost ([#28136](https://github.com/frappe/erpnext/pull/28136))
- TDS round off not working from second transaction ([#27934](https://github.com/frappe/erpnext/pull/27934))
- Update receivable/payable account on company change in the Sales / Purchase Invoice ([#28057](https://github.com/frappe/erpnext/pull/28057))
- Changes in Maintenance Schedule gets overwritten on save ([#27990](https://github.com/frappe/erpnext/pull/27990))
- Fetch thumbnail from Item master instead of regenerating ([#28005](https://github.com/frappe/erpnext/pull/28005))
- Serial Nos not set in the row after scanning in popup ([#28202](https://github.com/frappe/erpnext/pull/28202))
- Taxjar customer_address fix, currency fix ([#28262](https://github.com/frappe/erpnext/pull/28262))
- TaxJar update - added nexus list, making api call only for nexus ([#27497](https://github.com/frappe/erpnext/pull/27497))
- Don't reset rates in Timesheet Detail when Activity Type is cleared ([#28056](https://github.com/frappe/erpnext/pull/28056))
- Show full item name in search widget ([#28283](https://github.com/frappe/erpnext/pull/28283))
- Avoid automatic customer creation on website user login ([#27914](https://github.com/frappe/erpnext/pull/27914))
- POS Closing Entry without linked invoices ([#28042](https://github.com/frappe/erpnext/pull/28042))
- Added patch to fix production plan status ([#27567](https://github.com/frappe/erpnext/pull/27567))
- Interstate internal transfer invoices was not displying in the GSTR-1 report ([#27970](https://github.com/frappe/erpnext/pull/27970))
- Shows opening balance from filtered from date in the stock balance and stock ledger report ([#26877](https://github.com/frappe/erpnext/pull/26877))
- Employee filter in YTD and MTD in salary slip ([#27997](https://github.com/frappe/erpnext/pull/27997))
- Removed warehouse filter on Batch field for Material Receipt ([#28195](https://github.com/frappe/erpnext/pull/28195))
- Account number and name incorrectly imported using COA importer ([#27967](https://github.com/frappe/erpnext/pull/27967))
- Autoemail report not showing dynamic report filters ([#28114](https://github.com/frappe/erpnext/pull/28114))
- Incorrect VAT Amount in UAE VAT 201 report ([#27994](https://github.com/frappe/erpnext/pull/27994))
- Employee Leave Balance report should only consider ledgers of transaction type Leave Allocation([#27728](https://github.com/frappe/erpnext/pull/27728))