### PR TITLE
fix: no default email account causing reposting issue

### DIFF
--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
@@ -271,7 +271,11 @@ def repost(doc):
 			message += "<br>" + "Traceback: <br>" + traceback
 		frappe.db.set_value(doc.doctype, doc.name, "error_log", message)
 
-		if not isinstance(e, RecoverableErrors):
+		outgoing_email_account = frappe.get_cached_value(
+			"Email Account", {"default_outgoing": 1, "enable_outgoing": 1}, "name"
+		)
+
+		if outgoing_email_account and not isinstance(e, RecoverableErrors):
 			notify_error_to_stock_managers(doc, message)
 			doc.set_status("Failed")
 	finally:


### PR DESCRIPTION
**Issue**

The repost item valuation record showing the status as "In Progress" since 5 days and due to which other reposting records are in Queued state. There is no error in the respective repost item valuation. After debug found an error log in the Scheduled Job Log as "Please setup default Email Account from Setup > Email > Email Account". The traceback of an error is as below.


```
Traceback (most recent call last):
  File "apps/frappe/frappe/core/doctype/scheduled_job_type/scheduled_job_type.py", line 96, in execute
    frappe.get_attr(self.method)()
  File "apps/erpnext/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py", line 383, in repost_entries
    repost(doc)
  File "apps/erpnext/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py", line 260, in repost
    notify_error_to_stock_managers(doc, message)
  File "apps/erpnext/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py", line 356, in notify_error_to_stock_managers
    frappe.sendmail(recipients=recipients, subject=subject, message=message)
  File "apps/frappe/frappe/__init__.py", line 719, in sendmail
    builder.process(send_now=now)
  File "apps/frappe/frappe/email/doctype/email_queue/email_queue.py", line 655, in process
    queue_data = self.as_dict(include_recipients=False)
  File "apps/frappe/frappe/email/doctype/email_queue/email_queue.py", line 696, in as_dict
    email_account = self.get_outgoing_email_account()
  File "apps/frappe/frappe/email/doctype/email_queue/email_queue.py", line 564, in get_outgoing_email_account
    self._email_account = EmailAccount.find_outgoing(
  File "apps/frappe/frappe/email/doctype/email_account/email_account.py", line 43, in wrapper_cache_email_account
    matched_accounts = func(*args, **kwargs)
  File "apps/frappe/frappe/email/doctype/email_account/email_account.py", line 327, in find_outgoing
    frappe.throw(
  File "apps/frappe/frappe/__init__.py", line 533, in throw
    msgprint(
  File "apps/frappe/frappe/__init__.py", line 501, in msgprint
    _raise_exception()
  File "apps/frappe/frappe/__init__.py", line 450, in _raise_exception
    raise raise_exception(msg)
frappe.exceptions.OutgoingEmailError: Please setup default Email Account from Setup > Email > Email Account
```

