### PR TITLE
ci: collate codecov reports before uploading

### DIFF
--- a/.github/workflows/server-tests-mariadb.yml
+++ b/.github/workflows/server-tests-mariadb.yml
@@ -119,9 +119,22 @@ jobs:
           ORCHESTRATOR_URL: http://test-orchestrator.frappe.io
 
       - name: Upload coverage data
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-${{ matrix.container }}
+          path: /home/runner/frappe-bench/sites/coverage.xml
+
+  coverage:
+    name: Coverage Wrap Up
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+
+      - name: Upload coverage data
         uses: codecov/codecov-action@v2
         with:
           name: MariaDB
           fail_ci_if_error: true
-          files: /home/runner/frappe-bench/sites/coverage.xml
           verbose: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -21,7 +21,6 @@ coverage:
 comment:
   layout: "diff, files"
   require_changes: true
-  after_n_builds: 3
 
 ignore:
   - "erpnext/demo"

--- a/erpnext/stock/doctype/pick_list/test_pick_list.py
+++ b/erpnext/stock/doctype/pick_list/test_pick_list.py
@@ -8,7 +8,7 @@ test_dependencies = ["Item", "Sales Invoice", "Stock Entry", "Batch"]
 
 from frappe.tests.utils import FrappeTestCase
 
-from erpnext.stock.doctype.item.test_item import create_item
+from erpnext.stock.doctype.item.test_item import create_item, make_item
 from erpnext.stock.doctype.pick_list.pick_list import create_delivery_note
 from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import make_purchase_receipt
 from erpnext.stock.doctype.stock_reconciliation.stock_reconciliation import (
@@ -18,6 +18,7 @@ from erpnext.stock.doctype.stock_reconciliation.stock_reconciliation import (
 
 class TestPickList(FrappeTestCase):
 	def test_pick_list_picks_warehouse_for_each_item(self):
+		item_code = make_item().name
 		try:
 			frappe.get_doc(
 				{
@@ -27,7 +28,7 @@ class TestPickList(FrappeTestCase):
 					"expense_account": "Temporary Opening - _TC",
 					"items": [
 						{
-							"item_code": "_Test Item",
+							"item_code": item_code,
 							"warehouse": "_Test Warehouse - _TC",
 							"valuation_rate": 100,
 							"qty": 5,
@@ -47,7 +48,7 @@ class TestPickList(FrappeTestCase):
 				"purpose": "Delivery",
 				"locations": [
 					{
-						"item_code": "_Test Item",
+						"item_code": item_code,
 						"qty": 5,
 						"stock_qty": 5,
 						"conversion_factor": 1,
@@ -59,7 +60,7 @@ class TestPickList(FrappeTestCase):
 		)
 		pick_list.set_item_locations()
 
-		self.assertEqual(pick_list.locations[0].item_code, "_Test Item")
+		self.assertEqual(pick_list.locations[0].item_code, item_code)
 		self.assertEqual(pick_list.locations[0].warehouse, "_Test Warehouse - _TC")
 		self.assertEqual(pick_list.locations[0].qty, 5)
 
@@ -270,6 +271,8 @@ class TestPickList(FrappeTestCase):
 		pr2.cancel()
 
 	def test_pick_list_for_items_from_multiple_sales_orders(self):
+
+		item_code = make_item().name
 		try:
 			frappe.get_doc(
 				{
@@ -279,7 +282,7 @@ class TestPickList(FrappeTestCase):
 					"expense_account": "Temporary Opening - _TC",
 					"items": [
 						{
-							"item_code": "_Test Item",
+							"item_code": item_code,
 							"warehouse": "_Test Warehouse - _TC",
 							"valuation_rate": 100,
 							"qty": 10,
@@ -295,7 +298,14 @@ class TestPickList(FrappeTestCase):
 				"doctype": "Sales Order",
 				"customer": "_Test Customer",
 				"company": "_Test Company",
-				"items": [{"item_code": "_Test Item", "qty": 10, "delivery_date": frappe.utils.today()}],
+				"items": [
+					{
+						"item_code": item_code,
+						"qty": 10,
+						"delivery_date": frappe.utils.today(),
+						"warehouse": "_Test Warehouse - _TC",
+					}
+				],
 			}
 		)
 		sales_order.submit()
@@ -309,7 +319,7 @@ class TestPickList(FrappeTestCase):
 				"purpose": "Delivery",
 				"locations": [
 					{
-						"item_code": "_Test Item",
+						"item_code": item_code,
 						"qty": 5,
 						"stock_qty": 5,
 						"conversion_factor": 1,
@@ -317,7 +327,7 @@ class TestPickList(FrappeTestCase):
 						"sales_order_item": "_T-Sales Order-1_item",
 					},
 					{
-						"item_code": "_Test Item",
+						"item_code": item_code,
 						"qty": 5,
 						"stock_qty": 5,
 						"conversion_factor": 1,
@@ -329,18 +339,19 @@ class TestPickList(FrappeTestCase):
 		)
 		pick_list.set_item_locations()
 
-		self.assertEqual(pick_list.locations[0].item_code, "_Test Item")
+		self.assertEqual(pick_list.locations[0].item_code, item_code)
 		self.assertEqual(pick_list.locations[0].warehouse, "_Test Warehouse - _TC")
 		self.assertEqual(pick_list.locations[0].qty, 5)
 		self.assertEqual(pick_list.locations[0].sales_order_item, "_T-Sales Order-1_item")
 
-		self.assertEqual(pick_list.locations[1].item_code, "_Test Item")
+		self.assertEqual(pick_list.locations[1].item_code, item_code)
 		self.assertEqual(pick_list.locations[1].warehouse, "_Test Warehouse - _TC")
 		self.assertEqual(pick_list.locations[1].qty, 5)
 		self.assertEqual(pick_list.locations[1].sales_order_item, sales_order.items[0].name)
 
 	def test_pick_list_for_items_with_multiple_UOM(self):
-		purchase_receipt = make_purchase_receipt(item_code="_Test Item", qty=10)
+		item_code = make_item().name
+		purchase_receipt = make_purchase_receipt(item_code=item_code, qty=10)
 		purchase_receipt.submit()
 
 		sales_order = frappe.get_doc(
@@ -350,17 +361,19 @@ class TestPickList(FrappeTestCase):
 				"company": "_Test Company",
 				"items": [
 					{
-						"item_code": "_Test Item",
+						"item_code": item_code,
 						"qty": 1,
 						"conversion_factor": 5,
 						"stock_qty": 5,
 						"delivery_date": frappe.utils.today(),
+						"warehouse": "_Test Warehouse - _TC",
 					},
 					{
-						"item_code": "_Test Item",
+						"item_code": item_code,
 						"qty": 1,
 						"conversion_factor": 1,
 						"delivery_date": frappe.utils.today(),
+						"warehouse": "_Test Warehouse - _TC",
 					},
 				],
 			}
@@ -376,7 +389,7 @@ class TestPickList(FrappeTestCase):
 				"purpose": "Delivery",
 				"locations": [
 					{
-						"item_code": "_Test Item",
+						"item_code": item_code,
 						"qty": 2,
 						"stock_qty": 1,
 						"conversion_factor": 0.5,
@@ -384,7 +397,7 @@ class TestPickList(FrappeTestCase):
 						"sales_order_item": sales_order.items[0].name,
 					},
 					{
-						"item_code": "_Test Item",
+						"item_code": item_code,
 						"qty": 1,
 						"stock_qty": 1,
 						"conversion_factor": 1,


### PR DESCRIPTION
Currently due to flake partial reports are submitting which results in
constant fluctuation of coverage reports.
Change: First collect coverage and if all builds pass then submit it.

