### PR TITLE
fix: Valuation Rate column UX in stock ledger report

### DIFF
--- a/erpnext/stock/report/stock_ledger/stock_ledger.py
+++ b/erpnext/stock/report/stock_ledger/stock_ledger.py
@@ -58,6 +58,12 @@ def execute(filters=None):
 		if sle.serial_no:
 			update_available_serial_nos(available_serial_nos, sle)
 
+		if sle.actual_qty:
+			sle["in_out_rate"] = flt(sle.stock_value_difference / sle.actual_qty, precision)
+
+		elif sle.voucher_type == "Stock Reconciliation":
+			sle["in_out_rate"] = sle.valuation_rate
+
 		data.append(sle)
 
 		if include_uom:
@@ -185,10 +191,18 @@ def get_columns(filters):
 				"convertible": "rate",
 			},
 			{
-				"label": _("Valuation Rate"),
+				"label": _("Avg Rate (Balance Stock)"),
 				"fieldname": "valuation_rate",
 				"fieldtype": "Currency",
-				"width": 110,
+				"width": 180,
+				"options": "Company:company:default_currency",
+				"convertible": "rate",
+			},
+			{
+				"label": _("Valuation Rate"),
+				"fieldname": "in_out_rate",
+				"fieldtype": "Currency",
+				"width": 140,
 				"options": "Company:company:default_currency",
 				"convertible": "rate",
 			},


### PR DESCRIPTION
The "Valuation Rate" in stock ledger report is the average cost of available balance and not a cost at which the Stock has either In-warded or Out-warded. Most of the time people get confused with it and their expectation is that the valuation rate should show the Rate at which the materials were either In-warded or Out-warded. 

**Solution**
In this PR I have updated the column name of Valuation Rate to the Avg Rate (Balance Stock) and added new column Valuation Rate which will show the rate at which the materials were either In-warded or Out-warded.
<img width="1114" alt="Screenshot 2022-11-23 at 4 43 54 PM" src="https://user-images.githubusercontent.com/8780500/203533621-0b6815c3-240c-4b84-af27-6b7301b5e1e2.png">

