### PR TITLE
fix: multiple fixes for booking advances in seperate account

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -1123,7 +1123,7 @@ class PaymentEntry(AccountsController):
 		if self.book_advance_payments_in_separate_party_account:
 			gl_entries = []
 			for d in self.get("references"):
-				if d.reference_doctype in ("Sales Invoice", "Purchase Invoice"):
+				if d.reference_doctype in ("Sales Invoice", "Purchase Invoice", "Journal Entry"):
 					if not (against_voucher_type and against_voucher) or (
 						d.reference_doctype == against_voucher_type and d.reference_name == against_voucher
 					):
@@ -1159,6 +1159,10 @@ class PaymentEntry(AccountsController):
 			"voucher_detail_no": invoice.name,
 		}
 
+		posting_date = frappe.db.get_value(
+			invoice.reference_doctype, invoice.reference_name, "posting_date"
+		)
+
 		dr_or_cr = "credit" if invoice.reference_doctype == "Sales Invoice" else "debit"
 		args_dict["account"] = invoice.account
 		args_dict[dr_or_cr] = invoice.allocated_amount
@@ -1167,6 +1171,7 @@ class PaymentEntry(AccountsController):
 			{
 				"against_voucher_type": invoice.reference_doctype,
 				"against_voucher": invoice.reference_name,
+				"posting_date": posting_date,
 			}
 		)
 		gle = self.get_gl_dict(

--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.js
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.js
@@ -24,7 +24,8 @@ erpnext.accounts.PaymentReconciliationController = class PaymentReconciliationCo
 				filters: {
 					"company": this.frm.doc.company,
 					"is_group": 0,
-					"account_type": frappe.boot.party_account_types[this.frm.doc.party_type]
+					"account_type": frappe.boot.party_account_types[this.frm.doc.party_type],
+					"root_type": this.frm.doc.party_type == 'Customer' ? "Asset" : "Liability"
 				}
 			};
 		});

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -489,14 +489,13 @@ def reconcile_against_document(args, skip_ref_details_update_for_pe=False):  # n
 		gl_map = doc.build_gl_map()
 		create_payment_ledger_entry(gl_map, update_outstanding="No", cancel=0, adv_adj=1)
 
-		if voucher_type == "Payment Entry":
-			doc.make_advance_gl_entries()
-
 		# Only update outstanding for newly linked vouchers
 		for entry in entries:
 			update_voucher_outstanding(
 				entry.against_voucher_type, entry.against_voucher, entry.account, entry.party_type, entry.party
 			)
+			if voucher_type == "Payment Entry":
+				doc.make_advance_gl_entries(entry.against_voucher_type, entry.against_voucher)
 
 		frappe.flags.ignore_party_validation = False
 

--- a/erpnext/buying/doctype/supplier/supplier.js
+++ b/erpnext/buying/doctype/supplier/supplier.js
@@ -12,6 +12,7 @@ frappe.ui.form.on("Supplier", {
 			return {
 				filters: {
 					'account_type': 'Payable',
+					'root_type': 'Liability',
 					'company': d.company,
 					"is_group": 0
 				}

--- a/erpnext/selling/doctype/customer/customer.js
+++ b/erpnext/selling/doctype/customer/customer.js
@@ -23,6 +23,7 @@ frappe.ui.form.on("Customer", {
 			let d  = locals[cdt][cdn];
 			let filters = {
 				'account_type': 'Receivable',
+				'root_type': 'Asset',
 				'company': d.company,
 				"is_group": 0
 			};

--- a/erpnext/setup/doctype/company/company.js
+++ b/erpnext/setup/doctype/company/company.js
@@ -200,8 +200,8 @@ erpnext.company.setup_queries = function(frm) {
 	$.each([
 		["default_bank_account", {"account_type": "Bank"}],
 		["default_cash_account", {"account_type": "Cash"}],
-		["default_receivable_account", {"account_type": "Receivable"}],
-		["default_payable_account", {"account_type": "Payable"}],
+		["default_receivable_account", { "root_type": "Asset", "account_type": "Receivable" }],
+		["default_payable_account", { "root_type": "Liability", "account_type": "Payable" }],
 		["default_expense_account", {"root_type": "Expense"}],
 		["default_income_account", {"root_type": "Income"}],
 		["round_off_account", {"root_type": "Expense"}],

--- a/erpnext/setup/doctype/customer_group/customer_group.js
+++ b/erpnext/setup/doctype/customer_group/customer_group.js
@@ -30,6 +30,7 @@ frappe.ui.form.on("Customer Group", {
 		frm.set_query('account', 'accounts', function (doc, cdt, cdn) {
 			return {
 				filters: {
+					'root_type': 'Asset',
 					"account_type": 'Receivable',
 					"company": locals[cdt][cdn].company,
 					"is_group": 0

--- a/erpnext/setup/doctype/supplier_group/supplier_group.js
+++ b/erpnext/setup/doctype/supplier_group/supplier_group.js
@@ -30,6 +30,7 @@ frappe.ui.form.on("Supplier Group", {
 		frm.set_query('account', 'accounts', function (doc, cdt, cdn) {
 			return {
 				filters: {
+					'root_type': 'Liability',
 					'account_type': 'Payable',
 					'company': locals[cdt][cdn].company,
 					"is_group": 0


### PR DESCRIPTION
Reference PR: #35609

- [x] Adjust advance at a date later than the posting date or adjustment date

eg: Old invoice here is adjusted on 12th Sept, but Invoice after posting date of Payment Entry is on Invoice Date:
![image](https://github.com/frappe/erpnext/assets/10496564/3e54af90-f2ff-44fb-a106-8cb725b9ae3e)


- [x] Avoid Duplicate entry on advance selection (utils.py)

earlier, if there was already available reference in payment entry, and a new reference was added, it used to recreate GL entry for old reference

- [x] Support adjustment of Journal Entry from references
- [x] Move `make_advance_gl_entries` to `make_gl_entries` to show the correct preview of entries

![image](https://github.com/frappe/erpnext/assets/10496564/896457bc-d945-4807-8568-1ed50549259d)

- [x] Better `set_query` for original accounts