### PR TITLE
fix: correct value difference in case of repeated-item transaction

### DIFF
--- a/erpnext/stock/doctype/stock_ledger_entry/test_stock_ledger_entry.py
+++ b/erpnext/stock/doctype/stock_ledger_entry/test_stock_ledger_entry.py
@@ -392,7 +392,7 @@ class TestStockLedgerEntry(FrappeTestCase):
 	def assertSLEs(self, doc, expected_sles, sle_filters=None):
 		""" Compare sorted SLEs, useful for vouchers that create multiple SLEs for same line"""
 
-		filters = {"voucher_no": doc.name, "voucher_type": doc.doctype, "is_cancelled":0}
+		filters = {"voucher_no": doc.name, "voucher_type": doc.doctype, "is_cancelled": 0}
 		if sle_filters:
 			filters.update(sle_filters)
 		sles = frappe.get_all("Stock Ledger Entry", fields=["*"], filters=filters,
@@ -694,7 +694,6 @@ class TestStockLedgerEntry(FrappeTestCase):
 		transfer = make_stock_entry(item_code=item.name, source=source, target=target, qty=10, do_not_save=True, rate=10)
 		for rate in rates[1:]:
 			row = frappe.copy_doc(transfer.items[0], ignore_no_copy=False)
-			row.basic_rate = rate
 			transfer.append("items", row)
 
 		transfer.save()
@@ -702,6 +701,43 @@ class TestStockLedgerEntry(FrappeTestCase):
 
 		# same exact queue should be transferred
 		self.assertSLEs(transfer, expected_queues, sle_filters={"warehouse": target})
+
+	def test_fifo_multi_item_repack_consumption(self):
+		rm = make_item("_TestFifoRepackRM")
+		packed = make_item("_TestFifoRepackFinished")
+		warehouse = "_Test Warehouse - _TC"
+
+		rates = [10 * i for i in range(1, 5)]
+
+		receipt = make_stock_entry(item_code=rm.name, target=warehouse, qty=10, do_not_save=True, rate=10)
+		for rate in rates[1:]:
+			row = frappe.copy_doc(receipt.items[0], ignore_no_copy=False)
+			row.basic_rate = rate
+			receipt.append("items", row)
+
+		receipt.save()
+		receipt.submit()
+
+		repack = make_stock_entry(item_code=rm.name, source=warehouse, qty=10,
+				do_not_save=True, rate=10, purpose="Repack")
+		for rate in rates[1:]:
+			row = frappe.copy_doc(repack.items[0], ignore_no_copy=False)
+			repack.append("items", row)
+
+		repack.append("items", {
+			"item_code": packed.name,
+			"t_warehouse": warehouse,
+			"qty": 1,
+			"transfer_qty": 1,
+		})
+
+		repack.save()
+		repack.submit()
+
+		# same exact queue should be transferred
+		self.assertSLEs(repack, [
+			{"incoming_rate": sum(rates) * 10}
+		], sle_filters={"item_code": packed.name})
 
 
 def create_repack_entry(**args):

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -438,8 +438,8 @@ class update_entries_after(object):
 				return
 
 		# Get dynamic incoming/outgoing rate
-		# XXX: performance regression
-		self.get_dynamic_incoming_outgoing_rate(sle)
+		if not self.args.get("sle_id"):
+			self.get_dynamic_incoming_outgoing_rate(sle)
 
 		if get_serial_nos(sle.serial_no):
 			self.get_serialized_values(sle)
@@ -482,8 +482,8 @@ class update_entries_after(object):
 		sle.doctype="Stock Ledger Entry"
 		frappe.get_doc(sle).db_update()
 
-		# XXX: performance regression
-		self.update_outgoing_rate_on_transaction(sle)
+		if not self.args.get("sle_id"):
+			self.update_outgoing_rate_on_transaction(sle)
 
 
 	def validate_negative_stock(self, sle):
@@ -566,8 +566,9 @@ class update_entries_after(object):
 	def update_rate_on_stock_entry(self, sle, outgoing_rate):
 		frappe.db.set_value("Stock Entry Detail", sle.voucher_detail_no, "basic_rate", outgoing_rate)
 
-		# XXX: performance regression
-		self.recalculate_amounts_in_stock_entry(sle.voucher_no)
+		# Update outgoing item's rate, recalculate FG Item's rate and total incoming/outgoing amount
+		if not sle.dependant_sle_voucher_detail_no:
+			self.recalculate_amounts_in_stock_entry(sle.voucher_no)
 
 	def recalculate_amounts_in_stock_entry(self, voucher_no):
 		stock_entry = frappe.get_doc("Stock Entry", voucher_no, for_update=True)

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -438,8 +438,8 @@ class update_entries_after(object):
 				return
 
 		# Get dynamic incoming/outgoing rate
-		if not self.args.get("sle_id"):
-			self.get_dynamic_incoming_outgoing_rate(sle)
+		# XXX: performance regression
+		self.get_dynamic_incoming_outgoing_rate(sle)
 
 		if get_serial_nos(sle.serial_no):
 			self.get_serialized_values(sle)
@@ -482,8 +482,8 @@ class update_entries_after(object):
 		sle.doctype="Stock Ledger Entry"
 		frappe.get_doc(sle).db_update()
 
-		if not self.args.get("sle_id"):
-			self.update_outgoing_rate_on_transaction(sle)
+		# XXX: performance regression
+		self.update_outgoing_rate_on_transaction(sle)
 
 
 	def validate_negative_stock(self, sle):
@@ -566,9 +566,8 @@ class update_entries_after(object):
 	def update_rate_on_stock_entry(self, sle, outgoing_rate):
 		frappe.db.set_value("Stock Entry Detail", sle.voucher_detail_no, "basic_rate", outgoing_rate)
 
-		# Update outgoing item's rate, recalculate FG Item's rate and total incoming/outgoing amount
-		if not sle.dependant_sle_voucher_detail_no:
-			self.recalculate_amounts_in_stock_entry(sle.voucher_no)
+		# XXX: performance regression
+		self.recalculate_amounts_in_stock_entry(sle.voucher_no)
 
 	def recalculate_amounts_in_stock_entry(self, voucher_no):
 		stock_entry = frappe.get_doc("Stock Entry", voucher_no, for_update=True)


### PR DESCRIPTION
closes https://github.com/frappe/erpnext/issues/29468

Problem:

FIFO/LIFO values are incorrect when transferring multiple items with different rates in the same transaction. This is because the incoming rate is computed during submission so FIFO logic doesn't apply there. FIFO logic has to apply at exact moment SLE is created. 

There is "recalculate_rate" provision but this is disabled for "current transaction" i.e. not backdated. Enabling this leads to huge performance regression (~5-10x slowdown, check comment below)

Since this is only required in edge cases where FIFO item is repeated in same transaction it's better to re-process specific edge-case instead of doing it for all transactions. 

Fix: repost transactions with repeated FIFO item-wh consumption. 


TODO:
- [x] [imp] fix performance regression caused by recomputing stock entry table for every SLE. Resolved by queuing repost of vouchers that are affected by this instead of processing while submitting.  
- [x] FIFO multi-item transfer
- [x] FIFO multi-item repack
- [x] FIFO multi-item manufacture