### PR TITLE
fix: incorrect reposting causing stock adjustment entry

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -1797,6 +1797,121 @@ class TestPurchaseReceipt(FrappeTestCase):
 
 		self.assertEqual(abs(data["stock_value_difference"]), 400.00)
 
+	def test_purchase_receipt_with_backdated_landed_cost_voucher(self):
+		from erpnext.controllers.sales_and_purchase_return import make_return_doc
+		from erpnext.stock.doctype.landed_cost_voucher.test_landed_cost_voucher import (
+			create_landed_cost_voucher,
+		)
+		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
+
+		item_code = "_Test Purchase Item With Landed Cost"
+		create_item(item_code)
+
+		warehouse = create_warehouse("_Test Purchase Warehouse With Landed Cost")
+		warehouse1 = create_warehouse("_Test Purchase Warehouse With Landed Cost 1")
+		warehouse2 = create_warehouse("_Test Purchase Warehouse With Landed Cost 2")
+		warehouse3 = create_warehouse("_Test Purchase Warehouse With Landed Cost 3")
+
+		pr = make_purchase_receipt(
+			item_code=item_code,
+			warehouse=warehouse,
+			posting_date=add_days(today(), -10),
+			posting_time="10:59:59",
+			qty=100,
+			rate=275.00,
+		)
+
+		pr_return = make_return_doc("Purchase Receipt", pr.name)
+		pr_return.posting_date = add_days(today(), -9)
+		pr_return.items[0].qty = 2 * -1
+		pr_return.items[0].received_qty = 2 * -1
+		pr_return.submit()
+
+		ste1 = make_stock_entry(
+			purpose="Material Transfer",
+			posting_date=add_days(today(), -8),
+			source=warehouse,
+			target=warehouse1,
+			item_code=item_code,
+			qty=20,
+			company=pr.company,
+		)
+
+		ste1.reload()
+		self.assertEqual(ste1.items[0].valuation_rate, 275.00)
+
+		ste2 = make_stock_entry(
+			purpose="Material Transfer",
+			posting_date=add_days(today(), -7),
+			source=warehouse,
+			target=warehouse2,
+			item_code=item_code,
+			qty=20,
+			company=pr.company,
+		)
+
+		ste2.reload()
+		self.assertEqual(ste2.items[0].valuation_rate, 275.00)
+
+		ste3 = make_stock_entry(
+			purpose="Material Transfer",
+			posting_date=add_days(today(), -6),
+			source=warehouse,
+			target=warehouse3,
+			item_code=item_code,
+			qty=20,
+			company=pr.company,
+		)
+
+		ste3.reload()
+		self.assertEqual(ste3.items[0].valuation_rate, 275.00)
+
+		ste4 = make_stock_entry(
+			purpose="Material Transfer",
+			posting_date=add_days(today(), -5),
+			source=warehouse1,
+			target=warehouse,
+			item_code=item_code,
+			qty=20,
+			company=pr.company,
+		)
+
+		ste4.reload()
+		self.assertEqual(ste4.items[0].valuation_rate, 275.00)
+
+		ste5 = make_stock_entry(
+			purpose="Material Transfer",
+			posting_date=add_days(today(), -4),
+			source=warehouse,
+			target=warehouse1,
+			item_code=item_code,
+			qty=20,
+			company=pr.company,
+		)
+
+		ste5.reload()
+		self.assertEqual(ste5.items[0].valuation_rate, 275.00)
+
+		create_landed_cost_voucher("Purchase Receipt", pr.name, pr.company, charges=2500 * -1)
+
+		pr.reload()
+		valuation_rate = pr.items[0].valuation_rate
+
+		ste1.reload()
+		self.assertEqual(ste1.items[0].valuation_rate, valuation_rate)
+
+		ste2.reload()
+		self.assertEqual(ste2.items[0].valuation_rate, valuation_rate)
+
+		ste3.reload()
+		self.assertEqual(ste3.items[0].valuation_rate, valuation_rate)
+
+		ste4.reload()
+		self.assertEqual(ste4.items[0].valuation_rate, valuation_rate)
+
+		ste5.reload()
+		self.assertEqual(ste5.items[0].valuation_rate, valuation_rate)
+
 
 def prepare_data_for_internal_transfer():
 	from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_internal_supplier

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -513,6 +513,7 @@ class update_entries_after(object):
 	def update_distinct_item_warehouses(self, dependant_sle):
 		key = (dependant_sle.item_code, dependant_sle.warehouse)
 		val = frappe._dict({"sle": dependant_sle})
+
 		if key not in self.distinct_item_warehouses:
 			self.distinct_item_warehouses[key] = val
 			self.new_items_found = True
@@ -522,6 +523,9 @@ class update_entries_after(object):
 			)
 			if getdate(dependant_sle.posting_date) < getdate(existing_sle_posting_date):
 				val.sle_changed = True
+				self.distinct_item_warehouses[key] = val
+				self.new_items_found = True
+			elif self.distinct_item_warehouses[key].get("reposting_status"):
 				self.distinct_item_warehouses[key] = val
 				self.new_items_found = True
 
@@ -1255,6 +1259,8 @@ def get_sle_by_voucher_detail_no(voucher_detail_no, excluded_sle=None):
 		[
 			"item_code",
 			"warehouse",
+			"actual_qty",
+			"qty_after_transaction",
 			"posting_date",
 			"posting_time",
 			"timestamp(posting_date, posting_time) as timestamp",


### PR DESCRIPTION
### **Issue**

1. Created Purchase Receipt for the item A with 100 Qty and Rate as 273.45 in the warehouse Stores
2. Created return entry against above purchase receipt for 2 quantity 
3. Created Stock Transfer Entry from "Stores" to "Warehouse A"  for 20 Qty
4. Created Stock Transfer Entry from "Stores" to "Warehouse B"  for 20 Qty
5. Created Stock Transfer Entry from "Stores" to "Warehouse C"  for 20 Qty
6. Created Stock Transfer Entry from "Warehouse A" to "Stores"  for 20 Qty (This entry has an issue)
7. After that created Backdated Landed Cost Voucher against the Purchase Receipt (created at point no 1)
8. In the landed cost voucher reduced the cost from 273.45 to 250
9. System has auto created Repost Item Valuation entry after the landed cost voucher
10. Then checked the Stock Ledger Entries and found that the system has changed the valuation rate from 273.45 to 250 for all future stock ledgers except for the Stock Entry which was created at point no 6 ("Warehouse A" to "Stores")
11. Because of this system has created Stock Adjustment gl entries against the "Material Transfer" entry


Stock Entry has no Stock Difference
<img width="1331" alt="Screenshot 2023-07-01 at 9 20 51 AM" src="https://github.com/frappe/erpnext/assets/8780500/afdade98-5c5b-479d-a6e9-6f298c3811e5">

But still has Stock Adjustment Entry
<img width="1040" alt="Screenshot 2023-07-01 at 9 20 44 AM" src="https://github.com/frappe/erpnext/assets/8780500/efb6fad2-0029-4918-8a5d-be3c8bde5d47">

