### PR TITLE
fix: Display 'Make Depreciation Entry' only for submitted or partially depreciated Assets 

### DIFF
--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -78,6 +78,7 @@ frappe.ui.form.on('Asset', {
 		frappe.ui.form.trigger("Asset", "is_existing_asset");
 		frm.toggle_display("next_depreciation_date", frm.doc.docstatus < 1);
 		frm.events.make_schedules_editable(frm);
+		frm.trigger("toggle_make_depreciation_entry");
 
 		if (frm.doc.docstatus==1) {
 			if (in_list(["Submitted", "Partially Depreciated", "Fully Depreciated"], frm.doc.status)) {
@@ -138,6 +139,18 @@ frappe.ui.form.on('Asset', {
 			frm.toggle_reqd("finance_books", frm.doc.calculate_depreciation);
 			frm.set_df_property('depreciation_start_date', 'reqd', 1, frm.doc.name, 'finance_books');
 			frm.refresh_field('finance_books');
+		}
+	},
+
+	toggle_make_depreciation_entry: function(frm) {
+		if (frm.doc.calculate_depreciation){
+			if (in_list(["Submitted", "Partially Depreciated"], frm.doc.status)){
+				frm.fields_dict['schedules'].grid.set_column_disp('make_depreciation_entry', true);
+			} else {
+				frm.fields_dict['schedules'].grid.set_column_disp('make_depreciation_entry', false);
+			}
+
+			frm.refresh_field('schedules');
 		}
 	},
 

--- a/erpnext/assets/doctype/asset/depreciation.py
+++ b/erpnext/assets/doctype/asset/depreciation.py
@@ -34,6 +34,8 @@ def make_depreciation_entry(asset_name, date=None):
 		date = today()
 
 	asset = frappe.get_doc("Asset", asset_name)
+	validate_asset(asset)
+
 	fixed_asset_account, accumulated_depreciation_account, depreciation_expense_account = \
 		get_depreciation_accounts(asset)
 
@@ -100,6 +102,10 @@ def make_depreciation_entry(asset_name, date=None):
 	asset.set_status()
 
 	return asset
+
+def validate_asset(asset):
+	if asset.status not in ['Submitted', 'Partially Depreciated']:
+		frappe.throw(_("Cannot depreciate {0} Asset").format(asset.status))
 
 def get_depreciation_accounts(asset):
 	fixed_asset_account = accumulated_depreciation_account = depreciation_expense_account = None


### PR DESCRIPTION
## Problem

In v12, selling an Asset has no effect on its Depreciation Schedule. While `post_depreciation_entries()` excludes Assets that are not in the Submitted or Partially Depreciated states, `make_depreciation_entry()` does not. Therefore, users are able to post Depreciation Entries using the _Make Depreciation Entry_ button even after the Asset has been sold.

![Screenshot 2022-01-14 at 3 39 20 PM](https://user-images.githubusercontent.com/25903035/149514801-fbc831ba-0c11-4650-8e24-7c8ff627fd98.png)

## Fix

- Hide the _Make Depreciation Entry_ button for Assets that are not in the Submitted or Partially Depreciated state.
- Throw an error if `make_depreciation_entry()` is run for such Assets.

![Screenshot 2022-01-14 at 3 27 20 PM](https://user-images.githubusercontent.com/25903035/149514786-e033727f-7bbb-468d-b82b-35b5a8132098.png)

<details>
<summary>Testing Info</summary>

1. Create a depreciable Asset with Depreciation Starting Date in the past.
2. Confirm that the _Make Depreciation Entry_ button is visible for the Depreciation Schedule row with Schedule Date in the past.
3. Sell the Asset.
4. Confirm that the _Make Depreciation Entry_ button is no longer visible for the Depreciation Schedule row with Schedule Date in the past.

</details>
