### PR TITLE
feat(accounts): add Portuguese SNC CoA

### DIFF
--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/pt_pt_chart_template.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/pt_pt_chart_template.json
@@ -1,0 +1,2475 @@
+{
+    "country_code": "pt",
+    "name": "Portugal - Plano de Contas SNC",
+    "tree": {
+        "1 - Meios financeiros l\u00edquidos": {
+            "root_type": "Asset",
+            "Caixa": {
+                "account_number": "11",
+                "account_name": "Caixa",
+                "account_type": "Cash"
+            },
+            "Dep\u00f3sitos \u00e0 ordem": {
+                "account_number": "12",
+                "account_name": "Dep\u00f3sitos \u00e0 ordem",
+                "account_type": "Bank"
+            },
+            "Outros dep\u00f3sitos banc\u00e1rios": {
+                "account_number": "13",
+                "account_name": "Outros dep\u00f3sitos banc\u00e1rios",
+                "account_type": "Cash"
+            },
+            "Outros instrumentos financeiros": {
+                "account_number": "14",
+                "account_name": "Outros instrumentos financeiros",
+                "account_type": "Cash"
+            },
+            "Derivados": {
+                "account_number": "141",
+                "account_name": "Derivados",
+                "account_type": "Cash"
+            },
+            "Potencialmente favor\u00e1veis": {
+                "account_number": "1411",
+                "account_name": "Potencialmente favor\u00e1veis",
+                "account_type": "Cash"
+            },
+            "Potencialmente desfavor\u00e1veis": {
+                "account_number": "1412",
+                "account_name": "Potencialmente desfavor\u00e1veis",
+                "account_type": "Cash"
+            },
+            "Instrumentos financeiros detidos para negocia\u00e7\u00e3o": {
+                "account_number": "142",
+                "account_name": "Instrumentos financeiros detidos para negocia\u00e7\u00e3o",
+                "account_type": "Cash"
+            },
+            "Activos financeiros": {
+                "account_number": "1421",
+                "account_name": "Activos financeiros",
+                "account_type": "Cash"
+            },
+            "Passivos financeiros": {
+                "account_number": "1422",
+                "account_name": "Passivos financeiros",
+                "account_type": "Cash"
+            },
+            "Outros activos e passivos financeiros": {
+                "account_number": "143",
+                "account_name": "Outros activos e passivos financeiros",
+                "account_type": "Cash"
+            },
+            "Outros activos financeiros": {
+                "account_number": "1431",
+                "account_name": "Outros activos financeiros",
+                "account_type": "Cash"
+            },
+            "Outros passivos financeiros": {
+                "account_number": "1432",
+                "account_name": "Outros passivos financeiros",
+                "account_type": "Cash"
+            }
+        },
+        "2 - Contas a receber e a pagar": {
+            "root_type": "Liability",
+            "Clientes": {
+                "account_number": "21",
+                "account_name": "Clientes",
+                "account_type": "Receivable"
+            },
+            "Clientes c/c": {
+                "account_number": "211",
+                "account_name": "Clientes c/c",
+                "account_type": "Receivable"
+            },
+            "Clientes gerais": {
+                "account_number": "2111",
+                "account_name": "Clientes gerais",
+                "account_type": "Receivable"
+            },
+            "Clientes empresa m\u00e3e": {
+                "account_number": "2112",
+                "account_name": "Clientes empresa m\u00e3e",
+                "account_type": "Receivable"
+            },
+            "Clientes empresas subsidi\u00e1rias": {
+                "account_number": "2113",
+                "account_name": "Clientes empresas subsidi\u00e1rias",
+                "account_type": "Receivable"
+            },
+            "Clientes empresas associadas": {
+                "account_number": "2114",
+                "account_name": "Clientes empresas associadas",
+                "account_type": "Receivable"
+            },
+            "Clientes empreendimentos conjuntos": {
+                "account_number": "2115",
+                "account_name": "Clientes empreendimentos conjuntos",
+                "account_type": "Receivable"
+            },
+            "Clientes outras partes relacionadas": {
+                "account_number": "2116",
+                "account_name": "Clientes outras partes relacionadas",
+                "account_type": "Receivable"
+            },
+            "Clientes t\u00edtulos a receber": {
+                "account_number": "212",
+                "account_name": "Clientes t\u00edtulos a receber",
+                "account_type": "Receivable"
+            },
+            "Clientes gerais_2121": {
+                "account_number": "2121",
+                "account_name": "Clientes gerais",
+                "account_type": "Receivable"
+            },
+            "Clientes empresa m\u00e3e_2122": {
+                "account_number": "2122",
+                "account_name": "Clientes empresa m\u00e3e",
+                "account_type": "Receivable"
+            },
+            "Clientes empresas subsidi\u00e1rias_2123": {
+                "account_number": "2123",
+                "account_name": "Clientes empresas subsidi\u00e1rias",
+                "account_type": "Receivable"
+            },
+            "Clientes empresas associadas_2124": {
+                "account_number": "2124",
+                "account_name": "Clientes empresas associadas",
+                "account_type": "Receivable"
+            },
+            "Clientes empreendimentos conjuntos_2125": {
+                "account_number": "2125",
+                "account_name": "Clientes empreendimentos conjuntos",
+                "account_type": "Receivable"
+            },
+            "Clientes outras partes relacionadas_2126": {
+                "account_number": "2126",
+                "account_name": "Clientes outras partes relacionadas",
+                "account_type": "Receivable"
+            },
+            "Adiantamentos de clientes": {
+                "account_number": "218",
+                "account_name": "Adiantamentos de clientes",
+                "account_type": "Receivable"
+            },
+            "Perdas por imparidade acumuladas": {
+                "account_number": "219",
+                "account_name": "Perdas por imparidade acumuladas",
+                "account_type": "Receivable"
+            },
+            "Fornecedores": {
+                "account_number": "22",
+                "account_name": "Fornecedores",
+                "account_type": "Payable"
+            },
+            "Fornecedores c/c": {
+                "account_number": "221",
+                "account_name": "Fornecedores c/c",
+                "account_type": "Payable"
+            },
+            "Fornecedores gerais": {
+                "account_number": "2211",
+                "account_name": "Fornecedores gerais",
+                "account_type": "Payable"
+            },
+            "Fornecedores empresa m\u00e3e": {
+                "account_number": "2212",
+                "account_name": "Fornecedores empresa m\u00e3e",
+                "account_type": "Payable"
+            },
+            "Fornecedores empresas subsidi\u00e1rias": {
+                "account_number": "2213",
+                "account_name": "Fornecedores empresas subsidi\u00e1rias",
+                "account_type": "Payable"
+            },
+            "Fornecedores empresas associadas": {
+                "account_number": "2214",
+                "account_name": "Fornecedores empresas associadas",
+                "account_type": "Payable"
+            },
+            "Fornecedores empreendimentos conjuntos": {
+                "account_number": "2215",
+                "account_name": "Fornecedores empreendimentos conjuntos",
+                "account_type": "Payable"
+            },
+            "Fornecedores outras partes relacionadas": {
+                "account_number": "2216",
+                "account_name": "Fornecedores outras partes relacionadas",
+                "account_type": "Payable"
+            },
+            "Fornecedores t\u00edtulos a pagar": {
+                "account_number": "222",
+                "account_name": "Fornecedores t\u00edtulos a pagar",
+                "account_type": "Payable"
+            },
+            "Fornecedores gerais_2221": {
+                "account_number": "2221",
+                "account_name": "Fornecedores gerais",
+                "account_type": "Payable"
+            },
+            "Fornecedores empresa m\u00e3e_2222": {
+                "account_number": "2222",
+                "account_name": "Fornecedores empresa m\u00e3e",
+                "account_type": "Payable"
+            },
+            "Fornecedores empresas subsidi\u00e1rias_2223": {
+                "account_number": "2223",
+                "account_name": "Fornecedores empresas subsidi\u00e1rias",
+                "account_type": "Payable"
+            },
+            "Fornecedores empresas associadas_2224": {
+                "account_number": "2224",
+                "account_name": "Fornecedores empresas associadas",
+                "account_type": "Payable"
+            },
+            "Fornecedores empreendimentos conjuntos_2225": {
+                "account_number": "2225",
+                "account_name": "Fornecedores empreendimentos conjuntos",
+                "account_type": "Payable"
+            },
+            "Fornecedores outras partes relacionadas_2226": {
+                "account_number": "2226",
+                "account_name": "Fornecedores outras partes relacionadas",
+                "account_type": "Payable"
+            },
+            "Facturas em recep\u00e7\u00e3o e confer\u00eancia": {
+                "account_number": "225",
+                "account_name": "Facturas em recep\u00e7\u00e3o e confer\u00eancia",
+                "account_type": "Payable"
+            },
+            "Adiantamentos a fornecedores": {
+                "account_number": "228",
+                "account_name": "Adiantamentos a fornecedores",
+                "account_type": "Payable"
+            },
+            "Perdas por imparidade acumuladas_229": {
+                "account_number": "229",
+                "account_name": "Perdas por imparidade acumuladas",
+                "account_type": "Payable"
+            },
+            "Pessoal": {
+                "account_number": "23",
+                "account_name": "Pessoal",
+                "account_type": "Payable"
+            },
+            "Remunera\u00e7\u00f5es a pagar": {
+                "account_number": "231",
+                "account_name": "Remunera\u00e7\u00f5es a pagar",
+                "account_type": "Payable"
+            },
+            "Aos \u00f3rg\u00e3os sociais": {
+                "account_number": "2311",
+                "account_name": "Aos \u00f3rg\u00e3os sociais",
+                "account_type": "Payable"
+            },
+            "Ao pessoal": {
+                "account_number": "2312",
+                "account_name": "Ao pessoal",
+                "account_type": "Payable"
+            },
+            "Adiantamentos": {
+                "account_number": "232",
+                "account_name": "Adiantamentos",
+                "account_type": "Payable"
+            },
+            "Aos \u00f3rg\u00e3os sociais_2321": {
+                "account_number": "2321",
+                "account_name": "Aos \u00f3rg\u00e3os sociais",
+                "account_type": "Payable"
+            },
+            "Ao pessoal_2322": {
+                "account_number": "2322",
+                "account_name": "Ao pessoal",
+                "account_type": "Payable"
+            },
+            "Cau\u00e7\u00f5es": {
+                "account_number": "237",
+                "account_name": "Cau\u00e7\u00f5es",
+                "account_type": "Payable"
+            },
+            "Dos \u00f3rg\u00e3os sociais": {
+                "account_number": "2371",
+                "account_name": "Dos \u00f3rg\u00e3os sociais",
+                "account_type": "Payable"
+            },
+            "Do pessoal": {
+                "account_number": "2372",
+                "account_name": "Do pessoal",
+                "account_type": "Payable"
+            },
+            "Outras opera\u00e7\u00f5es": {
+                "account_number": "238",
+                "account_name": "Outras opera\u00e7\u00f5es",
+                "account_type": "Payable"
+            },
+            "Com os \u00f3rg\u00e3os sociais": {
+                "account_number": "2381",
+                "account_name": "Com os \u00f3rg\u00e3os sociais",
+                "account_type": "Payable"
+            },
+            "Com o pessoal": {
+                "account_number": "2382",
+                "account_name": "Com o pessoal",
+                "account_type": "Payable"
+            },
+            "Perdas por imparidade acumuladas_239": {
+                "account_number": "239",
+                "account_name": "Perdas por imparidade acumuladas",
+                "account_type": "Payable"
+            },
+            "Estado e outros entes p\u00fablicos": {
+                "account_number": "24",
+                "account_name": "Estado e outros entes p\u00fablicos",
+                "account_type": "Tax"
+            },
+            "Imposto sobre o rendimento": {
+                "account_number": "241",
+                "account_name": "Imposto sobre o rendimento",
+                "account_type": "Tax"
+            },
+            "Reten\u00e7\u00e3o de impostos sobre rendimentos": {
+                "account_number": "242",
+                "account_name": "Reten\u00e7\u00e3o de impostos sobre rendimentos",
+                "account_type": "Tax"
+            },
+            "Imposto sobre o valor acrescentado": {
+                "account_number": "243",
+                "account_name": "Imposto sobre o valor acrescentado",
+                "account_type": "Tax"
+            },
+            "Iva suportado": {
+                "account_number": "2431",
+                "account_name": "Iva suportado",
+                "account_type": "Tax"
+            },
+            "Iva dedut\u00edvel": {
+                "account_number": "2432",
+                "account_name": "Iva dedut\u00edvel",
+                "account_type": "Tax"
+            },
+            "Iva liquidado": {
+                "account_number": "2433",
+                "account_name": "Iva liquidado",
+                "account_type": "Tax"
+            },
+            "Iva regulariza\u00e7\u00f5es": {
+                "account_number": "2434",
+                "account_name": "Iva regulariza\u00e7\u00f5es",
+                "account_type": "Tax"
+            },
+            "Iva apuramento": {
+                "account_number": "2435",
+                "account_name": "Iva apuramento",
+                "account_type": "Tax"
+            },
+            "Iva a pagar": {
+                "account_number": "2436",
+                "account_name": "Iva a pagar",
+                "account_type": "Tax"
+            },
+            "Iva a recuperar": {
+                "account_number": "2437",
+                "account_name": "Iva a recuperar",
+                "account_type": "Tax"
+            },
+            "Iva reembolsos pedidos": {
+                "account_number": "2438",
+                "account_name": "Iva reembolsos pedidos",
+                "account_type": "Tax"
+            },
+            "Iva liquida\u00e7\u00f5es oficiosas": {
+                "account_number": "2439",
+                "account_name": "Iva liquida\u00e7\u00f5es oficiosas",
+                "account_type": "Tax"
+            },
+            "Outros impostos": {
+                "account_number": "244",
+                "account_name": "Outros impostos",
+                "account_type": "Tax"
+            },
+            "Contribui\u00e7\u00f5es para a seguran\u00e7a social": {
+                "account_number": "245",
+                "account_name": "Contribui\u00e7\u00f5es para a seguran\u00e7a social",
+                "account_type": "Tax"
+            },
+            "Tributos das autarquias locais": {
+                "account_number": "246",
+                "account_name": "Tributos das autarquias locais",
+                "account_type": "Tax"
+            },
+            "Outras tributa\u00e7\u00f5es": {
+                "account_number": "248",
+                "account_name": "Outras tributa\u00e7\u00f5es",
+                "account_type": "Tax"
+            },
+            "Financiamentos obtidos": {
+                "account_number": "25",
+                "account_name": "Financiamentos obtidos",
+                "account_type": "Equity"
+            },
+            "Institui\u00e7\u00f5es de cr\u00e9dito e sociedades financeiras": {
+                "account_number": "251",
+                "account_name": "Institui\u00e7\u00f5es de cr\u00e9dito e sociedades financeiras",
+                "account_type": "Equity"
+            },
+            "Empr\u00e9stimos banc\u00e1rios": {
+                "account_number": "2511",
+                "account_name": "Empr\u00e9stimos banc\u00e1rios",
+                "account_type": "Equity"
+            },
+            "Descobertos banc\u00e1rios": {
+                "account_number": "2512",
+                "account_name": "Descobertos banc\u00e1rios",
+                "account_type": "Equity"
+            },
+            "Loca\u00e7\u00f5es financeiras": {
+                "account_number": "2513",
+                "account_name": "Loca\u00e7\u00f5es financeiras",
+                "account_type": "Equity"
+            },
+            "Mercado de valores mobili\u00e1rios": {
+                "account_number": "252",
+                "account_name": "Mercado de valores mobili\u00e1rios",
+                "account_type": "Equity"
+            },
+            "Empr\u00e9stimos por obriga\u00e7\u00f5es": {
+                "account_number": "2521",
+                "account_name": "Empr\u00e9stimos por obriga\u00e7\u00f5es",
+                "account_type": "Equity"
+            },
+            "Participantes de capital": {
+                "account_number": "253",
+                "account_name": "Participantes de capital",
+                "account_type": "Equity"
+            },
+            "Empresa m\u00e3e suprimentos e outros m\u00fatuos": {
+                "account_number": "2531",
+                "account_name": "Empresa m\u00e3e suprimentos e outros m\u00fatuos",
+                "account_type": "Equity"
+            },
+            "Outros participantes suprimentos e outros m\u00fatuos": {
+                "account_number": "2532",
+                "account_name": "Outros participantes suprimentos e outros m\u00fatuos",
+                "account_type": "Equity"
+            },
+            "Subsidi\u00e1rias, associadas e empreendimentos conjuntos": {
+                "account_number": "254",
+                "account_name": "Subsidi\u00e1rias, associadas e empreendimentos conjuntos",
+                "account_type": "Equity"
+            },
+            "Outros financiadores": {
+                "account_number": "258",
+                "account_name": "Outros financiadores",
+                "account_type": "Equity"
+            },
+            "Accionistas/s\u00f3cios": {
+                "account_number": "26",
+                "account_name": "Accionistas/s\u00f3cios",
+                "account_type": "Equity"
+            },
+            "Accionistas c. subscri\u00e7\u00e3o": {
+                "account_number": "261",
+                "account_name": "Accionistas c. subscri\u00e7\u00e3o",
+                "account_type": "Equity"
+            },
+            "Quotas n\u00e3o liberadas": {
+                "account_number": "262",
+                "account_name": "Quotas n\u00e3o liberadas",
+                "account_type": "Equity"
+            },
+            "Adiantamentos por conta de lucros": {
+                "account_number": "263",
+                "account_name": "Adiantamentos por conta de lucros",
+                "account_type": "Equity"
+            },
+            "Resultados atribu\u00eddos": {
+                "account_number": "264",
+                "account_name": "Resultados atribu\u00eddos",
+                "account_type": "Equity"
+            },
+            "Lucros dispon\u00edveis": {
+                "account_number": "265",
+                "account_name": "Lucros dispon\u00edveis",
+                "account_type": "Equity"
+            },
+            "Empr\u00e9stimos concedidos empresa m\u00e3e": {
+                "account_number": "266",
+                "account_name": "Empr\u00e9stimos concedidos empresa m\u00e3e",
+                "account_type": "Equity"
+            },
+            "Outras opera\u00e7\u00f5es_268": {
+                "account_number": "268",
+                "account_name": "Outras opera\u00e7\u00f5es",
+                "account_type": "Equity"
+            },
+            "Perdas por imparidade acumuladas_269": {
+                "account_number": "269",
+                "account_name": "Perdas por imparidade acumuladas",
+                "account_type": "Equity"
+            },
+            "Outras contas a receber e a pagar": {
+                "account_number": "27",
+                "account_name": "Outras contas a receber e a pagar",
+                "account_type": "Equity"
+            },
+            "Fornecedores de investimentos": {
+                "account_number": "271",
+                "account_name": "Fornecedores de investimentos",
+                "account_type": "Equity"
+            },
+            "Fornecedores de investimentos contas gerais": {
+                "account_number": "2711",
+                "account_name": "Fornecedores de investimentos contas gerais",
+                "account_type": "Equity"
+            },
+            "Facturas em recep\u00e7\u00e3o e confer\u00eancia_2712": {
+                "account_number": "2712",
+                "account_name": "Facturas em recep\u00e7\u00e3o e confer\u00eancia",
+                "account_type": "Equity"
+            },
+            "Adiantamentos a fornecedores de investimentos": {
+                "account_number": "2713",
+                "account_name": "Adiantamentos a fornecedores de investimentos",
+                "account_type": "Equity"
+            },
+            "Devedores e credores por acr\u00e9scimos": {
+                "account_number": "272",
+                "account_name": "Devedores e credores por acr\u00e9scimos",
+                "account_type": "Equity"
+            },
+            "Devedores por acr\u00e9scimo de rendimentos": {
+                "account_number": "2721",
+                "account_name": "Devedores por acr\u00e9scimo de rendimentos",
+                "account_type": "Equity"
+            },
+            "Credores por acr\u00e9scimos de gastos": {
+                "account_number": "2722",
+                "account_name": "Credores por acr\u00e9scimos de gastos",
+                "account_type": "Equity"
+            },
+            "Benef\u00edcios p\u00f3s emprego": {
+                "account_number": "273",
+                "account_name": "Benef\u00edcios p\u00f3s emprego",
+                "account_type": "Equity"
+            },
+            "Impostos diferidos": {
+                "account_number": "274",
+                "account_name": "Impostos diferidos",
+                "account_type": "Equity"
+            },
+            "Activos por impostos diferidos": {
+                "account_number": "2741",
+                "account_name": "Activos por impostos diferidos",
+                "account_type": "Equity"
+            },
+            "Passivos por impostos diferidos": {
+                "account_number": "2742",
+                "account_name": "Passivos por impostos diferidos",
+                "account_type": "Equity"
+            },
+            "Credores por subscri\u00e7\u00f5es n\u00e3o liberadas": {
+                "account_number": "275",
+                "account_name": "Credores por subscri\u00e7\u00f5es n\u00e3o liberadas",
+                "account_type": "Equity"
+            },
+            "Adiantamentos por conta de vendas": {
+                "account_number": "276",
+                "account_name": "Adiantamentos por conta de vendas",
+                "account_type": "Equity"
+            },
+            "Outros devedores e credores": {
+                "account_number": "278",
+                "account_name": "Outros devedores e credores",
+                "account_type": "Equity"
+            },
+            "Perdas por imparidade acumuladas_279": {
+                "account_number": "279",
+                "account_name": "Perdas por imparidade acumuladas",
+                "account_type": "Equity"
+            },
+            "Diferimentos": {
+                "account_number": "28",
+                "account_name": "Diferimentos",
+                "account_type": "Equity"
+            },
+            "Gastos a reconhecer": {
+                "account_number": "281",
+                "account_name": "Gastos a reconhecer",
+                "account_type": "Equity"
+            },
+            "Rendimentos a reconhecer": {
+                "account_number": "282",
+                "account_name": "Rendimentos a reconhecer",
+                "account_type": "Equity"
+            },
+            "Provis\u00f5es": {
+                "account_number": "29",
+                "account_name": "Provis\u00f5es",
+                "account_type": "Equity"
+            },
+            "Impostos": {
+                "account_number": "291",
+                "account_name": "Impostos",
+                "account_type": "Equity"
+            },
+            "Garantias a clientes": {
+                "account_number": "292",
+                "account_name": "Garantias a clientes",
+                "account_type": "Equity"
+            },
+            "Processos judiciais em curso": {
+                "account_number": "293",
+                "account_name": "Processos judiciais em curso",
+                "account_type": "Equity"
+            },
+            "Acidentes de trabalho e doen\u00e7as profissionais": {
+                "account_number": "294",
+                "account_name": "Acidentes de trabalho e doen\u00e7as profissionais",
+                "account_type": "Equity"
+            },
+            "Mat\u00e9rias ambientais": {
+                "account_number": "295",
+                "account_name": "Mat\u00e9rias ambientais",
+                "account_type": "Equity"
+            },
+            "Contratos onerosos": {
+                "account_number": "296",
+                "account_name": "Contratos onerosos",
+                "account_type": "Equity"
+            },
+            "Reestrutura\u00e7\u00e3o": {
+                "account_number": "297",
+                "account_name": "Reestrutura\u00e7\u00e3o",
+                "account_type": "Equity"
+            },
+            "Outras provis\u00f5es": {
+                "account_number": "298",
+                "account_name": "Outras provis\u00f5es",
+                "account_type": "Equity"
+            }
+        },
+        "3 - Invent\u00e1rios e activos biol\u00f3gicos": {
+            "root_type": "Expense",
+            "Compras": {
+                "account_number": "31",
+                "account_name": "Compras",
+                "account_type": "Stock"
+            },
+            "Mercadorias": {
+                "account_number": "311",
+                "account_name": "Mercadorias",
+                "account_type": "Expense Account"
+            },
+            "Mat\u00e9rias primas, subsidi\u00e1rias e de consumo": {
+                "account_number": "312",
+                "account_name": "Mat\u00e9rias primas, subsidi\u00e1rias e de consumo",
+                "account_type": "Expense Account"
+            },
+            "Activos biol\u00f3gicos": {
+                "account_number": "313",
+                "account_name": "Activos biol\u00f3gicos",
+                "account_type": "Expense Account"
+            },
+            "Devolu\u00e7\u00f5es de compras": {
+                "account_number": "317",
+                "account_name": "Devolu\u00e7\u00f5es de compras",
+                "account_type": "Expense Account"
+            },
+            "Descontos e abatimentos em compras": {
+                "account_number": "318",
+                "account_name": "Descontos e abatimentos em compras",
+                "account_type": "Expense Account"
+            },
+            "Mercadorias_32": {
+                "account_number": "32",
+                "account_name": "Mercadorias",
+                "account_type": "Stock"
+            },
+            "Mercadorias em tr\u00e2nsito": {
+                "account_number": "325",
+                "account_name": "Mercadorias em tr\u00e2nsito",
+                "account_type": "Expense Account"
+            },
+            "Mercadorias em poder de terceiros": {
+                "account_number": "326",
+                "account_name": "Mercadorias em poder de terceiros",
+                "account_type": "Expense Account"
+            },
+            "Perdas por imparidade acumuladas_329": {
+                "account_number": "329",
+                "account_name": "Perdas por imparidade acumuladas",
+                "account_type": "Expense Account"
+            },
+            "Mat\u00e9rias primas, subsidi\u00e1rias e de consumo_33": {
+                "account_number": "33",
+                "account_name": "Mat\u00e9rias primas, subsidi\u00e1rias e de consumo",
+                "account_type": "Expense Account"
+            },
+            "Mat\u00e9rias primas": {
+                "account_number": "331",
+                "account_name": "Mat\u00e9rias primas",
+                "account_type": "Expense Account"
+            },
+            "Mat\u00e9rias subsidi\u00e1rias": {
+                "account_number": "332",
+                "account_name": "Mat\u00e9rias subsidi\u00e1rias",
+                "account_type": "Expense Account"
+            },
+            "Embalagens": {
+                "account_number": "333",
+                "account_name": "Embalagens",
+                "account_type": "Expense Account"
+            },
+            "Materiais diversos": {
+                "account_number": "334",
+                "account_name": "Materiais diversos",
+                "account_type": "Expense Account"
+            },
+            "Mat\u00e9rias em tr\u00e2nsito": {
+                "account_number": "335",
+                "account_name": "Mat\u00e9rias em tr\u00e2nsito",
+                "account_type": "Expense Account"
+            },
+            "Perdas por imparidade acumuladas_339": {
+                "account_number": "339",
+                "account_name": "Perdas por imparidade acumuladas",
+                "account_type": "Expense Account"
+            },
+            "Produtos acabados e interm\u00e9dios": {
+                "account_number": "34",
+                "account_name": "Produtos acabados e interm\u00e9dios",
+                "account_type": "Expense Account"
+            },
+            "Produtos em poder de terceiros": {
+                "account_number": "346",
+                "account_name": "Produtos em poder de terceiros",
+                "account_type": "Expense Account"
+            },
+            "Perdas por imparidade acumuladas_349": {
+                "account_number": "349",
+                "account_name": "Perdas por imparidade acumuladas",
+                "account_type": "Expense Account"
+            },
+            "Subprodutos, desperd\u00edcios, res\u00edduos e refugos": {
+                "account_number": "35",
+                "account_name": "Subprodutos, desperd\u00edcios, res\u00edduos e refugos",
+                "account_type": "Expense Account"
+            },
+            "Subprodutos": {
+                "account_number": "351",
+                "account_name": "Subprodutos",
+                "account_type": "Expense Account"
+            },
+            "Desperd\u00edcios, res\u00edduos e refugos": {
+                "account_number": "352",
+                "account_name": "Desperd\u00edcios, res\u00edduos e refugos",
+                "account_type": "Expense Account"
+            },
+            "Perdas por imparidade acumuladas_359": {
+                "account_number": "359",
+                "account_name": "Perdas por imparidade acumuladas",
+                "account_type": "Expense Account"
+            },
+            "Produtos e trabalhos em curso": {
+                "account_number": "36",
+                "account_name": "Produtos e trabalhos em curso",
+                "account_type": "Capital Work in Progress"
+            },
+            "Activos biol\u00f3gicos_37": {
+                "account_number": "37",
+                "account_name": "Activos biol\u00f3gicos",
+                "account_type": "Expense Account"
+            },
+            "Consum\u00edveis": {
+                "account_number": "371",
+                "account_name": "Consum\u00edveis",
+                "account_type": "Expense Account"
+            },
+            "Animais": {
+                "account_number": "3711",
+                "account_name": "Animais",
+                "account_type": "Expense Account"
+            },
+            "Plantas": {
+                "account_number": "3712",
+                "account_name": "Plantas",
+                "account_type": "Expense Account"
+            },
+            "De produ\u00e7\u00e3o": {
+                "account_number": "372",
+                "account_name": "De produ\u00e7\u00e3o",
+                "account_type": "Expense Account"
+            },
+            "Animais_3721": {
+                "account_number": "3721",
+                "account_name": "Animais",
+                "account_type": "Expense Account"
+            },
+            "Plantas_3722": {
+                "account_number": "3722",
+                "account_name": "Plantas",
+                "account_type": "Expense Account"
+            },
+            "Reclassifica\u00e7\u00e3o e regular. de invent. e activos biol\u00f3g.": {
+                "account_number": "38",
+                "account_name": "Reclassifica\u00e7\u00e3o e regular. de invent. e activos biol\u00f3g.",
+                "account_type": "Stock Adjustment"
+            },
+            "Mercadorias_382": {
+                "account_number": "382",
+                "account_name": "Mercadorias",
+                "account_type": "Expense Account"
+            },
+            "Mat\u00e9rias primas, subsidi\u00e1rias e de consumo_383": {
+                "account_number": "383",
+                "account_name": "Mat\u00e9rias primas, subsidi\u00e1rias e de consumo",
+                "account_type": "Expense Account"
+            },
+            "Produtos acabados e interm\u00e9dios_384": {
+                "account_number": "384",
+                "account_name": "Produtos acabados e interm\u00e9dios",
+                "account_type": "Expense Account"
+            },
+            "Subprodutos, desperd\u00edcios, res\u00edduos e refugos_385": {
+                "account_number": "385",
+                "account_name": "Subprodutos, desperd\u00edcios, res\u00edduos e refugos",
+                "account_type": "Expense Account"
+            },
+            "Produtos e trabalhos em curso_386": {
+                "account_number": "386",
+                "account_name": "Produtos e trabalhos em curso",
+                "account_type": "Expense Account"
+            },
+            "Activos biol\u00f3gicos_387": {
+                "account_number": "387",
+                "account_name": "Activos biol\u00f3gicos",
+                "account_type": "Expense Account"
+            },
+            "Adiantamentos por conta de compras": {
+                "account_number": "39",
+                "account_name": "Adiantamentos por conta de compras",
+                "account_type": "Expense Account"
+            }
+        },
+
+        "4 - Investimentos": {
+            "root_type": "Asset",
+            "Investimentos financeiros": {
+                "account_number": "41",
+                "account_name": "Investimentos financeiros",
+                "account_type": "Fixed Asset"
+            },
+            "Investimentos em subsidi\u00e1rias": {
+                "account_number": "411",
+                "account_name": "Investimentos em subsidi\u00e1rias",
+                "account_type": "Fixed Asset"
+            },
+            "Participa\u00e7\u00f5es de capital m\u00e9todo da equiv. patrimonial": {
+                "account_number": "4111",
+                "account_name": "Participa\u00e7\u00f5es de capital m\u00e9todo da equiv. patrimonial",
+                "account_type": "Fixed Asset"
+            },
+            "Participa\u00e7\u00f5es de capital outros m\u00e9todos": {
+                "account_number": "4112",
+                "account_name": "Participa\u00e7\u00f5es de capital outros m\u00e9todos",
+                "account_type": "Fixed Asset"
+            },
+            "Empr\u00e9stimos concedidos": {
+                "account_number": "4113",
+                "account_name": "Empr\u00e9stimos concedidos",
+                "account_type": "Fixed Asset"
+            },
+            "Investimentos em associadas": {
+                "account_number": "412",
+                "account_name": "Investimentos em associadas",
+                "account_type": "Fixed Asset"
+            },
+            "Participa\u00e7\u00f5es de capital m\u00e9todo da equiv. patrimonial_4121": {
+                "account_number": "4121",
+                "account_name": "Participa\u00e7\u00f5es de capital m\u00e9todo da equiv. patrimonial",
+                "account_type": "Fixed Asset"
+            },
+            "Participa\u00e7\u00f5es de capital outros m\u00e9todos_4122": {
+                "account_number": "4122",
+                "account_name": "Participa\u00e7\u00f5es de capital outros m\u00e9todos",
+                "account_type": "Fixed Asset"
+            },
+            "Empr\u00e9stimos concedidos_4123": {
+                "account_number": "4123",
+                "account_name": "Empr\u00e9stimos concedidos",
+                "account_type": "Fixed Asset"
+            },
+            "Investimentos em entidades conjuntamente controladas": {
+                "account_number": "413",
+                "account_name": "Investimentos em entidades conjuntamente controladas",
+                "account_type": "Fixed Asset"
+            },
+            "Participa\u00e7\u00f5es de capital m\u00e9todo da equiv. patrimonial_4131": {
+                "account_number": "4131",
+                "account_name": "Participa\u00e7\u00f5es de capital m\u00e9todo da equiv. patrimonial",
+                "account_type": "Fixed Asset"
+            },
+            "Participa\u00e7\u00f5es de capital outros m\u00e9todos_4132": {
+                "account_number": "4132",
+                "account_name": "Participa\u00e7\u00f5es de capital outros m\u00e9todos",
+                "account_type": "Fixed Asset"
+            },
+            "Empr\u00e9stimos concedidos_4133": {
+                "account_number": "4133",
+                "account_name": "Empr\u00e9stimos concedidos",
+                "account_type": "Fixed Asset"
+            },
+            "Investimentos noutras empresas": {
+                "account_number": "414",
+                "account_name": "Investimentos noutras empresas",
+                "account_type": "Fixed Asset"
+            },
+            "Participa\u00e7\u00f5es de capital": {
+                "account_number": "4141",
+                "account_name": "Participa\u00e7\u00f5es de capital",
+                "account_type": "Fixed Asset"
+            },
+            "Empr\u00e9stimos concedidos_4142": {
+                "account_number": "4142",
+                "account_name": "Empr\u00e9stimos concedidos",
+                "account_type": "Fixed Asset"
+            },
+            "Outros investimentos financeiros": {
+                "account_number": "415",
+                "account_name": "Outros investimentos financeiros",
+                "account_type": "Fixed Asset"
+            },
+            "Detidos at\u00e9 \u00e0 maturidade": {
+                "account_number": "4151",
+                "account_name": "Detidos at\u00e9 \u00e0 maturidade",
+                "account_type": "Fixed Asset"
+            },
+            "Ac\u00e7\u00f5es da sgm (6500x1,00)": {
+                "account_number": "4158",
+                "account_name": "Ac\u00e7\u00f5es da sgm (6500x1,00)",
+                "account_type": "Fixed Asset"
+            },
+            "Perdas por imparidade acumuladas_419": {
+                "account_number": "419",
+                "account_name": "Perdas por imparidade acumuladas",
+                "account_type": "Fixed Asset"
+            },
+            "Propriedades de investimento": {
+                "account_number": "42",
+                "account_name": "Propriedades de investimento",
+                "account_type": "Fixed Asset"
+            },
+            "Terrenos e recursos naturais": {
+                "account_number": "421",
+                "account_name": "Terrenos e recursos naturais",
+                "account_type": "Fixed Asset"
+            },
+            "Edif\u00edcios e outras constru\u00e7\u00f5es": {
+                "account_number": "422",
+                "account_name": "Edif\u00edcios e outras constru\u00e7\u00f5es",
+                "account_type": "Fixed Asset"
+            },
+            "Outras propriedades de investimento": {
+                "account_number": "426",
+                "account_name": "Outras propriedades de investimento",
+                "account_type": "Fixed Asset"
+            },
+            "Deprecia\u00e7\u00f5es acumuladas": {
+                "account_number": "428",
+                "account_name": "Deprecia\u00e7\u00f5es acumuladas",
+                "account_type": "Accumulated Depreciation"
+            },
+            "Perdas por imparidade acumuladas_429": {
+                "account_number": "429",
+                "account_name": "Perdas por imparidade acumuladas",
+                "account_type": "Fixed Asset"
+            },
+            "Activo fixos tang\u00edveis": {
+                "account_number": "43",
+                "account_name": "Activo fixos tang\u00edveis",
+                "account_type": "Fixed Asset"
+            },
+            "Terrenos e recursos naturais_431": {
+                "account_number": "431",
+                "account_name": "Terrenos e recursos naturais",
+                "account_type": "Fixed Asset"
+            },
+            "Edif\u00edcios e outras constru\u00e7\u00f5es_432": {
+                "account_number": "432",
+                "account_name": "Edif\u00edcios e outras constru\u00e7\u00f5es",
+                "account_type": "Fixed Asset"
+            },
+            "Equipamento b\u00e1sico": {
+                "account_number": "433",
+                "account_name": "Equipamento b\u00e1sico",
+                "account_type": "Fixed Asset"
+            },
+            "Equipamento de transporte": {
+                "account_number": "434",
+                "account_name": "Equipamento de transporte",
+                "account_type": "Fixed Asset"
+            },
+            "Equipamento administrativo": {
+                "account_number": "435",
+                "account_name": "Equipamento administrativo",
+                "account_type": "Fixed Asset"
+            },
+            "Equipamentos biol\u00f3gicos": {
+                "account_number": "436",
+                "account_name": "Equipamentos biol\u00f3gicos",
+                "account_type": "Fixed Asset"
+            },
+            "Outros activos fixos tang\u00edveis": {
+                "account_number": "437",
+                "account_name": "Outros activos fixos tang\u00edveis",
+                "account_type": "Fixed Asset"
+            },
+            "Deprecia\u00e7\u00f5es acumuladas_438": {
+                "account_number": "438",
+                "account_name": "Deprecia\u00e7\u00f5es acumuladas",
+                "account_type": "Accumulated Depreciation"
+            },
+            "Perdas por imparidade acumuladas_439": {
+                "account_number": "439",
+                "account_name": "Perdas por imparidade acumuladas",
+                "account_type": "Fixed Asset"
+            },
+            "Activos intang\u00edveis": {
+                "account_number": "44",
+                "account_name": "Activos intang\u00edveis",
+                "account_type": "Fixed Asset"
+            },
+            "Goodwill": {
+                "account_number": "441",
+                "account_name": "Goodwill",
+                "account_type": "Fixed Asset"
+            },
+            "Projectos de desenvolvimento": {
+                "account_number": "442",
+                "account_name": "Projectos de desenvolvimento",
+                "account_type": "Fixed Asset"
+            },
+            "Programas de computador": {
+                "account_number": "443",
+                "account_name": "Programas de computador",
+                "account_type": "Fixed Asset"
+            },
+            "Propriedade industrial": {
+                "account_number": "444",
+                "account_name": "Propriedade industrial",
+                "account_type": "Fixed Asset"
+            },
+            "Outros activos intang\u00edveis": {
+                "account_number": "446",
+                "account_name": "Outros activos intang\u00edveis",
+                "account_type": "Fixed Asset"
+            },
+            "Deprecia\u00e7\u00f5es acumuladas_448": {
+                "account_number": "448",
+                "account_name": "Deprecia\u00e7\u00f5es acumuladas",
+                "account_type": "Accumulated Depreciation"
+            },
+            "Perdas por imparidade acumuladas_449": {
+                "account_number": "449",
+                "account_name": "Perdas por imparidade acumuladas",
+                "account_type": "Fixed Asset"
+            },
+            "Investimentos em curso": {
+                "account_number": "45",
+                "account_name": "Investimentos em curso",
+                "account_type": "Fixed Asset"
+            },
+            "Investimentos financeiros em curso": {
+                "account_number": "451",
+                "account_name": "Investimentos financeiros em curso",
+                "account_type": "Fixed Asset"
+            },
+            "Propriedades de investimento em curso": {
+                "account_number": "452",
+                "account_name": "Propriedades de investimento em curso",
+                "account_type": "Fixed Asset"
+            },
+            "Activos fixos tang\u00edveis em curso": {
+                "account_number": "453",
+                "account_name": "Activos fixos tang\u00edveis em curso",
+                "account_type": "Fixed Asset"
+            },
+            "Activos intang\u00edveis em curso": {
+                "account_number": "454",
+                "account_name": "Activos intang\u00edveis em curso",
+                "account_type": "Fixed Asset"
+            },
+            "Adiantamentos por conta de investimentos": {
+                "account_number": "455",
+                "account_name": "Adiantamentos por conta de investimentos",
+                "account_type": "Fixed Asset"
+            },
+            "Perdas por imparidade acumuladas_459": {
+                "account_number": "459",
+                "account_name": "Perdas por imparidade acumuladas",
+                "account_type": "Fixed Asset"
+            },
+            "Activos n\u00e3o correntes detidos para venda": {
+                "account_number": "46",
+                "account_name": "Activos n\u00e3o correntes detidos para venda",
+                "account_type": "Fixed Asset"
+            },
+            "Perdas por imparidade acumuladas_469": {
+                "account_number": "469",
+                "account_name": "Perdas por imparidade acumuladas",
+                "account_type": "Fixed Asset"
+            }
+        },
+        "5 - Capital, reservas e resultados transitados": {
+            "root_type": "Equity",
+            "Capital": {
+                "account_number": "51",
+                "account_name": "Capital",
+                "account_type": "Equity"
+            },
+            "Ac\u00e7\u00f5es (quotas) pr\u00f3prias": {
+                "account_number": "52",
+                "account_name": "Ac\u00e7\u00f5es (quotas) pr\u00f3prias",
+                "account_type": "Equity"
+            },
+            "Valor nominal": {
+                "account_number": "521",
+                "account_name": "Valor nominal",
+                "account_type": "Equity"
+            },
+            "Descontos e pr\u00e9mios": {
+                "account_number": "522",
+                "account_name": "Descontos e pr\u00e9mios",
+                "account_type": "Equity"
+            },
+            "Outros instrumentos de capital pr\u00f3prio": {
+                "account_number": "53",
+                "account_name": "Outros instrumentos de capital pr\u00f3prio",
+                "account_type": "Equity"
+            },
+            "Pr\u00e9mios de emiss\u00e3o": {
+                "account_number": "54",
+                "account_name": "Pr\u00e9mios de emiss\u00e3o",
+                "account_type": "Equity"
+            },
+            "Reservas": {
+                "account_number": "55",
+                "account_name": "Reservas",
+                "account_type": "Equity"
+            },
+            "Reservas legais": {
+                "account_number": "551",
+                "account_name": "Reservas legais",
+                "account_type": "Equity"
+            },
+            "Outras reservas": {
+                "account_number": "552",
+                "account_name": "Outras reservas",
+                "account_type": "Equity"
+            },
+            "Resultados transitados": {
+                "account_number": "56",
+                "account_name": "Resultados transitados",
+                "account_type": "Equity"
+            },
+            "Ajustamentos em activos financeiros": {
+                "account_number": "57",
+                "account_name": "Ajustamentos em activos financeiros",
+                "account_type": "Equity"
+            },
+            "Relacionados com o m\u00e9todo da equival\u00eancia patrimonial": {
+                "account_number": "571",
+                "account_name": "Relacionados com o m\u00e9todo da equival\u00eancia patrimonial",
+                "account_type": "Equity"
+            },
+            "Ajustamentos de transi\u00e7\u00e3o": {
+                "account_number": "5711",
+                "account_name": "Ajustamentos de transi\u00e7\u00e3o",
+                "account_type": "Equity"
+            },
+            "Lucros n\u00e3o atribu\u00eddos": {
+                "account_number": "5712",
+                "account_name": "Lucros n\u00e3o atribu\u00eddos",
+                "account_type": "Equity"
+            },
+            "Decorrentes de outras varia\u00e7\u00f5es nos capitais pr\u00f3prios d": {
+                "account_number": "5713",
+                "account_name": "Decorrentes de outras varia\u00e7\u00f5es nos capitais pr\u00f3prios d",
+                "account_type": "Equity"
+            },
+            "Outros": {
+                "account_number": "579",
+                "account_name": "Outros",
+                "account_type": "Equity"
+            },
+            "Excedentes de revalor. de activos fixos tang\u00edveis e int": {
+                "account_number": "58",
+                "account_name": "Excedentes de revalor. de activos fixos tang\u00edveis e int",
+                "account_type": "Equity"
+            },
+            "Reavalia\u00e7\u00f5es decorrentes de diplomas legais": {
+                "account_number": "581",
+                "account_name": "Reavalia\u00e7\u00f5es decorrentes de diplomas legais",
+                "account_type": "Equity"
+            },
+            "Antes de imposto sobre o rendimento": {
+                "account_number": "5811",
+                "account_name": "Antes de imposto sobre o rendimento",
+                "account_type": "Equity"
+            },
+            "Impostos diferidos_5812": {
+                "account_number": "5812",
+                "account_name": "Impostos diferidos",
+                "account_type": "Equity"
+            },
+            "Outros excedentes": {
+                "account_number": "589",
+                "account_name": "Outros excedentes",
+                "account_type": "Equity"
+            },
+            "Antes de imposto sobre o rendimento_5891": {
+                "account_number": "5891",
+                "account_name": "Antes de imposto sobre o rendimento",
+                "account_type": "Equity"
+            },
+            "Impostos diferidos_5892": {
+                "account_number": "5892",
+                "account_name": "Impostos diferidos",
+                "account_type": "Equity"
+            },
+            "Outras varia\u00e7\u00f5es no capital pr\u00f3prio": {
+                "account_number": "59",
+                "account_name": "Outras varia\u00e7\u00f5es no capital pr\u00f3prio",
+                "account_type": "Equity"
+            },
+            "Diferen\u00e7as de convers\u00e3o de demonstra\u00e7\u00f5es financeiras": {
+                "account_number": "591",
+                "account_name": "Diferen\u00e7as de convers\u00e3o de demonstra\u00e7\u00f5es financeiras",
+                "account_type": "Equity"
+            },
+            "Ajustamentos por impostos diferidos": {
+                "account_number": "592",
+                "account_name": "Ajustamentos por impostos diferidos",
+                "account_type": "Equity"
+            },
+            "Subs\u00eddios": {
+                "account_number": "593",
+                "account_name": "Subs\u00eddios",
+                "account_type": "Equity"
+            },
+            "Doa\u00e7\u00f5es": {
+                "account_number": "594",
+                "account_name": "Doa\u00e7\u00f5es",
+                "account_type": "Equity"
+            },
+            "Outras": {
+                "account_number": "599",
+                "account_name": "Outras",
+                "account_type": "Equity"
+            }
+        },
+
+        "6 - Gastos": {
+            "root_type": "Expense",
+            "Custo das mercadorias vendidas e mat\u00e9rias consumidas": {
+                "account_number": "61",
+                "account_name": "Custo das mercadorias vendidas e mat\u00e9rias consumidas",
+                "account_type": "Cost of Goods Sold"
+            },
+            "Mercadorias_611": {
+                "account_number": "611",
+                "account_name": "Mercadorias",
+                "account_type": "Expense Account"
+            },
+            "Mat\u00e9rias primas, subsidi\u00e1rias e de consumo_612": {
+                "account_number": "612",
+                "account_name": "Mat\u00e9rias primas, subsidi\u00e1rias e de consumo",
+                "account_type": "Expense Account"
+            },
+            "Activos biol\u00f3gicos (compras)": {
+                "account_number": "613",
+                "account_name": "Activos biol\u00f3gicos (compras)",
+                "account_type": "Expense Account"
+            },
+            "Fornecimentos e servi\u00e7os externos": {
+                "account_number": "62",
+                "account_name": "Fornecimentos e servi\u00e7os externos",
+                "account_type": "Expense Account"
+            },
+            "Subcontratos": {
+                "account_number": "621",
+                "account_name": "Subcontratos",
+                "account_type": "Expense Account"
+            },
+            "Trabalhos especializados": {
+                "account_number": "622",
+                "account_name": "Trabalhos especializados",
+                "account_type": "Expense Account"
+            },
+            "Trabalhos especializados_6221": {
+                "account_number": "6221",
+                "account_name": "Trabalhos especializados",
+                "account_type": "Expense Account"
+            },
+            "Publicidade e propaganda": {
+                "account_number": "6222",
+                "account_name": "Publicidade e propaganda",
+                "account_type": "Expense Account"
+            },
+            "Vigil\u00e2ncia e seguran\u00e7a": {
+                "account_number": "6223",
+                "account_name": "Vigil\u00e2ncia e seguran\u00e7a",
+                "account_type": "Expense Account"
+            },
+            "Honor\u00e1rios": {
+                "account_number": "6224",
+                "account_name": "Honor\u00e1rios",
+                "account_type": "Expense Account"
+            },
+            "Comiss\u00f5es": {
+                "account_number": "6225",
+                "account_name": "Comiss\u00f5es",
+                "account_type": "Expense Account"
+            },
+            "Conserva\u00e7\u00e3o e repara\u00e7\u00e3o": {
+                "account_number": "6226",
+                "account_name": "Conserva\u00e7\u00e3o e repara\u00e7\u00e3o",
+                "account_type": "Expense Account"
+            },
+            "Outros_6228": {
+                "account_number": "6228",
+                "account_name": "Outros",
+                "account_type": "Expense Account"
+            },
+            "Materiais": {
+                "account_number": "623",
+                "account_name": "Materiais",
+                "account_type": "Expense Account"
+            },
+            "Ferramentas e utens\u00edlios de desgaste r\u00e1pido": {
+                "account_number": "6231",
+                "account_name": "Ferramentas e utens\u00edlios de desgaste r\u00e1pido",
+                "account_type": "Expense Account"
+            },
+            "Livros de documenta\u00e7\u00e3o t\u00e9cnica": {
+                "account_number": "6232",
+                "account_name": "Livros de documenta\u00e7\u00e3o t\u00e9cnica",
+                "account_type": "Expense Account"
+            },
+            "Material de escrit\u00f3rio": {
+                "account_number": "6233",
+                "account_name": "Material de escrit\u00f3rio",
+                "account_type": "Expense Account"
+            },
+            "Artigos de oferta": {
+                "account_number": "6234",
+                "account_name": "Artigos de oferta",
+                "account_type": "Expense Account"
+            },
+            "Outros_6238": {
+                "account_number": "6238",
+                "account_name": "Outros",
+                "account_type": "Expense Account"
+            },
+            "Energia e flu\u00eddos": {
+                "account_number": "624",
+                "account_name": "Energia e flu\u00eddos",
+                "account_type": "Expense Account"
+            },
+            "Electricidade": {
+                "account_number": "6241",
+                "account_name": "Electricidade",
+                "account_type": "Expense Account"
+            },
+            "Combust\u00edveis": {
+                "account_number": "6242",
+                "account_name": "Combust\u00edveis",
+                "account_type": "Expense Account"
+            },
+            "\u00c1gua": {
+                "account_number": "6243",
+                "account_name": "\u00c1gua",
+                "account_type": "Expense Account"
+            },
+            "Outros_6248": {
+                "account_number": "6248",
+                "account_name": "Outros",
+                "account_type": "Expense Account"
+            },
+            "Desloca\u00e7\u00f5es, estadas e transportes": {
+                "account_number": "625",
+                "account_name": "Desloca\u00e7\u00f5es, estadas e transportes",
+                "account_type": "Expense Account"
+            },
+            "Desloca\u00e7\u00f5es e estadas": {
+                "account_number": "6251",
+                "account_name": "Desloca\u00e7\u00f5es e estadas",
+                "account_type": "Expense Account"
+            },
+            "Transporte de pessoal": {
+                "account_number": "6252",
+                "account_name": "Transporte de pessoal",
+                "account_type": "Expense Account"
+            },
+            "Transportes de mercadorias": {
+                "account_number": "6253",
+                "account_name": "Transportes de mercadorias",
+                "account_type": "Expense Account"
+            },
+            "Outros_6258": {
+                "account_number": "6258",
+                "account_name": "Outros",
+                "account_type": "Expense Account"
+            },
+            "Servi\u00e7os diversos": {
+                "account_number": "626",
+                "account_name": "Servi\u00e7os diversos",
+                "account_type": "Expense Account"
+            },
+            "Rendas e alugueres": {
+                "account_number": "6261",
+                "account_name": "Rendas e alugueres",
+                "account_type": "Expense Account"
+            },
+            "Comunica\u00e7\u00e3o": {
+                "account_number": "6262",
+                "account_name": "Comunica\u00e7\u00e3o",
+                "account_type": "Expense Account"
+            },
+            "Seguros": {
+                "account_number": "6263",
+                "account_name": "Seguros",
+                "account_type": "Expense Account"
+            },
+            "Royalties": {
+                "account_number": "6264",
+                "account_name": "Royalties",
+                "account_type": "Expense Account"
+            },
+            "Contencioso e notariado": {
+                "account_number": "6265",
+                "account_name": "Contencioso e notariado",
+                "account_type": "Expense Account"
+            },
+            "Despesas de representa\u00e7\u00e3o": {
+                "account_number": "6266",
+                "account_name": "Despesas de representa\u00e7\u00e3o",
+                "account_type": "Expense Account"
+            },
+            "Limpeza, higiene e conforto": {
+                "account_number": "6267",
+                "account_name": "Limpeza, higiene e conforto",
+                "account_type": "Expense Account"
+            },
+            "Outros servi\u00e7os": {
+                "account_number": "6268",
+                "account_name": "Outros servi\u00e7os",
+                "account_type": "Expense Account"
+            },
+            "Gastos com o pessoal": {
+                "account_number": "63",
+                "account_name": "Gastos com o pessoal",
+                "account_type": "Expense Account"
+            },
+            "Remunera\u00e7\u00f5es dos \u00f3rg\u00e3os sociais": {
+                "account_number": "631",
+                "account_name": "Remunera\u00e7\u00f5es dos \u00f3rg\u00e3os sociais",
+                "account_type": "Expense Account"
+            },
+            "Remunera\u00e7\u00f5es do pessoal": {
+                "account_number": "632",
+                "account_name": "Remunera\u00e7\u00f5es do pessoal",
+                "account_type": "Expense Account"
+            },
+            "Benef\u00edcios p\u00f3s emprego_633": {
+                "account_number": "633",
+                "account_name": "Benef\u00edcios p\u00f3s emprego",
+                "account_type": "Expense Account"
+            },
+            "Pr\u00e9mios para pens\u00f5es": {
+                "account_number": "6331",
+                "account_name": "Pr\u00e9mios para pens\u00f5es",
+                "account_type": "Expense Account"
+            },
+            "Outros benef\u00edcios": {
+                "account_number": "6332",
+                "account_name": "Outros benef\u00edcios",
+                "account_type": "Expense Account"
+            },
+            "Indemniza\u00e7\u00f5es": {
+                "account_number": "634",
+                "account_name": "Indemniza\u00e7\u00f5es",
+                "account_type": "Expense Account"
+            },
+            "Encargos sobre remunera\u00e7\u00f5es": {
+                "account_number": "635",
+                "account_name": "Encargos sobre remunera\u00e7\u00f5es",
+                "account_type": "Expense Account"
+            },
+            "Seguros de acidentes no trabalho e doen\u00e7as profissionais": {
+                "account_number": "636",
+                "account_name": "Seguros de acidentes no trabalho e doen\u00e7as profissionais",
+                "account_type": "Expense Account"
+            },
+            "Gastos de ac\u00e7\u00e3o social": {
+                "account_number": "637",
+                "account_name": "Gastos de ac\u00e7\u00e3o social",
+                "account_type": "Expense Account"
+            },
+            "Outros gastos com o pessoal": {
+                "account_number": "638",
+                "account_name": "Outros gastos com o pessoal",
+                "account_type": "Expense Account"
+            },
+            "Gastos de deprecia\u00e7\u00e3o e de amortiza\u00e7\u00e3o": {
+                "account_number": "64",
+                "account_name": "Gastos de deprecia\u00e7\u00e3o e de amortiza\u00e7\u00e3o",
+                "account_type": "Depreciation"
+            },
+            "Propriedades de investimento_641": {
+                "account_number": "641",
+                "account_name": "Propriedades de investimento",
+                "account_type": "Expense Account"
+            },
+            "Activos fixos tang\u00edveis": {
+                "account_number": "642",
+                "account_name": "Activos fixos tang\u00edveis",
+                "account_type": "Expense Account"
+            },
+            "Activos intang\u00edveis_643": {
+                "account_number": "643",
+                "account_name": "Activos intang\u00edveis",
+                "account_type": "Expense Account"
+            },
+            "Perdas por imparidade": {
+                "account_number": "65",
+                "account_name": "Perdas por imparidade",
+                "account_type": "Expense Account"
+            },
+            "Em d\u00edvidas a receber": {
+                "account_number": "651",
+                "account_name": "Em d\u00edvidas a receber",
+                "account_type": "Expense Account"
+            },
+            "Clientes_6511": {
+                "account_number": "6511",
+                "account_name": "Clientes",
+                "account_type": "Expense Account"
+            },
+            "Outros devedores": {
+                "account_number": "6512",
+                "account_name": "Outros devedores",
+                "account_type": "Expense Account"
+            },
+            "Em invent\u00e1rios": {
+                "account_number": "652",
+                "account_name": "Em invent\u00e1rios",
+                "account_type": "Expense Account"
+            },
+            "Em investimentos financeiros": {
+                "account_number": "653",
+                "account_name": "Em investimentos financeiros",
+                "account_type": "Expense Account"
+            },
+            "Em propriedades de investimento": {
+                "account_number": "654",
+                "account_name": "Em propriedades de investimento",
+                "account_type": "Expense Account"
+            },
+            "Em activos fixos tang\u00edveis": {
+                "account_number": "655",
+                "account_name": "Em activos fixos tang\u00edveis",
+                "account_type": "Expense Account"
+            },
+            "Em activos intang\u00edveis": {
+                "account_number": "656",
+                "account_name": "Em activos intang\u00edveis",
+                "account_type": "Expense Account"
+            },
+            "Em investimentos em curso": {
+                "account_number": "657",
+                "account_name": "Em investimentos em curso",
+                "account_type": "Expense Account"
+            },
+            "Em activos n\u00e3o correntes detidos para venda": {
+                "account_number": "658",
+                "account_name": "Em activos n\u00e3o correntes detidos para venda",
+                "account_type": "Expense Account"
+            },
+            "Perdas por redu\u00e7\u00f5es de justo valor": {
+                "account_number": "66",
+                "account_name": "Perdas por redu\u00e7\u00f5es de justo valor",
+                "account_type": "Expense Account"
+            },
+            "Em instrumentos financeiros": {
+                "account_number": "661",
+                "account_name": "Em instrumentos financeiros",
+                "account_type": "Expense Account"
+            },
+            "Em investimentos financeiros_662": {
+                "account_number": "662",
+                "account_name": "Em investimentos financeiros",
+                "account_type": "Expense Account"
+            },
+            "Em propriedades de investimento_663": {
+                "account_number": "663",
+                "account_name": "Em propriedades de investimento",
+                "account_type": "Expense Account"
+            },
+            "Em activos biol\u00f3gicos": {
+                "account_number": "664",
+                "account_name": "Em activos biol\u00f3gicos",
+                "account_type": "Expense Account"
+            },
+            "Provis\u00f5es do per\u00edodo": {
+                "account_number": "67",
+                "account_name": "Provis\u00f5es do per\u00edodo",
+                "account_type": "Expense Account"
+            },
+            "Impostos_671": {
+                "account_number": "671",
+                "account_name": "Impostos",
+                "account_type": "Expense Account"
+            },
+            "Garantias a clientes_672": {
+                "account_number": "672",
+                "account_name": "Garantias a clientes",
+                "account_type": "Expense Account"
+            },
+            "Processos judiciais em curso_673": {
+                "account_number": "673",
+                "account_name": "Processos judiciais em curso",
+                "account_type": "Expense Account"
+            },
+            "Acidentes de trabalho e doen\u00e7as profissionais_674": {
+                "account_number": "674",
+                "account_name": "Acidentes de trabalho e doen\u00e7as profissionais",
+                "account_type": "Expense Account"
+            },
+            "Mat\u00e9rias ambientais_675": {
+                "account_number": "675",
+                "account_name": "Mat\u00e9rias ambientais",
+                "account_type": "Expense Account"
+            },
+            "Contratos onerosos_676": {
+                "account_number": "676",
+                "account_name": "Contratos onerosos",
+                "account_type": "Expense Account"
+            },
+            "Reestrutura\u00e7\u00e3o_677": {
+                "account_number": "677",
+                "account_name": "Reestrutura\u00e7\u00e3o",
+                "account_type": "Expense Account"
+            },
+            "Outras provis\u00f5es_678": {
+                "account_number": "678",
+                "account_name": "Outras provis\u00f5es",
+                "account_type": "Expense Account"
+            },
+            "Outros gastos e perdas": {
+                "account_number": "68",
+                "account_name": "Outros gastos e perdas",
+                "account_type": "Expense Account"
+            },
+            "Impostos_681": {
+                "account_number": "681",
+                "account_name": "Impostos",
+                "account_type": "Expense Account"
+            },
+            "Impostos directos": {
+                "account_number": "6811",
+                "account_name": "Impostos directos",
+                "account_type": "Expense Account"
+            },
+            "Impostos indirectos": {
+                "account_number": "6812",
+                "account_name": "Impostos indirectos",
+                "account_type": "Expense Account"
+            },
+            "Taxas": {
+                "account_number": "6813",
+                "account_name": "Taxas",
+                "account_type": "Expense Account"
+            },
+            "Descontos de pronto pagamento concedidos": {
+                "account_number": "682",
+                "account_name": "Descontos de pronto pagamento concedidos",
+                "account_type": "Expense Account"
+            },
+            "D\u00edvidas incobr\u00e1veis": {
+                "account_number": "683",
+                "account_name": "D\u00edvidas incobr\u00e1veis",
+                "account_type": "Expense Account"
+            },
+            "Perdas em invent\u00e1rios": {
+                "account_number": "684",
+                "account_name": "Perdas em invent\u00e1rios",
+                "account_type": "Expense Account"
+            },
+            "Sinistros": {
+                "account_number": "6841",
+                "account_name": "Sinistros",
+                "account_type": "Expense Account"
+            },
+            "Quebras": {
+                "account_number": "6842",
+                "account_name": "Quebras",
+                "account_type": "Expense Account"
+            },
+            "Outras perdas": {
+                "account_number": "6848",
+                "account_name": "Outras perdas",
+                "account_type": "Expense Account"
+            },
+            "Gastos e perdas em subsid. , assoc. e empreend. conjuntos": {
+                "account_number": "685",
+                "account_name": "Gastos e perdas em subsid. , assoc. e empreend. conjuntos",
+                "account_type": "Expense Account"
+            },
+            "Cobertura de preju\u00edzos": {
+                "account_number": "6851",
+                "account_name": "Cobertura de preju\u00edzos",
+                "account_type": "Expense Account"
+            },
+            "Aplica\u00e7\u00e3o do m\u00e9todo da equival\u00eancia patrimonial": {
+                "account_number": "6852",
+                "account_name": "Aplica\u00e7\u00e3o do m\u00e9todo da equival\u00eancia patrimonial",
+                "account_type": "Expense Account"
+            },
+            "Aliena\u00e7\u00f5es": {
+                "account_number": "6853",
+                "account_name": "Aliena\u00e7\u00f5es",
+                "account_type": "Expense Account"
+            },
+            "Outros gastos e perdas_6858": {
+                "account_number": "6858",
+                "account_name": "Outros gastos e perdas",
+                "account_type": "Expense Account"
+            },
+            "Gastos e perdas nos restantes investimentos financeiros": {
+                "account_number": "686",
+                "account_name": "Gastos e perdas nos restantes investimentos financeiros",
+                "account_type": "Expense Account"
+            },
+            "Cobertura de preju\u00edzos_6861": {
+                "account_number": "6861",
+                "account_name": "Cobertura de preju\u00edzos",
+                "account_type": "Expense Account"
+            },
+            "Aliena\u00e7\u00f5es_6862": {
+                "account_number": "6862",
+                "account_name": "Aliena\u00e7\u00f5es",
+                "account_type": "Expense Account"
+            },
+            "Outros gastos e perdas_6868": {
+                "account_number": "6868",
+                "account_name": "Outros gastos e perdas",
+                "account_type": "Expense Account"
+            },
+            "Gastos e perdas em investimentos n\u00e3o financeiros": {
+                "account_number": "687",
+                "account_name": "Gastos e perdas em investimentos n\u00e3o financeiros",
+                "account_type": "Expense Account"
+            },
+            "Aliena\u00e7\u00f5es_6871": {
+                "account_number": "6871",
+                "account_name": "Aliena\u00e7\u00f5es",
+                "account_type": "Expense Account"
+            },
+            "Sinistros_6872": {
+                "account_number": "6872",
+                "account_name": "Sinistros",
+                "account_type": "Expense Account"
+            },
+            "Abates": {
+                "account_number": "6873",
+                "account_name": "Abates",
+                "account_type": "Expense Account"
+            },
+            "Gastos em propriedades de investimento": {
+                "account_number": "6874",
+                "account_name": "Gastos em propriedades de investimento",
+                "account_type": "Expense Account"
+            },
+            "Outros gastos e perdas_6878": {
+                "account_number": "6878",
+                "account_name": "Outros gastos e perdas",
+                "account_type": "Expense Account"
+            },
+            "Outros_688": {
+                "account_number": "688",
+                "account_name": "Outros",
+                "account_type": "Expense Account"
+            },
+            "Correc\u00e7\u00f5es relativas a per\u00edodos anteriores": {
+                "account_number": "6881",
+                "account_name": "Correc\u00e7\u00f5es relativas a per\u00edodos anteriores",
+                "account_type": "Expense Account"
+            },
+            "Donativos": {
+                "account_number": "6882",
+                "account_name": "Donativos",
+                "account_type": "Expense Account"
+            },
+            "Quotiza\u00e7\u00f5es": {
+                "account_number": "6883",
+                "account_name": "Quotiza\u00e7\u00f5es",
+                "account_type": "Expense Account"
+            },
+            "Ofertas e amostras de invent\u00e1rios": {
+                "account_number": "6884",
+                "account_name": "Ofertas e amostras de invent\u00e1rios",
+                "account_type": "Expense Account"
+            },
+            "Insufici\u00eancia da estimativa para impostos": {
+                "account_number": "6885",
+                "account_name": "Insufici\u00eancia da estimativa para impostos",
+                "account_type": "Expense Account"
+            },
+            "Perdas em instrumentos financeiros": {
+                "account_number": "6886",
+                "account_name": "Perdas em instrumentos financeiros",
+                "account_type": "Expense Account"
+            },
+            "Outros n\u00e3o especificados": {
+                "account_number": "6888",
+                "account_name": "Outros n\u00e3o especificados",
+                "account_type": "Expense Account"
+            },
+            "Gastos e perdas de financiamento": {
+                "account_number": "69",
+                "account_name": "Gastos e perdas de financiamento",
+                "account_type": "Expense Account"
+            },
+            "Juros suportados": {
+                "account_number": "691",
+                "account_name": "Juros suportados",
+                "account_type": "Expense Account"
+            },
+            "Juros de financiamento obtidos": {
+                "account_number": "6911",
+                "account_name": "Juros de financiamento obtidos",
+                "account_type": "Expense Account"
+            },
+            "Outros juros": {
+                "account_number": "6918",
+                "account_name": "Outros juros",
+                "account_type": "Expense Account"
+            },
+            "Diferen\u00e7as de c\u00e2mbio desfavor\u00e1veis": {
+                "account_number": "692",
+                "account_name": "Diferen\u00e7as de c\u00e2mbio desfavor\u00e1veis",
+                "account_type": "Expense Account"
+            },
+            "Relativos a financiamentos obtidos": {
+                "account_number": "6921",
+                "account_name": "Relativos a financiamentos obtidos",
+                "account_type": "Expense Account"
+            },
+            "Outras_6928": {
+                "account_number": "6928",
+                "account_name": "Outras",
+                "account_type": "Expense Account"
+            },
+            "Outros gastos e perdas de financiamento": {
+                "account_number": "698",
+                "account_name": "Outros gastos e perdas de financiamento",
+                "account_type": "Expense Account"
+            },
+            "Relativos a financiamentos obtidos_6981": {
+                "account_number": "6981",
+                "account_name": "Relativos a financiamentos obtidos",
+                "account_type": "Expense Account"
+            },
+            "Outros_6988": {
+                "account_number": "6988",
+                "account_name": "Outros",
+                "account_type": "Expense Account"
+            }
+        },
+        "7 - Rendimentos": {
+            "root_type": "Income",
+            "Vendas": {
+                "account_number": "71",
+                "account_name": "Vendas",
+                "account_type": "Income Account"
+            },
+            "Mercadoria": {
+                "account_number": "711",
+                "account_name": "Mercadoria",
+                "account_type": "Income Account"
+            },
+            "Produtos acabados e interm\u00e9dios_712": {
+                "account_number": "712",
+                "account_name": "Produtos acabados e interm\u00e9dios",
+                "account_type": "Income Account"
+            },
+            "Subprodutos, desperd\u00edcios, res\u00edduos e refugos_713": {
+                "account_number": "713",
+                "account_name": "Subprodutos, desperd\u00edcios, res\u00edduos e refugos",
+                "account_type": "Income Account"
+            },
+            "Activos biol\u00f3gicos_714": {
+                "account_number": "714",
+                "account_name": "Activos biol\u00f3gicos",
+                "account_type": "Income Account"
+            },
+            "Iva das vendas com imposto inclu\u00eddo": {
+                "account_number": "716",
+                "account_name": "Iva das vendas com imposto inclu\u00eddo",
+                "account_type": "Income Account"
+            },
+            "Devolu\u00e7\u00f5es de vendas": {
+                "account_number": "717",
+                "account_name": "Devolu\u00e7\u00f5es de vendas",
+                "account_type": "Income Account"
+            },
+            "Descontos e abatimentos em vendas": {
+                "account_number": "718",
+                "account_name": "Descontos e abatimentos em vendas",
+                "account_type": "Income Account"
+            },
+            "Presta\u00e7\u00f5es de servi\u00e7os": {
+                "account_number": "72",
+                "account_name": "Presta\u00e7\u00f5es de servi\u00e7os",
+                "account_type": "Income Account"
+            },
+            "Servi\u00e7o a": {
+                "account_number": "721",
+                "account_name": "Servi\u00e7o a",
+                "account_type": "Income Account"
+            },
+            "Servi\u00e7o b": {
+                "account_number": "722",
+                "account_name": "Servi\u00e7o b",
+                "account_type": "Income Account"
+            },
+            "Servi\u00e7os secund\u00e1rios": {
+                "account_number": "725",
+                "account_name": "Servi\u00e7os secund\u00e1rios",
+                "account_type": "Income Account"
+            },
+            "Iva dos servi\u00e7os com imposto inclu\u00eddo": {
+                "account_number": "726",
+                "account_name": "Iva dos servi\u00e7os com imposto inclu\u00eddo",
+                "account_type": "Income Account"
+            },
+            "Descontos e abatimentos": {
+                "account_number": "728",
+                "account_name": "Descontos e abatimentos",
+                "account_type": "Income Account"
+            },
+            "Varia\u00e7\u00f5es nos invent\u00e1rios da produ\u00e7\u00e3o": {
+                "account_number": "73",
+                "account_name": "Varia\u00e7\u00f5es nos invent\u00e1rios da produ\u00e7\u00e3o",
+                "account_type": "Income Account"
+            },
+            "Produtos acabados e interm\u00e9dios_731": {
+                "account_number": "731",
+                "account_name": "Produtos acabados e interm\u00e9dios",
+                "account_type": "Income Account"
+            },
+            "Subprodutos, desperd\u00edcios, res\u00edduos e refugos_732": {
+                "account_number": "732",
+                "account_name": "Subprodutos, desperd\u00edcios, res\u00edduos e refugos",
+                "account_type": "Income Account"
+            },
+            "Produtos e trabalhos em curso_733": {
+                "account_number": "733",
+                "account_name": "Produtos e trabalhos em curso",
+                "account_type": "Income Account"
+            },
+            "Activos biol\u00f3gicos_734": {
+                "account_number": "734",
+                "account_name": "Activos biol\u00f3gicos",
+                "account_type": "Income Account"
+            },
+            "Trabalhos para a pr\u00f3pria entidade": {
+                "account_number": "74",
+                "account_name": "Trabalhos para a pr\u00f3pria entidade",
+                "account_type": "Income Account"
+            },
+            "Activos fixos tang\u00edveis_741": {
+                "account_number": "741",
+                "account_name": "Activos fixos tang\u00edveis",
+                "account_type": "Income Account"
+            },
+            "Activos intang\u00edveis_742": {
+                "account_number": "742",
+                "account_name": "Activos intang\u00edveis",
+                "account_type": "Income Account"
+            },
+            "Propriedades de investimento_743": {
+                "account_number": "743",
+                "account_name": "Propriedades de investimento",
+                "account_type": "Income Account"
+            },
+            "Activos por gastos diferidos": {
+                "account_number": "744",
+                "account_name": "Activos por gastos diferidos",
+                "account_type": "Income Account"
+            },
+            "Subs\u00eddios \u00e0 explora\u00e7\u00e3o": {
+                "account_number": "75",
+                "account_name": "Subs\u00eddios \u00e0 explora\u00e7\u00e3o",
+                "account_type": "Income Account"
+            },
+            "Subs\u00eddios do estado e outros entes p\u00fablicos": {
+                "account_number": "751",
+                "account_name": "Subs\u00eddios do estado e outros entes p\u00fablicos",
+                "account_type": "Income Account"
+            },
+            "Subs\u00eddios de outras entidades": {
+                "account_number": "752",
+                "account_name": "Subs\u00eddios de outras entidades",
+                "account_type": "Income Account"
+            },
+            "Revers\u00f5es": {
+                "account_number": "76",
+                "account_name": "Revers\u00f5es",
+                "account_type": "Income Account"
+            },
+            "De deprecia\u00e7\u00f5es e de amortiza\u00e7\u00f5es": {
+                "account_number": "761",
+                "account_name": "De deprecia\u00e7\u00f5es e de amortiza\u00e7\u00f5es",
+                "account_type": "Income Account"
+            },
+            "Propriedades de investimento_7611": {
+                "account_number": "7611",
+                "account_name": "Propriedades de investimento",
+                "account_type": "Income Account"
+            },
+            "Activos fixos tang\u00edveis_7612": {
+                "account_number": "7612",
+                "account_name": "Activos fixos tang\u00edveis",
+                "account_type": "Income Account"
+            },
+            "Activos intang\u00edveis_7613": {
+                "account_number": "7613",
+                "account_name": "Activos intang\u00edveis",
+                "account_type": "Income Account"
+            },
+            "De perdas por imparidade": {
+                "account_number": "762",
+                "account_name": "De perdas por imparidade",
+                "account_type": "Income Account"
+            },
+            "Em d\u00edvidas a receber_7621": {
+                "account_number": "7621",
+                "account_name": "Em d\u00edvidas a receber",
+                "account_type": "Income Account"
+            },
+            "Clientes_76211": {
+                "account_number": "76211",
+                "account_name": "Clientes",
+                "account_type": "Income Account"
+            },
+            "Outros devedores_76212": {
+                "account_number": "76212",
+                "account_name": "Outros devedores",
+                "account_type": "Income Account"
+            },
+            "Em invent\u00e1rios_7622": {
+                "account_number": "7622",
+                "account_name": "Em invent\u00e1rios",
+                "account_type": "Income Account"
+            },
+            "Em investimentos financeiros_7623": {
+                "account_number": "7623",
+                "account_name": "Em investimentos financeiros",
+                "account_type": "Income Account"
+            },
+            "Em propriedades de investimento_7624": {
+                "account_number": "7624",
+                "account_name": "Em propriedades de investimento",
+                "account_type": "Income Account"
+            },
+            "Em activos fixos tang\u00edveis_7625": {
+                "account_number": "7625",
+                "account_name": "Em activos fixos tang\u00edveis",
+                "account_type": "Income Account"
+            },
+            "Em activos intang\u00edveis_7626": {
+                "account_number": "7626",
+                "account_name": "Em activos intang\u00edveis",
+                "account_type": "Income Account"
+            },
+            "Em investimentos em curso_7627": {
+                "account_number": "7627",
+                "account_name": "Em investimentos em curso",
+                "account_type": "Income Account"
+            },
+            "Em activos n\u00e3o correntes detidos para venda_7628": {
+                "account_number": "7628",
+                "account_name": "Em activos n\u00e3o correntes detidos para venda",
+                "account_type": "Income Account"
+            },
+            "De provis\u00f5es": {
+                "account_number": "763",
+                "account_name": "De provis\u00f5es",
+                "account_type": "Income Account"
+            },
+            "Impostos_7631": {
+                "account_number": "7631",
+                "account_name": "Impostos",
+                "account_type": "Income Account"
+            },
+            "Garantias a clientes_7632": {
+                "account_number": "7632",
+                "account_name": "Garantias a clientes",
+                "account_type": "Income Account"
+            },
+            "Processos judiciais em curso_7633": {
+                "account_number": "7633",
+                "account_name": "Processos judiciais em curso",
+                "account_type": "Income Account"
+            },
+            "Acidentes no trabalho e doen\u00e7as profissionais": {
+                "account_number": "7634",
+                "account_name": "Acidentes no trabalho e doen\u00e7as profissionais",
+                "account_type": "Income Account"
+            },
+            "Mat\u00e9rias ambientais_7635": {
+                "account_number": "7635",
+                "account_name": "Mat\u00e9rias ambientais",
+                "account_type": "Income Account"
+            },
+            "Contratos onerosos_7636": {
+                "account_number": "7636",
+                "account_name": "Contratos onerosos",
+                "account_type": "Income Account"
+            },
+            "Reestrutura\u00e7\u00e3o_7637": {
+                "account_number": "7637",
+                "account_name": "Reestrutura\u00e7\u00e3o",
+                "account_type": "Income Account"
+            },
+            "Outras provis\u00f5es_7638": {
+                "account_number": "7638",
+                "account_name": "Outras provis\u00f5es",
+                "account_type": "Income Account"
+            },
+            "Ganhos por aumentos de justo valor": {
+                "account_number": "77",
+                "account_name": "Ganhos por aumentos de justo valor",
+                "account_type": "Income Account"
+            },
+            "Em instrumentos financeiros_771": {
+                "account_number": "771",
+                "account_name": "Em instrumentos financeiros",
+                "account_type": "Income Account"
+            },
+            "Em investimentos financeiros_772": {
+                "account_number": "772",
+                "account_name": "Em investimentos financeiros",
+                "account_type": "Income Account"
+            },
+            "Em propriedades de investimento_773": {
+                "account_number": "773",
+                "account_name": "Em propriedades de investimento",
+                "account_type": "Income Account"
+            },
+            "Em activos biol\u00f3gicos_774": {
+                "account_number": "774",
+                "account_name": "Em activos biol\u00f3gicos",
+                "account_type": "Income Account"
+            },
+            "Outros rendimentos e ganhos": {
+                "account_number": "78",
+                "account_name": "Outros rendimentos e ganhos",
+                "account_type": "Income Account"
+            },
+            "Rendimentos suplementares": {
+                "account_number": "781",
+                "account_name": "Rendimentos suplementares",
+                "account_type": "Income Account"
+            },
+            "Servi\u00e7os sociais": {
+                "account_number": "7811",
+                "account_name": "Servi\u00e7os sociais",
+                "account_type": "Income Account"
+            },
+            "Aluguer de equipamento": {
+                "account_number": "7812",
+                "account_name": "Aluguer de equipamento",
+                "account_type": "Income Account"
+            },
+            "Estudos, projectos e assist\u00eancia tecnol\u00f3gica": {
+                "account_number": "7813",
+                "account_name": "Estudos, projectos e assist\u00eancia tecnol\u00f3gica",
+                "account_type": "Income Account"
+            },
+            "Royalties_7814": {
+                "account_number": "7814",
+                "account_name": "Royalties",
+                "account_type": "Income Account"
+            },
+            "Desempenho de cargos sociais noutras empresas": {
+                "account_number": "7815",
+                "account_name": "Desempenho de cargos sociais noutras empresas",
+                "account_type": "Income Account"
+            },
+            "Outros rendimentos suplementares": {
+                "account_number": "7816",
+                "account_name": "Outros rendimentos suplementares",
+                "account_type": "Income Account"
+            },
+            "Descontos de pronto pagamento obtidos": {
+                "account_number": "782",
+                "account_name": "Descontos de pronto pagamento obtidos",
+                "account_type": "Income Account"
+            },
+            "Recupera\u00e7\u00e3o de d\u00edvidas a receber": {
+                "account_number": "783",
+                "account_name": "Recupera\u00e7\u00e3o de d\u00edvidas a receber",
+                "account_type": "Income Account"
+            },
+            "Ganhos em invent\u00e1rios": {
+                "account_number": "784",
+                "account_name": "Ganhos em invent\u00e1rios",
+                "account_type": "Income Account"
+            },
+            "Sinistros_7841": {
+                "account_number": "7841",
+                "account_name": "Sinistros",
+                "account_type": "Income Account"
+            },
+            "Sobras": {
+                "account_number": "7842",
+                "account_name": "Sobras",
+                "account_type": "Income Account"
+            },
+            "Outros ganhos": {
+                "account_number": "7848",
+                "account_name": "Outros ganhos",
+                "account_type": "Income Account"
+            },
+            "Rendimentos e ganhos em subsidi\u00e1rias, associadas e empr": {
+                "account_number": "785",
+                "account_name": "Rendimentos e ganhos em subsidi\u00e1rias, associadas e empr",
+                "account_type": "Income Account"
+            },
+            "Aplica\u00e7\u00e3o do m\u00e9todo da equival\u00eancia patrimonial_7851": {
+                "account_number": "7851",
+                "account_name": "Aplica\u00e7\u00e3o do m\u00e9todo da equival\u00eancia patrimonial",
+                "account_type": "Income Account"
+            },
+            "Aliena\u00e7\u00f5es_7852": {
+                "account_number": "7852",
+                "account_name": "Aliena\u00e7\u00f5es",
+                "account_type": "Income Account"
+            },
+            "Outros rendimentos e ganhos_7858": {
+                "account_number": "7858",
+                "account_name": "Outros rendimentos e ganhos",
+                "account_type": "Income Account"
+            },
+            "Rendimentos e ganhos nos restantes activos financeiros": {
+                "account_number": "786",
+                "account_name": "Rendimentos e ganhos nos restantes activos financeiros",
+                "account_type": "Income Account"
+            },
+            "Diferen\u00e7as de c\u00e2mbio favor\u00e1veis": {
+                "account_number": "7861",
+                "account_name": "Diferen\u00e7as de c\u00e2mbio favor\u00e1veis",
+                "account_type": "Income Account"
+            },
+            "Aliena\u00e7\u00f5es_7862": {
+                "account_number": "7862",
+                "account_name": "Aliena\u00e7\u00f5es",
+                "account_type": "Income Account"
+            },
+            "Outros rendimentos e ganhos_7868": {
+                "account_number": "7868",
+                "account_name": "Outros rendimentos e ganhos",
+                "account_type": "Income Account"
+            },
+            "Rendimentos e ganhos em investimentos n\u00e3o financeiros": {
+                "account_number": "787",
+                "account_name": "Rendimentos e ganhos em investimentos n\u00e3o financeiros",
+                "account_type": "Income Account"
+            },
+            "Aliena\u00e7\u00f5es_7871": {
+                "account_number": "7871",
+                "account_name": "Aliena\u00e7\u00f5es",
+                "account_type": "Income Account"
+            },
+            "Sinistros_7872": {
+                "account_number": "7872",
+                "account_name": "Sinistros",
+                "account_type": "Income Account"
+            },
+            "Rendas e outros rendimentos em propriedades de investimento": {
+                "account_number": "7873",
+                "account_name": "Rendas e outros rendimentos em propriedades de investimento",
+                "account_type": "Income Account"
+            },
+            "Outros rendimentos e ganhos_7878": {
+                "account_number": "7878",
+                "account_name": "Outros rendimentos e ganhos",
+                "account_type": "Income Account"
+            },
+            "Outros_788": {
+                "account_number": "788",
+                "account_name": "Outros",
+                "account_type": "Income Account"
+            },
+            "Correc\u00e7\u00f5es relativas a per\u00edodos anteriores_7881": {
+                "account_number": "7881",
+                "account_name": "Correc\u00e7\u00f5es relativas a per\u00edodos anteriores",
+                "account_type": "Income Account"
+            },
+            "Excesso da estimativa para impostos": {
+                "account_number": "7882",
+                "account_name": "Excesso da estimativa para impostos",
+                "account_type": "Income Account"
+            },
+            "Imputa\u00e7\u00e3o de subs\u00eddios para investimentos": {
+                "account_number": "7883",
+                "account_name": "Imputa\u00e7\u00e3o de subs\u00eddios para investimentos",
+                "account_type": "Income Account"
+            },
+            "Ganhos em outros instrumentos financeiros": {
+                "account_number": "7884",
+                "account_name": "Ganhos em outros instrumentos financeiros",
+                "account_type": "Income Account"
+            },
+            "Restitui\u00e7\u00e3o de impostos": {
+                "account_number": "7885",
+                "account_name": "Restitui\u00e7\u00e3o de impostos",
+                "account_type": "Income Account"
+            },
+            "Outros n\u00e3o especificados_7888": {
+                "account_number": "7888",
+                "account_name": "Outros n\u00e3o especificados",
+                "account_type": "Income Account"
+            },
+            "Juros, dividendos e outros rendimentos similares": {
+                "account_number": "79",
+                "account_name": "Juros, dividendos e outros rendimentos similares",
+                "account_type": "Income Account"
+            },
+            "Juros obtidos": {
+                "account_number": "791",
+                "account_name": "Juros obtidos",
+                "account_type": "Income Account"
+            },
+            "De dep\u00f3sitos": {
+                "account_number": "7911",
+                "account_name": "De dep\u00f3sitos",
+                "account_type": "Income Account"
+            },
+            "De outras aplica\u00e7\u00f5es de meios financeiros l\u00edquidos": {
+                "account_number": "7912",
+                "account_name": "De outras aplica\u00e7\u00f5es de meios financeiros l\u00edquidos",
+                "account_type": "Income Account"
+            },
+            "De financiamentos concedidos a associadas e emp. conjun": {
+                "account_number": "7913",
+                "account_name": "De financiamentos concedidos a associadas e emp. conjun",
+                "account_type": "Income Account"
+            },
+            "De financiamentos concedidos a subsidi\u00e1rias": {
+                "account_number": "7914",
+                "account_name": "De financiamentos concedidos a subsidi\u00e1rias",
+                "account_type": "Income Account"
+            },
+            "De financiamentos obtidos": {
+                "account_number": "7915",
+                "account_name": "De financiamentos obtidos",
+                "account_type": "Income Account"
+            },
+            "De outros financiamentos obtidos": {
+                "account_number": "7918",
+                "account_name": "De outros financiamentos obtidos",
+                "account_type": "Income Account"
+            },
+            "Dividendos obtidos": {
+                "account_number": "792",
+                "account_name": "Dividendos obtidos",
+                "account_type": "Income Account"
+            },
+            "De aplica\u00e7\u00f5es de meios financeiros l\u00edquidos": {
+                "account_number": "7921",
+                "account_name": "De aplica\u00e7\u00f5es de meios financeiros l\u00edquidos",
+                "account_type": "Income Account"
+            },
+            "De associadas e empreendimentos conjuntos": {
+                "account_number": "7922",
+                "account_name": "De associadas e empreendimentos conjuntos",
+                "account_type": "Income Account"
+            },
+            "De subsidi\u00e1rias": {
+                "account_number": "7923",
+                "account_name": "De subsidi\u00e1rias",
+                "account_type": "Income Account"
+            },
+            "Outras_7928": {
+                "account_number": "7928",
+                "account_name": "Outras",
+                "account_type": "Income Account"
+            },
+            "Outros rendimentos similares": {
+                "account_number": "798",
+                "account_name": "Outros rendimentos similares",
+                "account_type": "Income Account"
+            }
+        },
+        "8 - Resultados": {
+            "root_type": "Liability",
+            "Resultado l\u00edquido do per\u00edodo": {
+                "account_number": "81",
+                "account_name": "Resultado l\u00edquido do per\u00edodo",
+                "account_type": "Income Account"
+            },
+            "Resultado antes de impostos": {
+                "account_number": "811",
+                "account_name": "Resultado antes de impostos",
+                "account_type": "Income Account"
+            },
+            "Impostos sobre o rendimento do per\u00edodo": {
+                "account_number": "812",
+                "account_name": "Impostos sobre o rendimento do per\u00edodo",
+                "account_type": "Payable"
+            },
+            "Imposto estimado para o per\u00edodo": {
+                "account_number": "8121",
+                "account_name": "Imposto estimado para o per\u00edodo",
+                "account_type": "Payable"
+            },
+            "Imposto diferido": {
+                "account_number": "8122",
+                "account_name": "Imposto diferido",
+                "account_type": "Payable"
+            },
+            "Resultado l\u00edquido": {
+                "account_number": "818",
+                "account_name": "Resultado l\u00edquido",
+                "account_type": "Income Account"
+            },
+            "Dividendos antecipados": {
+                "account_number": "89",
+                "account_name": "Dividendos antecipados",
+                "account_type": "Payable"
+            }
+        },
+        "Others": {
+            "root_type": "Liability",
+            "Asset Received But Not Billed": {
+                "account_number": "",
+                "account_name": "Asset Received But Not Billed",
+                "account_type": "Asset Received But Not Billed"
+            },
+            "Stock Received But Not Billed": {
+                "account_number": "",
+                "account_name": "Stock Received But Not Billed",
+                "account_type": "Stock Received But Not Billed"
+            },
+            "Expenses Included In Valuation": {
+                "account_number": "",
+                "account_name": "Expenses Included In Valuation",
+                "account_type": "Expenses Included In Valuation"
+            }
+        }
+    }
+}


### PR DESCRIPTION
The ultimate goal of this commit is to add an updated Portuguese Chart of Accounts (CoA), based on Portugal's SNC norm. Account numbers are included. "Account types" shall ideally be confirmed and improved by an accountant. Howbeit, the account types are mostly inspired on former OpenERP, now designated Odoo.

This is my first PR to Frappe's team. Truly, I would like to thank you, the talented and illustrious programmers that delighted us with this project and crafted a fascinating application that is open and extremely helpful for the entire community.

![image](https://github.com/frappe/erpnext/assets/135072213/2dad11ab-a179-4e85-ba5b-400136c7bf68)

Some notes and assumptions (feel free to help, modify or improve if something is wrong):

List of "main account types" in the Portuguese SNC norm, and the proposed "root account type" in ERPNext.

| SNC                                          | root_type   |
| -------------------------------------------- | ----------- |
| 1 Meios Financeiros Líquidos                 | `Asset`     |
| 2 Contas a Receber e a Pagar                | `Liability` |
| 3 Inventários e Activos Biológicos           | `Expense`   |
| 4 Investimentos                              | `Asset`     |
| 5 Capital, Reservas e Resultados Transitados | `Liability` |
| 6 Gastos                                     | `Expense`   |
| 7 Rendimentos                                | `Income`    |
| 8 Resultados                                 | `Liability` |


## Mapping Between Specific ERPNext Account Types and Portuguese SNC Accounts:

- [x] Bank: The account group under which bank account will be created. (12 Depósitos à ordem) 
- [x] Cash: The account group under which cash account will be created.  (11 Caixa)
- [x] Cost of Goods Sold: The account to book the accumulated total of all costs used to manufacture / purchase a product or service, sold by a company. (61 Custo das mercadorias vendidas e das matérias consumidas)
- [x] Depreciation: The expense account to book the depreciation of the fixed assets. (64 Gastos de depreciação e de amortização)  
- [x] Accumulated Depreciation: The asset account is used to reduce Fixed Asset value while making depreciation entry. (428/ 438 Depreciações acumuladas, 448 Amortizações acumuladas)
- [x] Capital Work in Progress: Capital Work in Progress (Asset) account contains all expenses incurred on the asset until it is converted into working condition. (36 Produtos e trabalhos em curso) 
- [x] Asset Received But Not Billed: A temporary liability account which holds the value of assets received but not billed yet and used in Purchase Receipt for receiving assets. (Custom) 
- [x] Expenses Included In Asset Valuation: The other expenses included in valuation of an asset, apart from direct material costs. (Custom)
- [x] Expenses Included In Valuation: The other expenses included in landed cost/valuation of an item/product, apart from direct material costs (used in Perpetual Inventory). (Custom)
- [x] Fixed Asset: The account to maintain the costs of fixed assets. (4 - Investimentos)
- [x] Payable: The account which represents the amount owed by a company to its creditors. (22 Fornecedores, 23 Pessoal)  
- [x] Receivable: It is a current asset account, which represents the money to be received by the company, against the goods delivered or services rendered to the customers. (21 Clientes) 
- [x] Stock: The asset account for booking the inventory value. (31 Compras, 32 Mercadorias)
- [x] Stock Adjustment: An expense account to book any adjustment entry of stock/inventory, and generally comes at the same level of Cost of Goods Sold.  (38 Reclassificação e regularização de inventários e activos biológicos)
- [x] Stock Received But Not Billed: A temporary liability account which holds the value of stock received but not billed yet and used in Perpetual Inventory. (Custom)



