### PR TITLE
fix: website_image field not copied when creating Website Items

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -351,3 +351,4 @@ erpnext.patches.v13_0.update_disbursement_account
 erpnext.patches.v13_0.update_reserved_qty_closed_wo
 erpnext.patches.v13_0.amazon_mws_deprecation_warning
 erpnext.patches.v13_0.set_work_order_qty_in_so_from_mr
+erpnext.patches.v13_0.create_website_items_imagefix

--- a/erpnext/patches/v13_0/create_website_items_imagefix.py
+++ b/erpnext/patches/v13_0/create_website_items_imagefix.py
@@ -1,0 +1,9 @@
+import frappe
+
+def execute():
+	"Copy website_image field from Item if image is not already populated"
+	for website_item_name in frappe.db.get_list('Website Item', {'image': ("=", "")}, pluck='name'):
+		witem = frappe.get_doc('Website Item', website_item_name)
+		image = frappe.db.get_value('Item', witem.item_code, 'website_image')
+		witem.image = image
+		witem.save()


### PR DESCRIPTION
The `create_website_items` v13 patch assumes that the website image for an item is in the `image` field.
This is clearly not correct since there is a `website_image` field in both the original `Item` and `Website Item` doctypes.

## This means upgrades from v12 to v13 lose images on the homepage.

Introduces a new patch to copy the field across.

This needs someone with an idea of the ERPNext roadmap to figure out if it was intended to remove the `website_image` field on the `Website Item` or not. `image` and `website_image` seem redundant but why doesn't the original patch copy the image from `Item.website_image` to `Website Item.image` ??

PS why isn't the website_image_alt field used in the home.html template instead of item_name ??