### PR TITLE
fix: Display 'Total' before the totals row in the Gross Profit report

### DIFF
--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -265,7 +265,7 @@ class GrossProfitGenerator(object):
 		if self.filters.get("group_by") == "Invoice":
 			self.totals.indent = 0.0
 			self.totals.parent_invoice = ""
-			self.totals.parent = "Total"
+			self.totals.invoice_or_item = "Total"
 			self.si_list.append(self.totals)
 		else:
 			self.grouped_data.append(self.totals)


### PR DESCRIPTION
_Problem:_

In https://github.com/frappe/erpnext/pull/28380, I'd replaced `parent` with `invoice_or_row` as the first column when the Gross Profit report is grouped by Invoice. Around the same time, I'd added a new totals row to the report when grouped by Invoice(https://github.com/frappe/erpnext/pull/28402), which used `parent` to represent the first column. Consequently, after merging https://github.com/frappe/erpnext/pull/28380, the 'Total' in the Totals row is missing.

![Screenshot 2021-11-23 at 6 55 17 AM](https://user-images.githubusercontent.com/25903035/142958602-673c99ca-fb69-43d8-94dc-0bd9d5a3f32a.png)

_Fix:_

Replace `parent` with `invoice_or_item` in the totals row.

![Screenshot 2021-11-23 at 6 56 58 AM](https://user-images.githubusercontent.com/25903035/142958727-07fafa31-8596-4acc-8dcb-84c693851b4a.png)
