### PR TITLE
refactor: remove `Recalculate Rate` from SCR Item

### DIFF
--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.js
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.js
@@ -239,12 +239,6 @@ frappe.ui.form.on('Subcontracting Receipt Item', {
 		set_missing_values(frm);
 	},
 
-	recalculate_rate(frm) {
-		if (frm.doc.recalculate_rate) {
-			set_missing_values(frm);
-		}
-	},
-
 	items_remove: (frm) => {
 		set_missing_values(frm);
 	},

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
@@ -180,7 +180,6 @@ class SubcontractingReceipt(SubcontractingController):
 							"item_name": scrap_item.item_name,
 							"qty": qty,
 							"stock_uom": scrap_item.stock_uom,
-							"recalculate_rate": 0,
 							"rate": rate,
 							"rm_cost_per_qty": 0,
 							"service_cost_per_qty": 0,
@@ -277,13 +276,12 @@ class SubcontractingReceipt(SubcontractingController):
 					else:
 						item.scrap_cost_per_qty = 0
 
-				if item.recalculate_rate:
-					item.rate = (
-						flt(item.rm_cost_per_qty)
-						+ flt(item.service_cost_per_qty)
-						+ flt(item.additional_cost_per_qty)
-						- flt(item.scrap_cost_per_qty)
-					)
+				item.rate = (
+					flt(item.rm_cost_per_qty)
+					+ flt(item.service_cost_per_qty)
+					+ flt(item.additional_cost_per_qty)
+					- flt(item.scrap_cost_per_qty)
+				)
 
 			item.received_qty = flt(item.qty) + flt(item.rejected_qty)
 			item.amount = flt(item.qty) * flt(item.rate)

--- a/erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
@@ -28,7 +28,6 @@
   "rate_and_amount",
   "rate",
   "amount",
-  "recalculate_rate",
   "column_break_19",
   "rm_cost_per_qty",
   "service_cost_per_qty",
@@ -202,7 +201,6 @@
    "options": "currency",
    "print_width": "100px",
    "read_only": 1,
-   "read_only_depends_on": "eval: doc.recalculate_rate",
    "width": "100px"
   },
   {
@@ -476,14 +474,6 @@
    "label": "Accounting Details"
   },
   {
-   "default": "1",
-   "depends_on": "eval: !doc.is_scrap_item",
-   "fieldname": "recalculate_rate",
-   "fieldtype": "Check",
-   "label": "Recalculate Rate",
-   "read_only_depends_on": "eval: doc.is_scrap_item"
-  },
-  {
    "fieldname": "serial_and_batch_bundle",
    "fieldtype": "Link",
    "label": "Serial and Batch Bundle",
@@ -531,7 +521,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-08-25 20:09:03.069417",
+ "modified": "2023-09-03 17:04:21.214316",
  "modified_by": "Administrator",
  "module": "Subcontracting",
  "name": "Subcontracting Receipt Item",


### PR DESCRIPTION
**Problem:** The `Recalculate Rate` field can cause issues while reposting. For example, if there is a Subcontracting Receipt with a recalculated rate disabled, if we do a back-dated transaction before the Subcontracting Receipt that changes the Valuation Rate of the Raw-Materials used in the Subcontracting Receipt then a Repost Item Valuation is created and fails while the process the Subcontracting Receipt saying `Debit and Credit not equal ...` since the rate won't get calculated if Recalculated Rate is disabled.

**Steps to replicate:**
- Create a Subcontract Purchase Order.
- Create a Subcontracting Order.
- Create Subcontracting Receipt [disabled the Recalculate Rate for Items].
- Create a back-dated (before Subcontracting Receipt) Stock Reconciliation to update the Valuation Rate of the raw material used.
- Check the created Repost Item Valuation for the Stock Reconciliation.