### PR TITLE
feat(pos): Total item qty field to POS screen

### DIFF
--- a/erpnext/public/scss/point-of-sale.scss
+++ b/erpnext/public/scss/point-of-sale.scss
@@ -495,6 +495,10 @@
 						font-size: var(--text-md);
 					}
 
+					> .item-qty-total-container {
+						@extend .net-total-container;
+					}
+
 					> .taxes-container {
 						display: none;
 						flex-direction: column;

--- a/erpnext/public/scss/point-of-sale.scss
+++ b/erpnext/public/scss/point-of-sale.scss
@@ -497,6 +497,7 @@
 
 					> .item-qty-total-container {
 						@extend .net-total-container;
+						padding: 5px 0px 0px 0px;
 					}
 
 					> .taxes-container {

--- a/erpnext/selling/page/point_of_sale/pos_item_cart.js
+++ b/erpnext/selling/page/point_of_sale/pos_item_cart.js
@@ -146,8 +146,8 @@ erpnext.PointOfSale.ItemCart = class {
 
 		this.$numpad_section.prepend(
 			`<div class="numpad-totals">
+			<span class="numpad-item-qty-total"></span>
 				<span class="numpad-net-total"></span>
-				<span class="numpad-item-qty-total"></span>
 				<span class="numpad-grand-total"></span>
 			</div>`
 		)

--- a/erpnext/selling/page/point_of_sale/pos_item_cart.js
+++ b/erpnext/selling/page/point_of_sale/pos_item_cart.js
@@ -101,7 +101,7 @@ erpnext.PointOfSale.ItemCart = class {
 				${this.get_discount_icon()} Add Discount
 			</div>
 			<div class="item-qty-total-container">
-				<div class="item-qty-total-label">Total Items</div>
+				<div class="item-qty-total-label">${__('Total Items')}</div>
 				<div class="item-qty-total-value">0.00</div>
 			</div>
 			<div class="net-total-container">
@@ -500,11 +500,11 @@ erpnext.PointOfSale.ItemCart = class {
 		});
 
 		this.$totals_section.find('.item-qty-total-container').html(
-			`<div>Total Item Qty</div><div>${total_item_qty}</div>`
+			`<div>${__('Total Item Qty')}</div><div>${total_item_qty}</div>`
 		);
 
 		this.$numpad_section.find('.numpad-item-qty-total').html(
-			`<div>Total Item Qty: <span>${total_item_qty}</span></div>`
+			`<div>${__('Total Item Qty')}: <span>${total_item_qty}</span></div>`
 		);
 	}
 

--- a/erpnext/selling/page/point_of_sale/pos_item_cart.js
+++ b/erpnext/selling/page/point_of_sale/pos_item_cart.js
@@ -500,11 +500,11 @@ erpnext.PointOfSale.ItemCart = class {
 		});
 
 		this.$totals_section.find('.item-qty-total-container').html(
-			`<div>${__('Total Item Qty')}</div><div>${total_item_qty}</div>`
+			`<div>${__('Total Quantity')}</div><div>${total_item_qty}</div>`
 		);
 
 		this.$numpad_section.find('.numpad-item-qty-total').html(
-			`<div>${__('Total Item Qty')}: <span>${total_item_qty}</span></div>`
+			`<div>${__('Total Quantity')}: <span>${total_item_qty}</span></div>`
 		);
 	}
 

--- a/erpnext/selling/page/point_of_sale/pos_item_cart.js
+++ b/erpnext/selling/page/point_of_sale/pos_item_cart.js
@@ -100,6 +100,10 @@ erpnext.PointOfSale.ItemCart = class {
 			`<div class="add-discount-wrapper">
 				${this.get_discount_icon()} Add Discount
 			</div>
+			<div class="item-qty-total-container">
+				<div class="item-qty-total-label">Total Items</div>
+				<div class="item-qty-total-value">0.00</div>
+			</div>
 			<div class="net-total-container">
 				<div class="net-total-label">Net Total</div>
 				<div class="net-total-value">0.00</div>
@@ -143,6 +147,7 @@ erpnext.PointOfSale.ItemCart = class {
 		this.$numpad_section.prepend(
 			`<div class="numpad-totals">
 				<span class="numpad-net-total"></span>
+				<span class="numpad-item-qty-total"></span>
 				<span class="numpad-grand-total"></span>
 			</div>`
 		)
@@ -470,6 +475,7 @@ erpnext.PointOfSale.ItemCart = class {
 		if (!frm) frm = this.events.get_frm();
 
 		this.render_net_total(frm.doc.net_total);
+		this.render_total_item_qty(frm.doc.items);
 		const grand_total = cint(frappe.sys_defaults.disable_rounded_total) ? frm.doc.grand_total : frm.doc.rounded_total;
 		this.render_grand_total(grand_total);
 
@@ -484,6 +490,21 @@ erpnext.PointOfSale.ItemCart = class {
 
 		this.$numpad_section.find('.numpad-net-total').html(
 			`<div>Net Total: <span>${format_currency(value, currency)}</span></div>`
+		);
+	}
+
+	render_total_item_qty(items) {
+		var total_item_qty = 0;
+		items.map((item) => {
+			total_item_qty = total_item_qty + item.qty
+		});
+
+		this.$totals_section.find('.item-qty-total-container').html(
+			`<div>Total Item Qty</div><div>${total_item_qty}</div>`
+		);
+
+		this.$numpad_section.find('.numpad-item-qty-total').html(
+			`<div>Total Item Qty: <span>${total_item_qty}</span></div>`
 		);
 	}
 

--- a/erpnext/selling/page/point_of_sale/pos_item_cart.js
+++ b/erpnext/selling/page/point_of_sale/pos_item_cart.js
@@ -496,7 +496,7 @@ erpnext.PointOfSale.ItemCart = class {
 	render_total_item_qty(items) {
 		var total_item_qty = 0;
 		items.map((item) => {
-			total_item_qty = total_item_qty + item.qty
+			total_item_qty = total_item_qty + item.qty;
 		});
 
 		this.$totals_section.find('.item-qty-total-container').html(


### PR DESCRIPTION
**Description:**
- Similar to **Grand Total**, a field **Total Item Qty** added to display total number of items in the cart
  
   <img width="700" alt="Screenshot 2021-11-23 at 1 11 28 PM" src="https://user-images.githubusercontent.com/36098155/142986564-db54c76a-9f9e-46f8-a183-d515f40a5e7b.png">
   
   <img width="700" alt="Screenshot 2021-11-23 at 1 12 00 PM" src="https://user-images.githubusercontent.com/36098155/142986619-3c6cfd0c-78bc-491b-b416-b9a6923cba71.png">

 
`no-docs`




