### PR TITLE
fix: include gain/loss journal in AR/AP reports

### DIFF
--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -1090,7 +1090,10 @@ class ReceivablePayableReport(object):
 			.where(
 				(je.company == self.filters.company)
 				& (je.posting_date.lte(self.filters.report_date))
-				& (je.voucher_type == "Exchange Rate Revaluation")
+				& (
+					(je.voucher_type == "Exchange Rate Revaluation")
+					| (je.voucher_type == "Exchange Gain Or Loss")
+				)
 			)
 			.run()
 		)


### PR DESCRIPTION
Exchange Gain/Loss journal created through Exchange Rate Revaluation is not fetched on Accounts Receivable Report. This leads to outstanding amount being reported even though total debit matches total credit in ledger.