### PR TITLE
fix: AR/AP report based on payment terms

### DIFF
--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -452,8 +452,7 @@ class ReceivablePayableReport(object):
 			"""
 			select
 				si.name, si.party_account_currency, si.currency, si.conversion_rate,
-				si.total_advance, si.conversion_rate,
-				ps.due_date, ps.payment_term, ps.payment_amount, ps.base_payment_amount,
+				si.total_advance, ps.due_date, ps.payment_term, ps.payment_amount, ps.base_payment_amount,
 				ps.description, ps.paid_amount, ps.discounted_amount
 			from `tab{0}` si, `tabPayment Schedule` ps
 			where


### PR DESCRIPTION
In a specific scenario when the Accounts Receivable/Payable report is viewed based on payment terms the outstanding amount shows up as negative

Exact steps to follow to replicate the issue
- Create an advance payment against a customer (ex: 15000)
- Make a sales invoice for 30000 and allocate the 15000 advance (outstanding will remain as 15000)
- Add payment terms, split into two terms of 50-50 percent (7500 each)
- Make a payment against the invoice of 8500 to knock off the first term and partially the second term

Check the AR report now based on payment terms, it should not show the outstanding as negative

Note to reviewer: Check for multi-currency scenarios as well