### PR TITLE
fix: org chart connectors not rendered when Employee Naming is set to Full Name

### DIFF
--- a/erpnext/public/js/hierarchy_chart/hierarchy_chart_desktop.js
+++ b/erpnext/public/js/hierarchy_chart/hierarchy_chart_desktop.js
@@ -304,12 +304,13 @@ erpnext.HierarchyChart = class {
 	}
 
 	get_child_nodes(node_id) {
+		let me = this;
 		return new Promise(resolve => {
 			frappe.call({
-				method: this.method,
+				method: me.method,
 				args: {
 					parent: node_id,
-					company: this.company
+					company: me.company
 				}
 			}).then(r => resolve(r.message));
 		});
@@ -350,12 +351,13 @@ erpnext.HierarchyChart = class {
 	}
 
 	get_all_nodes() {
+		let me = this;
 		return new Promise(resolve => {
 			frappe.call({
 				method: 'erpnext.utilities.hierarchy_chart.get_all_nodes',
 				args: {
-					method: this.method,
-					company: this.company
+					method: me.method,
+					company: me.company
 				},
 				callback: (r) => {
 					resolve(r.message);
@@ -427,8 +429,8 @@ erpnext.HierarchyChart = class {
 
 	add_connector(parent_id, child_id) {
 		// using pure javascript for better performance
-		const parent_node = document.querySelector(`#${parent_id}`);
-		const child_node = document.querySelector(`#${child_id}`);
+		const parent_node = document.getElementById(`${parent_id}`);
+		const child_node = document.getElementById(`${child_id}`);
 
 		let path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
 

--- a/erpnext/public/js/hierarchy_chart/hierarchy_chart_mobile.js
+++ b/erpnext/public/js/hierarchy_chart/hierarchy_chart_mobile.js
@@ -235,7 +235,7 @@ erpnext.HierarchyChartMobile = class {
 		let me = this;
 		return new Promise(resolve => {
 			frappe.call({
-				method: this.method,
+				method: me.method,
 				args: {
 					parent: node_id,
 					company: me.company,
@@ -286,8 +286,8 @@ erpnext.HierarchyChartMobile = class {
 	}
 
 	add_connector(parent_id, child_id) {
-		const parent_node = document.querySelector(`#${parent_id}`);
-		const child_node = document.querySelector(`#${child_id}`);
+		const parent_node = document.getElementById(`${parent_id}`);
+		const child_node = document.getElementById(`${child_id}`);
 
 		const path = document.createElementNS('http://www.w3.org/2000/svg', 'path');
 
@@ -518,7 +518,8 @@ erpnext.HierarchyChartMobile = class {
 		level.nextAll('li').remove();
 
 		let node_object = this.nodes[node.id];
-		let current_node = level.find(`#${node.id}`).detach();
+		let current_node = level.find(`[id="${node.id}"]`).detach();
+
 		current_node.removeClass('active-child active-path');
 
 		node_object.expanded = 0;


### PR DESCRIPTION
## Steps to Replicate

- In HR Settings, set **Employee Naming By** to **Full Name**
- Create 2 employees (one reporting to another) having spaces in the name
- The connectors for nodes will not be rendered for such nodes

<img width="1440" alt="connec" src="https://user-images.githubusercontent.com/24353136/155758548-2d7c5760-4cc3-49d4-9d45-930bcdc0d2dc.png">

Also, sometimes after clicking on **Expand All** button following error is thrown:

```python
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 68, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 31, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 68, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1214, in call
    return fn(*args, **newargs)
TypeError: get_all_nodes() missing 1 required positional argument: 'company'
```

## Fix

- Use attribute selectors while finding parent and child nodes to connect to handle spaces.

   <img width="1440" alt="test-1" src="https://user-images.githubusercontent.com/24353136/155758346-da07e75d-c1e0-43dd-ba79-1c8a15afd520.png">

- Fix object scope in `get_all_nodes`
