### PR TITLE
fix: web supplier quotation

### DIFF
--- a/erpnext/templates/pages/order.py
+++ b/erpnext/templates/pages/order.py
@@ -38,22 +38,27 @@ def get_context(context):
 	if not frappe.has_website_permission(context.doc):
 		frappe.throw(_("Not Permitted"), frappe.PermissionError)
 
-	# check for the loyalty program of the customer
-	customer_loyalty_program = frappe.db.get_value(
-		"Customer", context.doc.customer, "loyalty_program"
-	)
-	if customer_loyalty_program:
-		from erpnext.accounts.doctype.loyalty_program.loyalty_program import (
-			get_loyalty_program_details_with_points,
+	context.available_loyalty_points = 0.0
+	if context.doc.get("customer"):
+		# check for the loyalty program of the customer
+		customer_loyalty_program = frappe.db.get_value(
+			"Customer", context.doc.customer, "loyalty_program"
 		)
 
-		loyalty_program_details = get_loyalty_program_details_with_points(
-			context.doc.customer, customer_loyalty_program
-		)
-		context.available_loyalty_points = int(loyalty_program_details.get("loyalty_points"))
+		if customer_loyalty_program:
+			from erpnext.accounts.doctype.loyalty_program.loyalty_program import (
+				get_loyalty_program_details_with_points,
+			)
 
-	# show Make Purchase Invoice button based on permission
-	context.show_make_pi_button = frappe.has_permission("Purchase Invoice", "create")
+			loyalty_program_details = get_loyalty_program_details_with_points(
+				context.doc.customer, customer_loyalty_program
+			)
+			context.available_loyalty_points = int(loyalty_program_details.get("loyalty_points"))
+
+	context.show_make_pi_button = False
+	if context.doc.get("supplier"):
+		# show Make Purchase Invoice button based on permission
+		context.show_make_pi_button = frappe.has_permission("Purchase Invoice", "create")
 
 
 def get_attachments(dt, dn):


### PR DESCRIPTION
While creating supplier quotation from RFQ getting below error

```
  File "apps/frappe/frappe/website/page_renderers/template_page.py", line 89, in get_html
    self.update_context()
  File "apps/frappe/frappe/website/page_renderers/template_page.py", line 157, in update_context
    data = self.run_pymodule_method("get_context")
  File "apps/frappe/frappe/website/page_renderers/template_page.py", line 219, in run_pymodule_method
    return method(self.context)
  File "apps/erpnext/erpnext/templates/pages/order.py", line 43, in get_context
    "Customer", context.doc.customer, "loyalty_program"
AttributeError: 'SupplierQuotation' object has no attribute 'customer'
```