### PR TITLE
fix: Exchange Rate Revaluation should only post on the currency that has balance in a 'zero' balance account

### DIFF
--- a/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.js
+++ b/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.js
@@ -37,7 +37,7 @@ frappe.ui.form.on('Exchange Rate Revaluation', {
 
 	validate_rounding_loss: function(frm) {
 		let allowance = frm.doc.rounding_loss_allowance;
-		if (!(allowance > 0 && allowance < 1)) {
+		if (!(allowance >= 0 && allowance < 1)) {
 			frappe.throw(__("Rounding Loss Allowance should be between 0 and 1"));
 		}
 	},

--- a/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.json
+++ b/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.json
@@ -100,15 +100,16 @@
   },
   {
    "default": "0.05",
-   "description": "Only values between 0 and 1 are allowed. \nEx: If allowance is set at 0.07, accounts that have balance of 0.07 in either of the currencies will be considered as zero balance account",
+   "description": "Only values between [0,1) are allowed. Like {0.00, 0.04, 0.09, ...}\nEx: If allowance is set at 0.07, accounts that have balance of 0.07 in either of the currencies will be considered as zero balance account",
    "fieldname": "rounding_loss_allowance",
    "fieldtype": "Float",
-   "label": "Rounding Loss Allowance"
+   "label": "Rounding Loss Allowance",
+   "precision": "9"
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2023-06-12 21:02:09.818208",
+ "modified": "2023-06-20 07:29:06.972434",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Exchange Rate Revaluation",

--- a/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py
+++ b/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py
@@ -373,6 +373,24 @@ class ExchangeRateRevaluation(Document):
 						"credit": 0,
 					}
 				)
+
+				journal_entry_accounts.append(journal_account)
+
+				journal_entry_accounts.append(
+					{
+						"account": unrealized_exchange_gain_loss_account,
+						"balance": get_balance_on(unrealized_exchange_gain_loss_account),
+						"debit": 0,
+						"credit": 0,
+						"debit_in_account_currency": abs(d.gain_loss) if d.gain_loss < 0 else 0,
+						"credit_in_account_currency": abs(d.gain_loss) if d.gain_loss > 0 else 0,
+						"cost_center": erpnext.get_default_cost_center(self.company),
+						"exchange_rate": 1,
+						"reference_type": "Exchange Rate Revaluation",
+						"reference_name": self.name,
+					}
+				)
+
 			elif d.get("balance_in_base_currency") and not d.get("new_balance_in_base_currency"):
 				# Base currency has balance
 				dr_or_cr = "credit" if d.get("balance_in_base_currency") > 0 else "debit"
@@ -388,22 +406,22 @@ class ExchangeRateRevaluation(Document):
 					}
 				)
 
-			journal_entry_accounts.append(journal_account)
+				journal_entry_accounts.append(journal_account)
 
-		journal_entry_accounts.append(
-			{
-				"account": unrealized_exchange_gain_loss_account,
-				"balance": get_balance_on(unrealized_exchange_gain_loss_account),
-				"debit": abs(self.gain_loss_booked) if self.gain_loss_booked < 0 else 0,
-				"credit": abs(self.gain_loss_booked) if self.gain_loss_booked > 0 else 0,
-				"debit_in_account_currency": abs(self.gain_loss_booked) if self.gain_loss_booked < 0 else 0,
-				"credit_in_account_currency": self.gain_loss_booked if self.gain_loss_booked > 0 else 0,
-				"cost_center": erpnext.get_default_cost_center(self.company),
-				"exchange_rate": 1,
-				"reference_type": "Exchange Rate Revaluation",
-				"reference_name": self.name,
-			}
-		)
+				journal_entry_accounts.append(
+					{
+						"account": unrealized_exchange_gain_loss_account,
+						"balance": get_balance_on(unrealized_exchange_gain_loss_account),
+						"debit": abs(d.gain_loss) if d.gain_loss < 0 else 0,
+						"credit": abs(d.gain_loss) if d.gain_loss > 0 else 0,
+						"debit_in_account_currency": 0,
+						"credit_in_account_currency": 0,
+						"cost_center": erpnext.get_default_cost_center(self.company),
+						"exchange_rate": 1,
+						"reference_type": "Exchange Rate Revaluation",
+						"reference_name": self.name,
+					}
+				)
 
 		journal_entry.set("accounts", journal_entry_accounts)
 		journal_entry.set_total_debit_credit()

--- a/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py
+++ b/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py
@@ -22,7 +22,7 @@ class ExchangeRateRevaluation(Document):
 		self.set_total_gain_loss()
 
 	def validate_rounding_loss_allowance(self):
-		if not (self.rounding_loss_allowance > 0 and self.rounding_loss_allowance < 1):
+		if not (self.rounding_loss_allowance >= 0 and self.rounding_loss_allowance < 1):
 			frappe.throw(_("Rounding Loss Allowance should be between 0 and 1"))
 
 	def set_total_gain_loss(self):

--- a/erpnext/accounts/doctype/exchange_rate_revaluation_account/exchange_rate_revaluation_account.json
+++ b/erpnext/accounts/doctype/exchange_rate_revaluation_account/exchange_rate_revaluation_account.json
@@ -92,6 +92,7 @@
    "fieldtype": "Float",
    "in_list_view": 1,
    "label": "New Exchange Rate",
+   "precision": "9",
    "reqd": 1
   },
   {
@@ -147,7 +148,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2022-12-29 19:38:52.915295",
+ "modified": "2023-06-20 07:21:40.743460",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Exchange Rate Revaluation Account",


### PR DESCRIPTION
On Accounts that have balance only in account currency, Journals created by Exchange Rate Revaluation cause debit - credit mismatch in Trial Balance report. ERR should only post to currencies that have balance.