### PR TITLE
fix: Correct Tax Breakup for different tax rates for same hsn code

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -1900,16 +1900,22 @@ class TestSalesInvoice(unittest.TestCase):
 
 		si = self.create_si_to_test_tax_breakup()
 
-		itemised_tax, itemised_taxable_amount = get_itemised_tax_breakup_data(si)
+		itemised_tax_data = get_itemised_tax_breakup_data(si)
 
-		expected_itemised_tax = {
-			"_Test Item": {"Service Tax": {"tax_rate": 10.0, "tax_amount": 1000.0}},
-			"_Test Item 2": {"Service Tax": {"tax_rate": 10.0, "tax_amount": 500.0}},
-		}
-		expected_itemised_taxable_amount = {"_Test Item": 10000.0, "_Test Item 2": 5000.0}
+		expected_itemised_tax = [
+			{
+				"item": "_Test Item",
+				"taxable_amount": 10000.0,
+				"Service Tax": {"tax_rate": 10.0, "tax_amount": 1000.0},
+			},
+			{
+				"item": "_Test Item 2",
+				"taxable_amount": 5000.0,
+				"Service Tax": {"tax_rate": 10.0, "tax_amount": 500.0},
+			},
+		]
 
-		self.assertEqual(itemised_tax, expected_itemised_tax)
-		self.assertEqual(itemised_taxable_amount, expected_itemised_taxable_amount)
+		self.assertEqual(itemised_tax_data, expected_itemised_tax)
 
 		frappe.flags.country = None
 

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -999,8 +999,8 @@ def get_itemised_tax_breakup_header(item_doctype, tax_accounts):
 
 
 @erpnext.allow_regional
-def get_itemised_tax_breakup_data(doc, with_tax_account=False):
-	return _get_itemised_tax_breakup_data(doc, with_tax_account=False)
+def get_itemised_tax_breakup_data(doc):
+	return _get_itemised_tax_breakup_data(doc)
 
 
 def _get_itemised_tax_breakup_data(doc, with_tax_account=False):

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -957,7 +957,7 @@ def get_itemised_tax_breakup_html(doc):
 	# get tax breakup data
 	itemised_tax_data = get_itemised_tax_breakup_data(doc)
 
-	get_rounded_tax_amount(itemised_tax_data, doc.precision("tax_amount", "taxes"), tax_accounts)
+	get_rounded_tax_amount(itemised_tax_data, doc.precision("tax_amount", "taxes"))
 
 	update_itemised_tax_data(doc)
 	frappe.flags.company = None
@@ -1000,21 +1000,17 @@ def get_itemised_tax_breakup_header(item_doctype, tax_accounts):
 
 @erpnext.allow_regional
 def get_itemised_tax_breakup_data(doc):
-	return _get_itemised_tax_breakup_data(doc)
-
-
-def _get_itemised_tax_breakup_data(doc, with_tax_account=False):
-	itemised_tax = get_itemised_tax(doc.taxes, with_tax_account=with_tax_account)
+	itemised_tax = get_itemised_tax(doc.taxes)
 
 	itemised_taxable_amount = get_itemised_taxable_amount(doc.items)
 
 	itemised_tax_data = []
 	for item_code, taxes in itemised_tax.items():
-		for _item_code, taxable_amount in itemised_taxable_amount.items():
-			if item_code == _item_code:
-				itemised_tax_data.append(
-					frappe._dict({"item": item_code, "taxable_amount": taxable_amount, **taxes})
-				)
+		itemised_tax_data.append(
+			frappe._dict(
+				{"item": item_code, "taxable_amount": itemised_taxable_amount.get(item_code), **taxes}
+			)
+		)
 
 	return itemised_tax_data
 
@@ -1059,12 +1055,12 @@ def get_itemised_taxable_amount(items):
 	return itemised_taxable_amount
 
 
-def get_rounded_tax_amount(itemised_tax, precision, tax_accounts):
+def get_rounded_tax_amount(itemised_tax, precision):
 	# Rounding based on tax_amount precision
-	for _itemised_tax in itemised_tax:
-		for key, value in _itemised_tax.items():
-			if key in tax_accounts:
-				value["tax_amount"] = flt(value["tax_amount"], precision)
+	for taxes in itemised_tax:
+		for row in taxes.values():
+			if isinstance(row, dict) and isinstance(row["tax_amount"], float):
+				row["tax_amount"] = flt(row["tax_amount"], precision)
 
 
 class init_landed_taxes_and_totals(object):

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -955,9 +955,9 @@ def get_itemised_tax_breakup_html(doc):
 	headers = get_itemised_tax_breakup_header(doc.doctype + " Item", tax_accounts)
 
 	# get tax breakup data
-	itemised_tax, itemised_taxable_amount = get_itemised_tax_breakup_data(doc)
+	itemised_tax_data = get_itemised_tax_breakup_data(doc)
 
-	get_rounded_tax_amount(itemised_tax, doc.precision("tax_amount", "taxes"))
+	get_rounded_tax_amount(itemised_tax_data, doc.precision("tax_amount", "taxes"), tax_accounts)
 
 	update_itemised_tax_data(doc)
 	frappe.flags.company = None
@@ -966,8 +966,7 @@ def get_itemised_tax_breakup_html(doc):
 		"templates/includes/itemised_tax_breakup.html",
 		dict(
 			headers=headers,
-			itemised_tax=itemised_tax,
-			itemised_taxable_amount=itemised_taxable_amount,
+			itemised_tax_data=itemised_tax_data,
 			tax_accounts=tax_accounts,
 			doc=doc,
 		),
@@ -1000,12 +999,24 @@ def get_itemised_tax_breakup_header(item_doctype, tax_accounts):
 
 
 @erpnext.allow_regional
-def get_itemised_tax_breakup_data(doc):
-	itemised_tax = get_itemised_tax(doc.taxes)
+def get_itemised_tax_breakup_data(doc, with_tax_account=False):
+	return _get_itemised_tax_breakup_data(doc, with_tax_account=False)
+
+
+def _get_itemised_tax_breakup_data(doc, with_tax_account=False):
+	itemised_tax = get_itemised_tax(doc.taxes, with_tax_account=with_tax_account)
 
 	itemised_taxable_amount = get_itemised_taxable_amount(doc.items)
 
-	return itemised_tax, itemised_taxable_amount
+	itemised_tax_data = []
+	for item_code, taxes in itemised_tax.items():
+		for _item_code, taxable_amount in itemised_taxable_amount.items():
+			if item_code == _item_code:
+				itemised_tax_data.append(
+					frappe._dict({"item": item_code, "taxable_amount": taxable_amount, **taxes})
+				)
+
+	return itemised_tax_data
 
 
 def get_itemised_tax(taxes, with_tax_account=False):
@@ -1048,11 +1059,12 @@ def get_itemised_taxable_amount(items):
 	return itemised_taxable_amount
 
 
-def get_rounded_tax_amount(itemised_tax, precision):
+def get_rounded_tax_amount(itemised_tax, precision, tax_accounts):
 	# Rounding based on tax_amount precision
-	for taxes in itemised_tax.values():
-		for tax_account in taxes:
-			taxes[tax_account]["tax_amount"] = flt(taxes[tax_account]["tax_amount"], precision)
+	for _itemised_tax in itemised_tax:
+		for key, value in _itemised_tax.items():
+			if key in tax_accounts:
+				value["tax_amount"] = flt(value["tax_amount"], precision)
 
 
 class init_landed_taxes_and_totals(object):

--- a/erpnext/templates/includes/itemised_tax_breakup.html
+++ b/erpnext/templates/includes/itemised_tax_breakup.html
@@ -12,14 +12,14 @@
 			</tr>
 		</thead>
 		<tbody>
-			{% for item, taxes in itemised_tax.items() %}
+			{% for taxes in itemised_tax_data %}
 				<tr>
-					<td>{{ item }}</td>
+					<td>{{ taxes.item }}</td>
 					<td class="text-right">
 						{% if doc.get('is_return') %}
-							{{ frappe.utils.fmt_money((itemised_taxable_amount.get(item, 0))|abs, None, doc.currency) }}
+							{{ frappe.utils.fmt_money(taxes.taxable_amount |abs, None, doc.currency) }}
 						{% else %}
-							{{ frappe.utils.fmt_money(itemised_taxable_amount.get(item, 0), None, doc.currency) }}
+							{{ frappe.utils.fmt_money(taxes.taxable_amount, None, doc.currency) }}
 						{% endif %}
 					</td>
 					{% for tax_account in tax_accounts %}


### PR DESCRIPTION
**Issue**
In case of different tax rates for same HSN code, tax rate and taxable amount was getting overriden.

**Before**
![image](https://github.com/frappe/erpnext/assets/54097382/af5938d2-518a-437c-a159-45365075bb98)


**After**

![image](https://github.com/frappe/erpnext/assets/54097382/757b5735-6176-4385-8e25-1d3472d59fee)
