### PR TITLE
fix: Exclude unpublished items while fetching items from other item groups

### DIFF
--- a/erpnext/e_commerce/product_data_engine/query.py
+++ b/erpnext/e_commerce/product_data_engine/query.py
@@ -197,7 +197,10 @@ class ProductQuery:
 			website_item_groups = frappe.db.get_all(
 				"Website Item",
 				fields=self.fields + ["`tabWebsite Item Group`.parent as wig_parent"],
-				filters=[["Website Item Group", "item_group", "=", item_group]]
+				filters=[
+					["Website Item Group", "item_group", "=", item_group],
+					["published", "=", 1]
+				]
 			)
 		return website_item_groups
 


### PR DESCRIPTION
**Issue:**
- Assume Item A belonging to Item Group **Products** and Item B belonging to Item Group**Accessories**
- Add **Accessories** to Website Item A's **Website Item Groups table**.
- In Item Group **Accessories** page, we expect to see Item B and also Item A (which actually belongs to **Products** but should be visible in **Accessories** as well)
- Now, **unpublish** Item A (untick the published button in the website item)
- Item A is still visible in the **Accessories** page (it should not be)

**Fix:**
- Add `published` as a filter while fetching Items from Website Item Groups table too