### PR TITLE
feat: group pick lists by parent warehouse

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -441,10 +441,18 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 	}
 
 	create_pick_list() {
-		frappe.model.open_mapped_doc({
+		frappe.call({
 			method: "erpnext.selling.doctype.sales_order.sales_order.create_pick_list",
-			frm: this.frm
-		})
+			args: {
+				source_name: this.frm.doc.name,
+			},
+			callback({ message }) {
+				if (!$.isArray(message)) {
+					frappe.model.sync(message);
+					frappe.set_route("Form", message.doctype, message.name);
+				}
+			}
+		});
 	}
 
 	make_work_order() {


### PR DESCRIPTION
Generate Pick List(s) based on warehouse from Sales Order.

Example Warehouse Structure:

Store 1:
   - 01 - Bin A
   - 01 - Bin B
   - 01 - Bin C
 
Store 2:
   - 02 - Bin A
   - 02 - Bin B
   - 02 - Bin C


Sales Order Example 1:
| Item Code | Qty | Warehouse |
|-----------|-----|-----------|
| Item A    | 1   | Store 1   |
| Item A    | 10  | Store 2   |
| Item B    | 1   | Store 1   |

This will generate two pick lists.
PL-1: Will contain Item A x1, Item B x1 with parent warehouse set as Store 1
PL-2: Will contain Item A x10 with parent warehouse set as Store 2

Sales Order Example 2:
| Item Code | Qty | Warehouse  |
|-----------|-----|------------|
| Item A    | 1   | 01 - Bin A |
| Item A    | 10  | 02 - Bin A |
| Item B    | 1   | 01 - Bin B |

In this case only 1 pick list will be created since all items are a leaf node. Even though one of the warehouses are from store 2 we don't know it's parent. So we will create a single pick list.

Sales Order Example 3:
| Item Code | Qty | Warehouse  |
|-----------|-----|------------|
| Item A    | 1   | 01 - Bin A |
| Item A    | 10  | Store 2    |
| Item B    | 1   | 01 - Bin B |

This example will throw an error. In the event of both group and leaf warehouse nodes. We don't know how to proceed in this case.