### PR TITLE
refactor: tax rule validity query

### DIFF
--- a/erpnext/accounts/doctype/tax_rule/tax_rule.py
+++ b/erpnext/accounts/doctype/tax_rule/tax_rule.py
@@ -163,17 +163,15 @@ def get_party_details(party, party_type, args=None):
 def get_tax_template(posting_date, args):
 	"""Get matching tax rule"""
 	args = frappe._dict(args)
-	from_date = to_date = posting_date
-	if not posting_date:
-		from_date = "1900-01-01"
-		to_date = "4000-01-01"
+	conditions = []
 
-	conditions = [
-		"""(from_date is null or from_date <= '{0}')
-		and (to_date is null or to_date >= '{1}')""".format(
-			from_date, to_date
+	if posting_date:
+		conditions.append(
+			f"""(from_date is null or from_date <= '{posting_date}')
+			and (to_date is null or to_date >= '{posting_date}')"""
 		)
-	]
+	else:
+		conditions.append("(from_date is null) and (to_date is null)")
 
 	conditions.append(
 		"ifnull(tax_category, '') = {0}".format(frappe.db.escape(cstr(args.get("tax_category"))))

--- a/erpnext/e_commerce/shopping_cart/test_shopping_cart.py
+++ b/erpnext/e_commerce/shopping_cart/test_shopping_cart.py
@@ -139,7 +139,7 @@ class TestShoppingCart(unittest.TestCase):
 		tax_rule_master = set_taxes(
 			quotation.party_name,
 			"Customer",
-			quotation.transaction_date,
+			None,
 			quotation.company,
 			customer_group=None,
 			supplier_group=None,


### PR DESCRIPTION
This query is reason behind flaky test `test_tax_rule`. 

posting_date isn't being specified when fetching in doc, but it is when doing it in tests, so two different queries result in two different outcome. 

<img width="1383" alt="Screenshot 2022-05-09 at 2 16 14 PM" src="https://user-images.githubusercontent.com/9079960/167373939-5a81f568-2c07-419c-8fb8-cef5af47ecf5.png">




TODO:
- [x] `posting_date` field doesn't exist on quotation, tax rule is receiving `None`