### PR TITLE
fix: inventory dimension filter's label not showing in the report

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -226,7 +226,7 @@ $.extend(erpnext.utils, {
 						if (!found) {
 							filters.splice(index, 0, {
 								"fieldname": dimension["fieldname"],
-								"label": __(dimension["label"]),
+								"label": __(dimension["doctype"]),
 								"fieldtype": "MultiSelectList",
 								get_data: function(txt) {
 									return frappe.db.get_link_options(dimension["doctype"], txt);


### PR DESCRIPTION
**Issue**

Inventory dimension filter's label not showing in the report

<img width="1312" alt="Screenshot 2022-09-07 at 2 39 20 PM" src="https://user-images.githubusercontent.com/8780500/188839688-a75f106b-f501-4caa-a36f-ac847e00c05a.png">


**After Fix**
<img width="1317" alt="Screenshot 2022-09-07 at 2 39 04 PM" src="https://user-images.githubusercontent.com/8780500/188839810-bdff9b78-53be-4479-bf11-7cae48e14835.png">

