### PR TITLE
feat: 'Invoice Number' field in Opening Invoice Creation Tool

### DIFF
--- a/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.py
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.py
@@ -201,7 +201,7 @@ def start_import(invoices):
 	names = []
 	for idx, d in enumerate(invoices):
 		try:
-			invoice_number = ''
+			invoice_number = None
 			if d.invoice_number:
 				invoice_number = d.invoice_number
 			publish(idx, len(invoices), d.doctype)

--- a/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.py
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.py
@@ -202,7 +202,6 @@ def start_import(invoices):
 	for idx, d in enumerate(invoices):
 		try:
 			invoice_number = None
-			set_child_names = False
 			if d.invoice_number:
 				invoice_number = d.invoice_number
 			publish(idx, len(invoices), d.doctype)

--- a/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.py
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.py
@@ -201,7 +201,7 @@ def start_import(invoices):
 	names = []
 	for idx, d in enumerate(invoices):
 		try:
-			invoice_number = None
+			invoice_number = ''
 			if d.invoice_number:
 				invoice_number = d.invoice_number
 			publish(idx, len(invoices), d.doctype)

--- a/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.py
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.py
@@ -160,7 +160,7 @@ class OpeningInvoiceCreationTool(Document):
 			"is_pos": 0,
 			"doctype": "Sales Invoice" if self.invoice_type == "Sales" else "Purchase Invoice",
 			"update_stock": 0,
-			"old_invoice_number": row.old_invoice_number
+			"invoice_number": row.invoice_number
 		})
 
 		accounting_dimension = get_accounting_dimensions()
@@ -201,15 +201,15 @@ def start_import(invoices):
 	names = []
 	for idx, d in enumerate(invoices):
 		try:
-			old_invoice_number = ''
+			invoice_number = ''
 			set_child_names = False
-			if d.old_invoice_number:
-				old_invoice_number = d.old_invoice_number
+			if d.invoice_number:
+				invoice_number = d.invoice_number
 				set_child_names = True
 			publish(idx, len(invoices), d.doctype)
 			doc = frappe.get_doc(d)
 			doc.flags.ignore_mandatory = True
-			doc.insert(set_name=old_invoice_number, set_child_names=set_child_names)
+			doc.insert(set_name=invoice_number, set_child_names=set_child_names)
 			doc.submit()
 			frappe.db.commit()
 			names.append(doc.name)

--- a/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.py
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.py
@@ -201,15 +201,14 @@ def start_import(invoices):
 	names = []
 	for idx, d in enumerate(invoices):
 		try:
-			invoice_number = ''
+			invoice_number = None
 			set_child_names = False
 			if d.invoice_number:
 				invoice_number = d.invoice_number
-				set_child_names = True
 			publish(idx, len(invoices), d.doctype)
 			doc = frappe.get_doc(d)
 			doc.flags.ignore_mandatory = True
-			doc.insert(set_name=invoice_number, set_child_names=set_child_names)
+			doc.insert(set_name=invoice_number)
 			doc.submit()
 			frappe.db.commit()
 			names.append(doc.name)

--- a/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.py
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.py
@@ -159,7 +159,8 @@ class OpeningInvoiceCreationTool(Document):
 			frappe.scrub(row.party_type): row.party,
 			"is_pos": 0,
 			"doctype": "Sales Invoice" if self.invoice_type == "Sales" else "Purchase Invoice",
-			"update_stock": 0
+			"update_stock": 0,
+			"old_invoice_number": row.old_invoice_number
 		})
 
 		accounting_dimension = get_accounting_dimensions()
@@ -200,10 +201,15 @@ def start_import(invoices):
 	names = []
 	for idx, d in enumerate(invoices):
 		try:
+			old_invoice_number = ''
+			set_child_names = False
+			if d.old_invoice_number:
+				old_invoice_number = d.old_invoice_number
+				set_child_names = True
 			publish(idx, len(invoices), d.doctype)
 			doc = frappe.get_doc(d)
 			doc.flags.ignore_mandatory = True
-			doc.insert()
+			doc.insert(set_name=old_invoice_number, set_child_names=set_child_names)
 			doc.submit()
 			frappe.db.commit()
 			names.append(doc.name)

--- a/erpnext/accounts/doctype/opening_invoice_creation_tool/test_opening_invoice_creation_tool.py
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool/test_opening_invoice_creation_tool.py
@@ -18,7 +18,7 @@ class TestOpeningInvoiceCreationTool(unittest.TestCase):
 		if not frappe.db.exists("Company", "_Test Opening Invoice Company"):
 			make_company()
 
-	def make_invoices(self, invoice_type="Sales", company=None, party_1=None, party_2=None, invoice_number=''):
+	def make_invoices(self, invoice_type="Sales", company=None, party_1=None, party_2=None, invoice_number=None):
 		doc = frappe.get_single("Opening Invoice Creation Tool")
 		args = get_opening_invoice_creation_dict(invoice_type=invoice_type, company=company,
 			party_1=party_1, party_2=party_2, invoice_number=invoice_number)
@@ -105,6 +105,7 @@ class TestOpeningInvoiceCreationTool(unittest.TestCase):
 		for inv in [sales_inv1, sales_inv2]:
 			doc = frappe.get_doc('Sales Invoice', inv)
 			doc.cancel()
+			doc.delete()
 
 def get_opening_invoice_creation_dict(**args):
 	party = "Customer" if args.get("invoice_type", "Sales") == "Sales" else "Supplier"
@@ -132,7 +133,7 @@ def get_opening_invoice_creation_dict(**args):
 				"due_date": "2016-09-10",
 				"posting_date": "2016-09-05",
 				"temporary_opening_account": get_temporary_opening_account(company),
-				"invoice_number": ""
+				"invoice_number": None
 			}
 		]
 	})

--- a/erpnext/accounts/doctype/opening_invoice_creation_tool/test_opening_invoice_creation_tool.py
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool/test_opening_invoice_creation_tool.py
@@ -95,7 +95,7 @@ class TestOpeningInvoiceCreationTool(unittest.TestCase):
 	def test_renaming_of_invoice_using_invoice_number_field(self):
 		company = "_Test Opening Invoice Company"
 		party_1, party_2 = make_customer("Customer A"), make_customer("Customer B")
-		invoices = self.make_invoices(company=company, party_1=party_1, party_2=party_2, invoice_number="TEST-NEW-INV-11")
+		self.make_invoices(company=company, party_1=party_1, party_2=party_2, invoice_number="TEST-NEW-INV-11")
 
 		sales_inv1 = frappe.get_all('Sales Invoice', filters={'customer':'Customer A'})[0].get("name")
 		sales_inv2 = frappe.get_all('Sales Invoice', filters={'customer':'Customer B'})[0].get("name")

--- a/erpnext/accounts/doctype/opening_invoice_creation_tool/test_opening_invoice_creation_tool.py
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool/test_opening_invoice_creation_tool.py
@@ -105,7 +105,6 @@ class TestOpeningInvoiceCreationTool(unittest.TestCase):
 		for inv in [sales_inv1, sales_inv2]:
 			doc = frappe.get_doc('Sales Invoice', inv)
 			doc.cancel()
-			doc.delete()
 
 def get_opening_invoice_creation_dict(**args):
 	party = "Customer" if args.get("invoice_type", "Sales") == "Sales" else "Supplier"

--- a/erpnext/accounts/doctype/opening_invoice_creation_tool/test_opening_invoice_creation_tool.py
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool/test_opening_invoice_creation_tool.py
@@ -18,10 +18,10 @@ class TestOpeningInvoiceCreationTool(unittest.TestCase):
 		if not frappe.db.exists("Company", "_Test Opening Invoice Company"):
 			make_company()
 
-	def make_invoices(self, invoice_type="Sales", company=None, party_1=None, party_2=None):
+	def make_invoices(self, invoice_type="Sales", company=None, party_1=None, party_2=None, invoice_number=''):
 		doc = frappe.get_single("Opening Invoice Creation Tool")
 		args = get_opening_invoice_creation_dict(invoice_type=invoice_type, company=company,
-			party_1=party_1, party_2=party_2)
+			party_1=party_1, party_2=party_2, invoice_number=invoice_number)
 		doc.update(args)
 		return doc.make_invoices()
 
@@ -92,6 +92,20 @@ class TestOpeningInvoiceCreationTool(unittest.TestCase):
 		# teardown
 		frappe.db.set_value("Company", company, "default_receivable_account", old_default_receivable_account)
 
+	def test_renaming_of_invoice_using_invoice_number_field(self):
+		company = "_Test Opening Invoice Company"
+		party_1, party_2 = make_customer("Customer A"), make_customer("Customer B")
+		invoices = self.make_invoices(company=company, party_1=party_1, party_2=party_2, invoice_number="TEST-NEW-INV-11")
+
+		sales_inv1 = frappe.get_all('Sales Invoice', filters={'customer':'Customer A'})[0].get("name")
+		sales_inv2 = frappe.get_all('Sales Invoice', filters={'customer':'Customer B'})[0].get("name")
+		self.assertEqual(sales_inv1, "TEST-NEW-INV-11")
+
+		#teardown
+		for inv in [sales_inv1, sales_inv2]:
+			doc = frappe.get_doc('Sales Invoice', inv)
+			doc.cancel()
+
 def get_opening_invoice_creation_dict(**args):
 	party = "Customer" if args.get("invoice_type", "Sales") == "Sales" else "Supplier"
 	company = args.get("company", "_Test Company")
@@ -107,7 +121,8 @@ def get_opening_invoice_creation_dict(**args):
 				"item_name": "Opening Item",
 				"due_date": "2016-09-10",
 				"posting_date": "2016-09-05",
-				"temporary_opening_account": get_temporary_opening_account(company)
+				"temporary_opening_account": get_temporary_opening_account(company),
+				"invoice_number": args.get("invoice_number")
 			},
 			{
 				"qty": 2.0,
@@ -116,7 +131,8 @@ def get_opening_invoice_creation_dict(**args):
 				"item_name": "Opening Item",
 				"due_date": "2016-09-10",
 				"posting_date": "2016-09-05",
-				"temporary_opening_account": get_temporary_opening_account(company)
+				"temporary_opening_account": get_temporary_opening_account(company),
+				"invoice_number": ""
 			}
 		]
 	})

--- a/erpnext/accounts/doctype/opening_invoice_creation_tool_item/opening_invoice_creation_tool_item.json
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool_item/opening_invoice_creation_tool_item.json
@@ -107,7 +107,7 @@
    "fieldtype": "Column Break"
   },
   {
-   "description": "Write reference number of the invoices from the previous system",
+   "description": "Reference number of the invoice from the previous system",
    "fieldname": "invoice_number",
    "fieldtype": "Data",
    "label": "Invoice Number"

--- a/erpnext/accounts/doctype/opening_invoice_creation_tool_item/opening_invoice_creation_tool_item.json
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool_item/opening_invoice_creation_tool_item.json
@@ -5,7 +5,7 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "old_invoice_number",
+  "invoice_number",
   "party_type",
   "party",
   "temporary_opening_account",
@@ -108,14 +108,14 @@
   },
   {
    "description": "Write reference number of the invoices from the previous system",
-   "fieldname": "old_invoice_number",
+   "fieldname": "invoice_number",
    "fieldtype": "Data",
-   "label": "Old Invoice Number"
+   "label": "Invoice Number"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2021-12-13 17:48:33.937956",
+ "modified": "2021-12-13 18:15:41.295007",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Opening Invoice Creation Tool Item",

--- a/erpnext/accounts/doctype/opening_invoice_creation_tool_item/opening_invoice_creation_tool_item.json
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool_item/opening_invoice_creation_tool_item.json
@@ -1,9 +1,11 @@
 {
+ "actions": [],
  "creation": "2017-08-29 04:26:36.159247",
  "doctype": "DocType",
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
+  "old_invoice_number",
   "party_type",
   "party",
   "temporary_opening_account",
@@ -103,10 +105,17 @@
   {
    "fieldname": "dimension_col_break",
    "fieldtype": "Column Break"
+  },
+  {
+   "description": "Write reference number of the invoices from the previous system",
+   "fieldname": "old_invoice_number",
+   "fieldtype": "Data",
+   "label": "Old Invoice Number"
   }
  ],
  "istable": 1,
- "modified": "2019-07-25 15:00:00.460695",
+ "links": [],
+ "modified": "2021-12-13 17:48:33.937956",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Opening Invoice Creation Tool Item",


### PR DESCRIPTION
**Description:**
---
- A field to store the Invoice Number of the invoices being imported in the Open Invoice Creation Tool has been added
- If the field has a name the invoice created will have that name instead of the conventional naming series stored in ERPNext
- If empty the series is continued from the last invoice of the series

<details>
<summary><b>Field is populated:</b></summary>
<img src='https://user-images.githubusercontent.com/36098155/145815516-95693d0c-0f4e-4be2-a764-a41778be4682.gif' width='700'>
</details>

<details>
<summary><b>Field is empty:</b></summary>
<img src='https://user-images.githubusercontent.com/36098155/145815534-bc0ef30b-9f62-49e7-9a71-952bb76b6053.gif' width='700'>
</details>

**Steps:**
1. Open **Opening Invoice Creation Tool**
2. Select a Company and Type of invoice, in this case - Sales
3. Add row in Items table with a customer, outstanding amount and add the invoice name after expanding the row
4. Check the newly created invoice in sales invoice list

docs: https://docs.erpnext.com/docs/v13/user/manual/en/accounts/articles/opening-invoice-creation-tool