### PR TITLE
fix: internal transfer condition

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -379,7 +379,7 @@ class PurchaseReceipt(BuyingController):
 					)
 
 					outgoing_amount = d.base_net_amount
-					if self.is_internal_supplier and d.valuation_rate:
+					if self.is_internal_transfer() and d.valuation_rate:
 						outgoing_amount = abs(
 							frappe.db.get_value(
 								"Stock Ledger Entry",

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -556,7 +556,7 @@ class update_entries_after(object):
 			sle.voucher_type in ["Purchase Receipt", "Purchase Invoice"]
 			and sle.voucher_detail_no
 			and sle.actual_qty < 0
-			and frappe.get_cached_value(sle.voucher_type, sle.voucher_no, "is_internal_supplier")
+			and is_internal_transfer(sle)
 		):
 			sle.outgoing_rate = get_incoming_rate_for_inter_company_transfer(sle)
 
@@ -679,7 +679,7 @@ class update_entries_after(object):
 			elif (
 				sle.voucher_type in ["Purchase Receipt", "Purchase Invoice"]
 				and sle.voucher_detail_no
-				and frappe.get_cached_value(sle.voucher_type, sle.voucher_no, "is_internal_supplier")
+				and is_internal_transfer(sle)
 			):
 				rate = get_incoming_rate_for_inter_company_transfer(sle)
 			else:
@@ -1609,3 +1609,15 @@ def get_incoming_rate_for_inter_company_transfer(sle) -> float:
 		)
 
 	return rate
+
+
+def is_internal_transfer(sle):
+	data = frappe.get_cached_value(
+		sle.voucher_type,
+		sle.voucher_no,
+		["is_internal_supplier", "represents_company", "company"],
+		as_dict=True,
+	)
+
+	if data.is_internal_supplier and data.represents_company == data.company:
+		return True


### PR DESCRIPTION
There are two scenarios which are as follows

Transfer between two branches of same company -> Delivery Note Required while making Purchase Receipt 
Transfer between two branches of different company -> You can make Delivery Note and Purchase Receipt Individually


In the first case the rate in the purchase receipt should be same as delivery note and therefore reference of delivery note is required. Where as in the second case the rate of delivery note and purchase receipt might be different and therefore rate is not required.

Currently system is forcing to check reference in second case which is not required.