### PR TITLE
fix: Currency fix for `cost` field in subscription plan

### DIFF
--- a/erpnext/accounts/doctype/subscription_plan/subscription_plan.json
+++ b/erpnext/accounts/doctype/subscription_plan/subscription_plan.json
@@ -75,7 +75,8 @@
    "fieldname": "cost",
    "fieldtype": "Currency",
    "in_list_view": 1,
-   "label": "Cost"
+   "label": "Cost",
+   "options": "currency"
   },
   {
    "depends_on": "eval:doc.price_determination==\"Based On Price List\"",
@@ -147,7 +148,7 @@
   }
  ],
  "links": [],
- "modified": "2021-08-13 10:53:44.205774",
+ "modified": "2021-12-10 15:24:15.794477",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Subscription Plan",


### PR DESCRIPTION
**Issue:**
The **cost** field of Subscription plan would always have the company currency

<details>
<summary><b>Before:</b></summary>

<img width="700" alt="Screenshot 2021-12-10 at 6 33 49 PM" src="https://user-images.githubusercontent.com/36098155/145578668-08cccb59-71c2-45bc-af4e-12994aeccf37.png">
<img width="700" alt="Screenshot 2021-12-10 at 6 34 06 PM" src="https://user-images.githubusercontent.com/36098155/145578752-81680352-1e74-4655-bb4f-b637424db707.png">

</details>

<details>
<summary><b>After:</b></summary>

<img width="1271" alt="Screenshot 2021-12-10 at 6 39 26 PM" src="https://user-images.githubusercontent.com/36098155/145579071-92bdaa26-16c7-4c25-b7c0-1392e083b90d.png">
<img width="1271" alt="Screenshot 2021-12-10 at 6 39 44 PM" src="https://user-images.githubusercontent.com/36098155/145579112-5c0ddd56-c671-4130-8a29-ea70d5a06a27.png">

</details>

**Fix:**
Picking up the currency from the `currency` link field in the form

steps:
1. create a new Subscription Plan with currency different than the company currency
2. Save and check in the list view if correct one is displayed