### PR TITLE
fix: show stock UOM for material transfers

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -948,6 +948,7 @@ def get_materials_from_other_locations(item, warehouses, new_mr_items, company):
 		warehouses, item.get("quantity"), company, ignore_validation=True)
 
 	required_qty = item.get("quantity")
+	# get available material by transferring to production warehouse
 	for d in locations:
 		if required_qty <=0: return
 
@@ -958,12 +959,14 @@ def get_materials_from_other_locations(item, warehouses, new_mr_items, company):
 			new_dict.update({
 				"quantity": quantity,
 				"material_request_type": "Material Transfer",
+				"uom": new_dict.get("stock_uom"),  # internal transfer should be in stock UOM
 				"from_warehouse": d.get("warehouse")
 			})
 
 			required_qty -= quantity
 			new_mr_items.append(new_dict)
 
+	# raise purchase request for remaining qty
 	if required_qty:
 		stock_uom, purchase_uom = frappe.db.get_value(
 			'Item',


### PR DESCRIPTION
To reproduce: follow https://github.com/frappe/erpnext/pull/28570

In the production plan, the material request table shown was showing purchase UOM for all rows; it was handled correctly internally just UOM displayed was incorrect. 

Before:
![image](https://user-images.githubusercontent.com/9079960/150306109-819b24d8-0bd7-4be6-902b-54b0afd15340.png)



After: 
<img width="1041" alt="Screenshot 2022-01-20 at 2 23 45 PM" src="https://user-images.githubusercontent.com/9079960/150305740-e764361f-202a-416f-83a6-dbb300cbe75c.png">
