### PR TITLE
refactor: get_fiscal_years API

### DIFF
--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -115,4 +115,5 @@ jobs:
           echo "Updating to latest version"
           git -C "apps/frappe" checkout -q -f "${GITHUB_BASE_REF:-${GITHUB_REF##*/}}"
           git -C "apps/erpnext" checkout -q -f "$GITHUB_SHA"
+          bench setup requirements --python
           bench --site test_site migrate

--- a/erpnext/regional/report/irs_1099/irs_1099.py
+++ b/erpnext/regional/report/irs_1099/irs_1099.py
@@ -10,7 +10,7 @@ from frappe.utils.data import fmt_money
 from frappe.utils.jinja import render_template
 from frappe.utils.pdf import get_pdf
 from frappe.utils.print_format import read_multi_pdf
-from PyPDF2 import PdfFileWriter
+from PyPDF2 import PdfWriter
 
 from erpnext.accounts.utils import get_fiscal_year
 
@@ -106,7 +106,7 @@ def irs_1099_print(filters):
 
 	columns, data = execute(filters)
 	template = frappe.get_doc("Print Format", "IRS 1099 Form").html
-	output = PdfFileWriter()
+	output = PdfWriter()
 
 	for row in data:
 		row["fiscal_year"] = fiscal_year

--- a/erpnext/tests/test_exotel.py
+++ b/erpnext/tests/test_exotel.py
@@ -59,7 +59,6 @@ class TestExotel(FrappeAPITestCase):
 			f"/api/method/erpnext.erpnext_integrations.exotel_integration.{api_method}",
 			data=frappe.as_json(data),
 			content_type="application/json",
-			as_tuple=True,
 		)
 		# restart db connection to get latest data
 		frappe.connect()


### PR DESCRIPTION
### Changes

* Refactor get_fiscal_years API (raised for https://github.com/frappe/frappe/pull/16961) 
* Fix import paths of PyPDF2 (ref: https://github.com/frappe/erpnext/runs/6856328546?check_suite_focus=true) (through https://github.com/frappe/frappe/pull/17127)
* Removed use of deprecated `as_tuple` in FrappeTestAPICase's methods (Werkzeug 2.1 ref: https://github.com/pallets/werkzeug/commit/7d2784f139b7ef3c14c63e73d8b616ae440838ad)