### PR TITLE
fix: calculate correct amount for qty == 0

### DIFF
--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -122,24 +122,16 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 	calculate_item_values() {
 		var me = this;
 		if (!this.discount_amount_applied) {
-			$.each(this.frm.doc["items"] || [], function(i, item) {
+			for (item of this.frm.doc.items || []) {
 				frappe.model.round_floats_in(item);
 				item.net_rate = item.rate;
-
-				if ((!item.qty) && me.frm.doc.is_return) {
-					item.amount = flt(item.rate * -1, precision("amount", item));
-				} else if ((!item.qty) && me.frm.doc.is_debit_note) {
-					item.amount = flt(item.rate, precision("amount", item));
-				} else {
-					item.amount = flt(item.rate * item.qty, precision("amount", item));
-				}
-
-				item.net_amount = item.amount;
+				item.qty = item.qty === undefined ? (me.frm.doc.is_return ? -1 : 1) : item.qty;
+				item.net_amount = item.amount = flt(item.rate * item.qty, precision("amount", item));
 				item.item_tax_amount = 0.0;
 				item.total_weight = flt(item.weight_per_unit * item.stock_qty);
 
 				me.set_in_company_currency(item, ["price_list_rate", "rate", "amount", "net_rate", "net_amount"]);
-			});
+			}
 		}
 	}
 


### PR DESCRIPTION
When entering `0` as line item quantity, the calculated amount was not correct. The code checked for `!item.qty`, which is `true` when `item.qty == 0`, and in this case used `1` (or `-1` for returns) as the qty instead, resulting in an incorrect amount.

Before:

```python
qty = 0
rate = 10
amount = (qty or 1) * rate  # == 10
```

After:

```python
qty = 0
rate = 10
amount = (1 if qty is None else qty) * rate  # == 0
```

Fixed in JS by checking for `item.qty === undefined`.

Also used the opportunity to replace the jQuery `$.each` with a `for .. of` loop.

Internal reference: LAN-714