### PR TITLE
fix: avoid creating bins without item-wh

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1955,7 +1955,8 @@ def update_bin_on_delete(row, doctype):
 
 		qty_dict["ordered_qty"] = get_ordered_qty(row.item_code, row.warehouse)
 
-	update_bin_qty(row.item_code, row.warehouse, qty_dict)
+	if row.warehouse:
+		update_bin_qty(row.item_code, row.warehouse, qty_dict)
 
 def validate_and_delete_children(parent, data):
 	deleted_children = []

--- a/erpnext/patches/v12_0/recalculate_requested_qty_in_bin.py
+++ b/erpnext/patches/v12_0/recalculate_requested_qty_in_bin.py
@@ -9,6 +9,8 @@ def execute():
 		FROM `tabBin`""",as_dict=1)
 
 	for entry in bin_details:
+		if not (entry.item_code and entry.warehouse):
+			continue
 		update_bin_qty(entry.get("item_code"), entry.get("warehouse"), {
 			"indented_qty": get_indented_qty(entry.get("item_code"), entry.get("warehouse"))
 		})

--- a/erpnext/patches/v4_2/repost_reserved_qty.py
+++ b/erpnext/patches/v4_2/repost_reserved_qty.py
@@ -29,9 +29,11 @@ def execute():
 	""")
 
 	for item_code, warehouse in repost_for:
-			update_bin_qty(item_code, warehouse, {
-				"reserved_qty": get_reserved_qty(item_code, warehouse)
-			})
+		if not (item_code and warehouse):
+			continue
+		update_bin_qty(item_code, warehouse, {
+			"reserved_qty": get_reserved_qty(item_code, warehouse)
+		})
 
 	frappe.db.sql("""delete from tabBin
 		where exists(

--- a/erpnext/patches/v4_2/update_requested_and_ordered_qty.py
+++ b/erpnext/patches/v4_2/update_requested_and_ordered_qty.py
@@ -14,6 +14,8 @@ def execute():
 		union
 		select item_code, warehouse from `tabStock Ledger Entry`) a"""):
 			try:
+				if not (item_code and warehouse):
+					continue
 				count += 1
 				update_bin_qty(item_code, warehouse, {
 					"indented_qty": get_indented_qty(item_code, warehouse),


### PR DESCRIPTION
https://github.com/frappe/erpnext/pull/29519 added unique and mandatory constraints however some old patches were still attempting to create bins when item/wh isn't available. 