### PR TITLE
fix: earned leaves not allocated if assignment is created on month-end based on Leave Period

### DIFF
--- a/erpnext/hr/doctype/leave_application/test_leave_application.py
+++ b/erpnext/hr/doctype/leave_application/test_leave_application.py
@@ -546,7 +546,7 @@ class TestLeaveApplication(unittest.TestCase):
 		from erpnext.hr.utils import allocate_earned_leaves
 		i = 0
 		while(i<14):
-			allocate_earned_leaves()
+			allocate_earned_leaves(ignore_duplicates=True)
 			i += 1
 		self.assertEqual(get_leave_balance_on(employee.name, leave_type, nowdate()), 6)
 
@@ -554,7 +554,7 @@ class TestLeaveApplication(unittest.TestCase):
 		frappe.db.set_value('Leave Type', leave_type, 'max_leaves_allowed', 0)
 		i = 0
 		while(i<6):
-			allocate_earned_leaves()
+			allocate_earned_leaves(ignore_duplicates=True)
 			i += 1
 		self.assertEqual(get_leave_balance_on(employee.name, leave_type, nowdate()), 9)
 

--- a/erpnext/hr/doctype/leave_policy_assignment/test_leave_policy_assignment.py
+++ b/erpnext/hr/doctype/leave_policy_assignment/test_leave_policy_assignment.py
@@ -4,7 +4,7 @@
 import unittest
 
 import frappe
-from frappe.utils import add_months, get_first_day, getdate
+from frappe.utils import add_months, get_first_day, get_last_day, getdate
 
 from erpnext.hr.doctype.leave_application.test_leave_application import (
 	get_employee,
@@ -125,6 +125,69 @@ class TestLeavePolicyAssignment(unittest.TestCase):
 		}, "total_leaves_allocated")
 		self.assertEqual(leaves_allocated, 0)
 
+	def test_earned_leave_allocation_for_passed_months(self):
+		employee = get_employee()
+		leave_type = create_earned_leave_type("Test Earned Leave")
+		leave_period = create_leave_period("Test Earned Leave Period",
+			start_date=get_first_day(add_months(getdate(), -1)))
+		leave_policy = frappe.get_doc({
+			"doctype": "Leave Policy",
+			"title": "Test Leave Policy",
+			"leave_policy_details": [{"leave_type": leave_type.name, "annual_allocation": 12}]
+		}).insert()
+
+		# Case 1: assignment created one month after the leave period, should allocate 1 leave
+		frappe.flags.current_date = get_first_day(getdate())
+		data = {
+			"assignment_based_on": "Leave Period",
+			"leave_policy": leave_policy.name,
+			"leave_period": leave_period.name
+		}
+		leave_policy_assignments = create_assignment_for_multiple_employees([employee.name], frappe._dict(data))
+
+		leaves_allocated = frappe.db.get_value("Leave Allocation", {
+			"leave_policy_assignment": leave_policy_assignments[0]
+		}, "total_leaves_allocated")
+		self.assertEqual(leaves_allocated, 1)
+
+	def test_earned_leave_allocation_for_passed_months_on_month_end(self):
+		employee = get_employee()
+		leave_type = create_earned_leave_type("Test Earned Leave")
+		leave_period = create_leave_period("Test Earned Leave Period",
+			start_date=get_first_day(add_months(getdate(), -2)))
+		leave_policy = frappe.get_doc({
+			"doctype": "Leave Policy",
+			"title": "Test Leave Policy",
+			"leave_policy_details": [{"leave_type": leave_type.name, "annual_allocation": 12}]
+		}).insert()
+
+		# Case 2: assignment created on the last day of the leave period's latter month
+		# should allocate 1 leave for current month even though the month has not ended
+		# since the daily job might have already executed
+		frappe.flags.current_date = get_last_day(getdate())
+
+		data = {
+			"assignment_based_on": "Leave Period",
+			"leave_policy": leave_policy.name,
+			"leave_period": leave_period.name
+		}
+		leave_policy_assignments = create_assignment_for_multiple_employees([employee.name], frappe._dict(data))
+
+		leaves_allocated = frappe.db.get_value("Leave Allocation", {
+			"leave_policy_assignment": leave_policy_assignments[0]
+		}, "total_leaves_allocated")
+		self.assertEqual(leaves_allocated, 3)
+
+		# if the daily job is not completed yet, there is another check present
+		# to ensure leave is not already allocated to avoid duplication
+		from erpnext.hr.utils import allocate_earned_leaves
+		allocate_earned_leaves()
+
+		leaves_allocated = frappe.db.get_value("Leave Allocation", {
+			"leave_policy_assignment": leave_policy_assignments[0]
+		}, "total_leaves_allocated")
+		self.assertEqual(leaves_allocated, 3)
+
 	def tearDown(self):
 		frappe.db.rollback()
 
@@ -137,14 +200,14 @@ def create_earned_leave_type(leave_type):
 		doctype="Leave Type",
 		is_earned_leave=1,
 		earned_leave_frequency="Monthly",
-		rounding=0.5,
-		max_leaves_allowed=6
+		rounding=0.5
 	)).insert()
 
 
-def create_leave_period(name):
+def create_leave_period(name, start_date=None):
 	frappe.delete_doc_if_exists("Leave Period", name, force=1)
-	start_date = get_first_day(getdate())
+	if not start_date:
+		start_date = get_first_day(getdate())
 
 	return frappe.get_doc(dict(
 		name=name,

--- a/erpnext/hr/doctype/leave_policy_assignment/test_leave_policy_assignment.py
+++ b/erpnext/hr/doctype/leave_policy_assignment/test_leave_policy_assignment.py
@@ -188,6 +188,58 @@ class TestLeavePolicyAssignment(unittest.TestCase):
 		}, "total_leaves_allocated")
 		self.assertEqual(leaves_allocated, 3)
 
+	def test_earned_leave_allocation_for_passed_months_with_carry_forwarded_leaves(self):
+		from erpnext.hr.doctype.leave_allocation.test_leave_allocation import create_leave_allocation
+
+		employee = get_employee()
+		leave_type = create_earned_leave_type("Test Earned Leave")
+		leave_period = create_leave_period("Test Earned Leave Period",
+			start_date=get_first_day(add_months(getdate(), -2)))
+		leave_policy = frappe.get_doc({
+			"doctype": "Leave Policy",
+			"title": "Test Leave Policy",
+			"leave_policy_details": [{"leave_type": leave_type.name, "annual_allocation": 12}]
+		}).insert()
+
+		# initial leave allocation = 5
+		leave_allocation = create_leave_allocation(
+			employee=employee.name,
+			employee_name=employee.employee_name,
+			leave_type=leave_type.name,
+			from_date=add_months(getdate(), -12),
+			to_date=add_months(getdate(), -3),
+			new_leaves_allocated=5,
+			carry_forward=0)
+		leave_allocation.submit()
+
+		# Case 3: assignment created on the last day of the leave period's latter month with carry forwarding
+		frappe.flags.current_date = get_last_day(add_months(getdate(), -1))
+
+		data = {
+			"assignment_based_on": "Leave Period",
+			"leave_policy": leave_policy.name,
+			"leave_period": leave_period.name,
+			"carry_forward": 1
+		}
+		# carry forwarded leaves = 5, 3 leaves allocated for passed months
+		leave_policy_assignments = create_assignment_for_multiple_employees([employee.name], frappe._dict(data))
+
+		details = frappe.db.get_value("Leave Allocation", {
+			"leave_policy_assignment": leave_policy_assignments[0]
+		}, ["total_leaves_allocated", "new_leaves_allocated", "unused_leaves", "name"], as_dict=True)
+		self.assertEqual(details.new_leaves_allocated, 2)
+		self.assertEqual(details.unused_leaves, 5)
+		self.assertEqual(details.total_leaves_allocated, 7)
+
+		# if the daily job is not completed yet, there is another check present
+		# to ensure leave is not already allocated to avoid duplication
+		from erpnext.hr.utils import is_earned_leave_already_allocated
+		frappe.flags.current_date = get_last_day(getdate())
+
+		allocation = frappe.get_doc('Leave Allocation', details.name)
+		# 1 leave is still pending to be allocated, irrespective of carry forwarded leaves
+		self.assertFalse(is_earned_leave_already_allocated(allocation, leave_policy.leave_policy_details[0].annual_allocation))
+
 	def tearDown(self):
 		frappe.db.rollback()
 
@@ -200,7 +252,8 @@ def create_earned_leave_type(leave_type):
 		doctype="Leave Type",
 		is_earned_leave=1,
 		earned_leave_frequency="Monthly",
-		rounding=0.5
+		rounding=0.5,
+		is_carry_forward=1
 	)).insert()
 
 

--- a/erpnext/hr/utils.py
+++ b/erpnext/hr/utils.py
@@ -237,7 +237,7 @@ def generate_leave_encashment():
 
 		create_leave_encashment(leave_allocation=leave_allocation)
 
-def allocate_earned_leaves():
+def allocate_earned_leaves(ignore_duplicates=False):
 	'''Allocate earned leaves to Employees'''
 	e_leave_types = get_earned_leaves()
 	today = getdate()
@@ -265,9 +265,9 @@ def allocate_earned_leaves():
 				from_date  = frappe.db.get_value("Employee", allocation.employee, "date_of_joining")
 
 			if check_effective_date(from_date, today, e_leave_type.earned_leave_frequency, e_leave_type.based_on_date_of_joining_date):
-				update_previous_leave_allocation(allocation, annual_allocation, e_leave_type)
+				update_previous_leave_allocation(allocation, annual_allocation, e_leave_type, ignore_duplicates)
 
-def update_previous_leave_allocation(allocation, annual_allocation, e_leave_type):
+def update_previous_leave_allocation(allocation, annual_allocation, e_leave_type, ignore_duplicates=False):
 		earned_leaves = get_monthly_earned_leave(annual_allocation, e_leave_type.earned_leave_frequency, e_leave_type.rounding)
 
 		allocation = frappe.get_doc('Leave Allocation', allocation.name)
@@ -279,7 +279,7 @@ def update_previous_leave_allocation(allocation, annual_allocation, e_leave_type
 		if new_allocation != allocation.total_leaves_allocated:
 			today_date = today()
 
-			if not is_earned_leave_already_allocated(allocation, annual_allocation):
+			if ignore_duplicates or not is_earned_leave_already_allocated(allocation, annual_allocation):
 				allocation.db_set("total_leaves_allocated", new_allocation, update_modified=False)
 				create_additional_leave_ledger_entry(allocation, earned_leaves, today_date)
 

--- a/erpnext/hr/utils.py
+++ b/erpnext/hr/utils.py
@@ -312,7 +312,12 @@ def is_earned_leave_already_allocated(allocation, annual_allocation):
 	leaves_for_passed_months = assignment.get_leaves_for_passed_months(allocation.leave_type,
 		annual_allocation, leave_type_details, date_of_joining)
 
-	if allocation.total_leaves_allocated >= leaves_for_passed_months:
+	# exclude carry-forwarded leaves while checking for leave allocation for passed months
+	num_allocations = allocation.total_leaves_allocated
+	if allocation.unused_leaves:
+		num_allocations -= allocation.unused_leaves
+
+	if num_allocations >= leaves_for_passed_months:
 		return True
 	return False
 

--- a/erpnext/hr/utils.py
+++ b/erpnext/hr/utils.py
@@ -301,7 +301,9 @@ def get_monthly_earned_leave(annual_leaves, frequency, rounding):
 
 
 def is_earned_leave_already_allocated(allocation, annual_allocation):
-	from erpnext.hr.doctype.leave_policy_assignment.leave_policy_assignment import get_leave_type_details
+	from erpnext.hr.doctype.leave_policy_assignment.leave_policy_assignment import (
+		get_leave_type_details,
+	)
 
 	leave_type_details = get_leave_type_details()
 	date_of_joining = frappe.db.get_value("Employee", allocation.employee, "date_of_joining")


### PR DESCRIPTION
## Background

1. On the creation of a **Leave Policy Assignment** for **Earned Leaves**, allocation of leaves happens in 2 stages:
    - If this assignment is done in the latter months of the leave period, it allocates leaves for past months. 
    - then, a daily background job runs for allocating "earned" leaves at the end of every month (in case of monthly frequency)
2. For eg: the leave period starts from Jan 2022 and you create an assignment in Feb 2022 then it will allocate leave for Jan and then allocate leaves for Feb onwards during month-end as per your frequency set in the leave type

## Problem
1. If you create an assignment on month-end, say 31st Jan 2022, and the policy period starts from 1st Jan 2022, then 1 leave should be allocated since it is the last day of the month.
2. But this does not happen because as per the current logic, the month has not "passed".
3. Also, the daily background job would run at 12:00 am on 31st Jan 2022, but if you create an assignment after it, then the job is already over and it will next run on 1st Feb 2022, but this is not the last day of the month, so leave is never allocated for Jan.

<details> 

<summary> Steps to Replicate </summary>

- Leave Type configuration

  ![image](https://user-images.githubusercontent.com/24353136/152639256-0faedd01-6744-4490-8644-e24f7760de0e.png)

- Leave Policy:
   
  ![image](https://user-images.githubusercontent.com/24353136/152639051-e95bce31-9e35-4a6f-b808-38274b72958c.png)

- Leave Policy Assignment created for Jan 2022-Dec 2022 on 31st Jan 2022
  
  ![image](https://user-images.githubusercontent.com/24353136/152639154-b4f961f2-ea69-4e35-91ec-604572548edb.png)

- 0 _Total Leaves Allocated_ in Leave Allocation although Jan has passed (it is 31st)
   
   ![image](https://user-images.githubusercontent.com/24353136/152639187-e0ceb4d9-45a3-44e8-9837-df41e532cf6b.png)

</details>

## Fix

1. If the assignment is created on the last day of the month within the leave period, consider it in "past months" because the employee should already "earn" this leave.
2. Add a check in the background job allocation to determine if the leave is not already allocated, to avoid duplication.
3. Add tests for both cases.

1 Leave allocated for Jan on policy assignment creation. Check _Total Leaves Allocated_

![image](https://user-images.githubusercontent.com/24353136/152639219-35c8d0d6-0e33-4737-8f61-6d3c52b28615.png)

- [x] Handle carry-forwarded leaves while checking if leaves are already allocated