### PR TITLE
fix: `Inventory Dimension` for `Stock Reconciliation`

### DIFF
--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -406,6 +406,8 @@ class StockReconciliation(StockController):
 			}
 		)
 
+		self.update_inventory_dimensions(row, data)
+
 		if not row.batch_no:
 			data.qty_after_transaction = flt(row.qty, row.precision("qty"))
 


### PR DESCRIPTION
Source / Ref: ISS-22-23-05638

Issue(s): `Inventory Dimension` not getting copied in Stock Ledger Entry (Stock Reconciliation).

_**Before:**_

   ![image](https://user-images.githubusercontent.com/63660334/222811401-8391a225-fcd3-4140-995c-7ed9cb8cd959.png)

_**After:**_ 

   ![image](https://user-images.githubusercontent.com/63660334/222811466-8a9997ce-a8e9-45d5-994b-d11386ed74c7.png)


