### PR TITLE
fix: Lower deduction certificate for multi-company

### DIFF
--- a/erpnext/regional/doctype/lower_deduction_certificate/lower_deduction_certificate.py
+++ b/erpnext/regional/doctype/lower_deduction_certificate/lower_deduction_certificate.py
@@ -34,6 +34,7 @@ class LowerDeductionCertificate(Document):
 				"supplier": self.supplier,
 				"tax_withholding_category": self.tax_withholding_category,
 				"name": ("!=", self.name),
+				"company": self.company,
 			},
 			["name", "valid_from", "valid_upto"],
 			as_dict=True,


### PR DESCRIPTION
Company field was recently introduced in the Lower Deduction certificate to allow users to make company-specific lower deduction certificates

Looks like this validation was somehow missed which is not allowing the user to create a LDC for same tax category for different companies