### PR TITLE
fix: only float row values for total in AP summary

### DIFF
--- a/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py
+++ b/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py
@@ -99,13 +99,11 @@ class AccountsReceivableSummary(ReceivablePayableReport):
 
 			# Add all amount columns
 			for k in list(self.party_total[d.party]):
-				if k not in ["currency", "sales_person"]:
-
-					self.party_total[d.party][k] += d.get(k, 0.0)
+				if type(self.party_total[d.party][k]) == float:
+					self.party_total[d.party][k] += d.get(k) or 0.0
 
 			# set territory, customer_group, sales person etc
 			self.set_party_details(d)
-			self.party_total[d.party].update({"party_type": d.party_type})
 
 	def init_party_total(self, row):
 		self.party_total.setdefault(
@@ -124,6 +122,7 @@ class AccountsReceivableSummary(ReceivablePayableReport):
 					"total_due": 0.0,
 					"future_amount": 0.0,
 					"sales_person": [],
+					"party_type": row.party_type,
 				}
 			),
 		)
@@ -133,13 +132,12 @@ class AccountsReceivableSummary(ReceivablePayableReport):
 
 		for key in ("territory", "customer_group", "supplier_group"):
 			if row.get(key):
-				self.party_total[row.party][key] = row.get(key)
-
+				self.party_total[row.party][key] = row.get(key, "")
 		if row.sales_person:
-			self.party_total[row.party].sales_person.append(row.sales_person)
+			self.party_total[row.party].sales_person.append(row.get("sales_person", ""))
 
 		if self.filters.sales_partner:
-			self.party_total[row.party]["default_sales_partner"] = row.get("default_sales_partner")
+			self.party_total[row.party]["default_sales_partner"] = row.get("default_sales_partner", "")
 
 	def get_columns(self):
 		self.columns = []

--- a/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py
+++ b/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py
@@ -99,7 +99,7 @@ class AccountsReceivableSummary(ReceivablePayableReport):
 
 			# Add all amount columns
 			for k in list(self.party_total[d.party]):
-				if type(self.party_total[d.party][k]) == float:
+				if isinstance(self.party_total[d.party][k], float):
 					self.party_total[d.party][k] += d.get(k) or 0.0
 
 			# set territory, customer_group, sales person etc


### PR DESCRIPTION
**Bug** 
While calculating total values for the party, the AP / AR Summary Reports iteratively add values for each row to the party map. But since there is no check for only adding int / float values, the other key values are also added which leads to the following error since NoneType values are added.

**Error Traceback**
```
Traceback (most recent call last):
File "apps/frappe/frappe/core/doctype/prepared_report/prepared_[report.py](http://report.py/)", line 79, in generate_report
result = generate_report_result(report=report, filters=instance.filters, user=instance.owner)
File "apps/frappe/frappe/__init__.py", line 802, in wrapper_fn
retval = fn(*args, **get_newargs(fn, kwargs))
File "apps/frappe/frappe/desk/query_[report.py](http://report.py/)", line 89, in generate_report_result
res = get_report_result(report, filters) or []
File "apps/frappe/frappe/desk/query_[report.py](http://report.py/)", line 70, in get_report_result
res = report.execute_script_report(filters)
File "apps/frappe/frappe/core/doctype/report/[report.py](http://report.py/)", line 131, in execute_script_report
res = self.execute_module(filters)
File "apps/frappe/frappe/core/doctype/report/[report.py](http://report.py/)", line 148, in execute_module
return frappe.get_attr(method_name)(frappe._dict(filters))
File "apps/erpnext/erpnext/accounts/report/accounts_payable_summary/accounts_payable_[summary.py](http://summary.py/)", line 15, in execute
return AccountsReceivableSummary(filters).run(args)
File "apps/erpnext/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_[summary.py](http://summary.py/)", line 32, in run
self.get_data(args)
File "apps/erpnext/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_[summary.py](http://summary.py/)", line 39, in get_data
self.get_party_total(args)
File "apps/erpnext/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_[summary.py](http://summary.py/)", line 104, in get_party_total
self.party_total[d.party][k] += d.get(k) or 0.0
TypeError: unsupported operand type(s) for +=: 'NoneType' and 'NoneType'

```

----

**Fix**

- Only add keys with float values.
- Set empty values for strings having no values.

`no-docs`