### PR TITLE
fix: can't change valuation_method on item

### DIFF
--- a/erpnext/stock/doctype/item/item.json
+++ b/erpnext/stock/doctype/item/item.json
@@ -361,8 +361,7 @@
    "fieldname": "valuation_method",
    "fieldtype": "Select",
    "label": "Valuation Method",
-   "options": "\nFIFO\nMoving Average",
-   "set_only_once": 1
+   "options": "\nFIFO\nMoving Average"
   },
   {
    "depends_on": "is_stock_item",
@@ -1035,7 +1034,7 @@
  "image_field": "image",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2021-12-03 08:32:03.869294",
+ "modified": "2021-12-14 04:13:16.857534",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Item",


### PR DESCRIPTION
But the underlying cause is in some cases `NULL` is set as default value and then the frontend adds `''` empty string as the valuation method from select field's first value. While most of the code works fine with both of them framework treats `None` != `''` for constant field validation. This kinda feels weird to me. `NULL` implies unset so set only field validation shouldn't kick in here. 

Changes:

1. Remove set only once from item's valuation method. The valuation method can now be changed as long as there are no transactions against it. 



closes https://github.com/frappe/erpnext/issues/16799
closes https://github.com/frappe/erpnext/issues/26369 