### PR TITLE
fix: unsupported operand type(s) for //: 'float' and 'NoneType' for POS Barcode search

### DIFF
--- a/erpnext/selling/page/point_of_sale/point_of_sale.py
+++ b/erpnext/selling/page/point_of_sale/point_of_sale.py
@@ -49,7 +49,6 @@ def search_by_term(search_term, warehouse, price_list):
 			)
 
 	item_stock_qty, is_stock_item = get_stock_availability(item_code, warehouse)
-	item_stock_qty = item_stock_qty // item.get("conversion_factor")
 	item_stock_qty = item_stock_qty // item.get("conversion_factor", 1)
 	item.update({"actual_qty": item_stock_qty})
 
@@ -59,7 +58,7 @@ def search_by_term(search_term, warehouse, price_list):
 			"price_list": price_list,
 			"item_code": item_code,
 		},
-		fields=["uom", "stock_uom", "currency", "price_list_rate"],
+		fields=["uom", "currency", "price_list_rate"],
 	)
 
 	def __sort(p):


### PR DESCRIPTION
error: Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 66, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 54, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 45, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 83, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1607, in call
    return fn(*args, **newargs)
  File "apps/erpnext/erpnext/selling/page/point_of_sale/point_of_sale.py", line 96, in get_items
    result = search_by_term(search_term, warehouse, price_list) or []
  File "apps/erpnext/erpnext/selling/page/point_of_sale/point_of_sale.py", line 52, in search_by_term
    item_stock_qty = item_stock_qty // item.get("conversion_factor")
TypeError: unsupported operand type(s) for //: 'float' and 'NoneType'

before:


https://github.com/frappe/erpnext/assets/6947417/02028ec3-6dac-40aa-b27f-47e88f286ca1


after:


https://github.com/frappe/erpnext/assets/6947417/10d442da-f9e3-4f76-8662-68d79222571a

