### PR TITLE
fix: Accounts closing balance patch

### DIFF
--- a/erpnext/patches/v14_0/update_closing_balances.py
+++ b/erpnext/patches/v14_0/update_closing_balances.py
@@ -62,7 +62,10 @@ def execute():
 				entry["closing_date"] = pcv_doc.posting_date
 				entry["period_closing_voucher"] = pcv_doc.name
 
-			make_closing_entries(gl_entries + closing_entries, voucher_name=pcv.name)
+			entries = gl_entries + closing_entries
+			if entries:
+				make_closing_entries(entries, voucher_name=pcv.name)
+
 			company_wise_order[pcv.company].append(pcv.posting_date)
 
 			i += 1


### PR DESCRIPTION
```bash
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/accounts/doctype/account_closing_balance/account_closing_balance.py", line 19, in make_closing_entries
    company = closing_entries[0].get("company")
      closing_entries = []
      voucher_name = 'ACC-PCV-2022-00002'
      accounting_dimensions = []
builtins.IndexError: list index out of range
```