### PR TITLE
fix: convert asynchronous field update to synchronous

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -430,12 +430,9 @@ erpnext.utils.select_alternate_items = function(opts) {
 					qty = row.qty;
 				}
 				row[item_field] = d.alternate_item;
-				frm.script_manager.trigger(item_field, row.doctype, row.name)
-					.then(() => {
-						frappe.model.set_value(row.doctype, row.name, 'qty', qty);
-						frappe.model.set_value(row.doctype, row.name,
-							opts.original_item_field, d.item_code);
-					});
+				frappe.model.set_value(row.doctype, row.name, 'qty', qty);
+				frappe.model.set_value(row.doctype, row.name, opts.original_item_field, d.item_code);
+				frm.trigger(item_field, row.doctype, row.name);
 			});
 
 			refresh_field(opts.child_docname);


### PR DESCRIPTION
Issue: When using the Item Alternate button. The field original_item for each item doesn't get properly updated.

To reproduce
1. Create a Stock Entry for a work order with more than a couple of required items.
2. Create Item Alternative for each Item
3. Use the "Item Alternate" button to replace all required items with Item Alternative
4. Open console and print the object cur_frm.doc.items
5. Notice that some items with item alternative doesn't have the original_item field filled out
6. Even after Submission the original_item field isn't filled out



Fix: Change field updates to synchronous

