### PR TITLE
fix: allow deletion of cancelled Invoices once payments are unlinked

### DIFF
--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -648,6 +648,16 @@ def unlink_ref_doc_from_payment_entries(ref_doc):
 		(now(), frappe.session.user, ref_doc.doctype, ref_doc.name),
 	)
 
+	ple = qb.DocType("Payment Ledger Entry")
+
+	qb.update(ple).set(ple.against_voucher_type, ple.voucher_type).set(
+		ple.against_voucher_no, ple.voucher_no
+	).set(ple.modified, now()).set(ple.modified_by, frappe.session.user).where(
+		(ple.against_voucher_type == ref_doc.doctype)
+		& (ple.against_voucher_no == ref_doc.name)
+		& (ple.delinked == 0)
+	).run()
+
 	if ref_doc.doctype in ("Sales Invoice", "Purchase Invoice"):
 		ref_doc.set("advances", [])
 


### PR DESCRIPTION
With `Unlink Payment on Cancellation of Invoice` enabled in account settings, remove references to Sales/Purchase Invoices from Payments and JE's Payment Ledger entries upon cancellation. Same applies for Sales/Purchase orders through `Unlink Advance Payment on Cancellation of Order`