### PR TITLE
fix: credit limit validation in delivery note

### DIFF
--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -280,8 +280,11 @@ class DeliveryNote(SellingController):
 		)
 
 		if bypass_credit_limit_check_at_sales_order:
-			validate_against_credit_limit = True
-			extra_amount = self.base_grand_total
+			for d in self.get("items"):
+				if not d.against_sales_invoice:
+					validate_against_credit_limit = True
+					extra_amount = self.base_grand_total
+					break
 		else:
 			for d in self.get("items"):
 				if not (d.against_sales_order or d.against_sales_invoice):


### PR DESCRIPTION
Problem:
- Create a Customer with a Credit Limit of 200 and "Bypass Credit Limit at SO" checked
- Create a Sales Order for 200 against that customer
- Create a Sales Invoice against the Sales Order
- Create a Delivery Note against the Sales Invoice or Sales Order
- On DN submission user gets an error "Credit Limit exhausted"
  - Fix: Since DN is against SO / SI, the credit limit shouldn't be validated