### PR TITLE
fix: enclose ternary operator in parenthesis

### DIFF
--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -135,7 +135,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 				}
 				else {
 					// allow for '0' qty on Credit/Debit notes
-					let qty = item.qty || me.frm.doc.is_debit_note ? 1 : -1;
+					let qty = item.qty || (me.frm.doc.is_debit_note ? 1 : -1);
 					item.net_amount = item.amount = flt(item.rate * qty, precision("amount", item));
 				}
 


### PR DESCRIPTION
Fixing POS Credit notes having positive net total. Ternary operator wasn't enclosed properly causing this issue.