### PR TITLE
fix: Added validation for serial nos selected at POS invoice level

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -214,6 +214,7 @@ class POSInvoice(SalesInvoice):
 			frappe.throw(error_msg, title=_("Invalid Item"), as_list=True)
 
 	def validate_serial_nos(self):
+		from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos
 		error_msg = []
 		for item in self.get("items"):
 			serialized = item.get("has_serial_no")
@@ -221,7 +222,7 @@ class POSInvoice(SalesInvoice):
 			if serialized:
 				valid_serial_nos = frappe.get_all('Serial No', filters={'item_code':item.get("item_code")}, pluck="name")
 				invalid_serials = ""
-				for serial_no in item.get('serial_no').split("\n"):
+				for serial_no in get_serial_nos(item.get('serial_no')):
 					if serial_no not in valid_serial_nos:
 						invalid_serials = ", " if invalid_serials else "" + invalid_serials + serial_no
 						msg = (_("Row #{}: Following Serial numbers for item {} are <b>invalid</b>: {}").format(item.idx, frappe.bold(item.get("item_code")), frappe.bold(invalid_serials)))

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -217,10 +217,9 @@ class POSInvoice(SalesInvoice):
 		error_msg = []
 		for item in self.get("items"):
 			serialized = item.get("has_serial_no")
-			valid_serial_nos = frappe.get_all('Serial No', filters={'item_code':item.get("item_code")}, pluck="name")
-
 			msg = ""
 			if serialized:
+				valid_serial_nos = frappe.get_all('Serial No', filters={'item_code':item.get("item_code")}, pluck="name")
 				invalid_serials = ""
 				for serial_no in item.get('serial_no').split("\n"):
 					if serial_no not in valid_serial_nos:

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -220,12 +220,12 @@ class POSInvoice(SalesInvoice):
 			serialized = item.get("has_serial_no")
 			msg = ""
 			if serialized:
-				valid_serial_nos = frappe.get_all('Serial No', filters={'item_code':item.get("item_code")}, pluck="name")
+				valid_serial_nos = frappe.get_all('Serial No', filters={'item_code':item.get("item_code"), "status":'Active'}, pluck="name")
 				invalid_serials = ""
 				for serial_no in get_serial_nos(item.get('serial_no')):
 					if serial_no not in valid_serial_nos:
 						invalid_serials = ", " if invalid_serials else "" + invalid_serials + serial_no
-						msg = (_("Row #{}: Following Serial numbers for item {} are <b>invalid</b>: {}").format(item.idx, frappe.bold(item.get("item_code")), frappe.bold(invalid_serials)))
+						msg = (_("Row #{}: Following Serial numbers for item {} are <b>Invalid</b>: {}").format(item.idx, frappe.bold(item.get("item_code")), frappe.bold(invalid_serials)))
 
 			if msg:
 				error_msg.append(msg)

--- a/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
@@ -326,7 +326,6 @@ class TestPOSInvoice(unittest.TestCase):
 		self.assertRaises(frappe.ValidationError, pos2.submit)
 
 	def test_invalid_serial_no_validation(self):
-		from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos
 		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_serialized_item
 
 		se = make_serialized_item(company='_Test Company',

--- a/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
@@ -325,6 +325,22 @@ class TestPOSInvoice(unittest.TestCase):
 		pos2.insert()
 		self.assertRaises(frappe.ValidationError, pos2.submit)
 
+	def test_invalid_serial_no_validation(self):
+		from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos
+		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_serialized_item
+
+		se = make_serialized_item(company='_Test Company',
+			target_warehouse="Stores - _TC", cost_center='Main - _TC', expense_account='Cost of Goods Sold - _TC')
+
+		pos = create_pos_invoice(company='_Test Company', debit_to='Debtors - _TC',
+			account_for_change_amount='Cash - _TC', warehouse='Stores - _TC', income_account='Sales - _TC',
+			expense_account='Cost of Goods Sold - _TC', cost_center='Main - _TC',
+			item=se.get("items")[0].item_code, rate=1000, do_not_save=1)
+		pos.get('items')[0].serial_no = 'ABCD00015\nABCD00016wrong'
+		pos.insert()
+
+		self.assertRaises(frappe.ValidationError, pos.submit)
+
 	def test_delivered_serialized_item_transaction(self):
 		from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos
 		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_serialized_item

--- a/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
@@ -330,14 +330,16 @@ class TestPOSInvoice(unittest.TestCase):
 
 		se = make_serialized_item(company='_Test Company',
 			target_warehouse="Stores - _TC", cost_center='Main - _TC', expense_account='Cost of Goods Sold - _TC')
+		serial_nos = se.get("items")[0].serial_no + 'wrong'
 
 		pos = create_pos_invoice(company='_Test Company', debit_to='Debtors - _TC',
 			account_for_change_amount='Cash - _TC', warehouse='Stores - _TC', income_account='Sales - _TC',
 			expense_account='Cost of Goods Sold - _TC', cost_center='Main - _TC',
-			item=se.get("items")[0].item_code, rate=1000, do_not_save=1)
-		pos.get('items')[0].serial_no = 'ABCD00015\nABCD00016wrong'
-		pos.insert()
+			item=se.get("items")[0].item_code, rate=1000, qty=2, do_not_save=1)
 
+		pos.get('items')[0].has_serial_no = 1
+		pos.get('items')[0].serial_no = serial_nos
+		pos.insert()
 		self.assertRaises(frappe.ValidationError, pos.submit)
 
 	def test_delivered_serialized_item_transaction(self):

--- a/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
@@ -339,8 +339,8 @@ class TestPOSInvoice(unittest.TestCase):
 
 		pos.get('items')[0].has_serial_no = 1
 		pos.get('items')[0].serial_no = serial_nos
-		pos.insert()
-		self.assertRaises(frappe.ValidationError, pos.submit)
+
+		self.assertRaises(frappe.ValidationError, pos.insert)
 
 	def test_delivered_serialized_item_transaction(self):
 		from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos

--- a/erpnext/stock/doctype/serial_no/serial_no.py
+++ b/erpnext/stock/doctype/serial_no/serial_no.py
@@ -622,7 +622,7 @@ def fetch_serial_numbers(filters, qty, do_not_include=None):
 			{qty}
 		""".format(
 				excluded_sr_nos=excluded_sr_nos,
-				qty=qty or 1,
+				qty=int(qty) or 1,
 				batch_join_selection=batch_join_selection,
 				batch_no_condition=batch_no_condition
 			), filters, as_dict=1)


### PR DESCRIPTION
**Issue:**
After auto fetching the serial nos in the POS screen if the serial is modified incorrectly no error will be thrown and the invoice gets submitted. It is thrown only during consolidation.

**Fix:**
Added validation for checking if the selected serial nos are valid or not.

<details>
<summary><b>Steps:</b> </summary>
<ol>
<li>
 Create a serialized item and create a Serial No for that item.
   <img src='https://user-images.githubusercontent.com/36098155/148900146-eba05d36-63e9-4237-9c2c-69a9a98bb16a.png' width='500'>

   <img src='https://user-images.githubusercontent.com/36098155/148899988-4ac1c8b1-8880-422f-848f-45234fdac9e1.png' width='500'>
</li>
<li> In POS Screen add the serialized item, after setting the quantity auto fetch the serial nos</li>
<li> Edit one of the serial nos</li>
   <img src='https://user-images.githubusercontent.com/36098155/148902588-7b2265cb-3b12-4285-ac8c-e283d02db936.png' width='500'></li>
<li> After checkout it will throw a validation now:
    <img src='https://user-images.githubusercontent.com/36098155/148903506-582b88d4-e17a-4434-8492-616cdc588765.png' width='500'>
 
   **Note: Before the fix it would simply go ahead and submit the invoice and show the bill**
</li>
</details>
