### PR TITLE
fix: Cart & Popup Logic of Item variant without Website Item

### DIFF
--- a/erpnext/e_commerce/shopping_cart/cart.py
+++ b/erpnext/e_commerce/shopping_cart/cart.py
@@ -42,7 +42,7 @@ def get_cart_quotation(doc=None):
 
 	if not doc.customer_address and addresses:
 		update_cart_address("billing", addresses[0].name)
-	print("doc>>", doc, type(doc))
+
 	return {
 		"doc": decorate_quotation_doc(doc),
 		"shipping_addresses": get_shipping_addresses(party),
@@ -284,12 +284,16 @@ def decorate_quotation_doc(doc):
 			variant_data = frappe.db.get_values(
 				"Item",
 				filters={"item_code": item_code},
-				fieldname=["variant_of", "item_name"],
+				fieldname=["variant_of", "item_name", "image"],
 				as_dict=True
 			)[0]
 			item_code = variant_data.variant_of
-			d.website_item_name = variant_data.item_name
 			fields = fields[1:]
+			d.website_item_name = variant_data.item_name
+
+			if variant_data.image: # get image from variant or template web item
+				d.thumbnail = variant_data.image
+				fields = fields[2:]
 
 		d.update(frappe.db.get_value(
 			"Website Item",

--- a/erpnext/e_commerce/shopping_cart/cart.py
+++ b/erpnext/e_commerce/shopping_cart/cart.py
@@ -42,7 +42,7 @@ def get_cart_quotation(doc=None):
 
 	if not doc.customer_address and addresses:
 		update_cart_address("billing", addresses[0].name)
-
+	print("doc>>", doc, type(doc))
 	return {
 		"doc": decorate_quotation_doc(doc),
 		"shipping_addresses": get_shipping_addresses(party),
@@ -276,10 +276,25 @@ def guess_territory():
 
 def decorate_quotation_doc(doc):
 	for d in doc.get("items", []):
+		item_code = d.item_code
+		fields = ["web_item_name", "thumbnail", "website_image", "description", "route"]
+
+		# Variant Item
+		if not frappe.db.exists("Website Item", {"item_code": item_code}):
+			variant_data = frappe.db.get_values(
+				"Item",
+				filters={"item_code": item_code},
+				fieldname=["variant_of", "item_name"],
+				as_dict=True
+			)[0]
+			item_code = variant_data.variant_of
+			d.website_item_name = variant_data.item_name
+			fields = fields[1:]
+
 		d.update(frappe.db.get_value(
 			"Website Item",
-			{"item_code": d.item_code},
-			["web_item_name", "thumbnail", "website_image", "description", "route"],
+			{"item_code": item_code},
+			fields,
 			as_dict=True)
 		)
 

--- a/erpnext/e_commerce/shopping_cart/test_shopping_cart.py
+++ b/erpnext/e_commerce/shopping_cart/test_shopping_cart.py
@@ -9,8 +9,8 @@ from frappe.utils import add_months, nowdate
 
 from erpnext.accounts.doctype.tax_rule.tax_rule import ConflictingTaxRule
 from erpnext.e_commerce.doctype.website_item.website_item import make_website_item
-from erpnext.e_commerce.shopping_cart.cart import _get_cart_quotation, get_party, update_cart
-from erpnext.tests.utils import create_test_contact_and_address
+from erpnext.e_commerce.shopping_cart.cart import _get_cart_quotation, get_cart_quotation, get_party, update_cart
+from erpnext.tests.utils import create_test_contact_and_address, change_settings
 
 
 class TestShoppingCart(unittest.TestCase):
@@ -34,6 +34,7 @@ class TestShoppingCart(unittest.TestCase):
 			make_website_item(frappe.get_cached_doc("Item",  "_Test Item 2"))
 
 	def tearDown(self):
+		frappe.db.rollback()
 		frappe.set_user("Administrator")
 		self.disable_shopping_cart()
 
@@ -127,6 +128,41 @@ class TestShoppingCart(unittest.TestCase):
 		self.assertEqual(quotation.total_taxes_and_charges, 1000.0)
 
 		self.remove_test_quotation(quotation)
+
+	@change_settings("E Commerce Settings",{
+		"company": "_Test Company",
+		"enabled": 1,
+		"default_customer_group": "_Test Customer Group",
+		"price_list": "_Test Price List India",
+		"show_price": 1
+		}
+	)
+	def test_add_item_variant_without_web_item_to_cart(self):
+		"Test adding Variants having no Website Items in cart via Template Web Item."
+		from erpnext.controllers.item_variant import create_variant
+		from erpnext.e_commerce.doctype.website_item.website_item import make_website_item
+		from erpnext.stock.doctype.item.test_item import make_item
+
+		template_item = make_item("Test-Tshirt-Temp", {
+			"has_variant": 1,
+			"variant_based_on": "Item Attribute",
+			"attributes": [
+				{"attribute": "Test Size"},
+				{"attribute": "Test Colour"}
+			]
+		})
+		variant = create_variant("Test-Tshirt-Temp", {
+			"Test Size": "Small", "Test Colour": "Red"
+		})
+		variant.save()
+		make_website_item(template_item) # publish template not variant
+
+		update_cart("Test-Tshirt-Temp-S-R", 1)
+
+		cart = get_cart_quotation() # test if cart page gets data without errors
+		doc = cart.get("doc")
+
+		self.assertEqual(doc.get("items")[0].item_name, "Test-Tshirt-Temp-S-R")
 
 	def create_tax_rule(self):
 		tax_rule = frappe.get_test_records("Tax Rule")[0]

--- a/erpnext/e_commerce/shopping_cart/test_shopping_cart.py
+++ b/erpnext/e_commerce/shopping_cart/test_shopping_cart.py
@@ -9,8 +9,13 @@ from frappe.utils import add_months, nowdate
 
 from erpnext.accounts.doctype.tax_rule.tax_rule import ConflictingTaxRule
 from erpnext.e_commerce.doctype.website_item.website_item import make_website_item
-from erpnext.e_commerce.shopping_cart.cart import _get_cart_quotation, get_cart_quotation, get_party, update_cart
-from erpnext.tests.utils import create_test_contact_and_address, change_settings
+from erpnext.e_commerce.shopping_cart.cart import (
+	_get_cart_quotation,
+	get_cart_quotation,
+	get_party,
+	update_cart,
+)
+from erpnext.tests.utils import change_settings, create_test_contact_and_address
 
 
 class TestShoppingCart(unittest.TestCase):
@@ -135,8 +140,7 @@ class TestShoppingCart(unittest.TestCase):
 		"default_customer_group": "_Test Customer Group",
 		"price_list": "_Test Price List India",
 		"show_price": 1
-		}
-	)
+	})
 	def test_add_item_variant_without_web_item_to_cart(self):
 		"Test adding Variants having no Website Items in cart via Template Web Item."
 		from erpnext.controllers.item_variant import create_variant

--- a/erpnext/e_commerce/variant_selector/test_variant_selector.py
+++ b/erpnext/e_commerce/variant_selector/test_variant_selector.py
@@ -100,6 +100,7 @@ class TestVariantSelector(ERPNextTestCase):
 		"""
 		from erpnext.e_commerce.doctype.website_item.test_website_item import make_web_item_price
 
+		frappe.set_user("Administrator")
 		make_web_item_price(item_code="Test-Tshirt-Temp-S-R", price_list_rate=100)
 		next_values = get_next_attribute_and_values(
 			"Test-Tshirt-Temp",

--- a/erpnext/e_commerce/variant_selector/test_variant_selector.py
+++ b/erpnext/e_commerce/variant_selector/test_variant_selector.py
@@ -93,15 +93,12 @@ class TestVariantSelector(ERPNextTestCase):
 		"default_customer_group": "_Test Customer Group",
 		"price_list": "_Test Price List India",
 		"show_price": 1
-		}
-	)
+	})
 	def test_exact_match_with_price(self):
 		"""
 			Test price fetching and matching of variant without Website Item
 		"""
-		from erpnext.e_commerce.doctype.website_item.test_website_item import (
-			make_web_item_price,
-		)
+		from erpnext.e_commerce.doctype.website_item.test_website_item import make_web_item_price
 
 		make_web_item_price(item_code="Test-Tshirt-Temp-S-R", price_list_rate=100)
 		next_values = get_next_attribute_and_values(

--- a/erpnext/e_commerce/variant_selector/utils.py
+++ b/erpnext/e_commerce/variant_selector/utils.py
@@ -1,7 +1,10 @@
 import frappe
 from frappe.utils import cint
 
-from erpnext.e_commerce.doctype.e_commerce_settings.e_commerce_settings import get_shopping_cart_settings
+from erpnext.e_commerce.doctype.e_commerce_settings.e_commerce_settings import (
+	get_shopping_cart_settings
+)
+from erpnext.e_commerce.shopping_cart.cart import _set_price_list
 from erpnext.e_commerce.variant_selector.item_variants_cache import ItemVariantsCacheManager
 from erpnext.utilities.product import get_price
 
@@ -202,9 +205,10 @@ def get_item_variant_price_dict(item_code, cart_settings):
 		# Show Price if logged in.
 		# If not logged in, check if price is hidden for guest.
 		if not is_guest or not cart_settings.hide_price_for_guest:
+			price_list = _set_price_list(cart_settings, None)
 			price = get_price(
 				item_code,
-				cart_settings.price_list, #TODO
+				price_list,
 				cart_settings.default_customer_group,
 				cart_settings.company
 			)

--- a/erpnext/e_commerce/variant_selector/utils.py
+++ b/erpnext/e_commerce/variant_selector/utils.py
@@ -1,7 +1,9 @@
 import frappe
 from frappe.utils import cint
 
+from erpnext.e_commerce.doctype.e_commerce_settings.e_commerce_settings import get_shopping_cart_settings
 from erpnext.e_commerce.variant_selector.item_variants_cache import ItemVariantsCacheManager
+from erpnext.utilities.product import get_price
 
 
 def get_item_codes_by_attributes(attribute_filters, template_item_code=None):
@@ -143,14 +145,13 @@ def get_next_attribute_and_values(item_code, selected_attributes):
 	filtered_items_count = len(filtered_items)
 
 	# get product info if exact match
-	from erpnext.e_commerce.shopping_cart.product_info import get_product_info_for_website
+	# from erpnext.e_commerce.shopping_cart.product_info import get_product_info_for_website
 	if exact_match:
-		data = get_product_info_for_website(exact_match[0])
-		product_info = data.product_info
+		cart_settings = get_shopping_cart_settings()
+		product_info = get_item_variant_price_dict(exact_match[0], cart_settings)
+
 		if product_info:
-			product_info["allow_items_not_in_stock"] = cint(data.cart_settings.allow_items_not_in_stock)
-		if not data.cart_settings.show_price:
-			product_info = None
+			product_info["allow_items_not_in_stock"] = cint(cart_settings.allow_items_not_in_stock)
 	else:
 		product_info = None
 
@@ -194,4 +195,20 @@ def get_item_attributes(item_code):
 			a.optional = True
 
 	return attributes
+
+def get_item_variant_price_dict(item_code, cart_settings):
+	if cart_settings.enabled and cart_settings.show_price:
+		is_guest = frappe.session.user == "Guest"
+		# Show Price if logged in.
+		# If not logged in, check if price is hidden for guest.
+		if not is_guest or not cart_settings.hide_price_for_guest:
+			price = get_price(
+				item_code,
+				cart_settings.price_list, #TODO
+				cart_settings.default_customer_group,
+				cart_settings.company
+			)
+			return {"price": price}
+
+	return None
 

--- a/erpnext/e_commerce/variant_selector/utils.py
+++ b/erpnext/e_commerce/variant_selector/utils.py
@@ -2,7 +2,7 @@ import frappe
 from frappe.utils import cint
 
 from erpnext.e_commerce.doctype.e_commerce_settings.e_commerce_settings import (
-	get_shopping_cart_settings
+	get_shopping_cart_settings,
 )
 from erpnext.e_commerce.shopping_cart.cart import _set_price_list
 from erpnext.e_commerce.variant_selector.item_variants_cache import ItemVariantsCacheManager

--- a/erpnext/templates/generators/item/item_configure.js
+++ b/erpnext/templates/generators/item/item_configure.js
@@ -214,7 +214,7 @@ class ItemConfigure {
 			? `<div class="alert alert-success d-flex justify-content-between align-items-center" role="alert">
 				<div><div>
 					${one_item}
-					${product_info && product_info.price && !$.isEmptyObject()
+					${product_info && product_info.price && !$.isEmptyObject(product_info.price)
 						? '(' + product_info.price.formatted_price_sales_uom + ')'
 						: ''
 					}


### PR DESCRIPTION
Fix over https://github.com/frappe/erpnext/pull/29219

## **Issue:**
- Lets assume Item **Tshirt** has many variants which don't need individual Web Pages. We just want the variants to be selected based on Color/Size and added to cart
- [This fix](https://github.com/frappe/erpnext/pull/29219) made sure that we don't need a Website Item of variants to select them from the template's web page
- While getting the exact matched item, it used to try fetch all product details, in which it to fetch Website Item details (in this case variants don't have website items):
![image](https://user-images.githubusercontent.com/25857446/150354579-fb3bb0ad-3684-41cd-a6cb-324cee5cb440.png)
- Another issue was display in shopping cart would also break because it relied on Website Item.

## **Fix:**
**To consider:** There's only two actions with variants not having a Website Item - add to cart & fetch in popup
- While getting the exact match in template web item popup, fetch only price details, not entire product details since it's not even used. Only price is used for display
- For Variant items without Website Items, get web data like image from the template. But get name from Item master itself
- Below you will see the name is from the Variant Item master, and the image is from the Template Item
   <img width="775" alt="Screenshot 2022-01-20 at 7 46 05 PM" src="https://user-images.githubusercontent.com/25857446/150355503-1012b25f-f0b2-4a29-975e-e63db5c8c11f.png">

**todo:**
- [x] Provide right selling price list to `get_price`
- [x] Test full flow from popup to cart

**To Test:**
- Against Template Item **Tshirt**, create a variant **Tshirt-Small-Red** (keep a human readable item name)
- Publish the Template Item only
- Create Item Price for variant **Tshirt-Small-Red**
- Go to template item web page > Click on **Select Variant** > select attributes for variant **Tshirt-Small-Red**
- This item should get an exact match and its price should be visible in popup too
- Add variant to cart
- Go to cart and check it's name, image and price (if no image in variant item master, it should fetch from template website item). Name should be same as Variant Item master

Try the same flow with another template item whose variant does have a published website item