### PR TITLE
fix: broken 'set exchange gain/loss' btn in payment entry

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -977,6 +977,7 @@ frappe.ui.form.on('Payment Entry', {
 							precision("difference_amount"));
 
 						const add_deductions = (details) => {
+							let row = null;
 							if (!write_off_row.length && difference_amount) {
 								row = frm.add_child("deductions");
 								row.account = details[account];


### PR DESCRIPTION
Fix undefined `row` error when `Set Exchange Gain/Loss` is triggered.

<img width="1440" alt="Screenshot 2023-04-20 at 10 41 26 AM" src="https://user-images.githubusercontent.com/3272205/233264227-05cd222a-2f69-41cf-a35d-110475ab3d95.png">
