### PR TITLE
fix: unset custom account fields in company when importing COA

### DIFF
--- a/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py
+++ b/erpnext/accounts/doctype/chart_of_accounts_importer/chart_of_accounts_importer.py
@@ -459,8 +459,14 @@ def unset_existing_data(company):
 		as_dict=True,
 	)
 
+	custom_linked = frappe.db.sql(
+		'''select fieldname from `tabCustom Field`
+		where fieldtype="Link" and options="Account" and dt="Company"''',
+		as_dict=True,
+	)
+
 	# remove accounts data from company
-	update_values = {d.fieldname: "" for d in linked}
+	update_values = {d.fieldname: "" for d in linked + custom_linked}
 	frappe.db.set_value("Company", company, update_values, update_values)
 
 	# remove accounts data from various doctypes


### PR DESCRIPTION
Module: Accounts
Related to: Chart of Accounts Importer

If an app like Frappe HR is installed with ERPNext, it adds a few custom link fields in the Company doctype which link to an Account (e.g.: Default Payroll Payable Account). 
When we import a new COA for a company, these accounts that are set in the Company might not be available in the new COA and hence it throws an error. 

Solution: when "unsetting" accounts in the COA Importer (`unset_existing_data` method) - we should also fetch custom fields in addition to the standard fields in the doctype and unset those account values. This would not only clear fields added by other apps like HR, but also any custom Account field that might be added by the user.

This is related to #37238 - but it clears the account fields in the company for all custom fields - system-based or added by a user. Not sure which is the right way to tackle this. I assume having links to accounts that do not exist in the company might cause unintended issues.