### PR TITLE
feat: Add operating cost based on bom quanity without creating job card

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.json
+++ b/erpnext/manufacturing/doctype/bom/bom.json
@@ -33,6 +33,9 @@
   "column_break_23",
   "transfer_material_against",
   "routing",
+  "fg_based_operating_cost",
+  "fg_based_section_section",
+  "operating_cost_per_bom_quantity",
   "operations_section",
   "operations",
   "materials_section",
@@ -575,7 +578,26 @@
   {
    "fieldname": "scrap_items_section",
    "fieldtype": "Section Break",
-   "label": "Scrap Items"
+   "label": "Scrap Items",
+   "hide_border": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "fg_based_operating_cost",
+   "fieldtype": "Check",
+   "label": "FG based Operating Cost"
+  },
+  {
+   "depends_on": "fg_based_operating_cost",
+   "fieldname": "fg_based_section_section",
+   "fieldtype": "Section Break",
+   "label": "FG Based Operating Cost Section"
+  },
+  {
+   "depends_on": "fg_based_operating_cost",
+   "fieldname": "operating_cost_per_bom_quantity",
+   "fieldtype": "Currency",
+   "label": "Operating Cost Per BOM Quantity"
   }
  ],
  "icon": "fa fa-sitemap",

--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -614,18 +614,24 @@ class BOM(WebsiteGenerator):
 		"""Update workstation rate and calculates totals"""
 		self.operating_cost = 0
 		self.base_operating_cost = 0
-		for d in self.get("operations"):
-			if d.workstation:
-				self.update_rate_and_time(d, update_hour_rate)
+		if (self.get("with_operations")):
+			for d in self.get("operations"):
+				if d.workstation:
+					self.update_rate_and_time(d, update_hour_rate)
 
-			operating_cost = d.operating_cost
-			base_operating_cost = d.base_operating_cost
-			if d.set_cost_based_on_bom_qty:
-				operating_cost = flt(d.cost_per_unit) * flt(self.quantity)
-				base_operating_cost = flt(d.base_cost_per_unit) * flt(self.quantity)
+				operating_cost = d.operating_cost
+				base_operating_cost = d.base_operating_cost
+				if d.set_cost_based_on_bom_qty:
+					operating_cost = flt(d.cost_per_unit) * flt(self.quantity)
+					base_operating_cost = flt(d.base_cost_per_unit) * flt(self.quantity)
 
-			self.operating_cost += flt(operating_cost)
-			self.base_operating_cost += flt(base_operating_cost)
+				self.operating_cost += flt(operating_cost)
+				self.base_operating_cost += flt(base_operating_cost)
+
+		elif(self.get("fg_based_operating_cost")):
+			total_operating_cost = flt(self.get("quantity")) * flt(self.get("operating_cost_per_bom_quantity"))
+			self.operating_cost = total_operating_cost
+			self.base_operating_cost = flt(total_operating_cost * self.conversion_rate, 2)
 
 	def update_rate_and_time(self, row, update_hour_rate=False):
 		if not row.hour_rate or update_hour_rate:

--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -614,7 +614,7 @@ class BOM(WebsiteGenerator):
 		"""Update workstation rate and calculates totals"""
 		self.operating_cost = 0
 		self.base_operating_cost = 0
-		if (self.get("with_operations")):
+		if self.get("with_operations"):
 			for d in self.get("operations"):
 				if d.workstation:
 					self.update_rate_and_time(d, update_hour_rate)
@@ -628,8 +628,10 @@ class BOM(WebsiteGenerator):
 				self.operating_cost += flt(operating_cost)
 				self.base_operating_cost += flt(base_operating_cost)
 
-		elif(self.get("fg_based_operating_cost")):
-			total_operating_cost = flt(self.get("quantity")) * flt(self.get("operating_cost_per_bom_quantity"))
+		elif self.get("fg_based_operating_cost"):
+			total_operating_cost = flt(self.get("quantity")) * flt(
+				self.get("operating_cost_per_bom_quantity")
+			)
 			self.operating_cost = total_operating_cost
 			self.base_operating_cost = flt(total_operating_cost * self.conversion_rate, 2)
 

--- a/erpnext/manufacturing/doctype/bom/test_records.json
+++ b/erpnext/manufacturing/doctype/bom/test_records.json
@@ -162,5 +162,31 @@
   "item": "_Test Variant Item",
   "quantity": 1.0,
   "with_operations": 1
+ },
+ {
+  "items": [
+   {
+    "amount": 5000.0,
+    "doctype": "BOM Item",
+    "item_code": "_Test Item",
+    "parentfield": "items",
+    "qty": 2.0,
+    "rate": 3000.0,
+    "uom": "_Test UOM",
+    "stock_uom": "_Test UOM",
+    "source_warehouse": "_Test Warehouse - _TC",
+    "include_item_in_manufacturing": 1
+   }
+  ],
+  "docstatus": 1,
+  "doctype": "BOM",
+  "is_active": 1,
+  "is_default": 1,
+  "currency": "USD",
+  "item": "_Test Variant Item",
+  "quantity": 1.0,
+  "with_operations": 0,
+  "fg_based_operating_cost": 1,
+  "operating_cost_per_bom_quantity": 140
  }
 ]


### PR DESCRIPTION
Problem Statement: Across Manufacturing organisation with multiple operation and illiterate job worker its difficult to create job card. Hence it should be record operating cost per finished good Item. 
Step 1. Add Per BOM quantity operating cost in bom
Step 2. You will see Planned operating cost in BOM
Setp 3. In Manufactured Stock Entry it will record operating_cost_per_bom_quantity * FG Quantity 

Why this change:
1. Need operating cost but want to skip job card need sku based operating cost.

Step1. Add operating cost per BOM quanity. operating cost = 45*10 = 450 as shown in pic
![BOM-Makhana_7-107-006](https://user-images.githubusercontent.com/6947417/207785408-906eec89-2122-4b49-a862-a1746285c630.png)

Final Manufactured stock entry without job card
![Manufacture-MAT-STE-2022-00088](https://user-images.githubusercontent.com/6947417/207785726-f32a55d9-82a3-4182-92ce-7799171fed45.png)



GIF:

https://user-images.githubusercontent.com/6947417/207784936-d9159dfb-c2de-43a0-a6b7-2d41503b8cac.mp4

`no-docs`