### PR TITLE
fix: tax accounts in sales register

### DIFF
--- a/erpnext/accounts/report/purchase_register/purchase_register.py
+++ b/erpnext/accounts/report/purchase_register/purchase_register.py
@@ -393,6 +393,7 @@ def get_invoices(filters, additional_query_columns):
 			pi.remarks,
 			pi.base_net_total,
 			pi.base_grand_total,
+			pi.base_rounded_total,
 			pi.outstanding_amount,
 			pi.mode_of_payment,
 		)

--- a/erpnext/accounts/report/sales_register/sales_register.py
+++ b/erpnext/accounts/report/sales_register/sales_register.py
@@ -38,7 +38,7 @@ def _execute(filters, additional_table_columns=None):
 	if filters.get("include_payments"):
 		invoice_list += get_payments(filters)
 
-	columns, income_accounts, tax_accounts, unrealized_profit_loss_accounts = get_columns(
+	columns, income_accounts, unrealized_profit_loss_accounts, tax_accounts = get_columns(
 		invoice_list, additional_table_columns, include_payments
 	)
 


### PR DESCRIPTION
**Problem**
Wrong order of accounts in the accounts list led to the Tax Totals to be 0 in the Sales Register. 

**Solution**
Fixed the sequence of accounts to fetch Tax amounts correctly.