### PR TITLE
fix: only trigger onload checks on saved docs

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.js
+++ b/erpnext/manufacturing/doctype/job_card/job_card.js
@@ -28,12 +28,12 @@ frappe.ui.form.on('Job Card', {
 		frappe.flags.resume_job = 0;
 		let has_items = frm.doc.items && frm.doc.items.length;
 
-		if (frm.doc.__onload.work_order_closed) {
+		if (!frm.is_new() && frm.doc.__onload.work_order_closed) {
 			frm.disable_save();
 			return;
 		}
 
-		if (!frm.doc.__islocal && has_items && frm.doc.docstatus < 2) {
+		if (!frm.doc.is_new() && has_items && frm.doc.docstatus < 2) {
 			let to_request = frm.doc.for_quantity > frm.doc.transferred_qty;
 			let excess_transfer_allowed = frm.doc.__onload.job_card_excess_transfer;
 


### PR DESCRIPTION
Opening a new job card shows this error in the console 

<img width="937" alt="Screenshot 2022-04-06 at 6 07 51 PM" src="https://user-images.githubusercontent.com/9079960/161977069-b9b57474-f4d3-4c22-a1c1-c2cece274bc2.png">
