### PR TITLE
fix: add translation variable index

### DIFF
--- a/erpnext/controllers/status_updater.py
+++ b/erpnext/controllers/status_updater.py
@@ -349,7 +349,7 @@ class StatusUpdater(Document):
 	def warn_about_bypassing_with_role(self, item, qty_or_amount, role):
 		action = _("Over Receipt/Delivery") if qty_or_amount == "qty" else _("Overbilling")
 
-		msg = _("{} of {} {} ignored for item {} because you have {} role.").format(
+		msg = _("{0} of {1} {2} ignored for item {3} because you have {4} role.").format(
 			action,
 			_(item["target_ref_field"].title()),
 			frappe.bold(item["reduce_by"]),

--- a/erpnext/translations/de.csv
+++ b/erpnext/translations/de.csv
@@ -9914,3 +9914,4 @@ Cost and Freight,Kosten und Fracht,
 Delivered at Place,Geliefert benannter Ort,
 Delivered at Place Unloaded,Geliefert benannter Ort entladen,
 Delivered Duty Paid,Geliefert verzollt,
+{0} of {1} {2} ignored for item {3} because you have {4} role,"{0} von Artikel {3} mit {1} {2} wurde ignoriert, weil Sie die Rolle {4} haben."


### PR DESCRIPTION
Add index to variables, because in other languages the order can be different.

This string is not yet contained in any other translation files.