### PR TITLE
fix: ambiguous 'cost_center' while using payment reconciliation

### DIFF
--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
@@ -47,6 +47,10 @@ class PaymentReconciliation(Document):
 	def get_payment_entries(self):
 		order_doctype = "Sales Order" if self.party_type == "Customer" else "Purchase Order"
 		condition = self.get_conditions(get_payments=True)
+
+		if self.get("cost_center"):
+			condition += " and cost_center = '{0}' ".format(self.cost_center)
+
 		payment_entries = get_advance_payment_entries(
 			self.party_type,
 			self.party,
@@ -61,6 +65,10 @@ class PaymentReconciliation(Document):
 
 	def get_jv_entries(self):
 		condition = self.get_conditions()
+
+		if self.get("cost_center"):
+			condition += " and t2.cost_center = '{0}' ".format(self.cost_center)
+
 		dr_or_cr = (
 			"credit_in_account_currency"
 			if erpnext.get_party_account_type(self.party_type) == "Receivable"
@@ -113,6 +121,10 @@ class PaymentReconciliation(Document):
 
 	def get_dr_or_cr_notes(self):
 		condition = self.get_conditions(get_return_invoices=True)
+
+		if self.get("cost_center"):
+			condition += " and doc.cost_center = '{0}' ".format(self.cost_center)
+
 		dr_or_cr = (
 			"credit_in_account_currency"
 			if erpnext.get_party_account_type(self.party_type) == "Receivable"
@@ -171,6 +183,9 @@ class PaymentReconciliation(Document):
 		# Fetch JVs, Sales and Purchase Invoices for 'invoices' to reconcile against
 
 		condition = self.get_conditions(get_invoices=True)
+
+		if self.get("cost_center"):
+			condition += " and cost_center = '{0}' ".format(self.cost_center)
 
 		non_reconciled_invoices = get_outstanding_invoices(
 			self.party_type, self.party, self.receivable_payable_account, condition=condition
@@ -356,9 +371,6 @@ class PaymentReconciliation(Document):
 
 	def get_conditions(self, get_invoices=False, get_payments=False, get_return_invoices=False):
 		condition = " and company = '{0}' ".format(self.company)
-
-		if self.get("cost_center"):
-			condition = " and cost_center = '{0}' ".format(self.cost_center)
 
 		if get_invoices:
 			condition += (


### PR DESCRIPTION
Steps to replicate:
1. Customize `Journal Entry` and create a new field `cost_center`
2. Open Payment Reconciliation tool
3. Apply Filter on `Cost Center` and trigger `Get Unreconciled Entries`
<img width="1307" alt="Screenshot 2022-11-11 at 10 01 17 AM" src="https://user-images.githubusercontent.com/3272205/201266943-22a45f3b-25fb-4986-aaeb-a7ad478e919c.png">


Maybe a Validation must be added in the Framework to restrict creation of custom fields with same name as standard. Should apply recusively on child tables as well.