### PR TITLE
fix: Disbursement Account in patch to update old loans

### DIFF
--- a/erpnext/patches/v13_0/update_old_loans.py
+++ b/erpnext/patches/v13_0/update_old_loans.py
@@ -100,6 +100,7 @@ def execute():
 					"mode_of_payment": loan.mode_of_payment,
 					"loan_account": loan.loan_account,
 					"payment_account": loan.payment_account,
+					"disbursement_account": loan.payment_account,
 					"interest_income_account": loan.interest_income_account,
 					"penalty_income_account": loan.penalty_income_account,
 				},
@@ -190,6 +191,7 @@ def create_loan_type(loan, loan_type_name, penalty_account):
 	loan_type_doc.company = loan.company
 	loan_type_doc.mode_of_payment = loan.mode_of_payment
 	loan_type_doc.payment_account = loan.payment_account
+	loan_type_doc.disbursement_account = loan.payment_account
 	loan_type_doc.loan_account = loan.loan_account
 	loan_type_doc.interest_income_account = loan.interest_income_account
 	loan_type_doc.penalty_income_account = penalty_account


### PR DESCRIPTION
```bash
File "/home/frappe/frappe-bench/apps/erpnext/erpnext/patches/v13_0/update_old_loans.py", line 130, in execute
    loan_type_doc.submit()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1018, in submit
    return self._submit()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1007, in _submit
    return self.save()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 310, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 350, in _save
    self._validate()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 538, in _validate
    self._validate_mandatory()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 891, in _validate_mandatory
    fields=", ".join((each[0] for each in missing)), doctype=self.doctype, name=self.name
frappe.exceptions.MandatoryError: [Loan Type, vale]: disbursement_account
```