### PR TITLE
fix: use `name` for links not `item_code`

### DIFF
--- a/erpnext/selling/report/item_wise_sales_history/item_wise_sales_history.py
+++ b/erpnext/selling/report/item_wise_sales_history/item_wise_sales_history.py
@@ -177,11 +177,11 @@ def get_customer_details():
 
 
 def get_item_details():
-	details = frappe.db.get_all("Item", fields=["item_code", "item_name", "item_group"])
+	details = frappe.db.get_all("Item", fields=["name", "item_name", "item_group"])
 	item_details = {}
 	for d in details:
 		item_details.setdefault(
-			d.item_code, frappe._dict({"item_name": d.item_name, "item_group": d.item_group})
+			d.name, frappe._dict({"item_name": d.item_name, "item_group": d.item_group})
 		)
 	return item_details
 


### PR DESCRIPTION
All link fields are "linked" using `name` field and not the way name field is defined which in this case is `item_code`