### PR TITLE
fix: incorrect transferred qty in the job card

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -653,23 +653,19 @@ class JobCard(Document):
 					exc=JobCardOverTransferError,
 				)
 
-		job_card_items_transferred_qty = _get_job_card_items_transferred_qty(ste_doc)
+		job_card_items_transferred_qty = _get_job_card_items_transferred_qty(ste_doc) or {}
+		allow_excess = frappe.db.get_single_value("Manufacturing Settings", "job_card_excess_transfer")
 
-		if job_card_items_transferred_qty:
-			allow_excess = frappe.db.get_single_value("Manufacturing Settings", "job_card_excess_transfer")
+		for row in ste_doc.items:
+			if not row.job_card_item:
+				continue
 
-			for row in ste_doc.items:
-				if not row.job_card_item:
-					continue
+			transferred_qty = flt(job_card_items_transferred_qty.get(row.job_card_item, 0.0))
 
-				transferred_qty = flt(job_card_items_transferred_qty.get(row.job_card_item))
+			if not allow_excess:
+				_validate_over_transfer(row, transferred_qty)
 
-				if not allow_excess:
-					_validate_over_transfer(row, transferred_qty)
-
-				frappe.db.set_value(
-					"Job Card Item", row.job_card_item, "transferred_qty", flt(transferred_qty)
-				)
+			frappe.db.set_value("Job Card Item", row.job_card_item, "transferred_qty", flt(transferred_qty))
 
 	def set_transferred_qty(self, update_status=False):
 		"Set total FG Qty in Job Card for which RM was transferred."

--- a/erpnext/manufacturing/doctype/job_card/test_job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/test_job_card.py
@@ -342,6 +342,12 @@ class TestJobCard(FrappeTestCase):
 		job_card.reload()
 		self.assertEqual(job_card.transferred_qty, 2)
 
+		transfer_entry_2.cancel()
+		transfer_entry.cancel()
+
+		job_card.reload()
+		self.assertEqual(job_card.transferred_qty, 0.0)
+
 	def test_job_card_material_transfer_correctness(self):
 		"""
 		1. Test if only current Job Card Items are pulled in a Stock Entry against a Job Card


### PR DESCRIPTION
**Issue**

Job Card has cancelled still showing the transferred qty as 1 

<img width="1339" alt="Screenshot 2023-05-30 at 4 54 36 PM" src="https://github.com/frappe/erpnext/assets/8780500/6b5b2beb-efb7-4eb7-9bd0-b6c6d04d18b1">

