### PR TITLE
fix: double salutation on quotation print

### DIFF
--- a/erpnext/crm/doctype/lead/lead.py
+++ b/erpnext/crm/doctype/lead/lead.py
@@ -390,7 +390,7 @@ def get_lead_details(lead, posting_date=None, company=None):
 		{
 			"territory": lead.territory,
 			"customer_name": lead.company_name or lead.lead_name,
-			"contact_display": " ".join(filter(None, [lead.salutation, lead.lead_name])),
+			"contact_display": " ".join(filter(None, [lead.lead_name])),
 			"contact_email": lead.email_id,
 			"contact_mobile": lead.mobile_no,
 			"contact_phone": lead.phone,


### PR DESCRIPTION
`lead_name` always has salutation. So, ignoring salutation on `get_lead_details()` function.
<img width="413" alt="Screenshot 2023-01-27 at 9 59 58 AM" src="https://user-images.githubusercontent.com/3272205/215010374-e94c7233-2c21-4f08-9e08-3219421dc236.png">
