### PR TITLE
fix: Purchase Order creation from Sales Order

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -892,6 +892,7 @@ def make_purchase_order_for_default_supplier(source_name, selected_items=None, t
 		target.additional_discount_percentage = 0.0
 		target.discount_amount = 0.0
 		target.inter_company_order_reference = ""
+		target.shipping_rule = ""
 
 		default_price_list = frappe.get_value("Supplier", supplier, "default_price_list")
 		if default_price_list:
@@ -1010,6 +1011,7 @@ def make_purchase_order(source_name, selected_items=None, target_doc=None):
 		target.additional_discount_percentage = 0.0
 		target.discount_amount = 0.0
 		target.inter_company_order_reference = ""
+		target.shipping_rule = ""
 		target.customer = ""
 		target.customer_name = ""
 		target.run_method("set_missing_values")


### PR DESCRIPTION
**Version:**

ERPNext: v14.0.2 (version-14)
Frappe Framework: v14.4.2 (version-14)
___
Issue: https://discuss.erpnext.com/t/sales-order-to-po-question/93789
___
**Before:**
- When adding the shipping rule in the sales order and submitting it, when create a purchase order from the sales order with the default supplier and without the default supplier then faced issues like the Shipping rule only applicable for selling.


https://user-images.githubusercontent.com/34390782/186832028-bce8e275-4ab9-4e14-83df-4307ee48b1fa.mp4


**After:**
- After developing, when the purchase order creates from the sales order with the shipping rule then the purchase order will create successfully.


https://user-images.githubusercontent.com/34390782/186833348-141451b5-b3e1-498a-b611-0012c2e240ae.mp4


Thank You!