### PR TITLE
fix: Payment Entry filters not working in report view

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry_list.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry_list.js
@@ -1,6 +1,6 @@
 frappe.listview_settings['Payment Entry'] = {
 
-	onload: function(listview) {
+	refresh: function(listview) {
 		if (listview.page.fields_dict.party_type) {
 			listview.page.fields_dict.party_type.get_query = function() {
 				return {


### PR DESCRIPTION
**Issue:**
In payment entry, the filters are applied on the fields when we are in list view, but those filters are not applied when we select report view. 

**Filters working for Report View:**
<img width="1290" alt="Screenshot 2023-09-21 at 2 30 56 PM" src="https://github.com/frappe/erpnext/assets/65544983/8b9e71fd-bf80-4c40-8f39-03d13da1fff3">


**Filters not working in Report View:**

<img width="1372" alt="Screenshot 2023-09-21 at 2 32 18 PM" src="https://github.com/frappe/erpnext/assets/65544983/2ae1ec8c-74fe-4b7a-9657-5753d8c09748">

**Reason:**

In payment_entry_list.js file we are using "onload" method instead of "refresh".
