### PR TITLE
feat: Reallow customizing company abbreviation on setup.

### DIFF
--- a/erpnext/public/js/setup_wizard.js
+++ b/erpnext/public/js/setup_wizard.js
@@ -24,12 +24,14 @@ erpnext.setup.slides_settings = [
 				fieldtype: 'Data',
 				reqd: 1
 			},
+			{ fieldtype: "Column Break" },
 			{
 				fieldname: 'company_abbr',
 				label: __('Company Abbreviation'),
 				fieldtype: 'Data',
-				hidden: 1
+				reqd: 1
 			},
+			{ fieldtype: "Section Break" },
 			{
 				fieldname: 'chart_of_accounts', label: __('Chart of Accounts'),
 				options: "", fieldtype: 'Select'
@@ -134,18 +136,20 @@ erpnext.setup.slides_settings = [
 				me.charts_modal(slide, chart_template);
 			});
 
-			slide.get_input("company_name").on("change", function () {
+			slide.get_input("company_name").on("input", function () {
 				let parts = slide.get_input("company_name").val().split(" ");
 				let abbr = $.map(parts, function (p) { return p ? p.substr(0, 1) : null }).join("");
 				slide.get_field("company_abbr").set_value(abbr.slice(0, 10).toUpperCase());
 			}).val(frappe.boot.sysdefaults.company_name || "").trigger("change");
 
 			slide.get_input("company_abbr").on("change", function () {
-				if (slide.get_input("company_abbr").val().length > 10) {
+				let abbr = slide.get_input("company_abbr").val();
+				if (abbr.length > 10) {
 					frappe.msgprint(__("Company Abbreviation cannot have more than 5 characters"));
-					slide.get_field("company_abbr").set_value("");
+					abbr = abbr.slice(0, 10);
 				}
-			});
+				slide.get_field("company_abbr").set_value(abbr);
+			}).val(frappe.boot.sysdefaults.company_abbr || "").trigger("change");
 		},
 
 		charts_modal: function(slide, chart_template) {


### PR DESCRIPTION
The company abbreviation field was only removed earlier this year, in January, as part of a larger effort at simplifying the setup wizard: #33675.

While many if not most settings don‘t have to be set this early, thus the cleanup greatly improved simplicity for first time users, the company abbreviation field is a different beast.
It cannot be changed later as per #27766 and is hardcoded into the CoA and several other places during setup.

In the long term we should avoid hardcoding anything anywhere, but for now we need to reinstate this one field in the setup wizard.

Enclosed PR accomplishes this efficiently while minimizing noise, clutter. The installing user who may currently feel disempowered by an automatism that doesn’t fit their needs, is handed back control.

Example with the PR applied: obviously it‘s “NASA,” not “NAASA.”

https://github.com/frappe/erpnext/assets/46800703/7b714e59-1879-48c7-8125-bbcd4d164ac7

`no-docs`