### PR TITLE
fix: add possibility to create lead without a persons name

### DIFF
--- a/erpnext/crm/doctype/lead/lead.js
+++ b/erpnext/crm/doctype/lead/lead.js
@@ -73,12 +73,6 @@ erpnext.LeadController = frappe.ui.form.Controller.extend({
 		this.frm.toggle_reqd("company_name", this.frm.doc.organization_lead);
 	},
 
-	company_name: function () {
-		if (this.frm.doc.organization_lead && !this.frm.doc.lead_name) {
-			this.frm.set_value("lead_name", this.frm.doc.company_name);
-		}
-	},
-
 	contact_date: function () {
 		if (this.frm.doc.contact_date) {
 			let d = moment(this.frm.doc.contact_date);

--- a/erpnext/crm/doctype/lead/lead.py
+++ b/erpnext/crm/doctype/lead/lead.py
@@ -208,7 +208,7 @@ class Lead(SellingController):
 			self.address_doc.append("links", {
 				"link_doctype": "Lead",
 				"link_name": self.name,
-				"link_title": self.lead_name if not self.organization_lead else self.company_name
+				"link_title": self.title
 			})
 			self.address_doc.save()
 

--- a/erpnext/crm/doctype/lead/lead.py
+++ b/erpnext/crm/doctype/lead/lead.py
@@ -217,7 +217,7 @@ class Lead(SellingController):
 			self.contact_doc.append("links", {
 				"link_doctype": "Lead",
 				"link_name": self.name,
-				"link_title": self.lead_name if not self.organization_lead else self.company_name
+				"link_title": self.title
 			})
 			self.contact_doc.save()
 

--- a/erpnext/crm/doctype/lead/lead.py
+++ b/erpnext/crm/doctype/lead/lead.py
@@ -43,10 +43,8 @@ class Lead(SellingController):
 		self.update_links()
 
 	def validate(self):
-		if self.organization_lead:
-			self.set_company_name()
-		else:
-			self.set_lead_name()
+		self.validate_company_name()
+		self.set_lead_name()
 		self.set_title()
 		self._prev = frappe._dict({
 			"contact_date": frappe.db.get_value("Lead", self.name, "contact_date") if (not cint(self.is_new())) else None,
@@ -162,7 +160,8 @@ class Lead(SellingController):
 		return address
 
 	def create_contact(self):
-		if self.lead_name:
+		if not self.lead_name:
+			return
 
 			names = self.lead_name.strip().split(" ")
 			if len(names) > 1:

--- a/erpnext/crm/doctype/lead/lead.py
+++ b/erpnext/crm/doctype/lead/lead.py
@@ -34,10 +34,10 @@ class Lead(SellingController):
 	def before_insert(self):
 		if self.address_title and self.address_type:
 			self.address_doc = self.create_address()
+
+		self.contact_doc = None
 		if self.lead_name:
 			self.contact_doc = self.create_contact()
-		else:
-			self.contact_doc = None
 
 	def after_insert(self):
 		self.update_links()

--- a/erpnext/crm/doctype/lead/lead.py
+++ b/erpnext/crm/doctype/lead/lead.py
@@ -36,7 +36,7 @@ class Lead(SellingController):
 			self.address_doc = self.create_address()
 		if self.lead_name:
 			self.contact_doc = self.create_contact()
-		else: 
+		else:
 			self.contact_doc = None
 
 	def after_insert(self):


### PR DESCRIPTION
When creating a lead, a person's name (lead_name) has to always be specified currently, even if the lead is an organization. Often, however, there are cases where only the company name is known so far but no contact person is yet known.

This PR makes it possible to create a lead as an organization without necessarily having to add a person's name.