### PR TITLE
fix: filter gl entries in process soa

### DIFF
--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
@@ -65,6 +65,7 @@ def get_report_pdf(doc, consolidated=True):
 		filters = get_common_filters(doc)
 
 		if doc.report == "General Ledger":
+			filters.update(get_gl_filters(doc, entry, tax_id, presentation_currency))
 			col, res = get_soa(filters)
 			for x in [0, -2, -1]:
 				res[x]["account"] = res[x]["account"].replace("'", "")


### PR DESCRIPTION

On creation of a new process SOA for General Ledger Report the entries do not get filtered correctly due to a missing function call in the changes made by this [PR](https://github.com/frappe/erpnext/pull/36843).

`no-docs`