### PR TITLE
refactor: ignore PLE's on PCV cancellation

### DIFF
--- a/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
+++ b/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
@@ -33,7 +33,7 @@ class PeriodClosingVoucher(AccountsController):
 	def on_cancel(self):
 		self.validate_future_closing_vouchers()
 		self.db_set("gle_processing_status", "In Progress")
-		self.ignore_linked_doctypes = ("GL Entry", "Stock Ledger Entry")
+		self.ignore_linked_doctypes = ("GL Entry", "Stock Ledger Entry", "Payment Ledger Entry")
 		gle_count = frappe.db.count(
 			"GL Entry",
 			{"voucher_type": "Period Closing Voucher", "voucher_no": self.name, "is_cancelled": 0},


### PR DESCRIPTION
On rare scenarios, Users who have `Receivable` or `Payable` accounts under the Income/Expense head in Chart of Accounts face issues while cancelling Period Closing Vouchers. 

<img width="579" alt="Screenshot 2023-09-22 at 12 39 50 PM" src="https://github.com/frappe/erpnext/assets/3272205/ed382437-1302-43ca-ba12-ff4eb7685ff9">
