### PR TITLE
fix: enable row deletion in reference table

### DIFF
--- a/erpnext/accounts/doctype/payment_order/payment_order.js
+++ b/erpnext/accounts/doctype/payment_order/payment_order.js
@@ -12,7 +12,6 @@ frappe.ui.form.on('Payment Order', {
 		});
 
 		frm.set_df_property('references', 'cannot_add_rows', true);
-		frm.set_df_property('references', 'cannot_delete_rows', true);
 	},
 	refresh: function(frm) {
 		if (frm.doc.docstatus == 0) {


### PR DESCRIPTION
[#ISS-21-22-13502](https://frappe.io/app/issue/ISS-21-22-13502)

Enabling deletion of payment order reference table rows. 
Deleting rows are necessary since the alternative to removing rows that were mistakenly fetched is to reload the page and fetch all of the correct entries again or to create a new Payment Order which is pretty much the same.