### PR TITLE
test: Fix failing tests related to empty tax categories

### DIFF
--- a/erpnext/accounts/doctype/sales_taxes_and_charges_template/sales_taxes_and_charges_template.py
+++ b/erpnext/accounts/doctype/sales_taxes_and_charges_template/sales_taxes_and_charges_template.py
@@ -55,5 +55,8 @@ def validate_disabled(doc):
 		frappe.throw(_("Disabled template must not be default template"))
 
 def validate_for_tax_category(doc):
+	if not doc.tax_category:
+		return
+
 	if frappe.db.exists(doc.doctype, {"company": doc.company, "tax_category": doc.tax_category, "disabled": 0, "name": ["!=", doc.name]}):
 		frappe.throw(_("A template with tax category {0} already exists. Only one template is allowed with each tax category").format(frappe.bold(doc.tax_category)))


### PR DESCRIPTION
A [bug fix in frappe](https://github.com/frappe/frappe/pull/16117) is leading to test failures because of incorrect fixtures. Cleaning up stale fixtures.