### PR TITLE
fix: translation for filter status on report

### DIFF
--- a/erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js
+++ b/erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.js
@@ -59,6 +59,7 @@ frappe.query_reports["Purchase Order Analysis"] = {
 				for (let option of status){
 					options.push({
 						"value": option,
+						"label": __(option),
 						"description": ""
 					})
 				}

--- a/erpnext/selling/report/sales_order_analysis/sales_order_analysis.js
+++ b/erpnext/selling/report/sales_order_analysis/sales_order_analysis.js
@@ -55,6 +55,7 @@ frappe.query_reports["Sales Order Analysis"] = {
 				for (let option of status){
 					options.push({
 						"value": option,
+						"label": __(option),
 						"description": ""
 					})
 				}


### PR DESCRIPTION
Translation for status filter values! 
Reports:
- Purchase Order Analysis
- Sales Order Analysis


![image](https://user-images.githubusercontent.com/25017988/174871053-3d320d72-665f-445e-91f2-b336c46b751b.png)
