### PR TITLE
fix: getting error to show sales invoice group or print rep…

### DIFF
--- a/erpnext/accounts/report/gross_profit/gross_profit.js
+++ b/erpnext/accounts/report/gross_profit/gross_profit.js
@@ -44,14 +44,14 @@ frappe.query_reports["Gross Profit"] = {
 	"parent_field": "parent_invoice",
 	"initial_depth": 3,
 	"formatter": function(value, row, column, data, default_formatter) {
-		if (column.fieldname == "sales_invoice" && column.options == "Item" && data.indent == 0) {
+		if (column.fieldname == "sales_invoice" && column.options == "Item" && data && data.indent == 0) {
 			column._options = "Sales Invoice";
 		} else {
 			column._options = "Item";
 		}
 		value = default_formatter(value, row, column, data);
 
-		if (data && (data.indent == 0.0 || row[1].content == "Total")) {
+		if (data && (data.indent == 0.0 || (row[1] && row[1].content == "Total"))) {
 			value = $(`<span>${value}</span>`);
 			var $value = $(value).css("font-weight", "bold");
 			value = $value.wrap("<p></p>").parent().html();


### PR DESCRIPTION
1 - When I view the Gross Profit report in Sales Invoice mode, the table is all broken .
https://prnt.sc/7iOqo6wr8y5C

Error on browser console: 
TypeError: Cannot read properties of undefined (reading 'indent')


2 - When I try to print, no matter the Group (Sales Invoice, Item Code, Item Group...) nothing happens. in browser log console I have the following error:
TypeError: Cannot read properties of undefined (reading 'content')


i fixed both errors and all working perfectly.