### PR TITLE
fix: get `consumed_qty` based on `received_qty` in SCR

### DIFF
--- a/erpnext/controllers/subcontracting_controller.py
+++ b/erpnext/controllers/subcontracting_controller.py
@@ -100,7 +100,7 @@ class SubcontractingController(StockController):
 			and self._doc_before_save
 		):
 			for row in self._doc_before_save.get("items"):
-				item_dict[row.name] = (row.item_code, row.qty)
+				item_dict[row.name] = (row.item_code, row.received_qty or row.qty)
 
 		return item_dict
 
@@ -118,7 +118,9 @@ class SubcontractingController(StockController):
 
 		for row in self.items:
 			self.__reference_name.append(row.name)
-			if (row.name not in item_dict) or (row.item_code, row.qty) != item_dict[row.name]:
+			if (row.name not in item_dict) or (row.item_code, row.received_qty or row.qty) != item_dict[
+				row.name
+			]:
 				self.__changed_name.append(row.name)
 
 			if item_dict.get(row.name):
@@ -461,12 +463,13 @@ class SubcontractingController(StockController):
 
 	def __get_qty_based_on_material_transfer(self, item_row, transfer_item):
 		key = (item_row.item_code, item_row.get(self.subcontract_data.order_field))
+		item_qty = item_row.received_qty or item_row.qty
 
-		if self.qty_to_be_received == item_row.qty:
+		if self.qty_to_be_received.get(key) == item_qty:
 			return transfer_item.qty
 
 		if self.qty_to_be_received:
-			qty = (flt(item_row.qty) * flt(transfer_item.qty)) / flt(self.qty_to_be_received.get(key, 0))
+			qty = (flt(item_qty) * flt(transfer_item.qty)) / flt(self.qty_to_be_received.get(key, 0))
 			transfer_item.item_details.required_qty = transfer_item.qty
 
 			if transfer_item.serial_no or frappe.get_cached_value(
@@ -491,7 +494,11 @@ class SubcontractingController(StockController):
 				for bom_item in self.__get_materials_from_bom(
 					row.item_code, row.bom, row.get("include_exploded_items")
 				):
-					qty = flt(bom_item.qty_consumed_per_unit) * flt(row.qty) * row.conversion_factor
+					qty = (
+						flt(bom_item.qty_consumed_per_unit)
+						* flt(row.received_qty or row.qty)
+						* row.conversion_factor
+					)
 					bom_item.main_item_code = row.item_code
 					self.__update_reserve_warehouse(bom_item, row)
 					self.__set_alternative_item(bom_item)

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
@@ -58,6 +58,7 @@ class SubcontractingReceipt(SubcontractingController):
 	def before_validate(self):
 		super(SubcontractingReceipt, self).before_validate()
 		self.set_items_bom()
+		self.set_received_qty()
 		self.set_items_cost_center()
 		self.set_items_expense_account()
 
@@ -211,6 +212,10 @@ class SubcontractingReceipt(SubcontractingController):
 						{"name": item.subcontracting_order_item, "parent": item.subcontracting_order},
 						"bom",
 					)
+
+	def set_received_qty(self):
+		for item in self.items:
+			item.received_qty = flt(item.qty) + flt(item.rejected_qty)
 
 	def set_items_cost_center(self):
 		if self.company:


### PR DESCRIPTION
**ref:** ISS-22-23-03098

**Steps to reproduce:**

- Create a Subcontracted Purchase Order.
- Create a Subcontracting Order against that Purchase Order.
- Create a Subcontracting Receipt against that Subcontracting Order (Set the Rejected Qty).

**_Problem:_**
The system ignores the **Rejected Qty** while getting the Supplied Item **Consumed Qty**. 

**_Before:_**

[Screencast from 2022-11-06 15-03-34.webm](https://user-images.githubusercontent.com/63660334/200163775-4deda049-25ef-4a70-b762-4f08262030fc.webm)

**_After:_**

[Screencast from 2022-11-06 15-04-15.webm](https://user-images.githubusercontent.com/63660334/200163781-6d8eaddc-9700-4f86-9c65-0a3ed3118d54.webm)
