### PR TITLE
chore: styling improvements for asset depr sch table

### DIFF
--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -228,18 +228,21 @@ frappe.ui.form.on('Asset', {
 				{name: __("Schedule Date"), editable: false, resizable: false, width: 270},
 				{name: __("Depreciation Amount"), editable: false, resizable: false, width: 164},
 				{name: __("Accumulated Depreciation Amount"), editable: false, resizable: false, width: 164},
-				{name: __("Journal Entry"), editable: false, resizable: false, format: value => `<a href="/app/journal-entry/${value}">${value}</a>`, width: 312}
+				{name: __("Journal Entry"), editable: false, resizable: false, format: value => `<a href="/app/journal-entry/${value}">${value}</a>`, width: 304}
 			],
 			data: data,
+			layout: "fluid",
 			serialNoColumn: false,
 			checkboxColumn: true,
 			cellHeight: 35
 		});
 
-		datatable.style.setStyle(`.dt-scrollable`, {'font-size': '0.75rem', 'margin-bottom': '1rem'});
+		datatable.style.setStyle(`.dt-scrollable`, {'font-size': '0.75rem', 'margin-bottom': '1rem', 'margin-left': '0.35rem', 'margin-right': '0.35rem'});
+		datatable.style.setStyle(`.dt-header`, {'margin-left': '0.35rem', 'margin-right': '0.35rem'});
 		datatable.style.setStyle(`.dt-cell--col-1`, {'text-align': 'center'});
 		datatable.style.setStyle(`.dt-cell--col-2`, {'font-weight': 600});
 		datatable.style.setStyle(`.dt-cell--col-3`, {'font-weight': 600});
+		datatable.style.setStyle(`.dt-cell--header`, {'color': 'var(--text-muted)'});
 	},
 
 	setup_chart_and_depr_schedule_view: async function(frm) {

--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -239,10 +239,11 @@ frappe.ui.form.on('Asset', {
 
 		datatable.style.setStyle(`.dt-scrollable`, {'font-size': '0.75rem', 'margin-bottom': '1rem', 'margin-left': '0.35rem', 'margin-right': '0.35rem'});
 		datatable.style.setStyle(`.dt-header`, {'margin-left': '0.35rem', 'margin-right': '0.35rem'});
+		datatable.style.setStyle(`.dt-cell--header`, {'color': 'var(--text-muted)'});
+		datatable.style.setStyle(`.dt-cell`, {'color': 'var(--text-color)'});
 		datatable.style.setStyle(`.dt-cell--col-1`, {'text-align': 'center'});
 		datatable.style.setStyle(`.dt-cell--col-2`, {'font-weight': 600});
 		datatable.style.setStyle(`.dt-cell--col-3`, {'font-weight': 600});
-		datatable.style.setStyle(`.dt-cell--header`, {'color': 'var(--text-muted)'});
 	},
 
 	setup_chart_and_depr_schedule_view: async function(frm) {


### PR DESCRIPTION
Minor styling changes to make the asset depr schedule datatable look as similar as possible to the >v14 child table.