### PR TITLE
fix: Ignore account closing balance for financial statement

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -58,6 +58,7 @@
   "closing_settings_tab",
   "period_closing_settings_section",
   "acc_frozen_upto",
+  "ignore_account_closing_balance",
   "column_break_25",
   "frozen_accounts_modifier",
   "tab_break_dpet",
@@ -406,6 +407,13 @@
    "fieldname": "enable_fuzzy_matching",
    "fieldtype": "Check",
    "label": "Enable Fuzzy Matching"
+  },
+  {
+   "default": "0",
+   "description": "Financial reports will be generated using GL Entry doctypes (should be enabled if Period Closing Voucher is not posted for all years sequentially or missing) ",
+   "fieldname": "ignore_account_closing_balance",
+   "fieldtype": "Check",
+   "label": "Ignore Account Closing Balance"
   }
  ],
  "icon": "icon-cog",
@@ -413,7 +421,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-06-15 16:35:45.123456",
+ "modified": "2023-07-27 15:05:34.000264",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounts Settings",

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
@@ -14,21 +14,32 @@ from erpnext.stock.utils import check_pending_reposting
 
 
 class AccountsSettings(Document):
-	def on_update(self):
-		frappe.clear_cache()
-
 	def validate(self):
-		frappe.db.set_default(
-			"add_taxes_from_item_tax_template", self.get("add_taxes_from_item_tax_template", 0)
-		)
+		old_doc = self.get_doc_before_save()
+		clear_cache = False
 
-		frappe.db.set_default(
-			"enable_common_party_accounting", self.get("enable_common_party_accounting", 0)
-		)
+		if old_doc.add_taxes_from_item_tax_template != self.add_taxes_from_item_tax_template:
+			frappe.db.set_default(
+				"add_taxes_from_item_tax_template", self.get("add_taxes_from_item_tax_template", 0)
+			)
+			clear_cache = True
+
+		if old_doc.enable_common_party_accounting != self.enable_common_party_accounting:
+			frappe.db.set_default(
+				"enable_common_party_accounting", self.get("enable_common_party_accounting", 0)
+			)
+			clear_cache = True
 
 		self.validate_stale_days()
-		self.enable_payment_schedule_in_print()
-		self.validate_pending_reposts()
+
+		if old_doc.show_payment_schedule_in_print != self.show_payment_schedule_in_print:
+			self.enable_payment_schedule_in_print()
+
+		if old_doc.acc_frozen_upto != self.acc_frozen_upto:
+			self.validate_pending_reposts()
+
+		if clear_cache:
+			frappe.clear_cache()
 
 	def validate_stale_days(self):
 		if not self.allow_stale and cint(self.stale_days) <= 0:

--- a/erpnext/accounts/report/financial_statements.py
+++ b/erpnext/accounts/report/financial_statements.py
@@ -429,11 +429,17 @@ def set_gl_entries_by_account(
 
 	if accounts_list:
 		# For balance sheet
-		if not from_date:
-			from_date = filters["period_start_date"]
+		ignore_closing_balances = frappe.db.get_single_value(
+			"Accounts Settings", "ignore_account_closing_balance"
+		)
+		if not from_date and not ignore_closing_balances:
 			last_period_closing_voucher = frappe.db.get_all(
 				"Period Closing Voucher",
-				filters={"docstatus": 1, "company": filters.company, "posting_date": ("<", from_date)},
+				filters={
+					"docstatus": 1,
+					"company": filters.company,
+					"posting_date": ("<", filters["period_start_date"]),
+				},
 				fields=["posting_date", "name"],
 				order_by="posting_date desc",
 				limit=1,

--- a/erpnext/accounts/report/trial_balance/trial_balance.py
+++ b/erpnext/accounts/report/trial_balance/trial_balance.py
@@ -142,13 +142,19 @@ def get_opening_balances(filters):
 def get_rootwise_opening_balances(filters, report_type):
 	gle = []
 
-	last_period_closing_voucher = frappe.db.get_all(
-		"Period Closing Voucher",
-		filters={"docstatus": 1, "company": filters.company, "posting_date": ("<", filters.from_date)},
-		fields=["posting_date", "name"],
-		order_by="posting_date desc",
-		limit=1,
+	last_period_closing_voucher = ""
+	ignore_closing_balances = frappe.db.get_single_value(
+		"Accounts Settings", "ignore_account_closing_balance"
 	)
+
+	if not ignore_closing_balances:
+		last_period_closing_voucher = frappe.db.get_all(
+			"Period Closing Voucher",
+			filters={"docstatus": 1, "company": filters.company, "posting_date": ("<", filters.from_date)},
+			fields=["posting_date", "name"],
+			order_by="posting_date desc",
+			limit=1,
+		)
 
 	accounting_dimensions = get_accounting_dimensions(as_list=False)
 


### PR DESCRIPTION
In some cases, users might not have posted a Period Closing Voucher for certain years or might not have posted correctly.
In such cases, the financial reports might show incorrect numbers.

This check will allow users to generate reports purely using GL Entries meanwhile the underlying issues are resolved.

<img width="1341" alt="image" src="https://github.com/frappe/erpnext/assets/42651287/88dcc03d-6023-481f-91a7-ee8e499dc60b">

- Fixed a balance sheet-related issue as well along with this
- One minor perf fix, on updating accounts settings many things were getting checked or updated even though the concerned field was not updated and the doc took a couple of seconds to update, default updating and validations will be triggered only if needed