### PR TITLE
fix: unsupported operand type(s) for +=: 'int' and 'NoneType'

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -192,13 +192,13 @@ class PickList(Document):
 
 			if item_map.get(key):
 				item_map[key].qty += item.qty
-				item_map[key].stock_qty += item.stock_qty
+				item_map[key].stock_qty += flt(item.stock_qty, item.precision("stock_qty"))
 			else:
 				item_map[key] = item
 
 			# maintain count of each item (useful to limit get query)
 			self.item_count_map.setdefault(item_code, 0)
-			self.item_count_map[item_code] += item.stock_qty
+			self.item_count_map[item_code] += flt(item.stock_qty, item.precision("stock_qty"))
 
 		return item_map.values()
 


### PR DESCRIPTION
**Issue**

```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 69, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 38, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 76, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1457, in call
    return fn(*args, **newargs)
  File "apps/erpnext/erpnext/manufacturing/doctype/work_order/work_order.py", line 1441, in create_pick_list
    doc.set_item_locations()
  File "apps/erpnext/erpnext/stock/doctype/pick_list/pick_list.py", line 115, in set_item_locations
    items = self.aggregate_item_qty()
  File "apps/erpnext/erpnext/stock/doctype/pick_list/pick_list.py", line 190, in aggregate_item_qty
    self.item_count_map[item_code] += item.stock_qty
TypeError: unsupported operand type(s) for +=: 'int' and 'NoneType'
```