### PR TITLE
fix: include payment against PO in AR/AP report

### DIFF
--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -178,6 +178,11 @@ class ReceivablePayableReport(object):
 
 		key = (ple.against_voucher_type, ple.against_voucher_no, ple.party)
 		row = self.voucher_balance.get(key)
+
+		if not row:
+			# no invoice, this is an invoice / stand-alone payment / credit note
+			row = self.voucher_balance.get((ple.voucher_type, ple.voucher_no, ple.party))
+
 		return row
 
 	def update_voucher_balance(self, ple):


### PR DESCRIPTION
Payments against Purchase Order/Sales Order should be included in Accounts Receivable/Payable report under the same Voucher no as outstanding amount.

Before:
<img width="1269" alt="before_ar_rpt" src="https://user-images.githubusercontent.com/3272205/186370625-ca015c78-5c25-4c57-98ff-9ed1b9313e66.png">

After:
<img width="1269" alt="after_ar_rpt" src="https://user-images.githubusercontent.com/3272205/186370646-f3bbfca2-4673-4398-b56a-43e62dee1560.png">
