### PR TITLE
fix: minor Non Profit fixes

### DIFF
--- a/erpnext/non_profit/doctype/donation/donation.py
+++ b/erpnext/non_profit/doctype/donation/donation.py
@@ -100,7 +100,9 @@ def capture_razorpay_donations(*args, **kwargs):
 			return
 
 		# to avoid capturing subscription payments as donations
-		if payment.description and "subscription" in str(payment.description).lower():
+		if payment.invoice_id or (
+			payment.description and "subscription" in str(payment.description).lower()
+		):
 			return
 
 		donor = get_donor(payment.email)

--- a/erpnext/non_profit/doctype/membership/membership.py
+++ b/erpnext/non_profit/doctype/membership/membership.py
@@ -61,10 +61,6 @@ class Membership(Document):
 				frappe.throw(_("You can only renew if your membership expires within 30 days"))
 
 			self.from_date = add_days(last_membership.to_date, 1)
-		elif frappe.session.user == "Administrator":
-			self.from_date = self.from_date
-		else:
-			self.from_date = nowdate()
 
 		if frappe.db.get_single_value("Non Profit Settings", "billing_cycle") == "Yearly":
 			self.to_date = add_years(self.from_date, 1)


### PR DESCRIPTION
- If a non-administrator creates a Membership, it resets the **From Date** to the current date, not letting the user create backdated memberships. Remove this default.
- If donations and subscriptions are set up in the same dashboard, membership payments also trigger a payment webhook. In order to differentiate, there is already a check for RP's auto-generated description but if subscriptions are configured using subscription links, RP doesn't send descriptions. Use `invoice_id` to ignore such payments instead.