### PR TITLE
fix: Job Card validation fixed when displaying total completed quantity

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -544,12 +544,12 @@ class JobCard(Document):
 		if self.for_quantity and flt(total_completed_qty, precision) != flt(
 			self.for_quantity, precision
 		):
-			total_completed_qty = bold(_("Total Completed Qty"))
+			total_completed_qty_label = bold(_("Total Completed Qty"))
 			qty_to_manufacture = bold(_("Qty to Manufacture"))
 
 			frappe.throw(
 				_("The {0} ({1}) must be equal to {2} ({3})").format(
-					total_completed_qty,
+					total_completed_qty_label,
 					bold(flt(total_completed_qty, precision)),
 					qty_to_manufacture,
 					bold(self.for_quantity),


### PR DESCRIPTION
When job card total completed qty does not match the for quantity it shows an error with the two values but, the variable that should be the total completed qty is substituted by a string and always returns 0.0 from the flt function.
