### PR TITLE
perf: slimmer and faster before_tests

### DIFF
--- a/erpnext/setup/utils.py
+++ b/erpnext/setup/utils.py
@@ -155,18 +155,9 @@ def set_defaults_for_tests():
 
 
 def insert_record(records):
-	for r in records:
-		doc = frappe.new_doc(r.get("doctype"))
-		doc.update(r)
-		try:
-			doc.insert(ignore_permissions=True, ignore_if_duplicate=True)
-		except frappe.DuplicateEntryError as e:
-			# pass DuplicateEntryError and continue
-			if e.args and e.args[0]==doc.doctype and e.args[1]==doc.name:
-				# make sure DuplicateEntryError is for the exact same doc and not a related doc
-				pass
-			else:
-				raise
+	from frappe.desk.page.setup_wizard.setup_wizard import make_records
+
+	make_records(records)
 
 def welcome_email():
 	site_name = get_default_company() or "ERPNext"


### PR DESCRIPTION
**95% speedup** in `before_test` which executes before all tests locally but it really doesn't need to run again after the first time it runs.  

before:

<img width="412" alt="Screenshot 2022-03-25 at 11 02 07 PM" src="https://user-images.githubusercontent.com/9079960/160172252-3947484f-6561-4ed9-a820-69777934ab2c.png">


after:

<img width="412" alt="Screenshot 2022-03-25 at 11 01 04 PM" src="https://user-images.githubusercontent.com/9079960/160172268-45e8b98d-202d-4283-ba31-132a55e5277c.png">

Yes, those 1.5 seconds add up over time 🚀 😬 
