### PR TITLE
fix: based on status_update.py update opportunity status to converted…

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -217,6 +217,7 @@ class SalesOrder(SellingController):
 					frappe.throw(_("Quotation {0} is cancelled").format(quotation))
 
 				doc.set_status(update=True)
+				doc.update_opportunity("Converted" if flag == "submit" else "Quotation")
 
 	def validate_drop_ship(self):
 		for d in self.get("items"):


### PR DESCRIPTION
Looking at status_updater.py, the logic for the opportunity to be converted is to create a **Sales Order**.

However, currently this status does not update, I create the sales order and the status of the opportunity remains as **Quotation**.

So to solve the problem, when updating the Quotation status, it already updates the Opportunity status.

On submit sales order set opportunity status to **Converted**, on Cancel set status to **Quotation** back.