### PR TITLE
fix: RFQ emails not sent with pdf attachment

### DIFF
--- a/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
+++ b/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
@@ -216,6 +216,7 @@ class RequestforQuotation(BuyingController):
 			recipients=data.email_id,
 			sender=sender,
 			attachments=attachments,
+			print_format=self.meta.default_print_format or "Standard",
 			send_email=True,
 			doctype=self.doctype,
 			name=self.name,
@@ -224,9 +225,7 @@ class RequestforQuotation(BuyingController):
 		frappe.msgprint(_("Email Sent to Supplier {0}").format(data.supplier))
 
 	def get_attachments(self):
-		attachments = [d.name for d in get_attachments(self.doctype, self.name)]
-		attachments.append(frappe.attach_print(self.doctype, self.name, doc=self))
-		return attachments
+		return [d.name for d in get_attachments(self.doctype, self.name)]
 
 	def update_rfq_supplier_status(self, sup_name=None):
 		for supplier in self.suppliers:


### PR DESCRIPTION
## Issue

- Emails automatically sent on submit of Request for Quotation, to the suppliers should go with PDF attachments of RFQ.
- `email.make` expects print_format as a variable.
- Default to `Standard` where the default print format is missing.


### Before

**Email Queue**

![image](https://user-images.githubusercontent.com/10496564/211567662-a41ca8ba-e343-46e5-87c5-3f8c6018c669.png)


**Email without attachments**

![image](https://user-images.githubusercontent.com/10496564/211567788-84728886-8113-4ee3-a09b-33ede6f6abcc.png)


## After

**Email Queue**

![image](https://user-images.githubusercontent.com/10496564/211568018-2692d2a8-097f-4990-a2f9-2f257336d655.png)


**Email with attachments**

![image](https://user-images.githubusercontent.com/10496564/211568145-41aa0f81-7512-4e72-a9b5-f81f1b290c28.png)

