### PR TITLE
fix: batch_no filtering not working when batch no is also a number in…

### DIFF
--- a/erpnext/stock/doctype/serial_no/serial_no.py
+++ b/erpnext/stock/doctype/serial_no/serial_no.py
@@ -777,11 +777,11 @@ def auto_fetch_serial_number(
 		exclude_sr_nos = get_serial_nos(clean_serial_no_string("\n".join(exclude_sr_nos)))
 
 	if batch_nos:
-		batch_nos = safe_json_loads(batch_nos)
-		if isinstance(batch_nos, list):
-			filters.batch_no = batch_nos
+		batch_nos_list = safe_json_loads(batch_nos)
+		if isinstance(batch_nos_list, list):
+			filters.batch_no = batch_nos_list
 		else:
-			filters.batch_no = [str(batch_nos)]
+			filters.batch_no = [batch_nos]
 
 	if posting_date:
 		filters.expiry_date = posting_date


### PR DESCRIPTION
Problem: Automatic fetching of serial nos fails if the batch filter is a batch number that's also a number in scientific notation. E.g. `3709E93` which gets converted to `3709 * 10^93` by `safe_json_loads`. 

Fix: reuse batch query string if JSON parsed data isn't a list. 

```
======================================================================
 FAIL  test_auto_fetch (erpnext.stock.doctype.serial_no.test_serial_no.TestSerialNo)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/stock/doctype/serial_no/test_serial_no.py", line 319, in test_auto_fetch
    self.assertEqual(fetched_sr, sorted(expected_serials))
    batch = '3709E93'
    batch1 = '3709E93'
    batch2 = '401DA09'
    batch_wise_serials = {'3709E93': ['TEST0000001', 'TEST0000002', 'TEST0000003', 'TEST0000004', 'TEST0000005'], '401DA09': ['TEST0000006', 'TEST0000007', 'TEST0000008', 'TEST0000009', 'TEST0000010']}
    expected_serials = ['TEST0000001', 'TEST0000002', 'TEST0000003', 'TEST0000004', 'TEST0000005']
    fetched_sr = []
    first_fetch = ['TEST0000001', 'TEST0000002', 'TEST0000003', 'TEST0000004', 'TEST0000005']
    in1 = <StockEntry: MAT-STE-2022-00024 docstatus=1>
    in2 = <StockEntry: MAT-STE-2022-00025 docstatus=1>
    item_code = '8c7de508cbda010d'
    partial_fetch = ['TEST0000001', 'TEST0000002']
    remaining = ['TEST0000003', 'TEST0000004', 'TEST0000005']
    self = <erpnext.stock.doctype.serial_no.test_serial_no.TestSerialNo testMethod=test_auto_fetch>
    warehouse = '_Test Warehouse - _TC'
AssertionError: Lists differ: [] != ['TEST0000001', 'TEST0000002', 'TEST0000003', 'TEST0000004', 'TEST0000005']

Second list contains 5 additional elements.
First extra element 0:
'TEST0000001'

- []
+ ['TEST0000001', 'TEST0000002', 'TEST0000003', 'TEST0000004', 'TEST0000005']
```