### PR TITLE
fix(sales): add sales user to read stock settings for js refresh code path

### DIFF
--- a/erpnext/stock/doctype/stock_settings/stock_settings.json
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.json
@@ -428,7 +428,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-09-01 16:16:34.018947",
+ "modified": "2023-10-01 14:22:36.136111",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Settings",
@@ -442,6 +442,10 @@
    "role": "Stock Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "read": 1,
+   "role": "Sales User"
   }
  ],
  "quick_entry": 1,


### PR DESCRIPTION
# Context

https://github.com/frappe/erpnext/blob/e7f4b7b190ab2da7fcd7579abdb0ba7bbed17b65/erpnext/selling/doctype/sales_order/sales_order.js#L91-L101

^^ This is a code path exercised by evey _Sales User_ when e.g. creating a new sales order.

However the _Sales User_, alone, doesn't have access to _Stock Settings_.

This is clearly not working as intendet because there's no way a _User_ with only _Sale User_ role can actually, well, create a new _Sale Order_.

Every such time, the user is greated with a permission error message and the potentially important default setting on stock reservation is **silently** ignored as if it was disabled.

# Proposed Solution

- Give _Sale User_ role read-only access to _Stock Settings_.
