### PR TITLE
fix: Billing Address for inter-company purchase docs

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -2017,6 +2017,9 @@ def make_inter_company_transaction(doctype, source_name, target_doc=None):
 			update_address(
 				target_doc, "shipping_address", "shipping_address_display", source_doc.customer_address
 			)
+			update_address(
+				target_doc, "billing_address", "billing_address_display", source_doc.customer_address
+			)
 
 			if currency:
 				target_doc.currency = currency

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -842,6 +842,9 @@ def make_inter_company_transaction(doctype, source_name, target_doc=None):
 			update_address(
 				target_doc, "shipping_address", "shipping_address_display", source_doc.customer_address
 			)
+			update_address(
+				target_doc, "billing_address", "billing_address_display", source_doc.customer_address
+			)
 
 			update_taxes(
 				target_doc,


### PR DESCRIPTION
While making an internal Purchase Receipt or Purchase Invoice from a Delivery Note or Sales Invoice respectively the Company Billing Address was not getting mapped properly as the customer's billing address from the sales invoice.

The expectation is as follows:

**Delivery Note |-> Internal Purchase Receipt** 
'Company Billing and Shipping Addresses': A |-> 'Supplier Address': A
'Customer Billing Address': B |-> Company Billing Address: should become B. Not A

Similarly,
**Sales Invoice -> Internal Purchase Invoice** 
'Company Billing Address' = A -> 'Supplier Address' = A
'Customer Address' = B. -> Billing Address should become B. Not remain A