### PR TITLE
fix: get batch_no. for item automatically

### DIFF
--- a/erpnext/selling/page/point_of_sale/point_of_sale.py
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.py
@@ -55,7 +55,7 @@ def search_by_term(search_term, warehouse, price_list):
 			)
 
 	item_stock_qty, is_stock_item = get_stock_availability(item_code, warehouse)
-	item_stock_qty = item_stock_qty // item.get("conversion_factor")
+	item_stock_qty = item_stock_qty // item.get("conversion_factor", 1)
 	item.update({"actual_qty": item_stock_qty})
 
 	price = frappe.get_list(

--- a/erpnext/selling/page/point_of_sale/point_of_sale.py
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.py
@@ -63,8 +63,9 @@ def search_by_term(search_term, warehouse, price_list):
 		filters={
 			"price_list": price_list,
 			"item_code": item_code,
+			"batch_no": batch_no,
 		},
-		fields=["uom", "stock_uom", "currency", "price_list_rate"],
+		fields=["uom", "stock_uom", "currency", "price_list_rate", "batch_no"],
 	)
 
 	def __sort(p):
@@ -167,7 +168,7 @@ def get_items(start, page_length, price_list, item_group, pos_profile, search_te
 
 		item_price = frappe.get_all(
 			"Item Price",
-			fields=["price_list_rate", "currency", "uom"],
+			fields=["price_list_rate", "currency", "uom", "batch_no"],
 			filters={
 				"price_list": price_list,
 				"item_code": item.item_code,
@@ -190,9 +191,9 @@ def get_items(start, page_length, price_list, item_group, pos_profile, search_te
 					"price_list_rate": price.get("price_list_rate"),
 					"currency": price.get("currency"),
 					"uom": price.uom or item.uom,
+					"batch_no": price.batch_no,
 				}
 			)
-
 	return {"items": result}
 
 


### PR DESCRIPTION
Issue:
- When selecting an item for POS, batch no. for the item wasn't selected automatically. one would have to select it manually like shown below:

![error_batch_selection](https://user-images.githubusercontent.com/65490105/225630681-8e9cf649-5fa1-4f06-ae83-5943457d2d10.gif)

Fix:
- adding batch no. to result. It now works in the following way:

![fix_atch_selection](https://user-images.githubusercontent.com/65490105/225631048-57dcae88-3136-43ce-abc8-58c6b2d9a052.gif)
