### PR TITLE
fix(ux): SCR consumed-qty read-only property

### DIFF
--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.js
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.js
@@ -76,26 +76,14 @@ frappe.ui.form.on('Subcontracting Receipt', {
 			}
 		});
 
-		let batch_no_field = frm.get_docfield("items", "batch_no");
+		let batch_no_field = frm.get_docfield('items', 'batch_no');
 		if (batch_no_field) {
 			batch_no_field.get_route_options_for_new_doc = function(row) {
 				return {
-					"item": row.doc.item_code
+					'item': row.doc.item_code
 				}
 			};
 		}
-
-		frappe.db.get_single_value('Buying Settings', 'backflush_raw_materials_of_subcontract_based_on').then(val => {
-			if (val == 'Material Transferred for Subcontract') {
-				frm.fields_dict['supplied_items'].grid.grid_rows.forEach((grid_row) => {
-					grid_row.docfields.forEach((df) => {
-						if (df.fieldname == 'consumed_qty') {
-							df.read_only = 0;
-						}
-					});
-				});
-			}
-		});
 	},
 
 	refresh: (frm) => {
@@ -157,6 +145,8 @@ frappe.ui.form.on('Subcontracting Receipt', {
 					}
 				});
 			}, __('Get Items From'));
+
+			frm.fields_dict.supplied_items.grid.update_docfield_property('consumed_qty', 'read_only', frm.doc.__onload && frm.doc.__onload.backflush_based_on === 'BOM');
 		}
 	},
 

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
@@ -28,6 +28,14 @@ class SubcontractingReceipt(SubcontractingController):
 			},
 		]
 
+	def onload(self):
+		self.set_onload(
+			"backflush_based_on",
+			frappe.db.get_single_value(
+				"Buying Settings", "backflush_raw_materials_of_subcontract_based_on"
+			),
+		)
+
 	def update_status_updater_args(self):
 		if cint(self.is_return):
 			self.status_updater.extend(


### PR DESCRIPTION
The user is allowed to update the `Consumed Qty` in Subcontracting Receipt Supplied Items table if the `Backflush Raw Materials of Subcontract Based On` is set to `Material Transferred for Subcontract` in Buying Settings but after saving the Subcontracting Receipt a reload is required if the user wants to update the consumed qty.

![image](https://github.com/frappe/erpnext/assets/63660334/b5464ccb-b449-42c9-a121-701f47c0648c)

Before:

[Screencast from 2023-05-17 15-14-29.webm](https://github.com/frappe/erpnext/assets/63660334/71eb2c4e-1e39-44fe-b3e0-da1ba4a98961)

After:

[Screencast from 2023-05-17 15-15-34.webm](https://github.com/frappe/erpnext/assets/63660334/e8256f17-a5be-4736-8c66-4cd181171e2f)
