### PR TITLE
fix:Nonstock item showing in Itemwise Recommended Reorder Level report

### DIFF
--- a/erpnext/stock/report/itemwise_recommended_reorder_level/itemwise_recommended_reorder_level.py
+++ b/erpnext/stock/report/itemwise_recommended_reorder_level/itemwise_recommended_reorder_level.py
@@ -48,6 +48,7 @@ def get_item_info(filters):
 	conditions = [get_item_group_condition(filters.get("item_group"))]
 	if filters.get("brand"):
 		conditions.append("item.brand=%(brand)s")
+	conditions.append("is_stock_item = 1")
 
 	return frappe.db.sql("""select name, item_name, description, brand, item_group,
 		safety_stock, lead_time_days from `tabItem` item where {}"""


### PR DESCRIPTION
### Issue :
For an item where maintain stock is unchecked then there is no Auto-Reorder section for this item. Yet, this item appears in Itemwise Recommended Reorder Level Report

### Fixed Behaviour : 
An item with maintain stock unchecked will not appear in Itemwise Recommended Reorder Level Report.

Fixes #20825