### PR TITLE
fix: deduplicate after finishing the repost

### DIFF
--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
@@ -168,8 +168,8 @@ def repost_entries():
 	for row in riv_entries:
 		doc = frappe.get_doc('Repost Item Valuation', row.name)
 		if doc.status in ('Queued', 'In Progress'):
-			doc.deduplicate_similar_repost()
 			repost(doc)
+			doc.deduplicate_similar_repost()
 
 	riv_entries = get_repost_item_valuation_entries()
 	if riv_entries:


### PR DESCRIPTION
Not really a bug but avoids the potential of prematurely skipping something if a failure occurs and failure isn't resolved.