### PR TITLE
perf: Timeout while doing payment reconciliation (v13)

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -1255,6 +1255,7 @@ def get_outstanding_reference_documents(args):
 		args.get("party_type"),
 		args.get("party"),
 		args.get("party_account"),
+		args.get("company"),
 		filters=args,
 		condition=condition,
 	)

--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
@@ -211,7 +211,7 @@ class PaymentReconciliation(Document):
 			condition += " and cost_center = '{0}' ".format(self.cost_center)
 
 		non_reconciled_invoices = get_outstanding_invoices(
-			self.party_type, self.party, self.receivable_payable_account, condition=condition
+			self.party_type, self.party, self.receivable_payable_account, self.company, condition=condition
 		)
 
 		if self.invoice_limit:


### PR DESCRIPTION
The payment entry was taking a lot of time to execute as it was checking all the records.
That was unnecessary as the amounts only against the fetched invoices were checked, so only fetched records against the outstanding invoices