### PR TITLE
fix: from time and to time not updated in drag and drop action

### DIFF
--- a/erpnext/education/api.py
+++ b/erpnext/education/api.py
@@ -201,8 +201,8 @@ def get_course_schedule_events(start, end, filters=None):
 	conditions = get_event_conditions("Course Schedule", filters)
 
 	data = frappe.db.sql("""select name, course, color,
-			timestamp(schedule_date, from_time) as from_datetime,
-			timestamp(schedule_date, to_time) as to_datetime,
+			timestamp(schedule_date, from_time) as from_time,
+			timestamp(schedule_date, to_time) as to_time,
 			room, student_group, 0 as 'allDay'
 		from `tabCourse Schedule`
 		where ( schedule_date between %(start)s and %(end)s )

--- a/erpnext/education/doctype/course_schedule/course_schedule.py
+++ b/erpnext/education/doctype/course_schedule/course_schedule.py
@@ -3,6 +3,8 @@
 # For license information, please see license.txt
 
 
+from datetime import datetime
+
 import frappe
 from frappe import _
 from frappe.model.document import Document
@@ -29,6 +31,11 @@ class CourseSchedule(Document):
 		"""Validates if from_time is greater than to_time"""
 		if self.from_time > self.to_time:
 			frappe.throw(_("From Time cannot be greater than To Time."))
+
+		"""Handles specicfic case to update schedule date in calendar """
+		datetime_obj = datetime.strptime(self.from_time, '%Y-%m-%d %H:%M:%S')
+		if isinstance(datetime_obj, datetime) and self.schedule_date != self.from_time:
+			self.schedule_date = datetime_obj
 
 	def validate_overlap(self):
 		"""Validates overlap for Student Group, Instructor, Room"""

--- a/erpnext/education/doctype/course_schedule/course_schedule.py
+++ b/erpnext/education/doctype/course_schedule/course_schedule.py
@@ -33,9 +33,12 @@ class CourseSchedule(Document):
 			frappe.throw(_("From Time cannot be greater than To Time."))
 
 		"""Handles specicfic case to update schedule date in calendar """
-		datetime_obj = datetime.strptime(self.from_time, '%Y-%m-%d %H:%M:%S')
-		if isinstance(datetime_obj, datetime) and self.schedule_date != self.from_time:
-			self.schedule_date = datetime_obj
+		if isinstance(self.from_time, str):
+			try:
+				datetime_obj = datetime.strptime(self.from_time, '%Y-%m-%d %H:%M:%S')
+				self.schedule_date = datetime_obj
+			except ValueError:
+				pass
 
 	def validate_overlap(self):
 		"""Validates overlap for Student Group, Instructor, Room"""

--- a/erpnext/education/doctype/course_schedule/course_schedule_calendar.js
+++ b/erpnext/education/doctype/course_schedule/course_schedule_calendar.js
@@ -1,12 +1,10 @@
 frappe.views.calendar["Course Schedule"] = {
 	field_map: {
-		// from_datetime and to_datetime don't exist as docfields but are used in onload
 		"start": "from_time",
 		"end": "to_time",
 		"id": "name",
 		"title": "course",
 		"allDay": "allDay",
-		"schedule_date": "schedule_date"
 	},
 	gantt: false,
 	order_by: "schedule_date",

--- a/erpnext/education/doctype/course_schedule/course_schedule_calendar.js
+++ b/erpnext/education/doctype/course_schedule/course_schedule_calendar.js
@@ -1,11 +1,12 @@
 frappe.views.calendar["Course Schedule"] = {
 	field_map: {
 		// from_datetime and to_datetime don't exist as docfields but are used in onload
-		"start": "from_datetime",
-		"end": "to_datetime",
+		"start": "from_time",
+		"end": "to_time",
 		"id": "name",
 		"title": "course",
-		"allDay": "allDay"
+		"allDay": "allDay",
+		"schedule_date": "schedule_date"
 	},
 	gantt: false,
 	order_by: "schedule_date",

--- a/erpnext/education/doctype/course_schedule/test_course_schedule.py
+++ b/erpnext/education/doctype/course_schedule/test_course_schedule.py
@@ -6,6 +6,7 @@ import unittest
 
 import frappe
 from frappe.utils import to_timedelta, today
+from frappe.utils.data import add_to_date
 
 from erpnext.education.utils import OverlapError
 
@@ -38,6 +39,11 @@ class TestCourseSchedule(unittest.TestCase):
 
 		make_course_schedule_test_record(from_time= cs1.from_time, to_time= cs1.to_time,
 			student_group="Course-TC102-2014-2015 (_Test Academic Term)", instructor="_Test Instructor 2", room=frappe.get_all("Room")[1].name)
+
+	def test_update_schedule_date(self):
+		doc = make_course_schedule_test_record(schedule_date= add_to_date(today(), days=1))
+		doc.schedule_date = add_to_date(doc.schedule_date, days=1)
+		doc.save()
 
 def make_course_schedule_test_record(**args):
 	args = frappe._dict(args)


### PR DESCRIPTION
Before Fix: 

The Course Schedule Calendar did not update **from time** and **to time** when a drag and drop action is performed in time slots of a day 
![drag_and_drop_in_time_slots](https://user-images.githubusercontent.com/49878143/147929548-24b22d5d-a08f-4255-ae4e-bc467eb95b0b.gif)

After Fix:

**from time** and **to time** updated correctly so new changes are saved



![drag_and_drop_in_time_slots_fix](https://user-images.githubusercontent.com/49878143/147930034-f8474fe8-626b-411c-a4e6-37ad24c8a023.gif)

This issue was identified from here [GitHub Issue](https://github.com/frappe/erpnext/issues/28727)

There is also a bug identified from this issue which doesn't allow user to drag and drop events to a different date which required a fix in the framework. A PR has been raised for the same [#15509](https://github.com/frappe/frappe/pull/15509)
