### PR TITLE
feat: exclude Quotation from automatic payment schedule entries

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1591,7 +1591,7 @@ class AccountsController(TransactionBase):
 				)
 				for item in data:
 					self.append("payment_schedule", item)
-			elif self.doctype not in ["Purchase Receipt"]:
+			elif self.doctype not in ["Purchase Receipt", "Quotation"]:
 				data = dict(
 					due_date=due_date,
 					invoice_portion=100,


### PR DESCRIPTION
Hi together,

we recently discovered a problem related to the user flow from Quotation to Sales Order:

When a new Quotation is created with the current date in the Date field (as per standard), a new entry in the Payment Schedule will be automatically created when saving with the Due Date being the same as the Date field from the header. After that the Quotation is submitted.
When the user comes back the next day and tries to create a new Sales Order from that Quotation the following errors is shown:

<img width="589" alt="Due Date Error Message" src="https://user-images.githubusercontent.com/49870752/178740419-f5d75895-ef20-4b4c-bd90-c88855e9f571.png">

Since in a real world use case it likely happens that clients accept Quotations not on the same day, I suggest to not pre-fill the payment schedule table in the Quotation and instead leave it up to the user to decide if Payment Terms shall be included or not.

This PR would already solve the issue by not automatically adding payment terms to the Quotation. However, when the Sales Order is saved, the Payment Terms are generated (which doesn't cause this issue since the due date in the payment schedule equals the date of the Sales Order)

Full video for reference:

https://user-images.githubusercontent.com/49870752/178740799-1a52e3f8-9b01-4dfd-ba52-0674fd609d3a.mp4


Related discuss forum issue: 
https://discuss.erpnext.com/t/from-quotation-to-sales-order-row-1-due-date-cannot-be-before-posting-date/60172


`closes #19410`