### PR TITLE
fix: wrong consumed items in SCR return

### DIFF
--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -503,7 +503,7 @@ def make_return_doc(doctype: str, source_name: str, target_doc=None):
 			doctype
 			+ " Item": {
 				"doctype": doctype + " Item",
-				"field_map": {"serial_no": "serial_no", "batch_no": "batch_no"},
+				"field_map": {"serial_no": "serial_no", "batch_no": "batch_no", "bom": "bom"},
 				"postprocess": update_item,
 			},
 			"Payment Schedule": {"doctype": "Payment Schedule", "postprocess": update_terms},

--- a/erpnext/controllers/subcontracting_controller.py
+++ b/erpnext/controllers/subcontracting_controller.py
@@ -89,6 +89,9 @@ class SubcontractingController(StockController):
 				if bom.item != item.item_code:
 					msg = f"Please select an valid BOM for Item {item.item_name}."
 					frappe.throw(_(msg))
+			else:
+				msg = f"Please select a BOM for Item {item.item_name}."
+				frappe.throw(_(msg))
 
 	def __get_data_before_save(self):
 		item_dict = {}

--- a/erpnext/controllers/tests/test_subcontracting_controller.py
+++ b/erpnext/controllers/tests/test_subcontracting_controller.py
@@ -815,6 +815,7 @@ def add_second_row_in_scr(scr):
 		"item_name",
 		"qty",
 		"uom",
+		"bom",
 		"warehouse",
 		"stock_uom",
 		"subcontracting_order",

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
@@ -57,6 +57,7 @@ class SubcontractingReceipt(SubcontractingController):
 
 	def before_validate(self):
 		super(SubcontractingReceipt, self).before_validate()
+		self.set_items_bom()
 		self.set_items_cost_center()
 		self.set_items_expense_account()
 
@@ -192,6 +193,24 @@ class SubcontractingReceipt(SubcontractingController):
 						"Row {0}: Consumed Qty must be less than or equal to Available Qty For Consumption in Consumed Items Table."
 					).format(item.idx)
 				)
+
+	def set_items_bom(self):
+		if self.is_return:
+			for item in self.items:
+				if not item.bom:
+					item.bom = frappe.db.get_value(
+						"Subcontracting Receipt Item",
+						{"name": item.subcontracting_receipt_item, "parent": self.return_against},
+						"bom",
+					)
+		else:
+			for item in self.items:
+				if not item.bom:
+					item.bom = frappe.db.get_value(
+						"Subcontracting Order Item",
+						{"name": item.subcontracting_order_item, "parent": item.subcontracting_order},
+						"bom",
+					)
 
 	def set_items_cost_center(self):
 		if self.company:

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/test_subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/test_subcontracting_receipt.py
@@ -327,7 +327,7 @@ class TestSubcontractingReceipt(FrappeTestCase):
 		for row in scr.supplied_items:
 			self.assertEqual(transferred_batch.get(row.batch_no), row.consumed_qty)
 
-	def test_subcontracting_order_partial_return(self):
+	def test_subcontracting_receipt_partial_return(self):
 		sco = get_subcontracting_order()
 		rm_items = get_rm_items(sco.supplied_items)
 		itemwise_details = make_stock_in_entry(rm_items=rm_items)
@@ -351,7 +351,7 @@ class TestSubcontractingReceipt(FrappeTestCase):
 		self.assertEqual(scr1.status, "Return Issued")
 		self.assertEqual(scr1.items[0].returned_qty, 10)
 
-	def test_subcontracting_order_over_return(self):
+	def test_subcontracting_receipt_over_return(self):
 		sco = get_subcontracting_order()
 		rm_items = get_rm_items(sco.supplied_items)
 		itemwise_details = make_stock_in_entry(rm_items=rm_items)

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/test_subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/test_subcontracting_receipt.py
@@ -343,11 +343,13 @@ class TestSubcontractingReceipt(FrappeTestCase):
 		scr1_return = make_return_subcontracting_receipt(scr_name=scr1.name, qty=-3)
 		scr1.load_from_db()
 		self.assertEqual(scr1_return.status, "Return")
+		self.assertIsNotNone(scr1_return.items[0].bom)
 		self.assertEqual(scr1.items[0].returned_qty, 3)
 
 		scr2_return = make_return_subcontracting_receipt(scr_name=scr1.name, qty=-7)
 		scr1.load_from_db()
 		self.assertEqual(scr2_return.status, "Return")
+		self.assertIsNotNone(scr2_return.items[0].bom)
 		self.assertEqual(scr1.status, "Return Issued")
 		self.assertEqual(scr1.items[0].returned_qty, 10)
 

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/test_subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/test_subcontracting_receipt.py
@@ -404,8 +404,8 @@ class TestSubcontractingReceipt(FrappeTestCase):
 			"stock_value_difference",
 		)
 
-		# Service Cost(100 * 10) + Raw Materials Cost(50 * 10) + Additional Costs(100) = 1600
-		self.assertEqual(stock_value_difference, 1600)
+		# Service Cost(100 * 10) + Raw Materials Cost(100 * 10) + Additional Costs(10 * 10) = 2100
+		self.assertEqual(stock_value_difference, 2100)
 		self.assertFalse(get_gl_entries("Subcontracting Receipt", scr.name))
 
 	def test_subcontracting_receipt_gl_entry(self):


### PR DESCRIPTION
ref: ISS-22-23-03145

**Steps to reproduce:**

- Create FG Item and RM Items.
- Create more than one BOM for that FG Item with different RM Items.
- Create Subcontracted Purchase Order.
- Create Subcontracting Order against that Purchase Order.
- Create Subcontracting Receipt against that Subcontracting Order.
- Create Return Subcontracting Receipt against that Subcontracting Receipt.

Before:

[Screencast from 2022-11-05 16-26-28.webm](https://user-images.githubusercontent.com/63660334/200116552-f85064c8-b3e8-4863-a3b8-51a3b5001e74.webm)


After:

[Screencast from 2022-11-05 16-28-01.webm](https://user-images.githubusercontent.com/63660334/200116578-37df58f5-6995-48a3-953c-3934bb998977.webm)
