### PR TITLE
fix: handle asset depreciation entries posting failure, show error alert and send email

### DIFF
--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -136,6 +136,10 @@ frappe.ui.form.on('Asset', {
 				}, __("Manage"));
 			}
 
+			if (frm.doc.depr_entry_posting_status === "Failed") {
+				frm.trigger("set_depr_posting_failure_alert");
+			}
+
 			frm.trigger("setup_chart");
 		}
 
@@ -144,6 +148,19 @@ frappe.ui.form.on('Asset', {
 		if (frm.doc.docstatus == 0) {
 			frm.toggle_reqd("finance_books", frm.doc.calculate_depreciation);
 		}
+	},
+
+	set_depr_posting_failure_alert: function (frm) {
+		const alert = `
+			<div class="row">
+				<div class="col-xs-12 col-sm-6">
+					<span class="indicator whitespace-nowrap red">
+						<span>Failed to post depreciation entries</span>
+					</span>
+				</div>
+			</div>`;
+
+		frm.dashboard.set_headline_alert(alert);
 	},
 
 	toggle_reference_doc: function(frm) {

--- a/erpnext/assets/doctype/asset/asset.json
+++ b/erpnext/assets/doctype/asset/asset.json
@@ -70,6 +70,7 @@
   "column_break_51",
   "purchase_receipt_amount",
   "default_finance_book",
+  "depr_entry_posting_status",
   "amended_from"
  ],
  "fields": [
@@ -488,6 +489,16 @@
    "fieldtype": "Int",
    "label": "Asset Quantity",
    "read_only_depends_on": "eval:!doc.is_existing_asset"
+  },
+  {
+   "fieldname": "depr_entry_posting_status",
+   "fieldtype": "Select",
+   "hidden": 1,
+   "label": "Depreciation Entry Posting Status",
+   "no_copy": 1,
+   "options": "\nSuccessful\nFailed",
+   "print_hide": 1,
+   "read_only": 1
   }
  ],
  "idx": 72,
@@ -510,7 +521,7 @@
    "link_fieldname": "asset"
   }
  ],
- "modified": "2022-07-20 10:15:12.887372",
+ "modified": "2022-12-05 16:21:30.024060",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset",

--- a/erpnext/assets/doctype/asset/depreciation.py
+++ b/erpnext/assets/doctype/asset/depreciation.py
@@ -5,9 +5,8 @@
 import frappe
 from frappe import _
 from frappe.utils import add_months, cint, flt, getdate, nowdate, today
-from frappe.utils.user import get_users_with_role
 from frappe.utils.data import get_link_to_form
-
+from frappe.utils.user import get_users_with_role
 
 from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
 	get_checks_for_pl_and_bs_accounts,
@@ -226,9 +225,7 @@ def notify_depr_entry_posting_error_to_account_managers(failed_asset_names):
 	message = (
 		_("Hi,")
 		+ "<br>"
-		+_(
-			"The following assets have failed to post depreciation entries: {0}"
-		).format(asset_links)
+		+ _("The following assets have failed to post depreciation entries: {0}").format(asset_links)
 		+ "."
 	)
 

--- a/erpnext/assets/doctype/asset/depreciation.py
+++ b/erpnext/assets/doctype/asset/depreciation.py
@@ -5,6 +5,9 @@
 import frappe
 from frappe import _
 from frappe.utils import add_months, cint, flt, getdate, nowdate, today
+from frappe.utils.user import get_users_with_role
+from frappe.utils.data import get_link_to_form
+
 
 from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
 	get_checks_for_pl_and_bs_accounts,
@@ -12,7 +15,7 @@ from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
 from erpnext.accounts.doctype.journal_entry.journal_entry import make_reverse_journal_entry
 
 
-def post_depreciation_entries(date=None, commit=True):
+def post_depreciation_entries(date=None):
 	# Return if automatic booking of asset depreciation is disabled
 	if not cint(
 		frappe.db.get_value("Accounts Settings", None, "book_asset_depreciation_entry_automatically")
@@ -21,10 +24,22 @@ def post_depreciation_entries(date=None, commit=True):
 
 	if not date:
 		date = today()
-	for asset in get_depreciable_assets(date):
-		make_depreciation_entry(asset, date)
-		if commit:
+
+	failed_asset_names = []
+
+	for asset_name in get_depreciable_assets(date):
+		try:
+			make_depreciation_entry(asset_name, date)
 			frappe.db.commit()
+		except Exception as e:
+			frappe.db.rollback()
+			failed_asset_names.append(asset_name)
+
+	if failed_asset_names:
+		mark_asset_depr_entry_posting_status_as_failed(failed_asset_names)
+		notify_depr_entry_posting_error_to_account_managers(failed_asset_names)
+
+	frappe.db.commit()
 
 
 def get_depreciable_assets(date):
@@ -123,6 +138,10 @@ def make_depreciation_entry(asset_name, date=None):
 			finance_books.value_after_depreciation -= d.depreciation_amount
 			finance_books.db_update()
 
+	asset.flags.ignore_validate_update_after_submit = True
+	asset.depr_entry_posting_status = "Successful"
+	asset.save()
+
 	asset.set_status()
 
 	return asset
@@ -184,6 +203,47 @@ def get_credit_and_debit_accounts(accumulated_depreciation_account, depreciation
 		frappe.throw(_("Depreciation Expense Account should be an Income or Expense Account."))
 
 	return credit_account, debit_account
+
+
+def mark_asset_depr_entry_posting_status_as_failed(failed_asset_names):
+	for asset_name in failed_asset_names:
+		asset = frappe.get_doc("Asset", asset_name)
+		asset.flags.ignore_validate_update_after_submit = True
+		asset.depr_entry_posting_status = "Failed"
+		asset.save()
+
+
+def notify_depr_entry_posting_error_to_account_managers(failed_asset_names):
+	recipients = get_users_with_role("Accounts Manager")
+
+	if not recipients:
+		recipients = get_users_with_role("System Manager")
+
+	subject = _("Error while posting depreciation entries")
+
+	asset_links = get_comma_separated_asset_links(failed_asset_names)
+
+	message = (
+		_("Hi,")
+		+ "<br>"
+		+_(
+			"The following assets have failed to post depreciation entries: {0}"
+		).format(asset_links)
+		+ "."
+	)
+
+	frappe.sendmail(recipients=recipients, subject=subject, message=message)
+
+
+def get_comma_separated_asset_links(asset_names):
+	asset_links = []
+
+	for asset_name in asset_names:
+		asset_links.append(get_link_to_form("Asset", asset_name))
+
+	asset_links = ", ".join(asset_links)
+
+	return asset_links
 
 
 @frappe.whitelist()

--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -1478,6 +1478,7 @@ def create_asset(**args):
 			"asset_owner": args.asset_owner or "Company",
 			"is_existing_asset": args.is_existing_asset or 1,
 			"asset_quantity": args.get("asset_quantity") or 1,
+			"depr_entry_posting_status": args.depr_entry_posting_status or "",
 		}
 	)
 


### PR DESCRIPTION
Before, if depreciation entries for 100 assets were to be posted (through the `post_depreciation_entries` daily job) and an error is encountered while posting the entries of the 10th asset, entries for rest of the 90 assets aren't posted. Additionally, even though an error log would be created for this, customers wouldn’t be notified of this in any way, so they often go days before noticing that an asset is not depreciating properly.

Now, if depreciation posting fails for the 10th asset, entries for rest of the 90 assets are posted. All the users with the `Accounts Manager` or `System Manager` role are sent an email. An alert (`Failed to post depreciation entries`) is shown on the asset, which would only go away once the issue with the asset is fixed and the entries are successfully posted.