### PR TITLE
fix: Fetch conversion factor even if it already existed in row, on item change

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -525,6 +525,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 
 		item.weight_per_unit = 0;
 		item.weight_uom = '';
+		item.conversion_factor = 0;
 
 		if(['Sales Invoice'].includes(this.frm.doc.doctype)) {
 			update_stock = cint(me.frm.doc.update_stock);

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -346,8 +346,7 @@ def get_basic_details(args, item, overwrite_warehouse=True):
 	if item.stock_uom == args.uom:
 		out.conversion_factor = 1.0
 	else:
-		out.conversion_factor = args.conversion_factor or \
-			get_conversion_factor(item.name, args.uom).get("conversion_factor")
+		out.conversion_factor = get_conversion_factor(item.name, args.uom).get("conversion_factor")
 
 	args.conversion_factor = out.conversion_factor
 	out.stock_qty = out.qty * out.conversion_factor

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -346,7 +346,8 @@ def get_basic_details(args, item, overwrite_warehouse=True):
 	if item.stock_uom == args.uom:
 		out.conversion_factor = 1.0
 	else:
-		out.conversion_factor = get_conversion_factor(item.name, args.uom).get("conversion_factor")
+		out.conversion_factor = args.conversion_factor or \
+			get_conversion_factor(item.name, args.uom).get("conversion_factor")
 
 	args.conversion_factor = out.conversion_factor
 	out.stock_qty = out.qty * out.conversion_factor


### PR DESCRIPTION
**Issue:**
1. Create two items with Stock UOM **Nos**
2. Add conversion [Box: 12] in one and [Box: 24] in another
3. Set Default sales UOM in both items as **Box**
4. Assume both have a rate of **1**
4. Go to Sales Invoice > Add Item 1 > UOM is Box and Conversion is 12 > Rate = Item price * 12
5. In the very same row, change Item 1 to Item 2 > UOM is Box > **Conversion is still 12 (should have been 24)** > Rate = Item price * 12 (**should have been 24**)
  ![2022-02-21 19 04 07](https://user-images.githubusercontent.com/25857446/154965314-ed2ef559-a8ea-4797-866d-d5ebcca1de20.gif)


**Fix:**
- Reset conversion factor on client side every time item changes. Keep `get_item_details` API behaviour as is.
  ![2022-02-21 19 02 02](https://user-images.githubusercontent.com/25857446/154965036-0437e60c-bf67-49c7-8c99-9571da1432cf.gif)
- `get_item_details` will fetch fresh conversion factor if it gets 0 from the client side
 