### PR TITLE
fix: show Purchase Order Portal `Pay` button based on configuration

### DIFF
--- a/erpnext/buying/doctype/buying_settings/buying_settings.json
+++ b/erpnext/buying/doctype/buying_settings/buying_settings.json
@@ -21,6 +21,7 @@
   "allow_multiple_items",
   "bill_for_rejected_quantity_in_purchase_invoice",
   "disable_last_purchase_rate",
+  "show_pay_button",
   "subcontract",
   "backflush_raw_materials_of_subcontract_based_on",
   "column_break_11",
@@ -140,6 +141,12 @@
    "fieldname": "disable_last_purchase_rate",
    "fieldtype": "Check",
    "label": "Disable Last Purchase Rate"
+  },
+  {
+   "default": "1",
+   "fieldname": "show_pay_button",
+   "fieldtype": "Check",
+   "label": "Show Pay Button in Purchase Order Portal"
   }
  ],
  "icon": "fa fa-cog",
@@ -147,7 +154,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-01-09 17:08:28.828173",
+ "modified": "2023-02-15 14:42:10.200679",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Buying Settings",

--- a/erpnext/templates/pages/order.html
+++ b/erpnext/templates/pages/order.html
@@ -34,16 +34,18 @@
 				</a>
 			</ul>
 		</div>
-		<div class="form-column col-sm-6">
-			<div class="page-header-actions-block" data-html-block="header-actions">
-				<p>
-					<a href="/api/method/erpnext.accounts.doctype.payment_request.payment_request.make_payment_request?dn={{ doc.name }}&dt={{ doc.doctype }}&submit_doc=1&order_type=Shopping Cart"
-						class="btn btn-primary btn-sm" id="pay-for-order">
-						{{ _("Pay") }} {{doc.get_formatted("grand_total") }}
-					</a>
-				</p>
+		{% if show_pay_button %}
+			<div class="form-column col-sm-6">
+				<div class="page-header-actions-block" data-html-block="header-actions">
+					<p>
+						<a href="/api/method/erpnext.accounts.doctype.payment_request.payment_request.make_payment_request?dn={{ doc.name }}&dt={{ doc.doctype }}&submit_doc=1&order_type=Shopping Cart"
+							class="btn btn-primary btn-sm" id="pay-for-order">
+							{{ _("Pay") }} {{doc.get_formatted("grand_total") }}
+						</a>
+					</p>
+				</div>
 			</div>
-		</div>
+		{% endif %}
 	</div>
 {% endblock %}
 

--- a/erpnext/templates/pages/order.py
+++ b/erpnext/templates/pages/order.py
@@ -55,6 +55,7 @@ def get_context(context):
 			)
 			context.available_loyalty_points = int(loyalty_program_details.get("loyalty_points"))
 
+	context.show_pay_button = frappe.db.get_single_value("Buying Settings", "show_pay_button")
 	context.show_make_pi_button = False
 	if context.doc.get("supplier"):
 		# show Make Purchase Invoice button based on permission


### PR DESCRIPTION
**source/ref:** ISS-22-23-05031

**Changes:**

- Add `show_pay_button` field in `Buying Settings`.

  ![image](https://user-images.githubusercontent.com/63660334/218990462-591bbf1e-b365-420d-aeb3-3134c84e4294.png)

- Show the `Pay` button in the Purchase Order Portal based on the configuration from `Buying Settings`

  ![image](https://user-images.githubusercontent.com/63660334/218990173-3dad655b-736c-4b3f-a052-edbbd2d27e9b.png)



