### PR TITLE
fix: Ambiguous column error while submitting stock entry

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -1026,7 +1026,7 @@ class WorkOrder(Document):
 			consumed_qty = frappe.db.sql(
 				"""
 				SELECT
-					SUM(qty)
+					SUM(detail.qty)
 				FROM
 					`tabStock Entry` entry,
 					`tabStock Entry Detail` detail


### PR DESCRIPTION
1052, "Column 'qty' in field list is ambiguous in latest version-14

![error](https://github.com/frappe/erpnext/assets/973676/176cc40d-0215-45cd-b47f-f77587c4dd30)
