### PR TITLE
chore: bump python version for docs-checker

### DIFF
--- a/.github/workflows/docs-checker.yml
+++ b/.github/workflows/docs-checker.yml
@@ -12,7 +12,7 @@ jobs:
       - name: 'Setup Environment'
         uses: actions/setup-python@v2
         with:
-          python-version: 3.6
+          python-version: '3.10'
 
       - name: 'Clone repo'
         uses: actions/checkout@v2


### PR DESCRIPTION
[This](https://github.com/frappe/erpnext/actions/runs/3968637674/jobs/6802060753) and [that](https://github.com/frappe/erpnext/actions/runs/3968412761/jobs/6801547803) run failed with:

```
Version 3.6 was not found in the local cache
Error: Version 3.6 with arch x64 not found
```

Partial backport of https://github.com/frappe/erpnext/commit/57d08b7cdf13f7c2c48098d3eb91004913d04f3e

This is only an independent CI script, so a higher python version doesn't hurt here.