### PR TITLE
fix: batch_no field mapping from Purchase Receipt to Purchase Invoice

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -1055,6 +1055,7 @@ def make_purchase_invoice(source_name, target_doc=None):
 					"is_fixed_asset": "is_fixed_asset",
 					"asset_location": "asset_location",
 					"asset_category": "asset_category",
+					"batch_no": "batch_no",
 				},
 				"postprocess": update_item,
 				"filter": lambda d: get_pending_qty(d)[0] <= 0


### PR DESCRIPTION
batch_no field mapping from Purchase Receipt to Purchase Invoice

