### PR TITLE
fix: ignore empty customer/supplier in item query

### DIFF
--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -249,6 +249,9 @@ def item_query(doctype, txt, searchfield, start, page_len, filters, as_dict=Fals
 				del filters['customer']
 			else:
 				del filters['supplier']
+		else:
+			filters.pop('customer', None)
+			filters.pop('supplier', None)
 
 
 	description_cond = ''

--- a/erpnext/controllers/tests/test_queries.py
+++ b/erpnext/controllers/tests/test_queries.py
@@ -56,6 +56,12 @@ class TestQueries(unittest.TestCase):
 		bundled_stock_items = query(txt="_test product bundle item 5", filters={"is_stock_item": 1})
 		self.assertEqual(len(bundled_stock_items), 0)
 
+		# empty customer/supplier should be stripped of instead of failure
+		query(txt="", filters={"customer": None})
+		query(txt="", filters={"customer": ""})
+		query(txt="", filters={"supplier": None})
+		query(txt="", filters={"supplier": ""})
+
 	def test_bom_qury(self):
 		query = add_default_params(queries.bom, "BOM")
 


### PR DESCRIPTION
Steps to reproduce:
- Open purchase invoice
- don't select a supplier, go straight to the items table and add items, you'll get some SQL error. 

fix: ignore `None` and `""` values for customer/supplier


Affected functionality: anywhere item is a link field and customer/supplier fields exist on same document.