### PR TITLE
fix: currency in bank reconciliation chart

### DIFF
--- a/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.js
+++ b/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.js
@@ -14,6 +14,10 @@ frappe.ui.form.on("Bank Reconciliation Tool", {
 		});
 	},
 
+	onload: function (frm) {
+		frm.trigger('bank_account');
+	},
+
 	refresh: function (frm) {
 		frappe.require("bank-reconciliation-tool.bundle.js", () =>
 			frm.trigger("make_reconciliation_tool")
@@ -51,7 +55,7 @@ frappe.ui.form.on("Bank Reconciliation Tool", {
 	bank_account: function (frm) {
 		frappe.db.get_value(
 			"Bank Account",
-			frm.bank_account,
+			frm.doc.bank_account,
 			"account",
 			(r) => {
 				frappe.db.get_value(


### PR DESCRIPTION
Issue: Changing the Bank Account in Bank Reconciliation Tool and then saving doesn't update the currency in the Account Balance Chart. 

For eg. If an Indian Company has a Bank Account that is linked with an Account that has Account Currency set as USD, then in this account is selected in the Bank Reconciliation Tool then the currency is still INR

