### PR TITLE
fix(Employee Advance): Return/Deduction from Salary button visibility

### DIFF
--- a/erpnext/hr/doctype/employee_advance/employee_advance.js
+++ b/erpnext/hr/doctype/employee_advance/employee_advance.js
@@ -65,9 +65,10 @@ frappe.ui.form.on('Employee Advance', {
 			);
 		}
 
-		if (frm.doc.docstatus === 1 &&
-			(flt(frm.doc.claimed_amount) < flt(frm.doc.paid_amount) && flt(frm.doc.paid_amount) != flt(frm.doc.return_amount))) {
-
+		if (
+			frm.doc.docstatus === 1
+			&& (flt(frm.doc.claimed_amount) < flt(frm.doc.paid_amount) - flt(frm.doc.return_amount))
+		) {
 			if (frm.doc.repay_unclaimed_amount_from_salary == 0 && frappe.model.can_create("Journal Entry")) {
 				frm.add_custom_button(__("Return"), function() {
 					frm.trigger('make_return_entry');


### PR DESCRIPTION
Return/Deduction from Salary button is still visible if Advance is partially claimed and returned.

![emp-advance](https://user-images.githubusercontent.com/24353136/168302585-db922910-f904-43a3-a45d-8c41243229a5.png)

