### PR TITLE
fix: create multiple variants button count and status

### DIFF
--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -590,7 +590,7 @@ $.extend(erpnext.item, {
 			let selected_attributes = {};
 			me.multiple_variant_dialog.$wrapper.find('.form-column').each((i, col) => {
 				if(i===0) return;
-				let attribute_name = $(col).find('.control-label').html().trim();
+				let attribute_name = $(col).find('.column-label').html().trim();
 				selected_attributes[attribute_name] = [];
 				let checked_opts = $(col).find('.checkbox input');
 				checked_opts.each((i, opt) => {


### PR DESCRIPTION
Previously, when creating multiple variants for a specific Item Template the submit button remained disabled even after selection of attribute values for all attributes. 

<img width="780" alt="Screenshot 2023-06-28 at 2 51 49 PM" src="https://github.com/frappe/erpnext/assets/40693548/f8702dd1-2428-42aa-b2b1-012078fdaa6d">

Now it gets enabled if atleast one value for each attribute is selected.

<img width="774" alt="Screenshot 2023-06-28 at 2 52 50 PM" src="https://github.com/frappe/erpnext/assets/40693548/e137dc35-2844-41af-9545-7340587733e0">
