### PR TITLE
fix(pos): freeze screen while processing pos invoices

### DIFF
--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.js
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.js
@@ -100,27 +100,33 @@ frappe.ui.form.on('POS Closing Entry', {
 		});
 	},
 
-	before_save: function(frm) {
-		frm.set_value("grand_total", 0);
-		frm.set_value("net_total", 0);
-		frm.set_value("total_quantity", 0);
-		frm.set_value("taxes", []);
-
-		for (let row of frm.doc.payment_reconciliation) {
-			row.expected_amount = row.opening_amount;
-		}
-
-		for (let row of frm.doc.pos_transactions) {
-			frappe.db.get_doc("POS Invoice", row.pos_invoice).then(doc => {
-				frm.doc.grand_total += flt(doc.grand_total);
-				frm.doc.net_total += flt(doc.net_total);
-				frm.doc.total_quantity += flt(doc.total_qty);
-				refresh_payments(doc, frm);
-				refresh_taxes(doc, frm);
-				refresh_fields(frm);
-				set_html_data(frm);
-			});
-		}
+	before_save: async function(frm) {
+		await frappe.run_serially([
+			() => frappe.dom.freeze(__('Processing Sales! Please Wait...')),
+			async () => {
+				frm.set_value("grand_total", 0);
+				frm.set_value("net_total", 0);
+				frm.set_value("total_quantity", 0);
+				frm.set_value("taxes", []);
+		
+				for (let row of frm.doc.payment_reconciliation) {
+					row.expected_amount = row.opening_amount;
+				}
+		
+				for (let row of frm.doc.pos_transactions) {
+					await frappe.db.get_doc("POS Invoice", row.pos_invoice).then(doc => {
+						frm.doc.grand_total += flt(doc.grand_total);
+						frm.doc.net_total += flt(doc.net_total);
+						frm.doc.total_quantity += flt(doc.total_qty);
+						refresh_payments(doc, frm);
+						refresh_taxes(doc, frm);
+						refresh_fields(frm);
+						set_html_data(frm);
+					});
+				}
+			},
+			() => frappe.dom.unfreeze()
+		]);
 	}
 });
 

--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.js
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.js
@@ -101,32 +101,34 @@ frappe.ui.form.on('POS Closing Entry', {
 	},
 
 	before_save: async function(frm) {
-		await frappe.run_serially([
-			() => frappe.dom.freeze(__('Processing Sales! Please Wait...')),
-			async () => {
-				frm.set_value("grand_total", 0);
-				frm.set_value("net_total", 0);
-				frm.set_value("total_quantity", 0);
-				frm.set_value("taxes", []);
-		
-				for (let row of frm.doc.payment_reconciliation) {
-					row.expected_amount = row.opening_amount;
-				}
-		
-				for (let row of frm.doc.pos_transactions) {
-					await frappe.db.get_doc("POS Invoice", row.pos_invoice).then(doc => {
-						frm.doc.grand_total += flt(doc.grand_total);
-						frm.doc.net_total += flt(doc.net_total);
-						frm.doc.total_quantity += flt(doc.total_qty);
-						refresh_payments(doc, frm);
-						refresh_taxes(doc, frm);
-						refresh_fields(frm);
-						set_html_data(frm);
-					});
-				}
-			},
-			() => frappe.dom.unfreeze()
-		]);
+		frappe.dom.freeze(__('Processing Sales! Please Wait...'));
+
+		frm.set_value("grand_total", 0);
+		frm.set_value("net_total", 0);
+		frm.set_value("total_quantity", 0);
+		frm.set_value("taxes", []);
+
+		for (let row of frm.doc.payment_reconciliation) {
+			row.expected_amount = row.opening_amount;
+		}
+
+		const pos_inv_promises = frm.doc.pos_transactions.map(
+			row => frappe.db.get_doc("POS Invoice", row.pos_invoice)
+		);
+
+		const pos_invoices = await Promise.all(pos_inv_promises);
+
+		for (let doc of pos_invoices) {
+			frm.doc.grand_total += flt(doc.grand_total);
+			frm.doc.net_total += flt(doc.net_total);
+			frm.doc.total_quantity += flt(doc.total_qty);
+			refresh_payments(doc, frm);
+			refresh_taxes(doc, frm);
+			refresh_fields(frm);
+			set_html_data(frm);
+		}
+
+		frappe.dom.unfreeze();
 	}
 });
 


### PR DESCRIPTION
In situations where the cashier has many POS Invoice 100+, the screen is very slow because the rules were created in javascript, so it happens that the user clicks more than once on the save button because he thinks that nothing is being done.

When the user clicks the button several times, the expected value of the closing is totally wrong...