### PR TITLE
fix(demo): More exception handling on demo data generation

### DIFF
--- a/erpnext/setup/demo.py
+++ b/erpnext/setup/demo.py
@@ -114,7 +114,7 @@ def create_transaction(doctype, company, start_date):
 	if document_type == "Purchase Order":
 		posting_date = get_random_date(start_date, 1, 30)
 	else:
-		posting_date = get_random_date(start_date, 31, 365)
+		posting_date = get_random_date(start_date, 31, 364)
 
 	doctype.update(
 		{

--- a/erpnext/setup/demo_data/purchase_order.json
+++ b/erpnext/setup/demo_data/purchase_order.json
@@ -4,6 +4,7 @@
         "supplier": "Zuckerman Security Ltd.",
         "doctype": "Purchase Order",
         "update_stock": 1,
+        "disable_rounded_total": 1,
         "items": [
             {
                 "doctype": "Purchase Order Item",
@@ -20,6 +21,7 @@
         "supplier": "MA Inc.",
         "doctype": "Purchase Order",
         "update_stock": 1,
+        "disable_rounded_total": 1,
         "items": [
             {
                 "doctype": "Purchase Order Item",
@@ -36,6 +38,7 @@
         "supplier": "Summit Traders Ltd.",
         "doctype": "Purchase Order",
         "update_stock": 1,
+        "disable_rounded_total": 1,
         "items": [
             {
                 "doctype": "Purchase Order Item",
@@ -52,6 +55,7 @@
         "supplier": "Zuckerman Security Ltd.",
         "doctype": "Purchase Order",
         "update_stock": 1,
+        "disable_rounded_total": 1,
         "items": [
             {
                 "doctype": "Purchase Order Item",
@@ -68,6 +72,7 @@
         "supplier": "MA Inc.",
         "doctype": "Purchase Order",
         "update_stock": 1,
+        "disable_rounded_total": 1,
         "items": [
             {
                 "doctype": "Purchase Order Item",
@@ -84,6 +89,7 @@
         "supplier": "Summit Traders Ltd.",
         "doctype": "Purchase Order",
         "update_stock": 1,
+        "disable_rounded_total": 1,
         "items": [
             {
                 "doctype": "Purchase Order Item",
@@ -100,6 +106,7 @@
         "supplier": "Zuckerman Security Ltd.",
         "doctype": "Purchase Order",
         "update_stock": 1,
+        "disable_rounded_total": 1,
         "items": [
             {
                 "doctype": "Purchase Order Item",
@@ -116,6 +123,7 @@
         "supplier": "MA Inc.",
         "doctype": "Purchase Order",
         "update_stock": 1,
+        "disable_rounded_total": 1,
         "items": [
             {
                 "doctype": "Purchase Order Item",
@@ -132,6 +140,7 @@
         "supplier": "Summit Traders Ltd.",
         "doctype": "Purchase Order",
         "update_stock": 1,
+        "disable_rounded_total": 1,
         "items": [
             {
                 "doctype": "Purchase Order Item",
@@ -148,6 +157,7 @@
         "supplier": "Zuckerman Security Ltd.",
         "doctype": "Purchase Order",
         "update_stock": 1,
+        "disable_rounded_total": 1,
         "items": [
             {
                 "doctype": "Purchase Order Item",

--- a/erpnext/setup/demo_data/sales_order.json
+++ b/erpnext/setup/demo_data/sales_order.json
@@ -4,6 +4,7 @@
         "customer": "Grant Plastics Ltd.",
         "doctype": "Sales Order",
         "update_stock": 1,
+        "disable_rounded_total": 1,
         "items": [
             {
                 "doctype": "Sales Order Item",
@@ -20,6 +21,7 @@
         "customer": "West View Software Ltd.",
         "doctype": "Sales Order",
         "update_stock": 1,
+        "disable_rounded_total": 1,
         "items": [
             {
                 "doctype": "Sales Order Item",
@@ -44,6 +46,7 @@
         "customer": "West View Software Ltd.",
         "doctype": "Sales Order",
         "update_stock": 1,
+        "disable_rounded_total": 1,
         "items": [
             {
                 "doctype": "Sales Order Item",
@@ -76,6 +79,7 @@
         "customer": "Palmer Productions Ltd.",
         "doctype": "Sales Order",
         "update_stock": 1,
+        "disable_rounded_total": 1,
         "items": [
             {
                 "doctype": "Sales Order Item",
@@ -92,6 +96,7 @@
         "customer": "Grant Plastics Ltd.",
         "doctype": "Sales Order",
         "update_stock": 1,
+        "disable_rounded_total": 1,
         "items": [
             {
                 "doctype": "Sales Order Item",


### PR DESCRIPTION
```bash
File "apps/erpnext/erpnext/accounts/doctype/sales_invoice/sales_invoice.py", line 256, in on_submit self.update_stock_ledger() File "apps/erpnext/erpnext/controllers/selling_controller.py", line 495, in update_stock_ledger sl_entries.append(self.get_sle_for_source_warehouse(d)) 
File "apps/erpnext/erpnext/controllers/selling_controller.py", line 509, in get_sle_for_source_warehouse sle = self.get_sl_entries(
File "apps/erpnext/erpnext/controllers/stock_controller.py", line 442, in get_sl_entries "fiscal_year": get_fiscal_year(self.posting_date, company=self.company)[0], File "apps/frappe/frappe/utils/typing_validations.py", line 30, in wrapper return func(*args, **kwargs) 
File "apps/erpnext/erpnext/accounts/utils.py", line 56, in get_fiscal_year fiscal_years = get_fiscal_years(  
File "apps/erpnext/erpnext/accounts/utils.py", line 142, in get_fiscal_years raise FiscalYearError(error_msg) erpnext.accounts.utils.FiscalYearError: Date 01-01-2024 is not in any active Fiscal Year for <strong>alhammadi (Demo)</strong>
```

1. If the random deviation of days is 365 then the date generated spans out of the current fiscal year
2. Round Off account not available in company master

