### PR TITLE
fix: TypeError in add_indicator_for_multicompany

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -125,7 +125,7 @@ $.extend(erpnext.utils, {
 	},
 
 	add_indicator_for_multicompany: function(frm, info) {
-		frm.dashboard.stats_area.removeClass('hidden');
+		frm.dashboard.stats_area.show();
 		frm.dashboard.stats_area_row.addClass('flex');
 		frm.dashboard.stats_area_row.css('flex-wrap', 'wrap');
 


### PR DESCRIPTION
If a customer has done transactions with multiple companies, the add (+)  buttons in connection dashboard will not appear. This is caused by TypeError during stats area creation for customer. Error msg in console looks like 
**"TypeError: e.dashboard.stats_area.removeClass is not a function"**
which is created by **"frm.dashboard.stats_area.removeClass('hidden');"**
So we can use existing show() function to do the similar job 
`frm.dashboard.stats_area.show();`
