### PR TITLE
perf: Index pick list field in stock entry and DN

### DIFF
--- a/erpnext/stock/doctype/delivery_note/delivery_note.json
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.json
@@ -1223,7 +1223,8 @@
    "hidden": 1,
    "label": "Pick List",
    "options": "Pick List",
-   "read_only": 1
+   "read_only": 1,
+   "search_index": 1
   },
   {
    "default": "0",
@@ -1399,7 +1400,7 @@
  "idx": 146,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-06-03 16:13:25.011487",
+ "modified": "2023-06-16 14:58:55.066602",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Note",

--- a/erpnext/stock/doctype/stock_entry/stock_entry.json
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.json
@@ -577,7 +577,8 @@
    "fieldtype": "Link",
    "label": "Pick List",
    "options": "Pick List",
-   "read_only": 1
+   "read_only": 1,
+   "search_index": 1
   },
   {
    "fieldname": "print_settings_col_break",
@@ -677,7 +678,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-06-09 15:46:28.418339",
+ "modified": "2023-06-16 14:59:10.917235",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Entry",
@@ -738,7 +739,6 @@
    "read": 1,
    "report": 1,
    "role": "Stock Manager",
-   "set_user_permissions": 1,
    "share": 1,
    "submit": 1,
    "write": 1


### PR DESCRIPTION
We check if pick list is created against them but there's no index so we
end up reading entire table.

```
+------+-------------+------------------+-------+---------------+----------+---------+------+--------+-----------+----------+------------+-------------+
| id   | select_type | table            | type  | possible_keys | key      | key_len | ref  | rows   | r_rows    | filtered | r_filtered | Extra       |
+------+-------------+------------------+-------+---------------+----------+---------+------+--------+-----------+----------+------------+-------------+
|    1 | SIMPLE      | tabDelivery Note | index | NULL          | modified | 9       | NULL | 207015 | 348940.00 |   100.00 |       0.00 | Using where |
+------+-------------+------------------+-------+---------------+----------+---------+------+--------+-----------+----------+------------+-------------+
```

After

```
+------+-------------+------------------+------+-----------------+-----------------+---------+-------+------+--------+----------+------------+------------------------------->
| id   | select_type | table            | type | possible_keys   | key             | key_len | ref   | rows | r_rows | filtered | r_filtered | Extra                         >
+------+-------------+------------------+------+-----------------+-----------------+---------+-------+------+--------+----------+------------+------------------------------->
|    1 | SIMPLE      | tabDelivery Note | ref  | pick_list_index | pick_list_index | 563     | const | 1    | 0.00   |   100.00 |     100.00 | Using index condition; Using w>
+------+-------------+------------------+------+-----------------+-----------------+---------+-------+------+--------+----------+------------+------------------------------->
```
