### PR TITLE
revert: "fix: expected value after useful life validation"

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -495,7 +495,6 @@ class Asset(AccountsController):
 
 				asset_value_after_full_schedule = flt(
 					flt(self.gross_purchase_amount) -
-					flt(self.opening_accumulated_depreciation) -
 					flt(accumulated_depreciation_after_full_schedule), self.precision('gross_purchase_amount'))
 
 				if (row.expected_value_after_useful_life and


### PR DESCRIPTION
The `accumulated_depreciation_after_full_schedule` already includes `opening_accumulated_depreciation`
To validate the PR, the same scenario mentioned in #27539 should work