### PR TITLE
fix(Salary Slip): set default amount to 0 if None

### DIFF
--- a/erpnext/payroll/doctype/salary_slip/salary_slip.py
+++ b/erpnext/payroll/doctype/salary_slip/salary_slip.py
@@ -687,8 +687,8 @@ class SalarySlip(TransactionBase):
 
 		for key in ("earnings", "deductions"):
 			for d in self.get(key):
-				default_data[d.abbr] = d.default_amount
-				data[d.abbr] = d.amount
+				default_data[d.abbr] = d.default_amount or 0
+				data[d.abbr] = d.amount or 0
 
 		return data, default_data
 


### PR DESCRIPTION
**Problem**:

Components dependent on additional salary components by formulae error out during calculation if the additional salary default amount is None.
Add 0 as a fallback while setting default amount in structures

<img width="1336" alt="image" src="https://user-images.githubusercontent.com/24353136/189665429-3b189c17-1a39-48cb-a7c0-df119edfb3de.png">
