### PR TITLE
fix: Handle missing HSN Codes

### DIFF
--- a/erpnext/regional/report/gstr_1/gstr_1.py
+++ b/erpnext/regional/report/gstr_1/gstr_1.py
@@ -449,7 +449,7 @@ class Gstr1Report(object):
 					hsn_code = self.item_hsn_map.get(item_code)
 					tax_rate = 0
 					taxable_value = items.get(item_code)
-					for rates in hsn_wise_tax_rate.get(hsn_code):
+					for rates in hsn_wise_tax_rate.get(hsn_code, []):
 						if taxable_value > rates.get("minimum_taxable_value"):
 							tax_rate = rates.get("tax_rate")
 


### PR DESCRIPTION
```bash
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 69, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 37, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 75, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1447, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/__init__.py", line 766, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "apps/frappe/frappe/desk/query_report.py", line 256, in run
    result = generate_report_result(report, filters, user, custom_columns, is_tree, parent_field)
  File "apps/frappe/frappe/__init__.py", line 766, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "apps/frappe/frappe/desk/query_report.py", line 90, in generate_report_result
    res = get_report_result(report, filters) or []
  File "apps/frappe/frappe/desk/query_report.py", line 71, in get_report_result
    res = report.execute_script_report(filters)
  File "apps/frappe/frappe/core/doctype/report/report.py", line 146, in execute_script_report
    res = self.execute_module(filters)
  File "apps/frappe/frappe/core/doctype/report/report.py", line 163, in execute_module
    return frappe.get_attr(method_name)(frappe._dict(filters))
  File "apps/erpnext/erpnext/regional/report/gstr_1/gstr_1.py", line 17, in execute
    return Gstr1Report(filters).run()
  File "apps/erpnext/erpnext/regional/report/gstr_1/gstr_1.py", line 56, in run
    self.get_items_based_on_tax_rate()
  File "apps/erpnext/erpnext/regional/report/gstr_1/gstr_1.py", line 452, in get_items_based_on_tax_rate
    for rates in hsn_wise_tax_rate.get(hsn_code):
TypeError: 'NoneType' object is not iterable
```