### PR TITLE
fix: Payment Term must be mandatory if `Allocate Payment based on ..` is checked

### DIFF
--- a/erpnext/accounts/doctype/payment_terms_template/payment_terms_template.js
+++ b/erpnext/accounts/doctype/payment_terms_template/payment_terms_template.js
@@ -2,7 +2,11 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on('Payment Terms Template', {
-	setup: function(frm) {
+	refresh: function(frm) {
+		frm.fields_dict.terms.grid.toggle_reqd("payment_term", frm.doc.allocate_payment_based_on_payment_terms);
+	},
 
+	allocate_payment_based_on_payment_terms: function(frm) {
+		frm.fields_dict.terms.grid.toggle_reqd("payment_term", frm.doc.allocate_payment_based_on_payment_terms);
 	}
 });

--- a/erpnext/accounts/doctype/payment_terms_template/payment_terms_template.py
+++ b/erpnext/accounts/doctype/payment_terms_template/payment_terms_template.py
@@ -11,7 +11,7 @@ from frappe.utils import flt
 class PaymentTermsTemplate(Document):
 	def validate(self):
 		self.validate_invoice_portion()
-		self.check_duplicate_terms()
+		self.validate_terms()
 
 	def validate_invoice_portion(self):
 		total_portion = 0
@@ -23,9 +23,12 @@ class PaymentTermsTemplate(Document):
 				_("Combined invoice portion must equal 100%"), raise_exception=1, indicator="red"
 			)
 
-	def check_duplicate_terms(self):
+	def validate_terms(self):
 		terms = []
 		for term in self.terms:
+			if self.allocate_payment_based_on_payment_terms and not term.payment_term:
+				frappe.throw(_("Row {0}: Payment Term is mandatory").format(term.idx))
+
 			term_info = (term.payment_term, term.credit_days, term.credit_months, term.due_date_based_on)
 			if term_info in terms:
 				frappe.msgprint(

--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -72,6 +72,11 @@ class TestPurchaseReceipt(FrappeTestCase):
 		self.assertEqual(sl_entry_cancelled[1].actual_qty, -0.5)
 
 	def test_make_purchase_invoice(self):
+		from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_payment_term
+
+		create_payment_term("_Test Payment Term 1 for Purchase Invoice")
+		create_payment_term("_Test Payment Term 2 for Purchase Invoice")
+
 		if not frappe.db.exists(
 			"Payment Terms Template", "_Test Payment Terms Template For Purchase Invoice"
 		):
@@ -83,12 +88,14 @@ class TestPurchaseReceipt(FrappeTestCase):
 					"terms": [
 						{
 							"doctype": "Payment Terms Template Detail",
+							"payment_term": "_Test Payment Term 1 for Purchase Invoice",
 							"invoice_portion": 50.00,
 							"credit_days_based_on": "Day(s) after invoice date",
 							"credit_days": 00,
 						},
 						{
 							"doctype": "Payment Terms Template Detail",
+							"payment_term": "_Test Payment Term 2 for Purchase Invoice",
 							"invoice_portion": 50.00,
 							"credit_days_based_on": "Day(s) after invoice date",
 							"credit_days": 30,


### PR DESCRIPTION
- Make sure Payment Term is set if `Allocate Payment Based On Payment Terms` is enabled.
- Payment Entry does not update linked Invoices' Payment Schedule if the Payment Term is missing in the Payment Schedule row
- This beats the point of having the `Allocate Payment Based On Payment Terms` checkbox which is not respected

<img width="1317" alt="Screenshot 2023-06-20 at 11 26 41 AM" src="https://github.com/frappe/erpnext/assets/25857446/2cfe603b-5de8-468f-9e49-92be5e4c4357">
