### PR TITLE
fix: filter by cost center in trial balance

### DIFF
--- a/erpnext/accounts/report/trial_balance/trial_balance.py
+++ b/erpnext/accounts/report/trial_balance/trial_balance.py
@@ -253,7 +253,7 @@ def get_opening_balance(
 		lft, rgt = frappe.db.get_value("Cost Center", filters.cost_center, ["lft", "rgt"])
 		cost_center = frappe.qb.DocType("Cost Center")
 		opening_balance = opening_balance.where(
-			closing_balance.cost_center.in_(
+			closing_balance.cost_center.isin(
 				frappe.qb.from_(cost_center)
 				.select("name")
 				.where((cost_center.lft >= lft) & (cost_center.rgt <= rgt))


### PR DESCRIPTION
**Problem**
Filtering the Trial Balance Report resulted in the following error - 

<img width="1293" alt="Screenshot 2023-07-26 at 11 08 48 AM" src="https://github.com/frappe/erpnext/assets/40693548/7ba8f774-d185-4ec7-894c-99ecfb415e73">
<br>

**Solution**
Changed the where clause for cost centers in the Trial Balance query to filter the list of cost centers correctly.