### PR TITLE
fix: failing broken patches

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -1,7 +1,7 @@
 [pre_model_sync]
 erpnext.patches.v12_0.update_is_cancelled_field
-erpnext.patches.v13_0.add_bin_unique_constraint
 erpnext.patches.v11_0.rename_production_order_to_work_order
+erpnext.patches.v13_0.add_bin_unique_constraint
 erpnext.patches.v11_0.refactor_naming_series
 erpnext.patches.v11_0.refactor_autoname_naming
 execute:frappe.reload_doc("accounts", "doctype", "POS Payment Method") #2020-05-28

--- a/erpnext/patches/v13_0/rename_issue_doctype_fields.py
+++ b/erpnext/patches/v13_0/rename_issue_doctype_fields.py
@@ -60,7 +60,7 @@ def execute():
 
 def convert_to_seconds(value, unit):
 	seconds = 0
-	if value == 0:
+	if value == 0 or not value:
 		return seconds
 	if unit == 'Hours':
 		seconds = value * 3600

--- a/erpnext/patches/v13_0/rename_issue_doctype_fields.py
+++ b/erpnext/patches/v13_0/rename_issue_doctype_fields.py
@@ -60,7 +60,7 @@ def execute():
 
 def convert_to_seconds(value, unit):
 	seconds = 0
-	if value == 0 or not value:
+	if not value:
 		return seconds
 	if unit == 'Hours':
 		seconds = value * 3600


### PR DESCRIPTION
### Changes:
- Reordered the `rename_production_order_to_work_order` patch since it was breaking for v10 migrations.
- fix to take care of NoneType values

#### Traceback for 1:
```
  File "/home/frappe/benches/bench-version-13-2022-03-24/apps/frappe/frappe/modules/patch_handler.py", line 41, in run_all
    run_patch(patch)
  File "/home/frappe/benches/bench-version-13-2022-03-24/apps/frappe/frappe/modules/patch_handler.py", line 30, in run_patch
    if not run_single(patchmodule = patch):
  File "/home/frappe/benches/bench-version-13-2022-03-24/apps/frappe/frappe/modules/patch_handler.py", line 71, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/home/frappe/benches/bench-version-13-2022-03-24/apps/frappe/frappe/modules/patch_handler.py", line 91, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/home/frappe/benches/bench-version-13-2022-03-24/apps/erpnext/erpnext/patches/v13_0/add_bin_unique_constraint.py", line 15, in execute
    delete_and_patch_duplicate_bins()
  File "/home/frappe/benches/bench-version-13-2022-03-24/apps/erpnext/erpnext/patches/v13_0/add_bin_unique_constraint.py", line 55, in delete_and_patch_duplicate_bins
    "planned_qty": get_planned_qty(item_code, warehouse),
  File "/home/frappe/benches/bench-version-13-2022-03-24/apps/erpnext/erpnext/stock/stock_balance.py", line 161, in get_planned_qty
    planned_qty = frappe.db.sql("""
  File "/home/frappe/benches/bench-version-13-2022-03-24/apps/frappe/frappe/database/database.py", line 146, in sql
    self._cursor.execute(query, values)
  File "/home/frappe/benches/bench-version-13-2022-03-24/env/lib/python3.8/site-packages/pymysql/cursors.py", line 148, in execute
    result = self._query(query)
  File "/home/frappe/benches/bench-version-13-2022-03-24/env/lib/python3.8/site-packages/pymysql/cursors.py", line 310, in _query
    conn.query(q)
  File "/home/frappe/benches/bench-version-13-2022-03-24/env/lib/python3.8/site-packages/pymysql/connections.py", line 548, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/home/frappe/benches/bench-version-13-2022-03-24/env/lib/python3.8/site-packages/pymysql/connections.py", line 775, in _read_query_result
    result.read()
  File "/home/frappe/benches/bench-version-13-2022-03-24/env/lib/python3.8/site-packages/pymysql/connections.py", line 1156, in read
    first_packet = self.connection._read_packet()
  File "/home/frappe/benches/bench-version-13-2022-03-24/env/lib/python3.8/site-packages/pymysql/connections.py", line 725, in _read_packet
    packet.raise_for_error()
  File "/home/frappe/benches/bench-version-13-2022-03-24/env/lib/python3.8/site-packages/pymysql/protocol.py", line 221, in raise_for_error
    err.raise_mysql_exception(self._data)
  File "/home/frappe/benches/bench-version-13-2022-03-24/env/lib/python3.8/site-packages/pymysql/err.py", line 143, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.ProgrammingError: (1146, "Table '785e876682712ab0.tabWork Order' doesn't exist")
```


### Traceback for 2:
```
 File "/home/frappe/benches/bench-version-13-2022-03-22/apps/frappe/frappe/commands/site.py", line 309, in migrate
    migrate(
  File "/home/frappe/benches/bench-version-13-2022-03-22/apps/frappe/frappe/migrate.py", line 69, in migrate
    frappe.modules.patch_handler.run_all(skip_failing)
  File "/home/frappe/benches/bench-version-13-2022-03-22/apps/frappe/frappe/modules/patch_handler.py", line 41, in run_all
    run_patch(patch)
  File "/home/frappe/benches/bench-version-13-2022-03-22/apps/frappe/frappe/modules/patch_handler.py", line 30, in run_patch
    if not run_single(patchmodule = patch):
  File "/home/frappe/benches/bench-version-13-2022-03-22/apps/frappe/frappe/modules/patch_handler.py", line 71, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/home/frappe/benches/bench-version-13-2022-03-22/apps/frappe/frappe/modules/patch_handler.py", line 91, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/home/frappe/benches/bench-version-13-2022-03-22/apps/erpnext/erpnext/patches/v13_0/rename_issue_doctype_fields.py", line 26, in execute
    response_by_variance = convert_to_seconds(entry.response_by_variance, 'Hours')
  File "/home/frappe/benches/bench-version-13-2022-03-22/apps/erpnext/erpnext/patches/v13_0/rename_issue_doctype_fields.py", line 66, in convert_to_seconds
    seconds = value * 3600
TypeError: unsupported operand type(s) for *: 'NoneType' and 'int'
```
