### PR TITLE
feat: provision to disable closing stock balance in stock settings

### DIFF
--- a/erpnext/stock/doctype/stock_settings/stock_settings.json
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.json
@@ -59,7 +59,9 @@
   "stock_frozen_upto_days",
   "column_break_26",
   "role_allowed_to_create_edit_back_dated_transactions",
-  "stock_auth_role"
+  "stock_auth_role",
+  "section_break_plhx",
+  "disable_closing_stock_balance"
  ],
  "fields": [
   {
@@ -363,7 +365,8 @@
   },
   {
    "fieldname": "section_break_plhx",
-   "fieldtype": "Section Break"
+   "fieldtype": "Section Break",
+   "label": "Stock Balance Closing"
   },
   {
    "fieldname": "column_break_mhzc",
@@ -383,6 +386,13 @@
    "fieldname": "auto_create_serial_and_batch_bundle_for_outward",
    "fieldtype": "Check",
    "label": "Auto Create Serial and Batch Bundle For Outward"
+  },
+  {
+   "default": "0",
+   "description": "To know more about Closing Stock Balance, please check <a href=\"https://docs.erpnext.com/docs/user/manual/en/closing-stock-balance\">documentation.</a>",
+   "fieldname": "disable_closing_stock_balance",
+   "fieldtype": "Check",
+   "label": "Disable Closing Stock Balance"
   }
  ],
  "icon": "icon-cog",
@@ -390,7 +400,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-05-29 15:10:54.959411",
+ "modified": "2023-08-24 12:16:51.243508",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Settings",

--- a/erpnext/stock/report/stock_balance/stock_balance.js
+++ b/erpnext/stock/report/stock_balance/stock_balance.js
@@ -87,12 +87,6 @@ frappe.query_reports["Stock Balance"] = {
 			"label": __('Show Stock Ageing Data'),
 			"fieldtype": 'Check'
 		},
-		{
-			"fieldname": 'ignore_closing_balance',
-			"label": __('Ignore Closing Balance'),
-			"fieldtype": 'Check',
-			"default": 1
-		},
 	],
 
 	"formatter": function (value, row, column, data, default_formatter) {


### PR DESCRIPTION
Removed Ignore Closing Balance checkbox from Stock Balance report and added a provision to disable "[Closing Stock Balance](https://docs.erpnext.com/docs/user/manual/en/closing-stock-balance)" feature in Stock Settings

<img width="1332" alt="Screenshot 2023-08-24 at 12 17 28 PM" src="https://github.com/frappe/erpnext/assets/8780500/59e77a82-367d-4671-aaa2-1fbc9c592e73">


#no-docs