### PR TITLE
fix: Wrong quotes make Account.get_children fail on PostgreSQL.

### DIFF
--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -950,7 +950,7 @@ def get_children(doctype, parent, company, is_root=False):
 	fields = ["name as value", "is_group as expandable"]
 	filters = [["docstatus", "<", 2]]
 
-	filters.append(['ifnull(`{0}`,"")'.format(parent_fieldname), "=", "" if is_root else parent])
+	filters.append(["ifnull(`{0}`, '')".format(parent_fieldname), "=", "" if is_root else parent])
 
 	if is_root:
 		fields += ["root_type", "report_type", "account_currency"] if doctype == "Account" else []


### PR DESCRIPTION
Fixes #35181

Postgres uses single quotes for string values and double quotes for table names. I'm not sure what the Frappe's DB layer exact usage is.

Most places that uses double quotes for SQL queries, but not all.