### PR TITLE
fix: allow higher debit-credit diff tolerance in Exchange Rate Revaluation

### DIFF
--- a/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.js
+++ b/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.js
@@ -35,6 +35,21 @@ frappe.ui.form.on('Exchange Rate Revaluation', {
 		}
 	},
 
+	validate_rounding_loss: function(frm) {
+		allowance = frm.doc.rounding_loss_allowance;
+		if (!(allowance > 0 && allowance < 1)) {
+			frappe.throw(__("Rounding Loss Allowance should be between 0 and 1"));
+		}
+	},
+
+	rounding_loss_allowance: function(frm) {
+		frm.events.validate_rounding_loss(frm);
+	},
+
+	validate: function(frm) {
+		frm.events.validate_rounding_loss(frm);
+	},
+
 	get_entries: function(frm, account) {
 		frappe.call({
 			method: "get_accounts_data",
@@ -126,7 +141,8 @@ var get_account_details = function(frm, cdt, cdn) {
 			company: frm.doc.company,
 			posting_date: frm.doc.posting_date,
 			party_type: row.party_type,
-			party: row.party
+			party: row.party,
+			rounding_loss_allowance: frm.doc.rounding_loss_allowance
 		},
 		callback: function(r){
 			$.extend(row, r.message);

--- a/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.json
+++ b/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.json
@@ -8,6 +8,7 @@
  "engine": "InnoDB",
  "field_order": [
   "posting_date",
+  "rounding_loss_allowance",
   "column_break_2",
   "company",
   "section_break_4",
@@ -96,11 +97,18 @@
   {
    "fieldname": "column_break_10",
    "fieldtype": "Column Break"
+  },
+  {
+   "default": "0.05",
+   "description": "Only values between 0 and 1 are allowed. \nEx: If allowance is set at 0.07, accounts that have balance of 0.07 in either of the currencies will be considered as zero balance account",
+   "fieldname": "rounding_loss_allowance",
+   "fieldtype": "Float",
+   "label": "Rounding Loss Allowance"
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2022-12-29 19:38:24.416529",
+ "modified": "2023-06-12 21:02:09.818208",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Exchange Rate Revaluation",


### PR DESCRIPTION
Exchange Rate Revaluation should have default (debit-credit) difference allowance of 0.05 on a 2 digit precision. A new field "Rounding Loss Allowance" is added to set the allowance between 0 and 1.
<img width="1191" alt="Screenshot 2023-06-09 at 12 44 41 PM" src="https://github.com/frappe/erpnext/assets/3272205/6c4c5fbe-e16b-48a2-9e47-ae91346c5813">


Higher Allowance enables handling above cases where the differnece is not below standard allowance and not high as well.
<img width="1408" alt="Screenshot 2023-06-12 at 9 03 17 PM" src="https://github.com/frappe/erpnext/assets/3272205/269fed6f-ee53-4a7b-992d-519a47a6e16a">

