### PR TITLE
chore: add docker pull count to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![CI](https://github.com/frappe/erpnext/actions/workflows/server-tests.yml/badge.svg?branch=develop)](https://github.com/frappe/erpnext/actions/workflows/server-tests.yml)
 [![Open Source Helpers](https://www.codetriage.com/frappe/erpnext/badges/users.svg)](https://www.codetriage.com/frappe/erpnext)
 [![codecov](https://codecov.io/gh/frappe/erpnext/branch/develop/graph/badge.svg?token=0TwvyUg3I5)](https://codecov.io/gh/frappe/erpnext)
+[![docker pulls](https://img.shields.io/docker/pulls/frappe/erpnext-worker.svg)](https://hub.docker.com/r/frappe/erpnext-worker)
 
 [https://erpnext.com](https://erpnext.com)
 


### PR DESCRIPTION
Show active docker pull count. Gives a rough idea of usage.

![image](https://user-images.githubusercontent.com/33246109/141931712-95830c03-9130-479e-b7b4-f6e69f038d70.png)
