### PR TITLE
fix: zero rm-cost in SCR

### DIFF
--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
@@ -63,6 +63,11 @@ class SubcontractingReceipt(SubcontractingController):
 		self.set_items_expense_account()
 
 	def validate(self):
+		if (
+			frappe.db.get_single_value("Buying Settings", "backflush_raw_materials_of_subcontract_based_on")
+			== "BOM"
+		):
+			self.supplied_items = []
 		super(SubcontractingReceipt, self).validate()
 		self.set_missing_values()
 		self.validate_posting_time()


### PR DESCRIPTION
**Source / Reference**: #ISS-22-23-04417 

**Steps to replicate:**

- Set the Backflush Based on _BOM_.

  ![image](https://user-images.githubusercontent.com/63660334/212487468-0f5e16a9-4700-4ec7-8a70-65a02b105764.png)

- Create Subcontracted Purchase Order.

  ![image](https://user-images.githubusercontent.com/63660334/212481669-3f807217-ed61-4ae2-8041-5ad298641470.png)

- Create Subcontracting Order.

  ![image](https://user-images.githubusercontent.com/63660334/212481796-99c6b304-8cd1-4543-9b8f-bfa21f8807b7.png)

- Transfer the required Raw-Materials to Supplier via Stock Entry (Send to Subcontractor).
  
![image](https://user-images.githubusercontent.com/63660334/212482028-f27b0fd4-1f8f-4efa-a05f-fe351b498148.png)

- Consume the transferred Raw-Materials via Subcontracting Receipt for another Subcontracting Order or Just move it to another warehouse via Stock Entry (Material Transfer).

  ![image](https://user-images.githubusercontent.com/63660334/212482125-332536bc-c5c1-4823-856b-7a50304e5553.png)

- Create a Subcontracting Receipt for the main Subcontracting Order, the RM cost will be zero as the available stock is zero.

  ![image](https://user-images.githubusercontent.com/63660334/212482208-a5f81ee0-fe95-4281-acda-3db34819cf32.png)

- Transfer the Raw Material using Stock Entry (Material Transfer) to the Supplier Warehouse or cancel the Material Transfer Stock Entry.

  ![image](https://user-images.githubusercontent.com/63660334/212482292-345875b0-c347-49db-877e-a5a763307b83.png)

- Now, submit the Draft Subcontracting Receipt, the RM Cost will not be included in the FG Item valuation.

  ![image](https://user-images.githubusercontent.com/63660334/212482366-0b63de95-1651-4e20-becb-9edf4571c387.png)

  ![image](https://user-images.githubusercontent.com/63660334/212482459-57c1dd5b-b0b4-4193-bcd0-c3d0b5591102.png)

**Why this is happening?**
The `consumed_items` table is created when there is a change in the `items` table like a row added, a row removed, the rate changed etc. Since there is no change in the `items` table the system posted the same doc with zero RM Cost.

**Solution?**
The ideal solution is to generate the `supplied_items` table on every save i.e., on the `validate` method which is also required since the `valuation_rate` changes very frequently. But this can't be possible now as it will break the v13 flow. In v13 we have an `Update Items` button which also triggers the same method to generate the `supplied_items` table, it considers only the changed row(s). So, if we generate the `supplied_items` on every change the qty(received, returned etc) will get reset.

![scrnli_1_14_2023_8-58-52 PM](https://user-images.githubusercontent.com/63660334/212482562-a2eb59f9-df6b-410c-af16-be438aacb9ec.png)

**Then?**
A simple fix, for now, is to reset the `supplied_items` only for Subcontracting Receipt in the `validate` method.