### PR TITLE
fix: Issues in Bank Reconciliation tool

### DIFF
--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
@@ -102,7 +102,7 @@ def get_total_allocated_amount(payment_entry):
 		AND
 			bt.docstatus = 1""", (payment_entry.payment_document, payment_entry.payment_entry), as_dict=True)
 
-def get_paid_amount(payment_entry, currency):
+def get_paid_amount(payment_entry, currency, bank_account):
 	if payment_entry.payment_document in ["Payment Entry", "Sales Invoice", "Purchase Invoice"]:
 
 		paid_amount_field = "paid_amount"
@@ -115,7 +115,7 @@ def get_paid_amount(payment_entry, currency):
 			payment_entry.payment_entry, paid_amount_field)
 
 	elif payment_entry.payment_document == "Journal Entry":
-		return frappe.db.get_value(payment_entry.payment_document, payment_entry.payment_entry, "total_credit")
+		return frappe.db.get_value('Journal Entry Account', {'parent': payment_entry.payment_entry, 'account': bank_account}, "sum(credit_in_account_currency)", debug=1)
 
 	elif payment_entry.payment_document == "Expense Claim":
 		return frappe.db.get_value(payment_entry.payment_document, payment_entry.payment_entry, "total_amount_reimbursed")

--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
@@ -115,7 +115,7 @@ def get_paid_amount(payment_entry, currency, bank_account):
 			payment_entry.payment_entry, paid_amount_field)
 
 	elif payment_entry.payment_document == "Journal Entry":
-		return frappe.db.get_value('Journal Entry Account', {'parent': payment_entry.payment_entry, 'account': bank_account}, "sum(credit_in_account_currency)", debug=1)
+		return frappe.db.get_value('Journal Entry Account', {'parent': payment_entry.payment_entry, 'account': bank_account}, "sum(credit_in_account_currency)")
 
 	elif payment_entry.payment_document == "Expense Claim":
 		return frappe.db.get_value(payment_entry.payment_document, payment_entry.payment_entry, "total_amount_reimbursed")


### PR DESCRIPTION
Read about bank reco in ERPNext https://docs.erpnext.com/docs/v13/user/manual/en/accounts/bank-reconciliation

The mapping of the bank accounts is maintained at the bank level. But however, one bank could have both types of bank account like Asset (Savings and Current Account) and Liability like (Credit Card Accounts). Now there was an issue while reconciling the bank transactions of the bank account of type liability. The amount to be reconciled was shown as 0 for such transactions and it became difficult to reconcile such a transaction

Steps to test the issue:
1. Create a bank and add mapping for bank statement import
2.  Make a bank account and map a company account of type liability
3. Import bank statements for the above-created bank account.
4. Add a JV for expenses using such a bank account and check