### PR TITLE
feat(exotel): make use of `CustomField` in API

### DIFF
--- a/erpnext/erpnext_integrations/doctype/exotel_settings/exotel_settings.json
+++ b/erpnext/erpnext_integrations/doctype/exotel_settings/exotel_settings.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "creation": "2019-05-21 07:41:53.536536",
  "doctype": "DocType",
  "engine": "InnoDB",
@@ -7,10 +8,14 @@
   "section_break_2",
   "account_sid",
   "api_key",
-  "api_token"
+  "api_token",
+  "section_break_6",
+  "map_custom_field_to_doctype",
+  "target_doctype"
  ],
  "fields": [
   {
+   "default": "0",
    "fieldname": "enabled",
    "fieldtype": "Check",
    "label": "Enabled"
@@ -18,7 +23,8 @@
   {
    "depends_on": "enabled",
    "fieldname": "section_break_2",
-   "fieldtype": "Section Break"
+   "fieldtype": "Section Break",
+   "label": "Credentials"
   },
   {
    "fieldname": "account_sid",
@@ -34,10 +40,31 @@
    "fieldname": "api_key",
    "fieldtype": "Data",
    "label": "API Key"
+  },
+  {
+   "depends_on": "enabled",
+   "fieldname": "section_break_6",
+   "fieldtype": "Section Break",
+   "label": "Custom Field"
+  },
+  {
+   "default": "0",
+   "fieldname": "map_custom_field_to_doctype",
+   "fieldtype": "Check",
+   "label": "Map Custom Field to DocType"
+  },
+  {
+   "depends_on": "map_custom_field_to_doctype",
+   "fieldname": "target_doctype",
+   "fieldtype": "Link",
+   "label": "Target DocType",
+   "mandatory_depends_on": "map_custom_field_to_doctype",
+   "options": "DocType"
   }
  ],
  "issingle": 1,
- "modified": "2019-05-22 06:25:18.026997",
+ "links": [],
+ "modified": "2022-12-14 17:24:50.176107",
  "modified_by": "Administrator",
  "module": "ERPNext Integrations",
  "name": "Exotel Settings",
@@ -57,5 +84,6 @@
  "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "ASC",
+ "states": [],
  "track_changes": 1
 }

--- a/erpnext/erpnext_integrations/exotel_integration.py
+++ b/erpnext/erpnext_integrations/exotel_integration.py
@@ -72,6 +72,24 @@ def get_call_log(call_payload):
 		return frappe.get_doc("Call Log", call_log_id)
 
 
+def map_custom_field(call_payload, call_log):
+	field_value = call_payload.get("CustomField")
+
+	if not field_value:
+		return call_log
+
+	settings = get_exotel_settings()
+	target_doctype = settings.target_doctype
+	mapping_enabled = settings.map_custom_field_to_doctype
+
+	if not mapping_enabled or not target_doctype:
+		return call_log
+
+	call_log.append("links", {"link_doctype": target_doctype, "link_name": field_value})
+
+	return call_log
+
+
 def create_call_log(call_payload):
 	call_log = frappe.new_doc("Call Log")
 	call_log.id = call_payload.get("CallSid")
@@ -79,6 +97,7 @@ def create_call_log(call_payload):
 	call_log.medium = call_payload.get("To")
 	call_log.status = "Ringing"
 	setattr(call_log, "from", call_payload.get("CallFrom"))
+	map_custom_field(call_payload, call_log)
 	call_log.save(ignore_permissions=True)
 	frappe.db.commit()
 	return call_log

--- a/erpnext/erpnext_integrations/exotel_integration.py
+++ b/erpnext/erpnext_integrations/exotel_integration.py
@@ -93,10 +93,10 @@ def get_call_status(call_id):
 
 
 @frappe.whitelist()
-def make_a_call(from_number, to_number, caller_id):
+def make_a_call(from_number, to_number, caller_id, **kwargs):
 	endpoint = get_exotel_endpoint("Calls/connect.json?details=true")
 	response = requests.post(
-		endpoint, data={"From": from_number, "To": to_number, "CallerId": caller_id}
+		endpoint, data={"From": from_number, "To": to_number, "CallerId": caller_id, **kwargs}
 	)
 
 	return response.json()


### PR DESCRIPTION
This PR adds an option to map `CustomField` in Exotel `StatusCallback` to any DocType

<p align="center">
<img width="536" alt="Screenshot 2022-12-26 at 11 06 55 AM" src="https://user-images.githubusercontent.com/28098330/209507372-7f588918-215f-4ec7-9d0d-0fe3bee1a579.png">
<br>
<em>Exotel Settings</em>
</p>

Exotel documentation: https://developer.exotel.com/api/make-a-call-api

`no-docs`