### PR TITLE
fix: Depreciate asset on the last day of the month if its depr start date falls on the last day of its month

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -257,6 +257,7 @@ class Asset(AccountsController):
 				number_of_pending_depreciations += 1
 
 			skip_row = False
+			should_get_last_day = self.is_last_day_of_the_month(finance_book.depreciation_start_date)
 
 			for n in range(start[finance_book.idx - 1], number_of_pending_depreciations):
 				# If depreciation is already completed (for double declining balance)
@@ -269,6 +270,9 @@ class Asset(AccountsController):
 					schedule_date = add_months(
 						finance_book.depreciation_start_date, n * cint(finance_book.frequency_of_depreciation)
 					)
+
+					if should_get_last_day:
+						schedule_date = get_last_day(schedule_date)
 
 					# schedule date will be a year later from start date
 					# so monthly schedule date is calculated by removing 11 months from it
@@ -404,6 +408,14 @@ class Asset(AccountsController):
 								"finance_book_id": finance_book.idx,
 							},
 						)
+
+	def is_last_day_of_the_month(self, depreciation_start_date):
+		last_day_of_the_month = get_last_day(depreciation_start_date)
+
+		if getdate(last_day_of_the_month) == getdate(depreciation_start_date):
+			return True
+		else:
+			return False
 
 	# depreciation schedules need to be cleared before modification due to increase in asset life/asset sales
 	# JE: Journal Entry, FB: Finance Book

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -412,10 +412,7 @@ class Asset(AccountsController):
 	def is_last_day_of_the_month(self, depreciation_start_date):
 		last_day_of_the_month = get_last_day(depreciation_start_date)
 
-		if getdate(last_day_of_the_month) == getdate(depreciation_start_date):
-			return True
-		else:
-			return False
+		return getdate(last_day_of_the_month) == getdate(depreciation_start_date)
 
 	# depreciation schedules need to be cleared before modification due to increase in asset life/asset sales
 	# JE: Journal Entry, FB: Finance Book

--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -1275,7 +1275,14 @@ class TestDepreciationBasics(AssetSetup):
 			submit=1,
 		)
 
-		expected_dates = ["2020-02-28", "2020-03-31", "2020-04-30", "2020-05-31", "2020-06-30", "2020-07-15"]
+		expected_dates = [
+			"2020-02-28",
+			"2020-03-31",
+			"2020-04-30",
+			"2020-05-31",
+			"2020-06-30",
+			"2020-07-15",
+		]
 
 		for i, schedule in enumerate(asset.schedules):
 			self.assertEqual(expected_dates[i], schedule.schedule_date)

--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -787,7 +787,7 @@ class TestDepreciationBasics(AssetSetup):
 		expected_values = [["2020-12-31", 30000.0], ["2021-12-31", 30000.0], ["2022-12-31", 30000.0]]
 
 		for i, schedule in enumerate(asset.schedules):
-			self.assertEqual(expected_values[i][0], getdate(schedule.schedule_date))
+			self.assertEqual(getdate(expected_values[i][0]), getdate(schedule.schedule_date))
 			self.assertEqual(expected_values[i][1], schedule.depreciation_amount)
 
 	def test_set_accumulated_depreciation(self):
@@ -1285,7 +1285,7 @@ class TestDepreciationBasics(AssetSetup):
 		]
 
 		for i, schedule in enumerate(asset.schedules):
-			self.assertEqual(getdate(expected_dates[i]), schedule.schedule_date)
+			self.assertEqual(getdate(expected_dates[i]), getdate(schedule.schedule_date))
 
 
 def create_asset_data():

--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -1261,6 +1261,25 @@ class TestDepreciationBasics(AssetSetup):
 		asset.cost_center = "Main - _TC"
 		asset.submit()
 
+	def test_depreciation_on_final_day_of_the_month(self):
+		"""Tests if final day of the month is picked each time, if the depreciation start date is the last day of the month."""
+
+		asset = create_asset(
+			item_code="Macbook Pro",
+			calculate_depreciation=1,
+			purchase_date="2020-01-30",
+			available_for_use_date="2020-02-15",
+			depreciation_start_date="2020-02-28",
+			frequency_of_depreciation=1,
+			total_number_of_depreciations=5,
+			submit=1,
+		)
+
+		expected_dates = ["2020-02-28", "2020-03-31", "2020-04-30", "2020-05-31", "2020-06-30", "2020-07-15"]
+
+		for i, schedule in enumerate(asset.schedules):
+			self.assertEqual(expected_dates[i], schedule.schedule_date)
+
 
 def create_asset_data():
 	if not frappe.db.exists("Asset Category", "Computers"):

--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -787,7 +787,7 @@ class TestDepreciationBasics(AssetSetup):
 		expected_values = [["2020-12-31", 30000.0], ["2021-12-31", 30000.0], ["2022-12-31", 30000.0]]
 
 		for i, schedule in enumerate(asset.schedules):
-			self.assertEqual(expected_values[i][0], schedule.schedule_date)
+			self.assertEqual(expected_values[i][0], getdate(schedule.schedule_date))
 			self.assertEqual(expected_values[i][1], schedule.depreciation_amount)
 
 	def test_set_accumulated_depreciation(self):
@@ -1285,7 +1285,7 @@ class TestDepreciationBasics(AssetSetup):
 		]
 
 		for i, schedule in enumerate(asset.schedules):
-			self.assertEqual(expected_dates[i], schedule.schedule_date)
+			self.assertEqual(getdate(expected_dates[i]), schedule.schedule_date)
 
 
 def create_asset_data():


### PR DESCRIPTION
## Issue

If an Asset that depreciates monthly starts depreciating on, say, Feb 28, then it would depreciate next on March 28, then April 28 and so on. However, customers usually intend to have the asset depreciate on the last day of each month in this case- i.e. Feb 28 should be followed by March 31 and April 30 instead.

## Fix

This PR checks if the `depreciation_start_date` falls on the last day of its month, and if so, modify the schedule dates so that they'd each fall on the last day of their respective months.

![Screenshot 2022-06-09 at 2 38 31 AM](https://user-images.githubusercontent.com/25903035/172717432-01ae6329-8e06-404e-955e-e6d750168ab4.png)

