### PR TITLE
feat: Provision to send Accounts Receivable Reports using Process SOA

### DIFF
--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.html
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.html
@@ -1,6 +1,6 @@
 <div class="page-break">
 	<div id="header-html" class="hidden-pdf">
-		{% if letter_head %}
+		{% if letter_head.content %}
 		<div class="letter-head text-center">{{ letter_head.content }}</div>
 		<hr style="height:2px;border-width:0;color:black;background-color:black;">
 		{% endif %}

--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.js
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.js
@@ -65,6 +65,20 @@ frappe.ui.form.on('Process Statement Of Accounts', {
 			frm.set_value('to_date', frappe.datetime.get_today());
 		}
 	},
+	report: function(frm){
+		let filters = {
+			'company': frm.doc.company,
+		}
+		if(frm.doc.report == 'Accounts Receivable'){
+			filters['account_type'] = 'Receivable';
+		}
+		frm.set_query("account", function() {
+			return {
+				filters: filters
+			};
+		});
+
+	},
 	customer_collection: function(frm){
 		frm.set_value('collection_name', '');
 		if(frm.doc.customer_collection){

--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
@@ -326,7 +326,8 @@
    "fieldname": "report",
    "fieldtype": "Select",
    "label": "Report",
-   "options": "General Ledger\nAccounts Receivable"
+   "options": "General Ledger\nAccounts Receivable",
+   "reqd": 1
   },
   {
    "default": "Today",
@@ -372,7 +373,7 @@
   }
  ],
  "links": [],
- "modified": "2023-06-19 18:37:10.040570",
+ "modified": "2023-06-23 10:13:15.051950",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Process Statement Of Accounts",

--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
@@ -6,17 +6,24 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
+  "report",
   "section_break_11",
   "from_date",
+  "posting_date",
   "company",
   "account",
   "group_by",
   "cost_center",
+  "territory",
   "column_break_14",
   "to_date",
   "finance_book",
   "currency",
   "project",
+  "payment_terms_template",
+  "sales_partner",
+  "sales_person",
+  "based_on_payment_terms",
   "section_break_3",
   "customer_collection",
   "collection_name",
@@ -67,14 +74,14 @@
    "reqd": 1
   },
   {
-   "depends_on": "eval:doc.enable_auto_email == 0;",
+   "depends_on": "eval:(doc.enable_auto_email == 0 && doc.report == 'General Ledger');",
    "fieldname": "from_date",
    "fieldtype": "Date",
    "label": "From Date",
    "mandatory_depends_on": "eval:doc.frequency == '';"
   },
   {
-   "depends_on": "eval:doc.enable_auto_email == 0;",
+   "depends_on": "eval:(doc.enable_auto_email == 0 && doc.report == 'General Ledger');",
    "fieldname": "to_date",
    "fieldtype": "Date",
    "label": "To Date",
@@ -87,6 +94,7 @@
    "options": "PSOA Cost Center"
   },
   {
+   "depends_on": "eval: (doc.report == 'General Ledger');",
    "fieldname": "project",
    "fieldtype": "Table MultiSelect",
    "label": "Project",
@@ -104,7 +112,7 @@
   {
    "fieldname": "section_break_11",
    "fieldtype": "Section Break",
-   "label": "General Ledger Filters"
+   "label": "Report Filters"
   },
   {
    "fieldname": "column_break_14",
@@ -164,12 +172,14 @@
   },
   {
    "default": "Group by Voucher (Consolidated)",
+   "depends_on": "eval:(doc.report == 'General Ledger');",
    "fieldname": "group_by",
    "fieldtype": "Select",
    "label": "Group By",
    "options": "\nGroup by Voucher\nGroup by Voucher (Consolidated)"
   },
   {
+   "depends_on": "eval: (doc.report == 'General Ledger');",
    "fieldname": "currency",
    "fieldtype": "Link",
    "label": "Currency",
@@ -297,6 +307,7 @@
   },
   {
    "default": "0",
+   "depends_on": "eval: (doc.report == 'General Ledger');",
    "fieldname": "show_net_values_in_party_account",
    "fieldtype": "Check",
    "label": "Show Net Values in Party Account"
@@ -310,10 +321,58 @@
   {
    "fieldname": "column_break_ocfq",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "report",
+   "fieldtype": "Select",
+   "label": "Report",
+   "options": "General Ledger\nAccounts Receivable"
+  },
+  {
+   "default": "Today",
+   "depends_on": "eval:(doc.report == 'Accounts Receivable');",
+   "fieldname": "posting_date",
+   "fieldtype": "Date",
+   "label": "Posting Date"
+  },
+  {
+   "depends_on": "eval: (doc.report == 'Accounts Receivable');",
+   "fieldname": "payment_terms_template",
+   "fieldtype": "Link",
+   "label": "Payment Terms Template",
+   "options": "Payment Terms Template"
+  },
+  {
+   "depends_on": "eval: (doc.report == 'Accounts Receivable');",
+   "fieldname": "sales_partner",
+   "fieldtype": "Link",
+   "label": "Sales Partner",
+   "options": "Sales Partner"
+  },
+  {
+   "depends_on": "eval: (doc.report == 'Accounts Receivable');",
+   "fieldname": "sales_person",
+   "fieldtype": "Link",
+   "label": "Sales Person",
+   "options": "Sales Person"
+  },
+  {
+   "depends_on": "eval: (doc.report == 'Accounts Receivable');",
+   "fieldname": "territory",
+   "fieldtype": "Link",
+   "label": "Territory",
+   "options": "Territory"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:(doc.report == 'Accounts Receivable');",
+   "fieldname": "based_on_payment_terms",
+   "fieldtype": "Check",
+   "label": "Based On Payment Terms"
   }
  ],
  "links": [],
- "modified": "2023-04-26 12:46:43.645455",
+ "modified": "2023-06-19 18:37:10.040570",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Process Statement Of Accounts",

--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
@@ -15,6 +15,7 @@ from frappe.www.printview import get_print_style
 
 from erpnext import get_company_currency
 from erpnext.accounts.party import get_party_account_currency
+from erpnext.accounts.report.accounts_receivable.accounts_receivable import execute as get_ar_soa
 from erpnext.accounts.report.accounts_receivable_summary.accounts_receivable_summary import (
 	execute as get_ageing,
 )
@@ -43,29 +44,10 @@ class ProcessStatementOfAccounts(Document):
 def get_report_pdf(doc, consolidated=True):
 	statement_dict = {}
 	ageing = ""
-	base_template_path = "frappe/www/printview.html"
-	template_path = (
-		"erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.html"
-	)
 
 	for entry in doc.customers:
 		if doc.include_ageing:
-			ageing_filters = frappe._dict(
-				{
-					"company": doc.company,
-					"report_date": doc.to_date,
-					"ageing_based_on": doc.ageing_based_on,
-					"range1": 30,
-					"range2": 60,
-					"range3": 90,
-					"range4": 120,
-					"customer": entry.customer,
-				}
-			)
-			col1, ageing = get_ageing(ageing_filters)
-
-			if ageing:
-				ageing[0]["ageing_based_on"] = doc.ageing_based_on
+			ageing = set_ageing(doc, entry)
 
 		tax_id = frappe.get_doc("Customer", entry.customer).tax_id
 		presentation_currency = (
@@ -73,60 +55,25 @@ def get_report_pdf(doc, consolidated=True):
 			or doc.currency
 			or get_company_currency(doc.company)
 		)
-		if doc.letter_head:
-			from frappe.www.printview import get_letter_head
 
-			letter_head = get_letter_head(doc, 0)
+		filters = get_common_filters(doc)
 
-		filters = frappe._dict(
-			{
-				"from_date": doc.from_date,
-				"to_date": doc.to_date,
-				"company": doc.company,
-				"finance_book": doc.finance_book if doc.finance_book else None,
-				"account": [doc.account] if doc.account else None,
-				"party_type": "Customer",
-				"party": [entry.customer],
-				"party_name": [entry.customer_name] if entry.customer_name else None,
-				"presentation_currency": presentation_currency,
-				"group_by": doc.group_by,
-				"currency": doc.currency,
-				"cost_center": [cc.cost_center_name for cc in doc.cost_center],
-				"project": [p.project_name for p in doc.project],
-				"show_opening_entries": 0,
-				"include_default_book_entries": 0,
-				"tax_id": tax_id if tax_id else None,
-				"show_net_values_in_party_account": doc.show_net_values_in_party_account,
-			}
-		)
-		col, res = get_soa(filters)
+		if doc.report == "General Ledger":
+			filters.update(get_gl_filters(doc, entry, tax_id, presentation_currency))
+		else:
+			filters.update(get_ar_filters(doc, entry))
 
-		for x in [0, -2, -1]:
-			res[x]["account"] = res[x]["account"].replace("'", "")
+		if doc.report == "General Ledger":
+			col, res = get_soa(filters)
+			for x in [0, -2, -1]:
+				res[x]["account"] = res[x]["account"].replace("'", "")
+			if len(res) == 3:
+				continue
+		else:
+			ar_res = get_ar_soa(filters)
+			col, res = ar_res[0], ar_res[1]
 
-		if len(res) == 3:
-			continue
-
-		html = frappe.render_template(
-			template_path,
-			{
-				"filters": filters,
-				"data": res,
-				"ageing": ageing[0] if (doc.include_ageing and ageing) else None,
-				"letter_head": letter_head if doc.letter_head else None,
-				"terms_and_conditions": frappe.db.get_value(
-					"Terms and Conditions", doc.terms_and_conditions, "terms"
-				)
-				if doc.terms_and_conditions
-				else None,
-			},
-		)
-
-		html = frappe.render_template(
-			base_template_path,
-			{"body": html, "css": get_print_style(), "title": "Statement For " + entry.customer},
-		)
-		statement_dict[entry.customer] = html
+		statement_dict[entry.customer] = get_html(doc, filters, entry, col, res, ageing)
 
 	if not bool(statement_dict):
 		return False
@@ -138,6 +85,110 @@ def get_report_pdf(doc, consolidated=True):
 		for customer, statement_html in statement_dict.items():
 			statement_dict[customer] = get_pdf(statement_html, {"orientation": doc.orientation})
 		return statement_dict
+
+
+def set_ageing(doc, entry):
+	ageing_filters = frappe._dict(
+		{
+			"company": doc.company,
+			"report_date": doc.to_date,
+			"ageing_based_on": doc.ageing_based_on,
+			"range1": 30,
+			"range2": 60,
+			"range3": 90,
+			"range4": 120,
+			"customer": entry.customer,
+		}
+	)
+	col1, ageing = get_ageing(ageing_filters)
+
+	if ageing:
+		ageing[0]["ageing_based_on"] = doc.ageing_based_on
+
+	return ageing
+
+
+def get_common_filters(doc):
+	return frappe._dict(
+		{
+			"company": doc.company,
+			"finance_book": doc.finance_book if doc.finance_book else None,
+			"account": [doc.account] if doc.account else None,
+			"cost_center": [cc.cost_center_name for cc in doc.cost_center],
+		}
+	)
+
+
+def get_gl_filters(doc, entry, tax_id, presentation_currency):
+	return {
+		"from_date": doc.from_date,
+		"to_date": doc.to_date,
+		"party_type": "Customer",
+		"party": [entry.customer],
+		"party_name": [entry.customer_name] if entry.customer_name else None,
+		"presentation_currency": presentation_currency,
+		"group_by": doc.group_by,
+		"currency": doc.currency,
+		"project": [p.project_name for p in doc.project],
+		"show_opening_entries": 0,
+		"include_default_book_entries": 0,
+		"tax_id": tax_id if tax_id else None,
+		"show_net_values_in_party_account": doc.show_net_values_in_party_account,
+	}
+
+
+def get_ar_filters(doc, entry):
+	return {
+		"report_date": doc.posting_date if doc.posting_date else None,
+		"customer_name": entry.customer,
+		"payment_terms_template": doc.payment_terms_template if doc.payment_terms_template else None,
+		"sales_partner": doc.sales_partner if doc.sales_partner else None,
+		"sales_person": doc.sales_person if doc.sales_person else None,
+		"territory": doc.territory if doc.territory else None,
+		"based_on_payment_terms": doc.based_on_payment_terms,
+		"report_name": "Accounts Receivable",
+		"ageing_based_on": doc.ageing_based_on,
+		"range1": 30,
+		"range2": 60,
+		"range3": 90,
+		"range4": 120,
+	}
+
+
+def get_html(doc, filters, entry, col, res, ageing):
+	base_template_path = "frappe/www/printview.html"
+	template_path = (
+		"erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.html"
+		if doc.report == "General Ledger"
+		else "erpnext/accounts/report/accounts_receivable/accounts_receivable.html"
+	)
+
+	if doc.letter_head:
+		from frappe.www.printview import get_letter_head
+
+		letter_head = get_letter_head(doc, 0)
+
+	html = frappe.render_template(
+		template_path,
+		{
+			"filters": filters,
+			"data": res,
+			"report": {"report_name": doc.report, "columns": col},
+			"ageing": ageing[0] if (doc.include_ageing and ageing) else None,
+			"letter_head": letter_head if doc.letter_head else None,
+			"terms_and_conditions": frappe.db.get_value(
+				"Terms and Conditions", doc.terms_and_conditions, "terms"
+			)
+			if doc.terms_and_conditions
+			else None,
+		},
+	)
+
+	html = frappe.render_template(
+		base_template_path,
+		{"body": html, "css": get_print_style(), "title": "Statement For " + entry.customer},
+	)
+	return html
 
 
 def get_customers_based_on_territory_or_customer_group(customer_collection, collection_name):

--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
@@ -160,7 +160,7 @@ def get_html(doc, filters, entry, col, res, ageing):
 	template_path = (
 		"erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.html"
 		if doc.report == "General Ledger"
-		else "erpnext/accounts/report/accounts_receivable/accounts_receivable.html"
+		else "erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html"
 	)
 
 	if doc.letter_head:

--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html
@@ -1,0 +1,348 @@
+<style>
+	.print-format {
+		padding: 4mm;
+		font-size: 8.0pt !important;
+	}
+	.print-format td {
+		vertical-align:middle !important;
+	}
+	</style>
+
+	<h2 class="text-center" style="margin-top:0">{{ _(report.report_name) }}</h2>
+	<h4 class="text-center">
+		{% if (filters.customer_name) %}
+			{{ filters.customer_name }}
+		{% else %}
+			{{ filters.customer ~ filters.supplier }}
+		{% endif %}
+	</h4>
+	<h6 class="text-center">
+			{% if (filters.tax_id) %}
+			{{ _("Tax Id: ") }}{{ filters.tax_id }}
+			{% endif %}
+	</h6>
+	<h5 class="text-center">
+		{{ _(filters.ageing_based_on) }}
+		{{ _("Until") }}
+		{{ frappe.format(filters.report_date, 'Date') }}
+	</h5>
+
+	<div class="clearfix">
+		<div class="pull-left">
+		{% if(filters.payment_terms) %}
+			<strong>{{ _("Payment Terms") }}:</strong> {{ filters.payment_terms }}
+		{% endif %}
+		</div>
+		<div class="pull-right">
+		{% if(filters.credit_limit) %}
+			<strong>{{ _("Credit Limit") }}:</strong> {{ frappe.utils.fmt_money(filters.credit_limit) }}
+		{% endif %}
+		</div>
+	</div>
+
+	{% if(filters.show_future_payments) %}
+		{% set balance_row = data.slice(-1).pop() %}
+		{% for i in report.columns %}
+			{% if i.fieldname == 'age' %}
+				{% set elem = i %}
+			{% endif %}
+		{% endfor %}
+		{% set start = report.columns.findIndex(elem) %}
+		{% set range1 = report.columns[start].label %}
+		{% set range2 = report.columns[start+1].label %}
+		{% set range3 = report.columns[start+2].label %}
+		{% set range4 = report.columns[start+3].label %}
+		{% set range5 = report.columns[start+4].label %}
+		{% set range6 = report.columns[start+5].label %}
+
+		{% if(balance_row) %}
+		<table class="table table-bordered table-condensed">
+			<caption class="text-right">(Amount in {{ data[0]["currency"] ~ "" }})</caption>
+				<colgroup>
+					<col style="width: 30mm;">
+					<col style="width: 18mm;">
+					<col style="width: 18mm;">
+					<col style="width: 18mm;">
+					<col style="width: 18mm;">
+					<col style="width: 18mm;">
+					<col style="width: 18mm;">
+					<col style="width: 18mm;">
+				</colgroup>
+
+			<thead>
+				<tr>
+					<th>{{ _(" ") }}</th>
+					<th>{{ _(range1) }}</th>
+					<th>{{ _(range2) }}</th>
+					<th>{{ _(range3) }}</th>
+					<th>{{ _(range4) }}</th>
+					<th>{{ _(range5) }}</th>
+					<th>{{ _(range6) }}</th>
+					<th>{{ _("Total") }}</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>{{ _("Total Outstanding") }}</td>
+					<td class="text-right">
+						{{ format_number(balance_row["age"], null, 2) }}
+					</td>
+					<td class="text-right">
+						{{ frappe.utils.fmt_money(balance_row["range1"], data[data.length-1]["currency"]) }}
+					</td>
+					<td class="text-right">
+						{{ frappe.utils.fmt_money(balance_row["range2"], data[data.length-1]["currency"]) }}
+					</td>
+					<td class="text-right">
+						{{ frappe.utils.fmt_money(balance_row["range3"], data[data.length-1]["currency"]) }}
+					</td>
+					<td class="text-right">
+						{{ frappe.utils.fmt_money(balance_row["range4"], data[data.length-1]["currency"]) }}
+					</td>
+					<td class="text-right">
+						{{ frappe.utils.fmt_money(balance_row["range5"], data[data.length-1]["currency"]) }}
+					</td>
+					<td class="text-right">
+						{{ frappe.utils.fmt_money(flt(balance_row["outstanding"]), data[data.length-1]["currency"]) }}
+					</td>
+				</tr>
+					<td>{{ _("Future Payments") }}</td>
+					<td></td>
+					<td></td>
+					<td></td>
+					<td></td>
+					<td></td>
+					<td></td>
+					<td class="text-right">
+						{{ frappe.utils.fmt_money(flt(balance_row[("future_amount")]), data[data.length-1]["currency"]) }}
+					</td>
+				<tr class="cvs-footer">
+					<th class="text-left">{{ _("Cheques Required") }}</th>
+					<th></th>
+					<th></th>
+					<th></th>
+					<th></th>
+					<th></th>
+					<th></th>
+					<th class="text-right">
+						{{ frappe.utils.fmt_money(flt(balance_row["outstanding"] - balance_row[("future_amount")]), data[data.length-1]["currency"]) }}</th>
+				</tr>
+			</tbody>
+
+		</table>
+		{% endif %}
+	{% endif %}
+	<table class="table table-bordered">
+		<thead>
+			<tr>
+				{% if(report.report_name == "Accounts Receivable" or report.report_name == "Accounts Payable") %}
+					<th style="width: 10%">{{ _("Date") }}</th>
+					<th style="width: 4%">{{ _("Age (Days)") }}</th>
+
+					{% if(report.report_name == "Accounts Receivable" and filters.show_sales_person) %}
+						<th style="width: 14%">{{ _("Reference") }}</th>
+						<th style="width: 10%">{{ _("Sales Person") }}</th>
+					{% else %}
+						<th style="width: 24%">{{ _("Reference") }}</th>
+					{% endif %}
+					{% if not(filters.show_future_payments) %}
+						<th style="width: 20%">
+						{% if (filters.customer or filters.supplier or filters.customer_name) %}
+							{{ _("Remarks") }}
+						{% else %}
+							{{ _("Party") }}
+						{% endif %}
+						</th>
+					{% endif %}
+					<th style="width: 10%; text-align: right">{{ _("Invoiced Amount") }}</th>
+					{% if not(filters.show_future_payments) %}
+						<th style="width: 10%; text-align: right">{{ _("Paid Amount") }}</th>
+						<th style="width: 10%; text-align: right">
+							{% if report.report_name == "Accounts Receivable" %}
+								{{ _('Credit Note') }}
+							{% else %}
+								{{ _('Debit Note') }}
+							{% endif %}
+						</th>
+					{% endif %}
+					<th style="width: 10%; text-align: right">{{ _("Outstanding Amount") }}</th>
+					{% if(filters.show_future_payments) %}
+						{% if(report.report_name == "Accounts Receivable") %}
+							<th style="width: 12%">{{ _("Customer LPO No.") }}</th>
+						{% endif %}
+						<th style="width: 10%">{{ _("Future Payment Ref") }}</th>
+						<th style="width: 10%">{{ _("Future Payment Amount") }}</th>
+						<th style="width: 10%">{{ _("Remaining Balance") }}</th>
+					{% endif %}
+				{% else %}
+					<th style="width: 40%">
+						{% if (filters.customer or filters.supplier or filters.customer_name) %}
+							{{ _("Remarks")}}
+						{% else %}
+							{{ _("Party") }}
+						{% endif %}
+					</th>
+					<th style="width: 15%">{{ _("Total Invoiced Amount") }}</th>
+					<th style="width: 15%">{{ _("Total Paid Amount") }}</th>
+					<th style="width: 15%">
+						{% if report.report_name == "Accounts Receivable Summary" %}
+							{{ _('Credit Note Amount') }}
+						{% else %}
+							{{ _('Debit Note Amount') }}
+						{% endif %}
+					</th>
+					<th style="width: 15%">{{ _("Total Outstanding Amount") }}</th>
+				{% endif %}
+			</tr>
+		</thead>
+		<tbody>
+			{% for i in range(data|length) %}
+				<tr>
+				{% if(report.report_name == "Accounts Receivable" or report.report_name == "Accounts Payable") %}
+					{% if(data[i]["party"]) %}
+						<td>{{ (data[i]["posting_date"]) }}</td>
+						<td style="text-align: right">{{ data[i]["age"] }}</td>
+						<td>
+							{% if not(filters.show_future_payments) %}
+								{{ data[i]["voucher_type"] }}
+								<br>
+							{% endif %}
+							{{ data[i]["voucher_no"] }}
+						</td>
+
+						{% if(report.report_name == "Accounts Receivable" and filters.show_sales_person) %}
+						<td>{{ data[i]["sales_person"] }}</td>
+						{% endif %}
+
+						{% if not (filters.show_future_payments) %}
+						<td>
+							{% if(not(filters.customer or filters.supplier or filters.customer_name)) %}
+								{{ data[i]["party"] }}
+								{% if(data[i]["customer_name"] and data[i]["customer_name"] != data[i]["party"]) %}
+									<br> {{ data[i]["customer_name"] }}
+								{% elif(data[i]["supplier_name"] != data[i]["party"]) %}
+									<br> {{ data[i]["supplier_name"] }}
+								{% endif %}
+							{% endif %}
+							<div>
+							{% if data[i]["remarks"] %}
+								{{ _("Remarks") }}:
+								{{ data[i]["remarks"] }}
+							{% endif %}
+							</div>
+						</td>
+						{% endif %}
+
+						<td style="text-align: right">
+							{{ frappe.utils.fmt_money(data[i]["invoiced"], currency=data[i]["currency"]) }}</td>
+
+						{% if not(filters.show_future_payments) %}
+							<td style="text-align: right">
+								{{ frappe.utils.fmt_money(data[i]["paid"], currency=data[i]["currency"]) }}</td>
+							<td style="text-align: right">
+								{{ frappe.utils.fmt_money(data[i]["credit_note"], currency=data[i]["currency"]) }}</td>
+						{% endif %}
+						<td style="text-align: right">
+							{{ frappe.utils.fmt_money(data[i]["outstanding"], currency=data[i]["currency"]) }}</td>
+
+						{% if(filters.show_future_payments) %}
+							{% if(report.report_name == "Accounts Receivable") %}
+								<td style="text-align: right">
+									{{ data[i]["po_no"] }}</td>
+							{% endif %}
+							<td style="text-align: right">{{ data[i]["future_ref"] }}</td>
+							<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["future_amount"], currency=data[i]["currency"]) }}</td>
+							<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["remaining_balance"], currency=data[i]["currency"]) }}</td>
+						{% endif %}
+					{% else %}
+						<td></td>
+						{% if not(filters.show_future_payments) %}
+						<td></td>
+						{% endif %}
+						{% if(report.report_name == "Accounts Receivable" and filters.show_sales_person) %}
+						<td></td>
+						{% endif %}
+						<td></td>
+						<td style="text-align: right"><b>{{ _("Total") }}</b></td>
+						<td style="text-align: right">
+							{{ frappe.utils.fmt_money(data[i]["invoiced"], data[i]["currency"]) }}</td>
+
+						{% if not(filters.show_future_payments) %}
+							<td style="text-align: right">
+								{{ frappe.utils.fmt_money(data[i]["paid"], currency=data[i]["currency"]) }}</td>
+							<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["credit_note"], currency=data[i]["currency"]) }} </td>
+						{% endif %}
+						<td style="text-align: right">
+							{{ frappe.utils.fmt_money(data[i]["outstanding"], currency=data[i]["currency"]) }}</td>
+
+						{% if(filters.show_future_payments) %}
+							{% if(report.report_name == "Accounts Receivable") %}
+								<td style="text-align: right">
+									{{ data[i]["po_no"] }}</td>
+							{% endif %}
+							<td style="text-align: right">{{ data[i]["future_ref"] }}</td>
+							<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["future_amount"], currency=data[i]["currency"]) }}</td>
+							<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["remaining_balance"], currency=data[i]["currency"]) }}</td>
+						{% endif %}
+					{% endif %}
+				{% else %}
+					{% if(data[i]["party"] or "&nbsp;") %}
+						{% if not(data[i]["is_total_row"]) %}
+							<td>
+								{% if(not(filters.customer | filters.supplier)) %}
+									{{ data[i]["party"] }}
+									{% if(data[i]["customer_name"] and data[i]["customer_name"] != data[i]["party"]) %}
+										<br> {{ data[i]["customer_name"] }}
+									{% elif(data[i]["supplier_name"] != data[i]["party"]) %}
+										<br> {{ data[i]["supplier_name"] }}
+									{% endif %}
+								{% endif %}
+								<br>{{ _("Remarks") }}:
+								{{ data[i]["remarks"] }}
+							</td>
+						{% else %}
+							<td><b>{{ _("Total") }}</b></td>
+						{% endif %}
+						<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["invoiced"], currency=data[i]["currency"]) }}</td>
+						<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["paid"], currency=data[i]["currency"]) }}</td>
+						<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["credit_note"], currency=data[i]["currency"]) }}</td>
+						<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["outstanding"], currency=data[i]["currency"]) }}</td>
+					{% endif %}
+				{% endif %}
+				</tr>
+			{% endfor %}
+			<td></td>
+			<td></td>
+			<td></td>
+			<td></td>
+			<td style="text-align: right"><b>{{ frappe.utils.fmt_money(data|sum(attribute="invoiced"), currency=data[0]["currency"]) }}</b></td>
+			<td style="text-align: right"><b>{{ frappe.utils.fmt_money(data|sum(attribute="paid"), currency=data[0]["currency"]) }}</b></td>
+			<td style="text-align: right"><b>{{ frappe.utils.fmt_money(data|sum(attribute="credit_note"), currency=data[0]["currency"]) }}</b></td>
+			<td style="text-align: right"><b>{{ frappe.utils.fmt_money(data|sum(attribute="outstanding"), currency=data[0]["currency"]) }}</b></td>
+		</tbody>
+	</table>
+	<br>
+	{% if ageing %}
+	<h4 class="text-center">{{ _("Ageing Report based on ") }} {{ ageing.ageing_based_on }}
+		{{ _("up to " ) }}  {{ frappe.format(filters.report_date, 'Date')}}
+	</h4>
+	<table class="table table-bordered">
+		<thead>
+			<tr>
+				<th style="width: 25%">30 Days</th>
+				<th style="width: 25%">60 Days</th>
+				<th style="width: 25%">90 Days</th>
+				<th style="width: 25%">120 Days</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td>{{ frappe.utils.fmt_money(ageing.range1, currency=data[0]["currency"]) }}</td>
+				<td>{{ frappe.utils.fmt_money(ageing.range2, currency=data[0]["currency"]) }}</td>
+				<td>{{ frappe.utils.fmt_money(ageing.range3, currency=data[0]["currency"]) }}</td>
+				<td>{{ frappe.utils.fmt_money(ageing.range4, currency=data[0]["currency"]) }}</td>
+			</tr>
+		</tbody>
+	</table>
+	{% endif %}
+	<p class="text-right text-muted">{{ _("Printed On ") }}{{ frappe.utils.now() }}</p>

--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.html
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.html
@@ -8,56 +8,51 @@
 	}
 	</style>
 
-	<h2 class="text-center" style="margin-top:0">{{ _(report.report_name) }}</h2>
+	<h2 class="text-center" style="margin-top:0">{%= __(report.report_name) %}</h2>
 	<h4 class="text-center">
-		{% if (filters.customer_name) %}
-			{{ filters.customer_name }}
-		{% else %}
-			{{ filters.customer ~ filters.supplier }}
-		{% endif %}
+		{% if (filters.customer_name) { %}
+			{%= filters.customer_name %}
+		{% } else { %}
+			{%= filters.customer || filters.supplier %}
+		{% } %}
 	</h4>
 	<h6 class="text-center">
-			{% if (filters.tax_id) %}
-			{{ _("Tax Id: ") }}{{ filters.tax_id }}
-			{% endif %}
+			{% if (filters.tax_id) { %}
+			{%= __("Tax Id: ")%}	{%= filters.tax_id %}
+			{% } %}
 	</h6>
 	<h5 class="text-center">
-		{{ _(filters.ageing_based_on) }}
-		{{ _("Until") }}
-		{{ frappe.format(filters.report_date, 'Date') }}
+		{%= __(filters.ageing_based_on) %}
+		{%= __("Until") %}
+		{%= frappe.datetime.str_to_user(filters.report_date) %}
 	</h5>
 
 	<div class="clearfix">
 		<div class="pull-left">
-		{% if(filters.payment_terms) %}
-			<strong>{{ _("Payment Terms") }}:</strong> {{ filters.payment_terms }}
-		{% endif %}
+		{% if(filters.payment_terms) { %}
+			<strong>{%= __("Payment Terms") %}:</strong> {%= filters.payment_terms %}
+		{% } %}
 		</div>
 		<div class="pull-right">
-		{% if(filters.credit_limit) %}
-			<strong>{{ _("Credit Limit") }}:</strong> {{ frappe.utils.fmt_money(filters.credit_limit) }}
-		{% endif %}
+		{% if(filters.credit_limit) { %}
+			<strong>{%= __("Credit Limit") %}:</strong> {%= format_currency(filters.credit_limit) %}
+		{% } %}
 		</div>
 	</div>
 
-	{% if(filters.show_future_payments) %}
-		{% set balance_row = data.slice(-1).pop() %}
-		{% for i in report.columns %}
-			{% if i.fieldname == 'age' %}
-				{% set elem = i %}
-			{% endif %}
-		{% endfor %}
-		{% set start = report.columns.findIndex(elem) %}
-		{% set range1 = report.columns[start].label %}
-		{% set range2 = report.columns[start+1].label %}
-		{% set range3 = report.columns[start+2].label %}
-		{% set range4 = report.columns[start+3].label %}
-		{% set range5 = report.columns[start+4].label %}
-		{% set range6 = report.columns[start+5].label %}
-
-		{% if(balance_row) %}
+	{% if(filters.show_future_payments) { %}
+		{% var balance_row = data.slice(-1).pop();
+			var start = report.columns.findIndex((elem) => (elem.fieldname == 'age'));
+			var range1 = report.columns[start].label;
+			var range2 = report.columns[start+1].label;
+			var range3 = report.columns[start+2].label;
+			var range4 = report.columns[start+3].label;
+			var range5 = report.columns[start+4].label;
+			var range6 = report.columns[start+5].label;
+		%}
+		{% if(balance_row) { %}
 		<table class="table table-bordered table-condensed">
-			<caption class="text-right">(Amount in {{ data[0]["currency"] ~ "" }})</caption>
+			<caption class="text-right">(Amount in {%= data[0]["currency"] || "" %})</caption>
 				<colgroup>
 					<col style="width: 30mm;">
 					<col style="width: 18mm;">
@@ -71,42 +66,42 @@
 
 			<thead>
 				<tr>
-					<th>{{ _(" ") }}</th>
-					<th>{{ _(range1) }}</th>
-					<th>{{ _(range2) }}</th>
-					<th>{{ _(range3) }}</th>
-					<th>{{ _(range4) }}</th>
-					<th>{{ _(range5) }}</th>
-					<th>{{ _(range6) }}</th>
-					<th>{{ _("Total") }}</th>
+					<th>{%= __(" ") %}</th>
+					<th>{%= __(range1) %}</th>
+					<th>{%= __(range2) %}</th>
+					<th>{%= __(range3) %}</th>
+					<th>{%= __(range4) %}</th>
+					<th>{%= __(range5) %}</th>
+					<th>{%= __(range6) %}</th>
+					<th>{%= __("Total") %}</th>
 				</tr>
 			</thead>
 			<tbody>
 				<tr>
-					<td>{{ _("Total Outstanding") }}</td>
+					<td>{%= __("Total Outstanding") %}</td>
 					<td class="text-right">
-						{{ format_number(balance_row["age"], null, 2) }}
+						{%= format_number(balance_row["age"], null, 2) %}
 					</td>
 					<td class="text-right">
-						{{ frappe.utils.fmt_money(balance_row["range1"], data[data.length-1]["currency"]) }}
+						{%= format_currency(balance_row["range1"], data[data.length-1]["currency"]) %}
 					</td>
 					<td class="text-right">
-						{{ frappe.utils.fmt_money(balance_row["range2"], data[data.length-1]["currency"]) }}
+						{%= format_currency(balance_row["range2"], data[data.length-1]["currency"]) %}
 					</td>
 					<td class="text-right">
-						{{ frappe.utils.fmt_money(balance_row["range3"], data[data.length-1]["currency"]) }}
+						{%= format_currency(balance_row["range3"], data[data.length-1]["currency"]) %}
 					</td>
 					<td class="text-right">
-						{{ frappe.utils.fmt_money(balance_row["range4"], data[data.length-1]["currency"]) }}
+						{%= format_currency(balance_row["range4"], data[data.length-1]["currency"]) %}
 					</td>
 					<td class="text-right">
-						{{ frappe.utils.fmt_money(balance_row["range5"], data[data.length-1]["currency"]) }}
+						{%= format_currency(balance_row["range5"], data[data.length-1]["currency"]) %}
 					</td>
 					<td class="text-right">
-						{{ frappe.utils.fmt_money(flt(balance_row["outstanding"]), data[data.length-1]["currency"]) }}
+						{%= format_currency(flt(balance_row["outstanding"]), data[data.length-1]["currency"]) %}
 					</td>
 				</tr>
-					<td>{{ _("Future Payments") }}</td>
+					<td>{%= __("Future Payments") %}</td>
 					<td></td>
 					<td></td>
 					<td></td>
@@ -114,10 +109,10 @@
 					<td></td>
 					<td></td>
 					<td class="text-right">
-						{{ frappe.utils.fmt_money(flt(balance_row[("future_amount")]), data[data.length-1]["currency"]) }}
+						{%= format_currency(flt(balance_row[("future_amount")]), data[data.length-1]["currency"]) %}
 					</td>
 				<tr class="cvs-footer">
-					<th class="text-left">{{ _("Cheques Required") }}</th>
+					<th class="text-left">{%= __("Cheques Required") %}</th>
 					<th></th>
 					<th></th>
 					<th></th>
@@ -125,224 +120,168 @@
 					<th></th>
 					<th></th>
 					<th class="text-right">
-						{{ frappe.utils.fmt_money(flt(balance_row["outstanding"] - balance_row[("future_amount")]), data[data.length-1]["currency"]) }}</th>
+						{%= format_currency(flt(balance_row["outstanding"] - balance_row[("future_amount")]), data[data.length-1]["currency"]) %}</th>
 				</tr>
 			</tbody>
 
 		</table>
-		{% endif %}
-	{% endif %}
+		{% } %}
+	{% } %}
 	<table class="table table-bordered">
 		<thead>
 			<tr>
-				{% if(report.report_name == "Accounts Receivable" or report.report_name == "Accounts Payable") %}
-					<th style="width: 10%">{{ _("Date") }}</th>
-					<th style="width: 4%">{{ _("Age (Days)") }}</th>
+				{% if(report.report_name === "Accounts Receivable" || report.report_name === "Accounts Payable") { %}
+					<th style="width: 10%">{%= __("Date") %}</th>
+					<th style="width: 4%">{%= __("Age (Days)") %}</th>
 
-					{% if(report.report_name == "Accounts Receivable" and filters.show_sales_person) %}
-						<th style="width: 14%">{{ _("Reference") }}</th>
-						<th style="width: 10%">{{ _("Sales Person") }}</th>
-					{% else %}
-						<th style="width: 24%">{{ _("Reference") }}</th>
-					{% endif %}
-					{% if not(filters.show_future_payments) %}
-						<th style="width: 20%">
-						{% if (filters.customer or filters.supplier or filters.customer_name) %}
-							{{ _("Remarks") }}
-						{% else %}
-							{{ _("Party") }}
-						{% endif %}
-						</th>
-					{% endif %}
-					<th style="width: 10%; text-align: right">{{ _("Invoiced Amount") }}</th>
-					{% if not(filters.show_future_payments) %}
-						<th style="width: 10%; text-align: right">{{ _("Paid Amount") }}</th>
-						<th style="width: 10%; text-align: right">
-							{% if report.report_name == "Accounts Receivable" %}
-								{{ _('Credit Note') }}
-							{% else %}
-								{{ _('Debit Note') }}
-							{% endif %}
-						</th>
-					{% endif %}
-					<th style="width: 10%; text-align: right">{{ _("Outstanding Amount") }}</th>
-					{% if(filters.show_future_payments) %}
-						{% if(report.report_name == "Accounts Receivable") %}
-							<th style="width: 12%">{{ _("Customer LPO No.") }}</th>
-						{% endif %}
-						<th style="width: 10%">{{ _("Future Payment Ref") }}</th>
-						<th style="width: 10%">{{ _("Future Payment Amount") }}</th>
-						<th style="width: 10%">{{ _("Remaining Balance") }}</th>
-					{% endif %}
-				{% else %}
-					<th style="width: 40%">
-						{% if (filters.customer or filters.supplier or filters.customer_name) %}
-							{{ _("Remarks")}}
-						{% else %}
-							{{ _("Party") }}
-						{% endif %}
-					</th>
-					<th style="width: 15%">{{ _("Total Invoiced Amount") }}</th>
-					<th style="width: 15%">{{ _("Total Paid Amount") }}</th>
-					<th style="width: 15%">
-						{% if report.report_name == "Accounts Receivable Summary" %}
-							{{ _('Credit Note Amount') }}
-						{% else %}
-							{{ _('Debit Note Amount') }}
-						{% endif %}
-					</th>
-					<th style="width: 15%">{{ _("Total Outstanding Amount") }}</th>
-				{% endif %}
+					{% if(report.report_name === "Accounts Receivable" && filters.show_sales_person) { %}
+						<th style="width: 14%">{%= __("Reference") %}</th>
+						<th style="width: 10%">{%= __("Sales Person") %}</th>
+					{% } else { %}
+						<th style="width: 24%">{%= __("Reference") %}</th>
+					{% } %}
+					{% if(!filters.show_future_payments) { %}
+						<th style="width: 20%">{%= (filters.customer || filters.supplier) ? __("Remarks"): __("Party") %}</th>
+					{% } %}
+					<th style="width: 10%; text-align: right">{%= __("Invoiced Amount") %}</th>
+					{% if(!filters.show_future_payments) { %}
+						<th style="width: 10%; text-align: right">{%= __("Paid Amount") %}</th>
+						<th style="width: 10%; text-align: right">{%= report.report_name === "Accounts Receivable" ? __('Credit Note') : __('Debit Note') %}</th>
+					{% } %}
+					<th style="width: 10%; text-align: right">{%= __("Outstanding Amount") %}</th>
+					{% if(filters.show_future_payments) { %}
+						{% if(report.report_name === "Accounts Receivable") { %}
+							<th style="width: 12%">{%= __("Customer LPO No.") %}</th>
+						{% } %}
+						<th style="width: 10%">{%= __("Future Payment Ref") %}</th>
+						<th style="width: 10%">{%= __("Future Payment Amount") %}</th>
+						<th style="width: 10%">{%= __("Remaining Balance") %}</th>
+					{% } %}
+				{% } else { %}
+					<th style="width: 40%">{%= (filters.customer || filters.supplier) ? __("Remarks"): __("Party") %}</th>
+					<th style="width: 15%">{%= __("Total Invoiced Amount") %}</th>
+					<th style="width: 15%">{%= __("Total Paid Amount") %}</th>
+					<th style="width: 15%">{%= report.report_name === "Accounts Receivable Summary" ? __('Credit Note Amount') : __('Debit Note Amount') %}</th>
+					<th style="width: 15%">{%= __("Total Outstanding Amount") %}</th>
+				{% } %}
 			</tr>
 		</thead>
 		<tbody>
-			{% for i in range(data|length) %}
+			{% for(var i=0, l=data.length; i<l; i++) { %}
 				<tr>
-				{% if(report.report_name == "Accounts Receivable" or report.report_name == "Accounts Payable") %}
-					{% if(data[i]["party"]) %}
-						<td>{{ (data[i]["posting_date"]) }}</td>
-						<td style="text-align: right">{{ data[i]["age"] }}</td>
+				{% if(report.report_name === "Accounts Receivable" || report.report_name === "Accounts Payable") { %}
+					{% if(data[i]["party"]) { %}
+						<td>{%= frappe.datetime.str_to_user(data[i]["posting_date"]) %}</td>
+						<td style="text-align: right">{%= data[i]["age"] %}</td>
 						<td>
-							{% if not(filters.show_future_payments) %}
-								{{ data[i]["voucher_type"] }}
+							{% if(!filters.show_future_payments) { %}
+								{%= data[i]["voucher_type"] %}
 								<br>
-							{% endif %}
-							{{ data[i]["voucher_no"] }}
+							{% } %}
+							{%= data[i]["voucher_no"] %}
 						</td>
 
-						{% if(report.report_name == "Accounts Receivable" and filters.show_sales_person) %}
-						<td>{{ data[i]["sales_person"] }}</td>
-						{% endif %}
+						{% if(report.report_name === "Accounts Receivable" && filters.show_sales_person) { %}
+						<td>{%= data[i]["sales_person"] %}</td>
+						{% } %}
 
-						{% if not (filters.show_future_payments) %}
+						{% if(!filters.show_future_payments) { %}
 						<td>
-							{% if(not(filters.customer or filters.supplier or filters.customer_name)) %}
-								{{ data[i]["party"] }}
-								{% if(data[i]["customer_name"] and data[i]["customer_name"] != data[i]["party"]) %}
-									<br> {{ data[i]["customer_name"] }}
-								{% elif(data[i]["supplier_name"] != data[i]["party"]) %}
-									<br> {{ data[i]["supplier_name"] }}
-								{% endif %}
-							{% endif %}
+							{% if(!(filters.customer || filters.supplier)) { %}
+								{%= data[i]["party"] %}
+								{% if(data[i]["customer_name"] && data[i]["customer_name"] != data[i]["party"]) { %}
+									<br> {%= data[i]["customer_name"] %}
+								{% } else if(data[i]["supplier_name"] != data[i]["party"]) { %}
+									<br> {%= data[i]["supplier_name"] %}
+								{% } %}
+							{% } %}
 							<div>
 							{% if data[i]["remarks"] %}
-								{{ _("Remarks") }}:
-								{{ data[i]["remarks"] }}
-							{% endif %}
+								{%= __("Remarks") %}:
+								{%= data[i]["remarks"] %}
+							{% } %}
 							</div>
 						</td>
-						{% endif %}
+						{% } %}
 
 						<td style="text-align: right">
-							{{ frappe.utils.fmt_money(data[i]["invoiced"], currency=data[i]["currency"]) }}</td>
+							{%= format_currency(data[i]["invoiced"], data[i]["currency"]) %}</td>
 
-						{% if not(filters.show_future_payments) %}
+						{% if(!filters.show_future_payments) { %}
 							<td style="text-align: right">
-								{{ frappe.utils.fmt_money(data[i]["paid"], currency=data[i]["currency"]) }}</td>
+								{%= format_currency(data[i]["paid"], data[i]["currency"]) %}</td>
 							<td style="text-align: right">
-								{{ frappe.utils.fmt_money(data[i]["credit_note"], currency=data[i]["currency"]) }}</td>
-						{% endif %}
+								{%= format_currency(data[i]["credit_note"], data[i]["currency"]) %}</td>
+						{% } %}
 						<td style="text-align: right">
-							{{ frappe.utils.fmt_money(data[i]["outstanding"], currency=data[i]["currency"]) }}</td>
+							{%= format_currency(data[i]["outstanding"], data[i]["currency"]) %}</td>
 
-						{% if(filters.show_future_payments) %}
-							{% if(report.report_name == "Accounts Receivable") %}
+						{% if(filters.show_future_payments) { %}
+							{% if(report.report_name === "Accounts Receivable") { %}
 								<td style="text-align: right">
-									{{ data[i]["po_no"] }}</td>
-							{% endif %}
-							<td style="text-align: right">{{ data[i]["future_ref"] }}</td>
-							<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["future_amount"], currency=data[i]["currency"]) }}</td>
-							<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["remaining_balance"], currency=data[i]["currency"]) }}</td>
-						{% endif %}
-					{% else %}
+									{%= data[i]["po_no"] %}</td>
+							{% } %}
+							<td style="text-align: right">{%= data[i]["future_ref"] %}</td>
+							<td style="text-align: right">{%= format_currency(data[i]["future_amount"], data[i]["currency"]) %}</td>
+							<td style="text-align: right">{%= format_currency(data[i]["remaining_balance"], data[i]["currency"]) %}</td>
+						{% } %}
+					{% } else { %}
 						<td></td>
-						{% if not(filters.show_future_payments) %}
+						{% if(!filters.show_future_payments) { %}
 						<td></td>
-						{% endif %}
-						{% if(report.report_name == "Accounts Receivable" and filters.show_sales_person) %}
+						{% } %}
+						{% if(report.report_name === "Accounts Receivable" && filters.show_sales_person) { %}
 						<td></td>
-						{% endif %}
+						{% } %}
 						<td></td>
-						<td style="text-align: right"><b>{{ _("Total") }}</b></td>
+						<td style="text-align: right"><b>{%= __("Total") %}</b></td>
 						<td style="text-align: right">
-							{{ frappe.utils.fmt_money(data[i]["invoiced"], data[i]["currency"]) }}</td>
+							{%= format_currency(data[i]["invoiced"], data[i]["currency"] ) %}</td>
 
-						{% if not(filters.show_future_payments) %}
+						{% if(!filters.show_future_payments) { %}
 							<td style="text-align: right">
-								{{ frappe.utils.fmt_money(data[i]["paid"], currency=data[i]["currency"]) }}</td>
-							<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["credit_note"], currency=data[i]["currency"]) }} </td>
-						{% endif %}
+								{%= format_currency(data[i]["paid"], data[i]["currency"]) %}</td>
+							<td style="text-align: right">{%= format_currency(data[i]["credit_note"], data[i]["currency"]) %} </td>
+						{% } %}
 						<td style="text-align: right">
-							{{ frappe.utils.fmt_money(data[i]["outstanding"], currency=data[i]["currency"]) }}</td>
+							{%= format_currency(data[i]["outstanding"], data[i]["currency"]) %}</td>
 
-						{% if(filters.show_future_payments) %}
-							{% if(report.report_name == "Accounts Receivable") %}
+						{% if(filters.show_future_payments) { %}
+							{% if(report.report_name === "Accounts Receivable") { %}
 								<td style="text-align: right">
-									{{ data[i]["po_no"] }}</td>
-							{% endif %}
-							<td style="text-align: right">{{ data[i]["future_ref"] }}</td>
-							<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["future_amount"], currency=data[i]["currency"]) }}</td>
-							<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["remaining_balance"], currency=data[i]["currency"]) }}</td>
-						{% endif %}
-					{% endif %}
-				{% else %}
-					{% if(data[i]["party"] or "&nbsp;") %}
-						{% if not(data[i]["is_total_row"]) %}
+									{%= data[i]["po_no"] %}</td>
+							{% } %}
+							<td style="text-align: right">{%= data[i]["future_ref"] %}</td>
+							<td style="text-align: right">{%= format_currency(data[i]["future_amount"], data[i]["currency"]) %}</td>
+							<td style="text-align: right">{%= format_currency(data[i]["remaining_balance"], data[i]["currency"]) %}</td>
+						{% } %}
+					{% } %}
+				{% } else { %}
+					{% if(data[i]["party"]|| "&nbsp;") { %}
+						{% if(!data[i]["is_total_row"]) { %}
 							<td>
-								{% if(not(filters.customer | filters.supplier)) %}
-									{{ data[i]["party"] }}
-									{% if(data[i]["customer_name"] and data[i]["customer_name"] != data[i]["party"]) %}
-										<br> {{ data[i]["customer_name"] }}
-									{% elif(data[i]["supplier_name"] != data[i]["party"]) %}
-										<br> {{ data[i]["supplier_name"] }}
-									{% endif %}
-								{% endif %}
-								<br>{{ _("Remarks") }}:
-								{{ data[i]["remarks"] }}
+								{% if(!(filters.customer || filters.supplier)) { %}
+									{%= data[i]["party"] %}
+									{% if(data[i]["customer_name"] && data[i]["customer_name"] != data[i]["party"]) { %}
+										<br> {%= data[i]["customer_name"] %}
+									{% } else if(data[i]["supplier_name"] != data[i]["party"]) { %}
+										<br> {%= data[i]["supplier_name"] %}
+									{% } %}
+								{% } %}
+								<br>{%= __("Remarks") %}:
+								{%= data[i]["remarks"] %}
 							</td>
-						{% else %}
-							<td><b>{{ _("Total") }}</b></td>
-						{% endif %}
-						<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["invoiced"], currency=data[i]["currency"]) }}</td>
-						<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["paid"], currency=data[i]["currency"]) }}</td>
-						<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["credit_note"], currency=data[i]["currency"]) }}</td>
-						<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["outstanding"], currency=data[i]["currency"]) }}</td>
-					{% endif %}
-				{% endif %}
+						{% } else { %}
+							<td><b>{%= __("Total") %}</b></td>
+						{% } %}
+						<td style="text-align: right">{%= format_currency(data[i]["invoiced"], data[i]["currency"]) %}</td>
+						<td style="text-align: right">{%= format_currency(data[i]["paid"], data[i]["currency"]) %}</td>
+						<td style="text-align: right">{%= format_currency(data[i]["credit_note"], data[i]["currency"]) %}</td>
+						<td style="text-align: right">{%= format_currency(data[i]["outstanding"], data[i]["currency"]) %}</td>
+					{% } %}
+				{% } %}
 				</tr>
-			{% endfor %}
-			<td></td>
-			<td></td>
-			<td></td>
-			<td></td>
-			<td style="text-align: right"><b>{{ frappe.utils.fmt_money(data|sum(attribute="invoiced"), currency=data[0]["currency"]) }}</b></td>
-			<td style="text-align: right"><b>{{ frappe.utils.fmt_money(data|sum(attribute="paid"), currency=data[0]["currency"]) }}</b></td>
-			<td style="text-align: right"><b>{{ frappe.utils.fmt_money(data|sum(attribute="credit_note"), currency=data[0]["currency"]) }}</b></td>
-			<td style="text-align: right"><b>{{ frappe.utils.fmt_money(data|sum(attribute="outstanding"), currency=data[0]["currency"]) }}</b></td>
+			{% } %}
 		</tbody>
 	</table>
-	<br>
-	{% if ageing %}
-	<h4 class="text-center">{{ _("Ageing Report based on ") }} {{ ageing.ageing_based_on }}
-		{{ _("up to " ) }}  {{ frappe.format(filters.report_date, 'Date')}}
-	</h4>
-	<table class="table table-bordered">
-		<thead>
-			<tr>
-				<th style="width: 25%">30 Days</th>
-				<th style="width: 25%">60 Days</th>
-				<th style="width: 25%">90 Days</th>
-				<th style="width: 25%">120 Days</th>
-			</tr>
-		</thead>
-		<tbody>
-			<tr>
-				<td>{{ frappe.utils.fmt_money(ageing.range1, currency=data[0]["currency"]) }}</td>
-				<td>{{ frappe.utils.fmt_money(ageing.range2, currency=data[0]["currency"]) }}</td>
-				<td>{{ frappe.utils.fmt_money(ageing.range3, currency=data[0]["currency"]) }}</td>
-				<td>{{ frappe.utils.fmt_money(ageing.range4, currency=data[0]["currency"]) }}</td>
-			</tr>
-		</tbody>
-	</table>
-	{% endif %}
-	<p class="text-right text-muted">{{ _("Printed On ") }}{{ frappe.utils.now() }}</p>
+	<p class="text-right text-muted">{{ __("Printed On ") }}{%= frappe.datetime.str_to_user(frappe.datetime.get_datetime_as_string()) %}</p>

--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.html
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.html
@@ -8,51 +8,56 @@
 	}
 	</style>
 
-	<h2 class="text-center" style="margin-top:0">{%= __(report.report_name) %}</h2>
+	<h2 class="text-center" style="margin-top:0">{{ _(report.report_name) }}</h2>
 	<h4 class="text-center">
-		{% if (filters.customer_name) { %}
-			{%= filters.customer_name %}
-		{% } else { %}
-			{%= filters.customer || filters.supplier %}
-		{% } %}
+		{% if (filters.customer_name) %}
+			{{ filters.customer_name }}
+		{% else %}
+			{{ filters.customer ~ filters.supplier }}
+		{% endif %}
 	</h4>
 	<h6 class="text-center">
-			{% if (filters.tax_id) { %}
-			{%= __("Tax Id: ")%}	{%= filters.tax_id %}
-			{% } %}
+			{% if (filters.tax_id) %}
+			{{ _("Tax Id: ") }}{{ filters.tax_id }}
+			{% endif %}
 	</h6>
 	<h5 class="text-center">
-		{%= __(filters.ageing_based_on) %}
-		{%= __("Until") %}
-		{%= frappe.datetime.str_to_user(filters.report_date) %}
+		{{ _(filters.ageing_based_on) }}
+		{{ _("Until") }}
+		{{ frappe.format(filters.report_date, 'Date') }}
 	</h5>
 
 	<div class="clearfix">
 		<div class="pull-left">
-		{% if(filters.payment_terms) { %}
-			<strong>{%= __("Payment Terms") %}:</strong> {%= filters.payment_terms %}
-		{% } %}
+		{% if(filters.payment_terms) %}
+			<strong>{{ _("Payment Terms") }}:</strong> {{ filters.payment_terms }}
+		{% endif %}
 		</div>
 		<div class="pull-right">
-		{% if(filters.credit_limit) { %}
-			<strong>{%= __("Credit Limit") %}:</strong> {%= format_currency(filters.credit_limit) %}
-		{% } %}
+		{% if(filters.credit_limit) %}
+			<strong>{{ _("Credit Limit") }}:</strong> {{ frappe.utils.fmt_money(filters.credit_limit) }}
+		{% endif %}
 		</div>
 	</div>
 
-	{% if(filters.show_future_payments) { %}
-		{% var balance_row = data.slice(-1).pop();
-			var start = report.columns.findIndex((elem) => (elem.fieldname == 'age'));
-			var range1 = report.columns[start].label;
-			var range2 = report.columns[start+1].label;
-			var range3 = report.columns[start+2].label;
-			var range4 = report.columns[start+3].label;
-			var range5 = report.columns[start+4].label;
-			var range6 = report.columns[start+5].label;
-		%}
-		{% if(balance_row) { %}
+	{% if(filters.show_future_payments) %}
+		{% set balance_row = data.slice(-1).pop() %}
+		{% for i in report.columns %}
+			{% if i.fieldname == 'age' %}
+				{% set elem = i %}
+			{% endif %}
+		{% endfor %}
+		{% set start = report.columns.findIndex(elem) %}
+		{% set range1 = report.columns[start].label %}
+		{% set range2 = report.columns[start+1].label %}
+		{% set range3 = report.columns[start+2].label %}
+		{% set range4 = report.columns[start+3].label %}
+		{% set range5 = report.columns[start+4].label %}
+		{% set range6 = report.columns[start+5].label %}
+
+		{% if(balance_row) %}
 		<table class="table table-bordered table-condensed">
-			<caption class="text-right">(Amount in {%= data[0]["currency"] || "" %})</caption>
+			<caption class="text-right">(Amount in {{ data[0]["currency"] ~ "" }})</caption>
 				<colgroup>
 					<col style="width: 30mm;">
 					<col style="width: 18mm;">
@@ -66,42 +71,42 @@
 
 			<thead>
 				<tr>
-					<th>{%= __(" ") %}</th>
-					<th>{%= __(range1) %}</th>
-					<th>{%= __(range2) %}</th>
-					<th>{%= __(range3) %}</th>
-					<th>{%= __(range4) %}</th>
-					<th>{%= __(range5) %}</th>
-					<th>{%= __(range6) %}</th>
-					<th>{%= __("Total") %}</th>
+					<th>{{ _(" ") }}</th>
+					<th>{{ _(range1) }}</th>
+					<th>{{ _(range2) }}</th>
+					<th>{{ _(range3) }}</th>
+					<th>{{ _(range4) }}</th>
+					<th>{{ _(range5) }}</th>
+					<th>{{ _(range6) }}</th>
+					<th>{{ _("Total") }}</th>
 				</tr>
 			</thead>
 			<tbody>
 				<tr>
-					<td>{%= __("Total Outstanding") %}</td>
+					<td>{{ _("Total Outstanding") }}</td>
 					<td class="text-right">
-						{%= format_number(balance_row["age"], null, 2) %}
+						{{ format_number(balance_row["age"], null, 2) }}
 					</td>
 					<td class="text-right">
-						{%= format_currency(balance_row["range1"], data[data.length-1]["currency"]) %}
+						{{ frappe.utils.fmt_money(balance_row["range1"], data[data.length-1]["currency"]) }}
 					</td>
 					<td class="text-right">
-						{%= format_currency(balance_row["range2"], data[data.length-1]["currency"]) %}
+						{{ frappe.utils.fmt_money(balance_row["range2"], data[data.length-1]["currency"]) }}
 					</td>
 					<td class="text-right">
-						{%= format_currency(balance_row["range3"], data[data.length-1]["currency"]) %}
+						{{ frappe.utils.fmt_money(balance_row["range3"], data[data.length-1]["currency"]) }}
 					</td>
 					<td class="text-right">
-						{%= format_currency(balance_row["range4"], data[data.length-1]["currency"]) %}
+						{{ frappe.utils.fmt_money(balance_row["range4"], data[data.length-1]["currency"]) }}
 					</td>
 					<td class="text-right">
-						{%= format_currency(balance_row["range5"], data[data.length-1]["currency"]) %}
+						{{ frappe.utils.fmt_money(balance_row["range5"], data[data.length-1]["currency"]) }}
 					</td>
 					<td class="text-right">
-						{%= format_currency(flt(balance_row["outstanding"]), data[data.length-1]["currency"]) %}
+						{{ frappe.utils.fmt_money(flt(balance_row["outstanding"]), data[data.length-1]["currency"]) }}
 					</td>
 				</tr>
-					<td>{%= __("Future Payments") %}</td>
+					<td>{{ _("Future Payments") }}</td>
 					<td></td>
 					<td></td>
 					<td></td>
@@ -109,10 +114,10 @@
 					<td></td>
 					<td></td>
 					<td class="text-right">
-						{%= format_currency(flt(balance_row[("future_amount")]), data[data.length-1]["currency"]) %}
+						{{ frappe.utils.fmt_money(flt(balance_row[("future_amount")]), data[data.length-1]["currency"]) }}
 					</td>
 				<tr class="cvs-footer">
-					<th class="text-left">{%= __("Cheques Required") %}</th>
+					<th class="text-left">{{ _("Cheques Required") }}</th>
 					<th></th>
 					<th></th>
 					<th></th>
@@ -120,168 +125,224 @@
 					<th></th>
 					<th></th>
 					<th class="text-right">
-						{%= format_currency(flt(balance_row["outstanding"] - balance_row[("future_amount")]), data[data.length-1]["currency"]) %}</th>
+						{{ frappe.utils.fmt_money(flt(balance_row["outstanding"] - balance_row[("future_amount")]), data[data.length-1]["currency"]) }}</th>
 				</tr>
 			</tbody>
 
 		</table>
-		{% } %}
-	{% } %}
+		{% endif %}
+	{% endif %}
 	<table class="table table-bordered">
 		<thead>
 			<tr>
-				{% if(report.report_name === "Accounts Receivable" || report.report_name === "Accounts Payable") { %}
-					<th style="width: 10%">{%= __("Date") %}</th>
-					<th style="width: 4%">{%= __("Age (Days)") %}</th>
+				{% if(report.report_name == "Accounts Receivable" or report.report_name == "Accounts Payable") %}
+					<th style="width: 10%">{{ _("Date") }}</th>
+					<th style="width: 4%">{{ _("Age (Days)") }}</th>
 
-					{% if(report.report_name === "Accounts Receivable" && filters.show_sales_person) { %}
-						<th style="width: 14%">{%= __("Reference") %}</th>
-						<th style="width: 10%">{%= __("Sales Person") %}</th>
-					{% } else { %}
-						<th style="width: 24%">{%= __("Reference") %}</th>
-					{% } %}
-					{% if(!filters.show_future_payments) { %}
-						<th style="width: 20%">{%= (filters.customer || filters.supplier) ? __("Remarks"): __("Party") %}</th>
-					{% } %}
-					<th style="width: 10%; text-align: right">{%= __("Invoiced Amount") %}</th>
-					{% if(!filters.show_future_payments) { %}
-						<th style="width: 10%; text-align: right">{%= __("Paid Amount") %}</th>
-						<th style="width: 10%; text-align: right">{%= report.report_name === "Accounts Receivable" ? __('Credit Note') : __('Debit Note') %}</th>
-					{% } %}
-					<th style="width: 10%; text-align: right">{%= __("Outstanding Amount") %}</th>
-					{% if(filters.show_future_payments) { %}
-						{% if(report.report_name === "Accounts Receivable") { %}
-							<th style="width: 12%">{%= __("Customer LPO No.") %}</th>
-						{% } %}
-						<th style="width: 10%">{%= __("Future Payment Ref") %}</th>
-						<th style="width: 10%">{%= __("Future Payment Amount") %}</th>
-						<th style="width: 10%">{%= __("Remaining Balance") %}</th>
-					{% } %}
-				{% } else { %}
-					<th style="width: 40%">{%= (filters.customer || filters.supplier) ? __("Remarks"): __("Party") %}</th>
-					<th style="width: 15%">{%= __("Total Invoiced Amount") %}</th>
-					<th style="width: 15%">{%= __("Total Paid Amount") %}</th>
-					<th style="width: 15%">{%= report.report_name === "Accounts Receivable Summary" ? __('Credit Note Amount') : __('Debit Note Amount') %}</th>
-					<th style="width: 15%">{%= __("Total Outstanding Amount") %}</th>
-				{% } %}
+					{% if(report.report_name == "Accounts Receivable" and filters.show_sales_person) %}
+						<th style="width: 14%">{{ _("Reference") }}</th>
+						<th style="width: 10%">{{ _("Sales Person") }}</th>
+					{% else %}
+						<th style="width: 24%">{{ _("Reference") }}</th>
+					{% endif %}
+					{% if not(filters.show_future_payments) %}
+						<th style="width: 20%">
+						{% if (filters.customer or filters.supplier or filters.customer_name) %}
+							{{ _("Remarks") }}
+						{% else %}
+							{{ _("Party") }}
+						{% endif %}
+						</th>
+					{% endif %}
+					<th style="width: 10%; text-align: right">{{ _("Invoiced Amount") }}</th>
+					{% if not(filters.show_future_payments) %}
+						<th style="width: 10%; text-align: right">{{ _("Paid Amount") }}</th>
+						<th style="width: 10%; text-align: right">
+							{% if report.report_name == "Accounts Receivable" %}
+								{{ _('Credit Note') }}
+							{% else %}
+								{{ _('Debit Note') }}
+							{% endif %}
+						</th>
+					{% endif %}
+					<th style="width: 10%; text-align: right">{{ _("Outstanding Amount") }}</th>
+					{% if(filters.show_future_payments) %}
+						{% if(report.report_name == "Accounts Receivable") %}
+							<th style="width: 12%">{{ _("Customer LPO No.") }}</th>
+						{% endif %}
+						<th style="width: 10%">{{ _("Future Payment Ref") }}</th>
+						<th style="width: 10%">{{ _("Future Payment Amount") }}</th>
+						<th style="width: 10%">{{ _("Remaining Balance") }}</th>
+					{% endif %}
+				{% else %}
+					<th style="width: 40%">
+						{% if (filters.customer or filters.supplier or filters.customer_name) %}
+							{{ _("Remarks")}}
+						{% else %}
+							{{ _("Party") }}
+						{% endif %}
+					</th>
+					<th style="width: 15%">{{ _("Total Invoiced Amount") }}</th>
+					<th style="width: 15%">{{ _("Total Paid Amount") }}</th>
+					<th style="width: 15%">
+						{% if report.report_name == "Accounts Receivable Summary" %}
+							{{ _('Credit Note Amount') }}
+						{% else %}
+							{{ _('Debit Note Amount') }}
+						{% endif %}
+					</th>
+					<th style="width: 15%">{{ _("Total Outstanding Amount") }}</th>
+				{% endif %}
 			</tr>
 		</thead>
 		<tbody>
-			{% for(var i=0, l=data.length; i<l; i++) { %}
+			{% for i in range(data|length) %}
 				<tr>
-				{% if(report.report_name === "Accounts Receivable" || report.report_name === "Accounts Payable") { %}
-					{% if(data[i]["party"]) { %}
-						<td>{%= frappe.datetime.str_to_user(data[i]["posting_date"]) %}</td>
-						<td style="text-align: right">{%= data[i]["age"] %}</td>
+				{% if(report.report_name == "Accounts Receivable" or report.report_name == "Accounts Payable") %}
+					{% if(data[i]["party"]) %}
+						<td>{{ (data[i]["posting_date"]) }}</td>
+						<td style="text-align: right">{{ data[i]["age"] }}</td>
 						<td>
-							{% if(!filters.show_future_payments) { %}
-								{%= data[i]["voucher_type"] %}
+							{% if not(filters.show_future_payments) %}
+								{{ data[i]["voucher_type"] }}
 								<br>
-							{% } %}
-							{%= data[i]["voucher_no"] %}
+							{% endif %}
+							{{ data[i]["voucher_no"] }}
 						</td>
 
-						{% if(report.report_name === "Accounts Receivable" && filters.show_sales_person) { %}
-						<td>{%= data[i]["sales_person"] %}</td>
-						{% } %}
+						{% if(report.report_name == "Accounts Receivable" and filters.show_sales_person) %}
+						<td>{{ data[i]["sales_person"] }}</td>
+						{% endif %}
 
-						{% if(!filters.show_future_payments) { %}
+						{% if not (filters.show_future_payments) %}
 						<td>
-							{% if(!(filters.customer || filters.supplier)) { %}
-								{%= data[i]["party"] %}
-								{% if(data[i]["customer_name"] && data[i]["customer_name"] != data[i]["party"]) { %}
-									<br> {%= data[i]["customer_name"] %}
-								{% } else if(data[i]["supplier_name"] != data[i]["party"]) { %}
-									<br> {%= data[i]["supplier_name"] %}
-								{% } %}
-							{% } %}
+							{% if(not(filters.customer or filters.supplier or filters.customer_name)) %}
+								{{ data[i]["party"] }}
+								{% if(data[i]["customer_name"] and data[i]["customer_name"] != data[i]["party"]) %}
+									<br> {{ data[i]["customer_name"] }}
+								{% elif(data[i]["supplier_name"] != data[i]["party"]) %}
+									<br> {{ data[i]["supplier_name"] }}
+								{% endif %}
+							{% endif %}
 							<div>
 							{% if data[i]["remarks"] %}
-								{%= __("Remarks") %}:
-								{%= data[i]["remarks"] %}
-							{% } %}
+								{{ _("Remarks") }}:
+								{{ data[i]["remarks"] }}
+							{% endif %}
 							</div>
 						</td>
-						{% } %}
+						{% endif %}
 
 						<td style="text-align: right">
-							{%= format_currency(data[i]["invoiced"], data[i]["currency"]) %}</td>
+							{{ frappe.utils.fmt_money(data[i]["invoiced"], currency=data[i]["currency"]) }}</td>
 
-						{% if(!filters.show_future_payments) { %}
+						{% if not(filters.show_future_payments) %}
 							<td style="text-align: right">
-								{%= format_currency(data[i]["paid"], data[i]["currency"]) %}</td>
+								{{ frappe.utils.fmt_money(data[i]["paid"], currency=data[i]["currency"]) }}</td>
 							<td style="text-align: right">
-								{%= format_currency(data[i]["credit_note"], data[i]["currency"]) %}</td>
-						{% } %}
+								{{ frappe.utils.fmt_money(data[i]["credit_note"], currency=data[i]["currency"]) }}</td>
+						{% endif %}
 						<td style="text-align: right">
-							{%= format_currency(data[i]["outstanding"], data[i]["currency"]) %}</td>
+							{{ frappe.utils.fmt_money(data[i]["outstanding"], currency=data[i]["currency"]) }}</td>
 
-						{% if(filters.show_future_payments) { %}
-							{% if(report.report_name === "Accounts Receivable") { %}
+						{% if(filters.show_future_payments) %}
+							{% if(report.report_name == "Accounts Receivable") %}
 								<td style="text-align: right">
-									{%= data[i]["po_no"] %}</td>
-							{% } %}
-							<td style="text-align: right">{%= data[i]["future_ref"] %}</td>
-							<td style="text-align: right">{%= format_currency(data[i]["future_amount"], data[i]["currency"]) %}</td>
-							<td style="text-align: right">{%= format_currency(data[i]["remaining_balance"], data[i]["currency"]) %}</td>
-						{% } %}
-					{% } else { %}
+									{{ data[i]["po_no"] }}</td>
+							{% endif %}
+							<td style="text-align: right">{{ data[i]["future_ref"] }}</td>
+							<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["future_amount"], currency=data[i]["currency"]) }}</td>
+							<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["remaining_balance"], currency=data[i]["currency"]) }}</td>
+						{% endif %}
+					{% else %}
 						<td></td>
-						{% if(!filters.show_future_payments) { %}
+						{% if not(filters.show_future_payments) %}
 						<td></td>
-						{% } %}
-						{% if(report.report_name === "Accounts Receivable" && filters.show_sales_person) { %}
+						{% endif %}
+						{% if(report.report_name == "Accounts Receivable" and filters.show_sales_person) %}
 						<td></td>
-						{% } %}
+						{% endif %}
 						<td></td>
-						<td style="text-align: right"><b>{%= __("Total") %}</b></td>
+						<td style="text-align: right"><b>{{ _("Total") }}</b></td>
 						<td style="text-align: right">
-							{%= format_currency(data[i]["invoiced"], data[i]["currency"] ) %}</td>
+							{{ frappe.utils.fmt_money(data[i]["invoiced"], data[i]["currency"]) }}</td>
 
-						{% if(!filters.show_future_payments) { %}
+						{% if not(filters.show_future_payments) %}
 							<td style="text-align: right">
-								{%= format_currency(data[i]["paid"], data[i]["currency"]) %}</td>
-							<td style="text-align: right">{%= format_currency(data[i]["credit_note"], data[i]["currency"]) %} </td>
-						{% } %}
+								{{ frappe.utils.fmt_money(data[i]["paid"], currency=data[i]["currency"]) }}</td>
+							<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["credit_note"], currency=data[i]["currency"]) }} </td>
+						{% endif %}
 						<td style="text-align: right">
-							{%= format_currency(data[i]["outstanding"], data[i]["currency"]) %}</td>
+							{{ frappe.utils.fmt_money(data[i]["outstanding"], currency=data[i]["currency"]) }}</td>
 
-						{% if(filters.show_future_payments) { %}
-							{% if(report.report_name === "Accounts Receivable") { %}
+						{% if(filters.show_future_payments) %}
+							{% if(report.report_name == "Accounts Receivable") %}
 								<td style="text-align: right">
-									{%= data[i]["po_no"] %}</td>
-							{% } %}
-							<td style="text-align: right">{%= data[i]["future_ref"] %}</td>
-							<td style="text-align: right">{%= format_currency(data[i]["future_amount"], data[i]["currency"]) %}</td>
-							<td style="text-align: right">{%= format_currency(data[i]["remaining_balance"], data[i]["currency"]) %}</td>
-						{% } %}
-					{% } %}
-				{% } else { %}
-					{% if(data[i]["party"]|| "&nbsp;") { %}
-						{% if(!data[i]["is_total_row"]) { %}
+									{{ data[i]["po_no"] }}</td>
+							{% endif %}
+							<td style="text-align: right">{{ data[i]["future_ref"] }}</td>
+							<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["future_amount"], currency=data[i]["currency"]) }}</td>
+							<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["remaining_balance"], currency=data[i]["currency"]) }}</td>
+						{% endif %}
+					{% endif %}
+				{% else %}
+					{% if(data[i]["party"] or "&nbsp;") %}
+						{% if not(data[i]["is_total_row"]) %}
 							<td>
-								{% if(!(filters.customer || filters.supplier)) { %}
-									{%= data[i]["party"] %}
-									{% if(data[i]["customer_name"] && data[i]["customer_name"] != data[i]["party"]) { %}
-										<br> {%= data[i]["customer_name"] %}
-									{% } else if(data[i]["supplier_name"] != data[i]["party"]) { %}
-										<br> {%= data[i]["supplier_name"] %}
-									{% } %}
-								{% } %}
-								<br>{%= __("Remarks") %}:
-								{%= data[i]["remarks"] %}
+								{% if(not(filters.customer | filters.supplier)) %}
+									{{ data[i]["party"] }}
+									{% if(data[i]["customer_name"] and data[i]["customer_name"] != data[i]["party"]) %}
+										<br> {{ data[i]["customer_name"] }}
+									{% elif(data[i]["supplier_name"] != data[i]["party"]) %}
+										<br> {{ data[i]["supplier_name"] }}
+									{% endif %}
+								{% endif %}
+								<br>{{ _("Remarks") }}:
+								{{ data[i]["remarks"] }}
 							</td>
-						{% } else { %}
-							<td><b>{%= __("Total") %}</b></td>
-						{% } %}
-						<td style="text-align: right">{%= format_currency(data[i]["invoiced"], data[i]["currency"]) %}</td>
-						<td style="text-align: right">{%= format_currency(data[i]["paid"], data[i]["currency"]) %}</td>
-						<td style="text-align: right">{%= format_currency(data[i]["credit_note"], data[i]["currency"]) %}</td>
-						<td style="text-align: right">{%= format_currency(data[i]["outstanding"], data[i]["currency"]) %}</td>
-					{% } %}
-				{% } %}
+						{% else %}
+							<td><b>{{ _("Total") }}</b></td>
+						{% endif %}
+						<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["invoiced"], currency=data[i]["currency"]) }}</td>
+						<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["paid"], currency=data[i]["currency"]) }}</td>
+						<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["credit_note"], currency=data[i]["currency"]) }}</td>
+						<td style="text-align: right">{{ frappe.utils.fmt_money(data[i]["outstanding"], currency=data[i]["currency"]) }}</td>
+					{% endif %}
+				{% endif %}
 				</tr>
-			{% } %}
+			{% endfor %}
+			<td></td>
+			<td></td>
+			<td></td>
+			<td></td>
+			<td style="text-align: right"><b>{{ frappe.utils.fmt_money(data|sum(attribute="invoiced"), currency=data[0]["currency"]) }}</b></td>
+			<td style="text-align: right"><b>{{ frappe.utils.fmt_money(data|sum(attribute="paid"), currency=data[0]["currency"]) }}</b></td>
+			<td style="text-align: right"><b>{{ frappe.utils.fmt_money(data|sum(attribute="credit_note"), currency=data[0]["currency"]) }}</b></td>
+			<td style="text-align: right"><b>{{ frappe.utils.fmt_money(data|sum(attribute="outstanding"), currency=data[0]["currency"]) }}</b></td>
 		</tbody>
 	</table>
-	<p class="text-right text-muted">{{ __("Printed On ") }}{%= frappe.datetime.str_to_user(frappe.datetime.get_datetime_as_string()) %}</p>
+	<br>
+	{% if ageing %}
+	<h4 class="text-center">{{ _("Ageing Report based on ") }} {{ ageing.ageing_based_on }}
+		{{ _("up to " ) }}  {{ frappe.format(filters.report_date, 'Date')}}
+	</h4>
+	<table class="table table-bordered">
+		<thead>
+			<tr>
+				<th style="width: 25%">30 Days</th>
+				<th style="width: 25%">60 Days</th>
+				<th style="width: 25%">90 Days</th>
+				<th style="width: 25%">120 Days</th>
+			</tr>
+		</thead>
+		<tbody>
+			<tr>
+				<td>{{ frappe.utils.fmt_money(ageing.range1, currency=data[0]["currency"]) }}</td>
+				<td>{{ frappe.utils.fmt_money(ageing.range2, currency=data[0]["currency"]) }}</td>
+				<td>{{ frappe.utils.fmt_money(ageing.range3, currency=data[0]["currency"]) }}</td>
+				<td>{{ frappe.utils.fmt_money(ageing.range4, currency=data[0]["currency"]) }}</td>
+			</tr>
+		</tbody>
+	</table>
+	{% endif %}
+	<p class="text-right text-muted">{{ _("Printed On ") }}{{ frappe.utils.now() }}</p>

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -339,3 +339,4 @@ execute:frappe.delete_doc('DocType', 'Cash Flow Mapper', ignore_missing=True)
 execute:frappe.delete_doc('DocType', 'Cash Flow Mapping Template', ignore_missing=True)
 execute:frappe.delete_doc('DocType', 'Cash Flow Mapping Accounts', ignore_missing=True)
 erpnext.patches.v14_0.cleanup_workspaces
+erpnext.patches.v14_0.set_report_in_process_SOA 

--- a/erpnext/patches/v14_0/set_report_in_process_SOA.py
+++ b/erpnext/patches/v14_0/set_report_in_process_SOA.py
@@ -5,6 +5,7 @@ import frappe
 
 
 def execute():
+	frappe.reload_doc("accounts", "doctype", "Process Statement of Accounts", force=True)
 	process_soa = frappe.qb.DocType("Process Statement of Accounts")
 	q = frappe.qb.update(process_soa).set(process_soa.report, "General Ledger")
 	q.run()

--- a/erpnext/patches/v14_0/set_report_in_process_SOA.py
+++ b/erpnext/patches/v14_0/set_report_in_process_SOA.py
@@ -1,0 +1,10 @@
+# Copyright (c) 2022, Frappe Technologies Pvt. Ltd. and Contributors
+# License: MIT. See LICENSE
+
+import frappe
+
+
+def execute():
+	process_soa = frappe.qb.DocType("Process Statement of Accounts")
+	q = frappe.qb.update(process_soa).set(process_soa.report, "General Ledger")
+	q.run()

--- a/erpnext/patches/v14_0/set_report_in_process_SOA.py
+++ b/erpnext/patches/v14_0/set_report_in_process_SOA.py
@@ -5,7 +5,6 @@ import frappe
 
 
 def execute():
-	frappe.reload_doc("accounts", "doctype", "Process Statement of Accounts", force=True)
-	process_soa = frappe.qb.DocType("Process Statement of Accounts")
+	process_soa = frappe.qb.DocType("Process Statement Of Accounts")
 	q = frappe.qb.update(process_soa).set(process_soa.report, "General Ledger")
 	q.run()


### PR DESCRIPTION
Added a simple Select Field to allow the user to create either the General Ledger Report Statement or the Accounts Receivable Report Statement from the **Process Statement of Accounts** Doctype.

On selection of either of the Report options, the corresponding Filters are visible.

A basic Accounts Receivable Report Template is used for displaying the entries.

The Process Statement of Accounts includes the following filters to get the report  - 
<br>
<img width="1297" alt="Screenshot 2023-06-19 at 8 16 16 PM" src="https://github.com/frappe/erpnext/assets/40693548/e809115e-097a-4fa6-b1e7-27652b0540a1">
<br>

The generated report has the following columns - 
<br>
<img width="1420" alt="Screenshot 2023-06-19 at 8 17 43 PM" src="https://github.com/frappe/erpnext/assets/40693548/08bd06a3-614f-44a2-9bf3-d93dffbc6490">
<br>

`no-docs`

Issue #35707