### PR TITLE
fix: (ux) Add `is_group=0` filter on website warehouse field in Website Item

### DIFF
--- a/erpnext/e_commerce/doctype/website_item/website_item.js
+++ b/erpnext/e_commerce/doctype/website_item/website_item.js
@@ -5,6 +5,12 @@ frappe.ui.form.on('Website Item', {
 	onload: function(frm) {
 		// should never check Private
 		frm.fields_dict["website_image"].df.is_private = 0;
+
+		frm.set_query("website_warehouse", () => {
+			return {
+				filters: {"is_group": 0}
+			};
+		});
 	},
 
 	image: function() {


### PR DESCRIPTION
It does not support group warehouses right now and it is misleading, so the filter sets the right expectation
<img width="1304" alt="Screenshot 2022-03-24 at 12 48 11 PM" src="https://user-images.githubusercontent.com/25857446/159863683-6846c81e-cb34-4669-b209-794c337ae575.png">

> Looking to add support for group warehouses in a while