### PR TITLE
fix: unset contact details

### DIFF
--- a/erpnext/public/js/utils/party.js
+++ b/erpnext/public/js/utils/party.js
@@ -242,20 +242,29 @@ erpnext.utils.set_taxes = function(frm, triggered_from_field) {
 	});
 };
 
-erpnext.utils.get_contact_details = function(frm) {
+erpnext.utils.get_contact_details = function (frm) {
 	if (frm.updating_party_details) return;
 
 	if (frm.doc["contact_person"]) {
 		frappe.call({
 			method: "frappe.contacts.doctype.contact.contact.get_contact_details",
-			args: {contact: frm.doc.contact_person },
-			callback: function(r) {
-				if (r.message)
-					frm.set_value(r.message);
-			}
-		})
+			args: { contact: frm.doc.contact_person },
+			callback: function (r) {
+				if (r.message) frm.set_value(r.message);
+			},
+		});
+	} else {
+		frm.set_value({
+			contact_person: "",
+			contact_display: "",
+			contact_email: "",
+			contact_mobile: "",
+			contact_phone: "",
+			contact_designation: "",
+			contact_department: "",
+		});
 	}
-}
+};
 
 erpnext.utils.validate_mandatory = function(frm, label, value, trigger_on) {
 	if (!value) {


### PR DESCRIPTION
Unset contact details if link to contact person is cleared.

### Test
1. Create a new Quotation (or other transaction) and select a contact
2. Clear the link to contact

### Result
Before this PR: all contact details (name, etc.) in the transaction remain unchanged
After this PR: all contact details are reset to empty