### PR TITLE
fix(pos): consolidated invoice posting date

### DIFF
--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.js
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.js
@@ -17,11 +17,13 @@ frappe.ui.form.on('POS Closing Entry', {
 			};
 		});
 
-		frm.set_query("pos_opening_entry", function(doc) {
+		frm.set_query("pos_opening_entry", function() {
 			return { filters: { 'status': 'Open', 'docstatus': 1 } };
 		});
 
-		if (frm.doc.docstatus === 0 && !frm.doc.amended_from) frm.set_value("period_end_date", frappe.datetime.now_datetime());
+		if (frm.doc.docstatus === 0 && !frm.doc.amended_from) {
+			frm.set_value("period_end_date", frappe.datetime.now_datetime());
+		}
 
 		frappe.realtime.on('closing_process_complete', async function(data) {
 			await frm.reload_doc();

--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.json
@@ -51,7 +51,6 @@
    "fieldtype": "Datetime",
    "in_list_view": 1,
    "label": "Period End Date",
-   "read_only": 1,
    "reqd": 1
   },
   {
@@ -228,7 +227,7 @@
    "link_fieldname": "pos_closing_entry"
   }
  ],
- "modified": "2021-10-20 16:19:25.340565",
+ "modified": "2022-07-14 12:15:25.340565",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Closing Entry",

--- a/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
@@ -397,7 +397,7 @@ def create_merge_logs(invoice_by_customer, closing_entry=None):
 			for _invoices in split_invoices(invoices):
 				merge_log = frappe.new_doc("POS Invoice Merge Log")
 				merge_log.posting_date = (
-					getdate(closing_entry.get("posting_date")) if closing_entry else nowdate()
+					getdate(closing_entry.get("period_end_date")) if closing_entry else nowdate()
 				)
 				merge_log.customer = customer
 				merge_log.pos_closing_entry = closing_entry.get("name") if closing_entry else None

--- a/erpnext/accounts/doctype/pos_opening_entry/pos_opening_entry.json
+++ b/erpnext/accounts/doctype/pos_opening_entry/pos_opening_entry.json
@@ -179,6 +179,7 @@
    "write": 1
   }
  ],
+ "search_fields": "status,user,period_start_date",
  "sort_field": "modified",
  "sort_order": "DESC",
  "track_changes": 1


### PR DESCRIPTION
Consider a scenario,
- POS Closing Entry has **Period Start Date** as 8th July 2022 and **Period End Date** as 10th July 2022
- Now, the user sets the **Posting Date** as 8th July 2022
- On submission, the **Sales Invoices** that are created have **Posting Date** set as 8th July 2022, while containing the items of **POS Invoices** that were created on 9th July 2022

Fix:
- Set Period End Date as Posting Date of Consolidated Sales Invoices
- So, now Consolidated Sales Invoices will have the Posting Date as Period End Date i.e the day POS Closing was created