### PR TITLE
fix: child acc will inherit acc currency if explicitly specified

### DIFF
--- a/erpnext/accounts/doctype/account/account.py
+++ b/erpnext/accounts/doctype/account/account.py
@@ -204,8 +204,11 @@ class Account(NestedSet):
 				)
 
 	def validate_account_currency(self):
+		self.currency_explicitly_specified = True
+
 		if not self.account_currency:
 			self.account_currency = frappe.get_cached_value("Company", self.company, "default_currency")
+			self.currency_explicitly_specified = False
 
 		gl_currency = frappe.db.get_value("GL Entry", {"account": self.name}, "account_currency")
 
@@ -251,8 +254,10 @@ class Account(NestedSet):
 					{
 						"company": company,
 						# parent account's currency should be passed down to child account's curreny
-						# if it is None, it picks it up from default company currency, which might be unintended
-						"account_currency": erpnext.get_company_currency(company),
+						# if currency explicitly specified by user, child will inherit. else, default currency will be used.
+						"account_currency": self.account_currency
+						if self.currency_explicitly_specified
+						else erpnext.get_company_currency(company),
 						"parent_account": parent_acc_name_map[company],
 					}
 				)

--- a/erpnext/accounts/doctype/account/test_account.py
+++ b/erpnext/accounts/doctype/account/test_account.py
@@ -5,9 +5,12 @@
 import unittest
 
 import frappe
+from frappe.test_runner import make_test_records
 
 from erpnext.accounts.doctype.account.account import merge_account, update_account_number
 from erpnext.stock import get_company_default_inventory_account, get_warehouse_account
+
+test_dependencies = ["Company"]
 
 
 class TestAccount(unittest.TestCase):
@@ -187,6 +190,58 @@ class TestAccount(unittest.TestCase):
 		frappe.delete_doc("Account", "1234 - Test Rename Sync Account - _TC3")
 		frappe.delete_doc("Account", "1234 - Test Rename Sync Account - _TC4")
 		frappe.delete_doc("Account", "1234 - Test Rename Sync Account - _TC5")
+
+	def test_account_currency_sync(self):
+		"""
+		In a parent->child company setup, child should inherit parent account currency if explicitly specified.
+		"""
+
+		make_test_records("Company")
+
+		frappe.local.flags.pop("ignore_root_company_validation", None)
+
+		def create_bank_account():
+			acc = frappe.new_doc("Account")
+			acc.account_name = "_Test Bank JPY"
+
+			acc.parent_account = "Temporary Accounts - _TC6"
+			acc.company = "_Test Company 6"
+			return acc
+
+		acc = create_bank_account()
+		# Explicitly set currency
+		acc.account_currency = "JPY"
+		acc.insert()
+		self.assertTrue(
+			frappe.db.exists(
+				{
+					"doctype": "Account",
+					"account_name": "_Test Bank JPY",
+					"account_currency": "JPY",
+					"company": "_Test Company 7",
+				}
+			)
+		)
+
+		frappe.delete_doc("Account", "_Test Bank JPY - _TC6")
+		frappe.delete_doc("Account", "_Test Bank JPY - _TC7")
+
+		acc = create_bank_account()
+		# default currency is used
+		acc.insert()
+		self.assertTrue(
+			frappe.db.exists(
+				{
+					"doctype": "Account",
+					"account_name": "_Test Bank JPY",
+					"account_currency": "USD",
+					"company": "_Test Company 7",
+				}
+			)
+		)
+
+		frappe.delete_doc("Account", "_Test Bank JPY - _TC6")
+		frappe.delete_doc("Account", "_Test Bank JPY - _TC7")
 
 	def test_child_company_account_rename_sync(self):
 		frappe.local.flags.pop("ignore_root_company_validation", None)

--- a/erpnext/setup/doctype/company/test_records.json
+++ b/erpnext/setup/doctype/company/test_records.json
@@ -80,5 +80,30 @@
 		"chart_of_accounts": "Standard",
 		"enable_perpetual_inventory": 1,
 		"default_holiday_list": "_Test Holiday List"
+	},
+	{
+		"abbr": "_TC6",
+		"company_name": "_Test Company 6",
+		"is_group": 1,
+		"country": "India",
+		"default_currency": "INR",
+		"doctype": "Company",
+		"domain": "Manufacturing",
+		"chart_of_accounts": "Standard",
+		"default_holiday_list": "_Test Holiday List",
+		"enable_perpetual_inventory": 0
+	},
+	{
+		"abbr": "_TC7",
+		"company_name": "_Test Company 7",
+		"parent_company": "_Test Company 6",
+		"is_group": 1,
+		"country": "United States",
+		"default_currency": "USD",
+		"doctype": "Company",
+		"domain": "Manufacturing",
+		"chart_of_accounts": "Standard",
+		"default_holiday_list": "_Test Holiday List",
+		"enable_perpetual_inventory": 0
 	}
 ]


### PR DESCRIPTION
In a Parent->Child company setup, if `account_currency` is explicitly specified on creation of an account in Parent company, the child will inherit that `account_currency`