### PR TITLE
fix: Reset advance paid amount on Order cancel and amend

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -101,6 +101,11 @@ frappe.ui.form.on("Purchase Order", {
 		erpnext.queries.setup_queries(frm, "Warehouse", function() {
 			return erpnext.queries.warehouse(frm.doc);
 		});
+
+		// On cancel and amending a purchase order with advance payment, reset advance paid amount
+		if (frm.is_new()) {
+			frm.set_value("advance_paid", 0)
+		}
 	},
 
 	apply_tds: function(frm) {

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -124,6 +124,11 @@ frappe.ui.form.on("Sales Order", {
 			return query;
 		});
 
+		// On cancel and amending a sales order with advance payment, reset advance paid amount
+		if (frm.is_new()) {
+			frm.set_value("advance_paid", 0)
+		}
+
 		frm.ignore_doctypes_on_cancel_all = ['Purchase Order'];
 	},
 


### PR DESCRIPTION
Advance paid amount doesn't get reset when an Order against which advance has been paid is cancelled without cancelling the payment entry