### PR TITLE
fix: error messages while evaluating formulas and handle line boundaries

### DIFF
--- a/erpnext/payroll/utils.py
+++ b/erpnext/payroll/utils.py
@@ -4,6 +4,7 @@ import frappe
 from frappe import _
 from frappe.utils import get_link_to_form
 
+
 def sanitize_expression(string: Optional[str] = None) -> Optional[str]:
 	"""
 	Sanitizes an expression string by removing leading/trailing spaces, newlines, and line boundaries.

--- a/erpnext/payroll/utils.py
+++ b/erpnext/payroll/utils.py
@@ -1,0 +1,34 @@
+from typing import Optional
+
+import frappe
+from frappe import _
+from frappe.utils import get_link_to_form
+
+
+def sanitize_expression(string: Optional[str] = None) -> Optional[str]:
+	if not string:
+		return None
+
+	# remove forward and trailing spaces, newlines and other line boundaries
+	parts = string.strip().splitlines()
+	string = " ".join(parts)
+
+	return string
+
+
+def prepare_error_msg(*, row: dict, error: str, expression: str, description: str) -> str:
+	data = frappe._dict(
+		{
+			"doctype": row.parenttype,
+			"doclink": get_link_to_form(row.parenttype, row.parent),
+			"parentfield": row.parentfield.title(),
+			"row_id": row.idx,
+			"expression": expression,
+			"error": error,
+			"description": description or "",
+		}
+	)
+
+	return _(
+		"Error in {parentfield}, while evaluating the {doctype} {doclink} at row {row_id}. <br><br> <b>Expression:</b> {expression}. <br><br> <b>Error:</b> {error} <br><br> <b>Hint:</b> {description}"
+	).format(**data)

--- a/erpnext/payroll/utils.py
+++ b/erpnext/payroll/utils.py
@@ -53,20 +53,14 @@ def prepare_error_msg(*, row: dict, error: str, expression: str, description: st
 	    description = "Check the syntax of the expression."
 	    error_msg = prepare_error_msg(row=row, error=error, expression=expression, description=description)
 	"""
-	# Create a dictionary to store the error message data
-	data = frappe._dict(
-		{
-			"doctype": row.parenttype,
-			"doclink": get_link_to_form(row.parenttype, row.parent),
-			"parentfield": row.parentfield.title(),
-			"row_id": row.idx,
-			"expression": expression,
-			"error": error,
-			"description": description or "",
-		}
+	msg = _("Error in {0} while evaluating the {1} {2} at row {3}").format(
+		row.parentfield.title(), row.parenttype, get_link_to_form(row.parenttype, row.parent), row.idx
+	)
+	msg += "<br><br>{0}: {1}<br><br>{2}: {3}".format(
+		frappe.bold(_("Expression:")), expression, frappe.bold(_("Error:")), error
 	)
 
-	# Format and return the error message string
-	return _(
-		"Error in {parentfield}, while evaluating the {doctype} {doclink} at row {row_id}. <br><br> <b>Expression:</b> {expression}. <br><br> <b>Error:</b> {error} <br><br> <b>Hint:</b> {description}"
-	).format(**data)
+	if description:
+		msg += "<br><br>{0}: {1}".format(frappe.bold(_("Hint:")), description)
+
+	return msg

--- a/erpnext/payroll/utils.py
+++ b/erpnext/payroll/utils.py
@@ -4,12 +4,23 @@ import frappe
 from frappe import _
 from frappe.utils import get_link_to_form
 
-
 def sanitize_expression(string: Optional[str] = None) -> Optional[str]:
+	"""
+	Sanitizes an expression string by removing leading/trailing spaces, newlines, and line boundaries.
+
+	Args:
+	    string (Optional[str]): The input string to be sanitized (default: None).
+
+	Returns:
+	    Optional[str]: The sanitized string or None if the input string is empty or None.
+
+	Example:
+	    expression = "\r\n    gross_pay > 10000\n    "
+	    sanitized_expr = sanitize_expression(expression)
+	"""
 	if not string:
 		return None
 
-	# remove forward and trailing spaces, newlines and other line boundaries
 	parts = string.strip().splitlines()
 	string = " ".join(parts)
 
@@ -17,6 +28,31 @@ def sanitize_expression(string: Optional[str] = None) -> Optional[str]:
 
 
 def prepare_error_msg(*, row: dict, error: str, expression: str, description: str) -> str:
+	"""
+	Prepares an error message string with formatted information about the error.
+
+	Args:
+	    row (dict): A dictionary representing the row data.
+	    error (str): The error message.
+	    expression (str): The expression that caused the error.
+	    description (str): Additional description or hint for the error (optional).
+
+	Returns:
+	    str: The formatted error message string.
+
+	Example:
+	    row = {
+	        "parenttype": "Salary Structure",
+	        "parent": "Salary Structure-00001",
+	        "parentfield": "earnings",
+	        "idx": 1
+	    }
+	    error = "SyntaxError: invalid syntax"
+	    expression = " 200 if (gross_pay>10000 and month!=  'Feb')) else 0 "
+	    description = "Check the syntax of the expression."
+	    error_msg = prepare_error_msg(row=row, error=error, expression=expression, description=description)
+	"""
+	# Create a dictionary to store the error message data
 	data = frappe._dict(
 		{
 			"doctype": row.parenttype,
@@ -29,6 +65,7 @@ def prepare_error_msg(*, row: dict, error: str, expression: str, description: st
 		}
 	)
 
+	# Format and return the error message string
 	return _(
 		"Error in {parentfield}, while evaluating the {doctype} {doclink} at row {row_id}. <br><br> <b>Expression:</b> {expression}. <br><br> <b>Error:</b> {error} <br><br> <b>Hint:</b> {description}"
 	).format(**data)


### PR DESCRIPTION
### Issue 1: error message is not user friendly 
#### Before 
![2023-07-04 12 18 01](https://github.com/frappe/erpnext/assets/3784093/1a1b7d46-1b05-474e-a3e5-0f98fbc752ed)

#### After
<img width="594" alt="Screenshot 2023-07-04 at 2 42 59 PM" src="https://github.com/frappe/erpnext/assets/3784093/d843877d-e8b3-4517-a4b4-3867e423cee3">



### Issue 2: The system not considering line boundaries character
Before evaluating formulas or conditions, the system use to replace newline character `\n` but its not considering `\r\n`.

To fix the issue, added a function to sanitise condition and formula string. The function uses `splitlines` method to remove all the line boundaries characters. 

ref: https://www.geeksforgeeks.org/python-string-splitlines-method/

![2023-07-04 12 30 35](https://github.com/frappe/erpnext/assets/3784093/74d00b4c-221a-4214-b711-eb73e4dac896)


