### PR TITLE
fix(pos): removal of coupon code

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_payment.js
+++ b/erpnext/selling/page/point_of_sale/pos_payment.js
@@ -180,14 +180,6 @@ erpnext.PointOfSale.Payment = class {
 						() => frm.save(),
 						() => this.update_totals_section(frm.doc)
 					]);
-				} else {
-					frappe.run_serially([
-						() => frm.doc.ignore_pricing_rule=1,
-						() => frm.trigger('ignore_pricing_rule'),
-						() => frm.doc.ignore_pricing_rule=0,
-						() => frm.save(),
-						() => this.update_totals_section(frm.doc)
-					]);
 				}
 			}
 		});


### PR DESCRIPTION
No need to save after removing the coupon code. This also avoids unnecessary save when the pos payment section is rendered for the first time. 