### PR TITLE
fix: Payment Entry button is visible even when claim is fully paid

### DIFF
--- a/erpnext/hr/doctype/expense_claim/expense_claim.js
+++ b/erpnext/hr/doctype/expense_claim/expense_claim.js
@@ -254,9 +254,11 @@ frappe.ui.form.on("Expense Claim", {
 			}, __("View"));
 		}
 
-		if (frm.doc.docstatus===1 && !cint(frm.doc.is_paid) && cint(frm.doc.grand_total) > 0
-				&& (cint(frm.doc.total_amount_reimbursed) < cint(frm.doc.total_sanctioned_amount))
-				&& frappe.model.can_create("Payment Entry")) {
+		if (
+			frm.doc.docstatus === 1
+			&& frm.doc.status !== "Paid"
+			&& frappe.model.can_create("Payment Entry")
+		) {
 			frm.add_custom_button(__('Payment'),
 				function() { frm.events.make_payment_entry(frm); }, __('Create'));
 		}

--- a/erpnext/hr/doctype/expense_claim/expense_claim.py
+++ b/erpnext/hr/doctype/expense_claim/expense_claim.py
@@ -305,8 +305,9 @@ class ExpenseClaim(AccountsController):
 
 		if self.total_advance_amount:
 			precision = self.precision("total_advance_amount")
-			amount_with_taxes = flt(self.total_sanctioned_amount, precision) + flt(
-				self.total_taxes_and_charges, precision
+			amount_with_taxes = flt(
+				(flt(self.total_sanctioned_amount, precision) + flt(self.total_taxes_and_charges, precision)),
+				precision,
 			)
 
 			if flt(self.total_advance_amount, precision) > amount_with_taxes:


### PR DESCRIPTION
## Before:

1. Payment Entry button is visible even when the claim is fully paid (partial advance and partial payment)

	<img width="1310" alt="after-claim" src="https://user-images.githubusercontent.com/24353136/183651026-f77b8740-c019-4246-b687-f67b25bc68d0.png">

2. Here sanctioned amount + tax amount = advance amount, so the system should allow allocating but the validation doesn't consider precision:

	<img width="1310" alt="adv" src="https://user-images.githubusercontent.com/24353136/183654376-80a10a34-9e1d-4ff4-bac7-f21f0c00b4dc.png">

	<img width="1310" alt="image" src="https://user-images.githubusercontent.com/24353136/183654614-f008ad07-94c8-455c-8477-5512289ef683.png">


## After:

1. <img width="1310" alt="image" src="https://user-images.githubusercontent.com/24353136/183651163-db6d236e-8454-45d2-ad36-63e9b206b8ab.png">
