### PR TITLE
fix: show subassembly table always

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.json
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.json
@@ -351,7 +351,6 @@
    "hide_border": 1
   },
   {
-   "depends_on": "get_items_from",
    "fieldname": "sub_assembly_items",
    "fieldtype": "Table",
    "label": "Sub Assembly Items",
@@ -385,7 +384,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2022-03-14 03:56:23.209247",
+ "modified": "2022-03-25 09:15:25.017664",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Production Plan",


### PR DESCRIPTION
caused by https://github.com/frappe/erpnext/pull/30223 