### PR TITLE
fix: update To Date in Employee Work History

### DIFF
--- a/erpnext/hr/doctype/employee_transfer/test_employee_transfer.py
+++ b/erpnext/hr/doctype/employee_transfer/test_employee_transfer.py
@@ -80,12 +80,14 @@ class TestEmployeeTransfer(unittest.TestCase):
 		department = ["Accounts - TC", "Management - TC"]
 		designation = ["Accountant", "Manager"]
 		dt = [getdate("01-10-2021"), getdate()]
+		to_date = [add_days(dt[1], -1), None]
 
 		employee = frappe.get_doc("Employee", employee)
 		for data in employee.internal_work_history:
 			self.assertEqual(data.department, department[count])
 			self.assertEqual(data.designation, designation[count])
 			self.assertEqual(data.from_date, dt[count])
+			self.assertEqual(data.to_date, to_date[count])
 			count = count + 1
 
 		transfer.cancel()
@@ -95,6 +97,7 @@ class TestEmployeeTransfer(unittest.TestCase):
 			self.assertEqual(data.designation, designation[0])
 			self.assertEqual(data.department, department[0])
 			self.assertEqual(data.from_date, dt[0])
+			self.assertEqual(data.to_date, None)
 
 
 def create_company():

--- a/erpnext/hr/utils.py
+++ b/erpnext/hr/utils.py
@@ -224,6 +224,7 @@ def delete_employee_work_history(details, employee, date):
 				filters["from_date"] = date
 	if filters:
 		frappe.db.delete("Employee Internal Work History", filters)
+		employee.reload()
 
 
 @frappe.whitelist()


### PR DESCRIPTION
## Problem:

On Employee Promotion/Employee Transfer submission, internal work history gets updated in the Employee master. This updates From Date but doesn't update To Date.

The To Date functionality was never implemented in work history. When you create a promotion, the system won't really know until when is that applicable. 

<img width="1310" alt="image" src="https://user-images.githubusercontent.com/24353136/183646631-41aff726-a614-4f22-9040-dbf28f88fdff.png">


## Solution:
Update the previous row when a new promotion/transfer happens.
Eg: Promotion 1: From Date - 01-01-2022
Promotion 2: From Date - 04-04-2022 - this will update the previous promotion's To Date to 03-04-2022

<img width="1310" alt="image" src="https://user-images.githubusercontent.com/24353136/183646570-dcb9dfc5-ec45-4090-b6bb-b89714e85cb6.png">
