### PR TITLE
fix: create entries for only PR items present in LCV

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -759,21 +759,22 @@ class PurchaseInvoice(BuyingController):
 
 					# Amount added through landed-cost-voucher
 					if landed_cost_entries:
-						for account, amount in landed_cost_entries[(item.item_code, item.name)].items():
-							gl_entries.append(
-								self.get_gl_dict(
-									{
-										"account": account,
-										"against": item.expense_account,
-										"cost_center": item.cost_center,
-										"remarks": self.get("remarks") or _("Accounting Entry for Stock"),
-										"credit": flt(amount["base_amount"]),
-										"credit_in_account_currency": flt(amount["amount"]),
-										"project": item.project or self.project,
-									},
-									item=item,
+						if (item.item_code, item.name) in landed_cost_entries:
+							for account, amount in landed_cost_entries[(item.item_code, item.name)].items():
+								gl_entries.append(
+									self.get_gl_dict(
+										{
+											"account": account,
+											"against": item.expense_account,
+											"cost_center": item.cost_center,
+											"remarks": self.get("remarks") or _("Accounting Entry for Stock"),
+											"credit": flt(amount["base_amount"]),
+											"credit_in_account_currency": flt(amount["amount"]),
+											"project": item.project or self.project,
+										},
+										item=item,
+									)
 								)
-							)
 
 					# sub-contracting warehouse
 					if flt(item.rm_supp_cost):

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -470,27 +470,28 @@ class PurchaseReceipt(BuyingController):
 
 					# Amount added through landed-cos-voucher
 					if d.landed_cost_voucher_amount and landed_cost_entries:
-						for account, amount in landed_cost_entries[(d.item_code, d.name)].items():
-							account_currency = get_account_currency(account)
-							credit_amount = (
-								flt(amount["base_amount"])
-								if (amount["base_amount"] or account_currency != self.company_currency)
-								else flt(amount["amount"])
-							)
+						if (d.item_code, d.name) in landed_cost_entries:
+							for account, amount in landed_cost_entries[(d.item_code, d.name)].items():
+								account_currency = get_account_currency(account)
+								credit_amount = (
+									flt(amount["base_amount"])
+									if (amount["base_amount"] or account_currency != self.company_currency)
+									else flt(amount["amount"])
+								)
 
-							self.add_gl_entry(
-								gl_entries=gl_entries,
-								account=account,
-								cost_center=d.cost_center,
-								debit=0.0,
-								credit=credit_amount,
-								remarks=remarks,
-								against_account=warehouse_account_name,
-								credit_in_account_currency=flt(amount["amount"]),
-								account_currency=account_currency,
-								project=d.project,
-								item=d,
-							)
+								self.add_gl_entry(
+									gl_entries=gl_entries,
+									account=account,
+									cost_center=d.cost_center,
+									debit=0.0,
+									credit=credit_amount,
+									remarks=remarks,
+									against_account=warehouse_account_name,
+									credit_in_account_currency=flt(amount["amount"]),
+									account_currency=account_currency,
+									project=d.project,
+									item=d,
+								)
 
 					if d.rate_difference_with_purchase_invoice and stock_rbnb:
 						account_currency = get_account_currency(stock_rbnb)


### PR DESCRIPTION
**Problem**
_KeyError_ is thrown while submitting LCV for a Purchase Invoice where items do not match.

**Steps to replicate bug**

1. Create a Purchase Invoice with multiple items. 
2. Create a LCV and select the PI in the Purchase Receipts table.
3. Fetch items from the Purchase Invoice by clicking **Get Items from Purchase Receipts**.
4. Delete some items from the **Purchase Receipt Items** child table.
5. Allocate the total tax amount among remaining items.
6. Submit the document.

**Screenshot**

<br>
<img width="1031" alt="Screenshot 2023-08-28 at 5 46 33 PM" src="https://github.com/frappe/erpnext/assets/40693548/9716aa62-332f-4293-a50d-f57947e6b16f">
<br>
<br>

**Fix**
Added check to ensure GL entries are made only for items present in the LCV.

`no-docs`
