### PR TITLE
chore: Change autoname to v13 compatible value

### DIFF
--- a/erpnext/manufacturing/doctype/bom_update_batch/bom_update_batch.json
+++ b/erpnext/manufacturing/doctype/bom_update_batch/bom_update_batch.json
@@ -1,6 +1,6 @@
 {
  "actions": [],
- "autoname": "autoincrement",
+ "autoname": "hash",
  "creation": "2022-05-31 17:34:39.825537",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -42,7 +42,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2022-06-06 14:50:35.161062",
+ "modified": "2022-06-20 15:10:15.826571",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "BOM Update Batch",
@@ -50,6 +50,5 @@
  "owner": "Administrator",
  "permissions": [],
  "sort_field": "modified",
- "sort_order": "DESC",
- "states": []
+ "sort_order": "DESC"
 }


### PR DESCRIPTION
Consistency with https://github.com/frappe/erpnext/pull/31364 
> `autoincrement` is only present in v14. It was ported by mistake but does no harm. It defaults to hash in v13 even with `autoname=autoincrement`. This is a correctness + safety measure

> The `name` column is of type `varchar` anyway. This doesn't break migration