### PR TITLE
fix: Packed item incorrectly picks expired price on Sales Order

### DIFF
--- a/erpnext/stock/doctype/packed_item/packed_item.py
+++ b/erpnext/stock/doctype/packed_item/packed_item.py
@@ -207,6 +207,9 @@ def update_packed_item_price_data(pi_row, item_data, doc):
 			"conversion_rate": doc.get("conversion_rate"),
 		}
 	)
+	if not row_data.get("transaction_date"):
+		row_data.update({"transaction_date": doc.get("transaction_date")})
+
 	rate = get_price_list_rate(row_data, item_doc).get("price_list_rate")
 
 	pi_row.rate = rate or item_data.get("valuation_rate") or 0.0


### PR DESCRIPTION
1. Enable `Calculate Product Bundle Price based on Child Items' Rates` in Selling Settings
2. Add an expired Item Price(`valid_upto` lesser than Sales Order transaction date) for a child item of the product bundle
3. Make a Sales Order with the product bundle.

Expired Item price should not be picked.