### PR TITLE
fix: fix get outstanding invoices btn and add get outstanding orders btn

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -612,7 +612,7 @@ frappe.ui.form.on('Payment Entry', {
 			frm.events.set_unallocated_amount(frm);
 	},
 
-	get_outstanding_invoice: function(frm) {
+	get_outstanding_invoices_or_orders: function(frm, get_outstanding_invoices, get_orders_to_be_billed) {
 		const today = frappe.datetime.get_today();
 		const fields = [
 			{fieldtype:"Section Break", label: __("Posting Date")},
@@ -642,12 +642,29 @@ frappe.ui.form.on('Payment Entry', {
 			{fieldtype:"Check", label: __("Allocate Payment Amount"), fieldname:"allocate_payment_amount", default:1},
 		];
 
+		let btn_text = "";
+
+		if (get_outstanding_invoices) {
+			btn_text = "Get Outstanding Invoices";
+		}
+		else if (get_orders_to_be_billed) {
+			btn_text = "Get Outstanding Orders";
+		}
+
 		frappe.prompt(fields, function(filters){
 			frappe.flags.allocate_payment_amount = true;
 			frm.events.validate_filters_data(frm, filters);
 			frm.doc.cost_center = filters.cost_center;
-			frm.events.get_outstanding_documents(frm, filters);
-		}, __("Filters"), __("Get Outstanding Documents"));
+			frm.events.get_outstanding_documents(frm, filters, get_outstanding_invoices, get_orders_to_be_billed);
+		}, __("Filters"), __(btn_text));
+	},
+
+	get_outstanding_invoices: function(frm) {
+		frm.events.get_outstanding_invoices_or_orders(frm, true, false);
+	},
+
+	get_outstanding_orders: function(frm) {
+		frm.events.get_outstanding_invoices_or_orders(frm, false, true);
 	},
 
 	validate_filters_data: function(frm, filters) {
@@ -673,7 +690,7 @@ frappe.ui.form.on('Payment Entry', {
 		}
 	},
 
-	get_outstanding_documents: function(frm, filters) {
+	get_outstanding_documents: function(frm, filters, get_outstanding_invoices, get_orders_to_be_billed) {
 		frm.clear_table("references");
 
 		if(!frm.doc.party) {
@@ -695,6 +712,13 @@ frappe.ui.form.on('Payment Entry', {
 
 		for (let key in filters) {
 			args[key] = filters[key];
+		}
+
+		if (get_outstanding_invoices) {
+			args["get_outstanding_invoices"] = true;
+		}
+		else if (get_orders_to_be_billed) {
+			args["get_orders_to_be_billed"] = true;
 		}
 
 		frappe.flags.allocate_payment_amount = filters['allocate_payment_amount'];

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.json
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.json
@@ -48,7 +48,8 @@
   "base_received_amount",
   "base_received_amount_after_tax",
   "section_break_14",
-  "get_outstanding_invoice",
+  "get_outstanding_invoices",
+  "get_outstanding_orders",
   "references",
   "section_break_34",
   "total_allocated_amount",
@@ -354,12 +355,6 @@
    "fieldname": "section_break_14",
    "fieldtype": "Section Break",
    "label": "Reference"
-  },
-  {
-   "depends_on": "eval:doc.docstatus==0",
-   "fieldname": "get_outstanding_invoice",
-   "fieldtype": "Button",
-   "label": "Get Outstanding Invoice"
   },
   {
    "fieldname": "references",
@@ -728,12 +723,24 @@
    "fieldname": "section_break_60",
    "fieldtype": "Section Break",
    "hide_border": 1
+  },
+  {
+   "depends_on": "eval:doc.docstatus==0",
+   "fieldname": "get_outstanding_invoices",
+   "fieldtype": "Button",
+   "label": "Get Outstanding Invoices"
+  },
+  {
+   "depends_on": "eval:doc.docstatus==0",
+   "fieldname": "get_outstanding_orders",
+   "fieldtype": "Button",
+   "label": "Get Outstanding Orders"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-02-14 04:52:30.478523",
+ "modified": "2023-06-19 11:38:04.387219",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Entry",

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -174,7 +174,6 @@ class PaymentEntry(AccountsController):
 				"party_account": self.paid_from if self.payment_type == "Receive" else self.paid_to,
 				"get_outstanding_invoices": True,
 				"get_orders_to_be_billed": True,
-				"get_negative_outstanding_invoices": True,
 			}
 		)
 

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -172,6 +172,9 @@ class PaymentEntry(AccountsController):
 				"payment_type": self.payment_type,
 				"party": self.party,
 				"party_account": self.paid_from if self.payment_type == "Receive" else self.paid_to,
+				"get_outstanding_invoices": True,
+				"get_orders_to_be_billed": True,
+				"get_negative_outstanding_invoices": True,
 			}
 		)
 
@@ -196,7 +199,7 @@ class PaymentEntry(AccountsController):
 			):
 				frappe.throw(
 					_(
-						"{0} {1} has already been partly paid. Please use the 'Get Outstanding Invoice' button to get the latest outstanding amount."
+						"{0} {1} has already been partly paid. Please use the 'Get Outstanding Invoice' or the 'Get Outstanding Orders' button to get the latest outstanding amounts."
 					).format(d.reference_doctype, d.reference_name)
 				)
 
@@ -1356,62 +1359,75 @@ def get_outstanding_reference_documents(args):
 		condition += " and company = {0}".format(frappe.db.escape(args.get("company")))
 		common_filter.append(ple.company == args.get("company"))
 
-	outstanding_invoices = get_outstanding_invoices(
-		args.get("party_type"),
-		args.get("party"),
-		args.get("party_account"),
-		common_filter=common_filter,
-		posting_date=posting_and_due_date,
-		min_outstanding=args.get("outstanding_amt_greater_than"),
-		max_outstanding=args.get("outstanding_amt_less_than"),
-		accounting_dimensions=accounting_dimensions_filter,
-	)
-
-	outstanding_invoices = split_invoices_based_on_payment_terms(outstanding_invoices)
-
-	for d in outstanding_invoices:
-		d["exchange_rate"] = 1
-		if party_account_currency != company_currency:
-			if d.voucher_type in frappe.get_hooks("invoice_doctypes"):
-				d["exchange_rate"] = frappe.db.get_value(d.voucher_type, d.voucher_no, "conversion_rate")
-			elif d.voucher_type == "Journal Entry":
-				d["exchange_rate"] = get_exchange_rate(
-					party_account_currency, company_currency, d.posting_date
-				)
-		if d.voucher_type in ("Purchase Invoice"):
-			d["bill_no"] = frappe.db.get_value(d.voucher_type, d.voucher_no, "bill_no")
-
-	# Get all SO / PO which are not fully billed or against which full advance not paid
-	orders_to_be_billed = []
-	orders_to_be_billed = get_orders_to_be_billed(
-		args.get("posting_date"),
-		args.get("party_type"),
-		args.get("party"),
-		args.get("company"),
-		party_account_currency,
-		company_currency,
-		filters=args,
-	)
-
-	# Get negative outstanding sales /purchase invoices
+	outstanding_invoices = []
 	negative_outstanding_invoices = []
-	if args.get("party_type") != "Employee" and not args.get("voucher_no"):
-		negative_outstanding_invoices = get_negative_outstanding_invoices(
+
+	if args.get("get_outstanding_invoices"):
+		outstanding_invoices = get_outstanding_invoices(
 			args.get("party_type"),
 			args.get("party"),
 			args.get("party_account"),
+			common_filter=common_filter,
+			posting_date=posting_and_due_date,
+			min_outstanding=args.get("outstanding_amt_greater_than"),
+			max_outstanding=args.get("outstanding_amt_less_than"),
+			accounting_dimensions=accounting_dimensions_filter,
+		)
+
+		outstanding_invoices = split_invoices_based_on_payment_terms(outstanding_invoices)
+
+		for d in outstanding_invoices:
+			d["exchange_rate"] = 1
+			if party_account_currency != company_currency:
+				if d.voucher_type in frappe.get_hooks("invoice_doctypes"):
+					d["exchange_rate"] = frappe.db.get_value(d.voucher_type, d.voucher_no, "conversion_rate")
+				elif d.voucher_type == "Journal Entry":
+					d["exchange_rate"] = get_exchange_rate(
+						party_account_currency, company_currency, d.posting_date
+					)
+			if d.voucher_type in ("Purchase Invoice"):
+				d["bill_no"] = frappe.db.get_value(d.voucher_type, d.voucher_no, "bill_no")
+
+		# Get negative outstanding sales /purchase invoices
+		if args.get("party_type") != "Employee" and not args.get("voucher_no"):
+			negative_outstanding_invoices = get_negative_outstanding_invoices(
+				args.get("party_type"),
+				args.get("party"),
+				args.get("party_account"),
+				party_account_currency,
+				company_currency,
+				condition=condition,
+			)
+
+	# Get all SO / PO which are not fully billed or against which full advance not paid
+	orders_to_be_billed = []
+	if args.get("get_orders_to_be_billed"):
+		orders_to_be_billed = get_orders_to_be_billed(
+			args.get("posting_date"),
+			args.get("party_type"),
+			args.get("party"),
+			args.get("company"),
 			party_account_currency,
 			company_currency,
-			condition=condition,
+			filters=args,
 		)
 
 	data = negative_outstanding_invoices + outstanding_invoices + orders_to_be_billed
 
 	if not data:
+		if args.get("get_outstanding_invoices") and args.get("get_orders_to_be_billed"):
+			ref_document_type = "invoices or orders"
+		elif args.get("get_outstanding_invoices"):
+			ref_document_type = "invoices"
+		elif args.get("get_orders_to_be_billed"):
+			ref_document_type = "orders"
+
 		frappe.msgprint(
 			_(
-				"No outstanding invoices found for the {0} {1} which qualify the filters you have specified."
-			).format(_(args.get("party_type")).lower(), frappe.bold(args.get("party")))
+				"No outstanding {0} found for the {1} {2} which qualify the filters you have specified."
+			).format(
+				ref_document_type, _(args.get("party_type")).lower(), frappe.bold(args.get("party"))
+			)
 		)
 
 	return data


### PR DESCRIPTION
Problem:

The `Get Outstanding Invoices` button in `Payment Entry` fetches both invoices and orders which is confusing.

Solution:

Provide two buttons -- `Get Outstanding Invoices` and `Get Outstanding Orders`.

![image](https://github.com/frappe/erpnext/assets/2698932/20cca13e-df16-4bc1-b4df-3f86aead515d)
