### PR TITLE
fix: consumed qty validation for subcontracting receipt

### DIFF
--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
@@ -191,14 +191,17 @@ class SubcontractingReceipt(SubcontractingController):
 
 	def validate_available_qty_for_consumption(self):
 		for item in self.get("supplied_items"):
+			precision = item.precision("consumed_qty")
 			if (
-				item.available_qty_for_consumption and item.available_qty_for_consumption < item.consumed_qty
+				item.available_qty_for_consumption
+				and flt(item.available_qty_for_consumption, precision) - flt(item.consumed_qty, precision) < 0
 			):
-				frappe.throw(
-					_(
-						"Row {0}: Consumed Qty must be less than or equal to Available Qty For Consumption in Consumed Items Table."
-					).format(item.idx)
-				)
+				msg = f"""Row {item.idx}: Consumed Qty {flt(item.consumed_qty, precision)}
+					must be less than or equal to Available Qty For Consumption
+					{flt(item.available_qty_for_consumption, precision)}
+					in Consumed Items Table."""
+
+				frappe.throw(_(msg))
 
 	def validate_items_qty(self):
 		for item in self.items:


### PR DESCRIPTION
Even though stock exists in the supplier's warehouse system throwing an error that "Consumed Qty must be less than or equal to Available Qty For Consumption in Consumed Items Table" 

**Stock Exists**

<img width="861" alt="Screenshot 2023-03-01 at 11 02 43 AM" src="https://user-images.githubusercontent.com/8780500/222054406-e37360ee-fffa-4fb3-9c8e-8d6d5a87eb5a.png">

**Still getting an Error**
<img width="639" alt="Screenshot 2023-03-01 at 11 02 58 AM" src="https://user-images.githubusercontent.com/8780500/222054491-44fc8ad6-aff4-4822-9752-2c8562f9698a.png">



**Changed Validation Message**
Quantity data was missing which added in the validation message 
<img width="663" alt="Screenshot 2023-03-01 at 11 42 27 AM" src="https://user-images.githubusercontent.com/8780500/222059625-7560f30c-54e2-4632-948d-870cc428425a.png">

