### PR TITLE
fix: POS opening Issue if Product Bundle is available

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -683,7 +683,7 @@ def get_bundle_availability(bundle_item_code, warehouse):
 		item_pos_reserved_qty = get_pos_reserved_qty(item.item_code, warehouse)
 		available_qty = item_bin_qty - item_pos_reserved_qty
 
-		max_available_bundles = available_qty / item.stock_qty
+		max_available_bundles = available_qty / item.qty
 		if bundle_bin_qty > max_available_bundles and frappe.get_value(
 			"Item", item.item_code, "is_stock_item"
 		):


### PR DESCRIPTION
While opening POS, we get the following error, if there is any Product Bundle Item in our inventory.
<img width="1340" alt="Screenshot 2023-09-18 at 5 22 43 PM" src="https://github.com/frappe/erpnext/assets/65544983/71b043b4-8d25-4835-ab9b-6cfdf0ce22f3">

**Reason**
We were using wrong variable name in v14 to access the quantity. 
"item.stock_qty" we were using

**Solution**
item.qty should be used.
