### PR TITLE
fix: added validation for extra job cards

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -74,6 +74,37 @@ class JobCard(Document):
 		self.update_sub_operation_status()
 		self.validate_work_order()
 
+	def on_update(self):
+		self.validate_job_card_qty()
+
+	def validate_job_card_qty(self):
+		if not (self.operation_id and self.work_order):
+			return
+
+		wo_qty = flt(frappe.get_cached_value("Work Order", self.work_order, "qty"))
+
+		completed_qty = flt(
+			frappe.db.get_value("Work Order Operation", self.operation_id, "completed_qty")
+		)
+
+		job_card_qty = frappe.get_all(
+			"Job Card",
+			fields=["sum(for_quantity)"],
+			filters={
+				"work_order": self.work_order,
+				"operation_id": self.operation_id,
+				"docstatus": ["!=", 2],
+			},
+			as_list=1,
+		)
+
+		job_card_qty = flt(job_card_qty[0][0]) if job_card_qty else 0
+
+		if job_card_qty and ((job_card_qty - completed_qty) > wo_qty):
+			msg = f"""Job Card quantity cannot be greater than
+				Work Order quantity for the operation {self.operation}"""
+			frappe.throw(_(msg), title=_("Extra Job Card Quantity"))
+
 	def set_sub_operations(self):
 		if not self.sub_operations and self.operation:
 			self.sub_operations = []


### PR DESCRIPTION
fixed https://github.com/frappe/erpnext/issues/34936

If user tried to make an extra job card then system will throw the below error

<img width="689" alt="image" src="https://user-images.githubusercontent.com/8780500/233631651-3212ff2a-7ef7-4aae-92ed-3aae96f559b1.png">

#no-docs