### PR TITLE
fix: incorrect available quantity in BIN

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -1066,15 +1066,15 @@ class update_entries_after(object):
 
 	def update_bin_data(self, sle):
 		bin_name = get_or_make_bin(sle.item_code, sle.warehouse)
-		frappe.db.set_value(
-			"Bin",
-			bin_name,
-			{
-				"actual_qty": sle.qty_after_transaction,
-				"valuation_rate": sle.valuation_rate,
-				"stock_value": sle.stock_value,
-			},
-		)
+		values_to_update = {
+			"actual_qty": sle.qty_after_transaction,
+			"stock_value": sle.stock_value,
+		}
+
+		if sle.valuation_rate is not None:
+			values_to_update["valuation_rate"] = sle.valuation_rate
+
+		frappe.db.set_value("Bin", bin_name, values_to_update)
 
 	def update_bin(self):
 		# update bin for each warehouse

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -443,11 +443,10 @@ class update_entries_after(object):
 				i += 1
 
 				self.process_sle(sle)
+				self.update_bin_data(sle)
 
 				if sle.dependant_sle_voucher_detail_no:
 					entries_to_fix = self.get_dependent_entries_to_fix(entries_to_fix, sle)
-
-			self.update_bin()
 
 		if self.exceptions:
 			self.raise_exceptions()
@@ -1064,6 +1063,18 @@ class update_entries_after(object):
 				frappe.throw(message, NegativeStockError, title=_("Insufficient Stock"))
 			else:
 				raise NegativeStockError(message)
+
+	def update_bin_data(self, sle):
+		bin_name = get_or_make_bin(sle.item_code, sle.warehouse)
+		frappe.db.set_value(
+			"Bin",
+			bin_name,
+			{
+				"actual_qty": sle.qty_after_transaction,
+				"valuation_rate": sle.valuation_rate,
+				"stock_value": sle.stock_value,
+			},
+		)
 
 	def update_bin(self):
 		# update bin for each warehouse

--- a/erpnext/stock/utils.py
+++ b/erpnext/stock/utils.py
@@ -220,7 +220,7 @@ def get_bin(item_code, warehouse):
 
 
 def get_or_make_bin(item_code: str, warehouse: str) -> str:
-	bin_record = frappe.db.get_value("Bin", {"item_code": item_code, "warehouse": warehouse})
+	bin_record = frappe.get_cached_value("Bin", {"item_code": item_code, "warehouse": warehouse})
 
 	if not bin_record:
 		bin_obj = _create_bin(item_code, warehouse)


### PR DESCRIPTION


### **Issue**

During reposting system calculated the incorrect available quantity in the BIN.

Example :-
In the Stock Balance the available quantity was showing correct as 1, but in BIN the available quantity was showing as 14.
<img width="1338" alt="Screenshot 2023-05-25 at 7 59 10 PM" src="https://github.com/frappe/erpnext/assets/8780500/20b606a7-8213-4de6-9129-3d2528295d14">


<img width="493" alt="Screenshot 2023-05-25 at 7 58 32 PM" src="https://github.com/frappe/erpnext/assets/8780500/24d3594e-65d6-4329-b94a-4910ed60ff16">

### **After Fix**



<img width="359" alt="Screenshot 2023-05-25 at 11 50 54 PM" src="https://github.com/frappe/erpnext/assets/8780500/822f1078-499e-4619-ac2f-b7d57d0f6801">

fixed https://github.com/frappe/erpnext/issues/35408