### PR TITLE
fix: incorrect debit credit amount in presentation currency

### DIFF
--- a/erpnext/accounts/report/general_ledger/test_general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/test_general_ledger.py
@@ -1,0 +1,134 @@
+# Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
+# MIT License. See license.txt
+
+import frappe
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import today
+
+from erpnext.accounts.report.general_ledger.general_ledger import execute
+
+
+class TestGeneralLedger(FrappeTestCase):
+
+	def test_foreign_account_balance_after_exchange_rate_revaluation(self):
+		"""
+		Checks the correctness of balance after exchange rate revaluation
+		"""
+		# create a new account with USD currency
+		account_name = "Test USD Account for Revalutation"
+		company = "_Test Company"
+		account = frappe.get_doc({
+			"account_name": account_name,
+			"is_group": 0,
+			"company": company,
+			"root_type": "Asset",
+			"report_type": "Balance Sheet",
+			"account_currency": "USD",
+			"inter_company_account": 0,
+			"parent_account": "Bank Accounts - _TC",
+			"account_type": "Bank",
+			"doctype": "Account"
+		})
+		account.insert(ignore_if_duplicate=True)
+		# create a JV to debit 1000 USD at 75 exchange rate
+		jv = frappe.new_doc("Journal Entry")
+		jv.posting_date = today()
+		jv.company = company
+		jv.multi_currency = 1
+		jv.cost_center = "_Test Cost Center - _TC"
+		jv.set("accounts", [
+			{
+				"account": account.name,
+				"debit_in_account_currency": 1000,
+				"credit_in_account_currency": 0,
+				"exchange_rate": 75,
+				"cost_center": "_Test Cost Center - _TC",
+			},
+			{
+				"account": "Cash - _TC",
+				"debit_in_account_currency": 0,
+				"credit_in_account_currency": 75000,
+				"cost_center": "_Test Cost Center - _TC",
+			},
+		])
+		jv.save()
+		jv.submit()
+		# create a JV to credit 900 USD at 100 exchange rate
+		jv = frappe.new_doc("Journal Entry")
+		jv.posting_date = today()
+		jv.company = company
+		jv.multi_currency = 1
+		jv.cost_center = "_Test Cost Center - _TC"
+		jv.set("accounts", [
+			{
+				"account": account.name,
+				"debit_in_account_currency": 0,
+				"credit_in_account_currency": 900,
+				"exchange_rate": 100,
+				"cost_center": "_Test Cost Center - _TC",
+			},
+			{
+				"account": "Cash - _TC",
+				"debit_in_account_currency": 90000,
+				"credit_in_account_currency": 0,
+				"cost_center": "_Test Cost Center - _TC",
+			},
+		])
+		jv.save()
+		jv.submit()
+
+		# create an exchange rate revaluation entry at 77 exchange rate
+		revaluation = frappe.new_doc("Exchange Rate Revaluation")
+		revaluation.posting_date = today()
+		revaluation.company = company
+		revaluation.set("accounts", [
+			{
+				"account": account.name,
+				"account_currency": "USD",
+				"new_exchange_rate": 77,
+				"new_balance_in_base_currency": 7700,
+				"balance_in_base_currency": -15000,
+				"balance_in_account_currency": 100,
+				"current_exchange_rate": -150
+			}
+		])
+		revaluation.save()
+		revaluation.submit()
+
+		# post journal entry to revaluate
+		frappe.db.set_value('Company',  company, "unrealized_exchange_gain_loss_account", "_Test Exchange Gain/Loss - _TC")
+		revaluation_jv = revaluation.make_jv_entry()
+		revaluation_jv = frappe.get_doc(revaluation_jv)
+		revaluation_jv.cost_center = "_Test Cost Center - _TC"
+		for acc in revaluation_jv.get("accounts"):
+			acc.cost_center = "_Test Cost Center - _TC"
+		revaluation_jv.save()
+		revaluation_jv.submit()
+
+		# check the balance of the account
+		balance = frappe.db.sql(
+			"""
+				select sum(debit_in_account_currency) - sum(credit_in_account_currency)
+				from `tabGL Entry`
+				where account = %s
+				group by account
+			""", account.name)
+
+		self.assertEqual(balance[0][0], 100)
+
+		# check if general ledger shows correct balance
+		columns, data = execute(frappe._dict({
+			"company": company,
+			"from_date": today(),
+			"to_date": today(),
+			"account": [account.name],
+			"group_by": "Group by Voucher (Consolidated)",
+		}))
+
+		self.assertEqual(data[1]["account"], account.name)
+		self.assertEqual(data[1]["debit"], 1000)
+		self.assertEqual(data[1]["credit"], 0)
+		self.assertEqual(data[2]["debit"], 0)
+		self.assertEqual(data[2]["credit"], 900)
+		self.assertEqual(data[3]["debit"], 100)
+		self.assertEqual(data[3]["credit"], 100)

--- a/erpnext/accounts/report/utils.py
+++ b/erpnext/accounts/report/utils.py
@@ -92,10 +92,10 @@ def convert_to_presentation_currency(gl_entries, currency_info, company):
 		account_currency = entry['account_currency']
 
 		if len(account_currencies) == 1 and account_currency == presentation_currency:
-			if entry.get('debit'):
+			if debit_in_account_currency:
 				entry['debit'] = debit_in_account_currency
 
-			if entry.get('credit'):
+			if credit_in_account_currency:
 				entry['credit'] = credit_in_account_currency
 		else:
 			date = currency_info['report_date']


### PR DESCRIPTION
Fix for the following case:

- Create a Foreign Currency Account eg. HDFC - USD
- Debit some amount via JV with an exchange rate of 75
- Credit some amount via JV with an exchange rate of 90
- Create an Exchange Rate Revaluation Entry with an exchange rate of 77
- Now General Ledger for HDFC - USD looks like this

  Account | Debit (USD) | Credit (USD) | Balance (USD)
  -- | -- | -- | --
  HDFC - USD | 1000 | 0 | 1000
  HDFC - USD | 0 | 900 | 100
  HDFC - USD | 100 | 0 | 200
  Total | 1100 | 900 | 200

- The balance is incorrect. It should have been 100. This is because the 3rd entry only shows the Debit amount while the GL Entry has the Credit amount too

---
After fix General Ledger shows

  Account | Debit (USD) | Credit (USD) | Balance (USD)
  -- | -- | -- | --
  HDFC - USD | 1000 | 0 | 1000
  HDFC - USD | 0 | 900 | 100
  HDFC - USD | 100 | 100 | 100
  Total | 1100 | 1000 | 100



