### PR TITLE
fix: project filtering based on company in P&L Report

### DIFF
--- a/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.js
+++ b/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.js
@@ -14,8 +14,10 @@ frappe.require("assets/erpnext/js/financial_statements.js", function() {
 			"label": __("Project"),
 			"fieldtype": "MultiSelectList",
 			get_data: function(txt) {
-				return frappe.db.get_link_options('Project', txt);
-			}
+				return frappe.db.get_link_options('Project', txt, {
+					company: frappe.query_report.get_filter_value("company")
+				});
+			},
 		},
 		{
 			"fieldname": "include_default_book_entries",

--- a/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.js
+++ b/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.js
@@ -15,7 +15,7 @@ frappe.require("assets/erpnext/js/financial_statements.js", function() {
 			"fieldtype": "MultiSelectList",
 			get_data: function(txt) {
 				return frappe.db.get_link_options('Project', txt, {
-					company: ["in", [frappe.query_report.get_filter_value("company"), ""]],
+					company: frappe.query_report.get_filter_value("company")
 				});
 			},
 		},

--- a/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.js
+++ b/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.js
@@ -15,7 +15,7 @@ frappe.require("assets/erpnext/js/financial_statements.js", function() {
 			"fieldtype": "MultiSelectList",
 			get_data: function(txt) {
 				return frappe.db.get_link_options('Project', txt, {
-					company: frappe.query_report.get_filter_value("company")
+					company: ["in", [frappe.query_report.get_filter_value("company"), ""]],
 				});
 			},
 		},

--- a/erpnext/projects/doctype/project/project.json
+++ b/erpnext/projects/doctype/project/project.json
@@ -289,7 +289,8 @@
    "fieldtype": "Link",
    "label": "Company",
    "options": "Company",
-   "remember_last_selected_value": 1
+   "remember_last_selected_value": 1,
+   "reqd": 1
   },
   {
    "fieldname": "column_break_28",


### PR DESCRIPTION
Added company specific Project Filtering in P&L report.

Previously the P&L Report filter for **Project** showed projects for all companies instead of for the selected company. 
<br>
**_Project belonging to company - Twiga_**
<img width="1304" alt="Screenshot 2023-06-30 at 12 15 48 PM" src="https://github.com/frappe/erpnext/assets/40693548/e7ca637c-bb94-4965-b556-af5c3647f02e">
<br>
**_Project filter shows the project even though another company is selected._**
<img width="1304" alt="Screenshot 2023-06-30 at 12 16 10 PM" src="https://github.com/frappe/erpnext/assets/40693548/06d25931-9b5c-4e98-a8c0-a67b158b3c2f">
<br>
**_Project filter now shows only projects for selected company._**
<img width="1304" alt="Screenshot 2023-06-30 at 12 20 13 PM" src="https://github.com/frappe/erpnext/assets/40693548/512083b4-f04e-42d4-b27f-91437cf7d12e">
