### PR TITLE
fix: ignore cancelled SLEs

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -219,7 +219,7 @@ class StockController(AccountsController):
 			from
 				`tabStock Ledger Entry`
 			where
-				voucher_type=%s and voucher_no=%s
+				voucher_type=%s and voucher_no=%s and is_cancelled = 0
 		""", (self.doctype, self.name), as_dict=True)
 
 		for sle in stock_ledger_entries:


### PR DESCRIPTION
TODO:
- [x] check impact on LCV (which deliberately cancels and resubmits entries) (unaffected cause PR/PI have different GL entry computation function)
- [x] impact on other transactions using this method. 

PS: This does not affect you if you only create docs using Desk or API. Defensive fix in a way.