### PR TITLE
fix: dont attempt to set batch number if item doesn't have batch no

### DIFF
--- a/erpnext/selling/sales_common.js
+++ b/erpnext/selling/sales_common.js
@@ -227,11 +227,11 @@ erpnext.selling.SellingController = class SellingController extends erpnext.Tran
 					},
 					callback:function(r){
 						if (in_list(['Delivery Note', 'Sales Invoice'], doc.doctype)) {
-
 							if (doc.doctype === 'Sales Invoice' && (!doc.update_stock)) return;
-
-							me.set_batch_number(cdt, cdn);
-							me.batch_no(doc, cdt, cdn);
+							if (has_batch_no) {
+								me.set_batch_number(cdt, cdn);
+								me.batch_no(doc, cdt, cdn);
+							}
 						}
 					}
 				});


### PR DESCRIPTION
This causes other triggers and unnecessary changes (e.g. price list)

Steps to reproduce:
1. Create item with simple item price
2. Create SO with different price
3. Create DN from SO
4. Change warehouse on DN (price changes via unexpected triggers from batch info)