### PR TITLE
fix(accounts): Ignore Cancelled GL Entries

### DIFF
--- a/erpnext/accounts/report/profitability_analysis/profitability_analysis.py
+++ b/erpnext/accounts/report/profitability_analysis/profitability_analysis.py
@@ -211,6 +211,7 @@ def set_gl_entries_by_account(
 		{additional_conditions}
 		and posting_date <= %(to_date)s
 		and {based_on} is not null
+		and is_cancelled = 0
 		order by {based_on}, posting_date""".format(
 			additional_conditions="\n".join(additional_conditions), based_on=based_on
 		),


### PR DESCRIPTION
Profitability Analysis includes 'is_cancelled' GL Entries which means that the profit numbers are incorrect. This change will ensure that the profit figures ignore cancelled GL Entries.