### PR TITLE
perf: index against_sales_invoice field on DN items

### DIFF
--- a/erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
+++ b/erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -636,7 +636,8 @@
    "no_copy": 1,
    "options": "Sales Invoice",
    "print_hide": 1,
-   "read_only": 1
+   "read_only": 1,
+   "search_index": 1
   },
   {
    "fieldname": "so_detail",
@@ -837,7 +838,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2022-11-09 12:17:50.850142",
+ "modified": "2023-03-20 14:24:10.406746",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Note Item",


### PR DESCRIPTION
This is used on Sales invoice dashboard and takes a lot of time to load
as db size increases.

Results:

Before: ~10-20 seconds to load dashboard
After: few milliseconds because of index

[skip ci]

