### PR TITLE
fix: incorrect stock balance quantity for batch item

### DIFF
--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 import frappe
 from frappe import _, bold, msgprint
+from frappe.query_builder.functions import Sum
 from frappe.utils import cint, cstr, flt
 
 import erpnext
@@ -568,6 +569,54 @@ class StockReconciliation(StockController):
 			self.queue_action("cancel", timeout=2000)
 		else:
 			self._cancel()
+
+	def recalculate_current_qty(self, item_code, batch_no):
+		for row in self.items:
+			if not (row.item_code == item_code and row.batch_no == batch_no):
+				continue
+
+			row.current_qty = get_batch_qty_for_stock_reco(item_code, row.warehouse, batch_no)
+
+			qty, val_rate = get_stock_balance(
+				item_code,
+				row.warehouse,
+				self.posting_date,
+				self.posting_time,
+				with_valuation_rate=True,
+			)
+
+			row.current_valuation_rate = val_rate
+
+			row.db_set(
+				{
+					"current_qty": row.current_qty,
+					"current_valuation_rate": row.current_valuation_rate,
+					"current_amount": flt(row.current_qty * row.current_valuation_rate),
+				}
+			)
+
+
+def get_batch_qty_for_stock_reco(item_code, warehouse, batch_no):
+	ledger = frappe.qb.DocType("Stock Ledger Entry")
+
+	query = (
+		frappe.qb.from_(ledger)
+		.select(
+			Sum(ledger.actual_qty).as_("batch_qty"),
+		)
+		.where(
+			(ledger.item_code == item_code)
+			& (ledger.warehouse == warehouse)
+			& (ledger.docstatus == 1)
+			& (ledger.is_cancelled == 0)
+			& (ledger.batch_no == batch_no)
+		)
+		.groupby(ledger.batch_no)
+	)
+
+	sle = query.run(as_dict=True)
+
+	return flt(sle[0].batch_qty) if sle else 0
 
 
 @frappe.whitelist()


### PR DESCRIPTION
Backdated entries causing an incorrect stock balance for the Batch Items if the future transactions has Stock Reconciliation entry. 