### PR TITLE
fix: use primary key for link lookup

### DIFF
--- a/erpnext/stock/report/stock_balance/stock_balance.py
+++ b/erpnext/stock/report/stock_balance/stock_balance.py
@@ -339,8 +339,10 @@ class StockBalanceReport(object):
 		for field in ["item_code", "brand"]:
 			if not self.filters.get(field):
 				continue
-
-			query = query.where(item_table[field] == self.filters.get(field))
+			elif field == "item_code":
+				query = query.where(item_table.name == self.filters.get(field))
+			else:
+				query = query.where(item_table[field] == self.filters.get(field))
 
 		return query
 


### PR DESCRIPTION
### Overview
The stock balance report uses the `tabItem`.`item_code` column as a lookup for it's item filter. This differs from the expected `name` column used as lookup.

### Context
![image](https://github.com/frappe/erpnext/assets/29856401/26c72ad1-2da8-45d3-8f1b-611113455921)

The item has a `name` of **597f38b5c1** and an `item_code` of **Demo Item**

### Before PR
![image](https://github.com/frappe/erpnext/assets/29856401/b1e89b6d-36ba-4728-8b6d-a8e5e81090cc)


### After PR
![image](https://github.com/frappe/erpnext/assets/29856401/c3372ac6-bb3e-4488-bcb2-bbee7807985a)
