### PR TITLE
fix: assign duplicate_items_msg outside conditional

### DIFF
--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -614,13 +614,13 @@ class SellingController(StockController):
 				stock_items = [d.item_code, d.description, d.warehouse, ""]
 				non_stock_items = [d.item_code, d.description]
 
+			duplicate_items_msg = _("Item {0} entered multiple times.").format(frappe.bold(d.item_code))
+			duplicate_items_msg += "<br><br>"
+			duplicate_items_msg += _("Please enable {} in {} to allow same item in multiple rows").format(
+				frappe.bold("Allow Item to Be Added Multiple Times in a Transaction"),
+				get_link_to_form("Selling Settings", "Selling Settings"),
+			)
 			if frappe.db.get_value("Item", d.item_code, "is_stock_item") == 1:
-				duplicate_items_msg = _("Item {0} entered multiple times.").format(frappe.bold(d.item_code))
-				duplicate_items_msg += "<br><br>"
-				duplicate_items_msg += _("Please enable {} in {} to allow same item in multiple rows").format(
-					frappe.bold("Allow Item to Be Added Multiple Times in a Transaction"),
-					get_link_to_form("Selling Settings", "Selling Settings"),
-				)
 				if stock_items in check_list:
 					frappe.throw(duplicate_items_msg)
 				else:


### PR DESCRIPTION
duplicate_items_msg was defined inside if the statement  of stock_item so when duplicate was found in non_stock_item it raised referenced before assignment error.