### PR TITLE
fix: valuation rate issue while making stock entry from PO

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -644,7 +644,7 @@ def make_rm_stock_entry(purchase_order, rm_items):
 					}
 					stock_entry.add_to_stock_entry_detail(items_dict)
 
-		stock_entry.set_missing_values()
+		stock_entry.set_missing_values(raise_error_if_no_rate=False)
 		return stock_entry.as_dict()
 	else:
 		frappe.throw(_("No Items selected for transfer"))

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -2229,11 +2229,11 @@ class StockEntry(StockController):
 
 		return sorted(list(set(get_serial_nos(self.pro_doc.serial_no)) - set(used_serial_nos)))
 
-	def set_missing_values(self):
+	def set_missing_values(self, raise_error_if_no_rate=True):
 		"Updates rate and availability of all the items of mapped doc."
 		self.set_transfer_qty()
 		self.set_actual_qty()
-		self.calculate_rate_and_amount()
+		self.calculate_rate_and_amount(raise_error_if_no_rate=raise_error_if_no_rate)
 
 
 @frappe.whitelist()


### PR DESCRIPTION
1. Create subcontracted Purchase Order
2. Clicked on Transfer Materials to Supplier
3. System has not opened the stock entry form and throw an error that "Valuation Rate Missing"
4. Ideally this validation should throw on stock entry form and not on the purchase order form

