### PR TITLE
fix: Duplicate addresses are creating while using the E-commerce

### DIFF
--- a/erpnext/e_commerce/shopping_cart/cart.py
+++ b/erpnext/e_commerce/shopping_cart/cart.py
@@ -3,7 +3,7 @@
 
 import frappe
 import frappe.defaults
-from frappe import _, throw
+from frappe import _, bold, throw
 from frappe.contacts.doctype.address.address import get_address_display
 from frappe.contacts.doctype.contact.contact import get_contact_name
 from frappe.utils import cint, cstr, flt, get_fullname
@@ -201,6 +201,11 @@ def get_shopping_cart_menu(context=None):
 @frappe.whitelist()
 def add_new_address(doc):
 	doc = frappe.parse_json(doc)
+	address_title = doc.get("address_title")
+	if frappe.db.exists("Address", {"address_title": address_title}):
+		msg = f"The address with the title {bold(address_title)} already exists. Please change the title accordingly."
+		frappe.throw(_(msg), title=_("Address Already Exists"))
+
 	doc.update({"doctype": "Address"})
 	address = frappe.get_doc(doc)
 	address.save(ignore_permissions=True)


### PR DESCRIPTION
**Issue**

Multiple addresses with same title are creating while using the E-commerce

<img width="1317" alt="Screenshot 2023-06-20 at 2 31 32 PM" src="https://github.com/frappe/erpnext/assets/8780500/f33d31c0-2621-4836-951f-91332c358452">


**After Fix**

If a duplicate address is found, the user will receive an error.

<img width="607" alt="Screenshot 2023-06-20 at 2 31 21 PM" src="https://github.com/frappe/erpnext/assets/8780500/5bfbea1b-88a2-460e-b6ef-1767169aad61">

