### PR TITLE
fix(pricing rule): consider child tables in condition

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/utils.py
+++ b/erpnext/accounts/doctype/pricing_rule/utils.py
@@ -252,10 +252,15 @@ def get_other_conditions(conditions, values, args):
 
 	if args.get("doctype") in [
 		"Quotation",
+		"Quotation Item",
 		"Sales Order",
+		"Sales Order Item",
 		"Delivery Note",
+		"Delivery Note Item",
 		"Sales Invoice",
+		"Sales Invoice Item",
 		"POS Invoice",
+		"POS Invoice Item",
 	]:
 		conditions += """ and ifnull(`tabPricing Rule`.selling, 0) = 1"""
 	else:


### PR DESCRIPTION
https://user-images.githubusercontent.com/52111700/209809040-ff4c1a25-2e0b-4ec4-b0f7-1070f2bca968.mp4

On save, the doctype passed to the python function is `Sales Invoice`, but on qty change of individual item, it is `Sales Invoice Item`. On the function to fetch applicable pricing rules, `buying = 1` was added to the condition since `Sales Invoice Item` was missing from 
https://github.com/frappe/erpnext/blob/882f92e732853c7257f6ba91e6342887fb7edae6/erpnext/accounts/doctype/pricing_rule/utils.py#L253-L262
