### PR TITLE
perf: Index sales_order_item in Pick list item

### DIFF
--- a/erpnext/stock/doctype/pick_list_item/pick_list_item.json
+++ b/erpnext/stock/doctype/pick_list_item/pick_list_item.json
@@ -153,7 +153,8 @@
    "fieldtype": "Data",
    "hidden": 1,
    "label": "Sales Order Item",
-   "read_only": 1
+   "read_only": 1,
+   "search_index": 1
   },
   {
    "fieldname": "serial_no_and_batch_section",
@@ -208,7 +209,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2023-03-12 13:50:22.258100",
+ "modified": "2023-06-16 14:05:51.719959",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Pick List Item",


### PR DESCRIPTION
- `get_picked_items_qty` does full table scan
- because it also locks, it does full table lock.


![image](https://github.com/frappe/erpnext/assets/9079960/f2121e92-d3c2-45e5-9016-3797b2f76405)



Not adding before/after measurements. O(N) -> O(1) is infinite speedup theoretically :woozy_face: 