### PR TITLE
fix(ux): add `Ordered Qty` column in Get Items From > MR

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -366,7 +366,7 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends e
 					},
 					allow_child_item_selection: true,
 					child_fieldname: "items",
-					child_columns: ["item_code", "qty"]
+					child_columns: ["item_code", "qty", "ordered_qty"]
 				})
 			}, __("Get Items From"));
 


### PR DESCRIPTION
**Issue:** PO > Get Items From > MR [✅ Select Material Request Item], the Qty should be (Qty - Ordered Qty). The dialog box is created using `frappe.ui.form.MultiSelectDialog` where the item's table [field names](https://github.com/s-aga-r/erpnext/blob/9d27a25e5f2335386402f96f83a10729695b20c8/erpnext/buying/doctype/purchase_order/purchase_order.js#L372) are passed to create a data table.

There are a couple of ways to fix this:
- using eval instead of the field name
- use a new field Pending Qty? whose value will be (Qty - Ordered Qty), doesn't a good fix though as this dialog box is used in so many places every time we need a new field for a similar case.
- allow using `(qty - ordered_qty) AS qty`

Although, there is a validation on MR items mapping so only the items which have pending qty get added in PO items. Adding the Ordered Qty column for now.

**Before:**

https://github.com/frappe/erpnext/assets/63660334/de9951d8-ad08-437f-829b-2e476039a921

**After:**

https://github.com/frappe/erpnext/assets/63660334/c06b63be-15fb-44f5-9ba7-333ebcc0d355

