### PR TITLE
Fix tax amount in customer portal

### DIFF
--- a/erpnext/templates/includes/order/order_taxes.html
+++ b/erpnext/templates/includes/order/order_taxes.html
@@ -19,7 +19,7 @@
 					{{ d.description }}
 				</div>
 				<div class="item-grand-total col-4 text-right pr-0">
-					{{ doc.get_formatted("net_total") }}
+					{{ d.get_formatted("base_tax_amount") }}
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
fix(portal pages): wrong value displayed for tax amount

Change the tax amount to display base_tax_amount instead of net_total.

> Desk - Sales Invoice
![257569891-cceb283c-9276-4fd0-9d55-14133e547112](https://github.com/frappe/erpnext/assets/59009890/3a9c6c17-78cc-4916-93d0-380e59130836)

> Customer Portal - Sales Invoice
![257569723-483588cb-5473-4a06-be75-f3f7d2b0952d](https://github.com/frappe/erpnext/assets/59009890/abae8118-67c7-4d2c-8459-66a9c9abdc15)
