### PR TITLE
fix: added validation for insufficient stock during stock transfer

### DIFF
--- a/erpnext/public/js/utils/serial_no_batch_selector.js
+++ b/erpnext/public/js/utils/serial_no_batch_selector.js
@@ -68,6 +68,26 @@ erpnext.SerialBatchPackageSelector = class SerialNoBatchBundleUpdate {
 			}
 		});
 
+		if (this.frm.doc.doctype === 'Stock Entry'
+			&& this.frm.doc.purpose === 'Manufacture') {
+			fields.push({
+				fieldtype: 'Column Break',
+			});
+
+			fields.push({
+				fieldtype: 'Link',
+				fieldname: 'work_order',
+				label: __('For Work Order'),
+				options: 'Work Order',
+				read_only: 1,
+				default: this.frm.doc.work_order,
+			});
+
+			fields.push({
+				fieldtype: 'Section Break',
+			});
+		}
+
 		fields.push({
 			fieldtype: 'Column Break',
 		});
@@ -98,22 +118,6 @@ erpnext.SerialBatchPackageSelector = class SerialNoBatchBundleUpdate {
 				fieldname: 'scan_batch_no',
 				label: __('Scan Batch No'),
 				onchange: () => this.update_serial_batch_no()
-			});
-		}
-
-		if (this.frm.doc.doctype === 'Stock Entry'
-			&& this.frm.doc.purpose === 'Manufacture') {
-			fields.push({
-				fieldtype: 'Column Break',
-			});
-
-			fields.push({
-				fieldtype: 'Link',
-				fieldname: 'work_order',
-				label: __('For Work Order'),
-				options: 'Work Order',
-				read_only: 1,
-				default: this.frm.doc.work_order,
 			});
 		}
 

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -2351,7 +2351,11 @@ class StockEntry(StockController):
 			return
 
 		for d in self.items:
-			if d.is_finished_item and d.item_code == self.pro_doc.production_item:
+			if (
+				d.is_finished_item
+				and d.item_code == self.pro_doc.production_item
+				and not d.serial_and_batch_bundle
+			):
 				serial_nos = self.get_available_serial_nos()
 				if serial_nos:
 					row = frappe._dict({"serial_nos": serial_nos[0 : cint(d.qty)]})


### PR DESCRIPTION
While material transfer against the work order if stock is not available then throw the error

<img width="867" alt="Screenshot 2023-06-05 at 4 54 19 PM" src="https://github.com/frappe/erpnext/assets/8780500/b16d42de-4430-4d64-8432-a46234ff3b4a">
