### PR TITLE
fix: use correct fieldname for purchase receipt column in item_wise_purchase_register report

### DIFF
--- a/erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py
+++ b/erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py
@@ -87,7 +87,7 @@ def _execute(filters=None, additional_table_columns=None, additional_query_colum
 				"project": d.project,
 				"company": d.company,
 				"purchase_order": d.purchase_order,
-				"purchase_receipt": d.purchase_receipt,
+				"purchase_receipt": purchase_receipt,
 				"expense_account": expense_account,
 				"stock_qty": d.stock_qty,
 				"stock_uom": d.stock_uom,
@@ -241,7 +241,7 @@ def get_columns(additional_table_columns, filters):
 		},
 		{
 			"label": _("Purchase Receipt"),
-			"fieldname": "Purchase Receipt",
+			"fieldname": "purchase_receipt",
 			"fieldtype": "Link",
 			"options": "Purchase Receipt",
 			"width": 100,


### PR DESCRIPTION
Purchase Receipt not visible in item-wise purchase register

before:

![2023-06-22_15-16](https://github.com/frappe/erpnext/assets/32034600/89222abf-b8ac-4789-83b5-28ad1b3ac4f4)

after:

![2023-06-22_15-17](https://github.com/frappe/erpnext/assets/32034600/99f8ce59-5d09-485f-bcbb-36d7f2ce53d0)
