### PR TITLE
fix: don't show disabled warehouses in warehouse tree

### DIFF
--- a/erpnext/stock/doctype/warehouse/test_warehouse.py
+++ b/erpnext/stock/doctype/warehouse/test_warehouse.py
@@ -92,6 +92,23 @@ class TestWarehouse(FrappeTestCase):
 		children = get_children("Warehouse", parent=company, company=company, is_root=True)
 		self.assertTrue(any(wh['value'] == "_Test Warehouse - _TC" for wh in children))
 
+	def test_disabled_warehouse_tree(self):
+		warehouse = create_warehouse('Test Disabled Warehouse', company='_Test Company')
+
+		def validate_disabled_warehouse(warehouse, disabled = 0):
+			warehouse_doc = frappe.get_doc('Warehouse', warehouse)
+			warehouse_doc.disabled = disabled
+			warehouse_doc.save()
+
+			for row in get_children('Warehouse', 'All Warehouses - _TC', '_Test Company'):
+				if row.value == warehouse:
+					return True
+
+		# Non disabled warehouse
+		self.assertTrue(validate_disabled_warehouse(warehouse))
+
+		# Disabled warehouse
+		self.assertFalse(validate_disabled_warehouse(warehouse, disabled=1))
 
 def create_warehouse(warehouse_name, properties=None, company=None):
 	if not company:

--- a/erpnext/stock/doctype/warehouse/warehouse.py
+++ b/erpnext/stock/doctype/warehouse/warehouse.py
@@ -98,6 +98,7 @@ def get_children(doctype, parent=None, company=None, is_root=False):
 	fields = ['name as value', 'is_group as expandable']
 	filters = [
 		['docstatus', '<', '2'],
+		['disabled', '=', '0'],
 		['ifnull(`parent_warehouse`, "")', '=', parent],
 		['company', 'in', (company, None,'')]
 	]


### PR DESCRIPTION
**Issue**

Disabled warehouses are showing in the warehouse tree

