### PR TITLE
fix: validate 0 transfer qty in stock entry

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -225,12 +225,16 @@ class StockEntry(StockController):
 	def set_transfer_qty(self):
 		for item in self.get("items"):
 			if not flt(item.qty):
-				frappe.throw(_("Row {0}: Qty is mandatory").format(item.idx))
+				frappe.throw(_("Row {0}: Qty is mandatory").format(item.idx), title=_("Zero quantity"))
 			if not flt(item.conversion_factor):
 				frappe.throw(_("Row {0}: UOM Conversion Factor is mandatory").format(item.idx))
 			item.transfer_qty = flt(
 				flt(item.qty) * flt(item.conversion_factor), self.precision("transfer_qty", item)
 			)
+			if not flt(item.transfer_qty):
+				frappe.throw(
+					_("Row {0}: Qty in Stock UOM can not be zero.").format(item.idx), title=_("Zero quantity")
+				)
 
 	def update_cost_in_project(self):
 		if self.work_order and not frappe.db.get_value(

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -51,7 +51,6 @@ class TestStockEntry(FrappeTestCase):
 	def tearDown(self):
 		frappe.db.rollback()
 		frappe.set_user("Administrator")
-		frappe.db.set_value("Manufacturing Settings", None, "material_consumption", "0")
 
 	def test_fifo(self):
 		frappe.db.set_value("Stock Settings", None, "allow_negative_stock", 1)
@@ -767,12 +766,11 @@ class TestStockEntry(FrappeTestCase):
 			fg_cost, flt(rm_cost + bom_operation_cost + work_order.additional_operating_cost, 2)
 		)
 
+	@change_settings("Manufacturing Settings", {"material_consumption": 1})
 	def test_work_order_manufacture_with_material_consumption(self):
 		from erpnext.manufacturing.doctype.work_order.work_order import (
 			make_stock_entry as _make_stock_entry,
 		)
-
-		frappe.db.set_value("Manufacturing Settings", None, "material_consumption", "1")
 
 		bom_no = frappe.db.get_value("BOM", {"item": "_Test FG Item", "is_default": 1, "docstatus": 1})
 
@@ -982,43 +980,6 @@ class TestStockEntry(FrappeTestCase):
 
 		repack.insert()
 		self.assertRaises(frappe.ValidationError, repack.submit)
-
-	# def test_material_consumption(self):
-	# 	frappe.db.set_value("Manufacturing Settings", None, "backflush_raw_materials_based_on", "BOM")
-	# 	frappe.db.set_value("Manufacturing Settings", None, "material_consumption", "0")
-
-	# 	from erpnext.manufacturing.doctype.work_order.work_order \
-	# 		import make_stock_entry as _make_stock_entry
-	# 	bom_no = frappe.db.get_value("BOM", {"item": "_Test FG Item 2",
-	# 		"is_default": 1, "docstatus": 1})
-
-	# 	work_order = frappe.new_doc("Work Order")
-	# 	work_order.update({
-	# 		"company": "_Test Company",
-	# 		"fg_warehouse": "_Test Warehouse 1 - _TC",
-	# 		"production_item": "_Test FG Item 2",
-	# 		"bom_no": bom_no,
-	# 		"qty": 4.0,
-	# 		"stock_uom": "_Test UOM",
-	# 		"wip_warehouse": "_Test Warehouse - _TC",
-	# 		"additional_operating_cost": 1000,
-	# 		"use_multi_level_bom": 1
-	# 	})
-	# 	work_order.insert()
-	# 	work_order.submit()
-
-	# 	make_stock_entry(item_code="_Test Serialized Item With Series", target="_Test Warehouse - _TC", qty=50, basic_rate=100)
-	# 	make_stock_entry(item_code="_Test Item 2", target="_Test Warehouse - _TC", qty=50, basic_rate=20)
-
-	# 	item_quantity = {
-	# 		'_Test Item': 2.0,
-	# 		'_Test Item 2': 12.0,
-	# 		'_Test Serialized Item With Series': 6.0
-	# 	}
-
-	# 	stock_entry = frappe.get_doc(_make_stock_entry(work_order.name, "Material Consumption for Manufacture", 2))
-	# 	for d in stock_entry.get('items'):
-	# 		self.assertEqual(item_quantity.get(d.item_code), d.qty)
 
 	def test_customer_provided_parts_se(self):
 		create_item(
@@ -1357,6 +1318,13 @@ class TestStockEntry(FrappeTestCase):
 
 		issue.reload()  # reload because reposting current voucher updates rate
 		self.assertEqual(issue.value_difference, -30)
+
+	def test_transfer_qty_validation(self):
+		se = make_stock_entry(item_code="_Test Item", do_not_save=True, qty=0.001, rate=100)
+		se.items[0].uom = "Kg"
+		se.items[0].conversion_factor = 0.002
+
+		self.assertRaises(frappe.ValidationError, se.save)
 
 
 def make_serialized_item(**args):


### PR DESCRIPTION
If qty and conversion factors are close to zero then stock qty becomes 0. This is usually incorrect data but currently, there's no good error message and it fails during SLE submission. 


<img width="972" alt="Screenshot 2022-03-29 at 4 33 40 PM" src="https://user-images.githubusercontent.com/9079960/160601732-b239d34c-b7b4-42cd-ab78-e1dc03ea94cc.png">
