### PR TITLE
fix: POS closing with item name 

### DIFF
--- a/erpnext/accounts/doctype/pos_closing_entry/test_pos_closing_entry.py
+++ b/erpnext/accounts/doctype/pos_closing_entry/test_pos_closing_entry.py
@@ -49,6 +49,24 @@ class TestPOSClosingEntry(unittest.TestCase):
 		self.assertEqual(pcv_doc.total_quantity, 2)
 		self.assertEqual(pcv_doc.net_total, 6700)
 
+	def test_pos_closing_without_item_code(self):
+		"""
+		Test if POS Closing Entry is created without item code
+		"""
+		test_user, pos_profile = init_user_and_profile()
+		opening_entry = create_opening_entry(pos_profile, test_user.name)
+
+		pos_inv = create_pos_invoice(
+			rate=3500, do_not_submit=1, item_name="Test Item", without_item_code=1
+		)
+		pos_inv.append("payments", {"mode_of_payment": "Cash", "account": "Cash - _TC", "amount": 3500})
+		pos_inv.submit()
+
+		pcv_doc = make_closing_entry_from_opening(opening_entry)
+		pcv_doc.submit()
+
+		self.assertTrue(pcv_doc.name)
+
 	def test_cancelling_of_pos_closing_entry(self):
 		test_user, pos_profile = init_user_and_profile()
 		opening_entry = create_opening_entry(pos_profile, test_user.name)

--- a/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
@@ -986,19 +986,36 @@ def create_pos_invoice(**args):
 			msg = f"Serial No {args.serial_no} not available for Item {args.item}"
 			frappe.throw(_(msg))
 
-	pos_inv.append(
-		"items",
-		{
-			"item_code": args.item or args.item_code or "_Test Item",
-			"warehouse": args.warehouse or "_Test Warehouse - _TC",
-			"qty": args.qty or 1,
-			"rate": args.rate if args.get("rate") is not None else 100,
-			"income_account": args.income_account or "Sales - _TC",
-			"expense_account": args.expense_account or "Cost of Goods Sold - _TC",
-			"cost_center": args.cost_center or "_Test Cost Center - _TC",
-			"serial_and_batch_bundle": bundle_id,
-		},
-	)
+	# append in pos invoice items without item_code by checking flag without_item_code
+	if args.without_item_code:
+		pos_inv.append(
+			"items",
+			{
+				"item_name": args.item_name or "_Test Item",
+				"description": args.item_name or "_Test Item",
+				"warehouse": args.warehouse or "_Test Warehouse - _TC",
+				"qty": args.qty or 1,
+				"rate": args.rate if args.get("rate") is not None else 100,
+				"income_account": args.income_account or "Sales - _TC",
+				"expense_account": args.expense_account or "Cost of Goods Sold - _TC",
+				"cost_center": args.cost_center or "_Test Cost Center - _TC",
+			},
+		)
+
+	else:
+		pos_inv.append(
+			"items",
+			{
+				"item_code": args.item or args.item_code or "_Test Item",
+				"warehouse": args.warehouse or "_Test Warehouse - _TC",
+				"qty": args.qty or 1,
+				"rate": args.rate if args.get("rate") is not None else 100,
+				"income_account": args.income_account or "Sales - _TC",
+				"expense_account": args.expense_account or "Cost of Goods Sold - _TC",
+				"cost_center": args.cost_center or "_Test Cost Center - _TC",
+				"serial_and_batch_bundle": bundle_id,
+			},
+		)
 
 	if not args.do_not_save:
 		pos_inv.insert()

--- a/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
@@ -986,19 +986,23 @@ def create_pos_invoice(**args):
 			msg = f"Serial No {args.serial_no} not available for Item {args.item}"
 			frappe.throw(_(msg))
 
+	pos_invoice_item = {
+		"warehouse": args.warehouse or "_Test Warehouse - _TC",
+		"qty": args.qty or 1,
+		"rate": args.rate if args.get("rate") is not None else 100,
+		"income_account": args.income_account or "Sales - _TC",
+		"expense_account": args.expense_account or "Cost of Goods Sold - _TC",
+		"cost_center": args.cost_center or "_Test Cost Center - _TC",
+		"serial_and_batch_bundle": bundle_id,
+	}
 	# append in pos invoice items without item_code by checking flag without_item_code
 	if args.without_item_code:
 		pos_inv.append(
 			"items",
 			{
+				**pos_invoice_item,
 				"item_name": args.item_name or "_Test Item",
 				"description": args.item_name or "_Test Item",
-				"warehouse": args.warehouse or "_Test Warehouse - _TC",
-				"qty": args.qty or 1,
-				"rate": args.rate if args.get("rate") is not None else 100,
-				"income_account": args.income_account or "Sales - _TC",
-				"expense_account": args.expense_account or "Cost of Goods Sold - _TC",
-				"cost_center": args.cost_center or "_Test Cost Center - _TC",
 			},
 		)
 
@@ -1006,14 +1010,8 @@ def create_pos_invoice(**args):
 		pos_inv.append(
 			"items",
 			{
+				**pos_invoice_item,
 				"item_code": args.item or args.item_code or "_Test Item",
-				"warehouse": args.warehouse or "_Test Warehouse - _TC",
-				"qty": args.qty or 1,
-				"rate": args.rate if args.get("rate") is not None else 100,
-				"income_account": args.income_account or "Sales - _TC",
-				"expense_account": args.expense_account or "Cost of Goods Sold - _TC",
-				"cost_center": args.cost_center or "_Test Cost Center - _TC",
-				"serial_and_batch_bundle": bundle_id,
 			},
 		)
 

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -773,7 +773,7 @@ frappe.ui.form.on('Sales Invoice', {
 
 	update_stock: function(frm, dt, dn) {
 		frm.events.hide_fields(frm);
-		frm.fields_dict.items.grid.toggle_reqd("item_code", frm.doc.update_stock);
+		// frm.fields_dict.items.grid.toggle_reqd("item_code", frm.doc.update_stock);
 		frm.trigger('reset_posting_time');
 	},
 

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -773,7 +773,6 @@ frappe.ui.form.on('Sales Invoice', {
 
 	update_stock: function(frm, dt, dn) {
 		frm.events.hide_fields(frm);
-		// frm.fields_dict.items.grid.toggle_reqd("item_code", frm.doc.update_stock);
 		frm.trigger('reset_posting_time');
 	},
 

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -113,7 +113,7 @@ class SalesInvoice(SellingController):
 
 		if cint(self.update_stock):
 			self.validate_dropship_item()
-			self.validate_item_code()
+			# self.validate_item_code()
 			self.validate_warehouse()
 			self.update_current_stock()
 			self.validate_delivery_note()

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -113,7 +113,6 @@ class SalesInvoice(SellingController):
 
 		if cint(self.update_stock):
 			self.validate_dropship_item()
-			# self.validate_item_code()
 			self.validate_warehouse()
 			self.update_current_stock()
 			self.validate_delivery_note()
@@ -853,11 +852,6 @@ class SalesInvoice(SellingController):
 				10.0 ** (self.precision("grand_total") + 1.0)
 			):
 				frappe.throw(_("Paid amount + Write Off Amount can not be greater than Grand Total"))
-
-	def validate_item_code(self):
-		for d in self.get("items"):
-			if not d.item_code and self.is_opening == "No":
-				msgprint(_("Item Code required at Row No {0}").format(d.idx), raise_exception=True)
 
 	def validate_warehouse(self):
 		super(SalesInvoice, self).validate_warehouse()


### PR DESCRIPTION
**Problem :**
When u try to close a POS in POS Invoice Merge Log doctype for an item without the item code.
We get the following error :

![telegram-cloud-photo-size-5-6185780954363180809-y](https://github.com/frappe/erpnext/assets/65544983/e80487d5-dda0-4286-be47-184a9ae18900)


**Reason :** 
The doctype uses the function : 
<img width="935" alt="1" src="https://github.com/frappe/erpnext/assets/65544983/8b7cfc11-95dc-4c8a-bc2c-74e46648a437">
which is present in Sales Invoice, this function is used when we update the stock.

**Solution :**  
Removed the above function, along with this in [sales_invoice.js]

<img width="931" alt="Screenshot 2023-07-22 at 1 56 30 PM" src="https://github.com/frappe/erpnext/assets/65544983/61e34e64-9961-43ed-b127-3311d92e2ed2">
