### PR TITLE
fix(patch): validation error on cost center allocation migration

### DIFF
--- a/erpnext/accounts/doctype/cost_center_allocation/cost_center_allocation.py
+++ b/erpnext/accounts/doctype/cost_center_allocation/cost_center_allocation.py
@@ -28,9 +28,14 @@ class InvalidDateError(frappe.ValidationError):
 
 
 class CostCenterAllocation(Document):
+	def __init__(self, *args, **kwargs):
+		super(CostCenterAllocation, self).__init__(*args, **kwargs)
+		self._skip_from_date_validation = False
+
 	def validate(self):
 		self.validate_total_allocation_percentage()
-		self.validate_from_date_based_on_existing_gle()
+		if not self._skip_from_date_validation:
+			self.validate_from_date_based_on_existing_gle()
 		self.validate_backdated_allocation()
 		self.validate_main_cost_center()
 		self.validate_child_cost_centers()

--- a/erpnext/patches/v14_0/migrate_cost_center_allocations.py
+++ b/erpnext/patches/v14_0/migrate_cost_center_allocations.py
@@ -18,9 +18,11 @@ def create_new_cost_center_allocation_records(cc_allocations):
 		cca = frappe.new_doc("Cost Center Allocation")
 		cca.main_cost_center = main_cc
 		cca.valid_from = today()
+		cca._skip_from_date_validation = True
 
 		for child_cc, percentage in allocations.items():
 			cca.append("allocation_percentages", ({"cost_center": child_cc, "percentage": percentage}))
+
 		cca.save()
 		cca.submit()
 


### PR DESCRIPTION
If Distributed cost centers have GL postings on patch run date, patch fails with validation error.
Skip `from_date` validation during patch run.

<img width="1021" alt="validation_error" src="https://user-images.githubusercontent.com/3272205/215025348-288c7acd-8f39-427a-822e-763229e93328.png">

