### PR TITLE
fix: cannot create multicurrency sales order with product bundles

### DIFF
--- a/erpnext/stock/doctype/packed_item/packed_item.json
+++ b/erpnext/stock/doctype/packed_item/packed_item.json
@@ -223,6 +223,7 @@
    "fieldtype": "Currency",
    "in_list_view": 1,
    "label": "Rate",
+   "options": "currency",
    "print_hide": 1,
    "read_only": 1
   },
@@ -239,7 +240,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2022-02-22 12:57:45.325488",
+ "modified": "2022-03-10 15:42:00.265915",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Packed Item",

--- a/erpnext/stock/doctype/packed_item/packed_item.py
+++ b/erpnext/stock/doctype/packed_item/packed_item.py
@@ -185,7 +185,8 @@ def update_packed_item_price_data(pi_row, item_data, doc):
 	row_data.update({
 		"company": doc.get("company"),
 		"price_list": doc.get("selling_price_list"),
-		"currency": doc.get("currency")
+		"currency": doc.get("currency"),
+		"conversion_rate": doc.get("conversion_rate"),
 	})
 	rate = get_price_list_rate(row_data, item_doc).get("price_list_rate")
 


### PR DESCRIPTION
Problem:

- Create a multi-currency Sales Order
- Add a Product Bundle as an Item and save
- While fetching the prices of the sub-items there's an error thrown "Exchange Rate is mandatory. Maybe Currency Exchange record is not created for USD to INR."