### PR TITLE
fix: performance issue while submitting the Journal Entry

### DIFF
--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -463,11 +463,14 @@ def get_customer_list(doctype, txt, searchfield, start, page_len, filters=None):
 
 
 def check_credit_limit(customer, company, ignore_outstanding_sales_order=False, extra_amount=0):
+	credit_limit = get_credit_limit(customer, company)
+	if not credit_limit:
+		return
+
 	customer_outstanding = get_customer_outstanding(customer, company, ignore_outstanding_sales_order)
 	if extra_amount > 0:
 		customer_outstanding += flt(extra_amount)
 
-	credit_limit = get_credit_limit(customer, company)
 	if credit_limit > 0 and flt(customer_outstanding) > credit_limit:
 		msgprint(_("Credit limit has been crossed for customer {0} ({1}/{2})")
 			.format(customer, customer_outstanding, credit_limit))


### PR DESCRIPTION
While submitting the Journal Entry user were getting the Timeout Error. During profiling we came to know that the check_credit_limit method taking time, even though user has not setup the credit limit in the customer master or customer group or in the company master.

Found below query in the processlist which was taking time. System run this query before to check whether the credit limit has set in the customer master or not

<img width="1434" alt="Screenshot 2021-11-16 at 11 51 45 PM" src="https://user-images.githubusercontent.com/8780500/142141543-0747e4bd-6b8f-46ee-8719-60651ec3a0e1.png">

**After Fix**

System has submitted journal entry within 20 seconds
 