### PR TITLE
fix: only consider draft pending asset repair docs

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -825,7 +825,9 @@ def update_maintenance_status():
 
 	for asset in assets:
 		asset = frappe.get_doc("Asset", asset.name)
-		if frappe.db.exists("Asset Repair", {"asset_name": asset.name, "repair_status": "Pending"}):
+		if frappe.db.exists(
+			"Asset Repair", {"asset_name": asset.name, "repair_status": "Pending", "docstatus": 0}
+		):
 			asset.set_status("Out of Order")
 		elif frappe.db.exists(
 			"Asset Maintenance Task", {"parent": asset.name, "next_due_date": today()}


### PR DESCRIPTION
In user X's system, there are some submitted Asset Repair docs with a `Pending` status made 2-3 years ago, which shouldn't have happened (an Asset Repair doc needs to be either `Completed` or `Cancelled` before being submitted). Now, if the user wants to scrap an Asset linked to those old Asset Repair docs with a `Pending` status, they can't, because the Asset's status is `Out of Order` (even if they cancel the Asset Repair docs). So the solution is to set an Asset `Out of Order` only if there are draft Asset Repair docs associated with it.