### PR TITLE
test: overallocation validation in payment entry

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
@@ -1063,7 +1063,11 @@ class TestPaymentEntry(FrappeTestCase):
 
 	@change_settings(
 		"Accounts Settings",
-		{"unlink_payment_on_cancellation_of_invoice": 1, "delete_linked_ledger_entries": 1},
+		{
+			"unlink_payment_on_cancellation_of_invoice": 1,
+			"delete_linked_ledger_entries": 1,
+			"allow_multi_currency_invoices_against_single_party_account": 1,
+		},
 	)
 	def test_overallocation_validation_on_payment_terms(self):
 		"""

--- a/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
@@ -1136,10 +1136,11 @@ class TestPaymentEntry(FrappeTestCase):
 
 		si3.reload()
 		pe = get_payment_entry(si3.doctype, si3.name).save()
-		# Allocated amount should be according to the payment schedule
-		for idx, schedule in enumerate(si3.payment_schedule):
+		# Allocated amount should be equal to payment term outstanding
+		self.assertEqual(len(pe.references), 2)
+		for idx, ref in enumerate(pe.references):
 			with self.subTest(idx=idx):
-				self.assertEqual(flt(schedule.base_payment_amount), flt(pe.references[idx].allocated_amount))
+				self.assertEqual(ref.payment_term_outstanding, ref.allocated_amount)
 		pe.save()
 
 		# Overallocation validation should trigger


### PR DESCRIPTION
Test case for overallocation validation.
continues https://github.com/frappe/erpnext/pull/36181