### PR TITLE
test: don't silently fail reposts in tests

### DIFF
--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
@@ -138,6 +138,11 @@ def repost(doc):
 		doc.set_status("Completed")
 
 	except Exception as e:
+		if frappe.flags.in_test:
+			# Don't silently fail in tests,
+			# there is no reason for reposts to fail in CI
+			raise
+
 		frappe.db.rollback()
 		traceback = frappe.get_traceback()
 		doc.log_error("Unable to repost item valuation")


### PR DESCRIPTION
Because of this silent rollback and exception handling, it's difficult to debug what's actually failing. 


Discovered while debugging https://github.com/frappe/frappe/pull/17350 where some generated query is invalid but no proper exception is raised. 