### PR TITLE
chore: Show 'Produced Qty' field in Sales Order Item

### DIFF
--- a/erpnext/selling/doctype/sales_order_item/sales_order_item.json
+++ b/erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -83,8 +83,8 @@
   "planned_qty",
   "column_break_69",
   "work_order_qty",
-  "delivered_qty",
   "produced_qty",
+  "delivered_qty",
   "returned_qty",
   "shopping_cart_section",
   "additional_notes",
@@ -701,10 +701,8 @@
    "width": "50px"
   },
   {
-   "description": "For Production",
    "fieldname": "produced_qty",
    "fieldtype": "Float",
-   "hidden": 1,
    "label": "Produced Quantity",
    "oldfieldname": "produced_qty",
    "oldfieldtype": "Currency",
@@ -802,7 +800,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2021-10-05 12:27:25.014789",
+ "modified": "2022-02-21 13:55:08.883104",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order Item",
@@ -811,5 +809,6 @@
  "permissions": [],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }


### PR DESCRIPTION
- There's a field called "Produced Qty" in **Sales Order Item** that is hidden. That stores how much was produced via WO
- While the "Work Order Qty" field stores for how much qty the Work Order was raised (submitted)
- The hidden field makes users think the produced qty will be updated in the "Work Order Qty" field, which is False

**Fix:**
- Show "Produced Qty" field to indicate difference between fields
  <img width="964" alt="Screenshot 2022-02-21 at 2 13 29 PM" src="https://user-images.githubusercontent.com/25857446/154919124-135eff84-e533-41fa-abaf-69fa51615a0d.png">
