### PR TITLE
fix: "sr no created" misleading message

### DIFF
--- a/erpnext/stock/doctype/serial_no/serial_no.py
+++ b/erpnext/stock/doctype/serial_no/serial_no.py
@@ -444,6 +444,18 @@ def auto_make_serial_nos(args):
 		message = _("The following serial numbers were created: <br><br> {0}").format(get_items_html(form_links, item_code))
 		frappe.msgprint(message, multiple_title)
 
+	# Add rollback watcher to remove misleading message that
+	# "serial nos are created" in case of future failures.
+	def _remove_misleading_messages():
+		import frappe
+
+		msg_log = frappe.local.message_log
+		if msg_log:
+			frappe.local.message_log = msg_log[-1:]
+
+	rollback_watcher = frappe._dict(on_rollback=_remove_misleading_messages)
+	frappe.local.rollback_observers.append(rollback_watcher)
+
 def get_items_html(serial_nos, item_code):
 	body = ', '.join(serial_nos)
 	return '''<details><summary>

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -950,7 +950,7 @@ class StockEntry(StockController):
 			(self.company, args.get('item_code'), nowdate()), as_dict = 1)
 
 		if not item:
-			frappe.throw(_("Item {0} is not active or end of life has been reached").format(args.get("item_code")))
+			frappe.throw(_("Item {0} is disabled or end of life has been reached").format(args.get("item_code")))
 
 		item = item[0]
 		item_group_defaults = get_item_group_defaults(item.name, self.company)


### PR DESCRIPTION
To reproduce:

1. create 2 serialized items, 1 with series and 2nd with no series (i.e. you manually need to input sr no)
2. create stock receipt of both items, 1st with auto generated serial nos and 2nd manual.
3. Save and submit. 

<img width="612" alt="Screenshot 2022-01-20 at 4 19 44 PM" src="https://user-images.githubusercontent.com/9079960/150324639-c81608c8-ae87-4a66-ae26-ce1a35328c28.png">


Root cause: msgprints just go brrrr but the entire transaction has actually been rolled back so nothing got committed to database i.e. no new serial nos. So it's misleading. 

Solution: on rollback clear all messages except last one. It's ugly; MAYBE framework should provide a default solution for this. 





PS: doesn't work :lol: rollback observers are called after processing message. 
 https://github.com/frappe/frappe/blob/1e70c02e43b3a7212e4c35598721dcf1d183c249/frappe/app.py#L86-L94 