### PR TITLE
fix: currency wise pricing rule not working

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
@@ -543,6 +543,75 @@ class TestPricingRule(unittest.TestCase):
 		frappe.get_doc("Item Price", {"item_code": "Water Flask"}).delete()
 		item.delete()
 
+	def test_pricing_rule_for_different_currency(self):
+		make_item("Test Sanitizer Item")
+
+		pricing_rule_record = {
+			"doctype": "Pricing Rule",
+			"title": "_Test Sanitizer Rule",
+			"apply_on": "Item Code",
+			"items": [{
+				"item_code": "Test Sanitizer Item",
+			}],
+			"selling": 1,
+			"currency": "INR",
+			"rate_or_discount": "Rate",
+			"rate": 0,
+			"priority": 2,
+			"margin_type": "Percentage",
+			"margin_rate_or_amount": 0.0,
+			"company": "_Test Company"
+		}
+
+		rule = frappe.get_doc(pricing_rule_record)
+		rule.rate_or_discount = 'Rate'
+		rule.rate = 100.0
+		rule.insert()
+
+		rule1 = frappe.get_doc(pricing_rule_record)
+		rule1.currency = 'USD'
+		rule1.rate_or_discount = 'Rate'
+		rule1.rate = 2.0
+		rule1.priority = 1
+		rule1.insert()
+
+		args = frappe._dict({
+			"item_code": "Test Sanitizer Item",
+			"company": "_Test Company",
+			"price_list": "_Test Price List",
+			"currency": "USD",
+			"doctype": "Sales Invoice",
+			"conversion_rate": 1,
+			"price_list_currency": "_Test Currency",
+			"plc_conversion_rate": 1,
+			"order_type": "Sales",
+			"customer": "_Test Customer",
+			"name": None,
+			"transaction_date": frappe.utils.nowdate()
+		})
+
+		details = get_item_details(args)
+		self.assertEqual(details.price_list_rate, 2.0)
+
+
+		args = frappe._dict({
+			"item_code": "Test Sanitizer Item",
+			"company": "_Test Company",
+			"price_list": "_Test Price List",
+			"currency": "INR",
+			"doctype": "Sales Invoice",
+			"conversion_rate": 1,
+			"price_list_currency": "_Test Currency",
+			"plc_conversion_rate": 1,
+			"order_type": "Sales",
+			"customer": "_Test Customer",
+			"name": None,
+			"transaction_date": frappe.utils.nowdate()
+		})
+
+		details = get_item_details(args)
+		self.assertEqual(details.price_list_rate, 100.0)
+
 	def test_pricing_rule_for_transaction(self):
 		make_item("Water Flask 1")
 		frappe.delete_doc_if_exists('Pricing Rule', '_Test Pricing Rule')

--- a/erpnext/accounts/doctype/pricing_rule/utils.py
+++ b/erpnext/accounts/doctype/pricing_rule/utils.py
@@ -264,6 +264,11 @@ def filter_pricing_rules(args, pricing_rules, doc=None):
 			else:
 				p.variant_of = None
 
+	if len(pricing_rules) > 1:
+		filtered_rules = list(filter(lambda x: x.currency==args.get('currency'), pricing_rules))
+		if filtered_rules:
+			pricing_rules = filtered_rules
+
 	# find pricing rule with highest priority
 	if pricing_rules:
 		max_priority = max(cint(p.priority) for p in pricing_rules)


### PR DESCRIPTION
**Issue**

Create two different pricing rules for the same item with different currency and different Rate and set priority to high to the currency INR

<img width="1054" alt="Screenshot 2021-11-16 at 7 46 56 PM" src="https://user-images.githubusercontent.com/8780500/142001777-fed04096-fb3c-44d9-a4e8-6b90a3a423e0.png">

In the transaction, select the currency as USD and check 
System fetched the Pricing Rule with the currency as INR and not the Pricing Rule with currency as USD

Expected Output

System should fetch the pricing rule as per Transaction Currency

