### PR TITLE
fix: test_scrap_asset not working on end of month

### DIFF
--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -249,7 +249,9 @@ class TestAsset(AssetSetup):
 			asset.gross_purchase_amount - asset.finance_books[0].value_after_depreciation,
 			asset.precision("gross_purchase_amount"),
 		)
-		self.assertEquals(accumulated_depr_amount, 18000.0)
+		this_month_depr_amount = 9000.0 if get_last_day(date) == date else 0
+
+		self.assertEquals(accumulated_depr_amount, 18000.0 + this_month_depr_amount)
 
 	def test_gle_made_by_asset_sale(self):
 		date = nowdate()


### PR DESCRIPTION
`test_scrap_asset` fails on the end of the month since it didn't take into account scrapping at the end of the month.