### PR TITLE
fix: incorrect outgoing rates when material_consumption enabled

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -545,7 +545,7 @@ class StockEntry(StockController):
 		scrap_items_cost = sum([flt(d.basic_amount) for d in self.get("items") if d.is_scrap_item])
 
 		# Get raw materials cost from BOM if multiple material consumption entries
-		if frappe.db.get_single_value("Manufacturing Settings", "material_consumption", cache=True):
+		if not outgoing_items_cost and frappe.db.get_single_value("Manufacturing Settings", "material_consumption", cache=True):
 			bom_items = self.get_bom_raw_materials(finished_item_qty)
 			outgoing_items_cost = sum([flt(row.qty)*flt(row.rate) for row in bom_items.values()])
 

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -41,6 +41,7 @@ def get_sle(**args):
 class TestStockEntry(unittest.TestCase):
 	def tearDown(self):
 		frappe.set_user("Administrator")
+		frappe.db.set_value("Manufacturing Settings", None, "material_consumption", "0")
 
 	def test_fifo(self):
 		frappe.db.set_value("Stock Settings", None, "allow_negative_stock", 1)
@@ -582,6 +583,65 @@ class TestStockEntry(unittest.TestCase):
 		self.assertEqual(fg_cost,
 			flt(rm_cost + bom_operation_cost + work_order.additional_operating_cost, 2))
 
+	def test_work_order_manufacture_with_material_consumption(self):
+		from erpnext.manufacturing.doctype.work_order.work_order import (
+			make_stock_entry as _make_stock_entry,
+		)
+		frappe.db.set_value("Manufacturing Settings", None, "material_consumption", "1")
+
+		bom_no = frappe.db.get_value("BOM", {"item": "_Test FG Item",
+			"is_default": 1, "docstatus": 1})
+
+		work_order = frappe.new_doc("Work Order")
+		work_order.update({
+			"company": "_Test Company",
+			"fg_warehouse": "_Test Warehouse 1 - _TC",
+			"production_item": "_Test FG Item",
+			"bom_no": bom_no,
+			"qty": 1.0,
+			"stock_uom": "_Test UOM",
+			"wip_warehouse": "_Test Warehouse - _TC"
+		})
+		work_order.insert()
+		work_order.submit()
+
+		make_stock_entry(item_code="_Test Item",
+			target="Stores - _TC", qty=10, basic_rate=5000.0)
+		make_stock_entry(item_code="_Test Item Home Desktop 100",
+			target="Stores - _TC", qty=10, basic_rate=1000.0)
+
+
+		s = frappe.get_doc(_make_stock_entry(work_order.name, "Material Transfer for Manufacture", 1))
+		for d in s.get("items"):
+			d.s_warehouse = "Stores - _TC"
+		s.insert()
+		s.submit()
+
+		# When Stock Entry has RM and FG
+		s = frappe.get_doc(_make_stock_entry(work_order.name, "Manufacture", 1))
+		s.save()
+		rm_cost = 0
+		for d in s.get('items'):
+			if d.s_warehouse:
+				rm_cost += d.amount
+		fg_cost = list(filter(lambda x: x.item_code=="_Test FG Item", s.get("items")))[0].amount
+		scrap_cost = list(filter(lambda x: x.is_scrap_item, s.get("items")))[0].amount
+		self.assertEqual(fg_cost,
+			flt(rm_cost - scrap_cost, 2))
+
+		# When Stock Entry has only FG + Scrap
+		s.items.pop(0)
+		s.items.pop(0)
+		s.submit()
+
+		rm_cost = 0
+		for d in s.get('items'):
+			if d.s_warehouse:
+				rm_cost += d.amount
+		self.assertEqual(rm_cost, 0)
+		expected_fg_cost = s.get_basic_rate_for_manufactured_item(1)
+		fg_cost = list(filter(lambda x: x.item_code=="_Test FG Item", s.get("items")))[0].amount
+		self.assertEqual(flt(fg_cost, 2), flt(expected_fg_cost, 2))
 
 	def test_variant_work_order(self):
 		bom_no = frappe.db.get_value("BOM", {"item": "_Test Variant Item",


### PR DESCRIPTION
### Pre-requisite
![image](https://user-images.githubusercontent.com/43572428/144577278-025c518b-d800-4c9f-9319-6eb63ad7a002.png)

- Enable "**Allow Continuous Material Consumption**".

### Issue
- When creating a Manufacture Entry which has the RM and FG, the outgoing rate was calculated based on the BOM and not the RM in the Stock Entry.
- This creates a difference between Incoming and Outgoing Values.

![outgoing_before](https://user-images.githubusercontent.com/43572428/144598799-fd21565d-8f00-416a-99da-e20257d22994.gif)


### Fix

- Even if the setting is enabled, while calculating the outgoing rate, the stock entry should give priority to the RM in the Stock Entry before the RM rates in the BOM.

![outgoing_after](https://user-images.githubusercontent.com/43572428/144599052-20cc4ee1-ec80-4891-a9d7-7dfdd6fd0ace.gif)

### Steps
- Enable the setting.
- Submit a Work Order.
- Create a Material Transfer.
- Click on **Finish** to create a Manufacture Entry.




