### PR TITLE
fix: SCO Supplied Items returned-qty

### DIFF
--- a/erpnext/controllers/subcontracting_controller.py
+++ b/erpnext/controllers/subcontracting_controller.py
@@ -877,6 +877,7 @@ def make_return_stock_entry_for_subcontract(
 		{
 			order_doctype: {
 				"doctype": "Stock Entry",
+				"field_no_map": ["purchase_order", "subcontracting_order"],
 			},
 		},
 		ignore_child_tables=True,


### PR DESCRIPTION
Problem: Subcontracting Order Supplied Items Returned Qty not getting updated on submit of Stock Entry (Return of Components). 

Occurred after:  https://github.com/frappe/erpnext/pull/32106