### PR TITLE
fix: `shipping_address` in PO for non-drop ship item

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -1024,6 +1024,15 @@ def make_purchase_order(source_name, selected_items=None, target_doc=None):
 	]
 	items_to_map = list(set(items_to_map))
 
+	def is_drop_ship_order(target):
+		drop_ship = True
+		for item in target.items:
+			if not item.delivered_by_supplier:
+				drop_ship = False
+				break
+
+		return drop_ship
+
 	def set_missing_values(source, target):
 		target.supplier = ""
 		target.apply_discount_on = ""
@@ -1031,6 +1040,14 @@ def make_purchase_order(source_name, selected_items=None, target_doc=None):
 		target.discount_amount = 0.0
 		target.inter_company_order_reference = ""
 		target.shipping_rule = ""
+
+		if is_drop_ship_order(target):
+			target.customer = source.customer
+			target.customer_name = source.customer_name
+			target.shipping_address = source.shipping_address_name
+		else:
+			target.customer = target.customer_name = target.shipping_address = None
+
 		target.run_method("set_missing_values")
 		target.run_method("calculate_taxes_and_totals")
 
@@ -1057,10 +1074,8 @@ def make_purchase_order(source_name, selected_items=None, target_doc=None):
 					"contact_email",
 					"contact_person",
 					"taxes_and_charges",
+					"shipping_address",
 					"terms",
-				],
-				"field_map": [
-					["shipping_address_name", "shipping_address"],
 				],
 				"validation": {"docstatus": ["=", 1]},
 			},


### PR DESCRIPTION
occurred from: https://github.com/frappe/erpnext/pull/33434

Sales Order without drop-ship

![image](https://user-images.githubusercontent.com/63660334/209474241-65ad70eb-e660-49cf-ada0-082074bdfd19.png)

Before: Shipping Address gets fetched from Sales Order

![image](https://user-images.githubusercontent.com/63660334/209474277-ce0fd722-abeb-4953-ac8c-6fa2c1946451.png)

After: Only fetch in case of drop-ship

![image](https://user-images.githubusercontent.com/63660334/209474261-d4341f10-c037-42ed-809c-d2feb338fc93.png)

