### PR TITLE
fix: mode of payment fetched from pos profile company in POS

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.js
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.js
@@ -131,6 +131,7 @@ erpnext.selling.POSInvoiceController = class POSInvoiceController extends erpnex
 			args: { "pos_profile": frm.pos_profile },
 			callback: ({ message: profile }) => {
 				this.update_customer_groups_settings(profile?.customer_groups);
+				this.frm.set_value("company", profile?.company);
 			},
 		});
 	}

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -49,6 +49,7 @@ class POSInvoice(SalesInvoice):
 		self.validate_pos()
 		self.validate_payment_amount()
 		self.validate_loyalty_transaction()
+		self.validate_company_with_pos_company()
 		if self.coupon_code:
 			from erpnext.accounts.doctype.pricing_rule.utils import validate_coupon_code
 
@@ -281,6 +282,14 @@ class POSInvoice(SalesInvoice):
 			if total_amount_in_payments and total_amount_in_payments < invoice_total:
 				frappe.throw(_("Total payments amount can't be greater than {}").format(-invoice_total))
 
+	def validate_company_with_pos_company(self):
+		if self.company != frappe.db.get_value("POS Profile", self.pos_profile, "company"):
+			frappe.throw(
+				_("Company {} does not match with POS Profile Company {}").format(
+					self.company, frappe.db.get_value("POS Profile", self.pos_profile, "company")
+				)
+			)
+
 	def validate_loyalty_transaction(self):
 		if self.redeem_loyalty_points and (
 			not self.loyalty_redemption_account or not self.loyalty_redemption_cost_center
@@ -359,6 +368,7 @@ class POSInvoice(SalesInvoice):
 		profile = {}
 		if self.pos_profile:
 			profile = frappe.get_doc("POS Profile", self.pos_profile)
+			self.company = profile.get("company")
 
 		if not self.get("payments") and not for_validate:
 			update_multi_mode_option(self, profile)


### PR DESCRIPTION
**Issue:**
In a multi company setup where each company has one or more pos profiles, when setting mode of payments for the pos profile, these are fetched for the default company instead of the company for each pos profile.

**Reason:**
before the pos profile company was set, we were throwing the error.


