### PR TITLE
chore: Accidental '=' instead of comma in French translation

### DIFF
--- a/erpnext/translations/fr.csv
+++ b/erpnext/translations/fr.csv
@@ -9908,5 +9908,5 @@ Delete Transactions,Supprimer les transactions
 Default Payment Discount Account,Compte par défaut des paiements de remise
 Unrealized Profit / Loss Account,Compte de perte
 Enable Provisional Accounting For Non Stock Items,Activer la provision pour les articles non stockés
-Publish in Website=Publier sur le Site Web
+Publish in Website,Publier sur le Site Web
 List View,Vue en liste


### PR DESCRIPTION
Missed in https://github.com/frappe/erpnext/pull/31232

> Don't backport, fixed in hotfix via  https://github.com/frappe/erpnext/pull/31334