### PR TITLE
fix: precision in asset tests

### DIFF
--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -230,9 +230,22 @@ class TestAsset(AssetSetup):
 		self.assertTrue(asset.journal_entry_for_scrap)
 
 		expected_gle = (
-			("_Test Accumulated Depreciations - _TC", 18000.0 + pro_rata_amount, 0.0),
-			("_Test Fixed Asset - _TC", 0.0, 100000.0),
-			("_Test Gain/Loss on Asset Disposal - _TC", 82000.0 - pro_rata_amount, 0.0),
+			(
+				"_Test Accumulated Depreciations - _TC",
+				flt(18000.0 + pro_rata_amount, asset.precision("gross_purchase_amount")),
+				0.0
+			),
+			(
+				"_Test Fixed Asset - _TC",
+				0.0,
+				100000.0
+			),
+			(
+				"_Test Gain/Loss on Asset Disposal - _TC",
+				flt(82000.0 - pro_rata_amount, asset.precision("gross_purchase_amount")),
+				0.0
+			),
+			
 		)
 
 		gle = frappe.db.sql(
@@ -288,10 +301,26 @@ class TestAsset(AssetSetup):
 		pro_rata_amount = flt(pro_rata_amount, asset.precision("gross_purchase_amount"))
 
 		expected_gle = (
-			("_Test Accumulated Depreciations - _TC", 18000.0 + pro_rata_amount, 0.0),
-			("_Test Fixed Asset - _TC", 0.0, 100000.0),
-			("_Test Gain/Loss on Asset Disposal - _TC", 57000.0 - pro_rata_amount, 0.0),
-			("Debtors - _TC", 25000.0, 0.0),
+			(
+				"_Test Accumulated Depreciations - _TC",
+				flt(18000.0 + pro_rata_amount, asset.precision("gross_purchase_amount"))
+				0.0
+			),
+			(
+				"_Test Fixed Asset - _TC",
+				0.0,
+				100000.0
+			),
+			(
+				"_Test Gain/Loss on Asset Disposal - _TC",
+				flt(57000.0 - pro_rata_amount, asset.precision("gross_purchase_amount"))
+				0.0
+			),
+			(
+				"Debtors - _TC",
+				25000.0,
+				0.0
+			),
 		)
 
 		gle = frappe.db.sql(

--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -233,19 +233,14 @@ class TestAsset(AssetSetup):
 			(
 				"_Test Accumulated Depreciations - _TC",
 				flt(18000.0 + pro_rata_amount, asset.precision("gross_purchase_amount")),
-				0.0
-			),
-			(
-				"_Test Fixed Asset - _TC",
 				0.0,
-				100000.0
 			),
+			("_Test Fixed Asset - _TC", 0.0, 100000.0),
 			(
 				"_Test Gain/Loss on Asset Disposal - _TC",
 				flt(82000.0 - pro_rata_amount, asset.precision("gross_purchase_amount")),
-				0.0
+				0.0,
 			),
-			
 		)
 
 		gle = frappe.db.sql(
@@ -303,24 +298,16 @@ class TestAsset(AssetSetup):
 		expected_gle = (
 			(
 				"_Test Accumulated Depreciations - _TC",
-				flt(18000.0 + pro_rata_amount, asset.precision("gross_purchase_amount"))
-				0.0
-			),
-			(
-				"_Test Fixed Asset - _TC",
+				flt(18000.0 + pro_rata_amount, asset.precision("gross_purchase_amount")),
 				0.0,
-				100000.0
 			),
+			("_Test Fixed Asset - _TC", 0.0, 100000.0),
 			(
 				"_Test Gain/Loss on Asset Disposal - _TC",
-				flt(57000.0 - pro_rata_amount, asset.precision("gross_purchase_amount"))
-				0.0
+				flt(57000.0 - pro_rata_amount, asset.precision("gross_purchase_amount")),
+				0.0,
 			),
-			(
-				"Debtors - _TC",
-				25000.0,
-				0.0
-			),
+			("Debtors - _TC", 25000.0, 0.0),
 		)
 
 		gle = frappe.db.sql(


### PR DESCRIPTION
This is to fix the failing `test_gle_made_by_asset_sale` test due to incorrect precision [here](https://github.com/frappe/erpnext/blob/65e855bfff6b0e2ca935c3f81a907ad9b6eb7e2d/erpnext/assets/doctype/asset/test_asset.py#L304).

```
-  ('_Test Gain/Loss on Asset Disposal - _TC', 52064.52, 0.0),
+  ('_Test Gain/Loss on Asset Disposal - _TC', 52064.520000000004, 0.0),
```