### PR TITLE
feat: Allow Overwriting Salary Structure Amount

### DIFF
--- a/erpnext/payroll/doctype/salary_component/salary_component.json
+++ b/erpnext/payroll/doctype/salary_component/salary_component.json
@@ -244,7 +244,7 @@
  "icon": "fa fa-flag",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2020-10-07 20:38:33.795853",
+ "modified": "2022-07-25 17:42:56.009493",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Salary Component",
@@ -268,5 +268,6 @@
   }
  ],
  "sort_field": "modified",
- "sort_order": "DESC"
+ "sort_order": "DESC",
+ "track_changes": 1
 }

--- a/erpnext/payroll/doctype/salary_detail/salary_detail.json
+++ b/erpnext/payroll/doctype/salary_detail/salary_detail.json
@@ -22,6 +22,7 @@
   "variable_based_on_taxable_salary",
   "do_not_include_in_total",
   "deduct_full_tax_on_selected_payroll_date",
+  "allow_overwrite",
   "section_break_2",
   "condition",
   "column_break_18",
@@ -238,17 +239,25 @@
    "read_only": 1
   },
   {
-    "default": "0",
-    "depends_on": "eval:doc.parenttype=='Salary Slip' && doc.additional_salary",
-    "fieldname": "is_recurring_additional_salary",
-    "fieldtype": "Check",
-    "label": "Is Recurring Additional Salary",
-    "read_only": 1
-   }
+   "default": "0",
+   "depends_on": "eval:doc.parenttype=='Salary Slip' && doc.additional_salary",
+   "fieldname": "is_recurring_additional_salary",
+   "fieldtype": "Check",
+   "label": "Is Recurring Additional Salary",
+   "read_only": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "default": "0",
+   "depends_on": "eval:!doc.additional_salary",
+   "fieldname": "allow_overwrite",
+   "fieldtype": "Check",
+   "label": "Allow Overwriting Salary Structure Amount"
+  }
  ],
  "istable": 1,
  "links": [],
- "modified": "2021-08-30 13:39:15.847158",
+ "modified": "2022-07-25 17:04:15.406577",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Salary Detail",

--- a/erpnext/payroll/doctype/salary_slip/salary_slip.json
+++ b/erpnext/payroll/doctype/salary_slip/salary_slip.json
@@ -647,7 +647,7 @@
  "idx": 9,
  "is_submittable": 1,
  "links": [],
- "modified": "2021-10-08 11:48:47.098248",
+ "modified": "2022-07-25 17:42:36.996827",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Salary Slip",
@@ -687,5 +687,6 @@
  "sort_field": "modified",
  "sort_order": "DESC",
  "timeline_field": "employee",
- "title_field": "employee_name"
+ "title_field": "employee_name",
+ "track_changes": 1
 }

--- a/erpnext/payroll/doctype/salary_slip/salary_slip.py
+++ b/erpnext/payroll/doctype/salary_slip/salary_slip.py
@@ -841,6 +841,8 @@ class SalarySlip(TransactionBase):
 				additional_salary.deduct_full_tax_on_selected_payroll_date
 			)
 		else:
+			if amount != component_row.amount and component_data.allow_overwrite:
+				return
 			component_row.default_amount = amount
 			component_row.additional_amount = 0
 			component_row.deduct_full_tax_on_selected_payroll_date = (

--- a/erpnext/payroll/doctype/salary_structure/salary_structure.json
+++ b/erpnext/payroll/doctype/salary_structure/salary_structure.json
@@ -233,7 +233,7 @@
  "idx": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2022-02-03 23:50:10.205676",
+ "modified": "2022-07-25 17:42:47.459045",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Salary Structure",
@@ -274,5 +274,5 @@
  "show_name_in_global_search": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
- "states": []
+ "track_changes": 1
 }


### PR DESCRIPTION
Earlier users were allowed to overwrite the salary component amount in the slip due to a bug that didn't update the component row if the amount evaluated to 0. This bug was actually used as a feature by users.

After fixing this bug in https://github.com/frappe/erpnext/pull/31425, as a side-effect, the scenario mentioned above stopped working for people who manually generate salary slips or some component amounts irrespective of the amount/formula set up in the component.

Add a checkbox: **Allow Overwriting Salary Structure Amount** to allow certain components to be manually entered into the salary slip 

