### PR TITLE
feat: Ignore permlevel for specific fields

### DIFF
--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -22,6 +22,9 @@ class QtyMismatchError(ValidationError):
 
 
 class BuyingController(StockController, Subcontracting):
+	def __setup__(self):
+		self.flags.ignore_permlevel_for_fields = ["buying_price_list", "price_list_currency"]
+
 	def get_feed(self):
 		if self.get("supplier_name"):
 			return _("From {0} | {1} {2}").format(self.supplier_name, self.currency, self.grand_total)

--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -16,6 +16,9 @@ from erpnext.stock.utils import get_incoming_rate
 
 
 class SellingController(StockController):
+	def __setup__(self):
+		self.flags.ignore_permlevel_for_fields = ["selling_price_list", "price_list_currency"]
+
 	def get_feed(self):
 		return _("To {0} | {1} {2}").format(self.customer_name, self.currency, self.grand_total)
 


### PR DESCRIPTION
**Current Behaviour:**
Currently, if a field has a higher permlevel and a user does not have permission to that permlevel, on saving the document system resets the value of the field if there are any changes.

**Solution:**
There are some use-cases where the value of the field is changed by the code, not by the user. To allow those changes, introduced a document level flag to mention those specific fields for which permlevel will be ignored.

**Actual Use Case:**
In the ERPNext sales cycle, users want to set a higher permlevel for the price_list field because they want to control and it is set based on configuration.
On loading a transaction, the default value for price_list is set based on default_price_list set on Selling Settings. Then on the selection of Customers, it gets overwritten by the customer's default price list. But on saving the transaction, the system resets the price_list field's value to the original (system settings). This change will fix it.

Associated PR on the Frappe: https://github.com/frappe/frappe/pull/16590

docs: no-docs