### PR TITLE
fix: coa balance rendering bug

### DIFF
--- a/erpnext/accounts/doctype/account/account_tree.js
+++ b/erpnext/accounts/doctype/account/account_tree.js
@@ -78,6 +78,7 @@ frappe.treeview_settings["Account"] = {
 				const format = (value, currency) => format_currency(Math.abs(value), currency);
 
 				if (account.balance!==undefined) {
+					node.parent && node.parent.find('.balance-area').remove();
 					$('<span class="balance-area pull-right">'
 						+ (account.balance_in_account_currency ?
 							(format(account.balance_in_account_currency, account.account_currency) + " / ") : "")


### PR DESCRIPTION
A company with a high volume of GL Entries takes time to display balance alongside the Company in the Chart of Accounts Tree.

![CleanShot 2021-11-19 at 21 03 40](https://user-images.githubusercontent.com/25369014/142649014-bdb0120f-1b77-4883-bae6-6f4796aaa374.png)

 There was a bug, (cannot replicate locally since a low number of GL Entries)
- User opens Chart of Accounts Tree
- Before balances has been rendered, the user expands an account
- Once the balances are rendered, due to expansion, the balance is rendered twice for unknown reasons

Fix:
Remove balances if exists before rendering on any node.