### PR TITLE
fix: better comparision of `difference_value` of Stock and Account

### DIFF
--- a/erpnext/stock/report/stock_and_account_value_comparison/stock_and_account_value_comparison.py
+++ b/erpnext/stock/report/stock_and_account_value_comparison/stock_and_account_value_comparison.py
@@ -41,7 +41,7 @@ def get_data(report_filters):
 		key = (d.voucher_type, d.voucher_no)
 		gl_data = voucher_wise_gl_data.get(key) or {}
 		d.account_value = gl_data.get("account_value", 0)
-		d.difference_value = abs(d.stock_value - d.account_value)
+		d.difference_value = d.stock_value - d.account_value
 		if abs(d.difference_value) > 0.1:
 			data.append(d)
 


### PR DESCRIPTION
## Objective

Absolute difference values would give the incorrect total difference and may be misleading.

## Before
![image](https://user-images.githubusercontent.com/10496564/211724190-4a9bc170-4ec1-49af-a49f-97d3e463e0c6.png)


## After
![image](https://user-images.githubusercontent.com/10496564/211724965-54637ed9-8c65-4284-9f03-665e0e2baf41.png)

