### PR TITLE
fix: update `modified` timestamp for delivery note

### DIFF
--- a/erpnext/stock/doctype/delivery_note/delivery_note.json
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.json
@@ -1315,7 +1315,7 @@
  "idx": 146,
  "is_submittable": 1,
  "links": [],
- "modified": "2021-10-08 14:29:13.428984",
+ "modified": "2021-10-09 14:29:13.428984",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Note",


### PR DESCRIPTION
For consistency with https://github.com/frappe/erpnext/pull/28645/commits/8f5b1ea3d2b809cb260bc5ce3b6899ab988fbf2d
This was inadvertently not updated in #27467, but I guess this is no longer a requirement with https://github.com/frappe/frappe/pull/14246