### PR TITLE
feat: Toggle net values in Trial Balance report

### DIFF
--- a/erpnext/accounts/report/trial_balance/trial_balance.js
+++ b/erpnext/accounts/report/trial_balance/trial_balance.js
@@ -99,6 +99,12 @@ frappe.require("assets/erpnext/js/financial_statements.js", function() {
 				"label": __("Include Default Book Entries"),
 				"fieldtype": "Check",
 				"default": 1
+			},
+			{
+				"fieldname": "show_net_values",
+				"label": __("Show net values in opening and closing columns"),
+				"fieldtype": "Check",
+				"default": 1
 			}
 		],
 		"formatter": erpnext.financial_statements.formatter,

--- a/erpnext/accounts/report/trial_balance/trial_balance.py
+++ b/erpnext/accounts/report/trial_balance/trial_balance.py
@@ -120,7 +120,9 @@ def get_data(filters):
 		ignore_opening_entries=True,
 	)
 
-	calculate_values(accounts, gl_entries_by_account, opening_balances)
+	calculate_values(
+		accounts, gl_entries_by_account, opening_balances, filters.get("show_net_values")
+	)
 	accumulate_values_into_parents(accounts, accounts_by_name)
 
 	data = prepare_data(accounts, filters, parent_children_map, company_currency)
@@ -310,7 +312,7 @@ def get_opening_balance(
 	return gle
 
 
-def calculate_values(accounts, gl_entries_by_account, opening_balances):
+def calculate_values(accounts, gl_entries_by_account, opening_balances, show_net_values):
 	init = {
 		"opening_debit": 0.0,
 		"opening_credit": 0.0,
@@ -335,7 +337,8 @@ def calculate_values(accounts, gl_entries_by_account, opening_balances):
 		d["closing_debit"] = d["opening_debit"] + d["debit"]
 		d["closing_credit"] = d["opening_credit"] + d["credit"]
 
-		prepare_opening_closing(d)
+		if show_net_values:
+			prepare_opening_closing(d)
 
 
 def calculate_total_row(accounts, company_currency):
@@ -375,7 +378,7 @@ def prepare_data(accounts, filters, parent_children_map, company_currency):
 
 	for d in accounts:
 		# Prepare opening closing for group account
-		if parent_children_map.get(d.account):
+		if parent_children_map.get(d.account) and filters.get("show_net_values"):
 			prepare_opening_closing(d)
 
 		has_value = False


### PR DESCRIPTION
<img width="1370" alt="Screenshot 2023-09-23 at 2 35 26 PM" src="https://github.com/frappe/erpnext/assets/42651287/776c7092-c94e-40dd-8917-e45e706c09fa">

Many users want to see actual debit and credit values instead of net values on TB opening and closing values, added a check to toggle this.

`no-docs`