### PR TITLE
ci: coverage not getting processed

### DIFF
--- a/.github/workflows/server-tests-mariadb.yml
+++ b/.github/workflows/server-tests-mariadb.yml
@@ -129,6 +129,9 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
+      - name: Clone
+        uses: actions/checkout@v2
+
       - name: Download artifacts
         uses: actions/download-artifact@v3
 


### PR DESCRIPTION
codecov unable to process coverage after https://github.com/frappe/erpnext/pull/30668