### PR TITLE
fix: use correct filter name in `item_query`

### DIFF
--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.py
@@ -221,7 +221,7 @@ class QualityInspection(Document):
 def item_query(doctype, txt, searchfield, start, page_len, filters):
 	from frappe.desk.reportview import get_match_cond
 
-	from_doctype = cstr(filters.get("doctype"))
+	from_doctype = cstr(filters.get("from"))
 	if not from_doctype or not frappe.db.exists("DocType", from_doctype):
 		return []
 


### PR DESCRIPTION
Closes #33565

Fix issue introduced in #33004