### PR TITLE
fix: incorrect balance in "Warehouse Wise Item Balance and Age" report

### DIFF
--- a/erpnext/stock/report/warehouse_wise_item_balance_age_and_value/warehouse_wise_item_balance_age_and_value.py
+++ b/erpnext/stock/report/warehouse_wise_item_balance_age_and_value/warehouse_wise_item_balance_age_and_value.py
@@ -46,8 +46,8 @@ def execute(filters=None):
 		item_balance.setdefault((item, item_map[item]["item_group"]), [])
 		total_stock_value = 0.00
 		for wh in warehouse_list:
-			row += [qty_dict.bal_qty] if wh.name in warehouse else [0.00]
-			total_stock_value += qty_dict.bal_val if wh.name in warehouse else 0.00
+			row += [qty_dict.bal_qty] if wh.name == warehouse else [0.00]
+			total_stock_value += qty_dict.bal_val if wh.name == warehouse else 0.00
 
 		item_balance[(item, item_map[item]["item_group"])].append(row)
 		item_value.setdefault((item, item_map[item]["item_group"]),[])


### PR DESCRIPTION
### Pre-requisite
- Create a warehouse that is a substring of another warehouse.
- I created a warehouse named **"Progress - S"** which is a substring of the **"Work In Progress - S"** warehouse.
<details>
<summary>Warehouses</summary>

![image](https://user-images.githubusercontent.com/43572428/143571953-3e391901-baf8-4568-b070-444193f97aee.png)

![image](https://user-images.githubusercontent.com/43572428/143568532-513fa09f-962e-4862-94f3-26946ea64763.png)

</details>
<details>
<summary>Stock Balances</summary>

#### Work In Progress - S = 3107.00

<img width="1296" alt="Screenshot 2021-11-26 at 4 24 11 PM" src="https://user-images.githubusercontent.com/43572428/143570022-271e3491-3a2a-4033-86ba-f7e6013b79b2.png">

#### Progress - S = 1003.00

<img width="1265" alt="Screenshot 2021-11-26 at 4 35 59 PM" src="https://user-images.githubusercontent.com/43572428/143571754-93f0038a-57e2-443b-a099-470e92a923bd.png">


</details>


### Issue
- When viewing the **"Warehouse Wise Item Balance and Age"** report, warehouses that are a substring of another warehouse would also have the qty values of other warehouses. Eg. In this case, Progress - S would display the sum of Progress - S + Work In Progress - S = 3107 + 1003 = 4110 instead of the expected value of 1003.

<img width="1272" alt="Screenshot 2021-11-26 at 4 41 15 PM" src="https://user-images.githubusercontent.com/43572428/143572276-ddf5e55b-c479-4099-a388-72905f7c20b3.png">

### Fix
- Updated condition `if wh.name in warehouse else [0.00]` to `if wh.name == warehouse else [0.00]`

### After Fix

<img width="1276" alt="Screenshot 2021-11-26 at 4 47 26 PM" src="https://user-images.githubusercontent.com/43572428/143573049-936d1fdb-0cac-4985-ad54-84e8fa2221ce.png">


