### PR TITLE
perf: use `get_cached_value` instead of `db.get_value` in setup module

### DIFF
--- a/erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py
+++ b/erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py
@@ -169,7 +169,7 @@ def prepare_chart_data(suppliers, qty_list, supplier_qty_price_map):
 				data_points_map[qty].append(None)
 
 	dataset = []
-	currency_symbol = frappe.db.get_value("Currency", frappe.db.get_default("currency"), "symbol")
+	currency_symbol = frappe.get_cached_value("Currency", frappe.db.get_default("currency"), "symbol")
 	for qty in qty_list:
 		datapoints = {
 			"name": currency_symbol + " (Qty " + str(qty) + " )",

--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -100,7 +100,7 @@ class Company(NestedSet):
 
 		for account in accounts:
 			if self.get(account[1]):
-				for_company = frappe.db.get_value("Account", self.get(account[1]), "company")
+				for_company = frappe.get_cached_value("Account", self.get(account[1]), "company")
 				if for_company != self.name:
 					frappe.throw(
 						_("Account {0} does not belong to company: {1}").format(self.get(account[1]), self.name)
@@ -374,7 +374,7 @@ class Company(NestedSet):
 
 	def validate_parent_company(self):
 		if self.parent_company:
-			is_group = frappe.get_value("Company", self.parent_company, "is_group")
+			is_group = frappe.get_cached_value("Company", self.parent_company, "is_group")
 
 			if not is_group:
 				frappe.throw(_("Parent Company must be a group company"))
@@ -587,7 +587,7 @@ class Company(NestedSet):
 	def check_parent_changed(self):
 		frappe.flags.parent_company_changed = False
 
-		if not self.is_new() and self.parent_company != frappe.db.get_value(
+		if not self.is_new() and self.parent_company != frappe.get_cached_value(
 			"Company", self.name, "parent_company"
 		):
 			frappe.flags.parent_company_changed = True

--- a/erpnext/setup/doctype/customer_group/customer_group.py
+++ b/erpnext/setup/doctype/customer_group/customer_group.py
@@ -25,7 +25,7 @@ class CustomerGroup(NestedSet):
 
 
 def get_parent_customer_groups(customer_group):
-	lft, rgt = frappe.db.get_value("Customer Group", customer_group, ["lft", "rgt"])
+	lft, rgt = frappe.get_cached_value("Customer Group", customer_group, ["lft", "rgt"])
 
 	return frappe.db.sql(
 		"""select name from `tabCustomer Group`

--- a/erpnext/setup/doctype/email_digest/email_digest.py
+++ b/erpnext/setup/doctype/email_digest/email_digest.py
@@ -36,7 +36,7 @@ class EmailDigest(Document):
 		self.from_date, self.to_date = self.get_from_to_date()
 		self.set_dates()
 		self._accounts = {}
-		self.currency = frappe.db.get_value("Company", self.company, "default_currency")
+		self.currency = frappe.get_cached_value("Company", self.company, "default_currency")
 
 	@frappe.whitelist()
 	def get_users(self):

--- a/erpnext/setup/doctype/party_type/party_type.py
+++ b/erpnext/setup/doctype/party_type/party_type.py
@@ -15,7 +15,7 @@ class PartyType(Document):
 def get_party_type(doctype, txt, searchfield, start, page_len, filters):
 	cond = ""
 	if filters and filters.get("account"):
-		account_type = frappe.db.get_value("Account", filters.get("account"), "account_type")
+		account_type = frappe.get_cached_value("Account", filters.get("account"), "account_type")
 		cond = "and account_type = '%s'" % account_type
 
 	return frappe.db.sql(

--- a/erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py
+++ b/erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py
@@ -110,7 +110,7 @@ class TransactionDeletionRecord(Document):
 					self.delete_child_tables(docfield["parent"], docfield["fieldname"])
 					self.delete_docs_linked_with_specified_company(docfield["parent"], docfield["fieldname"])
 
-					naming_series = frappe.db.get_value("DocType", docfield["parent"], "autoname")
+					naming_series = frappe.get_cached_value("DocType", docfield["parent"], "autoname")
 					if naming_series:
 						if "#" in naming_series:
 							self.update_naming_series(naming_series, docfield["parent"])

--- a/erpnext/setup/setup_wizard/operations/taxes_setup.py
+++ b/erpnext/setup/setup_wizard/operations/taxes_setup.py
@@ -81,7 +81,7 @@ def simple_to_detailed(templates):
 
 def from_detailed_data(company_name, data):
 	"""Create Taxes and Charges Templates from detailed data."""
-	coa_name = frappe.db.get_value("Company", company_name, "chart_of_accounts")
+	coa_name = frappe.get_cached_value("Company", company_name, "chart_of_accounts")
 	coa_data = data.get("chart_of_accounts", {})
 	tax_templates = coa_data.get(coa_name) or coa_data.get("*", {})
 	tax_categories = data.get("tax_categories")
@@ -132,7 +132,7 @@ def make_taxes_and_charges_template(company_name, doctype, template):
 		tax_row_defaults = {
 			"category": "Total",
 			"charge_type": "On Net Total",
-			"cost_center": frappe.db.get_value("Company", company_name, "cost_center"),
+			"cost_center": frappe.get_cached_value("Company", company_name, "cost_center"),
 		}
 
 		if doctype == "Purchase Taxes and Charges Template":


### PR DESCRIPTION
Continues: #32836

Replaced `db.get_value` with `get_cached_value` in **setup** Module.

### Before
```
In [1]: %timeit doc.validate_default_accounts()
7.33 ms ± 61.7 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

### After
```
In [1]: %timeit doc.validate_default_accounts()
40.2 µs ± 3.78 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```