### PR TITLE
fix: pass reference_doctype in link queries

### DIFF
--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -576,7 +576,9 @@ def get_income_account(doctype, txt, searchfield, start, page_len, filters):
 
 @frappe.whitelist()
 @frappe.validate_and_sanitize_search_inputs
-def get_filtered_dimensions(doctype, txt, searchfield, start, page_len, filters):
+def get_filtered_dimensions(
+	doctype, txt, searchfield, start, page_len, filters, reference_doctype=None
+):
 	from erpnext.accounts.doctype.accounting_dimension_filter.accounting_dimension_filter import (
 		get_dimension_filter_map,
 	)
@@ -617,7 +619,12 @@ def get_filtered_dimensions(doctype, txt, searchfield, start, page_len, filters)
 		query_filters.append(["name", query_selector, dimensions])
 
 	output = frappe.get_list(
-		doctype, fields=fields, filters=query_filters, or_filters=or_filters, as_list=1
+		doctype,
+		fields=fields,
+		filters=query_filters,
+		or_filters=or_filters,
+		as_list=1,
+		reference_doctype=reference_doctype,
 	)
 
 	return [tuple(d) for d in set(output)]


### PR DESCRIPTION
Isssue: If you create user permissions with "applicable_for" it's supposed to apply those UP to queries when link field is getting queries, however, the reference doctype isn't passed at all in this query so there's no way for framework to know where it's being linked. 

refer:


- https://github.com/frappe/frappe/blob/e6279e08f28f4b970d474bb8b7e4e0b0637b955b/frappe/model/db_query.py#L174-L176
- https://github.com/frappe/frappe/blob/e6279e08f28f4b970d474bb8b7e4e0b0637b955b/frappe/model/db_query.py#L962-L969



depends on https://github.com/frappe/frappe/pull/20842
