### PR TITLE
fix: remove item-item group name validation

### DIFF
--- a/erpnext/setup/doctype/item_group/item_group.py
+++ b/erpnext/setup/doctype/item_group/item_group.py
@@ -43,7 +43,6 @@ class ItemGroup(NestedSet, WebsiteGenerator):
 	def on_update(self):
 		NestedSet.on_update(self)
 		invalidate_cache_for(self)
-		self.validate_name_with_item()
 		self.validate_one_root()
 		self.delete_child_item_groups_key()
 
@@ -66,10 +65,6 @@ class ItemGroup(NestedSet, WebsiteGenerator):
 		NestedSet.on_trash(self)
 		WebsiteGenerator.on_trash(self)
 		self.delete_child_item_groups_key()
-
-	def validate_name_with_item(self):
-		if frappe.db.exists("Item", self.name):
-			frappe.throw(frappe._("An item exists with same name ({0}), please change the item group name or rename the item").format(self.name), frappe.NameError)
 
 	def get_context(self, context):
 		context.show_search=True

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -152,7 +152,6 @@ class Item(WebsiteGenerator):
 
 	def on_update(self):
 		invalidate_cache_for_item(self)
-		self.validate_name_with_item_group()
 		self.update_variants()
 		self.update_item_price()
 		self.update_template_item()
@@ -627,12 +626,6 @@ class Item(WebsiteGenerator):
 			self._stock_ledger_created = len(frappe.db.sql("""select name from `tabStock Ledger Entry`
 				where item_code = %s and is_cancelled = 0 limit 1""", self.name))
 		return self._stock_ledger_created
-
-	def validate_name_with_item_group(self):
-		# causes problem with tree build
-		if frappe.db.exists("Item Group", self.name):
-			frappe.throw(
-				_("An Item Group exists with same name, please change the item name or rename the item group"))
 
 	def update_item_price(self):
 		frappe.db.sql("""


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

There's an [old validation from ~9 years ago](https://github.com/frappe/erpnext/commit/8cf90f18f0a3de7c7039363f3a15e9a31cae9af9) that prevents item names to be the same as an item group's name. The comment against it says that it's to avoid causing issues to build the tree, but it seems like the validation is no longer necessary, considering how much the framework has changed and how treeviews are built now.
