### PR TITLE
emergency hotfix: change in Python Error handling

### DIFF
--- a/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.py
+++ b/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.py
@@ -226,7 +226,7 @@ def new_bank_transaction(transaction):
 	try:
 		tags += transaction["category"]
 		tags += ["Plaid Cat. {}".format(transaction["category_id"])]
-	except KeyError:
+	except Exception:
 		pass
 
 	if not frappe.db.exists("Bank Transaction", dict(transaction_id=transaction["transaction_id"])):

--- a/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.py
+++ b/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.py
@@ -226,7 +226,7 @@ def new_bank_transaction(transaction):
 	try:
 		tags += transaction["category"]
 		tags += ["Plaid Cat. {}".format(transaction["category_id"])]
-	except (KeyError, NoneType):
+	except (KeyError, TypeError):
 		pass
 
 	if not frappe.db.exists("Bank Transaction", dict(transaction_id=transaction["transaction_id"])):

--- a/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.py
+++ b/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.py
@@ -226,7 +226,7 @@ def new_bank_transaction(transaction):
 	try:
 		tags += transaction["category"]
 		tags += ["Plaid Cat. {}".format(transaction["category_id"])]
-	except Exception:
+	except (KeyError, NoneType):
 		pass
 
 	if not frappe.db.exists("Bank Transaction", dict(transaction_id=transaction["transaction_id"])):


### PR DESCRIPTION
suddenly non existence of ["catagory"] creates an NoneType error in pyhton (change in handling python 3.5 ?). since tags are not strictly needed all execptions should pass.