### PR TITLE
fix(minor): Dirty the form after clicking on Get advances button in Invoices

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1884,11 +1884,13 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 
 	get_advances() {
 		if(!this.frm.is_return) {
+			var me = this;
 			return this.frm.call({
 				method: "set_advances",
 				doc: this.frm.doc,
 				callback: function(r, rt) {
 					refresh_field("advances");
+					me.frm.dirty();
 				}
 			})
 		}


### PR DESCRIPTION
**Before:**

Table contents can be cleared on reload. It gives an impression as though there were no changes in the form
![2023-03-07 14 01 22](https://user-images.githubusercontent.com/25857446/223367040-5b233655-6101-4a8e-adc3-c9310db8354f.gif)


**After:**

![2023-03-07 13 59 40](https://user-images.githubusercontent.com/25857446/223366730-0532763d-0151-4774-a3a9-df033307bf39.gif)
