### PR TITLE
fix: incorrect gl balance on AR summary rpt on multi company setup

### DIFF
--- a/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py
+++ b/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py
@@ -55,7 +55,7 @@ class AccountsReceivableSummary(ReceivablePayableReport):
 		)
 
 		if self.filters.show_gl_balance:
-			gl_balance_map = get_gl_balance(self.filters.report_date)
+			gl_balance_map = get_gl_balance(self.filters.report_date, self.filters.company)
 
 		for party, party_dict in self.party_total.items():
 			if party_dict.outstanding == 0:
@@ -232,12 +232,12 @@ class AccountsReceivableSummary(ReceivablePayableReport):
 		self.add_column(label="Total Amount Due", fieldname="total_due")
 
 
-def get_gl_balance(report_date):
+def get_gl_balance(report_date, company):
 	return frappe._dict(
 		frappe.db.get_all(
 			"GL Entry",
 			fields=["party", "sum(debit -  credit)"],
-			filters={"posting_date": ("<=", report_date), "is_cancelled": 0},
+			filters={"posting_date": ("<=", report_date), "is_cancelled": 0, "company": company},
 			group_by="party",
 			as_list=1,
 		)


### PR DESCRIPTION
On a multi company setup, incorrect GL Balance was shown on Accounts Receivable Summary report.