### PR TITLE
fix: index error on Receivable report based on payment terms

### DIFF
--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -467,6 +467,10 @@ class ReceivablePayableReport(object):
 		original_row = frappe._dict(row)
 		row.payment_terms = []
 
+		# Cr Note's don't have Payment Terms
+		if not payment_terms_details:
+			return
+
 		# Advance allocated during invoicing is not considered in payment terms
 		# Deduct that from paid amount pre allocation
 		row.paid -= flt(payment_terms_details[0].total_advance)


### PR DESCRIPTION
Cr Notes don't have payment terms. Skip term based allocation for them.
```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 83, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 53, in handle
    return _RESTAPIHandler(call, doctype, name).get_response()
  File "apps/frappe/frappe/api.py", line 69, in get_response
    return self.handle_method()
  File "apps/frappe/frappe/api.py", line 79, in handle_method
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 48, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 86, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1671, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/utils/typing_validations.py", line 31, in wrapper
    return func(*args, **kwargs)
  File "apps/frappe/frappe/__init__.py", line 836, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "apps/frappe/frappe/desk/query_report.py", line 214, in run
    result = generate_report_result(report, filters, user, custom_columns, is_tree, parent_field)
  File "apps/frappe/frappe/__init__.py", line 836, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "apps/frappe/frappe/desk/query_report.py", line 82, in generate_report_result
    res = get_report_result(report, filters) or []
  File "apps/frappe/frappe/desk/query_report.py", line 63, in get_report_result
    res = report.execute_script_report(filters)
  File "apps/frappe/frappe/core/doctype/report/report.py", line 164, in execute_script_report
    res = self.execute_module(filters)
  File "apps/frappe/frappe/core/doctype/report/report.py", line 181, in execute_module
    return frappe.get_attr(method_name)(frappe._dict(filters))
  File "apps/erpnext/erpnext/accounts/report/accounts_receivable/accounts_receivable.py", line 40, in execute
    return ReceivablePayableReport(filters).run(args)
  File "apps/erpnext/erpnext/accounts/report/accounts_receivable/accounts_receivable.py", line 62, in run
    self.get_data()
  File "apps/erpnext/erpnext/accounts/report/accounts_receivable/accounts_receivable.py", line 113, in get_data
    self.build_data()
  File "apps/erpnext/erpnext/accounts/report/accounts_receivable/accounts_receivable.py", line 280, in build_data
    self.allocate_outstanding_based_on_payment_terms(row)
  File "apps/erpnext/erpnext/accounts/report/accounts_receivable/accounts_receivable.py", line 435, in allocate_outstanding_based_on_payment_terms
    self.get_payment_terms(row)
  File "apps/erpnext/erpnext/accounts/report/accounts_receivable/accounts_receivable.py", line 472, in get_payment_terms
    row.paid -= flt(payment_terms_details[0].total_advance)
IndexError: list index out of range
```