### PR TITLE
fix: unable to change `company` for manual `Serial No` entry

### DIFF
--- a/erpnext/stock/doctype/serial_no/serial_no.json
+++ b/erpnext/stock/doctype/serial_no/serial_no.json
@@ -410,10 +410,10 @@
    "fieldtype": "Link",
    "label": "Company",
    "options": "Company",
-   "read_only": 1,
    "remember_last_selected_value": 1,
    "reqd": 1,
-   "search_index": 1
+   "search_index": 1,
+   "set_only_once": 1
   },
   {
    "fieldname": "status",
@@ -433,7 +433,7 @@
  "icon": "fa fa-barcode",
  "idx": 1,
  "links": [],
- "modified": "2021-12-23 10:44:30.299450",
+ "modified": "2023-04-14 15:58:46.139887",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Serial No",
@@ -461,7 +461,6 @@
    "read": 1,
    "report": 1,
    "role": "Stock Manager",
-   "set_user_permissions": 1,
    "write": 1
   },
   {


### PR DESCRIPTION
**Source / Ref:** ISS-23-24-00199

**Issue:** The user is unable to change the company for the manual `Serial No` entry.

**Steps to replicate:**
- Create a `Serial No` entry manually for the Item.
- Try to change the company.

**Before:**

![image](https://user-images.githubusercontent.com/63660334/232022228-459d8a1e-2b7f-47cd-aa8b-61af00cdcc87.png)


**After:**

![image](https://user-images.githubusercontent.com/63660334/232022040-43aacb34-1f35-44d9-bf2e-053598ed9a2d.png)


