### PR TITLE
fix: update inventory dimensions before returning sle

### DIFF
--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -397,6 +397,7 @@ class StockReconciliation(StockController):
 				"voucher_type": self.doctype,
 				"voucher_no": self.name,
 				"voucher_detail_no": row.name,
+				"actual_qty": flt(row.current_qty),
 				"company": self.company,
 				"stock_uom": frappe.db.get_value("Item", row.item_code, "stock_uom"),
 				"is_cancelled": 1 if self.docstatus == 2 else 0,
@@ -405,8 +406,6 @@ class StockReconciliation(StockController):
 				"valuation_rate": flt(row.valuation_rate, row.precision("valuation_rate")),
 			}
 		)
-
-		self.update_inventory_dimensions(row, data)
 
 		if not row.batch_no:
 			data.qty_after_transaction = flt(row.qty, row.precision("qty"))
@@ -424,6 +423,8 @@ class StockReconciliation(StockController):
 				data.qty_after_transaction = 0.0
 				data.valuation_rate = flt(row.valuation_rate)
 				data.stock_value_difference = -1 * flt(row.amount_difference)
+
+		self.update_inventory_dimensions(row, data)
 
 		return data
 


### PR DESCRIPTION
Source: https://github.com/frappe/erpnext/pull/34293

Issue: getting `TypeError: '<' not supported between instances of 'NoneType' and 'int'` while cancelling `Stock Reconciliation`.

![image](https://user-images.githubusercontent.com/63660334/222893589-7c7c7ff3-705d-4e38-9c39-dd580b78bbcd.png)


