### PR TITLE
chore: change log for v12.27

### DIFF
--- a/erpnext/change_log/v12/v12_27_0.md
+++ b/erpnext/change_log/v12/v12_27_0.md
@@ -1,0 +1,9 @@
+## ERPNext Version 12.27.0 Release Notes
+
+### Fixes & Enhancements
+- Always expect signature in webhook requests for WooCommerce ([#28367](https://github.com/frappe/erpnext/pull/28367))
+- Debit & Credit currency in bank transaction ([#28574](https://github.com/frappe/erpnext/pull/28574))
+- Incorrect balance in "Warehouse Wise Item Balance and Age" report ([#28583](https://github.com/frappe/erpnext/pull/28583))
+- Check if gst_category exists while validating GSTIN ([#28065](https://github.com/frappe/erpnext/pull/28065))
+- Skip empty rows while updating unsaved BOM cost ([#28136](https://github.com/frappe/erpnext/pull/28136))
+- Remove warehouse filter on Batch field for Material Receipt ([#28195](https://github.com/frappe/erpnext/pull/28195))


### PR DESCRIPTION
## ERPNext Version 12.27.0 Release Notes

### Fixes & Enhancements
- Always expect signature in webhook requests for WooCommerce ([#28367](https://github.com/frappe/erpnext/pull/28367))
- Debit & Credit currency in bank transaction ([#28574](https://github.com/frappe/erpnext/pull/28574))
- Incorrect balance in "Warehouse Wise Item Balance and Age" report ([#28583](https://github.com/frappe/erpnext/pull/28583))
- Check if gst_category exists while validating GSTIN ([#28065](https://github.com/frappe/erpnext/pull/28065))
- Skip empty rows while updating unsaved BOM cost ([#28136](https://github.com/frappe/erpnext/pull/28136))
- Remove warehouse filter on Batch field for Material Receipt ([#28195](https://github.com/frappe/erpnext/pull/28195))