### PR TITLE
fix: fetch currency in discount accounting SI

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1381,7 +1381,7 @@ class AccountsController(TransactionBase):
 					{
 						"account": self.additional_discount_account,
 						"against": supplier_or_customer,
-						dr_or_cr: self.discount_amount,
+						dr_or_cr: self.base_discount_amount,
 						"cost_center": self.cost_center,
 					},
 					item=self,
@@ -1653,6 +1653,7 @@ class AccountsController(TransactionBase):
 					and party_account_currency != self.company_currency
 					and self.currency != party_account_currency
 				):
+
 					frappe.throw(
 						_("Accounting Entry for {0}: {1} can only be made in currency: {2}").format(
 							party_type, party, party_account_currency


### PR DESCRIPTION
**Problem**
When using Discount Accounting, if a Sales Invoice is created using a different currency instead of the default currency for that company, the GL entries created consider the SI currency for the discount account but the company default currency for all other accounts. This leads to a mismatch in the total debit and total credit values and the SI cannot be submitted.

**Solution**
Use the `base_discount_amount` instead of the `discount_amount` in the GL entry for Discount Accounting.

Closes #36529