### PR TITLE
fix: Creating landed cost voucher from connections

### DIFF
--- a/erpnext/public/js/controllers/accounts.js
+++ b/erpnext/public/js/controllers/accounts.js
@@ -91,6 +91,12 @@ frappe.ui.form.on("Sales Invoice", {
 });
 
 frappe.ui.form.on('Purchase Invoice', {
+	setup: (frm) => {
+		frm.make_methods = {
+			'Landed Cost Voucher': function () { frm.trigger('create_landedcost_voucher') },
+		}
+	},
+
 	mode_of_payment: function(frm) {
 		get_payment_mode_account(frm, frm.doc.mode_of_payment, function(account){
 			frm.set_value('cash_bank_account', account);
@@ -99,6 +105,20 @@ frappe.ui.form.on('Purchase Invoice', {
 
 	payment_terms_template: function() {
 		cur_frm.trigger("disable_due_date");
+	},
+
+	create_landedcost_voucher: function (frm) {
+		let lcv = frappe.model.get_new_doc('Landed Cost Voucher');
+		lcv.company = frm.doc.company;
+
+		let lcv_receipt = frappe.model.get_new_doc('Landed Cost Purchase Invoice');
+		lcv_receipt.receipt_document_type = 'Purchase Invoice';
+		lcv_receipt.receipt_document = frm.doc.name;
+		lcv_receipt.supplier = frm.doc.supplier;
+		lcv_receipt.grand_total = frm.doc.grand_total;
+		lcv.purchase_receipts = [lcv_receipt];
+
+		frappe.set_route("Form", lcv.doctype, lcv.name);
 	}
 });
 


### PR DESCRIPTION
Upon clicking the Landed Cost voucher button from a Purchase Invoice connection, certain fields in the child table of the Landed Cost voucher are not automatically populated.

https://user-images.githubusercontent.com/105106551/234461860-155c8fd7-a7a4-4e7e-b5df-9c8df2fa1064.mp4
