### PR TITLE
fix: Route condition set for stock ledger

### DIFF
--- a/erpnext/stock/doctype/item/item_dashboard.py
+++ b/erpnext/stock/doctype/item/item_dashboard.py
@@ -5,7 +5,7 @@ def get_data():
 	return {
 		"heatmap": True,
 		"heatmap_message": _("This is based on stock movement. See {0} for details").format(
-			'<a href="#query-report/Stock Ledger">' + _("Stock Ledger") + "</a>"
+			'<a href="/app/query-report/Stock Ledger">' + _("Stock Ledger") + "</a>"
 		),
 		"fieldname": "item_code",
 		"non_standard_fieldnames": {


### PR DESCRIPTION
**Version**

ERPNext: v14.0.1 (version-14)
Frappe Framework: v14.4.0 (version-14)

___

**Before:**

- When clicking stock ledger on item dashboard then the error shows like Page #query-report not found because does not go to proper redirect to the stock ledger report.

https://user-images.githubusercontent.com/34390782/186082761-a004068b-b148-40ee-bf3a-a32773ebccc5.mp4


**After:**
- After set condition, when clicking stock ledger then will properly redirect to the stock ledger report.


https://user-images.githubusercontent.com/34390782/186083329-f935fb34-6248-48ec-a3b8-eb994e206fec.mp4

Thank You!