### PR TITLE
test: create new item instead of using with _Test Item

### DIFF
--- a/erpnext/stock/doctype/delivery_note/test_delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/test_delivery_note.py
@@ -78,56 +78,6 @@ class TestDeliveryNote(FrappeTestCase):
 
 		self.assertFalse(get_gl_entries("Delivery Note", dn.name))
 
-	# def test_delivery_note_gl_entry(self):
-	# 	company = frappe.db.get_value('Warehouse', 'Stores - TCP1', 'company')
-
-	# 	set_valuation_method("_Test Item", "FIFO")
-
-	# 	make_stock_entry(target="Stores - TCP1", qty=5, basic_rate=100)
-
-	# 	stock_in_hand_account = get_inventory_account('_Test Company with perpetual inventory')
-	# 	prev_bal = get_balance_on(stock_in_hand_account)
-
-	# 	dn = create_delivery_note(company='_Test Company with perpetual inventory', warehouse='Stores - TCP1', cost_center = 'Main - TCP1', expense_account = "Cost of Goods Sold - TCP1")
-
-	# 	gl_entries = get_gl_entries("Delivery Note", dn.name)
-	# 	self.assertTrue(gl_entries)
-
-	# 	stock_value_difference = abs(frappe.db.get_value("Stock Ledger Entry",
-	# 		{"voucher_type": "Delivery Note", "voucher_no": dn.name}, "stock_value_difference"))
-
-	# 	expected_values = {
-	# 		stock_in_hand_account: [0.0, stock_value_difference],
-	# 		"Cost of Goods Sold - TCP1": [stock_value_difference, 0.0]
-	# 	}
-	# 	for i, gle in enumerate(gl_entries):
-	# 		self.assertEqual([gle.debit, gle.credit], expected_values.get(gle.account))
-
-	# 	# check stock in hand balance
-	# 	bal = get_balance_on(stock_in_hand_account)
-	# 	self.assertEqual(bal, prev_bal - stock_value_difference)
-
-	# 	# back dated incoming entry
-	# 	make_stock_entry(posting_date=add_days(nowdate(), -2), target="Stores - TCP1",
-	# 		qty=5, basic_rate=100)
-
-	# 	gl_entries = get_gl_entries("Delivery Note", dn.name)
-	# 	self.assertTrue(gl_entries)
-
-	# 	stock_value_difference = abs(frappe.db.get_value("Stock Ledger Entry",
-	# 		{"voucher_type": "Delivery Note", "voucher_no": dn.name}, "stock_value_difference"))
-
-	# 	expected_values = {
-	# 		stock_in_hand_account: [0.0, stock_value_difference],
-	# 		"Cost of Goods Sold - TCP1": [stock_value_difference, 0.0]
-	# 	}
-	# 	for i, gle in enumerate(gl_entries):
-	# 		self.assertEqual([gle.debit, gle.credit], expected_values.get(gle.account))
-
-	# 	dn.cancel()
-	# 	self.assertTrue(get_gl_entries("Delivery Note", dn.name))
-	# 	set_perpetual_inventory(0, company)
-
 	def test_delivery_note_gl_entry_packing_item(self):
 		company = frappe.db.get_value("Warehouse", "Stores - TCP1", "company")
 
@@ -854,8 +804,6 @@ class TestDeliveryNote(FrappeTestCase):
 			company="_Test Company with perpetual inventory",
 		)
 
-		company = frappe.db.get_value("Warehouse", "Stores - TCP1", "company")
-
 		set_valuation_method("_Test Item", "FIFO")
 
 		make_stock_entry(target="Stores - TCP1", qty=5, basic_rate=100)
@@ -880,8 +828,6 @@ class TestDeliveryNote(FrappeTestCase):
 
 	def test_delivery_note_cost_center_with_balance_sheet_account(self):
 		cost_center = "Main - TCP1"
-
-		company = frappe.db.get_value("Warehouse", "Stores - TCP1", "company")
 
 		set_valuation_method("_Test Item", "FIFO")
 

--- a/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
@@ -30,7 +30,6 @@ class TestStockReconciliation(FrappeTestCase):
 		frappe.db.set_value("Stock Settings", None, "allow_negative_stock", 1)
 
 	def tearDown(self):
-		frappe.flags.dont_execute_stock_reposts = None
 		frappe.local.future_sle = {}
 
 	def test_reco_for_fifo(self):
@@ -40,7 +39,9 @@ class TestStockReconciliation(FrappeTestCase):
 		self._test_reco_sle_gle("Moving Average")
 
 	def _test_reco_sle_gle(self, valuation_method):
-		se1, se2, se3 = insert_existing_sle(warehouse="Stores - TCP1")
+		item_code = make_item(properties={"valuation_method": valuation_method}).name
+
+		se1, se2, se3 = insert_existing_sle(warehouse="Stores - TCP1", item_code=item_code)
 		company = frappe.db.get_value("Warehouse", "Stores - TCP1", "company")
 		# [[qty, valuation_rate, posting_date,
 		# 		posting_time, expected_stock_value, bin_qty, bin_valuation]]
@@ -54,11 +55,9 @@ class TestStockReconciliation(FrappeTestCase):
 		]
 
 		for d in input_data:
-			set_valuation_method("_Test Item", valuation_method)
-
 			last_sle = get_previous_sle(
 				{
-					"item_code": "_Test Item",
+					"item_code": item_code,
 					"warehouse": "Stores - TCP1",
 					"posting_date": d[2],
 					"posting_time": d[3],
@@ -67,6 +66,7 @@ class TestStockReconciliation(FrappeTestCase):
 
 			# submit stock reconciliation
 			stock_reco = create_stock_reconciliation(
+				item_code=item_code,
 				qty=d[0],
 				rate=d[1],
 				posting_date=d[2],
@@ -481,9 +481,11 @@ class TestStockReconciliation(FrappeTestCase):
 		"""
 		from erpnext.stock.doctype.delivery_note.test_delivery_note import create_delivery_note
 
+		frappe.db.rollback()
+
 		# repost will make this test useless, qty should update in realtime without reposts
 		frappe.flags.dont_execute_stock_reposts = True
-		frappe.db.rollback()
+		self.addCleanup(frappe.flags.pop, "dont_execute_stock_reposts")
 
 		item_code = make_item().name
 		warehouse = "_Test Warehouse - _TC"
@@ -594,26 +596,26 @@ def create_batch_item_with_batch(item_name, batch_id):
 		b.save()
 
 
-def insert_existing_sle(warehouse):
+def insert_existing_sle(warehouse, item_code="_Test Item"):
 	from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
 
 	se1 = make_stock_entry(
 		posting_date="2012-12-15",
 		posting_time="02:00",
-		item_code="_Test Item",
+		item_code=item_code,
 		target=warehouse,
 		qty=10,
 		basic_rate=700,
 	)
 
 	se2 = make_stock_entry(
-		posting_date="2012-12-25", posting_time="03:00", item_code="_Test Item", source=warehouse, qty=15
+		posting_date="2012-12-25", posting_time="03:00", item_code=item_code, source=warehouse, qty=15
 	)
 
 	se3 = make_stock_entry(
 		posting_date="2013-01-05",
 		posting_time="07:00",
-		item_code="_Test Item",
+		item_code=item_code,
 		target=warehouse,
 		qty=15,
 		basic_rate=1200,


### PR DESCRIPTION
Unnecessary dependency causes flake in stock test. The test was reposting all
entries for item just to test some behavior that is best tested on a
newly created item _anyway_.

