### PR TITLE
fix: unresponsive sales invoice form

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -897,6 +897,8 @@ frappe.ui.form.on('Sales Invoice', {
 				frm.events.append_time_log(frm, timesheet, 1.0);
 			}
 		});
+		frm.refresh_field("timesheets");
+		frm.trigger("calculate_timesheet_totals");
 	},
 
 	async get_exchange_rate(frm, from_currency, to_currency) {
@@ -936,9 +938,6 @@ frappe.ui.form.on('Sales Invoice', {
 		row.billing_amount = flt(time_log.billing_amount) * flt(exchange_rate);
 		row.timesheet_detail = time_log.name;
 		row.project_name = time_log.project_name;
-
-		frm.refresh_field("timesheets");
-		frm.trigger("calculate_timesheet_totals");
 	},
 
 	calculate_timesheet_totals: function(frm) {


### PR DESCRIPTION
If a project has 1000+ timesheets, selecting that project in Sales Invoice will make the page unresponsive/crash as the current logic refreshes the table(DOM) for each timesheet.
<img width="1440" alt="Screenshot 2023-07-23 at 7 54 28 PM" src="https://github.com/frappe/erpnext/assets/3272205/ba74249a-42a9-48c2-93c9-feec54263881">


Refreshing child table once all the rows are added is enough.