### PR TITLE
fix: incorrect incoming rate set for inter transfer purchase receipt

### DIFF
--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -307,7 +307,8 @@ class BuyingController(SubcontractingController):
 
 					rate = flt(outgoing_rate * (d.conversion_factor or 1), d.precision("rate"))
 				else:
-					rate = frappe.db.get_value(ref_doctype, d.get(frappe.scrub(ref_doctype)), "rate")
+					field = "incoming_rate" if self.get("is_internal_supplier") else "rate"
+					rate = frappe.db.get_value(ref_doctype, d.get(frappe.scrub(ref_doctype)), field)
 
 				if self.is_internal_transfer():
 					if rate != d.rate:

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -646,6 +646,24 @@ class update_entries_after(object):
 					voucher_detail_no=sle.voucher_detail_no,
 					sle=sle,
 				)
+
+			elif (
+				sle.voucher_type in ["Purchase Receipt", "Purchase Invoice"]
+				and sle.actual_qty > 0
+				and frappe.get_cached_value(sle.voucher_type, sle.voucher_no, "is_internal_supplier")
+			):
+				sle_details = frappe.db.get_value(
+					"Stock Ledger Entry",
+					{
+						"voucher_type": sle.voucher_type,
+						"voucher_no": sle.voucher_no,
+						"dependant_sle_voucher_detail_no": sle.voucher_detail_no,
+					},
+					["stock_value_difference", "actual_qty"],
+					as_dict=1,
+				)
+
+				rate = abs(sle_details.stock_value_difference / sle.actual_qty)
 			else:
 				if sle.voucher_type in ("Purchase Receipt", "Purchase Invoice"):
 					rate_field = "valuation_rate"


### PR DESCRIPTION
**Issue**

1. Make Intra Company transfer transaction for Item A with valuation rate as 100
2. Make Delivery Note and Purchase Receipt 
3. Create backdated purchase entry for Item A with incoming rate as 200 in a way that the previous delivery note's valuation rate should change to new rate as 200
4. System update the valuation rate to 200 for the previous delivery note
5. But System not update the valuation rate in the Purchase Receipt which causing incorrect stock and account value