### PR TITLE
build(deps): update tweepy 3.10.0 -> 4.14.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "googlemaps",
     "plaid-python~=7.2.1",
     "python-youtube~=0.8.0",
-    "tweepy~=3.10.0",
+    "tweepy~=4.14.0",
 
     # Not used directly - required by PyQRCode for PNG generation
     "pypng~=0.20220715.0",


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

Older versions of `tweepy` are [no longer available in `nixpkgs`](https://search.nixos.org/packages?channel=23.05&show=python311Packages.tweepy&from=0&size=50&sort=relevance&type=packages&query=tweepy). cc @teutat3s

> Explain the **details** for making this change. What existing problem does the pull request solve?

- Changes to the [errors](https://docs.tweepy.org/en/stable/changelog.html#major-new-features-improvements:~:text=Replace%20TweepError%20with)

- [Renaming of `OAuthHandler`](https://docs.tweepy.org/en/stable/changelog.html#major-new-features-improvements:~:text=Rename%20OAuthHandler%20to%20OAuth1UserHandler)

