### PR TITLE
fix: Failing accounting dimension patch

### DIFF
--- a/erpnext/patches/v13_0/create_accounting_dimensions_in_orders.py
+++ b/erpnext/patches/v13_0/create_accounting_dimensions_in_orders.py
@@ -33,7 +33,7 @@ def execute():
 				"insert_after": insert_after_field,
 			}
 
-			create_custom_field(doctype, df, ignore_validate=False)
+			create_custom_field(doctype, df, ignore_validate=True)
 			frappe.clear_cache(doctype=doctype)
 
 		count += 1


### PR DESCRIPTION
Introduced in https://github.com/frappe/erpnext/pull/30806

Fix for :

```bash
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/patches/v13_0/create_accounting_dimensions_in_orders.py", line 36, in execute
    create_custom_field(doctype, df, ignore_validate=False)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/custom/doctype/custom_field/custom_field.py", line 176, in create_custom_field
    custom_field.insert()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 254, in insert
    self.run_method("before_insert")
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 941, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1260, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1242, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 938, in fn
    return method_object(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/custom/doctype/custom_field/custom_field.py", line 45, in before_insert
    _("A field with the name '{}' already exists in doctype {}.").format(self.fieldname, self.dt)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 510, in throw
    as_list=as_list,
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 478, in msgprint
    _raise_exception()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/__init__.py", line 433, in _raise_exception
    raise raise_exception(msg)
frappe.exceptions.ValidationError: A field with the name 'customer_group' already exists in doctype Sales Order.
```