### PR TITLE
fix: set resolution by only if not on hold

### DIFF
--- a/erpnext/support/doctype/issue/test_issue.py
+++ b/erpnext/support/doctype/issue/test_issue.py
@@ -98,6 +98,7 @@ class TestIssue(TestSetUp):
 		issue.save()
 
 		self.assertEqual(issue.on_hold_since, frappe.flags.current_time)
+		self.assertFalse(issue.resolution_by)
 
 		creation = get_datetime("2020-03-04 5:00")
 		frappe.flags.current_time = get_datetime("2020-03-04 5:00")

--- a/erpnext/support/doctype/service_level_agreement/service_level_agreement.py
+++ b/erpnext/support/doctype/service_level_agreement/service_level_agreement.py
@@ -476,7 +476,7 @@ def update_response_and_resolution_metrics(doc, apply_sla_for_resolution):
 	priority = get_response_and_resolution_duration(doc)
 	start_date_time = get_datetime(doc.get("service_level_agreement_creation") or doc.creation)
 	set_response_by(doc, start_date_time, priority)
-	if apply_sla_for_resolution:
+	if apply_sla_for_resolution and not doc.get('on_hold_since'): # resolution_by is reset if on hold
 		set_resolution_by(doc, start_date_time, priority)
 
 
@@ -623,9 +623,6 @@ def reset_resolution_metrics(doc):
 
 	if doc.meta.has_field("user_resolution_time"):
 		doc.user_resolution_time = None
-
-	if doc.meta.has_field("agreement_status"):
-		doc.agreement_status = "First Response Due"
 
 
 # called via hooks on communication update


### PR DESCRIPTION
If an Issue is marked as Replied, the `resolution_by` is reset
But it was again being set in `update_response_and_resolution_metrics`

If an Issue is on hold, then resolution by will be changed once the Issue is Open again, hence `resolution_by` should be reset when Issue is on hold.