### PR TITLE
fix(RFQ): hide description in print and report

### DIFF
--- a/erpnext/buying/doctype/request_for_quotation/request_for_quotation.json
+++ b/erpnext/buying/doctype/request_for_quotation/request_for_quotation.json
@@ -273,7 +273,9 @@
    "fieldname": "html_llwp",
    "fieldtype": "HTML",
    "options": "<p>In your <b>Email Template</b>, you can use the following special variables:\n</p>\n<ul>\n        <li>\n            <code>{{ update_password_link }}</code>: A link where your supplier can set a new password to log into your portal.\n        </li>\n        <li>\n            <code>{{ portal_link }}</code>: A link to this RFQ in your supplier portal.\n        </li>\n        <li>\n            <code>{{ supplier_name }}</code>: The company name of your supplier.\n        </li>\n        <li>\n            <code>{{ contact.salutation }} {{ contact.last_name }}</code>: The contact person of your supplier.\n        </li><li>\n            <code>{{ user_fullname }}</code>: Your full name.\n        </li>\n    </ul>\n<p></p>\n<p>Apart from these, you can access all values in this RFQ, like <code>{{ message_for_supplier }}</code> or <code>{{ terms }}</code>.</p>",
-   "read_only": 1
+   "print_hide": 1,
+   "read_only": 1,
+   "report_hide": 1
   },
   {
    "default": "1",
@@ -287,7 +289,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-07-27 16:41:48.468873",
+ "modified": "2023-08-08 16:30:10.870429",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Request for Quotation",


### PR DESCRIPTION
The Jinja variables from the HTML description were evaluated in print preview using standard print format and caused issues there.

This PR hides the HTML description in print and report.

Introduced with #36353.
Cherry-pick into backport #36531 after merge. ✅ 