### PR TITLE
fix: validate repost item valuation against accounts freeze date

### DIFF
--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
@@ -37,8 +37,9 @@ class RepostItemValuation(Document):
 		if not acc_settings.acc_frozen_upto:
 			return
 		if getdate(self.posting_date) <= getdate(acc_settings.acc_frozen_upto):
-			if acc_settings.frozen_accounts_modifier and frappe.session.user in get_users_with_role(
+			if (
 				acc_settings.frozen_accounts_modifier
+				and frappe.session.user in get_users_with_role(acc_settings.frozen_accounts_modifier)
 			):
 				frappe.msgprint(_("Caution: This might alter frozen accounts."))
 				return

--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
@@ -29,17 +29,21 @@ class RepostItemValuation(Document):
 
 	def validate_accounts_freeze(self):
 		acc_settings = frappe.db.get_value(
-			'Accounts Settings',
-			'Accounts Settings',
-			['acc_frozen_upto', 'frozen_accounts_modifier'],
-			as_dict=1
+			"Accounts Settings",
+			"Accounts Settings",
+			["acc_frozen_upto", "frozen_accounts_modifier"],
+			as_dict=1,
 		)
 		if not acc_settings.acc_frozen_upto:
 			return
-		if acc_settings.frozen_accounts_modifier and self.owner in get_users_with_role(acc_settings.frozen_accounts_modifier):
+		if acc_settings.frozen_accounts_modifier and self.owner in get_users_with_role(
+			acc_settings.frozen_accounts_modifier
+		):
 			return
 		if getdate(self.posting_date) <= getdate(acc_settings.acc_frozen_upto):
-			frappe.throw(_("You cannot repost item valuation before {}").format(acc_settings.acc_frozen_upto))
+			frappe.throw(
+				_("You cannot repost item valuation before {}").format(acc_settings.acc_frozen_upto)
+			)
 
 	def reset_field_values(self):
 		if self.based_on == "Transaction":

--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
@@ -5,7 +5,7 @@ import frappe
 from frappe import _
 from frappe.exceptions import QueryDeadlockError, QueryTimeoutError
 from frappe.model.document import Document
-from frappe.utils import cint, get_link_to_form, get_weekday, now, nowtime
+from frappe.utils import cint, get_link_to_form, get_weekday, getdate, now, nowtime
 from frappe.utils.user import get_users_with_role
 from rq.timeouts import JobTimeoutException
 
@@ -25,6 +25,21 @@ class RepostItemValuation(Document):
 		self.set_status(write=False)
 		self.reset_field_values()
 		self.set_company()
+		self.validate_accounts_freeze()
+
+	def validate_accounts_freeze(self):
+		acc_settings = frappe.db.get_value(
+			'Accounts Settings',
+			'Accounts Settings',
+			['acc_frozen_upto', 'frozen_accounts_modifier'],
+			as_dict=1
+		)
+		if not acc_settings.acc_frozen_upto:
+			return
+		if acc_settings.frozen_accounts_modifier and self.owner in get_users_with_role(acc_settings.frozen_accounts_modifier):
+			return
+		if getdate(self.posting_date) <= getdate(acc_settings.acc_frozen_upto):
+			frappe.throw(_("You cannot repost item valuation before {}").format(acc_settings.acc_frozen_upto))
 
 	def reset_field_values(self):
 		if self.based_on == "Transaction":
@@ -240,7 +255,7 @@ def _get_directly_dependent_vouchers(doc):
 def notify_error_to_stock_managers(doc, traceback):
 	recipients = get_users_with_role("Stock Manager")
 	if not recipients:
-		get_users_with_role("System Manager")
+		recipients = get_users_with_role("System Manager")
 
 	subject = _("Error while reposting item valuation")
 	message = (

--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
@@ -36,11 +36,12 @@ class RepostItemValuation(Document):
 		)
 		if not acc_settings.acc_frozen_upto:
 			return
-		if acc_settings.frozen_accounts_modifier and self.owner in get_users_with_role(
-			acc_settings.frozen_accounts_modifier
-		):
-			return
 		if getdate(self.posting_date) <= getdate(acc_settings.acc_frozen_upto):
+			if acc_settings.frozen_accounts_modifier and frappe.session.user in get_users_with_role(
+				acc_settings.frozen_accounts_modifier
+			):
+				frappe.msgprint(_("Caution: This might alter frozen accounts."))
+				return
 			frappe.throw(
 				_("You cannot repost item valuation before {}").format(acc_settings.acc_frozen_upto)
 			)

--- a/erpnext/stock/doctype/repost_item_valuation/test_repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/test_repost_item_valuation.py
@@ -343,10 +343,10 @@ class TestRepostItemValuation(FrappeTestCase, StockTestMixin):
 
 		accounts_settings = frappe.get_doc("Accounts Settings")
 		accounts_settings.acc_frozen_upto = today
-		accounts_settings.frozen_accounts_modifier = ''
+		accounts_settings.frozen_accounts_modifier = ""
 		accounts_settings.save()
 
 		self.assertRaises(frappe.ValidationError, riv.save)
 
-		accounts_settings.acc_frozen_upto = ''
+		accounts_settings.acc_frozen_upto = ""
 		accounts_settings.save()

--- a/erpnext/stock/doctype/repost_item_valuation/test_repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/test_repost_item_valuation.py
@@ -327,3 +327,26 @@ class TestRepostItemValuation(FrappeTestCase, StockTestMixin):
 		# outstanding should not be affected
 		sinv.reload()
 		self.assertEqual(sinv.outstanding_amount, 100)
+
+	def test_account_freeze_validation(self):
+		today = nowdate()
+
+		riv = frappe.get_doc(
+			doctype="Repost Item Valuation",
+			item_code="_Test Item",
+			warehouse="_Test Warehouse - _TC",
+			based_on="Item and Warehouse",
+			posting_date=today,
+			posting_time="00:01:00",
+		)
+		riv.flags.dont_run_in_test = True  # keep it queued
+
+		accounts_settings = frappe.get_doc("Accounts Settings")
+		accounts_settings.acc_frozen_upto = today
+		accounts_settings.frozen_accounts_modifier = ''
+		accounts_settings.save()
+
+		self.assertRaises(frappe.ValidationError, riv.save)
+
+		accounts_settings.acc_frozen_upto = ''
+		accounts_settings.save()


### PR DESCRIPTION
![Peek 2022-11-17 15-33](https://user-images.githubusercontent.com/52111700/202417098-7931273a-3e5c-4ab3-83ef-b919736a6984.gif)

I have taken into consideration the role allowed to override. Maybe we shouldn't do that?
@deepeshgarg007

#no-docs