### PR TITLE
fix: Behaviour of Item Variants Cache generation

### DIFF
--- a/erpnext/e_commerce/doctype/website_item/website_item.py
+++ b/erpnext/e_commerce/doctype/website_item/website_item.py
@@ -203,16 +203,15 @@ class WebsiteItem(WebsiteGenerator):
 		context.body_class = "product-page"
 
 		context.parents = get_parent_item_groups(self.item_group, from_item=True) # breadcumbs
-		self.attributes = frappe.get_all("Item Variant Attribute",
+		self.attributes = frappe.get_all(
+			"Item Variant Attribute",
 			fields=["attribute", "attribute_value"],
-			filters={"parent": self.item_code})
+			filters={"parent": self.item_code}
+		)
 
 		if self.slideshow:
 			context.update(get_slideshow(self))
 
-		self.set_variant_context(context)
-		self.set_attribute_context(context)
-		self.set_disabled_attributes(context)
 		self.set_metatags(context)
 		self.set_shopping_cart_data(context)
 
@@ -236,61 +235,6 @@ class WebsiteItem(WebsiteGenerator):
 			context.recommended_items = self.get_recommended_items(settings)
 
 		return context
-
-	def set_variant_context(self, context):
-		if not self.has_variants:
-			return
-
-		context.no_cache = True
-		variant = frappe.form_dict.variant
-
-		# load variants
-		# also used in set_attribute_context
-		context.variants = frappe.get_all(
-			"Item",
-			filters={
-				"variant_of": self.item_code,
-				"published_in_website": 1
-			},
-			order_by="name asc")
-
-		# the case when the item is opened for the first time from its list
-		if not variant and context.variants:
-			variant = context.variants[0]
-
-		if variant:
-			context.variant = frappe.get_doc("Item", variant)
-			fields = ("website_image", "website_image_alt", "web_long_description", "description",
-				"website_specifications")
-
-			for fieldname in fields:
-				if context.variant.get(fieldname):
-					value = context.variant.get(fieldname)
-					if isinstance(value, list):
-						value = [d.as_dict() for d in value]
-
-					context[fieldname] = value
-
-		if self.slideshow and context.variant and context.variant.slideshow:
-			context.update(get_slideshow(context.variant))
-
-
-	def set_attribute_context(self, context):
-		if not self.has_variants:
-			return
-
-		attribute_values_available = {}
-		context.attribute_values = {}
-		context.selected_attributes = {}
-
-		# load attributes
-		self.set_selected_attributes(context.variants, context, attribute_values_available)
-
-		# filter attributes, order based on attribute table
-		item = frappe.get_cached_doc("Item", self.item_code)
-		self.set_attribute_values(item.attributes, context, attribute_values_available)
-
-		context.variant_info = json.dumps(context.variants)
 
 	def set_selected_attributes(self, variants, context, attribute_values_available):
 		for variant in variants:
@@ -327,50 +271,6 @@ class WebsiteItem(WebsiteGenerator):
 
 					if attr_value.attribute_value in attribute_values_available.get(attr.attribute, []):
 						values.append(attr_value.attribute_value)
-
-	def set_disabled_attributes(self, context):
-		"""Disable selection options of attribute combinations that do not result in a variant"""
-
-		if not self.attributes or not self.has_variants:
-			return
-
-		context.disabled_attributes = {}
-		attributes = [attr.attribute for attr in self.attributes]
-
-		def find_variant(combination):
-			for variant in context.variants:
-				if len(variant.attributes) < len(attributes):
-					continue
-
-				if "combination" not in variant:
-					ref_combination = []
-
-					for attr in variant.attributes:
-						idx = attributes.index(attr.attribute)
-						ref_combination.insert(idx, attr.attribute_value)
-
-					variant["combination"] = ref_combination
-
-				if not (set(combination) - set(variant["combination"])):
-					# check if the combination is a subset of a variant combination
-					# eg. [Blue, 0.5] is a possible combination if exists [Blue, Large, 0.5]
-					return True
-
-		for i, attr in enumerate(self.attributes):
-			if i == 0:
-				continue
-
-			combination_source = []
-
-			# loop through previous attributes
-			for prev_attr in self.attributes[:i]:
-				combination_source.append([context.selected_attributes.get(prev_attr.attribute)])
-
-			combination_source.append(context.attribute_values[attr.attribute])
-
-			for combination in itertools.product(*combination_source):
-				if not find_variant(combination):
-					context.disabled_attributes.setdefault(attr.attribute, []).append(combination[-1])
 
 	def set_metatags(self, context):
 		context.metatags = frappe._dict({})

--- a/erpnext/e_commerce/doctype/website_item/website_item.py
+++ b/erpnext/e_commerce/doctype/website_item/website_item.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
-import itertools
 import json
 
 import frappe

--- a/erpnext/e_commerce/variant_selector/test_variant_selector.py
+++ b/erpnext/e_commerce/variant_selector/test_variant_selector.py
@@ -39,8 +39,7 @@ class TestVariantSelector(unittest.TestCase):
 		})
 		variant.save()
 
-	@classmethod
-	def tearDownClass(cls):
+	def tearDown(self):
 		frappe.db.rollback()
 
 	def test_item_attributes(self):
@@ -71,6 +70,10 @@ class TestVariantSelector(unittest.TestCase):
 
 		# Only L and M attribute values must be fetched since S is disabled
 		self.assertEqual(len(attr_data[0]["values"]), 2)  # ['Medium', 'Large']
+
+		# teardown
+		small_variant.disabled = 1
+		small_variant.save()
 
 	def test_next_item_variant_values(self):
 		"""

--- a/erpnext/e_commerce/variant_selector/test_variant_selector.py
+++ b/erpnext/e_commerce/variant_selector/test_variant_selector.py
@@ -1,5 +1,6 @@
-import frappe
 import unittest
+
+import frappe
 
 from erpnext.controllers.item_variant import create_variant
 from erpnext.e_commerce.doctype.website_item.website_item import make_website_item
@@ -71,18 +72,22 @@ class TestVariantSelector(unittest.TestCase):
 		# Only L and M attribute values must be fetched since S is disabled
 		self.assertEqual(len(attr_data[0]["values"]), 2)  # ['Medium', 'Large']
 
-	# def test_next_item_variant_values(self):
-	# 	"""
-	# 		Test if on selecting an attribute value, the next possible values
-	# 		are filtered accordingly.
-	# 		Values that dont apply should not be fetched.
-	# 		E.g.
-	# 		There is a ** Small-Red ** Tshirt. No other colour in this size.
-	# 		On selecting ** Small **, only ** Red ** should be selectable next.
-	# 	"""
-	# 	from erpnext.e_commerce.variant_selector.utils import get_next_attribute_and_values
+	def test_next_item_variant_values(self):
+		"""
+			Test if on selecting an attribute value, the next possible values
+			are filtered accordingly.
+			Values that dont apply should not be fetched.
+			E.g.
+			There is a ** Small-Red ** Tshirt. No other colour in this size.
+			On selecting ** Small **, only ** Red ** should be selectable next.
+		"""
+		from erpnext.e_commerce.variant_selector.utils import get_next_attribute_and_values
 
-	# 	next_values = get_next_attribute_and_values("Test-Tshirt-Temp", selected_attributes={
-	# 		"Colour": "Red"
-	# 	})
-	# 	print(next_values)
+		next_values = get_next_attribute_and_values("Test-Tshirt-Temp", selected_attributes={"Test Size": "Small"})
+		next_colours = next_values["valid_options_for_attributes"]["Test Colour"]
+		filtered_items = next_values["filtered_items"]
+
+		self.assertEqual(len(next_colours), 1)
+		self.assertEqual(next_colours.pop(), "Red")
+		self.assertEqual(len(filtered_items), 1)
+		self.assertEqual(filtered_items.pop(), "Test-Tshirt-Temp-S-R")

--- a/erpnext/e_commerce/variant_selector/test_variant_selector.py
+++ b/erpnext/e_commerce/variant_selector/test_variant_selector.py
@@ -1,11 +1,88 @@
-# import frappe
+import frappe
 import unittest
 
-# from erpnext.e_commerce.product_data_engine.query import ProductQuery
-# from erpnext.e_commerce.doctype.website_item.website_item import make_website_item
+from erpnext.controllers.item_variant import create_variant
+from erpnext.e_commerce.doctype.website_item.website_item import make_website_item
+from erpnext.stock.doctype.item.test_item import make_item
 
 test_dependencies = ["Item"]
 
 class TestVariantSelector(unittest.TestCase):
-	# TODO: Variant Selector Tests
-	pass
+
+	def setUp(self) -> None:
+		self.template_item = make_item("Test-Tshirt-Temp", {
+			"has_variant": 1,
+			"variant_based_on": "Item Attribute",
+			"attributes": [
+				{
+					"attribute": "Test Size"
+				},
+				{
+					"attribute": "Test Colour"
+				}
+			]
+		})
+
+		# create L-R, L-G, M-R, M-G and S-R
+		for size in ("Large", "Medium",):
+			for colour in ("Red", "Green",):
+				variant = create_variant("Test-Tshirt-Temp", {
+					"Test Size": size,
+					"Test Colour": colour
+				})
+				variant.save()
+
+		variant = create_variant("Test-Tshirt-Temp", {
+			"Test Size": "Small",
+			"Test Colour": "Red"
+		})
+		variant.save()
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.db.rollback()
+
+	def test_item_attributes(self):
+		"""
+			Test if the right attributes are fetched in the popup.
+			(Attributes must only come from active items)
+
+			Attribute selection must not be linked to Website Items.
+		"""
+		from erpnext.e_commerce.variant_selector.utils import get_attributes_and_values
+
+		make_website_item(self.template_item) # publish template not variants
+
+		attr_data = get_attributes_and_values("Test-Tshirt-Temp")
+
+		self.assertEqual(attr_data[0]["attribute"], "Test Size")
+		self.assertEqual(attr_data[1]["attribute"], "Test Colour")
+		self.assertEqual(len(attr_data[0]["values"]), 3) # ['Small', 'Medium', 'Large']
+		self.assertEqual(len(attr_data[1]["values"]), 2) # ['Red', 'Green']
+
+		# disable small red tshirt, now there are no small tshirts.
+		# but there are some red tshirts
+		small_variant = frappe.get_doc("Item", "Test-Tshirt-Temp-S-R")
+		small_variant.disabled = 1
+		small_variant.save() # trigger cache rebuild
+
+		attr_data = get_attributes_and_values("Test-Tshirt-Temp")
+
+		# Only L and M attribute values must be fetched since S is disabled
+		self.assertEqual(len(attr_data[0]["values"]), 2)  # ['Medium', 'Large']
+
+	# def test_next_item_variant_values(self):
+	# 	"""
+	# 		Test if on selecting an attribute value, the next possible values
+	# 		are filtered accordingly.
+	# 		Values that dont apply should not be fetched.
+	# 		E.g.
+	# 		There is a ** Small-Red ** Tshirt. No other colour in this size.
+	# 		On selecting ** Small **, only ** Red ** should be selectable next.
+	# 	"""
+	# 	from erpnext.e_commerce.variant_selector.utils import get_next_attribute_and_values
+
+	# 	next_values = get_next_attribute_and_values("Test-Tshirt-Temp", selected_attributes={
+	# 		"Colour": "Red"
+	# 	})
+	# 	print(next_values)


### PR DESCRIPTION
**Issue:**
- Currently for certain attributes to be pulled in the **Item Configuration** popup, the Variant Item needs to be published or needs to be a Website Item.
- E.g. if colour **Red** must be there in the popup, at least one variant with colour 'Red' must be a Website Item.
- In some cases users don't want full page views/Website Items for variants. They only want it to be selectable in the Variant Selector.
- **Website Item and Variant popup should ideally have no direct dependence.**
- This resulted in users making Website Items for each variant (which is a bit useless since no full page views of variants are required)and increased db size

**Old Behaviour:**
-  Before the e-commerce refactor, **all variant attributes were pulled given that the variant was not disabled.**
- That means all variants will be able to be added to cart unless they are disabled

**Fix:**
- Revert to old behaviour. Showing select variants will be taken up later as a better designed feature
- Deleted unused functions that contributed to nothing and did unnecessary computation. All variant/attributes computation is done by `ItemVariantsCache`. So its not need in `get_context`

### **To Test:**
Item Variant popup in template item web page
**Case 1:**
- Make template e.g. tshirt (and publish) and variants large-red, large-green, medium-red, medium-green and small-red
- Disable variant small-red
- go to popup on template web page, size dropdown should only show **large** and **medium** , since item with small attribute is disabled and theres no other item with this attribute.

**Case 2:**
- Make template e.g. tshirt (and publish) and variants large-red, large-green, medium-red, medium-green and small-red
- select size "small". 
- Now open the color dropdown, only **red** should be a valid attribute value since only red is available in small size (small-red item)

ToDo:
- [x] Tests
