### PR TITLE
fix: Allow Sales Orders with multiple lines of the same item_codes to have their supplier validated correctly. 

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -353,7 +353,7 @@ class SalesOrder(SellingController):
 		for item in self.items:
 			if item.supplier:
 				supplier = frappe.db.get_value(
-					"Sales Order Item", {"parent": self.name, "item_code": item.item_code}, "supplier"
+					"Sales Order Item", {"name": item.name}, "supplier"
 				)
 				if item.ordered_qty > 0.0 and item.supplier != supplier:
 					exc_list.append(


### PR DESCRIPTION
We found this bug when updating existing Sales Orders, if you have many items of the same `item_code` albeit with different suppliers for each the validation fails as it only finds the first one (assuming there would only be a single line for each `item_code`). Updated the validation method to use `name` instead of `item_code` fixes the problem and does the same thing. 
