### PR TITLE
fix: can't cancel reconciliation that created new sr no

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -256,11 +256,7 @@ class StockController(AccountsController):
 		for d in self.items:
 			if not d.batch_no: continue
 
-			serial_nos = [sr.name for sr in frappe.get_all("Serial No",
-				{'batch_no': d.batch_no, 'status': 'Inactive'})]
-
-			if serial_nos:
-				frappe.db.set_value("Serial No", { 'name': ['in', serial_nos] }, "batch_no", None)
+			frappe.db.set_value("Serial No", {"batch_no": d.batch_no, "status": "Inactive"}, "batch_no", None)
 
 			d.batch_no = None
 			d.db_set("batch_no", None)

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -318,6 +318,7 @@ erpnext.patches.v13_0.create_ksa_vat_custom_fields # 07-01-2022
 erpnext.patches.v14_0.rename_ongoing_status_in_sla_documents
 erpnext.patches.v14_0.migrate_crm_settings
 erpnext.patches.v13_0.rename_ksa_qr_field
+erpnext.patches.v13_0.wipe_serial_no_field_for_0_qty
 erpnext.patches.v13_0.disable_ksa_print_format_for_others # 16-12-2021
 erpnext.patches.v14_0.add_default_exit_questionnaire_notification_template
 erpnext.patches.v13_0.update_tax_category_for_rcm

--- a/erpnext/patches/v13_0/wipe_serial_no_field_for_0_qty.py
+++ b/erpnext/patches/v13_0/wipe_serial_no_field_for_0_qty.py
@@ -1,0 +1,11 @@
+import frappe
+
+
+def execute():
+	sr_item = frappe.qb.DocType("Stock Reconciliation Item")
+
+	(frappe.qb
+		.update(sr_item)
+		.set(sr_item.current_serial_no, None)
+		.where(sr_item.current_qty == 0)
+	).run()

--- a/erpnext/stock/utils.py
+++ b/erpnext/stock/utils.py
@@ -103,7 +103,7 @@ def get_stock_balance(item_code, warehouse, posting_date=None, posting_time=None
 			serial_nos = get_serial_nos_data_after_transactions(args)
 
 			return ((last_entry.qty_after_transaction, last_entry.valuation_rate, serial_nos)
-				if last_entry else (0.0, 0.0, 0.0))
+				if last_entry else (0.0, 0.0, None))
 		else:
 			return (last_entry.qty_after_transaction, last_entry.valuation_rate) if last_entry else (0.0, 0.0)
 	else:


### PR DESCRIPTION
closes: https://github.com/frappe/erpnext/issues/25390 

Steps to reproduce:
1. Create a new serialized item (WITHOUT batches)
2. Create a stock reco and add serial nos for it via stock reco. 
3. New serial nos will get created
4. Cancel the said stock reco. You'll get error that `sr is undefined`.


Root cause: stock reco was setting `"0"` as `current_serial_no` instead it should have been `""` (empty string) or `None`.

Fix: set current_serial_no to empty string when none are found
patch: update stock reco item row's serial no to `NULL` where qty is 0.

Minor unrelated perf: `N+1` query for unlinking inactive serial nos instead of `N+2`. (will become just `2` after https://github.com/frappe/frappe/pull/15560 goes through)  