### PR TITLE
Subscription Cost center value is fixed to Default value(Bug fix)

### DIFF
--- a/erpnext/accounts/doctype/subscription/subscription.py
+++ b/erpnext/accounts/doctype/subscription/subscription.py
@@ -280,7 +280,8 @@ class Subscription(Document):
 		self.validate_plans_billing_cycle(self.get_billing_cycle_and_interval())
 		self.validate_end_date()
 		self.validate_to_follow_calendar_months()
-		self.cost_center = erpnext.get_default_cost_center(self.get("company"))
+		if not self.cost_center:
+			self.cost_center = erpnext.get_default_cost_center(self.get("company"))
 
 	def validate_trial_period(self):
 		"""


### PR DESCRIPTION
`self.cost_center ` field value keeps changing to `erpnext.get_default_cost_center(self.get("company"))` after validation of this doctype. This overrides the user input.
**Simple fix,** 
It will first check if the field is empty, if empty then puts the company's default cost center value if not then user input will be saved.

