### PR TITLE
fix: test case PyPDF2

### DIFF
--- a/erpnext/regional/report/irs_1099/irs_1099.py
+++ b/erpnext/regional/report/irs_1099/irs_1099.py
@@ -10,7 +10,7 @@ from frappe.utils.data import fmt_money
 from frappe.utils.jinja import render_template
 from frappe.utils.pdf import get_pdf
 from frappe.utils.print_format import read_multi_pdf
-from PyPDF2 import PdfWriter
+from pypdf import PdfWriter
 
 from erpnext.accounts.utils import get_fiscal_year
 


### PR DESCRIPTION
**Issue**

```
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
      f = <built-in function exec>
      args = (<code object <module> at 0x7f4010751240, file "/home/runner/frappe-bench/apps/erpnext/erpnext/regional/united_states/test_united_states.py", line 1>, {'__name__': 'erpnext.regional.united_states.test_united_states', '__doc__': None, '__package__': 'erpnext.regional.united_states', '__loader__': <_frozen_importlib_external.SourceFileLoader object at 0x7f4011d33d50>, '__spec__': ModuleSpec(name='erpnext.regional.united_states.test_united_states', loader=<_frozen_importlib_external.SourceFileLoader object at 0x7f4011d33d50>, origin='/home/runner/frappe-bench/apps/erpnext/erpnext/regional/united_states/test_united_states.py'), '__file__': '/home/runner/frappe-bench/apps/erpnext/erpnext/regional/united_states/test_united_states.py', '__cached__': '/home/runner/frappe-bench/apps/erpnext/erpnext/regional/united_states/__pycache__/test_united_states.cpython-311.pyc', '__builtins__': {'__name__': 'builtins', '__doc__': "Built-in functions, exceptions, and other objects.\n\nNoteworthy: None is ...
      kwds = {}
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/regional/united_states/test_united_states.py", line 8, in <module>
    from erpnext.regional.report.irs_1099.irs_1099 import execute as execute_1099_report
      ...skipped... 10 vars
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/regional/report/irs_1099/irs_1099.py", line 13, in <module>
    from PyPDF2 import PdfWriter
      ...skipped... 17 vars
builtins.ModuleNotFoundError: No module named 'PyPDF2'
```

Replaced pypdf2 to pypdf

Ref https://github.com/frappe/frappe/pull/21232