### PR TITLE
refactor: map serial from schedule if only one

### DIFF
--- a/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py
+++ b/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py
@@ -323,10 +323,14 @@ def make_maintenance_visit(source_name, target_doc=None, item_name=None, s_id=No
 		target.maintenance_schedule = source.name
 		target.maintenance_schedule_detail = s_id
 
-	def update_sales(source, target, parent):
+	def update_sales_and_serial(source, target, parent):
 		sales_person = frappe.db.get_value('Maintenance Schedule Detail', s_id, 'sales_person')
 		target.service_person = sales_person
-		target.serial_no = ''
+		serial_nos = get_serial_nos(target.serial_no)
+		if len(serial_nos) == 1:
+			target.serial_no = serial_nos[0]
+		else:
+			target.serial_no = ''
 
 	doclist = get_mapped_doc("Maintenance Schedule", source_name, {
 		"Maintenance Schedule": {
@@ -342,7 +346,7 @@ def make_maintenance_visit(source_name, target_doc=None, item_name=None, s_id=No
 		"Maintenance Schedule Item": {
 			"doctype": "Maintenance Visit Purpose",
 			"condition": lambda doc: doc.item_name == item_name,
-			"postprocess": update_sales
+			"postprocess": update_sales_and_serial
 		}
 	}, target_doc)
 


### PR DESCRIPTION
### Before
- Serial No was not mapped while creating a **Visit** from a **Maintenance Schedule**.

![serial_before](https://user-images.githubusercontent.com/43572428/144802470-47d2e7ba-c65d-41a6-add7-67ebf17835a9.gif)

### Changes
- Serial No is now mapped while creating a **Visit** from a **Maintenance Schedule** if there is only one serial number.

![serial_before](https://user-images.githubusercontent.com/43572428/144802241-48b0582c-4a73-49ca-8fc5-8480efb10a4c.gif)