### PR TITLE
fix: display amount in account currency if party is supplied

### DIFF
--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -192,7 +192,11 @@ class ReceivablePayableReport(object):
 		if not row:
 			return
 
-		amount = ple.amount
+		# amount in "Party Currency", if its supplied. If not, amount in company currency
+		if self.filters.get(scrub(self.party_type)):
+			amount = ple.amount_in_account_currency
+		else:
+			amount = ple.amount
 		amount_in_account_currency = ple.amount_in_account_currency
 
 		# update voucher
@@ -690,7 +694,7 @@ class ReceivablePayableReport(object):
 				ple.party,
 				ple.posting_date,
 				ple.due_date,
-				ple.account_currency.as_("currency"),
+				ple.account_currency,
 				ple.amount,
 				ple.amount_in_account_currency,
 			)


### PR DESCRIPTION
Accounts Receivable/Payable report should display amount in account currency, if party is supplied.
Company Currency:
<img width="1269" alt="Screenshot 2022-08-25 at 10 09 32 AM" src="https://user-images.githubusercontent.com/3272205/186576441-0ce57a34-de18-4716-af06-00c70b788002.png">
Account curreny:
<img width="1269" alt="Screenshot 2022-08-25 at 10 09 22 AM" src="https://user-images.githubusercontent.com/3272205/186576457-8f57b108-f827-4123-bac4-286a954879d2.png">

