### PR TITLE
fix: Print/PDF for financial statement reports displays either wrong date range or wrong fiscal year

### DIFF
--- a/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js
+++ b/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js
@@ -50,7 +50,15 @@ frappe.require("assets/erpnext/js/financial_statements.js", function() {
 				"fieldtype": "Link",
 				"options": "Fiscal Year",
 				"default": frappe.defaults.get_user_default("fiscal_year"),
-				"reqd": 1
+				"reqd": 1,
+				on_change: () => {
+					frappe.model.with_doc("Fiscal Year", frappe.query_report.get_filter_value('from_fiscal_year'), function(r) {
+						let start_fy = frappe.model.get_doc("Fiscal Year", frappe.query_report.get_filter_value('from_fiscal_year'));
+						frappe.query_report.set_filter_value({
+							period_start_date: start_fy.year_start_date
+						});
+					});
+				}
 			},
 			{
 				"fieldname":"to_fiscal_year",
@@ -58,7 +66,15 @@ frappe.require("assets/erpnext/js/financial_statements.js", function() {
 				"fieldtype": "Link",
 				"options": "Fiscal Year",
 				"default": frappe.defaults.get_user_default("fiscal_year"),
-				"reqd": 1
+				"reqd": 1,
+				on_change: () => {
+					frappe.model.with_doc("Fiscal Year", frappe.query_report.get_filter_value('to_fiscal_year'), function(r) {
+						let to_fy = frappe.model.get_doc("Fiscal Year", frappe.query_report.get_filter_value('to_fiscal_year'));
+						frappe.query_report.set_filter_value({
+							period_end_date: to_fy.year_end_date
+						});
+					});
+				}
 			},
 			{
 				"fieldname":"finance_book",

--- a/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js
+++ b/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js
@@ -53,9 +53,9 @@ frappe.require("assets/erpnext/js/financial_statements.js", function() {
 				"reqd": 1,
 				on_change: () => {
 					frappe.model.with_doc("Fiscal Year", frappe.query_report.get_filter_value('from_fiscal_year'), function(r) {
-						let start_fy = frappe.model.get_doc("Fiscal Year", frappe.query_report.get_filter_value('from_fiscal_year'));
+						let year_start_date = frappe.model.get_value("Fiscal Year", frappe.query_report.get_filter_value('from_fiscal_year'), "year_start_date");
 						frappe.query_report.set_filter_value({
-							period_start_date: start_fy.year_start_date
+							period_start_date: year_start_date
 						});
 					});
 				}
@@ -69,9 +69,9 @@ frappe.require("assets/erpnext/js/financial_statements.js", function() {
 				"reqd": 1,
 				on_change: () => {
 					frappe.model.with_doc("Fiscal Year", frappe.query_report.get_filter_value('to_fiscal_year'), function(r) {
-						let to_fy = frappe.model.get_doc("Fiscal Year", frappe.query_report.get_filter_value('to_fiscal_year'));
+						let year_end_date = frappe.model.get_value("Fiscal Year", frappe.query_report.get_filter_value('to_fiscal_year'), "year_end_date");
 						frappe.query_report.set_filter_value({
-							period_end_date: to_fy.year_end_date
+							period_end_date: year_end_date
 						});
 					});
 				}


### PR DESCRIPTION
fixed issue: https://github.com/frappe/erpnext/issues/31079

While changing fiscal year it's not updating period_start_date and period_end_date. so added this change to show valid info in print format.

![image](https://user-images.githubusercontent.com/6947417/171823439-5558f5e2-5978-4fc1-9789-ff9c9c8a443f.png)
