### PR TITLE
fix: handle `ImportError` when installing country fixtures

### DIFF
--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -422,7 +422,7 @@ def get_name_with_abbr(name, company):
 
 def install_country_fixtures(company, country):
 	try:
-		module_name = "erpnext.regional.{0}.setup.setup".format(frappe.scrub(country))
+		module_name = f"erpnext.regional.{frappe.scrub(country)}.setup.setup"
 		frappe.get_attr(module_name)(company, False)
 	except ImportError:
 		pass

--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -3,7 +3,6 @@
 
 
 import json
-import os
 
 import frappe
 import frappe.defaults
@@ -422,14 +421,14 @@ def get_name_with_abbr(name, company):
 	return " - ".join(parts)
 
 def install_country_fixtures(company, country):
-	path = frappe.get_app_path('erpnext', 'regional', frappe.scrub(country))
-	if os.path.exists(path.encode("utf-8")):
-		try:
-			module_name = "erpnext.regional.{0}.setup.setup".format(frappe.scrub(country))
-			frappe.get_attr(module_name)(company, False)
-		except Exception as e:
-			frappe.log_error()
-			frappe.throw(_("Failed to setup defaults for country {0}. Please contact support.").format(frappe.bold(country)))
+	try:
+		module_name = "erpnext.regional.{0}.setup.setup".format(frappe.scrub(country))
+		frappe.get_attr(module_name)(company, False)
+	except ImportError:
+		pass
+	except Exception:
+		frappe.log_error()
+		frappe.throw(_("Failed to setup defaults for country {0}. Please contact support.").format(frappe.bold(country)))
 
 
 def update_company_current_month_sales(company):


### PR DESCRIPTION
This change is required for moving regional functionality into a separate app. `os.path.exists` succeeds on `erpnext/regional/india` even after pulling ERPNext with India-specific code removed. This is because `git` does not remove empty folders when pulling changes.

**Solution:** Allow `ImportError` to pass silently instead of checking path. This would mean that `install_country_fixtures` will work only if `country/setup.py` or `country/setup/__init__.py` file is found. `ImportError` is the parent exception of `ModuleNotFoundError`, which is what was getting raised previously:

```
Traceback (most recent call last):
12:00:28 web.1            |   File "apps/erpnext/erpnext/setup/doctype/company/company.py", line 429, in install_country_fixtures
12:00:28 web.1            |     frappe.get_attr(module_name)(company, False)
12:00:28 web.1            |   File "apps/frappe/frappe/__init__.py", line 1224, in get_attr
12:00:28 web.1            |     return getattr(get_module(modulename), methodname)
12:00:28 web.1            |   File "apps/frappe/frappe/__init__.py", line 1000, in get_module
12:00:28 web.1            |     return importlib.import_module(modulename)
12:00:28 web.1            |   File "/usr/lib/python3.9/importlib/__init__.py", line 127, in import_module
12:00:28 web.1            |     return _bootstrap._gcd_import(name[level:], package, level)
12:00:28 web.1            |   File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
12:00:28 web.1            |   File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
12:00:28 web.1            |   File "<frozen importlib._bootstrap>", line 984, in _find_and_load_unlocked
12:00:28 web.1            | ModuleNotFoundError: No module named 'erpnext.regional.india.setup'
```