### PR TITLE
fix: incorrect logic for  "Reserved Qty for Production"

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -95,7 +95,7 @@ class TestWorkOrder(ERPNextTestCase):
 
 	def test_reserved_qty_for_partial_completion(self):
 		item = "_Test Item"
-		warehouse = create_warehouse("Test Warehouse for reserved_qty - _TC")
+		warehouse = "_Test Warehouse - _TC"
 
 		bin1_at_start = get_bin(item, warehouse)
 

--- a/erpnext/stock/doctype/bin/bin.py
+++ b/erpnext/stock/doctype/bin/bin.py
@@ -43,9 +43,9 @@ class Bin(Document):
 				frappe.qb
 					.from_(wo)
 					.from_(wo_item)
-					.select(Case()
-							.when(wo.skip_transfer == 0, Sum(wo_item.required_qty - wo_item.transferred_qty))
-							.else_(Sum(wo_item.required_qty - wo_item.consumed_qty))
+					.select(Sum(Case()
+							.when(wo.skip_transfer == 0, wo_item.required_qty - wo_item.transferred_qty)
+							.else_(wo_item.required_qty - wo_item.consumed_qty))
 						)
 					.where(
 						(wo_item.item_code == self.item_code)


### PR DESCRIPTION
The query uses `case` to decide what fields to compute reservation on,
this case is outermost statement hence the very first Work order's "Skip
transfer" is considered for ALL work orders.

Solution: move the case inside Sum.

Steps to reproduce:
1. Make work orders for more than 1 qty (with and without skip transfer)
2. Create manufacture and transfer entries.
3. Keep checking reserved production quantities on Bin doctype during this process.

