### PR TITLE
fix(india): re-arrange e-way bill dialog fields

### DIFF
--- a/erpnext/regional/india/e_invoice/einvoice.js
+++ b/erpnext/regional/india/e_invoice/einvoice.js
@@ -167,7 +167,7 @@ erpnext.setup_einvoice_actions = (doctype) => {
 const get_ewaybill_fields = (frm) => {
 	return [
 		{
-			fieldname: "transporter_section_break",
+			fieldname: "eway_part_a_section_break",
 			fieldtype: "Section Break",
 			label: "Part A",
 		},
@@ -187,7 +187,7 @@ const get_ewaybill_fields = (frm) => {
 			depends_on: "transporter",
 		},
 		{
-			fieldname: "transporter_column_break",
+			fieldname: "part_a_column_break",
 			fieldtype: "Column Break",
 		},
 		{
@@ -204,7 +204,7 @@ const get_ewaybill_fields = (frm) => {
 			description: "Set as zero to auto calculate distance using pin codes",
 		},
 		{
-			fieldname: "transporter_section_break",
+			fieldname: "eway_part_b_section_break",
 			fieldtype: "Section Break",
 			label: "Part B",
 		},
@@ -230,7 +230,7 @@ const get_ewaybill_fields = (frm) => {
 			default: frm.doc.vehicle_no,
 		},
 		{
-			fieldname: "vehicle_column_break",
+			fieldname: "part_b_column_break",
 			fieldtype: "Column Break",
 		},
 		{

--- a/erpnext/regional/india/e_invoice/einvoice.js
+++ b/erpnext/regional/india/e_invoice/einvoice.js
@@ -201,7 +201,7 @@ const get_ewaybill_fields = (frm) => {
 			label: "Distance (in km)",
 			fieldtype: "Float",
 			default: frm.doc.distance,
-			description: "Set as zero to auto calculate distance using pin codes",
+			description: 'Set as zero to auto calculate distance using pin codes',
 		},
 		{
 			fieldname: "eway_part_b_section_break",

--- a/erpnext/regional/india/e_invoice/einvoice.js
+++ b/erpnext/regional/india/e_invoice/einvoice.js
@@ -167,85 +167,100 @@ erpnext.setup_einvoice_actions = (doctype) => {
 const get_ewaybill_fields = (frm) => {
 	return [
 		{
-			'fieldname': 'transporter',
-			'label': 'Transporter',
-			'fieldtype': 'Link',
-			'options': 'Supplier',
-			'default': frm.doc.transporter
+			fieldname: "transporter_section_break",
+			fieldtype: "Section Break",
+			label: "Part A",
 		},
 		{
-			'fieldname': 'gst_transporter_id',
-			'label': 'GST Transporter ID',
-			'fieldtype': 'Data',
-			'default': frm.doc.gst_transporter_id
+			fieldname: "transporter",
+			label: "Transporter",
+			fieldtype: "Link",
+			options: "Supplier",
+			default: frm.doc.transporter,
 		},
 		{
-			'fieldname': 'driver',
-			'label': 'Driver',
-			'fieldtype': 'Link',
-			'options': 'Driver',
-			'default': frm.doc.driver
+			fieldname: "transporter_name",
+			label: "Transporter Name",
+			fieldtype: "Data",
+			read_only: 1,
+			default: frm.doc.transporter_name,
+			depends_on: "transporter",
 		},
 		{
-			'fieldname': 'lr_no',
-			'label': 'Transport Receipt No',
-			'fieldtype': 'Data',
-			'default': frm.doc.lr_no
+			fieldname: "transporter_column_break",
+			fieldtype: "Column Break",
 		},
 		{
-			'fieldname': 'vehicle_no',
-			'label': 'Vehicle No',
-			'fieldtype': 'Data',
-			'default': frm.doc.vehicle_no
+			fieldname: "gst_transporter_id",
+			label: "GST Transporter ID",
+			fieldtype: "Data",
+			default: frm.doc.gst_transporter_id,
 		},
 		{
-			'fieldname': 'distance',
-			'label': 'Distance (in km)',
-			'fieldtype': 'Float',
-			'default': frm.doc.distance
+			fieldname: "distance",
+			label: "Distance (in km)",
+			fieldtype: "Float",
+			default: frm.doc.distance,
+			description: "Set as zero to auto calculate distance using pin codes",
 		},
 		{
-			'fieldname': 'transporter_col_break',
-			'fieldtype': 'Column Break',
+			fieldname: "transporter_section_break",
+			fieldtype: "Section Break",
+			label: "Part B",
 		},
 		{
-			'fieldname': 'transporter_name',
-			'label': 'Transporter Name',
-			'fieldtype': 'Data',
-			'read_only': 1,
-			'default': frm.doc.transporter_name,
-			'depends_on': 'transporter'
+			fieldname: "mode_of_transport",
+			label: "Mode of Transport",
+			fieldtype: "Select",
+			options: `\nRoad\nAir\nRail\nShip`,
+			default: frm.doc.mode_of_transport,
 		},
 		{
-			'fieldname': 'mode_of_transport',
-			'label': 'Mode of Transport',
-			'fieldtype': 'Select',
-			'options': `\nRoad\nAir\nRail\nShip`,
-			'default': frm.doc.mode_of_transport
+			fieldname: "gst_vehicle_type",
+			label: "GST Vehicle Type",
+			fieldtype: "Select",
+			options: `Regular\nOver Dimensional Cargo (ODC)`,
+			depends_on: 'eval:(doc.mode_of_transport === "Road")',
+			default: frm.doc.gst_vehicle_type,
 		},
 		{
-			'fieldname': 'driver_name',
-			'label': 'Driver Name',
-			'fieldtype': 'Data',
-			'fetch_from': 'driver.full_name',
-			'read_only': 1,
-			'default': frm.doc.driver_name,
-			'depends_on': 'driver'
+			fieldname: "vehicle_no",
+			label: "Vehicle No",
+			fieldtype: "Data",
+			default: frm.doc.vehicle_no,
 		},
 		{
-			'fieldname': 'lr_date',
-			'label': 'Transport Receipt Date',
-			'fieldtype': 'Date',
-			'default': frm.doc.lr_date
+			fieldname: "vehicle_column_break",
+			fieldtype: "Column Break",
 		},
 		{
-			'fieldname': 'gst_vehicle_type',
-			'label': 'GST Vehicle Type',
-			'fieldtype': 'Select',
-			'options': `Regular\nOver Dimensional Cargo (ODC)`,
-			'depends_on': 'eval:(doc.mode_of_transport === "Road")',
-			'default': frm.doc.gst_vehicle_type
-		}
+			fieldname: "lr_date",
+			label: "Transport Receipt Date",
+			fieldtype: "Date",
+			default: frm.doc.lr_date,
+		},
+		{
+			fieldname: "lr_no",
+			label: "Transport Receipt No",
+			fieldtype: "Data",
+			default: frm.doc.lr_no,
+		},
+		{
+			fieldname: "driver",
+			label: "Driver",
+			fieldtype: "Link",
+			options: "Driver",
+			default: frm.doc.driver,
+		},
+		{
+			fieldname: "driver_name",
+			label: "Driver Name",
+			fieldtype: "Data",
+			fetch_from: "driver.full_name",
+			read_only: 1,
+			default: frm.doc.driver_name,
+			depends_on: "driver",
+		},
 	];
 };
 


### PR DESCRIPTION
Generate E-way Bill Dialog was not structured properly so I have created 2 sections (Part A & B) and added appropriate fields in their section.

I am working on e-way bill form validations as well I will soon add PR for that as well.

Before :
![before_eway_bill_dialog](https://user-images.githubusercontent.com/39730881/167131947-4365740e-319c-4ac0-bbb6-cd6928229f63.png)

After:
![After_eway_bill](https://user-images.githubusercontent.com/39730881/167132154-3b5527f6-9859-40ad-a691-274f596fa838.png)

