### PR TITLE
fix: item not showing in the BOM

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -1317,7 +1317,7 @@ def item_query(doctype, txt, searchfield, start, page_len, filters):
 		if not field in searchfields
 	]
 
-	query_filters = {"disabled": 0, "end_of_life": (">", today())}
+	query_filters = {"disabled": 0, "ifnull(end_of_life, '3099-12-31')": (">", today())}
 
 	or_cond_filters = {}
 	if txt:


### PR DESCRIPTION
**Issue**

Item is not showing while making the BOM

<img width="1327" alt="Screenshot 2023-04-24 at 2 49 13 PM" src="https://user-images.githubusercontent.com/8780500/233955337-b9fbf529-1ba2-4c39-a56f-09ab4b32b6b7.png">

**Investigate**  

This end of life has not set in the Item, system was taking the fallback date as "0001-01-01" which is less than current date and due to which the item was not showing in the BOM
<img width="848" alt="Screenshot 2023-04-24 at 2 50 56 PM" src="https://user-images.githubusercontent.com/8780500/233955496-bee8256f-33a5-40b0-a2f0-d0e97509dd3d.png">


**After Fix**
<img width="1331" alt="Screenshot 2023-04-24 at 2 49 31 PM" src="https://user-images.githubusercontent.com/8780500/233956091-979d0ed8-b8ee-4947-836a-a264da609747.png">

