### PR TITLE
chore: revert manual handling of stock level section

### DIFF
--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -376,8 +376,7 @@ $.extend(erpnext.item, {
 		// Show Stock Levels only if is_stock_item
 		if (frm.doc.is_stock_item) {
 			frappe.require('item-dashboard.bundle.js', function() {
-				frm.dashboard.parent.find('.stock-levels').remove();
-				const section = frm.dashboard.add_section('', __("Stock Levels"), 'stock-levels');
+				const section = frm.dashboard.add_section('', __("Stock Levels"));
 				erpnext.item.item_dashboard = new erpnext.stock.ItemDashboard({
 					parent: section,
 					item_code: frm.doc.name,


### PR DESCRIPTION
reverts a temporary solution added a while ago to fix disappearing item stock levels: https://github.com/frappe/erpnext/commit/b99469cdabc646cdfa55ae1ce1709374c7246a7a 