### PR TITLE
fix: use highest precision for exchange rate.

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.json
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.json
@@ -305,6 +305,7 @@
    "fieldname": "source_exchange_rate",
    "fieldtype": "Float",
    "label": "Exchange Rate",
+   "precision": "9",
    "print_hide": 1,
    "reqd": 1
   },
@@ -334,6 +335,7 @@
    "fieldname": "target_exchange_rate",
    "fieldtype": "Float",
    "label": "Exchange Rate",
+   "precision": "9",
    "print_hide": 1,
    "reqd": 1
   },
@@ -731,7 +733,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2022-02-23 20:08:39.559814",
+ "modified": "2022-12-08 16:25:43.824051",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Entry",


### PR DESCRIPTION
Update payment entry exchange rate fields to use highest precision setting.

This is to follow the same convention as:
`Sales Invoice`: 

https://github.com/frappe/erpnext/blob/7d41f63c5dc409878c98304a361bf21589ac0552/erpnext/accounts/doctype/sales_invoice/sales_invoice.json#L615

`Purchase Invoice`: 

https://github.com/frappe/erpnext/blob/7d41f63c5dc409878c98304a361bf21589ac0552/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json#L492