### PR TITLE
fix: fetch JVs without party value in tax withholding report

### DIFF
--- a/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
+++ b/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
@@ -257,7 +257,7 @@ def get_tds_docs(filters):
 	}
 
 	party = frappe.get_all(filters.get("party_type"), pluck="name")
-	query_filters.update({"against": ("in", party)})
+	or_filters.update({"against": ("in", party), "voucher_type": "Journal Entry"})
 
 	if filters.get("party"):
 		del query_filters["account"]
@@ -294,7 +294,7 @@ def get_tds_docs(filters):
 
 	if journal_entries:
 		journal_entry_party_map = get_journal_entry_party_map(journal_entries)
-		get_doc_info(journal_entries, "Journal Entry", tax_category_map)
+		get_doc_info(journal_entries, "Journal Entry", tax_category_map, net_total_map)
 
 	return (
 		tds_documents,
@@ -309,7 +309,11 @@ def get_journal_entry_party_map(journal_entries):
 	journal_entry_party_map = {}
 	for d in frappe.db.get_all(
 		"Journal Entry Account",
-		{"parent": ("in", journal_entries), "party_type": "Supplier", "party": ("is", "set")},
+		{
+			"parent": ("in", journal_entries),
+			"party_type": ("in", ("Supplier", "Customer")),
+			"party": ("is", "set"),
+		},
 		["parent", "party"],
 	):
 		if d.parent not in journal_entry_party_map:
@@ -320,41 +324,29 @@ def get_journal_entry_party_map(journal_entries):
 
 
 def get_doc_info(vouchers, doctype, tax_category_map, net_total_map=None):
-	if doctype == "Purchase Invoice":
-		fields = [
-			"name",
-			"tax_withholding_category",
-			"base_tax_withholding_net_total",
-			"grand_total",
-			"base_total",
-		]
-	elif doctype == "Sales Invoice":
-		fields = ["name", "base_net_total", "grand_total", "base_total"]
-	elif doctype == "Payment Entry":
-		fields = [
-			"name",
-			"tax_withholding_category",
-			"paid_amount",
-			"paid_amount_after_tax",
-			"base_paid_amount",
-		]
-	else:
-		fields = ["name", "tax_withholding_category"]
+	common_fields = ["name", "tax_withholding_category"]
+	fields_dict = {
+		"Purchase Invoice": ["base_tax_withholding_net_total", "grand_total", "base_total"],
+		"Sales Invoice": ["base_net_total", "grand_total", "base_total"],
+		"Payment Entry": ["paid_amount", "paid_amount_after_tax", "base_paid_amount"],
+		"Journal Entry": ["total_amount"],
+	}
 
-	entries = frappe.get_all(doctype, filters={"name": ("in", vouchers)}, fields=fields)
+	entries = frappe.get_all(
+		doctype, filters={"name": ("in", vouchers)}, fields=common_fields + fields_dict[doctype]
+	)
 
 	for entry in entries:
 		tax_category_map.update({entry.name: entry.tax_withholding_category})
 		if doctype == "Purchase Invoice":
-			net_total_map.update(
-				{entry.name: [entry.base_tax_withholding_net_total, entry.grand_total, entry.base_total]}
-			)
+			value = [entry.base_tax_withholding_net_total, entry.grand_total, entry.base_total]
 		elif doctype == "Sales Invoice":
-			net_total_map.update({entry.name: [entry.base_net_total, entry.grand_total, entry.base_total]})
+			value = [entry.base_net_total, entry.grand_total, entry.base_total]
 		elif doctype == "Payment Entry":
-			net_total_map.update(
-				{entry.name: [entry.paid_amount, entry.paid_amount_after_tax, entry.base_paid_amount]}
-			)
+			value = [entry.paid_amount, entry.paid_amount_after_tax, entry.base_paid_amount]
+		else:
+			value = [entry.total_amount] * 3
+		net_total_map.update({entry.name: value})
 
 
 def get_tax_rate_map(filters):

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -908,9 +908,9 @@ def get_outstanding_invoices(
 	min_outstanding=None,
 	max_outstanding=None,
 	accounting_dimensions=None,
-	vouchers=None, # list of dicts [{'voucher_type': '', 'voucher_no': ''}] for filtering
-	limit=None, # passed by reconciliation tool
-	voucher_no=None, # filter passed by reconciliation tool
+	vouchers=None,  # list of dicts [{'voucher_type': '', 'voucher_no': ''}] for filtering
+	limit=None,  # passed by reconciliation tool
+	voucher_no=None,  # filter passed by reconciliation tool
 ):
 
 	ple = qb.DocType("Payment Ledger Entry")


### PR DESCRIPTION
**Problem**
The `party_type` field is mandatory in the Tax Withholding Details report. The GL entries are fetched using this `party_type` value as one of the filters. But, since the JV doctype does not have the `party_type` and `party` fields as mandatory, any JVs with these fields not mentioned do not show up in the Tax Withholding Details report.

**Solution**
Made an exception to fetch JVs without any `party_type` mentioned.

**Note :**
Values not shown for JVs without any party mentioned still include -

- Party Details
- Tax Category and Rate - Since no actual TDS has been applied, the JV doctype does not have the Tax Withholding Category value. The JV entry only highlights the transaction made for the TDS account. These are fetched from the `journal_entry_party_map`.