### PR TITLE
feat:updated changes for account wise redirection

### DIFF
--- a/erpnext/public/js/financial_statements.js
+++ b/erpnext/public/js/financial_statements.js
@@ -77,7 +77,7 @@ erpnext.financial_statements = {
 					"project": (project && project.length > 0) ? project[0].$input.val() : ""
 				};
 			}
-		frappe.set_route("query-report", report);
+	frappe.set_route("query-report", report);
 	},
 	"tree": true,
 	"name_field": "account",

--- a/erpnext/public/js/financial_statements.js
+++ b/erpnext/public/js/financial_statements.js
@@ -30,14 +30,54 @@ erpnext.financial_statements = {
 		if (!data.account) return;
 		var project = $.grep(frappe.query_report.filters, function(e){ return e.df.fieldname == 'project'; })
 
-		frappe.route_options = {
-			"account": data.account,
-			"company": frappe.query_report.get_filter_value('company'),
-			"from_date": data.from_date || data.year_start_date,
-			"to_date": data.to_date || data.year_end_date,
-			"project": (project && project.length > 0) ? project[0].$input.val() : ""
-		};
-		frappe.set_route("query-report", "General Ledger");
+		if (data.account_type == "Payable"){
+			report="Accounts Payable Summary"
+			frappe.route_options = {
+				"party_account": data.account,
+				"company": frappe.query_report.get_filter_value('company'),
+				"report_date": data.year_end_date
+			};
+
+		}
+		else if(data.account_type == "Receivable"){
+			report="Accounts Receivable Summary"
+			frappe.route_options = {
+				"party_account": data.account,
+				"company": frappe.query_report.get_filter_value('company'),
+				"report_date": data.year_end_date
+			};
+
+		}
+		else if(["Fixed Asset","Accumulated Depreciation"].includes(data.account_type)){ 
+			report="Asset Depreciations and Balances"
+			frappe.route_options = {
+				"company": frappe.query_report.get_filter_value('company'),
+				"from_date": data.from_date || data.year_start_date,
+				"to_date": data.to_date || data.year_end_date,
+			};
+
+		}
+		else if(data.account_type == "Stock"){
+			report="Stock Balance"
+			frappe.route_options = {
+				"party_account": data.account,
+				"company": frappe.query_report.get_filter_value('company'),
+				"from_date": data.from_date || data.year_start_date,
+				"to_date": data.to_date || data.year_end_date,
+			};
+
+		}
+		else{
+			report="General Ledger"
+			frappe.route_options = {
+					"account": data.account,
+					"company": frappe.query_report.get_filter_value('company'),
+					"from_date": data.from_date || data.year_start_date,
+					"to_date": data.to_date || data.year_end_date,
+					"project": (project && project.length > 0) ? project[0].$input.val() : ""
+				};
+			}
+		frappe.set_route("query-report", report);
 	},
 	"tree": true,
 	"name_field": "account",


### PR DESCRIPTION
>Problem Statement:

When someone is checking balance-sheet in ERPNext, he will get total Payable in Creditors Account, Total Receivable in Debtors Account.

Now the obvious question will be who are the those creditors or debtors, which is available in our Account Payable and Receivable Summary report. By default in balance sheet report the click on account leads to redirection in general ledger report from all the accounts. Looking general ledger of creditors/debtors without party doesn’t make sense to anyone.
Same issue is with Stock in hand account and Fixed asset accounts.

>Solution:

We have tried to improve this user experience by changing redirect to reports based on Account Type as below:

1. Payable -> Accounts Payable Summary
2. Receivable -> Accounts Receivable Summary
3. Stock -> Stock Balance
4. Fixed Asset, Accumulated Depreciation ->  Asset Depreciations and Balances
5. All Other account type will continue to point to General Ledger Report as current.

> Video

https://user-images.githubusercontent.com/18363620/193403987-e6e1e30d-1479-4322-9d86-2681372eb05f.mp4





