### PR TITLE
fix: allow over-payment against SO

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -264,7 +264,7 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 					}
 				}
 				// payment request
-				if(flt(doc.per_billed)<100) {
+				if(flt(doc.per_billed, precision('per_billed', doc)) < 100 + frappe.boot.sysdefaults.over_billing_allowance) {
 					this.frm.add_custom_button(__('Payment Request'), () => this.make_payment_request(), __('Create'));
 					this.frm.add_custom_button(__('Payment'), () => this.make_payment_entry(), __('Create'));
 				}

--- a/erpnext/startup/boot.py
+++ b/erpnext/startup/boot.py
@@ -21,6 +21,10 @@ def boot_session(bootinfo):
 		bootinfo.sysdefaults.allow_stale = cint(
 			frappe.db.get_single_value("Accounts Settings", "allow_stale")
 		)
+		bootinfo.sysdefaults.over_billing_allowance = frappe.db.get_single_value(
+			"Accounts Settings", "over_billing_allowance"
+		)
+
 		bootinfo.sysdefaults.quotation_valid_till = cint(
 			frappe.db.get_single_value("CRM Settings", "default_valid_till")
 		)


### PR DESCRIPTION
If overbilling is allowed via **Accounts Settings**, users should be able to record advance payments against SO up to that amount.

Backend validation handled in #34969