### PR TITLE
fix: unhide `uom` and `stock_uom` fields in print view

### DIFF
--- a/erpnext/controllers/print_settings.py
+++ b/erpnext/controllers/print_settings.py
@@ -14,9 +14,6 @@ def set_print_templates_for_item_table(doc, settings):
 		}
 	}
 
-	if doc.meta.get_field("items"):
-		doc.meta.get_field("items").hide_in_print_layout = ["uom", "stock_uom"]
-
 	doc.flags.compact_item_fields = ["description", "qty", "rate", "amount"]
 
 	if settings.compact_item_print:


### PR DESCRIPTION
Users have the ability to show or hide fields in Print format, no need to deliberately hide `stock_uom` and `uom`