### PR TITLE
feat: Purchase Receipt Planning

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.json
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.json
@@ -24,6 +24,7 @@
   "apply_tds",
   "tax_withholding_category",
   "is_subcontracted",
+  "has_receipt_plan",
   "supplier_warehouse",
   "amended_from",
   "accounting_dimensions_section",
@@ -131,6 +132,8 @@
   "terms_section_break",
   "tc_name",
   "terms",
+  "receipt_plan_tab",
+  "receipt_plan",
   "more_info_tab",
   "tracking_section",
   "status",
@@ -1265,13 +1268,33 @@
    "fieldtype": "Tab Break",
    "label": "Connections",
    "show_dashboard": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "default": "0",
+   "fieldname": "has_receipt_plan",
+   "fieldtype": "Check",
+   "label": "Has Receipt Plan"
+  },
+  {
+   "depends_on": "eval:doc.has_receipt_plan",
+   "fieldname": "receipt_plan_tab",
+   "fieldtype": "Tab Break",
+   "label": "Receipt Plan"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "receipt_plan",
+   "fieldtype": "Table",
+   "label": "Receipt Plan",
+   "options": "Receipt Plan"
   }
  ],
  "icon": "fa fa-file-text",
  "idx": 105,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-05-24 11:16:41.195340",
+ "modified": "2023-06-05 14:46:15.977592",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Purchase Order",

--- a/erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
+++ b/erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
@@ -86,6 +86,7 @@
   "quality_inspection",
   "material_request_item",
   "purchase_order_item",
+  "receipt_plan",
   "purchase_invoice_item",
   "purchase_receipt_item",
   "delivery_note_item",
@@ -1016,12 +1017,21 @@
    "no_copy": 1,
    "print_hide": 1,
    "read_only": 1
+  },
+  {
+   "fieldname": "receipt_plan",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Receipt Plan",
+   "no_copy": 1,
+   "print_hide": 1,
+   "search_index": 1
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-02-28 15:43:04.470104",
+ "modified": "2023-06-05 12:59:32.603377",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Purchase Receipt Item",

--- a/erpnext/stock/doctype/receipt_plan/receipt_plan.js
+++ b/erpnext/stock/doctype/receipt_plan/receipt_plan.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('Receipt Plan', {
+	// refresh: function(frm) {
+
+	// }
+});

--- a/erpnext/stock/doctype/receipt_plan/receipt_plan.json
+++ b/erpnext/stock/doctype/receipt_plan/receipt_plan.json
@@ -1,0 +1,43 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2023-06-02 17:31:07.215246",
+ "default_view": "List",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "description",
+  "receipt_portion"
+ ],
+ "fields": [
+  {
+   "allow_on_submit": 1,
+   "fieldname": "receipt_portion",
+   "fieldtype": "Percent",
+   "in_list_view": 1,
+   "label": "Receipt Portion",
+   "reqd": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "description",
+   "fieldtype": "Data",
+   "in_list_view": 1,
+   "label": "Description",
+   "reqd": 1
+  }
+ ],
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2023-08-17 14:30:09.143572",
+ "modified_by": "Administrator",
+ "module": "Stock",
+ "name": "Receipt Plan",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/erpnext/stock/doctype/receipt_plan/receipt_plan.py
+++ b/erpnext/stock/doctype/receipt_plan/receipt_plan.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+class ReceiptPlan(Document):
+	pass

--- a/erpnext/stock/doctype/receipt_plan/test_receipt_plan.py
+++ b/erpnext/stock/doctype/receipt_plan/test_receipt_plan.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestReceiptPlan(FrappeTestCase):
+	pass


### PR DESCRIPTION
This module add new feature, Purchase Receipt Planning, which normally useful if for i.e., construction where we normally pay by planned installment.

Design
* On Purchase Order, add new checkbox "Has Receipt Plan"
* If checked, user must plan receipt portions which should sum to 100%
* Validate Receipt Plan on Submit and after Submit.
* Create Purchase Receipt will now has dialog for user to choose the Installment (which has not been used).