### PR TITLE
fix: fetch company details for Lead based quotation

### DIFF
--- a/erpnext/crm/doctype/lead/lead.py
+++ b/erpnext/crm/doctype/lead/lead.py
@@ -379,7 +379,7 @@ def get_lead_details(lead, posting_date=None, company=None):
 		}
 	)
 
-	set_address_details(out, lead, "Lead")
+	set_address_details(out, lead, "Lead", company=company)
 
 	taxes_and_charges = set_taxes(
 		None,


### PR DESCRIPTION
Fetch Company details while making Quotation against Lead based Opportunity. Avoids missing field error.

<img width="1372" alt="Screenshot 2023-10-05 at 1 16 54 PM" src="https://github.com/frappe/erpnext/assets/3272205/da31165c-d080-40ff-aa13-aec2366bfda3">
