### PR TITLE
refactor: Use `db.set_single_value`

### DIFF
--- a/erpnext/accounts/doctype/fiscal_year/fiscal_year.py
+++ b/erpnext/accounts/doctype/fiscal_year/fiscal_year.py
@@ -12,7 +12,7 @@ from frappe.utils import add_days, add_years, cstr, getdate
 class FiscalYear(Document):
 	@frappe.whitelist()
 	def set_as_default(self):
-		frappe.db.set_value("Global Defaults", None, "current_fiscal_year", self.name)
+		frappe.db.set_single_value("Global Defaults", "current_fiscal_year", self.name)
 		global_defaults = frappe.get_doc("Global Defaults")
 		global_defaults.check_permission("write")
 		global_defaults.on_update()

--- a/erpnext/accounts/doctype/journal_entry/test_journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/test_journal_entry.py
@@ -105,8 +105,8 @@ class TestJournalEntry(unittest.TestCase):
 
 		elif test_voucher.doctype in ["Sales Order", "Purchase Order"]:
 			# if test_voucher is a Sales Order/Purchase Order, test error on cancellation of test_voucher
-			frappe.db.set_value(
-				"Accounts Settings", "Accounts Settings", "unlink_advance_payment_on_cancelation_of_order", 0
+			frappe.db.set_single_value(
+				"Accounts Settings", "unlink_advance_payment_on_cancelation_of_order", 0
 			)
 			submitted_voucher = frappe.get_doc(test_voucher.doctype, test_voucher.name)
 			self.assertRaises(frappe.LinkExistsError, submitted_voucher.cancel)

--- a/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
@@ -31,7 +31,7 @@ class TestPOSInvoice(unittest.TestCase):
 			frappe.set_user("Administrator")
 
 		if frappe.db.get_single_value("Selling Settings", "validate_selling_price"):
-			frappe.db.set_value("Selling Settings", None, "validate_selling_price", 0)
+			frappe.db.set_single_value("Selling Settings", "validate_selling_price", 0)
 
 	def test_timestamp_change(self):
 		w = create_pos_invoice(do_not_save=1)
@@ -722,7 +722,7 @@ class TestPOSInvoice(unittest.TestCase):
 		)
 
 		if not frappe.db.get_single_value("Selling Settings", "validate_selling_price"):
-			frappe.db.set_value("Selling Settings", "Selling Settings", "validate_selling_price", 1)
+			frappe.db.set_single_value("Selling Settings", "validate_selling_price", 1)
 
 		item = "Test Selling Price Validation"
 		make_item(item, {"is_stock_item": 1})

--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -42,7 +42,7 @@ class TestPurchaseInvoice(unittest.TestCase, StockTestMixin):
 	@classmethod
 	def setUpClass(self):
 		unlink_payment_on_cancel_of_invoice()
-		frappe.db.set_value("Buying Settings", None, "allow_multiple_items", 1)
+		frappe.db.set_single_value("Buying Settings", "allow_multiple_items", 1)
 
 	@classmethod
 	def tearDownClass(self):
@@ -1232,9 +1232,7 @@ class TestPurchaseInvoice(unittest.TestCase, StockTestMixin):
 			"Accounts Settings", "Accounts Settings", "unlink_payment_on_cancel_of_invoice"
 		)
 
-		frappe.db.set_value(
-			"Accounts Settings", "Accounts Settings", "unlink_payment_on_cancel_of_invoice", 1
-		)
+		frappe.db.set_single_value("Accounts Settings", "unlink_payment_on_cancel_of_invoice", 1)
 
 		original_account = frappe.db.get_value("Company", "_Test Company", "exchange_gain_loss_account")
 		frappe.db.set_value(
@@ -1369,8 +1367,8 @@ class TestPurchaseInvoice(unittest.TestCase, StockTestMixin):
 		pay.reload()
 		pay.cancel()
 
-		frappe.db.set_value(
-			"Accounts Settings", "Accounts Settings", "unlink_payment_on_cancel_of_invoice", unlink_enabled
+		frappe.db.set_single_value(
+			"Accounts Settings", "unlink_payment_on_cancel_of_invoice", unlink_enabled
 		)
 		frappe.db.set_value("Company", "_Test Company", "exchange_gain_loss_account", original_account)
 

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -1063,7 +1063,7 @@ class TestSalesInvoice(unittest.TestCase):
 		self.assertEqual(pos.write_off_amount, 10)
 
 	def test_pos_with_no_gl_entry_for_change_amount(self):
-		frappe.db.set_value("Accounts Settings", None, "post_change_gl_entries", 0)
+		frappe.db.set_single_value("Accounts Settings", "post_change_gl_entries", 0)
 
 		make_pos_profile(
 			company="_Test Company with perpetual inventory",
@@ -1113,7 +1113,7 @@ class TestSalesInvoice(unittest.TestCase):
 
 		self.validate_pos_gl_entry(pos, pos, 60, validate_without_change_gle=True)
 
-		frappe.db.set_value("Accounts Settings", None, "post_change_gl_entries", 1)
+		frappe.db.set_single_value("Accounts Settings", "post_change_gl_entries", 1)
 
 	def validate_pos_gl_entry(self, si, pos, cash_amount, validate_without_change_gle=False):
 		if validate_without_change_gle:
@@ -2452,7 +2452,7 @@ class TestSalesInvoice(unittest.TestCase):
 		"Check mapping (expense account) of inter company SI to PI in absence of default warehouse."
 		# setup
 		old_negative_stock = frappe.db.get_single_value("Stock Settings", "allow_negative_stock")
-		frappe.db.set_value("Stock Settings", None, "allow_negative_stock", 1)
+		frappe.db.set_single_value("Stock Settings", "allow_negative_stock", 1)
 
 		old_perpetual_inventory = erpnext.is_perpetual_inventory_enabled("_Test Company 1")
 		frappe.local.enable_perpetual_inventory["_Test Company 1"] = 1
@@ -2506,7 +2506,7 @@ class TestSalesInvoice(unittest.TestCase):
 
 		# tear down
 		frappe.local.enable_perpetual_inventory["_Test Company 1"] = old_perpetual_inventory
-		frappe.db.set_value("Stock Settings", None, "allow_negative_stock", old_negative_stock)
+		frappe.db.set_single_value("Stock Settings", "allow_negative_stock", old_negative_stock)
 
 	def test_sle_for_target_warehouse(self):
 		se = make_stock_entry(
@@ -2898,7 +2898,7 @@ class TestSalesInvoice(unittest.TestCase):
 		party_link = create_party_link("Supplier", supplier, customer)
 
 		# enable common party accounting
-		frappe.db.set_value("Accounts Settings", None, "enable_common_party_accounting", 1)
+		frappe.db.set_single_value("Accounts Settings", "enable_common_party_accounting", 1)
 
 		# create a sales invoice
 		si = create_sales_invoice(customer=customer, parent_cost_center="_Test Cost Center - _TC")
@@ -2925,7 +2925,7 @@ class TestSalesInvoice(unittest.TestCase):
 		self.assertEqual(jv[0], si.grand_total)
 
 		party_link.delete()
-		frappe.db.set_value("Accounts Settings", None, "enable_common_party_accounting", 0)
+		frappe.db.set_single_value("Accounts Settings", "enable_common_party_accounting", 0)
 
 	def test_payment_statuses(self):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import get_payment_entry
@@ -3045,7 +3045,7 @@ class TestSalesInvoice(unittest.TestCase):
 			self.assertRaises(frappe.ValidationError, si.save)
 
 	def test_sales_invoice_submission_post_account_freezing_date(self):
-		frappe.db.set_value("Accounts Settings", None, "acc_frozen_upto", add_days(getdate(), 1))
+		frappe.db.set_single_value("Accounts Settings", "acc_frozen_upto", add_days(getdate(), 1))
 		si = create_sales_invoice(do_not_save=True)
 		si.posting_date = add_days(getdate(), 1)
 		si.save()
@@ -3054,7 +3054,7 @@ class TestSalesInvoice(unittest.TestCase):
 		si.posting_date = getdate()
 		si.submit()
 
-		frappe.db.set_value("Accounts Settings", None, "acc_frozen_upto", None)
+		frappe.db.set_single_value("Accounts Settings", "acc_frozen_upto", None)
 
 	def test_over_billing_case_against_delivery_note(self):
 		"""
@@ -3066,7 +3066,7 @@ class TestSalesInvoice(unittest.TestCase):
 		over_billing_allowance = frappe.db.get_single_value(
 			"Accounts Settings", "over_billing_allowance"
 		)
-		frappe.db.set_value("Accounts Settings", None, "over_billing_allowance", 0)
+		frappe.db.set_single_value("Accounts Settings", "over_billing_allowance", 0)
 
 		dn = create_delivery_note()
 		dn.submit()
@@ -3082,7 +3082,7 @@ class TestSalesInvoice(unittest.TestCase):
 
 		self.assertTrue("cannot overbill" in str(err.exception).lower())
 
-		frappe.db.set_value("Accounts Settings", None, "over_billing_allowance", over_billing_allowance)
+		frappe.db.set_single_value("Accounts Settings", "over_billing_allowance", over_billing_allowance)
 
 	def test_multi_currency_deferred_revenue_via_journal_entry(self):
 		deferred_account = create_account(
@@ -3121,7 +3121,7 @@ class TestSalesInvoice(unittest.TestCase):
 		si.save()
 		si.submit()
 
-		frappe.db.set_value("Accounts Settings", None, "acc_frozen_upto", getdate("2019-01-31"))
+		frappe.db.set_single_value("Accounts Settings", "acc_frozen_upto", getdate("2019-01-31"))
 
 		pda1 = frappe.get_doc(
 			dict(
@@ -3166,7 +3166,7 @@ class TestSalesInvoice(unittest.TestCase):
 		acc_settings.submit_journal_entries = 0
 		acc_settings.save()
 
-		frappe.db.set_value("Accounts Settings", None, "acc_frozen_upto", None)
+		frappe.db.set_single_value("Accounts Settings", "acc_frozen_upto", None)
 
 	def test_standalone_serial_no_return(self):
 		si = create_sales_invoice(
@@ -3216,9 +3216,7 @@ class TestSalesInvoice(unittest.TestCase):
 			"Accounts Settings", "Accounts Settings", "unlink_payment_on_cancel_of_invoice"
 		)
 
-		frappe.db.set_value(
-			"Accounts Settings", "Accounts Settings", "unlink_payment_on_cancel_of_invoice", 1
-		)
+		frappe.db.set_single_value("Accounts Settings", "unlink_payment_on_cancel_of_invoice", 1)
 
 		jv = make_journal_entry("_Test Receivable USD - _TC", "_Test Bank - _TC", -7000, save=False)
 
@@ -3261,8 +3259,8 @@ class TestSalesInvoice(unittest.TestCase):
 
 		check_gl_entries(self, si.name, expected_gle, nowdate())
 
-		frappe.db.set_value(
-			"Accounts Settings", "Accounts Settings", "unlink_payment_on_cancel_of_invoice", unlink_enabled
+		frappe.db.set_single_value(
+			"Accounts Settings", "unlink_payment_on_cancel_of_invoice", unlink_enabled
 		)
 
 	def test_batch_expiry_for_sales_invoice_return(self):

--- a/erpnext/accounts/doctype/tax_rule/test_tax_rule.py
+++ b/erpnext/accounts/doctype/tax_rule/test_tax_rule.py
@@ -15,7 +15,7 @@ test_records = frappe.get_test_records("Tax Rule")
 class TestTaxRule(unittest.TestCase):
 	@classmethod
 	def setUpClass(cls):
-		frappe.db.set_value("Shopping Cart Settings", None, "enabled", 0)
+		frappe.db.set_single_value("Shopping Cart Settings", "enabled", 0)
 
 	@classmethod
 	def tearDownClass(cls):

--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -1804,7 +1804,7 @@ def set_depreciation_settings_in_company(company=None):
 	company.save()
 
 	# Enable booking asset depreciation entry automatically
-	frappe.db.set_value("Accounts Settings", None, "book_asset_depreciation_entry_automatically", 1)
+	frappe.db.set_single_value("Accounts Settings", "book_asset_depreciation_entry_automatically", 1)
 
 
 def enable_cwip_accounting(asset_category, enable=1):

--- a/erpnext/assets/doctype/asset_maintenance/test_asset_maintenance.py
+++ b/erpnext/assets/doctype/asset_maintenance/test_asset_maintenance.py
@@ -182,4 +182,4 @@ def set_depreciation_settings_in_company():
 	company.save()
 
 	# Enable booking asset depreciation entry automatically
-	frappe.db.set_value("Accounts Settings", None, "book_asset_depreciation_entry_automatically", 1)
+	frappe.db.set_single_value("Accounts Settings", "book_asset_depreciation_entry_automatically", 1)

--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -92,7 +92,7 @@ class TestPurchaseOrder(FrappeTestCase):
 
 		frappe.db.set_value("Item", "_Test Item", "over_delivery_receipt_allowance", 0)
 		frappe.db.set_value("Item", "_Test Item", "over_billing_allowance", 0)
-		frappe.db.set_value("Accounts Settings", None, "over_billing_allowance", 0)
+		frappe.db.set_single_value("Accounts Settings", "over_billing_allowance", 0)
 
 	def test_update_remove_child_linked_to_mr(self):
 		"""Test impact on linked PO and MR on deleting/updating row."""
@@ -581,7 +581,7 @@ class TestPurchaseOrder(FrappeTestCase):
 		)
 
 	def test_group_same_items(self):
-		frappe.db.set_value("Buying Settings", None, "allow_multiple_items", 1)
+		frappe.db.set_single_value("Buying Settings", "allow_multiple_items", 1)
 		frappe.get_doc(
 			{
 				"doctype": "Purchase Order",
@@ -836,8 +836,8 @@ class TestPurchaseOrder(FrappeTestCase):
 		)
 		from erpnext.stock.doctype.delivery_note.delivery_note import make_inter_company_purchase_receipt
 
-		frappe.db.set_value("Selling Settings", None, "maintain_same_sales_rate", 1)
-		frappe.db.set_value("Buying Settings", None, "maintain_same_rate", 1)
+		frappe.db.set_single_value("Selling Settings", "maintain_same_sales_rate", 1)
+		frappe.db.set_single_value("Buying Settings", "maintain_same_rate", 1)
 
 		prepare_data_for_internal_transfer()
 		supplier = "_Test Internal Supplier 2"

--- a/erpnext/buying/doctype/supplier/test_supplier.py
+++ b/erpnext/buying/doctype/supplier/test_supplier.py
@@ -156,7 +156,7 @@ class TestSupplier(FrappeTestCase):
 	def test_serach_fields_for_supplier(self):
 		from erpnext.controllers.queries import supplier_query
 
-		frappe.db.set_value("Buying Settings", None, "supp_master_name", "Naming Series")
+		frappe.db.set_single_value("Buying Settings", "supp_master_name", "Naming Series")
 
 		supplier_name = create_supplier(supplier_name="Test Supplier 1").name
 
@@ -189,7 +189,7 @@ class TestSupplier(FrappeTestCase):
 		self.assertEqual(data[0].supplier_type, "Company")
 		self.assertTrue("supplier_type" in data[0])
 
-		frappe.db.set_value("Buying Settings", None, "supp_master_name", "Supplier Name")
+		frappe.db.set_single_value("Buying Settings", "supp_master_name", "Supplier Name")
 
 
 def create_supplier(**args):

--- a/erpnext/controllers/tests/test_subcontracting_controller.py
+++ b/erpnext/controllers/tests/test_subcontracting_controller.py
@@ -1074,8 +1074,8 @@ def make_bom_for_subcontracted_items():
 
 
 def set_backflush_based_on(based_on):
-	frappe.db.set_value(
-		"Buying Settings", None, "backflush_raw_materials_of_subcontract_based_on", based_on
+	frappe.db.set_single_value(
+		"Buying Settings", "backflush_raw_materials_of_subcontract_based_on", based_on
 	)
 
 

--- a/erpnext/crm/doctype/opportunity/test_opportunity.py
+++ b/erpnext/crm/doctype/opportunity/test_opportunity.py
@@ -53,9 +53,7 @@ class TestOpportunity(unittest.TestCase):
 		self.assertEqual(opportunity_doc.total, 2200)
 
 	def test_carry_forward_of_email_and_comments(self):
-		frappe.db.set_value(
-			"CRM Settings", "CRM Settings", "carry_forward_communication_and_comments", 1
-		)
+		frappe.db.set_single_value("CRM Settings", "carry_forward_communication_and_comments", 1)
 		lead_doc = make_lead()
 		lead_doc.add_comment("Comment", text="Test Comment 1")
 		lead_doc.add_comment("Comment", text="Test Comment 2")

--- a/erpnext/e_commerce/shopping_cart/test_shopping_cart.py
+++ b/erpnext/e_commerce/shopping_cart/test_shopping_cart.py
@@ -205,7 +205,7 @@ class TestShoppingCart(unittest.TestCase):
 
 		self.assertEqual(quote_doctstatus, 0)
 
-		frappe.db.set_value("E Commerce Settings", None, "save_quotations_as_draft", 0)
+		frappe.db.set_single_value("E Commerce Settings", "save_quotations_as_draft", 0)
 		frappe.local.shopping_cart_settings = None
 		update_cart("_Test Item", 1)
 		quote_name = request_for_quotation()  # Request for Quote

--- a/erpnext/erpnext_integrations/doctype/plaid_settings/test_plaid_settings.py
+++ b/erpnext/erpnext_integrations/doctype/plaid_settings/test_plaid_settings.py
@@ -32,7 +32,7 @@ class TestPlaidSettings(unittest.TestCase):
 				frappe.delete_doc(doctype, d.name, force=True)
 
 	def test_plaid_disabled(self):
-		frappe.db.set_value("Plaid Settings", None, "enabled", 0)
+		frappe.db.set_single_value("Plaid Settings", "enabled", 0)
 		self.assertTrue(get_plaid_configuration() == "disabled")
 
 	def test_add_account_type(self):

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -503,10 +503,8 @@ class TestWorkOrder(FrappeTestCase):
 			stock_entry.cancel()
 
 	def test_capcity_planning(self):
-		frappe.db.set_value(
-			"Manufacturing Settings",
-			None,
-			{"disable_capacity_planning": 0, "capacity_planning_for_days": 1},
+		frappe.db.set_single_value(
+			"Manufacturing Settings", {"disable_capacity_planning": 0, "capacity_planning_for_days": 1}
 		)
 
 		data = frappe.get_cached_value(
@@ -529,7 +527,7 @@ class TestWorkOrder(FrappeTestCase):
 
 			self.assertRaises(CapacityError, work_order1.submit)
 
-			frappe.db.set_value("Manufacturing Settings", None, {"capacity_planning_for_days": 30})
+			frappe.db.set_single_value("Manufacturing Settings", {"capacity_planning_for_days": 30})
 
 			work_order1.reload()
 			work_order1.submit()
@@ -539,7 +537,7 @@ class TestWorkOrder(FrappeTestCase):
 			work_order.cancel()
 
 	def test_work_order_with_non_transfer_item(self):
-		frappe.db.set_value("Manufacturing Settings", None, "backflush_raw_materials_based_on", "BOM")
+		frappe.db.set_single_value("Manufacturing Settings", "backflush_raw_materials_based_on", "BOM")
 
 		items = {"Finished Good Transfer Item": 1, "_Test FG Item": 1, "_Test FG Item 1": 0}
 		for item, allow_transfer in items.items():
@@ -619,7 +617,7 @@ class TestWorkOrder(FrappeTestCase):
 		fg_item = "Test Batch Size Item For BOM 3"
 		rm1 = "Test Batch Size Item RM 1 For BOM 3"
 
-		frappe.db.set_value("Manufacturing Settings", None, "make_serial_no_batch_from_work_order", 0)
+		frappe.db.set_single_value("Manufacturing Settings", "make_serial_no_batch_from_work_order", 0)
 		for item in ["Test Batch Size Item For BOM 3", "Test Batch Size Item RM 1 For BOM 3"]:
 			item_args = {"include_item_in_manufacturing": 1, "is_stock_item": 1}
 
@@ -655,7 +653,7 @@ class TestWorkOrder(FrappeTestCase):
 		work_order = make_wo_order_test_record(
 			item=fg_item, skip_transfer=True, planned_start_date=now(), qty=1
 		)
-		frappe.db.set_value("Manufacturing Settings", None, "make_serial_no_batch_from_work_order", 1)
+		frappe.db.set_single_value("Manufacturing Settings", "make_serial_no_batch_from_work_order", 1)
 		ste1 = frappe.get_doc(make_stock_entry(work_order.name, "Manufacture", 1))
 		for row in ste1.get("items"):
 			if row.is_finished_item:
@@ -699,10 +697,10 @@ class TestWorkOrder(FrappeTestCase):
 
 		self.assertEqual(sorted(remaining_batches), sorted(batches))
 
-		frappe.db.set_value("Manufacturing Settings", None, "make_serial_no_batch_from_work_order", 0)
+		frappe.db.set_single_value("Manufacturing Settings", "make_serial_no_batch_from_work_order", 0)
 
 	def test_partial_material_consumption(self):
-		frappe.db.set_value("Manufacturing Settings", None, "material_consumption", 1)
+		frappe.db.set_single_value("Manufacturing Settings", "material_consumption", 1)
 		wo_order = make_wo_order_test_record(planned_start_date=now(), qty=4)
 
 		ste_cancel_list = []
@@ -736,13 +734,12 @@ class TestWorkOrder(FrappeTestCase):
 		for ste_doc in ste_cancel_list:
 			ste_doc.cancel()
 
-		frappe.db.set_value("Manufacturing Settings", None, "material_consumption", 0)
+		frappe.db.set_single_value("Manufacturing Settings", "material_consumption", 0)
 
 	def test_extra_material_transfer(self):
-		frappe.db.set_value("Manufacturing Settings", None, "material_consumption", 0)
-		frappe.db.set_value(
+		frappe.db.set_single_value("Manufacturing Settings", "material_consumption", 0)
+		frappe.db.set_single_value(
 			"Manufacturing Settings",
-			None,
 			"backflush_raw_materials_based_on",
 			"Material Transferred for Manufacture",
 		)
@@ -787,7 +784,7 @@ class TestWorkOrder(FrappeTestCase):
 		for ste_doc in ste_cancel_list:
 			ste_doc.cancel()
 
-		frappe.db.set_value("Manufacturing Settings", None, "backflush_raw_materials_based_on", "BOM")
+		frappe.db.set_single_value("Manufacturing Settings", "backflush_raw_materials_based_on", "BOM")
 
 	def test_make_stock_entry_for_customer_provided_item(self):
 		finished_item = "Test Item for Make Stock Entry 1"
@@ -1087,9 +1084,8 @@ class TestWorkOrder(FrappeTestCase):
 	def test_partial_manufacture_entries(self):
 		cancel_stock_entry = []
 
-		frappe.db.set_value(
+		frappe.db.set_single_value(
 			"Manufacturing Settings",
-			None,
 			"backflush_raw_materials_based_on",
 			"Material Transferred for Manufacture",
 		)
@@ -1139,7 +1135,7 @@ class TestWorkOrder(FrappeTestCase):
 			doc = frappe.get_doc("Stock Entry", ste)
 			doc.cancel()
 
-		frappe.db.set_value("Manufacturing Settings", None, "backflush_raw_materials_based_on", "BOM")
+		frappe.db.set_single_value("Manufacturing Settings", "backflush_raw_materials_based_on", "BOM")
 
 	@change_settings("Manufacturing Settings", {"make_serial_no_batch_from_work_order": 1})
 	def test_auto_batch_creation(self):
@@ -1283,9 +1279,8 @@ class TestWorkOrder(FrappeTestCase):
 		self.assertEqual(work_order.required_items[1].transferred_qty, 2)
 
 	def test_backflushed_batch_raw_materials_based_on_transferred(self):
-		frappe.db.set_value(
+		frappe.db.set_single_value(
 			"Manufacturing Settings",
-			None,
 			"backflush_raw_materials_based_on",
 			"Material Transferred for Manufacture",
 		)
@@ -1356,9 +1351,8 @@ class TestWorkOrder(FrappeTestCase):
 			self.assertEqual(abs(d.qty), 2)
 
 	def test_backflushed_serial_no_raw_materials_based_on_transferred(self):
-		frappe.db.set_value(
+		frappe.db.set_single_value(
 			"Manufacturing Settings",
-			None,
 			"backflush_raw_materials_based_on",
 			"Material Transferred for Manufacture",
 		)
@@ -1400,9 +1394,8 @@ class TestWorkOrder(FrappeTestCase):
 		self.assertEqual(manufacture_ste_doc2.items[0].qty, 2)
 
 	def test_backflushed_serial_no_batch_raw_materials_based_on_transferred(self):
-		frappe.db.set_value(
+		frappe.db.set_single_value(
 			"Manufacturing Settings",
-			None,
 			"backflush_raw_materials_based_on",
 			"Material Transferred for Manufacture",
 		)
@@ -1486,9 +1479,8 @@ class TestWorkOrder(FrappeTestCase):
 		self.assertFalse(serial_nos)
 
 	def test_non_consumed_material_return_against_work_order(self):
-		frappe.db.set_value(
+		frappe.db.set_single_value(
 			"Manufacturing Settings",
-			None,
 			"backflush_raw_materials_based_on",
 			"Material Transferred for Manufacture",
 		)

--- a/erpnext/patches/v11_0/update_backflush_subcontract_rm_based_on_bom.py
+++ b/erpnext/patches/v11_0/update_backflush_subcontract_rm_based_on_bom.py
@@ -7,8 +7,8 @@ import frappe
 
 def execute():
 	frappe.reload_doc("buying", "doctype", "buying_settings")
-	frappe.db.set_value(
-		"Buying Settings", None, "backflush_raw_materials_of_subcontract_based_on", "BOM"
+	frappe.db.set_single_value(
+		"Buying Settings", "backflush_raw_materials_of_subcontract_based_on", "BOM"
 	)
 
 	frappe.reload_doc("stock", "doctype", "stock_entry_detail")

--- a/erpnext/patches/v12_0/rename_tolerance_fields.py
+++ b/erpnext/patches/v12_0/rename_tolerance_fields.py
@@ -11,6 +11,6 @@ def execute():
 	rename_field("Item", "tolerance", "over_delivery_receipt_allowance")
 
 	qty_allowance = frappe.db.get_single_value("Stock Settings", "over_delivery_receipt_allowance")
-	frappe.db.set_value("Accounts Settings", None, "over_delivery_receipt_allowance", qty_allowance)
+	frappe.db.set_single_value("Accounts Settings", "over_delivery_receipt_allowance", qty_allowance)
 
 	frappe.db.sql("update tabItem set over_billing_allowance=over_delivery_receipt_allowance")

--- a/erpnext/patches/v12_0/set_automatically_process_deferred_accounting_in_accounts_settings.py
+++ b/erpnext/patches/v12_0/set_automatically_process_deferred_accounting_in_accounts_settings.py
@@ -4,6 +4,6 @@ import frappe
 def execute():
 	frappe.reload_doc("accounts", "doctype", "accounts_settings")
 
-	frappe.db.set_value(
-		"Accounts Settings", None, "automatically_process_deferred_accounting_entry", 1
+	frappe.db.set_single_value(
+		"Accounts Settings", "automatically_process_deferred_accounting_entry", 1
 	)

--- a/erpnext/patches/v12_0/set_default_homepage_type.py
+++ b/erpnext/patches/v12_0/set_default_homepage_type.py
@@ -2,4 +2,4 @@ import frappe
 
 
 def execute():
-	frappe.db.set_value("Homepage", "Homepage", "hero_section_based_on", "Default")
+	frappe.db.set_single_value("Homepage", "hero_section_based_on", "Default")

--- a/erpnext/patches/v12_0/set_priority_for_support.py
+++ b/erpnext/patches/v12_0/set_priority_for_support.py
@@ -46,7 +46,7 @@ def set_priorities_service_level():
 
 		frappe.reload_doc("support", "doctype", "service_level")
 		frappe.reload_doc("support", "doctype", "support_settings")
-		frappe.db.set_value("Support Settings", None, "track_service_level_agreement", 1)
+		frappe.db.set_single_value("Support Settings", "track_service_level_agreement", 1)
 
 		for service_level in service_level_priorities:
 			if service_level:

--- a/erpnext/patches/v13_0/modify_invalid_gain_loss_gl_entries.py
+++ b/erpnext/patches/v13_0/modify_invalid_gain_loss_gl_entries.py
@@ -47,7 +47,7 @@ def execute():
 
 	acc_frozen_upto = frappe.db.get_value("Accounts Settings", None, "acc_frozen_upto")
 	if acc_frozen_upto:
-		frappe.db.set_value("Accounts Settings", None, "acc_frozen_upto", None)
+		frappe.db.set_single_value("Accounts Settings", "acc_frozen_upto", None)
 
 	for invoice in purchase_invoices + sales_invoices:
 		try:
@@ -65,4 +65,4 @@ def execute():
 			print(f"Failed to correct gl entries of {invoice.name}")
 
 	if acc_frozen_upto:
-		frappe.db.set_value("Accounts Settings", None, "acc_frozen_upto", acc_frozen_upto)
+		frappe.db.set_single_value("Accounts Settings", "acc_frozen_upto", acc_frozen_upto)

--- a/erpnext/patches/v14_0/discount_accounting_separation.py
+++ b/erpnext/patches/v14_0/discount_accounting_separation.py
@@ -8,4 +8,4 @@ def execute():
 	discount_account = data and int(data[0][0]) or 0
 	if discount_account:
 		for doctype in ["Buying Settings", "Selling Settings"]:
-			frappe.db.set_value(doctype, doctype, "enable_discount_accounting", 1, update_modified=False)
+			frappe.db.set_single_value(doctype, "enable_discount_accounting", 1, update_modified=False)

--- a/erpnext/patches/v14_0/migrate_crm_settings.py
+++ b/erpnext/patches/v14_0/migrate_crm_settings.py
@@ -11,8 +11,7 @@ def execute():
 
 	frappe.reload_doc("crm", "doctype", "crm_settings")
 	if settings:
-		frappe.db.set_value(
-			"CRM Settings",
+		frappe.db.set_single_value(
 			"CRM Settings",
 			{
 				"campaign_naming_by": settings.campaign_naming_by,

--- a/erpnext/selling/doctype/customer/test_customer.py
+++ b/erpnext/selling/doctype/customer/test_customer.py
@@ -345,7 +345,7 @@ class TestCustomer(FrappeTestCase):
 	def test_serach_fields_for_customer(self):
 		from erpnext.controllers.queries import customer_query
 
-		frappe.db.set_value("Selling Settings", None, "cust_master_name", "Naming Series")
+		frappe.db.set_single_value("Selling Settings", "cust_master_name", "Naming Series")
 
 		make_property_setter(
 			"Customer", None, "search_fields", "customer_group", "Data", for_doctype="Doctype"
@@ -371,7 +371,7 @@ class TestCustomer(FrappeTestCase):
 		self.assertEqual(data[0].territory, "_Test Territory")
 		self.assertTrue("territory" in data[0])
 
-		frappe.db.set_value("Selling Settings", None, "cust_master_name", "Customer Name")
+		frappe.db.set_single_value("Selling Settings", "cust_master_name", "Customer Name")
 
 
 def get_customer_dict(customer_name):

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -43,11 +43,8 @@ class TestSalesOrder(FrappeTestCase):
 	@classmethod
 	def tearDownClass(cls) -> None:
 		# reset config to previous state
-		frappe.db.set_value(
-			"Accounts Settings",
-			"Accounts Settings",
-			"unlink_advance_payment_on_cancelation_of_order",
-			cls.unlink_setting,
+		frappe.db.set_single_value(
+			"Accounts Settings", "unlink_advance_payment_on_cancelation_of_order", cls.unlink_setting
 		)
 		super().tearDownClass()
 
@@ -705,7 +702,7 @@ class TestSalesOrder(FrappeTestCase):
 		self.assertEqual(so.taxes[0].total, 110)
 
 		old_stock_settings_value = frappe.db.get_single_value("Stock Settings", "default_warehouse")
-		frappe.db.set_value("Stock Settings", None, "default_warehouse", "_Test Warehouse - _TC")
+		frappe.db.set_single_value("Stock Settings", "default_warehouse", "_Test Warehouse - _TC")
 
 		items = json.dumps(
 			[
@@ -741,7 +738,7 @@ class TestSalesOrder(FrappeTestCase):
 		so.delete()
 		new_item_with_tax.delete()
 		frappe.get_doc("Item Tax Template", "Test Update Items Template - _TC").delete()
-		frappe.db.set_value("Stock Settings", None, "default_warehouse", old_stock_settings_value)
+		frappe.db.set_single_value("Stock Settings", "default_warehouse", old_stock_settings_value)
 
 	def test_warehouse_user(self):
 		test_user = create_user("test_so_warehouse_user@example.com", "Sales User", "Stock User")
@@ -820,7 +817,7 @@ class TestSalesOrder(FrappeTestCase):
 	def test_auto_insert_price(self):
 		make_item("_Test Item for Auto Price List", {"is_stock_item": 0})
 		make_item("_Test Item for Auto Price List with Discount Percentage", {"is_stock_item": 0})
-		frappe.db.set_value("Stock Settings", None, "auto_insert_price_list_rate_if_missing", 1)
+		frappe.db.set_single_value("Stock Settings", "auto_insert_price_list_rate_if_missing", 1)
 
 		item_price = frappe.db.get_value(
 			"Item Price", {"price_list": "_Test Price List", "item_code": "_Test Item for Auto Price List"}
@@ -861,7 +858,7 @@ class TestSalesOrder(FrappeTestCase):
 		)
 
 		# do not update price list
-		frappe.db.set_value("Stock Settings", None, "auto_insert_price_list_rate_if_missing", 0)
+		frappe.db.set_single_value("Stock Settings", "auto_insert_price_list_rate_if_missing", 0)
 
 		item_price = frappe.db.get_value(
 			"Item Price", {"price_list": "_Test Price List", "item_code": "_Test Item for Auto Price List"}
@@ -882,7 +879,7 @@ class TestSalesOrder(FrappeTestCase):
 			None,
 		)
 
-		frappe.db.set_value("Stock Settings", None, "auto_insert_price_list_rate_if_missing", 1)
+		frappe.db.set_single_value("Stock Settings", "auto_insert_price_list_rate_if_missing", 1)
 
 	def test_drop_shipping(self):
 		from erpnext.buying.doctype.purchase_order.purchase_order import update_status
@@ -1257,8 +1254,8 @@ class TestSalesOrder(FrappeTestCase):
 	def test_advance_payment_entry_unlink_against_sales_order(self):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import get_payment_entry
 
-		frappe.db.set_value(
-			"Accounts Settings", "Accounts Settings", "unlink_advance_payment_on_cancelation_of_order", 0
+		frappe.db.set_single_value(
+			"Accounts Settings", "unlink_advance_payment_on_cancelation_of_order", 0
 		)
 
 		so = make_sales_order()
@@ -1312,8 +1309,8 @@ class TestSalesOrder(FrappeTestCase):
 		so = make_sales_order()
 
 		# disable unlinking of payment entry
-		frappe.db.set_value(
-			"Accounts Settings", "Accounts Settings", "unlink_advance_payment_on_cancelation_of_order", 0
+		frappe.db.set_single_value(
+			"Accounts Settings", "unlink_advance_payment_on_cancelation_of_order", 0
 		)
 
 		# create a payment entry against sales order
@@ -2080,7 +2077,7 @@ def make_sales_order(**args):
 
 
 def create_dn_against_so(so, delivered_qty=0):
-	frappe.db.set_value("Stock Settings", None, "allow_negative_stock", 1)
+	frappe.db.set_single_value("Stock Settings", "allow_negative_stock", 1)
 
 	dn = make_delivery_note(so)
 	dn.get("items")[0].qty = delivered_qty or 5

--- a/erpnext/setup/doctype/currency_exchange/test_currency_exchange.py
+++ b/erpnext/setup/doctype/currency_exchange/test_currency_exchange.py
@@ -87,13 +87,13 @@ class TestCurrencyExchange(unittest.TestCase):
 			cache.delete(key)
 
 	def tearDown(self):
-		frappe.db.set_value("Accounts Settings", None, "allow_stale", 1)
+		frappe.db.set_single_value("Accounts Settings", "allow_stale", 1)
 		self.clear_cache()
 
 	def test_exchange_rate(self, mock_get):
 		save_new_records(test_records)
 
-		frappe.db.set_value("Accounts Settings", None, "allow_stale", 1)
+		frappe.db.set_single_value("Accounts Settings", "allow_stale", 1)
 
 		# Start with allow_stale is True
 		exchange_rate = get_exchange_rate("USD", "INR", "2016-01-01", "for_buying")
@@ -124,7 +124,7 @@ class TestCurrencyExchange(unittest.TestCase):
 		settings.save()
 
 		# Update exchange
-		frappe.db.set_value("Accounts Settings", None, "allow_stale", 1)
+		frappe.db.set_single_value("Accounts Settings", "allow_stale", 1)
 
 		# Start with allow_stale is True
 		exchange_rate = get_exchange_rate("USD", "INR", "2016-01-01", "for_buying")
@@ -152,8 +152,8 @@ class TestCurrencyExchange(unittest.TestCase):
 
 	def test_exchange_rate_strict(self, mock_get):
 		# strict currency settings
-		frappe.db.set_value("Accounts Settings", None, "allow_stale", 0)
-		frappe.db.set_value("Accounts Settings", None, "stale_days", 1)
+		frappe.db.set_single_value("Accounts Settings", "allow_stale", 0)
+		frappe.db.set_single_value("Accounts Settings", "stale_days", 1)
 
 		exchange_rate = get_exchange_rate("USD", "INR", "2016-01-01", "for_buying")
 		self.assertEqual(exchange_rate, 60.0)
@@ -175,8 +175,8 @@ class TestCurrencyExchange(unittest.TestCase):
 		exchange_rate = get_exchange_rate("USD", "INR", "2016-01-15", "for_buying")
 		self.assertEqual(exchange_rate, 65.1)
 
-		frappe.db.set_value("Accounts Settings", None, "allow_stale", 0)
-		frappe.db.set_value("Accounts Settings", None, "stale_days", 1)
+		frappe.db.set_single_value("Accounts Settings", "allow_stale", 0)
+		frappe.db.set_single_value("Accounts Settings", "stale_days", 1)
 
 		self.clear_cache()
 		exchange_rate = get_exchange_rate("USD", "INR", "2016-01-30", "for_buying")

--- a/erpnext/setup/install.py
+++ b/erpnext/setup/install.py
@@ -190,7 +190,7 @@ def add_standard_navbar_items():
 
 
 def add_app_name():
-	frappe.db.set_value("System Settings", None, "app_name", "ERPNext")
+	frappe.db.set_single_value("System Settings", "app_name", "ERPNext")
 
 
 def setup_log_settings():

--- a/erpnext/stock/doctype/delivery_note/test_delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/test_delivery_note.py
@@ -43,7 +43,7 @@ from erpnext.stock.stock_ledger import get_previous_sle
 
 class TestDeliveryNote(FrappeTestCase):
 	def test_over_billing_against_dn(self):
-		frappe.db.set_value("Stock Settings", None, "allow_negative_stock", 1)
+		frappe.db.set_single_value("Stock Settings", "allow_negative_stock", 1)
 
 		dn = create_delivery_note(do_not_submit=True)
 		self.assertRaises(frappe.ValidationError, make_sales_invoice, dn.name)
@@ -709,7 +709,7 @@ class TestDeliveryNote(FrappeTestCase):
 		# Testing if Customer's Purchase Order No was rightly copied
 		self.assertEqual(so.po_no, si.po_no)
 
-		frappe.db.set_value("Stock Settings", None, "allow_negative_stock", 1)
+		frappe.db.set_single_value("Stock Settings", "allow_negative_stock", 1)
 
 		dn1 = make_delivery_note(so.name)
 		dn1.get("items")[0].qty = 2
@@ -741,7 +741,7 @@ class TestDeliveryNote(FrappeTestCase):
 			make_sales_invoice as make_sales_invoice_from_so,
 		)
 
-		frappe.db.set_value("Stock Settings", None, "allow_negative_stock", 1)
+		frappe.db.set_single_value("Stock Settings", "allow_negative_stock", 1)
 
 		so = make_sales_order()
 

--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -585,7 +585,7 @@ class Item(Document):
 		existing_allow_negative_stock = frappe.db.get_value(
 			"Stock Settings", None, "allow_negative_stock"
 		)
-		frappe.db.set_value("Stock Settings", None, "allow_negative_stock", 1)
+		frappe.db.set_single_value("Stock Settings", "allow_negative_stock", 1)
 
 		repost_stock_for_warehouses = frappe.get_all(
 			"Stock Ledger Entry",
@@ -601,8 +601,8 @@ class Item(Document):
 		for warehouse in repost_stock_for_warehouses:
 			repost_stock(new_name, warehouse)
 
-		frappe.db.set_value(
-			"Stock Settings", None, "allow_negative_stock", existing_allow_negative_stock
+		frappe.db.set_single_value(
+			"Stock Settings", "allow_negative_stock", existing_allow_negative_stock
 		)
 
 	def update_bom_item_desc(self):

--- a/erpnext/stock/doctype/landed_cost_voucher/test_landed_cost_voucher.py
+++ b/erpnext/stock/doctype/landed_cost_voucher/test_landed_cost_voucher.py
@@ -25,7 +25,7 @@ from erpnext.stock.serial_batch_bundle import SerialNoValuation
 
 class TestLandedCostVoucher(FrappeTestCase):
 	def test_landed_cost_voucher(self):
-		frappe.db.set_value("Buying Settings", None, "allow_multiple_items", 1)
+		frappe.db.set_single_value("Buying Settings", "allow_multiple_items", 1)
 
 		pr = make_purchase_receipt(
 			company="_Test Company with perpetual inventory",

--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -400,7 +400,7 @@ class TestMaterialRequest(FrappeTestCase):
 		mr.insert()
 		mr.submit()
 
-		frappe.db.set_value("Stock Settings", None, "mr_qty_allowance", 20)
+		frappe.db.set_single_value("Stock Settings", "mr_qty_allowance", 20)
 
 		# map a stock entry
 

--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -27,7 +27,7 @@ from erpnext.stock.stock_ledger import SerialNoExistsInFutureTransaction
 
 class TestPurchaseReceipt(FrappeTestCase):
 	def setUp(self):
-		frappe.db.set_value("Buying Settings", None, "allow_multiple_items", 1)
+		frappe.db.set_single_value("Buying Settings", "allow_multiple_items", 1)
 
 	def test_purchase_receipt_received_qty(self):
 		"""
@@ -1925,7 +1925,7 @@ def make_purchase_receipt(**args):
 	if not frappe.db.exists("Location", "Test Location"):
 		frappe.get_doc({"doctype": "Location", "location_name": "Test Location"}).insert()
 
-	frappe.db.set_value("Buying Settings", None, "allow_multiple_items", 1)
+	frappe.db.set_single_value("Buying Settings", "allow_multiple_items", 1)
 	pr = frappe.new_doc("Purchase Receipt")
 	args = frappe._dict(args)
 	pr.posting_date = args.posting_date or today()

--- a/erpnext/stock/doctype/quality_inspection/test_quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/test_quality_inspection.py
@@ -167,13 +167,13 @@ class TestQualityInspection(FrappeTestCase):
 			reference_type="Stock Entry", reference_name=se.name, readings=readings, status="Rejected"
 		)
 
-		frappe.db.set_value("Stock Settings", None, "action_if_quality_inspection_is_rejected", "Stop")
+		frappe.db.set_single_value("Stock Settings", "action_if_quality_inspection_is_rejected", "Stop")
 		se.reload()
 		self.assertRaises(
 			QualityInspectionRejectedError, se.submit
 		)  # when blocked in Stock settings, block rejected QI
 
-		frappe.db.set_value("Stock Settings", None, "action_if_quality_inspection_is_rejected", "Warn")
+		frappe.db.set_single_value("Stock Settings", "action_if_quality_inspection_is_rejected", "Warn")
 		se.reload()
 		se.submit()  # when allowed in Stock settings, allow rejected QI
 
@@ -182,7 +182,7 @@ class TestQualityInspection(FrappeTestCase):
 		qa.cancel()
 		se.reload()
 		se.cancel()
-		frappe.db.set_value("Stock Settings", None, "action_if_quality_inspection_is_rejected", "Stop")
+		frappe.db.set_single_value("Stock Settings", "action_if_quality_inspection_is_rejected", "Stop")
 
 	def test_qi_status(self):
 		make_stock_entry(

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -55,7 +55,7 @@ class TestStockEntry(FrappeTestCase):
 		frappe.set_user("Administrator")
 
 	def test_fifo(self):
-		frappe.db.set_value("Stock Settings", None, "allow_negative_stock", 1)
+		frappe.db.set_single_value("Stock Settings", "allow_negative_stock", 1)
 		item_code = "_Test Item 2"
 		warehouse = "_Test Warehouse - _TC"
 
@@ -142,7 +142,7 @@ class TestStockEntry(FrappeTestCase):
 			or 0
 		)
 
-		frappe.db.set_value("Stock Settings", None, "auto_indent", 1)
+		frappe.db.set_single_value("Stock Settings", "auto_indent", 1)
 
 		# update re-level qty so that it is more than projected_qty
 		if projected_qty >= variant.reorder_levels[0].warehouse_reorder_level:
@@ -154,7 +154,7 @@ class TestStockEntry(FrappeTestCase):
 
 		mr_list = reorder_item()
 
-		frappe.db.set_value("Stock Settings", None, "auto_indent", 0)
+		frappe.db.set_single_value("Stock Settings", "auto_indent", 0)
 
 		items = []
 		for mr in mr_list:
@@ -792,24 +792,24 @@ class TestStockEntry(FrappeTestCase):
 		remove_user_permission("Company", "_Test Company 1", "test2@example.com")
 
 	def test_freeze_stocks(self):
-		frappe.db.set_value("Stock Settings", None, "stock_auth_role", "")
+		frappe.db.set_single_value("Stock Settings", "stock_auth_role", "")
 
 		# test freeze_stocks_upto
-		frappe.db.set_value("Stock Settings", None, "stock_frozen_upto", add_days(nowdate(), 5))
+		frappe.db.set_single_value("Stock Settings", "stock_frozen_upto", add_days(nowdate(), 5))
 		se = frappe.copy_doc(test_records[0]).insert()
 		self.assertRaises(StockFreezeError, se.submit)
 
-		frappe.db.set_value("Stock Settings", None, "stock_frozen_upto", "")
+		frappe.db.set_single_value("Stock Settings", "stock_frozen_upto", "")
 
 		# test freeze_stocks_upto_days
-		frappe.db.set_value("Stock Settings", None, "stock_frozen_upto_days", -1)
+		frappe.db.set_single_value("Stock Settings", "stock_frozen_upto_days", -1)
 		se = frappe.copy_doc(test_records[0])
 		se.set_posting_time = 1
 		se.posting_date = nowdate()
 		se.set_stock_entry_type()
 		se.insert()
 		self.assertRaises(StockFreezeError, se.submit)
-		frappe.db.set_value("Stock Settings", None, "stock_frozen_upto_days", 0)
+		frappe.db.set_single_value("Stock Settings", "stock_frozen_upto_days", 0)
 
 	def test_work_order(self):
 		from erpnext.manufacturing.doctype.work_order.work_order import (
@@ -1211,7 +1211,7 @@ class TestStockEntry(FrappeTestCase):
 		)
 
 	def test_conversion_factor_change(self):
-		frappe.db.set_value("Stock Settings", None, "allow_negative_stock", 1)
+		frappe.db.set_single_value("Stock Settings", "allow_negative_stock", 1)
 		repack_entry = frappe.copy_doc(test_records[3])
 		repack_entry.posting_date = nowdate()
 		repack_entry.posting_time = nowtime()

--- a/erpnext/stock/doctype/stock_ledger_entry/test_stock_ledger_entry.py
+++ b/erpnext/stock/doctype/stock_ledger_entry/test_stock_ledger_entry.py
@@ -416,8 +416,8 @@ class TestStockLedgerEntry(FrappeTestCase, StockTestMixin):
 
 	def test_back_dated_entry_not_allowed(self):
 		# Back dated stock transactions are only allowed to stock managers
-		frappe.db.set_value(
-			"Stock Settings", None, "role_allowed_to_create_edit_back_dated_transactions", "Stock Manager"
+		frappe.db.set_single_value(
+			"Stock Settings", "role_allowed_to_create_edit_back_dated_transactions", "Stock Manager"
 		)
 
 		# Set User with Stock User role but not Stock Manager
@@ -453,8 +453,8 @@ class TestStockLedgerEntry(FrappeTestCase, StockTestMixin):
 			stock_entry_on_today.cancel()
 
 		finally:
-			frappe.db.set_value(
-				"Stock Settings", None, "role_allowed_to_create_edit_back_dated_transactions", None
+			frappe.db.set_single_value(
+				"Stock Settings", "role_allowed_to_create_edit_back_dated_transactions", None
 			)
 			frappe.set_user("Administrator")
 			user.remove_roles("Stock Manager")

--- a/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
@@ -33,7 +33,7 @@ class TestStockReconciliation(FrappeTestCase, StockTestMixin):
 	def setUpClass(cls):
 		create_batch_or_serial_no_items()
 		super().setUpClass()
-		frappe.db.set_value("Stock Settings", None, "allow_negative_stock", 1)
+		frappe.db.set_single_value("Stock Settings", "allow_negative_stock", 1)
 
 	def tearDown(self):
 		frappe.local.future_sle = {}

--- a/erpnext/stock/doctype/stock_settings/test_stock_settings.py
+++ b/erpnext/stock/doctype/stock_settings/test_stock_settings.py
@@ -10,7 +10,7 @@ from frappe.tests.utils import FrappeTestCase
 class TestStockSettings(FrappeTestCase):
 	def setUp(self):
 		super().setUp()
-		frappe.db.set_value("Stock Settings", None, "clean_description_html", 0)
+		frappe.db.set_single_value("Stock Settings", "clean_description_html", 0)
 
 	def test_settings(self):
 		item = frappe.get_doc(

--- a/erpnext/stock/stock_balance.py
+++ b/erpnext/stock/stock_balance.py
@@ -18,7 +18,7 @@ def repost(only_actual=False, allow_negative_stock=False, allow_zero_rate=False,
 		existing_allow_negative_stock = frappe.db.get_value(
 			"Stock Settings", None, "allow_negative_stock"
 		)
-		frappe.db.set_value("Stock Settings", None, "allow_negative_stock", 1)
+		frappe.db.set_single_value("Stock Settings", "allow_negative_stock", 1)
 
 	item_warehouses = frappe.db.sql(
 		"""
@@ -37,8 +37,8 @@ def repost(only_actual=False, allow_negative_stock=False, allow_zero_rate=False,
 			frappe.db.rollback()
 
 	if allow_negative_stock:
-		frappe.db.set_value(
-			"Stock Settings", None, "allow_negative_stock", existing_allow_negative_stock
+		frappe.db.set_single_value(
+			"Stock Settings", "allow_negative_stock", existing_allow_negative_stock
 		)
 	frappe.db.auto_commit_on_many_writes = 0
 

--- a/erpnext/support/doctype/issue/test_issue.py
+++ b/erpnext/support/doctype/issue/test_issue.py
@@ -20,7 +20,7 @@ class TestSetUp(unittest.TestCase):
 		frappe.db.sql("delete from `tabSLA Fulfilled On Status`")
 		frappe.db.sql("delete from `tabPause SLA On Status`")
 		frappe.db.sql("delete from `tabService Day`")
-		frappe.db.set_value("Support Settings", None, "track_service_level_agreement", 1)
+		frappe.db.set_single_value("Support Settings", "track_service_level_agreement", 1)
 		create_service_level_agreements_for_issues()
 
 

--- a/erpnext/support/doctype/service_level_agreement/test_service_level_agreement.py
+++ b/erpnext/support/doctype/service_level_agreement/test_service_level_agreement.py
@@ -16,7 +16,7 @@ from erpnext.support.doctype.service_level_agreement.service_level_agreement imp
 class TestServiceLevelAgreement(unittest.TestCase):
 	def setUp(self):
 		self.create_company()
-		frappe.db.set_value("Support Settings", None, "track_service_level_agreement", 1)
+		frappe.db.set_single_value("Support Settings", "track_service_level_agreement", 1)
 		lead = frappe.qb.DocType("Lead")
 		frappe.qb.from_(lead).delete().where(lead.company == self.company).run()
 

--- a/erpnext/support/report/issue_analytics/test_issue_analytics.py
+++ b/erpnext/support/report/issue_analytics/test_issue_analytics.py
@@ -17,7 +17,7 @@ class TestIssueAnalytics(unittest.TestCase):
 	@classmethod
 	def setUpClass(self):
 		frappe.db.sql("delete from `tabIssue` where company='_Test Company'")
-		frappe.db.set_value("Support Settings", None, "track_service_level_agreement", 1)
+		frappe.db.set_single_value("Support Settings", "track_service_level_agreement", 1)
 
 		current_month_date = getdate()
 		last_month_date = add_months(current_month_date, -1)

--- a/erpnext/tests/test_exotel.py
+++ b/erpnext/tests/test_exotel.py
@@ -12,7 +12,7 @@ class TestExotel(FrappeAPITestCase):
 		cls.test_employee_name = make_employee(
 			user="test_employee_exotel@company.com", cell_number="9999999999"
 		)
-		frappe.db.set_value("Exotel Settings", "Exotel Settings", "enabled", 1)
+		frappe.db.set_single_value("Exotel Settings", "enabled", 1)
 		phones = [{"phone": "+91 9999999991", "is_primary_phone": 0, "is_primary_mobile_no": 1}]
 		create_contact(name="Test Contact", salutation="Mr", phones=phones)
 		frappe.db.commit()


### PR DESCRIPTION
I just applied semgrep autofix. Untested completely, review before merging.

```yaml
- id: frappe-set-value-semantics
  patterns:
    - pattern-either:
      - pattern: frappe.db.set_value($DOCTYPE, None, $...AFTER)
      - pattern: frappe.db.set_value($DOCTYPE, $DOCTYPE, $...AFTER)
  fix: frappe.db.set_single_value($DOCTYPE, $...AFTER)
  message: |
    If $DOCTYPE is a single doctype then using `frappe.db.set_value` is discouraged for setting values in DB. Use db.set_single_value for single doctype instead.
  languages: [python]
  severity: ERROR
```
