### PR TITLE
feat: UOM specific barcodes

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -423,7 +423,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		item.barcode = null;
 
 
-		if(item.item_code || item.barcode || item.serial_no) {
+		if(item.item_code || item.serial_no) {
 			if(!this.validate_company_and_party()) {
 				this.frm.fields_dict["items"].grid.grid_rows[item.idx - 1].remove();
 			} else {
@@ -463,6 +463,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 							stock_qty: item.stock_qty,
 							conversion_factor: item.conversion_factor,
 							weight_per_unit: item.weight_per_unit,
+							uom: item.uom,
 							weight_uom: item.weight_uom,
 							manufacturer: item.manufacturer,
 							stock_uom: item.stock_uom,

--- a/erpnext/stock/doctype/item_barcode/item_barcode.json
+++ b/erpnext/stock/doctype/item_barcode/item_barcode.json
@@ -6,7 +6,8 @@
  "engine": "InnoDB",
  "field_order": [
   "barcode",
-  "barcode_type"
+  "barcode_type",
+  "uom"
  ],
  "fields": [
   {
@@ -24,11 +25,18 @@
    "in_list_view": 1,
    "label": "Barcode Type",
    "options": "\nEAN\nUPC-A"
+  },
+  {
+   "fieldname": "uom",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "UOM",
+   "options": "UOM"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2022-04-01 05:54:27.314030",
+ "modified": "2022-06-01 06:24:33.969534",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Item Barcode",

--- a/erpnext/stock/utils.py
+++ b/erpnext/stock/utils.py
@@ -558,7 +558,7 @@ def scan_barcode(search_value: str) -> Dict[str, Optional[str]]:
 	barcode_data = frappe.db.get_value(
 		"Item Barcode",
 		{"barcode": search_value},
-		["barcode", "parent as item_code"],
+		["barcode", "parent as item_code", "uom"],
 		as_dict=True,
 	)
 	if barcode_data:


### PR DESCRIPTION
Often warehouses might have different packaging items they stock. Like single unit, box of 100, a special pack of 42 etc. 

These different packaging can be represented by UOM and people use different barcodes for each type of UOM. The problem is, when these barcodes are scanned in transaction the default UOM is fetched instead of fetching barcode-specific UOM. 

This feature adds a new field on the barcode table where you can specify the UOM for any barcode. When that barcode is scanned the UOM is auto-updated on the table. 


You can also scan two different UOMs in same transactions and they'll be added as separate rows instead. 

Demo:

![uom_scan](https://user-images.githubusercontent.com/9079960/171386242-9754abad-d12a-47f6-b5bd-d1373fe0ae17.gif)

docs: https://docs.erpnext.com/docs/v14/user/manual/en/stock/articles/track-items-using-barcode 

closes https://github.com/frappe/erpnext/issues/30777 


integration test: https://github.com/erpnext/erpnext_ui_tests/pull/112


Credit: This is largely based on proposed implementation by @szufisher ( https://discuss.erpnext.com/t/multiple-barcodes-for-different-uoms/31577/10?u=ankush )