### PR TITLE
fix: salary slip amount rounding errors

### DIFF
--- a/erpnext/payroll/doctype/salary_slip/salary_slip.py
+++ b/erpnext/payroll/doctype/salary_slip/salary_slip.py
@@ -1002,7 +1002,7 @@ class SalarySlip(TransactionBase):
 
 		# apply rounding
 		if frappe.get_cached_value("Salary Component", row.salary_component, "round_to_the_nearest_integer"):
-			amount, additional_amount = rounded(amount), rounded(additional_amount)
+			amount, additional_amount = rounded(amount or 0), rounded(additional_amount or 0)
 
 		return amount, additional_amount
 
@@ -1279,9 +1279,9 @@ class SalarySlip(TransactionBase):
 	def set_base_totals(self):
 		self.base_gross_pay = flt(self.gross_pay) * flt(self.exchange_rate)
 		self.base_total_deduction = flt(self.total_deduction) * flt(self.exchange_rate)
-		self.rounded_total = rounded(self.net_pay)
+		self.rounded_total = rounded(self.net_pay or 0)
 		self.base_net_pay = flt(self.net_pay) * flt(self.exchange_rate)
-		self.base_rounded_total = rounded(self.base_net_pay)
+		self.base_rounded_total = rounded(self.base_net_pay or 0)
 		self.set_net_total_in_words()
 
 	#calculate total working hours, earnings based on hourly wages and totals


### PR DESCRIPTION
<details>
<summary>Traceback</summary>

```python
Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2021-06-22/apps/frappe/frappe/desk/form/[save.py](http://save.py/)", line 21, in savedocs
    doc.save()
  File "/home/frappe/benches/bench-version-12-2021-06-22/apps/frappe/frappe/model/[document.py](http://document.py/)", line 273, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2021-06-22/apps/frappe/frappe/model/[document.py](http://document.py/)", line 296, in _save
    self.insert()
  File "/home/frappe/benches/bench-version-12-2021-06-22/apps/frappe/frappe/model/[document.py](http://document.py/)", line 230, in insert
    self.run_before_save_methods()
  File "/home/frappe/benches/bench-version-12-2021-06-22/apps/frappe/frappe/model/[document.py](http://document.py/)", line 896, in run_before_save_methods
    self.run_method("validate")
  File "/home/frappe/benches/bench-version-12-2021-06-22/apps/frappe/frappe/model/[document.py](http://document.py/)", line 797, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2021-06-22/apps/frappe/frappe/model/[document.py](http://document.py/)", line 1073, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2021-06-22/apps/frappe/frappe/model/[document.py](http://document.py/)", line 1056, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-version-12-2021-06-22/apps/frappe/frappe/model/[document.py](http://document.py/)", line 791, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2021-06-22/apps/erpnext/erpnext/hr/doctype/salary_slip/[salary_slip.py](http://salary_slip.py/)", line 50, in validate
    self.calculate_net_pay()
  File "/home/frappe/benches/bench-version-12-2021-06-22/apps/erpnext/erpnext/hr/doctype/salary_slip/[salary_slip.py](http://salary_slip.py/)", line 302, in calculate_net_pay
    self.gross_pay = self.get_component_totals("earnings", depends_on_payment_days=1)
  File "/home/frappe/benches/bench-version-12-2021-06-22/apps/erpnext/erpnext/hr/doctype/salary_slip/[salary_slip.py](http://salary_slip.py/)", line 824, in get_component_totals
    amount = self.get_amount_based_on_payment_days(d, joining_date, relieving_date)[0]
  File "/home/frappe/benches/bench-version-12-2021-06-22/apps/erpnext/erpnext/hr/doctype/salary_slip/[salary_slip.py](http://salary_slip.py/)", line 697, in get_amount_based_on_payment_days
    amount, additional_amount = rounded(amount), rounded(additional_amount)
  File "/home/frappe/benches/bench-version-12-2021-06-22/apps/frappe/frappe/utils/[data.py](http://data.py/)", line 410, in rounded
    num = round(num * multiplier if precision else num, 8)
TypeError: type NoneType doesn't define __round__ method

Traceback (most recent call last):
  File "/home/frappe/benches/bench-version-12-2021-06-22/apps/frappe/frappe/[app.py](http://app.py/)", line 67, in application
    response = frappe.api.handle()
  File "/home/frappe/benches/bench-version-12-2021-06-22/apps/frappe/frappe/[api.py](http://api.py/)", line 59, in handle
    return frappe.handler.handle()
  File "/home/frappe/benches/bench-version-12-2021-06-22/apps/frappe/frappe/[handler.py](http://handler.py/)", line 24, in handle
    data = execute_cmd(cmd)
  File "/home/frappe/benches/bench-version-12-2021-06-22/apps/frappe/frappe/[handler.py](http://handler.py/)", line 64, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "/home/frappe/benches/bench-version-12-2021-06-22/apps/frappe/frappe/[__init__.py](http://__init__.py/)", line 1075, in call
    return fn(*args, **newargs)
  File "/home/frappe/benches/bench-version-12-2021-06-22/apps/frappe/frappe/desk/form/[save.py](http://save.py/)", line 21, in savedocs
    doc.save()
  File "/home/frappe/benches/bench-version-12-2021-06-22/apps/frappe/frappe/model/[document.py](http://document.py/)", line 273, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2021-06-22/apps/frappe/frappe/model/[document.py](http://document.py/)", line 296, in _save
    self.insert()
  File "/home/frappe/benches/bench-version-12-2021-06-22/apps/frappe/frappe/model/[document.py](http://document.py/)", line 230, in insert
    self.run_before_save_methods()
  File "/home/frappe/benches/bench-version-12-2021-06-22/apps/frappe/frappe/model/[document.py](http://document.py/)", line 896, in run_before_save_methods
    self.run_method("validate")
  File "/home/frappe/benches/bench-version-12-2021-06-22/apps/frappe/frappe/model/[document.py](http://document.py/)", line 797, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2021-06-22/apps/frappe/frappe/model/[document.py](http://document.py/)", line 1073, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2021-06-22/apps/frappe/frappe/model/[document.py](http://document.py/)", line 1056, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/benches/bench-version-12-2021-06-22/apps/frappe/frappe/model/[document.py](http://document.py/)", line 791, in 
    fn = lambda self, *args, **kwargs: getattr(self, method)(*args, **kwargs)
  File "/home/frappe/benches/bench-version-12-2021-06-22/apps/erpnext/erpnext/hr/doctype/salary_slip/[salary_slip.py](http://salary_slip.py/)", line 50, in validate
    self.calculate_net_pay()
  File "/home/frappe/benches/bench-version-12-2021-06-22/apps/erpnext/erpnext/hr/doctype/salary_slip/[salary_slip.py](http://salary_slip.py/)", line 302, in calculate_net_pay
    self.gross_pay = self.get_component_totals("earnings", depends_on_payment_days=1)
  File "/home/frappe/benches/bench-version-12-2021-06-22/apps/erpnext/erpnext/hr/doctype/salary_slip/[salary_slip.py](http://salary_slip.py/)", line 824, in get_component_totals
    amount = self.get_amount_based_on_payment_days(d, joining_date, relieving_date)[0]
  File "/home/frappe/benches/bench-version-12-2021-06-22/apps/erpnext/erpnext/hr/doctype/salary_slip/[salary_slip.py](http://salary_slip.py/)", line 697, in get_amount_based_on_payment_days
    amount, additional_amount = rounded(amount), rounded(additional_amount)
  File "/home/frappe/benches/bench-version-12-2021-06-22/apps/frappe/frappe/utils/[data.py](http://data.py/)", line 410, in rounded
    num = round(num * multiplier if precision else num, 8)
TypeError: type NoneType doesn't define __round__ method
```
</details>