### PR TITLE
fix: discount ledger entry in case of multicurrency invoice

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1121,11 +1121,10 @@ class AccountsController(TransactionBase):
 							{
 								"account": item.discount_account,
 								"against": supplier_or_customer,
-								dr_or_cr: flt(discount_amount, item.precision("discount_amount")),
-								dr_or_cr
-								+ "_in_account_currency": flt(
+								dr_or_cr: flt(
 									discount_amount * self.get("conversion_rate"), item.precision("discount_amount")
 								),
+								dr_or_cr + "_in_account_currency": flt(discount_amount, item.precision("discount_amount")),
 								"cost_center": item.cost_center,
 								"project": item.project,
 							},
@@ -1140,11 +1139,11 @@ class AccountsController(TransactionBase):
 							{
 								"account": income_or_expense_account,
 								"against": supplier_or_customer,
-								rev_dr_cr: flt(discount_amount, item.precision("discount_amount")),
-								rev_dr_cr
-								+ "_in_account_currency": flt(
+								rev_dr_cr: flt(
 									discount_amount * self.get("conversion_rate"), item.precision("discount_amount")
 								),
+								rev_dr_cr
+								+ "_in_account_currency": flt(discount_amount, item.precision("discount_amount")),
 								"cost_center": item.cost_center,
 								"project": item.project or self.project,
 							},


### PR DESCRIPTION
Problem:
If _Discount Accounting_ is enabled and a discount is applied on a multicurrency invoice, then the ledger entry for the discount is posted with an incorrect base amount. 
The _base_ amount i.e debit should be in company currency.

Invoice:

<img width="1005" alt="CleanShot 2022-05-16 at 12 08 52@2x" src="https://user-images.githubusercontent.com/25369014/168533561-042faa55-f07d-479a-aa0c-8acd2781de41.png">

Incorrect GLE:

<img width="947" alt="CleanShot 2022-05-16 at 12 04 22@2x" src="https://user-images.githubusercontent.com/25369014/168532953-5b3429b3-1663-4f32-9153-9c622bc9f61a.png">

Correct GLE:

<img width="947" alt="CleanShot 2022-05-16 at 12 04 46@2x" src="https://user-images.githubusercontent.com/25369014/168533004-73913cf6-7d99-4251-a7d6-5dbba2dc4243.png">
