### PR TITLE
fix: status of assets with maintenance_required changing back to 'Partially Depreciated' some time after being sold [v13]

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -649,19 +649,7 @@ class Asset(AccountsController):
 		elif self.docstatus == 1:
 			status = "Submitted"
 
-			item = frappe.qb.DocType("Sales Invoice Item").as_("item")
-			si = frappe.qb.DocType("Sales Invoice").as_("si")
-
-			is_asset_sold = (
-				frappe.qb.from_(item)
-				.select(item.parent)
-				.inner_join(si)
-				.on(item.parent == si.name)
-				.where(item.asset == self.name)
-				.where(si.docstatus == 1)
-			).run()
-
-			if is_asset_sold:
+			if self.is_sold():
 				status = "Sold"
 			elif self.journal_entry_for_scrap:
 				status = "Scrapped"
@@ -678,6 +666,21 @@ class Asset(AccountsController):
 		elif self.docstatus == 2:
 			status = "Cancelled"
 		return status
+
+	def is_sold(self):
+		item = frappe.qb.DocType("Sales Invoice Item").as_("item")
+		si = frappe.qb.DocType("Sales Invoice").as_("si")
+
+		asset_sales_invoice = (
+			frappe.qb.from_(item)
+			.select(item.parent)
+			.inner_join(si)
+			.on(item.parent == si.name)
+			.where(item.asset == self.name)
+			.where(si.docstatus == 1)
+		).run()
+
+		return True if asset_sales_invoice else False
 
 	def get_default_finance_book_idx(self):
 		if not self.get("default_finance_book") and self.company:

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -643,15 +643,13 @@ class Asset(AccountsController):
 		self.db_set("status", status)
 
 	def get_status(self):
-		"""Returns status based on whether it is draft, submitted, sold, scrapped or depreciated"""
+		"""Returns status based on whether it is draft, submitted, scrapped or depreciated"""
 		if self.docstatus == 0:
 			status = "Draft"
 		elif self.docstatus == 1:
 			status = "Submitted"
 
-			if self.is_sold():
-				status = "Sold"
-			elif self.journal_entry_for_scrap:
+			if self.journal_entry_for_scrap:
 				status = "Scrapped"
 			elif self.finance_books:
 				idx = self.get_default_finance_book_idx() or 0
@@ -666,21 +664,6 @@ class Asset(AccountsController):
 		elif self.docstatus == 2:
 			status = "Cancelled"
 		return status
-
-	def is_sold(self):
-		item = frappe.qb.DocType("Sales Invoice Item").as_("item")
-		si = frappe.qb.DocType("Sales Invoice").as_("si")
-
-		asset_sales_invoice = (
-			frappe.qb.from_(item)
-			.select(item.parent)
-			.inner_join(si)
-			.on(item.parent == si.name)
-			.where(item.asset == self.name)
-			.where(si.docstatus == 1)
-		).run()
-
-		return True if asset_sales_invoice else False
 
 	def get_default_finance_book_idx(self):
 		if not self.get("default_finance_book") and self.company:
@@ -836,7 +819,9 @@ class Asset(AccountsController):
 
 
 def update_maintenance_status():
-	assets = frappe.get_all("Asset", filters={"docstatus": 1, "maintenance_required": 1})
+	assets = frappe.get_all(
+		"Asset", filters={"docstatus": 1, "maintenance_required": 1, "disposal_date": ("is", "not set")}
+	)
 
 	for asset in assets:
 		asset = frappe.get_doc("Asset", asset.name)


### PR DESCRIPTION
### Steps to Reproduce:

1. Create asset with the date 01-07-2022 for 12 monthly depreciation with `maintenance_required` set
2. Make depreciation entries for July and August
3. Sell the asset on 27th of September
4. Wait one day for the `update_maintenance_status` job to run (or run it manually)

You will see that the asset's status changes back to `Partially Depreciated` from `Sold`.

--

Now the status' of sold assets with `maintenance_required` remains sold even after daily maintenance.