### PR TITLE
feat: add Employee Status filter in leave balance reports

### DIFF
--- a/erpnext/hr/report/employee_leave_balance/employee_leave_balance.js
+++ b/erpnext/hr/report/employee_leave_balance/employee_leave_balance.js
@@ -41,7 +41,13 @@ frappe.query_reports["Employee Leave Balance"] = {
 			"fieldname": "employee_status",
 			"label": __("Employee Status"),
 			"fieldtype": "Select",
-			"options": ["", "Active", "Inactive", "Suspended", "Left"],
+			"options": [
+				"",
+				{ "value": "Active", "label": __("Active") },
+				{ "value": "Inactive", "label": __("Inactive") },
+				{ "value": "Suspended", "label": __("Suspended") },
+				{ "value": "Left", "label": __("Left") },
+			],
 			"default": "Active",
 		}
 	],

--- a/erpnext/hr/report/employee_leave_balance/employee_leave_balance.js
+++ b/erpnext/hr/report/employee_leave_balance/employee_leave_balance.js
@@ -4,21 +4,21 @@
 frappe.query_reports["Employee Leave Balance"] = {
 	"filters": [
 		{
-			"fieldname":"from_date",
+			"fieldname": "from_date",
 			"label": __("From Date"),
 			"fieldtype": "Date",
 			"reqd": 1,
 			"default": frappe.defaults.get_default("year_start_date")
 		},
 		{
-			"fieldname":"to_date",
+			"fieldname": "to_date",
 			"label": __("To Date"),
 			"fieldtype": "Date",
 			"reqd": 1,
 			"default": frappe.defaults.get_default("year_end_date")
 		},
 		{
-			"fieldname":"company",
+			"fieldname": "company",
 			"label": __("Company"),
 			"fieldtype": "Link",
 			"options": "Company",
@@ -26,16 +26,23 @@ frappe.query_reports["Employee Leave Balance"] = {
 			"default": frappe.defaults.get_user_default("Company")
 		},
 		{
-			"fieldname":"department",
+			"fieldname": "department",
 			"label": __("Department"),
 			"fieldtype": "Link",
 			"options": "Department",
 		},
 		{
-			"fieldname":"employee",
+			"fieldname": "employee",
 			"label": __("Employee"),
 			"fieldtype": "Link",
 			"options": "Employee",
+		},
+		{
+			"fieldname": "employee_status",
+			"label": __("Employee Status"),
+			"fieldtype": "Select",
+			"options": ["", "Active", "Inactive", "Suspended", "Left"],
+			"default": "Active",
 		}
 	],
 

--- a/erpnext/hr/report/employee_leave_balance/employee_leave_balance.py
+++ b/erpnext/hr/report/employee_leave_balance/employee_leave_balance.py
@@ -168,9 +168,8 @@ def get_opening_balance(
 
 
 def get_conditions(filters: Filters) -> Dict:
-	conditions = {
-		"status": "Active",
-	}
+	conditions = {}
+
 	if filters.get("employee"):
 		conditions["name"] = filters.get("employee")
 
@@ -179,6 +178,9 @@ def get_conditions(filters: Filters) -> Dict:
 
 	if filters.get("department"):
 		conditions["department"] = filters.get("department")
+
+	if filters.get("employee_status"):
+		conditions["status"] = filters.get("employee_status")
 
 	return conditions
 

--- a/erpnext/hr/report/employee_leave_balance_summary/employee_leave_balance_summary.js
+++ b/erpnext/hr/report/employee_leave_balance_summary/employee_leave_balance_summary.js
@@ -30,6 +30,13 @@ frappe.query_reports['Employee Leave Balance Summary'] = {
 			label: __('Department'),
 			fieldtype: 'Link',
 			options: 'Department',
+		},
+		{
+			fieldname: "employee_status",
+			label: __("Employee Status"),
+			fieldtype: "Select",
+			options: ["", "Active", "Inactive", "Suspended", "Left"],
+			default: "Active",
 		}
 	]
 };

--- a/erpnext/hr/report/employee_leave_balance_summary/employee_leave_balance_summary.js
+++ b/erpnext/hr/report/employee_leave_balance_summary/employee_leave_balance_summary.js
@@ -35,7 +35,13 @@ frappe.query_reports['Employee Leave Balance Summary'] = {
 			fieldname: "employee_status",
 			label: __("Employee Status"),
 			fieldtype: "Select",
-			options: ["", "Active", "Inactive", "Suspended", "Left"],
+			options: [
+				"",
+				{ "value": "Active", "label": __("Active") },
+				{ "value": "Inactive", "label": __("Inactive") },
+				{ "value": "Suspended", "label": __("Suspended") },
+				{ "value": "Left", "label": __("Left") },
+			],
 			default: "Active",
 		}
 	]

--- a/erpnext/hr/report/employee_leave_balance_summary/employee_leave_balance_summary.py
+++ b/erpnext/hr/report/employee_leave_balance_summary/employee_leave_balance_summary.py
@@ -35,9 +35,10 @@ def get_columns(leave_types):
 
 def get_conditions(filters):
 	conditions = {
-		"status": "Active",
 		"company": filters.company,
 	}
+	if filters.get("employee_status"):
+		conditions.update({"status": filters.get("employee_status")})
 	if filters.get("department"):
 		conditions.update({"department": filters.get("department")})
 	if filters.get("employee"):


### PR DESCRIPTION
## Problem:

In the leave balance reports: Employee Leave Balance and Employee Leave Balance Summary, only "Active" employees are shown by default. If HR wants to check balances for employees with Inactive/Left status for Leave Encashment or other purposes, they cannot.

<img width="1308" alt="image" src="https://user-images.githubusercontent.com/24353136/168311569-aab4e3f1-1584-405f-9ab8-5a960fa2b18a.png">

<img width="1308" alt="image" src="https://user-images.githubusercontent.com/24353136/168311660-55a612df-168b-4726-8800-8e176c978694.png">

## Solution:

Added a filter for **Employee Status** which defaults to "Active" since only active employees were shown in the report:

<img width="1308" alt="image" src="https://user-images.githubusercontent.com/24353136/168311067-ad5d3826-5654-4796-879c-fabf53a67d2c.png">

<img width="1308" alt="image" src="https://user-images.githubusercontent.com/24353136/168311529-de6f4908-76b6-456d-a1d6-eaa013a07803.png">


This filter has been added to both the reports.

`no-docs` Just added a filter (self-explanatory)