### PR TITLE
fix: Center alignment in 'Hero Slider' web template

### DIFF
--- a/erpnext/e_commerce/web_template/hero_slider/hero_slider.html
+++ b/erpnext/e_commerce/web_template/hero_slider/hero_slider.html
@@ -1,7 +1,7 @@
 {%- macro slide(image, title, subtitle, action, label, index, align="Left", theme="Dark") -%}
 {%- set align_class = resolve_class({
 	'text-right': align == 'Right',
-	'text-centre': align == 'Centre',
+	'text-center': align == 'Centre',
 	'text-left': align == 'Left',
 }) -%}
 


### PR DESCRIPTION
Before
![before-fix](https://github.com/frappe/erpnext/assets/141210323/761e2eea-a1e3-429a-84b4-ab3ab7786bef)

After
![after-fix](https://github.com/frappe/erpnext/assets/141210323/caefc000-554d-457b-bc80-6e0f2a6a4258)
