### PR TITLE
fix: SEZ Without Payment of Tax don't add tax rows

### DIFF
--- a/erpnext/regional/india/utils.py
+++ b/erpnext/regional/india/utils.py
@@ -257,9 +257,16 @@ def get_regional_address_details(party_details, doctype, company):
 
 	update_party_details(party_details, doctype)
 
+	customer_gst_category = frappe.get_value(
+		"Customer", party_details.customer, ["gst_category", "export_type"]
+	)
+
 	party_details.place_of_supply = get_place_of_supply(party_details, doctype)
 
-	if is_internal_transfer(party_details, doctype):
+	if is_internal_transfer(party_details, doctype) or customer_gst_category == (
+		"SEZ",
+		"Without Payment of Tax",
+	):
 		party_details.taxes_and_charges = ""
 		party_details.taxes = []
 		return party_details


### PR DESCRIPTION
taxes were added even when gst_category = "SEZ" and export_type = "Without Payment of Tax".


### Before:
https://user-images.githubusercontent.com/39730881/192470867-0817810f-a178-4b3d-871e-5f3c8ee9a0fb.mov

### After:
https://user-images.githubusercontent.com/39730881/192470940-6754ec53-b49f-46e3-8ef7-2bab17fe6673.mov


