### PR TITLE
fix: Allocated amount validation for other party types

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -152,7 +152,7 @@ class PaymentEntry(AccountsController):
 			return
 
 		if self.party_type in ("Customer", "Supplier"):
-			self.validate_allocated_amount_with_latest_date()
+			self.validate_allocated_amount_with_latest_data()
 		else:
 			fail_message = _("Row #{0}: Allocated Amount cannot be greater than outstanding amount.")
 			for d in self.get("references"):
@@ -163,7 +163,7 @@ class PaymentEntry(AccountsController):
 				if flt(d.allocated_amount) < 0 and flt(d.allocated_amount) < flt(d.outstanding_amount):
 					frappe.throw(fail_message.format(d.idx))
 
-	def validate_allocated_amount_with_latest_date(self):
+	def validate_allocated_amount_with_latest_data(self):
 		latest_references = get_outstanding_reference_documents(
 			{
 				"posting_date": self.posting_date,

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -156,11 +156,11 @@ class PaymentEntry(AccountsController):
 		else:
 			fail_message = _("Row #{0}: Allocated Amount cannot be greater than outstanding amount.")
 			for d in self.get("references"):
-				if (flt(d.allocated_amount)) and flt(d.allocated_amount) > flt(d.outstanding_amount):
+				if (flt(d.allocated_amount)) > 0 and flt(d.allocated_amount) > flt(d.outstanding_amount):
 					frappe.throw(fail_message.format(d.idx))
 
 				# Check for negative outstanding invoices as well
-				if flt(d.allocated_amount) and flt(d.allocated_amount) < flt(d.outstanding_amount):
+				if flt(d.allocated_amount) < 0 and flt(d.allocated_amount) < flt(d.outstanding_amount):
 					frappe.throw(fail_message.format(d.idx))
 
 	def validate_allocated_amount_with_latest_date(self):
@@ -202,11 +202,11 @@ class PaymentEntry(AccountsController):
 
 			fail_message = _("Row #{0}: Allocated Amount cannot be greater than outstanding amount.")
 
-			if (flt(d.allocated_amount)) and flt(d.allocated_amount) > flt(latest.outstanding_amount):
+			if (flt(d.allocated_amount)) > 0 and flt(d.allocated_amount) > flt(latest.outstanding_amount):
 				frappe.throw(fail_message.format(d.idx))
 
 			# Check for negative outstanding invoices as well
-			if flt(d.allocated_amount) and flt(d.allocated_amount) < flt(latest.outstanding_amount):
+			if flt(d.allocated_amount) < 0 and flt(d.allocated_amount) < flt(latest.outstanding_amount):
 				frappe.throw(fail_message.format(d.idx))
 
 	def delink_advance_entry_references(self):


### PR DESCRIPTION
Users were unable to make payment entries for party types other than Customer and Supplier

<img width="807" alt="image" src="https://github.com/frappe/erpnext/assets/42651287/16933ce7-e4f4-4b0b-ad1e-09a6c4ce03a7">
