### PR TITLE
chore: reuse doc object in test_pick_list_grouping_before_print

### DIFF
--- a/erpnext/stock/doctype/pick_list/test_pick_list.py
+++ b/erpnext/stock/doctype/pick_list/test_pick_list.py
@@ -460,16 +460,7 @@ class TestPickList(FrappeTestCase):
 		self.assertEqual(len(pl.locations), 4)
 
 		# grouping should halve the number of items
-		pl = frappe.get_doc(
-			doctype="Pick List",
-			group_same_items=True,
-			locations=[
-				_dict(item_code="A", warehouse="X", qty=5, picked_qty=1),
-				_dict(item_code="B", warehouse="Y", qty=4, picked_qty=2),
-				_dict(item_code="A", warehouse="X", qty=3, picked_qty=2),
-				_dict(item_code="B", warehouse="Y", qty=2, picked_qty=2),
-			],
-		)
+		pl.group_same_items = True
 		pl.before_print()
 		self.assertEqual(len(pl.locations), 2)
 


### PR DESCRIPTION
reduces duplication in `test_pick_list_grouping_before_print`

forgot to do in https://github.com/frappe/erpnext/pull/33627