### PR TITLE
ci: bump container count for unittests

### DIFF
--- a/.github/workflows/server-tests-mariadb.yml
+++ b/.github/workflows/server-tests-mariadb.yml
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        container: [1, 2, 3]
+        container: [1, 2, 3, 4]
 
     name: Python Unit Tests
 

--- a/.github/workflows/server-tests-postgres.yml
+++ b/.github/workflows/server-tests-postgres.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-       container: [1, 2, 3]
+       container: [1]
 
     name: Python Unit Tests
 


### PR DESCRIPTION
Reduce actual build times by ~4 minutes. 

Runners | 3 | 4
-- | -- | --
const time | 4.5 | 4.5
variable time | 16 | 12
total variable time | 48 |  
Time for full build | 20.5 | 16.5
Total Build minutes | 61.5 | 66

