### PR TITLE
fix: set stock UOM in args to ensure item price is fetched

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -330,6 +330,9 @@ def get_basic_details(args, item, overwrite_warehouse=True):
 		else:
 			args.uom = item.stock_uom
 
+	# Set stock UOM in args, so that it can be used while fetching item price
+	args.stock_uom = item.stock_uom
+
 	if args.get("batch_no") and item.name != frappe.get_cached_value(
 		"Batch", args.get("batch_no"), "item"
 	):


### PR DESCRIPTION
## Issue

If the following the conditions are satisfied, item price was not fetched earlier.

- the default Stock UOM is the items table is not the same as the Default Stock UOM for the selected item
- Item price is saved in stock UOM and converted to sales UOM

## Screen GIFs

### Before

![before item price fix](https://user-images.githubusercontent.com/16315650/200842711-eb78e0f2-c6ed-4ff0-94f7-97a02b949d34.gif)


### After

![after item price fix](https://user-images.githubusercontent.com/16315650/200842732-25d5b495-aa5a-47f7-bb0c-1a44f5e924dc.gif)
