### PR TITLE
fix: Work order creation from sales order

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -319,7 +319,7 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 						title: __('Select Items to Manufacture'),
 						fields: fields,
 						primary_action: function() {
-							var data = d.get_values();
+							var data = {items:d.fields_dict.items.grid.get_selected_children()};
 							me.frm.call({
 								method: 'make_work_orders',
 								args: {

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -319,7 +319,7 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 						title: __('Select Items to Manufacture'),
 						fields: fields,
 						primary_action: function() {
-							var data = {items:d.fields_dict.items.grid.get_selected_children()};
+							var data = {items: d.fields_dict.items.grid.get_selected_children()};
 							me.frm.call({
 								method: 'make_work_orders',
 								args: {


### PR DESCRIPTION
Source/Reference :  (FR-ISS-318344)

Screenshots : 

Before :
<img src="https://user-images.githubusercontent.com/63660334/141752732-43753484-e083-48ec-bafe-9ea7181543d5.png">
<img src="https://user-images.githubusercontent.com/63660334/141752753-06d0aea4-5a77-4d4e-bfbf-e93b766e058d.png">

After :
<img width="1324" alt="Screenshot 2021-11-15 at 2 19 56 PM" src="https://user-images.githubusercontent.com/63660334/141753040-c5ff6201-9dbe-402b-8583-d71afea02b64.png">
<img width="1324" alt="Screenshot 2021-11-15 at 2 20 05 PM" src="https://user-images.githubusercontent.com/63660334/141753071-cdc4cc1d-f883-4ee0-8cf4-420664d65d1c.png">

Changes :
Get selected items using "get_selected_children()" and pass them to the "make_work_orders" method.


