### PR TITLE
fix: threshold fields shows incorrect currency

### DIFF
--- a/erpnext/accounts/doctype/tax_withholding_rate/tax_withholding_rate.json
+++ b/erpnext/accounts/doctype/tax_withholding_rate/tax_withholding_rate.json
@@ -28,14 +28,14 @@
   {
    "columns": 2,
    "fieldname": "single_threshold",
-   "fieldtype": "Currency",
+   "fieldtype": "Float",
    "in_list_view": 1,
    "label": "Single Transaction Threshold"
   },
   {
    "columns": 3,
    "fieldname": "cumulative_threshold",
-   "fieldtype": "Currency",
+   "fieldtype": "Float",
    "in_list_view": 1,
    "label": "Cumulative Transaction Threshold"
   },
@@ -59,7 +59,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2021-08-31 11:42:12.213977",
+ "modified": "2022-01-13 12:04:42.904263",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Tax Withholding Rate",
@@ -68,5 +68,6 @@
  "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }


### PR DESCRIPTION
In case the Tax Withholding Category is not created for the same region as Company's country, the currency fields shows Company's currency which is incorrect.

For eg. for a US-based company if a user creates a Tax Withholding Category for India, then the Threshold fields show $ symbols

Fix:
Convert Currency fields to Float

