### PR TITLE
fix: Set filter condition and spell in AR

### DIFF
--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -784,7 +784,7 @@ class ReceivablePayableReport(object):
 	def add_customer_filters(
 		self,
 	):
-		self.customter = qb.DocType("Customer")
+		self.customer = qb.DocType("Customer")
 
 		if self.filters.get("customer_group"):
 			self.get_hierarchical_filters("Customer Group", "customer_group")
@@ -838,7 +838,7 @@ class ReceivablePayableReport(object):
 		customer = self.customer
 		groups = qb.from_(doc).select(doc.name).where((doc.lft >= lft) & (doc.rgt <= rgt))
 		customers = qb.from_(customer).select(customer.name).where(customer[key].isin(groups))
-		self.qb_selection_filter.append(ple.isin(ple.party.isin(customers)))
+		self.qb_selection_filter.append(ple.party.isin(customers))
 
 	def add_accounting_dimensions_filters(self):
 		accounting_dimensions = get_accounting_dimensions(as_list=False)


### PR DESCRIPTION
**Version:**

ERPNext: v14.1.0 (version-14)
Frappe Framework: v14.6.0 (version-14)
Payments: v0.0.1 (develop)
___
Issue: #32160
___
**Before:**
- In AR, when selecting territory then faced errors like AttributeError: 'ReceivablePayableReport' object has no attribute 'customer' and also in spell mistake of customer in line 787.
https://github.com/frappe/erpnext/blob/6b94b5334c674410ef0d7a1822ccd214bfbd1dd4/erpnext/accounts/report/accounts_receivable/accounts_receivable.py#L787


https://user-images.githubusercontent.com/34390782/189613550-ba0ac61c-f463-437e-99c4-60db5978c0c2.mp4

**After:**
- After developing in AR, First set the spell of the customer and then set the filter condition. When selecting territory or territory with the group by customer, data will show perfectly.


https://user-images.githubusercontent.com/34390782/189614493-d82ffe25-2e50-406f-8925-deebd5705b2a.mp4

Thank You!