### PR TITLE
fix: Use account currency on Payment Reconciliation tool

### DIFF
--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
@@ -162,7 +162,7 @@ class PaymentReconciliation(Document):
 							{
 								"reference_type": inv.voucher_type,
 								"reference_name": inv.voucher_no,
-								"amount": -(inv.outstanding),
+								"amount": -(inv.outstanding_in_account_currency),
 								"posting_date": inv.posting_date,
 								"currency": inv.currency,
 							}

--- a/erpnext/accounts/doctype/payment_reconciliation/test_payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/test_payment_reconciliation.py
@@ -19,6 +19,7 @@ class TestPaymentReconciliation(FrappeTestCase):
 		self.create_company()
 		self.create_item()
 		self.create_customer()
+		self.create_account()
 		self.clear_old_entries()
 
 	def tearDown(self):
@@ -88,6 +89,38 @@ class TestPaymentReconciliation(FrappeTestCase):
 			customer.type = "Individual"
 			customer.save()
 			self.customer2 = customer.name
+
+		if frappe.db.exists("Customer", "_Test PR Customer 3"):
+			self.customer3 = "_Test PR Customer 3"
+		else:
+			customer = frappe.new_doc("Customer")
+			customer.customer_name = "_Test PR Customer 3"
+			customer.type = "Individual"
+			customer.default_currency = "EUR"
+			customer.save()
+			self.customer3 = customer.name
+
+	def create_account(self):
+		account_name = "Debtors EUR"
+		if not frappe.db.get_value(
+			"Account", filters={"account_name": account_name, "company": self.company}
+		):
+			acc = frappe.new_doc("Account")
+			acc.account_name = account_name
+			acc.parent_account = "Accounts Receivable - _PR"
+			acc.company = self.company
+			acc.account_currency = "EUR"
+			acc.account_type = "Receivable"
+			acc.insert()
+		else:
+			name = frappe.db.get_value(
+				"Account",
+				filters={"account_name": account_name, "company": self.company},
+				fieldname="name",
+				pluck=True,
+			)
+			acc = frappe.get_doc("Account", name)
+		self.debtors_eur = acc.name
 
 	def create_sales_invoice(
 		self, qty=1, rate=100, posting_date=nowdate(), do_not_save=False, do_not_submit=False
@@ -454,3 +487,56 @@ class TestPaymentReconciliation(FrappeTestCase):
 		self.assertEqual(len(pr.get("payments")), 1)
 		self.assertEqual(pr.get("invoices")[0].outstanding_amount, 20)
 		self.assertEqual(pr.get("payments")[0].amount, 20)
+
+	def test_pr_output_foreign_currency_and_amount(self):
+		# test for currency and amount invoices and payments
+		transaction_date = nowdate()
+		# In EUR
+		amount = 100
+		exchange_rate = 80
+
+		si = self.create_sales_invoice(
+			qty=1, rate=amount, posting_date=transaction_date, do_not_save=True, do_not_submit=True
+		)
+		si.customer = self.customer3
+		si.currency = "EUR"
+		si.conversion_rate = exchange_rate
+		si.debit_to = self.debtors_eur
+		si = si.save().submit()
+
+		cr_note = self.create_sales_invoice(
+			qty=-1, rate=amount, posting_date=transaction_date, do_not_save=True, do_not_submit=True
+		)
+		cr_note.customer = self.customer3
+		cr_note.is_return = 1
+		cr_note.currency = "EUR"
+		cr_note.conversion_rate = exchange_rate
+		cr_note.debit_to = self.debtors_eur
+		cr_note = cr_note.save().submit()
+
+		pr = self.create_payment_reconciliation()
+		pr.party = self.customer3
+		pr.receivable_payable_account = self.debtors_eur
+		pr.get_unreconciled_entries()
+
+		self.assertEqual(len(pr.invoices), 1)
+		self.assertEqual(len(pr.payments), 1)
+
+		self.assertEqual(pr.invoices[0].amount, amount)
+		self.assertEqual(pr.invoices[0].currency, "EUR")
+		self.assertEqual(pr.payments[0].amount, amount)
+		self.assertEqual(pr.payments[0].currency, "EUR")
+
+		cr_note.cancel()
+
+		from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
+
+		pay = get_payment_entry(si.doctype, si.name)
+		pay.references.clear()
+		pay = pay.save().submit()
+
+		pr.get_unreconciled_entries()
+		self.assertEqual(len(pr.invoices), 1)
+		self.assertEqual(len(pr.payments), 1)
+		self.assertEqual(pr.payments[0].amount, amount)
+		self.assertEqual(pr.payments[0].currency, "EUR")

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -855,8 +855,8 @@ def get_outstanding_invoices(
 	)
 
 	for d in invoice_list:
-		payment_amount = d.invoice_amount - d.outstanding
-		outstanding_amount = d.outstanding
+		payment_amount = d.invoice_amount_in_account_currency - d.outstanding_in_account_currency
+		outstanding_amount = d.outstanding_in_account_currency
 		if outstanding_amount > 0.5 / (10**precision):
 			if (
 				min_outstanding
@@ -872,7 +872,7 @@ def get_outstanding_invoices(
 							"voucher_no": d.voucher_no,
 							"voucher_type": d.voucher_type,
 							"posting_date": d.posting_date,
-							"invoice_amount": flt(d.invoice_amount),
+							"invoice_amount": flt(d.invoice_amount_in_account_currency),
 							"payment_amount": payment_amount,
 							"outstanding_amount": outstanding_amount,
 							"due_date": d.due_date,
@@ -1412,7 +1412,7 @@ def create_payment_ledger_entry(
 						if gle.against_voucher_type
 						else gle.voucher_type,
 						"against_voucher_no": gle.against_voucher if gle.against_voucher else gle.voucher_no,
-						"currency": gle.currency,
+						"account_currency": gle.account_currency,
 						"amount": dr_or_cr,
 						"amount_in_account_currency": dr_or_cr_account_currency,
 						"delinked": True if cancel else False,


### PR DESCRIPTION
## Fix
1. Incorrect `currency` field name in payment ledger entry creation
<img width="824" alt="Screenshot 2022-07-01 at 1 13 36 PM" src="https://user-images.githubusercontent.com/3272205/176849331-4cf7037d-29ee-47ff-bb2e-6e8987631b87.png">

2. Fetch outstanding amount in account currency on Payment Reconciliation Tool

| Before| After |
|--|--|
|||
| <img width="1213" alt="Screenshot 2022-07-01 at 1 08 24 PM" src="https://user-images.githubusercontent.com/3272205/176848415-6389b5e1-0f5a-4bd9-99e4-89b766af1aea.png"> | <img width="1213" alt="Screenshot 2022-07-01 at 1 09 55 PM" src="https://user-images.githubusercontent.com/3272205/176848509-f9f2082d-b71f-4e9b-a87e-134be64f1cbd.png"> |

Closes: https://github.com/frappe/erpnext/issues/31428