### PR TITLE
chore: change log for v12.28.0

### DIFF
--- a/erpnext/change_log/v12/v12_28_0.md
+++ b/erpnext/change_log/v12/v12_28_0.md
@@ -1,0 +1,7 @@
+## ERPNext Version 12.28.0 Release Notes
+
+### Fixes & Enhancements
+- Set cost center for credit entries while posting Depreciation Entries ([#28908](https://github.com/frappe/erpnext/pull/28908))
+- Incorrect amount based on Payment Days in timesheet based salary slip ([#28884](https://github.com/frappe/erpnext/pull/28884))
+- Removed rename feature for the Warehouse document ([#28712](https://github.com/frappe/erpnext/pull/28712))
+- Actual tax conversion in case of multicurrency invoices ([#28539](https://github.com/frappe/erpnext/pull/28539))


### PR DESCRIPTION
## ERPNext Version 12.28.0 Release Notes

### Fixes & Enhancements
- Set cost center for credit entries while posting Depreciation Entries ([#28908](https://github.com/frappe/erpnext/pull/28908))
- Incorrect amount based on Payment Days in timesheet based salary slip ([#28884](https://github.com/frappe/erpnext/pull/28884))
- Removed rename feature for the Warehouse document ([#28712](https://github.com/frappe/erpnext/pull/28712))
- Actual tax conversion in case of multicurrency invoices ([#28539](https://github.com/frappe/erpnext/pull/28539))