### PR TITLE
fix: dont show zero qty available items in stock ageing report

### DIFF
--- a/erpnext/stock/report/stock_ageing/stock_ageing.py
+++ b/erpnext/stock/report/stock_ageing/stock_ageing.py
@@ -34,6 +34,9 @@ def format_report_data(filters: Filters, item_details: Dict, to_date: str) -> Li
 	precision = cint(frappe.db.get_single_value("System Settings", "float_precision", cache=True))
 
 	for item, item_dict in item_details.items():
+		if not flt(item_dict.get("total_qty"), precision):
+			continue
+
 		earliest_age, latest_age = 0, 0
 		details = item_dict["details"]
 


### PR DESCRIPTION
**Issue**

Zero quantity available items are showing in the stock ageing report
<img width="1166" alt="Screenshot 2022-07-22 at 5 55 25 PM" src="https://user-images.githubusercontent.com/8780500/180439019-1ed288bf-5854-408b-b3de-f023fd7d5630.png">

