### PR TITLE
fix: limit pos recent order page result

### DIFF
--- a/erpnext/selling/page/point_of_sale/point_of_sale.py
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.py
@@ -253,16 +253,20 @@ def get_past_order_list(search_term, status, limit=20):
 			"POS Invoice",
 			filters={"customer": ["like", "%{}%".format(search_term)], "status": status},
 			fields=fields,
+			page_length=limit,
 		)
 		invoices_by_name = frappe.db.get_all(
 			"POS Invoice",
 			filters={"name": ["like", "%{}%".format(search_term)], "status": status},
 			fields=fields,
+			page_length=limit,
 		)
 
 		invoice_list = invoices_by_customer + invoices_by_name
 	elif status:
-		invoice_list = frappe.db.get_all("POS Invoice", filters={"status": status}, fields=fields)
+		invoice_list = frappe.db.get_all(
+			"POS Invoice", filters={"status": status}, fields=fields, page_length=limit
+		)
 
 	return invoice_list
 


### PR DESCRIPTION
## Issue
POS Recent Order page crashes if the no of invoice grows larger in size.

<img width="1213" alt="Screenshot 2022-08-09 at 8 35 12 PM" src="https://user-images.githubusercontent.com/3272205/183686609-4086181f-7182-464f-9795-025ba169f50b.png">

<img width="1307" alt="Screenshot 2022-08-09 at 8 36 00 PM" src="https://user-images.githubusercontent.com/3272205/183686760-249373bc-0a8b-4fb8-9504-1e48e60a53ad.png">

## Fix
Query result should be limited by default.