### PR TITLE
fix: function `batch_no` should only be declared once

### DIFF
--- a/erpnext/selling/sales_common.js
+++ b/erpnext/selling/sales_common.js
@@ -299,7 +299,8 @@ erpnext.selling.SellingController = class SellingController extends erpnext.Tran
 	}
 
 	batch_no(doc, cdt, cdn) {
-		var me = this;
+		super.batch_no(doc, cdt, cdn);
+
 		var item = frappe.get_doc(cdt, cdn);
 
 		if (item.serial_no) {
@@ -376,10 +377,6 @@ erpnext.selling.SellingController = class SellingController extends erpnext.Tran
 				if (doc.doctype === 'Sales Invoice' && (!doc.update_stock)) return;
 				this.set_batch_number(cdt, cdn);
 			}
-	}
-
-	batch_no(doc, cdt, cdn) {
-		super.batch_no(doc, cdt, cdn);
 	}
 
 	qty(doc, cdt, cdn) {


### PR DESCRIPTION
**Issue**

In Sales Invoice, **Available Batch Qty** was not updated on selection of `batch_no` because earlier function `batch_no` at https://github.com/frappe/erpnext/blob/85f3a5d318058676b8cd9f751d48399eb8b5b4d1/erpnext/selling/sales_common.js#L301 was never executed as it was overridden by https://github.com/frappe/erpnext/blob/85f3a5d318058676b8cd9f751d48399eb8b5b4d1/erpnext/selling/sales_common.js#L381.


![Before_change_in_batch_no](https://user-images.githubusercontent.com/54097382/235444697-8c721b5d-a075-4899-8893-3aa696942679.gif)

**After Fix**

![after_batch_no_change](https://user-images.githubusercontent.com/54097382/235444727-2c63c099-336f-4ac4-9d85-726efe2378cd.gif)
