### PR TITLE
fix(UX): record reason for skipping attendance or marking absent for auto attendance

### DIFF
--- a/erpnext/hr/doctype/shift_type/shift_type.py
+++ b/erpnext/hr/doctype/shift_type/shift_type.py
@@ -134,7 +134,17 @@ class ShiftType(Document):
 			shift_details = get_employee_shift(employee, timestamp, True)
 
 			if shift_details and shift_details.shift_type.name == self.name:
-				mark_attendance(employee, date, "Absent", self.name)
+				attendance = mark_attendance(employee, date, "Absent", self.name)
+				if attendance:
+					frappe.get_doc(
+						{
+							"doctype": "Comment",
+							"comment_type": "Comment",
+							"reference_doctype": "Attendance",
+							"reference_name": attendance,
+							"content": frappe._("Employee was marked Absent due to missing Employee Checkins."),
+						}
+					).insert(ignore_permissions=True)
 
 	def get_start_and_end_dates(self, employee):
 		"""Returns start and end dates for checking attendance and marking absent


### PR DESCRIPTION
## Problem

In the Auto Attendance scheduler job there are multiple reasons why an employee is marked Absent or attendance is skipped for check-in records. The user has to compare the calculated working hours with the shift timings and investigate Employee Check-ins to find out why the employee was marked Absent or why attendance was skipped for the employee.

## Fix

**Add comments to the Attendance record when the scheduler runs:**

For not meeting the working hours threshold:

<img width="1302" alt="image" src="https://user-images.githubusercontent.com/24353136/165921586-43f23fcd-b0b3-4755-92d3-84c752adc850.png">

Due to missing Employee Checkins:

<img width="1302" alt="image" src="https://user-images.githubusercontent.com/24353136/165920782-4e24a38f-bc4d-4b40-b8c5-11b8f634e19d.png">

**Add relevant comments to Employee Checkin when the scheduler runs:**

The Skip Auto Attendance checkbox is editable so this comment is required to distinguish whether it was skipped during the scheduler job or skipping was enabled by the user during log creation:

<img width="1302" alt="image" src="https://user-images.githubusercontent.com/24353136/165921321-b1f4a673-7274-4a92-802c-629923bea60e.png">

_Adding comments of type "Comment" instead of "Info" because comments are visible in the report view and can be exported._