### PR TITLE
fix: link error on supplier deletion

### DIFF
--- a/erpnext/buying/doctype/supplier/supplier.py
+++ b/erpnext/buying/doctype/supplier/supplier.py
@@ -127,7 +127,7 @@ class Supplier(TransactionBase):
 			self.db_set("primary_address", address_display)
 
 	def on_trash(self):
-		if self.supplier_primary_contact:
+		if self.supplier_primary_contact or self.supplier_primary_address:
 			frappe.db.sql(
 				"""
 				UPDATE `tabSupplier`


### PR DESCRIPTION
When deleting suppliers with primary address, system throws link error.
![supplier](https://user-images.githubusercontent.com/92985225/176985793-241cc436-2f7e-45b1-b37a-c95775c986ad.png)

