### PR TITLE
fix: force to do reposting for cancelled document

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -770,6 +770,9 @@ class StockController(AccountsController):
 			}
 		)
 
+		if self.docstatus == 2:
+			force = True
+
 		if force or future_sle_exists(args) or repost_required_for_queue(self):
 			item_based_reposting = cint(
 				frappe.db.get_single_value("Stock Reposting Settings", "item_based_reposting")

--- a/erpnext/stock/doctype/repost_item_valuation/test_repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/test_repost_item_valuation.py
@@ -376,3 +376,19 @@ class TestRepostItemValuation(FrappeTestCase, StockTestMixin):
 
 		accounts_settings.acc_frozen_upto = ""
 		accounts_settings.save()
+
+	def test_create_repost_entry_for_cancelled_document(self):
+		pr = make_purchase_receipt(
+			company="_Test Company with perpetual inventory",
+			warehouse="Stores - TCP1",
+			get_multiple_items=True,
+		)
+
+		self.assertTrue(pr.docstatus == 1)
+		self.assertFalse(frappe.db.exists("Repost Item Valuation", {"voucher_no": pr.name}))
+
+		pr.load_from_db()
+
+		pr.cancel()
+		self.assertTrue(pr.docstatus == 2)
+		self.assertTrue(frappe.db.exists("Repost Item Valuation", {"voucher_no": pr.name}))


### PR DESCRIPTION
While investigating incorrect quantity in FIFO Queue, we identified that for the cancelled document the reposting entry has not made(because of concurrent entries) and due to this the system has calculated incorrect valuation rate.

<img width="1325" alt="Screenshot 2023-05-16 at 4 27 23 PM" src="https://github.com/frappe/erpnext/assets/8780500/a07724aa-80a3-4a01-92ac-6c9b16630052">



To Solve this problem we have decided to create reposting entry for the cancelled document even if there is no future stock exists.