### PR TITLE
feat: provision to set required by from Production Plan

### DIFF
--- a/erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.json
+++ b/erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.json
@@ -10,22 +10,25 @@
   "warehouse",
   "item_name",
   "material_request_type",
-  "actual_qty",
-  "ordered_qty",
+  "quantity",
   "required_bom_qty",
   "column_break_4",
-  "quantity",
+  "schedule_date",
   "uom",
   "conversion_factor",
-  "projected_qty",
-  "reserved_qty_for_production",
-  "safety_stock",
   "item_details",
   "description",
   "min_order_qty",
   "section_break_8",
   "sales_order",
-  "requested_qty"
+  "bin_qty_section",
+  "actual_qty",
+  "requested_qty",
+  "reserved_qty_for_production",
+  "column_break_yhelv",
+  "ordered_qty",
+  "projected_qty",
+  "safety_stock"
  ],
  "fields": [
   {
@@ -65,7 +68,7 @@
    "fieldtype": "Column Break"
   },
   {
-   "columns": 1,
+   "columns": 2,
    "fieldname": "quantity",
    "fieldtype": "Float",
    "in_list_view": 1,
@@ -80,12 +83,12 @@
    "read_only": 1
   },
   {
-   "columns": 2,
+   "columns": 1,
    "default": "0",
    "fieldname": "actual_qty",
    "fieldtype": "Float",
    "in_list_view": 1,
-   "label": "Available Qty",
+   "label": "Qty In Stock",
    "no_copy": 1,
    "read_only": 1
   },
@@ -176,11 +179,27 @@
    "fieldtype": "Float",
    "label": "Conversion Factor",
    "read_only": 1
+  },
+  {
+   "columns": 1,
+   "fieldname": "schedule_date",
+   "fieldtype": "Date",
+   "in_list_view": 1,
+   "label": "Required By"
+  },
+  {
+   "fieldname": "bin_qty_section",
+   "fieldtype": "Section Break",
+   "label": "BIN Qty"
+  },
+  {
+   "fieldname": "column_break_yhelv",
+   "fieldtype": "Column Break"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2023-05-03 12:43:29.895754",
+ "modified": "2023-09-12 12:09:08.358326",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Material Request Plan Item",

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -725,7 +725,7 @@ class ProductionPlan(Document):
 
 			# key for Sales Order:Material Request Type:Customer
 			key = "{}:{}:{}".format(item.sales_order, material_request_type, item_doc.customer or "")
-			schedule_date = add_days(nowdate(), cint(item_doc.lead_time_days))
+			schedule_date = item.schedule_date or add_days(nowdate(), cint(item_doc.lead_time_days))
 
 			if not key in material_request_map:
 				# make a new MR for the combination

--- a/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
@@ -2,7 +2,7 @@
 # See license.txt
 import frappe
 from frappe.tests.utils import FrappeTestCase
-from frappe.utils import add_to_date, flt, now_datetime, nowdate
+from frappe.utils import add_to_date, flt, getdate, now_datetime, nowdate
 
 from erpnext.controllers.item_variant import create_variant
 from erpnext.manufacturing.doctype.production_plan.production_plan import (
@@ -58,6 +58,9 @@ class TestProductionPlan(FrappeTestCase):
 		pln = create_production_plan(item_code="Test Production Item 1")
 		self.assertTrue(len(pln.mr_items), 2)
 
+		for row in pln.mr_items:
+			row.schedule_date = add_to_date(nowdate(), days=10)
+
 		pln.make_material_request()
 		pln.reload()
 		self.assertTrue(pln.status, "Material Requested")
@@ -70,6 +73,13 @@ class TestProductionPlan(FrappeTestCase):
 		)
 
 		self.assertTrue(len(material_requests), 2)
+
+		for row in material_requests:
+			mr_schedule_date = getdate(frappe.db.get_value("Material Request", row[0], "schedule_date"))
+
+			expected_date = getdate(add_to_date(nowdate(), days=10))
+
+			self.assertEqual(mr_schedule_date, expected_date)
 
 		pln.make_work_order()
 		work_orders = frappe.get_all(


### PR DESCRIPTION
We've added a 'Required By' date field to the Production Plan Material Request table. The system will automatically set the corresponding date in the material request when it generates material requests from the production plan.


<img width="1333" alt="Screenshot 2023-09-12 at 12 27 04 PM" src="https://github.com/frappe/erpnext/assets/8780500/5415d662-2431-4261-a868-d9eff4a9936c">
