### PR TITLE
chore: test with wkhtmltopdf 12.6

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -41,8 +41,12 @@ fi
 
 
 install_whktml() {
-    wget -O /tmp/wkhtmltox.deb https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb
-    sudo apt install /tmp/wkhtmltox.deb
+    if [ "$(lsb_release -rs)" = "22.04" ]; then
+        wget -O /tmp/wkhtmltox.deb https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb
+        sudo apt install /tmp/wkhtmltox.deb
+    else
+        echo "Please update this script to support wkhtmltopdf for $(lsb_release -ds)"
+    fi
 }
 install_whktml &
 

--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -41,10 +41,8 @@ fi
 
 
 install_whktml() {
-    wget -O /tmp/wkhtmltox.tar.xz https://github.com/frappe/wkhtmltopdf/raw/master/wkhtmltox-0.12.3_linux-generic-amd64.tar.xz
-    tar -xf /tmp/wkhtmltox.tar.xz -C /tmp
-    sudo mv /tmp/wkhtmltox/bin/wkhtmltopdf /usr/local/bin/wkhtmltopdf
-    sudo chmod o+x /usr/local/bin/wkhtmltopdf
+    wget -O /tmp/wkhtmltox.deb https://github.com/wkhtmltopdf/packaging/releases/download/0.12.6.1-2/wkhtmltox_0.12.6.1-2.jammy_amd64.deb
+    sudo apt install /tmp/wkhtmltox.deb
 }
 install_whktml &
 

--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -46,9 +46,12 @@ install_whktml() {
         sudo apt install /tmp/wkhtmltox.deb
     else
         echo "Please update this script to support wkhtmltopdf for $(lsb_release -ds)"
+        exit 1
     fi
 }
 install_whktml &
+wkpid=$!
+
 
 cd ~/frappe-bench || exit
 
@@ -61,6 +64,8 @@ bench get-app payments
 bench get-app erpnext "${GITHUB_WORKSPACE}"
 
 if [ "$TYPE" == "server" ]; then bench setup requirements --dev; fi
+
+wait $wkpid
 
 bench start &> bench_run_logs.txt &
 CI=Yes bench build --app frappe &


### PR DESCRIPTION
- We used to test with wkhtmltopdf 12.3.
- Our official requirements are 12.5.
- We run tests on Ubuntu 22.04.
- The earliest wkhtmltopdf release that has explicit support for ubuntu 22.04 is 12.6.

See also #33553