### PR TITLE
fix(pos): warehouse selection

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.js
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.js
@@ -19,10 +19,19 @@ erpnext.selling.POSInvoiceController = class POSInvoiceController extends erpnex
 	onload(doc) {
 		super.onload();
 		this.frm.ignore_doctypes_on_cancel_all = ['POS Invoice Merge Log', 'POS Closing Entry'];
+
 		if(doc.__islocal && doc.is_pos && frappe.get_route_str() !== 'point-of-sale') {
 			this.frm.script_manager.trigger("is_pos");
 			this.frm.refresh_fields();
 		}
+
+		this.frm.set_query("set_warehouse", function(doc) {
+			return {
+				filters: {
+					company: doc.company ? doc.company : '',
+				}
+			}
+		});
 
 		erpnext.accounts.dimensions.setup_dimension_filters(this.frm, this.frm.doctype);
 	}

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.js
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.js
@@ -12,6 +12,8 @@ erpnext.selling.POSInvoiceController = class POSInvoiceController extends erpnex
 
 	company() {
 		erpnext.accounts.dimensions.update_dimension(this.frm, this.frm.doctype);
+		this.frm.set_value("set_warehouse", "");
+		this.frm.set_value("taxes_and_charges", "");
 	}
 
 	onload(doc) {


### PR DESCRIPTION
In POS Invoice,
- [x] unset `Warehouse` and `Sales Taxes and Charges Template` when changing company
- [x] filter warehouse by company

closes https://github.com/frappe/erpnext/issues/28905