### PR TITLE
fix: Customer, Supplier heatmap data not rendering

### DIFF
--- a/erpnext/buying/doctype/supplier/supplier.py
+++ b/erpnext/buying/doctype/supplier/supplier.py
@@ -13,8 +13,8 @@ from frappe.model.naming import set_name_by_naming_series, set_name_from_naming_
 
 from erpnext.accounts.party import (  # noqa
 	get_dashboard_info,
-	validate_party_accounts,
 	get_timeline_data,
+	validate_party_accounts,
 )
 from erpnext.utilities.transaction_base import TransactionBase
 

--- a/erpnext/buying/doctype/supplier/supplier.py
+++ b/erpnext/buying/doctype/supplier/supplier.py
@@ -11,7 +11,7 @@ from frappe.contacts.address_and_contact import (
 )
 from frappe.model.naming import set_name_by_naming_series, set_name_from_naming_options
 
-from erpnext.accounts.party import get_dashboard_info, validate_party_accounts
+from erpnext.accounts.party import get_dashboard_info, validate_party_accounts, get_timeline_data #used for heatmap
 from erpnext.utilities.transaction_base import TransactionBase
 
 

--- a/erpnext/buying/doctype/supplier/supplier.py
+++ b/erpnext/buying/doctype/supplier/supplier.py
@@ -11,7 +11,7 @@ from frappe.contacts.address_and_contact import (
 )
 from frappe.model.naming import set_name_by_naming_series, set_name_from_naming_options
 
-from erpnext.accounts.party import get_dashboard_info, validate_party_accounts, get_timeline_data #used for heatmap
+from erpnext.accounts.party import get_dashboard_info, validate_party_accounts, get_timeline_data # noqa
 from erpnext.utilities.transaction_base import TransactionBase
 
 

--- a/erpnext/buying/doctype/supplier/supplier.py
+++ b/erpnext/buying/doctype/supplier/supplier.py
@@ -11,7 +11,11 @@ from frappe.contacts.address_and_contact import (
 )
 from frappe.model.naming import set_name_by_naming_series, set_name_from_naming_options
 
-from erpnext.accounts.party import get_dashboard_info, validate_party_accounts, get_timeline_data # isort:skip
+from erpnext.accounts.party import (  # noqa
+	get_dashboard_info,
+	validate_party_accounts,
+	get_timeline_data,
+)
 from erpnext.utilities.transaction_base import TransactionBase
 
 

--- a/erpnext/buying/doctype/supplier/supplier.py
+++ b/erpnext/buying/doctype/supplier/supplier.py
@@ -11,7 +11,7 @@ from frappe.contacts.address_and_contact import (
 )
 from frappe.model.naming import set_name_by_naming_series, set_name_from_naming_options
 
-from erpnext.accounts.party import get_dashboard_info, validate_party_accounts, get_timeline_data # noqa
+from erpnext.accounts.party import get_dashboard_info, validate_party_accounts, get_timeline_data # isort:skip
 from erpnext.utilities.transaction_base import TransactionBase
 
 

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -18,7 +18,7 @@ from frappe.model.rename_doc import update_linked_doctypes
 from frappe.utils import cint, cstr, flt, get_formatted_email, today
 from frappe.utils.user import get_users_with_role
 
-from erpnext.accounts.party import get_dashboard_info, validate_party_accounts
+from erpnext.accounts.party import get_dashboard_info, validate_party_accounts, get_timeline_data #used for heatmap
 from erpnext.utilities.transaction_base import TransactionBase
 
 

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -18,7 +18,11 @@ from frappe.model.rename_doc import update_linked_doctypes
 from frappe.utils import cint, cstr, flt, get_formatted_email, today
 from frappe.utils.user import get_users_with_role
 
-from erpnext.accounts.party import get_dashboard_info, validate_party_accounts, get_timeline_data # isort:skip
+from erpnext.accounts.party import (  # noqa
+	get_dashboard_info,
+	validate_party_accounts,
+	get_timeline_data,
+)
 from erpnext.utilities.transaction_base import TransactionBase
 
 

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -20,8 +20,8 @@ from frappe.utils.user import get_users_with_role
 
 from erpnext.accounts.party import (  # noqa
 	get_dashboard_info,
-	validate_party_accounts,
 	get_timeline_data,
+	validate_party_accounts,
 )
 from erpnext.utilities.transaction_base import TransactionBase
 

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -18,7 +18,7 @@ from frappe.model.rename_doc import update_linked_doctypes
 from frappe.utils import cint, cstr, flt, get_formatted_email, today
 from frappe.utils.user import get_users_with_role
 
-from erpnext.accounts.party import get_dashboard_info, validate_party_accounts, get_timeline_data #used for heatmap
+from erpnext.accounts.party import get_dashboard_info, validate_party_accounts, get_timeline_data # noqa
 from erpnext.utilities.transaction_base import TransactionBase
 
 

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -18,7 +18,7 @@ from frappe.model.rename_doc import update_linked_doctypes
 from frappe.utils import cint, cstr, flt, get_formatted_email, today
 from frappe.utils.user import get_users_with_role
 
-from erpnext.accounts.party import get_dashboard_info, validate_party_accounts, get_timeline_data # noqa
+from erpnext.accounts.party import get_dashboard_info, validate_party_accounts, get_timeline_data # isort:skip
 from erpnext.utilities.transaction_base import TransactionBase
 
 


### PR DESCRIPTION
Caused by https://github.com/frappe/erpnext/pull/27302

**Issue:**
The data of heatmap for customer and supplier is not rendered.

**Reason:**
To get the timeline_data to display on heatmap `get_timeline_data` method should be in the customer.py and supplier.py
which was removed since it was considered an unused import. 

**Before:**
![image](https://user-images.githubusercontent.com/30859809/143276321-e065b7f6-052a-46b0-8f97-2fead8038826.png)


**After:**
![image](https://user-images.githubusercontent.com/30859809/143276231-2c427dae-3666-4c39-8c52-411c3eb0fc48.png)

To test this, test with any Customer or Supplier with some transaction history.