### PR TITLE
fix: update repay_from_salary, payment_account and payroll_payable_account fields

### DIFF
--- a/erpnext/loan_management/doctype/loan_repayment/loan_repayment.json
+++ b/erpnext/loan_management/doctype/loan_repayment/loan_repayment.json
@@ -281,7 +281,7 @@
    "label": "Accounting Details"
   },
   {
-    "depends_on": "eval:!doc.repay_from_salary",
+   "depends_on": "eval:!doc.repay_from_salary",
    "fetch_from": "against_loan.payment_account",
    "fetch_if_empty": 1,
    "fieldname": "payment_account",

--- a/erpnext/loan_management/doctype/loan_repayment/loan_repayment.json
+++ b/erpnext/loan_management/doctype/loan_repayment/loan_repayment.json
@@ -15,7 +15,6 @@
   "posting_date",
   "clearance_date",
   "rate_of_interest",
-  "payroll_payable_account",
   "is_term_loan",
   "repay_from_salary",
   "payment_details_section",
@@ -41,6 +40,7 @@
   "amended_from",
   "accounting_details_section",
   "payment_account",
+  "payroll_payable_account",
   "penalty_income_account",
   "column_break_36",
   "loan_account"
@@ -263,6 +263,7 @@
   {
    "default": "0",
    "fetch_from": "against_loan.repay_from_salary",
+   "fetch_if_empty": 1,
    "fieldname": "repay_from_salary",
    "fieldtype": "Check",
    "label": "Repay From Salary"
@@ -280,6 +281,7 @@
    "label": "Accounting Details"
   },
   {
+    "depends_on": "eval:!doc.repay_from_salary",
    "fetch_from": "against_loan.payment_account",
    "fetch_if_empty": 1,
    "fieldname": "payment_account",


### PR DESCRIPTION
- Making `Loan Repayment`'s `repay_from_salary` editable
- Moving `Loan Repayment`'s `Payroll Payable Account` to a better position (among other accounts)
- Hide `Loan Repayment`'s `Repayment Account` if `repay_from_salary` is checked since `Payroll Payable Account` is used in that case