### PR TITLE
fix: unable to create partial invoice with auto fetch terms enabled

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1679,6 +1679,9 @@ class AccountsController(TransactionBase):
 					d.base_payment_amount = flt(
 						d.payment_amount * self.get("conversion_rate"), d.precision("base_payment_amount")
 					)
+		else:
+			self.fetch_payment_terms_from_order(po_or_so, doctype)
+			self.ignore_default_payment_terms_template = 1
 
 	def get_order_details(self):
 		if self.doctype == "Sales Invoice":


### PR DESCRIPTION
With 'Automatically Fetch Payment Terms' enabled in Accounts Settings, partial invoice creation from Orders wasn't possible.

Fix: If Auto Fetch is enabled, Partial Invoice will pull the same Payment Terms from Sales/Purchase Order the validation on the terms will be skipped.