### PR TITLE
fix: picking list picked_qty cannot be greater than stock_qty

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -48,6 +48,13 @@ class PickList(Document):
 					).format(item.idx, item.stock_qty - item.picked_qty, item.stock_uom),
 					title=_("Pick List Incomplete"),
 				)
+			elif item.picked_qty > item.stock_qty:
+				frappe.throw(
+					_(
+						"Row {0} picked quantity is greater than the required quantity of {1} {2}."
+					).format(item.idx, item.stock_qty, item.stock_uom),
+					title=_("Pick List Over Picked")
+				)
 			elif not self.scan_mode and item.picked_qty == 0:
 				# if the user has not entered any picked qty, set it to stock_qty, before submit
 				item.picked_qty = item.stock_qty

--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -50,10 +50,10 @@ class PickList(Document):
 				)
 			elif item.picked_qty > item.stock_qty:
 				frappe.throw(
-					_(
-						"Row {0} picked quantity is greater than the required quantity of {1} {2}."
-					).format(item.idx, item.stock_qty, item.stock_uom),
-					title=_("Pick List Over Picked")
+					_("Row {0} picked quantity is greater than the required quantity of {1} {2}.").format(
+						item.idx, item.stock_qty, item.stock_uom
+					),
+					title=_("Pick List Over Picked"),
 				)
 			elif not self.scan_mode and item.picked_qty == 0:
 				# if the user has not entered any picked qty, set it to stock_qty, before submit

--- a/erpnext/stock/doctype/pick_list/test_pick_list.py
+++ b/erpnext/stock/doctype/pick_list/test_pick_list.py
@@ -665,8 +665,12 @@ class TestPickList(FrappeTestCase):
 		pick_list = create_pick_list(so.name)
 
 		pick_list.scan_mode = 0
-		pick_list.submit()
 
+		pick_list.locations[0].picked_qty = so_qty + 1
+		self.assertRaises(frappe.ValidationError, pick_list.submit)
+
+		pick_list.locations[0].picked_qty = 0
+		pick_list.submit()
 		self.assertEqual(pick_list.locations[0].picked_qty, so_qty)
 
 	def test_picked_qty_scan_mode(self):

--- a/erpnext/stock/doctype/pick_list/test_pick_list.py
+++ b/erpnext/stock/doctype/pick_list/test_pick_list.py
@@ -658,3 +658,24 @@ class TestPickList(FrappeTestCase):
 		self.assertEqual(dn.items[0].rate, 42)
 		so.reload()
 		self.assertEqual(so.per_delivered, 100)
+
+	def test_picked_qty_non_scan_mode(self):
+		so = make_sales_order()
+		so_qty = so.items[0].qty
+		pick_list = create_pick_list(so.name)
+
+		pick_list.scan_mode = 0
+		pick_list.submit()
+
+		self.assertEqual(pick_list.locations[0].picked_qty, so_qty)
+
+	def test_picked_qty_scan_mode(self):
+		so = make_sales_order()
+		so_qty = so.items[0].qty
+		pick_list = create_pick_list(so.name)
+
+		pick_list.scan_mode = 1
+		self.assertRaises(frappe.ValidationError, pick_list.submit)
+
+		pick_list.locations[0].picked_qty = so_qty
+		pick_list.submit()


### PR DESCRIPTION
This PR adds a validation that will ensure user doesn't pick more than the required qty.