### PR TITLE
fix: Issues while cancel/amending Purchase Invoice with TDS enabled

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -569,6 +569,10 @@ frappe.ui.form.on("Purchase Invoice", {
 		erpnext.queries.setup_queries(frm, "Warehouse", function() {
 			return erpnext.queries.warehouse(frm.doc);
 		});
+
+		if (frm.is_new()) {
+			frm.clear_table("tax_withheld_vouchers");
+		}
 	},
 
 	is_subcontracted: function(frm) {

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -71,6 +71,9 @@ class PurchaseInvoice(BuyingController):
 		supplier_tds = frappe.db.get_value("Supplier", self.supplier, "tax_withholding_category")
 		self.set_onload("supplier_tds", supplier_tds)
 
+		if self.is_new():
+			self.set("tax_withheld_vouchers", [])
+
 	def before_save(self):
 		if not self.on_hold:
 			self.release_date = ""
@@ -1415,7 +1418,7 @@ class PurchaseInvoice(BuyingController):
 			"Stock Ledger Entry",
 			"Repost Item Valuation",
 			"Payment Ledger Entry",
-			"Purchase Invoice",
+			"Tax Withheld Vouchers",
 		)
 		self.update_advance_tax_references(cancel=1)
 


### PR DESCRIPTION
This [PR](https://github.com/frappe/erpnext/pull/32622) didn't fully fix the issue, a few loose ends were still left, but this PR fixes them all

- Ignore linked invoices while canceling any old invoice
- On amending, clear the `tax_withheld_voucher_table` to avoid canceled doc linking errors