### PR TITLE
fix: POS Invoice Email Receipt Mail

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_past_order_summary.js
+++ b/erpnext/selling/page/point_of_sale/pos_past_order_summary.js
@@ -49,7 +49,7 @@ erpnext.PointOfSale.PastOrderSummary = class {
 			title: 'Email Receipt',
 			fields: [
 				{fieldname: 'email_id', fieldtype: 'Data', options: 'Email', label: 'Email ID'},
-				// {fieldname:'remarks', fieldtype:'Text', label:'Remarks (if any)'}
+				{fieldname:'content', fieldtype:'Small Text', label:'Message (if any)'}
 			],
 			primary_action: () => {
 				this.send_email();
@@ -243,6 +243,7 @@ erpnext.PointOfSale.PastOrderSummary = class {
 	send_email() {
 		const frm = this.events.get_frm();
 		const recipients = this.email_dialog.get_values().email_id;
+		const content = this.email_dialog.get_values().content;
 		const doc = this.doc || frm.doc;
 		const print_format = frm.pos_print_format;
 
@@ -251,6 +252,7 @@ erpnext.PointOfSale.PastOrderSummary = class {
 			args: {
 				recipients: recipients,
 				subject: __(frm.meta.name) + ': ' + doc.name,
+				content: content ? content : __(frm.meta.name) + ': ' + doc.name,
 				doctype: doc.doctype,
 				name: doc.name,
 				send_email: 1,

--- a/erpnext/selling/page/point_of_sale/pos_past_order_summary.js
+++ b/erpnext/selling/page/point_of_sale/pos_past_order_summary.js
@@ -48,7 +48,7 @@ erpnext.PointOfSale.PastOrderSummary = class {
 		const email_dialog = new frappe.ui.Dialog({
 			title: 'Email Receipt',
 			fields: [
-				{fieldname: 'email_id', fieldtype: 'Data', options: 'Email', label: 'Email ID'},
+				{fieldname: 'email_id', fieldtype: 'Data', options: 'Email', label: 'Email ID', reqd: 1},
 				{fieldname:'content', fieldtype:'Small Text', label:'Message (if any)'}
 			],
 			primary_action: () => {


### PR DESCRIPTION
Version:

ERPNext: v14.33.2 (version-14)
Frappe Framework: v14.43.1 (version-14)

fixes : https://discuss.frappe.io/t/unsupported-operand-type-s-for-nonetype-and-str/108358
___

**Before:**

When click on Email Receipt in POS Invoice then faced an issue because the content shows none and faced an error in mixins.py

and if added str in content then worked but shows None
```py
	def get_content(self, print_format=None):
		print("------------", self.content)
		# Output: None
		if print_format:
			return self.content + self.get_attach_link(print_format)
			# return str(self.content) + self.get_attach_link(print_format)
			# If applied above line then its works
		return self.content
```

https://github.com/frappe/erpnext/assets/141945075/c2875452-af70-4af0-8b03-2fd6dac13bd8

<br>

**After:**

- I added an alternative solution like customise the dialog in pos_past_order_summary.js and added functionality like if the message is available then set it in the content. If the message is not available then set the meta name and doc name.


https://github.com/frappe/erpnext/assets/141945075/cae172ec-ef6b-4b54-a74a-c77cf0cb88f8

<br>

Thank You!