### PR TITLE
fix: Maintain backward compatibility with older bench versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # TODO: Remove this file when  v15.0.0 is released
 from setuptools import setup
 
-name = "frappe"
+name = "erpnext"
 
 setup()


### PR DESCRIPTION
Older versions of bench depend on `name` in setup.py

Setting it to `frappe` causes some weird behavior like moving `apps/erpnext` to `apps/frappe`

And thanks to our error reporting
```
bench get-app erpnext
```
~~fails~~ passes without any error message
```shell
Getting erpnext
$ git clone https://github.com/frappe/erpnext  --depth 1 --origin upstream
Cloning into 'erpnext'...
INFO: A newer version of bench is available: 5.2.1 → 5.12.1
```