### PR TITLE
fix: non manufacturing items/fixed asset items in BOM

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.js
+++ b/erpnext/manufacturing/doctype/bom/bom.js
@@ -48,7 +48,9 @@ frappe.ui.form.on("BOM", {
 			return {
 				query: "erpnext.manufacturing.doctype.bom.bom.item_query",
 				filters: {
-					"item_code": doc.item
+					"item_code": doc.item,
+					"include_item_in_manufacturing": 1,
+					"is_fixed_asset": 0
 				}
 			};
 		});

--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -1339,8 +1339,9 @@ def item_query(doctype, txt, searchfield, start, page_len, filters):
 		if not has_variants:
 			query_filters["has_variants"] = 0
 
-	if filters and filters.get("is_stock_item"):
-		query_filters["is_stock_item"] = 1
+	if filters:
+		for fieldname, value in filters.items():
+			query_filters[fieldname] = value
 
 	return frappe.get_list(
 		"Item",


### PR DESCRIPTION
**Issue**

User can select the Fixed Items / Do Not Include Item In Manufacturing items in the BOM

**Item Master**
<img width="1334" alt="Screenshot 2023-05-09 at 4 50 04 PM" src="https://github.com/frappe/erpnext/assets/8780500/9f15dc31-9bdc-420e-9c60-6f459f9e721c">

**BOM**
<img width="723" alt="Screenshot 2023-05-09 at 4 50 52 PM" src="https://github.com/frappe/erpnext/assets/8780500/c0b8b60d-2561-4514-9898-120089ee4b23">


**After Fix**

Not able to select items having "Include Item In Manufacturing" has disabled and "Is Fixed Asset" has enabled

<img width="1154" alt="Screenshot 2023-05-09 at 4 29 07 PM" src="https://github.com/frappe/erpnext/assets/8780500/2afbf018-bb5e-474a-b1c1-99583e3ac580">

