### PR TITLE
feat: added a filter for item group on "get items" stock reconciliation

### DIFF
--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.js
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.js
@@ -104,6 +104,12 @@ frappe.ui.form.on("Stock Reconciliation", {
 				}
 			},
 			{
+				label: "Item Group",
+				fieldname: "item_group",
+				fieldtype: "Link",
+				options: "Item Group"
+			},
+			{
 				label: __("Ignore Empty Stock"),
 				fieldname: "ignore_empty_stock",
 				fieldtype: "Check"
@@ -119,7 +125,8 @@ frappe.ui.form.on("Stock Reconciliation", {
 					posting_time: frm.doc.posting_time,
 					company: frm.doc.company,
 					item_code: data.item_code,
-					ignore_empty_stock: data.ignore_empty_stock
+					ignore_empty_stock: data.ignore_empty_stock,
+					item_group: data.item_group
 				},
 				callback: function(r) {
 					if (r.exc || !r.message || !r.message.length) return;


### PR DESCRIPTION
A filter was added for the Item Group, it is very common for inventory reconciliation to be performed by item group session within the company... so this change will make it much easier.

https://prnt.sc/Mo2tr7ULfGQW