### PR TITLE
fix: in payment_entry 'Unallocated Amount' cal is broken

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -903,12 +903,12 @@ frappe.ui.form.on('Payment Entry', {
 			if(frm.doc.payment_type == "Receive"
 				&& frm.doc.base_total_allocated_amount < frm.doc.base_received_amount + total_deductions
 				&& frm.doc.total_allocated_amount < frm.doc.paid_amount + (total_deductions / frm.doc.source_exchange_rate)) {
-					unallocated_amount = (frm.doc.base_received_amount + total_deductions + frm.doc.base_total_taxes_and_charges
+					unallocated_amount = (frm.doc.base_received_amount + total_deductions + flt(frm.doc.base_total_taxes_and_charges)
 						- frm.doc.base_total_allocated_amount) / frm.doc.source_exchange_rate;
 			} else if (frm.doc.payment_type == "Pay"
 				&& frm.doc.base_total_allocated_amount < frm.doc.base_paid_amount - total_deductions
 				&& frm.doc.total_allocated_amount < frm.doc.received_amount + (total_deductions / frm.doc.target_exchange_rate)) {
-					unallocated_amount = (frm.doc.base_paid_amount + frm.doc.base_total_taxes_and_charges - (total_deductions
+					unallocated_amount = (frm.doc.base_paid_amount + flt(frm.doc.base_total_taxes_and_charges) - (total_deductions
 						+ frm.doc.base_total_allocated_amount)) / frm.doc.target_exchange_rate;
 			}
 		}


### PR DESCRIPTION
**Business case:**
for a customer who is paying more than his invoices amt, `Unallocated Amount` calculation should happen.
at present it is not happening

Paid Amount : amt he is paying
Total Allocated Amount  : amt total as per Sales Invoice
Unallocated Amount : extra amt, as he is paying more than total of pending
ie.
Unallocated Amount=Paid Amount-Total Allocated Amount 

**Actual :**
Unallocated Amount remains empty

**Expected:**
Unallocated Amount=Paid Amount-Total Allocated Amount 

**Reason:**
There is frm.doc.base_total_taxes_and_charges field used in calculation, which is undefined till the Payment Entry is saved.
hence, when this field  is referred as part of calculation, it makes the entire calculation result as NaN
Ex:
`unallocated_amount = (frm.doc.base_received_amount + total_deductions + frm.doc.base_total_taxes_and_charges
						- frm.doc.base_total_allocated_amount) / frm.doc.source_exchange_rate;`
As, frm.doc.base_total_taxes_and_charges --> is undefined,
unallocated_amount result in NaN

**Fix:**
flt(frm.doc.base_total_taxes_and_charges) --> flt converts undefined to 0, and hence unallocated_amount calcuation becomes correct


**Reference:**
We have done similar fix.
#35239

**GIF Before Fix**
![Peek 2023-07-28 11-28](https://github.com/frappe/erpnext/assets/29812965/78932647-fb30-4bc1-b365-14652f9405ee)

**GIF After Fix**
![Peek 2023-07-28 11-40](https://github.com/frappe/erpnext/assets/29812965/6a159729-d9ea-4d05-9f29-54f863202c03)
