### PR TITLE
fix: Error in bank reconciliation statement

### DIFF
--- a/erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py
+++ b/erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py
@@ -267,7 +267,7 @@ def get_loan_amount(filters):
 
 		total_amount += flt(amount)
 
-	return amount
+	return total_amount
 
 def get_balance_row(label, amount, account_currency):
 	if amount > 0:


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 68, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 31, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 68, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1213, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/__init__.py", line 629, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "apps/frappe/frappe/desk/query_report.py", line 244, in run
    result = generate_report_result(report, filters, user, custom_columns, is_tree, parent_field)
  File "apps/frappe/frappe/__init__.py", line 629, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "apps/frappe/frappe/desk/query_report.py", line 86, in generate_report_result
    res = get_report_result(report, filters) or []
  File "apps/frappe/frappe/desk/query_report.py", line 70, in get_report_result
    res = report.execute_script_report(filters)
  File "apps/frappe/frappe/core/doctype/report/report.py", line 133, in execute_script_report
    res = self.execute_module(filters)
  File "apps/frappe/frappe/core/doctype/report/report.py", line 150, in execute_module
    return frappe.get_attr(method_name)(frappe._dict(filters))
  File "apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py", line 33, in execute
    amounts_not_reflected_in_system = get_amounts_not_reflected_in_system(filters)
  File "apps/erpnext/erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py", line 239, in get_amounts_not_reflected_in_system
    return je_amount + pe_amount + loan_amount
TypeError: unsupported operand type(s) for +: 'float' and 'NoneType'
```