### PR TITLE
fix: Write off amount wrongly calculated in POS Invoice

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -812,12 +812,37 @@ class TestSalesInvoice(unittest.TestCase):
 		pos.append("payments", {'mode_of_payment': 'Bank Draft', 'account': '_Test Bank - TCP1', 'amount': 50})
 		pos.append("payments", {'mode_of_payment': 'Cash', 'account': 'Cash - TCP1', 'amount': 60})
 
-		pos.change_amount = 5.0
+		pos.write_off_outstanding_amount_automatically = 1
 		pos.insert()
 		pos.submit()
 
 		self.assertEqual(pos.grand_total, 100.0)
-		self.assertEqual(pos.write_off_amount, -5)
+		self.assertEqual(pos.write_off_amount, 0)
+
+	def test_auto_write_off_amount(self):
+		make_pos_profile(company="_Test Company with perpetual inventory", income_account = "Sales - TCP1",
+			expense_account = "Cost of Goods Sold - TCP1", warehouse="Stores - TCP1", cost_center = "Main - TCP1", write_off_account="_Test Write Off - TCP1")
+
+		make_purchase_receipt(company= "_Test Company with perpetual inventory",
+			item_code= "_Test FG Item",warehouse= "Stores - TCP1", cost_center= "Main - TCP1")
+
+		pos = create_sales_invoice(company= "_Test Company with perpetual inventory",
+			debit_to="Debtors - TCP1", item_code= "_Test FG Item", warehouse="Stores - TCP1",
+			income_account = "Sales - TCP1", expense_account = "Cost of Goods Sold - TCP1",
+			cost_center = "Main - TCP1", do_not_save=True)
+
+		pos.is_pos = 1
+		pos.update_stock = 1
+
+		pos.append("payments", {'mode_of_payment': 'Bank Draft', 'account': '_Test Bank - TCP1', 'amount': 50})
+		pos.append("payments", {'mode_of_payment': 'Cash', 'account': 'Cash - TCP1', 'amount': 40})
+
+		pos.write_off_outstanding_amount_automatically = 1
+		pos.insert()
+		pos.submit()
+
+		self.assertEqual(pos.grand_total, 100.0)
+		self.assertEqual(pos.write_off_amount, 10)
 
 	def test_pos_with_no_gl_entry_for_change_amount(self):
 		frappe.db.set_value('Accounts Settings', None, 'post_change_gl_entries', 0)

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -580,6 +580,9 @@ class calculate_taxes_and_totals(object):
 					.format(self.doc.party_account_currency, invoice_total))
 
 			if self.doc.docstatus == 0:
+				if self.doc.get('write_off_outstanding_amount_automatically'):
+					self.doc.write_off_amount = 0
+
 				self.calculate_outstanding_amount()
 				self.calculate_write_off_amount()
 

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -682,7 +682,7 @@ class calculate_taxes_and_totals(object):
 				self.doc.precision("base_change_amount"))
 
 	def calculate_write_off_amount(self):
-		if self.doc.write_off_outstanding_amount_automatically:
+		if self.doc.get('write_off_outstanding_amount_automatically'):
 			self.doc.write_off_amount = flt(self.doc.outstanding_amount, self.doc.precision("write_off_amount"))
 			self.doc.base_write_off_amount = flt(self.doc.write_off_amount * self.doc.conversion_rate,
 				self.doc.precision("base_write_off_amount"))

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -668,6 +668,7 @@ erpnext.taxes_and_totals = erpnext.payments.extend({
 		this.frm.doc.total_advance = flt(total_allocated_amount, precision("total_advance"));
 
 		this.calculate_outstanding_amount(update_paid_amount);
+		this.calculate_write_off_amount();
 	},
 
 	is_internal_invoice: function() {
@@ -803,26 +804,23 @@ erpnext.taxes_and_totals = erpnext.payments.extend({
 				var grand_total = this.frm.doc.rounded_total || this.frm.doc.grand_total;
 				var base_grand_total = this.frm.doc.base_rounded_total || this.frm.doc.base_grand_total;
 
-				this.frm.doc.change_amount = flt(this.frm.doc.paid_amount - grand_total +
-					this.frm.doc.write_off_amount, precision("change_amount"));
+				this.frm.doc.change_amount = flt(this.frm.doc.paid_amount - grand_total,
+					precision("change_amount"));
 
 				this.frm.doc.base_change_amount = flt(this.frm.doc.base_paid_amount -
-					base_grand_total + this.frm.doc.base_write_off_amount,
-					precision("base_change_amount"));
+					base_grand_total, precision("base_change_amount"));
 			}
 		}
 	},
 
-	calculate_write_off_amount: function(){
-		if(this.frm.doc.paid_amount > this.frm.doc.grand_total){
+	calculate_write_off_amount: function() {
+		if (this.frm.doc.write_off_outstanding_amount_automatically) {
 			this.frm.doc.write_off_amount = flt(this.frm.doc.grand_total - this.frm.doc.paid_amount
 				+ this.frm.doc.change_amount, precision("write_off_amount"));
-
 			this.frm.doc.base_write_off_amount = flt(this.frm.doc.write_off_amount * this.frm.doc.conversion_rate,
 				precision("base_write_off_amount"));
-		}else{
-			this.frm.doc.paid_amount = 0.0;
 		}
+
 		this.calculate_outstanding_amount(false);
 	}
 });

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -667,6 +667,10 @@ erpnext.taxes_and_totals = erpnext.payments.extend({
 		}));
 		this.frm.doc.total_advance = flt(total_allocated_amount, precision("total_advance"));
 
+		if (this.frm.doc.write_off_outstanding_amount_automatically) {
+			this.frm.doc.write_off_amount = 0;
+		}
+
 		this.calculate_outstanding_amount(update_paid_amount);
 		this.calculate_write_off_amount();
 	},
@@ -815,12 +819,12 @@ erpnext.taxes_and_totals = erpnext.payments.extend({
 
 	calculate_write_off_amount: function() {
 		if (this.frm.doc.write_off_outstanding_amount_automatically) {
-			this.frm.doc.write_off_amount = flt(this.frm.doc.grand_total - this.frm.doc.paid_amount
-				+ this.frm.doc.change_amount, precision("write_off_amount"));
+			this.frm.doc.write_off_amount = flt(this.frm.doc.outstanding_amount, precision("write_off_amount"));
 			this.frm.doc.base_write_off_amount = flt(this.frm.doc.write_off_amount * this.frm.doc.conversion_rate,
 				precision("base_write_off_amount"));
+
+			this.calculate_outstanding_amount(false);
 		}
 
-		this.calculate_outstanding_amount(false);
 	}
 });

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -793,7 +793,7 @@ erpnext.taxes_and_totals = erpnext.payments.extend({
 		this.frm.set_value('base_paid_amount', flt(base_paid_amount, precision("base_paid_amount")));
 	},
 
-	calculate_change_amount: function(){
+	calculate_change_amount: function() {
 		this.frm.doc.change_amount = 0.0;
 		this.frm.doc.base_change_amount = 0.0;
 		if(in_list(["Sales Invoice", "POS Invoice"], this.frm.doc.doctype)


### PR DESCRIPTION
Currently, the change amount is dependent on the write-off amount and the write-off amount is dependent on the change amount. The write-off is auto-calculated if there is a change amount. All the behaviors leads to incorrect calculation of write-off amount in some cases as both the amounts are interdependent on each other.

Write off amount should not be dependent on any field since its a user input field and the only way to auto calculate the write off amount is when it has to be equal to the outstanding amount