### PR TITLE
fix(UX): dont apply price list  when changing batch on mapped docs

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1107,9 +1107,25 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		}
 	}
 
+	is_a_mapped_document(item) {
+		const mapped_item_field_map = {
+			"Delivery Note Item": ["si_detail", "so_detail", "dn_detail"],
+			"Sales Invoice Item": ["dn_detail", "so_detail", "sales_invoice_item"],
+			"Purchase Receipt Item": ["purchase_order_item", "purchase_invoice_item", "purchase_receipt_item"],
+			"Purchase Invoice Item": ["purchase_order_item", "pr_detail", "po_detail"],
+		};
+		const mappped_fields = mapped_item_field_map[item.doctype] || [];
+
+		return mappped_fields
+			.map((field) => item[field])
+			.filter(Boolean).length > 0;
+	}
+
 	batch_no(doc, cdt, cdn) {
 		let item = frappe.get_doc(cdt, cdn);
-		this.apply_price_list(item, true);
+		if (!this.is_a_mapped_document(item)) {
+			this.apply_price_list(item, true);
+		}
 	}
 
 	toggle_conversion_factor(item) {


### PR DESCRIPTION
This PR adds a utility function to check if the transaction is a mapped document.

"mapped document" -> mapped from another transaction like SO -> DN.

In such cases batch, no change won't trigger the price list application. 


Well documented in the issues:

closes https://github.com/frappe/erpnext/issues/31468
closes https://github.com/frappe/erpnext/issues/30540 


UI tests (all green): https://github.com/erpnext/erpnext_ui_tests/actions/runs/2597164537 