### PR TITLE
fix: gst_hsn_code is ambiguous on gst reports

### DIFF
--- a/erpnext/regional/report/gst_itemised_purchase_register/gst_itemised_purchase_register.py
+++ b/erpnext/regional/report/gst_itemised_purchase_register/gst_itemised_purchase_register.py
@@ -28,7 +28,7 @@ def execute(filters=None):
 			"gst_category",
 			"export_type",
 			"ecommerce_gstin",
-			"gst_hsn_code",
+			"`tabPurchase Invoice Item`.gst_hsn_code",
 			"bill_no",
 			"bill_date",
 		],

--- a/erpnext/regional/report/gst_itemised_sales_register/gst_itemised_sales_register.py
+++ b/erpnext/regional/report/gst_itemised_sales_register/gst_itemised_sales_register.py
@@ -39,7 +39,7 @@ def execute(filters=None):
 		"gst_category",
 		"export_type",
 		"ecommerce_gstin",
-		"gst_hsn_code",
+		"`tabSales Invoice Item`.gst_hsn_code",
 	]
 
 	additional_conditions = get_conditions(filters, additional_query_columns)


### PR DESCRIPTION
Fix ambiguous field error in GST Itemised Sales and Purchase Register.

<img width="1406" alt="Screenshot 2023-07-08 at 6 55 06 AM" src="https://github.com/frappe/erpnext/assets/3272205/abcd0b56-ea3c-43ef-85f2-e78585be95d5">
