### PR TITLE
fix: validate if asset account is set against company

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -294,8 +294,15 @@ class PurchaseInvoice(BuyingController):
 						item.expense_account = stock_not_billed_account
 
 			elif item.is_fixed_asset and not is_cwip_accounting_enabled(asset_category):
-				item.expense_account = get_asset_category_account('fixed_asset_account', item=item.item_code,
+				asset_category_account = get_asset_category_account('fixed_asset_account', item=item.item_code,
 					company = self.company)
+				if not asset_category_account:
+					form_link = get_link_to_form('Asset Category', asset_category)
+					throw(
+						_("Please set Fixed Asset Account in {} against {}.").format(form_link, self.company),
+						title=_("Missing Account")
+					)
+				item.expense_account = asset_category_account
 			elif item.is_fixed_asset and item.pr_detail:
 				item.expense_account = asset_received_but_not_billed
 			elif not item.expense_account and for_validate:


### PR DESCRIPTION
Problem:
- Asset Category "Office Equipments" has a Fixed Asset Account set for Company 1
- Printer belongs to Asset Category Office Equipments
- Creating Purchase Invoice for Company 2 with Printer as item throws an error "Account is Required", if expense account is not explicitly set

Fix:
- Throw a proper error message if expense account is not found for the asset item

   ![CleanShot 2021-12-08 at 17 35 09](https://user-images.githubusercontent.com/25369014/145206045-0194a43c-a533-45e9-b3e6-689ff016dc2e.png)
