### PR TITLE
fix: typo in sales_register's filter mode_of_payment

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -239,14 +239,14 @@ class POSInvoice(SalesInvoice):
 					frappe.bold(d.warehouse),
 					frappe.bold(d.qty),
 				)
-				if is_stock_item and flt(available_stock) <= 0:
+				if flt(available_stock) <= 0:
 					frappe.throw(
 						_("Row #{}: Item Code: {} is not available under warehouse {}.").format(
 							d.idx, item_code, warehouse
 						),
 						title=_("Item Unavailable"),
 					)
-				elif is_stock_item and flt(available_stock) < flt(d.qty):
+				elif flt(available_stock) < flt(d.qty):
 					frappe.throw(
 						_(
 							"Row #{}: Stock quantity not enough for Item Code: {} under warehouse {}. Available quantity {}."

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -239,14 +239,14 @@ class POSInvoice(SalesInvoice):
 					frappe.bold(d.warehouse),
 					frappe.bold(d.qty),
 				)
-				if flt(available_stock) <= 0:
+				if is_stock_item and flt(available_stock) <= 0:
 					frappe.throw(
 						_("Row #{}: Item Code: {} is not available under warehouse {}.").format(
 							d.idx, item_code, warehouse
 						),
 						title=_("Item Unavailable"),
 					)
-				elif flt(available_stock) < flt(d.qty):
+				elif is_stock_item and flt(available_stock) < flt(d.qty):
 					frappe.throw(
 						_(
 							"Row #{}: Stock quantity not enough for Item Code: {} under warehouse {}. Available quantity {}."

--- a/erpnext/accounts/report/sales_register/sales_register.py
+++ b/erpnext/accounts/report/sales_register/sales_register.py
@@ -370,7 +370,7 @@ def get_conditions(filters):
 				where parent=`tabSales Invoice`.name
 					and ifnull(`tab{table}`.{field}, '') = %({field})s)"""
 
-	conditions += get_sales_invoice_item_field_condition("mode_of_payments", "Sales Invoice Payment")
+	conditions += get_sales_invoice_item_field_condition("mode_of_payment", "Sales Invoice Payment")
 	conditions += get_sales_invoice_item_field_condition("cost_center")
 	conditions += get_sales_invoice_item_field_condition("warehouse")
 	conditions += get_sales_invoice_item_field_condition("brand")


### PR DESCRIPTION
There was typo in sales_register's mode_of_payment filter.

### Before
![Before Mode of Payment Filter](https://user-images.githubusercontent.com/39730881/192479691-386f01b5-ea2b-4ee9-95e8-c7b0a06a0d14.png)

### After
![After Mode of Payment Filter](https://user-images.githubusercontent.com/39730881/192479734-1b42a680-07ba-4ceb-aea7-fc42d15259e9.png)

