### PR TITLE
fix: change currency exchange API to api.frankfurter.app

### DIFF
--- a/erpnext/setup/doctype/currency_exchange/test_currency_exchange.py
+++ b/erpnext/setup/doctype/currency_exchange/test_currency_exchange.py
@@ -75,7 +75,7 @@ class TestCurrencyExchange(unittest.TestCase):
 		self.clear_cache()
 		exchange_rate = get_exchange_rate("USD", "INR", "2015-12-15", "for_selling")
 		self.assertFalse(exchange_rate == 60)
-		self.assertEqual(flt(exchange_rate, 3), 66.999)
+		self.assertEqual(flt(exchange_rate, 3), 66.894)
 
 	def test_exchange_rate_strict(self):
 		# strict currency settings
@@ -87,7 +87,7 @@ class TestCurrencyExchange(unittest.TestCase):
 
 		self.clear_cache()
 		exchange_rate = get_exchange_rate("USD", "INR", "2016-01-15", "for_buying")
-		self.assertEqual(flt(exchange_rate, 3), 67.235)
+		self.assertEqual(flt(exchange_rate, 3), 67.79)
 
 		exchange_rate = get_exchange_rate("USD", "INR", "2016-01-30", "for_selling")
 		self.assertEqual(exchange_rate, 62.9)
@@ -95,7 +95,7 @@ class TestCurrencyExchange(unittest.TestCase):
 		# Exchange rate as on 15th Dec, 2015
 		self.clear_cache()
 		exchange_rate = get_exchange_rate("USD", "INR", "2015-12-15", "for_buying")
-		self.assertEqual(flt(exchange_rate, 3), 66.999)
+		self.assertEqual(flt(exchange_rate, 3), 66.894)
 
 	def test_exchange_rate_strict_switched(self):
 		# Start with allow_stale is True
@@ -108,4 +108,4 @@ class TestCurrencyExchange(unittest.TestCase):
 		# Will fetch from fixer.io
 		self.clear_cache()
 		exchange_rate = get_exchange_rate("USD", "INR", "2016-01-15", "for_buying")
-		self.assertEqual(flt(exchange_rate, 3), 67.235)
+		self.assertEqual(flt(exchange_rate, 3), 67.79)

--- a/erpnext/setup/utils.py
+++ b/erpnext/setup/utils.py
@@ -113,13 +113,12 @@ def get_exchange_rate(from_currency, to_currency, transaction_date=None, args=No
 		if not value:
 			import requests
 
-			api_url = "https://api.exchangerate.host/convert"
-			response = requests.get(
-				api_url, params={"date": transaction_date, "from": from_currency, "to": to_currency}
-			)
+			api_url = f"https://api.frankfurter.app/{transaction_date}"
+			response = requests.get(api_url, params={"from": from_currency, "to": to_currency})
+
 			# expire in 6 hours
 			response.raise_for_status()
-			value = response.json()["result"]
+			value = response.json()["rates"][to_currency]
 			cache.setex(name=key, time=21600, value=flt(value))
 		return flt(value)
 	except Exception:


### PR DESCRIPTION
api.exchangerate.host now requires an API key to use.

switching to api.frankfurter.app

