### PR TITLE
fix: local variable 'stock_rbnb' referenced before assignment

### DIFF
--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
@@ -262,15 +262,17 @@ class SubcontractingReceipt(SubcontractingController):
 	def get_gl_entries(self, warehouse_account=None):
 		from erpnext.accounts.general_ledger import process_gl_map
 
+		if not erpnext.is_perpetual_inventory_enabled(self.company):
+			return []
+
 		gl_entries = []
 		self.make_item_gl_entries(gl_entries, warehouse_account)
 
 		return process_gl_map(gl_entries)
 
 	def make_item_gl_entries(self, gl_entries, warehouse_account=None):
-		if erpnext.is_perpetual_inventory_enabled(self.company):
-			stock_rbnb = self.get_company_default("stock_received_but_not_billed")
-			expenses_included_in_valuation = self.get_company_default("expenses_included_in_valuation")
+		stock_rbnb = self.get_company_default("stock_received_but_not_billed")
+		expenses_included_in_valuation = self.get_company_default("expenses_included_in_valuation")
 
 		warehouse_with_no_account = []
 


### PR DESCRIPTION
**Issue**

```
  self.run_method("on_submit")
  File "apps/frappe/frappe/model/document.py", line 909, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1259, in composer
    return composed(self, method, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1241, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "apps/frappe/frappe/model/document.py", line 906, in fn
    return method_object(*args, **kwargs)
  File "apps/erpnext/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py", line 92, in on_submit
    self.make_gl_entries()
  File "apps/erpnext/erpnext/controllers/stock_controller.py", line 73, in make_gl_entries
    gl_entries = self.get_gl_entries(warehouse_account)
  File "apps/erpnext/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py", line 253, in get_gl_entries
    self.make_item_gl_entries(gl_entries, warehouse_account)
  File "apps/erpnext/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py", line 295, in make_item_gl_entries
    against_account=stock_rbnb,
UnboundLocalError: local variable 'stock_rbnb' referenced before assignment
```