### PR TITLE
fix: get_items method in stock_entry shouldnt raise error

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -1072,7 +1072,7 @@ class StockEntry(StockController):
 		self.set_actual_qty()
 		self.update_items_for_process_loss()
 		self.validate_customer_provided_item()
-		self.calculate_rate_and_amount()
+		self.calculate_rate_and_amount(raise_error_if_no_rate=False)
 
 	def set_scrap_items(self):
 		if self.purpose != "Send to Subcontractor" and self.purpose in ["Manufacture", "Repack"]:


### PR DESCRIPTION
Issue: Some front end dialog boxes that creates a draft Stock Entry errors out because the stock_entry.get_items() method raises an error if an item has no valuation rate. An example of this is the "Start" button in Work Order which if used and a required item has no valuation rate will raise an error which will then lead to the stock entry draft not being created

Fix: set raise_error_if_no_rate=False . This will not affect the validation when a stock entry is submitted
