### PR TITLE
feat: filtering based on accounting dimensions in profitability analysis

### DIFF
--- a/erpnext/accounts/report/profitability_analysis/profitability_analysis.js
+++ b/erpnext/accounts/report/profitability_analysis/profitability_analysis.js
@@ -18,7 +18,15 @@ frappe.require("assets/erpnext/js/financial_statements.js", function() {
 				"fieldtype": "Select",
 				"options": ["Cost Center", "Project", "Accounting Dimension"],
 				"default": "Cost Center",
-				"reqd": 1
+				"reqd": 1,
+				"on_change": function(query_report){
+					let based_on = query_report.get_values().based_on;
+					if(based_on!='Accounting Dimension'){
+						frappe.query_report.set_filter_value({
+							accounting_dimension: ''
+						});
+					}
+				}
 			},
 			{
 				"fieldname": "accounting_dimension",

--- a/erpnext/accounts/report/profitability_analysis/profitability_analysis.js
+++ b/erpnext/accounts/report/profitability_analysis/profitability_analysis.js
@@ -16,9 +16,22 @@ frappe.require("assets/erpnext/js/financial_statements.js", function() {
 				"fieldname": "based_on",
 				"label": __("Based On"),
 				"fieldtype": "Select",
-				"options": ["Cost Center", "Project"],
+				"options": ["Cost Center", "Project", "Accounting Dimension"],
 				"default": "Cost Center",
 				"reqd": 1
+			},
+			{
+				"fieldname": "accounting_dimension",
+				"label": __("Accounting Dimension"),
+				"fieldtype": "Link",
+				"options": "Accounting Dimension",
+				"get_query": () =>{
+					return {
+						filters: {
+							"disabled": 0
+						}
+					}
+				}
 			},
 			{
 				"fieldname": "fiscal_year",

--- a/erpnext/accounts/report/profitability_analysis/profitability_analysis.py
+++ b/erpnext/accounts/report/profitability_analysis/profitability_analysis.py
@@ -6,6 +6,7 @@ import frappe
 from frappe import _
 from frappe.utils import cstr, flt
 
+from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import get_dimensions
 from erpnext.accounts.report.financial_statements import (
 	filter_accounts,
 	filter_out_zero_value_rows,
@@ -19,7 +20,9 @@ def execute(filters=None):
 	if filters.get("based_on") == "Accounting Dimension" and not filters.get("accounting_dimension"):
 		frappe.throw(_("Select Accounting Dimension."))
 
-	based_on = filters.based_on.replace(" ", "_").lower()
+	based_on = (
+		filters.based_on if filters.based_on != "Accounting Dimension" else filters.accounting_dimension
+	)
 	validate_filters(filters)
 	accounts = get_accounts_data(based_on, filters.get("company"))
 	data = get_data(accounts, filters, based_on)
@@ -28,17 +31,15 @@ def execute(filters=None):
 
 
 def get_accounts_data(based_on, company):
-	if based_on == "cost_center":
+	if based_on == "Cost Center":
 		return frappe.db.sql(
 			"""select name, parent_cost_center as parent_account, cost_center_name as account_name, lft, rgt
 			from `tabCost Center` where company=%s order by name""",
 			company,
 			as_dict=True,
 		)
-	elif based_on == "project":
+	elif based_on == "Project":
 		return frappe.get_all("Project", fields=["name"], filters={"company": company}, order_by="name")
-	elif based_on == "accounting_dimension":
-		return frappe.get_all("Accounting Dimension", fields=["name"], order_by="name")
 	else:
 		filters = {}
 		doctype = frappe.unscrub(based_on)
@@ -58,13 +59,17 @@ def get_data(accounts, filters, based_on):
 
 	gl_entries_by_account = {}
 
+	accounting_dimensions = get_dimensions(with_cost_center_and_project=True)[0]
+	fieldname = ""
+	for dimension in accounting_dimensions:
+		if dimension["document_type"] == based_on:
+			fieldname = dimension["fieldname"]
+
 	set_gl_entries_by_account(
 		filters.get("company"),
 		filters.get("from_date"),
 		filters.get("to_date"),
-		based_on
-		if based_on != "accounting_dimension"
-		else filters.accounting_dimension.replace(" ", "_").lower(),
+		fieldname,
 		gl_entries_by_account,
 		ignore_closing_entries=not flt(filters.get("with_period_closing_entry")),
 	)

--- a/erpnext/accounts/report/profitability_analysis/profitability_analysis.py
+++ b/erpnext/accounts/report/profitability_analysis/profitability_analysis.py
@@ -16,8 +16,8 @@ value_fields = ("income", "expense", "gross_profit_loss")
 
 
 def execute(filters=None):
-	if not filters.get("based_on"):
-		filters["based_on"] = "Cost Center"
+	if filters.get("based_on") == "Accounting Dimension" and not filters.get("accounting_dimension"):
+		frappe.throw(_("Select Accounting Dimension."))
 
 	based_on = filters.based_on.replace(" ", "_").lower()
 	validate_filters(filters)
@@ -37,6 +37,8 @@ def get_accounts_data(based_on, company):
 		)
 	elif based_on == "project":
 		return frappe.get_all("Project", fields=["name"], filters={"company": company}, order_by="name")
+	elif based_on == "accounting_dimension":
+		return frappe.get_all("Accounting Dimension", fields=["name"], order_by="name")
 	else:
 		filters = {}
 		doctype = frappe.unscrub(based_on)
@@ -60,7 +62,9 @@ def get_data(accounts, filters, based_on):
 		filters.get("company"),
 		filters.get("from_date"),
 		filters.get("to_date"),
-		based_on,
+		based_on
+		if based_on != "accounting_dimension"
+		else filters.accounting_dimension.replace(" ", "_").lower(),
 		gl_entries_by_account,
 		ignore_closing_entries=not flt(filters.get("with_period_closing_entry")),
 	)


### PR DESCRIPTION
Option in **Profitability Analysis Report** that allows filtering results based on any **Accounting Dimensions** created.

Removed validation for `based_on` filter since default value is defined as **Cost Center**.

Issue #30482

`no-docs`