### PR TITLE
fix: set `supplier` details while mapping SE(Send to Subcontractor)

### DIFF
--- a/erpnext/controllers/subcontracting_controller.py
+++ b/erpnext/controllers/subcontracting_controller.py
@@ -829,6 +829,9 @@ def make_rm_stock_entry(
 					order_doctype: {
 						"doctype": "Stock Entry",
 						"field_map": {
+							"supplier": "supplier",
+							"supplier_name": "supplier_name",
+							"supplier_address": "supplier_address",
 							"to_warehouse": "supplier_warehouse",
 						},
 						"field_no_map": [field_no_map],


### PR DESCRIPTION
closes: https://github.com/frappe/erpnext/issues/33417

Subcontracting Order

![image](https://user-images.githubusercontent.com/63660334/210365545-ee4efdcf-2696-4eac-9444-2c7e96393f64.png)


SE Before:

![image](https://user-images.githubusercontent.com/63660334/210365868-85683c51-6fd8-42c9-96d1-31f074dc1835.png)

SE After:

![image](https://user-images.githubusercontent.com/63660334/210365685-3a937920-ce84-4a70-9544-3213aeea222b.png)

