### PR TITLE
fix(General Ledger): Wrap unexpectedly long word 

### DIFF
--- a/erpnext/accounts/report/general_ledger/general_ledger.html
+++ b/erpnext/accounts/report/general_ledger/general_ledger.html
@@ -38,8 +38,11 @@
 			{% if(data[i].posting_date) { %}
 				<td>{%= frappe.datetime.str_to_user(data[i].posting_date) %}</td>
 				<td>{%= data[i].voucher_type %}
-					<br>{%= data[i].voucher_no %}</td>
-				<td>
+					<br>{%= data[i].voucher_no %}
+				</td>
+				{% var longest_word = cstr(data[i].remarks).split(" ").reduce((longest, word) => word.length > longest.length ? word : longest, ""); %}
+				<td {% if longest_word.length > 45 %} class="overflow-wrap-anywhere" {% endif %}>
+					<span>
 					{% if(!(filters.party || filters.account)) { %}
 						{%= data[i].party || data[i].account %}
 						<br>
@@ -49,11 +52,14 @@
 					{% if(data[i].bill_no) { %}
 						<br>{%= __("Supplier Invoice No") %}: {%= data[i].bill_no %}
 					{% } %}
-					</td>
-					<td style="text-align: right">
-						{%= format_currency(data[i].debit, filters.presentation_currency) %}</td>
-					<td style="text-align: right">
-						{%= format_currency(data[i].credit, filters.presentation_currency) %}</td>
+					</span>
+				</td>
+				<td style="text-align: right">
+					{%= format_currency(data[i].debit, filters.presentation_currency) %}
+				</td>
+				<td style="text-align: right">
+					{%= format_currency(data[i].credit, filters.presentation_currency) %}
+				</td>
 			{% } else { %}
 				<td></td>
 				<td></td>


### PR DESCRIPTION
**Before:**
<img width="1185" alt="Screenshot 2023-03-01 at 1 15 33 PM" src="https://user-images.githubusercontent.com/13928957/222118144-80d05390-ebed-4372-9cd1-7b4f5f6fc50e.png">

**After:**
<img width="1420" alt="Screenshot 2023-03-01 at 4 12 13 PM" src="https://user-images.githubusercontent.com/13928957/222118124-b96e78a1-958a-4b72-82ed-c26440dc3406.png">

A more generic fix has been done with [this](https://github.com/frappe/frappe/pull/20152) but since General Ledger is using custom format it needed a separate fix.