### PR TITLE
fix: don't make naming series mandatory for items

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -306,6 +306,7 @@ erpnext.patches.v13_0.requeue_failed_reposts
 erpnext.patches.v13_0.update_job_card_status
 erpnext.patches.v12_0.update_production_plan_status
 erpnext.patches.v13_0.healthcare_deprecation_warning
+erpnext.patches.v13_0.item_naming_series_not_mandatory
 erpnext.patches.v14_0.delete_healthcare_doctypes
 erpnext.patches.v13_0.update_category_in_ltds_certificate
 erpnext.patches.v13_0.create_pan_field_for_india #2

--- a/erpnext/patches/v13_0/item_naming_series_not_mandatory.py
+++ b/erpnext/patches/v13_0/item_naming_series_not_mandatory.py
@@ -1,0 +1,11 @@
+import frappe
+
+from erpnext.setup.doctype.naming_series.naming_series import set_by_naming_series
+
+
+def execute():
+
+	stock_settings = frappe.get_doc("Stock Settings")
+
+	set_by_naming_series("Item", "item_code",
+		stock_settings.get("item_naming_by")=="Naming Series", hide_name_field=True, make_mandatory=0)

--- a/erpnext/setup/doctype/naming_series/naming_series.py
+++ b/erpnext/setup/doctype/naming_series/naming_series.py
@@ -180,11 +180,11 @@ class NamingSeries(Document):
 		prefix = parse_naming_series(parts)
 		return prefix
 
-def set_by_naming_series(doctype, fieldname, naming_series, hide_name_field=True):
+def set_by_naming_series(doctype, fieldname, naming_series, hide_name_field=True, make_mandatory=1):
 	from frappe.custom.doctype.property_setter.property_setter import make_property_setter
 	if naming_series:
 		make_property_setter(doctype, "naming_series", "hidden", 0, "Check", validate_fields_for_doctype=False)
-		make_property_setter(doctype, "naming_series", "reqd", 1, "Check", validate_fields_for_doctype=False)
+		make_property_setter(doctype, "naming_series", "reqd", make_mandatory, "Check", validate_fields_for_doctype=False)
 
 		# set values for mandatory
 		try:

--- a/erpnext/stock/doctype/stock_settings/stock_settings.py
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.py
@@ -20,7 +20,7 @@ class StockSettings(Document):
 
 		from erpnext.setup.doctype.naming_series.naming_series import set_by_naming_series
 		set_by_naming_series("Item", "item_code",
-			self.get("item_naming_by")=="Naming Series", hide_name_field=True)
+			self.get("item_naming_by")=="Naming Series", hide_name_field=True, make_mandatory=0)
 
 		stock_frozen_limit = 356
 		submitted_stock_frozen = self.stock_frozen_upto_days or 0


### PR DESCRIPTION
To reproduce:

- Change item creation to naming series from stock settings
- create a template
- try to create variant
- "series" is mandatory will pop up. 

1. Item variants are an exception, hence this needs to be checked conditionally.
2. There's no need to even check this. document naming checks it already. 


- [x] Made "naming_series" non-mandatory field upon enabling item naming by "naming series"
- [x] patch to toggle this for everyone using naming series
