### PR TITLE
refactor: Customer and Supplier Ledger summary will have hidden fields for better handling of user permission

### DIFF
--- a/erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.js
+++ b/erpnext/accounts/report/supplier_ledger_summary/supplier_ledger_summary.js
@@ -64,24 +64,6 @@ frappe.query_reports["Supplier Ledger Summary"] = {
 			"options": "Payment Terms Template"
 		},
 		{
-			"fieldname":"territory",
-			"label": __("Territory"),
-			"fieldtype": "Link",
-			"options": "Territory"
-		},
-		{
-			"fieldname":"sales_partner",
-			"label": __("Sales Partner"),
-			"fieldtype": "Link",
-			"options": "Sales Partner"
-		},
-		{
-			"fieldname":"sales_person",
-			"label": __("Sales Person"),
-			"fieldtype": "Link",
-			"options": "Sales Person"
-		},
-		{
 			"fieldname":"tax_id",
 			"label": __("Tax Id"),
 			"fieldtype": "Data",

--- a/erpnext/setup/doctype/customer_group/customer_group.json
+++ b/erpnext/setup/doctype/customer_group/customer_group.json
@@ -139,10 +139,11 @@
  "idx": 1,
  "is_tree": 1,
  "links": [],
- "modified": "2021-02-08 17:01:52.162202",
+ "modified": "2022-12-24 11:15:17.142746",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Customer Group",
+ "naming_rule": "By fieldname",
  "nsm_parent_field": "parent_customer_group",
  "owner": "Administrator",
  "permissions": [
@@ -198,10 +199,19 @@
    "role": "Customer",
    "select": 1,
    "share": 1
+  },
+  {
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Accounts User",
+   "share": 1
   }
  ],
  "search_fields": "parent_customer_group",
  "show_name_in_global_search": 1,
  "sort_field": "modified",
- "sort_order": "DESC"
+ "sort_order": "DESC",
+ "states": []
 }

--- a/erpnext/setup/doctype/supplier_group/supplier_group.json
+++ b/erpnext/setup/doctype/supplier_group/supplier_group.json
@@ -6,6 +6,7 @@
  "creation": "2013-01-10 16:34:24",
  "doctype": "DocType",
  "document_type": "Setup",
+ "engine": "InnoDB",
  "field_order": [
   "supplier_group_name",
   "parent_supplier_group",
@@ -106,10 +107,11 @@
  "idx": 1,
  "is_tree": 1,
  "links": [],
- "modified": "2020-03-18 18:10:49.228407",
+ "modified": "2022-12-24 11:16:12.486719",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Supplier Group",
+ "naming_rule": "By fieldname",
  "nsm_parent_field": "parent_supplier_group",
  "owner": "Administrator",
  "permissions": [
@@ -156,8 +158,18 @@
    "permlevel": 1,
    "read": 1,
    "role": "Purchase User"
+  },
+  {
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Accounts User",
+   "share": 1
   }
  ],
  "show_name_in_global_search": 1,
- "sort_order": "ASC"
+ "sort_field": "modified",
+ "sort_order": "ASC",
+ "states": []
 }

--- a/erpnext/setup/doctype/territory/territory.json
+++ b/erpnext/setup/doctype/territory/territory.json
@@ -123,11 +123,12 @@
  "idx": 1,
  "is_tree": 1,
  "links": [],
- "modified": "2021-02-08 17:10:03.767426",
+ "modified": "2022-12-24 11:16:39.964956",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Territory",
  "name_case": "Title Case",
+ "naming_rule": "By fieldname",
  "nsm_parent_field": "parent_territory",
  "owner": "Administrator",
  "permissions": [
@@ -175,10 +176,19 @@
    "role": "Customer",
    "select": 1,
    "share": 1
+  },
+  {
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "report": 1,
+   "role": "Accounts User",
+   "share": 1
   }
  ],
  "search_fields": "parent_territory,territory_manager",
  "show_name_in_global_search": 1,
  "sort_field": "modified",
- "sort_order": "DESC"
+ "sort_order": "DESC",
+ "states": []
 }


### PR DESCRIPTION
Changes in this PR:
1. Removed following filters from Supplier Ledger Summary as they are unrelated to Purchase Invoice: `Territory`, `Sales Partner` and `Sales Person`.
2.  'Accounts User' role now has `read` permission for `Territory`, `Customer Group` and `Supplier Group` doctypes. This is so that users' with said role can make use of the Filters. Previously, it just threw 'Permission Error'.
3. Hidden fields - `Territory`, `Customer Group` in Customer Ledger Summary and `Supplier Group` in Supplier Ledger Summary will be added to report output for handling User Permission based access control. 