### PR TITLE
fix: incorrect tax amt due to different exchange rate in PR and PI

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -1791,4 +1791,6 @@ def make_purchase_receipt(source_name, target_doc=None):
 		target_doc,
 	)
 
+	doc.set_onload("ignore_price_list", True)
+
 	return doc


### PR DESCRIPTION
## Issue
On Purchase Receipt, tax amount is recalcalated based on current exchange rate even when created from Purchase Invoice.

https://user-images.githubusercontent.com/3272205/185071297-b8bb4983-39fe-4f21-aca6-1e1ac79b2b8f.mov


## Fix
Suppress call to fetch exchange rate and reuse same from Purchase Invoice.

https://user-images.githubusercontent.com/3272205/185071310-ecd979d3-e2a6-40a3-9d1e-159d16db0ef8.mov


