### PR TITLE
fix: allow to create Sales Order from expired Quotation

### DIFF
--- a/erpnext/selling/doctype/quotation/quotation.js
+++ b/erpnext/selling/doctype/quotation/quotation.js
@@ -84,11 +84,12 @@ erpnext.selling.QuotationController = class QuotationController extends erpnext.
 			}
 		}
 
-		if(doc.docstatus == 1 && !(['Lost', 'Ordered']).includes(doc.status)) {
-			if(!doc.valid_till || frappe.datetime.get_diff(doc.valid_till, frappe.datetime.get_today()) >= 0) {
-				cur_frm.add_custom_button(__('Sales Order'),
-					cur_frm.cscript['Make Sales Order'], __('Create'));
-			}
+		if (doc.docstatus == 1 && !["Lost", "Ordered"].includes(doc.status)) {
+			this.frm.add_custom_button(
+				__("Sales Order"),
+				this.frm.cscript["Make Sales Order"],
+				__("Create")
+			);
 
 			if(doc.status!=="Ordered") {
 				this.frm.add_custom_button(__('Set as Lost'), () => {


### PR DESCRIPTION
The company should always be able to accept an order, even if the **Quotation** is expired.

Let's assume, the customer orders a couple days "too late". What are we supposed to tell them? Sorry, we'd love to take your order, but the quotation is already expired so we technically cannot serve you? 😅

Legally speaking, the validity date gives us the option, _but not the obligation_, to refuse the order.