### PR TITLE
feat(accounts_controller): Allow update item in Update Item button in PO and SO

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2044,7 +2044,7 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 		else:
 			check_doc_permissions(parent, 'write')
 			child_item = frappe.get_doc(parent_doctype + ' Item', d.get("docname"))
-
+			prev_item_code, new_item_code = child_item.item_code,d.get('item_code')
 			prev_rate, new_rate = flt(child_item.get("rate")), flt(d.get("rate"))
 			prev_qty, new_qty = flt(child_item.get("qty")), flt(d.get("qty"))
 			prev_con_fac, new_con_fac = flt(child_item.get("conversion_factor")), flt(d.get("conversion_factor"))
@@ -2054,13 +2054,13 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 				prev_date, new_date = child_item.get("delivery_date"), d.get("delivery_date")
 			elif parent_doctype == 'Purchase Order':
 				prev_date, new_date = child_item.get("schedule_date"), d.get("schedule_date")
-
+			item_code_changed = prev_item_code == new_item_code
 			rate_unchanged = prev_rate == new_rate
 			qty_unchanged = prev_qty == new_qty
 			uom_unchanged = prev_uom == new_uom
 			conversion_factor_unchanged = prev_con_fac == new_con_fac
 			date_unchanged = prev_date == getdate(new_date) if prev_date and new_date else False # in case of delivery note etc
-			if rate_unchanged and qty_unchanged and conversion_factor_unchanged and uom_unchanged and date_unchanged:
+			if item_code_changed and rate_unchanged and qty_unchanged and conversion_factor_unchanged and uom_unchanged and date_unchanged:
 				continue
 
 		validate_quantity(child_item, d)
@@ -2070,6 +2070,22 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 		conv_fac_precision = child_item.precision("conversion_factor") or 2
 		qty_precision = child_item.precision("qty") or 2
 
+		user = frappe.session.user
+		if child_item.item_code != d.get("item_code"):
+			if ("Sales Manager" in frappe.get_roles(user)):
+				if parent_doctype in ['Sales Order', 'Purchase Order']:
+					qty_cond = child_item.delivered_qty if parent_doctype == 'Sales Order' else child_item.received_qty
+					if (child_item.billed_amt > 0 or qty_cond > 0):
+						frappe.throw(_("Cannot update item since partial bill or partial delivery exists."))
+					else:
+						item_data = frappe.get_doc("Item", d.get("item_code"))
+						child_item.item_code = d.get("item_code")
+						child_item.item_name = item_data.item_name
+						child_item.description = item_data.description
+						child_item.stock_uom = item_data.stock_uom
+						child_item.uom = item_data.stock_uom
+			else:
+				frappe.throw(_("User must be Sales Manager to update Item Code."))
 		if flt(child_item.billed_amt, rate_precision) > flt(flt(d.get("rate"), rate_precision) * flt(d.get("qty"), qty_precision), rate_precision):
 			frappe.throw(_("Row #{0}: Cannot set Rate if amount is greater than billed amount for Item {1}.")
 						 .format(child_item.idx, child_item.item_code))


### PR DESCRIPTION
Feature Details:
--
Allow Sales Manager users to change the item_code in Purchase Order and Sales Order using the "Update Item" button.

Users should be able to update the items in the Sales Order/Purchase Order. By updating the item_code directly, the current process for updating submitted SO/PO is deleting the item and using the add button.


Purchase Order:
--
![Purchase Order (submitted)](https://user-images.githubusercontent.com/85614308/157585434-f179f245-b915-45e9-a603-6f0f8f19dbb0.gif)

Sales Order:
--
![Sales Order (Submitted)](https://user-images.githubusercontent.com/85614308/157585480-90813aba-d4d2-4c91-a33d-db2fc59178a8.gif)

Validations:
--
Only users with the Sales Manager role are only ones allowed to perform the update.
![Non-salesmanager](https://user-images.githubusercontent.com/85614308/157585834-16506a5f-a125-4795-bb56-ad3746161cda.gif)

if item line is partially billed or delivered. Prevent item code from being updated.

**Purchase Order**
![Purchase Order (billed)](https://user-images.githubusercontent.com/85614308/157586044-d3f2f12f-b0e8-4e15-b29d-414c639a86a5.gif)
**Sales Order**
![Sales Order (billed)](https://user-images.githubusercontent.com/85614308/157586059-b2dbf835-794e-4074-baf3-474698381fcf.gif)

