### PR TITLE
fix: dont show cancelled PO items in plan report

### DIFF
--- a/erpnext/manufacturing/report/production_planning_report/production_planning_report.py
+++ b/erpnext/manufacturing/report/production_planning_report/production_planning_report.py
@@ -172,10 +172,15 @@ class ProductionPlanReport(object):
 
 		self.purchase_details = {}
 
-		for d in frappe.get_all("Purchase Order Item",
+		purchased_items = frappe.get_all("Purchase Order Item",
 			fields=["item_code", "min(schedule_date) as arrival_date", "qty as arrival_qty", "warehouse"],
-			filters = {"item_code": ("in", self.item_codes), "warehouse": ("in", self.warehouses)},
-			group_by = "item_code, warehouse"):
+			filters={
+				"item_code": ("in", self.item_codes),
+				"warehouse": ("in", self.warehouses),
+				"docstatus": 1,
+			},
+			group_by = "item_code, warehouse")
+		for d in purchased_items:
 			key = (d.item_code, d.warehouse)
 			if key not in self.purchase_details:
 				self.purchase_details.setdefault(key, d)


### PR DESCRIPTION
In "Production Plannning report" we show the expected arrival date. This is computed from purchase orders, however, canceled purchase orders are still showing this DOA. 

<img width="1147" alt="Screenshot 2022-02-06 at 7 03 17 PM" src="https://user-images.githubusercontent.com/9079960/152683440-b46e1410-ac3c-426b-9138-4a027ad42ea8.png">


fix: add filter for docstatus