### PR TITLE
fix: allow website permissions for administrator

### DIFF
--- a/erpnext/controllers/website_list_for_contact.py
+++ b/erpnext/controllers/website_list_for_contact.py
@@ -183,6 +183,9 @@ def get_customers_suppliers(doctype, user):
 		suppliers if has_supplier_field else None
 
 def has_website_permission(doc, ptype, user, verbose=False):
+	if user == 'Administrator':
+		return True
+		
 	doctype = doc.doctype
 	customers, suppliers = get_customers_suppliers(doctype, user)
 	if customers:


### PR DESCRIPTION
***Issue***
Administrator does not have any website permission.


****Before****

https://user-images.githubusercontent.com/58825865/148497164-85a05e16-423f-4ca2-a767-bd7714e45925.mov

****After****

https://user-images.githubusercontent.com/58825865/148497192-420133ec-508d-4ebc-9742-a9fcb22c17dd.mov


***Steps to reproduce***
1. log in as administrator
2. go to /me page
3. From the sidebar, go to any page (i.e., invoices, orders or quotations)
4. click on any item from the list

****Result****
Not permitted error

****Expected****
Since you are an administrator, you should be able to see the pages.