### PR TITLE
fix: invalid gain/loss JE created on base currency Expense Claim

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -856,6 +856,11 @@ class PaymentEntry(AccountsController):
 				flt(d.allocated_amount) * flt(exchange_rate), self.precision("base_paid_amount")
 			)
 
+			# on rare case, when `exchange_rate` is unset, gain/loss amount is incorrectly calculated
+			# for base currency transactions
+			if d.exchange_rate is None:
+				d.exchange_rate = 1
+
 			allocated_amount_in_pe_exchange_rate = flt(
 				flt(d.allocated_amount) * flt(d.exchange_rate), self.precision("base_paid_amount")
 			)


### PR DESCRIPTION
If `exchange_rate` of individual reference is unset, make it `1`. If left unset, `exchange_gain_loss` is calculated leading to an incorrect JE being posted.
part of: https://github.com/frappe/hrms/pull/848