### PR TITLE
fix: upscrolling in single item variant

### DIFF
--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -772,12 +772,6 @@ $.extend(erpnext.item, {
 					if (modal) {
 						$(modal).removeClass("modal-dialog-scrollable");
 					}
-				})
-				.on("awesomplete-close", () => {
-					let modal = field.$input.parents('.modal-dialog')[0];
-					if (modal) {
-						$(modal).addClass("modal-dialog-scrollable");
-					}
 				});
 		});
 	},


### PR DESCRIPTION
**Title: Fix scrolling issue in variant dialog window for single variants**

**Description:**
This pull request fixes an issue in the variant dialog window for single variants in ERPNext. When the dialog window is too long, it keeps scrolling back to the top, making it difficult to use.

To fix this issue, we have removed some of the extra lines of code that were causing the problem, while keeping the same functionality. With this fix, users will be able to easily scroll through the dialog window without any interruptions.

Thanks for considering this pull request.