### PR TITLE
Update tax_rule.json

### DIFF
--- a/erpnext/accounts/doctype/tax_rule/tax_rule.json
+++ b/erpnext/accounts/doctype/tax_rule/tax_rule.json
@@ -129,6 +129,7 @@
    "fieldname": "tax_category",
    "fieldtype": "Link",
    "label": "Tax Category",
+   "reqd": 1,
    "options": "Tax Category"
   },
   {
@@ -225,7 +226,7 @@
   }
  ],
  "links": [],
- "modified": "2021-06-04 23:14:27.186879",
+ "modified": "2022-11-28 23:14:27.186879",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Tax Rule",


### PR DESCRIPTION
added required option to field that it is visible on UI. If not set you get an error when trying to save a Tax Rule.
![image](https://user-images.githubusercontent.com/22279621/204396518-384875a4-3015-481a-8b26-a237a7a3b0ac.png)

In the field we link a Template for Sales/Purchase Taxes & Charges
