### PR TITLE
fix(ux): show `Make Purchase Invoice` button based on permission

### DIFF
--- a/erpnext/templates/pages/order.html
+++ b/erpnext/templates/pages/order.html
@@ -18,7 +18,7 @@
 			<b class="caret"></b>
 		</button>
 		<ul class="dropdown-menu dropdown-menu-right" role="menu">
-			{% if doc.doctype == 'Purchase Order' %}
+			{% if doc.doctype == 'Purchase Order' and show_make_pi_button %}
 				<a class="dropdown-item" href="/api/method/erpnext.buying.doctype.purchase_order.purchase_order.make_purchase_invoice_from_portal?purchase_order_name={{ doc.name }}" data-action="make_purchase_invoice">{{ _("Make Purchase Invoice") }}</a>
 			{% endif %}
 			<a class="dropdown-item" href='/printview?doctype={{ doc.doctype}}&name={{ doc.name }}&format={{ print_format }}'

--- a/erpnext/templates/pages/order.py
+++ b/erpnext/templates/pages/order.py
@@ -52,6 +52,9 @@ def get_context(context):
 		)
 		context.available_loyalty_points = int(loyalty_program_details.get("loyalty_points"))
 
+	# show Make Purchase Invoice button based on permission
+	context.show_make_pi_button = frappe.has_permission("Purchase Invoice", "create")
+
 
 def get_attachments(dt, dn):
 	return frappe.get_all(


### PR DESCRIPTION
ref: ISS-22-23-02516

<img width="1250" alt="192753472-91b45af7-7ed8-41d2-ae34-8e84ffd00446" src="https://user-images.githubusercontent.com/63660334/192761283-57426d0e-5b17-4309-911f-63744ce1d5f7.png">

Problem: The "Make Purchase Invoice" button is visible even if the logged-in user doesn't have the create permission.