### PR TITLE
fix: Incorrect default amount to pay for POS invoices

### DIFF
--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -34,12 +34,12 @@ erpnext.taxes_and_totals = erpnext.payments.extend({
 		frappe.model.set_value(item.doctype, item.name, "rate", item_rate);
 	},
 
-	calculate_taxes_and_totals: function(update_paid_amount) {
+	calculate_taxes_and_totals: async function(update_paid_amount) {
 		this.discount_amount_applied = false;
 		this._calculate_taxes_and_totals();
 		this.calculate_discount_amount();
 
-		this.calculate_shipping_charges();
+		await this.calculate_shipping_charges();
 
 		// Advance calculation applicable to Sales /Purchase Invoice
 		if(in_list(["Sales Invoice", "POS Invoice", "Purchase Invoice"], this.frm.doc.doctype)
@@ -273,8 +273,7 @@ erpnext.taxes_and_totals = erpnext.payments.extend({
 	calculate_shipping_charges: function() {
 		frappe.model.round_floats_in(this.frm.doc, ["total", "base_total", "net_total", "base_net_total"]);
 		if (frappe.meta.get_docfield(this.frm.doc.doctype, "shipping_rule", this.frm.doc.name)) {
-			this.shipping_rule();
-			this._calculate_taxes_and_totals();
+			return this.shipping_rule();
 		}
 	},
 

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1086,6 +1086,9 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 			return this.frm.call({
 				doc: this.frm.doc,
 				method: "apply_shipping_rule",
+				callback: function(r) {
+					me._calculate_taxes_and_totals();
+				}
 			}).fail(() => this.frm.set_value('shipping_rule', ''));
 		}
 	},


### PR DESCRIPTION
Bug introduced in https://github.com/frappe/erpnext/pull/30181

The `calculate_shipping_charge` function is an async function. Once the shipping charges are applied taxes are calculated again and this async behavior was causing incorrect calculation of the total amount to pay and in turn left the invoice as overdue