### PR TITLE
fix(UX): combine_items checkbox to trigger get_items and sub_assembly button

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.js
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.js
@@ -238,6 +238,12 @@ frappe.ui.form.on('Production Plan', {
 			method: "get_items",
 			freeze: true,
 			doc: frm.doc,
+			callback: function() {
+				frm.refresh_field("po_items");
+				if (frm.doc.sub_assembly_items.length > 0) {
+					frm.trigger("get_sub_assembly_items");
+				}
+			}
 		});
 	},
 


### PR DESCRIPTION
### Issue
- When ticking the **"Consolidate Items"** checkbox, you would need to click on the **"Get Finished Goods for Manufacture"** button to get the combined items.
- Similarly for getting the combined **Sub-Assembly Items**, you would have to click on the button after ticking the checkbox.

![combine_items](https://user-images.githubusercontent.com/43572428/143421313-89479d91-beb0-47d4-a5dd-b6d1e3ffcf59.gif)

### Fix
- On ticking the **"Consolidate Items"** checkbox, the **"Get Finished Goods for Manufacture""** button is triggered. 
- If there are items in the sub-assembly items table before the checkbox is ticked, the **"Get Sub Assembly Items"** button would also get triggered.

![combine_items_fix](https://user-images.githubusercontent.com/43572428/143422441-66456fd5-99a6-49a6-b8be-0c6a73b6ada0.gif)
