### PR TITLE
fix: add payment hook to point of sale JS

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_payment.js
+++ b/erpnext/selling/page/point_of_sale/pos_payment.js
@@ -322,6 +322,11 @@ erpnext.PointOfSale.Payment = class {
 		this.focus_on_default_mop();
 	}
 
+	after_render() {
+		const frm = this.events.get_frm();
+		frm.script_manager.trigger("after_payment_render", frm.doc.doctype, frm.doc.docname);
+	}
+
 	edit_cart() {
 		this.events.toggle_other_sections(false);
 		this.toggle_component(false);
@@ -332,6 +337,7 @@ erpnext.PointOfSale.Payment = class {
 		this.toggle_component(true);
 
 		this.render_payment_section();
+		this.after_render();
 	}
 
 	toggle_remarks_control() {


### PR DESCRIPTION
Allows external modules to be added to the payment page of POS