### PR TITLE
test: flaky employee leave test

### DIFF
--- a/erpnext/hr/doctype/leave_application/test_leave_application.py
+++ b/erpnext/hr/doctype/leave_application/test_leave_application.py
@@ -1,10 +1,9 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
 
-import unittest
-
 import frappe
 from frappe.permissions import clear_user_permissions_for_doctype
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import (
 	add_days,
 	add_months,
@@ -74,7 +73,7 @@ _test_records = [
 ]
 
 
-class TestLeaveApplication(unittest.TestCase):
+class TestLeaveApplication(FrappeTestCase):
 	def setUp(self):
 		for dt in ["Leave Application", "Leave Allocation", "Salary Slip", "Leave Ledger Entry"]:
 			frappe.db.delete(dt)

--- a/erpnext/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
+++ b/erpnext/hr/doctype/leave_ledger_entry/leave_ledger_entry.py
@@ -12,6 +12,9 @@ class LeaveLedgerEntry(Document):
 	def validate(self):
 		if getdate(self.from_date) > getdate(self.to_date):
 			frappe.throw(_("To date needs to be before from date"))
+		if self.name == "_T-Leave Allocation-00001":
+			import traceback
+			traceback.print_stack()
 
 	def on_cancel(self):
 		# allow cancellation of expiry leaves


### PR DESCRIPTION
Future tests fail with "unable to find `_T-Leave Allocation-00001`".

