### PR TITLE
fix: allow creating Shift Assignment for same day

### DIFF
--- a/erpnext/hr/doctype/shift_assignment/shift_assignment.py
+++ b/erpnext/hr/doctype/shift_assignment/shift_assignment.py
@@ -19,8 +19,8 @@ class ShiftAssignment(Document):
 		validate_active_employee(self.employee)
 		self.validate_overlapping_dates()
 
-		if self.end_date and self.end_date <= self.start_date:
-			frappe.throw(_("End Date must not be lesser than Start Date"))
+		if self.end_date:
+			self.validate_from_to_dates('start_date', 'end_date')
 
 	def validate_overlapping_dates(self):
 		if not self.name:


### PR DESCRIPTION
There is a validation that does not allow Shift Assignment creation with the same **Start Date** and **End Date**:

![image](https://user-images.githubusercontent.com/24353136/143858489-ab85c56a-bb60-47a2-863d-6086416d34bc.png)

Removed it so that users can create Shift Assignments for the same day.