### PR TITLE
fix(ecommerce): breadcrumb: fallback to `/all-products`

### DIFF
--- a/erpnext/e_commerce/doctype/website_item/test_website_item.py
+++ b/erpnext/e_commerce/doctype/website_item/test_website_item.py
@@ -174,7 +174,10 @@ class TestWebsiteItem(unittest.TestCase):
 	# Website Item Portal Tests Begin
 
 	def test_website_item_breadcrumbs(self):
-		"Check if breadcrumbs include homepage, product listing navigation page, parent item group(s) and item group."
+		"""
+		Check if breadcrumbs include homepage, product listing navigation page,
+		parent item group(s) and item group
+		"""
 		from erpnext.setup.doctype.item_group.item_group import get_parent_item_groups
 
 		item_code = "Test Breadcrumb Item"
@@ -197,7 +200,7 @@ class TestWebsiteItem(unittest.TestCase):
 		breadcrumbs = get_parent_item_groups(item.item_group)
 
 		self.assertEqual(breadcrumbs[0]["name"], "Home")
-		self.assertEqual(breadcrumbs[1]["name"], "Shop by Category")
+		self.assertEqual(breadcrumbs[1]["name"], "All Products")
 		self.assertEqual(breadcrumbs[2]["name"], "_Test Item Group B")  # parent item group
 		self.assertEqual(breadcrumbs[3]["name"], "_Test Item Group B - 1")
 

--- a/erpnext/setup/doctype/item_group/item_group.py
+++ b/erpnext/setup/doctype/item_group/item_group.py
@@ -148,12 +148,12 @@ def get_item_for_list_in_html(context):
 
 
 def get_parent_item_groups(item_group_name, from_item=False):
-	base_nav_page = {"name": _("Shop by Category"), "route": "/shop-by-category"}
+	base_nav_page = {"name": _("All Products"), "route": "/all-products"}
 
 	if from_item and frappe.request.environ.get("HTTP_REFERER"):
 		# base page after 'Home' will vary on Item page
 		last_page = frappe.request.environ["HTTP_REFERER"].split("/")[-1].split("?")[0]
-		if last_page and last_page in ("shop-by-category", "all-products"):
+		if last_page and last_page is "shop-by-category":
 			base_nav_page_title = " ".join(last_page.split("-")).title()
 			base_nav_page = {"name": _(base_nav_page_title), "route": "/" + last_page}
 

--- a/erpnext/setup/doctype/item_group/item_group.py
+++ b/erpnext/setup/doctype/item_group/item_group.py
@@ -153,7 +153,7 @@ def get_parent_item_groups(item_group_name, from_item=False):
 	if from_item and frappe.request.environ.get("HTTP_REFERER"):
 		# base page after 'Home' will vary on Item page
 		last_page = frappe.request.environ["HTTP_REFERER"].split("/")[-1].split("?")[0]
-		if last_page and last_page is "shop-by-category":
+		if last_page and last_page == "shop-by-category":
 			base_nav_page_title = " ".join(last_page.split("-")).title()
 			base_nav_page = {"name": _(base_nav_page_title), "route": "/" + last_page}
 


### PR DESCRIPTION
We can show either `All Products` or `Shop By Category` in breadcrumbs. This logic
- Check if there is an HTTP referrer
- If there is a referrer (if it comes from either `All Products` or `Shop By Category` page), then breadcrumb item is set to previous page
- If there is no referrer, a fallback item is set

Issue: `Shop By Category` is the fallback, when `All Products` is almost always the preferred setting

Fix: Change fallback to `All Products`