### PR TITLE
refactor: In Quotation Item, discount_and_margin section should have same collapsible_depends_on as other similar DocType (Sales Order Item,Sales Invoice Item,...)

### DIFF
--- a/erpnext/selling/doctype/quotation_item/quotation_item.json
+++ b/erpnext/selling/doctype/quotation_item/quotation_item.json
@@ -235,6 +235,7 @@
   },
   {
    "collapsible": 1,
+   "collapsible_depends_on": "eval: doc.margin_type || doc.discount_amount",
    "fieldname": "discount_and_margin",
    "fieldtype": "Section Break",
    "label": "Discount and Margin"
@@ -666,7 +667,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-02-06 11:00:07.042364",
+ "modified": "2023-09-26 13:42:11.410294",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Quotation Item",


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

Actually on Quotation Item when you fill a discount % or choose a margin type, the section collapse on blur event

> Explain the **details** for making this change. What existing problem does the pull request solve?

Set the same collapsible_depends_on 

 eval: doc.margin_type || doc.discount_amount

on Quotation Item, field: discount_and_margin

as it is already the case on 

"Sales Invoice Item": field discount_and_margin
"Purchase Order Item": field discount_and_margin_section
"Purchase Receipt Item": field discount_and_margin_section
"Delivery Note Item":field discount_and_margin
"Sales Order Item":field discount_and_margin

> no-docs

