### PR TITLE
fix(ksa): qrcode for invoices with special chars

### DIFF
--- a/erpnext/regional/saudi_arabia/utils.py
+++ b/erpnext/regional/saudi_arabia/utils.py
@@ -101,8 +101,10 @@ def create_qr_code(doc, method):
 			url = qr_create(base64_string, error='L')
 			url.png(qr_image, scale=2, quiet_zone=1)
 
+			name = frappe.generate_hash(doc.name, 5)
+
 			# making file
-			filename = f"QR-CODE-{doc.name}.png".replace(os.path.sep, "__")
+			filename = f"QRCode-{name}.png".replace(os.path.sep, "__")
 			_file = frappe.get_doc({
 				"doctype": "File",
 				"file_name": filename,


### PR DESCRIPTION
Fix QRCode image name for invoices that have special characters like #, &, etc.