### PR TITLE
fix: slow stock reposting

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -209,8 +209,12 @@ def repost_future_sle(
 	via_landed_cost_voucher=False,
 	doc=None,
 ):
-	if not args and voucher_type and voucher_no:
-		args = get_items_to_be_repost(voucher_type, voucher_no, doc)
+
+	items_to_be_repost = get_items_to_be_repost(
+		voucher_type=voucher_type, voucher_no=voucher_no, doc=doc
+	)
+	if items_to_be_repost:
+		args = items_to_be_repost
 
 	distinct_item_warehouses = get_distinct_item_warehouse(args, doc)
 	affected_transactions = get_affected_transactions(doc)
@@ -286,17 +290,21 @@ def update_args_in_repost_item_valuation(
 	)
 
 
-def get_items_to_be_repost(voucher_type, voucher_no, doc=None):
+def get_items_to_be_repost(voucher_type=None, voucher_no=None, doc=None):
+	items_to_be_repost = []
 	if doc and doc.items_to_be_repost:
-		return json.loads(doc.items_to_be_repost) or []
+		items_to_be_repost = json.loads(doc.items_to_be_repost) or []
 
-	return frappe.db.get_all(
-		"Stock Ledger Entry",
-		filters={"voucher_type": voucher_type, "voucher_no": voucher_no},
-		fields=["item_code", "warehouse", "posting_date", "posting_time", "creation"],
-		order_by="creation asc",
-		group_by="item_code, warehouse",
-	)
+	if not items_to_be_repost and voucher_type and voucher_no:
+		items_to_be_repost = frappe.db.get_all(
+			"Stock Ledger Entry",
+			filters={"voucher_type": voucher_type, "voucher_no": voucher_no},
+			fields=["item_code", "warehouse", "posting_date", "posting_time", "creation"],
+			order_by="creation asc",
+			group_by="item_code, warehouse",
+		)
+
+	return items_to_be_repost
 
 
 def get_distinct_item_warehouse(args=None, doc=None):
@@ -496,7 +504,8 @@ class update_entries_after(object):
 		elif dependant_sle.item_code == self.item_code and dependant_sle.warehouse in self.data:
 			return entries_to_fix
 		else:
-			self.append_future_sle_for_dependant(dependant_sle, entries_to_fix)
+			self.initialize_previous_data(dependant_sle)
+			self.update_distinct_item_warehouses(dependant_sle)
 			return entries_to_fix
 
 	def update_distinct_item_warehouses(self, dependant_sle):
@@ -513,14 +522,6 @@ class update_entries_after(object):
 				val.sle_changed = True
 				self.distinct_item_warehouses[key] = val
 				self.new_items_found = True
-
-	def append_future_sle_for_dependant(self, dependant_sle, entries_to_fix):
-		self.initialize_previous_data(dependant_sle)
-		self.distinct_item_warehouses[(self.item_code, dependant_sle.warehouse)] = frappe._dict(
-			{"sle": dependant_sle}
-		)
-
-		self.new_items_found = True
 
 	def process_sle(self, sle):
 		from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos


### PR DESCRIPTION
1) Slow Stock Reposting

Recently we have made [changes](https://github.com/frappe/erpnext/pull/31519) which would enqueue the same item with different warehouse so that system won't throw the timeout error. This changes causing the slow reposting issue.

To fix this issue, before enqueue check whether the same item and warehouse exists in the queue or not and if it's exists then check the posting date. If the posting date is less than the current posting date then update the posting date.

```
def update_distinct_item_warehouses(self, dependant_sle):
		key = (dependant_sle.item_code, dependant_sle.warehouse)
		val = frappe._dict({"sle": dependant_sle})
		if key not in self.distinct_item_warehouses:
			self.distinct_item_warehouses[key] = val
			self.new_items_found = True
		else:
			existing_sle_posting_date = (
				self.distinct_item_warehouses[key].get("sle", {}).get("posting_date")
			)
			if getdate(dependant_sle.posting_date) < getdate(existing_sle_posting_date):
				val.sle_changed = True
				self.distinct_item_warehouses[key] = val
				self.new_items_found = True
```

2) Item and Warehouse reposting

In case of item and warehouse based reposting, system partially repost with status as **Completed**. The cause for this issue is if because of timeout the system has reposted Repost Item Valuation partially and when the reposting runs again system failed to pick the correct items which has to be repost.

<img width="1344" alt="Screenshot 2022-07-19 at 12 59 14 PM" src="https://user-images.githubusercontent.com/8780500/179742917-42dd5de3-7893-4a75-83ea-9defd688a800.png">

