### PR TITLE
fix: Ageing in AR/AP report for advances

### DIFF
--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -545,7 +545,9 @@ class ReceivablePayableReport(object):
 
 	def set_ageing(self, row):
 		if self.filters.ageing_based_on == "Due Date":
-			entry_date = row.due_date
+			# use posting date as a fallback for advances posted via journal and payment entry
+			# when ageing viewed by due date
+			entry_date = row.due_date or row.posting_date
 		elif self.filters.ageing_based_on == "Supplier Invoice Date":
 			entry_date = row.bill_date
 		else:


### PR DESCRIPTION
When ageing is viewed by due date no ageing is shown for advances received via Journal Entry or payment as they don't have any Due Date.


This leads to a mismatch in the outstanding amount and the amount when the ageing amount in all the ageing columns is added.

This PR considers the Jounral Entry's  and Payment Entry's posting date as the due date to show the ageing based on due date for such entries   