### PR TITLE
fix: don't allow to update `Maintain Stock` if the item has a `BOM`

### DIFF
--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -937,17 +937,21 @@ class Item(Document):
 				"Purchase Order Item",
 				"Material Request Item",
 				"Product Bundle",
+				"BOM",
 			]
 
 		for doctype in linked_doctypes:
 			filters = {"item_code": self.name, "docstatus": 1}
 
-			if doctype == "Product Bundle":
-				filters = {"new_item_code": self.name}
+			if doctype in ("Product Bundle", "BOM"):
+				if doctype == "Product Bundle":
+					filters = {"new_item_code": self.name}
+					fieldname = "new_item_code as docname"
+				else:
+					filters = {"item": self.name, "docstatus": 1}
+					fieldname = "name as docname"
 
-				if linked_doc := frappe.db.get_value(
-					doctype, filters, ["new_item_code as docname"], as_dict=True
-				):
+				if linked_doc := frappe.db.get_value(doctype, filters, fieldname, as_dict=True):
 					return linked_doc.update({"doctype": doctype})
 
 			elif doctype in (


### PR DESCRIPTION
_**Problem**: The system allows the user to update the `Maintain Stock` field in the Item master even if the item has a BOM._

Steps to reproduce:
1. Create an Item (Maintain Stock checked).
2. Create a BOM for that Item.
3. Try to uncheck/disable Maintain Stock checkbox.

_**Proposed Solution**: Don't allow the user to update the value of Maintain Stock if the item has a BOM. Users need to cancel the BOM before updating Maintain Stock value._

