### PR TITLE
chore: Rollback after each test, due to premature commit via `remove_user_permission`

### DIFF
--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -691,6 +691,8 @@ class TestStockEntry(ERPNextTestCase):
 		bom_no = frappe.db.get_value("BOM", {"item": "_Test Variant Item",
 			"is_default": 1, "docstatus": 1})
 
+		make_item_variant() # make variant of _Test Variant Item if absent
+
 		work_order = frappe.new_doc("Work Order")
 		work_order.update({
 			"company": "_Test Company",

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -44,6 +44,7 @@ def get_sle(**args):
 
 class TestStockEntry(ERPNextTestCase):
 	def tearDown(self):
+		frappe.db.rollback()
 		frappe.set_user("Administrator")
 		frappe.db.set_value("Manufacturing Settings", None, "material_consumption", "0")
 
@@ -565,6 +566,7 @@ class TestStockEntry(ERPNextTestCase):
 		st1.set_stock_entry_type()
 		st1.insert()
 		st1.submit()
+		st1.cancel()
 
 		frappe.set_user("Administrator")
 		remove_user_permission("Warehouse", "_Test Warehouse 1 - _TC", "test@example.com")
@@ -1023,12 +1025,9 @@ class TestStockEntry(ERPNextTestCase):
 
 		# Check if FG cost is calculated based on RM total cost
 		# RM total cost = 200, FG rate = 200/4(FG qty) =  50
-		self.assertEqual(se.items[1].basic_rate, 50)
+		self.assertEqual(se.items[1].basic_rate, flt(se.items[0].basic_rate/4))
 		self.assertEqual(se.value_difference, 0.0)
 		self.assertEqual(se.total_incoming_value, se.total_outgoing_value)
-
-		# teardown
-		se.delete()
 
 	@change_settings("Stock Settings", {"allow_negative_stock": 0})
 	def test_future_negative_sle(self):


### PR DESCRIPTION
**Issue:**
- `remove_user_permission` in `test_warehouse_user` calls `delete_doc` that enqueues dynamic link deletion
- Execution of background job eventually commits
- While in the test suite it runs sequentially in the same thread and commits whatever was done until then
- Which is why the rollback in `tearDownClass` is quite useless here
- This premature commit causes many illegal transactions caught by `assertRaises` to be committed in the db
- This creates faulty/dirty ledgers and breaks reports, as outiside the test suite this shouldn't/wouldn't happen

**Eg:**
- `test_serial_no_reqd` creates a Serial No SLE without any Serial no in it, which is caught and asserted
- The same would ideally be rolled back after `TestStockEntry` runs, but due to the premature commit, it did not
- Such an SLE is illegal and ideally would not exist.
- When reports try to compute using such an illegal SLE, they break because they cannot handle this illegal case.

**Fix:**
- Rollback after each test, and for `test_warehouse_user` in particular, manually cancel transaction
- I cannot find a way to avoid the premature commit at https://github.com/frappe/frappe/blob/9006f92296c2594667154d43f7362c0951c826f9/frappe/utils/background_jobs.py#L136, so this should protect the test for now
