### PR TITLE
fix: (india) (e-invoice) margin & internal company transfer

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -2712,6 +2712,19 @@ class TestSalesInvoice(unittest.TestCase):
 		self.assertEqual(einvoice["ItemList"][2]["UnitPrice"], 20)
 		self.assertEqual(einvoice["ItemList"][3]["UnitPrice"], 10)
 
+		si = get_sales_invoice_for_e_invoice()
+		si.apply_discount_on = ""
+		si.items[1].price_list_rate = 15
+		si.items[1].discount_amount = -5
+		si.items[1].rate = 20
+		si.save()
+
+		einvoice = make_einvoice(si)
+		validate_totals(einvoice)
+
+		self.assertEqual(einvoice["ItemList"][1]["Discount"], 0)
+		self.assertEqual(einvoice["ItemList"][1]["UnitPrice"], 20)
+
 	def test_einvoice_without_discounts(self):
 		from erpnext.regional.india.e_invoice.utils import make_einvoice, validate_totals
 
@@ -2803,6 +2816,19 @@ class TestSalesInvoice(unittest.TestCase):
 		self.assertEqual(einvoice["ItemList"][1]["UnitPrice"], 15)
 		self.assertEqual(einvoice["ItemList"][2]["UnitPrice"], 18)
 		self.assertEqual(einvoice["ItemList"][3]["UnitPrice"], 5)
+
+		si = get_sales_invoice_for_e_invoice()
+		si.apply_discount_on = ""
+		si.items[1].price_list_rate = 15
+		si.items[1].discount_amount = -5
+		si.items[1].rate = 20
+		si.save()
+
+		einvoice = make_einvoice(si)
+		validate_totals(einvoice)
+
+		self.assertEqual(einvoice["ItemList"][1]["Discount"], 0)
+		self.assertEqual(einvoice["ItemList"][1]["UnitPrice"], 20)
 
 	def test_item_tax_net_range(self):
 		item = create_item("T Shirt")

--- a/erpnext/regional/india/e_invoice/utils.py
+++ b/erpnext/regional/india/e_invoice/utils.py
@@ -285,7 +285,7 @@ def get_item_list(invoice):
 		if invoice.get("is_return") or invoice.get("is_debit_note"):
 			item_qty = item_qty or 1
 
-		if hide_discount_in_einvoice or invoice.is_internal_customer or (item.discount_amount <= 0):
+		if hide_discount_in_einvoice or invoice.is_internal_customer or item.discount_amount < 0:
 			item.unit_rate = item.taxable_value / item_qty
 			item.gross_amount = item.taxable_value
 			item.discount_amount = 0

--- a/erpnext/regional/india/e_invoice/utils.py
+++ b/erpnext/regional/india/e_invoice/utils.py
@@ -265,6 +265,10 @@ def get_overseas_address_details(address_name):
 def get_item_list(invoice):
 	item_list = []
 
+	hide_discount_in_einvoice = cint(
+		frappe.db.get_single_value("E Invoice Settings", "dont_show_discounts_in_e_invoice")
+	)
+
 	for d in invoice.items:
 		einvoice_item_schema = read_json("einv_item_template")
 		item = frappe._dict({})
@@ -276,17 +280,12 @@ def get_item_list(invoice):
 		item.qty = abs(item.qty)
 		item_qty = item.qty
 
-		item.discount_amount = abs(item.discount_amount)
 		item.taxable_value = abs(item.taxable_value)
 
 		if invoice.get("is_return") or invoice.get("is_debit_note"):
 			item_qty = item_qty or 1
 
-		hide_discount_in_einvoice = cint(
-			frappe.db.get_single_value("E Invoice Settings", "dont_show_discounts_in_e_invoice")
-		)
-
-		if hide_discount_in_einvoice:
+		if hide_discount_in_einvoice or invoice.is_internal_customer or (item.discount_amount <= 0):
 			item.unit_rate = item.taxable_value / item_qty
 			item.gross_amount = item.taxable_value
 			item.discount_amount = 0


### PR DESCRIPTION
**Problem:**
When the item price is more than the price list rate ( margin added ) discount value becomes negative. The previous attempt to solve this was to convert discount to absolute value. However, that gives incorrect unit price and discount value. For Internal company transfer (different state), the rate is supposed to be the valuation rate.

**Solution:**
To solve this, I have made changes to report net rates in cases where the margin is added or is an internal company transfer.
