### PR TITLE
fix: allocate payment amount for split invoices in PE

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -880,19 +880,15 @@ frappe.ui.form.on('Payment Entry', {
 				//If allocate payment amount checkbox is unchecked, set zero to allocate amount
 				row.allocated_amount = 0;
 
-			} else if (frappe.flags.allocate_payment_amount != 0 && (row.payment_term || !row.allocated_amount || paid_amount_change)) {
-				if(row.payment_term)
-					outstanding_amount = row.allocated_amount;
-				else
-					outstanding_amount = row.outstanding_amount;
-				if (outstanding_amount > 0 && allocated_positive_outstanding >= 0) {
-					row.allocated_amount = (outstanding_amount >= allocated_positive_outstanding) ?
-						allocated_positive_outstanding : outstanding_amount;
+			} else if (frappe.flags.allocate_payment_amount != 0 && (!row.allocated_amount || paid_amount_change)) {
+				if (row.outstanding_amount > 0 && allocated_positive_outstanding >= 0) {
+					row.allocated_amount = (row.outstanding_amount >= allocated_positive_outstanding) ?
+						allocated_positive_outstanding : row.outstanding_amount;
 					allocated_positive_outstanding -= flt(row.allocated_amount);
 
-				} else if (outstanding_amount < 0 && allocated_negative_outstanding) {
-					row.allocated_amount = (Math.abs(outstanding_amount) >= allocated_negative_outstanding) ?
-						-1*allocated_negative_outstanding : outstanding_amount;
+				} else if (row.outstanding_amount < 0 && allocated_negative_outstanding) {
+					row.allocated_amount = (Math.abs(row.outstanding_amount) >= allocated_negative_outstanding) ?
+						-1*allocated_negative_outstanding : row.outstanding_amount;
 					allocated_negative_outstanding -= Math.abs(flt(row.allocated_amount));
 				}
 			}

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -874,20 +874,25 @@ frappe.ui.form.on('Payment Entry', {
 			}
 		}
 
+		let outstanding_amount;
 		$.each(frm.doc.references || [], function(i, row) {
 			if (frappe.flags.allocate_payment_amount == 0) {
 				//If allocate payment amount checkbox is unchecked, set zero to allocate amount
 				row.allocated_amount = 0;
 
-			} else if (frappe.flags.allocate_payment_amount != 0 && (!row.allocated_amount || paid_amount_change)) {
-				if (row.outstanding_amount > 0 && allocated_positive_outstanding >= 0) {
-					row.allocated_amount = (row.outstanding_amount >= allocated_positive_outstanding) ?
-						allocated_positive_outstanding : row.outstanding_amount;
+			} else if (frappe.flags.allocate_payment_amount != 0 && (row.payment_term || !row.allocated_amount || paid_amount_change)) {
+				if(row.payment_term)
+					outstanding_amount = row.allocated_amount;
+				else
+					outstanding_amount = row.outstanding_amount;
+				if (outstanding_amount > 0 && allocated_positive_outstanding >= 0) {
+					row.allocated_amount = (outstanding_amount >= allocated_positive_outstanding) ?
+						allocated_positive_outstanding : outstanding_amount;
 					allocated_positive_outstanding -= flt(row.allocated_amount);
 
-				} else if (row.outstanding_amount < 0 && allocated_negative_outstanding) {
-					row.allocated_amount = (Math.abs(row.outstanding_amount) >= allocated_negative_outstanding) ?
-						-1*allocated_negative_outstanding : row.outstanding_amount;
+				} else if (outstanding_amount < 0 && allocated_negative_outstanding) {
+					row.allocated_amount = (Math.abs(outstanding_amount) >= allocated_negative_outstanding) ?
+						-1*allocated_negative_outstanding : outstanding_amount;
 					allocated_negative_outstanding -= Math.abs(flt(row.allocated_amount));
 				}
 			}

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -874,7 +874,6 @@ frappe.ui.form.on('Payment Entry', {
 			}
 		}
 
-		let outstanding_amount;
 		$.each(frm.doc.references || [], function(i, row) {
 			if (frappe.flags.allocate_payment_amount == 0) {
 				//If allocate payment amount checkbox is unchecked, set zero to allocate amount

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -271,16 +271,18 @@ class PaymentEntry(AccountsController):
 
 				# if no payment template is used by invoice and has a custom term(no `payment_term`), then invoice outstanding will be in 'None' key
 				latest = latest.get(d.payment_term) or latest.get(None)
-
 				# The reference has already been fully paid
 				if not latest:
 					frappe.throw(
 						_("{0} {1} has already been fully paid.").format(_(d.reference_doctype), d.reference_name)
 					)
 				# The reference has already been partly paid
-				elif latest.outstanding_amount < latest.invoice_amount and flt(
-					d.outstanding_amount, d.precision("outstanding_amount")
-				) != flt(latest.outstanding_amount, d.precision("outstanding_amount")):
+				elif (
+					latest.outstanding_amount < latest.invoice_amount
+					and flt(d.outstanding_amount, d.precision("outstanding_amount"))
+					!= flt(latest.outstanding_amount, d.precision("outstanding_amount"))
+					and d.payment_term == ""
+				):
 					frappe.throw(
 						_(
 							"{0} {1} has already been partly paid. Please use the 'Get Outstanding Invoice' or the 'Get Outstanding Orders' button to get the latest outstanding amounts."
@@ -1751,11 +1753,10 @@ def split_invoices_based_on_payment_terms(outstanding_invoices, company):
 										"voucher_type": d.voucher_type,
 										"posting_date": d.posting_date,
 										"invoice_amount": flt(d.invoice_amount),
-										"outstanding_amount": flt(d.outstanding_amount),
-										"payment_term_outstanding": payment_term_outstanding,
-										"allocated_amount": payment_term_outstanding
+										"outstanding_amount": payment_term_outstanding
 										if payment_term_outstanding
 										else d.outstanding_amount,
+										"payment_term_outstanding": payment_term_outstanding,
 										"payment_amount": payment_term.payment_amount,
 										"payment_term": payment_term.payment_term,
 										"account": d.account,


### PR DESCRIPTION
**Bug**
In Payment Entries, when reference invoices are fetched using the **Get Outstanding Invoices** button, the automatically allocated amount is calculated incorrectly for invoices split across multiple rows ie. invoices having some payment terms.

**Example**
When a Payment Entry with amount **₹1000** fetches the outstanding invoices for the party, the automatically allocated amount for invoices ends up as **₹4100** which is greater than the paid amount.


https://github.com/frappe/erpnext/assets/40693548/29ddc5c1-22ef-42ed-b8a8-b0b3a50dc981


<br>


**Fix**

https://github.com/frappe/erpnext/assets/40693548/266c7245-d851-4f90-858d-9426d64608b6


Closes #37078 

`no-docs`
