### PR TITLE
fix: show user id in emp group table

### DIFF
--- a/erpnext/hr/doctype/employee_group_table/employee_group_table.json
+++ b/erpnext/hr/doctype/employee_group_table/employee_group_table.json
@@ -27,12 +27,13 @@
    "fetch_from": "employee.user_id",
    "fieldname": "user_id",
    "fieldtype": "Data",
+   "in_list_view": 1,
    "label": "ERPNext User ID",
    "read_only": 1
   }
  ],
  "istable": 1,
- "modified": "2019-06-06 10:41:20.313756",
+ "modified": "2022-02-13 19:44:21.302938",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Employee Group Table",


### PR DESCRIPTION
User ID is a read only field that is fetched from the Employee document.
Users, while adding new rows, fail to acknowledge if the field is correctly fetched as it isn't visible in the table columns. 

Before:
![image](https://user-images.githubusercontent.com/52111700/153757599-6d0327fc-5275-4acf-90fa-e38acea50af6.png)


After:
![image](https://user-images.githubusercontent.com/52111700/153757546-7a6a28bd-347b-4897-a7e9-fc7af3ed745d.png)
