### PR TITLE
feat: make Material Request for sub-assembly items

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan_sub_assembly_item/production_plan_sub_assembly_item.json
+++ b/erpnext/manufacturing/doctype/production_plan_sub_assembly_item/production_plan_sub_assembly_item.json
@@ -169,7 +169,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Manufacturing Type",
-   "options": "In House\nSubcontract"
+   "options": "In House\nSubcontract\nMaterial Request"
   },
   {
    "fieldname": "supplier",
@@ -188,7 +188,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2022-01-30 21:31:10.527559",
+ "modified": "2022-11-28 13:50:15.116082",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Production Plan Sub Assembly Item",


### PR DESCRIPTION
Use Case

There is 3 a level BOM

<img width="374" alt="image" src="https://user-images.githubusercontent.com/8780500/204244064-35b956ea-e77f-4bd4-a14a-ef1425d74236.png">


If I want to make Material Request for my Sub-assembly items from production plan then there is no option available because either I can make Subcontracting Order / Work Order against the Sub-assembly items. 
<img width="1102" alt="Screenshot 2022-11-28 at 1 39 50 PM" src="https://user-images.githubusercontent.com/8780500/204245466-ec62f1cd-92d6-421a-b3db-cdbcc989d6dc.png">



Solution 

Added option to make Material Request against the sub-assembly items

<img width="1071" alt="Screenshot 2022-11-28 at 3 09 22 PM" src="https://user-images.githubusercontent.com/8780500/204245489-b617545e-ffe6-4348-bd05-b408e0161cb4.png">


After this user has to click on "Get Raw Materials for Purchase" button to fetch Raw Materials as well Sub-assembly items in Material Request Plan Item child table

<img width="1118" alt="Screenshot 2022-11-28 at 3 09 55 PM" src="https://user-images.githubusercontent.com/8780500/204245809-f1136919-ce2f-4a78-b6a5-21b357d4d9fb.png">



Fixed https://github.com/frappe/erpnext/issues/26563

#docs https://docs.erpnext.com/docs/v14/user/manual/en/manufacturing/production-plan#231-sub-assembly-items