### PR TITLE
fix: incorrect depr schedules after asset repair [v13]

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -387,10 +387,14 @@ class Asset(AccountsController):
 					)
 					or value_after_depreciation < finance_book.expected_value_after_useful_life
 				):
-					depreciation_amount += (
-						value_after_depreciation - finance_book.expected_value_after_useful_life
-					)
-					skip_row = True
+					if (
+						not self.flags.increase_in_asset_value_due_to_repair
+						or not finance_book.depreciation_method in ("Written Down Value", "Double Declining Balance")
+					):
+						depreciation_amount += (
+							value_after_depreciation - finance_book.expected_value_after_useful_life
+						)
+						skip_row = True
 
 				if depreciation_amount > 0:
 					self.append(

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -1175,17 +1175,21 @@ def get_total_days(date, frequency):
 @erpnext.allow_regional
 def get_depreciation_amount(asset, depreciable_value, row):
 	if row.depreciation_method in ("Straight Line", "Manual"):
-		# if the Depreciation Schedule is being prepared for the first time
-		if not asset.flags.increase_in_asset_life:
-			depreciation_amount = (
-				flt(asset.gross_purchase_amount) - flt(row.expected_value_after_useful_life)
-			) / flt(row.total_number_of_depreciations)
-
-		# if the Depreciation Schedule is being modified after Asset Repair
-		else:
+		# if the Depreciation Schedule is being modified after Asset Repair due to increase in asset life and value
+		if asset.flags.increase_in_asset_life:
 			depreciation_amount = (
 				flt(row.value_after_depreciation) - flt(row.expected_value_after_useful_life)
 			) / (date_diff(asset.to_date, asset.available_for_use_date) / 365)
+		# if the Depreciation Schedule is being modified after Asset Repair due to increase in asset value
+		elif asset.flags.increase_in_asset_value_due_to_repair:
+			depreciation_amount = (
+				flt(row.value_after_depreciation) - flt(row.expected_value_after_useful_life)
+			) / flt(row.total_number_of_depreciations)
+		# if the Depreciation Schedule is being prepared for the first time
+		else:
+			depreciation_amount = (
+				flt(asset.gross_purchase_amount) - flt(row.expected_value_after_useful_life)
+			) / flt(row.total_number_of_depreciations)
 	else:
 		depreciation_amount = flt(depreciable_value * (flt(row.rate_of_depreciation) / 100))
 

--- a/erpnext/assets/doctype/asset_repair/asset_repair.py
+++ b/erpnext/assets/doctype/asset_repair/asset_repair.py
@@ -39,7 +39,11 @@ class AssetRepair(AccountsController):
 	def before_submit(self):
 		self.check_repair_status()
 
+		self.asset_doc.flags.increase_in_asset_value_due_to_repair = False
+
 		if self.get("stock_consumption") or self.get("capitalize_repair_cost"):
+			self.asset_doc.flags.increase_in_asset_value_due_to_repair = True
+
 			self.increase_asset_value()
 
 			if self.get("stock_consumption"):
@@ -57,12 +61,17 @@ class AssetRepair(AccountsController):
 
 			self.asset_doc.flags.ignore_validate_update_after_submit = True
 			self.asset_doc.prepare_depreciation_data()
+			self.update_asset_expected_value_after_useful_life()
 			self.asset_doc.save()
 
 	def before_cancel(self):
 		self.asset_doc = frappe.get_doc("Asset", self.asset)
 
+		self.asset_doc.flags.increase_in_asset_value_due_to_repair = False
+
 		if self.get("stock_consumption") or self.get("capitalize_repair_cost"):
+			self.asset_doc.flags.increase_in_asset_value_due_to_repair = True
+
 			self.decrease_asset_value()
 
 			if self.get("stock_consumption"):
@@ -80,6 +89,7 @@ class AssetRepair(AccountsController):
 
 			self.asset_doc.flags.ignore_validate_update_after_submit = True
 			self.asset_doc.prepare_depreciation_data()
+			self.update_asset_expected_value_after_useful_life()
 			self.asset_doc.save()
 
 	def after_delete(self):
@@ -99,6 +109,26 @@ class AssetRepair(AccountsController):
 				_("Please enter Warehouse from which Stock Items consumed during the Repair were taken."),
 				title=_("Missing Warehouse"),
 			)
+
+	def update_asset_expected_value_after_useful_life(self):
+		for row in self.asset_doc.get("finance_books"):
+			if row.depreciation_method in ("Written Down Value", "Double Declining Balance"):
+				accumulated_depreciation_after_full_schedule = [
+					d.accumulated_depreciation_amount
+					for d in self.asset_doc.get("schedules")
+					if cint(d.finance_book_id) == row.idx
+				]
+
+				accumulated_depreciation_after_full_schedule = max(
+					accumulated_depreciation_after_full_schedule
+				)
+
+				asset_value_after_full_schedule = flt(
+					flt(row.value_after_depreciation) - flt(accumulated_depreciation_after_full_schedule),
+					row.precision("expected_value_after_useful_life"),
+				)
+
+				row.expected_value_after_useful_life = asset_value_after_full_schedule
 
 	def increase_asset_value(self):
 		total_value_of_stock_consumed = self.get_total_value_of_stock_consumed()

--- a/erpnext/regional/india/utils.py
+++ b/erpnext/regional/india/utils.py
@@ -1101,18 +1101,21 @@ def update_taxable_values(doc, method):
 
 def get_depreciation_amount(asset, depreciable_value, row):
 	if row.depreciation_method in ("Straight Line", "Manual"):
-		# if the Depreciation Schedule is being prepared for the first time
-		if not asset.flags.increase_in_asset_life:
-			depreciation_amount = (
-				flt(asset.gross_purchase_amount) - flt(row.expected_value_after_useful_life)
-			) / flt(row.total_number_of_depreciations)
-
-		# if the Depreciation Schedule is being modified after Asset Repair
-		else:
+		# if the Depreciation Schedule is being modified after Asset Repair due to increase in asset life and value
+		if asset.flags.increase_in_asset_life:
 			depreciation_amount = (
 				flt(row.value_after_depreciation) - flt(row.expected_value_after_useful_life)
 			) / (date_diff(asset.to_date, asset.available_for_use_date) / 365)
-
+		# if the Depreciation Schedule is being modified after Asset Repair due to increase in asset value
+		elif asset.flags.increase_in_asset_value_due_to_repair:
+			depreciation_amount = (
+				flt(row.value_after_depreciation) - flt(row.expected_value_after_useful_life)
+			) / flt(row.total_number_of_depreciations)
+		# if the Depreciation Schedule is being prepared for the first time
+		else:
+			depreciation_amount = (
+				flt(asset.gross_purchase_amount) - flt(row.expected_value_after_useful_life)
+			) / flt(row.total_number_of_depreciations)
 	else:
 		rate_of_depreciation = row.rate_of_depreciation
 		# if its the first depreciation


### PR DESCRIPTION
Depreciation schedules after asset repair were incorrectly calculated in case of asset value/life increase, so fixed it.