### PR TITLE
fix: Gross Profit report totals

### DIFF
--- a/erpnext/accounts/report/gross_profit/gross_profit.js
+++ b/erpnext/accounts/report/gross_profit/gross_profit.js
@@ -44,7 +44,7 @@ frappe.query_reports["Gross Profit"] = {
 	"formatter": function(value, row, column, data, default_formatter) {
 		value = default_formatter(value, row, column, data);
 
-		if (data && data.indent == 0.0) {
+		if (data && (data.indent == 0.0 || row[1].content == "Total")) {
 			value = $(`<span>${value}</span>`);
 			var $value = $(value).css("font-weight", "bold");
 			value = $value.wrap("<p></p>").parent().html();

--- a/erpnext/accounts/report/gross_profit/gross_profit.json
+++ b/erpnext/accounts/report/gross_profit/gross_profit.json
@@ -9,7 +9,7 @@
  "filters": [],
  "idx": 3,
  "is_standard": "Yes",
- "modified": "2021-08-19 18:57:07.468202",
+ "modified": "2021-11-13 19:14:23.730198",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Gross Profit",

--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -77,7 +77,8 @@ def get_data_when_not_grouped_by_invoice(gross_profit_data, filters, group_wise_
 
 		row.append(filters.currency)
 		if idx == len(gross_profit_data.grouped_data)-1:
-			row[0] = frappe.bold("Total")
+			row[0] = "Total"
+
 		data.append(row)
 
 def get_columns(group_wise_columns, filters):

--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -245,19 +245,28 @@ class GrossProfitGenerator(object):
 				self.add_to_totals(new_row)
 			else:
 				for i, row in enumerate(self.grouped[key]):
-					if row.parent in self.returned_invoices \
-							and row.item_code in self.returned_invoices[row.parent]:
-						returned_item_rows = self.returned_invoices[row.parent][row.item_code]
-						for returned_item_row in returned_item_rows:
-							row.qty += flt(returned_item_row.qty)
-							row.base_amount += flt(returned_item_row.base_amount, self.currency_precision)
-						row.buying_amount = flt(flt(row.qty) * flt(row.buying_rate), self.currency_precision)
-					if (flt(row.qty) or row.base_amount) and self.is_not_invoice_row(row):
-						row = self.set_average_rate(row)
-						self.grouped_data.append(row)
-					self.add_to_totals(row)
+					if row.indent == 1.0:
+						if row.parent in self.returned_invoices \
+								and row.item_code in self.returned_invoices[row.parent]:
+							returned_item_rows = self.returned_invoices[row.parent][row.item_code]
+							for returned_item_row in returned_item_rows:
+								row.qty += flt(returned_item_row.qty)
+								row.base_amount += flt(returned_item_row.base_amount, self.currency_precision)
+							row.buying_amount = flt(flt(row.qty) * flt(row.buying_rate), self.currency_precision)
+						if (flt(row.qty) or row.base_amount) and self.is_not_invoice_row(row):
+							row = self.set_average_rate(row)
+							self.grouped_data.append(row)
+						self.add_to_totals(row)
+
 		self.set_average_gross_profit(self.totals)
-		self.grouped_data.append(self.totals)
+
+		if self.filters.get("group_by") == "Invoice":
+			self.totals.indent = 0.0
+			self.totals.parent_invoice = ""
+			self.totals.parent = "Totals"
+			self.si_list.append(self.totals)
+		else:
+			self.grouped_data.append(self.totals)
 
 	def is_not_invoice_row(self, row):
 		return (self.filters.get("group_by") == "Invoice" and row.indent != 0.0) or self.filters.get("group_by") != "Invoice"

--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -264,7 +264,7 @@ class GrossProfitGenerator(object):
 		if self.filters.get("group_by") == "Invoice":
 			self.totals.indent = 0.0
 			self.totals.parent_invoice = ""
-			self.totals.parent = "Totals"
+			self.totals.parent = "Total"
 			self.si_list.append(self.totals)
 		else:
 			self.grouped_data.append(self.totals)

--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -253,7 +253,7 @@ class GrossProfitGenerator(object):
 								row.qty += flt(returned_item_row.qty)
 								row.base_amount += flt(returned_item_row.base_amount, self.currency_precision)
 							row.buying_amount = flt(flt(row.qty) * flt(row.buying_rate), self.currency_precision)
-						if (flt(row.qty) or row.base_amount) and self.is_not_invoice_row(row):
+						if (flt(row.qty) or row.base_amount):
 							row = self.set_average_rate(row)
 							self.grouped_data.append(row)
 						self.add_to_totals(row)


### PR DESCRIPTION
## Problems

- When the Gross Profit report is Grouped By anything other than Invoice, there are two rows displaying the total values, only one of which is accurate.

![Screenshot 2021-11-13 at 2 17 21 AM](https://user-images.githubusercontent.com/25903035/141855888-2f587c28-e08c-4e85-8534-1da1cfed9740.png)

- When it's Grouped By Invoice, there is no row displaying the total values.
- The Gross Profit Percentage value in the totals row is incorrect.
- The custom totals row(the first one, the one that's actually right) is not displayed in bold.

![Screenshot 2021-11-16 at 2 38 22 AM](https://user-images.githubusercontent.com/25903035/141858654-2b888375-d9e2-4fc1-8552-6df85e960e0b.png)

## Fixes

- Remove the inaccurate totals row.
- Add totals row for the report when Grouped By Invoice.
- Fix incorrect Gross Profit Percentage value in the totals row.
- Display totals row in bold.

![Screenshot 2021-11-16 at 3 17 11 AM](https://user-images.githubusercontent.com/25903035/141858683-ab0228e0-fbaf-4ecb-aa52-9207be3c1329.png)

<details>
<summary>Testing Info</summary>

1. Open the Gross Profit report.
2. Group by Invoice.
3. Check if it has a Totals row.
4. Now Group By everything else(Item Code, Customer, etc).
5. Confirm that there's only one Totals row and that that row is displayed in bold.
6. Verify that the Gross Profit Percentage displayed in the totals row is constant, irrespective of the value of the Group By filter.

</details>
