### PR TITLE
fix: error messages while evaluating formulas and handle line boundaries characters

### DIFF
--- a/erpnext/payroll/utils.py
+++ b/erpnext/payroll/utils.py
@@ -1,0 +1,33 @@
+import frappe
+from frappe import _
+from frappe.utils import get_link_to_form
+
+
+def sanitize_condition_and_formula(string: str) -> str:
+	if not string:
+		return " "
+
+	# remove forward and trailing spaces, newlines and other line boundaries
+	parts = string.strip().splitlines()
+	string = " ".join(parts)
+
+	return string
+
+def prepare_error_msg(*, row: dict, error: str, title: str, description: str):
+	data = frappe._dict(
+		{
+			"doctype": row.parenttype,
+			"name": row.parent,
+			"doclink": get_link_to_form(row.parenttype, row.parent),
+			"row_id": row.idx,
+			"error": error,
+			"title": title,
+			"description": description or "",
+		}
+	)
+
+	message = _(
+		"Error while evaluating the {doctype} {doclink} at row {row_id}. <br><br> <b>Error:</b> {error} <br><br> <b>Hint:</b> {description}"
+	).format(**data)
+
+	frappe.throw(message, title=title)


### PR DESCRIPTION
### Issue 1: error message is not user friendly 
#### Before 
![2023-07-04 12 18 01](https://github.com/frappe/erpnext/assets/3784093/1a1b7d46-1b05-474e-a3e5-0f98fbc752ed)

#### After

<img width="615" alt="Screenshot 2023-07-04 at 12 20 30 PM" src="https://github.com/frappe/erpnext/assets/3784093/7356f83b-014c-4c9f-8998-f64e42e93a51">

### Issue 2: The system not considering line boundaries character
Before evaluating formulas or conditions, the system use to replace newline character `\n` but its not considering `\r\n`.

To fix the issue, added a function to sanitise condition and formula string. The function uses `splitlines` method to remove all the line boundaries characters. 

ref: https://www.geeksforgeeks.org/python-string-splitlines-method/

![2023-07-04 12 30 35](https://github.com/frappe/erpnext/assets/3784093/74d00b4c-221a-4214-b711-eb73e4dac896)


