### PR TITLE
fix: map Accounting Dimensions for Bank Entry against Payroll Entry

### DIFF
--- a/erpnext/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/erpnext/payroll/doctype/payroll_entry/payroll_entry.py
@@ -398,23 +398,24 @@ class PayrollEntry(Document):
 		currencies = []
 		multi_currency = 0
 		company_currency = erpnext.get_company_currency(self.company)
+		accounting_dimensions = get_accounting_dimensions() or []
 
 		exchange_rate, amount = self.get_amount_and_exchange_rate_for_journal_entry(self.payment_account, je_payment_amount, company_currency, currencies)
-		accounts.append({
+		accounts.append(self.update_accounting_dimensions({
 			"account": self.payment_account,
 			"bank_account": self.bank_account,
 			"credit_in_account_currency": flt(amount, precision),
 			"exchange_rate": flt(exchange_rate),
-		})
+		}, accounting_dimensions))
 
 		exchange_rate, amount = self.get_amount_and_exchange_rate_for_journal_entry(payroll_payable_account, je_payment_amount, company_currency, currencies)
-		accounts.append({
+		accounts.append(self.update_accounting_dimensions({
 			"account": payroll_payable_account,
 			"debit_in_account_currency": flt(amount, precision),
 			"exchange_rate": flt(exchange_rate),
 			"reference_type": self.doctype,
 			"reference_name": self.name
-		})
+		}, accounting_dimensions))
 
 		if len(currencies) > 1:
 				multi_currency = 1


### PR DESCRIPTION
**Steps to Replicate**:

1. Create an Accounting Dimension eg: Branch
    ![image](https://user-images.githubusercontent.com/24353136/148069177-0e0beae0-0030-483e-a16a-0ecbc5051f38.png)
2. Create a Payroll Entry, submit salary slips.
3. **Make Bank Entry** against Payroll Entry. This will create a Journal Entry to book salary payment. 
4. This Journal Entry won't get submitted due to missing mandatory accounting dimension.

    ![Kapture 2022-01-04 at 19 29 34](https://user-images.githubusercontent.com/24353136/148070154-0fcf2701-4057-41fb-b688-23816fdda41d.gif)

**Fix**:

Accounting Dimensions get mapped while making accrual JV on salary slip submission but not when making Bank Entry. Map accounting dimensions in this method too.

![Kapture 2022-01-04 at 19 32 05](https://user-images.githubusercontent.com/24353136/148070571-86c521ec-5f2f-4cff-a16e-cc6f9b5a3c71.gif)
