### PR TITLE
chore: typo in pricing rule schema

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.json
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.json
@@ -469,7 +469,7 @@
    "options": "UOM"
   },
   {
-   "description": "If rate is zero them item will be treated as \"Free Item\"",
+   "description": "If rate is zero then item will be treated as \"Free Item\"",
    "fieldname": "free_item_rate",
    "fieldtype": "Currency",
    "label": "Free Item Rate"


### PR DESCRIPTION
fixes the typo in Pricing Rule Schema, `free_rate_item_rate` field's description.  

~~them~~  **then**

### Before
https://github.com/frappe/erpnext/blob/d84c8de46cb21deb13bbd1c26bb850c4e7de5681/erpnext/accounts/doctype/pricing_rule/pricing_rule.json#L472

### After
https://github.com/frappe/erpnext/blob/38d3325c4cb1d1a2f6f3416fdaf97c40ca8bab35/erpnext/accounts/doctype/pricing_rule/pricing_rule.json#L472

no-docs
