### PR TITLE
fix: validate Subcontracting Order Status in Stock Entry

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -815,7 +815,8 @@ erpnext.stock.StockEntry = class StockEntry extends erpnext.stock.StockControlle
 			return {
 				"filters": {
 					"docstatus": 1,
-					"company": me.frm.doc.company
+					"company": me.frm.doc.company,
+					"status": ["not in", ["Completed", "Closed"]]
 				}
 			};
 		});

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -117,6 +117,7 @@ class StockEntry(StockController):
 		self.validate_work_order()
 		self.validate_bom()
 		self.validate_purchase_order()
+		self.validate_subcontracting_order()
 
 		if self.purpose in ("Manufacture", "Repack"):
 			self.mark_finished_and_scrap_items()
@@ -957,6 +958,20 @@ class StockEntry(StockController):
 				frappe.throw(
 					_("Please select Subcontracting Order instead of Purchase Order {0}").format(
 						self.purchase_order
+					)
+				)
+
+	def validate_subcontracting_order(self):
+		if self.get("subcontracting_order") and self.purpose in [
+			"Send to Subcontractor",
+			"Material Transfer",
+		]:
+			sco_status = frappe.db.get_value("Subcontracting Order", self.subcontracting_order, "status")
+
+			if sco_status == "Closed":
+				frappe.throw(
+					_("Cannot create Stock Entry against a closed Subcontracting Order {0}.").format(
+						self.subcontracting_order
 					)
 				)
 


### PR DESCRIPTION
Problem: Allowed to create Stock Entry of type Send to Subcontractor or Material Transfer with the reference of a Closed Subcontracting Order.

Steps to replicate:

1. Create Subcontract Purchase Order.
2. Create Subcontracting Order.
3. Transfer the Raw-Materials to the Subcontractor.
4. Create Subcontracting Receipt (Partial).
5. Create Stock Entry of type Material Transfer (Return of Components [Partial]), Subcontracting Order status changed to Closed. 
6. Create Stock Entry of type Send to Subcontractor or Material Transfer with Subcontracting Order reference.