### PR TITLE
fix: Sales and Purchase return optimization

### DIFF
--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -208,7 +208,7 @@ def get_already_returned_items(doc):
 
 	return items
 
-def get_returned_qty_map_for_row(row_name, doctype):
+def get_returned_qty_map_for_row(return_against, supplier, row_name, doctype):
 	child_doctype = doctype + " Item"
 	reference_field = "dn_detail" if doctype == "Delivery Note" else frappe.scrub(child_doctype)
 
@@ -226,9 +226,12 @@ def get_returned_qty_map_for_row(row_name, doctype):
 		if doctype == "Purchase Receipt":
 			fields += ["sum(abs(`tab{0}`.received_stock_qty)) as received_stock_qty".format(child_doctype)]
 
+	# Used retrun against and supplier and is_retrun because there is an index added for it
 	data = frappe.db.get_list(doctype,
 		fields = fields,
 		filters = [
+			[doctype, "return_against", "=", return_against],
+			[doctype, "supplier", "=", supplier],
 			[doctype, "docstatus", "=", 1],
 			[doctype, "is_return", "=", 1],
 			[child_doctype, reference_field, "=", row_name]
@@ -307,7 +310,7 @@ def make_return_doc(doctype, source_name, target_doc=None):
 				target_doc.serial_no = '\n'.join(serial_nos)
 
 		if doctype == "Purchase Receipt":
-			returned_qty_map = get_returned_qty_map_for_row(source_doc.name, doctype)
+			returned_qty_map = get_returned_qty_map_for_row(source_parent.name, source_parent.supplier, source_doc.name, doctype)
 			target_doc.received_qty = -1 * flt(source_doc.received_qty - (returned_qty_map.get('received_qty') or 0))
 			target_doc.rejected_qty = -1 * flt(source_doc.rejected_qty - (returned_qty_map.get('rejected_qty') or 0))
 			target_doc.qty = -1 * flt(source_doc.qty - (returned_qty_map.get('qty') or 0))
@@ -321,7 +324,7 @@ def make_return_doc(doctype, source_name, target_doc=None):
 			target_doc.purchase_receipt_item = source_doc.name
 
 		elif doctype == "Purchase Invoice":
-			returned_qty_map = get_returned_qty_map_for_row(source_doc.name, doctype)
+			returned_qty_map = get_returned_qty_map_for_row(source_parent.name, source_parent.supplier, source_doc.name, doctype)
 			target_doc.received_qty = -1 * flt(source_doc.received_qty - (returned_qty_map.get('received_qty') or 0))
 			target_doc.rejected_qty = -1 * flt(source_doc.rejected_qty - (returned_qty_map.get('rejected_qty') or 0))
 			target_doc.qty = -1 * flt(source_doc.qty - (returned_qty_map.get('qty') or 0))
@@ -335,7 +338,7 @@ def make_return_doc(doctype, source_name, target_doc=None):
 			target_doc.purchase_invoice_item = source_doc.name
 
 		elif doctype == "Delivery Note":
-			returned_qty_map = get_returned_qty_map_for_row(source_doc.name, doctype)
+			returned_qty_map = get_returned_qty_map_for_row(source_parent.name, source_parent.supplier, source_doc.name, doctype)
 			target_doc.qty = -1 * flt(source_doc.qty - (returned_qty_map.get('qty') or 0))
 			target_doc.stock_qty = -1 * flt(source_doc.stock_qty - (returned_qty_map.get('stock_qty') or 0))
 
@@ -348,7 +351,7 @@ def make_return_doc(doctype, source_name, target_doc=None):
 			if default_warehouse_for_sales_return:
 				target_doc.warehouse = default_warehouse_for_sales_return
 		elif doctype == "Sales Invoice" or doctype == "POS Invoice":
-			returned_qty_map = get_returned_qty_map_for_row(source_doc.name, doctype)
+			returned_qty_map = get_returned_qty_map_for_row(source_parent.name, source_parent.supplier, source_doc.name, doctype)
 			target_doc.qty = -1 * flt(source_doc.qty - (returned_qty_map.get('qty') or 0))
 			target_doc.stock_qty = -1 * flt(source_doc.stock_qty - (returned_qty_map.get('stock_qty') or 0))
 

--- a/erpnext/stock/doctype/delivery_note/delivery_note.json
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.json
@@ -1315,7 +1315,7 @@
  "idx": 146,
  "is_submittable": 1,
  "links": [],
- "modified": "2021-10-09 14:29:13.428984",
+ "modified": "2022-03-10 14:29:13.428984",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Note",

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -798,3 +798,6 @@ def make_inter_company_transaction(doctype, source_name, target_doc=None):
 	}, target_doc, set_missing_values)
 
 	return doclist
+
+def on_doctype_update():
+	frappe.db.add_index("Delivery Note", ["customer", "is_return", "return_against"])

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.json
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.json
@@ -1165,7 +1165,7 @@
  "idx": 261,
  "is_submittable": 1,
  "links": [],
- "modified": "2022-02-01 11:40:52.690984",
+ "modified": "2022-03-10 11:40:52.690984",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Purchase Receipt",

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -926,3 +926,6 @@ def get_item_account_wise_additional_cost(purchase_document):
 						account.base_amount * item.get(based_on_field) / total_item_cost
 
 	return item_account_wise_cost
+
+def on_doctype_update():
+	frappe.db.add_index("Purchase Receipt", ["supplier", "is_return", "return_against"])


### PR DESCRIPTION
Trying to create a return invoice (Credit Note) against a purchase invoice that has a lot of items (around 250+) and when the database size is comparatively large (have a lot of other purchase invoices) the credit note creation request gets timed out because the `get_returned_qty_map_for_row` has a query which takes a lot of time. 

Solution:
Modified the query to use an already existing index due to which the query time is reduced. Also added the same index for some missing doctypes 