### PR TITLE
fix: fetch logic for repay_from_salary in loan_repayment [v14]

### DIFF
--- a/erpnext/loan_management/doctype/loan_repayment/loan_repayment.js
+++ b/erpnext/loan_management/doctype/loan_repayment/loan_repayment.js
@@ -9,7 +9,9 @@ frappe.ui.form.on('Loan Repayment', {
 	// },
 
 	setup: function(frm) {
-		frm.add_fetch("against_loan", "repay_from_salary", "repay_from_salary");
+		if (frappe.meta.has_field("Loan Repayment", "repay_from_salary")) {
+			frm.add_fetch("against_loan", "repay_from_salary", "repay_from_salary");
+		}
 	},
 
 	onload: function(frm) {

--- a/erpnext/loan_management/doctype/loan_repayment/loan_repayment.js
+++ b/erpnext/loan_management/doctype/loan_repayment/loan_repayment.js
@@ -6,7 +6,12 @@
 frappe.ui.form.on('Loan Repayment', {
 	// refresh: function(frm) {
 
-	// }
+	// },
+
+	setup: function(frm) {
+		frm.add_fetch("against_loan", "repay_from_salary", "repay_from_salary");
+	},
+
 	onload: function(frm) {
 		frm.set_query('against_loan', function() {
 			return {

--- a/erpnext/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/erpnext/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -80,6 +80,12 @@ class LoanRepayment(AccountsController):
 		if amounts.get("due_date"):
 			self.due_date = amounts.get("due_date")
 
+		if hasattr(self, "repay_from_salary") and hasattr(self, "payroll_payable_account"):
+			if self.repay_from_salary and not self.payroll_payable_account:
+				frappe.throw(_("Please set Payroll Payable Account in Loan Repayment"))
+			elif not self.repay_from_salary and self.payroll_payable_account:
+				self.repay_from_salary = 1
+
 	def check_future_entries(self):
 		future_repayment_date = frappe.db.get_value(
 			"Loan Repayment",


### PR DESCRIPTION
Currently checkboxes with `fetch_from` and `fetch_if_empty` set (like `repay_from_salary` check in `loan_repayment` doctype) don't work in the framework. We [tried](https://github.com/frappe/frappe/pull/22442) to fix it in the framework but we haven't come up with a solution which won't break lots of custom code. This PR fixes the issue until we come up with a long-term fix.