### PR TITLE
fix: handle asset depr entries posting failure and fix asset repair link [v13]

### DIFF
--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -132,6 +132,10 @@ frappe.ui.form.on('Asset', {
 				}, __("Manage"));
 			}
 
+			if (frm.doc.depr_entry_posting_status === "Failed") {
+				frm.trigger("set_depr_posting_failure_alert");
+			}
+
 			frm.trigger("setup_chart");
 		}
 
@@ -140,6 +144,19 @@ frappe.ui.form.on('Asset', {
 		if (frm.doc.docstatus == 0) {
 			frm.toggle_reqd("finance_books", frm.doc.calculate_depreciation);
 		}
+	},
+
+	set_depr_posting_failure_alert: function (frm) {
+		const alert = `
+			<div class="row">
+				<div class="col-xs-12 col-sm-6">
+					<span class="indicator whitespace-nowrap red">
+						<span>Failed to post depreciation entries</span>
+					</span>
+				</div>
+			</div>`;
+
+		frm.dashboard.set_headline_alert(alert);
 	},
 
 	toggle_reference_doc: function(frm) {

--- a/erpnext/assets/doctype/asset/asset.json
+++ b/erpnext/assets/doctype/asset/asset.json
@@ -68,6 +68,7 @@
   "column_break_51",
   "purchase_receipt_amount",
   "default_finance_book",
+  "depr_entry_posting_status",
   "amended_from"
  ],
  "fields": [
@@ -473,6 +474,16 @@
    "fieldname": "section_break_36",
    "fieldtype": "Section Break",
    "label": "Finance Books"
+  },
+  {
+   "fieldname": "depr_entry_posting_status",
+   "fieldtype": "Select",
+   "hidden": 1,
+   "label": "Depreciation Entry Posting Status",
+   "no_copy": 1,
+   "options": "\nSuccessful\nFailed",
+   "print_hide": 1,
+   "read_only": 1
   }
  ],
  "idx": 72,
@@ -487,7 +498,7 @@
   {
    "group": "Repair",
    "link_doctype": "Asset Repair",
-   "link_fieldname": "asset_name"
+   "link_fieldname": "asset"
   },
   {
    "group": "Value",
@@ -495,7 +506,7 @@
    "link_fieldname": "asset"
   }
  ],
- "modified": "2022-07-20 16:22:44.437579",
+ "modified": "2023-01-17 00:28:37.789345",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset",

--- a/erpnext/assets/doctype/asset/depreciation.py
+++ b/erpnext/assets/doctype/asset/depreciation.py
@@ -4,7 +4,8 @@
 
 import frappe
 from frappe import _
-from frappe.utils import cint, flt, getdate, today
+from frappe.utils import cint, flt, get_link_to_form, getdate, today
+from frappe.utils.user import get_users_with_role
 
 from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
 	get_checks_for_pl_and_bs_accounts,
@@ -20,9 +21,22 @@ def post_depreciation_entries(date=None):
 
 	if not date:
 		date = today()
-	for asset in get_depreciable_assets(date):
-		make_depreciation_entry(asset, date)
-		frappe.db.commit()
+
+	failed_asset_names = []
+
+	for asset_name in get_depreciable_assets(date):
+		try:
+			make_depreciation_entry(asset_name, date)
+			frappe.db.commit()
+		except Exception as e:
+			frappe.db.rollback()
+			failed_asset_names.append(asset_name)
+
+	if failed_asset_names:
+		set_depr_entry_posting_status_for_failed_assets(failed_asset_names)
+		notify_depr_entry_posting_error(failed_asset_names)
+
+	frappe.db.commit()
 
 
 def get_depreciable_assets(date):
@@ -121,6 +135,8 @@ def make_depreciation_entry(asset_name, date=None):
 			finance_books.value_after_depreciation -= d.depreciation_amount
 			finance_books.db_update()
 
+	frappe.db.set_value("Asset", asset_name, "depr_entry_posting_status", "Successful")
+
 	asset.set_status()
 
 	return asset
@@ -182,6 +198,42 @@ def get_credit_and_debit_accounts(accumulated_depreciation_account, depreciation
 		frappe.throw(_("Depreciation Expense Account should be an Income or Expense Account."))
 
 	return credit_account, debit_account
+
+
+def set_depr_entry_posting_status_for_failed_assets(failed_asset_names):
+	for asset_name in failed_asset_names:
+		frappe.db.set_value("Asset", asset_name, "depr_entry_posting_status", "Failed")
+
+
+def notify_depr_entry_posting_error(failed_asset_names):
+	recipients = get_users_with_role("Accounts Manager")
+
+	if not recipients:
+		recipients = get_users_with_role("System Manager")
+
+	subject = _("Error while posting depreciation entries")
+
+	asset_links = get_comma_separated_asset_links(failed_asset_names)
+
+	message = (
+		_("Hi,")
+		+ "<br>"
+		+ _("The following assets have failed to post depreciation entries: {0}").format(asset_links)
+		+ "."
+	)
+
+	frappe.sendmail(recipients=recipients, subject=subject, message=message)
+
+
+def get_comma_separated_asset_links(asset_names):
+	asset_links = []
+
+	for asset_name in asset_names:
+		asset_links.append(get_link_to_form("Asset", asset_name))
+
+	asset_links = ", ".join(asset_links)
+
+	return asset_links
 
 
 @frappe.whitelist()

--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -1387,6 +1387,7 @@ def create_asset(**args):
 			"location": args.location or "Test Location",
 			"asset_owner": args.asset_owner or "Company",
 			"is_existing_asset": args.is_existing_asset or 1,
+			"depr_entry_posting_status": args.depr_entry_posting_status or "",
 		}
 	)
 


### PR DESCRIPTION
1. Before, if depreciation entries for 100 assets were to be posted (through the post_depreciation_entries daily job) and an error is encountered while posting the entries of the 10th asset, entries for rest of the 90 assets aren't posted. Additionally, even though an error log would be created for this, customers wouldn’t be notified of this in any way, so they often go days before noticing that an asset is not depreciating properly. Now, if depreciation posting fails for the 10th asset, entries for rest of the 90 assets are posted. All the users with the Accounts Manager or System Manager role are sent an email. An alert (Failed to post depreciation entries) is shown on the asset, which would only go away once the issue with the asset is fixed and the entries are successfully posted.
2. Asset repair docs weren't showing up in the linked documents section of asset, so fixed the link.