### PR TITLE
fix: Bulk Payment Entry from PO/SO

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order_list.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order_list.js
@@ -43,7 +43,7 @@ frappe.listview_settings['Purchase Order'] = {
 		});
 
 		listview.page.add_action_item(__("Advance Payment"), ()=>{
-			erpnext.bulk_transaction_processing.create(listview, "Purchase Order", "Advance Payment");
+			erpnext.bulk_transaction_processing.create(listview, "Purchase Order", "Payment Entry");
 		});
 
 	}

--- a/erpnext/selling/doctype/sales_order/sales_order_list.js
+++ b/erpnext/selling/doctype/sales_order/sales_order_list.js
@@ -57,7 +57,7 @@ frappe.listview_settings['Sales Order'] = {
 		});
 
 		listview.page.add_action_item(__("Advance Payment"), ()=>{
-			erpnext.bulk_transaction_processing.create(listview, "Sales Order", "Advance Payment");
+			erpnext.bulk_transaction_processing.create(listview, "Sales Order", "Payment Entry");
 		});
 
 	}

--- a/erpnext/utilities/bulk_transaction.py
+++ b/erpnext/utilities/bulk_transaction.py
@@ -69,7 +69,7 @@ def task(doc_name, from_doctype, to_doctype):
 		"Sales Order": {
 			"Sales Invoice": sales_order.make_sales_invoice,
 			"Delivery Note": sales_order.make_delivery_note,
-			"Advance Payment": payment_entry.get_payment_entry,
+			"Payment Entry": payment_entry.get_payment_entry,
 		},
 		"Sales Invoice": {
 			"Delivery Note": sales_invoice.make_delivery_note,
@@ -86,11 +86,11 @@ def task(doc_name, from_doctype, to_doctype):
 		"Supplier Quotation": {
 			"Purchase Order": supplier_quotation.make_purchase_order,
 			"Purchase Invoice": supplier_quotation.make_purchase_invoice,
-			"Advance Payment": payment_entry.get_payment_entry,
 		},
 		"Purchase Order": {
 			"Purchase Invoice": purchase_order.make_purchase_invoice,
 			"Purchase Receipt": purchase_order.make_purchase_receipt,
+			"Payment Entry": payment_entry.get_payment_entry,
 		},
 		"Purchase Invoice": {
 			"Purchase Receipt": purchase_invoice.make_purchase_receipt,
@@ -98,7 +98,7 @@ def task(doc_name, from_doctype, to_doctype):
 		},
 		"Purchase Receipt": {"Purchase Invoice": purchase_receipt.make_purchase_invoice},
 	}
-	if to_doctype in ["Advance Payment", "Payment Entry"]:
+	if to_doctype in ["Payment Entry"]:
 		obj = mapper[from_doctype][to_doctype](from_doctype, doc_name)
 	else:
 		obj = mapper[from_doctype][to_doctype](doc_name)


### PR DESCRIPTION
**Version:** 
ERPNext: v14.22.0 (version-14)
Frappe Framework: v14.33.0 (version-14)
___
Issue: https://discuss.frappe.io/t/bulk-payment-entry-from-po/103818
___
**Before:**
- When create a bulk payment entry from a Purchase Order or Sales Order, then the Advance Payment doctype not found error shows. And we checked in the doctype list so there is not an Advance Payment doctype.
- And also there is not any feature/option found in Supplier Quotation for Advance Payment so we did remove the line from bulk_transaction.py


https://user-images.githubusercontent.com/34390782/233266242-99a5c9f0-5324-4eaf-b5c9-9b8d96733d46.mp4

<br>

**After:**
- After the set to Advance Payment to Payment Entry in sales_order_list.js, purchase_order_list.js, and bulk_transaction.py, and checked it so it worked.

Check it.

https://user-images.githubusercontent.com/34390782/233267086-781181f2-6bf3-4d42-bb63-b3a65a32dabc.mp4

Thanks and Regards,
Nihantra Patel (NCP)
Solufy