### PR TITLE
fix: auto refresh serial and batch bundle field

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -702,7 +702,13 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 	}
 
 	on_submit() {
-		refresh_field("items");
+		this.refresh_serial_batch_bundle_field();
+	}
+
+	refresh_serial_batch_bundle_field() {
+		frappe.route_hooks.after_submit = (frm_obj) => {
+			frm_obj.reload_doc();
+		}
 	}
 
 	update_qty(cdt, cdn) {


### PR DESCRIPTION
**Issue**
If the Serial and Batch bundle auto created on submission of the purchase receipt, then it wasn't immediately showing on the form. User has to manually refresh the page to see the Serial and Batch bundle link on the form