### PR TITLE
fix: allow to use formatting for the field to_discuss in opportunity

### DIFF
--- a/erpnext/crm/doctype/opportunity/opportunity.py
+++ b/erpnext/crm/doctype/opportunity/opportunity.py
@@ -9,7 +9,7 @@ from frappe import _
 from frappe.email.inbox import link_communication_to_document
 from frappe.model.mapper import get_mapped_doc
 from frappe.query_builder import DocType
-from frappe.utils import cint, cstr, flt, get_fullname
+from frappe.utils import cint, flt, get_fullname
 
 from erpnext.crm.utils import add_link_in_communication, copy_comments
 from erpnext.setup.utils import get_exchange_rate
@@ -215,20 +215,20 @@ class Opportunity(TransactionBase):
 
 			if self.party_name and self.opportunity_from == "Customer":
 				if self.contact_person:
-					opts.description = "Contact " + cstr(self.contact_person)
+					opts.description = f"Contact {self.contact_person}"
 				else:
-					opts.description = "Contact customer " + cstr(self.party_name)
+					opts.description = f"Contact customer {self.party_name}"
 			elif self.party_name and self.opportunity_from == "Lead":
 				if self.contact_display:
-					opts.description = "Contact " + cstr(self.contact_display)
+					opts.description = f"Contact {self.contact_display}"
 				else:
-					opts.description = "Contact lead " + cstr(self.party_name)
+					opts.description = f"Contact lead {self.party_name}"
 
 			opts.subject = opts.description
-			opts.description += ". By : " + cstr(self.contact_by)
+			opts.description += f". By : {self.contact_by}"
 
 			if self.to_discuss:
-				opts.description += " To Discuss : " + cstr(self.to_discuss)
+				opts.description += f" To Discuss : {frappe.render_template(self.to_discuss, {'doc': self})}"
 
 			super(Opportunity, self).add_calendar_event(opts, force)
 

--- a/erpnext/crm/doctype/opportunity/test_opportunity.py
+++ b/erpnext/crm/doctype/opportunity/test_opportunity.py
@@ -4,7 +4,7 @@
 import unittest
 
 import frappe
-from frappe.utils import now_datetime, random_string, today
+from frappe.utils import add_days, now_datetime, random_string, today
 
 from erpnext.crm.doctype.lead.lead import make_customer
 from erpnext.crm.doctype.lead.test_lead import make_lead
@@ -96,6 +96,22 @@ class TestOpportunity(unittest.TestCase):
 		)
 		self.assertEqual(quotation_comment_count, 4)
 		self.assertEqual(quotation_communication_count, 4)
+
+	def test_render_template_for_to_discuss(self):
+		doc = make_opportunity(with_items=0, opportunity_from="Lead")
+		doc.contact_by = "test@example.com"
+		doc.contact_date = add_days(today(), days=2)
+		doc.to_discuss = "{{ doc.name }} test data"
+		doc.save()
+
+		event = frappe.get_all(
+			"Event Participants",
+			fields=["parent"],
+			filters={"reference_doctype": doc.doctype, "reference_docname": doc.name},
+		)
+
+		event_description = frappe.db.get_value("Event", event[0].parent, "description")
+		self.assertTrue(doc.name in event_description)
 
 
 def make_opportunity_from_lead():


### PR DESCRIPTION
**Issue**
The users are receiving emails regarding their upcoming follow-ups on Opportunities.
But the email does not mention the exact Opportunity ID for the follow-up making it a very tedious task for the user to track and identify the exact opportunity.

**Solution**

Formatting on the field to discuss

<img width="1109" alt="image" src="https://user-images.githubusercontent.com/8780500/167384299-5b827442-1e06-402a-937f-1a0255b18245.png">
