### PR TITLE
fix: remove "scrap %" field

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.js
+++ b/erpnext/manufacturing/doctype/bom/bom.js
@@ -499,15 +499,11 @@ cur_frm.cscript.qty = function(doc) {
 
 cur_frm.cscript.rate = function(doc, cdt, cdn) {
 	var d = locals[cdt][cdn];
-	var scrap_items = false;
-
-	if(cdt == 'BOM Scrap Item') {
-		scrap_items = true;
-	}
+	const is_scrap_item = cdt == "BOM Scrap Item";
 
 	if (d.bom_no) {
 		frappe.msgprint(__("You cannot change the rate if BOM is mentioned against any Item."));
-		get_bom_material_detail(doc, cdt, cdn, scrap_items);
+		get_bom_material_detail(doc, cdt, cdn, is_scrap_item);
 	} else {
 		erpnext.bom.calculate_rm_cost(doc);
 		erpnext.bom.calculate_scrap_materials_cost(doc);

--- a/erpnext/manufacturing/doctype/bom_item/bom_item.json
+++ b/erpnext/manufacturing/doctype/bom_item/bom_item.json
@@ -33,7 +33,6 @@
   "amount",
   "base_amount",
   "section_break_18",
-  "scrap",
   "qty_consumed_per_unit",
   "section_break_27",
   "has_variants",
@@ -224,15 +223,6 @@
    "fieldtype": "Section Break"
   },
   {
-   "columns": 1,
-   "fieldname": "scrap",
-   "fieldtype": "Float",
-   "label": "Scrap %",
-   "oldfieldname": "scrap",
-   "oldfieldtype": "Currency",
-   "print_hide": 1
-  },
-  {
    "fieldname": "qty_consumed_per_unit",
    "fieldtype": "Float",
    "hidden": 1,
@@ -298,7 +288,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2022-01-24 16:57:57.020232",
+ "modified": "2022-05-19 02:32:43.785470",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "BOM Item",

--- a/erpnext/manufacturing/report/bom_explorer/bom_explorer.py
+++ b/erpnext/manufacturing/report/bom_explorer/bom_explorer.py
@@ -21,7 +21,7 @@ def get_exploded_items(bom, data, indent=0, qty=1):
 	exploded_items = frappe.get_all(
 		"BOM Item",
 		filters={"parent": bom},
-		fields=["qty", "bom_no", "qty", "scrap", "item_code", "item_name", "description", "uom"],
+		fields=["qty", "bom_no", "qty", "item_code", "item_name", "description", "uom"],
 	)
 
 	for item in exploded_items:
@@ -37,7 +37,6 @@ def get_exploded_items(bom, data, indent=0, qty=1):
 				"qty": item.qty * qty,
 				"uom": item.uom,
 				"description": item.description,
-				"scrap": item.scrap,
 			}
 		)
 		if item.bom_no:
@@ -64,5 +63,4 @@ def get_columns():
 			"fieldname": "description",
 			"width": 150,
 		},
-		{"label": _("Scrap"), "fieldtype": "data", "fieldname": "scrap", "width": 100},
 	]


### PR DESCRIPTION
This field does nothing, there's a scrap items table below that's actually used for specifying scrap.

<img width="924" alt="Screenshot 2022-05-19 at 12 04 41 PM" src="https://user-images.githubusercontent.com/9079960/169226018-8c342948-f0b5-4a00-af2b-6042d0c90884.png">
