### PR TITLE
fix: Timeout error while saving the purchase invoice

### DIFF
--- a/erpnext/buying/doctype/buying_settings/buying_settings.json
+++ b/erpnext/buying/doctype/buying_settings/buying_settings.json
@@ -9,8 +9,8 @@
   "supplier_and_price_defaults_section",
   "supp_master_name",
   "supplier_group",
-  "column_break_4",
   "buying_price_list",
+  "column_break_4",
   "maintain_same_rate_action",
   "role_to_override_stop_action",
   "transaction_settings_section",
@@ -20,6 +20,7 @@
   "maintain_same_rate",
   "allow_multiple_items",
   "bill_for_rejected_quantity_in_purchase_invoice",
+  "disable_last_purchase_rate",
   "subcontract",
   "backflush_raw_materials_of_subcontract_based_on",
   "column_break_11",
@@ -71,7 +72,7 @@
   },
   {
    "fieldname": "subcontract",
-   "fieldtype": "Section Break",
+   "fieldtype": "Tab Break",
    "label": "Subcontracting Settings"
   },
   {
@@ -118,8 +119,8 @@
   },
   {
    "fieldname": "supplier_and_price_defaults_section",
-   "fieldtype": "Section Break",
-   "label": "Supplier and Price Defaults"
+   "fieldtype": "Tab Break",
+   "label": "Naming Series and Price Defaults"
   },
   {
    "fieldname": "column_break_4",
@@ -127,12 +128,18 @@
   },
   {
    "fieldname": "transaction_settings_section",
-   "fieldtype": "Section Break",
+   "fieldtype": "Tab Break",
    "label": "Transaction Settings"
   },
   {
    "fieldname": "column_break_12",
    "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "disable_last_purchase_rate",
+   "fieldtype": "Check",
+   "label": "Disable Last Purchase Rate"
   }
  ],
  "icon": "fa fa-cog",
@@ -140,7 +147,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2022-09-27 10:50:27.050252",
+ "modified": "2023-01-09 17:08:28.828173",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Buying Settings",

--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -274,6 +274,11 @@ class BuyingController(SubcontractingController):
 		if self.doctype not in ("Purchase Receipt", "Purchase Invoice", "Purchase Order"):
 			return
 
+		if (
+			self.doctype == "Purchase Invoice" and not self.update_stock and not self.is_internal_transfer()
+		):
+			return
+
 		ref_doctype_map = {
 			"Purchase Order": "Sales Order Item",
 			"Purchase Receipt": "Delivery Note Item",

--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -274,9 +274,7 @@ class BuyingController(SubcontractingController):
 		if self.doctype not in ("Purchase Receipt", "Purchase Invoice", "Purchase Order"):
 			return
 
-		if (
-			self.doctype == "Purchase Invoice" and not self.update_stock and not self.is_internal_transfer()
-		):
+		if not self.is_internal_transfer():
 			return
 
 		ref_doctype_map = {
@@ -549,7 +547,9 @@ class BuyingController(SubcontractingController):
 			self.process_fixed_asset()
 			self.update_fixed_asset(field)
 
-		if self.doctype in ["Purchase Order", "Purchase Receipt"]:
+		if self.doctype in ["Purchase Order", "Purchase Receipt"] and not frappe.db.get_single_value(
+			"Buying Settings", "disable_last_purchase_rate"
+		):
 			update_last_purchase_rate(self, is_submit=1)
 
 	def on_cancel(self):
@@ -558,7 +558,9 @@ class BuyingController(SubcontractingController):
 		if self.get("is_return"):
 			return
 
-		if self.doctype in ["Purchase Order", "Purchase Receipt"]:
+		if self.doctype in ["Purchase Order", "Purchase Receipt"] and not frappe.db.get_single_value(
+			"Buying Settings", "disable_last_purchase_rate"
+		):
 			update_last_purchase_rate(self, is_submit=0)
 
 		if self.doctype in ["Purchase Receipt", "Purchase Invoice"]:

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -279,7 +279,7 @@ class Item(Document):
 				frappe.throw(_("Row #{0}: Maximum Net Rate cannot be greater than Minimum Net Rate"))
 
 	def update_template_tables(self):
-		template = frappe.get_doc("Item", self.variant_of)
+		template = frappe.get_cached_doc("Item", self.variant_of)
 
 		# add item taxes from template
 		for d in template.get("taxes"):

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -164,10 +164,7 @@ class Item(Document):
 		if not self.is_stock_item or self.has_serial_no or self.has_batch_no:
 			return
 
-		if not self.valuation_rate and self.standard_rate:
-			self.valuation_rate = self.standard_rate
-
-		if not self.valuation_rate and not self.is_customer_provided_item:
+		if not self.valuation_rate and not self.standard_rate and not self.is_customer_provided_item:
 			frappe.throw(_("Valuation Rate is mandatory if Opening Stock entered"))
 
 		from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
@@ -192,7 +189,7 @@ class Item(Document):
 					item_code=self.name,
 					target=default_warehouse,
 					qty=self.opening_stock,
-					rate=self.valuation_rate,
+					rate=self.valuation_rate or self.standard_rate,
 					company=default.company,
 					posting_date=getdate(),
 					posting_time=nowtime(),

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -411,7 +411,9 @@ def get_basic_details(args, item, overwrite_warehouse=True):
 	args.stock_qty = out.stock_qty
 
 	# calculate last purchase rate
-	if args.get("doctype") in purchase_doctypes:
+	if args.get("doctype") in purchase_doctypes and not frappe.db.get_single_value(
+		"Buying Settings", "disable_last_purchase_rate"
+	):
 		from erpnext.buying.doctype.purchase_order.purchase_order import item_last_purchase_rate
 
 		out.last_purchase_rate = item_last_purchase_rate(

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -813,6 +813,9 @@ def get_price_list_rate(args, item_doc, out=None):
 			flt(price_list_rate) * flt(args.plc_conversion_rate) / flt(args.conversion_rate)
 		)
 
+		if frappe.db.get_single_value("Buying Settings", "disable_last_purchase_rate"):
+			return out
+
 		if not out.price_list_rate and args.transaction_type == "buying":
 			from erpnext.stock.doctype.item.item import get_last_purchase_details
 


### PR DESCRIPTION
**Issue**

While saving the Purchase Invoice, system throwing the timeout error
<img width="1035" alt="image" src="https://user-images.githubusercontent.com/8780500/211279867-562c267d-fc24-429b-ab20-ea262eaa65ef.png">

- Customer has created Single Purchase Order with Single Item and 2,00,000 Quantity
- Customer has created different 715 Purchase Receipts against the above Purchase Order with same Item Code.
- Customer was trying to make single Purchase Invoice against the above 715 Purchase Receipts but they got Timeout Error.

**Investigation** 

- The Get Last Purchase rate takes lot of time and this method calls 715 times though the Item Code is same in all 715 line items.
- The method set_incoming_rate takes time to execute and this method also calls 715 times for the same Item Code


**Solution**

- The set_incoming_rate method should only call if it's internal transfer entry
<img width="936" alt="image" src="https://user-images.githubusercontent.com/8780500/211281640-fc6849b4-a2ce-4d47-b0ad-93feac7706ea.png">

- Provision to disable Get Last Purchase Rate feature
<img width="1324" alt="Screenshot 2023-01-09 at 5 09 58 PM" src="https://user-images.githubusercontent.com/8780500/211300327-0a7791d3-32ee-44fe-ab6e-72d200a07cfa.png">


**After Fix**

<img width="710" alt="Screenshot 2023-01-09 at 2 51 10 PM" src="https://user-images.githubusercontent.com/8780500/211282051-07b14911-3562-4ab5-8ba5-43dd1a72f08b.png">

Changed get_doc to get_cached_doc

<img width="606" alt="image" src="https://user-images.githubusercontent.com/8780500/211310740-95164947-4acb-4c3b-9459-260db0e434a1.png">

**After Change**

<img width="730" alt="Screenshot 2023-01-09 at 6 08 24 PM" src="https://user-images.githubusercontent.com/8780500/211310644-379a51e2-1fcc-41c1-a330-e8282c087073.png">


