### PR TITLE
fix(ux): warning for disabled carry forwarding in Policy Assignment

### DIFF
--- a/erpnext/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
+++ b/erpnext/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
@@ -8,13 +8,14 @@ from math import ceil
 import frappe
 from frappe import _, bold
 from frappe.model.document import Document
-from frappe.utils import date_diff, flt, formatdate, get_last_day, getdate
+from frappe.utils import date_diff, flt, formatdate, get_last_day, get_link_to_form, getdate
 
 
 class LeavePolicyAssignment(Document):
 	def validate(self):
-		self.validate_policy_assignment_overlap()
 		self.set_dates()
+		self.validate_policy_assignment_overlap()
+		self.warn_about_carry_forwarding()
 
 	def on_submit(self):
 		self.grant_leave_alloc_for_employee()
@@ -37,6 +38,20 @@ class LeavePolicyAssignment(Document):
 		if len(leave_policy_assignments):
 			frappe.throw(_("Leave Policy: {0} already assigned for Employee {1} for period {2} to {3}")
 				.format(bold(self.leave_policy), bold(self.employee), bold(formatdate(self.effective_from)), bold(formatdate(self.effective_to))))
+
+	def warn_about_carry_forwarding(self):
+		if not self.carry_forward:
+			return
+
+		leave_types = get_leave_type_details()
+		leave_policy = frappe.get_doc("Leave Policy", self.leave_policy)
+
+		for policy in leave_policy.leave_policy_details:
+			leave_type = leave_types.get(policy.leave_type)
+			if not leave_type.is_carry_forward:
+				msg = _("Leaves for the Leave Type {0} won't be carry-forwarded since carry-forwarding is disabled.").format(
+						frappe.bold(get_link_to_form("Leave Type", leave_type.name)))
+				frappe.msgprint(msg, indicator="orange", alert=True)
 
 	@frappe.whitelist()
 	def grant_leave_alloc_for_employee(self):


### PR DESCRIPTION
## Problem:
- While creating Leave Policy Assignment there is an option to add unused leaves from the previous allocation (carry forwarding)

   <img width="1440" alt="unused" src="https://user-images.githubusercontent.com/24353136/159230600-bd7edd61-949c-4531-9888-eff381d5ab9d.png">

- On submission, this creates allocations but does not carry forward leaves for leave types with "Is Carry Forward" unchecked. This happens silently so it confuses the user about why leaves weren't carried forward.

## Fix:

Warn the user about Leave Types which don't have carry forwarding enabled so that they can enable this (if needed) before submission:

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/24353136/159233408-7a473202-d47d-4997-85a3-0dd8fd736314.png">

