### PR TITLE
fix: Loan repayment via Salary Slip

### DIFF
--- a/erpnext/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/erpnext/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -346,7 +346,7 @@ class LoanRepayment(AccountsController):
 			gle_map.append(
 				self.get_gl_dict({
 					"account": loan_details.penalty_income_account,
-					"against": payment_account,
+					"against": loan_details.loan_account,
 					"credit": self.total_penalty_paid,
 					"credit_in_account_currency": self.total_penalty_paid,
 					"against_voucher_type": "Loan",
@@ -368,7 +368,9 @@ class LoanRepayment(AccountsController):
 				"against_voucher": self.against_loan,
 				"remarks": remarks,
 				"cost_center": self.cost_center,
-				"posting_date": getdate(self.posting_date)
+				"posting_date": getdate(self.posting_date),
+				"party_type": loan_details.applicant_type if self.repay_from_salary else '',
+				"party": loan_details.applicant if self.repay_from_salary else ''
 			})
 		)
 

--- a/erpnext/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/erpnext/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -125,7 +125,7 @@ class TestPayrollEntry(unittest.TestCase):
 
 		if not frappe.db.exists("Account", "_Test Payroll Payable - _TC"):
 				create_account(account_name="_Test Payroll Payable",
-					company="_Test Company", parent_account="Current Liabilities - _TC")
+					company="_Test Company", parent_account="Current Liabilities - _TC", account_type=None)
 
 		if not frappe.db.get_value("Company", "_Test Company", "default_payroll_payable_account") or \
 			frappe.db.get_value("Company", "_Test Company", "default_payroll_payable_account") != "_Test Payroll Payable - _TC":

--- a/erpnext/payroll/doctype/payroll_entry/test_payroll_entry.py
+++ b/erpnext/payroll/doctype/payroll_entry/test_payroll_entry.py
@@ -125,7 +125,7 @@ class TestPayrollEntry(unittest.TestCase):
 
 		if not frappe.db.exists("Account", "_Test Payroll Payable - _TC"):
 				create_account(account_name="_Test Payroll Payable",
-					company="_Test Company", parent_account="Current Liabilities - _TC", account_type=None)
+					company="_Test Company", parent_account="Current Liabilities - _TC", account_type="Payable")
 
 		if not frappe.db.get_value("Company", "_Test Company", "default_payroll_payable_account") or \
 			frappe.db.get_value("Company", "_Test Company", "default_payroll_payable_account") != "_Test Payroll Payable - _TC":

--- a/erpnext/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/erpnext/payroll/doctype/salary_slip/test_salary_slip.py
@@ -730,7 +730,7 @@ def get_salary_component_account(sal_comp, company_list=None):
 			})
 			sal_comp.save()
 
-def create_account(account_name, company, parent_account):
+def create_account(account_name, company, parent_account, account_type=None):
 	company_abbr = frappe.get_cached_value('Company',  company,  'abbr')
 	account = frappe.db.get_value("Account", account_name + " - " + company_abbr)
 	if not account:


### PR DESCRIPTION
The user gets the following error message while submitting salary slip with Loan paid via salary if the payroll payable account has account type as "Payable" due to missing party types in GL Entry

![image](https://user-images.githubusercontent.com/42651287/153150703-0ec2dbe5-5dc0-4019-a867-ce67b69b7549.png)

Steps to test:
1. Create a Loan Type
2. Create a loan against an employee and mark it as repay from Salary
3. Create Loan Disbursement
4. Process loan interest using Process Loan Interest Accrual Doctype
5. Make a salary slip against that same employee, make sure the payroll payable account type is updated as "Payable"
6. Try and submit the Salary Slip