### PR TITLE
fix: fetch swift number in payment request from bank doctype

### DIFF
--- a/erpnext/accounts/doctype/payment_request/payment_request.js
+++ b/erpnext/accounts/doctype/payment_request/payment_request.js
@@ -9,6 +9,13 @@ frappe.ui.form.on("Payment Request", {
 				query: "erpnext.setup.doctype.party_type.party_type.get_party_type",
 			};
 		});
+	},
+	"bank_account": function(frm) {
+		frappe.db.get_value('Bank', frm.doc.bank, ['swift_number'])
+	.then(r => {
+		let values = r.message;
+		frm.set_value('swift_number', values.swift_number)
+	})
 	}
 })
 

--- a/erpnext/accounts/doctype/payment_request/payment_request.js
+++ b/erpnext/accounts/doctype/payment_request/payment_request.js
@@ -9,13 +9,6 @@ frappe.ui.form.on("Payment Request", {
 				query: "erpnext.setup.doctype.party_type.party_type.get_party_type",
 			};
 		});
-	},
-	"bank_account": function(frm) {
-		frappe.db.get_value('Bank', frm.doc.bank, ['swift_number'])
-	.then(r => {
-		let values = r.message;
-		frm.set_value('swift_number', values.swift_number)
-	})
 	}
 })
 

--- a/erpnext/accounts/doctype/payment_request/payment_request.json
+++ b/erpnext/accounts/doctype/payment_request/payment_request.json
@@ -186,8 +186,10 @@
   {
    "fetch_from": "bank_account.bank",
    "fieldname": "bank",
-   "fieldtype": "Read Only",
-   "label": "Bank"
+   "fieldtype": "Link",
+   "label": "Bank",
+   "options": "Bank",
+   "read_only": 1
   },
   {
    "fetch_from": "bank_account.bank_account_no",
@@ -366,10 +368,11 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2020-09-18 12:24:14.178853",
+ "modified": "2022-09-30 16:19:43.680025",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Request",
+ "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
  "permissions": [
   {
@@ -401,5 +404,6 @@
   }
  ],
  "sort_field": "modified",
- "sort_order": "DESC"
+ "sort_order": "DESC",
+ "states": []
 }

--- a/erpnext/accounts/doctype/payment_request/payment_request.json
+++ b/erpnext/accounts/doctype/payment_request/payment_request.json
@@ -219,7 +219,6 @@
    "label": "Branch Code"
   },
   {
-   "fetch_from": "bank.swift_number",
    "fieldname": "swift_number",
    "fieldtype": "Read Only",
    "label": "SWIFT Number"
@@ -366,7 +365,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2020-09-18 12:24:14.178853",
+ "modified": "2022-09-28 12:39:30.160837",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Request",

--- a/erpnext/accounts/doctype/payment_request/payment_request.json
+++ b/erpnext/accounts/doctype/payment_request/payment_request.json
@@ -219,6 +219,7 @@
    "label": "Branch Code"
   },
   {
+   "fetch_from": "bank.swift_number",
    "fieldname": "swift_number",
    "fieldtype": "Read Only",
    "label": "SWIFT Number"
@@ -365,7 +366,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2022-09-28 12:39:30.160837",
+ "modified": "2020-09-18 12:24:14.178853",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Request",


### PR DESCRIPTION
There isn't direct link between payment_request and bank as it was Read Only field so swift_number wasn't fetched using Fetch form. I fixed it by making bank Link field.

### Bank with SWIFT Number
![Bank with SWIFT Number](https://user-images.githubusercontent.com/39730881/192717110-6d755ffb-7d75-468a-8669-7d22695f7596.png)


### Before Payment Request:
https://user-images.githubusercontent.com/39730881/192717277-71d092be-ad8d-4fe2-8c36-872e97fa567b.mov

### After Payment Request:
https://user-images.githubusercontent.com/39730881/192717339-96b6d322-2548-4992-a3f4-5363882973d9.mov


