### PR TITLE
refactor: button in Payment Entry to filter associated Journals

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -154,6 +154,12 @@ frappe.ui.form.on('Payment Entry', {
 		frm.events.set_dynamic_labels(frm);
 		frm.events.show_general_ledger(frm);
 		erpnext.accounts.ledger_preview.show_accounting_ledger_preview(frm);
+		if(frm.doc.references.find((elem) => {return elem.exchange_gain_loss != 0})) {
+			frm.add_custom_button(__("View Exchange Gain/Loss Journals"), function() {
+				frappe.set_route("List", "Journal Entry", {"voucher_type": "Exchange Gain Or Loss", "reference_name": frm.doc.name});
+			}, __('Actions'));
+
+		}
 		erpnext.accounts.unreconcile_payments.add_unreconcile_btn(frm);
 	},
 

--- a/erpnext/public/js/utils/unreconcile.js
+++ b/erpnext/public/js/utils/unreconcile.js
@@ -17,7 +17,7 @@ erpnext.accounts.unreconcile_payments = {
 				},
 				callback: function(r) {
 					if (r.message) {
-						frm.add_custom_button(__("Un-Reconcile"), function() {
+						frm.add_custom_button(__("UnReconcile"), function() {
 							erpnext.accounts.unreconcile_payments.build_unreconcile_dialog(frm);
 						}, __('Actions'));
 					}
@@ -87,11 +87,11 @@ erpnext.accounts.unreconcile_payments = {
 						unreconcile_dialog_fields[0].get_data = function(){ return r.message};
 
 						let d = new frappe.ui.Dialog({
-							title: 'Un-Reconcile Allocations',
+							title: 'UnReconcile Allocations',
 							fields: unreconcile_dialog_fields,
 							size: 'large',
 							cannot_add_rows: true,
-							primary_action_label: 'Un-Reconcile',
+							primary_action_label: 'UnReconcile',
 							primary_action(values) {
 
 								let selected_allocations = values.allocations.filter(x=>x.__checked);


### PR DESCRIPTION
Faciliate filtering on associated Exc Gain/Loss journals of a Payment Entry through UI.

<img width="1440" alt="Screenshot 2023-09-22 at 11 32 16 AM" src="https://github.com/frappe/erpnext/assets/3272205/461b4dc7-3d6f-49f8-bb17-05b2ba44dabe">
<img width="1440" alt="Screenshot 2023-09-22 at 11 32 34 AM" src="https://github.com/frappe/erpnext/assets/3272205/a6a05744-ad22-45f7-bac3-593a7065da78">
