### PR TITLE
feat(Bank Transaction): button create Bank Account

### DIFF
--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.js
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.js
@@ -13,10 +13,11 @@ frappe.ui.form.on("Bank Transaction", {
 		});
 	},
 	refresh(frm) {
-		frm.add_custom_button(__('Unreconcile Transaction'), () => {
-			frm.call('remove_payment_entries')
-			.then( () => frm.refresh() );
-		});
+		if (!frm.is_dirty() && frm.doc.payment_entries.length > 0) {
+			frm.add_custom_button(__("Unreconcile Transaction"), () => {
+				frm.call("remove_payment_entries").then(() => frm.refresh());
+			});
+		}
 
 		if (
 			["bank_party_account_number", "bank_party_iban"].some(

--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.js
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.js
@@ -17,6 +17,26 @@ frappe.ui.form.on("Bank Transaction", {
 			frm.call('remove_payment_entries')
 			.then( () => frm.refresh() );
 		});
+
+		if (
+			["bank_party_account_number", "bank_party_iban"].some(
+				(field) => frm.doc[field]
+			)
+		) {
+			frm.add_custom_button(
+				__("Bank Account"),
+				() => {
+					frappe.new_doc("Bank Account", {
+						iban: frm.doc.bank_party_iban,
+						bank_account_no: frm.doc.bank_party_account_number,
+						account_name: frm.doc.bank_party_name,
+						party: frm.doc.party,
+						party_type: frm.doc.party_type,
+					});
+				},
+				__("Make")
+			);
+		}
 	},
 	bank_account: function (frm) {
 		set_bank_statement_filter(frm);


### PR DESCRIPTION
Depends on https://github.com/frappe/erpnext/pull/34675

If _Bank Account Number_ or _IBAN_ is available in **Bank Transaction**, show a button to create a mapped **Bank Account**.

The **Bank Account** can later be used to auto-match the party in future **Bank Transactions**.

Also: only show the "Unreconcile Transaction" button if there are any reconciled transactions / payment entries.

> no-docs