### PR TITLE
docs: Add "Try on PWD" button

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,16 @@ ERPNext is built on the [Frappe Framework](https://github.com/frappe/frappe), a 
 
 ---
 
-<div align="center">
+<div align="center" style="max-height: 40px;">
     <a href="https://frappecloud.com/deploy?apps=frappe,erpnext&source=erpnext_readme">
         <img src=".github/try-on-f-cloud-button.svg" height="40">
     </a>
+    <a href="https://labs.play-with-docker.com/?stack=https://raw.githubusercontent.com/frappe/frappe_docker/main/pwd.yml">
+      <img src="https://raw.githubusercontent.com/play-with-docker/stacks/master/assets/images/button.png" alt="Try in PWD" height="37"/>
+    </a>
 </div>
+
+> Login for the PWD site: (username: Administrator, password: admin)
 
 ### Containerized Installation
 


### PR DESCRIPTION
Added the button from the Frappe Docker repo here. If you have a Docker Hub account, you can create a temporary ERPNext instance in ~3 minutes.

<img width="1552" alt="Screenshot 2022-04-27 at 12 19 56 PM" src="https://user-images.githubusercontent.com/36654812/165458418-1071b5c6-ada1-46e3-967f-8ada4e58d070.png">


PS: Spent a lot of time getting the alignment right. This is the best I could do after spending way too long.