### PR TITLE
fix: not able to repost gl entries

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -473,7 +473,7 @@ class PurchaseReceipt(BuyingController):
 					)
 
 					divisional_loss = flt(
-						valuation_amount_as_per_doc - stock_value_diff, d.precision("base_net_amount")
+						valuation_amount_as_per_doc - flt(stock_value_diff), d.precision("base_net_amount")
 					)
 
 					if divisional_loss:


### PR DESCRIPTION
**Issue**

```
Traceback (most recent call last):
  File "apps/erpnext/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py", line 139, in repost
    repost_gl_entries(doc)
  File "apps/erpnext/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py", line 199, in repost_gl_entries
    repost_doc=doc,
  File "apps/erpnext/erpnext/accounts/utils.py", line 1201, in repost_gle_for_stock_vouchers
    expected_gle = voucher_obj.get_gl_entries(warehouse_account)
  File "apps/erpnext/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py", line 292, in get_gl_entries
    self.make_item_gl_entries(gl_entries, warehouse_account=warehouse_account)
  File "apps/erpnext/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py", line 439, in make_item_gl_entries
    valuation_amount_as_per_doc - stock_value_diff, d.precision("base_net_amount")
TypeError: unsupported operand type(s) for -: 'float' and 'NoneType'
```