### PR TITLE
fix: added validation for unique serial numbers in pos invoice

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -162,7 +162,7 @@ class POSInvoice(SalesInvoice):
 				if len(serial_nos) != len(set(serial_nos)):
 					frappe.throw(
 						_("Duplicate Serial Numbers Found in item {0} ").format(item.item_code),
-						title=_("Item Unavailable"),
+						title=_("Duplicate Serial Numbers Found"),
 					)
 
 	def validate_pos_reserved_batch_qty(self, item):

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -44,6 +44,7 @@ class POSInvoice(SalesInvoice):
 		self.validate_debit_to_acc()
 		self.validate_write_off_account()
 		self.validate_change_amount()
+		self.validate_duplicate_serial_nos()
 		self.validate_change_account()
 		self.validate_item_cost_centers()
 		self.validate_warehouse()
@@ -153,6 +154,16 @@ class POSInvoice(SalesInvoice):
 				).format(item.idx, bold_invalid_serial_nos),
 				title=_("Item Unavailable"),
 			)
+
+	def validate_duplicate_serial_nos(self):
+		for item in self.get("items"):
+			if item.serial_no:
+				serial_nos = get_serial_nos(item.serial_no)
+				if len(serial_nos) != len(set(serial_nos)):
+					frappe.throw(
+						_("Duplicate Serial Numbers Found in item {0} ").format(item.item_code),
+						title=_("Item Unavailable"),
+					)
 
 	def validate_pos_reserved_batch_qty(self, item):
 		filters = {"item_code": item.item_code, "warehouse": item.warehouse, "batch_no": item.batch_no}

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors and contributors
 # For license information, please see license.txt
-
+import collections
 
 import frappe
 from frappe import _
@@ -44,7 +44,7 @@ class POSInvoice(SalesInvoice):
 		self.validate_debit_to_acc()
 		self.validate_write_off_account()
 		self.validate_change_amount()
-		self.validate_duplicate_serial_nos()
+		self.validate_duplicate_serial_and_batch_no()
 		self.validate_change_account()
 		self.validate_item_cost_centers()
 		self.validate_warehouse()
@@ -155,15 +155,26 @@ class POSInvoice(SalesInvoice):
 				title=_("Item Unavailable"),
 			)
 
-	def validate_duplicate_serial_nos(self):
-		for item in self.get("items"):
-			if item.serial_no:
-				serial_nos = get_serial_nos(item.serial_no)
-				if len(serial_nos) != len(set(serial_nos)):
-					frappe.throw(
-						_("Duplicate Serial Numbers Found in item {0}").format(item.item_code),
-						title=_("Duplicate Serial Numbers Found"),
-					)
+	def validate_duplicate_serial_and_batch_no(self):
+		serial_nos = []
+		batch_nos = []
+
+		for row in self.get("items"):
+			if row.serial_no:
+				serial_nos = row.serial_no.split("\n")
+
+			if row.batch_no and not row.serial_no:
+				batch_nos.append(row.batch_no)
+
+		if serial_nos:
+			for key, value in collections.Counter(serial_nos).items():
+				if value > 1:
+					frappe.throw(_("Duplicate Serial No {0} found").format("key"))
+
+		if batch_nos:
+			for key, value in collections.Counter(batch_nos).items():
+				if value > 1:
+					frappe.throw(_("Duplicate Batch No {0} found").format("key"))
 
 	def validate_pos_reserved_batch_qty(self, item):
 		filters = {"item_code": item.item_code, "warehouse": item.warehouse, "batch_no": item.batch_no}

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -161,7 +161,7 @@ class POSInvoice(SalesInvoice):
 				serial_nos = get_serial_nos(item.serial_no)
 				if len(serial_nos) != len(set(serial_nos)):
 					frappe.throw(
-						_("Duplicate Serial Numbers Found in item {0} ").format(item.item_code),
+						_("Duplicate Serial Numbers Found in item {0}").format(item.item_code),
 						title=_("Duplicate Serial Numbers Found"),
 					)
 


### PR DESCRIPTION
**Issue :** 
In the POS Invoicing, it was possible to select the same serial number multiple times. 
<img width="266" alt="image" src="https://github.com/frappe/erpnext/assets/65544983/6fe9bf70-a364-4463-8a55-a77a2ce5ee7b">


**Reason:**
No validation was there to check whether duplicate serial numbers exist or not

**Solution:**
Added a validation in file POS Invoice


**Result:**
![image](https://github.com/frappe/erpnext/assets/65544983/da7c4c72-3760-4d27-9284-238129d3387f)
