### PR TITLE
fix: Make abbreviation limit to 10

### DIFF
--- a/erpnext/public/js/setup_wizard.js
+++ b/erpnext/public/js/setup_wizard.js
@@ -78,11 +78,11 @@ erpnext.setup.slides_settings = [
 			slide.get_input("company_name").on("change", function () {
 				var parts = slide.get_input("company_name").val().split(" ");
 				var abbr = $.map(parts, function (p) { return p ? p.substr(0, 1) : null }).join("");
-				slide.get_field("company_abbr").set_value(abbr.slice(0, 5).toUpperCase());
+				slide.get_field("company_abbr").set_value(abbr.slice(0, 10).toUpperCase());
 			}).val(frappe.boot.sysdefaults.company_name || "").trigger("change");
 
 			slide.get_input("company_abbr").on("change", function () {
-				if (slide.get_input("company_abbr").val().length > 5) {
+				if (slide.get_input("company_abbr").val().length > 10) {
 					frappe.msgprint(__("Company Abbreviation cannot have more than 5 characters"));
 					slide.get_field("company_abbr").set_value("");
 				}
@@ -96,7 +96,7 @@ erpnext.setup.slides_settings = [
 			if (!this.values.company_abbr) {
 				return false;
 			}
-			if (this.values.company_abbr.length > 5) {
+			if (this.values.company_abbr.length > 10) {
 				return false;
 			}
 			return true;


### PR DESCRIPTION
The ERPNext setup wizard had a limit of 5 characters for the Company abbreviation
Changed this limit to 10 to handle cases where more than 5 was needed

<img width="703" alt="image" src="https://user-images.githubusercontent.com/42651287/155698542-1839cb49-5627-4ae0-82af-bad3fce8a24d.png">