### PR TITLE
fix: link `Item Price` brand to `Brand` doctype.

### DIFF
--- a/erpnext/stock/doctype/item_price/item_price.json
+++ b/erpnext/stock/doctype/item_price/item_price.json
@@ -1,6 +1,7 @@
 {
  "actions": [],
  "allow_import": 1,
+ "autoname": "hash",
  "creation": "2013-05-02 16:29:48",
  "description": "Multiple Item prices.",
  "doctype": "DocType",
@@ -219,10 +220,11 @@
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-11-14 17:26:49.052007",
+ "modified": "2022-11-15 08:26:04.041861",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Item Price",
+ "naming_rule": "Random",
  "owner": "Administrator",
  "permissions": [
   {

--- a/erpnext/stock/doctype/item_price/item_price.json
+++ b/erpnext/stock/doctype/item_price/item_price.json
@@ -77,9 +77,10 @@
   {
    "fetch_from": "item_code.brand",
    "fieldname": "brand",
-   "fieldtype": "Read Only",
+   "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Brand",
+   "options": "Brand",
    "read_only": 1
   },
   {
@@ -218,11 +219,10 @@
  "idx": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2022-09-02 16:33:55.612992",
+ "modified": "2022-11-14 17:26:49.052007",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Item Price",
- "name_case": "Title Case",
  "owner": "Administrator",
  "permissions": [
   {


### PR DESCRIPTION
If there are item price records assigned a brand, and that brand gets renamed. The brand shown in the item price will remain outdated.

Changing the brand field from Read Only to Link will force the item price brand to be updated to the renamed brand.