### PR TITLE
fix: change fieldtype from Currency to Float for the valuation rate in reports

### DIFF
--- a/erpnext/stock/report/stock_balance/stock_balance.py
+++ b/erpnext/stock/report/stock_balance/stock_balance.py
@@ -446,10 +446,9 @@ class StockBalanceReport(object):
 				{
 					"label": _("Valuation Rate"),
 					"fieldname": "val_rate",
-					"fieldtype": "Currency",
+					"fieldtype": "Float",
 					"width": 90,
 					"convertible": "rate",
-					"options": "currency",
 				},
 				{
 					"label": _("Reserved Stock"),

--- a/erpnext/stock/report/stock_ledger/stock_ledger.py
+++ b/erpnext/stock/report/stock_ledger/stock_ledger.py
@@ -196,7 +196,7 @@ def get_columns(filters):
 			{
 				"label": _("Avg Rate (Balance Stock)"),
 				"fieldname": "valuation_rate",
-				"fieldtype": "Currency",
+				"fieldtype": "Float",
 				"width": 180,
 				"options": "Company:company:default_currency",
 				"convertible": "rate",
@@ -204,7 +204,7 @@ def get_columns(filters):
 			{
 				"label": _("Valuation Rate"),
 				"fieldname": "in_out_rate",
-				"fieldtype": "Currency",
+				"fieldtype": "Float",
 				"width": 140,
 				"options": "Company:company:default_currency",
 				"convertible": "rate",


### PR DESCRIPTION
Change the fieldtype from Currency to Float for the valuation rate column in the Stock Balance and Stock Ledger report