### PR TITLE
fix: allocation validation blocks partial payment for SO and PO

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -66,7 +66,7 @@ class PaymentEntry(AccountsController):
 		self.setup_party_account_field()
 		self.set_missing_values()
 		self.set_liability_account()
-		self.set_missing_ref_details()
+		self.set_missing_ref_details(force=True)
 		self.validate_payment_type()
 		self.validate_party_details()
 		self.set_exchange_rate()


### PR DESCRIPTION
1. Make Sales Order
2. Create Data Import with 2 Payment Entries referencing [1]
3. The second payment entry will throw `"Sales Order SAL-ORD-2023-00066 has already been partly paid. Please use the 'Get Outstanding Invoice' or the 'Get Outstanding Orders' button to get the latest outstanding amounts."`

