### PR TITLE
fix: report sales payments summary

### DIFF
--- a/erpnext/accounts/report/sales_payment_summary/sales_payment_summary.py
+++ b/erpnext/accounts/report/sales_payment_summary/sales_payment_summary.py
@@ -199,31 +199,39 @@ def get_mode_of_payment_details(filters):
 	invoice_list = get_invoices(filters)
 	invoice_list_names = ",".join('"' + invoice['name'] + '"' for invoice in invoice_list)
 	if invoice_list:
-		inv_mop_detail = frappe.db.sql("""select a.owner, a.posting_date,
-			ifnull(b.mode_of_payment, '') as mode_of_payment, sum(b.base_amount) as paid_amount
-			from `tabSales Invoice` a, `tabSales Invoice Payment` b
-			where a.name = b.parent
-			and a.docstatus = 1
-			and a.name in ({invoice_list_names})
-			group by a.owner, a.posting_date, mode_of_payment
-			union
-			select a.owner,a.posting_date,
-			ifnull(b.mode_of_payment, '') as mode_of_payment, sum(b.base_paid_amount) as paid_amount
-			from `tabSales Invoice` a, `tabPayment Entry` b,`tabPayment Entry Reference` c
-			where a.name = c.reference_name
-			and b.name = c.parent
-			and b.docstatus = 1
-			and a.name in ({invoice_list_names})
-			group by a.owner, a.posting_date, mode_of_payment
-			union
-			select a.owner, a.posting_date,
-			ifnull(a.voucher_type,'') as mode_of_payment, sum(b.credit)
-			from `tabJournal Entry` a, `tabJournal Entry Account` b
-			where a.name = b.parent
-			and a.docstatus = 1
-			and b.reference_type = "Sales Invoice"
-			and b.reference_name in ({invoice_list_names})
-			group by a.owner, a.posting_date, mode_of_payment
+		inv_mop_detail = frappe.db.sql("""
+			select t.owner, 
+			       t.posting_date,
+				   t.mode_of_payment, 
+				   sum(t.paid_amount) as paid_amount
+			from (
+				select a.owner, a.posting_date,
+				ifnull(b.mode_of_payment, '') as mode_of_payment, sum(b.base_amount) as paid_amount
+				from `tabSales Invoice` a, `tabSales Invoice Payment` b
+				where a.name = b.parent
+				and a.docstatus = 1
+				and a.name in ({invoice_list_names})
+				group by a.owner, a.posting_date, mode_of_payment
+				union
+				select a.owner,a.posting_date,
+				ifnull(b.mode_of_payment, '') as mode_of_payment, sum(c.allocated_amount) as paid_amount
+				from `tabSales Invoice` a, `tabPayment Entry` b,`tabPayment Entry Reference` c
+				where a.name = c.reference_name
+				and b.name = c.parent
+				and b.docstatus = 1
+				and a.name in ({invoice_list_names})
+				group by a.owner, a.posting_date, mode_of_payment
+				union
+				select a.owner, a.posting_date,
+				ifnull(a.voucher_type,'') as mode_of_payment, sum(b.credit)
+				from `tabJournal Entry` a, `tabJournal Entry Account` b
+				where a.name = b.parent
+				and a.docstatus = 1
+				and b.reference_type = "Sales Invoice"
+				and b.reference_name in ({invoice_list_names})
+				group by a.owner, a.posting_date, mode_of_payment
+			) t	 
+			group by t.owner, t.posting_date, t.mode_of_payment
 			""".format(invoice_list_names=invoice_list_names), as_dict=1)
 
 		inv_change_amount = frappe.db.sql("""select a.owner, a.posting_date,
@@ -231,7 +239,7 @@ def get_mode_of_payment_details(filters):
 			from `tabSales Invoice` a, `tabSales Invoice Payment` b
 			where a.name = b.parent
 			and a.name in ({invoice_list_names})
-			and b.mode_of_payment = 'Cash'
+			and b.Type = 'Cash'
 			and a.base_change_amount > 0
 			group by a.owner, a.posting_date, mode_of_payment""".format(invoice_list_names=invoice_list_names), as_dict=1)
 

--- a/erpnext/accounts/report/sales_payment_summary/sales_payment_summary.py
+++ b/erpnext/accounts/report/sales_payment_summary/sales_payment_summary.py
@@ -239,7 +239,7 @@ def get_mode_of_payment_details(filters):
 			from `tabSales Invoice` a, `tabSales Invoice Payment` b
 			where a.name = b.parent
 			and a.name in ({invoice_list_names})
-			and b.Type = 'Cash'
+			and b.type = 'Cash'
 			and a.base_change_amount > 0
 			group by a.owner, a.posting_date, mode_of_payment""".format(invoice_list_names=invoice_list_names), as_dict=1)
 


### PR DESCRIPTION
PS: on report filters Check **payment_detail** must be checked

I found two problems in the report:

1 - When searching for the change amount, the system was searching based on the mode_of_payment field, but as this is a field of the payment method description, it is not correct.

Changed to base type = 'Cash'


2 - In the select that searches for payments made through Payment Entry, it was bringing a wrong value for the following situation:

Ex: Let's say I have 5 sales invoices for the same customer
$50 / each invoice
$250 total

I create only 1 Payment Entry, paying $250 by linking 5 invoices of $50.

In the report this was showing 5x250= $1250...

Changed base_paid_amount to allocated_amount.

3 - it's not a problem, just for better view and wrong duplicate payment methods...

I did a select with group by for the 3 select inside. 