### PR TITLE
fix: made item or warehouse filter mandatory

### DIFF
--- a/erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.py
+++ b/erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.py
@@ -10,10 +10,17 @@ from pypika import functions as fn
 
 from erpnext.stock.doctype.warehouse.warehouse import apply_warehouse_filter
 
+SLE_COUNT_LIMIT = 10_000
+
 
 def execute(filters=None):
 	if not filters:
 		filters = {}
+
+	sle_count = frappe.db.count("Stock Ledger Entry", {"is_cancelled": 0})
+
+	if sle_count > SLE_COUNT_LIMIT and not filters.get("item_code") and not filters.get("warehouse"):
+		frappe.throw(_("Please select either the Item or Warehouse filter to generate the report."))
 
 	if filters.from_date > filters.to_date:
 		frappe.throw(_("From Date must be before To Date"))


### PR DESCRIPTION
If Stock Ledger Entries count is more than 10,000 then user should select the filter of Item Code or Warehouse to view the Batch Wise Balance History Report.

<img width="1307" alt="Screenshot 2023-07-20 at 12 59 38 PM" src="https://github.com/frappe/erpnext/assets/8780500/69a00dd4-9650-4e59-a703-3df962becbbd">


**Why Mandatory?**

Currently, users are facing performance issues and are unable to generate the report due to the lack of a filter on large data.

