### PR TITLE
fix: dunning fees and interest updated when duning_type is changed

### DIFF
--- a/erpnext/accounts/doctype/dunning/dunning.json
+++ b/erpnext/accounts/doctype/dunning/dunning.json
@@ -112,7 +112,6 @@
   {
    "default": "0",
    "fetch_from": "dunning_type.dunning_fee",
-   "fetch_if_empty": 1,
    "fieldname": "dunning_fee",
    "fieldtype": "Currency",
    "label": "Dunning Fee",
@@ -172,7 +171,6 @@
   {
    "default": "0",
    "fetch_from": "dunning_type.rate_of_interest",
-   "fetch_if_empty": 1,
    "fieldname": "rate_of_interest",
    "fieldtype": "Float",
    "label": "Rate of Interest (%) Yearly"
@@ -381,7 +379,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2023-06-15 15:46:53.865712",
+ "modified": "2023-09-19 12:52:39.769625",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Dunning",


### PR DESCRIPTION
**Issue:**
Dunning fee and dunning rate of interest is not updated when dunning type is changed.

**Reason:**
dunning_fees and rate_of_interest field's "Fetch only if value is not set" was set to "1" in Dunning Doctype.

**Explanation:**
Once we add a dunning_type, "rate_of_interest" and "dunning_fee" is set.

<img width="804" alt="image" src="https://github.com/frappe/erpnext/assets/65544983/6816c6cf-144b-4742-9680-db85227dcd43">



Now if we change the dunning type, these value will not be changed because 
<img width="809" alt="image" src="https://github.com/frappe/erpnext/assets/65544983/a8389ff4-e303-4a88-aa90-551a57cab8e0">
<img width="1297" alt="Screenshot 2023-09-19 at 7 20 35 PM" src="https://github.com/frappe/erpnext/assets/65544983/f7063300-7606-40f6-9913-2961509f8443">




the below field is ticked.


<img width="1680" alt="Screenshot 2023-09-19 at 7 14 48 PM" src="https://github.com/frappe/erpnext/assets/65544983/6a606977-b445-4e42-92ec-834a2ebee531">



Now if we untick it, then the response which we get, will be applied to the fields

**API Response:**
<img width="322" alt="image" src="https://github.com/frappe/erpnext/assets/65544983/57c33fae-8133-4071-9127-ea9d839bb0ec">



**Result:**
<img width="872" alt="image" src="https://github.com/frappe/erpnext/assets/65544983/e7c282d8-fed1-4cd4-9840-f6d310ec0ea4">
