### PR TITLE
fix: multiple fixes in reconciliation tools

### DIFF
--- a/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.py
+++ b/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.py
@@ -10,6 +10,7 @@ from frappe.model.document import Document
 from frappe.query_builder.custom import ConstantColumn
 from frappe.utils import cint, flt
 
+from erpnext import get_default_cost_center
 from erpnext.accounts.doctype.bank_transaction.bank_transaction import get_total_allocated_amount
 from erpnext.accounts.report.bank_reconciliation_statement.bank_reconciliation_statement import (
 	get_amounts_not_reflected_in_system,
@@ -140,6 +141,9 @@ def create_journal_entry_bts(
 					second_account
 				)
 			)
+
+	company = frappe.get_value("Account", company_account, "company")
+
 	accounts = []
 	# Multi Currency?
 	accounts.append(
@@ -149,6 +153,7 @@ def create_journal_entry_bts(
 			"debit_in_account_currency": bank_transaction.withdrawal,
 			"party_type": party_type,
 			"party": party,
+			"cost_center": get_default_cost_center(company),
 		}
 	)
 
@@ -158,10 +163,9 @@ def create_journal_entry_bts(
 			"bank_account": bank_transaction.bank_account,
 			"credit_in_account_currency": bank_transaction.withdrawal,
 			"debit_in_account_currency": bank_transaction.deposit,
+			"cost_center": get_default_cost_center(company),
 		}
 	)
-
-	company = frappe.get_value("Account", company_account, "company")
 
 	journal_entry_dict = {
 		"voucher_type": entry_type,

--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.js
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.js
@@ -85,25 +85,29 @@ erpnext.accounts.PaymentReconciliationController = class PaymentReconciliationCo
 
 		// check for any running reconciliation jobs
 		if (this.frm.doc.receivable_payable_account) {
-			frappe.db.get_single_value("Accounts Settings", "auto_reconcile_payments").then((enabled) => {
- 				if(enabled) {
-					this.frm.call({
-						'method': "erpnext.accounts.doctype.process_payment_reconciliation.process_payment_reconciliation.is_any_doc_running",
-						"args": {
-							for_filter: {
-								company: this.frm.doc.company,
-								party_type: this.frm.doc.party_type,
-								party: this.frm.doc.party,
-								receivable_payable_account: this.frm.doc.receivable_payable_account
+			this.frm.call({
+				doc: this.frm.doc,
+				method: 'is_auto_process_enabled',
+				callback: (r) => {
+					if (r.message) {
+						this.frm.call({
+							'method': "erpnext.accounts.doctype.process_payment_reconciliation.process_payment_reconciliation.is_any_doc_running",
+							"args": {
+								for_filter: {
+									company: this.frm.doc.company,
+									party_type: this.frm.doc.party_type,
+									party: this.frm.doc.party,
+									receivable_payable_account: this.frm.doc.receivable_payable_account
+								}
 							}
-						}
-					}).then(r => {
-						if (r.message) {
-							let doc_link = frappe.utils.get_form_link("Process Payment Reconciliation", r.message, true);
-							let msg = __("Payment Reconciliation Job: {0} is running for this party. Can't reconcile now.", [doc_link]);
-							this.frm.dashboard.add_comment(msg, "yellow");
-						}
-					});
+						}).then(r => {
+							if (r.message) {
+								let doc_link = frappe.utils.get_form_link("Process Payment Reconciliation", r.message, true);
+								let msg = __("Payment Reconciliation Job: {0} is running for this party. Can't reconcile now.", [doc_link]);
+								this.frm.dashboard.add_comment(msg, "yellow");
+							}
+						});
+					}
 				}
 			});
 		}

--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
@@ -253,6 +253,10 @@ class PaymentReconciliation(Document):
 		return difference_amount
 
 	@frappe.whitelist()
+	def is_auto_process_enabled(self):
+		return frappe.db.get_single_value("Accounts Settings", "auto_reconcile_payments")
+
+	@frappe.whitelist()
 	def calculate_difference_on_allocation_change(self, payment_entry, invoice, allocated_amount):
 		invoice_exchange_map = self.get_invoice_exchange_map(invoice, payment_entry)
 		invoice[0]["exchange_rate"] = invoice_exchange_map.get(invoice[0].get("invoice_number"))


### PR DESCRIPTION
1. Permission error while using Payment Reconciliation tool. Happens if user only has 'Accounts User' role. <img width="1440" alt="Screenshot 2023-06-21 at 2 20 54 PM" src="https://github.com/frappe/erpnext/assets/3272205/57629a0a-2556-4001-b336-9c20605f3c1e">
2.  While reconciling bank transaction, Journal Entry creation throws cost center validation error, as cost center from different company is used in Journal. This only happens on multi company setup. 
<img width="1440" alt="Screenshot 2023-06-21 at 9 55 16 PM" src="https://github.com/frappe/erpnext/assets/3272205/2b7b4f2f-a00f-4996-9906-68b309dfadce">
