### PR TITLE
feat: add Link to Opportunity

### DIFF
--- a/erpnext/buying/doctype/request_for_quotation/request_for_quotation.json
+++ b/erpnext/buying/doctype/request_for_quotation/request_for_quotation.json
@@ -32,7 +32,9 @@
   "terms",
   "printing_settings",
   "select_print_heading",
-  "letter_head"
+  "letter_head",
+  "more_info",
+  "opportunity"
  ],
  "fields": [
   {
@@ -194,6 +196,23 @@
    "print_hide": 1
   },
   {
+   "collapsible": 1,
+   "fieldname": "more_info",
+   "fieldtype": "Section Break",
+   "label": "More Information",
+   "oldfieldtype": "Section Break",
+   "options": "fa fa-file-text",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "opportunity",
+   "fieldtype": "Link",
+   "label": "Opportunity",
+   "options": "Opportunity",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
    "fieldname": "status",
    "fieldtype": "Select",
    "label": "Status",
@@ -258,7 +277,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2021-11-24 17:47:49.909000",
+ "modified": "2022-04-06 17:47:49.909000",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Request for Quotation",


### PR DESCRIPTION
Following the process of Opportunity to Quotation I added a section and link field to Opportunity for a backlink when using "create"-> Request for Quotation from Opportunity.

- [ ] Also one would need to create a dashboard link in opportunity to ease the navigation:

<img width="1353" alt="image" src="https://user-images.githubusercontent.com/22279621/162049641-12101046-ea3c-4fdc-a20e-c0e29a96d6ab.png">

In Action
![rfq_from_opportunity](https://user-images.githubusercontent.com/22279621/162050406-22126977-5d60-40b9-8f2b-d2af2b9863cc.gif)

`no-docs`