### PR TITLE
feat: add german sales tax template

### DIFF
--- a/erpnext/setup/setup_wizard/data/country_wise_tax.json
+++ b/erpnext/setup/setup_wizard/data/country_wise_tax.json
@@ -581,6 +581,11 @@
 						"title": "Bauleistungen nach § 13b UStG",
 						"is_default": 0,
 						"taxes": []
+					},
+					{
+						"title": "Nullsteuersatz nach § 12 Abs. 3 UStG",
+						"is_default": 0,
+						"taxes": []
 					}
 				],
 				"purchase_tax_templates": [
@@ -1337,6 +1342,11 @@
 					},
 					{
 						"title": "Bauleistungen nach § 13b UStG",
+						"is_default": 0,
+						"taxes": []
+					},
+					{
+						"title": "Nullsteuersatz nach § 12 Abs. 3 UStG",
 						"is_default": 0,
 						"taxes": []
 					}
@@ -2097,6 +2107,11 @@
 						"title": "Bauleistungen nach § 13b UStG",
 						"is_default": 0,
 						"taxes": []
+					},
+					{
+						"title": "Nullsteuersatz nach § 12 Abs. 3 UStG",
+						"is_default": 0,
+						"taxes": []
 					}
 				],
 				"purchase_tax_templates": [
@@ -2847,6 +2862,11 @@
 					},
 					{
 						"title": "Bauleistungen nach § 13b UStG",
+						"is_default": 0,
+						"taxes": []
+					},
+					{
+						"title": "Nullsteuersatz nach § 12 Abs. 3 UStG",
 						"is_default": 0,
 						"taxes": []
 					}


### PR DESCRIPTION
Recent legislation allows zero taxation on delivery and installation of photovoltaics and related goods and services. This usually applies to the entire invoice, not individual line items.

Added an empty **Sales Taxes and Charges Template** "Nullsteuersatz nach § 12 Abs. 3 UStG" for all german CoAs.

This only affects the default templates for new companies. Existing companies will have to adjust/extend their tax config manually.

> no-docs