### PR TITLE
fix(Timesheet): fetch exchange rate only if currency is set

### DIFF
--- a/erpnext/projects/doctype/timesheet/timesheet.js
+++ b/erpnext/projects/doctype/timesheet/timesheet.js
@@ -116,7 +116,7 @@ frappe.ui.form.on("Timesheet", {
 
 	currency: function(frm) {
 		let base_currency = frappe.defaults.get_global_default('currency');
-		if (base_currency != frm.doc.currency) {
+		if (frm.doc.currency && (base_currency != frm.doc.currency)) {
 			frappe.call({
 				method: "erpnext.setup.utils.get_exchange_rate",
 				args: {


### PR DESCRIPTION
In Timesheets if the currency field is not set fetching exchange rate fails:

```python
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 66, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 54, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 31, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 68, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1232, in call
    return fn(*args, **newargs)
TypeError: get_exchange_rate() missing 1 required positional argument: 'from_currency'
```

Only call `get_exchange_rate` once the currency is set.