### PR TITLE
fix: Negative value in Reserved Qty for Production Plan

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -1534,7 +1534,7 @@ def get_reserved_qty_for_production_plan(item_code, warehouse):
 		frappe.qb.from_(table)
 		.inner_join(child)
 		.on(table.name == child.parent)
-		.select(Sum(child.quantity * IfNull(child.conversion_factor, 1.0)))
+		.select(Sum(child.required_bom_qty * IfNull(child.conversion_factor, 1.0)))
 		.where(
 			(table.docstatus == 1)
 			& (child.item_code == item_code)
@@ -1551,6 +1551,9 @@ def get_reserved_qty_for_production_plan(item_code, warehouse):
 	reserved_qty_for_production = flt(
 		get_reserved_qty_for_production(item_code, warehouse, check_production_plan=True)
 	)
+
+	if reserved_qty_for_production > reserved_qty_for_production_plan:
+		return 0.0
 
 	return reserved_qty_for_production_plan - reserved_qty_for_production
 


### PR DESCRIPTION
### **Issue**

Steps

1. Create stock entry with type Material Receipt against the raw material RM-123 for 5 quantity 
2. Make production plan against FG item FG-123 for 10 quantity
3. In the raw materials section, system will show that 5 quantity needs to be purchase against the RM-123
4. Submit the production plan and create the work order
5. After submission of the work order check bin, you will see the "Reserved Qty for Production Plan" as -5.0 
6. Ideally the value should be zero

<img width="510" alt="Screenshot 2023-05-24 at 3 24 49 PM" src="https://github.com/frappe/erpnext/assets/8780500/ca6e95ae-5464-4a66-bb94-b964c6fe7186">


### **After Fix**
<img width="512" alt="Screenshot 2023-05-24 at 3 25 23 PM" src="https://github.com/frappe/erpnext/assets/8780500/6a73ee31-a10f-4f7a-bd01-f24716049333">
