### PR TITLE
fix: use correct lang separator for frappe

### DIFF
--- a/erpnext/setup/doctype/holiday_list/holiday_list.py
+++ b/erpnext/setup/doctype/holiday_list/holiday_list.py
@@ -6,7 +6,6 @@ import json
 from datetime import date
 
 import frappe
-from babel import Locale
 from frappe import _, throw
 from frappe.model.document import Document
 from frappe.utils import formatdate, getdate, today
@@ -169,4 +168,6 @@ def is_holiday(holiday_list, date=None):
 
 def local_country_name(country_code: str) -> str:
 	"""Return the localized country name for the given country code."""
+	from babel import Locale
+
 	return Locale.parse(frappe.local.lang, sep="-").territories.get(country_code, country_code)

--- a/erpnext/setup/doctype/holiday_list/holiday_list.py
+++ b/erpnext/setup/doctype/holiday_list/holiday_list.py
@@ -169,4 +169,4 @@ def is_holiday(holiday_list, date=None):
 
 def local_country_name(country_code: str) -> str:
 	"""Return the localized country name for the given country code."""
-	return Locale.parse(frappe.local.lang).territories.get(country_code, country_code)
+	return Locale.parse(frappe.local.lang, sep="-").territories.get(country_code, country_code)

--- a/erpnext/setup/doctype/holiday_list/test_holiday_list.py
+++ b/erpnext/setup/doctype/holiday_list/test_holiday_list.py
@@ -8,6 +8,8 @@ from datetime import date, timedelta
 import frappe
 from frappe.utils import getdate
 
+from erpnext.setup.doctype.holiday_list.holiday_list import local_country_name
+
 
 class TestHolidayList(unittest.TestCase):
 	def test_holiday_list(self):
@@ -57,6 +59,16 @@ class TestHolidayList(unittest.TestCase):
 		self.assertIn(date(2023, 4, 7), holidays)
 		self.assertIn(date(2023, 4, 10), holidays)
 		self.assertNotIn(date(2023, 5, 1), holidays)
+
+	def test_localized_country_names(self):
+		lang = frappe.local.lang
+		frappe.local.lang = "en-gb"
+		self.assertEqual(local_country_name("IN"), "India")
+		self.assertEqual(local_country_name("DE"), "Germany")
+
+		frappe.local.lang = "de"
+		self.assertEqual(local_country_name("DE"), "Deutschland")
+		frappe.local.lang = lang
 
 
 def make_holiday_list(


### PR DESCRIPTION


closes https://github.com/frappe/erpnext/issues/36518
