### PR TITLE
fix: Integrity Error on PLE while submitting sales invoice

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -3228,6 +3228,22 @@ class TestSalesInvoice(unittest.TestCase):
 
 		self.assertTrue(return_si.docstatus == 1)
 
+	def test_sales_invoice_with_payable_tax_account(self):
+		si = create_sales_invoice(do_not_submit=True)
+		si.append(
+			"taxes",
+			{
+				"charge_type": "Actual",
+				"account_head": "Creditors - _TC",
+				"description": "Test",
+				"cost_center": "Main - _TC",
+				"tax_amount": 10,
+				"total": 10,
+				"dont_recompute_tax": 0,
+			},
+		)
+		self.assertRaises(frappe.ValidationError, si.submit)
+
 
 def get_sales_invoice_for_e_invoice():
 	si = make_sales_invoice_for_ewaybill()

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -1467,7 +1467,12 @@ def update_voucher_outstanding(voucher_type, voucher_no, account, party_type, pa
 
 	# on cancellation outstanding can be an empty list
 	voucher_outstanding = ple_query.get_voucher_outstandings(vouchers, common_filter=common_filter)
-	if voucher_type in ["Sales Invoice", "Purchase Invoice", "Fees"] and voucher_outstanding:
+	if (
+		voucher_type in ["Sales Invoice", "Purchase Invoice", "Fees"]
+		and party_type
+		and party
+		and voucher_outstanding
+	):
 		outstanding = voucher_outstanding[0]
 		ref_doc = frappe.get_doc(voucher_type, voucher_no)
 


### PR DESCRIPTION
Avoid updating outstanding amount using PLE on Receivable/Payable Account heads that doesn't have `party_type` and  `party` field value supplied.
<img width="576" alt="Screenshot 2022-10-18 at 5 35 09 PM" src="https://user-images.githubusercontent.com/3272205/196424633-4d6b4af8-33b0-4d9a-910d-b84336910475.png">

