### PR TITLE
fix: allow `regional_overrides` hook to be set in subsequent apps

### DIFF
--- a/erpnext/__init__.py
+++ b/erpnext/__init__.py
@@ -2,8 +2,6 @@ import inspect
 
 import frappe
 
-from erpnext.hooks import regional_overrides
-
 __version__ = '14.0.0-dev'
 
 def get_default_company(user=None):
@@ -121,13 +119,16 @@ def allow_regional(fn):
 	@erpnext.allow_regional
 	def myfunction():
 	  pass'''
+
 	def caller(*args, **kwargs):
-		region = get_region()
-		fn_name = inspect.getmodule(fn).__name__ + '.' + fn.__name__
-		if region in regional_overrides and fn_name in regional_overrides[region]:
-			return frappe.get_attr(regional_overrides[region][fn_name])(*args, **kwargs)
-		else:
+		overrides = frappe.get_hooks("regional_overrides", {}).get(get_region())
+		function_path = f"{inspect.getmodule(fn).__name__}.{fn.__name__}"
+
+		if not overrides or function_path not in overrides:
 			return fn(*args, **kwargs)
+
+		# Priority given to last installed app
+		return frappe.get_attr(overrides[function_path][-1])(*args, **kwargs)
 
 	return caller
 


### PR DESCRIPTION
This change is necessary in preparation for separating the regional module into multiple apps.