### PR TITLE
fix: in gross profit report

### DIFF
--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -503,7 +503,7 @@ class GrossProfitGenerator(object):
 						invoice_portion = 100
 					elif row.invoice_portion:
 						invoice_portion = row.invoice_portion
-					else:
+					elif row.payment_amount:
 						invoice_portion = row.payment_amount * 100 / row.base_net_amount
 
 					if i == 0:


### PR DESCRIPTION
**Issue:**
![image](https://user-images.githubusercontent.com/95605271/207512279-b7c58875-9229-49de-b79e-943bb8c65484.png)

In Gross Profit Report, while using the payment term grouping it will thrown an above error, nonetype cannot be multiply by int.

**Changes:**

I will add the elif instead of else, in elif condition check whether the variable has value or nonetype, if variable has the value condition allow to multiply otherwise not allow, so above issue will solve.