### PR TITLE
fix: Deferred revenue date comparison

### DIFF
--- a/erpnext/accounts/deferred_revenue.py
+++ b/erpnext/accounts/deferred_revenue.py
@@ -378,7 +378,7 @@ def book_deferred_income_or_expense(doc, deferred_process, posting_date=None):
 			return
 
 		# check if books nor frozen till endate:
-		if accounts_frozen_upto and (end_date) <= getdate(accounts_frozen_upto):
+		if accounts_frozen_upto and getdate(end_date) <= getdate(accounts_frozen_upto):
 			end_date = get_last_day(add_days(accounts_frozen_upto, 1))
 
 		if via_journal_entry:


### PR DESCRIPTION
`str` and `datetime` comparison error while posting deferred revenue