### PR TITLE
fix: Further sort purchase_order_analysis to get consistent response

### DIFF
--- a/erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py
+++ b/erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py
@@ -84,7 +84,7 @@ def get_data(conditions, filters):
 			and po.docstatus = 1
 			{0}
 		GROUP BY poi.name
-		ORDER BY po.transaction_date ASC
+		ORDER BY po.transaction_date ASC, poi.item_code ASC
 	""".format(
 			conditions
 		),


### PR DESCRIPTION
Since the data was sorted by transaction_date, the report sorting order used to be inconsistent every time if there were lots of records with the same transaction date. This is used to create problems while exporting reports as "Excel" with filters.

more info:

> while exporting data as Excel with column filter, we pass “visible_idx” from client-side… but due to inconsistent response from the server (DB) the… server picks wrong column as visible row.

similar to: https://github.com/frappe/erpnext/pull/29471

--
better fix might take some time: https://github.com/frappe/frappe/issues/21581