### PR TITLE
fix: test cases

### DIFF
--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -591,6 +591,7 @@ class TestMaterialRequest(FrappeTestCase):
 		mr.material_request_type = "Material Issue"
 		mr.submit()
 
+		self.assertTrue(frappe.db.exists("Material Request", mr.name))
 		# testing bin value after material request is submitted
 		self.assertEqual(_get_requested_qty(), existing_requested_qty - 54.0)
 

--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -590,8 +590,8 @@ class TestMaterialRequest(FrappeTestCase):
 		mr = frappe.copy_doc(test_records[0])
 		mr.material_request_type = "Material Issue"
 		mr.submit()
+		frappe.db.value_cache = {}
 
-		self.assertTrue(frappe.db.exists("Material Request", mr.name))
 		# testing bin value after material request is submitted
 		self.assertEqual(_get_requested_qty(), existing_requested_qty - 54.0)
 


### PR DESCRIPTION
frappe.db.get_value with cache causing the travis fail for the below test case

```
ERROR  test_completed_qty_for_issue (erpnext.stock.doctype.material_request.test_material_request.TestMaterialRequest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/stock/doctype/material_request/test_material_request.py", line 605, in test_completed_qty_for_issue
    se_doc.insert()
    _get_requested_qty = <function TestMaterialRequest.test_completed_qty_for_issue.<locals>._get_requested_qty at 0x7facb80d95a0>
    existing_requested_qty = 54.0
    mr = <MaterialRequest: _T-Material Request-00008 docstatus=1>
    se_doc = <StockEntry: unsaved>
    self = <erpnext.stock.doctype.material_request.test_material_request.TestMaterialRequest testMethod=test_completed_qty_for_issue>
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 250, in insert
    self._validate_links()
    ignore_if_duplicate = False
    ignore_links = None
    ignore_mandatory = None
    ignore_permissions = None
    self = <StockEntry: unsaved>
    set_child_names = True
    set_name = None
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 872, in _validate_links
    frappe.throw(_("Could not find {0}").format(msg), frappe.LinkValidationError)
    cancelled_links = []
    d = <StockEntryDetail: unsaved>
    invalid_links = [('material_request', '_T-Material Request-00008', 'Row #1: Material Request: _T-Material Request-00008'), ('material_request', '_T-Material Request-00008', 'Row #2: Material Request: _T-Material Request-00008')]
    msg = 'Row #1: Material Request: _T-Material Request-00008, Row #2: Material Request: _T-Material Request-00008'
    result = ([('material_request', '_T-Material Request-00008', 'Row #2: Material Request: _T-Material Request-00008')], [])
    self = <StockEntry: unsaved>
  File "/home/runner/frappe-bench/apps/frappe/frappe/__init__.py", line 521, in throw
    msgprint(
    as_list = False
    exc = <class 'frappe.exceptions.LinkValidationError'>
    is_minimizable = False
    msg = 'Could not find Row #1: Material Request: _T-Material Request-00008, Row #2: Material Request: _T-Material Request-00008'
    title = None
    wide = False
  File "/home/runner/frappe-bench/apps/frappe/frappe/__init__.py", line [489](https://github.com/frappe/erpnext/actions/runs/3370867079/jobs/5592319399#step:13:490), in msgprint
    _raise_exception()
    _raise_exception = <function msgprint.<locals>._raise_exception at 0x7facb80d8dc0>
    _strip_html_tags = <functools._lru_cache_wrapper object at 0x7facb7d24040>
    alert = False
    as_list = False
    as_table = False
    indicator = 'red'
    inspect = <module 'inspect' from '/opt/hostedtoolcache/Python/3.10.8/x64/lib/python3.10/inspect.py'>
    is_minimizable = False
    msg = 'Could not find Row #1: Material Request: _T-Material Request-00008, Row #2: Material Request: _T-Material Request-00008'
    out = {'message': 'Could not find Row #1: Material Request: _T-Material Request-00008, Row #2: Material Request: _T-Material Request-00008', 'title': 'Message', 'indicator': 'red', 'raise_exception': 1}
    primary_action = None
    raise_exception = <class 'frappe.exceptions.LinkValidationError'>
    strip_html_tags = <function strip_html_tags at 0x7facc028a560>
    sys = <module 'sys' (built-in)>
    title = None
    wide = False
  File "/home/runner/frappe-bench/apps/frappe/frappe/__init__.py", line 441, in _raise_exception
    raise raise_exception(msg)
    inspect = <module 'inspect' from '/opt/hostedtoolcache/Python/3.10.8/x64/lib/python3.10/inspect.py'>
    msg = 'Could not find Row #1: Material Request: _T-Material Request-00008, Row #2: Material Request: _T-Material Request-00008'
    raise_exception = <class 'frappe.exceptions.LinkValidationError'>
frappe.exceptions.LinkValidationError: Could not find Row #1: Material Request: _T-Material Request-00008, Row #2: Material Request: _T-Material Request-00008
```
