### PR TITLE
fix: duplicate custom fields for inventory dimension

### DIFF
--- a/erpnext/stock/doctype/inventory_dimension/test_inventory_dimension.py
+++ b/erpnext/stock/doctype/inventory_dimension/test_inventory_dimension.py
@@ -191,6 +191,21 @@ class TestInventoryDimension(FrappeTestCase):
 
 		self.assertEqual(sle_rack, "Rack 1")
 
+	def test_check_standard_dimensions(self):
+		create_inventory_dimension(
+			reference_document="Project",
+			type_of_transaction="Outward",
+			dimension_name="Project",
+			apply_to_all_doctypes=0,
+			document_type="Stock Ledger Entry",
+		)
+
+		self.assertFalse(
+			frappe.db.get_value(
+				"Custom Field", {"fieldname": "project", "dt": "Stock Ledger Entry"}, "name"
+			)
+		)
+
 
 def prepare_test_data():
 	if not frappe.db.exists("DocType", "Shelf"):


### PR DESCRIPTION
While adding Project dimension field getting below error
<img width="1083" alt="Screenshot 2022-10-27 at 5 19 58 PM" src="https://user-images.githubusercontent.com/8780500/198288587-247763da-1183-46df-bfd5-b13b0fa102e8.png">


If custom field exists then system skip to add custom field but if standard field exists with same name then throws the above error.