### PR TITLE
fix: Setup flake8 to stop turning trailing commas into tuples

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,6 +40,7 @@ repos:
       - id: flake8
         additional_dependencies: [
           'flake8-bugbear',
+          'flake8-tuple',
         ]
         args: ['--config', '.github/helper/.flake8_strict']
         exclude: ".*setup.py$"

--- a/erpnext/accounts/doctype/exchange_rate_revaluation/test_exchange_rate_revaluation.py
+++ b/erpnext/accounts/doctype/exchange_rate_revaluation/test_exchange_rate_revaluation.py
@@ -67,7 +67,7 @@ class TestExchangeRateRevaluation(AccountsTestMixin, FrappeTestCase):
 		si.save().submit()
 
 		err = frappe.new_doc("Exchange Rate Revaluation")
-		err.company = (self.company,)
+		err.company = self.company
 		err.posting_date = today()
 		accounts = err.get_accounts_data()
 		err.extend("accounts", accounts)
@@ -133,7 +133,7 @@ class TestExchangeRateRevaluation(AccountsTestMixin, FrappeTestCase):
 		frappe.get_doc("Journal Entry", je).cancel()
 
 		err = frappe.new_doc("Exchange Rate Revaluation")
-		err.company = (self.company,)
+		err.company = self.company
 		err.posting_date = today()
 		err.fetch_and_calculate_accounts_data()
 		err = err.save().submit()
@@ -215,7 +215,7 @@ class TestExchangeRateRevaluation(AccountsTestMixin, FrappeTestCase):
 		self.assertEqual(flt(acc_balance.balance_in_account_currency, precision), 5.0)  # in USD
 
 		err = frappe.new_doc("Exchange Rate Revaluation")
-		err.company = (self.company,)
+		err.company = self.company
 		err.posting_date = today()
 		err.fetch_and_calculate_accounts_data()
 		err.set_total_gain_loss()


### PR DESCRIPTION
There was a couple of *unwanted* single element tuples `(abc,)` in the codebase because of automated re-formatting.

I tried finding more by searching for the string `,)` but I only found these.

I added flake8-tuple to prevent this kind of automatically introduced bug from happening again