### PR TITLE
fix: default pos conversion factor set to 1

### DIFF
--- a/erpnext/selling/page/point_of_sale/point_of_sale.py
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.py
@@ -55,7 +55,7 @@ def search_by_term(search_term, warehouse, price_list):
 			)
 
 	item_stock_qty, is_stock_item = get_stock_availability(item_code, warehouse)
-	item_stock_qty = item_stock_qty // item.get("conversion_factor")
+	item_stock_qty = item_stock_qty // item.get("conversion_factor", 1)
 	item.update({"actual_qty": item_stock_qty})
 
 	price = frappe.get_list(


### PR DESCRIPTION
Issue #33005:
- `item.get("conversion factor")` returned None type.

![1](https://user-images.githubusercontent.com/65490105/224915296-bf5f29a8-a631-4523-a03b-b426e7a46c86.png)

Fix:
- set 1 as default value to `item.get("conversion factor")`. 

![Fixed_Issue](https://user-images.githubusercontent.com/65490105/224915329-27d75275-e5e0-46b9-b7de-52efe22910f8.gif)
