### PR TITLE
fix: `payment entry is already created` on posawesome.

### DIFF
--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -492,33 +492,33 @@ def make_payment_request(**args):
 
 
 def get_amount(ref_doc, payment_account=None):
-    """get amount based on doctype"""
-    dt = ref_doc.doctype
-    if dt in ["Sales Order", "Purchase Order"]:
-        grand_total = flt(ref_doc.rounded_total) or flt(ref_doc.grand_total)
-    elif dt in ["Sales Invoice", "Purchase Invoice"]:
-        if not ref_doc.is_pos:
-            if ref_doc.party_account_currency == ref_doc.currency:
-                grand_total = flt(ref_doc.outstanding_amount)
-            else:
-                grand_total = flt(ref_doc.outstanding_amount) / ref_doc.conversion_rate
-        elif dt == "Sales Invoice":
-            for pay in ref_doc.payments:
-                if pay.type == "Phone" and pay.account == payment_account:
-                    grand_total = pay.amount
-                    break
-    elif dt == "POS Invoice":
-        for pay in ref_doc.payments:
-            if pay.type == "Phone" and pay.account == payment_account:
-                grand_total = pay.amount
-                break
-    elif dt == "Fees":
-        grand_total = ref_doc.outstanding_amount
+	"""get amount based on doctype"""
+	dt = ref_doc.doctype
+	if dt in ["Sales Order", "Purchase Order"]:
+		grand_total = flt(ref_doc.rounded_total) or flt(ref_doc.grand_total)
+	elif dt in ["Sales Invoice", "Purchase Invoice"]:
+		if not ref_doc.is_pos:
+			if ref_doc.party_account_currency == ref_doc.currency:
+				grand_total = flt(ref_doc.outstanding_amount)
+			else:
+				grand_total = flt(ref_doc.outstanding_amount) / ref_doc.conversion_rate
+		elif dt == "Sales Invoice":
+			for pay in ref_doc.payments:
+				if pay.type == "Phone" and pay.account == payment_account:
+					grand_total = pay.amount
+					break
+	elif dt == "POS Invoice":
+		for pay in ref_doc.payments:
+			if pay.type == "Phone" and pay.account == payment_account:
+				grand_total = pay.amount
+				break
+	elif dt == "Fees":
+		grand_total = ref_doc.outstanding_amount
 
-    if grand_total > 0:
-        return grand_total
-    else:
-        frappe.throw(_("Payment Entry is already created"))
+	if grand_total > 0:
+		return grand_total
+	else:
+		frappe.throw(_("Payment Entry is already created"))
 
 
 def get_existing_payment_request_amount(ref_dt, ref_dn):


### PR DESCRIPTION
Above error occurs when making payment request from poswesome using mpesa express.
![payment entry created](https://user-images.githubusercontent.com/55623011/229453965-608feb05-7714-4c1f-943e-efae37bfba61.jpeg)

This is however caused by: [erpnext/erpnext/accounts/doctype/payment_request/payment_request.py](https://github.com/frappe/erpnext/blob/e271935673f1e27d7bd8ab7b7e1731a22b2e0bee/erpnext/accounts/doctype/payment_request/payment_request.py#L499)
```elif dt in ["Sales Invoice", "Purchase Invoice"]: ```
Line 499

POSawesome creates sales invoices of type `is_pos`. Due to this, they are not handled as `POS Invoice` in the get_amount method in payment_request.py These are cash invoices hence no outstanding amount. This leads to the `frappe.throw(_("Payment Entry is already created"))` block when making payment requests.

Closes: https://github.com/frappe/erpnext/issues/34598
