### PR TITLE
fix: supplied items added twice in Stock Entry

### DIFF
--- a/erpnext/controllers/subcontracting_controller.py
+++ b/erpnext/controllers/subcontracting_controller.py
@@ -841,7 +841,7 @@ def make_rm_stock_entry(
 			for fg_item_code in fg_item_code_list:
 				for rm_item in rm_items:
 
-					if rm_item.get("main_item_code") or rm_item.get("item_code") == fg_item_code:
+					if rm_item.get("main_item_code") == fg_item_code or rm_item.get("item_code") == fg_item_code:
 						rm_item_code = rm_item.get("rm_item_code")
 
 						items_dict = {


### PR DESCRIPTION
ref: ISS-22-23-02579

![1](https://user-images.githubusercontent.com/63660334/192766243-aa76f30f-a5f4-45e5-a4ca-00387110c315.png)

![2](https://user-images.githubusercontent.com/63660334/192766301-edeeed81-db9a-41ac-bc3e-4dc78a54668a.png)

Problem: Supplied Items added twice while creating Stock Entry of type Send to Subcontractor with Purchase Order reference i.e., Old Subcontracting Flow

https://github.com/frappe/erpnext/pull/32274