### PR TITLE
fix: Error on viewing consolidated financial statement

### DIFF
--- a/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py
+++ b/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py
@@ -370,7 +370,7 @@ def get_account_heads(root_type, companies, filters):
 	accounts = get_accounts(root_type, filters)
 
 	if not accounts:
-		return None, None
+		return None, None, None
 
 	accounts = update_parent_account_names(accounts)
 


### PR DESCRIPTION
### App Versions
```
{
	"erpnext": "13.16.1",
	"frappe": "13.16.0"
}
```
### Route
```
query-report/Consolidated Financial Statement
```
### Trackeback
```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 68, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 31, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 67, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1208, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/__init__.py", line 624, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "apps/frappe/frappe/desk/query_report.py", line 244, in run
    result = generate_report_result(report, filters, user, custom_columns)
  File "apps/frappe/frappe/__init__.py", line 624, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "apps/frappe/frappe/desk/query_report.py", line 86, in generate_report_result
    res = get_report_result(report, filters) or []
  File "apps/frappe/frappe/desk/query_report.py", line 70, in get_report_result
    res = report.execute_script_report(filters)
  File "apps/frappe/frappe/core/doctype/report/report.py", line 133, in execute_script_report
    res = self.execute_module(filters)
  File "apps/frappe/frappe/core/doctype/report/report.py", line 150, in execute_module
    return frappe.get_attr(method_name)(frappe._dict(filters))
  File "apps/erpnext/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py", line 53, in execute
    data, message, chart, report_summary = get_balance_sheet_data(fiscal_year, companies, columns, filters)
  File "apps/erpnext/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py", line 70, in get_balance_sheet_data
    equity = get_data(companies, "Equity", "Credit", fiscal_year, filters=filters)
  File "apps/erpnext/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py", line 273, in get_data
    companies, filters)
ValueError: not enough values to unpack (expected 3, got 2)

```
### Request Data
```
{
	"type": "GET",
	"args": {
		"report_name": "Consolidated Financial Statement",
		"filters": "{\"company\":\"Frappe Testing\",\"filter_based_on\":\"Fiscal Year\",\"period_start_date\":\"2021-04-01\",\"period_end_date\":\"2022-03-31\",\"from_fiscal_year\":\"2021-2022\",\"to_fiscal_year\":\"2021-2022\",\"report\":\"Balance Sheet\",\"presentation_currency\":\"INR\",\"include_default_book_entries\":1}"
	},
	"headers": {},
	"error_handlers": {},
	"url": "/api/method/frappe.desk.query_report.run"
}
```
### Response Data
```
{
	"exception": "ValueError: not enough values to unpack (expected 3, got 2)"
}
```