### PR TITLE
fix: Payment Request Amount calculation in case of multi-currency

### DIFF
--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -394,7 +394,10 @@ def get_amount(ref_doc, payment_account=None):
 	"""get amount based on doctype"""
 	dt = ref_doc.doctype
 	if dt in ["Sales Order", "Purchase Order"]:
-		grand_total = flt(ref_doc.grand_total) - flt(ref_doc.advance_paid)
+		if ref_doc.party_account_currency == ref_doc.currency:
+			grand_total = flt(ref_doc.grand_total) - flt(ref_doc.advance_paid)
+		else:
+			grand_total = flt(ref_doc.grand_total) - flt(ref_doc.advance_paid) / ref_doc.conversion_rate
 
 	elif dt in ["Sales Invoice", "Purchase Invoice"]:
 		if ref_doc.party_account_currency == ref_doc.currency:


### PR DESCRIPTION
**Issue:**
Payment Request Amount is calculated incorrectly if the PO currency is different from the party account currency and there is any advance against the PO.

Purchase Order:

PO Currency = USD
Company Currency = INR
Party Account Currency = INR
Conversion Rate = 70

Grand Total = $100
Advance Paid = INR 3500

**Calculation Before fix:**
The system was calculating the outstanding amount as $(100 - 3500) = -$3400, hence giving an error saying "Payment Request is already created"

**Calculation After fix:**
Outstanding Amount = $(100 - 3500/70) = $50

