### PR TITLE
feat(sales order): added required_by_date in Update Items dialog, SO form & SO items table

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1906,6 +1906,7 @@ def set_order_defaults(parent_doctype, parent_doctype_name, child_doctype, child
 	child_item.warehouse = get_item_warehouse(item, p_doc, overwrite_warehouse=True)
 	conversion_factor = flt(get_conversion_factor(item.item_code, child_item.uom).get("conversion_factor"))
 	child_item.conversion_factor = flt(trans_item.get('conversion_factor')) or conversion_factor
+	child_item.reqd_by_date = trans_item.get('reqd_by_date') or p_doc.reqd_by_date
 
 	if child_doctype == "Purchase Order Item":
 		# Initialized value will update in parent validation

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -557,6 +557,15 @@ erpnext.utils.update_child_items = function(opts) {
 		})
 	}
 
+	if (frm.doc.doctype == 'Sales Order') {
+		fields.splice(2, 0, {
+			fieldtype: 'Date',
+			fieldname: "reqd_by_date",
+			in_list_view: 1,
+			label: __("Reqd By Date")
+		})
+	}
+
 	const dialog = new frappe.ui.Dialog({
 		title: __("Update Items"),
 		fields: [
@@ -600,6 +609,7 @@ erpnext.utils.update_child_items = function(opts) {
 			"docname": d.name,
 			"name": d.name,
 			"item_code": d.item_code,
+			"reqd_by_date": d.reqd_by_date,
 			"delivery_date": d.delivery_date,
 			"schedule_date": d.schedule_date,
 			"conversion_factor": d.conversion_factor,

--- a/erpnext/selling/doctype/sales_order/sales_order.json
+++ b/erpnext/selling/doctype/sales_order/sales_order.json
@@ -21,6 +21,7 @@
   "amended_from",
   "company",
   "transaction_date",
+  "reqd_by_date",
   "delivery_date",
   "po_no",
   "po_date",
@@ -1514,17 +1515,21 @@
    "fieldtype": "Currency",
    "label": "Amount Eligible for Commission",
    "read_only": 1
+  },
+  {
+   "fieldname": "reqd_by_date",
+   "fieldtype": "Date",
+   "label": "Reqd By Date"
   }
  ],
  "icon": "fa fa-file-text",
  "idx": 105,
  "is_submittable": 1,
  "links": [],
- "modified": "2021-10-05 12:16:40.775704",
+ "modified": "2022-03-07 14:52:35.187967",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order",
- "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
  "permissions": [
   {

--- a/erpnext/selling/doctype/sales_order_item/sales_order_item.json
+++ b/erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -11,6 +11,7 @@
   "customer_item_code",
   "ensure_delivery_based_on_produced_serial_no",
   "col_break1",
+  "reqd_by_date",
   "delivery_date",
   "item_name",
   "section_break_5",
@@ -798,12 +799,17 @@
    "fieldtype": "Check",
    "label": "Grant Commission",
    "read_only": 1
+  },
+  {
+   "fieldname": "reqd_by_date",
+   "fieldtype": "Date",
+   "label": "Reqd By Date"
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2022-02-24 14:41:57.325799",
+ "modified": "2022-03-07 14:51:48.360507",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order Item",


### PR DESCRIPTION

**Details of the feature request:**
To add Reqd By Date in the Sales order form, sales order items table, and on update items dialog

**Solution:**
1. Added Reqd By Date in Sales Order and Sales Order Item Doctype
2. Added Reqd By Date column in Update Items Dialog

Screenshot of the feature request:
**Before**
![OLD](https://user-images.githubusercontent.com/40702858/156986136-86fc69bd-4879-4b7b-819e-5c3df0efb037.gif)

**After**
![New](https://user-images.githubusercontent.com/40702858/156986174-a1da1ea5-f27e-42fd-ba1f-c04694890b35.gif)


