### PR TITLE
fix: add Document Date in E-Invoice print format

### DIFF
--- a/erpnext/accounts/print_format/gst_e_invoice/gst_e_invoice.html
+++ b/erpnext/accounts/print_format/gst_e_invoice/gst_e_invoice.html
@@ -50,6 +50,10 @@
 				<div class="col-xs-4"><label>Document No</label></div>
 				<div class="col-xs-8 value">{{ einvoice.DocDtls.No }}</div>
 			</div>
+			<div class="row data-field">
+				<div class="col-xs-4"><label>Document Date</label></div>
+				<div class="col-xs-8 value">{{ einvoice.DocDtls.Dt }}</div>
+			</div>
 		</div>
 		<div class="col-xs-4 column-break">
 			<img src="{{ doc.qrcode_image }}" width="175px" style="float: right;">


### PR DESCRIPTION
Added Document Date in GST E-Invoice print format.

<img width="735" alt="E Invoice document date" src="https://user-images.githubusercontent.com/39730881/200551013-4a26cf34-3152-4d26-9fd2-d2090cb5c98b.png">
