### PR TITLE
refactor: apply terms based validation only on sales/purchase doctypes

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -210,7 +210,11 @@ class PaymentEntry(AccountsController):
 	def term_based_allocation_enabled_for_reference(
 		self, reference_doctype: str, reference_name: str
 	) -> bool:
-		if reference_doctype and reference_name:
+		if (
+			reference_doctype
+			and reference_doctype in ["Sales Invoice", "Sales Order", "Purchase Order", "Purchase Invoice"]
+			and reference_name
+		):
 			if template := frappe.db.get_value(reference_doctype, reference_name, "payment_terms_template"):
 				return frappe.db.get_value(
 					"Payment Terms Template", template, "allocate_payment_based_on_payment_terms"


### PR DESCRIPTION
Apply Payment Terms based allocation validation on Sales/Puchase Invoice and Orders.
continues: https://github.com/frappe/erpnext/pull/36241

This has been directly added in the v14 backport: https://github.com/frappe/erpnext/pull/36252