### PR TITLE
fix: Do not apply shipping rule for POS transactions

### DIFF
--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -307,6 +307,11 @@ class calculate_taxes_and_totals(object):
 		self.doc.round_floats_in(self.doc, ["total", "base_total", "net_total", "base_net_total"])
 
 	def calculate_shipping_charges(self):
+
+		# Do not apply shipping rule for POS
+		if self.doc.is_pos:
+			return
+
 		if hasattr(self.doc, "shipping_rule") and self.doc.shipping_rule:
 			shipping_rule = frappe.get_doc("Shipping Rule", self.doc.shipping_rule)
 			shipping_rule.apply(self.doc)

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -309,7 +309,7 @@ class calculate_taxes_and_totals(object):
 	def calculate_shipping_charges(self):
 
 		# Do not apply shipping rule for POS
-		if self.doc.is_pos:
+		if self.doc.get("is_pos"):
 			return
 
 		if hasattr(self.doc, "shipping_rule") and self.doc.shipping_rule:

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -271,6 +271,11 @@ erpnext.taxes_and_totals = erpnext.payments.extend({
 	},
 
 	calculate_shipping_charges: function() {
+		// Do not apply shipping rule for POS
+		if (this.frm.doc.is_pos) {
+			return;
+		}
+
 		frappe.model.round_floats_in(this.frm.doc, ["total", "base_total", "net_total", "base_net_total"]);
 		if (frappe.meta.get_docfield(this.frm.doc.doctype, "shipping_rule", this.frm.doc.name)) {
 			return this.shipping_rule();


### PR DESCRIPTION
POS transactions doesn't involve any shipping so shipping rule should not be applied on POS transactions