### PR TITLE
fix: default value for allow neg stock in repost_item_valuation

### DIFF
--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
@@ -31,6 +31,9 @@ class RepostItemValuation(Document):
 			self.voucher_type = None
 			self.voucher_no = None
 
+		self.allow_negative_stock = self.allow_negative_stock or \
+				cint(frappe.db.get_single_value("Stock Settings", "allow_negative_stock"))
+
 	def set_company(self):
 		if self.voucher_type and self.voucher_no:
 			self.company = frappe.get_cached_value(self.voucher_type, self.voucher_no, "company")


### PR DESCRIPTION
Negative stock can be toggled back after queuing transactions, this
causes failure when repost is executed.

Now allow_negative_stock stock is set at time of queuing the repost job.
This means setting changes done afterwards won't affect already
submitted reposts.
