### PR TITLE
feat: Inventory Dimension

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -367,14 +367,13 @@ class StockController(AccountsController):
 		)
 
 		sl_dict.update(args)
-		if self.docstatus == 1:
-			self.update_inventory_dimensions(d, sl_dict)
+		self.update_inventory_dimensions(d, sl_dict)
 
 		return sl_dict
 
 	def update_inventory_dimensions(self, row, sl_dict) -> None:
 		dimension = get_evaluated_inventory_dimension(row, sl_dict, parent_doc=self)
-		if dimension:
+		if dimension and row.get(dimension.source_fieldname):
 			sl_dict[dimension.target_fieldname] = row.get(dimension.source_fieldname)
 
 	def make_sl_entries(self, sl_entries, allow_negative_stock=False, via_landed_cost_voucher=False):

--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -372,9 +372,10 @@ class StockController(AccountsController):
 		return sl_dict
 
 	def update_inventory_dimensions(self, row, sl_dict) -> None:
-		dimension = get_evaluated_inventory_dimension(row, sl_dict, parent_doc=self)
-		if dimension and row.get(dimension.source_fieldname):
-			sl_dict[dimension.target_fieldname] = row.get(dimension.source_fieldname)
+		dimensions = get_evaluated_inventory_dimension(row, sl_dict, parent_doc=self)
+		for dimension in dimensions:
+			if dimension and row.get(dimension.source_fieldname):
+				sl_dict[dimension.target_fieldname] = row.get(dimension.source_fieldname)
 
 	def make_sl_entries(self, sl_entries, allow_negative_stock=False, via_landed_cost_voucher=False):
 		from erpnext.stock.stock_ledger import make_sl_entries

--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -18,6 +18,9 @@ from erpnext.accounts.general_ledger import (
 from erpnext.accounts.utils import get_fiscal_year
 from erpnext.controllers.accounts_controller import AccountsController
 from erpnext.stock import get_warehouse_account_map
+from erpnext.stock.doctype.inventory_dimension.inventory_dimension import (
+	get_evaluated_inventory_dimension,
+)
 from erpnext.stock.stock_ledger import get_items_to_be_repost
 
 
@@ -364,7 +367,15 @@ class StockController(AccountsController):
 		)
 
 		sl_dict.update(args)
+		if self.docstatus == 1:
+			self.update_inventory_dimensions(d, sl_dict)
+
 		return sl_dict
+
+	def update_inventory_dimensions(self, row, sl_dict) -> None:
+		dimension = get_evaluated_inventory_dimension(row, sl_dict, parent_doc=self)
+		if dimension:
+			sl_dict[dimension.target_fieldname] = row.get(dimension.source_fieldname)
 
 	def make_sl_entries(self, sl_entries, allow_negative_stock=False, via_landed_cost_voucher=False):
 		from erpnext.stock.stock_ledger import make_sl_entries

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -224,6 +224,32 @@ $.extend(erpnext.utils, {
 		});
 	},
 
+	add_inventory_dimensions: function(report_name, index) {
+		let filters = frappe.query_reports[report_name].filters;
+
+		frappe.call({
+			method: "erpnext.stock.doctype.inventory_dimension.inventory_dimension.get_inventory_dimensions",
+			callback: function(r) {
+				if (r.message && r.message.length) {
+					r.message.forEach((dimension) => {
+						let found = filters.some(el => el.fieldname === dimension['fieldname']);
+
+						if (!found) {
+							filters.splice(index, 0, {
+								"fieldname": dimension["fieldname"],
+								"label": __(dimension["label"]),
+								"fieldtype": "MultiSelectList",
+								get_data: function(txt) {
+									return frappe.db.get_link_options(dimension["doctype"], txt);
+								},
+							});
+						}
+					});
+				}
+			}
+		});
+	},
+
 	make_subscription: function(doctype, docname) {
 		frappe.call({
 			method: "frappe.automation.doctype.auto_repeat.auto_repeat.make_auto_repeat",

--- a/erpnext/stock/doctype/inventory_dimension/inventory_dimension.js
+++ b/erpnext/stock/doctype/inventory_dimension/inventory_dimension.js
@@ -32,25 +32,15 @@ frappe.ui.form.on('Inventory Dimension', {
 		frm.trigger('render_traget_field');
 	},
 
-	map_with_existing_field(frm) {
-		frm.trigger('render_traget_field');
-	},
+	refresh(frm) {
+		if (frm.doc.__onload && frm.doc.__onload.has_stock_ledger
+			&& frm.doc.__onload.has_stock_ledger.length) {
+			let msg = __('Stock transactions exists against this dimension, user can not update document.');
+			frm.dashboard.add_comment(msg, 'blue', true);
 
-	render_traget_field(frm) {
-		if (frm.doc.map_with_existing_field && !frm.doc.disabled) {
-			frappe.call({
-				method: 'erpnext.stock.doctype.inventory_dimension.inventory_dimension.get_source_fieldnames',
-				args: {
-					reference_document: frm.doc.reference_document,
-					ignore_document: frm.doc.name
-				},
-				callback: function(r) {
-					if (r.message && r.message.length) {
-						frm.set_df_property('stock_ledger_dimension', 'options', r.message);
-					} else {
-						frm.set_value("map_with_existing_field", 0);
-						frappe.msgprint(__('Inventory Dimensions not found'));
-					}
+			frm.fields.forEach((field) => {
+				if (field.df.fieldname !== 'disabled') {
+					frm.set_df_property(field.df.fieldname, "read_only", "1");
 				}
 			});
 		}

--- a/erpnext/stock/doctype/inventory_dimension/inventory_dimension.js
+++ b/erpnext/stock/doctype/inventory_dimension/inventory_dimension.js
@@ -1,0 +1,58 @@
+// Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('Inventory Dimension', {
+	setup(frm) {
+		frm.trigger('set_query_on_fields');
+	},
+
+	set_query_on_fields(frm) {
+		frm.set_query('reference_document', () => {
+			let invalid_doctypes = frappe.model.core_doctypes_list;
+			invalid_doctypes.push('Batch', 'Serial No', 'Warehouse', 'Item', 'Inventory Dimension',
+				'Accounting Dimension', 'Accounting Dimension Filter');
+
+			return {
+				filters: {
+					'istable': 0,
+					'issingle': 0,
+					'name': ['not in', invalid_doctypes]
+				}
+			};
+		});
+
+		frm.set_query('document_type', () => {
+			return {
+				query: 'erpnext.stock.doctype.inventory_dimension.inventory_dimension.get_inventory_documents',
+			};
+		});
+	},
+
+	onload(frm) {
+		frm.trigger('render_traget_field');
+	},
+
+	map_with_existing_field(frm) {
+		frm.trigger('render_traget_field');
+	},
+
+	render_traget_field(frm) {
+		if (frm.doc.map_with_existing_field && !frm.doc.disabled) {
+			frappe.call({
+				method: 'erpnext.stock.doctype.inventory_dimension.inventory_dimension.get_source_fieldnames',
+				args: {
+					reference_document: frm.doc.reference_document,
+					ignore_document: frm.doc.name
+				},
+				callback: function(r) {
+					if (r.message && r.message.length) {
+						frm.set_df_property('stock_ledger_dimension', 'options', r.message);
+					} else {
+						frm.set_value("map_with_existing_field", 0);
+						frappe.msgprint(__('Inventory Dimensions not found'));
+					}
+				}
+			});
+		}
+	}
+});

--- a/erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
+++ b/erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
@@ -10,21 +10,22 @@
   "dimension_details_tab",
   "dimension_name",
   "reference_document",
+  "column_break_4",
   "disabled",
   "section_break_7",
   "field_mapping_section",
   "source_fieldname",
-  "target_fieldname",
   "column_break_9",
-  "map_with_existing_field",
-  "stock_ledger_dimension",
+  "target_fieldname",
   "applicable_for_documents_tab",
   "apply_to_all_doctypes",
   "document_type",
   "istable",
   "type_of_transaction",
   "column_break_16",
-  "condition"
+  "condition",
+  "applicable_condition_example_section",
+  "html_19"
  ],
  "fields": [
   {
@@ -81,7 +82,7 @@
    "label": "Applicable Condition"
   },
   {
-   "default": "1",
+   "default": "0",
    "fieldname": "apply_to_all_doctypes",
    "fieldtype": "Check",
    "label": "Apply to All Document Types"
@@ -115,31 +116,35 @@
    "label": "Field Mapping"
   },
   {
-   "default": "0",
-   "fieldname": "map_with_existing_field",
-   "fieldtype": "Check",
-   "label": "Map with existing field"
-  },
-  {
    "fieldname": "column_break_16",
    "fieldtype": "Column Break"
-  },
-  {
-   "depends_on": "map_with_existing_field",
-   "fieldname": "stock_ledger_dimension",
-   "fieldtype": "Select",
-   "label": "Stock Ledger Dimension"
   },
   {
    "fieldname": "type_of_transaction",
    "fieldtype": "Select",
    "label": "Type of Transaction",
    "options": "\nInward\nOutward"
+  },
+  {
+   "fieldname": "html_19",
+   "fieldtype": "HTML",
+   "options": "<table class=\"table table-bordered table-condensed\">\n<thead>\n  <tr>\n         <th class=\"table-sr\" style=\"width: 50%;\">Child Document</th>\n         <th class=\"table-sr\" style=\"width: 50%;\">Non Child Document</th>\n   </tr>\n</thead>\n<tbody>\n<tr>\n         <td>\n                  <p> To access parent document field use parent.fieldname and to access child table document field use doc.fieldname </p>\n\n         </td>\n         <td>\n                    <p>To access document field use doc.fieldname </p>\n         </td>\n</tr>\n<tr>\n        <td>\n                   <p><b>Example: </b> parent.doctype == \"Stock Entry\" and doc.item_code == \"Test\" </p>\n\n        </td>\n         <td>\n                   <p><b>Example: </b> doc.doctype == \"Stock Entry\" and doc.purpose == \"Manufacture\"</p>    \n          </td>\n</tr>\n\n</tbody>\n</table>\n\n\n\n\n\n\n"
+  },
+  {
+   "collapsible": 1,
+   "depends_on": "eval:!doc.apply_to_all_doctypes",
+   "fieldname": "applicable_condition_example_section",
+   "fieldtype": "Section Break",
+   "label": "Applicable Condition Examples"
+  },
+  {
+   "fieldname": "column_break_4",
+   "fieldtype": "Column Break"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-06-22 10:56:43.753713",
+ "modified": "2022-07-05 15:33:37.270373",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Inventory Dimension",

--- a/erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
+++ b/erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
@@ -85,7 +85,7 @@
    "default": "0",
    "fieldname": "apply_to_all_doctypes",
    "fieldtype": "Check",
-   "label": "Apply to All Document Types"
+   "label": "Apply to All Inventory Document Types"
   },
   {
    "default": "0",
@@ -144,7 +144,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-07-05 15:33:37.270373",
+ "modified": "2022-07-19 21:06:11.824976",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Inventory Dimension",

--- a/erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
+++ b/erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
@@ -1,0 +1,189 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "autoname": "field:dimension_name",
+ "creation": "2022-06-17 13:04:16.554051",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "dimension_details_tab",
+  "dimension_name",
+  "reference_document",
+  "disabled",
+  "section_break_7",
+  "field_mapping_section",
+  "source_fieldname",
+  "target_fieldname",
+  "column_break_9",
+  "map_with_existing_field",
+  "stock_ledger_dimension",
+  "applicable_for_documents_tab",
+  "apply_to_all_doctypes",
+  "document_type",
+  "istable",
+  "type_of_transaction",
+  "column_break_16",
+  "condition"
+ ],
+ "fields": [
+  {
+   "fieldname": "dimension_details_tab",
+   "fieldtype": "Tab Break",
+   "label": "Dimension Details"
+  },
+  {
+   "fieldname": "reference_document",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Reference Document",
+   "options": "DocType",
+   "reqd": 1
+  },
+  {
+   "fieldname": "dimension_name",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Dimension Name",
+   "reqd": 1,
+   "unique": 1
+  },
+  {
+   "fieldname": "applicable_for_documents_tab",
+   "fieldtype": "Tab Break",
+   "label": "Applicable For Documents"
+  },
+  {
+   "depends_on": "eval:!doc.apply_to_all_doctypes",
+   "fieldname": "document_type",
+   "fieldtype": "Link",
+   "label": "Applicable to Document",
+   "mandatory_depends_on": "eval:!doc.apply_to_all_doctypes",
+   "options": "DocType"
+  },
+  {
+   "fieldname": "column_break_9",
+   "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:!doc.apply_to_all_doctypes && doc.document_type",
+   "fetch_from": "document_type.istable",
+   "fieldname": "istable",
+   "fieldtype": "Check",
+   "label": " Is Child Table",
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval:!doc.apply_to_all_doctypes",
+   "fieldname": "condition",
+   "fieldtype": "Code",
+   "label": "Applicable Condition"
+  },
+  {
+   "default": "1",
+   "fieldname": "apply_to_all_doctypes",
+   "fieldtype": "Check",
+   "label": "Apply to All Document Types"
+  },
+  {
+   "default": "0",
+   "fieldname": "disabled",
+   "fieldtype": "Check",
+   "label": "Disabled"
+  },
+  {
+   "fieldname": "section_break_7",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "target_fieldname",
+   "fieldtype": "Data",
+   "label": "Target Fieldname (Stock Ledger Entry)",
+   "read_only": 1
+  },
+  {
+   "fieldname": "source_fieldname",
+   "fieldtype": "Data",
+   "label": "Source Fieldname",
+   "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "field_mapping_section",
+   "fieldtype": "Section Break",
+   "label": "Field Mapping"
+  },
+  {
+   "default": "0",
+   "fieldname": "map_with_existing_field",
+   "fieldtype": "Check",
+   "label": "Map with existing field"
+  },
+  {
+   "fieldname": "column_break_16",
+   "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "map_with_existing_field",
+   "fieldname": "stock_ledger_dimension",
+   "fieldtype": "Select",
+   "label": "Stock Ledger Dimension"
+  },
+  {
+   "fieldname": "type_of_transaction",
+   "fieldtype": "Select",
+   "label": "Type of Transaction",
+   "options": "\nInward\nOutward"
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "links": [],
+ "modified": "2022-06-22 10:56:43.753713",
+ "modified_by": "Administrator",
+ "module": "Stock",
+ "name": "Inventory Dimension",
+ "naming_rule": "By fieldname",
+ "owner": "Administrator",
+ "permissions": [
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "System Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Stock Manager",
+   "share": 1,
+   "write": 1
+  },
+  {
+   "create": 1,
+   "delete": 1,
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Stock User",
+   "share": 1,
+   "write": 1
+  }
+ ],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/erpnext/stock/doctype/inventory_dimension/inventory_dimension.py
+++ b/erpnext/stock/doctype/inventory_dimension/inventory_dimension.py
@@ -1,0 +1,163 @@
+# Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+import frappe
+from frappe import _, scrub
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
+from frappe.model.document import Document
+
+
+class InventoryDimension(Document):
+	def validate(self):
+		self.reset_value()
+		self.validate_reference_document()
+		self.set_source_and_target_fieldname()
+
+	def reset_value(self):
+		if self.apply_to_all_doctypes:
+			self.istable = 0
+			for field in ["document_type", "parent_field", "condition", "type_of_transaction"]:
+				self.set(field, None)
+
+	def validate_reference_document(self):
+		if frappe.get_cached_value("DocType", self.reference_document, "istable") == 1:
+			frappe.throw(_(f"The reference document {self.reference_document} can not be child table."))
+
+		if self.reference_document in ["Batch", "Serial No", "Warehouse", "Item"]:
+			frappe.throw(
+				_(f"The reference document {self.reference_document} can not be an Inventory Dimension.")
+			)
+
+	def set_source_and_target_fieldname(self):
+		self.source_fieldname = scrub(self.dimension_name)
+		if not self.map_with_existing_field:
+			self.target_fieldname = self.source_fieldname
+
+	def on_update(self):
+		self.add_custom_fields()
+
+	def add_custom_fields(self):
+		dimension_field = dict(
+			fieldname=self.source_fieldname,
+			fieldtype="Link",
+			insert_after="warehouse",
+			options=self.reference_document,
+			label=self.dimension_name,
+		)
+
+		custom_fields = {}
+
+		if self.apply_to_all_doctypes:
+			for doctype in get_inventory_documents():
+				if not frappe.db.get_value(
+					"Custom Field", {"dt": doctype[0], "fieldname": self.source_fieldname}
+				):
+					custom_fields.setdefault(doctype[0], dimension_field)
+		elif not frappe.db.get_value(
+			"Custom Field", {"dt": self.document_type, "fieldname": self.source_fieldname}
+		):
+			custom_fields.setdefault(self.document_type, dimension_field)
+
+		if not frappe.db.get_value(
+			"Custom Field", {"dt": "Stock Ledger Entry", "fieldname": self.target_fieldname}
+		):
+			dimension_field["fieldname"] = self.target_fieldname
+			custom_fields["Stock Ledger Entry"] = dimension_field
+
+		create_custom_fields(custom_fields)
+
+
+@frappe.whitelist()
+def get_inventory_documents(
+	doctype=None, txt=None, searchfield=None, start=None, page_len=None, filters=None
+):
+	and_filters = [["DocField", "parent", "not in", ["Batch", "Serial No"]]]
+	or_filters = [
+		["DocField", "options", "in", ["Batch", "Serial No"]],
+		["DocField", "parent", "in", ["Putaway Rule"]],
+	]
+
+	if txt:
+		and_filters.append(["DocField", "parent", "like", f"%{txt}%"])
+
+	return frappe.get_all(
+		"DocField",
+		fields=["distinct parent"],
+		filters=and_filters,
+		or_filters=or_filters,
+		start=start,
+		page_length=page_len,
+		as_list=1,
+	)
+
+
+def get_evaluated_inventory_dimension(doc, sl_dict, parent_doc=None) -> dict:
+	dimensions = get_document_wise_inventory_dimensions(doc.doctype)
+	for row in dimensions:
+		if (
+			row.type_of_transaction == "Inward"
+			if doc.docstatus == 1
+			else row.type_of_transaction != "Inward"
+		) and sl_dict.actual_qty < 0:
+			continue
+		elif (
+			row.type_of_transaction == "Outward"
+			if doc.docstatus == 1
+			else row.type_of_transaction != "Inward"
+		) and sl_dict.actual_qty > 0:
+			continue
+
+		if frappe.safe_eval(row.condition, {"doc": doc, "parent_doc": parent_doc}):
+			return row
+
+
+def get_document_wise_inventory_dimensions(doctype) -> dict:
+	if not hasattr(frappe.local, "document_wise_inventory_dimensions"):
+		frappe.local.document_wise_inventory_dimensions = {}
+
+	if doctype not in frappe.local.document_wise_inventory_dimensions:
+		dimensions = frappe.get_all(
+			"Inventory Dimension",
+			fields=["name", "source_fieldname", "condition", "target_fieldname", "type_of_transaction"],
+			filters={"disabled": 0},
+			or_filters={"document_type": doctype, "apply_to_all_doctypes": 1},
+		)
+
+		frappe.local.document_wise_inventory_dimensions[doctype] = dimensions
+
+	return frappe.local.document_wise_inventory_dimensions[doctype]
+
+
+@frappe.whitelist()
+def get_source_fieldnames(reference_document, ignore_document):
+	return frappe.get_all(
+		"Inventory Dimension",
+		fields=["source_fieldname as value", "dimension_name as label"],
+		filters={
+			"disabled": 0,
+			"map_with_existing_field": 0,
+			"name": ("!=", ignore_document),
+			"reference_document": reference_document,
+		},
+	)
+
+
+@frappe.whitelist()
+def get_inventory_dimensions():
+	if not hasattr(frappe.local, "inventory_dimensions"):
+		frappe.local.inventory_dimensions = {}
+
+	if not frappe.local.inventory_dimensions:
+		dimensions = frappe.get_all(
+			"Inventory Dimension",
+			fields=[
+				"distinct target_fieldname as fieldname",
+				"dimension_name as label",
+				"reference_document as doctype",
+			],
+			filters={"disabled": 0, "map_with_existing_field": 0},
+		)
+
+		frappe.local.inventory_dimensions = dimensions
+
+	return frappe.local.inventory_dimensions

--- a/erpnext/stock/doctype/inventory_dimension/test_inventory_dimension.py
+++ b/erpnext/stock/doctype/inventory_dimension/test_inventory_dimension.py
@@ -1,9 +1,112 @@
 # Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
-# import frappe
+import frappe
 from frappe.tests.utils import FrappeTestCase
+
+from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
+from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
 
 
 class TestInventoryDimension(FrappeTestCase):
-	pass
+	def setUp(self):
+		prepare_test_data()
+
+	def test_inventory_dimension(self):
+		warehouse = "Shelf Warehouse - _TC"
+		item_code = "_Test Item"
+
+		create_inventory_dimension(
+			reference_document="Shelf",
+			type_of_transaction="Outward",
+			dimension_name="Shelf",
+			apply_to_all_doctypes=0,
+			document_type="Stock Entry Detail",
+			condition="parent.purpose == 'Material Issue'",
+		)
+
+		create_inventory_dimension(
+			reference_document="Shelf",
+			type_of_transaction="Inward",
+			dimension_name="To Shelf",
+			apply_to_all_doctypes=0,
+			document_type="Stock Entry Detail",
+			condition="parent.purpose == 'Material Receipt'",
+		)
+
+		inward = make_stock_entry(
+			item_code=item_code,
+			target=warehouse,
+			qty=5,
+			basic_rate=10,
+			do_not_save=True,
+			purpose="Material Receipt",
+		)
+
+		inward.items[0].to_shelf = "Shelf 1"
+		inward.save()
+		inward.submit()
+		inward.load_from_db()
+		print(inward.name)
+
+		sle_data = frappe.db.get_value(
+			"Stock Ledger Entry", {"voucher_no": inward.name}, ["shelf", "warehouse"], as_dict=1
+		)
+
+		self.assertEqual(inward.items[0].to_shelf, "Shelf 1")
+		self.assertEqual(sle_data.warehouse, warehouse)
+		self.assertEqual(sle_data.shelf, "Shelf 1")
+
+		outward = make_stock_entry(
+			item_code=item_code,
+			source=warehouse,
+			qty=3,
+			basic_rate=10,
+			do_not_save=True,
+			purpose="Material Issue",
+		)
+
+		outward.items[0].shelf = "Shelf 1"
+		outward.save()
+		outward.submit()
+		outward.load_from_db()
+
+		sle_shelf = frappe.db.get_value("Stock Ledger Entry", {"voucher_no": outward.name}, "shelf")
+		self.assertEqual(sle_shelf, "Shelf 1")
+
+
+def prepare_test_data():
+	if not frappe.db.exists("DocType", "Shelf"):
+		frappe.get_doc(
+			{
+				"doctype": "DocType",
+				"name": "Shelf",
+				"module": "Stock",
+				"custom": 1,
+				"naming_rule": "By fieldname",
+				"autoname": "field:shelf_name",
+				"fields": [{"label": "Shelf Name", "fieldname": "shelf_name", "fieldtype": "Data"}],
+				"permissions": [
+					{"role": "System Manager", "permlevel": 0, "read": 1, "write": 1, "create": 1, "delete": 1}
+				],
+			}
+		).insert(ignore_permissions=True)
+
+	for shelf in ["Shelf 1", "Shelf 2"]:
+		if not frappe.db.exists("Shelf", shelf):
+			frappe.get_doc({"doctype": "Shelf", "shelf_name": shelf}).insert(ignore_permissions=True)
+
+	create_warehouse("Shelf Warehouse")
+
+
+def create_inventory_dimension(**args):
+	args = frappe._dict(args)
+
+	if frappe.db.exists("Inventory Dimension", args.dimension_name):
+		return frappe.get_doc("Inventory Dimension", args.dimension_name)
+
+	doc = frappe.new_doc("Inventory Dimension")
+	doc.update(args)
+	doc.insert(ignore_permissions=True)
+
+	return doc

--- a/erpnext/stock/doctype/inventory_dimension/test_inventory_dimension.py
+++ b/erpnext/stock/doctype/inventory_dimension/test_inventory_dimension.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestInventoryDimension(FrappeTestCase):
+	pass

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -478,10 +478,10 @@ class StockEntry(StockController):
 						if not d.s_warehouse:
 							frappe.throw(_("Source warehouse is mandatory for row {0}").format(d.idx))
 
-			if (
-				cstr(d.s_warehouse) == cstr(d.t_warehouse)
-				and not self.purpose == "Material Transfer for Manufacture"
-			):
+			if cstr(d.s_warehouse) == cstr(d.t_warehouse) and self.purpose not in [
+				"Material Transfer for Manufacture",
+				"Material Transfer",
+			]:
 				frappe.throw(_("Source and target warehouse cannot be same for row {0}").format(d.idx))
 
 			if not (d.s_warehouse or d.t_warehouse):

--- a/erpnext/stock/report/stock_balance/stock_balance.js
+++ b/erpnext/stock/report/stock_balance/stock_balance.js
@@ -102,3 +102,5 @@ frappe.query_reports["Stock Balance"] = {
 		return value;
 	}
 };
+
+erpnext.utils.add_inventory_dimensions('Stock Balance', 8);

--- a/erpnext/stock/report/stock_balance/stock_balance.py
+++ b/erpnext/stock/report/stock_balance/stock_balance.py
@@ -13,6 +13,7 @@ from frappe.utils.nestedset import get_descendants_of
 from pypika.terms import ExistsCriterion
 
 import erpnext
+from erpnext.stock.doctype.inventory_dimension.inventory_dimension import get_inventory_dimensions
 from erpnext.stock.report.stock_ageing.stock_ageing import FIFOSlots, get_average_age
 from erpnext.stock.utils import add_additional_uom_columns, is_reposting_item_valuation_in_progress
 
@@ -66,9 +67,14 @@ def execute(filters: Optional[StockBalanceFilter] = None):
 	_func = itemgetter(1)
 
 	to_date = filters.get("to_date")
-	for (company, item, warehouse) in sorted(iwb_map):
+
+	for group_by_key in iwb_map:
+		item = group_by_key[1]
+		warehouse = group_by_key[2]
+		company = group_by_key[0]
+
 		if item_map.get(item):
-			qty_dict = iwb_map[(company, item, warehouse)]
+			qty_dict = iwb_map[group_by_key]
 			item_reorder_level = 0
 			item_reorder_qty = 0
 			if item + warehouse in item_reorder_detail_map:
@@ -135,87 +141,103 @@ def get_columns(filters: StockBalanceFilter):
 			"options": "Warehouse",
 			"width": 100,
 		},
-		{
-			"label": _("Stock UOM"),
-			"fieldname": "stock_uom",
-			"fieldtype": "Link",
-			"options": "UOM",
-			"width": 90,
-		},
-		{
-			"label": _("Balance Qty"),
-			"fieldname": "bal_qty",
-			"fieldtype": "Float",
-			"width": 100,
-			"convertible": "qty",
-		},
-		{
-			"label": _("Balance Value"),
-			"fieldname": "bal_val",
-			"fieldtype": "Currency",
-			"width": 100,
-			"options": "currency",
-		},
-		{
-			"label": _("Opening Qty"),
-			"fieldname": "opening_qty",
-			"fieldtype": "Float",
-			"width": 100,
-			"convertible": "qty",
-		},
-		{
-			"label": _("Opening Value"),
-			"fieldname": "opening_val",
-			"fieldtype": "Currency",
-			"width": 110,
-			"options": "currency",
-		},
-		{
-			"label": _("In Qty"),
-			"fieldname": "in_qty",
-			"fieldtype": "Float",
-			"width": 80,
-			"convertible": "qty",
-		},
-		{"label": _("In Value"), "fieldname": "in_val", "fieldtype": "Float", "width": 80},
-		{
-			"label": _("Out Qty"),
-			"fieldname": "out_qty",
-			"fieldtype": "Float",
-			"width": 80,
-			"convertible": "qty",
-		},
-		{"label": _("Out Value"), "fieldname": "out_val", "fieldtype": "Float", "width": 80},
-		{
-			"label": _("Valuation Rate"),
-			"fieldname": "val_rate",
-			"fieldtype": "Currency",
-			"width": 90,
-			"convertible": "rate",
-			"options": "currency",
-		},
-		{
-			"label": _("Reorder Level"),
-			"fieldname": "reorder_level",
-			"fieldtype": "Float",
-			"width": 80,
-			"convertible": "qty",
-		},
-		{
-			"label": _("Reorder Qty"),
-			"fieldname": "reorder_qty",
-			"fieldtype": "Float",
-			"width": 80,
-			"convertible": "qty",
-		},
-		{
-			"label": _("Company"),
-			"fieldname": "company",
-			"fieldtype": "Link",
-			"options": "Company",
-			"width": 100,
-		},
 	]
+
+	for dimension in get_inventory_dimensions():
+		columns.append(
+			{
+				"label": _(dimension.label),
+				"fieldname": dimension.fieldname,
+				"fieldtype": "Link",
+				"options": dimension.doctype,
+				"width": 110,
+			}
+		)
+
+	columns.extend(
+		[
+			{
+				"label": _("Stock UOM"),
+				"fieldname": "stock_uom",
+				"fieldtype": "Link",
+				"options": "UOM",
+				"width": 90,
+			},
+			{
+				"label": _("Balance Qty"),
+				"fieldname": "bal_qty",
+				"fieldtype": "Float",
+				"width": 100,
+				"convertible": "qty",
+			},
+			{
+				"label": _("Balance Value"),
+				"fieldname": "bal_val",
+				"fieldtype": "Currency",
+				"width": 100,
+				"options": "currency",
+			},
+			{
+				"label": _("Opening Qty"),
+				"fieldname": "opening_qty",
+				"fieldtype": "Float",
+				"width": 100,
+				"convertible": "qty",
+			},
+			{
+				"label": _("Opening Value"),
+				"fieldname": "opening_val",
+				"fieldtype": "Currency",
+				"width": 110,
+				"options": "currency",
+			},
+			{
+				"label": _("In Qty"),
+				"fieldname": "in_qty",
+				"fieldtype": "Float",
+				"width": 80,
+				"convertible": "qty",
+			},
+			{"label": _("In Value"), "fieldname": "in_val", "fieldtype": "Float", "width": 80},
+			{
+				"label": _("Out Qty"),
+				"fieldname": "out_qty",
+				"fieldtype": "Float",
+				"width": 80,
+				"convertible": "qty",
+			},
+			{"label": _("Out Value"), "fieldname": "out_val", "fieldtype": "Float", "width": 80},
+			{
+				"label": _("Valuation Rate"),
+				"fieldname": "val_rate",
+				"fieldtype": "Currency",
+				"width": 90,
+				"convertible": "rate",
+				"options": "currency",
+			},
+			{
+				"label": _("Reorder Level"),
+				"fieldname": "reorder_level",
+				"fieldtype": "Float",
+				"width": 80,
+				"convertible": "qty",
+			},
+			{
+				"label": _("Reorder Qty"),
+				"fieldname": "reorder_qty",
+				"fieldtype": "Float",
+				"width": 80,
+				"convertible": "qty",
+			},
+			{
+				"label": _("Company"),
+				"fieldname": "company",
+				"fieldtype": "Link",
+				"options": "Company",
+				"width": 100,
+			},
+		]
+	)
 
 	if filters.get("show_stock_ageing_data"):
 		columns += [
@@ -296,11 +318,23 @@ def get_stock_ledger_entries(filters: StockBalanceFilter, items: List[str]) -> L
 		.orderby(sle.actual_qty)
 	)
 
+	inventory_dimension_fields = get_inventory_dimension_fields()
+	if inventory_dimension_fields:
+		query = query.select(", ".join(inventory_dimension_fields))
+
+		for fieldname in inventory_dimension_fields:
+			if fieldname in filters and filters.get(fieldname):
+				query = query.where(sle[fieldname].isin(filters.get(fieldname)))
+
 	if items:
 		query = query.where(sle.item_code.isin(items))
 
 	query = apply_conditions(query, filters)
-	return query.run(as_dict=True)
+	return query.run(as_dict=True, debug=1)
+
+
+def get_inventory_dimension_fields():
+	return [dimension.fieldname for dimension in get_inventory_dimensions()]
 
 
 def get_item_warehouse_map(filters: StockBalanceFilter, sle: List[SLEntry]):
@@ -310,10 +344,12 @@ def get_item_warehouse_map(filters: StockBalanceFilter, sle: List[SLEntry]):
 
 	float_precision = cint(frappe.db.get_default("float_precision")) or 3
 
+	inventory_dimensions = get_inventory_dimension_fields()
+
 	for d in sle:
-		key = (d.company, d.item_code, d.warehouse)
-		if key not in iwb_map:
-			iwb_map[key] = frappe._dict(
+		group_by_key = get_group_by_key(d, inventory_dimensions)
+		if group_by_key not in iwb_map:
+			iwb_map[group_by_key] = frappe._dict(
 				{
 					"opening_qty": 0.0,
 					"opening_val": 0.0,
@@ -327,7 +363,9 @@ def get_item_warehouse_map(filters: StockBalanceFilter, sle: List[SLEntry]):
 				}
 			)
 
-		qty_dict = iwb_map[(d.company, d.item_code, d.warehouse)]
+		qty_dict = iwb_map[group_by_key]
+		for field in inventory_dimensions:
+			qty_dict[field] = d.get(field)
 
 		if d.voucher_type == "Stock Reconciliation" and not d.batch_no:
 			qty_diff = flt(d.qty_after_transaction) - flt(qty_dict.bal_qty)
@@ -356,24 +394,36 @@ def get_item_warehouse_map(filters: StockBalanceFilter, sle: List[SLEntry]):
 		qty_dict.bal_qty += qty_diff
 		qty_dict.bal_val += value_diff
 
-	iwb_map = filter_items_with_no_transactions(iwb_map, float_precision)
+	iwb_map = filter_items_with_no_transactions(iwb_map, float_precision, inventory_dimensions)
 
 	return iwb_map
 
 
-def filter_items_with_no_transactions(iwb_map, float_precision: float):
-	for (company, item, warehouse) in sorted(iwb_map):
-		qty_dict = iwb_map[(company, item, warehouse)]
+def get_group_by_key(row, inventory_dimension_fields) -> tuple:
+	group_by_key = [row.company, row.item_code, row.warehouse]
+
+	for fieldname in inventory_dimension_fields:
+		group_by_key.append(row.get(fieldname))
+
+	return tuple(group_by_key)
+
+
+def filter_items_with_no_transactions(iwb_map, float_precision: float, inventory_dimensions: list):
+	for group_by_key in iwb_map:
+		qty_dict = iwb_map[group_by_key]
 
 		no_transactions = True
 		for key, val in qty_dict.items():
+			if key in inventory_dimensions:
+				continue
+
 			val = flt(val, float_precision)
 			qty_dict[key] = val
 			if key != "val_rate" and val:
 				no_transactions = False
 
 		if no_transactions:
-			iwb_map.pop((company, item, warehouse))
+			iwb_map.pop(group_by_key)
 
 	return iwb_map
 

--- a/erpnext/stock/report/stock_balance/stock_balance.py
+++ b/erpnext/stock/report/stock_balance/stock_balance.py
@@ -329,7 +329,7 @@ def get_stock_ledger_entries(filters: StockBalanceFilter, items: List[str]) -> L
 		query = query.where(sle.item_code.isin(items))
 
 	query = apply_conditions(query, filters)
-	return query.run(as_dict=True, debug=1)
+	return query.run(as_dict=True)
 
 
 def get_inventory_dimension_fields():

--- a/erpnext/stock/report/stock_ledger/stock_ledger.js
+++ b/erpnext/stock/report/stock_ledger/stock_ledger.js
@@ -95,4 +95,6 @@ frappe.query_reports["Stock Ledger"] = {
 
 		return value;
 	},
-}
+};
+
+erpnext.utils.add_inventory_dimensions('Stock Ledger', 10);

--- a/erpnext/stock/report/stock_ledger/stock_ledger.py
+++ b/erpnext/stock/report/stock_ledger/stock_ledger.py
@@ -224,7 +224,7 @@ def get_columns(filters):
 	for dimension in get_inventory_dimensions():
 		columns.append(
 			{
-				"label": _(dimension.label),
+				"label": _(dimension.doctype),
 				"fieldname": dimension.fieldname,
 				"fieldtype": "Link",
 				"options": dimension.doctype,


### PR DESCRIPTION
### Inventory Dimension Configuration
<img width="1300" alt="new-inventory-dimension" src="https://user-images.githubusercontent.com/8780500/179797469-c78de400-3baf-4a5c-8d08-ae3c0f7f7ea2.png">


<img width="1300" alt="Screenshot 2022-06-27 at 1 29 42 PM" src="https://user-images.githubusercontent.com/8780500/175890730-b1a405e8-2eea-4412-a751-52ed62562c0d.png">


### Inventory Dimension on Stock Entry
<img width="1300" alt="Screenshot 2022-06-22 at 12 50 09 PM" src="https://user-images.githubusercontent.com/8780500/174968386-5bc30991-6458-422f-a4be-8063701d6a0f.png">


### Inventory Dimension on Stock Ledger Entry
<img width="1300" alt="Screenshot 2022-06-22 at 12 50 51 PM" src="https://user-images.githubusercontent.com/8780500/174968457-42fd0b04-f6b4-4ecb-8e19-f95856fcd0d6.png">


### Inventory Dimension wise Stock Report

#### Stock Ledger Report
<img width="1300" alt="Screenshot 2022-06-22 at 12 53 25 PM" src="https://user-images.githubusercontent.com/8780500/174969061-097ac7fc-3f7f-4cf7-ab3a-0a4fe9a4fb79.png">


#### Stock Balance Report
<img width="1300" alt="Screenshot 2022-06-22 at 12 54 25 PM" src="https://user-images.githubusercontent.com/8780500/174969103-b6d4b2d3-8ab6-4966-bb27-ec37df153f87.png">



- [x] Configuration and Reports
- [x] Test Cases
- [x] Documentation 

#docs https://docs.erpnext.com/docs/v14/user/manual/en/stock/inventory_dimension