### PR TITLE
fix: Wrong variable name breaks Cart Items rendering

### DIFF
--- a/erpnext/e_commerce/shopping_cart/cart.py
+++ b/erpnext/e_commerce/shopping_cart/cart.py
@@ -289,7 +289,7 @@ def decorate_quotation_doc(doc):
 			)[0]
 			item_code = variant_data.variant_of
 			fields = fields[1:]
-			d.website_item_name = variant_data.item_name
+			d.web_item_name = variant_data.item_name
 
 			if variant_data.image: # get image from variant or template web item
 				d.thumbnail = variant_data.image

--- a/erpnext/e_commerce/shopping_cart/test_shopping_cart.py
+++ b/erpnext/e_commerce/shopping_cart/test_shopping_cart.py
@@ -168,6 +168,9 @@ class TestShoppingCart(unittest.TestCase):
 
 		self.assertEqual(doc.get("items")[0].item_name, "Test-Tshirt-Temp-S-R")
 
+		# test if items are rendered without error
+		frappe.render_template("templates/includes/cart/cart_items.html", cart)
+
 	def create_tax_rule(self):
 		tax_rule = frappe.get_test_records("Tax Rule")[0]
 		try:

--- a/erpnext/e_commerce/variant_selector/test_variant_selector.py
+++ b/erpnext/e_commerce/variant_selector/test_variant_selector.py
@@ -3,10 +3,13 @@ import unittest
 import frappe
 
 from erpnext.controllers.item_variant import create_variant
+from erpnext.e_commerce.doctype.e_commerce_settings.test_e_commerce_settings import (
+	setup_e_commerce_settings,
+)
 from erpnext.e_commerce.doctype.website_item.website_item import make_website_item
 from erpnext.e_commerce.variant_selector.utils import get_next_attribute_and_values
 from erpnext.stock.doctype.item.test_item import make_item
-from erpnext.tests.utils import ERPNextTestCase, change_settings
+from erpnext.tests.utils import ERPNextTestCase
 
 test_dependencies = ["Item"]
 
@@ -87,13 +90,6 @@ class TestVariantSelector(ERPNextTestCase):
 		self.assertEqual(len(filtered_items), 1)
 		self.assertEqual(filtered_items.pop(), "Test-Tshirt-Temp-S-R")
 
-	@change_settings("E Commerce Settings",{
-		"company": "_Test Company",
-		"enabled": 1,
-		"default_customer_group": "_Test Customer Group",
-		"price_list": "_Test Price List India",
-		"show_price": 1
-	})
 	def test_exact_match_with_price(self):
 		"""
 			Test price fetching and matching of variant without Website Item
@@ -101,11 +97,20 @@ class TestVariantSelector(ERPNextTestCase):
 		from erpnext.e_commerce.doctype.website_item.test_website_item import make_web_item_price
 
 		frappe.set_user("Administrator")
+		setup_e_commerce_settings({
+			"company": "_Test Company",
+			"enabled": 1,
+			"default_customer_group": "_Test Customer Group",
+			"price_list": "_Test Price List India",
+			"show_price": 1
+		})
+
 		make_web_item_price(item_code="Test-Tshirt-Temp-S-R", price_list_rate=100)
 		next_values = get_next_attribute_and_values(
 			"Test-Tshirt-Temp",
 			selected_attributes={"Test Size": "Small", "Test Colour": "Red"}
 		)
+		print(">>>>", next_values)
 		price_info = next_values["product_info"]["price"]
 
 		self.assertEqual(next_values["exact_match"][0],"Test-Tshirt-Temp-S-R")


### PR DESCRIPTION
**issue:**
After adding a variant to cart from the popup , having no image (nothing in template web item too), cart breaks:
```py
jinja2.exceptions.UndefinedError: 'erpnext.selling.doctype.quotation_item.quotation_item.QuotationItem object' has no attribute 'web_item_name'
```

**fix:**
- Correct variable name
- Test cart items rendering 
