### PR TITLE
fix: Spelling mistake in quotation depend on

### DIFF
--- a/erpnext/selling/doctype/quotation/quotation.json
+++ b/erpnext/selling/doctype/quotation/quotation.json
@@ -296,7 +296,7 @@
    "read_only": 1
   },
   {
-   "depends_on": "eval:doc.quotaion_to=='Customer' && doc.party_name",
+   "depends_on": "eval:doc.quotation_to=='Customer' && doc.party_name",
    "fieldname": "col_break98",
    "fieldtype": "Column Break",
    "width": "50%"
@@ -316,7 +316,7 @@
    "read_only": 1
   },
   {
-   "depends_on": "eval:doc.quotaion_to=='Customer' && doc.party_name",
+   "depends_on": "eval:doc.quotation_to=='Customer' && doc.party_name",
    "fieldname": "customer_group",
    "fieldtype": "Link",
    "hidden": 1,


### PR DESCRIPTION
**`Version`**
ERPNext: v14.0.0-develop
Frappe Framework: v14.x.x-develop

**Before:**

- A spelling mistake in col_break98 and customer_group
`eval:doc.quotaion_to=='Customer' && doc.party_name`

- when hide option unchecked then customer group does not show in quotation.

![image](https://user-images.githubusercontent.com/99652762/173754035-8336ecb5-9330-435e-b361-ee6b8286e942.png)

![image](https://user-images.githubusercontent.com/99652762/173754721-441b406f-7e4c-476f-9f6d-9f3caf2dbb7f.png)

**After Develop:**

- Set depend on conditions like:
`eval:doc.quotation_to=='Customer' && doc.party_name`

- hide option unchecked then customer group will show properly in quotation.

![image](https://user-images.githubusercontent.com/99652762/173755140-9fb7f2ff-e07f-4a14-a607-d1e2f875e71f.png)


Thank You!