### PR TITLE
chore: "refactor" readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <div align="center">
-    <img src="https://raw.githubusercontent.com/frappe/erpnext/develop/erpnext/public/images/erpnext-logo.png" height="128">
+    <a href="https://erpnext.com">
+        <img src="https://raw.githubusercontent.com/frappe/erpnext/develop/erpnext/public/images/erpnext-logo.png" height="128">
+    </a>
     <h2>ERPNext</h2>
     <p align="center">
         <p>ERP made simple</p>
@@ -32,14 +34,9 @@ ERPNext as a monolith includes the following areas for managing businesses:
 1. [Customize ERPNext](https://erpnext.com/docs/user/manual/en/customize-erpnext)
 1. [And More](https://erpnext.com/docs/user/manual/en/)
 
-ERPNext requires MariaDB.
-
 ERPNext is built on the [Frappe Framework](https://github.com/frappe/frappe), a full-stack web app framework built with Python & JavaScript.
 
-- [User Guide](https://erpnext.com/docs/user)
-- [Discussion Forum](https://discuss.erpnext.com/)
-
----
+## Installation
 
 <div align="center" style="max-height: 40px;">
     <a href="https://frappecloud.com/deploy?apps=frappe,erpnext&source=erpnext_readme">
@@ -56,21 +53,20 @@ ERPNext is built on the [Frappe Framework](https://github.com/frappe/frappe), a 
 
 Use docker to deploy ERPNext in production or for development of [Frappe](https://github.com/frappe/frappe) apps. See https://github.com/frappe/frappe_docker for more details.
 
-### Full Install
+### Manual Install
 
 The Easy Way: our install script for bench will install all dependencies (e.g. MariaDB). See https://github.com/frappe/bench for more details.
 
 New passwords will be created for the ERPNext "Administrator" user, the MariaDB root user, and the frappe user (the script displays the passwords and saves them to ~/frappe_passwords.txt).
 
----
 
-## License
+## Learning and community
 
-GNU/General Public License (see [license.txt](license.txt))
+1. [Frappe School](https://frappe.school) - Learn Frappe Framework and ERPNext from the various courses by the maintainers or from the community.
+2. [Official documentation](https://docs.erpnext.com/) - Extensive documentation for ERPNext.
+3. [Discussion Forum](https://discuss.erpnext.com/) - Engage with community of ERPNext users and service providers.
+4. [Telegram Group](https://t.me/erpnexthelp) - Get instant help from huge community of users.
 
-The ERPNext code is licensed as GNU General Public License (v3) and the Documentation is licensed as Creative Commons (CC-BY-SA-3.0) and the copyright is owned by Frappe Technologies Pvt Ltd (Frappe) and Contributors.
-
----
 
 ## Contributing
 
@@ -78,49 +74,14 @@ The ERPNext code is licensed as GNU General Public License (v3) and the Document
 1. [Report Security Vulnerabilities](https://erpnext.com/security)
 1. [Pull Request Requirements](https://github.com/frappe/erpnext/wiki/Contribution-Guidelines)
 1. [Translations](https://translate.erpnext.com)
-1. [Chart of Accounts](https://charts.erpnext.com)
 
----
 
-## Learning
+## License
 
-1. [Frappe School](https://frappe.school) - Learn Frappe Framework and ERPNext from the various courses by the maintainers or from the community.
+GNU/General Public License (see [license.txt](license.txt))
 
----
+The ERPNext code is licensed as GNU General Public License (v3) and the Documentation is licensed as Creative Commons (CC-BY-SA-3.0) and the copyright is owned by Frappe Technologies Pvt Ltd (Frappe) and Contributors.
 
-## Logo and Trademark
+## Logo and Trademark Policy
 
-The brand name ERPNext and the logo are trademarks of Frappe Technologies Pvt. Ltd.
-
-### Introduction
-
-Frappe Technologies Pvt. Ltd. (Frappe) owns and oversees the trademarks for the ERPNext name and logos. We have developed this trademark usage policy with the following goals in mind:
-
-- We’d like to make it easy for anyone to use the ERPNext name or logo for community-oriented efforts that help spread and improve ERPNext.
-- We’d like to make it clear how ERPNext-related businesses and projects can (and cannot) use the ERPNext name and logo.
-- We’d like to make it hard for anyone to use the ERPNext name and logo to unfairly profit from, trick or confuse people who are looking for official ERPNext resources.
-
-### Frappe Trademark Usage Policy
-
-Permission from Frappe is required to use the ERPNext name or logo as part of any project, product, service, domain or company name.
-
-We will grant permission to use the ERPNext name and logo for projects that meet the following criteria:
-
-- The primary purpose of your project is to promote the spread and improvement of the ERPNext software.
-- Your project is non-commercial in nature (it can make money to cover its costs or contribute to non-profit entities, but it cannot be run as a for-profit project or business).
-Your project neither promotes nor is associated with entities that currently fail to comply with the GPL license under which ERPNext is distributed.
-- If your project meets these criteria, you will be permitted to use the ERPNext name and logo to promote your project in any way you see fit with one exception: Please do not use ERPNext as part of a domain name.
-
-Use of the ERPNext name and logo is additionally allowed in the following situations:
-
-All other ERPNext-related businesses or projects can use the ERPNext name and logo to refer to and explain their services, but they cannot use them as part of a product, project, service, domain, or company name and they cannot use them in any way that suggests an affiliation with or endorsement by ERPNext or Frappe Technologies or the ERPNext open source project. For example, a consulting company can describe its business as “123 Web Services, offering ERPNext consulting for small businesses,” but cannot call its business “The ERPNext Consulting Company.”
-
-Similarly, it’s OK to use the ERPNext logo as part of a page that describes your products or services, but it is not OK to use it as part of your company or product logo or branding itself. Under no circumstances is it permitted to use ERPNext as part of a top-level domain name.
-
-We do not allow the use of the trademark in advertising, including AdSense/AdWords.
-
-Please note that it is not the goal of this policy to limit commercial activity around ERPNext. We encourage ERPNext-based businesses, and we would love to see hundreds of them.
-
-When in doubt about your use of the ERPNext name or logo, please contact Frappe Technologies for clarification.
-
-(inspired by WordPress)
+Please read our [Logo and Trademark Policy](TRADEMARK_POLICY.md).

--- a/TRADEMARK_POLICY.md
+++ b/TRADEMARK_POLICY.md
@@ -1,0 +1,36 @@
+## Logo and Trademark Policy
+
+The brand name ERPNext and the logo are trademarks of Frappe Technologies Pvt. Ltd.
+
+### Introduction
+
+Frappe Technologies Pvt. Ltd. (Frappe) owns and oversees the trademarks for the ERPNext name and logos. We have developed this trademark usage policy with the following goals in mind:
+
+- We’d like to make it easy for anyone to use the ERPNext name or logo for community-oriented efforts that help spread and improve ERPNext.
+- We’d like to make it clear how ERPNext-related businesses and projects can (and cannot) use the ERPNext name and logo.
+- We’d like to make it hard for anyone to use the ERPNext name and logo to unfairly profit from, trick or confuse people who are looking for official ERPNext resources.
+
+### Frappe Trademark Usage Policy
+
+Permission from Frappe is required to use the ERPNext name or logo as part of any project, product, service, domain or company name.
+
+We will grant permission to use the ERPNext name and logo for projects that meet the following criteria:
+
+- The primary purpose of your project is to promote the spread and improvement of the ERPNext software.
+- Your project is non-commercial in nature (it can make money to cover its costs or contribute to non-profit entities, but it cannot be run as a for-profit project or business).
+Your project neither promotes nor is associated with entities that currently fail to comply with the GPL license under which ERPNext is distributed.
+- If your project meets these criteria, you will be permitted to use the ERPNext name and logo to promote your project in any way you see fit with one exception: Please do not use ERPNext as part of a domain name.
+
+Use of the ERPNext name and logo is additionally allowed in the following situations:
+
+All other ERPNext-related businesses or projects can use the ERPNext name and logo to refer to and explain their services, but they cannot use them as part of a product, project, service, domain, or company name and they cannot use them in any way that suggests an affiliation with or endorsement by ERPNext or Frappe Technologies or the ERPNext open source project. For example, a consulting company can describe its business as “123 Web Services, offering ERPNext consulting for small businesses,” but cannot call its business “The ERPNext Consulting Company.”
+
+Similarly, it’s OK to use the ERPNext logo as part of a page that describes your products or services, but it is not OK to use it as part of your company or product logo or branding itself. Under no circumstances is it permitted to use ERPNext as part of a top-level domain name.
+
+We do not allow the use of the trademark in advertising, including AdSense/AdWords.
+
+Please note that it is not the goal of this policy to limit commercial activity around ERPNext. We encourage ERPNext-based businesses, and we would love to see hundreds of them.
+
+When in doubt about your use of the ERPNext name or logo, please contact Frappe Technologies for clarification.
+
+(inspired by WordPress)


### PR DESCRIPTION
- move trademark notice to separate file
- reorder sections and remove unnecessary separators
- link logo to erpnext.com
- remove "erpnext requires mariadb" (who cares?)
- consolidate "learning" section

preview: https://github.com/frappe/erpnext/tree/readme_cr 