### PR TITLE
fix: incorrect serial no valuation

### DIFF
--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -385,7 +385,7 @@ class SellingController(StockController):
 				# Get incoming rate based on original item cost based on valuation method
 				qty = flt(d.get('stock_qty') or d.get('actual_qty'))
 
-				if not d.incoming_rate:
+				if not (self.get("is_return") and d.incoming_rate):
 					d.incoming_rate = get_incoming_rate({
 						"item_code": d.item_code,
 						"warehouse": d.warehouse,

--- a/erpnext/stock/doctype/serial_no/test_serial_no.py
+++ b/erpnext/stock/doctype/serial_no/test_serial_no.py
@@ -11,6 +11,7 @@ from erpnext.stock.doctype.delivery_note.test_delivery_note import create_delive
 from erpnext.stock.doctype.item.test_item import make_item
 from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import make_purchase_receipt
 from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos
+from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
 from erpnext.stock.doctype.stock_entry.test_stock_entry import make_serialized_item
 from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
 
@@ -22,6 +23,10 @@ from erpnext.tests.utils import ERPNextTestCase
 
 
 class TestSerialNo(ERPNextTestCase):
+
+	def tearDown(self):
+		frappe.db.rollback()
+
 	def test_cannot_create_direct(self):
 		frappe.delete_doc_if_exists("Serial No", "_TCSER0001")
 
@@ -211,7 +216,28 @@ class TestSerialNo(ERPNextTestCase):
 
 		self.assertEqual(se.get("items")[0].serial_no, "_TS1\n_TS2\n_TS3\n_TS4 - 2021")
 
-		frappe.db.rollback()
+	def test_correct_serial_no_incoming_rate(self):
+		""" Check correct consumption rate based on serial no record.
+		"""
+		item_code = "_Test Serialized Item"
+		warehouse = "_Test Warehouse - _TC"
+		serial_nos = ["LOWVALUATION", "HIGHVALUATION"]
 
-	def tearDown(self):
-		frappe.db.rollback()
+		in1 = make_stock_entry(item_code=item_code, to_warehouse=warehouse, qty=1, rate=42,
+				serial_no=serial_nos[0])
+		in2 = make_stock_entry(item_code=item_code, to_warehouse=warehouse, qty=1, rate=113,
+				serial_no=serial_nos[1])
+
+		out = create_delivery_note(item_code=item_code, qty=1, serial_no=serial_nos[0], do_not_submit=True)
+
+		# change serial no
+		out.items[0].serial_no = serial_nos[1]
+		out.save()
+		out.submit()
+
+		value_diff = frappe.db.get_value("Stock Ledger Entry",
+				{"voucher_no": out.name, "voucher_type": "Delivery Note"},
+				"stock_value_difference"
+			)
+		self.assertEqual(value_diff, -113)
+

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -602,9 +602,9 @@ class update_entries_after(object):
 			incoming_rate = self.wh_data.valuation_rate
 
 		stock_value_change = 0
-		if incoming_rate:
+		if actual_qty > 0:
 			stock_value_change = actual_qty * incoming_rate
-		elif actual_qty < 0:
+		else:
 			# In case of delivery/stock issue, get average purchase rate
 			# of serial nos of current entry
 			if not sle.is_cancelled:


### PR DESCRIPTION
Steps to reproduce:
1. have multiple serial nos with different rates
2. Create a delivery for 1 serial no; do not submit. 
3. Update serial number to some other number with different purchase/manufacture rates. 
4. Submit and check stock value difference. It should be same as incoming rate but it would be from previous serial no instead. 

caused by & potentially affected use cases: https://github.com/frappe/erpnext/pull/25306 & https://github.com/frappe/erpnext/pull/27036

**To Test:**
- The case above
- Delivery return of a serial no (single) and multiple serial nos