### PR TITLE
fix: fetch `Stock UOM` from Item if not set

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.json
+++ b/erpnext/manufacturing/doctype/work_order/work_order.json
@@ -404,6 +404,8 @@
    "read_only": 1
   },
   {
+   "fetch_from": "production_item.stock_uom",
+   "fetch_if_empty": 1,
    "fieldname": "stock_uom",
    "fieldtype": "Link",
    "label": "Stock UOM",
@@ -590,7 +592,7 @@
  "image_field": "image",
  "is_submittable": 1,
  "links": [],
- "modified": "2023-06-09 13:20:09.154362",
+ "modified": "2023-08-11 18:35:49.852069",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Work Order",
@@ -610,7 +612,6 @@
    "read": 1,
    "report": 1,
    "role": "Manufacturing User",
-   "set_user_permissions": 1,
    "share": 1,
    "submit": 1,
    "write": 1


### PR DESCRIPTION
**Issue:** Stock UOM didn't get set when we create WO from SO.

**Steps to Replicate:**
- Create SO.
- Create SO -> WO.
- Check WO Stock UOM.

**Changes:** Fetch `Stock UOM` from `Item to Manufacture` in Work Order. 

