### PR TITLE
chore: change log for v13.16.0

### DIFF
--- a/erpnext/change_log/v13/v13_16_0.md
+++ b/erpnext/change_log/v13/v13_16_0.md
@@ -1,0 +1,37 @@
+# Version 13.16.0 Release Notes
+
+### Features & Enhancements
+
+- Accounts, Selling & Assets Onboarding cleanup ([#27112](https://github.com/frappe/erpnext/pull/27112))
+- Create party link from customer/supplier ([#28387](https://github.com/frappe/erpnext/pull/28387))
+
+### Fixes
+- Customer, Supplier heatmap data not rendering ([#28553](https://github.com/frappe/erpnext/pull/28553))
+- Item-Warehouse based reposting ([#28124](https://github.com/frappe/erpnext/pull/28124))
+- Filter out cancelled and non-depreciable Assets in Asset Value Adjustment ([#28443](https://github.com/frappe/erpnext/pull/28443))
+- Allow creating Shift Assignment for same day ([#28613](https://github.com/frappe/erpnext/pull/28613))
+- Taxes and Charges template not getting copied from Purchase Order/Receipt to Invoice ([#28654](https://github.com/frappe/erpnext/pull/28654))
+- Invoice amount in KSA E Invoice QR Code ([#28708](https://github.com/frappe/erpnext/pull/28708))
+- Replaced `get_list` with `get_all` for child doctypes ([#28538](https://github.com/frappe/erpnext/pull/28538))
+- Don't requeue repost immediately and clear progress ([#28684](https://github.com/frappe/erpnext/pull/28684))
+- Employee Advance paid amount not updated on PE cancellation ([#28572](https://github.com/frappe/erpnext/pull/28572))
+- COA balance rendering bug ([#28468](https://github.com/frappe/erpnext/pull/28468))
+- The combine items checkbox to trigger get_items and sub_assembly button ([#28558](https://github.com/frappe/erpnext/pull/28558))
+- Added missing job card item link in material request ([#28222](https://github.com/frappe/erpnext/pull/28222))
+- Incorrect discount amount set when item is replaced ([#28556](https://github.com/frappe/erpnext/pull/28556))
+- Display 'Total' before the totals row in the Gross Profit report ([#28513](https://github.com/frappe/erpnext/pull/28513))
+- Cost Center wise ledger posting for Period Closing Voucher ([#28477](https://github.com/frappe/erpnext/pull/28477))
+- Allocated Amount in Advances not updated on updating expense amount in Expense Claim ([#28497](https://github.com/frappe/erpnext/pull/28497))
+- Employee link formatter showing incorrect value for Employee Name ([#28504](https://github.com/frappe/erpnext/pull/28504))
+- Remove RM Cost column as cost is not retrievable from Job card ([#28123](https://github.com/frappe/erpnext/pull/28123))
+- Fixed total stock summary UI glitch ([#28564](https://github.com/frappe/erpnext/pull/28564))
+- Shipping Rule picking up old net_rate ([#28302](https://github.com/frappe/erpnext/pull/28302))
+- Changed fields position in the work order form ([#28217](https://github.com/frappe/erpnext/pull/28217))
+- Warehouse Capacity Dashboard UI ([#28431](https://github.com/frappe/erpnext/pull/28431))
+- Fixed broken bom tree view and removed duplicate button ([#28512](https://github.com/frappe/erpnext/pull/28512))
+- Incorrect balance in "Warehouse Wise Item Balance and Age" report ([#28583](https://github.com/frappe/erpnext/pull/28583))
+- Tax Withholding for Advances using Payment Entry against suppliers ([#27348](https://github.com/frappe/erpnext/pull/27348))
+- Removed abbreviation renaming ([#27766](https://github.com/frappe/erpnext/pull/27766))
+- Accepted/Rejected/Received Qty UX ([#28269](https://github.com/frappe/erpnext/pull/28269))
+- QR Code as per ZATKA specification ([#28605](https://github.com/frappe/erpnext/pull/28605))
+- POS Item cart only taxes with amount displayed ([#28501](https://github.com/frappe/erpnext/pull/28501))


### PR DESCRIPTION
# Version 13.16.0 Release Notes

### Features & Enhancements

- Accounts, Selling & Assets Onboarding cleanup ([#27112](https://github.com/frappe/erpnext/pull/27112))
- Create party link from customer/supplier ([#28387](https://github.com/frappe/erpnext/pull/28387))

### Fixes
- Customer, Supplier heatmap data not rendering ([#28553](https://github.com/frappe/erpnext/pull/28553))
- Item-Warehouse based reposting ([#28124](https://github.com/frappe/erpnext/pull/28124))
- Filter out cancelled and non-depreciable Assets in Asset Value Adjustment ([#28443](https://github.com/frappe/erpnext/pull/28443))
- Allow creating Shift Assignment for same day ([#28613](https://github.com/frappe/erpnext/pull/28613))
- Taxes and Charges template not getting copied from Purchase Order/Receipt to Invoice ([#28654](https://github.com/frappe/erpnext/pull/28654))
- Invoice amount in KSA E Invoice QR Code ([#28708](https://github.com/frappe/erpnext/pull/28708))
- Replaced `get_list` with `get_all` for child doctypes ([#28538](https://github.com/frappe/erpnext/pull/28538))
- Don't requeue repost immediately and clear progress ([#28684](https://github.com/frappe/erpnext/pull/28684))
- Employee Advance paid amount not updated on PE cancellation ([#28572](https://github.com/frappe/erpnext/pull/28572))
- COA balance rendering bug ([#28468](https://github.com/frappe/erpnext/pull/28468))
- The combine items checkbox to trigger get_items and sub_assembly button ([#28558](https://github.com/frappe/erpnext/pull/28558))
- Added missing job card item link in material request ([#28222](https://github.com/frappe/erpnext/pull/28222))
- Incorrect discount amount set when item is replaced ([#28556](https://github.com/frappe/erpnext/pull/28556))
- Display 'Total' before the totals row in the Gross Profit report ([#28513](https://github.com/frappe/erpnext/pull/28513))
- Cost Center wise ledger posting for Period Closing Voucher ([#28477](https://github.com/frappe/erpnext/pull/28477))
- Allocated Amount in Advances not updated on updating expense amount in Expense Claim ([#28497](https://github.com/frappe/erpnext/pull/28497))
- Employee link formatter showing incorrect value for Employee Name ([#28504](https://github.com/frappe/erpnext/pull/28504))
- Remove RM Cost column as cost is not retrievable from Job card ([#28123](https://github.com/frappe/erpnext/pull/28123))
- Fixed total stock summary UI glitch ([#28564](https://github.com/frappe/erpnext/pull/28564))
- Shipping Rule picking up old net_rate ([#28302](https://github.com/frappe/erpnext/pull/28302))
- Changed fields position in the work order form ([#28217](https://github.com/frappe/erpnext/pull/28217))
- Warehouse Capacity Dashboard UI ([#28431](https://github.com/frappe/erpnext/pull/28431))
- Fixed broken bom tree view and removed duplicate button ([#28512](https://github.com/frappe/erpnext/pull/28512))
- Incorrect balance in "Warehouse Wise Item Balance and Age" report ([#28583](https://github.com/frappe/erpnext/pull/28583))
- Tax Withholding for Advances using Payment Entry against suppliers ([#27348](https://github.com/frappe/erpnext/pull/27348))
- Removed abbreviation renaming ([#27766](https://github.com/frappe/erpnext/pull/27766))
- Accepted/Rejected/Received Qty UX ([#28269](https://github.com/frappe/erpnext/pull/28269))
- QR Code as per ZATKA specification ([#28605](https://github.com/frappe/erpnext/pull/28605))
- POS Item cart only taxes with amount displayed ([#28501](https://github.com/frappe/erpnext/pull/28501))