### PR TITLE
fix(patch): fix failing patches

### DIFF
--- a/erpnext/patches/v13_0/update_exchange_rate_settings.py
+++ b/erpnext/patches/v13_0/update_exchange_rate_settings.py
@@ -4,7 +4,7 @@ from erpnext.setup.install import setup_currency_exchange
 
 
 def execute():
-	frappe.reload_doc("accounts", "doctype", "currency_exchange_settings")
 	frappe.reload_doc("accounts", "doctype", "currency_exchange_settings_result")
 	frappe.reload_doc("accounts", "doctype", "currency_exchange_settings_details")
+	frappe.reload_doc("accounts", "doctype", "currency_exchange_settings")
 	setup_currency_exchange()

--- a/erpnext/patches/v14_0/update_opportunity_currency_fields.py
+++ b/erpnext/patches/v14_0/update_opportunity_currency_fields.py
@@ -6,6 +6,7 @@ from erpnext.setup.utils import get_exchange_rate
 
 
 def execute():
+	frappe.reload_doctype("Opportunity")
 	opportunities = frappe.db.get_list('Opportunity', filters={
 		'opportunity_amount': ['>', 0]
 	}, fields=['name', 'company', 'currency', 'opportunity_amount'])


### PR DESCRIPTION
Migrating from v13.21 to current develop causes two errors from failing patches:

- **Opportunity** was not reloaded before patching
- **Currency Exchange Settings** was reloaded before the child tables

This PR fixes them.

Close #30425

> no-docs