### PR TITLE
refactor: use base_tax_withholding_net_total for treshold validation

### DIFF
--- a/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
+++ b/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
@@ -476,7 +476,12 @@ def get_tds_amount(ldc, parties, inv, tax_details, tax_deducted, vouchers):
 	threshold = tax_details.get("threshold", 0)
 	cumulative_threshold = tax_details.get("cumulative_threshold", 0)
 
-	if (threshold and inv.base_tax_withholding_net_total >= threshold) or (
+	if inv.doctype != "Payment Entry":
+		tax_withholding_net_total = inv.base_tax_withholding_net_total
+	else:
+		tax_withholding_net_total = inv.tax_withholding_net_total
+
+	if (threshold and tax_withholding_net_total >= threshold) or (
 		cumulative_threshold and supp_credit_amt >= cumulative_threshold
 	):
 		if (cumulative_threshold and supp_credit_amt >= cumulative_threshold) and cint(

--- a/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
+++ b/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
@@ -476,7 +476,7 @@ def get_tds_amount(ldc, parties, inv, tax_details, tax_deducted, vouchers):
 	threshold = tax_details.get("threshold", 0)
 	cumulative_threshold = tax_details.get("cumulative_threshold", 0)
 
-	if (threshold and inv.tax_withholding_net_total >= threshold) or (
+	if (threshold and inv.base_tax_withholding_net_total >= threshold) or (
 		cumulative_threshold and supp_credit_amt >= cumulative_threshold
 	):
 		if (cumulative_threshold and supp_credit_amt >= cumulative_threshold) and cint(


### PR DESCRIPTION
While calculating TDS on a foreign currency transaction, say Purchase Order, the `base_tax_withholding_net_total` must be used to check for threshold breach.