### PR TITLE
fix: error on bank statement import

### DIFF
--- a/erpnext/accounts/doctype/bank_statement_import/bank_statement_import.js
+++ b/erpnext/accounts/doctype/bank_statement_import/bank_statement_import.js
@@ -141,7 +141,7 @@ frappe.ui.form.on("Bank Statement Import", {
 	},
 
 	show_import_status(frm) {
-		let import_log = JSON.parse(frm.doc.import_log || "[]");
+		let import_log = JSON.parse(frm.doc.statement_import_log || "[]");
 		let successful_records = import_log.filter((log) => log.success);
 		let failed_records = import_log.filter((log) => !log.success);
 		if (successful_records.length === 0) return;
@@ -309,7 +309,7 @@ frappe.ui.form.on("Bank Statement Import", {
 	// method: 'frappe.core.doctype.data_import.data_import.get_preview_from_template',
 
 	show_import_preview(frm, preview_data) {
-		let import_log = JSON.parse(frm.doc.import_log || "[]");
+		let import_log = JSON.parse(frm.doc.statement_import_log || "[]");
 
 		if (
 			frm.import_preview &&
@@ -439,7 +439,7 @@ frappe.ui.form.on("Bank Statement Import", {
 	},
 
 	show_import_log(frm) {
-		let import_log = JSON.parse(frm.doc.import_log || "[]");
+		let import_log = JSON.parse(frm.doc.statement_import_log || "[]");
 		let logs = import_log;
 		frm.toggle_display("import_log", false);
 		frm.toggle_display("import_log_section", logs.length > 0);

--- a/erpnext/accounts/doctype/bank_statement_import/bank_statement_import.json
+++ b/erpnext/accounts/doctype/bank_statement_import/bank_statement_import.json
@@ -24,7 +24,7 @@
   "section_import_preview",
   "import_preview",
   "import_log_section",
-  "import_log",
+  "statement_import_log",
   "show_failed_logs",
   "import_log_preview",
   "reference_doctype",
@@ -89,12 +89,6 @@
    "label": "Template Options",
    "options": "JSON",
    "read_only": 1
-  },
-  {
-   "fieldname": "import_log",
-   "fieldtype": "Code",
-   "label": "Import Log",
-   "options": "JSON"
   },
   {
    "fieldname": "import_log_section",
@@ -198,11 +192,17 @@
   {
    "fieldname": "column_break_4",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "statement_import_log",
+   "fieldtype": "Code",
+   "label": "Statement Import Log",
+   "options": "JSON"
   }
  ],
  "hide_toolbar": 1,
  "links": [],
- "modified": "2021-05-12 14:17:37.777246",
+ "modified": "2022-09-07 11:11:40.293317",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Bank Statement Import",


### PR DESCRIPTION
## Issue
Bank Statement Import throws 'Value for Import log cannot be List'. 
This is caused by name collision between Framework's File importer's internal attribute and Bank Statement import log - `import_log` field.

https://github.com/frappe/frappe/blob/b47205ff01d3276d87c590c9ad0d9595e6c5eb45/frappe/core/doctype/data_import/importer.py#L50-L61

`import_log` overridden on call to `get_preview_from_template`

https://github.com/frappe/erpnext/blob/008542b7155791d3f5cbbd4701fde2d953be3802/erpnext/accounts/doctype/bank_statement_import/bank_statement_import.py#L86-L88
## Fix
Renamed `import_log` to `statement_import_log`.

Fixes: #31288 , #31688 