### PR TITLE
fix: use current pos profile on sales return

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -497,7 +497,10 @@ erpnext.PointOfSale.Controller = class {
 
 	set_pos_profile_data() {
 		if (this.company && !this.frm.doc.company) this.frm.doc.company = this.company;
-		if (this.pos_profile && !this.frm.doc.pos_profile) this.frm.doc.pos_profile = this.pos_profile;
+		if ((this.pos_profile && !this.frm.doc.pos_profile) | (this.frm.doc.is_return && this.pos_profile != this.frm.doc.pos_profile)) {
+			this.frm.doc.pos_profile = this.pos_profile;
+		}
+
 		if (!this.frm.doc.company) return;
 
 		return this.frm.trigger("set_pos_data");


### PR DESCRIPTION
## Issue
1. **Item A** -> Sold by **POS Profile 1**
2. **Item A** -> Returned and Sales return submitted by **POS Profile 2**
But, sales return still has **POS Profile 1**.

## Fix
Sales Return submitted from different POS Profile should have that current Profile.
### Sales from **Profile 1**:
1. <img width="1066" alt="Screenshot 2022-07-21 at 12 07 11 PM" src="https://user-images.githubusercontent.com/3272205/180146555-22d33a8a-1afe-4673-b338-cc0249bba8e7.png"> 2. <img width="707" alt="Screenshot 2022-07-21 at 12 08 56 PM" src="https://user-images.githubusercontent.com/3272205/180146652-de11fd0f-29b9-444a-9aa5-16e0760208b7.png">

### Return from **Profile 2**:
1. <img width="939" alt="Screenshot 2022-07-21 at 12 08 40 PM" src="https://user-images.githubusercontent.com/3272205/180146587-21fd4937-374c-4228-b1a2-7a69248374b0.png"> 2. <img width="707" alt="Screenshot 2022-07-21 at 12 08 53 PM" src="https://user-images.githubusercontent.com/3272205/180146632-d7e68aaf-3825-4aaa-866e-45c9ab389b86.png">
