### PR TITLE
fix: don't try to update youtube data if disabled in settings

### DIFF
--- a/erpnext/utilities/doctype/video/video.py
+++ b/erpnext/utilities/doctype/video/video.py
@@ -59,7 +59,7 @@ def update_youtube_data():
 		"Video Settings", "Video Settings", ["enable_youtube_tracking", "frequency"]
 	)
 
-	if not enable_youtube_tracking:
+	if not cint(enable_youtube_tracking):
 		return
 
 	frequency = get_frequency(frequency)


### PR DESCRIPTION
### Issue
You may find many failed jobs in your Scheduled Job Log:

![Bildschirmfoto 2022-10-12 um 18 41 43](https://user-images.githubusercontent.com/14891507/195400486-dd95a5ed-007d-4356-ab34-5b9a1246ff2b.png)

### Analysis
`frappe.db.get_value()` returns a string (`"0"` or `"1"`, for a checkbox), so `not enable_youtube_tracking` was always true. The process crashed only when it found the API key to be missing.

### Solution
Fixed by casting to `int`.

