### PR TITLE
fix: Use default Cost Center of the Company for additional discount

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1466,7 +1466,7 @@ class AccountsController(TransactionBase):
 						"account": self.additional_discount_account,
 						"against": supplier_or_customer,
 						dr_or_cr: self.base_discount_amount,
-						"cost_center": self.cost_center,
+						"cost_center": self.cost_center or erpnext.get_default_cost_center(self.company),
 					},
 					item=self,
 				)


### PR DESCRIPTION
Problem:
When Discount Accounting in enabled in Selling Settings, in Sales Invoice the company Default Cot Center is not picked up for the GL entry for the discount amount.

Solution:
use the Company Default Cost Center while making GL entries for additional discount

Closes #37233
