### PR TITLE
fix: multiple Work Orders against same production plan

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.js
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.js
@@ -99,7 +99,7 @@ frappe.ui.form.on('Production Plan', {
 					}, __('Create'));
 				}
 
-				if (frm.doc.mr_items && !in_list(['Material Requested', 'Closed'], frm.doc.status)) {
+				if (frm.doc.mr_items && frm.doc.mr_items.length && !in_list(['Material Requested', 'Closed'], frm.doc.status)) {
 					frm.add_custom_button(__("Material Request"), ()=> {
 						frm.trigger("make_material_request");
 					}, __('Create'));

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -515,6 +515,9 @@ class ProductionPlan(Document):
 		self.show_list_created_message("Work Order", wo_list)
 		self.show_list_created_message("Purchase Order", po_list)
 
+		if not wo_list:
+			frappe.msgprint(_("No Work Orders were created"))
+
 	def make_work_order_for_finished_goods(self, wo_list, default_warehouses):
 		items_data = self.get_production_items()
 
@@ -617,6 +620,9 @@ class ProductionPlan(Document):
 
 	def create_work_order(self, item):
 		from erpnext.manufacturing.doctype.work_order.work_order import OverProductionError
+
+		if item.get("qty") <= 0:
+			return
 
 		wo = frappe.new_doc("Work Order")
 		wo.update(item)

--- a/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
@@ -76,6 +76,13 @@ class TestProductionPlan(FrappeTestCase):
 			"Work Order", fields=["name"], filters={"production_plan": pln.name}, as_list=1
 		)
 
+		pln.make_work_order()
+		nwork_orders = frappe.get_all(
+			"Work Order", fields=["name"], filters={"production_plan": pln.name}, as_list=1
+		)
+
+		self.assertTrue(len(work_orders), len(nwork_orders))
+
 		self.assertTrue(len(work_orders), len(pln.po_items))
 
 		for name in material_requests:


### PR DESCRIPTION
**Issue**

1. Create the production plan and create the work orders against the production plan.
2. Submit the few work orders and go back to the Production Plan
3. Click on "Make Work Orders / Subcontracted PO"
4. System will create the Work Order with zero quantity

<img width="1368" alt="Screenshot 2023-06-22 at 4 11 34 PM" src="https://github.com/frappe/erpnext/assets/8780500/644f3202-c292-44c8-a2ac-7a02bc0b7b0f">
