### PR TITLE
fix: stock reconciliation test case

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -1451,6 +1451,8 @@ def get_next_stock_reco(kwargs):
 				)
 			)
 		)
+		.orderby(CombineDatetime(sle.posting_date, sle.posting_time))
+		.orderby(sle.creation)
 	)
 
 	if kwargs.get("batch_no"):


### PR DESCRIPTION
```
 FAIL  test_backdated_stock_reco_qty_reposting (erpnext.stock.doctype.stock_reconciliation.test_stock_reconciliation.TestStockReconciliation.test_backdated_stock_reco_qty_reposting)
Test if a backdated stock reco recalculates future qty until next reco.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py", line 440, in test_backdated_stock_reco_qty_reposting
    assertBalance(sr5, 8)
    assertBalance = <function TestStockReconciliation.test_backdated_stock_reco_qty_reposting.<locals>.assertBalance at 0x7f7e141e7ec0>
    item_code = 'd6c32d2cfbf0e09c'
    pr1 = <PurchaseReceipt: MAT-PRE-2023-00002 docstatus=1>
    pr2 = <PurchaseReceipt: MAT-PRE-2023-00003 docstatus=1>
    pr3 = <PurchaseReceipt: MAT-PRE-2023-00004 docstatus=1>
    pr5 = <PurchaseReceipt: MAT-PRE-2023-00005 docstatus=1>
    self = <erpnext.stock.doctype.stock_reconciliation.test_stock_reconciliation.TestStockReconciliation testMethod=test_backdated_stock_reco_qty_reposting>
    sr4 = <StockReconciliation: MAT-RECO-2023-00004 docstatus=1>
    sr5 = <StockReconciliation: MAT-RECO-2023-00005 docstatus=1>
    warehouse = '_Test Warehouse - _TC'
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py", line 405, in assertBalance
    self.assertEqual(sle_balance, qty_after_transaction)
    doc = <StockReconciliation: MAT-RECO-2023-00005 docstatus=1>
    qty_after_transaction = 8
    self = <erpnext.stock.doctype.stock_reconciliation.test_stock_reconciliation.TestStockReconciliation testMethod=test_backdated_stock_reco_qty_reposting>
    sle_balance = 18.0
AssertionError: 18.0 != 8
```