### PR TITLE
feat(india): E Invoice Eway Bill Distance is calculated automatically.

### DIFF
--- a/erpnext/regional/india/e_invoice/einvoice.js
+++ b/erpnext/regional/india/e_invoice/einvoice.js
@@ -99,8 +99,8 @@ erpnext.setup_einvoice_actions = (doctype) => {
 									...data
 								},
 								freeze: true,
-								callback: () => frm.reload_doc() || d.hide(),
-								error: () => d.hide()
+								callback: () => frappe.show_alert({ message:__('E-Way Bill Generated successfully'), indicator:'green'}, 7) && frm.reload_doc() && d.hide(),
+								error: () => frappe.show_alert({ message:__('E-Way Bill was not Generated'), indicator:'red'}, 7)
 							});
 						},
 						primary_action_label: __('Submit')
@@ -202,7 +202,8 @@ const get_ewaybill_fields = (frm) => {
 			'fieldname': 'distance',
 			'label': 'Distance (in km)',
 			'fieldtype': 'Float',
-			'default': frm.doc.distance
+			'default': frm.doc.distance,
+			'description': 'By Default, It will be calculated automatically using Pincodes.<br> (You can also enter it Manually)',
 		},
 		{
 			'fieldname': 'transporter_col_break',

--- a/erpnext/regional/india/e_invoice/einvoice.js
+++ b/erpnext/regional/india/e_invoice/einvoice.js
@@ -99,7 +99,14 @@ erpnext.setup_einvoice_actions = (doctype) => {
 									...data
 								},
 								freeze: true,
-								callback: () => frappe.show_alert({ message:__('E-Way Bill Generated successfully'), indicator:'green'}, 7) && frm.reload_doc() && d.hide(),
+								callback: () => {
+									frappe.show_alert({
+										message: __('E-Way Bill Generated successfully'),
+										indicator: 'green'
+									}, 7);
+									frm.reload_doc();
+									d.hide();
+								},
 								error: () => frappe.show_alert({ message:__('E-Way Bill was not Generated'), indicator:'red'}, 7)
 							});
 						},

--- a/erpnext/regional/india/e_invoice/einvoice.js
+++ b/erpnext/regional/india/e_invoice/einvoice.js
@@ -203,7 +203,7 @@ const get_ewaybill_fields = (frm) => {
 			'label': 'Distance (in km)',
 			'fieldtype': 'Float',
 			'default': frm.doc.distance,
-			'description': 'By Default, It will be calculated automatically using Pincodes.<br> (You can also enter it Manually)',
+			'description': 'Set as zero to auto calculate distance using pin codes',
 		},
 		{
 			'fieldname': 'transporter_col_break',

--- a/erpnext/regional/india/e_invoice/einvoice.js
+++ b/erpnext/regional/india/e_invoice/einvoice.js
@@ -107,7 +107,13 @@ erpnext.setup_einvoice_actions = (doctype) => {
 									frm.reload_doc();
 									d.hide();
 								},
-								error: () => frappe.show_alert({ message:__('E-Way Bill was not Generated'), indicator:'red'}, 7)
+								error: () => {
+									frappe.show_alert({
+										message: __('E-Way Bill was not Generated'),
+										indicator: 'red'
+									}, 7);
+									d.hide();
+								}
 							});
 						},
 						primary_action_label: __('Submit')

--- a/erpnext/regional/india/e_invoice/utils.py
+++ b/erpnext/regional/india/e_invoice/utils.py
@@ -1120,9 +1120,9 @@ class GSPConnector:
 						if msg.get("InfCd") == "EWBPPD":
 							pin_to_pin_distance = int(re.search(r"\d+", msg.get("Desc")).group())
 							frappe.msgprint(
-    									msg="Auto Calculated Distance is " + str(pin_to_pin_distance) + " KM.",
-    									title="Notification",
-									)
+								msg="Auto Calculated Distance is " + str(pin_to_pin_distance) + " KM.",
+								title="Notification",
+							)
 							self.invoice.distance = flt(pin_to_pin_distance)
 				self.invoice.flags.updater_reference = {
 					"doctype": self.invoice.doctype,

--- a/erpnext/regional/india/e_invoice/utils.py
+++ b/erpnext/regional/india/e_invoice/utils.py
@@ -1113,6 +1113,17 @@ class GSPConnector:
 				self.invoice.eway_bill_validity = res.get("result").get("EwbValidTill")
 				self.invoice.eway_bill_cancelled = 0
 				self.invoice.update(args)
+				if res.get("info"):
+					info = res.get("info")
+					# when we have more features (responses) in eway bill, we can add them using below forloop.
+					for msg in info:
+						if msg.get("InfCd") == "EWBPPD":
+							pin_to_pin_distance = int(re.search(r'\d+', msg.get("Desc")).group())
+							frappe.msgprint(
+    									msg="Auto Calculated Distance is " + str(pin_to_pin_distance) + " KM.",
+    									title='Notification',
+									)
+							self.invoice.distance = flt(pin_to_pin_distance)
 				self.invoice.flags.updater_reference = {
 					"doctype": self.invoice.doctype,
 					"docname": self.invoice.name,

--- a/erpnext/regional/india/e_invoice/utils.py
+++ b/erpnext/regional/india/e_invoice/utils.py
@@ -1120,9 +1120,7 @@ class GSPConnector:
 						if msg.get("InfCd") == "EWBPPD":
 							pin_to_pin_distance = int(re.search(r"\d+", msg.get("Desc")).group())
 							frappe.msgprint(
-								_(
-									"Auto Calculated Distance is {} KM."
-								).format(str(pin_to_pin_distance)),
+								_("Auto Calculated Distance is {} KM.").format(str(pin_to_pin_distance)),
 								title="Notification",
 								indicator="green",
 							)

--- a/erpnext/regional/india/e_invoice/utils.py
+++ b/erpnext/regional/india/e_invoice/utils.py
@@ -1123,6 +1123,7 @@ class GSPConnector:
 								_("Auto Calculated Distance is {} KM.").format(str(pin_to_pin_distance)),
 								title="Notification",
 								indicator="green",
+								alert=True,
 							)
 							self.invoice.distance = flt(pin_to_pin_distance)
 				self.invoice.flags.updater_reference = {

--- a/erpnext/regional/india/e_invoice/utils.py
+++ b/erpnext/regional/india/e_invoice/utils.py
@@ -1118,10 +1118,10 @@ class GSPConnector:
 					# when we have more features (responses) in eway bill, we can add them using below forloop.
 					for msg in info:
 						if msg.get("InfCd") == "EWBPPD":
-							pin_to_pin_distance = int(re.search(r'\d+', msg.get("Desc")).group())
+							pin_to_pin_distance = int(re.search(r"\d+", msg.get("Desc")).group())
 							frappe.msgprint(
     									msg="Auto Calculated Distance is " + str(pin_to_pin_distance) + " KM.",
-    									title='Notification',
+    									title="Notification",
 									)
 							self.invoice.distance = flt(pin_to_pin_distance)
 				self.invoice.flags.updater_reference = {

--- a/erpnext/regional/india/e_invoice/utils.py
+++ b/erpnext/regional/india/e_invoice/utils.py
@@ -1120,8 +1120,11 @@ class GSPConnector:
 						if msg.get("InfCd") == "EWBPPD":
 							pin_to_pin_distance = int(re.search(r"\d+", msg.get("Desc")).group())
 							frappe.msgprint(
-								msg="Auto Calculated Distance is " + str(pin_to_pin_distance) + " KM.",
+								_(
+									"Auto Calculated Distance is {} KM."
+								).format(str(pin_to_pin_distance)),
 								title="Notification",
+								indicator="green",
 							)
 							self.invoice.distance = flt(pin_to_pin_distance)
 				self.invoice.flags.updater_reference = {


### PR DESCRIPTION
Passing Distance as ‘0’ is an indication that the user wants the eway bill system to take the distance as per the E Way Bill database.

I have added the description to notify the user about this and added functionality to save that distance in Sales Invoice Distance Field & show the auto-calculated distance.

I have also added an alert to let the user know whether the request was successful or not.

* I used msgprint to show the user that distance was auto-calculated. this is a temporary solution to notify the user that distance was auto-calculated until a better non-destructive method is used.

* I am currently working on that and for some reason, sanitize_error_message or raise_error is not working.

This Closes #30907 

`no-docs`