### PR TITLE
fix:show invoices name instead of object address

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -441,7 +441,7 @@ class PaymentEntry(AccountsController):
 				_(
 					"References {0} of type {1} had no outstanding amount left before submitting the Payment Entry. Now they have a negative outstanding amount."
 				).format(
-					frappe.bold(comma_and((d.reference_name for d in references))),
+					frappe.bold(comma_and([d.reference_name for d in references])),
 					_(reference_doctype),
 				)
 				+ "<br><br>"


### PR DESCRIPTION
comma_and function in expecting a list but it gets a tuple so it is returning an object instead of a string so in message it also show  object


![Screenshot from 2023-07-25 14-35-48](https://github.com/frappe/erpnext/assets/63018500/28fe0dec-f47b-42f7-a993-e0d78581f12f)

after passing a list in comma_and function

![Screenshot from 2023-07-25 14-36-38](https://github.com/frappe/erpnext/assets/63018500/4b91da8d-5f18-4b8f-9379-93fcad55fa3e)



