### PR TITLE
fix: Fix pro rata calculation for monthly depreciation

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -353,10 +353,9 @@ class Asset(AccountsController):
 					if self.allow_monthly_depreciation:
 						# month range is 1 to 12
 						# In pro rata case, for first and last depreciation, month range would be different
-						if (
-							(has_pro_rata and n == 0 and not self.number_of_depreciations_booked)
-							or (has_pro_rata and n == cint(number_of_pending_depreciations) - 1)
-						):
+						if (has_pro_rata and n == 0 and not self.number_of_depreciations_booked) or (
+							has_pro_rata and n == cint(number_of_pending_depreciations) - 1
+ 						):
 							month_range = months
 						else:
 							month_range = finance_book.frequency_of_depreciation

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -353,15 +353,16 @@ class Asset(AccountsController):
 					if self.allow_monthly_depreciation:
 						# month range is 1 to 12
 						# In pro rata case, for first and last depreciation, month range would be different
-						month_range = (
-							months
-							if (has_pro_rata and n == 0)
+						if (
+							(has_pro_rata and n == 0 and not self.number_of_depreciations_booked)
 							or (has_pro_rata and n == cint(number_of_pending_depreciations) - 1)
-							else finance_book.frequency_of_depreciation
-						)
+						):
+							month_range = months
+						else:
+							month_range = finance_book.frequency_of_depreciation
 
 						for r in range(month_range):
-							if has_pro_rata and n == 0:
+							if has_pro_rata and n == 0 and not self.number_of_depreciations_booked:
 								# For first entry of monthly depr
 								if r == 0:
 									days_until_first_depr = date_diff(monthly_schedule_date, self.available_for_use_date) + 1

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -355,7 +355,7 @@ class Asset(AccountsController):
 						# In pro rata case, for first and last depreciation, month range would be different
 						if (has_pro_rata and n == 0 and not self.number_of_depreciations_booked) or (
 							has_pro_rata and n == cint(number_of_pending_depreciations) - 1
- 						):
+						):
 							month_range = months
 						else:
 							month_range = finance_book.frequency_of_depreciation

--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -743,23 +743,6 @@ class TestDepreciationBasics(AssetSetup):
 			self.assertEqual(expected_values[i][1], schedule.depreciation_amount)
 			self.assertEqual(expected_values[i][2], schedule.accumulated_depreciation_amount)
 
-	def test_pro_rata_calculation_for_first_row_for_existing_assets(self):
-		"""Tests if pro-rata calculation is skipped for the first row when number_of_depreciations_booked != 0."""
-
-		asset = create_asset(
-			item_code="Macbook Pro",
-			calculate_depreciation=1,
-			available_for_use_date=getdate("2020-01-01"),
-			total_number_of_depreciations=3,
-			expected_value_after_useful_life=10000,
-			opening_accumulated_depreciation=15000,
-			number_of_depreciations_booked=1,
-			depreciation_start_date=getdate("2020-07-01"),
-			submit=1,
-		)
-
-		self.assertEqual(asset.schedules[0].depreciation_amount, 30000)
-
 	def test_get_depreciation_amount(self):
 		"""Tests if get_depreciation_amount() returns the right value."""
 

--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -743,6 +743,23 @@ class TestDepreciationBasics(AssetSetup):
 			self.assertEqual(expected_values[i][1], schedule.depreciation_amount)
 			self.assertEqual(expected_values[i][2], schedule.accumulated_depreciation_amount)
 
+	def test_pro_rata_calculation_for_first_row_for_existing_assets(self):
+		"""Tests if pro-rata calculation is skipped for the first row when number_of_depreciations_booked != 0."""
+
+		asset = create_asset(
+			item_code="Macbook Pro",
+			calculate_depreciation=1,
+			available_for_use_date=getdate("2020-01-01"),
+			total_number_of_depreciations=3,
+			expected_value_after_useful_life=10000,
+			opening_accumulated_depreciation=15000,
+			number_of_depreciations_booked=1,
+			depreciation_start_date=getdate("2020-07-01"),
+			submit=1,
+		)
+
+		self.assertEqual(asset.schedules[0].depreciation_amount, 30000)
+
 	def test_get_depreciation_amount(self):
 		"""Tests if get_depreciation_amount() returns the right value."""
 


### PR DESCRIPTION
## Issue

For an Asset that depreciates on a monthly basis, if the Available-for-use Date is the first of a month, but the Depreciation Start Date is on the 15th of that month, then the first and last depreciation amounts only needs to be a fraction  of the standard depreciation amount. In the case of monthly depreciation, the system checks this by checking the value of the variable `has_pro_rata` and the iteration number. However, in the case of existing assets that had already booked their first depreciation, this is not enough, since the first iteration does not correspond to the first depreciation, only the first depreciation in this system.

## Fix

Check the number of depreciations booked, in addition to the iteration number and `has_pro_rata`.

<details>
<summary>Reference Issue</summary>

ISS-21-22-14391

</details>