### PR TITLE
fix: Gross Profit PDF and Print

### DIFF
--- a/erpnext/accounts/report/gross_profit/gross_profit.js
+++ b/erpnext/accounts/report/gross_profit/gross_profit.js
@@ -51,7 +51,7 @@ frappe.query_reports["Gross Profit"] = {
 		}
 		value = default_formatter(value, row, column, data);
 
-		if (data && (data.indent == 0.0 || row[1].content == "Total")) {
+		if (data && (data.indent == 0.0 || (row[1] != undefined ? row[1].content == "Total" : true))) {
 			value = $(`<span>${value}</span>`);
 			var $value = $(value).css("font-weight", "bold");
 			value = $value.wrap("<p></p>").parent().html();


### PR DESCRIPTION
**`Version`**

ERPNext: v14.x.x-develop
Frappe Framework: v14.x.x-develop
___
Issue: #31718 

- pdf and print issue has in version-13 and also in develop branch.

___
**Before:**
- In gross profit report, clicking pdf or print does not generate pdf or print.

https://user-images.githubusercontent.com/34390782/181434947-ea389c59-f927-4fce-bb39-b9119cafe443.mp4


**After:**
- After set condition in gross profit report, when user clicks pdf or print then will be generate pdf or print.

https://user-images.githubusercontent.com/34390782/181435462-3f27e3e2-12d8-4bad-b7cb-8482bcf78817.mp4

Thank You!