### PR TITLE
fix(psoa): no such element: dict object['account']

### DIFF
--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.html
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.html
@@ -64,10 +64,10 @@
 				<td></td>
 				<td><b>{{ frappe.format(row.account, {fieldtype: "Link"}) or "&nbsp;" }}</b></td>
 				<td style="text-align: right">
-					{{ row.account and frappe.utils.fmt_money(row.debit, currency=filters.presentation_currency) }}
+					{{ row.get('account', '') and frappe.utils.fmt_money(row.debit, currency=filters.presentation_currency) }}
 				</td>
 				<td style="text-align: right">
-					{{ row.account and frappe.utils.fmt_money(row.credit, currency=filters.presentation_currency) }}
+					{{ row.get('account', '') and frappe.utils.fmt_money(row.credit, currency=filters.presentation_currency) }}
 				</td>
 			{% endif %}
 				<td style="text-align: right">


### PR DESCRIPTION
If Group By is set as Group By Voucher, the Statement of Account PDF contains these

![CleanShot 2022-03-10 at 11 13 21@2x](https://user-images.githubusercontent.com/25369014/157597276-b451bc1b-2d5b-43d6-a180-9316003bf6dc.png)

