### PR TITLE
fix: Set cost center for credit entries while posting Depreciation Entries

### DIFF
--- a/erpnext/assets/doctype/asset/depreciation.py
+++ b/erpnext/assets/doctype/asset/depreciation.py
@@ -59,7 +59,7 @@ def make_depreciation_entry(asset_name, date=None):
 				"credit_in_account_currency": d.depreciation_amount,
 				"reference_type": "Asset",
 				"reference_name": asset.name,
-				"cost_center": ""
+				"cost_center": depreciation_cost_center
 			}
 
 			debit_entry = {


### PR DESCRIPTION
_Problem:_

While posting Depreciation Entries, two Accounting Entries- a debit entry and a credit entry- are added in the Journal Entry.

![Screenshot 2021-12-15 at 11 29 58 PM](https://user-images.githubusercontent.com/25903035/146240280-21056800-e596-4adc-bd32-9694dbb3be5d.png)

These entries are supposed to use either the Cost Center specified in the Asset doc or the default Depreciation Cost Center for the Company. However, in v12, this is only being done for Debit Entries, and not Credit Entries, even though Cost Center is a mandatory field for Journal Entries. Consequently, Depreciation Entries are not being posted.

<details>
<summary>Testing Info</summary>

1. Create an Asset in v12 of ERPNext, with Depreciation Posting Date set as any date in the past.
2. Enter Depreciation Cost Center in the Company doc or Cost Center in the Asset doc.
3. Submit the Asset.
4. Expand any of the Depreciation Schedule rows whose Schedule Dates are in the past and click on the 'Make Depreciation Entry' button.

The Depreciation Entries will not be posted, even though the Cost Center was entered.

</details>
