### PR TITLE
fix: don't fetch item_code if already exists.

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -199,7 +199,7 @@ def process_args(args):
 	if not args.get("price_list"):
 		args.price_list = args.get("selling_price_list") or args.get("buying_price_list")
 
-	if args.barcode:
+	if not args.item_code and args.barcode:
 		args.item_code = get_item_code(barcode=args.barcode)
 	elif not args.item_code and args.serial_no:
 		args.item_code = get_item_code(serial_no=args.serial_no)


### PR DESCRIPTION
The problem is if you're processing a return where an old barcode no longer exists in the item master. You'll get an error Barcode for item X not found. 


The solution, if the item_code already exists, no need to fetch it.