### PR TITLE
fix: Add extra column to display Invoice or Item when grouped by Invoice

### DIFF
--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -19,7 +19,7 @@ def execute(filters=None):
 	data = []
 
 	group_wise_columns = frappe._dict({
-		"invoice": ["invoice_or_item", "customer", "customer_group", "posting_date","item_code", "item_name","item_group", "brand", "description", \
+		"invoice": ["invoice_or_item", "customer", "customer_group", "posting_date","item_code", "item_name","item_group", "brand", "description",
 			"warehouse", "qty", "base_rate", "buying_rate", "base_amount",
 			"buying_amount", "gross_profit", "gross_profit_percent", "project"],
 		"item_code": ["item_code", "item_name", "brand", "description", "qty", "base_rate",

--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -19,7 +19,7 @@ def execute(filters=None):
 	data = []
 
 	group_wise_columns = frappe._dict({
-		"invoice": ["parent", "customer", "customer_group", "posting_date","item_code", "item_name","item_group", "brand", "description", \
+		"invoice": ["invoice_or_item", "customer", "customer_group", "posting_date","item_code", "item_name","item_group", "brand", "description", \
 			"warehouse", "qty", "base_rate", "buying_rate", "base_amount",
 			"buying_amount", "gross_profit", "gross_profit_percent", "project"],
 		"item_code": ["item_code", "item_name", "brand", "description", "qty", "base_rate",
@@ -84,6 +84,7 @@ def get_columns(group_wise_columns, filters):
 	columns = []
 	column_map = frappe._dict({
 		"parent": _("Sales Invoice") + ":Link/Sales Invoice:120",
+		"invoice_or_item": _("Sales Invoice") + ":Link/Sales Invoice:120",
 		"posting_date": _("Posting Date") + ":Date:100",
 		"posting_time": _("Posting Time") + ":Data:100",
 		"item_code": _("Item Code") + ":Link/Item:100",
@@ -122,7 +123,7 @@ def get_columns(group_wise_columns, filters):
 
 def get_column_names():
 	return frappe._dict({
-		'parent': 'sales_invoice',
+		'invoice_or_item': 'sales_invoice',
 		'customer': 'customer',
 		'customer_group': 'customer_group',
 		'posting_date': 'posting_date',
@@ -446,7 +447,7 @@ class GrossProfitGenerator(object):
 				if not row.indent:
 					row.indent = 1.0
 					row.parent_invoice = row.parent
-					row.parent = row.item_code
+					row.invoice_or_item = row.item_code
 
 					if frappe.db.exists('Product Bundle', row.item_code):
 						self.add_bundle_items(row, index)
@@ -455,7 +456,8 @@ class GrossProfitGenerator(object):
 		return frappe._dict({
 			'parent_invoice': "",
 			'indent': 0.0,
-			'parent': row.parent,
+			'invoice_or_item': row.parent,
+			'parent': None,
 			'posting_date': row.posting_date,
 			'posting_time': row.posting_time,
 			'project': row.project,
@@ -499,7 +501,8 @@ class GrossProfitGenerator(object):
 		return frappe._dict({
 			'parent_invoice': product_bundle.item_code,
 			'indent': product_bundle.indent + 1,
-			'parent': item.item_code,
+			'parent': None,
+			'invoice_or_item': item.item_code,
 			'posting_date': product_bundle.posting_date,
 			'posting_time': product_bundle.posting_time,
 			'project': product_bundle.project,


### PR DESCRIPTION
_Problem:_

The Gross Profit report uses a variable called `parent` to represent Sales Invoices. While modifying the report to accommodate Product Bundles in https://github.com/frappe/erpnext/pull/27124, I'd modified the `parent` variable to represent either the name of the Invoice or the Item Code. However, this seems to have caused a problem with the calculation of Buying Amounts. 

_Fix:_

- Undo the changes made to `parent`
- Replace the `parent` column with a new column called `invoice_or_item` to display the items included in an Invoice in tree form.

<details>
<summary>Testing Info</summary>

1. Open the Gross Profit Report.
2. Group by Invoice.
3. Check if the Sales Invoice column still displays all the Invoices and their Items in tree form.

</details>