### PR TITLE
chore: add Interview doctypes to HR workspace

### DIFF
--- a/erpnext/hr/workspace/hr/hr.json
+++ b/erpnext/hr/workspace/hr/hr.json
@@ -596,6 +596,46 @@
    "type": "Link"
   },
   {
+    "hidden": 0,
+    "is_query_report": 0,
+    "label": "Interview Type",
+    "link_count": 0,
+    "link_to": "Interview Type",
+    "link_type": "DocType",
+    "onboard": 0,
+    "type": "Link"
+   },
+   {
+    "hidden": 0,
+    "is_query_report": 0,
+    "label": "Interview Round",
+    "link_count": 0,
+    "link_to": "Interview Round",
+    "link_type": "DocType",
+    "onboard": 0,
+    "type": "Link"
+   },
+   {
+    "hidden": 0,
+    "is_query_report": 0,
+    "label": "Interview",
+    "link_count": 0,
+    "link_to": "Interview",
+    "link_type": "DocType",
+    "onboard": 0,
+    "type": "Link"
+   },
+   {
+    "hidden": 0,
+    "is_query_report": 0,
+    "label": "Interview Feedback",
+    "link_count": 0,
+    "link_to": "Interview Feedback",
+    "link_type": "DocType",
+    "onboard": 0,
+    "type": "Link"
+   },
+  {
    "hidden": 0,
    "is_query_report": 0,
    "label": "Loans",
@@ -841,7 +881,7 @@
    "type": "Link"
   }
  ],
- "modified": "2021-05-13 17:19:40.524444",
+ "modified": "2022-05-30 17:19:40.524444",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "HR",


### PR DESCRIPTION
Closes: https://github.com/frappe/erpnext/issues/31171

v14 workspace already has these doctypes