### PR TITLE
fix: exclude disabled customers when fetching customers on process statement of accounts

### DIFF
--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
@@ -158,7 +158,10 @@ def get_customers_based_on_territory_or_customer_group(customer_collection, coll
 	return frappe.get_list(
 		"Customer",
 		fields=["name", "customer_name", "email_id"],
-		filters=[[fields_dict[customer_collection], "IN", selected]],
+		filters=[
+			["disabled", "=", 0],
+			[fields_dict[customer_collection], "IN", selected]
+		],
 	)
 
 


### PR DESCRIPTION
Fixes #35538 

**Details:**

On a "Process Statement of Account", when setting the "Select Customers By" field to Customer Group, the "Fetch Customers" button will include Disabled customers in the Customers Child Table

![image](https://github.com/frappe/erpnext/assets/4974009/b1af1022-ff21-42c1-83c9-51fb0b495e5f)

This PR adds a filter to the `frappe.get_list()` call for the `disabled` field on `Customer`