### PR TITLE
refactor: refactor set_missing_values and set_missing_ref_details in Payment Entry

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -60,6 +60,7 @@ class PaymentEntry(AccountsController):
 	def validate(self):
 		self.setup_party_account_field()
 		self.set_missing_values()
+		self.set_missing_ref_details()
 		self.validate_payment_type()
 		self.validate_party_details()
 		self.set_exchange_rate()
@@ -218,8 +219,6 @@ class PaymentEntry(AccountsController):
 			if self.payment_type == "Receive"
 			else self.paid_to_account_currency
 		)
-
-		self.set_missing_ref_details()
 
 	def set_missing_ref_details(self, force=False):
 		for d in self.get("references"):
@@ -1811,6 +1810,7 @@ def get_payment_entry(
 
 	pe.setup_party_account_field()
 	pe.set_missing_values()
+	pe.set_missing_ref_details()
 
 	update_accounting_dimensions(pe, doc)
 

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -220,9 +220,16 @@ class PaymentEntry(AccountsController):
 			else self.paid_to_account_currency
 		)
 
-	def set_missing_ref_details(self, force=False):
+	def set_missing_ref_details(
+		self, force: bool = False, update_ref_details_only_for: list | None = None
+	) -> None:
 		for d in self.get("references"):
 			if d.allocated_amount:
+				if update_ref_details_only_for and (
+					not (d.reference_doctype, d.reference_name) in update_ref_details_only_for
+				):
+					continue
+
 				ref_details = get_reference_details(
 					d.reference_doctype, d.reference_name, self.party_account_currency
 				)

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -646,6 +646,7 @@ def update_reference_in_payment_entry(d, payment_entry, do_not_save=False):
 	payment_entry.flags.ignore_validate_update_after_submit = True
 	payment_entry.setup_party_account_field()
 	payment_entry.set_missing_values()
+	payment_entry.set_missing_ref_details()
 	payment_entry.set_amounts()
 
 	if not do_not_save:


### PR DESCRIPTION
Pull `set_missing_ref_details` out of `set_missing_values` method in Payment Entry. This was needed to pick and choose when to update ref details while reconciling large no of invoices.

related: https://github.com/frappe/erpnext/pull/34596, https://github.com/frappe/hrms/pull/458

`no-docs`