### PR TITLE
refactor: add `access_key` field to facilitate use of exchangerate.host provider

### DIFF
--- a/erpnext/accounts/doctype/currency_exchange_settings/currency_exchange_settings.json
+++ b/erpnext/accounts/doctype/currency_exchange_settings/currency_exchange_settings.json
@@ -9,6 +9,7 @@
   "disabled",
   "service_provider",
   "api_endpoint",
+  "access_key",
   "url",
   "column_break_3",
   "help",
@@ -84,12 +85,18 @@
    "fieldname": "disabled",
    "fieldtype": "Check",
    "label": "Disabled"
+  },
+  {
+   "depends_on": "eval:doc.service_provider == 'exchangerate.host';",
+   "fieldname": "access_key",
+   "fieldtype": "Data",
+   "label": "Access Key"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-01-09 12:19:03.955906",
+ "modified": "2023-10-04 15:30:25.333860",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Currency Exchange Settings",

--- a/erpnext/accounts/doctype/currency_exchange_settings/currency_exchange_settings.py
+++ b/erpnext/accounts/doctype/currency_exchange_settings/currency_exchange_settings.py
@@ -18,11 +18,21 @@ class CurrencyExchangeSettings(Document):
 
 	def set_parameters_and_result(self):
 		if self.service_provider == "exchangerate.host":
+
+			if not self.access_key:
+				frappe.throw(
+					_("Access Key is required for Service Provider: {0}").format(
+						frappe.bold(self.service_provider)
+					)
+				)
+
 			self.set("result_key", [])
 			self.set("req_params", [])
 
 			self.api_endpoint = "https://api.exchangerate.host/convert"
 			self.append("result_key", {"key": "result"})
+			self.append("req_params", {"key": "access_key", "value": self.access_key})
+			self.append("req_params", {"key": "amount", "value": "1"})
 			self.append("req_params", {"key": "date", "value": "{transaction_date}"})
 			self.append("req_params", {"key": "from", "value": "{from_currency}"})
 			self.append("req_params", {"key": "to", "value": "{to_currency}"})

--- a/erpnext/setup/doctype/currency_exchange/test_currency_exchange.py
+++ b/erpnext/setup/doctype/currency_exchange/test_currency_exchange.py
@@ -121,6 +121,7 @@ class TestCurrencyExchange(unittest.TestCase):
 		# Update Currency Exchange Rate
 		settings = frappe.get_single("Currency Exchange Settings")
 		settings.service_provider = "exchangerate.host"
+		settings.access_key = "12345667890"
 		settings.save()
 
 		# Update exchange


### PR DESCRIPTION
Access Key is mandatory for `exchangerate.host` service provider. Currency Exchange Settings will have provision to add access_key to request parameter.
<img width="1407" alt="Screenshot 2023-10-04 at 3 51 49 PM" src="https://github.com/frappe/erpnext/assets/3272205/6ea155e7-352c-444b-9271-1a699fe4d4e0">
