### PR TITLE
fix: patch for renaming membership settings

### DIFF
--- a/erpnext/non_profit/workspace/non_profit/non_profit.json
+++ b/erpnext/non_profit/workspace/non_profit/non_profit.json
@@ -109,7 +109,7 @@
    "dependencies": "",
    "hidden": 0,
    "is_query_report": 0,
-   "label": "Membership Settings",
+   "label": "Non Profit Settings",
    "link_to": "Non Profit Settings",
    "link_type": "DocType",
    "onboard": 0,
@@ -213,7 +213,7 @@
    "type": "Link"
   }
  ],
- "modified": "2021-03-11 11:38:09.140655",
+ "modified": "2022-05-09 11:38:09.140655",
  "modified_by": "Administrator",
  "module": "Non Profit",
  "name": "Non Profit",

--- a/erpnext/patches/v13_0/rename_membership_settings_to_non_profit_settings.py
+++ b/erpnext/patches/v13_0/rename_membership_settings_to_non_profit_settings.py
@@ -3,11 +3,11 @@ from frappe.model.utils.rename_field import rename_field
 
 
 def execute():
-	if frappe.db.table_exists("Membership Settings"):
+	if frappe.db.exists("DocType", "Membership Settings"):
 		frappe.rename_doc("DocType", "Membership Settings", "Non Profit Settings")
 		frappe.reload_doctype("Non Profit Settings", force=True)
 
-	if frappe.db.table_exists("Non Profit Settings"):
+	if frappe.db.exists("DocType", "Non Profit Settings"):
 		rename_fields_map = {
 			"enable_invoicing": "allow_invoicing",
 			"create_for_web_forms": "automate_membership_invoicing",
@@ -20,3 +20,5 @@ def execute():
 
 		for old_name, new_name in rename_fields_map.items():
 			rename_field("Non Profit Settings", old_name, new_name)
+
+		frappe.delete_doc_if_exists("DocType", "Membership Settings")


### PR DESCRIPTION
In the patch `rename_membership_settings_to_non_profit_settings`, `frappe.db.table_exists` doesn't check for single doctypes so this check fails. 

Use `frappe.db.exists("DocType", "Membership Settings")` instead.

Delete stale doc after renaming if it exists

closes: https://github.com/frappe/erpnext/issues/25154