### PR TITLE
feat: Toggle display of Account Balance in Chart of Accounts

### DIFF
--- a/erpnext/accounts/doctype/account/account_tree.js
+++ b/erpnext/accounts/doctype/account/account_tree.js
@@ -56,36 +56,41 @@ frappe.treeview_settings["Account"] = {
 			accounts = nodes;
 		}
 
-		const get_balances = frappe.call({
-			method: 'erpnext.accounts.utils.get_account_balances',
-			args: {
-				accounts: accounts,
-				company: cur_tree.args.company
-			},
-		});
+		frappe.db.get_single_value("Accounts Settings", "show_balance_in_coa").then((value) => {
+			if(value) {
 
-		get_balances.then(r => {
-			if (!r.message || r.message.length == 0) return;
+				const get_balances = frappe.call({
+					method: 'erpnext.accounts.utils.get_account_balances',
+					args: {
+						accounts: accounts,
+						company: cur_tree.args.company
+					},
+				});
 
-			for (let account of r.message) {
+				get_balances.then(r => {
+					if (!r.message || r.message.length == 0) return;
 
-				const node = cur_tree.nodes && cur_tree.nodes[account.value];
-				if (!node || node.is_root) continue;
+					for (let account of r.message) {
 
-				// show Dr if positive since balance is calculated as debit - credit else show Cr
-				const balance = account.balance_in_account_currency || account.balance;
-				const dr_or_cr = balance > 0 ? "Dr": "Cr";
-				const format = (value, currency) => format_currency(Math.abs(value), currency);
+						const node = cur_tree.nodes && cur_tree.nodes[account.value];
+						if (!node || node.is_root) continue;
 
-				if (account.balance!==undefined) {
-					node.parent && node.parent.find('.balance-area').remove();
-					$('<span class="balance-area pull-right">'
-						+ (account.balance_in_account_currency ?
-							(format(account.balance_in_account_currency, account.account_currency) + " / ") : "")
-						+ format(account.balance, account.company_currency)
-						+ " " + dr_or_cr
-						+ '</span>').insertBefore(node.$ul);
-				}
+						// show Dr if positive since balance is calculated as debit - credit else show Cr
+						const balance = account.balance_in_account_currency || account.balance;
+						const dr_or_cr = balance > 0 ? "Dr": "Cr";
+						const format = (value, currency) => format_currency(Math.abs(value), currency);
+
+						if (account.balance!==undefined) {
+							node.parent && node.parent.find('.balance-area').remove();
+							$('<span class="balance-area pull-right">'
+							  + (account.balance_in_account_currency ?
+							     (format(account.balance_in_account_currency, account.account_currency) + " / ") : "")
+							  + format(account.balance, account.company_currency)
+							  + " " + dr_or_cr
+							  + '</span>').insertBefore(node.$ul);
+						}
+					}
+				});
 			}
 		});
 	},

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -56,7 +56,9 @@
   "acc_frozen_upto",
   "column_break_25",
   "frozen_accounts_modifier",
-  "report_settings_sb"
+  "report_settings_sb",
+  "tab_break_dpet",
+  "show_balance_in_coa"
  ],
  "fields": [
   {
@@ -347,6 +349,17 @@
    "fieldname": "allow_multi_currency_invoices_against_single_party_account",
    "fieldtype": "Check",
    "label": "Allow multi-currency invoices against single party account "
+  },
+  {
+   "fieldname": "tab_break_dpet",
+   "fieldtype": "Tab Break",
+   "label": "Chart Of Accounts"
+  },
+  {
+   "default": "1",
+   "fieldname": "show_balance_in_coa",
+   "fieldtype": "Check",
+   "label": "Show Balances in Chart Of Accounts"
   }
  ],
  "icon": "icon-cog",
@@ -354,7 +367,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2022-11-27 21:49:52.538655",
+ "modified": "2023-01-02 12:07:42.434214",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounts Settings",


### PR DESCRIPTION
Checkbox in Accounts Settings to toggle display of Account Balance in Chart of Accounts.

Accounts Settings:
<img width="1358" alt="Screenshot 2023-01-02 at 12 25 37 PM" src="https://user-images.githubusercontent.com/3272205/210202018-8cb013d4-1648-4b1a-99be-03e77be06f00.png">
COA:
<img width="1358" alt="Screenshot 2023-01-02 at 12 25 52 PM" src="https://user-images.githubusercontent.com/3272205/210202026-576d6d23-7acc-4f2c-8dcb-5d4398a57664.png">

`no-docs`