### PR TITLE
perf: send SLA doctypes in boot

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -611,3 +611,8 @@ global_search_doctypes = {
 additional_timeline_content = {
 	"*": ["erpnext.telephony.doctype.call_log.call_log.get_linked_call_logs"]
 }
+
+
+extend_bootinfo = [
+	"erpnext.support.doctype.service_level_agreement.service_level_agreement.add_sla_doctypes",
+]

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -854,95 +854,87 @@ $(document).on('app_ready', function() {
 
 // Show SLA dashboard
 $(document).on('app_ready', function() {
-	frappe.call({
-		method: 'erpnext.support.doctype.service_level_agreement.service_level_agreement.get_sla_doctypes',
-		callback: function(r) {
-			if (!r.message)
-				return;
+	$.each(frappe.boot.service_level_agreement_doctypes, function(_i, d) {
+		frappe.ui.form.on(d, {
+			onload: function(frm) {
+				if (!frm.doc.service_level_agreement)
+					return;
 
-			$.each(r.message, function(_i, d) {
-				frappe.ui.form.on(d, {
-					onload: function(frm) {
-						if (!frm.doc.service_level_agreement)
-							return;
-
-						frappe.call({
-							method: 'erpnext.support.doctype.service_level_agreement.service_level_agreement.get_service_level_agreement_filters',
-							args: {
-								doctype: frm.doc.doctype,
-								name: frm.doc.service_level_agreement,
-								customer: frm.doc.customer
-							},
-							callback: function (r) {
-								if (r && r.message) {
-									frm.set_query('priority', function() {
-										return {
-											filters: {
-												'name': ['in', r.message.priority],
-											}
-										};
-									});
-									frm.set_query('service_level_agreement', function() {
-										return {
-											filters: {
-												'name': ['in', r.message.service_level_agreements],
-											}
-										};
-									});
-								}
-							}
-						});
+				frappe.call({
+					method: 'erpnext.support.doctype.service_level_agreement.service_level_agreement.get_service_level_agreement_filters',
+					args: {
+						doctype: frm.doc.doctype,
+						name: frm.doc.service_level_agreement,
+						customer: frm.doc.customer
 					},
-
-					refresh: function(frm) {
-						if (frm.doc.status !== 'Closed' && frm.doc.service_level_agreement
-							&& ['First Response Due', 'Resolution Due'].includes(frm.doc.agreement_status)) {
-							frappe.call({
-								'method': 'frappe.client.get',
-								args: {
-									doctype: 'Service Level Agreement',
-									name: frm.doc.service_level_agreement
-								},
-								callback: function(data) {
-									let statuses = data.message.pause_sla_on;
-									const hold_statuses = [];
-									$.each(statuses, (_i, entry) => {
-										hold_statuses.push(entry.status);
-									});
-									if (hold_statuses.includes(frm.doc.status)) {
-										frm.dashboard.clear_headline();
-										let message = {'indicator': 'orange', 'msg': __('SLA is on hold since {0}', [moment(frm.doc.on_hold_since).fromNow(true)])};
-										frm.dashboard.set_headline_alert(
-											'<div class="row">' +
-												'<div class="col-xs-12">' +
-													'<span class="indicator whitespace-nowrap '+ message.indicator +'"><span>'+ message.msg +'</span></span> ' +
-												'</div>' +
-											'</div>'
-										);
-									} else {
-										set_time_to_resolve_and_response(frm, data.message.apply_sla_for_resolution);
+					callback: function (r) {
+						if (r && r.message) {
+							frm.set_query('priority', function() {
+								return {
+									filters: {
+										'name': ['in', r.message.priority],
 									}
-								}
+								};
 							});
-						} else if (frm.doc.service_level_agreement) {
-							frm.dashboard.clear_headline();
-
-							let agreement_status = (frm.doc.agreement_status == 'Fulfilled') ?
-								{'indicator': 'green', 'msg': 'Service Level Agreement has been fulfilled'} :
-								{'indicator': 'red', 'msg': 'Service Level Agreement Failed'};
-
-							frm.dashboard.set_headline_alert(
-								'<div class="row">' +
-									'<div class="col-xs-12">' +
-										'<span class="indicator whitespace-nowrap '+ agreement_status.indicator +'"><span class="hidden-xs">'+ agreement_status.msg +'</span></span> ' +
-									'</div>' +
-								'</div>'
-							);
+							frm.set_query('service_level_agreement', function() {
+								return {
+									filters: {
+										'name': ['in', r.message.service_level_agreements],
+									}
+								};
+							});
 						}
-					},
+					}
 				});
-			});
-		}
+			},
+
+			refresh: function(frm) {
+				if (frm.doc.status !== 'Closed' && frm.doc.service_level_agreement
+					&& ['First Response Due', 'Resolution Due'].includes(frm.doc.agreement_status)) {
+					frappe.call({
+						'method': 'frappe.client.get',
+						args: {
+							doctype: 'Service Level Agreement',
+							name: frm.doc.service_level_agreement
+						},
+						callback: function(data) {
+							let statuses = data.message.pause_sla_on;
+							const hold_statuses = [];
+							$.each(statuses, (_i, entry) => {
+								hold_statuses.push(entry.status);
+							});
+							if (hold_statuses.includes(frm.doc.status)) {
+								frm.dashboard.clear_headline();
+								let message = {'indicator': 'orange', 'msg': __('SLA is on hold since {0}', [moment(frm.doc.on_hold_since).fromNow(true)])};
+								frm.dashboard.set_headline_alert(
+									'<div class="row">' +
+										'<div class="col-xs-12">' +
+											'<span class="indicator whitespace-nowrap '+ message.indicator +'"><span>'+ message.msg +'</span></span> ' +
+										'</div>' +
+									'</div>'
+								);
+							} else {
+								set_time_to_resolve_and_response(frm, data.message.apply_sla_for_resolution);
+							}
+						}
+					});
+				} else if (frm.doc.service_level_agreement) {
+					frm.dashboard.clear_headline();
+
+					let agreement_status = (frm.doc.agreement_status == 'Fulfilled') ?
+						{'indicator': 'green', 'msg': 'Service Level Agreement has been fulfilled'} :
+						{'indicator': 'red', 'msg': 'Service Level Agreement Failed'};
+
+					frm.dashboard.set_headline_alert(
+						'<div class="row">' +
+							'<div class="col-xs-12">' +
+								'<span class="indicator whitespace-nowrap '+ agreement_status.indicator +'"><span class="hidden-xs">'+ agreement_status.msg +'</span></span> ' +
+							'</div>' +
+						'</div>'
+					);
+				}
+			},
+		});
 	});
 });
 

--- a/erpnext/support/doctype/service_level_agreement/service_level_agreement.py
+++ b/erpnext/support/doctype/service_level_agreement/service_level_agreement.py
@@ -21,6 +21,7 @@ from frappe.utils import (
 	time_diff_in_seconds,
 	to_timedelta,
 )
+from frappe.utils.caching import redis_cache
 from frappe.utils.nestedset import get_ancestors_of
 from frappe.utils.safe_exec import get_safe_globals
 
@@ -208,6 +209,10 @@ class ServiceLevelAgreement(Document):
 
 	def on_update(self):
 		set_documents_with_active_service_level_agreement()
+
+	def clear_cache(self):
+		get_sla_doctypes.clear_cache()
+		return super().clear_cache()
 
 	def create_docfields(self, meta, service_level_agreement_fields):
 		last_index = len(meta.fields)
@@ -990,6 +995,7 @@ def get_user_time(user, to_string=False):
 
 
 @frappe.whitelist()
+@redis_cache()
 def get_sla_doctypes():
 	doctypes = []
 	data = frappe.get_all("Service Level Agreement", {"enabled": 1}, ["document_type"], distinct=1)
@@ -998,3 +1004,7 @@ def get_sla_doctypes():
 		doctypes.append(entry.document_type)
 
 	return doctypes
+
+
+def add_sla_doctypes(bootinfo):
+	bootinfo.service_level_agreement_doctypes = get_sla_doctypes()


### PR DESCRIPTION
This request is fired on every load, data rarely if ever changes though.

fix:
- send SLA doctypes via boot, eliminate the request.
- cache SLA doctypes
