### PR TITLE
fix: validation of job card in stock entry

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -266,10 +266,10 @@ class StockEntry(StockController):
 			return
 
 		for row in self.items:
-			if row.job_card_item:
+			if row.job_card_item or not row.s_warehouse:
 				continue
 
-			msg = f"""Row #{0}: The job card item reference
+			msg = f"""Row #{row.idx}: The job card item reference
 				is missing. Kindly create the stock entry
 				from the job card. If you have added the row manually
 				then you won't be able to add job card item reference."""


### PR DESCRIPTION
**Issue**

job_card_item reference not set for the FG Item and therefore this validation is showing for the custom code.

<img width="1240" alt="Screenshot 2023-06-17 at 12 14 01 PM" src="https://github.com/frappe/erpnext/assets/8780500/a46134c9-ad8c-4b63-add2-5cd72550ee7a">
