### PR TITLE
fix(minor): don't print tax rate if its '0'

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_item_cart.js
+++ b/erpnext/selling/page/point_of_sale/pos_item_cart.js
@@ -524,7 +524,8 @@ erpnext.PointOfSale.ItemCart = class {
 			const currency = this.events.get_frm().doc.currency;
 			const taxes_html = taxes.map(t => {
 				if (t.tax_amount_after_discount_amount == 0.0) return;
-				const description = /[0-9]+/.test(t.description) ? t.description : `${t.description} @ ${t.rate}%`;
+				// if tax rate is 0, don't print it.
+				const description = /[0-9]+/.test(t.description) ? t.description : ((t.rate != 0) ? `${t.description} @ ${t.rate}%`: t.description);
 				return `<div class="tax-row">
 					<div class="tax-label">${description}</div>
 					<div class="tax-value">${format_currency(t.tax_amount_after_discount_amount, currency)}</div>

--- a/erpnext/selling/page/point_of_sale/pos_past_order_summary.js
+++ b/erpnext/selling/page/point_of_sale/pos_past_order_summary.js
@@ -130,7 +130,8 @@ erpnext.PointOfSale.PastOrderSummary = class {
 		if (!doc.taxes.length) return '';
 
 		let taxes_html = doc.taxes.map(t => {
-			const description = /[0-9]+/.test(t.description) ? t.description : `${t.description} @ ${t.rate}%`;
+			// if tax rate is 0, don't print it.
+			const description = /[0-9]+/.test(t.description) ? t.description : ((t.rate != 0) ? `${t.description} @ ${t.rate}%`: t.description);
 			return `
 				<div class="tax-row">
 					<div class="tax-label">${description}</div>


### PR DESCRIPTION
## Minor UI fix
If tax rate is 0, don't print it on tax description.

<img width="1015" alt="Screenshot 2022-08-16 at 2 16 33 PM" src="https://user-images.githubusercontent.com/3272205/184837832-dfd8d17d-e5f9-4be6-b6d9-a4b3a6e15b8e.png">
<img width="481" alt="Screenshot 2022-08-12 at 6 41 03 PM" src="https://user-images.githubusercontent.com/3272205/184370130-64eef73f-2da8-42e6-aa2a-98e495f4dd07.png">

<img width="465" alt="Screenshot 2022-08-12 at 6 40 57 PM" src="https://user-images.githubusercontent.com/3272205/184370139-a19b3442-f2eb-4363-8415-233d5d79c05c.png">

