### PR TITLE
fix: enable customs in Selling Workpace by default

### DIFF
--- a/erpnext/selling/workspace/selling/selling.json
+++ b/erpnext/selling/workspace/selling/selling.json
@@ -13,7 +13,7 @@
  "docstatus": 0,
  "doctype": "Workspace",
  "extends_another_page": 0,
- "hide_custom": 1,
+ "hide_custom": 0,
  "icon": "sell",
  "idx": 0,
  "is_standard": 1,


### PR DESCRIPTION
Like in all other version (version-14 and develop), and like all other defualt Workspace, there is no reason the hide custom doctype and custom report by default in this workspace