### PR TITLE
chore: change log for v13.18.0

### DIFF
--- a/erpnext/change_log/v13/v13_18_0.md
+++ b/erpnext/change_log/v13/v13_18_0.md
@@ -1,0 +1,43 @@
+# Version 13.18.0 Release Notes
+
+### Features & Enhancements
+
+- Deferred Revenue and Expense report with actual and upcoming postings ([#28822](https://github.com/frappe/erpnext/pull/28822))
+- 'Invoice Number' field in Opening Invoice Creation Tool ([#29147](https://github.com/frappe/erpnext/pull/29147))
+- Added required_date field to set date in child table ([#28432](https://github.com/frappe/erpnext/pull/28432))
+
+### Fixes
+
+- Enable ksa POS Invoice print format ([#28911](https://github.com/frappe/erpnext/pull/28911))
+- Rename non existent doctype field to the right one ([#29055](https://github.com/frappe/erpnext/pull/29055))
+- Mapped accounting dimensions for Bank Entry against Payroll Entry ([#29142](https://github.com/frappe/erpnext/pull/29142))
+- Validate Finished Goods for independent Manufacture entries ([#28555](https://github.com/frappe/erpnext/pull/28555))
+- Incorrect posting time fetching incorrect stock quantity in stock reconciliation ([#29103](https://github.com/frappe/erpnext/pull/29103))
+- Stock Ageing Report - Negative Opening Stock ([#28966](https://github.com/frappe/erpnext/pull/28966))
+- Can't change valuation_method on item ([#28876](https://github.com/frappe/erpnext/pull/28876))
+- Optimize rate updation on changing price list ([#28953](https://github.com/frappe/erpnext/pull/28953))
+- Added filter for dispatch address ([#28937](https://github.com/frappe/erpnext/pull/28937))
+- Convert Item links to Website Item links in `Item Card Group` template data ([#28985](https://github.com/frappe/erpnext/pull/28985))
+- Earned Leave allocation from Leave Policy Assignment ([#29163](https://github.com/frappe/erpnext/pull/29163))
+- Items not mapped when trying to create a Maintenance Visit via Maintenance Schedule ([#28917](https://github.com/frappe/erpnext/pull/28917))
+- For performance improvement, removed forcing of posting sort index on stock balance report ([#28902](https://github.com/frappe/erpnext/pull/28902))
+- Future recurring period calculation ([#29083](https://github.com/frappe/erpnext/pull/29083))
+- Nonstock items are showing in the Itemwise Recommended Reorder Level report ([#28873](https://github.com/frappe/erpnext/pull/28873))
+- Incorrect amount based on payment days in timesheet salary slip ([#28845](https://github.com/frappe/erpnext/pull/28845))
+- Currency fix for `cost` field in subscription plan ([#28821](https://github.com/frappe/erpnext/pull/28821))
+- Fetch selling price with pricing rule ([#28951](https://github.com/frappe/erpnext/pull/28951))
+- Filter out Claimed employee advances in Expense Claim ([#29046](https://github.com/frappe/erpnext/pull/29046))
+- Tax and Charges template not getting fetched based on tax category assigned ([#29092](https://github.com/frappe/erpnext/pull/29092))
+- Ignore links while setting default notification templates in Settings ([#29042](https://github.com/frappe/erpnext/pull/29042))
+- Reset "Value After Depreciation" on reversing journal entry during Asset return ([#28975](https://github.com/frappe/erpnext/pull/28975))
+- Multicurrency invoices using subscription ([#28916](https://github.com/frappe/erpnext/pull/28916))
+- Fetch the appointment letter content in the same order as template ([#28968](https://github.com/frappe/erpnext/pull/28968))
+- Incorrect serial no valuation report showing cancelled entries ([#29172](https://github.com/frappe/erpnext/pull/29172))
+- Start date validation for deferred invoices ([#29009](https://github.com/frappe/erpnext/pull/29009))
+- HSN-Wise summary report is incorrect if an invoice has same item code multiple times ([#28783](https://github.com/frappe/erpnext/pull/28783))
+- Incorrect logic for the "Reserved Qty for Production" field in BIN ([#28880](https://github.com/frappe/erpnext/pull/28880))
+- Issues in Bank Reconciliation tool ([#28996](https://github.com/frappe/erpnext/pull/28996))
+- Hide Raw Material table in the Job Card if material transfer is against work order ([#28746](https://github.com/frappe/erpnext/pull/28746))
+- Added "Is Reverse Charge" checkbox in Tax Category for Indian Companies ([#28935](https://github.com/frappe/erpnext/pull/28935))
+- Updates in term loan processing ([#28034](https://github.com/frappe/erpnext/pull/28034))
+- Incorrect bin qty on backdated reconciliation ([#28588](https://github.com/frappe/erpnext/pull/28588))


### PR DESCRIPTION
# Version 13.18.0 Release Notes

### Features & Enhancements

- Deferred Revenue and Expense report with actual and upcoming postings ([#28822](https://github.com/frappe/erpnext/pull/28822))
- 'Invoice Number' field in Opening Invoice Creation Tool ([#29147](https://github.com/frappe/erpnext/pull/29147))
- Added required_date field to set date in child table ([#28432](https://github.com/frappe/erpnext/pull/28432))

### Fixes

- Enable ksa POS Invoice print format ([#28911](https://github.com/frappe/erpnext/pull/28911))
- Rename non existent doctype field to the right one ([#29055](https://github.com/frappe/erpnext/pull/29055))
- Mapped accounting dimensions for Bank Entry against Payroll Entry ([#29142](https://github.com/frappe/erpnext/pull/29142))
- Validate Finished Goods for independent Manufacture entries ([#28555](https://github.com/frappe/erpnext/pull/28555))
- Incorrect posting time fetching incorrect stock quantity in stock reconciliation ([#29103](https://github.com/frappe/erpnext/pull/29103))
- Stock Ageing Report - Negative Opening Stock ([#28966](https://github.com/frappe/erpnext/pull/28966))
- Can't change valuation_method on item ([#28876](https://github.com/frappe/erpnext/pull/28876))
- Optimize rate updation on changing price list ([#28953](https://github.com/frappe/erpnext/pull/28953))
- Added filter for dispatch address ([#28937](https://github.com/frappe/erpnext/pull/28937))
- Convert Item links to Website Item links in `Item Card Group` template data ([#28985](https://github.com/frappe/erpnext/pull/28985))
- Earned Leave allocation from Leave Policy Assignment ([#29163](https://github.com/frappe/erpnext/pull/29163))
- Items not mapped when trying to create a Maintenance Visit via Maintenance Schedule ([#28917](https://github.com/frappe/erpnext/pull/28917))
- For performance improvement, removed forcing of posting sort index on stock balance report ([#28902](https://github.com/frappe/erpnext/pull/28902))
- Future recurring period calculation ([#29083](https://github.com/frappe/erpnext/pull/29083))
- Nonstock items are showing in the Itemwise Recommended Reorder Level report ([#28873](https://github.com/frappe/erpnext/pull/28873))
- Incorrect amount based on payment days in timesheet salary slip ([#28845](https://github.com/frappe/erpnext/pull/28845))
- Currency fix for `cost` field in subscription plan ([#28821](https://github.com/frappe/erpnext/pull/28821))
- Fetch selling price with pricing rule ([#28951](https://github.com/frappe/erpnext/pull/28951))
- Filter out Claimed employee advances in Expense Claim ([#29046](https://github.com/frappe/erpnext/pull/29046))
- Tax and Charges template not getting fetched based on tax category assigned ([#29092](https://github.com/frappe/erpnext/pull/29092))
- Ignore links while setting default notification templates in Settings ([#29042](https://github.com/frappe/erpnext/pull/29042))
- Reset "Value After Depreciation" on reversing journal entry during Asset return ([#28975](https://github.com/frappe/erpnext/pull/28975))
- Multicurrency invoices using subscription ([#28916](https://github.com/frappe/erpnext/pull/28916))
- Fetch the appointment letter content in the same order as template ([#28968](https://github.com/frappe/erpnext/pull/28968))
- Incorrect serial no valuation report showing cancelled entries ([#29172](https://github.com/frappe/erpnext/pull/29172))
- Start date validation for deferred invoices ([#29009](https://github.com/frappe/erpnext/pull/29009))
- HSN-Wise summary report is incorrect if an invoice has same item code multiple times ([#28783](https://github.com/frappe/erpnext/pull/28783))
- Incorrect logic for the "Reserved Qty for Production" field in BIN ([#28880](https://github.com/frappe/erpnext/pull/28880))
- Issues in Bank Reconciliation tool ([#28996](https://github.com/frappe/erpnext/pull/28996))
- Hide Raw Material table in the Job Card if material transfer is against work order ([#28746](https://github.com/frappe/erpnext/pull/28746))
- Added "Is Reverse Charge" checkbox in Tax Category for Indian Companies ([#28935](https://github.com/frappe/erpnext/pull/28935))
- Updates in term loan processing ([#28034](https://github.com/frappe/erpnext/pull/28034))
- Incorrect bin qty on backdated reconciliation ([#28588](https://github.com/frappe/erpnext/pull/28588))