### PR TITLE
fix: + btn not appearing for delivery note connection

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice_dashboard.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice_dashboard.py
@@ -15,8 +15,10 @@ def get_data():
 		},
 		"internal_links": {
 			"Sales Order": ["items", "sales_order"],
-			"Delivery Note": ["items", "delivery_note"],
 			"Timesheet": ["timesheets", "time_sheet"],
+		},
+		"internal_and_external_links": {
+			"Delivery Note": ["items", "delivery_note"],
 		},
 		"transactions": [
 			{

--- a/erpnext/stock/doctype/delivery_note/delivery_note_dashboard.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note_dashboard.py
@@ -11,9 +11,11 @@ def get_data():
 		},
 		"internal_links": {
 			"Sales Order": ["items", "against_sales_order"],
-			"Sales Invoice": ["items", "against_sales_invoice"],
 			"Material Request": ["items", "material_request"],
 			"Purchase Order": ["items", "purchase_order"],
+		},
+		"internal_and_external_links": {
+			"Sales Invoice": ["items", "against_sales_invoice"],
 		},
 		"transactions": [
 			{"label": _("Related"), "items": ["Sales Invoice", "Packing Slip", "Delivery Trip"]},


### PR DESCRIPTION
Moving SI and DI connected links to `internal_and_external_links`, which also fixes the problem of + btn not appearing for delivery note connection.

Soft dependency on https://github.com/frappe/frappe/pull/22320.