### PR TITLE
fix: CSS not applied to product title (backport #35582)

### DIFF
--- a/erpnext/e_commerce/product_ui/list.js
+++ b/erpnext/e_commerce/product_ui/list.js
@@ -78,9 +78,10 @@ erpnext.ProductList = class {
 		let title_html = `<div style="display: flex; margin-left: -15px;">`;
 		title_html += `
 			<div class="col-8" style="margin-right: -15px;">
-				<a class="" href="/${ item.route || '#' }"
-					style="color: var(--gray-800); font-weight: 500;">
+				<a href="/${ item.route || '#' }">
+					<div class="product-title">
 					${ title }
+					</div>
 				</a>
 			</div>
 		`;


### PR DESCRIPTION
This is a backport to version-13-hotfix of #35582 

In an erpnext website, the /all-products route shows website items that have been published to the web site.

In the list view (erpnext/e_commerce/product_ui/list.js), the css class is null for the product title. Instead, inline style statements have been added in that can not be modified by overriding CSS.

This fix uses a similar approach to that which is taken in the grid view (erpnext/e_commerce/product_ui/grid.js). It removes the null CSS parameter in the product title link as well as the inline style statement. Then, as in the grid view, the product title is wrapped in a div tag with the product_title CSS class.

This makes it possible to style the product title as desired with a CSS override.