### PR TITLE
fix: block cancellation of SL/GL entries

### DIFF
--- a/erpnext/accounts/doctype/gl_entry/gl_entry.js
+++ b/erpnext/accounts/doctype/gl_entry/gl_entry.js
@@ -3,6 +3,6 @@
 
 frappe.ui.form.on('GL Entry', {
 	refresh: function(frm) {
-
+		frm.page.btn_secondary.hide()
 	}
 });

--- a/erpnext/accounts/doctype/gl_entry/gl_entry.py
+++ b/erpnext/accounts/doctype/gl_entry/gl_entry.py
@@ -269,6 +269,11 @@ class GLEntry(Document):
 		if not self.fiscal_year:
 			self.fiscal_year = get_fiscal_year(self.posting_date, company=self.company)[0]
 
+	def on_cancel(self):
+		msg = _("Individual GL Entry cannot be cancelled.")
+		msg += "<br>" + _("Please cancel related transaction.")
+		frappe.throw(msg)
+
 
 def validate_balance_type(account, adv_adj=False):
 	if not adv_adj and account:

--- a/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.js
+++ b/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.js
@@ -3,6 +3,6 @@
 
 frappe.ui.form.on('Stock Ledger Entry', {
 	refresh: function(frm) {
-
+		frm.page.btn_secondary.hide()
 	}
 });

--- a/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py
+++ b/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py
@@ -209,6 +209,11 @@ class StockLedgerEntry(Document):
 					msg += "<br>" + "<br>".join(authorized_users)
 					frappe.throw(msg, BackDatedStockTransaction, title=_("Backdated Stock Entry"))
 
+	def on_cancel(self):
+		msg = _("Individual Stock Ledger Entry cannot be cancelled.")
+		msg += "<br>" + _("Please cancel related transaction.")
+		frappe.throw(msg)
+
 
 def on_doctype_update():
 	if not frappe.db.has_index("tabStock Ledger Entry", "posting_sort_index"):


### PR DESCRIPTION
Individual GL/SLEs aren't supposed to be canceled by users. This is mostly harmless but leads to inconsistency as some queries filter on docstatus too. 