### PR TITLE
fix: allow submit delivery note when the sales order was billed...

### DIFF
--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -271,6 +271,9 @@ class DeliveryNote(SellingController):
 	def check_credit_limit(self):
 		from erpnext.selling.doctype.customer.customer import check_credit_limit
 
+		if self.per_billed == 100:
+			return
+
 		extra_amount = 0
 		validate_against_credit_limit = False
 		bypass_credit_limit_check_at_sales_order = cint(


### PR DESCRIPTION
Thinking of a flow below, where the Delivery Note and the Sales Invoice are generated from the sales order.

![image](https://user-images.githubusercontent.com/25017988/232777413-eefddf09-6703-47d4-a222-593783e36a76.png)

When the customer is checking for bypass_credit_limit_check_at_sales_order = 1 the system is forcing the validation of credit in the delivery note.

This makes sense because if the delivery note did not come from the invoice and skipped the credit validation on the order, it must validate on the delivery note.

However, if the order is already 100% invoiced even if the customer does not have credit, it means that he paid in advance or paid the invoice, which makes it possible for the delivery note not to validate the credit limit as it already happened on the invoice of sale and must not appear on the delivery note.