### PR TITLE
fix: payment terms and sales partner filter issue in Accounts Receivable report

### DIFF
--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -794,19 +794,19 @@ class ReceivablePayableReport(object):
 
 		if self.filters.get("payment_terms_template"):
 			self.qb_selection_filter.append(
-				self.ple.party_isin(
-					qb.from_(self.customer).where(
-						self.customer.payment_terms == self.filters.get("payment_terms_template")
-					)
+				self.ple.party.isin(
+					qb.from_(self.customer)
+					.select(self.customer.name)
+					.where(self.customer.payment_terms == self.filters.get("payment_terms_template"))
 				)
 			)
 
 		if self.filters.get("sales_partner"):
 			self.qb_selection_filter.append(
-				self.ple.party_isin(
-					qb.from_(self.customer).where(
-						self.customer.default_sales_partner == self.filters.get("payment_terms_template")
-					)
+				self.ple.party.isin(
+					qb.from_(self.customer)
+					.select(self.customer.name)
+					.where(self.customer.default_sales_partner == self.filters.get("payment_terms_template"))
 				)
 			)
 


### PR DESCRIPTION
TypeError while using Payment Terms Template and Sales Partner Filters in Accounts Receivable Report
<img width="1364" alt="Screenshot 2022-12-22 at 10 56 44 AM" src="https://user-images.githubusercontent.com/3272205/209063427-c151a943-7867-4eb9-a6a7-dae1b779afad.png">
