### PR TITLE
fix: KeyError for closed status

### DIFF
--- a/erpnext/manufacturing/report/work_order_summary/work_order_summary.py
+++ b/erpnext/manufacturing/report/work_order_summary/work_order_summary.py
@@ -65,7 +65,8 @@ def get_chart_based_on_status(data):
 		"In Process": 0,
 		"Stopped": 0,
 		"Completed": 0,
-		"Draft": 0
+		"Draft": 0,
+		"Closed": 0
 	}
 
 	for d in data:


### PR DESCRIPTION
### Pre-requisite
- Close a **Work Order**.

![image](https://user-images.githubusercontent.com/43572428/143546528-fc01ca9d-31b0-40b9-b473-20598b4529e3.png)


### Issue
![image](https://user-images.githubusercontent.com/43572428/143546587-11501ade-8669-4a80-aa38-9c287dac3f0b.png)

- The error is thrown when trying to open the **Manufacturing Dashboard** if there are "Closed" Work Orders present.
-  There is no key for the "Closed" status.

### Fix
- Added the "Closed" key.

