### PR TITLE
fix: Set the condition to create a purchase receipt

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -539,7 +539,7 @@ frappe.ui.form.on("Purchase Invoice", {
 	},
 
 	add_custom_buttons: function(frm) {
-		if (frm.doc.per_received < 100) {
+		if (frm.doc.docstatus == 1 && frm.doc.per_received < 100) {
 			frm.add_custom_button(__('Purchase Receipt'), () => {
 				frm.events.make_purchase_receipt(frm);
 			}, __('Create'));


### PR DESCRIPTION
PR: #31531
___

**Version**

ERPNext: v13.36.4
Frappe Framework: v13.38.0
___

**Before:**
- When creating the purchase invoice and saving it on the draft stage, the purchase receipt option show in create button and when clicking on the purchase receipt then error show like Cannot map because following condition fails: docstatus=1


https://user-images.githubusercontent.com/34390782/185857592-5e58f169-2693-4d31-bfa5-082882ec478f.mp4


**After:**
- After developing the purchase_invoice.js file, the purchase receipt option will not show in the draft stage.
- Only will show when you submit the purchase invoice.


https://user-images.githubusercontent.com/34390782/185857867-7b54ec20-77b7-4c8f-b556-696fe1b8d0d1.mp4


Thank You!
