### PR TITLE
chore(Item Group): remove redundant autoname

### DIFF
--- a/erpnext/setup/doctype/item_group/item_group.py
+++ b/erpnext/setup/doctype/item_group/item_group.py
@@ -24,9 +24,6 @@ class ItemGroup(NestedSet, WebsiteGenerator):
 		no_breadcrumbs=1,
 	)
 
-	def autoname(self):
-		self.name = self.item_group_name
-
 	def validate(self):
 		super(ItemGroup, self).validate()
 


### PR DESCRIPTION
Autoname is already defined in doctype:

https://github.com/frappe/erpnext/blob/eead2bba9f40848026086ebef05d822ef027cfea/erpnext/setup/doctype/item_group/item_group.json#L5

Overwriting this in the backend makes customization harder and leads to unexpected behavior in the rename dialog.