### PR TITLE
chore: auto fill asset name and available for use date

### DIFF
--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -466,6 +466,9 @@ frappe.ui.form.on('Asset', {
 		} else {
 			frm.set_value('purchase_date', purchase_doc.posting_date);
 		}
+		if (!frm.doc.is_existing_asset && !frm.doc.available_for_use_date) {
+			frm.set_value('available_for_use_date', frm.doc.purchase_date);
+		}
 		const item = purchase_doc.items.find(item => item.item_code === frm.doc.item_code);
 		if (!item) {
 			doctype_field = frappe.scrub(doctype)

--- a/erpnext/assets/doctype/asset/asset.json
+++ b/erpnext/assets/doctype/asset/asset.json
@@ -79,6 +79,9 @@
    "options": "ACC-ASS-.YYYY.-"
   },
   {
+   "depends_on": "item_code",
+   "fetch_from": "item_code.item_name",
+   "fetch_if_empty": 1,
    "fieldname": "asset_name",
    "fieldtype": "Data",
    "in_list_view": 1,
@@ -517,7 +520,7 @@
    "table_fieldname": "accounts"
   }
  ],
- "modified": "2023-02-02 00:03:11.706427",
+ "modified": "2023-03-30 15:07:41.542374",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset",


### PR DESCRIPTION
To improve UX:
- now `asset_name` is set to the `item_name` by default
- `available_for_use_date` is set to the `purchase_date` by default for non-existing assets