### PR TITLE
fix: Reduce font size for Process Statement of accounts print/pdf

### DIFF
--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.html
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.html
@@ -25,7 +25,7 @@
 	</div>
 	<br>
 
-	<table class="table table-bordered">
+	<table class="table table-bordered" style="font-size: 10px">
 		<thead>
 			<tr>
 				<th style="width: 12%">{{ _("Date") }}</th>


### PR DESCRIPTION
The Print statement of accounts was inheriting the font size from the base template which is specifically designed to show pages in "Portrait Orientation"

The PSOA sends AR/AP reports which are usually in landscape mode and due to the big font size the report was taking more pages unlike the one made from the general ledger, so reduced the font size to accommodate more rows.