### PR TITLE
fix: `bench update` broken after subscription refactor

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -262,7 +262,6 @@ erpnext.patches.v14_0.update_reference_due_date_in_journal_entry
 erpnext.patches.v15_0.saudi_depreciation_warning
 erpnext.patches.v15_0.delete_saudi_doctypes
 erpnext.patches.v14_0.show_loan_management_deprecation_warning
-erpnext.patches.v14_0.update_subscription_details
 execute:frappe.rename_doc("Report", "TDS Payable Monthly", "Tax Withholding Details", force=True)
 
 [post_model_sync]
@@ -322,6 +321,7 @@ erpnext.patches.v14_0.create_accounting_dimensions_for_closing_balance
 erpnext.patches.v14_0.update_closing_balances #14-07-2023
 execute:frappe.db.set_single_value("Accounts Settings", "merge_similar_account_heads", 0)
 erpnext.patches.v14_0.update_reference_type_in_journal_entry_accounts
+erpnext.patches.v14_0.update_subscription_details
 # below migration patches should always run last
 erpnext.patches.v14_0.migrate_gl_to_payment_ledger
 execute:frappe.delete_doc_if_exists("Report", "Tax Detail")


### PR DESCRIPTION
<img width="1346" alt="Screenshot 2023-08-09 at 1 55 25 PM" src="https://github.com/frappe/erpnext/assets/3272205/c9b88a89-6de7-4067-9994-92676f63a8ac">


Moving `erpnext.patches.v14_0.update_subscription_details` to **post_model_sync** as new fields are only available after the doctypes are updated in DB

regression: https://github.com/frappe/erpnext/pull/30963