### PR TITLE
fix: unsupported operand type(s) for +: 'int' and 'NoneType'

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -828,9 +828,9 @@ def insert_item_price(args):
 	):
 		if frappe.has_permission("Item Price", "write"):
 			price_list_rate = (
-				(args.rate + args.discount_amount) / args.get("conversion_factor")
+				(flt(args.rate) + flt(args.discount_amount)) / args.get("conversion_factor")
 				if args.get("conversion_factor")
-				else (args.rate + args.discount_amount)
+				else (flt(args.rate) + flt(args.discount_amount))
 			)
 
 			item_price = frappe.db.get_value(


### PR DESCRIPTION
**Error**

```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 69, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 38, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 76, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1457, in call
    return fn(*args, **newargs)
  File "apps/erpnext/erpnext/stock/get_item_details.py", line 91, in get_item_details
    out.update(get_price_list_rate(args, item))
  File "apps/erpnext/erpnext/stock/get_item_details.py", line 792, in get_price_list_rate
    insert_item_price(args)
  File "apps/erpnext/erpnext/stock/get_item_details.py", line 817, in insert_item_price
    if args.get("conversion_factor")
TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'
```