### PR TITLE
refactor: 'is system generated' field and better remarks in Journal Entry

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.json
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.json
@@ -537,9 +537,9 @@
   },
   {
    "default": "0",
+   "depends_on": "eval:doc.is_system_generated == 1;",
    "fieldname": "is_system_generated",
    "fieldtype": "Check",
-   "hidden": 1,
    "label": "Is System Generated",
    "read_only": 1
   }
@@ -548,7 +548,7 @@
  "idx": 176,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-08-09 20:47:27.719809",
+ "modified": "2023-08-10 09:54:52.060639",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Journal Entry",

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.json
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.json
@@ -9,6 +9,7 @@
  "engine": "InnoDB",
  "field_order": [
   "entry_type_and_date",
+  "is_system_generated",
   "title",
   "voucher_type",
   "naming_series",
@@ -88,7 +89,7 @@
    "label": "Entry Type",
    "oldfieldname": "voucher_type",
    "oldfieldtype": "Select",
-   "options": "Journal Entry\nInter Company Journal Entry\nBank Entry\nCash Entry\nCredit Card Entry\nDebit Note\nCredit Note\nContra Entry\nExcise Entry\nWrite Off Entry\nOpening Entry\nDepreciation Entry\nExchange Rate Revaluation\nExchange Gain Or Loss\nDeferred Revenue\nDeferred Expense",
+   "options": "Journal Entry\nInter Company Journal Entry\nBank Entry\nCash Entry\nCredit Card Entry\nDebit Note\nCredit Note\nContra Entry\nExcise Entry\nWrite Off Entry\nOpening Entry\nDepreciation Entry\nExchange Rate Revaluation\nExchange Gain Or Loss\nDeferred Revenue\nDeferred Expense\nReversal Of ITC",
    "reqd": 1,
    "search_index": 1
   },
@@ -533,57 +534,27 @@
    "label": "Process Deferred Accounting",
    "options": "Process Deferred Accounting",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "is_system_generated",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Is System Generated",
+   "read_only": 1
   }
  ],
  "icon": "fa fa-file-text",
  "idx": 176,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-03-01 14:58:59.286591",
+ "modified": "2023-08-09 20:47:27.719809",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Journal Entry",
  "naming_rule": "By \"Naming Series\" field",
  "owner": "Administrator",
- "permissions": [
-  {
-   "amend": 1,
-   "cancel": 1,
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "Accounts User",
-   "share": 1,
-   "submit": 1,
-   "write": 1
-  },
-  {
-   "amend": 1,
-   "cancel": 1,
-   "create": 1,
-   "delete": 1,
-   "email": 1,
-   "export": 1,
-   "import": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "Accounts Manager",
-   "share": 1,
-   "submit": 1,
-   "write": 1
-  },
-  {
-   "email": 1,
-   "print": 1,
-   "read": 1,
-   "report": 1,
-   "role": "Auditor"
-  }
- ],
+ "permissions": [],
  "search_fields": "voucher_type,posting_date, due_date, cheque_no",
  "sort_field": "modified",
  "sort_order": "DESC",

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.json
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.json
@@ -541,6 +541,7 @@
    "fieldname": "is_system_generated",
    "fieldtype": "Check",
    "label": "Is System Generated",
+   "no_copy": 1,
    "read_only": 1
   }
  ],
@@ -548,7 +549,7 @@
  "idx": 176,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-08-10 09:54:52.060639",
+ "modified": "2023-08-10 14:32:22.366895",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Journal Entry",

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -797,6 +797,9 @@ class JournalEntry(AccountsController):
 	def create_remarks(self):
 		r = []
 
+		if self.flags.skip_remarks_creation:
+			return
+
 		if self.user_remark:
 			r.append(_("Note: {0}").format(self.user_remark))
 

--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
@@ -6,7 +6,7 @@ import frappe
 from frappe import _, msgprint, qb
 from frappe.model.document import Document
 from frappe.query_builder.custom import ConstantColumn
-from frappe.utils import flt, get_link_to_form, getdate, nowdate, today
+from frappe.utils import flt, fmt_money, get_link_to_form, getdate, nowdate, today
 
 import erpnext
 from erpnext.accounts.doctype.process_payment_reconciliation.process_payment_reconciliation import (
@@ -657,6 +657,7 @@ def reconcile_dr_cr_note(dr_cr_notes, company):
 						"reference_name": inv.against_voucher,
 						"cost_center": erpnext.get_default_cost_center(company),
 						"exchange_rate": inv.exchange_rate,
+						"user_remark": f"{fmt_money(flt(inv.allocated_amount), currency=company_currency)} against {inv.against_voucher}",
 					},
 					{
 						"account": inv.account,
@@ -671,6 +672,7 @@ def reconcile_dr_cr_note(dr_cr_notes, company):
 						"reference_name": inv.voucher_no,
 						"cost_center": erpnext.get_default_cost_center(company),
 						"exchange_rate": inv.exchange_rate,
+						"user_remark": f"{fmt_money(flt(inv.allocated_amount), currency=company_currency)} from {inv.voucher_no}",
 					},
 				],
 			}
@@ -678,6 +680,8 @@ def reconcile_dr_cr_note(dr_cr_notes, company):
 
 		jv.flags.ignore_mandatory = True
 		jv.flags.ignore_exchange_rate = True
+		jv.remark = None
+		jv.flags.skip_remarks_creation = True
 		jv.submit()
 
 		if inv.difference_amount != 0:

--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
@@ -682,6 +682,7 @@ def reconcile_dr_cr_note(dr_cr_notes, company):
 		jv.flags.ignore_exchange_rate = True
 		jv.remark = None
 		jv.flags.skip_remarks_creation = True
+		jv.is_system_generated = True
 		jv.submit()
 
 		if inv.difference_amount != 0:


### PR DESCRIPTION
New field: `is_system_generated` is added to Journal Entry. This will only be set on `Credit Note` and `Debit Note` created by the reconciliation tool.
<img width="1440" alt="Screenshot 2023-08-10 at 10 02 40 AM" src="https://github.com/frappe/erpnext/assets/3272205/2f3df1f1-da29-404c-89cd-a460db5e9cf0">



`Remarks` for above Journal Types has been updated as well.
<img width="1440" alt="Screenshot 2023-08-10 at 10 51 59 AM" src="https://github.com/frappe/erpnext/assets/3272205/93e06240-7a36-4153-9047-3f0036982e98">

<img width="1440" alt="Screenshot 2023-08-10 at 10 52 14 AM" src="https://github.com/frappe/erpnext/assets/3272205/82054a99-5e7c-4efb-a31e-011f4cd63535">
