### PR TITLE
fix(ux): hide new version btn on unsaved BOM

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.js
+++ b/erpnext/manufacturing/doctype/bom/bom.js
@@ -81,7 +81,7 @@ frappe.ui.form.on("BOM", {
 			}
 		)
 
-		if (!frm.doc.__islocal && frm.doc.docstatus<2) {
+		if (!frm.is_new() && frm.doc.docstatus<2) {
 			frm.add_custom_button(__("Update Cost"), function() {
 				frm.events.update_cost(frm, true);
 			});
@@ -93,10 +93,12 @@ frappe.ui.form.on("BOM", {
 			});
 		}
 
-		frm.add_custom_button(__("New Version"), function() {
-			let new_bom = frappe.model.copy_doc(frm.doc);
-			frappe.set_route("Form", "BOM", new_bom.name);
-		});
+		if (!frm.is_new() && !frm.doc.docstatus == 0) {
+			frm.add_custom_button(__("New Version"), function() {
+				let new_bom = frappe.model.copy_doc(frm.doc);
+				frappe.set_route("Form", "BOM", new_bom.name);
+			});
+		}
 
 		if(frm.doc.docstatus==1) {
 			frm.add_custom_button(__("Work Order"), function() {


### PR DESCRIPTION
Doesn't make much sense to create a new version from BOM that's not saved or submitted ever 😄 

Missed out in https://github.com/frappe/erpnext/pull/31175