### PR TITLE
fix: ineffective bypass flag for Credit Limit in Customer Group

### DIFF
--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -617,11 +617,15 @@ def get_credit_limit(customer, company):
 
 		if not credit_limit:
 			customer_group = frappe.get_cached_value("Customer", customer, "customer_group")
-			credit_limit = frappe.db.get_value(
+
+			result = frappe.db.get_values(
 				"Customer Credit Limit",
 				{"parent": customer_group, "parenttype": "Customer Group", "company": company},
-				"credit_limit",
+				fieldname=["credit_limit", "bypass_credit_limit_check"],
+				as_dict=True,
 			)
+			if result and not result[0].bypass_credit_limit_check:
+				credit_limit = result[0].credit_limit
 
 	if not credit_limit:
 		credit_limit = frappe.get_cached_value("Company", company, "credit_limit")


### PR DESCRIPTION
Bypass flag for Credit Limit in `Customer Group` wasn't working. Fixing in this PR
<img width="1316" alt="Screenshot 2023-05-03 at 4 41 55 PM" src="https://user-images.githubusercontent.com/3272205/235900561-6d75ce97-dbbe-46b7-a18b-45eedb08c3bf.png">
