### PR TITLE
fix: don't allow negative rate

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -3371,6 +3371,13 @@ class TestSalesInvoice(unittest.TestCase):
 
 		set_advance_flag(company="_Test Company", flag=0, default_account="")
 
+	def test_sales_return_negative_rate(self):
+		si = create_sales_invoice(is_return=1, qty=-2, rate=-10, do_not_save=True)
+		self.assertRaises(frappe.ValidationError, si.save)
+
+		si.items[0].rate = 10
+		si.save()
+
 
 def set_advance_flag(company, flag, default_account):
 	frappe.db.set_value(

--- a/erpnext/controllers/status_updater.py
+++ b/erpnext/controllers/status_updater.py
@@ -233,6 +233,9 @@ class StatusUpdater(Document):
 				if hasattr(d, "qty") and d.qty > 0 and self.get("is_return"):
 					frappe.throw(_("For an item {0}, quantity must be negative number").format(d.item_code))
 
+				if hasattr(d, "rate") and d.rate < 0:
+					frappe.throw(_("For an item {0}, rate must be a positive number").format(d.item_code))
+
 				if d.doctype == args["source_dt"] and d.get(args["join_field"]):
 					args["name"] = d.get(args["join_field"])
 

--- a/erpnext/controllers/status_updater.py
+++ b/erpnext/controllers/status_updater.py
@@ -233,7 +233,7 @@ class StatusUpdater(Document):
 				if hasattr(d, "qty") and d.qty > 0 and self.get("is_return"):
 					frappe.throw(_("For an item {0}, quantity must be negative number").format(d.item_code))
 
-				if hasattr(d, "rate") and d.rate < 0:
+				if hasattr(d, "item_code") and hasattr(d, "rate") and d.rate < 0:
 					frappe.throw(_("For an item {0}, rate must be a positive number").format(d.item_code))
 
 				if d.doctype == args["source_dt"] and d.get(args["join_field"]):


### PR DESCRIPTION
closes: https://github.com/frappe/erpnext/issues/31533

### Context
If rate is **negative**, and is_return is `True` the sales invoice will be posted to the GL as a debit note, instead of a credit note.