### PR TITLE
fix: prevent picked qty getting set as previous items picked qty.

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -182,8 +182,9 @@ class PickList(Document):
 			if not item.item_code:
 				frappe.throw("Row #{0}: Item Code is Mandatory".format(item.idx))
 			item_code = item.item_code
+			warehouse = item.warehouse
 			reference = item.sales_order_item or item.material_request_item
-			key = (item_code, item.uom, reference)
+			key = (item_code, warehouse, item.uom, reference)
 
 			item.idx = None
 			item.name = None

--- a/erpnext/stock/doctype/pick_list/test_pick_list.py
+++ b/erpnext/stock/doctype/pick_list/test_pick_list.py
@@ -128,15 +128,19 @@ class TestPickList(FrappeTestCase):
 			}
 		)
 
+		pick_list.locations[0].picked_qty = 1
+
 		pick_list.set_item_locations()
 
 		self.assertEqual(pick_list.locations[0].item_code, "_Test Item Warehouse Group Wise Reorder")
 		self.assertEqual(pick_list.locations[0].warehouse, "_Test Warehouse Group-C1 - _TC")
 		self.assertEqual(pick_list.locations[0].qty, 5)
+		self.assertEqual(pick_list.locations[0].picked_qty, 1)
 
 		self.assertEqual(pick_list.locations[1].item_code, "_Test Item Warehouse Group Wise Reorder")
 		self.assertEqual(pick_list.locations[1].warehouse, "_Test Warehouse 2 - _TC")
 		self.assertEqual(pick_list.locations[1].qty, 10)
+		self.assertEqual(pick_list.locations[1].picked_qty, 0)
 
 	def test_pick_list_shows_serial_no_for_serialized_item(self):
 

--- a/erpnext/stock/doctype/pick_list/test_pick_list.py
+++ b/erpnext/stock/doctype/pick_list/test_pick_list.py
@@ -128,8 +128,8 @@ class TestPickList(FrappeTestCase):
 			}
 		)
 
+		pick_list.set_item_locations()
 		pick_list.locations[0].picked_qty = 1
-
 		pick_list.set_item_locations()
 
 		self.assertEqual(pick_list.locations[0].item_code, "_Test Item Warehouse Group Wise Reorder")


### PR DESCRIPTION
**Before PR**
![picked qty before](https://user-images.githubusercontent.com/29856401/178560087-795b1c43-079a-47e2-bec0-f266060a3f65.gif)


**After PR**
![picked qty after](https://user-images.githubusercontent.com/29856401/178560117-93326be2-8ade-4f5a-8644-63696e6c3ad5.gif)

