### PR TITLE
fix: show customer name for naming series in process soa

### DIFF
--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.json
@@ -51,6 +51,7 @@
   "column_break_21",
   "start_date",
   "section_break_33",
+  "pdf_name",
   "subject",
   "column_break_28",
   "cc_to",
@@ -275,7 +276,7 @@
    "fieldname": "help_text",
    "fieldtype": "HTML",
    "label": "Help Text",
-   "options": "<br>\n<h4>Note</h4>\n<ul>\n<li>\nYou can use <a href=\"https://jinja.palletsprojects.com/en/2.11.x/\" target=\"_blank\">Jinja tags</a> in <b>Subject</b> and <b>Body</b> fields for dynamic values.\n</li><li>\n    All fields in this doctype are available under the <b>doc</b> object and all fields for the customer to whom the mail will go to is available under the  <b>customer</b> object.\n</li></ul>\n<h4> Examples</h4>\n<!-- {% raw %} -->\n<ul>\n    <li><b>Subject</b>:<br><br><pre><code>Statement Of Accounts for {{ customer.name }}</code></pre><br></li>\n    <li><b>Body</b>: <br><br>\n<pre><code>Hello {{ customer.name }},<br>PFA your Statement Of Accounts from {{ doc.from_date }} to {{ doc.to_date }}.</code> </pre></li>\n</ul>\n<!-- {% endraw %} -->"
+   "options": "<br>\n<h4>Note</h4>\n<ul>\n<li>\nYou can use <a href=\"https://jinja.palletsprojects.com/en/2.11.x/\" target=\"_blank\">Jinja tags</a> in <b>Subject</b> and <b>Body</b> fields for dynamic values.\n</li><li>\n    All fields in this doctype are available under the <b>doc</b> object and all fields for the customer to whom the mail will go to is available under the  <b>customer</b> object.\n</li></ul>\n<h4> Examples</h4>\n<!-- {% raw %} -->\n<ul>\n    <li><b>Subject</b>:<br><br><pre><code>Statement Of Accounts for {{ customer.customer_name }}</code></pre><br></li>\n    <li><b>Body</b>: <br><br>\n<pre><code>Hello {{ customer.customer_name }},<br>PFA your Statement Of Accounts from {{ doc.from_date }} to {{ doc.to_date }}.</code> </pre></li>\n</ul>\n<!-- {% endraw %} -->"
   },
   {
    "fieldname": "subject",
@@ -370,10 +371,15 @@
    "fieldname": "based_on_payment_terms",
    "fieldtype": "Check",
    "label": "Based On Payment Terms"
+  },
+  {
+   "fieldname": "pdf_name",
+   "fieldtype": "Data",
+   "label": "PDF Name"
   }
  ],
  "links": [],
- "modified": "2023-06-23 10:13:15.051950",
+ "modified": "2023-08-28 12:59:53.071334",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Process Statement Of Accounts",

--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
@@ -65,19 +65,17 @@ def get_report_pdf(doc, consolidated=True):
 		filters = get_common_filters(doc)
 
 		if doc.report == "General Ledger":
-			filters.update(get_gl_filters(doc, entry, tax_id, presentation_currency))
-		else:
-			filters.update(get_ar_filters(doc, entry))
-
-		if doc.report == "General Ledger":
 			col, res = get_soa(filters)
 			for x in [0, -2, -1]:
 				res[x]["account"] = res[x]["account"].replace("'", "")
 			if len(res) == 3:
 				continue
 		else:
+			filters.update(get_ar_filters(doc, entry))
 			ar_res = get_ar_soa(filters)
 			col, res = ar_res[0], ar_res[1]
+			if not res:
+				continue
 
 		statement_dict[entry.customer] = get_html(doc, filters, entry, col, res, ageing)
 

--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
@@ -412,10 +412,11 @@ def send_emails(document_name, from_scheduler=False, posting_date=None):
 			doc.add_comment(
 				"Comment", "Emails sent on: " + frappe.utils.format_datetime(frappe.utils.now())
 			)
-			doc.db_set("to_date", new_to_date, commit=True)
-			doc.db_set("from_date", new_from_date, commit=True)
-			doc.db_set("posting_date", new_to_date, commit=True)
-			doc.db_set("report", doc.report, commit=True)
+			if doc.report == "General Ledger":
+				doc.db_set("to_date", new_to_date, commit=True)
+				doc.db_set("from_date", new_from_date, commit=True)
+			else:
+				doc.db_set("posting_date", new_to_date, commit=True)
 		return True
 	else:
 		return False

--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
@@ -27,7 +27,13 @@ class ProcessStatementOfAccounts(Document):
 		if not self.subject:
 			self.subject = "Statement Of Accounts for {{ customer.customer_name }}"
 		if not self.body:
-			self.body = "Hello {{ customer.name }},<br>PFA your Statement Of Accounts from {{ doc.from_date }} to {{ doc.to_date }}."
+			if self.report == "General Ledger":
+				body_str = " from {{ doc.from_date }} to {{ doc.to_date }}."
+			else:
+				body_str = " until {{ doc.posting_date }}."
+			self.body = "Hello {{ customer.customer_name }},<br>PFA your Statement Of Accounts" + body_str
+		if not self.pdf_name:
+			self.pdf_name = "{{ customer.customer_name }}"
 
 		validate_template(self.subject)
 		validate_template(self.body)
@@ -141,6 +147,7 @@ def get_ar_filters(doc, entry):
 	return {
 		"report_date": doc.posting_date if doc.posting_date else None,
 		"customer": entry.customer,
+		"customer_name": entry.customer_name if entry.customer_name else None,
 		"payment_terms_template": doc.payment_terms_template if doc.payment_terms_template else None,
 		"sales_partner": doc.sales_partner if doc.sales_partner else None,
 		"sales_person": doc.sales_person if doc.sales_person else None,
@@ -372,12 +379,14 @@ def send_emails(document_name, from_scheduler=False):
 
 	if report:
 		for customer, report_pdf in report.items():
-			attachments = [{"fname": customer + ".pdf", "fcontent": report_pdf}]
+			context = get_context(customer, doc)
+			filename = frappe.render_template(doc.pdf_name, context)
+			attachments = [{"fname": filename + ".pdf", "fcontent": report_pdf}]
 
 			recipients, cc = get_recipients_and_cc(customer, doc)
 			if not recipients:
 				continue
-			context = get_context(customer, doc)
+
 			subject = frappe.render_template(doc.subject, context)
 			message = frappe.render_template(doc.body, context)
 

--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts_accounts_receivable.html
@@ -8,9 +8,24 @@
 	}
 	</style>
 
+	<div id="header-html" class="hidden-pdf">
+		{% if letter_head.content %}
+		<div class="letter-head text-center">{{ letter_head.content }}</div>
+		<hr style="height:2px;border-width:0;color:black;background-color:black;">
+		{% endif %}
+	</div>
+	<div id="footer-html" class="visible-pdf">
+		{% if letter_head.footer %}
+		<div class="letter-head-footer">
+			<hr style="border-width:0;color:black;background-color:black;padding-bottom:2px;">
+			{{ letter_head.footer }}
+		</div>
+		{% endif %}
+	</div>
+
 	<h2 class="text-center" style="margin-top:0">{{ _(report.report_name) }}</h2>
 	<h4 class="text-center">
-		{{ filters.customer }}
+		{{ filters.customer_name }}
 	</h4>
 	<h6 class="text-center">
 		{% if (filters.tax_id) %}
@@ -340,5 +355,10 @@
 			</tr>
 		</tbody>
 	</table>
+	{% endif %}
+	{% if terms_and_conditions %}
+	<div>
+		{{ terms_and_conditions }}
+	</div>
 	{% endif %}
 	<p class="text-right text-muted">{{ _("Printed On ") }}{{ frappe.utils.now() }}</p>

--- a/erpnext/accounts/doctype/process_statement_of_accounts/test_process_statement_of_accounts.py
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/test_process_statement_of_accounts.py
@@ -1,9 +1,42 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
-# import frappe
 import unittest
+
+import frappe
+from frappe.utils import add_days, getdate, today
+
+from erpnext.accounts.doctype.process_statement_of_accounts.process_statement_of_accounts import (
+	send_emails,
+)
+from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_sales_invoice
 
 
 class TestProcessStatementOfAccounts(unittest.TestCase):
-	pass
+	def setUp(self):
+		self.si = create_sales_invoice()
+		self.process_soa = create_process_soa()
+
+	def test_auto_email_for_process_soa_ar(self):
+		send_emails(self.process_soa.name, from_scheduler=True)
+		self.process_soa.load_from_db()
+		self.assertEqual(self.process_soa.posting_date, getdate(add_days(today(), 7)))
+
+	def tearDown(self):
+		frappe.delete_doc_if_exists("Process Statement Of Accounts", "Test Process SOA")
+
+
+def create_process_soa():
+	frappe.delete_doc_if_exists("Process Statement Of Accounts", "Test Process SOA")
+	process_soa = frappe.new_doc("Process Statement Of Accounts")
+	soa_dict = {
+		"name": "Test Process SOA",
+		"company": "_Test Company",
+	}
+	process_soa.update(soa_dict)
+	process_soa.set("customers", [{"customer": "_Test Customer"}])
+	process_soa.enable_auto_email = 1
+	process_soa.frequency = "Weekly"
+	process_soa.report = "Accounts Receivable"
+	process_soa.save()
+	return process_soa


### PR DESCRIPTION
**Problem**

- In Process Statement of Accounts - GL and AR the default subject and body of the email used the `name` field for specifying the customer. However, in cases where the `name` of the Customer document is different from the `customer_name` field (eg: when naming series is used for Customer doctype), the subject and body of the email show the document name instead of the customer name.
- For the AR report, the html template fetches the `name` field instead of the `customer_name`.
- AR report PDF does not show the Letterhead and Terms.

**Solution**

- Used `customer_name` field instead of `name` wherever necessary.
- Added HTML code for rendering Letterhead and Terms in AR Report.

**Notes for Reviewer**

As mentioned in the issue, there was a need to use the Subject as the PDF name before sending the report PDF in the email. Have added an extra field for specifying the **PDF name** format in **Email Settings** to keep things general. Please mention if a different approach can be used here.
<br>
<img width="1078" alt="Screenshot 2023-08-28 at 1 32 18 PM" src="https://github.com/frappe/erpnext/assets/40693548/dc7f73f1-8476-4d65-938c-c7e77669b154">
<br>

`no-docs`
