### PR TITLE
fix: use correct filter name in reports

### DIFF
--- a/erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.js
+++ b/erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.js
@@ -39,7 +39,7 @@ frappe.query_reports["Supplier Quotation Comparison"] = {
 					return {
 						query: "erpnext.stock.doctype.quality_inspection.quality_inspection.item_query",
 						filters: {
-							"from": "Supplier Quotation Item",
+							"doctype": "Supplier Quotation Item",
 							"parent": quote
 						}
 					}

--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.js
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.js
@@ -36,7 +36,7 @@ frappe.ui.form.on("Quality Inspection", {
 
 			if (doc.reference_type && doc.reference_name) {
 				let filters = {
-					"from": doctype,
+					"doctype": doctype,
 					"inspection_type": doc.inspection_type
 				};
 


### PR DESCRIPTION
Closes #33565

Fix issue introduced in #33004
