### PR TITLE
feat: provision to make reposting entries from Stock and Account Value Comparison Report

### DIFF
--- a/erpnext/stock/report/stock_and_account_value_comparison/stock_and_account_value_comparison.js
+++ b/erpnext/stock/report/stock_and_account_value_comparison/stock_and_account_value_comparison.js
@@ -33,5 +33,40 @@ frappe.query_reports["Stock and Account Value Comparison"] = {
 			"fieldtype": "Date",
 			"default": frappe.datetime.get_today(),
 		},
-	]
+	],
+
+	get_datatable_options(options) {
+		return Object.assign(options, {
+			checkboxColumn: true,
+		});
+	},
+
+	onload(report) {
+		report.page.add_inner_button(__("Create Reposting Entries"), function() {
+			let message = `<div>
+				<p>
+					Reposting Entries will change the value of
+					accounts Stock In Hand, and Stock Expenses
+					in the Trial Balance report and will also change
+					the Balance Value in the Stock Balance report.
+				</p>
+				<p>Are you sure you want to create Reposting Entries?</p>
+				</div>
+			`;
+
+			frappe.confirm(__(message), () => {
+				let indexes = frappe.query_report.datatable.rowmanager.getCheckedRows();
+				let selected_rows = indexes.map(i => frappe.query_report.data[i]);
+
+				frappe.call({
+					method: "erpnext.stock.report.stock_and_account_value_comparison.stock_and_account_value_comparison.create_reposting_entries",
+					args: {
+						rows: selected_rows,
+						company: frappe.query_report.get_filter_values().company
+					}
+				});
+
+			});
+		});
+	}
 };


### PR DESCRIPTION
### Provision to create reposting entries from Stock and Account Value 

<img width="1239" alt="Screenshot 2023-05-19 at 6 54 50 PM" src="https://github.com/frappe/erpnext/assets/8780500/8b60fdb0-ebca-4e9f-9a63-57b5ec213bc7">


###  On Click of button user will get below Message

<img width="855" alt="Screenshot 2023-05-19 at 6 42 45 PM" src="https://github.com/frappe/erpnext/assets/8780500/e8adfc11-ca10-4ed8-bc6e-33ae8c759dde">


### If period has closed, then system won't allow you to make Reposting Entries
<img width="1299" alt="Screenshot 2023-05-19 at 6 47 09 PM" src="https://github.com/frappe/erpnext/assets/8780500/0ba4aa11-6eac-447c-97b3-c9260a43b70d">

### On Success 
<img width="906" alt="Screenshot 2023-05-19 at 6 47 37 PM" src="https://github.com/frappe/erpnext/assets/8780500/31101a21-2311-4cb4-8fee-39dc3afca13e">



#no-docs