### PR TITLE
fix: default due_date was wrong calculated on template "_Test Payment Term Template 1" (last day of next month)

### DIFF
--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -550,7 +550,7 @@ def get_due_date_from_template(template_name, posting_date, bill_date):
 		elif term.due_date_based_on == "Day(s) after the end of the invoice month":
 			due_date = max(due_date, add_days(get_last_day(due_date), term.credit_days))
 		else:
-			due_date = max(due_date, add_months(get_last_day(due_date), term.credit_months))
+			due_date = max(due_date, get_last_day(add_months(due_date, term.credit_months)))
 	return due_date
 
 

--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -687,7 +687,7 @@ class TestPurchaseOrder(FrappeTestCase):
 				raise Exception
 
 	def test_default_payment_terms(self):
-		due_date = get_due_date_from_template("_Test Payment Term Template 1", "2023-02-03", None)
+		due_date = get_due_date_from_template("_Test Payment Term Template 1", "2023-02-03", None).strftime("%Y-%m-%d")
 		self.assertEqual(due_date, "2023-03-31")
 
 	def test_terms_are_not_copied_if_automatically_fetch_payment_terms_is_unchecked(self):

--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -23,6 +23,7 @@ from erpnext.stock.doctype.material_request.test_material_request import make_ma
 from erpnext.stock.doctype.purchase_receipt.purchase_receipt import (
 	make_purchase_invoice as make_pi_from_pr,
 )
+from erpnext.accounts.party import get_due_date_from_template
 
 
 class TestPurchaseOrder(FrappeTestCase):
@@ -684,6 +685,10 @@ class TestPurchaseOrder(FrappeTestCase):
 				pass
 			else:
 				raise Exception
+
+	def test_default_payment_terms(self):
+		due_date = get_due_date_from_template("_Test Payment Term Template 1", "2023-02-03")
+		self.assertEqual(due_date, "2023-03-31")
 
 	def test_terms_are_not_copied_if_automatically_fetch_payment_terms_is_unchecked(self):
 		po = create_purchase_order(do_not_save=1)

--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -10,6 +10,7 @@ from frappe.utils import add_days, flt, getdate, nowdate
 from frappe.utils.data import today
 
 from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
+from erpnext.accounts.party import get_due_date_from_template
 from erpnext.buying.doctype.purchase_order.purchase_order import make_inter_company_sales_order
 from erpnext.buying.doctype.purchase_order.purchase_order import (
 	make_purchase_invoice as make_pi_from_po,
@@ -23,7 +24,6 @@ from erpnext.stock.doctype.material_request.test_material_request import make_ma
 from erpnext.stock.doctype.purchase_receipt.purchase_receipt import (
 	make_purchase_invoice as make_pi_from_pr,
 )
-from erpnext.accounts.party import get_due_date_from_template
 
 
 class TestPurchaseOrder(FrappeTestCase):

--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -687,7 +687,9 @@ class TestPurchaseOrder(FrappeTestCase):
 				raise Exception
 
 	def test_default_payment_terms(self):
-		due_date = get_due_date_from_template("_Test Payment Term Template 1", "2023-02-03", None).strftime("%Y-%m-%d")
+		due_date = get_due_date_from_template(
+			"_Test Payment Term Template 1", "2023-02-03", None
+		).strftime("%Y-%m-%d")
 		self.assertEqual(due_date, "2023-03-31")
 
 	def test_terms_are_not_copied_if_automatically_fetch_payment_terms_is_unchecked(self):

--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -687,7 +687,7 @@ class TestPurchaseOrder(FrappeTestCase):
 				raise Exception
 
 	def test_default_payment_terms(self):
-		due_date = get_due_date_from_template("_Test Payment Term Template 1", "2023-02-03")
+		due_date = get_due_date_from_template("_Test Payment Term Template 1", "2023-02-03", None)
 		self.assertEqual(due_date, "2023-03-31")
 
 	def test_terms_are_not_copied_if_automatically_fetch_payment_terms_is_unchecked(self):


### PR DESCRIPTION
This bugfix fixes the problem currently all workflows fails on the tests:
test_terms_are_not_copied_if_automatically_fetch_payment_terms_is_unchecked
test_terms_copied
test_update_qty

![1](https://user-images.githubusercontent.com/8073152/216580224-1739fc6e-4430-4e1a-a59a-2d341443f913.png)
