### PR TITLE
fix(Non Profit): fetch memberships for 80G certificate by from date only

### DIFF
--- a/erpnext/regional/doctype/tax_exemption_80g_certificate/tax_exemption_80g_certificate.py
+++ b/erpnext/regional/doctype/tax_exemption_80g_certificate/tax_exemption_80g_certificate.py
@@ -82,7 +82,6 @@ class TaxExemption80GCertificate(Document):
 		memberships = frappe.db.get_all('Membership', {
 			'member': self.member,
 			'from_date': ['between', (fiscal_year.year_start_date, fiscal_year.year_end_date)],
-			'to_date': ['between', (fiscal_year.year_start_date, fiscal_year.year_end_date)],
 			'membership_status': ('!=', 'Cancelled')
 		}, ['from_date', 'amount', 'name', 'invoice', 'payment_id'], order_by='from_date')
 


### PR DESCRIPTION
It's possible for a membership to start in the last month of this fiscal year and end in the first month of the next fiscal year. In such a case, this membership will never be fetched in any 80G certificate because it checks for both Start and End dates for memberships.

Ideally, only the **From Date** should be checked since 80G is handed out for payments done and payments are done at the start of the membership period so **To Date** should not come into the picture while fetching memberships.