### PR TITLE
refactor: Bank Reconciliation Tool APIs

### DIFF
--- a/erpnext/accounts/doctype/bank_reconciliation_tool/test_bank_reconciliation_tool.py
+++ b/erpnext/accounts/doctype/bank_reconciliation_tool/test_bank_reconciliation_tool.py
@@ -1,9 +1,100 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
-# import frappe
 import unittest
 
+import frappe
+from frappe import qb
+from frappe.tests.utils import FrappeTestCase, change_settings
+from frappe.utils import add_days, flt, getdate, today
 
-class TestBankReconciliationTool(unittest.TestCase):
-	pass
+from erpnext.accounts.doctype.bank_reconciliation_tool.bank_reconciliation_tool import (
+	auto_reconcile_vouchers,
+	get_bank_transactions,
+)
+from erpnext.accounts.doctype.payment_entry.test_payment_entry import create_payment_entry
+from erpnext.accounts.test.accounts_mixin import AccountsTestMixin
+
+
+class TestBankReconciliationTool(AccountsTestMixin, FrappeTestCase):
+	def setUp(self):
+		self.create_company()
+		self.create_customer()
+		self.clear_old_entries()
+		bank_dt = qb.DocType("Bank")
+		q = qb.from_(bank_dt).delete().where(bank_dt.name == "HDFC").run()
+		self.create_bank_account()
+
+	def tearDown(self):
+		frappe.db.rollback()
+
+	def create_bank_account(self):
+		bank = frappe.get_doc(
+			{
+				"doctype": "Bank",
+				"bank_name": "HDFC",
+			}
+		).save()
+
+		self.bank_account = (
+			frappe.get_doc(
+				{
+					"doctype": "Bank Account",
+					"account_name": "HDFC _current_",
+					"bank": bank,
+					"is_company_account": True,
+					"account": self.bank,  # account from Chart of Accounts
+				}
+			)
+			.insert()
+			.name
+		)
+
+	def test_auto_reconcile(self):
+		# make payment
+		from_date = add_days(today(), -1)
+		to_date = today()
+		payment = create_payment_entry(
+			company=self.company,
+			posting_date=from_date,
+			payment_type="Receive",
+			party_type="Customer",
+			party=self.customer,
+			paid_from=self.debit_to,
+			paid_to=self.bank,
+			paid_amount=100,
+		).save()
+		payment.reference_no = "123"
+		payment = payment.save().submit()
+
+		# make bank transaction
+		bank_transaction = (
+			frappe.get_doc(
+				{
+					"doctype": "Bank Transaction",
+					"date": to_date,
+					"deposit": 100,
+					"bank_account": self.bank_account,
+					"reference_number": "123",
+				}
+			)
+			.save()
+			.submit()
+		)
+
+		# assert API output pre reconciliation
+		transactions = get_bank_transactions(self.bank_account, from_date, to_date)
+		self.assertEqual(len(transactions), 1)
+		self.assertEqual(transactions[0].name, bank_transaction.name)
+
+		# auto reconcile
+		auto_reconcile_vouchers(
+			bank_account=self.bank_account,
+			from_date=from_date,
+			to_date=to_date,
+			filter_by_reference_date=False,
+		)
+
+		# assert API output post reconciliation
+		transactions = get_bank_transactions(self.bank_account, from_date, to_date)
+		self.assertEqual(len(transactions), 0)

--- a/erpnext/accounts/doctype/bank_transaction/test_bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/test_bank_transaction.py
@@ -47,7 +47,7 @@ class TestBankTransaction(FrappeTestCase):
 			from_date=bank_transaction.date,
 			to_date=utils.today(),
 		)
-		self.assertTrue(linked_payments[0][6] == "Conrad Electronic")
+		self.assertTrue(linked_payments[0]["party"] == "Conrad Electronic")
 
 	# This test validates a simple reconciliation leading to the clearance of the bank transaction and the payment
 	def test_reconcile(self):
@@ -93,7 +93,7 @@ class TestBankTransaction(FrappeTestCase):
 			from_date=bank_transaction.date,
 			to_date=utils.today(),
 		)
-		self.assertTrue(linked_payments[0][3])
+		self.assertTrue(linked_payments[0]["paid_amount"])
 
 	# Check error if already reconciled
 	def test_already_reconciled(self):
@@ -188,7 +188,7 @@ class TestBankTransaction(FrappeTestCase):
 		repayment_entry = create_loan_and_repayment()
 
 		linked_payments = get_linked_payments(bank_transaction.name, ["loan_repayment", "exact_match"])
-		self.assertEqual(linked_payments[0][2], repayment_entry.name)
+		self.assertEqual(linked_payments[0]["name"], repayment_entry.name)
 
 
 @if_lending_app_installed

--- a/erpnext/accounts/test/accounts_mixin.py
+++ b/erpnext/accounts/test/accounts_mixin.py
@@ -136,6 +136,8 @@ class AccountsTestMixin:
 			"Journal Entry",
 			"Sales Order",
 			"Exchange Rate Revaluation",
+			"Bank Account",
+			"Bank Transaction",
 		]
 		for doctype in doctype_list:
 			qb.from_(qb.DocType(doctype)).delete().where(qb.DocType(doctype).company == self.company).run()

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -558,8 +558,6 @@ get_matching_queries = (
 	"erpnext.accounts.doctype.bank_reconciliation_tool.bank_reconciliation_tool.get_matching_queries"
 )
 
-get_matching_vouchers_for_bank_reconciliation = "erpnext.accounts.doctype.bank_reconciliation_tool.bank_reconciliation_tool.get_matching_vouchers_for_bank_reconciliation"
-
 get_amounts_not_reflected_in_system_for_bank_reconciliation_statement = "erpnext.accounts.report.bank_reconciliation_statement.bank_reconciliation_statement.get_amounts_not_reflected_in_system_for_bank_reconciliation_statement"
 
 get_payment_entries_for_bank_clearance = (

--- a/erpnext/public/js/bank_reconciliation_tool/dialog_manager.js
+++ b/erpnext/public/js/bank_reconciliation_tool/dialog_manager.js
@@ -134,12 +134,12 @@ erpnext.accounts.bank_reconciliation.DialogManager = class DialogManager {
 
 	format_row(row) {
 		return [
-			row[1], // Document Type
-			row[2], // Document Name
-			row[5] || row[8], // Reference Date
-			format_currency(row[3], row[9]), // Remaining
-			row[4], // Reference Number
-			row[6], // Party
+			row["doctype"],
+			row["name"],
+			row["reference_date"] || row["posting_date"],
+			format_currency(row["paid_amount"], row["currency"]),
+			row["reference_no"],
+			row["party"],
 		];
 	}
 


### PR DESCRIPTION
> Does not change functionality

### Changes
- `auto_reconcile_vouchers`: Use `reconcile_vouchers` instead of re-implementing reconciliation logic
- `auto_reconcile_vouchers`: More clear result message. Consider partially reconciled transactions
- `get_linked_payments`: Return field names rather than indices in result
- Remove `get_matching_vouchers_for_bank_reconciliation` and use only `get_matching_queries` just like before (for uniformity and less confusion)
- Convert `db.sql` to QB
- Add `currency` where to clause to SI/PI queries

**ToDo:**

- [x] Change `db.sql` to `qb`
- [x] Remove `get_matching_vouchers_for_bank_reconciliation` from hooks
- [x] Make change in frappe/lending
