### PR TITLE
perf: use `LEFT JOIN` instead of `NOT EXISTS`

### DIFF
--- a/erpnext/manufacturing/doctype/bom_update_log/bom_update_log.py
+++ b/erpnext/manufacturing/doctype/bom_update_log/bom_update_log.py
@@ -93,6 +93,7 @@ class BOMUpdateLog(Document):
 		else:
 			frappe.enqueue(
 				method="erpnext.manufacturing.doctype.bom_update_log.bom_update_log.process_boms_cost_level_wise",
+				queue="long",
 				update_doc=self,
 				now=frappe.flags.in_test,
 				enqueue_after_commit=True,

--- a/erpnext/manufacturing/doctype/bom_update_log/bom_updation_utils.py
+++ b/erpnext/manufacturing/doctype/bom_update_log/bom_updation_utils.py
@@ -157,12 +157,19 @@ def get_next_higher_level_boms(
 def get_leaf_boms() -> List[str]:
 	"Get BOMs that have no dependencies."
 
-	return frappe.db.sql_list(
-		"""select name from `tabBOM` bom
-		where docstatus=1 and is_active=1
-			and not exists(select bom_no from `tabBOM Item`
-				where parent=bom.name and bom_no !='')"""
-	)
+	bom = frappe.qb.DocType("BOM")
+	bom_item = frappe.qb.DocType("BOM Item")
+
+	boms = (
+		frappe.qb.from_(bom)
+		.left_join(bom_item)
+		.on((bom.name == bom_item.parent) & (bom_item.bom_no != ""))
+		.select(bom.name)
+		.where((bom.docstatus == 1) & (bom.is_active == 1) & (bom_item.bom_no.isnull()))
+		.distinct()
+	).run(pluck=True)
+
+	return boms
 
 
 def _generate_dependence_map() -> defaultdict:


### PR DESCRIPTION
**Source / Ref**: ISS-23-24-02079

**Issue:** The `BOM Update Log` gets stuck in Queued (timeout) if there are a large number of BOMs.

![image](https://github.com/frappe/erpnext/assets/63660334/ddaa2b0e-392c-4eca-bec2-4720470e2ae1)

**Before:**

```
171906 function calls (171733 primitive calls) in 83.689 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     24/1    0.000    0.000   83.689   83.689 {built-in method builtins.exec}
        1    0.000    0.000   83.689   83.689 <string>:1(<module>)
        1    0.000    0.000   83.689   83.689 bom_updation_utils.py:157(get_leaf_boms)
        1    0.000    0.000   83.689   83.689 database.py:286(sql_list)
        1    0.000    0.000   83.689   83.689 database.py:111(sql)
        1    0.000    0.000   83.678   83.678 cursors.py:129(execute)
        1    0.000    0.000   83.678   83.678 cursors.py:306(_query)
        1    0.000    0.000   83.678   83.678 connections.py:542(query)
        1    0.000    0.000   83.678   83.678 connections.py:763(_read_query_result)
        1    0.000    0.000   83.678   83.678 connections.py:1154(read)
     7117    0.016    0.000   83.646    0.012 connections.py:683(_read_packet)
    14234    0.010    0.000   83.626    0.006 connections.py:728(_read_bytes)
    14234    0.005    0.000   83.607    0.006 {method 'read' of '_io.BufferedReader' objects}
       38    0.000    0.000   83.602    2.200 socket.py:575(readinto)
       38   83.602    2.200   83.602    2.200 {method 'recv_into' of '_socket.socket' objects}
        1    0.000    0.000   73.674   73.674 connections.py:1233(_read_result_packet)
        1    0.007    0.007   73.674   73.674 connections.py:1266(_read_rowdata_packet)
     7109    0.007    0.000    0.021    0.000 connections.py:1279(_read_row_from_packet)
     7115    0.003    0.000    0.012    0.000 protocol.py:165(read_length_coded_string)
        1    0.000    0.000    0.010    0.010 database.py:82(connect)
```

**After**

```
179055 function calls (178948 primitive calls) in 17.308 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
        1    0.000    0.000   17.308   17.308 {built-in method builtins.exec}
        1    0.000    0.000   17.308   17.308 <string>:1(<module>)
        1    0.000    0.000   17.308   17.308 <ipython-input-5-ab8ea441ed2a>:1(get_leaf_boms)
        1    0.000    0.000   17.307   17.307 utils.py:64(execute_query)
        1    0.000    0.000   17.306   17.306 database.py:111(sql)
        1    0.000    0.000   17.303   17.303 cursors.py:129(execute)
        1    0.000    0.000   17.303   17.303 cursors.py:306(_query)
        1    0.000    0.000   17.303   17.303 connections.py:542(query)
        1    0.000    0.000   17.302   17.302 connections.py:763(_read_query_result)
        1    0.000    0.000   17.302   17.302 connections.py:1154(read)
     7113    0.015    0.000   17.271    0.002 connections.py:683(_read_packet)
    14226    0.010    0.000   17.252    0.001 connections.py:728(_read_bytes)
    14226    0.005    0.000   17.234    0.001 {method 'read' of '_io.BufferedReader' objects}
```