### PR TITLE
fix: (india) (e-invoice) allow generation for UIN Holders

### DIFF
--- a/erpnext/regional/india/e_invoice/utils.py
+++ b/erpnext/regional/india/e_invoice/utils.py
@@ -65,6 +65,7 @@ def validate_eligibility(doc):
 		"SEZ",
 		"Overseas",
 		"Deemed Export",
+		"UIN Holders",
 	]
 	company_transaction = doc.get("billing_address_gstin") == doc.get("company_gstin")
 
@@ -130,9 +131,7 @@ def read_json(name):
 
 def get_transaction_details(invoice):
 	supply_type = ""
-	if (
-		invoice.gst_category == "Registered Regular" or invoice.gst_category == "Registered Composition"
-	):
+	if invoice.gst_category in ("Registered Regular", "Registered Composition", "UIN Holders"):
 		supply_type = "B2B"
 	elif invoice.gst_category == "SEZ":
 		if invoice.export_type == "Without Payment of Tax":
@@ -148,15 +147,18 @@ def get_transaction_details(invoice):
 		supply_type = "DEXP"
 
 	if not supply_type:
-		rr, rc, sez, overseas, export = (
+		rr, rc, sez, overseas, export, uin = (
 			bold("Registered Regular"),
 			bold("Registered Composition"),
 			bold("SEZ"),
 			bold("Overseas"),
 			bold("Deemed Export"),
+			bold("UIN Holders"),
 		)
 		frappe.throw(
-			_("GST category should be one of {}, {}, {}, {}, {}").format(rr, rc, sez, overseas, export),
+			_("GST category should be one of {}, {}, {}, {}, {}, {}").format(
+				rr, rc, sez, overseas, export, uin
+			),
 			title=_("Invalid Supply Type"),
 		)
 

--- a/erpnext/regional/india/setup.py
+++ b/erpnext/regional/india/setup.py
@@ -714,7 +714,7 @@ def get_custom_fields():
 			insert_after="customer",
 			no_copy=1,
 			print_hide=1,
-			depends_on='eval:in_list(["Registered Regular", "Registered Composition", "SEZ", "Overseas", "Deemed Export"], doc.gst_category) && doc.irn_cancelled === 0',
+			depends_on='eval:in_list(["Registered Regular", "Registered Composition", "SEZ", "Overseas", "Deemed Export", "UIN Holders"], doc.gst_category) && doc.irn_cancelled === 0',
 		),
 		dict(
 			fieldname="irn_cancelled",

--- a/erpnext/regional/india/utils.py
+++ b/erpnext/regional/india/utils.py
@@ -40,13 +40,12 @@ def validate_gstin_for_india(doc, method):
 
 	gst_category = []
 
-	if hasattr(doc, "gst_category"):
-		if len(doc.links):
-			link_doctype = doc.links[0].get("link_doctype")
-			link_name = doc.links[0].get("link_name")
+	if len(doc.links):
+		link_doctype = doc.links[0].get("link_doctype")
+		link_name = doc.links[0].get("link_name")
 
-			if link_doctype in ["Customer", "Supplier"]:
-				gst_category = frappe.db.get_value(link_doctype, {"name": link_name}, ["gst_category"])
+		if link_doctype in ["Customer", "Supplier"]:
+			gst_category = frappe.db.get_value(link_doctype, {"name": link_name}, ["gst_category"])
 
 	doc.gstin = doc.gstin.upper().strip()
 	if not doc.gstin or doc.gstin == "NA":


### PR DESCRIPTION
e-invoice is required for UIN Holders and they should be treated as Registered Regular. there was incorrect if hasattr check that prevented UIN number validation.

https://www.gstzen.in/a/unique-identification-number-uin-under-gst.html