### PR TITLE
fix(crm): ensure primary address and contact follows customer setting

### DIFF
--- a/erpnext/crm/doctype/lead/lead.py
+++ b/erpnext/crm/doctype/lead/lead.py
@@ -7,6 +7,8 @@ from frappe.contacts.address_and_contact import (
 	delete_contact_and_address,
 	load_address_and_contact,
 )
+from frappe.contacts.doctype.address.address import get_default_address
+from frappe.contacts.doctype.contact.contact import get_default_contact
 from frappe.email.inbox import link_communication_to_document
 from frappe.model.mapper import get_mapped_doc
 from frappe.utils import comma_and, get_link_to_form, has_gravatar, validate_email_address
@@ -250,6 +252,13 @@ def _make_customer(source_name, target_doc=None, ignore_permissions=False):
 			target.customer_name = source.lead_name
 
 		target.customer_group = frappe.db.get_default("Customer Group")
+
+		address = get_default_address("Lead", source.name)
+		contact = get_default_contact("Lead", source.name)
+		if address:
+			target.customer_primary_address = address
+		if contact:
+			target.customer_primary_contact = contact
 
 	doclist = get_mapped_doc(
 		"Lead",

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -198,6 +198,8 @@ class Customer(TransactionBase):
 				self.db_set("customer_primary_contact", contact.name)
 				self.db_set("mobile_no", self.mobile_no)
 				self.db_set("email_id", self.email_id)
+		elif self.customer_primary_contact:
+			frappe.set_value("Contact", self.customer_primary_contact, "is_primary_contact", 1)  # ensure
 
 	def create_primary_address(self):
 		from frappe.contacts.doctype.address.address import get_address_display
@@ -208,6 +210,8 @@ class Customer(TransactionBase):
 
 			self.db_set("customer_primary_address", address.name)
 			self.db_set("primary_address", address_display)
+		elif self.customer_primary_address:
+			frappe.set_value("Address", self.customer_primary_address, "is_primary_address", 1)  # ensure
 
 	def update_lead_status(self):
 		"""If Customer created from Lead, update lead status to "Converted"
@@ -324,6 +328,7 @@ def create_contact(contact, party_type, party, email):
 			"doctype": "Contact",
 			"first_name": contact[0],
 			"last_name": len(contact) > 1 and contact[1] or "",
+			"is_primary_contact": 1,
 		}
 	)
 	contact.append("email_ids", dict(email_id=email, is_primary=1))
@@ -687,6 +692,7 @@ def make_address(args, is_primary_address=1):
 			"state": args.get("state"),
 			"pincode": args.get("pincode"),
 			"country": args.get("country"),
+			"is_primary_address": is_primary_address,
 			"links": [{"link_doctype": args.get("doctype"), "link_name": args.get("name")}],
 		}
 	).insert()


### PR DESCRIPTION
# Context

- If set in settings, a lead creates a contact on save
- If the lead progresses into a customer, that contact is being linked to the customer
- However, it is not set as the primary contact (even if it's the only contact for the lead / customer)
- Same for address (if created on the lead)
- Because it is obvious that a single contact / address also _must_ behave as the primary contact/address, the erp user often times forgets to set these flags
- As a consequence of this, several workflows may fail, such as for example because no primary contact is set on the customer, a payment requert may not fetch the correct email address (and on some gateways completely fail because of this).

Shoot!

# Proposed Solution
- When the customer is prepared coming from Lead:
   - Set customer primary contact based on frappe default heuristic (i.e. `is_primary_contact` or first in list)
   - Set customer primary address based on frappe default heuristic (i.e. `is_primary_address` or first in list)
- When the custemer is saved, ensure the customer's:
   - primary contact's underlaying `Contact` document is markes as `is_primary_contact`
   - primary addresse's underlaying `Address` document is marked as `is_primary_address`

In this way, it is ensured that:

- [x] the lead to customer flow is more ergonomic and set's the right field in the customer if contacts and addresses had already been collected on the lead
- [x] the `is_primary_` attribute on the underlaying documents (Address and Contact) are ensured to follow the current setting on the Customer document
