### PR TITLE
fix: from Purchase Order, while creating sales order, is internal customer check was missing in SO

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -2136,6 +2136,8 @@ def make_inter_company_transaction(doctype, source_name, target_doc=None):
 			currency = frappe.db.get_value("Customer", details.get("party"), "default_currency")
 			target_doc.company = details.get("company")
 			target_doc.customer = details.get("party")
+			target_doc.is_internal_customer = 1
+			target_doc.ignore_pricing_rule = 1
 			target_doc.selling_price_list = source_doc.buying_price_list
 
 			update_address(


### PR DESCRIPTION
Step1. Create Internal Sales order from PO
Step2. Internal Customer is fetch but is internal customer check was not set
this change will set is_internal_customer = 1
