### PR TITLE
fix(Sales Register): incorrect query with dimensions

### DIFF
--- a/erpnext/accounts/report/sales_register/sales_register.py
+++ b/erpnext/accounts/report/sales_register/sales_register.py
@@ -346,9 +346,13 @@ def get_columns(invoice_list, additional_table_columns):
 def get_conditions(filters):
 	conditions = ""
 
+	accounting_dimensions = get_accounting_dimensions(as_list=False) or []
+	accounting_dimensions_list = [d.fieldname for d in accounting_dimensions]
+
 	if filters.get("company"):
 		conditions += " and company=%(company)s"
-	if filters.get("customer"):
+
+	if filters.get("customer") and "customer" not in accounting_dimensions_list:
 		conditions += " and customer = %(customer)s"
 
 	if filters.get("from_date"):
@@ -359,32 +363,18 @@ def get_conditions(filters):
 	if filters.get("owner"):
 		conditions += " and owner = %(owner)s"
 
-	if filters.get("mode_of_payment"):
-		conditions += """ and exists(select name from `tabSales Invoice Payment`
+	def get_sales_invoice_item_field_condition(field, table="Sales Invoice Item") -> str:
+		if not filters.get(field) or field in accounting_dimensions_list:
+			return ""
+		return f""" and exists(select name from `tab{table}`
 			 where parent=`tabSales Invoice`.name
-			 	and ifnull(`tabSales Invoice Payment`.mode_of_payment, '') = %(mode_of_payment)s)"""
+			 	and ifnull(`tab{table}`.{field}, '') = %({field})s)"""
 
-	if filters.get("cost_center"):
-		conditions += """ and exists(select name from `tabSales Invoice Item`
-			 where parent=`tabSales Invoice`.name
-			 	and ifnull(`tabSales Invoice Item`.cost_center, '') = %(cost_center)s)"""
-
-	if filters.get("warehouse"):
-		conditions += """ and exists(select name from `tabSales Invoice Item`
-			 where parent=`tabSales Invoice`.name
-			 	and ifnull(`tabSales Invoice Item`.warehouse, '') = %(warehouse)s)"""
-
-	if filters.get("brand"):
-		conditions += """ and exists(select name from `tabSales Invoice Item`
-			 where parent=`tabSales Invoice`.name
-			 	and ifnull(`tabSales Invoice Item`.brand, '') = %(brand)s)"""
-
-	if filters.get("item_group"):
-		conditions += """ and exists(select name from `tabSales Invoice Item`
-			 where parent=`tabSales Invoice`.name
-			 	and ifnull(`tabSales Invoice Item`.item_group, '') = %(item_group)s)"""
-
-	accounting_dimensions = get_accounting_dimensions(as_list=False)
+	conditions += get_sales_invoice_item_field_condition("mode_of_payments", "Sales Invoice Payment")
+	conditions += get_sales_invoice_item_field_condition("cost_center")
+	conditions += get_sales_invoice_item_field_condition("warehouse")
+	conditions += get_sales_invoice_item_field_condition("brand")
+	conditions += get_sales_invoice_item_field_condition("item_group")
 
 	if accounting_dimensions:
 		common_condition = """


### PR DESCRIPTION
If the accounting dimension is also part of the default filters then same the query is repeated with incorrect syntax.

e.g. `item_group = (child1, child2)` instead of `in` query.

fix: don't add default filters if they are part of the dimensions to be added.



### App Versions
```
{
	"erpnext": "14.0.0-dev",
	"frappe": "14.0.0-dev"
}
```
### Route
```
query-report/Sales Register
```
### Trackeback
```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 67, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 54, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 39, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 77, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1502, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/__init__.py", line 759, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "apps/frappe/frappe/desk/query_report.py", line 252, in run
    result = generate_report_result(report, filters, user, custom_columns, is_tree, parent_field)
  File "apps/frappe/frappe/__init__.py", line 759, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "apps/frappe/frappe/desk/query_report.py", line 86, in generate_report_result
    res = get_report_result(report, filters) or []
  File "apps/frappe/frappe/desk/query_report.py", line 67, in get_report_result
    res = report.execute_script_report(filters)
  File "apps/frappe/frappe/core/doctype/report/report.py", line 142, in execute_script_report
    res = self.execute_module(filters)
  File "apps/frappe/frappe/core/doctype/report/report.py", line 159, in execute_module
    return frappe.get_attr(method_name)(frappe._dict(filters))
  File "apps/erpnext/erpnext/accounts/report/sales_register/sales_register.py", line 17, in execute
    return _execute(filters)
  File "apps/erpnext/erpnext/accounts/report/sales_register/sales_register.py", line 24, in _execute
    invoice_list = get_invoices(filters, additional_query_columns)
  File "apps/erpnext/erpnext/accounts/report/sales_register/sales_register.py", line 419, in get_invoices
    return frappe.db.sql(
  File "apps/frappe/frappe/database/database.py", line 169, in sql
    self._cursor.execute(query, values)
  File "env/lib/python3.9/site-packages/pymysql/cursors.py", line 148, in execute
    result = self._query(query)
  File "env/lib/python3.9/site-packages/pymysql/cursors.py", line 310, in _query
    conn.query(q)
  File "env/lib/python3.9/site-packages/pymysql/connections.py", line 548, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "env/lib/python3.9/site-packages/pymysql/connections.py", line 775, in _read_query_result
    result.read()
  File "env/lib/python3.9/site-packages/pymysql/connections.py", line 1156, in read
    first_packet = self.connection._read_packet()
  File "env/lib/python3.9/site-packages/pymysql/connections.py", line 725, in _read_packet
    packet.raise_for_error()
  File "env/lib/python3.9/site-packages/pymysql/protocol.py", line 221, in raise_for_error
    err.raise_mysql_exception(self._data)
  File "env/lib/python3.9/site-packages/pymysql/err.py", line 143, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.OperationalError: (4078, "Illegal parameter data types varchar and row for operation '='")

```
### Request Data
```
{
	"type": "GET",
	"args": {
		"report_name": "Sales Register",
		"filters": "{\"from_date\":\"2022-05-06\",\"to_date\":\"2022-06-06\",\"company\":\"Wind Power LLC\",\"item_group\":\"DENTAL\"}"
	},
	"headers": {},
	"error_handlers": {},
	"url": "/api/method/frappe.desk.query_report.run"
}
```
### Response Data
```
{
	"exception": "pymysql.err.OperationalError: (4078, \"Illegal parameter data types varchar and row for operation '='\")"
}
```
