### PR TITLE
fix: Avoid resetting Default wh fields for Manufacture Entry

### DIFF
--- a/erpnext/controllers/tests/test_transaction_base.py
+++ b/erpnext/controllers/tests/test_transaction_base.py
@@ -4,73 +4,72 @@ import frappe
 
 
 class TestUtils(unittest.TestCase):
-    def test_reset_default_field_value(self):
-        doc = frappe.get_doc({
-            "doctype": "Purchase Receipt",
-            "set_warehouse": "Warehouse 1",
-        })
+	def test_reset_default_field_value(self):
+		doc = frappe.get_doc({
+			"doctype": "Purchase Receipt",
+			"set_warehouse": "Warehouse 1",
+		})
 
-        # Same values
-        doc.items = [{"warehouse": "Warehouse 1"}, {"warehouse": "Warehouse 1"}, {"warehouse": "Warehouse 1"}]
-        doc.reset_default_field_value("set_warehouse", "items", "warehouse")
-        self.assertEqual(doc.set_warehouse, "Warehouse 1")
+		# Same values
+		doc.items = [{"warehouse": "Warehouse 1"}, {"warehouse": "Warehouse 1"}, {"warehouse": "Warehouse 1"}]
+		doc.reset_default_field_value("set_warehouse", "items", "warehouse")
+		self.assertEqual(doc.set_warehouse, "Warehouse 1")
 
-        # Mixed values
-        doc.items = [{"warehouse": "Warehouse 1"}, {"warehouse": "Warehouse 2"}, {"warehouse": "Warehouse 1"}]
-        doc.reset_default_field_value("set_warehouse", "items", "warehouse")
-        self.assertEqual(doc.set_warehouse, None)
+		# Mixed values
+		doc.items = [{"warehouse": "Warehouse 1"}, {"warehouse": "Warehouse 2"}, {"warehouse": "Warehouse 1"}]
+		doc.reset_default_field_value("set_warehouse", "items", "warehouse")
+		self.assertEqual(doc.set_warehouse, None)
 
-    def test_reset_default_field_value_in_mfg_stock_entry(self):
-        doc = frappe.get_doc({
-            "doctype": "Stock Entry",
-            "purpose": "Manufacture",
-            "from_warehouse": "Warehouse 1",
-            "to_warehouse": "Warehouse 2",
-        })
+	def test_reset_default_field_value_in_mfg_stock_entry(self):
+		# manufacture stock entry with rows having blank source/target wh
+		se = frappe.get_doc(
+			doctype="Stock Entry",
+			purpose="Manufacture",
+			stock_entry_type="Manufacture",
+			company="_Test Company",
+			from_warehouse="_Test Warehouse - _TC",
+			to_warehouse="_Test Warehouse 1 - _TC",
+			items=[
+				frappe._dict(item_code="_Test Item", qty=1, basic_rate=200, s_warehouse="_Test Warehouse - _TC"),
+				frappe._dict(item_code="_Test FG Item", qty=4, t_warehouse="_Test Warehouse 1 - _TC", is_finished_item=1)
+			]
+		)
+		se.save()
 
-        # manufacture stock entry with rows having blank
-        # source/target wh
-        doc.items = [
-            {"s_warehouse": "Warehouse 1"},
-            {"s_warehouse": "Warehouse 1"},
-            {"t_warehouse": "Warehouse 2"}
-        ]
+		# default fields must be untouched
+		self.assertEqual(se.from_warehouse, "_Test Warehouse - _TC")
+		self.assertEqual(se.to_warehouse, "_Test Warehouse 1 - _TC")
 
-        doc.reset_default_field_value("from_warehouse", "items", "s_warehouse")
-        doc.reset_default_field_value("to_warehouse", "items", "t_warehouse")
+		se.delete()
 
-        # default fields must be untouched
-        self.assertEqual(doc.from_warehouse, "Warehouse 1")
-        self.assertEqual(doc.to_warehouse, "Warehouse 2")
+	def test_reset_default_field_value_in_transfer_stock_entry(self):
+		doc = frappe.get_doc({
+			"doctype": "Stock Entry",
+			"purpose": "Material Receipt",
+			"from_warehouse": "Warehouse 1",
+			"to_warehouse": "Warehouse 2",
+		})
 
-    def test_reset_default_field_value_in_transfer_stock_entry(self):
-        doc = frappe.get_doc({
-            "doctype": "Stock Entry",
-            "purpose": "Material Receipt",
-            "from_warehouse": "Warehouse 1",
-            "to_warehouse": "Warehouse 2",
-        })
+		# Same values
+		doc.items = [
+			{"s_warehouse": "Warehouse 1", "t_warehouse": "Warehouse 2"},
+			{"s_warehouse": "Warehouse 1", "t_warehouse": "Warehouse 2"},
+			{"s_warehouse": "Warehouse 1", "t_warehouse": "Warehouse 2"}
+		]
 
-        # Same values
-        doc.items = [
-            {"s_warehouse": "Warehouse 1", "t_warehouse": "Warehouse 2"},
-            {"s_warehouse": "Warehouse 1", "t_warehouse": "Warehouse 2"},
-            {"s_warehouse": "Warehouse 1", "t_warehouse": "Warehouse 2"}
-        ]
+		doc.reset_default_field_value("from_warehouse", "items", "s_warehouse")
+		doc.reset_default_field_value("to_warehouse", "items", "t_warehouse")
+		self.assertEqual(doc.from_warehouse, "Warehouse 1")
+		self.assertEqual(doc.to_warehouse, "Warehouse 2")
 
-        doc.reset_default_field_value("from_warehouse", "items", "s_warehouse")
-        doc.reset_default_field_value("to_warehouse", "items", "t_warehouse")
-        self.assertEqual(doc.from_warehouse, "Warehouse 1")
-        self.assertEqual(doc.to_warehouse, "Warehouse 2")
+		# Mixed values in source wh
+		doc.items = [
+			{"s_warehouse": "Warehouse 1", "t_warehouse": "Warehouse 2"},
+			{"s_warehouse": "Warehouse 3", "t_warehouse": "Warehouse 2"},
+			{"s_warehouse": "Warehouse 1", "t_warehouse": "Warehouse 2"}
+		]
 
-        # Mixed values in source wh
-        doc.items = [
-            {"s_warehouse": "Warehouse 1", "t_warehouse": "Warehouse 2"},
-            {"s_warehouse": "Warehouse 3", "t_warehouse": "Warehouse 2"},
-            {"s_warehouse": "Warehouse 1", "t_warehouse": "Warehouse 2"}
-        ]
-
-        doc.reset_default_field_value("from_warehouse", "items", "s_warehouse")
-        doc.reset_default_field_value("to_warehouse", "items", "t_warehouse")
-        self.assertEqual(doc.from_warehouse, None)
-        self.assertEqual(doc.to_warehouse, "Warehouse 2")
+		doc.reset_default_field_value("from_warehouse", "items", "s_warehouse")
+		doc.reset_default_field_value("to_warehouse", "items", "t_warehouse")
+		self.assertEqual(doc.from_warehouse, None)
+		self.assertEqual(doc.to_warehouse, "Warehouse 2")

--- a/erpnext/controllers/tests/test_transaction_base.py
+++ b/erpnext/controllers/tests/test_transaction_base.py
@@ -20,3 +20,57 @@ class TestUtils(unittest.TestCase):
         doc.reset_default_field_value("set_warehouse", "items", "warehouse")
         self.assertEqual(doc.set_warehouse, None)
 
+    def test_reset_default_field_value_in_mfg_stock_entry(self):
+        doc = frappe.get_doc({
+            "doctype": "Stock Entry",
+            "purpose": "Manufacture",
+            "from_warehouse": "Warehouse 1",
+            "to_warehouse": "Warehouse 2",
+        })
+
+        # manufacture stock entry with rows having blank
+        # source/target wh
+        doc.items = [
+            {"s_warehouse": "Warehouse 1"},
+            {"s_warehouse": "Warehouse 1"},
+            {"t_warehouse": "Warehouse 2"}
+        ]
+
+        doc.reset_default_field_value("from_warehouse", "items", "s_warehouse")
+        doc.reset_default_field_value("to_warehouse", "items", "t_warehouse")
+
+        # default fields must be untouched
+        self.assertEqual(doc.from_warehouse, "Warehouse 1")
+        self.assertEqual(doc.to_warehouse, "Warehouse 2")
+
+    def test_reset_default_field_value_in_transfer_stock_entry(self):
+        doc = frappe.get_doc({
+            "doctype": "Stock Entry",
+            "purpose": "Material Receipt",
+            "from_warehouse": "Warehouse 1",
+            "to_warehouse": "Warehouse 2",
+        })
+
+        # Same values
+        doc.items = [
+            {"s_warehouse": "Warehouse 1", "t_warehouse": "Warehouse 2"},
+            {"s_warehouse": "Warehouse 1", "t_warehouse": "Warehouse 2"},
+            {"s_warehouse": "Warehouse 1", "t_warehouse": "Warehouse 2"}
+        ]
+
+        doc.reset_default_field_value("from_warehouse", "items", "s_warehouse")
+        doc.reset_default_field_value("to_warehouse", "items", "t_warehouse")
+        self.assertEqual(doc.from_warehouse, "Warehouse 1")
+        self.assertEqual(doc.to_warehouse, "Warehouse 2")
+
+        # Mixed values in source wh
+        doc.items = [
+            {"s_warehouse": "Warehouse 1", "t_warehouse": "Warehouse 2"},
+            {"s_warehouse": "Warehouse 3", "t_warehouse": "Warehouse 2"},
+            {"s_warehouse": "Warehouse 1", "t_warehouse": "Warehouse 2"}
+        ]
+
+        doc.reset_default_field_value("from_warehouse", "items", "s_warehouse")
+        doc.reset_default_field_value("to_warehouse", "items", "t_warehouse")
+        self.assertEqual(doc.from_warehouse, None)
+        self.assertEqual(doc.to_warehouse, "Warehouse 2")

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -110,8 +110,12 @@ class StockEntry(StockController):
 		self.set_actual_qty()
 		self.calculate_rate_and_amount()
 		self.validate_putaway_capacity()
-		self.reset_default_field_value("from_warehouse", "items", "s_warehouse")
-		self.reset_default_field_value("to_warehouse", "items", "t_warehouse")
+
+		if not self.get("purpose") == "Manufacture":
+			# ignore scrap item wh difference and empty source/target wh
+			# in Manufacture Entry
+			self.reset_default_field_value("from_warehouse", "items", "s_warehouse")
+			self.reset_default_field_value("to_warehouse", "items", "t_warehouse")
 
 	def on_submit(self):
 		self.update_stock_ledger()

--- a/erpnext/utilities/transaction_base.py
+++ b/erpnext/utilities/transaction_base.py
@@ -176,11 +176,6 @@ class TransactionBase(StatusUpdater):
 			"""
 		child_table_values = set()
 
-		# ignore scrap item wh difference and empty source/target wh
-		# in Manufacture Entry
-		if self.get("purpose") and self.get("purpose") == "Manufacture":
-			return
-
 		for row in self.get(child_table):
 			child_table_values.add(row.get(child_table_field))
 

--- a/erpnext/utilities/transaction_base.py
+++ b/erpnext/utilities/transaction_base.py
@@ -176,13 +176,16 @@ class TransactionBase(StatusUpdater):
 			"""
 		child_table_values = set()
 
+		# ignore scrap item wh difference and empty source/target wh
+		# in Manufacture Entry
+		if self.get("purpose") and self.get("purpose") == "Manufacture":
+			return
+
 		for row in self.get(child_table):
 			child_table_values.add(row.get(child_table_field))
 
 		if len(child_table_values) > 1:
 			self.set(default_field, None)
-		else:
-			self.set(default_field, list(child_table_values)[0])
 
 def delete_events(ref_type, ref_name):
 	events = frappe.db.sql_list(""" SELECT


### PR DESCRIPTION
Introducted via https://github.com/frappe/erpnext/pull/28798

**Issue:**
- Source/target is blank on some rows in a Manufacture Stock Entry
- Users still want an overall reference of the warehouses involved in this mfg entry
- Scrap item may have different warehouse (just one row), it should be overlooked

**Fix:**
- Avoid resetting Default source/target warehouse in manufacture entry alone
- For Repack entry users most like will not use these fields since each row has to have a different warehouse. And repack entries aren't auto generated from anywhere, like Manufacture entries are generated from Work Orders
- If there's 1 entry in `child_table_values`, dont do anything. **There's nothing to reset**. Reset and set to None only if there's more than one value for a field in the table rows.