### PR TITLE
fix: add child button in coa tree

### DIFF
--- a/erpnext/accounts/doctype/account/account_tree.js
+++ b/erpnext/accounts/doctype/account/account_tree.js
@@ -175,7 +175,7 @@ frappe.treeview_settings["Account"] = {
 					&& node.expandable && !node.hide_add;
 			},
 			click: function() {
-				var me = frappe.treeview_settings['Account'].treeview;
+				var me = frappe.views.trees['Account'];
 				me.new_node();
 			},
 			btnClass: "hidden-xs"


### PR DESCRIPTION
The 'Add Child' button in COA tree view, which extends the TreeView toolbar, didn't work because of wrong instance reference. It's fixed now.