### PR TITLE
Expired Item handling

### DIFF
--- a/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py
+++ b/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py
@@ -157,11 +157,11 @@ class StockLedgerEntry(Document):
 				self.voucher_type in ["Delivery Note", "Sales Invoice"] and self.actual_qty > 0
 			):
 				return
-
-			expiry_date = frappe.db.get_value("Batch", self.batch_no, "expiry_date")
-			if expiry_date:
-				if getdate(self.posting_date) > getdate(expiry_date):
-					frappe.throw(_("Batch {0} of Item {1} has expired.").format(self.batch_no, self.item_code))
+			if self.voucher_type not in ["Purchase Receipt","Stock Reconciliation","Stock Entry"]:
+				expiry_date = frappe.db.get_value("Batch", self.batch_no, "expiry_date")
+				if expiry_date:
+					if getdate(self.posting_date) > getdate(expiry_date):
+						frappe.throw(_("Batch {0} of Item {1} has expired.").format(self.batch_no, self.item_code))
 
 	def validate_and_set_fiscal_year(self):
 		if not self.fiscal_year:


### PR DESCRIPTION
<!--
#19029 
As the issue suggest that
In Purchase Invoice/Receipt As Purchase return, it will not allow returning Expired Batch number

So when we want to return the items in the purchase receipt it will allow for expired product 
when we adjust expired stock in stock entry then it will allow for stock entry 

-->
