### PR TITLE
fix: Allow backdated repayment cancels for term loans

### DIFF
--- a/erpnext/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/erpnext/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -246,6 +246,9 @@ class LoanRepayment(AccountsController):
 		)
 
 	def check_future_accruals(self):
+		if self.is_term_loan:
+			return
+
 		future_accrual_date = frappe.db.get_value(
 			"Loan Interest Accrual",
 			{"posting_date": (">", self.posting_date), "docstatus": 1, "loan": self.against_loan},


### PR DESCRIPTION
Users are unable to cancel a backdated payment entry for term loans.
Since for term loans, the interest calculation is already fixed it doesn't depend on previous payments and this validation can be safely ignored