### PR TITLE
fix: add supported currencies for GoCardless

### DIFF
--- a/erpnext/erpnext_integrations/doctype/gocardless_settings/gocardless_settings.py
+++ b/erpnext/erpnext_integrations/doctype/gocardless_settings/gocardless_settings.py
@@ -13,7 +13,7 @@ from frappe.utils import call_hook_method, cint, flt, get_url
 
 
 class GoCardlessSettings(Document):
-	supported_currencies = ["EUR", "DKK", "GBP", "SEK"]
+	supported_currencies = ["EUR", "DKK", "GBP", "SEK", "AUD", "NZD", "CAD", "USD"]
 
 	def validate(self):
 		self.initialize_client()
@@ -80,7 +80,7 @@ class GoCardlessSettings(Document):
 
 	def validate_transaction_currency(self, currency):
 		if currency not in self.supported_currencies:
-			frappe.throw(_("Please select another payment method. Stripe does not support transactions in currency '{0}'").format(currency))
+			frappe.throw(_("Please select another payment method. Go Cardless does not support transactions in currency '{0}'").format(currency))
 
 	def get_payment_url(self, **kwargs):
 		return get_url("./integrations/gocardless_checkout?{0}".format(urlencode(kwargs)))


### PR DESCRIPTION
Fix for: https://github.com/frappe/erpnext/issues/29631

1. Added more supported currencies that include USD, NZD, AUD, CAD
2. Fix error message by replacing Stripe with Go Cardless.

[reference](https://gocardless.com/faq/merchants/international-payments/#:~:text=United%20States-,Which%20currencies%20does%20GoCardless%20support%3F,please%20register%20your%20interest%20here.)