### PR TITLE
fix: batch selector for alternate item

### DIFF
--- a/erpnext/public/js/utils/serial_no_batch_selector.js
+++ b/erpnext/public/js/utils/serial_no_batch_selector.js
@@ -592,6 +592,6 @@ function check_can_calculate_pending_qty(me) {
 		&& doc.fg_completed_qty
 		&& erpnext.stock.bom
 		&& erpnext.stock.bom.name === doc.bom_no;
-	const itemChecks = !!item;
+	const itemChecks = !!item  && !item.allow_alternative_item;
 	return docChecks && itemChecks;
 }


### PR DESCRIPTION
1. Setup alternate items - A and B (both with batches)
2. Make A part of some BOM
3. Create work order and keep "allow alternative item" checked
4. create stock entry for stock transfer
5. save stock entry
6. Select alternate item
7. open row in stock entry and click on "pick batch no" to select batch no.
8. nothing shows up.

root cause: https://github.com/frappe/erpnext/pull/25519 added pending qty section BUT the alternate item's info isn't present the global state from stock entry 🥲 

https://github.com/frappe/erpnext/blob/1ee17b43d5e65b2fc4796de2a33fdbe3ea86d45a/erpnext/public/js/utils/serial_no_batch_selector.js#L542-L549

Solution: disable pending qty computation for alternate items.

ref: ISS-21-22-10622 