### PR TITLE
fix: asset validation misfire on debit notes

### DIFF
--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -190,10 +190,13 @@ class BuyingController(SubcontractingController):
 		purchase_doc_field = (
 			"purchase_receipt" if self.doctype == "Purchase Receipt" else "purchase_invoice"
 		)
-		not_cancelled_asset = [
-			d.name
-			for d in frappe.db.get_all("Asset", {purchase_doc_field: self.return_against, "docstatus": 1})
-		]
+		not_cancelled_asset = []
+		if self.return_against:
+			not_cancelled_asset = [
+				d.name
+				for d in frappe.db.get_all("Asset", {purchase_doc_field: self.return_against, "docstatus": 1})
+			]
+
 		if self.is_return and len(not_cancelled_asset):
 			frappe.throw(
 				_(


### PR DESCRIPTION
1. Make Purchase Invoice and Cancel it.
2. Amend it. Enable `Is Return(Debit Note)` and save

```
request.js:457 Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 95, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 54, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 47, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 85, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1622, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/desk/form/save.py", line 28, in savedocs
    doc.save()
  File "apps/frappe/frappe/model/document.py", line 307, in save
    return self._save(*args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 329, in _save
    return self.insert()
  File "apps/frappe/frappe/model/document.py", line 261, in insert
    self.run_before_save_methods()
  File "apps/frappe/frappe/model/document.py", line 1053, in run_before_save_methods
    self.run_method("validate")
  File "apps/frappe/frappe/model/document.py", line 917, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1279, in composer
    return composed(self, method, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1261, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "apps/frappe/frappe/model/document.py", line 914, in fn
    return method_object(*args, **kwargs)
  File "apps/erpnext/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py", line 91, in validate
    super(PurchaseInvoice, self).validate()
  File "apps/erpnext/erpnext/controllers/buying_controller.py", line 45, in validate
    self.validate_asset_return()
  File "apps/erpnext/erpnext/controllers/buying_controller.py", line 170, in validate_asset_return
    frappe.throw(
  File "apps/frappe/frappe/__init__.py", line 534, in throw
    msgprint(
  File "apps/frappe/frappe/__init__.py", line 502, in msgprint
    _raise_exception()
  File "apps/frappe/frappe/__init__.py", line 451, in _raise_exception
    raise raise_exception(msg)
frappe.exceptions.ValidationError:  has submitted assets linked to it. You need to cancel the assets to create purchase return.
```