### PR TITLE
fix(pos): pricing rule on transactions doesn't work

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -248,7 +248,7 @@ erpnext.PointOfSale.Controller = class {
 
 				numpad_event: (value, action) => this.update_item_field(value, action),
 
-				checkout: () => this.payment.checkout(),
+				checkout: () => this.save_and_checkout(),
 
 				edit_cart: () => this.payment.edit_cart(),
 
@@ -712,5 +712,10 @@ erpnext.PointOfSale.Controller = class {
 				frappe.dom.unfreeze();
 			})
 			.catch(e => console.log(e));
+	}
+
+	async save_and_checkout() {
+		this.frm.is_dirty() && await this.frm.save();
+		this.payment.checkout();
 	}
 };

--- a/erpnext/selling/page/point_of_sale/pos_item_cart.js
+++ b/erpnext/selling/page/point_of_sale/pos_item_cart.js
@@ -191,10 +191,10 @@ erpnext.PointOfSale.ItemCart = class {
 			this.numpad_value = '';
 		});
 
-		this.$component.on('click', '.checkout-btn', function() {
+		this.$component.on('click', '.checkout-btn', async function() {
 			if ($(this).attr('style').indexOf('--blue-500') == -1) return;
 
-			me.events.checkout();
+			await me.events.checkout();
 			me.toggle_checkout_btn(false);
 
 			me.allow_discount_change && me.$add_discount_elem.removeClass("d-none");
@@ -985,6 +985,7 @@ erpnext.PointOfSale.ItemCart = class {
 		$(frm.wrapper).off('refresh-fields');
 		$(frm.wrapper).on('refresh-fields', () => {
 			if (frm.doc.items.length) {
+				this.$cart_items_wrapper.html('');
 				frm.doc.items.forEach(item => {
 					this.update_item_html(item);
 				});


### PR DESCRIPTION
While making a POS Invoice using POS UI, the invoice is not saved at any point. It is directly submitted with the "Submit Order" button. 

This causes problems such as:

- Pricing Rule with **Apply On** set as **Transaction** doesn't get applied from POS UI since the invoice is never saved.
   Such pricing rules are only applied when the invoice is saved. This behavior is the same across transactions.
   For eg., if there is a pricing rule such that, a 10% discount is to be applied for a specific set of customers and if you try 
   to create a POS Invoice for one such customer, the discount will only be applied unless you click "Submit Order" at 
   Payment Page

Other similar issues have been fixed with this PR. Now, when a user clicks on "Checkout" before moving to the payment page, the invoice is first saved to set all the missing details