### PR TITLE
fix: Multiple rows for same warehouse and batches in pick list

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.js
+++ b/erpnext/stock/doctype/pick_list/pick_list.js
@@ -51,7 +51,15 @@ frappe.ui.form.on('Pick List', {
 		if (!(frm.doc.locations && frm.doc.locations.length)) {
 			frappe.msgprint(__('Add items in the Item Locations table'));
 		} else {
-			frm.call('set_item_locations', {save: save});
+			frappe.call({
+				method: "set_item_locations",
+				doc: frm.doc,
+				args: {
+					"save": save,
+				},
+				freeze: 1,
+				freeze_message: __("Setting Item Locations..."),
+			});
 		}
 	},
 	get_item_locations: (frm) => {


### PR DESCRIPTION
Continuation of https://github.com/frappe/erpnext/pull/33449

There were still multiple rows getting added for the key `(item_code, warehouse, uom, batch, reference)` which is undesired. Grouped the location by key again post picking the items 