### PR TITLE
fix: allow assets with depr entries to be cancelled

### DIFF
--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -41,6 +41,8 @@ frappe.ui.form.on('Asset', {
 	},
 
 	setup: function(frm) {
+		frm.ignore_doctypes_on_cancel_all = ['Journal Entry'];
+
 		frm.make_methods = {
 			'Asset Movement': () => {
 				frappe.call({


### PR DESCRIPTION
Cancellation of assets with depreciation entries were failing with a "frappe.exceptions.ValidationError: Cannot edit cancelled document" error. It was caused due to "frappe.desk.form.linked_with.cancel_all_linked_docs" trying to cancel the entries after "erpnext.assets.doctype.asset_depreciation_schedule.asset_depreciation_schedule.cancel_depreciation_entries" had already cancelled the entries. So added Journal Entry to Asset's ignore_doctypes_on_cancel_all.