### PR TITLE
fix: Sales Order Connections Tabs do not show linked Material Request or "+" button  (intoduce by #33304)

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order_dashboard.py
+++ b/erpnext/selling/doctype/sales_order/sales_order_dashboard.py
@@ -14,7 +14,6 @@ def get_data():
 		},
 		"internal_links": {
 			"Quotation": ["items", "prevdoc_docname"],
-			"Material Request": ["items", "material_request"],
 		},
 		"transactions": [
 			{


### PR DESCRIPTION
ERPNext develop, versoin-14, version-13

How to reproduce :
Create a Sales order
Create a Material request from the sales order (use create blue button as "+" is missing) => Go to Connections tabs => Go back to originated Sales Order
Check Sales Order Connections Tab, the materials Request is not here.

Before PR:

https://user-images.githubusercontent.com/1050053/212759149-7daaed86-d408-4319-ba39-e6ea5d95a8c4.mp4


After PR:

https://user-images.githubusercontent.com/1050053/212758598-3cdba92d-f8c3-4a34-b139-ab9238816b97.mp4



Note To Reviewer:
 - I don't know why @s-aga-r have (or I have) different result, but I test from fresh install without any custom app or customization in version-13, version-14 and develop, and this PR broke exactly what it should to fix 
 - Linters error is not related with this change. 
