### PR TITLE
fix: bom update log not working for large batch size

### DIFF
--- a/erpnext/manufacturing/doctype/bom_update_log/bom_update_log.py
+++ b/erpnext/manufacturing/doctype/bom_update_log/bom_update_log.py
@@ -164,7 +164,7 @@ def queue_bom_cost_jobs(
 
 	while current_boms_list:
 		batch_no += 1
-		batch_size = 20_000
+		batch_size = 7_000
 		boms_to_process = current_boms_list[:batch_size]  # slice out batch of 20k BOMs
 
 		# update list to exclude 20K (queued) BOMs
@@ -212,7 +212,7 @@ def resume_bom_cost_update_jobs():
 			["name", "boms_updated", "status"],
 		)
 		incomplete_level = any(row.get("status") == "Pending" for row in bom_batches)
-		if not bom_batches or not incomplete_level:
+		if not bom_batches or incomplete_level:
 			continue
 
 		# Prep parent BOMs & updated processed BOMs for next level
@@ -252,9 +252,6 @@ def get_processed_current_boms(
 	current_boms = []
 
 	for row in bom_batches:
-		if not row.boms_updated:
-			continue
-
 		boms_updated = json.loads(row.boms_updated)
 		current_boms.extend(boms_updated)
 		boms_updated_dict = {bom: True for bom in boms_updated}


### PR DESCRIPTION
**Issue**

BOM cost update throw timeout error if number of BOMs are more.