### PR TITLE
fix: set `from_warehouse` and `to_warehouse` while mapping SE

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -587,6 +587,9 @@ def make_stock_entry(source_name, target_doc=None):
 
 	def set_missing_values(source, target):
 		target.purpose = source.material_request_type
+		target.from_warehouse = source.set_from_warehouse
+		target.to_warehouse = source.set_warehouse
+
 		if source.job_card:
 			target.purpose = "Material Transfer for Manufacture"
 
@@ -722,6 +725,7 @@ def create_pick_list(source_name, target_doc=None):
 def make_in_transit_stock_entry(source_name, in_transit_warehouse):
 	ste_doc = make_stock_entry(source_name)
 	ste_doc.add_to_transit = 1
+	ste_doc.to_warehouse = in_transit_warehouse
 
 	for row in ste_doc.items:
 		row.t_warehouse = in_transit_warehouse


### PR DESCRIPTION
Steps to replicate:

1. Create Material Transfer (Purpose = Material Transfer).
2. Create > Material Transfer OR Material Transfer (In Transit).

Problem: The fields `from_warehouse` and `to_warehouse` didn't get copied from Material Request to Stock Entry.

ref: https://github.com/frappe/erpnext/pull/34170