### PR TITLE
feat: allow to make in transit transfer entry from material request

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -110,8 +110,11 @@ frappe.ui.form.on('Material Request', {
 
 				if (frm.doc.material_request_type === "Material Transfer") {
 					add_create_pick_list_button();
-					frm.add_custom_button(__("Transfer Material"),
+					frm.add_custom_button(__("Material Transfer"),
 						() => frm.events.make_stock_entry(frm), __('Create'));
+
+					frm.add_custom_button(__("Material Transfer (In Transit)"),
+						() => frm.events.make_in_transit_stock_entry(frm), __('Create'));
 				}
 
 				if (frm.doc.material_request_type === "Material Issue") {
@@ -331,6 +334,46 @@ frappe.ui.form.on('Material Request', {
 			method: "erpnext.stock.doctype.material_request.material_request.make_stock_entry",
 			frm: frm
 		});
+	},
+
+	make_in_transit_stock_entry(frm) {
+		frappe.prompt(
+			[
+				{
+					label: __('In Transit Warehouse'),
+					fieldname: 'in_transit_warehouse',
+					fieldtype: 'Link',
+					options: 'Warehouse',
+					reqd: 1,
+					get_query: () => {
+						return{
+							filters: {
+								'company': frm.doc.company,
+								'is_group': 0,
+								'warehouse_type': 'Transit'
+							}
+						}
+					}
+				}
+			],
+			(values) => {
+				frappe.call({
+					method: "erpnext.stock.doctype.material_request.material_request.make_in_transit_stock_entry",
+					args: {
+						source_name: frm.doc.name,
+						in_transit_warehouse: values.in_transit_warehouse
+					},
+					callback: function(r) {
+						if (r.message) {
+							let doc = frappe.model.sync(r.message);
+							frappe.set_route('Form', doc[0].doctype, doc[0].name);
+						}
+					}
+				})
+			},
+			__('In Transit Transfer'),
+			__("Create Stock Entry")
+		)
 	},
 
 	create_pick_list: (frm) => {

--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -716,3 +716,14 @@ def create_pick_list(source_name, target_doc=None):
 	doc.set_item_locations()
 
 	return doc
+
+
+@frappe.whitelist()
+def make_in_transit_stock_entry(source_name, in_transit_warehouse):
+	ste_doc = make_stock_entry(source_name)
+	ste_doc.add_to_transit = 1
+
+	for row in ste_doc.items:
+		row.t_warehouse = in_transit_warehouse
+
+	return ste_doc

--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -11,6 +11,7 @@ from frappe.utils import flt, today
 
 from erpnext.stock.doctype.item.test_item import create_item
 from erpnext.stock.doctype.material_request.material_request import (
+	make_in_transit_stock_entry,
 	make_purchase_order,
 	make_stock_entry,
 	make_supplier_quotation,
@@ -55,6 +56,22 @@ class TestMaterialRequest(FrappeTestCase):
 
 		self.assertEqual(se.doctype, "Stock Entry")
 		self.assertEqual(len(se.get("items")), len(mr.get("items")))
+
+	def test_in_transit_make_stock_entry(self):
+		mr = frappe.copy_doc(test_records[0]).insert()
+
+		self.assertRaises(frappe.ValidationError, make_stock_entry, mr.name)
+
+		mr = frappe.get_doc("Material Request", mr.name)
+		mr.material_request_type = "Material Transfer"
+		mr.submit()
+
+		in_transit_warehouse = get_in_transit_warehouse(mr.company)
+		se = make_in_transit_stock_entry(mr.name, in_transit_warehouse)
+
+		self.assertEqual(se.doctype, "Stock Entry")
+		for row in se.get("items"):
+			self.assertEqual(row.t_warehouse, in_transit_warehouse)
 
 	def _insert_stock_entry(self, qty1, qty2, warehouse=None):
 		se = frappe.get_doc(
@@ -740,6 +757,36 @@ class TestMaterialRequest(FrappeTestCase):
 
 		self.assertEqual(mr.per_ordered, 100)
 		self.assertEqual(existing_requested_qty, current_requested_qty)
+
+
+def get_in_transit_warehouse(company):
+	if not frappe.db.exists("Warehouse Type", "Transit"):
+		frappe.get_doc(
+			{
+				"doctype": "Warehouse Type",
+				"name": "Transit",
+			}
+		).insert()
+
+	in_transit_warehouse = frappe.db.exists(
+		"Warehouse", {"warehouse_type": "Transit", "company": company}
+	)
+
+	if not in_transit_warehouse:
+		in_transit_warehouse = (
+			frappe.get_doc(
+				{
+					"doctype": "Warehouse",
+					"warehouse_name": "Transit",
+					"warehouse_type": "Transit",
+					"company": company,
+				}
+			)
+			.insert()
+			.name
+		)
+
+	return in_transit_warehouse
 
 
 def make_material_request(**args):


### PR DESCRIPTION
**Problem**

Currently there is an option to make Material Transfer entry from Material Request but in this case user has to manually Enable the checkbox "Add to Transit" on the stock entry and also they need to manually change the target warehouse to In Transit Warehouse.

**After Change** 

Added option to make In Transit Stock Entry for Material Transfer
<img width="1310" alt="Screenshot 2023-02-14 at 6 18 23 PM" src="https://user-images.githubusercontent.com/8780500/218754278-213dd2b4-654f-4a21-a317-e787fe11309d.png">


On click of "Material Transfer (In Transit)" button, system will ask user to select the In Transit Warehouse
<img width="860" alt="Screenshot 2023-02-14 at 6 18 27 PM" src="https://user-images.githubusercontent.com/8780500/218754364-aa11e129-1234-4ead-a537-39f5c023d888.png">




