### PR TITLE
fix: make rate field read-only in subcontracting receipt item

### DIFF
--- a/erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
@@ -194,6 +194,8 @@
             "label": "Rate",
             "options": "currency",
             "print_width": "100px",
+            "read_only": 1,
+            "read_only_depends_on": "eval: doc.recalculate_rate",
             "width": "100px"
         },
         {
@@ -472,7 +474,7 @@
     "idx": 1,
     "istable": 1,
     "links": [],
-    "modified": "2022-08-18 19:42:24.313449",
+    "modified": "2022-08-20 17:16:48.269164",
     "modified_by": "Administrator",
     "module": "Subcontracting",
     "name": "Subcontracting Receipt Item",


### PR DESCRIPTION
make the 'rate' field read-only in subcontracting receipt item based on the 'recalculate' field.