### PR TITLE
fix: delivery trip driver is only required on submit

### DIFF
--- a/erpnext/stock/doctype/delivery_trip/delivery_trip.json
+++ b/erpnext/stock/doctype/delivery_trip/delivery_trip.json
@@ -66,8 +66,7 @@
    "fieldname": "driver",
    "fieldtype": "Link",
    "label": "Driver",
-   "options": "Driver",
-   "reqd": 1
+   "options": "Driver"
   },
   {
    "fetch_from": "driver.full_name",
@@ -189,10 +188,11 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2021-04-30 21:21:36.610142",
+ "modified": "2023-06-27 11:22:27.927637",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Trip",
+ "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
  "permissions": [
   {
@@ -228,5 +228,6 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "title_field": "driver_name"
 }

--- a/erpnext/stock/doctype/delivery_trip/delivery_trip.py
+++ b/erpnext/stock/doctype/delivery_trip/delivery_trip.py
@@ -24,6 +24,9 @@ class DeliveryTrip(Document):
 		)
 
 	def validate(self):
+		if self._action == "submit" and not self.driver:
+			frappe.throw(_("A driver must be set to submit."))
+
 		self.validate_stop_addresses()
 
 	def on_submit(self):


### PR DESCRIPTION
This allows drafting trips and stops without yet deciding on the
assignable driver which, in real life, may well be decided on after
preparing and planning the trip.
