### PR TITLE
fix: remove item attribute limit from variant selector

### DIFF
--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -586,8 +586,7 @@ $.extend(erpnext.item, {
 								["parent","=", d.attribute]
 							],
 							fields: ["attribute_value"],
-							limit_start: 0,
-							limit_page_length: 500,
+							limit_page_length: 0,
 							parent: "Item Attribute",
 							order_by: "idx"
 						}


### PR DESCRIPTION
This limit was raised from 20 to 500, well someone has 500 attribute values too :D 

Soln: just remove this limit totally. 

ref: https://github.com/frappe/erpnext/pull/13155