### PR TITLE
chore: pin ubuntu version for tests

### DIFF
--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
 
     name: Patch Test

--- a/.github/workflows/server-tests-mariadb.yml
+++ b/.github/workflows/server-tests-mariadb.yml
@@ -32,7 +32,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
 
     strategy:

--- a/.github/workflows/server-tests-postgres.yml
+++ b/.github/workflows/server-tests-postgres.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   test:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'postgres') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 60
 
     strategy:


### PR DESCRIPTION
This will make installing dependencies easier, since some of them have builds for a specific ubuntu version (for example, wkhtmltopdf). Also, now it will not fail unexpectedly whenever GitHub decides to deploy the latest ubuntu release.