### PR TITLE
fix: made lead status field read-only

### DIFF
--- a/erpnext/crm/doctype/lead/lead.json
+++ b/erpnext/crm/doctype/lead/lead.json
@@ -471,11 +471,12 @@
  "idx": 5,
  "image_field": "image",
  "links": [],
- "modified": "2021-08-04 00:24:57.208590",
+ "modified": "2022-02-16 18:49:09.569678",
  "modified_by": "Administrator",
  "module": "CRM",
  "name": "Lead",
  "name_case": "Title Case",
+ "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
  "permissions": [
   {
@@ -535,6 +536,7 @@
  "show_name_in_global_search": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "subject_field": "title",
  "title_field": "title"
 }

--- a/erpnext/crm/doctype/lead/lead.json
+++ b/erpnext/crm/doctype/lead/lead.json
@@ -140,6 +140,7 @@
    "oldfieldname": "status",
    "oldfieldtype": "Select",
    "options": "Lead\nOpen\nReplied\nOpportunity\nQuotation\nLost Quotation\nInterested\nConverted\nDo Not Contact",
+   "read_only": 1,
    "reqd": 1,
    "search_index": 1
   },
@@ -471,7 +472,7 @@
  "idx": 5,
  "image_field": "image",
  "links": [],
- "modified": "2022-02-16 18:49:09.569678",
+ "modified": "2022-02-16 18:55:21.188181",
  "modified_by": "Administrator",
  "module": "CRM",
  "name": "Lead",


### PR DESCRIPTION
**Issue-** User is not able to change the lead status
![lead-status](https://user-images.githubusercontent.com/20715976/154274857-f2fb4383-9bbe-4982-a191-c6fbb550d3da.gif)



**Fix-** Made Lead status field read-only since status is managed by StatusUpdater.