### PR TITLE
chore: remove precision on discount_percentage of Sales Invoice Item

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
+++ b/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
@@ -282,7 +282,6 @@
    "label": "Discount (%) on Price List Rate with Margin",
    "oldfieldname": "adj_rate",
    "oldfieldtype": "Float",
-   "precision": "2",
    "print_hide": 1
   },
   {
@@ -846,7 +845,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2022-06-17 05:33:15.335912",
+ "modified": "2022-08-26 12:06:31.205417",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice Item",


### PR DESCRIPTION
## Issue
Discount percentages of 99.999% gets rounded up to 100% effectively making the item rate 0. Caused by precision '2'.

## Fix
Remove precision on discount_percentage field of Sales Invoice Item and use system default '3'.