### PR TITLE
fix(India): Inward supplies from Composition Supplier in GST 3B report

### DIFF
--- a/erpnext/regional/doctype/gstr_3b_report/gstr_3b_report.py
+++ b/erpnext/regional/doctype/gstr_3b_report/gstr_3b_report.py
@@ -144,7 +144,7 @@ class GSTR3BReport(Document):
 	def get_inward_nil_exempt(self, state):
 		inward_nil_exempt = frappe.db.sql(
 			"""
-			SELECT p.place_of_supply, p.supplier_address,
+			SELECT p.name, p.place_of_supply, p.supplier_address, p.gst_category,
 			i.base_amount, i.is_nil_exempt, i.is_non_gst
 			FROM `tabPurchase Invoice` p , `tabPurchase Invoice Item` i
 			WHERE p.docstatus = 1 and p.name = i.parent


### PR DESCRIPTION
Invoices based on GST category were not getting segregated properly because gst category was not selected in the query, which led to incorrect reporting of inward supplies from a composite supplier.