### PR TITLE
fix: skip payments against orders in AP / AR

### DIFF
--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -791,6 +791,9 @@ class ReceivablePayableReport(object):
 		self.qb_selection_filter.append(self.ple.cost_center.isin(cost_center_list))
 
 	def add_common_filters(self):
+		self.qb_selection_filter.append(
+			self.ple.against_voucher_type.notin(["Purchase Order", "Sales Order"])
+		)
 		if self.filters.company:
 			self.qb_selection_filter.append(self.ple.company == self.filters.company)
 


### PR DESCRIPTION
**Problem**
Currently, when a Payment Entry is created against a Purchase / Sales Order, the corresponding Payment Ledger Entry gets fetched in the Accounts Payable / Receivable Report. However, since there are no PLEs made against the order, the outstanding total of the order never gets added to the AP / AR total. But the payment amount against that order gets deducted from the AP / AR total. This leads to an incorrect total amount.

**Example**

Suppose a Purchase Order is created with a total amount of `₹1000`. And a Payment Entry is created against the PO for `₹300`. The Accounts Payable Report shows the following entries - 

><img width="1175" alt="Screenshot 2023-09-28 at 12 08 36 PM" src="https://github.com/frappe/erpnext/assets/40693548/5d82af2f-b37a-419d-a9cc-ec5870edebc3">

`₹300` was reduced from the total Payable amount although the Purchase Order total was never added since no Payment Ledger Entries exist against it.

 ---

**Solution**
Skip PLEs made against Orders in the query for AP / AR Report.


`no-docs`