### PR TITLE
feat(RFQ): make sending attachments configurable

### DIFF
--- a/erpnext/buying/doctype/request_for_quotation/request_for_quotation.json
+++ b/erpnext/buying/doctype/request_for_quotation/request_for_quotation.json
@@ -24,6 +24,7 @@
   "preview",
   "col_break_email_1",
   "html_llwp",
+  "send_attached_files",
   "sec_break_email_2",
   "message_for_supplier",
   "terms_section_break",
@@ -273,13 +274,20 @@
    "fieldtype": "HTML",
    "options": "<p>In your <b>Email Template</b>, you can use the following special variables:\n</p>\n<ul>\n        <li>\n            <code>{{ update_password_link }}</code>: A link where your supplier can set a new password to log into your portal.\n        </li>\n        <li>\n            <code>{{ portal_link }}</code>: A link to this RFQ in your supplier portal.\n        </li>\n        <li>\n            <code>{{ supplier_name }}</code>: The company name of your supplier.\n        </li>\n        <li>\n            <code>{{ contact.salutation }} {{ contact.last_name }}</code>: The contact person of your supplier.\n        </li><li>\n            <code>{{ user_fullname }}</code>: Your full name.\n        </li>\n    </ul>\n<p></p>\n<p>Apart from these, you can access all values in this RFQ, like <code>{{ message_for_supplier }}</code> or <code>{{ terms }}</code>.</p>",
    "read_only": 1
+  },
+  {
+   "default": "1",
+   "description": "If enabled, all files attached to this document will be attached to each email",
+   "fieldname": "send_attached_files",
+   "fieldtype": "Check",
+   "label": "Send Attached Files"
   }
  ],
  "icon": "fa fa-shopping-cart",
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-07-27 14:01:14.534594",
+ "modified": "2023-07-27 16:41:48.468873",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Request for Quotation",

--- a/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
+++ b/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
@@ -202,7 +202,9 @@ class RequestforQuotation(BuyingController):
 		if preview:
 			return {"message": message, "subject": subject}
 
-		attachments = self.get_attachments()
+		attachments = None
+		if self.send_attached_files:
+			attachments = self.get_attachments()
 
 		self.send_email(data, sender, subject, message, attachments)
 


### PR DESCRIPTION
Until now, all files attached to a **Request for Quotation** were silently sent along to the suppliers. This PR makes this behavior explicit and configurable.

![Bildschirmfoto 2023-07-27 um 16 47 29](https://github.com/frappe/erpnext/assets/14891507/7ad5b47c-af2f-42f3-a805-92d0922a4fca)

> no-docs

(will add docs after merge)