### PR TITLE
fix: incorrect buying amount in Gross Profit rpt

### DIFF
--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -616,7 +616,7 @@ class GrossProfitGenerator(object):
 						previous_stock_value = len(my_sle) > i + 1 and flt(my_sle[i + 1].stock_value) or 0.0
 
 						if previous_stock_value:
-							return (previous_stock_value - flt(sle.stock_value)) * flt(row.qty) / abs(flt(sle.qty))
+							return abs(previous_stock_value - flt(sle.stock_value)) * flt(row.qty) / abs(flt(sle.qty))
 						else:
 							return flt(row.qty) * self.get_average_buying_rate(row, item_code)
 			else:


### PR DESCRIPTION
## Incorrect Buying amount in Gross Profit report
Items with sales return has inflated buying amount which leads to incorrect valuation rate and gross profit.
1. Sales invoice for Item A @ 25 (Item bought at 25).
2. Sales invoice for Item A @ 30
3. Make Sales Return for [2]

<img width="1145" alt="Screenshot 2022-08-18 at 4 03 02 PM" src="https://user-images.githubusercontent.com/3272205/185375297-d64f700a-3ae5-42ed-8b53-bf72635bfad4.png">

## Fix
Consider the absolute value of stock change while calculating buying amount.

After Fix:
<img width="1145" alt="Screenshot 2022-08-18 at 4 03 13 PM" src="https://user-images.githubusercontent.com/3272205/185375335-906a334d-ff40-49ff-acf2-fdac13021643.png">


fixes: #30529 