### PR TITLE
fix: cannot jump to sales invoice in gross profit report

### DIFF
--- a/erpnext/accounts/report/gross_profit/gross_profit.js
+++ b/erpnext/accounts/report/gross_profit/gross_profit.js
@@ -42,6 +42,11 @@ frappe.query_reports["Gross Profit"] = {
 	"parent_field": "parent_invoice",
 	"initial_depth": 3,
 	"formatter": function(value, row, column, data, default_formatter) {
+		if (column.fieldname == "sales_invoice" && column.options == "Item" && data.indent == 0) {
+			column._options = "Sales Invoice";
+		} else {
+			column._options = "Item";
+		}
 		value = default_formatter(value, row, column, data);
 
 		if (data && (data.indent == 0.0 || row[1].content == "Total")) {


### PR DESCRIPTION
Fix: When Grouped By - Invoice in Gross Profit Report, on clicking the Sales Invoice Link in the first column it routes to `app/item/SI-0001`

Expected behavior, clicking on Sales Invoice should route to `app/sales-invoice/SI-0001` and clicking on Item should route to `app/item/ITM-001`

