### PR TITLE
fix: Auto advance allocation against partial invoices

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -804,15 +804,12 @@ class AccountsController(TransactionBase):
 		self.set("advances", [])
 		advance_allocated = 0
 		for d in res:
-			if d.against_order:
-				allocated_amount = flt(d.amount)
+			if self.get("party_account_currency") == self.company_currency:
+				amount = self.get("base_rounded_total") or self.base_grand_total
 			else:
-				if self.get("party_account_currency") == self.company_currency:
-					amount = self.get("base_rounded_total") or self.base_grand_total
-				else:
-					amount = self.get("rounded_total") or self.grand_total
+				amount = self.get("rounded_total") or self.grand_total
 
-				allocated_amount = min(amount - advance_allocated, d.amount)
+			allocated_amount = min(amount - advance_allocated, d.amount)
 			advance_allocated += flt(allocated_amount)
 
 			advance_row = {

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -1747,6 +1747,69 @@ class TestSalesOrder(FrappeTestCase):
 		sales_order.save()
 		self.assertEqual(sales_order.taxes[0].tax_amount, 0)
 
+	def test_sales_order_partial_advance_payment(self):
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import (
+			create_payment_entry,
+			get_payment_entry,
+		)
+		from erpnext.selling.doctype.customer.test_customer import get_customer_dict
+
+		# Make a customer
+		customer = get_customer_dict("QA Logistics")
+		frappe.get_doc(customer).insert()
+
+		# Make a Sales Order
+		so = make_sales_order(
+			customer="QA Logistics",
+			item_list=[
+				{"item_code": "_Test Item", "qty": 1, "rate": 200},
+				{"item_code": "_Test Item 2", "qty": 1, "rate": 300},
+			],
+		)
+
+		# Create a advance payment against that Sales Order
+		pe = get_payment_entry("Sales Order", so.name, bank_account="_Test Bank - _TC")
+		pe.reference_no = "1"
+		pe.reference_date = nowdate()
+		pe.paid_from_account_currency = so.currency
+		pe.paid_to_account_currency = so.currency
+		pe.source_exchange_rate = 1
+		pe.target_exchange_rate = 1
+		pe.paid_amount = so.grand_total
+		pe.save(ignore_permissions=True)
+		pe.submit()
+
+		# Make standalone advance payment entry
+		create_payment_entry(
+			payment_type="Receive",
+			party_type="Customer",
+			party="QA Logistics",
+			paid_from="Debtors - _TC",
+			paid_to="_Test Bank - _TC",
+			save=1,
+			submit=1,
+		)
+
+		si = make_sales_invoice(so.name)
+
+		item = si.get("items")[1]
+		si.remove(item)
+
+		si.allocate_advances_automatically = 1
+		si.save()
+
+		self.assertEqual(len(si.get("advances")), 1)
+		self.assertEqual(si.get("advances")[0].allocated_amount, 200)
+		self.assertEqual(si.get("advances")[0].reference_name, pe.name)
+
+		si.submit()
+		pe.load_from_db()
+
+		self.assertEqual(pe.references[0].reference_name, si.name)
+		self.assertEqual(pe.references[0].allocated_amount, 200)
+		self.assertEqual(pe.references[1].reference_name, so.name)
+		self.assertEqual(pe.references[1].allocated_amount, 300)
+
 
 def automatically_fetch_payment_terms(enable=1):
 	accounts_settings = frappe.get_doc("Accounts Settings")


### PR DESCRIPTION
Incorrect amount gets allocated in invoices while partially billing a Sales Order

Typical scenario when this is seen is
- User makes a Sales Order and makes an Advance Payment against it
- Make a standalone advance payment against the same customer
- Partially bill the created Sales Order

The advances allocated are incorrect

Before:
<img width="1337" alt="image" src="https://user-images.githubusercontent.com/42651287/199964969-e20c7f00-e355-4533-8f1a-a508b369aa0e.png">

After:
<img width="1313" alt="image" src="https://user-images.githubusercontent.com/42651287/199958599-1b5ce6b2-4cb6-4205-b112-46a5d7267017.png">
