### PR TITLE
fix: create portal user for customer from shopping cart

### DIFF
--- a/erpnext/e_commerce/shopping_cart/cart.py
+++ b/erpnext/e_commerce/shopping_cart/cart.py
@@ -517,6 +517,8 @@ def get_party(user=None):
 			}
 		)
 
+		customer.append("portal_users", {"user": user})
+
 		if debtors_account:
 			customer.update({"accounts": [{"company": cart_settings.company, "account": debtors_account}]})
 


### PR DESCRIPTION
fix #36744

From shopping cart, customer is created when order/quotation is placed. But customer don't connect with user.
This PR adds user to portal_user child on customer form.


