### PR TITLE
fix: apply discount on item after applying price list

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1068,6 +1068,16 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 		this.frm.set_df_property("conversion_rate", "read_only", erpnext.stale_rate_allowed() ? 0 : 1);
 	},
 
+	apply_discount_on_item: function(doc, cdt, cdn, field) {
+		var item = frappe.get_doc(cdt, cdn);
+		if(!item.price_list_rate) {
+			item[field] = 0.0;
+		} else {
+			this.price_list_rate(doc, cdt, cdn);
+		}
+		this.set_gross_profit(item);
+	},
+
 	shipping_rule: function() {
 		var me = this;
 		if(this.frm.doc.shipping_rule) {
@@ -1720,6 +1730,9 @@ erpnext.TransactionController = erpnext.taxes_and_totals.extend({
 						() => {
 							if(args.items.length) {
 								me._set_values_for_item_list(r.message.children);
+								$.each(r.message.children || [], function(i, d) {
+									me.apply_discount_on_item(d, d.doctype, d.name, 'discount_percentage');
+								});
 							}
 						},
 						() => { me.in_apply_price_list = false; }

--- a/erpnext/selling/sales_common.js
+++ b/erpnext/selling/sales_common.js
@@ -145,16 +145,6 @@ erpnext.selling.SellingController = erpnext.TransactionController.extend({
 		this.apply_discount_on_item(doc, cdt, cdn, 'discount_amount');
 	},
 
-	apply_discount_on_item: function(doc, cdt, cdn, field) {
-		var item = frappe.get_doc(cdt, cdn);
-		if(!item.price_list_rate) {
-			item[field] = 0.0;
-		} else {
-			this.price_list_rate(doc, cdt, cdn);
-		}
-		this.set_gross_profit(item);
-	},
-
 	commission_rate: function() {
 		this.calculate_commission();
 	},


### PR DESCRIPTION
When a user changes the exchange rate for a currency in a SI, the rate of the items are automatically updated. But the items which have a discount applied get an incorrect rate because the discount isn't applied again after the rate update. This is due to the `apply_price_list` function (which is called from `conversion_rate` when the exchange rate changes) not applying discount once the rate changes, so fixed that.