### PR TITLE
fix: dont reset UOM in MR on every get_item_detail call

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -214,6 +214,7 @@ frappe.ui.form.on('Material Request', {
 					material_request_type: frm.doc.material_request_type,
 					plc_conversion_rate: 1,
 					rate: item.rate,
+					uom: item.uom,
 					conversion_factor: item.conversion_factor
 				},
 				overwrite_warehouse: overwrite_warehouse
@@ -392,6 +393,7 @@ frappe.ui.form.on("Material Request Item", {
 	item_code: function(frm, doctype, name) {
 		const item = locals[doctype][name];
 		item.rate = 0;
+		item.uom = '';
 		set_schedule_date(frm);
 		frm.events.get_item_data(frm, item, true);
 	},


### PR DESCRIPTION
Steps to reproduce:

1. Have an item having separate stock UOM and sales UOM2. Create sales orders with sales UOM
3. Create New Material Request
4. Click on the button "Get items from sales order"
5. Item table of material requests is loaded.
6. Try to change the quantity of any row, the UOM changes to stock UOM, which should not happen as there is already stock UOM and stock qty fields.


This is not limited to qty, other fields can also trigger item detail update which resets UOM right now. 

TODO:
- [x] reset UOM when item changes. 