### PR TITLE
fix: fetch new fields from routing to bom

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -192,7 +192,8 @@ class BOM(WebsiteGenerator):
 		if self.routing:
 			self.set("operations", [])
 			fields = ["sequence_id", "operation", "workstation", "description",
-				"time_in_mins", "batch_size", "operating_cost", "idx", "hour_rate"]
+				"time_in_mins", "batch_size", "operating_cost", "idx", "hour_rate",
+				"set_cost_based_on_bom_qty", "fixed_time"]
 
 			for row in frappe.get_all("BOM Operation", fields = fields,
 				filters = {'parenttype': 'Routing', 'parent': self.routing}, order_by="sequence_id, idx"):

--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -198,7 +198,7 @@ class BOM(WebsiteGenerator):
 			for row in frappe.get_all("BOM Operation", fields = fields,
 				filters = {'parenttype': 'Routing', 'parent': self.routing}, order_by="sequence_id, idx"):
 				child = self.append('operations', row)
-				child.hour_rate = flt(row.hour_rate / self.conversion_rate, 2)
+				child.hour_rate = flt(row.hour_rate / self.conversion_rate, child.precision("hour_rate"))
 
 	def set_bom_material_details(self):
 		for item in self.get("items"):

--- a/erpnext/manufacturing/doctype/bom_operation/bom_operation.json
+++ b/erpnext/manufacturing/doctype/bom_operation/bom_operation.json
@@ -66,7 +66,8 @@
    "label": "Hour Rate",
    "oldfieldname": "hour_rate",
    "oldfieldtype": "Currency",
-   "options": "currency"
+   "options": "currency",
+   "precision": "2"
   },
   {
    "description": "In minutes",
@@ -186,7 +187,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2021-12-15 03:00:00.473173",
+ "modified": "2022-03-10 06:19:08.462027",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "BOM Operation",


### PR DESCRIPTION
Problem: Newly added fields like "set_cost_based_on_bom_qty" (checkbox) aren't properly mapped to BOM while fetched from routing. 

Steps to reproduce:
1. Create routing with "set_cost_based_on_bom_qty" checked in operation
2. Create BOM. Set routing and save.
3. The field value won't be fetched.