### PR TITLE
fix: ignore mandatory fields while saving WO

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -702,6 +702,7 @@ def raise_work_orders(material_request):
 				)
 
 				wo_order.set_work_order_operations()
+				wo_order.flags.ignore_mandatory = True
 				wo_order.save()
 
 				work_orders.append(wo_order.name)


### PR DESCRIPTION
**Source / Ref:** 953

![image](https://github.com/frappe/erpnext/assets/63660334/0068b11b-9a62-4cff-8cf0-80417bb9683d)

**Problem:** Work Order should be saved at least instead of throwing an error, mandatory fields can be added later before submitting.

**Steps to Replicate:**
- Add a mandatory custom field in the Work Order.
- Create a Manufacture Material Request. 
- Create Work Order from Material Request > Create > Work Order.





