### PR TITLE
Change default Customer naming to Naming Series

### DIFF
--- a/erpnext/setup/setup_wizard/operations/defaults_setup.py
+++ b/erpnext/setup/setup_wizard/operations/defaults_setup.py
@@ -41,7 +41,7 @@ def set_default_settings(args):
 	stock_settings.save()
 
 	selling_settings = frappe.get_doc("Selling Settings")
-	selling_settings.cust_master_name = "Customer Name"
+	selling_settings.cust_master_name = "Naming Series"
 	selling_settings.so_required = "No"
 	selling_settings.dn_required = "No"
 	selling_settings.allow_multiple_items = 1


### PR DESCRIPTION
On a new installation, a customer is identified by their name. This becomes a problem if you get customers who share names as it raises a duplicate exception. I think the default naming scheme should be series, and then an administrator can change it to the customer's name if need be as opposed to it being the other way around.