### PR TITLE
fix: Delivery note reference updated in Sales Invoice connection

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice_dashboard.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice_dashboard.py
@@ -16,6 +16,7 @@ def get_data():
 		"internal_links": {
 			"Sales Order": ["items", "sales_order"],
 			"Timesheet": ["timesheets", "time_sheet"],
+			"Delivery Note": ["items", "delivery_note"],
 		},
 		"transactions": [
 			{


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/6947417/215056368-d6426781-10e0-4e65-8c8c-07e1b9f29504.png)


after:
![image](https://user-images.githubusercontent.com/6947417/215056420-29782b37-2657-45e7-a8ff-552b791cec42.png)
