### PR TITLE
fix: locale Currency and Float setting in update_employee

### DIFF
--- a/erpnext/hr/utils.py
+++ b/erpnext/hr/utils.py
@@ -138,6 +138,8 @@ def update_employee(employee, details, date=None, cancel=False):
 			new_data = getdate(new_data)
 		elif fieldtype =="Datetime" and new_data:
 			new_data = get_datetime(new_data)
+		elif fieldtype in ["Currency", "Float"] and new_data:
+			new_data = flt(new_data)			
 		setattr(employee, item.fieldname, new_data)
 		if item.fieldname in ["department", "designation", "branch"]:
 			internal_work_history[item.fieldname] = item.new


### PR DESCRIPTION
In fieldtypes locale settings (example NL) . and , changes whereby the field is inproperly filled