### PR TITLE
fix: allow payment_account of loan repayment to be edited

### DIFF
--- a/erpnext/loan_management/doctype/loan_repayment/loan_repayment.json
+++ b/erpnext/loan_management/doctype/loan_repayment/loan_repayment.json
@@ -263,12 +263,13 @@
    "label": "Accounting Details"
   },
   {
+   "depends_on": "eval:!doc.repay_from_salary",
    "fetch_from": "against_loan.payment_account",
+   "fetch_if_empty": 1,
    "fieldname": "payment_account",
    "fieldtype": "Link",
    "label": "Repayment Account",
-   "options": "Account",
-   "read_only": 1
+   "options": "Account"
   },
   {
    "fieldname": "column_break_36",
@@ -294,7 +295,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2022-06-21 10:10:07.742298",
+ "modified": "2023-09-04 15:44:29.148766",
  "modified_by": "Administrator",
  "module": "Loan Management",
  "name": "Loan Repayment",


### PR DESCRIPTION
Allow `payment_account` of `Loan Repayment` to be edited and hide it if `repay_from_salary` is checked since `Payroll Payable Account` is used in that case.

Related but not dependent: https://github.com/frappe/frappe/pull/22306, https://github.com/frappe/hrms/pull/851