### PR TITLE
Bug add accouting dimension in asset repair

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -507,6 +507,7 @@ accounting_dimension_doctypes = [
 	"Shipping Rule",
 	"Landed Cost Item",
 	"Asset Value Adjustment",
+	"Asset Repair",
 	"Loyalty Program",
 	"Stock Reconciliation",
 	"POS Profile",

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -268,6 +268,7 @@ erpnext.patches.v13_0.enable_ksa_vat_docs #1
 erpnext.patches.v13_0.show_india_localisation_deprecation_warning
 erpnext.patches.v13_0.show_hr_payroll_deprecation_warning
 erpnext.patches.v13_0.reset_corrupt_defaults
+erpnext.patches.v13_0.create_accounting_dimensions_for_asset_repair
 
 [post_model_sync]
 execute:frappe.delete_doc_if_exists('Workspace', 'ERPNext Integrations Settings')

--- a/erpnext/patches/v13_0/create_accounting_dimensions_for_asset_repair.py
+++ b/erpnext/patches/v13_0/create_accounting_dimensions_for_asset_repair.py
@@ -1,0 +1,29 @@
+import frappe
+from frappe.custom.doctype.custom_field.custom_field import create_custom_field
+
+
+def execute():
+	accounting_dimensions = frappe.db.get_all(
+		"Accounting Dimension", fields=["fieldname", "label", "document_type", "disabled"]
+	)
+
+	if not accounting_dimensions:
+		return
+
+	for d in accounting_dimensions:
+		doctype = "Asset Repair"
+		field = frappe.db.get_value("Custom Field", {"dt": doctype, "fieldname": d.fieldname})
+
+		if field:
+			continue
+
+		df = {
+			"fieldname": d.fieldname,
+			"label": d.label,
+			"fieldtype": "Link",
+			"options": d.document_type,
+			"insert_after": "accounting_dimensions_section",
+		}
+
+		create_custom_field(doctype, df, ignore_validate=True)
+		frappe.clear_cache(doctype=doctype)


### PR DESCRIPTION
## Issue
When asset repair cost is capitalized, GL entries are posted. In such case, validation error is thrown for accounting dimension that are mandatory for P/L accounts. There is no provision to enter the new dimensions in the **Accounting Dimensions** section.

## Fix
Include **Asset Repair** in dimension creation hook.