### PR TITLE
feat(Supplier Scorecard): added method for ordered quantity in supplier scorecard

### DIFF
--- a/erpnext/buying/doctype/supplier_scorecard/supplier_scorecard.py
+++ b/erpnext/buying/doctype/supplier_scorecard/supplier_scorecard.py
@@ -329,6 +329,11 @@ def make_default_records():
 			"variable_label": "Total Shipments",
 			"path": "get_total_shipments",
 		},
+		{
+			"param_name": "total_ordered",
+			"variable_label": "Total Ordered",
+			"path": "get_ordered_qty",
+		},
 	]
 	install_standing_docs = [
 		{

--- a/erpnext/buying/doctype/supplier_scorecard_variable/supplier_scorecard_variable.py
+++ b/erpnext/buying/doctype/supplier_scorecard_variable/supplier_scorecard_variable.py
@@ -7,6 +7,7 @@ import sys
 import frappe
 from frappe import _
 from frappe.model.document import Document
+from frappe.query_builder.functions import Sum
 from frappe.utils import getdate
 
 
@@ -420,6 +421,23 @@ def get_total_shipments(scorecard):
 	if not data:
 		data = 0
 	return data
+
+
+def get_ordered_qty(scorecard):
+	"""Returns the total number of ordered quantity (based on Purchase Orders)"""
+
+	po = frappe.qb.DocType("Purchase Order")
+
+	return (
+		frappe.qb.from_(po)
+		.select(Sum(po.total_qty))
+		.where(
+			(po.supplier == scorecard.supplier)
+			& (po.docstatus == 1)
+			& (po.transaction_date >= scorecard.get("start_date"))
+			& (po.transaction_date <= scorecard.get("end_date"))
+		)
+	).run(as_list=True)[0][0] or 0
 
 
 def get_rfq_total_number(scorecard):


### PR DESCRIPTION
This commit introduces a new method to retrieve the ordered quantity in the supplier scorecard variable. 
By incorporating this functionality, the supplier scorecard system becomes more comprehensive and provides valuable insights into the quantities of products or services ordered from each supplier. 

This enhancement enables better analysis and evaluation of suppliers based on their order quantities


`no-docs`