### PR TITLE
fix: manual depr entry not updating asset value [v13]

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -87,6 +87,7 @@ class JournalEntry(AccountsController):
 		self.check_credit_limit()
 		self.make_gl_entries()
 		self.update_advance_paid()
+		self.update_asset_value()
 		self.update_expense_claim()
 		self.update_inter_company_jv()
 		self.update_invoice_discounting()
@@ -235,6 +236,34 @@ class JournalEntry(AccountsController):
 		for d in to_remove:
 			self.remove(d)
 
+	def update_asset_value(self):
+		if self.voucher_type != "Depreciation Entry":
+			return
+
+		processed_assets = []
+
+		for d in self.get("accounts"):
+			if (
+				d.reference_type == "Asset" and d.reference_name and d.reference_name not in processed_assets
+			):
+				processed_assets.append(d.reference_name)
+
+				asset = frappe.db.get_value(
+					"Asset", d.reference_name, ["calculate_depreciation", "value_after_depreciation"], as_dict=1
+				)
+
+				if asset.calculate_depreciation:
+					continue
+
+				depr_value = d.debit or d.credit
+
+				frappe.db.set_value(
+					"Asset",
+					d.reference_name,
+					"value_after_depreciation",
+					asset.value_after_depreciation - depr_value,
+				)
+
 	def update_inter_company_jv(self):
 		if (
 			self.voucher_type == "Inter Company Journal Entry"
@@ -293,19 +322,39 @@ class JournalEntry(AccountsController):
 				d.db_update()
 
 	def unlink_asset_reference(self):
+		if self.voucher_type != "Depreciation Entry":
+			return
+
+		processed_assets = []
+
 		for d in self.get("accounts"):
-			if d.reference_type == "Asset" and d.reference_name:
+			if (
+				d.reference_type == "Asset" and d.reference_name and d.reference_name not in processed_assets
+			):
+				processed_assets.append(d.reference_name)
+
 				asset = frappe.get_doc("Asset", d.reference_name)
-				for s in asset.get("schedules"):
-					if s.journal_entry == self.name:
-						s.db_set("journal_entry", None)
 
-						idx = cint(s.finance_book_id) or 1
-						finance_books = asset.get("finance_books")[idx - 1]
-						finance_books.value_after_depreciation += s.depreciation_amount
-						finance_books.db_update()
+				if asset.calculate_depreciation:
+					for s in asset.get("schedules"):
+						if s.journal_entry == self.name:
+							s.db_set("journal_entry", None)
 
-						asset.set_status()
+							idx = cint(s.finance_book_id) or 1
+							finance_books = asset.get("finance_books")[idx - 1]
+							finance_books.value_after_depreciation += s.depreciation_amount
+							finance_books.db_update()
+
+							asset.set_status()
+				else:
+					depr_value = d.debit or d.credit
+
+					frappe.db.set_value(
+						"Asset",
+						d.reference_name,
+						"value_after_depreciation",
+						asset.value_after_depreciation + depr_value,
+					)
 
 	def unlink_inter_company_jv(self):
 		if (

--- a/erpnext/assets/doctype/asset/asset.json
+++ b/erpnext/assets/doctype/asset/asset.json
@@ -504,9 +504,15 @@
    "group": "Value",
    "link_doctype": "Asset Value Adjustment",
    "link_fieldname": "asset"
+  },
+  {
+   "group": "Journal Entry",
+   "link_doctype": "Journal Entry",
+   "link_fieldname": "reference_name",
+   "table_fieldname": "accounts"
   }
  ],
- "modified": "2023-01-17 00:28:37.789345",
+ "modified": "2023-01-31 01:03:09.467817",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset",

--- a/erpnext/assets/doctype/asset/depreciation.py
+++ b/erpnext/assets/doctype/asset/depreciation.py
@@ -469,18 +469,8 @@ def get_asset_details(asset, finance_book=None):
 	disposal_account, depreciation_cost_center = get_disposal_account_and_cost_center(asset.company)
 	depreciation_cost_center = asset.cost_center or depreciation_cost_center
 
-	idx = 1
-	if finance_book:
-		for d in asset.finance_books:
-			if d.finance_book == finance_book:
-				idx = d.idx
-				break
+	value_after_depreciation = asset.get_value_after_depreciation(finance_book)
 
-	value_after_depreciation = (
-		asset.finance_books[idx - 1].value_after_depreciation
-		if asset.calculate_depreciation
-		else asset.value_after_depreciation
-	)
 	accumulated_depr_amount = flt(asset.gross_purchase_amount) - flt(value_after_depreciation)
 
 	return (

--- a/erpnext/assets/doctype/asset_repair/test_asset_repair.py
+++ b/erpnext/assets/doctype/asset_repair/test_asset_repair.py
@@ -6,6 +6,7 @@ import unittest
 import frappe
 from frappe.utils import flt, nowdate
 
+from erpnext.assets.doctype.asset.asset import get_asset_value_after_depreciation
 from erpnext.assets.doctype.asset.test_asset import (
 	create_asset,
 	create_asset_data,
@@ -105,20 +106,20 @@ class TestAssetRepair(unittest.TestCase):
 
 	def test_increase_in_asset_value_due_to_stock_consumption(self):
 		asset = create_asset(calculate_depreciation=1, submit=1)
-		initial_asset_value = get_asset_value(asset)
+		initial_asset_value = get_asset_value_after_depreciation(asset.name)
 		asset_repair = create_asset_repair(asset=asset, stock_consumption=1, submit=1)
 		asset.reload()
 
-		increase_in_asset_value = get_asset_value(asset) - initial_asset_value
+		increase_in_asset_value = get_asset_value_after_depreciation(asset.name) - initial_asset_value
 		self.assertEqual(asset_repair.stock_items[0].total_value, increase_in_asset_value)
 
 	def test_increase_in_asset_value_due_to_repair_cost_capitalisation(self):
 		asset = create_asset(calculate_depreciation=1, submit=1)
-		initial_asset_value = get_asset_value(asset)
+		initial_asset_value = get_asset_value_after_depreciation(asset.name)
 		asset_repair = create_asset_repair(asset=asset, capitalize_repair_cost=1, submit=1)
 		asset.reload()
 
-		increase_in_asset_value = get_asset_value(asset) - initial_asset_value
+		increase_in_asset_value = get_asset_value_after_depreciation(asset.name) - initial_asset_value
 		self.assertEqual(asset_repair.repair_cost, increase_in_asset_value)
 
 	def test_purchase_invoice(self):
@@ -141,10 +142,6 @@ class TestAssetRepair(unittest.TestCase):
 			asset.schedules[-1].accumulated_depreciation_amount,
 			asset.finance_books[0].value_after_depreciation,
 		)
-
-
-def get_asset_value(asset):
-	return asset.finance_books[0].value_after_depreciation
 
 
 def num_of_depreciations(asset):

--- a/erpnext/assets/doctype/asset_value_adjustment/asset_value_adjustment.js
+++ b/erpnext/assets/doctype/asset_value_adjustment/asset_value_adjustment.js
@@ -47,7 +47,7 @@ frappe.ui.form.on('Asset Value Adjustment', {
 	set_current_asset_value: function(frm) {
 		if (frm.doc.asset) {
 			frm.call({
-				method: "erpnext.assets.doctype.asset_value_adjustment.asset_value_adjustment.get_current_asset_value",
+				method: "erpnext.assets.doctype.asset.asset.get_asset_value_after_depreciation",
 				args: {
 					asset: frm.doc.asset,
 					finance_book: frm.doc.finance_book

--- a/erpnext/assets/doctype/asset_value_adjustment/asset_value_adjustment.py
+++ b/erpnext/assets/doctype/asset_value_adjustment/asset_value_adjustment.py
@@ -10,7 +10,10 @@ from frappe.utils import cint, date_diff, flt, formatdate, getdate
 from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
 	get_checks_for_pl_and_bs_accounts,
 )
-from erpnext.assets.doctype.asset.asset import get_depreciation_amount
+from erpnext.assets.doctype.asset.asset import (
+	get_asset_value_after_depreciation,
+	get_depreciation_amount,
+)
 from erpnext.assets.doctype.asset.depreciation import get_depreciation_accounts
 from erpnext.regional.india.utils import (
 	get_depreciation_amount as get_depreciation_amount_for_india,
@@ -45,7 +48,7 @@ class AssetValueAdjustment(Document):
 
 	def set_current_asset_value(self):
 		if not self.current_asset_value and self.asset:
-			self.current_asset_value = get_current_asset_value(self.asset, self.finance_book)
+			self.current_asset_value = get_asset_value_after_depreciation(self.asset, self.finance_book)
 
 	def make_depreciation_entry(self):
 		asset = frappe.get_doc("Asset", self.asset)
@@ -148,12 +151,3 @@ class AssetValueAdjustment(Document):
 		for asset_data in asset.schedules:
 			if not asset_data.journal_entry:
 				asset_data.db_update()
-
-
-@frappe.whitelist()
-def get_current_asset_value(asset, finance_book=None):
-	cond = {"parent": asset, "parenttype": "Asset"}
-	if finance_book:
-		cond.update({"finance_book": finance_book})
-
-	return frappe.db.get_value("Asset Finance Book", cond, "value_after_depreciation")

--- a/erpnext/assets/doctype/asset_value_adjustment/test_asset_value_adjustment.py
+++ b/erpnext/assets/doctype/asset_value_adjustment/test_asset_value_adjustment.py
@@ -6,10 +6,8 @@ import unittest
 import frappe
 from frappe.utils import add_days, get_last_day, nowdate
 
+from erpnext.assets.doctype.asset.asset import get_asset_value_after_depreciation
 from erpnext.assets.doctype.asset.test_asset import create_asset_data
-from erpnext.assets.doctype.asset_value_adjustment.asset_value_adjustment import (
-	get_current_asset_value,
-)
 from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import make_purchase_receipt
 
 
@@ -43,7 +41,7 @@ class TestAssetValueAdjustment(unittest.TestCase):
 		)
 		asset_doc.submit()
 
-		current_value = get_current_asset_value(asset_doc.name)
+		current_value = get_asset_value_after_depreciation(asset_doc.name)
 		self.assertEqual(current_value, 100000.0)
 
 	def test_asset_depreciation_value_adjustment(self):
@@ -73,7 +71,7 @@ class TestAssetValueAdjustment(unittest.TestCase):
 		)
 		asset_doc.submit()
 
-		current_value = get_current_asset_value(asset_doc.name)
+		current_value = get_asset_value_after_depreciation(asset_doc.name)
 		adj_doc = make_asset_value_adjustment(
 			asset=asset_doc.name, current_asset_value=current_value, new_asset_value=50000.0
 		)

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -375,3 +375,4 @@ erpnext.patches.v13_0.show_hr_payroll_deprecation_warning
 erpnext.patches.v13_0.create_accounting_dimensions_for_asset_repair
 execute:frappe.db.set_value("Naming Series", "Naming Series", {"select_doc_for_series": "", "set_options": "", "prefix": "", "current_value": 0, "user_must_always_select": 0})
 erpnext.patches.v13_0.update_schedule_type_in_loans
+erpnext.patches.v13_0.update_asset_value_for_manual_depr_entries

--- a/erpnext/patches/v13_0/update_asset_value_for_manual_depr_entries.py
+++ b/erpnext/patches/v13_0/update_asset_value_for_manual_depr_entries.py
@@ -1,0 +1,38 @@
+import frappe
+from frappe.query_builder.functions import IfNull, Sum
+
+
+def execute():
+	asset = frappe.qb.DocType("Asset")
+	gle = frappe.qb.DocType("GL Entry")
+	aca = frappe.qb.DocType("Asset Category Account")
+	company = frappe.qb.DocType("Company")
+
+	asset_total_depr_value_map = (
+		frappe.qb.from_(gle)
+		.join(asset)
+		.on(gle.against_voucher == asset.name)
+		.join(aca)
+		.on((aca.parent == asset.asset_category) & (aca.company_name == asset.company))
+		.join(company)
+		.on(company.name == asset.company)
+		.select(Sum(gle.debit).as_("value"), asset.name.as_("asset_name"))
+		.where(
+			gle.account == IfNull(aca.depreciation_expense_account, company.depreciation_expense_account)
+		)
+		.where(gle.debit != 0)
+		.where(gle.is_cancelled == 0)
+		.where(asset.docstatus == 1)
+		.where(asset.calculate_depreciation == 0)
+		.groupby(asset.name)
+	)
+
+	frappe.qb.update(asset).join(asset_total_depr_value_map).on(
+		asset_total_depr_value_map.asset_name == asset.name
+	).set(
+		asset.value_after_depreciation, asset.value_after_depreciation - asset_total_depr_value_map.value
+	).where(
+		asset.docstatus == 1
+	).where(
+		asset.calculate_depreciation == 0
+	).run()


### PR DESCRIPTION
1. When manual depreciation entries (created using the `Create Depreciation Entry` option in the `Manage` dropdown of assets with `calculate_depreciation` not checked) are submitted, the value of the asset isn't updated, so fixed that.
2. We have quite a few functions which (sometimes incorrectly) performed the same task of fetching an asset's current value after depreciation, so refactored all of them and now there's just one function.
3. The fixed asset register and the chart on asset documents weren't reflecting manual depr entries, so fixed them.
4. Wrote a patch to update value of all assets which have manual depr entries created for them.
5. In the fixed asset report register, assets with finance books weren't filtered properly resulting in an `TypeError: unsupported operand type(s) for +=: 'int' and 'NoneType'` error, so fixed it.
6. Fixed asset register report was throwing a `AttributeError: 'list' object has no attribute 'strip'` error because db.get_value doesn't support list based and ("is", "set")-style filters on v13, so fixed it.