### PR TITLE
fix: Opening Invoice Creation Tool msgprint

### DIFF
--- a/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.js
+++ b/erpnext/accounts/doctype/opening_invoice_creation_tool/opening_invoice_creation_tool.js
@@ -49,7 +49,15 @@ frappe.ui.form.on('Opening Invoice Creation Tool', {
 				doc: frm.doc,
 				btn: $(btn_primary),
 				method: "make_invoices",
-				freeze_message: __("Creating {0} Invoice", [frm.doc.invoice_type])
+				freeze: 1,
+				freeze_message: __("Creating {0} Invoice", [frm.doc.invoice_type]),
+				callback: function(r) {
+					if (r.message.length == 1) {
+						frappe.msgprint(__("{0} Invoice created successfully.", [frm.doc.invoice_type]));
+					} else if (r.message.length < 50) {
+						frappe.msgprint(__("{0} Invoices created successfully.", [frm.doc.invoice_type]));
+					}
+				}
 			});
 		});
 


### PR DESCRIPTION
Port of https://github.com/frappe/erpnext/pull/25998

**`Version`**
ERPNext: v13.35.2 (version-13)
Frappe Framework: v13.35.1 (version-13)

**Before:**
- In Opening Invoice Creation, Doesn't creation message show in popup, when create a any type of invoice then click create invoices.

https://user-images.githubusercontent.com/34390782/178667935-67cbbd72-9fe5-48ac-a8ff-357aaede5a31.mp4

**After:**
- After some development in opening_invoice_creation_tool.js, when create a any type of invoice then click create invoices, and Invoice created successfully message will show in popup.

https://user-images.githubusercontent.com/34390782/178669053-3aca7e3e-e65d-430b-ae05-b8ee9c85130a.mp4

Thank You!