### PR TITLE
fix: opportunity list doesn't show assigned user

### DIFF
--- a/erpnext/crm/utils.py
+++ b/erpnext/crm/utils.py
@@ -120,7 +120,7 @@ def link_open_tasks(ref_doctype, ref_docname, doc):
 		todo_doc = frappe.get_doc("ToDo", todo.name)
 		todo_doc.reference_type = doc.doctype
 		todo_doc.reference_name = doc.name
-		todo_doc.db_update()
+		todo_doc.save()
 
 
 def link_open_events(ref_doctype, ref_docname, doc):


### PR DESCRIPTION
Because `db_update` is performed `_assign` property is not updated and
hence lead -> opportunity conversion makes it disappear from list view.

Steps to reproduce:

1. Create lead
2. Assign anyone
3. Create opportunity from lead.
4. Form view shows assigned user, list view wont.

reference: https://github.com/frappe/frappe/blob/7ebc0462fdef05a158786546397c9be177f729ca/frappe/desk/doctype/todo/todo.py#L67-L90