### PR TITLE
fix(demo): drop parent item group

### DIFF
--- a/erpnext/setup/demo_data/item_group.json
+++ b/erpnext/setup/demo_data/item_group.json
@@ -1,7 +1,6 @@
 [
     {
         "doctype": "Item Group",
-        "item_group_name": "Demo Item Group",
-        "parent_item_group": "All Item Groups"
+        "item_group_name": "Demo Item Group"
     }
 ]


### PR DESCRIPTION
This is translated according to user language, so "All Item Groups" might not
exist on site.

The code already finds root item group without doing anything.

towards https://github.com/frappe/erpnext/issues/36635
