### PR TITLE
fix: don't allow to cancel non completed repost item valuation

### DIFF
--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
@@ -83,6 +83,17 @@ class RepostItemValuation(Document):
 		if write:
 			self.db_set("status", self.status)
 
+	def on_cancel(self):
+		self.validate_repost_cancelled()
+
+	def validate_repost_cancelled(self):
+		if self.status != "Completed":
+			frappe.throw(
+				_(
+					"User can't cancel the non completed Repost Item Valuation. Please try after completion of reposting."
+				)
+			)
+
 	def on_submit(self):
 		"""During tests reposts are executed immediately.
 

--- a/erpnext/stock/doctype/repost_item_valuation/test_repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/test_repost_item_valuation.py
@@ -376,3 +376,17 @@ class TestRepostItemValuation(FrappeTestCase, StockTestMixin):
 
 		accounts_settings.acc_frozen_upto = ""
 		accounts_settings.save()
+
+	def test_validate_repost_cancelled(self):
+		riv = frappe.get_doc(
+			doctype="Repost Item Valuation",
+			item_code="_Test Item",
+			warehouse="_Test Warehouse - _TC",
+			based_on="Item and Warehouse",
+			posting_date=today(),
+			posting_time="00:01:00",
+		)
+		riv.flags.dont_run_in_test = True  # keep it queued
+		riv.submit()
+
+		self.assertRaises(frappe.ValidationError, riv.cancel)


### PR DESCRIPTION
If user trying to cancel the non completed repost item valuation then system will throw the below error 

<img width="838" alt="Screenshot 2023-02-01 at 10 16 58 AM" src="https://user-images.githubusercontent.com/8780500/215954357-ab13c94d-c2f0-481c-bc23-adb08e31a476.png">
