### PR TITLE
fix(Employee Advance): check if return amount is set before validating

### DIFF
--- a/erpnext/hr/doctype/employee_advance/employee_advance.py
+++ b/erpnext/hr/doctype/employee_advance/employee_advance.py
@@ -108,8 +108,8 @@ class EmployeeAdvance(Document):
 				EmployeeAdvanceOverPayment,
 			)
 
-		if flt(return_amount) > self.paid_amount - self.claimed_amount:
-			frappe.throw(_("Return amount cannot be greater unclaimed amount"))
+		if flt(return_amount) > 0 and flt(return_amount) > (self.paid_amount - self.claimed_amount):
+			frappe.throw(_("Return amount cannot be greater than unclaimed amount"))
 
 		self.db_set("paid_amount", paid_amount)
 		self.db_set("return_amount", return_amount)


### PR DESCRIPTION
## Steps to replicate

1. Create an Employee Advance
2. Create a Payment Entry against the advance. The advance will be marked as Paid.
3. Create an Expense Claim against the advance (paid advances are available for claim). The advance will be marked as Claimed.
4. Cancel the payment entry created in step 2 (maybe for some correction in the reference number, etc.). Advance will be marked as Unpaid. 
5. Now try creating a payment entry against the unpaid advance. This throws a validation error regarding return amount:

<img width="1314" alt="image" src="https://github.com/frappe/erpnext/assets/24353136/e7ef09c3-88d0-4db8-9175-b48acd7b7056">


This expression is True here:

`flt(return_amount) > self.paid_amount - self.claimed_amount`
`= 0 > 0 - 5000`

<img width="1069" alt="image" src="https://github.com/frappe/erpnext/assets/24353136/ba6a387a-1044-4c80-a4d6-b292be70cba9">

## Fix

Check if the return amount is set before validating it.

Although canceling payment entry against an already claimed advance shouldn't be allowed IG. That's a separate discussion.
