### PR TITLE
fix: "Based on" field always has the value "Not applicable"

### DIFF
--- a/erpnext/setup/doctype/authorization_rule/authorization_rule.py
+++ b/erpnext/setup/doctype/authorization_rule/authorization_rule.py
@@ -55,8 +55,6 @@ class AuthorizationRule(Document):
 			frappe.throw(_("Discount must be less than 100"))
 		elif self.based_on == "Customerwise Discount" and not self.master_name:
 			frappe.throw(_("Customer required for 'Customerwise Discount'"))
-		else:
-			self.based_on = "Not Applicable"
 
 	def validate(self):
 		self.check_duplicate_entry()


### PR DESCRIPTION
When i try to create a Authorization Rule "Based on" field always has the value "Not applicable".

Making it impossible to create other types...

Problem was generated in this pull:
https://github.com/frappe/erpnext/commit/a1a6810b5807417a2b4bbdfb4933847deeaa7ea6