### PR TITLE
fix: make showing taxes as table in print configurable

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -34,6 +34,7 @@
   "book_tax_discount_loss",
   "print_settings",
   "show_inclusive_tax_in_print",
+  "show_taxes_as_table_in_print",
   "column_break_12",
   "show_payment_schedule_in_print",
   "currency_exchange_section",
@@ -376,6 +377,12 @@
    "fieldname": "auto_reconcile_payments",
    "fieldtype": "Check",
    "label": "Auto Reconcile Payments"
+  },
+  {
+   "default": "0",
+   "fieldname": "show_taxes_as_table_in_print",
+   "fieldtype": "Check",
+   "label": "Show Taxes as Table in Print"
   }
  ],
  "icon": "icon-cog",
@@ -383,7 +390,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-06-01 15:42:44.912316",
+ "modified": "2023-06-13 18:47:46.430291",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounts Settings",

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -917,6 +917,9 @@ class AccountsController(TransactionBase):
 
 		return is_inclusive
 
+	def should_show_taxes_as_table_in_print(self):
+		return cint(frappe.db.get_single_value("Accounts Settings", "show_taxes_as_table_in_print"))
+
 	def validate_advance_entries(self):
 		order_field = "sales_order" if self.doctype == "Sales Invoice" else "purchase_order"
 		order_list = list(set(d.get(order_field) for d in self.get("items") if d.get(order_field)))

--- a/erpnext/controllers/print_settings.py
+++ b/erpnext/controllers/print_settings.py
@@ -30,9 +30,15 @@ def set_print_templates_for_taxes(doc, settings):
 	doc.print_templates.update(
 		{
 			"total": "templates/print_formats/includes/total.html",
-			"taxes": "templates/print_formats/includes/taxes.html",
 		}
 	)
+
+	if not doc.should_show_taxes_as_table_in_print():
+		doc.print_templates.update(
+			{
+				"taxes": "templates/print_formats/includes/taxes.html",
+			}
+		)
 
 
 def format_columns(display_columns, compact_fields):


### PR DESCRIPTION
Closes #35662

Adding a new Accounts setting called `show_taxes_as_table_in_print` to let users choose whether they want to have taxes as a table in print formats or they want to go with the `templates/print_formats/includes/taxes.html` template.