### PR TITLE
fix(Timesheet): convert time logs to datetime while checking for overlap

### DIFF
--- a/erpnext/projects/doctype/timesheet/test_timesheet.py
+++ b/erpnext/projects/doctype/timesheet/test_timesheet.py
@@ -151,6 +151,35 @@ class TestTimesheet(unittest.TestCase):
 		settings.ignore_employee_time_overlap = initial_setting
 		settings.save()
 
+	def test_timesheet_not_overlapping_with_continuous_timelogs(self):
+		emp = make_employee("test_employee_6@salary.com")
+
+		update_activity_type("_Test Activity Type")
+		timesheet = frappe.new_doc("Timesheet")
+		timesheet.employee = emp
+		timesheet.append(
+			'time_logs',
+			{
+				"billable": 1,
+				"activity_type": "_Test Activity Type",
+				"from_time": now_datetime(),
+				"to_time": now_datetime() + datetime.timedelta(hours=3),
+				"company": "_Test Company"
+			}
+		)
+		timesheet.append(
+			'time_logs',
+			{
+				"billable": 1,
+				"activity_type": "_Test Activity Type",
+				"from_time": now_datetime() + datetime.timedelta(hours=3),
+				"to_time": now_datetime() + datetime.timedelta(hours=4),
+				"company": "_Test Company"
+			}
+		)
+
+		timesheet.save() # should not throw an error
+
 	def test_to_time(self):
 		emp = make_employee("test_employee_6@salary.com")
 		from_time = now_datetime()

--- a/erpnext/projects/doctype/timesheet/timesheet.py
+++ b/erpnext/projects/doctype/timesheet/timesheet.py
@@ -7,7 +7,7 @@ import json
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import add_to_date, flt, getdate, time_diff_in_hours
+from frappe.utils import add_to_date, flt, get_datetime, getdate, time_diff_in_hours
 
 from erpnext.controllers.queries import get_match_cond
 from erpnext.hr.utils import validate_active_employee
@@ -145,7 +145,7 @@ class Timesheet(Document):
 		if not (data.from_time and data.hours):
 			return
 
-		_to_time = add_to_date(data.from_time, hours=data.hours, as_datetime=True)
+		_to_time = get_datetime(add_to_date(data.from_time, hours=data.hours, as_datetime=True))
 		if data.to_time != _to_time:
 			data.to_time = _to_time
 
@@ -186,23 +186,36 @@ class Timesheet(Document):
 			and ts.docstatus < 2""".format(cond),
 			{
 				"val": value,
-				"from_time": args.from_time,
-				"to_time": args.to_time,
+				"from_time": get_datetime(args.from_time),
+				"to_time": get_datetime(args.to_time),
 				"name": args.name or "No Name",
 				"parent": args.parent or "No Name"
 			}, as_dict=True)
-		# check internal overlap
-		for time_log in self.time_logs:
-			if not (time_log.from_time and time_log.to_time
-				and args.from_time and args.to_time): continue
 
-			if (fieldname != 'workstation' or args.get(fieldname) == time_log.get(fieldname)) and \
-				args.idx != time_log.idx and ((args.from_time > time_log.from_time and args.from_time < time_log.to_time) or
-				(args.to_time > time_log.from_time and args.to_time < time_log.to_time) or
-				(args.from_time <= time_log.from_time and args.to_time >= time_log.to_time)):
-				return self
+		if self.check_internal_overlap(fieldname, args):
+			return self
 
 		return existing[0] if existing else None
+
+	def check_internal_overlap(self, fieldname, args):
+		for time_log in self.time_logs:
+			if not (time_log.from_time and time_log.to_time
+				and args.from_time and args.to_time):
+				continue
+
+			from_time = get_datetime(time_log.from_time)
+			to_time = get_datetime(time_log.to_time)
+			args_from_time = get_datetime(args.from_time)
+			args_to_time = get_datetime(args.to_time)
+
+			if (fieldname != 'workstation' or args.get(fieldname) == time_log.get(fieldname)) and \
+				args.idx != time_log.idx and (
+					(args_from_time > from_time and args_from_time < to_time)
+					or (args_to_time > from_time and args_to_time < to_time)
+					or (args_from_time <= from_time and args_to_time >= to_time)
+				):
+				return True
+		return False
 
 	def update_cost(self):
 		for data in self.time_logs:

--- a/erpnext/projects/doctype/timesheet_detail/timesheet_detail.json
+++ b/erpnext/projects/doctype/timesheet_detail/timesheet_detail.json
@@ -14,12 +14,6 @@
   "to_time",
   "hours",
   "completed",
-  "section_break_7",
-  "completed_qty",
-  "workstation",
-  "column_break_12",
-  "operation",
-  "operation_id",
   "project_details",
   "project",
   "project_name",
@@ -82,43 +76,6 @@
    "fieldname": "completed",
    "fieldtype": "Check",
    "label": "Completed"
-  },
-  {
-   "fieldname": "section_break_7",
-   "fieldtype": "Section Break"
-  },
-  {
-   "depends_on": "eval:parent.work_order",
-   "fieldname": "completed_qty",
-   "fieldtype": "Float",
-   "label": "Completed Qty"
-  },
-  {
-   "depends_on": "eval:parent.work_order",
-   "fieldname": "workstation",
-   "fieldtype": "Link",
-   "label": "Workstation",
-   "options": "Workstation",
-   "read_only": 1
-  },
-  {
-   "fieldname": "column_break_12",
-   "fieldtype": "Column Break"
-  },
-  {
-   "depends_on": "eval:parent.work_order",
-   "fieldname": "operation",
-   "fieldtype": "Link",
-   "label": "Operation",
-   "options": "Operation",
-   "read_only": 1
-  },
-  {
-   "depends_on": "eval:parent.work_order",
-   "fieldname": "operation_id",
-   "fieldtype": "Data",
-   "hidden": 1,
-   "label": "Operation Id"
   },
   {
    "fieldname": "project_details",
@@ -267,7 +224,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2021-05-18 12:19:33.205940",
+ "modified": "2022-02-17 16:53:34.878798",
  "modified_by": "Administrator",
  "module": "Projects",
  "name": "Timesheet Detail",
@@ -275,5 +232,6 @@
  "permissions": [],
  "quick_entry": 1,
  "sort_field": "modified",
- "sort_order": "ASC"
+ "sort_order": "ASC",
+ "states": []
 }


### PR DESCRIPTION
## Steps to replicate

1. Create a timesheet with an employee linked.
2. Set From Time for one log as 10:00. Set hours to 1
3. Set From Time for another log as 11:00. Set hours to 1
4. These time logs are actually non-overlapping: 10-11 and 11-12. So overlap validation shouldn't be thrown but it will be thrown.

<img width="1326" alt="overlap" src="https://user-images.githubusercontent.com/24353136/154420105-badffc95-30ee-4773-8d9b-739fb37d7e8f.png">

## Fix

After https://github.com/frappe/erpnext/pull/28589 `to_time` values in time logs are set on the server-side. The `set_to_time` function also converts value set on client-side:

<img width="246" alt="image" src="https://user-images.githubusercontent.com/24353136/154418797-62c191fe-19c7-4a21-aa0e-5c739aebb830.png">

While checking for overlap, the function compares strings. So this happens:

<img width="658" alt="image" src="https://user-images.githubusercontent.com/24353136/154420450-a2898c16-576a-43bc-89ce-32f1f58f2430.png">

Convert values to datetime before comparing for overlap.

## Additional Changes

The following fields from the Timesheet Detail table are not being used anywhere and they are only visible when the parent is Work Order. But Work Order doctype doesn't have any child table for timesheet detail. Hence removing these fields and the code related to it (dead code)

`completed_qty`
`workstation`
`operation`
`operation_id`
