### PR TITLE
feat: Ignore company related doctype for other apps via hooks

### DIFF
--- a/erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py
+++ b/erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py
@@ -204,7 +204,7 @@ class TransactionDeletionRecord(Document):
 
 @frappe.whitelist()
 def get_doctypes_to_be_ignored():
-	doctypes_to_be_ignored_list = [
+	doctypes_to_be_ignored = [
 		"Account",
 		"Cost Center",
 		"Warehouse",
@@ -223,4 +223,7 @@ def get_doctypes_to_be_ignored():
 		"Customer",
 		"Supplier",
 	]
-	return doctypes_to_be_ignored_list
+
+	doctypes_to_be_ignored.extend(frappe.get_hooks("company_data_to_be_ignored") or [])
+
+	return doctypes_to_be_ignored


### PR DESCRIPTION
Ignore company linked doctypes from other apps via hooks on clearing transactions

`no-docs`