### PR TITLE
fix(india): duplicate qrcode and hide button

### DIFF
--- a/erpnext/regional/india/e_invoice/einvoice.js
+++ b/erpnext/regional/india/e_invoice/einvoice.js
@@ -11,7 +11,7 @@ erpnext.setup_einvoice_actions = (doctype) => {
 
 			if (!invoice_eligible) return;
 
-			const { doctype, irn, irn_cancelled, ewaybill, eway_bill_cancelled, name, __unsaved } = frm.doc;
+			const { doctype, irn, irn_cancelled, ewaybill, eway_bill_cancelled, name, qrcode_image, __unsaved } = frm.doc;
 
 			const add_custom_button = (label, action) => {
 				if (!frm.custom_buttons[label]) {
@@ -175,7 +175,23 @@ erpnext.setup_einvoice_actions = (doctype) => {
 			}
 
 			if (irn && !irn_cancelled) {
+				let is_qrcode_attached = false;
+				if (qrcode_image && frm.attachments) {
+					let attachments = frm.attachments.get_attachments()
+					if (attachments.length != 0) {
+						for (let i = 0; i < attachments.length; i++) {
+							if (attachments[i].file_url == qrcode_image) {
+								is_qrcode_attached = true;
+								break;
+							}
+						}
+					}
+				}
+				if (!is_qrcode_attached || !qrcode_image) {
 				const action = () => {
+					if (frm.doc.__unsaved) {
+						frappe.throw(__('Please save the document to generate QRCode.'));
+					}
 					const dialog = frappe.msgprint({
 						title: __("Generate QRCode"),
 						message: __("Generate and attach QR Code using IRN?"),
@@ -195,6 +211,7 @@ erpnext.setup_einvoice_actions = (doctype) => {
 					dialog.show();
 				};
 				add_custom_button(__("Generate QRCode"), action);
+			}
 			}
 		}
 	});

--- a/erpnext/regional/india/e_invoice/einvoice.js
+++ b/erpnext/regional/india/e_invoice/einvoice.js
@@ -177,7 +177,7 @@ erpnext.setup_einvoice_actions = (doctype) => {
 			if (irn && !irn_cancelled) {
 				let is_qrcode_attached = false;
 				if (qrcode_image && frm.attachments) {
-					let attachments = frm.attachments.get_attachments()
+					let attachments = frm.attachments.get_attachments();
 					if (attachments.length != 0) {
 						for (let i = 0; i < attachments.length; i++) {
 							if (attachments[i].file_url == qrcode_image) {
@@ -189,23 +189,23 @@ erpnext.setup_einvoice_actions = (doctype) => {
 				}
 				if (!is_qrcode_attached || !qrcode_image) {
 				const action = () => {
-					if (frm.doc.__unsaved) {
-						frappe.throw(__('Please save the document to generate QRCode.'));
-					}
-					const dialog = frappe.msgprint({
-						title: __("Generate QRCode"),
-						message: __("Generate and attach QR Code using IRN?"),
-						primary_action: {
-							action: function() {
-								frappe.call({
-									method: 'erpnext.regional.india.e_invoice.utils.generate_qrcode',
-									args: { doctype, docname: name },
-									freeze: true,
-									callback: () => frm.reload_doc() || dialog.hide(),
-									error: () => dialog.hide()
-								});
-							}
-						},
+						if (frm.doc.__unsaved) {
+							frappe.throw(__('Please save the document to generate QRCode.'));
+						}
+						const dialog = frappe.msgprint({
+							title: __("Generate QRCode"),
+							message: __("Generate and attach QR Code using IRN?"),
+							primary_action: {
+								action: function() {
+									frappe.call({
+										method: 'erpnext.regional.india.e_invoice.utils.generate_qrcode',
+										args: { doctype, docname: name },
+										freeze: true,
+										callback: () => frm.reload_doc() || dialog.hide(),
+										error: () => dialog.hide()
+									});
+								}
+							},
 						primary_action_label: __('Yes')
 					});
 					dialog.show();

--- a/erpnext/regional/india/e_invoice/einvoice.js
+++ b/erpnext/regional/india/e_invoice/einvoice.js
@@ -188,7 +188,7 @@ erpnext.setup_einvoice_actions = (doctype) => {
 					}
 				}
 				if (!is_qrcode_attached || !qrcode_image) {
-				const action = () => {
+					const action = () => {
 						if (frm.doc.__unsaved) {
 							frappe.throw(__('Please save the document to generate QRCode.'));
 						}

--- a/erpnext/regional/india/e_invoice/einvoice.js
+++ b/erpnext/regional/india/e_invoice/einvoice.js
@@ -187,7 +187,7 @@ erpnext.setup_einvoice_actions = (doctype) => {
 						}
 					}
 				}
-				if (!is_qrcode_attached || !qrcode_image) {
+				if (!is_qrcode_attached) {
 					const action = () => {
 						if (frm.doc.__unsaved) {
 							frappe.throw(__('Please save the document to generate QRCode.'));

--- a/erpnext/regional/india/e_invoice/utils.py
+++ b/erpnext/regional/india/e_invoice/utils.py
@@ -1010,13 +1010,29 @@ class GSPConnector:
 		return failed
 
 	def fetch_and_attach_qrcode_from_irn(self):
-		qrcode = self.get_qrcode_from_irn(self.invoice.irn)
-		if qrcode:
-			qrcode_file = self.create_qr_code_file(qrcode)
-			frappe.db.set_value("Sales Invoice", self.invoice.name, "qrcode_image", qrcode_file.file_url)
-			frappe.msgprint(_("QR Code attached to the invoice"), alert=True)
-		else:
-			frappe.msgprint(_("QR Code not found for the IRN"), alert=True)
+		is_qrcode_file_attached = frappe.db.exists(
+			"File",
+			{
+				"attached_to_doctype": "Sales Invoice",
+				"attached_to_name": self.invoice.name,
+				"file_url": self.invoice.qrcode_image,
+				"attached_to_field": "qrcode_image",
+			},
+		)
+		if not is_qrcode_file_attached:
+			if self.invoice.signed_qr_code:
+				self.attach_qrcode_image(update_url=True)
+				frappe.msgprint(_("QR Code attached to the invoice."), alert=True)
+			else:
+				qrcode = self.get_qrcode_from_irn(self.invoice.irn)
+				if qrcode:
+					qrcode_file = self.create_qr_code_file(qrcode)
+					frappe.db.set_value("Sales Invoice", self.invoice.name, "qrcode_image", qrcode_file.file_url)
+					frappe.msgprint(_("QR Code attached to the invoice."), alert=True)
+				else:
+					frappe.msgprint(_("QR Code not found for the IRN"), alert=True)
+		elif is_qrcode_file_attached and self.invoice.qrcode_image:
+			frappe.msgprint(_("QR Code is already Attached"), indicator="green", alert=True)
 
 	def get_qrcode_from_irn(self, irn):
 		import requests
@@ -1279,7 +1295,7 @@ class GSPConnector:
 		}
 		self.update_invoice()
 
-	def attach_qrcode_image(self):
+	def attach_qrcode_image(self, update_url=False):
 		qrcode = self.invoice.signed_qr_code
 
 		qr_image = io.BytesIO()
@@ -1287,6 +1303,8 @@ class GSPConnector:
 		url.png(qr_image, scale=2, quiet_zone=1)
 		qrcode_file = self.create_qr_code_file(qr_image.getvalue())
 		self.invoice.qrcode_image = qrcode_file.file_url
+		if update_url:
+			frappe.db.set_value("Sales Invoice", self.invoice.name, "qrcode_image", qrcode_file.file_url)
 
 	def create_qr_code_file(self, qr_image):
 		doctype = self.invoice.doctype

--- a/erpnext/regional/india/e_invoice/utils.py
+++ b/erpnext/regional/india/e_invoice/utils.py
@@ -1010,7 +1010,7 @@ class GSPConnector:
 		return failed
 
 	def fetch_and_attach_qrcode_from_irn(self):
-		is_qrcode_file_attached = frappe.db.exists(
+		is_qrcode_file_attached = self.invoice.qrcode_image and frappe.db.exists(
 			"File",
 			{
 				"attached_to_doctype": "Sales Invoice",
@@ -1021,7 +1021,8 @@ class GSPConnector:
 		)
 		if not is_qrcode_file_attached:
 			if self.invoice.signed_qr_code:
-				self.attach_qrcode_image(update_url=True)
+				self.attach_qrcode_image()
+				frappe.db.set_value("Sales Invoice", self.invoice.name, "qrcode_image", self.invoice.qrcode_image)
 				frappe.msgprint(_("QR Code attached to the invoice."), alert=True)
 			else:
 				qrcode = self.get_qrcode_from_irn(self.invoice.irn)
@@ -1031,7 +1032,7 @@ class GSPConnector:
 					frappe.msgprint(_("QR Code attached to the invoice."), alert=True)
 				else:
 					frappe.msgprint(_("QR Code not found for the IRN"), alert=True)
-		elif is_qrcode_file_attached and self.invoice.qrcode_image:
+		else:
 			frappe.msgprint(_("QR Code is already Attached"), indicator="green", alert=True)
 
 	def get_qrcode_from_irn(self, irn):

--- a/erpnext/regional/india/e_invoice/utils.py
+++ b/erpnext/regional/india/e_invoice/utils.py
@@ -1022,7 +1022,9 @@ class GSPConnector:
 		if not is_qrcode_file_attached:
 			if self.invoice.signed_qr_code:
 				self.attach_qrcode_image()
-				frappe.db.set_value("Sales Invoice", self.invoice.name, "qrcode_image", self.invoice.qrcode_image)
+				frappe.db.set_value(
+					"Sales Invoice", self.invoice.name, "qrcode_image", self.invoice.qrcode_image
+				)
 				frappe.msgprint(_("QR Code attached to the invoice."), alert=True)
 			else:
 				qrcode = self.get_qrcode_from_irn(self.invoice.irn)
@@ -1296,16 +1298,13 @@ class GSPConnector:
 		}
 		self.update_invoice()
 
-	def attach_qrcode_image(self, update_url=False):
+	def attach_qrcode_image(self):
 		qrcode = self.invoice.signed_qr_code
-
 		qr_image = io.BytesIO()
 		url = qrcreate(qrcode, error="L")
 		url.png(qr_image, scale=2, quiet_zone=1)
 		qrcode_file = self.create_qr_code_file(qr_image.getvalue())
 		self.invoice.qrcode_image = qrcode_file.file_url
-		if update_url:
-			frappe.db.set_value("Sales Invoice", self.invoice.name, "qrcode_image", qrcode_file.file_url)
 
 	def create_qr_code_file(self, qr_image):
 		doctype = self.invoice.doctype


### PR DESCRIPTION
Problem: allows qrcode generation even if it exists and makes API call even though data will most likely be available in signed_qr_code field.

Solution: I have added logic on the server & client side to prevent the duplicate generation of qrcode and use signed_qr_code if available this will allow generating qrcode even after 2 days. if all fails it will get qrcode using api.

Note: I have added __unsaved check on the client side this is for future proofing.

> currently, there is no way to change anything in the invoice once you generate IRN however this is not the correct approach as there are many fields that have nothing to do with Invoice details that we send to the IRP ( government ) and we should be able to change fields that don't affect data we sent to the IRP. I am working on it and will send separate PR or this.