### PR TITLE
fix: Allow on Submit for Material Request Item Required Date

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -85,7 +85,7 @@ class MaterialRequest(BuyingController):
 
 	def before_update_after_submit(self):
 		self.validate_schedule_date()
-		
+
 	def validate_material_request_type(self):
 		""" Validate fields in accordance with selected type """
 

--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -83,6 +83,9 @@ class MaterialRequest(BuyingController):
 		self.reset_default_field_value("set_warehouse", "items", "warehouse")
 		self.reset_default_field_value("set_from_warehouse", "items", "from_warehouse")
 
+	def before_update_after_submit(self):
+		self.validate_schedule_date()
+		
 	def validate_material_request_type(self):
 		""" Validate fields in accordance with selected type """
 

--- a/erpnext/stock/doctype/material_request_item/material_request_item.json
+++ b/erpnext/stock/doctype/material_request_item/material_request_item.json
@@ -177,6 +177,7 @@
    "fieldtype": "Column Break"
   },
   {
+   "allow_on_submit": 1,
    "bold": 1,
    "columns": 2,
    "fieldname": "schedule_date",
@@ -459,7 +460,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2021-11-03 14:40:24.409826",
+ "modified": "2022-03-10 18:42:42.705190",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Material Request Item",


### PR DESCRIPTION
### ISSUE
User not able to change/update the Required Date after Submitting, but the main(parent) document has "Allow on Submit" for Required date.

### SOLUTION
Allow user to Update the Required Date Item wise after Submitting the document.