### PR TITLE
fix: warehouse naming when suffix is present

### DIFF
--- a/erpnext/stock/doctype/warehouse/test_warehouse.py
+++ b/erpnext/stock/doctype/warehouse/test_warehouse.py
@@ -38,6 +38,16 @@ class TestWarehouse(FrappeTestCase):
 			self.assertEqual(p_warehouse.name, child_warehouse.parent_warehouse)
 			self.assertEqual(child_warehouse.is_group, 0)
 
+	def test_naming(self):
+		company = "Wind Power LLC"
+		warehouse_name = "Named Warehouse - WP"
+		wh = frappe.get_doc(doctype="Warehouse", warehouse_name=warehouse_name, company=company).insert()
+		self.assertEqual(wh.name, warehouse_name)
+
+		warehouse_name = "Unnamed Warehouse"
+		wh = frappe.get_doc(doctype="Warehouse", warehouse_name=warehouse_name, company=company).insert()
+		self.assertIn(warehouse_name, wh.name)
+
 	def test_unlinking_warehouse_from_item_defaults(self):
 		company = "_Test Company"
 

--- a/erpnext/stock/doctype/warehouse/warehouse.py
+++ b/erpnext/stock/doctype/warehouse/warehouse.py
@@ -21,8 +21,9 @@ class Warehouse(NestedSet):
 			suffix = " - " + frappe.get_cached_value("Company", self.company, "abbr")
 			if not self.warehouse_name.endswith(suffix):
 				self.name = self.warehouse_name + suffix
-		else:
-			self.name = self.warehouse_name
+				return
+
+		self.name = self.warehouse_name
 
 	def onload(self):
 		"""load account name for General Ledger Report"""


### PR DESCRIPTION
If `warehouse_name` already has an expected suffix then the warehouse name is not set and hash is used instead. 

<img width="453" alt="Screenshot 2022-04-07 at 12 50 54 PM" src="https://user-images.githubusercontent.com/9079960/162142807-eef8da1c-4407-4442-aa26-55249fede53f.png">
