### PR TITLE
fix(portal): used rounded total in transaction rows, if enabled

### DIFF
--- a/erpnext/templates/includes/transaction_row.html
+++ b/erpnext/templates/includes/transaction_row.html
@@ -15,9 +15,13 @@
 				{{ doc.items_preview }}
 			</div>
 		</div>
-		{% if doc.get('grand_total') %}
+		{% if doc.is_rounded_total_disabled() and doc.get('grand_total') %}
 			<div class="col-sm-3 text-right font-weight-bold item-total">
 				{{ doc.get_formatted("grand_total") }}
+			</div>
+		{% elif doc.get('rounded_total') %}
+			<div class="col-sm-3 text-right font-weight-bold item-total">
+				{{ doc.get_formatted("rounded_total") }}
 			</div>
 		{% endif %}
 	</div>


### PR DESCRIPTION
# Context

When a portal user goes to a transaction list, e.g. sales orders, and rounding was effective on a particular document,
regardless all rows would show non-rounded amounts.

The portal user (client), as a consequence, may be confused by not finding the exact same values as in their PDF / printed copy.

# Proposed Solution

- In the transaction row, show _rounded totals_, if it's enabled and _grand totals_ otherwise
