### PR TITLE
fix: Price changing on creating Sales return from Delivery Note

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1388,6 +1388,11 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 			return;
 		}
 
+		// Target doc created from a mapped doc
+		if (this.frm.doc.__onload && this.frm.doc.__onload.ignore_price_list) {
+			return;
+		}
+
 		return this.frm.call({
 			method: "erpnext.accounts.doctype.pricing_rule.pricing_rule.apply_pricing_rule",
 			args: {	args: args, doc: me.frm.doc },
@@ -1504,7 +1509,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 				me.remove_pricing_rule(frappe.get_doc(d.doctype, d.name));
 			}
 
-			if (d.free_item_data) {
+			if (d.free_item_data.length > 0) {
 				me.apply_product_discount(d);
 			}
 


### PR DESCRIPTION
Rate for items having pricing rule gets changed when making a sales return through a delivery note and the user gets the below invalid validation

<img width="696" alt="image" src="https://user-images.githubusercontent.com/42651287/162577534-10c74a06-9f21-4b91-a987-02ff9f0e0871.png">
