### PR TITLE
fix: Cleanup empty rows on bank statement import

### DIFF
--- a/erpnext/accounts/doctype/bank_statement_import/bank_statement_import.py
+++ b/erpnext/accounts/doctype/bank_statement_import/bank_statement_import.py
@@ -17,6 +17,7 @@ from openpyxl.styles import Font
 from openpyxl.utils import get_column_letter
 from six import string_types
 
+INVALID_VALUES = ("", None)
 
 class BankStatementImport(DataImport):
 	def __init__(self, *args, **kwargs):
@@ -96,6 +97,18 @@ def download_errored_template(data_import_name):
 	data_import = frappe.get_doc("Bank Statement Import", data_import_name)
 	data_import.export_errored_rows()
 
+def parse_data_from_template(raw_data):
+	data = []
+
+	for i, row in enumerate(raw_data):
+		if all(v in INVALID_VALUES for v in row):
+			# empty row
+			continue
+
+		data.append(row)
+
+	return data
+
 def start_import(data_import, bank_account, import_file_path, google_sheets_url, bank, template_options):
 	"""This method runs in background job"""
 
@@ -105,7 +118,8 @@ def start_import(data_import, bank_account, import_file_path, google_sheets_url,
 	file = import_file_path if import_file_path else google_sheets_url
 
 	import_file = ImportFile("Bank Transaction", file = file, import_type="Insert New Records")
-	data = import_file.raw_data
+
+	data = parse_data_from_template(import_file.raw_data)
 
 	if import_file_path:
 		add_bank_account(data, bank_account)


### PR DESCRIPTION
Bank Statement Import fails if there are empty rows in the template as follows and gives the below error

```
Traceback (most recent call last):
  File "apps/frappe/frappe/utils/background_jobs.py", line 104, in execute_job
    method(**kwargs)
  File "apps/erpnext/erpnext/accounts/doctype/bank_statement_import/bank_statement_import.py", line 111, in start_import
    add_bank_account(data, bank_account)
  File "apps/erpnext/erpnext/accounts/doctype/bank_statement_import/bank_statement_import.py", line 147, in add_bank_account
    row[bank_account_loc] = bank_account
IndexError: list assignment index out of range
```

![image](https://user-images.githubusercontent.com/42651287/150278818-5ddeb7d4-bce7-4737-a7ad-f50d75d30a28.png)

Added a function to clean up empty rows before importing
