### PR TITLE
fix: remove naming series from bin, repost queue

### DIFF
--- a/erpnext/stock/doctype/bin/bin.json
+++ b/erpnext/stock/doctype/bin/bin.json
@@ -1,6 +1,6 @@
 {
  "actions": [],
- "autoname": "MAT-BIN-.YYYY.-.#####",
+ "autoname": "hash",
  "creation": "2013-01-10 16:34:25",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -171,11 +171,11 @@
  "idx": 1,
  "in_create": 1,
  "links": [],
- "modified": "2022-01-30 17:04:54.715288",
+ "modified": "2022-03-30 07:22:23.868602",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Bin",
- "naming_rule": "Expression (old style)",
+ "naming_rule": "Random",
  "owner": "Administrator",
  "permissions": [
   {

--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
@@ -1,6 +1,6 @@
 {
  "actions": [],
- "autoname": "REPOST-ITEM-VAL-.######",
+ "autoname": "hash",
  "creation": "2022-01-11 15:03:38.273179",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -177,11 +177,11 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2022-01-18 10:57:33.450907",
+ "modified": "2022-03-30 07:22:48.520266",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Repost Item Valuation",
- "naming_rule": "Expression (old style)",
+ "naming_rule": "Random",
  "owner": "Administrator",
  "permissions": [
   {


### PR DESCRIPTION
Removing naming series from:
1. Bin
2. Repost queue

These doctypes are not user facing and dont really need naming series.
Current implementation of naming makes stock transaction sequential if
these documents are to be created during submission.

Note: If users want it they can get it back by adding naming series from "customize form".

Don't backport. 