### PR TITLE
fix(demo): Default accounts for demo company

### DIFF
--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/ae_uae_chart_template_standard.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/ae_uae_chart_template_standard.json
@@ -437,12 +437,20 @@
             },
             "Sales": {
                 "Sales from Other Regions": {
-                    "Sales from Other Region": {}
+                    "Sales from Other Region": {
+                        "account_type": "Income Account"
+                    }
                 },
                 "Sales of same region": {
-                    "Management Consultancy Fees 1": {},
-                    "Sales Account": {},
-                    "Sales of I/C": {}
+                    "Management Consultancy Fees 1": {
+                        "account_type": "Income Account"
+                    },
+                    "Sales Account": {
+                        "account_type": "Income Account"
+                    },
+                    "Sales of I/C": {
+                        "account_type": "Income Account"
+                    }
                 }
             },
             "root_type": "Income"

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/id_chart_of_accounts.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/id_chart_of_accounts.json
@@ -669,7 +669,8 @@
             }, 
             "Penjualan Barang Dagangan": {
                 "Penjualan": {
-                    "account_number": "4110.000"
+                    "account_number": "4110.000",
+                    "account_type": "Income Account"
                 }, 
                 "Potongan Penjualan": {
                     "account_number": "4130.000"

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/id_chart_of_accounts.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/id_chart_of_accounts.json
@@ -69,8 +69,7 @@
                 "Persediaan Barang": {
                     "Persediaan Barang": {
                         "account_number": "1141.000", 
-                        "account_type": "Stock", 
-                        "is_group": 1
+                        "account_type": "Stock"
                     }, 
                     "Uang Muka Pembelian": {
                         "Uang Muka Pembelian": {

--- a/erpnext/accounts/general_ledger.py
+++ b/erpnext/accounts/general_ledger.py
@@ -539,6 +539,10 @@ def get_round_off_account_and_cost_center(
 		"Company", company, ["round_off_account", "round_off_cost_center"]
 	) or [None, None]
 
+	# Use expense account as fallback
+	if not round_off_account:
+		round_off_account = frappe.get_cached_value("Company", company, "default_expense_account")
+
 	meta = frappe.get_meta(voucher_type)
 
 	# Give first preference to parent cost center for round off GLE

--- a/erpnext/public/js/setup_wizard.js
+++ b/erpnext/public/js/setup_wizard.js
@@ -45,7 +45,8 @@ erpnext.setup.slides_settings = [
 				fieldname: 'setup_demo',
 				label: __('Generate Demo Data for Exploration'),
 				fieldtype: 'Check',
-				description: 'If checked, we will create demo data for you to explore the system. This demo data can be erased later.'},
+				description: __('If checked, we will create demo data for you to explore the system. This demo data can be erased later.')
+			},
 		],
 
 		onload: function (slide) {

--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -403,14 +403,18 @@ class Company(NestedSet):
 				self._set_default_account(default_account, default_accounts.get(default_account))
 
 		if not self.default_income_account:
-			income_account = frappe.db.get_value(
-				"Account", {"account_name": _("Sales"), "company": self.name, "is_group": 0}
+			income_account = frappe.db.get_all(
+				"Account",
+				filters={"company": self.name, "is_group": 0},
+				or_filters={
+					"account_name": ("in", [_("Sales"), _("Sales Account")]),
+					"account_type": "Income Account",
+				},
+				pluck="name",
 			)
 
-			if not income_account:
-				income_account = frappe.db.get_value(
-					"Account", {"account_name": _("Sales Account"), "company": self.name}
-				)
+			if income_account:
+				income_account = income_account[0]
 
 			self.db_set("default_income_account", income_account)
 

--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -415,6 +415,8 @@ class Company(NestedSet):
 
 			if income_account:
 				income_account = income_account[0]
+			else:
+				income_account = None
 
 			self.db_set("default_income_account", income_account)
 


### PR DESCRIPTION
Country-specific demo data issues
- Demo data generation fails if no non group income and expense accounts are present in COA
     - Fixed for Indonesia and UAE
     - Added fallbacks
- Fallback for roundoff account


closes https://github.com/frappe/erpnext/issues/36635