### PR TITLE
fix: AP report does not show expense claim payables

### DIFF
--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -928,7 +928,7 @@ def get_partywise_advanced_payment_amount(
 		frappe.qb.from_(gle)
 		.select(gle.party)
 		.where(
-			(gle.party_type.isin(party_type)) & (gle.against_voucher == None) & (gle.is_cancelled == 0)
+			(gle.party_type.isin(party_type)) & (gle.against_voucher.isnull()) & (gle.is_cancelled == 0)
 		)
 		.groupby(gle.party)
 	)

--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -14,6 +14,7 @@ from frappe.contacts.doctype.address.address import (
 from frappe.contacts.doctype.contact.contact import get_contact_details
 from frappe.core.doctype.user_permission.user_permission import get_permitted_documents
 from frappe.model.utils import get_fetch_values
+from frappe.query_builder.functions import Date, Sum
 from frappe.utils import (
 	add_days,
 	add_months,
@@ -920,32 +921,35 @@ def get_party_shipping_address(doctype: str, name: str) -> Optional[str]:
 
 
 def get_partywise_advanced_payment_amount(
-	party_type, posting_date=None, future_payment=0, company=None, party=None
+	party_type, posting_date=None, future_payment=0, company=None, party=None, account_type=None
 ):
-	cond = "1=1"
+	gle = frappe.qb.DocType("GL Entry")
+	query = (
+		frappe.qb.from_(gle)
+		.select(gle.party)
+		.where(
+			(gle.party_type.isin(party_type)) & (gle.against_voucher == None) & (gle.is_cancelled == 0)
+		)
+		.groupby(gle.party)
+	)
+	if account_type == "Receivable":
+		query = query.select(Sum(gle.credit).as_("amount"))
+	else:
+		query = query.select(Sum(gle.debit).as_("amount"))
+
 	if posting_date:
 		if future_payment:
-			cond = "(posting_date <= '{0}' OR DATE(creation) <= '{0}')" "".format(posting_date)
+			query = query.where((gle.posting_date <= posting_date) | (Date(gle.creation) <= posting_date))
 		else:
-			cond = "posting_date <= '{0}'".format(posting_date)
+			query = query.where(gle.posting_date <= posting_date)
 
 	if company:
-		cond += "and company = {0}".format(frappe.db.escape(company))
+		query = query.where(gle.company == company)
 
 	if party:
-		cond += "and party = {0}".format(frappe.db.escape(party))
+		query = query.where(gle.party == party)
 
-	data = frappe.db.sql(
-		""" SELECT party, sum({0}) as amount
-		FROM `tabGL Entry`
-		WHERE
-			party_type = %s and against_voucher is null
-			and is_cancelled = 0
-			and {1} GROUP BY party""".format(
-			("credit") if party_type == "Customer" else "debit", cond
-		),
-		party_type,
-	)
+	data = query.run(as_dict=True)
 	if data:
 		return frappe._dict(data)
 

--- a/erpnext/accounts/report/accounts_payable/accounts_payable.py
+++ b/erpnext/accounts/report/accounts_payable/accounts_payable.py
@@ -7,7 +7,7 @@ from erpnext.accounts.report.accounts_receivable.accounts_receivable import Rece
 
 def execute(filters=None):
 	args = {
-		"party_type": "Supplier",
+		"account_type": "Payable",
 		"naming_by": ["Buying Settings", "supp_master_name"],
 	}
 	return ReceivablePayableReport(filters).run(args)

--- a/erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.py
+++ b/erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.py
@@ -9,7 +9,7 @@ from erpnext.accounts.report.accounts_receivable_summary.accounts_receivable_sum
 
 def execute(filters=None):
 	args = {
-		"party_type": "Supplier",
+		"account_type": "Payable",
 		"naming_by": ["Buying Settings", "supp_master_name"],
 	}
 	return AccountsReceivableSummary(filters).run(args)

--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -34,7 +34,7 @@ from erpnext.accounts.utils import get_currency_precision
 
 def execute(filters=None):
 	args = {
-		"party_type": "Customer",
+		"account_type": "Receivable",
 		"naming_by": ["Selling Settings", "cust_master_name"],
 	}
 	return ReceivablePayableReport(filters).run(args)
@@ -70,8 +70,11 @@ class ReceivablePayableReport(object):
 			"Company", self.filters.get("company"), "default_currency"
 		)
 		self.currency_precision = get_currency_precision() or 2
-		self.dr_or_cr = "debit" if self.filters.party_type == "Customer" else "credit"
-		self.party_type = self.filters.party_type
+		self.dr_or_cr = "debit" if self.filters.account_type == "Receivable" else "credit"
+		self.account_type = self.filters.account_type
+		self.party_type = frappe.db.get_all(
+			"Party Type", {"account_type": self.account_type}, pluck="name"
+		)
 		self.party_details = {}
 		self.invoices = set()
 		self.skip_total_row = 0
@@ -197,6 +200,7 @@ class ReceivablePayableReport(object):
 			# no invoice, this is an invoice / stand-alone payment / credit note
 			row = self.voucher_balance.get((ple.voucher_type, ple.voucher_no, ple.party))
 
+		row.party_type = ple.party_type
 		return row
 
 	def update_voucher_balance(self, ple):
@@ -207,8 +211,9 @@ class ReceivablePayableReport(object):
 			return
 
 		# amount in "Party Currency", if its supplied. If not, amount in company currency
-		if self.filters.get(scrub(self.party_type)):
-			amount = ple.amount_in_account_currency
+		for party_type in self.party_type:
+			if self.filters.get(scrub(party_type)):
+				amount = ple.amount_in_account_currency
 		else:
 			amount = ple.amount
 		amount_in_account_currency = ple.amount_in_account_currency
@@ -362,7 +367,7 @@ class ReceivablePayableReport(object):
 
 	def get_invoice_details(self):
 		self.invoice_details = frappe._dict()
-		if self.party_type == "Customer":
+		if self.account_type == "Receivable":
 			si_list = frappe.db.sql(
 				"""
 				select name, due_date, po_no
@@ -390,7 +395,7 @@ class ReceivablePayableReport(object):
 						d.sales_person
 					)
 
-		if self.party_type == "Supplier":
+		if self.account_type == "Payable":
 			for pi in frappe.db.sql(
 				"""
 				select name, due_date, bill_no, bill_date
@@ -421,12 +426,10 @@ class ReceivablePayableReport(object):
 		# customer / supplier name
 		party_details = self.get_party_details(row.party) or {}
 		row.update(party_details)
-		if row.voucher_type == "Expense Claim":
-			row.party_type = "Employee"
-		else:
-			row.party_type = self.party_type
-		if self.filters.get(scrub(self.filters.party_type)):
-			row.currency = row.account_currency
+		for party_type in self.party_type:
+			if self.filters.get(scrub(party_type)):
+				row.currency = row.account_currency
+				break
 		else:
 			row.currency = self.company_currency
 
@@ -552,7 +555,7 @@ class ReceivablePayableReport(object):
 			where
 				payment_entry.docstatus < 2
 				and payment_entry.posting_date > %s
-				and payment_entry.party_type = %s
+				and payment_entry.party_type in %s
 			""",
 			(self.filters.report_date, self.party_type),
 			as_dict=1,
@@ -562,11 +565,11 @@ class ReceivablePayableReport(object):
 		if self.filters.get("party"):
 			amount_field = (
 				"jea.debit_in_account_currency - jea.credit_in_account_currency"
-				if self.party_type == "Supplier"
+				if self.account_type == "Payable"
 				else "jea.credit_in_account_currency - jea.debit_in_account_currency"
 			)
 		else:
-			amount_field = "jea.debit - " if self.party_type == "Supplier" else "jea.credit"
+			amount_field = "jea.debit - " if self.account_type == "Payable" else "jea.credit"
 
 		return frappe.db.sql(
 			"""
@@ -584,7 +587,7 @@ class ReceivablePayableReport(object):
 			where
 				je.docstatus < 2
 				and je.posting_date > %s
-				and jea.party_type = %s
+				and jea.party_type in %s
 				and jea.reference_name is not null and jea.reference_name != ''
 			group by je.name, jea.reference_name
 			having future_amount > 0
@@ -623,13 +626,17 @@ class ReceivablePayableReport(object):
 			row.future_ref = ", ".join(row.future_ref)
 
 	def get_return_entries(self):
-		doctype = "Sales Invoice" if self.party_type == "Customer" else "Purchase Invoice"
+		doctype = "Sales Invoice" if self.account_type == "Receivable" else "Purchase Invoice"
 		filters = {"is_return": 1, "docstatus": 1, "company": self.filters.company}
-		party_field = scrub(self.filters.party_type)
-		if self.filters.get(party_field):
-			filters.update({party_field: self.filters.get(party_field)})
+		or_filters = {}
+		for party_type in self.party_type:
+			party_field = scrub(party_type)
+			if self.filters.get(party_field):
+				or_filters.update({party_field: self.filters.get(party_field)})
 		self.return_entries = frappe._dict(
-			frappe.get_all(doctype, filters, ["name", "return_against"], as_list=1)
+			frappe.get_all(
+				doctype, filters=filters, or_filters=or_filters, fields=["name", "return_against"], as_list=1
+			)
 		)
 
 	def set_ageing(self, row):
@@ -720,6 +727,7 @@ class ReceivablePayableReport(object):
 			)
 			.where(ple.delinked == 0)
 			.where(Criterion.all(self.qb_selection_filter))
+			.where(Criterion.any(self.or_filters))
 		)
 
 		if self.filters.get("group_by_party"):
@@ -750,19 +758,18 @@ class ReceivablePayableReport(object):
 
 	def prepare_conditions(self):
 		self.qb_selection_filter = []
-		party_type_field = scrub(self.party_type)
-		if self.party_type == "Supplier":
-			self.qb_selection_filter.append(self.ple.party_type.isin([self.party_type, "Employee"]))
-		else:
-			self.qb_selection_filter.append(self.ple.party_type == self.party_type)
+		self.or_filters = []
+		for party_type in self.party_type:
+			party_type_field = scrub(party_type)
+			self.or_filters.append(self.ple.party_type == party_type)
 
-		self.add_common_filters(party_type_field=party_type_field)
+			self.add_common_filters(party_type_field=party_type_field)
 
-		if party_type_field == "customer":
-			self.add_customer_filters()
+			if party_type_field == "customer":
+				self.add_customer_filters()
 
-		elif party_type_field == "supplier":
-			self.add_supplier_filters()
+			elif party_type_field == "supplier":
+				self.add_supplier_filters()
 
 		if self.filters.cost_center:
 			self.get_cost_center_conditions()
@@ -791,11 +798,10 @@ class ReceivablePayableReport(object):
 			self.qb_selection_filter.append(self.ple.account == self.filters.party_account)
 		else:
 			# get GL with "receivable" or "payable" account_type
-			account_type = "Receivable" if self.party_type == "Customer" else "Payable"
 			accounts = [
 				d.name
 				for d in frappe.get_all(
-					"Account", filters={"account_type": account_type, "company": self.filters.company}
+					"Account", filters={"account_type": self.account_type, "company": self.filters.company}
 				)
 			]
 
@@ -885,7 +891,7 @@ class ReceivablePayableReport(object):
 
 	def get_party_details(self, party):
 		if not party in self.party_details:
-			if self.party_type == "Customer":
+			if self.account_type == "Receivable":
 				fields = ["customer_name", "territory", "customer_group", "customer_primary_contact"]
 
 				if self.filters.get("sales_partner"):
@@ -921,7 +927,7 @@ class ReceivablePayableReport(object):
 			width=180,
 		)
 		self.add_column(
-			label="Receivable Account" if self.party_type == "Customer" else "Payable Account",
+			label=self.account_type + " Account",
 			fieldname="party_account",
 			fieldtype="Link",
 			options="Account",
@@ -929,13 +935,19 @@ class ReceivablePayableReport(object):
 		)
 
 		if self.party_naming_by == "Naming Series":
+			if self.account_type == "Payable":
+				label = "Supplier Name"
+				fieldname = "supplier_name"
+			else:
+				label = "Customer Name"
+				fieldname = "customer_name"
 			self.add_column(
-				_("{0} Name").format(self.party_type),
-				fieldname=scrub(self.party_type) + "_name",
+				label=label,
+				fieldname=fieldname,
 				fieldtype="Data",
 			)
 
-		if self.party_type == "Customer":
+		if self.account_type == "Receivable":
 			self.add_column(
 				_("Customer Contact"),
 				fieldname="customer_primary_contact",
@@ -955,7 +967,7 @@ class ReceivablePayableReport(object):
 
 		self.add_column(label="Due Date", fieldtype="Date")
 
-		if self.party_type == "Supplier":
+		if self.account_type == "Payable":
 			self.add_column(label=_("Bill No"), fieldname="bill_no", fieldtype="Data")
 			self.add_column(label=_("Bill Date"), fieldname="bill_date", fieldtype="Date")
 
@@ -965,7 +977,7 @@ class ReceivablePayableReport(object):
 
 		self.add_column(_("Invoiced Amount"), fieldname="invoiced")
 		self.add_column(_("Paid Amount"), fieldname="paid")
-		if self.party_type == "Customer":
+		if self.account_type == "Receivable":
 			self.add_column(_("Credit Note"), fieldname="credit_note")
 		else:
 			# note: fieldname is still `credit_note`
@@ -983,7 +995,7 @@ class ReceivablePayableReport(object):
 			self.add_column(label=_("Future Payment Amount"), fieldname="future_amount")
 			self.add_column(label=_("Remaining Balance"), fieldname="remaining_balance")
 
-		if self.filters.party_type == "Customer":
+		if self.filters.account_type == "Receivable":
 			self.add_column(label=_("Customer LPO"), fieldname="po_no", fieldtype="Data")
 
 			# comma separated list of linked delivery notes
@@ -1004,7 +1016,7 @@ class ReceivablePayableReport(object):
 			if self.filters.sales_partner:
 				self.add_column(label=_("Sales Partner"), fieldname="default_sales_partner", fieldtype="Data")
 
-		if self.filters.party_type == "Supplier":
+		if self.filters.account_type == "Payable":
 			self.add_column(
 				label=_("Supplier Group"),
 				fieldname="supplier_group",

--- a/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py
+++ b/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py
@@ -12,7 +12,7 @@ from erpnext.accounts.report.accounts_receivable.accounts_receivable import Rece
 
 def execute(filters=None):
 	args = {
-		"party_type": "Customer",
+		"account_type": "Receivable",
 		"naming_by": ["Selling Settings", "cust_master_name"],
 	}
 
@@ -21,7 +21,10 @@ def execute(filters=None):
 
 class AccountsReceivableSummary(ReceivablePayableReport):
 	def run(self, args):
-		self.party_type = args.get("party_type")
+		self.account_type = args.get("account_type")
+		self.party_type = frappe.db.get_all(
+			"Party Type", {"account_type": self.account_type}, pluck="name"
+		)
 		self.party_naming_by = frappe.db.get_value(
 			args.get("naming_by")[0], None, args.get("naming_by")[1]
 		)
@@ -35,13 +38,19 @@ class AccountsReceivableSummary(ReceivablePayableReport):
 
 		self.get_party_total(args)
 
+		party = None
+		for party_type in self.party_type:
+			if self.filters.get(scrub(party_type)):
+				party = self.filters.get(scrub(party_type))
+
 		party_advance_amount = (
 			get_partywise_advanced_payment_amount(
 				self.party_type,
 				self.filters.report_date,
 				self.filters.show_future_payments,
 				self.filters.company,
-				party=self.filters.get(scrub(self.party_type)),
+				party=party,
+				account_type=self.account_type,
 			)
 			or {}
 		)
@@ -57,9 +66,13 @@ class AccountsReceivableSummary(ReceivablePayableReport):
 
 			row.party = party
 			if self.party_naming_by == "Naming Series":
-				row.party_name = frappe.get_cached_value(
-					self.party_type, party, scrub(self.party_type) + "_name"
-				)
+				if self.account_type == "Payable":
+					doctype = "Supplier"
+					fieldname = "supplier_name"
+				else:
+					doctype = "Customer"
+					fieldname = "customer_name"
+				row.party_name = frappe.get_cached_value(doctype, party, fieldname)
 
 			row.update(party_dict)
 
@@ -93,6 +106,7 @@ class AccountsReceivableSummary(ReceivablePayableReport):
 
 			# set territory, customer_group, sales person etc
 			self.set_party_details(d)
+			self.party_total[d.party].update({"party_type": d.party_type})
 
 	def init_party_total(self, row):
 		self.party_total.setdefault(
@@ -131,17 +145,27 @@ class AccountsReceivableSummary(ReceivablePayableReport):
 	def get_columns(self):
 		self.columns = []
 		self.add_column(
-			label=_(self.party_type),
+			label="Party Type",
+			fieldname="party_type",
+			fieldtype="Data",
+			width=100,
+		)
+		self.add_column(
+			label="Party",
 			fieldname="party",
-			fieldtype="Link",
-			options=self.party_type,
+			fieldtype="Dynamic Link",
+			options="party_type",
 			width=180,
 		)
 
 		if self.party_naming_by == "Naming Series":
-			self.add_column(_("{0} Name").format(self.party_type), fieldname="party_name", fieldtype="Data")
+			self.add_column(
+				label="Supplier Name" if self.account_type == "Payable" else "Customer Name",
+				fieldname="party_name",
+				fieldtype="Data",
+			)
 
-		credit_debit_label = "Credit Note" if self.party_type == "Customer" else "Debit Note"
+		credit_debit_label = "Credit Note" if self.account_type == "Receivable" else "Debit Note"
 
 		self.add_column(_("Advance Amount"), fieldname="advance")
 		self.add_column(_("Invoiced Amount"), fieldname="invoiced")
@@ -159,7 +183,7 @@ class AccountsReceivableSummary(ReceivablePayableReport):
 			self.add_column(label=_("Future Payment Amount"), fieldname="future_amount")
 			self.add_column(label=_("Remaining Balance"), fieldname="remaining_balance")
 
-		if self.party_type == "Customer":
+		if self.account_type == "Receivable":
 			self.add_column(
 				label=_("Territory"), fieldname="territory", fieldtype="Link", options="Territory"
 			)


### PR DESCRIPTION
**Problem**
When an Expense Claim is created using the **Expense Claim** Doctype from the `hrms` app, the Accounts Payable Report does not fetch the Payment Ledger Entries for the payable expense. This leads to a mismatch between the General Ledger Report balance amount and the Accounts Payable total amount.

**Accounting Ledger for an Expense Claim of** `₹1000`

<img width="1320" alt="Screenshot 2023-07-26 at 4 54 26 PM" src="https://github.com/frappe/erpnext/assets/40693548/b8857079-690e-4f37-9261-8e091ccaac7c">
<br>
<br>

**Accounts Payable Report ( Payable for the Expense Claim not recorded )** - Outstanding `₹1000`

<img width="1320" alt="Screenshot 2023-07-26 at 4 58 32 PM" src="https://github.com/frappe/erpnext/assets/40693548/6dd8a305-ddd3-47be-9b0e-5fc36ce1fe41">
<br><br>

**General Ledger for the Creditors Account** - Balance `-₹2000`

<img width="1320" alt="Screenshot 2023-07-26 at 5 01 47 PM" src="https://github.com/frappe/erpnext/assets/40693548/14cbe022-a653-4510-9018-1a9a807bdccc">
<br><br>

---

**Solution**

- Add an extra column for showing Party Type.
- Fetch Payment Ledger Entries with the party type **Employee** along with **Supplier** in AP Report.
