### PR TITLE
fix: Purchase Order creation from Sales Order

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -962,6 +962,7 @@ def make_purchase_order_for_default_supplier(source_name, selected_items=None, t
 		target.additional_discount_percentage = 0.0
 		target.discount_amount = 0.0
 		target.inter_company_order_reference = ""
+		target.shipping_rule = ""
 
 		default_price_list = frappe.get_value("Supplier", supplier, "default_price_list")
 		if default_price_list:
@@ -1080,6 +1081,7 @@ def make_purchase_order(source_name, selected_items=None, target_doc=None):
 		target.additional_discount_percentage = 0.0
 		target.discount_amount = 0.0
 		target.inter_company_order_reference = ""
+		target.shipping_rule = ""
 		target.customer = ""
 		target.customer_name = ""
 		target.run_method("set_missing_values")


### PR DESCRIPTION
**Version:**

ERPNext:  v13.38.0 (version-13)
Frappe Framework: v13.41.0 (version-13)

___
PR: #31984
___

**Before:**

- When adding the shipping rule in the sales order and submitting it, when create a purchase order from the sales order with the default supplier and without the default supplier then faced issues like the Shipping rule only applicable for selling.

https://user-images.githubusercontent.com/34390782/189077414-7fe06ece-9f3e-4bae-9522-a392bfc5885e.mp4


**After:**

- After developing, when the purchase order creates from the sales order with the shipping rule then the purchase order will create successfully.


https://user-images.githubusercontent.com/34390782/189078003-8f55a341-cd1a-47ca-b3f7-c663d462e8e7.mp4




