### PR TITLE
test: search test failing because of stale data

### DIFF
--- a/erpnext/tests/test_search.py
+++ b/erpnext/tests/test_search.py
@@ -8,6 +8,7 @@ class TestSearch(unittest.TestCase):
 	# Search for the word "cond", part of the word "conduire" (Lead) in french.
 	def test_contact_search_in_foreign_language(self):
 		try:
+			frappe.local.lang_full_dict = None  # reset cached translations
 			frappe.local.lang = "fr"
 			output = filter_dynamic_link_doctypes(
 				"DocType", "cond", "name", 0, 20, {"fieldtype": "HTML", "fieldname": "contact_html"}


### PR DESCRIPTION
Not a bug, it was just receiving stale data which doesn't happen IRL 

ref: https://github.com/frappe/frappe/pull/16949 