### PR TITLE
fix: misaligned columns in print format of AR/AP report

### DIFF
--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.html
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.html
@@ -42,7 +42,7 @@
 
 	{% if(filters.show_future_payments) { %}
 		{% var balance_row = data.slice(-1).pop();
-			var start = filters.based_on_payment_terms ? 13 : 11;
+			var start = report.columns.findIndex((elem) => (elem.fieldname == 'age'));
 			var range1 = report.columns[start].label;
 			var range2 = report.columns[start+1].label;
 			var range3 = report.columns[start+2].label;


### PR DESCRIPTION
With 'Show Future Payments' checked, table headers are misaligned In Print Format of AR/AP report. Fixing in this PR.

Before
<img width="1117" alt="Screenshot 2022-06-09 at 3 24 30 PM" src="https://user-images.githubusercontent.com/3272205/172820511-42175798-37db-4bbe-b8e5-ed7ec57702d1.png">

After
<img width="1117" alt="Screenshot 2022-06-09 at 3 24 54 PM" src="https://user-images.githubusercontent.com/3272205/172820497-89c78adc-3df3-4526-8cab-a481522a7261.png">

