### PR TITLE
fix: use `get_all` instead of `get_list` while fetching SLA doctypes

### DIFF
--- a/erpnext/support/doctype/service_level_agreement/service_level_agreement.py
+++ b/erpnext/support/doctype/service_level_agreement/service_level_agreement.py
@@ -853,7 +853,7 @@ def get_user_time(user, to_string=False):
 @frappe.whitelist()
 def get_sla_doctypes():
 	doctypes = []
-	data = frappe.get_list('Service Level Agreement',
+	data = frappe.get_all('Service Level Agreement',
 		{'enabled': 1},
 		['document_type'],
 		distinct=1


### PR DESCRIPTION
`get_sla_doctypes` is called on the `app_ready` event to show the SLA dashboard on whichever doctypes it is configured for. Due to this, users who have nothing to do with SLA get insufficient permission pop-up

![image](https://user-images.githubusercontent.com/24353136/148763168-bb7122dd-cd62-4e77-a91b-3ed2ff46e558.png)

Use `get_all` instead of instead of `get_list` to ignore permissions 