### PR TITLE
fix: Create Depreciation Schedules for existing Assets accurately

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -353,7 +353,12 @@ class Asset(AccountsController):
 	# if it returns True, depreciation_amount will not be equal for the first and last rows
 	def check_is_pro_rata(self, row):
 		has_pro_rata = False
-		days = date_diff(row.depreciation_start_date, self.available_for_use_date) + 1
+
+		# if not existing asset, from_date = available_for_use_date
+		# otherwise, if number_of_depreciations_booked = 2, available_for_use_date = 01/01/2020 and frequency_of_depreciation = 12
+		# from_date = 01/01/2022
+		from_date = self.get_modified_available_for_use_date(row)
+		days = date_diff(row.depreciation_start_date, from_date) + 1
 
 		# if frequency_of_depreciation is 12 months, total_days = 365
 		total_days = get_total_days(row.depreciation_start_date, row.frequency_of_depreciation)
@@ -362,6 +367,9 @@ class Asset(AccountsController):
 			has_pro_rata = True
 
 		return has_pro_rata
+
+	def get_modified_available_for_use_date(self, row):
+		return add_months(self.available_for_use_date, (self.number_of_depreciations_booked * row.frequency_of_depreciation))
 
 	def validate_asset_finance_books(self, row):
 		if flt(row.expected_value_after_useful_life) >= flt(self.gross_purchase_amount):

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -858,13 +858,11 @@ def get_total_days(date, frequency):
 
 @erpnext.allow_regional
 def get_depreciation_amount(asset, depreciable_value, row):
-	depreciation_left = flt(row.total_number_of_depreciations)
-
 	if row.depreciation_method in ("Straight Line", "Manual"):
 		# if the Depreciation Schedule is being prepared for the first time
 		if not asset.flags.increase_in_asset_life:
 			depreciation_amount = (flt(asset.gross_purchase_amount) -
-				flt(row.expected_value_after_useful_life)) / depreciation_left
+				flt(row.expected_value_after_useful_life)) / flt(row.total_number_of_depreciations)
 
 		# if the Depreciation Schedule is being modified after Asset Repair
 		else:

--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -409,19 +409,18 @@ class TestDepreciationMethods(AssetSetup):
 			calculate_depreciation = 1,
 			available_for_use_date = "2030-06-06",
 			is_existing_asset = 1,
-			number_of_depreciations_booked = 1,
-			opening_accumulated_depreciation = 40000,
+			number_of_depreciations_booked = 2,
+			opening_accumulated_depreciation = 47095.89,
 			expected_value_after_useful_life = 10000,
-			depreciation_start_date = "2030-12-31",
+			depreciation_start_date = "2032-12-31",
 			total_number_of_depreciations = 3,
 			frequency_of_depreciation = 12
 		)
 
 		self.assertEqual(asset.status, "Draft")
 		expected_schedules = [
-			["2030-12-31", 14246.58, 54246.58],
-			["2031-12-31", 25000.00, 79246.58],
-			["2032-06-06", 10753.42, 90000.00]
+			["2032-12-31", 30000.0, 77095.89],
+			["2033-06-06", 12904.11, 90000.0]
 		]
 		schedules = [[cstr(d.schedule_date), flt(d.depreciation_amount, 2), d.accumulated_depreciation_amount]
 			for d in asset.get("schedules")]

--- a/erpnext/regional/india/utils.py
+++ b/erpnext/regional/india/utils.py
@@ -847,12 +847,12 @@ def update_taxable_values(doc, method):
 		doc.get('items')[item_count - 1].taxable_value += diff
 
 def get_depreciation_amount(asset, depreciable_value, row):
-	depreciation_left = flt(row.total_number_of_depreciations) - flt(asset.number_of_depreciations_booked)
+	depreciation_left = flt(row.total_number_of_depreciations)
 
 	if row.depreciation_method in ("Straight Line", "Manual"):
 		# if the Depreciation Schedule is being prepared for the first time
 		if not asset.flags.increase_in_asset_life:
-			depreciation_amount = (flt(asset.gross_purchase_amount) - flt(asset.opening_accumulated_depreciation) -
+			depreciation_amount = (flt(asset.gross_purchase_amount) -
 				flt(row.expected_value_after_useful_life)) / depreciation_left
 
 		# if the Depreciation Schedule is being modified after Asset Repair

--- a/erpnext/regional/india/utils.py
+++ b/erpnext/regional/india/utils.py
@@ -847,13 +847,11 @@ def update_taxable_values(doc, method):
 		doc.get('items')[item_count - 1].taxable_value += diff
 
 def get_depreciation_amount(asset, depreciable_value, row):
-	depreciation_left = flt(row.total_number_of_depreciations)
-
 	if row.depreciation_method in ("Straight Line", "Manual"):
 		# if the Depreciation Schedule is being prepared for the first time
 		if not asset.flags.increase_in_asset_life:
 			depreciation_amount = (flt(asset.gross_purchase_amount) -
-				flt(row.expected_value_after_useful_life)) / depreciation_left
+				flt(row.expected_value_after_useful_life)) / flt(row.total_number_of_depreciations)
 
 		# if the Depreciation Schedule is being modified after Asset Repair
 		else:


### PR DESCRIPTION
## Problem Addressed

Depreciation Schedules for Existing Assets with 

- Gross Purchase Value = x
- Number of Depreciations = y
- Opening Accumulated Depreciation = a
- Number of Depreciations Booked = b

are being created as though they're new Assets with 
- Gross Purchase Value = (x - a) 
- Number of Depreciations = (y - b)

<details>
<summary>Example</summary>

Consider the following Asset:

![Screenshot 2021-12-01 at 11 07 32 PM](https://user-images.githubusercontent.com/25903035/144284933-e353bcc7-581d-4a08-98b5-d61fd12eb9b2.png)

![Screenshot 2021-12-01 at 10 55 07 PM](https://user-images.githubusercontent.com/25903035/144283020-edfd7583-eb84-4a9d-ad84-e1c05e3873cb.png)

![Screenshot 2021-12-01 at 10 55 41 PM](https://user-images.githubusercontent.com/25903035/144283093-e4c7610c-4e78-4b8f-9e2b-374a5bc9e8dd.png)

Its Depreciation Schedule will be created as follows:

![Screenshot 2021-12-01 at 6 18 49 PM](https://user-images.githubusercontent.com/25903035/144283193-b4416605-9371-4c49-bdda-bb67a9a6e921.png)

If this Asset had already been depreciated till 30-10-2021 for Rs 6483.87(i.e, if it were an _Existing Asset_ with _Opening Accumulated Depreciation_ =  Rs 6483.87 and _Number of Depreciations Booked_ = 7), then the Depreciation Schedule should ideally consist of the last four rows alone.

![Screenshot 2021-12-01 at 6 18 49 PM](https://user-images.githubusercontent.com/25903035/144284178-8ba3f4f3-d160-4f2a-9062-4813846f94d1.png)

i.e. it should look like this:

![Screenshot 2021-12-01 at 11 03 42 PM](https://user-images.githubusercontent.com/25903035/144284334-d0d57a8d-9386-49dc-823e-c1797beccaca.png)

However, it currently looks like this instead:

![Screenshot 2021-12-01 at 11 21 02 PM](https://user-images.githubusercontent.com/25903035/144286939-caac47b8-903c-4963-b7cd-969c04e4081a.png)

</details>


