### PR TITLE
fix: consider Stock Entry purpose while getting total supplied qty

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -856,15 +856,22 @@ class StockEntry(StockController):
 							se_item.item_code, self.purchase_order
 						)
 					)
-				total_supplied = frappe.db.sql(
-					"""select sum(transfer_qty)
-					from `tabStock Entry Detail`, `tabStock Entry`
-					where `tabStock Entry`.purchase_order = %s
-						and `tabStock Entry`.docstatus = 1
-						and `tabStock Entry Detail`.item_code = %s
-						and `tabStock Entry Detail`.parent = `tabStock Entry`.name""",
-					(self.purchase_order, se_item.item_code),
-				)[0][0]
+
+				se = frappe.qb.DocType("Stock Entry")
+				se_detail = frappe.qb.DocType("Stock Entry Detail")
+
+				total_supplied = (
+					frappe.qb.from_(se)
+					.inner_join(se_detail)
+					.on(se.name == se_detail.parent)
+					.select(Sum(se_detail.transfer_qty))
+					.where(
+						(se.purpose == "Send to Subcontractor")
+						& (se.purchase_order == self.purchase_order)
+						& (se_detail.item_code == se_item.item_code)
+						& (se.docstatus == 1)
+					)
+				).run()[0][0]
 
 				if flt(total_supplied, precision) > flt(total_allowed, precision):
 					frappe.throw(


### PR DESCRIPTION
Source / Reference: ISS-22-23-02199

Problem: While getting the Supplied Qty for an Item, the system considers all the Stock Entries having the reference of Purchase Order. Ideally, it should consider only the Stock Entries of type Send to Subcontractor with the Purchase Order reference.

Steps to replicate the issue:
1. Create Subcontract Purchase Order for 100 Qty.
2. Create Stock Entry of type Send to Subcontractor for 75 Qty.
3. Again Create a Stock Entry of type Material Transfer with Purchase Order reference for 25 Qty.
4. Now, try to create Stock Entry of type Send to Subcontractor for 25 Qty.