### PR TITLE
fix: manually generated salary slips overwritten by structure amount

### DIFF
--- a/erpnext/payroll/doctype/salary_slip/salary_slip.py
+++ b/erpnext/payroll/doctype/salary_slip/salary_slip.py
@@ -632,7 +632,11 @@ class SalarySlip(TransactionBase):
 				continue
 
 			amount = self.eval_condition_and_formula(struct_row, data)
-			if amount is not None and struct_row.statistical_component == 0:
+			if (
+				amount
+				or (struct_row.amount_based_on_formula and amount is not None)
+				and struct_row.statistical_component == 0
+			):
 				self.update_component_row(struct_row, amount, component_type, data=data)
 
 	def get_data_for_eval(self):


### PR DESCRIPTION
## Problem

Earlier users were allowed to overwrite the salary component amount in the slip due to a bug that didn't update the component row if the amount was evaluated to 0. This bug was actually used as a feature by users.

After fixing this bug in https://github.com/frappe/erpnext/pull/31425, as a side-effect, the scenario mentioned above stopped working for people who manually generate salary slips or some component amounts irrespective of the amount/formula set up in the component.

## Fix

Only update the component row:
- if the amount is not 0 or 
- structure row is not based on formula and amount is not None
- not a statistical component
