### PR TITLE
chore: add Work Order test dependencies

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -26,6 +26,8 @@ from erpnext.stock.doctype.stock_entry import test_stock_entry
 from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
 from erpnext.stock.utils import get_bin
 
+test_dependencies = ["BOM"]
+
 
 class TestWorkOrder(FrappeTestCase):
 	def setUp(self):


### PR DESCRIPTION
Add work order test dependencies to run only 

bench --site XXXX --verbose run-tests --module erpnext.manufacturing.doctype.work_order.test_work_order