### PR TITLE
[ branch mistake ] fix: (india) (e-invoice) CN / DN with 0 qty

### DIFF
--- a/erpnext/regional/india/e_invoice/utils.py
+++ b/erpnext/regional/india/e_invoice/utils.py
@@ -276,7 +276,18 @@ def get_item_list(invoice):
 		if invoice.get("apply_discount_on"):
 			item.discount_amount = item.base_amount - item.base_net_amount
 
-		item.unit_rate = abs(item.taxable_value - item.discount_amount) / item.qty
+		if (invoice.get("is_return") or invoice.get("is_debit_note")):
+			item.unit_rate = abs(item.taxable_value - item.discount_amount) / ( 1 if (item.qty == 0) else item.qty )
+		else:
+			try:
+				item.unit_rate = abs(item.taxable_value - item.discount_amount) / item.qty
+			except ZeroDivisionError:
+				# This will never run but added as safety measure
+				frappe.throw(
+					title="Error: Qty is Zero",
+					msg="Quantity can't be zero unless it's Credit/Debit Note.",
+				)
+
 
 		item.gross_amount = abs(item.taxable_value) + item.discount_amount
 		item.taxable_value = abs(item.taxable_value)


### PR DESCRIPTION
Qty 0 is allowed when creating Credit or Debit Note this caused ZeroDivisionError during unit_rate calculation.
fixed the issue by adding required conditionals.