### PR TITLE
fix: Block 0 Qty via Update Items to be consistent with form validation

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2451,11 +2451,21 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 			parent_doctype, parent_doctype_name, child_doctype, child_docname, item_row
 		)
 
-	def validate_quantity(child_item, d):
-		if parent_doctype == "Sales Order" and flt(d.get("qty")) < flt(child_item.delivered_qty):
+	def validate_quantity(child_item, new_data):
+		if not flt(new_data.get("qty")):
+			frappe.throw(
+				_("Row # {0}: Quantity for Item {1} cannot be zero").format(
+					new_data.get("idx"), frappe.bold(new_data.get("item_code"))
+				),
+				title=_("Invalid Qty"),
+			)
+
+		if parent_doctype == "Sales Order" and flt(new_data.get("qty")) < flt(child_item.delivered_qty):
 			frappe.throw(_("Cannot set quantity less than delivered quantity"))
 
-		if parent_doctype == "Purchase Order" and flt(d.get("qty")) < flt(child_item.received_qty):
+		if parent_doctype == "Purchase Order" and flt(new_data.get("qty")) < flt(
+			child_item.received_qty
+		):
 			frappe.throw(_("Cannot set quantity less than received quantity"))
 
 	data = json.loads(trans_items)


### PR DESCRIPTION
**Issue:**
- One can set Qty as 0 via **Update Items** which is illegal and breaks stuff
   ```py
    Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 69, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 37, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 75, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1447, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/model/mapper.py", line 41, in make_mapped_doc
    return method(source_name)
  File "apps/erpnext/erpnext/selling/doctype/sales_order/sales_order.py", line 1362, in create_pick_list
    target_doc,
  File "apps/frappe/frappe/model/mapper.py", line 146, in get_mapped_doc
    map_child_doc(source_d, target_doc, table_map, source_doc)
  File "apps/frappe/frappe/model/mapper.py", line 265, in map_child_doc
    map_doc(source_d, target_d, table_map, source_parent)
  File "apps/frappe/frappe/model/mapper.py", line 175, in map_doc
    table_map["postprocess"](source_doc, target_doc, source_parent)
  File "apps/erpnext/erpnext/selling/doctype/sales_order/sales_order.py", line 1329, in update_packed_item_qty
    pending_percent = (item.qty - max(picked_qty, item.delivered_qty)) / item.qty
  ZeroDivisionError: float division by zero
  ```
**Fix:**
- Block it
  <img width="1282" alt="Screenshot 2022-05-10 at 6 08 36 PM" src="https://user-images.githubusercontent.com/25857446/167630096-b976fda2-cdc9-4d95-90bb-4ae4e24b2a46.png">

   