### PR TITLE
Fix payment entry bug: Handle None value in payment_term_outstanding

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -281,7 +281,8 @@ class PaymentEntry(AccountsController):
 				d.payment_term
 				and (
 					(flt(d.allocated_amount)) > 0
-					and (not latest.payment_term_outstanding or flt(d.allocated_amount) > flt(latest.payment_term_outstanding))
+					and latest.payment_term_outstanding
+					and (flt(d.allocated_amount) > flt(latest.payment_term_outstanding))
 				)
 				and self.term_based_allocation_enabled_for_reference(d.reference_doctype, d.reference_name)
 			):

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -281,7 +281,7 @@ class PaymentEntry(AccountsController):
 				d.payment_term
 				and (
 					(flt(d.allocated_amount)) > 0
-					and flt(d.allocated_amount) > flt(latest.payment_term_outstanding)
+					and (not latest.payment_term_outstanding or flt(d.allocated_amount) > flt(latest.payment_term_outstanding))
 				)
 				and self.term_based_allocation_enabled_for_reference(d.reference_doctype, d.reference_name)
 			):


### PR DESCRIPTION
Fix Payment Entry Bug: Handle None Value in Payment Term Outstanding

Description:

This pull request addresses the bug in the Payment Entry module, which occurs when a Payment Entry is generated from a Purchase Order with payment terms. The issue results in a validation error due to an unexpected None value for the latest.payment_term_outstanding when referencing the Purchase Order on the Payment Entry.

Bug Details:

Module: accounts
Version: Frappe v14.42.0, ERPNext v14.32.1
Root Cause:

The bug occurs because the original code does not handle the case when latest.payment_term_outstanding is None for the Purchase Order reference on the Payment Entry.

Solution:

To fix the issue, I introduced a condition to check whether latest.payment_term_outstanding is None. If it is None, the comparison is bypassed, allowing the Payment Entry to proceed without throwing an error.