### PR TITLE
feat: packing slip barcode scanning

### DIFF
--- a/erpnext/stock/doctype/packing_slip/packing_slip.js
+++ b/erpnext/stock/doctype/packing_slip/packing_slip.js
@@ -11,7 +11,7 @@ frappe.ui.form.on("Packing Slip", {
 	refresh(frm) {
 		frm.toggle_display("misc_details", frm.doc.amended_from);
 
-		if (frm.doc.delivery_note && frm.doc.status === 0) {
+		if (frm.doc.delivery_note && frm.doc.docstatus === 0) {
 			frm.add_custom_button(__("Get Items"), () => get_items(frm));
 		}
 	},

--- a/erpnext/stock/doctype/packing_slip/packing_slip.js
+++ b/erpnext/stock/doctype/packing_slip/packing_slip.js
@@ -72,8 +72,7 @@ frappe.ui.form.on("Packing Slip", {
 		barcode_scanner.process_scan().then(scanned_row => {
 			frm.call({
 				doc: frm.doc,
-				method: "validate_scanned_item",
-				args: {scanned_row}
+				method: "validate_scanned_item"
 			}).catch(({ responseJSON }) => {
 				after_scan(scanned_row, responseJSON.exc_type);
 			});

--- a/erpnext/stock/doctype/packing_slip/packing_slip.js
+++ b/erpnext/stock/doctype/packing_slip/packing_slip.js
@@ -10,6 +10,10 @@ frappe.ui.form.on("Packing Slip", {
 
 	refresh(frm) {
 		frm.toggle_display("misc_details", frm.doc.amended_from);
+
+		if (frm.doc.delivery_note && frm.doc.__islocal) {
+			frm.add_custom_button(__("Get Items"), () => get_items(frm));
+		}
 	},
 
 	validate(frm) {
@@ -20,6 +24,10 @@ frappe.ui.form.on("Packing Slip", {
 	scan_barcode(frm) {
 		const barcode_scanner = new erpnext.utils.BarcodeScanner({frm});
 		barcode_scanner.process_scan();
+	},
+
+	delivery_note(frm) {
+		frm.trigger("refresh");
 	}
 });
 

--- a/erpnext/stock/doctype/packing_slip/packing_slip.js
+++ b/erpnext/stock/doctype/packing_slip/packing_slip.js
@@ -58,10 +58,14 @@ frappe.ui.form.on("Packing Slip", {
 			}
 			else if (exc_type === "InvalidPackedQty") {
 				// Reset the qty to the value before the row was scanned.
+				// If the row didn't exist, set the qty to zero.
 				const row = backup.find(row => row.name === scanned_row.name);
+				row.item_code = row.item_code ?? scanned_row.item_code;
+				row.qty = row.qty ?? 0;
+
 				frappe.model.set_value(row.doctype, row.name, "qty", row.qty, "Float");
 				frappe.msgprint(__("Item {0} packed quantity has been reverted to {1}",
-					[scanned_row.item_code, scanned_row.qty]));
+					[row.item_code, row.qty]));
 			}
 		}
 

--- a/erpnext/stock/doctype/packing_slip/packing_slip.js
+++ b/erpnext/stock/doctype/packing_slip/packing_slip.js
@@ -11,7 +11,7 @@ frappe.ui.form.on("Packing Slip", {
 	refresh(frm) {
 		frm.toggle_display("misc_details", frm.doc.amended_from);
 
-		if (frm.doc.delivery_note && frm.doc.__islocal) {
+		if (frm.doc.delivery_note && frm.doc.status === 0) {
 			frm.add_custom_button(__("Get Items"), () => get_items(frm));
 		}
 	},

--- a/erpnext/stock/doctype/packing_slip/packing_slip.js
+++ b/erpnext/stock/doctype/packing_slip/packing_slip.js
@@ -78,6 +78,13 @@ frappe.ui.form.on("Packing Slip", {
 
 	delivery_note(frm) {
 		frm.trigger("refresh");
+	},
+
+	from_case_no(frm) {
+		const {doctype, name, from_case_no, to_case_no} = frm.doc;
+		if (!to_case_no || to_case_no < from_case_no) {
+			frappe.model.set_value(doctype, name, "to_case_no", from_case_no, "Int");
+		}
 	}
 });
 

--- a/erpnext/stock/doctype/packing_slip/packing_slip.js
+++ b/erpnext/stock/doctype/packing_slip/packing_slip.js
@@ -31,6 +31,12 @@ frappe.ui.form.on("Packing Slip", {
 	}
 });
 
+frappe.ui.form.on("Packing Slip Item", {
+	items_add(frm) {
+		validate_item_codes(frm);
+	}
+});
+
 cur_frm.fields_dict['delivery_note'].get_query = function(doc, cdt, cdn) {
 	return{
 		filters:{ 'docstatus': 0}
@@ -55,6 +61,19 @@ function get_items(frm) {
 		method: "get_items",
 		callback: function(r) {
 			if(!r.exc) frm.refresh();
+		}
+	});
+}
+
+function validate_item_codes(frm) {
+	return frm.call({
+		doc: frm.doc,
+		method: "validate_item_codes",
+		error(r) {
+			if (r.exc_type && r.exc_type === "InvalidPackingSlipItem") {
+				// remove the last grid row.
+				frm.get_field("items").grid.grid_rows.at(-1).remove();
+			}
 		}
 	});
 }

--- a/erpnext/stock/doctype/packing_slip/packing_slip.js
+++ b/erpnext/stock/doctype/packing_slip/packing_slip.js
@@ -32,8 +32,6 @@ frappe.ui.form.on("Packing Slip", {
 		// this as a fallback to reference.
 		const backup = frm.doc.items.map(item => ({...item}));
 
-		frappe.msgprint
-
 		function after_scan(scanned_row, event) {
 			if (event === "remove") {
 				frm.get_field("items").grid.grid_rows[scanned_row.idx - 1].remove();

--- a/erpnext/stock/doctype/packing_slip/packing_slip.js
+++ b/erpnext/stock/doctype/packing_slip/packing_slip.js
@@ -1,6 +1,13 @@
 // Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 // License: GNU General Public License v3. See license.txt
 
+frappe.ui.form.on("Packing Slip", {
+	scan_barcode(frm) {
+		const barcode_scanner = new erpnext.utils.BarcodeScanner({frm});
+		barcode_scanner.process_scan();
+	}
+});
+
 cur_frm.fields_dict['delivery_note'].get_query = function(doc, cdt, cdn) {
 	return{
 		filters:{ 'docstatus': 0}

--- a/erpnext/stock/doctype/packing_slip/packing_slip.js
+++ b/erpnext/stock/doctype/packing_slip/packing_slip.js
@@ -22,7 +22,10 @@ frappe.ui.form.on("Packing Slip", {
 	},
 
 	scan_barcode(frm) {
-		const barcode_scanner = new erpnext.utils.BarcodeScanner({frm});
+		const barcode_scanner = new erpnext.utils.BarcodeScanner({
+			frm,
+			prompt_qty: frm.doc.prompt_qty
+		});
 		barcode_scanner.process_scan();
 	},
 

--- a/erpnext/stock/doctype/packing_slip/packing_slip.js
+++ b/erpnext/stock/doctype/packing_slip/packing_slip.js
@@ -5,8 +5,8 @@ frappe.ui.form.on("Packing Slip", {
 	onload(frm) {
 		frm.set_query("delivery_note", () => {
 			return {
-				filters: { 'docstatus': 0}
-			}
+				filters: { 'docstatus': 0 }
+			};
 		});
 
 		frm.set_query("item_code", "items", () => {
@@ -16,13 +16,13 @@ frappe.ui.form.on("Packing Slip", {
 
 			return {
 				query: "erpnext.stock.doctype.packing_slip.packing_slip.item_details",
-				filters:{ 'delivery_note': frm.doc.delivery_note}
-			}
+				filters: { 'delivery_note': frm.doc.delivery_note }
+			};
 		});
 	},
 
 	onload_post_render(frm) {
-		if(frm.doc.delivery_note && frm.doc.__islocal) {
+		if (frm.doc.delivery_note && frm.doc.__islocal) {
 			get_items(frm);
 		}
 	},
@@ -55,8 +55,7 @@ frappe.ui.form.on("Packing Slip", {
 			if (exc_type === "InvalidPackingSlipItem") {
 				frm.get_field("items").grid.grid_rows[scanned_row.idx - 1].remove();
 				frappe.msgprint(__("Item {0} has automatically been removed from this packing slip.", [scanned_row.item_code]));
-			}
-			else if (exc_type === "InvalidPackedQty") {
+			} else if (exc_type === "InvalidPackedQty") {
 				// Reset the qty to the value before the row was scanned.
 				// If the row didn't exist, set the qty to zero.
 				const row = backup.find(row => row.name === scanned_row.name);
@@ -96,7 +95,7 @@ function get_items(frm) {
 		doc: frm.doc,
 		method: "get_items",
 		callback: function(r) {
-			if(!r.exc) frm.refresh();
+			if (!r.exc) frm.refresh();
 		}
 	});
 }
@@ -104,13 +103,13 @@ function get_items(frm) {
 // To Case No. cannot be less than From Case No.
 function validate_case_nos(doc) {
 	doc = locals[doc.doctype][doc.name];
-	if(cint(doc.from_case_no)==0) {
+	if (cint(doc.from_case_no)==0) {
 		frappe.msgprint(__("The 'From Package No.' field must neither be empty nor it's value less than 1."));
 		frappe.validated = false;
-	} else if(!cint(doc.to_case_no)) {
+	} else if (!cint(doc.to_case_no)) {
 		doc.to_case_no = doc.from_case_no;
 		refresh_field('to_case_no');
-	} else if(cint(doc.to_case_no) < cint(doc.from_case_no)) {
+	} else if (cint(doc.to_case_no) < cint(doc.from_case_no)) {
 		frappe.msgprint(__("'To Case No.' cannot be less than 'From Case No.'"));
 		frappe.validated = false;
 	}
@@ -129,15 +128,15 @@ function validate_calculate_item_details(doc) {
 // Do not allow duplicate items i.e. items with same item_code
 // Also check for 0 qty
 function validate_duplicate_items(doc, ps_detail) {
-	for(var i=0; i<ps_detail.length; i++) {
-		for(var j=0; j<ps_detail.length; j++) {
-			if(i!=j && ps_detail[i].item_code && ps_detail[i].item_code==ps_detail[j].item_code) {
+	for (var i=0; i<ps_detail.length; i++) {
+		for (var j=0; j<ps_detail.length; j++) {
+			if (i!=j && ps_detail[i].item_code && ps_detail[i].item_code==ps_detail[j].item_code) {
 				frappe.msgprint(__("You have entered duplicate items. Please rectify and try again."));
 				frappe.validated = false;
 				return;
 			}
 		}
-		if(flt(ps_detail[i].qty)<=0) {
+		if (flt(ps_detail[i].qty)<=0) {
 			frappe.msgprint(__("Invalid quantity specified for item {0}. Quantity should be greater than 0.", [ps_detail[i].item_code]));
 			frappe.validated = false;
 		}
@@ -151,9 +150,9 @@ function calc_net_total_pkg (doc, ps_detail) {
 	doc.net_weight_uom = (ps_detail && ps_detail.length) ? ps_detail[0].weight_uom : '';
 	doc.gross_weight_uom = doc.net_weight_uom;
 
-	for(let i=0; i<ps_detail.length; i++) {
+	for (let i=0; i<ps_detail.length; i++) {
 		const item = ps_detail[i];
-		if(item.weight_uom != doc.net_weight_uom) {
+		if (item.weight_uom != doc.net_weight_uom) {
 			frappe.msgprint(__("Different UOM for items will lead to incorrect (Total) Net Weight value. Make sure that Net Weight of each item is in the same UOM."));
 			frappe.validated = false;
 		}
@@ -161,7 +160,7 @@ function calc_net_total_pkg (doc, ps_detail) {
 	}
 
 	doc.net_weight_pkg = roundNumber(net_weight_pkg, 2);
-	if(!flt(doc.gross_weight_pkg)) {
+	if (!flt(doc.gross_weight_pkg)) {
 		doc.gross_weight_pkg = doc.net_weight_pkg;
 	}
 	refresh_many(['net_weight_pkg', 'net_weight_uom', 'gross_weight_uom', 'gross_weight_pkg']);

--- a/erpnext/stock/doctype/packing_slip/packing_slip.json
+++ b/erpnext/stock/doctype/packing_slip/packing_slip.json
@@ -21,7 +21,6 @@
   "package_item_details",
   "scan_barcode",
   "column_break_13",
-  "get_items",
   "section_break_15",
   "items",
   "package_weight_details",
@@ -101,11 +100,6 @@
   {
    "fieldname": "package_item_details",
    "fieldtype": "Section Break"
-  },
-  {
-   "fieldname": "get_items",
-   "fieldtype": "Button",
-   "label": "Get Items"
   },
   {
    "fieldname": "items",
@@ -199,7 +193,7 @@
  "idx": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2022-05-14 12:06:16.124508",
+ "modified": "2022-05-14 12:13:11.169123",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Packing Slip",

--- a/erpnext/stock/doctype/packing_slip/packing_slip.json
+++ b/erpnext/stock/doctype/packing_slip/packing_slip.json
@@ -192,7 +192,7 @@
    "label": "Prompt Qty"
   },
   {
-   "depends_on": "eval:doc.delivery_note",
+   "depends_on": "eval:doc.delivery_note && doc.from_case_no && doc.to_case_no",
    "fieldname": "barcode_scanner_section",
    "fieldtype": "Section Break"
   }
@@ -201,7 +201,7 @@
  "idx": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2022-05-24 17:00:46.482577",
+ "modified": "2022-05-24 22:53:34.415039",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Packing Slip",

--- a/erpnext/stock/doctype/packing_slip/packing_slip.json
+++ b/erpnext/stock/doctype/packing_slip/packing_slip.json
@@ -18,11 +18,11 @@
   "from_case_no",
   "column_break3",
   "to_case_no",
-  "package_item_details",
+  "barcode_scanner_section",
   "scan_barcode",
   "column_break_13",
   "prompt_qty",
-  "section_break_15",
+  "package_item_details",
   "items",
   "package_weight_details",
   "net_weight_pkg",
@@ -186,21 +186,22 @@
    "fieldtype": "Column Break"
   },
   {
-   "fieldname": "section_break_15",
-   "fieldtype": "Section Break"
-  },
-  {
    "default": "0",
    "fieldname": "prompt_qty",
    "fieldtype": "Check",
    "label": "Prompt Qty"
+  },
+  {
+   "depends_on": "eval:doc.delivery_note",
+   "fieldname": "barcode_scanner_section",
+   "fieldtype": "Section Break"
   }
  ],
  "icon": "fa fa-suitcase",
  "idx": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2022-05-14 14:07:41.183290",
+ "modified": "2022-05-24 17:00:46.482577",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Packing Slip",

--- a/erpnext/stock/doctype/packing_slip/packing_slip.json
+++ b/erpnext/stock/doctype/packing_slip/packing_slip.json
@@ -1,264 +1,285 @@
 {
-   "allow_import": 1,
-   "autoname": "MAT-PAC-.YYYY.-.#####",
-   "creation": "2013-04-11 15:32:24",
-   "description": "Generate packing slips for packages to be delivered. Used to notify package number, package contents and its weight.",
-   "doctype": "DocType",
-   "document_type": "Document",
-   "engine": "InnoDB",
-   "field_order": [
-    "packing_slip_details",
-    "column_break0",
-    "delivery_note",
-    "column_break1",
-    "naming_series",
-    "section_break0",
-    "column_break2",
-    "from_case_no",
-    "column_break3",
-    "to_case_no",
-    "package_item_details",
-    "get_items",
-    "items",
-    "package_weight_details",
-    "net_weight_pkg",
-    "net_weight_uom",
-    "column_break4",
-    "gross_weight_pkg",
-    "gross_weight_uom",
-    "letter_head_details",
-    "letter_head",
-    "misc_details",
-    "amended_from"
-   ],
-   "fields": [
-    {
-     "fieldname": "packing_slip_details",
-     "fieldtype": "Section Break"
-    },
-    {
-     "fieldname": "column_break0",
-     "fieldtype": "Column Break"
-    },
-    {
-     "description": "Indicates that the package is a part of this delivery (Only Draft)",
-     "fieldname": "delivery_note",
-     "fieldtype": "Link",
-     "in_global_search": 1,
-     "in_list_view": 1,
-     "label": "Delivery Note",
-     "options": "Delivery Note",
-     "reqd": 1
-    },
-    {
-     "fieldname": "column_break1",
-     "fieldtype": "Column Break"
-    },
-    {
-     "fieldname": "naming_series",
-     "fieldtype": "Select",
-     "label": "Series",
-     "options": "MAT-PAC-.YYYY.-",
-     "print_hide": 1,
-     "reqd": 1,
-     "set_only_once": 1
-    },
-    {
-     "fieldname": "section_break0",
-     "fieldtype": "Section Break"
-    },
-    {
-     "fieldname": "column_break2",
-     "fieldtype": "Column Break"
-    },
-    {
-     "description": "Identification of the package for the delivery (for print)",
-     "fieldname": "from_case_no",
-     "fieldtype": "Int",
-     "in_list_view": 1,
-     "label": "From Package No.",
-     "no_copy": 1,
-     "reqd": 1,
-     "width": "50px"
-    },
-    {
-     "fieldname": "column_break3",
-     "fieldtype": "Column Break"
-    },
-    {
-     "description": "If more than one package of the same type (for print)",
-     "fieldname": "to_case_no",
-     "fieldtype": "Int",
-     "in_list_view": 1,
-     "label": "To Package No.",
-     "no_copy": 1,
-     "width": "50px"
-    },
-    {
-     "fieldname": "package_item_details",
-     "fieldtype": "Section Break"
-    },
-    {
-     "fieldname": "get_items",
-     "fieldtype": "Button",
-     "label": "Get Items"
-    },
-    {
-     "fieldname": "items",
-     "fieldtype": "Table",
-     "label": "Items",
-     "options": "Packing Slip Item",
-     "reqd": 1
-    },
-    {
-     "fieldname": "package_weight_details",
-     "fieldtype": "Section Break",
-     "label": "Package Weight Details"
-    },
-    {
-     "description": "The net weight of this package. (calculated automatically as sum of net weight of items)",
-     "fieldname": "net_weight_pkg",
-     "fieldtype": "Float",
-     "label": "Net Weight",
-     "no_copy": 1,
-     "read_only": 1
-    },
-    {
-     "fieldname": "net_weight_uom",
-     "fieldtype": "Link",
-     "label": "Net Weight UOM",
-     "no_copy": 1,
-     "options": "UOM",
-     "read_only": 1
-    },
-    {
-     "fieldname": "column_break4",
-     "fieldtype": "Column Break"
-    },
-    {
-     "description": "The gross weight of the package. Usually net weight + packaging material weight. (for print)",
-     "fieldname": "gross_weight_pkg",
-     "fieldtype": "Float",
-     "label": "Gross Weight",
-     "no_copy": 1
-    },
-    {
-     "fieldname": "gross_weight_uom",
-     "fieldtype": "Link",
-     "label": "Gross Weight UOM",
-     "no_copy": 1,
-     "options": "UOM"
-    },
-    {
-     "fieldname": "letter_head_details",
-     "fieldtype": "Section Break",
-     "label": "Letter Head"
-    },
-    {
-     "allow_on_submit": 1,
-     "fieldname": "letter_head",
-     "fieldtype": "Link",
-     "label": "Letter Head",
-     "options": "Letter Head",
-     "print_hide": 1
-    },
-    {
-     "fieldname": "misc_details",
-     "fieldtype": "Section Break"
-    },
-    {
-     "fieldname": "amended_from",
-     "fieldtype": "Link",
-     "ignore_user_permissions": 1,
-     "label": "Amended From",
-     "no_copy": 1,
-     "options": "Packing Slip",
-     "print_hide": 1,
-     "read_only": 1
-    }
-   ],
-   "icon": "fa fa-suitcase",
-   "idx": 1,
-   "is_submittable": 1,
-   "modified": "2019-09-09 04:45:08.082862",
-   "modified_by": "Administrator",
-   "module": "Stock",
-   "name": "Packing Slip",
-   "owner": "Administrator",
-   "permissions": [
-    {
-     "amend": 1,
-     "cancel": 1,
-     "create": 1,
-     "delete": 1,
-     "email": 1,
-     "print": 1,
-     "read": 1,
-     "report": 1,
-     "role": "Stock User",
-     "share": 1,
-     "submit": 1,
-     "write": 1
-    },
-    {
-     "amend": 1,
-     "cancel": 1,
-     "create": 1,
-     "delete": 1,
-     "email": 1,
-     "print": 1,
-     "read": 1,
-     "report": 1,
-     "role": "Sales User",
-     "share": 1,
-     "submit": 1,
-     "write": 1
-    },
-    {
-     "amend": 1,
-     "cancel": 1,
-     "create": 1,
-     "delete": 1,
-     "email": 1,
-     "print": 1,
-     "read": 1,
-     "report": 1,
-     "role": "Item Manager",
-     "share": 1,
-     "submit": 1,
-     "write": 1
-    },
-    {
-     "amend": 1,
-     "cancel": 1,
-     "create": 1,
-     "delete": 1,
-     "email": 1,
-     "print": 1,
-     "read": 1,
-     "report": 1,
-     "role": "Stock Manager",
-     "share": 1,
-     "submit": 1,
-     "write": 1
-    },
-    {
-     "amend": 1,
-     "cancel": 1,
-     "create": 1,
-     "delete": 1,
-     "email": 1,
-     "print": 1,
-     "read": 1,
-     "report": 1,
-     "role": "Sales Manager",
-     "share": 1,
-     "submit": 1,
-     "write": 1
-    }
-   ],
-   "search_fields": "delivery_note",
-   "show_name_in_global_search": 1,
-   "sort_field": "modified",
-   "sort_order": "DESC"
+ "actions": [],
+ "allow_import": 1,
+ "autoname": "MAT-PAC-.YYYY.-.#####",
+ "creation": "2013-04-11 15:32:24",
+ "description": "Generate packing slips for packages to be delivered. Used to notify package number, package contents and its weight.",
+ "doctype": "DocType",
+ "document_type": "Document",
+ "engine": "InnoDB",
+ "field_order": [
+  "packing_slip_details",
+  "column_break0",
+  "delivery_note",
+  "column_break1",
+  "naming_series",
+  "section_break0",
+  "column_break2",
+  "from_case_no",
+  "column_break3",
+  "to_case_no",
+  "package_item_details",
+  "scan_barcode",
+  "column_break_13",
+  "get_items",
+  "section_break_15",
+  "items",
+  "package_weight_details",
+  "net_weight_pkg",
+  "net_weight_uom",
+  "column_break4",
+  "gross_weight_pkg",
+  "gross_weight_uom",
+  "letter_head_details",
+  "letter_head",
+  "misc_details",
+  "amended_from"
+ ],
+ "fields": [
+  {
+   "fieldname": "packing_slip_details",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break0",
+   "fieldtype": "Column Break"
+  },
+  {
+   "description": "Indicates that the package is a part of this delivery (Only Draft)",
+   "fieldname": "delivery_note",
+   "fieldtype": "Link",
+   "in_global_search": 1,
+   "in_list_view": 1,
+   "label": "Delivery Note",
+   "options": "Delivery Note",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break1",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "naming_series",
+   "fieldtype": "Select",
+   "label": "Series",
+   "options": "MAT-PAC-.YYYY.-",
+   "print_hide": 1,
+   "reqd": 1,
+   "set_only_once": 1
+  },
+  {
+   "fieldname": "section_break0",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "column_break2",
+   "fieldtype": "Column Break"
+  },
+  {
+   "description": "Identification of the package for the delivery (for print)",
+   "fieldname": "from_case_no",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "From Package No.",
+   "no_copy": 1,
+   "reqd": 1,
+   "width": "50px"
+  },
+  {
+   "fieldname": "column_break3",
+   "fieldtype": "Column Break"
+  },
+  {
+   "description": "If more than one package of the same type (for print)",
+   "fieldname": "to_case_no",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "To Package No.",
+   "no_copy": 1,
+   "width": "50px"
+  },
+  {
+   "fieldname": "package_item_details",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "get_items",
+   "fieldtype": "Button",
+   "label": "Get Items"
+  },
+  {
+   "fieldname": "items",
+   "fieldtype": "Table",
+   "label": "Items",
+   "options": "Packing Slip Item",
+   "reqd": 1
+  },
+  {
+   "fieldname": "package_weight_details",
+   "fieldtype": "Section Break",
+   "label": "Package Weight Details"
+  },
+  {
+   "description": "The net weight of this package. (calculated automatically as sum of net weight of items)",
+   "fieldname": "net_weight_pkg",
+   "fieldtype": "Float",
+   "label": "Net Weight",
+   "no_copy": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "net_weight_uom",
+   "fieldtype": "Link",
+   "label": "Net Weight UOM",
+   "no_copy": 1,
+   "options": "UOM",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break4",
+   "fieldtype": "Column Break"
+  },
+  {
+   "description": "The gross weight of the package. Usually net weight + packaging material weight. (for print)",
+   "fieldname": "gross_weight_pkg",
+   "fieldtype": "Float",
+   "label": "Gross Weight",
+   "no_copy": 1
+  },
+  {
+   "fieldname": "gross_weight_uom",
+   "fieldtype": "Link",
+   "label": "Gross Weight UOM",
+   "no_copy": 1,
+   "options": "UOM"
+  },
+  {
+   "fieldname": "letter_head_details",
+   "fieldtype": "Section Break",
+   "label": "Letter Head"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "letter_head",
+   "fieldtype": "Link",
+   "label": "Letter Head",
+   "options": "Letter Head",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "misc_details",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "amended_from",
+   "fieldtype": "Link",
+   "ignore_user_permissions": 1,
+   "label": "Amended From",
+   "no_copy": 1,
+   "options": "Packing Slip",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "scan_barcode",
+   "fieldtype": "Data",
+   "label": "Scan Barcode",
+   "options": "Barcode"
+  },
+  {
+   "fieldname": "column_break_13",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_15",
+   "fieldtype": "Section Break"
   }
+ ],
+ "icon": "fa fa-suitcase",
+ "idx": 1,
+ "is_submittable": 1,
+ "links": [],
+ "modified": "2022-05-14 12:06:16.124508",
+ "modified_by": "Administrator",
+ "module": "Stock",
+ "name": "Packing Slip",
+ "naming_rule": "Expression (old style)",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "amend": 1,
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Stock User",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "amend": 1,
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Sales User",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "amend": 1,
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Item Manager",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "amend": 1,
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Stock Manager",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  },
+  {
+   "amend": 1,
+   "cancel": 1,
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Sales Manager",
+   "share": 1,
+   "submit": 1,
+   "write": 1
+  }
+ ],
+ "search_fields": "delivery_note",
+ "show_name_in_global_search": 1,
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/erpnext/stock/doctype/packing_slip/packing_slip.json
+++ b/erpnext/stock/doctype/packing_slip/packing_slip.json
@@ -21,6 +21,7 @@
   "package_item_details",
   "scan_barcode",
   "column_break_13",
+  "prompt_qty",
   "section_break_15",
   "items",
   "package_weight_details",
@@ -187,13 +188,19 @@
   {
    "fieldname": "section_break_15",
    "fieldtype": "Section Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "prompt_qty",
+   "fieldtype": "Check",
+   "label": "Prompt Qty"
   }
  ],
  "icon": "fa fa-suitcase",
  "idx": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2022-05-14 12:13:11.169123",
+ "modified": "2022-05-14 14:07:41.183290",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Packing Slip",

--- a/erpnext/stock/doctype/packing_slip/packing_slip.py
+++ b/erpnext/stock/doctype/packing_slip/packing_slip.py
@@ -209,12 +209,7 @@ class PackingSlip(Document):
 		self.update_item_details()
 
 	@frappe.whitelist()
-	def validate_scanned_item(self, scanned_row):
-		# Because sometimes frappe.model doesn't update the item row qty
-		# before the validation is triggered.
-		for k, v in scanned_row.items():
-			self.items[scanned_row.get("idx") - 1].set(k, v)
-
+	def validate_scanned_item(self):
 		try:
 			self.validate_item_codes()
 			self.validate_qty()

--- a/erpnext/stock/doctype/packing_slip/packing_slip.py
+++ b/erpnext/stock/doctype/packing_slip/packing_slip.py
@@ -234,7 +234,7 @@ def item_details(doctype, txt, searchfield, start, page_len, filters):
 		"""select name, item_name, description from `tabItem`
 				where name in ( select item_code FROM `tabDelivery Note Item`
 	 						where parent= %s)
-	 			and %s like "%s" %s
+	 			and %s like %s %s
 	 			limit  %s, %s """
 		% ("%s", searchfield, "%s", get_match_cond(doctype), "%s", "%s"),
 		((filters or {}).get("delivery_note"), "%%%s%%" % txt, start, page_len),

--- a/erpnext/stock/doctype/packing_slip/test_packing_slip.py
+++ b/erpnext/stock/doctype/packing_slip/test_packing_slip.py
@@ -1,11 +1,8 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
-import unittest
-
-# test_records = frappe.get_test_records('Packing Slip')
 from frappe.tests.utils import FrappeTestCase
 
 
-class TestPackingSlip(unittest.TestCase):
+class TestPackingSlip(FrappeTestCase):
 	pass

--- a/erpnext/stock/doctype/packing_slip_item/packing_slip_item.json
+++ b/erpnext/stock/doctype/packing_slip_item/packing_slip_item.json
@@ -19,8 +19,7 @@
   "column_break_10",
   "stock_uom",
   "weight_uom",
-  "page_break",
-  "dn_detail"
+  "page_break"
  ],
  "fields": [
   {
@@ -115,19 +114,12 @@
    "fieldtype": "Check",
    "in_list_view": 1,
    "label": "Page Break"
-  },
-  {
-   "fieldname": "dn_detail",
-   "fieldtype": "Data",
-   "hidden": 1,
-   "in_list_view": 1,
-   "label": "DN Detail"
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2021-12-14 01:22:00.715935",
+ "modified": "2022-05-16 20:35:45.242278",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Packing Slip Item",
@@ -136,5 +128,6 @@
  "permissions": [],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }


### PR DESCRIPTION
## Changes to Existing Features
1. Refactored old `cscript` to `frappe.ui.form.on`
2. Moved "Get Items" button from above "items" table into the forms custom button container.

**Before**
![image](https://user-images.githubusercontent.com/29856401/170395133-9cb0d50a-b01f-4813-8f84-d45ce3c19420.png)

**After**
![image](https://user-images.githubusercontent.com/29856401/170395218-544cdf41-5eef-40ad-b4e8-b2d578aca40f.png)

## New Features
1. Barcode Scanning
The barcode scan field will only be displayed if the delivery note is selected, and packing no. is set.
This is because `delivery_note`, `from_case_no`, and `to_case_no` are all required to validated scanned row.

2. Barcode Scan Validation
![Scan Barcode - Packing Slip](https://user-images.githubusercontent.com/29856401/170396415-f03d123e-7be9-4148-9318-4229b6116d0a.jpeg)

**Note**: These validations did already exist, but only validated when packing slip is saved. This is not practical when using barcode scanner. If there is a error in the scanned item the operator needs to be notified immediately, and not when the pallet has been fully packed and operator attempts to save and submit the packing slip. 

## Showcase
1. Scanning an item that doesn't belong to the selected delivery note.
![invalid item code](https://user-images.githubusercontent.com/29856401/170397178-02e98a80-c432-4cd7-be17-3d5e6f23ee27.gif)

2. Over scan qty of a item while packing. In this example `Item B` 100 units are being delivered.
![over qty](https://user-images.githubusercontent.com/29856401/170397434-f345e927-b16f-42af-87a1-a2f101a73022.gif)

Will update docs if PR gets approved. Looking forward to hearing your thoughts.