### PR TITLE
fix: update reference data for statistical component

### DIFF
--- a/erpnext/payroll/doctype/salary_slip/salary_slip.py
+++ b/erpnext/payroll/doctype/salary_slip/salary_slip.py
@@ -653,15 +653,17 @@ class SalarySlip(TransactionBase):
 			amount = self.eval_condition_and_formula(struct_row, data)
 
 			if struct_row.statistical_component:
+				default_data[struct_row.abbr] = amount
+
 				# update statitical component amount in reference data based on payment days
 				# since row for statistical component is not added to salary slip
 				if struct_row.depends_on_payment_days:
-					joining_date, relieving_date = self.get_joining_and_relieving_dates()
-					default_data[struct_row.abbr] = amount
-					data[struct_row.abbr] = flt(
-						(flt(amount) * flt(self.payment_days) / cint(self.total_working_days)),
-						struct_row.precision("amount"),
+					payment_days_amount = (
+						flt(amount) * flt(self.payment_days) / cint(self.total_working_days)
+						if self.total_working_days
+						else 0
 					)
+					data[struct_row.abbr] = payment_days_amount
 
 			elif amount or struct_row.amount_based_on_formula and amount is not None:
 				default_amount = self.eval_condition_and_formula(struct_row, default_data)


### PR DESCRIPTION
Issue: 

Total earnings for taxation, gets calculated on components default amount. 

<img width="667" alt="Screenshot 2023-05-12 at 12 27 33 PM" src="https://github.com/frappe/erpnext/assets/3784093/fd21ad88-e959-42a2-a11e-24be6ea6fe62">

But for statistical components, the system was not setting default value, which results into wrong data calculations

<img width="696" alt="Screenshot 2023-05-12 at 12 36 03 PM" src="https://github.com/frappe/erpnext/assets/3784093/fa81ffcf-4e47-4c83-b4fc-ee71ecd7b58a">

Fix:
Set default value for statistical components too!

Before Fix:

```
{
    'taxable_earnings': 66205.0, 
    'additional_income': 0, 
    'additional_income_with_full_tax': 0, 
    'flexi_benefits': 0
}
```

After Fix:

```
{
    'taxable_earnings': 38500.0, 
    'additional_income': 0, 
    'additional_income_with_full_tax': 0, 
    'flexi_benefits': 0
}
```






