### PR TITLE
feat: don't copy item title to description

### DIFF
--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -18,7 +18,6 @@ from frappe.utils import (
 	now_datetime,
 	nowtime,
 	strip,
-	strip_html,
 )
 from frappe.utils.html_utils import clean_html
 
@@ -82,9 +81,6 @@ class Item(Document):
 	def validate(self):
 		if not self.item_name:
 			self.item_name = self.item_code
-
-		if not strip_html(cstr(self.description)).strip():
-			self.description = self.item_name
 
 		self.validate_uom()
 		self.validate_description()


### PR DESCRIPTION
We used to copy the item name into the description, if the description was empty.

Why? It doesn't add information. What if the item name says enough and doesn't need a description?

Todo:

- [ ] make description optional in transaction items

> no-docs