### PR TITLE
fix(India): Supplies from composite dealer not showing up

### DIFF
--- a/erpnext/regional/doctype/gstr_3b_report/gstr_3b_report.py
+++ b/erpnext/regional/doctype/gstr_3b_report/gstr_3b_report.py
@@ -148,7 +148,6 @@ class GSTR3BReport(Document):
 			FROM `tabPurchase Invoice` p , `tabPurchase Invoice Item` i
 			WHERE p.docstatus = 1 and p.name = i.parent
 			and p.is_opening = 'No'
-			and p.gst_category != 'Registered Composition'
 			and (i.is_nil_exempt = 1 or i.is_non_gst = 1 or p.gst_category = 'Registered Composition') and
 			month(p.posting_date) = %s and year(p.posting_date) = %s
 			and p.company = %s and p.company_gstin = %s


### PR DESCRIPTION
<img width="933" alt="image" src="https://user-images.githubusercontent.com/42651287/172089806-45cc0a59-3b04-490b-93dc-e2a23b4ae08d.png">

Supplies from composite dealer was not showing up in GSTR-3B report list