### PR TITLE
fix(accounts): validate payment entry references with latest data.

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -174,10 +174,10 @@ class PaymentEntry(AccountsController):
 		for d in self.get("references").copy():
 			latest = latest_lookup.get((d.reference_doctype, d.reference_name))
 
-			# The reference has already been allocated.
-			if not latest:
+			# The reference has already been allocated, or partially allocated.
+			if not latest or d.outstanding_amount != latest.outstanding_amount:
 				frappe.throw(
-					_("{0} {1}, has already been allocated.").format(d.reference_doctype, d.reference_name)
+					_("{0} {1}, has already been allocated after the creation of Payment Entry {2}.").format(d.reference_doctype, d.reference_name, self.name)
 				)
 
 			d.outstanding_amount = latest.outstanding_amount

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -181,11 +181,7 @@ class PaymentEntry(AccountsController):
 				self.remove(d)
 				continue
 
-			d.due_date = latest.due_date
-			d.total_amount = latest.invoice_amount
 			d.outstanding_amount = latest.outstanding_amount
-			d.bill_no = latest.bill_no
-			d.payment_term = latest.payment_term
 
 			if (flt(d.allocated_amount)) > 0:
 				if flt(d.allocated_amount) > flt(d.outstanding_amount):

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -177,7 +177,9 @@ class PaymentEntry(AccountsController):
 			# The reference has already been allocated, or partially allocated.
 			if not latest or d.outstanding_amount != latest.outstanding_amount:
 				frappe.throw(
-					_("{0} {1}, has already been allocated after the creation of Payment Entry {2}.").format(d.reference_doctype, d.reference_name, self.name)
+					_("{0} {1}, has already been allocated after the creation of Payment Entry {2}.").format(
+						d.reference_doctype, d.reference_name, self.name
+					)
 				)
 
 			d.outstanding_amount = latest.outstanding_amount

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -151,9 +151,7 @@ class PaymentEntry(AccountsController):
 		if self.payment_type == "Internal Transfer":
 			return
 
-		fail_message = _(
-			"Row #{0}: Allocated Amount cannot be greater than outstanding amount. You may need to reload your payment references."
-		)
+		fail_message = _("Row #{0}: Allocated Amount cannot be greater than outstanding amount.")
 
 		latest_references = get_outstanding_reference_documents(
 			{
@@ -178,8 +176,9 @@ class PaymentEntry(AccountsController):
 
 			# The reference has already been allocated.
 			if not latest:
-				self.remove(d)
-				continue
+				frappe.throw(
+					_("{0} {1}, has already been allocated.").format(d.reference_doctype, d.reference_name)
+				)
 
 			d.outstanding_amount = latest.outstanding_amount
 

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -174,12 +174,17 @@ class PaymentEntry(AccountsController):
 		for d in self.get("references").copy():
 			latest = latest_lookup.get((d.reference_doctype, d.reference_name))
 
-			# The reference has already been allocated, or partially allocated.
-			if not latest or d.outstanding_amount != latest.outstanding_amount:
+			# The reference has already been fully paid
+			if not latest:
 				frappe.throw(
-					_("{0} {1}, has already been allocated after the creation of Payment Entry {2}.").format(
-						d.reference_doctype, d.reference_name, self.name
-					)
+					_("{0} {1} has already been fully paid.").format(d.reference_doctype, d.reference_name)
+				)
+			# The reference has already been partly paid
+			elif d.outstanding_amount != latest.outstanding_amount:
+				frappe.throw(
+					_(
+						"{0} {1} has already been partly paid. Please use the 'Get Outstanding Invoice' button to get the latest outstanding amount."
+					).format(d.reference_doctype, d.reference_name)
 				)
 
 			d.outstanding_amount = latest.outstanding_amount
@@ -404,7 +409,7 @@ class PaymentEntry(AccountsController):
 		for k, v in no_oustanding_refs.items():
 			frappe.msgprint(
 				_(
-					"{} - {} now have {} as they had no outstanding amount left before submitting the Payment Entry."
+					"{} - {} now has {} as it had no outstanding amount left before submitting the Payment Entry."
 				).format(
 					_(k),
 					frappe.bold(", ".join(d.reference_name for d in v)),

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -1483,7 +1483,7 @@ def get_orders_to_be_billed(
 	if voucher_type:
 		doc = frappe.get_doc({"doctype": voucher_type})
 		condition = ""
-		if doc and hasattr(doc, "cost_center"):
+		if doc and hasattr(doc, "cost_center") and doc.cost_center is not None:
 			condition = " and cost_center='%s'" % cost_center
 
 	orders = []
@@ -1529,9 +1529,15 @@ def get_orders_to_be_billed(
 
 	order_list = []
 	for d in orders:
-		if not (
-			flt(d.outstanding_amount) >= flt(filters.get("outstanding_amt_greater_than"))
-			and flt(d.outstanding_amount) <= flt(filters.get("outstanding_amt_less_than"))
+		if (
+			filters
+			and filters.get("outstanding_amt_greater_than")
+			and filters.get("outstanding_amt_less_than")
+			and not (
+				flt(filters.get("outstanding_amt_greater_than"))
+				<= flt(d.outstanding_amount)
+				<= flt(filters.get("outstanding_amt_less_than"))
+			)
 		):
 			continue
 

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -1487,7 +1487,7 @@ def get_orders_to_be_billed(
 	if voucher_type:
 		doc = frappe.get_doc({"doctype": voucher_type})
 		condition = ""
-		if doc and hasattr(doc, "cost_center") and doc.cost_center is not None:
+		if doc and hasattr(doc, "cost_center") and doc.cost_center:
 			condition = " and cost_center='%s'" % cost_center
 
 	orders = []

--- a/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
@@ -1027,6 +1027,18 @@ class TestPaymentEntry(FrappeTestCase):
 		si.load_from_db()
 		self.assertEqual(si.outstanding_amount, 0)
 
+	def test_duplicate_payment_entry_partial_allocate_amount(self):
+		si = create_sales_invoice()
+
+		pe_draft = get_payment_entry("Sales Invoice", si.name)
+		pe_draft.insert()
+
+		pe = get_payment_entry("Sales Invoice", si.name)
+		pe.received_amount = si.total / 2
+		pe.references[0].allocated_amount = si.total / 2
+		pe.submit()
+
+		self.assertRaises(frappe.ValidationError, pe_draft.submit)
 
 def create_payment_entry(**args):
 	payment_entry = frappe.new_doc("Payment Entry")

--- a/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
@@ -1013,6 +1013,21 @@ class TestPaymentEntry(FrappeTestCase):
 		employee = make_employee("test_payment_entry@salary.com", company="_Test Company")
 		create_payment_entry(party_type="Employee", party=employee, save=True)
 
+	def test_payment_entry_over_allocate_amount(self):
+		si = create_sales_invoice()
+
+		pe_draft = get_payment_entry("Sales Invoice", si.name)
+		pe_draft.insert()
+
+		pe = get_payment_entry("Sales Invoice", si.name)
+		pe.submit()
+
+		pe_draft.validate()
+		pe_draft.submit()
+
+		si.load_from_db()
+		self.assertEqual(si.outstanding_amount, 0)
+
 
 def create_payment_entry(**args):
 	payment_entry = frappe.new_doc("Payment Entry")

--- a/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
@@ -1024,9 +1024,6 @@ class TestPaymentEntry(FrappeTestCase):
 
 		self.assertRaises(frappe.ValidationError, pe_draft.submit)
 
-		si.load_from_db()
-		self.assertEqual(si.outstanding_amount, 0)
-
 	def test_duplicate_payment_entry_partial_allocate_amount(self):
 		si = create_sales_invoice()
 

--- a/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
@@ -1022,8 +1022,7 @@ class TestPaymentEntry(FrappeTestCase):
 		pe = get_payment_entry("Sales Invoice", si.name)
 		pe.submit()
 
-		pe_draft.validate()
-		pe_draft.submit()
+		self.assertRaises(frappe.ValidationError, pe_draft.submit)
 
 		si.load_from_db()
 		self.assertEqual(si.outstanding_amount, 0)

--- a/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
@@ -1013,7 +1013,7 @@ class TestPaymentEntry(FrappeTestCase):
 		employee = make_employee("test_payment_entry@salary.com", company="_Test Company")
 		create_payment_entry(party_type="Employee", party=employee, save=True)
 
-	def test_payment_entry_over_allocate_amount(self):
+	def test_duplicate_payment_entry_allocate_amount(self):
 		si = create_sales_invoice()
 
 		pe_draft = get_payment_entry("Sales Invoice", si.name)

--- a/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
@@ -1037,6 +1037,7 @@ class TestPaymentEntry(FrappeTestCase):
 
 		self.assertRaises(frappe.ValidationError, pe_draft.submit)
 
+
 def create_payment_entry(**args):
 	payment_entry = frappe.new_doc("Payment Entry")
 	payment_entry.company = args.get("company") or "_Test Company"


### PR DESCRIPTION
Closes: https://github.com/frappe/erpnext/issues/31138

Problem:

The system allows multiple draft payment entries to be made for a single invoice, which is fine, but when the first payment entry is submitted, the outstanding amount of the invoice in the second payment entry isn't accurate anymore. But the system still allows the user to submit the entry, resulting in negative outstanding amounts.

Solution:

During validation of allocated amount in the payment entry, update each row in references with latest information before comparing amounts. If the user tries to submit another payment entry but the corresponding invoice has already been fully paid, the system would throw an error to let the user know. If the invoice has been already partly paid, the user would be told the same and would be asked to use the 'Get Outstanding Invoice' button to get the latest outstanding amount.

Unrelated: I discovered fetching documents for advance payment via payment entry form was also broken. Fixed in https://github.com/frappe/erpnext/pull/31166/commits/1ca20b97d066d3758fe85dd0bc6b9cc65d449bb3
