### PR TITLE
fix: show work order progress bar even it is closed

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -131,16 +131,14 @@ frappe.ui.form.on("Work Order", {
 		erpnext.work_order.set_custom_buttons(frm);
 		frm.set_intro("");
 
-		if (frm.doc.docstatus === 0 && !frm.doc.__islocal) {
+		if (frm.doc.docstatus === 0 && !frm.is_new()) {
 			frm.set_intro(__("Submit this Work Order for further processing."));
+		} else {
+			frm.trigger("show_progress_for_items");
+			frm.trigger("show_progress_for_operations");
 		}
 
 		if (frm.doc.status != "Closed") {
-			if (frm.doc.docstatus===1) {
-				frm.trigger('show_progress_for_items');
-				frm.trigger('show_progress_for_operations');
-			}
-
 			if (frm.doc.docstatus === 1
 				&& frm.doc.operations && frm.doc.operations.length) {
 


### PR DESCRIPTION
**Issue-** Progress bars are not visible when the work order state is closed.
![image](https://user-images.githubusercontent.com/20715976/149717519-d45eb7b7-3c46-435f-9820-3a5aa2939377.png)

**After Fix-**
![image](https://user-images.githubusercontent.com/20715976/149717429-9d13ee45-edea-4cd4-901a-6b1a8886e795.png)

