### PR TITLE
fix: batch selector flag

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -526,12 +526,6 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 											if(!d[k]) d[k] = v;
 										});
 
-										if (d.__disable_batch_serial_selector) {
-											// reset for future use.
-											d.__disable_batch_serial_selector = false;
-											return;
-										}
-
 										if (d.has_batch_no && d.has_serial_no) {
 											d.batch_no = undefined;
 										}

--- a/erpnext/public/js/utils/barcode_scanner.js
+++ b/erpnext/public/js/utils/barcode_scanner.js
@@ -98,6 +98,7 @@ erpnext.utils.BarcodeScanner = class BarcodeScanner {
 				() => this.set_batch_no(row, batch_no),
 				() => this.set_barcode(row, barcode),
 				() => this.clean_up(),
+				() => this.revert_selector_flag(row, data),
 				() => resolve(row)
 			]);
 		});
@@ -112,8 +113,12 @@ erpnext.utils.BarcodeScanner = class BarcodeScanner {
 		const require_selecting_serial = has_serial_no && !serial_no;
 
 		if (!(require_selecting_batch || require_selecting_serial)) {
-			row.__disable_batch_serial_selector = true;
+			frappe.flags.hide_serial_batch_dialog = true;
 		}
+	}
+
+	revert_selector_flag() {
+		frappe.flags.hide_serial_batch_dialog = false;
 	}
 
 	set_item(row, item_code) {


### PR DESCRIPTION
This is broken again after serializing scan actions, which causes
selector to trigger before batch_no is set.

Solution: for the duration of the scan, disable the selector with the existing flag. 


Caused by #31058
Refer for more info https://github.com/frappe/erpnext/pull/30516