### PR TITLE
perf: show update items dialog

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -491,7 +491,20 @@ erpnext.utils.update_child_items = function(opts) {
 	const child_meta = frappe.get_meta(`${frm.doc.doctype} Item`);
 	const get_precision = (fieldname) => child_meta.fields.find(f => f.fieldname == fieldname).precision;
 
-	this.data = [];
+	this.data = frm.doc[opts.child_docname].map((d) => {
+		return {
+			"docname": d.name,
+			"name": d.name,
+			"item_code": d.item_code,
+			"delivery_date": d.delivery_date,
+			"schedule_date": d.schedule_date,
+			"conversion_factor": d.conversion_factor,
+			"qty": d.qty,
+			"rate": d.rate,
+			"uom": d.uom
+		}
+	});
+
 	const fields = [{
 		fieldtype:'Data',
 		fieldname:"docname",
@@ -588,7 +601,7 @@ erpnext.utils.update_child_items = function(opts) {
 		})
 	}
 
-	const dialog = new frappe.ui.Dialog({
+	new frappe.ui.Dialog({
 		title: __("Update Items"),
 		fields: [
 			{
@@ -624,24 +637,7 @@ erpnext.utils.update_child_items = function(opts) {
 			refresh_field("items");
 		},
 		primary_action_label: __('Update')
-	});
-
-	frm.doc[opts.child_docname].forEach(d => {
-		dialog.fields_dict.trans_items.df.data.push({
-			"docname": d.name,
-			"name": d.name,
-			"item_code": d.item_code,
-			"delivery_date": d.delivery_date,
-			"schedule_date": d.schedule_date,
-			"conversion_factor": d.conversion_factor,
-			"qty": d.qty,
-			"rate": d.rate,
-			"uom": d.uom
-		});
-		this.data = dialog.fields_dict.trans_items.df.data;
-		dialog.fields_dict.trans_items.grid.refresh();
-	})
-	dialog.show();
+	}).show();
 }
 
 erpnext.utils.map_current_doc = function(opts) {


### PR DESCRIPTION
Increase performance of opening Update Items dialog by around 10sec.

Number of rows: 257

### Before PR:
![before_pr_1](https://user-images.githubusercontent.com/29856401/214960185-314da4fc-a6f2-4fb6-9872-2c75eb7a64c3.gif)


### After PR:
![before_pr](https://user-images.githubusercontent.com/29856401/214960219-1bbede7f-eda3-41c7-9ea5-10b004467a4e.gif)
