### PR TITLE
fix: calculate amount based on payment days for statistical components too

### DIFF
--- a/erpnext/hr/doctype/attendance/test_attendance.py
+++ b/erpnext/hr/doctype/attendance/test_attendance.py
@@ -19,7 +19,7 @@ from erpnext.hr.doctype.attendance.attendance import (
 	mark_attendance,
 )
 from erpnext.hr.doctype.employee.test_employee import make_employee
-from erpnext.hr.doctype.leave_application.test_leave_application import get_first_sunday
+from erpnext.hr.tests.test_utils import get_first_sunday
 
 test_records = frappe.get_test_records("Attendance")
 

--- a/erpnext/hr/doctype/leave_application/test_leave_application.py
+++ b/erpnext/hr/doctype/leave_application/test_leave_application.py
@@ -1105,7 +1105,7 @@ def allocate_leaves(employee, leave_period, leave_type, new_leaves_allocated, el
 	allocate_leave.submit()
 
 
-def get_first_sunday(holiday_list, for_date=None):
+def get_first_sunday(holiday_list="Salary Slip Test Holiday List", for_date=None):
 	date = for_date or getdate()
 	month_start_date = get_first_day(date)
 	month_end_date = get_last_day(date)

--- a/erpnext/hr/doctype/leave_application/test_leave_application.py
+++ b/erpnext/hr/doctype/leave_application/test_leave_application.py
@@ -33,6 +33,7 @@ from erpnext.hr.doctype.leave_policy_assignment.leave_policy_assignment import (
 	create_assignment_for_multiple_employees,
 )
 from erpnext.hr.doctype.leave_type.test_leave_type import create_leave_type
+from erpnext.hr.tests.test_utils import get_first_sunday
 from erpnext.payroll.doctype.salary_slip.test_salary_slip import (
 	make_holiday_list,
 	make_leave_application,
@@ -1103,23 +1104,6 @@ def allocate_leaves(employee, leave_period, leave_type, new_leaves_allocated, el
 	).insert()
 
 	allocate_leave.submit()
-
-
-def get_first_sunday(holiday_list="Salary Slip Test Holiday List", for_date=None):
-	date = for_date or getdate()
-	month_start_date = get_first_day(date)
-	month_end_date = get_last_day(date)
-	first_sunday = frappe.db.sql(
-		"""
-		select holiday_date from `tabHoliday`
-		where parent = %s
-			and holiday_date between %s and %s
-		order by holiday_date
-	""",
-		(holiday_list, month_start_date, month_end_date),
-	)[0][0]
-
-	return first_sunday
 
 
 def make_policy_assignment(employee, leave_type, leave_period):

--- a/erpnext/hr/report/employee_leave_balance/test_employee_leave_balance.py
+++ b/erpnext/hr/report/employee_leave_balance/test_employee_leave_balance.py
@@ -9,13 +9,11 @@ from frappe.utils import add_days, add_months, flt, get_year_ending, get_year_st
 
 from erpnext.hr.doctype.employee.test_employee import make_employee
 from erpnext.hr.doctype.holiday_list.test_holiday_list import set_holiday_list
-from erpnext.hr.doctype.leave_application.test_leave_application import (
-	get_first_sunday,
-	make_allocation_record,
-)
+from erpnext.hr.doctype.leave_application.test_leave_application import make_allocation_record
 from erpnext.hr.doctype.leave_ledger_entry.leave_ledger_entry import process_expired_allocation
 from erpnext.hr.doctype.leave_type.test_leave_type import create_leave_type
 from erpnext.hr.report.employee_leave_balance.employee_leave_balance import execute
+from erpnext.hr.tests.test_utils import get_first_sunday
 from erpnext.payroll.doctype.salary_slip.test_salary_slip import (
 	make_holiday_list,
 	make_leave_application,

--- a/erpnext/hr/report/employee_leave_balance_summary/test_employee_leave_balance_summary.py
+++ b/erpnext/hr/report/employee_leave_balance_summary/test_employee_leave_balance_summary.py
@@ -9,12 +9,10 @@ from frappe.utils import add_days, flt, get_year_ending, get_year_start, getdate
 
 from erpnext.hr.doctype.employee.test_employee import make_employee
 from erpnext.hr.doctype.holiday_list.test_holiday_list import set_holiday_list
-from erpnext.hr.doctype.leave_application.test_leave_application import (
-	get_first_sunday,
-	make_allocation_record,
-)
+from erpnext.hr.doctype.leave_application.test_leave_application import make_allocation_record
 from erpnext.hr.doctype.leave_ledger_entry.leave_ledger_entry import process_expired_allocation
 from erpnext.hr.report.employee_leave_balance_summary.employee_leave_balance_summary import execute
+from erpnext.hr.tests.test_utils import get_first_sunday
 from erpnext.payroll.doctype.salary_slip.test_salary_slip import (
 	make_holiday_list,
 	make_leave_application,

--- a/erpnext/hr/tests/test_utils.py
+++ b/erpnext/hr/tests/test_utils.py
@@ -1,0 +1,19 @@
+import frappe
+from frappe.utils import get_first_day, get_last_day, getdate
+
+
+def get_first_sunday(holiday_list="Salary Slip Test Holiday List", for_date=None):
+	date = for_date or getdate()
+	month_start_date = get_first_day(date)
+	month_end_date = get_last_day(date)
+	first_sunday = frappe.db.sql(
+		"""
+		select holiday_date from `tabHoliday`
+		where parent = %s
+			and holiday_date between %s and %s
+		order by holiday_date
+	""",
+		(holiday_list, month_start_date, month_end_date),
+	)[0][0]
+
+	return first_sunday

--- a/erpnext/payroll/doctype/employee_benefit_application/test_employee_benefit_application.py
+++ b/erpnext/payroll/doctype/employee_benefit_application/test_employee_benefit_application.py
@@ -9,7 +9,7 @@ from frappe.utils import add_days, date_diff, get_year_ending, get_year_start, g
 
 from erpnext.hr.doctype.employee.test_employee import make_employee
 from erpnext.hr.doctype.holiday_list.test_holiday_list import set_holiday_list
-from erpnext.hr.doctype.leave_application.test_leave_application import get_first_sunday
+from erpnext.hr.tests.test_utils import get_first_sunday
 from erpnext.hr.utils import get_holiday_dates_for_employee
 from erpnext.payroll.doctype.employee_benefit_application.employee_benefit_application import (
 	calculate_lwp,


### PR DESCRIPTION
## Before:

Statistical components are not updated as per payment days since they are not added to the slip and are just used as ref values.

Here: CTC is a statistical component based on PD and Basic is dependent on CTC.

<img width="1336" alt="image" src="https://user-images.githubusercontent.com/24353136/189746534-c00e9166-b15a-4e4e-99e9-0b9ee6b89129.png">

Basic is not getting the updated value of CTC (8866.67) So it's still getting calculated as 14000 * 0.6 = 8400:

<img width="1336" alt="image" src="https://user-images.githubusercontent.com/24353136/189746409-45e24604-feab-4192-ad28-333aa90cc44c.png">

## After:

Calculate the amount based on PD for statistical components too so that they can be used in formulae for other components.

Basic getting the updated value so the amount is now correct: 8866.67 * 0.6 = 5320

<img width="1336" alt="image" src="https://user-images.githubusercontent.com/24353136/189746185-af252e21-0845-4cdc-9a23-5ab362caa7b0.png">

## Misc

Payroll and HR tests are very messy to read and it's becoming difficult to maintain and add new tests. Created a separate test utility file for commonly used imports to avoid messy imports inside functions (circular dependencies). Moved `get_first_sunday` function for now. Will open a separate PR for tests refactor.