### PR TITLE
fix: Item-wise sales history report

### DIFF
--- a/erpnext/selling/report/item_wise_sales_history/item_wise_sales_history.py
+++ b/erpnext/selling/report/item_wise_sales_history/item_wise_sales_history.py
@@ -156,24 +156,24 @@ def get_data(filters):
 		customer_record = customer_details.get(record.customer)
 		item_record = item_details.get(record.item_code)
 		row = {
-			"item_code": record.item_code,
-			"item_name": item_record.item_name,
-			"item_group": item_record.item_group,
-			"description": record.description,
-			"quantity": record.qty,
-			"uom": record.uom,
-			"rate": record.base_rate,
-			"amount": record.base_amount,
-			"sales_order": record.name,
-			"transaction_date": record.transaction_date,
-			"customer": record.customer,
-			"customer_name": customer_record.customer_name,
-			"customer_group": customer_record.customer_group,
-			"territory": record.territory,
-			"project": record.project,
-			"delivered_quantity": flt(record.delivered_qty),
-			"billed_amount": flt(record.billed_amt),
-			"company": record.company
+			"item_code": record.get('item_code'),
+			"item_name": item_record.get('item_name'),
+			"item_group": item_record.get('item_group'),
+			"description": record.get('description'),
+			"quantity": record.get('qty'),
+			"uom": record.get('uom'),
+			"rate": record.get('base_rate'),
+			"amount": record.get('base_amount'),
+			"sales_order": record.get('name'),
+			"transaction_date": record.get('transaction_date'),
+			"customer": record.get('customer'),
+			"customer_name": customer_record.get('customer_name'),
+			"customer_group": customer_record.get('customer_group'),
+			"territory": record.get('territory'),
+			"project": record.get('project'),
+			"delivered_quantity": flt(record.get('delivered_qty')),
+			"billed_amount": flt(record.get('billed_amt')),
+			"company": record.get('company')
 		}
 		data.append(row)
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 68, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 31, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 68, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1214, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/__init__.py", line 630, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "apps/frappe/frappe/desk/query_report.py", line 244, in run
    result = generate_report_result(report, filters, user, custom_columns)
  File "apps/frappe/frappe/__init__.py", line 630, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "apps/frappe/frappe/desk/query_report.py", line 86, in generate_report_result
    res = get_report_result(report, filters) or []
  File "apps/frappe/frappe/desk/query_report.py", line 70, in get_report_result
    res = report.execute_script_report(filters)
  File "apps/frappe/frappe/core/doctype/report/report.py", line 133, in execute_script_report
    res = self.execute_module(filters)
  File "apps/frappe/frappe/core/doctype/report/report.py", line 150, in execute_module
    return frappe.get_attr(method_name)(frappe._dict(filters))
  File "apps/erpnext/erpnext/selling/report/item_wise_sales_history/item_wise_sales_history.py", line 17, in execute
    data = get_data(filters)
  File "apps/erpnext/erpnext/selling/report/item_wise_sales_history/item_wise_sales_history.py", line 160, in get_data
    "item_name": item_record.item_name,
AttributeError: 'NoneType' object has no attribute 'item_name'
```