### PR TITLE
fix: Use `frappe.as_unicode` to decode output of redis module list

### DIFF
--- a/erpnext/e_commerce/redisearch_utils.py
+++ b/erpnext/e_commerce/redisearch_utils.py
@@ -38,7 +38,7 @@ def is_search_module_loaded():
 		out = cache.execute_command("MODULE LIST")
 
 		parsed_output = " ".join(
-			(" ".join([s.decode() for s in o if not isinstance(s, int)]) for o in out)
+			(" ".join([frappe.as_unicode(s) for s in o if not isinstance(s, int)]) for o in out)
 		)
 		return "search" in parsed_output
 	except Exception:


### PR DESCRIPTION
**Issue:**
- As of redis 7, a list is added to the result of fetching the module list
   ```py
    [[b'name', b'search', b'ver', 20205, b'path', b'/home/.../redisearch.so', b'args', []]]
    ```
- Using `element.decode()`
   ```py 
       AttributeError: 'list' object has no attribute 'decode'
    ```

**Fix:**
- This list cannot be "decoded",so use `frappe.as_unicode` that handles bytes as well as other types
