### PR TITLE
fix: don't set from warehouse for purchase material request

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.js
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.js
@@ -476,6 +476,15 @@ frappe.ui.form.on("Material Request Plan Item", {
 				}
 			})
 		}
+	},
+
+	material_request_type(frm, cdt, cdn) {
+		let row = locals[cdt][cdn];
+
+		if (row.from_warehouse &&
+			row.material_request_type !== "Material Transfer") {
+				frappe.model.set_value(cdt, cdn, 'from_warehouse', '');
+		}
 	}
 });
 

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -40,6 +40,12 @@ class ProductionPlan(Document):
 		self._rename_temporary_references()
 		validate_uom_is_integer(self, "stock_uom", "planned_qty")
 		self.validate_sales_orders()
+		self.validate_material_request_type()
+
+	def validate_material_request_type(self):
+		for row in self.get("mr_items"):
+			if row.from_warehouse and row.material_request_type != "Material Transfer":
+				row.from_warehouse = ""
 
 	@frappe.whitelist()
 	def validate_sales_orders(self, sales_order=None):
@@ -749,7 +755,9 @@ class ProductionPlan(Document):
 				"items",
 				{
 					"item_code": item.item_code,
-					"from_warehouse": item.from_warehouse,
+					"from_warehouse": item.from_warehouse
+					if material_request_type == "Material Transfer"
+					else None,
 					"qty": item.quantity,
 					"schedule_date": schedule_date,
 					"warehouse": item.warehouse,


### PR DESCRIPTION
1. Create Production Plan and get Raw Materials for Transfer
2. System will add raw materials with From Warehouse (For Material Transfer)
3. Change the Material Request type from Material Transfer to Purchase 
4. Save and Submit the Production Plan
5. Create the MR and PO
6. You will notice that on the PO from warehouse has set even though it's not an Internal Transfer entry. 
7. After point 3, system should remove the From Warehouse for the Material Request type Purchase.