### PR TITLE
perf: improve responsiveness of payment reconciliation tool

### DIFF
--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.js
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.js
@@ -163,6 +163,15 @@ erpnext.accounts.PaymentReconciliationController = class PaymentReconciliationCo
 		this.frm.refresh();
 	}
 
+	invoice_name() {
+		this.frm.trigger("get_unreconciled_entries");
+	}
+
+	payment_name() {
+		this.frm.trigger("get_unreconciled_entries");
+	}
+
+
 	clear_child_tables() {
 		this.frm.clear_table("invoices");
 		this.frm.clear_table("payments");

--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.json
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.json
@@ -27,8 +27,10 @@
   "bank_cash_account",
   "cost_center",
   "sec_break1",
+  "invoice_name",
   "invoices",
   "column_break_15",
+  "payment_name",
   "payments",
   "sec_break2",
   "allocation"
@@ -137,6 +139,7 @@
    "label": "Minimum Invoice Amount"
   },
   {
+   "default": "50",
    "description": "System will fetch all the entries if limit value is zero.",
    "fieldname": "invoice_limit",
    "fieldtype": "Int",
@@ -167,6 +170,7 @@
    "label": "Maximum Payment Amount"
   },
   {
+   "default": "50",
    "description": "System will fetch all the entries if limit value is zero.",
    "fieldname": "payment_limit",
    "fieldtype": "Int",
@@ -194,13 +198,23 @@
    "label": "Default Advance Account",
    "mandatory_depends_on": "doc.party_type",
    "options": "Account"
+  },
+  {
+   "fieldname": "invoice_name",
+   "fieldtype": "Data",
+   "label": "Filter on Invoice"
+  },
+  {
+   "fieldname": "payment_name",
+   "fieldtype": "Data",
+   "label": "Filter on Payment"
   }
  ],
  "hide_toolbar": 1,
  "icon": "icon-resize-horizontal",
  "issingle": 1,
  "links": [],
- "modified": "2023-06-09 13:02:48.718362",
+ "modified": "2023-08-15 05:35:50.109290",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Reconciliation",

--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
@@ -93,6 +93,9 @@ class PaymentReconciliation(Document):
 	def get_jv_entries(self):
 		condition = self.get_conditions()
 
+		if self.payment_name:
+			condition += f" and t1.name like '%%{self.payment_name}%%'"
+
 		if self.get("cost_center"):
 			condition += f" and t2.cost_center = '{self.cost_center}' "
 

--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
@@ -75,6 +75,9 @@ class PaymentReconciliation(Document):
 			}
 		)
 
+		if self.payment_name:
+			condition.update({"name": self.payment_name})
+
 		payment_entries = get_advance_payment_entries(
 			self.party_type,
 			self.party,

--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
@@ -226,6 +226,8 @@ class PaymentReconciliation(Document):
 			min_outstanding=self.minimum_invoice_amount if self.minimum_invoice_amount else None,
 			max_outstanding=self.maximum_invoice_amount if self.maximum_invoice_amount else None,
 			accounting_dimensions=self.accounting_dimension_filter_conditions,
+			limit=self.invoice_limit,
+			voucher_no=self.invoice_name,
 		)
 
 		cr_dr_notes = (

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -908,7 +908,9 @@ def get_outstanding_invoices(
 	min_outstanding=None,
 	max_outstanding=None,
 	accounting_dimensions=None,
-	vouchers=None,
+	vouchers=None, # list of dicts [{'voucher_type': '', 'voucher_no': ''}] for filtering
+	limit=None, # passed by reconciliation tool
+	voucher_no=None, # filter passed by reconciliation tool
 ):
 
 	ple = qb.DocType("Payment Ledger Entry")
@@ -941,6 +943,8 @@ def get_outstanding_invoices(
 		max_outstanding=max_outstanding,
 		get_invoices=True,
 		accounting_dimensions=accounting_dimensions or [],
+		limit=limit,
+		voucher_no=voucher_no,
 	)
 
 	for d in invoice_list:
@@ -1678,12 +1682,13 @@ class QueryPaymentLedger(object):
 		self.voucher_posting_date = []
 		self.min_outstanding = None
 		self.max_outstanding = None
+		self.limit = self.voucher_no = None
 
 	def reset(self):
 		# clear filters
 		self.vouchers.clear()
 		self.common_filter.clear()
-		self.min_outstanding = self.max_outstanding = None
+		self.min_outstanding = self.max_outstanding = self.limit = None
 
 		# clear result
 		self.voucher_outstandings.clear()
@@ -1697,6 +1702,7 @@ class QueryPaymentLedger(object):
 
 		filter_on_voucher_no = []
 		filter_on_against_voucher_no = []
+
 		if self.vouchers:
 			voucher_types = set([x.voucher_type for x in self.vouchers])
 			voucher_nos = set([x.voucher_no for x in self.vouchers])
@@ -1706,6 +1712,10 @@ class QueryPaymentLedger(object):
 
 			filter_on_against_voucher_no.append(ple.against_voucher_type.isin(voucher_types))
 			filter_on_against_voucher_no.append(ple.against_voucher_no.isin(voucher_nos))
+
+		if self.voucher_no:
+			filter_on_voucher_no.append(ple.voucher_no.like(f"%{self.voucher_no}%"))
+			filter_on_against_voucher_no.append(ple.against_voucher_no.like(f"%{self.voucher_no}%"))
 
 		# build outstanding amount filter
 		filter_on_outstanding_amount = []
@@ -1822,6 +1832,11 @@ class QueryPaymentLedger(object):
 				)
 			)
 
+		if self.limit:
+			self.cte_query_voucher_amount_and_outstanding = (
+				self.cte_query_voucher_amount_and_outstanding.limit(self.limit)
+			)
+
 		# execute SQL
 		self.voucher_outstandings = self.cte_query_voucher_amount_and_outstanding.run(as_dict=True)
 
@@ -1835,6 +1850,8 @@ class QueryPaymentLedger(object):
 		get_payments=False,
 		get_invoices=False,
 		accounting_dimensions=None,
+		limit=None,
+		voucher_no=None,
 	):
 		"""
 		Fetch voucher amount and outstanding amount from Payment Ledger using Database CTE
@@ -1856,6 +1873,8 @@ class QueryPaymentLedger(object):
 		self.max_outstanding = max_outstanding
 		self.get_payments = get_payments
 		self.get_invoices = get_invoices
+		self.limit = limit
+		self.voucher_no = voucher_no
 		self.query_for_outstanding()
 
 		return self.voucher_outstandings

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2396,6 +2396,9 @@ def get_common_query(
 		q = q.select((payment_entry.target_exchange_rate).as_("exchange_rate"))
 
 	if condition:
+		if condition.get("name", None):
+			q = q.where(payment_entry.name.like(f"%{condition.get('name')}%"))
+
 		q = q.where(payment_entry.company == condition["company"])
 		q = (
 			q.where(payment_entry.posting_date >= condition["from_payment_date"])


### PR DESCRIPTION
# Issue
There are cases where customers have outstanding invoices in 10s of thousands and the reconciliation tool timesout on normal operations like fetching and allocating. This happens because, the `Invoice Limit` and `Payment Limit` are applied after pulling in all outstanding invoices and payments. This is inefficient. 

# Goal
To fix this permanently, a default limit of 50(which is still editable by customer) is applied and a search field is supplied for outstanding invoices and payments. 

Search uses Indexed columns - `voucher_no` and `against_voucher_no` in Payment Ledger. This along with limit variable, makes the DB query fast. Fetch(`Get Unreconciled Entries`) becomes a constant time operation(`O(n)` -> `O(50)`) for default settings.

# Changes
Limits are set to 50 as a default and are passed directly to the DB query. 2 new fields - `Filter on Invoice` and `Filter on Payment`, are added which pass its value to DB query. This way Vouchers are filtered at the query level.

<img width="1440" alt="Screenshot 2023-08-15 at 6 18 36 AM" src="https://github.com/frappe/erpnext/assets/3272205/a9f3b608-f959-40ea-af37-bca14466e463">

## before
```
In [13]: %time pr.get_unreconciled_entries()
CPU times: user 792 ms, sys: 29 ms, total: 821 ms
Wall time: 19.2 s

In [14]: len(pr.invoices)
Out[14]: 10000

In [15]: len(pr.payments)
Out[15]: 803
```

## after
```
In [8]: %time pr.get_unreconciled_entries()
CPU times: user 107 ms, sys: 5.64 ms, total: 113 ms
Wall time: 643 ms

In [9]: len(pr.payments)
Out[9]: 50

In [10]: len(pr.invoices)
Out[10]: 50
```


https://github.com/frappe/erpnext/assets/3272205/27c418df-79b5-424c-85ef-3949087a4ba8

