### PR TITLE
fix: default log date needed to query records

### DIFF
--- a/erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.js
+++ b/erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.js
@@ -3,15 +3,11 @@
 
 frappe.ui.form.on('Bulk Transaction Log', {
 
-	before_load: function(frm) {
-		query(frm);
-	},
-
 	refresh: function(frm) {
 		frm.disable_save();
 		frm.add_custom_button(__('Retry Failed Transactions'), ()=>{
 			frappe.confirm(__("Retry Failing Transactions ?"), ()=>{
-				query(frm);
+				query(frm, 1);
 			}
 			);
 		});
@@ -25,8 +21,8 @@ function query(frm) {
 			log_date: frm.doc.log_date
 		}
 	}).then((r) => {
-		if (r.message) {
-			frm.remove_custom_button("Retry Failed Transactions");
+		if (r.message === "No Failed Records") {
+			frappe.show_alert(__(r.message), 5);
 		} else {
 			frappe.show_alert(__("Retrying Failed Transactions"), 5);
 		}

--- a/erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.py
+++ b/erpnext/bulk_transaction/doctype/bulk_transaction_log/bulk_transaction_log.py
@@ -15,6 +15,8 @@ class BulkTransactionLog(Document):
 
 @frappe.whitelist()
 def retry_failing_transaction(log_date=None):
+	if not log_date:
+		log_date = str(date.today())
 	btp = frappe.qb.DocType("Bulk Transaction Log Detail")
 	data = (
 		frappe.qb.from_(btp)
@@ -25,9 +27,7 @@ def retry_failing_transaction(log_date=None):
 		.where(btp.date == log_date)
 	).run(as_dict=True)
 
-	if data:
-		if not log_date:
-			log_date = str(date.today())
+	if data :
 		if len(data) > 10:
 			frappe.enqueue(job, queue="long", job_name="bulk_retry", data=data, log_date=log_date)
 		else:


### PR DESCRIPTION
The Issue:
In bulk transaction processing feature it retries failing transactions from the log every hour but the issue was the function that was retrying transactions had log_date parameter value None when no date was provided due to which it couldn't fetch failing transaction's in cases when a background job is running via hooks

The Solution:
When no log_date value is provided take value as today's date to fetch failing transaction's 
