### PR TITLE
fix: Tax withholding against order via Payment Entry

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -688,7 +688,9 @@ class PaymentEntry(AccountsController):
 		if not self.apply_tax_withholding_amount:
 			return
 
-		net_total = self.paid_amount
+		order_amount = self.get_order_net_total()
+
+		net_total = order_amount + self.unallocated_amount
 
 		# Adding args as purchase invoice to get TDS amount
 		args = frappe._dict(
@@ -732,6 +734,20 @@ class PaymentEntry(AccountsController):
 
 		for d in to_remove:
 			self.remove(d)
+
+	def get_order_net_total(self):
+		if self.party_type == "Supplier":
+			doctype = "Purchase Order"
+		else:
+			doctype = "Sales Order"
+
+		docnames = [d.reference_name for d in self.references if d.reference_doctype == doctype]
+
+		tax_withholding_net_total = frappe.db.get_value(
+			doctype, {"name": ["in", docnames]}, ["sum(base_tax_withholding_net_total)"]
+		)
+
+		return tax_withholding_net_total
 
 	def apply_taxes(self):
 		self.initialize_taxes()

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -690,7 +690,7 @@ class PaymentEntry(AccountsController):
 
 		order_amount = self.get_order_net_total()
 
-		net_total = order_amount + self.unallocated_amount
+		net_total = flt(order_amount) + flt(self.unallocated_amount)
 
 		# Adding args as purchase invoice to get TDS amount
 		args = frappe._dict(


### PR DESCRIPTION
Earlier while applying tax withholding via a payment entry, the amount for deduction was considered as the paid amount.

In some cases, this same entry might be done against an order and these orders might also have some other taxes added which might not be eligible for tax withholding.

For example, consider a Purchase Order with a net total of 100 and 18 rupees applied as GST and a 10% tax has to be withheld on this, in the PO the tax withheld will be correctly done on the base_net_total and the final amount would be 100-10+18 = 108.

But while making a Payment Entry against this the paid amount is 108 and the tax was withheld on 108 instead of 100.

Post the fix the eligible net total will be the net_total of the orders + the unallocated advance amount