### PR TITLE
feat: add link to leave application in leave notification

### DIFF
--- a/erpnext/hr/doctype/leave_application/leave_application_email_template.html
+++ b/erpnext/hr/doctype/leave_application/leave_application_email_template.html
@@ -23,3 +23,8 @@
 			<td>{{status}}</td>
 		</tr>
 	</table>
+
+	{% set doc_link = frappe.utils.get_url_to_form('Leave Application', name) %}
+
+	<br><br>
+	<a class="btn btn-primary" href="{{ doc_link }}" target="_blank">{{ _('Open Now') }}</a>

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -326,3 +326,4 @@ erpnext.patches.v13_0.agriculture_deprecation_warning
 erpnext.patches.v14_0.delete_agriculture_doctypes
 erpnext.patches.v13_0.update_exchange_rate_settings
 erpnext.patches.v14_0.rearrange_company_fields
+erpnext.patches.v14_0.update_leave_notification_template

--- a/erpnext/patches/v14_0/update_leave_notification_template.py
+++ b/erpnext/patches/v14_0/update_leave_notification_template.py
@@ -1,0 +1,17 @@
+import os
+
+import frappe
+from frappe import _
+
+
+def execute():
+	base_path = frappe.get_app_path("erpnext", "hr", "doctype")
+	response = frappe.read_file(os.path.join(base_path, "leave_application/leave_application_email_template.html"))
+
+	template = frappe.db.exists("Email Template", _("Leave Approval Notification"))
+	if template:
+		frappe.db.set_value("Email Template", template, "response", response)
+
+	template = frappe.db.exists("Email Template", _("Leave Status Notification"))
+	if template:
+		frappe.db.set_value("Email Template", template, "response", response)


### PR DESCRIPTION
Add a link to open leave application in the leave notification template

![image](https://user-images.githubusercontent.com/24353136/149735638-8f3a7468-2367-4b5d-aeef-b8d4f1a841da.png)

`no-docs`