### PR TITLE
fix: serial no not able to reject for the internal transfer

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -1258,6 +1258,70 @@ class TestPurchaseReceipt(FrappeTestCase):
 
 		self.assertEqual(query[0].value, 0)
 
+	def test_rejected_qty_for_internal_transfer(self):
+		from erpnext.stock.doctype.delivery_note.delivery_note import make_inter_company_purchase_receipt
+		from erpnext.stock.doctype.delivery_note.test_delivery_note import create_delivery_note
+
+		prepare_data_for_internal_transfer()
+		customer = "_Test Internal Customer 2"
+		company = "_Test Company with perpetual inventory"
+
+		from_warehouse = create_warehouse("_Test Internal From Warehouse New", company=company)
+		to_warehouse = create_warehouse("_Test Internal To Warehouse New", company=company)
+		rejected_warehouse = create_warehouse(
+			"_Test Rejected Internal To Warehouse New", company=company
+		)
+		item_doc = make_item(
+			"Test Internal Transfer Item DS",
+			{
+				"is_purchase_item": 1,
+				"is_stock_item": 1,
+				"has_serial_no": 1,
+				"serial_no_series": "SBNS.#####",
+			},
+		)
+
+		target_warehouse = create_warehouse("_Test Internal GIT Warehouse New", company=company)
+
+		pr = make_purchase_receipt(
+			item_code=item_doc.name,
+			company=company,
+			posting_date=add_days(today(), -1),
+			warehouse=from_warehouse,
+			qty=2,
+			rate=100,
+		)
+
+		dn1 = create_delivery_note(
+			item_code=item_doc.name,
+			company=company,
+			customer=customer,
+			serial_no=pr.items[0].serial_no,
+			cost_center="Main - TCP1",
+			expense_account="Cost of Goods Sold - TCP1",
+			qty=2,
+			rate=500,
+			warehouse=from_warehouse,
+			target_warehouse=target_warehouse,
+		)
+
+		sns = get_serial_nos(dn1.items[0].serial_no)
+
+		self.assertEqual(len(sns), 2)
+
+		pr1 = make_inter_company_purchase_receipt(dn1.name)
+		pr1.items[0].qty = 1.0
+		pr1.items[0].rejected_qty = 1.0
+		pr1.items[0].serial_no = sns[0]
+		pr1.items[0].rejected_serial_no = sns[1]
+		pr1.items[0].warehouse = to_warehouse
+		pr1.items[0].rejected_warehouse = rejected_warehouse
+		pr1.submit()
+
+		rejected_serial_no_wh = frappe.get_cached_value("Serial No", sns[1], "warehouse")
+
+		self.assertEqual(rejected_warehouse, rejected_serial_no_wh)
+
 	def test_backdated_transaction_for_internal_transfer_in_trasit_warehouse_for_purchase_receipt(
 		self,
 	):

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -74,6 +74,7 @@ def make_sl_entries(sl_entries, allow_negative_stock=False, via_landed_cost_vouc
 				sle_doc = make_entry(sle, allow_negative_stock, via_landed_cost_voucher)
 
 			args = sle_doc.as_dict()
+			args["allow_zero_valuation_rate"] = sle.get("allow_zero_valuation_rate") or False
 
 			if sle.get("voucher_type") == "Stock Reconciliation":
 				# preserve previous_qty_after_transaction for qty reposting
@@ -109,6 +110,7 @@ def repost_current_voucher(args, allow_negative_stock=False, via_landed_cost_vou
 					"sle_id": args.get("name"),
 					"creation": args.get("creation"),
 				},
+				allow_zero_rate=args.get("allow_zero_valuation_rate") or False,
 				allow_negative_stock=allow_negative_stock,
 				via_landed_cost_voucher=via_landed_cost_voucher,
 			)


### PR DESCRIPTION
**Steps to replicate the issue**
- Create the Internal Delivery Note for the one Serialized item with the quantity 3
- Create the Internal Purchase Receipt against the above DN
- Set the accepted qty as 2 and the rejected qty as 1 with rejected serial no and try to submit it

While submitting the purchase receipt, user will face the below issue

<img width="771" alt="Screenshot 2023-08-02 at 3 56 33 PM" src="https://github.com/frappe/erpnext/assets/8780500/de0bd6bf-d671-45ea-8b48-667366d61832">
