### PR TITLE
fix: allow both custodian and location while creating asset

### DIFF
--- a/erpnext/assets/doctype/asset_movement/asset_movement.py
+++ b/erpnext/assets/doctype/asset_movement/asset_movement.py
@@ -62,20 +62,21 @@ class AssetMovement(Document):
 					frappe.throw(_("Source and Target Location cannot be same"))
 
 			if self.purpose == "Receipt":
-				if not (d.source_location or d.from_employee) and not (d.target_location or d.to_employee):
+				if not (d.source_location) and not (d.target_location or d.to_employee):
 					frappe.throw(
 						_("Target Location or To Employee is required while receiving Asset {0}").format(d.asset)
 					)
-				elif d.from_employee and not d.target_location:
-					frappe.throw(
-						_("Target Location is required while receiving Asset {0} from an employee").format(d.asset)
-					)
-				elif d.to_employee and d.target_location:
-					frappe.throw(
-						_(
-							"Asset {0} cannot be received at a location and given to an employee in a single movement"
-						).format(d.asset)
-					)
+				elif d.source_location:
+					if d.from_employee and not d.target_location:
+						frappe.throw(
+							_("Target Location is required while receiving Asset {0} from an employee").format(d.asset)
+						)
+					elif d.to_employee and d.target_location:
+						frappe.throw(
+							_(
+								"Asset {0} cannot be received at a location and given to an employee in a single movement"
+							).format(d.asset)
+						)
 
 	def validate_employee(self):
 		for d in self.assets:


### PR DESCRIPTION
This https://github.com/frappe/erpnext/pull/36093 recent change in Asset Movement blocked users from setting both custodian and location while creating an asset, so fixed that.