### PR TITLE
fix: Naming series error in Journal Entry template

### DIFF
--- a/erpnext/accounts/doctype/journal_entry_template/journal_entry_template.js
+++ b/erpnext/accounts/doctype/journal_entry_template/journal_entry_template.js
@@ -2,6 +2,21 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Journal Entry Template", {
+	onload: function(frm) {
+		if(frm.is_new()) {
+			frappe.call({
+				type: "GET",
+				method: "erpnext.accounts.doctype.journal_entry_template.journal_entry_template.get_naming_series",
+				callback: function(r){
+					if(r.message) {
+						frm.set_df_property("naming_series", "options", r.message.split("\n"));
+						frm.set_value("naming_series", r.message.split("\n")[0]);
+						frm.refresh_field("naming_series");
+					}
+				}
+			});
+		}
+	},
 	refresh: function(frm) {
 		frappe.model.set_default_values(frm.doc);
 
@@ -18,18 +33,6 @@ frappe.ui.form.on("Journal Entry Template", {
 			}
 
 			return { filters: filters };
-		});
-
-		frappe.call({
-			type: "GET",
-			method: "erpnext.accounts.doctype.journal_entry_template.journal_entry_template.get_naming_series",
-			callback: function(r){
-				if(r.message){
-					frm.set_df_property("naming_series", "options", r.message.split("\n"));
-					frm.set_value("naming_series", r.message.split("\n")[0]);
-					frm.refresh_field("naming_series");
-				}
-			}
 		});
 	},
 	voucher_type: function(frm) {


### PR DESCRIPTION
Naming series should not get reset on every refresh, only onload when the form is still not saved and primary key is not generated