### PR TITLE
feat: provision to setup opening balances for earnings and deductions while creating SSA

### DIFF
--- a/erpnext/patches/v11_0/create_salary_structure_assignments.py
+++ b/erpnext/patches/v11_0/create_salary_structure_assignments.py
@@ -13,8 +13,10 @@ from erpnext.payroll.doctype.salary_structure_assignment.salary_structure_assign
 
 
 def execute():
+	frappe.reload_doc("Payroll", "doctype", "Payroll Settings")
 	frappe.reload_doc("Payroll", "doctype", "Salary Structure")
 	frappe.reload_doc("Payroll", "doctype", "Salary Structure Assignment")
+
 	frappe.db.sql(
 		"""
 		delete from `tabSalary Structure Assignment`

--- a/erpnext/payroll/doctype/payroll_settings/payroll_settings.json
+++ b/erpnext/payroll/doctype/payroll_settings/payroll_settings.json
@@ -11,6 +11,7 @@
   "max_working_hours_against_timesheet",
   "include_holidays_in_total_working_days",
   "disable_rounded_total",
+  "define_opening_balance_for_earning_and_deductions",
   "column_break_11",
   "daily_wages_fraction_for_half_day",
   "email_salary_slip_to_employee",
@@ -91,13 +92,20 @@
    "fieldname": "show_leave_balances_in_salary_slip",
    "fieldtype": "Check",
    "label": "Show Leave Balances in Salary Slip"
+  },
+  {
+   "default": "0",
+   "description": "If checked, then the system will enable the provision to set the opening balance for earnings and deductions till date while creating a Salary Structure Assignment (if any)",
+   "fieldname": "define_opening_balance_for_earning_and_deductions",
+   "fieldtype": "Check",
+   "label": "Define Opening Balance for Earning and Deductions"
   }
  ],
  "icon": "fa fa-cog",
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2021-03-03 17:49:59.579723",
+ "modified": "2022-12-21 17:30:08.704247",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Payroll Settings",

--- a/erpnext/payroll/doctype/salary_slip/salary_slip.py
+++ b/erpnext/payroll/doctype/salary_slip/salary_slip.py
@@ -1063,26 +1063,25 @@ class SalarySlip(TransactionBase):
 			)
 			exempted_amount = flt(exempted_amount[0][0]) if exempted_amount else 0
 
-		opening_taxable_earning = self.get_opening_for(
+		opening_taxable_earning = self.get_opening_balance_for(
 			"taxable_earnings_till_date", start_date, end_date
 		)
 
 		return (taxable_earnings + opening_taxable_earning) - exempted_amount
 
-	def get_opening_for(self, field_to_select, start_date, end_date):
-		return (
-			frappe.db.get_value(
-				"Salary Structure Assignment",
-				{
-					"employee": self.employee,
-					"salary_structure": self.salary_structure,
-					"from_date": ["between", [start_date, end_date]],
-					"docstatus": 1,
-				},
-				field_to_select,
-			)
-			or 0
+	def get_opening_balance_for(self, field_to_select, start_date, end_date):
+		opening_balance = frappe.db.get_all(
+			"Salary Structure Assignment",
+			{
+				"employee": self.employee,
+				"salary_structure": self.salary_structure,
+				"from_date": ["between", (start_date, end_date)],
+				"docstatus": 1,
+			},
+			field_to_select,
 		)
+
+		return opening_balance[0].get(field_to_select) if opening_balance else 0.0
 
 	def get_tax_paid_in_period(self, start_date, end_date, tax_component):
 		# find total_tax_paid, tax paid for benefit, additional_salary
@@ -1111,7 +1110,9 @@ class SalarySlip(TransactionBase):
 			)[0][0]
 		)
 
-		tax_deducted_till_date = self.get_opening_for("tax_deducted_till_date", start_date, end_date)
+		tax_deducted_till_date = self.get_opening_balance_for(
+			"tax_deducted_till_date", start_date, end_date
+		)
 
 		return total_tax_paid + tax_deducted_till_date
 

--- a/erpnext/payroll/doctype/salary_slip/salary_slip.py
+++ b/erpnext/payroll/doctype/salary_slip/salary_slip.py
@@ -1063,7 +1063,26 @@ class SalarySlip(TransactionBase):
 			)
 			exempted_amount = flt(exempted_amount[0][0]) if exempted_amount else 0
 
-		return taxable_earnings - exempted_amount
+		opening_taxable_earning = self.get_opening_for(
+			"taxable_earnings_till_date", start_date, end_date
+		)
+
+		return (taxable_earnings + opening_taxable_earning) - exempted_amount
+
+	def get_opening_for(self, field_to_select, start_date, end_date):
+		return (
+			frappe.db.get_value(
+				"Salary Structure Assignment",
+				{
+					"employee": self.employee,
+					"salary_structure": self.salary_structure,
+					"from_date": ["between", [start_date, end_date]],
+					"docstatus": 1,
+				},
+				field_to_select,
+			)
+			or 0
+		)
 
 	def get_tax_paid_in_period(self, start_date, end_date, tax_component):
 		# find total_tax_paid, tax paid for benefit, additional_salary
@@ -1092,7 +1111,9 @@ class SalarySlip(TransactionBase):
 			)[0][0]
 		)
 
-		return total_tax_paid
+		tax_deducted_till_date = self.get_opening_for("tax_deducted_till_date", start_date, end_date)
+
+		return total_tax_paid + tax_deducted_till_date
 
 	def get_taxable_earnings(
 		self, allow_tax_exemption=False, based_on_payment_days=0, payroll_period=None

--- a/erpnext/payroll/doctype/salary_structure_assignment/salary_structure_assignment.js
+++ b/erpnext/payroll/doctype/salary_structure_assignment/salary_structure_assignment.js
@@ -42,6 +42,13 @@ frappe.ui.form.on('Salary Structure Assignment', {
 		});
 	},
 
+	refresh: function(frm) {
+		if(frm.doc.__onload){
+			frm.unhide_earnings_and_taxation_section = frm.doc.__onload.earning_and_deduction_entries_does_not_exists;
+			frm.trigger("set_earnings_and_taxation_section_visibility");
+		}
+	},
+
 	employee: function(frm) {
 		if(frm.doc.employee){
 			frappe.call({
@@ -59,6 +66,8 @@ frappe.ui.form.on('Salary Structure Assignment', {
 					}
 				}
 			});
+
+			frm.trigger("valiadte_joining_date_and_salary_slips");
 		}
 		else{
 			frm.set_value("company", null);
@@ -71,5 +80,33 @@ frappe.ui.form.on('Salary Structure Assignment', {
 				frm.set_value("payroll_payable_account", r.default_payroll_payable_account);
 			});
 		}
-	}
+	},
+
+	valiadte_joining_date_and_salary_slips: function(frm) {
+		frappe.call({
+			method: "earning_and_deduction_entries_does_not_exists",
+			doc: frm.doc,
+			callback: function(data) {
+				let earning_and_deduction_entries_does_not_exists = data.message;
+				frm.unhide_earnings_and_taxation_section = earning_and_deduction_entries_does_not_exists;
+				frm.trigger("set_earnings_and_taxation_section_visibility");
+			}
+		});
+	},
+
+	set_earnings_and_taxation_section_visibility: function(frm) {
+		if(frm.unhide_earnings_and_taxation_section){
+			frm.set_df_property('earnings_and_taxation_section', 'hidden', 0);
+		}
+		else{
+			frm.set_df_property('earnings_and_taxation_section', 'hidden', 1);
+		}
+	},
+
+	from_date: function(frm) {
+		if (frm.doc.from_date) {
+			frm.trigger("valiadte_joining_date_and_salary_slips" );
+		}
+	},
+
 });

--- a/erpnext/payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+++ b/erpnext/payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
@@ -23,9 +23,9 @@
   "column_break_9",
   "variable",
   "earnings_and_taxation_section",
-  "tax_deducted_till_date",
-  "column_break_18",
   "taxable_earnings_till_date",
+  "column_break_18",
+  "tax_deducted_till_date",
   "amended_from"
  ],
  "fields": [
@@ -147,11 +147,11 @@
    "options": "Account"
   },
   {
-   "allow_on_submit": 1,
    "fieldname": "earnings_and_taxation_section",
    "fieldtype": "Section Break"
   },
   {
+   "allow_on_submit": 1,
    "fieldname": "tax_deducted_till_date",
    "fieldtype": "Currency",
    "label": "Tax Deducted Till Date"
@@ -169,7 +169,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2022-12-21 17:06:38.602361",
+ "modified": "2022-12-26 12:47:42.521891",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Salary Structure Assignment",

--- a/erpnext/payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
+++ b/erpnext/payroll/doctype/salary_structure_assignment/salary_structure_assignment.json
@@ -22,6 +22,10 @@
   "base",
   "column_break_9",
   "variable",
+  "earnings_and_taxation_section",
+  "tax_deducted_till_date",
+  "column_break_18",
+  "taxable_earnings_till_date",
   "amended_from"
  ],
  "fields": [
@@ -141,11 +145,31 @@
    "fieldtype": "Link",
    "label": "Payroll Payable Account",
    "options": "Account"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "earnings_and_taxation_section",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "tax_deducted_till_date",
+   "fieldtype": "Currency",
+   "label": "Tax Deducted Till Date"
+  },
+  {
+   "fieldname": "column_break_18",
+   "fieldtype": "Column Break"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "taxable_earnings_till_date",
+   "fieldtype": "Currency",
+   "label": "Taxable Earnings Till Date"
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2021-03-31 22:44:46.267974",
+ "modified": "2022-12-21 17:06:38.602361",
  "modified_by": "Administrator",
  "module": "Payroll",
  "name": "Salary Structure Assignment",

--- a/erpnext/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py
+++ b/erpnext/payroll/doctype/salary_structure_assignment/salary_structure_assignment.py
@@ -13,10 +13,36 @@ class DuplicateAssignment(frappe.ValidationError):
 
 
 class SalaryStructureAssignment(Document):
+	def onload(self):
+		if self.employee:
+			self.set_onload(
+				"earning_and_deduction_entries_exists", self.earning_and_deduction_entries_does_not_exists()
+			)
+
 	def validate(self):
 		self.validate_dates()
 		self.validate_income_tax_slab()
 		self.set_payroll_payable_account()
+		self.valiadte_missing_taxable_earnings_and_deductions_till_date()
+
+	def valiadte_missing_taxable_earnings_and_deductions_till_date(self):
+		if self.earning_and_deduction_entries_does_not_exists():
+			if not self.taxable_earnings_till_date and not self.tax_deducted_till_date:
+				frappe.msgprint(
+					_(
+						"""
+						Not found any salary slip record(s) for the employee {0}. <br><br>
+						Please specify {1} and {2} (if any),
+						for the correct tax calculation in future salary slips.
+						"""
+					).format(
+						self.employee,
+						"<b>" + _("Taxable Earnings Till Date") + "</b>",
+						"<b>" + _("Tax Deducted Till Date") + "</b>",
+					),
+					indicator="orange",
+					title=_("Warning"),
+				)
 
 	def validate_dates(self):
 		joining_date, relieving_date = frappe.db.get_value(
@@ -75,6 +101,56 @@ class SalaryStructureAssignment(Document):
 					},
 				)
 			self.payroll_payable_account = payroll_payable_account
+
+	@frappe.whitelist()
+	def earning_and_deduction_entries_does_not_exists(self):
+		if self.enabled_settings_to_specify_earnings_and_deductions_till_date():
+			if not self.joined_in_the_same_month() and not self.have_salary_slips():
+				return True
+			else:
+				if self.docstatus in [1, 2] and (
+					self.taxable_earnings_till_date or self.tax_deducted_till_date
+				):
+					return True
+				return False
+		else:
+			return False
+
+	def enabled_settings_to_specify_earnings_and_deductions_till_date(self):
+		"""returns True if settings are enabled to specify earnings and deductions till date else False"""
+
+		if frappe.db.get_single_value(
+			"Payroll Settings", "define_opening_balance_for_earning_and_deductions"
+		):
+			return True
+		return False
+
+	def have_salary_slips(self):
+		"""returns True if salary structure assignment has salary slips else False"""
+
+		salary_slip = frappe.db.get_value(
+			"Salary Slip", filters={"employee": self.employee, "docstatus": 1}
+		)
+
+		if salary_slip:
+			return True
+
+		return False
+
+	def joined_in_the_same_month(self):
+		"""returns True if employee joined in same month as salary structure assignment from date else False"""
+
+		date_of_joining = frappe.db.get_value("Employee", self.employee, "date_of_joining")
+		from_date = getdate(self.from_date)
+
+		if not self.from_date or not date_of_joining:
+			return False
+
+		elif date_of_joining.month == from_date.month:
+			return True
+
+		else:
+			return False
 
 
 def get_assigned_salary_structure(employee, on_date):


### PR DESCRIPTION
### Scenario: 
<img width="664" alt="Screenshot 2022-11-23 at 6 08 19 PM" src="https://user-images.githubusercontent.com/3784093/203548892-224026c3-7ed4-45cb-969c-486a7207e076.png">

There is no salary slip record in Frappe HRMS for the period of July to November. Now from November user wants to maintain salary slips in Frappe HRMS. But in Frappe HRMS, there is no provision to set up the salary paid to date and tax deducted it.  

### Solution

Settings to enable the provision
<img width="1309" alt="Screenshot 2022-12-21 at 5 35 28 PM" src="https://user-images.githubusercontent.com/3784093/208901412-ba518ea8-3b8c-481a-ac3d-1b785c7e3833.png">


Provision to set up opening balances for Salary paid to date and tax deducted to date.
<img width="1318" alt="Screenshot 2022-11-23 at 6 04 22 PM" src="https://user-images.githubusercontent.com/3784093/203548209-e415266d-b1c7-432c-9a8d-da83ab3b773d.png">

Warning message
<img width="652" alt="Screenshot 2022-11-28 at 1 36 47 PM" src="https://user-images.githubusercontent.com/3784093/204225738-63439de6-3bad-4250-ab5d-d387c6197e50.png">

