### PR TITLE
fix: ignore cancelled entries in incorrect balance qty report

### DIFF
--- a/erpnext/stock/report/incorrect_balance_qty_after_transaction/incorrect_balance_qty_after_transaction.py
+++ b/erpnext/stock/report/incorrect_balance_qty_after_transaction/incorrect_balance_qty_after_transaction.py
@@ -46,7 +46,7 @@ def get_incorrect_data(data):
 			return row
 
 def get_stock_ledger_entries(report_filters):
-	filters = {}
+	filters = {"is_cancelled": 0}
 	fields = ['name', 'voucher_type', 'voucher_no', 'item_code', 'actual_qty',
 		'posting_date', 'posting_time', 'company', 'warehouse', 'qty_after_transaction', 'batch_no']
 


### PR DESCRIPTION
Cancelled SLEs don't necessarily maintain ledger invariants, hence showing false positives. 