### PR TITLE
fix: Multiple WO for a single Production Plan Item

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -449,7 +449,7 @@ class WorkOrder(Document):
 
 	def update_ordered_qty(self):
 		if self.production_plan and self.production_plan_item:
-			qty = frappe.get_value("Production Plan Item", self.production_plan_item, "ordered_qty")
+			qty = frappe.get_value("Production Plan Item", self.production_plan_item, "ordered_qty") or 0.0
 
 			if self.docstatus == 1:
 				qty += self.qty

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -449,7 +449,13 @@ class WorkOrder(Document):
 
 	def update_ordered_qty(self):
 		if self.production_plan and self.production_plan_item:
-			qty = self.qty if self.docstatus == 1 else 0
+			qty = frappe.get_value("Production Plan Item", self.production_plan_item, "ordered_qty")
+
+			if self.docstatus == 1:
+				qty += self.qty
+			elif self.docstatus == 2:
+				qty -= self.qty
+
 			frappe.db.set_value('Production Plan Item',
 				self.production_plan_item, 'ordered_qty', qty)
 


### PR DESCRIPTION
#### Source/Reference: ISS-21-22-11528

### Issue(s): Production Plan

_Problem:_
- When creating multiple WO for a single Production Plan Item the ordered_qty for that item is resetting every time the WO is submitted or cancelled.

_Proposed Solution:_
- Increasing and Decreasing the Production Plan Item ordered_qty by WO qty on submitting and cancelling events respectively.
<details>
<summary>Images/GIF</summary>

_Before:_

https://user-images.githubusercontent.com/63660334/152211100-9a303b33-284e-498b-b854-8cd6dad972e2.mov

![p-2](https://user-images.githubusercontent.com/63660334/152282185-ef64cdbc-dfaf-4ebb-b163-49fb5022c281.gif)

_After:_

https://user-images.githubusercontent.com/63660334/152211124-32279e6f-0a4c-40af-8b20-b5c5917620f6.mov

![s-2](https://user-images.githubusercontent.com/63660334/152282204-cabc8ba4-563b-4a92-b43c-6568172072b2.gif)

</details>
