### PR TITLE
fix: Convert Item links to Website Item links in `Item Card Group` template data

### DIFF
--- a/erpnext/e_commerce/web_template/item_card_group/item_card_group.html
+++ b/erpnext/e_commerce/web_template/item_card_group/item_card_group.html
@@ -23,9 +23,9 @@
 		{%- for index in ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12'] -%}
 		{%- set item = values['card_' + index + '_item'] -%}
 			{%- if item -%}
-				{%- set item = frappe.get_doc("Item", item) -%}
+				{%- set web_item = frappe.get_doc("Website Item", item) -%}
 				{{ item_card(
-					item, is_featured=values['card_' + index + '_featured'],
+					web_item, is_featured=values['card_' + index + '_featured'],
 					is_full_width=True, align="Center"
 				) }}
 			{%- endif -%}

--- a/erpnext/e_commerce/web_template/item_card_group/item_card_group.json
+++ b/erpnext/e_commerce/web_template/item_card_group/item_card_group.json
@@ -37,8 +37,8 @@
   {
    "fieldname": "card_1_item",
    "fieldtype": "Link",
-   "label": "Item",
-   "options": "Item",
+   "label": "Website Item",
+   "options": "Website Item",
    "reqd": 0
   },
   {
@@ -56,8 +56,8 @@
   {
    "fieldname": "card_2_item",
    "fieldtype": "Link",
-   "label": "Item",
-   "options": "Item",
+   "label": "Website Item",
+   "options": "Website Item",
    "reqd": 0
   },
   {
@@ -76,8 +76,8 @@
   {
    "fieldname": "card_3_item",
    "fieldtype": "Link",
-   "label": "Item",
-   "options": "Item",
+   "label": "Website Item",
+   "options": "Website Item",
    "reqd": 0
   },
   {
@@ -95,8 +95,8 @@
   {
    "fieldname": "card_4_item",
    "fieldtype": "Link",
-   "label": "Item",
-   "options": "Item",
+   "label": "Website Item",
+   "options": "Website Item",
    "reqd": 0
   },
   {
@@ -114,8 +114,8 @@
   {
    "fieldname": "card_5_item",
    "fieldtype": "Link",
-   "label": "Item",
-   "options": "Item",
+   "label": "Website Item",
+   "options": "Website Item",
    "reqd": 0
   },
   {
@@ -133,8 +133,8 @@
   {
    "fieldname": "card_6_item",
    "fieldtype": "Link",
-   "label": "Item",
-   "options": "Item",
+   "label": "Website Item",
+   "options": "Website Item",
    "reqd": 0
   },
   {
@@ -152,8 +152,8 @@
   {
    "fieldname": "card_7_item",
    "fieldtype": "Link",
-   "label": "Item",
-   "options": "Item",
+   "label": "Website Item",
+   "options": "Website Item",
    "reqd": 0
   },
   {
@@ -171,8 +171,8 @@
   {
    "fieldname": "card_8_item",
    "fieldtype": "Link",
-   "label": "Item",
-   "options": "Item",
+   "label": "Website Item",
+   "options": "Website Item",
    "reqd": 0
   },
   {
@@ -190,8 +190,8 @@
   {
    "fieldname": "card_9_item",
    "fieldtype": "Link",
-   "label": "Item",
-   "options": "Item",
+   "label": "Website Item",
+   "options": "Website Item",
    "reqd": 0
   },
   {
@@ -209,8 +209,8 @@
   {
    "fieldname": "card_10_item",
    "fieldtype": "Link",
-   "label": "Item",
-   "options": "Item",
+   "label": "Website Item",
+   "options": "Website Item",
    "reqd": 0
   },
   {
@@ -228,8 +228,8 @@
   {
    "fieldname": "card_11_item",
    "fieldtype": "Link",
-   "label": "Item",
-   "options": "Item",
+   "label": "Website Item",
+   "options": "Website Item",
    "reqd": 0
   },
   {
@@ -247,8 +247,8 @@
   {
    "fieldname": "card_12_item",
    "fieldtype": "Link",
-   "label": "Item",
-   "options": "Item",
+   "label": "Website Item",
+   "options": "Website Item",
    "reqd": 0
   },
   {
@@ -259,7 +259,7 @@
   }
  ],
  "idx": 0,
- "modified": "2021-02-24 16:05:31.242342",
+ "modified": "2021-12-21 14:44:59.821335",
  "modified_by": "Administrator",
  "module": "E-commerce",
  "name": "Item Card Group",

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -337,3 +337,4 @@ erpnext.patches.v13_0.update_category_in_ltds_certificate
 erpnext.patches.v13_0.create_ksa_vat_custom_fields
 erpnext.patches.v13_0.rename_ksa_qr_field
 erpnext.patches.v13_0.disable_ksa_print_format_for_others # 16-12-2021
+erpnext.patches.v13_0.convert_to_website_item_in_item_card_group_template

--- a/erpnext/patches/v13_0/convert_to_website_item_in_item_card_group_template.py
+++ b/erpnext/patches/v13_0/convert_to_website_item_in_item_card_group_template.py
@@ -33,7 +33,6 @@ def execute():
                 website_item = frappe.db.get_value("Website Item", {"item_code": item})
             else:
                 website_item = make_new_website_item(item)
-                continue
 
             if website_item:
                 web_template_value[field] = website_item

--- a/erpnext/patches/v13_0/convert_to_website_item_in_item_card_group_template.py
+++ b/erpnext/patches/v13_0/convert_to_website_item_in_item_card_group_template.py
@@ -1,0 +1,58 @@
+import json
+from typing import List
+
+import frappe
+
+from erpnext.e_commerce.doctype.website_item.website_item import make_website_item
+
+
+def execute():
+    """
+        Convert all Item links to Website Item link values in
+        exisitng 'Item Card Group' Web Page Block data.
+    """
+    frappe.reload_doc("e_commerce", "web_template", "item_card_group")
+
+    blocks = frappe.db.get_all(
+        "Web Page Block",
+        filters={"web_template": "Item Card Group"},
+        fields=["parent", "web_template_values", "name"]
+    )
+
+    fields = generate_fields_to_edit()
+
+    for block in blocks:
+        web_template_value = json.loads(block.get('web_template_values'))
+
+        for field in fields:
+            item = web_template_value.get(field)
+            if not item:
+                continue
+
+            if frappe.db.exists("Website Item", {"item_code": item}):
+                website_item = frappe.db.get_value("Website Item", {"item_code": item})
+            else:
+                website_item = make_new_website_item(item, web_template_value, field)
+                continue
+
+            if website_item:
+                web_template_value[field] = website_item
+
+        frappe.db.set_value("Web Page Block", block.name, "web_template_values", json.dumps(web_template_value))
+
+def generate_fields_to_edit() -> List:
+    fields = []
+    for i in range(1, 13):
+        fields.append(f"card_{i}_item") # fields like 'card_1_item', etc.
+
+    return fields
+
+def make_new_website_item(item, web_template_value, field):
+    try:
+        doc = frappe.get_doc("Item", item)
+        web_item = make_website_item(doc) # returns [website_item.name, item_name]
+        return web_item[0]
+    except Exception:
+        title = f"{item}: Error while converting to Website Item "
+        frappe.log_error(title + "for Item Card Group Template" + "\n\n" +  frappe.get_traceback(), title=title)
+        return None

--- a/erpnext/patches/v13_0/convert_to_website_item_in_item_card_group_template.py
+++ b/erpnext/patches/v13_0/convert_to_website_item_in_item_card_group_template.py
@@ -1,5 +1,5 @@
 import json
-from typing import List
+from typing import List, Union
 
 import frappe
 
@@ -32,7 +32,7 @@ def execute():
             if frappe.db.exists("Website Item", {"item_code": item}):
                 website_item = frappe.db.get_value("Website Item", {"item_code": item})
             else:
-                website_item = make_new_website_item(item, web_template_value, field)
+                website_item = make_new_website_item(item)
                 continue
 
             if website_item:
@@ -47,7 +47,7 @@ def generate_fields_to_edit() -> List:
 
     return fields
 
-def make_new_website_item(item, web_template_value, field):
+def make_new_website_item(item: str) -> Union[str, None]:
     try:
         doc = frappe.get_doc("Item", item)
         web_item = make_website_item(doc) # returns [website_item.name, item_name]

--- a/erpnext/patches/v13_0/convert_to_website_item_in_item_card_group_template.py
+++ b/erpnext/patches/v13_0/convert_to_website_item_in_item_card_group_template.py
@@ -54,5 +54,5 @@ def make_new_website_item(item, web_template_value, field):
         return web_item[0]
     except Exception:
         title = f"{item}: Error while converting to Website Item "
-        frappe.log_error(title + "for Item Card Group Template" + "\n\n" +  frappe.get_traceback(), title=title)
+        frappe.log_error(title + "for Item Card Group Template" + "\n\n" + frappe.get_traceback(), title=title)
         return None


### PR DESCRIPTION
**Issue:**
- Item Cards did not redirect anywhere, this is because Item master does not have the **route** field anymore
- This template was still fetching Item master data

**Fix:**
- Changed link option to Website Item in Item card group template
- patch to convert pre-existing data
- ![2021-12-21 15 55 14](https://user-images.githubusercontent.com/25857446/146914337-80cc2878-5a94-49b8-8d0d-b7051602c7ac.gif)
 

**To test:**
- Make a web page and use Item card Group page block, add items to the block.
- check if the cards are responsive on the web page