### PR TITLE
fix: P&L account validation on cancellation

### DIFF
--- a/erpnext/accounts/doctype/gl_entry/gl_entry.py
+++ b/erpnext/accounts/doctype/gl_entry/gl_entry.py
@@ -134,7 +134,7 @@ class GLEntry(Document):
 
 	def check_pl_account(self):
 		if self.is_opening=='Yes' and \
-				frappe.db.get_value("Account", self.account, "report_type")=="Profit and Loss":
+				frappe.db.get_value("Account", self.account, "report_type")=="Profit and Loss" and not self.is_cancelled:
 			frappe.throw(_("{0} {1}: 'Profit and Loss' type account {2} not allowed in Opening Entry")
 				.format(self.voucher_type, self.voucher_no, self.account))
 


### PR DESCRIPTION
Validation for Profit and Loss account in GL Entry was added around a year back.

Canceling opening entries posted before this validation with the P&L account raises a validation while posting reverse ledger entries and the user is unable to cancel the document. The modification in the condition will allow users to cancel the old documents