### PR TITLE
fix: enable customs in Selling Workpace by default

### DIFF
--- a/erpnext/selling/workspace/selling/selling.json
+++ b/erpnext/selling/workspace/selling/selling.json
@@ -13,7 +13,7 @@
  "docstatus": 0,
  "doctype": "Workspace",
  "extends_another_page": 0,
- "hide_custom": 1,
+ "hide_custom": 0,
  "icon": "sell",
  "idx": 0,
  "is_standard": 1,

--- a/erpnext/selling/workspace/selling/selling.json
+++ b/erpnext/selling/workspace/selling/selling.json
@@ -16,6 +16,7 @@
  "hide_custom": 0,
  "icon": "sell",
  "idx": 0,
+ "is_default": 0,
  "is_standard": 1,
  "label": "Selling",
  "links": [
@@ -515,7 +516,7 @@
    "type": "Link"
   }
  ],
- "modified": "2020-12-01 13:38:35.971277",
+ "modified": "2023-01-28 17:10:02.716760",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Selling",


### PR DESCRIPTION
Like in all other version (version-14 and develop), and like all other default Workspace, there is no reason the hide custom doctype and custom report by default in this workspace

review from #33822 