### PR TITLE
fix: do not clear promotion/transfer details if doc is amended

### DIFF
--- a/erpnext/hr/employee_property_update.js
+++ b/erpnext/hr/employee_property_update.js
@@ -9,10 +9,10 @@ frappe.ui.form.on(cur_frm.doctype, {
 		});
 	},
 	onload: function(frm){
-		if(frm.doc.__islocal){
-			if(frm.doctype == "Employee Promotion"){
+		if (frm.doc.__islocal && !frm.doc.amended_from) {
+			if (frm.doctype == "Employee Promotion") {
 				frm.doc.promotion_details = [];
-			}else if (frm.doctype == "Employee Transfer") {
+			} else if (frm.doctype == "Employee Transfer") {
 				frm.doc.transfer_details = [];
 			}
 		}
@@ -123,6 +123,8 @@ var add_to_details = function(frm, d, table) {
 			new: data.new
 		});
 		frm.refresh_field(table);
+		frm.fields_dict[table].grid.wrapper.find(".grid-add-row").hide();
+
 		d.fields_dict.field_html.$wrapper.html("");
 		d.set_value("property", "");
 		d.set_value('current', "");

--- a/erpnext/hr/employee_property_update.js
+++ b/erpnext/hr/employee_property_update.js
@@ -8,7 +8,7 @@ frappe.ui.form.on(cur_frm.doctype, {
 			};
 		});
 	},
-	onload: function(frm){
+	onload: function(frm) {
 		if (frm.doc.__islocal && !frm.doc.amended_from) {
 			if (frm.doctype == "Employee Promotion") {
 				frm.doc.promotion_details = [];
@@ -106,12 +106,12 @@ var render_dynamic_field = function(d, fieldtype, options, fieldname) {
 
 var add_to_details = function(frm, d, table) {
 	let data = d.data;
-	if(data.fieldname){
-		if(validate_duplicate(frm, table, data.fieldname)){
+	if (data.fieldname) {
+		if (validate_duplicate(frm, table, data.fieldname)) {
 			frappe.show_alert({message:__("Property already added"), indicator:'orange'});
 			return false;
 		}
-		if(data.current == data.new){
+		if (data.current == data.new) {
 			frappe.show_alert({message:__("Nothing to change"), indicator:'orange'});
 			d.get_primary_btn().attr('disabled', false);
 			return false;
@@ -130,7 +130,7 @@ var add_to_details = function(frm, d, table) {
 		d.set_value('current', "");
 		frappe.show_alert({message:__("Added to details"),indicator:'green'});
 		d.data = {};
-	}else {
+	} else {
 		frappe.show_alert({message:__("Value missing"),indicator:'red'});
 	}
 };


### PR DESCRIPTION
1. Promotion and Transfer details are cleared from the child table on load for a new doc. Do not clear the details if it's an amended doc otherwise the user has to enter the details again.
2. The standard grid "Add Row" button is visible when a new row is added. Since there is a custom grid row button added, hide this when grid is refreshed.

Not fixing other stuff since most of it has been refactored in v14 / HRMS v1: https://github.com/frappe/erpnext/pull/30780