### PR TITLE
fix: do not consider submitted Work Orders in the Production Plan Res…

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -8,6 +8,7 @@ import json
 import frappe
 from frappe import _, msgprint
 from frappe.model.document import Document
+from frappe.query_builder import Case
 from frappe.query_builder.functions import IfNull, Sum
 from frappe.utils import (
 	add_days,
@@ -1616,18 +1617,33 @@ def get_reserved_qty_for_production_plan(item_code, warehouse):
 	table = frappe.qb.DocType("Production Plan")
 	child = frappe.qb.DocType("Material Request Plan Item")
 
+	completed_production_plans = get_completed_production_plans()
+
+	case = Case()
 	query = (
 		frappe.qb.from_(table)
 		.inner_join(child)
 		.on(table.name == child.parent)
-		.select(Sum(child.quantity * IfNull(child.conversion_factor, 1.0)))
+		.select(
+			Sum(
+				child.quantity
+				* IfNull(
+					case.when(child.material_request_type == "Purchase", child.conversion_factor).else_(1.0), 1.0
+				)
+			)
+		)
 		.where(
 			(table.docstatus == 1)
 			& (child.item_code == item_code)
 			& (child.warehouse == warehouse)
 			& (table.status.notin(["Completed", "Closed"]))
 		)
-	).run()
+	)
+
+	if completed_production_plans:
+		query = query.where(table.name.notin(completed_production_plans))
+
+	query = query.run()
 
 	if not query:
 		return 0.0
@@ -1635,13 +1651,34 @@ def get_reserved_qty_for_production_plan(item_code, warehouse):
 	reserved_qty_for_production_plan = flt(query[0][0])
 
 	reserved_qty_for_production = flt(
-		get_reserved_qty_for_production(item_code, warehouse, check_production_plan=True)
+		get_reserved_qty_for_production(
+			item_code, warehouse, completed_production_plans, check_production_plan=True
+		)
 	)
 
 	if reserved_qty_for_production > reserved_qty_for_production_plan:
 		return 0.0
 
 	return reserved_qty_for_production_plan - reserved_qty_for_production
+
+
+def get_completed_production_plans():
+	table = frappe.qb.DocType("Production Plan")
+	child = frappe.qb.DocType("Production Plan Item")
+
+	query = (
+		frappe.qb.from_(table)
+		.inner_join(child)
+		.on(table.name == child.parent)
+		.select(table.name)
+		.where(
+			(table.docstatus == 1)
+			& (table.status.notin(["Completed", "Closed"]))
+			& (child.ordered_qty >= child.planned_qty)
+		)
+	).run(as_dict=True)
+
+	return list(set([d.name for d in query]))
 
 
 def get_raw_materials_of_sub_assembly_items(

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -362,10 +362,10 @@ class WorkOrder(Document):
 		else:
 			self.update_work_order_qty_in_so()
 
+		self.update_ordered_qty()
 		self.update_reserved_qty_for_production()
 		self.update_completed_qty_in_material_request()
 		self.update_planned_qty()
-		self.update_ordered_qty()
 		self.create_job_card()
 
 	def on_cancel(self):
@@ -1491,7 +1491,10 @@ def create_pick_list(source_name, target_doc=None, for_qty=None):
 
 
 def get_reserved_qty_for_production(
-	item_code: str, warehouse: str, check_production_plan: bool = False
+	item_code: str,
+	warehouse: str,
+	completed_production_plans: list = None,
+	check_production_plan: bool = False,
 ) -> float:
 	"""Get total reserved quantity for any item in specified warehouse"""
 	wo = frappe.qb.DocType("Work Order")
@@ -1523,6 +1526,9 @@ def get_reserved_qty_for_production(
 
 	if check_production_plan:
 		query = query.where(wo.production_plan.isnotnull())
+
+	if completed_production_plans:
+		query = query.where(wo.production_plan.notin(completed_production_plans))
 
 	return query.run()[0][0] or 0.0
 


### PR DESCRIPTION
**Issue**
- Created production for Raw material A with qty as 100
- System has reserved the 100 qty against the production plan 
- Created work order with Raw material A
- Changed the qty from 100 to 90
- Submitted work order
- On submission of the work order the reserved qty for production plan should be zero but system showing the qty as 10

**Fix**
Will skip the production plans against which the work orders has submitted