### PR TITLE
fix: show depr schedule table in asset doc

### DIFF
--- a/erpnext/assets/doctype/asset/asset.json
+++ b/erpnext/assets/doctype/asset/asset.json
@@ -52,6 +52,8 @@
   "column_break_24",
   "frequency_of_depreciation",
   "next_depreciation_date",
+  "depreciation_schedule_sb",
+  "depreciation_schedule_view",
   "insurance_details",
   "policy_number",
   "insurer",
@@ -487,6 +489,17 @@
    "options": "\nSuccessful\nFailed",
    "print_hide": 1,
    "read_only": 1
+  },
+  {
+   "fieldname": "depreciation_schedule_sb",
+   "fieldtype": "Section Break",
+   "label": "Depreciation Schedule"
+  },
+  {
+   "fieldname": "depreciation_schedule_view",
+   "fieldtype": "HTML",
+   "hidden": 1,
+   "label": "Depreciation Schedule View"
   }
  ],
  "idx": 72,
@@ -520,7 +533,7 @@
    "table_fieldname": "accounts"
   }
  ],
- "modified": "2023-03-30 15:07:41.542374",
+ "modified": "2023-07-26 13:33:36.821534",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset",

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -21,6 +21,7 @@ from frappe.utils import (
 import erpnext
 from erpnext.accounts.general_ledger import make_reverse_gl_entries
 from erpnext.assets.doctype.asset.depreciation import (
+	get_comma_separated_links,
 	get_depreciation_accounts,
 	get_disposal_account_and_cost_center,
 )
@@ -59,8 +60,17 @@ class Asset(AccountsController):
 		if not self.booked_fixed_asset and self.validate_make_gl_entry():
 			self.make_gl_entries()
 		if not self.split_from:
-			make_draft_asset_depr_schedules_if_not_present(self)
+			asset_depr_schedules_names = make_draft_asset_depr_schedules_if_not_present(self)
 			convert_draft_asset_depr_schedules_into_active(self)
+			if asset_depr_schedules_names:
+				asset_depr_schedules_links = get_comma_separated_links(
+					asset_depr_schedules_names, "Asset Depreciation Schedule"
+				)
+				frappe.msgprint(
+					_(
+						"Asset Depreciation Schedules created:<br>{0}<br><br>Please check, edit if needed, and submit the Asset."
+					).format(asset_depr_schedules_links)
+				)
 
 	def on_cancel(self):
 		self.validate_cancellation()
@@ -74,7 +84,15 @@ class Asset(AccountsController):
 
 	def after_insert(self):
 		if not self.split_from:
-			make_draft_asset_depr_schedules(self)
+			asset_depr_schedules_names = make_draft_asset_depr_schedules(self)
+			asset_depr_schedules_links = get_comma_separated_links(
+				asset_depr_schedules_names, "Asset Depreciation Schedule"
+			)
+			frappe.msgprint(
+				_(
+					"Asset Depreciation Schedules created:<br>{0}<br><br>Please check, edit if needed, and submit the Asset."
+				).format(asset_depr_schedules_links)
+			)
 
 	def validate_asset_and_reference(self):
 		if self.purchase_invoice or self.purchase_receipt:

--- a/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
@@ -571,6 +571,8 @@ def get_wdv_or_dd_depr_amount(
 
 
 def make_draft_asset_depr_schedules_if_not_present(asset_doc):
+	asset_depr_schedules_names = []
+
 	for row in asset_doc.get("finance_books"):
 		draft_asset_depr_schedule_name = get_asset_depr_schedule_name(
 			asset_doc.name, "Draft", row.finance_book
@@ -581,12 +583,20 @@ def make_draft_asset_depr_schedules_if_not_present(asset_doc):
 		)
 
 		if not draft_asset_depr_schedule_name and not active_asset_depr_schedule_name:
-			make_draft_asset_depr_schedule(asset_doc, row)
+			name = make_draft_asset_depr_schedule(asset_doc, row)
+			asset_depr_schedules_names.append(name)
+
+	return asset_depr_schedules_names
 
 
 def make_draft_asset_depr_schedules(asset_doc):
+	asset_depr_schedules_names = []
+
 	for row in asset_doc.get("finance_books"):
-		make_draft_asset_depr_schedule(asset_doc, row)
+		name = make_draft_asset_depr_schedule(asset_doc, row)
+		asset_depr_schedules_names.append(name)
+
+	return asset_depr_schedules_names
 
 
 def make_draft_asset_depr_schedule(asset_doc, row):
@@ -595,6 +605,8 @@ def make_draft_asset_depr_schedule(asset_doc, row):
 	asset_depr_schedule_doc.prepare_draft_asset_depr_schedule_data(asset_doc, row)
 
 	asset_depr_schedule_doc.insert()
+
+	return asset_depr_schedule_doc.name
 
 
 def update_draft_asset_depr_schedules(asset_doc):

--- a/erpnext/assets/doctype/depreciation_schedule/depreciation_schedule.json
+++ b/erpnext/assets/doctype/depreciation_schedule/depreciation_schedule.json
@@ -53,7 +53,7 @@
   },
   {
    "allow_on_submit": 1,
-   "depends_on": "eval:(doc.docstatus==1 && !doc.journal_entry && doc.schedule_date <= get_today())",
+   "depends_on": "eval:(doc.docstatus==1 && !doc.journal_entry && doc.schedule_date <= frappe.datetime.now_date())",
    "fieldname": "make_depreciation_entry",
    "fieldtype": "Button",
    "label": "Make Depreciation Entry"
@@ -61,7 +61,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2023-03-13 23:17:15.849950",
+ "modified": "2023-07-26 12:56:48.718736",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Depreciation Schedule",


### PR DESCRIPTION
Now, a view of the `depreciation_schedule` table from the `Asset`'s active `Asset Depreciation Schedule` would be shown in the `Asset` to keep the UX a bit more consistent with how it was in v14. Also added a message to let the user know about the new `Asset Depreciation Schedule`s created on `Asset` creation. 