### PR TITLE
fix: Hyperlink in Quality Inspection Summary

### DIFF
--- a/erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py
+++ b/erpnext/manufacturing/report/quality_inspection_summary/quality_inspection_summary.py
@@ -69,7 +69,7 @@ def get_columns(filters):
 			"label": _("Id"),
 			"fieldname": "name",
 			"fieldtype": "Link",
-			"options": "Work Order",
+			"options": "Quality Inspection",
 			"width": 100,
 		},
 		{"label": _("Report Date"), "fieldname": "report_date", "fieldtype": "Date", "width": 150},


### PR DESCRIPTION
**Version:**

ERPNext: v14.23.0 (version-14)
Frappe Framework: v14.34.0 (version-14)

fixes #35074 
___

**Before:**

- When clicking on QC id then redirect to the work order.


https://user-images.githubusercontent.com/34390782/234850881-6029aec8-785c-497c-8b31-adc8b801217c.mp4

<br>

**After:**
- After setting the option Work Order -> Quality Inspection, the hyperlink works properly.


https://user-images.githubusercontent.com/34390782/234851173-6f287452-77bf-46f9-84ff-d1d00ffac661.mp4

<br>

Thanks and Regards,
Nihantra Patel (NCP)