### PR TITLE
fix: bad strings format for update-translations

### DIFF
--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
@@ -46,7 +46,7 @@ class BankTransaction(StatusUpdater):
 	def add_payment_entries(self, vouchers):
 		"Add the vouchers with zero allocation. Save() will perform the allocations and clearance"
 		if 0.0 >= self.unallocated_amount:
-			frappe.throw(frappe._(f"Bank Transaction {self.name} is already fully reconciled"))
+			frappe.throw(frappe._("Bank Transaction {0} is already fully reconciled").format(self.name))
 
 		added = False
 		for voucher in vouchers:
@@ -114,9 +114,7 @@ class BankTransaction(StatusUpdater):
 
 				elif 0.0 > unallocated_amount:
 					self.db_delete_payment_entry(payment_entry)
-					frappe.throw(
-						frappe._(f"Voucher {payment_entry.payment_entry} is over-allocated by {unallocated_amount}")
-					)
+					frappe.throw(frappe._("Voucher {0} is over-allocated by {1}").format(unallocated_amount))
 
 		self.reload()
 
@@ -178,7 +176,9 @@ def get_clearance_details(transaction, payment_entry):
 		if gle["gl_account"] == gl_bank_account:
 			if gle["amount"] <= 0.0:
 				frappe.throw(
-					frappe._(f"Voucher {payment_entry.payment_entry} value is broken: {gle['amount']}")
+					frappe._("Voucher {0} value is broken: {1}").format(
+						payment_entry.payment_entry, gle["amount"]
+					)
 				)
 
 			unmatched_gles -= 1


### PR DESCRIPTION
In [translation not work in some of doctypes](https://github.com/frappe/erpnext/issues/34588) issue.

I have check that accounts/utils.py, pick_list.py already be fixed on the develop branch, but bank_transaction.py not yet.
