### PR TITLE
refactor: Payment Request added to PO Dashboard

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order_dashboard.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order_dashboard.py
@@ -7,6 +7,7 @@ def get_data():
 		'non_standard_fieldnames': {
 			'Journal Entry': 'reference_name',
 			'Payment Entry': 'reference_name',
+			'Payment Request': 'reference_name',
 			'Auto Repeat': 'reference_document'
 		},
 		'internal_links': {
@@ -21,7 +22,7 @@ def get_data():
 			},
 			{
 				'label': _('Payment'),
-				'items': ['Payment Entry', 'Journal Entry']
+				'items': ['Payment Entry', 'Journal Entry', 'Payment Request']
 			},
 			{
 				'label': _('Reference'),


### PR DESCRIPTION
**Issue:** Users are unable to see if a Payment Request is already created against a Purchase Order. Hence, creating multiple requests for the same document.

**Solution:**
<img width="1033" alt="Screen Shot 2021-12-29 at 4 38 33 PM" src="https://user-images.githubusercontent.com/16913064/147656728-93c4f6e7-99a7-4cc9-b1fd-6572b680fb91.png">

