### PR TITLE
fix: Incorrect tax template in Sales Invoice via data import

### DIFF
--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -74,7 +74,8 @@ class SellingController(StockController):
 				doctype=self.doctype, company=self.company,
 				posting_date=self.get('posting_date'),
 				fetch_payment_terms_template=fetch_payment_terms_template,
-				party_address=self.customer_address, shipping_address=self.shipping_address_name)
+				party_address=self.customer_address, shipping_address=self.shipping_address_name,
+				company_address=self.get('company_address'))
 			if not self.meta.get_field("sales_team"):
 				party_details.pop("sales_team")
 			self.update_if_missing(party_details)


### PR DESCRIPTION
Correct GST template based on party details was not getting fetched when Importing Sales Invoice via data import tool
This PR fixes that issue