### PR TITLE
fix: lost quotation not to expired

### DIFF
--- a/erpnext/selling/doctype/quotation/quotation.py
+++ b/erpnext/selling/doctype/quotation/quotation.py
@@ -268,7 +268,7 @@ def _make_sales_order(source_name, target_doc=None, ignore_permissions=False):
 
 def set_expired_status():
 	# filter out submitted non expired quotations whose validity has been ended
-	cond = "`tabQuotation`.docstatus = 1 and `tabQuotation`.status != 'Expired' and `tabQuotation`.valid_till < %s"
+	cond = "`tabQuotation`.docstatus = 1 and `tabQuotation`.status NOT IN ('Expired', 'Lost') and `tabQuotation`.valid_till < %s"
 	# check if those QUO have SO against it
 	so_against_quo = """
 		SELECT


### PR DESCRIPTION
![photo_2022-08-29_14-48-45](https://user-images.githubusercontent.com/76736615/187168571-a766e623-c49c-4a30-a38f-8736713425a7.jpg)

Analyse the image you can see the user is already marked this quotation as lost. After the expire date of quotation the quotation is changed into expired and user need ato again mark the quitation as lost. 

If it is not okay. Please test from your side
@ankush 