### PR TITLE
chore: disable annoying flake8 formatting for QB

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -28,6 +28,7 @@ ignore =
     B007,
     B950,
     W191,
+    E124, # closing bracket, irritating while writing QB code
 
 max-line-length = 200
 exclude=.github/helper/semgrep_rules


### PR DESCRIPTION
Flake8 (on Sider) doesn't like QB formatting like this and keeps annoying with unnecessary failures:

<img width="518" alt="Screenshot 2022-01-28 at 1 12 49 PM" src="https://user-images.githubusercontent.com/9079960/151506908-75e1bcac-3f27-4668-98be-e6b1dbe36e18.png">

