### PR TITLE
fix: enabling lead even after "Opportunity" created against it

### DIFF
--- a/erpnext/crm/doctype/opportunity/opportunity.py
+++ b/erpnext/crm/doctype/opportunity/opportunity.py
@@ -33,7 +33,6 @@ class Opportunity(TransactionBase, CRMNote):
 	def after_insert(self):
 		if self.opportunity_from == "Lead":
 			frappe.get_doc("Lead", self.party_name).set_status(update=True)
-			self.disable_lead()
 
 			link_open_tasks(self.opportunity_from, self.party_name, self)
 			link_open_events(self.opportunity_from, self.party_name, self)
@@ -118,10 +117,6 @@ class Opportunity(TransactionBase, CRMNote):
 				prospect.flags.ignore_permissions = True
 				prospect.flags.ignore_mandatory = True
 				prospect.save()
-
-	def disable_lead(self):
-		if self.opportunity_from == "Lead":
-			frappe.db.set_value("Lead", self.party_name, {"disabled": 1, "docstatus": 1})
 
 	def make_new_lead_if_required(self):
 		"""Set lead against new opportunity"""

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -330,3 +330,4 @@ erpnext.patches.v14_0.update_closing_balances
 # below migration patches should always run last
 erpnext.patches.v14_0.migrate_gl_to_payment_ledger
 execute:frappe.delete_doc_if_exists("Report", "Tax Detail")
+erpnext.patches.v15_0.enable_all_leads

--- a/erpnext/patches/v15_0/enable_all_leads.py
+++ b/erpnext/patches/v15_0/enable_all_leads.py
@@ -1,5 +1,8 @@
 import frappe
 
+
 def execute():
-    lead = frappe.qb.DocType("Lead")
-    frappe.qb.update(lead).set(lead.disabled, 0).set(lead.docstatus, 0).where(lead.disabled == 1 and lead.docstatus == 1).run()
+	lead = frappe.qb.DocType("Lead")
+	frappe.qb.update(lead).set(lead.disabled, 0).set(lead.docstatus, 0).where(
+		lead.disabled == 1 and lead.docstatus == 1
+	).run()

--- a/erpnext/patches/v15_0/enable_all_leads.py
+++ b/erpnext/patches/v15_0/enable_all_leads.py
@@ -1,0 +1,5 @@
+import frappe
+
+def execute():
+    lead = frappe.qb.DocType("Lead")
+    frappe.qb.update(lead).set(lead.disabled, 0).set(lead.docstatus, 0).where(lead.disabled == 1 and lead.docstatus == 1).run()


### PR DESCRIPTION
Leads will be editable even after "Opportunity" has been created against it.

Refer recording below:

https://user-images.githubusercontent.com/81952590/228434396-3efbd8ea-a5a9-4a83-b367-f9cd4b16ebb2.mov

