### PR TITLE
fix: Patch for posting closing balances

### DIFF
--- a/erpnext/patches/v14_0/update_closing_balances.py
+++ b/erpnext/patches/v14_0/update_closing_balances.py
@@ -26,7 +26,15 @@ def execute():
 			pcv_doc.year_start_date = get_fiscal_year(
 				pcv.posting_date, pcv.fiscal_year, company=pcv.company
 			)[1]
-			gl_entries = pcv_doc.get_gl_entries()
+
+			gl_entries = frappe.db.get_all(
+				"GL Entry", filters={"voucher_no": pcv.name, "is_cancelled": 0}, fields=["*"]
+			)
+			for entry in gl_entries:
+				entry["is_period_closing_voucher_entry"] = 1
+				entry["closing_date"] = pcv_doc.posting_date
+				entry["period_closing_voucher"] = pcv_doc.name
+
 			closing_entries = pcv_doc.get_grouped_gl_entries(get_opening_entries=get_opening_entries)
 			make_closing_entries(gl_entries + closing_entries, voucher_name=pcv.name)
 			company_wise_order[pcv.company].append(pcv.posting_date)


### PR DESCRIPTION
The logic for posting GL Entries against Period Closing Voucher has changed over the period of last few years.
Earlier the patch was using the new logic to generate Account Closing Balances for PCV which led to a mismatch in the reports.

To avoid this use old PCV GL entries.