### PR TITLE
fix(e-commerce): Unique Shopping Cart Per Logged In User

### DIFF
--- a/erpnext/e_commerce/product_data_engine/query.py
+++ b/erpnext/e_commerce/product_data_engine/query.py
@@ -264,7 +264,7 @@ class ProductQuery:
 		customer = get_customer(silent=True)
 		if customer:
 			quotation = frappe.get_all("Quotation", fields=["name"], filters=
-				{"party_name": customer, "order_type": "Shopping Cart", "docstatus": 0},
+				{"party_name": customer, "contact_email": frappe.session.user, "order_type": "Shopping Cart", "docstatus": 0},
 				order_by="modified desc", limit_page_length=1)
 			if quotation:
 				items = frappe.get_all(

--- a/erpnext/e_commerce/shopping_cart/cart.py
+++ b/erpnext/e_commerce/shopping_cart/cart.py
@@ -310,7 +310,7 @@ def _get_cart_quotation(party=None):
 		party = get_party()
 
 	quotation = frappe.get_all("Quotation", fields=["name"], filters=
-		{"party_name": party.name, "order_type": "Shopping Cart", "docstatus": 0},
+		{"party_name": party.name, "contact_email": frappe.session.user, "order_type": "Shopping Cart", "docstatus": 0},
 		order_by="modified desc", limit_page_length=1)
 
 	if quotation:

--- a/erpnext/e_commerce/shopping_cart/test_shopping_cart.py
+++ b/erpnext/e_commerce/shopping_cart/test_shopping_cart.py
@@ -57,13 +57,19 @@ class TestShoppingCart(unittest.TestCase):
 		return quotation
 
 	def test_get_cart_customer(self):
-		self.login_as_customer()
+		def validate_quotation():
+			# test if quotation with customer is fetched
+			quotation = _get_cart_quotation()
+			self.assertEqual(quotation.quotation_to, "Customer")
+			self.assertEqual(quotation.party_name, "_Test Customer")
+			self.assertEqual(quotation.contact_email, frappe.session.user)
+			return quotation
 
-		# test if quotation with customer is fetched
-		quotation = _get_cart_quotation()
-		self.assertEqual(quotation.quotation_to, "Customer")
-		self.assertEqual(quotation.party_name, "_Test Customer")
-		self.assertEqual(quotation.contact_email, frappe.session.user)
+		self.login_as_customer("test_contact_two_customer@example.com", "_Test Contact 2 For _Test Customer")
+		validate_quotation()
+
+		self.login_as_customer()
+		quotation = validate_quotation()
 
 		return quotation
 
@@ -254,10 +260,9 @@ class TestShoppingCart(unittest.TestCase):
 		self.create_user_if_not_exists("test_cart_user@example.com")
 		frappe.set_user("test_cart_user@example.com")
 
-	def login_as_customer(self):
-		self.create_user_if_not_exists("test_contact_customer@example.com",
-			"_Test Contact For _Test Customer")
-		frappe.set_user("test_contact_customer@example.com")
+	def login_as_customer(self, email="test_contact_customer@example.com", name="_Test Contact For _Test Customer"):
+		self.create_user_if_not_exists(email, name)
+		frappe.set_user(email)
 
 	def clear_existing_quotations(self):
 		quotations = frappe.get_all("Quotation", filters={

--- a/erpnext/tests/utils.py
+++ b/erpnext/tests/utils.py
@@ -66,6 +66,20 @@ def create_test_contact_and_address():
 	contact.add_phone("+91 0000000000", is_primary_phone=True)
 	contact.insert()
 
+	contact_two = frappe.get_doc({
+		"doctype": 'Contact',
+		"first_name": "_Test Contact 2 for _Test Customer",
+		"links": [
+			{
+				"link_doctype": "Customer",
+				"link_name": "_Test Customer"
+			}
+		]
+	})
+	contact_two.add_email("test_contact_two_customer@example.com", is_primary=True)
+	contact_two.add_phone("+92 0000000000", is_primary_phone=True)
+	contact_two.insert()
+
 
 @contextmanager
 def change_settings(doctype, settings_dict):


### PR DESCRIPTION
**Before PR**
If a customer has multiple contacts with user accounts, they will all share the same shopping cart.

https://user-images.githubusercontent.com/29856401/153255024-8e310d26-1a14-4ff3-ad61-cef238cdfcc8.mp4

**After PR**
1. Modified test case to supporting multiple users associated with a customer.
2. _get_cart_quotation will return the quotation for the logged in user (Instead of the latest quotation for the party).
3. get_cart_items will return only the quotation items for the logged in user (Instead of the items from the latest quotation for the party)

https://user-images.githubusercontent.com/29856401/153256716-315c3cb4-34ab-4754-8e4f-ed8c19fc6fbc.mp4


