### PR TITLE
fix(India): GST category not getting auto updated

### DIFF
--- a/erpnext/regional/doctype/gstr_3b_report/test_gstr_3b_report.py
+++ b/erpnext/regional/doctype/gstr_3b_report/test_gstr_3b_report.py
@@ -105,6 +105,45 @@ class TestGSTR3BReport(unittest.TestCase):
 		gst_settings.round_off_gst_values = 1
 		gst_settings.save()
 
+	def test_gst_category_auto_update(self):
+		if not frappe.db.exists("Customer", "_Test GST Customer With GSTIN"):
+			customer = frappe.get_doc({
+				"customer_group": "_Test Customer Group",
+				"customer_name": "_Test GST Customer With GSTIN",
+				"customer_type": "Individual",
+				"doctype": "Customer",
+				"territory": "_Test Territory"
+			}).insert()
+
+			self.assertEqual(customer.gst_category, 'Unregistered')
+
+		if not frappe.db.exists('Address', '_Test GST Category-1-Billing'):
+			address = frappe.get_doc({
+				"address_line1": "_Test Address Line 1",
+				"address_title": "_Test GST Category-1",
+				"address_type": "Billing",
+				"city": "_Test City",
+				"state": "Test State",
+				"country": "India",
+				"doctype": "Address",
+				"is_primary_address": 1,
+				"phone": "+91 0000000000",
+				"gstin": "29AZWPS7135H1ZG",
+				"gst_state": "Karnataka",
+				"gst_state_number": "29"
+			}).insert()
+
+			address.append("links", {
+				"link_doctype": "Customer",
+				"link_name": "_Test GST Customer With GSTIN"
+			})
+
+			address.save()
+
+		customer.load_from_db()
+		self.assertEqual(customer.gst_category, 'Registered Regular')
+
+
 def make_sales_invoice():
 	si = create_sales_invoice(company="_Test Company GST",
 			customer = '_Test GST Customer',

--- a/erpnext/regional/india/utils.py
+++ b/erpnext/regional/india/utils.py
@@ -77,11 +77,11 @@ def validate_tax_category(doc, method):
 			frappe.throw(_("Intra State tax category for GST State {0} already exists").format(doc.gst_state))
 
 def update_gst_category(doc, method):
-	if hasattr(doc, 'gst_category'):
-		for link in doc.links:
-			if link.link_doctype in ['Customer', 'Supplier']:
-				if doc.get('gstin'):
-					frappe.db.set_value(link.link_doctype, {'name': link.link_name, 'gst_category': 'Unregistered'}, 'gst_category', 'Registered Regular')
+	for link in doc.links:
+		if link.link_doctype in ['Customer', 'Supplier']:
+			meta = frappe.get_meta(link.link_doctype)
+			if doc.get('gstin') and meta.has_field('gst_category'):
+				frappe.db.set_value(link.link_doctype, {'name': link.link_name, 'gst_category': 'Unregistered'}, 'gst_category', 'Registered Regular')
 
 def set_gst_state_and_state_number(doc):
 	if not doc.gst_state:


### PR DESCRIPTION
Fixes bug introduced in https://github.com/frappe/erpnext/pull/28065

GST Category for customer/supplier was not getting auto-updated on setting the Party GSTIN in the address master

The reason for this was that the check was looking for GST category field in address master and since it didn't had that field the GST category was not getting successfully updated

This PR fixes that issues 