### PR TITLE
fix: GST Category validation broken for pos unregistered customer who dont have address.

### DIFF
--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -211,7 +211,13 @@ def set_address_details(
 	else:
 		party_details.update(get_company_address(company))
 
-	if doctype and doctype in ["Delivery Note", "Sales Invoice", "Sales Order", "Quotation", "POS Invoice"]:
+	if doctype and doctype in [
+		"Delivery Note",
+		"Sales Invoice",
+		"Sales Order",
+		"Quotation",
+		"POS Invoice",
+	]:
 		if party_details.company_address:
 			party_details.update(
 				get_fetch_values(doctype, "company_address", party_details.company_address)

--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -211,7 +211,7 @@ def set_address_details(
 	else:
 		party_details.update(get_company_address(company))
 
-	if doctype and doctype in ["Delivery Note", "Sales Invoice", "Sales Order", "Quotation"]:
+	if doctype and doctype in ["Delivery Note", "Sales Invoice", "Sales Order", "Quotation", "POS Invoice"]:
 		if party_details.company_address:
 			party_details.update(
 				get_fetch_values(doctype, "company_address", party_details.company_address)


### PR DESCRIPTION
problem: Using Point of Sale for POS customer whose address is not available then it should fetch that details from party. 
IN case of POS their multiple customer whose address is not necessary above change will able to generated POS Invoice for unregistered customer. 

Before:

https://user-images.githubusercontent.com/6947417/214242318-8a32cc52-9a65-453c-8275-cb69cf23cc03.mp4



after:

https://user-images.githubusercontent.com/6947417/214241207-ce08bda7-3812-4af0-a913-1b54ff992a7d.mp4

