### PR TITLE
fix: ignore cancelled gle in voucher-wise balance report

### DIFF
--- a/erpnext/accounts/report/voucher_wise_balance/voucher_wise_balance.py
+++ b/erpnext/accounts/report/voucher_wise_balance/voucher_wise_balance.py
@@ -46,6 +46,7 @@ def get_data(filters):
 		.select(
 			gle.voucher_type, gle.voucher_no, Sum(gle.debit).as_("debit"), Sum(gle.credit).as_("credit")
 		)
+		.where(gle.is_cancelled == 0)
 		.groupby(gle.voucher_no)
 	)
 	query = apply_filters(query, filters, gle)


### PR DESCRIPTION
Fetch GL entries that have `is_cancelled` = 0 in Voucher-Wise Balance Report.