### PR TITLE
fix: re-validate warehouse after 'update items'

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2661,7 +2661,8 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 			parent.update_reserved_qty_for_subcontract()
 			parent.create_raw_materials_supplied("supplied_items")
 			parent.save()
-	else:
+	else:  # Sales Order
+		parent.validate_warehouse()
 		parent.update_reserved_qty()
 		parent.update_project()
 		parent.update_prevdoc_status("submit")


### PR DESCRIPTION
- If for some reason the warehouse isn't populated in SO item then reservation of qty doesn't happen.
- Check all items for warehouses again before reserving.

ref: ISS-22-23-00064