### PR TITLE
fix: sales person allocated amount calculation error nonetype and float

### DIFF
--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -168,7 +168,7 @@ class SellingController(StockController):
 			self.round_floats_in(sales_person)
 
 			sales_person.allocated_amount = flt(
-				self.amount_eligible_for_commission * sales_person.allocated_percentage / 100.0,
+				flt(self.amount_eligible_for_commission) * sales_person.allocated_percentage / 100.0,
 				self.precision("allocated_amount", sales_person),
 			)
 


### PR DESCRIPTION
Unsupported operant error

File "apps/erpnext/erpnext/controllers/accounts_controller.py", line 158, in validate
    self.calculate_taxes_and_totals()
  File "apps/erpnext/erpnext/controllers/accounts_controller.py", line 356, in calculate_taxes_and_totals
    self.calculate_contribution()
  File "apps/erpnext/erpnext/controllers/selling_controller.py", line 171, in calculate_contribution
    self.amount_eligible_for_commission * sales_person.allocated_percentage / 100.0,
TypeError: unsupported operand type(s) for *: 'NoneType' and 'float'

@marination 