### PR TITLE
fix: inventory dimension for material transfer not working

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -442,7 +442,29 @@ class StockController(AccountsController):
 			if not dimension:
 				continue
 
-			if row.get(dimension.source_fieldname):
+			if self.doctype in [
+				"Purchase Invoice",
+				"Purchase Receipt",
+				"Sales Invoice",
+				"Delivery Note",
+				"Stock Entry",
+			]:
+				if (sl_dict.actual_qty > 0 and self.doctype in ["Purchase Invoice", "Purchase Receipt"]) or (
+					sl_dict.actual_qty < 0 and self.doctype in ["Sales Invoice", "Delivery Note", "Stock Entry"]
+				):
+					sl_dict[dimension.target_fieldname] = row.get(dimension.source_fieldname)
+				else:
+					fieldname_start_with = "to"
+					if self.doctype in ["Purchase Invoice", "Purchase Receipt"]:
+						fieldname_start_with = "from"
+
+					fieldname = f"{fieldname_start_with}_{dimension.source_fieldname}"
+					sl_dict[dimension.target_fieldname] = row.get(fieldname)
+
+					if not sl_dict.get(dimension.target_fieldname):
+						sl_dict[dimension.target_fieldname] = row.get(dimension.source_fieldname)
+
+			elif row.get(dimension.source_fieldname):
 				sl_dict[dimension.target_fieldname] = row.get(dimension.source_fieldname)
 
 			if not sl_dict.get(dimension.target_fieldname) and dimension.fetch_from_parent:

--- a/erpnext/stock/doctype/inventory_dimension/inventory_dimension.py
+++ b/erpnext/stock/doctype/inventory_dimension/inventory_dimension.py
@@ -75,7 +75,16 @@ class InventoryDimension(Document):
 		self.delete_custom_fields()
 
 	def delete_custom_fields(self):
-		filters = {"fieldname": self.source_fieldname}
+		filters = {
+			"fieldname": (
+				"in",
+				[
+					self.source_fieldname,
+					f"to_{self.source_fieldname}",
+					f"from_{self.source_fieldname}",
+				],
+			)
+		}
 
 		if self.document_type:
 			filters["dt"] = self.document_type
@@ -88,6 +97,8 @@ class InventoryDimension(Document):
 
 	def reset_value(self):
 		if self.apply_to_all_doctypes:
+			self.type_of_transaction = ""
+
 			self.istable = 0
 			for field in ["document_type", "condition"]:
 				self.set(field, None)
@@ -111,12 +122,35 @@ class InventoryDimension(Document):
 	def on_update(self):
 		self.add_custom_fields()
 
-	def add_custom_fields(self):
-		dimension_fields = [
+	@staticmethod
+	def get_insert_after_fieldname(doctype):
+		return frappe.get_all(
+			"DocField",
+			fields=["fieldname"],
+			filters={"parent": doctype},
+			order_by="idx desc",
+			limit=1,
+		)[0].fieldname
+
+	def get_dimension_fields(self, doctype=None):
+		if not doctype:
+			doctype = self.document_type
+
+		label_start_with = ""
+		if doctype in ["Purchase Invoice Item", "Purchase Receipt Item"]:
+			label_start_with = "Target"
+		elif doctype in ["Sales Invoice Item", "Delivery Note Item", "Stock Entry Detail"]:
+			label_start_with = "Source"
+
+		label = self.dimension_name
+		if label_start_with:
+			label = f"{label_start_with} {self.dimension_name}"
+
+		return [
 			dict(
 				fieldname="inventory_dimension",
 				fieldtype="Section Break",
-				insert_after="warehouse",
+				insert_after=self.get_insert_after_fieldname(doctype),
 				label="Inventory Dimension",
 				collapsible=1,
 			),
@@ -125,24 +159,37 @@ class InventoryDimension(Document):
 				fieldtype="Link",
 				insert_after="inventory_dimension",
 				options=self.reference_document,
-				label=self.dimension_name,
+				label=label,
 				reqd=self.reqd,
 				mandatory_depends_on=self.mandatory_depends_on,
 			),
 		]
 
+	def add_custom_fields(self):
 		custom_fields = {}
 
+		dimension_fields = []
 		if self.apply_to_all_doctypes:
 			for doctype in get_inventory_documents():
-				if not field_exists(doctype[0], self.source_fieldname):
-					custom_fields.setdefault(doctype[0], dimension_fields)
+				if field_exists(doctype[0], self.source_fieldname):
+					continue
+
+				dimension_fields = self.get_dimension_fields(doctype[0])
+				self.add_transfer_field(doctype[0], dimension_fields)
+				custom_fields.setdefault(doctype[0], dimension_fields)
 		elif not field_exists(self.document_type, self.source_fieldname):
+			dimension_fields = self.get_dimension_fields()
+
+			self.add_transfer_field(self.document_type, dimension_fields)
 			custom_fields.setdefault(self.document_type, dimension_fields)
 
-		if not frappe.db.get_value(
-			"Custom Field", {"dt": "Stock Ledger Entry", "fieldname": self.target_fieldname}
-		) and not field_exists("Stock Ledger Entry", self.target_fieldname):
+		if (
+			dimension_fields
+			and not frappe.db.get_value(
+				"Custom Field", {"dt": "Stock Ledger Entry", "fieldname": self.target_fieldname}
+			)
+			and not field_exists("Stock Ledger Entry", self.target_fieldname)
+		):
 			dimension_field = dimension_fields[1]
 			dimension_field["mandatory_depends_on"] = ""
 			dimension_field["reqd"] = 0
@@ -151,6 +198,53 @@ class InventoryDimension(Document):
 
 		if custom_fields:
 			create_custom_fields(custom_fields)
+
+	def add_transfer_field(self, doctype, dimension_fields):
+		if doctype not in [
+			"Stock Entry Detail",
+			"Sales Invoice Item",
+			"Delivery Note Item",
+			"Purchase Invoice Item",
+			"Purchase Receipt Item",
+		]:
+			return
+
+		fieldname_start_with = "to"
+		label_start_with = "Target"
+		display_depends_on = ""
+
+		if doctype in ["Purchase Invoice Item", "Purchase Receipt Item"]:
+			fieldname_start_with = "from"
+			label_start_with = "Source"
+			display_depends_on = "eval:parent.is_internal_supplier == 1"
+		elif doctype != "Stock Entry Detail":
+			display_depends_on = "eval:parent.is_internal_customer == 1"
+		elif doctype == "Stock Entry Detail":
+			display_depends_on = "eval:parent.purpose != 'Material Issue'"
+
+		fieldname = f"{fieldname_start_with}_{self.source_fieldname}"
+		label = f"{label_start_with} {self.dimension_name}"
+
+		if field_exists(doctype, fieldname):
+			return
+
+		dimension_fields.extend(
+			[
+				dict(
+					fieldname="inventory_dimension_col_break",
+					fieldtype="Column Break",
+					insert_after=self.source_fieldname,
+				),
+				dict(
+					fieldname=fieldname,
+					fieldtype="Link",
+					insert_after="inventory_dimension_col_break",
+					options=self.reference_document,
+					label=label,
+					depends_on=display_depends_on,
+				),
+			]
+		)
 
 
 def field_exists(doctype, fieldname) -> str or None:
@@ -185,18 +279,19 @@ def get_evaluated_inventory_dimension(doc, sl_dict, parent_doc=None):
 	dimensions = get_document_wise_inventory_dimensions(doc.doctype)
 	filter_dimensions = []
 	for row in dimensions:
-		if (
-			row.type_of_transaction == "Inward"
-			if doc.docstatus == 1
-			else row.type_of_transaction != "Inward"
-		) and sl_dict.actual_qty < 0:
-			continue
-		elif (
-			row.type_of_transaction == "Outward"
-			if doc.docstatus == 1
-			else row.type_of_transaction != "Outward"
-		) and sl_dict.actual_qty > 0:
-			continue
+		if row.type_of_transaction:
+			if (
+				row.type_of_transaction == "Inward"
+				if doc.docstatus == 1
+				else row.type_of_transaction != "Inward"
+			) and sl_dict.actual_qty < 0:
+				continue
+			elif (
+				row.type_of_transaction == "Outward"
+				if doc.docstatus == 1
+				else row.type_of_transaction != "Outward"
+			) and sl_dict.actual_qty > 0:
+				continue
 
 		evals = {"doc": doc}
 		if parent_doc:


### PR DESCRIPTION
**Issue**

Crate material transfer entry for inventory dimension, you will see system has picked only Source Dimension and not Target Dimension in the Stock Ledger Entries.
<img width="1341" alt="Screenshot 2023-05-12 at 6 00 53 PM" src="https://github.com/frappe/erpnext/assets/8780500/a87ee788-b232-4654-b172-e8d708052314">



### After Fix

**Stock Entry**
<img width="1302" alt="Screenshot 2023-05-12 at 5 57 39 PM" src="https://github.com/frappe/erpnext/assets/8780500/177966ff-b61c-4a21-afda-e18a0a7778bb">




**Stock Ledger Entry**
<img width="1312" alt="Screenshot 2023-05-12 at 5 57 01 PM" src="https://github.com/frappe/erpnext/assets/8780500/3b5ec569-0dfe-4999-b551-c992953b072d">

