### PR TITLE
Update serial_no_batch_selector.js

### DIFF
--- a/erpnext/public/js/utils/serial_no_batch_selector.js
+++ b/erpnext/public/js/utils/serial_no_batch_selector.js
@@ -261,7 +261,8 @@ erpnext.SerialNoBatchSelector = class SerialNoBatchSelector {
 
 			return frappe.db.get_list("Serial No", {
 				filters: { 'name': ["in", selected_serial_nos]},
-				fields: ["batch_no", "name"]
+				fields: ["batch_no", "name"],
+				limit: 999
 			}).then((data) => {
 				// data = [{batch_no: 'batch-1', name: "SR-001"},
 				// 	{batch_no: 'batch-2', name: "SR-003"}, {batch_no: 'batch-2', name: "SR-004"}]


### PR DESCRIPTION
As there is a hard limit of 20 nos in frappe.db.get_list, auto fetched serial numbers more than 20 is not added in the new rows,this change avoid this error

