### PR TITLE
fix: add `Sales Order` reference in Material Request Dashboard

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request_dashboard.py
+++ b/erpnext/stock/doctype/material_request/material_request_dashboard.py
@@ -4,10 +4,13 @@ from frappe import _
 def get_data():
 	return {
 		"fieldname": "material_request",
+		"internal_links": {
+			"Sales Order": ["items", "sales_order"],
+		},
 		"transactions": [
 			{
 				"label": _("Reference"),
-				"items": ["Request for Quotation", "Supplier Quotation", "Purchase Order"],
+				"items": ["Sales Order", "Request for Quotation", "Supplier Quotation", "Purchase Order"],
 			},
 			{"label": _("Stock"), "items": ["Stock Entry", "Purchase Receipt", "Pick List"]},
 			{"label": _("Manufacturing"), "items": ["Work Order"]},


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/63660334/198817394-ad15a864-2369-490e-89b2-93bbd1069951.png)

After:
![image](https://user-images.githubusercontent.com/63660334/198817510-78d0703d-cbff-4f15-930e-625fd9f8a757.png)










Close: #32734