### PR TITLE
fix: when create doc from item dashboard default uom (buying or selling) is not correctly selected

### DIFF
--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -3,6 +3,9 @@
 
 frappe.provide("erpnext.item");
 
+const SALES_DOCTYPES = ['Quotation', 'Sales Order', 'Delivery Note', 'Sales Invoice'];
+const PURCHASE_DOCTYPES = ['Purchase Order', 'Purchase Receipt', 'Purchase Invoice'];
+
 frappe.ui.form.on("Item", {
 	setup: function(frm) {
 		frm.add_fetch('attribute', 'numeric_values', 'numeric_values');
@@ -888,7 +891,13 @@ function open_form(frm, doctype, child_doctype, parentfield) {
 		let new_child_doc = frappe.model.add_child(new_doc, child_doctype, parentfield);
 		new_child_doc.item_code = frm.doc.name;
 		new_child_doc.item_name = frm.doc.item_name;
-		new_child_doc.uom = frm.doc.stock_uom;
+		if (in_list(SALES_DOCTYPES, doctype) && frm.doc.sales_uom) {
+			new_child_doc.uom = frm.doc.sales_uom;
+		} else if (in_list(PURCHASE_DOCTYPES, doctype) && frm.doc.purchase_uom) {
+			new_child_doc.uom = frm.doc.purchase_uom;
+		} else {
+			new_child_doc.uom = frm.doc.stock_uom;
+		}
 		new_child_doc.description = frm.doc.description;
 		if (!new_child_doc.qty) {
 			new_child_doc.qty = 1.0;


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

Test case
Item 1  : default stock uom = Unit, Default Buying uom = Box, conversion Box=>Unit=100
Click on (+) Purchase Order from Item DashBoard, uom on the line is Unit instead of Default Buying uom (Box)

From a newly created a Purchase Order (not with Item Dashboard)
Add Item 1 uom is Box and conversion is apply

Actually adding an Item from newly created Sales or Buying Document apply the correct Uom, but create a Sales or Buying document from Item Dashoard don't pick the good uom

> Explain the **details** for making this change. What existing problem does the pull request solve?

Inspire by erpnext/public/js/utils/party.js where 
const SALES_DOCTYPES
const PURCHASE_DOCTYPES
are use

