### PR TITLE
fix: `Parent Task` link with `Project Task`

### DIFF
--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -125,6 +125,7 @@ class Project(Document):
 					filter(lambda x: x.subject == child_task_subject, project_tasks)
 				)
 				if len(corresponding_project_task):
+					project_task.reload()  # reload, as it might have been updated in the previous iteration
 					project_task.append("depends_on", {"task": corresponding_project_task[0].name})
 					project_task.save()
 

--- a/erpnext/projects/doctype/project/project.py
+++ b/erpnext/projects/doctype/project/project.py
@@ -87,6 +87,7 @@ class Project(Document):
 				issue=task_details.issue,
 				is_group=task_details.is_group,
 				color=task_details.color,
+				template_task=task_details.name,
 			)
 		).insert()
 
@@ -106,9 +107,13 @@ class Project(Document):
 		return date
 
 	def dependency_mapping(self, template_tasks, project_tasks):
-		for template_task in template_tasks:
-			project_task = list(filter(lambda x: x.subject == template_task.subject, project_tasks))[0]
-			project_task = frappe.get_doc("Task", project_task.name)
+		for project_task in project_tasks:
+			if project_task.get("template_task"):
+				template_task = frappe.get_doc("Task", project_task.template_task)
+			else:
+				template_task = list(filter(lambda x: x.subject == project_task.subject, template_tasks))[0]
+				template_task = frappe.get_doc("Task", template_task.name)
+
 			self.check_depends_on_value(template_task, project_task, project_tasks)
 			self.check_for_parent_tasks(template_task, project_task, project_tasks)
 

--- a/erpnext/projects/doctype/task/task.json
+++ b/erpnext/projects/doctype/task/task.json
@@ -52,13 +52,15 @@
   "company",
   "lft",
   "rgt",
-  "old_parent"
+  "old_parent",
+  "template_task"
  ],
  "fields": [
   {
    "fieldname": "subject",
    "fieldtype": "Data",
    "in_global_search": 1,
+   "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Subject",
    "reqd": 1,
@@ -138,6 +140,7 @@
    "fieldname": "parent_task",
    "fieldtype": "Link",
    "ignore_user_permissions": 1,
+   "in_list_view": 1,
    "label": "Parent Task",
    "options": "Task",
    "search_index": 1
@@ -382,6 +385,12 @@
    "fieldtype": "Date",
    "label": "Completed On",
    "mandatory_depends_on": "eval: doc.status == \"Completed\""
+  },
+  {
+   "fieldname": "template_task",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Template Task"
   }
  ],
  "icon": "fa fa-check",
@@ -389,7 +398,7 @@
  "is_tree": 1,
  "links": [],
  "max_attachments": 5,
- "modified": "2023-04-17 21:06:50.174418",
+ "modified": "2023-09-06 13:52:05.861175",
  "modified_by": "Administrator",
  "module": "Projects",
  "name": "Task",


### PR DESCRIPTION
**Source / Ref:** 883

**Problem:** When you have Tasks with Parent and Common Name in a Project Template, creating a Project against the template will not link the 2nd..nth Project Tasks with the Parent i.e., only the first Task in a group of Tasks with same name will have the Parent mapped.

- In the below image, Task TASK-2023-00116 and TASK-2023-00120 have the same subject. When we create a Project for this template only the Task TASK-2023-00116 will be linked with the Parent Task.

  ![image](https://github.com/frappe/erpnext/assets/63660334/94528b78-f4b4-4b6f-8e5a-a5127036271d)

**Solution:** Currently, the Subject is used as a key to find the Template Item for a Project Task. Added a new field in Task to hold the reference of Template Task in Project Task, which will be used to find the Template Task while setting up the dependencies.

**Before:**

https://github.com/frappe/erpnext/assets/63660334/0d7ec5fc-0d94-4ad9-9bda-be146eb1906b

**After:**

https://github.com/frappe/erpnext/assets/63660334/211e2385-c4a5-4077-9ff9-ec5257a0a2b6


