### PR TITLE
feat: consider tax templates without tax category for all categories

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -636,7 +636,7 @@ def _get_item_tax_template(args, taxes, out=None, for_validate=False):
 		if not common_tax_template and not tax.tax_category:
 			common_tax_template = tax.item_tax_template
 
-	out["item_tax_template"] = common_tax_template
+	out["item_tax_template"] = common_tax_template if common_tax_template else out.get("item_tax_template")
 	return common_tax_template
 
 

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -614,13 +614,13 @@ def _get_item_tax_template(args, taxes, out=None, for_validate=False):
 			tax.item_tax_template
 			for tax in taxes
 			if (
-				cstr(tax.tax_category) == cstr(args.get("tax_category"))
+				(cstr(tax.tax_category) == cstr(args.get('tax_category')) or not(tax.tax_category))
 				and (tax.item_tax_template not in taxes)
 			)
 		]
 
 	# all templates have validity and no template is valid
-	if not taxes_with_validity and (not taxes_with_no_validity):
+	if not taxes:
 		return None
 
 	# do not change if already a valid template
@@ -628,11 +628,16 @@ def _get_item_tax_template(args, taxes, out=None, for_validate=False):
 		out["item_tax_template"] = args.get("item_tax_template")
 		return args.get("item_tax_template")
 
+	common_tax_template = None
 	for tax in taxes:
 		if cstr(tax.tax_category) == cstr(args.get("tax_category")):
 			out["item_tax_template"] = tax.item_tax_template
 			return tax.item_tax_template
-	return None
+		if not common_tax_template and not tax.tax_category:
+			common_tax_template = tax.item_tax_template
+
+	out["item_tax_template"] = common_tax_template
+	return common_tax_template
 
 
 def is_within_valid_range(args, tax):


### PR DESCRIPTION
Item Tax Template that are common for all Tax Categories have that field left out empty while adding it in Item master. Currently, it gets applied only when the tax category is left out empty.

Current Scenario:

https://user-images.githubusercontent.com/52111700/168414760-8f353b9d-73f0-425a-a5e3-d2d1eea27dca.mp4

When same template is added for multiple tax categories:

https://user-images.githubusercontent.com/52111700/168414876-64591671-d7da-40c6-aa5f-760ac6a3560f.mp4

Fix:

https://user-images.githubusercontent.com/52111700/168414936-c9e775ce-d301-4985-b806-95e14fb499a6.mp4

#no-docs