### PR TITLE
fix: inserting of items with pricing rule with qty range

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -605,7 +605,6 @@ erpnext.PointOfSale.Controller = class {
 				i => i.item_code === item_code
 					&& (!has_batch_no || (has_batch_no && i.batch_no === batch_no))
 					&& (i.uom === uom)
-					&& (i.rate == rate)
 			);
 		}
 


### PR DESCRIPTION
To simulate this situation is simple:

Create a price rule to apply a % discount to an item of your choice.
As a rule to apply this discount, the customer has to buy 4 quantities to apply the discount.

So within the price rule created inform:
Min Qty: 4
Max Qty: 9999

Let's use a % off of 4%.


Assuming my item costs R$8.08

**without the fix**
If the customer buys 6 items, including the item through the point of sale, 2 lines will be inserted. but one of the lines will not be applied the discount.

In this case, 6 qty should go out for R$ 7.79 (considering 4% discount)...

![image](https://github.com/frappe/erpnext/assets/25017988/34012d52-72bc-4f73-bc0d-537ce6515996)


**With the change**

the system will always insert the item in the same line, respecting the promotion.

![image](https://github.com/frappe/erpnext/assets/25017988/ed09e831-f5b5-49fd-afd7-39f7681bd34b)

Now we can see, 6 qty selling for R$ 7,76, Respecting the functioning of the pricing rule.
 

**NOTE:**
I'm not sure if this is the most correct way!
If you have any other way to correct this situation, it was open to suggestions.