### PR TITLE
fix: incorrect gl if tax on multi currency payment entry

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -1091,7 +1091,7 @@ frappe.ui.form.on('Payment Entry', {
 
 			$.each(tax_fields, function(i, fieldname) { tax[fieldname] = 0.0; });
 
-			frm.doc.paid_amount_after_tax = frm.doc.paid_amount;
+			frm.doc.paid_amount_after_tax = frm.doc.base_paid_amount;
 		});
 	},
 
@@ -1182,7 +1182,7 @@ frappe.ui.form.on('Payment Entry', {
 			}
 
 			cumulated_tax_fraction += tax.tax_fraction_for_current_item;
-			frm.doc.paid_amount_after_tax = flt(frm.doc.paid_amount/(1+cumulated_tax_fraction))
+			frm.doc.paid_amount_after_tax = flt(frm.doc.base_paid_amount/(1+cumulated_tax_fraction))
 		});
 	},
 
@@ -1214,6 +1214,7 @@ frappe.ui.form.on('Payment Entry', {
 		frm.doc.total_taxes_and_charges = 0.0;
 		frm.doc.base_total_taxes_and_charges = 0.0;
 
+		let company_currency = frappe.get_doc(":Company", frm.doc.company).default_currency;
 		let actual_tax_dict = {};
 
 		// maintain actual tax rate based on idx
@@ -1234,8 +1235,8 @@ frappe.ui.form.on('Payment Entry', {
 				}
 			}
 
-			tax.tax_amount = current_tax_amount;
-			tax.base_tax_amount = tax.tax_amount * frm.doc.source_exchange_rate;
+			// tax accounts are only in company currency
+			tax.base_tax_amount = current_tax_amount;
 			current_tax_amount *= (tax.add_deduct_tax == "Deduct") ? -1.0 : 1.0;
 
 			if(i==0) {
@@ -1244,9 +1245,29 @@ frappe.ui.form.on('Payment Entry', {
 				tax.total = flt(frm.doc["taxes"][i-1].total + current_tax_amount, precision("total", tax));
 			}
 
-			tax.base_total = tax.total * frm.doc.source_exchange_rate;
-			frm.doc.total_taxes_and_charges += current_tax_amount;
-			frm.doc.base_total_taxes_and_charges += current_tax_amount * frm.doc.source_exchange_rate;
+			// tac accounts are only in company currency
+			tax.base_total = tax.total
+
+			// calculate total taxes and base total taxes
+			if(frm.doc.payment_type == "Pay") {
+				// tax accounts only have company currency
+				if(tax.currency != frm.doc.paid_to_account_currency) {
+					//total_taxes_and_charges has the target currency. so using target conversion rate
+					frm.doc.total_taxes_and_charges += flt(current_tax_amount / frm.doc.target_exchange_rate);
+
+				} else {
+					frm.doc.total_taxes_and_charges += current_tax_amount;
+				}
+			} else if(frm.doc.payment_type == "Receive") {
+				if(tax.currency != frm.doc.paid_from_account_currency) {
+					//total_taxes_and_charges has the target currency. so using source conversion rate
+					frm.doc.total_taxes_and_charges += flt(current_tax_amount / frm.doc.source_exchange_rate);
+				} else {
+					frm.doc.total_taxes_and_charges += current_tax_amount;
+				}
+			}
+
+			frm.doc.base_total_taxes_and_charges += tax.base_tax_amount;
 
 			frm.refresh_field('taxes');
 			frm.refresh_field('total_taxes_and_charges');


### PR DESCRIPTION
## Issue
On a multi currency Payment Entry with Advance tax, GL entries for the tax account have incorrect amount in account currency.

Ex: Payment of 12.5 USD to Creditors with a conversion rate of 80.
<img width="1062" alt="Screenshot 2022-09-17 at 4 11 02 PM" src="https://user-images.githubusercontent.com/3272205/190852802-d3ec37d9-6c8a-4d86-b667-034f18ea9e19.png">
## Without Fix:
1. Incorrect total tax amount on tax table. <img width="1036" alt="Screenshot 2022-09-17 at 4 11 09 PM" src="https://user-images.githubusercontent.com/3272205/190853000-0d244072-c524-4978-af61-fd3db9711238.png"> 
2. Incorrect GL entries for tax account and paid_from account. <img width="1159" alt="Screenshot 2022-09-17 at 4 11 34 PM" src="https://user-images.githubusercontent.com/3272205/190853003-66bce879-61d3-4f5f-93cd-3efd6cfc54a7.png">

## With Fix:
1. Tax table: <img width="1016" alt="Screenshot 2022-09-17 at 4 15 55 PM" src="https://user-images.githubusercontent.com/3272205/190853002-4221b632-e253-4bb7-8b65-83c519a31336.png">
2. GL Entries: <img width="1159" alt="Screenshot 2022-09-17 at 4 14 48 PM" src="https://user-images.githubusercontent.com/3272205/190852994-067c7b17-228d-4403-8f4d-63652ba0e471.png">


