### PR TITLE
fix: Missing opening entry in general ledger

### DIFF
--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -239,7 +239,7 @@ def get_conditions(filters):
 	):
 		conditions.append("(posting_date >=%(from_date)s or is_opening = 'Yes')")
 
-	conditions.append("(posting_date <=%(to_date)s)")
+	conditions.append("(posting_date <=%(to_date)s or is_opening = 'Yes')")
 
 	if filters.get("project"):
 		conditions.append("project in %(project)s")


### PR DESCRIPTION
Apply an account filter and date range in General Ledger, opening entries having a posting date after the `to_date`were ignored. Fixed the condition