### PR TITLE
fix: fetch "transfer material against" from BOM

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.json
+++ b/erpnext/manufacturing/doctype/work_order/work_order.json
@@ -333,12 +333,13 @@
    "options": "fa fa-wrench"
   },
   {
-   "default": "Work Order",
    "depends_on": "operations",
+   "fetch_from": "bom_no.transfer_material_against",
+   "fetch_if_empty": 1,
    "fieldname": "transfer_material_against",
    "fieldtype": "Select",
    "label": "Transfer Material Against",
-   "options": "Work Order\nJob Card"
+   "options": "\nWork Order\nJob Card"
   },
   {
    "fieldname": "operations",
@@ -574,7 +575,7 @@
  "image_field": "image",
  "is_submittable": 1,
  "links": [],
- "modified": "2021-11-08 17:36:07.016300",
+ "modified": "2022-01-24 21:18:12.160114",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Work Order",
@@ -607,6 +608,7 @@
  ],
  "sort_field": "modified",
  "sort_order": "ASC",
+ "states": [],
  "title_field": "production_item",
  "track_changes": 1,
  "track_seen": 1


### PR DESCRIPTION
closes https://github.com/frappe/erpnext/issues/26491 

We don't set this manually anywhere so just setting "fetch from" + "fetch only if empty" is enough to link WO's "transfer against field" with the same field on BOM. 

Steps to reproduce:
1. Create BOM with transfer against Job card. 
2. create production plan with the said BOM
3. create Work Order from production plan. 
4. Work Order shows transfer against "work order" instead of default specified on BOM which is "Job Card"