### PR TITLE
fix(projects): Add missing comma

### DIFF
--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -379,7 +379,7 @@ def get_users_for_project(doctype, txt, searchfield, start, page_len, filters):
 			{fcond} {mcond}
 		order by
 			(case when locate(%(_txt)s, name) > 0 then locate(%(_txt)s, name) else 99999 end),
-			(case when locate(%(_txt)s, full_name) > 0 then locate(%(_txt)s, full_name) else 99999 end)
+			(case when locate(%(_txt)s, full_name) > 0 then locate(%(_txt)s, full_name) else 99999 end),
 			idx desc,
 			name, full_name
 		limit %(page_len)s offset %(start)s""".format(


### PR DESCRIPTION
Trying to set in User field in Users child table in Project throws the following error.

```sql
select name, concat_ws(' ', first_name, middle_name, last_name)
		from `tabUser`
		where enabled=1
			and name not in ("Guest", "Administrator")
			and (name like %(txt)s
				or full_name like %(txt)s)
			 
		order by
			(case when locate(%(_txt)s, name) > 0 then locate(%(_txt)s, name) else 99999 end),
			(case when locate(%(_txt)s, full_name) > 0 then locate(%(_txt)s, full_name) else 99999 end)
			idx desc,
			name, full_name
		limit %(page_len)s offset %(start)s {'txt': '%', '_txt': '', 'start': 0, 'page_len': 20}
```
```python-traceback
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 69, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 54, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 45, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 83, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1598, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/desk/search.py", line 62, in search_link
    search_widget(
  File "apps/frappe/frappe/desk/search.py", line 122, in search_widget
    raise e
  File "apps/frappe/frappe/desk/search.py", line 110, in search_widget
    frappe.response["values"] = frappe.call(
  File "apps/frappe/frappe/__init__.py", line 1598, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/desk/search.py", line 326, in wrapper
    return fn(**kwargs)
  File "apps/erpnext/erpnext/projects/doctype/project/project.py", line 372, in get_users_for_project
    return frappe.db.sql(
  File "apps/frappe/frappe/database/database.py", line 209, in sql
    self._cursor.execute(query, values)
  File "env/lib/python3.10/site-packages/pymysql/cursors.py", line 148, in execute
    result = self._query(query)
  File "env/lib/python3.10/site-packages/pymysql/cursors.py", line 310, in _query
    conn.query(q)
  File "env/lib/python3.10/site-packages/pymysql/connections.py", line 548, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "env/lib/python3.10/site-packages/pymysql/connections.py", line 775, in _read_query_result
    result.read()
  File "env/lib/python3.10/site-packages/pymysql/connections.py", line 1156, in read
    first_packet = self.connection._read_packet()
  File "env/lib/python3.10/site-packages/pymysql/connections.py", line 725, in _read_packet
    packet.raise_for_error()
  File "env/lib/python3.10/site-packages/pymysql/protocol.py", line 221, in raise_for_error
    err.raise_mysql_exception(self._data)
  File "env/lib/python3.10/site-packages/pymysql/err.py", line 143, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.ProgrammingError: (1064, "You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'idx desc,\n\t\t\tname, full_name\n\t\tlimit 20 offset 0' at line 11")
```

Added with https://github.com/frappe/erpnext/pull/31360. Needs to be backported to version-14.