### PR TITLE
fix: unchecking the "With Operations" in BOM clears operations table

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.js
+++ b/erpnext/manufacturing/doctype/bom/bom.js
@@ -680,12 +680,6 @@ frappe.ui.form.on("BOM Item", "items_remove", function(frm) {
 	erpnext.bom.calculate_total(frm.doc);
 });
 
-frappe.ui.form.on("BOM", "with_operations", function(frm) {
-	if(!cint(frm.doc.with_operations)) {
-		frm.set_value("operations", []);
-	}
-});
-
 frappe.tour['BOM'] = [
 	{
 		fieldname: "item",

--- a/erpnext/manufacturing/doctype/bom/bom.json
+++ b/erpnext/manufacturing/doctype/bom/bom.json
@@ -237,6 +237,7 @@
    "options": "Price List"
   },
   {
+   "depends_on": "with_operations",
    "fieldname": "operations_section",
    "fieldtype": "Section Break",
    "hide_border": 1,
@@ -539,7 +540,7 @@
  "image_field": "image",
  "is_submittable": 1,
  "links": [],
- "modified": "2021-10-27 14:52:04.500251",
+ "modified": "2021-11-18 13:04:16.271975",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "BOM",


### PR DESCRIPTION
Source/Reference: FR-ISS-322190

Before:

https://user-images.githubusercontent.com/63660334/142377877-068cc786-d10b-4742-8f36-55484a86acfd.mov

After:

https://user-images.githubusercontent.com/63660334/142376123-44b0b280-f311-418f-86a4-2cd0e3aa2321.mov

Changes: 
1. Set "depends_on" property for "operations_section".
2. Remove the JS function which was removing "Operations" while un-checking the "With Operations" checkbox in BOM.



 
