### PR TITLE
fix: TDS Computation Summary and TDS Payable Monthly report

### DIFF
--- a/erpnext/accounts/report/tds_computation_summary/tds_computation_summary.py
+++ b/erpnext/accounts/report/tds_computation_summary/tds_computation_summary.py
@@ -83,8 +83,9 @@ def get_final_result(supplier_category_wise_map):
 
 
 def get_columns(filters):
+	pan = "pan" if frappe.db.has_column("Supplier", "pan") else "tax_id"
 	columns = [
-		{"label": _("PAN"), "fieldname": "pan", "fieldtype": "Data", "width": 90},
+		{"label": _(frappe.unscrub(pan)), "fieldname": pan, "fieldtype": "Data", "width": 90},
 		{
 			"label": _("Supplier"),
 			"options": "Supplier",

--- a/erpnext/accounts/report/tds_payable_monthly/tds_payable_monthly.py
+++ b/erpnext/accounts/report/tds_payable_monthly/tds_payable_monthly.py
@@ -96,8 +96,9 @@ def get_result(
 
 def get_supplier_pan_map():
 	supplier_map = frappe._dict()
+	pan = "pan" if frappe.db.has_column("Supplier", "pan") else "tax_id"
 	suppliers = frappe.db.get_all(
-		"Supplier", fields=["name", "pan", "supplier_type", "supplier_name", "tax_withholding_category"]
+		"Supplier", fields=["name", pan, "supplier_type", "supplier_name", "tax_withholding_category"]
 	)
 
 	for d in suppliers:


### PR DESCRIPTION
Tested Locally ✅

# Explanation
As issue #33970 describes, when trying to visit TDS Computation Summary or TDS Payable Monthly report, it will return error `pymysql.err.OperationalError: (1054, "Unknown column 'pan' in 'field list'")`. This is for any version of ERPNext >= 14. 

Looks like this issue surfaced because of the change made in PR https://github.com/frappe/erpnext/pull/28074 that removed `pan` from the `Supplier` DocType. To address this, I added the control flow logic to default to `tax_id` if `pan` is missing seeing as this is how other parts of the file handled it i.e. https://github.com/frappe/erpnext/blob/develop/erpnext/accounts/report/tds_payable_monthly/tds_payable_monthly.py#L130

Please backport this fix to version 14 (backport version-14-hotfix).

## Before 
![CleanShot 2023-07-18 at 20 03 03](https://github.com/frappe/erpnext/assets/14298160/0511bb38-77e8-43cf-b32b-3583b8082637)

![CleanShot 2023-07-18 at 20 03 14](https://github.com/frappe/erpnext/assets/14298160/47ee439a-c6d7-4d96-9591-ca7a54634d9b)


## After
![CleanShot 2023-07-18 at 20 01 40](https://github.com/frappe/erpnext/assets/14298160/31a7d824-480c-43af-b15a-4af2e43116b4)

![CleanShot 2023-07-18 at 20 02 11](https://github.com/frappe/erpnext/assets/14298160/3b56d19d-19f9-4844-ace4-775643c57bf5)

## Example reports
[TDS Computation Summary_My Company_2023-06-18_2023-07-18.pdf](https://github.com/frappe/erpnext/files/12080695/TDS.Computation.Summary_My.Company_2023-06-18_2023-07-18.pdf)
[TDS Payable Monthly_My Company_Nails and Hammers_2023-06-18_2023-07-18.pdf](https://github.com/frappe/erpnext/files/12080696/TDS.Payable.Monthly_My.Company_Nails.and.Hammers_2023-06-18_2023-07-18.pdf)

Closes #33970