### PR TITLE
fix: filter leave types and render leave application dashboard w/o from date

### DIFF
--- a/erpnext/hr/doctype/leave_application/leave_application.js
+++ b/erpnext/hr/doctype/leave_application/leave_application.js
@@ -52,7 +52,7 @@ frappe.ui.form.on("Leave Application", {
 	make_dashboard: function(frm) {
 		var leave_details;
 		let lwps;
-		if (frm.doc.employee && frm.doc.from_date) {
+		if (frm.doc.employee) {
 			frappe.call({
 				method: "erpnext.hr.doctype.leave_application.leave_application.get_leave_details",
 				async: false,


### PR DESCRIPTION
Filter Leave Type and show the Leave Application dashboard as soon as the employee is selected based on the current date (without From Date being set). Right now the dashboard and filter are only shown when the From Date is set.