### PR TITLE
fix: total value in all keys

### DIFF
--- a/erpnext/accounts/report/gross_and_net_profit_report/gross_and_net_profit_report.py
+++ b/erpnext/accounts/report/gross_and_net_profit_report/gross_and_net_profit_report.py
@@ -155,7 +155,6 @@ def adjust_account(data, period_list, consolidated=False):
 	for d in data:
 		for period in period_list:
 			key = period if consolidated else period.key
-			d[key] = totals[d["account"]]
 			d["total"] = totals[d["account"]]
 	return data
 


### PR DESCRIPTION
Gross and net profit report showing wrong values in monthly quarterly and half yearly filters which is the total value @ruthra-kumar added in develop branch as suggested ( https://github.com/frappe/erpnext/pull/32020)
