### PR TITLE
fix(patch): delete prepared reports before deleting report

### DIFF
--- a/erpnext/patches/v13_0/delete_old_purchase_reports.py
+++ b/erpnext/patches/v13_0/delete_old_purchase_reports.py
@@ -16,6 +16,8 @@ def execute():
 		if frappe.db.exists("Report", report):
 			delete_auto_email_reports(report)
 			check_and_delete_linked_reports(report)
+			for prepared_report in frappe.get_all('Prepared Report', filters={'ref_report_doctype': report}, pluck='name'):
+				frappe.delete_doc("Prepared Report", prepared_report)
 
 			frappe.delete_doc("Report", report)
 

--- a/erpnext/patches/v13_0/delete_old_sales_reports.py
+++ b/erpnext/patches/v13_0/delete_old_sales_reports.py
@@ -14,6 +14,8 @@ def execute():
 		if frappe.db.exists("Report", report):
 			delete_auto_email_reports(report)
 			check_and_delete_linked_reports(report)
+			for prepared_report in frappe.get_all('Prepared Report', filters={'ref_report_doctype': report}, pluck='name'):
+				frappe.delete_doc("Prepared Report", prepared_report)
 
 			frappe.delete_doc("Report", report)
 


### PR DESCRIPTION
v12 to v13 migration fails if prepared reports of certain reports exists in the database.
Closes #25319