### PR TITLE
fix(patch): create only component type field instead of running the whole setup

### DIFF
--- a/erpnext/patches/v13_0/check_is_income_tax_component.py
+++ b/erpnext/patches/v13_0/check_is_income_tax_component.py
@@ -3,9 +3,9 @@
 
 
 import frappe
+from frappe.custom.doctype.custom_field.custom_field import create_custom_field
 
 import erpnext
-from erpnext.regional.india.setup import setup
 
 
 def execute():
@@ -30,7 +30,14 @@ def execute():
 		frappe.reload_doc('Regional', 'Report', report)
 
 	if erpnext.get_region() == "India":
-		setup(patch=True)
+		create_custom_field('Salary Component',
+			dict(fieldname='component_type',
+			label='Component Type',
+			fieldtype='Select',
+			insert_after='description',
+			options='\nProvident Fund\nAdditional Provident Fund\nProvident Fund Loan\nProfessional Tax',
+			depends_on='eval:doc.type == "Deduction"')
+		)
 
 	if frappe.db.exists("Salary Component", "Income Tax"):
 		frappe.db.set_value("Salary Component", "Income Tax", "is_income_tax_component", 1)


### PR DESCRIPTION
v12 -> v13 migration breaking

<details>
<summary>Traceback</summary>

```python
Executing erpnext.patches.v13_0.check_is_income_tax_component
(_558b6d72c3c8124c)
Traceback (most recent call last):
  File "/usr/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 104, in <module>
    main()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 19, in main
    click.Group(commands=commands)(prog_name='bench')
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 27, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/site.py", line 309, in migrate
    skip_search_index=skip_search_index
  File "/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py", line 67, in migrate
    frappe.modules.patch_handler.run_all(skip_failing)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 41, in run_all
    run_patch(patch)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 30, in run_patch
    if not run_single(patchmodule = patch):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 71, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 91, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/patches/v13_0/check_is_income_tax_component.py", line 34, in execute
    setup(patch=True)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/regional/india/setup.py", line 22, in setup
    setup_company_independent_fixtures(patch=patch)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/regional/india/setup.py", line 29, in setup_company_independent_fixtures
    make_custom_fields()
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/regional/india/setup.py", line 143, in make_custom_fields
    create_custom_fields(custom_fields, update=update)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/custom/doctype/custom_field/custom_field.py", line 167, in create_custom_fields
    create_custom_field(doctype, df, ignore_validate=ignore_validate)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/custom/doctype/custom_field/custom_field.py", line 142, in create_custom_field
    custom_field.insert()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 231, in insert
    self.run_method("before_insert")
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 860, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1158, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1141, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 854, in <lambda>
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/custom/doctype/custom_field/custom_field.py", line 36, in before_insert
    meta = frappe.get_meta(self.dt, cached=False)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 916, in get_meta
    return frappe.model.meta.get_meta(doctype, cached=cached)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/meta.py", line 43, in get_meta
    return load_meta(doctype)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/meta.py", line 46, in load_meta
    return Meta(doctype)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/meta.py", line 83, in __init__
    super(Meta, self).__init__("DocType", doctype)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 113, in __init__
    self.load_from_db()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/meta.py", line 88, in load_from_db
    super(Meta, self).load_from_db()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 156, in load_from_db
    frappe.throw(_("{0} {1} not found").format(_(self.doctype), self.name), frappe.DoesNotExistError)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 438, in throw
    msgprint(msg, raise_exception=exc, title=title, indicator='red', is_minimizable=is_minimizable, wide=wide, as_list=as_list)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 417, in msgprint
    _raise_exception()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 371, in _raise_exception
    raise raise_exception(msg)
frappe.exceptions.DoesNotExistError: DocType POS Invoice not found
```
</details>

Patch tries to install all custom fields, some prematurely. Install only what's required, the **Component Type** field