### PR TITLE
refactor: department creation

### DIFF
--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -10,8 +10,9 @@ from frappe import _
 from frappe.cache_manager import clear_defaults_cache
 from frappe.contacts.address_and_contact import load_address_and_contact
 from frappe.custom.doctype.property_setter.property_setter import make_property_setter
+from frappe.desk.page.setup_wizard.setup_wizard import make_records
 from frappe.utils import cint, formatdate, get_timestamp, today
-from frappe.utils.nestedset import NestedSet
+from frappe.utils.nestedset import NestedSet, rebuild_tree
 
 from erpnext.accounts.doctype.account.account import get_account_currency
 from erpnext.setup.setup_wizard.operations.taxes_setup import setup_taxes_and_charges
@@ -150,9 +151,7 @@ class Company(NestedSet):
 			self.create_default_tax_template()
 
 		if not frappe.db.get_value("Department", {"company": self.name}):
-			from erpnext.setup.setup_wizard.operations.install_fixtures import install_post_company_fixtures
-
-			install_post_company_fixtures(frappe._dict({"company_name": self.name}))
+			self.create_default_departments()
 
 		if not frappe.local.flags.ignore_chart_of_accounts:
 			self.set_default_accounts()
@@ -223,6 +222,104 @@ class Company(NestedSet):
 				"Account", {"company": self.name, "account_type": "Payable", "is_group": 0}
 			),
 		)
+
+	def create_default_departments(self):
+		records = [
+			# Department
+			{
+				"doctype": "Department",
+				"department_name": _("All Departments"),
+				"is_group": 1,
+				"parent_department": "",
+				"__condition": lambda: not frappe.db.exists("Department", _("All Departments")),
+			},
+			{
+				"doctype": "Department",
+				"department_name": _("Accounts"),
+				"parent_department": _("All Departments"),
+				"company": self.name,
+			},
+			{
+				"doctype": "Department",
+				"department_name": _("Marketing"),
+				"parent_department": _("All Departments"),
+				"company": self.name,
+			},
+			{
+				"doctype": "Department",
+				"department_name": _("Sales"),
+				"parent_department": _("All Departments"),
+				"company": self.name,
+			},
+			{
+				"doctype": "Department",
+				"department_name": _("Purchase"),
+				"parent_department": _("All Departments"),
+				"company": self.name,
+			},
+			{
+				"doctype": "Department",
+				"department_name": _("Operations"),
+				"parent_department": _("All Departments"),
+				"company": self.name,
+			},
+			{
+				"doctype": "Department",
+				"department_name": _("Production"),
+				"parent_department": _("All Departments"),
+				"company": self.name,
+			},
+			{
+				"doctype": "Department",
+				"department_name": _("Dispatch"),
+				"parent_department": _("All Departments"),
+				"company": self.name,
+			},
+			{
+				"doctype": "Department",
+				"department_name": _("Customer Service"),
+				"parent_department": _("All Departments"),
+				"company": self.name,
+			},
+			{
+				"doctype": "Department",
+				"department_name": _("Human Resources"),
+				"parent_department": _("All Departments"),
+				"company": self.name,
+			},
+			{
+				"doctype": "Department",
+				"department_name": _("Management"),
+				"parent_department": _("All Departments"),
+				"company": self.name,
+			},
+			{
+				"doctype": "Department",
+				"department_name": _("Quality Management"),
+				"parent_department": _("All Departments"),
+				"company": self.name,
+			},
+			{
+				"doctype": "Department",
+				"department_name": _("Research & Development"),
+				"parent_department": _("All Departments"),
+				"company": self.name,
+			},
+			{
+				"doctype": "Department",
+				"department_name": _("Legal"),
+				"parent_department": _("All Departments"),
+				"company": self.name,
+			},
+		]
+
+		# Make root department with NSM updation
+		make_records(records[:1])
+
+		frappe.local.flags.ignore_update_nsm = True
+		make_records(records)
+		frappe.local.flags.ignore_update_nsm = False
+		rebuild_tree("Department", "parent_department")
 
 	def validate_coa_input(self):
 		if self.create_chart_of_accounts_based_on == "Existing Company":

--- a/erpnext/setup/setup_wizard/operations/install_fixtures.py
+++ b/erpnext/setup/setup_wizard/operations/install_fixtures.py
@@ -12,7 +12,6 @@ from frappe.desk.doctype.global_search_settings.global_search_settings import (
 )
 from frappe.desk.page.setup_wizard.setup_wizard import make_records
 from frappe.utils import cstr, getdate
-from frappe.utils.nestedset import rebuild_tree
 
 from erpnext.accounts.doctype.account.account import RootNotEditable
 from erpnext.regional.address_template.setup import set_up_address_templates
@@ -654,104 +653,6 @@ def install_company(args):
 	]
 
 	make_records(records)
-
-
-def install_post_company_fixtures(args=None):
-	records = [
-		# Department
-		{
-			"doctype": "Department",
-			"department_name": _("All Departments"),
-			"is_group": 1,
-			"parent_department": "",
-		},
-		{
-			"doctype": "Department",
-			"department_name": _("Accounts"),
-			"parent_department": _("All Departments"),
-			"company": args.company_name,
-		},
-		{
-			"doctype": "Department",
-			"department_name": _("Marketing"),
-			"parent_department": _("All Departments"),
-			"company": args.company_name,
-		},
-		{
-			"doctype": "Department",
-			"department_name": _("Sales"),
-			"parent_department": _("All Departments"),
-			"company": args.company_name,
-		},
-		{
-			"doctype": "Department",
-			"department_name": _("Purchase"),
-			"parent_department": _("All Departments"),
-			"company": args.company_name,
-		},
-		{
-			"doctype": "Department",
-			"department_name": _("Operations"),
-			"parent_department": _("All Departments"),
-			"company": args.company_name,
-		},
-		{
-			"doctype": "Department",
-			"department_name": _("Production"),
-			"parent_department": _("All Departments"),
-			"company": args.company_name,
-		},
-		{
-			"doctype": "Department",
-			"department_name": _("Dispatch"),
-			"parent_department": _("All Departments"),
-			"company": args.company_name,
-		},
-		{
-			"doctype": "Department",
-			"department_name": _("Customer Service"),
-			"parent_department": _("All Departments"),
-			"company": args.company_name,
-		},
-		{
-			"doctype": "Department",
-			"department_name": _("Human Resources"),
-			"parent_department": _("All Departments"),
-			"company": args.company_name,
-		},
-		{
-			"doctype": "Department",
-			"department_name": _("Management"),
-			"parent_department": _("All Departments"),
-			"company": args.company_name,
-		},
-		{
-			"doctype": "Department",
-			"department_name": _("Quality Management"),
-			"parent_department": _("All Departments"),
-			"company": args.company_name,
-		},
-		{
-			"doctype": "Department",
-			"department_name": _("Research & Development"),
-			"parent_department": _("All Departments"),
-			"company": args.company_name,
-		},
-		{
-			"doctype": "Department",
-			"department_name": _("Legal"),
-			"parent_department": _("All Departments"),
-			"company": args.company_name,
-		},
-	]
-
-	# Make root department with NSM updation
-	make_records(records[:1])
-
-	frappe.local.flags.ignore_update_nsm = True
-	make_records(records[1:])
-	frappe.local.flags.ignore_update_nsm = False
-	rebuild_tree("Department", "parent_department")
 
 
 def install_defaults(args=None):


### PR DESCRIPTION
- all department creation always fails after first company, this is
handled in exception handling code but better to not attempt this in
first place.
- move department creation to company.py; this has nothing to do with
  setup and previous function signature made no sense.




This eliminates the misleading error message in CI:

```
Traceback (most recent call last):
  File "apps/frappe/frappe/desk/page/setup_wizard/setup_wizard.py", line 437, in make_records
    doc.insert(ignore_permissions=True, ignore_if_duplicate=True)
  File "apps/frappe/frappe/model/document.py", line 278, in insert
    self.run_post_save_methods()
  File "apps/frappe/frappe/model/document.py", line 1084, in run_post_save_methods
    self.run_method("on_update")
  File "apps/frappe/frappe/model/document.py", line 925, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1263, in composer
    return composed(self, method, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1245, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "apps/frappe/frappe/model/document.py", line 9[22](https://github.com/frappe/erpnext/runs/7226846518?check_suite_focus=true#step:12:23), in fn
    return method_object(*args, **kwargs)
  File "apps/erpnext/erpnext/hr/doctype/department/department.py", line 36, in on_update
    super(Department, self).on_update()
  File "apps/frappe/frappe/utils/nestedset.py", line 246, in on_update
    update_nsm(self)
  File "apps/frappe/frappe/utils/nestedset.py", line 55, in update_nsm
    update_add_node(doc, parent or "", parent_field)
  File "apps/frappe/frappe/utils/nestedset.py", line 77, in update_add_node
    validate_loop(doc.doctype, doc.name, left, right)
  File "apps/frappe/frappe/utils/nestedset.py", line [23](https://github.com/frappe/erpnext/runs/7226846518?check_suite_focus=true#step:12:24)7, in validate_loop
    frappe.throw(_("Item cannot be added to its own descendents"), NestedSetRecursionError)
  File "apps/frappe/frappe/__init__.py", line 516, in throw
    msgprint(
  File "apps/frappe/frappe/__init__.py", line 484, in msgprint
    _raise_exception()
  File "apps/frappe/frappe/__init__.py", line 4[36](https://github.com/frappe/erpnext/runs/7226846518?check_suite_focus=true#step:12:37), in _raise_exception
    raise raise_exception(msg)
frappe.utils.nestedset.NestedSetRecursionError: Item cannot be added to its own descendents
```