### PR TITLE
fix: Unable to search project by project name and other search fields in Sales Invoice

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -517,15 +517,6 @@ cur_frm.fields_dict.write_off_cost_center.get_query = function(doc) {
 	}
 }
 
-// project name
-//--------------------------
-cur_frm.fields_dict['project'].get_query = function(doc, cdt, cdn) {
-	return{
-		query: "erpnext.controllers.queries.get_project_name",
-		filters: {'customer': doc.customer}
-	}
-}
-
 // Income Account in Details Table
 // --------------------------------
 cur_frm.set_query("income_account", "items", function(doc) {

--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -539,6 +539,10 @@ def get_filtered_dimensions(doctype, txt, searchfield, start, page_len, filters)
 	dimension_filters = get_dimension_filter_map()
 	dimension_filters = dimension_filters.get((filters.get('dimension'),filters.get('account')))
 	query_filters = []
+	or_filters = []
+	fields = ['name']
+
+	searchfields = frappe.get_meta(doctype).get_search_fields()
 
 	meta = frappe.get_meta(doctype)
 	if meta.is_tree:
@@ -550,8 +554,9 @@ def get_filtered_dimensions(doctype, txt, searchfield, start, page_len, filters)
 	if meta.has_field('company'):
 		query_filters.append(['company', '=', filters.get('company')])
 
-	if txt:
-		query_filters.append([searchfield, 'LIKE', "%%%s%%" % txt])
+	for field in searchfields:
+		or_filters.append([field, 'LIKE', "%%%s%%" % txt])
+		fields.append(field)
 
 	if dimension_filters:
 		if dimension_filters['allow_or_restrict'] == 'Allow':
@@ -566,10 +571,9 @@ def get_filtered_dimensions(doctype, txt, searchfield, start, page_len, filters)
 
 		query_filters.append(['name', query_selector, dimensions])
 
-	output = frappe.get_list(doctype, filters=query_filters)
-	result = [d.name for d in output]
+	output = frappe.get_list(doctype, fields=fields, filters=query_filters, or_filters=or_filters, as_list=1)
 
-	return [(d,) for d in set(result)]
+	return [tuple(d) for d in set(output)]
 
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs


### PR DESCRIPTION
In accounting doctypes like sales invoice for standard accounting dimensions like project and cost center a custom query is used, this query didn't use to consider searchfields which made it difficult for users to select links like project where most of the projects have naming series and is difficult for the user to know which project is what

Before:
<img width="1336" alt="Screenshot 2021-11-30 at 6 29 44 PM" src="https://user-images.githubusercontent.com/42651287/144051809-0bb6a150-ef89-459c-9432-2a6cd79c1e8e.png">

After:
![image](https://user-images.githubusercontent.com/42651287/144051650-cbb6fd44-83c3-47a1-bdf7-8bf8e6ecf206.png)


closes https://github.com/frappe/erpnext/issues/27345 