### PR TITLE
fix: Dispatch address details not displayed in v13

### DIFF
--- a/erpnext/selling/sales_common.js
+++ b/erpnext/selling/sales_common.js
@@ -111,6 +111,10 @@ erpnext.selling.SellingController = erpnext.TransactionController.extend({
 		erpnext.utils.set_taxes_from_address(this.frm, "shipping_address_name", "customer_address", "shipping_address_name");
 	},
 
+	dispatch_address_name: function() {
+		erpnext.utils.get_address_display(this.frm, "dispatch_address_name", "dispatch_address");
+	},
+
 	sales_partner: function() {
 		this.apply_pricing_rule();
 	},


### PR DESCRIPTION
**Problem:**
- On selecting dispatch address, the entire address was not visible in small_text field like other addresses 
- Dispatch address feat was added in this [PR](https://github.com/frappe/erpnext/pull/26464)
- JS trigger to display its details in small text field was missing from v13-hotfix backport

**Solution:**
- Added the trigger