### PR TITLE
fix: e-Way bill JSON for Intra-state internal transfers

### DIFF
--- a/erpnext/regional/india/utils.py
+++ b/erpnext/regional/india/utils.py
@@ -603,6 +603,10 @@ def get_ewb_data(dt, dn):
 
 		data = get_address_details(data, doc, company_address, billing_address, dispatch_address)
 
+		if is_intrastate_transfer_eway_bill(data):
+			data.docType = "CHL"
+			data.subSupplyType = 8
+			
 		data.itemList = []
 		data.totalValue = doc.total
 
@@ -644,6 +648,8 @@ def get_ewb_data(dt, dn):
 
 	return data
 
+def is_intrastate_transfer_eway_bill(data):
+	return data.fromGstin == data.toGstin
 
 @frappe.whitelist()
 def generate_ewb_json(dt, dn):

--- a/erpnext/regional/india/utils.py
+++ b/erpnext/regional/india/utils.py
@@ -606,7 +606,7 @@ def get_ewb_data(dt, dn):
 		if is_intrastate_transfer_eway_bill(data):
 			data.docType = "CHL"
 			data.subSupplyType = 8
-			
+
 		data.itemList = []
 		data.totalValue = doc.total
 
@@ -648,8 +648,10 @@ def get_ewb_data(dt, dn):
 
 	return data
 
+
 def is_intrastate_transfer_eway_bill(data):
 	return data.fromGstin == data.toGstin
+
 
 @frappe.whitelist()
 def generate_ewb_json(dt, dn):


### PR DESCRIPTION
Fix for error while uploading e-Way Bill JSON generated from ERPNext on e-Way bill portal, the error is only seen for Intra-State internal transfers

<img width="700" alt="Screenshot 2022-10-01 at 3 59 15 PM" src="https://user-images.githubusercontent.com/42651287/193405223-97cf0af7-315c-468c-9b44-8d14000dadd9.png">

Update the `docType` and `CHL` and `subSupplyType ` as 8 (Others) for such cases as per the specification mentioned on 
https://docs.ewaybillgst.gov.in/apidocs/sub-docType-mapping.html

<img width="1112" alt="Screenshot 2022-10-01 at 3 54 56 PM" src="https://user-images.githubusercontent.com/42651287/193405298-acdabbb3-be16-4d9f-af56-103c9592bb8b.png">
