### PR TITLE
fix(DX): Check Frappe and ERPNext major versions

### DIFF
--- a/erpnext/__init__.py
+++ b/erpnext/__init__.py
@@ -3,7 +3,7 @@ import inspect
 
 import frappe
 
-__version__ = "14.0.0-dev"
+__version__ = "15.0.0-dev"
 
 
 def get_default_company(user=None):

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -39,7 +39,10 @@ setup_wizard_requires = "assets/erpnext/js/setup_wizard.js"
 setup_wizard_stages = "erpnext.setup.setup_wizard.setup_wizard.get_setup_stages"
 setup_wizard_test = "erpnext.setup.setup_wizard.test_setup_wizard.run_setup_wizard_test"
 
-before_install = "erpnext.setup.install.check_setup_wizard_not_completed"
+before_install = [
+	"erpnext.setup.install.check_setup_wizard_not_completed",
+	"erpnext.setup.install.check_frappe_version",
+]
 after_install = "erpnext.setup.install.after_install"
 
 boot_session = "erpnext.startup.boot.boot_session"

--- a/erpnext/setup/install.py
+++ b/erpnext/setup/install.py
@@ -2,12 +2,14 @@
 # License: GNU General Public License v3. See license.txt
 
 
+import click
 import frappe
 from frappe import _
 from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
 from frappe.desk.page.setup_wizard.setup_wizard import add_all_roles_to
 from frappe.utils import cint
 
+import erpnext
 from erpnext.setup.default_energy_point_rules import get_default_energy_point_rules
 from erpnext.setup.doctype.incoterm.incoterm import create_incoterms
 
@@ -39,6 +41,25 @@ def check_setup_wizard_not_completed():
 		message = """ERPNext can only be installed on a fresh site where the setup wizard is not completed.
 You can reinstall this site (after saving your data) using: bench --site [sitename] reinstall"""
 		frappe.throw(message)  # nosemgrep
+
+
+def check_frappe_version():
+	def major_version(v: str) -> str:
+		return v.split(".")[0]
+
+	frappe_version = major_version(frappe.__version__)
+	erpnext_version = major_version(erpnext.__version__)
+
+	if frappe_version == erpnext_version:
+		return
+
+	click.secho(
+		f"You're attempting to install ERPNext version {erpnext_version} with Frappe version {frappe_version}. "
+		"This is not supported and will result in broken install. Switch to correct branch before installing.",
+		fg="red",
+	)
+
+	raise SystemExit(1)
 
 
 def set_single_defaults():


### PR DESCRIPTION
`bench get-app` is kinda confusing for new users so they end up setting up bench with different versions of frappe/erpnext... which doesn't work to say the least. 