### PR TITLE
fix: rewrite logic for duplicate check in Item Attribute

### DIFF
--- a/erpnext/stock/doctype/item_attribute/item_attribute.py
+++ b/erpnext/stock/doctype/item_attribute/item_attribute.py
@@ -75,11 +75,9 @@ class ItemAttribute(Document):
 		values, abbrs = [], []
 		for d in self.item_attribute_values:
 			if d.attribute_value.lower() in map(str.lower, values):
-				frappe.throw(
-					_("Attribute value: {0} must appear only once").format(d.attribute_value.title()))
+				frappe.throw(_("Attribute value: {0} must appear only once").format(d.attribute_value.title()))
 			values.append(d.attribute_value)
 
 			if d.abbr.lower() in map(str.lower, abbrs):
-				frappe.throw(
-					_("Abbreviation: {0} must appear only once").format(d.abbr.title()))
+				frappe.throw(_("Abbreviation: {0} must appear only once").format(d.abbr.title()))
 			abbrs.append(d.abbr)

--- a/erpnext/stock/doctype/item_attribute/item_attribute.py
+++ b/erpnext/stock/doctype/item_attribute/item_attribute.py
@@ -74,11 +74,12 @@ class ItemAttribute(Document):
 	def validate_duplication(self):
 		values, abbrs = [], []
 		for d in self.item_attribute_values:
-			d.abbr = d.abbr.upper()
-			if d.attribute_value in values:
-				frappe.throw(_("{0} must appear only once").format(d.attribute_value))
+			if d.attribute_value.lower() in map(str.lower, values):
+				frappe.throw(
+					_("Attribute value: {0} must appear only once").format(d.attribute_value.title()))
 			values.append(d.attribute_value)
 
-			if d.abbr in abbrs:
-				frappe.throw(_("{0} must appear only once").format(d.abbr))
+			if d.abbr.lower() in map(str.lower, abbrs):
+				frappe.throw(
+					_("Abbreviation: {0} must appear only once").format(d.abbr.title()))
 			abbrs.append(d.abbr)


### PR DESCRIPTION
Previously, Item Attribute values were not checked for case-insensitive duplicates, and Item tttribute abbreviations were forced to be uppercase. This commit fixes both problems.

Fixes: #22256
Partially fixes: #15467