### PR TITLE
fix: ignore `Non-Stock Item` while calculating `% Picked` in Sales Order

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -415,10 +415,17 @@ class SalesOrder(SellingController):
 	def update_picking_status(self):
 		total_picked_qty = 0.0
 		total_qty = 0.0
+		per_picked = 0.0
+
 		for so_item in self.items:
-			total_picked_qty += flt(so_item.picked_qty)
-			total_qty += flt(so_item.stock_qty)
-		per_picked = total_picked_qty / total_qty * 100
+			if cint(
+				frappe.get_cached_value("Item", so_item.item_code, "is_stock_item")
+			) or self.has_product_bundle(so_item.item_code):
+				total_picked_qty += flt(so_item.picked_qty)
+				total_qty += flt(so_item.stock_qty)
+
+		if total_picked_qty and total_qty:
+			per_picked = total_picked_qty / total_qty * 100
 
 		self.db_set("per_picked", flt(per_picked), update_modified=False)
 

--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -265,6 +265,10 @@ class PickList(Document):
 		for item in locations:
 			if not item.item_code:
 				frappe.throw("Row #{0}: Item Code is Mandatory".format(item.idx))
+			if not cint(
+				frappe.get_cached_value("Item", item.item_code, "is_stock_item")
+			) and not frappe.db.exists("Product Bundle", {"new_item_code": item.item_code}):
+				continue
 			item_code = item.item_code
 			reference = item.sales_order_item or item.material_request_item
 			key = (item_code, item.uom, item.warehouse, item.batch_no, reference)


### PR DESCRIPTION
**Source / Ref:** ISS-23-24-01141, ISS-23-24-01110

**Steps to Replicate:**
- Create a Sales Order for two items [Stock Item and Non-Stock Item].
- Create a Pick List against the Sales Order, a message will be shown stating "{qty} units of Item {item-code} is not available."
- Now, check the Sales Order **% Picked**. 

**Changes:**
- Ignore mapping of Non-Stock items (except Product Bundle) in the Pick List.
- Ignore Non-Stock Items (except Product Bundle) while calculating the Sales Order **% Picked**.

**Product Bundle**
![image](https://github.com/frappe/erpnext/assets/63660334/bd7ba83c-0780-4db9-b995-af3f084f7f9b)

**Sales Order Items**
![image](https://github.com/frappe/erpnext/assets/63660334/c393dd85-0a2d-46de-b95c-60474dd0a5ad)

**Pick List [Before]**

[Screencast from 2023-06-01 17-20-24.webm](https://github.com/frappe/erpnext/assets/63660334/8c521db3-d083-4009-a395-6e06b86cd30e)

**Pick List [After]**

[Screencast from 2023-06-01 17-23-05.webm](https://github.com/frappe/erpnext/assets/63660334/8ad3964d-3cba-4b7b-8f91-baecf2adb50d)

**Sales Order % Picked [Before]**
![image](https://github.com/frappe/erpnext/assets/63660334/feae62d7-f2ae-4c60-aef8-9a21617d2370)

**Sales Order % Picked [After]**
![image](https://github.com/frappe/erpnext/assets/63660334/220a6104-baf5-4273-bbad-92f3bc2d8e64)







