### PR TITLE
Fix error when import invoice

### DIFF
--- a/erpnext/regional/doctype/import_supplier_invoice/import_supplier_invoice.py
+++ b/erpnext/regional/doctype/import_supplier_invoice/import_supplier_invoice.py
@@ -95,12 +95,13 @@ class ImportSupplierInvoice(Document):
 				)
 
 	def prepare_items_for_invoice(self, file_content, invoices_args):
-		qty = 1
 		rate, tax_rate = [0, 0]
 		uom = self.default_uom
 
 		# read file for item information
 		for line in file_content.find_all("DettaglioLinee"):
+			# set qty = 1 before cycle new item line
+			qty = 1
 			if line.find("PrezzoUnitario") and line.find("PrezzoTotale"):
 				rate = flt(line.PrezzoUnitario.text) or 0
 				line_total = flt(line.PrezzoTotale.text) or 0


### PR DESCRIPTION
When quantity it’s 1 the cycle import with quantity of the last item import because qty = 1 it’s out of for cycle. With this mod now work fine.

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
