### PR TITLE
feat: Show Zero Values filter in consolidated financial statement

### DIFF
--- a/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js
+++ b/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js
@@ -92,6 +92,11 @@ frappe.require("assets/erpnext/js/financial_statements.js", function() {
 				"label": __("Include Default Book Entries"),
 				"fieldtype": "Check",
 				"default": 1
+			},
+			{
+				"fieldname": "show_zero_values",
+				"label": __("Show zero values"),
+				"fieldtype": "Check"
 			}
 		],
 		"formatter": function(value, row, column, data, default_formatter) {

--- a/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py
+++ b/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py
@@ -22,7 +22,11 @@ from erpnext.accounts.report.cash_flow.cash_flow import (
 	get_cash_flow_accounts,
 )
 from erpnext.accounts.report.cash_flow.cash_flow import get_report_summary as get_cash_flow_summary
-from erpnext.accounts.report.financial_statements import get_fiscal_year_data, sort_accounts
+from erpnext.accounts.report.financial_statements import (
+	filter_out_zero_value_rows,
+	get_fiscal_year_data,
+	sort_accounts,
+)
 from erpnext.accounts.report.profit_and_loss_statement.profit_and_loss_statement import (
 	get_chart_data as get_pl_chart_data,
 )
@@ -265,7 +269,7 @@ def get_columns(companies, filters):
 	return columns
 
 def get_data(companies, root_type, balance_must_be, fiscal_year, filters=None, ignore_closing_entries=False):
-	accounts, accounts_by_name = get_account_heads(root_type,
+	accounts, accounts_by_name, parent_children_map = get_account_heads(root_type,
 		companies, filters)
 
 	if not accounts: return []
@@ -293,6 +297,8 @@ def get_data(companies, root_type, balance_must_be, fiscal_year, filters=None, i
 	accumulate_values_into_parents(accounts, accounts_by_name, companies)
 
 	out = prepare_data(accounts, start_date, end_date, balance_must_be, companies, company_currency, filters)
+
+	out = filter_out_zero_value_rows(out, parent_children_map, show_zero_values=filters.get("show_zero_values"))
 
 	if out:
 		add_total_row(out, root_type, balance_must_be, companies, company_currency)
@@ -370,7 +376,7 @@ def get_account_heads(root_type, companies, filters):
 
 	accounts, accounts_by_name, parent_children_map = filter_accounts(accounts)
 
-	return accounts, accounts_by_name
+	return accounts, accounts_by_name, parent_children_map
 
 def update_parent_account_names(accounts):
 	"""Update parent_account_name in accounts list.


### PR DESCRIPTION
Added a filter to filter zero value rows in the Consolidated financial statement

<img width="1334" alt="Screenshot 2021-11-30 at 1 32 33 PM" src="https://user-images.githubusercontent.com/42651287/144009355-b4f79146-efd2-4675-9adc-1083f8034583.png">

From now zero value rows won't be seen by default, only after enabling this filter, zero value rows will be visible

On Enablig the filter:
<img width="927" alt="Screenshot 2021-11-30 at 1 37 24 PM" src="https://user-images.githubusercontent.com/42651287/144009211-7761a0d3-e384-49d5-afe3-ea50b7eac799.png">

On Disabling the filter:
<img width="918" alt="Screenshot 2021-11-30 at 1 37 57 PM" src="https://user-images.githubusercontent.com/42651287/144009276-81a6d900-255f-4f8f-a2cd-855248b8f585.png">

`no-docs`