### PR TITLE
fix: AP & AR summary filters to match AR 

### DIFF
--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
@@ -145,7 +145,8 @@ def get_gl_filters(doc, entry, tax_id, presentation_currency):
 def get_ar_filters(doc, entry):
 	return {
 		"report_date": doc.posting_date if doc.posting_date else None,
-		"customer": entry.customer,
+		"party_type": "Customer",
+		"party": entry.customer,
 		"customer_name": entry.customer_name if entry.customer_name else None,
 		"payment_terms_template": doc.payment_terms_template if doc.payment_terms_template else None,
 		"sales_partner": doc.sales_partner if doc.sales_partner else None,

--- a/erpnext/accounts/report/accounts_payable/accounts_payable.js
+++ b/erpnext/accounts/report/accounts_payable/accounts_payable.js
@@ -108,11 +108,8 @@ frappe.query_reports["Accounts Payable"] = {
 			},
 			on_change: () => {
 				frappe.query_report.set_filter_value('party', "");
-				let party_type = frappe.query_report.get_filter_value('party_type');
 				frappe.query_report.toggle_filter_display('supplier_group', frappe.query_report.get_filter_value('party_type') !== "Supplier");
-
 			}
-
 		},
 		{
 			"fieldname":"party",

--- a/erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js
+++ b/erpnext/accounts/report/accounts_payable_summary/accounts_payable_summary.js
@@ -72,10 +72,27 @@ frappe.query_reports["Accounts Payable Summary"] = {
 			}
 		},
 		{
-			"fieldname":"supplier",
-			"label": __("Supplier"),
+			"fieldname": "party_type",
+			"label": __("Party Type"),
 			"fieldtype": "Link",
-			"options": "Supplier"
+			"options": "Party Type",
+			get_query: () => {
+				return {
+					filters: {
+						'account_type': 'Payable'
+					}
+				};
+			},
+			on_change: () => {
+				frappe.query_report.set_filter_value('party', "");
+				frappe.query_report.toggle_filter_display('supplier_group', frappe.query_report.get_filter_value('party_type') !== "Supplier");
+			}
+		},
+		{
+			"fieldname":"party",
+			"label": __("Party"),
+			"fieldtype": "Dynamic Link",
+			"options": "party_type",
 		},
 		{
 			"fieldname":"payment_terms_template",

--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.js
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.js
@@ -52,9 +52,7 @@ frappe.query_reports["Accounts Receivable"] = {
 			},
 			on_change: () => {
 				frappe.query_report.set_filter_value('party', "");
-				let party_type = frappe.query_report.get_filter_value('party_type');
 				frappe.query_report.toggle_filter_display('customer_group', frappe.query_report.get_filter_value('party_type') !== "Customer");
-
 			}
 		},
 		{

--- a/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js
+++ b/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.js
@@ -72,10 +72,28 @@ frappe.query_reports["Accounts Receivable Summary"] = {
 			}
 		},
 		{
-			"fieldname":"customer",
-			"label": __("Customer"),
+			"fieldname": "party_type",
+			"label": __("Party Type"),
 			"fieldtype": "Link",
-			"options": "Customer"
+			"options": "Party Type",
+			"Default": "Customer",
+			get_query: () => {
+				return {
+					filters: {
+						'account_type': 'Receivable'
+					}
+				};
+			},
+			on_change: () => {
+				frappe.query_report.set_filter_value('party', "");
+				frappe.query_report.toggle_filter_display('customer_group', frappe.query_report.get_filter_value('party_type') !== "Customer");
+			}
+		},
+		{
+			"fieldname":"party",
+			"label": __("Party"),
+			"fieldtype": "Dynamic Link",
+			"options": "party_type",
 		},
 		{
 			"fieldname":"customer_group",


### PR DESCRIPTION
**Problem**

- After the AP / AR Report filters got renamed, the AP and AR Summary filters stopped working due to the common run method used by all of these reports.
- The Process Statement of Accounts also uses the old filters.

**Solution**

- Updated AR and AP Summary filters to match that of AR.
- Set the Process SOA filters with the new name.

`no-docs`