### PR TITLE
fix: ignore cancelled SLEs

### DIFF
--- a/erpnext/stock/doctype/batch/batch.py
+++ b/erpnext/stock/doctype/batch/batch.py
@@ -292,6 +292,7 @@ def get_batches(item_code, warehouse, qty=1, throw=False, serial_no=None):
 			join `tabStock Ledger Entry` ignore index (item_code, warehouse)
 				on (`tabBatch`.batch_id = `tabStock Ledger Entry`.batch_no )
 		where `tabStock Ledger Entry`.item_code = %s and `tabStock Ledger Entry`.warehouse = %s
+			and `tabStock Ledger Entry`.is_cancelled = 0
 			and (`tabBatch`.expiry_date >= CURDATE() or `tabBatch`.expiry_date IS NULL) {0}
 		group by batch_id
 		order by `tabBatch`.expiry_date ASC, `tabBatch`.creation ASC

--- a/erpnext/stock/report/batch_item_expiry_status/batch_item_expiry_status.py
+++ b/erpnext/stock/report/batch_item_expiry_status/batch_item_expiry_status.py
@@ -55,7 +55,8 @@ def get_stock_ledger_entries(filters):
 	return frappe.db.sql("""select item_code, batch_no, warehouse,
 		posting_date, actual_qty
 		from `tabStock Ledger Entry`
-		where docstatus < 2 and ifnull(batch_no, '') != '' %s order by item_code, warehouse""" %
+		where is_cancelled = 0
+		and docstatus < 2 and ifnull(batch_no, '') != '' %s order by item_code, warehouse""" %
 		conditions, as_dict=1)
 
 def get_item_warehouse_batch_map(filters, float_precision):

--- a/erpnext/stock/report/cogs_by_item_group/cogs_by_item_group.py
+++ b/erpnext/stock/report/cogs_by_item_group/cogs_by_item_group.py
@@ -91,7 +91,7 @@ def get_stock_value_difference_list(filtered_entries: FilteredEntries) -> SVDLis
 	voucher_nos = [fe.get('voucher_no') for fe in filtered_entries]
 	svd_list = frappe.get_list(
 		'Stock Ledger Entry', fields=['item_code','stock_value_difference'],
-		filters=[('voucher_no', 'in', voucher_nos)]
+		filters=[('voucher_no', 'in', voucher_nos), ("is_cancelled", "=", 0)]
 	)
 	assign_item_groups_to_svd_list(svd_list)
 	return svd_list

--- a/erpnext/stock/report/itemwise_recommended_reorder_level/itemwise_recommended_reorder_level.py
+++ b/erpnext/stock/report/itemwise_recommended_reorder_level/itemwise_recommended_reorder_level.py
@@ -76,6 +76,7 @@ def get_consumed_items(condition):
 			on sle.voucher_no = se.name
 		where
 			actual_qty < 0
+			and is_cancelled = 0
 			and voucher_type not in ('Delivery Note', 'Sales Invoice')
 			%s
 		group by item_code""" % condition, as_dict=1)

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -647,6 +647,7 @@ class update_entries_after(object):
 				where
 					company = %s
 					and actual_qty > 0
+					and is_cancelled = 0
 					and (serial_no = %s
 						or serial_no like %s
 						or serial_no like %s
@@ -902,6 +903,7 @@ def get_valuation_rate(item_code, warehouse, voucher_type, voucher_no,
 			item_code = %s
 			AND warehouse = %s
 			AND valuation_rate >= 0
+			AND is_cancelled = 0
 			AND NOT (voucher_no = %s AND voucher_type = %s)
 		order by posting_date desc, posting_time desc, name desc limit 1""", (item_code, warehouse, voucher_no, voucher_type))
 
@@ -912,6 +914,7 @@ def get_valuation_rate(item_code, warehouse, voucher_type, voucher_no,
 			where
 				item_code = %s
 				AND valuation_rate > 0
+				AND is_cancelled = 0
 				AND NOT(voucher_no = %s AND voucher_type = %s)
 			order by posting_date desc, posting_time desc, name desc limit 1""", (item_code, voucher_no, voucher_type))
 


### PR DESCRIPTION
Affected reports:
- batch item expiry
- cogs by item group
- item-wise reorder level

Other functionality:
- auto batch selection wasn't ignoring canceled SLEs
- get_valuation_rate  wasn't ignoring canceled SLEs