### PR TITLE
fix: job card "Qty to Manufacture" UX

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.js
+++ b/erpnext/manufacturing/doctype/job_card/job_card.js
@@ -33,6 +33,11 @@ frappe.ui.form.on('Job Card', {
 			return;
 		}
 
+		let has_stock_entry = frm.doc.__onload &&
+			frm.doc.__onload.has_stock_entry ? true : false;
+
+		frm.toggle_enable("for_quantity", !has_stock_entry);
+
 		if (!frm.is_new() && has_items && frm.doc.docstatus < 2) {
 			let to_request = frm.doc.for_quantity > frm.doc.transferred_qty;
 			let excess_transfer_allowed = frm.doc.__onload.job_card_excess_transfer;

--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -57,6 +57,10 @@ class JobCard(Document):
 		)
 		self.set_onload("job_card_excess_transfer", excess_transfer)
 		self.set_onload("work_order_closed", self.is_work_order_closed())
+		self.set_onload("has_stock_entry", self.has_stock_entry())
+
+	def has_stock_entry(self):
+		return frappe.db.exists("Stock Entry", {"job_card": self.name, "docstatus": ["!=", 2]})
 
 	def before_validate(self):
 		self.set_wip_warehouse()


### PR DESCRIPTION
**Issue**

1. Create Job Card against the work order and set material transfer against as "Job Card"
2. On job card, do material transfer for partial quantity
3. After that change "Qty to Manufacture" in the job card
4. You can see system update the transferred qty to zero against the raw materials in the child table.

**Solution**

If material transfer has made then not allow user to change the "Qty to Manufacture" field 
<img width="1186" alt="Screenshot 2022-11-24 at 5 32 18 PM" src="https://user-images.githubusercontent.com/8780500/203780415-89012b7c-0b8f-4ad2-9181-89789fa73393.png">

Fixed https://github.com/frappe/erpnext/issues/28778