### PR TITLE
fix: patch item_reposting_for_incorrect_sl_and_gl

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -194,7 +194,6 @@ erpnext.patches.v13_0.update_project_template_tasks
 erpnext.patches.v13_0.convert_qi_parameter_to_link_field
 erpnext.patches.v13_0.add_naming_series_to_old_projects # 1-02-2021
 erpnext.patches.v13_0.update_payment_terms_outstanding
-erpnext.patches.v13_0.item_reposting_for_incorrect_sl_and_gl
 erpnext.patches.v13_0.delete_old_bank_reconciliation_doctypes
 erpnext.patches.v13_0.update_vehicle_no_reqd_condition
 erpnext.patches.v13_0.rename_membership_settings_to_non_profit_settings
@@ -291,6 +290,7 @@ erpnext.patches.v13_0.update_exchange_rate_settings
 erpnext.patches.v14_0.delete_amazon_mws_doctype
 erpnext.patches.v13_0.set_work_order_qty_in_so_from_mr
 erpnext.patches.v13_0.update_accounts_in_loan_docs
+erpnext.patches.v13_0.item_reposting_for_incorrect_sl_and_gl
 erpnext.patches.v14_0.update_batch_valuation_flag
 erpnext.patches.v14_0.delete_non_profit_doctypes
 erpnext.patches.v13_0.add_cost_center_in_loans

--- a/erpnext/patches/v13_0/item_reposting_for_incorrect_sl_and_gl.py
+++ b/erpnext/patches/v13_0/item_reposting_for_incorrect_sl_and_gl.py
@@ -7,6 +7,7 @@ from erpnext.stock.stock_ledger import update_entries_after
 
 def execute():
 	doctypes_to_reload = [
+		("setup", "company"),
 		("stock", "repost_item_valuation"),
 		("stock", "stock_entry_detail"),
 		("stock", "purchase_receipt_item"),


### PR DESCRIPTION
**Issue**

```
Executing erpnext.patches.v13_0.item_reposting_for_incorrect_sl_and_gl in mylabdiscovery.erpnext.com (_02d08216f333cf23)
Reposting Stock Ledger Entries...
Reposting General Ledger Entries...

Traceback (most recent call last):
  File "/usr/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 110, in <module>
    main()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 20, in main
    click.Group(commands=commands)(prog_name="bench")
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 31, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/site.py", line 433, in migrate
    migrate(context.verbose, skip_failing=skip_failing, skip_search_index=skip_search_index)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py", line 73, in migrate
    frappe.modules.patch_handler.run_all(skip_failing)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 47, in run_all
    run_patch(patch)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 36, in run_patch
    if not run_single(patchmodule=patch):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 81, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 105, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/patches/v13_0/item_reposting_for_incorrect_sl_and_gl.py", line 80, in execute
    update_gl_entries_after(posting_date, posting_time, company=row.name)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/utils.py", line 1164, in update_gl_entries_after
    repost_gle_for_stock_vouchers(stock_vouchers, posting_date, company, warehouse_account)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/utils.py", line 1192, in repost_gle_for_stock_vouchers
    expected_gle = voucher_obj.get_gl_entries(warehouse_account)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py", line 292, in get_gl_entries
    self.make_item_gl_entries(gl_entries, warehouse_account=warehouse_account)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py", line 308, in make_item_gl_entries
    "Company", self.company, "enable_provisional_accounting_for_non_stock_items"
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/database.py", line 469, in get_value
    limit=1,
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/database.py", line 540, in get_values
    limit=limit,
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/database.py", line 739, in _get_values_from_table
    update=update,
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/database.py", line 174, in sql
    self._cursor.execute(query, values)
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/pymysql/cursors.py", line 148, in execute
    result = self._query(query)
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/pymysql/cursors.py", line 310, in _query
    conn.query(q)
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/pymysql/connections.py", line 548, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/pymysql/connections.py", line 775, in _read_query_result
    result.read()
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/pymysql/connections.py", line 1156, in read
    first_packet = self.connection._read_packet()
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/pymysql/connections.py", line 725, in _read_packet
    packet.raise_for_error()
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/pymysql/protocol.py", line 221, in raise_for_error
    err.raise_mysql_exception(self._data)
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/pymysql/err.py", line 143, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.OperationalError: (1054, "Unknown column 'enable_provisional_accounting_for_non_stock_items' in 'field list'")
```