### PR TITLE
perf(invoice): Faster return amount query

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -1651,15 +1651,13 @@ class SalesInvoice(SellingController):
 		frappe.db.set_value("Customer", self.customer, "loyalty_program_tier", lp_details.tier_name)
 
 	def get_returned_amount(self):
-		from frappe.query_builder.functions import Coalesce, Sum
+		from frappe.query_builder.functions import Sum
 
 		doc = frappe.qb.DocType(self.doctype)
 		returned_amount = (
 			frappe.qb.from_(doc)
 			.select(Sum(doc.grand_total))
-			.where(
-				(doc.docstatus == 1) & (doc.is_return == 1) & (Coalesce(doc.return_against, "") == self.name)
-			)
+			.where((doc.docstatus == 1) & (doc.is_return == 1) & (doc.return_against == self.name))
 		).run()
 
 		return abs(returned_amount[0][0]) if returned_amount[0][0] else 0


### PR DESCRIPTION
Coalesce is not required here. Read this for more info: https://github.com/frappe/frappe/pull/21822



Before

```
+------+-------------+----------------+------+---------------+------+---------+------+--------+-------------+
| id   | select_type | table          | type | possible_keys | key  | key_len | ref  | rows   | Extra       |
+------+-------------+----------------+------+---------------+------+---------+------+--------+-------------+
|    1 | SIMPLE      | tabPOS Invoice | ALL  | NULL          | NULL | NULL    | NULL | 390850 | Using where |
+------+-------------+----------------+------+---------------+------+---------+------+--------+-------------+
```


After

```
+------+-------------+----------------+------+----------------------+----------------------+---------+-------+------+------------------------------------+
| id   | select_type | table          | type | possible_keys        | key                  | key_len | ref   | rows | Extra                              |
+------+-------------+----------------+------+----------------------+----------------------+---------+-------+------+------------------------------------+
|    1 | SIMPLE      | tabPOS Invoice | ref  | return_against_index | return_against_index | 563     | const | 1    | Using index condition; Using where |
+------+-------------+----------------+------+----------------------+----------------------+---------+-------+------+------------------------------------+

```