### PR TITLE
fix: Incorrect Earned Leaves Proration

### DIFF
--- a/erpnext/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
+++ b/erpnext/hr/doctype/leave_policy_assignment/leave_policy_assignment.py
@@ -143,9 +143,9 @@ def add_current_month_if_applicable(months_passed, date_of_joining, based_on_doj
 	date = getdate(frappe.flags.current_date) or getdate()
 
 	if based_on_doj:
-		# if leave type allocation is based on DOJ, and the date of assignment creation is same as DOJ,
+		# if leave type allocation is based on DOJ, and the date of assignment creation is after DOJ,
 		# then the month should be considered
-		if date.day == date_of_joining.day:
+		if date.day >= date_of_joining.day:
 			months_passed += 1
 	else:
 		last_day_of_month = get_last_day(date)


### PR DESCRIPTION
If today date is after or equal to employee's joining date, current month should be considered in earned leaves proration.

## Test Cases
- [x] Today Date: 1, Joining Date: 5, Result: +0
- [x] Today Date: 5, Joining Date: 5, Result: +1
- [x] Today Date: 24, Joining Date: 5, Result: +1