### PR TITLE
fix: Payment Term wise Gross Profit

### DIFF
--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -504,7 +504,7 @@ class GrossProfitGenerator(object):
 					elif row.invoice_portion:
 						invoice_portion = row.invoice_portion
 					elif row.payment_amount:
-						invoice_portion = row.payment_amount * 100 / row.base_net_amount
+						invoice_portion = flt(row.payment_amount) * flt(100) / flt(row.base_net_amount)
 
 					if i == 0:
 						new_row = row


### PR DESCRIPTION
**Version:**

ERPNext: v14.10.1 (HEAD)
Frappe Framework: v14.19.1 (HEAD)
___

**Before:**

- When selecting the group by Payment Term then faced errors like TypeError: unsupported operand type(s) for *: 'NoneType' and 'int'.

https://user-images.githubusercontent.com/34390782/208060387-33fbb8cf-9ece-45e5-a646-fe033f797d29.mp4

**After:**

- When selecting the group by Payment Term then will show properly.


https://user-images.githubusercontent.com/34390782/208060613-c6a30dcd-1b48-42d4-8704-76524c057cc3.mp4


Thank You!