### PR TITLE
fix: rename non existent doctype field to the right one

### DIFF
--- a/erpnext/non_profit/doctype/membership/membership.py
+++ b/erpnext/non_profit/doctype/membership/membership.py
@@ -409,7 +409,7 @@ def get_plan_from_razorpay_id(plan_id):
 def set_expired_status():
 	frappe.db.sql("""
 		UPDATE
-			`tabMembership` SET `status` = 'Expired'
+			`tabMembership` SET `membership_status` = 'Expired'
 		WHERE
-			`status` not in ('Cancelled') AND `to_date` < %s
+			`membership_status` not in ('Cancelled') AND `to_date` < %s
 		""", (nowdate()))


### PR DESCRIPTION
Background job for settings membership expired status: `set_expired_status` considers `status` (non existent field) instead of `membership_status`