### PR TITLE
fix: Allow allocating advance amount against Expense Claim taxes

### DIFF
--- a/erpnext/hr/doctype/expense_claim/expense_claim.py
+++ b/erpnext/hr/doctype/expense_claim/expense_claim.py
@@ -305,12 +305,11 @@ class ExpenseClaim(AccountsController):
 
 		if self.total_advance_amount:
 			precision = self.precision("total_advance_amount")
-			if flt(self.total_advance_amount, precision) > flt(self.total_claimed_amount, precision):
-				frappe.throw(_("Total advance amount cannot be greater than total claimed amount"))
+			amount_with_taxes = flt(self.total_sanctioned_amount, precision) + flt(
+				self.total_taxes_and_charges, precision
+			)
 
-			if self.total_sanctioned_amount and flt(self.total_advance_amount, precision) > flt(
-				self.total_sanctioned_amount, precision
-			):
+			if flt(self.total_advance_amount, precision) > amount_with_taxes:
 				frappe.throw(_("Total advance amount cannot be greater than total sanctioned amount"))
 
 	def validate_sanctioned_amount(self):


### PR DESCRIPTION
## Problem

- Create an Employee Advance (5000)
- Create an Expense Claim (4000) with taxes (480) = 4480
- System doesn't allow allocating the advance amount against taxes.

<img width="1328" alt="tax" src="https://user-images.githubusercontent.com/24353136/181453570-b366eeb0-fd42-4d95-b22a-d00a27d63e1f.png">

## Fix

Allow allocating advance amount against taxes