### PR TITLE
fix(UX): enable Track Changes, show allocation history for earned leaves allocated via scheduler

### DIFF
--- a/erpnext/hr/doctype/leave_allocation/leave_allocation.js
+++ b/erpnext/hr/doctype/leave_allocation/leave_allocation.js
@@ -34,6 +34,15 @@ frappe.ui.form.on("Leave Allocation", {
 				});
 			}
 		}
+
+		// make new leaves allocated field read only if allocation is created via leave policy assignment
+		// and leave type is earned leave, since these leaves would be allocated via the scheduler
+		if (frm.doc.leave_policy_assignment) {
+			frappe.db.get_value("Leave Type", frm.doc.leave_type, "is_earned_leave", (r) => {
+				if (r && cint(r.is_earned_leave))
+					frm.set_df_property("new_leaves_allocated", "read_only", 1);
+			});
+		}
 	},
 
 	expire_allocation: function(frm) {

--- a/erpnext/hr/doctype/leave_allocation/leave_allocation.json
+++ b/erpnext/hr/doctype/leave_allocation/leave_allocation.json
@@ -237,7 +237,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2022-01-18 19:15:53.262536",
+ "modified": "2022-04-07 09:50:33.145825",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Leave Allocation",
@@ -281,5 +281,6 @@
  "sort_order": "DESC",
  "states": [],
  "timeline_field": "employee",
- "title_field": "employee_name"
+ "title_field": "employee_name",
+ "track_changes": 1
 }

--- a/erpnext/hr/utils.py
+++ b/erpnext/hr/utils.py
@@ -353,6 +353,17 @@ def update_previous_leave_allocation(
 			allocation.db_set("total_leaves_allocated", new_allocation, update_modified=False)
 			create_additional_leave_ledger_entry(allocation, earned_leaves, today_date)
 
+			if e_leave_type.based_on_date_of_joining:
+				text = _("allocated {0} leave(s) via scheduler on {1} based on the date of joining").format(
+					frappe.bold(earned_leaves), frappe.bold(formatdate(today_date))
+				)
+			else:
+				text = _("allocated {0} leave(s) via scheduler on {1}").format(
+					frappe.bold(earned_leaves), frappe.bold(formatdate(today_date))
+				)
+
+			allocation.add_comment(comment_type="Info", text=text)
+
 
 def get_monthly_earned_leave(annual_leaves, frequency, rounding):
 	earned_leaves = 0.0


### PR DESCRIPTION
## Background:

If Leave Policy Assignment is created for Earned Leave, initially 0 leaves are allocated and then allocation happens every month based on the configuration set in Leave Type. 
eg Policy: **Annual Allocation**: 24, **Frequency**: Monthly
In this case, 2 leaves will be allocated every month for the employee via scheduler. 

## Problem:

- Users are directly shown Total Leaves Allocated in Leave Allocation.
   <img width="1306" alt="image" src="https://user-images.githubusercontent.com/24353136/162035262-a7b9139a-a519-47c3-90be-7bacca46547d.png">
- There is no trace of when the scheduler allocates these leaves because this happens via `db_set`
- "New Leaves Allocated" field is editable after submission even for Earned Leave type with policy assignment which doesn't make sense because this allocation happens via scheduler. Users can reset leaves to 0 directly, without any trace and ledgers do not handle this.
- There is one more setting that decides when this leave will be allocated via the scheduler in Leave Type master. If Based on Date of Joining is enabled, it allocates leave every month on the Joining Date of the employee, else on month-end.

  <img width="1306" alt="image" src="https://user-images.githubusercontent.com/24353136/162036498-e3eea28e-4242-4d56-a643-d66f70e35e41.png">
- Basically, users have to see 3 different things and do the mental math to derive the number of leaves shown in the allocation: the annual allocation, the number of months that have passed, and the based on DOJ setting.

## Fix: 

- Enable Track Changes for Leave Allocation (useful for allocations not happening via a scheduler)
- Make New Leaves Allocated input read-only if the earned leave Allocation is linked to Leave Policy Assignment (indicating that this will happen via scheduler)
- Show the history of earned leaves allocated along with the date and the info of whether they were allocated based on DOJ or not

Based on DOJ:

<img width="1306" alt="log" src="https://user-images.githubusercontent.com/24353136/162037189-1ae38ff5-a87a-4bf4-9655-082319e099e7.png">

Usual:

<img width="556" alt="image" src="https://user-images.githubusercontent.com/24353136/162038352-ee4350e0-1942-403e-ae7d-6b29b2b51b44.png">
