### PR TITLE
fix: get_serial_nos_for_fg() missing 1 required positional argument: …

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -2236,16 +2236,16 @@ class StockEntry(StockController):
 			d.qty -= process_loss_dict[d.item_code][1]
 
 	def set_serial_no_batch_for_finished_good(self):
-		serial_nos = ""
+		serial_nos = []
 		if self.pro_doc.serial_no:
-			serial_nos = self.get_serial_nos_for_fg()
+			serial_nos = self.get_serial_nos_for_fg() or []
 
 		for row in self.items:
 			if row.is_finished_item and row.item_code == self.pro_doc.production_item:
 				if serial_nos:
 					row.serial_no = "\n".join(serial_nos[0 : cint(row.qty)])
 
-	def get_serial_nos_for_fg(self, args):
+	def get_serial_nos_for_fg(self):
 		fields = [
 			"`tabStock Entry`.`name`",
 			"`tabStock Entry Detail`.`qty`",
@@ -2261,9 +2261,7 @@ class StockEntry(StockController):
 		]
 
 		stock_entries = frappe.get_all("Stock Entry", fields=fields, filters=filters)
-
-		if self.pro_doc.serial_no:
-			return self.get_available_serial_nos(stock_entries)
+		return self.get_available_serial_nos(stock_entries)
 
 	def get_available_serial_nos(self, stock_entries):
 		used_serial_nos = []


### PR DESCRIPTION
**Issue**

```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 69, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 38, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 76, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1457, in call
    return fn(*args, **newargs)
  File "apps/erpnext/erpnext/manufacturing/doctype/work_order/work_order.py", line 1209, in make_stock_entry
    stock_entry.set_serial_no_batch_for_finished_good()
  File "apps/erpnext/erpnext/stock/doctype/stock_entry/stock_entry.py", line 2197, in set_serial_no_batch_for_finished_good
    serial_nos = self.get_serial_nos_for_fg()
TypeError: get_serial_nos_for_fg() missing 1 required positional argument: 'args'
```

Fixed https://github.com/frappe/erpnext/issues/33273