### PR TITLE
fix: rename duplicate field name with same type into a DocType to avoid import Error

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.json
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.json
@@ -239,7 +239,7 @@
    "depends_on": "paid_from",
    "fieldname": "paid_from_account_currency",
    "fieldtype": "Link",
-   "label": "Account Currency",
+   "label": "Account Currency (From)",
    "options": "Currency",
    "print_hide": 1,
    "read_only": 1,
@@ -249,7 +249,7 @@
    "depends_on": "paid_from",
    "fieldname": "paid_from_account_balance",
    "fieldtype": "Currency",
-   "label": "Account Balance",
+   "label": "Account Balance (From)",
    "options": "paid_from_account_currency",
    "print_hide": 1,
    "read_only": 1
@@ -272,7 +272,7 @@
    "depends_on": "paid_to",
    "fieldname": "paid_to_account_currency",
    "fieldtype": "Link",
-   "label": "Account Currency",
+   "label": "Account Currency (To)",
    "options": "Currency",
    "print_hide": 1,
    "read_only": 1,
@@ -282,7 +282,7 @@
    "depends_on": "paid_to",
    "fieldname": "paid_to_account_balance",
    "fieldtype": "Currency",
-   "label": "Account Balance",
+   "label": "Account Balance (To)",
    "options": "paid_to_account_currency",
    "print_hide": 1,
    "read_only": 1
@@ -304,7 +304,7 @@
   {
    "fieldname": "source_exchange_rate",
    "fieldtype": "Float",
-   "label": "Exchange Rate",
+   "label": "Source Exchange Rate",
    "precision": "9",
    "print_hide": 1,
    "reqd": 1
@@ -334,7 +334,7 @@
   {
    "fieldname": "target_exchange_rate",
    "fieldtype": "Float",
-   "label": "Exchange Rate",
+   "label": "Target Exchange Rate",
    "precision": "9",
    "print_hide": 1,
    "reqd": 1
@@ -633,14 +633,14 @@
    "depends_on": "eval:doc.party_type == 'Supplier'",
    "fieldname": "purchase_taxes_and_charges_template",
    "fieldtype": "Link",
-   "label": "Taxes and Charges Template",
+   "label": "Purchase Taxes and Charges Template",
    "options": "Purchase Taxes and Charges Template"
   },
   {
    "depends_on": "eval: doc.party_type == 'Customer'",
    "fieldname": "sales_taxes_and_charges_template",
    "fieldtype": "Link",
-   "label": "Taxes and Charges Template",
+   "label": "Sales Taxes and Charges Template",
    "options": "Sales Taxes and Charges Template"
   },
   {
@@ -733,7 +733,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2022-12-08 16:25:43.824051",
+ "modified": "2023-02-14 04:52:30.478523",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Entry",

--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.json
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.json
@@ -472,7 +472,7 @@
    "description": "If rate is zero them item will be treated as \"Free Item\"",
    "fieldname": "free_item_rate",
    "fieldtype": "Currency",
-   "label": "Rate"
+   "label": "Rate of Free Item"
   },
   {
    "collapsible": 1,
@@ -608,7 +608,7 @@
  "icon": "fa fa-gift",
  "idx": 1,
  "links": [],
- "modified": "2022-10-13 19:05:35.056304",
+ "modified": "2023-02-14 04:53:34.887358",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Pricing Rule",

--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.json
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.json
@@ -472,7 +472,7 @@
    "description": "If rate is zero them item will be treated as \"Free Item\"",
    "fieldname": "free_item_rate",
    "fieldtype": "Currency",
-   "label": "Rate of Free Item"
+   "label": "Free Item Rate"
   },
   {
    "collapsible": 1,

--- a/erpnext/projects/doctype/project/project.json
+++ b/erpnext/projects/doctype/project/project.json
@@ -408,7 +408,7 @@
    "depends_on": "eval:(doc.frequency == \"Daily\" && doc.collect_progress == true)",
    "fieldname": "daily_time_to_send",
    "fieldtype": "Time",
-   "label": "Time to send"
+   "label": "Daily Time to send"
   },
   {
    "depends_on": "eval:(doc.frequency == \"Weekly\" && doc.collect_progress == true)",
@@ -421,7 +421,7 @@
    "depends_on": "eval:(doc.frequency == \"Weekly\" && doc.collect_progress == true)",
    "fieldname": "weekly_time_to_send",
    "fieldtype": "Time",
-   "label": "Time to send"
+   "label": "Weekly Time to send"
   },
   {
    "fieldname": "column_break_45",
@@ -451,7 +451,7 @@
  "index_web_pages_for_search": 1,
  "links": [],
  "max_attachments": 4,
- "modified": "2022-06-23 16:45:06.108499",
+ "modified": "2023-02-14 04:54:25.819620",
  "modified_by": "Administrator",
  "module": "Projects",
  "name": "Project",

--- a/erpnext/projects/doctype/timesheet/timesheet.json
+++ b/erpnext/projects/doctype/timesheet/timesheet.json
@@ -282,21 +282,21 @@
   {
    "fieldname": "base_total_costing_amount",
    "fieldtype": "Currency",
-   "label": "Total Costing Amount",
+   "label": "Base Total Costing Amount",
    "print_hide": 1,
    "read_only": 1
   },
   {
    "fieldname": "base_total_billable_amount",
    "fieldtype": "Currency",
-   "label": "Total Billable Amount",
+   "label": "Base Total Billable Amount",
    "print_hide": 1,
    "read_only": 1
   },
   {
    "fieldname": "base_total_billed_amount",
    "fieldtype": "Currency",
-   "label": "Total Billed Amount",
+   "label": "Base Total Billed Amount",
    "print_hide": 1,
    "read_only": 1
   },
@@ -311,10 +311,11 @@
  "idx": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2022-06-15 22:08:53.930200",
+ "modified": "2023-02-14 04:55:41.735991",
  "modified_by": "Administrator",
  "module": "Projects",
  "name": "Timesheet",
+ "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
  "permissions": [
   {
@@ -388,5 +389,6 @@
  ],
  "sort_field": "modified",
  "sort_order": "ASC",
+ "states": [],
  "title_field": "title"
 }

--- a/erpnext/stock/doctype/delivery_note/delivery_note.json
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.json
@@ -521,6 +521,7 @@
    "allow_bulk_edit": 1,
    "fieldname": "items",
    "fieldtype": "Table",
+   "label": "Delivery Note Item",
    "oldfieldname": "delivery_note_details",
    "oldfieldtype": "Table",
    "options": "Delivery Note Item",
@@ -666,6 +667,7 @@
   {
    "fieldname": "taxes",
    "fieldtype": "Table",
+   "label": "Sales Taxes and Charges",
    "oldfieldname": "other_charges",
    "oldfieldtype": "Table",
    "options": "Sales Taxes and Charges"
@@ -1401,7 +1403,7 @@
  "idx": 146,
  "is_submittable": 1,
  "links": [],
- "modified": "2022-12-12 18:38:53.067799",
+ "modified": "2023-02-14 04:45:44.179670",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Note",

--- a/erpnext/stock/doctype/item/item.json
+++ b/erpnext/stock/doctype/item/item.json
@@ -706,7 +706,7 @@
    "depends_on": "enable_deferred_expense",
    "fieldname": "no_of_months_exp",
    "fieldtype": "Int",
-   "label": "No of Months (expense)"
+   "label": "No of Months (Expense)"
   },
   {
    "collapsible": 1,

--- a/erpnext/stock/doctype/item/item.json
+++ b/erpnext/stock/doctype/item/item.json
@@ -706,7 +706,7 @@
    "depends_on": "enable_deferred_expense",
    "fieldname": "no_of_months_exp",
    "fieldtype": "Int",
-   "label": "No of Months"
+   "label": "No of Months (expense)"
   },
   {
    "collapsible": 1,
@@ -911,7 +911,7 @@
  "index_web_pages_for_search": 1,
  "links": [],
  "make_attachments_public": 1,
- "modified": "2023-01-07 22:45:00.341745",
+ "modified": "2023-02-14 04:48:26.343620",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Item",


### PR DESCRIPTION
Following #34046 

The fields rename extracted from 

> SELECT df.parent,df.label,df.fieldname,df.fieldtype,count(df.name) FROM tabDocField as df
> INNER JOIN tabDocType as dt on dt.name = df.parent
> WHERE df.parenttype='DocType' AND df.fieldtype NOT IN ('Section Break','Column Break')
> AND dt.allow_import = 1
> GROUP BY df.parent,df.label,df.fieldtype
> HAVING count(df.name)>1

