### PR TITLE
fix: TDS calculation for advance payment

### DIFF
--- a/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
+++ b/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
@@ -309,7 +309,6 @@ def get_advance_vouchers(
 		"is_cancelled": 0,
 		"party_type": party_type,
 		"party": ["in", parties],
-		"against_voucher": ["is", "not set"],
 	}
 
 	if company:


### PR DESCRIPTION
```
"against_voucher": ["is", "not set"]
```
was used in query due to which if TDS was added on **advance** payment vouchers and then reconciled against purchase invoice. it will not find those vouchers and consider it as first-time threshold ( which is incorrect ) due to which it will calculate Tax for all transactions.