### PR TITLE
fix: Return against internal purchase invoice

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -394,7 +394,7 @@ class AccountsController(TransactionBase):
 				self.get("inter_company_reference")
 				or self.get("inter_company_invoice_reference")
 				or self.get("inter_company_order_reference")
-			):
+			) and not self.get("is_return"):
 				msg = _("Internal Sale or Delivery Reference missing.")
 				msg += _("Please create purchase from internal sale or delivery document itself")
 				frappe.throw(msg, title=_("Internal Sales Reference Missing"))


### PR DESCRIPTION
The user is unable to create a debit note (Return) against an internal purchase invoice because of the sales reference missing validation. Return invoices against any purchase invoice should be allowed hence ignoring this validation for such invoices.