### PR TITLE
fix: Do not force eligibilgity of itc for reverse charge

### DIFF
--- a/erpnext/regional/india/taxes.js
+++ b/erpnext/regional/india/taxes.js
@@ -47,6 +47,12 @@ erpnext.setup_auto_gst_taxation = (doctype) => {
 					}
 				}
 			});
+		},
+
+		reverse_charge: function(frm) {
+			if (frm.doc.reverse_charge == "Y") {
+				frm.set_value('eligibility_for_itc', 'ITC on Reverse Charge');
+			}
 		}
 	});
 }

--- a/erpnext/regional/india/utils.py
+++ b/erpnext/regional/india/utils.py
@@ -983,8 +983,6 @@ def validate_reverse_charge_transaction(doc, method):
 
 			frappe.throw(msg)
 
-		doc.eligibility_for_itc = "ITC on Reverse Charge"
-
 
 def update_itc_availed_fields(doc, method):
 	country = frappe.get_cached_value("Company", doc.company, "country")


### PR DESCRIPTION
There could be cases where the "Eligibility For ITC" could be something else than "TC on Reverse Charge" even for reverse charge invoices, hence removing the server-side code to allow users to manually update