### PR TITLE
Fix: Cost Per Unit Property read-only removed

### DIFF
--- a/erpnext/manufacturing/doctype/bom_operation/bom_operation.json
+++ b/erpnext/manufacturing/doctype/bom_operation/bom_operation.json
@@ -143,7 +143,7 @@
    "label": "Cost Per Unit",
    "no_copy": 1,
    "print_hide": 1,
-   "read_only": 1
+   "read_only": 0
   },
   {
    "fieldname": "base_cost_per_unit",
@@ -194,7 +194,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2022-11-04 17:17:16.986941",
+ "modified": "2023-03-19 15:40:10.175823",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "BOM Operation",


### PR DESCRIPTION
Field Cost per unit had a property read_only checked which was causing the issue and the Field was not visible even after depends on return True

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
