### PR TITLE
fix: asset movement

### DIFF
--- a/erpnext/assets/doctype/asset_movement/asset_movement.js
+++ b/erpnext/assets/doctype/asset_movement/asset_movement.js
@@ -70,19 +70,21 @@ frappe.ui.form.on('Asset Movement', {
 		else if (frm.doc.purpose === 'Issue') {
 			fieldnames_to_be_altered = {
 				target_location: { read_only: 1, reqd: 0 },
-				source_location: { read_only: 1, reqd: 1 },
+				source_location: { read_only: 1, reqd: 0 },
 				from_employee: { read_only: 1, reqd: 0 },
 				to_employee: { read_only: 0, reqd: 1 }
 			};
 		}
-		Object.keys(fieldnames_to_be_altered).forEach(fieldname => {
-			let property_to_be_altered = fieldnames_to_be_altered[fieldname];
-			Object.keys(property_to_be_altered).forEach(property => {
-				let value = property_to_be_altered[property];
-				frm.set_df_property(fieldname, property, value, cdn, 'assets');
+		if (fieldnames_to_be_altered) {
+			Object.keys(fieldnames_to_be_altered).forEach(fieldname => {
+				let property_to_be_altered = fieldnames_to_be_altered[fieldname];
+				Object.keys(property_to_be_altered).forEach(property => {
+					let value = property_to_be_altered[property];
+					frm.fields_dict['assets'].grid.update_docfield_property(fieldname, property, value);
+				});
 			});
-		});
-		frm.refresh_field('assets');
+			frm.refresh_field('assets');
+		}
 	}
 });
 

--- a/erpnext/assets/doctype/asset_movement/asset_movement.json
+++ b/erpnext/assets/doctype/asset_movement/asset_movement.json
@@ -37,6 +37,7 @@
    "reqd": 1
   },
   {
+   "default": "Now",
    "fieldname": "transaction_date",
    "fieldtype": "Datetime",
    "in_list_view": 1,
@@ -95,10 +96,11 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2021-01-22 12:30:55.295670",
+ "modified": "2023-06-28 16:54:26.571083",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset Movement",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {
@@ -148,5 +150,6 @@
   }
  ],
  "sort_field": "modified",
- "sort_order": "DESC"
+ "sort_order": "DESC",
+ "states": []
 }

--- a/erpnext/assets/doctype/asset_movement/test_asset_movement.py
+++ b/erpnext/assets/doctype/asset_movement/test_asset_movement.py
@@ -47,7 +47,7 @@ class TestAssetMovement(unittest.TestCase):
 		if not frappe.db.exists("Location", "Test Location 2"):
 			frappe.get_doc({"doctype": "Location", "location_name": "Test Location 2"}).insert()
 
-		movement1 = create_asset_movement(
+		create_asset_movement(
 			purpose="Transfer",
 			company=asset.company,
 			assets=[
@@ -58,7 +58,7 @@ class TestAssetMovement(unittest.TestCase):
 		)
 		self.assertEqual(frappe.db.get_value("Asset", asset.name, "location"), "Test Location 2")
 
-		create_asset_movement(
+		movement1 = create_asset_movement(
 			purpose="Transfer",
 			company=asset.company,
 			assets=[
@@ -70,20 +70,31 @@ class TestAssetMovement(unittest.TestCase):
 		self.assertEqual(frappe.db.get_value("Asset", asset.name, "location"), "Test Location")
 
 		movement1.cancel()
-		self.assertEqual(frappe.db.get_value("Asset", asset.name, "location"), "Test Location")
+		self.assertEqual(frappe.db.get_value("Asset", asset.name, "location"), "Test Location 2")
 
 		employee = make_employee("testassetmovemp@example.com", company="_Test Company")
 		create_asset_movement(
 			purpose="Issue",
 			company=asset.company,
-			assets=[{"asset": asset.name, "source_location": "Test Location", "to_employee": employee}],
+			assets=[{"asset": asset.name, "source_location": "Test Location 2", "to_employee": employee}],
 			reference_doctype="Purchase Receipt",
 			reference_name=pr.name,
 		)
 
-		# after issuing asset should belong to an employee not at a location
+		# after issuing, asset should belong to an employee not at a location
 		self.assertEqual(frappe.db.get_value("Asset", asset.name, "location"), None)
 		self.assertEqual(frappe.db.get_value("Asset", asset.name, "custodian"), employee)
+
+		create_asset_movement(
+			purpose="Receipt",
+			company=asset.company,
+			assets=[{"asset": asset.name, "from_employee": employee, "target_location": "Test Location"}],
+			reference_doctype="Purchase Receipt",
+			reference_name=pr.name,
+		)
+
+		# after receiving, asset should belong to a location not at an employee
+		self.assertEqual(frappe.db.get_value("Asset", asset.name, "location"), "Test Location")
 
 	def test_last_movement_cancellation(self):
 		pr = make_purchase_receipt(


### PR DESCRIPTION
Asset Movement's UX was confusing -- the unnecessary fields for each 'purpose' weren't made read-only properly hence users couldn't figure out how to ~transfer~ issue an Asset to an employee. The docs are insufficient too, so will update them as well.