### PR TITLE
fix: Job Card excess transfer behaviour

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -531,11 +531,9 @@ class JobCard(Document):
 
 		def _validate_over_transfer(row, transferred_qty):
 			"Block over transfer of items if not allowed in settings."
-			allow_excess = frappe.db.get_single_value("Manufacturing Settings", "job_card_excess_transfer")
 			required_qty = frappe.db.get_value("Job Card Item", row.job_card_item, "required_qty")
 			is_excess = flt(transferred_qty) > flt(required_qty)
-
-			if is_excess and not allow_excess:
+			if is_excess:
 				frappe.throw(
 					_(
 						"Row #{0}: Cannot transfer more than Required Qty {1} for Item {2} against Job Card {3}"
@@ -564,7 +562,9 @@ class JobCard(Document):
 				)
 			).run()[0][0]
 
-			_validate_over_transfer(row, transferred_qty)
+			allow_excess = frappe.db.get_single_value("Manufacturing Settings", "job_card_excess_transfer")
+			if not allow_excess:
+				_validate_over_transfer(row, transferred_qty)
 
 			frappe.db.set_value("Job Card Item", row.job_card_item, "transferred_qty", flt(transferred_qty))
 

--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -42,6 +42,10 @@ class JobCardCancelError(frappe.ValidationError):
 	pass
 
 
+class JobCardOverTransferError(frappe.ValidationError):
+	pass
+
+
 class JobCard(Document):
 	def onload(self):
 		excess_transfer = frappe.db.get_single_value(
@@ -522,23 +526,50 @@ class JobCard(Document):
 			},
 		)
 
-	def set_transferred_qty_in_job_card(self, ste_doc):
+	def set_transferred_qty_in_job_card_item(self, ste_doc):
+		from frappe.query_builder.functions import Sum
+
+		def _validate_over_transfer(row, transferred_qty):
+			"Block over transfer of items if not allowed in settings."
+			allow_excess = frappe.db.get_single_value("Manufacturing Settings", "job_card_excess_transfer")
+			required_qty = frappe.db.get_value("Job Card Item", row.job_card_item, "required_qty")
+			is_excess = flt(transferred_qty) > flt(required_qty)
+
+			if is_excess and not allow_excess:
+				frappe.throw(
+					_(
+						"Row #{0}: Cannot transfer more than Required Qty {1} for Item {2} against Job Card {3}"
+					).format(
+						row.idx, frappe.bold(required_qty), frappe.bold(row.item_code), ste_doc.job_card
+					),
+					title=_("Excess Transfer"),
+					exc=JobCardOverTransferError,
+				)
+
 		for row in ste_doc.items:
 			if not row.job_card_item:
 				continue
 
-			qty = frappe.db.sql(
-				""" SELECT SUM(qty) from `tabStock Entry Detail` sed, `tabStock Entry` se
-				WHERE  sed.job_card_item = %s and se.docstatus = 1 and sed.parent = se.name and
-				se.purpose = 'Material Transfer for Manufacture'
-			""",
-				(row.job_card_item),
-			)[0][0]
+			sed = frappe.qb.DocType("Stock Entry Detail")
+			se = frappe.qb.DocType("Stock Entry")
+			transferred_qty = (
+				frappe.qb.from_(sed)
+				.join(se)
+				.on(sed.parent == se.name)
+				.select(Sum(sed.qty))
+				.where(
+					(sed.job_card_item == row.job_card_item)
+					& (se.docstatus == 1)
+					& (se.purpose == "Material Transfer for Manufacture")
+				)
+			).run()[0][0]
 
-			frappe.db.set_value("Job Card Item", row.job_card_item, "transferred_qty", flt(qty))
+			_validate_over_transfer(row, transferred_qty)
+
+			frappe.db.set_value("Job Card Item", row.job_card_item, "transferred_qty", flt(transferred_qty))
 
 	def set_transferred_qty(self, update_status=False):
-		"Set total FG Qty for which RM was transferred."
+		"Set total FG Qty in Job Card for which RM was transferred."
 		if not self.items:
 			self.transferred_qty = self.for_quantity if self.docstatus == 1 else 0
 

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -1141,7 +1141,7 @@ class StockEntry(StockController):
 		if self.job_card:
 			job_doc = frappe.get_doc("Job Card", self.job_card)
 			job_doc.set_transferred_qty(update_status=True)
-			job_doc.set_transferred_qty_in_job_card(self)
+			job_doc.set_transferred_qty_in_job_card_item(self)
 
 		if self.work_order:
 			pro_doc = frappe.get_doc("Work Order", self.work_order)


### PR DESCRIPTION
**Issue:**
> TLDR: You can transfer as much excess against a Job Card (no way to restrict), which is also inconsistent with the front end's **Material Transfer** button

-  Make sure **Allow Excess Material Transfer** in Mfg Settings is disabled
- Make a Work Order with **Transfer Against: Job Card**  (operations and items) > Submit
- Go to one of the Job Cards (must have items) > Create two Material Transfer entries in **Draft** state
- Submit them one by one. You can submit both and the `transferred_qty` in the Job Card is double the required qty
- This is wrong since there's no way to control accidental over transfer
- Also inconsistent with the front end. We hide **Material Transfer** button if no pending qty to transfer and **Allow Excess Material Transfer** in Mfg Settings is disabled. Server side should also respect that

**Fix:**
- Block excess transfer of items if not allowed in settings.
- Behaviour made consistent with js behaviour (button disappears if not pending and not allowed in settings)
- Test for same case
   <img width="1303" alt="Screenshot 2022-05-17 at 5 35 24 PM" src="https://user-images.githubusercontent.com/25857446/168809149-e527414f-14fa-4406-a821-e6d80e19b4d1.png">

> Check is done item wise since total transferred qty in Job Card is not reliable