### PR TITLE
fix: Incorrect provisional expense booking while reposting

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -511,6 +511,7 @@ class PurchaseReceipt(BuyingController):
 				and not d.is_fixed_asset
 				and flt(d.qty)
 				and provisional_accounting_for_non_stock_items
+				and d.get("provisional_expense_account")
 			):
 				self.add_provisional_gl_entry(
 					d, gl_entries, self.posting_date, d.get("provisional_expense_account")


### PR DESCRIPTION
In cases where a single Purchase Receipt contains both stock and non-stock items is reposted provisional GL Entries with no account is posted which leads to incorrect balances in reports