### PR TITLE
fix: Incorrect TCS amount deducted in Sales Invoice

### DIFF
--- a/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
+++ b/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
@@ -496,13 +496,10 @@ def get_tcs_amount(parties, inv, tax_details, vouchers, adv_vouchers):
 	cumulative_threshold = tax_details.get("cumulative_threshold", 0)
 
 	current_invoice_total = get_invoice_total_without_tcs(inv, tax_details)
-	print(invoiced_amt, advance_amt, credit_note_amt, current_invoice_total)
 	total_invoiced_amt = current_invoice_total + invoiced_amt + advance_amt - credit_note_amt
 
-	print(total_invoiced_amt, "######", "total_invoiced_amt")
 	if cumulative_threshold and total_invoiced_amt >= cumulative_threshold:
 		chargeable_amt = total_invoiced_amt - cumulative_threshold
-		print(chargeable_amt, "#########")
 		tcs_amount = chargeable_amt * tax_details.rate / 100 if chargeable_amt > 0 else 0
 
 	return tcs_amount

--- a/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
+++ b/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
@@ -335,6 +335,9 @@ def get_advance_vouchers(
 		"party": ["in", parties],
 	}
 
+	if party_type == "Customer":
+		filters.update({"against_voucher": ["is", "not set"]})
+
 	if company:
 		filters["company"] = company
 	if from_date and to_date:
@@ -493,10 +496,13 @@ def get_tcs_amount(parties, inv, tax_details, vouchers, adv_vouchers):
 	cumulative_threshold = tax_details.get("cumulative_threshold", 0)
 
 	current_invoice_total = get_invoice_total_without_tcs(inv, tax_details)
+	print(invoiced_amt, advance_amt, credit_note_amt, current_invoice_total)
 	total_invoiced_amt = current_invoice_total + invoiced_amt + advance_amt - credit_note_amt
 
+	print(total_invoiced_amt, "######", "total_invoiced_amt")
 	if cumulative_threshold and total_invoiced_amt >= cumulative_threshold:
 		chargeable_amt = total_invoiced_amt - cumulative_threshold
+		print(chargeable_amt, "#########")
 		tcs_amount = chargeable_amt * tax_details.rate / 100 if chargeable_amt > 0 else 0
 
 	return tcs_amount


### PR DESCRIPTION
Advances were getting considered incorrectly while calculating TCS.

Payments against invoices that are already considered in the amount for check threshold was also getting considered which let to incorrect calculation of TCS amount