### PR TITLE
fix: incorrect balance on parent company on consolidate Balance sheet due to key mismatch

### DIFF
--- a/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py
+++ b/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py
@@ -533,12 +533,13 @@ def get_accounts(root_type, companies):
 			],
 			filters={"company": company, "root_type": root_type},
 		):
-			if account.account_name not in added_accounts:
+			if account.account_number:
+				account_key = account.account_number + "-" + account.account_name
+			else:
+				account_key = account.account_name
+
+			if account_key not in added_accounts:
 				accounts.append(account)
-				if account.account_number:
-					account_key = account.account_number + "-" + account.account_name
-				else:
-					account_key = account.account_name
 				added_accounts.append(account_key)
 
 	return accounts


### PR DESCRIPTION
1. Create a Parent company and 2 child companies. Ex: Parent 1 -> Node 1, Node 2
2. Create an Account with account number in the Parent company. Ex: 101 - HDFC
3. Perform a transaction on Parent company against account created on [2]

Balance Sheet:
<img width="996" alt="Screenshot 2022-12-12 at 8 28 23 PM" src="https://user-images.githubusercontent.com/3272205/207078682-a5462c45-cd2c-4d9c-81d1-80f6170f8ef3.png">

Consolidated Balance Sheet - without fix:
Report has no output. This is incorrect.
<img width="996" alt="Screenshot 2022-12-12 at 8 28 56 PM" src="https://user-images.githubusercontent.com/3272205/207078810-0188f6a2-bdab-4439-a0c7-ae7e08efc042.png">

Consolidated Balance Sheet - with fix:
<img width="996" alt="Screenshot 2022-12-12 at 8 28 31 PM" src="https://user-images.githubusercontent.com/3272205/207078831-7854e7f2-f548-48ad-9aee-4da0099cc9c2.png">

regression: https://github.com/frappe/erpnext/pull/32052