### PR TITLE
fix: set customer currency in pos_invoice if exists

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -414,7 +414,7 @@ class POSInvoice(SalesInvoice):
 				selling_price_list = (
 					customer_price_list or customer_group_price_list or profile.get("selling_price_list")
 				)
-				if customer_currency != profile.get("currency"):
+				if customer_currency and customer_currency != profile.get("currency"):
 					self.set("currency", customer_currency)
 
 			else:


### PR DESCRIPTION
if currency exists in the profile and customer currency doesn't exist still it will update currency to None, so update customer currency only if exists
