### PR TITLE
fix: Make Payment via Journal / Payment Entry

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -100,7 +100,7 @@
    "default": "0",
    "fieldname": "make_payment_via_journal_entry",
    "fieldtype": "Check",
-   "hidden": 1,
+   "hidden": 0,
    "label": "Make Payment via Journal Entry"
   },
   {
@@ -354,7 +354,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2022-07-11 13:37:50.605141",
+ "modified": "2022-07-13 11:07:50.015478",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounts Settings",


### PR DESCRIPTION
**`Version`**
ERPNext: v14.x.x-develop () (develop)
Frappe Framework: v14.x.x-develop () (develop)

**Before:**
- Make Payment via Journal Entry does not show in Accounts Setting because it's is hide from Accounts Setting.
![image](https://user-images.githubusercontent.com/34390782/178951119-472bd103-5dc1-42b7-8399-00590b41ce2c.png)




**After:**
- Remove hide option in Make Payment via Journal Entry from Accounts Setting.
![image](https://user-images.githubusercontent.com/34390782/178951698-f18a4d62-46a6-4d10-b491-d9be5cd68e25.png)


Thank You!