### PR TITLE
fix: actual tax conversion in case of multicurrency invoices

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1106,7 +1106,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		$.each(this.frm.doc.taxes || [], function(i, d) {
 			if(d.charge_type == "Actual") {
 				frappe.model.set_value(d.doctype, d.name, "tax_amount",
-					flt(d.tax_amount) / flt(exchange_rate));
+					flt(d.base_tax_amount) / flt(exchange_rate));
 			}
 		});
 	}


### PR DESCRIPTION
Steps to replicate:
- Create a multi-currency Purchase Invoice and modify the exchange rate
- Add an Item and add an Actual Tax of 10$
- Submit the Invoice
- Create Purchase Receipt using Create -> Purchase Receipt
- Check the Actual Tax Amount, it should be incorrect.

This happens because Actual Taxes are re-calculated based on the current exchange rate. And the expression for the same is incorrect. 