### PR TITLE
fix: Asset Category Filter Is Not Working In 'Asset Depreciations and Balances

### DIFF
--- a/erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py
+++ b/erpnext/accounts/report/asset_depreciations_and_balances/asset_depreciations_and_balances.py
@@ -58,6 +58,9 @@ def get_data(filters):
 
 
 def get_asset_categories(filters):
+	condition = ""
+	if filters.get("asset_category"):
+		condition += " and asset_category = %(asset_category)s"
 	return frappe.db.sql(
 		"""
 		SELECT asset_category,
@@ -98,15 +101,25 @@ def get_asset_categories(filters):
 								0
 						   end), 0) as cost_of_scrapped_asset
 		from `tabAsset`
-		where docstatus=1 and company=%(company)s and purchase_date <= %(to_date)s
+		where docstatus=1 and company=%(company)s and purchase_date <= %(to_date)s {}
 		group by asset_category
-	""",
-		{"to_date": filters.to_date, "from_date": filters.from_date, "company": filters.company},
+	""".format(
+			condition
+		),
+		{
+			"to_date": filters.to_date,
+			"from_date": filters.from_date,
+			"company": filters.company,
+			"asset_category": filters.get("asset_category"),
+		},
 		as_dict=1,
 	)
 
 
 def get_assets(filters):
+	condition = ""
+	if filters.get("asset_category"):
+		condition = " and a.asset_category = '{}'".format(filters.get("asset_category"))
 	return frappe.db.sql(
 		"""
 		SELECT results.asset_category,
@@ -138,7 +151,7 @@ def get_assets(filters):
 				aca.parent = a.asset_category and aca.company_name = %(company)s
 			join `tabCompany` company on
 				company.name = %(company)s
-			where a.docstatus=1 and a.company=%(company)s and a.purchase_date <= %(to_date)s and gle.debit != 0 and gle.is_cancelled = 0 and gle.account = ifnull(aca.depreciation_expense_account, company.depreciation_expense_account)
+			where a.docstatus=1 and a.company=%(company)s and a.purchase_date <= %(to_date)s and gle.debit != 0 and gle.is_cancelled = 0 and gle.account = ifnull(aca.depreciation_expense_account, company.depreciation_expense_account) {0}
 			group by a.asset_category
 			union
 			SELECT a.asset_category,
@@ -154,10 +167,12 @@ def get_assets(filters):
 							  end), 0) as depreciation_eliminated_during_the_period,
 				   0 as depreciation_amount_during_the_period
 			from `tabAsset` a
-			where a.docstatus=1 and a.company=%(company)s and a.purchase_date <= %(to_date)s
+			where a.docstatus=1 and a.company=%(company)s and a.purchase_date <= %(to_date)s {0}
 			group by a.asset_category) as results
 		group by results.asset_category
-		""",
+		""".format(
+			condition
+		),
 		{"to_date": filters.to_date, "from_date": filters.from_date, "company": filters.company},
 		as_dict=1,
 	)


### PR DESCRIPTION
fix: Asset Category Filter Is Not Working In 'Asset Depreciations and Balances


![asse](https://github.com/frappe/erpnext/assets/141210323/1810e662-052f-4721-88b5-c37edf5d8f58)
