### PR TITLE
fix(UX): job card status fixes

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -500,16 +500,15 @@ class JobCard(Document):
 			2: "Cancelled"
 		}[self.docstatus or 0]
 
+		if self.for_quantity <= self.transferred_qty:
+			self.status = 'Material Transferred'
+
 		if self.time_logs:
 			self.status = 'Work In Progress'
 
 		if (self.docstatus == 1 and
 			(self.for_quantity <= self.total_completed_qty or not self.items)):
 			self.status = 'Completed'
-
-		if self.status != 'Completed':
-			if self.for_quantity <= self.transferred_qty:
-				self.status = 'Material Transferred'
 
 		if update_status:
 			self.db_set('status', self.status)

--- a/erpnext/manufacturing/doctype/job_card/test_job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/test_job_card.py
@@ -169,6 +169,7 @@ class TestJobCard(FrappeTestCase):
 
 		job_card_name = frappe.db.get_value("Job Card", {'work_order': self.work_order.name})
 		job_card = frappe.get_doc("Job Card", job_card_name)
+		self.assertEqual(job_card.status, "Open")
 
 		# fully transfer both RMs
 		transfer_entry_1 = make_stock_entry_from_jc(job_card_name)

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -1150,6 +1150,10 @@ def create_job_card(work_order, row, enable_capacity_planning=False, auto_create
 		doc.insert()
 		frappe.msgprint(_("Job card {0} created").format(get_link_to_form("Job Card", doc.name)), alert=True)
 
+	if enable_capacity_planning:
+		# automatically added scheduling rows shouldn't change status to WIP
+		doc.db_set("status", "Open")
+
 	return doc
 
 def get_work_order_operation_data(work_order, operation, workstation):


### PR DESCRIPTION
1. Material transfer happens before processing so it should come before WIP. 


Status state machine should be like this

created (open) -> material transferred -> time log added (WIP) -> qty completed and submitted (complete)

2. Auto-created job cards are showing up as "WIP" after https://github.com/frappe/erpnext/pull/30243 This is because for scheduling rows are added in JC time logs and this makes it "WIP" instead of "Open" 