### PR TITLE
fix: Add permission for KSA VAT documents

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -333,6 +333,7 @@ erpnext.patches.v13_0.update_asset_quantity_field
 erpnext.patches.v13_0.delete_bank_reconciliation_detail
 erpnext.patches.v13_0.enable_provisional_accounting
 erpnext.patches.v13_0.non_profit_deprecation_warning
+erpnext.patches.v13_0.enable_ksa_vat_docs #1
 
 [post_model_sync]
 erpnext.patches.v14_0.rename_ongoing_status_in_sla_documents

--- a/erpnext/patches/v13_0/enable_ksa_vat_docs.py
+++ b/erpnext/patches/v13_0/enable_ksa_vat_docs.py
@@ -1,0 +1,12 @@
+import frappe
+
+from erpnext.regional.saudi_arabia.setup import add_permissions, add_print_formats
+
+
+def execute():
+	company = frappe.get_all('Company', filters = {'country': 'Saudi Arabia'})
+	if not company:
+		return
+
+	add_print_formats()
+	add_permissions()


### PR DESCRIPTION
KSA Vat documents like KSA Vat Settings were not visible for users who already had existing companies for Saudi Arabia as in the earlier patch only the custom fields were created but the required permission to the docs was not given.

Added a new patch to give permission to those docs.

