### PR TITLE
fix: rounding errors while closing pos

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
@@ -9,7 +9,7 @@ from frappe import _
 from frappe.core.page.background_jobs.background_jobs import get_info
 from frappe.model.document import Document
 from frappe.model.mapper import map_child_doc, map_doc
-from frappe.utils import flt, getdate, nowdate
+from frappe.utils import cint, flt, getdate, nowdate
 from frappe.utils.background_jobs import enqueue
 from frappe.utils.scheduler import is_scheduler_inactive
 
@@ -219,6 +219,9 @@ class POSInvoiceMergeLog(Document):
 		invoice.taxes_and_charges = None
 		invoice.ignore_pricing_rule = 1
 		invoice.customer = self.customer
+		invoice.disable_rounded_total = cint(
+			frappe.db.get_value("POS Profile", invoice.pos_profile, "disable_rounded_total")
+		)
 
 		if self.merge_invoices_based_on == "Customer Group":
 			invoice.flags.ignore_pos_profile = True

--- a/erpnext/accounts/doctype/pos_profile/pos_profile.json
+++ b/erpnext/accounts/doctype/pos_profile/pos_profile.json
@@ -44,6 +44,7 @@
   "write_off_account",
   "write_off_cost_center",
   "account_for_change_amount",
+  "disable_rounded_total",
   "column_break_23",
   "income_account",
   "expense_account",
@@ -358,6 +359,13 @@
    "fieldname": "validate_stock_on_save",
    "fieldtype": "Check",
    "label": "Validate Stock on Save"
+  },
+  {
+   "default": "0",
+   "description": "If enabled, the consolidated invoices will have rounded total disabled",
+   "fieldname": "disable_rounded_total",
+   "fieldtype": "Check",
+   "label": "Disable Rounded Total"
   }
  ],
  "icon": "icon-cog",
@@ -385,7 +393,7 @@
    "link_fieldname": "pos_profile"
   }
  ],
- "modified": "2022-03-21 13:29:28.480533",
+ "modified": "2022-07-21 11:16:46.911173",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Profile",


### PR DESCRIPTION
Ref. Issue: ISS-22-23-00950

In some rare cases, while consolidating returns, there exists a difference of 0.001 (if precision is 3) between Grand Total & Paid Amount
This happens due to manually calculating item values while merging pos invoices. One way to solve this issue is to enable rounding adjustments.

This PR by default enables Rounding Adjustments for all the consolidated invoices.