### PR TITLE
fix: enqueue submit/cancel action for stock entry to avoid time out error

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -187,6 +187,9 @@ class StockEntry(StockController):
 		if force:
 			return True
 
+		if frappe.flags.in_test:
+			return False
+
 		# If line items are more than 100 or record is older than 6 months
 		if len(self.items) > 100 or month_diff(nowdate(), self.posting_date) > 6:
 			return True

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -9,7 +9,17 @@ import frappe
 from frappe import _
 from frappe.model.mapper import get_mapped_doc
 from frappe.query_builder.functions import Sum
-from frappe.utils import cint, comma_or, cstr, flt, format_time, formatdate, getdate, nowdate
+from frappe.utils import (
+	cint,
+	comma_or,
+	cstr,
+	flt,
+	format_time,
+	formatdate,
+	getdate,
+	month_diff,
+	nowdate,
+)
 
 import erpnext
 from erpnext.accounts.general_ledger import process_gl_map
@@ -150,6 +160,38 @@ class StockEntry(StockController):
 			# in Manufacture Entry
 			self.reset_default_field_value("from_warehouse", "items", "s_warehouse")
 			self.reset_default_field_value("to_warehouse", "items", "t_warehouse")
+
+	def submit(self):
+		if self.is_enqueue_action():
+			frappe.msgprint(
+				_(
+					"The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Draft stage"
+				)
+			)
+			self.queue_action("submit", timeout=2000)
+		else:
+			self._submit()
+
+	def cancel(self):
+		if self.is_enqueue_action():
+			frappe.msgprint(
+				_(
+					"The task has been enqueued as a background job. In case there is any issue on processing in background, the system will add a comment about the error on this Stock Reconciliation and revert to the Submitted stage"
+				)
+			)
+			self.queue_action("cancel", timeout=2000)
+		else:
+			self._cancel()
+
+	def is_enqueue_action(self, force=False) -> bool:
+		if force:
+			return True
+
+		# If line items are more than 100 or record is older than 6 months
+		if len(self.items) > 100 or month_diff(nowdate(), self.posting_date) > 6:
+			return True
+
+		return False
 
 	def on_submit(self):
 		self.update_stock_ledger()

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -1708,6 +1708,7 @@ class TestStockEntry(FrappeTestCase):
 		self.assertRaises(frappe.ValidationError, sr_doc.submit)
 
 	def test_enqueue_action(self):
+		frappe.flags.in_test = False
 		item_code = "Test Enqueue Item - 001"
 		create_item(item_code=item_code, is_stock_item=1, valuation_rate=10)
 
@@ -1734,6 +1735,7 @@ class TestStockEntry(FrappeTestCase):
 		)
 
 		self.assertFalse(doc.is_enqueue_action())
+		frappe.flags.in_test = True
 
 
 def make_serialized_item(**args):

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -5,7 +5,7 @@
 import frappe
 from frappe.permissions import add_user_permission, remove_user_permission
 from frappe.tests.utils import FrappeTestCase, change_settings
-from frappe.utils import add_days, flt, nowdate, nowtime, today
+from frappe.utils import add_days, add_to_date, flt, nowdate, nowtime, today
 
 from erpnext.accounts.doctype.account.test_account import get_inventory_account
 from erpnext.stock.doctype.item.test_item import (
@@ -1706,6 +1706,34 @@ class TestStockEntry(FrappeTestCase):
 		)
 
 		self.assertRaises(frappe.ValidationError, sr_doc.submit)
+
+	def test_enqueue_action(self):
+		item_code = "Test Enqueue Item - 001"
+		create_item(item_code=item_code, is_stock_item=1, valuation_rate=10)
+
+		doc = make_stock_entry(
+			item_code=item_code,
+			posting_date=add_to_date(today(), months=-7),
+			posting_time="00:00:00",
+			purpose="Material Receipt",
+			qty=10,
+			to_warehouse="_Test Warehouse - _TC",
+			do_not_submit=True,
+		)
+
+		self.assertTrue(doc.is_enqueue_action())
+
+		doc = make_stock_entry(
+			item_code=item_code,
+			posting_date=today(),
+			posting_time="00:00:00",
+			purpose="Material Receipt",
+			qty=10,
+			to_warehouse="_Test Warehouse - _TC",
+			do_not_submit=True,
+		)
+
+		self.assertFalse(doc.is_enqueue_action())
 
 
 def make_serialized_item(**args):


### PR DESCRIPTION
**Issue**

Sometime if line items is more than 100 or stock entry is older than 6 months then while submitting or cancelling the stock entry user get the Time Out Error.

<img width="813" alt="image" src="https://github.com/frappe/erpnext/assets/8780500/4718feda-9b68-45c5-acdc-e59dcf31b7eb">


To fix this issue we have enqueue the submit/cancel action 

