### PR TITLE
fix: Report link, option, and added a link for Sales Person in GP

### DIFF
--- a/erpnext/accounts/report/gross_profit/gross_profit.js
+++ b/erpnext/accounts/report/gross_profit/gross_profit.js
@@ -73,7 +73,7 @@ frappe.query_reports["Gross Profit"] = {
 		if (column.fieldname == "sales_invoice" && column.options == "Item" && data && data.indent == 0) {
 			column._options = "Sales Invoice";
 		} else {
-			column._options = "Item";
+			column._options = "";
 		}
 		value = default_formatter(value, row, column, data);
 

--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -250,7 +250,7 @@ def get_columns(group_wise_columns, filters):
 				"label": _("Warehouse"),
 				"fieldname": "warehouse",
 				"fieldtype": "Link",
-				"options": "warehouse",
+				"options": "Warehouse",
 				"width": 100,
 			},
 			"qty": {"label": _("Qty"), "fieldname": "qty", "fieldtype": "Float", "width": 80},
@@ -305,7 +305,8 @@ def get_columns(group_wise_columns, filters):
 			"sales_person": {
 				"label": _("Sales Person"),
 				"fieldname": "sales_person",
-				"fieldtype": "Data",
+				"fieldtype": "Link",
+				"options": "Sales Person",
 				"width": 100,
 			},
 			"allocated_amount": {
@@ -326,14 +327,14 @@ def get_columns(group_wise_columns, filters):
 				"label": _("Customer Group"),
 				"fieldname": "customer_group",
 				"fieldtype": "Link",
-				"options": "customer",
+				"options": "Customer Group",
 				"width": 100,
 			},
 			"territory": {
 				"label": _("Territory"),
 				"fieldname": "territory",
 				"fieldtype": "Link",
-				"options": "territory",
+				"options": "Territory",
 				"width": 100,
 			},
 			"monthly": {


### PR DESCRIPTION
**Version:**

ERPNext: v14.23.0 (version-14)
Frappe Framework: v14.34.0 (version-14)

fixes #35072
___

**Before:**

- When selecting a group by Item Group, Brand, Warehouse, Customer, Customer Group, Territory, Sales Person, Project, and Payment Term, then click on columns that are linked so all links go to the item master 
```
/item/....
```


https://user-images.githubusercontent.com/34390782/234824475-7b95aefb-a309-4304-9128-4782e995368a.mp4

<br>

**After:**
- After setting the filter condition in gross_profit.js and report work properly with the link.
- Set the option in Warehouse, Customer Group, and Territory.
- Also added a link option for Sales Person.


https://user-images.githubusercontent.com/34390782/234826024-22cbcab9-f2af-4460-8030-035df20ff9e0.mp4

<br>

Thanks and Regards,
Nihantra Patel (NCP)