### PR TITLE
fix: remove product schema block from additional info section on item template

### DIFF
--- a/erpnext/templates/generators/item/item.html
+++ b/erpnext/templates/generators/item/item.html
@@ -32,7 +32,7 @@
 
 	<div class="product-container mt-4 {{ padding_top }} {{ info_col }}">
 		<div class="item-content {{ 'mt-minus-2' if (show_tabs and tabs) else '' }}">
-			<div class="product-page-content" itemscope itemtype="http://schema.org/Product">
+			<div class="product-page-content">
 				<!-- Product Specifications Table Section -->
 				{% if show_tabs and tabs %}
 					<div class="category-tabs">


### PR DESCRIPTION
Default product web page does not use any Structured Data markup tags using [Product Schema](https://schema.org/Product), in the Additional information/Reviews section.
<img width="1111" alt="Screenshot 2022-11-25 at 4 40 50 PM" src="https://user-images.githubusercontent.com/3272205/203974712-697ed836-5a4e-43aa-8149-9b4711181e86.png">

This breaks Rich text search crawler
<img width="1227" alt="Screenshot 2022-11-25 at 4 41 58 PM" src="https://user-images.githubusercontent.com/3272205/203974732-d3d6b16e-078a-4ec9-a089-ff9a2f66f986.png">


