### PR TITLE
fix(ux): negative stock warning

### DIFF
--- a/erpnext/stock/doctype/stock_settings/stock_settings.js
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.js
@@ -13,5 +13,24 @@ frappe.ui.form.on('Stock Settings', {
 
 		frm.set_query("default_warehouse", filters);
 		frm.set_query("sample_retention_warehouse", filters);
+	},
+	allow_negative_stock: function(frm) {
+		if (!frm.doc.allow_negative_stock) {
+			return;
+		}
+
+		let msg = __("Using negative stock disables FIFO/Moving average valuation when inventory is negative.");
+		msg += " ";
+		msg += __("This is considered dangerous from accounting point of view.")
+		msg += "<br>";
+		msg += ("Do you still want to enable negative inventory?");
+
+		frappe.confirm(
+			msg,
+			() => {},
+			() => {
+				frm.set_value("allow_negative_stock", 0);
+			}
+		);
 	}
 });


### PR DESCRIPTION
part of https://github.com/frappe/erpnext/issues/28990 

Show warning before enabling negative stock. We have often heard that users enable this without knowing the consequences of it.
<img width="933" alt="Screenshot 2022-03-14 at 4 34 02 PM" src="https://user-images.githubusercontent.com/9079960/158159702-10fc7d7d-1c13-48fc-88ce-481c9b1d41db.png">

