### PR TITLE
fix(Item Group): allow root deletion

### DIFF
--- a/erpnext/setup/doctype/item_group/item_group.py
+++ b/erpnext/setup/doctype/item_group/item_group.py
@@ -76,7 +76,7 @@ class ItemGroup(NestedSet, WebsiteGenerator):
 			return self.route
 
 	def on_trash(self):
-		NestedSet.on_trash(self)
+		NestedSet.on_trash(self, allow_root_deletion=True)
 		WebsiteGenerator.on_trash(self)
 		self.delete_child_item_groups_key()
 


### PR DESCRIPTION
It was not possible to delete an empty, unused Item Group without any children, if it was one of possibly multiple roots of the Item Group tree.

This is very annoying when you created Item Groups for test purposes or want to get rid of old Item Groups.

This fix allows deleting a root Item Group (if it doesn't have any children or linked records).
