### PR TITLE
fix: difference amount calculation logic in Payment Entry UI

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -547,7 +547,9 @@ frappe.ui.form.on('Payment Entry', {
 				frm.set_value("base_received_amount", frm.doc.base_paid_amount);
 			}
 
-			frm.events.set_unallocated_amount(frm);
+			// set_unallocated_amount is called by below method,
+			// no need trigger separately
+			frm.events.set_total_allocated_amount(frm);
 		}
 
 		// Make read only if Accounts Settings doesn't allow stale rates
@@ -571,7 +573,9 @@ frappe.ui.form.on('Payment Entry', {
 				frm.set_value("base_paid_amount", frm.doc.base_received_amount);
 			}
 
-			frm.events.set_unallocated_amount(frm);
+			// set_unallocated_amount is called by below method,
+			// no need trigger separately
+			frm.events.set_total_allocated_amount(frm);
 		}
 		frm.set_paid_amount_based_on_received_amount = false;
 
@@ -887,12 +891,18 @@ frappe.ui.form.on('Payment Entry', {
 	},
 
 	set_total_allocated_amount: function(frm) {
+		let exchange_rate = 1;
+		if (frm.doc.payment_type == "Receive") {
+			exchange_rate = frm.doc.source_exchange_rate;
+		} else if (frm.doc.payment_type == "Pay") {
+			exchange_rate = frm.doc.target_exchange_rate;
+		}
 		var total_allocated_amount = 0.0;
 		var base_total_allocated_amount = 0.0;
 		$.each(frm.doc.references || [], function(i, row) {
 			if (row.allocated_amount) {
 				total_allocated_amount += flt(row.allocated_amount);
-				base_total_allocated_amount += flt(flt(row.allocated_amount)*flt(row.exchange_rate),
+				base_total_allocated_amount += flt(flt(row.allocated_amount)*flt(exchange_rate),
 					precision("base_paid_amount"));
 			}
 		});


### PR DESCRIPTION
When adding references in Payment Entry, use Payment Entries exchange rate to calculate `base_total_allocated_amount`. This is to avoid difference amount being generated and submitted by Payment Entry. Said difference amount will be calculated and posted by Journals by an [internal logic](https://github.com/frappe/erpnext/pull/35644)

before:

https://github.com/frappe/erpnext/assets/3272205/cbcb9180-1f81-401f-9aba-3f218009cf1e



after:


https://github.com/frappe/erpnext/assets/3272205/8857c3fa-e4a9-4acf-a943-c9d1d94441c8

part of: https://github.com/frappe/erpnext/issues/36873
fixes: https://github.com/frappe/erpnext/issues/36873#issuecomment-1701270215