### PR TITLE
fix(Salary Slip): Components not updated when amount evaluates to 0 due to payment days

### DIFF
--- a/erpnext/payroll/doctype/salary_slip/salary_slip.py
+++ b/erpnext/payroll/doctype/salary_slip/salary_slip.py
@@ -625,7 +625,7 @@ class SalarySlip(TransactionBase):
 		data = self.get_data_for_eval()
 		for struct_row in self._salary_structure_doc.get(component_type):
 			amount = self.eval_condition_and_formula(struct_row, data)
-			if amount and struct_row.statistical_component == 0:
+			if amount is not None and struct_row.statistical_component == 0:
 				self.update_component_row(struct_row, amount, component_type)
 
 	def get_data_for_eval(self):

--- a/erpnext/payroll/doctype/salary_slip/salary_slip.py
+++ b/erpnext/payroll/doctype/salary_slip/salary_slip.py
@@ -857,6 +857,10 @@ class SalarySlip(TransactionBase):
 			component_row, joining_date, relieving_date
 		)[0]
 
+		# remove 0 valued components that have been updated later
+		if component_row.amount == 0:
+			self.remove(component_row)
+
 	def set_precision_for_component_amounts(self):
 		for component_type in ("earnings", "deductions"):
 			for component_row in self.get(component_type):


### PR DESCRIPTION
## Steps to Replicate:

- Salary component **Professional Tax** is dependent on Gross Pay and Bonus and these components are dependent on payment days:
   <img width="1318" alt="formula" src="https://user-images.githubusercontent.com/24353136/174979009-a58779ca-edd3-487f-9255-d649e57f8bf8.png">
- If the Payment Days are altered after saving by updating "Leave Without Pay", the gross changes to 12000 from 15000 and the professional tax should be 0 as per the formula. But this amount isn't updated because it fails the check made before calling `update_component`

  <img width="1318" alt="before" src="https://user-images.githubusercontent.com/24353136/174979510-81899faa-0093-470e-9866-ac836bb07e6e.png">

## Fix:

Explicitly check whether the `amount is not None` so that 0 valued components get updated after payment days are altered:

<img width="1288" alt="after" src="https://user-images.githubusercontent.com/24353136/174979529-cdc9f3fb-3380-4ecc-8fdc-a26e40e53c62.png">
 