### PR TITLE
fix(India): Tax and Charges template not getting fetched based on tax category assigned

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -1213,7 +1213,7 @@ def check_gl_entries(doc, voucher_no, expected_gle, posting_date):
 def update_tax_witholding_category(company, account):
 	from erpnext.accounts.utils import get_fiscal_year
 
-	fiscal_year = get_fiscal_year(fiscal_year='_Test Fiscal Year 2021')
+	fiscal_year = get_fiscal_year(date=nowdate())
 
 	if not frappe.db.get_value('Tax Withholding Rate',
 		{'parent': 'TDS - 194 - Dividends - Individual', 'from_date': ('>=', fiscal_year[1]),

--- a/erpnext/regional/india/utils.py
+++ b/erpnext/regional/india/utils.py
@@ -217,7 +217,7 @@ def get_regional_address_details(party_details, doctype, company):
 
 	if tax_template_by_category:
 		party_details['taxes_and_charges'] = tax_template_by_category
-		return
+		return party_details
 
 	if not party_details.place_of_supply: return party_details
 	if not party_details.company_gstin: return party_details


### PR DESCRIPTION
Tax and Charges template was not getting fetched based on the Tax Category Assigned to a customer or supplier.

Steps to test:

1. Assign a tax category to a Customer
2. Add the Same Tax Category to a Sales Taxes and Charges template
3. Make a Sales Invoice and select the customer, on selecting the customer appropriate taxes and charges template should be fetched.