### PR TITLE
fix: dont keep milliseconds in posting_time

### DIFF
--- a/erpnext/utilities/transaction_base.py
+++ b/erpnext/utilities/transaction_base.py
@@ -23,7 +23,7 @@ class TransactionBase(StatusUpdater):
 		if not getattr(self, "set_posting_time", None):
 			now = now_datetime()
 			self.posting_date = now.strftime("%Y-%m-%d")
-			self.posting_time = now.strftime("%H:%M:%S.%f")
+			self.posting_time = now.strftime("%H:%M:%S")
 		elif self.posting_time:
 			try:
 				get_time(self.posting_time)


### PR DESCRIPTION
In stock ledger, ties are always broken using creation, hidden milliseconds part is
confusing and can cause unexpected ordering like https://github.com/frappe/erpnext/pull/30913 


This was added here: https://github.com/frappe/erpnext/pull/10975/commits/c50b85fae2c8df147cbda782d040216adcbc43b2#diff-e48d53ef3463d9915ffdf9cc9d34fafb96ff861579bdbcb07243d3a6741dd01eR28 
(looks like just for tests? )