### PR TITLE
fix: minor URL link

### DIFF
--- a/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
+++ b/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
@@ -112,7 +112,7 @@ class RequestforQuotation(BuyingController):
 
 	def get_link(self):
 		# RFQ link for supplier portal
-		return get_url("/rfq/" + self.name)
+		return get_url("/app/request-for-quotation/" + self.name)
 
 	def update_supplier_part_no(self, supplier):
 		self.vendor = supplier


### PR DESCRIPTION
Incorrect RFQ URL link sent to supplier due to which supplier wouldn't able to open the RFQ page on web portal