### PR TITLE
fix: create `Delivery Trip` from `Delivery Note` list

### DIFF
--- a/erpnext/stock/doctype/delivery_note/delivery_note_list.js
+++ b/erpnext/stock/doctype/delivery_note/delivery_note_list.js
@@ -14,7 +14,7 @@ frappe.listview_settings['Delivery Note'] = {
 			return [__("Completed"), "green", "per_billed,=,100"];
 		}
 	},
-	onload: function (listview) {
+	onload: function (doclist) {
 		const action = () => {
 			const selected_docs = doclist.get_checked_items();
 			const docnames = doclist.get_checked_items(true);
@@ -56,14 +56,14 @@ frappe.listview_settings['Delivery Note'] = {
 
 		// doclist.page.add_actions_menu_item(__('Create Delivery Trip'), action, false);
 
-		listview.page.add_action_item(__('Create Delivery Trip'), action);
+		doclist.page.add_action_item(__('Create Delivery Trip'), action);
 
-		listview.page.add_action_item(__("Sales Invoice"), ()=>{
-			erpnext.bulk_transaction_processing.create(listview, "Delivery Note", "Sales Invoice");
+		doclist.page.add_action_item(__("Sales Invoice"), ()=>{
+			erpnext.bulk_transaction_processing.create(doclist, "Delivery Note", "Sales Invoice");
 		});
 
-		listview.page.add_action_item(__("Packaging Slip From Delivery Note"), ()=>{
-			erpnext.bulk_transaction_processing.create(listview, "Delivery Note", "Packing Slip");
+		doclist.page.add_action_item(__("Packaging Slip From Delivery Note"), ()=>{
+			erpnext.bulk_transaction_processing.create(doclist, "Delivery Note", "Packing Slip");
 		});
 	}
 };


### PR DESCRIPTION
- **Before:**

  [Screencast from 2023-02-15 22-11-58.webm](https://user-images.githubusercontent.com/63660334/219094569-abe9c37b-baee-4877-9cd7-f3509d663d22.webm)

- **After:**

  [Screencast from 2023-02-15 22-12-44.webm](https://user-images.githubusercontent.com/63660334/219094751-42e716ad-7b91-47db-862a-c98f1e76aa0c.webm)


closes: https://github.com/frappe/erpnext/issues/33930

