### PR TITLE
fix: Ignore mandatory fields while creating tax templates for new companies

### DIFF
--- a/erpnext/setup/setup_wizard/operations/taxes_setup.py
+++ b/erpnext/setup/setup_wizard/operations/taxes_setup.py
@@ -158,6 +158,7 @@ def make_taxes_and_charges_template(company_name, doctype, template):
 	# Ingone validations to make doctypes faster
 	doc.flags.ignore_links = True
 	doc.flags.ignore_validate = True
+	doc.flags.ignore_mandatory = True
 	doc.insert(ignore_permissions=True)
 	return doc
 


### PR DESCRIPTION
Fixes:

<img width="402" alt="image" src="https://user-images.githubusercontent.com/42651287/218158794-8a0bd8e0-04cb-41fa-ab46-37af6814fdfd.png">
