### PR TITLE
fix: Purposes not set in Maintenance Visit

### DIFF
--- a/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py
+++ b/erpnext/maintenance/doctype/maintenance_schedule/maintenance_schedule.py
@@ -415,7 +415,7 @@ def make_maintenance_visit(source_name, target_doc=None, item_name=None, s_id=No
 			},
 			"Maintenance Schedule Item": {
 				"doctype": "Maintenance Visit Purpose",
-				"condition": lambda doc: doc.item_name == item_name,
+				"condition": lambda doc: doc.item_name == item_name if item_name else True,
 				"field_map": {"sales_person": "service_person"},
 				"postprocess": update_serial,
 			},


### PR DESCRIPTION
While making Maintenance Visit from Maintenance Schedule the purposes table has not set any value

1) Go to Maintenance Visit DocType
2) Select any series and then Select customer as "ABC"
3) Click on the "Get Items From" and select "Maintenance Schedule".
4) Select the Maintenance schedule Document
5) Purposes table showing blank

