### PR TITLE
fix: leave_allocation variable not being defined

### DIFF
--- a/erpnext/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
+++ b/erpnext/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
@@ -56,8 +56,9 @@ class LeavePolicyAssignment(Document):
 						leave_policy_detail.leave_type, leave_policy_detail.annual_allocation,
 						leave_type_details, date_of_joining
 					)
+					leave_allocations[leave_policy_detail.leave_type] = {"name": leave_allocation, "leaves": new_leaves_allocated}
+				
 
-				leave_allocations[leave_policy_detail.leave_type] = {"name": leave_allocation, "leaves": new_leaves_allocated}
 
 			self.db_set("leaves_allocated", 1)
 			return leave_allocations

--- a/erpnext/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
+++ b/erpnext/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
@@ -57,7 +57,6 @@ class LeavePolicyAssignment(Document):
 						leave_type_details, date_of_joining
 					)
 					leave_allocations[leave_policy_detail.leave_type] = {"name": leave_allocation, "leaves": new_leaves_allocated}
-				
 			self.db_set("leaves_allocated", 1)
 			return leave_allocations
 

--- a/erpnext/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
+++ b/erpnext/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
@@ -58,8 +58,6 @@ class LeavePolicyAssignment(Document):
 					)
 					leave_allocations[leave_policy_detail.leave_type] = {"name": leave_allocation, "leaves": new_leaves_allocated}
 				
-
-
 			self.db_set("leaves_allocated", 1)
 			return leave_allocations
 


### PR DESCRIPTION
ISSUE

Recently while hosting erpnext for my company, I got an error while doing leave allocations, as mentioned in this issue.
https://discuss.erpnext.com/t/leave-policy-bulk-allocation-error/84246

This is a fix, which moves the assignment inside the if check, which makes more sense to me, and should prevent this error from occuring.