### PR TITLE
fix: Increase columns width in Warehouse wise Item Balance Age and Value

### DIFF
--- a/erpnext/stock/report/warehouse_wise_item_balance_age_and_value/warehouse_wise_item_balance_age_and_value.py
+++ b/erpnext/stock/report/warehouse_wise_item_balance_age_and_value/warehouse_wise_item_balance_age_and_value.py
@@ -91,8 +91,8 @@ def get_columns(filters):
 	columns = [
 		_("Item") + ":Link/Item:180",
 		_("Item Group") + "::100",
-		_("Value") + ":Currency:100",
-		_("Age") + ":Float:60",
+		_("Value") + ":Currency:120",
+		_("Age") + ":Float:80",
 	]
 	return columns
 
@@ -123,7 +123,7 @@ def get_warehouse_list(filters):
 
 def add_warehouse_column(columns, warehouse_list):
 	if len(warehouse_list) > 1:
-		columns += [_("Total Qty") + ":Int:50"]
+		columns += [_("Total Qty") + ":Int:90"]
 
 	for wh in warehouse_list:
-		columns += [_(wh.name) + ":Int:54"]
+		columns += [_(wh.name) + ":Int:120"]


### PR DESCRIPTION
**Version**

ERPNext: v14.5.1 (version-14)
Frappe Framework: v14.14.2 (version-14)
___
Issue: #32818
___
**Before:** 
- The column's width does not correctly set as the column's title name. If you increase the column for some time after then reload the system then happens to reset the column's width size and set it again manually.

![image](https://user-images.githubusercontent.com/34390782/200240531-bf673b99-333e-4310-9f2a-71c0c0258c86.png)

**After:**
- When entering the report then will at least show starting title of the column of the warehouse. 
- Also set the increase in the columns width of Value, Age, and Total Qty.

![image](https://user-images.githubusercontent.com/34390782/200241368-857ccecb-79f9-41be-8ef7-180eb0656e47.png)

Thank You!