### PR TITLE
fix(India): Sales Invoice with duplicate items not showing correct taxable value

### DIFF
--- a/erpnext/regional/report/gstr_1/gstr_1.py
+++ b/erpnext/regional/report/gstr_1/gstr_1.py
@@ -248,18 +248,17 @@ class Gstr1Report(object):
 		""" % (self.doctype, ', '.join(['%s']*len(self.invoices))), tuple(self.invoices), as_dict=1)
 
 		for d in items:
-			if d.item_code not in self.invoice_items.get(d.parent, {}):
-				self.invoice_items.setdefault(d.parent, {}).setdefault(d.item_code, 0.0)
-				self.invoice_items[d.parent][d.item_code] += d.get('taxable_value', 0) or d.get('base_net_amount', 0)
+			self.invoice_items.setdefault(d.parent, {}).setdefault(d.item_code, 0.0)
+			self.invoice_items[d.parent][d.item_code] += d.get('taxable_value', 0) or d.get('base_net_amount', 0)
 
-				item_tax_rate = {}
+			item_tax_rate = {}
 
-				if d.item_tax_rate:
-					item_tax_rate = json.loads(d.item_tax_rate)
+			if d.item_tax_rate:
+				item_tax_rate = json.loads(d.item_tax_rate)
 
-					for account, rate in item_tax_rate.items():
-						tax_rate_dict = self.item_tax_rate.setdefault(d.parent, {}).setdefault(d.item_code, [])
-						tax_rate_dict.append(rate)
+				for account, rate in item_tax_rate.items():
+					tax_rate_dict = self.item_tax_rate.setdefault(d.parent, {}).setdefault(d.item_code, [])
+					tax_rate_dict.append(rate)
 
 	def get_items_based_on_tax_rate(self):
 		self.tax_details = frappe.db.sql("""


### PR DESCRIPTION
Taxable value for Invoices having the same items multiple times was incorrectly shown

Steps to replicate:

1. Create a GST invoice with the same item added multiple times

![image](https://user-images.githubusercontent.com/42651287/141143181-f9396166-caac-4679-b28e-08500158cc59.png)

2. Check GSTR-1 Report

Before:

The expected total value is 5000 as the base net total is 5000

<img width="1331" alt="Screenshot 2021-11-10 at 9 06 37 PM" src="https://user-images.githubusercontent.com/42651287/141143513-6955503a-51e5-4ee5-a984-2aa21743f39b.png">

After:

Got taxable value as expected

<img width="1353" alt="Screenshot 2021-11-10 at 9 06 11 PM" src="https://user-images.githubusercontent.com/42651287/141143536-f664cab0-5de7-4251-847f-7d99cc2b4c32.png">

