### PR TITLE
fix:higher precision causes ERR to misjudge zero bal acc as non-zero

### DIFF
--- a/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py
+++ b/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py
@@ -12,6 +12,7 @@ from frappe.utils import flt, get_link_to_form
 
 import erpnext
 from erpnext.accounts.doctype.journal_entry.journal_entry import get_balance_on
+from erpnext.accounts.utils import get_currency_precision
 from erpnext.setup.utils import get_exchange_rate
 
 
@@ -169,6 +170,15 @@ class ExchangeRateRevaluation(Document):
 					.orderby(gle.account)
 					.run(as_dict=True)
 				)
+
+				# round off balance based on currency precision
+				currency_precision = get_currency_precision()
+				for acc in account_details:
+					acc.balance_in_account_currency = flt(acc.balance_in_account_currency, currency_precision)
+					acc.balance = flt(acc.balance, currency_precision)
+					acc.zero_balance = (
+						True if (acc.balance == 0 or acc.balance_in_account_currency == 0) else False
+					)
 
 		return account_details
 


### PR DESCRIPTION
| sum(debit)-sum(credit) | sum(debit_in_account_currency)-sum(credit_in_account_currency) |
|-|-|
|-102.4 |0.003324328 |

Consider the above scenario, ERR miscalculates this account as having balances in both the currencies, even when precision is set to '2', the default. 

Fix: Rounding balances using currency precision, similar to how it is done in rest of the codebase.