### PR TITLE
fix: incorrect pricing rule filtering on selecting first item

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -343,6 +343,7 @@ def get_basic_details(args, item, overwrite_warehouse=True):
 
 	args.conversion_factor = out.conversion_factor
 	out.stock_qty = out.qty * out.conversion_factor
+	args.stock_qty = out.stock_qty
 
 	# calculate last purchase rate
 	if args.get('doctype') in purchase_doctypes:


### PR DESCRIPTION
**Steps to replicate:**

- Create a Promotional Scheme for Buy 1 Get 1 Free
  <details>
    <summary>Screenshot</summary>
    ![CleanShot 2022-02-14 at 11 51 45](https://user-images.githubusercontent.com/25369014/153810859-158edb0d-3cd0-4681-904d-f44721857965.png)
  </details>
- Open a new Sales Order, select the Customer and add the Item
- The Free Item doesn't get added

**Why?**

In `get_pricing_rule_for_item` the pricing rules are filtered based on `qty` & `stock_qty`, and `stock_qty` is passed as zero while `qty` is _by default_ passed as `1`

https://github.com/frappe/erpnext/blob/d5e45481cd7f2213f01fea6b8e5dc9ff1f2373b7/erpnext/accounts/doctype/pricing_rule/utils.py#L167-L168