### PR TITLE
fix: bug with qrcode generation due to default print format name

### DIFF
--- a/erpnext/regional/saudi_arabia/utils.py
+++ b/erpnext/regional/saudi_arabia/utils.py
@@ -28,14 +28,22 @@ def create_qr_code(doc, method):
 
 	for field in meta.get_image_fields():
 		if field.fieldname == 'qr_code':
+			from urllib.parse import urlencode
+
 			# Creating public url to print format
 			default_print_format = frappe.db.get_value('Property Setter', dict(property='default_print_format', doc_type=doc.doctype), "value")
 
 			# System Language
 			language = frappe.get_system_settings('language')
 
+			params = urlencode({
+				'format': default_print_format or 'Standard',
+				'_lang': language,
+				'key': doc.get_signature()
+			})
+
 			# creating qr code for the url
-			url = f"{ frappe.utils.get_url() }/{ doc.doctype }/{ doc.name }?format={ default_print_format or 'Standard' }&_lang={ language }&key={ doc.get_signature() }"
+			url = f"{ frappe.utils.get_url() }/{ doc.doctype }/{ doc.name }?{ params }"
 			qr_image = io.BytesIO()
 			url = qr_create(url, error='L')
 			url.png(qr_image, scale=2, quiet_zone=1)


### PR DESCRIPTION
If Default Print Format is in the Urdu language, the QR code generation fails with the below error

`UnicodeEncodeError: 'latin-1' codec can't encode characters in position 57-62: ordinal not in range(256)`

Fix:
Encode the URL parameters before creating a QRCode