### PR TITLE
feat: german tax templates

### DIFF
--- a/erpnext/setup/setup_wizard/data/country_wise_tax.json
+++ b/erpnext/setup/setup_wizard/data/country_wise_tax.json
@@ -481,136 +481,461 @@
 	},
 
 	"Germany": {
-		"tax_categories": [
-			"Umsatzsteuer",
-			"Vorsteuer"
-		],
+		"tax_categories": [],
 		"chart_of_accounts": {
 			"SKR04 mit Kontonummern": {
 				"sales_tax_templates": [
 					{
-						"title": "Umsatzsteuer",
-						"tax_category": "Umsatzsteuer",
+						"title": "Lieferung oder sonstige Leistung im Inland",
 						"is_default": 1,
 						"taxes": [
 							{
 								"account_head": {
-									"account_name": "Umsatzsteuer 19%",
+									"account_name": "Umsatzsteuer 19 %",
 									"account_number": "3806",
 									"tax_rate": 19.00
 								},
+								"description": "Umsatzsteuer 19 %",
 								"rate": 0.00
 							},
 							{
 								"account_head": {
-									"account_name": "Umsatzsteuer 7%",
+									"account_name": "Umsatzsteuer 7 %",
 									"account_number": "3801",
 									"tax_rate": 7.00
 								},
-								"rate": 0.00
-							}
-						]
-					}
-				],
-				"purchase_tax_templates": [
-					{
-						"title": "Vorsteuer",
-						"tax_category": "Vorsteuer",
-						"is_default": 1,
-						"taxes": [
-							{
-								"account_head": {
-									"account_name": "Abziehbare Vorsteuer 19%",
-									"account_number": "1406",
-									"root_type": "Asset",
-									"tax_rate": 19.00
-								},
-								"rate": 0.00
-							},
-							{
-								"account_head": {
-									"account_name": "Abziehbare Vorsteuer 7%",
-									"account_number": "1401",
-									"root_type": "Asset",
-									"tax_rate": 7.00
-								},
+								"description": "Umsatzsteuer 7 %",
 								"rate": 0.00
 							}
 						]
 					},
 					{
-						"title": "Innergemeinschaftlicher Erwerb 19% Umsatzsteuer und 19% Vorsteuer",
+						"title": "Lieferung an Unternehmen in der EU",
+						"is_default": 0,
+						"taxes": []
+					},
+					{
+						"title": "Sonstige Leistung an Unternehmen in der EU",
+						"is_default": 0,
+						"taxes": []
+					},
+					{
+						"title": "Lieferung oder sonstige Leistung an nicht-Unternehmen in der EU",
+						"is_default": 0,
 						"taxes": [
 							{
 								"account_head": {
-									"account_name": "Abziehbare Vorsteuer nach § 13b UStG 19%",
-									"account_number": "1407",
-									"root_type": "Asset",
+									"account_name": "Umsatzsteuer 19 %",
+									"account_number": "3806",
 									"tax_rate": 19.00
 								},
-								"add_deduct_tax": "Add"
+								"description": "Umsatzsteuer 19 %",
+								"rate": 0.00
 							},
 							{
 								"account_head": {
-									"account_name": "Umsatzsteuer nach § 13b UStG 19%",
+									"account_name": "Umsatzsteuer 7 %",
+									"account_number": "3801",
+									"tax_rate": 7.00
+								},
+								"description": "Umsatzsteuer 7 %",
+								"rate": 0.00
+							}
+						]
+					},
+					{
+						"title": "Lieferung in Drittland",
+						"is_default": 0,
+						"taxes": []
+					},
+					{
+						"title": "Sonstige Leistung an Unternehmen in Drittland",
+						"is_default": 0,
+						"taxes": []
+					},
+					{
+						"title": "Sonstige Leistung an nicht-Unternehmen in Drittland",
+						"is_default": 0,
+						"taxes": [
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer 19 %",
+									"account_number": "3806",
+									"tax_rate": 19.00
+								},
+								"description": "Umsatzsteuer 19 %",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer 7 %",
+									"account_number": "3801",
+									"tax_rate": 7.00
+								},
+								"description": "Umsatzsteuer 7 %",
+								"rate": 0.00
+							}
+						]
+					},
+					{
+						"title": "Bauleistungen nach § 13b UStG",
+						"is_default": 0,
+						"taxes": []
+					}
+				],
+				"purchase_tax_templates": [
+					{
+						"title": "Lieferung aus dem Inland",
+						"is_default": 1,
+						"taxes": [
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer 19 %",
+									"account_number": "1406",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"description": "Abziehbare Vorsteuer 19 %",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer 7 %",
+									"account_number": "1401",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"description": "Abziehbare Vorsteuer 7 %",
+								"rate": 0.00
+							}
+						]
+					},
+					{
+						"title": "Sonstige Leistung aus dem Inland",
+						"is_default": 0,
+						"taxes": [
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer 19 %",
+									"account_number": "1406",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"description": "Abziehbare Vorsteuer 19 %",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer 7 %",
+									"account_number": "1401",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"description": "Abziehbare Vorsteuer 7 %",
+								"rate": 0.00
+							}
+						]
+					},
+					{
+						"title": "Lieferung aus der EU",
+						"is_default": 0,
+						"taxes": [
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer aus innergemeinschaftlichem Erwerb 19 %",
+									"account_number": "1404",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"description": "Abziehbare Vorsteuer aus innergemeinschaftlichem Erwerb 19 %",
+								"add_deduct_tax": "Add",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer aus innergemeinschaftlichem Erwerb",
+									"account_number": "1402",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"description": "Abziehbare Vorsteuer aus innergemeinschaftlichem Erwerb",
+								"add_deduct_tax": "Add",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer aus innergemeinschaftlichem Erwerb 19 %",
+									"account_number": "3804",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"description": "Umsatzsteuer aus innergemeinschaftlichem Erwerb 19 %",
+								"add_deduct_tax": "Deduct",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer aus innergemeinschaftlichem Erwerb",
+									"account_number": "3802",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"description": "Umsatzsteuer aus innergemeinschaftlichem Erwerb",
+								"add_deduct_tax": "Deduct",
+								"rate": 0.00
+							}
+						]
+					},
+					{
+						"title": "Sonstige Leistung aus der EU",
+						"is_default": 0,
+						"taxes": [
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG 19 %",
+									"account_number": "1540",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"description": "Abziehbare Vorsteuer nach § 13b UStG 19 %",
+								"add_deduct_tax": "Add",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG",
+									"account_number": "1541",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"description": "Abziehbare Vorsteuer nach § 13b UStG",
+								"add_deduct_tax": "Add",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer nach § 13b UStG 19 %",
 									"account_number": "3837",
 									"root_type": "Liability",
 									"tax_rate": 19.00
 								},
-								"add_deduct_tax": "Deduct"
+								"description": "Umsatzsteuer nach § 13b UStG 19 %",
+								"add_deduct_tax": "Deduct",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer nach § 13b UStG",
+									"account_number": "3835",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"description": "Umsatzsteuer nach § 13b UStG",
+								"add_deduct_tax": "Deduct",
+								"rate": 0.00
+							}
+						]
+					},
+					{
+						"title": "Sonstige Leistung aus Drittland",
+						"is_default": 0,
+						"taxes": [
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG 19 %",
+									"account_number": "1540",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"description": "Abziehbare Vorsteuer nach § 13b UStG 19 %",
+								"add_deduct_tax": "Add",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG",
+									"account_number": "1541",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"description": "Abziehbare Vorsteuer nach § 13b UStG",
+								"add_deduct_tax": "Add",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer nach § 13b UStG 19 %",
+									"account_number": "3837",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"description": "Umsatzsteuer nach § 13b UStG 19 %",
+								"add_deduct_tax": "Deduct",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer nach § 13b UStG",
+									"account_number": "3835",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"description": "Umsatzsteuer nach § 13b UStG",
+								"add_deduct_tax": "Deduct",
+								"rate": 0.00
+							}
+						]
+					},
+					{
+						"title": "Lieferung aus Drittland",
+						"is_default": 0,
+						"taxes": [
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer 19 %",
+									"account_number": "1406",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"description": "Abziehbare Vorsteuer 19 %",
+								"add_deduct_tax": "Add",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer 7 %",
+									"account_number": "1401",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"description": "Abziehbare Vorsteuer 7 %",
+								"add_deduct_tax": "Add",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Entstandene Einfuhrumsatzsteuer",
+									"account_number": "1433",
+									"root_type": "Asset"
+								},
+								"description": "Entstandene Einfuhrumsatzsteuer",
+								"add_deduct_tax": "Deduct",
+								"rate": 0.00
+							}
+						]
+					},
+					{
+						"title": "Bauleistungen nach § 13b UStG",
+						"is_default": 0,
+						"taxes": [
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG 19 %",
+									"account_number": "1540",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"description": "Abziehbare Vorsteuer nach § 13b UStG 19 %",
+								"add_deduct_tax": "Add",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG",
+									"account_number": "1541",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"description": "Abziehbare Vorsteuer nach § 13b UStG",
+								"add_deduct_tax": "Add",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer nach § 13b UStG 19 %",
+									"account_number": "3837",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"description": "Umsatzsteuer nach § 13b UStG 19 %",
+								"add_deduct_tax": "Deduct",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer nach § 13b UStG",
+									"account_number": "3835",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"description": "Umsatzsteuer nach § 13b UStG",
+								"add_deduct_tax": "Deduct",
+								"rate": 0.00
 							}
 						]
 					}
 				],
 				"item_tax_templates": [
 					{
-						"title": "Umsatzsteuer 19%",
+						"title": "19 %",
 						"taxes": [
 							{
 								"tax_type": {
-									"account_name": "Umsatzsteuer 19%",
+									"account_name": "Umsatzsteuer 19 %",
 									"account_number": "3806",
+									"root_type": "Liability",
 									"tax_rate": 19.00
 								},
 								"tax_rate": 19.00
 							},
 							{
 								"tax_type": {
-									"account_name": "Umsatzsteuer 7%",
+									"account_name": "Umsatzsteuer 7 %",
 									"account_number": "3801",
+									"root_type": "Liability",
 									"tax_rate": 7.00
-								},
-								"tax_rate": 0.00
-							}
-						]
-					},
-					{
-						"title": "Umsatzsteuer 7%",
-						"taxes": [
-							{
-								"tax_type": {
-									"account_name": "Umsatzsteuer 19%",
-									"account_number": "3806",
-									"tax_rate": 19.00
 								},
 								"tax_rate": 0.00
 							},
 							{
 								"tax_type": {
-									"account_name": "Umsatzsteuer 7%",
-									"account_number": "3801",
-									"tax_rate": 7.00
+									"account_name": "Umsatzsteuer aus innergemeinschaftlichem Erwerb 19 %",
+									"account_number": "3804",
+									"root_type": "Liability",
+									"tax_rate": 19.00
 								},
-								"tax_rate": 7.00
-							}
-						]
-					},
-					{
-						"title": "Vorsteuer 19%",
-						"taxes": [
+								"tax_rate": 19.00
+							},
 							{
 								"tax_type": {
-									"account_name": "Abziehbare Vorsteuer 19%",
+									"account_name": "Umsatzsteuer aus innergemeinschaftlichem Erwerb",
+									"account_number": "3802",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer nach § 13b UStG 19 %",
+									"account_number": "3837",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 19.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer nach § 13b UStG",
+									"account_number": "3835",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer 19 %",
 									"account_number": "1406",
 									"root_type": "Asset",
 									"tax_rate": 19.00
@@ -619,21 +944,119 @@
 							},
 							{
 								"tax_type": {
-									"account_name": "Abziehbare Vorsteuer 7%",
+									"account_name": "Abziehbare Vorsteuer 7 %",
 									"account_number": "1401",
 									"root_type": "Asset",
 									"tax_rate": 7.00
 								},
 								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer aus innergemeinschaftlichem Erwerb 19 %",
+									"account_number": "1404",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 19.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer aus innergemeinschaftlichem Erwerb",
+									"account_number": "1402",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG 19 %",
+									"account_number": "1540",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 19.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG",
+									"account_number": "1541",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Entstandene Einfuhrumsatzsteuer",
+									"account_number": "1433",
+									"root_type": "Asset"
+								},
+								"tax_rate": 19.00
 							}
 						]
 					},
 					{
-						"title": "Vorsteuer 7%",
+						"title": "7 %",
 						"taxes": [
 							{
 								"tax_type": {
-									"account_name": "Abziehbare Vorsteuer 19%",
+									"account_name": "Umsatzsteuer 19 %",
+									"account_number": "3806",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer 7 %",
+									"account_number": "3801",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 7.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer aus innergemeinschaftlichem Erwerb 19 %",
+									"account_number": "3804",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer aus innergemeinschaftlichem Erwerb",
+									"account_number": "3802",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 7.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer nach § 13b UStG 19 %",
+									"account_number": "3837",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer nach § 13b UStG",
+									"account_number": "3835",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 7.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer 19 %",
 									"account_number": "1406",
 									"root_type": "Asset",
 									"tax_rate": 19.00
@@ -642,12 +1065,177 @@
 							},
 							{
 								"tax_type": {
-									"account_name": "Abziehbare Vorsteuer 7%",
+									"account_name": "Abziehbare Vorsteuer 7 %",
 									"account_number": "1401",
 									"root_type": "Asset",
 									"tax_rate": 7.00
 								},
 								"tax_rate": 7.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer aus innergemeinschaftlichem Erwerb 19 %",
+									"account_number": "1404",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer aus innergemeinschaftlichem Erwerb",
+									"account_number": "1402",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 7.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG 19 %",
+									"account_number": "1540",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG",
+									"account_number": "1541",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 7.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Entstandene Einfuhrumsatzsteuer",
+									"account_number": "1433",
+									"root_type": "Asset"
+								},
+								"tax_rate": 7.00
+							}
+						]
+					},
+					{
+						"title": "0 %",
+						"taxes": [
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer 19 %",
+									"account_number": "3806",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer 7 %",
+									"account_number": "3801",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer aus innergemeinschaftlichem Erwerb 19 %",
+									"account_number": "3804",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer aus innergemeinschaftlichem Erwerb",
+									"account_number": "3802",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer nach § 13b UStG 19 %",
+									"account_number": "3837",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer nach § 13b UStG",
+									"account_number": "3835",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer 19 %",
+									"account_number": "1406",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer 7 %",
+									"account_number": "1401",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer aus innergemeinschaftlichem Erwerb 19 %",
+									"account_number": "1404",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer aus innergemeinschaftlichem Erwerb",
+									"account_number": "1402",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG 19 %",
+									"account_number": "1540",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG",
+									"account_number": "1541",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Entstandene Einfuhrumsatzsteuer",
+									"account_number": "1433",
+									"root_type": "Asset"
+								},
+								"tax_rate": 0.00
 							}
 						]
 					}
@@ -656,51 +1244,390 @@
 			"SKR03 mit Kontonummern": {
 				"sales_tax_templates": [
 					{
-						"title": "Umsatzsteuer",
-						"tax_category": "Umsatzsteuer",
+						"title": "Lieferung oder sonstige Leistung im Inland",
 						"is_default": 1,
 						"taxes": [
 							{
 								"account_head": {
-									"account_name": "Umsatzsteuer 19%",
+									"account_name": "Umsatzsteuer 19 %",
 									"account_number": "1776",
 									"tax_rate": 19.00
 								},
+								"description": "Umsatzsteuer 19 %",
 								"rate": 0.00
 							},
 							{
 								"account_head": {
-									"account_name": "Umsatzsteuer 7%",
+									"account_name": "Umsatzsteuer 7 %",
 									"account_number": "1771",
 									"tax_rate": 7.00
 								},
+								"description": "Umsatzsteuer 7 %",
 								"rate": 0.00
 							}
 						]
+					},
+					{
+						"title": "Lieferung an Unternehmen in der EU",
+						"is_default": 0,
+						"taxes": []
+					},
+					{
+						"title": "Sonstige Leistung an Unternehmen in der EU",
+						"is_default": 0,
+						"taxes": []
+					},
+					{
+						"title": "Lieferung oder sonstige Leistung an nicht-Unternehmen in der EU",
+						"is_default": 0,
+						"taxes": [
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer 19 %",
+									"account_number": "1776",
+									"tax_rate": 19.00
+								},
+								"description": "Umsatzsteuer 19 %",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer 7 %",
+									"account_number": "1771",
+									"tax_rate": 7.00
+								},
+								"description": "Umsatzsteuer 7 %",
+								"rate": 0.00
+							}
+						]
+					},
+					{
+						"title": "Lieferung in Drittland",
+						"is_default": 0,
+						"taxes": []
+					},
+					{
+						"title": "Sonstige Leistung an Unternehmen in Drittland",
+						"is_default": 0,
+						"taxes": []
+					},
+					{
+						"title": "Sonstige Leistung an nicht-Unternehmen in Drittland",
+						"is_default": 0,
+						"taxes": [
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer 19 %",
+									"account_number": "1776",
+									"tax_rate": 19.00
+								},
+								"description": "Umsatzsteuer 19 %",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer 7 %",
+									"account_number": "1771",
+									"tax_rate": 7.00
+								},
+								"description": "Umsatzsteuer 7 %",
+								"rate": 0.00
+							}
+						]
+					},
+					{
+						"title": "Bauleistungen nach § 13b UStG",
+						"is_default": 0,
+						"taxes": []
 					}
 				],
 				"purchase_tax_templates": [
 					{
-						"title": "Vorsteuer",
-						"tax_category": "Vorsteuer",
+						"title": "Lieferung aus dem Inland",
 						"is_default": 1,
 						"taxes": [
 							{
 								"account_head": {
-									"account_name": "Abziehbare Vorsteuer 19%",
+									"account_name": "Abziehbare Vorsteuer 19 %",
 									"account_number": "1576",
 									"root_type": "Asset",
 									"tax_rate": 19.00
 								},
+								"description": "Abziehbare Vorsteuer 19 %",
 								"rate": 0.00
 							},
 							{
 								"account_head": {
-									"account_name": "Abziehbare Vorsteuer 7%",
+									"account_name": "Abziehbare Vorsteuer 7 %",
 									"account_number": "1571",
 									"root_type": "Asset",
 									"tax_rate": 7.00
 								},
+								"description": "Abziehbare Vorsteuer 7 %",
+								"rate": 0.00
+							}
+						]
+					},
+					{
+						"title": "Sonstige Leistung aus dem Inland",
+						"is_default": 0,
+						"taxes": [
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer 19 %",
+									"account_number": "1576",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"description": "Abziehbare Vorsteuer 19 %",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer 7 %",
+									"account_number": "1571",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"description": "Abziehbare Vorsteuer 7 %",
+								"rate": 0.00
+							}
+						]
+					},
+					{
+						"title": "Lieferung aus der EU",
+						"is_default": 0,
+						"taxes": [
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer aus innergemeinschaftlichem Erwerb 19 %",
+									"account_number": "1574",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"description": "Abziehbare Vorsteuer aus innergemeinschaftlichem Erwerb 19 %",
+								"add_deduct_tax": "Add",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer aus innergemeinschaftlichem Erwerb",
+									"account_number": "1572",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"description": "Abziehbare Vorsteuer aus innergemeinschaftlichem Erwerb",
+								"add_deduct_tax": "Add",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer aus innergemeinschaftlichem Erwerb 19 %",
+									"account_number": "1774",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"description": "Umsatzsteuer aus innergemeinschaftlichem Erwerb 19 %",
+								"add_deduct_tax": "Deduct",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer aus innergemeinschaftlichem Erwerb",
+									"account_number": "1772",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"description": "Umsatzsteuer aus innergemeinschaftlichem Erwerb",
+								"add_deduct_tax": "Deduct",
+								"rate": 0.00
+							}
+						]
+					},
+					{
+						"title": "Sonstige Leistung aus der EU",
+						"is_default": 0,
+						"taxes": [
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG 19 %",
+									"account_number": "1540",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"description": "Abziehbare Vorsteuer nach § 13b UStG 19 %",
+								"add_deduct_tax": "Add",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG",
+									"account_number": "1541",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"description": "Abziehbare Vorsteuer nach § 13b UStG",
+								"add_deduct_tax": "Add",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer nach § 13b UStG 19 %",
+									"account_number": "1787",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"description": "Umsatzsteuer nach § 13b UStG 19 %",
+								"add_deduct_tax": "Deduct",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer nach § 13b UStG",
+									"account_number": "1785",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"description": "Umsatzsteuer nach § 13b UStG",
+								"add_deduct_tax": "Deduct",
+								"rate": 0.00
+							}
+						]
+					},
+					{
+						"title": "Sonstige Leistung aus Drittland",
+						"is_default": 0,
+						"taxes": [
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG 19 %",
+									"account_number": "1540",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"description": "Abziehbare Vorsteuer nach § 13b UStG 19 %",
+								"add_deduct_tax": "Add",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG",
+									"account_number": "1541",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"description": "Abziehbare Vorsteuer nach § 13b UStG",
+								"add_deduct_tax": "Add",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer nach § 13b UStG 19 %",
+									"account_number": "1787",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"description": "Umsatzsteuer nach § 13b UStG 19 %",
+								"add_deduct_tax": "Deduct",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer nach § 13b UStG",
+									"account_number": "1785",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"description": "Umsatzsteuer nach § 13b UStG",
+								"add_deduct_tax": "Deduct",
+								"rate": 0.00
+							}
+						]
+					},
+					{
+						"title": "Lieferung aus Drittland",
+						"is_default": 0,
+						"taxes": [
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer 19 %",
+									"account_number": "1576",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"description": "Abziehbare Vorsteuer 19 %",
+								"add_deduct_tax": "Add",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer 7 %",
+									"account_number": "1571",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"description": "Abziehbare Vorsteuer 7 %",
+								"add_deduct_tax": "Add",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Entstandene Einfuhrumsatzsteuer",
+									"account_number": "1588",
+									"root_type": "Asset"
+								},
+								"description": "Entstandene Einfuhrumsatzsteuer",
+								"add_deduct_tax": "Deduct",
+								"rate": 0.00
+							}
+						]
+					},
+					{
+						"title": "Bauleistungen nach § 13b UStG",
+						"is_default": 0,
+						"taxes": [
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG 19 %",
+									"account_number": "1540",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"description": "Abziehbare Vorsteuer nach § 13b UStG 19 %",
+								"add_deduct_tax": "Add",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG",
+									"account_number": "1541",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"description": "Abziehbare Vorsteuer nach § 13b UStG",
+								"add_deduct_tax": "Add",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer nach § 13b UStG 19 %",
+									"account_number": "1787",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"description": "Umsatzsteuer nach § 13b UStG 19 %",
+								"add_deduct_tax": "Deduct",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer nach § 13b UStG",
+									"account_number": "1785",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"description": "Umsatzsteuer nach § 13b UStG",
+								"add_deduct_tax": "Deduct",
 								"rate": 0.00
 							}
 						]
@@ -708,53 +1635,65 @@
 				],
 				"item_tax_templates": [
 					{
-						"title": "Umsatzsteuer 19%",
+						"title": "19 %",
 						"taxes": [
 							{
 								"tax_type": {
-									"account_name": "Umsatzsteuer 19%",
+									"account_name": "Umsatzsteuer 19 %",
 									"account_number": "1776",
+									"root_type": "Liability",
 									"tax_rate": 19.00
 								},
 								"tax_rate": 19.00
 							},
 							{
 								"tax_type": {
-									"account_name": "Umsatzsteuer 7%",
+									"account_name": "Umsatzsteuer 7 %",
 									"account_number": "1771",
+									"root_type": "Liability",
 									"tax_rate": 7.00
-								},
-								"tax_rate": 0.00
-							}
-						]
-					},
-					{
-						"title": "Umsatzsteuer 7%",
-						"taxes": [
-							{
-								"tax_type": {
-									"account_name": "Umsatzsteuer 19%",
-									"account_number": "1776",
-									"tax_rate": 19.00
 								},
 								"tax_rate": 0.00
 							},
 							{
 								"tax_type": {
-									"account_name": "Umsatzsteuer 7%",
-									"account_number": "1771",
-									"tax_rate": 7.00
+									"account_name": "Umsatzsteuer aus innergemeinschaftlichem Erwerb 19 %",
+									"account_number": "1774",
+									"root_type": "Liability",
+									"tax_rate": 19.00
 								},
-								"tax_rate": 7.00
-							}
-						]
-					},
-					{
-						"title": "Vorsteuer 19%",
-						"taxes": [
+								"tax_rate": 19.00
+							},
 							{
 								"tax_type": {
-									"account_name": "Abziehbare Vorsteuer 19%",
+									"account_name": "Umsatzsteuer aus innergemeinschaftlichem Erwerb",
+									"account_number": "1772",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer nach § 13b UStG 19 %",
+									"account_number": "1787",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 19.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer nach § 13b UStG",
+									"account_number": "1785",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer 19 %",
 									"account_number": "1576",
 									"root_type": "Asset",
 									"tax_rate": 19.00
@@ -763,21 +1702,119 @@
 							},
 							{
 								"tax_type": {
-									"account_name": "Abziehbare Vorsteuer 7%",
+									"account_name": "Abziehbare Vorsteuer 7 %",
 									"account_number": "1571",
 									"root_type": "Asset",
 									"tax_rate": 7.00
 								},
 								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer aus innergemeinschaftlichem Erwerb 19 %",
+									"account_number": "1574",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 19.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer aus innergemeinschaftlichem Erwerb",
+									"account_number": "1572",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG 19 %",
+									"account_number": "1540",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 19.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG",
+									"account_number": "1541",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Entstandene Einfuhrumsatzsteuer",
+									"account_number": "1588",
+									"root_type": "Asset"
+								},
+								"tax_rate": 19.00
 							}
 						]
 					},
 					{
-						"title": "Vorsteuer 7%",
+						"title": "7 %",
 						"taxes": [
 							{
 								"tax_type": {
-									"account_name": "Abziehbare Vorsteuer 19%",
+									"account_name": "Umsatzsteuer 19 %",
+									"account_number": "1776",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer 7 %",
+									"account_number": "1771",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 7.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer aus innergemeinschaftlichem Erwerb 19 %",
+									"account_number": "1774",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer aus innergemeinschaftlichem Erwerb",
+									"account_number": "1772",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 7.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer nach § 13b UStG 19 %",
+									"account_number": "1787",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer nach § 13b UStG",
+									"account_number": "1785",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 7.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer 19 %",
 									"account_number": "1576",
 									"root_type": "Asset",
 									"tax_rate": 19.00
@@ -786,12 +1823,177 @@
 							},
 							{
 								"tax_type": {
-									"account_name": "Abziehbare Vorsteuer 7%",
+									"account_name": "Abziehbare Vorsteuer 7 %",
 									"account_number": "1571",
 									"root_type": "Asset",
 									"tax_rate": 7.00
 								},
 								"tax_rate": 7.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer aus innergemeinschaftlichem Erwerb 19 %",
+									"account_number": "1574",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer aus innergemeinschaftlichem Erwerb",
+									"account_number": "1572",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 7.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG 19 %",
+									"account_number": "1540",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG",
+									"account_number": "1541",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 7.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Entstandene Einfuhrumsatzsteuer",
+									"account_number": "1588",
+									"root_type": "Asset"
+								},
+								"tax_rate": 7.00
+							}
+						]
+					},
+					{
+						"title": "0 %",
+						"taxes": [
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer 19 %",
+									"account_number": "1776",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer 7 %",
+									"account_number": "1771",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer aus innergemeinschaftlichem Erwerb 19 %",
+									"account_number": "1774",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer aus innergemeinschaftlichem Erwerb",
+									"account_number": "1772",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer nach § 13b UStG 19 %",
+									"account_number": "1787",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer nach § 13b UStG",
+									"account_number": "1785",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer 19 %",
+									"account_number": "1576",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer 7 %",
+									"account_number": "1571",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer aus innergemeinschaftlichem Erwerb 19 %",
+									"account_number": "1574",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer aus innergemeinschaftlichem Erwerb",
+									"account_number": "1572",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG 19 %",
+									"account_number": "1540",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG",
+									"account_number": "1541",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Entstandene Einfuhrumsatzsteuer",
+									"account_number": "1588",
+									"root_type": "Asset"
+								},
+								"tax_rate": 0.00
 							}
 						]
 					}
@@ -800,51 +2002,390 @@
 			"Standard with Numbers": {
 				"sales_tax_templates": [
 					{
-						"title": "Umsatzsteuer",
-						"tax_category": "Umsatzsteuer",
+						"title": "Lieferung oder sonstige Leistung im Inland",
 						"is_default": 1,
 						"taxes": [
 							{
 								"account_head": {
-									"account_name": "Umsatzsteuer 19%",
-									"account_number": "2301",
+									"account_name": "Umsatzsteuer 19 %",
+									"account_number": "2320",
 									"tax_rate": 19.00
 								},
+								"description": "Umsatzsteuer 19 %",
 								"rate": 0.00
 							},
 							{
 								"account_head": {
-									"account_name": "Umsatzsteuer 7%",
-									"account_number": "2302",
+									"account_name": "Umsatzsteuer 7 %",
+									"account_number": "2321",
 									"tax_rate": 7.00
 								},
+								"description": "Umsatzsteuer 7 %",
 								"rate": 0.00
 							}
 						]
+					},
+					{
+						"title": "Lieferung an Unternehmen in der EU",
+						"is_default": 0,
+						"taxes": []
+					},
+					{
+						"title": "Sonstige Leistung an Unternehmen in der EU",
+						"is_default": 0,
+						"taxes": []
+					},
+					{
+						"title": "Lieferung oder sonstige Leistung an nicht-Unternehmen in der EU",
+						"is_default": 0,
+						"taxes": [
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer 19 %",
+									"account_number": "2320",
+									"tax_rate": 19.00
+								},
+								"description": "Umsatzsteuer 19 %",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer 7 %",
+									"account_number": "2321",
+									"tax_rate": 7.00
+								},
+								"description": "Umsatzsteuer 7 %",
+								"rate": 0.00
+							}
+						]
+					},
+					{
+						"title": "Lieferung in Drittland",
+						"is_default": 0,
+						"taxes": []
+					},
+					{
+						"title": "Sonstige Leistung an Unternehmen in Drittland",
+						"is_default": 0,
+						"taxes": []
+					},
+					{
+						"title": "Sonstige Leistung an nicht-Unternehmen in Drittland",
+						"is_default": 0,
+						"taxes": [
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer 19 %",
+									"account_number": "2320",
+									"tax_rate": 19.00
+								},
+								"description": "Umsatzsteuer 19 %",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer 7 %",
+									"account_number": "2321",
+									"tax_rate": 7.00
+								},
+								"description": "Umsatzsteuer 7 %",
+								"rate": 0.00
+							}
+						]
+					},
+					{
+						"title": "Bauleistungen nach § 13b UStG",
+						"is_default": 0,
+						"taxes": []
 					}
 				],
 				"purchase_tax_templates": [
 					{
-						"title": "Vorsteuer",
-						"tax_category": "Vorsteuer",
+						"title": "Lieferung aus dem Inland",
 						"is_default": 1,
 						"taxes": [
 							{
 								"account_head": {
-									"account_name": "Abziehbare Vorsteuer 19%",
-									"account_number": "1501",
+									"account_name": "Abziehbare Vorsteuer 19 %",
+									"account_number": "1520",
 									"root_type": "Asset",
 									"tax_rate": 19.00
 								},
+								"description": "Abziehbare Vorsteuer 19 %",
 								"rate": 0.00
 							},
 							{
 								"account_head": {
-									"account_name": "Abziehbare Vorsteuer 7%",
-									"account_number": "1502",
+									"account_name": "Abziehbare Vorsteuer 7 %",
+									"account_number": "1521",
 									"root_type": "Asset",
 									"tax_rate": 7.00
 								},
+								"description": "Abziehbare Vorsteuer 7 %",
+								"rate": 0.00
+							}
+						]
+					},
+					{
+						"title": "Sonstige Leistung aus dem Inland",
+						"is_default": 0,
+						"taxes": [
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer 19 %",
+									"account_number": "1520",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"description": "Abziehbare Vorsteuer 19 %",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer 7 %",
+									"account_number": "1521",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"description": "Abziehbare Vorsteuer 7 %",
+								"rate": 0.00
+							}
+						]
+					},
+					{
+						"title": "Lieferung aus der EU",
+						"is_default": 0,
+						"taxes": [
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer aus innergemeinschaftlichen Erwerb 19 %",
+									"account_number": "1530",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"description": "Abziehbare Vorsteuer aus innergemeinschaftlichen Erwerb 19 %",
+								"add_deduct_tax": "Add",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer aus innergemeinschaftlichen Erwerb 7 %",
+									"account_number": "1531",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"description": "Abziehbare Vorsteuer aus innergemeinschaftlichen Erwerb 7 %",
+								"add_deduct_tax": "Add",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer aus innergemeinschaftlichen Erwerb 19 %",
+									"account_number": "2330",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"description": "Umsatzsteuer aus innergemeinschaftlichen Erwerb 19 %",
+								"add_deduct_tax": "Deduct",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer aus innergemeinschaftlichen Erwerb 7 %",
+									"account_number": "2331",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"description": "Umsatzsteuer aus innergemeinschaftlichen Erwerb 7 %",
+								"add_deduct_tax": "Deduct",
+								"rate": 0.00
+							}
+						]
+					},
+					{
+						"title": "Sonstige Leistung aus der EU",
+						"is_default": 0,
+						"taxes": [
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG 19%",
+									"account_number": "1540",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"description": "Abziehbare Vorsteuer nach § 13b UStG 19%",
+								"add_deduct_tax": "Add",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG 7%",
+									"account_number": "1541",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"description": "Abziehbare Vorsteuer nach § 13b UStG 7%",
+								"add_deduct_tax": "Add",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer nach § 13b UStG 19%",
+									"account_number": "2340",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"description": "Umsatzsteuer nach § 13b UStG 19%",
+								"add_deduct_tax": "Deduct",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer nach § 13b UStG 7%",
+									"account_number": "2341",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"description": "Umsatzsteuer nach § 13b UStG 7%",
+								"add_deduct_tax": "Deduct",
+								"rate": 0.00
+							}
+						]
+					},
+					{
+						"title": "Sonstige Leistung aus Drittland",
+						"is_default": 0,
+						"taxes": [
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG 19%",
+									"account_number": "1540",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"description": "Abziehbare Vorsteuer nach § 13b UStG 19%",
+								"add_deduct_tax": "Add",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG 7%",
+									"account_number": "1541",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"description": "Abziehbare Vorsteuer nach § 13b UStG 7%",
+								"add_deduct_tax": "Add",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer nach § 13b UStG 19%",
+									"account_number": "2340",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"description": "Umsatzsteuer nach § 13b UStG 19%",
+								"add_deduct_tax": "Deduct",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer nach § 13b UStG 7%",
+									"account_number": "2341",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"description": "Umsatzsteuer nach § 13b UStG 7%",
+								"add_deduct_tax": "Deduct",
+								"rate": 0.00
+							}
+						]
+					},
+					{
+						"title": "Lieferung aus Drittland",
+						"is_default": 0,
+						"taxes": [
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer 19 %",
+									"account_number": "1520",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"description": "Abziehbare Vorsteuer 19 %",
+								"add_deduct_tax": "Add",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer 7 %",
+									"account_number": "1521",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"description": "Abziehbare Vorsteuer 7 %",
+								"add_deduct_tax": "Add",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Entstandene Einfuhrumsatzsteuer",
+									"account_number": "1550",
+									"root_type": "Asset"
+								},
+								"description": "Entstandene Einfuhrumsatzsteuer",
+								"add_deduct_tax": "Deduct",
+								"rate": 0.00
+							}
+						]
+					},
+					{
+						"title": "Bauleistungen nach § 13b UStG",
+						"is_default": 0,
+						"taxes": [
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG 19%",
+									"account_number": "1540",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"description": "Abziehbare Vorsteuer nach § 13b UStG 19%",
+								"add_deduct_tax": "Add",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG 7%",
+									"account_number": "1541",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"description": "Abziehbare Vorsteuer nach § 13b UStG 7%",
+								"add_deduct_tax": "Add",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer nach § 13b UStG 19%",
+									"account_number": "2340",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"description": "Umsatzsteuer nach § 13b UStG 19%",
+								"add_deduct_tax": "Deduct",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer nach § 13b UStG 7%",
+									"account_number": "2341",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"description": "Umsatzsteuer nach § 13b UStG 7%",
+								"add_deduct_tax": "Deduct",
 								"rate": 0.00
 							}
 						]
@@ -852,54 +2393,66 @@
 				],
 				"item_tax_templates": [
 					{
-						"title": "Umsatzsteuer 19%",
+						"title": "19%",
 						"taxes": [
 							{
 								"tax_type": {
-									"account_name": "Umsatzsteuer 19%",
-									"account_number": "2301",
+									"account_name": "Umsatzsteuer 19 %",
+									"account_number": "2320",
+									"root_type": "Liability",
 									"tax_rate": 19.00
 								},
 								"tax_rate": 19.00
 							},
 							{
 								"tax_type": {
-									"account_name": "Umsatzsteuer 7%",
-									"account_number": "2302",
+									"account_name": "Umsatzsteuer 7 %",
+									"account_number": "2321",
+									"root_type": "Liability",
 									"tax_rate": 7.00
-								},
-								"tax_rate": 0.00
-							}
-						]
-					},
-					{
-						"title": "Umsatzsteuer 7%",
-						"taxes": [
-							{
-								"tax_type": {
-									"account_name": "Umsatzsteuer 19%",
-									"account_number": "2301",
-									"tax_rate": 19.00
 								},
 								"tax_rate": 0.00
 							},
 							{
 								"tax_type": {
-									"account_name": "Umsatzsteuer 7%",
-									"account_number": "2302",
-									"tax_rate": 7.00
+									"account_name": "Umsatzsteuer aus innergemeinschaftlichen Erwerb 19 %",
+									"account_number": "2330",
+									"root_type": "Liability",
+									"tax_rate": 19.00
 								},
-								"tax_rate": 7.00
-							}
-						]
-					},
-					{
-						"title": "Vorsteuer 19%",
-						"taxes": [
+								"tax_rate": 19.00
+							},
 							{
 								"tax_type": {
-									"account_name": "Abziehbare Vorsteuer 19%",
-									"account_number": "1501",
+									"account_name": "Umsatzsteuer aus innergemeinschaftlichen Erwerb 7 %",
+									"account_number": "2331",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer nach § 13b UStG 19%",
+									"account_number": "2340",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 19.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer nach § 13b UStG 7%",
+									"account_number": "2341",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer 19 %",
+									"account_number": "1520",
 									"root_type": "Asset",
 									"tax_rate": 19.00
 								},
@@ -907,22 +2460,120 @@
 							},
 							{
 								"tax_type": {
-									"account_name": "Abziehbare Vorsteuer 7%",
-									"account_number": "1502",
+									"account_name": "Abziehbare Vorsteuer 7 %",
+									"account_number": "1521",
 									"root_type": "Asset",
 									"tax_rate": 7.00
 								},
 								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer aus innergemeinschaftlichen Erwerb 19 %",
+									"account_number": "1530",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 19.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer aus innergemeinschaftlichen Erwerb 7 %",
+									"account_number": "1531",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG 19%",
+									"account_number": "1540",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 19.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG 7%",
+									"account_number": "1541",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Entstandene Einfuhrumsatzsteuer",
+									"account_number": "1550",
+									"root_type": "Asset"
+								},
+								"tax_rate": 19.00
 							}
 						]
 					},
 					{
-						"title": "Vorsteuer 7%",
+						"title": "7%",
 						"taxes": [
 							{
 								"tax_type": {
-									"account_name": "Abziehbare Vorsteuer 19%",
-									"account_number": "1501",
+									"account_name": "Umsatzsteuer 19 %",
+									"account_number": "2320",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer 7 %",
+									"account_number": "2321",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 7.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer aus innergemeinschaftlichen Erwerb 19 %",
+									"account_number": "2330",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer aus innergemeinschaftlichen Erwerb 7 %",
+									"account_number": "2331",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 7.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer nach § 13b UStG 19%",
+									"account_number": "2340",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 19.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer nach § 13b UStG 7%",
+									"account_number": "2341",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 7.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer 19 %",
+									"account_number": "1520",
 									"root_type": "Asset",
 									"tax_rate": 19.00
 								},
@@ -930,12 +2581,177 @@
 							},
 							{
 								"tax_type": {
-									"account_name": "Abziehbare Vorsteuer 7%",
-									"account_number": "1502",
+									"account_name": "Abziehbare Vorsteuer 7 %",
+									"account_number": "1521",
 									"root_type": "Asset",
 									"tax_rate": 7.00
 								},
 								"tax_rate": 7.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer aus innergemeinschaftlichen Erwerb 19 %",
+									"account_number": "1530",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer aus innergemeinschaftlichen Erwerb 7 %",
+									"account_number": "1531",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 7.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG 19%",
+									"account_number": "1540",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG 7%",
+									"account_number": "1541",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 7.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Entstandene Einfuhrumsatzsteuer",
+									"account_number": "1550",
+									"root_type": "Asset"
+								},
+								"tax_rate": 7.00
+							}
+						]
+					},
+					{
+						"title": "0 %",
+						"taxes": [
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer 19 %",
+									"account_number": "2320",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer 7 %",
+									"account_number": "2321",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer aus innergemeinschaftlichen Erwerb 19 %",
+									"account_number": "2330",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer aus innergemeinschaftlichen Erwerb 7 %",
+									"account_number": "2331",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer nach § 13b UStG 19%",
+									"account_number": "2340",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer nach § 13b UStG 7%",
+									"account_number": "2341",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer 19 %",
+									"account_number": "1520",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer 7 %",
+									"account_number": "1521",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer aus innergemeinschaftlichen Erwerb 19 %",
+									"account_number": "1530",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer aus innergemeinschaftlichen Erwerb 7 %",
+									"account_number": "1531",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG 19%",
+									"account_number": "1540",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG 7%",
+									"account_number": "1541",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Entstandene Einfuhrumsatzsteuer",
+									"account_number": "1550",
+									"root_type": "Asset"
+								},
+								"tax_rate": 0.00
 							}
 						]
 					}
@@ -944,47 +2760,361 @@
 			"*": {
 				"sales_tax_templates": [
 					{
-						"title": "Umsatzsteuer",
-						"tax_category": "Umsatzsteuer",
+						"title": "Lieferung oder sonstige Leistung im Inland",
 						"is_default": 1,
 						"taxes": [
 							{
 								"account_head": {
-									"account_name": "Umsatzsteuer 19%",
+									"account_name": "Umsatzsteuer 19 %",
 									"tax_rate": 19.00
 								},
+								"description": "Umsatzsteuer 19 %",
 								"rate": 0.00
 							},
 							{
 								"account_head": {
-									"account_name": "Umsatzsteuer 7%",
+									"account_name": "Umsatzsteuer 7 %",
 									"tax_rate": 7.00
 								},
+								"description": "Umsatzsteuer 7 %",
 								"rate": 0.00
 							}
 						]
+					},
+					{
+						"title": "Lieferung an Unternehmen in der EU",
+						"is_default": 0,
+						"taxes": []
+					},
+					{
+						"title": "Sonstige Leistung an Unternehmen in der EU",
+						"is_default": 0,
+						"taxes": []
+					},
+					{
+						"title": "Lieferung oder sonstige Leistung an nicht-Unternehmen in der EU",
+						"is_default": 0,
+						"taxes": [
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer 19 %",
+									"tax_rate": 19.00
+								},
+								"description": "Umsatzsteuer 19 %",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer 7 %",
+									"tax_rate": 7.00
+								},
+								"description": "Umsatzsteuer 7 %",
+								"rate": 0.00
+							}
+						]
+					},
+					{
+						"title": "Lieferung in Drittland",
+						"is_default": 0,
+						"taxes": []
+					},
+					{
+						"title": "Sonstige Leistung an Unternehmen in Drittland",
+						"is_default": 0,
+						"taxes": []
+					},
+					{
+						"title": "Sonstige Leistung an nicht-Unternehmen in Drittland",
+						"is_default": 0,
+						"taxes": [
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer 19 %",
+									"tax_rate": 19.00
+								},
+								"description": "Umsatzsteuer 19 %",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer 7 %",
+									"tax_rate": 7.00
+								},
+								"description": "Umsatzsteuer 7 %",
+								"rate": 0.00
+							}
+						]
+					},
+					{
+						"title": "Bauleistungen nach § 13b UStG",
+						"is_default": 0,
+						"taxes": []
 					}
 				],
 				"purchase_tax_templates": [
 					{
-						"title": "Vorsteuer 19%",
-						"tax_category": "Vorsteuer",
+						"title": "Lieferung aus dem Inland",
 						"is_default": 1,
 						"taxes": [
 							{
 								"account_head": {
-									"account_name": "Abziehbare Vorsteuer 19%",
-									"tax_rate": 19.00,
-									"root_type": "Asset"
+									"account_name": "Abziehbare Vorsteuer 19 %",
+									"root_type": "Asset",
+									"tax_rate": 19.00
 								},
+								"description": "Abziehbare Vorsteuer 19 %",
 								"rate": 0.00
 							},
 							{
 								"account_head": {
-									"account_name": "Abziehbare Vorsteuer 7%",
+									"account_name": "Abziehbare Vorsteuer 7 %",
 									"root_type": "Asset",
 									"tax_rate": 7.00
 								},
+								"description": "Abziehbare Vorsteuer 7 %",
+								"rate": 0.00
+							}
+						]
+					},
+					{
+						"title": "Sonstige Leistung aus dem Inland",
+						"is_default": 0,
+						"taxes": [
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer 19 %",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"description": "Abziehbare Vorsteuer 19 %",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer 7 %",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"description": "Abziehbare Vorsteuer 7 %",
+								"rate": 0.00
+							}
+						]
+					},
+					{
+						"title": "Lieferung aus der EU",
+						"is_default": 0,
+						"taxes": [
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer aus innergemeinschaftlichem Erwerb 19 %",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"description": "Abziehbare Vorsteuer aus innergemeinschaftlichem Erwerb 19 %",
+								"add_deduct_tax": "Add",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer aus innergemeinschaftlichem Erwerb",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"description": "Abziehbare Vorsteuer aus innergemeinschaftlichem Erwerb",
+								"add_deduct_tax": "Add",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer aus innergemeinschaftlichem Erwerb 19 %",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"description": "Umsatzsteuer aus innergemeinschaftlichem Erwerb 19 %",
+								"add_deduct_tax": "Deduct",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer aus innergemeinschaftlichem Erwerb",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"description": "Umsatzsteuer aus innergemeinschaftlichem Erwerb",
+								"add_deduct_tax": "Deduct",
+								"rate": 0.00
+							}
+						]
+					},
+					{
+						"title": "Sonstige Leistung aus der EU",
+						"is_default": 0,
+						"taxes": [
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG 19 %",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"description": "Abziehbare Vorsteuer nach § 13b UStG 19 %",
+								"add_deduct_tax": "Add",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"description": "Abziehbare Vorsteuer nach § 13b UStG",
+								"add_deduct_tax": "Add",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer nach § 13b UStG 19 %",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"description": "Umsatzsteuer nach § 13b UStG 19 %",
+								"add_deduct_tax": "Deduct",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer nach § 13b UStG",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"description": "Umsatzsteuer nach § 13b UStG",
+								"add_deduct_tax": "Deduct",
+								"rate": 0.00
+							}
+						]
+					},
+					{
+						"title": "Sonstige Leistung aus Drittland",
+						"is_default": 0,
+						"taxes": [
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG 19 %",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"description": "Abziehbare Vorsteuer nach § 13b UStG 19 %",
+								"add_deduct_tax": "Add",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"description": "Abziehbare Vorsteuer nach § 13b UStG",
+								"add_deduct_tax": "Add",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer nach § 13b UStG 19 %",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"description": "Umsatzsteuer nach § 13b UStG 19 %",
+								"add_deduct_tax": "Deduct",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer nach § 13b UStG",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"description": "Umsatzsteuer nach § 13b UStG",
+								"add_deduct_tax": "Deduct",
+								"rate": 0.00
+							}
+						]
+					},
+					{
+						"title": "Lieferung aus Drittland",
+						"is_default": 0,
+						"taxes": [
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer 19 %",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"description": "Abziehbare Vorsteuer 19 %",
+								"add_deduct_tax": "Add",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer 7 %",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"description": "Abziehbare Vorsteuer 7 %",
+								"add_deduct_tax": "Add",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Entstandene Einfuhrumsatzsteuer",
+									"root_type": "Asset"
+								},
+								"description": "Entstandene Einfuhrumsatzsteuer",
+								"add_deduct_tax": "Deduct",
+								"rate": 0.00
+							}
+						]
+					},
+					{
+						"title": "Bauleistungen nach § 13b UStG",
+						"is_default": 0,
+						"taxes": [
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG 19 %",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"description": "Abziehbare Vorsteuer nach § 13b UStG 19 %",
+								"add_deduct_tax": "Add",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"description": "Abziehbare Vorsteuer nach § 13b UStG",
+								"add_deduct_tax": "Add",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer nach § 13b UStG 19 %",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"description": "Umsatzsteuer nach § 13b UStG 19 %",
+								"add_deduct_tax": "Deduct",
+								"rate": 0.00
+							},
+							{
+								"account_head": {
+									"account_name": "Umsatzsteuer nach § 13b UStG",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"description": "Umsatzsteuer nach § 13b UStG",
+								"add_deduct_tax": "Deduct",
 								"rate": 0.00
 							}
 						]
@@ -992,49 +3122,59 @@
 				],
 				"item_tax_templates": [
 					{
-						"title": "Umsatzsteuer 19%",
+						"title": "19 %",
 						"taxes": [
 							{
 								"tax_type": {
-									"account_name": "Umsatzsteuer 19%",
+									"account_name": "Umsatzsteuer 19 %",
+									"root_type": "Liability",
 									"tax_rate": 19.00
 								},
 								"tax_rate": 19.00
 							},
 							{
 								"tax_type": {
-									"account_name": "Umsatzsteuer 7%",
+									"account_name": "Umsatzsteuer 7 %",
+									"root_type": "Liability",
 									"tax_rate": 7.00
-								},
-								"tax_rate": 0.00
-							}
-						]
-					},
-					{
-						"title": "Umsatzsteuer 7%",
-						"taxes": [
-							{
-								"tax_type": {
-									"account_name": "Umsatzsteuer 19%",
-									"tax_rate": 19.00
 								},
 								"tax_rate": 0.00
 							},
 							{
 								"tax_type": {
-									"account_name": "Umsatzsteuer 7%",
-									"tax_rate": 7.00
+									"account_name": "Umsatzsteuer aus innergemeinschaftlichem Erwerb 19 %",
+									"root_type": "Liability",
+									"tax_rate": 19.00
 								},
-								"tax_rate": 7.00
-							}
-						]
-					},
-					{
-						"title": "Vorsteuer 19%",
-						"taxes": [
+								"tax_rate": 19.00
+							},
 							{
 								"tax_type": {
-									"account_name": "Abziehbare Vorsteuer 19%",
+									"account_name": "Umsatzsteuer aus innergemeinschaftlichem Erwerb",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer nach § 13b UStG 19 %",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 19.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer nach § 13b UStG",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer 19 %",
 									"root_type": "Asset",
 									"tax_rate": 19.00
 								},
@@ -1042,20 +3182,107 @@
 							},
 							{
 								"tax_type": {
-									"account_name": "Abziehbare Vorsteuer 7%",
+									"account_name": "Abziehbare Vorsteuer 7 %",
 									"root_type": "Asset",
 									"tax_rate": 7.00
 								},
 								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer aus innergemeinschaftlichem Erwerb 19 %",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 19.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer aus innergemeinschaftlichem Erwerb",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG 19 %",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 19.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Entstandene Einfuhrumsatzsteuer",
+									"root_type": "Asset"
+								},
+								"tax_rate": 19.00
 							}
 						]
 					},
 					{
-						"title": "Vorsteuer 7%",
+						"title": "7 %",
 						"taxes": [
 							{
 								"tax_type": {
-									"account_name": "Abziehbare Vorsteuer 19%",
+									"account_name": "Umsatzsteuer 19 %",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer 7 %",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 7.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer aus innergemeinschaftlichem Erwerb 19 %",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer aus innergemeinschaftlichem Erwerb",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 7.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer nach § 13b UStG 19 %",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer nach § 13b UStG",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 7.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer 19 %",
 									"root_type": "Asset",
 									"tax_rate": 19.00
 								},
@@ -1063,11 +3290,158 @@
 							},
 							{
 								"tax_type": {
-									"account_name": "Abziehbare Vorsteuer 7%",
+									"account_name": "Abziehbare Vorsteuer 7 %",
 									"root_type": "Asset",
 									"tax_rate": 7.00
 								},
 								"tax_rate": 7.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer aus innergemeinschaftlichem Erwerb 19 %",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer aus innergemeinschaftlichem Erwerb",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 7.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG 19 %",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 7.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Entstandene Einfuhrumsatzsteuer",
+									"root_type": "Asset"
+								},
+								"tax_rate": 7.00
+							}
+						]
+					},
+					{
+						"title": "0%",
+						"taxes": [
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer 19 %",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer 7 %",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer aus innergemeinschaftlichem Erwerb 19 %",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer aus innergemeinschaftlichem Erwerb",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer nach § 13b UStG 19 %",
+									"root_type": "Liability",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Umsatzsteuer nach § 13b UStG",
+									"root_type": "Liability",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer 19 %",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer 7 %",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer aus innergemeinschaftlichem Erwerb 19 %",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer aus innergemeinschaftlichem Erwerb",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG 19 %",
+									"root_type": "Asset",
+									"tax_rate": 19.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Abziehbare Vorsteuer nach § 13b UStG",
+									"root_type": "Asset",
+									"tax_rate": 7.00
+								},
+								"tax_rate": 0.00
+							},
+							{
+								"tax_type": {
+									"account_name": "Entstandene Einfuhrumsatzsteuer",
+									"root_type": "Asset"
+								},
+								"tax_rate": 0.00
 							}
 						]
 					}


### PR DESCRIPTION
Cover more tax cases. Can be roughly summarized as follows:

(selling, buying) x (individual, company) x (Germany, EU country, third country) x (0-rate, reduced rate, full rate) x (services, goods)

### Sales Taxes and Charges Templates

- Lieferung oder sonstige Leistung im Inland
- Lieferung an Unternehmen in der EU
- Sonstige Leistung an Unternehmen in der EU
- Lieferung oder sonstige Leistung an nicht-Unternehmen in der EU
- Lieferung in Drittland
- Sonstige Leistung an Unternehmen in Drittland
- Sonstige Leistung an nicht-Unternehmen in Drittland
- Bauleistungen nach § 13b UStG

![Bildschirmfoto 2022-11-25 um 00 52 29](https://user-images.githubusercontent.com/14891507/203875763-a0035339-0e09-4256-83d7-a00e5fa10415.png)

![Bildschirmfoto 2022-11-25 um 00 52 40](https://user-images.githubusercontent.com/14891507/203875781-674c0fa0-a175-42a2-9a63-4bbd25c50e1f.png)

### Purchase Taxes and Charges Templates

- Lieferung aus dem Inland
- Sonstige Leistung aus dem Inland
- Lieferung aus der EU
- Sonstige Leistung aus der EU
- Sonstige Leistung aus Drittland
- Lieferung aus Drittland
- Bauleistungen nach § 13b UStG

![Bildschirmfoto 2022-11-25 um 00 52 04](https://user-images.githubusercontent.com/14891507/203875794-d5458266-c253-4c9c-a4dc-464e25bc5cfb.png)

![Bildschirmfoto 2022-11-25 um 00 52 14](https://user-images.githubusercontent.com/14891507/203875806-f4c66848-afe7-4c68-b483-1dc69db0a0aa.png)

### Item Tax Templates

- 0 %
- 7 %
- 19 %

![Bildschirmfoto 2022-11-25 um 00 52 52](https://user-images.githubusercontent.com/14891507/203875831-59c810db-2a36-4618-bc8d-d8d6e42a558d.png)

![Bildschirmfoto 2022-11-25 um 00 53 07](https://user-images.githubusercontent.com/14891507/203875844-5482d976-f251-42c2-80ee-93f747b9093a.png)

> Screenshots with CoA "SKR03 mit Kontonummern"
> no-docs