### PR TITLE
fix: incorrect buying amount on Gross Profit

### DIFF
--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -3,7 +3,8 @@
 
 
 import frappe
-from frappe import _, scrub
+from frappe import _, qb, scrub
+from frappe.query_builder import Order
 from frappe.utils import cint, flt, formatdate
 
 from erpnext.controllers.queries import get_match_cond
@@ -398,6 +399,7 @@ class GrossProfitGenerator(object):
 		self.average_buying_rate = {}
 		self.filters = frappe._dict(filters)
 		self.load_invoice_items()
+		self.get_delivery_notes()
 
 		if filters.group_by == "Invoice":
 			self.group_items_by_invoice()
@@ -591,6 +593,21 @@ class GrossProfitGenerator(object):
 
 		return flt(buying_amount, self.currency_precision)
 
+	def calculate_buying_amount_from_sle(self, row, my_sle, parenttype, parent, item_row, item_code):
+		for i, sle in enumerate(my_sle):
+			# find the stock valution rate from stock ledger entry
+			if (
+				sle.voucher_type == parenttype
+				and parent == sle.voucher_no
+				and sle.voucher_detail_no == item_row
+			):
+				previous_stock_value = len(my_sle) > i + 1 and flt(my_sle[i + 1].stock_value) or 0.0
+
+				if previous_stock_value:
+					return abs(previous_stock_value - flt(sle.stock_value)) * flt(row.qty) / abs(flt(sle.qty))
+				else:
+					return flt(row.qty) * self.get_average_buying_rate(row, item_code)
+
 	def get_buying_amount(self, row, item_code):
 		# IMP NOTE
 		# stock_ledger_entries should already be filtered by item_code and warehouse and
@@ -607,19 +624,22 @@ class GrossProfitGenerator(object):
 				if row.dn_detail:
 					parenttype, parent = "Delivery Note", row.delivery_note
 
-				for i, sle in enumerate(my_sle):
-					# find the stock valution rate from stock ledger entry
-					if (
-						sle.voucher_type == parenttype
-						and parent == sle.voucher_no
-						and sle.voucher_detail_no == row.item_row
-					):
-						previous_stock_value = len(my_sle) > i + 1 and flt(my_sle[i + 1].stock_value) or 0.0
-
-						if previous_stock_value:
-							return abs(previous_stock_value - flt(sle.stock_value)) * flt(row.qty) / abs(flt(sle.qty))
-						else:
-							return flt(row.qty) * self.get_average_buying_rate(row, item_code)
+				return self.calculate_buying_amount_from_sle(
+					row, my_sle, parenttype, parent, row.item_row, item_code
+				)
+			elif self.delivery_notes.get((row.parent, row.item_code), None):
+				#  check if Invoice has delivery notes
+				dn = self.delivery_notes.get((row.parent, row.item_code))
+				parenttype, parent, item_row, warehouse = (
+					"Delivery Note",
+					dn["delivery_note"],
+					dn["item_row"],
+					dn["warehouse"],
+				)
+				my_sle = self.sle.get((item_code, warehouse))
+				return self.calculate_buying_amount_from_sle(
+					row, my_sle, parenttype, parent, item_row, item_code
+				)
 			else:
 				return flt(row.qty) * self.get_average_buying_rate(row, item_code)
 
@@ -752,6 +772,29 @@ class GrossProfitGenerator(object):
 			self.filters,
 			as_dict=1,
 		)
+
+	def get_delivery_notes(self):
+		self.delivery_notes = frappe._dict({})
+		if self.si_list:
+			invoices = [x.parent for x in self.si_list]
+			dni = qb.DocType("Delivery Note Item")
+			delivery_notes = (
+				qb.from_(dni)
+				.select(
+					dni.against_sales_invoice.as_("sales_invoice"),
+					dni.item_code,
+					dni.warehouse,
+					dni.parent.as_("delivery_note"),
+					dni.name.as_("item_row"),
+				)
+				.where((dni.docstatus == 1) & (dni.against_sales_invoice.isin(invoices)))
+				.groupby(dni.against_sales_invoice, dni.item_code)
+				.orderby(dni.creation, order=Order.desc)
+				.run(as_dict=True)
+			)
+
+			for entry in delivery_notes:
+				self.delivery_notes[(entry.sales_invoice, entry.item_code)] = entry
 
 	def group_items_by_invoice(self):
 		"""

--- a/erpnext/accounts/report/gross_profit/test_gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/test_gross_profit.py
@@ -1,0 +1,209 @@
+import frappe
+from frappe import qb
+from frappe.tests.utils import FrappeTestCase
+from frappe.utils import add_days, flt, nowdate
+
+from erpnext.accounts.doctype.sales_invoice.sales_invoice import make_delivery_note
+from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
+from erpnext.accounts.report.gross_profit.gross_profit import execute
+from erpnext.stock.doctype.item.test_item import create_item
+from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
+
+
+class TestGrossProfit(FrappeTestCase):
+	def setUp(self):
+		self.create_company()
+		self.create_item()
+		self.create_customer()
+		self.create_sales_invoice()
+		self.clear_old_entries()
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def create_company(self):
+		company_name = "_Test Gross Profit"
+		abbr = "_GP"
+		if frappe.db.exists("Company", company_name):
+			company = frappe.get_doc("Company", company_name)
+		else:
+			company = frappe.get_doc(
+				{
+					"doctype": "Company",
+					"company_name": company_name,
+					"country": "India",
+					"default_currency": "INR",
+					"create_chart_of_accounts_based_on": "Standard Template",
+					"chart_of_accounts": "Standard",
+				}
+			)
+			company = company.save()
+
+		self.company = company.name
+		self.cost_center = company.cost_center
+		self.warehouse = "Stores - " + abbr
+		self.income_account = "Sales - " + abbr
+		self.expense_account = "Cost of Goods Sold - " + abbr
+		self.debit_to = "Debtors - " + abbr
+		self.creditors = "Creditors - " + abbr
+
+	def create_item(self):
+		item = create_item(
+			item_code="_Test GP Item", is_stock_item=1, company=self.company, warehouse=self.warehouse
+		)
+		self.item = item if isinstance(item, str) else item.item_code
+
+	def create_customer(self):
+		name = "_Test GP Customer"
+		if frappe.db.exists("Customer", name):
+			self.customer = name
+		else:
+			customer = frappe.new_doc("Customer")
+			customer.customer_name = name
+			customer.type = "Individual"
+			customer.save()
+			self.customer = customer.name
+
+	def create_sales_invoice(
+		self, qty=1, rate=100, posting_date=nowdate(), do_not_save=False, do_not_submit=False
+	):
+		"""
+		Helper function to populate default values in sales invoice
+		"""
+		sinv = create_sales_invoice(
+			qty=qty,
+			rate=rate,
+			company=self.company,
+			customer=self.customer,
+			item_code=self.item,
+			item_name=self.item,
+			cost_center=self.cost_center,
+			warehouse=self.warehouse,
+			debit_to=self.debit_to,
+			parent_cost_center=self.cost_center,
+			update_stock=0,
+			currency="INR",
+			is_pos=0,
+			is_return=0,
+			return_against=None,
+			income_account=self.income_account,
+			expense_account=self.expense_account,
+			do_not_save=do_not_save,
+			do_not_submit=do_not_submit,
+		)
+		return sinv
+
+	def clear_old_entries(self):
+		doctype_list = [
+			"Sales Invoice",
+			"GL Entry",
+			"Payment Ledger Entry",
+			"Stock Entry",
+			"Stock Ledger Entry",
+			"Delivery Note",
+		]
+		for doctype in doctype_list:
+			qb.from_(qb.DocType(doctype)).delete().where(qb.DocType(doctype).company == self.company).run()
+
+	def test_invoice_without_only_delivery_note(self):
+		"""
+		Test buying amount for Invoice without `update_stock` flag set but has Delivery Note
+		"""
+		se = make_stock_entry(
+			company=self.company,
+			item_code=self.item,
+			target=self.warehouse,
+			qty=1,
+			basic_rate=100,
+			do_not_submit=True,
+		)
+		item = se.items[0]
+		se.append(
+			"items",
+			{
+				"item_code": item.item_code,
+				"s_warehouse": item.s_warehouse,
+				"t_warehouse": item.t_warehouse,
+				"qty": 1,
+				"basic_rate": 200,
+				"conversion_factor": item.conversion_factor or 1.0,
+				"transfer_qty": flt(item.qty) * (flt(item.conversion_factor) or 1.0),
+				"serial_no": item.serial_no,
+				"batch_no": item.batch_no,
+				"cost_center": item.cost_center,
+				"expense_account": item.expense_account,
+			},
+		)
+		se = se.save().submit()
+
+		sinv = create_sales_invoice(
+			qty=1,
+			rate=100,
+			company=self.company,
+			customer=self.customer,
+			item_code=self.item,
+			item_name=self.item,
+			cost_center=self.cost_center,
+			warehouse=self.warehouse,
+			debit_to=self.debit_to,
+			parent_cost_center=self.cost_center,
+			update_stock=0,
+			currency="INR",
+			income_account=self.income_account,
+			expense_account=self.expense_account,
+		)
+
+		filters = frappe._dict(
+			company=self.company, from_date=nowdate(), to_date=nowdate(), group_by="Invoice"
+		)
+
+		columns, data = execute(filters=filters)
+
+		# Without Delivery Note, buying rate should be 150
+		expected_entry_without_dn = {
+			"parent_invoice": sinv.name,
+			"currency": "INR",
+			"sales_invoice": self.item,
+			"customer": self.customer,
+			"posting_date": frappe.utils.datetime.date.fromisoformat(nowdate()),
+			"item_code": self.item,
+			"item_name": self.item,
+			"warehouse": "Stores - _GP",
+			"qty": 1.0,
+			"avg._selling_rate": 100.0,
+			"valuation_rate": 150.0,
+			"selling_amount": 100.0,
+			"buying_amount": 150.0,
+			"gross_profit": -50.0,
+			"gross_profit_%": -50.0,
+		}
+		gp_entry = [x for x in data if x.parent_invoice == sinv.name]
+		self.assertDictContainsSubset(expected_entry_without_dn, gp_entry[0])
+
+		# make delivery note
+		dn = make_delivery_note(sinv.name)
+		dn.items[0].qty = 1
+		dn = dn.save().submit()
+
+		columns, data = execute(filters=filters)
+
+		# Without Delivery Note, buying rate should be 100
+		expected_entry_with_dn = {
+			"parent_invoice": sinv.name,
+			"currency": "INR",
+			"sales_invoice": self.item,
+			"customer": self.customer,
+			"posting_date": frappe.utils.datetime.date.fromisoformat(nowdate()),
+			"item_code": self.item,
+			"item_name": self.item,
+			"warehouse": "Stores - _GP",
+			"qty": 1.0,
+			"avg._selling_rate": 100.0,
+			"valuation_rate": 100.0,
+			"selling_amount": 100.0,
+			"buying_amount": 100.0,
+			"gross_profit": 0.0,
+			"gross_profit_%": 0.0,
+		}
+		gp_entry = [x for x in data if x.parent_invoice == sinv.name]
+		self.assertDictContainsSubset(expected_entry_with_dn, gp_entry[0])


### PR DESCRIPTION
Incorrect buying amount for Invoices(`update_stock` unchecked and no `warehouse`) but has Delivery Notes.

Steps:
1. Create `Material Receipt` with same item for 2 different rates 
<img width="1440" alt="Screenshot 2022-11-08 at 7 51 48 AM" src="https://user-images.githubusercontent.com/3272205/200460317-dd530d6f-67ca-4f16-90b5-0a07bb1fc780.png">

2. Make Sales Invoice for one Item without updating the stock 
<img width="1440" alt="Screenshot 2022-11-08 at 7 50 30 AM" src="https://user-images.githubusercontent.com/3272205/200460342-5942e98f-9b48-46f1-ac45-f5500bab2f0b.png">

3. Make Delivery Note for [2] 
<img width="1440" alt="Screenshot 2022-11-08 at 7 50 40 AM" src="https://user-images.githubusercontent.com/3272205/200460366-a335974e-6360-4469-ac99-c3b092577060.png">


Before:
Buying amount: 150(taken as average of last transaction)
<img width="1440" alt="Screenshot 2022-11-08 at 7 54 15 AM" src="https://user-images.githubusercontent.com/3272205/200460384-b7916ae4-a1b2-4a7d-b639-ca0e417b893a.png">

After:
Buying amount: 100
<img width="1440" alt="Screenshot 2022-11-08 at 7 54 43 AM" src="https://user-images.githubusercontent.com/3272205/200460402-ca1dbf4e-5376-4357-8770-8ffc52cce8d8.png">


fixes: #31786, #27297, #27400