### PR TITLE
fix(UX): hide RM table(Job Card) if material transfer is against work order

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.js
+++ b/erpnext/manufacturing/doctype/job_card/job_card.js
@@ -75,6 +75,15 @@ frappe.ui.form.on('Job Card', {
 			&& (frm.doc.items || !frm.doc.items.length || frm.doc.for_quantity == frm.doc.transferred_qty)) {
 			frm.trigger("prepare_timer_buttons");
 		}
+
+		if (frm.doc.work_order) {
+			frappe.db.get_value('Work Order', frm.doc.work_order,
+				'transfer_material_against').then((r) => {
+				if (r.message.transfer_material_against == 'Work Order') {
+					frm.set_df_property('items', 'hidden', 1);
+				}
+			});
+		}
 	},
 
 	setup_corrective_job_card: function(frm) {


### PR DESCRIPTION
### Before
![image](https://user-images.githubusercontent.com/43572428/144811191-72ca8283-ab67-49bb-8321-567102e24dd9.png)

- When **"Transfer Material Against"** is set to Work Order, the Raw Materials table was editable and visible in the **Job Card**.

![hide_before](https://user-images.githubusercontent.com/43572428/144812077-73f934dd-7c3e-4960-b02e-b90aa5cef0fc.gif)

### Changes
- The Raw Material table in Job Card is now hidden if the **Transfer Material Against** is set to Work Order.

![hide_after](https://user-images.githubusercontent.com/43572428/144812180-2141b0e2-4099-4f2d-90b4-e7c89e7b00f2.gif)
