### PR TITLE
perf: asset depreciation entry posting

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -946,7 +946,9 @@ class Asset(AccountsController):
 
 	@frappe.whitelist()
 	def get_manual_depreciation_entries(self):
-		(_, _, depreciation_expense_account) = get_depreciation_accounts(self)
+		(_, _, depreciation_expense_account) = get_depreciation_accounts(
+			self.asset_category, self.company
+		)
 
 		gle = frappe.qb.DocType("GL Entry")
 
@@ -1185,10 +1187,10 @@ def get_asset_account(account_name, asset=None, asset_category=None, company=Non
 def make_journal_entry(asset_name):
 	asset = frappe.get_doc("Asset", asset_name)
 	(
-		fixed_asset_account,
+		_,
 		accumulated_depreciation_account,
 		depreciation_expense_account,
-	) = get_depreciation_accounts(asset)
+	) = get_depreciation_accounts(asset.asset_category, asset.company)
 
 	depreciation_cost_center, depreciation_series = frappe.get_cached_value(
 		"Company", asset.company, ["depreciation_cost_center", "series_for_depreciation_entry"]

--- a/erpnext/assets/doctype/asset/depreciation.py
+++ b/erpnext/assets/doctype/asset/depreciation.py
@@ -48,29 +48,34 @@ def post_depreciation_entries(date=None):
 	accounting_dimensions = get_checks_for_pl_and_bs_accounts()
 
 	for asset in depreciable_assets:
-		if (asset[1], asset[2]) not in credit_and_debit_accounts_for_asset_category_and_company:
+		asset_name, asset_category, asset_company, sch_start_idx, sch_end_idx = asset
+
+		if (
+			asset_category,
+			asset_company,
+		) not in credit_and_debit_accounts_for_asset_category_and_company:
 			credit_and_debit_accounts_for_asset_category_and_company.update(
 				{
-					(asset[1], asset[2]): get_credit_and_debit_accounts_for_asset_category_and_company(
-						asset[1], asset[2]
+					(asset_category, asset_company): get_credit_and_debit_accounts_for_asset_category_and_company(
+						asset_category, asset_company
 					),
 				}
 			)
 
 		try:
 			make_depreciation_entry(
-				asset[0],
+				asset_name,
 				date,
-				asset[3],
-				asset[4],
-				credit_and_debit_accounts_for_asset_category_and_company[(asset[1], asset[2])],
-				depreciation_cost_center_and_depreciation_series_for_company[asset[2]],
+				sch_start_idx,
+				sch_end_idx,
+				credit_and_debit_accounts_for_asset_category_and_company[(asset_category, asset_company)],
+				depreciation_cost_center_and_depreciation_series_for_company[asset_company],
 				accounting_dimensions,
 			)
 			frappe.db.commit()
 		except Exception as e:
 			frappe.db.rollback()
-			failed_asset_names.append(asset[0])
+			failed_asset_names.append(asset_name)
 			error_log = frappe.log_error(e)
 			error_log_names.append(error_log.name)
 

--- a/erpnext/assets/doctype/asset/depreciation.py
+++ b/erpnext/assets/doctype/asset/depreciation.py
@@ -109,13 +109,13 @@ def get_depreciable_assets(date):
 
 
 def get_acc_frozen_upto():
-	acc_frozen_upto = frappe.db.get_value("Accounts Settings", None, "acc_frozen_upto")
+	acc_frozen_upto = frappe.db.get_single_value("Accounts Settings", "acc_frozen_upto")
 
 	if not acc_frozen_upto:
 		return
 
-	frozen_accounts_modifier = frappe.db.get_value(
-		"Accounts Settings", None, "frozen_accounts_modifier"
+	frozen_accounts_modifier = frappe.db.get_single_value(
+		"Accounts Settings", "frozen_accounts_modifier"
 	)
 
 	if frozen_accounts_modifier not in frappe.get_roles() or frappe.session.user == "Administrator":

--- a/erpnext/assets/doctype/asset_value_adjustment/asset_value_adjustment.py
+++ b/erpnext/assets/doctype/asset_value_adjustment/asset_value_adjustment.py
@@ -50,10 +50,10 @@ class AssetValueAdjustment(Document):
 	def make_depreciation_entry(self):
 		asset = frappe.get_doc("Asset", self.asset)
 		(
-			fixed_asset_account,
+			_,
 			accumulated_depreciation_account,
 			depreciation_expense_account,
-		) = get_depreciation_accounts(asset)
+		) = get_depreciation_accounts(asset.asset_category, asset.company)
 
 		depreciation_cost_center, depreciation_series = frappe.get_cached_value(
 			"Company", asset.company, ["depreciation_cost_center", "series_for_depreciation_entry"]

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -432,7 +432,6 @@ scheduler_events = {
 		"erpnext.controllers.accounts_controller.update_invoice_status",
 		"erpnext.accounts.doctype.fiscal_year.fiscal_year.auto_create_fiscal_year",
 		"erpnext.projects.doctype.task.task.set_tasks_as_overdue",
-		"erpnext.assets.doctype.asset.depreciation.post_depreciation_entries",
 		"erpnext.stock.doctype.serial_no.serial_no.update_maintenance_status",
 		"erpnext.buying.doctype.supplier_scorecard.supplier_scorecard.refresh_scorecards",
 		"erpnext.setup.doctype.company.company.cache_companies_monthly_sales_history",
@@ -459,6 +458,7 @@ scheduler_events = {
 		"erpnext.loan_management.doctype.process_loan_security_shortfall.process_loan_security_shortfall.create_process_loan_security_shortfall",
 		"erpnext.loan_management.doctype.process_loan_interest_accrual.process_loan_interest_accrual.process_loan_interest_accrual_for_term_loans",
 		"erpnext.crm.utils.open_leads_opportunities_based_on_todays_event",
+		"erpnext.assets.doctype.asset.depreciation.post_depreciation_entries",
 	],
 	"monthly_long": [
 		"erpnext.accounts.deferred_revenue.process_deferred_accounting",


### PR DESCRIPTION
A site with 100k+ assets had their depreciation posting job timing out, so made the job `daily_long`

Optimised and refactored `post_depreciation_entries` and `make_depreciation_entry`

Now schedules are independent of each other -- failure of posting of one schedule won't cause rollback for whole asset

Now if the `acc_frozen_upto` date is set, schedules before it won't be posted

On my local setup, for 1k assets with 3 pending depreciation postings:

Before: 1225s
After: 854s
Improvement: 30%