### PR TITLE
fix: don't show disabled items in `Item Shortage Report`

### DIFF
--- a/erpnext/stock/report/item_shortage_report/item_shortage_report.py
+++ b/erpnext/stock/report/item_shortage_report/item_shortage_report.py
@@ -40,7 +40,12 @@ def get_data(filters):
 			item.item_name,
 			item.description,
 		)
-		.where((bin.projected_qty < 0) & (wh.name == bin.warehouse) & (bin.item_code == item.name))
+		.where(
+			(item.disabled == 0)
+			& (bin.projected_qty < 0)
+			& (wh.name == bin.warehouse)
+			& (bin.item_code == item.name)
+		)
 		.orderby(bin.projected_qty)
 	)
 


### PR DESCRIPTION
fix: https://github.com/frappe/erpnext/issues/36340

Before:

![image](https://github.com/frappe/erpnext/assets/63660334/24747d5d-2d8b-4b32-901b-7d93bd393021)

After:

![image](https://github.com/frappe/erpnext/assets/63660334/8d8087ee-8b8c-418f-922e-e5e97ae65813)

