### PR TITLE
fix: Remove tax invoice no field

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
@@ -9,7 +9,6 @@
   "customer_section",
   "title",
   "naming_series",
-  "tax_invoice_number",
   "customer",
   "customer_name",
   "tax_id",
@@ -2026,12 +2025,6 @@
    "fieldname": "amount_eligible_for_commission",
    "fieldtype": "Currency",
    "label": "Amount Eligible for Commission",
-   "read_only": 1
-  },
-  {
-   "fieldname": "tax_invoice_number",
-   "fieldtype": "Data",
-   "label": "Tax Invoice Number",
    "read_only": 1
   }
  ],

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
@@ -2038,7 +2038,7 @@
    "link_fieldname": "consolidated_invoice"
   }
  ],
- "modified": "2022-03-07 16:08:53.517903",
+ "modified": "2022-03-08 16:08:53.517903",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice",


### PR DESCRIPTION
Introduced via https://github.com/frappe/erpnext/pull/30133

Remove wrongly added field