### PR TITLE
fix: the frappe throw message is corrected in the group task validation

### DIFF
--- a/erpnext/projects/doctype/task/task.py
+++ b/erpnext/projects/doctype/task/task.py
@@ -97,7 +97,7 @@ class Task(NestedSet):
 				if frappe.db.get_value("Task", d.task, "status") not in ("Completed", "Cancelled"):
 					frappe.throw(
 						_(
-							"Cannot complete task {0} as its dependant task {1} are not ccompleted / cancelled."
+							"Cannot complete task {0} as its dependant task {1} are not completed / cancelled."
 						).format(frappe.bold(self.name), frappe.bold(d.task))
 					)
 


### PR DESCRIPTION
Description: 

the frappe throw message is corrected in the group task validation if depend tasks were not completed or cancelled.

screenshots:

before

![Screenshot from 2023-01-17 12-27-01](https://user-images.githubusercontent.com/105269688/212835963-52adf307-be5e-4a9f-adba-8903e2ba9fc9.png)

after

![image](https://user-images.githubusercontent.com/105269688/212836122-ac93fa8e-ea17-4ba6-a682-30bb3c6e61c0.png)

