### PR TITLE
fix: increase the width of Posting Date Column on General Ledger Report

### DIFF
--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -526,7 +526,7 @@ def get_columns(filters):
 			"options": "GL Entry",
 			"hidden": 1,
 		},
-		{"label": _("Posting Date"), "fieldname": "posting_date", "fieldtype": "Date", "width": 90},
+		{"label": _("Posting Date"), "fieldname": "posting_date", "fieldtype": "Date", "width": 120},
 		{
 			"label": _("Account"),
 			"fieldname": "account",


### PR DESCRIPTION
Despite the posting date on General Ledger Report dont render collapsed, the column name no render properly.  In this change incremented the width of column to 120. And it avoid to extend the width manually to see the column name. 

Before 
![image](https://user-images.githubusercontent.com/67304498/215554047-a92996cb-01d3-4660-8643-3fbd186a08ee.png)

Then
![image](https://user-images.githubusercontent.com/67304498/215552051-2ad4254f-d8e1-48c0-b522-d8504348ca5c.png)



