### PR TITLE
fix: type error on Sales Pipeline Analytics

### DIFF
--- a/erpnext/crm/report/sales_pipeline_analytics/sales_pipeline_analytics.py
+++ b/erpnext/crm/report/sales_pipeline_analytics/sales_pipeline_analytics.py
@@ -217,7 +217,7 @@ class SalesPipelineAnalytics(object):
 
 	def check_for_assigned_to(self, period, value, count_or_amount, assigned_to, info):
 		if self.filters.get("assigned_to"):
-			for data in json.loads(info.get("opportunity_owner")):
+			for data in json.loads(info.get("opportunity_owner") or "[]"):
 				if data == self.filters.get("assigned_to"):
 					self.set_formatted_data(period, data, count_or_amount, assigned_to)
 		else:


### PR DESCRIPTION
Type Error while filtering Sales Pipeline Analytics on Owner.
<img width="1203" alt="Screenshot 2022-12-01 at 6 12 02 PM" src="https://user-images.githubusercontent.com/3272205/205055632-788c20d7-12bd-4fc5-a58b-197409b79d96.png">
