### PR TITLE
fix: validate pending reposts before freezing stock/account

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
@@ -10,6 +10,8 @@ from frappe.custom.doctype.property_setter.property_setter import make_property_
 from frappe.model.document import Document
 from frappe.utils import cint
 
+from erpnext.stock.utils import check_pending_reposting
+
 
 class AccountsSettings(Document):
 	def on_update(self):
@@ -25,6 +27,7 @@ class AccountsSettings(Document):
 		self.validate_stale_days()
 		self.enable_payment_schedule_in_print()
 		self.toggle_discount_accounting_fields()
+		self.validate_pending_reposts()
 
 	def validate_stale_days(self):
 		if not self.allow_stale and cint(self.stale_days) <= 0:
@@ -56,3 +59,8 @@ class AccountsSettings(Document):
 				make_property_setter(doctype, "additional_discount_account", "mandatory_depends_on", "", "Code", validate_fields_for_doctype=False)
 
 		make_property_setter("Item", "default_discount_account", "hidden", not(enable_discount_accounting), "Check", validate_fields_for_doctype=False)
+
+
+	def validate_pending_reposts(self):
+		if self.acc_frozen_upto:
+			check_pending_reposting(self.acc_frozen_upto)

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -84,6 +84,10 @@ $.extend(erpnext, {
 		});
 	},
 
+	route_to_pending_reposts: (args) => {
+		frappe.set_route('List', 'Repost Item Valuation', args);
+	},
+
 	proceed_save_with_reminders_frequency_change: () => {
 		frappe.ui.hide_open_dialog();
 

--- a/erpnext/stock/utils.py
+++ b/erpnext/stock/utils.py
@@ -12,6 +12,7 @@ import erpnext
 
 
 class InvalidWarehouseCompany(frappe.ValidationError): pass
+class PendingRepostingError(frappe.ValidationError): pass
 
 def get_stock_value_from_bin(warehouse=None, item_code=None):
 	values = {}
@@ -431,7 +432,7 @@ def check_pending_reposting(posting_date: str, throw_error: bool = True) -> bool
 	if reposting_pending and throw_error:
 		msg = _("Stock/Accounts can not be frozen as processing of backdated entries is going on. Please try again later.")
 		frappe.msgprint(msg,
-				raise_exception=frappe.ValidationError,
+				raise_exception=PendingRepostingError,
 				title="Stock Reposting Ongoing",
 				indicator="red",
 				primary_action={

--- a/erpnext/stock/utils.py
+++ b/erpnext/stock/utils.py
@@ -417,3 +417,28 @@ def is_reposting_item_valuation_in_progress():
 		{'docstatus': 1, 'status': ['in', ['Queued','In Progress']]})
 	if reposting_in_progress:
 		frappe.msgprint(_("Item valuation reposting in progress. Report might show incorrect item valuation."), alert=1)
+
+def check_pending_reposting(posting_date: str, throw_error: bool = True) -> bool:
+	"""Check if there are pending reposting job till the specified posting date."""
+
+	filters = {
+		"docstatus": 1,
+		"status": ["in", ["Queued","In Progress", "Failed"]],
+		"posting_date": ["<=", posting_date],
+	}
+
+	reposting_pending =  frappe.db.exists("Repost Item Valuation", filters)
+	if reposting_pending and throw_error:
+		msg = _("Stock/Accounts can not be frozen as processing of backdated entries is going on. Please try again later.")
+		frappe.msgprint(msg,
+				raise_exception=frappe.ValidationError,
+				title="Stock Reposting Ongoing",
+				indicator="red",
+				primary_action={
+					"label": _("Show pending entries"),
+					"client_action": "erpnext.route_to_pending_reposts",
+					"args": filters,
+				}
+			)
+
+	return bool(reposting_pending)


### PR DESCRIPTION
If stock/accounts are frozen before finishing processing of backdated entries it can leave bad data in the ledger. 

Change: stop users from freezing stock if reposting jobs are pending/in progress/failed before the frozen date. 

To test:
1. Create any backdated stock transaction.
2. Try to freeze stock/accounts **after** the posting date of repost item valuation in the previous step. 
3. Try again after 1 hour, it should let you do it (since processing is probably finished)

video:

https://user-images.githubusercontent.com/9079960/145532663-15b54e79-2385-4034-b5b1-923d15a4c988.mov


