### PR TITLE
fix: typeerror on Sales Order analysis report

### DIFF
--- a/erpnext/selling/report/sales_order_analysis/sales_order_analysis.py
+++ b/erpnext/selling/report/sales_order_analysis/sales_order_analysis.py
@@ -175,7 +175,9 @@ def prepare_data(data, so_elapsed_time, filters):
 				# update existing entry
 				so_row = sales_order_map[so_name]
 				so_row["required_date"] = max(getdate(so_row["delivery_date"]), getdate(row["delivery_date"]))
-				so_row["delay"] = min(so_row["delay"], row["delay"])
+				so_row["delay"] = (
+					min(so_row["delay"], row["delay"]) if row["delay"] and so_row["delay"] else so_row["delay"]
+				)
 
 				# sum numeric columns
 				fields = [


### PR DESCRIPTION
If, for some reason delivery date is missing in Sales order, TypeError is thrown on Sales Order Analysis report with 'Group by Sales Order' enabled. Reporting 'null' for delay field is better than throwing typeerror which makes the report usable.

<img width="1021" alt="Screenshot 2023-02-14 at 9 59 26 AM" src="https://user-images.githubusercontent.com/3272205/218639669-ae63e713-a279-4833-98c7-3a6add7745b4.png">
