### PR TITLE
fix: delete custom fields on deletion of inventory dimension

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -374,8 +374,23 @@ class StockController(AccountsController):
 	def update_inventory_dimensions(self, row, sl_dict) -> None:
 		dimensions = get_evaluated_inventory_dimension(row, sl_dict, parent_doc=self)
 		for dimension in dimensions:
-			if dimension and row.get(dimension.source_fieldname):
+			if not dimension:
+				continue
+
+			if row.get(dimension.source_fieldname):
 				sl_dict[dimension.target_fieldname] = row.get(dimension.source_fieldname)
+
+			if not sl_dict.get(dimension.target_fieldname) and dimension.fetch_from_parent:
+				sl_dict[dimension.target_fieldname] = self.get(dimension.fetch_from_parent)
+
+				# Get value based on doctype name
+				if not sl_dict.get(dimension.target_fieldname):
+					fieldname = frappe.get_cached_value(
+						"DocField", {"parent": self.doctype, "options": dimension.fetch_from_parent}, "fieldname"
+					)
+
+					if fieldname and self.get(fieldname):
+						sl_dict[dimension.target_fieldname] = self.get(fieldname)
 
 	def make_sl_entries(self, sl_entries, allow_negative_stock=False, via_landed_cost_voucher=False):
 		from erpnext.stock.stock_ledger import make_sl_entries

--- a/erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
+++ b/erpnext/stock/doctype/inventory_dimension/inventory_dimension.json
@@ -1,6 +1,5 @@
 {
  "actions": [],
- "allow_rename": 1,
  "autoname": "field:dimension_name",
  "creation": "2022-06-17 13:04:16.554051",
  "doctype": "DocType",
@@ -22,6 +21,7 @@
   "document_type",
   "istable",
   "type_of_transaction",
+  "fetch_from_parent",
   "column_break_16",
   "condition",
   "applicable_condition_example_section",
@@ -101,12 +101,14 @@
    "fieldname": "target_fieldname",
    "fieldtype": "Data",
    "label": "Target Fieldname (Stock Ledger Entry)",
+   "no_copy": 1,
    "read_only": 1
   },
   {
    "fieldname": "source_fieldname",
    "fieldtype": "Data",
    "label": "Source Fieldname",
+   "no_copy": 1,
    "read_only": 1
   },
   {
@@ -123,7 +125,7 @@
    "fieldname": "type_of_transaction",
    "fieldtype": "Select",
    "label": "Type of Transaction",
-   "options": "\nInward\nOutward"
+   "options": "\nInward\nOutward\nBoth"
   },
   {
    "fieldname": "html_19",
@@ -140,11 +142,18 @@
   {
    "fieldname": "column_break_4",
    "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "istable",
+   "description": "Set fieldname or DocType name like Supplier, Customer etc.",
+   "fieldname": "fetch_from_parent",
+   "fieldtype": "Data",
+   "label": "Fetch Value From Parent Form"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-07-19 21:06:11.824976",
+ "modified": "2022-08-17 11:43:24.722441",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Inventory Dimension",

--- a/erpnext/stock/doctype/inventory_dimension/test_inventory_dimension.py
+++ b/erpnext/stock/doctype/inventory_dimension/test_inventory_dimension.py
@@ -8,6 +8,7 @@ from erpnext.stock.doctype.inventory_dimension.inventory_dimension import (
 	CanNotBeChildDoc,
 	CanNotBeDefaultDimension,
 	DoNotChangeError,
+	delete_dimension,
 )
 from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
 from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
@@ -41,6 +42,32 @@ class TestInventoryDimension(FrappeTestCase):
 		)
 
 		self.assertRaises(CanNotBeDefaultDimension, inv_dim1.insert)
+
+	def test_delete_inventory_dimension(self):
+		inv_dim1 = create_inventory_dimension(
+			reference_document="Shelf",
+			type_of_transaction="Outward",
+			dimension_name="From Shelf",
+			apply_to_all_doctypes=0,
+			document_type="Stock Entry Detail",
+			condition="parent.purpose == 'Material Issue'",
+		)
+
+		inv_dim1.save()
+
+		custom_field = frappe.db.get_value(
+			"Custom Field", {"fieldname": "from_shelf", "dt": "Stock Entry Detail"}, "name"
+		)
+
+		self.assertTrue(custom_field)
+
+		delete_dimension(inv_dim1.name)
+
+		custom_field = frappe.db.get_value(
+			"Custom Field", {"fieldname": "from_shelf", "dt": "Stock Entry Detail"}, "name"
+		)
+
+		self.assertFalse(custom_field)
 
 	def test_inventory_dimension(self):
 		warehouse = "Shelf Warehouse - _TC"


### PR DESCRIPTION
- Delete custom fields on deletion of the inventory dimension
- Removed rename functionality for the inventory dimension
- Set value from the parent form (Using fieldname or doctype name)
<img width="1352" alt="image" src="https://user-images.githubusercontent.com/8780500/185050826-36dd08b8-c56a-4a1e-8768-fb8655dee228.png">
