### PR TITLE
fix: Update account number from parent company

### DIFF
--- a/erpnext/accounts/doctype/account/account.py
+++ b/erpnext/accounts/doctype/account/account.py
@@ -394,7 +394,13 @@ def update_account_number(name, account_name, account_number=None, from_descenda
 
 	if ancestors and not allow_independent_account_creation:
 		for ancestor in ancestors:
-			if frappe.db.get_value("Account", {"account_name": old_acc_name, "company": ancestor}, "name"):
+			old_name = frappe.db.get_value(
+				"Account",
+				{"account_number": old_acc_number, "account_name": old_acc_name, "company": ancestor},
+				"name",
+			)
+
+			if old_name:
 				# same account in parent company exists
 				allow_child_account_creation = _("Allow Account Creation Against Child Company")
 


### PR DESCRIPTION
The user is unable to change just the "Account Number" even from the parent company because of the following incorrect validation, this should be allowed. Fixing this in this PR

<img width="1365" alt="image" src="https://user-images.githubusercontent.com/42651287/225649335-ec2b84ca-b4a6-42d5-bd53-b5625824d6fe.png">
