### PR TITLE
fix: Maintain Stock Value

### DIFF
--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -958,13 +958,13 @@ class Item(Document):
 				):
 					return linked_doc
 
-			elif linked_doc := frappe.db.get_value(
-				doctype,
-				filters,
-				["parent as docname", "parenttype as doctype"],
-				as_dict=True,
-			):
-				return linked_doc
+				elif linked_doc := frappe.db.get_value(
+					doctype,
+					filters,
+					["parent as docname", "parenttype as doctype"],
+					as_dict=True,
+				):
+					return linked_doc
 
 	def validate_auto_reorder_enabled_in_stock_settings(self):
 		if self.reorder_levels:

--- a/erpnext/stock/doctype/item/test_item.py
+++ b/erpnext/stock/doctype/item/test_item.py
@@ -778,6 +778,22 @@ class TestItem(FrappeTestCase):
 			item.has_batch_no = 1
 			item.save()
 
+	def test_update_is_stock_item(self):
+		# Step - 1: Create an Item
+		item = make_item(properties={"is_stock_item": 1})
+
+		# Step - 2: Set is_stock_item = 0
+		item.is_stock_item = 0
+		item.save()
+		item.reload()
+		self.assertEqual(item.is_stock_item, 0)
+
+		# Step - 3: Again set is_stock_item = 1
+		item.is_stock_item = 1
+		item.save()
+		item.reload()
+		self.assertEqual(item.is_stock_item, 1)
+
 
 def set_item_variant_settings(fields):
 	doc = frappe.get_doc("Item Variant Settings")


### PR DESCRIPTION
**`Version`**
ERPNext: v14.x.x-develop () (develop)
Frappe Framework: v14.x.x-develop () (develop)

**Before:**

- In Item doctype, when Maintain Stock checked to unchecked then an error show like
```
pymysql.err.OperationalError: (1054, "Unknown column 'parent' in 'field list'")
```

https://user-images.githubusercontent.com/99652762/178058194-6fd0546b-f7b5-471e-a993-5af6613f9472.mp4



**After:**
- If condition and after elif condition is not set properly then set it via tab.

https://user-images.githubusercontent.com/99652762/178058259-100b7e92-7455-4fe6-8807-bba8831139ae.mp4


Thank You!