### PR TITLE
fix: Value error on validation of POS invoices with Serial Nos

### DIFF
--- a/erpnext/stock/doctype/serial_no/serial_no.py
+++ b/erpnext/stock/doctype/serial_no/serial_no.py
@@ -846,16 +846,15 @@ def get_pos_reserved_serial_nos(filters):
 
 	pos_transacted_sr_nos = query.run(as_dict=True)
 
-	reserved_sr_nos = []
-	returned_sr_nos = []
+	reserved_sr_nos = set()
+	returned_sr_nos = set()
 	for d in pos_transacted_sr_nos:
 		if d.is_return == 0:
-			reserved_sr_nos += get_serial_nos(d.serial_no)
+			[reserved_sr_nos.add(x) for x in get_serial_nos(d.serial_no)]
 		elif d.is_return == 1:
-			returned_sr_nos += get_serial_nos(d.serial_no)
+			[returned_sr_nos.add(x) for x in get_serial_nos(d.serial_no)]
 
-	for sr_no in returned_sr_nos:
-		reserved_sr_nos.remove(sr_no)
+	reserved_sr_nos = list(reserved_sr_nos - returned_sr_nos)
 
 	return reserved_sr_nos
 


### PR DESCRIPTION
## Issue
Value error on POS Invoice validation. 
1. Create POS Invoice with 1 item and Serial no
2. Make a return Invoice for [1]
3. Set docstatus = 2 for [1]. (Cancelling [1] cancels [2] automatically, if done through desk. But, if such scenario arises where only [1] is cancelled or deleted, next step throws error)
4. Make a POS Invoice with same serial no as [1] and Save

<img width="996" alt="Screenshot 2022-10-11 at 8 46 36 AM" src="https://user-images.githubusercontent.com/3272205/195023783-9d9197f3-1a99-48d6-b65d-5eaadc4c31a1.png">


## Fix
use Set() instead of List
