### PR TITLE
feat: Ability to manually update loan amount in Salary Slips

### DIFF
--- a/erpnext/loan_management/doctype/loan/loan.json
+++ b/erpnext/loan_management/doctype/loan/loan.json
@@ -17,6 +17,7 @@
   "posting_date",
   "status",
   "repay_from_salary",
+  "manually_update_paid_amount_in_salary_slip",
   "section_break_8",
   "loan_type",
   "loan_amount",
@@ -410,16 +411,23 @@
    "fieldname": "is_npa",
    "fieldtype": "Check",
    "label": "Is NPA"
+  },
+  {
+   "allow_on_submit": 1,
+   "default": "0",
+   "depends_on": "repay_from_salary",
+   "fieldname": "manually_update_paid_amount_in_salary_slip",
+   "fieldtype": "Check",
+   "label": "Manually Update Paid Amount in Salary Slip"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2022-06-30 12:04:13.728880",
+ "modified": "2022-09-12 03:36:49.145014",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan",
- "naming_rule": "Expression (old style)",
  "owner": "Administrator",
  "permissions": [
   {
@@ -445,6 +453,5 @@
  "search_fields": "posting_date",
  "sort_field": "creation",
  "sort_order": "DESC",
- "states": [],
  "track_changes": 1
 }


### PR DESCRIPTION
After the introduction of https://github.com/frappe/erpnext/pull/32011 users were unable to manually update loan amounts in Salary Slips.

Added a manual check-in Loan Document to toggle this and make the behavior more deterministic

<img width="1347" alt="Screenshot 2022-09-12 at 3 07 36 PM" src="https://user-images.githubusercontent.com/42651287/189622059-927641b2-9186-4ddf-8b64-d0733252fbf1.png">

`no-docs`