### PR TITLE
fix: precision causing outstanding issue on partly paid invoices

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -235,7 +235,7 @@ class PaymentEntry(AccountsController):
 			# The reference has already been partly paid
 			elif (
 				latest.outstanding_amount < latest.invoice_amount
-				and flt(d.outstanding_amount, d.precision("outstanding_amount")) != latest.outstanding_amount
+				and flt(d.outstanding_amount, d.precision("outstanding_amount")) != flt(latest.outstanding_amount, d.precision("outstanding_amount"))
 			):
 				frappe.throw(
 					_(

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -233,10 +233,9 @@ class PaymentEntry(AccountsController):
 					_("{0} {1} has already been fully paid.").format(d.reference_doctype, d.reference_name)
 				)
 			# The reference has already been partly paid
-			elif (
-				latest.outstanding_amount < latest.invoice_amount
-				and flt(d.outstanding_amount, d.precision("outstanding_amount")) != flt(latest.outstanding_amount, d.precision("outstanding_amount"))
-			):
+			elif latest.outstanding_amount < latest.invoice_amount and flt(
+				d.outstanding_amount, d.precision("outstanding_amount")
+			) != flt(latest.outstanding_amount, d.precision("outstanding_amount")):
 				frappe.throw(
 					_(
 						"{0} {1} has already been partly paid. Please use the 'Get Outstanding Invoice' or the 'Get Outstanding Orders' button to get the latest outstanding amounts."


### PR DESCRIPTION
Payment Entry submissions are at halt due to difference in outstanding caused by precision.
@ruthra-kumar @deepeshgarg007 