### PR TITLE
feat: Copy from_time and to_time to sales invoice.

### DIFF
--- a/erpnext/projects/doctype/timesheet/timesheet.py
+++ b/erpnext/projects/doctype/timesheet/timesheet.py
@@ -381,6 +381,7 @@ def make_sales_invoice(source_name, item_code=None, customer=None, currency=None
 				"timesheets",
 				{
 					"time_sheet": timesheet.name,
+					"project_name": time_log.project_name,
 					"from_time": time_log.from_time,
 					"to_time": time_log.to_time,
 					"billing_hours": time_log.billing_hours,

--- a/erpnext/projects/doctype/timesheet/timesheet.py
+++ b/erpnext/projects/doctype/timesheet/timesheet.py
@@ -381,6 +381,8 @@ def make_sales_invoice(source_name, item_code=None, customer=None, currency=None
 				"timesheets",
 				{
 					"time_sheet": timesheet.name,
+					"from_time": time_log.from_time,
+					"to_time": time_log.to_time,
 					"billing_hours": time_log.billing_hours,
 					"billing_amount": time_log.billing_amount,
 					"timesheet_detail": time_log.name,


### PR DESCRIPTION
This is a very small patch to the make_sales_invoice function in timesheet.py, allowing the function to copy the from_time and to_time fields from the Timesheet Detail to the Sales Invoice Timesheet.

These fields are identical in name and purpose in both documents, but never populated in the current make_sales_invoice script. Interestingly, they do copy when using the "Fetch Timesheet" function from the Sales Invoice, which was my workaround. This presents a better solution.