### PR TITLE
fix: accepted warehouse and rejected warehouse can't be same

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.json
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.json
@@ -1173,6 +1173,7 @@
    "depends_on": "is_internal_supplier",
    "fieldname": "set_from_warehouse",
    "fieldtype": "Link",
+   "ignore_user_permissions": 1,
    "label": "Set From Warehouse",
    "options": "Warehouse"
   },
@@ -1273,7 +1274,7 @@
  "idx": 105,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-06-03 16:19:45.710444",
+ "modified": "2023-09-13 16:21:07.361700",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Purchase Order",

--- a/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
+++ b/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
@@ -878,6 +878,7 @@
    "depends_on": "eval:parent.is_internal_supplier",
    "fieldname": "from_warehouse",
    "fieldtype": "Link",
+   "ignore_user_permissions": 1,
    "label": "From Warehouse",
    "options": "Warehouse"
   },
@@ -902,7 +903,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-08-17 10:17:40.893393",
+ "modified": "2023-09-13 16:22:40.825092",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Purchase Order Item",


### PR DESCRIPTION
Source / Ref: 967

Related to: https://github.com/frappe/erpnext/pull/36001

When PR/PI is created from PO having From Warehouse set.


