### PR TITLE
fix: incorrect consumed qty in subcontracting receipt

### DIFF
--- a/erpnext/controllers/subcontracting_controller.py
+++ b/erpnext/controllers/subcontracting_controller.py
@@ -409,7 +409,14 @@ class SubcontractingController(StockController):
 		if self.available_materials.get(key) and self.available_materials[key]["batch_no"]:
 			new_rm_obj = None
 			for batch_no, batch_qty in self.available_materials[key]["batch_no"].items():
-				if batch_qty >= qty:
+				if batch_qty >= qty or (
+					rm_obj.consumed_qty == 0
+					and self.backflush_based_on == "BOM"
+					and len(self.available_materials[key]["batch_no"]) == 1
+				):
+					if rm_obj.consumed_qty == 0:
+						self.__set_consumed_qty(rm_obj, qty)
+
 					self.__set_batch_no_as_per_qty(item_row, rm_obj, batch_no, qty)
 					self.available_materials[key]["batch_no"][batch_no] -= qty
 					return


### PR DESCRIPTION
**Issue**

1. Set "Backflush Raw Materials of Subcontract Based On" as "BOM" in the buying settings, 
2. Make sure raw materials are having batches 
3. Transferred raw materials less to the supplier through stock entry
4. While making subcontracting receipt, you will notice extra row with zero consumed qty

<img width="1144" alt="Screenshot 2023-02-16 at 1 23 10 PM" src="https://user-images.githubusercontent.com/8780500/219302840-83f0b571-9b99-45af-87d7-c7ab0895eb23.png">
