### PR TITLE
Fix tax amount in customer portal

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "githubPullRequests.ignoredPullRequestBranches": [
+        "develop"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "githubPullRequests.ignoredPullRequestBranches": [
-        "develop"
-    ]
-}

--- a/erpnext/templates/includes/order/order_taxes.html
+++ b/erpnext/templates/includes/order/order_taxes.html
@@ -19,7 +19,7 @@
 					{{ d.description }}
 				</div>
 				<div class="item-grand-total col-4 text-right pr-0">
-					{{ doc.get_formatted("net_total") }}
+					{{ doc.get_formatted("d.base_tax_amount") }}
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
The customer portal tax amount is filled incorrectly from the net_total instead of base_tax_amount.

> Customer Portal - Sales Invoice
![IMG_20230801_182435_487_(1)](https://github.com/frappe/erpnext/assets/59009890/483588cb-5473-4a06-be75-f3f7d2b0952d)

> Desk - Sales Invoice
![IMG_20230801_182432_304_(1)](https://github.com/frappe/erpnext/assets/59009890/cceb283c-9276-4fd0-9d55-14133e547112)
