### PR TITLE
fix(UX): validate setup on clicking Mark Attendance button in Shift Type

### DIFF
--- a/erpnext/hr/doctype/shift_type/shift_type.js
+++ b/erpnext/hr/doctype/shift_type/shift_type.js
@@ -4,15 +4,32 @@
 frappe.ui.form.on('Shift Type', {
 	refresh: function(frm) {
 		frm.add_custom_button(
-			'Mark Attendance',
-			() => frm.call({
-				doc: frm.doc,
-				method: 'process_auto_attendance',
-				freeze: true,
-				callback: () => {
-					frappe.msgprint(__("Attendance has been marked as per employee check-ins"));
+			__('Mark Attendance'),
+			() => {
+				if (!frm.doc.enable_auto_attendance) {
+					frm.scroll_to_field('enable_auto_attendance');
+					frappe.throw(__('Please Enable Auto Attendance and complete the setup first.'));
 				}
-			})
+
+				if (!frm.doc.process_attendance_after) {
+					frm.scroll_to_field('process_attendance_after');
+					frappe.throw(__('Please set {0}.', [__('Process Attendance After').bold()]));
+				}
+
+				if (!frm.doc.last_sync_of_checkin) {
+					frm.scroll_to_field('last_sync_of_checkin');
+					frappe.throw(__('Please set {0}.', [__('Last Sync of Checkin').bold()]));
+				}
+
+				frm.call({
+					doc: frm.doc,
+					method: 'process_auto_attendance',
+					freeze: true,
+					callback: () => {
+						frappe.msgprint(__('Attendance has been marked as per employee check-ins'));
+					}
+				});
+			}
 		);
 	}
 });


### PR DESCRIPTION
## Problem:

The **Mark Attendance** button on shift type calls the `process_auto_attendance` class method

![image](https://user-images.githubusercontent.com/24353136/148087554-c15a420f-a362-4ab1-a397-2808a4fc1727.png)

This method only processes attendance if the setup for fields is done in Shift Type. However, if the setup is missing user is not prompted and a message for successful attendance marking is shown which is perceived as a bug since no attendance records are created.

https://github.com/frappe/erpnext/blob/32197355add09ff4626dc704bc02a42f003d8b85/erpnext/hr/doctype/shift_type/shift_type.py#L18-L20

## Fix:

Explicitly check for missing configurations (Enable Auto Attendance, Process Attendance After, Last Sync of Checkin) before calling the method. 

![image](https://user-images.githubusercontent.com/24353136/148088088-8e087f28-c34a-4a1e-9b6b-771ae2c88bdc.png)