### PR TITLE
fix: Random behaviour while picking items using picklist

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -441,7 +441,7 @@ def get_available_item_locations_for_batched_item(
 			sle.`batch_no`,
 			sle.`item_code`
 		HAVING `qty` > 0
-		ORDER BY IFNULL(batch.`expiry_date`, '2200-01-01'), batch.`creation`
+		ORDER BY IFNULL(batch.`expiry_date`, '2200-01-01'), batch.`creation`, sle.`batch_no`, sle.`warehouse`
 	""".format(
 			warehouse_condition=warehouse_condition
 		),


### PR DESCRIPTION
"Get Item Locations" button returned values in random order if the batches didn't have any expiry dates. This in turn led to randomly picking on warehouses, splitting of rows, and overriding of user-entered picked qty incorrectly