### PR TITLE
fix(Gross Profit): 'company' column is ambiguous in filter

### DIFF
--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -736,7 +736,7 @@ class GrossProfitGenerator(object):
 	def load_invoice_items(self):
 		conditions = ""
 		if self.filters.company:
-			conditions += " and company = %(company)s"
+			conditions += " and `tabSales Invoice`.company = %(company)s"
 		if self.filters.from_date:
 			conditions += " and posting_date >= %(from_date)s"
 		if self.filters.to_date:


### PR DESCRIPTION
```
Error:
Traceback (most recent call last):
File "apps/frappe/frappe/core/doctype/prepared_report/prepared_report.py", line 43, in run_background
result = generate_report_result(report=report, filters=instance.filters, user=instance.owner)
File "apps/frappe/frappe/__init__.py", line 789, in wrapper_fn
retval = fn(*args, **get_newargs(fn, kwargs))
File "apps/frappe/frappe/desk/query_report.py", line 90, in generate_report_result
res = get_report_result(report, filters) or []
File "apps/frappe/frappe/desk/query_report.py", line 71, in get_report_result
res = report.execute_script_report(filters)
File "apps/frappe/frappe/core/doctype/report/report.py", line 142, in execute_script_report
res = self.execute_module(filters)
File "apps/frappe/frappe/core/doctype/report/report.py", line 159, in execute_module
return frappe.get_attr(method_name)(frappe._dict(filters))
File "apps/erpnext/erpnext/accounts/report/gross_profit/gross_profit.py", line 20, in execute
gross_profit_data = GrossProfitGenerator(filters)
File "apps/erpnext/erpnext/accounts/report/gross_profit/gross_profit.py", line 403, in __init__
self.load_invoice_items()
File "apps/erpnext/erpnext/accounts/report/gross_profit/gross_profit.py", line 785, in load_invoice_items
self.si_list = frappe.db.sql(
File "apps/frappe/frappe/database/database.py", line 219, in sql
self._cursor.execute(query, values)
File "env/lib/python3.10/site-packages/pymysql/cursors.py", line 158, in execute
result = self._query(query)
File "env/lib/python3.10/site-packages/pymysql/cursors.py", line 325, in _query
conn.query(q)
File "env/lib/python3.10/site-packages/pymysql/connections.py", line 549, in query
self._affected_rows = self._read_query_result(unbuffered=unbuffered)
File "env/lib/python3.10/site-packages/pymysql/connections.py", line 779, in _read_query_result
result.read()
File "env/lib/python3.10/site-packages/pymysql/connections.py", line 1157, in read
first_packet = self.connection._read_packet()
File "env/lib/python3.10/site-packages/pymysql/connections.py", line 729, in _read_packet
packet.raise_for_error()
File "env/lib/python3.10/site-packages/pymysql/protocol.py", line 221, in raise_for_error
err.raise_mysql_exception(self._data)
File "env/lib/python3.10/site-packages/pymysql/err.py", line 143, in raise_mysql_exception
raise errorclass(errno, errval)
pymysql.err.OperationalError: (1052, "Column 'company' in where clause is ambiguous")
```