### PR TITLE
fix: for Tree Type item and item group show net amout

### DIFF
--- a/erpnext/selling/report/sales_analytics/sales_analytics.py
+++ b/erpnext/selling/report/sales_analytics/sales_analytics.py
@@ -168,7 +168,7 @@ class Analytics(object):
 	def get_sales_transactions_based_on_items(self):
 
 		if self.filters["value_quantity"] == "Value":
-			value_field = "base_amount"
+			value_field = "base_net_amount"
 		else:
 			value_field = "stock_qty"
 
@@ -216,7 +216,7 @@ class Analytics(object):
 
 	def get_sales_transactions_based_on_item_group(self):
 		if self.filters["value_quantity"] == "Value":
-			value_field = "base_amount"
+			value_field = "base_net_amount"
 		else:
 			value_field = "qty"
 


### PR DESCRIPTION
When I place a Sales Order, let's assume my product costs $100, I sell 5 units, but I give $100 off, applying the discount in the "Additional Discount Amount" field.

Total products: $500
Additional Discount Amount: - $100
Net Amout: $400

Report: **Sales Analytics**
Tree Type = (Item, Item Group)

When I use the grouping by item or Item Group, the system is showing the sold value of the products, ex: $500, but the correct one must be $400, you must use the "base_net_amount" field to get the account in this report.
It doesn't make sense for me to open the Gross Profit report to view "$400" of sales and open the sales analytics respecting the groups informed above and the system display the value "$500".