### PR TITLE
fix: cancelled vouchers in tax withheld vouchers list

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -303,7 +303,7 @@ erpnext.accounts.PurchaseInvoice = class PurchaseInvoice extends erpnext.buying.
 
 	apply_tds(frm) {
 		var me = this;
-
+		me.frm.set_value("tax_withheld_vouchers", []);
 		if (!me.frm.doc.apply_tds) {
 			me.frm.set_value("tax_withholding_category", '');
 			me.frm.set_df_property("tax_withholding_category", "hidden", 1);


### PR DESCRIPTION
If one of the `tax_withheld_vouchers` in purchase invoice is cancelled, then document cannot be submitted.

`frappe.exceptions.CancelledLinkError: Cannot link cancelled document: Row #1: Voucher Name: PINV-23-00020-1`

Just uncheck and check `Apply TDS` to clear the `tax_withheld_vouchers` list