### PR TITLE
fix: convert dates to datetime before comparing in leave days calculation and fix half day edge case

### DIFF
--- a/erpnext/hr/doctype/leave_application/leave_application.py
+++ b/erpnext/hr/doctype/leave_application/leave_application.py
@@ -735,9 +735,9 @@ def get_number_of_leave_days(
 	(Based on the include_holiday setting in Leave Type)"""
 	number_of_days = 0
 	if cint(half_day) == 1:
-		if from_date == to_date:
+		if getdate(from_date) == getdate(to_date):
 			number_of_days = 0.5
-		elif half_day_date and half_day_date <= to_date:
+		elif half_day_date and getdate(from_date) <= getdate(half_day_date) <= getdate(to_date):
 			number_of_days = date_diff(to_date, from_date) + 0.5
 		else:
 			number_of_days = date_diff(to_date, from_date) + 1

--- a/erpnext/hr/doctype/leave_application/test_leave_application.py
+++ b/erpnext/hr/doctype/leave_application/test_leave_application.py
@@ -205,7 +205,12 @@ class TestLeaveApplication(unittest.TestCase):
 		# creates separate leave ledger entries
 		frappe.delete_doc_if_exists("Leave Type", "Test Leave Validation", force=1)
 		leave_type = frappe.get_doc(
-			dict(leave_type_name="Test Leave Validation", doctype="Leave Type", allow_negative=True)
+			dict(
+				leave_type_name="Test Leave Validation",
+				doctype="Leave Type",
+				allow_negative=True,
+				include_holiday=True,
+			)
 		).insert()
 
 		employee = get_employee()
@@ -217,8 +222,14 @@ class TestLeaveApplication(unittest.TestCase):
 		# application across allocations
 
 		# CASE 1: from date has no allocation, to date has an allocation / both dates have allocation
+		start_date = add_days(year_start, -10)
 		application = make_leave_application(
-			employee.name, add_days(year_start, -10), add_days(year_start, 3), leave_type.name
+			employee.name,
+			start_date,
+			add_days(year_start, 3),
+			leave_type.name,
+			half_day=1,
+			half_day_date=start_date,
 		)
 
 		# 2 separate leave ledger entries
@@ -828,6 +839,7 @@ class TestLeaveApplication(unittest.TestCase):
 			leave_type_name="_Test_CF_leave_expiry",
 			is_carry_forward=1,
 			expire_carry_forwarded_leaves_after_days=90,
+			include_holiday=True,
 		)
 		leave_type.submit()
 
@@ -840,6 +852,8 @@ class TestLeaveApplication(unittest.TestCase):
 				leave_type=leave_type.name,
 				from_date=add_days(nowdate(), -3),
 				to_date=add_days(nowdate(), 7),
+				half_day=1,
+				half_day_date=add_days(nowdate(), -3),
 				description="_Test Reason",
 				company="_Test Company",
 				docstatus=1,
@@ -855,7 +869,7 @@ class TestLeaveApplication(unittest.TestCase):
 		self.assertEqual(len(leave_ledger_entry), 2)
 		self.assertEqual(leave_ledger_entry[0].employee, leave_application.employee)
 		self.assertEqual(leave_ledger_entry[0].leave_type, leave_application.leave_type)
-		self.assertEqual(leave_ledger_entry[0].leaves, -9)
+		self.assertEqual(leave_ledger_entry[0].leaves, -8.5)
 		self.assertEqual(leave_ledger_entry[1].leaves, -2)
 
 	def test_leave_application_creation_after_expiry(self):

--- a/erpnext/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/erpnext/payroll/doctype/salary_slip/test_salary_slip.py
@@ -1290,7 +1290,16 @@ def create_additional_salary(employee, payroll_period, amount):
 	return salary_date
 
 
-def make_leave_application(employee, from_date, to_date, leave_type, company=None, submit=True):
+def make_leave_application(
+	employee,
+	from_date,
+	to_date,
+	leave_type,
+	company=None,
+	half_day=False,
+	half_day_date=None,
+	submit=True,
+):
 	leave_application = frappe.get_doc(
 		dict(
 			doctype="Leave Application",
@@ -1298,6 +1307,8 @@ def make_leave_application(employee, from_date, to_date, leave_type, company=Non
 			leave_type=leave_type,
 			from_date=from_date,
 			to_date=to_date,
+			half_day=half_day,
+			half_day_date=half_day_date,
 			company=company or erpnext.get_default_company() or "_Test Company",
 			status="Approved",
 			leave_approver="test@example.com",


### PR DESCRIPTION
- TypeError while getting leaves with half-day for splitting ledger entries (in case of application spanning over 2 allocations or application created with carry-forwarded leave). Convert dates to datetime before comparing them in `get_number_of_leave_days` for leave days calculation as there are multiple sources from where this function gets called.

<details>
<summary>Traceback</summary>

```python
Traceback (most recent call last):
  File "apps/frappe/frappe/desk/form/save.py", line 19, in savedocs
    doc.submit()
  File "apps/frappe/frappe/model/document.py", line 939, in submit
    return self._submit()
  File "apps/frappe/frappe/model/document.py", line 928, in _submit
    return self.save()
  File "apps/frappe/frappe/model/document.py", line 287, in save
    return self._save(*args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 341, in _save
    self.run_post_save_methods()
  File "apps/frappe/frappe/model/document.py", line 1007, in run_post_save_methods
    self.run_method("on_submit")
  File "apps/frappe/frappe/model/document.py", line 869, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1161, in composer
    return composed(self, method, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1144, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "apps/frappe/frappe/model/document.py", line 866, in fn
    return method_object(*args, **kwargs)
  File "apps/erpnext/erpnext/hr/doctype/leave_application/leave_application.py", line 86, in on_submit
    self.create_leave_ledger_entry()
  File "apps/erpnext/erpnext/hr/doctype/leave_application/leave_application.py", line 467, in create_leave_ledger_entry
    self.create_ledger_entry_for_intermediate_allocation_expiry(expiry_date, submit, lwp)
  File "apps/erpnext/erpnext/hr/doctype/leave_application/leave_application.py", line 539, in create_ledger_entry_for_intermediate_allocation_expiry
    leaves = get_number_of_leave_days(self.employee, self.leave_type,
  File "apps/erpnext/erpnext/hr/doctype/leave_application/leave_application.py", line 589, in get_number_of_leave_days
    elif half_day_date and half_day_date <= to_date:
TypeError: '<=' not supported between instances of 'str' and 'datetime.date'
```

</details>

- One more bug was discovered for half-day while fixing:
	- Create a leave application (1st - 10th) spanning over 2 allocations (1st - 5th) (6th - 10th)
	- Choose Half Day for any date within the first allocation, say 1st
	- Total leave days come to 9.5. But while creating ledger entries this will add 0.5 to each ledger entry making it 10 because  `get_number_of_leave_days` only checks if _Half Day Date_ is less than _To Date_. 
	- This adds 0.5 for both allocations. Fixed it to check if _Half Day Date_ falls between _From_ and _To_ dates. So that it checks if half day actually falls in which allocation of the 2.

Missed this half-day edge case in https://github.com/frappe/erpnext/pull/29439 
Extended tests for _separate ledger entry_ and _leave ledger entry for intermediate expiry_ to check for half day.