### PR TITLE
fix: can not cancel stock reconciliation with sr no

### DIFF
--- a/erpnext/stock/doctype/serial_no/serial_no.py
+++ b/erpnext/stock/doctype/serial_no/serial_no.py
@@ -342,7 +342,7 @@ def check_serial_no_validity_on_cancel(serial_no, sle):
 	is_stock_reco = sle.voucher_type == "Stock Reconciliation"
 	msg = None
 
-	if sr and (actual_qty < 0 or is_stock_reco) and sr.warehouse != sle.warehouse:
+	if sr and (actual_qty < 0 or is_stock_reco) and (sr.warehouse and sr.warehouse != sle.warehouse):
 		# receipt(inward) is being cancelled
 		msg = _("Cannot cancel {0} {1} as Serial No {2} does not belong to the warehouse {3}").format(
 			sle.voucher_type, doc_link, sr_link, frappe.bold(sle.warehouse))

--- a/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
@@ -399,6 +399,34 @@ class TestStockReconciliation(ERPNextTestCase):
 			, do_not_submit=True)
 		self.assertRaises(frappe.ValidationError, sr.submit)
 
+	def test_serial_no_cancellation(self):
+
+		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
+		item = create_item("Stock-Reco-Serial-Item-9", is_stock_item=1)
+		if not item.has_serial_no:
+			item.has_serial_no = 1
+			item.serial_no_series = "SRS9.####"
+			item.save()
+
+		item_code = item.name
+		warehouse = "_Test Warehouse - _TC"
+
+		se1 = make_stock_entry(item_code=item_code, target=warehouse, qty=10, basic_rate=700)
+
+		serial_nos = get_serial_nos(se1.items[0].serial_no)
+		# reduce 1 item
+		serial_nos.pop()
+		new_serial_nos = "\n".join(serial_nos)
+
+		sr = create_stock_reconciliation(item_code=item.name, warehouse=warehouse, serial_no=new_serial_nos, qty=9)
+		sr.cancel()
+
+		active_sr_no = frappe.get_all("Serial No",
+				filters={"item_code": item_code, "warehouse": warehouse, "status": "Active"})
+
+		self.assertEqual(len(active_sr_no), 10)
+
+
 def create_batch_item_with_batch(item_name, batch_id):
 	batch_item_doc = create_item(item_name, is_stock_item=1)
 	if not batch_item_doc.has_batch_no:


### PR DESCRIPTION
Steps to reproduce:

1. Create stock entry with serialized items of qty 10
2. Create stock reconciliation and reduce the quantity to 9 by removing one Sr no.  
3. Try to cancel the stock reco, it will fail saying sr no doesn't belong to warehouse. 


Solution: ignore none warehouse while canceling Stock recos.


Disclaimer: I am fully aware how bad this looks now 😄 cleaning up the code in separate PR, this fix can't wait till I am done with https://github.com/frappe/erpnext/pull/28326