### PR TITLE
fix: allow to select parent warehouse in the website item

### DIFF
--- a/erpnext/e_commerce/doctype/website_item/test_website_item.py
+++ b/erpnext/e_commerce/doctype/website_item/test_website_item.py
@@ -312,7 +312,7 @@ class TestWebsiteItem(unittest.TestCase):
 		# check if stock details are fetched and item not in stock with warehouse set
 		data = get_product_info_for_website(item_code, skip_quotation_creation=True)
 		self.assertFalse(bool(data.product_info["in_stock"]))
-		self.assertEqual(data.product_info["stock_qty"][0][0], 0)
+		self.assertEqual(data.product_info["stock_qty"], 0)
 
 		# disable show stock availability
 		setup_e_commerce_settings({"show_stock_availability": 0})
@@ -355,7 +355,7 @@ class TestWebsiteItem(unittest.TestCase):
 		# check if stock details are fetched and item is in stock with warehouse set
 		data = get_product_info_for_website(item_code, skip_quotation_creation=True)
 		self.assertTrue(bool(data.product_info["in_stock"]))
-		self.assertEqual(data.product_info["stock_qty"][0][0], 2)
+		self.assertEqual(data.product_info["stock_qty"], 2)
 
 		# unset warehouse
 		frappe.db.set_value("Website Item", {"item_code": item_code}, "website_warehouse", "")
@@ -364,7 +364,7 @@ class TestWebsiteItem(unittest.TestCase):
 		# (even though it has stock in some warehouse)
 		data = get_product_info_for_website(item_code, skip_quotation_creation=True)
 		self.assertFalse(bool(data.product_info["in_stock"]))
-		self.assertFalse(bool(data.product_info["stock_qty"]))
+		self.assertFalse(data.product_info["stock_qty"])
 
 		# disable show stock availability
 		setup_e_commerce_settings({"show_stock_availability": 0})

--- a/erpnext/e_commerce/doctype/website_item/website_item.js
+++ b/erpnext/e_commerce/doctype/website_item/website_item.js
@@ -5,12 +5,6 @@ frappe.ui.form.on('Website Item', {
 	onload: (frm) => {
 		// should never check Private
 		frm.fields_dict["website_image"].df.is_private = 0;
-
-		frm.set_query("website_warehouse", () => {
-			return {
-				filters: {"is_group": 0}
-			};
-		});
 	},
 
 	refresh: (frm) => {

--- a/erpnext/e_commerce/doctype/website_item/website_item.json
+++ b/erpnext/e_commerce/doctype/website_item/website_item.json
@@ -135,7 +135,7 @@
    "fieldtype": "Column Break"
   },
   {
-   "description": "Show Stock availability based on this warehouse.",
+   "description": "Show Stock availability based on this warehouse. If the parent warehouse is selected, then the system will display the consolidated available quantity of all child warehouses.",
    "fieldname": "website_warehouse",
    "fieldtype": "Link",
    "ignore_user_permissions": 1,
@@ -348,7 +348,7 @@
  "index_web_pages_for_search": 1,
  "links": [],
  "make_attachments_public": 1,
- "modified": "2022-09-30 04:01:52.090732",
+ "modified": "2023-09-12 14:19:22.822689",
  "modified_by": "Administrator",
  "module": "E-commerce",
  "name": "Website Item",

--- a/erpnext/e_commerce/product_data_engine/query.py
+++ b/erpnext/e_commerce/product_data_engine/query.py
@@ -259,6 +259,10 @@ class ProductQuery:
 			)
 
 	def get_stock_availability(self, item):
+		from erpnext.templates.pages.wishlist import (
+			get_stock_availability as get_stock_availability_from_template,
+		)
+
 		"""Modify item object and add stock details."""
 		item.in_stock = False
 		warehouse = item.get("website_warehouse")
@@ -274,11 +278,7 @@ class ProductQuery:
 			else:
 				item.in_stock = True
 		elif warehouse:
-			# stock item and has warehouse
-			actual_qty = frappe.db.get_value(
-				"Bin", {"item_code": item.item_code, "warehouse": item.get("website_warehouse")}, "actual_qty"
-			)
-			item.in_stock = bool(flt(actual_qty))
+			item.in_stock = get_stock_availability_from_template(item.item_code, warehouse)
 
 	def get_cart_items(self):
 		customer = get_customer(silent=True)

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -1292,6 +1292,9 @@ def get_default_bom(item_code=None):
 
 @frappe.whitelist()
 def get_valuation_rate(item_code, company, warehouse=None):
+	if frappe.get_cached_value("Warehouse", warehouse, "is_group"):
+		return {"valuation_rate": 0.0}
+
 	item = get_item_defaults(item_code, company)
 	item_group = get_item_group_defaults(item_code, company)
 	brand = get_brand_defaults(item_code, company)

--- a/erpnext/templates/generators/item/item_add_to_cart.html
+++ b/erpnext/templates/generators/item/item_add_to_cart.html
@@ -49,7 +49,7 @@
 				<span class="in-green has-stock">
 					{{ _('In stock') }}
 					{% if product_info.show_stock_qty and product_info.stock_qty %}
-						({{ product_info.stock_qty[0][0] }})
+						({{ product_info.stock_qty }})
 					{% endif %}
 				</span>
 			{% endif %}

--- a/erpnext/templates/pages/wishlist.py
+++ b/erpnext/templates/pages/wishlist.py
@@ -25,9 +25,19 @@ def get_context(context):
 
 
 def get_stock_availability(item_code, warehouse):
-	stock_qty = frappe.utils.flt(
-		frappe.db.get_value("Bin", {"item_code": item_code, "warehouse": warehouse}, "actual_qty")
-	)
+	from erpnext.stock.doctype.warehouse.warehouse import get_child_warehouses
+
+	if warehouse and frappe.get_cached_value("Warehouse", warehouse, "is_group") == 1:
+		warehouses = get_child_warehouses(warehouse)
+	else:
+		warehouses = [warehouse] if warehouse else []
+
+	stock_qty = 0.0
+	for warehouse in warehouses:
+		stock_qty += frappe.utils.flt(
+			frappe.db.get_value("Bin", {"item_code": item_code, "warehouse": warehouse}, "actual_qty")
+		)
+
 	return bool(stock_qty)
 
 


### PR DESCRIPTION
Allow to select the Group Warehouse in the Website Item. If the user has selected the group warehouse in the website item, then the system will display the consolidated available quantity of all child warehouses in the website.

<img width="937" alt="Screenshot 2023-09-12 at 3 54 22 PM" src="https://github.com/frappe/erpnext/assets/8780500/cb51c987-f840-4bf9-9e6d-851af02f9971">


Fixed https://github.com/frappe/erpnext/issues/35885