### PR TITLE
fix: do not add gst fields if no indian company

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -287,7 +287,7 @@ erpnext.patches.v14_0.delete_einvoicing_doctypes
 erpnext.patches.v13_0.custom_fields_for_taxjar_integration          #08-11-2021
 erpnext.patches.v13_0.set_operation_time_based_on_operating_cost
 erpnext.patches.v13_0.validate_options_for_data_field
-erpnext.patches.v13_0.create_gst_payment_entry_fields
+erpnext.patches.v13_0.create_gst_payment_entry_fields #27-11-2021
 erpnext.patches.v14_0.delete_shopify_doctypes
 erpnext.patches.v13_0.fix_invoice_statuses
 erpnext.patches.v13_0.replace_supplier_item_group_with_party_specific_item

--- a/erpnext/patches/v13_0/create_gst_payment_entry_fields.py
+++ b/erpnext/patches/v13_0/create_gst_payment_entry_fields.py
@@ -9,24 +9,29 @@ def execute():
 	frappe.reload_doc('accounts', 'doctype', 'advance_taxes_and_charges')
 	frappe.reload_doc('accounts', 'doctype', 'payment_entry')
 
-	custom_fields = {
-		'Payment Entry': [
-			dict(fieldname='gst_section', label='GST Details', fieldtype='Section Break', insert_after='deductions',
-				print_hide=1, collapsible=1),
-			dict(fieldname='company_address', label='Company Address', fieldtype='Link', insert_after='gst_section',
-				print_hide=1, options='Address'),
-			dict(fieldname='company_gstin', label='Company GSTIN',
-				fieldtype='Data', insert_after='company_address',
-				fetch_from='company_address.gstin', print_hide=1, read_only=1),
-			dict(fieldname='place_of_supply', label='Place of Supply',
-				fieldtype='Data', insert_after='company_gstin',
-				print_hide=1, read_only=1),
-			dict(fieldname='customer_address', label='Customer Address', fieldtype='Link', insert_after='place_of_supply',
-				print_hide=1, options='Address', depends_on = 'eval:doc.party_type == "Customer"'),
-			dict(fieldname='customer_gstin', label='Customer GSTIN',
-				fieldtype='Data', insert_after='customer_address',
-				fetch_from='customer_address.gstin', print_hide=1, read_only=1)
-		]
-	}
+	if frappe.db.exists('Company', {'country': 'India'}):
+		custom_fields = {
+			'Payment Entry': [
+				dict(fieldname='gst_section', label='GST Details', fieldtype='Section Break', insert_after='deductions',
+					print_hide=1, collapsible=1),
+				dict(fieldname='company_address', label='Company Address', fieldtype='Link', insert_after='gst_section',
+					print_hide=1, options='Address'),
+				dict(fieldname='company_gstin', label='Company GSTIN',
+					fieldtype='Data', insert_after='company_address',
+					fetch_from='company_address.gstin', print_hide=1, read_only=1),
+				dict(fieldname='place_of_supply', label='Place of Supply',
+					fieldtype='Data', insert_after='company_gstin',
+					print_hide=1, read_only=1),
+				dict(fieldname='customer_address', label='Customer Address', fieldtype='Link', insert_after='place_of_supply',
+					print_hide=1, options='Address', depends_on = 'eval:doc.party_type == "Customer"'),
+				dict(fieldname='customer_gstin', label='Customer GSTIN',
+					fieldtype='Data', insert_after='customer_address',
+					fetch_from='customer_address.gstin', print_hide=1, read_only=1)
+			]
+		}
 
-	create_custom_fields(custom_fields, update=True)
+		create_custom_fields(custom_fields, update=True)
+	else:
+		fields = ['gst_section', 'company_address', 'company_gstin', 'place_of_supply', 'customer_address', 'customer_gstin']
+		for field in fields:
+			frappe.delete_doc_if_exists("Custom Field", f"Payment Entry-{field}")


### PR DESCRIPTION
- Fixes the bug introduced with #26129
The patch for PR doesn't check if there is any company with country India that exists in the system while running the patch; due to this, the Payment Entry has a GST section irrespective of whether a company with country India exists in the system.
