### PR TITLE
fix: QR Code multi currency issue

### DIFF
--- a/erpnext/regional/saudi_arabia/utils.py
+++ b/erpnext/regional/saudi_arabia/utils.py
@@ -87,7 +87,7 @@ def create_qr_code(doc, method=None):
 		tlv_array.append("".join([tag, length, value]))
 
 		# Invoice Amount
-		invoice_amount = str(doc.grand_total)
+		invoice_amount = str(doc.base_grand_total)
 		tag = bytes([4]).hex()
 		length = bytes([len(invoice_amount)]).hex()
 		value = invoice_amount.encode("utf-8").hex()
@@ -147,7 +147,7 @@ def get_vat_amount(doc):
 
 	for tax in doc.get("taxes"):
 		if tax.account_head in vat_accounts:
-			vat_amount += tax.tax_amount
+			vat_amount += tax.base_tax_amount
 
 	return vat_amount
 


### PR DESCRIPTION
When try to scan qr code on app it is showing correct values for multi currencies because it is not getting base amount
<img width="1063" alt="image" src="https://user-images.githubusercontent.com/40721748/188373381-0c8b0b86-f02f-4136-b364-0a2dabf762fa.png">
<img width="758" alt="image" src="https://user-images.githubusercontent.com/40721748/188374386-74ca2332-1d98-4d83-9edd-28def748a8df.png">
As above images showing:
1. Grand Total is **105** in USD and **394.60** in SAR
2. Tax Amount is **5** in USD and **18.79** in SAR

whereas when try to scan QR code of invoice it is not fetching the base amount but using base currency symbol
<img width="288" alt="image" src="https://user-images.githubusercontent.com/40721748/188378360-7318a64e-f67f-4905-9df4-78804f48f824.png">
Before changing in the code this QR code is showing Invoice Total: **105 SAR** & VAT Total: **5 SAR** while it should show **105 USD** or **394.60 SAR**
<img width="195" alt="image" src="https://user-images.githubusercontent.com/40721748/188380291-1446370c-fb12-498b-9f0e-deb6eb0432de.png">
After amend the code it is showing **394.60 SAR** insted of **105 USD** which is correct