### PR TITLE
fix(selling): allow arbitrary quotation lines

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -524,7 +524,7 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 
 		item.weight_per_unit = 0;
 		item.weight_uom = '';
-		item.conversion_factor = 0;
+		item.conversion_factor = 1;
 
 		if(['Sales Invoice'].includes(this.frm.doc.doctype)) {
 			update_stock = cint(me.frm.doc.update_stock);

--- a/erpnext/selling/doctype/quotation_item/quotation_item.json
+++ b/erpnext/selling/doctype/quotation_item/quotation_item.json
@@ -90,7 +90,6 @@
    "oldfieldtype": "Link",
    "options": "Item",
    "print_width": "150px",
-   "reqd": 1,
    "search_index": 1,
    "width": "150px"
   },
@@ -189,6 +188,7 @@
    "reqd": 1
   },
   {
+   "default": "1.00",
    "fieldname": "conversion_factor",
    "fieldtype": "Float",
    "label": "UOM Conversion Factor",
@@ -649,7 +649,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2021-07-15 12:40:51.074820",
+ "modified": "2022-11-04 17:41:57.301086",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Quotation Item",


### PR DESCRIPTION
Just as for Sales Invoices, it should be possible to create Quotation lines without an item code.
Should also apply to Sales Orders