### PR TITLE
fix: POS not picking up pos profile company address instead fetch any random company address

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.js
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.js
@@ -112,7 +112,8 @@ erpnext.selling.POSInvoiceController = class POSInvoiceController extends erpnex
 				party_type: "Customer",
 				account: this.frm.doc.debit_to,
 				price_list: this.frm.doc.selling_price_list,
-				pos_profile: pos_profile
+				pos_profile: pos_profile,
+				company_address: this.frm.doc.company_address
 			}, () => {
 				this.apply_pricing_rule();
 			});


### PR DESCRIPTION

![NCR-POP-UP-Retail-Store](https://user-images.githubusercontent.com/6947417/226528269-b6882514-442e-4738-b597-64dcc214b975.png)

![Farmley-VJ-Business-Tower-201303-Billing (1)](https://user-images.githubusercontent.com/6947417/226528365-094f35bc-88e2-4285-bc42-c8ffcb3ebe3a.png)

Before:
![ACC-PSINV-2023-00690](https://user-images.githubusercontent.com/6947417/226528273-c89f5011-c543-4503-9d38-10e8e802f55c.png)


after:
![ACC-PSINV-2023-00355](https://user-images.githubusercontent.com/6947417/226528281-0895b606-6278-457a-a615-9a9517016d58.png)

