### PR TITLE
fix: only set batchwise valuation flag if new batch

### DIFF
--- a/erpnext/stock/doctype/batch/batch.json
+++ b/erpnext/stock/doctype/batch/batch.json
@@ -194,7 +194,7 @@
    "fieldtype": "Column Break"
   },
   {
-   "default": "1",
+   "default": "0",
    "fieldname": "use_batchwise_valuation",
    "fieldtype": "Check",
    "label": "Use Batch-wise Valuation",
@@ -207,10 +207,11 @@
  "image_field": "image",
  "links": [],
  "max_attachments": 5,
- "modified": "2021-10-11 13:38:12.806976",
+ "modified": "2022-02-21 08:08:23.999236",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Batch",
+ "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [
   {
@@ -231,6 +232,7 @@
  "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "title_field": "batch_id",
  "track_changes": 1
 }

--- a/erpnext/stock/doctype/batch/batch.py
+++ b/erpnext/stock/doctype/batch/batch.py
@@ -117,7 +117,10 @@ class Batch(Document):
 			frappe.throw(_("The selected item cannot have Batch"))
 
 	def set_batchwise_valuation(self):
-		self.use_batchwise_valuation = int(can_use_batchwise_valuation(self.item))
+		from erpnext.stock.stock_ledger import get_valuation_method
+
+		if self.is_new() and get_valuation_method(self.item) != "Moving Average":
+			self.use_batchwise_valuation = 1
 
 	def before_save(self):
 		has_expiry_date, shelf_life_in_days = frappe.db.get_value('Item', self.item, ['has_expiry_date', 'shelf_life_in_days'])
@@ -342,11 +345,3 @@ def get_pos_reserved_batch_qty(filters):
 
 	flt_reserved_batch_qty = flt(reserved_batch_qty[0][0])
 	return flt_reserved_batch_qty
-
-def can_use_batchwise_valuation(item_code: str) -> bool:
-	""" Check if item can use batchwise valuation.
-
-	Note: Moving average valuation method can not use batch_wise_valuation."""
-	from erpnext.stock.stock_ledger import get_valuation_method
-
-	return get_valuation_method(item_code) != "Moving Average"

--- a/erpnext/stock/doctype/batch/test_batch.py
+++ b/erpnext/stock/doctype/batch/test_batch.py
@@ -6,6 +6,7 @@ import json
 import frappe
 from frappe.exceptions import ValidationError
 from frappe.utils import cint, flt
+from frappe.utils.data import add_to_date, getdate
 
 from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice
 from erpnext.stock.doctype.batch.batch import UnableToSelectBatchError, get_batch_no, get_batch_qty
@@ -385,6 +386,25 @@ class TestBatch(ERPNextTestCase):
 
 		make_stock_entry(item_code=item_code, qty=20, rate=20, target=warehouse, batch_no=batch_no)
 		assertValuation((20 * 20 + 10 * 25) / (10 + 20))
+
+
+	def test_update_batch_properties(self):
+		item_code = "_TestBatchWiseVal"
+		self.make_batch_item(item_code)
+
+		se = make_stock_entry(item_code=item_code, qty=100, rate=10, target="_Test Warehouse - _TC")
+		batch_no = se.items[0].batch_no
+		batch = frappe.get_doc("Batch", batch_no)
+
+		expiry_date = add_to_date(batch.manufacturing_date, days=30)
+
+		batch.expiry_date = expiry_date
+		batch.save()
+
+		batch.reload()
+
+		self.assertEqual(getdate(batch.expiry_date), getdate(expiry_date))
+
 
 
 def create_batch(item_code, rate, create_item_price_for_batch):


### PR DESCRIPTION
caused by https://github.com/frappe/erpnext/pull/29804 



(no specific test but batchwise valuation PR covers most known cases already :) )