### PR TITLE
fix: Coupon code item pricing dynamic updation issue in pos screen

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -2288,7 +2288,8 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 				() => this.frm.doc.ignore_pricing_rule=1,
 				() => me.ignore_pricing_rule(),
 				() => this.frm.doc.ignore_pricing_rule=0,
-				() => me.apply_pricing_rule()
+				() => me.apply_pricing_rule(),
+				() => this.frm.save()
 			]);
 		} else {
 			frappe.run_serially([


### PR DESCRIPTION
**Issue:**
On adding a coupon code(additional field) in POS screen it wouldn't update the pricing dynamically, updates only after save

![couponcodepos](https://user-images.githubusercontent.com/36098155/152177046-fb513a93-3751-405a-b50a-69840817c52d.gif)
---

**Solution:**
Saving the form on coupon_code field trigger

![couponcodeposfix](https://user-images.githubusercontent.com/36098155/152178189-eff1efe1-82df-4055-a8d6-042b10f8493c.gif)
