### PR TITLE
fix: disabled items showing in the report Itemwise Recommended Reorder Level

### DIFF
--- a/erpnext/stock/report/itemwise_recommended_reorder_level/itemwise_recommended_reorder_level.py
+++ b/erpnext/stock/report/itemwise_recommended_reorder_level/itemwise_recommended_reorder_level.py
@@ -82,7 +82,7 @@ def get_item_info(filters):
 			item.safety_stock,
 			item.lead_time_days,
 		)
-		.where(item.is_stock_item == 1)
+		.where((item.is_stock_item == 1) & (item.disabled == 0))
 	)
 
 	if brand := filters.get("brand"):


### PR DESCRIPTION
**Issue**

Disabled items are showing in the report "Itemwise Recommended Reorder Level"