### PR TITLE
fix: Use for update flag in batch qty update

### DIFF
--- a/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py
+++ b/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py
@@ -65,7 +65,6 @@ class StockLedgerEntry(Document):
 					"Stock Ledger Entry",
 					{"docstatus": 1, "batch_no": self.batch_no, "is_cancelled": 0},
 					"sum(actual_qty)",
-					for_update=True,
 				)
 				or 0
 			)

--- a/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py
+++ b/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py
@@ -65,6 +65,7 @@ class StockLedgerEntry(Document):
 					"Stock Ledger Entry",
 					{"docstatus": 1, "batch_no": self.batch_no, "is_cancelled": 0},
 					"sum(actual_qty)",
+					for_update=True,
 				)
 				or 0
 			)

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -1456,7 +1456,7 @@ def get_next_stock_reco(kwargs):
 	)
 
 	if kwargs.get("batch_no"):
-		query.where(sle.batch_no == kwargs.get("batch_no"))
+		query = query.where(sle.batch_no == kwargs.get("batch_no"))
 
 	return query.run(as_dict=True)
 


### PR DESCRIPTION
![telegram-cloud-photo-size-5-6197368617213998334-y](https://user-images.githubusercontent.com/42651287/233282384-5f325905-85ad-4651-97f0-4d386ce25ac5.jpg)

Document submission throws a deadlock in the `calculate_batch_qty` method if the document has batched items