### PR TITLE
perf: use `get_cached_value` instead of `db.get_value` in controllers

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -634,7 +634,7 @@ class AccountsController(TransactionBase):
 		if (self.is_new() or self.is_pos_profile_changed()) and not self.get("taxes"):
 			if self.company and not self.get("taxes_and_charges"):
 				# get the default tax master
-				self.taxes_and_charges = frappe.get_cached_value(
+				self.taxes_and_charges = frappe.db.get_value(
 					tax_master_doctype, {"is_default": 1, "company": self.company}
 				)
 
@@ -644,7 +644,7 @@ class AccountsController(TransactionBase):
 		if (
 			self.doctype == "Sales Invoice"
 			and self.is_pos
-			and self.pos_profile != frappe.get_cached_value("Sales Invoice", self.name, "pos_profile")
+			and self.pos_profile != frappe.db.get_value("Sales Invoice", self.name, "pos_profile")
 		):
 			return True
 
@@ -1910,7 +1910,7 @@ def get_default_taxes_and_charges(master_doctype, tax_template=None, company=Non
 		if tax_template_company == company:
 			return
 
-	default_tax = frappe.get_cached_value(master_doctype, {"is_default": 1, "company": company})
+	default_tax = frappe.db.get_value(master_doctype, {"is_default": 1, "company": company})
 
 	return {
 		"taxes_and_charges": default_tax,

--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -326,7 +326,7 @@ def make_return_doc(doctype: str, source_name: str, target_doc=None):
 	from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos
 
 	company = frappe.db.get_value("Delivery Note", source_name, "company")
-	default_warehouse_for_sales_return = frappe.db.get_value(
+	default_warehouse_for_sales_return = frappe.get_cached_value(
 		"Company", company, "default_warehouse_for_sales_return"
 	)
 
@@ -340,11 +340,11 @@ def make_return_doc(doctype: str, source_name: str, target_doc=None):
 
 			# look for Print Heading "Credit Note"
 			if not doc.select_print_heading:
-				doc.select_print_heading = frappe.db.get_value("Print Heading", _("Credit Note"))
+				doc.select_print_heading = frappe.get_cached_value("Print Heading", _("Credit Note"))
 
 		elif doctype == "Purchase Invoice":
 			# look for Print Heading "Debit Note"
-			doc.select_print_heading = frappe.db.get_value("Print Heading", _("Debit Note"))
+			doc.select_print_heading = frappe.get_cached_value("Print Heading", _("Debit Note"))
 
 		for tax in doc.get("taxes") or []:
 			if tax.charge_type == "Actual":

--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -57,7 +57,7 @@ class StockController(AccountsController):
 			make_reverse_gl_entries(voucher_type=self.doctype, voucher_no=self.name)
 
 		provisional_accounting_for_non_stock_items = cint(
-			frappe.db.get_value(
+			frappe.get_cached_value(
 				"Company", self.company, "enable_provisional_accounting_for_non_stock_items"
 			)
 		)
@@ -200,7 +200,9 @@ class StockController(AccountsController):
 				elif self.get("is_internal_supplier"):
 					warehouse_asset_account = warehouse_account[item_row.get("warehouse")]["account"]
 
-				expense_account = frappe.db.get_value("Company", self.company, "default_expense_account")
+				expense_account = frappe.get_cached_value(
+					"Company", self.company, "default_expense_account"
+				)
 
 				gl_list.append(
 					self.get_gl_dict(
@@ -235,7 +237,7 @@ class StockController(AccountsController):
 
 		if warehouse_with_no_account:
 			for wh in warehouse_with_no_account:
-				if frappe.db.get_value("Warehouse", wh, "company"):
+				if frappe.get_cached_value("Warehouse", wh, "company"):
 					frappe.throw(
 						_(
 							"Warehouse {0} is not linked to any account, please mention the account in the warehouse record or set default inventory account in company {1}."

--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -451,7 +451,15 @@ class StockController(AccountsController):
 
 				# Get value based on doctype name
 				if not sl_dict.get(dimension.target_fieldname):
-					fieldname = next((field.fieldname for field in frappe.get_meta(self.doctype).fields if field.options == dimension.fetch_from_parent), None)
+
+					fieldname = next(
+						(
+							field.fieldname
+							for field in frappe.get_meta(self.doctype).fields
+							if field.options == dimension.fetch_from_parent
+						),
+						None,
+					)
 
 					if fieldname and self.get(fieldname):
 						sl_dict[dimension.target_fieldname] = self.get(fieldname)

--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -200,9 +200,7 @@ class StockController(AccountsController):
 				elif self.get("is_internal_supplier"):
 					warehouse_asset_account = warehouse_account[item_row.get("warehouse")]["account"]
 
-				expense_account = frappe.get_cached_value(
-					"Company", self.company, "default_expense_account"
-				)
+				expense_account = frappe.get_cached_value("Company", self.company, "default_expense_account")
 
 				gl_list.append(
 					self.get_gl_dict(

--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -451,7 +451,6 @@ class StockController(AccountsController):
 
 				# Get value based on doctype name
 				if not sl_dict.get(dimension.target_fieldname):
-
 					fieldname = next(
 						(
 							field.fieldname

--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -451,14 +451,7 @@ class StockController(AccountsController):
 
 				# Get value based on doctype name
 				if not sl_dict.get(dimension.target_fieldname):
-					fieldname = frappe.get_cached_value(
-						"DocField", {"parent": self.doctype, "options": dimension.fetch_from_parent}, "fieldname"
-					)
-
-					if not fieldname:
-						fieldname = frappe.get_cached_value(
-							"Custom Field", {"dt": self.doctype, "options": dimension.fetch_from_parent}, "fieldname"
-						)
+					fieldname = next((field.fieldname for field in frappe.get_meta(self.doctype).fields if field.options == dimension.fetch_from_parent), None)
 
 					if fieldname and self.get(fieldname):
 						sl_dict[dimension.target_fieldname] = self.get(fieldname)

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -1034,9 +1034,7 @@ class init_landed_taxes_and_totals(object):
 		company_currency = erpnext.get_company_currency(self.doc.company)
 		for d in self.doc.get(self.tax_field):
 			if not d.account_currency:
-				account_currency = frappe.get_cached_value(
-					"Account", d.expense_account, "account_currency"
-				)
+				account_currency = frappe.get_cached_value("Account", d.expense_account, "account_currency")
 				d.account_currency = account_currency or company_currency
 
 	def set_exchange_rate(self):

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -1034,7 +1034,9 @@ class init_landed_taxes_and_totals(object):
 		company_currency = erpnext.get_company_currency(self.doc.company)
 		for d in self.doc.get(self.tax_field):
 			if not d.account_currency:
-				account_currency = frappe.db.get_value("Account", d.expense_account, "account_currency")
+				account_currency = frappe.get_cached_value(
+					"Account", d.expense_account, "account_currency"
+				)
 				d.account_currency = account_currency or company_currency
 
 	def set_exchange_rate(self):

--- a/erpnext/controllers/trends.py
+++ b/erpnext/controllers/trends.py
@@ -80,7 +80,7 @@ def get_data(filters, conditions):
 	if conditions.get("trans") == "Quotation" and filters.get("group_by") == "Customer":
 		cond += " and t1.quotation_to = 'Customer'"
 
-	year_start_date, year_end_date = frappe.db.get_value(
+	year_start_date, year_end_date = frappe.get_cached_value(
 		"Fiscal Year", filters.get("fiscal_year"), ["year_start_date", "year_end_date"]
 	)
 
@@ -275,7 +275,7 @@ def get_period_date_ranges(period, fiscal_year=None, year_start_date=None):
 	from dateutil.relativedelta import relativedelta
 
 	if not year_start_date:
-		year_start_date, year_end_date = frappe.db.get_value(
+		year_start_date, year_end_date = frappe.get_cached_value(
 			"Fiscal Year", fiscal_year, ["year_start_date", "year_end_date"]
 		)
 


### PR DESCRIPTION
Replaced `db.get_value` with `get_cached_value` for masters doctype in **Controllers** file.

### Before
```
In [2]: %timeit doc.validate_enabled_taxes_and_charges()
528 µs ± 3.3 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

### After (without local cache)
```
In [3]: %timeit doc.validate_enabled_taxes_and_charges()
5.85 µs ± 64.2 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```
Closes #32720