### PR TITLE
fix: bom valuation - handle lack of LPP

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -780,8 +780,8 @@ def get_bom_item_rate(args, bom_doc):
 	if bom_doc.rm_cost_as_per == 'Valuation Rate':
 		rate = get_valuation_rate(args) * (args.get("conversion_factor") or 1)
 	elif bom_doc.rm_cost_as_per == 'Last Purchase Rate':
-		rate = ( flt(args.get('last_purchase_rate')) \
-			or frappe.db.get_value("Item", args['item_code'], "last_purchase_rate")) \
+		rate = (flt(args.get('last_purchase_rate'))
+			or flt(frappe.db.get_value("Item", args['item_code'], "last_purchase_rate"))) \
 				* (args.get("conversion_factor") or 1)
 	elif bom_doc.rm_cost_as_per == "Price List":
 		if not bom_doc.buying_price_list:
@@ -805,7 +805,7 @@ def get_bom_item_rate(args, bom_doc):
 		price_list_data = get_price_list_rate(bom_args, item_doc)
 		rate = price_list_data.price_list_rate
 
-	return rate
+	return flt(rate)
 
 def get_valuation_rate(args):
 	""" Get weighted average of valuation rate from all warehouses """

--- a/erpnext/manufacturing/doctype/bom/test_bom.py
+++ b/erpnext/manufacturing/doctype/bom/test_bom.py
@@ -509,6 +509,27 @@ class TestBOM(FrappeTestCase):
 
 		self.assertEqual(bom.quality_inspection_template, None)
 
+	def test_bom_pricing_based_on_lpp(self):
+		from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import make_purchase_receipt
+
+		parent = frappe.generate_hash(length=10)
+		child = frappe.generate_hash(length=10)
+		bom_tree = {parent: {child: {}}
+		}
+		bom = create_nested_bom(bom_tree, prefix="")
+
+		# add last purchase price
+		make_purchase_receipt(item_code=child, rate=42)
+
+		bom = frappe.copy_doc(bom)
+		bom.docstatus = 0
+		bom.amended_from = None
+		bom.rm_cost_as_per = "Last Purchase Rate"
+		bom.conversion_rate = 1
+		bom.save()
+		bom.submit()
+		self.assertEqual(bom.items[0].rate, 42)
+
 
 def get_default_bom(item_code="_Test FG Item 2"):
 	return frappe.db.get_value("BOM", {"item": item_code, "is_active": 1, "is_default": 1})
@@ -558,6 +579,7 @@ def create_nested_bom(tree, prefix="_Test bom "):
 			bom = frappe.get_doc(doctype="BOM", item=bom_item_code)
 			for child_item in child_items.keys():
 				bom.append("items", {"item_code": prefix + child_item})
+			bom.company = "_Test Company"
 			bom.currency = "INR"
 			bom.insert()
 			bom.submit()


### PR DESCRIPTION
- Handle a case where BOM uses LPP for valuation but RM doesn't have it. 
- Add a basic test for LPP. 