### PR TITLE
fix: GSTIN filter for GSTR-1 report

### DIFF
--- a/erpnext/regional/report/gstr_1/gstr_1.js
+++ b/erpnext/regional/report/gstr_1/gstr_1.js
@@ -17,7 +17,7 @@ frappe.query_reports["GSTR-1"] = {
 			"fieldtype": "Link",
 			"options": "Address",
 			"get_query": function () {
-				var company = frappe.query_report.get_filter_value('company');
+				let company = frappe.query_report.get_filter_value('company');
 				if (company) {
 					return {
 						"query": 'frappe.contacts.doctype.address.address.address_query',
@@ -25,6 +25,11 @@ frappe.query_reports["GSTR-1"] = {
 					};
 				}
 			}
+		},
+		{
+			"fieldname": "company_gstin",
+			"label": __("Company GSTIN"),
+			"fieldtype": "Select"
 		},
 		{
 			"fieldname": "from_date",
@@ -60,10 +65,22 @@ frappe.query_reports["GSTR-1"] = {
 		}
 	],
 	onload: function (report) {
+		let filters = report.get_values();
+
+		frappe.call({
+			method: 'erpnext.regional.report.gstr_1.gstr_1.get_company_gstins',
+			args: {
+				company: filters.company
+			},
+			callback: function(r) {
+				console.log(r.message);
+				frappe.query_report.page.fields_dict.company_gstin.df.options = r.message;
+				frappe.query_report.page.fields_dict.company_gstin.refresh();
+			}
+		});
+
 
 		report.page.add_inner_button(__("Download as JSON"), function () {
-			var filters = report.get_values();
-
 			frappe.call({
 				method: 'erpnext.regional.report.gstr_1.gstr_1.get_json',
 				args: {

--- a/erpnext/regional/report/gstr_1/gstr_1.js
+++ b/erpnext/regional/report/gstr_1/gstr_1.js
@@ -73,7 +73,6 @@ frappe.query_reports["GSTR-1"] = {
 				company: filters.company
 			},
 			callback: function(r) {
-				console.log(r.message);
 				frappe.query_report.page.fields_dict.company_gstin.df.options = r.message;
 				frappe.query_report.page.fields_dict.company_gstin.refresh();
 			}

--- a/erpnext/regional/report/gstr_1/gstr_1.py
+++ b/erpnext/regional/report/gstr_1/gstr_1.py
@@ -253,7 +253,8 @@ class Gstr1Report(object):
 		for opts in (("company", " and company=%(company)s"),
 			("from_date", " and posting_date>=%(from_date)s"),
 			("to_date", " and posting_date<=%(to_date)s"),
-			("company_address", " and company_address=%(company_address)s")):
+			("company_address", " and company_address=%(company_address)s"),
+			("company_gstin", " and company_gstin=%(company_gstin)s")):
 				if self.filters.get(opts[0]):
 					conditions += opts[1]
 
@@ -1192,3 +1193,23 @@ def is_inter_state(invoice_detail):
 		return True
 	else:
 		return False
+
+
+@frappe.whitelist()
+def get_company_gstins(company):
+	address = frappe.qb.DocType("Address")
+	links = frappe.qb.DocType("Dynamic Link")
+
+	addresses = frappe.qb.from_(address).inner_join(links).on(
+		address.name == links.parent
+	).select(
+		address.gstin
+	).where(
+		links.link_doctype == 'Company'
+	).where(
+		links.link_name == company
+	).run(as_dict=1)
+
+	address_list = [''] + [d.gstin for d in addresses]
+
+	return address_list


### PR DESCRIPTION
Added company GSTIN filters in GSTR-1 Report. Currently, only an address filter is available in the GSTR-1 report.
Users who have multiple addresses in the same state cannot view the report for a single GSTIN as the GSTIN is issued state-wise. This filter will help users to do that.

<img width="1333" alt="image" src="https://user-images.githubusercontent.com/42651287/154526515-4885c24d-1501-4b0a-99ea-c888d9833fac.png">
