### PR TITLE
perf: use cached single docs

### DIFF
--- a/erpnext/e_commerce/doctype/e_commerce_settings/e_commerce_settings.py
+++ b/erpnext/e_commerce/doctype/e_commerce_settings/e_commerce_settings.py
@@ -146,12 +146,7 @@ def validate_cart_settings(doc=None, method=None):
 
 
 def get_shopping_cart_settings():
-	if not getattr(frappe.local, "shopping_cart_settings", None):
-		frappe.local.shopping_cart_settings = frappe.get_doc(
-			"E Commerce Settings", "E Commerce Settings"
-		)
-
-	return frappe.local.shopping_cart_settings
+	return frappe.get_cached_doc("E Commerce Settings")
 
 
 @frappe.whitelist(allow_guest=True)

--- a/erpnext/education/doctype/education_settings/education_settings.py
+++ b/erpnext/education/doctype/education_settings/education_settings.py
@@ -41,4 +41,4 @@ class EducationSettings(Document):
 
 
 def update_website_context(context):
-	context["lms_enabled"] = frappe.get_doc("Education Settings").enable_lms
+	context["lms_enabled"] = frappe.get_cached_doc("Education Settings").enable_lms

--- a/erpnext/templates/pages/home.py
+++ b/erpnext/templates/pages/home.py
@@ -8,7 +8,7 @@ no_cache = 1
 
 
 def get_context(context):
-	homepage = frappe.get_doc("Homepage")
+	homepage = frappe.get_cached_doc("Homepage")
 
 	for item in homepage.products:
 		route = frappe.db.get_value("Website Item", {"item_code": item.item_code}, "route")
@@ -20,10 +20,10 @@ def get_context(context):
 	context.homepage = homepage
 
 	if homepage.hero_section_based_on == "Homepage Section" and homepage.hero_section:
-		homepage.hero_section_doc = frappe.get_doc("Homepage Section", homepage.hero_section)
+		homepage.hero_section_doc = frappe.get_cached_doc("Homepage Section", homepage.hero_section)
 
 	if homepage.slideshow:
-		doc = frappe.get_doc("Website Slideshow", homepage.slideshow)
+		doc = frappe.get_cached_doc("Website Slideshow", homepage.slideshow)
 		context.slideshow = homepage.slideshow
 		context.slideshow_header = doc.header
 		context.slides = doc.slideshow_items
@@ -46,7 +46,7 @@ def get_context(context):
 		order_by="section_order asc",
 	)
 	context.homepage_sections = [
-		frappe.get_doc("Homepage Section", name) for name in homepage_sections
+		frappe.get_cached_doc("Homepage Section", name) for name in homepage_sections
 	]
 
 	context.metatags = context.metatags or frappe._dict({})


### PR DESCRIPTION
- Ecommerce settings was cached in frappe.local, which is request-specific thread-local, hence is almost as good as no caching.
- Homepage / Education Settings were just `get_doc`

Singles can be simply cached using `get_cached_doc` (which will always hit Redis for network requests since locals wont have it) Ref: https://github.com/frappe/frappe/pull/16259 


Reduces 3 queries from homepage load. Do NOT backport. 