### PR TITLE
feat: add todo calendar to bootinfo.calendars

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -74,14 +74,7 @@ update_website_context = [
 my_account_context = "erpnext.e_commerce.shopping_cart.utils.update_my_account_context"
 webform_list_context = "erpnext.controllers.website_list_for_contact.get_webform_list_context"
 
-calendars = [
-	"Task",
-	"Work Order",
-	"Leave Application",
-	"Sales Order",
-	"Holiday List",
-	"ToDo"
-]
+calendars = ["Task", "Work Order", "Leave Application", "Sales Order", "Holiday List", "ToDo"]
 
 website_generators = ["Item Group", "Website Item", "BOM", "Sales Partner"]
 

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -80,6 +80,7 @@ calendars = [
 	"Leave Application",
 	"Sales Order",
 	"Holiday List",
+	"ToDo"
 ]
 
 website_generators = ["Item Group", "Website Item", "BOM", "Sales Partner"]


### PR DESCRIPTION
Using the new CRM flow for Lead and Opportunity, when accessing the Calendar for Events you should have quick access to the ToDo calendar, the other way around too.

**Now on Event Calendar we can acess ToDo calendar:**
![image](https://user-images.githubusercontent.com/25017988/235491947-456c59dd-11d5-4ff1-8526-dab31fca77e7.png)

**ToDo Calendar:**
![image](https://user-images.githubusercontent.com/25017988/235492092-cd07292e-a0db-43b7-8609-7bfe41d17bcd.png)

`no-docs`