### PR TITLE
fix: autoname generated for Job Applicant is too long

### DIFF
--- a/erpnext/hr/doctype/employee_onboarding/test_employee_onboarding.py
+++ b/erpnext/hr/doctype/employee_onboarding/test_employee_onboarding.py
@@ -19,7 +19,7 @@ class TestEmployeeOnboarding(unittest.TestCase):
 		if frappe.db.exists('Employee Onboarding', {'employee_name': 'Test Researcher'}):
 			frappe.delete_doc('Employee Onboarding', {'employee_name': 'Test Researcher'})
 
-		project = "Employee Onboarding : Test Researcher - test@researcher.com"
+		project = "Employee Onboarding : test@researcher.com"
 		frappe.db.sql("delete from tabProject where name=%s", project)
 		frappe.db.sql("delete from tabTask where project=%s", project)
 
@@ -27,7 +27,7 @@ class TestEmployeeOnboarding(unittest.TestCase):
 		onboarding = create_employee_onboarding()
 
 		project_name = frappe.db.get_value('Project', onboarding.project, 'project_name')
-		self.assertEqual(project_name, 'Employee Onboarding : Test Researcher - test@researcher.com')
+		self.assertEqual(project_name, 'Employee Onboarding : test@researcher.com')
 
 		# don't allow making employee if onboarding is not complete
 		self.assertRaises(IncompleteTaskError, make_employee, onboarding.name)
@@ -64,8 +64,8 @@ class TestEmployeeOnboarding(unittest.TestCase):
 
 
 def get_job_applicant():
-	if frappe.db.exists('Job Applicant', 'Test Researcher - test@researcher.com'):
-		return frappe.get_doc('Job Applicant', 'Test Researcher - test@researcher.com')
+	if frappe.db.exists('Job Applicant', 'test@researcher.com'):
+		return frappe.get_doc('Job Applicant', 'test@researcher.com')
 	applicant = frappe.new_doc('Job Applicant')
 	applicant.applicant_name = 'Test Researcher'
 	applicant.email_id = 'test@researcher.com'

--- a/erpnext/hr/doctype/job_applicant/job_applicant.json
+++ b/erpnext/hr/doctype/job_applicant/job_applicant.json
@@ -192,10 +192,11 @@
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2021-09-29 23:06:10.904260",
+ "modified": "2022-01-12 16:28:53.196881",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Job Applicant",
+ "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {
@@ -210,10 +211,11 @@
    "write": 1
   }
  ],
- "search_fields": "applicant_name",
+ "search_fields": "applicant_name, email_id, job_title, phone_number",
  "sender_field": "email_id",
  "sort_field": "modified",
  "sort_order": "ASC",
+ "states": [],
  "subject_field": "notes",
  "title_field": "applicant_name"
 }

--- a/erpnext/hr/doctype/job_applicant/job_applicant.py
+++ b/erpnext/hr/doctype/job_applicant/job_applicant.py
@@ -7,6 +7,7 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
+from frappe.model.naming import append_number_if_name_exists
 from frappe.utils import validate_email_address
 
 from erpnext.hr.doctype.interview.interview import get_interviewers
@@ -21,10 +22,11 @@ class JobApplicant(Document):
 			self.get("__onload").job_offer = job_offer[0].name
 
 	def autoname(self):
-		keys = filter(None, (self.applicant_name, self.email_id, self.job_title))
-		if not keys:
-			frappe.throw(_("Name or Email is mandatory"), frappe.NameError)
-		self.name = " - ".join(keys)
+		self.name = self.email_id
+
+		# applicant can apply more than once for a different job title
+		if frappe.db.exists("Job Applicant", self.name):
+			self.name = append_number_if_name_exists("Job Applicant", self.name)
 
 	def validate(self):
 		if self.email_id:

--- a/erpnext/hr/doctype/job_applicant/job_applicant.py
+++ b/erpnext/hr/doctype/job_applicant/job_applicant.py
@@ -24,7 +24,7 @@ class JobApplicant(Document):
 	def autoname(self):
 		self.name = self.email_id
 
-		# applicant can apply more than once for a different job title
+		# applicant can apply more than once for a different job title or reapply
 		if frappe.db.exists("Job Applicant", self.name):
 			self.name = append_number_if_name_exists("Job Applicant", self.name)
 

--- a/erpnext/hr/doctype/job_applicant/test_job_applicant.py
+++ b/erpnext/hr/doctype/job_applicant/test_job_applicant.py
@@ -9,7 +9,26 @@ from erpnext.hr.doctype.designation.test_designation import create_designation
 
 
 class TestJobApplicant(unittest.TestCase):
-	pass
+	def test_job_applicant_naming(self):
+		applicant = frappe.get_doc({
+			"doctype": "Job Applicant",
+			"status": "Open",
+			"applicant_name": "_Test Applicant",
+			"email_id": "job_applicant_naming@example.com"
+		}).insert()
+		self.assertEqual(applicant.name, 'job_applicant_naming@example.com')
+
+		applicant = frappe.get_doc({
+			"doctype": "Job Applicant",
+			"status": "Open",
+			"applicant_name": "_Test Applicant",
+			"email_id": "job_applicant_naming@example.com"
+		}).insert()
+		self.assertEqual(applicant.name, 'job_applicant_naming@example.com-1')
+
+	def tearDown(self):
+		frappe.db.rollback()
+
 
 def create_job_applicant(**args):
 	args = frappe._dict(args)


### PR DESCRIPTION
### **Problem**:

Auto name generated for a Job Applicant concatenates Applicant Name, Email, and Job Title.

![image](https://user-images.githubusercontent.com/24353136/149129365-50495761-bd5a-4b5b-91c7-34366907d293.png)

Although this is good for context, the name can be too long and exceed 140 chars for naming:

<details>
<summary> Traceback: </summary>

```python
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 68, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 31, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 67, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1208, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/desk/form/save.py", line 21, in savedocs
    doc.save()
  File "apps/frappe/frappe/model/document.py", line 285, in save
    return self._save(*args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 307, in _save
    self.insert()
  File "apps/frappe/frappe/model/document.py", line 250, in insert
    self.db_insert()
  File "apps/frappe/frappe/model/base_document.py", line 368, in db_insert
    ), list(d.values()))
  File "apps/frappe/frappe/database/database.py", line 148, in sql
    self._cursor.execute(query, values)
  File "env/lib/python3.6/site-packages/pymysql/cursors.py", line 148, in execute
    result = self._query(query)
  File "env/lib/python3.6/site-packages/pymysql/cursors.py", line 310, in _query
    conn.query(q)
  File "env/lib/python3.6/site-packages/pymysql/connections.py", line 548, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "env/lib/python3.6/site-packages/pymysql/connections.py", line 775, in _read_query_result
    result.read()
  File "env/lib/python3.6/site-packages/pymysql/connections.py", line 1156, in read
    first_packet = self.connection._read_packet()
  File "env/lib/python3.6/site-packages/pymysql/connections.py", line 725, in _read_packet
    packet.raise_for_error()
  File "env/lib/python3.6/site-packages/pymysql/protocol.py", line 221, in raise_for_error
    err.raise_mysql_exception(self._data)
  File "env/lib/python3.6/site-packages/pymysql/err.py", line 143, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.DataError: (1406, "Data too long for column 'name' at row 1")
```
</details>

### **Fix**:

- Auto name based on email and append number if job applicant with the same email already exists (when the same applicant applies for more than one job title or reapplies), similar to how Customer, Supplier, and other documents are named.
- Add more search fields to retain context. Apart from this, Applicant Name, Title are fetched almost in all the forms.
   ![image](https://user-images.githubusercontent.com/24353136/149130391-1f80f0e5-7ae7-40eb-8510-6004bccfb1f5.png)