### PR TITLE
fix: dont override default report options in charts

### DIFF
--- a/erpnext/buying/report/purchase_analytics/purchase_analytics.js
+++ b/erpnext/buying/report/purchase_analytics/purchase_analytics.js
@@ -130,11 +130,8 @@ frappe.query_reports["Purchase Analytics"] = {
 						labels: raw_data.labels,
 						datasets: new_datasets,
 					};
-					chart_options = {
-						data: new_data,
-						type: "line",
-					};
-					frappe.query_report.render_chart(chart_options);
+					const new_options = Object.assign({}, frappe.query_report.chart_options, {data: new_data});
+					frappe.query_report.render_chart(new_options);
 
 					frappe.query_report.raw_chart_data = new_data;
 				},

--- a/erpnext/buying/report/purchase_analytics/purchase_analytics.js
+++ b/erpnext/buying/report/purchase_analytics/purchase_analytics.js
@@ -68,9 +68,6 @@ frappe.query_reports["Purchase Analytics"] = {
 		}
 
 	],
-	after_datatable_render: function(datatable_obj) {
-		$(datatable_obj.wrapper).find(".dt-row-0").find('input[type=checkbox]').click();
-	},
 	get_datatable_options(options) {
 		return Object.assign(options, {
 			checkboxColumn: true,

--- a/erpnext/selling/report/sales_analytics/sales_analytics.js
+++ b/erpnext/selling/report/sales_analytics/sales_analytics.js
@@ -109,11 +109,8 @@ frappe.query_reports["Sales Analytics"] = {
 						labels: raw_data.labels,
 						datasets: new_datasets,
 					};
-
-					frappe.query_report.render_chart({
-						data: new_data,
-						type: "line",
-					});
+					const new_options = Object.assign({}, frappe.query_report.chart_options, {data: new_data});
+					frappe.query_report.render_chart(new_options);
 
 					frappe.query_report.raw_chart_data = new_data;
 				},

--- a/erpnext/selling/report/sales_analytics/sales_analytics.js
+++ b/erpnext/selling/report/sales_analytics/sales_analytics.js
@@ -67,9 +67,6 @@ frappe.query_reports["Sales Analytics"] = {
 			reqd: 1
 		}
 	],
-	after_datatable_render: function(datatable_obj) {
-		$(datatable_obj.wrapper).find(".dt-row-0").find('input[type=checkbox]').click();
-	},
 	get_datatable_options(options) {
 		return Object.assign(options, {
 			checkboxColumn: true,


### PR DESCRIPTION

Sales analytics and purchase analytics reports are clearing the default
options which includes number shortening, axis options etc. This makes
report unreadable when dealing with large numbers.

fix: update the options with new data instead of overriding it.

Before
<img width="1386" alt="Screenshot 2022-07-15 at 1 34 31 PM" src="https://user-images.githubusercontent.com/9079960/179180538-1afc230e-ee17-4940-9736-df397d8a66a5.png">




AFter

<img width="1386" alt="Screenshot 2022-07-15 at 1 30 44 PM" src="https://user-images.githubusercontent.com/9079960/179180337-807ac8cf-91e2-468c-9371-b0531988a9ca.png">


---


Fix behavior of first row wrt chart. Currently, first row checked == chart shows nothing; first row unchecked == chart shows first-row chart. This is opposite behavior of what it should be xD 


https://user-images.githubusercontent.com/9079960/179180422-80620cad-a843-4fc3-a65c-ad94c003dbcf.mov


