### PR TITLE
fix: always update item_name for stock entry

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -298,19 +298,17 @@ class StockEntry(StockController):
 				for_update=True,
 			)
 
-			for f in (
-				"uom",
-				"stock_uom",
-				"description",
-				"item_name",
-				"expense_account",
-				"cost_center",
-				"conversion_factor",
-			):
-				if f == "stock_uom" or not item.get(f):
-					item.set(f, item_details.get(f))
-				if f == "conversion_factor" and item.uom == item_details.get("stock_uom"):
-					item.set(f, item_details.get(f))
+			reset_fields = ("stock_uom", "item_name")
+			for field in reset_fields:
+				item.set(field, item_details.get(field))
+
+			update_fields = ("uom", "description", "expense_account", "cost_center", "conversion_factor")
+
+			for field in update_fields:
+				if not item.get(field):
+					item.set(field, item_details.get(field))
+				if field == "conversion_factor" and item.uom == item_details.get("stock_uom"):
+					item.set(field, item_details.get(field))
 
 			if not item.transfer_qty and item.qty:
 				item.transfer_qty = flt(

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -2,8 +2,6 @@
 # License: GNU General Public License v3. See license.txt
 
 
-import unittest
-
 import frappe
 from frappe.permissions import add_user_permission, remove_user_permission
 from frappe.tests.utils import FrappeTestCase, change_settings
@@ -12,6 +10,7 @@ from frappe.utils import flt, nowdate, nowtime
 from erpnext.accounts.doctype.account.test_account import get_inventory_account
 from erpnext.stock.doctype.item.test_item import (
 	create_item,
+	make_item,
 	make_item_variant,
 	set_item_variant_settings,
 )
@@ -1442,6 +1441,21 @@ class TestStockEntry(FrappeTestCase):
 		self.assertEqual(mapped_se.items[0].actual_qty, 2)
 		self.assertEqual(mapped_se.items[0].basic_rate, 100)
 		self.assertEqual(mapped_se.items[0].basic_amount, 200)
+
+	def test_stock_entry_item_details(self):
+		item = make_item()
+
+		se = make_stock_entry(
+			item_code=item.name, qty=1, to_warehouse="_Test Warehouse - _TC", do_not_submit=True
+		)
+
+		self.assertEqual(se.items[0].item_name, item.item_name)
+		se.items[0].item_name = "wat"
+		se.items[0].stock_uom = "Kg"
+		se.save()
+
+		self.assertEqual(se.items[0].item_name, item.item_name)
+		self.assertEqual(se.items[0].stock_uom, item.stock_uom)
 
 
 def make_serialized_item(**args):


### PR DESCRIPTION
If item_name is already set and for some reason becomes outdated then
it's not updated in backend.

Fix: always set item_name and stock_uom when fetching item details

