### PR TITLE
fix: disable "get items" buttons from submitted production plan

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.json
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.json
@@ -190,7 +190,7 @@
    "label": "Select Items to Manufacture"
   },
   {
-   "depends_on": "get_items_from",
+   "depends_on": "eval:doc.get_items_from && doc.docstatus == 0",
    "fieldname": "get_items",
    "fieldtype": "Button",
    "label": "Get Finished Goods for Manufacture"
@@ -198,6 +198,7 @@
   {
    "fieldname": "po_items",
    "fieldtype": "Table",
+   "label": "Assembly Items",
    "no_copy": 1,
    "options": "Production Plan Item",
    "reqd": 1
@@ -350,6 +351,7 @@
    "hide_border": 1
   },
   {
+   "depends_on": "get_items_from",
    "fieldname": "sub_assembly_items",
    "fieldtype": "Table",
    "label": "Sub Assembly Items",
@@ -357,6 +359,7 @@
    "options": "Production Plan Sub Assembly Item"
   },
   {
+   "depends_on": "eval:doc.po_items && doc.po_items.length && doc.docstatus == 0",
    "fieldname": "get_sub_assembly_items",
    "fieldtype": "Button",
    "label": "Get Sub Assembly Items"
@@ -382,7 +385,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2022-02-23 17:16:10.629378",
+ "modified": "2022-03-14 03:56:23.209247",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Production Plan",
@@ -404,5 +407,6 @@
   }
  ],
  "sort_field": "modified",
- "sort_order": "ASC"
+ "sort_order": "ASC",
+ "states": []
 }

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -359,3 +359,4 @@ erpnext.patches.v14_0.update_batch_valuation_flag
 erpnext.patches.v14_0.delete_non_profit_doctypes
 erpnext.patches.v14_0.update_employee_advance_status
 erpnext.patches.v13_0.add_cost_center_in_loans
+erpnext.patches.v13_0.remove_unknown_links_to_prod_plan_items

--- a/erpnext/patches/v13_0/remove_unknown_links_to_prod_plan_items.py
+++ b/erpnext/patches/v13_0/remove_unknown_links_to_prod_plan_items.py
@@ -1,0 +1,34 @@
+import frappe
+
+
+def execute():
+	"""
+	Remove "production_plan_item" field where linked field doesn't exist in tha table.
+	"""
+
+	work_order = frappe.qb.DocType("Work Order")
+	pp_item = frappe.qb.DocType("Production Plan Item")
+
+	broken_work_orders = (
+		frappe.qb
+			.from_(work_order)
+			.left_join(pp_item).on(work_order.production_plan_item == pp_item.name)
+			.select(work_order.name)
+			.where(
+				(work_order.docstatus == 0)
+				& (work_order.production_plan_item.notnull())
+				& (work_order.production_plan_item.like("new-production-plan%"))
+				& (pp_item.name.isnull())
+			)
+	).run(pluck=True)
+
+	if not broken_work_orders:
+		return
+
+	(frappe.qb
+		.update(work_order)
+		.set(work_order.production_plan_item, None)
+		.where(work_order.name.isin(broken_work_orders))
+	).run()
+
+


### PR DESCRIPTION
![telegram-cloud-photo-size-5-6159229316215451305-y](https://user-images.githubusercontent.com/9079960/158132159-1d332a38-4625-4361-8c48-e0e56cfbe3fc.jpg)


In bizarre cases when the doc is submitted and these buttons are clicked again it adds new rows to the production items table. 

If work orders are created from this client-side doc, they will be linked to a non-existing plan item.


Fix: remove buttons and patch data. 

