### PR TITLE
fix: ui freeze upon item selection in sales invoice

### DIFF
--- a/erpnext/selling/sales_common.js
+++ b/erpnext/selling/sales_common.js
@@ -418,8 +418,6 @@ erpnext.selling.SellingController = class SellingController extends erpnext.Tran
 			callback: function(r) {
 				if(r.message) {
 					frappe.model.set_value(doc.doctype, doc.name, 'batch_no', r.message);
-				} else {
-				    frappe.model.set_value(doc.doctype, doc.name, 'batch_no', r.message);
 				}
 			}
 		});


### PR DESCRIPTION
**Issue:** Desk UI Freezes when selecting an item in Sales Invoice. 
Possible Fix: Call to `get_batch_no` doesn't return any valid data. Yet, the else block sets 'batch_no' to undefined.