### PR TITLE
fix: rounding of percentage fields

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -62,7 +62,7 @@ frappe.ui.form.on("Purchase Order", {
 	get_materials_from_supplier: function(frm) {
 		let po_details = [];
 
-		if (frm.doc.supplied_items && (frm.doc.per_received == 100 || frm.doc.status === 'Closed')) {
+		if (frm.doc.supplied_items && (flt(frm.doc.per_received, 2) == 100 || frm.doc.status === 'Closed')) {
 			frm.doc.supplied_items.forEach(d => {
 				if (d.total_supplied_qty && d.total_supplied_qty != d.consumed_qty) {
 					po_details.push(d.name)
@@ -181,7 +181,7 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends e
 			}
 
 			if(!in_list(["Closed", "Delivered"], doc.status)) {
-				if(this.frm.doc.status !== 'Closed' && flt(this.frm.doc.per_received) < 100 && flt(this.frm.doc.per_billed) < 100) {
+				if(this.frm.doc.status !== 'Closed' && flt(this.frm.doc.per_received, 2) < 100 && flt(this.frm.doc.per_billed, 2) < 100) {
 					// Don't add Update Items button if the PO is following the new subcontracting flow.
 					if (!(this.frm.doc.is_subcontracted && !this.frm.doc.is_old_subcontracting_flow)) {
 						this.frm.add_custom_button(__('Update Items'), () => {
@@ -195,7 +195,7 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends e
 					}
 				}
 				if (this.frm.has_perm("submit")) {
-					if(flt(doc.per_billed, 6) < 100 || flt(doc.per_received, 6) < 100) {
+					if(flt(doc.per_billed, 2) < 100 || flt(doc.per_received, 2) < 100) {
 						if (doc.status != "On Hold") {
 							this.frm.add_custom_button(__('Hold'), () => this.hold_purchase_order(), __("Status"));
 						} else{
@@ -218,7 +218,7 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends e
 			}
 			if(doc.status != "Closed") {
 				if (doc.status != "On Hold") {
-					if(flt(doc.per_received) < 100 && allow_receipt) {
+					if(flt(doc.per_received, 2) < 100 && allow_receipt) {
 						cur_frm.add_custom_button(__('Purchase Receipt'), this.make_purchase_receipt, __('Create'));
 						if (doc.is_subcontracted) {
 							if (doc.is_old_subcontracting_flow) {
@@ -231,11 +231,11 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends e
 							}
 						}
 					}
-					if(flt(doc.per_billed) < 100)
+					if(flt(doc.per_billed, 2) < 100)
 						cur_frm.add_custom_button(__('Purchase Invoice'),
 							this.make_purchase_invoice, __('Create'));
 
-					if(flt(doc.per_billed) < 100 && doc.status != "Delivered") {
+					if(flt(doc.per_billed, 2) < 100 && doc.status != "Delivered") {
 						this.frm.add_custom_button(
 							__('Payment'),
 							() => this.make_payment_entry(),
@@ -243,7 +243,7 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends e
 						);
 					}
 
-					if(flt(doc.per_billed) < 100) {
+					if(flt(doc.per_billed, 2) < 100) {
 						this.frm.add_custom_button(__('Payment Request'),
 							function() { me.make_payment_request() }, __('Create'));
 					}

--- a/erpnext/controllers/website_list_for_contact.py
+++ b/erpnext/controllers/website_list_for_contact.py
@@ -206,9 +206,11 @@ def post_process(doctype, data):
 			)
 
 		if doc.get("per_delivered"):
-			doc.status_percent += flt(doc.per_delivered)
+			doc.status_percent += flt(doc.per_delivered, 2)
 			doc.status_display.append(
-				_("Delivered") if doc.per_delivered == 100 else _("{0}% Delivered").format(doc.per_delivered)
+				_("Delivered")
+				if flt(doc.per_delivered, 2) == 100
+				else _("{0}% Delivered").format(doc.per_delivered)
 			)
 
 		if hasattr(doc, "set_indicator"):

--- a/erpnext/patches/v12_0/update_bom_in_so_mr.py
+++ b/erpnext/patches/v12_0/update_bom_in_so_mr.py
@@ -6,7 +6,9 @@ def execute():
 	frappe.reload_doc("selling", "doctype", "sales_order_item")
 
 	for doctype in ["Sales Order", "Material Request"]:
-		condition = " and child_doc.stock_qty > child_doc.produced_qty and doc.per_delivered < 100"
+		condition = (
+			" and child_doc.stock_qty > child_doc.produced_qty and ROUND(doc.per_delivered, 2) < 100"
+		)
 		if doctype == "Material Request":
 			condition = " and doc.per_ordered < 100 and doc.material_request_type = 'Manufacture'"
 

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -50,7 +50,7 @@ frappe.ui.form.on("Sales Order", {
 
 	refresh: function(frm) {
 		if(frm.doc.docstatus === 1) {
-			if (frm.doc.status !== 'Closed' && flt(frm.doc.per_delivered, 6) < 100 && flt(frm.doc.per_billed, 6) < 100) {
+			if (frm.doc.status !== 'Closed' && flt(frm.doc.per_delivered, 2) < 100 && flt(frm.doc.per_billed, 2) < 100) {
 				frm.add_custom_button(__('Update Items'), () => {
 					erpnext.utils.update_child_items({
 						frm: frm,
@@ -307,7 +307,7 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 					   me.frm.cscript.update_status('Resume', 'Draft')
 				   }, __("Status"));
 
-				   if(flt(doc.per_delivered, 6) < 100 || flt(doc.per_billed) < 100) {
+				   if(flt(doc.per_delivered, 2) < 100 || flt(doc.per_billed, 2) < 100) {
 					   // close
 					   this.frm.add_custom_button(__('Close'), () => this.close_sales_order(), __("Status"))
 				   }
@@ -325,7 +325,7 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 						&& !this.frm.doc.skip_delivery_note
 
 					if (this.frm.has_perm("submit")) {
-						if(flt(doc.per_delivered, 6) < 100 || flt(doc.per_billed) < 100) {
+						if(flt(doc.per_delivered, 2) < 100 || flt(doc.per_billed, 2) < 100) {
 							// hold
 							this.frm.add_custom_button(__('Hold'), () => this.hold_sales_order(), __("Status"))
 							// close
@@ -333,7 +333,7 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 						}
 					}
 
-					if (flt(doc.per_picked, 6) < 100 && flt(doc.per_delivered, 6) < 100) {
+					if (flt(doc.per_picked, 2) < 100 && flt(doc.per_delivered, 2) < 100) {
 						this.frm.add_custom_button(__('Pick List'), () => this.create_pick_list(), __('Create'));
 					}
 
@@ -343,18 +343,18 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 					const order_is_a_custom_sale = ["Sales", "Shopping Cart", "Maintenance"].indexOf(doc.order_type) === -1;
 
 					// delivery note
-					if(flt(doc.per_delivered, 6) < 100 && (order_is_a_sale || order_is_a_custom_sale) && allow_delivery) {
+					if(flt(doc.per_delivered, 2) < 100 && (order_is_a_sale || order_is_a_custom_sale) && allow_delivery) {
 						this.frm.add_custom_button(__('Delivery Note'), () => this.make_delivery_note_based_on_delivery_date(), __('Create'));
 						this.frm.add_custom_button(__('Work Order'), () => this.make_work_order(), __('Create'));
 					}
 
 					// sales invoice
-					if(flt(doc.per_billed, 6) < 100) {
+					if(flt(doc.per_billed, 2) < 100) {
 						this.frm.add_custom_button(__('Sales Invoice'), () => me.make_sales_invoice(), __('Create'));
 					}
 
 					// material request
-					if(!doc.order_type || (order_is_a_sale || order_is_a_custom_sale) && flt(doc.per_delivered, 6) < 100) {
+					if(!doc.order_type || (order_is_a_sale || order_is_a_custom_sale) && flt(doc.per_delivered, 2) < 100) {
 						this.frm.add_custom_button(__('Material Request'), () => this.make_material_request(), __('Create'));
 						this.frm.add_custom_button(__('Request for Raw Materials'), () => this.make_raw_material_request(), __('Create'));
 					}

--- a/erpnext/selling/doctype/sales_order/sales_order_list.js
+++ b/erpnext/selling/doctype/sales_order/sales_order_list.js
@@ -10,7 +10,7 @@ frappe.listview_settings['Sales Order'] = {
 			return [__("On Hold"), "orange", "status,=,On Hold"];
 		} else if (doc.status === "Completed") {
 			return [__("Completed"), "green", "status,=,Completed"];
-		} else if (!doc.skip_delivery_note && flt(doc.per_delivered, 6) < 100) {
+		} else if (!doc.skip_delivery_note && flt(doc.per_delivered, 2) < 100) {
 			if (frappe.datetime.get_diff(doc.delivery_date) < 0) {
 			// not delivered & overdue
 				return [__("Overdue"), "red",
@@ -19,7 +19,7 @@ frappe.listview_settings['Sales Order'] = {
 				// not delivered (zeroount order)
 				return [__("To Deliver"), "orange",
 					"per_delivered,<,100|grand_total,=,0|status,!=,Closed"];
-			} else if (flt(doc.per_billed, 6) < 100) {
+			} else if (flt(doc.per_billed, 2) < 100) {
 				// not delivered & not billed
 				return [__("To Deliver and Bill"), "orange",
 					"per_delivered,<,100|per_billed,<,100|status,!=,Closed"];
@@ -28,12 +28,12 @@ frappe.listview_settings['Sales Order'] = {
 				return [__("To Deliver"), "orange",
 					"per_delivered,<,100|per_billed,=,100|status,!=,Closed"];
 			}
-		} else if ((flt(doc.per_delivered, 6) === 100) && flt(doc.grand_total) !== 0
-			&& flt(doc.per_billed, 6) < 100) {
+		} else if ((flt(doc.per_delivered, 2) === 100) && flt(doc.grand_total) !== 0
+			&& flt(doc.per_billed, 2) < 100) {
 			// to bill
 			return [__("To Bill"), "orange",
 				"per_delivered,=,100|per_billed,<,100|status,!=,Closed"];
-		} else if (doc.skip_delivery_note && flt(doc.per_billed, 6) < 100){
+		} else if (doc.skip_delivery_note && flt(doc.per_billed, 2) < 100){
 			return [__("To Bill"), "orange", "per_billed,<,100|status,!=,Closed"];
 		}
 	},

--- a/erpnext/templates/form_grid/item_grid.html
+++ b/erpnext/templates/form_grid/item_grid.html
@@ -17,7 +17,7 @@
 					title = "Warehouse",
 					actual_qty = (frm.doc.doctype==="Sales Order"
 						? doc.projected_qty : doc.actual_qty);
-                if(flt(frm.doc.per_delivered) < 100
+                if(flt(frm.doc.per_delivered, 2) < 100
                     && in_list(["Sales Order Item", "Delivery Note Item"], doc.doctype)) {
     				if(actual_qty != undefined) {
     					if(actual_qty >= doc.qty) {


### PR DESCRIPTION
Always round with precision of 2

- `per_delivered`
- `per_picked`
- `per_billed`
- `per_received`

These are of type "Percentage", which usually is a value between 0 and 100. Something that is delivered/picked/billed/received > 99.99% should probably be marked as done.

In the past we used a precision of 6 in some places. Orders would have to be very large for 0.004 % to be valuable enough for the order to to stay open.