### PR TITLE
fix: switch to supported update_linked_doctypes

### DIFF
--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -14,7 +14,7 @@ from frappe.contacts.address_and_contact import (
 from frappe.desk.reportview import build_match_conditions, get_filters_cond
 from frappe.model.mapper import get_mapped_doc
 from frappe.model.naming import set_name_by_naming_series, set_name_from_naming_options
-from frappe.model.rename_doc import update_linked_doctypes
+from frappe.model.utils.rename_doc import update_linked_doctypes
 from frappe.utils import cint, cstr, flt, get_formatted_email, today
 from frappe.utils.user import get_users_with_role
 


### PR DESCRIPTION
Switch to the `update_linked_doctypes` implementation of `frappe.model.utils.rename_doc`.
The one in `frappe.model.rename_doc` has been deprecated two years ago.