### PR TITLE
fix: bin uniqueness

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -1,5 +1,6 @@
 [pre_model_sync]
 erpnext.patches.v12_0.update_is_cancelled_field
+erpnext.patches.v13_0.add_bin_unique_constraint
 erpnext.patches.v11_0.rename_production_order_to_work_order
 erpnext.patches.v11_0.refactor_naming_series
 erpnext.patches.v11_0.refactor_autoname_naming

--- a/erpnext/patches/v13_0/add_bin_unique_constraint.py
+++ b/erpnext/patches/v13_0/add_bin_unique_constraint.py
@@ -11,35 +11,47 @@ from erpnext.stock.stock_balance import (
 
 
 def execute():
+	delete_broken_bins()
+	delete_and_patch_duplicate_bins()
 
-	duplicate_rows = frappe.db.sql("""
+def delete_broken_bins():
+	# delete useless bins
+	frappe.db.sql("delete from `tabBin` where item_code is null or warehouse is null")
+
+def delete_and_patch_duplicate_bins():
+
+	duplicate_bins = frappe.db.sql("""
 		SELECT
-		item_code, warehouse
+			item_code, warehouse, count(*) as bin_count
 		FROM
 			tabBin
 		GROUP BY
 			item_code, warehouse
 		HAVING
-			COUNT(*) > 1
+			bin_count > 1
 	""", as_dict=1)
 
-	for row in duplicate_rows:
-		bins = frappe.get_list("Bin",
-							   filters={"item_code": row.item_code,
-										"warehouse": row.warehouse},
-							   fields=["name"],
-							   order_by="creation",
-							   )
+	for duplicate_bin in duplicate_bins:
+		existing_bins = frappe.get_list("Bin",
+				filters={
+					"item_code": duplicate_bin.item_code,
+					"warehouse": duplicate_bin.warehouse
+					},
+				fields=["name"],
+				order_by="creation",)
 
-		for x in range(len(bins) - 1):
-			frappe.delete_doc("Bin", bins[x].name)
+		# keep last one
+		existing_bins.pop()
+
+		for broken_bin in existing_bins:
+			frappe.delete_doc("Bin", broken_bin.name)
 
 		qty_dict = {
-			"reserved_qty": get_reserved_qty(row.item_code, row.warehouse),
-			"indented_qty": get_indented_qty(row.item_code, row.warehouse),
-			"ordered_qty": get_ordered_qty(row.item_code, row.warehouse),
-			"planned_qty": get_planned_qty(row.item_code, row.warehouse),
-			"actual_qty": get_balance_qty_from_sle(row.item_code, row.warehouse)
+			"reserved_qty": get_reserved_qty(duplicate_bin.item_code, duplicate_bin.warehouse),
+			"indented_qty": get_indented_qty(duplicate_bin.item_code, duplicate_bin.warehouse),
+			"ordered_qty": get_ordered_qty(duplicate_bin.item_code, duplicate_bin.warehouse),
+			"planned_qty": get_planned_qty(duplicate_bin.item_code, duplicate_bin.warehouse),
+			"actual_qty": get_balance_qty_from_sle(duplicate_bin.item_code, duplicate_bin.warehouse)
 		}
 
-		update_bin_qty(row.item_code, row.warehouse, qty_dict)
+		update_bin_qty(duplicate_bin.item_code, duplicate_bin.warehouse, qty_dict)

--- a/erpnext/patches/v13_0/add_bin_unique_constraint.py
+++ b/erpnext/patches/v13_0/add_bin_unique_constraint.py
@@ -1,0 +1,45 @@
+import frappe
+
+from erpnext.stock.stock_balance import (
+	get_balance_qty_from_sle,
+	get_indented_qty,
+	get_ordered_qty,
+	get_planned_qty,
+	get_reserved_qty,
+	update_bin_qty,
+)
+
+
+def execute():
+
+	duplicate_rows = frappe.db.sql("""
+		SELECT
+		item_code, warehouse
+		FROM
+			tabBin
+		GROUP BY
+			item_code, warehouse
+		HAVING
+			COUNT(*) > 1
+	""", as_dict=1)
+
+	for row in duplicate_rows:
+		bins = frappe.get_list("Bin",
+							   filters={"item_code": row.item_code,
+										"warehouse": row.warehouse},
+							   fields=["name"],
+							   order_by="creation",
+							   )
+
+		for x in range(len(bins) - 1):
+			frappe.delete_doc("Bin", bins[x].name)
+
+		qty_dict = {
+			"reserved_qty": get_reserved_qty(row.item_code, row.warehouse),
+			"indented_qty": get_indented_qty(row.item_code, row.warehouse),
+			"ordered_qty": get_ordered_qty(row.item_code, row.warehouse),
+			"planned_qty": get_planned_qty(row.item_code, row.warehouse),
+			"actual_qty": get_balance_qty_from_sle(row.item_code, row.warehouse)
+		}
+
+		update_bin_qty(row.item_code, row.warehouse, qty_dict)

--- a/erpnext/stock/doctype/bin/bin.json
+++ b/erpnext/stock/doctype/bin/bin.json
@@ -33,6 +33,7 @@
    "oldfieldtype": "Link",
    "options": "Warehouse",
    "read_only": 1,
+   "reqd": 1,
    "search_index": 1
   },
   {
@@ -46,6 +47,7 @@
    "oldfieldtype": "Link",
    "options": "Item",
    "read_only": 1,
+   "reqd": 1,
    "search_index": 1
   },
   {
@@ -169,10 +171,11 @@
  "idx": 1,
  "in_create": 1,
  "links": [],
- "modified": "2021-03-30 23:09:39.572776",
+ "modified": "2022-01-30 17:04:54.715288",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Bin",
+ "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {
@@ -200,5 +203,6 @@
  "quick_entry": 1,
  "search_fields": "item_code,warehouse",
  "sort_field": "modified",
- "sort_order": "ASC"
+ "sort_order": "ASC",
+ "states": []
 }

--- a/erpnext/stock/doctype/bin/bin.py
+++ b/erpnext/stock/doctype/bin/bin.py
@@ -123,7 +123,7 @@ class Bin(Document):
 		self.db_set('projected_qty', self.projected_qty)
 
 def on_doctype_update():
-	frappe.db.add_index("Bin", ["item_code", "warehouse"])
+	frappe.db.add_unique("Bin", ["item_code", "warehouse"], constraint_name="unique_item_warehouse")
 
 
 def update_stock(bin_name, args, allow_negative_stock=False, via_landed_cost_voucher=False):

--- a/erpnext/stock/doctype/bin/test_bin.py
+++ b/erpnext/stock/doctype/bin/test_bin.py
@@ -1,9 +1,36 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
-import unittest
+import frappe
 
-# test_records = frappe.get_test_records('Bin')
+from erpnext.stock.doctype.item.test_item import make_item
+from erpnext.stock.utils import _create_bin
+from erpnext.tests.utils import ERPNextTestCase
 
-class TestBin(unittest.TestCase):
-	pass
+
+class TestBin(ERPNextTestCase):
+
+
+	def test_concurrent_inserts(self):
+		""" Ensure no duplicates are possible in case of concurrent inserts"""
+		item_code = "_TestConcurrentBin"
+		make_item(item_code)
+		warehouse = "_Test Warehouse - _TC"
+
+		bin1 = frappe.get_doc(doctype="Bin", item_code=item_code, warehouse=warehouse)
+		bin1.insert()
+
+		bin2 = frappe.get_doc(doctype="Bin", item_code=item_code, warehouse=warehouse)
+		with self.assertRaises(frappe.UniqueValidationError):
+			bin2.insert()
+
+		# util method should handle it
+		bin = _create_bin(item_code, warehouse)
+		self.assertEqual(bin.item_code, item_code)
+
+		frappe.db.rollback()
+
+	def test_index_exists(self):
+		indexes = frappe.db.sql("show index from tabBin where Non_unique = 0", as_dict=1)
+		if not any(index.get("Key_name") == "unique_item_warehouse" for index in indexes):
+			self.fail(f"Expected unique index on item-warehouse")

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -1673,6 +1673,8 @@ class StockEntry(StockController):
 			for d in self.get("items"):
 				item_code = d.get('original_item') or d.get('item_code')
 				reserve_warehouse = item_wh.get(item_code)
+				if not (reserve_warehouse and item_code):
+					continue
 				stock_bin = get_bin(item_code, reserve_warehouse)
 				stock_bin.update_reserved_qty_for_sub_contracting()
 


### PR DESCRIPTION
- In very rare cases concurrent updates can cause the creation of duplicate Bins.
- In some cases, item/warehouse is not specified for a new bin, such bins are of no use.


Fix:
- Add DB level unique constraint
- Handle constraint failure but only from known util methods.
- Add mandatory constraint on item_code and warehouse
- Add pre-model-sync patch for accommodating new constraints and fixing broken bins if any. 