### PR TITLE
refactor: readd remarks field to payment ledger

### DIFF
--- a/erpnext/accounts/doctype/payment_ledger_entry/payment_ledger_entry.json
+++ b/erpnext/accounts/doctype/payment_ledger_entry/payment_ledger_entry.json
@@ -22,7 +22,8 @@
   "amount",
   "account_currency",
   "amount_in_account_currency",
-  "delinked"
+  "delinked",
+  "remarks"
  ],
  "fields": [
   {
@@ -136,12 +137,17 @@
    "fieldtype": "Link",
    "label": "Finance Book",
    "options": "Finance Book"
+  },
+  {
+   "fieldname": "remarks",
+   "fieldtype": "Text",
+   "label": "Remarks"
   }
  ],
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-07-11 09:13:54.379168",
+ "modified": "2022-08-22 15:32:56.629430",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Ledger Entry",

--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.js
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.js
@@ -179,6 +179,11 @@ frappe.query_reports["Accounts Receivable"] = {
 			"hidden": 1
 		},
 		{
+			"fieldname": "show_remarks",
+			"label": __("Show Remarks"),
+			"fieldtype": "Check",
+		},
+		{
 			"fieldname": "customer_name",
 			"label": __("Customer Name"),
 			"fieldtype": "Data",

--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -119,6 +119,7 @@ class ReceivablePayableReport(object):
 					party_account=ple.account,
 					posting_date=ple.posting_date,
 					account_currency=ple.account_currency,
+					remarks=ple.remarks,
 					invoiced=0.0,
 					paid=0.0,
 					credit_note=0.0,
@@ -697,6 +698,7 @@ class ReceivablePayableReport(object):
 				ple.account_currency,
 				ple.amount,
 				ple.amount_in_account_currency,
+				ple.remarks,
 			)
 			.where(ple.delinked == 0)
 			.where(Criterion.all(self.qb_selection_filter))
@@ -973,6 +975,9 @@ class ReceivablePayableReport(object):
 				fieldtype="Link",
 				options="Supplier Group",
 			)
+
+		if self.filters.show_remarks:
+			self.add_column(label=_("Remarks"), fieldname="remarks", fieldtype="Text", width=200),
 
 	def add_column(self, label, fieldname=None, fieldtype="Currency", options=None, width=120):
 		if not fieldname:

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -1424,6 +1424,7 @@ def create_payment_ledger_entry(
 						"amount": dr_or_cr,
 						"amount_in_account_currency": dr_or_cr_account_currency,
 						"delinked": True if cancel else False,
+						"remarks": gle.remarks,
 					}
 				)
 

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -312,3 +312,4 @@ erpnext.patches.v13_0.fix_number_and_frequency_for_monthly_depreciation
 erpnext.patches.v14_0.remove_hr_and_payroll_modules # 20-07-2022
 erpnext.patches.v14_0.fix_crm_no_of_employees
 erpnext.patches.v14_0.create_accounting_dimensions_in_subcontracting_doctypes
+erpnext.patches.v14_0.migrate_remarks_from_gl_to_payment_ledger

--- a/erpnext/patches/v14_0/migrate_remarks_from_gl_to_payment_ledger.py
+++ b/erpnext/patches/v14_0/migrate_remarks_from_gl_to_payment_ledger.py
@@ -1,0 +1,56 @@
+import frappe
+from frappe import qb
+from frappe.utils import create_batch
+
+
+def execute():
+	if frappe.reload_doc("accounts", "doctype", "payment_ledger_entry"):
+
+		gle = qb.DocType("GL Entry")
+		ple = qb.DocType("Payment Ledger Entry")
+
+		# get ple and their remarks from GL Entry
+		pl_entries = (
+			qb.from_(ple)
+			.left_join(gle)
+			.on(
+				(ple.account == gle.account)
+				& (ple.party_type == gle.party_type)
+				& (ple.party == gle.party)
+				& (ple.voucher_type == gle.voucher_type)
+				& (ple.voucher_no == gle.voucher_no)
+				& (ple.company == gle.company)
+			)
+			.select(
+				ple.company,
+				ple.account,
+				ple.party_type,
+				ple.party,
+				ple.voucher_type,
+				ple.voucher_no,
+				gle.remarks.as_("gle_remarks"),
+			)
+			.where((ple.delinked == 0) & (gle.is_cancelled == 0))
+			.run(as_dict=True)
+		)
+
+		if pl_entries:
+			# split into multiple batches, update and commit for each batch
+			batch_size = 1000
+			for batch in create_batch(pl_entries, batch_size):
+				for entry in batch:
+					query = (
+						qb.update(ple)
+						.set(ple.remarks, entry.gle_remarks)
+						.where(
+							(ple.company == entry.company)
+							& (ple.account == entry.account)
+							& (ple.party_type == entry.party_type)
+							& (ple.party == entry.party)
+							& (ple.voucher_type == entry.voucher_type)
+							& (ple.voucher_no == entry.voucher_no)
+						)
+					)
+					query.run()
+
+				frappe.db.commit()


### PR DESCRIPTION
Add remarks field to Payment Ledger feature. Remarks field will be reintroduced in Accounts Receivable/Payable report.

Changes in PR:
1. Readd remarks field to Payment Ledger Entry doctype
2. Fetch value from GL Entry remarks on creation
3. Refactor AR/AP report to include remarks field
4. Patch to migrate old remarks from GL to payment ledger entry for existing data
5. add patch to patches.txt