### PR TITLE
feat: allow arbitrary purchase order items

### DIFF
--- a/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
+++ b/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
@@ -121,7 +121,6 @@
    "oldfieldname": "item_code",
    "oldfieldtype": "Link",
    "options": "Item",
-   "reqd": 1,
    "search_index": 1
   },
   {
@@ -180,7 +179,6 @@
    "oldfieldname": "description",
    "oldfieldtype": "Small Text",
    "print_width": "300px",
-   "reqd": 1,
    "width": "300px"
   },
   {
@@ -249,6 +247,7 @@
    "reqd": 1
   },
   {
+   "default": "1.00",
    "depends_on": "eval:doc.uom != doc.stock_uom",
    "fieldname": "conversion_factor",
    "fieldtype": "Float",
@@ -902,7 +901,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2022-11-29 16:47:41.364387",
+ "modified": "2023-02-08 19:23:43.438844",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Purchase Order Item",

--- a/erpnext/buying/doctype/request_for_quotation_item/request_for_quotation_item.json
+++ b/erpnext/buying/doctype/request_for_quotation_item/request_for_quotation_item.json
@@ -47,7 +47,6 @@
    "oldfieldtype": "Link",
    "options": "Item",
    "print_hide": 1,
-   "reqd": 1,
    "search_index": 1
   },
   {
@@ -84,7 +83,6 @@
    "oldfieldname": "description",
    "oldfieldtype": "Small Text",
    "print_width": "300px",
-   "reqd": 1,
    "width": "300px"
   },
   {
@@ -236,6 +234,7 @@
    "reqd": 1
   },
   {
+   "default": "1.00",
    "fieldname": "conversion_factor",
    "fieldtype": "Float",
    "label": "UOM Conversion Factor",
@@ -261,13 +260,15 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-09-24 17:26:46.276934",
+ "modified": "2023-02-08 20:11:56.099929",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Request for Quotation Item",
+ "naming_rule": "Random",
  "owner": "Administrator",
  "permissions": [],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/erpnext/buying/utils.py
+++ b/erpnext/buying/utils.py
@@ -51,10 +51,11 @@ def validate_for_items(doc) -> None:
 
 		set_stock_levels(row=d)  # update with latest quantities
 		item = validate_item_and_get_basic_data(row=d)
-		validate_stock_item_warehouse(row=d, item=item)
-		validate_end_of_life(d.item_code, item.end_of_life, item.disabled)
-
-		items.append(cstr(d.item_code))
+		# businesses may wish to buy arbitrary items and not set up an item_code
+		if item:
+			validate_stock_item_warehouse(row=d, item=item)
+			validate_end_of_life(d.item_code, item.end_of_life, item.disabled)
+			items.append(cstr(d.item_code))
 
 	if (
 		items
@@ -94,10 +95,8 @@ def validate_item_and_get_basic_data(row) -> Dict:
 		fieldname=["is_stock_item", "is_sub_contracted_item", "end_of_life", "disabled"],
 		as_dict=1,
 	)
-	if not item:
-		frappe.throw(_("Row #{0}: Item {1} does not exist").format(row.idx, frappe.bold(row.item_code)))
-
-	return item[0]
+	if item:
+		return item[0]
 
 
 def validate_stock_item_warehouse(row, item) -> None:

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -426,7 +426,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 
 		item.weight_per_unit = 0;
 		item.weight_uom = '';
-		item.conversion_factor = 0;
+		item.conversion_factor = 1;
 
 		if(['Sales Invoice'].includes(this.frm.doc.doctype)) {
 			update_stock = cint(me.frm.doc.update_stock);

--- a/erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
+++ b/erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
@@ -148,7 +148,6 @@
    "oldfieldtype": "Link",
    "options": "Item",
    "print_width": "100px",
-   "reqd": 1,
    "search_index": 1,
    "width": "100px"
   },
@@ -186,7 +185,6 @@
    "oldfieldname": "description",
    "oldfieldtype": "Text",
    "print_width": "300px",
-   "reqd": 1,
    "width": "300px"
   },
   {
@@ -275,6 +273,7 @@
    "width": "100px"
   },
   {
+   "default": "1.00",
    "depends_on": "eval:doc.uom != doc.stock_uom",
    "fieldname": "conversion_factor",
    "fieldtype": "Float",


### PR DESCRIPTION
Businesses may make arbitrary purchases of lots of items that they do not wish to make item_codes for, for example a prototype manufacturer.

Makes item_code & description non-mandatory, and sets conversion factor default to 1

Also purchase receipt and RFQ

Matches the current Sales and Purchase Invoice behaviour

You might think that you can just customise the doctype, but mandatory cannot be removed from standard fields using customisation.
Another argument for this is that the modules in erpnext were presumably split because they're supposed to be independent and self-contained, but requirements like this creates dependencies between the buying, selling and stock modules which defeats the objective.

Let me know if you want the mandatory properties added as property setters to maintain historic consistency?

version-14-hotfix
version-13-hotfix
no-docs