### PR TITLE
Allow bulk import of party specific item

### DIFF
--- a/erpnext/selling/doctype/party_specific_item/party_specific_item.json
+++ b/erpnext/selling/doctype/party_specific_item/party_specific_item.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_import": 1,
  "creation": "2021-08-27 19:28:07.559978",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -51,7 +52,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2021-09-14 13:27:58.612334",
+ "modified": "2023-02-15 13:00:50.379713",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Party Specific Item",
@@ -72,6 +73,7 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "title_field": "party",
  "track_changes": 1
 }


### PR DESCRIPTION
- Currently, `Party Specific Item` does not have `Allow Data Import` enabled. This makes creating multiple mappings quite cumbersome.
- This is a minor PR modifying the doctype to enable bulk import.