### PR TITLE
fix: Multi-currency issues in Bank Reconciliation Tool

### DIFF
--- a/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.py
+++ b/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.py
@@ -302,7 +302,7 @@ def reconcile_vouchers(bank_transaction_name, vouchers):
 			dict(
 				account=account, voucher_type=voucher["payment_doctype"], voucher_no=voucher["payment_name"]
 			),
-			["credit", "debit"],
+			["credit_in_account_currency as credit", "debit_in_account_currency as debit"],
 			as_dict=1,
 		)
 		gl_amount, transaction_amount = (

--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
@@ -137,7 +137,7 @@ def get_paid_amount(payment_entry, currency, bank_account):
 				)
 			elif doc.payment_type == "Pay":
 				paid_amount_field = (
-					"paid_amount" if doc.paid_to_account_currency == currency else "base_paid_amount"
+					"paid_amount" if doc.paid_from_account_currency == currency else "base_paid_amount"
 				)
 
 		return frappe.db.get_value(

--- a/erpnext/public/js/bank_reconciliation_tool/dialog_manager.js
+++ b/erpnext/public/js/bank_reconciliation_tool/dialog_manager.js
@@ -355,12 +355,14 @@ erpnext.accounts.bank_reconciliation.DialogManager = class DialogManager {
 				fieldname: "deposit",
 				fieldtype: "Currency",
 				label: "Deposit",
+				options: "currency",
 				read_only: 1,
 			},
 			{
 				fieldname: "withdrawal",
 				fieldtype: "Currency",
 				label: "Withdrawal",
+				options: "currency",
 				read_only: 1,
 			},
 			{
@@ -378,6 +380,7 @@ erpnext.accounts.bank_reconciliation.DialogManager = class DialogManager {
 				fieldname: "allocated_amount",
 				fieldtype: "Currency",
 				label: "Allocated Amount",
+				options: "Currency",
 				read_only: 1,
 			},
 
@@ -385,8 +388,17 @@ erpnext.accounts.bank_reconciliation.DialogManager = class DialogManager {
 				fieldname: "unallocated_amount",
 				fieldtype: "Currency",
 				label: "Unallocated Amount",
+				options: "Currency",
 				read_only: 1,
 			},
+			{
+				fieldname: "currency",
+				fieldtype: "Link",
+				label: "Currency",
+				options: "Currency",
+				read_only: 1,
+				hidden: 1,
+			}
 		];
 	}
 


### PR DESCRIPTION
- The allocated amount was not getting properly set for non-company currency bank accounts
- Currency symbol in data table for non, currency bank accounts