### PR TITLE
fix: While creating Payment Request from other forms, open a new Payment Request form without saving

### DIFF
--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -376,8 +376,8 @@ def make_payment_request(**args):
 		if args.order_type == "Shopping Cart" or args.mute_email:
 			pr.flags.mute_email = True
 
-		pr.insert(ignore_permissions=True)
 		if args.submit_doc:
+			pr.insert(ignore_permissions=True)
 			pr.submit()
 
 	if args.order_type == "Shopping Cart":

--- a/erpnext/accounts/doctype/payment_request/test_payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/test_payment_request.py
@@ -128,6 +128,7 @@ class TestPaymentRequest(unittest.TestCase):
 		pr1 = make_payment_request(dt="Sales Order", dn=so.name,
 			recipient_id="nabin@erpnext.com", return_doc=1)
 		pr1.grand_total = 200
+		pr1.insert()
 		pr1.submit()
 
 		# Make a 2nd Payment Request

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -456,6 +456,7 @@ class POSInvoice(SalesInvoice):
 				pay_req = self.get_existing_payment_request(pay)
 				if not pay_req:
 					pay_req = self.get_new_payment_request(pay)
+					pay_req.insert()
 					pay_req.submit()
 				else:
 					pay_req.request_phone_payment()


### PR DESCRIPTION
Issue:

Currently, while creating a Payment Request from other forms, the system saves a Payment Request and then redirect it to the new record. It does not allow to user to choose a different series for the Payment Request.

Fix:

Redirect to the new Payment Request after mapping proper data but without saving the record. It will allow the user to choose any other series.