### PR TITLE
fix: type-cast while saving an item

### DIFF
--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -232,10 +232,10 @@ class Item(Document):
 
 	def clear_retain_sample(self):
 		if not self.has_batch_no:
-			self.retain_sample = None
+			self.retain_sample = False
 
 		if not self.retain_sample:
-			self.sample_quantity = None
+			self.sample_quantity = 0
 
 	def add_default_uom_in_conversion_factor_table(self):
 		if not self.is_new() and self.has_value_changed("stock_uom"):

--- a/erpnext/stock/doctype/item/test_item.py
+++ b/erpnext/stock/doctype/item/test_item.py
@@ -717,8 +717,8 @@ class TestItem(FrappeTestCase):
 
 		item.has_batch_no = None
 		item.save()
-		self.assertEqual(item.retain_sample, None)
-		self.assertEqual(item.sample_quantity, None)
+		self.assertEqual(item.retain_sample, False)
+		self.assertEqual(item.sample_quantity, 0)
 		item.delete()
 
 	def consume_item_code_with_differet_stock_transactions(


### PR DESCRIPTION
**Problem:**

When a non-batch item is saved, the system adds unnecessary logs for version changes.

This happens because the item fields in this PR were being automatically modified and hard-set to `None` during runtime, due to which the version-checker would assume that there's a meaningful change in those fields.

![image](https://user-images.githubusercontent.com/13396535/194835489-52a95c03-2397-4755-920e-e7eb35d6680a.png)
