### PR TITLE
fix: Loan repayment entries for payroll payable account

### DIFF
--- a/erpnext/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/erpnext/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -447,8 +447,6 @@ class LoanRepayment(AccountsController):
 					"remarks": remarks,
 					"cost_center": self.cost_center,
 					"posting_date": getdate(self.posting_date),
-					"party_type": self.applicant_type if self.repay_from_salary else "",
-					"party": self.applicant if self.repay_from_salary else "",
 				}
 			)
 		)

--- a/erpnext/payroll/doctype/payroll_entry/payroll_entry.py
+++ b/erpnext/payroll/doctype/payroll_entry/payroll_entry.py
@@ -16,6 +16,7 @@ from frappe.utils import (
 	comma_and,
 	date_diff,
 	flt,
+	get_link_to_form,
 	getdate,
 )
 
@@ -45,6 +46,7 @@ class PayrollEntry(Document):
 
 	def before_submit(self):
 		self.validate_employee_details()
+		self.validate_payroll_payable_account()
 		if self.validate_attendance:
 			if self.validate_employee_attendance():
 				frappe.throw(_("Cannot Submit, Employees left to mark attendance"))
@@ -65,6 +67,14 @@ class PayrollEntry(Document):
 
 		if len(emp_with_sal_slip):
 			frappe.throw(_("Salary Slip already exists for {0}").format(comma_and(emp_with_sal_slip)))
+
+	def validate_payroll_payable_account(self):
+		if frappe.db.get_value("Account", self.payroll_payable_account, "account_type"):
+			frappe.throw(
+				_(
+					"Account type cannot be set for payroll payable account {0}, please remove and try again"
+				).format(frappe.bold(get_link_to_form("Account", self.payroll_payable_account)))
+			)
 
 	def on_cancel(self):
 		frappe.delete_doc(


### PR DESCRIPTION
The user was not getting a proper loan balance against an employee for a loan because no employee was added against the payroll payable account while processing Salary Slip. This is done so that no other employee for eg, an Accountant can directly link the final payable amount to a particular employee.

<img width="613" alt="image" src="https://user-images.githubusercontent.com/42651287/169442002-87c7c527-5f54-4970-9524-a9cfdf76dfc7.png">

So removed the party type from loan repayment entries and added validation for account type in Payroll Entry.

<img width="1364" alt="image" src="https://user-images.githubusercontent.com/42651287/169443071-0c767481-32db-4e4e-aaeb-53614a79829f.png">