### PR TITLE
chore: typo in stock_entry get_uom_details

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -2494,7 +2494,7 @@ def get_uom_details(item_code, uom, qty):
 
 	if not conversion_factor:
 		frappe.msgprint(
-			_("UOM coversion factor required for UOM: {0} in Item: {1}").format(uom, item_code)
+			_("UOM conversion factor required for UOM: {0} in Item: {1}").format(uom, item_code)
 		)
 		ret = {"uom": ""}
 	else:


### PR DESCRIPTION
There was a typo in [stock_entry.py](https://github.com/frappe/erpnext/blob/c5834c1db41db1379d428026ce1c8985919ff8b0/erpnext/stock/doctype/stock_entry/stock_entry.py#L2497)

### Before

https://github.com/frappe/erpnext/blob/c5834c1db41db1379d428026ce1c8985919ff8b0/erpnext/stock/doctype/stock_entry/stock_entry.py#L2497

### After
https://github.com/frappe/erpnext/blob/cc55e908f9c252f4032fca53534d9f423f0b4661/erpnext/stock/doctype/stock_entry/stock_entry.py#L2497