### PR TITLE
fix: not able to make stock entry

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -660,7 +660,10 @@ def make_stock_entry(source_name, target_doc=None):
 					"job_card_item": "job_card_item",
 				},
 				"postprocess": update_item,
-				"condition": lambda doc: doc.ordered_qty < doc.stock_qty,
+				"condition": lambda doc: (
+					flt(doc.ordered_qty, doc.precision("ordered_qty"))
+					< flt(doc.stock_qty, doc.precision("ordered_qty"))
+				),
 			},
 		},
 		target_doc,


### PR DESCRIPTION
-  Set float precision as 5 in system settings
- Create MR of purpose material transfer with multiple items, where item quanity is in 7-digit floating points in the upload file, and create MR.

For eg,

Item code Quantity

RM0001 - 5.7654321

RM0002 - 8.7654321

RM0003 - 9.8765432

- Create a stock entry and do the partial material transfer for 1 item, then MR will be partially ordered.

RM0001 - 5.76543

- Create 1 more stock entry against the MR, then the below error populates

“Row 1: Qty in Stock UOM can not be zero”