### PR TITLE
feat: Move "inspection_required" field from "Stock Entry" to "Stock Entry Details"

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -389,7 +389,7 @@ class StockController(AccountsController):
 
 		# return if inspection is not required on document level
 		if ((not inspection_required_fieldname and self.doctype != "Stock Entry") or
-			(self.doctype == "Stock Entry" and not self.inspection_required) or
+			self.doctype == "Stock Entry" or
 			(self.doctype in ["Sales Invoice", "Purchase Invoice"] and not self.update_stock)):
 				return
 

--- a/erpnext/stock/doctype/stock_entry/stock_entry.json
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.json
@@ -25,7 +25,6 @@
   "posting_date",
   "posting_time",
   "set_posting_time",
-  "inspection_required",
   "from_bom",
   "apply_putaway_rule",
   "sb1",
@@ -231,12 +230,6 @@
   },
   {
    "default": "0",
-   "fieldname": "inspection_required",
-   "fieldtype": "Check",
-   "label": "Inspection Required"
-  },
-  {
-   "default": "0",
    "depends_on": "eval:in_list([\"Material Issue\", \"Material Transfer\", \"Manufacture\", \"Repack\", \t\t\t\t\t\"Send to Subcontractor\", \"Material Transfer for Manufacture\", \"Material Consumption for Manufacture\"], doc.purpose)",
    "fieldname": "from_bom",
    "fieldtype": "Check",
@@ -353,9 +346,9 @@
   },
   {
    "fieldname": "scan_barcode",
-   "options": "Barcode",
    "fieldtype": "Data",
-   "label": "Scan Barcode"
+   "label": "Scan Barcode",
+   "options": "Barcode"
   },
   {
    "allow_bulk_edit": 1,
@@ -628,10 +621,11 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2021-08-20 19:19:31.514846",
+ "modified": "2021-12-06 15:08:40.539506",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Entry",
+ "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
  "permissions": [
   {

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -1697,18 +1697,18 @@ class StockEntry(StockController):
 			self._update_percent_field_in_targets(args, update_modified=True)
 
 	def update_quality_inspection(self):
-		if self.inspection_required:
-			reference_type = reference_name = ''
-			if self.docstatus == 1:
-				reference_name = self.name
-				reference_type = 'Stock Entry'
+		reference_type = reference_name = ''
+		if self.docstatus == 1:
+			reference_name = self.name
+			reference_type = 'Stock Entry'
 
-			for d in self.items:
-				if d.quality_inspection:
-					frappe.db.set_value("Quality Inspection", d.quality_inspection, {
-						'reference_type': reference_type,
-						'reference_name': reference_name
-					})
+		for d in self.items:
+			if d.inspection_required and d.quality_inspection:
+				frappe.db.set_value("Quality Inspection", d.quality_inspection, {
+					'reference_type': reference_type,
+					'reference_name': reference_name
+				})
+
 	def set_material_request_transfer_status(self, status):
 		material_requests = []
 		if self.outgoing_stock_entry:

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -753,7 +753,6 @@ class TestStockEntry(unittest.TestCase):
 			create_item(item_code)
 
 		repack = frappe.copy_doc(test_records[3])
-		repack.inspection_required = 1
 		for d in repack.items:
 			if not d.s_warehouse and d.t_warehouse:
 				d.item_code = item_code
@@ -761,6 +760,7 @@ class TestStockEntry(unittest.TestCase):
 				d.uom = "Nos"
 				d.stock_uom = "Nos"
 				d.basic_rate = 5000
+				d.inspection_required = 1
 
 		repack.insert()
 		self.assertRaises(frappe.ValidationError, repack.submit)

--- a/erpnext/stock/doctype/stock_entry_detail/stock_entry_detail.json
+++ b/erpnext/stock/doctype/stock_entry_detail/stock_entry_detail.json
@@ -20,6 +20,7 @@
   "is_scrap_item",
   "quality_inspection",
   "is_process_loss",
+  "inspection_required",
   "subcontracted_item",
   "section_break_8",
   "description",
@@ -550,16 +551,23 @@
    "fieldname": "is_process_loss",
    "fieldtype": "Check",
    "label": "Is Process Loss"
+  },
+  {
+   "default": "0",
+   "fieldname": "inspection_required",
+   "fieldtype": "Check",
+   "label": "Inspection Required"
   }
  ],
  "idx": 1,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2021-06-22 16:47:11.268975",
+ "modified": "2021-12-06 11:36:59.279165",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Entry Detail",
+ "naming_rule": "Random",
  "owner": "Administrator",
  "permissions": [],
  "sort_field": "modified",


### PR DESCRIPTION
#### Source/Reference: FRQ00169

### Feature(s): Stock Entry

_Current Behaviour:_
- When the stock entry is created during the work order cycle and the 'Quality Inspection' is checked then the stock entry can't be submitted until the quality check is performed for all the items in the stack entry. Sometimes the BOM might get very complicated, having 100s of line items. So it is not practical to create quality inspections for all those items to perform the stock entry.

_Proposed Feature:_
- Move the "inspection_required" field from "Stock Entry" to "Stock Entry Details". 
- Which allow the user to require inspection for specific item(s).

<details>
<summary>Images/GIF</summary>

_Before:_

![Screenshot 2021-12-06 at 3 53 35 PM](https://user-images.githubusercontent.com/63660334/144829993-eacd316c-4939-4abb-9be2-0b93e507ba23.png)

_After:_

https://user-images.githubusercontent.com/63660334/144830050-c9745c85-d829-47e3-b0de-a9dffd8d28a2.mov
</details>




