### PR TITLE
fix: do not update component amount for timesheet components

### DIFF
--- a/erpnext/non_profit/doctype/member/member.js
+++ b/erpnext/non_profit/doctype/member/member.js
@@ -27,7 +27,7 @@ frappe.ui.form.on('Member', {
 					frappe.set_route('query-report', 'General Ledger', {party_type: 'Member', party: frm.doc.name});
 				}
 			});
-			
+
 			if (frm.doc.customer) {
 				frm.add_custom_button(__('Accounts Receivable'), function() {
 					frappe.set_route('query-report', 'Accounts Receivable', {customer: frm.doc.customer});

--- a/erpnext/payroll/doctype/salary_slip/salary_slip.py
+++ b/erpnext/payroll/doctype/salary_slip/salary_slip.py
@@ -623,7 +623,14 @@ class SalarySlip(TransactionBase):
 
 	def add_structure_components(self, component_type):
 		data = self.get_data_for_eval()
+		timesheet_component = frappe.db.get_value(
+			"Salary Structure", self.salary_structure, "salary_component"
+		)
+
 		for struct_row in self._salary_structure_doc.get(component_type):
+			if self.salary_slip_based_on_timesheet and struct_row.salary_component == timesheet_component:
+				continue
+
 			amount = self.eval_condition_and_formula(struct_row, data)
 			if amount is not None and struct_row.statistical_component == 0:
 				self.update_component_row(struct_row, amount, component_type, data=data)

--- a/erpnext/payroll/doctype/salary_structure/salary_structure.py
+++ b/erpnext/payroll/doctype/salary_structure/salary_structure.py
@@ -20,6 +20,7 @@ class SalaryStructure(Document):
 		self.validate_max_benefits_with_flexi()
 		self.validate_component_based_on_tax_slab()
 		self.validate_payment_days_based_dependent_component()
+		self.validate_timesheet_component()
 
 	def set_missing_values(self):
 		overwritten_fields = [
@@ -88,6 +89,21 @@ class SalaryStructure(Document):
 		abbr += [d.abbr for d in self.deductions if d.depends_on_payment_days]
 
 		return abbr
+
+	def validate_timesheet_component(self):
+		if not self.salary_slip_based_on_timesheet:
+			return
+
+		for component in self.earnings:
+			if component.salary_component == self.salary_component:
+				frappe.msgprint(
+					_(
+						"Row #{0}: Timesheet amount will overwrite the Earning component amount for the Salary Component {1}"
+					).format(self.idx, frappe.bold(self.salary_component)),
+					title=_("Warning"),
+					indicator="orange",
+				)
+				break
 
 	def strip_condition_and_formula_fields(self):
 		# remove whitespaces from condition and formula fields


### PR DESCRIPTION
## Problem

- If a salary structure is configured with a timesheet component and the same component in the child table, it evaluates the component as per the structure formula/amount and overrides the timesheet amount. If it amounts to 0, the component is removed from the slip.

<img width="1313" alt="structure" src="https://user-images.githubusercontent.com/24353136/180932115-41de3052-5a7c-46e3-83f6-743a5ac94770.png">

## Fix

Do not update component amount for timesheet components. Also, add a warning in the salary structure.

<img width="1313" alt="image" src="https://user-images.githubusercontent.com/24353136/180938601-507649b0-7842-4aa6-91b0-455623137071.png">