### PR TITLE
fix: set parent_project when creating a new timesheet

### DIFF
--- a/erpnext/projects/doctype/task/task.py
+++ b/erpnext/projects/doctype/task/task.py
@@ -304,6 +304,7 @@ def set_tasks_as_overdue():
 @frappe.whitelist()
 def make_timesheet(source_name, target_doc=None, ignore_permissions=False):
 	def set_missing_values(source, target):
+		target.parent_project = source.project
 		target.append(
 			"time_logs",
 			{


### PR DESCRIPTION
fix "When Creating a new Timesheet from an Task - parent_project is empty" #35578


closes https://github.com/frappe/erpnext/issues/35578