### PR TITLE
fix: POS Item cart only taxes with amount displayed

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_item_cart.js
+++ b/erpnext/selling/page/point_of_sale/pos_item_cart.js
@@ -502,6 +502,7 @@ erpnext.PointOfSale.ItemCart = class {
 		if (taxes.length) {
 			const currency = this.events.get_frm().doc.currency;
 			const taxes_html = taxes.map(t => {
+				if (t.tax_amount_after_discount_amount == 0.0) return;
 				const description = /[0-9]+/.test(t.description) ? t.description : `${t.description} @ ${t.rate}%`;
 				return `<div class="tax-row">
 					<div class="tax-label">${description}</div>


### PR DESCRIPTION
**Problem:**
---
POS Item cart would display the taxes in **Sales Charges and Taxes Template** as 0.0 even when it is iverriden by **Item Tax Template** applied to the items, it creates a clutter in the screen and is not required.
<img width="700" alt="Screenshot 2021-11-22 at 6 58 43 PM" src="https://user-images.githubusercontent.com/36098155/142870592-60460699-dff6-4cf4-81b6-051b5c6be038.png">

**Solution:**
---
The tax name, rate, amount would only be rendered if it has tax amount != 0
<img width="700" alt="Screenshot 2021-11-22 at 6 56 52 PM" src="https://user-images.githubusercontent.com/36098155/142870577-5c756a7e-b6bd-4ae0-9f80-a6b01d3402db.png">