### PR TITLE
fix(Salary Slip): TypeError while clearing any amount field in components

### DIFF
--- a/erpnext/payroll/doctype/salary_slip/salary_slip.py
+++ b/erpnext/payroll/doctype/salary_slip/salary_slip.py
@@ -1268,7 +1268,7 @@ class SalarySlip(TransactionBase):
 			for i, earning in enumerate(self.earnings):
 				if earning.salary_component == salary_component:
 					self.earnings[i].amount = wages_amount
-				self.gross_pay += self.earnings[i].amount
+				self.gross_pay += flt(self.earnings[i].amount, earning.precision("amount"))
 		self.net_pay = flt(self.gross_pay) - flt(self.total_deduction)
 
 	def compute_year_to_date(self):


### PR DESCRIPTION
### Steps to Replicate

1. Create a Salary Slip based on Timesheet
2. Clear the amount for any amount field in components table

<img width="1326" alt="image" src="https://user-images.githubusercontent.com/24353136/155069430-10a48afc-3aa0-4472-a683-487b3d70facc.png"> 