### PR TITLE
test: fix flaky carry forwarded leave expiry test

### DIFF
--- a/erpnext/hr/doctype/leave_allocation/test_leave_allocation.py
+++ b/erpnext/hr/doctype/leave_allocation/test_leave_allocation.py
@@ -18,6 +18,7 @@ class TestLeaveAllocation(FrappeTestCase):
 	def setUp(self):
 		frappe.db.delete("Leave Period")
 		frappe.db.delete("Leave Allocation")
+		frappe.db.delete("Leave Ledger Entry")
 
 		emp_id = make_employee("test_emp_leave_allocation@salary.com", company="_Test Company")
 		self.employee = frappe.get_doc("Employee", emp_id)


### PR DESCRIPTION
`test_carry_forward_leaves_expiry` trying to expire stale leave ledger entries causing flaky behavior

<img width="921" alt="image" src="https://user-images.githubusercontent.com/24353136/165293814-282bc3e8-6ec3-41c1-950b-911e98946601.png">

Delete leave ledger entries in `setUp` along with allocations.