### PR TITLE
fix: incorrect stock value for purchase returned with rejected qty

### DIFF
--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -660,6 +660,9 @@ def get_filters(
 	if reference_voucher_detail_no:
 		filters["voucher_detail_no"] = reference_voucher_detail_no
 
+	if item_row and item_row.get("warehouse"):
+		filters["warehouse"] = item_row.get("warehouse")
+
 	return filters
 
 

--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -1781,6 +1781,52 @@ class TestPurchaseReceipt(FrappeTestCase):
 		pr.items[0].delivery_note_item = delivery_note_item
 		pr.save()
 
+	def test_purchase_return_valuation_with_rejected_qty(self):
+		item_code = "_Test Item Return Valuation"
+		create_item(item_code)
+
+		warehouse = create_warehouse("_Test Warehouse Return Valuation")
+		rejected_warehouse = create_warehouse("_Test Rejected Warehouse Return Valuation")
+
+		# Step 1: Create Purchase Receipt with valuation rate 100
+		make_purchase_receipt(
+			item_code=item_code,
+			warehouse=warehouse,
+			qty=10,
+			rate=100,
+			rejected_qty=2,
+			rejected_warehouse=rejected_warehouse,
+		)
+
+		# Step 2: Create One more Purchase Receipt with valuation rate 200
+		pr = make_purchase_receipt(
+			item_code=item_code,
+			warehouse=warehouse,
+			qty=10,
+			rate=200,
+			rejected_qty=2,
+			rejected_warehouse=rejected_warehouse,
+		)
+
+		# Step 3: Create Purchase Return for 2 qty
+		from erpnext.stock.doctype.purchase_receipt.purchase_receipt import make_purchase_return
+
+		pr_return = make_purchase_return(pr.name)
+		pr_return.items[0].qty = 2 * -1
+		pr_return.items[0].received_qty = 2 * -1
+		pr_return.items[0].rejected_qty = 0
+		pr_return.items[0].rejected_warehouse = ""
+		pr_return.save()
+		pr_return.submit()
+
+		data = frappe.get_all(
+			"Stock Ledger Entry",
+			filters={"voucher_no": pr_return.name, "docstatus": 1},
+			fields=["SUM(stock_value_difference) as stock_value_difference"],
+		)[0]
+
+		self.assertEqual(abs(data["stock_value_difference"]), 400.00)
+
 
 def prepare_data_for_internal_transfer():
 	from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_internal_supplier


### PR DESCRIPTION
**Issue**

1. Create Purchase Receipt and accept 10 qty and reject 2 qty with rate as 100
2. Create another Purchase Receipt for the same item and accept 10 qty and reject 2 qty with rate as 200  
3. Create Purchase Return entry against the second purchase receipt for 2 qty against the accepted warehouse 
4. Submit the entry and check accounting ledgers
5. You will notice that the system has picked the rate as 100 and not 200

<img width="782" alt="Screenshot 2023-06-16 at 4 45 51 PM" src="https://github.com/frappe/erpnext/assets/8780500/e99f8085-0548-4edb-9fc8-313e018c69b0">


**After Fix**

<img width="862" alt="Screenshot 2023-06-16 at 4 43 48 PM" src="https://github.com/frappe/erpnext/assets/8780500/240dec22-28ad-440a-a570-019befaaf1e1">


**Investigation**

While fetching the rate from the get_rate_for_return method, the system checked the voucher_detail_no. In the case of rejected quantities, the system creates two Stock Ledger Entries for the same voucher_detail_no - one for the accepted warehouse and another for the rejected warehouse. Due to the absence of a warehouse filter, the system erroneously selected the rate from the Stock Ledger Entry associated with the rejected warehouse. Since the rate for the rejected warehouse is always zero, the system returned a rate of zero from the get_rate_for_return method. If the rate is zero, the system then determines the rate based on the FIFO method in purchase returning cases.