### PR TITLE
feat: add project filter in reports importing financial statements js file

### DIFF
--- a/erpnext/accounts/report/gross_and_net_profit_report/gross_and_net_profit_report.js
+++ b/erpnext/accounts/report/gross_and_net_profit_report/gross_and_net_profit_report.js
@@ -13,14 +13,6 @@ frappe.require("assets/erpnext/js/financial_statements.js", function() {
 
 	frappe.query_reports["Gross and Net Profit Report"]["filters"].push(
 		{
-			"fieldname": "project",
-			"label": __("Project"),
-			"fieldtype": "MultiSelectList",
-			get_data: function(txt) {
-				return frappe.db.get_link_options('Project', txt);
-			}
-		},
-		{
 			"fieldname": "accumulated_values",
 			"label": __("Accumulated Values"),
 			"fieldtype": "Check"

--- a/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.js
+++ b/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.js
@@ -10,16 +10,6 @@ frappe.require("assets/erpnext/js/financial_statements.js", function() {
 
 	frappe.query_reports["Profit and Loss Statement"]["filters"].push(
 		{
-			"fieldname": "project",
-			"label": __("Project"),
-			"fieldtype": "MultiSelectList",
-			get_data: function(txt) {
-				return frappe.db.get_link_options('Project', txt, {
-					company: frappe.query_report.get_filter_value("company")
-				});
-			},
-		},
-		{
 			"fieldname": "include_default_book_entries",
 			"label": __("Include Default Book Entries"),
 			"fieldtype": "Check",

--- a/erpnext/public/js/financial_statements.js
+++ b/erpnext/public/js/financial_statements.js
@@ -182,6 +182,16 @@ function get_filters() {
 					company: frappe.query_report.get_filter_value("company")
 				});
 			}
+		},
+		{
+			"fieldname": "project",
+			"label": __("Project"),
+			"fieldtype": "MultiSelectList",
+			get_data: function(txt) {
+				return frappe.db.get_link_options('Project', txt, {
+					company: frappe.query_report.get_filter_value("company")
+				});
+			},
 		}
 	]
 


### PR DESCRIPTION
The reports that extended the `financial_statements.js` file either defined the project filter explicitly after inheriting the filters from the file or did not have the option to filter by project(Balance Sheet Report).

Added the Project filter in the `financial_statements.js` file which now shows up in the **Balance Sheet Report**. 
<br>
<img width="1273" alt="Screenshot 2023-07-12 at 10 35 45 AM" src="https://github.com/frappe/erpnext/assets/40693548/fceef304-0001-4397-b3e1-b18a71182d3e">
<br>
Removed the code to explicitly define the filter again in **Gross and Net Profit Report** and **Profit & Loss Statement Report**.

Issue #35967
<br>
`no-docs`