### PR TITLE
fix: make title field readonly

### DIFF
--- a/erpnext/crm/doctype/lead/lead.json
+++ b/erpnext/crm/doctype/lead/lead.json
@@ -312,7 +312,8 @@
    "fieldtype": "Data",
    "hidden": 1,
    "label": "Title",
-   "print_hide": 1
+   "print_hide": 1,
+   "read_only": 1
   },
   {
    "fieldname": "language",
@@ -514,11 +515,10 @@
  "idx": 5,
  "image_field": "image",
  "links": [],
- "modified": "2022-10-13 12:42:04.277879",
+ "modified": "2023-01-24 18:20:05.044791",
  "modified_by": "Administrator",
  "module": "CRM",
  "name": "Lead",
- "name_case": "Title Case",
  "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
  "permissions": [


### PR DESCRIPTION
closes: https://github.com/frappe/erpnext/issues/33806#issuecomment-1402804212

Make the title field read_only so when the user clicks the title, the rename dialog won't appear.