### PR TITLE
fix(ux): map warehouse fields for inter-company PO->SO

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -1834,6 +1834,11 @@ def make_inter_company_transaction(doctype, source_name, target_doc=None):
 			"name": target_detail_field,
 		})
 
+	if doctype in ("Purchase Order", "Sales Order"):
+		item_field_map["field_map"].update({
+			"warehouse": "warehouse"
+		})
+
 	if source_doc.get('update_stock'):
 		item_field_map["field_map"].update({
 			source_document_warehouse_field: target_document_warehouse_field,


### PR DESCRIPTION
Summary: Map intercompany Purchase Order's warehouse to Sales order's delivery warehouse. 

Steps to reproduce:

- Setup 2 parent/child or sibling companies in accordance with: https://docs.erpnext.com/docs/v13/user/manual/en/accounts/inter-company-invoices 
- Create an intercompany purchase order, specify where goods are to be received. Submit it. 
- Click create > intercompany sales order.
- The delivery warehouse is empty on line items. 

After:
- Delivery warehouse in SO is picked from PO.