### PR TITLE
fix: reset `voucher_type` and `voucher_no` if `based_on` is set to `Transaction`

### DIFF
--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.js
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.js
@@ -34,6 +34,22 @@ frappe.ui.form.on('Repost Item Valuation', {
 		frm.trigger('setup_realtime_progress');
 	},
 
+	based_on: function(frm) {
+		var fields_to_reset = [];
+
+		if (frm.doc.based_on == 'Transaction') {
+			fields_to_reset = ['item_code', 'warehouse'];
+		} else if (frm.doc.based_on == 'Item and Warehouse') {
+			fields_to_reset = ['voucher_type', 'voucher_no'];
+		}
+
+		if (fields_to_reset) {
+			fields_to_reset.forEach(field => {
+				frm.set_value(field, undefined);
+			});
+		}
+	},
+
 	setup_realtime_progress: function(frm) {
 		frappe.realtime.on('item_reposting_progress', data => {
 			if (frm.doc.name !== data.name) {

--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
@@ -50,13 +50,15 @@
    "fieldname": "posting_date",
    "fieldtype": "Date",
    "label": "Posting Date",
+   "read_only_depends_on": "eval: doc.based_on == \"Transaction\"",
    "reqd": 1
   },
   {
    "fetch_from": "voucher_no.posting_time",
    "fieldname": "posting_time",
    "fieldtype": "Time",
-   "label": "Posting Time"
+   "label": "Posting Time",
+   "read_only_depends_on": "eval: doc.based_on == \"Transaction\""
   },
   {
    "default": "Queued",
@@ -195,7 +197,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2022-06-13 12:20:22.182322",
+ "modified": "2022-11-28 16:00:05.637440",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Repost Item Valuation",


### PR DESCRIPTION
**_Problem:_** Can't change `posting_date` and `posting_time` when `based_on` is set to `Item and Warehouse` and `voucher_type` and `voucher_no` is also set.


**_Steps to reproduce:_**

- Create Repost Item Valuation.
   - Set Based On as Transaction.
   - Select any Voucher Type and Voucher No.
- Change **Based On** value from `Transaction` to `Item and Warehouse`.
- Now, try to change the `Posting Date` or `Posting Time`.

**_Before:_** 

https://user-images.githubusercontent.com/63660334/204262634-8477318c-7383-465e-a190-cec87b320d35.mp4

**_After:_**

https://user-images.githubusercontent.com/63660334/204262800-08699732-377e-4a04-8397-0023355733e8.mp4
