### PR TITLE
fix(india): e-invoice generation for registered composition gst category type

### DIFF
--- a/erpnext/regional/india/e_invoice/utils.py
+++ b/erpnext/regional/india/e_invoice/utils.py
@@ -125,7 +125,9 @@ def read_json(name):
 
 def get_transaction_details(invoice):
 	supply_type = ""
-	if invoice.gst_category == "Registered Regular" or invoice.gst_category == "Registered Composition":
+	if (
+		invoice.gst_category == "Registered Regular" or invoice.gst_category == "Registered Composition"
+	):
 		supply_type = "B2B"
 	elif invoice.gst_category == "SEZ":
 		supply_type = "SEZWOP"

--- a/erpnext/regional/india/e_invoice/utils.py
+++ b/erpnext/regional/india/e_invoice/utils.py
@@ -57,6 +57,7 @@ def validate_eligibility(doc):
 	invalid_company = not frappe.db.get_value("E Invoice User", {"company": doc.get("company")})
 	invalid_supply_type = doc.get("gst_category") not in [
 		"Registered Regular",
+		"Registered Composition",
 		"SEZ",
 		"Overseas",
 		"Deemed Export",
@@ -124,7 +125,7 @@ def read_json(name):
 
 def get_transaction_details(invoice):
 	supply_type = ""
-	if invoice.gst_category == "Registered Regular":
+	if invoice.gst_category == "Registered Regular" or invoice.gst_category == "Registered Composition":
 		supply_type = "B2B"
 	elif invoice.gst_category == "SEZ":
 		supply_type = "SEZWOP"
@@ -134,14 +135,15 @@ def get_transaction_details(invoice):
 		supply_type = "DEXP"
 
 	if not supply_type:
-		rr, sez, overseas, export = (
+		rr, rc, sez, overseas, export = (
 			bold("Registered Regular"),
+			bold("Registered Composition"),
 			bold("SEZ"),
 			bold("Overseas"),
 			bold("Deemed Export"),
 		)
 		frappe.throw(
-			_("GST category should be one of {}, {}, {}, {}").format(rr, sez, overseas, export),
+			_("GST category should be one of {}, {}, {}, {}, {}").format(rr, rc, sez, overseas, export),
 			title=_("Invalid Supply Type"),
 		)
 

--- a/erpnext/regional/india/setup.py
+++ b/erpnext/regional/india/setup.py
@@ -762,7 +762,7 @@ def get_custom_fields():
 			insert_after="customer",
 			no_copy=1,
 			print_hide=1,
-			depends_on='eval:in_list(["Registered Regular", "SEZ", "Overseas", "Deemed Export"], doc.gst_category) && doc.irn_cancelled === 0',
+			depends_on='eval:in_list(["Registered Regular", "Registered Composition", "SEZ", "Overseas", "Deemed Export"], doc.gst_category) && doc.irn_cancelled === 0',
 		),
 		dict(
 			fieldname="irn_cancelled",


### PR DESCRIPTION
Sales Invoice for Buyer with GST Category "Registered Composition" is also B2B Transaction and e-invoice generation is mandatory (required) in this case.

I have made the necessary changes to enable e-invoice generation for the "Registered Composition" gst_category type and show the IRN field for the same.

This Closes #30813.
