### PR TITLE
fix: subtract change_amount from paid_amount field on POS Register

### DIFF
--- a/erpnext/accounts/report/pos_register/pos_register.py
+++ b/erpnext/accounts/report/pos_register/pos_register.py
@@ -62,7 +62,7 @@ def get_pos_entries(filters, group_by_field):
 		"""
 		SELECT
 			p.posting_date, p.name as pos_invoice, p.pos_profile,
-			p.owner, p.base_grand_total as grand_total, p.base_paid_amount as paid_amount,
+			p.owner, p.base_grand_total as grand_total, p.base_paid_amount - p.change_amount  as paid_amount,
 			p.customer, p.is_return {select_mop_field}
 		FROM
 			`tabPOS Invoice` p {from_sales_invoice_payment}


### PR DESCRIPTION
When a sale is made and the difference amount is not allocated as change.

Example 1:
Sales: $9.90
Client pays $10 and receives change.
Change Amout: $0.1
Write Off Amout: $0

Report before my change show:
grand_total: $9.90
paid_amount: $10

With my change, show de real paid amout like show on pos close entry:
grand_total: $9.90
paid_amount: $9.90

Example 2:
Sales: $9.90
Customer pays $10 and will not receive change.
Change Amout: 0
Write Off Amout: $0.1

Rerpot before my change and with my changes show:
grand_total: $9.90
paid_amount: $10

With this we will have the real value received!
