### PR TITLE
chore: error logging for auto material requests

### DIFF
--- a/erpnext/stock/reorder_item.py
+++ b/erpnext/stock/reorder_item.py
@@ -252,11 +252,14 @@ def notify_errors(exceptions_list):
 	)
 
 	for exception in exceptions_list:
-		exception = json.loads(exception)
-		error_message = """<div class='small text-muted'>{0}</div><br>""".format(
-			_(exception.get("message"))
-		)
-		content += error_message
+		try:
+			exception = json.loads(exception)
+			error_message = """<div class='small text-muted'>{0}</div><br>""".format(
+				_(exception.get("message"))
+			)
+			content += error_message
+		except Exception:
+			pass
 
 	content += _("Regards,") + "<br>" + _("Administrator")
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "apps/frappe/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py", line 85, in execute
    frappe.get_attr(self.method)()
  File "apps/erpnext/erpnext/stock/reorder_item.py", line 22, in reorder_item
    return _reorder_item()
  File "apps/erpnext/erpnext/stock/reorder_item.py", line 99, in _reorder_item
    return create_material_request(material_requests)
  File "apps/erpnext/erpnext/stock/reorder_item.py", line 222, in create_material_request
    notify_errors(exceptions_list)
  File "apps/erpnext/erpnext/stock/reorder_item.py", line 256, in notify_errors
    exception = json.loads(exception)
  File "/usr/lib/python3.7/json/__init__.py", line 348, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.7/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.7/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

If traceback is not found for some error then error reporting fails. 