### PR TITLE
chore: change log for v12.29.0

### DIFF
--- a/erpnext/change_log/v12/v12_29_0.md
+++ b/erpnext/change_log/v12/v12_29_0.md
@@ -1,0 +1,5 @@
+## ERPNext Version 12.29.0 Release Notes
+
+### Fixes & Enhancements
+
+- Display 'Make Depreciation Entry' only for submitted or partially depreciated Assets  ([#29291](https://github.com/frappe/erpnext/pull/29291))


### PR DESCRIPTION
## ERPNext Version 12.29.0 Release Notes

### Fixes & Enhancements

- Display 'Make Depreciation Entry' only for submitted or partially depreciated Assets  ([#29291](https://github.com/frappe/erpnext/pull/29291))