### PR TITLE
fix: hide pending qty only if original item is assigned

### DIFF
--- a/erpnext/public/js/utils/serial_no_batch_selector.js
+++ b/erpnext/public/js/utils/serial_no_batch_selector.js
@@ -609,8 +609,8 @@ function check_can_calculate_pending_qty(me) {
 		&& erpnext.stock.bom
 		&& erpnext.stock.bom.name === doc.bom_no;
 	const itemChecks = !!item
-		&& !item.allow_alternative_item
-		&& erpnext.stock.bom && erpnext.stock.items
+		&& !item.original_item
+		&& erpnext.stock.bom && erpnext.stock.bom.items
 		&& (item.item_code in erpnext.stock.bom.items);
 	return docChecks && itemChecks;
 }


### PR DESCRIPTION
- Pending qty fields were missing if "allow alternative item" was checked. This is checked regardless of usage of alternate item. Check if an alternate item is ACTUALLY being used. 
- Correct nullish value check (caused by https://github.com/frappe/erpnext/pull/30378)