### PR TITLE
fix: don't add GL Entry for Acc. Depr. while scrapping non-depreciable assets

### DIFF
--- a/erpnext/assets/doctype/asset/depreciation.py
+++ b/erpnext/assets/doctype/asset/depreciation.py
@@ -513,17 +513,21 @@ def get_gl_entries_on_asset_disposal(
 			},
 			item=asset,
 		),
-		asset.get_gl_dict(
-			{
-				"account": accumulated_depr_account,
-				"debit_in_account_currency": accumulated_depr_amount,
-				"debit": accumulated_depr_amount,
-				"cost_center": depreciation_cost_center,
-				"posting_date": date,
-			},
-			item=asset,
-		),
 	]
+
+	if accumulated_depr_amount:
+		gl_entries.append(
+			asset.get_gl_dict(
+				{
+					"account": accumulated_depr_account,
+					"debit_in_account_currency": accumulated_depr_amount,
+					"debit": accumulated_depr_amount,
+					"cost_center": depreciation_cost_center,
+					"posting_date": date,
+				},
+				item=asset,
+			),
+		)
 
 	profit_amount = flt(selling_amount) - flt(value_after_depreciation)
 	if profit_amount:


### PR DESCRIPTION
Problem:

On scrapping of non-depreciable assets, the system fails with `Row 2: Both Debit and Credit values cannot be zero` because it tries to add a GL entry with 0 debit and 0 credit for the Accumulated Depreciation account.

Solution:

Don't add GL Entry for the Accumulated Depreciation account while scrapping non-depreciable assets.
