### PR TITLE
fix: loosen dependencies for pandas

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ braintree==3.57.1
 # frappe   # https://github.com/frappe/frappe is installed during bench-init
 gocardless-pro==1.11.0
 googlemaps==3.1.1
-pandas==0.24.2
+pandas>=0.24.0,<1.2.0
 plaid-python~=7.2.1
 PyGithub==1.44.1
 python-stdnum==1.12


### PR DESCRIPTION
Pandas dependency causes many installation failures because:
1. It has massive transitive dependencies of compiled things like the NumPy stack. This is much better in recent versions but for older versions, compiled wheels are often not available. 
2. Version-12 right now supports python 2.7 💩 to ~3.8. The pinned version doesn't have wheel for all of them because some of those versions didn't even exist when it was released 😄 


I checked the changelog wherever this is used. It's only used in a report and datev functionality both do not seem to use breaking changes from v0 to v1 in pandas. 


The ideal solution is to of course just remove this dependency totally. It's used as a crutch for very basic data transformations: https://github.com/frappe/erpnext/issues/27047 