### PR TITLE
fix: add validation for QI in PR

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -122,6 +122,7 @@ class PurchaseReceipt(BuyingController):
 			self.set_status()
 
 		self.po_required()
+		self.validate_items_quality_inspection()
 		self.validate_with_previous_doc()
 		self.validate_uom_is_integer("uom", ["qty", "received_qty"])
 		self.validate_uom_is_integer("stock_uom", "stock_qty")
@@ -194,6 +195,26 @@ class PurchaseReceipt(BuyingController):
 			for d in self.get("items"):
 				if not d.purchase_order:
 					frappe.throw(_("Purchase Order number required for Item {0}").format(d.item_code))
+
+	def validate_items_quality_inspection(self):
+		for item in self.get("items"):
+			if item.quality_inspection:
+				qi = frappe.db.get_value(
+					"Quality Inspection",
+					item.quality_inspection,
+					["reference_type", "reference_name", "item_code"],
+					as_dict=True,
+				)
+
+				if qi.reference_type != self.doctype or qi.reference_name != self.name:
+					msg = f"""Row #{item.idx}: Please select a valid Quality Inspection with Reference Type
+						{frappe.bold(self.doctype)} and Reference Name {frappe.bold(self.name)}."""
+					frappe.throw(_(msg))
+
+				if qi.item_code != item.item_code:
+					msg = f"""Row #{item.idx}: Please select a valid Quality Inspection with Item Code
+						{frappe.bold(item.item_code)}."""
+					frappe.throw(_(msg))
 
 	def get_already_received_qty(self, po, po_detail):
 		qty = frappe.db.sql(


### PR DESCRIPTION
**Source / Ref:** ISS-23-24-01397

**Issue:** A same Quality Inspection can be selected for different Items and Voucher Types which creates a circular linking between the Quality Inspection and Linked Vouchers. 

**Steps to Replicate:**
- Create a Purchase Receipt with two different line items.
- Create a Quality Inspection for the first item.
- Select the same Quality Inspection for both line items in Purchase Receipt. 
- Submit the Purchase Receipt.
- No, try to Cancel the Quality Inspection or Purchase Receipt.

**Changes:** Validation for Quality Inspection in Purchase Receipt.