### PR TITLE
fix: IN time not captured in Attendance through Employee Checkin

### DIFF
--- a/erpnext/hr/doctype/employee_checkin/employee_checkin.py
+++ b/erpnext/hr/doctype/employee_checkin/employee_checkin.py
@@ -227,11 +227,15 @@ def calculate_working_hours(logs, check_in_out_type, working_hours_calc_type):
 					in_log = out_log = None
 				if not in_log:
 					in_log = log if log.log_type == "IN" else None
+					if in_log and not in_time:
+						in_time = in_log.time
 				elif not out_log:
 					out_log = log if log.log_type == "OUT" else None
+
 			if in_log and out_log:
 				out_time = out_log.time
 				total_hours += time_diff_in_hours(in_log.time, out_log.time)
+
 	return total_hours, in_time, out_time
 
 

--- a/erpnext/hr/doctype/employee_checkin/test_employee_checkin.py
+++ b/erpnext/hr/doctype/employee_checkin/test_employee_checkin.py
@@ -125,6 +125,11 @@ class TestEmployeeCheckin(FrappeTestCase):
 		)
 		self.assertEqual(working_hours, (4.5, logs_type_2[1].time, logs_type_2[-1].time))
 
+		working_hours = calculate_working_hours(
+			[logs_type_2[1], logs_type_2[-1]], check_in_out_type[1], working_hours_calc_type[1]
+		)
+		self.assertEqual(working_hours, (5.0, logs_type_2[1].time, logs_type_2[-1].time))
+
 	def test_fetch_shift(self):
 		employee = make_employee("test_employee_checkin@example.com", company="_Test Company")
 


### PR DESCRIPTION
Closes https://github.com/frappe/erpnext/issues/31003

## Steps to replicate:

- Set up Shift Type with the following options:
   ![image](https://user-images.githubusercontent.com/24353136/168559256-2ede248c-b303-4cd7-b7f0-a59e2b33857b.png)
- Create one Employee Checkin with Log Type IN and one with OUT.
   <img width="1308" alt="image" src="https://user-images.githubusercontent.com/24353136/168560128-ab256b26-e5ec-42cb-a021-2e240a7876d1.png">

   <img width="1308" alt="image" src="https://user-images.githubusercontent.com/24353136/168560170-7c0b0965-2aa2-4a6b-9233-d4a50886a5a8.png">
	
- Mark Attendance from Shift Type
   <img width="1308" alt="image" src="https://user-images.githubusercontent.com/24353136/168560349-f96f18f6-c1df-48ab-900d-d3982f229029.png">

- IN Time is not set in the attendance record created
- This only happens when there is just a single check-in and check-out. Usually works fine when there are multiple logs.

## Fix:

Set `in_time` when `in_log` is found for the first time and there are only 2 logs. 

<img width="1308" alt="image" src="https://user-images.githubusercontent.com/24353136/168560587-2d78ae3f-1877-4c54-a3c9-071a2260261e.png">
