### PR TITLE
fix: do not add process loss in the stock

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -889,7 +889,7 @@ class BOM(WebsiteGenerator):
 				).format(frappe.bold(item.item_code))
 
 			must_be_whole_number = frappe.get_value("UOM", item.stock_uom, "must_be_whole_number")
-			if item.is_process_loss and must_be_whole_number:
+			if item.is_process_loss and must_be_whole_number and item.qty != cint(item.qty):
 				msg = _(
 					"Item: {0} with Stock UOM: {1} cannot be a Scrap/Loss Item as {1} is a whole UOM."
 				).format(frappe.bold(item.item_code), frappe.bold(item.stock_uom))

--- a/erpnext/manufacturing/doctype/manufacturing_settings/manufacturing_settings.json
+++ b/erpnext/manufacturing/doctype/manufacturing_settings/manufacturing_settings.json
@@ -21,6 +21,7 @@
   "default_fg_warehouse",
   "column_break_11",
   "default_scrap_warehouse",
+  "other_settings_section",
   "over_production_for_sales_and_work_order_section",
   "overproduction_percentage_for_sales_order",
   "column_break_16",
@@ -29,15 +30,16 @@
   "add_corrective_operation_cost_in_finished_good_valuation",
   "column_break_24",
   "job_card_excess_transfer",
-  "other_settings_section",
+  "section_break_5arj",
   "update_bom_costs_automatically",
   "column_break_23",
-  "make_serial_no_batch_from_work_order"
+  "make_serial_no_batch_from_work_order",
+  "add_process_loss_cost_in_fg_item"
  ],
  "fields": [
   {
    "fieldname": "capacity_planning",
-   "fieldtype": "Section Break",
+   "fieldtype": "Tab Break",
    "label": "Capacity Planning"
   },
   {
@@ -77,7 +79,7 @@
   },
   {
    "fieldname": "section_break_6",
-   "fieldtype": "Section Break",
+   "fieldtype": "Tab Break",
    "label": "Default Warehouses for Production"
   },
   {
@@ -146,7 +148,7 @@
   },
   {
    "fieldname": "raw_materials_consumption_section",
-   "fieldtype": "Section Break",
+   "fieldtype": "Tab Break",
    "label": "Raw Materials Consumption"
   },
   {
@@ -155,7 +157,7 @@
   },
   {
    "fieldname": "other_settings_section",
-   "fieldtype": "Section Break",
+   "fieldtype": "Tab Break",
    "label": "Other Settings"
   },
   {
@@ -194,13 +196,24 @@
    "fieldname": "job_card_excess_transfer",
    "fieldtype": "Check",
    "label": "Allow Excess Material Transfer"
+  },
+  {
+   "fieldname": "section_break_5arj",
+   "fieldtype": "Section Break"
+  },
+  {
+   "default": "0",
+   "description": "System will add process loss cost in the FG item's basic rate in the Manufacture stock entry.",
+   "fieldname": "add_process_loss_cost_in_fg_item",
+   "fieldtype": "Check",
+   "label": "Add Process Loss Cost in FG Item"
   }
  ],
  "icon": "icon-wrench",
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2021-09-13 22:09:09.401559",
+ "modified": "2022-12-29 14:54:34.638147",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Manufacturing Settings",
@@ -216,5 +229,6 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -885,6 +885,17 @@ class TestWorkOrder(FrappeTestCase):
 		items = se.get("items")
 		self.assertEqual(len(items), 3, "There should be 3 items including process loss.")
 
+		fg_sle_entries = frappe.get_all(
+			"Stock Ledger Entry",
+			filters={
+				"item_code": fg_item_non_whole.item_code,
+				"voucher_no": se.name,
+				"actual_qty": (">", 0),
+			},
+		)
+
+		self.assertEqual(len(fg_sle_entries), 1, "There should be 1 stock ledger entry for FG item.")
+
 		source_item, fg_item, pl_item = items
 
 		total_pl_qty = qty * scrap_qty


### PR DESCRIPTION
**Issue**

If have process loss during manufacturing process then system add the process loss item in the stock. Which needs to be stock out manually.

**After Change**

System will not add process loss item in the stock.
If User still wants to add process loss item in the stock then they need to enable Is Scrap Item checkbox in the stock entry.

### **Stock Entry**

<img width="1104" alt="image" src="https://user-images.githubusercontent.com/8780500/209933947-937bdd23-1c02-4baf-a382-e7d0c0932a7c.png">

###  **Stock Ledger Entry**

<img width="1323" alt="image" src="https://user-images.githubusercontent.com/8780500/209934107-d7ce6ffd-8d83-4394-934c-d62ceb3c4f96.png">


### New Feature

Also added provision to include Process Loss cost in the FG Item cost
<img width="1336" alt="Screenshot 2022-12-29 at 3 20 22 PM" src="https://user-images.githubusercontent.com/8780500/209934275-dd7ce1e8-1713-43bb-adec-ecc359805fff.png">



Closes https://github.com/frappe/erpnext/issues/33094