### PR TITLE
fix: Add return against indexes for POS Invoice

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.json
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.json
@@ -1553,7 +1553,7 @@
  "icon": "fa fa-file-text",
  "is_submittable": 1,
  "links": [],
- "modified": "2022-03-22 13:00:24.166684",
+ "modified": "2022-09-27 13:00:24.166684",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Invoice",

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -743,4 +743,4 @@ def add_return_modes(doc, pos_profile):
 
 
 def on_doctype_update():
-	frappe.db.add_index("POS Invoice", ["customer", "is_return", "return_against"])
+	frappe.db.add_index("POS Invoice", ["return_against"])

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -740,3 +740,7 @@ def add_return_modes(doc, pos_profile):
 		]:
 			payment_mode = get_mode_of_payment_info(mode_of_payment, doc.company)
 			append_payment(payment_mode[0])
+
+
+def on_doctype_update():
+	frappe.db.add_index("POS Invoice", ["customer", "is_return", "return_against"])


### PR DESCRIPTION
`set_status` is called twice while creating a POS Invoice, once on `validate` and once on `submit`. The `set_status` method in `pos_invoice.py` (similar to sales invoice) has an if block which check for return invoices to set the status as "Credit Note Issued"

The very same query in POS Invoice took around ~5 sec (depending on the no of existing POS Invoices) for a specific site. Post adding the index the POS invoice submission took 3 seconds instead of 13 seconds

![telegram-cloud-photo-size-5-6165440435925923276-y](https://user-images.githubusercontent.com/42651287/192499778-e516954c-e56b-4566-80aa-56c6bc598267.jpg)

Also showed up in slow query logs
![telegram-cloud-photo-size-5-6165440435925923281-y](https://user-images.githubusercontent.com/42651287/192499901-44c72bf5-d9f8-48f6-9717-77b9b2733a08.jpg)
 