### PR TITLE
fix: Ignore loan repayments made from salary slip

### DIFF
--- a/erpnext/accounts/doctype/bank_clearance/bank_clearance.py
+++ b/erpnext/accounts/doctype/bank_clearance/bank_clearance.py
@@ -118,6 +118,7 @@ class BankClearance(Document):
 			)
 			.where(loan_repayment.docstatus == 1)
 			.where(loan_repayment.clearance_date.isnull())
+			.where(loan_repayment.repay_from_salary == 0)
 			.where(loan_repayment.posting_date >= self.from_date)
 			.where(loan_repayment.posting_date <= self.to_date)
 			.where(loan_repayment.payment_account.isin([self.bank_account, self.account]))

--- a/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.py
+++ b/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.py
@@ -467,6 +467,7 @@ def get_lr_matching_query(bank_account, amount_condition, filters):
 			loan_repayment.posting_date,
 		)
 		.where(loan_repayment.docstatus == 1)
+		.where(loan_repayment.repay_from_salary == 0)
 		.where(loan_repayment.clearance_date.isnull())
 		.where(loan_repayment.payment_account == bank_account)
 	)

--- a/erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py
+++ b/erpnext/accounts/report/bank_reconciliation_statement/bank_reconciliation_statement.py
@@ -203,7 +203,7 @@ def get_loan_entries(filters):
 			posting_date = (loan_doc.posting_date).as_("posting_date")
 			account = loan_doc.payment_account
 
-		entries = (
+		query = (
 			frappe.qb.from_(loan_doc)
 			.select(
 				ConstantColumn(doctype).as_("payment_document"),
@@ -217,9 +217,12 @@ def get_loan_entries(filters):
 			.where(account == filters.get("account"))
 			.where(posting_date <= getdate(filters.get("report_date")))
 			.where(ifnull(loan_doc.clearance_date, "4000-01-01") > getdate(filters.get("report_date")))
-			.run(as_dict=1)
 		)
 
+		if doctype == "Loan Repayment":
+			query.where(loan_doc.repay_from_salary == 0)
+
+		entries = query.run(as_dict=1)
 		loan_docs.extend(entries)
 
 	return loan_docs


### PR DESCRIPTION
Loan repayments made via salary slip should not be considered in any Bank Reconciliation tool as the amount does not actually hit the bank account and the amount is deducted from Salary.