### PR TITLE
fix(patch): delete hospitality custom fields

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -326,7 +326,7 @@ erpnext.patches.v14_0.set_payroll_cost_centers
 erpnext.patches.v13_0.agriculture_deprecation_warning
 erpnext.patches.v14_0.delete_agriculture_doctypes
 erpnext.patches.v13_0.hospitality_deprecation_warning
-erpnext.patches.v14_0.delete_hospitality_doctypes
+erpnext.patches.v14_0.delete_hospitality_doctypes # 20-01-2022
 erpnext.patches.v13_0.update_exchange_rate_settings
 erpnext.patches.v14_0.rearrange_company_fields
 erpnext.patches.v14_0.update_leave_notification_template

--- a/erpnext/patches/v14_0/delete_hospitality_doctypes.py
+++ b/erpnext/patches/v14_0/delete_hospitality_doctypes.py
@@ -20,3 +20,13 @@ def execute():
 		doctypes = frappe.get_all("DocType", {"module": module, "custom": 0}, pluck='name')
 		for doctype in doctypes:
 			frappe.delete_doc("DocType", doctype, ignore_missing=True)
+
+	custom_fields = [
+		{"dt": "Sales Invoice", "fieldname": "restaurant"},
+		{"dt": "Sales Invoice", "fieldname": "restaurant_table"},
+		{"dt": "Price List", "fieldname": "restaurant_menu"},
+	]
+
+	for field in custom_fields:
+		custom_field = frappe.db.get_value("Custom Field", field)
+		frappe.delete_doc("Custom Field", custom_field, ignore_missing=True)


### PR DESCRIPTION
Missed out the deletion of custom fields as pointed out here: https://github.com/frappe/erpnext/pull/29167#discussion_r788444630

to test: 
- just see if the sales invoice page opens or not.
- check if restaurant custom field got deleted from custom fields list. 