### PR TITLE
feat: Accounting Dimension updation in Payment Request and Entry

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -1758,6 +1758,8 @@ def get_payment_entry(
 	pe.setup_party_account_field()
 	pe.set_missing_values()
 
+	update_accounting_dimensions(pe, doc)
+
 	if party_account and bank:
 		pe.set_exchange_rate(ref_doc=reference_doc)
 		pe.set_amounts()
@@ -1773,6 +1775,18 @@ def get_payment_entry(
 			pe.set_difference_amount()
 
 	return pe
+
+
+def update_accounting_dimensions(pe, doc):
+	"""
+	Updates accounting dimensions in Payment Entry based on the accounting dimensions in the reference document
+	"""
+	from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
+		get_accounting_dimensions,
+	)
+
+	for dimension in get_accounting_dimensions():
+		pe.set(dimension, doc.get(dimension))
 
 
 def get_bank_cash_account(doc, bank_account):

--- a/erpnext/accounts/doctype/payment_request/payment_request.json
+++ b/erpnext/accounts/doctype/payment_request/payment_request.json
@@ -32,6 +32,10 @@
   "iban",
   "branch_code",
   "swift_number",
+  "accounting_dimensions_section",
+  "cost_center",
+  "dimension_col_break",
+  "project",
   "recipient_and_message",
   "print_format",
   "email_to",
@@ -362,13 +366,35 @@
    "label": "Payment Channel",
    "options": "\nEmail\nPhone",
    "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "accounting_dimensions_section",
+   "fieldtype": "Section Break",
+   "label": "Accounting Dimensions"
+  },
+  {
+   "fieldname": "cost_center",
+   "fieldtype": "Link",
+   "label": "Cost Center",
+   "options": "Cost Center"
+  },
+  {
+   "fieldname": "dimension_col_break",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "project",
+   "fieldtype": "Link",
+   "label": "Project",
+   "options": "Project"
   }
  ],
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2022-09-30 16:19:43.680025",
+ "modified": "2022-12-21 16:56:40.115737",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Request",

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -319,3 +319,4 @@ erpnext.patches.v14_0.create_accounting_dimensions_for_asset_capitalization
 erpnext.patches.v14_0.update_partial_tds_fields
 erpnext.patches.v14_0.create_incoterms_and_migrate_shipment
 erpnext.patches.v14_0.setup_clear_repost_logs
+erpnext.patches.v14_0.create_accounting_dimensions_for_payment_request

--- a/erpnext/patches/v14_0/create_accounting_dimensions_for_payment_request.py
+++ b/erpnext/patches/v14_0/create_accounting_dimensions_for_payment_request.py
@@ -1,0 +1,31 @@
+import frappe
+from frappe.custom.doctype.custom_field.custom_field import create_custom_field
+
+
+def execute():
+	accounting_dimensions = frappe.db.get_all(
+		"Accounting Dimension", fields=["fieldname", "label", "document_type", "disabled"]
+	)
+
+	if not accounting_dimensions:
+		return
+
+	doctype = "Payment Request"
+
+	for d in accounting_dimensions:
+		field = frappe.db.get_value("Custom Field", {"dt": doctype, "fieldname": d.fieldname})
+
+		if field:
+			continue
+
+		df = {
+			"fieldname": d.fieldname,
+			"label": d.label,
+			"fieldtype": "Link",
+			"options": d.document_type,
+			"insert_after": "accounting_dimensions_section",
+		}
+
+		create_custom_field(doctype, df, ignore_validate=True)
+
+	frappe.clear_cache(doctype=doctype)


### PR DESCRIPTION
When making a Payment Entry from a Payment Request the accounting dimensions mentioned in the Purchase Order were not copied over to the payment entry

- Introduced Accounting Dimensions in Payment Request as well to handle such cases
- Added a patch to handle this for existing installations
- Also added a minor fix to copy the accounting dimensions directly from Order to Payment Entry