### PR TITLE
fix: Earned Leave allocation from Leave Policy Assignment

### DIFF
--- a/erpnext/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
+++ b/erpnext/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
@@ -128,6 +128,8 @@ class LeavePolicyAssignment(Document):
 			monthly_earned_leave = get_monthly_earned_leave(new_leaves_allocated,
 				leave_type_details.get(leave_type).earned_leave_frequency, leave_type_details.get(leave_type).rounding)
 			new_leaves_allocated = monthly_earned_leave * months_passed
+		else:
+			new_leaves_allocated = 0
 
 		return new_leaves_allocated
 

--- a/erpnext/hr/doctype/leave_policy_assignment/test_leave_policy_assignment.py
+++ b/erpnext/hr/doctype/leave_policy_assignment/test_leave_policy_assignment.py
@@ -4,6 +4,7 @@
 import unittest
 
 import frappe
+from frappe.utils import add_months, get_first_day, getdate
 
 from erpnext.hr.doctype.leave_application.test_leave_application import (
 	get_employee,
@@ -17,9 +18,8 @@ from erpnext.hr.doctype.leave_policy_assignment.leave_policy_assignment import (
 test_dependencies = ["Employee"]
 
 class TestLeavePolicyAssignment(unittest.TestCase):
-
 	def setUp(self):
-		for doctype in ["Leave Application", "Leave Allocation", "Leave Policy Assignment", "Leave Ledger Entry"]:
+		for doctype in ["Leave Period", "Leave Application", "Leave Allocation", "Leave Policy Assignment", "Leave Ledger Entry"]:
 			frappe.db.sql("delete from `tab{0}`".format(doctype)) #nosec
 
 	def test_grant_leaves(self):
@@ -54,8 +54,8 @@ class TestLeavePolicyAssignment(unittest.TestCase):
 
 		self.assertEqual(leave_alloc_doc.new_leaves_allocated, 10)
 		self.assertEqual(leave_alloc_doc.leave_type, "_Test Leave Type")
-		self.assertEqual(leave_alloc_doc.from_date, leave_period.from_date)
-		self.assertEqual(leave_alloc_doc.to_date, leave_period.to_date)
+		self.assertEqual(getdate(leave_alloc_doc.from_date), getdate(leave_period.from_date))
+		self.assertEqual(getdate(leave_alloc_doc.to_date), getdate(leave_period.to_date))
 		self.assertEqual(leave_alloc_doc.leave_policy, leave_policy.name)
 		self.assertEqual(leave_alloc_doc.leave_policy_assignment, leave_policy_assignments[0])
 
@@ -101,6 +101,55 @@ class TestLeavePolicyAssignment(unittest.TestCase):
 		# User are now allowed to grant leave
 		self.assertEqual(leave_policy_assignment_doc.leaves_allocated, 0)
 
+	def test_earned_leave_allocation(self):
+		leave_period = create_leave_period("Test Earned Leave Period")
+		employee = get_employee()
+		leave_type = create_earned_leave_type("Test Earned Leave")
+
+		leave_policy = frappe.get_doc({
+			"doctype": "Leave Policy",
+			"leave_policy_details": [{"leave_type": leave_type.name, "annual_allocation": 6}]
+		}).insert()
+
+		data = {
+			"assignment_based_on": "Leave Period",
+			"leave_policy": leave_policy.name,
+			"leave_period": leave_period.name
+		}
+		leave_policy_assignments = create_assignment_for_multiple_employees([employee.name], frappe._dict(data))
+
+		# leaves allocated should be 0 since it is an earned leave and allocation happens via scheduler based on set frequency
+		leaves_allocated = frappe.db.get_value("Leave Allocation", {
+			"leave_policy_assignment": leave_policy_assignments[0]
+		}, "total_leaves_allocated")
+		self.assertEqual(leaves_allocated, 0)
+
 	def tearDown(self):
-		for doctype in ["Leave Application", "Leave Allocation", "Leave Policy Assignment", "Leave Ledger Entry"]:
-			frappe.db.sql("delete from `tab{0}`".format(doctype)) #nosec
+		frappe.db.rollback()
+
+
+def create_earned_leave_type(leave_type):
+	frappe.delete_doc_if_exists("Leave Type", leave_type, force=1)
+
+	return frappe.get_doc(dict(
+		leave_type_name=leave_type,
+		doctype="Leave Type",
+		is_earned_leave=1,
+		earned_leave_frequency="Monthly",
+		rounding=0.5,
+		max_leaves_allowed=6
+	)).insert()
+
+
+def create_leave_period(name):
+	frappe.delete_doc_if_exists("Leave Period", name, force=1)
+	start_date = get_first_day(getdate())
+
+	return frappe.get_doc(dict(
+		name=name,
+		doctype="Leave Period",
+		from_date=start_date,
+		to_date=add_months(start_date, 12),
+		company="_Test Company",
+		is_active=1
+	)).insert()


### PR DESCRIPTION
## Problem:

Earned Leave allocation via Leave Policy Assignment is incorrect.

**Steps to replicate:**

1. Create a Leave Type for Earned Leave with monthly frequency
    ![image](https://user-images.githubusercontent.com/24353136/148331883-40f67a10-14d3-49f2-b854-493add572029.png)
2. Create a Leave Policy with Earned Leave
3. Create Leave Policy Assignment based on Leave Period. The Leave Allocation created from this assignment should allocate 0 leaves first since it is an Earned Leave and the scheduler will allocate leaves based on the set frequency (eg: if the policy is for 12 earned leaves for Monthly frequency, then the employee should get 0 leaves at first and 1 leave allocated at the end of every month). However, currently, it allocates all 12 leaves on assignment submission. 

   ![earned-leave-bug](https://user-images.githubusercontent.com/24353136/148332648-9138f68b-7ba0-45c6-b629-669739db8e89.gif)

## Fix:

The `get_leaves_for_passed_months` does not reset leaves allocated if months passed are 0 i.e if the allocation is done in the first month of the leave period

![earned-leave-assignment-corrected](https://user-images.githubusercontent.com/24353136/148332375-e0bc2a57-cc7b-40e6-aab2-b64e56406182.gif)

