### PR TITLE
fix: Period Closing Voucher is considering GL entries with is_cancelled=1

### DIFF
--- a/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
+++ b/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
@@ -166,8 +166,8 @@ class PeriodClosingVoucher(AccountsController):
 				sum(t1.debit_in_account_currency) - sum(t1.credit_in_account_currency) as bal_in_account_currency,
 				sum(t1.debit) - sum(t1.credit) as bal_in_company_currency
 			from `tabGL Entry` t1, `tabAccount` t2
-			where t1.account = t2.name and t2.report_type = 'Profit and Loss'
-			and t1.docstatus < 2 and t2.company = %s
+			where t1.is_cancelled = 0 and t1.account = t2.name and t2.report_type = 'Profit and Loss'
+			and t2.docstatus < 2 and t2.company = %s
 			and t1.posting_date between %s and %s
 			group by t1.account, {dimension_fields}
 		""".format(

--- a/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
+++ b/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
@@ -167,7 +167,7 @@ class PeriodClosingVoucher(AccountsController):
 				sum(t1.debit) - sum(t1.credit) as bal_in_company_currency
 			from `tabGL Entry` t1, `tabAccount` t2
 			where t1.account = t2.name and t2.report_type = 'Profit and Loss'
-			and t2.docstatus < 2 and t2.company = %s
+			and t1.docstatus < 2 and t2.company = %s
 			and t1.posting_date between %s and %s
 			group by t1.account, {dimension_fields}
 		""".format(


### PR DESCRIPTION
**Period Closing Voucher is considering GL entry with is_cancelled=1 as well**

Frappe version - v13.23.0 (version-13)
ERPNext version - v13.23.0 [(version-13)

Module
accounts

Version
Frappe version - v13.27.0 (version-13)
ERPNext version -  v13.27.1 (version-13)

Installation method
FrappeCloud

Currently there is an condition to check cancelled documents. but It's added for Account, Changed to GL Entry.
#30849