### PR TITLE
fix: GL Entries should not be split based on cost center allocation in PCV

### DIFF
--- a/erpnext/accounts/general_ledger.py
+++ b/erpnext/accounts/general_ledger.py
@@ -105,7 +105,8 @@ def process_gl_map(gl_map, merge_entries=True, precision=None):
 	if not gl_map:
 		return []
 
-	gl_map = distribute_gl_based_on_cost_center_allocation(gl_map, precision)
+	if gl_map[0].voucher_type != "Period Closing Voucher":
+		gl_map = distribute_gl_based_on_cost_center_allocation(gl_map, precision)
 
 	if merge_entries:
 		gl_map = merge_similar_entries(gl_map, precision)


### PR DESCRIPTION
GL Entries should not be split based on cost center allocation in PCV