### PR TITLE
fix: validation message for valuation rate

### DIFF
--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -282,7 +282,9 @@ class SellingController(StockController):
 			last_valuation_rate_in_sales_uom = last_valuation_rate * (item.conversion_factor or 1)
 
 			if flt(item.base_net_rate) < flt(last_valuation_rate_in_sales_uom):
-				throw_message(item.idx, item.item_name, last_valuation_rate_in_sales_uom, "valuation rate")
+				throw_message(
+					item.idx, item.item_name, last_valuation_rate_in_sales_uom, "valuation rate (Moving Average)"
+				)
 
 	def get_item_list(self):
 		il = []


### PR DESCRIPTION
**New Message**

If you enabled "Validate Selling Price for Item Against Purchase Rate or Valuation Rate" and you have set the FIFO as valuation method then system still use the Moving Average to check the valuation rate with selling rate. Have changed the validation message to understand it properly to the user.

<img width="632" alt="Screenshot 2023-09-29 at 5 10 02 PM" src="https://github.com/frappe/erpnext/assets/8780500/59ff0e27-1ca1-48a9-b7fd-a09f58100c69">
