### PR TITLE
refactor: multiple service providers for Currency Exchange rates

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.js
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.js
@@ -4,6 +4,12 @@
 frappe.ui.form.on('Accounts Settings', {
 	refresh: function(frm) {
 
+	},
+	validate_access_key(frm) {
+		frappe.call({
+			doc: frm.doc,
+			method: "validate_access_key"
+		});
 	}
 });
 

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -47,6 +47,9 @@
   "allow_stale",
   "stale_days",
   "service_provider",
+  "column_break_eiyok",
+  "access_key",
+  "validate_access_key",
   "report_settings_sb",
   "use_custom_cash_flow"
  ],
@@ -303,10 +306,28 @@
    "label": "Show Taxes as Table in Print"
   },
   {
+   "default": "frankfurter.app",
    "fieldname": "service_provider",
    "fieldtype": "Select",
    "label": "Service Provider",
    "options": "frankfurter.app\nexchangerate.host"
+  },
+  {
+   "depends_on": "eval:doc.service_provider == \"exchangerate.host\"",
+   "description": "Access Key is mandatory for exchangerate.host",
+   "fieldname": "access_key",
+   "fieldtype": "Data",
+   "label": "Access Key"
+  },
+  {
+   "depends_on": "eval:doc.service_provider == \"exchangerate.host\"",
+   "fieldname": "validate_access_key",
+   "fieldtype": "Button",
+   "label": "Validate Access Key"
+  },
+  {
+   "fieldname": "column_break_eiyok",
+   "fieldtype": "Column Break"
   }
  ],
  "icon": "icon-cog",
@@ -314,7 +335,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-10-06 15:05:51.999404",
+ "modified": "2023-10-07 14:20:01.779208",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounts Settings",

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -46,6 +46,7 @@
   "currency_exchange_section",
   "allow_stale",
   "stale_days",
+  "service_provider",
   "report_settings_sb",
   "use_custom_cash_flow"
  ],
@@ -282,32 +283,38 @@
    "label": "Enable Common Party Accounting"
   },
   {
-    "default": "0",
-    "description": "Enabling this will allow creation of multi-currency invoices against single party account in company currency",
-    "fieldname": "allow_multi_currency_invoices_against_single_party_account",
-    "fieldtype": "Check",
-    "label": "Allow multi-currency invoices against single party account"
-   },
-   {
-    "default": "0",
-    "description": "Split Early Payment Discount Loss into Income and Tax Loss",
-    "fieldname": "book_tax_discount_loss",
-    "fieldtype": "Check",
-    "label": "Book Tax Loss on Early Payment Discount"
-   },
-   {
-    "default": "0",
-    "fieldname": "show_taxes_as_table_in_print",
-    "fieldtype": "Check",
-    "label": "Show Taxes as Table in Print"
-   }
+   "default": "0",
+   "description": "Enabling this will allow creation of multi-currency invoices against single party account in company currency",
+   "fieldname": "allow_multi_currency_invoices_against_single_party_account",
+   "fieldtype": "Check",
+   "label": "Allow multi-currency invoices against single party account"
+  },
+  {
+   "default": "0",
+   "description": "Split Early Payment Discount Loss into Income and Tax Loss",
+   "fieldname": "book_tax_discount_loss",
+   "fieldtype": "Check",
+   "label": "Book Tax Loss on Early Payment Discount"
+  },
+  {
+   "default": "0",
+   "fieldname": "show_taxes_as_table_in_print",
+   "fieldtype": "Check",
+   "label": "Show Taxes as Table in Print"
+  },
+  {
+   "fieldname": "service_provider",
+   "fieldtype": "Select",
+   "label": "Service Provider",
+   "options": "frankfurter.app\nexchangerate.host"
+  }
  ],
  "icon": "icon-cog",
  "idx": 1,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-06-13 18:47:46.430291",
+ "modified": "2023-10-06 15:05:51.999404",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounts Settings",

--- a/erpnext/setup/utils.py
+++ b/erpnext/setup/utils.py
@@ -113,12 +113,30 @@ def get_exchange_rate(from_currency, to_currency, transaction_date=None, args=No
 		if not value:
 			import requests
 
-			api_url = f"https://api.frankfurter.app/{transaction_date}"
-			response = requests.get(api_url, params={"from": from_currency, "to": to_currency})
+			if currency_settings.service_provider == "exchangerate.host":
+				api_url = "https://api.exchangerate.host/convert"
+				response = requests.get(
+					api_url,
+					params={
+						"access_key": currency_settings.access_key,
+						"transaction_date": transaction_date,
+						"amount": 1,
+						"from": from_currency,
+						"to": to_currency,
+					},
+				)
+				# exchangerate.host return 200 for all requests. Can't rely on it to raise exception
+				value = response.json()["result"]
+				if not response.json()["success"]:
+					raise frappe.ValidationError
+
+			else:
+				api_url = f"https://api.frankfurter.app/{transaction_date}"
+				response = requests.get(api_url, params={"from": from_currency, "to": to_currency})
+				value = response.json()["rates"][to_currency]
 
 			# expire in 6 hours
 			response.raise_for_status()
-			value = response.json()["rates"][to_currency]
 			cache.setex(name=key, time=21600, value=flt(value))
 		return flt(value)
 	except Exception:


### PR DESCRIPTION
Exchange Rates service providers -- `api.exchangerate.host` and `api.frankfurter.app` will be selectable in `Accounts Settings` on v13. exchangerrate requires a mandatory access_key as well.

<img width="1440" alt="Screenshot 2023-10-07 at 2 28 57 PM" src="https://github.com/frappe/erpnext/assets/3272205/297c12e8-3a30-43ba-bdab-48db3400ca58">

