### PR TITLE
fix(patch): create only 80G custom fields instead of running the whole setup

### DIFF
--- a/erpnext/patches/v13_0/setup_fields_for_80g_certificate_and_donation.py
+++ b/erpnext/patches/v13_0/setup_fields_for_80g_certificate_and_donation.py
@@ -1,16 +1,61 @@
 import frappe
-
-from erpnext.regional.india.setup import make_custom_fields
+from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 
 
 def execute():
 	if frappe.get_all("Company", filters={"country": "India"}):
-		frappe.reload_doc("accounts", "doctype", "POS Invoice")
-		frappe.reload_doc("accounts", "doctype", "POS Invoice Item")
-
-		make_custom_fields()
+		custom_fields = get_non_profit_custom_fields()
+		create_custom_fields(custom_fields, update=True)
 
 		if not frappe.db.exists("Party Type", "Donor"):
 			frappe.get_doc(
 				{"doctype": "Party Type", "party_type": "Donor", "account_type": "Receivable"}
-			).insert(ignore_permissions=True)
+			).insert(ignore_permissions=True, ignore_mandatory=True)
+
+
+def get_non_profit_custom_fields():
+	return {
+		"Company": [
+			{
+				"fieldname": "non_profit_section",
+				"label": "Non Profit Settings",
+				"fieldtype": "Section Break",
+				"insert_after": "asset_received_but_not_billed",
+				"collapsible": 1,
+			},
+			{
+				"fieldname": "company_80g_number",
+				"label": "80G Number",
+				"fieldtype": "Data",
+				"insert_after": "non_profit_section",
+			},
+			{
+				"fieldname": "with_effect_from",
+				"label": "80G With Effect From",
+				"fieldtype": "Date",
+				"insert_after": "company_80g_number",
+			},
+			{
+				"fieldname": "pan_details",
+				"label": "PAN Number",
+				"fieldtype": "Data",
+				"insert_after": "with_effect_from",
+			},
+		],
+		"Member": [
+			{
+				"fieldname": "pan_number",
+				"label": "PAN Details",
+				"fieldtype": "Data",
+				"insert_after": "email_id",
+			},
+		],
+		"Donor": [
+			{
+				"fieldname": "pan_number",
+				"label": "PAN Details",
+				"fieldtype": "Data",
+				"insert_after": "email",
+			},
+		],
+	}


### PR DESCRIPTION
v12 -> v13 migration breaking

<details>
<summary>Traceback</summary>

```python
Executing erpnext.patches.v13_0.setup_fields_for_80g_certificate_and_donation in nexxbasetest.frappe.cloud (_28561ebd9aefea1c)

Traceback (most recent call last):
  File "/usr/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 110, in <module>
    main()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/utils/bench_helper.py", line 20, in main
    click.Group(commands=commands)(prog_name="bench")
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/__init__.py", line 31, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/commands/site.py", line 433, in migrate
    migrate(context.verbose, skip_failing=skip_failing, skip_search_index=skip_search_index)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/migrate.py", line 69, in migrate
    frappe.modules.patch_handler.run_all(skip_failing)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 47, in run_all
    run_patch(patch)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 36, in run_patch
    if not run_single(patchmodule=patch):
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 81, in run_single
    return execute_patch(patchmodule, method, methodargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/modules/patch_handler.py", line 105, in execute_patch
    frappe.get_attr(patchmodule.split()[0] + ".execute")()
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/patches/v13_0/setup_fields_for_80g_certificate_and_donation.py", line 11, in execute
    make_custom_fields()
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/regional/india/setup.py", line 169, in make_custom_fields
    create_custom_fields(custom_fields, update=update)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/custom/doctype/custom_field/custom_field.py", line 212, in create_custom_fields
    custom_field.save()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 312, in save
    return self._save(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 366, in _save
    self.run_post_save_methods()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1087, in run_post_save_methods
    self.run_method("on_update")
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 943, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1264, in composer
    return composed(self, method, *args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1246, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 940, in fn
    return method_object(*args, **kwargs)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/custom/doctype/custom_field/custom_field.py", line 92, in on_update
    frappe.db.updatedb(self.dt)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/mariadb/database.py", line 345, in updatedb
    db_table.sync()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/schema.py", line 45, in sync
    self.alter()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/mariadb/schema.py", line 132, in alter
    raise e
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/mariadb/schema.py", line 116, in alter
    frappe.db.sql(query)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/database.py", line 193, in sql
    self._cursor.execute(query)
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/pymysql/cursors.py", line 148, in execute
    result = self._query(query)
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/pymysql/cursors.py", line 310, in _query
    conn.query(q)
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/pymysql/connections.py", line 548, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/pymysql/connections.py", line 775, in _read_query_result
    result.read()
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/pymysql/connections.py", line 1156, in read
    first_packet = self.connection._read_packet()
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/pymysql/connections.py", line 725, in _read_packet
    packet.raise_for_error()
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/pymysql/protocol.py", line 221, in raise_for_error
    err.raise_mysql_exception(self._data)
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/pymysql/err.py", line 143, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.OperationalError: (1292, "Truncated incorrect DECIMAL value: '6,416.87'")
```
</details>

Patch tries to install all regional custom fields. Install only what's required for the non profit setup