### PR TITLE
fix: create contact after lead doctype insert

### DIFF
--- a/erpnext/crm/doctype/lead/lead.py
+++ b/erpnext/crm/doctype/lead/lead.py
@@ -31,12 +31,10 @@ class Lead(SellingController, CRMNote):
 		self.check_email_id_is_unique()
 		self.validate_email_id()
 
-	def before_insert(self):
+	def after_insert(self):
 		self.contact_doc = None
 		if frappe.db.get_single_value("CRM Settings", "auto_creation_of_contact"):
 			self.contact_doc = self.create_contact()
-
-	def after_insert(self):
 		self.link_to_contact()
 
 	def on_update(self):


### PR DESCRIPTION
when validate lead multiple contact has been created when its is placed on before_insert so i changed its to after insert.