### PR TITLE
fix: intercompany SO created from Purchase Order throws exception

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -2103,13 +2103,13 @@ def make_inter_company_transaction(doctype, source_name, target_doc=None):
 		target_detail_field = "sales_invoice_item" if doctype == "Sales Invoice" else "sales_order_item"
 		source_document_warehouse_field = "target_warehouse"
 		target_document_warehouse_field = "from_warehouse"
+		received_items = get_received_items(source_name, target_doctype, target_detail_field)
 	else:
 		source_doc = frappe.get_doc(doctype, source_name)
 		target_doctype = "Sales Invoice" if doctype == "Purchase Invoice" else "Sales Order"
 		source_document_warehouse_field = "from_warehouse"
 		target_document_warehouse_field = "target_warehouse"
-
-	received_items = get_received_items(source_name, target_doctype, target_detail_field)
+		received_items = {}
 
 	validate_inter_company_transaction(source_doc, doctype)
 	details = get_inter_company_details(source_doc, doctype)


### PR DESCRIPTION
## Issue
Inter company Sales Order created from a Purchase Order throws exception.

## Fix
Received items fetched only for Sales Invoice/Orders.

closes https://github.com/frappe/erpnext/issues/31590