### PR TITLE
Fix: CSS not applied to product title

### DIFF
--- a/erpnext/e_commerce/product_ui/list.js
+++ b/erpnext/e_commerce/product_ui/list.js
@@ -78,9 +78,10 @@ erpnext.ProductList = class {
 		let title_html = `<div style="display: flex; margin-left: -15px;">`;
 		title_html += `
 			<div class="col-8" style="margin-right: -15px;">
-				<a class="" href="/${ item.route || '#' }"
-					style="color: var(--gray-800); font-weight: 500;">
+				<a href="/${ item.route || '#' }">
+					<div class="product-title">
 					${ title }
+					</div>
 				</a>
 			</div>
 		`;


### PR DESCRIPTION
The product_title css is not applied in the list view of the product UI because the class in the link is null and inline style statement is applied instead in "erpnext/e_commerce/product_ui/list.js". 

This commit removes the null css class and inline style statement, then enclosing it in a div tag with the product_title css class applied, as it is done in the grid view (see "erpnext/e_commerce/product_ui/grid.js").

Closes #35580 