### PR TITLE
chore: python 3.10 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # frappe   # https://github.com/frappe/frappe is installed during bench-init
 gocardless-pro~=1.22.0
 googlemaps
-pandas~=1.1.5
+pandas>=1.1.5,<2.0.0
 plaid-python~=7.2.1
 pycountry~=20.7.3
 PyGithub~=1.55
@@ -10,4 +10,4 @@ python-youtube~=0.8.0
 taxjar~=1.9.2
 tweepy~=3.10.0
 Unidecode~=1.2.0
-redisearch==2.0.0
+redisearch~=2.1.0


### PR DESCRIPTION
closes #29236 

1. 3.10 support for `jsonobject` was released yesterday: https://github.com/dimagi/jsonobject/releases/tag/v1.0.0 
2. pandas needs 1.3.x+ for 3.10 (loosened dependencies) pinning this is a nightmare because of the gigantic list of transitive dependencies. This is getting kicked out of req.txt soon™️
3. bump redisearch to 2.1