### PR TITLE
perf: Ignore cancelled pick lists while fetching picked items

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -384,6 +384,7 @@ class PickList(Document):
 					(pi_item.item_code.isin([x.item_code for x in items]))
 					& ((pi_item.picked_qty > 0) | (pi_item.stock_qty > 0))
 					& (pi.status != "Completed")
+					& (pi.status != "Cancelled")
 					& (pi_item.docstatus != 2)
 				)
 				.groupby(


### PR DESCRIPTION
`docstatus!=2` is already a condition but it's not useful in status index. Hence add separate condition to prevent over-reading data. 

Before:

```
+------+-------------+-------------------+-------+----------------------+--------------+---------+-------------------------------------+-------+---------+----------+-------->
| id   | select_type | table             | type  | possible_keys        | key          | key_len | ref                                 | rows  | r_rows  | filtered | r_filte>
+------+-------------+-------------------+-------+----------------------+--------------+---------+-------------------------------------+-------+---------+----------+-------->
|    1 | SIMPLE      | tabPick List      | range | PRIMARY,status_index | status_index | 563     | NULL                                | 10591 | 7280.00 |   100.00 |      99>
|    1 | SIMPLE      | tabPick List Item | ref   | parent               | parent       | 563     | _fc28cbacdbac857b.tabPick List.name | 3     | 8.63    |   100.00 |       0>
+------+-------------+-------------------+-------+----------------------+--------------+---------+-------------------------------------+-------+---------+----------+-------->
```

After:

```
+------+-------------+-------------------+-------+----------------------+--------------+---------+-------------------------------------+------+---------+----------+--------->
| id   | select_type | table             | type  | possible_keys        | key          | key_len | ref                                 | rows | r_rows  | filtered | r_filter>
+------+-------------+-------------------+-------+----------------------+--------------+---------+-------------------------------------+------+---------+----------+--------->
|    1 | SIMPLE      | tabPick List      | range | PRIMARY,status_index | status_index | 563     | NULL                                | 1549 | 1547.00 |   100.00 |      99.>
|    1 | SIMPLE      | tabPick List Item | ref   | parent               | parent       | 563     | _fc28cbacdbac857b.tabPick List.name | 3    | 7.85    |   100.00 |       4.>
+------+-------------+-------------------+-------+----------------------+--------------+---------+-------------------------------------+------+---------+----------+--------->
```