### PR TITLE
feat: disable currency exchange api.

### DIFF
--- a/erpnext/accounts/doctype/currency_exchange_settings/currency_exchange_settings.json
+++ b/erpnext/accounts/doctype/currency_exchange_settings/currency_exchange_settings.json
@@ -6,6 +6,7 @@
  "engine": "InnoDB",
  "field_order": [
   "api_details_section",
+  "disabled",
   "service_provider",
   "api_endpoint",
   "url",
@@ -77,12 +78,18 @@
    "label": "Service Provider",
    "options": "frankfurter.app\nexchangerate.host\nCustom",
    "reqd": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "disabled",
+   "fieldtype": "Check",
+   "label": "Disabled"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2022-01-10 15:51:14.521174",
+ "modified": "2023-01-09 12:19:03.955906",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Currency Exchange Settings",

--- a/erpnext/setup/utils.py
+++ b/erpnext/setup/utils.py
@@ -81,6 +81,11 @@ def get_exchange_rate(from_currency, to_currency, transaction_date=None, args=No
 	if entries:
 		return flt(entries[0].exchange_rate)
 
+	if frappe.get_cached_value(
+		"Currency Exchange Settings", "Currency Exchange Settings", "disabled"
+	):
+		return 0.00
+
 	try:
 		cache = frappe.cache()
 		key = "currency_exchange_rate_{0}:{1}:{2}".format(transaction_date, from_currency, to_currency)


### PR DESCRIPTION
### Overview
Disable currency exchange API. When disabled if no exchange records are set 0.0 will be returned.

### Background
During an implementation client wants to force operator to manually enter an exchange rate. Sometimes operator forgets because exchange rate is automatically set from this API.

`no-docs`: There is currently no docs for Currency Exchange Settings doctype. Disabled checkbox is pretty self explanatory. 