### PR TITLE
fix: Mode of payment for returns in POS Sales Invoice

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -965,7 +965,8 @@ class TestSalesInvoice(unittest.TestCase):
 		pos_return.insert()
 		pos_return.submit()
 
-		self.assertEqual(pos_return.get("payments")[0].amount, -1000)
+		self.assertEqual(pos_return.get("payments")[0].amount, -500)
+		self.assertEqual(pos_return.get("payments")[1].amount, -500)
 
 	def test_pos_change_amount(self):
 		make_pos_profile(

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -889,23 +889,32 @@ class calculate_taxes_and_totals(object):
 		self.doc.other_charges_calculation = get_itemised_tax_breakup_html(self.doc)
 
 	def set_total_amount_to_default_mop(self, total_amount_to_pay):
-		default_mode_of_payment = frappe.db.get_value(
-			"POS Payment Method",
-			{"parent": self.doc.pos_profile, "default": 1},
-			["mode_of_payment"],
-			as_dict=1,
-		)
-
-		if default_mode_of_payment:
-			self.doc.payments = []
-			self.doc.append(
-				"payments",
-				{
-					"mode_of_payment": default_mode_of_payment.mode_of_payment,
-					"amount": total_amount_to_pay,
-					"default": 1,
-				},
+		total_paid_amount = 0
+		for payment in self.doc.get("payments"):
+			total_paid_amount += (
+				payment.amount if self.doc.party_account_currency == self.doc.currency else payment.base_amount
 			)
+
+		pending_amount = total_amount_to_pay - total_paid_amount
+
+		if pending_amount > 0:
+			default_mode_of_payment = frappe.db.get_value(
+				"POS Payment Method",
+				{"parent": self.doc.pos_profile, "default": 1},
+				["mode_of_payment"],
+				as_dict=1,
+			)
+
+			if default_mode_of_payment:
+				self.doc.payments = []
+				self.doc.append(
+					"payments",
+					{
+						"mode_of_payment": default_mode_of_payment.mode_of_payment,
+						"amount": pending_amount,
+						"default": 1,
+					},
+				)
 
 
 def get_itemised_tax_breakup_html(doc):


### PR DESCRIPTION
While making a return for a Sales Invoice (with Is POS check enabled) the mode of payment always used to reset to default one on saving overriding user entered mode of payment.

Modified the logic to do that only for the pending amount

  