### PR TITLE
fix: TypeError while saving Job card

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.json
+++ b/erpnext/manufacturing/doctype/job_card/job_card.json
@@ -120,7 +120,8 @@
    "fieldname": "for_quantity",
    "fieldtype": "Float",
    "in_list_view": 1,
-   "label": "Qty To Manufacture"
+   "label": "Qty To Manufacture",
+   "reqd": 1
   },
   {
    "fieldname": "wip_warehouse",
@@ -439,7 +440,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2022-11-09 15:02:44.490731",
+ "modified": "2023-05-22 23:26:57.589331",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Job Card",

--- a/erpnext/manufacturing/doctype/job_card/job_card.json
+++ b/erpnext/manufacturing/doctype/job_card/job_card.json
@@ -120,8 +120,7 @@
    "fieldname": "for_quantity",
    "fieldtype": "Float",
    "in_list_view": 1,
-   "label": "Qty To Manufacture",
-   "reqd": 1
+   "label": "Qty To Manufacture"
   },
   {
    "fieldname": "wip_warehouse",
@@ -440,7 +439,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2023-05-22 23:26:57.589331",
+ "modified": "2023-05-23 09:56:43.826602",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Job Card",

--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -730,7 +730,7 @@ class JobCard(Document):
 		self.status = {0: "Open", 1: "Submitted", 2: "Cancelled"}[self.docstatus or 0]
 
 		if self.docstatus < 2:
-			if self.for_quantity <= self.transferred_qty:
+			if flt(self.for_quantity) <= flt(self.transferred_qty):
 				self.status = "Material Transferred"
 
 			if self.time_logs:


### PR DESCRIPTION

![Screenshot (61)](https://github.com/frappe/erpnext/assets/105106551/e41f6cb6-3132-439f-a7e9-8989e3e0bd97)
request.js:457 Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 66, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 54, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 45, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 83, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1607, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/desk/form/save.py", line 26, in savedocs
    doc.save()
  File "apps/frappe/frappe/model/document.py", line 305, in save
    return self._save(*args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 327, in _save
    return self.insert()
  File "apps/frappe/frappe/model/document.py", line 259, in insert
    self.run_before_save_methods()
  File "apps/frappe/frappe/model/document.py", line 1045, in run_before_save_methods
    self.run_method("validate")
  File "apps/frappe/frappe/model/document.py", line 914, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1264, in composer
    return composed(self, method, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1246, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "apps/frappe/frappe/model/document.py", line 911, in fn
    return method_object(*args, **kwargs)
  File "apps/erpnext/erpnext/manufacturing/doctype/job_card/job_card.py", line 70, in validate
    self.set_status()
  File "apps/erpnext/erpnext/manufacturing/doctype/job_card/job_card.py", line 733, in set_status
    if self.for_quantity <= self.transferred_qty:
TypeError: '<=' not supported between instances of 'NoneType' and 'int'