### PR TITLE
fix: don't show disabled warehouses in the Warehouse Wise Stock Balance report

### DIFF
--- a/erpnext/stock/report/warehouse_wise_stock_balance/warehouse_wise_stock_balance.js
+++ b/erpnext/stock/report/warehouse_wise_stock_balance/warehouse_wise_stock_balance.js
@@ -11,6 +11,13 @@ frappe.query_reports["Warehouse Wise Stock Balance"] = {
 			"options": "Company",
 			"reqd": 1,
 			"default": frappe.defaults.get_user_default("Company")
+		},
+		{
+			"fieldname":"show_disabled_warehouses",
+			"label": __("Show Disabled Warehouses"),
+			"fieldtype": "Check",
+			"default": 0
+
 		}
 	],
 	"initial_depth": 3,

--- a/erpnext/stock/report/warehouse_wise_stock_balance/warehouse_wise_stock_balance.py
+++ b/erpnext/stock/report/warehouse_wise_stock_balance/warehouse_wise_stock_balance.py
@@ -11,6 +11,7 @@ from frappe.query_builder.functions import Sum
 class StockBalanceFilter(TypedDict):
 	company: Optional[str]
 	warehouse: Optional[str]
+	show_disabled_warehouses: Optional[int]
 
 
 SLEntry = Dict[str, Any]
@@ -18,7 +19,7 @@ SLEntry = Dict[str, Any]
 
 def execute(filters=None):
 	columns, data = [], []
-	columns = get_columns()
+	columns = get_columns(filters)
 	data = get_data(filters)
 
 	return columns, data
@@ -42,10 +43,14 @@ def get_warehouse_wise_balance(filters: StockBalanceFilter) -> List[SLEntry]:
 
 
 def get_warehouses(report_filters: StockBalanceFilter):
+	filters = {"company": report_filters.company, "disabled": 0}
+	if report_filters.get("show_disabled_warehouses"):
+		filters["disabled"] = ("in", [0, report_filters.show_disabled_warehouses])
+
 	return frappe.get_all(
 		"Warehouse",
-		fields=["name", "parent_warehouse", "is_group"],
-		filters={"company": report_filters.company},
+		fields=["name", "parent_warehouse", "is_group", "disabled"],
+		filters=filters,
 		order_by="lft",
 	)
 
@@ -90,8 +95,8 @@ def set_balance_in_parent(warehouses):
 		update_balance(warehouse, warehouse.stock_balance)
 
 
-def get_columns():
-	return [
+def get_columns(filters: StockBalanceFilter) -> List[Dict]:
+	columns = [
 		{
 			"label": _("Warehouse"),
 			"fieldname": "name",
@@ -101,3 +106,15 @@ def get_columns():
 		},
 		{"label": _("Stock Balance"), "fieldname": "stock_balance", "fieldtype": "Float", "width": 150},
 	]
+
+	if filters.get("show_disabled_warehouses"):
+		columns.append(
+			{
+				"label": _("Warehouse Disabled?"),
+				"fieldname": "disabled",
+				"fieldtype": "Check",
+				"width": 200,
+			}
+		)
+
+	return columns


### PR DESCRIPTION
Added filter "Show Disabled Warehouses" to show disabled warehouses otherwise this report won't show disabled warehouses

<img width="707" alt="Screenshot 2023-04-17 at 11 02 38 AM" src="https://user-images.githubusercontent.com/8780500/232391530-30f34d7c-5d35-48fc-b52b-77ef03d8576a.png">
