### PR TITLE
fix: broken save on empty row existance

### DIFF
--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -92,7 +92,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 
 	_calculate_taxes_and_totals() {
 		const is_quotation = this.frm.doc.doctype == "Quotation";
-		this.frm.doc._items = is_quotation ? this.filtered_items() : this.frm.doc.items;
+		this.frm._items = is_quotation ? this.filtered_items() : this.frm.doc.items;
 
 		this.validate_conversion_rate();
 		this.calculate_item_values();
@@ -125,7 +125,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 	calculate_item_values() {
 		var me = this;
 		if (!this.discount_amount_applied) {
-			for (const item of this.frm.doc._items || []) {
+			for (const item of this.frm._items || []) {
 				frappe.model.round_floats_in(item);
 				item.net_rate = item.rate;
 				item.qty = item.qty === undefined ? (me.frm.doc.is_return ? -1 : 1) : item.qty;
@@ -209,7 +209,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		});
 		if(has_inclusive_tax==false) return;
 
-		$.each(me.frm.doc._items || [], function(n, item) {
+		$.each(me.frm._items || [], function(n, item) {
 			var item_tax_map = me._load_item_tax_rate(item.item_tax_rate);
 			var cumulated_tax_fraction = 0.0;
 			var total_inclusive_tax_amount_per_qty = 0;
@@ -280,13 +280,13 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		var me = this;
 		this.frm.doc.total_qty = this.frm.doc.total = this.frm.doc.base_total = this.frm.doc.net_total = this.frm.doc.base_net_total = 0.0;
 
-		$.each(this.frm.doc._items || [], function(i, item) {
+		$.each(this.frm._items || [], function(i, item) {
 			me.frm.doc.total += item.amount;
 			me.frm.doc.total_qty += item.qty;
 			me.frm.doc.base_total += item.base_amount;
 			me.frm.doc.net_total += item.net_amount;
 			me.frm.doc.base_net_total += item.base_net_amount;
-			});
+		});
 	}
 
 	calculate_shipping_charges() {
@@ -333,7 +333,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 			}
 		});
 
-		$.each(this.frm.doc._items || [], function(n, item) {
+		$.each(this.frm._items || [], function(n, item) {
 			var item_tax_map = me._load_item_tax_rate(item.item_tax_rate);
 			$.each(me.frm.doc["taxes"] || [], function(i, tax) {
 				// tax_amount represents the amount of tax for the current step
@@ -342,7 +342,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 				// Adjust divisional loss to the last item
 				if (tax.charge_type == "Actual") {
 					actual_tax_dict[tax.idx] -= current_tax_amount;
-					if (n == me.frm.doc._items.length - 1) {
+					if (n == me.frm._items.length - 1) {
 						current_tax_amount += actual_tax_dict[tax.idx];
 					}
 				}
@@ -379,7 +379,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 				}
 
 				// set precision in the last item iteration
-				if (n == me.frm.doc._items.length - 1) {
+				if (n == me.frm._items.length - 1) {
 					me.round_off_totals(tax);
 					me.set_in_company_currency(tax,
 						["tax_amount", "tax_amount_after_discount_amount"]);
@@ -602,7 +602,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 
 	_cleanup() {
 		this.frm.doc.base_in_words = this.frm.doc.in_words = "";
-		let items = this.frm.doc._items;
+		let items = this.frm._items;
 
 		if(items && items.length) {
 			if(!frappe.meta.get_docfield(items[0].doctype, "item_tax_amount", this.frm.doctype)) {
@@ -659,7 +659,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 			var net_total = 0;
 			// calculate item amount after Discount Amount
 			if (total_for_discount_amount) {
-				$.each(this.frm.doc._items || [], function(i, item) {
+				$.each(this.frm._items || [], function(i, item) {
 					distributed_amount = flt(me.frm.doc.discount_amount) * item.net_amount / total_for_discount_amount;
 					item.net_amount = flt(item.net_amount - distributed_amount,
 						precision("base_amount", item));
@@ -667,7 +667,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 
 					// discount amount rounding loss adjustment if no taxes
 					if ((!(me.frm.doc.taxes || []).length || total_for_discount_amount==me.frm.doc.net_total || (me.frm.doc.apply_discount_on == "Net Total"))
-							&& i == (me.frm.doc._items || []).length - 1) {
+							&& i == (me.frm._items || []).length - 1) {
 						var discount_amount_loss = flt(me.frm.doc.net_total - net_total
 							- me.frm.doc.discount_amount, precision("net_total"));
 						item.net_amount = flt(item.net_amount + discount_amount_loss,


### PR DESCRIPTION
https://user-images.githubusercontent.com/52111700/236823586-00374089-bcdc-411b-bbb8-34d3ece4edfc.mp4

Problem:
Unable to save the document if the first save action was initiated with an empty row. Why leave the first row empty? Cause of multi select.

Cause:
- [`remove_empty_rows`](https://github.com/frappe/frappe/blob/develop/frappe/public/js/frappe/form/save.js#L43C6-L83) uses [`get_all_docs`](https://github.com/frappe/frappe/blob/develop/frappe/public/js/frappe/model/model.js#L791C10-L802) to fetch the child table rows.
- `get_all_docs` loops the document and if any key(field) is an array, treats it as a table
- [`_calculate_taxes_and_totals`](https://github.com/frappe/erpnext/blob/develop/erpnext/public/js/controllers/taxes_and_totals.js#L93-L106) adds a new key `_items` to the doc.
- `_items` is not an actual table, but a clone of the actual `items` field.
- `get_all_docs` treats `_items` and `items` as different table causing duplicated rows
- Trying to clear this duplicate empty row throws an error and takes away the user's ability to save.