### PR TITLE
fix: zero division error while making LCV

### DIFF
--- a/erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.py
+++ b/erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.py
@@ -55,7 +55,6 @@ class LandedCostVoucher(Document):
 			self.get_items_from_purchase_receipts()
 
 		self.set_applicable_charges_on_item()
-		self.validate_applicable_charges_for_item()
 
 	def check_mandatory(self):
 		if not self.get("purchase_receipts"):
@@ -115,6 +114,13 @@ class LandedCostVoucher(Document):
 				total_item_cost += item.get(based_on_field)
 
 			for item in self.get("items"):
+				if not total_item_cost and not item.get(based_on_field):
+					frappe.throw(
+						_(
+							"It's not possible to distribute charges equally when total amount is zero, please set 'Distribute Charges Based On' as 'Quantity'"
+						)
+					)
+
 				item.applicable_charges = flt(
 					flt(item.get(based_on_field)) * (flt(self.total_taxes_and_charges) / flt(total_item_cost)),
 					item.precision("applicable_charges"),
@@ -162,6 +168,7 @@ class LandedCostVoucher(Document):
 			)
 
 	def on_submit(self):
+		self.validate_applicable_charges_for_item()
 		self.update_landed_cost()
 
 	def on_cancel(self):

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -1121,13 +1121,25 @@ def get_item_account_wise_additional_cost(purchase_document):
 						account.expense_account, {"amount": 0.0, "base_amount": 0.0}
 					)
 
-					item_account_wise_cost[(item.item_code, item.purchase_receipt_item)][account.expense_account][
-						"amount"
-					] += (account.amount * item.get(based_on_field) / total_item_cost)
+					if total_item_cost > 0:
+						item_account_wise_cost[(item.item_code, item.purchase_receipt_item)][
+							account.expense_account
+						]["amount"] += (
+							account.amount * item.get(based_on_field) / total_item_cost
+						)
 
-					item_account_wise_cost[(item.item_code, item.purchase_receipt_item)][account.expense_account][
-						"base_amount"
-					] += (account.base_amount * item.get(based_on_field) / total_item_cost)
+						item_account_wise_cost[(item.item_code, item.purchase_receipt_item)][
+							account.expense_account
+						]["base_amount"] += (
+							account.base_amount * item.get(based_on_field) / total_item_cost
+						)
+					else:
+						item_account_wise_cost[(item.item_code, item.purchase_receipt_item)][
+							account.expense_account
+						]["amount"] += item.applicable_charges
+						item_account_wise_cost[(item.item_code, item.purchase_receipt_item)][
+							account.expense_account
+						]["base_amount"] += item.applicable_charges
 
 	return item_account_wise_cost
 


### PR DESCRIPTION
Steps to replicate issue

1. Created Purchase Receipt with Zero Rate
2. Created Landed cost voucher against zero rate Purchase Receipt
3. Select "Distribute Charges Based On" as "Distribute Manually"
4. Set Applicable Charges as 30
5. While submitting the landed cost voucher system throwing an error "Zero Division Error"

<img width="1215" alt="Screenshot 2023-02-22 at 10 49 25 AM" src="https://user-images.githubusercontent.com/8780500/220558956-a69c27e0-71b5-400c-a3e5-ad3588cef495.png">
