### PR TITLE
refactor: clean up product bundle client side code

### DIFF
--- a/erpnext/selling/doctype/product_bundle/product_bundle.js
+++ b/erpnext/selling/doctype/product_bundle/product_bundle.js
@@ -1,19 +1,13 @@
-// Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
+// Copyright (c) 2021, Frappe Technologies Pvt. Ltd. and Contributors
 // License: GNU General Public License v3. See license.txt
 
-cur_frm.cscript.refresh = function(doc, cdt, cdn) {
-	cur_frm.toggle_enable('new_item_code', doc.__islocal);
-}
-
-cur_frm.fields_dict.new_item_code.get_query = function() {
-	return{
-		query: "erpnext.selling.doctype.product_bundle.product_bundle.get_new_item_code"
-	}
-}
-cur_frm.fields_dict.new_item_code.query_description = __('Please select Item where "Is Stock Item" is "No" and "Is Sales Item" is "Yes" and there is no other Product Bundle');
-
-cur_frm.cscript.onload = function() {
-	// set add fetch for item_code's item_name and description
-	cur_frm.add_fetch('item_code', 'stock_uom', 'uom');
-	cur_frm.add_fetch('item_code', 'description', 'description');
-}
+frappe.ui.form.on("Product Bundle", {
+	refresh: function (frm) {
+		frm.toggle_enable("new_item_code", frm.is_new());
+		frm.set_query("new_item_code", () => {
+			return {
+				query: "erpnext.selling.doctype.product_bundle.product_bundle.get_new_item_code",
+			};
+		});
+	},
+});

--- a/erpnext/selling/doctype/product_bundle_item/product_bundle_item.json
+++ b/erpnext/selling/doctype/product_bundle_item/product_bundle_item.json
@@ -33,6 +33,8 @@
    "reqd": 1
   },
   {
+   "fetch_from": "item_code.description",
+   "fetch_if_empty": 1,
    "fieldname": "description",
    "fieldtype": "Text Editor",
    "in_list_view": 1,
@@ -51,6 +53,8 @@
    "print_hide": 1
   },
   {
+   "fetch_from": "item_code.stock_uom",
+   "fetch_if_empty": 1,
    "fieldname": "uom",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -64,7 +68,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-02-28 14:06:05.725655",
+ "modified": "2022-06-27 05:30:18.475150",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Product Bundle Item",
@@ -72,5 +76,6 @@
  "permissions": [],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }


### PR DESCRIPTION
- Remove deprecated CUR_FRM scripts
- Remove client-side fetches and move it to doctype schema.

Also resolves the issue of bulk pasting item codes and not auto-populating item info. 


ref: ISS-22-23-00838