### PR TITLE
fix: Allow multi-currency opening invoices

### DIFF
--- a/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.py
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.py
@@ -154,6 +154,7 @@ class OpeningInvoiceCreationTool(Document):
 				"income_account" if row.party_type == "Customer" else "expense_account"
 			)
 			default_uom = frappe.db.get_single_value("Stock Settings", "stock_uom") or _("Nos")
+			default_currency = frappe.db.get_value(row.party_type, row.party, "default_currency")
 			rate = flt(row.outstanding_amount) / flt(row.qty)
 
 			item_dict = frappe._dict(
@@ -166,6 +167,7 @@ class OpeningInvoiceCreationTool(Document):
 					"description": row.item_name or "Opening Invoice Item",
 					income_expense_account_field: row.temporary_opening_account,
 					"cost_center": cost_center,
+					"currency": default_currency,
 				}
 			)
 


### PR DESCRIPTION
<img width="1344" alt="image" src="https://user-images.githubusercontent.com/42651287/165906430-c032e89c-d4b4-4707-9f30-f9fe3d666b70.png">

The user gets the above error when while making an opening invoice against a customer having a default current other than the company currency 