### PR TITLE
fix: handle loan_repayment's posting_date datetime in bank_clearance_summary report

### DIFF
--- a/erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py
+++ b/erpnext/accounts/report/bank_clearance_summary/bank_clearance_summary.py
@@ -152,5 +152,5 @@ def get_entries(filters):
 
 	return sorted(
 		journal_entries + payment_entries + loan_disbursements + loan_repayments,
-		key=lambda k: k[2] or getdate(nowdate()),
+		key=lambda k: k[2].strftime("%H%M%S") or getdate(nowdate()),
 	)


### PR DESCRIPTION
The posting_date of loan_disbursement is "Date" and that of loan_repayment is "Datetime", resulting in `TypeError: can't compare datetime.datetime to datetime.date.`. So converting them into strings and then comparing.

Fixes #35949.