### PR TITLE
fix: purchase to Stock UOM conversion on Production Plan

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -969,20 +969,25 @@ def get_materials_from_other_locations(item, warehouses, new_mr_items, company):
 			new_mr_items.append(new_dict)
 
 	if required_qty:
-		stock_uom, purchase_uom = frappe.db.get_value('Item', item['item_code'], ['stock_uom', 'purchase_uom'])
+		stock_uom, purchase_uom = frappe.db.get_value(
+			'Item', 
+			item['item_code'], 
+			['stock_uom', 'purchase_uom']
+		)
 
-		if stock_uom != purchase_uom and purchase_uom == item['uom']:
+		if purchase_uom != stock_uom and purchase_uom == item['uom']:
 			conversion_factor = get_uom_conversion_factor(item['item_code'], item['uom'])
 			if not (conversion_factor or frappe.flags.show_qty_in_stock_uom):
 				frappe.throw(_("UOM Conversion factor ({0} -> {1}) not found for item: {2}")
 					.format(purchase_uom, stock_uom, item['item_code']))
 
-			required_qty = required_qty / required_qty
+			required_qty = required_qty / conversion_factor
 
-			if frappe.db.get_value("UOM", purchase_uom, "must_be_whole_number"):
-				required_qty = ceil(required_qty)
+		if frappe.db.get_value("UOM", purchase_uom, "must_be_whole_number"):
+			required_qty = ceil(required_qty)
 
 		item["quantity"] = required_qty
+
 		new_mr_items.append(item)
 
 @frappe.whitelist()

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -969,6 +969,19 @@ def get_materials_from_other_locations(item, warehouses, new_mr_items, company):
 			new_mr_items.append(new_dict)
 
 	if required_qty:
+		stock_uom, purchase_uom = frappe.db.get_value('Item', item['item_code'], ['stock_uom', 'purchase_uom'])
+
+		if stock_uom != purchase_uom and purchase_uom == item['uom']:
+			conversion_factor = get_uom_conversion_factor(item['item_code'], item['uom'])
+			if not (conversion_factor or frappe.flags.show_qty_in_stock_uom):
+				frappe.throw(_("UOM Conversion factor ({0} -> {1}) not found for item: {2}")
+					.format(purchase_uom, stock_uom, item['item_code']))
+
+			required_qty = required_qty / required_qty
+
+			if frappe.db.get_value("UOM", purchase_uom, "must_be_whole_number"):
+				required_qty = ceil(required_qty)
+
 		item["quantity"] = required_qty
 		new_mr_items.append(item)
 


### PR DESCRIPTION
The new Production Planning Tool, didnt take into consideration the UOM conversion for items that have a different purchase UOM.

With that, it will generate wrong material requests to purchase!

As a simple case

- Item XPTO (10 units available in stock)
   - Stock UOM: Unit <-- must be a whole number
   - Purchase UOM: Box of 100 <-- must be a whole number

BOM ABC:
     - XPTO - 4 units required

Production Plan for ABC
     - Produce 50 units

Actual Result
     - Stock Transfer of 10 units
     - Purchase Transfer of 40 Box of 100 (leading to 4000 units in Stock)

Expected Result
     - Stock Transfer of 10 units
     - Purchase Transfer of 1 Box of 100 (leading to 100 units in Stock)