### PR TITLE
fix: components in the same table don't get updated value of prev payment-days based component

### DIFF
--- a/erpnext/payroll/doctype/salary_slip/salary_slip.py
+++ b/erpnext/payroll/doctype/salary_slip/salary_slip.py
@@ -626,7 +626,7 @@ class SalarySlip(TransactionBase):
 		for struct_row in self._salary_structure_doc.get(component_type):
 			amount = self.eval_condition_and_formula(struct_row, data)
 			if amount is not None and struct_row.statistical_component == 0:
-				self.update_component_row(struct_row, amount, component_type)
+				self.update_component_row(struct_row, amount, component_type, data=data)
 
 	def get_data_for_eval(self):
 		"""Returns data for evaluating formula"""
@@ -780,7 +780,7 @@ class SalarySlip(TransactionBase):
 			self.update_component_row(tax_row, tax_amount, "deductions")
 
 	def update_component_row(
-		self, component_data, amount, component_type, additional_salary=None, is_recurring=0
+		self, component_data, amount, component_type, additional_salary=None, is_recurring=0, data=None
 	):
 		component_row = None
 		for d in self.get(component_type):
@@ -850,6 +850,8 @@ class SalarySlip(TransactionBase):
 		component_row.amount = amount
 
 		self.update_component_amount_based_on_payment_days(component_row)
+		if data:
+			data[component_row.abbr] = component_row.amount
 
 	def update_component_amount_based_on_payment_days(self, component_row):
 		joining_date, relieving_date = self.get_joining_and_relieving_dates()

--- a/erpnext/payroll/doctype/salary_slip/test_salary_slip.py
+++ b/erpnext/payroll/doctype/salary_slip/test_salary_slip.py
@@ -1119,6 +1119,7 @@ def make_earning_salary_component(
 			"formula": "BS*.5",
 			"type": "Earning",
 			"amount_based_on_formula": 1,
+			"depends_on_payment_days": 0,
 		},
 		{"salary_component": "Leave Encashment", "abbr": "LE", "type": "Earning"},
 	]


### PR DESCRIPTION
## Steps to Replicate

- Salary Component Basic has "Depends on Payment Days" enabled.
- Salary Component Bonus (which is in the same table: earnings) is dependent on this component by formula.

	<img width="1122" alt="salary-struc" src="https://user-images.githubusercontent.com/24353136/177205348-49082465-cb40-41ae-9d99-e8c67518a11a.png">
- Salary Slip with 6 LWP. 
	As per the formula `1249.5 if (B>=MBS) else (B * .0833)` the Bonus amount should be 
	`(B * 0.0833) = 12096.77 * 0.0833 = 1008.0  `
	since `B(12096.77) >= MBS(15000)` is false.
- But the amount is 1250 because the Bonus formula is not getting the updated value of Basic (12096.77). It is using the old basic amount = 15000. 
	
	<img width="1122" alt="bonus" src="https://user-images.githubusercontent.com/24353136/177205605-41969888-2e16-4868-bfb3-be577a3ed45b.png">

- This works fine if a component in another table is referring to a component in the current table. i.e if deductions component is dependent on earnings component by formula. But doesn't work if components from the same table are dependent. This is because, after processing earnings, the `get_data_for_eval` is called again for fetching all salary component's updated values. 

## Fix

- All formulae calculation uses `data` which has values for all the salary components to evaluate the amount. Once the amount is changed as per payment days, update the amount in `data` too, so that other components get the updated value.

<img width="1122" alt="bonus-recalculated" src="https://user-images.githubusercontent.com/24353136/177247291-a7bed4fd-cdaf-4027-8ddc-1189516d5679.png">

- Added validation for the scenario mentioned in: https://github.com/frappe/erpnext/pull/31521#issuecomment-1174598298

	<img width="1317" alt="image" src="https://user-images.githubusercontent.com/24353136/178420899-08451d4b-3ff9-4588-988c-bcaa0d6bafa4.png">
