### PR TITLE
fix: Start date validation for deferred invoices

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -184,6 +184,8 @@ class AccountsController(TransactionBase):
 					frappe.throw(_("Row #{0}: Service Start Date cannot be greater than Service End Date").format(d.idx))
 				elif getdate(self.posting_date) > getdate(d.service_end_date):
 					frappe.throw(_("Row #{0}: Service End Date cannot be before Invoice Posting Date").format(d.idx))
+				elif getdate(self.posting_date) > getdate(d.service_start_date):
+					frappe.throw(_("Row #{0}: Service Start Date cannot be before Invoice Posting Date").format(d.idx))
 
 	def validate_invoice_documents_schedule(self):
 		self.validate_payment_schedule_dates()


### PR DESCRIPTION
For more info on deferred revenue refer: https://docs.erpnext.com/docs/v13/user/manual/en/accounts/deferred-revenue

Service Start Date for deferred revenue booking should not be before the invoice posting date. Many times users creating invoices in the current month and enter service start dates of the previous months which cause issues while booking deferred revenue if the books for previous months are frozen and deferred revenue booking fails 