### PR TITLE
fix: unlink Attendance from Employee Checkins on cancellation

### DIFF
--- a/erpnext/hr/doctype/employee_checkin/test_employee_checkin.py
+++ b/erpnext/hr/doctype/employee_checkin/test_employee_checkin.py
@@ -76,6 +76,17 @@ class TestEmployeeCheckin(FrappeTestCase):
 		)
 		self.assertEqual(attendance_count, 1)
 
+	def test_unlink_attendance_on_cancellation(self):
+		employee = make_employee("test_mark_attendance_and_link_log@example.com")
+		logs = make_n_checkins(employee, 3)
+
+		frappe.db.delete("Attendance", {"employee": employee})
+		attendance = mark_attendance_and_link_log(logs, "Present", nowdate(), 8.2)
+		attendance.cancel()
+
+		linked_logs = frappe.db.get_all("Employee Checkin", {"attendance": attendance.name})
+		self.assertEquals(len(linked_logs), 0)
+
 	def test_calculate_working_hours(self):
 		check_in_out_type = [
 			"Alternating entries as IN and OUT during the same shift",


### PR DESCRIPTION
## Problem

- When attendance is marked via auto attendance, the attendance record is linked to the check-in logs.
- If a check-in is added later (usually happens in the case of onsite employees), the user needs to change the attendance. 
- They manually cancel the record, but the linking still remains, so when "Mark Attendance" is triggered by the user, the logs with linking are skipped. If they try to delete the Attendance record, they also need to delete the Employee Check-in although there should be no need to do this.

## Solution

- Unlink attendance record from check-in logs on cancellation.
- This will allow the user to add required check-ins and mark attendance correctly by relinking the record.

![Kapture 2022-05-17 at 10 46 57](https://user-images.githubusercontent.com/24353136/168734584-6f827962-70d1-46c9-8252-ca031eb23902.gif)

