### PR TITLE
fix: fiscal year error for existing assets in fixed asset register

### DIFF
--- a/erpnext/assets/report/fixed_asset_register/fixed_asset_register.py
+++ b/erpnext/assets/report/fixed_asset_register/fixed_asset_register.py
@@ -151,6 +151,7 @@ def prepare_chart_data(data, filters):
 		filters.filter_based_on,
 		"Monthly",
 		company=filters.company,
+		ignore_fiscal_year=True,
 	)
 
 	for d in period_list:


### PR DESCRIPTION
In the fixed asset register, when users set a date range like `01-04-2006` - `21-02-2023` to see existing assets purchased way back (like in 2007), the fixed asset register throws a `Date 30-04-2006 is not in any active fiscal year for company`. Fixed this, so now they don't need to create old fiscal years just to see existing assets in the register.