### PR TITLE
fix: Set contact filter link in Opportunity

### DIFF
--- a/erpnext/crm/doctype/opportunity/opportunity.js
+++ b/erpnext/crm/doctype/opportunity/opportunity.js
@@ -19,10 +19,6 @@ frappe.ui.form.on("Opportunity", {
 				}
 			}
 		});
-
-		if (frm.doc.opportunity_from && frm.doc.party_name){
-			frm.trigger('set_contact_link');
-		}
 	},
 
 	validate: function(frm) {
@@ -130,6 +126,10 @@ frappe.ui.form.on("Opportunity", {
 		} else {
 			frappe.contacts.clear_address_and_contact(frm);
 		}
+
+		if (frm.doc.opportunity_from && frm.doc.party_name) {
+			frm.trigger('set_contact_link');
+		}
 	},
 
 	set_contact_link: function(frm) {
@@ -137,6 +137,8 @@ frappe.ui.form.on("Opportunity", {
 			frappe.dynamic_link = {doc: frm.doc, fieldname: 'party_name', doctype: 'Customer'}
 		} else if(frm.doc.opportunity_from == "Lead" && frm.doc.party_name) {
 			frappe.dynamic_link = {doc: frm.doc, fieldname: 'party_name', doctype: 'Lead'}
+		} else if (frm.doc.opportunity_from == "Prospect" && frm.doc.party_name) {
+			frappe.dynamic_link = {doc: frm.doc, fieldname: 'party_name', doctype: 'Prospect'}
 		}
 	},
 


### PR DESCRIPTION
**Version**:

Frappe: v14.26.4
ERPNext: v14.17.4

___
Issue: #34307

___
**Before:**

- When creating a different type of opportunity, then adding a contact person then sometimes does not show properly, and also previous opportunity contact filter does show in the contact person. When selecting the Prospect the contact filter show wrong but when reloading the system then all contact are shown in the list.


https://user-images.githubusercontent.com/34390782/223373046-e41a2ca4-3088-4521-9a55-6fe832f1ec68.mp4

<br>

**After:** 
- After development did set the condition in the refresh event instead of the setup event. and added a filter for Prospect.


https://user-images.githubusercontent.com/34390782/223374482-b5072f01-73d4-4499-87d1-0d509897837d.mp4

<br>

Thanks and Regards,
Nihantra Patel (NCP)