### PR TITLE
fix: convert default_item_manufacturer to link field

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -365,5 +365,6 @@ erpnext.patches.v13_0.remove_unknown_links_to_prod_plan_items # 24-03-2022
 erpnext.patches.v13_0.update_expense_claim_status_for_paid_advances
 erpnext.patches.v13_0.create_gst_custom_fields_in_quotation
 erpnext.patches.v13_0.copy_custom_field_filters_to_website_item
+erpnext.patches.v13_0.change_default_item_manufacturer_fieldtype
 erpnext.patches.v14_0.discount_accounting_separation
 erpnext.patches.v14_0.delete_employee_transfer_property_doctype

--- a/erpnext/patches/v13_0/change_default_item_manufacturer_fieldtype.py
+++ b/erpnext/patches/v13_0/change_default_item_manufacturer_fieldtype.py
@@ -1,0 +1,16 @@
+import frappe
+
+
+def execute():
+
+	# Erase all default item manufacturers that dont exist.
+	item = frappe.qb.DocType("Item")
+	manufacturer = frappe.qb.DocType("Manufacturer")
+
+	(
+		frappe.qb.update(item)
+		.set(item.default_item_manufacturer, None)
+		.left_join(manufacturer)
+		.on(item.default_item_manufacturer == manufacturer.name)
+		.where(manufacturer.name.isnull() & item.default_item_manufacturer.isnotnull())
+	).run()

--- a/erpnext/stock/doctype/item/item.json
+++ b/erpnext/stock/doctype/item/item.json
@@ -869,8 +869,9 @@
   },
   {
    "fieldname": "default_item_manufacturer",
-   "fieldtype": "Data",
+   "fieldtype": "Link",
    "label": "Default Item Manufacturer",
+   "options": "Manufacturer",
    "read_only": 1
   },
   {
@@ -918,7 +919,7 @@
  "image_field": "image",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-03-25 06:38:55.942304",
+ "modified": "2022-04-28 04:52:10.272256",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Item",


### PR DESCRIPTION
better fix for https://github.com/frappe/erpnext/pull/30831 

`default_item_manufacturer` on Item doctype is not a link field so it gets out-of-sync when renamed. 

Fix: convert to link field and discard invalid data. 