### PR TITLE
feat: Copy task color from project template

### DIFF
--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -86,6 +86,7 @@ class Project(Document):
 				type=task_details.type,
 				issue=task_details.issue,
 				is_group=task_details.is_group,
+				color = task_details.color
 			)
 		).insert()
 

--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -86,7 +86,7 @@ class Project(Document):
 				type=task_details.type,
 				issue=task_details.issue,
 				is_group=task_details.is_group,
-				color = task_details.color
+				color=task_details.color,
 			)
 		).insert()
 


### PR DESCRIPTION
I noticed that when a new project is created from a project template, task colors are not copied to the new created tasks. It seems that adding a line of code in the “project.py” file, at the end of the function “create_task_from_template”, the new tasks mantain the same color that in the project template.

`no-docs`