### PR TITLE
fix: packed items return when items are removed

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -47,7 +47,6 @@ from erpnext.stock.doctype.serial_no.serial_no import (
 	get_serial_nos,
 	update_serial_nos_after_submit,
 )
-from erpnext.stock.utils import calculate_mapped_packed_items_return
 
 form_grid_templates = {
 	"items": "templates/form_grid/item_grid.html"
@@ -744,11 +743,8 @@ class SalesInvoice(SellingController):
 
 	def update_packing_list(self):
 		if cint(self.update_stock) == 1:
-			if cint(self.is_return) and self.return_against:
-				calculate_mapped_packed_items_return(self)
-			else:
-				from erpnext.stock.doctype.packed_item.packed_item import make_packing_list
-				make_packing_list(self)
+			from erpnext.stock.doctype.packed_item.packed_item import make_packing_list
+			make_packing_list(self)
 		else:
 			self.set('packed_items', [])
 

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -17,7 +17,6 @@ from erpnext.stock.doctype.serial_no.serial_no import (
 	get_delivery_note_serial_no,
 	update_serial_nos_after_submit,
 )
-from erpnext.stock.utils import calculate_mapped_packed_items_return
 
 form_grid_templates = {
 	"items": "templates/form_grid/item_grid.html"
@@ -132,12 +131,8 @@ class DeliveryNote(SellingController):
 		self.validate_uom_is_integer("uom", "qty")
 		self.validate_with_previous_doc()
 
-		# Keeps mapped packed_items in case product bundle is updated.
-		if self.is_return and self.return_against:
-			calculate_mapped_packed_items_return(self)
-		else:
-			from erpnext.stock.doctype.packed_item.packed_item import make_packing_list
-			make_packing_list(self)
+		from erpnext.stock.doctype.packed_item.packed_item import make_packing_list
+		make_packing_list(self)
 
 		if self._action != 'submit' and not self.is_return:
 			set_batch_nos(self, 'warehouse', throw=True)

--- a/erpnext/stock/doctype/delivery_note/test_delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/test_delivery_note.py
@@ -386,7 +386,8 @@ class TestDeliveryNote(FrappeTestCase):
 		self.assertEqual(actual_qty, 25)
 
 		#  return bundled item
-		dn1 = create_return_delivery_note(source_name=dn.name, rate=500, qty=-2)
+		dn1 = create_delivery_note(item_code='_Test Product Bundle Item', is_return=1,
+			return_against=dn.name, qty=-2, rate=500, company=company, warehouse="Stores - TCP1", expense_account="Cost of Goods Sold - TCP1", cost_center="Main - TCP1")
 
 		# qty after return
 		actual_qty = get_qty_after_transaction(warehouse="Stores - TCP1")
@@ -826,15 +827,6 @@ class TestDeliveryNote(FrappeTestCase):
 		dn = create_delivery_note(item_code="_Test Serialized Item With Series", is_return=True, qty=-1)
 		dn.reload()
 		self.assertTrue(dn.items[0].serial_no)
-
-def create_return_delivery_note(**args):
-	args = frappe._dict(args)
-	from erpnext.controllers.sales_and_purchase_return import make_return_doc
-	doc = make_return_doc("Delivery Note", args.source_name, None)
-	doc.items[0].rate = args.rate
-	doc.items[0].qty = args.qty
-	doc.submit()
-	return doc
 
 def create_delivery_note(**args):
 	dn = frappe.new_doc("Delivery Note")

--- a/erpnext/stock/doctype/packed_item/test_packed_item.py
+++ b/erpnext/stock/doctype/packed_item/test_packed_item.py
@@ -17,15 +17,25 @@ class TestPackedItem(FrappeTestCase):
 	@classmethod
 	def setUpClass(cls) -> None:
 		super().setUpClass()
+		cls.warehouse = "_Test Warehouse - _TC"
 		cls.bundle = "_Test Product Bundle X"
 		cls.bundle_items = ["_Test Bundle Item 1", "_Test Bundle Item 2"]
+
+		cls.bundle2 = "_Test Product Bundle Y"
+		cls.bundle2_items = ["_Test Bundle Item 3", "_Test Bundle Item 4"]
+
 		make_item(cls.bundle, {"is_stock_item": 0})
-		for item in cls.bundle_items:
+		make_item(cls.bundle2, {"is_stock_item": 0})
+		for item in cls.bundle_items + cls.bundle2_items:
 			make_item(item, {"is_stock_item": 1})
 
 		make_item("_Test Normal Stock Item", {"is_stock_item": 1})
 
 		make_product_bundle(cls.bundle, cls.bundle_items, qty=2)
+		make_product_bundle(cls.bundle2, cls.bundle2_items, qty=2)
+
+		for item in cls.bundle_items + cls.bundle2_items:
+			make_stock_entry(item_code=item, to_warehouse=cls.warehouse, qty=100, rate=100)
 
 	def test_adding_bundle_item(self):
 		"Test impact on packed items if bundle item row is added."
@@ -156,3 +166,104 @@ class TestPackedItem(FrappeTestCase):
 		credit_after_reposting = sum(gle.credit for gle in gles)
 		self.assertNotEqual(credit_before_repost, credit_after_reposting)
 		self.assertAlmostEqual(credit_after_reposting, 2 * credit_before_repost)
+
+	def assertReturns(self, original, returned):
+		self.assertEqual(len(original), len(returned))
+
+		sort_function = lambda p: (p.parent_item, p.item_code, p.qty)
+
+		for sent, returned in zip(
+			sorted(original, key=sort_function),
+			sorted(returned, key=sort_function)
+		):
+			self.assertEqual(sent.item_code, returned.item_code)
+			self.assertEqual(sent.parent_item, returned.parent_item)
+			self.assertEqual(sent.qty, -1 * returned.qty)
+
+	def test_returning_full_bundles(self):
+		from erpnext.stock.doctype.delivery_note.delivery_note import make_sales_return
+
+		item_list = [
+			{
+				"item_code": self.bundle,
+				"warehouse": self.warehouse,
+				"qty": 1,
+				"rate": 100,
+			},
+			{
+				"item_code": self.bundle2,
+				"warehouse": self.warehouse,
+				"qty": 1,
+				"rate": 100,
+			}
+		]
+		so = make_sales_order(item_list=item_list, warehouse=self.warehouse)
+
+		dn = make_delivery_note(so.name)
+		dn.save()
+		dn.submit()
+
+		# create return
+		dn_ret = make_sales_return(dn.name)
+		dn_ret.save()
+		dn_ret.submit()
+		self.assertReturns(dn.packed_items, dn_ret.packed_items)
+
+	def test_returning_partial_bundles(self):
+		from erpnext.stock.doctype.delivery_note.delivery_note import make_sales_return
+
+		item_list = [
+			{
+				"item_code": self.bundle,
+				"warehouse": self.warehouse,
+				"qty": 1,
+				"rate": 100,
+			},
+			{
+				"item_code": self.bundle2,
+				"warehouse": self.warehouse,
+				"qty": 1,
+				"rate": 100,
+			}
+		]
+		so = make_sales_order(item_list=item_list, warehouse=self.warehouse)
+
+		dn = make_delivery_note(so.name)
+		dn.save()
+		dn.submit()
+
+		# create return
+		dn_ret = make_sales_return(dn.name)
+		# remove bundle 2
+		dn_ret.items.pop()
+
+		dn_ret.save()
+		dn_ret.submit()
+		dn_ret.reload()
+
+		self.assertTrue(all(d.parent_item == self.bundle for d in dn_ret.packed_items))
+
+		expected_returns = [d for d in dn.packed_items if d.parent_item == self.bundle]
+		self.assertReturns(expected_returns, dn_ret.packed_items)
+
+
+	def test_returning_partial_bundle_qty(self):
+		from erpnext.stock.doctype.delivery_note.delivery_note import make_sales_return
+
+		so = make_sales_order(item_code=self.bundle, warehouse=self.warehouse, qty = 2)
+
+		dn = make_delivery_note(so.name)
+		dn.save()
+		dn.submit()
+
+		# create return
+		dn_ret = make_sales_return(dn.name)
+		# halve the qty
+		dn_ret.items[0].qty = -1
+		dn_ret.save()
+		dn_ret.submit()
+
+		expected_returns = dn.packed_items
+		for d in expected_returns:
+			d.qty /= 2
+		self.assertReturns(expected_returns, dn_ret.packed_items)

--- a/erpnext/stock/doctype/stock_ledger_entry/test_stock_ledger_entry.py
+++ b/erpnext/stock/doctype/stock_ledger_entry/test_stock_ledger_entry.py
@@ -10,10 +10,7 @@ from frappe.core.page.permission_manager.permission_manager import reset
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils import add_days, today
 
-from erpnext.stock.doctype.delivery_note.test_delivery_note import (
-	create_delivery_note,
-	create_return_delivery_note,
-)
+from erpnext.stock.doctype.delivery_note.test_delivery_note import create_delivery_note
 from erpnext.stock.doctype.item.test_item import make_item
 from erpnext.stock.doctype.landed_cost_voucher.test_landed_cost_voucher import (
 	create_landed_cost_voucher,
@@ -239,7 +236,8 @@ class TestStockLedgerEntry(FrappeTestCase):
 		self.assertEqual(outgoing_rate, 100)
 
 		# Return Entry: Qty = -2, Rate = 150
-		return_dn = create_return_delivery_note(source_name=dn.name, rate=150, qty=-2)
+		return_dn = create_delivery_note(is_return=1, return_against=dn.name, item_code=bundled_item, qty=-2, rate=150,
+			company=company, warehouse="Stores - _TC", expense_account="Cost of Goods Sold - _TC", cost_center="Main - _TC")
 
 		# check incoming rate for Return entry
 		incoming_rate, stock_value_difference = frappe.db.get_value("Stock Ledger Entry",

--- a/erpnext/stock/utils.py
+++ b/erpnext/stock/utils.py
@@ -422,19 +422,6 @@ def is_reposting_item_valuation_in_progress():
 	if reposting_in_progress:
 		frappe.msgprint(_("Item valuation reposting in progress. Report might show incorrect item valuation."), alert=1)
 
-
-def calculate_mapped_packed_items_return(return_doc):
-	parent_items = set([item.parent_item for item in return_doc.packed_items])
-	against_doc = frappe.get_doc(return_doc.doctype, return_doc.return_against)
-
-	for original_bundle, returned_bundle in zip(against_doc.items, return_doc.items):
-		if original_bundle.item_code in parent_items:
-			for returned_packed_item, original_packed_item in zip(return_doc.packed_items, against_doc.packed_items):
-				if returned_packed_item.parent_item == original_bundle.item_code:
-					returned_packed_item.parent_detail_docname = returned_bundle.name
-					returned_packed_item.qty = (original_packed_item.qty / original_bundle.qty) * returned_bundle.qty
-
-
 def check_pending_reposting(posting_date: str, throw_error: bool = True) -> bool:
 	"""Check if there are pending reposting job till the specified posting date."""
 


### PR DESCRIPTION
problem: incorrect packed items list when returning partial deliveries/invoices.
fix: reverted old PR and added tests for this use case. That old issue is better handled by implementing https://github.com/frappe/erpnext/issues/29462 


caused by: https://github.com/frappe/erpnext/pull/28607 
