### PR TITLE
fix: KSA E-Invoice QR Code showing wrong VAT amount

### DIFF
--- a/erpnext/regional/saudi_arabia/utils.py
+++ b/erpnext/regional/saudi_arabia/utils.py
@@ -130,7 +130,7 @@ def create_qr_code(doc, method=None):
 def get_vat_amount(doc):
 	vat_settings = frappe.db.get_value('KSA VAT Setting', {'company': doc.company})
 	vat_accounts = []
-	vat_amount  = 0
+	vat_amount = 0
 
 	if vat_settings:
 		vat_settings_doc = frappe.get_doc('KSA VAT Setting', vat_settings)

--- a/erpnext/regional/saudi_arabia/utils.py
+++ b/erpnext/regional/saudi_arabia/utils.py
@@ -90,7 +90,7 @@ def create_qr_code(doc, method=None):
 		tlv_array.append(''.join([tag, length, value]))
 
 		# VAT Amount
-		vat_amount = str(doc.total_taxes_and_charges)
+		vat_amount = str(get_vat_amount(doc))
 
 		tag = bytes([5]).hex()
 		length = bytes([len(vat_amount)]).hex()
@@ -127,6 +127,22 @@ def create_qr_code(doc, method=None):
 		doc.db_set('ksa_einv_qr', _file.file_url)
 		doc.notify_update()
 
+def get_vat_amount(doc):
+	vat_settings = frappe.db.get_value('KSA VAT Setting', {'company': doc.company})
+	vat_accounts = []
+	vat_amount  = 0
+
+	if vat_settings:
+		vat_settings_doc = frappe.get_doc('KSA VAT Setting', vat_settings)
+
+		for row in vat_settings_doc.get('ksa_vat_sales_accounts'):
+			vat_accounts.append(row.account)
+
+	for tax in doc.get('taxes'):
+		if tax.account_head in vat_accounts:
+			vat_amount += tax.tax_amount
+
+	return vat_amount
 
 def delete_qr_code_file(doc, method=None):
 	region = get_region(doc.company)

--- a/erpnext/regional/saudi_arabia/utils.py
+++ b/erpnext/regional/saudi_arabia/utils.py
@@ -133,7 +133,7 @@ def get_vat_amount(doc):
 	vat_amount = 0
 
 	if vat_settings:
-		vat_settings_doc = frappe.get_doc('KSA VAT Setting', vat_settings)
+		vat_settings_doc = frappe.get_cached_doc('KSA VAT Setting', vat_settings)
 
 		for row in vat_settings_doc.get('ksa_vat_sales_accounts'):
 			vat_accounts.append(row.account)

--- a/erpnext/regional/united_arab_emirates/utils.py
+++ b/erpnext/regional/united_arab_emirates/utils.py
@@ -26,9 +26,12 @@ def update_itemised_tax_data(doc):
 		elif row.item_code and itemised_tax.get(row.item_code):
 			tax_rate = sum([tax.get('tax_rate', 0) for d, tax in itemised_tax.get(row.item_code).items()])
 
-		row.tax_rate = flt(tax_rate, row.precision("tax_rate"))
-		row.tax_amount = flt((row.net_amount * tax_rate) / 100, row.precision("net_amount"))
-		row.total_amount = flt((row.net_amount + row.tax_amount), row.precision("total_amount"))
+		meta = frappe.get_meta(row.doctype)
+
+		if meta.has_field('tax_rate'):
+			row.tax_rate = flt(tax_rate, row.precision("tax_rate"))
+			row.tax_amount = flt((row.net_amount * tax_rate) / 100, row.precision("net_amount"))
+			row.total_amount = flt((row.net_amount + row.tax_amount), row.precision("total_amount"))
 
 def get_account_currency(account):
 	"""Helper function to get account currency."""


### PR DESCRIPTION
VAT Amount incorrect in KSA VAT Amount

<img width="1342" alt="Screenshot 2022-03-14 at 4 21 34 PM" src="https://user-images.githubusercontent.com/42651287/158158033-9b0a8c71-a650-478b-8d3d-70948634cf69.png">

Before (Incorrect):
![Before](https://user-images.githubusercontent.com/42651287/158158490-933b7ae0-7f6f-4d7c-a5ec-f9a055a164d6.jpg)

After (Correct):
![After](https://user-images.githubusercontent.com/42651287/158158512-71e6c76e-65c1-40a1-b0ff-5e2bbf83eb85.jpg)