### PR TITLE
fix: display currencies in validation message.

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1465,8 +1465,10 @@ class AccountsController(TransactionBase):
 
 		if not party_gle_currency and (party_account_currency != self.currency):
 			frappe.throw(
-				_("Party Account {0} currency and document currency should be same").format(
-					frappe.bold(party_account)
+				_("Party Account {0} currency ({1}) and document currency ({2}) should be same").format(
+					frappe.bold(party_account),
+					party_account_currency,
+					self.currency
 				)
 			)
 

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1466,9 +1466,7 @@ class AccountsController(TransactionBase):
 		if not party_gle_currency and (party_account_currency != self.currency):
 			frappe.throw(
 				_("Party Account {0} currency ({1}) and document currency ({2}) should be same").format(
-					frappe.bold(party_account),
-					party_account_currency,
-					self.currency
+					frappe.bold(party_account), party_account_currency, self.currency
 				)
 			)
 


### PR DESCRIPTION
It will be helpful to display the currency of the party and the document to help diagnose the issue.

Especially during failing test. It will take much greater time to find what the currency of these test documents are. Example: 
https://github.com/frappe/erpnext/runs/6712083194?check_suite_focus=true