### PR TITLE
fix: General Ledger and TB opening entries mismatch issues

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.js
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.js
@@ -149,22 +149,6 @@ frappe.ui.form.on("Journal Entry", {
 					}
 				});
 			}
-			else if(frm.doc.voucher_type=="Opening Entry") {
-				return frappe.call({
-					type:"GET",
-					method: "erpnext.accounts.doctype.journal_entry.journal_entry.get_opening_accounts",
-					args: {
-						"company": frm.doc.company
-					},
-					callback: function(r) {
-						frappe.model.clear_table(frm.doc, "accounts");
-						if(r.message) {
-							update_jv_details(frm.doc, r.message);
-						}
-						cur_frm.set_value("is_opening", "Yes");
-					}
-				});
-			}
 		}
 	},
 

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.json
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.json
@@ -137,7 +137,8 @@
    "fieldname": "finance_book",
    "fieldtype": "Link",
    "label": "Finance Book",
-   "options": "Finance Book"
+   "options": "Finance Book",
+   "read_only": 1
   },
   {
    "fieldname": "2_add_edit_gl_entries",
@@ -538,7 +539,7 @@
  "idx": 176,
  "is_submittable": 1,
  "links": [],
- "modified": "2022-04-06 17:18:46.865259",
+ "modified": "2022-06-23 22:01:32.348337",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Journal Entry",

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -1205,24 +1205,6 @@ def get_payment_entry(ref_doc, args):
 
 
 @frappe.whitelist()
-def get_opening_accounts(company):
-	"""get all balance sheet accounts for opening entry"""
-	accounts = frappe.db.sql_list(
-		"""select
-			name from tabAccount
-		where
-			is_group=0 and report_type='Balance Sheet' and company={0} and
-			name not in (select distinct account from tabWarehouse where
-			account is not null and account != '')
-		order by name asc""".format(
-			frappe.db.escape(company)
-		)
-	)
-
-	return [{"account": a, "balance": get_balance_on(a)} for a in accounts]
-
-
-@frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
 def get_against_jv(doctype, txt, searchfield, start, page_len, filters):
 	if not frappe.db.has_column("Journal Entry", searchfield):

--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -425,7 +425,7 @@ def get_accountwise_gle(filters, accounting_dimensions, gl_entries, gle_map):
 			update_value_in_dict(totals, "opening", gle)
 			update_value_in_dict(totals, "closing", gle)
 
-		elif gle.posting_date <= to_date:
+		elif gle.posting_date <= to_date or (cstr(gle.is_opening) == "Yes" and show_opening_entries):
 			if not group_by_voucher_consolidated:
 				update_value_in_dict(gle_map[group_by_value].totals, "total", gle)
 				update_value_in_dict(gle_map[group_by_value].totals, "closing", gle)


### PR DESCRIPTION
**1. General Ledger Issue when the "Show Opening Entries" check is enabled**

An "Opening Entry" against an account should be considered as an opening entry irrespective of the date when they were posted. Currently opening entries having posting greater than the GL report `to_date` were getting ignored when the "Show Opening Entries" check was enabled.

**2. Removed account fetching for Opening Entries in Journal Entry** 

On selecting `voucher_type` as Opening Entry in Journal Entry all balance sheet accounts except stock accounts are fetched. Have rarely seen anyone using this. It causes more annoyance to most users who don't need this than helping them.

**3. Make the finance book field in Journal Entry read-only**

The Finance book field in Journal Entry was only added for the purpose of single Asste depreciations via multiple methods as a compliance requirement for some companies. Many users end up using that without having proper knowledge or context about it and later end up having issues while reporting 




