### PR TITLE
fix: item rate not fetching

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1690,6 +1690,10 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		var me = this;
 		var valid = true;
 
+		if (frappe.flags.ignore_company_party_validation) {
+			return valid;
+		}
+
 		$.each(["company", "customer"], function(i, fieldname) {
 			if(frappe.meta.has_field(me.frm.doc.doctype, fieldname) &&  !["Purchase Order","Purchase Invoice"].includes(me.frm.doc.doctype)) {
 				if (!me.frm.doc[fieldname]) {

--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -894,6 +894,12 @@ function open_form(frm, doctype, child_doctype, parentfield) {
 		new_child_doc.uom = frm.doc.stock_uom;
 		new_child_doc.description = frm.doc.description;
 
-		frappe.ui.form.make_quick_entry(doctype, null, null, new_doc);
+		frappe.run_serially([
+			() => frappe.ui.form.make_quick_entry(doctype, null, null, new_doc),
+			() => {
+				frappe.flags.ignore_company_party_validation = true;
+				frappe.model.trigger("item_code", frm.doc.name, new_child_doc);
+			}
+		])
 	});
 }


### PR DESCRIPTION
### Issue

When user creates a new Purchase Order directly from ITEM connection section by pressing in connect for Purchase Order +, the price is not fetched. and if the same item entered manually in the Purchase Order System Fetches the Rate in the Purchase Order.

![before_fix_the_issue](https://user-images.githubusercontent.com/8780500/215255609-32eed732-5e6c-4d50-bdbd-264cfd6a507c.gif)



### **Rate Fetched after Fix**
![after_fix_the_issue](https://user-images.githubusercontent.com/8780500/215255542-71f156f4-d91b-4164-8339-2531ea9fa4f0.gif)
