### PR TITLE
chore(deps): specify `PyPNG` as a dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,9 @@ dependencies = [
     "python-youtube~=0.8.0",
     "taxjar~=1.9.2",
     "tweepy~=3.10.0",
+
+    # Not used directly - required by PyQRCode for PNG generation
+    "pypng~=0.20220715.0",
 ]
 
 [build-system]


### PR DESCRIPTION
`PyPNG` was removed from Frappe in https://github.com/frappe/frappe/pull/17962

It's required by PyQRCode for PNG Generation. Note that PyQRCode itself is defined in Frappe.