### PR TITLE
fix: duplicate entries in payment terms report output

### DIFF
--- a/erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py
+++ b/erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py
@@ -187,8 +187,9 @@ def get_so_with_invoices(filters):
 		.on(soi.parent == so.name)
 		.join(ps)
 		.on(ps.parent == so.name)
+		.select(so.name)
+		.distinct()
 		.select(
-			so.name,
 			so.customer,
 			so.transaction_date.as_("submitted"),
 			ifelse(datediff(ps.due_date, functions.CurDate()) < 0, "Overdue", "Unpaid").as_("status"),


### PR DESCRIPTION
### Fix
Duplicate line items appear in Payment Terms status report for SO's with more than one Items. This change will fix that.