### PR TITLE
fix: reconciled credit notes being fetched again in Payment Reconciliation tool

### DIFF
--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
@@ -172,22 +172,22 @@ class PaymentReconciliation(Document):
 		query = (
 			qb.from_(gl)
 			.select(
-				gl.voucher_type.as_("reference_type"),
-				gl.voucher_no.as_("reference_name"),
+				gl.against_voucher_type.as_("reference_type"),
+				gl.against_voucher.as_("reference_name"),
 				(Sum(dr_or_cr) - Sum(reconciled_dr_or_cr)).as_("amount"),
 				gl.posting_date,
 				gl.account_currency.as_("currency"),
 			)
 			.where(
-				(gl.voucher_type == voucher_type)
-				& (gl.voucher_no.isin(sub_query))
+				(gl.against_voucher.isin(sub_query))
+				& (gl.against_voucher_type == voucher_type)
 				& (gl.is_cancelled == 0)
 				& (gl.account == self.receivable_payable_account)
 				& (gl.party_type == self.party_type)
 				& (gl.party == self.party)
 			)
 			.where(Criterion.all(conditions))
-			.groupby(gl.voucher_no)
+			.groupby(gl.against_voucher)
 			.having(qb.Field("amount") > 0)
 		)
 		dr_cr_notes = query.run(as_dict=True)


### PR DESCRIPTION
Reconciled Credit Notes show up in Payment section on Reconciliation tool.

Before:

https://user-images.githubusercontent.com/3272205/209832219-5821397d-6a9e-4eb0-9a52-1e71e449038b.mp4


After:

https://user-images.githubusercontent.com/3272205/209832236-76501990-233e-41e8-8e5d-7a65a35bce6b.mp4


fixes: https://github.com/frappe/erpnext/issues/33462, https://github.com/frappe/erpnext/issues/33448
regression: https://github.com/frappe/erpnext/pull/33367