### PR TITLE
fix: ignore item-less maintenance visit for sr no

### DIFF
--- a/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.js
+++ b/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.js
@@ -12,6 +12,9 @@ frappe.ui.form.on('Maintenance Visit', {
 		// filters for serial no based on item code
 		if (frm.doc.maintenance_type === "Scheduled") {
 			let item_code = frm.doc.purposes[0].item_code;
+			if (!item_code) {
+				return;
+			}
 			frappe.call({
 				method: "erpnext.maintenance.doctype.maintenance_schedule.maintenance_schedule.get_serial_nos_from_schedule",
 				args: {


### PR DESCRIPTION
When the item code isn't present maintenance visit fails with this exception. It's technically harmless, but annoying. 

---

### App Versions
```
{
	"erpnext": "14.0.0-dev",
	"frappe": "14.0.0-dev"
}
```
### Route
```
Form/Maintenance Visit/MAT-MVS-2022-00002
```
### Trackeback
```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 66, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 54, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 31, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 68, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1259, in call
    return fn(*args, **newargs)
TypeError: get_serial_nos_from_schedule() missing 1 required positional argument: 'item_code'

```
### Request Data
```
{
	"type": "POST",
	"args": {},
	"headers": {},
	"error_handlers": {},
	"url": "/api/method/erpnext.maintenance.doctype.maintenance_schedule.maintenance_schedule.get_serial_nos_from_schedule"
}
```
### Response Data
```
{
	"exception": "TypeError: get_serial_nos_from_schedule() missing 1 required positional argument: 'item_code'"
}
```