### PR TITLE
fix: delete loan module workspace properly after separation

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -331,6 +331,6 @@ execute:frappe.delete_doc('DocType', 'Cash Flow Mapper', ignore_missing=True)
 execute:frappe.delete_doc('DocType', 'Cash Flow Mapping Template', ignore_missing=True)
 execute:frappe.delete_doc('DocType', 'Cash Flow Mapping Accounts', ignore_missing=True)
 erpnext.patches.v14_0.cleanup_workspaces
-erpnext.patches.v15_0.remove_loan_management_module
+erpnext.patches.v15_0.remove_loan_management_module #2023-07-03
 erpnext.patches.v14_0.set_report_in_process_SOA
 erpnext.buying.doctype.supplier.patches.migrate_supplier_portal_users

--- a/erpnext/patches/v15_0/remove_loan_management_module.py
+++ b/erpnext/patches/v15_0/remove_loan_management_module.py
@@ -7,7 +7,7 @@ def execute():
 
 	frappe.delete_doc("Module Def", "Loan Management", ignore_missing=True, force=True)
 
-	frappe.delete_doc("Workspace", "Loan Management", ignore_missing=True, force=True)
+	frappe.delete_doc("Workspace", "Loans", ignore_missing=True, force=True)
 
 	print_formats = frappe.get_all(
 		"Print Format", {"module": "Loan Management", "standard": "Yes"}, pluck="name"


### PR DESCRIPTION
Fixed incorrect workspace name in delete_doc. Fixes #35966.