### PR TITLE
fix: validate loyalty_amount against rounded_total instead of grand_total

### DIFF
--- a/erpnext/accounts/doctype/loyalty_program/loyalty_program.py
+++ b/erpnext/accounts/doctype/loyalty_program/loyalty_program.py
@@ -145,8 +145,8 @@ def validate_loyalty_points(ref_doc, points_to_redeem):
 
 		loyalty_amount = flt(points_to_redeem * loyalty_program_details.conversion_factor)
 
-		if loyalty_amount > ref_doc.grand_total:
-			frappe.throw(_("You can't redeem Loyalty Points having more value than the Grand Total."))
+		if loyalty_amount > ref_doc.rounded_total:
+			frappe.throw(_("You can't redeem Loyalty Points having more value than the Rounded Total."))
 
 		if not ref_doc.loyalty_amount and ref_doc.loyalty_amount != loyalty_amount:
 			ref_doc.loyalty_amount = loyalty_amount


### PR DESCRIPTION
Issue: Loyalty Amount is compared with grand total.

Real life case:
If someone has loyalty points, eg: 10,000, and conversion factor is $0.1, he has Loyalty Amount of $1,000. 
When this guy decided to buy with points and the invoice amount is $100.6:
Grand Total: $100.6
Rounded Total: $101

ERPNext will accept only to redeem 1,006 point, neglecting rounding amount, and he will ask you to pay $0.4 in any mode of payment

After this fix:
It will be allowed to use 1010 point and you will no longer required to pay more

Thanks 