### PR TITLE
feat: make Customer/Supplier Group and Territory optional

### DIFF
--- a/erpnext/buying/doctype/supplier/supplier.json
+++ b/erpnext/buying/doctype/supplier/supplier.json
@@ -157,6 +157,7 @@
    "width": "50%"
   },
   {
+   "allow_in_quick_entry": 1,
    "fieldname": "supplier_group",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -164,8 +165,7 @@
    "label": "Supplier Group",
    "oldfieldname": "supplier_type",
    "oldfieldtype": "Link",
-   "options": "Supplier Group",
-   "reqd": 1
+   "options": "Supplier Group"
   },
   {
    "default": "Company",
@@ -432,7 +432,7 @@
    "link_fieldname": "party"
   }
  ],
- "modified": "2022-04-16 18:02:27.838623",
+ "modified": "2022-05-19 18:59:18.503456",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Supplier",

--- a/erpnext/selling/doctype/customer/customer.json
+++ b/erpnext/selling/doctype/customer/customer.json
@@ -172,6 +172,7 @@
    "search_index": 1
   },
   {
+   "allow_in_quick_entry": 1,
    "fieldname": "territory",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -180,8 +181,7 @@
    "oldfieldname": "territory",
    "oldfieldtype": "Link",
    "options": "Territory",
-   "print_hide": 1,
-   "reqd": 1
+   "print_hide": 1
   },
   {
    "fieldname": "tax_id",
@@ -511,7 +511,7 @@
    "link_fieldname": "party"
   }
  ],
- "modified": "2022-05-19 18:55:07.137251",
+ "modified": "2022-05-19 18:56:42.488627",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Customer",

--- a/erpnext/selling/doctype/customer/customer.json
+++ b/erpnext/selling/doctype/customer/customer.json
@@ -160,6 +160,7 @@
    "options": "User"
   },
   {
+   "allow_in_quick_entry": 1,
    "fieldname": "customer_group",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -168,7 +169,6 @@
    "oldfieldname": "customer_group",
    "oldfieldtype": "Link",
    "options": "Customer Group",
-   "reqd": 1,
    "search_index": 1
   },
   {
@@ -511,7 +511,7 @@
    "link_fieldname": "party"
   }
  ],
- "modified": "2022-04-16 20:32:34.000304",
+ "modified": "2022-05-19 18:55:07.137251",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Customer",


### PR DESCRIPTION
_Customer/Supplier Group_ and _Territory_ is not useful for SMBs who operate locally. They always have to fill dummy values or set dummy defaults.

For me, a mandatory field implies that the value is strictly necessary for some piece of code to work properly. Is this the case here? If not, these should be optional and can be made mandatory by the user, if needed.

> no-docs