### PR TITLE
fix!: require sender and message for contact us page

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -28,6 +28,10 @@ doctype_js = {
 
 override_doctype_class = {"Address": "erpnext.accounts.custom.address.ERPNextAddress"}
 
+override_whitelisted_methods = {
+	"frappe.www.contact.send_message": "erpnext.templates.utils.send_message"
+}
+
 welcome_email = "erpnext.setup.utils.welcome_email"
 
 # setup wizard

--- a/erpnext/public/js/website_utils.js
+++ b/erpnext/public/js/website_utils.js
@@ -3,18 +3,6 @@
 
 if(!window.erpnext) window.erpnext = {};
 
-// Add / update a new Lead / Communication
-// subject, sender, description
-frappe.send_message = function(opts, btn) {
-	return frappe.call({
-		type: "POST",
-		method: "erpnext.templates.utils.send_message",
-		btn: btn,
-		args: opts,
-		callback: opts.callback
-	});
-};
-
 erpnext.subscribe_to_newsletter = function(opts, btn) {
 	return frappe.call({
 		type: "POST",
@@ -24,6 +12,3 @@ erpnext.subscribe_to_newsletter = function(opts, btn) {
 		callback: opts.callback
 	});
 }
-
-// for backward compatibility
-erpnext.send_message = frappe.send_message;

--- a/erpnext/templates/utils.py
+++ b/erpnext/templates/utils.py
@@ -6,13 +6,12 @@ import frappe
 
 
 @frappe.whitelist(allow_guest=True)
-def send_message(subject="Website Query", message="", sender="", status="Open"):
+def send_message(sender, message, subject="Website Query"):
 	from frappe.www.contact import send_message as website_send_message
 
+	website_send_message(sender, message, subject)
+
 	lead = customer = None
-
-	website_send_message(subject, message, sender)
-
 	customer = frappe.db.sql(
 		"""select distinct dl.link_name from `tabDynamic Link` dl
 		left join `tabContact` c on dl.parent=c.name where dl.link_doctype='Customer'
@@ -58,5 +57,3 @@ def send_message(subject="Website Query", message="", sender="", status="Open"):
 		}
 	)
 	comm.insert(ignore_permissions=True)
-
-	return "okay"


### PR DESCRIPTION
depends on: https://github.com/frappe/frappe/pull/20542

Other Changes:
- removed `frappe.send_message` util from erpnext - this was overriding the frappe.send_message util in frappe to create leads/opportunity. This is now done via `override_whitelisted_method` hook