### PR TITLE
fix: Map Production Plan company in subassembly WO created from it

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -500,6 +500,7 @@ class ProductionPlan(Document):
 
 		for supplier, po_list in subcontracted_po.items():
 			po = frappe.new_doc("Purchase Order")
+			po.company = self.company
 			po.supplier = supplier
 			po.schedule_date = getdate(po_list[0].schedule_date) if po_list[0].schedule_date else nowdate()
 			po.is_subcontracted = 1

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -462,6 +462,7 @@ class ProductionPlan(Document):
 			work_order_data = {
 				"wip_warehouse": default_warehouses.get("wip_warehouse"),
 				"fg_warehouse": default_warehouses.get("fg_warehouse"),
+				"company": self.get("company"),
 			}
 
 			self.prepare_data_for_sub_assembly_items(row, work_order_data)


### PR DESCRIPTION
Closes https://github.com/frappe/erpnext/issues/30505

**Issue:**
- Prod Plan made for company **TextileMart**, but while making WO, subassembly WO takes global default company **RetailMart**

- https://user-images.githubusercontent.com/25857446/163110562-5484c72e-6694-42e5-92f1-f6fdeb4eccd6.mov

**Fix:**
- Map company in Sub assembly WO. The same happens automatically due to queried company while making FG WO

- https://user-images.githubusercontent.com/25857446/163111689-9ad292df-5051-443a-b8c7-013d1e499ef4.mov





 