### PR TITLE
fix: explicitly check if additional salary is recurring while fetching components for payroll

### DIFF
--- a/erpnext/payroll/doctype/additional_salary/test_additional_salary.py
+++ b/erpnext/payroll/doctype/additional_salary/test_additional_salary.py
@@ -4,7 +4,8 @@
 import unittest
 
 import frappe
-from frappe.utils import add_days, nowdate
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import add_days, add_months, nowdate
 
 import erpnext
 from erpnext.hr.doctype.employee.test_employee import make_employee
@@ -16,18 +17,9 @@ from erpnext.payroll.doctype.salary_slip.test_salary_slip import (
 from erpnext.payroll.doctype.salary_structure.test_salary_structure import make_salary_structure
 
 
-class TestAdditionalSalary(unittest.TestCase):
+class TestAdditionalSalary(FrappeTestCase):
 	def setUp(self):
 		setup_test()
-
-	def tearDown(self):
-		for dt in [
-			"Salary Slip",
-			"Additional Salary",
-			"Salary Structure Assignment",
-			"Salary Structure",
-		]:
-			frappe.db.sql("delete from `tab%s`" % dt)
 
 	def test_recurring_additional_salary(self):
 		amount = 0
@@ -46,19 +38,66 @@ class TestAdditionalSalary(unittest.TestCase):
 			if earning.salary_component == "Recurring Salary Component":
 				amount = earning.amount
 				salary_component = earning.salary_component
+				break
 
 		self.assertEqual(amount, add_sal.amount)
 		self.assertEqual(salary_component, add_sal.salary_component)
 
+	def test_non_recurring_additional_salary(self):
+		amount = 0
+		salary_component = None
+		date = nowdate()
 
-def get_additional_salary(emp_id):
+		emp_id = make_employee("test_additional@salary.com")
+		frappe.db.set_value("Employee", emp_id, "relieving_date", add_days(date, 1800))
+		salary_structure = make_salary_structure(
+			"Test Salary Structure Additional Salary", "Monthly", employee=emp_id
+		)
+		add_sal = get_additional_salary(emp_id, recurring=False, payroll_date=date)
+
+		ss = make_employee_salary_slip(
+			"test_additional@salary.com", "Monthly", salary_structure=salary_structure.name
+		)
+
+		amount, salary_component = None, None
+		for earning in ss.earnings:
+			if earning.salary_component == "Recurring Salary Component":
+				amount = earning.amount
+				salary_component = earning.salary_component
+				break
+
+		self.assertEqual(amount, add_sal.amount)
+		self.assertEqual(salary_component, add_sal.salary_component)
+
+		# should not show up in next months
+		ss.posting_date = add_months(date, 1)
+		ss.start_date = ss.end_date = None
+		ss.earnings = []
+		ss.deductions = []
+		ss.save()
+
+		amount, salary_component = None, None
+		for earning in ss.earnings:
+			if earning.salary_component == "Recurring Salary Component":
+				amount = earning.amount
+				salary_component = earning.salary_component
+				break
+
+		self.assertIsNone(amount)
+		self.assertIsNone(salary_component)
+
+
+def get_additional_salary(emp_id, recurring=True, payroll_date=None):
 	create_salary_component("Recurring Salary Component")
 	add_sal = frappe.new_doc("Additional Salary")
 	add_sal.employee = emp_id
 	add_sal.salary_component = "Recurring Salary Component"
-	add_sal.is_recurring = 1
+
+	add_sal.is_recurring = 1 if recurring else 0
 	add_sal.from_date = add_days(nowdate(), -50)
 	add_sal.to_date = add_days(nowdate(), 180)
+	add_sal.payroll_date = payroll_date
+
 	add_sal.amount = 5000
 	add_sal.currency = erpnext.get_default_currency()
 	add_sal.save()


### PR DESCRIPTION
## Steps to Replicate

1. Create an Additional Salary with **Is Recurring** checked, set From Date and To Date
2. Save.
3. Disable Is Recurring, set Payroll Date field.
4. Save and Submit.
5. Now this additional salary component is not supposed to be recurring, but it will still show up in every Salary Slip till "To Date".

## Fix
 
The query that fetches additional salaries in the salary slip only checks if Payroll Date is within the period or both From Date and To Date are within the period. It doesn't explicitly check for **Is Recurring** checkbox. Modified query to check the same.