### PR TITLE
fix: monthly wdv depr schedule for existing assets [dev]

### DIFF
--- a/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
@@ -246,10 +246,6 @@ class AssetDepreciationSchedule(Document):
 				if should_get_last_day:
 					schedule_date = get_last_day(schedule_date)
 
-				# schedule date will be a year later from start date
-				# so monthly schedule date is calculated by removing 11 months from it
-				monthly_schedule_date = add_months(schedule_date, -row.frequency_of_depreciation + 1)
-
 			# if asset is being sold or scrapped
 			if date_of_disposal:
 				from_date = add_months(
@@ -275,14 +271,8 @@ class AssetDepreciationSchedule(Document):
 				break
 
 			# For first row
-			if (
-				(has_pro_rata or has_wdv_or_dd_non_yearly_pro_rata)
-				and not self.opening_accumulated_depreciation
-				and n == 0
-			):
-				from_date = add_days(
-					asset_doc.available_for_use_date, -1
-				)  # needed to calc depr amount for available_for_use_date too
+			if n == 0 and has_pro_rata and not self.opening_accumulated_depreciation:
+				from_date = add_days(asset_doc.available_for_use_date, -1)
 				depreciation_amount, days, months = _get_pro_rata_amt(
 					row,
 					depreciation_amount,
@@ -290,11 +280,18 @@ class AssetDepreciationSchedule(Document):
 					row.depreciation_start_date,
 					has_wdv_or_dd_non_yearly_pro_rata,
 				)
-
-				# For first depr schedule date will be the start date
-				# so monthly schedule date is calculated by removing
-				# month difference between use date and start date
-				monthly_schedule_date = add_months(row.depreciation_start_date, -months + 1)
+			elif n == 0 and has_wdv_or_dd_non_yearly_pro_rata and self.opening_accumulated_depreciation:
+				from_date = add_months(
+					getdate(asset_doc.available_for_use_date),
+					(self.number_of_depreciations_booked * row.frequency_of_depreciation),
+				)
+				depreciation_amount, days, months = _get_pro_rata_amt(
+					row,
+					depreciation_amount,
+					from_date,
+					row.depreciation_start_date,
+					has_wdv_or_dd_non_yearly_pro_rata,
+				)
 
 			# For last row
 			elif has_pro_rata and n == cint(number_of_pending_depreciations) - 1:
@@ -319,9 +316,7 @@ class AssetDepreciationSchedule(Document):
 					depreciation_amount_without_pro_rata, depreciation_amount
 				)
 
-				monthly_schedule_date = add_months(schedule_date, 1)
 				schedule_date = add_days(schedule_date, days)
-				last_schedule_date = schedule_date
 
 			if not depreciation_amount:
 				continue


### PR DESCRIPTION
For existing assets with monthly WDV depreciation, since the pro rata amount was not at all calculated for the first row, the system was calculating the whole schedule incorrectly resulting in lesser number of depreciations than specified. So fixed that.