### PR TITLE
fix(ux): customer/supplier docfield layout

### DIFF
--- a/erpnext/buying/doctype/supplier/supplier.json
+++ b/erpnext/buying/doctype/supplier/supplier.json
@@ -23,7 +23,6 @@
   "default_bank_account",
   "column_break_10",
   "default_price_list",
-  "payment_terms",
   "internal_supplier_section",
   "is_internal_supplier",
   "represents_company",
@@ -53,6 +52,7 @@
   "supplier_primary_address",
   "primary_address",
   "accounting_tab",
+  "payment_terms",
   "accounts",
   "settings_tab",
   "allow_purchase_invoice_creation_without_purchase_order",
@@ -457,11 +457,10 @@
    "link_fieldname": "party"
   }
  ],
- "modified": "2022-11-09 18:02:59.075203",
+ "modified": "2023-02-18 11:05:50.592270",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Supplier",
- "name_case": "Title Case",
  "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
  "permissions": [

--- a/erpnext/selling/doctype/customer/customer.json
+++ b/erpnext/selling/doctype/customer/customer.json
@@ -24,10 +24,10 @@
   "account_manager",
   "image",
   "defaults_tab",
-  "default_price_list",
+  "default_currency",
   "default_bank_account",
   "column_break_14",
-  "default_currency",
+  "default_price_list",
   "internal_customer_section",
   "is_internal_customer",
   "represents_company",
@@ -568,11 +568,10 @@
    "link_fieldname": "party"
   }
  ],
- "modified": "2022-11-08 15:52:34.462657",
+ "modified": "2023-02-18 11:04:46.343527",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Customer",
- "name_case": "Title Case",
  "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
  "permissions": [


### PR DESCRIPTION
Moved the layout so similar fields between customer and supplier are in the same position.

![image](https://user-images.githubusercontent.com/29856401/219876169-3813c04e-f55a-4499-98e7-acb87ebd9f30.png)

![image](https://user-images.githubusercontent.com/29856401/219876212-8f007cc7-2705-4b96-9d40-bf78835e5396.png)
