### PR TITLE
fix: Permission issue in Tax Detail report

### DIFF
--- a/erpnext/accounts/report/tax_detail/tax_detail.py
+++ b/erpnext/accounts/report/tax_detail/tax_detail.py
@@ -234,8 +234,11 @@ def modify_report_columns(doctype, field, column):
 		if field in ["item_tax_rate", "base_net_amount"]:
 			return None
 
-	if doctype == "GL Entry" and field in ["debit", "credit"]:
-		column.update({"label": _("Amount"), "fieldname": "amount"})
+	if doctype == "GL Entry":
+		if field in ["debit", "credit"]:
+			column.update({"label": _("Amount"), "fieldname": "amount"})
+		elif field == "voucher_type":
+			column.update({"fieldtype": "Data", "options": ""})
 
 	if field == "taxes_and_charges":
 		column.update({"label": _("Taxes and Charges Template")})


### PR DESCRIPTION
Permission issue was coming due to unsufficient permission on doctype DocType

Error Traceback:
```
request.js:462 Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 56, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 53, in handle
    return _RESTAPIHandler(call, doctype, name).get_response()
  File "apps/frappe/frappe/api.py", line 69, in get_response
    return self.handle_method()
  File "apps/frappe/frappe/api.py", line 79, in handle_method
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 45, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 83, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1586, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/__init__.py", line 780, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "apps/frappe/frappe/desk/query_report.py", line 249, in run
    result = generate_report_result(report, filters, user, custom_columns, is_tree, parent_field)
  File "apps/frappe/frappe/__init__.py", line 780, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "apps/frappe/frappe/desk/query_report.py", line 114, in generate_report_result
    result = get_filtered_data(report.ref_doctype, columns, result, user)
  File "apps/frappe/frappe/desk/query_report.py", line 563, in get_filtered_data
    match_filters_per_doctype = get_user_match_filters(linked_doctypes, user=user)
  File "apps/frappe/frappe/desk/query_report.py", line 746, in get_user_match_filters
    filter_list = frappe.desk.reportview.build_match_conditions(dt, user, False)
  File "apps/frappe/frappe/desk/reportview.py", line 682, in build_match_conditions
    match_conditions = DatabaseQuery(doctype, user=user).build_match_conditions(
  File "apps/frappe/frappe/model/db_query.py", line 746, in build_match_conditions
    frappe.throw(_("No permission to read {0}").format(_(self.doctype)), frappe.PermissionError)
  File "apps/frappe/frappe/__init__.py", line 521, in throw
    msgprint(
  File "apps/frappe/frappe/__init__.py", line 489, in msgprint
    _raise_exception()
  File "apps/frappe/frappe/__init__.py", line 441, in _raise_exception
    raise raise_exception(msg)
frappe.exceptions.PermissionError: No permission to read DocType
```