### PR TITLE
fix: reduce threshold for background job in PCV

### DIFF
--- a/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
+++ b/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
@@ -126,7 +126,7 @@ class PeriodClosingVoucher(AccountsController):
 	def make_gl_entries(self, get_opening_entries=False):
 		gl_entries = self.get_gl_entries()
 		closing_entries = self.get_grouped_gl_entries(get_opening_entries=get_opening_entries)
-		if len(gl_entries) > 5000:
+		if len(gl_entries + closing_entries) > 3000:
 			frappe.enqueue(
 				process_gl_entries,
 				gl_entries=gl_entries,


### PR DESCRIPTION
**Problem**
The function to evaluate if the processing of GL entries in PCV should be done in a background job does not consider the number of closing entries.

**Solution**
Added closing entries in the condition for evaluating if the process will take place in the background job.
Reduced the threshold to ensure if entries are more than 3000, the process should use a background job.