### PR TITLE
fix: Use set instead of db_set as it is called from validate

### DIFF
--- a/erpnext/crm/doctype/opportunity/opportunity.py
+++ b/erpnext/crm/doctype/opportunity/opportunity.py
@@ -59,7 +59,7 @@ class Opportunity(TransactionBase, CRMNote):
 			if not self.get(field) and frappe.db.field_exists(self.opportunity_from, field):
 				try:
 					value = frappe.db.get_value(self.opportunity_from, self.party_name, field)
-					self.db_set(field, value)
+					self.set(field, value)
 				except Exception:
 					continue
 


### PR DESCRIPTION
Use `set` instead of `db_set`  while fetching field values from lead, as it is called from validate