### PR TITLE
fix: Deferred revenue booking

### DIFF
--- a/erpnext/accounts/deferred_revenue.py
+++ b/erpnext/accounts/deferred_revenue.py
@@ -120,6 +120,7 @@ def get_booking_dates(doc, item, posting_date=None):
 	prev_gl_entry = frappe.db.sql('''
 		select name, posting_date from `tabGL Entry` where company=%s and account=%s and
 		voucher_type=%s and voucher_no=%s and voucher_detail_no=%s
+		and is_cancelled = 0
 		order by posting_date desc limit 1
 	''', (doc.company, item.get(deferred_account), doc.doctype, doc.name, item.name), as_dict=True)
 
@@ -227,6 +228,7 @@ def get_already_booked_amount(doc, item):
 	gl_entries_details = frappe.db.sql('''
 		select sum({0}) as total_credit, sum({1}) as total_credit_in_account_currency, voucher_detail_no
 		from `tabGL Entry` where company=%s and account=%s and voucher_type=%s and voucher_no=%s and voucher_detail_no=%s
+		and is_cancelled = 0
 		group by voucher_detail_no
 	'''.format(total_credit_debit, total_credit_debit_currency),
 		(doc.company, item.get(deferred_account), doc.doctype, doc.name, item.name), as_dict=True)
@@ -282,7 +284,7 @@ def book_deferred_income_or_expense(doc, deferred_process, posting_date=None):
 			return
 
 		# check if books nor frozen till endate:
-		if getdate(end_date) >= getdate(accounts_frozen_upto):
+		if accounts_frozen_upto and (end_date) <= getdate(accounts_frozen_upto):
 			end_date = get_last_day(add_days(accounts_frozen_upto, 1))
 
 		if via_journal_entry:


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "apps/erpnext/erpnext/accounts/deferred_revenue.py", line 379, in make_gl_entries
    make_gl_entries(gl_entries, cancel=(doc.docstatus == 2), merge_entries=True)
  File "apps/erpnext/erpnext/accounts/general_ledger.py", line 27, in make_gl_entries
    save_entries(gl_map, adv_adj, update_outstanding, from_repost)
  File "apps/erpnext/erpnext/accounts/general_ledger.py", line 211, in save_entries
    make_entry(entry, adv_adj, update_outstanding, from_repost)
  File "apps/erpnext/erpnext/accounts/general_ledger.py", line 220, in make_entry
    gle.submit()
  File "apps/frappe/frappe/model/document.py", line 944, in submit
    return self._submit()
  File "apps/frappe/frappe/model/document.py", line 932, in _submit
    return self.save()
  File "apps/frappe/frappe/model/document.py", line 284, in save
    return self._save(*args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 306, in _save
    return self.insert()
  File "apps/frappe/frappe/model/document.py", line 236, in insert
    self.set_new_name(set_name=set_name, set_child_names=set_child_names)
  File "apps/frappe/frappe/model/document.py", line 422, in set_new_name
    set_new_name(self)
  File "apps/frappe/frappe/model/naming.py", line 43, in set_new_name
    set_naming_from_document_naming_rule(doc)
  File "apps/frappe/frappe/model/naming.py", line 96, in set_naming_from_document_naming_rule
    for d in frappe.get_all('Document Naming Rule',
  File "apps/frappe/frappe/__init__.py", line 1493, in get_all
    return get_list(doctype, *args, **kwargs)
  File "apps/frappe/frappe/__init__.py", line 1466, in get_list
    return frappe.model.db_query.DatabaseQuery(doctype).execute(*args, **kwargs)
  File "apps/frappe/frappe/model/db_query.py", line 108, in execute
    result = self.build_and_run()
  File "apps/frappe/frappe/model/db_query.py", line 123, in build_and_run
    args = self.prepare_args()
  File "apps/frappe/frappe/model/db_query.py", line 153, in prepare_args
    self.build_conditions()
  File "apps/frappe/frappe/model/db_query.py", line 398, in build_conditions
    self.build_filter_conditions(self.filters, self.conditions)
  File "apps/frappe/frappe/model/db_query.py", line 419, in build_filter_conditions
    conditions.append(self.prepare_filter_condition(f))
  File "apps/frappe/frappe/model/db_query.py", line 428, in prepare_filter_condition
    f = get_filter(self.doctype, f, additional_filters_config)
  File "apps/frappe/frappe/utils/data.py", line 1383, in get_filter
    sanitize_column(f.fieldname)
  File "apps/frappe/frappe/utils/data.py", line 1446, in sanitize_column
    column_name = sqlparse.format(column_name, strip_comments=True, keyword_case="lower")
  File "env/lib/python3.9/site-packages/sqlparse/__init__.py", line 59, in format
    return ''.join(stack.run(sql, encoding))
  File "env/lib/python3.9/site-packages/sqlparse/engine/filter_stack.py", line 39, in run
    filter_.process(stmt)
  File "env/lib/python3.9/site-packages/sqlparse/filters/others.py", line 51, in process
    [self.process(sgroup) for sgroup in stmt.get_sublists()]
  File "env/lib/python3.9/site-packages/sqlparse/filters/others.py", line 51, in <listcomp>
    [self.process(sgroup) for sgroup in stmt.get_sublists()]
  File "env/lib/python3.9/site-packages/sqlparse/filters/others.py", line 52, in process
    StripCommentsFilter._process(stmt)
  File "env/lib/python3.9/site-packages/sqlparse/filters/others.py", line 31, in _process
    tidx, token = get_next_comment()
  File "env/lib/python3.9/site-packages/sqlparse/filters/others.py", line 20, in get_next_comment
    return tlist.token_next_by(i=sql.Comment, t=T.Comment)
  File "env/lib/python3.9/site-packages/sqlparse/sql.py", line 266, in token_next_by
    return self._token_matching(lambda tk: imt(tk, i, m, t), idx, end)
  File "env/lib/python3.9/site-packages/sqlparse/sql.py", line 245, in _token_matching
    if func(token):
  File "env/lib/python3.9/site-packages/sqlparse/sql.py", line 266, in <lambda>
    return self._token_matching(lambda tk: imt(tk, i, m, t), idx, end)
  File "env/lib/python3.9/site-packages/sqlparse/utils.py", line 99, in imt
    elif types and any(token.ttype in ttype for ttype in types):
  File "env/lib/python3.9/site-packages/sqlparse/utils.py", line 99, in <genexpr>
    elif types and any(token.ttype in ttype for ttype in types):
  File "env/lib/python3.9/site-packages/sqlparse/tokens.py", line 19, in __contains__
    return item is not None and (self is item or item[:len(self)] == self)
RecursionError: maximum recursion depth exceeded in comparison
```