### PR TITLE
fix: [concurrency issue] incorrect picked qty in sales order

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -100,6 +100,7 @@ class PickList(Document):
 			item_table,
 			item.sales_order_item,
 			["picked_qty", stock_qty_field],
+			for_update=True,
 		)
 
 		if self.docstatus == 1:
@@ -118,7 +119,7 @@ class PickList(Document):
 	def update_sales_order_picking_status(sales_orders: Set[str]) -> None:
 		for sales_order in sales_orders:
 			if sales_order:
-				frappe.get_doc("Sales Order", sales_order).update_picking_status()
+				frappe.get_doc("Sales Order", sales_order, for_update=True).update_picking_status()
 
 	@frappe.whitelist()
 	def set_item_locations(self, save=False):
@@ -262,7 +263,7 @@ class PickList(Document):
 		for so_row, item_code in product_bundles.items():
 			picked_qty = self._compute_picked_qty_for_bundle(so_row, product_bundle_qty_map[item_code])
 			item_table = "Sales Order Item"
-			already_picked = frappe.db.get_value(item_table, so_row, "picked_qty")
+			already_picked = frappe.db.get_value(item_table, so_row, "picked_qty", for_update=True)
 			frappe.db.set_value(
 				item_table,
 				so_row,


### PR DESCRIPTION
### Issue
When user submit the Pick List for the sales order, system updates the Picked Quantity in the respective sales order.  System calculate the Percentage Picked in the sales order based on the Picked Quantity. One of the client is facing the issue that some of their sales orders has not proper Picked Quantity and Percentage Picked. 
<img width="1096" alt="Screenshot 2023-01-02 at 7 03 11 PM" src="https://user-images.githubusercontent.com/8780500/210240048-95f80ce2-2760-421e-8a65-0f8e6fcf35a4.png">


### Not Replicating from Front End
To replicate the issue I have tried from the front end but it's working fine and I was not able to replicate 

### Replicated Issue
Finally I was able to replicate the issue using bench console

<img width="1297" alt="Screenshot 2023-01-02 at 6 49 33 PM" src="https://user-images.githubusercontent.com/8780500/210240270-75e34b9a-fc38-40b1-9467-7764ed807c13.png">

1. Created sales order SAL-ORD-2022-00023 with two items, 10 and 4 quantity respectively 
2. Created two pick lists STO-PICK-2023-00000 and STO-PICK-2023-00001 against the sales order SAL-ORD-2022-00023 and kept in draft state
3. Open bench console in two windows
4. Submitted one by one pick lists and checked Percentage Picked in the sales order SAL-ORD-2022-00023
5. System showed incorrect Percentage Picked as **35.71%**


### Solution

So this issue was related to concurrency, have used for_update in the selected query and issue has fixed. After changes in the query tries above steps to replicate the issue and it was worked. System has showed correct Percentage Picked as **100%** for the sales order SAL-ORD-2022-00023

<img width="1317" alt="Screenshot 2023-01-02 at 6 44 05 PM" src="https://user-images.githubusercontent.com/8780500/210240934-771fa910-1868-44e9-aac3-67aaa7eb10e2.png">


