### PR TITLE
fix(asset): schedule generation with opening accumulated depreciation

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -247,8 +247,15 @@ class Asset(AccountsController):
 				break
 
 			# For first row
-			if has_pro_rata and not self.opening_accumulated_depreciation and n==0:
-				from_date = add_days(self.available_for_use_date, -1) # needed to calc depr amount for available_for_use_date too
+			if has_pro_rata and n==0:
+				if self.opening_accumulated_depreciation:
+					# to split first and last row amount proportionately
+					# for eg. if monthly depreciation amount is 300 and available for use date is 10th of the month
+					# then first row will be 33% of 300 and last row will be 66% of 300
+					from_date = self.get_modified_available_for_use_date(finance_book)
+				else:
+					from_date = add_days(self.available_for_use_date, -1) # needed to calc depr amount for available_for_use_date too
+
 				depreciation_amount, days, months = self.get_pro_rata_amt(finance_book, depreciation_amount,
 					from_date, finance_book.depreciation_start_date)
 
@@ -405,6 +412,8 @@ class Asset(AccountsController):
 
 		# if frequency_of_depreciation is 12 months, total_days = 365
 		total_days = get_total_days(row.depreciation_start_date, row.frequency_of_depreciation)
+
+		print(from_date, days, total_days)
 
 		if days < total_days:
 			has_pro_rata = True
@@ -915,8 +924,15 @@ def get_depreciation_amount(asset, depreciable_value, row):
 	if row.depreciation_method in ("Straight Line", "Manual"):
 		# if the Depreciation Schedule is being prepared for the first time
 		if not asset.flags.increase_in_asset_life:
-			depreciation_amount = (flt(asset.gross_purchase_amount) -
-				flt(row.expected_value_after_useful_life)) / flt(row.total_number_of_depreciations)
+			depreciation_amount = (
+				(
+					flt(row.value_after_depreciation)
+					- flt(row.expected_value_after_useful_life)
+				) / (
+					cint(row.total_number_of_depreciations)
+					- cint(asset.number_of_depreciations_booked)
+				)
+			)
 
 		# if the Depreciation Schedule is being modified after Asset Repair
 		else:

--- a/erpnext/regional/india/utils.py
+++ b/erpnext/regional/india/utils.py
@@ -841,8 +841,15 @@ def get_depreciation_amount(asset, depreciable_value, row):
 	if row.depreciation_method in ("Straight Line", "Manual"):
 		# if the Depreciation Schedule is being prepared for the first time
 		if not asset.flags.increase_in_asset_life:
-			depreciation_amount = (flt(asset.gross_purchase_amount) -
-				flt(row.expected_value_after_useful_life)) / flt(row.total_number_of_depreciations)
+			depreciation_amount = (
+				(
+					flt(row.value_after_depreciation)
+					- flt(row.expected_value_after_useful_life)
+				) / (
+					cint(row.total_number_of_depreciations)
+					- cint(asset.number_of_depreciations_booked)
+				)
+			)
 
 		# if the Depreciation Schedule is being modified after Asset Repair
 		else:


### PR DESCRIPTION
Problem Fixed:
- Create an Existing Asset with
  - Gross Purchase Amount = 10000
  - Opening Accumulated Depreciation = 7000
  - Number of Depreciation Booked = 7
  - Available for Use Date = 15th Jan 2021
  - Depreciation Posting Date = 01st Aug 2021
  - Total Number of Depreciation = 12
  - Frequency of Depreciation = 1
- On Saving the Asset, the last date of the schedule comes as 31st Dec 2021, however it should have been 15th Jan 2022

The depreciation from 31st Dec 2021 to 15th Jan 2022 is booked in the previous schedule entries. 