### PR TITLE
fix: disable cwip in asset repair tests

### DIFF
--- a/erpnext/assets/doctype/asset_repair/test_asset_repair.py
+++ b/erpnext/assets/doctype/asset_repair/test_asset_repair.py
@@ -130,6 +130,7 @@ class TestAssetRepair(unittest.TestCase):
 		set_depreciation_settings_in_company(company="_Test Company with perpetual inventory")
 
 		asset_category = frappe.get_doc("Asset Category", "Computers")
+		asset_category.enable_cwip_accounting = 0
 		asset_category.append(
 			"accounts",
 			{


### PR DESCRIPTION
disable cwip accounting in asset repair tests