### PR TITLE
fix: consider qty field precision

### DIFF
--- a/erpnext/utilities/transaction_base.py
+++ b/erpnext/utilities/transaction_base.py
@@ -186,12 +186,15 @@ def validate_uom_is_integer(doc, uom_field, qty_fields, child_dt=None):
 			for f in qty_fields:
 				qty = d.get(f)
 				if qty:
-					if abs(cint(qty) - flt(qty)) > 0.0000001:
+					if abs(cint(qty) - flt(qty, d.precision(f))) > 0.0000001:
 						frappe.throw(
 							_(
 								"Row {1}: Quantity ({0}) cannot be a fraction. To allow this, disable '{2}' in UOM {3}."
 							).format(
-								qty, d.idx, frappe.bold(_("Must be Whole Number")), frappe.bold(d.get(uom_field))
+								flt(qty, d.precision(f)),
+								d.idx,
+								frappe.bold(_("Must be Whole Number")),
+								frappe.bold(d.get(uom_field)),
 							),
 							UOMMustBeIntegerError,
 						)


### PR DESCRIPTION
**Source / Ref:** ISS-22-23-06369

**Steps to Replicate:**
- Create an Item with Stock UOM as `Nos` and set `Units of Measure` for a fractional UOM.
   ![image](https://user-images.githubusercontent.com/63660334/229457729-fab16327-bb4f-4270-aa2e-30e8175162a1.png)
- Update the Purchase Order Item Conversion Factor `Precision` to 5 (using Customize Form). 
  ![image](https://user-images.githubusercontent.com/63660334/229458877-ceb1b677-5e37-438c-81f9-81d278786a79.png)
- Now, create a Purchase Order for 75.900 Kg (3 Nos), Conversion Factor will be `0.03953`. While saving you will get the below error.
  ![image](https://user-images.githubusercontent.com/63660334/229460107-7a60f6e6-4b57-425b-85f8-7f1bffafccab.png)
  ![image](https://user-images.githubusercontent.com/63660334/229460647-13fb4885-aaa0-434d-9006-d769cb9d570e.png)

**Solution:** Consider Qty in Stock UOM `Precision` while comparing. 





