### PR TITLE
fix(test): flaky test_point_of_sale

### DIFF
--- a/erpnext/tests/test_point_of_sale.py
+++ b/erpnext/tests/test_point_of_sale.py
@@ -25,7 +25,7 @@ class TestPointOfSale(unittest.TestCase):
 		Test Stock and Service Item Search.
 		"""
 
-		pos_profile = make_pos_profile()
+		pos_profile = make_pos_profile(name="Test POS Profile for Search")
 		item1 = make_item("Test Search Stock Item", {"is_stock_item": 1})
 		make_stock_entry(
 			item_code="Test Search Stock Item",


### PR DESCRIPTION
Possible scenario:
The pos profile's warehouse is possibly getting modified, so the item is being searched in some other warehouse 