### PR TITLE
fix: old data reposting causing low server disk space

### DIFF
--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.js
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.js
@@ -59,6 +59,7 @@ frappe.ui.form.on('Repost Item Valuation', {
 			if (frm.doc.status == 'In Progress') {
 				frm.doc.current_index = data.current_index;
 				frm.doc.items_to_be_repost = data.items_to_be_repost;
+				frm.doc.total_reposting_count = data.total_reposting_count;
 
 				frm.dashboard.reset();
 				frm.trigger('show_reposting_progress');
@@ -95,6 +96,11 @@ frappe.ui.form.on('Repost Item Valuation', {
 		var bars = [];
 
 		let total_count = frm.doc.items_to_be_repost ? JSON.parse(frm.doc.items_to_be_repost).length : 0;
+
+		if (frm.doc?.total_reposting_count) {
+			total_count = frm.doc.total_reposting_count;
+		}
+
 		let progress = flt(cint(frm.doc.current_index) / total_count * 100, 2) || 0.5;
 		var title = __('Reposting Completed {0}%', [progress]);
 

--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.json
@@ -22,11 +22,15 @@
   "amended_from",
   "error_section",
   "error_log",
+  "reposting_info_section",
+  "reposting_data_file",
   "items_to_be_repost",
-  "affected_transactions",
   "distinct_item_and_warehouse",
+  "column_break_o1sj",
+  "total_reposting_count",
   "current_index",
-  "gl_reposting_index"
+  "gl_reposting_index",
+  "affected_transactions"
  ],
  "fields": [
   {
@@ -191,13 +195,36 @@
    "fieldtype": "Int",
    "hidden": 1,
    "label": "GL reposting index",
+   "no_copy": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "reposting_info_section",
+   "fieldtype": "Section Break",
+   "label": "Reposting Info"
+  },
+  {
+   "fieldname": "column_break_o1sj",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "total_reposting_count",
+   "fieldtype": "Int",
+   "label": "Total Reposting Count",
+   "no_copy": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "reposting_data_file",
+   "fieldtype": "Attach",
+   "label": "Reposting Data File",
    "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2022-11-28 16:00:05.637440",
+ "modified": "2023-05-31 12:48:57.138693",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Repost Item Valuation",


### PR DESCRIPTION
**Issue**

If users is doing reposting for old entries then after sometime they gets an error that `No space left on device`

**Investigation**

During investigation we found that the mysql binlogs files are increasing rapidly while reposting the old entries. During reposting we update the state of items which are already posted and which will be posted in the future. In case of old entries this data is huge and after every 10 seconds it update the state of reposting in the database. For every write operation in the mysql the respective binlog file gets updated with information about write query. As old entries has multiple writes operations it increases the size of the binlog files rapidly and eventually get the error `No space left on device`

**Solution**

Instead of storing the state of the reposting in the database we can store the state in the JSON file in gzip format. This will reduce the number of writes operations into the database.

<img width="1328" alt="Screenshot 2023-05-31 at 2 23 00 PM" src="https://github.com/frappe/erpnext/assets/8780500/2a2593cf-c051-41c3-9884-0eb9558c23bf">


