### PR TITLE
fix: Show linked time sheets in sales invoice dashboard

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice_dashboard.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice_dashboard.py
@@ -12,7 +12,10 @@ def get_data():
 			"Sales Invoice": "return_against",
 			"Auto Repeat": "reference_document",
 		},
-		"internal_links": {"Sales Order": ["items", "sales_order"]},
+		"internal_links": {
+			"Sales Order": ["items", "sales_order"],
+			"Timesheet": ["timesheets", "time_sheet"],
+		},
 		"transactions": [
 			{
 				"label": _("Payment"),


### PR DESCRIPTION
<img width="1361" alt="Screenshot 2022-05-04 at 5 29 52 PM" src="https://user-images.githubusercontent.com/42651287/166677323-35f4e25e-c1c0-46e8-8638-c5b898d2f57f.png">

Linked timesheets and  count was not visible in the Sales Invoice dashboard