### PR TITLE
fix: incorrect bin qty on backdated reconciliation

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -199,8 +199,6 @@ class TestWorkOrder(ERPNextTestCase):
 		# no change in reserved / projected
 		self.assertEqual(cint(bin1_on_end_production.reserved_qty_for_production),
 			cint(bin1_on_start_production.reserved_qty_for_production))
-		self.assertEqual(cint(bin1_on_end_production.projected_qty),
-			cint(bin1_on_end_production.projected_qty))
 
 	def test_backflush_qty_for_overpduction_manufacture(self):
 		cancel_stock_entry = []

--- a/erpnext/stock/doctype/bin/bin.py
+++ b/erpnext/stock/doctype/bin/bin.py
@@ -130,8 +130,8 @@ def update_stock(bin_name, args, allow_negative_stock=False, via_landed_cost_vou
 	"""WARNING: This function is deprecated. Inline this function instead of using it."""
 	from erpnext.stock.stock_ledger import repost_current_voucher
 
-	update_qty(bin_name, args)
 	repost_current_voucher(args, allow_negative_stock, via_landed_cost_voucher)
+	update_qty(bin_name, args)
 
 def get_bin_details(bin_name):
 	return frappe.db.get_value('Bin', bin_name, ['actual_qty', 'ordered_qty',
@@ -139,13 +139,23 @@ def get_bin_details(bin_name):
 	'reserved_qty_for_sub_contract'], as_dict=1)
 
 def update_qty(bin_name, args):
-	bin_details = get_bin_details(bin_name)
+	from erpnext.controllers.stock_controller import future_sle_exists
 
-	# update the stock values (for current quantities)
-	if args.get("voucher_type")=="Stock Reconciliation":
-		actual_qty = args.get('qty_after_transaction')
-	else:
-		actual_qty = bin_details.actual_qty + flt(args.get("actual_qty"))
+	bin_details = get_bin_details(bin_name)
+	# actual qty is already updated by processing current voucher
+	actual_qty = bin_details.actual_qty
+
+	# actual qty is not up to date in case of backdated transaction
+	if future_sle_exists(args):
+		actual_qty = frappe.db.get_value("Stock Ledger Entry",
+				filters={
+					"item_code": args.get("item_code"),
+					"warehouse": args.get("warehouse"),
+					"is_cancelled": 0
+				},
+				fieldname="qty_after_transaction",
+				order_by="posting_date desc, posting_time desc, creation desc",
+			) or 0.0
 
 	ordered_qty = flt(bin_details.ordered_qty) + flt(args.get("ordered_qty"))
 	reserved_qty = flt(bin_details.reserved_qty) + flt(args.get("reserved_qty"))

--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
@@ -46,7 +46,7 @@ class RepostItemValuation(Document):
 			self.db_set('status', self.status)
 
 	def on_submit(self):
-		if not frappe.flags.in_test or self.flags.dont_run_in_test:
+		if not frappe.flags.in_test or self.flags.dont_run_in_test or frappe.flags.dont_execute_stock_reposts:
 			return
 
 		frappe.enqueue(repost, timeout=1800, queue='long',
@@ -97,7 +97,8 @@ def repost(doc):
 			return
 
 		doc.set_status('In Progress')
-		frappe.db.commit()
+		if not frappe.flags.in_test:
+			frappe.db.commit()
 
 		repost_sl_entries(doc)
 		repost_gl_entries(doc)

--- a/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
@@ -24,10 +24,14 @@ from erpnext.tests.utils import ERPNextTestCase, change_settings
 
 class TestStockReconciliation(ERPNextTestCase):
 	@classmethod
-	def setUpClass(self):
+	def setUpClass(cls):
 		super().setUpClass()
 		create_batch_or_serial_no_items()
 		frappe.db.set_value("Stock Settings", None, "allow_negative_stock", 1)
+
+	def tearDown(self):
+		frappe.flags.dont_execute_stock_reposts = None
+
 
 	def test_reco_for_fifo(self):
 		self._test_reco_sle_gle("FIFO")
@@ -391,6 +395,41 @@ class TestStockReconciliation(ERPNextTestCase):
 
 		repost_exists = bool(frappe.db.exists("Repost Item Valuation", {"voucher_no": sr.name}))
 		self.assertFalse(repost_exists, msg="Negative stock validation not working on reco cancellation")
+
+	def test_intermediate_sr_bin_update(self):
+		"""Bin should show correct qty even for backdated entries.
+
+			-------------------------------------------
+			| creation | Var | Doc  | Qty | balance qty
+			-------------------------------------------
+			|  1       | SR  | Reco | 10  | 10     (posting date: today+10)
+			|  3       | SR2 | Reco | 11  | 11     (posting date: today+11)
+			|  2       | DN  | DN   | 5   | 6 <-- assert in BIN  (posting date: today+12)
+		"""
+		from erpnext.stock.doctype.delivery_note.test_delivery_note import create_delivery_note
+
+		# repost will make this test useless, qty should update in realtime without reposts
+		frappe.flags.dont_execute_stock_reposts = True
+		frappe.db.rollback()
+
+		item_code = "Backdated-Reco-Cancellation-Item"
+		warehouse = "_Test Warehouse - _TC"
+		create_item(item_code)
+
+		sr = create_stock_reconciliation(item_code=item_code, warehouse=warehouse, qty=10, rate=100,
+			posting_date=add_days(nowdate(), 10))
+
+		dn = create_delivery_note(item_code=item_code, warehouse=warehouse, qty=5, rate=120,
+			posting_date=add_days(nowdate(), 12))
+		old_bin_qty = frappe.db.get_value("Bin", {"item_code": item_code, "warehouse": warehouse}, "actual_qty")
+
+		sr2 = create_stock_reconciliation(item_code=item_code, warehouse=warehouse, qty=11, rate=100,
+			posting_date=add_days(nowdate(), 11))
+		new_bin_qty = frappe.db.get_value("Bin", {"item_code": item_code, "warehouse": warehouse}, "actual_qty")
+
+		self.assertEqual(old_bin_qty + 1, new_bin_qty)
+		frappe.db.rollback()
+
 
 	def test_valid_batch(self):
 		create_batch_item_with_batch("Testing Batch Item 1", "001")

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -65,8 +65,8 @@ def make_sl_entries(sl_entries, allow_negative_stock=False, via_landed_cost_vouc
 			is_stock_item = frappe.get_cached_value('Item', args.get("item_code"), 'is_stock_item')
 			if is_stock_item:
 				bin_name = get_or_make_bin(args.get("item_code"), args.get("warehouse"))
-				update_bin_qty(bin_name, args)
 				repost_current_voucher(args, allow_negative_stock, via_landed_cost_voucher)
+				update_bin_qty(bin_name, args)
 			else:
 				frappe.msgprint(_("Item {0} ignored since it is not a stock item").format(args.get("item_code")))
 


### PR DESCRIPTION
Bin quantities are updated by adding actual_qty from current SLE to
Bin's qty. In stock reconciliation qty is "reset" hence
qty_after_transaction is used to set qty in bin.

However, in the case of backdated stock reconciliation, there are future
transactions that will affect the final sum of quantity available in bin.

Note: This gets auto-corrected after reposting finishes for backdated
transactions, but Bin shows wrong quantity till then. Bin is used in item
dashboard hence it's confusing. Also, reposting is only supposed to be
for valuation, qty should be correct in real-time.

Solution: Instead of overriding Bin's quantity, replace it with last sle qty in case of backdated transactions.

To test:

1. Pick one item - warehouse combination.
2. Create some stock transactions.
3. Open Bin and verify that current quantity is correct.
4. Create a backdated stock reconciliation.
5. Confirm that Bin's quantity matches with stock ledger and stock
   balance. (earlier this used to get reset to whatever stock reco
   quantity was)
6. Cancel the stock reconciliation and verify stock ledger/balance
   again.


Example transactions ordered by creation; more test cases on  https://github.com/frappe/erpnext/pull/26158  

| Transaction | Posting date | Qty | qty in Bin |
| --- | ---  | --- | --- |
| Create A | 0    | +1 | 1 |
| Create B | -1 | 2 (reset via stock reco) | 3  (this used to be 2 before)| 
| Cancel B | -1 | 0 | 1 (this used to be 0 before) |