### PR TITLE
'Make Asset Movement' button translation fix in asset_list.js

### DIFF
--- a/erpnext/assets/doctype/asset/asset_list.js
+++ b/erpnext/assets/doctype/asset/asset_list.js
@@ -36,7 +36,7 @@ frappe.listview_settings['Asset'] = {
 		}
 	},
 	onload: function(me) {
-		me.page.add_action_item('Make Asset Movement', function() {
+		me.page.add_action_item(__("Make Asset Movement"), function() {
 			const assets = me.get_checked_items();
 			frappe.call({
 				method: "erpnext.assets.doctype.asset.asset.make_asset_movement",


### PR DESCRIPTION
'Make Asset Movement' button is not translatable in 'Asset List' in the app.
asset_list.js is edited to fix this.