### PR TITLE
fix: repair status after deletion, asset status after manual depr entry and other misc bugs [v14]

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -238,21 +238,16 @@ class JournalEntry(AccountsController):
 			):
 				processed_assets.append(d.reference_name)
 
-				asset = frappe.db.get_value(
-					"Asset", d.reference_name, ["calculate_depreciation", "value_after_depreciation"], as_dict=1
-				)
+				asset = frappe.get_doc("Asset", d.reference_name)
 
 				if asset.calculate_depreciation:
 					continue
 
 				depr_value = d.debit or d.credit
 
-				frappe.db.set_value(
-					"Asset",
-					d.reference_name,
-					"value_after_depreciation",
-					asset.value_after_depreciation - depr_value,
-				)
+				asset.db_set("value_after_depreciation", asset.value_after_depreciation - depr_value)
+
+				asset.set_status()
 
 	def update_inter_company_jv(self):
 		if (
@@ -341,12 +336,9 @@ class JournalEntry(AccountsController):
 				else:
 					depr_value = d.debit or d.credit
 
-					frappe.db.set_value(
-						"Asset",
-						d.reference_name,
-						"value_after_depreciation",
-						asset.value_after_depreciation + depr_value,
-					)
+					asset.db_set("value_after_depreciation", asset.value_after_depreciation + depr_value)
+
+					asset.set_status()
 
 	def unlink_inter_company_jv(self):
 		if (

--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -250,7 +250,7 @@ frappe.ui.form.on('Asset', {
 			$.each(depr_entries || [], function(i, v) {
 				x_intervals.push(frappe.format(v.posting_date, { fieldtype: 'Date' }));
 				let last_asset_value = asset_values[asset_values.length - 1]
-				asset_values.push(last_asset_value - v.value);
+				asset_values.push(flt(last_asset_value - v.value, precision('gross_purchase_amount')));
 			});
 		}
 

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -677,11 +677,15 @@ class Asset(AccountsController):
 
 			if self.journal_entry_for_scrap:
 				status = "Scrapped"
-			elif self.finance_books:
-				idx = self.get_default_finance_book_idx() or 0
+			else:
+				expected_value_after_useful_life = 0
+				value_after_depreciation = self.value_after_depreciation
 
-				expected_value_after_useful_life = self.finance_books[idx].expected_value_after_useful_life
-				value_after_depreciation = self.finance_books[idx].value_after_depreciation
+				if self.calculate_depreciation:
+					idx = self.get_default_finance_book_idx() or 0
+
+					expected_value_after_useful_life = self.finance_books[idx].expected_value_after_useful_life
+					value_after_depreciation = self.finance_books[idx].value_after_depreciation
 
 				if flt(value_after_depreciation) <= expected_value_after_useful_life:
 					status = "Fully Depreciated"
@@ -843,6 +847,7 @@ class Asset(AccountsController):
 			.where(gle.debit != 0)
 			.where(gle.is_cancelled == 0)
 			.orderby(gle.posting_date)
+			.orderby(gle.creation)
 		).run(as_dict=True)
 
 		return records

--- a/erpnext/assets/doctype/asset/depreciation.py
+++ b/erpnext/assets/doctype/asset/depreciation.py
@@ -137,7 +137,7 @@ def make_depreciation_entry(asset_name, date=None):
 			finance_books.value_after_depreciation -= d.depreciation_amount
 			finance_books.db_update()
 
-	frappe.db.set_value("Asset", asset_name, "depr_entry_posting_status", "Successful")
+	asset.db_set("depr_entry_posting_status", "Successful")
 
 	asset.set_status()
 

--- a/erpnext/assets/doctype/asset_repair/asset_repair.py
+++ b/erpnext/assets/doctype/asset_repair/asset_repair.py
@@ -77,6 +77,9 @@ class AssetRepair(AccountsController):
 		self.asset_doc.prepare_depreciation_data()
 		self.asset_doc.save()
 
+	def after_delete(self):
+		frappe.get_doc("Asset", self.asset).set_status()
+
 	def check_repair_status(self):
 		if self.repair_status == "Pending":
 			frappe.throw(_("Please update Repair Status."))


### PR DESCRIPTION
- When the Asset Repair Status is changed to `Completed`/`Cancelled` and the doc is submitted, the asset's status is changed (not `Out of Order` anymore). But the status doesn't change when the Asset Repair doc is directly deleted -- it remains `Out of Order`, so fixed that
- After doing a manual depreciation entry for an asset, the status remains `Submitted`. It should change to `Partially Depreciated` or `Fully Depreciated`, so fixed that
- If multiple manual depr entries are created on same date, order by creation date
- Fixed minor rounding issue in asset chart