### PR TITLE
fix(pos): do not reset mode of payments in case of consolidation

### DIFF
--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -633,7 +633,12 @@ class calculate_taxes_and_totals(object):
 			self.doc.outstanding_amount = flt(total_amount_to_pay - flt(paid_amount) + flt(change_amount),
 				self.doc.precision("outstanding_amount"))
 
-			if self.doc.doctype == 'Sales Invoice' and self.doc.get('is_pos') and self.doc.get('is_return'):
+			if (
+				self.doc.doctype == 'Sales Invoice'
+				and self.doc.get('is_pos')
+				and self.doc.get('is_return')
+				and not self.doc.get('is_consolidated')
+			):
 				self.set_total_amount_to_default_mop(total_amount_to_pay)
 				self.calculate_paid_amount()
 


### PR DESCRIPTION
In the following case, the mode of payment is incorrect after consolidation. 
- POS Profile has 2 modes of payments configured, Cash (default) and Wire Transfer 
- A return POS Invoice has the mode of payment as Wire Transfer
- While consolidating this POS Invoice into Sales Invoice, the mode of payment is automatically changed to Cash (default)