### PR TITLE
feat(minor): fetch default salary structure and base from Employee Grade in Salary Structure Assignment

### DIFF
--- a/erpnext/hr/doctype/employee_grade/employee_grade.json
+++ b/erpnext/hr/doctype/employee_grade/employee_grade.json
@@ -8,7 +8,9 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "default_salary_structure"
+  "default_salary_structure",
+  "currency",
+  "default_base_pay"
  ],
  "fields": [
   {
@@ -16,14 +18,31 @@
    "fieldtype": "Link",
    "label": "Default Salary Structure",
    "options": "Salary Structure"
+  },
+  {
+   "depends_on": "default_salary_structure",
+   "fieldname": "default_base_pay",
+   "fieldtype": "Currency",
+   "label": "Default Base Pay",
+   "options": "currency"
+  },
+  {
+   "fetch_from": "default_salary_structure.currency",
+   "fieldname": "currency",
+   "fieldtype": "Link",
+   "hidden": 1,
+   "label": "Currency",
+   "options": "Currency",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2020-08-26 13:12:07.815330",
+ "modified": "2022-05-06 15:42:10.395508",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Employee Grade",
+ "naming_rule": "Set by user",
  "owner": "Administrator",
  "permissions": [
   {
@@ -65,5 +84,6 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/erpnext/payroll/doctype/salary_structure/salary_structure.js
+++ b/erpnext/payroll/doctype/salary_structure/salary_structure.js
@@ -164,6 +164,15 @@ frappe.ui.form.on('Salary Structure', {
 			primary_action_label: __('Assign')
 		});
 
+		d.fields_dict.grade.df.onchange = function() {
+			const grade = d.fields_dict.grade.value;
+			if (grade) {
+				frappe.db.get_value('Employee Grade', grade, 'default_base_pay')
+					.then(({ message }) => {
+						d.set_value('base', message.default_base_pay);
+					});
+			}
+		};
 
 		d.show();
 	},

--- a/erpnext/payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+++ b/erpnext/payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
@@ -10,6 +10,7 @@
   "employee",
   "employee_name",
   "department",
+  "grade",
   "company",
   "payroll_payable_account",
   "column_break_6",
@@ -67,6 +68,8 @@
    "fieldtype": "Column Break"
   },
   {
+   "fetch_from": "grade.default_salary_structure",
+   "fetch_if_empty": 1,
    "fieldname": "salary_structure",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -96,6 +99,8 @@
    "label": "Base & Variable"
   },
   {
+   "fetch_from": "grade.default_base_pay",
+   "fetch_if_empty": 1,
    "fieldname": "base",
    "fieldtype": "Currency",
    "label": "Base",
@@ -158,11 +163,19 @@
    "fieldtype": "Table",
    "label": "Cost Centers",
    "options": "Employee Cost Center"
+  },
+  {
+   "fetch_from": "employee.grade",
+   "fieldname": "grade",
+   "fieldtype": "Link",
+   "label": "Grade",
+   "options": "Employee Grade",
+   "read_only": 1
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2022-01-19 12:43:54.439073",
+ "modified": "2022-05-06 12:18:36.972336",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Salary Structure Assignment",


### PR DESCRIPTION
### Problem:

- Employee Grade has a field for "Default Salary Structure" but it doesn't do anything/isn't fetched anywhere.
- For implementing grade-based pay, when HR is assigning salary structure to employees they first need to define Employee Grade with default structure and base pay and assign the structure in bulk. 

### Solution

- Added one more field for **Default Base Pay** in Employee Grade.
  
  <img width="1287" alt="image" src="https://user-images.githubusercontent.com/24353136/167121663-44b0d103-8a9e-4dba-a00e-09932cbcb25a.png">

- The default structure and base defined in Employee Grade are fetched in the structure assignment based on the grade of the employee.

   ![assignment-fetch](https://user-images.githubusercontent.com/24353136/167122117-a0524f94-26ee-4050-8f69-87bee2c3f722.gif)

- During the bulk assignment, the base amount is pulled on selecting Employee Grade.

   ![grade-fetching-in-bulk](https://user-images.githubusercontent.com/24353136/167122368-9bb910d4-9813-4873-8ef4-5b27ba8ea00b.gif)


This minor feature was added to reduce redundant data entry and manual errors. 

Docs updated: https://docs.erpnext.com/docs/v13/user/manual/en/human-resources/employee-grade/edit?wiki_page_patch=aef52e16ff