### PR TITLE
fix: reposting record not created for backdated stock reconciliation 

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -1375,6 +1375,7 @@ def regenerate_sle_for_batch_stock_reco(detail):
 	doc.recalculate_current_qty(detail.item_code, detail.batch_no)
 	doc.docstatus = 1
 	doc.update_stock_ledger()
+	doc.repost_future_sle_and_gle()
 
 
 def get_stock_reco_qty_shift(args):


### PR DESCRIPTION
If the future transaction has Stock Reconciliation entry then system adjust the stock ledger entries for the batch item (Check PR (https://github.com/frappe/erpnext/pull/34743)). After adjusting the stock ledger entries system should create the Repost Item Valuation entry for reposting which was missed.
