### PR TITLE
chore: better err msg on cancelling JE for asset scrap [dev]

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.js
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.js
@@ -8,7 +8,7 @@ frappe.provide("erpnext.journal_entry");
 frappe.ui.form.on("Journal Entry", {
 	setup: function(frm) {
 		frm.add_fetch("bank_account", "account", "account");
-		frm.ignore_doctypes_on_cancel_all = ['Sales Invoice', 'Purchase Invoice', 'Journal Entry', "Repost Payment Ledger", 'Asset Depreciation Schedule'];
+		frm.ignore_doctypes_on_cancel_all = ['Sales Invoice', 'Purchase Invoice', 'Journal Entry', "Repost Payment Ledger", 'Asset', 'Asset Movement', 'Asset Depreciation Schedule'];
 	},
 
 	refresh: function(frm) {

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -326,12 +326,10 @@ class JournalEntry(AccountsController):
 				d.db_update()
 
 	def unlink_asset_reference(self):
-		if self.voucher_type != "Depreciation Entry":
-			return
-
 		for d in self.get("accounts"):
 			if (
-				d.reference_type == "Asset"
+				self.voucher_type == "Depreciation Entry"
+				and d.reference_type == "Asset"
 				and d.reference_name
 				and d.account_type == "Depreciation"
 				and d.debit
@@ -370,6 +368,15 @@ class JournalEntry(AccountsController):
 				else:
 					asset.db_set("value_after_depreciation", asset.value_after_depreciation + d.debit)
 				asset.set_status()
+			elif self.voucher_type == "Journal Entry" and d.reference_type == "Asset" and d.reference_name:
+				journal_entry_for_scrap = frappe.db.get_value(
+					"Asset", d.reference_name, "journal_entry_for_scrap"
+				)
+
+				if journal_entry_for_scrap == self.name:
+					frappe.throw(
+						_("Journal Entry for Asset scrapping cannot be cancelled. Please restore the Asset.")
+					)
 
 	def unlink_inter_company_jv(self):
 		if (


### PR DESCRIPTION
Added better error message when users tried to cancel JE for asset scrap. Also added Asset and Asset Movement to JE's ignore_doctypes_on_cancel_all since those doctypes don't really need to be cancelled on a JE's cancellation.