### PR TITLE
fix: cannot start / stop Job Card

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -161,7 +161,7 @@ class JobCard(Document):
 			self.total_completed_qty = flt(self.total_completed_qty, self.precision("total_completed_qty"))
 
 		for row in self.sub_operations:
-			self.c += row.completed_qty
+			self.total_completed_qty += row.completed_qty
 
 	def get_overlap_for(self, args, check_next_available_slot=False):
 		production_capacity = 1


### PR DESCRIPTION
```
  File "apps/erpnext/erpnext/manufacturing/doctype/job_card/job_card.py", line 855, in make_time_log
    doc.add_time_log(args)
  File "apps/erpnext/erpnext/manufacturing/doctype/job_card/job_card.py", line 346, in add_time_log
    self.save()
  File "apps/frappe/frappe/model/document.py", line 305, in save
    return self._save(*args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 339, in _save
    self.run_before_save_methods()
  File "apps/frappe/frappe/model/document.py", line 1045, in run_before_save_methods
    self.run_method("validate")
  File "apps/frappe/frappe/model/document.py", line 914, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1264, in composer
    return composed(self, method, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1246, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "apps/frappe/frappe/model/document.py", line 911, in fn
    return method_object(*args, **kwargs)
  File "apps/erpnext/erpnext/manufacturing/doctype/job_card/job_card.py", line 69, in validate
    self.validate_time_logs()
  File "apps/erpnext/erpnext/manufacturing/doctype/job_card/job_card.py", line 164, in validate_time_logs
    self.c += row.completed_qty
AttributeError: 'JobCard' object has no attribute 'c'
```