### PR TITLE
fix: enqueue submit/cancel action for stock entry having more than 50 line items

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -187,7 +187,7 @@ class StockEntry(StockController):
 			return False
 
 		# If line items are more than 100 or record is older than 6 months
-		if len(self.items) > 100 or month_diff(nowdate(), self.posting_date) > 6:
+		if len(self.items) > 50 or month_diff(nowdate(), self.posting_date) > 6:
 			return True
 
 		return False


### PR DESCRIPTION
https://github.com/frappe/erpnext/pull/35261

Stock Entry (Material Transfer for Manufacture) having 50+ line items get time out on cancel. Submit/Cancel action will be enqueued if there are more than 50+ line items or the posting date is over 6 months old. 