### PR TITLE
revert: BU Schlüssel (a21f76f)

### DIFF
--- a/erpnext/regional/report/datev/datev.py
+++ b/erpnext/regional/report/datev/datev.py
@@ -343,8 +343,7 @@ def run_query(filters, extra_fields, extra_joins, extra_filters, as_dict=1):
 			/* against number or, if empty, party against number */
 			%(temporary_against_account_number)s as 'Gegenkonto (ohne BU-Schlüssel)',
 
-			/* disable automatic VAT deduction */
-			'40' as 'BU-Schlüssel',
+			'' as 'BU-Schlüssel',
 
 			gl.posting_date as 'Belegdatum',
 			gl.voucher_no as 'Belegfeld 1',


### PR DESCRIPTION
Turns out this produces more problems than it solves:

- Added "40" to every row to disable automatic VAT deduction
- Problem: the target software complains if there's not VAT to disable

We just need to configure the right accounts (without automatic tax) to solve this problem properly.