### PR TITLE
fix: Write Off section visibility for non POS Invoices

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
@@ -2098,7 +2098,7 @@
   {
    "collapsible": 1,
    "collapsible_depends_on": "write_off_amount",
-   "depends_on": "grand_total",
+   "depends_on": "is_pos",
    "fieldname": "write_off_section",
    "fieldtype": "Section Break",
    "hide_days": 1,
@@ -2126,7 +2126,7 @@
    "link_fieldname": "consolidated_invoice"
   }
  ],
- "modified": "2022-11-07 16:02:07.972258",
+ "modified": "2022-11-15 09:33:47.870616",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice",

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -1393,7 +1393,11 @@ class SalesInvoice(SellingController):
 
 	def make_write_off_gl_entry(self, gl_entries):
 		# write off entries, applicable if only pos
-		if self.write_off_account and flt(self.write_off_amount, self.precision("write_off_amount")):
+		if (
+			self.is_pos
+			and self.write_off_account
+			and flt(self.write_off_amount, self.precision("write_off_amount"))
+		):
 			write_off_account_currency = get_account_currency(self.write_off_account)
 			default_cost_center = frappe.get_cached_value("Company", self.company, "cost_center")
 


### PR DESCRIPTION
Fixes: https://github.com/frappe/erpnext/issues/23068

Write off section is intended only for POS invoices as there is no separate payment entry made and the write-off has to be handled within the sales invoice itself.

Currently, it is also visible for nonpos invoices which should not be the case as write off for them should be handled in payment entries and not the invoices.

Adding write off to non-pos invoices leads to incorrect outstanding amount updates on posting GL Entries