### PR TITLE
fix: incorrect Balance qty in the stock ledger

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -579,7 +579,7 @@ class update_entries_after(object):
 		if get_serial_nos(sle.serial_no):
 			self.get_serialized_values(sle)
 			self.wh_data.qty_after_transaction += flt(sle.actual_qty)
-			if sle.voucher_type == "Stock Reconciliation":
+			if sle.voucher_type == "Stock Reconciliation" and not sle.batch_no:
 				self.wh_data.qty_after_transaction = sle.qty_after_transaction
 
 			self.wh_data.stock_value = flt(self.wh_data.qty_after_transaction) * flt(


### PR DESCRIPTION
**Issue**

The item with Serial No and Batch No has an incorrect Balance Qty after performing the stock reconciliation.

<img width="1312" alt="Screenshot 2023-07-17 at 8 51 14 PM" src="https://github.com/frappe/erpnext/assets/8780500/a5bf8506-ca23-4a3c-8990-5f267dabdd41">


**After Fix**
<img width="1353" alt="Screenshot 2023-07-17 at 8 53 22 PM" src="https://github.com/frappe/erpnext/assets/8780500/759345c3-8f83-41d3-ba59-52799850e0b6">

