### PR TITLE
fix: max_qty validation condition in WO

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
@@ -605,6 +605,17 @@ class TestProductionPlan(ERPNextTestCase):
 		]
 		self.assertFalse(pp.all_items_completed())
 
+	def test_production_plan_planned_qty(self):
+		pln = create_production_plan(item_code="_Test FG Item", planned_qty=0.55)
+		pln.make_work_order()
+		work_order = frappe.db.get_value('Work Order', {'production_plan': pln.name}, 'name')
+		wo_doc = frappe.get_doc('Work Order', work_order)
+		wo_doc.update({
+			'wip_warehouse': 'Work In Progress - _TC',
+			'fg_warehouse': 'Finished Goods - _TC'
+		})
+		wo_doc.submit()
+		self.assertEqual(wo_doc.qty, 0.55)
 
 def create_production_plan(**args):
 	"""

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -635,12 +635,12 @@ class WorkOrder(Document):
 		if self.production_plan and self.production_plan_item:
 			qty_dict = frappe.db.get_value("Production Plan Item", self.production_plan_item, ["planned_qty", "ordered_qty"], as_dict=1)
 
-			allowance_qty =flt(frappe.db.get_single_value("Manufacturing Settings",
+			allowance_qty = flt(frappe.db.get_single_value("Manufacturing Settings",
 			"overproduction_percentage_for_work_order"))/100 * qty_dict.get("planned_qty", 0)
 
 			max_qty = qty_dict.get("planned_qty", 0) + allowance_qty - qty_dict.get("ordered_qty", 0)
 
-			if max_qty < 1:
+			if not max_qty > 0:
 				frappe.throw(_("Cannot produce more item for {0}")
 				.format(self.production_item), OverProductionError)
 			elif self.qty > max_qty:


### PR DESCRIPTION
#### Source/Reference: ISS-21-22-13306

### Issue(s): Work Order

_Problem:_
- Since we can have decimal value for Qty. If the Max Qty is less than "1" the error will be thrown.

_Proposed Solution:_
- Error will throw if the planned qty is not greater than "0".