### PR TITLE
fix: Exchange gain and loss button in Payment Entry

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -224,10 +224,7 @@ frappe.ui.form.on('Payment Entry', {
 			(frm.doc.total_allocated_amount > party_amount)));
 
 		frm.toggle_display("set_exchange_gain_loss",
-			(frm.doc.paid_amount && frm.doc.received_amount && frm.doc.difference_amount &&
-				((frm.doc.paid_from_account_currency != company_currency ||
-					frm.doc.paid_to_account_currency != company_currency) &&
-					frm.doc.paid_from_account_currency != frm.doc.paid_to_account_currency)));
+			frm.doc.paid_amount && frm.doc.received_amount && frm.doc.difference_amount);
 
 		frm.refresh_fields();
 	},


### PR DESCRIPTION
Currently, the button to add exchange gain and loss as deductions show up in the UI only when the paid from and paid to account has different currencies and the currency is different currencies.

There could be scenarios where both the accounts have the same currency but still there is an exchange gain and loss due due to different exchange rates at the time of invoicing and make payment

Updated the condition to show up the button in both the scenarios 