### PR TITLE
feat: Utilities for computing total weight that normalizes UOM

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
@@ -73,9 +73,14 @@
   "base_total",
   "base_net_total",
   "column_break_28",
-  "total_net_weight",
   "total",
   "net_total",
+  "weight_details_section",
+  "custom_weight_uom",
+  "weight_in_selected_uom",
+  "column_break_49",
+  "default_weight_uom",
+  "total_net_weight",
   "taxes_section",
   "tax_category",
   "column_break_49",
@@ -1416,6 +1421,39 @@
    "hidden": 1,
    "label": "Advance Tax",
    "options": "Advance Tax",
+   "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "weight_details_section",
+   "fieldtype": "Section Break",
+   "label": "Weight Details"
+  },
+  {
+   "depends_on": "total_net_weight",
+   "fieldname": "custom_weight_uom",
+   "fieldtype": "Link",
+   "label": "Custom Weight UOM",
+   "options": "UOM"
+  },
+  {
+   "depends_on": "custom_weight_uom",
+   "fieldname": "weight_in_selected_uom",
+   "fieldtype": "Float",
+   "label": "Weight in Selected UOM",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_49",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "company.default_weight_uom",
+   "fetch_if_empty": 1,
+   "fieldname": "default_weight_uom",
+   "fieldtype": "Link",
+   "label": "Default Weight UOM",
+   "options": "UOM",
    "read_only": 1
   }
  ],

--- a/erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
+++ b/erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
@@ -103,6 +103,9 @@
   "total_weight",
   "column_break_38",
   "weight_uom",
+  "default_weight_uom",
+  "weight_conversion_factor",
+  "net_weight_as_per_default",
   "accounting_dimensions_section",
   "project",
   "dimension_col_break",
@@ -865,6 +868,25 @@
    "fieldtype": "Link",
    "label": "Product Bundle",
    "options": "Product Bundle",
+   "read_only": 1
+  },
+  {
+   "fieldname": "default_weight_uom",
+   "fieldtype": "Link",
+   "label": "Default Weight UOM",
+   "options": "UOM",
+   "read_only": 1
+  },
+  {
+   "fieldname": "weight_conversion_factor",
+   "fieldtype": "Float",
+   "label": "Weight Conversion Factor",
+   "read_only": 1
+  },
+  {
+   "fieldname": "net_weight_as_per_default",
+   "fieldtype": "Float",
+   "label": "Net Weight as Per Default",
    "read_only": 1
   }
  ],

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
@@ -80,9 +80,14 @@
   "base_total",
   "base_net_total",
   "column_break_32",
-  "total_net_weight",
   "total",
   "net_total",
+  "weight_details_section",
+  "custom_weight_uom",
+  "weight_in_selected_uom",
+  "column_break_49",
+  "default_weight_uom",
+  "total_net_weight",
   "taxes_section",
   "taxes_and_charges",
   "column_break_38",
@@ -2034,6 +2039,39 @@
    "fieldname": "is_cash_or_non_trade_discount",
    "fieldtype": "Check",
    "label": "Is Cash or Non Trade Discount"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "weight_details_section",
+   "fieldtype": "Section Break",
+   "label": "Weight Details"
+  },
+  {
+   "depends_on": "total_net_weight",
+   "fieldname": "custom_weight_uom",
+   "fieldtype": "Link",
+   "label": "Custom Weight UOM",
+   "options": "UOM"
+  },
+  {
+   "depends_on": "custom_weight_uom",
+   "fieldname": "weight_in_selected_uom",
+   "fieldtype": "Float",
+   "label": "Weight in Selected UOM",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_49",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "company.default_weight_uom",
+   "fetch_if_empty": 1,
+   "fieldname": "default_weight_uom",
+   "fieldtype": "Link",
+   "label": "Default Weight UOM",
+   "options": "UOM",
+   "read_only": 1
   }
  ],
  "icon": "fa fa-file-text",

--- a/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
+++ b/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
@@ -76,6 +76,9 @@
   "total_weight",
   "column_break_21",
   "weight_uom",
+  "default_weight_uom",
+  "weight_conversion_factor",
+  "net_weight_as_per_default",
   "warehouse_and_reference",
   "warehouse",
   "target_warehouse",
@@ -836,6 +839,25 @@
    "fieldname": "grant_commission",
    "fieldtype": "Check",
    "label": "Grant Commission",
+   "read_only": 1
+  },
+  {
+   "fieldname": "default_weight_uom",
+   "fieldtype": "Link",
+   "label": "Default Weight UOM",
+   "options": "UOM",
+   "read_only": 1
+  },
+  {
+   "fieldname": "weight_conversion_factor",
+   "fieldtype": "Float",
+   "label": "Weight Conversion Factor",
+   "read_only": 1
+  },
+  {
+   "fieldname": "net_weight_as_per_default",
+   "fieldtype": "Float",
+   "label": "Net Weight as Per Default",
    "read_only": 1
   }
  ],

--- a/erpnext/buying/doctype/purchase_order/purchase_order.json
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.json
@@ -70,9 +70,14 @@
   "base_total",
   "base_net_total",
   "column_break_26",
-  "total_net_weight",
   "total",
   "net_total",
+  "weight_details_section",
+  "custom_weight_uom",
+  "weight_in_selected_uom",
+  "column_break_49",
+  "default_weight_uom",
+  "total_net_weight",
   "section_break_48",
   "pricing_rules",
   "raw_material_details",
@@ -1164,6 +1169,39 @@
    "fieldtype": "Link",
    "label": "Project",
    "options": "Project"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "weight_details_section",
+   "fieldtype": "Section Break",
+   "label": "Weight Details"
+  },
+  {
+   "depends_on": "total_net_weight",
+   "fieldname": "custom_weight_uom",
+   "fieldtype": "Link",
+   "label": "Custom Weight UOM",
+   "options": "UOM"
+  },
+  {
+   "depends_on": "custom_weight_uom",
+   "fieldname": "weight_in_selected_uom",
+   "fieldtype": "Float",
+   "label": "Weight in Selected UOM",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_49",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "company.default_weight_uom",
+   "fetch_if_empty": 1,
+   "fieldname": "default_weight_uom",
+   "fieldtype": "Link",
+   "label": "Default Weight UOM",
+   "options": "UOM",
+   "read_only": 1
   }
  ],
  "icon": "fa fa-file-text",

--- a/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
+++ b/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
@@ -91,6 +91,9 @@
   "total_weight",
   "column_break_40",
   "weight_uom",
+  "default_weight_uom",
+  "weight_conversion_factor",
+  "net_weight_as_per_default",
   "accounting_dimensions_section",
   "project",
   "dimension_col_break",
@@ -845,6 +848,25 @@
    "label": "Sales Order Packed Item",
    "no_copy": 1,
    "print_hide": 1
+  },
+  {
+   "fieldname": "default_weight_uom",
+   "fieldtype": "Link",
+   "label": "Default Weight UOM",
+   "options": "UOM",
+   "read_only": 1
+  },
+  {
+   "fieldname": "weight_conversion_factor",
+   "fieldtype": "Float",
+   "label": "Weight Conversion Factor",
+   "read_only": 1
+  },
+  {
+   "fieldname": "net_weight_as_per_default",
+   "fieldtype": "Float",
+   "label": "Net Weight as Per Default",
+   "read_only": 1
   }
  ],
  "idx": 1,

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -554,8 +554,12 @@ class calculate_taxes_and_totals(object):
 		if self.doc.meta.get_field("total_net_weight"):
 			self.doc.total_net_weight = 0.0
 			for d in self.doc.items:
-				if d.total_weight:
-					self.doc.total_net_weight += d.total_weight
+				if d.net_weight_as_per_default:
+					self.doc.total_net_weight += d.net_weight_as_per_default
+				else:
+					self.doc.total_net_weight = 0.0
+					frappe.msgprint(msg = _("UOM details invalid/missing for item <b>{}</b>").format(d.item_code), alert=True, indicator='red')
+					break
 
 	def set_rounded_total(self):
 		if self.doc.get("is_consolidated") and self.doc.get("rounding_adjustment"):

--- a/erpnext/selling/doctype/quotation/quotation.json
+++ b/erpnext/selling/doctype/quotation/quotation.json
@@ -56,6 +56,11 @@
   "column_break_28",
   "total",
   "net_total",
+  "weight_details_section",
+  "custom_weight_uom",
+  "weight_in_selected_uom",
+  "column_break_49",
+  "default_weight_uom",
   "total_net_weight",
   "taxes_section",
   "tax_category",
@@ -1168,6 +1173,39 @@
    "read_only": 1,
    "show_days": 1,
    "show_seconds": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "weight_details_section",
+   "fieldtype": "Section Break",
+   "label": "Weight Details"
+  },
+  {
+   "depends_on": "total_net_weight",
+   "fieldname": "custom_weight_uom",
+   "fieldtype": "Link",
+   "label": "Custom Weight UOM",
+   "options": "UOM"
+  },
+  {
+   "depends_on": "custom_weight_uom",
+   "fieldname": "weight_in_selected_uom",
+   "fieldtype": "Float",
+   "label": "Weight in Selected UOM",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_49",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "company.default_weight_uom",
+   "fetch_if_empty": 1,
+   "fieldname": "default_weight_uom",
+   "fieldtype": "Link",
+   "label": "Default Weight UOM",
+   "options": "UOM",
+   "read_only": 1
   }
  ],
  "icon": "fa fa-shopping-cart",

--- a/erpnext/selling/doctype/quotation_item/quotation_item.json
+++ b/erpnext/selling/doctype/quotation_item/quotation_item.json
@@ -58,6 +58,9 @@
   "total_weight",
   "column_break_20",
   "weight_uom",
+  "default_weight_uom",
+  "weight_conversion_factor",
+  "net_weight_as_per_default",
   "reference",
   "warehouse",
   "against_blanket_order",
@@ -643,6 +646,25 @@
    "label": "Rate of Stock UOM",
    "no_copy": 1,
    "options": "currency",
+   "read_only": 1
+  },
+  {
+   "fieldname": "default_weight_uom",
+   "fieldtype": "Link",
+   "label": "Default Weight UOM",
+   "options": "UOM",
+   "read_only": 1
+  },
+  {
+   "fieldname": "weight_conversion_factor",
+   "fieldtype": "Float",
+   "label": "Weight Conversion Factor",
+   "read_only": 1
+  },
+  {
+   "fieldname": "net_weight_as_per_default",
+   "fieldtype": "Float",
+   "label": "Net Weight as Per Default",
    "read_only": 1
   }
  ],

--- a/erpnext/selling/doctype/sales_order/sales_order.json
+++ b/erpnext/selling/doctype/sales_order/sales_order.json
@@ -69,9 +69,14 @@
   "base_total",
   "base_net_total",
   "column_break_33",
-  "total_net_weight",
   "total",
   "net_total",
+  "weight_details_section",
+  "custom_weight_uom",
+  "weight_in_selected_uom",
+  "column_break_54",
+  "default_weight_uom",
+  "total_net_weight",
   "taxes_section",
   "tax_category",
   "column_break_38",
@@ -1543,6 +1548,39 @@
   {
    "fieldname": "dimension_col_break",
    "fieldtype": "Column Break"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "weight_details_section",
+   "fieldtype": "Section Break",
+   "label": "Weight Details"
+  },
+  {
+   "depends_on": "total_net_weight",
+   "fieldname": "custom_weight_uom",
+   "fieldtype": "Link",
+   "label": "Custom Weight UOM",
+   "options": "UOM"
+  },
+  {
+   "depends_on": "custom_weight_uom",
+   "fieldname": "weight_in_selected_uom",
+   "fieldtype": "Float",
+   "label": "Weight in Selected UOM",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_54",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "company.default_weight_uom",
+   "fetch_if_empty": 1,
+   "fieldname": "default_weight_uom",
+   "fieldtype": "Link",
+   "label": "Default Weight UOM",
+   "options": "UOM",
+   "read_only": 1
   }
  ],
  "icon": "fa fa-file-text",

--- a/erpnext/selling/doctype/sales_order_item/sales_order_item.json
+++ b/erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -67,6 +67,9 @@
   "total_weight",
   "column_break_21",
   "weight_uom",
+  "default_weight_uom",
+  "weight_conversion_factor",
+  "net_weight_as_per_default",
   "warehouse_and_reference",
   "warehouse",
   "target_warehouse",
@@ -803,6 +806,25 @@
    "fieldtype": "Float",
    "label": "Picked Qty (in Stock UOM)",
    "no_copy": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "default_weight_uom",
+   "fieldtype": "Link",
+   "label": "Default Weight UOM",
+   "options": "UOM",
+   "read_only": 1
+  },
+  {
+   "fieldname": "weight_conversion_factor",
+   "fieldtype": "Float",
+   "label": "Weight Conversion Factor",
+   "read_only": 1
+  },
+  {
+   "fieldname": "net_weight_as_per_default",
+   "fieldtype": "Float",
+   "label": "Net Weight as Per Default",
    "read_only": 1
   }
  ],

--- a/erpnext/setup/doctype/company/company.js
+++ b/erpnext/setup/doctype/company/company.js
@@ -16,6 +16,8 @@ frappe.ui.form.on("Company", {
 		frm.call('check_if_transactions_exist').then(r => {
 			frm.toggle_enable("default_currency", (!r.message));
 		});
+		
+		frm.trigger('get_weight_uoms');
 	},
 	setup: function(frm) {
 		erpnext.company.setup_queries(frm);
@@ -47,6 +49,25 @@ frappe.ui.form.on("Company", {
 					'company': frm.doc.company
 				}
 			};
+		});
+	},
+
+	get_weight_uoms: function(frm) {
+		var units = [];
+		frappe.call({
+			method: "frappe.client.get_list",
+			args: {
+				doctype: "UOM Conversion Factor",
+				filters: { "category": __("Mass") },
+				fields: ["to_uom"],
+				limit_page_length: 500
+			},
+			callback: function (r) {
+				r.message.forEach(row => units.push(row.to_uom));
+			}
+		});
+		frm.set_query("default_weight_uom", function () {
+			return { filters: { "name": ["IN", units] } };
 		});
 	},
 

--- a/erpnext/setup/doctype/company/company.json
+++ b/erpnext/setup/doctype/company/company.json
@@ -70,6 +70,7 @@
   "default_inventory_account",
   "stock_adjustment_account",
   "column_break_32",
+  "default_weight_uom",
   "stock_received_but_not_billed",
   "default_provisional_account",
   "expenses_included_in_valuation",
@@ -740,6 +741,12 @@
    "label": "Default Provisional Account",
    "no_copy": 1,
    "options": "Account"
+  },
+  {
+   "fieldname": "default_weight_uom",
+   "fieldtype": "Link",
+   "label": "Default Weight UOM",
+   "options": "UOM"
   }
  ],
  "icon": "fa fa-building",

--- a/erpnext/stock/doctype/delivery_note/delivery_note.json
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.json
@@ -73,9 +73,14 @@
   "base_total",
   "base_net_total",
   "column_break_33",
-  "total_net_weight",
   "total",
   "net_total",
+  "weight_details_section",
+  "custom_weight_uom",
+  "weight_in_selected_uom",
+  "column_break_49",
+  "default_weight_uom",
+  "total_net_weight",
   "taxes_section",
   "tax_category",
   "column_break_39",
@@ -1330,6 +1335,39 @@
   {
    "fieldname": "dimension_col_break",
    "fieldtype": "Column Break"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "weight_details_section",
+   "fieldtype": "Section Break",
+   "label": "Weight Details"
+  },
+  {
+   "depends_on": "total_net_weight",
+   "fieldname": "custom_weight_uom",
+   "fieldtype": "Link",
+   "label": "Custom Weight UOM",
+   "options": "UOM"
+  },
+  {
+   "depends_on": "custom_weight_uom",
+   "fieldname": "weight_in_selected_uom",
+   "fieldtype": "Float",
+   "label": "Weight in Selected UOM",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_49",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "company.default_weight_uom",
+   "fetch_if_empty": 1,
+   "fieldname": "default_weight_uom",
+   "fieldtype": "Link",
+   "label": "Default Weight UOM",
+   "options": "UOM",
+   "read_only": 1
   }
  ],
  "icon": "fa fa-truck",

--- a/erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
+++ b/erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -64,6 +64,9 @@
   "total_weight",
   "column_break_21",
   "weight_uom",
+  "default_weight_uom",
+  "weight_conversion_factor",
+  "net_weight_as_per_default",
   "warehouse_and_reference",
   "warehouse",
   "target_warehouse",
@@ -773,6 +776,25 @@
    "label": "Pick List Item",
    "no_copy": 1,
    "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "default_weight_uom",
+   "fieldtype": "Link",
+   "label": "Default Weight UOM",
+   "options": "UOM",
+   "read_only": 1
+  },
+  {
+   "fieldname": "weight_conversion_factor",
+   "fieldtype": "Float",
+   "label": "Weight Conversion Factor",
+   "read_only": 1
+  },
+  {
+   "fieldname": "net_weight_as_per_default",
+   "fieldtype": "Float",
+   "label": "Net Weight as Per Default",
    "read_only": 1
   }
  ],

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.json
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.json
@@ -63,9 +63,14 @@
   "base_total",
   "base_net_total",
   "column_break_27",
-  "total_net_weight",
   "total",
   "net_total",
+  "weight_details_section",
+  "custom_weight_uom",
+  "weight_in_selected_uom",
+  "column_break_49",
+  "default_weight_uom",
+  "total_net_weight",
   "pricing_rule_details",
   "pricing_rules",
   "raw_material_details",
@@ -1143,6 +1148,39 @@
   {
    "fieldname": "dimension_col_break",
    "fieldtype": "Column Break"
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "weight_details_section",
+   "fieldtype": "Section Break",
+   "label": "Weight Details"
+  },
+  {
+   "depends_on": "total_net_weight",
+   "fieldname": "custom_weight_uom",
+   "fieldtype": "Link",
+   "label": "Custom Weight UOM",
+   "options": "UOM"
+  },
+  {
+   "depends_on": "custom_weight_uom",
+   "fieldname": "weight_in_selected_uom",
+   "fieldtype": "Float",
+   "label": "Weight in Selected UOM",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_49",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fetch_from": "company.default_weight_uom",
+   "fetch_if_empty": 1,
+   "fieldname": "default_weight_uom",
+   "fieldtype": "Link",
+   "label": "Default Weight UOM",
+   "options": "UOM",
+   "read_only": 1
   }
  ],
  "icon": "fa fa-truck",


### PR DESCRIPTION
This PR adds the ability to calculate the weight of items in any particular UOM which can be set from the company form. Apart from that users can select custom UOM (from the form) to convert that further to their needs. For cases like missing weight UOM, the total net weight will be set to 0. #28653

![image](https://user-images.githubusercontent.com/36790711/184706936-e453ff3e-bbb7-431f-82dc-0fb264965144.png)

https://user-images.githubusercontent.com/36790711/184710623-396cee46-7c17-4e8c-a367-e3419216caf3.mp4


