### PR TITLE
fix: consider field precision while setting sle actual_qty

### DIFF
--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -445,7 +445,7 @@ class BuyingController(SubcontractingController):
 				continue
 
 			if d.warehouse:
-				pr_qty = flt(d.qty) * flt(d.conversion_factor)
+				pr_qty = flt(flt(d.qty) * flt(d.conversion_factor), d.precision("stock_qty"))
 
 				if pr_qty:
 
@@ -507,7 +507,7 @@ class BuyingController(SubcontractingController):
 						d,
 						{
 							"warehouse": d.rejected_warehouse,
-							"actual_qty": flt(d.rejected_qty) * flt(d.conversion_factor),
+							"actual_qty": flt(flt(d.rejected_qty) * flt(d.conversion_factor), d.precision("stock_qty")),
 							"serial_no": cstr(d.rejected_serial_no).strip(),
 							"incoming_rate": 0.0,
 						},


### PR DESCRIPTION
**Source / Ref:** ISS-23-24-01422

**Use case:** Purchase Receipt with a Serial Item having Qty **1581.632** (UOM = Kg) and Actual Received Qty is **410** i.e., Conversion Factor will be **0.196**. But now when you try to submit the receipt an error will be thrown **Serial No {item-code} quantity 309.99987200000004 cannot be a fraction.** 

**Changes:** Consider the field precision while setting the SLE Actual Qty. Users can update the Accepted Qty in Stock UOM field precision using Customize Form.

**Purchase Order**
![image](https://github.com/frappe/erpnext/assets/63660334/d95d2cba-5277-45a7-ae65-4d31fc9a87b1)

![image](https://github.com/frappe/erpnext/assets/63660334/b6c0ec22-bce1-4c63-9327-81374fcd6fbd)

**Before**
![image](https://github.com/frappe/erpnext/assets/63660334/4ab472f8-8de5-41c1-a66a-c995be5ccefa)

**After:**
![image](https://github.com/frappe/erpnext/assets/63660334/9579daf4-7cc0-4362-b471-a1e230e73403)

![image](https://github.com/frappe/erpnext/assets/63660334/72b643b5-0b64-48c9-956a-6355debe834f)



