### PR TITLE
fix: Reverse provisional entries on Purchase Invoice cancel

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -532,10 +532,7 @@ class PurchaseInvoice(BuyingController):
 
 	def make_gl_entries(self, gl_entries=None, from_repost=False):
 		if not gl_entries:
-			if self.docstatus == 1:
-				gl_entries = self.get_gl_entries()
-			else:
-				gl_entries = self.get_gl_entries(cancel=1)
+			gl_entries = self.get_gl_entries()
 
 		if gl_entries:
 			update_outstanding = "No" if (cint(self.is_paid) or self.write_off_account) else "Yes"
@@ -551,7 +548,13 @@ class PurchaseInvoice(BuyingController):
 				provisional_entries = [a for a in gl_entries if a.voucher_type == "Purchase Receipt"]
 				make_reverse_gl_entries(voucher_type=self.doctype, voucher_no=self.name)
 				if provisional_entries:
-					make_gl_entries(provisional_entries)
+					for entry in provisional_entries:
+						frappe.db.set_value(
+							"GL Entry",
+							{"voucher_type": "Purchase Receipt", "voucher_detail_no": entry.voucher_detail_no},
+							"is_cancelled",
+							1,
+						)
 
 			if update_outstanding == "No":
 				update_outstanding_amt(
@@ -565,7 +568,7 @@ class PurchaseInvoice(BuyingController):
 		elif self.docstatus == 2 and cint(self.update_stock) and self.auto_accounting_for_stock:
 			make_reverse_gl_entries(voucher_type=self.doctype, voucher_no=self.name)
 
-	def get_gl_entries(self, warehouse_account=None, cancel=0):
+	def get_gl_entries(self, warehouse_account=None):
 		self.auto_accounting_for_stock = erpnext.is_perpetual_inventory_enabled(self.company)
 		if self.auto_accounting_for_stock:
 			self.stock_received_but_not_billed = self.get_company_default("stock_received_but_not_billed")
@@ -578,7 +581,7 @@ class PurchaseInvoice(BuyingController):
 		gl_entries = []
 
 		self.make_supplier_gl_entry(gl_entries)
-		self.make_item_gl_entries(gl_entries, cancel=cancel)
+		self.make_item_gl_entries(gl_entries)
 		self.make_discount_gl_entries(gl_entries)
 
 		if self.check_asset_cwip_enabled():
@@ -645,7 +648,7 @@ class PurchaseInvoice(BuyingController):
 				)
 			)
 
-	def make_item_gl_entries(self, gl_entries, cancel=0):
+	def make_item_gl_entries(self, gl_entries):
 		# item gl entries
 		stock_items = self.get_stock_items()
 		if self.update_stock and self.auto_accounting_for_stock:
@@ -842,7 +845,7 @@ class PurchaseInvoice(BuyingController):
 							if expense_booked_in_pr:
 								# Intentionally passing purchase invoice item to handle partial billing
 								purchase_receipt_doc.add_provisional_gl_entry(
-									item, gl_entries, self.posting_date, provisional_account, reverse=not cancel
+									item, gl_entries, self.posting_date, provisional_account, reverse=1
 								)
 
 					if not self.is_internal_transfer():

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -532,7 +532,10 @@ class PurchaseInvoice(BuyingController):
 
 	def make_gl_entries(self, gl_entries=None, from_repost=False):
 		if not gl_entries:
-			gl_entries = self.get_gl_entries()
+			if self.docstatus == 1:
+				gl_entries = self.get_gl_entries()
+			else:
+				gl_entries = self.get_gl_entries(cancel=1)
 
 		if gl_entries:
 			update_outstanding = "No" if (cint(self.is_paid) or self.write_off_account) else "Yes"
@@ -545,7 +548,10 @@ class PurchaseInvoice(BuyingController):
 					from_repost=from_repost,
 				)
 			elif self.docstatus == 2:
+				provisional_entries = [a for a in gl_entries if a.voucher_type == "Purchase Receipt"]
 				make_reverse_gl_entries(voucher_type=self.doctype, voucher_no=self.name)
+				if provisional_entries:
+					make_gl_entries(provisional_entries)
 
 			if update_outstanding == "No":
 				update_outstanding_amt(
@@ -559,7 +565,7 @@ class PurchaseInvoice(BuyingController):
 		elif self.docstatus == 2 and cint(self.update_stock) and self.auto_accounting_for_stock:
 			make_reverse_gl_entries(voucher_type=self.doctype, voucher_no=self.name)
 
-	def get_gl_entries(self, warehouse_account=None):
+	def get_gl_entries(self, warehouse_account=None, cancel=0):
 		self.auto_accounting_for_stock = erpnext.is_perpetual_inventory_enabled(self.company)
 		if self.auto_accounting_for_stock:
 			self.stock_received_but_not_billed = self.get_company_default("stock_received_but_not_billed")
@@ -572,7 +578,7 @@ class PurchaseInvoice(BuyingController):
 		gl_entries = []
 
 		self.make_supplier_gl_entry(gl_entries)
-		self.make_item_gl_entries(gl_entries)
+		self.make_item_gl_entries(gl_entries, cancel=cancel)
 		self.make_discount_gl_entries(gl_entries)
 
 		if self.check_asset_cwip_enabled():
@@ -639,7 +645,7 @@ class PurchaseInvoice(BuyingController):
 				)
 			)
 
-	def make_item_gl_entries(self, gl_entries):
+	def make_item_gl_entries(self, gl_entries, cancel=0):
 		# item gl entries
 		stock_items = self.get_stock_items()
 		if self.update_stock and self.auto_accounting_for_stock:
@@ -836,7 +842,7 @@ class PurchaseInvoice(BuyingController):
 							if expense_booked_in_pr:
 								# Intentionally passing purchase invoice item to handle partial billing
 								purchase_receipt_doc.add_provisional_gl_entry(
-									item, gl_entries, self.posting_date, provisional_account, reverse=1
+									item, gl_entries, self.posting_date, provisional_account, reverse=not cancel
 								)
 
 					if not self.is_internal_transfer():

--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -1526,6 +1526,18 @@ class TestPurchaseInvoice(unittest.TestCase):
 
 		check_gl_entries(self, pr.name, expected_gle_for_purchase_receipt, pr.posting_date)
 
+		# Cancel purchase invoice to check reverse provisional entry cancellation
+		pi.cancel()
+
+		expected_gle_for_purchase_receipt_post_pi_cancel = [
+			["Provision Account - _TC", 0, 250, pi.posting_date],
+			["_Test Account Cost for Goods Sold - _TC", 250, 0, pi.posting_date],
+		]
+
+		check_gl_entries(
+			self, pr.name, expected_gle_for_purchase_receipt_post_pi_cancel, pr.posting_date
+		)
+
 		company.enable_provisional_accounting_for_non_stock_items = 0
 		company.save()
 


### PR DESCRIPTION
For context read https://docs.erpnext.com/docs/v13/user/manual/en/accounts/purchase-invoice#45-provisional-accounting-for-expenses-only-for-non-stock-items

On cancellation of Purchase Invoice against a service Purchase Receipt, the provisional entries posted against the Purchase Receipt were not getting canceled and on amending the Purchase Invoice against reverse provisional entries were passed due to which the balances went off

To avoid this simply cancel reversal entries on Purchase Invoice cancel