### PR TITLE
refactor: disable discount accounting on Buying module(PI)

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -575,7 +575,6 @@ class PurchaseInvoice(BuyingController):
 
 		self.make_supplier_gl_entry(gl_entries)
 		self.make_item_gl_entries(gl_entries)
-		self.make_discount_gl_entries(gl_entries)
 
 		if self.check_asset_cwip_enabled():
 			self.get_asset_gl_entry(gl_entries)
@@ -807,7 +806,7 @@ class PurchaseInvoice(BuyingController):
 					)
 
 					if not item.is_fixed_asset:
-						dummy, amount = self.get_amount_and_base_amount(item, enable_discount_accounting)
+						dummy, amount = self.get_amount_and_base_amount(item, None)
 					else:
 						amount = flt(item.base_net_amount + item.item_tax_amount, item.precision("base_net_amount"))
 
@@ -1165,7 +1164,7 @@ class PurchaseInvoice(BuyingController):
 		)
 
 		for tax in self.get("taxes"):
-			amount, base_amount = self.get_tax_amounts(tax, enable_discount_accounting)
+			amount, base_amount = self.get_tax_amounts(tax, None)
 			if tax.category in ("Total", "Valuation and Total") and flt(base_amount):
 				account_currency = get_account_currency(tax.account_head)
 

--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -338,59 +338,6 @@ class TestPurchaseInvoice(unittest.TestCase, StockTestMixin):
 
 		self.assertEqual(discrepancy_caused_by_exchange_rate_diff, amount)
 
-	@change_settings("Buying Settings", {"enable_discount_accounting": 1})
-	def test_purchase_invoice_with_discount_accounting_enabled(self):
-
-		discount_account = create_account(
-			account_name="Discount Account",
-			parent_account="Indirect Expenses - _TC",
-			company="_Test Company",
-		)
-		pi = make_purchase_invoice(discount_account=discount_account, rate=45)
-
-		expected_gle = [
-			["_Test Account Cost for Goods Sold - _TC", 250.0, 0.0, nowdate()],
-			["Creditors - _TC", 0.0, 225.0, nowdate()],
-			["Discount Account - _TC", 0.0, 25.0, nowdate()],
-		]
-
-		check_gl_entries(self, pi.name, expected_gle, nowdate())
-
-	@change_settings("Buying Settings", {"enable_discount_accounting": 1})
-	def test_additional_discount_for_purchase_invoice_with_discount_accounting_enabled(self):
-
-		additional_discount_account = create_account(
-			account_name="Discount Account",
-			parent_account="Indirect Expenses - _TC",
-			company="_Test Company",
-		)
-
-		pi = make_purchase_invoice(do_not_save=1, parent_cost_center="Main - _TC")
-		pi.apply_discount_on = "Grand Total"
-		pi.additional_discount_account = additional_discount_account
-		pi.additional_discount_percentage = 10
-		pi.disable_rounded_total = 1
-		pi.append(
-			"taxes",
-			{
-				"charge_type": "On Net Total",
-				"account_head": "_Test Account VAT - _TC",
-				"cost_center": "Main - _TC",
-				"description": "Test",
-				"rate": 10,
-			},
-		)
-		pi.submit()
-
-		expected_gle = [
-			["_Test Account Cost for Goods Sold - _TC", 250.0, 0.0, nowdate()],
-			["_Test Account VAT - _TC", 25.0, 0.0, nowdate()],
-			["Creditors - _TC", 0.0, 247.5, nowdate()],
-			["Discount Account - _TC", 0.0, 27.5, nowdate()],
-		]
-
-		check_gl_entries(self, pi.name, expected_gle, nowdate())
-
 	def test_purchase_invoice_change_naming_series(self):
 		pi = frappe.copy_doc(test_records[1])
 		pi.insert()


### PR DESCRIPTION
With discount accounting enabled, Purchase Receipt and its Purchase Invoice with discounts applied on them, post GL entries with discrepancy. For now, removing the discount accounting feature on Buying module(PI).

