### PR TITLE
fix(UX): task and project name  in error message

### DIFF
--- a/erpnext/projects/doctype/task/task.py
+++ b/erpnext/projects/doctype/task/task.py
@@ -66,8 +66,10 @@ class Task(NestedSet):
 				task_date = self.get(fieldname)
 				if task_date and date_diff(project_end_date, getdate(task_date)) < 0:
 					frappe.throw(
-						_("Task's {0} cannot be after Project's Expected End Date.").format(
-							_(self.meta.get_label(fieldname))
+						_("{0}'s {1} cannot be after {2}'s Expected End Date.").format(
+							frappe.bold(frappe.get_desk_link("Task", self.name)),
+							_(self.meta.get_label(fieldname)),
+							frappe.bold(frappe.get_desk_link("Project", self.project)),
 						),
 						frappe.exceptions.InvalidDates,
 					)


### PR DESCRIPTION
**Before**
![Screenshot (62)](https://github.com/frappe/erpnext/assets/105106551/960bb01a-4597-4b1d-9768-86f66c62e89e)

<hr>

**After**
![Screenshot (63)](https://github.com/frappe/erpnext/assets/105106551/54e023a3-d07a-45b1-b698-c1e77371168a)
