### PR TITLE
feat: Auto accrue loan interest for backdated term loans

### DIFF
--- a/erpnext/loan_management/doctype/loan/loan.py
+++ b/erpnext/loan_management/doctype/loan/loan.py
@@ -68,6 +68,8 @@ class Loan(AccountsController):
 
 	def on_submit(self):
 		self.link_loan_security_pledge()
+		# Interest accrual for backdated term loans
+		self.accrue_loan_interest()
 
 	def on_cancel(self):
 		self.unlink_loan_security_pledge()
@@ -186,6 +188,16 @@ class Loan(AccountsController):
 				)
 
 				self.db_set("maximum_loan_amount", maximum_loan_value)
+
+	def accrue_loan_interest(self):
+		from erpnext.loan_management.doctype.process_loan_interest_accrual.process_loan_interest_accrual import (
+			process_loan_interest_accrual_for_term_loans,
+		)
+
+		if getdate(self.repayment_start_date) < getdate() and self.is_term_loan:
+			process_loan_interest_accrual_for_term_loans(
+				posting_date=getdate(), loan_type=self.loan_type, loan=self.name
+			)
 
 	def unlink_loan_security_pledge(self):
 		pledges = frappe.get_all("Loan Security Pledge", fields=["name"], filters={"loan": self.name})


### PR DESCRIPTION
Loan Interest has to be accrued even for 0 interest loans for the loan amount to show up in Salary Slip. Loan Interest Accrual is a background job that runs at the end of the day, there are cases where users create a loan and directly try to make a salary slip but the loan amount doesn't show up since it's not accrued yet.

To resolve this confusion added a provision to auto accrue loans for such scenarios 

`no-docs`