### PR TITLE
refactor: removed validation to check zero qty

### DIFF
--- a/erpnext/controllers/subcontracting.py
+++ b/erpnext/controllers/subcontracting.py
@@ -363,20 +363,12 @@ class Subcontracting():
 			return
 
 		for row in self.get(self.raw_material_table):
-			self.__validate_consumed_qty(row)
-
 			key = (row.rm_item_code, row.main_item_code, row.purchase_order)
 			if not self.__transferred_items or not self.__transferred_items.get(key):
 				return
 
 			self.__validate_batch_no(row, key)
 			self.__validate_serial_no(row, key)
-
-	def __validate_consumed_qty(self, row):
-		if self.backflush_based_on != 'BOM' and flt(row.consumed_qty) == 0.0:
-			msg = f'Row {row.idx}: the consumed qty cannot be zero for the item {frappe.bold(row.rm_item_code)}'
-
-			frappe.throw(_(msg),title=_('Consumed Items Qty Check'))
 
 	def __validate_batch_no(self, row, key):
 		if row.get('batch_no') and row.get('batch_no') not in self.__transferred_items.get(key).get('batch_no'):


### PR DESCRIPTION

**Steps to replicate the issue**
1. Set backflush bashed on as "Material Transferred for Subcontract" in the buying settings
2. Create the subcontracted Purchase Order
3. Transfer extra materials in batches
4. While making purchase receipt, update the Consumed Qty of one raw material to zero 
5. Try to save the purchase receipt
6. You will get the error that "the consumed qty cannot be zero for the item XYZ"

**Why user wants to keep the qty as Zero?**
User has transferred extra materials which supplier has not consumed and user wants to return non consumed materials back to the their store warehouse

**Issue**
<img width="761" alt="Screenshot 2022-02-28 at 2 22 43 PM" src="https://user-images.githubusercontent.com/8780500/155953302-7c33d062-6e25-4623-9ded-d5a0d0fa7a06.png">

