### PR TITLE
fix: filter out Claimed employee advances in Expense Claim

### DIFF
--- a/erpnext/hr/doctype/expense_claim/expense_claim.js
+++ b/erpnext/hr/doctype/expense_claim/expense_claim.js
@@ -171,7 +171,7 @@ frappe.ui.form.on("Expense Claim", {
 					['docstatus', '=', 1],
 					['employee', '=', frm.doc.employee],
 					['paid_amount', '>', 0],
-					['paid_amount', '>', 'claimed_amount']
+					['status', '!=', 'Claimed']
 				]
 			};
 		});


### PR DESCRIPTION
## Problem:

1. Create an Employee Advance. Create a Payment Entry to pay the advance.
2. Create an Expense Claim against the advance, now the entire advance is claimed.
    
    <img width="1312" alt="claimed-advanc" src="https://user-images.githubusercontent.com/24353136/147486062-4ab58a6c-3a75-4343-aa37-d435d13b02b8.png">
     
3. Create a new Expense Claim, the advance still shows up for selection. 

    <img width="1312" alt="advance-shown" src="https://user-images.githubusercontent.com/24353136/147486078-62eab231-e9d4-4b1a-927c-019d0abfa7e6.png">

## Fix:

Filter out already claimed advances for selection. There was already a filter existing in the current codebase for:

`['paid_amount', '>', 'claimed_amount']`

However, search uses `get_list`, and column-based comparison is not supported in `get_list` or `get_all`. It was recently added with the query builder only for v14.

Easier way to filter out such advances is directly by the status field:

`['status', '!=', 'Claimed']`

<img width="1306" alt="not-available-adv" src="https://user-images.githubusercontent.com/24353136/147486129-c9c2f461-30ae-40f1-8566-f067893f07af.png">
 