### PR TITLE
fix: Creating landed cost voucher from connections

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -6,6 +6,23 @@ frappe.provide("erpnext.accounts");
 
 erpnext.accounts.PurchaseInvoice = class PurchaseInvoice extends erpnext.buying.BuyingController {
 	setup(doc) {
+		
+			frm.make_methods = {
+				'Landed Cost Voucher': () => {
+					let lcv = frappe.model.get_new_doc('Landed Cost Voucher');
+					lcv.company = frm.doc.company;
+	
+					let lcv_receipt = frappe.model.get_new_doc('Landed Cost Purchase Invoice');
+					lcv_receipt.receipt_document_type = 'Purchase Invoice';
+					lcv_receipt.receipt_document = frm.doc.name;
+					lcv_receipt.supplier = frm.doc.supplier;
+					lcv_receipt.grand_total = frm.doc.grand_total;
+					lcv.purchase_receipts = [lcv_receipt];
+	
+					frappe.set_route("Form", lcv.doctype, lcv.name);
+				},
+			}
+
 		this.setup_posting_date_time_check();
 		super.setup(doc);
 


### PR DESCRIPTION
when we click on landed cost voucher button from a purchase invoice connection.
it doesn't automatically fill in certain fields in the child table of the Landed Cost voucher

