### PR TITLE
fix: not allow to transfer excess materials against the job card

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -127,6 +127,7 @@ class StockEntry(StockController):
 		self.validate_fg_completed_qty()
 		self.validate_difference_account()
 		self.set_job_card_data()
+		self.validate_job_card_item()
 		self.set_purpose_for_stock_entry()
 		self.clean_serial_nos()
 		self.validate_duplicate_serial_no()
@@ -210,6 +211,24 @@ class StockEntry(StockController):
 			self.work_order = data.work_order
 			self.from_bom = 1
 			self.bom_no = data.bom_no
+
+	def validate_job_card_item(self):
+		if not self.job_card:
+			return
+
+		if cint(frappe.db.get_single_value("Manufacturing Settings", "job_card_excess_transfer")):
+			return
+
+		for row in self.items:
+			if row.job_card_item:
+				continue
+
+			msg = f"""Row #{0}: The job card item reference
+				is missing. Kindly create the stock entry
+				from the job card. If you have added the row manually
+				then you won't be able to add job card item reference."""
+
+			frappe.throw(_(msg))
 
 	def validate_work_order_status(self):
 		pro_doc = frappe.get_doc("Work Order", self.work_order)


### PR DESCRIPTION
**Issue**

1. Disabled the "Allow Excess Material Transfer" in the "Manufacturing Settings"
2. Create a work order with operations and set "Transfer Material Against" as "Job Card"
3. Submit the work order, system will create the job cards for operations.
4. Open a job card, click on "Material Transfer"
5. System will open the stock entry with raw materials
6. Now Manually add one more row for raw materials without reference of Job Card Item and submit the stock entry
7. System allowed to Transfer Excess Materials against the job card even though "Allow Excess Material Transfer" has disabled in the "Manufacturing Settings"

**After Fix**

System will throw below error
<img width="756" alt="image" src="https://user-images.githubusercontent.com/8780500/236213356-6f9b43f7-9ca8-411d-902f-760da9ce5d4c.png">

