### PR TITLE
fix: only publish repost progress to doc subscriber

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -358,6 +358,8 @@ def update_args_in_repost_item_valuation(
 			"current_index": index,
 			"total_reposting_count": len(args),
 		},
+		doctype=doc.doctype,
+		docname=doc.name,
 	)
 
 


### PR DESCRIPTION
Huge strings get blasted to everyone on site. Due to some memory
leak (cause unknown) till sockets are open the strings are also in
process' memory.

related https://github.com/frappe/frappe/issues/21863


![image](https://github.com/frappe/erpnext/assets/9079960/86dd0dba-6f87-4522-9e5f-61f87afb2dce)
