### PR TITLE
fix: Validate for deferred revenue only if sales invoice needs repost

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -571,13 +571,14 @@ class SalesInvoice(SellingController):
 
 			# validate if deferred revenue is enabled for any item
 			# Don't allow to update the invoice if deferred revenue is enabled
-			for item in self.get("items"):
-				if item.enable_deferred_revenue:
-					frappe.throw(
-						_(
-							"Deferred Revenue is enabled for item {0}. You cannot update the invoice after submission."
-						).format(item.item_code)
-					)
+			if needs_repost:
+				for item in self.get("items"):
+					if item.enable_deferred_revenue:
+						frappe.throw(
+							_(
+								"Deferred Revenue is enabled for item {0}. You cannot update the invoice after submission."
+							).format(item.item_code)
+						)
 
 			self.db_set("repost_required", needs_repost)
 


### PR DESCRIPTION
Issue: Deferred Revenue validation was appearing on updating any field on the sales invoice after submission, which should be checked only if the invoice needs reposting.