### PR TITLE
fix: enable tax withholding checkbox in PI with supplier_tds

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -162,6 +162,7 @@ class PurchaseInvoice(BuyingController):
 		if tds_category and not for_validate:
 			self.apply_tds = 1
 			self.tax_withholding_category = tds_category
+			self.set_onload("supplier_tds", tds_category)
 
 		super(PurchaseInvoice, self).set_missing_values(for_validate)
 


### PR DESCRIPTION
## Issue
1. Create PO without applying **tax_withholding_amount**, whose supplier has default tax withholding category.
2. Create PI from [1].
'Apply tax withholding amount' option is disabled in PI from [2].

## Fix
Add supplier_tds on the onload attribute of PI if the supplier has one.