### PR TITLE
fix: Use fallback conversion factor while setting incoming rate for petty purchase

### DIFF
--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -300,7 +300,7 @@ class BuyingController(StockController, Subcontracting):
 						raise_error_if_no_rate=False,
 					)
 
-					rate = flt(outgoing_rate * d.conversion_factor, d.precision("rate"))
+					rate = flt(outgoing_rate * (d.conversion_factor or 1), d.precision("rate"))
 				else:
 					rate = frappe.db.get_value(ref_doctype, d.get(frappe.scrub(ref_doctype)), "rate")
 


### PR DESCRIPTION
- Purchase Invoices for petty items (that do not need an Item record) are allowed using Item Name field
- If a different UOM (different from stock UOM) is used in this case, conversion factor stays 0 and causes an error
```py
 File "apps/erpnext/erpnext/controllers/buying_controller.py", line 33, in validate
    super(BuyingController, self).validate()
  File "apps/erpnext/erpnext/controllers/stock_controller.py", line 38, in validate
    super(StockController, self).validate()
  File "apps/erpnext/erpnext/controllers/accounts_controller.py", line 155, in validate
    self.set_incoming_rate()
  File "apps/erpnext/erpnext/controllers/buying_controller.py", line 302, in set_incoming_rate
    rate = flt(outgoing_rate * d.conversion_factor, d.precision("rate"))
TypeError: unsupported operand type(s) for *: 'float' and 'NoneType'
```

**Fix:**
- Fallback to 1 as conversion factor in `set_incoming_rate` for buying
- Selling will need a proper item, so this change is not needed there

