### PR TITLE
chore!: remove activity log feeds

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -34,9 +34,6 @@ class JournalEntry(AccountsController):
 	def __init__(self, *args, **kwargs):
 		super(JournalEntry, self).__init__(*args, **kwargs)
 
-	def get_feed(self):
-		return self.voucher_type
-
 	def validate(self):
 		if self.voucher_type == "Opening Entry":
 			self.is_opening = "Yes"

--- a/erpnext/buying/doctype/supplier/supplier.py
+++ b/erpnext/buying/doctype/supplier/supplier.py
@@ -20,9 +20,6 @@ from erpnext.utilities.transaction_base import TransactionBase
 
 
 class Supplier(TransactionBase):
-	def get_feed(self):
-		return self.supplier_name
-
 	def onload(self):
 		"""Load address and contacts in `__onload`"""
 		load_address_and_contact(self)

--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -25,10 +25,6 @@ class BuyingController(SubcontractingController):
 	def __setup__(self):
 		self.flags.ignore_permlevel_for_fields = ["buying_price_list", "price_list_currency"]
 
-	def get_feed(self):
-		if self.get("supplier_name"):
-			return _("From {0} | {1} {2}").format(self.supplier_name, self.currency, self.grand_total)
-
 	def validate(self):
 		super(BuyingController, self).validate()
 		if getattr(self, "supplier", None) and not self.supplier_name:

--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -19,9 +19,6 @@ class SellingController(StockController):
 	def __setup__(self):
 		self.flags.ignore_permlevel_for_fields = ["selling_price_list", "price_list_currency"]
 
-	def get_feed(self):
-		return _("To {0} | {1} {2}").format(self.customer_name, self.currency, self.grand_total)
-
 	def onload(self):
 		super(SellingController, self).onload()
 		if self.doctype in ("Sales Order", "Delivery Note", "Sales Invoice"):

--- a/erpnext/crm/doctype/lead/lead.py
+++ b/erpnext/crm/doctype/lead/lead.py
@@ -14,9 +14,6 @@ from erpnext.crm.utils import CRMNote, copy_comments, link_communications, link_
 
 
 class Lead(SellingController, CRMNote):
-	def get_feed(self):
-		return "{0}: {1}".format(_(self.status), self.lead_name)
-
 	def onload(self):
 		customer = frappe.db.get_value("Customer", {"lead_name": self.name})
 		self.get("__onload").is_customer = customer

--- a/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py
+++ b/erpnext/maintenance/doctype/maintenance_visit/maintenance_visit.py
@@ -10,9 +10,6 @@ from erpnext.utilities.transaction_base import TransactionBase
 
 
 class MaintenanceVisit(TransactionBase):
-	def get_feed(self):
-		return _("To {0}").format(self.customer_name)
-
 	def validate_serial_no(self):
 		for d in self.get("purposes"):
 			if d.serial_no and not frappe.db.exists("Serial No", d.serial_no):

--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -15,9 +15,6 @@ from erpnext.setup.doctype.holiday_list.holiday_list import is_holiday
 
 
 class Project(Document):
-	def get_feed(self):
-		return "{0}: {1}".format(_(self.status), frappe.safe_decode(self.project_name))
-
 	def onload(self):
 		self.set_onload(
 			"activity_summary",

--- a/erpnext/projects/doctype/task/task.py
+++ b/erpnext/projects/doctype/task/task.py
@@ -20,9 +20,6 @@ class CircularReferenceError(frappe.ValidationError):
 class Task(NestedSet):
 	nsm_parent_field = "parent_task"
 
-	def get_feed(self):
-		return "{0}: {1}".format(_(self.status), self.subject)
-
 	def get_customer_details(self):
 		cust = frappe.db.sql("select customer_name from `tabCustomer` where name=%s", self.customer)
 		if cust:

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -27,9 +27,6 @@ from erpnext.utilities.transaction_base import TransactionBase
 
 
 class Customer(TransactionBase):
-	def get_feed(self):
-		return self.customer_name
-
 	def onload(self):
 		"""Load address and contacts in `__onload`"""
 		load_address_and_contact(self)

--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -22,9 +22,6 @@ form_grid_templates = {"items": "templates/form_grid/material_request_grid.html"
 
 
 class MaterialRequest(BuyingController):
-	def get_feed(self):
-		return
-
 	def check_if_already_pulled(self):
 		pass
 

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -83,9 +83,6 @@ class StockEntry(StockController):
 				}
 			)
 
-	def get_feed(self):
-		return self.stock_entry_type
-
 	def onload(self):
 		for item in self.get("items"):
 			item.update(get_bin_details(item.item_code, item.s_warehouse))

--- a/erpnext/support/doctype/issue/issue.py
+++ b/erpnext/support/doctype/issue/issue.py
@@ -18,9 +18,6 @@ from frappe.utils.user import is_website_user
 
 
 class Issue(Document):
-	def get_feed(self):
-		return "{0}: {1}".format(_(self.status), self.subject)
-
 	def validate(self):
 		if self.is_new() and self.via_customer_portal:
 			self.flags.create_communication = True

--- a/erpnext/support/doctype/warranty_claim/warranty_claim.py
+++ b/erpnext/support/doctype/warranty_claim/warranty_claim.py
@@ -10,9 +10,6 @@ from erpnext.utilities.transaction_base import TransactionBase
 
 
 class WarrantyClaim(TransactionBase):
-	def get_feed(self):
-		return _("{0}: From {1}").format(self.status, self.customer_name)
-
 	def validate(self):
 		if session["user"] != "Guest" and not self.customer:
 			frappe.throw(_("Customer is required"))


### PR DESCRIPTION
- This contains little to no information and practically no one uses this.
- Also causes a lot of problem by adding way too many feeds in activity
  log to the point where activity page doesn't even load.

Mildly breaking. Don't backport.