### PR TITLE
fix: FY in naming series variable for orders

### DIFF
--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -1112,7 +1112,8 @@ def get_autoname_with_number(number_value, doc_title, company):
 
 def parse_naming_series_variable(doc, variable):
 	if variable == "FY":
-		return get_fiscal_year(date=doc.get("posting_date"), company=doc.get("company"))[0]
+		date = doc.get("posting_date") or doc.get("transaction_date") or getdate()
+		return get_fiscal_year(date=date, company=doc.get("company"))[0]
 
 
 @frappe.whitelist()


### PR DESCRIPTION
<img width="366" alt="Screenshot 2023-07-21 at 4 04 03 PM" src="https://github.com/frappe/erpnext/assets/42651287/8046ca17-8b79-4b82-b5d3-e3f48bbcfb75">
