### PR TITLE
fix: allocation error on partial payment against sales order

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -1993,10 +1993,15 @@ def get_reference_details(reference_doctype, reference_name, party_account_curre
 		if not total_amount:
 			if party_account_currency == company_currency:
 				# for handling cases that don't have multi-currency (base field)
-				total_amount = ref_doc.get("base_grand_total") or ref_doc.get("grand_total")
+				total_amount = (
+					ref_doc.get("base_rounded_total")
+					or ref_doc.get("rounded_total")
+					or ref_doc.get("base_grand_total")
+					or ref_doc.get("grand_total")
+				)
 				exchange_rate = 1
 			else:
-				total_amount = ref_doc.get("grand_total")
+				total_amount = ref_doc.get("rounded_total") or ref_doc.get("grand_total")
 		if not exchange_rate:
 			# Get the exchange rate from the original ref doc
 			# or get it based on the posting date of the ref doc.

--- a/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
@@ -1248,6 +1248,7 @@ class TestPaymentEntry(FrappeTestCase):
 		so = make_sales_order(do_not_save=True)
 		so.items[0].rate = 99.55
 		so.save().submit()
+		self.assertGreater(so.rounded_total, 0.0)
 		pe = get_payment_entry("Sales Order", so.name, bank_account="_Test Cash - _TC")
 		pe.paid_from = "Debtors - _TC"
 		pe.paid_amount = 45.55
@@ -1255,6 +1256,7 @@ class TestPaymentEntry(FrappeTestCase):
 		pe.save().submit()
 		pe = get_payment_entry("Sales Order", so.name, bank_account="_Test Cash - _TC")
 		pe.paid_from = "Debtors - _TC"
+		# No validation error should be thrown here.
 		pe.save().submit()
 
 		so.reload()

--- a/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
@@ -1244,6 +1244,22 @@ class TestPaymentEntry(FrappeTestCase):
 		template.allocate_payment_based_on_payment_terms = 1
 		template.save()
 
+	def test_allocation_validation_for_sales_order(self):
+		so = make_sales_order(do_not_save=True)
+		so.items[0].rate = 99.55
+		so.save().submit()
+		pe = get_payment_entry("Sales Order", so.name, bank_account="_Test Cash - _TC")
+		pe.paid_from = "Debtors - _TC"
+		pe.paid_amount = 45.55
+		pe.references[0].allocated_amount = 45.55
+		pe.save().submit()
+		pe = get_payment_entry("Sales Order", so.name, bank_account="_Test Cash - _TC")
+		pe.paid_from = "Debtors - _TC"
+		pe.save().submit()
+
+		so.reload()
+		self.assertEqual(so.advance_paid, so.rounded_total)
+
 
 def create_payment_entry(**args):
 	payment_entry = frappe.new_doc("Payment Entry")


### PR DESCRIPTION
1. Make Sales Order with a rounding adjustment amount.
2. Make partial payment for [1]. Save and Submit.
3. Make another partial payment for [1]. Upon save, allocation based validation error is thrown.
This happend as [get_reference_details](https://github.com/frappe/erpnext/blob/91927f2adac40844d39a9ee06cc5fec8424dcdfd/erpnext/accounts/doctype/payment_entry/payment_entry.py#L1994-L1997) was fetching `grand_total` rather than `rounded_total`.
<img width="1411" alt="Screenshot 2023-08-28 at 2 24 22 PM" src="https://github.com/frappe/erpnext/assets/3272205/4c302b69-1704-4d66-b820-6dc57db8eb4f">
