### PR TITLE
fix: KSA VAT report multi currency amount issue

### DIFF
--- a/erpnext/regional/report/ksa_vat/ksa_vat.py
+++ b/erpnext/regional/report/ksa_vat/ksa_vat.py
@@ -177,16 +177,16 @@ def get_tax_data_for_each_vat_setting(vat_setting, filters, doctype):
 				"parent": invoice.name,
 				"item_tax_template": vat_setting.item_tax_template,
 			},
-			fields=["item_code", "net_amount"],
+			fields=["item_code", "base_net_amount"],
 		)
 
 		for item in invoice_items:
 			# Summing up total taxable amount
 			if invoice.is_return == 0:
-				total_taxable_amount += item.net_amount
+				total_taxable_amount += item.base_net_amount
 
 			if invoice.is_return == 1:
-				total_taxable_adjustment_amount += item.net_amount
+				total_taxable_adjustment_amount += item.base_net_amount
 
 			# Summing up total tax
 			total_tax += get_tax_amount(item.item_code, vat_setting.account, doctype, invoice.name)


### PR DESCRIPTION
In KSA VAT report amount is not showing correctly for multi currencies because net_amount field is fetched instead of base_net_amount

<img width="1063" alt="image" src="https://user-images.githubusercontent.com/40721748/188066628-d5b5416e-6854-4ef4-9634-abed6fbbd29b.png">
<img width="1063" alt="image" src="https://user-images.githubusercontent.com/40721748/188066895-fe23656e-5bab-4a24-b79e-6f37f33fb667.png">

As you can see in picture base amount is **751.90 SAR** and base tax is **37.59 SAR** but when we show in report **200** in USD shows but VAT amount is **37.59 SAR** which is correct. I have attach the reference picture
<img width="810" alt="image" src="https://user-images.githubusercontent.com/40721748/188067120-6977dca4-e2b6-4f7d-83c4-e2443c19d8c4.png">

I have amend the code and changed net_amount to base_net_amount. After changing the code it looks like
<img width="674" alt="image" src="https://user-images.githubusercontent.com/40721748/188067508-e53a4e70-9b5b-45cf-939d-52af89992fbd.png">
