### PR TITLE
fix: Ignore permissions while submitting account closing balance record

### DIFF
--- a/erpnext/accounts/doctype/account_closing_balance/account_closing_balance.py
+++ b/erpnext/accounts/doctype/account_closing_balance/account_closing_balance.py
@@ -38,6 +38,7 @@ def make_closing_entries(closing_entries, voucher_name):
 				"closing_date": closing_date,
 			}
 		)
+		cle.flags.ignore_permissions = True
 		cle.submit()
 
 


### PR DESCRIPTION
Ignore permissions while submitting the account closing balance record