### PR TITLE
fix: Percentage billing in Sales Order

### DIFF
--- a/erpnext/controllers/status_updater.py
+++ b/erpnext/controllers/status_updater.py
@@ -464,7 +464,7 @@ class StatusUpdater(Document):
 					ifnull((select
 						ifnull(sum(case when abs(%(target_ref_field)s) > abs(%(target_field)s) then abs(%(target_field)s) else abs(%(target_ref_field)s) end), 0)
 						/ sum(abs(%(target_ref_field)s)) * 100
-					from `tab%(target_dt)s` where parent='%(name)s' having sum(abs(%(target_ref_field)s)) > 0), 0), 6)
+					from `tab%(target_dt)s` where parent='%(name)s' and parenttype='%(target_parent_dt)s' having sum(abs(%(target_ref_field)s)) > 0), 0), 6)
 					%(update_modified)s
 				where name='%(name)s'"""
 				% args


### PR DESCRIPTION
In the percentage update query, even the parent type should be checked
There are cases when the child tables are liked to other docs and the values updated are incorrect

Came across a scenario where the Sales Order Item table was also added to Project doctype and the project and sales order record both had the same name so the percentage value being updated was incorrect