### PR TITLE
fix: reset entries qty to `1` for serial item

### DIFF
--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.js
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.js
@@ -127,6 +127,14 @@ frappe.ui.form.on('Serial and Batch Bundle', {
 	},
 
 	toggle_fields(frm) {
+		if (frm.doc.has_serial_no) {
+			frm.doc.entries.forEach(row => {
+				if (Math.abs(row.qty) !== 1) {
+					frappe.model.set_value(row.doctype, row.name, "qty", 1);
+				}
+			})
+		}
+
 		frm.fields_dict.entries.grid.update_docfield_property(
 			'serial_no', 'read_only', !frm.doc.has_serial_no
 		);

--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.js
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.js
@@ -134,6 +134,10 @@ frappe.ui.form.on('Serial and Batch Bundle', {
 		frm.fields_dict.entries.grid.update_docfield_property(
 			'batch_no', 'read_only', !frm.doc.has_batch_no
 		);
+
+		frm.fields_dict.entries.grid.update_docfield_property(
+			'qty', 'read_only', frm.doc.has_serial_no
+		);
 	},
 
 	set_queries(frm) {

--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.js
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.js
@@ -210,9 +210,9 @@ frappe.ui.form.on('Serial and Batch Bundle', {
 
 
 frappe.ui.form.on("Serial and Batch Entry", {
-	ledgers_add(frm, cdt, cdn) {
+	entries_add(frm, cdt, cdn) {
 		if (frm.doc.warehouse) {
-			locals[cdt][cdn].warehouse = frm.doc.warehouse;
+			frappe.model.set_value(cdt, cdn, 'warehouse', frm.doc.warehouse);
 		}
 	},
 })

--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -133,7 +133,7 @@ class SerialandBatchBundle(Document):
 	def calculate_total_qty(self, save=True):
 		self.total_qty = 0.0
 		for d in self.entries:
-			d.qty = abs(d.qty) if d.qty else 0
+			d.qty = 1 if self.has_serial_no and abs(d.qty) > 1 else abs(d.qty) if d.qty else 0
 			d.stock_value_difference = abs(d.stock_value_difference) if d.stock_value_difference else 0
 			if self.type_of_transaction == "Outward":
 				d.qty *= -1


### PR DESCRIPTION
**Issue:** There is a 1:1 mapping between Serial No and Serial and Batch Entry, the system should validate the same.

**Steps to Replicate:** 
- Create a Serial and Batch Bundle for Serial Item, select Serial No and set the Qty > 1.
- Create a Delivery Note, select that bundle and check the Stock Ledger after submitting. 

**Serial and Batch Bundle**

![image](https://github.com/frappe/erpnext/assets/63660334/395f965a-8e6a-4ff0-bad4-17349e8d3f40)

**Delivery Note**

![image](https://github.com/frappe/erpnext/assets/63660334/4014c205-aa15-4bef-8bb9-420b64f12220)

**Stock Ledger Entry**

![image](https://github.com/frappe/erpnext/assets/63660334/d2467ba5-267f-4d1e-8f58-418fb84b39c0)

**Changes:**
- Reset the Qty to `1` and make the field read-only for serial item
- Set child table row warehouse as parent warehouse
