### PR TITLE
fix: Accounting Dimension filtering for Sales and Purchase Report

### DIFF
--- a/erpnext/accounts/report/purchase_register/purchase_register.py
+++ b/erpnext/accounts/report/purchase_register/purchase_register.py
@@ -232,12 +232,12 @@ def get_conditions(filters):
 
 					conditions += (
 						common_condition
-						+ "and ifnull(`tabPurchase Invoice Item`.{0}, '') in %({0})s)".format(dimension.fieldname)
+						+ "and ifnull(`tabPurchase Invoice`.{0}, '') in %({0})s)".format(dimension.fieldname)
 					)
 				else:
 					conditions += (
 						common_condition
-						+ "and ifnull(`tabPurchase Invoice Item`.{0}, '') in %({0})s)".format(dimension.fieldname)
+						+ "and ifnull(`tabPurchase Invoice`.{0}, '') in %({0})s)".format(dimension.fieldname)
 					)
 
 	return conditions

--- a/erpnext/accounts/report/sales_register/sales_register.py
+++ b/erpnext/accounts/report/sales_register/sales_register.py
@@ -390,12 +390,12 @@ def get_conditions(filters):
 
 					conditions += (
 						common_condition
-						+ "and ifnull(`tabSales Invoice Item`.{0}, '') in %({0})s)".format(dimension.fieldname)
+						+ "and ifnull(`tabSales Invoice`.{0}, '') in %({0})s)".format(dimension.fieldname)
 					)
 				else:
 					conditions += (
 						common_condition
-						+ "and ifnull(`tabSales Invoice Item`.{0}, '') in %({0})s)".format(dimension.fieldname)
+						+ "and ifnull(`tabSales Invoice`.{0}, '') in %({0})s)".format(dimension.fieldname)
 					)
 
 	return conditions


### PR DESCRIPTION
Sales and Purchase Invoices should be filtered based on the parent-level accounting dimensions instead of the item level. Parent and child tables can have different dimensions and viewing the parent-level reports after applying dimension filters might give different results when inline filters in the data table are applied.


With Inline filters
<img width="259" alt="image" src="https://user-images.githubusercontent.com/42651287/202672582-7d948065-8e3b-49d3-9eb8-099dbcc6b26f.png">

With Report filters
<img width="242" alt="image" src="https://user-images.githubusercontent.com/42651287/202672653-7ebb8c9b-7bde-4c08-a341-0ce21b43f262.png">

