### PR TITLE
fix: Plaid Integration status and categories

### DIFF
--- a/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.py
+++ b/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.py
@@ -237,14 +237,15 @@ def new_bank_transaction(transaction):
 		deposit = abs(amount)
 		withdrawal = 0.0
 
-	status = "Pending" if transaction["pending"] == "True" else "Settled"
+	status = "Pending" if transaction["pending"] == True else "Settled"
 
 	tags = []
-	try:
-		tags += transaction["category"]
-		tags += [f'Plaid Cat. {transaction["category_id"]}']
-	except KeyError:
-		pass
+	if transaction["category"]:
+		try:
+			tags += transaction["category"]
+			tags += [f'Plaid Cat. {transaction["category_id"]}']
+		except KeyError:
+			pass
 
 	if not frappe.db.exists("Bank Transaction", dict(transaction_id=transaction["transaction_id"])):
 		try:


### PR DESCRIPTION
This patch fixes two small issues with Plaid Integration.

First, the value of "pending" in a given transaction is a boolean, not a string, and should be evaluated as such.

Second, in some cases Plaid doesn't return any categories (and specifically, `None`), which would trigger the following error and abort the sync session:

```
Traceback (most recent call last):
  File "apps/erpnext/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.py", line 182, in sync_transactions
    result += new_bank_transaction(transaction)
  File "apps/erpnext/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.py", line 244, in new_bank_transaction
    tags += transaction["category"]
TypeError: 'NoneType' object is not iterable
```

This is fixed by checking for the existence of categories before attempting to iterate over them.