### PR TITLE
fix: POS idx issue in taxes table while merging

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
@@ -118,7 +118,6 @@ class POSInvoiceMergeLog(Document):
 
 		loyalty_amount_sum, loyalty_points_sum, idx = 0, 0, 1
 
-		invoice.write_off_amount = 0.0
 
 		for doc in data:
 			map_doc(doc, invoice, table_map={ "doctype": invoice.doctype })

--- a/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
@@ -171,8 +171,8 @@ class POSInvoiceMergeLog(Document):
 					payments.append(payment)
 			rounding_adjustment += doc.rounding_adjustment
 			rounded_total += doc.rounded_total
-			base_rounding_adjustment += doc.rounding_adjustment
-			base_rounded_total += doc.rounded_total
+			base_rounding_adjustment += doc.base_rounding_adjustment
+			base_rounded_total += doc.base_rounded_total
 
 
 		if loyalty_points_sum:

--- a/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
@@ -110,9 +110,16 @@ class POSInvoiceMergeLog(Document):
 
 	def merge_pos_invoice_into(self, invoice, data):
 		items, payments, taxes = [], [], []
+
 		loyalty_amount_sum, loyalty_points_sum = 0, 0
+
 		rounding_adjustment, base_rounding_adjustment = 0, 0
 		rounded_total, base_rounded_total = 0, 0
+
+		loyalty_amount_sum, loyalty_points_sum, idx = 0, 0, 1
+
+		invoice.write_off_amount = 0.0
+
 		for doc in data:
 			map_doc(doc, invoice, table_map={ "doctype": invoice.doctype })
 
@@ -146,6 +153,8 @@ class POSInvoiceMergeLog(Document):
 						found = True
 				if not found:
 					tax.charge_type = 'Actual'
+					tax.idx = idx
+					idx += 1
 					tax.included_in_print_rate = 0
 					tax.tax_amount = tax.tax_amount_after_discount_amount
 					tax.base_tax_amount = tax.base_tax_amount_after_discount_amount
@@ -176,9 +185,9 @@ class POSInvoiceMergeLog(Document):
 		invoice.set('payments', payments)
 		invoice.set('taxes', taxes)
 		invoice.set('rounding_adjustment',rounding_adjustment)
-		invoice.set('rounding_adjustment',base_rounding_adjustment)
-		invoice.set('base_rounded_total',base_rounded_total)
+		invoice.set('base_rounding_adjustment',base_rounding_adjustment)
 		invoice.set('rounded_total',rounded_total)
+		invoice.set('base_rounded_total',base_rounded_total)
 		invoice.additional_discount_percentage = 0
 		invoice.discount_amount = 0.0
 		invoice.taxes_and_charges = None


### PR DESCRIPTION
**Problem:**
While merging POS invoices, the idx parameter was not being tracked so during calculation of taxes it would get overwritten
<img src='https://user-images.githubusercontent.com/36098155/141755146-415b23f1-bde4-4f9b-9416-6f143db05e67.png' width='700'>

**Solution:**
Keeping track of idx in the merging logic itself where taxes are added
