### PR TITLE
fix(Payroll): Cannot submit salary slips from amended payroll entry.

### DIFF
--- a/erpnext/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/erpnext/payroll/doctype/payroll_entry/payroll_entry.py
@@ -60,8 +60,8 @@ class PayrollEntry(Document):
 	def on_cancel(self):
 		frappe.delete_doc("Salary Slip", frappe.db.sql_list("""select name from `tabSalary Slip`
 			where payroll_entry=%s """, (self.name)))
-		self.salary_slips_created = False
-		self.salary_slips_submitted = False
+		self.db_set("salary_slips_created", 0)
+		self.db_set("salary_slips_submitted", 0)
 
 	def get_emp_list(self):
 		"""

--- a/erpnext/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/erpnext/payroll/doctype/payroll_entry/payroll_entry.py
@@ -60,6 +60,8 @@ class PayrollEntry(Document):
 	def on_cancel(self):
 		frappe.delete_doc("Salary Slip", frappe.db.sql_list("""select name from `tabSalary Slip`
 			where payroll_entry=%s """, (self.name)))
+		self.salary_slips_created = False
+		self.salary_slips_submitted = False
 
 	def get_emp_list(self):
 		"""


### PR DESCRIPTION
**Problem**
When cancelling a payroll entry, the amended payroll entry retains the transaction state of the previously cancelled payroll entry for the linked salary slips.
Example:
![payroll-entry-ammend](https://user-images.githubusercontent.com/29856401/149170524-b1063c2c-181a-4864-a921-a44b15eb0731.gif)

**After PR**
![payroll-entry-ammend-fix](https://user-images.githubusercontent.com/29856401/149171474-a404be7c-69b0-4324-80c3-3ee33ab0fe03.gif)

