### PR TITLE
fix: Fetch commission rate from sales partner

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
@@ -1776,6 +1776,8 @@
    "width": "50%"
   },
   {
+   "fetch_from": "sales_partner.commission_rate",
+   "fetch_if_empty": 1,
    "fieldname": "commission_rate",
    "fieldtype": "Float",
    "hide_days": 1,
@@ -2141,7 +2143,7 @@
    "link_fieldname": "consolidated_invoice"
   }
  ],
- "modified": "2022-12-12 18:34:33.409895",
+ "modified": "2023-01-28 19:45:47.538163",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice",


### PR DESCRIPTION
Sales Partner has a commission field that doesn't get fetched in the Sales Invoice right now and the user has to add them manually.
Added a fetch from condition to fetch the commission rate from the Sales Partner