### PR TITLE
fix: allow negative stock condition for batch item

### DIFF
--- a/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
@@ -939,7 +939,7 @@ def insert_existing_sle(warehouse, item_code="_Test Item"):
 		posting_time="02:00",
 		item_code=item_code,
 		target=warehouse,
-		qty=10,
+		qty=15,
 		basic_rate=700,
 	)
 

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -635,16 +635,13 @@ class update_entries_after(object):
 
 	def reset_actual_qty_for_stock_reco(self, sle):
 		doc = frappe.get_cached_doc("Stock Reconciliation", sle.voucher_no)
-		doc.recalculate_current_qty(sle.voucher_detail_no, sle.creation, sle.actual_qty > 0)
+		doc.recalculate_current_qty(sle.voucher_detail_no, sle.creation, sle.actual_qty >= 0)
 
 		if sle.actual_qty < 0:
 			sle.actual_qty = (
 				flt(frappe.db.get_value("Stock Reconciliation Item", sle.voucher_detail_no, "current_qty"))
 				* -1
 			)
-
-			if abs(sle.actual_qty) == 0.0:
-				sle.is_cancelled = 1
 
 	def validate_negative_stock(self, sle):
 		"""


### PR DESCRIPTION
If there are no changes in the Quantity for the Batched Item in Stock Reconciliation, allow negative stock; otherwise, throw a validation error.

During stock reconciliation for the batched item, the system consumes the existing quantity and adds new quantity, even when there is no change in quantity. This logic previously allowed the system to have negative stock for the batched item. However, negative stock should not be allowed if the quantity has changed in the stock reconciliation.