### PR TITLE
fix(pos): creating pos returns resets pricing rules & discounts

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -479,16 +479,20 @@ erpnext.PointOfSale.Controller = class {
 		frappe.dom.freeze();
 		this.frm = this.get_new_frm(this.frm);
 		this.frm.doc.items = [];
-		const res = await frappe.call({
+		return frappe.call({
 			method: "erpnext.accounts.doctype.pos_invoice.pos_invoice.make_sales_return",
 			args: {
 				'source_name': doc.name,
 				'target_doc': this.frm.doc
+			},
+			callback: (r) => {
+				frappe.model.sync(r.message);
+				frappe.get_doc(r.message.doctype, r.message.name).__run_link_triggers = false;
+				this.set_pos_profile_data().then(() => {
+					frappe.dom.unfreeze();
+				});
 			}
 		});
-		frappe.model.sync(res.message);
-		await this.set_pos_profile_data();
-		frappe.dom.unfreeze();
 	}
 
 	set_pos_profile_data() {


### PR DESCRIPTION
Problem:
The pricing rules/discounts are reset if you create a POS Return from POS view for a POS Invoice that has pricing rules/discounts applied

Why:
This doesn't happens when returns are created from Form View, that is because links are not triggered for a new doc from Form View
Since the links are triggered in POS view when a new doc is loaded, the Price List link is triggered which leads to resetting of pricing rules

