### PR TITLE
fix: test case

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -1243,7 +1243,7 @@ class TestWorkOrder(FrappeTestCase):
 		ste_doc.insert()
 		ste_doc.submit()
 
-		batch_list = [row.batch_no for row in ste_doc.items]
+		batch_list = sorted([row.batch_no for row in ste_doc.items])
 
 		wo_doc = make_wo_order_test_record(production_item=fg_item, qty=4)
 		transferred_ste_doc = frappe.get_doc(

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -1661,7 +1661,8 @@ class StockEntry(StockController):
 				qty = frappe.utils.ceil(qty)
 
 			if row.batch_details:
-				for batch_no, batch_qty in row.batch_details.items():
+				batches = sorted(row.batch_details.items(), key=lambda x: x[0])
+				for batch_no, batch_qty in batches:
 					if qty <= 0 or batch_qty <= 0:
 						continue
 


### PR DESCRIPTION
```
 FAIL  test_backflushed_batch_raw_materials_based_on_transferred (erpnext.manufacturing.doctype.work_order.test_work_order.TestWorkOrder)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/manufacturing/doctype/work_order/test_work_order.py", line 1268, in test_backflushed_batch_raw_materials_based_on_transferred
    self.assertEqual(manufacture_ste_doc1.items[0].batch_no, batch_list[0])
    batch_item = 'Test Batch MCC Keyboard'
    batch_list = ['TBMK00001', 'TBMK00002']
    fg_item = 'Test FG Item with Batch Raw Materials'
    manufacture_ste_doc1 = <StockEntry: unsaved>
    new_row = <StockEntryDetail: 0e18516361 docstatus=1 parent=MAT-STE-2022-00040>
    self = <erpnext.manufacturing.doctype.work_order.test_work_order.TestWorkOrder testMethod=test_backflushed_batch_raw_materials_based_on_transferred>
    ste_doc = <StockEntry: MAT-STE-2022-00039 docstatus=1>
    transferred_ste_doc = <StockEntry: MAT-STE-2022-00040 docstatus=1>
    wo_doc = <WorkOrder: MFG-WO-2022-00001 docstatus=1>
AssertionError: 'TBMK00002' != 'TBMK00001'
- TBMK00002
?         ^
+ TBMK00001
?         ^
```