### PR TITLE
feat: asset salvage_value_percentage

### DIFF
--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -239,7 +239,7 @@ frappe.ui.form.on('Asset', {
 
 		datatable.style.setStyle(`.dt-scrollable`, {'font-size': '0.75rem', 'margin-bottom': '1rem', 'margin-left': '0.35rem', 'margin-right': '0.35rem'});
 		datatable.style.setStyle(`.dt-header`, {'margin-left': '0.35rem', 'margin-right': '0.35rem'});
-		datatable.style.setStyle(`.dt-cell--header`, {'color': 'var(--text-muted)'});
+		datatable.style.setStyle(`.dt-cell--header .dt-cell__content`, {'color': 'var(--gray-600)', 'font-size': 'var(--text-sm)'});
 		datatable.style.setStyle(`.dt-cell`, {'color': 'var(--text-color)'});
 		datatable.style.setStyle(`.dt-cell--col-1`, {'text-align': 'center'});
 		datatable.style.setStyle(`.dt-cell--col-2`, {'font-weight': 600});

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -797,7 +797,7 @@ def transfer_asset(args):
 
 
 @frappe.whitelist()
-def get_item_details(item_code, asset_category):
+def get_item_details(item_code, asset_category, gross_purchase_amount):
 	asset_category_doc = frappe.get_doc("Asset Category", asset_category)
 	books = []
 	for d in asset_category_doc.finance_books:
@@ -807,7 +807,11 @@ def get_item_details(item_code, asset_category):
 				"depreciation_method": d.depreciation_method,
 				"total_number_of_depreciations": d.total_number_of_depreciations,
 				"frequency_of_depreciation": d.frequency_of_depreciation,
-				"start_date": nowdate(),
+				"daily_depreciation": d.daily_depreciation,
+				"salvage_value_percentage": d.salvage_value_percentage,
+				"expected_value_after_useful_life": flt(gross_purchase_amount)
+				* flt(d.salvage_value_percentage / 100),
+				"depreciation_start_date": d.depreciation_start_date or nowdate(),
 			}
 		)
 

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -198,7 +198,9 @@ class Asset(AccountsController):
 			self.asset_category = frappe.get_cached_value("Item", self.item_code, "asset_category")
 
 		if self.item_code and not self.get("finance_books"):
-			finance_books = get_item_details(self.item_code, self.asset_category)
+			finance_books = get_item_details(
+				self.item_code, self.asset_category, self.gross_purchase_amount
+			)
 			self.set("finance_books", finance_books)
 
 	def validate_finance_books(self):

--- a/erpnext/assets/doctype/asset_activity/asset_activity.json
+++ b/erpnext/assets/doctype/asset_activity/asset_activity.json
@@ -75,13 +75,14 @@
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-08-01 11:09:52.584482",
+ "modified": "2023-09-29 15:56:17.608643",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset Activity",
  "owner": "Administrator",
  "permissions": [
   {
+   "delete": 1,
    "email": 1,
    "read": 1,
    "report": 1,
@@ -89,6 +90,7 @@
    "share": 1
   },
   {
+   "delete": 1,
    "email": 1,
    "read": 1,
    "report": 1,
@@ -96,6 +98,7 @@
    "share": 1
   },
   {
+   "delete": 1,
    "email": 1,
    "read": 1,
    "report": 1,

--- a/erpnext/assets/doctype/asset_finance_book/asset_finance_book.json
+++ b/erpnext/assets/doctype/asset_finance_book/asset_finance_book.json
@@ -12,6 +12,7 @@
   "column_break_5",
   "frequency_of_depreciation",
   "depreciation_start_date",
+  "salvage_value_percentage",
   "expected_value_after_useful_life",
   "value_after_depreciation",
   "rate_of_depreciation"
@@ -91,12 +92,17 @@
    "fieldname": "daily_depreciation",
    "fieldtype": "Check",
    "label": "Daily Depreciation"
+  },
+  {
+   "fieldname": "salvage_value_percentage",
+   "fieldtype": "Percent",
+   "label": "Salvage Value Percentage"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-08-10 22:10:36.576199",
+ "modified": "2023-09-29 15:39:52.740594",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset Finance Book",


### PR DESCRIPTION
Currently users need to calculate `expected_value_after_useful_life` manually if they want the value to be a percent of the asset's `gross_purchase_amount`. So I'm giving a `salvage_value_percentage` field in the finance books table where they can configure the percentage and the `expected_value_after_useful_life` would be automatically calculated.

Docs updated here: https://docs.erpnext.com/docs/user/manual/en/asset-asset#4-1-depreciation.