### PR TITLE
feat: Allow addition of custom product search box

### DIFF
--- a/erpnext/e_commerce/product_ui/search.js
+++ b/erpnext/e_commerce/product_ui/search.js
@@ -1,7 +1,10 @@
 erpnext.ProductSearch = class {
-	constructor() {
+	constructor(opts) {
+		/* Options: search_box_class (for custom search box) */
+		$.extend(this, opts);
 		this.MAX_RECENT_SEARCHES = 4;
-		this.searchBox = $("#search-box");
+		this.search_box_class = this.search_box_class || "#search-box"
+		this.searchBox = $(this.search_box_class);
 
 		this.setupSearchDropDown();
 		this.bindSearchAction();
@@ -24,7 +27,7 @@ erpnext.ProductSearch = class {
 		// If click occurs outside search input/results, hide results.
 		// Click can happen anywhere on the page
 		$("body").on("click", (e) => {
-			let searchEvent = $(e.target).closest('#search-box').length;
+			let searchEvent = $(e.target).closest(this.search_box_class).length;
 			let resultsEvent = $(e.target).closest('#search-results-container').length;
 			let isResultHidden = this.search_dropdown.hasClass("hidden");
 

--- a/erpnext/e_commerce/product_ui/search.js
+++ b/erpnext/e_commerce/product_ui/search.js
@@ -3,7 +3,7 @@ erpnext.ProductSearch = class {
 		/* Options: search_box_class (for custom search box) */
 		$.extend(this, opts);
 		this.MAX_RECENT_SEARCHES = 4;
-		this.search_box_class = this.search_box_class || "#search-box"
+		this.search_box_class = this.search_box_class || "#search-box";
 		this.searchBox = $(this.search_box_class);
 
 		this.setupSearchDropDown();

--- a/erpnext/e_commerce/product_ui/search.js
+++ b/erpnext/e_commerce/product_ui/search.js
@@ -1,10 +1,10 @@
 erpnext.ProductSearch = class {
 	constructor(opts) {
-		/* Options: search_box_class (for custom search box) */
+		/* Options: search_box_id (for custom search box) */
 		$.extend(this, opts);
 		this.MAX_RECENT_SEARCHES = 4;
-		this.search_box_class = this.search_box_class || "#search-box";
-		this.searchBox = $(this.search_box_class);
+		this.search_box_id = this.search_box_id || "#search-box";
+		this.searchBox = $(this.search_box_id);
 
 		this.setupSearchDropDown();
 		this.bindSearchAction();
@@ -27,7 +27,7 @@ erpnext.ProductSearch = class {
 		// If click occurs outside search input/results, hide results.
 		// Click can happen anywhere on the page
 		$("body").on("click", (e) => {
-			let searchEvent = $(e.target).closest(this.search_box_class).length;
+			let searchEvent = $(e.target).closest(this.search_box_id).length;
 			let resultsEvent = $(e.target).closest('#search-results-container').length;
 			let isResultHidden = this.search_dropdown.hasClass("hidden");
 


### PR DESCRIPTION
- Allow adding/injecting a custom search box anywhere on the site (with custom id)
- Allow passing this id to `erpnext.ProductSearch` to get a functional search running out of the box
- Usage (where input field id="nav-search-box"):
   ```js
       new erpnext.ProductSearch({
            search_box_id: "#nav-search-box"
       });
    ```
- This class defaults to `#search-box` as in core
- E.g:
   <img width="1283" alt="Screenshot 2021-11-29 at 1 53 40 PM" src="https://user-images.githubusercontent.com/25857446/143832516-c6de9d98-9765-4123-b500-d082b9c7de1e.png">

> To whoever customises: both core and custom search boxes cannot co-exist on the same page

`no-docs`

**To test:**
- test if normal product search in e-commerce works correctly, with categories and recent searches.