### PR TITLE
fix: key error on consolidated financial report

### DIFF
--- a/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py
+++ b/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py
@@ -535,7 +535,11 @@ def get_accounts(root_type, companies):
 		):
 			if account.account_name not in added_accounts:
 				accounts.append(account)
-				added_accounts.append(account.account_name)
+				if account.account_number:
+					account_key = account.account_number + "-" + account.account_name
+				else:
+					account_key = account.account_name
+				added_accounts.append(account_key)
 
 	return accounts
 


### PR DESCRIPTION
## Issue
Key Error on Consolidated Financial Report with Accounts having Same account name and differnet account number. Happens only on 'Profit and Loss Statement'.

Multiple Accounts with same account name and different account number.
<img width="273" alt="Screenshot 2022-09-02 at 10 06 10 AM" src="https://user-images.githubusercontent.com/3272205/188060184-cde87b3a-9f21-4f5c-a1f7-b6c454f01208.png">

<img width="585" alt="Screenshot 2022-09-02 at 10 05 43 AM" src="https://user-images.githubusercontent.com/3272205/188060187-94d03e5e-c472-4324-bd7d-43354c88232e.png">

## Fix
If account number is available, use it along account name to make key.

After Fix:
<img width="491" alt="Screenshot 2022-09-02 at 10 07 02 AM" src="https://user-images.githubusercontent.com/3272205/188060282-1d812d81-2142-449c-be79-16d80408a53b.png">
