### PR TITLE
fix: Search query of payroll entry reference in Journal Entry

### DIFF
--- a/erpnext/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/erpnext/payroll/doctype/payroll_entry/payroll_entry.py
@@ -671,7 +671,7 @@ def get_payroll_entries_for_jv(doctype, txt, searchfield, start, page_len, filte
 				where reference_type="Payroll Entry")
 		order by name limit %(start)s, %(page_len)s"""
 		.format(key=searchfield), {
-			'txt': "%%%s%%" % frappe.db.escape(txt),
+			'txt': "%%%s%%" % txt,
 			'start': start, 'page_len': page_len
 		})
 


### PR DESCRIPTION
Issue:
In the Journal Entry child table, "Reference name" does not populate if "Reference Type" is selected as "Payroll Entry".

<img width="996" alt="Screenshot 2022-03-14 at 2 18 20 PM" src="https://user-images.githubusercontent.com/836784/158137154-0b292510-b652-48c6-a43d-77c1c695d0f1.png">


Fix:
After this fix, it will show all the Payroll Entry records against which bank entry has not been created.


root cause: double escaping. 