### PR TITLE
fix: payments duplicate on pos closing entry

### DIFF
--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.js
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.js
@@ -65,7 +65,6 @@ frappe.ui.form.on('POS Closing Entry', {
 		if (frm.doc.pos_opening_entry && frm.doc.period_start_date && frm.doc.period_end_date && frm.doc.user) {
 			reset_values(frm);
 			frm.trigger("set_opening_amounts");
-			frm.trigger("get_pos_invoices");
 		}
 	},
 
@@ -79,6 +78,7 @@ frappe.ui.form.on('POS Closing Entry', {
 						expected_amount: detail.opening_amount
 					});
 				})
+				frm.trigger("get_pos_invoices");
 			});
 	},
 

--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.js
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.js
@@ -64,12 +64,15 @@ frappe.ui.form.on('POS Closing Entry', {
 	pos_opening_entry(frm) {
 		if (frm.doc.pos_opening_entry && frm.doc.period_start_date && frm.doc.period_end_date && frm.doc.user) {
 			reset_values(frm);
-			frm.trigger("set_opening_amounts");
+			frappe.run_serially([
+				() => frm.trigger("set_opening_amounts"),
+				() => frm.trigger("get_pos_invoices")
+			]);
 		}
 	},
 
 	set_opening_amounts(frm) {
-		frappe.db.get_doc("POS Opening Entry", frm.doc.pos_opening_entry)
+		return frappe.db.get_doc("POS Opening Entry", frm.doc.pos_opening_entry)
 			.then(({ balance_details }) => {
 				balance_details.forEach(detail => {
 					frm.add_child("payment_reconciliation", {
@@ -78,12 +81,11 @@ frappe.ui.form.on('POS Closing Entry', {
 						expected_amount: detail.opening_amount
 					});
 				})
-				frm.trigger("get_pos_invoices");
 			});
 	},
 
 	get_pos_invoices(frm) {
-		frappe.call({
+		return frappe.call({
 			method: 'erpnext.accounts.doctype.pos_closing_entry.pos_closing_entry.get_pos_invoices',
 			args: {
 				start: frappe.datetime.get_datetime_as_string(frm.doc.period_start_date),


### PR DESCRIPTION
**Problem**:  This error does not always happen, in 98% of the cases the closing always works, only in some situations it happens to duplicate the payment methods.

Sometimes the user will close the cashier and the payments are duplicated, the payment methods referring to the opening are inserted in the JS in an asynchronous way and then the function is called that inserts from the POS Invoice what was sold and each form of payment 

![image](https://user-images.githubusercontent.com/25017988/167877567-1b9b4f09-ad99-44be-9612-f942c8117a86.png)

We can see in the image selected in blue that the payment methods for sales were first inserted, we can see selected in red the payment methods for opening the POS was inserted later (without the sales values grouped), which should not happen.


**Solution**
Call "get_pos_invoices" after load the opening payments methods.