### PR TITLE
fix: only add stock queue if FIFO

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -449,8 +449,9 @@ class update_entries_after(object):
 				# assert
 				self.wh_data.valuation_rate = sle.valuation_rate
 				self.wh_data.qty_after_transaction = sle.qty_after_transaction
-				self.wh_data.stock_queue = [[self.wh_data.qty_after_transaction, self.wh_data.valuation_rate]]
 				self.wh_data.stock_value = flt(self.wh_data.qty_after_transaction) * flt(self.wh_data.valuation_rate)
+				if self.valuation_method != "Moving Average":
+					self.wh_data.stock_queue = [[self.wh_data.qty_after_transaction, self.wh_data.valuation_rate]]
 			else:
 				if self.valuation_method == "Moving Average":
 					self.get_moving_average_values(sle)


### PR DESCRIPTION
Issue:
- Even when moving average is the valuation method, stock reconciliation adds FIFO queue in SLE. 

PS: This is mostly harmless, fixed for correctness.