### PR TITLE
fix: Set the default filter in All Trends Report

### DIFF
--- a/erpnext/public/js/purchase_trends_filters.js
+++ b/erpnext/public/js/purchase_trends_filters.js
@@ -28,7 +28,7 @@ erpnext.get_purchase_trends_filters = function() {
 			"label": __("Fiscal Year"),
 			"fieldtype": "Link",
 			"options":'Fiscal Year',
-			"default": frappe.sys_defaults.fiscal_year
+			"default": erpnext.utils.get_fiscal_year(frappe.datetime.get_today())
 		},
 		{
 			"fieldname":"period_based_on",

--- a/erpnext/public/js/sales_trends_filters.js
+++ b/erpnext/public/js/sales_trends_filters.js
@@ -48,7 +48,7 @@ erpnext.get_sales_trends_filters = function() {
 			"label": __("Fiscal Year"),
 			"fieldtype": "Link",
 			"options":'Fiscal Year',
-			"default": frappe.sys_defaults.fiscal_year
+			"default": erpnext.utils.get_fiscal_year(frappe.datetime.get_today())
 		},
 		{
 			"fieldname":"company",


### PR DESCRIPTION
**Version:**

ERPNext: v14.37.0 (version-14)
Frappe Framework: v14.47.1 (version-14)
___

It's worked on develop and version-15-beta version but **not worked on version-14.**

**Before:**

- When checking all trend reports (Quotation Trends, Sales Order Trends, Delivery Note Trends, Sales Invoice Trends, Purchase Order Trends, Purchase Receipt Trends, and Purchase Invoice Trends), then faced errors like Fiscal Year is mandatory.


https://github.com/frappe/erpnext/assets/141945075/fd03fa71-de93-4027-b1b7-651609453300

<br>

**After:**

- After correcting the default condition, all trend reports (Quotation Trends, Sales Order Trends, Delivery Note Trends, Sales Invoice Trends, Purchase Order Trends, Purchase Receipt Trends, and Purchase Invoice Trends) worked properly.


https://github.com/frappe/erpnext/assets/141945075/312f2bd8-08c1-4a10-9bc5-16f27902408e

<br>

Thank You!