### PR TITLE
fix: consider packed items too when reposting

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -3,6 +3,7 @@
 
 import json
 from collections import defaultdict
+from typing import List, Tuple
 
 import frappe
 from frappe import _
@@ -181,33 +182,28 @@ class StockController(AccountsController):
 
 			return details
 
-	def get_items_and_warehouses(self):
-		items, warehouses = [], []
+	def get_items_and_warehouses(self) -> Tuple[List[str], List[str]]:
+		"""Get list of items and warehouses affected by a transaction"""
 
-		if hasattr(self, "items") or hasattr(self, "packed_items"):
-			item_doclist = (self.get("items") or []) + (self.get("packed_items") or [])
-		elif self.doctype == "Stock Reconciliation":
-			item_doclist = []
-			data = json.loads(self.reconciliation_json)
-			for row in data[data.index(self.head_row)+1:]:
-				d = frappe._dict(zip(["item_code", "warehouse", "qty", "valuation_rate"], row))
-				item_doclist.append(d)
+		if not (hasattr(self, "items") or hasattr(self, "packed_items")):
+			return [], []
 
-		if item_doclist:
-			for d in item_doclist:
-				if d.item_code and d.item_code not in items:
-					items.append(d.item_code)
+		item_rows = (self.get("items") or []) + (self.get("packed_items") or [])
 
-				if d.get("warehouse") and d.warehouse not in warehouses:
-					warehouses.append(d.warehouse)
+		items = {d.item_code for d in item_rows if d.item_code}
 
-				if self.doctype == "Stock Entry":
-					if d.get("s_warehouse") and d.s_warehouse not in warehouses:
-						warehouses.append(d.s_warehouse)
-					if d.get("t_warehouse") and d.t_warehouse not in warehouses:
-						warehouses.append(d.t_warehouse)
+		warehouses = set()
+		for d in item_rows:
+			if d.get("warehouse"):
+				warehouses.add(d.warehouse)
 
-		return items, warehouses
+			if self.doctype == "Stock Entry":
+				if d.get("s_warehouse"):
+					warehouses.add(d.s_warehouse)
+				if d.get("t_warehouse"):
+					warehouses.add(d.t_warehouse)
+
+		return list(items), list(warehouses)
 
 	def get_stock_ledger_details(self):
 		stock_ledger = {}

--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -184,8 +184,8 @@ class StockController(AccountsController):
 	def get_items_and_warehouses(self):
 		items, warehouses = [], []
 
-		if hasattr(self, "items"):
-			item_doclist = self.get("items")
+		if hasattr(self, "items") or hasattr(self, "packed_items"):
+			item_doclist = (self.get("items") or []) + (self.get("packed_items") or [])
 		elif self.doctype == "Stock Reconciliation":
 			item_doclist = []
 			data = json.loads(self.reconciliation_json)

--- a/erpnext/stock/doctype/packed_item/test_packed_item.py
+++ b/erpnext/stock/doctype/packed_item/test_packed_item.py
@@ -5,6 +5,7 @@ from erpnext.selling.doctype.product_bundle.test_product_bundle import make_prod
 from erpnext.selling.doctype.sales_order.sales_order import make_delivery_note
 from erpnext.selling.doctype.sales_order.test_sales_order import make_sales_order
 from erpnext.stock.doctype.item.test_item import make_item
+from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
 from erpnext.tests.utils import ERPNextTestCase, change_settings
 
 
@@ -12,31 +13,29 @@ class TestPackedItem(ERPNextTestCase):
 	"Test impact on Packed Items table in various scenarios."
 	@classmethod
 	def setUpClass(cls) -> None:
-		make_item("_Test Product Bundle X", {"is_stock_item": 0})
-		make_item("_Test Bundle Item 1", {"is_stock_item": 1})
-		make_item("_Test Bundle Item 2", {"is_stock_item": 1})
+		cls.bundle = "_Test Product Bundle X"
+		cls.bundle_items = ["_Test Bundle Item 1", "_Test Bundle Item 2"]
+		make_item(cls.bundle, {"is_stock_item": 0})
+		for item in cls.bundle_items:
+			make_item(item, {"is_stock_item": 1})
+
 		make_item("_Test Normal Stock Item", {"is_stock_item": 1})
 
-		make_product_bundle(
-			"_Test Product Bundle X",
-			["_Test Bundle Item 1", "_Test Bundle Item 2"],
-			qty=2
-		)
+		make_product_bundle(cls.bundle, cls.bundle_items, qty=2)
 
 	def test_adding_bundle_item(self):
 		"Test impact on packed items if bundle item row is added."
-		so = make_sales_order(item_code = "_Test Product Bundle X", qty=1,
+		so = make_sales_order(item_code = self.bundle, qty=1,
 			do_not_submit=True)
 
 		self.assertEqual(so.items[0].qty, 1)
 		self.assertEqual(len(so.packed_items), 2)
-		self.assertEqual(so.packed_items[0].item_code, "_Test Bundle Item 1")
+		self.assertEqual(so.packed_items[0].item_code, self.bundle_items[0])
 		self.assertEqual(so.packed_items[0].qty, 2)
 
 	def test_updating_bundle_item(self):
 		"Test impact on packed items if bundle item row is updated."
-		so = make_sales_order(item_code = "_Test Product Bundle X", qty=1,
-			do_not_submit=True)
+		so = make_sales_order(item_code=self.bundle, qty=1, do_not_submit=True)
 
 		so.items[0].qty = 2 # change qty
 		so.save()
@@ -55,7 +54,7 @@ class TestPackedItem(ERPNextTestCase):
 		so_items = []
 		for qty in [2, 4, 6, 8]:
 			so_items.append({
-				"item_code": "_Test Product Bundle X",
+				"item_code": self.bundle,
 				"qty": qty,
 				"rate": 400,
 				"warehouse": "_Test Warehouse - _TC"
@@ -66,7 +65,7 @@ class TestPackedItem(ERPNextTestCase):
 
 		# check alternate rows for qty
 		self.assertEqual(len(so.packed_items), 8)
-		self.assertEqual(so.packed_items[1].item_code, "_Test Bundle Item 2")
+		self.assertEqual(so.packed_items[1].item_code, self.bundle_items[1])
 		self.assertEqual(so.packed_items[1].qty, 4)
 		self.assertEqual(so.packed_items[3].qty, 8)
 		self.assertEqual(so.packed_items[5].qty, 12)
@@ -94,8 +93,7 @@ class TestPackedItem(ERPNextTestCase):
 	@change_settings("Selling Settings", {"editable_bundle_item_rates": 1})
 	def test_bundle_item_cumulative_price(self):
 		"Test if Bundle Item rate is cumulative from packed items."
-		so = make_sales_order(item_code = "_Test Product Bundle X", qty=2,
-			do_not_submit=True)
+		so = make_sales_order(item_code=self.bundle, qty=2, do_not_submit=True)
 
 		so.packed_items[0].rate = 150
 		so.packed_items[1].rate = 200
@@ -109,7 +107,7 @@ class TestPackedItem(ERPNextTestCase):
 		so_items = []
 		for qty in [2, 4]:
 			so_items.append({
-				"item_code": "_Test Product Bundle X",
+				"item_code": self.bundle,
 				"qty": qty,
 				"rate": 400,
 				"warehouse": "_Test Warehouse - _TC"

--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
@@ -13,7 +13,7 @@ from erpnext.accounts.utils import (
 	check_if_stock_and_account_balance_synced,
 	update_gl_entries_after,
 )
-from erpnext.stock.stock_ledger import repost_future_sle
+from erpnext.stock.stock_ledger import get_items_to_be_repost, repost_future_sle
 
 
 class RepostItemValuation(Document):
@@ -138,13 +138,20 @@ def repost_gl_entries(doc):
 
 	if doc.based_on == 'Transaction':
 		ref_doc = frappe.get_doc(doc.voucher_type, doc.voucher_no)
-		items, warehouses = ref_doc.get_items_and_warehouses()
+		doc_items, doc_warehouses = ref_doc.get_items_and_warehouses()
+
+		sles = get_items_to_be_repost(doc.voucher_type, doc.voucher_no)
+		sle_items = [sle.item_code for sle in sles]
+		sle_warehouse = [sle.warehouse for sle in sles]
+
+		items = list(set(doc_items).union(set(sle_items)))
+		warehouses = list(set(doc_warehouses).union(set(sle_warehouse)))
 	else:
 		items = [doc.item_code]
 		warehouses = [doc.warehouse]
 
 	update_gl_entries_after(doc.posting_date, doc.posting_time,
-		warehouses, items, company=doc.company)
+		for_warehouses=warehouses, for_items=items, company=doc.company)
 
 def notify_error_to_stock_managers(doc, traceback):
 	recipients = get_users_with_role("Stock Manager")

--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.json
@@ -18,7 +18,6 @@
   "items",
   "section_break_9",
   "expense_account",
-  "reconciliation_json",
   "column_break_13",
   "difference_amount",
   "amended_from",
@@ -112,15 +111,6 @@
    "options": "Cost Center"
   },
   {
-   "fieldname": "reconciliation_json",
-   "fieldtype": "Long Text",
-   "hidden": 1,
-   "label": "Reconciliation JSON",
-   "no_copy": 1,
-   "print_hide": 1,
-   "read_only": 1
-  },
-  {
    "fieldname": "column_break_13",
    "fieldtype": "Column Break"
   },
@@ -155,7 +145,7 @@
  "idx": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2021-11-30 01:33:51.437194",
+ "modified": "2022-02-06 14:28:19.043905",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Reconciliation",
@@ -178,5 +168,6 @@
  "search_fields": "posting_date",
  "show_name_in_global_search": 1,
  "sort_field": "modified",
- "sort_order": "DESC"
+ "sort_order": "DESC",
+ "states": []
 }

--- a/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
@@ -25,8 +25,8 @@ from erpnext.tests.utils import ERPNextTestCase, change_settings
 class TestStockReconciliation(ERPNextTestCase):
 	@classmethod
 	def setUpClass(cls):
-		super().setUpClass()
 		create_batch_or_serial_no_items()
+		super().setUpClass()
 		frappe.db.set_value("Stock Settings", None, "allow_negative_stock", 1)
 
 	def tearDown(self):


### PR DESCRIPTION
Changes:
- [x] test
- [x] merge sle item-wh lists while reposting to avoid similar issues in future. i.e. whatever gets reposted in stock **has** to be considered in GLE reposting. (possibly affected: RM supplied in PR)
- [x] remove dead field called "reconciliation_json" and related code from stock reconciliation.

To test:
1. create a bundle. Use FIFO.
2. create stock at some X rate. 
3. sell the bundle. Check GL entries for inventory.
4. create more stock with backdated entry and after reposting is finished verify that sold bundle's GLE reflects changed value for inventory.