### PR TITLE
chore: patch for removing stale values in Naming Series

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -373,3 +373,4 @@ erpnext.patches.v13_0.fix_number_and_frequency_for_monthly_depreciation
 erpnext.patches.v13_0.reset_corrupt_defaults
 erpnext.patches.v13_0.show_hr_payroll_deprecation_warning
 erpnext.patches.v13_0.create_accounting_dimensions_for_asset_repair
+execute:frappe.db.set_value("Naming Series", "Naming Series", {"select_doc_for_series": "", "set_options": "", "prefix": "", "current_value": 0, "user_must_always_select": 0})


### PR DESCRIPTION
This PR is for removing stale values from `Naming Series` doctype due to the removal of "Save" button which previously used to update the values in `tabSingles`.