### PR TITLE
feat: Provision to auto create Exchange Rate Revaluation

### DIFF
--- a/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py
+++ b/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.py
@@ -93,6 +93,12 @@ class ExchangeRateRevaluation(Document):
 
 		return True
 
+	def fetch_and_calculate_accounts_data(self):
+		accounts = self.get_accounts_data()
+		if accounts:
+			for acc in accounts:
+				self.append("accounts", acc)
+
 	@frappe.whitelist()
 	def get_accounts_data(self):
 		self.validate_mandatory()

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -1408,6 +1408,50 @@ def check_and_delete_linked_reports(report):
 			frappe.delete_doc("Desktop Icon", icon)
 
 
+def create_err_and_its_journals(companies: list = None) -> None:
+	if companies:
+		for company in companies:
+			err = frappe.new_doc("Exchange Rate Revaluation")
+			err.company = company.name
+			err.posting_date = nowdate()
+			err.rounding_loss_allowance = 0.0
+
+			err.fetch_and_calculate_accounts_data()
+			if err.accounts:
+				err.save().submit()
+				response = err.make_jv_entries()
+
+				if company.submit_err_jv:
+					jv = response.get("revaluation_jv", None)
+					jv and frappe.get_doc("Journal Entry", jv).submit()
+					jv = response.get("zero_balance_jv", None)
+					jv and frappe.get_doc("Journal Entry", jv).submit()
+
+
+def auto_create_exchange_rate_revaluation_daily() -> None:
+	"""
+	Executed by background job
+	"""
+	companies = frappe.db.get_all(
+		"Company",
+		filters={"auto_exchange_rate_revaluation": 1, "auto_err_frequency": "Daily"},
+		fields=["name", "submit_err_jv"],
+	)
+	create_err_and_its_journals(companies)
+
+
+def auto_create_exchange_rate_revaluation_weekly() -> None:
+	"""
+	Executed by background job
+	"""
+	companies = frappe.db.get_all(
+		"Company",
+		filters={"auto_exchange_rate_revaluation": 1, "auto_err_frequency": "Weekly"},
+		fields=["name", "submit_err_jv"],
+	)
+	create_err_and_its_journals(companies)
+
+
 def get_payment_ledger_entries(gl_entries, cancel=0):
 	ple_map = []
 	if gl_entries:

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -415,6 +415,10 @@ scheduler_events = {
 		"erpnext.selling.doctype.quotation.quotation.set_expired_status",
 		"erpnext.buying.doctype.supplier_quotation.supplier_quotation.set_expired_status",
 		"erpnext.accounts.doctype.process_statement_of_accounts.process_statement_of_accounts.send_auto_email",
+		"erpnext.accounts.utils.auto_create_exchange_rate_revaluation_daily",
+	],
+	"weekly": [
+		"erpnext.accounts.utils.auto_create_exchange_rate_revaluation_weekly",
 	],
 	"daily_long": [
 		"erpnext.setup.doctype.email_digest.email_digest.send",

--- a/erpnext/setup/doctype/company/company.json
+++ b/erpnext/setup/doctype/company/company.json
@@ -98,6 +98,7 @@
   "exchange_rate_revaluation_settings_section",
   "auto_exchange_rate_revaluation",
   "auto_err_frequency",
+  "submit_err_jv",
   "budget_detail",
   "exception_budget_approver_role",
   "registration_info",
@@ -751,6 +752,12 @@
    "fieldtype": "Select",
    "label": "Frequency",
    "options": "Daily\nWeekly"
+  },
+  {
+   "default": "0",
+   "fieldname": "submit_err_jv",
+   "fieldtype": "Check",
+   "label": "Submit ERR Journals?"
   }
  ],
  "icon": "fa fa-building",
@@ -758,7 +765,7 @@
  "image_field": "company_logo",
  "is_tree": 1,
  "links": [],
- "modified": "2023-07-03 14:29:56.262188",
+ "modified": "2023-07-07 05:41:41.537256",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Company",

--- a/erpnext/setup/doctype/company/company.json
+++ b/erpnext/setup/doctype/company/company.json
@@ -95,6 +95,9 @@
   "depreciation_cost_center",
   "capital_work_in_progress_account",
   "asset_received_but_not_billed",
+  "exchange_rate_revaluation_settings_section",
+  "auto_exchange_rate_revaluation",
+  "auto_err_frequency",
   "budget_detail",
   "exception_budget_approver_role",
   "registration_info",
@@ -731,6 +734,23 @@
    "fieldname": "book_advance_payments_in_separate_party_account",
    "fieldtype": "Check",
    "label": "Book Advance Payments in Separate Party Account"
+  },
+  {
+   "fieldname": "exchange_rate_revaluation_settings_section",
+   "fieldtype": "Section Break",
+   "label": "Exchange Rate Revaluation Settings"
+  },
+  {
+   "default": "0",
+   "fieldname": "auto_exchange_rate_revaluation",
+   "fieldtype": "Check",
+   "label": "Auto Create Exchange Rate Revaluation"
+  },
+  {
+   "fieldname": "auto_err_frequency",
+   "fieldtype": "Select",
+   "label": "Frequency",
+   "options": "Daily\nWeekly"
   }
  ],
  "icon": "fa fa-building",
@@ -738,7 +758,7 @@
  "image_field": "company_logo",
  "is_tree": 1,
  "links": [],
- "modified": "2023-06-23 18:22:27.219706",
+ "modified": "2023-07-03 14:29:56.262188",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Company",


### PR DESCRIPTION
Provision for auto creation of Exchange Rate Revaluation on a daily/weekly frequency.

Company master will have new section called `Exchange Rate Revaluation Settings`, through which this can be enabled.
<img width="973" alt="Screenshot 2023-07-10 at 10 54 55 AM" src="https://github.com/frappe/erpnext/assets/3272205/e6ba671e-90f7-4f3e-bd2f-ff0ce5fcbd8f">


Documentation can be found [here](https://docs.erpnext.com/docs/v14/user/manual/en/accounts/exchange-rate-revaluation#3-automate-exchange-rate-revaluation-creation). 