### PR TITLE
Update fields after item row removal

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -118,6 +118,12 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 				erpnext.accounts.dimensions.copy_dimension_from_first_row(frm, cdt, cdn, 'items');
 			}
 		});
+		
+		frappe.ui.form.on(this.frm.doctype + " Item", {
+			items_remove: function(frm, cdt, cdn) {
+				cur_frm.cscript.calculate_taxes_and_totals()
+			}
+		});
 
 		if(this.frm.fields_dict["items"].grid.get_field('batch_no')) {
 			this.frm.set_query("batch_no", "items", function(doc, cdt, cdn) {


### PR DESCRIPTION
Case: when one enters multiple items and then if one item is removed from the child table then all the doctype fields like Quantity and Amount should be updated automatically, instead of the validation at the before save. 

1. Items selected
![Screenshot from 2023-02-13 17-26-05](https://user-images.githubusercontent.com/48860013/218453408-eb4a48c6-e0a5-49b9-b947-6855f0598343.png)

2. One item row being deleted
![Screenshot from 2023-02-13 17-26-15](https://user-images.githubusercontent.com/48860013/218453611-89b1aef4-fcf6-474c-a3db-c191c373a1b6.png)

4. Fields auto updation after row removal
![Screenshot from 2023-02-13 17-26-20](https://user-images.githubusercontent.com/48860013/218453293-b566e53b-38df-4326-be67-eeb44fbc2cd7.png)