### PR TITLE
test: fix flaky bin value test

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -161,6 +161,15 @@ class TestPurchaseReceipt(FrappeTestCase):
 				qty=abs(existing_bin_qty)
 			)
 
+		existing_bin_qty, existing_bin_stock_value = frappe.db.get_value(
+			"Bin",
+			{
+				"item_code": "_Test Item",
+				"warehouse": "_Test Warehouse - _TC"
+			},
+			["actual_qty", "stock_value"]
+		)
+
 		pr = make_purchase_receipt()
 
 		stock_value_difference = frappe.db.get_value(


### PR DESCRIPTION
This test was flaky/failing when some previous test causes negative stock. 