### PR TITLE
fix: Add Invoice Number field to list view in Opening Invoice Creation Tool

### DIFF
--- a/erpnext/accounts/doctype/opening_invoice_creation_tool_item/opening_invoice_creation_tool_item.json
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool_item/opening_invoice_creation_tool_item.json
@@ -110,12 +110,13 @@
    "description": "Reference number of the invoice from the previous system",
    "fieldname": "invoice_number",
    "fieldtype": "Data",
+   "in_list_view": 1,
    "label": "Invoice Number"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2021-12-13 18:15:41.295007",
+ "modified": "2021-12-17 19:25:06.053187",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Opening Invoice Creation Tool Item",


### PR DESCRIPTION
Just added the `Invoice Number` field to list view in the Opening Invoice Creation Tool Item child table for better accessibility, earlier the row would have to be expanded to edit that field.

![image](https://user-images.githubusercontent.com/36098155/146555480-083e967c-6b00-46f1-a0cc-49179b363f65.png)
