### PR TITLE
fix(v13 patch): website_image field not copied when creating Website Items

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -375,3 +375,4 @@ erpnext.patches.v13_0.show_hr_payroll_deprecation_warning
 erpnext.patches.v13_0.create_accounting_dimensions_for_asset_repair
 execute:frappe.db.set_value("Naming Series", "Naming Series", {"select_doc_for_series": "", "set_options": "", "prefix": "", "current_value": 0, "user_must_always_select": 0})
 erpnext.patches.v13_0.update_schedule_type_in_loans
+erpnext.patches.v13_0.create_website_items_imagefix

--- a/erpnext/patches/v13_0/create_website_items_imagefix.py
+++ b/erpnext/patches/v13_0/create_website_items_imagefix.py
@@ -1,0 +1,12 @@
+import frappe
+
+
+def execute():
+    "Copy website_image field from Item if image is not already populated"
+    for website_item_name in frappe.db.get_list(
+        "Website Item", {"image": ("=", "")}, pluck="name"
+    ):
+        witem = frappe.get_doc("Website Item", website_item_name)
+        image = frappe.db.get_value("Item", witem.item_code, "website_image")
+        witem.image = image
+        witem.save()


### PR DESCRIPTION
When upgrading, item images are not copied to the new Website Items