### PR TITLE
fix: Refresh Stock Items table in Asset Repair after inserting Serial Numbers

### DIFF
--- a/erpnext/assets/doctype/asset_repair/asset_repair.js
+++ b/erpnext/assets/doctype/asset_repair/asset_repair.js
@@ -68,8 +68,8 @@ frappe.ui.form.on('Asset Repair', {
 });
 
 frappe.ui.form.on('Asset Repair Consumed Item', {
-	consumed_quantity: function(frm, cdt, cdn) {
+	qty: function(frm, cdt, cdn) {
 		var row = locals[cdt][cdn];
-		frappe.model.set_value(cdt, cdn, 'total_value', row.consumed_quantity * row.valuation_rate);
+		frappe.model.set_value(cdt, cdn, 'total_value', row.qty * row.rate);
 	},
 });

--- a/erpnext/assets/doctype/asset_repair/asset_repair.py
+++ b/erpnext/assets/doctype/asset_repair/asset_repair.py
@@ -28,7 +28,7 @@ class AssetRepair(AccountsController):
 
 	def set_total_value(self):
 		for item in self.get('stock_items'):
-			item.total_value = flt(item.valuation_rate) * flt(item.consumed_quantity)
+			item.total_value = flt(item.rate) * flt(item.qty)
 
 	def calculate_total_repair_cost(self):
 		self.total_repair_cost = flt(self.repair_cost)
@@ -119,8 +119,8 @@ class AssetRepair(AccountsController):
 			stock_entry.append('items', {
 				"s_warehouse": self.warehouse,
 				"item_code": stock_item.item_code,
-				"qty": stock_item.consumed_quantity,
-				"basic_rate": stock_item.valuation_rate,
+				"qty": stock_item.qty,
+				"basic_rate": stock_item.rate,
 				"serial_no": stock_item.serial_no
 			})
 

--- a/erpnext/assets/doctype/asset_repair_consumed_item/asset_repair_consumed_item.json
+++ b/erpnext/assets/doctype/asset_repair_consumed_item/asset_repair_consumed_item.json
@@ -6,26 +6,12 @@
  "engine": "InnoDB",
  "field_order": [
   "item_code",
-  "valuation_rate",
-  "consumed_quantity",
+  "rate",
+  "qty",
   "total_value",
   "serial_no"
  ],
  "fields": [
-  {
-   "fetch_from": "item.valuation_rate",
-   "fieldname": "valuation_rate",
-   "fieldtype": "Currency",
-   "in_list_view": 1,
-   "label": "Valuation Rate",
-   "read_only": 1
-  },
-  {
-   "fieldname": "consumed_quantity",
-   "fieldtype": "Data",
-   "in_list_view": 1,
-   "label": "Consumed Quantity"
-  },
   {
    "fieldname": "total_value",
    "fieldtype": "Currency",
@@ -44,12 +30,26 @@
    "in_list_view": 1,
    "label": "Item",
    "options": "Item"
+  },
+  {
+   "fetch_from": "item.valuation_rate",
+   "fieldname": "rate",
+   "fieldtype": "Currency",
+   "in_list_view": 1,
+   "label": "Valuation Rate",
+   "read_only": 1
+  },
+  {
+   "fieldname": "qty",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Consumed Quantity"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2021-11-11 18:23:00.492483",
+ "modified": "2021-12-17 08:20:44.877624",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset Repair Consumed Item",

--- a/erpnext/public/js/utils/serial_no_batch_selector.js
+++ b/erpnext/public/js/utils/serial_no_batch_selector.js
@@ -150,6 +150,7 @@ erpnext.SerialNoBatchSelector = class SerialNoBatchSelector {
 					() => {
 						refresh_field("items");
 						refresh_field("packed_items");
+						refresh_field("stock_items");
 						if (me.callback) {
 							return me.callback(me.item);
 						}


### PR DESCRIPTION
_Problems Addressed:_

- https://github.com/frappe/erpnext/pull/28349 introduced the option to add Serial Numbers to Stock Items consumed during Asset Repairs. However, after inserting Serial Numbers using the Add Serial No button, the Serial No field in the Stock Items table isn't updated instantly, it only gets updated on expanding the row again. This PR fixes this by refreshing the Stock Items table after inserting the Serial Numbers.

<details>
<summary>Testing Info</summary>

1. Create a Serialized Item
2. Submit Stock Entry of type Material Receipt for it(or just create Serial No docs)
3. Create an Asset
4. Create an Asset Repair for it
5. Check the _Stock Consumed During Repair_ box
6. Enter the Serialized Item in the Stock Items table
7. Expand the row for the Serialized Item
8. Click on the _Add Serial No_ button and select the Serial No of your choice
9. Click the _Insert_ button

![Screenshot 2021-12-17 at 8 37 21 AM](https://user-images.githubusercontent.com/25903035/146483230-12bac764-0afa-4ba7-ab2d-7559d813c210.png)

_Expected Result:_ The entered Serial Numbers should instantly be added to the _Serial No_ field.

![Screenshot 2021-12-17 at 8 37 52 AM](https://user-images.githubusercontent.com/25903035/146483283-291ae7a9-a66b-47b7-8b5e-2676870d30a8.png)

</details>

- [minor] The Stock Items table uses fieldnames `valuation_rate` for `rate` and `consumed_qty` for `qty`, which is inconsistent with the rest of ERPNext and causes minor problems here and there. This PR renames them to just `rate` and `qty`.
