### PR TITLE
fix: Maintenance Visit purposes tables is not visible on submission

### DIFF
--- a/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.js
+++ b/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.js
@@ -43,14 +43,11 @@ frappe.ui.form.on('Maintenance Visit', {
 				}
 			});
 		}
-		else {
-			frm.clear_table("purposes");
-		}
-
 		if (!frm.doc.status) {
 			frm.set_value({ status: 'Draft' });
 		}
 		if (frm.doc.__islocal) {
+			frm.clear_table("purposes");
 			frm.set_value({ mntc_date: frappe.datetime.get_today() });
 		}
 	},


### PR DESCRIPTION
### Issue
- For maintenance visits, the purpose table is empty or is not visible on document save or submit.

 ### Fix
- Updated to show an empty purpose table only when the document is not in the draft, saved, or submitted state.