### PR TITLE
fix: incorrect scrap item qty

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -2,7 +2,7 @@
 # License: GNU General Public License v3. See license.txt
 
 import frappe
-from frappe.utils import add_months, cint, flt, now, today
+from frappe.utils import add_days, add_months, cint, flt, now, today
 
 from erpnext.manufacturing.doctype.job_card.job_card import JobCardCancelError
 from erpnext.manufacturing.doctype.production_plan.test_production_plan import make_bom
@@ -12,6 +12,7 @@ from erpnext.manufacturing.doctype.work_order.work_order import (
 	OverProductionError,
 	StockOverProductionError,
 	close_work_order,
+	make_job_card,
 	make_stock_entry,
 	stop_unstop,
 )
@@ -804,6 +805,34 @@ class TestWorkOrder(ERPNextTestCase):
 			if row.is_scrap_item:
 				self.assertEqual(row.qty, 1)
 
+		# Partial Job Card 1 with qty 10
+		wo_order = make_wo_order_test_record(item=item, company=company, planned_start_date=add_days(now(), 60), qty=20, skip_transfer=1)
+		job_card = frappe.db.get_value('Job Card', {'work_order': wo_order.name}, 'name')
+		update_job_card(job_card, 10)
+
+		stock_entry = frappe.get_doc(make_stock_entry(wo_order.name, "Manufacture", 10))
+		for row in stock_entry.items:
+			if row.is_scrap_item:
+				self.assertEqual(row.qty, 2)
+
+		# Partial Job Card 2 with qty 10
+		operations = []
+		wo_order.load_from_db()
+		for row in wo_order.operations:
+			n_dict = row.as_dict()
+			n_dict['qty'] = 10
+			n_dict['pending_qty'] = 10
+			operations.append(n_dict)
+
+		make_job_card(wo_order.name, operations)
+		job_card = frappe.db.get_value('Job Card', {'work_order': wo_order.name, 'docstatus': 0}, 'name')
+		update_job_card(job_card, 10)
+
+		stock_entry = frappe.get_doc(make_stock_entry(wo_order.name, "Manufacture", 10))
+		for row in stock_entry.items:
+			if row.is_scrap_item:
+				self.assertEqual(row.qty, 2)
+
 	def test_close_work_order(self):
 		items = ['Test FG Item for Closed WO', 'Test RM Item 1 for Closed WO',
 			'Test RM Item 2 for Closed WO']
@@ -883,7 +912,8 @@ class TestWorkOrder(ERPNextTestCase):
 		self.assertEqual(wo1.operations[0].time_in_mins, wo2.operations[0].time_in_mins)
 
 
-def update_job_card(job_card):
+def update_job_card(job_card, jc_qty=None):
+	employee = frappe.db.get_value('Employee', {'status': 'Active'}, 'name')
 	job_card_doc = frappe.get_doc('Job Card', job_card)
 	job_card_doc.set('scrap_items', [
 		{
@@ -896,8 +926,12 @@ def update_job_card(job_card):
 		},
 	])
 
+	if jc_qty:
+		job_card_doc.for_quantity = jc_qty
+
 	job_card_doc.append('time_logs', {
 		'from_time': now(),
+		'employee': employee,
 		'time_in_mins': 60,
 		'completed_qty': job_card_doc.for_quantity
 	})

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -8,6 +8,7 @@ from collections import defaultdict
 import frappe
 from frappe import _
 from frappe.model.mapper import get_mapped_doc
+from frappe.query_builder.functions import Sum
 from frappe.utils import cint, comma_or, cstr, flt, format_time, formatdate, getdate, nowdate
 
 import erpnext
@@ -1275,21 +1276,28 @@ class StockEntry(StockController):
 		if not self.pro_doc:
 			self.set_work_order_details()
 
-		scrap_items = frappe.db.sql('''
-			SELECT
-				JCSI.item_code, JCSI.item_name, SUM(JCSI.stock_qty) as stock_qty, JCSI.stock_uom, JCSI.description
-			FROM
-				`tabJob Card` JC, `tabJob Card Scrap Item` JCSI
-			WHERE
-				JCSI.parent = JC.name AND JC.docstatus = 1
-				AND JCSI.item_code IS NOT NULL AND JC.work_order = %s
-			GROUP BY
-				JCSI.item_code
-		''', self.work_order, as_dict=1)
-
-		pending_qty = flt(self.pro_doc.qty) - flt(self.pro_doc.produced_qty)
-		if pending_qty <=0:
+		if not self.pro_doc.operations:
 			return []
+
+		job_card = frappe.qb.DocType('Job Card')
+		job_card_scrap_item = frappe.qb.DocType('Job Card Scrap Item')
+
+		scrap_items = (
+			frappe.qb.from_(job_card)
+			.select(
+				Sum(job_card_scrap_item.stock_qty).as_('stock_qty'),
+				job_card_scrap_item.item_code, job_card_scrap_item.item_name,
+				job_card_scrap_item.description, job_card_scrap_item.stock_uom)
+			.join(job_card_scrap_item)
+			.on(job_card_scrap_item.parent == job_card.name)
+			.where(
+				(job_card_scrap_item.item_code.isnotnull())
+				& (job_card.work_order == self.work_order)
+				& (job_card.docstatus == 1))
+			.groupby(job_card_scrap_item.item_code)
+		).run(as_dict=1)
+
+		pending_qty = flt(self.get_completed_job_card_qty()) - flt(self.pro_doc.produced_qty)
 
 		used_scrap_items = self.get_used_scrap_items()
 		for row in scrap_items:
@@ -1303,6 +1311,9 @@ class StockEntry(StockController):
 				row.stock_qty = frappe.utils.ceil(row.stock_qty)
 
 		return scrap_items
+
+	def get_completed_job_card_qty(self):
+		return flt(min([d.completed_qty for d in self.pro_doc.operations]))
 
 	def get_used_scrap_items(self):
 		used_scrap_items = defaultdict(float)


### PR DESCRIPTION
## **Issue**

The scrap qty in the Manufacture stock entry calculated incorrectly

Steps to replicate the issue

1. Create work order with qty 1000 and 2 operations
2. Enable "Skip Material Transfer to WIP Warehouse" in the work order and submit it.
2. On submission of the work order, system has created 2 job card with 1000 qty each against 2 operations
3. Modified "Qty To Manufacture" from 1000 to 800 in the first job and added two scrap items as per below image and then submitted

<img width="1126" alt="Screenshot 2022-01-07 at 12 39 51 AM" src="https://user-images.githubusercontent.com/8780500/148437875-cac62a09-1162-4f41-9ab4-6679d540c4e6.png">


5. Open the second job card and Modified "Qty To Manufacture" from 1000 to 800 in the job card and added two scrap items as per below image and then submitted

<img width="1094" alt="Screenshot 2022-01-07 at 12 41 46 AM" src="https://user-images.githubusercontent.com/8780500/148438026-e830b5c5-f527-412a-a434-165e4bd93681.png">

6. After that Open the Work Order and clicked on finish button, system has open the popup to set the Qty for Manufacture
7. Set the Qty for Manufacture as 800 and clicked on Create button
<img width="708" alt="Screenshot 2022-01-07 at 12 44 30 AM" src="https://user-images.githubusercontent.com/8780500/148438365-45ed313c-3085-4fa3-a26d-efed1d704c31.png">

8. System has opened the stock entry where the scrap items are showing the incorrect quantity 

<img width="1076" alt="Screenshot 2022-01-06 at 2 11 35 PM" src="https://user-images.githubusercontent.com/8780500/148438561-bd67e651-628b-4537-a699-f996b7ba9306.png">

First item should show qty as 40 and second as 25


## **After Fix**

System showing the correct qty for the scrap items
<img width="1064" alt="Screenshot 2022-01-06 at 2 38 04 PM" src="https://user-images.githubusercontent.com/8780500/148438740-f8f83e28-aca4-4792-b645-d41eae605a5e.png">

