### PR TITLE
fix: incorrect cost center error in bank reconciliation

### DIFF
--- a/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.py
+++ b/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.py
@@ -10,6 +10,7 @@ from frappe.model.document import Document
 from frappe.query_builder.custom import ConstantColumn
 from frappe.utils import cint, flt
 
+from erpnext import get_default_cost_center
 from erpnext.accounts.doctype.bank_transaction.bank_transaction import get_total_allocated_amount
 from erpnext.accounts.report.bank_reconciliation_statement.bank_reconciliation_statement import (
 	get_amounts_not_reflected_in_system,
@@ -140,6 +141,9 @@ def create_journal_entry_bts(
 					second_account
 				)
 			)
+
+	company = frappe.get_value("Account", company_account, "company")
+
 	accounts = []
 	# Multi Currency?
 	accounts.append(
@@ -149,6 +153,7 @@ def create_journal_entry_bts(
 			"debit_in_account_currency": bank_transaction.withdrawal,
 			"party_type": party_type,
 			"party": party,
+			"cost_center": get_default_cost_center(company),
 		}
 	)
 
@@ -158,10 +163,9 @@ def create_journal_entry_bts(
 			"bank_account": bank_transaction.bank_account,
 			"credit_in_account_currency": bank_transaction.withdrawal,
 			"debit_in_account_currency": bank_transaction.deposit,
+			"cost_center": get_default_cost_center(company),
 		}
 	)
-
-	company = frappe.get_value("Account", company_account, "company")
 
 	journal_entry_dict = {
 		"voucher_type": entry_type,


### PR DESCRIPTION
While reconciling bank transaction, Journal Entry creation throws cost center validation error, as cost center from different company is used in Journal. This only happens on multi company setup.
<img width="1440" alt="Screenshot 2023-06-21 at 9 55 16 PM" src="https://github.com/frappe/erpnext/assets/3272205/1adbf0cb-b9d2-45ca-8048-50894b134abe">
