### PR TITLE
fix(ux): don't throw error when company defaults aren't set

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -970,29 +970,47 @@ frappe.ui.form.on('Payment Entry', {
 				},
 				callback: function(r, rt) {
 					if(r.message) {
-						var write_off_row = $.map(frm.doc["deductions"] || [], function(t) {
+						const write_off_row = $.map(frm.doc["deductions"] || [], function(t) {
 							return t.account==r.message[account] ? t : null; });
 
-						var row = [];
-
-						var difference_amount = flt(frm.doc.difference_amount,
+						const difference_amount = flt(frm.doc.difference_amount,
 							precision("difference_amount"));
 
-						if (!write_off_row.length && difference_amount) {
-							row = frm.add_child("deductions");
-							row.account = r.message[account];
-							row.cost_center = r.message["cost_center"];
-						} else {
-							row = write_off_row[0];
-						}
+						const add_deductions = (details) => {
+							if (!write_off_row.length && difference_amount) {
+								row = frm.add_child("deductions");
+								row.account = details[account];
+								row.cost_center = details["cost_center"];
+							} else {
+								row = write_off_row[0];
+							}
 
-						if (row) {
-							row.amount = flt(row.amount) + difference_amount;
-						} else {
-							frappe.msgprint(__("No gain or loss in the exchange rate"))
-						}
+							if (row) {
+								row.amount = flt(row.amount) + difference_amount;
+							} else {
+								frappe.msgprint(__("No gain or loss in the exchange rate"))
+							}
+							refresh_field("deductions");
+						};
 
-						refresh_field("deductions");
+						if (!r.message[account]) {
+							frappe.prompt({
+								label: frappe.unscrub(account),
+								fieldname: account,
+								fieldtype: "Link",
+								options: "Account",
+								get_query: () => ({
+									filters: {
+										company: frm.doc.company,
+									}
+								})
+							}, (values) => {
+								const details = Object.assign({}, r.message, values);
+								add_deductions(details);
+							});
+						} else {
+							add_deductions(r.message);
+						}
 
 						frm.events.set_unallocated_amount(frm);
 					}

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -995,7 +995,7 @@ frappe.ui.form.on('Payment Entry', {
 
 						if (!r.message[account]) {
 							frappe.prompt({
-								label: frappe.unscrub(account),
+								label: __("Please Specify Account"),
 								fieldname: account,
 								fieldtype: "Link",
 								options: "Account",
@@ -1007,7 +1007,7 @@ frappe.ui.form.on('Payment Entry', {
 							}, (values) => {
 								const details = Object.assign({}, r.message, values);
 								add_deductions(details);
-							});
+							}, __(frappe.unscrub(account)));
 						} else {
 							add_deductions(r.message);
 						}

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -1594,17 +1594,7 @@ def get_account_details(account, date, cost_center=None):
 @frappe.whitelist()
 def get_company_defaults(company):
 	fields = ["write_off_account", "exchange_gain_loss_account", "cost_center"]
-	ret = frappe.get_cached_value("Company", company, fields, as_dict=1)
-
-	for fieldname in fields:
-		if not ret[fieldname]:
-			frappe.throw(
-				_("Please set default {0} in Company {1}").format(
-					frappe.get_meta("Company").get_label(fieldname), company
-				)
-			)
-
-	return ret
+	return frappe.get_cached_value("Company", company, fields, as_dict=1)
 
 
 def get_outstanding_on_journal_entry(name):


### PR DESCRIPTION
### Summary
Previously when "Set Exchange Gain/Loss", or "Set Write Off" button appeared, if their respective company default wasn't set an error would prompt.

Now a prompt is displayed for the user to provide an account to write off too.

### Before PR
![ux-writeoff-before](https://user-images.githubusercontent.com/29856401/231287567-b3ff56cd-e3ee-4cc9-b401-87e2c9b65799.gif)


### After PR
![ux-writeoff-after](https://user-images.githubusercontent.com/29856401/231287604-5a6b07ea-e8b0-4d17-9af4-3a3c2246728d.gif)

### Backport
version-14
version-13
