### PR TITLE
fix: for asset's purchase_date, if bill_date is set, use that instead of posting_date

### DIFF
--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -432,7 +432,11 @@ frappe.ui.form.on('Asset', {
 
 	set_values_from_purchase_doc: function(frm, doctype, purchase_doc) {
 		frm.set_value('company', purchase_doc.company);
-		frm.set_value('purchase_date', purchase_doc.posting_date);
+		if (purchase_doc.bill_date) {
+			frm.set_value('purchase_date', purchase_doc.bill_date);
+		} else {
+			frm.set_value('purchase_date', purchase_doc.posting_date);
+		}
 		const item = purchase_doc.items.find(item => item.item_code === frm.doc.item_code);
 		if (!item) {
 			doctype_field = frappe.scrub(doctype)


### PR DESCRIPTION
### Steps to Reproduce:

1. Your company receives an asset and the invoice on 01-10-2022
2. Your company starts using the asset but since it takes some time for the procurement team to get permissions for the purchase, the finance team doesn't create the `Purchase Invoice` or an `Asset` in the system, yet.
3. On 22-10-2022, the procurement team gets the permission. The finance team performs the payment and creates a `Purchase Invoice`, with the `Supplier Invoice Date` (`bill_date`) set to 01-10-2022. Note that the `posting_date` in the `Purchase Invoice` would be 22-10-2022 automatically.
4. Next, the finance team tries to create an `Asset` in the system. They set the relevant details, and they find that the `purchase_date` field is automatically set to 22-10-2022 (from the `posting_date` of the `Purchase Invoice`), which shouldn't be the case. The `purchase_date` field should be 01-10-2022 since the `Supplier Invoice Date` (`bill_date`) is set to 01-10-2022.

--

Now for an `Asset`'s `purchase_date`, if `bill_date` is set in the `Purchase Invoice`, that is used instead of `posting_date`. Thanks to @deepeshgarg007 for helping me understand the issue (ISS-22-23-02455).