### PR TITLE
fix: Add cost center in loan document

### DIFF
--- a/erpnext/loan_management/doctype/loan/loan.json
+++ b/erpnext/loan_management/doctype/loan/loan.json
@@ -32,6 +32,8 @@
   "monthly_repayment_amount",
   "repayment_start_date",
   "is_term_loan",
+  "accounting_dimensions_section",
+  "cost_center",
   "account_info",
   "mode_of_payment",
   "disbursement_account",
@@ -366,12 +368,23 @@
    "options": "Account",
    "read_only": 1,
    "reqd": 1
+  },
+  {
+   "fieldname": "accounting_dimensions_section",
+   "fieldtype": "Section Break",
+   "label": "Accounting Dimensions"
+  },
+  {
+   "fieldname": "cost_center",
+   "fieldtype": "Link",
+   "label": "Cost Center",
+   "options": "Cost Center"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2022-01-25 16:29:16.325501",
+ "modified": "2022-03-10 11:50:31.957360",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan",

--- a/erpnext/loan_management/doctype/loan/loan.py
+++ b/erpnext/loan_management/doctype/loan/loan.py
@@ -25,6 +25,7 @@ class Loan(AccountsController):
 		self.set_loan_amount()
 		self.validate_loan_amount()
 		self.set_missing_fields()
+		self.validate_cost_center()
 		self.validate_accounts()
 		self.check_sanctioned_amount_limit()
 		self.validate_repay_from_salary()
@@ -44,6 +45,13 @@ class Loan(AccountsController):
 			if company != self.company:
 				frappe.throw(_("Account {0} does not belongs to company {1}").format(frappe.bold(self.get(fieldname)),
 					frappe.bold(self.company)))
+
+	def validate_cost_center(self):
+		if not self.cost_center and self.rate_of_interest != 0:
+			self.cost_center = frappe.db.get_value('Company', self.company, 'cost_center')
+
+		if not self.cost_center:
+			frappe.throw(_('Cost center is mandatory for loans having rate of interest greater than 0'))
 
 	def on_submit(self):
 		self.link_loan_security_pledge()

--- a/erpnext/loan_management/doctype/loan_interest_accrual/loan_interest_accrual.py
+++ b/erpnext/loan_management/doctype/loan_interest_accrual/loan_interest_accrual.py
@@ -6,7 +6,6 @@ import frappe
 from frappe import _
 from frappe.utils import add_days, cint, date_diff, flt, get_datetime, getdate, nowdate
 
-import erpnext
 from erpnext.accounts.general_ledger import make_gl_entries
 from erpnext.controllers.accounts_controller import AccountsController
 
@@ -41,6 +40,8 @@ class LoanInterestAccrual(AccountsController):
 	def make_gl_entries(self, cancel=0, adv_adj=0):
 		gle_map = []
 
+		cost_center = frappe.db.get_value('Loan', self.loan, 'cost_center')
+
 		if self.interest_amount:
 			gle_map.append(
 				self.get_gl_dict({
@@ -54,7 +55,7 @@ class LoanInterestAccrual(AccountsController):
 					"against_voucher": self.loan,
 					"remarks": _("Interest accrued from {0} to {1} against loan: {2}").format(
 						self.last_accrual_date, self.posting_date, self.loan),
-					"cost_center": erpnext.get_default_cost_center(self.company),
+					"cost_center": cost_center,
 					"posting_date": self.posting_date
 				})
 			)
@@ -69,7 +70,7 @@ class LoanInterestAccrual(AccountsController):
 					"against_voucher": self.loan,
 					"remarks": ("Interest accrued from {0} to {1} against loan: {2}").format(
 						self.last_accrual_date, self.posting_date, self.loan),
-					"cost_center": erpnext.get_default_cost_center(self.company),
+					"cost_center": cost_center,
 					"posting_date": self.posting_date
 				})
 			)

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -358,3 +358,4 @@ erpnext.patches.v13_0.update_accounts_in_loan_docs
 erpnext.patches.v14_0.update_batch_valuation_flag
 erpnext.patches.v14_0.delete_non_profit_doctypes
 erpnext.patches.v14_0.update_employee_advance_status
+erpnext.patches.v13_0.add_cost_center_in_loans

--- a/erpnext/patches/v13_0/add_cost_center_in_loans.py
+++ b/erpnext/patches/v13_0/add_cost_center_in_loans.py
@@ -1,0 +1,16 @@
+import frappe
+
+
+def execute():
+	frappe.reload_doc('loan_management', 'doctype', 'loan')
+	loan = frappe.qb.DocType('Loan')
+
+	for company in frappe.get_all('Company', pluck='name'):
+		default_cost_center = frappe.db.get_value('Company', company, 'cost_center')
+		frappe.qb.update(
+			loan
+		).set(
+			loan.cost_center, default_cost_center
+		).where(
+			loan.company == company
+		).run()


### PR DESCRIPTION
Currently, the Loan Interest Accrual booking relies on the default cost center mentioned in the company master for booking the loan accounting entries.

This has 2 problems:

1. The loan Interest Accrual fails if the default cost center is not updated in the company master.
2. User cannot use multiple cost centers for different loans.


Added cost center field in Loan Doctype for user to select along with proper validation