### PR TITLE
fix(india): eway bill cancel api is disabled

### DIFF
--- a/erpnext/regional/india/e_invoice/einvoice.js
+++ b/erpnext/regional/india/e_invoice/einvoice.js
@@ -149,58 +149,27 @@ erpnext.setup_einvoice_actions = (doctype) => {
 			}
 
 			if (irn && ewaybill && !irn_cancelled && !eway_bill_cancelled) {
-				const fields = [
-					{
-						"label": "Reason",
-						"fieldname": "reason",
-						"fieldtype": "Select",
-						"reqd": 1,
-						"default": "1-Duplicate",
-						"options": ["1-Duplicate", "2-Data Entry Error", "3-Order Cancelled", "4-Other"]
-					},
-					{
-						"label": "Remark",
-						"fieldname": "remark",
-						"fieldtype": "Data",
-						"reqd": 1
-					}
-				];
 				const action = () => {
-					const d = new frappe.ui.Dialog({
-						title: __('Cancel E-Way Bill'),
-						fields: fields,
-						primary_action: function() {
-							const data = d.get_values();
-							frappe.call({
-								method: 'erpnext.regional.india.e_invoice.utils.cancel_eway_bill',
-								args: {
-									doctype,
-									docname: name,
-									eway_bill: ewaybill,
-									reason: data.reason.split('-')[0],
-									remark: data.remark
-								},
-								freeze: true,
-								callback: () => {
-									frappe.show_alert({
-										message: __('E-Way Bill Cancelled successfully'),
-										indicator: 'green'
-									}, 7);
-									frm.reload_doc();
-									d.hide();
-								},
-								error: () => {
-									frappe.show_alert({
-										message: __('E-Way Bill was not Cancelled'),
-										indicator: 'red'
-									}, 7);
-									d.hide();
-								}
-							});
+					let message = __('Cancellation of e-way bill is currently not supported.') + ' ';
+					message += '<br><br>';
+					message += __('You must first use the portal to cancel the e-way bill and then update the cancelled status in the ERPNext system.');
+
+					const dialog = frappe.msgprint({
+						title: __('Update E-Way Bill Cancelled Status?'),
+						message: message,
+						indicator: 'orange',
+						primary_action: {
+							action: function() {
+								frappe.call({
+									method: 'erpnext.regional.india.e_invoice.utils.cancel_eway_bill',
+									args: { doctype, docname: name },
+									freeze: true,
+									callback: () => frm.reload_doc() && dialog.hide()
+								});
+							}
 						},
-						primary_action_label: __('Submit')
+						primary_action_label: __('Yes')
 					});
-					d.show();
 				};
 				add_custom_button(__("Cancel E-Way Bill"), action);
 			}

--- a/erpnext/regional/india/e_invoice/utils.py
+++ b/erpnext/regional/india/e_invoice/utils.py
@@ -797,9 +797,8 @@ class GSPConnector:
 		self.irn_details_url = self.base_url + "/enriched/ei/api/invoice/irn"
 		self.generate_irn_url = self.base_url + "/enriched/ei/api/invoice"
 		self.gstin_details_url = self.base_url + "/enriched/ei/api/master/gstin"
-		self.cancel_ewaybill_url = (
-			self.base_url + "/enriched/ewb/ewayapi?action=CANEWB"
-		)  # this will only work if user have bought ewb api from adaequare.
+		# cancel_ewaybill_url will only work if user have bought ewb api from adaequare.
+		self.cancel_ewaybill_url = self.base_url + "/enriched/ewb/ewayapi?action=CANEWB"
 		self.generate_ewaybill_url = self.base_url + "/enriched/ei/api/ewaybill"
 		self.get_qrcode_url = self.base_url + "/enriched/ei/others/qr/image"
 

--- a/erpnext/regional/india/e_invoice/utils.py
+++ b/erpnext/regional/india/e_invoice/utils.py
@@ -797,7 +797,9 @@ class GSPConnector:
 		self.irn_details_url = self.base_url + "/enriched/ei/api/invoice/irn"
 		self.generate_irn_url = self.base_url + "/enriched/ei/api/invoice"
 		self.gstin_details_url = self.base_url + "/enriched/ei/api/master/gstin"
-		self.cancel_ewaybill_url = self.base_url + "/enriched/ei/api/ewayapi"
+		self.cancel_ewaybill_url = (
+			self.base_url + "/enriched/ewb/ewayapi?action=CANEWB"
+		)  # this will only work if user have bought ewb api from adaequare.
 		self.generate_ewaybill_url = self.base_url + "/enriched/ei/api/ewaybill"
 		self.get_qrcode_url = self.base_url + "/enriched/ei/others/qr/image"
 
@@ -1185,6 +1187,7 @@ class GSPConnector:
 		headers = self.get_headers()
 		data = json.dumps({"ewbNo": eway_bill, "cancelRsnCode": reason, "cancelRmrk": remark}, indent=4)
 		headers["username"] = headers["user_name"]
+		del headers["user_name"]
 		try:
 			res = self.make_request("post", self.cancel_ewaybill_url, headers, data)
 			if res.get("success"):
@@ -1358,9 +1361,13 @@ def generate_eway_bill(doctype, docname, **kwargs):
 
 
 @frappe.whitelist()
-def cancel_eway_bill(doctype, docname, eway_bill, reason, remark):
-	gsp_connector = GSPConnector(doctype, docname)
-	gsp_connector.cancel_eway_bill(eway_bill, reason, remark)
+def cancel_eway_bill(doctype, docname):
+	# NOTE: cancel_eway_bill api is disabled by Adequare.
+	# gsp_connector = GSPConnector(doctype, docname)
+	# gsp_connector.cancel_eway_bill(eway_bill, reason, remark)
+
+	frappe.db.set_value(doctype, docname, "ewaybill", "")
+	frappe.db.set_value(doctype, docname, "eway_bill_cancelled", 1)
 
 
 @frappe.whitelist()


### PR DESCRIPTION
E-invoice API for E-way bill cancellation from Adaequare is permanently disabled on their production API.

I had tested their API on staging and it was working fine. I had also checked their API documentation and everything suggested that it was available. Still, it gives a 404 error on production API so I contacted them and after discussion, they have told me that it is disabled on production API and will not be available user will have to cancel it from the e-way bill portal. 

I have removed the changes made by #30888 that enabled the cancel API.

@nextchamp-saqib API URL for cancelation https://gsp.adaequare.com/enriched/ewb/ewayapi?action=CANEWB will only work if the user has purchased their e-way bill API Package.

There is no need for the cancel_eway_bill function anymore but I have not removed it.