### PR TITLE
fix: per_billed condition for Payment Entry

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -1687,7 +1687,10 @@ def get_payment_entry(
 ):
 	reference_doc = None
 	doc = frappe.get_doc(dt, dn)
-	if dt in ("Sales Order", "Purchase Order") and flt(doc.per_billed, 2) >= 99.99:
+	over_billing_allowance = frappe.db.get_single_value("Accounts Settings", "over_billing_allowance")
+	if dt in ("Sales Order", "Purchase Order") and flt(doc.per_billed, 2) >= (
+		100.0 + over_billing_allowance
+	):
 		frappe.throw(_("Can only make payment against unbilled {0}").format(dt))
 
 	if not party_type:


### PR DESCRIPTION
Old behavior:

- v13: if SO has been billed `>= 0 %`, you cannot create a Payment Entry against the SO
- v14: if SO has been billed `>= 99.99 %`, you cannot create a Payment Entry against the SO

New behavior:

- v14: if SO has been billed `>= 100 % + over_billing_allowance`, you cannot create a Payment Entry against the SO

(same applies to PO)

Use case: in services, orders can get more expensive during fulfillment. Overbilling allows us to put more on the sales invoice. But it was not possible to create overbilled advance payments against the SO, due to above validations.