### PR TITLE
fix: option to start reposting from repost item valuation

### DIFF
--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.js
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.js
@@ -58,6 +58,21 @@ frappe.ui.form.on('Repost Item Valuation', {
 		}
 
 		frm.trigger('show_reposting_progress');
+
+		if (frm.doc.status === 'Queued' && frm.doc.docstatus === 1) {
+			frm.trigger('execute_reposting');
+		}
+	},
+
+	execute_reposting(frm) {
+		frm.add_custom_button(__("Start Reposting"), () => {
+			frappe.call({
+				method: 'erpnext.stock.doctype.repost_item_valuation.repost_item_valuation.execute_repost_item_valuation',
+				callback: function() {
+					frappe.msgprint(__('Reposting has been started in the background.'));
+				}
+			});
+		});
 	},
 
 	show_reposting_progress: function(frm) {

--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
@@ -307,3 +307,9 @@ def in_configured_timeslot(repost_settings=None, current_time=None):
 		return end_time >= now_time >= start_time
 	else:
 		return now_time >= start_time or now_time <= end_time
+
+
+@frappe.whitelist()
+def execute_repost_item_valuation():
+	"""Execute repost item valuation via scheduler."""
+	frappe.get_doc("Scheduled Job Type", "repost_item_valuation.repost_entries").enqueue(force=True)


### PR DESCRIPTION
**Current Issue**

If user has created Repost Item Valuation record manually and if they wants to start reposting immediately then they have to goto the 

Scheduled Job Type -> repost_item_valuation.repost_entries -> Click on Execute button
<img width="1338" alt="Screenshot 2022-09-07 at 4 23 41 PM" src="https://user-images.githubusercontent.com/8780500/188864607-808561c9-2cac-4f0d-8f8a-b60c094a3c99.png">



For basic user this is difficult to identify the path


**After Fix**

Added option to start reposting from Repost Item Valuation screen
<img width="1303" alt="Screenshot 2022-09-07 at 4 37 09 PM" src="https://user-images.githubusercontent.com/8780500/188864765-b0a42f20-84d4-44c7-bd8f-853227939ec2.png">

