### PR TITLE
Set Asset cost center default as PR or PI Item Cost Center while auto creating

### DIFF
--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -709,7 +709,7 @@ class BuyingController(SubcontractingController):
 				"asset_quantity": row.qty if is_grouped_asset else 0,
 				"purchase_receipt": self.name if self.doctype == "Purchase Receipt" else None,
 				"purchase_invoice": self.name if self.doctype == "Purchase Invoice" else None,
-				"cost_center": row.cost_center or None
+				"cost_center": row.cost_center,
 			}
 		)
 

--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -709,6 +709,7 @@ class BuyingController(SubcontractingController):
 				"asset_quantity": row.qty if is_grouped_asset else 0,
 				"purchase_receipt": self.name if self.doctype == "Purchase Receipt" else None,
 				"purchase_invoice": self.name if self.doctype == "Purchase Invoice" else None,
+				"cost_center": row.cost_center or None
 			}
 		)
 


### PR DESCRIPTION


<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?


Currently when an Asset is Auto Created from Purchase Receipt or Purchase Invoice, The Cost Center is not being carried over the Asset
This change sets the Cost Center of the Asset to the value given in the Purchase Receipt/Invoice Line Item
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
