### PR TITLE
fix: Error on creating invoice

### DIFF
--- a/erpnext/regional/india/utils.py
+++ b/erpnext/regional/india/utils.py
@@ -219,6 +219,7 @@ def get_regional_address_details(party_details, doctype, company):
 		return
 
 	if not party_details.place_of_supply: return party_details
+	if not party_details.company_gstin: return party_details
 
 	if ((doctype in ("Sales Invoice", "Delivery Note", "Sales Order") and party_details.company_gstin
 		and party_details.company_gstin[:2] != party_details.place_of_supply[:2]) or (doctype in ("Purchase Invoice",


### PR DESCRIPTION
```Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-13-2021-12-07/apps/frappe/frappe/app.py", line 68, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-13-2021-12-07/apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-13-2021-12-07/apps/frappe/frappe/handler.py", line 31, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-13-2021-12-07/apps/frappe/frappe/handler.py", line 67, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-13-2021-12-07/apps/frappe/frappe/__init__.py", line 1208, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-13-2021-12-07/apps/erpnext/erpnext/accounts/party.py", line 50, in get_party_details
    fetch_payment_terms_template, party_address, company_address, shipping_address, pos_profile)
  File "/home/frappe/benches/bench-version-13-2021-12-07/apps/erpnext/erpnext/accounts/party.py", line 64, in _get_party_details
    party_address, shipping_address = set_address_details(party_details, party, party_type, doctype, company, party_address, company_address, shipping_address)
  File "/home/frappe/benches/bench-version-13-2021-12-07/apps/erpnext/erpnext/accounts/party.py", line 122, in set_address_details
    get_regional_address_details(party_details, doctype, company)
  File "/home/frappe/benches/bench-version-13-2021-12-07/apps/erpnext/erpnext/__init__.py", line 129, in caller
    return frappe.get_attr(regional_overrides[region][fn_name])(*args, **kwargs)
  File "/home/frappe/benches/bench-version-13-2021-12-07/apps/erpnext/erpnext/regional/india/utils.py", line 228, in get_regional_address_details
    default_tax = get_tax_template(master_doctype, company, 0, party_details.company_gstin[:2])
TypeError: 'NoneType' object is not subscriptable
```