### PR TITLE
fix: batch/serial selector in case of missing item info

### DIFF
--- a/erpnext/public/js/utils/serial_no_batch_selector.js
+++ b/erpnext/public/js/utils/serial_no_batch_selector.js
@@ -611,3 +611,5 @@ function check_can_calculate_pending_qty(me) {
 	const itemChecks = !!item  && !item.allow_alternative_item;
 	return docChecks && itemChecks;
 }
+
+//# sourceURL=serial_no_batch_selector.js

--- a/erpnext/public/js/utils/serial_no_batch_selector.js
+++ b/erpnext/public/js/utils/serial_no_batch_selector.js
@@ -608,7 +608,10 @@ function check_can_calculate_pending_qty(me) {
 		&& doc.fg_completed_qty
 		&& erpnext.stock.bom
 		&& erpnext.stock.bom.name === doc.bom_no;
-	const itemChecks = !!item  && !item.allow_alternative_item;
+	const itemChecks = !!item
+		&& !item.allow_alternative_item
+		&& erpnext.stock.bom && erpnext.stock.items
+		&& (item.item_code in erpnext.stock.bom.items);
 	return docChecks && itemChecks;
 }
 


### PR DESCRIPTION
alternate items or alternate items moved to other documents aren't present in info about "pending qty" computation. Because of this selector doesn't show up. 

This feature is only used for BOM's required qty computation, if for any reason such info is not available, it's better to ignore this feature than to cause a bigger failure (i.e. dysfunctional selector)

ref: ISS-21-22-13566 