### PR TITLE
fix: added validation for discount ammount in insert_item_price

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -812,10 +812,11 @@ def insert_item_price(args):
 		frappe.db.get_single_value("Stock Settings", "auto_insert_price_list_rate_if_missing")
 	):
 		if frappe.has_permission("Item Price", "write"):
+			rate = args.rate + args.discount_amount if args.get("discount_amount") else args.rate
 			price_list_rate = (
-				(args.rate + args.discount_amount) / args.get("conversion_factor")
+				(rate / args.get("conversion_factor"))
 				if args.get("conversion_factor")
-				else (args.rate + args.discount_amount)
+				else rate
 			)
 
 			item_price = frappe.db.get_value(


### PR DESCRIPTION
### Information about bug
The Error pops up if I try to add the rate of the items which are initially zero

### Module
Stock

### Version
Frappe version - 13.42.0 (version-13)
ERPNext version - v13.44.0 (version-13)

### Installation method
Manual Installation

### Relevant log output / Stack trace / Full Error Message.
> Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 69, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 38, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 76, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1457, in call
    return fn(*args, **newargs)
  File "apps/erpnext/erpnext/stock/get_item_details.py", line 91, in get_item_details
    out.update(get_price_list_rate(args, item))
  File "apps/erpnext/erpnext/stock/get_item_details.py", line 792, in get_price_list_rate
    insert_item_price(args)
  File "apps/erpnext/erpnext/stock/get_item_details.py", line 816, in insert_item_price
    (args.rate + args.discount_amount) / args.get("conversion_factor")
TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'

closes #33054 