### PR TITLE
fix: create rounding gl entry for PCV during gle post processing

### DIFF
--- a/erpnext/accounts/general_ledger.py
+++ b/erpnext/accounts/general_ledger.py
@@ -394,20 +394,22 @@ def make_round_off_gle(gl_map, debit_credit_diff, precision):
 	round_off_account, round_off_cost_center = get_round_off_account_and_cost_center(
 		gl_map[0].company, gl_map[0].voucher_type, gl_map[0].voucher_no
 	)
-	round_off_account_exists = False
 	round_off_gle = frappe._dict()
-	for d in gl_map:
-		if d.account == round_off_account:
-			round_off_gle = d
-			if d.debit:
-				debit_credit_diff -= flt(d.debit)
-			else:
-				debit_credit_diff += flt(d.credit)
-			round_off_account_exists = True
+	round_off_account_exists = False
 
-	if round_off_account_exists and abs(debit_credit_diff) < (1.0 / (10**precision)):
-		gl_map.remove(round_off_gle)
-		return
+	if gl_map[0].voucher_type != "Period Closing Voucher":
+		for d in gl_map:
+			if d.account == round_off_account:
+				round_off_gle = d
+				if d.debit:
+					debit_credit_diff -= flt(d.debit) - flt(d.credit)
+				else:
+					debit_credit_diff += flt(d.credit)
+				round_off_account_exists = True
+
+		if round_off_account_exists and abs(debit_credit_diff) < (1.0 / (10**precision)):
+			gl_map.remove(round_off_gle)
+			return
 
 	if not round_off_gle:
 		for k in ["voucher_type", "voucher_no", "company", "posting_date", "remarks"]:
@@ -430,7 +432,6 @@ def make_round_off_gle(gl_map, debit_credit_diff, precision):
 	)
 
 	update_accounting_dimensions(round_off_gle)
-
 	if not round_off_account_exists:
 		gl_map.append(round_off_gle)
 


### PR DESCRIPTION
**Issue:**
While submitting Period Closing Voucher, the error "Debit != Credit" appeared with a difference of 33.

**Solution:**
After investigation came to know that on postprocessing of `make_gl_entries`, there was a difference of 0.02, that's why the system was creating an extra round-off-gle. And in this process, the system tries to adjust the values if there is already any gle for round-off-account in the current voucher's gl entries. Generally, we expect only a single existing gle for round-off-account for any voucher.
But in the case of Period Closing Voucher, there can be multiple gl entries against round-off-account based on different accounting dimensions. And that's why we should not try to adjust the rounding difference against the existing round-off-gle for PCV. The system should create a new gle for the rounding difference.

