### PR TITLE
fix: grant commission in inter company transaction

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -1826,7 +1826,7 @@ def make_inter_company_transaction(doctype, source_name, target_doc=None):
 
 	def update_item_details(source_doc, target_doc, source_parent):
 		target_doc.grant_commission = frappe.get_value("Item", target_doc.item_code, 'grant_commission')
-	
+
 	item_field_map = {
 		"doctype": target_doctype + " Item",
 		"postprocess": update_item_details,
@@ -1867,7 +1867,7 @@ def make_inter_company_transaction(doctype, source_name, target_doc=None):
 		doctype +" Item": item_field_map
 
 	}, target_doc, set_missing_values)
-	
+
 	return doclist
 
 def set_purchase_references(doc):

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -1826,7 +1826,6 @@ def make_inter_company_transaction(doctype, source_name, target_doc=None):
 
 	def update_item_details(source_doc, target_doc, source_parent):
 		target_doc.grant_commission = frappe.get_value("Item", target_doc.item_code, 'grant_commission')
-
 	
 	item_field_map = {
 		"doctype": target_doctype + " Item",


### PR DESCRIPTION
On Inter-Company Transaction Sales Order is not fetching grant commission on the Item child table
In case of Normal Sales Order it is fetching Grant commission from Item

Because of which sales calculation is getting affected