### PR TITLE
fix: prorate factor for subscription plan

### DIFF
--- a/erpnext/accounts/doctype/subscription/test_subscription.py
+++ b/erpnext/accounts/doctype/subscription/test_subscription.py
@@ -694,3 +694,23 @@ class TestSubscription(unittest.TestCase):
 		# Check the currency of the created invoice
 		currency = frappe.db.get_value("Sales Invoice", subscription.invoices[0].invoice, "currency")
 		self.assertEqual(currency, "USD")
+
+	def test_plan_rate_for_midmonth_start_date(self):
+		subscription = frappe.new_doc("Subscription")
+		subscription.party_type = "Supplier"
+		subscription.party = "_Test Supplier"
+		subscription.generate_invoice_at_period_start = 1
+		subscription.follow_calendar_months = 1
+		subscription.generate_new_invoices_past_due_date = 1
+		subscription.start_date = "2023-04-08"
+		subscription.end_date = "2024-02-27"
+		subscription.append("plans", {"plan": "_Test Plan Name 4", "qty": 1})
+		subscription.save()
+
+		subscription.process()
+
+		self.assertEqual(len(subscription.invoices), 1)
+		pi = frappe.get_doc("Purchase Invoice", subscription.invoices[0].invoice)
+		self.assertEqual(pi.total, 55333.33)
+
+		subscription.delete()

--- a/erpnext/accounts/doctype/subscription_plan/subscription_plan.py
+++ b/erpnext/accounts/doctype/subscription_plan/subscription_plan.py
@@ -57,18 +57,17 @@ def get_plan_rate(
 		prorate = frappe.db.get_single_value("Subscription Settings", "prorate")
 
 		if prorate:
-			prorate_factor = flt(
-				date_diff(start_date, get_first_day(start_date))
-				/ date_diff(get_last_day(start_date), get_first_day(start_date)),
-				1,
-			)
-
-			prorate_factor += flt(
-				date_diff(get_last_day(end_date), end_date)
-				/ date_diff(get_last_day(end_date), get_first_day(end_date)),
-				1,
-			)
-
-			cost -= plan.cost * prorate_factor
-
+			cost -= plan.cost * get_prorate_factor(start_date, end_date)
 		return cost
+
+
+def get_prorate_factor(start_date, end_date):
+	total_days_to_skip = date_diff(start_date, get_first_day(start_date))
+	total_days_in_month = int(get_last_day(start_date).strftime("%d"))
+	prorate_factor = flt(total_days_to_skip / total_days_in_month)
+
+	total_days_to_skip = date_diff(get_last_day(end_date), end_date)
+	total_days_in_month = int(get_last_day(end_date).strftime("%d"))
+	prorate_factor += flt(total_days_to_skip / total_days_in_month)
+
+	return prorate_factor


### PR DESCRIPTION
**Problem**
On creation of a Subscription for a Subscription Plan which determines the price based on the **Monthly Rate**, the resulting Invoices have incorrect total amounts.

**Solution**
If a Subscription Plan is created with a Monthly Rate of **₹3950** and a Billing Interval of **3 months**.
<br>
<img width="1031" alt="Screenshot 2023-08-30 at 6 49 20 PM" src="https://github.com/frappe/erpnext/assets/40693548/90c9452f-f8df-4723-a554-5ea6f8ca37fa">
<br>
Suppose the start date of current invoice's period for the Subscription is `08-04-2023` and the end date of current invoice's period is `30-06-2023`.

The prorate factor is now calculated by considering the total number of days in the current month ie. **30 days** instead of just the `datediff` between the start and end dates which gives **29 days**. 

Since, 
Cost for 1 day = ₹3950 / 30 = ₹131.66
Total Days to be skipped = 7 days
Total Cost for the month of April should be : 3950 - 131.66 * 7 = ₹3028.34

Old Total for 3 month Invoice (considering 29 days) = ₹11060.00
New Total for 3 month Invoice (considering 30 days) = ₹10928.33

`no-docs`