### PR TITLE
feat: 'customer' column and more filter to Payment terms status report

### DIFF
--- a/erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.js
+++ b/erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.js
@@ -27,28 +27,64 @@ function get_filters() {
 			"default": frappe.datetime.get_today()
 		},
 		{
-			"fieldname":"sales_order",
-			"label": __("Sales Order"),
-			"fieldtype": "MultiSelectList",
+			"fieldname":"customer_group",
+			"label": __("Customer Group"),
+			"fieldtype": "Link",
 			"width": 100,
-			"options": "Sales Order",
-			"get_data": function(txt) {
-				return frappe.db.get_link_options("Sales Order", txt, this.filters());
-			},
-			"filters": () => {
+			"options": "Customer Group",
+			"get_query": () => {
 				return {
-					docstatus: 1,
-					payment_terms_template: ['not in', ['']],
-					company: frappe.query_report.get_filter_value("company"),
-					transaction_date: ['between', [frappe.query_report.get_filter_value("period_start_date"), frappe.query_report.get_filter_value("period_end_date")]]
+					filters: { 'is_group': 0 }
 				}
-			},
-			on_change: function(){
-				frappe.query_report.refresh();
+			}
+
+		},
+		{
+			"fieldname":"customer",
+			"label": __("Customer"),
+			"fieldtype": "Link",
+			"width": 100,
+			"options": "Customer",
+			"get_query": () => {
+				filters = {
+					'disabled':  0
+				}
+				if(frappe.query_report.get_filter_value("customer_group") != "") {
+					filters['customer_group'] = frappe.query_report.get_filter_value("customer_group");
+				}
+				return { 'filters': filters };
+			}
+		},
+		{
+			"fieldname":"item_group",
+			"label": __("Item Group"),
+			"fieldtype": "Link",
+			"width": 100,
+			"options": "Item Group",
+			"get_query": () => {
+				return {
+					filters: { 'is_group': 0 }
+				}
+			}
+
+		},
+		{
+			"fieldname":"item",
+			"label": __("Item"),
+			"fieldtype": "Link",
+			"width": 100,
+			"options": "Item",
+			"get_query": () => {
+				filters = {
+					'disabled':  0
+				}
+				if(frappe.query_report.get_filter_value("item_group") != "") {
+					filters['item_group'] = frappe.query_report.get_filter_value("item_group");
+				}
+				return { 'filters': filters };
 			}
 		}
 	]
-
 	return filters;
 }
 

--- a/erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.js
+++ b/erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.js
@@ -32,12 +32,6 @@ function get_filters() {
 			"fieldtype": "Link",
 			"width": 100,
 			"options": "Customer Group",
-			"get_query": () => {
-				return {
-					filters: { 'is_group': 0 }
-				}
-			}
-
 		},
 		{
 			"fieldname":"customer",
@@ -46,13 +40,14 @@ function get_filters() {
 			"width": 100,
 			"options": "Customer",
 			"get_query": () => {
-				filters = {
-					'disabled':  0
+				var customer_group = frappe.query_report.get_filter_value('customer_group');
+				return{
+					"query": "erpnext.selling.report.payment_terms_status_for_sales_order.payment_terms_status_for_sales_order.get_customers_or_items",
+					"filters": [
+						['Customer', 'disabled', '=', '0'],
+						['Customer Group','name', '=', customer_group]
+					]
 				}
-				if(frappe.query_report.get_filter_value("customer_group") != "") {
-					filters['customer_group'] = frappe.query_report.get_filter_value("customer_group");
-				}
-				return { 'filters': filters };
 			}
 		},
 		{
@@ -61,11 +56,6 @@ function get_filters() {
 			"fieldtype": "Link",
 			"width": 100,
 			"options": "Item Group",
-			"get_query": () => {
-				return {
-					filters: { 'is_group': 0 }
-				}
-			}
 
 		},
 		{
@@ -75,13 +65,14 @@ function get_filters() {
 			"width": 100,
 			"options": "Item",
 			"get_query": () => {
-				filters = {
-					'disabled':  0
+				var item_group = frappe.query_report.get_filter_value('item_group');
+				return{
+					"query": "erpnext.selling.report.payment_terms_status_for_sales_order.payment_terms_status_for_sales_order.get_customers_or_items",
+					"filters": [
+						['Item', 'disabled', '=', '0'],
+						['Item Group','name', '=', item_group]
+					]
 				}
-				if(frappe.query_report.get_filter_value("item_group") != "") {
-					filters['item_group'] = frappe.query_report.get_filter_value("item_group");
-				}
-				return { 'filters': filters };
 			}
 		}
 	]

--- a/erpnext/selling/report/payment_terms_status_for_sales_order/test_payment_terms_status_for_sales_order.py
+++ b/erpnext/selling/report/payment_terms_status_for_sales_order/test_payment_terms_status_for_sales_order.py
@@ -48,9 +48,9 @@ class TestPaymentTermsStatusForSalesOrder(FrappeTestCase):
 			template.insert()
 		self.template = template
 
-	def test_payment_terms_status(self):
+	def test_01_payment_terms_status(self):
 		self.create_payment_terms_template()
-		item = create_item(item_code="_Test Excavator", is_stock_item=0)
+		item = create_item(item_code="_Test Excavator 1", is_stock_item=0)
 		so = make_sales_order(
 			transaction_date="2021-06-15",
 			delivery_date=add_days("2021-06-15", -30),
@@ -78,13 +78,14 @@ class TestPaymentTermsStatusForSalesOrder(FrappeTestCase):
 				"company": "_Test Company",
 				"period_start_date": "2021-06-01",
 				"period_end_date": "2021-06-30",
-				"sales_order": [so.name],
+				"item": item.item_code,
 			}
 		)
 
 		expected_value = [
 			{
 				"name": so.name,
+				"customer": so.customer,
 				"submitted": datetime.date(2021, 6, 15),
 				"status": "Completed",
 				"payment_term": None,
@@ -98,6 +99,7 @@ class TestPaymentTermsStatusForSalesOrder(FrappeTestCase):
 			},
 			{
 				"name": so.name,
+				"customer": so.customer,
 				"submitted": datetime.date(2021, 6, 15),
 				"status": "Partly Paid",
 				"payment_term": None,
@@ -132,11 +134,11 @@ class TestPaymentTermsStatusForSalesOrder(FrappeTestCase):
 			)
 			doc.insert()
 
-	def test_alternate_currency(self):
+	def test_02_alternate_currency(self):
 		transaction_date = "2021-06-15"
 		self.create_payment_terms_template()
 		self.create_exchange_rate(transaction_date)
-		item = create_item(item_code="_Test Excavator", is_stock_item=0)
+		item = create_item(item_code="_Test Excavator 2", is_stock_item=0)
 		so = make_sales_order(
 			transaction_date=transaction_date,
 			currency="USD",
@@ -166,7 +168,7 @@ class TestPaymentTermsStatusForSalesOrder(FrappeTestCase):
 				"company": "_Test Company",
 				"period_start_date": "2021-06-01",
 				"period_end_date": "2021-06-30",
-				"sales_order": [so.name],
+				"item": item.item_code,
 			}
 		)
 
@@ -174,6 +176,7 @@ class TestPaymentTermsStatusForSalesOrder(FrappeTestCase):
 		expected_value = [
 			{
 				"name": so.name,
+				"customer": so.customer,
 				"submitted": datetime.date(2021, 6, 15),
 				"status": "Completed",
 				"payment_term": None,
@@ -187,6 +190,7 @@ class TestPaymentTermsStatusForSalesOrder(FrappeTestCase):
 			},
 			{
 				"name": so.name,
+				"customer": so.customer,
 				"submitted": datetime.date(2021, 6, 15),
 				"status": "Partly Paid",
 				"payment_term": None,

--- a/erpnext/selling/report/payment_terms_status_for_sales_order/test_payment_terms_status_for_sales_order.py
+++ b/erpnext/selling/report/payment_terms_status_for_sales_order/test_payment_terms_status_for_sales_order.py
@@ -11,10 +11,13 @@ from erpnext.selling.report.payment_terms_status_for_sales_order.payment_terms_s
 )
 from erpnext.stock.doctype.item.test_item import create_item
 
-test_dependencies = ["Sales Order", "Item", "Sales Invoice", "Payment Terms Template"]
+test_dependencies = ["Sales Order", "Item", "Sales Invoice", "Payment Terms Template", "Customer"]
 
 
 class TestPaymentTermsStatusForSalesOrder(FrappeTestCase):
+	def tearDown(self):
+		frappe.db.rollback()
+
 	def create_payment_terms_template(self):
 		# create template for 50-50 payments
 		template = None
@@ -204,3 +207,134 @@ class TestPaymentTermsStatusForSalesOrder(FrappeTestCase):
 			},
 		]
 		self.assertEqual(data, expected_value)
+
+	def test_03_group_filters(self):
+		transaction_date = "2021-06-15"
+		self.create_payment_terms_template()
+		item1 = create_item(item_code="_Test Excavator 1", is_stock_item=0)
+		item1.item_group = "Products"
+		item1.save()
+
+		so1 = make_sales_order(
+			transaction_date=transaction_date,
+			delivery_date=add_days(transaction_date, -30),
+			item=item1.item_code,
+			qty=1,
+			rate=1000000,
+			do_not_save=True,
+		)
+		so1.po_no = ""
+		so1.taxes_and_charges = ""
+		so1.taxes = ""
+		so1.payment_terms_template = self.template.name
+		so1.save()
+		so1.submit()
+
+		item2 = create_item(item_code="_Test Steel", is_stock_item=0)
+		item2.item_group = "Raw Material"
+		item2.save()
+
+		so2 = make_sales_order(
+			customer="_Test Customer 1",
+			transaction_date=transaction_date,
+			delivery_date=add_days(transaction_date, -30),
+			item=item2.item_code,
+			qty=100,
+			rate=1000,
+			do_not_save=True,
+		)
+		so2.po_no = ""
+		so2.taxes_and_charges = ""
+		so2.taxes = ""
+		so2.payment_terms_template = self.template.name
+		so2.save()
+		so2.submit()
+
+		base_filters = {
+			"company": "_Test Company",
+			"period_start_date": "2021-06-01",
+			"period_end_date": "2021-06-30",
+		}
+
+		expected_value_so1 = [
+			{
+				"name": so1.name,
+				"customer": so1.customer,
+				"submitted": datetime.date(2021, 6, 15),
+				"status": "Overdue",
+				"payment_term": None,
+				"description": "_Test 50-50",
+				"due_date": datetime.date(2021, 6, 30),
+				"invoice_portion": 50.0,
+				"currency": "INR",
+				"base_payment_amount": 500000.0,
+				"paid_amount": 0.0,
+				"invoices": "",
+			},
+			{
+				"name": so1.name,
+				"customer": so1.customer,
+				"submitted": datetime.date(2021, 6, 15),
+				"status": "Overdue",
+				"payment_term": None,
+				"description": "_Test 50-50",
+				"due_date": datetime.date(2021, 7, 15),
+				"invoice_portion": 50.0,
+				"currency": "INR",
+				"base_payment_amount": 500000.0,
+				"paid_amount": 0.0,
+				"invoices": "",
+			},
+		]
+
+		expected_value_so2 = [
+			{
+				"name": so2.name,
+				"customer": so2.customer,
+				"submitted": datetime.date(2021, 6, 15),
+				"status": "Overdue",
+				"payment_term": None,
+				"description": "_Test 50-50",
+				"due_date": datetime.date(2021, 6, 30),
+				"invoice_portion": 50.0,
+				"currency": "INR",
+				"base_payment_amount": 50000.0,
+				"paid_amount": 0.0,
+				"invoices": "",
+			},
+			{
+				"name": so2.name,
+				"customer": so2.customer,
+				"submitted": datetime.date(2021, 6, 15),
+				"status": "Overdue",
+				"payment_term": None,
+				"description": "_Test 50-50",
+				"due_date": datetime.date(2021, 7, 15),
+				"invoice_portion": 50.0,
+				"currency": "INR",
+				"base_payment_amount": 50000.0,
+				"paid_amount": 0.0,
+				"invoices": "",
+			},
+		]
+
+		group_filters = [
+			{"customer_group": "All Customer Groups"},
+			{"item_group": "All Item Groups"},
+			{"item_group": "Products"},
+			{"item_group": "Raw Material"},
+		]
+
+		expected_values_for_group_filters = [
+			expected_value_so1 + expected_value_so2,
+			expected_value_so1 + expected_value_so2,
+			expected_value_so1,
+			expected_value_so2,
+		]
+
+		for idx, g in enumerate(group_filters, 0):
+			# build filter
+			filters = frappe._dict({}).update(base_filters).update(g)
+			with self.subTest(filters=filters):
+				columns, data, message, chart = execute(filters)
+				self.assertEqual(data, expected_values_for_group_filters[idx])


### PR DESCRIPTION
## Change
New field 'Customer' has been added to 'Payment Terms Status for Sales Order' report output. Additional filters Customer, Customer Group, Item and Item group have been added as well.

<img width="1427" alt="Screenshot 2022-03-30 at 6 51 52 PM" src="https://user-images.githubusercontent.com/3272205/160846340-24885941-23c6-4e28-88a4-763b76ec21ae.png">

<img width="1426" alt="Screenshot 2022-03-31 at 9 41 32 AM" src="https://user-images.githubusercontent.com/3272205/160975013-798f2728-008f-49fc-822c-635909e1bcc6.png">


**no-docs**