### PR TITLE
fix: timeout error while cancelling the Purchase Receipt

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
+++ b/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
@@ -603,7 +603,8 @@
    "in_list_view": 1,
    "label": "Batch No",
    "options": "Batch",
-   "print_hide": 1
+   "print_hide": 1,
+   "search_index": 1
   },
   {
    "fieldname": "col_break5",
@@ -890,7 +891,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2022-10-17 12:51:44.825398",
+ "modified": "2023-07-25 11:58:10.723833",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice Item",

--- a/erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
+++ b/erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -515,7 +515,8 @@
    "oldfieldname": "batch_no",
    "oldfieldtype": "Link",
    "options": "Batch",
-   "print_hide": 1
+   "print_hide": 1,
+   "search_index": 1
   },
   {
    "allow_on_submit": 1,
@@ -867,7 +868,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-05-01 21:05:14.175640",
+ "modified": "2023-07-25 11:58:28.101919",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Note Item",

--- a/erpnext/stock/doctype/pick_list_item/pick_list_item.json
+++ b/erpnext/stock/doctype/pick_list_item/pick_list_item.json
@@ -79,7 +79,8 @@
    "fieldname": "batch_no",
    "fieldtype": "Link",
    "label": "Batch No",
-   "options": "Batch"
+   "options": "Batch",
+   "search_index": 1
   },
   {
    "fieldname": "column_break_2",
@@ -192,7 +193,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2023-06-16 14:05:51.719959",
+ "modified": "2023-07-25 11:56:23.361867",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Pick List Item",

--- a/erpnext/stock/doctype/stock_reconciliation_item/stock_reconciliation_item.json
+++ b/erpnext/stock/doctype/stock_reconciliation_item/stock_reconciliation_item.json
@@ -168,7 +168,8 @@
    "fieldname": "batch_no",
    "fieldtype": "Link",
    "label": "Batch No",
-   "options": "Batch"
+   "options": "Batch",
+   "search_index": 1
   },
   {
    "default": "0",
@@ -189,7 +190,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2023-05-09 18:42:19.224916",
+ "modified": "2023-07-25 11:58:44.992419",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Reconciliation Item",


### PR DESCRIPTION
**Issue**

While cancelling the Purchase Receipt, user were getting the timeout error.
After profiling came to know that system is taking 10 mins to submit the Purchase Receipt and causing the timeout error

<img width="814" alt="Screenshot 2023-07-24 at 5 52 38 PM" src="https://github.com/frappe/erpnext/assets/8780500/bae1677c-51a8-47ef-96b2-dc514bffd69c">

**Investigation**

- On cancellation of the Purchase Receipt, the system deletes the batches which were created against the respective Purchase Receipt.
- While deleting batches, the system checks whether the batch has been linked to any document or not.
- If the batch is linked to any document, then the system won't allow deleting that batch.
- In the Processlist, it was found that the document "Sales Invoice Item, Delivery Note Item, Stock Reconciliation Item, Pick List Item" took a lot of time to check whether the respective batch is linked or not.

**Solution** 

Added indexing for the batch_no column in the document "Sales Invoice Item, Delivery Note Item, Stock Reconciliation Item, Pick List Item". After that system has took 13 seconds to cancel the Purchase Receipt 
<img width="745" alt="Screenshot 2023-07-25 at 11 52 28 AM" src="https://github.com/frappe/erpnext/assets/8780500/e1da2d56-2584-40b4-b9d7-f6bddccf0c01">



