### PR TITLE
fix(startup): coa drill down

### DIFF
--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -1117,7 +1117,7 @@ def parse_naming_series_variable(doc, variable):
 
 
 @frappe.whitelist()
-def get_coa(doctype, parent, is_root, chart=None):
+def get_coa(doctype, parent, is_root=None, chart=None):
 	from erpnext.accounts.doctype.account.chart_of_accounts.chart_of_accounts import (
 		build_tree_from_json,
 	)


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

`erpnext/public/js/setup_wizard.js` does not provide positional argument `is_root` when calling `get_coa` from  `erpnext/accounts/utils.py`.

As a consequence, users can't drill down into accounts in the chart preview during the initial setup wizard.

> Explain the **details** for making this change. What existing problem does the pull request solve?

To not change the api, setting `is_root=None`. However, it is not even used in the function. Please remove at will.
