### PR TITLE
fix: Added filter for dispatch address

### DIFF
--- a/erpnext/public/js/queries.js
+++ b/erpnext/public/js/queries.js
@@ -83,6 +83,13 @@ $.extend(erpnext.queries, {
 		};
 	},
 
+	dispatch_address_query: function(doc) {
+		return {
+			query: 'frappe.contacts.doctype.address.address.address_query',
+			filters: { link_doctype: 'Company', link_name: doc.company || '' }
+		};
+	},
+
 	supplier_filter: function(doc) {
 		if(!doc.supplier) {
 			frappe.throw(__("Please set {0}", [__(frappe.meta.get_label(doc.doctype, "supplier", doc.name))]));

--- a/erpnext/selling/sales_common.js
+++ b/erpnext/selling/sales_common.js
@@ -41,6 +41,7 @@ erpnext.selling.SellingController = class SellingController extends erpnext.Tran
 		me.frm.set_query('contact_person', erpnext.queries.contact_query);
 		me.frm.set_query('customer_address', erpnext.queries.address_query);
 		me.frm.set_query('shipping_address_name', erpnext.queries.address_query);
+		me.frm.set_query('dispatch_address_name', erpnext.queries.address_query);
 
 
 		if(this.frm.fields_dict.selling_price_list) {

--- a/erpnext/selling/sales_common.js
+++ b/erpnext/selling/sales_common.js
@@ -41,7 +41,7 @@ erpnext.selling.SellingController = class SellingController extends erpnext.Tran
 		me.frm.set_query('contact_person', erpnext.queries.contact_query);
 		me.frm.set_query('customer_address', erpnext.queries.address_query);
 		me.frm.set_query('shipping_address_name', erpnext.queries.address_query);
-		me.frm.set_query('dispatch_address_name', erpnext.queries.address_query);
+		me.frm.set_query('dispatch_address_name', erpnext.queries.dispatch_address_query);
 
 
 		if(this.frm.fields_dict.selling_price_list) {


### PR DESCRIPTION
**Issue:**
In the Dispatch Address Name field the Address is showing off all customers. whereas we are preparing the Sales Order for internal customer
<img src='https://user-images.githubusercontent.com/36098155/146549848-1d69fef8-67bd-49b1-9961-429e98494594.png' width='700'>

**Solution:**
Added filter to dispatch address field
<img src='https://user-images.githubusercontent.com/36098155/146550151-31eb6b56-3ab8-42de-b4f1-d8bf2b02d22f.png' width='700'>

steps:
- select new sales invoice
- check if the addresses are filtered out in `dispatch address` field under the Address and Contact section
