### PR TITLE
fix: remove check for already allocated earned leaves

### DIFF
--- a/erpnext/hr/doctype/leave_allocation/leave_allocation.js
+++ b/erpnext/hr/doctype/leave_allocation/leave_allocation.js
@@ -34,15 +34,6 @@ frappe.ui.form.on("Leave Allocation", {
 				});
 			}
 		}
-
-		// make new leaves allocated field read only if allocation is created via leave policy assignment
-		// and leave type is earned leave, since these leaves would be allocated via the scheduler
-		if (frm.doc.leave_policy_assignment) {
-			frappe.db.get_value("Leave Type", frm.doc.leave_type, "is_earned_leave", (r) => {
-				if (r && cint(r.is_earned_leave))
-					frm.set_df_property("new_leaves_allocated", "read_only", 1);
-			});
-		}
 	},
 
 	expire_allocation: function(frm) {

--- a/erpnext/hr/doctype/leave_application/test_leave_application.py
+++ b/erpnext/hr/doctype/leave_application/test_leave_application.py
@@ -745,7 +745,7 @@ class TestLeaveApplication(unittest.TestCase):
 
 		i = 0
 		while i < 14:
-			allocate_earned_leaves(ignore_duplicates=True)
+			allocate_earned_leaves()
 			i += 1
 		self.assertEqual(get_leave_balance_on(employee.name, leave_type, nowdate()), 6)
 
@@ -753,7 +753,7 @@ class TestLeaveApplication(unittest.TestCase):
 		frappe.db.set_value("Leave Type", leave_type, "max_leaves_allowed", 0)
 		i = 0
 		while i < 6:
-			allocate_earned_leaves(ignore_duplicates=True)
+			allocate_earned_leaves()
 			i += 1
 		self.assertEqual(get_leave_balance_on(employee.name, leave_type, nowdate()), 9)
 

--- a/erpnext/hr/utils.py
+++ b/erpnext/hr/utils.py
@@ -269,7 +269,7 @@ def generate_leave_encashment():
 		create_leave_encashment(leave_allocation=leave_allocation)
 
 
-def allocate_earned_leaves(ignore_duplicates=False):
+def allocate_earned_leaves():
 	"""Allocate earned leaves to Employees"""
 	e_leave_types = get_earned_leaves()
 	today = getdate()
@@ -305,14 +305,10 @@ def allocate_earned_leaves(ignore_duplicates=False):
 			if check_effective_date(
 				from_date, today, e_leave_type.earned_leave_frequency, e_leave_type.based_on_date_of_joining
 			):
-				update_previous_leave_allocation(
-					allocation, annual_allocation, e_leave_type, ignore_duplicates
-				)
+				update_previous_leave_allocation(allocation, annual_allocation, e_leave_type)
 
 
-def update_previous_leave_allocation(
-	allocation, annual_allocation, e_leave_type, ignore_duplicates=False
-):
+def update_previous_leave_allocation(allocation, annual_allocation, e_leave_type):
 	earned_leaves = get_monthly_earned_leave(
 		annual_allocation, e_leave_type.earned_leave_frequency, e_leave_type.rounding
 	)
@@ -326,20 +322,19 @@ def update_previous_leave_allocation(
 	if new_allocation != allocation.total_leaves_allocated:
 		today_date = today()
 
-		if ignore_duplicates or not is_earned_leave_already_allocated(allocation, annual_allocation):
-			allocation.db_set("total_leaves_allocated", new_allocation, update_modified=False)
-			create_additional_leave_ledger_entry(allocation, earned_leaves, today_date)
+		allocation.db_set("total_leaves_allocated", new_allocation, update_modified=False)
+		create_additional_leave_ledger_entry(allocation, earned_leaves, today_date)
 
-			if e_leave_type.based_on_date_of_joining:
-				text = _("allocated {0} leave(s) via scheduler on {1} based on the date of joining").format(
-					frappe.bold(earned_leaves), frappe.bold(formatdate(today_date))
-				)
-			else:
-				text = _("allocated {0} leave(s) via scheduler on {1}").format(
-					frappe.bold(earned_leaves), frappe.bold(formatdate(today_date))
-				)
+		if e_leave_type.based_on_date_of_joining:
+			text = _("allocated {0} leave(s) via scheduler on {1} based on the date of joining").format(
+				frappe.bold(earned_leaves), frappe.bold(formatdate(today_date))
+			)
+		else:
+			text = _("allocated {0} leave(s) via scheduler on {1}").format(
+				frappe.bold(earned_leaves), frappe.bold(formatdate(today_date))
+			)
 
-			allocation.add_comment(comment_type="Info", text=text)
+		allocation.add_comment(comment_type="Info", text=text)
 
 
 def get_monthly_earned_leave(annual_leaves, frequency, rounding):


### PR DESCRIPTION
Leave allocation for earned leaves happens through a scheduler job and there is a check to find out if the required number of earned leaves has been already allocated to avoid duplicates. 

However, the "New Leaves Allocated" field was editable before, even for earned leaves, and users might have edited the leave allocation so this check doesn't work as expected. This field was recently made read-only if it's an earned leave in https://github.com/frappe/erpnext/pull/30613. Removing this too, until there's a better way to update existing allocations.

Remove the check to continue the allocation of leaves as it's not really necessary.

P.S Updating existing leave allocations by directly editing the **New Leaves Allocated** field by putting in any number is bad UX and creates inconsistencies. Will fix this UX later.