### PR TITLE
fix: employee reminders fixes

### DIFF
--- a/erpnext/hr/doctype/employee/employee_reminders.py
+++ b/erpnext/hr/doctype/employee/employee_reminders.py
@@ -51,7 +51,7 @@ def send_advance_holiday_reminders(frequency):
 			raise_exception=False
 		)
 
-		if not (holidays is None):
+		if holidays:
 			send_holidays_reminder_in_advance(employee, holidays)
 
 def send_holidays_reminder_in_advance(employee, holidays):

--- a/erpnext/hr/doctype/employee/employee_reminders.py
+++ b/erpnext/hr/doctype/employee/employee_reminders.py
@@ -42,7 +42,7 @@ def send_advance_holiday_reminders(frequency):
 	else:
 		return
 
-	employees = frappe.db.get_all('Employee', pluck='name')
+	employees = frappe.db.get_all('Employee', filters={'status': 'Active'}, pluck='name')
 	for employee in employees:
 		holidays = get_holidays_for_employee(
 			employee,

--- a/erpnext/hr/doctype/employee/employee_reminders.py
+++ b/erpnext/hr/doctype/employee/employee_reminders.py
@@ -53,11 +53,13 @@ def send_advance_holiday_reminders(frequency):
 			raise_exception=False
 		)
 
-		if holidays:
-			send_holidays_reminder_in_advance(employee, holidays)
+		send_holidays_reminder_in_advance(employee, holidays)
 
 
 def send_holidays_reminder_in_advance(employee, holidays):
+	if not holidays:
+		return
+
 	employee_doc = frappe.get_doc('Employee', employee)
 	employee_email = get_employee_email(employee_doc)
 	frequency = frappe.db.get_single_value("HR Settings", "frequency")
@@ -258,5 +260,5 @@ def send_work_anniversary_reminder(recipients, reminder_text, anniversary_person
 			anniversary_persons=anniversary_persons,
 			message=message,
 		),
-		header=_("🎊️🎊️ Work Anniversary Reminder 🎊️🎊️")
+		header=_("Work Anniversary Reminder")
 	)

--- a/erpnext/hr/doctype/employee/employee_reminders.py
+++ b/erpnext/hr/doctype/employee/employee_reminders.py
@@ -20,6 +20,7 @@ def send_reminders_in_advance_weekly():
 
 	send_advance_holiday_reminders("Weekly")
 
+
 def send_reminders_in_advance_monthly():
 	to_send_in_advance = int(frappe.db.get_single_value("HR Settings", "send_holiday_reminders"))
 	frequency = frappe.db.get_single_value("HR Settings", "frequency")
@@ -27,6 +28,7 @@ def send_reminders_in_advance_monthly():
 		return
 
 	send_advance_holiday_reminders("Monthly")
+
 
 def send_advance_holiday_reminders(frequency):
 	"""Send Holiday Reminders in Advance to Employees
@@ -53,6 +55,7 @@ def send_advance_holiday_reminders(frequency):
 
 		if holidays:
 			send_holidays_reminder_in_advance(employee, holidays)
+
 
 def send_holidays_reminder_in_advance(employee, holidays):
 	employee_doc = frappe.get_doc('Employee', employee)
@@ -101,6 +104,7 @@ def send_birthday_reminders():
 				reminder_text, message = get_birthday_reminder_text_and_message(others)
 				send_birthday_reminder(person_email, reminder_text, others, message)
 
+
 def get_birthday_reminder_text_and_message(birthday_persons):
 	if len(birthday_persons) == 1:
 		birthday_person_text = birthday_persons[0]['name']
@@ -116,6 +120,7 @@ def get_birthday_reminder_text_and_message(birthday_persons):
 
 	return reminder_text, message
 
+
 def send_birthday_reminder(recipients, reminder_text, birthday_persons, message):
 	frappe.sendmail(
 		recipients=recipients,
@@ -129,9 +134,11 @@ def send_birthday_reminder(recipients, reminder_text, birthday_persons, message)
 		header=_("Birthday Reminder 🎂")
 	)
 
+
 def get_employees_who_are_born_today():
 	"""Get all employee born today & group them based on their company"""
 	return get_employees_having_an_event_today("birthday")
+
 
 def get_employees_having_an_event_today(event_type):
 	"""Get all employee who have `event_type` today
@@ -210,13 +217,14 @@ def send_work_anniversary_reminders():
 				reminder_text, message = get_work_anniversary_reminder_text_and_message(others)
 				send_work_anniversary_reminder(person_email, reminder_text, others, message)
 
+
 def get_work_anniversary_reminder_text_and_message(anniversary_persons):
 	if len(anniversary_persons) == 1:
 		anniversary_person = anniversary_persons[0]['name']
 		persons_name = anniversary_person
 		# Number of years completed at the company
 		completed_years = getdate().year - anniversary_persons[0]['date_of_joining'].year
-		anniversary_person += f" completed {completed_years} years"
+		anniversary_person += f" completed {completed_years} year(s)"
 	else:
 		person_names_with_years = []
 		names = []
@@ -225,7 +233,7 @@ def get_work_anniversary_reminder_text_and_message(anniversary_persons):
 			names.append(person_text)
 			# Number of years completed at the company
 			completed_years = getdate().year - person['date_of_joining'].year
-			person_text += f" completed {completed_years} years"
+			person_text += f" completed {completed_years} year(s)"
 			person_names_with_years.append(person_text)
 
 		# converts ["Jim", "Rim", "Dim"] to Jim, Rim & Dim
@@ -238,6 +246,7 @@ def get_work_anniversary_reminder_text_and_message(anniversary_persons):
 	message += _("Everyone, let’s congratulate {0} on their work anniversary!").format(persons_name)
 
 	return reminder_text, message
+
 
 def send_work_anniversary_reminder(recipients, reminder_text, anniversary_persons, message):
 	frappe.sendmail(

--- a/erpnext/hr/doctype/employee/test_employee_reminders.py
+++ b/erpnext/hr/doctype/employee/test_employee_reminders.py
@@ -64,6 +64,7 @@ class TestEmployeeReminders(unittest.TestCase):
 		test_employee_2.save()
 
 		cls.test_employee_2 = test_employee_2
+		cls.holiday_list_2 = test_holiday_list
 
 	@classmethod
 	def get_test_holiday_dates(cls):
@@ -190,38 +191,50 @@ class TestEmployeeReminders(unittest.TestCase):
 
 		setup_hr_settings('Monthly')
 
-		# disable emp 2
-		frappe.db.set_value('Employee', self.test_employee_2.name, 'status', 'Left')
+		# disable emp 2, set same holiday list
+		frappe.db.set_value('Employee', self.test_employee_2.name, {
+			'status': 'Left',
+			'holiday_list': self.test_employee.holiday_list
+		})
 
 		send_reminders_in_advance_monthly()
 		email_queue = frappe.db.sql("""select * from `tabEmail Queue`""", as_dict=True)
 		self.assertTrue(len(email_queue) > 0)
 
-		# non-active employees should not be recipients
+		# even though emp 2 has holiday, non-active employees should not be recipients
 		recipients = frappe.db.get_all('Email Queue Recipient', pluck='recipient')
 		self.assertTrue(self.test_employee_2.user_id not in recipients)
 
 		# teardown: enable emp 2
-		frappe.db.set_value('Employee', self.test_employee_2.name, 'status', 'Active')
+		frappe.db.set_value('Employee', self.test_employee_2.name, {
+			'status': 'Left',
+			'holiday_list': self.holiday_list_2
+		})
 
 	def test_advance_holiday_reminders_weekly(self):
 		from erpnext.hr.doctype.employee.employee_reminders import send_reminders_in_advance_weekly
 
 		setup_hr_settings('Weekly')
 
-		# disable emp 2
-		frappe.db.set_value('Employee', self.test_employee_2.name, 'status', 'Left')
+		# disable emp 2, set same holiday list
+		frappe.db.set_value('Employee', self.test_employee_2.name, {
+			'status': 'Left',
+			'holiday_list': self.test_employee.holiday_list
+		})
 
 		send_reminders_in_advance_weekly()
 		email_queue = frappe.db.sql("""select * from `tabEmail Queue`""", as_dict=True)
 		self.assertTrue(len(email_queue) > 0)
 
-		# non-active employees should not be recipients
+		# even though emp 2 has holiday, non-active employees should not be recipients
 		recipients = frappe.db.get_all('Email Queue Recipient', pluck='recipient')
 		self.assertTrue(self.test_employee_2.user_id not in recipients)
 
 		# teardown: enable emp 2
-		frappe.db.set_value('Employee', self.test_employee_2.name, 'status', 'Active')
+		frappe.db.set_value('Employee', self.test_employee_2.name, {
+			'status': 'Left',
+			'holiday_list': self.holiday_list_2
+		})
 
 	def test_reminder_not_sent_if_no_holdays(self):
 		setup_hr_settings('Monthly')


### PR DESCRIPTION
Introduced via https://github.com/frappe/erpnext/pull/25735 as mentioned in https://github.com/frappe/erpnext/pull/25735#issuecomment-1026481465

- Send Reminders to Active employees only
- Don't send reminders if there are no holidays: 
  
   ![image](https://user-images.githubusercontent.com/24353136/151955373-13b90b5c-f7ce-44cf-850b-e4e194cb6e45.png)

- Use optional plural in work anniversary reminder message: years -> year(s)

  <img width="628" alt="1-years" src="https://user-images.githubusercontent.com/24353136/151955687-06e101fe-1497-426f-a05d-42f4b04b2ca9.png">
 