### PR TITLE
fix: erase UOMs when changing stock UOM

### DIFF
--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -492,18 +492,20 @@ class Item(WebsiteGenerator):
 		context.shopping_cart = get_product_info_for_website(self.name, skip_quotation_creation=True)
 
 	def add_default_uom_in_conversion_factor_table(self):
-		uom_conv_list = [d.uom for d in self.get("uoms")]
-		if self.stock_uom not in uom_conv_list:
-			ch = self.append('uoms', {})
-			ch.uom = self.stock_uom
-			ch.conversion_factor = 1
+		if not self.is_new() and self.has_value_changed("stock_uom"):
+			self.uoms = []
+			frappe.msgprint(
+				_("Successfully changed Stock UOM, please redefine conversion factors for new UOM."),
+				alert=True,
+			)
 
-		to_remove = []
-		for d in self.get("uoms"):
-			if d.conversion_factor == 1 and d.uom != self.stock_uom:
-				to_remove.append(d)
+		uoms_list = [d.uom for d in self.get("uoms")]
 
-		[self.remove(d) for d in to_remove]
+		if self.stock_uom not in uoms_list:
+			self.append("uoms", {
+				"uom": self.stock_uom,
+				"conversion_factor": 1
+			})
 
 	def update_show_in_website(self):
 		if self.disabled:

--- a/erpnext/stock/doctype/item/test_item.py
+++ b/erpnext/stock/doctype/item/test_item.py
@@ -584,6 +584,16 @@ class TestItem(ERPNextTestCase):
 		except frappe.ValidationError as e:
 			self.fail(f"UoM change not allowed even though no SLE / BIN with positive qty exists: {e}")
 
+	def test_erasure_of_old_conversions(self):
+		item = create_item("_item change uom")
+		item.stock_uom = "Gram"
+		item.append("uoms", frappe._dict(uom="Box", conversion_factor=2))
+		item.save()
+		item.reload()
+		item.stock_uom = "Nos"
+		item.save()
+		self.assertEqual(len(item.uoms), 1)
+
 	def test_validate_stock_item(self):
 		self.assertRaises(frappe.ValidationError, validate_is_stock_item, "_Test Non Stock Item")
 


### PR DESCRIPTION
**Issue-** When item's default stock UOM is changed, the old conversion factors become unusable, erase UOM conversion list upon updating stock UOM. 

<img width="997" alt="Screenshot 2022-01-12 at 7 25 45 PM" src="https://user-images.githubusercontent.com/9079960/149153837-b8bde640-0dfa-4c23-b604-8594d2a8ac1b.png">
