### PR TITLE
fix(e-invoicing): remove batch no from e-invoices

### DIFF
--- a/erpnext/regional/india/e_invoice/einv_item_template.json
+++ b/erpnext/regional/india/e_invoice/einv_item_template.json
@@ -23,9 +23,5 @@
     "StateCesAmt": "{item.state_cess_amount}",
     "StateCesNonAdvlAmt": "{item.state_cess_nadv_amount}",
     "OthChrg": "{item.other_charges}",
-    "TotItemVal": "{item.total_value}",
-    "BchDtls": {{
-        "Nm": "{item.batch_no}",
-        "ExpDt": "{item.batch_expiry_date}"
-    }}
+    "TotItemVal": "{item.total_value}"
 }}

--- a/erpnext/regional/india/e_invoice/utils.py
+++ b/erpnext/regional/india/e_invoice/utils.py
@@ -214,8 +214,6 @@ def get_item_list(invoice):
 		item.taxable_value = abs(item.taxable_value)
 		item.discount_amount = 0
 
-		item.batch_expiry_date = frappe.db.get_value('Batch', d.batch_no, 'expiry_date') if d.batch_no else None
-		item.batch_expiry_date = format_date(item.batch_expiry_date, 'dd/mm/yyyy') if item.batch_expiry_date else None
 		item.is_service_item = 'Y' if item.gst_hsn_code and item.gst_hsn_code[:2] == "99" else 'N'
 		item.serial_no = ""
 


### PR DESCRIPTION
Batch numbers are optional for e-invoicing. Hence removing it to avoid unnecessary problems like "batch number should be less than 20 letters" 