### PR TITLE
fix(Material Request): consider project for item details

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -218,7 +218,8 @@ frappe.ui.form.on('Material Request', {
 					plc_conversion_rate: 1,
 					rate: item.rate,
 					uom: item.uom,
-					conversion_factor: item.conversion_factor
+					conversion_factor: item.conversion_factor,
+					project: item.project,
 				},
 				overwrite_warehouse: overwrite_warehouse
 			},


### PR DESCRIPTION
### Problem

**Material Request** didn't consider the _Project_ while fetching item details. For example, when creating a **Material Request** from a **Project**, you'd expect the project's _Default Cost Center_ to be used. However, the **Material Request** didn't consider the selected _Project_, which resulted in the company's _Default Cost Center_ being set.

### Solution

Pass the selected _Project_ to `get_item_details`.