### PR TITLE
fix: Trial Balance failing to ignore Finance Book

### DIFF
--- a/erpnext/accounts/report/trial_balance/trial_balance.py
+++ b/erpnext/accounts/report/trial_balance/trial_balance.py
@@ -160,14 +160,10 @@ def get_rootwise_opening_balances(filters, report_type):
 	if filters.project:
 		additional_conditions += " and project = %(project)s"
 
-	if filters.finance_book:
-		fb_conditions = " AND finance_book = %(finance_book)s"
-		if filters.include_default_book_entries:
-			fb_conditions = (
-				" AND (finance_book in (%(finance_book)s, %(company_fb)s, '') OR finance_book IS NULL)"
-			)
-
-		additional_conditions += fb_conditions
+	if filters.get("include_default_book_entries"):
+		additional_conditions += "AND (finance_book in (%(finance_book)s, %(company_fb)s, '') OR finance_book IS NULL)"
+	else:
+		additional_conditions += "AND (finance_book in (%(finance_book)s, '') OR finance_book IS NULL)"
 
 	accounting_dimensions = get_accounting_dimensions(as_list=False)
 

--- a/erpnext/accounts/report/trial_balance/trial_balance.py
+++ b/erpnext/accounts/report/trial_balance/trial_balance.py
@@ -161,7 +161,9 @@ def get_rootwise_opening_balances(filters, report_type):
 		additional_conditions += " and project = %(project)s"
 
 	if filters.get("include_default_book_entries"):
-		additional_conditions += "AND (finance_book in (%(finance_book)s, %(company_fb)s, '') OR finance_book IS NULL)"
+		additional_conditions += (
+			"AND (finance_book in (%(finance_book)s, %(company_fb)s, '') OR finance_book IS NULL)"
+		)
 	else:
 		additional_conditions += "AND (finance_book in (%(finance_book)s, '') OR finance_book IS NULL)"
 

--- a/erpnext/accounts/report/trial_balance/trial_balance.py
+++ b/erpnext/accounts/report/trial_balance/trial_balance.py
@@ -162,10 +162,10 @@ def get_rootwise_opening_balances(filters, report_type):
 
 	if filters.get("include_default_book_entries"):
 		additional_conditions += (
-			"AND (finance_book in (%(finance_book)s, %(company_fb)s, '') OR finance_book IS NULL)"
+			" AND (finance_book in (%(finance_book)s, %(company_fb)s, '') OR finance_book IS NULL)"
 		)
 	else:
-		additional_conditions += "AND (finance_book in (%(finance_book)s, '') OR finance_book IS NULL)"
+		additional_conditions += " AND (finance_book in (%(finance_book)s, '') OR finance_book IS NULL)"
 
 	accounting_dimensions = get_accounting_dimensions(as_list=False)
 


### PR DESCRIPTION
Fixes #31214.

This issue was occurring because the removed code block only considers cases if the `finance_book` filter was set. When `finance_book` is not set, the resulting query would execute over all **GL Entry** irrespective of the value of the `GL Entry.finance_book`. However, the expected query would have been to return all `GL Entry.finance_book` which are not `company_fb` or empty.

Therefore, this block has been replaced with one that's unabashedly pulled from `financial_statements.py`.
https://github.com/frappe/erpnext/blob/3974fbbb6e0f4f41b292b870b80d6eab300f5e32/erpnext/accounts/report/financial_statements.py#L494-L499

For cases where the `finance_book` filter is not set, the condition could evaluate to 
```sql
... AND (finance_book in (NULL, NULL, '') OR finance_book IS NULL) ...
```
which should work although probably not ideal.
