### PR TITLE
fix: Set the condition to create a purchase receipt

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -539,7 +539,7 @@ frappe.ui.form.on("Purchase Invoice", {
 	},
 
 	add_custom_buttons: function(frm) {
-		if (frm.doc.per_received < 100) {
+		if (frm.doc.docstatus == 1 && frm.doc.per_received < 100) {
 			frm.add_custom_button(__('Purchase Receipt'), () => {
 				frm.events.make_purchase_receipt(frm);
 			}, __('Create'));


### PR DESCRIPTION
**`Version`**
ERPNext: v14.x.x-develop () (develop)
Frappe Framework: v14.x.x-develop () (develop)

- Please also update version 13

**Before:**
- When creating the purchase invoice and saving it on the draft stage, the purchase receipt option show in create button and when clicking on the purchase receipt then error show like Cannot map because following condition fails: docstatus=1


https://user-images.githubusercontent.com/99652762/177368522-d93f5122-a889-4411-83de-e088857ec9f3.mp4

**After:**
- After developing the purchase_invoice.js file, the purchase receipt option will not show in the draft stage.
- Only will show when you submit the purchase invoice.


https://user-images.githubusercontent.com/99652762/177369469-3543d582-fb15-4e8f-ab4a-aa8e734d3d3f.mp4

If convenient for the changes then go ahead with the process.

Thank You!