### PR TITLE
fix: serial no with zero quantity issue in stock reco

### DIFF
--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -4,7 +4,7 @@
 from typing import Optional
 
 import frappe
-from frappe import _, msgprint
+from frappe import _, bold, msgprint
 from frappe.utils import cint, cstr, flt
 
 import erpnext
@@ -89,7 +89,7 @@ class StockReconciliation(StockController):
 
 				if item_dict.get("serial_nos"):
 					item.current_serial_no = item_dict.get("serial_nos")
-					if self.purpose == "Stock Reconciliation" and not item.serial_no:
+					if self.purpose == "Stock Reconciliation" and not item.serial_no and item.qty:
 						item.serial_no = item.current_serial_no
 
 				item.current_qty = item_dict.get("qty")
@@ -139,6 +139,14 @@ class StockReconciliation(StockController):
 				item_warehouse_combinations.append(key)
 
 			self.validate_item(row.item_code, row)
+
+			if row.serial_no and not row.qty:
+				self.validation_messages.append(
+					_get_msg(
+						row_num,
+						f"Quantity should not be zero for the {bold(row.item_code)} since serial nos are specified",
+					)
+				)
 
 			# validate warehouse
 			if not frappe.db.get_value("Warehouse", row.warehouse):


### PR DESCRIPTION
**Issue**

1. Created Purchase Receipt with quantity as 30 for Serialized Items
2. On submission of Purchase Receipt, system has created 30 Serial Nos
3. Next, created stock reconciliation for the same item and set quantity as Zero
4. Submitted stock reconciliation with Zero quantity and 30 Serial Nos
5. System has not updated status of Serial Nos to Inactive 

**After Fix**
Added validation for zero quantity
 
<img width="723" alt="Screenshot 2023-03-30 at 11 44 57 AM" src="https://user-images.githubusercontent.com/8780500/228747212-7392f3bb-afd0-46f1-9101-59f69f76a9c1.png">
