### PR TITLE
fix: use default supplier currency if default supplier is enabled

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -880,6 +880,9 @@ def get_events(start, end, filters=None):
 @frappe.whitelist()
 def make_purchase_order_for_default_supplier(source_name, selected_items=None, target_doc=None):
 	"""Creates Purchase Order for each Supplier. Returns a list of doc objects."""
+
+	from erpnext.setup.utils import get_exchange_rate
+
 	if not selected_items:
 		return
 
@@ -888,6 +891,15 @@ def make_purchase_order_for_default_supplier(source_name, selected_items=None, t
 
 	def set_missing_values(source, target):
 		target.supplier = supplier
+		target.currency = frappe.db.get_value(
+			"Supplier", filters={"name": supplier}, fieldname=["default_currency"]
+		)
+		company_currency = frappe.db.get_value(
+			"Company", filters={"name": target.company}, fieldname=["default_currency"]
+		)
+
+		target.conversion_rate = get_exchange_rate(target.currency, company_currency, args="for_buying")
+
 		target.apply_discount_on = ""
 		target.additional_discount_percentage = 0.0
 		target.discount_amount = 0.0


### PR DESCRIPTION
While creating Purchase Order from Sales Order, if default Supplier is provided, use Supplier currency as the transaction currency for the Sales Order.

1. Sales Order item with Supplier. 
<img width="1072" alt="Screenshot 2022-09-17 at 4 36 53 PM" src="https://user-images.githubusercontent.com/3272205/190853812-e0c4ce40-92b2-4a5c-bd40-98fa53c135c7.png">
<img width="578" alt="Screenshot 2022-09-17 at 4 37 10 PM" src="https://user-images.githubusercontent.com/3272205/190853818-06ab56b4-e4c3-4056-abf6-95268f8872ae.png">
2. Supplier billing currency. 
<img width="713" alt="Screenshot 2022-09-17 at 4 40 51 PM" src="https://user-images.githubusercontent.com/3272205/190853825-8abcee76-15e8-49c8-a82a-abfa3a225f62.png">
3. Create Purchase Order. 
<img width="804" alt="Screenshot 2022-09-17 at 4 42 19 PM" src="https://user-images.githubusercontent.com/3272205/190853834-8ead5d04-916d-488a-8b38-72518fd7fa6c.png">

## Old behaviour:
Purchase Order created in Sales Order currency. 
<img width="1172" alt="Screenshot 2022-09-17 at 4 42 51 PM" src="https://user-images.githubusercontent.com/3272205/190853872-8c36b23c-198b-4c1f-9b0b-84549e06eb15.png">

## New behaviour:
Purchase Order created in Supplier currency. <img width="1172" alt="Screenshot 2022-09-17 at 4 43 19 PM" src="https://user-images.githubusercontent.com/3272205/190853878-fa8c832e-304c-45e7-a9bb-9ed2a32a813e.png">
