### PR TITLE
fix: Use get for conditionally available fields while setting missing values

### DIFF
--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -70,9 +70,18 @@ class BuyingController(StockController, Subcontracting):
 
 		# set contact and address details for supplier, if they are not mentioned
 		if getattr(self, "supplier", None):
-			self.update_if_missing(get_party_details(self.supplier, party_type="Supplier", ignore_permissions=self.flags.ignore_permissions,
-			doctype=self.doctype, company=self.company, party_address=self.supplier_address, shipping_address=self.get('shipping_address'),
-			fetch_payment_terms_template= not self.get('ignore_default_payment_terms_template')))
+			self.update_if_missing(
+				get_party_details(
+					self.supplier,
+					party_type="Supplier",
+					doctype=self.doctype,
+					company=self.company,
+					party_address=self.get("supplier_address"),
+					shipping_address=self.get('shipping_address'),
+					fetch_payment_terms_template= not self.get('ignore_default_payment_terms_template'),
+					ignore_permissions=self.flags.ignore_permissions
+				)
+			)
 
 		self.set_missing_item_details(for_validate)
 


### PR DESCRIPTION
**To Replicate Issue:**
- Add custom field `supplier` in Material Request
- Create a new MR > Save > watch the world burn

**Issue:**
- Due to custom field "supplier" and missing field "supplier_address", dot operator breaks in `buying_controller > set_missing_values > get_party_details`
   ```py
    File "apps/erpnext/erpnext/controllers/buying_controller.py", line 74, in set_missing_values
      doctype=self.doctype, company=self.company, party_address=self.supplier_address, 
      shipping_address=self.get('shipping_address'),
    AttributeError: 'MaterialRequest' object has no attribute 'supplier_address'
    ```
- This scenario is brought to you by **customisation**

**Fix:**
- Make sure to use `get` instead of just dot operator if field is in some doctypes and not all


**Ambiguity:**
- Adding such custom fields with core field names, triggers JS functions also that technically aren't supposed to be triggered. The user won't have a clue. Not sure how to go about that