### PR TITLE
feat: show stock value difference on Stock Ledger report

### DIFF
--- a/erpnext/stock/report/stock_ledger/stock_ledger.py
+++ b/erpnext/stock/report/stock_ledger/stock_ledger.py
@@ -104,6 +104,7 @@ def get_columns():
 		{"label": _("Incoming Rate"), "fieldname": "incoming_rate", "fieldtype": "Currency", "width": 110, "options": "Company:company:default_currency", "convertible": "rate"},
 		{"label": _("Valuation Rate"), "fieldname": "valuation_rate", "fieldtype": "Currency", "width": 110, "options": "Company:company:default_currency", "convertible": "rate"},
 		{"label": _("Balance Value"), "fieldname": "stock_value", "fieldtype": "Currency", "width": 110, "options": "Company:company:default_currency"},
+		{"label": _("Value Change"), "fieldname": "stock_value_difference", "fieldtype": "Currency", "width": 110, "options": "Company:company:default_currency"},
 		{"label": _("Voucher Type"), "fieldname": "voucher_type", "width": 110},
 		{"label": _("Voucher #"), "fieldname": "voucher_no", "fieldtype": "Dynamic Link", "options": "voucher_type", "width": 100},
 		{"label": _("Batch"), "fieldname": "batch_no", "fieldtype": "Link", "options": "Batch", "width": 100},


### PR DESCRIPTION
Show stock value difference and sum of stock value difference so it's easy to infer the accounting impact of a particular voucher. 

<img width="1333" alt="Screenshot 2022-02-03 at 10 52 35 AM" src="https://user-images.githubusercontent.com/9079960/152286085-3287d570-076f-4f3a-ad51-c808b9d78275.png">


TODO:
~~don't show totals for all the rows. (requires FW change)~~ deferred, not a small change as it seemed first - https://github.com/frappe/frappe/issues/15866 


`no-docs`