### PR TITLE
fix: prevent bypassing forced valuation rate

### DIFF
--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -307,14 +307,15 @@ class BuyingController(StockController, Subcontracting):
 				if self.is_internal_transfer():
 					if rate != d.rate:
 						d.rate = rate
-						d.discount_percentage = 0
-						d.discount_amount = 0
 						frappe.msgprint(
 							_(
 								"Row {0}: Item rate has been updated as per valuation rate since its an internal stock transfer"
 							).format(d.idx),
 							alert=1,
 						)
+					d.discount_percentage = 0.0
+					d.discount_amount = 0.0
+					d.margin_rate_or_amount = 0.0
 
 	def get_supplied_items_cost(self, item_row_id, reset_outgoing_rate=True):
 		supplied_items_cost = 0.0

--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -447,15 +447,16 @@ class SellingController(StockController):
 						rate = flt(d.incoming_rate * d.conversion_factor, d.precision("rate"))
 						if d.rate != rate:
 							d.rate = rate
+							frappe.msgprint(
+								_(
+									"Row {0}: Item rate has been updated as per valuation rate since its an internal stock transfer"
+								).format(d.idx),
+								alert=1,
+							)
 
-						d.discount_percentage = 0
-						d.discount_amount = 0
-						frappe.msgprint(
-							_(
-								"Row {0}: Item rate has been updated as per valuation rate since its an internal stock transfer"
-							).format(d.idx),
-							alert=1,
-						)
+						d.discount_percentage = 0.0
+						d.discount_amount = 0.0
+						d.margin_rate_or_amount = 0.0
 
 			elif self.get("return_against"):
 				# Get incoming rate of return entry from reference document

--- a/erpnext/selling/doctype/customer/test_customer.py
+++ b/erpnext/selling/doctype/customer/test_customer.py
@@ -367,7 +367,14 @@ def set_credit_limit(customer, company, credit_limit):
 		customer.credit_limits[-1].db_insert()
 
 
-def create_internal_customer(customer_name, represents_company, allowed_to_interact_with):
+def create_internal_customer(
+	customer_name=None, represents_company=None, allowed_to_interact_with=None
+):
+	if not customer_name:
+		customer_name = represents_company
+	if not allowed_to_interact_with:
+		allowed_to_interact_with = represents_company
+
 	if not frappe.db.exists("Customer", customer_name):
 		customer = frappe.get_doc(
 			{


### PR DESCRIPTION
Internal transfers are equivalent to stock entry of "transfer" type. The rate isn't supposed to be editable. However, by changing the margin the rate change limitation can be bypassed right now. 

if you edit "margin_rate_or_amount" after saving DN then based on the selected margin the rate gets updated which isn't the valuation rate.

<img width="1053" alt="Screenshot 2022-05-12 at 6 44 39 PM" src="https://user-images.githubusercontent.com/9079960/168083249-74479c01-76f1-4824-ba2a-4e39ca7c3e64.png">
