### PR TITLE
fix: dont reassign mutable (list) to a different field

### DIFF
--- a/erpnext/accounts/report/purchase_register/purchase_register.py
+++ b/erpnext/accounts/report/purchase_register/purchase_register.py
@@ -124,11 +124,11 @@ def get_columns(invoice_list, additional_table_columns):
 		_("Purchase Receipt") + ":Link/Purchase Receipt:100",
 		{"fieldname": "currency", "label": _("Currency"), "fieldtype": "Data", "width": 80},
 	]
-	expense_accounts = (
-		tax_accounts
-	) = (
-		expense_columns
-	) = tax_columns = unrealized_profit_loss_accounts = unrealized_profit_loss_account_columns = []
+
+	expense_accounts = []
+	tax_accounts = []
+	tax_columns = []
+	unrealized_profit_loss_accounts = []
 
 	if invoice_list:
 		expense_accounts = frappe.db.sql_list(

--- a/erpnext/accounts/report/purchase_register/purchase_register.py
+++ b/erpnext/accounts/report/purchase_register/purchase_register.py
@@ -127,7 +127,6 @@ def get_columns(invoice_list, additional_table_columns):
 
 	expense_accounts = []
 	tax_accounts = []
-	tax_columns = []
 	unrealized_profit_loss_accounts = []
 
 	if invoice_list:
@@ -163,10 +162,11 @@ def get_columns(invoice_list, additional_table_columns):
 	unrealized_profit_loss_account_columns = [
 		(account + ":Currency/currency:120") for account in unrealized_profit_loss_accounts
 	]
-
-	for account in tax_accounts:
-		if account not in expense_accounts:
-			tax_columns.append(account + ":Currency/currency:120")
+	tax_columns = [
+		(account + ":Currency/currency:120")
+		for account in tax_accounts
+		if account not in expense_accounts
+	]
 
 	columns = (
 		columns

--- a/erpnext/crm/doctype/opportunity/opportunity.py
+++ b/erpnext/crm/doctype/opportunity/opportunity.py
@@ -126,7 +126,8 @@ class Opportunity(TransactionBase):
 	def declare_enquiry_lost(self, lost_reasons_list, competitors, detailed_reason=None):
 		if not self.has_active_quotation():
 			self.status = "Lost"
-			self.lost_reasons = self.competitors = []
+			self.lost_reasons = []
+			self.competitors = []
 
 			if detailed_reason:
 				self.order_lost_reason = detailed_reason

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -100,7 +100,8 @@ class Customer(TransactionBase):
 	@frappe.whitelist()
 	def get_customer_group_details(self):
 		doc = frappe.get_doc("Customer Group", self.customer_group)
-		self.accounts = self.credit_limits = []
+		self.accounts = []
+		self.credit_limits = []
 		self.payment_terms = self.default_price_list = ""
 
 		tables = [["accounts", "account"], ["credit_limits", "credit_limit"]]

--- a/erpnext/selling/doctype/customer/test_customer.py
+++ b/erpnext/selling/doctype/customer/test_customer.py
@@ -45,7 +45,8 @@ class TestCustomer(FrappeTestCase):
 		c_doc.customer_name = "Testing Customer"
 		c_doc.customer_group = "_Testing Customer Group"
 		c_doc.payment_terms = c_doc.default_price_list = ""
-		c_doc.accounts = c_doc.credit_limits = []
+		c_doc.accounts = []
+		c_doc.credit_limits = []
 		c_doc.insert()
 		c_doc.get_customer_group_details()
 		self.assertEqual(c_doc.payment_terms, "_Test Payment Term Template 3")


### PR DESCRIPTION
Search regex for those interested: `[^=]*=[^=]+=.*\[\]`

Identified here: https://github.com/frappe/erpnext/runs/5866861172?check_suite_focus=true#step:12:843 