### PR TITLE
fix: incorrect gl entries for standalone debit note

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -642,13 +642,6 @@ class TestPurchaseInvoice(unittest.TestCase, StockTestMixin):
 			gle_filters={"account": "Stock In Hand - TCP1"},
 		)
 
-		# assert loss booked in COGS
-		self.assertGLEs(
-			return_pi,
-			[{"credit": 0, "debit": 200}],
-			gle_filters={"account": "Cost of Goods Sold - TCP1"},
-		)
-
 	def test_return_with_lcv(self):
 		from erpnext.controllers.sales_and_purchase_return import make_return_doc
 		from erpnext.stock.doctype.landed_cost_voucher.test_landed_cost_voucher import (
@@ -1670,6 +1663,21 @@ class TestPurchaseInvoice(unittest.TestCase, StockTestMixin):
 		return_pi.save().submit()
 
 		self.assertTrue(return_pi.docstatus == 1)
+
+	def test_gl_entries_for_standalone_debit_note(self):
+		make_purchase_invoice(qty=5, rate=500, update_stock=True)
+
+		returned_inv = make_purchase_invoice(qty=-5, rate=5, update_stock=True, is_return=True)
+
+		# override the rate with valuation rate
+		sle = frappe.get_all(
+			"Stock Ledger Entry",
+			fields=["stock_value_difference", "actual_qty"],
+			filters={"voucher_no": returned_inv.name},
+		)[0]
+
+		rate = flt(sle.stock_value_difference) / flt(sle.actual_qty)
+		self.assertAlmostEqual(returned_inv.items[0].rate, rate)
 
 
 def check_gl_entries(doc, voucher_no, expected_gle, posting_date):

--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -105,6 +105,8 @@ class BuyingController(SubcontractingController):
 	def set_rate_for_standalone_debit_note(self):
 		if self.get("is_return") and self.get("update_stock") and not self.return_against:
 			for row in self.items:
+
+				# override the rate with valuation rate
 				row.rate = get_incoming_rate(
 					{
 						"item_code": row.item_code,

--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -26,6 +26,8 @@ class BuyingController(SubcontractingController):
 		self.flags.ignore_permlevel_for_fields = ["buying_price_list", "price_list_currency"]
 
 	def validate(self):
+		self.set_rate_for_standalone_debit_note()
+
 		super(BuyingController, self).validate()
 		if getattr(self, "supplier", None) and not self.supplier_name:
 			self.supplier_name = frappe.db.get_value("Supplier", self.supplier, "supplier_name")
@@ -99,6 +101,28 @@ class BuyingController(SubcontractingController):
 						type_of_transaction="Outward",
 						do_not_submit=True,
 					)
+
+	def set_rate_for_standalone_debit_note(self):
+		if self.get("is_return") and self.get("update_stock") and not self.return_against:
+			for row in self.items:
+				row.rate = get_incoming_rate(
+					{
+						"item_code": row.item_code,
+						"warehouse": row.warehouse,
+						"posting_date": self.get("posting_date"),
+						"posting_time": self.get("posting_time"),
+						"qty": row.qty,
+						"serial_and_batch_bundle": row.get("serial_and_batch_bundle"),
+						"company": self.company,
+						"voucher_type": self.doctype,
+						"voucher_no": self.name,
+					},
+					raise_error_if_no_rate=False,
+				)
+
+				row.discount_percentage = 0.0
+				row.discount_amount = 0.0
+				row.margin_rate_or_amount = 0.0
 
 	def set_missing_values(self, for_validate=False):
 		super(BuyingController, self).set_missing_values(for_validate)


### PR DESCRIPTION
**Issue**

1. Create standalone debit note with update stock
2. Change the rate manually to zero and submit it
3. You will notice that the Stock Value and Account value is not matching for the standalone debit note

**Solution**

Set the rate based on valuation rate in case of "standalone debit note with update stock"