### PR TITLE
fix: mapping to maintenance visit gets erased

### DIFF
--- a/erpnext/maintenance/doctype/maintenance_schedule/test_maintenance_schedule.py
+++ b/erpnext/maintenance/doctype/maintenance_schedule/test_maintenance_schedule.py
@@ -56,9 +56,14 @@ class TestMaintenanceSchedule(unittest.TestCase):
 
 		ms.submit()
 		s_id = ms.get_pending_data(data_type = "id", item_name = i.item_name, s_date = expected_dates[1])
-		test = make_maintenance_visit(source_name = ms.name, item_name = "_Test Item", s_id = s_id)
+
+		# Check if item is mapped in visit.
+		test_map_visit = make_maintenance_visit(source_name = ms.name, item_name = "_Test Item", s_id = s_id)
+		self.assertEqual(len(test_map_visit.purposes), 1)
+		self.assertEqual(test_map_visit.purposes[0].item_name, "_Test Item")
+
 		visit = frappe.new_doc('Maintenance Visit')
-		visit = test
+		visit = test_map_visit
 		visit.maintenance_schedule = ms.name
 		visit.maintenance_schedule_detail = s_id
 		visit.completion_status = "Partially Completed"

--- a/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.js
+++ b/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.js
@@ -47,7 +47,7 @@ frappe.ui.form.on('Maintenance Visit', {
 			frm.set_value({ status: 'Draft' });
 		}
 		if (frm.doc.__islocal) {
-			frm.clear_table("purposes");
+			frm.doc.maintenance_type == 'Unscheduled' && frm.clear_table("purposes");
 			frm.set_value({ mntc_date: frappe.datetime.get_today() });
 		}
 	},


### PR DESCRIPTION
### Issue
- When trying to create a **Maintenance Visit** via **Maintenance Schedule**, no items get mapped.

![mapping_broken](https://user-images.githubusercontent.com/43572428/146366418-611664fd-76a8-448a-af78-e1bd6bea8064.gif)

### Reason
- When mapping to visit, the form is still in the `__islocal` state.

![image](https://user-images.githubusercontent.com/43572428/146366683-dbbbd32f-6230-4842-9be3-f7f3c30bbf5b.png)

### Fix
- Since the items are mapped to Visit only via Schedule, added the condition `frm.doc.maintenance_type == 'Unscheduled'` as it would only need to be cleared if the maintenance_type is of type "Unscheduled". (When creating visit via schedule, the type is set to "Scheduled")

### Notes
- The `frm.clear_table()` was introduced to removed the empty row on creating a new Unscheduled Visit.

![empty_row](https://user-images.githubusercontent.com/43572428/146367717-860eabb2-9b6a-4e91-9b46-d292ffd27088.gif)
