### PR TITLE
feat: allow Sales Invoice as data source

### DIFF
--- a/erpnext/manufacturing/report/exponential_smoothing_forecasting/exponential_smoothing_forecasting.js
+++ b/erpnext/manufacturing/report/exponential_smoothing_forecasting/exponential_smoothing_forecasting.js
@@ -30,7 +30,7 @@ frappe.query_reports["Exponential Smoothing Forecasting"] = {
 			"fieldname":"based_on_document",
 			"label": __("Based On Document"),
 			"fieldtype": "Select",
-			"options": ["Sales Order", "Delivery Note", "Quotation"],
+			"options": ["Sales Order", "Sales Invoice", "Delivery Note", "Quotation"],
 			"default": "Sales Order",
 			"reqd": 1
 		},

--- a/erpnext/manufacturing/report/exponential_smoothing_forecasting/exponential_smoothing_forecasting.py
+++ b/erpnext/manufacturing/report/exponential_smoothing_forecasting/exponential_smoothing_forecasting.py
@@ -99,7 +99,9 @@ class ForecastingReport(ExponentialSmoothingForecast):
 		parent = frappe.qb.DocType(self.doctype)
 		child = frappe.qb.DocType(self.child_doctype)
 
-		date_field = "posting_date" if self.doctype in ("Delivery Note", "Sales Invoice") else "transaction_date"
+		date_field = (
+			"posting_date" if self.doctype in ("Delivery Note", "Sales Invoice") else "transaction_date"
+		)
 
 		query = (
 			frappe.qb.from_(parent)

--- a/erpnext/manufacturing/report/exponential_smoothing_forecasting/exponential_smoothing_forecasting.py
+++ b/erpnext/manufacturing/report/exponential_smoothing_forecasting/exponential_smoothing_forecasting.py
@@ -99,7 +99,7 @@ class ForecastingReport(ExponentialSmoothingForecast):
 		parent = frappe.qb.DocType(self.doctype)
 		child = frappe.qb.DocType(self.child_doctype)
 
-		date_field = "posting_date" if self.doctype == "Delivery Note" else "transaction_date"
+		date_field = "posting_date" if self.doctype in ("Delivery Note", "Sales Invoice") else "transaction_date"
 
 		query = (
 			frappe.qb.from_(parent)


### PR DESCRIPTION
**Use Case:** Sales Order / Delivery Note process is skipped, only Sales Invoice is generated. Customer wants to utilize the Exponential Smoothing Forecasting  report.

`no-docs`