### PR TITLE
fix: change project's actual_start_date fieldtype from Data to Date

### DIFF
--- a/erpnext/projects/doctype/project/project.json
+++ b/erpnext/projects/doctype/project/project.json
@@ -458,7 +458,7 @@
  "index_web_pages_for_search": 1,
  "links": [],
  "max_attachments": 4,
- "modified": "2022-01-29 13:58:27.712714",
+ "modified": "2022-05-25 22:45:06.108499",
  "modified_by": "Administrator",
  "module": "Projects",
  "name": "Project",

--- a/erpnext/projects/doctype/project/project.json
+++ b/erpnext/projects/doctype/project/project.json
@@ -234,7 +234,7 @@
   },
   {
    "fieldname": "actual_start_date",
-   "fieldtype": "Data",
+   "fieldtype": "Date",
    "label": "Actual Start Date (via Time Sheet)",
    "read_only": 1
   },


### PR DESCRIPTION
I have noticed that project's “actual_start_date” is not shown with the same format that other start/end dates in some reports. See image below.

![project_report](https://user-images.githubusercontent.com/93864988/169659387-bcbf5777-a173-4a19-9ff2-3f4b6d3da7a4.png)

This is because the field actual_start_date is defined as "Data" instead of "Date" in the doctype. I have looked through the code and the fields actual_start_date and actual_end_date are managed in the same way, but actual_end_date is defined as "Date" while actual_start_date is defined as "Data". I think this could be a typo.