### PR TITLE
build: python 3.11 support

### DIFF
--- a/.github/workflows/server-tests-mariadb.yml
+++ b/.github/workflows/server-tests-mariadb.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.10'
+          python-version: '3.11'
 
       - name: Check for valid Python & Merge Conflicts
         run: |


### PR DESCRIPTION
closes https://github.com/frappe/erpnext/issues/32715 