### PR TITLE
fix: broken UOM auto complete

### DIFF
--- a/erpnext/controllers/tests/test_queries.py
+++ b/erpnext/controllers/tests/test_queries.py
@@ -1,6 +1,8 @@
 import unittest
 from functools import partial
 
+import frappe
+
 from erpnext.controllers import queries
 
 
@@ -85,3 +87,6 @@ class TestQueries(unittest.TestCase):
 
 		wh = query(filters=[["Bin", "item_code", "=", "_Test Item"]])
 		self.assertGreaterEqual(len(wh), 1)
+
+	def test_default_uoms(self):
+		self.assertGreaterEqual(frappe.db.count("UOM", {"enabled": 1}), 10)

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -305,6 +305,7 @@ erpnext.patches.v13_0.add_default_interview_notification_templates
 erpnext.patches.v13_0.enable_scheduler_job_for_item_reposting
 erpnext.patches.v13_0.requeue_failed_reposts
 erpnext.patches.v13_0.update_job_card_status
+erpnext.patches.v13_0.enable_uoms
 erpnext.patches.v12_0.update_production_plan_status
 erpnext.patches.v13_0.healthcare_deprecation_warning
 erpnext.patches.v13_0.item_naming_series_not_mandatory

--- a/erpnext/patches/v13_0/enable_uoms.py
+++ b/erpnext/patches/v13_0/enable_uoms.py
@@ -1,0 +1,13 @@
+import frappe
+
+
+def execute():
+	frappe.reload_doc('setup', 'doctype', 'uom')
+
+	uom = frappe.qb.DocType("UOM")
+
+	(frappe.qb
+		.update(uom)
+		.set(uom.enabled, 1)
+		.where(uom.creation >= "2021-10-18")  # date when this field was released
+	).run()

--- a/erpnext/setup/setup_wizard/operations/install_fixtures.py
+++ b/erpnext/setup/setup_wizard/operations/install_fixtures.py
@@ -353,7 +353,8 @@ def add_uom_data():
 				"doctype": "UOM",
 				"uom_name": _(d.get("uom_name")),
 				"name": _(d.get("uom_name")),
-				"must_be_whole_number": d.get("must_be_whole_number")
+				"must_be_whole_number": d.get("must_be_whole_number"),
+				"enabled": 1,
 			}).db_insert()
 
 	# bootstrap uom conversion factors


### PR DESCRIPTION
closes: https://github.com/frappe/erpnext/issues/28749 

This is broken on newly created sites because during setup we do `db_insert` which converts `None` to 0 and inserts it, so DB's column default doesn't work. 🤦 

Added patch to toggle on all sites created after the PR was merged. 

PS: Only affects newly created sites. 

caused by combination of https://github.com/frappe/erpnext/pull/27993 and https://github.com/frappe/erpnext/pull/25606 