### PR TITLE
fix: get incoming rate instead of BOM rate

### DIFF
--- a/erpnext/controllers/subcontracting_controller.py
+++ b/erpnext/controllers/subcontracting_controller.py
@@ -550,7 +550,7 @@ class SubcontractingController(StockController):
 			if rm_obj.serial_and_batch_bundle:
 				args["serial_and_batch_bundle"] = rm_obj.serial_and_batch_bundle
 
-			rm_obj.rate = bom_item.rate if self.backflush_based_on == "BOM" else get_incoming_rate(args)
+			rm_obj.rate = get_incoming_rate(args)
 
 	def __get_qty_based_on_material_transfer(self, item_row, transfer_item):
 		key = (item_row.item_code, item_row.get(self.subcontract_data.order_field))

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/test_subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/test_subcontracting_receipt.py
@@ -506,6 +506,67 @@ class TestSubcontractingReceipt(FrappeTestCase):
 		self.assertNotEqual(scr.supplied_items[0].rate, prev_cost)
 		self.assertEqual(scr.supplied_items[0].rate, sr.items[0].valuation_rate)
 
+	def test_subcontracting_receipt_raw_material_rate(self):
+		from erpnext.manufacturing.doctype.production_plan.test_production_plan import make_bom
+
+		# Step - 1: Set Backflush Based On as "BOM"
+		set_backflush_based_on("BOM")
+
+		# Step - 2: Create FG and RM Items
+		fg_item = make_item(properties={"is_stock_item": 1, "is_sub_contracted_item": 1}).name
+		rm_item1 = make_item(properties={"is_stock_item": 1}).name
+		rm_item2 = make_item(properties={"is_stock_item": 1}).name
+
+		# Step - 3: Create BOM for FG Item
+		bom = make_bom(item=fg_item, raw_materials=[rm_item1, rm_item2])
+		for rm_item in bom.items:
+			self.assertEqual(rm_item.rate, 0)
+			self.assertEqual(rm_item.amount, 0)
+		bom = bom.name
+
+		# Step - 4: Create PO and SCO
+		service_items = [
+			{
+				"warehouse": "_Test Warehouse - _TC",
+				"item_code": "Subcontracted Service Item 1",
+				"qty": 100,
+				"rate": 100,
+				"fg_item": fg_item,
+				"fg_item_qty": 100,
+			},
+		]
+		sco = get_subcontracting_order(service_items=service_items)
+		for rm_item in sco.supplied_items:
+			self.assertEqual(rm_item.rate, 0)
+			self.assertEqual(rm_item.amount, 0)
+
+		# Step - 5: Inward Raw Materials
+		rm_items = get_rm_items(sco.supplied_items)
+		for rm_item in rm_items:
+			rm_item["rate"] = 100
+		itemwise_details = make_stock_in_entry(rm_items=rm_items)
+
+		# Step - 6: Transfer RM's to Subcontractor
+		se = make_stock_transfer_entry(
+			sco_no=sco.name,
+			rm_items=rm_items,
+			itemwise_details=copy.deepcopy(itemwise_details),
+		)
+		for item in se.items:
+			self.assertEqual(item.qty, 100)
+			self.assertEqual(item.basic_rate, 100)
+			self.assertEqual(item.amount, item.qty * item.basic_rate)
+
+		# Step - 7: Create Subcontracting Receipt
+		scr = make_subcontracting_receipt(sco.name)
+		scr.save()
+		scr.submit()
+		scr.load_from_db()
+		for rm_item in scr.supplied_items:
+			self.assertEqual(rm_item.consumed_qty, 100)
+			self.assertEqual(rm_item.rate, 100)
+			self.assertEqual(rm_item.amount, rm_item.consumed_qty * rm_item.rate)
+
 
 def make_return_subcontracting_receipt(**args):
 	args = frappe._dict(args)


### PR DESCRIPTION
**Issue:** 0 RM rate in SCR results in incorrect FG Valuation Rate.

**Steps to replicate:**
- Set **Backflush Raw Materials of Subcontract Based** On to `BOM` in Buying Settings
- Create an FG Item.
- Create RM Item(s) with Valuation Rate as 0.
- Create BOM for FG Item, RM(s) will have a rate of 0 since there is no SLE/Valuation Rate.
- Create PO -> SCO
- Inward RM(s) and transfer against the SCO
- Now, create SCO -> SCR (save), the RM rate will be 0.

**Changes:** Set the Incoming Rate as the rate for RMs in the SCR Consumed Items table.

![image](https://github.com/frappe/erpnext/assets/63660334/8c7fdb5b-d9d1-453a-96cc-ed60fe487ec8)

**Before:**

https://github.com/frappe/erpnext/assets/63660334/d983b845-8f52-4f1b-afb7-dd92986f7ae1

**After:**

https://github.com/frappe/erpnext/assets/63660334/3237fa61-1539-408c-8bdc-043ebab93c11

