### PR TITLE
fix: multiple issues related to Production Plan

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.js
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.js
@@ -9,19 +9,25 @@ frappe.ui.form.on('Production Plan', {
 			item.temporary_name = item.name;
 		});
 	},
+
 	setup(frm) {
+		frm.trigger("setup_queries");
+
 		frm.custom_make_buttons = {
 			'Work Order': 'Work Order / Subcontract PO',
 			'Material Request': 'Material Request',
 		};
+	},
 
-		frm.fields_dict['po_items'].grid.get_field('warehouse').get_query = function(doc) {
+	setup_queries(frm) {
+		frm.set_query("sales_order", "sales_orders", () => {
 			return {
+				query: "erpnext.manufacturing.doctype.production_plan.production_plan.sales_order_query",
 				filters: {
-					company: doc.company
+					company: frm.doc.company,
 				}
 			}
-		}
+		});
 
 		frm.set_query('for_warehouse', function(doc) {
 			return {
@@ -42,32 +48,40 @@ frappe.ui.form.on('Production Plan', {
 			};
 		});
 
-		frm.fields_dict['po_items'].grid.get_field('item_code').get_query = function(doc) {
+		frm.set_query("item_code", "po_items", (doc, cdt, cdn) => {
 			return {
 				query: "erpnext.controllers.queries.item_query",
 				filters:{
 					'is_stock_item': 1,
 				}
 			}
-		}
+		});
 
-		frm.fields_dict['po_items'].grid.get_field('bom_no').get_query = function(doc, cdt, cdn) {
+		frm.set_query("bom_no", "po_items", (doc, cdt, cdn) => {
 			var d = locals[cdt][cdn];
 			if (d.item_code) {
 				return {
 					query: "erpnext.controllers.queries.bom",
-					filters:{'item': cstr(d.item_code), 'docstatus': 1}
+					filters:{'item': d.item_code, 'docstatus': 1}
 				}
 			} else frappe.msgprint(__("Please enter Item first"));
-		}
+		});
 
-		frm.fields_dict['mr_items'].grid.get_field('warehouse').get_query = function(doc) {
+		frm.set_query("warehouse", "mr_items", (doc) => {
 			return {
 				filters: {
 					company: doc.company
 				}
 			}
-		}
+		});
+
+		frm.set_query("warehouse", "po_items", (doc) => {
+			return {
+				filters: {
+					company: doc.company
+				}
+			}
+		});
 	},
 
 	refresh(frm) {
@@ -436,7 +450,7 @@ frappe.ui.form.on("Production Plan Item", {
 				}
 			});
 		}
-	}
+	},
 });
 
 frappe.ui.form.on("Material Request Plan Item", {
@@ -467,30 +481,35 @@ frappe.ui.form.on("Material Request Plan Item", {
 
 frappe.ui.form.on("Production Plan Sales Order", {
 	sales_order(frm, cdt, cdn) {
-		const { sales_order } = locals[cdt][cdn];
+		let row = locals[cdt][cdn];
+		const sales_order = row.sales_order;
 		if (!sales_order) {
 			return;
 		}
-		frappe.call({
-			method: "erpnext.manufacturing.doctype.production_plan.production_plan.get_so_details",
-			args: { sales_order },
-			callback(r) {
-				const {transaction_date, customer, grand_total} = r.message;
-				frappe.model.set_value(cdt, cdn, 'sales_order_date', transaction_date);
-				frappe.model.set_value(cdt, cdn, 'customer', customer);
-				frappe.model.set_value(cdt, cdn, 'grand_total', grand_total);
-			}
-		});
+
+		if (row.sales_order) {
+			frm.call({
+				method: "validate_sales_orders",
+				doc: frm.doc,
+				args: {
+					sales_order: row.sales_order,
+				},
+				callback(r) {
+					frappe.call({
+						method: "erpnext.manufacturing.doctype.production_plan.production_plan.get_so_details",
+						args: { sales_order },
+						callback(r) {
+							const {transaction_date, customer, grand_total} = r.message;
+							frappe.model.set_value(cdt, cdn, 'sales_order_date', transaction_date);
+							frappe.model.set_value(cdt, cdn, 'customer', customer);
+							frappe.model.set_value(cdt, cdn, 'grand_total', grand_total);
+						}
+					});
+				}
+			});
+		}
 	}
 });
-
-cur_frm.fields_dict['sales_orders'].grid.get_field("sales_order").get_query = function() {
-	return{
-		filters: [
-			['Sales Order','docstatus', '=' ,1]
-		]
-	}
-};
 
 frappe.tour['Production Plan'] = [
 	{

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.json
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.json
@@ -228,10 +228,10 @@
   },
   {
    "default": "0",
-   "description": "To know more about projected quantity, <a href=\"https://erpnext.com/docs/user/manual/en/stock/projected-quantity\" style=\"text-decoration: underline;\" target=\"_blank\">click here</a>.",
+   "description": "If enabled, the system won't create material requests for the available items.",
    "fieldname": "ignore_existing_ordered_qty",
    "fieldtype": "Check",
-   "label": "Ignore Existing Projected Quantity"
+   "label": "Ignore Available Stock"
   },
   {
    "fieldname": "column_break_25",
@@ -339,7 +339,7 @@
    "depends_on": "eval:doc.get_items_from == 'Sales Order'",
    "fieldname": "combine_items",
    "fieldtype": "Check",
-   "label": "Consolidate Items"
+   "label": "Consolidate Sales Order Items"
   },
   {
    "fieldname": "section_break_25",
@@ -399,7 +399,7 @@
   },
   {
    "default": "0",
-   "description": "System consider the projected quantity to check available or will be available sub-assembly items ",
+   "description": "If this checkbox is enabled, then the system won\u2019t run the MRP for the available sub-assembly items.",
    "fieldname": "skip_available_sub_assembly_item",
    "fieldtype": "Check",
    "label": "Skip Available Sub Assembly Items"
@@ -422,7 +422,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-05-22 23:36:31.770517",
+ "modified": "2023-07-28 13:37:43.926686",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Production Plan",

--- a/erpnext/selling/doctype/sales_order_item/sales_order_item.json
+++ b/erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -84,6 +84,7 @@
   "actual_qty",
   "ordered_qty",
   "planned_qty",
+  "production_plan_qty",
   "column_break_69",
   "work_order_qty",
   "delivered_qty",
@@ -882,12 +883,19 @@
    "print_hide": 1,
    "read_only": 1,
    "report_hide": 1
+  },
+  {
+   "fieldname": "production_plan_qty",
+   "fieldtype": "Float",
+   "label": "Production Plan Qty",
+   "no_copy": 1,
+   "read_only": 1
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-04-04 10:44:05.707488",
+ "modified": "2023-07-28 14:56:42.031636",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order Item",


### PR DESCRIPTION
## Issues

### Multiple Production Plan against the same Sales Order

- Make a sales order for the item A
- Create the production plan against the above sales order and submit it
- Create another production plan against the same sales order, system will allow you to submit it

**After Fix**

Added validation that user shouldn't create a production plan against the sales order for which production plan has already created.

<img width="655" alt="Screenshot 2023-07-28 at 4 11 37 PM" src="https://github.com/frappe/erpnext/assets/8780500/369ef7bf-07dc-4b7f-ad82-23b1b76c95c8">

### Get BOM from the Sales Order

- Created a new BOM for the Item A and created a new sales order SO-1, system has picked the latest BOM in the SO
- Created another new BOM for the same Item A and created a new sales order SO-2, system has picked the latest BOM in the SO
- Created production plan against the SO-1, system has picked the last BOM and not the BOM which has linked in the sales order SO-1.
**After Fix**
- System will pick the BOM from the sales order and not the latest Active BOM

### Production Plan showing Semi-FG item in Raw materials
<img width="1115" alt="Screenshot 2023-07-28 at 4 06 49 PM" src="https://github.com/frappe/erpnext/assets/8780500/e21e85eb-f015-4017-8fd2-c9300ddddb18">


**After Fix**
<img width="1037" alt="Screenshot 2023-07-28 at 4 07 21 PM" src="https://github.com/frappe/erpnext/assets/8780500/da7b1aa5-fb50-4b93-81ab-ae1ae84f2163">




