### PR TITLE
fix(ux): ensure correct-ish transfer against in BOM

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -149,6 +149,7 @@ class BOM(WebsiteGenerator):
 		self.set_bom_material_details()
 		self.set_bom_scrap_items_detail()
 		self.validate_materials()
+		self.validate_transfer_against()
 		self.set_routing_operations()
 		self.validate_operations()
 		self.calculate_cost()
@@ -689,6 +690,12 @@ class BOM(WebsiteGenerator):
 
 			if act_pbom and act_pbom[0][0]:
 				frappe.throw(_("Cannot deactivate or cancel BOM as it is linked with other BOMs"))
+
+	def validate_transfer_against(self):
+		if not self.with_operations:
+			self.transfer_material_against = "Work Order"
+		if not self.transfer_material_against and not self.is_new():
+			frappe.throw(_("Setting {} is required").format(self.meta.get_label("transfer_material_against")), title=_("Missing value"))
 
 	def set_routing_operations(self):
 		if self.routing and self.with_operations and not self.operations:

--- a/erpnext/manufacturing/doctype/bom/test_bom.py
+++ b/erpnext/manufacturing/doctype/bom/test_bom.py
@@ -403,6 +403,35 @@ class TestBOM(ERPNextTestCase):
 
 		new_bom.delete()
 
+	def test_valid_transfer_defaults(self):
+		bom_with_op = frappe.db.get_value("BOM", {"item": "_Test FG Item 2", "with_operations": 1, "is_active": 1})
+		bom = frappe.copy_doc(frappe.get_doc("BOM", bom_with_op), ignore_no_copy=False)
+
+		# test defaults
+		bom.docstatus = 0
+		bom.transfer_material_against = None
+		bom.insert()
+		self.assertEqual(bom.transfer_material_against, "Work Order")
+
+		bom.reload()
+		bom.transfer_material_against = None
+		with self.assertRaises(frappe.ValidationError):
+			bom.save()
+		bom.reload()
+
+		# test saner default
+		bom.transfer_material_against = "Job Card"
+		bom.with_operations = 0
+		bom.save()
+		self.assertEqual(bom.transfer_material_against, "Work Order")
+
+		# test no value on existing doc
+		bom.transfer_material_against = None
+		bom.with_operations = 0
+		bom.save()
+		self.assertEqual(bom.transfer_material_against, "Work Order")
+
+
 def get_default_bom(item_code="_Test FG Item 2"):
 	return frappe.db.get_value("BOM", {"item": item_code, "is_active": 1, "is_default": 1})
 

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -65,12 +65,14 @@ class WorkOrder(Document):
 		self.validate_warehouse_belongs_to_company()
 		self.calculate_operating_cost()
 		self.validate_qty()
+		self.validate_transfer_against()
 		self.validate_operation_time()
 		self.status = self.get_status()
 
 		validate_uom_is_integer(self, "stock_uom", ["qty", "produced_qty"])
 
 		self.set_required_items(reset_only_qty = len(self.get("required_items")))
+
 
 	def validate_sales_order(self):
 		if self.sales_order:
@@ -624,6 +626,16 @@ class WorkOrder(Document):
 	def validate_qty(self):
 		if not self.qty > 0:
 			frappe.throw(_("Quantity to Manufacture must be greater than 0."))
+
+	def validate_transfer_against(self):
+		if not self.docstatus == 1:
+			# let user configure operations until they're ready to submit
+			return
+		if not self.operations:
+			self.transfer_material_against = "Work Order"
+		if not self.transfer_material_against:
+			frappe.throw(_("Setting {} is required").format(self.meta.get_label("transfer_material_against")), title=_("Missing value"))
+
 
 	def validate_operation_time(self):
 		for d in self.operations:

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -334,3 +334,4 @@ erpnext.patches.v14_0.delete_hospitality_doctypes # 20-01-2022
 erpnext.patches.v14_0.delete_agriculture_doctypes
 erpnext.patches.v14_0.rearrange_company_fields
 erpnext.patches.v14_0.update_leave_notification_template
+erpnext.patches.v13_0.update_sane_transfer_against

--- a/erpnext/patches/v13_0/update_sane_transfer_against.py
+++ b/erpnext/patches/v13_0/update_sane_transfer_against.py
@@ -1,0 +1,11 @@
+import frappe
+
+
+def execute():
+	bom = frappe.qb.DocType("BOM")
+
+	(frappe.qb
+		.update(bom)
+		.set(bom.transfer_material_against, "Work Order")
+		.where(bom.with_operations == 0)
+	).run()


### PR DESCRIPTION
In BOM there are three options for transfer material against: 
- empty (to allow setting and using defaults while saving a new doc)
- job card
- work order

This PR adds some constraint/sane defaults:
1. When there are no operations force Work Order.
2. Don't allow empty transfer against. 

---

Similarly for work order:
1. If no operations are present then set "Work Order" as default material transfer against option while submitting. 
2. Don't allow empty transfer against.

---

Patch existing BOMs but not Work Order. (patching finished WO is not useful and ongoing WO anyways shouldn't be patched)