### PR TITLE
fix: maintain FIFO queue even if outgoing_rate is not found

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -866,16 +866,9 @@ class update_entries_after(object):
 							index = i
 							break
 
-					# If no entry found with outgoing rate, collapse stack
+					# If no entry found with outgoing rate, consume as per FIFO
 					if index is None:  # nosemgrep
-						new_stock_value = (
-							sum((d[0] * d[1] for d in self.wh_data.stock_queue)) - qty_to_pop * outgoing_rate
-						)
-						new_stock_qty = sum((d[0] for d in self.wh_data.stock_queue)) - qty_to_pop
-						self.wh_data.stock_queue = [
-							[new_stock_qty, new_stock_value / new_stock_qty if new_stock_qty > 0 else outgoing_rate]
-						]
-						break
+						index = 0
 				else:
 					index = 0
 


### PR DESCRIPTION
port of #30560

