### PR TITLE
fix: improve "Update Items" modal

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -632,7 +632,6 @@ erpnext.utils.update_child_items = function(opts) {
 		fields.splice(3, 0, {
 			fieldtype: 'Float',
 			fieldname: "conversion_factor",
-			in_list_view: 1,
 			label: __("Conversion Factor"),
 			precision: get_precision('conversion_factor')
 		})

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -640,6 +640,7 @@ erpnext.utils.update_child_items = function(opts) {
 
 	new frappe.ui.Dialog({
 		title: __("Update Items"),
+		size: "extra-large",
 		fields: [
 			{
 				fieldname: "trans_items",


### PR DESCRIPTION
### Before

- The modal was quite small, hard to make sense of long item names and many items
- Item list showed a column _Conversion Factor_, which seemed pretty random. This would only make sense with two different UOMs next to it.

![Bildschirmfoto 2023-07-12 um 13 22 42](https://github.com/frappe/erpnext/assets/14891507/77744725-237e-4457-98bf-cd08f774bc8a)

### After

- Increased the size of the modal to look less crammed
- Removed the column _Conversion Factor_ from the overview. (It stays available in the detail view.)

![Bildschirmfoto 2023-07-12 um 13 30 58](https://github.com/frappe/erpnext/assets/14891507/ef28e0a0-7ade-4442-8e09-61006c80a588)
