### PR TITLE
fix(patch): enable allow existing serial no in stock settings

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -333,3 +333,4 @@ erpnext.patches.v14_0.migrate_gl_to_payment_ledger
 erpnext.patches.v14_0.update_company_in_ldc
 erpnext.patches.v14_0.set_packed_qty_in_draft_delivery_notes
 erpnext.patches.v14_0.cleanup_workspaces
+erpnext.patches.v14_0.enable_allow_existing_serial_no

--- a/erpnext/patches/v14_0/enable_allow_existing_serial_no.py
+++ b/erpnext/patches/v14_0/enable_allow_existing_serial_no.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+import frappe
+
+
+def execute():
+	frappe.reload_doc("stock", "doctype", frappe.scrub("Stock Settings"))
+	frappe.db.set_single_value("Stock Settings", "allow_existing_serial_no", 1, update_modified=False)


### PR DESCRIPTION
Enable `Existing Serial No` by default in Stock Settings.