### PR TITLE
fix: Ignore linked JE on JE cancellation

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.js
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.js
@@ -8,7 +8,7 @@ frappe.provide("erpnext.journal_entry");
 frappe.ui.form.on("Journal Entry", {
 	setup: function(frm) {
 		frm.add_fetch("bank_account", "account", "account");
-		frm.ignore_doctypes_on_cancel_all = ['Sales Invoice', 'Purchase Invoice'];
+		frm.ignore_doctypes_on_cancel_all = ['Sales Invoice', 'Purchase Invoice', 'Journal Entry'];
 	},
 
 	refresh: function(frm) {


### PR DESCRIPTION
<img width="642" alt="image" src="https://user-images.githubusercontent.com/42651287/215272914-ddc87a72-ff61-480a-bfe2-d21968fb3b7f.png">

Ignore and just unlike the reconciled Journal Entry on canceling