### PR TITLE
fix: pick_list - picked qty getting set to 1

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -174,7 +174,7 @@ class PickList(Document):
 				frappe.throw("Row #{0}: Item Code is Mandatory".format(item.idx))
 			item_code = item.item_code
 			reference = item.sales_order_item or item.material_request_item
-			key = (item_code, item.uom, reference)
+			key = (item_code, item.uom, item.warehouse, reference)
 
 			item.idx = None
 			item.name = None


### PR DESCRIPTION
Case:
Material Request created for ITEM-123 for qty 8
available at WarehouseA: 1
available at WarehouseB:100

Both warehouse are under the same parent.

While creating pick list from Material Request. The system successfully identifies that it has to set qty from the two warehouses
1 from Warehouse A
2 fro Warehouse B

But the picked qty is always set to 1

https://user-images.githubusercontent.com/7881486/189622498-630e26a7-56e5-4060-8968-f277a41bf244.mp4


