### PR TITLE
fix(pos): do not reset search input on item selection

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_item_selector.js
+++ b/erpnext/selling/page/point_of_sale/pos_item_selector.js
@@ -243,7 +243,7 @@ erpnext.PointOfSale.ItemSelector = class {
 				value: "+1",
 				item: { item_code, batch_no, serial_no, uom, rate }
 			});
-			me.set_search_value('');
+			me.search_field.set_focus()
 		});
 
 		this.search_field.$input.on('input', (e) => {
@@ -328,6 +328,7 @@ erpnext.PointOfSale.ItemSelector = class {
 
 	add_filtered_item_to_cart() {
 		this.$items_container.find(".item-wrapper").click();
+		this.set_search_value('');
 	}
 
 	resize_selector(minimize) {

--- a/erpnext/selling/page/point_of_sale/pos_item_selector.js
+++ b/erpnext/selling/page/point_of_sale/pos_item_selector.js
@@ -243,7 +243,7 @@ erpnext.PointOfSale.ItemSelector = class {
 				value: "+1",
 				item: { item_code, batch_no, serial_no, uom, rate }
 			});
-			me.search_field.set_focus()
+			me.search_field.set_focus();
 		});
 
 		this.search_field.$input.on('input', (e) => {


### PR DESCRIPTION
Consider a case where a user has several items named AA1...AA20
For creating an invoice like
- 3x AA1
- 4x AA12
- 5x AA14

The user has to
- Search for AA1, then click on the item, then click on the cart and edit the quantity to 3
- Search for AA12, then click on the item, then click on the cart and edit the quantity to 4
- Search for AA14, then click on the item, then click on the cart and edit the quantity to 5

This PR aims to improve that by not resetting the search input field on item selection
So now,
The user has to
- Search for AA1 (AA12 & AA14 should also be displayed)
    - Click on AA1 3 times
    - Click on AA12 4 times
    - Click on AA14 5 times

Provided "Auto-add filtered item to the cart" is disabled