### PR TITLE
fix: set `billing_address` for purchases in `get_party_details`

### DIFF
--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -207,7 +207,7 @@ def set_address_details(
 			)
 
 	if company_address:
-		party_details.update({"company_address": company_address})
+		party_details.company_address = company_address
 	else:
 		party_details.update(get_company_address(company))
 
@@ -219,12 +219,31 @@ def set_address_details(
 		get_regional_address_details(party_details, doctype, company)
 
 	elif doctype and doctype in ["Purchase Invoice", "Purchase Order", "Purchase Receipt"]:
-		if party_details.company_address:
-			party_details["shipping_address"] = shipping_address or party_details["company_address"]
-			party_details.shipping_address_display = get_address_display(party_details["shipping_address"])
+		if shipping_address:
 			party_details.update(
-				get_fetch_values(doctype, "shipping_address", party_details.shipping_address)
+				shipping_address=shipping_address,
+				shipping_address_display=get_address_display(shipping_address),
+				**get_fetch_values(doctype, "shipping_address", shipping_address)
 			)
+
+		if party_details.company_address:
+			# billing address
+			party_details.update(
+				billing_address=party_details.company_address,
+				billing_address_display=(
+					party_details.company_address_display or get_address_display(party_details.company_address)
+				),
+				**get_fetch_values(doctype, "billing_address", party_details.company_address)
+			)
+
+			# shipping address - if not already set
+			if not party_details.shipping_address:
+				party_details.update(
+					shipping_address=party_details.billing_address,
+					shipping_address_display=party_details.billing_address_display,
+					**get_fetch_values(doctype, "shipping_address", party_details.billing_address)
+				)
+
 		get_regional_address_details(party_details, doctype, company)
 
 	return party_details.get(billing_address_field), party_details.shipping_address_name

--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -86,6 +86,7 @@ class BuyingController(SubcontractingController):
 					company=self.company,
 					party_address=self.get("supplier_address"),
 					shipping_address=self.get("shipping_address"),
+					company_address=self.get("billing_address"),
 					fetch_payment_terms_template=not self.get("ignore_default_payment_terms_template"),
 					ignore_permissions=self.flags.ignore_permissions,
 				)

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1,7 +1,6 @@
 // Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 // License: GNU General Public License v3. See license.txt
 
-frappe.provide('erpnext.accounts.dimensions');
 
 erpnext.TransactionController = class TransactionController extends erpnext.taxes_and_totals {
 	setup() {
@@ -793,24 +792,6 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 			erpnext.utils.get_shipping_address(this.frm, function() {
 				set_party_account(set_pricing);
 			});
-
-			// Get default company billing address in Purchase Invoice, Order and Receipt
-			if (this.frm.doc.company && frappe.meta.get_docfield(this.frm.doctype, "billing_address")) {
-				frappe.call({
-					method: "erpnext.setup.doctype.company.company.get_default_company_address",
-					args: {name: this.frm.doc.company, existing_address: this.frm.doc.billing_address || ""},
-					debounce: 2000,
-					callback: function(r) {
-						if (r.message) {
-							me.frm.set_value("billing_address", r.message);
-						} else {
-							if (frappe.meta.get_docfield(me.frm.doctype, 'company_address')) {
-								me.frm.set_value("company_address", "");
-							}
-						}
-					}
-				});
-			}
 
 		} else {
 			set_party_account(set_pricing);

--- a/erpnext/public/js/utils/party.js
+++ b/erpnext/public/js/utils/party.js
@@ -3,23 +3,12 @@
 
 frappe.provide("erpnext.utils");
 
+const SALES_DOCTYPES = ['Quotation', 'Sales Order', 'Delivery Note', 'Sales Invoice'];
+const PURCHASE_DOCTYPES = ['Purchase Order', 'Purchase Receipt', 'Purchase Invoice'];
+
 erpnext.utils.get_party_details = function(frm, method, args, callback) {
 	if (!method) {
 		method = "erpnext.accounts.party.get_party_details";
-	}
-
-	if (args) {
-		if (in_list(['Sales Invoice', 'Sales Order', 'Delivery Note'], frm.doc.doctype)) {
-			if (frm.doc.company_address && (!args.company_address)) {
-				args.company_address = frm.doc.company_address;
-			}
-		}
-
-		if (in_list(['Purchase Invoice', 'Purchase Order', 'Purchase Receipt'], frm.doc.doctype)) {
-			if (frm.doc.shipping_address && (!args.shipping_address)) {
-				args.shipping_address = frm.doc.shipping_address;
-			}
-		}
 	}
 
 	if (!args) {
@@ -45,41 +34,44 @@ erpnext.utils.get_party_details = function(frm, method, args, callback) {
 			};
 		}
 
-		if (in_list(['Sales Invoice', 'Sales Order', 'Delivery Note'], frm.doc.doctype)) {
-			if (!args) {
+		if (!args) {
+			if (in_list(SALES_DOCTYPES, frm.doc.doctype)) {
 				args = {
 					party: frm.doc.customer || frm.doc.party_name,
 					party_type: 'Customer'
-				}
-			}
-			if (frm.doc.company_address && (!args.company_address)) {
-				args.company_address = frm.doc.company_address;
+				};
 			}
 
-			if (frm.doc.shipping_address_name &&(!args.shipping_address_name)) {
-				args.shipping_address_name = frm.doc.shipping_address_name;
-			}
-		}
-
-		if (in_list(['Purchase Invoice', 'Purchase Order', 'Purchase Receipt'], frm.doc.doctype)) {
-			if (!args) {
+			if (in_list(PURCHASE_DOCTYPES, frm.doc.doctype)) {
 				args = {
 					party: frm.doc.supplier,
 					party_type: 'Supplier'
-				}
-			}
-
-			if (frm.doc.shipping_address && (!args.shipping_address)) {
-				args.shipping_address = frm.doc.shipping_address;
+				};
 			}
 		}
 
-		if (args) {
-			args.posting_date = frm.doc.posting_date || frm.doc.transaction_date;
-			args.fetch_payment_terms_template = cint(!frm.doc.ignore_default_payment_terms_template);
+		if (!args || !args.party) return;
+
+		args.posting_date = frm.doc.posting_date || frm.doc.transaction_date;
+		args.fetch_payment_terms_template = cint(!frm.doc.ignore_default_payment_terms_template);
+	}
+
+	if (in_list(SALES_DOCTYPES, frm.doc.doctype)) {
+		if (!args.company_address && frm.doc.company_address) {
+			args.company_address = frm.doc.company_address;
 		}
 	}
-	if (!args || !args.party) return;
+
+	if (in_list(PURCHASE_DOCTYPES, frm.doc.doctype)) {
+		if (!args.company_address && frm.doc.billing_address) {
+			args.company_address = frm.doc.billing_address;
+		}
+
+		if (!args.shipping_address && frm.doc.shipping_address) {
+			args.shipping_address = frm.doc.shipping_address;
+		}
+	}
+
 
 	if (frappe.meta.get_docfield(frm.doc.doctype, "taxes")) {
 		if (!erpnext.utils.validate_mandatory(frm, "Posting / Transaction Date",


### PR DESCRIPTION
## Issue

Company billing address is required for proper processing of regional taxation in purchase documents. However, this was unavailable when `get_party_details` was called, leading to incorrect execution of `get_regional_address_details`.

## Changes Made

### party.py

- Update `billing_address` from `company_address` for purchases, fetch values from the `billing_address`.
- Set `shipping_address` from specified value if available, else fallback to `billing_address`, i.e., `company_address` - same as before.

### buying.py
- Pass `billing_address` as `company_address` when setting missing values.

### transaction.js
- Remove JS code responsible for setting default company billing address in purchase transactions. This will now be handled in `get_party_details` itself.
- Remove unnecessary call to `frappe.provide` - it's only needed if you want an object to update, not to use a predefined object.

### party.js
- Add logic to set `company_address` for purchase doctypes.
- Do not  set `args.shipping_address_name` - the correct arg is `shipping_address`, and anyway, this is supposed to be reset based on the change in party.
- Create constants - `PURCHASE_DOCTYPES` and `SALES_DOCTYPES` to avoid repetition.
- Add **Quotation** in `SALES_DOCTYPES`, for consistency with `party.py`
- Rearrange code to reduce duplication.

### accounts_receivable.py
- semantic change to please linter