### PR TITLE
fix(Employee): enable no copy for lft rgt fields

### DIFF
--- a/erpnext/hr/doctype/employee/employee.json
+++ b/erpnext/hr/doctype/employee/employee.json
@@ -726,6 +726,7 @@
    "fieldtype": "Int",
    "hidden": 1,
    "label": "lft",
+   "no_copy": 1,
    "read_only": 1
   },
   {
@@ -733,6 +734,7 @@
    "fieldtype": "Int",
    "hidden": 1,
    "label": "rgt",
+   "no_copy": 1,
    "read_only": 1
   },
   {
@@ -813,11 +815,12 @@
  "idx": 24,
  "image_field": "image",
  "links": [],
- "modified": "2021-06-17 11:31:37.730760",
+ "modified": "2021-11-30 13:54:19.616448",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Employee",
  "name_case": "Title Case",
+ "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
  "permissions": [
   {


### PR DESCRIPTION
**Problem**

1. Create an employee - emp1
2. Duplicate the Document to create another employee - emp2
3. Set "Reports To" field in emp1 as emp2
4. NestedSet throws an error while validating the loop

![image](https://user-images.githubusercontent.com/24353136/144012633-6d1955a1-fac9-42bc-bb18-6f2b2c140847.png)

**Fix**:

When you duplicate the employee the Left Index and Right Index fields also get copied so when you try to rebuild the hierarchy by setting Reports To, it will throw this error as lft and rgt are same for both the docs.

Enabled no copy for these fields

