### PR TITLE
chore: Default role profiles

### DIFF
--- a/erpnext/setup/install.py
+++ b/erpnext/setup/install.py
@@ -25,6 +25,7 @@ def after_install():
 	create_default_success_action()
 	create_default_energy_point_rules()
 	create_incoterms()
+	create_default_role_profiles()
 	add_company_to_session_defaults()
 	add_standard_navbar_items()
 	add_app_name()
@@ -202,3 +203,16 @@ def setup_log_settings():
 def hide_workspaces():
 	for ws in ["Integration", "Settings"]:
 		frappe.db.set_value("Workspace", ws, "public", 0)
+
+
+def create_default_role_profiles():
+	for module in ["Accounts", "Stock", "Manufacturing"]:
+		create_role_profile(module)
+
+
+def create_role_profile(module):
+	role_profile = frappe.new_doc("Role Profile")
+	role_profile.role_profile = _("{0} User").format(module)
+	role_profile.append("roles", {"role": module + " User"})
+	role_profile.append("roles", {"role": module + " Manager"})
+	role_profile.insert()


### PR DESCRIPTION
Adding some default role profiles for Accounts, Stock, and Manufacturing that can be added in the quick entry form

Right now if a user gets created from the quick-entry form no roles are assigned and they are merely made as just "Website Users". The default profiles will nudge users to add some role basic roles at least

For PR https://github.com/frappe/frappe/pull/21251