### PR TITLE
fix: Job Card sub operations status and list view

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -48,7 +48,7 @@ class JobCard(Document):
 		self.validate_work_order()
 
 	def set_sub_operations(self):
-		if self.operation:
+		if not self.sub_operations and self.operation:
 			self.sub_operations = []
 			for row in frappe.get_all('Sub Operation',
 				filters = {'parent': self.operation}, fields=['operation', 'idx'], order_by='idx'):

--- a/erpnext/manufacturing/doctype/job_card/job_card_list.js
+++ b/erpnext/manufacturing/doctype/job_card/job_card_list.js
@@ -1,4 +1,5 @@
 frappe.listview_settings['Job Card'] = {
+	has_indicator_for_draft: true,
 	get_indicator: function(doc) {
 		if (doc.status === "Work In Progress") {
 			return [__("Work In Progress"), "orange", "status,=,Work In Progress"];


### PR DESCRIPTION
1 - Job Card - Sub Operations table status field on pause / resume
![Job-Card-Status-On-Pause](https://user-images.githubusercontent.com/3326959/158196868-acc911f6-bf9b-4f1f-809e-772b6f53d96d.gif)


Fix: reset and build sub operations table only if not already built
![Job-Card-Status-On-Pause-Fixed](https://user-images.githubusercontent.com/3326959/158193103-903b0010-2596-4e9a-b7ef-add098ca9406.gif)


2 - Job Card List View
![jc-before](https://user-images.githubusercontent.com/3326959/158189290-42be95e9-c459-4d6e-a8ae-265ba358d56c.png)
After the fix
![jc-after](https://user-images.githubusercontent.com/3326959/158189550-7d6d28d2-804d-4998-b594-a5241212ad8a.png)

