### PR TITLE
feat: Customer and Supplier - Primary Address and Contact on the same column as new address and contact

### DIFF
--- a/erpnext/buying/doctype/supplier/supplier.json
+++ b/erpnext/buying/doctype/supplier/supplier.json
@@ -45,12 +45,13 @@
   "column_break1",
   "contact_html",
   "primary_address_and_contact_detail_section",
-  "supplier_primary_contact",
-  "mobile_no",
-  "email_id",
   "column_break_44",
   "supplier_primary_address",
   "primary_address",
+  "column_break_mglr",
+  "supplier_primary_contact",
+  "mobile_no",
+  "email_id",
   "accounting_tab",
   "payment_terms",
   "default_accounts_section",
@@ -469,6 +470,10 @@
   {
    "fieldname": "column_break_1mqv",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_mglr",
+   "fieldtype": "Column Break"
   }
  ],
  "icon": "fa fa-user",
@@ -481,7 +486,7 @@
    "link_fieldname": "party"
   }
  ],
- "modified": "2023-06-26 14:20:00.961554",
+ "modified": "2023-09-21 12:24:20.398889",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Supplier",

--- a/erpnext/selling/doctype/customer/customer.json
+++ b/erpnext/selling/doctype/customer/customer.json
@@ -48,12 +48,13 @@
   "column_break1",
   "contact_html",
   "primary_address_and_contact_detail",
-  "customer_primary_contact",
-  "mobile_no",
-  "email_id",
   "column_break_26",
   "customer_primary_address",
   "primary_address",
+  "column_break_nwor",
+  "customer_primary_contact",
+  "mobile_no",
+  "email_id",
   "tax_tab",
   "taxation_section",
   "tax_id",
@@ -339,12 +340,12 @@
    "label": "Default Accounts"
   },
   {
-    "description": "Mention if non-standard Receivable account",
-    "fieldname": "accounts",
-    "fieldtype": "Table",
-    "label": "Accounts",
-    "options": "Party Account"
-   },
+   "description": "Mention if non-standard Receivable account",
+   "fieldname": "accounts",
+   "fieldtype": "Table",
+   "label": "Accounts",
+   "options": "Party Account"
+  },
   {
    "fieldname": "credit_limit_section",
    "fieldtype": "Section Break",
@@ -568,6 +569,10 @@
    "fieldtype": "Table",
    "label": "Customer Portal Users",
    "options": "Portal User"
+  },
+  {
+   "fieldname": "column_break_nwor",
+   "fieldtype": "Column Break"
   }
  ],
  "icon": "fa fa-user",
@@ -581,7 +586,7 @@
    "link_fieldname": "party"
   }
  ],
- "modified": "2023-06-22 13:21:10.678382",
+ "modified": "2023-09-21 12:23:20.706020",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Customer",


### PR DESCRIPTION

> Please provide enough information so that others can review your pull request:

On Contact & Adress tab on Customer and Supplier
In section "Address and Contact"  : the first column is for address and the second for contact
but 
in section "Primary Address and Contact" : the first column is for contact and the second is for address
It's confusing that the same kind of information aren't place in the same column on the same page

> Explain the **details** for making this change. What existing problem does the pull request solve?

Use Update DocType in developper mode (with this awesome new feature of drag and drop form) to switch the two panels in "Primary Address and Contact" section

> Screenshots/GIFs

Before
![image](https://github.com/frappe/erpnext/assets/1050053/6ec9de3a-95f2-412d-89fe-863823060d90)

After
![image](https://github.com/frappe/erpnext/assets/1050053/f2bbcc37-c79a-480d-9a0c-9ffb71863d51)

> no-docs

