### PR TITLE
fix: ignore mandatory fields while creating WO from SO

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -978,6 +978,7 @@ def make_work_orders(items, sales_order, company, project=None):
 			description=i['description']
 		)).insert()
 		work_order.set_work_order_operations()
+		work_order.flags.ignore_mandatory = True
 		work_order.save()
 		out.append(work_order)
 


### PR DESCRIPTION
If fields are made mandatory from customizations the WO creation simply fails.


To reproduce:
- Make "source warehouse" on Work order mandatory from customization
- Create SO with manufacturing items (with BOM) 
- Create WO from SO. It will fail with "Source warehouse" not set. 