### PR TITLE
feat:deallocation of payment entry with one click on button , now no …

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -1400,6 +1400,27 @@ frappe.ui.form.on('Payment Entry Reference', {
 
 	references_remove: function(frm) {
 		frm.events.set_total_allocated_amount(frm);
+	},
+
+	deallocate_payment: function(frm,cdt,cdn){
+		let d = locals[cdt][cdn];
+		if (frm.doc.docstatus == 1){
+			frappe.call({
+				method:"erpnext.accounts.doctype.payment_entry.payment_entry.deallocate_payment",
+				args:{
+					"child_doc_name":d.name,
+					"parent_doc_name":frm.doc.name,
+					"reference_doctype":d.reference_doctype,
+					"reference_name":d.reference_name,
+                    "self":frm.doc
+				},
+				callback: function(r){
+					if (r.message){
+						frappe.msgprint(r.message)
+					}
+				}
+			})
+		}
 	}
 })
 

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -7,7 +7,7 @@ from functools import reduce
 
 import frappe
 from frappe import ValidationError, _, qb, scrub, throw
-from frappe.utils import cint, comma_or, flt, getdate, nowdate
+from frappe.utils import cint, comma_or, flt, getdate, now, nowdate
 from frappe.utils.data import comma_and, fmt_money
 
 import erpnext
@@ -2584,3 +2584,100 @@ def make_payment_order(source_name, target_doc=None):
 	)
 
 	return doclist
+
+@frappe.whitelist()
+def deallocate_payment(child_doc_name, parent_doc_name, reference_doctype, reference_name, self):
+	self = frappe.json.loads(self)
+	if reference_doctype in ["Sales Invoice", "Purchase Invoice"]:
+		frappe.db.sql(f"delete from `tabPayment Entry Reference` where name = '{child_doc_name}'")
+		doc = frappe.get_doc("Payment Entry", parent_doc_name)
+		doc.set_amounts()
+
+		doc.db_update()
+		doc.make_gl_entries(cancel=1)
+		doc.make_gl_entries(cancel=0)
+		if self.get("payment_type") == "Receive":
+			account_type = "Receivable"
+			account = self.get("paid_from")
+		if self.get("payment_type") == "Pay":
+			account_type = "Payable"
+			account = self.get("paid_to")
+		# frappe.throw(str(self.get('party_type') +" "+ account_type+" "+self.get("party")+" "+ self.get('paid_from')))
+		frappe.db.sql(
+			"""Update  `tabPayment Ledger Entry`
+                        SET delinked=1,modified=%(date)s,modified_by=%(user)s
+                        WHERE company=%(company)s AND account_type=%(account_type)s
+                        AND account=%(account)s  AND party=%(party)s
+                        AND voucher_type='Payment Entry' AND voucher_no=%(name)s AND against_voucher_type=%(against_voucher_type)s
+                        AND against_voucher_no=%(against_voucher_no)s""",
+			{
+				"date": now(),
+				"user": frappe.session.user,
+				"company": self.get("company"),
+				"account_type": account_type,
+				"account": account,
+				"name": self.get("name"),
+				"against_voucher_type": reference_doctype,
+				"against_voucher_no": reference_name,
+				"party": self.get("party"),
+			},
+		)
+		update_outstanding_amt(
+			doc.paid_from if doc.payment_type == "Receive" else doc.paid_to,
+			doc.party_type,
+			doc.party,
+			reference_doctype,
+			reference_name,
+		)
+
+		ref_doc = frappe.get_doc(reference_doctype, reference_name)
+		ref_doc.delink_advance_entries(doc.name)
+
+		return "Payment Unallocated Successfully<br>Please Refresh a Page"
+	else:
+		return "Not able to Unallocate the Payment"
+
+
+def update_outstanding_amt(account, party_type, party, against_voucher_type, against_voucher):
+	if party_type and party:
+		party_condition = " and party_type={0} and party={1}".format(
+			frappe.db.escape(party_type), frappe.db.escape(party)
+		)
+	else:
+		party_condition = ""
+
+	if against_voucher_type == "Sales Invoice":
+		party_account = frappe.db.get_value(against_voucher_type, against_voucher, "debit_to")
+		account_condition = "and account in ({0}, {1})".format(
+			frappe.db.escape(account), frappe.db.escape(party_account)
+		)
+	else:
+		account_condition = " and account = {0}".format(frappe.db.escape(account))
+
+	# get final outstanding amt
+	bal = flt(
+		frappe.db.sql(
+			"""
+        select sum(debit_in_account_currency) - sum(credit_in_account_currency)
+        from `tabGL Entry`
+        where is_cancelled = 0 and against_voucher_type=%s and against_voucher=%s
+        and voucher_type != 'Invoice Discounting'
+        {0} {1}""".format(
+				party_condition, account_condition
+			),
+			(against_voucher_type, against_voucher),
+		)[0][0]
+		or 0.0
+	)
+
+	if against_voucher_type == "Purchase Invoice":
+		bal = -bal
+
+	if against_voucher_type in ["Sales Invoice", "Purchase Invoice"]:
+		ref_doc = frappe.get_doc(against_voucher_type, against_voucher)
+
+		# Didn't use db_set for optimisation purpose
+		ref_doc.outstanding_amount = bal
+		frappe.db.set_value(against_voucher_type, against_voucher, "outstanding_amount", bal)
+
+		ref_doc.set_status(update=True)

--- a/erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json
+++ b/erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json
@@ -10,6 +10,7 @@
   "due_date",
   "bill_no",
   "payment_term",
+  "deallocation_payment",
   "column_break_4",
   "total_amount",
   "outstanding_amount",
@@ -108,6 +109,12 @@
    "fieldtype": "Link",
    "label": "Account",
    "options": "Account"
+  },
+  {
+    "allow_on_submit": 1,
+    "fieldname": "deallocate_payment",
+    "fieldtype": "Button",
+    "label": "Deallocate Payment"
   }
  ],
  "index_web_pages_for_search": 1,

--- a/erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json
+++ b/erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json
@@ -10,7 +10,7 @@
   "due_date",
   "bill_no",
   "payment_term",
-  "deallocation_payment",
+  "deallocate_payment",
   "column_break_4",
   "total_amount",
   "outstanding_amount",


### PR DESCRIPTION
During a Payment Reconciliation if user is reconcile with wrong payment entry or invoice , without cancelation of payment entry
we can de-link invoice and payment entry

check this video

https://youtu.be/d89Xs7HbCr4 

Testing Path 

1, Create a Payment Entry
2, Reconcile a Payment a Payment entry by Payment Reconciliation
3,Go to that Reconcile payment entry , in in Payment Entry Reference there is button "Deallocation Payment"
    click on that and automatically payment entry will be de-link with invoice
and you can again reconcile that entry