### PR TITLE
fix: set new purchase_receipt_amount on asset split

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -1413,6 +1413,8 @@ def create_new_asset_after_split(asset, split_qty):
 	)
 
 	new_asset.gross_purchase_amount = new_gross_purchase_amount
+	if asset.purchase_receipt_amount:
+		new_asset.purchase_receipt_amount = new_gross_purchase_amount
 	new_asset.opening_accumulated_depreciation = opening_accumulated_depreciation
 	new_asset.asset_quantity = split_qty
 	new_asset.split_from = asset.name


### PR DESCRIPTION
If an asset with a purchase receipt was split, a `Gross Purchase Amount should be equal to purchase amount of one single Asset` error was thrown since the `purchase_receipt_amount` for the new asset wasn't updated. So fixed that.