### PR TITLE
fix: multiple fixes on payment terms based issues in payment entry

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -122,13 +122,10 @@ frappe.ui.form.on('Payment Entry', {
 		frm.set_query('payment_term', 'references', function(frm, cdt, cdn) {
 			const child = locals[cdt][cdn];
 			if (in_list(['Purchase Invoice', 'Sales Invoice'], child.reference_doctype) && child.reference_name) {
-				let payment_term_list = frappe.get_list('Payment Schedule', {'parent': child.reference_name});
-
-				payment_term_list = payment_term_list.map(pt => pt.payment_term);
-
 				return {
+					query: "erpnext.controllers.queries.get_payment_terms_for_references",
 					filters: {
-						'name': ['in', payment_term_list]
+						'reference': child.reference_name
 					}
 				}
 			}

--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -874,3 +874,18 @@ def get_fields(doctype, fields=None):
 		fields.insert(1, meta.title_field.strip())
 
 	return unique(fields)
+
+
+@frappe.whitelist()
+@frappe.validate_and_sanitize_search_inputs
+def get_payment_terms_for_references(doctype, txt, searchfield, start, page_len, filters) -> list:
+	terms = []
+	if filters:
+		terms = frappe.db.get_all(
+			"Payment Schedule",
+			filters={"parent": filters.get("reference")},
+			fields=["payment_term"],
+			limit=page_len,
+			as_list=1,
+		)
+	return terms


### PR DESCRIPTION
## 1. Payment Term query in Payment References section
`Payment Term` select field wasn't giving any results. 
before:
<img width="1440" alt="Screenshot 2023-07-23 at 11 58 31 AM" src="https://github.com/frappe/erpnext/assets/3272205/5fe2b3e4-aa5e-492c-bc0a-e33755663497">

after:
<img width="1440" alt="Screenshot 2023-07-23 at 11 59 30 AM" src="https://github.com/frappe/erpnext/assets/3272205/26c160fd-ffd4-4f56-b5ee-1658cc75a429">


## 2. Incorrect Validation Error for term based allocation
If Payment Term based allocation has been enabled for an invoice, term has to be selected in references section.

<img width="1440" alt="Screenshot 2023-07-23 at 12 00 26 PM" src="https://github.com/frappe/erpnext/assets/3272205/51bbc86a-8321-422d-9053-c85210bf11cc">

before:
When no term was selected, validation miscalculated that invoice as fully paid. 
<img width="1440" alt="Screenshot 2023-07-23 at 11 58 02 AM" src="https://github.com/frappe/erpnext/assets/3272205/0ea77164-c991-402d-8255-b2a7c3d89783">

after:
<img width="1440" alt="Screenshot 2023-07-23 at 11 59 14 AM" src="https://github.com/frappe/erpnext/assets/3272205/99bf3b3b-2884-4280-a415-f3e3e61f5a3b">

## 3. Incorrect Validation Err for Invoice without any payment template or term
An Invoice without any Payment Terms Template or Payment Term, was incorrectly throwing fully paid validation error. Its fixed now.
<img width="1440" alt="Screenshot 2023-07-23 at 12 07 36 PM" src="https://github.com/frappe/erpnext/assets/3272205/b8bfcc32-7601-4c9a-af85-8a073f51f126">

before:
<img width="1440" alt="Screenshot 2023-07-23 at 12 09 28 PM" src="https://github.com/frappe/erpnext/assets/3272205/307c28a1-e690-4821-bda7-7105df40f3e9">

after:
<img width="1440" alt="Screenshot 2023-07-23 at 12 12 19 PM" src="https://github.com/frappe/erpnext/assets/3272205/531eaaac-1630-487d-97e0-558deb8a3c97">



