### PR TITLE
fix: additional-costs in SCO and SCR

### DIFF
--- a/erpnext/controllers/subcontracting_controller.py
+++ b/erpnext/controllers/subcontracting_controller.py
@@ -720,6 +720,25 @@ class SubcontractingController(StockController):
 					sco_doc = frappe.get_doc("Subcontracting Order", sco)
 					sco_doc.update_status()
 
+	def set_missing_values_in_additional_costs(self):
+		self.total_additional_costs = sum(flt(item.amount) for item in self.get("additional_costs"))
+
+		if self.total_additional_costs:
+			if self.distribute_additional_costs_based_on == "Amount":
+				total_amt = sum(flt(item.amount) for item in self.get("items"))
+				for item in self.items:
+					item.additional_cost_per_qty = (
+						(item.amount * self.total_additional_costs) / total_amt
+					) / item.qty
+			else:
+				total_qty = sum(flt(item.qty) for item in self.get("items"))
+				additional_cost_per_qty = self.total_additional_costs / total_qty
+				for item in self.items:
+					item.additional_cost_per_qty = additional_cost_per_qty
+		else:
+			for item in self.items:
+				item.additional_cost_per_qty = 0
+
 	@frappe.whitelist()
 	def get_current_stock(self):
 		if self.doctype in ["Purchase Receipt", "Subcontracting Receipt"]:

--- a/erpnext/controllers/subcontracting_controller.py
+++ b/erpnext/controllers/subcontracting_controller.py
@@ -490,7 +490,7 @@ class SubcontractingController(StockController):
 						row.item_code,
 						row.get(self.subcontract_data.order_field),
 					) and transfer_item.qty > 0:
-						qty = self.__get_qty_based_on_material_transfer(row, transfer_item) or 0
+						qty = flt(self.__get_qty_based_on_material_transfer(row, transfer_item))
 						transfer_item.qty -= qty
 						self.__add_supplied_item(row, transfer_item.get("item_details"), qty)
 
@@ -749,7 +749,7 @@ class SubcontractingController(StockController):
 						{"item_code": item.rm_item_code, "warehouse": self.supplier_warehouse},
 						"actual_qty",
 					)
-					item.current_stock = flt(actual_qty) or 0
+					item.current_stock = flt(actual_qty)
 
 	@property
 	def sub_contracted_items(self):

--- a/erpnext/stock/landed_taxes_and_charges_common.js
+++ b/erpnext/stock/landed_taxes_and_charges_common.js
@@ -1,4 +1,4 @@
-let document_list = ['Landed Cost Voucher', 'Stock Entry'];
+let document_list = ['Landed Cost Voucher', 'Stock Entry', 'Subcontracting Order'];
 
 document_list.forEach((doctype) => {
 	frappe.ui.form.on(doctype, {

--- a/erpnext/stock/landed_taxes_and_charges_common.js
+++ b/erpnext/stock/landed_taxes_and_charges_common.js
@@ -1,4 +1,4 @@
-let document_list = ['Landed Cost Voucher', 'Stock Entry', 'Subcontracting Order'];
+let document_list = ['Landed Cost Voucher', 'Stock Entry', 'Subcontracting Order', 'Subcontracting Receipt'];
 
 document_list.forEach((doctype) => {
 	frappe.ui.form.on(doctype, {

--- a/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.js
+++ b/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.js
@@ -3,6 +3,8 @@
 
 frappe.provide('erpnext.buying');
 
+{% include 'erpnext/stock/landed_taxes_and_charges_common.js' %};
+
 frappe.ui.form.on('Subcontracting Order', {
 	setup: (frm) => {
 		frm.get_field("items").grid.cannot_add_rows = true;
@@ -133,6 +135,16 @@ frappe.ui.form.on('Subcontracting Order', {
 				});
 			}, __('Create'));
 		}
+	}
+});
+
+frappe.ui.form.on('Landed Cost Taxes and Charges', {
+	amount: function (frm, cdt, cdn) {
+		frm.events.set_base_amount(frm, cdt, cdn);
+	},
+
+	expense_account: function (frm, cdt, cdn) {
+		frm.events.set_account_currency(frm, cdt, cdn);
 	}
 });
 

--- a/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.py
+++ b/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.py
@@ -95,9 +95,7 @@ class SubcontractingOrder(SubcontractingController):
 	def set_missing_values_in_items(self):
 		total_qty = total = 0
 		for item in self.items:
-			item.rate = (
-				item.rm_cost_per_qty + item.service_cost_per_qty + (item.additional_cost_per_qty or 0)
-			)
+			item.rate = item.rm_cost_per_qty + item.service_cost_per_qty + flt(item.additional_cost_per_qty)
 			item.amount = item.qty * item.rate
 			total_qty += flt(item.qty)
 			total += flt(item.amount)
@@ -168,7 +166,7 @@ class SubcontractingOrder(SubcontractingController):
 					total_required_qty = total_supplied_qty = 0
 					for item in self.supplied_items:
 						total_required_qty += item.required_qty
-						total_supplied_qty += item.supplied_qty or 0
+						total_supplied_qty += flt(item.supplied_qty)
 					if total_supplied_qty:
 						status = "Partial Material Transferred"
 						if total_supplied_qty >= total_required_qty:

--- a/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.py
+++ b/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.py
@@ -82,25 +82,6 @@ class SubcontractingOrder(SubcontractingController):
 		self.set_missing_values_in_supplied_items()
 		self.set_missing_values_in_items()
 
-	def set_missing_values_in_additional_costs(self):
-		self.total_additional_costs = sum(flt(item.amount) for item in self.get("additional_costs"))
-
-		if self.total_additional_costs:
-			if self.distribute_additional_costs_based_on == "Amount":
-				total_amt = sum(flt(item.amount) for item in self.get("items"))
-				for item in self.items:
-					item.additional_cost_per_qty = (
-						(item.amount * self.total_additional_costs) / total_amt
-					) / item.qty
-			else:
-				total_qty = sum(flt(item.qty) for item in self.get("items"))
-				additional_cost_per_qty = self.total_additional_costs / total_qty
-				for item in self.items:
-					item.additional_cost_per_qty = additional_cost_per_qty
-		else:
-			for item in self.items:
-				item.additional_cost_per_qty = 0
-
 	def set_missing_values_in_service_items(self):
 		for idx, item in enumerate(self.get("service_items")):
 			self.items[idx].service_cost_per_qty = item.amount / self.items[idx].qty

--- a/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.py
+++ b/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.py
@@ -83,23 +83,23 @@ class SubcontractingOrder(SubcontractingController):
 		self.set_missing_values_in_items()
 
 	def set_missing_values_in_additional_costs(self):
-		if self.get("additional_costs"):
-			self.total_additional_costs = sum(flt(item.amount) for item in self.get("additional_costs"))
+		self.total_additional_costs = sum(flt(item.amount) for item in self.get("additional_costs"))
 
-			if self.total_additional_costs:
-				if self.distribute_additional_costs_based_on == "Amount":
-					total_amt = sum(flt(item.amount) for item in self.get("items"))
-					for item in self.items:
-						item.additional_cost_per_qty = (
-							(item.amount * self.total_additional_costs) / total_amt
-						) / item.qty
-				else:
-					total_qty = sum(flt(item.qty) for item in self.get("items"))
-					additional_cost_per_qty = self.total_additional_costs / total_qty
-					for item in self.items:
-						item.additional_cost_per_qty = additional_cost_per_qty
+		if self.total_additional_costs:
+			if self.distribute_additional_costs_based_on == "Amount":
+				total_amt = sum(flt(item.amount) for item in self.get("items"))
+				for item in self.items:
+					item.additional_cost_per_qty = (
+						(item.amount * self.total_additional_costs) / total_amt
+					) / item.qty
+			else:
+				total_qty = sum(flt(item.qty) for item in self.get("items"))
+				additional_cost_per_qty = self.total_additional_costs / total_qty
+				for item in self.items:
+					item.additional_cost_per_qty = additional_cost_per_qty
 		else:
-			self.total_additional_costs = 0
+			for item in self.items:
+				item.additional_cost_per_qty = 0
 
 	def set_missing_values_in_service_items(self):
 		for idx, item in enumerate(self.get("service_items")):

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.js
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.js
@@ -3,6 +3,8 @@
 
 frappe.provide('erpnext.buying');
 
+{% include 'erpnext/stock/landed_taxes_and_charges_common.js' %};
+
 frappe.ui.form.on('Subcontracting Receipt', {
 	setup: (frm) => {
 		frm.get_field('supplied_items').grid.cannot_add_rows = true;
@@ -126,6 +128,16 @@ frappe.ui.form.on('Subcontracting Receipt', {
 	rejected_warehouse: (frm) => {
 		set_warehouse_in_children(frm.doc.items, 'rejected_warehouse', frm.doc.rejected_warehouse);
 	},
+});
+
+frappe.ui.form.on('Landed Cost Taxes and Charges', {
+	amount: function (frm, cdt, cdn) {
+		frm.events.set_base_amount(frm, cdt, cdn);
+	},
+
+	expense_account: function (frm, cdt, cdn) {
+		frm.events.set_account_currency(frm, cdt, cdn);
+	}
 });
 
 frappe.ui.form.on('Subcontracting Receipt Item', {

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.json
@@ -47,6 +47,10 @@
         "raw_material_details",
         "get_current_stock",
         "supplied_items",
+        "additional_costs_section",
+        "distribute_additional_costs_based_on",
+        "additional_costs",
+        "total_additional_costs",
         "section_break_46",
         "in_words",
         "bill_no",
@@ -595,11 +599,39 @@
             "fieldtype": "Link",
             "label": "Project",
             "options": "Project"
+        },
+        {
+            "collapsible": 1,
+            "collapsible_depends_on": "total_additional_costs",
+            "depends_on": "eval:(doc.docstatus == 0 || doc.total_additional_costs)",
+            "fieldname": "additional_costs_section",
+            "fieldtype": "Section Break",
+            "label": "Additional Costs"
+        },
+        {
+            "default": "Qty",
+            "fieldname": "distribute_additional_costs_based_on",
+            "fieldtype": "Select",
+            "label": "Distribute Additional Costs Based On ",
+            "options": "Qty\nAmount"
+        },
+        {
+            "fieldname": "additional_costs",
+            "fieldtype": "Table",
+            "label": "Additional Costs",
+            "options": "Landed Cost Taxes and Charges"
+        },
+        {
+            "fieldname": "total_additional_costs",
+            "fieldtype": "Currency",
+            "label": "Total Additional Costs",
+            "print_hide_if_no_value": 1,
+            "read_only": 1
         }
     ],
     "is_submittable": 1,
     "links": [],
-    "modified": "2022-08-15 14:30:29.447307",
+    "modified": "2022-08-18 15:48:57.419191",
     "modified_by": "Administrator",
     "module": "Subcontracting",
     "name": "Subcontracting Receipt",

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
@@ -125,7 +125,7 @@ class SubcontractingReceipt(SubcontractingController):
 				item.rm_cost_per_qty = item.rm_supp_cost / item.qty
 				rm_supp_cost.pop(item.name)
 
-			if self.is_new() and item.rm_supp_cost > 0:
+			if item.recalculate_rate:
 				item.rate = (
 					item.rm_cost_per_qty + (item.service_cost_per_qty or 0) + item.additional_cost_per_qty
 				)

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
@@ -103,6 +103,7 @@ class SubcontractingReceipt(SubcontractingController):
 
 	@frappe.whitelist()
 	def set_missing_values(self):
+		self.set_missing_values_in_additional_costs()
 		self.set_missing_values_in_supplied_items()
 		self.set_missing_values_in_items()
 

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
@@ -3,7 +3,7 @@
 
 import frappe
 from frappe import _
-from frappe.utils import cint, getdate, nowdate
+from frappe.utils import cint, flt, getdate, nowdate
 
 from erpnext.controllers.subcontracting_controller import SubcontractingController
 
@@ -128,10 +128,10 @@ class SubcontractingReceipt(SubcontractingController):
 
 			if item.recalculate_rate:
 				item.rate = (
-					item.rm_cost_per_qty + (item.service_cost_per_qty or 0) + item.additional_cost_per_qty
+					flt(item.rm_cost_per_qty) + flt(item.service_cost_per_qty) + flt(item.additional_cost_per_qty)
 				)
 
-			item.received_qty = item.qty + (item.rejected_qty or 0)
+			item.received_qty = item.qty + flt(item.rejected_qty)
 			item.amount = item.qty * item.rate
 			total_qty += item.qty
 			total_amount += item.amount

--- a/erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
@@ -29,6 +29,7 @@
         "rate_and_amount",
         "rate",
         "amount",
+        "recalculate_rate",
         "column_break_19",
         "rm_cost_per_qty",
         "service_cost_per_qty",
@@ -460,12 +461,18 @@
             "fieldname": "accounting_details_section",
             "fieldtype": "Section Break",
             "label": "Accounting Details"
+        },
+        {
+            "default": "1",
+            "fieldname": "recalculate_rate",
+            "fieldtype": "Check",
+            "label": "Recalculate Rate"
         }
     ],
     "idx": 1,
     "istable": 1,
     "links": [],
-    "modified": "2022-08-15 14:51:10.613347",
+    "modified": "2022-08-18 19:42:24.313449",
     "modified_by": "Administrator",
     "module": "Subcontracting",
     "name": "Subcontracting Receipt Item",


### PR DESCRIPTION
- Fix: Not able to reset Additional Cost once set for the item.
- Fix: Exchange Rate and Base Amount not getting set.
- Fix: Recalculate rate (Service Cost + RM Cost + Additional Cost) based on "Recalculate Rate" checkbox.
- Feat: Add Additional Cost table in SCR.