### PR TITLE
fix: disable rounded total in opening invoice creation tool

### DIFF
--- a/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.py
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.py
@@ -167,7 +167,8 @@ class OpeningInvoiceCreationTool(Document):
 			"is_pos": 0,
 			"doctype": "Sales Invoice" if self.invoice_type == "Sales" else "Purchase Invoice",
 			"update_stock": 0,
-			"invoice_number": row.invoice_number
+			"invoice_number": row.invoice_number,
+			"disable_rounded_total": 1
 		})
 
 		accounting_dimension = get_accounting_dimensions()


### PR DESCRIPTION
If you try to create an Invoice with grand total of 1000.01, and the Global Default has unchecked Disabled Rounded Total, then you'll face an error:

![CleanShot 2022-02-14 at 18 32 56](https://user-images.githubusercontent.com/25369014/153870264-917adb78-369d-4170-9ba3-c7075bcb79cd.png)

Solution:
Disable Rounded Total for invoices created from Opening Invoice Creation Tool

