### PR TITLE
fix(accounts): payment entry exchange rate precision

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -532,7 +532,8 @@ frappe.ui.form.on('Payment Entry', {
 				to_currency: to_currency
 			},
 			callback: function(r, rt) {
-				frm.set_value(exchange_rate_field, r.message);
+				const ex_rate = flt(r.message, frm.get_field(exchange_rate_field).get_precision());
+				frm.set_value(exchange_rate_field, ex_rate);
 			}
 		})
 	},


### PR DESCRIPTION
When the exchange rate is set from the API call `erpnext.setup.utils.get_exchange_rate` the value set is not validated against the precision of the field. 

![payment-entry-ex-rate](https://user-images.githubusercontent.com/29856401/160907119-19532c9a-2444-44ec-8c27-5d6504baa353.png)

