### PR TITLE
fix: incorrect posting time fetching incorrect qty

### DIFF
--- a/erpnext/stock/utils.py
+++ b/erpnext/stock/utils.py
@@ -86,8 +86,8 @@ def get_stock_balance(item_code, warehouse, posting_date=None, posting_time=None
 
 	from erpnext.stock.stock_ledger import get_previous_sle
 
-	if not posting_date: posting_date = nowdate()
-	if not posting_time: posting_time = nowtime()
+	if posting_date is None: posting_date = nowdate()
+	if posting_time is None: posting_time = nowtime()
 
 	args = {
 		"item_code": item_code,


### PR DESCRIPTION
The get_stock_balance method fetches incorrect qty if the posting time is set as 00:00:00

**Issue**

1. Created Purchase Receipt entry for Item A with Warehouse A and qty as 1 and rate as 100, on the 1st of April 2021 and kept posting time as 00:00:10
2. Created Stock Reco for the item **Item A**, warehouse as **Warehouse A**, qty as 1 and valuation rate as 100 on the 1st of April 2021 and kept posting time as 00:00:00
3. While submitting the stock reco system throwing an error that "None of the items have any change in quantity or value."
4. Ideally it should allow because the Stock against the **Item A** before 1st of April 2021 and posting time as 00:00:00 is None
5. After debug came to know that if posting time is none then we set the posting time = Current Time
6. With the current time system fetching the Qty and Rate from the Purchase Receipt

Somehow system ignoring the value 0:00:00
<img width="591" alt="Screenshot 2022-01-03 at 1 53 07 PM" src="https://user-images.githubusercontent.com/8780500/147911428-1137f69b-3082-48dd-89cd-ba4a51e03cea.png">


**After Fix**

To fix the issue added condition that `if posting_time is None`