### PR TITLE
fix: incorrect OR condition causing timeout error (For more than 50 line items)

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -1441,13 +1441,13 @@ def get_next_stock_reco(kwargs):
 				(
 					CombineDatetime(sle.posting_date, sle.posting_time)
 					> CombineDatetime(kwargs.get("posting_date"), kwargs.get("posting_time"))
-					| (
-						(
-							CombineDatetime(sle.posting_date, sle.posting_time)
-							== CombineDatetime(kwargs.get("posting_date"), kwargs.get("posting_time"))
-						)
-						& (sle.creation > kwargs.get("creation"))
+				)
+				| (
+					(
+						CombineDatetime(sle.posting_date, sle.posting_time)
+						== CombineDatetime(kwargs.get("posting_date"), kwargs.get("posting_time"))
 					)
+					& (sle.creation > kwargs.get("creation"))
 				)
 			)
 		)


### PR DESCRIPTION
**Issue**

```
SELECT `name`,`posting_date`,`posting_time`,`creation`,`voucher_no`,`item_code`,`batch_no`,`actual_qty` FROM `tabStock Ledger Entry` WHERE `item_code`='PSM 025' AND `warehouse`='Chen-FG - KEPL:' AND `voucher_type`='Stock Reconciliation' AND `voucher_no`<>'KE/DN/24/00856' AND `is_cancelled`=0 AND TIMESTAMP(`posting_date`,`posting_time`)>TIMESTAMP('2023-04-24','16:41:39.543594') OR (TIMESTAMP(`posting_date`,`posting_time`)=TIMESTAMP('2023-04-24','16:41:39.543594') AND `creation`>'2023-04-24 16:42:12.282963') ORDER BY TIMESTAMP(`posting_date`,`posting_time`),`creation` LIMIT 1
```

In the above query, after the is_cancelled condition and before the timestamp condition round bracket was expected but due to incorrect formatting the round bracket has missed (check below highlighted part). 

`is_cancelled`=0 AND **TIMESTAMP(`posting_date`,`posting_time`)>TIMESTAMP('2023-04-24','16:41:39.543594') OR (TIMESTAMP(`posting_date`,`posting_time`)=TIMESTAMP('2023-04-24','16:41:39.543594') AND `creation`>'2023-04-24 16:42:12.282963')**

 Because of missing the round brackets, the query was taking extra time to execute which was causing the timeout error. Below image showing that the system was taking 1.05 seconds to execute the query.


<img width="1438" alt="Screenshot 2023-04-24 at 5 21 02 PM" src="https://user-images.githubusercontent.com/8780500/233991878-93c56cbc-af65-402a-be5f-9b558c31191f.png">


**After Fix**

After the fix system is taking 0.009 seconds

<img width="1431" alt="Screenshot 2023-04-24 at 5 21 02 PM" src="https://user-images.githubusercontent.com/8780500/233992117-9a307732-823e-4ba8-b4d7-d05a06e39c88.png">



