### PR TITLE
fix: Ambigous column in picklist query

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -9,7 +9,6 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.model.mapper import map_child_doc
 from frappe.utils import cint, floor, flt, today
-from six import iteritems
 
 from erpnext.selling.doctype.sales_order.sales_order import (
 	make_delivery_note as create_delivery_note_from_sales_order,
@@ -246,7 +245,7 @@ def get_available_item_locations_for_serialized_item(item_code, from_warehouses,
 		warehouse_serial_nos_map.setdefault(warehouse, []).append(serial_no)
 
 	locations = []
-	for warehouse, serial_nos in iteritems(warehouse_serial_nos_map):
+	for warehouse, serial_nos in warehouse_serial_nos_map.items():
 		locations.append({
 			'qty': len(serial_nos),
 			'warehouse': warehouse,

--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -9,6 +9,7 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.model.mapper import map_child_doc
 from frappe.utils import cint, floor, flt, today
+from six import iteritems
 
 from erpnext.selling.doctype.sales_order.sales_order import (
 	make_delivery_note as create_delivery_note_from_sales_order,
@@ -245,7 +246,7 @@ def get_available_item_locations_for_serialized_item(item_code, from_warehouses,
 		warehouse_serial_nos_map.setdefault(warehouse, []).append(serial_no)
 
 	locations = []
-	for warehouse, serial_nos in warehouse_serial_nos_map.items():
+	for warehouse, serial_nos in iteritems(warehouse_serial_nos_map):
 		locations.append({
 			'qty': len(serial_nos),
 			'warehouse': warehouse,
@@ -272,9 +273,9 @@ def get_available_item_locations_for_batched_item(item_code, from_warehouses, re
 			and IFNULL(batch.`expiry_date`, '2200-01-01') > %(today)s
 			{warehouse_condition}
 		GROUP BY
-			`warehouse`,
-			`batch_no`,
-			`item_code`
+			sle.`warehouse`,
+			sle.`batch_no`,
+			sle.`item_code`
 		HAVING `qty` > 0
 		ORDER BY IFNULL(batch.`expiry_date`, '2200-01-01'), batch.`creation`
 	""".format(warehouse_condition=warehouse_condition), { #nosec


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 68, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 31, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 68, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1214, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/model/mapper.py", line 36, in make_mapped_doc
    return method(source_name)
  File "apps/erpnext/erpnext/selling/doctype/sales_order/sales_order.py", line 1137, in create_pick_list
    doc.set_item_locations()
  File "apps/erpnext/erpnext/stock/doctype/pick_list/pick_list.py", line 60, in set_item_locations
    get_available_item_locations(item_code, from_warehouses, self.item_count_map.get(item_code), self.company))
  File "apps/erpnext/erpnext/stock/doctype/pick_list/pick_list.py", line 211, in get_available_item_locations
    locations = get_available_item_locations_for_batched_item(item_code, from_warehouses, required_qty, company)
  File "apps/erpnext/erpnext/stock/doctype/pick_list/pick_list.py", line 286, in get_available_item_locations_for_batched_item
    }, as_dict=1)
  File "apps/frappe/frappe/database/database.py", line 146, in sql
    self._cursor.execute(query, values)
  File "env/lib/python3.7/site-packages/pymysql/cursors.py", line 148, in execute
    result = self._query(query)
  File "env/lib/python3.7/site-packages/pymysql/cursors.py", line 310, in _query
    conn.query(q)
  File "env/lib/python3.7/site-packages/pymysql/connections.py", line 548, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "env/lib/python3.7/site-packages/pymysql/connections.py", line 775, in _read_query_result
    result.read()
  File "env/lib/python3.7/site-packages/pymysql/connections.py", line 1156, in read
    first_packet = self.connection._read_packet()
  File "env/lib/python3.7/site-packages/pymysql/connections.py", line 725, in _read_packet
    packet.raise_for_error()
  File "env/lib/python3.7/site-packages/pymysql/protocol.py", line 221, in raise_for_error
    err.raise_mysql_exception(self._data)
  File "env/lib/python3.7/site-packages/pymysql/err.py", line 143, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.OperationalError: (1052, "Column 'item_code' in group statement is ambiguous")
```