### PR TITLE
fix: Gratuity status not updated on salary slip submission

### DIFF
--- a/erpnext/payroll/doctype/gratuity/gratuity.json
+++ b/erpnext/payroll/doctype/gratuity/gratuity.json
@@ -76,9 +76,8 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Status",
-   "options": "Draft\nUnpaid\nPaid",
-   "read_only": 1,
-   "reqd": 1
+   "options": "Draft\nUnpaid\nPaid\nSubmitted\nCancelled",
+   "read_only": 1
   },
   {
    "depends_on": "eval: !doc.pay_via_salary_slip",
@@ -194,7 +193,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2022-02-02 14:00:45.536152",
+ "modified": "2022-05-27 13:56:14.349183",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Gratuity",

--- a/erpnext/payroll/doctype/gratuity/gratuity_list.js
+++ b/erpnext/payroll/doctype/gratuity/gratuity_list.js
@@ -1,0 +1,12 @@
+frappe.listview_settings["Gratuity"] = {
+	get_indicator: function(doc) {
+		let status_color = {
+			"Draft": "red",
+			"Submitted": "blue",
+			"Cancelled": "red",
+			"Paid": "green",
+			"Unpaid": "orange",
+		};
+		return [__(doc.status), status_color[doc.status], "status,=,"+doc.status];
+	}
+};

--- a/erpnext/payroll/doctype/gratuity/test_gratuity.py
+++ b/erpnext/payroll/doctype/gratuity/test_gratuity.py
@@ -5,10 +5,11 @@ import unittest
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
-from frappe.utils import add_days, add_months, flt, get_datetime, get_first_day, getdate
+from frappe.utils import add_days, add_months, floor, flt, get_datetime, get_first_day, getdate
 
 from erpnext.hr.doctype.employee.test_employee import make_employee
 from erpnext.hr.doctype.expense_claim.test_expense_claim import get_payable_account
+from erpnext.hr.doctype.holiday_list.test_holiday_list import set_holiday_list
 from erpnext.payroll.doctype.gratuity.gratuity import get_last_salary_slip
 from erpnext.payroll.doctype.salary_slip.test_salary_slip import (
 	make_deduction_salary_component,
@@ -32,32 +33,38 @@ class TestGratuity(FrappeTestCase):
 		)
 		make_deduction_salary_component(setup=True, test_tax=True, company_list=["_Test Company"])
 
+	@set_holiday_list("Salary Slip Test Holiday List", "_Test Company")
 	def test_get_last_salary_slip_should_return_none_for_new_employee(self):
 		new_employee = make_employee("new_employee@salary.com", company="_Test Company")
 		salary_slip = get_last_salary_slip(new_employee)
-		assert salary_slip is None
+		self.assertIsNone(salary_slip)
 
-	def test_check_gratuity_amount_based_on_current_slab_and_additional_salary_creation(self):
-		employee, sal_slip = create_employee_and_get_last_salary_slip()
+	@set_holiday_list("Salary Slip Test Holiday List", "_Test Company")
+	def test_gratuity_based_on_current_slab_via_additional_salary(self):
+		"""
+		Range	|	Fraction
+		5-0		|	1
+		"""
+		doj = add_days(getdate(), -(6 * 365))
+		relieving_date = getdate()
+
+		employee = make_employee(
+			"test_employee_gratuity@salary.com",
+			company="_Test Company",
+			date_of_joining=doj,
+			relieving_date=relieving_date,
+		)
+		sal_slip = create_salary_slip("test_employee_gratuity@salary.com")
 
 		rule = get_gratuity_rule("Rule Under Unlimited Contract on termination (UAE)")
 		gratuity = create_gratuity(pay_via_salary_slip=1, employee=employee, rule=rule.name)
 
 		# work experience calculation
-		date_of_joining, relieving_date = frappe.db.get_value(
-			"Employee", employee, ["date_of_joining", "relieving_date"]
-		)
-		employee_total_workings_days = (
-			get_datetime(relieving_date) - get_datetime(date_of_joining)
-		).days
+		employee_total_workings_days = (get_datetime(relieving_date) - get_datetime(doj)).days
+		experience = floor(employee_total_workings_days / rule.total_working_days_per_year)
+		self.assertEqual(gratuity.current_work_experience, experience)
 
-		experience = employee_total_workings_days / rule.total_working_days_per_year
-		gratuity.reload()
-		from math import floor
-
-		self.assertEqual(floor(experience), gratuity.current_work_experience)
-
-		# amount Calculation
+		# amount calculation
 		component_amount = frappe.get_all(
 			"Salary Detail",
 			filters={
@@ -67,18 +74,15 @@ class TestGratuity(FrappeTestCase):
 				"salary_component": "Basic Salary",
 			},
 			fields=["amount"],
+			limit=1,
 		)
-
-		""" 5 - 0 fraction is 1 """
-
 		gratuity_amount = component_amount[0].amount * experience
-		gratuity.reload()
-
 		self.assertEqual(flt(gratuity_amount, 2), flt(gratuity.amount, 2))
 
 		# additional salary creation (Pay via salary slip)
 		self.assertTrue(frappe.db.exists("Additional Salary", {"ref_docname": gratuity.name}))
 
+		# gratuity should be marked "Paid" on the next salary slip submission
 		salary_slip = make_salary_slip("Test Gratuity", employee=employee)
 		salary_slip.posting_date = getdate()
 		salary_slip.insert()
@@ -87,8 +91,27 @@ class TestGratuity(FrappeTestCase):
 		gratuity.reload()
 		self.assertEqual(gratuity.status, "Paid")
 
-	def test_check_gratuity_amount_based_on_all_previous_slabs(self):
-		employee, sal_slip = create_employee_and_get_last_salary_slip()
+	@set_holiday_list("Salary Slip Test Holiday List", "_Test Company")
+	def test_gratuity_based_on_all_previous_slabs_via_payment_entry(self):
+		"""
+		Range	|	Fraction
+		0-1		|	0
+		1-5		|	0.7
+		5-0		|	1
+		"""
+		from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
+
+		doj = add_days(getdate(), -(6 * 365))
+		relieving_date = getdate()
+
+		employee = make_employee(
+			"test_employee_gratuity@salary.com",
+			company="_Test Company",
+			date_of_joining=doj,
+			relieving_date=relieving_date,
+		)
+
+		sal_slip = create_salary_slip("test_employee_gratuity@salary.com")
 		rule = get_gratuity_rule("Rule Under Limited Contract (UAE)")
 		set_mode_of_payment_account()
 
@@ -97,22 +120,11 @@ class TestGratuity(FrappeTestCase):
 		)
 
 		# work experience calculation
-		date_of_joining, relieving_date = frappe.db.get_value(
-			"Employee", employee, ["date_of_joining", "relieving_date"]
-		)
-		employee_total_workings_days = (
-			get_datetime(relieving_date) - get_datetime(date_of_joining)
-		).days
+		employee_total_workings_days = (get_datetime(relieving_date) - get_datetime(doj)).days
+		experience = floor(employee_total_workings_days / rule.total_working_days_per_year)
+		self.assertEqual(gratuity.current_work_experience, experience)
 
-		experience = employee_total_workings_days / rule.total_working_days_per_year
-
-		gratuity.reload()
-
-		from math import floor
-
-		self.assertEqual(floor(experience), gratuity.current_work_experience)
-
-		# amount Calculation
+		# amount calculation
 		component_amount = frappe.get_all(
 			"Salary Detail",
 			filters={
@@ -122,34 +134,21 @@ class TestGratuity(FrappeTestCase):
 				"salary_component": "Basic Salary",
 			},
 			fields=["amount"],
+			limit=1,
 		)
 
-		""" range  | Fraction
-			0-1    |    0
-			1-5    |   0.7
-			5-0    |    1
-		"""
-
 		gratuity_amount = ((0 * 1) + (4 * 0.7) + (1 * 1)) * component_amount[0].amount
-		gratuity.reload()
-
 		self.assertEqual(flt(gratuity_amount, 2), flt(gratuity.amount, 2))
 		self.assertEqual(gratuity.status, "Unpaid")
 
-		from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
+		pe = get_payment_entry("Gratuity", gratuity.name)
+		pe.reference_no = "123467"
+		pe.reference_date = getdate()
+		pe.submit()
 
-		pay_entry = get_payment_entry("Gratuity", gratuity.name)
-		pay_entry.reference_no = "123467"
-		pay_entry.reference_date = getdate()
-		pay_entry.save()
-		pay_entry.submit()
 		gratuity.reload()
-
 		self.assertEqual(gratuity.status, "Paid")
 		self.assertEqual(flt(gratuity.paid_amount, 2), flt(gratuity.amount, 2))
-
-	def tearDown(self):
-		frappe.db.rollback()
 
 
 def get_gratuity_rule(name):
@@ -160,7 +159,6 @@ def get_gratuity_rule(name):
 	rule.applicable_earnings_component = []
 	rule.append("applicable_earnings_component", {"salary_component": "Basic Salary"})
 	rule.save()
-	rule.reload()
 
 	return rule
 
@@ -215,29 +213,17 @@ def create_account():
 	).insert(ignore_permissions=True)
 
 
-def create_employee_and_get_last_salary_slip():
-	employee = make_employee("test_employee@salary.com", company="_Test Company")
-	frappe.db.set_value("Employee", employee, "relieving_date", getdate())
-	frappe.db.set_value("Employee", employee, "date_of_joining", add_days(getdate(), -(6 * 365)))
+def create_salary_slip(employee):
 	if not frappe.db.exists("Salary Slip", {"employee": employee}):
 		posting_date = get_first_day(add_months(getdate(), -1))
 		salary_slip = make_employee_salary_slip(
-			"test_employee@salary.com", "Monthly", "Test Gratuity", posting_date=posting_date
+			employee, "Monthly", "Test Gratuity", posting_date=posting_date
 		)
 		salary_slip.start_date = posting_date
 		salary_slip.end_date = None
-		salary_slip.save()
 		salary_slip.submit()
 		salary_slip = salary_slip.name
 	else:
 		salary_slip = get_last_salary_slip(employee)
 
-	if not frappe.db.get_value("Employee", "test_employee@salary.com", "holiday_list"):
-		from erpnext.payroll.doctype.salary_slip.test_salary_slip import make_holiday_list
-
-		make_holiday_list()
-		frappe.db.set_value(
-			"Company", "_Test Company", "default_holiday_list", "Salary Slip Test Holiday List"
-		)
-
-	return employee, salary_slip
+	return salary_slip

--- a/erpnext/payroll/doctype/gratuity/test_gratuity.py
+++ b/erpnext/payroll/doctype/gratuity/test_gratuity.py
@@ -15,6 +15,7 @@ from erpnext.payroll.doctype.salary_slip.test_salary_slip import (
 	make_deduction_salary_component,
 	make_earning_salary_component,
 	make_employee_salary_slip,
+	make_holiday_list,
 )
 from erpnext.payroll.doctype.salary_structure.salary_structure import make_salary_slip
 from erpnext.regional.united_arab_emirates.setup import create_gratuity_rule
@@ -32,6 +33,7 @@ class TestGratuity(FrappeTestCase):
 			setup=True, test_tax=True, company_list=["_Test Company"], include_flexi_benefits=True
 		)
 		make_deduction_salary_component(setup=True, test_tax=True, company_list=["_Test Company"])
+		make_holiday_list()
 
 	@set_holiday_list("Salary Slip Test Holiday List", "_Test Company")
 	def test_get_last_salary_slip_should_return_none_for_new_employee(self):

--- a/erpnext/payroll/doctype/gratuity/test_gratuity.py
+++ b/erpnext/payroll/doctype/gratuity/test_gratuity.py
@@ -4,7 +4,8 @@
 import unittest
 
 import frappe
-from frappe.utils import add_days, flt, get_datetime, getdate
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import add_days, add_months, flt, get_datetime, get_first_day, getdate
 
 from erpnext.hr.doctype.employee.test_employee import make_employee
 from erpnext.hr.doctype.expense_claim.test_expense_claim import get_payable_account
@@ -14,14 +15,16 @@ from erpnext.payroll.doctype.salary_slip.test_salary_slip import (
 	make_earning_salary_component,
 	make_employee_salary_slip,
 )
+from erpnext.payroll.doctype.salary_structure.salary_structure import make_salary_slip
 from erpnext.regional.united_arab_emirates.setup import create_gratuity_rule
 
 test_dependencies = ["Salary Component", "Salary Slip", "Account"]
 
 
-class TestGratuity(unittest.TestCase):
+class TestGratuity(FrappeTestCase):
 	def setUp(self):
 		frappe.db.delete("Gratuity")
+		frappe.db.delete("Salary Slip")
 		frappe.db.delete("Additional Salary", {"ref_doctype": "Gratuity"})
 
 		make_earning_salary_component(
@@ -75,6 +78,14 @@ class TestGratuity(unittest.TestCase):
 
 		# additional salary creation (Pay via salary slip)
 		self.assertTrue(frappe.db.exists("Additional Salary", {"ref_docname": gratuity.name}))
+
+		salary_slip = make_salary_slip("Test Gratuity", employee=employee)
+		salary_slip.posting_date = getdate()
+		salary_slip.insert()
+		salary_slip.submit()
+
+		gratuity.reload()
+		self.assertEqual(gratuity.status, "Paid")
 
 	def test_check_gratuity_amount_based_on_all_previous_slabs(self):
 		employee, sal_slip = create_employee_and_get_last_salary_slip()
@@ -209,7 +220,13 @@ def create_employee_and_get_last_salary_slip():
 	frappe.db.set_value("Employee", employee, "relieving_date", getdate())
 	frappe.db.set_value("Employee", employee, "date_of_joining", add_days(getdate(), -(6 * 365)))
 	if not frappe.db.exists("Salary Slip", {"employee": employee}):
-		salary_slip = make_employee_salary_slip("test_employee@salary.com", "Monthly")
+		posting_date = get_first_day(add_months(getdate(), -1))
+		salary_slip = make_employee_salary_slip(
+			"test_employee@salary.com", "Monthly", "Test Gratuity", posting_date=posting_date
+		)
+		salary_slip.start_date = posting_date
+		salary_slip.end_date = None
+		salary_slip.save()
 		salary_slip.submit()
 		salary_slip = salary_slip.name
 	else:

--- a/erpnext/payroll/doctype/salary_slip/salary_slip.py
+++ b/erpnext/payroll/doctype/salary_slip/salary_slip.py
@@ -116,10 +116,10 @@ class SalarySlip(TransactionBase):
 		self.update_payment_status_for_gratuity()
 
 	def update_payment_status_for_gratuity(self):
-		add_salary = frappe.db.get_all(
+		additional_salary = frappe.db.get_all(
 			"Additional Salary",
 			filters={
-				"payroll_date": ("BETWEEN", [self.start_date, self.end_date]),
+				"payroll_date": ("between", [self.start_date, self.end_date]),
 				"employee": self.employee,
 				"ref_doctype": "Gratuity",
 				"docstatus": 1,
@@ -128,10 +128,10 @@ class SalarySlip(TransactionBase):
 			limit=1,
 		)
 
-		if len(add_salary):
+		if additional_salary:
 			status = "Paid" if self.docstatus == 1 else "Unpaid"
-			if add_salary[0].name in [data.additional_salary for data in self.earnings]:
-				frappe.db.set_value("Gratuity", add_salary.ref_docname, "status", status)
+			if additional_salary[0].name in [entry.additional_salary for entry in self.earnings]:
+				frappe.db.set_value("Gratuity", additional_salary[0].ref_docname, "status", status)
 
 	def on_cancel(self):
 		self.set_status()

--- a/erpnext/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/erpnext/payroll/doctype/salary_slip/test_salary_slip.py
@@ -997,7 +997,7 @@ class TestSalarySlip(unittest.TestCase):
 		return [no_of_days_in_month[1], no_of_holidays_in_month]
 
 
-def make_employee_salary_slip(user, payroll_frequency, salary_structure=None):
+def make_employee_salary_slip(user, payroll_frequency, salary_structure=None, posting_date=None):
 	from erpnext.payroll.doctype.salary_structure.test_salary_structure import make_salary_structure
 
 	if not salary_structure:
@@ -1008,7 +1008,11 @@ def make_employee_salary_slip(user, payroll_frequency, salary_structure=None):
 	)
 
 	salary_structure_doc = make_salary_structure(
-		salary_structure, payroll_frequency, employee=employee.name, company=employee.company
+		salary_structure,
+		payroll_frequency,
+		employee=employee.name,
+		company=employee.company,
+		from_date=posting_date,
 	)
 	salary_slip_name = frappe.db.get_value(
 		"Salary Slip", {"employee": frappe.db.get_value("Employee", {"user_id": user})}
@@ -1018,7 +1022,7 @@ def make_employee_salary_slip(user, payroll_frequency, salary_structure=None):
 		salary_slip = make_salary_slip(salary_structure_doc.name, employee=employee.name)
 		salary_slip.employee_name = employee.employee_name
 		salary_slip.payroll_frequency = payroll_frequency
-		salary_slip.posting_date = nowdate()
+		salary_slip.posting_date = posting_date or nowdate()
 		salary_slip.insert()
 	else:
 		salary_slip = frappe.get_doc("Salary Slip", salary_slip_name)


### PR DESCRIPTION
Closes https://github.com/frappe/erpnext/issues/31134

## Steps to Replicate

1. Create a Gratuity with "Pay via Salary Slip" enabled. It will create an Additional Salary on submission
2. Create Salary Slip for gratuity's payroll date
3. Error on salary slip submission when it tries to update gratuity's payment status from Unpaid to Paid:

<img width="1440" alt="additional" src="https://user-images.githubusercontent.com/24353136/170660537-06f3b724-e6f7-4f8e-81b0-9f89c27231f4.png">

<details>
<summary>Traceback</summary>

```python
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 67, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 54, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 39, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 77, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1500, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/desk/form/save.py", line 21, in savedocs
    doc.submit()
  File "apps/frappe/frappe/model/document.py", line 999, in submit
    return self._submit()
  File "apps/frappe/frappe/model/document.py", line 978, in _submit
    return self.save()
  File "apps/frappe/frappe/model/document.py", line 288, in save
    return self._save(*args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 339, in _save
    self.run_post_save_methods()
  File "apps/frappe/frappe/model/document.py", line 1074, in run_post_save_methods
    self.run_method("on_submit")
  File "apps/frappe/frappe/model/document.py", line 912, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1251, in composer
    return composed(self, method, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1233, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "apps/frappe/frappe/model/document.py", line 909, in fn
    return method_object(*args, **kwargs)
  File "apps/erpnext/erpnext/payroll/doctype/salary_slip/salary_slip.py", line 116, in on_submit
    self.update_payment_status_for_gratuity()
  File "apps/erpnext/erpnext/payroll/doctype/salary_slip/salary_slip.py", line 134, in update_payment_status_for_gratuity
    frappe.db.set_value("Gratuity", add_salary.ref_docname, "status", status)
AttributeError: 'list' object has no attribute 'ref_docname'
```
</details>

## Fix:

- Fixed update
- Cleaned up and extended tests
- Added list view settings for Gratuity

![Kapture 2022-05-27 at 13 51 33](https://user-images.githubusercontent.com/24353136/170661086-00b8c24c-b4e0-4ff4-96c6-6426b9d28487.gif)

