### PR TITLE
fix: opening invoice creation tool can fetch multiple accounting dimension

### DIFF
--- a/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.py
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.py
@@ -135,7 +135,7 @@ class OpeningInvoiceCreationTool(Document):
 			default_uom = frappe.db.get_single_value("Stock Settings", "stock_uom") or _("Nos")
 			rate = flt(row.outstanding_amount) / flt(row.qty)
 
-			return frappe._dict({
+			item_dict = frappe._dict({
 				"uom": default_uom,
 				"rate": rate or 0.0,
 				"qty": row.qty,
@@ -145,6 +145,13 @@ class OpeningInvoiceCreationTool(Document):
 				income_expense_account_field: row.temporary_opening_account,
 				"cost_center": cost_center
 			})
+
+			for dimension in get_accounting_dimensions():
+				item_dict.update({
+					dimension: row.get(dimension)
+				})
+
+			return item_dict
 
 		item = get_item_dict()
 
@@ -166,7 +173,7 @@ class OpeningInvoiceCreationTool(Document):
 		accounting_dimension = get_accounting_dimensions()
 		for dimension in accounting_dimension:
 			invoice.update({
-				dimension: item.get(dimension)
+				dimension: self.get(dimension) or item.get(dimension)
 			})
 
 		return invoice

--- a/erpnext/accounts/doctype/opening_invoice_creation_tool/test_opening_invoice_creation_tool.py
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool/test_opening_invoice_creation_tool.py
@@ -9,6 +9,7 @@ from frappe.custom.doctype.property_setter.property_setter import make_property_
 
 from erpnext.accounts.doctype.accounting_dimension.test_accounting_dimension import (
 	create_dimension,
+	disable_dimension,
 )
 from erpnext.accounts.doctype.opening_invoice_creation_tool.opening_invoice_creation_tool import (
 	get_temporary_opening_account,
@@ -20,6 +21,7 @@ class TestOpeningInvoiceCreationTool(unittest.TestCase):
 	def setUp(self):
 		if not frappe.db.exists("Company", "_Test Opening Invoice Company"):
 			make_company()
+		create_dimension()
 
 	def make_invoices(self, invoice_type="Sales", company=None, party_1=None, party_2=None, invoice_number=None, department=None):
 		doc = frappe.get_single("Opening Invoice Creation Tool")
@@ -110,8 +112,6 @@ class TestOpeningInvoiceCreationTool(unittest.TestCase):
 			doc.cancel()
 
 	def test_opening_invoice_with_accounting_dimension(self):
-		# new dimensions department and location are created
-		create_dimension()
 		invoices = self.make_invoices(invoice_type="Sales", company="_Test Opening Invoice Company", department='Sales - _TOIC')
 
 		expected_value = {
@@ -120,6 +120,9 @@ class TestOpeningInvoiceCreationTool(unittest.TestCase):
 			1: ["_Test Customer 1", 250, "Overdue", "Sales - _TOIC"],
 		}
 		self.check_expected_values(invoices, expected_value, invoice_type="Sales")
+
+	def tearDown(self):
+		disable_dimension()
 
 def get_opening_invoice_creation_dict(**args):
 	party = "Customer" if args.get("invoice_type", "Sales") == "Sales" else "Supplier"

--- a/erpnext/accounts/doctype/opening_invoice_creation_tool/test_opening_invoice_creation_tool.py
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool/test_opening_invoice_creation_tool.py
@@ -7,11 +7,12 @@ import frappe
 from frappe.cache_manager import clear_doctype_cache
 from frappe.custom.doctype.property_setter.property_setter import make_property_setter
 
+from erpnext.accounts.doctype.accounting_dimension.test_accounting_dimension import (
+	create_dimension,
+)
 from erpnext.accounts.doctype.opening_invoice_creation_tool.opening_invoice_creation_tool import (
 	get_temporary_opening_account,
 )
-
-from erpnext.accounts.doctype.accounting_dimension.test_accounting_dimension import create_dimension
 
 test_dependencies = ["Customer", "Supplier", "Accounting Dimension"]
 


### PR DESCRIPTION
## Issue
Opening Invoice Creation tool has provision for accepting multiple accounting dimensions if they are already created in the system. But, the invoices created doesn't have the new accounting dimensions. It has been fixed with this change.

## Screenshot
Creation Tool
<img width="1552" alt="Screenshot 2022-01-21 at 7 45 36 PM" src="https://user-images.githubusercontent.com/3272205/150542238-957f264e-97da-4a36-b43b-950b76a20eba.png">
Invoice
<img width="1552" alt="Screenshot 2022-01-21 at 7 46 41 PM" src="https://user-images.githubusercontent.com/3272205/150542247-ebb77c2b-0116-497a-82f1-2ee64778e383.png">

