### PR TITLE
    perf(stock_balance): Use iterator for querying SLE

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -8,8 +8,8 @@ sudo apt update && sudo apt install redis-server libcups2-dev
 
 pip install frappe-bench
 
-frappeuser=${FRAPPE_USER:-"frappe"}
-frappebranch=${FRAPPE_BRANCH:-${GITHUB_BASE_REF:-${GITHUB_REF##*/}}}
+frappeuser="ankush"
+frappebranch="sql_iter"
 
 git clone "https://github.com/${frappeuser}/frappe" --branch "${frappebranch}" --depth 1
 bench init --skip-assets --frappe-path ~/frappe --python "$(which python)" frappe-bench

--- a/erpnext/stock/report/stock_balance/test_stock_balance.py
+++ b/erpnext/stock/report/stock_balance/test_stock_balance.py
@@ -172,3 +172,5 @@ class TestStockBalance(FrappeTestCase):
 		)
 		self.assertPartialDictEq(attributes, rows[0])
 		self.assertInvariants(rows)
+
+	# TODO: tests that check for iterator behaviours


### PR DESCRIPTION
- Use iterator instead of reading all SLEs at once.
- Near constant memory usage even for reading large # of SLEs. Memory usage is roughly `O(# of unique item-warehouse combinations)` instead of `O(# of SLEs)`


Depends on https://github.com/frappe/frappe/pull/19810 but backward compatible without it too.
