### PR TITLE
fix: only show "Unreconcile" if reconciled

### DIFF
--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.js
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.js
@@ -13,10 +13,11 @@ frappe.ui.form.on("Bank Transaction", {
 		});
 	},
 	refresh(frm) {
-		frm.add_custom_button(__('Unreconcile Transaction'), () => {
-			frm.call('remove_payment_entries')
-			.then( () => frm.refresh() );
-		});
+		if (!frm.is_dirty() && frm.doc.payment_entries.length > 0) {
+			frm.add_custom_button(__("Unreconcile Transaction"), () => {
+				frm.call("remove_payment_entries").then(() => frm.refresh());
+			});
+		}
 	},
 	bank_account: function (frm) {
 		set_bank_statement_filter(frm);


### PR DESCRIPTION
### Problem

Button "Unreconcile Transaction" in **Bank Transaction** is shown even if it is not reconciled.

### Fix

Show button only if there are any reconciled payment entries.