### PR TITLE
fix: batch qty conversion factor issue fixed in pos transaction

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -559,8 +559,10 @@ erpnext.PointOfSale.Controller = class {
 
 				item_row = this.frm.add_child('items', new_item);
 
-				if (field === 'qty' && value !== 0 && !this.allow_negative_stock)
-					await this.check_stock_availability(item_row, value, this.frm.doc.set_warehouse);
+				if (field === 'qty' && value !== 0 && !this.allow_negative_stock) {
+					const qty_needed = value * item_row.conversion_factor;
+					await this.check_stock_availability(item_row, qty_needed, this.frm.doc.set_warehouse);
+				}
 
 				await this.trigger_new_item_events(item_row);
 

--- a/erpnext/stock/doctype/batch/batch.py
+++ b/erpnext/stock/doctype/batch/batch.py
@@ -376,7 +376,7 @@ def get_pos_reserved_batch_qty(filters):
 
 	p = frappe.qb.DocType("POS Invoice").as_("p")
 	item = frappe.qb.DocType("POS Invoice Item").as_("item")
-	sum_qty = frappe.query_builder.functions.Sum(item.qty).as_("qty")
+	sum_qty = frappe.query_builder.functions.Sum(item.stock_qty).as_("qty")
 
 	reserved_batch_qty = (
 		frappe.qb.from_(p)


### PR DESCRIPTION
Problem: Batch Qty not taking as stock qty.
In Batch .2 kgs  means 200 gram stock available.
If we try to sell 50g stock form it should allow to sell
which will be 200g - 50g = 150g it should allow but gives error

Before:

https://user-images.githubusercontent.com/6947417/230882688-2b705d9b-db64-49a0-a2d1-fc52581525f1.mp4


After:

https://user-images.githubusercontent.com/6947417/230882762-d9b805ae-6f5b-4b5c-9ea1-829b28d846ce.mp4



