### PR TITLE
fix(UX): misleading stock entry lables

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.json
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.json
@@ -46,9 +46,9 @@
   "items",
   "get_stock_and_rate",
   "section_break_19",
-  "total_incoming_value",
-  "column_break_22",
   "total_outgoing_value",
+  "column_break_22",
+  "total_incoming_value",
   "value_difference",
   "additional_costs_section",
   "additional_costs",
@@ -374,7 +374,7 @@
   {
    "fieldname": "total_incoming_value",
    "fieldtype": "Currency",
-   "label": "Total Incoming Value",
+   "label": "Total Incoming Value (Receipt)",
    "options": "Company:company:default_currency",
    "print_hide": 1,
    "read_only": 1
@@ -386,7 +386,7 @@
   {
    "fieldname": "total_outgoing_value",
    "fieldtype": "Currency",
-   "label": "Total Outgoing Value",
+   "label": "Total Outgoing Value (Consumption)",
    "options": "Company:company:default_currency",
    "print_hide": 1,
    "read_only": 1
@@ -394,7 +394,7 @@
   {
    "fieldname": "value_difference",
    "fieldtype": "Currency",
-   "label": "Total Value Difference (Out - In)",
+   "label": "Total Value Difference (In - Out)",
    "options": "Company:company:default_currency",
    "print_hide_if_no_value": 1,
    "read_only": 1
@@ -619,7 +619,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2022-02-07 12:55:14.614077",
+ "modified": "2022-05-02 05:21:39.060501",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Entry",

--- a/erpnext/stock/doctype/stock_entry/stock_entry.json
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.json
@@ -394,7 +394,7 @@
   {
    "fieldname": "value_difference",
    "fieldtype": "Currency",
-   "label": "Total Value Difference (In - Out)",
+   "label": "Total Value Difference (Incoming - Outgoing)",
    "options": "Company:company:default_currency",
    "print_hide_if_no_value": 1,
    "read_only": 1


### PR DESCRIPTION
1. flip field location (consumption on left, receipt on right like warehouses)
2. Change incorrect label on value difference field


closes https://github.com/frappe/erpnext/issues/30867

before
<img width="1132" alt="Screenshot 2022-05-02 at 2 43 50 PM" src="https://user-images.githubusercontent.com/9079960/166211942-9ac6678e-ba23-4a2f-b5fc-d5f416915fea.png">


after

![image](https://user-images.githubusercontent.com/9079960/166213257-a1ae6b18-9bd3-4c4c-9345-7781fd44d761.png)
