### PR TITLE
fix: incorrect usage `get_cached_value` on single doctypes

### DIFF
--- a/erpnext/accounts/deferred_revenue.py
+++ b/erpnext/accounts/deferred_revenue.py
@@ -341,7 +341,7 @@ def book_deferred_income_or_expense(doc, deferred_process, posting_date=None):
 		"enable_deferred_revenue" if doc.doctype == "Sales Invoice" else "enable_deferred_expense"
 	)
 
-	accounts_frozen_upto = frappe.get_cached_value("Accounts Settings", "None", "acc_frozen_upto")
+	accounts_frozen_upto = frappe.db.get_single_value("Accounts Settings", "acc_frozen_upto")
 
 	def _book_deferred_revenue_or_expense(
 		item,

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -229,7 +229,7 @@ class PurchaseInvoice(BuyingController):
 		)
 
 		if (
-			cint(frappe.get_cached_value("Buying Settings", "None", "maintain_same_rate"))
+			cint(frappe.db.get_single_value("Buying Settings", "maintain_same_rate"))
 			and not self.is_return
 			and not self.is_internal_supplier
 		):

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -50,7 +50,7 @@ class SalesOrder(SellingController):
 		super(SalesOrder, self).__init__(*args, **kwargs)
 
 	def onload(self) -> None:
-		if frappe.get_cached_value("Stock Settings", None, "enable_stock_reservation"):
+		if frappe.db.get_single_value("Stock Settings", "enable_stock_reservation"):
 			if self.has_unreserved_stock():
 				self.set_onload("has_unreserved_stock", True)
 

--- a/erpnext/stock/doctype/price_list/price_list.py
+++ b/erpnext/stock/doctype/price_list/price_list.py
@@ -45,7 +45,7 @@ class PriceList(Document):
 
 		doc_before_save = self.get_doc_before_save()
 		currency_changed = self.currency != doc_before_save.currency
-		affects_cart = self.name == frappe.get_cached_value("E Commerce Settings", None, "price_list")
+		affects_cart = self.name == frappe.db.get_single_value("E Commerce Settings", "price_list")
 
 		if currency_changed and affects_cart:
 			validate_cart_settings()


### PR DESCRIPTION
Incorrect usage of `frappe.get_cached_value` on single doctypes causes [breakage](https://github.com/frappe/erpnext/actions/runs/5688075401/job/15417805929?pr=36367). Replacing with `frappe.db.get_single_value` which is cached by default.