### PR TITLE
fix: fetch description only if empty on the payment schedule

### DIFF
--- a/erpnext/accounts/doctype/payment_schedule/payment_schedule.json
+++ b/erpnext/accounts/doctype/payment_schedule/payment_schedule.json
@@ -39,6 +39,7 @@
   {
    "columns": 2,
    "fetch_from": "payment_term.description",
+   "fetch_if_empty": 1,
    "fieldname": "description",
    "fieldtype": "Small Text",
    "in_list_view": 1,
@@ -159,7 +160,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2021-04-28 05:41:35.084233",
+ "modified": "2022-09-16 13:57:06.382859",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Schedule",
@@ -168,5 +169,6 @@
  "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }


### PR DESCRIPTION
added fetch_if_empty on the description field of payment_schedule.

### BEFORE :
https://user-images.githubusercontent.com/39730881/190598913-7c81d6c9-94de-420a-a678-c45a1261972b.mov

### AFTER :


https://user-images.githubusercontent.com/39730881/190599062-7564f06d-f8c2-4b05-859a-4740c9f47cb7.mov

