### PR TITLE
fix: Changed type of column 'serial_no' in Stock Reconciliation to fix Data too Long error

### DIFF
--- a/erpnext/stock/doctype/stock_reconciliation_item/stock_reconciliation_item.json
+++ b/erpnext/stock/doctype/stock_reconciliation_item/stock_reconciliation_item.json
@@ -99,7 +99,7 @@
   },
   {
    "fieldname": "serial_no",
-   "fieldtype": "Small Text",
+   "fieldtype": "Long Text",
    "label": "Serial No"
   },
   {
@@ -120,7 +120,7 @@
   },
   {
    "fieldname": "current_serial_no",
-   "fieldtype": "Small Text",
+   "fieldtype": "Long Text",
    "label": "Current Serial No",
    "no_copy": 1,
    "print_hide": 1,
@@ -189,7 +189,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2022-11-02 13:01:23.580937",
+ "modified": "2023-05-09 18:42:19.224916",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Reconciliation Item",


### PR DESCRIPTION
**Issue**

<img width="973" alt="Screenshot 2023-05-09 at 6 11 36 PM" src="https://github.com/frappe/erpnext/assets/8780500/a41feab4-4b43-4d83-a0df-c2f533fdfbe2">


**Fix**

Changed fieldtype from Small Text to Long Text