### PR TITLE
fix: maintain same rate throughout sales cycle doesn't work with quotation

### DIFF
--- a/erpnext/selling/doctype/quotation/test_quotation.py
+++ b/erpnext/selling/doctype/quotation/test_quotation.py
@@ -33,10 +33,8 @@ class TestQuotation(FrappeTestCase):
 	def test_maintain_rate_in_sales_cycle_is_enforced(self):
 		from erpnext.selling.doctype.quotation.quotation import make_sales_order
 
-		maintain_rate = frappe.db.get_value(
-			"Selling Settings", "Selling Settings", "maintain_same_sales_rate"
-		)
-		frappe.db.set_value("Selling Settings", "Selling Settings", "maintain_same_sales_rate", 1)
+		maintain_rate = frappe.db.get_single_value("Selling Settings", "maintain_same_sales_rate")
+		frappe.db.set_single_value("Selling Settings", "maintain_same_sales_rate", 1)
 
 		quotation = frappe.copy_doc(test_records[0])
 		quotation.transaction_date = nowdate()
@@ -48,9 +46,7 @@ class TestQuotation(FrappeTestCase):
 		sales_order.items[0].rate = 1
 		self.assertRaises(frappe.ValidationError, sales_order.save)
 
-		frappe.db.set_value(
-			"Selling Settings", "Selling Settings", "maintain_same_sales_rate", maintain_rate
-		)
+		frappe.db.set_single_value("Selling Settings", "maintain_same_sales_rate", maintain_rate)
 
 	def test_make_sales_order_with_different_currency(self):
 		from erpnext.selling.doctype.quotation.quotation import make_sales_order

--- a/erpnext/selling/doctype/quotation/test_quotation.py
+++ b/erpnext/selling/doctype/quotation/test_quotation.py
@@ -33,6 +33,11 @@ class TestQuotation(FrappeTestCase):
 	def test_maintain_rate_in_sales_cycle_is_enforced(self):
 		from erpnext.selling.doctype.quotation.quotation import make_sales_order
 
+		maintain_rate = frappe.db.get_value(
+			"Selling Settings", "Selling Settings", "maintain_same_sales_rate"
+		)
+		frappe.db.set_value("Selling Settings", "Selling Settings", "maintain_same_sales_rate", 1)
+
 		quotation = frappe.copy_doc(test_records[0])
 		quotation.transaction_date = nowdate()
 		quotation.valid_till = add_months(quotation.transaction_date, 1)
@@ -42,6 +47,10 @@ class TestQuotation(FrappeTestCase):
 		sales_order = make_sales_order(quotation.name)
 		sales_order.items[0].rate = 1
 		self.assertRaises(frappe.ValidationError, sales_order.save)
+
+		frappe.db.set_value(
+			"Selling Settings", "Selling Settings", "maintain_same_sales_rate", maintain_rate
+		)
 
 	def test_make_sales_order_with_different_currency(self):
 		from erpnext.selling.doctype.quotation.quotation import make_sales_order

--- a/erpnext/selling/doctype/quotation/test_quotation.py
+++ b/erpnext/selling/doctype/quotation/test_quotation.py
@@ -30,6 +30,19 @@ class TestQuotation(FrappeTestCase):
 
 		self.assertTrue(sales_order.get("payment_schedule"))
 
+	def test_maintain_rate_in_sales_cycle_is_enforced(self):
+		from erpnext.selling.doctype.quotation.quotation import make_sales_order
+
+		quotation = frappe.copy_doc(test_records[0])
+		quotation.transaction_date = nowdate()
+		quotation.valid_till = add_months(quotation.transaction_date, 1)
+		quotation.insert()
+		quotation.submit()
+
+		sales_order = make_sales_order(quotation.name)
+		sales_order.items[0].rate = 1
+		self.assertRaises(frappe.ValidationError, sales_order.save)
+
 	def test_make_sales_order_with_different_currency(self):
 		from erpnext.selling.doctype.quotation.quotation import make_sales_order
 

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -194,7 +194,7 @@ class SalesOrder(SellingController):
 		)
 
 		if cint(frappe.db.get_single_value("Selling Settings", "maintain_same_sales_rate")):
-			self.validate_rate_with_reference_doc([["Quotation", "prev_docname", "quotation_item"]])
+			self.validate_rate_with_reference_doc([["Quotation", "prevdoc_docname", "quotation_item"]])
 
 	def update_enquiry_status(self, prevdoc, flag):
 		enq = frappe.db.sql(


### PR DESCRIPTION
Issue #29976  was partly fixed by #32923 but the problem still persists. The reason is because an incorrect fieldname was passed to the `validate_rate_with_reference_doc` method.

This commit fixes it.

version-14-hotfix

version-13-hotfix
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
