### PR TITLE
fix: incorrect packing items

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -620,6 +620,8 @@ def make_project(source_name, target_doc=None):
 
 @frappe.whitelist()
 def make_delivery_note(source_name, target_doc=None, skip_item_mapping=False):
+	from erpnext.stock.doctype.packed_item.packed_item import make_packing_list
+
 	def set_missing_values(source, target):
 		target.run_method("set_missing_values")
 		target.run_method("set_po_nos")
@@ -633,6 +635,8 @@ def make_delivery_note(source_name, target_doc=None, skip_item_mapping=False):
 
 		if target.company_address:
 			target.update(get_fetch_values("Delivery Note", "company_address", target.company_address))
+
+		make_packing_list(target)
 
 	def update_item(source, target, source_parent):
 		target.base_amount = (flt(source.qty) - flt(source.delivered_qty)) * flt(source.base_rate)


### PR DESCRIPTION
**Steps to replicate the Issue**

1. Create sales order and add 2 Product Bundle Items
2. Out of 2 product bundle delivery one product bundle to customer
3. Create another delivery note from the same sales order
4. System fetch the remaining second product bundle in the delivery note correctly but packing items not fetches correctly.
5. System fetch packing items of the product bundle which is already delivered. 

#no-docs