### PR TITLE
perf: remove forcing of posting sort index on stock balance report

### DIFF
--- a/erpnext/stock/report/stock_balance/stock_balance.py
+++ b/erpnext/stock/report/stock_balance/stock_balance.py
@@ -167,7 +167,7 @@ def get_stock_ledger_entries(filters, items):
 			sle.company, sle.voucher_type, sle.qty_after_transaction, sle.stock_value_difference,
 			sle.item_code as name, sle.voucher_no, sle.stock_value, sle.batch_no
 		from
-			`tabStock Ledger Entry` sle force index (posting_sort_index)
+			`tabStock Ledger Entry` sle
 		where sle.docstatus < 2 %s %s
 		and is_cancelled = 0
 		order by sle.posting_date, sle.posting_time, sle.creation, sle.actual_qty""" % #nosec


### PR DESCRIPTION
mysql is generally smart enough to figure out which index is better
based on cardinality of index. While posting sort index is better when there are too many SLEs of same items; it's bad when there are many many item-WH combos each with comparatively less SLE count. 

Now we have another index: item_wh which could be better than posting_sort index in some cases. So, let MySQL pick whatever it feels is best. 