### PR TITLE
fix: not able to create delivery note from sales order

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -1508,11 +1508,15 @@ def get_so_reservation_for_item(args):
 	elif args.get("against_sales_invoice"):
 		sales_order = frappe.db.get_all(
 			"Sales Invoice Item",
-			filters={"parent": args.get("against_sales_invoice"), "item_code": args.get("item_code")},
+			filters={
+				"parent": args.get("against_sales_invoice"),
+				"item_code": args.get("item_code"),
+				"docstatus": 1,
+			},
 			fields="sales_order",
 		)
 		if sales_order and sales_order[0]:
-			if get_reserved_qty_for_so(sales_order[0][0], args.get("item_code")):
+			if get_reserved_qty_for_so(sales_order[0].sales_order, args.get("item_code")):
 				reserved_so = sales_order[0]
 	elif args.get("sales_order"):
 		if get_reserved_qty_for_so(args.get("sales_order"), args.get("item_code")):


### PR DESCRIPTION
**Issue**

Getting below error while making delivery note against the sales order

```
 File "apps/erpnext/erpnext/accounts/doctype/sales_invoice/sales_invoice.py", line 1941, in make_delivery_note
  doclist = get_mapped_doc(
 File "apps/frappe/frappe/model/mapper.py", line 144, in get_mapped_doc
  postprocess(source_doc, target_doc)
 File "apps/erpnext/erpnext/accounts/doctype/sales_invoice/sales_invoice.py", line 1930, in set_missing_values
  target.run_method("set_missing_values")
 File "apps/frappe/frappe/model/document.py", line 914, in run_method
  out = Document.hook(fn)(self, *args, **kwargs)
 File "apps/frappe/frappe/model/document.py", line 1264, in composer
  return composed(self, method, *args, **kwargs)
 File "apps/frappe/frappe/model/document.py", line 1246, in runner
  add_to_return_value(self, fn(self, *args, **kwargs))
 File "apps/frappe/frappe/model/document.py", line 911, in fn
  return method_object(*args, **kwargs)
 File "apps/erpnext/erpnext/controllers/selling_controller.py", line 51, in set_missing_values
  self.set_price_list_and_item_details(for_validate=for_validate)
 File "apps/erpnext/erpnext/controllers/selling_controller.py", line 110, in set_price_list_and_item_details
  self.set_missing_item_details(for_validate=for_validate)
 File "apps/erpnext/erpnext/controllers/accounts_controller.py", line 539, in set_missing_item_details
  ret, basic_item_details = get_item_details(
 File "apps/erpnext/erpnext/stock/get_item_details.py", line 143, in get_item_details
  update_stock(args, out)
 File "apps/erpnext/erpnext/stock/get_item_details.py", line 192, in update_stock
  reserved_so = get_so_reservation_for_item(args)
 File "apps/erpnext/erpnext/stock/get_item_details.py", line 1531, in get_so_reservation_for_item
  if get_reserved_qty_for_so(sales_order[0][0], args.get("item_code")):
KeyError: 0
```