### PR TITLE
fix: over production percentage not considered in validation

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -87,6 +87,12 @@ class JobCard(Document):
 			frappe.db.get_value("Work Order Operation", self.operation_id, "completed_qty")
 		)
 
+		over_production_percentage = flt(
+			frappe.db.get_single_value("Manufacturing Settings", "overproduction_percentage_for_work_order")
+		)
+
+		wo_qty = wo_qty + (wo_qty * over_production_percentage / 100)
+
 		job_card_qty = frappe.get_all(
 			"Job Card",
 			fields=["sum(for_quantity)"],
@@ -101,8 +107,17 @@ class JobCard(Document):
 		job_card_qty = flt(job_card_qty[0][0]) if job_card_qty else 0
 
 		if job_card_qty and ((job_card_qty - completed_qty) > wo_qty):
-			msg = f"""Job Card quantity cannot be greater than
-				Work Order quantity for the operation {self.operation}"""
+			form_link = get_link_to_form("Manufacturing Settings", "Manufacturing Settings")
+
+			msg = f"""
+				Qty To Manufacture in the job card
+				cannot be greater than Qty To Manufacture in the
+				work order for the operation {bold(self.operation)}.
+				<br><br><b>Solution: </b> Either you can reduce the
+				Qty To Manufacture in the job card or set the
+				'Overproduction Percentage For Work Order'
+				in the {form_link}."""
+
 			frappe.throw(_(msg), title=_("Extra Job Card Quantity"))
 
 	def set_sub_operations(self):

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -1649,6 +1649,14 @@ class TestWorkOrder(FrappeTestCase):
 		job_card2 = frappe.copy_doc(job_card_doc)
 		self.assertRaises(frappe.ValidationError, job_card2.save)
 
+		frappe.db.set_single_value(
+			"Manufacturing Settings", "overproduction_percentage_for_work_order", 100
+		)
+
+		job_card2 = frappe.copy_doc(job_card_doc)
+		job_card2.time_logs = []
+		job_card2.save()
+
 
 def prepare_data_for_workstation_type_check():
 	from erpnext.manufacturing.doctype.operation.test_operation import make_operation


### PR DESCRIPTION
**Issue**

Overproduction Percentage For Work Order is set in the Manufacturing Settings, still getting below error

<img width="682" alt="image" src="https://user-images.githubusercontent.com/8780500/236003124-f62e186a-81af-493b-8952-2f0278981d47.png">

**After Fix**

User will able to submit the job card


Also changed the validation message

<img width="656" alt="image" src="https://user-images.githubusercontent.com/8780500/236003401-e991a4f7-7992-4ab3-bf33-d12320f3b548.png">