### PR TITLE
fix: Change Department fieldtype to Link in Leave Balance Report

### DIFF
--- a/erpnext/hr/report/employee_leave_balance_summary/employee_leave_balance_summary.py
+++ b/erpnext/hr/report/employee_leave_balance_summary/employee_leave_balance_summary.py
@@ -22,9 +22,9 @@ def execute(filters=None):
 
 def get_columns(leave_types):
 	columns = [
-		_("Employee") + ":Link.Employee:150",
+		_("Employee") + ":Link/Employee:150",
 		_("Employee Name") + "::200",
-		_("Department") + "::150",
+		_("Department") + ":Link/Department:150",
 	]
 
 	for leave_type in leave_types:


### PR DESCRIPTION
**Version:** 

ERPNext: v13.39.0 (version-13)
Frappe Framework: v13.41.1 (version-13)
___
Issue: #32249
___

**Before:**
- When add column from the report then does not show link fields like employee and department.

https://user-images.githubusercontent.com/34390782/190858295-33044a5a-c6a4-40c5-bd39-87d7372ba0d6.mp4

**After:**
- After set the link field option, when add columns from the report then link fields will appear.

https://user-images.githubusercontent.com/34390782/190858479-00984ba0-672d-48f6-91ef-da627afb0198.mp4

___
Version 14 PR: https://github.com/frappe/hrms/pull/59

Thank You!