### PR TITLE
fix: Search field not working for customer, supplier

### DIFF
--- a/erpnext/buying/doctype/supplier/test_supplier.py
+++ b/erpnext/buying/doctype/supplier/test_supplier.py
@@ -3,6 +3,7 @@
 
 
 import frappe
+from frappe.custom.doctype.property_setter.property_setter import make_property_setter
 from frappe.test_runner import make_test_records
 
 from erpnext.accounts.party import get_due_date
@@ -151,6 +152,40 @@ class TestSupplier(FrappeTestCase):
 
 		# Rollback
 		address.delete()
+
+	def test_serach_fields_for_supplier(self):
+		from erpnext.controllers.queries import supplier_query
+
+		supplier_name = create_supplier(supplier_name="Test Supplier 1").name
+
+		make_property_setter(
+			"Supplier", None, "search_fields", "supplier_group", "Data", for_doctype="Doctype"
+		)
+
+		data = supplier_query(
+			"Supplier", supplier_name, "name", 0, 20, filters={"name": supplier_name}, as_dict=True
+		)
+
+		self.assertEqual(data[0].name, supplier_name)
+		self.assertEqual(data[0].supplier_group, "Services")
+		self.assertTrue("supplier_type" not in data[0])
+
+		make_property_setter(
+			"Supplier",
+			None,
+			"search_fields",
+			"supplier_group, supplier_type",
+			"Data",
+			for_doctype="Doctype",
+		)
+		data = supplier_query(
+			"Supplier", supplier_name, "name", 0, 20, filters={"name": supplier_name}, as_dict=True
+		)
+
+		self.assertEqual(data[0].name, supplier_name)
+		self.assertEqual(data[0].supplier_group, "Services")
+		self.assertEqual(data[0].supplier_type, "Company")
+		self.assertTrue("supplier_type" in data[0])
 
 
 def create_supplier(**args):

--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -78,7 +78,7 @@ def lead_query(doctype, txt, searchfield, start, page_len, filters):
 
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
-def customer_query(doctype, txt, searchfield, start, page_len, filters):
+def customer_query(doctype, txt, searchfield, start, page_len, filters, as_dict=False):
 	doctype = "Customer"
 	conditions = []
 	cust_master_name = frappe.defaults.get_user_default("cust_master_name")
@@ -110,13 +110,14 @@ def customer_query(doctype, txt, searchfield, start, page_len, filters):
 			}
 		),
 		{"txt": "%%%s%%" % txt, "_txt": txt.replace("%", ""), "start": start, "page_len": page_len},
+		as_dict=as_dict,
 	)
 
 
 # searches for supplier
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
-def supplier_query(doctype, txt, searchfield, start, page_len, filters):
+def supplier_query(doctype, txt, searchfield, start, page_len, filters, as_dict=False):
 	doctype = "Supplier"
 	supp_master_name = frappe.defaults.get_user_default("supp_master_name")
 
@@ -142,6 +143,7 @@ def supplier_query(doctype, txt, searchfield, start, page_len, filters):
 			**{"field": ", ".join(fields), "key": searchfield, "mcond": get_match_cond(doctype)}
 		),
 		{"txt": "%%%s%%" % txt, "_txt": txt.replace("%", ""), "start": start, "page_len": page_len},
+		as_dict=as_dict,
 	)
 
 

--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -83,13 +83,11 @@ def customer_query(doctype, txt, searchfield, start, page_len, filters):
 	conditions = []
 	cust_master_name = frappe.defaults.get_user_default("cust_master_name")
 
-	if cust_master_name == "Customer Name":
-		fields = ["name", "customer_group", "territory"]
-	else:
-		fields = ["name", "customer_name", "customer_group", "territory"]
+	fields = ["name"]
+	if cust_master_name != "Customer Name":
+		fields = ["customer_name"]
 
 	fields = get_fields(doctype, fields)
-
 	searchfields = frappe.get_meta(doctype).get_search_fields()
 	searchfields = " or ".join(field + " like %(txt)s" for field in searchfields)
 
@@ -122,10 +120,9 @@ def supplier_query(doctype, txt, searchfield, start, page_len, filters):
 	doctype = "Supplier"
 	supp_master_name = frappe.defaults.get_user_default("supp_master_name")
 
-	if supp_master_name == "Supplier Name":
-		fields = ["name", "supplier_group"]
-	else:
-		fields = ["name", "supplier_name", "supplier_group"]
+	fields = ["name"]
+	if supp_master_name != "Supplier Name":
+		fields = ["supplier_name"]
 
 	fields = get_fields(doctype, fields)
 

--- a/erpnext/selling/doctype/customer/test_customer.py
+++ b/erpnext/selling/doctype/customer/test_customer.py
@@ -3,6 +3,7 @@
 
 
 import frappe
+from frappe.custom.doctype.property_setter.property_setter import make_property_setter
 from frappe.test_runner import make_test_records
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils import flt
@@ -340,6 +341,33 @@ class TestCustomer(FrappeTestCase):
 
 		due_date = get_due_date("2017-01-22", "Customer", "_Test Customer")
 		self.assertEqual(due_date, "2017-01-22")
+
+	def test_serach_fields_for_customer(self):
+		from erpnext.controllers.queries import customer_query
+
+		make_property_setter(
+			"Customer", None, "search_fields", "customer_group", "Data", for_doctype="Doctype"
+		)
+
+		data = customer_query(
+			"Customer", "_Test Customer", "", 0, 20, filters={"name": "_Test Customer"}, as_dict=True
+		)
+
+		self.assertEqual(data[0].name, "_Test Customer")
+		self.assertEqual(data[0].customer_group, "_Test Customer Group")
+		self.assertTrue("territory" not in data[0])
+
+		make_property_setter(
+			"Customer", None, "search_fields", "customer_group, territory", "Data", for_doctype="Doctype"
+		)
+		data = customer_query(
+			"Customer", "_Test Customer", "", 0, 20, filters={"name": "_Test Customer"}, as_dict=True
+		)
+
+		self.assertEqual(data[0].name, "_Test Customer")
+		self.assertEqual(data[0].customer_group, "_Test Customer Group")
+		self.assertEqual(data[0].territory, "_Test Territory")
+		self.assertTrue("territory" in data[0])
 
 
 def get_customer_dict(customer_name):


### PR DESCRIPTION
**Issue**

Set searchfield as "customer_group" for the customer doctype, still can see other fields in the customer dropdown

<img width="659" alt="image" src="https://user-images.githubusercontent.com/8780500/197508994-7d872019-d771-418e-926d-a898b8e053be.png">



<img width="728" alt="Screenshot 2022-10-24 at 4 12 34 PM" src="https://user-images.githubusercontent.com/8780500/197508933-c5e22996-1d2b-45de-a578-34d2c5d9ac94.png">


**After Fix**

<img width="687" alt="Screenshot 2022-10-24 at 4 13 02 PM" src="https://user-images.githubusercontent.com/8780500/197509036-7cddf224-9063-43f1-8f07-c93dcbd7a819.png">
