### PR TITLE
fix: after applying coupon code, field in_words not updated

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -162,6 +162,9 @@ class AccountsController(TransactionBase):
 		self.disable_tax_included_prices_for_internal_transfer()
 		self.set_incoming_rate()
 
+		if self.doctype != "Material Request" and not self.ignore_pricing_rule:
+			apply_pricing_rule_on_transaction(self)
+
 		if self.meta.get_field("currency"):
 			self.calculate_taxes_and_totals()
 
@@ -204,9 +207,6 @@ class AccountsController(TransactionBase):
 		with temporary_flag("company", self.company):
 			validate_regional(self)
 			validate_einvoice_fields(self)
-
-		if self.doctype != "Material Request" and not self.ignore_pricing_rule:
-			apply_pricing_rule_on_transaction(self)
 
 	def before_cancel(self):
 		validate_einvoice_fields(self)

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -162,9 +162,6 @@ class AccountsController(TransactionBase):
 		self.disable_tax_included_prices_for_internal_transfer()
 		self.set_incoming_rate()
 
-		if self.doctype != "Material Request" and not self.ignore_pricing_rule:
-			apply_pricing_rule_on_transaction(self)
-
 		if self.meta.get_field("currency"):
 			self.calculate_taxes_and_totals()
 
@@ -172,7 +169,6 @@ class AccountsController(TransactionBase):
 				self.validate_value("base_grand_total", ">=", 0)
 
 			validate_return(self)
-			self.set_total_in_words()
 
 		self.validate_all_documents_schedule()
 
@@ -207,6 +203,11 @@ class AccountsController(TransactionBase):
 		with temporary_flag("company", self.company):
 			validate_regional(self)
 			validate_einvoice_fields(self)
+
+		if self.doctype != "Material Request" and not self.ignore_pricing_rule:
+			apply_pricing_rule_on_transaction(self)
+
+		self.set_total_in_words()
 
 	def before_cancel(self):
 		validate_einvoice_fields(self)


### PR DESCRIPTION
**Issue:**

After applying coupon code in Sales Order, the field "in_words" shows the value for previous amount instead of the after discount price(in words).

<img width="1086" alt="Screenshot 2023-09-18 at 3 58 46 PM" src="https://github.com/frappe/erpnext/assets/65544983/2c142875-11db-4243-91a1-4fcf54c9abc4">


**Reason:**
We were applying pricing rule after setting the "in_words" field.

**Result:**
<img width="1070" alt="Screenshot 2023-09-18 at 4 00 44 PM" src="https://github.com/frappe/erpnext/assets/65544983/f6545310-7679-4461-957f-b092d57dfed6">


