### PR TITLE
fix: Sub-Category Routing in Item Group Page Listing pills

### DIFF
--- a/erpnext/e_commerce/product_ui/views.js
+++ b/erpnext/e_commerce/product_ui/views.js
@@ -495,7 +495,7 @@ erpnext.ProductView =  class {
 
 			categories.forEach(category => {
 				sub_group_html += `
-					<a href="${ category.route || '#' }" style="text-decoration: none;">
+					<a href="/${ category.route || '#' }" style="text-decoration: none;">
 						<div class="category-pill">
 							${ category.name }
 						</div>

--- a/erpnext/public/scss/shopping_cart.scss
+++ b/erpnext/public/scss/shopping_cart.scss
@@ -569,15 +569,12 @@ body.product-page {
 }
 
 .scroll-categories {
-	white-space: nowrap;
-	overflow-x: auto;
-
 	.category-pill {
-		margin: 0px 4px;
 		display: inline-block;
-		padding: 6px 12px;
-		background-color: #ecf5fe;
 		width: fit-content;
+		padding: 6px 12px;
+		margin-bottom: 8px;
+		background-color: #ecf5fe;
 		font-size: 14px;
 		border-radius: 18px;
 		color: var(--blue-500);

--- a/erpnext/setup/doctype/item_group/item_group.py
+++ b/erpnext/setup/doctype/item_group/item_group.py
@@ -132,7 +132,8 @@ def get_child_groups_for_website(item_group_name, immediate=False, include_self=
 	return frappe.get_all(
 		"Item Group",
 		filters=filters,
-		fields=["name", "route"]
+		fields=["name", "route"],
+		order_by="name"
 	)
 
 def get_child_item_groups(item_group_name):


### PR DESCRIPTION
## **Issue:**
- Sub-Categories 3-4 levels down had an improper relative path constructed
   ![2022-03-15 16 43 09](https://user-images.githubusercontent.com/25857446/158365980-9030a1f9-8f17-4067-9517-b2ee8baf3ac3.gif)

- Higher number of sub categories let to inaccessibility of pills
   <img width="970" alt="Screenshot 2022-03-15 at 4 47 16 PM" src="https://user-images.githubusercontent.com/25857446/158366634-701d31bd-8a8c-47da-9e3a-388f6bcc7305.png">
  

## **Fix:**
- Use absolute route even 3-4 sub-category levels down
   ![2022-03-15 16 40 18](https://user-images.githubusercontent.com/25857446/158365422-2b79bf47-6cc0-438f-817c-3af79c1d09a1.gif)
- Remove scroll from category pills due to accessibility issues
- Arrange sub-category pills alphabetically
   <img width="943" alt="Screenshot 2022-03-15 at 4 50 08 PM" src="https://user-images.githubusercontent.com/25857446/158367114-4f4820c3-30d5-465a-86f0-8ab93451ff44.png">
