### PR TITLE
fix: Ignore linked invoices on Journal Entry cancel

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.js
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.js
@@ -8,6 +8,7 @@ frappe.provide("erpnext.journal_entry");
 frappe.ui.form.on("Journal Entry", {
 	setup: function(frm) {
 		frm.add_fetch("bank_account", "account", "account");
+		frm.ignore_doctypes_on_cancel_all = ['Sales Invoice', 'Purchase Invoice'];
 	},
 
 	refresh: function(frm) {


### PR DESCRIPTION
The user used to get below warning on canceling a Journal Entry that has been allocated to invoice as an Advance payment and the Sales Invoice also used to get canceled on canceling the Journal Entry

![image](https://user-images.githubusercontent.com/42651287/152682984-5ae02861-0d8d-4cc5-8e73-32db5a375c11.png)

Only journal entry should be canceled and the invoice should be just delinked and not canceled.

Steps to test:

1. Create an advance Journal Entry against a customer
2. Create Sales Invoice against the same customer and allocate advance payment entry.
3. Cancel the payment entry and check, Sales Invoice should not get canceled 
