### PR TITLE
fix: reposting error `AttributeError: 'datetime.timedelta' object has no attribute 'replace'`

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -263,7 +263,7 @@ def repost_future_sle(
 
 def validate_item_warehouse(args):
 	for field in ["item_code", "warehouse", "posting_date", "posting_time"]:
-		if not args.get(field):
+		if args.get(field) in [None, ""]:
 			validation_msg = f"The field {frappe.unscrub(field)} is required for the reposting"
 			frappe.throw(_(validation_msg))
 

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -264,7 +264,7 @@ def repost_future_sle(
 def validate_item_warehouse(args):
 	for field in ["item_code", "warehouse", "posting_date", "posting_time"]:
 		if not args.get(field):
-			validation_msg = f"The field {frappe.unscrub(args.get(field))} is required for the reposting"
+			validation_msg = f"The field {frappe.unscrub(field)} is required for the reposting"
 			frappe.throw(_(validation_msg))
 
 


### PR DESCRIPTION
ref: ISS-22-23-03518

Problem: Repost Item Valuation Entry gets failed if the `posting_time` is `00:00:00`.

![image](https://user-images.githubusercontent.com/63660334/204293533-9b6cdf00-4959-47a5-b3a2-2bb0515db21e.png)
