### PR TITLE
fix: Button Alignment center in hero slider

### DIFF
--- a/erpnext/e_commerce/web_template/hero_slider/hero_slider.html
+++ b/erpnext/e_commerce/web_template/hero_slider/hero_slider.html
@@ -1,7 +1,7 @@
 {%- macro slide(image, title, subtitle, action, label, index, align="Left", theme="Dark") -%}
 {%- set align_class = resolve_class({
 	'text-right': align == 'Right',
-	'text-centre': align == 'Centre',
+	'text-center': align == 'Centre',
 	'text-left': align == 'Left',
 }) -%}
 


### PR DESCRIPTION
#36561 
Button alignment center 

before

![before-fix](https://github.com/frappe/erpnext/assets/141210323/0b197d30-0403-48c7-a28f-475a4d7858d8)


after

![after-fix](https://github.com/frappe/erpnext/assets/141210323/a124250d-91d5-411b-8f2f-b0c4a1691b20)
