### PR TITLE
fix: cost center filter for fetching payments

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2217,6 +2217,9 @@ def get_advance_payment_entries(
 			reference_condition = ""
 			order_list = []
 
+		if not condition:
+			condition = ""
+
 		payment_entries_against_order = frappe.db.sql(
 			"""
 			select
@@ -2231,12 +2234,12 @@ def get_advance_payment_entries(
 				and t2.reference_doctype = %s {2} {3}
 			order by t1.posting_date {4}
 		""".format(
-				currency_field, 
-				party_account_field, 
-				reference_condition, 
-				condition, 
-				limit_cond, 
-				exchange_rate_field
+				currency_field,
+				party_account_field,
+				reference_condition,
+				condition,
+				limit_cond,
+				exchange_rate_field,
 			),
 			[party_account, payment_type, party_type, party, order_doctype] + order_list,
 			as_dict=1,

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2223,15 +2223,15 @@ def get_advance_payment_entries(
 				'Payment Entry' as reference_type, t1.name as reference_name,
 				t1.remarks, t2.allocated_amount as amount, t2.name as reference_row,
 				t2.reference_name as against_order, t1.posting_date,
-				t1.{0} as currency, t1.{4} as exchange_rate
+				t1.{0} as currency, t1.{5} as exchange_rate
 			from `tabPayment Entry` t1, `tabPayment Entry Reference` t2
 			where
 				t1.name = t2.parent and t1.{1} = %s and t1.payment_type = %s
 				and t1.party_type = %s and t1.party = %s and t1.docstatus = 1
-				and t2.reference_doctype = %s {2}
-			order by t1.posting_date {3}
+				and t2.reference_doctype = %s {2} {3}
+			order by t1.posting_date {4}
 		""".format(
-				currency_field, party_account_field, reference_condition, limit_cond, exchange_rate_field
+				currency_field, party_account_field, reference_condition, condition, limit_cond, exchange_rate_field
 			),
 			[party_account, payment_type, party_type, party, order_doctype] + order_list,
 			as_dict=1,

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2231,7 +2231,12 @@ def get_advance_payment_entries(
 				and t2.reference_doctype = %s {2} {3}
 			order by t1.posting_date {4}
 		""".format(
-				currency_field, party_account_field, reference_condition, condition, limit_cond, exchange_rate_field
+				currency_field, 
+				party_account_field, 
+				reference_condition, 
+				condition, 
+				limit_cond, 
+				exchange_rate_field
 			),
 			[party_account, payment_type, party_type, party, order_doctype] + order_list,
 			as_dict=1,


### PR DESCRIPTION
**Problem**
While fetching the Payment entries against an Order in Payment Reconciliation, all payment entries were fetched in the Payments table irrespective of the cost center selected in the Filters.

**Solution**
Added the condition in the query for `payment_entries_against_order`.