### PR TITLE
fix: Reset represents company on disabling internal customer and supplier

### DIFF
--- a/erpnext/buying/doctype/supplier/supplier.py
+++ b/erpnext/buying/doctype/supplier/supplier.py
@@ -84,6 +84,9 @@ class Supplier(TransactionBase):
 		self.save()
 
 	def validate_internal_supplier(self):
+		if not self.is_internal_supplier:
+			self.represents_company = ""
+
 		internal_supplier = frappe.db.get_value(
 			"Supplier",
 			{

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -141,6 +141,9 @@ class Customer(TransactionBase):
 				)
 
 	def validate_internal_customer(self):
+		if not self.is_internal_customer:
+			self.represents_company = ""
+
 		internal_customer = frappe.db.get_value(
 			"Customer",
 			{


### PR DESCRIPTION
The `Represents Company` field is dependent on the `is_internal_customer` and `is_internal_suppliers` fields in Customer and Supplier doctypes respectively and it is a unique field that means there can be only one customer/supplier representing a particular internal company at a time

Many times users uncheck `is_internal_(customer/supplier)` from a record but don't clear the represented company field which leads to issues in creating new ones.

 Added a check to auto clear this field