### PR TITLE
feat: deprecate get_customer_list

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -275,7 +275,7 @@ has_website_permission = {
 before_tests = "erpnext.setup.utils.before_tests"
 
 standard_queries = {
-	"Customer": "erpnext.selling.doctype.customer.customer.get_customer_list",
+	"Customer": "erpnext.controllers.queries.customer_query",
 }
 
 doc_events = {

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -448,7 +448,13 @@ def get_nested_links(link_doctype, link_name, ignore_permissions=False):
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
 def get_customer_list(doctype, txt, searchfield, start, page_len, filters=None):
+	from frappe.utils.deprecations import deprecation_warning
+
 	from erpnext.controllers.queries import get_fields
+
+	deprecation_warning(
+		"`get_customer_list` is deprecated and will be removed in version 15. Use `erpnext.controllers.queries.customer_query` instead."
+	)
 
 	fields = ["name", "customer_name", "customer_group", "territory"]
 


### PR DESCRIPTION
Customer query is implemented twice, once in `customer.py` and once in `queries.py`. IMO the one in `queries.py` is superior since it allows for customization.

This PR changes the standard query for customers to `erpnext.controllers.queries.customer_query` and marks the other query as deprecated. Also, this query is already covered by a test in `test_customer.py`, the other one is not.

> no-docs
