### PR TITLE
fix: stock reconciliation negative stock error

### DIFF
--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -696,7 +696,7 @@ class StockReconciliation(StockController):
 			)
 
 		if sl_entries:
-			self.make_sl_entries(sl_entries)
+			self.make_sl_entries(sl_entries, allow_negative_stock=True)
 
 	def recalculate_qty_for_serial_and_batch_bundle(self, row):
 		doc = frappe.get_doc("Serial and Batch Bundle", row.current_serial_and_batch_bundle)


### PR DESCRIPTION
While submitting the stock reco getting below error

<img width="755" alt="image" src="https://github.com/frappe/erpnext/assets/8780500/1fdbdc6a-8247-433d-9c59-439a4eb65782">
