### PR TITLE
fix: Tax withholding reversal on Debit Notes

### DIFF
--- a/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
+++ b/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
@@ -271,9 +271,9 @@ def get_tax_amount(party_type, parties, inv, tax_details, posting_date, pan_no=N
 						net_total, limit_consumed, ldc.certificate_limit, ldc.rate, tax_details
 					)
 				else:
-					tax_amount = net_total * tax_details.rate / 100 if net_total > 0 else 0
+					tax_amount = net_total * tax_details.rate / 100
 			else:
-				tax_amount = net_total * tax_details.rate / 100 if net_total > 0 else 0
+				tax_amount = net_total * tax_details.rate / 100
 
 			# once tds is deducted, not need to add vouchers in the invoice
 			voucher_wise_amount = {}

--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -345,6 +345,8 @@ def make_return_doc(
 		elif doctype == "Purchase Invoice":
 			# look for Print Heading "Debit Note"
 			doc.select_print_heading = frappe.get_cached_value("Print Heading", _("Debit Note"))
+			if source.tax_withholding_category:
+				doc.set_onload("supplier_tds", source.tax_withholding_category)
 
 		for tax in doc.get("taxes") or []:
 			if tax.charge_type == "Actual":


### PR DESCRIPTION
There is no tax withholding reversal on the creation of returns against Purchase Invoices. Ideally whatever amount is reversed using a Debit Note the corresponding Tax Withheld should also be reversed.