### PR TITLE
test: test failure due to rounding

### DIFF
--- a/erpnext/hr/doctype/interview_feedback/test_interview_feedback.py
+++ b/erpnext/hr/doctype/interview_feedback/test_interview_feedback.py
@@ -59,7 +59,7 @@ class TestInterviewFeedback(unittest.TestCase):
 		}, 'average_rating')
 
 		# 1. average should be reflected in Interview Detail.
-		self.assertEqual(avg_on_interview_detail, round(feedback_1.average_rating))
+		self.assertEqual(avg_on_interview_detail, feedback_1.average_rating)
 
 		'''For Second Interviewer Feedback'''
 		interviewer = interview.interview_details[1].interviewer


### PR DESCRIPTION
```
FAIL  test_average_ratings_on_feedback_submission_and_cancellation
(erpnext.hr.doctype.interview_feedback.test_interview_feedback.TestInterviewFeedback)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/hr/doctype/interview_feedback/
        test_interview_feedback.py", line 62, in test_average_ratings_on_feedback_submission_and_cancellation
    self.assertEqual(avg_on_interview_detail, round(feedback_1.average_rating))
AssertionError: 3.5 != 4
```

Rounding produces different result in case of averages with decimal and hence the assertEqual fails.