### PR TITLE
fix(ecommerce): remove query to non-existing field

### DIFF
--- a/erpnext/setup/doctype/item_group/item_group.py
+++ b/erpnext/setup/doctype/item_group/item_group.py
@@ -142,10 +142,6 @@ def get_item_for_list_in_html(context):
 	if (context.get("website_image") or "").startswith("files/"):
 		context["website_image"] = "/" + quote(context["website_image"])
 
-	context["show_availability_status"] = cint(
-		frappe.db.get_single_value("E Commerce Settings", "show_availability_status")
-	)
-
 	products_template = "templates/includes/products_as_list.html"
 
 	return frappe.get_template(products_template).render(context)


### PR DESCRIPTION
From frappe docker tests shared by @revant 


root cause: querying a field that was removed a long time back.

```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 69, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 54, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 45, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 83, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1588, in call
    return fn(*args, **newargs)
  File "apps/erpnext/erpnext/templates/pages/product_search.py", line 34, in get_product_list
    return [get_item_for_list_in_html(r) for r in data]
  File "apps/erpnext/erpnext/templates/pages/product_search.py", line 34, in <listcomp>
    return [get_item_for_list_in_html(r) for r in data]
  File "apps/erpnext/erpnext/setup/doctype/item_group/item_group.py", line 146, in get_item_for_list_in_html
    frappe.db.get_single_value("E Commerce Settings", "show_availability_status")
  File "apps/frappe/frappe/database/database.py", line 756, in get_single_value
    frappe.throw(
  File "apps/frappe/frappe/__init__.py", line 523, in throw
    msgprint(
  File "apps/frappe/frappe/__init__.py", line 491, in msgprint
    _raise_exception()
  File "apps/frappe/frappe/__init__.py", line 443, in _raise_exception
    raise raise_exception(msg)
frappe.database.database.Database.InvalidColumnName: Invalid field name: show_availability_status
```



removed here: https://github.com/frappe/erpnext/commit/82f8f3caf2a0233a216e56f013abe36f2c0a6caa 