### PR TITLE
fix: filter parent warehouses not showing

### DIFF
--- a/erpnext/stock/doctype/warehouse/warehouse.js
+++ b/erpnext/stock/doctype/warehouse/warehouse.js
@@ -13,7 +13,7 @@ frappe.ui.form.on("Warehouse", {
 			};
 		});
 
-		frm.set_query("parent_warehouse", function () {
+		frm.set_query("parent_warehouse", function (doc) {
 			return {
 				filters: {
 					is_group: 1,


### PR DESCRIPTION
fix bug: issue  #35778 

**Information about bug**
Parent Warehouse not showing, when creating a new warehouse