### PR TITLE
feat: maximum overdue invoice count limit

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -32,6 +32,7 @@
   "column_break_19",
   "add_taxes_from_item_tax_template",
   "book_tax_discount_loss",
+  "round_row_wise_tax",
   "print_settings",
   "show_inclusive_tax_in_print",
   "show_taxes_as_table_in_print",
@@ -49,6 +50,10 @@
   "role_allowed_to_over_bill",
   "credit_controller",
   "make_payment_via_journal_entry",
+  "overdue_settings_section",
+  "max_allowed_overdue_bills",
+  "column_break_nkiw",
+  "overdue_controller",
   "pos_tab",
   "pos_setting_section",
   "post_change_gl_entries",
@@ -414,6 +419,35 @@
    "fieldname": "ignore_account_closing_balance",
    "fieldtype": "Check",
    "label": "Ignore Account Closing Balance"
+  },
+  {
+   "default": "0",
+   "description": "Tax Amount will be rounded on a row(items) level",
+   "fieldname": "round_row_wise_tax",
+   "fieldtype": "Check",
+   "label": "Round Tax Amount Row-wise"
+  },
+  {
+   "fieldname": "overdue_settings_section",
+   "fieldtype": "Section Break",
+   "label": "Overdue Settings"
+  },
+  {
+   "description": "The maximum number of bills that can be overdue against a customer after which no new invoice can be raised",
+   "fieldname": "max_allowed_overdue_bills",
+   "fieldtype": "Int",
+   "label": "Max Allowed Overdue Bills"
+  },
+  {
+   "fieldname": "column_break_nkiw",
+   "fieldtype": "Column Break"
+  },
+  {
+   "description": "Users with this role are allowed to bill even if the maximum allowed overdue bill count exceeds",
+   "fieldname": "overdue_controller",
+   "fieldtype": "Link",
+   "label": "Role allowed to bypass Overdue Limit",
+   "options": "Role"
   }
  ],
  "icon": "icon-cog",
@@ -421,7 +455,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-07-27 15:05:34.000264",
+ "modified": "2023-10-02 21:35:51.995947",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounts Settings",

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -32,7 +32,6 @@
   "column_break_19",
   "add_taxes_from_item_tax_template",
   "book_tax_discount_loss",
-  "round_row_wise_tax",
   "print_settings",
   "show_inclusive_tax_in_print",
   "show_taxes_as_table_in_print",
@@ -421,13 +420,6 @@
    "label": "Ignore Account Closing Balance"
   },
   {
-   "default": "0",
-   "description": "Tax Amount will be rounded on a row(items) level",
-   "fieldname": "round_row_wise_tax",
-   "fieldtype": "Check",
-   "label": "Round Tax Amount Row-wise"
-  },
-  {
    "fieldname": "overdue_settings_section",
    "fieldtype": "Section Break",
    "label": "Overdue Settings"
@@ -455,7 +447,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-10-02 21:35:51.995947",
+ "modified": "2023-10-02 23:49:31.987665",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounts Settings",

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -425,6 +425,7 @@
    "label": "Overdue Settings"
   },
   {
+   "default": "0",
    "description": "The maximum number of bills that can be overdue against a customer after which no new invoice can be raised",
    "fieldname": "max_allowed_overdue_bills",
    "fieldtype": "Int",
@@ -447,7 +448,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-10-02 23:49:31.987665",
+ "modified": "2023-10-03 10:28:08.790268",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounts Settings",

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -138,6 +138,7 @@ class SalesInvoice(SellingController):
 		self.set_against_income_account()
 		self.validate_time_sheets_are_submitted()
 		self.validate_multiple_billing("Delivery Note", "dn_detail", "amount")
+		self.validate_overdue_bill_count()
 		if not self.is_return:
 			self.validate_serial_numbers()
 		else:

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -138,7 +138,6 @@ class SalesInvoice(SellingController):
 		self.set_against_income_account()
 		self.validate_time_sheets_are_submitted()
 		self.validate_multiple_billing("Delivery Note", "dn_detail", "amount")
-		self.validate_overdue_bill_count()
 		if not self.is_return:
 			self.validate_serial_numbers()
 		else:
@@ -272,6 +271,7 @@ class SalesInvoice(SellingController):
 			self.update_billing_status_for_zero_amount_refdoc("Delivery Note")
 			self.update_billing_status_for_zero_amount_refdoc("Sales Order")
 			self.check_credit_limit()
+			self.validate_overdue_bill_count()
 
 		if not cint(self.is_pos) == 1 and not self.is_return:
 			self.update_against_document_in_jv()

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -3164,10 +3164,10 @@ class TestSalesInvoice(unittest.TestCase):
 		overdue_inv.submit()
 
 		si = create_sales_invoice(customer=customer.name)
-		self.assertRaises(frappe.exceptions.ValidationError, si.save)
+		self.assertRaises(frappe.exceptions.ValidationError, si.submit)
 
 		overdue_inv.cancel()
-		si.save()
+		si.submit()
 
 	def test_multi_currency_deferred_revenue_via_journal_entry(self):
 		deferred_account = create_account(
@@ -3764,7 +3764,7 @@ def create_internal_supplier(supplier_name, represents_company, allowed_to_inter
 
 
 def setup_accounts():
-	## Create internal transfer account
+	# Create internal transfer account
 	account = create_account(
 		account_name="Unrealized Profit",
 		parent_account="Current Liabilities - TCP1",

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -3164,10 +3164,10 @@ class TestSalesInvoice(unittest.TestCase):
 		overdue_inv.submit()
 
 		si = create_sales_invoice(customer=customer.name)
-		with self.assertRaises(frappe.ValidationError) as err:
-			si.save()
+		self.assertRaises(frappe.ValidationError, si.save)
 
-		self.assertTrue("overdue invoice(s) against them" in str(err.exception).lower())
+		overdue_inv.cancel()
+		si.save()
 
 	def test_multi_currency_deferred_revenue_via_journal_entry(self):
 		deferred_account = create_account(

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -3117,10 +3117,6 @@ class TestSalesInvoice(unittest.TestCase):
 		Test a case where invoice is raised against customer with
 		overdue bills exceeding the limit
 		"""
-		max_allowed_overdue_bills = frappe.db.get_single_value(
-			"Accounts Settings", "max_allowed_overdue_bills"
-		)
-		overdue_controller = frappe.db.get_single_value("Accounts Settings", "overdue_controller")
 		frappe.db.set_single_value(
 			"Accounts Settings", {"max_allowed_overdue_bills": 1, "overdue_controller": ""}
 		)
@@ -3154,8 +3150,8 @@ class TestSalesInvoice(unittest.TestCase):
 		frappe.db.set_single_value(
 			"Accounts Settings",
 			{
-				"max_allowed_overdue_bills": max_allowed_overdue_bills,
-				"overdue_controller": overdue_controller,
+				"max_allowed_overdue_bills": 0,
+				"overdue_controller": "",
 			},
 		)
 

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -3164,7 +3164,7 @@ class TestSalesInvoice(unittest.TestCase):
 		overdue_inv.submit()
 
 		si = create_sales_invoice(customer=customer.name)
-		self.assertRaises(frappe.ValidationError, si.save)
+		self.assertRaises(frappe.exceptions.ValidationError, si.save)
 
 		overdue_inv.cancel()
 		si.save()

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1497,6 +1497,45 @@ class AccountsController(TransactionBase):
 				)
 			)
 
+	def validate_overdue_bill_count(self):
+		if self.doctype != "Sales Invoice":
+			return
+
+		max_allowed_overdue_bills = frappe.db.get_value(
+			"Accounts Settings", None, "max_allowed_overdue_bills", cache=True
+		)
+
+		if not flt(max_allowed_overdue_bills):
+			return
+
+		overdue_controller = frappe.db.get_value(
+			"Accounts Settings", None, "overdue_controller", cache=True
+		)
+
+		overdue_invoices = frappe.db.get_all(
+			self.doctype,
+			{"customer": self.customer, "docstatus": 1, "status": "Overdue", "name": ["!=", self.name]},
+			pluck="name",
+		)
+
+		if flt(len(overdue_invoices)) >= flt(max_allowed_overdue_bills):
+			msg = f"""
+				Cannot raise and invoice against {self.customer} as there
+				are {max_allowed_overdue_bills} or more overdue invoice(s) against them.
+				To allow more, please set allowance in Accounts Settings.<br>
+				Overdue invoice(s):
+			"""
+			msg += "<br><ul>"
+
+			for d in overdue_invoices:
+				msg += f"<li>{get_link_to_form('Sales Invoice', d)}</li>"
+			msg += "</li></ul>"
+
+			if overdue_controller in frappe.get_roles():
+				frappe.msgprint(_(msg), alert=True, indicator="yellow")
+			else:
+				frappe.throw(_(msg), title=_("Overdue Invoice Limit Reached"))
+
 	def validate_multiple_billing(self, ref_dt, item_ref_dn, based_on):
 		from erpnext.controllers.status_updater import get_allowance_for
 

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1520,11 +1520,7 @@ class AccountsController(TransactionBase):
 
 		if flt(len(overdue_invoices)) >= flt(max_allowed_overdue_bills):
 			msg = _(
-				"""
-				Cannot raise and invoice against {0} as there
-				are {1} or more overdue invoice(s) against them.
-				To allow more, please set allowance in Accounts Settings.
-				"""
+				"Cannot raise and invoice against {0} as there are {1} or more overdue invoice(s) against them. To allow more, please set allowance in Accounts Settings."
 			).format(self.customer, max_allowed_overdue_bills)
 			msg += "<br>"
 			msg += _("Overdue invoice(s):")

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1498,7 +1498,7 @@ class AccountsController(TransactionBase):
 			)
 
 	def validate_overdue_bill_count(self):
-		if self.doctype != "Sales Invoice":
+		if self.doctype not in ["Sales Invoice", "Delivery Note"]:
 			return
 
 		max_allowed_overdue_bills = frappe.db.get_single_value(
@@ -1513,7 +1513,7 @@ class AccountsController(TransactionBase):
 		)
 
 		overdue_invoices = frappe.db.get_all(
-			self.doctype,
+			"Sales Invoice",
 			{"customer": self.customer, "docstatus": 1, "status": "Overdue", "name": ["!=", self.name]},
 			pluck="name",
 		)

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1524,7 +1524,7 @@ class AccountsController(TransactionBase):
 				Cannot raise and invoice against {0} as there
 				are {1} or more overdue invoice(s) against them.
 				To allow more, please set allowance in Accounts Settings.
-			"""
+				"""
 			).format(self.customer, max_allowed_overdue_bills)
 			msg += "<br>"
 			msg += _("Overdue invoice(s):")

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1501,15 +1501,15 @@ class AccountsController(TransactionBase):
 		if self.doctype != "Sales Invoice":
 			return
 
-		max_allowed_overdue_bills = frappe.db.get_value(
-			"Accounts Settings", None, "max_allowed_overdue_bills", cache=True
+		max_allowed_overdue_bills = frappe.db.get_single_value(
+			"Accounts Settings", "max_allowed_overdue_bills", cache=True
 		)
 
 		if not flt(max_allowed_overdue_bills):
 			return
 
-		overdue_controller = frappe.db.get_value(
-			"Accounts Settings", None, "overdue_controller", cache=True
+		overdue_controller = frappe.db.get_single_value(
+			"Accounts Settings", "overdue_controller", cache=True
 		)
 
 		overdue_invoices = frappe.db.get_all(
@@ -1519,12 +1519,15 @@ class AccountsController(TransactionBase):
 		)
 
 		if flt(len(overdue_invoices)) >= flt(max_allowed_overdue_bills):
-			msg = f"""
-				Cannot raise and invoice against {self.customer} as there
-				are {max_allowed_overdue_bills} or more overdue invoice(s) against them.
-				To allow more, please set allowance in Accounts Settings.<br>
-				Overdue invoice(s):
+			msg = _(
+				"""
+				Cannot raise and invoice against {0} as there
+				are {1} or more overdue invoice(s) against them.
+				To allow more, please set allowance in Accounts Settings.
 			"""
+			).format(self.customer, max_allowed_overdue_bills)
+			msg += "<br>"
+			msg += _("Overdue invoice(s):")
 			msg += "<br><ul>"
 
 			for d in overdue_invoices:
@@ -1532,9 +1535,9 @@ class AccountsController(TransactionBase):
 			msg += "</li></ul>"
 
 			if overdue_controller in frappe.get_roles():
-				frappe.msgprint(_(msg), alert=True, indicator="yellow")
+				frappe.msgprint(msg, alert=True, indicator="yellow")
 			else:
-				frappe.throw(_(msg), title=_("Overdue Invoice Limit Reached"))
+				frappe.throw(msg, title=_("Overdue Invoice Limit Reached"))
 
 	def validate_multiple_billing(self, ref_dt, item_ref_dn, based_on):
 		from erpnext.controllers.status_updater import get_allowance_for

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -262,6 +262,7 @@ class DeliveryNote(SellingController):
 
 		if not self.is_return:
 			self.check_credit_limit()
+			self.validate_overdue_bill_count()
 		elif self.issue_credit_note:
 			self.make_return_invoice()
 		# Updating stock ledger should always be called after updating prevdoc status,


### PR DESCRIPTION
![image](https://github.com/frappe/erpnext/assets/52111700/ac781ee6-3230-4d2e-b616-3f44227a779a)


https://github.com/frappe/erpnext/assets/52111700/ec27711c-d72f-45b0-a174-ce83dae78af1


This PR enables a configurable setting to validate against overdue invoices before billing a customer.