### PR TITLE
fix: Payment reco query with max invoice and payment amount limit

### DIFF
--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
@@ -350,9 +350,13 @@ class PaymentReconciliation(Document):
 			)
 
 			if self.minimum_invoice_amount:
-				condition += " and `{0}` >= {1}".format(dr_or_cr, flt(self.minimum_invoice_amount))
+				condition += " and {dr_or_cr} >= {amount}".format(
+					dr_or_cr=dr_or_cr, amount=flt(self.minimum_invoice_amount)
+				)
 			if self.maximum_invoice_amount:
-				condition += " and `{0}` <= {1}".format(dr_or_cr, flt(self.maximum_invoice_amount))
+				condition += " and {dr_or_cr} <= {amount}".format(
+					dr_or_cr=dr_or_cr, amount=flt(self.maximum_invoice_amount)
+				)
 
 		elif get_return_invoices:
 			condition = " and doc.company = '{0}' ".format(self.company)
@@ -367,15 +371,19 @@ class PaymentReconciliation(Document):
 				else ""
 			)
 			dr_or_cr = (
-				"gl.debit_in_account_currency"
+				"debit_in_account_currency"
 				if erpnext.get_party_account_type(self.party_type) == "Receivable"
-				else "gl.credit_in_account_currency"
+				else "credit_in_account_currency"
 			)
 
 			if self.minimum_invoice_amount:
-				condition += " and `{0}` >= {1}".format(dr_or_cr, flt(self.minimum_payment_amount))
+				condition += " and gl.{dr_or_cr} >= {amount}".format(
+					dr_or_cr=dr_or_cr, amount=flt(self.minimum_payment_amount)
+				)
 			if self.maximum_invoice_amount:
-				condition += " and `{0}` <= {1}".format(dr_or_cr, flt(self.maximum_payment_amount))
+				condition += " and gl.{dr_or_cr} <= {amount}".format(
+					dr_or_cr=dr_or_cr, amount=flt(self.maximum_payment_amount)
+				)
 
 		else:
 			condition += (


### PR DESCRIPTION
Specifying maximum and minimum amount limits in Payment Reconciliation leads to the below errors. This PR fixes the query for it

<img width="1335" alt="Screenshot 2022-04-13 at 1 10 58 PM" src="https://user-images.githubusercontent.com/42651287/163125292-c4ed513e-c537-4972-bbcd-5e8accaf1764.png">
