### PR TITLE
fix: misc setup fixes

### DIFF
--- a/erpnext/accounts/doctype/currency_exchange_settings/currency_exchange_settings.py
+++ b/erpnext/accounts/doctype/currency_exchange_settings/currency_exchange_settings.py
@@ -11,6 +11,8 @@ from frappe.utils import nowdate
 class CurrencyExchangeSettings(Document):
 	def validate(self):
 		self.set_parameters_and_result()
+		if frappe.flags.in_test or frappe.flags.in_install or frappe.flags.in_setup_wizard:
+			return
 		response, value = self.validate_parameters()
 		self.validate_result(response, value)
 
@@ -35,9 +37,6 @@ class CurrencyExchangeSettings(Document):
 			self.append("req_params", {"key": "symbols", "value": "{to_currency}"})
 
 	def validate_parameters(self):
-		if frappe.flags.in_test:
-			return None, None
-
 		params = {}
 		for row in self.req_params:
 			params[row.key] = row.value.format(
@@ -59,9 +58,6 @@ class CurrencyExchangeSettings(Document):
 		return response, value
 
 	def validate_result(self, response, value):
-		if frappe.flags.in_test:
-			return
-
 		try:
 			for key in self.result_key:
 				value = value[

--- a/erpnext/selling/doctype/selling_settings/test_selling_settings.py
+++ b/erpnext/selling/doctype/selling_settings/test_selling_settings.py
@@ -1,9 +1,14 @@
 # Copyright (c) 2019, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
-# import frappe
 import unittest
+
+import frappe
 
 
 class TestSellingSettings(unittest.TestCase):
-	pass
+	def test_defaults_populated(self):
+		# Setup default values are not populated on migrate, this test checks
+		# if setup was completed correctly
+		default = frappe.db.get_single_value("Selling Settings", "maintain_same_rate_action")
+		self.assertEqual("Stop", default)

--- a/erpnext/setup/install.py
+++ b/erpnext/setup/install.py
@@ -56,12 +56,11 @@ def set_single_defaults():
 		)
 		if default_values:
 			try:
-				b = frappe.get_doc(dt, dt)
+				doc = frappe.get_doc(dt, dt)
 				for fieldname, value in default_values:
-					b.set(fieldname, value)
-				b.save()
-			except frappe.MandatoryError:
-				pass
+					doc.set(fieldname, value)
+				doc.flags.ignore_mandatory = True
+				doc.save()
 			except frappe.ValidationError:
 				pass
 


### PR DESCRIPTION
- Disable currency exchange validation: This reduces ~4-5 seconds of setup time and chances of setup failure. It's implicitly ignored anyway, not sure why we attempt to do it in first place. 
- Explicitly ignore mandatory fields during single updates (This should really be handled by the framework)