### PR TITLE
chore: remove currency info from boot

### DIFF
--- a/erpnext/startup/boot.py
+++ b/erpnext/startup/boot.py
@@ -14,7 +14,6 @@ def boot_session(bootinfo):
 	if frappe.session["user"] != "Guest":
 		update_page_info(bootinfo)
 
-		load_country_and_currency(bootinfo)
 		bootinfo.sysdefaults.territory = frappe.db.get_single_value("Selling Settings", "territory")
 		bootinfo.sysdefaults.customer_group = frappe.db.get_single_value(
 			"Selling Settings", "customer_group"
@@ -51,20 +50,6 @@ def boot_session(bootinfo):
 			""" select name, ifnull(account_type, '') from `tabParty Type`"""
 		)
 		bootinfo.party_account_types = frappe._dict(party_account_types)
-
-
-def load_country_and_currency(bootinfo):
-	country = frappe.db.get_default("country")
-	if country and frappe.db.exists("Country", country):
-		bootinfo.docs += [frappe.get_doc("Country", country)]
-
-	bootinfo.docs += frappe.db.sql(
-		"""select name, fraction, fraction_units,
-		number_format, smallest_currency_fraction_value, symbol from tabCurrency
-		where enabled=1""",
-		as_dict=1,
-		update={"doctype": ":Currency"},
-	)
 
 
 def update_page_info(bootinfo):


### PR DESCRIPTION
Framework loads this info by default now, so no need to add it here.

depends on: https://github.com/frappe/frappe/pull/17405