### PR TITLE
fix: make credit note and debit note exclusive

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
@@ -320,6 +320,7 @@
   },
   {
    "default": "0",
+   "depends_on": "eval: !doc.is_debit_note",
    "fieldname": "is_return",
    "fieldtype": "Check",
    "hide_days": 1,
@@ -1960,6 +1961,7 @@
   },
   {
    "default": "0",
+   "depends_on": "eval: !doc.is_return",
    "description": "Issue a debit note with 0 qty against an existing Sales Invoice",
    "fieldname": "is_debit_note",
    "fieldtype": "Check",
@@ -2155,7 +2157,7 @@
    "link_fieldname": "consolidated_invoice"
   }
  ],
- "modified": "2023-06-03 16:22:16.219333",
+ "modified": "2023-06-19 16:02:05.309332",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice",


### PR DESCRIPTION
## Before

- The user was able to select Is Rate Adjustment Entry and Is Return together.
- Closes: https://github.com/resilient-tech/india-compliance/issues/757 

## After

https://github.com/frappe/erpnext/assets/10496564/0f735b70-1369-4f68-a3b8-a23c226c8a5e

