### PR TITLE
fix: pos return throwing amount greater than grand total

### DIFF
--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -131,8 +131,8 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 					item.net_amount = item.amount = flt(item.rate * item.qty, precision("amount", item));
 				}
 				else {
-					let qty = item.qty || 1;
-					qty = me.frm.doc.is_return ? -1 * qty : qty;
+					// allow for '0' qty on Credit/Debit notes
+					let qty = item.qty || -1
 					item.net_amount = item.amount = flt(item.rate * qty, precision("amount", item));
 				}
 


### PR DESCRIPTION
Credit Notes against POS Invoices throwing 'Paid Amount + Write off amount cannot be greater than Grand Total'.

If `item.qty` is `0`, just do rate*-1 as the else block will only process Credit/Debit notes
regression: https://github.com/frappe/erpnext/pull/33902
