### PR TITLE
refactor: rename loan type to loan product in lending

### DIFF
--- a/erpnext/accounts/doctype/bank_clearance/test_bank_clearance.py
+++ b/erpnext/accounts/doctype/bank_clearance/test_bank_clearance.py
@@ -35,13 +35,13 @@ class TestBankClearance(unittest.TestCase):
 		from lending.loan_management.doctype.loan.test_loan import (
 			create_loan,
 			create_loan_accounts,
-			create_loan_type,
+			create_loan_product,
 			create_repayment_entry,
 			make_loan_disbursement_entry,
 		)
 
 		def create_loan_masters():
-			create_loan_type(
+			create_loan_product(
 				"Clearance Loan",
 				2000000,
 				13.5,

--- a/erpnext/accounts/doctype/bank_transaction/test_bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/test_bank_transaction.py
@@ -410,7 +410,7 @@ def add_vouchers():
 def create_loan_and_repayment():
 	from lending.loan_management.doctype.loan.test_loan import (
 		create_loan,
-		create_loan_type,
+		create_loan_product,
 		create_repayment_entry,
 		make_loan_disbursement_entry,
 	)
@@ -420,7 +420,7 @@ def create_loan_and_repayment():
 
 	from erpnext.setup.doctype.employee.test_employee import make_employee
 
-	create_loan_type(
+	create_loan_product(
 		"Personal Loan",
 		500000,
 		8.4,
@@ -441,7 +441,7 @@ def create_loan_and_repayment():
 			"applicant_type": "Employee",
 			"company": "_Test Company",
 			"applicant": applicant,
-			"loan_type": "Personal Loan",
+			"loan_product": "Personal Loan",
 			"loan_amount": 5000,
 			"repayment_method": "Repay Fixed Amount per Period",
 			"monthly_repayment_amount": 500,


### PR DESCRIPTION
Loan Type has been renamed to Loan Product, hence this change. Depends on https://github.com/frappe/lending/pull/67.