### PR TITLE
fix(Payment Entry): compare rounded amount

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -235,7 +235,7 @@ class PaymentEntry(AccountsController):
 			# The reference has already been partly paid
 			elif (
 				latest.outstanding_amount < latest.invoice_amount
-				and d.outstanding_amount != latest.outstanding_amount
+				and flt(d.outstanding_amount, d.precision("outstanding_amount")) != latest.outstanding_amount
 			):
 				frappe.throw(
 					_(


### PR DESCRIPTION
Resolves a bug introduced by #31166

The condition used to compare `d.outstanding_amount` (precise value) with `latest.outstanding_amount` (rounded value). The result is that we cannot currently create Payment Entries because of tiny differences like `0.0000003`.