### PR TITLE
fix: 'save_quotations_as_draft' checkbox not honoured

### DIFF
--- a/erpnext/e_commerce/shopping_cart/cart.py
+++ b/erpnext/e_commerce/shopping_cart/cart.py
@@ -120,7 +120,11 @@ def place_order():
 def request_for_quotation():
 	quotation = _get_cart_quotation()
 	quotation.flags.ignore_permissions = True
-	quotation.submit()
+
+	if get_shopping_cart_settings().save_quotations_as_draft:
+		quotation.save()
+	else:
+		quotation.submit()
 	return quotation.name
 
 @frappe.whitelist()

--- a/erpnext/e_commerce/shopping_cart/test_shopping_cart.py
+++ b/erpnext/e_commerce/shopping_cart/test_shopping_cart.py
@@ -6,7 +6,7 @@ import unittest
 
 import frappe
 from frappe.tests.utils import change_settings
-from frappe.utils import add_months, nowdate
+from frappe.utils import add_months, cint, nowdate
 
 from erpnext.accounts.doctype.tax_rule.tax_rule import ConflictingTaxRule
 from erpnext.e_commerce.doctype.website_item.website_item import make_website_item
@@ -14,22 +14,17 @@ from erpnext.e_commerce.shopping_cart.cart import (
 	_get_cart_quotation,
 	get_cart_quotation,
 	get_party,
+	request_for_quotation,
 	update_cart,
 )
 from erpnext.tests.utils import create_test_contact_and_address
 
-# test_dependencies = ['Payment Terms Template']
 
 class TestShoppingCart(unittest.TestCase):
 	"""
 		Note:
 		Shopping Cart == Quotation
 	"""
-
-	@classmethod
-	def tearDownClass(cls):
-		frappe.db.sql("delete from `tabTax Rule`")
-
 	def setUp(self):
 		frappe.set_user("Administrator")
 		create_test_contact_and_address()
@@ -44,6 +39,10 @@ class TestShoppingCart(unittest.TestCase):
 		frappe.db.rollback()
 		frappe.set_user("Administrator")
 		self.disable_shopping_cart()
+
+	@classmethod
+	def tearDownClass(cls):
+		frappe.db.sql("delete from `tabTax Rule`")
 
 	def test_get_cart_new_user(self):
 		self.login_as_new_user()
@@ -178,6 +177,28 @@ class TestShoppingCart(unittest.TestCase):
 
 		# test if items are rendered without error
 		frappe.render_template("templates/includes/cart/cart_items.html", cart)
+
+	@change_settings("E Commerce Settings",{
+		"save_quotations_as_draft": 1
+	})
+	def test_cart_without_checkout_and_draft_quotation(self):
+		"Test impact of 'save_quotations_as_draft' checkbox."
+		frappe.local.shopping_cart_settings = None
+
+		# add item to cart
+		update_cart("_Test Item", 1)
+		quote_name = request_for_quotation() # Request for Quote
+		quote_doctstatus = cint(frappe.db.get_value("Quotation", quote_name, "docstatus"))
+
+		self.assertEqual(quote_doctstatus, 0)
+
+		frappe.db.set_value("E Commerce Settings", None, "save_quotations_as_draft", 0)
+		frappe.local.shopping_cart_settings = None
+		update_cart("_Test Item", 1)
+		quote_name = request_for_quotation() # Request for Quote
+		quote_doctstatus = cint(frappe.db.get_value("Quotation", quote_name, "docstatus"))
+
+		self.assertEqual(quote_doctstatus, 1)
 
 	def create_tax_rule(self):
 		tax_rule = frappe.get_test_records("Tax Rule")[0]


### PR DESCRIPTION
**Issue:**
- Quotations were submitted even though `save_quotations_as_draft` was enabled in E commerce Settings

**Fix:**
- Make sure `request_for_quotation` considers `save_quotations_as_draft`
- Added test for checkout disabled quote
