### PR TITLE
Update period_closing_voucher.py

### DIFF
--- a/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
+++ b/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
@@ -93,10 +93,10 @@ class PeriodClosingVoucher(AccountsController):
 					"account": self.closing_account_head,
 					"cost_center": cost_center,
 					"finance_book": acc.finance_book,
-					"account_currency": acc.account_currency,
-					"debit_in_account_currency": abs(flt(acc.bal_in_account_currency)) if flt(acc.bal_in_account_currency) > 0 else 0,
+					#"account_currency": acc.account_currency,
+					#"debit_in_account_currency": abs(flt(acc.bal_in_account_currency)) if flt(acc.bal_in_account_currency) > 0 else 0,
 					"debit": abs(flt(acc.bal_in_company_currency)) if flt(acc.bal_in_company_currency) > 0 else 0,
-					"credit_in_account_currency": abs(flt(acc.bal_in_account_currency)) if flt(acc.bal_in_account_currency) < 0 else 0,
+					#"credit_in_account_currency": abs(flt(acc.bal_in_account_currency)) if flt(acc.bal_in_account_currency) < 0 else 0,
 					"credit": abs(flt(acc.bal_in_company_currency)) if flt(acc.bal_in_company_currency) < 0 else 0
 				}, item=acc)
 


### PR DESCRIPTION
Fix: delete account_currency from get_pnl_gl_entry function because closing account head has same company currency  and acc.account_currency may have a different currency

