### PR TITLE
fix: `Enough Parts to Build` in `BOM Stock Report`

### DIFF
--- a/erpnext/manufacturing/report/bom_stock_report/bom_stock_report.py
+++ b/erpnext/manufacturing/report/bom_stock_report/bom_stock_report.py
@@ -4,7 +4,7 @@
 
 import frappe
 from frappe import _
-from frappe.query_builder.functions import Floor, Sum
+from frappe.query_builder.functions import Sum
 from pypika.terms import ExistsCriterion
 
 
@@ -58,9 +58,9 @@ def get_bom_stock(filters):
 			bom_item.description,
 			bom_item.stock_qty,
 			bom_item.stock_uom,
-			bom_item.stock_qty * qty_to_produce / bom.quantity,
-			Sum(bin.actual_qty).as_("actual_qty"),
-			Sum(Floor(bin.actual_qty / (bom_item.stock_qty * qty_to_produce / bom.quantity))),
+			(bom_item.stock_qty / bom.quantity) * qty_to_produce,
+			Sum(bin.actual_qty),
+			Sum(bin.actual_qty) / (bom_item.stock_qty / bom.quantity),
 		)
 		.where((bom_item.parent == filters.get("bom")) & (bom_item.parenttype == "BOM"))
 		.groupby(bom_item.item_code)


### PR DESCRIPTION
closes: #33145

Before:

![image](https://user-images.githubusercontent.com/63660334/207265622-bd2ca298-ea92-41aa-ba30-0acd14c4bdc7.png)

After:

![image](https://user-images.githubusercontent.com/63660334/207265555-216cb255-6cdc-41eb-8aea-af05d42678f4.png)

#32735
