### PR TITLE
fix: limited options for no-of-employees in the crm documents

### DIFF
--- a/erpnext/crm/doctype/lead/lead.json
+++ b/erpnext/crm/doctype/lead/lead.json
@@ -340,8 +340,8 @@
    "fieldname": "no_of_employees",
    "fieldtype": "Select",
    "label": "No of Employees",
-   "options": "1-10\n11-20\n21-30\n31-100\n11-50\n51-200\n201-500\n101-500\n500-1000\n501-1000\n>1000\n1000+"
-  }, 
+   "options": "1-10\n11-50\n51-200\n201-500\n501-1000\n1000+"
+  },
   {
    "fieldname": "column_break_22",
    "fieldtype": "Column Break"
@@ -514,7 +514,7 @@
  "idx": 5,
  "image_field": "image",
  "links": [],
- "modified": "2022-07-22 15:55:03.176094",
+ "modified": "2022-08-09 18:26:17.101521",
  "modified_by": "Administrator",
  "module": "CRM",
  "name": "Lead",

--- a/erpnext/crm/doctype/opportunity/opportunity.json
+++ b/erpnext/crm/doctype/opportunity/opportunity.json
@@ -463,7 +463,7 @@
    "fieldname": "no_of_employees",
    "fieldtype": "Select",
    "label": "No of Employees",
-   "options": "1-10\n11-20\n21-30\n31-100\n11-50\n51-200\n201-500\n101-500\n500-1000\n501-1000\n>1000\n1000+"
+   "options": "1-10\n11-50\n51-200\n201-500\n501-1000\n1000+"
   },
   {
    "fieldname": "annual_revenue",
@@ -622,7 +622,7 @@
  "icon": "fa fa-info-sign",
  "idx": 195,
  "links": [],
- "modified": "2022-07-22 18:46:32.858696",
+ "modified": "2022-08-09 18:26:37.235964",
  "modified_by": "Administrator",
  "module": "CRM",
  "name": "Opportunity",

--- a/erpnext/crm/doctype/prospect/prospect.json
+++ b/erpnext/crm/doctype/prospect/prospect.json
@@ -82,7 +82,7 @@
    "fieldname": "no_of_employees",
    "fieldtype": "Select",
    "label": "No. of Employees",
-   "options": "1-10\n11-20\n21-30\n31-100\n11-50\n51-200\n201-500\n101-500\n500-1000\n501-1000\n>1000\n1000+"
+   "options": "1-10\n11-50\n51-200\n201-500\n501-1000\n1000+"
   },
   {
    "fieldname": "annual_revenue",
@@ -218,7 +218,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-06-22 15:10:26.887502",
+ "modified": "2022-08-09 18:26:56.950185",
  "modified_by": "Administrator",
  "module": "CRM",
  "name": "Prospect",

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -310,3 +310,4 @@ erpnext.patches.v14_0.crm_ux_cleanup
 erpnext.patches.v14_0.remove_india_localisation # 14-07-2022
 erpnext.patches.v13_0.fix_number_and_frequency_for_monthly_depreciation
 erpnext.patches.v14_0.remove_hr_and_payroll_modules # 20-07-2022
+erpnext.patches.v14_0.fix_crm_no_of_employees

--- a/erpnext/patches/v14_0/fix_crm_no_of_employees.py
+++ b/erpnext/patches/v14_0/fix_crm_no_of_employees.py
@@ -1,0 +1,26 @@
+import frappe
+
+
+def execute():
+	options = {
+		"11-20": "11-50",
+		"21-30": "11-50",
+		"31-100": "51-200",
+		"101-500": "201-500",
+		"500-1000": "501-1000",
+		">1000": "1000+",
+	}
+
+	for doctype in ("Lead", "Opportunity", "Prospect"):
+		frappe.reload_doctype(doctype)
+		for key, value in options.items():
+			frappe.db.sql(
+				"""
+                update `tab{doctype}`
+                set no_of_employees = %s
+                where no_of_employees = %s
+            """.format(
+					doctype=doctype
+				),
+				(value, key),
+			)


### PR DESCRIPTION
Limited options for no-of-employees in the Lead, Opportunity and Prospect documents.

Old options:
```
1-10
11-20
21-30
31-100
11-50
51-200
201-500
101-500
500-1000
501-1000
>1000
1000+
```

New Options:
```
1-10
11-50
51-200
201-500
501-1000
1000+
```