### PR TITLE
fix: use stock qty to calculate POS reserved stock

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -675,7 +675,7 @@ def get_bin_qty(item_code, warehouse):
 
 def get_pos_reserved_qty(item_code, warehouse):
 	reserved_qty = frappe.db.sql(
-		"""select sum(p_item.qty) as qty
+		"""select sum(p_item.stock_qty) as qty
 		from `tabPOS Invoice` p, `tabPOS Invoice Item` p_item
 		where p.name = p_item.parent
 		and ifnull(p.consolidated_invoice, '') = ''


### PR DESCRIPTION
Use `stock_qty` when calculating POS reserved stock. Currently it uses the `qty` field which doesn't represent UOM's conversion factor, making the available stock incorrect.
