### PR TITLE
fix: Budget validation while saving the document

### DIFF
--- a/erpnext/accounts/doctype/budget/budget.py
+++ b/erpnext/accounts/doctype/budget/budget.py
@@ -115,7 +115,7 @@ def validate_expense_against_budget(args, expense_amount=0):
 		frappe.flags.exception_approver_role = frappe.get_cached_value(
 			"Company", args.get("company"), "exception_budget_approver_role"
 		)
-
+	# breakpoint()
 	if not args.account:
 		args.account = args.get("expense_account")
 
@@ -198,7 +198,6 @@ def validate_budget_records(args, budget_records, expense_amount):
 			yearly_action, monthly_action = get_actions(args, budget)
 
 			if yearly_action in ("Stop", "Warn"):
-				breakpoint()
 
 				compare_expense_with_budget(
 					args, flt(budget.budget_amount), _("Annual"), yearly_action, budget.budget_against, amount
@@ -219,6 +218,7 @@ def validate_budget_records(args, budget_records, expense_amount):
 def compare_expense_with_budget(args, budget_amount, action_for, action, budget_against, amount=0):
 	actual_expense = get_actual_expense(args)
 	total_expense = actual_expense + amount
+	# breakpoint()
 
 	if total_expense > budget_amount:
 		if actual_expense > budget_amount:
@@ -269,14 +269,16 @@ def get_actions(args, budget):
 
 def get_amount(args, budget):
 	amount = 0
-
+	# breakpoint()
 	if args.get("doctype") == "Material Request" and budget.for_material_request:
 		amount = (
 			get_requested_amount(args, budget) + get_ordered_amount(args, budget) + get_actual_expense(args)
 		)
 
 	elif args.get("doctype") == "Purchase Order" and budget.for_purchase_order:
-		amount = get_ordered_amount(args, budget) + get_actual_expense(args)
+		# amount = get_ordered_amount(args, budget) + get_actual_expense(args)
+		# above to include both then below we add it again so its included twice
+		amount = args.get("amount")
 
 	elif args.get("doctype") == "Purchase Invoice":
 		amount = args.get("amount")

--- a/erpnext/accounts/doctype/budget/budget.py
+++ b/erpnext/accounts/doctype/budget/budget.py
@@ -109,13 +109,12 @@ class Budget(Document):
 
 def validate_expense_against_budget(args, expense_amount=0):
 	args = frappe._dict(args)
-
 	if args.get("company") and not args.fiscal_year:
 		args.fiscal_year = get_fiscal_year(args.get("posting_date"), company=args.get("company"))[0]
 		frappe.flags.exception_approver_role = frappe.get_cached_value(
 			"Company", args.get("company"), "exception_budget_approver_role"
 		)
-	# breakpoint()
+
 	if not args.account:
 		args.account = args.get("expense_account")
 
@@ -218,7 +217,6 @@ def validate_budget_records(args, budget_records, expense_amount):
 def compare_expense_with_budget(args, budget_amount, action_for, action, budget_against, amount=0):
 	actual_expense = get_actual_expense(args)
 	total_expense = actual_expense + amount
-	# breakpoint()
 
 	if total_expense > budget_amount:
 		if actual_expense > budget_amount:
@@ -269,11 +267,11 @@ def get_actions(args, budget):
 
 def get_amount(args, budget):
 	amount = 0
-	# breakpoint()
 	if args.get("doctype") == "Material Request" and budget.for_material_request:
 		amount = (
 			get_requested_amount(args, budget) + get_ordered_amount(args, budget) + get_actual_expense(args)
 		)
+		amount = args.get("amount")
 
 	elif args.get("doctype") == "Purchase Order" and budget.for_purchase_order:
 		# amount = get_ordered_amount(args, budget) + get_actual_expense(args)

--- a/erpnext/accounts/doctype/budget/budget.py
+++ b/erpnext/accounts/doctype/budget/budget.py
@@ -276,6 +276,9 @@ def get_amount(args, budget):
 	elif args.get("doctype") == "Purchase Order" and budget.for_purchase_order:
 		amount = get_ordered_amount(args, budget) + get_actual_expense(args)
 
+	elif args.get("doctype") == "Purchase Invoice":
+		amount = args.get("amount")
+
 	return amount
 
 

--- a/erpnext/accounts/doctype/budget/budget.py
+++ b/erpnext/accounts/doctype/budget/budget.py
@@ -198,6 +198,8 @@ def validate_budget_records(args, budget_records, expense_amount):
 			yearly_action, monthly_action = get_actions(args, budget)
 
 			if yearly_action in ("Stop", "Warn"):
+				breakpoint()
+
 				compare_expense_with_budget(
 					args, flt(budget.budget_amount), _("Annual"), yearly_action, budget.budget_against, amount
 				)

--- a/erpnext/accounts/doctype/budget/test_budget.py
+++ b/erpnext/accounts/doctype/budget/test_budget.py
@@ -143,10 +143,11 @@ class TestBudget(unittest.TestCase):
 		)
 		frappe.db.set_value("Budget", budget.name, "fiscal_year", fiscal_year)
 
-		po = create_purchase_order(transaction_date=nowdate(), do_not_submit=True)
+		po = create_purchase_order(transaction_date=nowdate(), do_not_submit=True, do_not_save=True)
 
 		po.set_missing_values()
 
+		self.assertRaises(BudgetError, po.save)
 		self.assertRaises(BudgetError, po.submit)
 
 		budget.load_from_db()

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -86,7 +86,6 @@ class JournalEntry(AccountsController):
 		self.update_asset_value()
 		self.update_inter_company_jv()
 		self.update_invoice_discounting()
-		self.validate_budget()
 
 	def on_cancel(self):
 		# References for this Journal are removed on the `on_cancel` event in accounts_controller

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -86,6 +86,7 @@ class JournalEntry(AccountsController):
 		self.update_asset_value()
 		self.update_inter_company_jv()
 		self.update_invoice_discounting()
+		self.validate_budget()
 
 	def on_cancel(self):
 		# References for this Journal are removed on the `on_cancel` event in accounts_controller

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -78,6 +78,7 @@ class PurchaseInvoice(BuyingController):
 	def before_save(self):
 		if not self.on_hold:
 			self.release_date = ""
+		self.validate_budget()
 
 	def invoice_is_blocked(self):
 		return self.on_hold and (not self.release_date or self.release_date > getdate(nowdate()))

--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -53,9 +53,11 @@ class PurchaseOrder(BuyingController):
 		supplier_tds = frappe.db.get_value("Supplier", self.supplier, "tax_withholding_category")
 		self.set_onload("supplier_tds", supplier_tds)
 
+	# def before_save(self):
+	# 	self.validate_budget()
+
 	def validate(self):
 		super(PurchaseOrder, self).validate()
-
 		self.set_status()
 
 		# apply tax withholding only if checked and applicable

--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -53,8 +53,8 @@ class PurchaseOrder(BuyingController):
 		supplier_tds = frappe.db.get_value("Supplier", self.supplier, "tax_withholding_category")
 		self.set_onload("supplier_tds", supplier_tds)
 
-	# def before_save(self):
-	# 	self.validate_budget()
+	def before_save(self):
+		self.validate_budget()
 
 	def validate(self):
 		super(PurchaseOrder, self).validate()

--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -660,20 +660,20 @@ class BuyingController(SubcontractingController):
 			self.update_fixed_asset(field, delete_asset=True)
 
 	def validate_budget(self):
-		if self.docstatus == 1:
-			for data in self.get("items"):
-				args = data.as_dict()
-				args.update(
-					{
-						"doctype": self.doctype,
-						"company": self.company,
-						"posting_date": (
-							self.schedule_date if self.doctype == "Material Request" else self.transaction_date
-						),
-					}
-				)
-
-				validate_expense_against_budget(args)
+		for data in self.get("items"):
+			args = data.as_dict()
+			args.update(
+				{
+					"doctype": self.doctype,
+					"company": self.company,
+					"posting_date": (
+						self.schedule_date
+						if self.doctype == "Material Request"
+						else (self.get("transaction_date") or self.get("posting_date"))
+					),
+				}
+			)
+			validate_expense_against_budget(args)
 
 	def process_fixed_asset(self):
 		if self.doctype == "Purchase Invoice" and not self.update_stock:

--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -125,6 +125,8 @@ class MaterialRequest(BuyingController):
 
 	def before_save(self):
 		self.set_status(update=True)
+		if self.material_request_type == "Purchase":
+			self.validate_budget()
 
 	def before_submit(self):
 		self.set_status(update=True)


### PR DESCRIPTION
Currently budget is only validated while submitting PI/PO/MR doctype.

Now while saving the above DocTypes we will validate the budget.  Soft intimation at the time of saving the document.


**Another Issue:**
While calculating the budget in PO.
The calculated amount is incorrect. So corrected that as well
