### PR TITLE
fix: disable form save on naming series tool

### DIFF
--- a/erpnext/setup/doctype/naming_series/naming_series.js
+++ b/erpnext/setup/doctype/naming_series/naming_series.js
@@ -4,8 +4,11 @@
 
 frappe.ui.form.on("Naming Series", {
 	onload: function(frm) {
-		frm.disable_save();
 		frm.events.get_doc_and_prefix(frm);
+	},
+
+	refresh: function(frm) {
+		frm.disable_save();
 	},
 
 	get_doc_and_prefix: function(frm) {


### PR DESCRIPTION
Naming series page is a tool, there's nothing to "SAVE" there. 

closes https://github.com/frappe/erpnext/issues/30905 