### PR TITLE
chore: change log for v13.17.0

### DIFF
--- a/erpnext/change_log/v13/v13_17_0.md
+++ b/erpnext/change_log/v13/v13_17_0.md
@@ -1,0 +1,33 @@
+# Version 13.17.0 Release Notes
+
+### Features & Enhancements
+
+- Provision to consumed the serialized raw materials during Asset Repairs ([#28349](https://github.com/frappe/erpnext/pull/28349))
+- Grant commission on certain items ([#27467](https://github.com/frappe/erpnext/pull/27467))
+- KSA E-Invoing optimizations and POS support ([#28799](https://github.com/frappe/erpnext/pull/28799))
+- Added QI link in Job Card Dashboard ([#28643](https://github.com/frappe/erpnext/pull/28643))
+- Show Zero Values filter in consolidated financial statement ([#28636](https://github.com/frappe/erpnext/pull/28636))
+- Validate pending reposts before freezing stock/account ([#28815](https://github.com/frappe/erpnext/pull/28815))
+
+
+### Fixes
+
+- Mapping to maintenance visit gets erased ([#28917](https://github.com/frappe/erpnext/pull/28917))
+- Ignore mandatory fields while creating WO from SO ([#28772](https://github.com/frappe/erpnext/pull/28772))
+- Map serial no from schedule if only one ([#28745](https://github.com/frappe/erpnext/pull/28745))
+- TDS Monthly payable report ([#28764](https://github.com/frappe/erpnext/pull/28764))
+- Maintenance Visit purposes tables is not visible on submission ([#28792](https://github.com/frappe/erpnext/pull/28792))
+- fetch memberships for 80G certificate by from date only ([#28700](https://github.com/frappe/erpnext/pull/28700))
+- Do not add GST fields if company is not from India ([#28592](https://github.com/frappe/erpnext/pull/28592))
+- Wrong german translation of abbreviation: PAN ([#28802](https://github.com/frappe/erpnext/pull/28802))
+- Removed attachment limit from item doctype ([#28632](https://github.com/frappe/erpnext/pull/28632))
+- Better Error logging for deferred revenue/expense booking ([#28731](https://github.com/frappe/erpnext/pull/28731))
+- Create Depreciation Schedules for existing Assets accurately ([#28675](https://github.com/frappe/erpnext/pull/28675))
+- Incorrect hsn-wise summary if the invoice has repeated item code ([#28783](https://github.com/frappe/erpnext/pull/28783))
+- Paid invoices showing in Accounts Receivable /Accounts Payable report ([#28627](https://github.com/frappe/erpnext/pull/28627))
+- Shipping Rule picking up old net_rate ([#28302](https://github.com/frappe/erpnext/pull/28302))
+- Actual tax conversion in case of multicurrency invoices ([#28539](https://github.com/frappe/erpnext/pull/28539))
+- QRCode for invoices with special characters ([#28715](https://github.com/frappe/erpnext/pull/28715))
+- Incorrect outgoing rates when "Allow Continuous Material Consumption" enabled in manufacturing settings ([#28710](https://github.com/frappe/erpnext/pull/28710))
+- Misleading "Set Default Warehouse" fields after saving ([#28798](https://github.com/frappe/erpnext/pull/28798))
+- Taxjar Nexus list visible only if child table is visible ([#28656](https://github.com/frappe/erpnext/pull/28656))


### PR DESCRIPTION
# Version 13.17.0 Release Notes

### Features & Enhancements

- Provision to consumed the serialized raw materials during Asset Repairs ([#28349](https://github.com/frappe/erpnext/pull/28349))
- Grant commission on certain items ([#27467](https://github.com/frappe/erpnext/pull/27467))
- KSA E-Invoing optimizations and POS support ([#28799](https://github.com/frappe/erpnext/pull/28799))
- Added QI link in Job Card Dashboard ([#28643](https://github.com/frappe/erpnext/pull/28643))
- Show Zero Values filter in consolidated financial statement ([#28636](https://github.com/frappe/erpnext/pull/28636))
- Validate pending reposts before freezing stock/account ([#28815](https://github.com/frappe/erpnext/pull/28815))


### Fixes

- Mapping to maintenance visit gets erased ([#28917](https://github.com/frappe/erpnext/pull/28917))
- Ignore mandatory fields while creating WO from SO ([#28772](https://github.com/frappe/erpnext/pull/28772))
- Map serial no from schedule if only one ([#28745](https://github.com/frappe/erpnext/pull/28745))
- TDS Monthly payable report ([#28764](https://github.com/frappe/erpnext/pull/28764))
- Maintenance Visit purposes tables is not visible on submission ([#28792](https://github.com/frappe/erpnext/pull/28792))
- fetch memberships for 80G certificate by from date only ([#28700](https://github.com/frappe/erpnext/pull/28700))
- Do not add GST fields if company is not from India ([#28592](https://github.com/frappe/erpnext/pull/28592))
- Wrong german translation of abbreviation: PAN ([#28802](https://github.com/frappe/erpnext/pull/28802))
- Removed attachment limit from item doctype ([#28632](https://github.com/frappe/erpnext/pull/28632))
- Better Error logging for deferred revenue/expense booking ([#28731](https://github.com/frappe/erpnext/pull/28731))
- Create Depreciation Schedules for existing Assets accurately ([#28675](https://github.com/frappe/erpnext/pull/28675))
- Incorrect hsn-wise summary if the invoice has repeated item code ([#28783](https://github.com/frappe/erpnext/pull/28783))
- Paid invoices showing in Accounts Receivable /Accounts Payable report ([#28627](https://github.com/frappe/erpnext/pull/28627))
- Shipping Rule picking up old net_rate ([#28302](https://github.com/frappe/erpnext/pull/28302))
- Actual tax conversion in case of multicurrency invoices ([#28539](https://github.com/frappe/erpnext/pull/28539))
- QRCode for invoices with special characters ([#28715](https://github.com/frappe/erpnext/pull/28715))
- Incorrect outgoing rates when "Allow Continuous Material Consumption" enabled in manufacturing settings ([#28710](https://github.com/frappe/erpnext/pull/28710))
- Misleading "Set Default Warehouse" fields after saving ([#28798](https://github.com/frappe/erpnext/pull/28798))
- Taxjar Nexus list visible only if child table is visible ([#28656](https://github.com/frappe/erpnext/pull/28656))