### PR TITLE
feat: rearrange fields in Leave Application

### DIFF
--- a/erpnext/hr/doctype/leave_application/leave_application.js
+++ b/erpnext/hr/doctype/leave_application/leave_application.js
@@ -147,12 +147,18 @@ frappe.ui.form.on("Leave Application", {
 		frm.trigger("make_dashboard");
 		frm.trigger("half_day_datepicker");
 		frm.trigger("calculate_total_days");
+		frm.fields_dict.to_date.datepicker.update({
+			minDate: frm.doc.from_date ? new Date(frm.doc.from_date) : null
+		});
 	},
 
 	to_date: function(frm) {
 		frm.trigger("make_dashboard");
 		frm.trigger("half_day_datepicker");
 		frm.trigger("calculate_total_days");
+		frm.fields_dict.from_date.datepicker.update({
+			maxDate: frm.doc.to_date ? new Date(frm.doc.to_date) : null
+		});
 	},
 
 	half_day_date(frm) {

--- a/erpnext/hr/doctype/leave_application/leave_application.js
+++ b/erpnext/hr/doctype/leave_application/leave_application.js
@@ -1,9 +1,6 @@
 // Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 // License: GNU General Public License v3. See license.txt
 
-cur_frm.add_fetch('employee', 'employee_name', 'employee_name');
-cur_frm.add_fetch('employee', 'company', 'company');
-
 frappe.ui.form.on("Leave Application", {
 	setup: function(frm) {
 		frm.set_query("leave_approver", function() {
@@ -16,7 +13,14 @@ frappe.ui.form.on("Leave Application", {
 			};
 		});
 
-		frm.set_query("employee", erpnext.queries.employee);
+		frm.set_query("employee", function(doc) {
+			return {
+				query: "erpnext.controllers.queries.employee_query",
+				filters: {
+					company: doc.company,
+				},
+			};
+		});
 	},
 	onload: function(frm) {
 		// Ignore cancellation of doctype on cancel all.

--- a/erpnext/hr/doctype/leave_application/leave_application.json
+++ b/erpnext/hr/doctype/leave_application/leave_application.json
@@ -9,34 +9,34 @@
  "engine": "InnoDB",
  "field_order": [
   "naming_series",
+  "company",
   "employee",
   "employee_name",
   "column_break_4",
+  "posting_date",
   "leave_type",
   "department",
-  "leave_balance",
+  "color",
   "section_break_5",
   "from_date",
   "to_date",
+  "description",
+  "column_break1",
+  "leave_balance",
+  "total_leave_days",
   "half_day",
   "half_day_date",
-  "total_leave_days",
-  "column_break1",
-  "description",
   "section_break_7",
   "leave_approver",
   "leave_approver_name",
   "column_break_18",
   "status",
-  "salary_slip",
   "sb10",
-  "posting_date",
-  "follow_via_email",
-  "color",
-  "column_break_17",
-  "company",
   "letter_head",
-  "amended_from"
+  "salary_slip",
+  "amended_from",
+  "column_break_17",
+  "follow_via_email"
  ],
  "fields": [
   {
@@ -60,6 +60,7 @@
    "search_index": 1
   },
   {
+   "fetch_from": "employee.employee_name",
    "fieldname": "employee_name",
    "fieldtype": "Data",
    "in_global_search": 1,
@@ -190,12 +191,10 @@
    "reqd": 1
   },
   {
-   "fetch_from": "employee.company",
    "fieldname": "company",
    "fieldtype": "Link",
    "label": "Company",
    "options": "Company",
-   "read_only": 1,
    "remember_last_selected_value": 1,
    "reqd": 1
   },
@@ -229,6 +228,8 @@
   },
   {
    "allow_on_submit": 1,
+   "fetch_from": "leave_type.color",
+   "fetch_if_empty": 1,
    "fieldname": "color",
    "fieldtype": "Color",
    "label": "Color",
@@ -250,10 +251,11 @@
  "is_submittable": 1,
  "links": [],
  "max_attachments": 3,
- "modified": "2020-05-18 13:00:41.577327",
+ "modified": "2022-07-12 20:51:09.229245",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Leave Application",
+ "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
  "permissions": [
   {
@@ -333,6 +335,7 @@
  "search_fields": "employee,employee_name,leave_type,from_date,to_date,total_leave_days",
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "timeline_field": "employee",
  "title_field": "employee_name"
 }

--- a/erpnext/hr/doctype/leave_type/leave_type.json
+++ b/erpnext/hr/doctype/leave_type/leave_type.json
@@ -12,6 +12,7 @@
   "max_leaves_allowed",
   "applicable_after",
   "max_continuous_days_allowed",
+  "color",
   "column_break_3",
   "is_carry_forward",
   "is_lwp",
@@ -219,12 +220,17 @@
    "fieldname": "allow_over_allocation",
    "fieldtype": "Check",
    "label": "Allow Over Allocation"
+  },
+  {
+   "fieldname": "color",
+   "fieldtype": "Color",
+   "label": "Color"
   }
  ],
  "icon": "fa fa-flag",
  "idx": 1,
  "links": [],
- "modified": "2022-05-09 05:01:38.957545",
+ "modified": "2022-07-12 20:26:48.158102",
  "modified_by": "Administrator",
  "module": "HR",
  "name": "Leave Type",


### PR DESCRIPTION
- Add color to **Leave Type**
- Fetch color from **Leave Type** into **Leave Application**, leading to a useful calendar view

    ![Bildschirmfoto 2022-07-12 um 20 52 50](https://user-images.githubusercontent.com/14891507/178574004-3ba5cabc-323d-4094-a19e-11a14380d6ad.png)

- Invert logic

    - before: select from all employees, fetch company
    - after: select company (pre-filled), select from filtered employees

- Move mandatory fields towards the top and "calculated" fields towards the right

    ![Bildschirmfoto 2022-07-12 um 20 52 33](https://user-images.githubusercontent.com/14891507/178574145-cd79b746-49c5-4fbe-92a9-1f00d28736c5.png)

- toggle valid date range on other field, when setting `from_date` or `to_date`

    https://user-images.githubusercontent.com/14891507/178597225-bb6292cf-66ac-4232-9a97-01a35a804f87.mov



