### PR TITLE
fix: disable pricing rules for internal transfers

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -148,6 +148,7 @@ class AccountsController(TransactionBase):
 
 		self.validate_inter_company_reference()
 
+		self.disable_pricing_rule_on_internal_transfer()
 		self.set_incoming_rate()
 
 		if self.meta.get_field("currency"):
@@ -381,6 +382,14 @@ class AccountsController(TransactionBase):
 				msg = _("Internal Sale or Delivery Reference missing.")
 				msg += _("Please create purchase from internal sale or delivery document itself")
 				frappe.throw(msg, title=_("Internal Sales Reference Missing"))
+
+	def disable_pricing_rule_on_internal_transfer(self):
+		if not self.get("ignore_pricing_rule"):
+			self.ignore_pricing_rule = 1
+			frappe.msgprint(
+				_("Disabled pricing rules since this {} is an internal transfer").format(self.doctype),
+				alert=1,
+			)
 
 	def validate_due_date(self):
 		if self.get("is_pos"):

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -384,7 +384,7 @@ class AccountsController(TransactionBase):
 				frappe.throw(msg, title=_("Internal Sales Reference Missing"))
 
 	def disable_pricing_rule_on_internal_transfer(self):
-		if not self.get("ignore_pricing_rule"):
+		if not self.get("ignore_pricing_rule") and self.is_internal_transfer():
 			self.ignore_pricing_rule = 1
 			frappe.msgprint(
 				_("Disabled pricing rules since this {} is an internal transfer").format(self.doctype),

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1747,6 +1747,8 @@ class AccountsController(TransactionBase):
 			internal_party_field = "is_internal_customer"
 		elif self.doctype in ("Purchase Invoice", "Purchase Receipt", "Purchase Order"):
 			internal_party_field = "is_internal_supplier"
+		else:
+			return False
 
 		if self.get(internal_party_field) and (self.represents_company == self.company):
 			return True


### PR DESCRIPTION
Extends https://github.com/frappe/erpnext/pull/30987 


Problem: Pricing rules can also bypass the forced valuation rate required by the internal transfers. 
Fix: disable pricing rules on internal transfers completely. 


Check test case and linked PR above for steps to reproduce. 