### PR TITLE
fix: tab-uniformity

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.json
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.json
@@ -157,7 +157,7 @@
   "party_account_currency",
   "inter_company_order_reference",
   "is_old_subcontracting_flow",
-  "dashboard"
+  "connections_tab"
  ],
  "fields": [
   {
@@ -1171,7 +1171,6 @@
    "depends_on": "is_internal_supplier",
    "fieldname": "set_from_warehouse",
    "fieldtype": "Link",
-   "ignore_user_permissions": 1,
    "label": "Set From Warehouse",
    "options": "Warehouse"
   },
@@ -1184,12 +1183,6 @@
    "fieldname": "more_info_tab",
    "fieldtype": "Tab Break",
    "label": "More Info"
-  },
-  {
-   "fieldname": "dashboard",
-   "fieldtype": "Tab Break",
-   "label": "Dashboard",
-   "show_dashboard": 1
   },
   {
    "fieldname": "column_break_7",
@@ -1266,13 +1259,19 @@
    "fieldname": "shipping_address_section",
    "fieldtype": "Section Break",
    "label": "Shipping Address"
+  },
+  {
+   "fieldname": "connections_tab",
+   "fieldtype": "Tab Break",
+   "label": "Connections",
+   "show_dashboard": 1
   }
  ],
  "icon": "fa fa-file-text",
  "idx": 105,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-05-07 20:18:09.196799",
+ "modified": "2023-05-24 11:16:41.195340",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Purchase Order",


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Changed the Purchase Order tab name to **Connections** to match that of other Doctypes including Purchase Invoice, Sales Invoice, Sales Order etc.

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Enabled uniformity of Tabs in Doctypes.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots

**Purchase Order**
<img width="1299" alt="Screenshot 2023-05-24 at 11 49 00 AM" src="https://github.com/frappe/erpnext/assets/40693548/3a001d4b-e4c2-4dab-9aef-cd5885f7cfac">

**Purchase Invoice**
<img width="1289" alt="Screenshot 2023-05-24 at 11 46 40 AM" src="https://github.com/frappe/erpnext/assets/40693548/9d890ae8-f8b8-4cbc-9065-00da65412897">

<!-- Add images/recordings to better visualize the change: expected/current behviour -->

Closes: https://github.com/frappe/erpnext/issues/34072
