### PR TITLE
fix: key error while filtering on date range and reporting on foreign currency

### DIFF
--- a/erpnext/accounts/doctype/fiscal_year/fiscal_year.py
+++ b/erpnext/accounts/doctype/fiscal_year/fiscal_year.py
@@ -169,5 +169,6 @@ def auto_create_fiscal_year():
 
 
 def get_from_and_to_date(fiscal_year):
-	fields = ["year_start_date as from_date", "year_end_date as to_date"]
-	return frappe.get_cached_value("Fiscal Year", fiscal_year, fields, as_dict=1)
+	fields = ["year_start_date", "year_end_date"]
+	cached_results = frappe.get_cached_value("Fiscal Year", fiscal_year, fields, as_dict=1)
+	return dict(from_date=cached_results.year_start_date, to_date=cached_results.year_end_date)

--- a/erpnext/accounts/report/utils.py
+++ b/erpnext/accounts/report/utils.py
@@ -28,7 +28,7 @@ def get_currency(filters):
 		filters["presentation_currency"] if filters.get("presentation_currency") else company_currency
 	)
 
-	report_date = filters.get("to_date")
+	report_date = filters.get("period_end_date")
 
 	if not report_date:
 		fiscal_year_to_date = get_from_and_to_date(filters.get("to_fiscal_year"))["to_date"]

--- a/erpnext/accounts/report/utils.py
+++ b/erpnext/accounts/report/utils.py
@@ -28,7 +28,7 @@ def get_currency(filters):
 		filters["presentation_currency"] if filters.get("presentation_currency") else company_currency
 	)
 
-	report_date = filters.get("period_end_date")
+	report_date = filters.get("to_date") or filters.get("period_end_date")
 
 	if not report_date:
 		fiscal_year_to_date = get_from_and_to_date(filters.get("to_fiscal_year"))["to_date"]


### PR DESCRIPTION
Financial Reports - P/L and Balance sheet, throw Key error while filtering on date range and reporting on a foreign currency.

<img width="1203" alt="Screenshot 2022-12-01 at 3 35 14 PM" src="https://user-images.githubusercontent.com/3272205/205024867-bb79b815-fe09-4e45-8a3c-28e1696d5687.png">

1. Regression in `get_from_and_to_date` by https://github.com/frappe/erpnext/pull/32836 https://github.com/frappe/erpnext/blob/d23b5d8f2fc9bdf2e0f267fbaf38bdf11167fc87/erpnext/accounts/doctype/fiscal_year/fiscal_year.py#L162-L164


2. `get_currency` should handle both Fiscal Year and Manual date range in General Ledger, P/L Report and Balance sheet. https://github.com/frappe/erpnext/blob/d23b5d8f2fc9bdf2e0f267fbaf38bdf11167fc87/erpnext/accounts/report/utils.py#L31
