### PR TITLE
fix: cost center wise ledger posting for pcv

### DIFF
--- a/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
+++ b/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
@@ -88,9 +88,10 @@ class PeriodClosingVoucher(AccountsController):
 
 		for acc in pl_accounts:
 			if flt(acc.bal_in_company_currency):
+				cost_center = acc.cost_center if self.cost_center_wise_pnl else company_cost_center
 				gl_entry = self.get_gl_dict({
 					"account": self.closing_account_head,
-					"cost_center": acc.cost_center or company_cost_center,
+					"cost_center": cost_center,
 					"finance_book": acc.finance_book,
 					"account_currency": acc.account_currency,
 					"debit_in_account_currency": abs(flt(acc.bal_in_account_currency)) if flt(acc.bal_in_account_currency) > 0 else 0,

--- a/erpnext/accounts/doctype/period_closing_voucher/test_period_closing_voucher.py
+++ b/erpnext/accounts/doctype/period_closing_voucher/test_period_closing_voucher.py
@@ -66,8 +66,8 @@ class TestPeriodClosingVoucher(unittest.TestCase):
 		company = create_company()
 		surplus_account = create_account()
 
-		cost_center1 = create_cost_center("Test Cost Center 1")
-		cost_center2 = create_cost_center("Test Cost Center 2")
+		cost_center1 = create_cost_center("Main")
+		cost_center2 = create_cost_center("Western Branch")
 
 		create_sales_invoice(
 			company=company,
@@ -86,7 +86,10 @@ class TestPeriodClosingVoucher(unittest.TestCase):
 			debit_to="Debtors - TPC"
 		)
 
-		pcv = self.make_period_closing_voucher()
+		pcv = self.make_period_closing_voucher(submit=False)
+		pcv.cost_center_wise_pnl = 1
+		pcv.save()
+		pcv.submit()
 		surplus_account = pcv.closing_account_head
 
 		expected_gle = (
@@ -149,7 +152,7 @@ class TestPeriodClosingVoucher(unittest.TestCase):
 
 		self.assertEqual(pcv_gle, expected_gle)
 
-	def make_period_closing_voucher(self):
+	def make_period_closing_voucher(self, submit=True):
 		surplus_account = create_account()
 		cost_center = create_cost_center("Test Cost Center 1")
 		pcv = frappe.get_doc({
@@ -163,7 +166,8 @@ class TestPeriodClosingVoucher(unittest.TestCase):
 			"remarks": "test"
 		})
 		pcv.insert()
-		pcv.submit()
+		if submit:
+			pcv.submit()
 
 		return pcv
 


### PR DESCRIPTION
Ledger Entries of Period Closing Voucher were posted cost-center wise by default. It is expected to be posted only if `cost_center_wise_pnl` is checked