### PR TITLE
fix: don't set default payment amount in case of invoice return

### DIFF
--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -805,11 +805,13 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 			);
 		}
 
-		this.frm.doc.payments.find(pay => {
-			if (pay.default) {
-				pay.amount = total_amount_to_pay;
-			}
-		});
+		if(!this.frm.doc.is_return){
+			this.frm.doc.payments.find(payment => {
+				if (payment.default) {
+					payment.amount = total_amount_to_pay;
+				}
+			});
+		}
 
 		this.frm.refresh_fields();
 	}


### PR DESCRIPTION
This is the payment methods table of a POS profile:
![image](https://github.com/frappe/erpnext/assets/2698932/927d311b-2f92-440f-963d-ed2c89b6767d)

So, when a POS invoice is created, the default method of cash is chosen and the respective amount is set. One user wanted to go with another method, such as wire transfer, in which case, the payments table of the invoice looks like:
![image](https://github.com/frappe/erpnext/assets/2698932/0962565b-8a61-4fe4-9a0c-c8e1b61f54fe)

Now the issue is that when a return for that POS invoice was created, the default method of cash is chosen along with the other method chosen for the original invoice:
![image](https://github.com/frappe/erpnext/assets/2698932/4b326aa7-2583-427b-a4e9-db6f60663424)
