### PR TITLE
fix: allow arbitary items in Quotation and Sales Order

### DIFF
--- a/erpnext/selling/doctype/quotation_item/quotation_item.json
+++ b/erpnext/selling/doctype/quotation_item/quotation_item.json
@@ -90,7 +90,6 @@
    "oldfieldtype": "Link",
    "options": "Item",
    "print_width": "150px",
-   "reqd": 1,
    "search_index": 1,
    "width": "150px"
   },
@@ -649,7 +648,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2021-07-15 12:40:51.074820",
+ "modified": "2022-12-25 02:49:53.926625",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Quotation Item",

--- a/erpnext/selling/doctype/sales_order_item/sales_order_item.json
+++ b/erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -114,7 +114,6 @@
    "oldfieldtype": "Link",
    "options": "Item",
    "print_width": "150px",
-   "reqd": 1,
    "width": "150px"
   },
   {
@@ -865,7 +864,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2022-11-18 11:39:01.741665",
+ "modified": "2022-12-25 02:51:10.247569",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order Item",


### PR DESCRIPTION
Arbitary items are required while quoting for an engineered-to-order product. There can't be an item in your database for every  request your customer makes.
Allowing arbitary items in Sales Orders follows the same logic. Billing of arbitary items is already allowed.

closes https://github.com/frappe/erpnext/issues/33429

The Buying side of this issue can possibly be implemented in a similar fashion, but I'm not sure if it'll break anything.