### PR TITLE
fix: exclude existing serial numbers while auto creating new

### DIFF
--- a/erpnext/stock/doctype/serial_no/serial_no.py
+++ b/erpnext/stock/doctype/serial_no/serial_no.py
@@ -402,9 +402,15 @@ def update_serial_nos(sle, item_det):
 def get_auto_serial_nos(serial_no_series, qty):
 	serial_nos = []
 	for i in range(cint(qty)):
-		serial_nos.append(make_autoname(serial_no_series, "Serial No"))
+		serial_nos.append(create_sno(serial_no_series))
 
 	return "\n".join(serial_nos)
+
+def create_sno(serial_no_series):
+	sno = make_autoname(serial_no_series, "Serial No")
+	if frappe.db.exists("Serial No", sno):
+		sno = create_sno(serial_no_series)
+	return sno
 
 def auto_make_serial_nos(args):
 	serial_nos = get_serial_nos(args.get('serial_no'))

--- a/erpnext/stock/doctype/serial_no/serial_no.py
+++ b/erpnext/stock/doctype/serial_no/serial_no.py
@@ -402,15 +402,15 @@ def update_serial_nos(sle, item_det):
 def get_auto_serial_nos(serial_no_series, qty):
 	serial_nos = []
 	for i in range(cint(qty)):
-		serial_nos.append(create_sno(serial_no_series))
+		serial_nos.append(get_new_serial_number(serial_no_series))
 
 	return "\n".join(serial_nos)
 
-def create_sno(serial_no_series):
-	sno = make_autoname(serial_no_series, "Serial No")
-	if frappe.db.exists("Serial No", sno):
-		sno = create_sno(serial_no_series)
-	return sno
+def get_new_serial_number(series):
+	sr_no = make_autoname(series, "Serial No")
+	if frappe.db.exists("Serial No", sr_no):
+		sr_no = get_new_serial_number(series)
+	return sr_no
 
 def auto_make_serial_nos(args):
 	serial_nos = get_serial_nos(args.get('serial_no'))


### PR DESCRIPTION
In cases where Serial No is auto generated, consider the serial number template is XYZ.### and that the counter is at 0.

Assume I create a purchase receipt with 1 qty and manually input the serial number as XYZ005.
And if I create another purchase receipt with 10 qty and no serial number given, the system will try to use serial numbers XYZ001 to XYZ010. In that case, I will get a validation error regarding XYZ005.

Further: https://discuss.erpnext.com/t/serial-number-generation-problem/84831

This PR aims to solve the issue by checking if the serial number already exists or not.
#no-docs