### PR TITLE
fix: don't get zero value entries for exchange rate calculation

### DIFF
--- a/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py
+++ b/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py
@@ -222,6 +222,9 @@ class ExchangeRateRevaluation(Document):
 					new_balance_in_base_currency = 0
 					new_balance_in_account_currency = 0
 
+					if d["party"] == "500100158":
+						print("debug")
+
 					current_exchange_rate = calculate_exchange_rate_using_last_gle(
 						company, d.account, d.party_type, d.party
 					)
@@ -490,6 +493,8 @@ def calculate_exchange_rate_using_last_gle(company, account, party_type, party):
 		conditions.append(gl.company == company)
 		conditions.append(gl.account == account)
 		conditions.append(gl.is_cancelled == 0)
+		conditions.append((gl.debit > 0) | (gl.credit > 0))
+		conditions.append((gl.debit_in_account_currency > 0) | (gl.credit_in_account_currency > 0))
 		if party_type:
 			conditions.append(gl.party_type == party_type)
 		if party:

--- a/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py
+++ b/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py
@@ -222,9 +222,6 @@ class ExchangeRateRevaluation(Document):
 					new_balance_in_base_currency = 0
 					new_balance_in_account_currency = 0
 
-					if d["party"] == "500100158":
-						print("debug")
-
 					current_exchange_rate = calculate_exchange_rate_using_last_gle(
 						company, d.account, d.party_type, d.party
 					)


### PR DESCRIPTION
### App Versions
```
{
	"erpnext": "14.0.0-dev",
	"frappe": "15.0.0-dev"
}
```
### Route
```
Form/Exchange Rate Revaluation/new-exchange-rate-revaluation-1
```
### Trackeback
```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 56, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 53, in handle
    return _RESTAPIHandler(call, doctype, name).get_response()
  File "apps/frappe/frappe/api.py", line 69, in get_response
    return self.handle_method()
  File "apps/frappe/frappe/api.py", line 79, in handle_method
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 48, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 86, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1589, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/handler.py", line 307, in run_doc_method
    response = doc.run_method(method)
  File "apps/frappe/frappe/model/document.py", line 922, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1276, in composer
    return composed(self, method, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1258, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "apps/frappe/frappe/model/document.py", line 919, in fn
    return method_object(*args, **kwargs)
  File "apps/frappe/frappe/utils/typing_validations.py", line 33, in wrapper
    return func(*args, **kwargs)
  File "apps/erpnext/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py", line 96, in get_accounts_data
    accounts_with_new_balance = self.calculate_new_account_balance(
  File "apps/erpnext/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py", line 230, in calculate_new_account_balance
    current_exchange_rate * d.balance_in_account_currency
TypeError: unsupported operand type(s) for *: 'NoneType' and 'float'

```
### Request Data
```
{
	"type": "POST",
	"args": {
		"docs": "{\"docstatus\":0,\"doctype\":\"Exchange Rate Revaluation\",\"name\":\"new-exchange-rate-revaluation-1\",\"__islocal\":1,\"__unsaved\":1,\"owner\":\"ds@partsupinc.com\",\"posting_date\":\"2023-03-16\",\"company\":\"PPS Premium Part Supply Inc.\",\"accounts\":[{\"docstatus\":0,\"doctype\":\"Exchange Rate Revaluation Account\",\"name\":\"new-exchange-rate-revaluation-account-1\",\"__islocal\":1,\"__unsaved\":1,\"owner\":\"ds@partsupinc.com\",\"account_currency\":\"CAD\",\"zero_balance\":0,\"parent\":\"new-exchange-rate-revaluation-1\",\"parentfield\":\"accounts\",\"parenttype\":\"Exchange Rate Revaluation\",\"idx\":1}]}",
		"method": "get_accounts_data"
	},
	"headers": {},
	"error_handlers": {},
	"url": "/api/method/run_doc_method"
}
```
### Response Data
```
{
	"exception": "TypeError: unsupported operand type(s) for *: 'NoneType' and 'float'"
}
```