### PR TITLE
fix: Depreciation Amount calculation for first row when Monthly Depreciation is allowed

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -364,7 +364,7 @@ class Asset(AccountsController):
 							if has_pro_rata and n == 0:
 								# For first entry of monthly depr
 								if r == 0:
-									days_until_first_depr = date_diff(monthly_schedule_date, self.available_for_use_date)
+									days_until_first_depr = date_diff(monthly_schedule_date, self.available_for_use_date) + 1
 									per_day_amt = depreciation_amount / days
 									depreciation_amount_for_current_month = per_day_amt * days_until_first_depr
 									depreciation_amount -= depreciation_amount_for_current_month


### PR DESCRIPTION
### Problem:

The Depreciation Amount calculation for the first row is incorrect when Monthly Depreciation is allowed. It doesn't add the Available for Use Date while calculating the number of days until the first depreciation, thereby throwing the calculation off.

### Fix:

Increment the number of days until the first depreciation by 1 to include the Available for Use Date as well.

<details>
<summary>Reference Issue</summary>
ISS-21-22-14006
</details>