### PR TITLE
fix(rfq): Use `<a>` directly and style it as button instead of using `<button>`

### DIFF
--- a/erpnext/templates/emails/request_for_quotation.html
+++ b/erpnext/templates/emails/request_for_quotation.html
@@ -1,24 +1,29 @@
 <h4>{{_("Request for Quotation")}}</h4>
 <p>{{ supplier_salutation if supplier_salutation else ''}} {{ supplier_name }},</p>
 <p>{{ message }}</p>
-
 <p>{{_("The Request for Quotation can be accessed by clicking on the following button")}}:</p>
-<p>
-	<button style="border: 1px solid #15c; padding: 6px; border-radius: 5px; background-color: white;">
-		<a href="{{ rfq_link }}" style="color: #15c; text-decoration:none;" target="_blank">Submit your Quotation</a>
-	</button>
-</p><br>
-
-<p>{{_("Regards")}},<br>
-{{ user_fullname }}</p><br>
-
+<br>
+<a
+	href="{{ rfq_link }}"
+	class="btn btn-default btn-sm"
+	target="_blank">
+	{{ _("Submit your Quotation") }}
+</a>
+<br>
+<br>
 {% if update_password_link %}
-
+<br>
 <p>{{_("Please click on the following button to set your new password")}}:</p>
-<p>
-	<button style="border: 1px solid #15c; padding: 4px; border-radius: 5px; background-color: white;">
-		<a href="{{ update_password_link }}" style="color: #15c; font-size: 12px; text-decoration:none;" target="_blank">{{_("Update Password") }}</a>
-	</button>
-</p>
-
+<a
+	href="{{ update_password_link }}"
+	class="btn btn-default btn-xs"
+	target="_blank">
+	{{_("Set Password") }}
+</a>
+<br>
+<br>
 {% endif %}
+<p>
+	{{_("Regards")}},<br>
+	{{ user_fullname }}
+</p>


### PR DESCRIPTION
Use `<a>` directly and style it as a button instead of using `<button>` since few email servers (like outlook) strip out the link in the button making them unclickable.

**Issue:** Link stripped out from the "Submit Your Quotation" button. As of now, noticed this issue when the email is sent out from outlook servers.

<img width="500" alt="Screenshot 2022-05-23 at 10 14 38 AM" src="https://user-images.githubusercontent.com/13928957/169745070-d9d43e09-c07a-427b-bcc9-ca4581cb191c.png">

**Email Preview after changes**:

<img width="459" alt="Screenshot 2022-05-23 at 11 54 38 AM" src="https://user-images.githubusercontent.com/13928957/169756576-c6a6ae73-7c82-4c52-93fb-fa76a9f6ca08.png">


