### PR TITLE
fix: process_loss_percentage in BOM

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.js
+++ b/erpnext/manufacturing/doctype/bom/bom.js
@@ -411,7 +411,6 @@ frappe.ui.form.on("BOM", {
 		}
 
 		frm.set_value("process_loss_qty", qty);
-		frm.set_value("add_process_loss_cost_in_fg", qty ? 1: 0);
 	}
 });
 


### PR DESCRIPTION
**Version:**
ERPNext: v14.22.0 (version-14)
Frappe Framework: v14.33.0 (version-14)
___
Issue: #34941
___

**Before:**

- When creating a new BOM and then adding the (%) Process Loss then show the message like Field add_process_loss_cost_in_fg not found. 
- We checked in BOM doctype so there is no name of the add_process_loss_cost_in_fg field.

![image](https://user-images.githubusercontent.com/34390782/233318204-a74af7b1-7aea-4b80-9879-06be98331989.png)

<br>

**After:**
- After the remove the below line, it works properly.

https://github.com/frappe/erpnext/blob/ea6eeace8028ded8d19ae4795887ec9750298d89/erpnext/manufacturing/doctype/bom/bom.js#L414

![image](https://user-images.githubusercontent.com/34390782/233319455-d0403e0a-f72f-4580-8a47-a792a076398e.png)

Thanks and Regards,
Nihantra Patel (NCP)
Solufy