### PR TITLE
fix: overlap error not raised for job card in case of workstation with production capacity

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -133,7 +133,7 @@ class JobCard(Document):
 				(%(from_time)s <= jctl.from_time and %(to_time)s >= jctl.to_time) {0}
 			)
 			and jctl.name != %(name)s and jc.name != %(parent)s and jc.docstatus < 2 {1}
-			order by jctl.to_time desc limit 1""".format(
+			order by jctl.to_time desc""".format(
 				extra_cond, validate_overlap_for
 			),
 			{


### PR DESCRIPTION
**Issue**

- Set production capacity as 3 in the workstation and created 4 Work Order against the same workstation 
- Set "Planned Start Date" same to all 4 work orders and submitted
- System has created Job Card with same time logs and not raised Overlap Error

Ideally system should consider next available time slot



