### PR TITLE
fix: advance paid updated in account currency for SO/PO

### DIFF
--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -736,27 +736,29 @@ class TestPurchaseOrder(FrappeTestCase):
 	def test_advance_paid_upon_payment_entry_cancellation(self):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import get_payment_entry
 
-		po_doc = create_purchase_order()
+		po_doc = create_purchase_order(supplier="_Test Supplier USD", currency="USD", do_not_submit=1)
+		po_doc.conversion_rate = 80
+		po_doc.submit()
 
-		pe = get_payment_entry("Purchase Order", po_doc.name, bank_account="_Test Bank - _TC")
-		pe.reference_no = "1"
-		pe.reference_date = nowdate()
-		pe.paid_from_account_currency = po_doc.currency
-		pe.paid_to_account_currency = po_doc.currency
-		pe.source_exchange_rate = 1
+		pe = get_payment_entry("Purchase Order", po_doc.name)
+		pe.mode_of_payment = "Cash"
+		pe.paid_from = "Cash - _TC"
+		pe.source_exchange_rate = 80
 		pe.target_exchange_rate = 1
 		pe.paid_amount = po_doc.grand_total
 		pe.save(ignore_permissions=True)
 		pe.submit()
 
 		po_doc.reload()
-		self.assertEqual(po_doc.advance_paid, po_doc.base_grand_total)
+		self.assertEqual(po_doc.advance_paid, po_doc.grand_total)
+		self.assertEqual(po_doc.party_account_currency, "USD")
 
 		pe_doc = frappe.get_doc("Payment Entry", pe.name)
 		pe_doc.cancel()
 
 		po_doc.reload()
 		self.assertEqual(po_doc.advance_paid, 0)
+		self.assertEqual(po_doc.party_account_currency, "USD")
 
 	def test_schedule_date(self):
 		po = create_purchase_order(do_not_submit=True)

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1352,12 +1352,12 @@ class AccountsController(TransactionBase):
 		party = self.customer if self.doctype == "Sales Order" else self.supplier
 		advance = (
 			frappe.qb.from_(ple)
-			.select(ple.account_currency, Abs(Sum(ple.amount)).as_("amount"))
+			.select(ple.account_currency, Abs(Sum(ple.amount_in_account_currency)).as_("amount"))
 			.where(
 				(ple.against_voucher_type == self.doctype)
 				& (ple.against_voucher_no == self.name)
 				& (ple.party == party)
-				& (ple.delinked == 0)
+				& (ple.docstatus == 1)
 				& (ple.company == self.company)
 			)
 			.run(as_dict=True)


### PR DESCRIPTION
Update `advance_paid` of Sales/Purchase Order in account currency using Payment Ledger.

regression: https://github.com/frappe/erpnext/pull/32816