### PR TITLE
feat: add after_refresh hook to item dashboard

### DIFF
--- a/erpnext/stock/dashboard/item_dashboard.js
+++ b/erpnext/stock/dashboard/item_dashboard.js
@@ -97,11 +97,14 @@ erpnext.stock.ItemDashboard = class ItemDashboard {
 		};
 
 		var me = this;
-		return frappe.call({
+		frappe.call({
 			method: this.method,
 			args: args,
 			callback: function (r) {
 				me.render(r.message);
+				if(me.after_refresh) {
+					me.after_refresh();
+				}
 			}
 		});
 	}

--- a/erpnext/stock/dashboard/item_dashboard.js
+++ b/erpnext/stock/dashboard/item_dashboard.js
@@ -97,7 +97,7 @@ erpnext.stock.ItemDashboard = class ItemDashboard {
 		};
 
 		var me = this;
-		frappe.call({
+		return frappe.call({
 			method: this.method,
 			args: args,
 			callback: function (r) {


### PR DESCRIPTION
When using the ItemDashboard and developer wants to make some modification after data is fetched. An after_refresh hook is required.

`no-docs`