### PR TITLE
fix: removed "fetch_from"

### DIFF
--- a/erpnext/quality_management/doctype/quality_goal_objective/quality_goal_objective.json
+++ b/erpnext/quality_management/doctype/quality_goal_objective/quality_goal_objective.json
@@ -1,4 +1,5 @@
 {
+ "actions": [],
  "autoname": "format:{####}",
  "creation": "2019-05-26 15:03:43.996455",
  "doctype": "DocType",
@@ -12,7 +13,6 @@
  ],
  "fields": [
   {
-   "fetch_from": "goal.objective",
    "fieldname": "objective",
    "fieldtype": "Text",
    "in_list_view": 1,
@@ -38,14 +38,17 @@
   }
  ],
  "istable": 1,
- "modified": "2019-05-26 16:12:54.832058",
+ "links": [],
+ "modified": "2023-07-28 18:10:23.351246",
  "modified_by": "Administrator",
  "module": "Quality Management",
  "name": "Quality Goal Objective",
+ "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [],
  "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }


### PR DESCRIPTION
*fix: removed ("fetch_from": "goal.objective")
* The field was disabled due to "fetch_from".
* And it doesn't carry a value, perhaps because the "goal" field belongs to the parent doctype.