### PR TITLE
fix: validate duplicate serial no in DN

### DIFF
--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -138,6 +138,7 @@ class DeliveryNote(SellingController):
 		self.validate_uom_is_integer("stock_uom", "stock_qty")
 		self.validate_uom_is_integer("uom", "qty")
 		self.validate_with_previous_doc()
+		self.validate_duplicate_serial_nos()
 
 		from erpnext.stock.doctype.packed_item.packed_item import make_packing_list
 
@@ -411,6 +412,21 @@ class DeliveryNote(SellingController):
 			filters={"new_item_code": ["in", items_list]},
 			pluck="name",
 		)
+
+	def validate_duplicate_serial_nos(self):
+		serial_nos = []
+		for item in self.items:
+			if not item.serial_no:
+				continue
+
+			for serial_no in item.serial_no.split("\n"):
+				if serial_no in serial_nos:
+					frappe.throw(
+						_("Row #{0}: Serial No {1} is already selected.").format(item.idx, serial_no),
+						title=_("Duplicate Serial No"),
+					)
+				else:
+					serial_nos.append(serial_no)
 
 
 def update_billed_amount_based_on_so(so_detail, update_modified=True):


### PR DESCRIPTION
**Source / Ref:** 1334

**Problem:** The user is able to select duplicate Serial No in Delivery Note although on submit the system throws `Serial No ABCD00001 does not belong to Warehouse Stores - V14H`.

**Before:**

![image](https://github.com/frappe/erpnext/assets/63660334/0e3fc67e-9973-4e88-9af6-4c6da960c02d)

**After:**

![image](https://github.com/frappe/erpnext/assets/63660334/f97e9a19-cde8-41ef-8659-02b2b9021f46)
