### PR TITLE
fix: incorrect balance qty

### DIFF
--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -230,7 +230,7 @@ class StockReconciliation(StockController):
 
 			if item.has_serial_no or item.has_batch_no:
 				has_serial_no = True
-				self.get_sle_for_serialized_items(row, sl_entries)
+				self.get_sle_for_serialized_items(row, sl_entries, item)
 			else:
 				if row.serial_no or row.batch_no:
 					frappe.throw(
@@ -282,7 +282,7 @@ class StockReconciliation(StockController):
 		if has_serial_no and sl_entries:
 			self.update_valuation_rate_for_serial_no()
 
-	def get_sle_for_serialized_items(self, row, sl_entries):
+	def get_sle_for_serialized_items(self, row, sl_entries, item):
 		from erpnext.stock.stock_ledger import get_previous_sle
 
 		serial_nos = get_serial_nos(row.serial_no)
@@ -348,7 +348,7 @@ class StockReconciliation(StockController):
 		if row.qty:
 			args = self.get_sle_for_items(row)
 
-			if row.serial_no and row.batch_no:
+			if item.has_serial_no and item.has_batch_no:
 				args["qty_after_transaction"] = row.qty
 
 			args.update(

--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -348,6 +348,9 @@ class StockReconciliation(StockController):
 		if row.qty:
 			args = self.get_sle_for_items(row)
 
+			if row.serial_no and row.batch_no:
+				args["qty_after_transaction"] = row.qty
+
 			args.update(
 				{
 					"actual_qty": row.qty,

--- a/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
@@ -644,6 +644,38 @@ class TestStockReconciliation(FrappeTestCase, StockTestMixin):
 		)
 		self.assertEqual(len(active_sr_no), 0)
 
+	def test_serial_no_batch_no_item(self):
+		item = self.make_item(
+			"Test Serial No Batch No Item",
+			{
+				"is_stock_item": 1,
+				"has_serial_no": 1,
+				"has_batch_no": 1,
+				"serial_no_series": "SRS9.####",
+				"batch_number_series": "BNS9.####",
+				"create_new_batch": 1,
+			},
+		)
+
+		warehouse = "_Test Warehouse - _TC"
+
+		sr = create_stock_reconciliation(
+			item_code=item.name,
+			warehouse=warehouse,
+			qty=1,
+			rate=100,
+		)
+
+		sl_entry = frappe.db.get_value(
+			"Stock Ledger Entry",
+			{"voucher_type": "Stock Reconciliation", "voucher_no": sr.name},
+			["actual_qty", "qty_after_transaction"],
+			as_dict=1,
+		)
+
+		self.assertEqual(flt(sl_entry.actual_qty), 1.0)
+		self.assertEqual(flt(sl_entry.qty_after_transaction), 1.0)
+
 
 def create_batch_item_with_batch(item_name, batch_id):
 	batch_item_doc = create_item(item_name, is_stock_item=1)


### PR DESCRIPTION
**Issue**

In the stock ledger report, for the Serialized Batch Item (Which has Serial and Batch No) after stock reconciliation the Balance Qty is showing as Zero.
<img width="1322" alt="image" src="https://user-images.githubusercontent.com/8780500/204342332-59f9f30f-fb24-4978-9672-22637631b3f3.png">


**After Fix**
<img width="1322" alt="Screenshot 2022-11-28 at 10 51 58 PM" src="https://user-images.githubusercontent.com/8780500/204342117-65d17cad-d2e7-4a2c-9530-c536efdeb7db.png">
