### PR TITLE
fix: fetch taxes on item tax template change

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1886,6 +1886,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 				callback: function(r) {
 					if(!r.exc) {
 						item.item_tax_rate = r.message;
+						me.add_taxes_from_item_tax_template(item.item_tax_rate);
 						me.calculate_taxes_and_totals();
 					}
 				}


### PR DESCRIPTION
Setting/Replacing the **Item Tax Template** under **Sales Invoice Item** manually doesn't fetch taxes in the taxes table. 