### PR TITLE
fix: time_in_minutes should return integer value

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -896,7 +896,7 @@ def make_stock_entry(source_name, target_doc=None):
 
 
 def time_diff_in_minutes(string_ed_date, string_st_date):
-	return time_diff(string_ed_date, string_st_date).total_seconds() / 60
+	return time_diff(string_ed_date, string_st_date).total_seconds() // 60
 
 
 @frappe.whitelist()


### PR DESCRIPTION
fix: In job card doctype, the function time_in_minutes() should return integer value, so I change division to entire division by 60.

![image](https://user-images.githubusercontent.com/58433943/230567081-54ad5080-fd8a-4616-abb2-ed89672ba8bc.png)
