### PR TITLE
fix: timeout error while submitting stock entry

### DIFF
--- a/erpnext/stock/doctype/bin/bin.py
+++ b/erpnext/stock/doctype/bin/bin.py
@@ -162,6 +162,7 @@ def update_qty(bin_name, args):
 			.where((sle.item_code == args.get("item_code")) & (sle.warehouse == args.get("warehouse")))
 			.orderby(CombineDatetime(sle.posting_date, sle.posting_time), order=Order.desc)
 			.orderby(sle.creation, order=Order.desc)
+			.limit(1)
 			.run()
 		)
 

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -470,8 +470,10 @@ class update_entries_after(object):
 				item_code = %(item_code)s
 				and warehouse = %(warehouse)s
 				and is_cancelled = 0
-				and timestamp(posting_date, time_format(posting_time, %(time_format)s)) = timestamp(%(posting_date)s, time_format(%(posting_time)s, %(time_format)s))
-
+				and (
+					posting_date = %(posting_date)s and
+					time_format(posting_time, %(time_format)s) = time_format(%(posting_time)s, %(time_format)s)
+				)
 			order by
 				creation ASC
 			for update
@@ -1070,7 +1072,13 @@ def get_previous_sle_of_current_voucher(args, exclude_current_voucher=False):
 			and warehouse = %(warehouse)s
 			and is_cancelled = 0
 			{voucher_condition}
-			and timestamp(posting_date, time_format(posting_time, %(time_format)s)) < timestamp(%(posting_date)s, time_format(%(posting_time)s, %(time_format)s))
+			and (
+				posting_date < %(posting_date)s or
+				(
+					posting_date = %(posting_date)s and
+					time_format(posting_time, %(time_format)s) < time_format(%(posting_time)s, %(time_format)s)
+				)
+			)
 		order by timestamp(posting_date, posting_time) desc, creation desc
 		limit 1
 		for update""".format(
@@ -1355,8 +1363,13 @@ def update_qty_in_future_sle(args, allow_negative_stock=False):
 			and warehouse = %(warehouse)s
 			and voucher_no != %(voucher_no)s
 			and is_cancelled = 0
-			and timestamp(posting_date, time_format(posting_time, %(time_format)s))
-				> timestamp(%(posting_date)s, time_format(%(posting_time)s, %(time_format)s))
+			and (
+				posting_date > %(posting_date)s or
+				(
+					posting_date = %(posting_date)s and
+					time_format(posting_time, %(time_format)s) > time_format(%(posting_time)s, %(time_format)s)
+				)
+			)
 		{datetime_limit_condition}
 		""",
 		args,


### PR DESCRIPTION
**Issue**

While submitting the stock entry, system was throwing the timeout error. @ankush and me were finding the root cause of the time out issue.

During debugging we came to know that update_qty_in_future_sle is taking more time and causing the time-out error. In the update_qty_in_future_sle method, the system runs 3 queries mostly. The first query checks whether the stock reconciliation exists or not in the future entries, the second query update the "qty_after_transaction" field in the stock ledger entry table for the future entries, and the third query checks whether the qty_after_transaction is negative or not after the update for the future entries. In all three queries, the posting_date column plays an important role. So we had already added the indexing on the posting_date column to improve the performance of these queries.

<img width="798" alt="Screenshot 2022-12-20 at 6 59 50 PM" src="https://user-images.githubusercontent.com/8780500/209291682-5693a296-b526-466f-b311-885564377096.png">

Out of these three queries, the first two queries were running slowly. After debugging we came to know that the posting_date index is not working because the time_format function has been used in the query. So if the query has a function on an indexed column then indexing won't work because for the MariaDB engine it's difficult to identify what is written in the function.

To fix the problem, we had two choices either we have to apply force index or change the query. We decided to change the query because there are other columns on which indexing was applied and we don't want to skip them.

We have changed the conditon in a query as follows 

Old Query
```
and timestamp(posting_date, time_format(posting_time, %(time_format)s)) < timestamp(%(posting_date)s, time_format(%(posting_time)s, %(time_format)s))
```

New Query
```
and (
	posting_date < %(posting_date)s or
	(
		posting_date = %(posting_date)s and
		time_format(posting_time, %(time_format)s) < time_format(%(posting_time)s, %(time_format)s)
	)
)
```

**Profiling result after change**

<img width="747" alt="Screenshot 2022-12-22 at 1 52 10 AM" src="https://user-images.githubusercontent.com/8780500/209295192-3beabbf4-eebf-4f8c-9313-d00cd5871b5c.png">


