### PR TITLE
fix: Correct precision for asset value after full schedule

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -628,7 +628,7 @@ class Asset(AccountsController):
 
 				asset_value_after_full_schedule = flt(
 					flt(self.gross_purchase_amount) - flt(accumulated_depreciation_after_full_schedule),
-					self.precision("gross_purchase_amount"),
+					row.precision("expected_value_after_useful_life"),
 				)
 
 				if (


### PR DESCRIPTION
### Issue:

Ideally, `asset_value_after_useful_life` should be the same as `expected_value_after_useful_life`, however, the precision applied on both are different, leading to minor inconsistencies which could possibly throw errors.

### Fix:

Apply precision for `expected_value_after_useful_life` on `asset_value_after_useful_life`, instead of that of `gross_purchase_amount`.

<details>
<summary>Reference Issue</summary>

ISS-21-22-14006

</details>