### PR TITLE
fix: incorrect arg name in asset value adjustment

### DIFF
--- a/erpnext/assets/doctype/asset_value_adjustment/asset_value_adjustment.js
+++ b/erpnext/assets/doctype/asset_value_adjustment/asset_value_adjustment.js
@@ -49,7 +49,7 @@ frappe.ui.form.on('Asset Value Adjustment', {
 			frm.call({
 				method: "erpnext.assets.doctype.asset.asset.get_asset_value_after_depreciation",
 				args: {
-					asset: frm.doc.asset,
+					asset_name: frm.doc.asset,
 					finance_book: frm.doc.finance_book
 				},
 				callback: function(r) {


### PR DESCRIPTION
`erpnext.assets.doctype.asset.asset.get_asset_value_after_depreciation` requires `asset_name` but `asset_value_adjustment.js` was sending `asset`, so fixed that.

Closes #34634