### PR TITLE
fix : customer selection not mandatory in  purchase invoice to fetch item details

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1691,7 +1691,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		var valid = true;
 
 		$.each(["company", "customer"], function(i, fieldname) {
-			if(frappe.meta.has_field(me.frm.doc.doctype, fieldname) && me.frm.doc.doctype != "Purchase Order") {
+			if(frappe.meta.has_field(me.frm.doc.doctype, fieldname) &&  !["Purchase Order","Purchase Invoice"].includes(me.frm.doc.doctype)) {
 				if (!me.frm.doc[fieldname]) {
 					frappe.msgprint(__("Please specify") + ": " +
 						frappe.meta.get_label(me.frm.doc.doctype, fieldname, me.frm.doc.name) +


### PR DESCRIPTION
Use Case : Enable Accounting Dimension for “Customer” 

ERPNext expects Customer to be selected  in Purchase Invoice, but customer will be optional in Purchase Invoice. 

The fix handles the scenario.

@deepeshgarg007 Please review.

