### PR TITLE
feat(HR): Leave Type configuration to allow over allocation

### DIFF
--- a/erpnext/hr/doctype/leave_allocation/leave_allocation.py
+++ b/erpnext/hr/doctype/leave_allocation/leave_allocation.py
@@ -254,7 +254,18 @@ class LeaveAllocation(Document):
 		# Adding a day to include To Date in the difference
 		date_difference = date_diff(self.to_date, self.from_date) + 1
 		if date_difference < self.total_leaves_allocated:
-			frappe.throw(_("Total allocated leaves are more than days in the period"), OverAllocationError)
+			if frappe.db.get_value("Leave Type", self.leave_type, "allow_over_allocation"):
+				frappe.msgprint(
+					_("<b>Total Leaves Allocated</b> are more than the number of days in the allocation period"),
+					indicator="orange",
+					alert=True,
+				)
+			else:
+				frappe.throw(
+					_("<b>Total Leaves Allocated</b> are more than the number of days in the allocation period"),
+					exc=OverAllocationError,
+					title=_("Over Allocation"),
+				)
 
 	def create_leave_ledger_entry(self, submit=True):
 		if self.unused_leaves:

--- a/erpnext/hr/doctype/leave_type/leave_type.json
+++ b/erpnext/hr/doctype/leave_type/leave_type.json
@@ -19,6 +19,7 @@
   "fraction_of_daily_salary_per_leave",
   "is_optional_leave",
   "allow_negative",
+  "allow_over_allocation",
   "include_holiday",
   "is_compensatory",
   "carry_forward_section",
@@ -211,15 +212,23 @@
    "fieldtype": "Float",
    "label": "Fraction of Daily Salary per Leave",
    "mandatory_depends_on": "eval:doc.is_ppl == 1"
+  },
+  {
+   "default": "0",
+   "description": "Allows allocating more leaves than the number of days in the allocation period.",
+   "fieldname": "allow_over_allocation",
+   "fieldtype": "Check",
+   "label": "Allow Over Allocation"
   }
  ],
  "icon": "fa fa-flag",
  "idx": 1,
  "links": [],
- "modified": "2021-10-02 11:59:40.503359",
+ "modified": "2022-05-09 05:01:38.957545",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Leave Type",
+ "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [
   {
@@ -251,5 +260,6 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }


### PR DESCRIPTION
In Leave Allocation, there is a validation for checking if the number of leaves being allocated is exceeding the number of days in the allocation period. Eg: You cannot allocate 400 leaves for 365 days. But in some organizations, this is allowed. Usually happens when a Leave Type is carry-forwarded every year and this number keeps increasing cumulatively, and eventually exceeds the number of days in the allocation period.

In such cases, the organizations handle it by setting **Maximum Consecutive Leaves Allowed** to ensure that the employee is not on leave forever.

This doesn't make much sense, but HR policies don't either! 🙈

Added a configuration in Leave Type to "Allow Over Allocation"

<img width="1308" alt="allow-over-allocation" src="https://user-images.githubusercontent.com/24353136/167403174-c8e7a133-5956-4137-8bb6-2b0759d947e3.png">

If this is enabled, it just warns the user about the scenario

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/24353136/167402985-c3d03c6d-8390-46da-8f70-a683a954413a.png">

Else, it throws an error as usual

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/24353136/167402904-2b3f4bbc-df61-4972-a434-475ad3e44bf3.png">

Docs for PR: https://docs.erpnext.com/compare?wiki_page=cab0571766&&compare=3b042fca02#