### PR TITLE
fix: Shopping cart quotation without website item.

### DIFF
--- a/erpnext/selling/doctype/quotation/quotation.py
+++ b/erpnext/selling/doctype/quotation/quotation.py
@@ -64,10 +64,10 @@ class Quotation(SellingController):
 
 			if not has_web_item:
 				frappe.throw(
-					_(
-						"Row #{0}: Item {1} must have a Website Item for Shopping Cart Quotations"
-					).format(item.idx, frappe.bold(item.item_code)),
-					title=_("Unpublished Item")
+					_("Row #{0}: Item {1} must have a Website Item for Shopping Cart Quotations").format(
+						item.idx, frappe.bold(item.item_code)
+					),
+					title=_("Unpublished Item"),
 				)
 
 	def has_sales_order(self):

--- a/erpnext/selling/doctype/quotation/quotation.py
+++ b/erpnext/selling/doctype/quotation/quotation.py
@@ -27,6 +27,7 @@ class Quotation(SellingController):
 		self.set_status()
 		self.validate_uom_is_integer("stock_uom", "qty")
 		self.validate_valid_till()
+		self.validate_shopping_cart_items()	
 		self.set_customer_name()
 		if self.items:
 			self.with_items = 1
@@ -48,6 +49,13 @@ class Quotation(SellingController):
 	def validate_valid_till(self):
 		if self.valid_till and getdate(self.valid_till) < getdate(self.transaction_date):
 			frappe.throw(_("Valid till date cannot be before transaction date"))
+
+	def validate_shopping_cart_items(self):
+		if self.order_type != "Shopping Cart": return
+
+		for item in self.items:
+			if not frappe.db.exists("Website Item", {"item_code": item.item_code}):
+				frappe.throw(_("Item {0} must be a website item for Shopping Cart quotations".format(item.item_code)))
 
 	def has_sales_order(self):
 		return frappe.db.get_value("Sales Order Item", {"prevdoc_docname": self.name, "docstatus": 1})

--- a/erpnext/selling/doctype/quotation/quotation.py
+++ b/erpnext/selling/doctype/quotation/quotation.py
@@ -51,7 +51,8 @@ class Quotation(SellingController):
 			frappe.throw(_("Valid till date cannot be before transaction date"))
 
 	def validate_shopping_cart_items(self):
-		if self.order_type != "Shopping Cart": return
+		if self.order_type != "Shopping Cart":
+			return
 
 		for item in self.items:
 			if not frappe.db.exists("Website Item", {"item_code": item.item_code}):

--- a/erpnext/selling/doctype/quotation/quotation.py
+++ b/erpnext/selling/doctype/quotation/quotation.py
@@ -27,7 +27,7 @@ class Quotation(SellingController):
 		self.set_status()
 		self.validate_uom_is_integer("stock_uom", "qty")
 		self.validate_valid_till()
-		self.validate_shopping_cart_items()	
+		self.validate_shopping_cart_items()
 		self.set_customer_name()
 		if self.items:
 			self.with_items = 1

--- a/erpnext/selling/doctype/quotation/quotation.py
+++ b/erpnext/selling/doctype/quotation/quotation.py
@@ -56,7 +56,7 @@ class Quotation(SellingController):
 
 		for item in self.items:
 			if not frappe.db.exists("Website Item", {"item_code": item.item_code}):
-				frappe.throw(_("Item {0} must be a website item for Shopping Cart quotations".format(item.item_code)))
+				frappe.throw(_("Item {0} must be a website item for Shopping Cart quotations").format(item.item_code))
 
 	def has_sales_order(self):
 		return frappe.db.get_value("Sales Order Item", {"prevdoc_docname": self.name, "docstatus": 1})

--- a/erpnext/selling/doctype/quotation/test_quotation.py
+++ b/erpnext/selling/doctype/quotation/test_quotation.py
@@ -131,8 +131,6 @@ class TestQuotation(FrappeTestCase):
 		self.assertRaises(frappe.ValidationError, make_sales_order, quotation.name)
 
 	def test_shopping_cart_without_website_item(self):
-		from erpnext.selling.doctype.quotation.quotation import make_sales_order
-
 		if frappe.db.exists('Website Item', {'item_code': '_Test Item Home Desktop 100'}):
 			frappe.get_last_doc('Website Item', {'item_code': '_Test Item Home Desktop 100'}).delete()
 

--- a/erpnext/selling/doctype/quotation/test_quotation.py
+++ b/erpnext/selling/doctype/quotation/test_quotation.py
@@ -131,11 +131,11 @@ class TestQuotation(FrappeTestCase):
 		self.assertRaises(frappe.ValidationError, make_sales_order, quotation.name)
 
 	def test_shopping_cart_without_website_item(self):
-		if frappe.db.exists('Website Item', {'item_code': '_Test Item Home Desktop 100'}):
-			frappe.get_last_doc('Website Item', {'item_code': '_Test Item Home Desktop 100'}).delete()
+		if frappe.db.exists("Website Item", {"item_code": "_Test Item Home Desktop 100"}):
+			frappe.get_last_doc("Website Item", {"item_code": "_Test Item Home Desktop 100"}).delete()
 
 		quotation = frappe.copy_doc(test_records[0])
-		quotation.order_type = 'Shopping Cart'
+		quotation.order_type = "Shopping Cart"
 		quotation.valid_till = getdate()
 		self.assertRaises(frappe.ValidationError, quotation.validate)
 

--- a/erpnext/selling/doctype/quotation/test_quotation.py
+++ b/erpnext/selling/doctype/quotation/test_quotation.py
@@ -129,7 +129,20 @@ class TestQuotation(FrappeTestCase):
 		quotation.insert()
 		quotation.submit()
 		self.assertRaises(frappe.ValidationError, make_sales_order, quotation.name)
+  
+	def test_shopping_cart_without_website_item(self):
+		from erpnext.selling.doctype.quotation.quotation import make_sales_order
 
+		if frappe.db.exists('Website Item', {'item_code': '_Test Item Home Desktop 100'}):
+			frappe.get_last_doc('Website Item', {'item_code': '_Test Item Home Desktop 100'}).delete()
+   
+		quotation = frappe.copy_doc(test_records[0])
+		quotation.order_type = 'Shopping Cart'
+		quotation.valid_till = getdate()
+		quotation.insert()
+		quotation.submit()
+		self.assertRaises(frappe.ValidationError, make_sales_order, quotation.name)
+  
 	def test_create_quotation_with_margin(self):
 		from erpnext.selling.doctype.quotation.quotation import make_sales_order
 		from erpnext.selling.doctype.sales_order.sales_order import (

--- a/erpnext/selling/doctype/quotation/test_quotation.py
+++ b/erpnext/selling/doctype/quotation/test_quotation.py
@@ -129,20 +129,18 @@ class TestQuotation(FrappeTestCase):
 		quotation.insert()
 		quotation.submit()
 		self.assertRaises(frappe.ValidationError, make_sales_order, quotation.name)
-  
+
 	def test_shopping_cart_without_website_item(self):
 		from erpnext.selling.doctype.quotation.quotation import make_sales_order
 
 		if frappe.db.exists('Website Item', {'item_code': '_Test Item Home Desktop 100'}):
 			frappe.get_last_doc('Website Item', {'item_code': '_Test Item Home Desktop 100'}).delete()
-   
+
 		quotation = frappe.copy_doc(test_records[0])
 		quotation.order_type = 'Shopping Cart'
 		quotation.valid_till = getdate()
-		quotation.insert()
-		quotation.submit()
-		self.assertRaises(frappe.ValidationError, make_sales_order, quotation.name)
-  
+		self.assertRaises(frappe.ValidationError, quotation.validate)
+
 	def test_create_quotation_with_margin(self):
 		from erpnext.selling.doctype.quotation.quotation import make_sales_order
 		from erpnext.selling.doctype.sales_order.sales_order import (


### PR DESCRIPTION
Front port of https://github.com/frappe/erpnext/pull/29085

**Problem / Motivation**
Our customer is browsing our e-store and cannot find what they are looking for. They call a customer service rep to see if the item is available. The rep adds the item into the quotation and saves it. Without realizing, that item hasn't been added as a Website Item yet. 

The customer goes to visit their shopping cart to realize the web page is broken. Caused by: https://github.com/frappe/erpnext/blob/498d933e9ce7c18d6c595d2e0f575645dc020d81/erpnext/e_commerce/shopping_cart/cart.py#L277-L286
<details>
<summary>Error Snapshot</summary>

![image](https://user-images.githubusercontent.com/29856401/147777836-279ff673-315a-4749-b215-55124c176981.png)
</details>

**Proposed Resolution**
If the quotation is of type Shopping Cart validate that all item's have a Website Item associated with it.
<img width="1302" alt="Screenshot 2022-04-22 at 1 21 03 PM" src="https://user-images.githubusercontent.com/25857446/164701975-10cdc65a-2c01-4b2c-a1b7-c3824971a535.png">

