### PR TITLE
fix: 'attribute error' on AR/AP report with delivery note filter

### DIFF
--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -128,6 +128,7 @@ class ReceivablePayableReport(object):
 					credit_note_in_account_currency=0.0,
 					outstanding_in_account_currency=0.0,
 				)
+			self.get_invoices(ple)
 
 			if self.filters.get("group_by_party"):
 				self.init_subtotal_row(ple.party)


### PR DESCRIPTION
Fixing attribute error on AR/AP report with 'Show Delivery Note' filter selected.
<img width="694" alt="Screenshot 2022-06-27 at 5 32 22 PM" src="https://user-images.githubusercontent.com/3272205/175936646-7aa091b1-5434-4869-b356-5f692a3ad04a.png">

