### PR TITLE
fix: transaction date gets unset in material request

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -453,7 +453,6 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 							is_pos: cint(me.frm.doc.is_pos),
 							is_return: cint(me.frm.doc.is_return),
 							is_subcontracted: me.frm.doc.is_subcontracted,
-							transaction_date: me.frm.doc.transaction_date || me.frm.doc.posting_date,
 							ignore_pricing_rule: me.frm.doc.ignore_pricing_rule,
 							doctype: me.frm.doc.doctype,
 							name: me.frm.doc.name,

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -63,18 +63,17 @@ def get_item_details(args, doc=None, for_validate=False, overwrite_warehouse=Tru
 	item = frappe.get_cached_doc("Item", args.item_code)
 	validate_item_details(args, item)
 
-	out = get_basic_details(args, item, overwrite_warehouse)
-
 	if isinstance(doc, str):
 		doc = json.loads(doc)
-
-	if doc and doc.get("doctype") == "Purchase Invoice":
-		args["bill_date"] = doc.get("bill_date")
 
 	if doc:
 		args["posting_date"] = doc.get("posting_date")
 		args["transaction_date"] = doc.get("transaction_date")
 
+		if doc.get("doctype") == "Purchase Invoice":
+			args["bill_date"] = doc.get("bill_date")
+
+	out = get_basic_details(args, item, overwrite_warehouse)
 	get_item_tax_template(args, item, out)
 	out["item_tax_rate"] = get_item_tax_map(
 		args.company,
@@ -378,7 +377,7 @@ def get_basic_details(args, item, overwrite_warehouse=True):
 			"last_purchase_rate": item.last_purchase_rate
 			if args.get("doctype") in ["Purchase Order"]
 			else 0,
-			"transaction_date": args.get("transaction_date"),
+			"transaction_date": args.get("transaction_date") or args.get("posting_date"),
 			"against_blanket_order": args.get("against_blanket_order"),
 			"bom_no": item.get("default_bom"),
 			"weight_per_unit": args.get("weight_per_unit") or item.get("weight_per_unit"),


### PR DESCRIPTION
## Issue
If `transaction_date` is set in args (as in `transaction.js` before this PR):
`out` gets the same `transaction_date` as `args` in `get_basic_details` and the date remains unchanged in `doc`

If `transaction_date` is not set in args (as in `material_request.js`):
`out` doesn't get the `transaction_date` in `get_basic_details`, and the date consequently gets unset

## Solution
- don't pass `transaction_date` at all if we're overwriting `args` anyway
- move `get_basic_details` to below where args are overwritten
- set `transaction_date or posting_date` as `transaction_date` in `args` (as per current behavior in `transaction.js`). The reason why this is harmless is because docs have either `transaction_date` or `posting_date`, but not both.
- remove all references of `posting_date` to simplify code

A side effect of this is exchange rate being correct on Invoices. Since `get_item_details.validate_conversion_rate` only considers `args.transaction_rate`, this rate was incorrect for documents with `posting_date` instead of `transaction_date`.