### PR TITLE
fix: precision in asset test_scrap_asset

### DIFF
--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -224,7 +224,10 @@ class TestAsset(AssetSetup):
 			asset.finance_books[0], 9000, get_last_day(add_months(purchase_date, 1)), date
 		)
 		pro_rata_amount = flt(pro_rata_amount, asset.precision("gross_purchase_amount"))
-		self.assertEquals(accumulated_depr_amount, 18000.00 + pro_rata_amount)
+		self.assertEquals(
+			accumulated_depr_amount,
+			flt(18000.0 + pro_rata_amount, asset.precision("gross_purchase_amount")),
+		)
 
 		self.assertEqual(asset.status, "Scrapped")
 		self.assertTrue(asset.journal_entry_for_scrap)


### PR DESCRIPTION
This is to fix the failing `test_scrap_asset` [here](https://github.com/frappe/erpnext/actions/runs/3539226903/jobs/5940888822) due to incorrect precision.