### PR TITLE
feat: barcode scanning in quotation

### DIFF
--- a/erpnext/selling/doctype/quotation/quotation.json
+++ b/erpnext/selling/doctype/quotation/quotation.json
@@ -41,6 +41,8 @@
   "price_list_currency",
   "plc_conversion_rate",
   "ignore_pricing_rule",
+  "section_break_33",
+  "scan_barcode",
   "items_section",
   "items",
   "bundle_items_section",
@@ -955,13 +957,23 @@
    "label": "Competitors",
    "options": "Competitor Detail",
    "read_only": 1
+  },
+  {
+   "fieldname": "section_break_33",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "scan_barcode",
+   "fieldtype": "Data",
+   "label": "Scan Barcode",
+   "options": "Barcode"
   }
  ],
  "icon": "fa fa-shopping-cart",
  "idx": 82,
  "is_submittable": 1,
  "links": [],
- "modified": "2021-11-30 01:33:21.106073",
+ "modified": "2022-04-07 11:01:31.157084",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Quotation",
@@ -1056,6 +1068,7 @@
  "show_name_in_global_search": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "timeline_field": "party_name",
  "title_field": "title"
 }


### PR DESCRIPTION
closes https://github.com/frappe/erpnext/issues/6221 


All the code already exists, it just needed the "scan barcode" field to enable this 😄 

Looks and functions like the rest of the transactions. 

<img width="1140" alt="Screenshot 2022-04-07 at 8 35 54 PM" src="https://user-images.githubusercontent.com/9079960/162231049-3735e1a9-86ad-4c2e-875e-2c11d389fedc.png">

`no-docs` (self-explanatory)