### PR TITLE
feat: get items from Transit Stock Entry

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -169,6 +169,8 @@ frappe.ui.form.on('Stock Entry', {
 	},
 
 	refresh: function(frm) {
+		frm.trigger("get_items_from_transit_entry");
+
 		if(!frm.doc.docstatus) {
 			frm.trigger('validate_purpose_consumption');
 			frm.add_custom_button(__('Material Request'), function() {
@@ -334,6 +336,28 @@ frappe.ui.form.on('Stock Entry', {
 
 		if(!check_should_not_attach_bom_items(frm.doc.bom_no)) {
 			erpnext.accounts.dimensions.update_dimension(frm, frm.doctype);
+		}
+	},
+
+	get_items_from_transit_entry: function(frm) {
+		if (frm.doc.docstatus===0) {
+			frm.add_custom_button(__('Transit Entry'), function() {
+				erpnext.utils.map_current_doc({
+					method: "erpnext.stock.doctype.stock_entry.stock_entry.make_stock_in_entry",
+					source_doctype: "Stock Entry",
+					target: frm,
+					date_field: "posting_date",
+					setters: {
+						stock_entry_type: "Material Transfer",
+						purpose: "Material Transfer",
+					},
+					get_query_filters: {
+						docstatus: 1,
+						purpose: "Material Transfer",
+						add_to_transit: 1,
+					}
+				})
+			}, __("Get Items From"));
 		}
 	},
 

--- a/erpnext/stock/doctype/stock_entry/stock_entry_utils.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry_utils.py
@@ -117,6 +117,7 @@ def make_stock_entry(**args):
 			args.item = "_Test Item"
 
 	s.company = args.company or erpnext.get_default_company()
+	s.add_to_transit = args.add_to_transit or 0
 	s.purchase_receipt_no = args.purchase_receipt_no
 	s.delivery_note_no = args.delivery_note_no
 	s.sales_invoice_no = args.sales_invoice_no

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -17,6 +17,7 @@ from erpnext.stock.doctype.item.test_item import (
 from erpnext.stock.doctype.serial_no.serial_no import *  # noqa
 from erpnext.stock.doctype.stock_entry.stock_entry import (
 	FinishedGoodError,
+	make_stock_in_entry,
 	move_sample_to_retention_warehouse,
 )
 from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
@@ -159,6 +160,53 @@ class TestStockEntry(FrappeTestCase):
 				items.append(d.item_code)
 
 		self.assertTrue(item_code in items)
+
+	def test_add_to_transit_entry(self):
+		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+
+		item_code = "_Test Transit Item"
+		company = "_Test Company"
+
+		create_warehouse("Test From Warehouse")
+		create_warehouse("Test Transit Warehouse")
+		create_warehouse("Test To Warehouse")
+
+		create_item(
+			item_code=item_code,
+			is_stock_item=1,
+			is_purchase_item=1,
+			company=company,
+		)
+
+		# create inward stock entry
+		make_stock_entry(
+			item_code=item_code,
+			target="Test From Warehouse - _TC",
+			qty=10,
+			basic_rate=100,
+			expense_account="Stock Adjustment - _TC",
+			cost_center="Main - _TC",
+		)
+
+		transit_entry = make_stock_entry(
+			item_code=item_code,
+			source="Test From Warehouse - _TC",
+			target="Test Transit Warehouse - _TC",
+			add_to_transit=1,
+			stock_entry_type="Material Transfer",
+			purpose="Material Transfer",
+			qty=10,
+			basic_rate=100,
+			expense_account="Stock Adjustment - _TC",
+			cost_center="Main - _TC",
+		)
+
+		end_transit_entry = make_stock_in_entry(transit_entry.name)
+		self.assertEqual(transit_entry.name, end_transit_entry.outgoing_stock_entry)
+		self.assertEqual(transit_entry.name, end_transit_entry.items[0].against_stock_entry)
+		self.assertEqual(transit_entry.items[0].name, end_transit_entry.items[0].ste_detail)
+
+		# create add to transit
 
 	def test_material_receipt_gl_entry(self):
 		company = frappe.db.get_value("Warehouse", "Stores - TCP1", "company")


### PR DESCRIPTION
Added provision to get Items from Transit Stock Entry

<img width="1317" alt="Screenshot 2023-01-23 at 12 05 16 PM" src="https://user-images.githubusercontent.com/8780500/213978884-f881608b-4ba3-4570-9dee-67d43a0e346e.png">

#docs https://docs.erpnext.com/stock-entry#4-add-to-transit