### PR TITLE
fix: remove hardcoded routing precision

### DIFF
--- a/erpnext/manufacturing/doctype/operation/operation_dashboard.py
+++ b/erpnext/manufacturing/doctype/operation/operation_dashboard.py
@@ -7,7 +7,7 @@ def get_data():
 		'transactions': [
 			{
 				'label': _('Manufacture'),
-				'items': ['BOM', 'Work Order', 'Job Card', 'Timesheet']
+				'items': ['BOM', 'Work Order', 'Job Card']
 			}
 		]
 	}

--- a/erpnext/manufacturing/doctype/routing/routing.js
+++ b/erpnext/manufacturing/doctype/routing/routing.js
@@ -17,7 +17,7 @@ frappe.ui.form.on('Routing', {
 	},
 
 	calculate_operating_cost: function(frm, child) {
-		const operating_cost = flt(flt(child.hour_rate) * flt(child.time_in_mins) / 60, 2);
+		const operating_cost = flt(flt(child.hour_rate) * flt(child.time_in_mins) / 60, precision("operating_cost", child));
 		frappe.model.set_value(child.doctype, child.name, "operating_cost", operating_cost);
 	}
 });

--- a/erpnext/manufacturing/doctype/routing/routing.py
+++ b/erpnext/manufacturing/doctype/routing/routing.py
@@ -20,7 +20,8 @@ class Routing(Document):
 		for operation in self.operations:
 			if not operation.hour_rate:
 				operation.hour_rate = frappe.db.get_value("Workstation", operation.workstation, 'hour_rate')
-			operation.operating_cost = flt(flt(operation.hour_rate) * flt(operation.time_in_mins) / 60, 2)
+			operation.operating_cost = flt(flt(operation.hour_rate) * flt(operation.time_in_mins) / 60,
+					operation.precision("operating_cost"))
 
 	def set_routing_id(self):
 		sequence_id = 0

--- a/erpnext/manufacturing/doctype/workstation/workstation_dashboard.py
+++ b/erpnext/manufacturing/doctype/workstation/workstation_dashboard.py
@@ -11,9 +11,9 @@ def get_data():
 			},
 			{
 				'label': _('Transaction'),
-				'items': ['Work Order', 'Job Card', 'Timesheet']
+				'items': ['Work Order', 'Job Card',]
 			}
 		],
 		'disable_create_buttons': ['BOM', 'Routing', 'Operation',
-			'Work Order', 'Job Card', 'Timesheet']
+			'Work Order', 'Job Card',]
 	}


### PR DESCRIPTION
`Routing` doctype had hardcoded field precision to 2. This change undoes that and uses doctype / user set precision instead. 