### PR TITLE
fix: objective field set readonly on the Quality Goal form

### DIFF
--- a/erpnext/quality_management/doctype/quality_goal_objective/quality_goal_objective.json
+++ b/erpnext/quality_management/doctype/quality_goal_objective/quality_goal_objective.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "autoname": "format:{####}",
  "creation": "2019-05-26 15:03:43.996455",
  "doctype": "DocType",
@@ -12,7 +13,6 @@
  ],
  "fields": [
   {
-   "fetch_from": "goal.objective",
    "fieldname": "objective",
    "fieldtype": "Text",
    "in_list_view": 1,
@@ -38,14 +38,17 @@
   }
  ],
  "istable": 1,
- "modified": "2019-05-26 16:12:54.832058",
+ "links": [],
+ "modified": "2023-03-07 21:17:01.928658",
  "modified_by": "Administrator",
  "module": "Quality Management",
  "name": "Quality Goal Objective",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [],
  "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }


### PR DESCRIPTION

When you define a goal on the **Quality Goal** form, the objective field become read only. 
It happens due the objective field handle the goal field as link type, and try to fetch the objective value from it.  

In this PR, the `fetch_from` property is set empty to avoid fetch this value from goal field. 