### PR TITLE
feat: In BOM,  Operation time can be fix (backport #27063)

### DIFF
--- a/erpnext/manufacturing/doctype/bom/test_records.json
+++ b/erpnext/manufacturing/doctype/bom/test_records.json
@@ -162,5 +162,54 @@
   "item": "_Test Variant Item",
   "quantity": 1.0,
   "with_operations": 1
+ },
+ {
+  "operations": [
+   {
+    "operation": "_Test Operation 1",
+    "description": "_Test",
+    "workstation": "_Test Workstation 1",
+    "hour_rate": 100,
+    "time_in_mins": 60,
+    "operating_cost": 100
+   }
+   ],
+  "items": [
+   {
+    "amount": 5000.0,
+    "doctype": "BOM Item",
+    "item_code": "_Test Item",
+    "parentfield": "items",
+    "qty": 1.0,
+    "rate": 5000.0,
+    "uom": "_Test UOM",
+    "stock_uom": "_Test UOM",
+    "source_warehouse": "_Test Warehouse - _TC",
+    "include_item_in_manufacturing": 1
+   },
+   {
+    "amount": 3000.0,
+    "bom_no": "BOM-_Test Item Home Desktop Manufactured-001",
+    "doctype": "BOM Item",
+    "item_code": "_Test Item Home Desktop Manufactured",
+    "parentfield": "items",
+    "qty": 3.0,
+    "rate": 1000.0,
+    "uom": "_Test UOM",
+    "stock_uom": "_Test UOM",
+    "source_warehouse": "_Test Warehouse - _TC",
+    "include_item_in_manufacturing": 1
+   }
+  ],
+  "docstatus": 1,
+  "doctype": "BOM",
+  "is_active": 1,
+  "is_default": 1,
+  "currency": "USD",
+  "conversion_rate": 60,
+  "company": "_Test Company",
+  "item": "_Test FG Item 3",
+  "quantity": 1.0,
+  "with_operations": 1
  }
 ]

--- a/erpnext/manufacturing/doctype/bom_operation/bom_operation.json
+++ b/erpnext/manufacturing/doctype/bom_operation/bom_operation.json
@@ -11,6 +11,7 @@
   "col_break1",
   "workstation",
   "time_in_mins",
+  "fixed_time",
   "costing_section",
   "hour_rate",
   "base_hour_rate",
@@ -79,6 +80,14 @@
    "oldfieldname": "time_in_mins",
    "oldfieldtype": "Currency",
    "reqd": 1
+  },
+  {
+   "default": "0",
+   "description": "Operation time does not depend on quantity to produce",
+   "fieldname": "fixed_time",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Fixed Time"
   },
   {
    "fieldname": "operating_cost",
@@ -177,7 +186,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2022-04-08 01:18:33.547481",
+ "modified": "2022-22-08 01:18:33.547481",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "BOM Operation",

--- a/erpnext/manufacturing/doctype/bom_operation/bom_operation.json
+++ b/erpnext/manufacturing/doctype/bom_operation/bom_operation.json
@@ -186,7 +186,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2022-22-08 01:18:33.547481",
+ "modified": "2022-08-22 01:18:33.547481",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "BOM Operation",

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -1159,6 +1159,42 @@ class TestWorkOrder(FrappeTestCase):
 		self.assertEqual(work_order.required_items[0].transferred_qty, 1)
 		self.assertEqual(work_order.required_items[1].transferred_qty, 2)
 
+	def test_fix_time_operations(self):
+		bom = frappe.get_doc({
+			"doctype": "BOM",
+			"item": "_Test FG Item 2",
+			"is_active": 1,
+			"is_default": 1,
+			"quantity": 1.0,
+			"with_operations": 1,
+			"operations": [
+				{
+					"operation": "_Test Operation 1",
+					"description": "_Test",
+					"workstation": "_Test Workstation 1",
+					"time_in_mins": 60,
+					"operating_cost": 140,
+					"fixed_time": 1
+				}
+			],
+			"items": [
+				{
+					"amount": 5000.0,
+					"doctype": "BOM Item",
+					"item_code": "_Test Item",
+					"parentfield": "items",
+					"qty": 1.0,
+					"rate": 5000.0,
+				},
+			],
+		})
+		bom.save()
+		bom.submit()
+
+		wo1 = make_wo_order_test_record(item=bom.item, bom_no=bom.name, qty=1, skip_transfer=1, do_not_submit=1)
+		wo2 = make_wo_order_test_record(item=bom.item, bom_no=bom.name, qty=2, skip_transfer=1, do_not_submit=1)
+
+		self.assertEqual(wo1.operations[0].time_in_mins, wo2.operations[0].time_in_mins)
 
 def update_job_card(job_card, jc_qty=None):
 	employee = frappe.db.get_value("Employee", {"status": "Active"}, "name")

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -999,6 +999,49 @@ class TestWorkOrder(FrappeTestCase):
 			close_work_order(wo_order, "Closed")
 			self.assertEqual(wo_order.get("status"), "Closed")
 
+	def test_fix_time_operations(self):
+		bom = frappe.get_doc(
+			{
+				"doctype": "BOM",
+				"item": "_Test FG Item 2",
+				"is_active": 1,
+				"is_default": 1,
+				"quantity": 1.0,
+				"with_operations": 1,
+				"operations": [
+					{
+						"operation": "_Test Operation 1",
+						"description": "_Test",
+						"workstation": "_Test Workstation 1",
+						"time_in_mins": 60,
+						"operating_cost": 140,
+						"fixed_time": 1,
+					}
+				],
+				"items": [
+					{
+						"amount": 5000.0,
+						"doctype": "BOM Item",
+						"item_code": "_Test Item",
+						"parentfield": "items",
+						"qty": 1.0,
+						"rate": 5000.0,
+					},
+				],
+			}
+		)
+		bom.save()
+		bom.submit()
+
+		wo1 = make_wo_order_test_record(
+			item=bom.item, bom_no=bom.name, qty=1, skip_transfer=1, do_not_submit=1
+		)
+		wo2 = make_wo_order_test_record(
+			item=bom.item, bom_no=bom.name, qty=2, skip_transfer=1, do_not_submit=1
+		)
+
+		self.assertEqual(wo1.operations[0].time_in_mins, wo2.operations[0].time_in_mins)
+
 	def test_partial_manufacture_entries(self):
 		cancel_stock_entry = []
 
@@ -1013,7 +1056,6 @@ class TestWorkOrder(FrappeTestCase):
 		ste1 = test_stock_entry.make_stock_entry(
 			item_code="_Test Item", target="_Test Warehouse - _TC", qty=120, basic_rate=5000.0
 		)
-
 		ste2 = test_stock_entry.make_stock_entry(
 			item_code="_Test Item Home Desktop 100",
 			target="_Test Warehouse - _TC",
@@ -1026,7 +1068,7 @@ class TestWorkOrder(FrappeTestCase):
 		sm = frappe.get_doc(make_stock_entry(wo_order.name, "Material Transfer for Manufacture", 100))
 		for row in sm.get("items"):
 			if row.get("item_code") == "_Test Item":
-				row.qty = 110
+				row.qty = 120
 
 		sm.submit()
 		cancel_stock_entry.append(sm.name)
@@ -1034,22 +1076,21 @@ class TestWorkOrder(FrappeTestCase):
 		s = frappe.get_doc(make_stock_entry(wo_order.name, "Manufacture", 90))
 		for row in s.get("items"):
 			if row.get("item_code") == "_Test Item":
-				self.assertEqual(row.get("qty"), 100)
-
+				self.assertEqual(row.get("qty"), 108)
 		s.submit()
 		cancel_stock_entry.append(s.name)
 
 		s1 = frappe.get_doc(make_stock_entry(wo_order.name, "Manufacture", 5))
 		for row in s1.get("items"):
 			if row.get("item_code") == "_Test Item":
-				self.assertEqual(row.get("qty"), 5)
+				self.assertEqual(row.get("qty"), 6)
 		s1.submit()
 		cancel_stock_entry.append(s1.name)
 
 		s2 = frappe.get_doc(make_stock_entry(wo_order.name, "Manufacture", 5))
 		for row in s2.get("items"):
 			if row.get("item_code") == "_Test Item":
-				self.assertEqual(row.get("qty"), 5)
+				self.assertEqual(row.get("qty"), 6)
 
 		cancel_stock_entry.reverse()
 		for ste in cancel_stock_entry:
@@ -1158,49 +1199,6 @@ class TestWorkOrder(FrappeTestCase):
 		self.assertEqual(work_order.material_transferred_for_manufacturing, 1)
 		self.assertEqual(work_order.required_items[0].transferred_qty, 1)
 		self.assertEqual(work_order.required_items[1].transferred_qty, 2)
-
-	def test_fix_time_operations(self):
-		bom = frappe.get_doc(
-			{
-				"doctype": "BOM",
-				"item": "_Test FG Item 2",
-				"is_active": 1,
-				"is_default": 1,
-				"quantity": 1.0,
-				"with_operations": 1,
-				"operations": [
-					{
-						"operation": "_Test Operation 1",
-						"description": "_Test",
-						"workstation": "_Test Workstation 1",
-						"time_in_mins": 60,
-						"operating_cost": 140,
-						"fixed_time": 1,
-					}
-				],
-				"items": [
-					{
-						"amount": 5000.0,
-						"doctype": "BOM Item",
-						"item_code": "_Test Item",
-						"parentfield": "items",
-						"qty": 1.0,
-						"rate": 5000.0,
-					},
-				],
-			}
-		)
-		bom.save()
-		bom.submit()
-
-		wo1 = make_wo_order_test_record(
-			item=bom.item, bom_no=bom.name, qty=1, skip_transfer=1, do_not_submit=1
-		)
-		wo2 = make_wo_order_test_record(
-			item=bom.item, bom_no=bom.name, qty=2, skip_transfer=1, do_not_submit=1
-		)
-
-		self.assertEqual(wo1.operations[0].time_in_mins, wo2.operations[0].time_in_mins)
 
 
 def update_job_card(job_card, jc_qty=None):

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -1160,41 +1160,48 @@ class TestWorkOrder(FrappeTestCase):
 		self.assertEqual(work_order.required_items[1].transferred_qty, 2)
 
 	def test_fix_time_operations(self):
-		bom = frappe.get_doc({
-			"doctype": "BOM",
-			"item": "_Test FG Item 2",
-			"is_active": 1,
-			"is_default": 1,
-			"quantity": 1.0,
-			"with_operations": 1,
-			"operations": [
-				{
-					"operation": "_Test Operation 1",
-					"description": "_Test",
-					"workstation": "_Test Workstation 1",
-					"time_in_mins": 60,
-					"operating_cost": 140,
-					"fixed_time": 1
-				}
-			],
-			"items": [
-				{
-					"amount": 5000.0,
-					"doctype": "BOM Item",
-					"item_code": "_Test Item",
-					"parentfield": "items",
-					"qty": 1.0,
-					"rate": 5000.0,
-				},
-			],
-		})
+		bom = frappe.get_doc(
+			{
+				"doctype": "BOM",
+				"item": "_Test FG Item 2",
+				"is_active": 1,
+				"is_default": 1,
+				"quantity": 1.0,
+				"with_operations": 1,
+				"operations": [
+					{
+						"operation": "_Test Operation 1",
+						"description": "_Test",
+						"workstation": "_Test Workstation 1",
+						"time_in_mins": 60,
+						"operating_cost": 140,
+						"fixed_time": 1,
+					}
+				],
+				"items": [
+					{
+						"amount": 5000.0,
+						"doctype": "BOM Item",
+						"item_code": "_Test Item",
+						"parentfield": "items",
+						"qty": 1.0,
+						"rate": 5000.0,
+					},
+				],
+			}
+		)
 		bom.save()
 		bom.submit()
 
-		wo1 = make_wo_order_test_record(item=bom.item, bom_no=bom.name, qty=1, skip_transfer=1, do_not_submit=1)
-		wo2 = make_wo_order_test_record(item=bom.item, bom_no=bom.name, qty=2, skip_transfer=1, do_not_submit=1)
+		wo1 = make_wo_order_test_record(
+			item=bom.item, bom_no=bom.name, qty=1, skip_transfer=1, do_not_submit=1
+		)
+		wo2 = make_wo_order_test_record(
+			item=bom.item, bom_no=bom.name, qty=2, skip_transfer=1, do_not_submit=1
+		)
 
 		self.assertEqual(wo1.operations[0].time_in_mins, wo2.operations[0].time_in_mins)
+
 
 def update_job_card(job_card, jc_qty=None):
 	employee = frappe.db.get_value("Employee", {"status": "Active"}, "name")

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -23,6 +23,8 @@ from erpnext.stock.doctype.stock_entry import test_stock_entry
 from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
 from erpnext.stock.utils import get_bin
 
+test_dependencies = ["BOM"]
+
 
 class TestWorkOrder(FrappeTestCase):
 	def setUp(self):
@@ -93,7 +95,7 @@ class TestWorkOrder(FrappeTestCase):
 
 	def test_planned_operating_cost(self):
 		wo_order = make_wo_order_test_record(
-			item="_Test FG Item 2", planned_start_date=now(), qty=1, do_not_save=True
+			item="_Test FG Item 3", planned_start_date=now(), qty=1, do_not_save=True
 		)
 		wo_order.set_work_order_operations()
 		cost = wo_order.planned_operating_cost

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -1068,7 +1068,7 @@ class TestWorkOrder(FrappeTestCase):
 		sm = frappe.get_doc(make_stock_entry(wo_order.name, "Material Transfer for Manufacture", 100))
 		for row in sm.get("items"):
 			if row.get("item_code") == "_Test Item":
-				row.qty = 120
+				row.qty = 110
 
 		sm.submit()
 		cancel_stock_entry.append(sm.name)
@@ -1076,21 +1076,22 @@ class TestWorkOrder(FrappeTestCase):
 		s = frappe.get_doc(make_stock_entry(wo_order.name, "Manufacture", 90))
 		for row in s.get("items"):
 			if row.get("item_code") == "_Test Item":
-				self.assertEqual(row.get("qty"), 108)
+				self.assertEqual(row.get("qty"), 100)
+
 		s.submit()
 		cancel_stock_entry.append(s.name)
 
 		s1 = frappe.get_doc(make_stock_entry(wo_order.name, "Manufacture", 5))
 		for row in s1.get("items"):
 			if row.get("item_code") == "_Test Item":
-				self.assertEqual(row.get("qty"), 6)
+				self.assertEqual(row.get("qty"), 5)
 		s1.submit()
 		cancel_stock_entry.append(s1.name)
 
 		s2 = frappe.get_doc(make_stock_entry(wo_order.name, "Manufacture", 5))
 		for row in s2.get("items"):
 			if row.get("item_code") == "_Test Item":
-				self.assertEqual(row.get("qty"), 6)
+				self.assertEqual(row.get("qty"), 5)
 
 		cancel_stock_entry.reverse()
 		for ste in cancel_stock_entry:

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -1161,7 +1161,7 @@ class TestWorkOrder(FrappeTestCase):
 
 	def test_fix_time_operations(self):
 		bom = frappe.get_doc({
-			"doctype": "BOMa",
+			"doctype": "BOM",
 			"item": "_Test FG Item 2",
 			"is_active": 1,
 			"is_default": 1,

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -1161,7 +1161,7 @@ class TestWorkOrder(FrappeTestCase):
 
 	def test_fix_time_operations(self):
 		bom = frappe.get_doc({
-			"doctype": "BOM",
+			"doctype": "BOMa",
 			"item": "_Test FG Item 2",
 			"is_active": 1,
 			"is_default": 1,

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -657,7 +657,7 @@ class WorkOrder(Document):
 			                      filters={"parent": bom_no},
 			                      fields=["operation", "description", "workstation", "idx",
 			                              "base_hour_rate as hour_rate", "time_in_mins", "parent as bom",
-			                              "batch_size", "sequence_id", "fixed_time"],
+			                              "batch_size", "sequence_id", "fixed_timed"],
 			                      order_by="idx")
 
 			for d in data:

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -653,12 +653,23 @@ class WorkOrder(Document):
 		"""Fetch operations from BOM and set in 'Work Order'"""
 
 		def _get_operations(bom_no, qty=1):
-			data = frappe.get_all("BOM Operation",
-			                      filters={"parent": bom_no},
-			                      fields=["operation", "description", "workstation", "idx",
-			                              "base_hour_rate as hour_rate", "time_in_mins", "parent as bom",
-			                              "batch_size", "sequence_id", "fixed_timed"],
-			                      order_by="idx")
+			data = frappe.get_all(
+				"BOM Operation",
+				filters={"parent": bom_no},
+				fields=[
+					"operation",
+					"description",
+					"workstation",
+					"idx",
+					"base_hour_rate as hour_rate",
+					"time_in_mins",
+					"parent as bom",
+					"batch_size",
+					"sequence_id",
+					"fixed_time",
+				],
+				order_by="idx",
+			)
 
 			for d in data:
 				if not d.fixed_time:

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -1320,7 +1320,7 @@ def get_serial_nos_for_job_card(row, wo_doc):
 		used_serial_nos.extend(get_serial_nos(d.serial_no))
 
 	serial_nos = sorted(list(set(serial_nos) - set(used_serial_nos)))
-	row.serial_no = "\n".join(serial_nos[0: cint(row.job_card_qty)])
+	row.serial_no = "\n".join(serial_nos[0 : cint(row.job_card_qty)])
 
 
 def validate_operation_data(row):
@@ -1438,24 +1438,24 @@ def get_reserved_qty_for_production(item_code: str, warehouse: str) -> float:
 	wo_item = frappe.qb.DocType("Work Order Item")
 
 	return (
-		       frappe.qb.from_(wo)
-			       .from_(wo_item)
-			       .select(
-			       Sum(
-				       Case()
-					       .when(wo.skip_transfer == 0, wo_item.required_qty - wo_item.transferred_qty)
-					       .else_(wo_item.required_qty - wo_item.consumed_qty)
-			       )
-		       )
-			       .where(
-			       (wo_item.item_code == item_code)
-			       & (wo_item.parent == wo.name)
-			       & (wo.docstatus == 1)
-			       & (wo_item.source_warehouse == warehouse)
-			       & (wo.status.notin(["Stopped", "Completed", "Closed"]))
-			       & (
-				       (wo_item.required_qty > wo_item.transferred_qty)
-				       | (wo_item.required_qty > wo_item.consumed_qty)
-			       )
-		       )
-	       ).run()[0][0] or 0.0
+		frappe.qb.from_(wo)
+		.from_(wo_item)
+		.select(
+			Sum(
+				Case()
+				.when(wo.skip_transfer == 0, wo_item.required_qty - wo_item.transferred_qty)
+				.else_(wo_item.required_qty - wo_item.consumed_qty)
+			)
+		)
+		.where(
+			(wo_item.item_code == item_code)
+			& (wo_item.parent == wo.name)
+			& (wo.docstatus == 1)
+			& (wo_item.source_warehouse == warehouse)
+			& (wo.status.notin(["Stopped", "Completed", "Closed"]))
+			& (
+				(wo_item.required_qty > wo_item.transferred_qty)
+				| (wo_item.required_qty > wo_item.consumed_qty)
+			)
+		)
+	).run()[0][0] or 0.0

--- a/erpnext/stock/doctype/item/test_records.json
+++ b/erpnext/stock/doctype/item/test_records.json
@@ -273,6 +273,28 @@
   }]
  },
  {
+  "description": "_Test FG Item 3 11",
+  "doctype": "Item",
+  "has_batch_no": 0,
+  "has_serial_no": 0,
+  "inspection_required": 0,
+  "is_stock_item": 1,
+  "is_sub_contracted_item": 1,
+  "item_code": "_Test FG Item 3",
+  "item_group": "_Test Item Group Desktops",
+  "item_name": "_Test FG Item 3",
+  "stock_uom": "_Test UOM",
+  "gst_hsn_code": "999800",
+  "item_defaults": [{
+    "company": "_Test Company",
+    "default_warehouse": "_Test Warehouse - _TC",
+    "expense_account": "_Test Account Cost for Goods Sold - _TC",
+    "buying_cost_center": "_Test Cost Center - _TC",
+    "selling_cost_center": "_Test Cost Center - _TC",
+    "income_account": "Sales - _TC"
+  }]
+ },
+ {
   "description": "_Test Variant Item 12",
   "doctype": "Item",
   "has_batch_no": 0,


### PR DESCRIPTION
feat: In BOM Operation time can be fix 

Manual  from backport #27063

Note to reviewer: It's an old PR, but at this time I didn't understand the mergify bot (truth is it didn't exits at this time). My initial goal was to introduce this feature into version-13, but it was merge into develop and I didn't take the action to push it into version-13-hotfix, now it's time to do it as it's a core feature on version-14
