### PR TITLE
fix: Default sales team not getting set

### DIFF
--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -84,6 +84,9 @@ class SellingController(StockController):
 			)
 			if not self.meta.get_field("sales_team"):
 				party_details.pop("sales_team")
+			else:
+				self.set("sales_team", party_details.get("sales_team"))
+
 			self.update_if_missing(party_details)
 
 		elif lead:


### PR DESCRIPTION
Default sales team not getting set when converting quotation to sales order