### PR TITLE
fix: Customer Primary Contact

### DIFF
--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -737,7 +737,7 @@ def get_customer_primary_contact(doctype, txt, searchfield, start, page_len, fil
 		qb.from_(con)
 		.join(dlink)
 		.on(con.name == dlink.parent)
-		.select(con.name, con.full_name, con.email_id)
+		.select(con.name, con.email_id)
 		.where((dlink.link_name == customer) & (con.name.like(f"%{txt}%")))
 		.run()
 	)


### PR DESCRIPTION
**Version:**

ERPNext: v14.11.0 (version-14)
Frappe Framework: v14.20.0 (version-14)
Payments: v0.0.1 (develop)
___
Issue: #33420
___

**Before:** 
- When selecting the customer's primary contact then faced an error because the contact hasn't the full_name field.

![image](https://user-images.githubusercontent.com/34390782/209303266-672b7ed1-9637-4b46-ad1b-0ba75d3d9328.png)


**After:**
- After the remove the full_name from the get_customer_primary_contact method the contact shows properly.

![image](https://user-images.githubusercontent.com/34390782/209303983-965783c0-854d-4440-af26-fe880c5c750c.png)

![image](https://user-images.githubusercontent.com/34390782/209304111-3a10914a-d379-4566-85df-e565819978f1.png)

Thank You!