### PR TITLE
fix: reset barcode scan field

### DIFF
--- a/erpnext/public/js/utils/barcode_scanner.js
+++ b/erpnext/public/js/utils/barcode_scanner.js
@@ -204,7 +204,8 @@ erpnext.utils.BarcodeScanner = class BarcodeScanner {
 	}
 
 	clean_up() {
-		this.scan_barcode_field.set_value("");
+		const doc = this.frm.doc;
+		frappe.model.set_value(doc.doctype, doc.name, this.scan_field_name, "", "Data");
 		refresh_field(this.items_table_name);
 	}
 	show_alert(msg, indicator, duration=3) {


### PR DESCRIPTION
The barcode scan field was not doing a reset after each scan, most likely caused by the promise introduced in https://github.com/frappe/erpnext/pull/31018

Not sure how I missed this when I made the initial PR. Anyways, resetting directly with frappe.model is working.

cc: @ankush 