### PR TITLE
fix(india): e-way bill json for unregistered gst category

### DIFF
--- a/erpnext/regional/india/utils.py
+++ b/erpnext/regional/india/utils.py
@@ -580,7 +580,7 @@ def get_ewb_data(dt, dn):
 
 		if dt == "Delivery Note":
 			data.subSupplyType = 1
-		elif doc.gst_category in ["Registered Regular", "SEZ"]:
+		elif doc.gst_category in ["Unregistered", "Registered Regular", "SEZ"]:
 			data.subSupplyType = 1
 		elif doc.gst_category in ["Overseas", "Deemed Export"]:
 			data.subSupplyType = 3


### PR DESCRIPTION
Currently, for unregistered customers, E-Way Bill JSON can only be generated via Delivery Note.
Have added provision to generate it via Sales Invoice as well.