### PR TITLE
fix: Document Name link validation in Bank Reconciliation Tool

### DIFF
--- a/erpnext/public/js/bank_reconciliation_tool/dialog_manager.js
+++ b/erpnext/public/js/bank_reconciliation_tool/dialog_manager.js
@@ -104,6 +104,9 @@ erpnext.accounts.bank_reconciliation.DialogManager = class DialogManager {
 				name: __("Document Name"),
 				editable: false,
 				width: 1,
+				format: (value, row) => {
+					return frappe.form.formatters.Link(value, {options: row[2].content});
+				},
 			},
 			{
 				name: __("Reference Date"),
@@ -132,7 +135,7 @@ erpnext.accounts.bank_reconciliation.DialogManager = class DialogManager {
 	format_row(row) {
 		return [
 			row[1], // Document Type
-			frappe.form.formatters.Link(row[2], {options: row[1]}), // Document Name
+			row[2], // Document Name
 			row[5] || row[8], // Reference Date
 			format_currency(row[3], row[9]), // Remaining
 			row[4], // Reference Number


### PR DESCRIPTION
#35540 broke Voucher Matching, leading to an invalid link exception on submission. This is because the format_row() function overwrites the row data instead of just providing a formatter on the DataTable column, and therefore passes through the formatted (linked) column data instead of the Document Name only.

This patch moves the appropriate `frappe.form.formatters.Link` function to a dedicated `format` hook on the DataTable columns definition, both fixing the error and retaining the functionality enhancements of #35540.

