### PR TITLE
fix: Taxes getting overriden from mapped to target doc

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -276,6 +276,8 @@ erpnext.accounts.PurchaseInvoice = class PurchaseInvoice extends erpnext.buying.
 		if(this.frm.updating_party_details || this.frm.doc.inter_company_invoice_reference)
 			return;
 
+		if (this.frm.doc.__onload && this.frm.doc.__onload.load_after_mapping) return;
+
 		erpnext.utils.get_party_details(this.frm, "erpnext.accounts.party.get_party_details",
 			{
 				posting_date: this.frm.doc.posting_date,

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -280,6 +280,9 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends e
 		}
 		var me = this;
 		if(this.frm.updating_party_details) return;
+
+		if (this.frm.doc.__onload && this.frm.doc.__onload.load_after_mapping) return;
+
 		erpnext.utils.get_party_details(this.frm,
 			"erpnext.accounts.party.get_party_details", {
 				posting_date: this.frm.doc.posting_date,


### PR DESCRIPTION
While mapping a source doc (for eg, Purchase Receipt) to a target doc (Purchase Invoice) the taxes should not change and the taxes added manually by the user in the source doc should persist in the target doc

On mapping the doc the `get_party_details` trigger used to reset the taxes from the tax templated added in the doc and the taxes manually added by the user gets removed. The change will prevent this from happening