### PR TITLE
fix: asset manual depr schedule

### DIFF
--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -567,19 +567,23 @@ frappe.ui.form.on('Depreciation Schedule', {
 	},
 
 	depreciation_amount: function(frm, cdt, cdn) {
-		erpnext.asset.set_accumulated_depreciation(frm);
+		erpnext.asset.set_accumulated_depreciation(frm, locals[cdt][cdn].finance_book_id);
 	}
 
-})
+});
 
-erpnext.asset.set_accumulated_depreciation = function(frm) {
-	if(frm.doc.depreciation_method != "Manual") return;
+erpnext.asset.set_accumulated_depreciation = function(frm, finance_book_id) {
+	var depreciation_method = frm.doc.finance_books[Number(finance_book_id) - 1].depreciation_method;
+
+	if(depreciation_method != "Manual") return;
 
 	var accumulated_depreciation = flt(frm.doc.opening_accumulated_depreciation);
+
 	$.each(frm.doc.schedules || [], function(i, row) {
-		accumulated_depreciation  += flt(row.depreciation_amount);
-		frappe.model.set_value(row.doctype, row.name,
-			"accumulated_depreciation_amount", accumulated_depreciation);
+		if (row.finance_book_id === finance_book_id) {
+			accumulated_depreciation  += flt(row.depreciation_amount);
+			frappe.model.set_value(row.doctype, row.name, "accumulated_depreciation_amount", accumulated_depreciation);
+		};
 	})
 };
 

--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -302,10 +302,6 @@ frappe.ui.form.on('Asset', {
 		// frm.toggle_reqd("next_depreciation_date", (!frm.doc.is_existing_asset && frm.doc.calculate_depreciation));
 	},
 
-	opening_accumulated_depreciation: function(frm) {
-		erpnext.asset.set_accumulated_depreciation(frm);
-	},
-
 	make_schedules_editable: function(frm) {
 		if (frm.doc.finance_books) {
 			var is_editable = frm.doc.finance_books.filter(d => d.depreciation_method == "Manual").length > 0

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -102,29 +102,33 @@ class Asset(AccountsController):
 		if not old_asset_doc:
 			return True
 
-		if (
+		have_asset_details_been_modified = (
 			old_asset_doc.gross_purchase_amount != self.gross_purchase_amount
 			or old_asset_doc.opening_accumulated_depreciation != self.opening_accumulated_depreciation
 			or old_asset_doc.number_of_depreciations_booked != self.number_of_depreciations_booked
-		):
+		)
+
+		if have_asset_details_been_modified:
 			return True
 
 		manual_fb_idx = -1
 		for d in self.finance_books:
 			if d.depreciation_method == "Manual":
-				manual_fb_idx = d.idx
+				manual_fb_idx = d.idx - 1
 
-		if (
+		no_manual_depr_or_have_manual_depr_details_been_modified = (
 			manual_fb_idx == -1
-			or old_asset_doc.finance_books[manual_fb_idx - 1].total_number_of_depreciations
-			!= self.finance_books[manual_fb_idx - 1].total_number_of_depreciations
-			or old_asset_doc.finance_books[manual_fb_idx - 1].frequency_of_depreciation
-			!= self.finance_books[manual_fb_idx - 1].frequency_of_depreciation
-			or old_asset_doc.finance_books[manual_fb_idx - 1].depreciation_start_date
-			!= getdate(self.finance_books[manual_fb_idx - 1].depreciation_start_date)
-			or old_asset_doc.finance_books[manual_fb_idx - 1].expected_value_after_useful_life
-			!= self.finance_books[manual_fb_idx - 1].expected_value_after_useful_life
-		):
+			or old_asset_doc.finance_books[manual_fb_idx].total_number_of_depreciations
+			!= self.finance_books[manual_fb_idx].total_number_of_depreciations
+			or old_asset_doc.finance_books[manual_fb_idx].frequency_of_depreciation
+			!= self.finance_books[manual_fb_idx].frequency_of_depreciation
+			or old_asset_doc.finance_books[manual_fb_idx].depreciation_start_date
+			!= getdate(self.finance_books[manual_fb_idx].depreciation_start_date)
+			or old_asset_doc.finance_books[manual_fb_idx].expected_value_after_useful_life
+			!= self.finance_books[manual_fb_idx].expected_value_after_useful_life
+		)
+
+		if no_manual_depr_or_have_manual_depr_details_been_modified:
 			return True
 
 		return False

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -85,7 +85,10 @@ class Asset(AccountsController):
 			self.value_after_depreciation = 0
 			self.set_depreciation_rate()
 			if not (
-				self.get("schedules") and "Manual" in [d.depreciation_method for d in self.finance_books]
+				self.get("schedules")
+				and "Manual" in [d.depreciation_method for d in self.finance_books]
+				and self.get_doc_before_save().opening_accumulated_depreciation
+				== self.opening_accumulated_depreciation
 			):
 				self.make_depreciation_schedule(date_of_disposal)
 				self.set_accumulated_depreciation(date_of_disposal, date_of_return)

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -84,12 +84,7 @@ class Asset(AccountsController):
 		if self.calculate_depreciation:
 			self.value_after_depreciation = 0
 			self.set_depreciation_rate()
-			if not (
-				self.get("schedules")
-				and "Manual" in [d.depreciation_method for d in self.finance_books]
-				and self.get_doc_before_save().opening_accumulated_depreciation
-				== self.opening_accumulated_depreciation
-			):
+			if self.should_prepare_depreciation_schedule():
 				self.make_depreciation_schedule(date_of_disposal)
 				self.set_accumulated_depreciation(date_of_disposal, date_of_return)
 		else:
@@ -97,6 +92,39 @@ class Asset(AccountsController):
 			self.value_after_depreciation = flt(self.gross_purchase_amount) - flt(
 				self.opening_accumulated_depreciation
 			)
+
+	def should_prepare_depreciation_schedule(self):
+		if not self.get("schedules"):
+			return True
+
+		old_asset_doc = self.get_doc_before_save()
+
+		if (
+			old_asset_doc.gross_purchase_amount != self.gross_purchase_amount
+			or old_asset_doc.opening_accumulated_depreciation != self.opening_accumulated_depreciation
+			or old_asset_doc.number_of_depreciations_booked != self.number_of_depreciations_booked
+		):
+			return True
+
+		manual_fb_idx = -1
+		for d in self.finance_books:
+			if d.depreciation_method == "Manual":
+				manual_fb_idx = d.idx
+
+		if (
+			manual_fb_idx == -1
+			or old_asset_doc.finance_books[manual_fb_idx - 1].total_number_of_depreciations
+			!= self.finance_books[manual_fb_idx - 1].total_number_of_depreciations
+			or old_asset_doc.finance_books[manual_fb_idx - 1].frequency_of_depreciation
+			!= self.finance_books[manual_fb_idx - 1].frequency_of_depreciation
+			or old_asset_doc.finance_books[manual_fb_idx - 1].depreciation_start_date
+			!= getdate(self.finance_books[manual_fb_idx - 1].depreciation_start_date)
+			or old_asset_doc.finance_books[manual_fb_idx - 1].expected_value_after_useful_life
+			!= self.finance_books[manual_fb_idx - 1].expected_value_after_useful_life
+		):
+			return True
+
+		return False
 
 	def validate_item(self):
 		item = frappe.get_cached_value(
@@ -559,11 +587,7 @@ class Asset(AccountsController):
 	def set_accumulated_depreciation(
 		self, date_of_disposal=None, date_of_return=None, ignore_booked_entry=False
 	):
-		straight_line_idx = [
-			d.idx
-			for d in self.get("schedules")
-			if d.depreciation_method == "Straight Line" or d.depreciation_method == "Manual"
-		]
+		straight_line_idx = []
 		finance_books = []
 
 		for i, d in enumerate(self.get("schedules")):
@@ -571,6 +595,12 @@ class Asset(AccountsController):
 				continue
 
 			if int(d.finance_book_id) not in finance_books:
+				straight_line_idx = [
+					s.idx
+					for s in self.get("schedules")
+					if s.finance_book_id == d.finance_book_id
+					and (s.depreciation_method == "Straight Line" or s.depreciation_method == "Manual")
+				]
 				accumulated_depreciation = flt(self.opening_accumulated_depreciation)
 				value_after_depreciation = flt(
 					self.get("finance_books")[cint(d.finance_book_id) - 1].value_after_depreciation

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -99,6 +99,9 @@ class Asset(AccountsController):
 
 		old_asset_doc = self.get_doc_before_save()
 
+		if not old_asset_doc:
+			return True
+
 		if (
 			old_asset_doc.gross_purchase_amount != self.gross_purchase_amount
 			or old_asset_doc.opening_accumulated_depreciation != self.opening_accumulated_depreciation


### PR DESCRIPTION
First issue is that the users weren't able to edit the `Schedule Date` and `Depreciation Amount` for each period using the `Manual` method. Actually they were able to edit, but on save, the values are reverted back to system generated values. Second issue is that the final `Accumulated Depreciation Amount` in the schedule was not equal to the `Gross Purchase Amount` when the schedule is generated for an existing asset with `Opening Accumumated Depreciation`. So, fixed both of the issues.