### PR TITLE
fix: Set `serial_and_batch_bundle` in right field for Asset Repair Stock Entry

### DIFF
--- a/erpnext/assets/doctype/asset_repair/asset_repair.py
+++ b/erpnext/assets/doctype/asset_repair/asset_repair.py
@@ -177,7 +177,7 @@ class AssetRepair(AccountsController):
 					"item_code": stock_item.item_code,
 					"qty": stock_item.consumed_quantity,
 					"basic_rate": stock_item.valuation_rate,
-					"serial_no": stock_item.serial_and_batch_bundle,
+					"serial_and_batch_bundle": stock_item.serial_and_batch_bundle,
 					"cost_center": self.cost_center,
 					"project": self.project,
 				},


### PR DESCRIPTION
- `serial_and_batch_bundle` was earlier set in `serial_no` field
