### PR TITLE
fix: incorrect available qty for backdated stock reco with batch

### DIFF
--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -6,7 +6,7 @@ from typing import Optional
 import frappe
 from frappe import _, bold, msgprint
 from frappe.query_builder.functions import CombineDatetime, Sum
-from frappe.utils import cint, cstr, flt
+from frappe.utils import add_to_date, cint, cstr, flt
 
 import erpnext
 from erpnext.accounts.utils import get_company_default
@@ -570,44 +570,58 @@ class StockReconciliation(StockController):
 		else:
 			self._cancel()
 
-	def recalculate_current_qty(self, item_code, batch_no):
+	def recalculate_current_qty(self, voucher_detail_no, sle_creation, add_new_sle=False):
 		from erpnext.stock.stock_ledger import get_valuation_rate
 
 		sl_entries = []
 		for row in self.items:
-			if not (row.item_code == item_code and row.batch_no == batch_no):
+			if voucher_detail_no != row.name:
 				continue
 
 			current_qty = get_batch_qty_for_stock_reco(
-				item_code, row.warehouse, batch_no, self.posting_date, self.posting_time, self.name
+				row.item_code, row.warehouse, row.batch_no, self.posting_date, self.posting_time, self.name
 			)
 
 			precesion = row.precision("current_qty")
-			if flt(current_qty, precesion) == flt(row.current_qty, precesion):
-				continue
+			if flt(current_qty, precesion) != flt(row.current_qty, precesion):
+				val_rate = get_valuation_rate(
+					row.item_code,
+					row.warehouse,
+					self.doctype,
+					self.name,
+					company=self.company,
+					batch_no=row.batch_no,
+				)
 
-			val_rate = get_valuation_rate(
-				item_code, row.warehouse, self.doctype, self.name, company=self.company, batch_no=batch_no
-			)
+				row.current_valuation_rate = val_rate
+				row.current_qty = current_qty
+				row.db_set(
+					{
+						"current_qty": row.current_qty,
+						"current_valuation_rate": row.current_valuation_rate,
+						"current_amount": flt(row.current_qty * row.current_valuation_rate),
+					}
+				)
 
-			row.current_valuation_rate = val_rate
-			if not row.current_qty and current_qty:
-				sle = self.get_sle_for_items(row)
-				sle.actual_qty = current_qty * -1
-				sle.valuation_rate = val_rate
-				sl_entries.append(sle)
-
-			row.current_qty = current_qty
-			row.db_set(
-				{
-					"current_qty": row.current_qty,
-					"current_valuation_rate": row.current_valuation_rate,
-					"current_amount": flt(row.current_qty * row.current_valuation_rate),
-				}
-			)
+			if (
+				add_new_sle
+				and not frappe.db.get_value(
+					"Stock Ledger Entry",
+					{"voucher_detail_no": row.name, "actual_qty": ("<", 0), "is_cancelled": 0},
+					"name",
+				)
+				and current_qty
+			):
+				new_sle = self.get_sle_for_items(row)
+				new_sle.actual_qty = current_qty * -1
+				new_sle.valuation_rate = row.current_valuation_rate
+				new_sle.creation_time = add_to_date(sle_creation, seconds=-1)
+				sl_entries.append(new_sle)
 
 		if sl_entries:
 			self.make_sl_entries(sl_entries, allow_negative_stock=True)
+			if frappe.db.exists("Repost Item Valuation", {"voucher_no": self.name, "status": "Queued"}):
+				self.repost_future_sle_and_gle(force=True)
 
 
 def get_batch_qty_for_stock_reco(


### PR DESCRIPTION
1. Create backdated Purchase Receipt for the batched item with 100 qty. 
2. Create delivery note on the current date with 100 qty and same batch.
3. Create backdated Stock Reconciliation entry after the Purchase Receipt entry date and change the qty from 100 to 200
4. Create Two Backdated Stock Reconciliations before the above stock reco and after the Purchase Receipt date for the same item with different valuation rate.
5. You will notice that the Backdated Stock Reconciliations causing the incorrect available qty

<img width="1346" alt="Screenshot 2023-08-10 at 4 11 48 PM" src="https://github.com/frappe/erpnext/assets/8780500/7a5f205f-a08a-4e8a-9caa-b14efc935912">

