### PR TITLE
fix: Update links to Frappe Cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ ERPNext is built on the [Frappe Framework](https://github.com/frappe/frappe), a 
 ## Installation
 
 <div align="center" style="max-height: 40px;">
-    <a href="https://frappecloud.com/deploy?apps=frappe,erpnext&source=erpnext_readme">
+    <a href="https://frappecloud.com/erpnext/signup">
         <img src=".github/try-on-f-cloud-button.svg" height="40">
     </a>
     <a href="https://labs.play-with-docker.com/?stack=https://raw.githubusercontent.com/frappe/frappe_docker/main/pwd.yml">


### PR DESCRIPTION


This logo + link was added a few months ago, right now it redirects to the homepage. 

This feature is gonna take some time, it's better to redirect to the signup page where the user can pick FC trial [frappecloud.com/erpnext/signup](https://frappecloud.com/erpnext/signup)