### PR TITLE
fix: Further sort sales_order_analysis to get consistent response

### DIFF
--- a/erpnext/selling/report/sales_order_analysis/sales_order_analysis.py
+++ b/erpnext/selling/report/sales_order_analysis/sales_order_analysis.py
@@ -85,7 +85,7 @@ def get_data(conditions, filters):
 			and so.docstatus = 1
 			{conditions}
 		GROUP BY soi.name
-		ORDER BY so.transaction_date ASC
+		ORDER BY so.transaction_date ASC, soi.item_code ASC
 	""".format(conditions=conditions), filters, as_dict=1)
 
 	return data


### PR DESCRIPTION
- Since the data was sorted by `transaction_date`, the report sorting order used to be inconsistent every time if there were lots of records with the same transaction date. This is used to create problems while exporting reports as "Excel" with filters.

For more details
https://frappe.io/app/issue/ISS-21-22-06182

more info:

> while exporting data as Excel with column filter, we pass “visible_idx” from client-side… but due to inconsistent response from the server (DB) the… server picks wrong column as visible row.