### PR TITLE
fix: Advance paid amount in orders

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -995,7 +995,9 @@ class PaymentEntry(AccountsController):
 		if self.payment_type in ("Receive", "Pay") and self.party:
 			for d in self.get("references"):
 				if d.allocated_amount and d.reference_doctype in frappe.get_hooks("advance_payment_doctypes"):
-					frappe.get_doc(d.reference_doctype, d.reference_name).set_total_advance_paid()
+					frappe.get_doc(
+						d.reference_doctype, d.reference_name, for_update=True
+					).set_total_advance_paid()
 
 	def on_recurring(self, reference_doc, auto_repeat_doc):
 		self.reference_no = reference_doc.name


### PR DESCRIPTION
When two partial payment entries are made simultaneously against a single order using two separate requests, both requests try to update the Advance Paid amount simultaneously and create a race condition.

Since both the requests read the previous advance amount as 0 the amount of the request which updates the value later is only seen rather than the sum of both entries.

Added a `for_update` flag to resolve the issue 