### PR TITLE
fix: Better budget exceeding validation messages

### DIFF
--- a/erpnext/accounts/doctype/budget/budget.py
+++ b/erpnext/accounts/doctype/budget/budget.py
@@ -184,6 +184,11 @@ def validate_budget_records(args, budget_records, expense_amount):
 			amount = expense_amount or get_amount(args, budget)
 			yearly_action, monthly_action = get_actions(args, budget)
 
+			if yearly_action in ("Stop", "Warn"):
+				compare_expense_with_budget(
+					args, flt(budget.budget_amount), _("Annual"), yearly_action, budget.budget_against, amount
+				)
+
 			if monthly_action in ["Stop", "Warn"]:
 				budget_amount = get_accumulated_monthly_budget(
 					budget.monthly_distribution, args.posting_date, args.fiscal_year, budget.budget_amount
@@ -195,28 +200,28 @@ def validate_budget_records(args, budget_records, expense_amount):
 					args, budget_amount, _("Accumulated Monthly"), monthly_action, budget.budget_against, amount
 				)
 
-			if (
-				yearly_action in ("Stop", "Warn")
-				and monthly_action != "Stop"
-				and yearly_action != monthly_action
-			):
-				compare_expense_with_budget(
-					args, flt(budget.budget_amount), _("Annual"), yearly_action, budget.budget_against, amount
-				)
-
 
 def compare_expense_with_budget(args, budget_amount, action_for, action, budget_against, amount=0):
-	actual_expense = amount or get_actual_expense(args)
-	if actual_expense > budget_amount:
-		diff = actual_expense - budget_amount
+	actual_expense = get_actual_expense(args)
+	total_expense = actual_expense + amount
+
+	if total_expense > budget_amount:
+		if actual_expense > budget_amount:
+			error_tense = _("is already")
+			diff = actual_expense - budget_amount
+		else:
+			error_tense = _("will be")
+			diff = total_expense - budget_amount
+
 		currency = frappe.get_cached_value("Company", args.company, "default_currency")
 
-		msg = _("{0} Budget for Account {1} against {2} {3} is {4}. It will exceed by {5}").format(
+		msg = _("{0} Budget for Account {1} against {2} {3} is {4}. It {5} exceed by {6}").format(
 			_(action_for),
 			frappe.bold(args.account),
-			args.budget_against_field,
+			frappe.unscrub(args.budget_against_field),
 			frappe.bold(budget_against),
 			frappe.bold(fmt_money(budget_amount, currency=currency)),
+			error_tense,
 			frappe.bold(fmt_money(diff, currency=currency)),
 		)
 
@@ -227,9 +232,9 @@ def compare_expense_with_budget(args, budget_amount, action_for, action, budget_
 			action = "Warn"
 
 		if action == "Stop":
-			frappe.throw(msg, BudgetError)
+			frappe.throw(msg, BudgetError, title=_("Budget Exceeded"))
 		else:
-			frappe.msgprint(msg, indicator="orange")
+			frappe.msgprint(msg, indicator="orange", title=_("Budget Exceeded"))
 
 
 def get_actions(args, budget):
@@ -351,7 +356,9 @@ def get_actual_expense(args):
 			"""
 		select sum(gle.debit) - sum(gle.credit)
 		from `tabGL Entry` gle
-		where gle.account=%(account)s
+		where
+			is_cancelled = 0
+			and gle.account=%(account)s
 			{condition1}
 			and gle.fiscal_year=%(fiscal_year)s
 			and gle.company=%(company)s

--- a/erpnext/controllers/status_updater.py
+++ b/erpnext/controllers/status_updater.py
@@ -226,7 +226,8 @@ class StatusUpdater(Document):
 				continue
 
 			# get unique transactions to update
-			for d in self.get_all_children():
+			children = self.get_all_children()
+			for d in children:
 				if hasattr(d, "qty") and d.qty < 0 and not self.get("is_return"):
 					frappe.throw(_("For an item {0}, quantity must be positive number").format(d.item_code))
 

--- a/erpnext/controllers/status_updater.py
+++ b/erpnext/controllers/status_updater.py
@@ -226,8 +226,7 @@ class StatusUpdater(Document):
 				continue
 
 			# get unique transactions to update
-			children = self.get_all_children()
-			for d in children:
+			for d in self.get_all_children():
 				if hasattr(d, "qty") and d.qty < 0 and not self.get("is_return"):
 					frappe.throw(_("For an item {0}, quantity must be positive number").format(d.item_code))
 


### PR DESCRIPTION
There are scenarios where the budget validation can be a bit deceiving.

The budget actions like "Ignore", "Warn" and "Stop" can be updated even after submitting the budget record.
Many times user updates the budget action as "Ignore" and then exceeds the yearly budget and then again updates the action as "Stop"

In such cases, the Monthly accumulated budget validation is a bit confusing to the users, first yearly budget should be checked in each case.

Made some other minor fixes in the message as well