### PR TITLE
fix: Delivery Note return valuation

### DIFF
--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -669,7 +669,11 @@ def get_filters(
 	if reference_voucher_detail_no:
 		filters["voucher_detail_no"] = reference_voucher_detail_no
 
-	if item_row and item_row.get("warehouse"):
+	if (
+		voucher_type in ["Purchase Receipt", "Purchase Invoice"]
+		and item_row
+		and item_row.get("warehouse")
+	):
 		filters["warehouse"] = item_row.get("warehouse")
 
 	return filters


### PR DESCRIPTION
Recently to fix the rejected qty return issue we have added the warehouse filter, more detail can check [here](https://github.com/frappe/erpnext/pull/35747).

After the fix one of the customer started facing an issue that for the returned Delivery Note the valuation rate has set as zero. After the investigation came to know that they've changed the Warehouse on the returned Delivery Note which is causing the issue. 

To fix this issue added the condition that if the return is against the delivery note / sales invoice then don't check the warehouse condition.