### PR TITLE
fix: Performance improvement when adding a new item

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -488,7 +488,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 								() => {
 									var d = locals[cdt][cdn];
 									me.add_taxes_from_item_tax_template(d.item_tax_rate);
-									if (d.free_item_data) {
+									if (d.free_item_data && d.free_item_data.length > 0) {
 										me.apply_product_discount(d);
 									}
 								},


### PR DESCRIPTION
When I have a sale with many items, in my test case I had 40 items.

Whenever I entered the "apply_product_discount" method, it took about 400ms to execute this method, considering that nothing is done in there and the slowdown is caused by "refresh_field('items');" which is within this method.

So for better performance when including the item, it will call "apply_product_discount" only when it should be called.

PS: As the javascript runs on the client's machine, and usually the client's machine is not very good, this can take more than a few seconds.

I have:
i7 10700k
32GB ram
SSD