### PR TITLE
fix: cover case when all material needs to be bought

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -947,10 +947,6 @@ def get_materials_from_other_locations(item, warehouses, new_mr_items, company):
 	locations = get_available_item_locations(item.get("item_code"),
 		warehouses, item.get("quantity"), company, ignore_validation=True)
 
-	if not locations:
-		new_mr_items.append(item)
-		return
-
 	required_qty = item.get("quantity")
 	for d in locations:
 		if required_qty <=0: return
@@ -970,8 +966,8 @@ def get_materials_from_other_locations(item, warehouses, new_mr_items, company):
 
 	if required_qty:
 		stock_uom, purchase_uom = frappe.db.get_value(
-			'Item', 
-			item['item_code'], 
+			'Item',
+			item['item_code'],
 			['stock_uom', 'purchase_uom']
 		)
 


### PR DESCRIPTION
When a material request is to be made for purchase qty should be converted to purchase UOM.

Identified missing case when reviewing https://github.com/frappe/erpnext/pull/28570#issuecomment-1014702798 