### PR TITLE
fix: don't recalculate rate for SCR rejected warehouse SLE

### DIFF
--- a/erpnext/controllers/subcontracting_controller.py
+++ b/erpnext/controllers/subcontracting_controller.py
@@ -689,7 +689,6 @@ class SubcontractingController(StockController):
 								"actual_qty": flt(item.rejected_qty) * flt(item.conversion_factor),
 								"serial_no": cstr(item.rejected_serial_no).strip(),
 								"incoming_rate": 0.0,
-								"recalculate_rate": 1,
 							},
 						)
 					)


### PR DESCRIPTION
Issue: The rate gets recalculated for Rejected Warehouse SLE. Which results in a difference in Stock and Account Value Comparison.

Steps to Replicate:
1. Create a Subcontracted Purchase Order.
2. Create Subcontracting Order.
3. Transfer Required Raw Materials.
4. Create Subcontracting Receipt with Rejected Qty.
5. Create Repost Item Valuation for Subcontracting Receipt.
6. Check the Stock and Account Value Comparison Report, there will be a difference.

Solution: Don't recalculate the rate for SCR Rejected Warehouse SLE.