### PR TITLE
fix: allow cancelling purchase invoice if linked asset is already cancelled

### DIFF
--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -712,6 +712,8 @@ class BuyingController(SubcontractingController):
 						asset.purchase_date = self.posting_date
 						asset.supplier = self.supplier
 					elif self.docstatus == 2:
+						if asset.docstatus == 2:
+							break
 						if asset.docstatus == 0:
 							asset.set(field, None)
 							asset.supplier = None

--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -713,7 +713,7 @@ class BuyingController(SubcontractingController):
 						asset.supplier = self.supplier
 					elif self.docstatus == 2:
 						if asset.docstatus == 2:
-							break
+							continue
 						if asset.docstatus == 0:
 							asset.set(field, None)
 							asset.supplier = None


### PR DESCRIPTION
Users weren't able to cancel a PI if an asset linked to it if was already cancelled, so fixed that.