### PR TITLE
fix(regional): item wise tax calc issue

### DIFF
--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -908,9 +908,9 @@ def get_outstanding_invoices(
 	min_outstanding=None,
 	max_outstanding=None,
 	accounting_dimensions=None,
-	vouchers=None, # list of dicts [{'voucher_type': '', 'voucher_no': ''}] for filtering
-	limit=None, # passed by reconciliation tool
-	voucher_no=None, # filter passed by reconciliation tool
+	vouchers=None,  # list of dicts [{'voucher_type': '', 'voucher_no': ''}] for filtering
+	limit=None,  # passed by reconciliation tool
+	voucher_no=None,  # filter passed by reconciliation tool
 ):
 
 	ple = qb.DocType("Payment Ledger Entry")


### PR DESCRIPTION
Earlier: Tax calculation was don based on item tax template, but, item tax template can have both input and output accounts and hence wrong tax rate.

After this PR: Tax calculation based on actual value in tax table