### PR TITLE
fix: unnecessary GLE reposts

### DIFF
--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -1145,7 +1145,7 @@ def repost_gle_for_stock_vouchers(
 	precision = get_field_precision(frappe.get_meta("GL Entry").get_field("debit")) or 2
 
 	gle = get_voucherwise_gl_entries(stock_vouchers, posting_date)
-	for voucher_type, voucher_no in stock_vouchers:
+	for idx, (voucher_type, voucher_no) in enumerate(stock_vouchers):
 		existing_gle = gle.get((voucher_type, voucher_no), [])
 		voucher_obj = frappe.get_doc(voucher_type, voucher_no)
 		# Some transactions post credit as negative debit, this is handled while posting GLE
@@ -1159,6 +1159,11 @@ def repost_gle_for_stock_vouchers(
 				voucher_obj.make_gl_entries(gl_entries=expected_gle, from_repost=True)
 		else:
 			_delete_gl_entries(voucher_type, voucher_no)
+
+		if idx % 20 == 0:
+			# Commit every 20 documents to avoid losing progress
+			# and reducing memory usage
+			frappe.db.commit()
 
 
 def sort_stock_vouchers_by_posting_date(


### PR DESCRIPTION
In Sales/Purchase invoices credit/debit are flipped and negated while making GLE,
this is unflipped while posting them but if we compare the flipped ones
it will always result in comparison failure and repost it.