### PR TITLE
feat: Unit Price Items

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -797,10 +797,15 @@ class AccountsController(TransactionBase):
 		return gl_dict
 
 	def validate_qty_is_not_zero(self):
-		if self.doctype != "Purchase Receipt":
-			for item in self.items:
-				if not item.qty:
-					frappe.throw(_("Item quantity can not be zero"))
+		if self.doctype == "Purchase Receipt":
+			return
+
+		for item in self.items:
+			if not item.qty and not item.get("is_unit_price_item"):
+				frappe.throw(
+					_("Row #{0}: Item quantity can not be zero").format(item.idx),
+					title=_("Invalid Quantity"),
+				)
 
 	def validate_account_currency(self, account, account_currency=None):
 		valid_currency = [self.company_currency]

--- a/erpnext/controllers/status_updater.py
+++ b/erpnext/controllers/status_updater.py
@@ -543,7 +543,7 @@ class StatusUpdater(Document):
 				)[0][0]
 			)
 
-			per_billed = (min(ref_doc_qty, billed_qty) / ref_doc_qty) * 100
+			per_billed = (min(ref_doc_qty, billed_qty) / (ref_doc_qty or 1)) * 100
 
 			ref_doc = frappe.get_doc(ref_dt, ref_dn)
 

--- a/erpnext/selling/doctype/quotation_item/quotation_item.json
+++ b/erpnext/selling/doctype/quotation_item/quotation_item.json
@@ -48,6 +48,7 @@
   "base_net_amount",
   "pricing_rules",
   "stock_uom_rate",
+  "is_unit_price_item",
   "is_free_item",
   "is_alternative",
   "has_alternative_item",
@@ -661,12 +662,20 @@
    "label": "Has Alternative Item",
    "print_hide": 1,
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "is_unit_price_item",
+   "fieldtype": "Check",
+   "in_list_view": 1,
+   "label": "Is Unit Price Item",
+   "print_hide": 1
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-02-06 11:00:07.042364",
+ "modified": "2023-07-07 12:12:39.691139",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Quotation Item",

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -901,7 +901,9 @@ def make_sales_invoice(source_name, target_doc=None, ignore_permissions=False):
 		target.debit_to = get_party_account("Customer", source.customer, source.company)
 
 	def update_item(source, target, source_parent):
-		target.amount = flt(source.amount) - flt(source.billed_amt)
+		pending_amount = flt(source.amount) - flt(source.billed_amt)
+		target.amount = 0 if source.get("is_unit_price_item") else pending_amount
+
 		target.base_amount = target.amount * flt(source_parent.conversion_rate)
 		target.qty = (
 			target.amount / flt(source.rate)
@@ -939,7 +941,7 @@ def make_sales_invoice(source_name, target_doc=None, ignore_permissions=False):
 					"parent": "sales_order",
 				},
 				"postprocess": update_item,
-				"condition": lambda doc: doc.qty
+				"condition": lambda doc: (doc.qty or doc.get("is_unit_price_item"))
 				and (doc.base_amount == 0 or abs(doc.billed_amt) < abs(doc.amount)),
 			},
 			"Sales Taxes and Charges": {"doctype": "Sales Taxes and Charges", "add_if_empty": True},

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -902,7 +902,8 @@ def make_sales_invoice(source_name, target_doc=None, ignore_permissions=False):
 
 	def update_item(source, target, source_parent):
 		pending_amount = flt(source.amount) - flt(source.billed_amt)
-		target.amount = 0 if source.get("is_unit_price_item") else pending_amount
+		# 0 Amount rows (as seen in Unit Price Items) should be mapped as it is
+		target.amount = pending_amount if flt(source.amount) else 0
 
 		target.base_amount = target.amount * flt(source_parent.conversion_rate)
 		target.qty = (

--- a/erpnext/selling/doctype/sales_order_item/sales_order_item.json
+++ b/erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -49,6 +49,7 @@
   "base_amount",
   "pricing_rules",
   "stock_uom_rate",
+  "is_unit_price_item",
   "is_free_item",
   "grant_commission",
   "section_break_24",
@@ -882,12 +883,20 @@
    "print_hide": 1,
    "read_only": 1,
    "report_hide": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "is_unit_price_item",
+   "fieldtype": "Check",
+   "in_standard_filter": 1,
+   "label": "Is Unit Price Item",
+   "print_hide": 1
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-04-04 10:44:05.707488",
+ "modified": "2023-07-07 12:13:55.264267",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order Item",


### PR DESCRIPTION
Closes https://github.com/frappe/erpnext/issues/36012 (Refer for more Info)

#### Concept
- **Unit Price Items** or **Unit Price Contracts** are a way to sell/agree upon a list of items whose quantity cannot be determined at the time of the sale but Rate/Unit Price can.
- The quantity is determined once the job is fully or partially done and the agreement is to bill as per the Unit Price

<details><summary> <b>Examples:</b> </summary>

-  **Sales Order for a Consultation firm:**
<table>
<th>Item</th>
<th>Rate</th>
<th>Qty</th>

<tr>
  <td>Consulting (per hour)</td>
  <td>$60</td>
  <td>?</td>
</tr>
</table>

-  **Sales Order for a Construction Company for Road Work:**
<table>
<th>Item</th>
<th>Rate</th>
<th>Qty</th>

<tr>
  <td>Labour (per hour)</td>
  <td>$60</td>
  <td>?</td>
</tr>
<tr>
  <td>Subcontracting/Partner Costs (per hour)</td>
  <td>$40</td>
  <td>?</td>
</tr>
</table>

- The Sales Order/Quotation in both cases is agreed upon based on the unit cost/rate. 
- The ? Quantities will be determined once the job is done **E.g.** The hours put in for road work will be updated once half or all of the work is done. Invoicing is done on the basis of actual quantities.

</details>

### Solution:

- Rows in a Quotation or Sales Order can be marked as **Is Unit Price Item**. These rows can have 0 qty as their qty is unknown
- <img width="600" alt="Screenshot 2023-07-07 at 5 30 29 PM" src="https://github.com/frappe/erpnext/assets/25857446/8f5704d0-b1e0-41f5-898a-9786c6da3629">
- <img width="600" alt="Screenshot 2023-07-07 at 5 32 34 PM" src="https://github.com/frappe/erpnext/assets/25857446/c53363b8-2264-4ce2-a736-87c784410331">


- **Why 0 qty ?** 1 Qty might be confusing as users might assume 1 qty is being sold in actuality. Also this makes handling billing, etc. easy with the least amount of code changes
- While mapping from SO > SI, the Unit Price row qty is mapped as-is. Since the final qty is indeterminate, no pending qty can be calculated
    ![2023-07-07 17 34 50](https://github.com/frappe/erpnext/assets/25857446/fa7dad95-91c6-422c-b8ed-29609f2b39f9)


Users can decide to manage their Sales Orders in two ways

1. Keep updating the Qty in the Sales Order
    - Once a portion of work is done, users can update the qty in the SO > Create a SI for the updated qty
2. Keep the SO Qty 0
    - For those who might think constant updation SO is adding friction or are not particular about tracking via SO, can leave the quantities to be 0.
    - They can keep making Sales Invoices with actual quantities against the SO with 0 qty. The Billed % will always show as 0
    - **The Sales Order will have to be manually Closed**. Since there's no way to know when the Sales Order is truly Completed.


ToDo:

- [ ] Docs
- [ ] Tests