### PR TITLE
fix(e-invoicing): local variable 'res' referenced before assignment

### DIFF
--- a/erpnext/regional/india/e_invoice/utils.py
+++ b/erpnext/regional/india/e_invoice/utils.py
@@ -894,6 +894,7 @@ class GSPConnector:
 		return self.e_invoice_settings.auth_token
 
 	def make_request(self, request_type, url, headers=None, data=None):
+		res = None
 		try:
 			if request_type == "post":
 				res = make_post_request(url, headers=headers, data=data)


### PR DESCRIPTION
E-Invoicing authenticates with the GSP via an `auth_token` which is generated using `client_id` & `client_secret` and the token expires every 30 days

If the `auth_token` expires, a 401 or 403 error is raised and that's when it is "auto-refreshed"

In some cases, for eg., when you enable `sandbox_mode` and don't change the `client_id` & `client_secret` to the sandbox one, then the `auth_token` is invalid and again 403 error is raised which triggers auto-refresh.

But, even after auto-refreshing, the token is invalid and 403 is raised, and the request fails, which causes this error

