### PR TITLE
fix: pro_rata_amount calculation in assets tests

### DIFF
--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -221,7 +221,7 @@ class TestAsset(AssetSetup):
 			asset.precision("gross_purchase_amount"),
 		)
 		pro_rata_amount, _, _ = asset.get_pro_rata_amt(
-			asset.finance_books[0], 9000, add_months(get_last_day(purchase_date), 1), date
+			asset.finance_books[0], 9000, get_last_day(add_months(purchase_date, 1)), date
 		)
 		pro_rata_amount = flt(pro_rata_amount, asset.precision("gross_purchase_amount"))
 		self.assertEquals(accumulated_depr_amount, 18000.00 + pro_rata_amount)
@@ -283,7 +283,7 @@ class TestAsset(AssetSetup):
 		self.assertEqual(frappe.db.get_value("Asset", asset.name, "status"), "Sold")
 
 		pro_rata_amount, _, _ = asset.get_pro_rata_amt(
-			asset.finance_books[0], 9000, add_months(get_last_day(purchase_date), 1), date
+			asset.finance_books[0], 9000, get_last_day(add_months(purchase_date, 1)), date
 		)
 		pro_rata_amount = flt(pro_rata_amount, asset.precision("gross_purchase_amount"))
 


### PR DESCRIPTION
This is to fix two of the [failing](https://github.com/frappe/erpnext/actions/runs/3363147889/jobs/5584235627) tests in the assets module due to incorrect pro_rata_amount calculation.
Thanks to @rohitwaghchaure for letting me know about the failing tests.