### PR TITLE
fix: broken overallocation validation in payment entry

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -1514,7 +1514,9 @@ def get_outstanding_reference_documents(args, validate=False):
 			accounting_dimensions=accounting_dimensions_filter,
 		)
 
-		outstanding_invoices = split_invoices_based_on_payment_terms(outstanding_invoices)
+		outstanding_invoices = split_invoices_based_on_payment_terms(
+			outstanding_invoices, args.get("company")
+		)
 
 		for d in outstanding_invoices:
 			d["exchange_rate"] = 1
@@ -1574,8 +1576,27 @@ def get_outstanding_reference_documents(args, validate=False):
 	return data
 
 
-def split_invoices_based_on_payment_terms(outstanding_invoices):
+def split_invoices_based_on_payment_terms(outstanding_invoices, company):
 	invoice_ref_based_on_payment_terms = {}
+
+	company_currency = (
+		frappe.db.get_value("Company", company, "default_currency") if company else None
+	)
+	exc_rates = frappe._dict()
+	for doctype in ["Sales Invoice", "Purchase Invoice"]:
+		invoices = [x.voucher_no for x in outstanding_invoices if x.voucher_type == doctype]
+		for x in frappe.db.get_all(
+			doctype,
+			filters={"name": ["in", invoices]},
+			fields=["name", "currency", "conversion_rate", "party_account_currency"],
+		):
+			exc_rates[x.name] = frappe._dict(
+				conversion_rate=x.conversion_rate,
+				currency=x.currency,
+				party_account_currency=x.party_account_currency,
+				company_currency=company_currency,
+			)
+
 	for idx, d in enumerate(outstanding_invoices):
 		if d.voucher_type in ["Sales Invoice", "Purchase Invoice"]:
 			payment_term_template = frappe.db.get_value(
@@ -1592,6 +1613,14 @@ def split_invoices_based_on_payment_terms(outstanding_invoices):
 
 					for payment_term in payment_schedule:
 						if payment_term.outstanding > 0.1:
+							doc_details = exc_rates.get(payment_term.parent, None)
+							is_multi_currency_acc = (doc_details.currency != doc_details.company_currency) and (
+								doc_details.party_account_currency != doc_details.company_currency
+							)
+							payment_term_outstanding = flt(payment_term.outstanding)
+							if not is_multi_currency_acc:
+								payment_term_outstanding = doc_details.conversion_rate * flt(payment_term.outstanding)
+
 							invoice_ref_based_on_payment_terms.setdefault(idx, [])
 							invoice_ref_based_on_payment_terms[idx].append(
 								frappe._dict(
@@ -1603,7 +1632,7 @@ def split_invoices_based_on_payment_terms(outstanding_invoices):
 										"posting_date": d.posting_date,
 										"invoice_amount": flt(d.invoice_amount),
 										"outstanding_amount": flt(d.outstanding_amount),
-										"payment_term_outstanding": flt(payment_term.outstanding),
+										"payment_term_outstanding": payment_term_outstanding,
 										"payment_amount": payment_term.payment_amount,
 										"payment_term": payment_term.payment_term,
 										"account": d.account,


### PR DESCRIPTION
In a multi term payment schedule, overallocation logic broke. Fixing it using individual term outstanding amount in references. this should work for the simple, one term payment schedule as well

1. Create a Payment Terms Template with 20%-80% split and enable `Allocate Payment Based On Payment Terms` 
<img width="1347" alt="Screenshot 2023-07-18 at 6 05 00 PM" src="https://github.com/frappe/erpnext/assets/3272205/8ef883a8-6feb-4767-8e91-a017aa07c24d">

2. Create an invoice with above payment terms template 
<img width="1347" alt="Screenshot 2023-07-18 at 6 05 06 PM" src="https://github.com/frappe/erpnext/assets/3272205/01e2435b-1702-43df-ba2b-3c3c5ea51e60">

3. Make a Payment Entry for [1] with overallocation in references section. 

Overallocation validation should've triggered. But, it didn't.

Post Fix:
<img width="1347" alt="Screenshot 2023-07-19 at 10 15 56 AM" src="https://github.com/frappe/erpnext/assets/3272205/fd574e3a-2f4e-4ffe-ba91-7a24e97f1eb6">
