### PR TITLE
fix: incorrect amount based on payment days in timesheet salary slip

### DIFF
--- a/erpnext/projects/doctype/timesheet/test_timesheet.py
+++ b/erpnext/projects/doctype/timesheet/test_timesheet.py
@@ -20,10 +20,6 @@ class TestTimesheet(unittest.TestCase):
 		for dt in ["Salary Slip", "Salary Structure", "Salary Structure Assignment", "Timesheet"]:
 			frappe.db.sql("delete from `tab%s`" % dt)
 
-		if not frappe.db.exists("Salary Component", "Timesheet Component"):
-			frappe.get_doc({"doctype": "Salary Component", "salary_component": "Timesheet Component"}).insert()
-
-
 	def test_timesheet_billing_amount(self):
 		make_salary_structure_for_timesheet("_T-Employee-00001")
 		timesheet = make_timesheet("_T-Employee-00001", simulate=True, billable=1)
@@ -176,6 +172,9 @@ class TestTimesheet(unittest.TestCase):
 def make_salary_structure_for_timesheet(employee):
 	salary_structure_name = "Timesheet Salary Structure Test"
 	frequency = "Monthly"
+
+	if not frappe.db.exists("Salary Component", "Timesheet Component"):
+		frappe.get_doc({"doctype": "Salary Component", "salary_component": "Timesheet Component"}).insert()
 
 	salary_structure = make_salary_structure(salary_structure_name, frequency, dont_submit=True)
 	salary_structure.salary_component = "Timesheet Component"


### PR DESCRIPTION
backport of: https://github.com/frappe/erpnext/pull/28845

## Problem

1. Create a Salary Structure with "**Salary Slip Based on Timesheet**" enabled.
2. Add other components to the structure with "**Depends on Payment Days**" checked.
3. Create a Salary Slip. If the Payment Days are less than the Total Days, the system won't calculate amounts based on Payment Days for other components.

## Fix

It skips Payment Days calculation for all components when Salary Slip is based on Timesheet. It should only skip payment days calculation for the Timesheet Component and correctly calculate for others.
