### PR TITLE
fix: Rate for internal PI have non stock UOM items

### DIFF
--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -309,7 +309,11 @@ class BuyingController(SubcontractingController):
 					rate = flt(outgoing_rate * (d.conversion_factor or 1), d.precision("rate"))
 				else:
 					field = "incoming_rate" if self.get("is_internal_supplier") else "rate"
-					rate = frappe.db.get_value(ref_doctype, d.get(frappe.scrub(ref_doctype)), field)
+					rate = flt(
+						frappe.db.get_value(ref_doctype, d.get(frappe.scrub(ref_doctype)), field)
+						* (d.conversion_factor or 1),
+						d.precision("rate"),
+					)
 
 				if self.is_internal_transfer():
 					if rate != d.rate:


### PR DESCRIPTION
For Internal transfers within the same company, the net rate was fetched incorrectly for Purchase Invoices.

For Eg, Lets an internal Sales Invoice is made for Item A with UOM "Kg" for 1 Kg having the stock UOM as grams
while making an internal Purchase Invoice against that SI the rate for the Item is fetched from the corresponding SI items
`internal_rate` field. The `internal_rate` is maintained in stock UOM and making a PI in non-stock UOM fetched an incorrect rate as the conversion factor was not considered.

This PR fixes that issue