### PR TITLE
fix: rate not fetching properly for inter transfer purchase order

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -494,7 +494,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 								},
 								() => {
 									// for internal customer instead of pricing rule directly apply valuation rate on item
-									if (me.frm.doc.is_internal_customer || me.frm.doc.is_internal_supplier) {
+									if ((me.frm.doc.is_internal_customer || me.frm.doc.is_internal_supplier) && me.frm.doc.represents_company === me.frm.doc.company) {
 										me.get_incoming_rate(item, me.frm.posting_date, me.frm.posting_time,
 											me.frm.doc.doctype, me.frm.doc.company);
 									} else {


### PR DESCRIPTION
If the supplier is internal supplier and user is creating the transfer entry within a same company of two different branches then only fetch valuation rate else get the rate from the item price.

[Refer code](https://github.com/frappe/erpnext/blob/develop/erpnext/controllers/accounts_controller.py#L1868) 