### PR TITLE
fix: consider cost center for journal entry in payment reconciliation tool 

### DIFF
--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
@@ -332,7 +332,7 @@ class PaymentReconciliation(Document):
 	def get_conditions(self, get_invoices=False, get_payments=False, get_return_invoices=False):
 		condition = " and company = '{0}' ".format(self.company)
 
-		if self.get("cost_center") and (get_invoices or get_payments or get_return_invoices):
+		if self.get("cost_center"):
 			condition = " and cost_center = '{0}' ".format(self.cost_center)
 
 		if get_invoices:


### PR DESCRIPTION
We need to consider the cost center in all four cases of get_conditions. I have removed check in if statement for get_invoices, get_payments, and get_return_invoices as it is not required.

### Before:
https://user-images.githubusercontent.com/39730881/192158299-35ee80ce-b08e-4467-8b8d-eff66d3722d2.mov

### After:
https://user-images.githubusercontent.com/39730881/192158365-badc219c-85a7-4ad6-a4d3-aa16ec579a29.mov

