### PR TITLE
fix: fetch appointment letter content in the same order as template

### DIFF
--- a/erpnext/hr/doctype/appointment_letter/appointment_letter.py
+++ b/erpnext/hr/doctype/appointment_letter/appointment_letter.py
@@ -12,14 +12,15 @@ class AppointmentLetter(Document):
 @frappe.whitelist()
 def get_appointment_letter_details(template):
 	body = []
-	intro= frappe.get_list("Appointment Letter Template",
-		fields = ['introduction', 'closing_notes'],
-		filters={'name': template
-	})[0]
-	content = frappe.get_list("Appointment Letter content",
-		fields = ['title', 'description'],
-		filters={'parent': template
-	})
+	intro = frappe.get_list('Appointment Letter Template',
+		fields=['introduction', 'closing_notes'],
+		filters={'name': template}
+	)[0]
+	content = frappe.get_all('Appointment Letter content',
+		fields=['title', 'description'],
+		filters={'parent': template},
+		order_by='idx'
+	)
 	body.append(intro)
 	body.append({'description': content})
 	return body


### PR DESCRIPTION
**Problem**:

1. Create an Appointment Letter Template with terms

    ![image](https://user-images.githubusercontent.com/24353136/146804120-83607bcd-a8f7-42c2-9f50-bcc49648a26e.png)

2. Create an Appointment Letter with that template. The terms don't get fetched in the same order as the template. The system should follow the same sequence which is in Appointment Letter Template.
  
    ![appointment-letter](https://user-images.githubusercontent.com/24353136/146804415-1ef2e14e-0029-45c8-95d5-df375072e1f5.png)

**Fix**:

While fetching terms, order by `idx` so that the same order is followed in all the letters generated using a template.