### PR TITLE
fix: wrap none type rate under flt

### DIFF
--- a/erpnext/controllers/status_updater.py
+++ b/erpnext/controllers/status_updater.py
@@ -233,7 +233,7 @@ class StatusUpdater(Document):
 				if hasattr(d, "qty") and d.qty > 0 and self.get("is_return"):
 					frappe.throw(_("For an item {0}, quantity must be negative number").format(d.item_code))
 
-				if hasattr(d, "item_code") and hasattr(d, "rate") and d.rate < 0:
+				if hasattr(d, "item_code") and hasattr(d, "rate") and flt(d.rate) < 0:
 					frappe.throw(_("For an item {0}, rate must be a positive number").format(d.item_code))
 
 				if d.doctype == args["source_dt"] and d.get(args["join_field"]):


### PR DESCRIPTION
Wrapping `d.rate` under `flt` to avoid `TypeError: '<' not supported between instances of 'NoneType' and 'int'` error when `d.rate` is None.