### PR TITLE
fix: zero rm-cost for batch rm item in SCR

### DIFF
--- a/erpnext/controllers/subcontracting_controller.py
+++ b/erpnext/controllers/subcontracting_controller.py
@@ -455,7 +455,7 @@ class SubcontractingController(StockController):
 					"allow_zero_valuation": 1,
 				}
 			)
-			rm_obj.rate = get_incoming_rate(args)
+			rm_obj.rate = bom_item.rate if self.backflush_based_on == "BOM" else get_incoming_rate(args)
 
 		if self.doctype == self.subcontract_data.order_doctype:
 			rm_obj.required_qty = qty


### PR DESCRIPTION
Source / Ref: ISS-22-23-05891

Steps to replicate:
- Set Backflush Based on `BOM` in Buying Settings.
- Complete Subcontracting cycle (RM Item should be a Batch item).
- The Rate will be zero in the SCR supplier items table.

<details>
<summary>Screenshots</summary>

**Before:**

![image](https://user-images.githubusercontent.com/63660334/228205180-bb4335d9-9d60-48ce-b773-d3492094e1a6.png)

![image](https://user-images.githubusercontent.com/63660334/228205487-13284e31-b562-4cf8-94ab-9bcfee57d2fc.png)

**After:** 

![image](https://user-images.githubusercontent.com/63660334/228205754-9692c0cf-4be4-45fb-ad27-0139ec053288.png)

![image](https://user-images.githubusercontent.com/63660334/228205932-dbf8f7b9-ac0e-45f2-913a-b08a3d16fd3a.png)

</details>










