### PR TITLE
fix: Collapse Scrap Items in Job Card

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.js
+++ b/erpnext/manufacturing/doctype/job_card/job_card.js
@@ -23,6 +23,12 @@ frappe.ui.form.on('Job Card', {
 		);
 	},
 
+	onload: function(frm) {
+		if (frm.doc.scrap_items.length == 0) {
+			frm.fields_dict['scrap_items_section'].collapse();
+		}
+	},
+
 	refresh: function(frm) {
 		frappe.flags.pause_job = 0;
 		frappe.flags.resume_job = 0;

--- a/erpnext/manufacturing/doctype/job_card/job_card.json
+++ b/erpnext/manufacturing/doctype/job_card/job_card.json
@@ -396,6 +396,7 @@
    "options": "Batch"
   },
   {
+   "collapsible": 1,
    "fieldname": "scrap_items_section",
    "fieldtype": "Section Break",
    "label": "Scrap Items"
@@ -411,7 +412,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2021-09-14 00:38:46.873105",
+ "modified": "2021-11-12 10:15:03.572401",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Job Card",


### PR DESCRIPTION
Source/Reference: (FR-ISS-316618)

Screenshots:

Before:

![](https://user-images.githubusercontent.com/63660334/141418273-0023b8f1-2d9d-47c8-9f1b-0a8d4853daa7.png)

After:

![](https://user-images.githubusercontent.com/63660334/141418553-ab9fe604-d96a-4137-8f9b-0ad88c4e3a93.png)

Changes:

https://user-images.githubusercontent.com/63660334/141418305-3f20db83-dcbe-46c1-b6b5-0e07d34d81eb.png

If the Scrap Item table is empty i.e., length == 0 then the scrap_items_section is collapsed by default.
