### PR TITLE
fix: Reset value_after_depreciation on reversing journal entry during Asset return

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -1049,6 +1049,8 @@ class SalesInvoice(SellingController):
 					frappe.flags.is_reverse_depr_entry = False
 					asset.flags.ignore_validate_update_after_submit = True
 					schedule.journal_entry = None
+					depreciation_amount = self.get_depreciation_amount_in_je(reverse_journal_entry)
+					asset.finance_books[0].value_after_depreciation += depreciation_amount
 					asset.save()
 
 	def get_posting_date_of_sales_invoice(self):
@@ -1070,6 +1072,12 @@ class SalesInvoice(SellingController):
 			return True
 
 		return False
+
+	def get_depreciation_amount_in_je(self, journal_entry):
+		if journal_entry.accounts[0].debit_in_account_currency:
+			return journal_entry.accounts[0].debit_in_account_currency
+		else:
+			return journal_entry.accounts[0].credit_in_account_currency
 
 	@property
 	def enable_discount_accounting(self):


### PR DESCRIPTION
### Problem Addressed:

Selling a depreciable Asset modifies its Depreciation Schedule and posts a final Depreciation Entry and returning it after that should reset the schedule and reverse that Depreciation Entry(see https://github.com/frappe/erpnext/pull/26543 for details). The Depreciation Entry posted while selling the Asset modifies its `value_after_depreciation`, but this is not undone once the Asset is returned. 