### PR TITLE
fix: frappe.exceptions.DoesNotExistError: DocType KSA VAT Setting not found

### DIFF
--- a/erpnext/regional/saudi_arabia/setup.py
+++ b/erpnext/regional/saudi_arabia/setup.py
@@ -35,6 +35,7 @@ def add_print_formats():
 
 
 def add_permissions():
+	frappe.reload_doc("regional", "doctype", "ksa_vat_setting", force=True)
 	"""Add Permissions for KSA VAT Setting."""
 	add_permission("KSA VAT Setting", "All", 0)
 	for role in ("Accounts Manager", "Accounts User", "System Manager"):


### PR DESCRIPTION
When migrating from v12->v13 migration fails
While migrating the doctype is not reloaded before adding permission. https://github.com/frappe/erpnext/issues/35795

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
