### PR TITLE
fix: don't check other warehouse ledgers to calculate valuation rate

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -1270,20 +1270,6 @@ def get_valuation_rate(
 			(item_code, warehouse, voucher_no, voucher_type),
 		)
 
-	if not last_valuation_rate:
-		# Get valuation rate from last sle for the item against any warehouse
-		last_valuation_rate = frappe.db.sql(
-			"""select valuation_rate
-			from `tabStock Ledger Entry` force index (item_code)
-			where
-				item_code = %s
-				AND valuation_rate > 0
-				AND is_cancelled = 0
-				AND NOT(voucher_no = %s AND voucher_type = %s)
-			order by posting_date desc, posting_time desc, name desc limit 1""",
-			(item_code, voucher_no, voucher_type),
-		)
-
 	if last_valuation_rate:
 		return flt(last_valuation_rate[0][0])
 


### PR DESCRIPTION
**Issue**

- Consider we have item 'ABC' and two warehouse as "Warehouse A" and "Warehouse B"
- ABC has transactions in the warehouse A
- ABC don't have any transactions in the warehouse B
- While making first inward transactions in the warehouse B, system has picked the wrong valuation rate from warehouse A
- After sometime through reposting the valuation rate of warehouse A has been fixed. But this will not fixed the valuation rate of warehouse B

Also this change will improve the performance of get_valuation_rate  method.

Fixed https://github.com/frappe/erpnext/issues/32628