### PR TITLE
fix: key error while checking the stock balance report

### DIFF
--- a/erpnext/stock/utils.py
+++ b/erpnext/stock/utils.py
@@ -475,7 +475,7 @@ def add_additional_uom_columns(columns, result, include_uom, conversion_factors)
 
 	for row_idx, row in enumerate(result):
 		for convertible_col, data in convertible_column_map.items():
-			conversion_factor = conversion_factors[row.get("item_code")] or 1
+			conversion_factor = conversion_factors.get(row.get("item_code")) or 1.0
 			for_type = data.for_type
 			value_before_conversion = row.get(convertible_col)
 			if for_type == "rate":


### PR DESCRIPTION
```
  File "apps/erpnext/erpnext/stock/report/stock_balance/stock_balance.py", line 39, in execute
    return StockBalanceReport(filters).run()
  File "apps/erpnext/erpnext/stock/report/stock_balance/stock_balance.py", line 71, in run
    self.add_additional_uom_columns()
  File "apps/erpnext/erpnext/stock/report/stock_balance/stock_balance.py", line 492, in add_additional_uom_columns
    add_additional_uom_columns(self.columns, self.data, self.filters.include_uom, conversion_factors)
  File "apps/erpnext/erpnext/stock/utils.py", line 478, in add_additional_uom_columns
    conversion_factor = conversion_factors[row.get("item_code")] or 1
KeyError: 'Macbook Pro'
```