### PR TITLE
fix: POS items added to cart despite low qty

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -643,7 +643,7 @@ erpnext.PointOfSale.Controller = class {
 				message: __('Item Code: {0} is not available under warehouse {1}.', [bold_item_code, bold_warehouse])
 			})
 		} else if (available_qty < qty_needed) {
-			frappe.show_alert({
+			frappe.throw({
 				message: __('Stock quantity not enough for Item Code: {0} under warehouse {1}. Available quantity {2}.', [bold_item_code, bold_warehouse, bold_available_qty]),
 				indicator: 'orange'
 			});


### PR DESCRIPTION
**Issue:**
- Go to point of sale.
- Add items into the cart.
- Notice if the available quantity of the item is 2 it will still keep on adding the item in the cart. (It gives an error but increases the number of item in the cart).

**Expected Result:**
Although we are getting the error, the item gets added in the cart.If the item is not available it should not get added in the cart as well.

**Fix:**
Item is not adde to cart and error is thrown instead of alert
<img src='https://user-images.githubusercontent.com/36098155/148036641-478cd781-2bb2-4665-b9a6-283ecc677dc7.png' width='700'>

