### PR TITLE
fix: not able to declare opportunity lost without competitors

### DIFF
--- a/erpnext/selling/sales_common.js
+++ b/erpnext/selling/sales_common.js
@@ -499,7 +499,7 @@ frappe.ui.form.on(cur_frm.doctype, {
 					method: 'declare_enquiry_lost',
 					args: {
 						'lost_reasons_list': values.lost_reason,
-						'competitors': values.competitors,
+						'competitors': values.competitors ? values.competitors : [],
 						'detailed_reason': values.detailed_reason
 					},
 					callback: function(r) {


### PR DESCRIPTION
issue- 
in opportunity doc Select the lost reason and click on Declare Lost. System throws this error
![telegram-cloud-photo-size-5-6323301890170925858-y](https://user-images.githubusercontent.com/20715976/151749017-ff7ff8c9-01a5-470d-836b-78ff84ecd57d.jpg)

Closes #29252 