### PR TITLE
fix: deferred report division by zero exception

### DIFF
--- a/erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.py
+++ b/erpnext/accounts/report/deferred_revenue_and_expense/deferred_revenue_and_expense.py
@@ -121,20 +121,21 @@ class Deferred_Item(object):
 		"""
 		simulate future posting by creating dummy gl entries. starts from the last posting date.
 		"""
-		if add_days(self.last_entry_date, 1) < self.period_list[-1].to_date:
-			self.estimate_for_period_list = get_period_list(
-				self.filters.from_fiscal_year,
-				self.filters.to_fiscal_year,
-				add_days(self.last_entry_date, 1),
-				self.period_list[-1].to_date,
-				"Date Range",
-				"Monthly",
-				company=self.filters.company,
-			)
-			for period in self.estimate_for_period_list:
-				amount = self.calculate_amount(period.from_date, period.to_date)
-				gle = self.make_dummy_gle(period.key, period.to_date, amount)
-				self.gle_entries.append(gle)
+		if self.service_start_date != self.service_end_date:
+			if add_days(self.last_entry_date, 1) < self.period_list[-1].to_date:
+				self.estimate_for_period_list = get_period_list(
+					self.filters.from_fiscal_year,
+					self.filters.to_fiscal_year,
+					add_days(self.last_entry_date, 1),
+					self.period_list[-1].to_date,
+					"Date Range",
+					"Monthly",
+					company=self.filters.company,
+				)
+				for period in self.estimate_for_period_list:
+					amount = self.calculate_amount(period.from_date, period.to_date)
+					gle = self.make_dummy_gle(period.key, period.to_date, amount)
+					self.gle_entries.append(gle)
 
 	def calculate_item_revenue_expense_for_period(self):
 		"""


### PR DESCRIPTION
Fixing issue where 'Deferred Revenue and Expense Report' throws exception if deferred item has no period (0 months).


<img width="945" alt="Screenshot 2022-01-07 at 6 05 18 PM" src="https://user-images.githubusercontent.com/3272205/148544968-ef2951c8-b755-4382-b7a2-f29772716f15.png">

