### PR TITLE
fix(Employee): set user image and validate user id only if user data is found

### DIFF
--- a/erpnext/hr/doctype/employee/employee.py
+++ b/erpnext/hr/doctype/employee/employee.py
@@ -68,12 +68,18 @@ class Employee(NestedSet):
 		self.employee_name = ' '.join(filter(lambda x: x, [self.first_name, self.middle_name, self.last_name]))
 
 	def validate_user_details(self):
-		data = frappe.db.get_value('User',
-			self.user_id, ['enabled', 'user_image'], as_dict=1)
-		if data.get("user_image") and self.image == '':
-			self.image = data.get("user_image")
-		self.validate_for_enabled_user_id(data.get("enabled", 0))
-		self.validate_duplicate_user_id()
+		if self.user_id:
+			data = frappe.db.get_value("User",
+				self.user_id, ["enabled", "user_image"], as_dict=1)
+
+			if not data:
+				self.user_id = None
+				return
+
+			if data.get("user_image") and self.image == "":
+				self.image = data.get("user_image")
+			self.validate_for_enabled_user_id(data.get("enabled", 0))
+			self.validate_duplicate_user_id()
 
 	def update_nsm_model(self):
 		frappe.utils.nestedset.update_nsm(self)


### PR DESCRIPTION
Setting user image in employee and validating user details fails if a stale/non-existent user id is linked to employee master

```python
Traceback (most recent call last):
  File "apps/frappe/frappe/desk/form/save.py", line 21, in savedocs
    doc.save()
  File "apps/frappe/frappe/model/document.py", line 287, in save
    return self._save(*args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 309, in _save
    return self.insert()
  File "apps/frappe/frappe/model/document.py", line 240, in insert
    self.run_before_save_methods()
  File "apps/frappe/frappe/model/document.py", line 971, in run_before_save_methods
    self.run_method("validate")
  File "apps/frappe/frappe/model/document.py", line 868, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1161, in composer
    return composed(self, method, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1144, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "apps/frappe/frappe/model/document.py", line 862, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "apps/erpnext/erpnext/hr/doctype/employee/employee.py", line 57, in validate
    self.validate_user_details()
  File "apps/erpnext/erpnext/hr/doctype/employee/employee.py", line 73, in validate_user_details
    if data.get("user_image") and self.image == '':
AttributeError: 'NoneType' object has no attribute 'get'
```

Already fixed for `develop` in https://github.com/frappe/erpnext/pull/29024
Not adding tests; Its a defensive fix