### PR TITLE
fix: standard formula to calculate the "difference"

### DIFF
--- a/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.js
+++ b/erpnext/accounts/doctype/pos_closing_entry/pos_closing_entry.js
@@ -153,7 +153,7 @@ frappe.ui.form.on('POS Closing Entry', {
 frappe.ui.form.on('POS Closing Entry Detail', {
 	closing_amount: (frm, cdt, cdn) => {
 		const row = locals[cdt][cdn];
-		frappe.model.set_value(cdt, cdn, "difference", flt(row.expected_amount - row.closing_amount));
+		frappe.model.set_value(cdt, cdn, "difference", flt(row.closing_amount - row.expected_amount));
 	}
 })
 


### PR DESCRIPTION
When we changed the closing_amount field, the formula was used:

**difference = expected_amount - closing_amount**

when executing the refresh_payments method, it executed the formula:

**difference = closing_amount - expected_amount**

User was lost with this logic...


Standardized to:
**difference = closing_amount - expected_amount**