### PR TITLE
fix: seperate custom field creation for KSA

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -312,7 +312,7 @@ erpnext.patches.v14_0.delete_healthcare_doctypes
 erpnext.patches.v13_0.update_category_in_ltds_certificate
 erpnext.patches.v13_0.create_pan_field_for_india #2
 erpnext.patches.v14_0.delete_hub_doctypes
-erpnext.patches.v13_0.create_ksa_vat_custom_fields
+erpnext.patches.v13_0.create_ksa_vat_custom_fields # 07-01-2022
 erpnext.patches.v14_0.rename_ongoing_status_in_sla_documents
 erpnext.patches.v14_0.migrate_crm_settings
 erpnext.patches.v13_0.rename_ksa_qr_field

--- a/erpnext/regional/saudi_arabia/setup.py
+++ b/erpnext/regional/saudi_arabia/setup.py
@@ -41,7 +41,7 @@ def make_custom_fields():
 	is_zero_rated = dict(fieldname='is_zero_rated', label='Is Zero Rated',
 		fieldtype='Check', fetch_from='item_code.is_zero_rated', insert_after='description',
 		print_hide=1)
-	
+
 	is_exempt = dict(fieldname='is_exempt', label='Is Exempt',
 		fieldtype='Check', fetch_from='item_code.is_exempt', insert_after='is_zero_rated',
 		print_hide=1)

--- a/erpnext/regional/saudi_arabia/setup.py
+++ b/erpnext/regional/saudi_arabia/setup.py
@@ -3,15 +3,71 @@
 
 import frappe
 from frappe.permissions import add_permission, update_permission_property
-from erpnext.regional.united_arab_emirates.setup import make_custom_fields as uae_custom_fields
 from erpnext.regional.saudi_arabia.wizard.operations.setup_ksa_vat_setting import create_ksa_vat_setting
 from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 
 def setup(company=None, patch=True):
-	uae_custom_fields()
+	make_custom_fields()
 	add_print_formats()
 	add_permissions()
 	make_custom_fields()
+
+def make_custom_fields():
+	is_zero_rated = dict(fieldname='is_zero_rated', label='Is Zero Rated',
+		fieldtype='Check', fetch_from='item_code.is_zero_rated', insert_after='description',
+		print_hide=1)
+	
+	is_exempt = dict(fieldname='is_exempt', label='Is Exempt',
+		fieldtype='Check', fetch_from='item_code.is_exempt', insert_after='is_zero_rated',
+		print_hide=1)
+
+	purchase_invoice_fields = [
+			dict(fieldname='company_trn', label='Company TRN',
+				fieldtype='Read Only', insert_after='shipping_address',
+				fetch_from='company.tax_id', print_hide=1),
+			dict(fieldname='supplier_name_in_arabic', label='Supplier Name in Arabic',
+				fieldtype='Read Only', insert_after='supplier_name',
+				fetch_from='supplier.supplier_name_in_arabic', print_hide=1)
+		]
+
+	sales_invoice_fields = [
+			dict(fieldname='company_trn', label='Company TRN',
+				fieldtype='Read Only', insert_after='company_address',
+				fetch_from='company.tax_id', print_hide=1),
+			dict(fieldname='customer_name_in_arabic', label='Customer Name in Arabic',
+				fieldtype='Read Only', insert_after='customer_name',
+				fetch_from='customer.customer_name_in_arabic', print_hide=1)
+		]
+
+	custom_fields = {
+		'Item': [is_zero_rated, is_exempt],
+		'Customer': [
+			dict(fieldname='customer_name_in_arabic', label='Customer Name in Arabic',
+				fieldtype='Data', insert_after='customer_name'),
+		],
+		'Supplier': [
+			dict(fieldname='supplier_name_in_arabic', label='Supplier Name in Arabic',
+				fieldtype='Data', insert_after='supplier_name'),
+		],
+		'Purchase Invoice': purchase_invoice_fields,
+		'Purchase Order': purchase_invoice_fields,
+		'Purchase Receipt': purchase_invoice_fields,
+		'Sales Invoice': sales_invoice_fields,
+		'POS Invoice': sales_invoice_fields,
+		'Sales Order': sales_invoice_fields,
+		'Delivery Note': sales_invoice_fields,
+		'Sales Invoice Item': [is_zero_rated, is_exempt],
+		'POS Invoice Item': [is_zero_rated, is_exempt],
+		'Purchase Invoice Item': [is_zero_rated, is_exempt],
+		'Sales Order Item': [is_zero_rated, is_exempt],
+		'Delivery Note Item': [is_zero_rated, is_exempt],
+		'Quotation Item': [is_zero_rated, is_exempt],
+		'Purchase Order Item': [is_zero_rated, is_exempt],
+		'Purchase Receipt Item': [is_zero_rated, is_exempt],
+		'Supplier Quotation Item': [is_zero_rated, is_exempt],
+	}
+
+	create_custom_fields(custom_fields)
 
 def add_print_formats():
 	frappe.reload_doc("regional", "print_format", "detailed_tax_invoice", force=True)

--- a/erpnext/regional/saudi_arabia/setup.py
+++ b/erpnext/regional/saudi_arabia/setup.py
@@ -7,67 +7,9 @@ from erpnext.regional.saudi_arabia.wizard.operations.setup_ksa_vat_setting impor
 from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 
 def setup(company=None, patch=True):
-	make_custom_fields()
 	add_print_formats()
 	add_permissions()
 	make_custom_fields()
-
-def make_custom_fields():
-	is_zero_rated = dict(fieldname='is_zero_rated', label='Is Zero Rated',
-		fieldtype='Check', fetch_from='item_code.is_zero_rated', insert_after='description',
-		print_hide=1)
-	
-	is_exempt = dict(fieldname='is_exempt', label='Is Exempt',
-		fieldtype='Check', fetch_from='item_code.is_exempt', insert_after='is_zero_rated',
-		print_hide=1)
-
-	purchase_invoice_fields = [
-			dict(fieldname='company_trn', label='Company TRN',
-				fieldtype='Read Only', insert_after='shipping_address',
-				fetch_from='company.tax_id', print_hide=1),
-			dict(fieldname='supplier_name_in_arabic', label='Supplier Name in Arabic',
-				fieldtype='Read Only', insert_after='supplier_name',
-				fetch_from='supplier.supplier_name_in_arabic', print_hide=1)
-		]
-
-	sales_invoice_fields = [
-			dict(fieldname='company_trn', label='Company TRN',
-				fieldtype='Read Only', insert_after='company_address',
-				fetch_from='company.tax_id', print_hide=1),
-			dict(fieldname='customer_name_in_arabic', label='Customer Name in Arabic',
-				fieldtype='Read Only', insert_after='customer_name',
-				fetch_from='customer.customer_name_in_arabic', print_hide=1)
-		]
-
-	custom_fields = {
-		'Item': [is_zero_rated, is_exempt],
-		'Customer': [
-			dict(fieldname='customer_name_in_arabic', label='Customer Name in Arabic',
-				fieldtype='Data', insert_after='customer_name'),
-		],
-		'Supplier': [
-			dict(fieldname='supplier_name_in_arabic', label='Supplier Name in Arabic',
-				fieldtype='Data', insert_after='supplier_name'),
-		],
-		'Purchase Invoice': purchase_invoice_fields,
-		'Purchase Order': purchase_invoice_fields,
-		'Purchase Receipt': purchase_invoice_fields,
-		'Sales Invoice': sales_invoice_fields,
-		'POS Invoice': sales_invoice_fields,
-		'Sales Order': sales_invoice_fields,
-		'Delivery Note': sales_invoice_fields,
-		'Sales Invoice Item': [is_zero_rated, is_exempt],
-		'POS Invoice Item': [is_zero_rated, is_exempt],
-		'Purchase Invoice Item': [is_zero_rated, is_exempt],
-		'Sales Order Item': [is_zero_rated, is_exempt],
-		'Delivery Note Item': [is_zero_rated, is_exempt],
-		'Quotation Item': [is_zero_rated, is_exempt],
-		'Purchase Order Item': [is_zero_rated, is_exempt],
-		'Purchase Receipt Item': [is_zero_rated, is_exempt],
-		'Supplier Quotation Item': [is_zero_rated, is_exempt],
-	}
-
-	create_custom_fields(custom_fields)
 
 def add_print_formats():
 	frappe.reload_doc("regional", "print_format", "detailed_tax_invoice", force=True)
@@ -96,38 +38,67 @@ def make_custom_fields():
 	- Company Name in Arabic
 	- Address in Arabic
 	"""
+	is_zero_rated = dict(fieldname='is_zero_rated', label='Is Zero Rated',
+		fieldtype='Check', fetch_from='item_code.is_zero_rated', insert_after='description',
+		print_hide=1)
+	
+	is_exempt = dict(fieldname='is_exempt', label='Is Exempt',
+		fieldtype='Check', fetch_from='item_code.is_exempt', insert_after='is_zero_rated',
+		print_hide=1)
+
+	purchase_invoice_fields = [
+			dict(fieldname='company_trn', label='Company TRN',
+				fieldtype='Read Only', insert_after='shipping_address',
+				fetch_from='company.tax_id', print_hide=1),
+			dict(fieldname='supplier_name_in_arabic', label='Supplier Name in Arabic',
+				fieldtype='Read Only', insert_after='supplier_name',
+				fetch_from='supplier.supplier_name_in_arabic', print_hide=1)
+		]
+
+	sales_invoice_fields = [
+			dict(fieldname='company_trn', label='Company TRN',
+				fieldtype='Read Only', insert_after='company_address',
+				fetch_from='company.tax_id', print_hide=1),
+			dict(fieldname='customer_name_in_arabic', label='Customer Name in Arabic',
+				fieldtype='Read Only', insert_after='customer_name',
+				fetch_from='customer.customer_name_in_arabic', print_hide=1),
+			dict(fieldname='ksa_einv_qr', label='KSA E-Invoicing QR',
+				fieldtype='Attach Image', read_only=1, no_copy=1, hidden=1)
+		]
+
 	custom_fields = {
-		'Sales Invoice': [
-			dict(
-				fieldname='ksa_einv_qr',
-				label='KSA E-Invoicing QR',
-				fieldtype='Attach Image',
-				read_only=1, no_copy=1, hidden=1
-			)
+		'Item': [is_zero_rated, is_exempt],
+		'Customer': [
+			dict(fieldname='customer_name_in_arabic', label='Customer Name in Arabic',
+				fieldtype='Data', insert_after='customer_name'),
 		],
-		'POS Invoice': [
-			dict(
-				fieldname='ksa_einv_qr',
-				label='KSA E-Invoicing QR',
-				fieldtype='Attach Image',
-				read_only=1, no_copy=1, hidden=1
-			)
+		'Supplier': [
+			dict(fieldname='supplier_name_in_arabic', label='Supplier Name in Arabic',
+				fieldtype='Data', insert_after='supplier_name'),
 		],
+		'Purchase Invoice': purchase_invoice_fields,
+		'Purchase Order': purchase_invoice_fields,
+		'Purchase Receipt': purchase_invoice_fields,
+		'Sales Invoice': sales_invoice_fields,
+		'POS Invoice': sales_invoice_fields,
+		'Sales Order': sales_invoice_fields,
+		'Delivery Note': sales_invoice_fields,
+		'Sales Invoice Item': [is_zero_rated, is_exempt],
+		'POS Invoice Item': [is_zero_rated, is_exempt],
+		'Purchase Invoice Item': [is_zero_rated, is_exempt],
+		'Sales Order Item': [is_zero_rated, is_exempt],
+		'Delivery Note Item': [is_zero_rated, is_exempt],
+		'Quotation Item': [is_zero_rated, is_exempt],
+		'Purchase Order Item': [is_zero_rated, is_exempt],
+		'Purchase Receipt Item': [is_zero_rated, is_exempt],
+		'Supplier Quotation Item': [is_zero_rated, is_exempt],
 		'Address': [
-			dict(
-				fieldname='address_in_arabic',
-				label='Address in Arabic',
-				fieldtype='Data',
-				insert_after='address_line2'
-			)
+			dict(fieldname='address_in_arabic', label='Address in Arabic',
+				fieldtype='Data',insert_after='address_line2')
 		],
 		'Company': [
-			dict(
-				fieldname='company_name_in_arabic',
-				label='Company Name In Arabic',
-				fieldtype='Data',
-				insert_after='company_name'
-			)
+			dict(fieldname='company_name_in_arabic', label='Company Name In Arabic',
+				fieldtype='Data', insert_after='company_name')
 		]
 	}
 


### PR DESCRIPTION
If a company is created where country is Kingdom of Saudi Arabia, the system lazily copies the custom field creation from UAE setup. This PR aims to add only KSA specific fields upon setup.
Closes #29110