### PR TITLE
fix: patch failure due to new doctype

### DIFF
--- a/erpnext/patches/v12_0/move_target_distribution_from_parent_to_child.py
+++ b/erpnext/patches/v12_0/move_target_distribution_from_parent_to_child.py
@@ -7,6 +7,7 @@ import frappe
 
 def execute():
     frappe.reload_doc("setup", "doctype", "target_detail")
+    frappe.reload_doc("core", "doctype", "prepared_report")
 
     for d in ['Sales Person', 'Sales Partner', 'Territory']:
         frappe.db.sql("""


### PR DESCRIPTION
v10 to latest migration is broken because prepared report doctype doesn't exist and in one of patches ERPNext tries to delete a report. 

This patch doesn't even need to be run pre-migration, long term solution: https://github.com/frappe/frappe/issues/15089 