### PR TITLE
fix: show group warehouse in Sales Order

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -65,7 +65,11 @@ frappe.ui.form.on("Sales Order", {
 			frm.set_value('transaction_date', frappe.datetime.get_today())
 		}
 		erpnext.queries.setup_queries(frm, "Warehouse", function() {
-			return erpnext.queries.warehouse(frm.doc);
+			return {
+				filters: [
+					["Warehouse", "company", "in", ["", cstr(frm.doc.company)]],
+				]
+			};
 		});
 
 		frm.set_query('project', function(doc, cdt, cdn) {
@@ -77,7 +81,19 @@ frappe.ui.form.on("Sales Order", {
 			}
 		});
 
-		erpnext.queries.setup_warehouse_query(frm);
+		frm.set_query('warehouse', 'items', function(doc, cdt, cdn) {
+			let row  = locals[cdt][cdn];
+			let query = {
+				filters: [
+					["Warehouse", "company", "in", ["", cstr(frm.doc.company)]],
+				]
+			};
+			if (row.item_code) {
+				query.query = "erpnext.controllers.queries.warehouse_query";
+				query.filters.push(["Bin", "item_code", "=", row.item_code]);
+			}
+			return query;
+		});
 
 		frm.ignore_doctypes_on_cancel_all = ['Purchase Order'];
 	},


### PR DESCRIPTION
- Sales Order has a mandatory field for Warehouse
- This is required for reservation logic and all the dependent reports. 
- However, when ordering you might not know which exact warehouse it will be sold from. In which case selecting a group warehouse should be allowed (representing a specific location instead of exact warehouse)
- reservation works in a similar manner. But you'd need to refer to consolidated reports instead of single warehouses. 

<img width="562" alt="Screenshot 2022-05-04 at 11 31 32 AM" src="https://user-images.githubusercontent.com/9079960/166629769-786d3d9a-22b4-4a64-9c96-65929ec6d4f6.png">
