### PR TITLE
fix: Ignore linked purchase invoice on cancel

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -31,7 +31,7 @@ erpnext.accounts.PurchaseInvoice = class PurchaseInvoice extends erpnext.buying.
 		super.onload();
 
 		// Ignore linked advances
-		this.frm.ignore_doctypes_on_cancel_all = ['Journal Entry', 'Payment Entry'];
+		this.frm.ignore_doctypes_on_cancel_all = ['Journal Entry', 'Payment Entry', 'Purchase Invoice'];
 
 		if(!this.frm.doc.__islocal) {
 			// show credit_to in print format

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -1415,6 +1415,7 @@ class PurchaseInvoice(BuyingController):
 			"Stock Ledger Entry",
 			"Repost Item Valuation",
 			"Payment Ledger Entry",
+			"Purchase Invoice",
 		)
 		self.update_advance_tax_references(cancel=1)
 


### PR DESCRIPTION
After addition of https://github.com/frappe/erpnext/pull/32204 users were facing issues cancelling old purchase invoices
Added ignore checks to allow cancellation

<img width="663" alt="Screenshot 2022-10-17 at 6 42 53 PM" src="https://user-images.githubusercontent.com/42651287/196188982-2d0fdf37-c678-4714-a7fb-388bf0055bd4.png">
