### PR TITLE
fix: Employee link formatter showing incorrect value for Employee Name

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -751,9 +751,13 @@ frappe.form.link_formatters['Item'] = function(value, doc) {
 }
 
 frappe.form.link_formatters['Employee'] = function(value, doc) {
-	if(doc && doc.employee_name && doc.employee_name !== value) {
-		return value? value + ': ' + doc.employee_name: doc.employee_name;
+	if (doc && value && doc.employee_name && doc.employee_name !== value && doc.employee === value) {
+		return value + ': ' + doc.employee_name;
+	} else if (!value && doc.doctype && doc.employee_name) {
+		// format blank value in child table
+		return doc.employee;
 	} else {
+		// if value is blank in report view or project name and name are the same, return as is
 		return value;
 	}
 }


### PR DESCRIPTION
**Before:**

If a DocType has 2 _Employee_ Link fields and corresponding _Employee Name_ fields, the link formatter appends the _Employee Name_ value incorrectly.

<img width="1038" alt="fetch-from" src="https://user-images.githubusercontent.com/24353136/142879981-e62389ae-2dc1-4da8-afb8-66a4256cd49e.png">


<img width="535" alt="incorrect" src="https://user-images.githubusercontent.com/24353136/142872978-5a89d461-06bb-44b7-814b-42eede636c64.png">


**After:**

Check if the value matches the employee attribute of the doc. Only then append the employee name

![image](https://user-images.githubusercontent.com/24353136/142872644-ee518e88-5acf-48ad-97b5-9a15c83b4445.png)
