### PR TITLE
fix(call log): Convert `Data` to `Link` for type_of_call

### DIFF
--- a/erpnext/quality_management/doctype/quality_procedure/test_quality_procedure.py
+++ b/erpnext/quality_management/doctype/quality_procedure/test_quality_procedure.py
@@ -19,7 +19,6 @@ class TestQualityProcedure(unittest.TestCase):
 				)
 			).insert()
 
-
 			frappe.local.form_dict = frappe._dict(
 				doctype="Quality Procedure",
 				quality_procedure_name="Test Child 1",

--- a/erpnext/telephony/doctype/call_log/call_log.json
+++ b/erpnext/telephony/doctype/call_log/call_log.json
@@ -141,27 +141,30 @@
   },
   {
    "fieldname": "employee_user_id",
-   "fieldtype": "Data",
+   "fieldtype": "Link",
    "hidden": 1,
-   "label": "Employee User Id"
+   "label": "Employee User Id",
+   "options": "Employee"
   },
   {
    "fieldname": "type_of_call",
-   "fieldtype": "Data",
-   "label": "Type Of Call"
+   "fieldtype": "Link",
+   "label": "Type Of Call",
+   "options": "Telephony Call Type"
   },
   {
    "depends_on": "to",
    "fieldname": "call_received_by",
-   "fieldtype": "Data",
+   "fieldtype": "Link",
    "label": "Call Received By",
+   "options": "User",
    "read_only": 1
   }
  ],
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-02-25 14:37:48.575230",
+ "modified": "2022-04-14 00:18:31.148428",
  "modified_by": "Administrator",
  "module": "Telephony",
  "name": "Call Log",


### PR DESCRIPTION
Convert `Data` to `Link` for `type_of_call`, `employee_user_id` and `call_received_by` fields to establish proper linking.

New fields added [in this PR](https://github.com/frappe/erpnext/pull/29962) were all data fields instead of Link fields 😑 
