### PR TITLE
refactor: increase precision for current exc rate in Exchange Rate Revaluation

### DIFF
--- a/erpnext/accounts/doctype/exchange_rate_revaluation_account/exchange_rate_revaluation_account.json
+++ b/erpnext/accounts/doctype/exchange_rate_revaluation_account/exchange_rate_revaluation_account.json
@@ -73,6 +73,7 @@
    "fieldname": "current_exchange_rate",
    "fieldtype": "Float",
    "label": "Current Exchange Rate",
+   "precision": "9",
    "read_only": 1
   },
   {
@@ -148,7 +149,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2023-06-20 07:21:40.743460",
+ "modified": "2023-06-22 12:39:56.446722",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Exchange Rate Revaluation Account",


### PR DESCRIPTION
Increase currency precision for 'current exchange rate' field in Exchange Rate Revalution master. This is to avoid rounding mismatch when re-evaluating a forex account.