### PR TITLE
fix: Handle multiple item transfer in separate SEs against WO

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -540,8 +540,10 @@ erpnext.work_order = {
 				|| frm.doc.transfer_material_against == 'Job Card') ? 0 : 1;
 
 			if (show_start_btn) {
-				if ((flt(doc.material_transferred_for_manufacturing) < flt(doc.qty))
-					&& frm.doc.status != 'Stopped') {
+				let pending_to_transfer = frm.doc.required_items.some(
+					item => flt(item.transferred_qty) < flt(item.required_qty)
+				)
+				if (pending_to_transfer && frm.doc.status != 'Stopped') {
 					frm.has_start_btn = true;
 					frm.add_custom_button(__('Create Pick List'), function() {
 						erpnext.work_order.create_pick_list(frm);

--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -542,7 +542,7 @@ erpnext.work_order = {
 			if (show_start_btn) {
 				let pending_to_transfer = frm.doc.required_items.some(
 					item => flt(item.transferred_qty) < flt(item.required_qty)
-				)
+				);
 				if (pending_to_transfer && frm.doc.status != 'Stopped') {
 					frm.has_start_btn = true;
 					frm.add_custom_button(__('Create Pick List'), function() {

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -1186,7 +1186,11 @@ def make_stock_entry(work_order_id, purpose, qty=None):
 	stock_entry.from_bom = 1
 	stock_entry.bom_no = work_order.bom_no
 	stock_entry.use_multi_level_bom = work_order.use_multi_level_bom
-	stock_entry.fg_completed_qty = qty or (flt(work_order.qty) - flt(work_order.produced_qty))
+	# accept 0 qty as well
+	stock_entry.fg_completed_qty = (
+		qty if qty is not None else (flt(work_order.qty) - flt(work_order.produced_qty))
+	)
+
 	if work_order.bom_no:
 		stock_entry.inspection_required = frappe.db.get_value(
 			"BOM", work_order.bom_no, "inspection_required"

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -1803,7 +1803,9 @@ class StockEntry(StockController):
 				or (desire_to_transfer > 0 and backflush_based_on == "Material Transferred for Manufacture")
 				or allow_overproduction
 			):
-				item_dict[item]["qty"] = desire_to_transfer
+				# "No need for transfer but qty still pending to transfer" case can occur
+				# when transferring multiple RM in different Stock Entries
+				item_dict[item]["qty"] = desire_to_transfer if (desire_to_transfer > 0) else pending_to_issue
 			elif pending_to_issue > 0:
 				item_dict[item]["qty"] = pending_to_issue
 			else:


### PR DESCRIPTION
> Closes https://github.com/frappe/erpnext/issues/26535 and more.

**Issue:**
- Consider FG with Raw Materials Item A and B. 
- FG : RM 1 : RM2 = **1 : 1 : 1**
- Backflush Raw Materials Based On = **Material Transferred for Manufacture**
- Make a WO for **1 Qty**.
- Transfer Item A only. **Material Transferred for Manufacturing** in WO = 1
- Now there's no way to transfer Item B, since WO assumes transfer is done due to **Material Transferred for Manufacturing**

- https://user-images.githubusercontent.com/25857446/162720486-369bdd2c-af8a-4c97-bfcd-c7784944588d.mov

**Fix:**
- Check for pending qty in child items to show/hide "Start" button, even if **Material Transferred for Manufacturing** meets requirements
- If no qty needed to transfer (FG qty is fulfilled), but RM qty pending: **map pending in SE** with **For Quantity = 0**

- https://user-images.githubusercontent.com/25857446/162720148-1748edee-8363-409e-8afe-4a577dae1543.mov

----
> For partial transfers of larger qty, users will have to edit "For Quantity" and set it to 0 for now if they don't want to increase **Material Transferred for Manufacturing**. Thinking of a way to improve this UX