### PR TITLE
feat(stock): Audible indication of barcode scan status.

### DIFF
--- a/erpnext/public/js/utils/barcode_scanner.js
+++ b/erpnext/public/js/utils/barcode_scanner.js
@@ -59,14 +59,14 @@ erpnext.utils.BarcodeScanner = class BarcodeScanner {
 					}
 
 					me.update_table(data).then(row => {
-						row ? resolve(row) : reject();
-					});
+						resolve(row);
+					}).catch(() => reject());
 				});
 		});
 	}
 
 	update_table(data) {
-		return new Promise(resolve => {
+		return new Promise((resolve, reject) => {
 			let cur_grid = this.frm.fields_dict[this.items_table_name].grid;
 
 			const {item_code, barcode, batch_no, serial_no, uom} = data;
@@ -77,6 +77,7 @@ erpnext.utils.BarcodeScanner = class BarcodeScanner {
 				if (this.dont_allow_new_row) {
 					this.show_alert(__("Maximum quantity scanned for item {0}.", [item_code]), "red");
 					this.clean_up();
+					reject();
 					return;
 				}
 
@@ -88,6 +89,7 @@ erpnext.utils.BarcodeScanner = class BarcodeScanner {
 
 			if (this.is_duplicate_serial_no(row, serial_no)) {
 				this.clean_up();
+				reject();
 				return;
 			}
 


### PR DESCRIPTION
In some cases, just displaying a short alert regarding the scan status isn't enough. If the user doesn't look back at their screen fast enough after scanning they should visually scan the whole `items`? table just to confirm if the scan was successful or not.

Proposed solution is to add an audible noise to indicate the scan status.

- Adds `play_success_sound` to barcode scan API.
- ADds `play_fail_sound` to barcode scan API.

`no-docs`