### PR TITLE
fix: german chart of accounts "SKR03"

### DIFF
--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/de_kontenplan_SKR03_gnucash.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/de_kontenplan_SKR03_gnucash.json
@@ -1,38 +1,38 @@
 {
-    "country_code": "de",
-    "name": "SKR03 mit Kontonummern",
-    "tree": {
-        "Aktiva": {
-            "is_group": 1,
+	"country_code": "de",
+	"name": "SKR03 mit Kontonummern",
+	"tree": {
+		"Aktiva": {
+			"is_group": 1,
 			"root_type": "Asset",
-            "A - Anlagevermögen": {
-                "is_group": 1,
-                "EDV-Software": {
-                    "account_number": "0027",
-                    "account_type": "Fixed Asset"
-                },
-                "Gesch\u00e4ftsausstattung": {
-                    "account_number": "0410",
-                    "account_type": "Fixed Asset"
-                },
-                "B\u00fcroeinrichtung": {
-                    "account_number": "0420",
-                    "account_type": "Fixed Asset"
-                },
-                "Darlehen": {
-                    "account_number": "0565"
-                },
-                "Maschinen": {
-                    "account_number": "0210",
-                    "account_type": "Fixed Asset"
-                },
-                "Betriebsausstattung": {
-                    "account_number": "0400",
-                    "account_type": "Fixed Asset"
-                },
-                "Ladeneinrichtung": {
-                    "account_number": "0430",
-                    "account_type": "Fixed Asset"
+			"A - Anlagevermögen": {
+				"is_group": 1,
+				"EDV-Software": {
+					"account_number": "0027",
+					"account_type": "Fixed Asset"
+				},
+				"Gesch\u00e4ftsausstattung": {
+					"account_number": "0410",
+					"account_type": "Fixed Asset"
+				},
+				"B\u00fcroeinrichtung": {
+					"account_number": "0420",
+					"account_type": "Fixed Asset"
+				},
+				"Darlehen": {
+					"account_number": "0565"
+				},
+				"Maschinen": {
+					"account_number": "0210",
+					"account_type": "Fixed Asset"
+				},
+				"Betriebsausstattung": {
+					"account_number": "0400",
+					"account_type": "Fixed Asset"
+				},
+				"Ladeneinrichtung": {
+					"account_number": "0430",
+					"account_type": "Fixed Asset"
 				},
 				"Accumulated Depreciation": {
 					"account_type": "Accumulated Depreciation"
@@ -67,67 +67,67 @@
 						"is_group": 1,
 						"Abziehbare Vorsteuer 7%": {
 							"account_number": "1571",
-                            "account_type": "Tax",
-                            "tax_rate": 7.0
+							"account_type": "Tax",
+							"tax_rate": 7.0
 						},
 						"Abziehbare Vorsteuer 19%": {
 							"account_number": "1576",
-                            "account_type": "Tax",
-                            "tax_rate": 19.0
+							"account_type": "Tax",
+							"tax_rate": 19.0
 						},
 						"Abziehbare Vorsteuer nach \u00a713b UStG 19%": {
 							"account_number": "1577",
-                            "account_type": "Tax",
-                            "tax_rate": 19.0
+							"account_type": "Tax",
+							"tax_rate": 19.0
 						}
 					}
 				},
 				"III. Wertpapiere": {
 					"is_group": 1,
-                    "Anteile an verbundenen Unternehmen (Umlaufvermögen)": {
-                        "account_number": "1340"
-                    },
-                    "Anteile an herrschender oder mit Mehrheit beteiligter Gesellschaft": {
-                        "account_number": "1344"
-                    },
-                    "Sonstige Wertpapiere": {
-                        "account_number": "1348"
-                    }
+					"Anteile an verbundenen Unternehmen (Umlaufvermögen)": {
+						"account_number": "1340"
+					},
+					"Anteile an herrschender oder mit Mehrheit beteiligter Gesellschaft": {
+						"account_number": "1344"
+					},
+					"Sonstige Wertpapiere": {
+						"account_number": "1348"
+					}
 				},
 				"IV. Kassenbestand, Bundesbankguthaben, Guthaben bei Kreditinstituten und Schecks.": {
 					"is_group": 1,
-                    "Kasse": {
-                        "account_number": "1000",
-                        "account_type": "Cash"
-                    },
-                    "Postbank": {
-                        "account_number": "1100",
-                        "account_type": "Bank"
-                    },
-                    "Bankkonto": {
-                        "account_number": "1200",
-                        "account_type": "Bank"
-                    }
+					"Kasse": {
+						"account_number": "1000",
+						"account_type": "Cash"
+					},
+					"Postbank": {
+						"account_number": "1100",
+						"account_type": "Bank"
+					},
+					"Bankkonto": {
+						"account_number": "1200",
+						"account_type": "Bank"
+					}
 				}
 			},
 			"C - Rechnungsabgrenzungsposten": {
 				"is_group": 1,
 				"Aktive Rechnungsabgrenzung": {
-                    "account_number": "0980"
+					"account_number": "0980"
 				}
 			},
 			"D - Aktive latente Steuern": {
 				"is_group": 1,
 				"Aktive latente Steuern": {
-                    "account_number": "0983"
+					"account_number": "0983"
 				}
 			},
 			"E - Aktiver Unterschiedsbetrag aus der Vermögensverrechnung": {
 				"is_group": 1
 			}
-        },
-        "Passiva": {
-            "is_group": 1,
+		},
+		"Passiva": {
+			"is_group": 1,
 			"root_type": "Liability",
 			"A. Eigenkapital": {
 				"is_group": 1,
@@ -204,25 +204,25 @@
 						"is_group": 1,
 						"Umsatzsteuer 7%": {
 							"account_number": "1771",
-                            "account_type": "Tax",
-                            "tax_rate": 7.0
+							"account_type": "Tax",
+							"tax_rate": 7.0
 						},
 						"Umsatzsteuer 19%": {
 							"account_number": "1776",
-                            "account_type": "Tax",
-                            "tax_rate": 19.0
+							"account_type": "Tax",
+							"tax_rate": 19.0
 						},
 						"Umsatzsteuer-Vorauszahlung": {
 							"account_number": "1780",
-                            "account_type": "Tax"
+							"account_type": "Tax"
 						},
 						"Umsatzsteuer-Vorauszahlung 1/11": {
 							"account_number": "1781"
 						},
 						"Umsatzsteuer \u00a7 13b UStG 19%": {
 							"account_number": "1787",
-                            "account_type": "Tax",
-                            "tax_rate": 19.0
+							"account_type": "Tax",
+							"tax_rate": 19.0
 						},
 						"Umsatzsteuer Vorjahr": {
 							"account_number": "1790"
@@ -242,48 +242,48 @@
 			"E. Passive latente Steuern": {
 				"is_group": 1
 			}
-        },
-        "Erl\u00f6se u. Ertr\u00e4ge 2/8": {
-            "is_group": 1,
-            "root_type": "Income",
-            "Erl\u00f6skonten 8": {
+		},
+		"Erl\u00f6se u. Ertr\u00e4ge 2/8": {
+			"is_group": 1,
+			"root_type": "Income",
+			"Erl\u00f6skonten 8": {
 				"is_group": 1,
 				"Erl\u00f6se": {
-                    "account_number": "8200",
-                    "account_type": "Income Account"
-                },
-                "Erl\u00f6se USt. 19%": {
-                    "account_number": "8400",
-                    "account_type": "Income Account"
-                },
-                "Erl\u00f6se USt. 7%": {
-                    "account_number": "8300",
-                    "account_type": "Income Account"
-                }
-            },
-            "Ertragskonten 2": {
-                "is_group": 1,
-                "sonstige Zinsen und \u00e4hnliche Ertr\u00e4ge": {
-                    "account_number": "2650",
-                    "account_type": "Income Account"
-                },
-                "Au\u00dferordentliche Ertr\u00e4ge": {
-                    "account_number": "2500",
-                    "account_type": "Income Account"
-                },
-                "Sonstige Ertr\u00e4ge": {
-                    "account_number": "2700",
-                    "account_type": "Income Account"
-                }
-            }
-        },
-        "Aufwendungen 2/4": {
-            "is_group": 1,
+					"account_number": "8200",
+					"account_type": "Income Account"
+				},
+				"Erl\u00f6se USt. 19%": {
+					"account_number": "8400",
+					"account_type": "Income Account"
+				},
+				"Erl\u00f6se USt. 7%": {
+					"account_number": "8300",
+					"account_type": "Income Account"
+				}
+			},
+			"Ertragskonten 2": {
+				"is_group": 1,
+				"sonstige Zinsen und \u00e4hnliche Ertr\u00e4ge": {
+					"account_number": "2650",
+					"account_type": "Income Account"
+				},
+				"Au\u00dferordentliche Ertr\u00e4ge": {
+					"account_number": "2500",
+					"account_type": "Income Account"
+				},
+				"Sonstige Ertr\u00e4ge": {
+					"account_number": "2700",
+					"account_type": "Income Account"
+				}
+			}
+		},
+		"Aufwendungen 2/4": {
+			"is_group": 1,
 			"root_type": "Expense",
-            "Leistungen \u00a713b UStG 19% Vorsteuer, 19% Umsatzsteuer": {
-                "account_number": "3120",
-                "account_type": "Expense Account"
-            },
+			"Leistungen \u00a713b UStG 19% Vorsteuer, 19% Umsatzsteuer": {
+				"account_number": "3120",
+				"account_type": "Expense Account"
+			},
 			"Wareneingang": {
 				"account_number": "3200"
 			},
@@ -310,234 +310,234 @@
 			"Gegenkonto 4996-4998": {
 				"account_number": "4999"
 			},
-            "Abschreibungen": {
-                "is_group": 1,
+			"Abschreibungen": {
+				"is_group": 1,
 				"Abschreibungen auf Sachanlagen (ohne AfA auf Kfz und Gebäude)": {
-                    "account_number": "4830",
-                    "account_type": "Accumulated Depreciation"
+					"account_number": "4830",
+					"account_type": "Accumulated Depreciation"
 				},
 				"Abschreibungen auf Gebäude": {
-                    "account_number": "4831",
-                    "account_type": "Depreciation"
+					"account_number": "4831",
+					"account_type": "Depreciation"
 				},
 				"Abschreibungen auf Kfz": {
-                    "account_number": "4832",
-                    "account_type": "Depreciation"
+					"account_number": "4832",
+					"account_type": "Depreciation"
 				},
 				"Sofortabschreibung GWG": {
-                    "account_number": "4855",
-                    "account_type": "Expense Account"
+					"account_number": "4855",
+					"account_type": "Expense Account"
 				}
-            },
-            "Kfz-Kosten": {
-                "is_group": 1,
-                "Kfz-Steuer": {
-                    "account_number": "4510",
-                    "account_type": "Expense Account"
-                },
-                "Kfz-Versicherungen": {
-                    "account_number": "4520",
-                    "account_type": "Expense Account"
-                },
-                "laufende Kfz-Betriebskosten": {
-                    "account_number": "4530",
-                    "account_type": "Expense Account"
-                },
-                "Kfz-Reparaturen": {
-                    "account_number": "4540",
-                    "account_type": "Expense Account"
-                },
-                "Fremdfahrzeuge": {
-                    "account_number": "4570",
-                    "account_type": "Expense Account"
-                },
-                "sonstige Kfz-Kosten": {
-                    "account_number": "4580",
-                    "account_type": "Expense Account"
-                }
-            },
-            "Personalkosten": {
-                "is_group": 1,
-                "Geh\u00e4lter": {
-                    "account_number": "4120",
-                    "account_type": "Expense Account"
-                },
-                "gesetzliche soziale Aufwendungen": {
-                    "account_number": "4130",
-                    "account_type": "Expense Account"
-                },
-                "Aufwendungen f\u00fcr Altersvorsorge": {
-                    "account_number": "4165",
-                    "account_type": "Expense Account"
-                },
-                "Verm\u00f6genswirksame Leistungen": {
-                    "account_number": "4170",
-                    "account_type": "Expense Account"
-                },
-                "Aushilfsl\u00f6hne": {
-                    "account_number": "4190",
-                    "account_type": "Expense Account"
-                }
-            },
-            "Raumkosten": {
-                "is_group": 1,
-                "Miete und Nebenkosten": {
-                    "account_number": "4210",
-                    "account_type": "Expense Account"
-                },
-                "Gas, Wasser, Strom (Verwaltung, Vertrieb)": {
-                    "account_number": "4240",
-                    "account_type": "Expense Account"
-                },
-                "Reinigung": {
-                    "account_number": "4250",
-                    "account_type": "Expense Account"
-                }
-            },
-            "Reparatur/Instandhaltung": {
-                "is_group": 1,
-                "Reparatur u. Instandh. von Anlagen/Maschinen u. Betriebs- u. Gesch\u00e4ftsausst.": {
-                    "account_number": "4805",
-                    "account_type": "Expense Account"
-                }
-            },
-            "Versicherungsbeitr\u00e4ge": {
-                "is_group": 1,
-                "Versicherungen": {
-                    "account_number": "4360",
-                    "account_type": "Expense Account"
-                },
-                "Beitr\u00e4ge": {
-                    "account_number": "4380",
-                    "account_type": "Expense Account"
-                },
-                "sonstige Ausgaben": {
-                    "account_number": "4390",
-                    "account_type": "Expense Account"
-                },
-                "steuerlich abzugsf\u00e4hige Versp\u00e4tungszuschl\u00e4ge und Zwangsgelder": {
-                    "account_number": "4396",
-                    "account_type": "Expense Account"
-                }
-            },
-            "Werbe-/Reisekosten": {
-                "is_group": 1,
-                "Werbekosten": {
-                    "account_number": "4610",
-                    "account_type": "Expense Account"
-                },
-                "Aufmerksamkeiten": {
-                    "account_number": "4653",
-                    "account_type": "Expense Account"
-                },
-                "nicht abzugsf\u00e4hige Betriebsausg. aus Werbe-, Repr\u00e4s.- u. Reisekosten": {
-                    "account_number": "4665",
-                    "account_type": "Expense Account"
-                },
-                "Reisekosten Unternehmer": {
-                    "account_number": "4670",
-                    "account_type": "Expense Account"
-                }
-            },
-            "verschiedene Kosten": {
-                "is_group": 1,
-                "Porto": {
-                    "account_number": "4910",
-                    "account_type": "Expense Account"
-                },
-                "Telekom": {
-                    "account_number": "4920",
-                    "account_type": "Expense Account"
-                },
-                "Mobilfunk D2": {
-                    "account_number": "4921",
-                    "account_type": "Expense Account"
-                },
-                "Internet": {
-                    "account_number": "4922",
-                    "account_type": "Expense Account"
-                },
-                "B\u00fcrobedarf": {
-                    "account_number": "4930",
-                    "account_type": "Expense Account"
-                },
-                "Zeitschriften, B\u00fccher": {
-                    "account_number": "4940",
-                    "account_type": "Expense Account"
-                },
-                "Fortbildungskosten": {
-                    "account_number": "4945",
-                    "account_type": "Expense Account"
-                },
-                "Buchf\u00fchrungskosten": {
-                    "account_number": "4955",
-                    "account_type": "Expense Account"
-                },
-                "Abschlu\u00df- u. Pr\u00fcfungskosten": {
-                    "account_number": "4957",
-                    "account_type": "Expense Account"
-                },
-                "Nebenkosten des Geldverkehrs": {
-                    "account_number": "4970",
-                    "account_type": "Expense Account"
-                },
-                "Werkzeuge und Kleinger\u00e4te": {
-                    "account_number": "4985",
-                    "account_type": "Expense Account"
-                }
-            },
-            "Zinsaufwendungen": {
-                "is_group": 1,
-                "Zinsaufwendungen f\u00fcr kurzfristige Verbindlichkeiten": {
-                    "account_number": "2110",
-                    "account_type": "Expense Account"
-                },
-                "Zinsaufwendungen f\u00fcr KFZ Finanzierung": {
-                    "account_number": "2121",
-                    "account_type": "Expense Account"
-                }
-            }
-        },
-        "Anfangsbestand 9": {
-            "is_group": 1,
-            "root_type": "Equity",
-            "Saldenvortragskonten": {
-                "is_group": 1,
-                "Saldenvortrag Sachkonten": {
-                    "account_number": "9000"
-                },
-                "Saldenvortr\u00e4ge Debitoren": {
-                    "account_number": "9008"
-                },
-                "Saldenvortr\u00e4ge Kreditoren": {
-                    "account_number": "9009"
-                }
-            }
-        },
-        "Privatkonten 1": {
-            "is_group": 1,
-            "root_type": "Equity",
-            "Privatentnahmen/-einlagen": {
-                "is_group": 1,
-                "Privatentnahme allgemein": {
-                    "account_number": "1800"
-                },
-                "Privatsteuern": {
-                    "account_number": "1810"
-                },
-                "Sonderausgaben beschr\u00e4nkt abzugsf\u00e4hig": {
-                    "account_number": "1820"
-                },
-                "Sonderausgaben unbeschr\u00e4nkt abzugsf\u00e4hig": {
-                    "account_number": "1830"
-                },
-                "Au\u00dfergew\u00f6hnliche Belastungen": {
-                    "account_number": "1850"
-                },
-                "Privateinlagen": {
-                    "account_number": "1890"
-                }
-            }
-        }
-    }
+			},
+			"Kfz-Kosten": {
+				"is_group": 1,
+				"Kfz-Steuer": {
+					"account_number": "4510",
+					"account_type": "Expense Account"
+				},
+				"Kfz-Versicherungen": {
+					"account_number": "4520",
+					"account_type": "Expense Account"
+				},
+				"laufende Kfz-Betriebskosten": {
+					"account_number": "4530",
+					"account_type": "Expense Account"
+				},
+				"Kfz-Reparaturen": {
+					"account_number": "4540",
+					"account_type": "Expense Account"
+				},
+				"Fremdfahrzeuge": {
+					"account_number": "4570",
+					"account_type": "Expense Account"
+				},
+				"sonstige Kfz-Kosten": {
+					"account_number": "4580",
+					"account_type": "Expense Account"
+				}
+			},
+			"Personalkosten": {
+				"is_group": 1,
+				"Geh\u00e4lter": {
+					"account_number": "4120",
+					"account_type": "Expense Account"
+				},
+				"gesetzliche soziale Aufwendungen": {
+					"account_number": "4130",
+					"account_type": "Expense Account"
+				},
+				"Aufwendungen f\u00fcr Altersvorsorge": {
+					"account_number": "4165",
+					"account_type": "Expense Account"
+				},
+				"Verm\u00f6genswirksame Leistungen": {
+					"account_number": "4170",
+					"account_type": "Expense Account"
+				},
+				"Aushilfsl\u00f6hne": {
+					"account_number": "4190",
+					"account_type": "Expense Account"
+				}
+			},
+			"Raumkosten": {
+				"is_group": 1,
+				"Miete und Nebenkosten": {
+					"account_number": "4210",
+					"account_type": "Expense Account"
+				},
+				"Gas, Wasser, Strom (Verwaltung, Vertrieb)": {
+					"account_number": "4240",
+					"account_type": "Expense Account"
+				},
+				"Reinigung": {
+					"account_number": "4250",
+					"account_type": "Expense Account"
+				}
+			},
+			"Reparatur/Instandhaltung": {
+				"is_group": 1,
+				"Reparatur u. Instandh. von Anlagen/Maschinen u. Betriebs- u. Gesch\u00e4ftsausst.": {
+					"account_number": "4805",
+					"account_type": "Expense Account"
+				}
+			},
+			"Versicherungsbeitr\u00e4ge": {
+				"is_group": 1,
+				"Versicherungen": {
+					"account_number": "4360",
+					"account_type": "Expense Account"
+				},
+				"Beitr\u00e4ge": {
+					"account_number": "4380",
+					"account_type": "Expense Account"
+				},
+				"sonstige Ausgaben": {
+					"account_number": "4390",
+					"account_type": "Expense Account"
+				},
+				"steuerlich abzugsf\u00e4hige Versp\u00e4tungszuschl\u00e4ge und Zwangsgelder": {
+					"account_number": "4396",
+					"account_type": "Expense Account"
+				}
+			},
+			"Werbe-/Reisekosten": {
+				"is_group": 1,
+				"Werbekosten": {
+					"account_number": "4610",
+					"account_type": "Expense Account"
+				},
+				"Aufmerksamkeiten": {
+					"account_number": "4653",
+					"account_type": "Expense Account"
+				},
+				"nicht abzugsf\u00e4hige Betriebsausg. aus Werbe-, Repr\u00e4s.- u. Reisekosten": {
+					"account_number": "4665",
+					"account_type": "Expense Account"
+				},
+				"Reisekosten Unternehmer": {
+					"account_number": "4670",
+					"account_type": "Expense Account"
+				}
+			},
+			"verschiedene Kosten": {
+				"is_group": 1,
+				"Porto": {
+					"account_number": "4910",
+					"account_type": "Expense Account"
+				},
+				"Telekom": {
+					"account_number": "4920",
+					"account_type": "Expense Account"
+				},
+				"Mobilfunk D2": {
+					"account_number": "4921",
+					"account_type": "Expense Account"
+				},
+				"Internet": {
+					"account_number": "4922",
+					"account_type": "Expense Account"
+				},
+				"B\u00fcrobedarf": {
+					"account_number": "4930",
+					"account_type": "Expense Account"
+				},
+				"Zeitschriften, B\u00fccher": {
+					"account_number": "4940",
+					"account_type": "Expense Account"
+				},
+				"Fortbildungskosten": {
+					"account_number": "4945",
+					"account_type": "Expense Account"
+				},
+				"Buchf\u00fchrungskosten": {
+					"account_number": "4955",
+					"account_type": "Expense Account"
+				},
+				"Abschlu\u00df- u. Pr\u00fcfungskosten": {
+					"account_number": "4957",
+					"account_type": "Expense Account"
+				},
+				"Nebenkosten des Geldverkehrs": {
+					"account_number": "4970",
+					"account_type": "Expense Account"
+				},
+				"Werkzeuge und Kleinger\u00e4te": {
+					"account_number": "4985",
+					"account_type": "Expense Account"
+				}
+			},
+			"Zinsaufwendungen": {
+				"is_group": 1,
+				"Zinsaufwendungen f\u00fcr kurzfristige Verbindlichkeiten": {
+					"account_number": "2110",
+					"account_type": "Expense Account"
+				},
+				"Zinsaufwendungen f\u00fcr KFZ Finanzierung": {
+					"account_number": "2121",
+					"account_type": "Expense Account"
+				}
+			}
+		},
+		"Anfangsbestand 9": {
+			"is_group": 1,
+			"root_type": "Equity",
+			"Saldenvortragskonten": {
+				"is_group": 1,
+				"Saldenvortrag Sachkonten": {
+					"account_number": "9000"
+				},
+				"Saldenvortr\u00e4ge Debitoren": {
+					"account_number": "9008"
+				},
+				"Saldenvortr\u00e4ge Kreditoren": {
+					"account_number": "9009"
+				}
+			}
+		},
+		"Privatkonten 1": {
+			"is_group": 1,
+			"root_type": "Equity",
+			"Privatentnahmen/-einlagen": {
+				"is_group": 1,
+				"Privatentnahme allgemein": {
+					"account_number": "1800"
+				},
+				"Privatsteuern": {
+					"account_number": "1810"
+				},
+				"Sonderausgaben beschr\u00e4nkt abzugsf\u00e4hig": {
+					"account_number": "1820"
+				},
+				"Sonderausgaben unbeschr\u00e4nkt abzugsf\u00e4hig": {
+					"account_number": "1830"
+				},
+				"Au\u00dfergew\u00f6hnliche Belastungen": {
+					"account_number": "1850"
+				},
+				"Privateinlagen": {
+					"account_number": "1890"
+				}
+			}
+		}
+	}
 }

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/de_kontenplan_SKR03_gnucash.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/de_kontenplan_SKR03_gnucash.json
@@ -280,7 +280,15 @@
 		"Aufwendungen 2/4": {
 			"is_group": 1,
 			"root_type": "Expense",
-			"Leistungen \u00a713b UStG 19 % Vorsteuer, 19 % Umsatzsteuer": {
+			"Fremdleistungen": {
+				"account_number": "3100",
+				"account_type": "Expense Account"
+			},
+			"Fremdleistungen ohne Vorsteuer": {
+				"account_number": "3109",
+				"account_type": "Expense Account"
+			},
+			"Bauleistungen eines im Inland ansässigen Unternehmers 19 % Vorsteuer und 19 % Umsatzsteuer": {
 				"account_number": "3120",
 				"account_type": "Expense Account"
 			},

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/de_kontenplan_SKR03_gnucash.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/de_kontenplan_SKR03_gnucash.json
@@ -65,17 +65,17 @@
 					},
 					"Abziehbare Vorsteuer": {
 						"is_group": 1,
-						"Abziehbare Vorsteuer 7%": {
+						"Abziehbare Vorsteuer 7 %": {
 							"account_number": "1571",
 							"account_type": "Tax",
 							"tax_rate": 7.0
 						},
-						"Abziehbare Vorsteuer 19%": {
+						"Abziehbare Vorsteuer 19 %": {
 							"account_number": "1576",
 							"account_type": "Tax",
 							"tax_rate": 19.0
 						},
-						"Abziehbare Vorsteuer nach \u00a713b UStG 19%": {
+						"Abziehbare Vorsteuer nach \u00a713b UStG 19 %": {
 							"account_number": "1577",
 							"account_type": "Tax",
 							"tax_rate": 19.0
@@ -202,12 +202,12 @@
 					},
 					"Umsatzsteuer": {
 						"is_group": 1,
-						"Umsatzsteuer 7%": {
+						"Umsatzsteuer 7 %": {
 							"account_number": "1771",
 							"account_type": "Tax",
 							"tax_rate": 7.0
 						},
-						"Umsatzsteuer 19%": {
+						"Umsatzsteuer 19 %": {
 							"account_number": "1776",
 							"account_type": "Tax",
 							"tax_rate": 19.0
@@ -219,7 +219,7 @@
 						"Umsatzsteuer-Vorauszahlung 1/11": {
 							"account_number": "1781"
 						},
-						"Umsatzsteuer \u00a7 13b UStG 19%": {
+						"Umsatzsteuer \u00a7 13b UStG 19 %": {
 							"account_number": "1787",
 							"account_type": "Tax",
 							"tax_rate": 19.0
@@ -252,11 +252,11 @@
 					"account_number": "8200",
 					"account_type": "Income Account"
 				},
-				"Erl\u00f6se USt. 19%": {
+				"Erl\u00f6se USt. 19 %": {
 					"account_number": "8400",
 					"account_type": "Income Account"
 				},
-				"Erl\u00f6se USt. 7%": {
+				"Erl\u00f6se USt. 7 %": {
 					"account_number": "8300",
 					"account_type": "Income Account"
 				}
@@ -280,7 +280,7 @@
 		"Aufwendungen 2/4": {
 			"is_group": 1,
 			"root_type": "Expense",
-			"Leistungen \u00a713b UStG 19% Vorsteuer, 19% Umsatzsteuer": {
+			"Leistungen \u00a713b UStG 19 % Vorsteuer, 19 % Umsatzsteuer": {
 				"account_number": "3120",
 				"account_type": "Expense Account"
 			},

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/de_kontenplan_SKR03_gnucash.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/de_kontenplan_SKR03_gnucash.json
@@ -11,11 +11,11 @@
 					"account_number": "0027",
 					"account_type": "Fixed Asset"
 				},
-				"Gesch\u00e4ftsausstattung": {
+				"Geschäftsausstattung": {
 					"account_number": "0410",
 					"account_type": "Fixed Asset"
 				},
-				"B\u00fcroeinrichtung": {
+				"Büroeinrichtung": {
 					"account_number": "0420",
 					"account_type": "Fixed Asset"
 				},
@@ -60,7 +60,7 @@
 					"Durchlaufende Posten": {
 						"account_number": "1590"
 					},
-					"Gewinnermittlung \u00a74/3 nicht Ergebniswirksam": {
+					"Verrechnungskonto Gewinnermittlung § 4 Abs. 3 EStG, nicht ergebniswirksam": {
 						"account_number": "1371"
 					},
 					"Abziehbare Vorsteuer": {
@@ -75,7 +75,7 @@
 							"account_type": "Tax",
 							"tax_rate": 19.0
 						},
-						"Abziehbare Vorsteuer nach \u00a713b UStG 19 %": {
+						"Abziehbare Vorsteuer nach § 13b UStG 19 %": {
 							"account_number": "1577",
 							"account_type": "Tax",
 							"tax_rate": 19.0
@@ -219,7 +219,7 @@
 						"Umsatzsteuer-Vorauszahlung 1/11": {
 							"account_number": "1781"
 						},
-						"Umsatzsteuer \u00a7 13b UStG 19 %": {
+						"Umsatzsteuer nach § 13b UStG 19 %": {
 							"account_number": "1787",
 							"account_type": "Tax",
 							"tax_rate": 19.0
@@ -227,7 +227,7 @@
 						"Umsatzsteuer Vorjahr": {
 							"account_number": "1790"
 						},
-						"Umsatzsteuer fr\u00fchere Jahre": {
+						"Umsatzsteuer frühere Jahre": {
 							"account_number": "1791"
 						}
 					}
@@ -243,35 +243,35 @@
 				"is_group": 1
 			}
 		},
-		"Erl\u00f6se u. Ertr\u00e4ge 2/8": {
+		"Erlöse u. Erträge 2/8": {
 			"is_group": 1,
 			"root_type": "Income",
-			"Erl\u00f6skonten 8": {
+			"Erlöskonten 8": {
 				"is_group": 1,
-				"Erl\u00f6se": {
+				"Erlöse": {
 					"account_number": "8200",
 					"account_type": "Income Account"
 				},
-				"Erl\u00f6se USt. 19 %": {
+				"Erlöse USt. 19 %": {
 					"account_number": "8400",
 					"account_type": "Income Account"
 				},
-				"Erl\u00f6se USt. 7 %": {
+				"Erlöse USt. 7 %": {
 					"account_number": "8300",
 					"account_type": "Income Account"
 				}
 			},
 			"Ertragskonten 2": {
 				"is_group": 1,
-				"sonstige Zinsen und \u00e4hnliche Ertr\u00e4ge": {
+				"sonstige Zinsen und ähnliche Erträge": {
 					"account_number": "2650",
 					"account_type": "Income Account"
 				},
-				"Au\u00dferordentliche Ertr\u00e4ge": {
+				"Außerordentliche Erträge": {
 					"account_number": "2500",
 					"account_type": "Income Account"
 				},
-				"Sonstige Ertr\u00e4ge": {
+				"Sonstige Erträge": {
 					"account_number": "2700",
 					"account_type": "Income Account"
 				}
@@ -366,7 +366,7 @@
 			},
 			"Personalkosten": {
 				"is_group": 1,
-				"Geh\u00e4lter": {
+				"Gehälter": {
 					"account_number": "4120",
 					"account_type": "Expense Account"
 				},
@@ -374,15 +374,15 @@
 					"account_number": "4130",
 					"account_type": "Expense Account"
 				},
-				"Aufwendungen f\u00fcr Altersvorsorge": {
+				"Aufwendungen für Altersvorsorge": {
 					"account_number": "4165",
 					"account_type": "Expense Account"
 				},
-				"Verm\u00f6genswirksame Leistungen": {
+				"Vermögenswirksame Leistungen": {
 					"account_number": "4170",
 					"account_type": "Expense Account"
 				},
-				"Aushilfsl\u00f6hne": {
+				"Aushilfslöhne": {
 					"account_number": "4190",
 					"account_type": "Expense Account"
 				}
@@ -404,18 +404,18 @@
 			},
 			"Reparatur/Instandhaltung": {
 				"is_group": 1,
-				"Reparatur u. Instandh. von Anlagen/Maschinen u. Betriebs- u. Gesch\u00e4ftsausst.": {
+				"Reparaturen und Instandhaltungen von anderen Anlagen und Betriebs- und Geschäftsausstattung": {
 					"account_number": "4805",
 					"account_type": "Expense Account"
 				}
 			},
-			"Versicherungsbeitr\u00e4ge": {
+			"Versicherungsbeiträge": {
 				"is_group": 1,
 				"Versicherungen": {
 					"account_number": "4360",
 					"account_type": "Expense Account"
 				},
-				"Beitr\u00e4ge": {
+				"Beiträge": {
 					"account_number": "4380",
 					"account_type": "Expense Account"
 				},
@@ -423,7 +423,7 @@
 					"account_number": "4390",
 					"account_type": "Expense Account"
 				},
-				"steuerlich abzugsf\u00e4hige Versp\u00e4tungszuschl\u00e4ge und Zwangsgelder": {
+				"steuerlich abzugsfähige Verspätungszuschläge und Zwangsgelder": {
 					"account_number": "4396",
 					"account_type": "Expense Account"
 				}
@@ -438,7 +438,7 @@
 					"account_number": "4653",
 					"account_type": "Expense Account"
 				},
-				"nicht abzugsf\u00e4hige Betriebsausg. aus Werbe-, Repr\u00e4s.- u. Reisekosten": {
+				"nicht abzugsfähige Betriebsausg. aus Werbe-, Repräs.- u. Reisekosten": {
 					"account_number": "4665",
 					"account_type": "Expense Account"
 				},
@@ -465,11 +465,11 @@
 					"account_number": "4922",
 					"account_type": "Expense Account"
 				},
-				"B\u00fcrobedarf": {
+				"Bürobedarf": {
 					"account_number": "4930",
 					"account_type": "Expense Account"
 				},
-				"Zeitschriften, B\u00fccher": {
+				"Zeitschriften, Bücher": {
 					"account_number": "4940",
 					"account_type": "Expense Account"
 				},
@@ -477,11 +477,11 @@
 					"account_number": "4945",
 					"account_type": "Expense Account"
 				},
-				"Buchf\u00fchrungskosten": {
+				"Buchführungskosten": {
 					"account_number": "4955",
 					"account_type": "Expense Account"
 				},
-				"Abschlu\u00df- u. Pr\u00fcfungskosten": {
+				"Abschluß- u. Prüfungskosten": {
 					"account_number": "4957",
 					"account_type": "Expense Account"
 				},
@@ -489,18 +489,18 @@
 					"account_number": "4970",
 					"account_type": "Expense Account"
 				},
-				"Werkzeuge und Kleinger\u00e4te": {
+				"Werkzeuge und Kleingeräte": {
 					"account_number": "4985",
 					"account_type": "Expense Account"
 				}
 			},
 			"Zinsaufwendungen": {
 				"is_group": 1,
-				"Zinsaufwendungen f\u00fcr kurzfristige Verbindlichkeiten": {
+				"Zinsaufwendungen für kurzfristige Verbindlichkeiten": {
 					"account_number": "2110",
 					"account_type": "Expense Account"
 				},
-				"Zinsaufwendungen f\u00fcr KFZ Finanzierung": {
+				"Zinsaufwendungen für KFZ Finanzierung": {
 					"account_number": "2121",
 					"account_type": "Expense Account"
 				}
@@ -514,10 +514,10 @@
 				"Saldenvortrag Sachkonten": {
 					"account_number": "9000"
 				},
-				"Saldenvortr\u00e4ge Debitoren": {
+				"Saldenvorträge Debitoren": {
 					"account_number": "9008"
 				},
-				"Saldenvortr\u00e4ge Kreditoren": {
+				"Saldenvorträge Kreditoren": {
 					"account_number": "9009"
 				}
 			}
@@ -533,13 +533,13 @@
 				"Privatsteuern": {
 					"account_number": "1810"
 				},
-				"Sonderausgaben beschr\u00e4nkt abzugsf\u00e4hig": {
+				"Sonderausgaben beschränkt abzugsfähig": {
 					"account_number": "1820"
 				},
-				"Sonderausgaben unbeschr\u00e4nkt abzugsf\u00e4hig": {
+				"Sonderausgaben unbeschränkt abzugsfähig": {
 					"account_number": "1830"
 				},
-				"Au\u00dfergew\u00f6hnliche Belastungen": {
+				"Außergewöhnliche Belastungen": {
 					"account_number": "1850"
 				},
 				"Privateinlagen": {

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/de_kontenplan_SKR03_gnucash.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/de_kontenplan_SKR03_gnucash.json
@@ -64,48 +64,50 @@
 						"account_number": "1371"
 					},
 					"Abziehbare Vorsteuer": {
-						"account_type": "Tax",
 						"is_group": 1,
 						"Abziehbare Vorsteuer 7%": {
-							"account_number": "1571"
+							"account_number": "1571",
+                            "account_type": "Tax",
+                            "tax_rate": 7.0
 						},
 						"Abziehbare Vorsteuer 19%": {
-							"account_number": "1576"
+							"account_number": "1576",
+                            "account_type": "Tax",
+                            "tax_rate": 19.0
 						},
 						"Abziehbare Vorsteuer nach \u00a713b UStG 19%": {
-							"account_number": "1577"
-						},
-						"Leistungen \u00a713b UStG 19% Vorsteuer, 19% Umsatzsteuer": {
-							"account_number": "3120"
+							"account_number": "1577",
+                            "account_type": "Tax",
+                            "tax_rate": 19.0
 						}
 					}
 				},
 				"III. Wertpapiere": {
-					"is_group": 1
+					"is_group": 1,
+                    "Anteile an verbundenen Unternehmen (Umlaufvermögen)": {
+                        "account_number": "1340"
+                    },
+                    "Anteile an herrschender oder mit Mehrheit beteiligter Gesellschaft": {
+                        "account_number": "1344"
+                    },
+                    "Sonstige Wertpapiere": {
+                        "account_number": "1348"
+                    }
 				},
 				"IV. Kassenbestand, Bundesbankguthaben, Guthaben bei Kreditinstituten und Schecks.": {
 					"is_group": 1,
-					"Kasse": {
-						"account_type": "Cash",
-						"is_group": 1,
-						"Kasse": {
-							"is_group": 1,
-							"account_number": "1000",
-							"account_type": "Cash"
-						}
-					},
-					"Bank": {
-						"is_group": 1,
-						"account_type": "Bank",
-						"Postbank": {
-							"account_number": "1100",
-							"account_type": "Bank"
-						},
-						"Bankkonto": {
-							"account_number": "1200",
-							"account_type": "Bank"
-						}
-					}
+                    "Kasse": {
+                        "account_number": "1000",
+                        "account_type": "Cash"
+                    },
+                    "Postbank": {
+                        "account_number": "1100",
+                        "account_type": "Bank"
+                    },
+                    "Bankkonto": {
+                        "account_number": "1200",
+                        "account_type": "Bank"
+                    }
 				}
 			},
 			"C - Rechnungsabgrenzungsposten": {
@@ -200,21 +202,27 @@
 					},
 					"Umsatzsteuer": {
 						"is_group": 1,
-						"account_type": "Tax",
 						"Umsatzsteuer 7%": {
-							"account_number": "1771"
+							"account_number": "1771",
+                            "account_type": "Tax",
+                            "tax_rate": 7.0
 						},
 						"Umsatzsteuer 19%": {
-							"account_number": "1776"
+							"account_number": "1776",
+                            "account_type": "Tax",
+                            "tax_rate": 19.0
 						},
 						"Umsatzsteuer-Vorauszahlung": {
-							"account_number": "1780"
+							"account_number": "1780",
+                            "account_type": "Tax"
 						},
 						"Umsatzsteuer-Vorauszahlung 1/11": {
 							"account_number": "1781"
 						},
 						"Umsatzsteuer \u00a7 13b UStG 19%": {
-							"account_number": "1787"
+							"account_number": "1787",
+                            "account_type": "Tax",
+                            "tax_rate": 19.0
 						},
 						"Umsatzsteuer Vorjahr": {
 							"account_number": "1790"
@@ -272,6 +280,10 @@
         "Aufwendungen 2/4": {
             "is_group": 1,
 			"root_type": "Expense",
+            "Leistungen \u00a713b UStG 19% Vorsteuer, 19% Umsatzsteuer": {
+                "account_number": "3120",
+                "account_type": "Expense Account"
+            },
 			"Wareneingang": {
 				"account_number": "3200"
 			},

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/de_kontenplan_SKR03_gnucash.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/de_kontenplan_SKR03_gnucash.json
@@ -97,16 +97,24 @@
 				"IV. Kassenbestand, Bundesbankguthaben, Guthaben bei Kreditinstituten und Schecks.": {
 					"is_group": 1,
 					"Kasse": {
-						"account_number": "1000",
-						"account_type": "Cash"
+						"is_group": 1,
+						"account_type": "Cash",
+						"Kasse": {
+							"account_number": "1000",
+							"account_type": "Cash"
+						}
 					},
-					"Postbank": {
-						"account_number": "1100",
-						"account_type": "Bank"
-					},
-					"Bankkonto": {
-						"account_number": "1200",
-						"account_type": "Bank"
+					"Bank": {
+						"is_group": 1,
+						"account_type": "Bank",
+						"Postbank": {
+							"account_number": "1100",
+							"account_type": "Bank"
+						},
+						"Bankkonto": {
+							"account_number": "1200",
+							"account_type": "Bank"
+						}
 					}
 				}
 			},


### PR DESCRIPTION
- Added some missing account types and tax rates
- Added some missing accounts
- Converted mixed indentation to all-tabs (exclude whitespace for a clearer diff)
- Added spaces before percentage signs for consistency with tax configuration and original template
- Replaced unicode characters with umlauts for better readability (tested, doesn't cause any issues)

no-docs
