### PR TITLE
feat: LIFO valuation

### DIFF
--- a/erpnext/stock/doctype/item/item.json
+++ b/erpnext/stock/doctype/item/item.json
@@ -346,7 +346,7 @@
    "fieldname": "valuation_method",
    "fieldtype": "Select",
    "label": "Valuation Method",
-   "options": "\nFIFO\nMoving Average"
+   "options": "\nFIFO\nMoving Average\nLIFO"
   },
   {
    "depends_on": "is_stock_item",

--- a/erpnext/stock/doctype/stock_settings/stock_settings.json
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.json
@@ -92,7 +92,7 @@
    "fieldname": "valuation_method",
    "fieldtype": "Select",
    "label": "Default Valuation Method",
-   "options": "FIFO\nMoving Average"
+   "options": "FIFO\nMoving Average\nLIFO"
   },
   {
    "description": "The percentage you are allowed to receive or deliver more against the quantity ordered. For example, if you have ordered 100 units, and your Allowance is 10%, then you are allowed to receive 110 units.",
@@ -305,7 +305,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2021-11-06 19:40:02.183592",
+ "modified": "2022-01-15 17:42:53.174865",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Settings",
@@ -324,5 +324,6 @@
  "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "ASC",
+ "states": [],
  "track_changes": 1
 }

--- a/erpnext/stock/report/stock_ledger_invariant_check/stock_ledger_invariant_check.py
+++ b/erpnext/stock/report/stock_ledger_invariant_check/stock_ledger_invariant_check.py
@@ -167,7 +167,7 @@ def get_columns():
 		{
 			"fieldname": "stock_queue",
 			"fieldtype": "Data",
-			"label": "FIFO Queue",
+			"label": "FIFO/LIFO Queue",
 		},
 
 		{

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -16,7 +16,7 @@ from erpnext.stock.utils import (
 	get_or_make_bin,
 	get_valuation_method,
 )
-from erpnext.stock.valuation import FIFOValuation
+from erpnext.stock.valuation import FIFOValuation, LIFOValuation
 
 
 class NegativeStockError(frappe.ValidationError): pass
@@ -461,7 +461,7 @@ class update_entries_after(object):
 					self.wh_data.qty_after_transaction += flt(sle.actual_qty)
 					self.wh_data.stock_value = flt(self.wh_data.qty_after_transaction) * flt(self.wh_data.valuation_rate)
 				else:
-					self.update_fifo_values(sle)
+					self.update_fifo_lifo_values(sle)
 					self.wh_data.qty_after_transaction += flt(sle.actual_qty)
 
 		# rounding as per precision
@@ -701,14 +701,18 @@ class update_entries_after(object):
 						sle.voucher_type, sle.voucher_no, self.allow_zero_rate,
 						currency=erpnext.get_company_currency(sle.company), company=sle.company)
 
-	def update_fifo_values(self, sle):
+	def update_fifo_lifo_values(self, sle):
 		incoming_rate = flt(sle.incoming_rate)
 		actual_qty = flt(sle.actual_qty)
 		outgoing_rate = flt(sle.outgoing_rate)
 
-		fifo_queue = FIFOValuation(self.wh_data.stock_queue)
+		if self.valuation_method == "LIFO":
+			stock_queue = LIFOValuation(self.wh_data.stock_queue)
+		else:
+			stock_queue = FIFOValuation(self.wh_data.stock_queue)
+
 		if actual_qty > 0:
-			fifo_queue.add_stock(qty=actual_qty, rate=incoming_rate)
+			stock_queue.add_stock(qty=actual_qty, rate=incoming_rate)
 		else:
 			def rate_generator() -> float:
 				allow_zero_valuation_rate = self.check_if_allow_zero_valuation_rate(sle.voucher_type, sle.voucher_detail_no)
@@ -719,11 +723,11 @@ class update_entries_after(object):
 				else:
 					return 0.0
 
-			fifo_queue.remove_stock(qty=abs(actual_qty), outgoing_rate=outgoing_rate, rate_generator=rate_generator)
+			stock_queue.remove_stock(qty=abs(actual_qty), outgoing_rate=outgoing_rate, rate_generator=rate_generator)
 
-		stock_qty, stock_value = fifo_queue.get_total_stock_and_value()
+		stock_qty, stock_value = stock_queue.get_total_stock_and_value()
 
-		self.wh_data.stock_queue = fifo_queue.state
+		self.wh_data.stock_queue = stock_queue.state
 		self.wh_data.stock_value = stock_value
 		if stock_qty:
 			self.wh_data.valuation_rate = stock_value / stock_qty

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -723,7 +723,7 @@ class update_entries_after(object):
 
 		stock_qty, stock_value = fifo_queue.get_total_stock_and_value()
 
-		self.wh_data.stock_queue = fifo_queue.get_state()
+		self.wh_data.stock_queue = fifo_queue.state
 		self.wh_data.stock_value = stock_value
 		if stock_qty:
 			self.wh_data.valuation_rate = stock_value / stock_qty

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -461,7 +461,7 @@ class update_entries_after(object):
 					self.wh_data.qty_after_transaction += flt(sle.actual_qty)
 					self.wh_data.stock_value = flt(self.wh_data.qty_after_transaction) * flt(self.wh_data.valuation_rate)
 				else:
-					self.update_fifo_lifo_values(sle)
+					self.update_queue_values(sle)
 					self.wh_data.qty_after_transaction += flt(sle.actual_qty)
 
 		# rounding as per precision
@@ -701,7 +701,7 @@ class update_entries_after(object):
 						sle.voucher_type, sle.voucher_no, self.allow_zero_rate,
 						currency=erpnext.get_company_currency(sle.company), company=sle.company)
 
-	def update_fifo_lifo_values(self, sle):
+	def update_queue_values(self, sle):
 		incoming_rate = flt(sle.incoming_rate)
 		actual_qty = flt(sle.actual_qty)
 		outgoing_rate = flt(sle.outgoing_rate)

--- a/erpnext/stock/utils.py
+++ b/erpnext/stock/utils.py
@@ -9,6 +9,7 @@ from frappe import _
 from frappe.utils import cstr, flt, get_link_to_form, nowdate, nowtime
 
 import erpnext
+from erpnext.stock.valuation import FIFOValuation, LIFOValuation
 
 
 class InvalidWarehouseCompany(frappe.ValidationError): pass
@@ -228,10 +229,10 @@ def get_incoming_rate(args, raise_error_if_no_rate=True):
 	else:
 		valuation_method = get_valuation_method(args.get("item_code"))
 		previous_sle = get_previous_sle(args)
-		if valuation_method == 'FIFO':
+		if valuation_method in ('FIFO', 'LIFO'):
 			if previous_sle:
 				previous_stock_queue = json.loads(previous_sle.get('stock_queue', '[]') or '[]')
-				in_rate = get_fifo_rate(previous_stock_queue, args.get("qty") or 0) if previous_stock_queue else 0
+				in_rate = _get_fifo_lifo_rate(previous_stock_queue, args.get("qty") or 0, valuation_method) if previous_stock_queue else 0
 		elif valuation_method == 'Moving Average':
 			in_rate = previous_sle.get('valuation_rate') or 0
 
@@ -261,29 +262,25 @@ def get_valuation_method(item_code):
 
 def get_fifo_rate(previous_stock_queue, qty):
 	"""get FIFO (average) Rate from Queue"""
-	if flt(qty) >= 0:
-		total = sum(f[0] for f in previous_stock_queue)
-		return sum(flt(f[0]) * flt(f[1]) for f in previous_stock_queue) / flt(total) if total else 0.0
-	else:
-		available_qty_for_outgoing, outgoing_cost = 0, 0
-		qty_to_pop = abs(flt(qty))
-		while qty_to_pop and previous_stock_queue:
-			batch = previous_stock_queue[0]
-			if 0 < batch[0] <= qty_to_pop:
-				# if batch qty > 0
-				# not enough or exactly same qty in current batch, clear batch
-				available_qty_for_outgoing += flt(batch[0])
-				outgoing_cost += flt(batch[0]) * flt(batch[1])
-				qty_to_pop -= batch[0]
-				previous_stock_queue.pop(0)
-			else:
-				# all from current batch
-				available_qty_for_outgoing += flt(qty_to_pop)
-				outgoing_cost += flt(qty_to_pop) * flt(batch[1])
-				batch[0] -= qty_to_pop
-				qty_to_pop = 0
+	return _get_fifo_lifo_rate(previous_stock_queue, qty, "FIFO")
 
-		return outgoing_cost / available_qty_for_outgoing
+def get_lifo_rate(previous_stock_queue, qty):
+	"""get LIFO (average) Rate from Queue"""
+	return _get_fifo_lifo_rate(previous_stock_queue, qty, "LIFO")
+
+
+def _get_fifo_lifo_rate(previous_stock_queue, qty, method):
+	ValuationKlass = LIFOValuation if method == "LIFO" else FIFOValuation
+
+	stock_queue = ValuationKlass(previous_stock_queue)
+	if flt(qty) >= 0:
+		total_qty, total_value = stock_queue.get_total_stock_and_value()
+		return total_value / total_qty if total_qty else 0.0
+	else:
+		popped_bins = stock_queue.remove_stock(abs(flt(qty)))
+
+		total_qty, total_value = ValuationKlass(popped_bins).get_total_stock_and_value()
+		return total_value / total_qty if total_qty else 0.0
 
 def get_valid_serial_nos(sr_nos, qty=0, item_code=''):
 	"""split serial nos, validate and return list of valid serial nos"""


### PR DESCRIPTION
Similar to FIFO valuation except when consuming last received material is consumed first. 

https://www.investopedia.com/articles/02/060502.asp

- LIFO can be enabled globally or on an individual item. 
- Negative inventory handling is equivalent to current FIFO handling. 
- PS: LIFO is banned by some accounting bodies, make sure your regional bodies allow using it: https://www.investopedia.com/articles/investing/042115/why-last-first-out-banned-under-ifrs.asp


<details>
  <summary></summary>

my first feature in ERPNext

<img src="https://user-images.githubusercontent.com/9079960/149886766-c5c8ac8c-9840-407e-9a4a-0190be9f2318.gif"/>


</details>

todo:
- [x] rebase
- [x] some more manual testing
- [x] docs https://docs.erpnext.com/docs/v13/user/manual/en/stock/articles/calculation-of-valuation-rate-in-fifo-and-moving-average


To test:
- automated tests added. To check behavior create new item with LIFO valuation and run sales/purchase cycles (A lot of different ways it can be tested)
- check that FIFO/Moving average still work as expected. 