### PR TITLE
fix: travis failing

### DIFF
--- a/erpnext/accounts/doctype/fiscal_year/test_fiscal_year.py
+++ b/erpnext/accounts/doctype/fiscal_year/test_fiscal_year.py
@@ -43,9 +43,9 @@ def test_record_generator():
 	for year in range(start, end):
 		test_records.append({
 			"doctype": "Fiscal Year",
-			"year": f"_Test Fiscal Year {year}",
-			"year_start_date": f"{year}-01-01",
-			"year_end_date": f"{year}-12-31"
+			"year": "_Test Fiscal Year {}".format(year),
+			"year_start_date": "{}-01-01".format(year),
+			"year_end_date": "{}-12-31".format(year)
 		})
 
 	return test_records


### PR DESCRIPTION
Python 2.7 travis failing
```
    make_test_records(options, verbose, force)
  File "/home/travis/frappe-bench/apps/frappe/frappe/test_runner.py", line 284, in make_test_records
    make_test_records(options, verbose, force)
  File "/home/travis/frappe-bench/apps/frappe/frappe/test_runner.py", line 284, in make_test_records
    make_test_records(options, verbose, force)
  File "/home/travis/frappe-bench/apps/frappe/frappe/test_runner.py", line 284, in make_test_records
    make_test_records(options, verbose, force)
  File "/home/travis/frappe-bench/apps/frappe/frappe/test_runner.py", line 284, in make_test_records
    make_test_records(options, verbose, force)
  File "/home/travis/frappe-bench/apps/frappe/frappe/test_runner.py", line 278, in make_test_records
    for options in get_dependencies(doctype):
  File "/home/travis/frappe-bench/apps/frappe/frappe/test_runner.py", line 299, in get_dependencies
    module, test_module = get_modules(doctype)
  File "/home/travis/frappe-bench/apps/frappe/frappe/test_runner.py", line 290, in get_modules
    test_module = load_doctype_module(doctype, module, "test_")
  File "/home/travis/frappe-bench/apps/frappe/frappe/modules/utils.py", line 204, in load_doctype_module
    doctype_python_modules[key] = frappe.get_module(module_name)
  File "/home/travis/frappe-bench/apps/frappe/frappe/__init__.py", line 870, in get_module
    return importlib.import_module(modulename)
  File "/opt/python/2.7.14/lib/python2.7/importlib/__init__.py", line 37, in import_module
    __import__(name)
  File "/home/travis/frappe-bench/apps/erpnext/erpnext/accounts/doctype/fiscal_year/test_fiscal_year.py", line 46
    "year": f"_Test Fiscal Year {year}",
                                      ^
```