### PR TITLE
fix: Defined "Open" Status as default

### DIFF
--- a/erpnext/quality_management/doctype/quality_review_objective/quality_review_objective.json
+++ b/erpnext/quality_management/doctype/quality_review_objective/quality_review_objective.json
@@ -56,6 +56,7 @@
    "fieldtype": "Column Break"
   },
   {
+   "default": "Open",
    "columns": 2,
    "fieldname": "status",
    "fieldtype": "Select",
@@ -67,7 +68,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2020-10-27 16:28:20.908637",
+ "modified": "2023-07-31 09:20:20.908637",
  "modified_by": "Administrator",
  "module": "Quality Management",
  "name": "Quality Review Objective",


### PR DESCRIPTION
Defined "Open" Status as default of the child doctype (Quality Review Objective), because without it the main doctype (Quality Review) has "Passed" status.

This happens because in the "set_status" function, the status is updated according to the status of the child records.
