### PR TITLE
fix: show/hide return_against field

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
@@ -419,7 +419,7 @@
    "read_only": 1
   },
   {
-   "depends_on": "eval:doc.return_against || doc.is_debit_note",
+   "depends_on": "eval:doc.is_return || doc.is_debit_note",
    "fieldname": "return_against",
    "fieldtype": "Link",
    "hide_days": 1,
@@ -428,7 +428,6 @@
    "no_copy": 1,
    "options": "Sales Invoice",
    "print_hide": 1,
-   "read_only_depends_on": "eval:doc.is_return",
    "search_index": 1
   },
   {


### PR DESCRIPTION
When make **Return Invoice** from from scratch and we check option **Is Return**, the field **return_against** does not show on the doctype,  this is because **depends_on** option **eval** is incorrect

