### PR TITLE
fix: change parameter name for letter head

### DIFF
--- a/erpnext/buying/doctype/request_for_quotation/request_for_quotation.js
+++ b/erpnext/buying/doctype/request_for_quotation/request_for_quotation.js
@@ -124,7 +124,6 @@ frappe.ui.form.on("Request for Quotation",{
 								frappe.urllib.get_full_url(
 									"/api/method/erpnext.buying.doctype.request_for_quotation.request_for_quotation.get_pdf?" +
 									new URLSearchParams({
-										doctype: frm.doc.doctype,
 										name: frm.doc.name,
 										supplier: data.supplier,
 										print_format: data.print_format || "Standard",

--- a/erpnext/buying/doctype/request_for_quotation/request_for_quotation.js
+++ b/erpnext/buying/doctype/request_for_quotation/request_for_quotation.js
@@ -129,7 +129,7 @@ frappe.ui.form.on("Request for Quotation",{
 										supplier: data.supplier,
 										print_format: data.print_format || "Standard",
 										language: data.language || frappe.boot.lang,
-										letter_head: data.letter_head || frm.doc.letter_head || "",
+										letterhead: data.letter_head || frm.doc.letter_head || "",
 									}).toString()
 								)
 							);

--- a/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
+++ b/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
@@ -3,6 +3,7 @@
 
 
 import json
+from typing import Optional
 
 import frappe
 from frappe import _
@@ -388,24 +389,26 @@ def create_rfq_items(sq_doc, supplier, data):
 
 
 @frappe.whitelist()
-def get_pdf(doctype, name, supplier, print_format=None, language=None, letterhead=None):
-	# permissions get checked in `download_pdf`
-	if doc := get_rfq_doc(doctype, name, supplier):
-		download_pdf(
-			doctype,
-			name,
-			print_format,
-			doc=doc,
-			language=language,
-			letterhead=letterhead or None,
-		)
-
-
-def get_rfq_doc(doctype, name, supplier):
+def get_pdf(
+	name: str,
+	supplier: str,
+	print_format: Optional[str] = None,
+	language: Optional[str] = None,
+	letterhead: Optional[str] = None,
+):
+	doc = frappe.get_doc("Request for Quotation", name)
 	if supplier:
-		doc = frappe.get_doc(doctype, name)
 		doc.update_supplier_part_no(supplier)
-		return doc
+
+	# permissions get checked in `download_pdf`
+	download_pdf(
+		doc.doctype,
+		doc.name,
+		print_format,
+		doc=doc,
+		language=language,
+		letterhead=letterhead or None,
+	)
 
 
 @frappe.whitelist()

--- a/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
+++ b/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
@@ -388,7 +388,7 @@ def create_rfq_items(sq_doc, supplier, data):
 
 
 @frappe.whitelist()
-def get_pdf(doctype, name, supplier, print_format=None, language=None, letter_head=None):
+def get_pdf(doctype, name, supplier, print_format=None, language=None, letterhead=None):
 	# permissions get checked in `download_pdf`
 	if doc := get_rfq_doc(doctype, name, supplier):
 		download_pdf(
@@ -397,7 +397,7 @@ def get_pdf(doctype, name, supplier, print_format=None, language=None, letter_he
 			print_format,
 			doc=doc,
 			language=language,
-			letter_head=letter_head or None,
+			letterhead=letterhead or None,
 		)
 
 

--- a/erpnext/buying/doctype/request_for_quotation/test_request_for_quotation.py
+++ b/erpnext/buying/doctype/request_for_quotation/test_request_for_quotation.py
@@ -8,6 +8,7 @@ from frappe.utils import nowdate
 
 from erpnext.buying.doctype.request_for_quotation.request_for_quotation import (
 	create_supplier_quotation,
+	get_pdf,
 	make_supplier_quotation_from_rfq,
 )
 from erpnext.crm.doctype.opportunity.opportunity import make_request_for_quotation as make_rfq
@@ -123,6 +124,11 @@ class TestRequestforQuotation(FrappeTestCase):
 
 		rfq.status = "Draft"
 		rfq.submit()
+
+	def test_get_pdf(self):
+		rfq = make_request_for_quotation()
+		get_pdf(rfq.name, rfq.get("suppliers")[0].supplier)
+		self.assertEqual(frappe.local.response.type, "pdf")
 
 
 def make_request_for_quotation(**args):


### PR DESCRIPTION
To match changes from https://github.com/frappe/frappe/pull/19627 . Added a test to make sure we'll notice this earlier in the future.

Also added type hints, removed the slightly dangerous `doctype` parameter and got rid of a helper function that didn't help very much. This slightly changes the logic in the following ways: we cannot pass arbitrary `doctype` anymore and it won't fail on empty `supplier`.