### PR TITLE
perf: don't use ifnull where it's not required

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -1738,7 +1738,7 @@ def get_orders_to_be_billed(
 			{party_type} = %s
 			and docstatus = 1
 			and company = %s
-			and ifnull(status, "") != "Closed"
+			and status != "Closed"
 			and if({rounded_total_field}, {rounded_total_field}, {grand_total_field}) > advance_paid
 			and abs(100 - per_billed) > 0.01
 			{condition}

--- a/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py
+++ b/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py
@@ -720,7 +720,7 @@ def get_additional_conditions(from_date, ignore_closing_entries, filters):
 	additional_conditions = []
 
 	if ignore_closing_entries:
-		additional_conditions.append("ifnull(gl.voucher_type, '')!='Period Closing Voucher'")
+		additional_conditions.append("gl.voucher_type != 'Period Closing Voucher'")
 
 	if from_date:
 		additional_conditions.append("gl.posting_date >= %(from_date)s")

--- a/erpnext/accounts/report/profitability_analysis/profitability_analysis.py
+++ b/erpnext/accounts/report/profitability_analysis/profitability_analysis.py
@@ -208,7 +208,7 @@ def set_gl_entries_by_account(
 	additional_conditions = []
 
 	if ignore_closing_entries:
-		additional_conditions.append("and ifnull(voucher_type, '')!='Period Closing Voucher'")
+		additional_conditions.append("and voucher_type !='Period Closing Voucher'")
 
 	if from_date:
 		additional_conditions.append("and posting_date >= %(from_date)s")

--- a/erpnext/accounts/report/sales_register/sales_register.py
+++ b/erpnext/accounts/report/sales_register/sales_register.py
@@ -475,7 +475,7 @@ def get_invoice_so_dn_map(invoice_list):
 	si_items = frappe.db.sql(
 		"""select parent, sales_order, delivery_note, so_detail
 		from `tabSales Invoice Item` where parent in (%s)
-		and (ifnull(sales_order, '') != '' or ifnull(delivery_note, '') != '')"""
+		and (sales_order != '' or delivery_note != '')"""
 		% ", ".join(["%s"] * len(invoice_list)),
 		tuple(inv.name for inv in invoice_list),
 		as_dict=1,
@@ -510,7 +510,7 @@ def get_invoice_cc_wh_map(invoice_list):
 	si_items = frappe.db.sql(
 		"""select parent, cost_center, warehouse
 		from `tabSales Invoice Item` where parent in (%s)
-		and (ifnull(cost_center, '') != '' or ifnull(warehouse, '') != '')"""
+		and (cost_center != '' or warehouse != '')"""
 		% ", ".join(["%s"] * len(invoice_list)),
 		tuple(inv.name for inv in invoice_list),
 		as_dict=1,

--- a/erpnext/manufacturing/doctype/bom_update_log/bom_updation_utils.py
+++ b/erpnext/manufacturing/doctype/bom_update_log/bom_updation_utils.py
@@ -161,7 +161,7 @@ def get_leaf_boms() -> List[str]:
 		"""select name from `tabBOM` bom
 		where docstatus=1 and is_active=1
 			and not exists(select bom_no from `tabBOM Item`
-				where parent=bom.name and ifnull(bom_no, '')!='')"""
+				where parent=bom.name and bom_no !='')"""
 	)
 
 

--- a/erpnext/projects/report/project_wise_stock_tracking/project_wise_stock_tracking.py
+++ b/erpnext/projects/report/project_wise_stock_tracking/project_wise_stock_tracking.py
@@ -77,7 +77,7 @@ def get_issued_items_cost():
 		"""select se.project, sum(se_item.amount) as amount
 		from `tabStock Entry` se, `tabStock Entry Detail` se_item
 		where se.name = se_item.parent and se.docstatus = 1 and ifnull(se_item.t_warehouse, '') = ''
-		and ifnull(se.project, '') != '' group by se.project""",
+		and se.project != '' group by se.project""",
 		as_dict=1,
 	)
 

--- a/erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.py
+++ b/erpnext/stock/report/batch_wise_balance_history/batch_wise_balance_history.py
@@ -102,7 +102,7 @@ def get_stock_ledger_entries_for_batch_no(filters):
 		.where(
 			(sle.docstatus < 2)
 			& (sle.is_cancelled == 0)
-			& (fn.IfNull(sle.batch_no, "") != "")
+			& (sle.batch_no != "")
 			& (sle.posting_date <= filters["to_date"])
 		)
 		.groupby(sle.voucher_no, sle.batch_no, sle.item_code, sle.warehouse)


### PR DESCRIPTION
`ifnull` isn't really required here.

`null != '' -> null` in SQL so it won't show up in results, we don't need to specifically translate null to first `''` and then compare. 

Use of `ifnull` confuses query planner and it can't use right indexes. 

explanation: https://github.com/frappe/frappe/pull/21822
