### PR TITLE
fix: Infinite Loop on Loan Repayment

### DIFF
--- a/erpnext/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/erpnext/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -570,6 +570,7 @@ def regenerate_repayment_schedule(loan, cancel=0):
 		get_monthly_repayment_amount,
 	)
 
+	precision = cint(frappe.db.get_default("currency_precision")) or 2
 	loan_doc = frappe.get_doc("Loan", loan)
 	next_accrual_date = None
 	accrued_entries = 0
@@ -607,7 +608,7 @@ def regenerate_repayment_schedule(loan, cancel=0):
 
 	payment_date = next_accrual_date
 
-	while balance_amount > 0:
+	while flt(balance_amount, precision) > 0:
 		interest_amount = flt(balance_amount * flt(loan_doc.rate_of_interest) / (12 * 100))
 		principal_amount = monthly_repayment_amount - interest_amount
 		balance_amount = flt(balance_amount + interest_amount - monthly_repayment_amount)


### PR DESCRIPTION
On some case of Loan, user make repayment in order to close the Loan (multiple installments at once), I experience infinite loop as balance_amount never reach zero.

![image](https://github.com/frappe/erpnext/assets/1973598/f79e42bf-d833-447f-880c-dd3c5e4ad771)

I trace the balance, i.e,
09:08:14 web.1            | ----------------- 2.838184960784259e+91
09:08:14 web.1            | ----------------- 2.8736622727940624e+91
09:08:14 web.1            | ----------------- 2.909583051203988e+91
09:08:14 web.1            | ----------------- 2.945952839344038e+91
09:08:14 web.1            | ----------------- 2.9827772498358387e+91
09:08:14 web.1            | ----------------- 3.0200619654587865e+91
09:08:14 web.1            | ----------------- 3.0578127400270215e+91
09:08:14 web.1            | ----------------- 3.0960353992773592e+91

Note: I found a lot of case in ERPNext where precision is not used and result in digit errors. Should there be good practice of using precision overall?

Note 2: I can't find module loan in branch develop, so I push it here for now. Thanks.
