### PR TITLE
fix: Allow multi currency invoice against single party account

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -18,6 +18,7 @@
   "automatically_fetch_payment_terms",
   "column_break_17",
   "enable_common_party_accounting",
+  "allow_multi_currency_invoices_against_single_party_account",
   "report_setting_section",
   "use_custom_cash_flow",
   "deferred_accounting_settings_section",
@@ -339,6 +340,13 @@
    "fieldname": "report_setting_section",
    "fieldtype": "Section Break",
    "label": "Report Setting"
+  },
+  {
+   "default": "0",
+   "description": "Enabling this will allow creation of multi-currency invoices against single party account in company currency",
+   "fieldname": "allow_multi_currency_invoices_against_single_party_account",
+   "fieldtype": "Check",
+   "label": "Allow multi-currency invoices against single party account "
   }
  ],
  "icon": "icon-cog",
@@ -346,7 +354,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2022-04-08 14:45:06.796418",
+ "modified": "2022-07-11 13:37:50.605141",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounts Settings",

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1472,7 +1472,7 @@ class AccountsController(TransactionBase):
 			self.get("debit_to") if self.doctype == "Sales Invoice" else self.get("credit_to")
 		)
 		party_account_currency = get_account_currency(party_account)
-		allow_multi_currency_invoices_against_single_party_account = frappe.get_single_value(
+		allow_multi_currency_invoices_against_single_party_account = frappe.db.get_singles_value(
 			"Accounts Settings", "allow_multi_currency_invoices_against_single_party_account"
 		)
 

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1472,8 +1472,15 @@ class AccountsController(TransactionBase):
 			self.get("debit_to") if self.doctype == "Sales Invoice" else self.get("credit_to")
 		)
 		party_account_currency = get_account_currency(party_account)
+		allow_multi_currency_invoices_against_single_party_account = frappe.get_single_value(
+			"Accounts Settings", "allow_multi_currency_invoices_against_single_party_account"
+		)
 
-		if not party_gle_currency and (party_account_currency != self.currency):
+		if (
+			not party_gle_currency
+			and (party_account_currency != self.currency)
+			and not allow_multi_currency_invoices_against_single_party_account
+		):
 			frappe.throw(
 				_("Party Account {0} currency ({1}) and document currency ({2}) should be same").format(
 					frappe.bold(party_account), party_account_currency, self.currency


### PR DESCRIPTION
A validation was introduced in this https://github.com/frappe/erpnext/pull/26916, some users don't view reports in Party's billing currency and are okay with the exchange rate differences in the reports. Such users who are aware of the effects of using a single account for multicurrency and are okay with it can enable this and use one single account for multicurrency

By default, this has been kept disabled so that unaware users don't end up using the same account for multicurrency invoices.

<img width="1362" alt="Screenshot 2022-07-11 at 1 38 05 PM" src="https://user-images.githubusercontent.com/42651287/178218998-6f61a43b-08d3-4938-b265-362d263d71d5.png">
