### PR TITLE
fix: recalculate WDV rate after asset repair [v13]

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -380,19 +380,12 @@ class Asset(AccountsController):
 				value_after_depreciation -= flt(depreciation_amount, self.precision("gross_purchase_amount"))
 
 				# Adjust depreciation amount in the last period based on the expected value after useful life
-				if (
-					finance_book.expected_value_after_useful_life
-					and (
-						(
-							n == cint(number_of_pending_depreciations) - 1
-							and value_after_depreciation != finance_book.expected_value_after_useful_life
-						)
-						or value_after_depreciation < finance_book.expected_value_after_useful_life
+				if finance_book.expected_value_after_useful_life and (
+					(
+						n == cint(number_of_pending_depreciations) - 1
+						and value_after_depreciation != finance_book.expected_value_after_useful_life
 					)
-					and (
-						not self.flags.increase_in_asset_value_due_to_repair
-						or not finance_book.depreciation_method in ("Written Down Value", "Double Declining Balance")
-					)
+					or value_after_depreciation < finance_book.expected_value_after_useful_life
 				):
 					depreciation_amount += (
 						value_after_depreciation - finance_book.expected_value_after_useful_life
@@ -903,10 +896,19 @@ class Asset(AccountsController):
 			return 200.0 / args.get("total_number_of_depreciations")
 
 		if args.get("depreciation_method") == "Written Down Value":
-			if args.get("rate_of_depreciation") and on_validate:
+			if (
+				args.get("rate_of_depreciation")
+				and on_validate
+				and not self.flags.increase_in_asset_value_due_to_repair
+			):
 				return args.get("rate_of_depreciation")
 
-			value = flt(args.get("expected_value_after_useful_life")) / flt(self.gross_purchase_amount)
+			if self.flags.increase_in_asset_value_due_to_repair:
+				value = flt(args.get("expected_value_after_useful_life")) / flt(
+					args.get("value_after_depreciation")
+				)
+			else:
+				value = flt(args.get("expected_value_after_useful_life")) / flt(self.gross_purchase_amount)
 
 			depreciation_rate = math.pow(value, 1.0 / flt(args.get("total_number_of_depreciations"), 2))
 

--- a/erpnext/assets/doctype/asset_repair/asset_repair.py
+++ b/erpnext/assets/doctype/asset_repair/asset_repair.py
@@ -58,8 +58,6 @@ class AssetRepair(AccountsController):
 
 			self.asset_doc.flags.ignore_validate_update_after_submit = True
 			self.asset_doc.prepare_depreciation_data()
-			if self.asset_doc.calculate_depreciation:
-				self.update_asset_expected_value_after_useful_life()
 			self.asset_doc.save()
 
 	def before_cancel(self):
@@ -84,8 +82,6 @@ class AssetRepair(AccountsController):
 
 			self.asset_doc.flags.ignore_validate_update_after_submit = True
 			self.asset_doc.prepare_depreciation_data()
-			if self.asset_doc.calculate_depreciation:
-				self.update_asset_expected_value_after_useful_life()
 			self.asset_doc.save()
 
 	def after_delete(self):
@@ -105,26 +101,6 @@ class AssetRepair(AccountsController):
 				_("Please enter Warehouse from which Stock Items consumed during the Repair were taken."),
 				title=_("Missing Warehouse"),
 			)
-
-	def update_asset_expected_value_after_useful_life(self):
-		for row in self.asset_doc.get("finance_books"):
-			if row.depreciation_method in ("Written Down Value", "Double Declining Balance"):
-				accumulated_depreciation_after_full_schedule = [
-					d.accumulated_depreciation_amount
-					for d in self.asset_doc.get("schedules")
-					if cint(d.finance_book_id) == row.idx
-				]
-
-				accumulated_depreciation_after_full_schedule = max(
-					accumulated_depreciation_after_full_schedule
-				)
-
-				asset_value_after_full_schedule = flt(
-					flt(row.value_after_depreciation) - flt(accumulated_depreciation_after_full_schedule),
-					row.precision("expected_value_after_useful_life"),
-				)
-
-				row.expected_value_after_useful_life = asset_value_after_full_schedule
 
 	def increase_asset_value(self):
 		total_value_of_stock_consumed = self.get_total_value_of_stock_consumed()


### PR DESCRIPTION
In https://github.com/frappe/erpnext/pull/34520, I recalculated the `expected_value_after_useful_life` after an asset repair in case the depreciation method was WDV, but it was incorrect. The `rate_of_depreciation` is what's supposed to be recalculated.