### PR TITLE
fix: Naming series in Journal Entry Template

### DIFF
--- a/erpnext/accounts/doctype/journal_entry_template/journal_entry_template.js
+++ b/erpnext/accounts/doctype/journal_entry_template/journal_entry_template.js
@@ -2,7 +2,7 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Journal Entry Template", {
-	setup: function(frm) {
+	refresh: function(frm) {
 		frappe.model.set_default_values(frm.doc);
 
 		frm.set_query("account" ,"accounts", function(){


### PR DESCRIPTION
**Version:**

ERPNext: v14.0.3 (version-14)
Frappe Framework: v14.5.0 (version-14)
Payments: v0.0.1 (develop)

___

**Before:**

- When creating a new journal entry template the first time naming series appears but when duplicating the journal entry template or back to the journal entry template and again creating a new journal entry template the naming series does not appear. But when reloading the system and creating the journal entry template then will be naming series appear.


https://user-images.githubusercontent.com/34390782/187846470-0c94d74d-0338-4ca2-8c5e-be5b1d822181.mp4


**After:**
- After the form event set, when When creating a new journal entry, duplicating the entry, and back to the journal entry template and again creating a new journal entry template the naming series will appear.
- For cross-checking, also multi-currency wise and without multi-currency account show in Accounting Entries (Table).


https://user-images.githubusercontent.com/34390782/187847897-9ba79020-881b-42ca-9744-129cd35a05f7.mp4

___

Issue: #32040

It problem is also in version 13.

___

Thank You!
