### PR TITLE
fix: Missing constructor args in Bank Reco Tool

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.json
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.json
@@ -137,8 +137,7 @@
    "fieldname": "finance_book",
    "fieldtype": "Link",
    "label": "Finance Book",
-   "options": "Finance Book",
-   "read_only": 1
+   "options": "Finance Book"
   },
   {
    "fieldname": "2_add_edit_gl_entries",
@@ -539,7 +538,7 @@
  "idx": 176,
  "is_submittable": 1,
  "links": [],
- "modified": "2022-11-28 17:40:01.241908",
+ "modified": "2023-01-17 12:53:53.280620",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Journal Entry",

--- a/erpnext/public/js/bank_reconciliation_tool/dialog_manager.js
+++ b/erpnext/public/js/bank_reconciliation_tool/dialog_manager.js
@@ -1,7 +1,7 @@
 frappe.provide("erpnext.accounts.bank_reconciliation");
 
 erpnext.accounts.bank_reconciliation.DialogManager = class DialogManager {
-	constructor(company, bank_account) {
+	constructor(company, bank_account, bank_statement_from_date, bank_statement_to_date, filter_by_reference_date, from_reference_date, to_reference_date) {
 		this.bank_account = bank_account;
 		this.company = company;
 		this.make_dialog();


### PR DESCRIPTION
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/42651287/212918405-6231f441-cf7d-458a-9086-cc874151dc76.png">

Introduced in https://github.com/frappe/erpnext/pull/33271