### PR TITLE
fix: (style) Warehouse Capacity Dashboard UI

### DIFF
--- a/erpnext/stock/page/warehouse_capacity_summary/warehouse_capacity_summary.html
+++ b/erpnext/stock/page/warehouse_capacity_summary/warehouse_capacity_summary.html
@@ -1,19 +1,19 @@
 {% for d in data %}
 	<div class="dashboard-list-item" style="padding: 7px 15px;">
 		<div class="row">
-			<div class="col-sm-2 small" style="margin-top: 8px;">
+			<div class="col-sm-2" style="margin-top: 8px;">
 				<a data-type="warehouse" data-name="{{ d.warehouse }}">{{ d.warehouse }}</a>
 			</div>
-			<div class="col-sm-2 small" style="margin-top: 8px; ">
+			<div class="col-sm-2" style="margin-top: 8px; ">
 				<a data-type="item" data-name="{{ d.item_code }}">{{ d.item_code }}</a>
 			</div>
-			<div class="col-sm-1 small" style="margin-top: 8px; ">
+			<div class="col-sm-1" style="margin-top: 8px; ">
 				{{ d.stock_capacity }}
 			</div>
-			<div class="col-sm-2 small" style="margin-top: 8px; ">
+			<div class="col-sm-2" style="margin-top: 8px; ">
 				{{ d.actual_qty }}
 			</div>
-			<div class="col-sm-2 small">
+			<div class="col-sm-2">
 				<div class="progress" title="Occupied Qty: {{ d.actual_qty }}" style="margin-bottom: 4px; height: 7px; margin-top: 14px;">
 					<div class="progress-bar" role="progressbar"
 						aria-valuenow="{{ d.percent_occupied }}"
@@ -23,16 +23,19 @@
 					</div>
 				</div>
 			</div>
-			<div class="col-sm-1 small" style="margin-top: 8px;">
+			<div class="col-sm-1" style="margin-top: 8px;">
 				{{ d.percent_occupied }}%
 			</div>
 			{% if can_write %}
-			<div class="col-sm-1 text-right" style="margin-top: 2px;">
-				<button class="btn btn-default btn-xs btn-edit"
-				style="margin-top: 4px;margin-bottom: 4px;"
-				data-warehouse="{{ d.warehouse }}"
-				data-item="{{ escape(d.item_code) }}"
-				data-company="{{ escape(d.company) }}">{{ __("Edit Capacity") }}</a>
+			<div class="col-sm-2 text-right" style="margin-top: 2px;">
+				<button
+					class="btn btn-default btn-xs btn-edit"
+					style="margin: 4px 0; float: left;"
+					data-warehouse="{{ d.warehouse }}"
+					data-item="{{ escape(d.item_code) }}"
+					data-company="{{ escape(d.company) }}">
+					{{ __("Edit Capacity") }}
+				</button>
 			</div>
 			{% endif %}
 		</div>

--- a/erpnext/stock/page/warehouse_capacity_summary/warehouse_capacity_summary.js
+++ b/erpnext/stock/page/warehouse_capacity_summary/warehouse_capacity_summary.js
@@ -4,7 +4,7 @@ frappe.pages['warehouse-capacity-summary'].on_page_load = function(wrapper) {
 		title: 'Warehouse Capacity Summary',
 		single_column: true
 	});
-	page.set_secondary_action('Refresh', () => page.capacity_dashboard.refresh(), 'octicon octicon-sync');
+	page.set_secondary_action('Refresh', () => page.capacity_dashboard.refresh(), 'refresh');
 	page.start = 0;
 
 	page.company_field = page.add_field({

--- a/erpnext/stock/page/warehouse_capacity_summary/warehouse_capacity_summary_header.html
+++ b/erpnext/stock/page/warehouse_capacity_summary/warehouse_capacity_summary_header.html
@@ -1,18 +1,18 @@
 <div class="dashboard-list-item" style="padding: 12px 15px;">
 	<div class="row">
-		<div class="col-sm-2 small text-muted" style="margin-top: 8px;">
+		<div class="col-sm-2 text-muted" style="margin-top: 8px;">
 			Warehouse
 		</div>
-		<div class="col-sm-2 small text-muted" style="margin-top: 8px;">
+		<div class="col-sm-2 text-muted" style="margin-top: 8px;">
 			Item
 		</div>
-		<div class="col-sm-1 small text-muted" style="margin-top: 8px;">
+		<div class="col-sm-1 text-muted" style="margin-top: 8px;">
 			Stock Capacity
 		</div>
-		<div class="col-sm-2 small text-muted" style="margin-top: 8px;">
+		<div class="col-sm-2 text-muted" style="margin-top: 8px;">
 			Balance Stock Qty
 		</div>
-		<div class="col-sm-2 small text-muted" style="margin-top: 8px;">
+		<div class="col-sm-2 text-muted" style="margin-top: 8px;">
 			% Occupied
 		</div>
 	</div>


### PR DESCRIPTION
- Made refresh button icon visible
- Edit Capacity button size and alignment
- Medium font on dashboard

**Before:**
<img width="1296" alt="Screenshot 2021-11-17 at 2 25 06 PM" src="https://user-images.githubusercontent.com/25857446/142168667-0da12ce3-41f4-4161-9ccf-681df4c13484.png">

**After:**
<img width="1303" alt="Screenshot 2021-11-17 at 1 31 30 PM" src="https://user-images.githubusercontent.com/25857446/142168307-ee6cb8dc-b442-4688-8bd0-f46a76763ce8.png">
