### PR TITLE
fix: serial number decimal issue

### DIFF
--- a/erpnext/controllers/subcontracting_controller.py
+++ b/erpnext/controllers/subcontracting_controller.py
@@ -655,7 +655,7 @@ class SubcontractingController(StockController):
 						{
 							"item_code": item.rm_item_code,
 							"warehouse": self.supplier_warehouse,
-							"actual_qty": -1 * flt(item.consumed_qty),
+							"actual_qty": -1 * flt(item.consumed_qty, item.precision("consumed_qty")),
 							"dependant_sle_voucher_detail_no": item.reference_name,
 						},
 					)


### PR DESCRIPTION
**Issue**

The raw material consumed quantity has set as 10 as per BOM in the Subcontracting Receipt, still system is throwing the below error while submitting the Subcontracting Receipt

<img width="730" alt="Screenshot 2023-09-26 at 1 01 55 PM" src="https://github.com/frappe/erpnext/assets/8780500/9864a2ff-6b12-4003-b4cc-15b14c624edc">
