### PR TITLE
fix: only fetch membership expiry if not already set in `member.js`

### DIFF
--- a/erpnext/__init__.py
+++ b/erpnext/__init__.py
@@ -149,6 +149,7 @@ def allow_regional(fn):
 	return caller
 
 
+@frappe.whitelist()
 def get_last_membership(member):
 	"""Returns last membership if exists"""
 	last_membership = frappe.get_all(

--- a/erpnext/non_profit/doctype/member/member.js
+++ b/erpnext/non_profit/doctype/member/member.js
@@ -44,21 +44,18 @@ frappe.ui.form.on('Member', {
 			frappe.contacts.clear_address_and_contact(frm);
 		}
 
-		frappe.call({
-			method:"frappe.client.get_value",
-			args:{
-				'doctype':"Membership",
-				'filters':{'member': frm.doc.name},
-				'fieldname':[
-					'to_date'
-				]
-			},
-			callback: function (data) {
-				if(data.message) {
-					frappe.model.set_value(frm.doctype,frm.docname,
-						"membership_expiry_date", data.message.to_date);
+		if (!frm.doc.membership_expiry_date && !frm.doc.__islocal) {
+			frappe.call({
+				method: "erpnext.get_last_membership",
+				args: {
+					member: frm.doc.member
+				},
+				callback: function(data) {
+					if (data.message) {
+						frappe.model.set_value(frm.doctype, frm.docname, "membership_expiry_date", data.message.to_date);
+					}
 				}
-			}
-		});
+			});
+		}
 	}
 });


### PR DESCRIPTION
**Problem**:

Member client fetches expiry from existing memberships even if a new one is set. These continuous calls are made on `refresh` and set the doc as dirty with "Not Saved" which is super annoying.

**Fix**:

Only fetch membership expiry if not already set.