### PR TITLE
fix: precision loss when transferring 

### DIFF
--- a/erpnext/stock/doctype/stock_ledger_entry/test_stock_ledger_entry.py
+++ b/erpnext/stock/doctype/stock_ledger_entry/test_stock_ledger_entry.py
@@ -8,9 +8,8 @@ import frappe
 from frappe.core.page.permission_manager.permission_manager import reset
 from frappe.custom.doctype.property_setter.property_setter import make_property_setter
 from frappe.query_builder.functions import CombineDatetime
-from frappe.tests.utils import FrappeTestCase
-from frappe.utils import add_days, today
-from frappe.utils.data import add_to_date
+from frappe.tests.utils import FrappeTestCase, change_settings
+from frappe.utils import add_days, add_to_date, flt, today
 
 from erpnext.accounts.doctype.gl_entry.gl_entry import rename_gle_sle_docs
 from erpnext.stock.doctype.delivery_note.test_delivery_note import create_delivery_note
@@ -1218,6 +1217,41 @@ class TestStockLedgerEntry(FrappeTestCase):
 			backdated_receipt.cancel()
 		except Exception as e:
 			self.fail("Double processing of qty for clashing timestamp.")
+
+	@change_settings("System Settings", {"float_precision": 3, "currency_precision": 2})
+	def test_transfer_invariants(self):
+		"""Extact stock value should be transferred."""
+
+		item = make_item(
+			properties={
+				"valuation_method": "Moving Average",
+				"stock_uom": "Kg",
+			}
+		).name
+		source_warehouse = "Stores - TCP1"
+		target_warehouse = "Finished Goods - TCP1"
+
+		make_purchase_receipt(
+			item=item,
+			warehouse=source_warehouse,
+			qty=20,
+			conversion_factor=1000,
+			uom="Tonne",
+			rate=156_526.0,
+			company="_Test Company with perpetual inventory",
+		)
+		transfer = make_stock_entry(
+			item=item, from_warehouse=source_warehouse, to_warehouse=target_warehouse, qty=1_728.0
+		)
+
+		filters = {"voucher_no": transfer.name, "voucher_type": transfer.doctype, "is_cancelled": 0}
+		sles = frappe.get_all(
+			"Stock Ledger Entry",
+			fields=["*"],
+			filters=filters,
+			order_by="timestamp(posting_date, posting_time), creation",
+		)
+		self.assertEqual(abs(sles[0].stock_value_difference), sles[1].stock_value_difference)
 
 
 def create_repack_entry(**args):


### PR DESCRIPTION
- Stock Entry transfer relies on "incoming_rate" to determine added value in target warehouse during transfers. 
- Incoming rate was getting rounded off while setting. This means if rate was more _precise_ than currency precision then remaining value wont be added to target warehouse. 
- This results in very small rounding adjustment which in turn results in GLE for stock adjustment account. 

This change disables rounding of incoming rate to preserve incoming value = outgoing value invariant. 


Example (same as test case):
1. Material bought at 156,526 for 20 tonne where stock UOM is KG. So per kg rate is 156.526 (but currency precision is 2 so this would get rounded off to 156.53 when transferring)
2. This rounding off results in small rounding adjustment. 1000 * 156.526 - 1000 * 156.53 = 4.0. 


This only happens when purchase UOM is higher than stock UOM and rate doesn't fit in currency precision. 