### PR TITLE
fix: filter set in Bank Clearance Summary

### DIFF
--- a/erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py
+++ b/erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py
@@ -43,7 +43,7 @@ def get_columns():
 			"options": "Account",
 			"width": 170,
 		},
-		{"label": _("Amount"), "fieldname": "amount", "width": 120},
+		{"label": _("Amount"), "fieldname": "amount", "fieldtype": "Currency", "width": 120},
 	]
 
 	return columns


### PR DESCRIPTION
**`Version`**
ERPNext: v14.0.0-develop
Frappe Framework: v14.x.x-develop

- Please also update version 13

**Before:**
- In Bank Clearance Summary, when entering values in the filter for amount column, it does not filter out the rows (Amount).
- Because field type does not define.


https://user-images.githubusercontent.com/99652762/174304200-c155e42b-b97a-4dd0-a18c-32f8e7b39ade.mp4

**After Develop:**
- Set field type of amount in bank_clearance_summary.py

```
{"label": _("Amount"), "fieldname": "amount", "fieldtype": "Currency", "width": 120},
```
- Then after checking so the amount filter works properly.


https://user-images.githubusercontent.com/99652762/174304634-fb823f10-039a-4556-b6ba-4c772a515a0e.mp4


Thank You!