### PR TITLE
fix: add translation  function to Bank Reconciliation Tool related files

### DIFF
--- a/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.js
+++ b/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.js
@@ -12,7 +12,7 @@ frappe.ui.form.on("Bank Reconciliation Tool", {
 				},
 			};
 		});
-		var no_bank_transactions_text =
+		let no_bank_transactions_text =
 			`<div class="text-muted text-center">${__("No Matching Bank Transactions Found")}</div>`
 		set_field_options("no_bank_transactions", no_bank_transactions_text);
 	},

--- a/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.js
+++ b/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.js
@@ -12,6 +12,9 @@ frappe.ui.form.on("Bank Reconciliation Tool", {
 				},
 			};
 		});
+		var no_bank_transactions_text = 
+			`<div class="text-muted text-center">${__("No Matching Bank Transactions Found")}</div>`
+		set_field_options("no_bank_transactions", no_bank_transactions_text);
 	},
 
 	onload: function (frm) {

--- a/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.js
+++ b/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.js
@@ -11,7 +11,7 @@ frappe.ui.form.on("Bank Reconciliation Tool", {
 					'is_company_account': 1
 				},
 			};
-		});		
+		});
 		var no_bank_transactions_text =
 			`<div class="text-muted text-center">${__("No Matching Bank Transactions Found")}</div>`
 		set_field_options("no_bank_transactions", no_bank_transactions_text);

--- a/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.js
+++ b/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.js
@@ -11,9 +11,8 @@ frappe.ui.form.on("Bank Reconciliation Tool", {
 					'is_company_account': 1
 				},
 			};
-		});
-		
-		var no_bank_transactions_text = 
+		});		
+		var no_bank_transactions_text =
 			`<div class="text-muted text-center">${__("No Matching Bank Transactions Found")}</div>`
 		set_field_options("no_bank_transactions", no_bank_transactions_text);
 	},

--- a/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.js
+++ b/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.js
@@ -12,6 +12,7 @@ frappe.ui.form.on("Bank Reconciliation Tool", {
 				},
 			};
 		});
+		
 		var no_bank_transactions_text = 
 			`<div class="text-muted text-center">${__("No Matching Bank Transactions Found")}</div>`
 		set_field_options("no_bank_transactions", no_bank_transactions_text);

--- a/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.json
+++ b/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.json
@@ -81,8 +81,7 @@
   },
   {
    "fieldname": "no_bank_transactions",
-   "fieldtype": "HTML",
-   "options": "<div class=\"text-muted text-center\">No Matching Bank Transactions Found</div>"
+   "fieldtype": "HTML"
   }
  ],
  "hide_toolbar": 1,

--- a/erpnext/accounts/doctype/bank_statement_import/bank_statement_import.js
+++ b/erpnext/accounts/doctype/bank_statement_import/bank_statement_import.js
@@ -100,7 +100,7 @@ frappe.ui.form.on("Bank Statement Import", {
 
 		if (frm.doc.status.includes("Success")) {
 			frm.add_custom_button(
-				__("Go to {0} List", [frm.doc.reference_doctype]),
+				__("Go to {0} List", [__(frm.doc.reference_doctype)]),
 				() => frappe.set_route("List", frm.doc.reference_doctype)
 			);
 		}

--- a/erpnext/public/js/bank_reconciliation_tool/data_table_manager.js
+++ b/erpnext/public/js/bank_reconciliation_tool/data_table_manager.js
@@ -30,28 +30,28 @@ erpnext.accounts.bank_reconciliation.DataTableManager = class DataTableManager {
 	get_dt_columns() {
 		this.columns = [
 			{
-				name: "Date",
+				name: __("Date"),
 				editable: false,
 				width: 100,
 			},
 
 			{
-				name: "Party Type",
+				name: __("Party Type"),
 				editable: false,
 				width: 95,
 			},
 			{
-				name: "Party",
+				name: __("Party"),
 				editable: false,
 				width: 100,
 			},
 			{
-				name: "Description",
+				name: __("Description"),
 				editable: false,
 				width: 350,
 			},
 			{
-				name: "Deposit",
+				name: __("Deposit"),
 				editable: false,
 				width: 100,
 				format: (value) =>
@@ -60,7 +60,7 @@ erpnext.accounts.bank_reconciliation.DataTableManager = class DataTableManager {
 					"</span>",
 			},
 			{
-				name: "Withdrawal",
+				name: __("Withdrawal"),
 				editable: false,
 				width: 100,
 				format: (value) =>
@@ -69,26 +69,26 @@ erpnext.accounts.bank_reconciliation.DataTableManager = class DataTableManager {
 					"</span>",
 			},
 			{
-				name: "Unallocated Amount",
+				name: __("Unallocated Amount"),
 				editable: false,
 				width: 100,
 				format: (value) =>
-					"<span style='color:blue;'>" +
+					"<span style='color:var(--blue-500);'>" +
 					format_currency(value, this.currency) +
 					"</span>",
 			},
 			{
-				name: "Reference Number",
+				name: __("Reference Number"),
 				editable: false,
 				width: 140,
 			},
 			{
-				name: "Actions",
+				name: __("Actions"),
 				editable: false,
 				sortable: false,
 				focusable: false,
 				dropdown: false,
-				width: 80,
+				width: 100,
 			},
 		];
 	}
@@ -118,10 +118,10 @@ erpnext.accounts.bank_reconciliation.DataTableManager = class DataTableManager {
 			row["reference_number"],
 			`
 			<Button class="btn btn-primary btn-xs center"  data-name = ${row["name"]} >
-				Actions
+				${__("Actions")}
 			</a>
 			`,
-		];
+		];	
 	}
 
 	get_datatable() {

--- a/erpnext/public/js/bank_reconciliation_tool/data_table_manager.js
+++ b/erpnext/public/js/bank_reconciliation_tool/data_table_manager.js
@@ -121,8 +121,7 @@ erpnext.accounts.bank_reconciliation.DataTableManager = class DataTableManager {
 				${__("Actions")}
 			</a>
 			`,
-			
-		];	
+		];
 	}
 
 	get_datatable() {

--- a/erpnext/public/js/bank_reconciliation_tool/data_table_manager.js
+++ b/erpnext/public/js/bank_reconciliation_tool/data_table_manager.js
@@ -121,6 +121,7 @@ erpnext.accounts.bank_reconciliation.DataTableManager = class DataTableManager {
 				${__("Actions")}
 			</a>
 			`,
+			
 		];	
 	}
 

--- a/erpnext/public/js/bank_reconciliation_tool/dialog_manager.js
+++ b/erpnext/public/js/bank_reconciliation_tool/dialog_manager.js
@@ -87,33 +87,33 @@ erpnext.accounts.bank_reconciliation.DialogManager = class DialogManager {
 	get_dt_columns() {
 		this.columns = [
 			{
-				name: "Document Type",
+				name: __("Document Type"),
 				editable: false,
 				width: 125,
 			},
 			{
-				name: "Document Name",
+				name: __("Document Name"),
 				editable: false,
 				width: 150,
 			},
 			{
-				name: "Reference Date",
+				name: __("Reference Date"),
 				editable: false,
 				width: 120,
 			},
 			{
-				name: "Amount",
+				name: __("Amount"),
 				editable: false,
 				width: 100,
 			},
 			{
-				name: "Party",
+				name: __("Party"),
 				editable: false,
 				width: 120,
 			},
 
 			{
-				name: "Reference Number",
+				name: __("Reference Number"),
 				editable: false,
 				width: 140,
 			},
@@ -222,7 +222,7 @@ erpnext.accounts.bank_reconciliation.DialogManager = class DialogManager {
 			{
 				fieldtype: "HTML",
 				fieldname: "no_matching_vouchers",
-				options: "<div class=\"text-muted text-center\">No Matching Vouchers Found</div>"
+				options: __("<div class=\"text-muted text-center\">{0}</div>", [__("No Matching Vouchers Found")])
 			},
 			{
 				fieldtype: "Section Break",
@@ -444,10 +444,7 @@ erpnext.accounts.bank_reconciliation.DialogManager = class DialogManager {
 				vouchers: vouchers,
 			},
 			callback: (response) => {
-				const alert_string =
-					"Bank Transaction " +
-					this.bank_transaction.name +
-					" Matched";
+				const alert_string = __("Bank Transaction {0} Matched", [this.bank_transaction.name]);
 				frappe.show_alert(alert_string);
 				this.update_dt_cards(response.message);
 				this.dialog.hide();
@@ -471,10 +468,7 @@ erpnext.accounts.bank_reconciliation.DialogManager = class DialogManager {
 				cost_center: values.cost_center,
 			},
 			callback: (response) => {
-				const alert_string =
-					"Bank Transaction " +
-					this.bank_transaction.name +
-					" added as Payment Entry";
+				const alert_string = __("Bank Transaction {0} added as Payment Entry", [this.bank_transaction.name]);
 				frappe.show_alert(alert_string);
 				this.update_dt_cards(response.message);
 				this.dialog.hide();
@@ -498,10 +492,7 @@ erpnext.accounts.bank_reconciliation.DialogManager = class DialogManager {
 				second_account: values.second_account,
 			},
 			callback: (response) => {
-				const alert_string =
-					"Bank Transaction " +
-					this.bank_transaction.name +
-					" added as Journal Entry";
+				const alert_string = __("Bank Transaction {0} added as Journal Entry", [this.bank_transaction.name]);
 				frappe.show_alert(alert_string);
 				this.update_dt_cards(response.message);
 				this.dialog.hide();
@@ -520,10 +511,7 @@ erpnext.accounts.bank_reconciliation.DialogManager = class DialogManager {
 				party: values.party,
 			},
 			callback: (response) => {
-				const alert_string =
-					"Bank Transaction " +
-					this.bank_transaction.name +
-					" updated";
+				const alert_string = __("Bank Transaction {0} updated", [this.bank_transaction.name]);
 				frappe.show_alert(alert_string);
 				this.update_dt_cards(response.message);
 				this.dialog.hide();

--- a/erpnext/public/js/bank_reconciliation_tool/number_card.js
+++ b/erpnext/public/js/bank_reconciliation_tool/number_card.js
@@ -15,20 +15,20 @@ erpnext.accounts.bank_reconciliation.NumberCardManager = class NumberCardManager
 		var chart_data = [
 			{
 				value: this.bank_statement_closing_balance,
-				label: "Closing Balance as per Bank Statement",
+				label: __("Closing Balance as per Bank Statement"),
 				datatype: "Currency",
 				currency: this.currency,
 			},
 			{
 				value: this.cleared_balance,
-				label: "Closing Balance as per ERP",
+				label: __("Closing Balance as per ERP"),
 				datatype: "Currency",
 				currency: this.currency,
 			},
 			{
 				value:
 					this.bank_statement_closing_balance - this.cleared_balance,
-				label: "Difference",
+				label: __("Difference"),
 				datatype: "Currency",
 				currency: this.currency,
 			},


### PR DESCRIPTION
In this commit also include color change of unallocated ammount from "blue" to "blue-500" for mor readability  on dark theme

Before:
![antes_rec](https://user-images.githubusercontent.com/1592496/199766198-15b918b2-d64a-4472-981d-f6976bf8772c.PNG)


After:
![despues_rec](https://user-images.githubusercontent.com/1592496/199766284-da11e52c-f9ef-4117-aa0a-fff2a0b7ea56.PNG)
