### PR TITLE
fix: Multicurrency invoices using subscription

### DIFF
--- a/erpnext/accounts/doctype/subscription/subscription.py
+++ b/erpnext/accounts/doctype/subscription/subscription.py
@@ -23,6 +23,7 @@ from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
 	get_accounting_dimensions,
 )
 from erpnext.accounts.doctype.subscription_plan.subscription_plan import get_plan_rate
+from erpnext.accounts.party import get_party_account_currency
 
 
 class Subscription(Document):
@@ -354,6 +355,9 @@ class Subscription(Document):
 			invoice.supplier = self.party
 			if frappe.db.get_value('Supplier', self.party, 'tax_withholding_category'):
 				invoice.apply_tds = 1
+
+		### Add party currency to invoice
+		invoice.currency = get_party_account_currency(self.party_type, self.party, self.company)
 
 		## Add dimensions in invoice for subscription:
 		accounting_dimensions = get_accounting_dimensions()

--- a/erpnext/accounts/doctype/subscription/test_subscription.py
+++ b/erpnext/accounts/doctype/subscription/test_subscription.py
@@ -60,15 +60,38 @@ def create_plan():
 		plan.billing_interval_count = 3
 		plan.insert()
 
+	if not frappe.db.exists('Subscription Plan', '_Test Plan Multicurrency'):
+		plan = frappe.new_doc('Subscription Plan')
+		plan.plan_name = '_Test Plan Multicurrency'
+		plan.item = '_Test Non Stock Item'
+		plan.price_determination = "Fixed Rate"
+		plan.cost = 50
+		plan.currency = 'USD'
+		plan.billing_interval = 'Month'
+		plan.billing_interval_count = 1
+		plan.insert()
+
+def create_parties():
 	if not frappe.db.exists('Supplier', '_Test Supplier'):
 		supplier = frappe.new_doc('Supplier')
 		supplier.supplier_name = '_Test Supplier'
 		supplier.supplier_group = 'All Supplier Groups'
 		supplier.insert()
 
+	if not frappe.db.exists('Customer', '_Test Subscription Customer'):
+		customer = frappe.new_doc('Customer')
+		customer.customer_name = '_Test Subscription Customer'
+		customer.billing_currency = 'USD'
+		customer.append('accounts', {
+			'company': '_Test Company',
+			'account': '_Test Receivable USD - _TC'
+		})
+		customer.insert()
+
 class TestSubscription(unittest.TestCase):
 	def setUp(self):
 		create_plan()
+		create_parties()
 
 	def test_create_subscription_with_trial_with_correct_period(self):
 		subscription = frappe.new_doc('Subscription')
@@ -637,3 +660,22 @@ class TestSubscription(unittest.TestCase):
 
 		subscription.process()
 		self.assertEqual(len(subscription.invoices), 1)
+
+	def test_multicurrency_subscription(self):
+		subscription = frappe.new_doc('Subscription')
+		subscription.party_type = 'Customer'
+		subscription.party = '_Test Subscription Customer'
+		subscription.generate_invoice_at_period_start = 1
+		subscription.company = '_Test Company'
+		# select subscription start date as '2018-01-15'
+		subscription.start_date = '2018-01-01'
+		subscription.append('plans', {'plan': '_Test Plan Multicurrency', 'qty': 1})
+		subscription.save()
+
+		subscription.process()
+		self.assertEqual(len(subscription.invoices), 1)
+		self.assertEqual(subscription.status, 'Unpaid')
+
+		# Check the currency of the created invoice
+		currency = frappe.db.get_value('Sales Invoice', subscription.invoices[0].invoice, 'currency')
+		self.assertEqual(currency, 'USD')


### PR DESCRIPTION
The user gets the following error on trying to create an invoice using subscription against a party having billing currency other than the company currency

![image](https://user-images.githubusercontent.com/42651287/146500849-4d73bc9a-de3c-4926-b004-6d4d36358e88.png)

Sets to test the pull request
1. Create a customer with billing currency other than company currency, Eg USD if company currency is INR
<img width="1322" alt="Screenshot 2021-12-17 at 12 18 05 PM" src="https://user-images.githubusercontent.com/42651287/146501575-c52e1d5f-3219-4411-b9af-7c14822b5abb.png">

2. Create a subscription plan in party currency
![image](https://user-images.githubusercontent.com/42651287/146501711-174a4569-3f78-4323-a369-aaa53e882364.png)

3. Create a backdated subscription as per the following details
![image](https://user-images.githubusercontent.com/42651287/146502550-2d44e3c6-18bc-4302-855f-4369e26c2936.png)

4. Click on the fetch subscription updates button on the top right and see if the invoice gets generated successfully
![image](https://user-images.githubusercontent.com/42651287/146502576-e6567e46-25d3-4437-b946-3d70fbedcce1.png)