### PR TITLE
fix: `required_qty` get reset to `1` for Alternative Item in WO

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -506,7 +506,7 @@ frappe.ui.form.on("Work Order Item", {
 				callback: function(r) {
 					if (r.message) {
 						frappe.model.set_value(cdt, cdn, {
-							"required_qty": 1,
+							"required_qty": row.required_qty || 1,
 							"item_name": r.message.item_name,
 							"description": r.message.description,
 							"source_warehouse": r.message.default_warehouse,


### PR DESCRIPTION
Source / Ref: ISS-22-23-05697

Before:

[Screencast from 2023-03-08 20-43-11.webm](https://user-images.githubusercontent.com/63660334/223751401-6dbc6982-3762-4b7b-be7a-720fc49922d1.webm)

After:

[Screencast from 2023-03-08 20-41-30.webm](https://user-images.githubusercontent.com/63660334/223751190-7ceed2b6-c8fd-4aed-a3d0-81e37b1a4a95.webm)

