### PR TITLE
fix: Updating SO throws ordered_qty not allowed to change after submission

### DIFF
--- a/erpnext/selling/doctype/sales_order_item/sales_order_item.json
+++ b/erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -638,6 +638,7 @@
    "width": "70px"
   },
   {
+   "allow_on_submit": 1,
    "fieldname": "ordered_qty",
    "fieldtype": "Float",
    "label": "Ordered Qty",
@@ -864,7 +865,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2022-12-25 02:51:10.247569",
+ "modified": "2023-01-12 13:13:28.691585",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order Item",


### PR DESCRIPTION
Fixes Not allowed to change 'Order Qty' after submission while updating Sales Order
<img width="401" alt="Screenshot 2023-01-12 at 1 25 11 PM" src="https://user-images.githubusercontent.com/3272205/212009631-ea332b5c-743e-4d53-95bf-32f19d8ad447.png">


regression: https://github.com/frappe/erpnext/pull/33495