### PR TITLE
refactor: remove duplicate entries on remarks migration patch

### DIFF
--- a/erpnext/patches/v14_0/migrate_remarks_from_gl_to_payment_ledger.py
+++ b/erpnext/patches/v14_0/migrate_remarks_from_gl_to_payment_ledger.py
@@ -3,6 +3,29 @@ from frappe import qb
 from frappe.utils import create_batch
 
 
+def remove_duplicate_entries(pl_entries):
+	unique_vouchers = set()
+	for x in pl_entries:
+		unique_vouchers.add(
+			(x.company, x.account, x.party_type, x.party, x.voucher_type, x.voucher_no, x.gle_remarks)
+		)
+
+	entries = []
+	for x in unique_vouchers:
+		entries.append(
+			frappe._dict(
+				company=x[0],
+				account=x[1],
+				party_type=x[2],
+				party=x[3],
+				voucher_type=x[4],
+				voucher_no=x[5],
+				gle_remarks=x[6],
+			)
+		)
+	return entries
+
+
 def execute():
 	if frappe.reload_doc("accounts", "doctype", "payment_ledger_entry"):
 
@@ -33,6 +56,8 @@ def execute():
 			.where((ple.delinked == 0) & (gle.is_cancelled == 0))
 			.run(as_dict=True)
 		)
+
+		pl_entries = remove_duplicate_entries(pl_entries)
 
 		if pl_entries:
 			# split into multiple batches, update and commit for each batch


### PR DESCRIPTION
Performance Issue in `migrate_remarks_from_gl_to_payment_ledger.py` caused by duplicate entries from select query.