### PR TITLE
fix: consider received qty while creating SO -> MR

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -606,29 +606,37 @@ def close_or_unclose_sales_orders(names, status):
 
 
 def get_requested_item_qty(sales_order):
-	return frappe._dict(
-		frappe.db.sql(
-			"""
-		select sales_order_item, sum(qty)
-		from `tabMaterial Request Item`
-		where docstatus = 1
-			and sales_order = %s
-		group by sales_order_item
-	""",
-			sales_order,
-		)
-	)
+	result = {}
+	for d in frappe.db.get_all(
+		"Material Request Item",
+		filters={"docstatus": 1, "sales_order": sales_order},
+		fields=["sales_order_item", "sum(qty) as qty", "sum(received_qty) as received_qty"],
+		group_by="sales_order_item",
+	):
+		result[d.sales_order_item] = frappe._dict({"qty": d.qty, "received_qty": d.received_qty})
+
+	return result
 
 
 @frappe.whitelist()
 def make_material_request(source_name, target_doc=None):
 	requested_item_qty = get_requested_item_qty(source_name)
 
+	def get_remaining_qty(so_item):
+		return flt(
+			flt(so_item.qty)
+			- flt(requested_item_qty.get(so_item.name, {}).get("qty"))
+			- max(
+				flt(so_item.get("delivered_qty"))
+				- flt(requested_item_qty.get(so_item.name, {}).get("received_qty")),
+				0,
+			)
+		)
+
 	def update_item(source, target, source_parent):
 		# qty is for packed items, because packed items don't have stock_qty field
-		qty = source.get("qty")
 		target.project = source_parent.project
-		target.qty = qty - requested_item_qty.get(source.name, 0) - flt(source.get("delivered_qty"))
+		target.qty = get_remaining_qty(source)
 		target.stock_qty = flt(target.qty) * flt(target.conversion_factor)
 
 		args = target.as_dict().copy()
@@ -661,8 +669,8 @@ def make_material_request(source_name, target_doc=None):
 			"Sales Order Item": {
 				"doctype": "Material Request Item",
 				"field_map": {"name": "sales_order_item", "parent": "sales_order"},
-				"condition": lambda doc: not frappe.db.exists("Product Bundle", doc.item_code)
-				and (doc.stock_qty - flt(doc.get("delivered_qty"))) > requested_item_qty.get(doc.name, 0),
+				"condition": lambda item: not frappe.db.exists("Product Bundle", item.item_code)
+				and get_remaining_qty(item) > 0,
 				"postprocess": update_item,
 			},
 		},


### PR DESCRIPTION
**Source / Ref:** 4347

**Issue:** Incorrect Qty auto-populated in Material Request created from Sales Order. 

**Steps to Replicate:**
- Create a Sales Order for 7 Qty.
- Create Material Request for 5 Qty [Sales Order -> Material Request].
- Create Purchase Order and Purchase Receipt for Material Request [Material Request -> Purchase Order, Purchase Order -> Purchase Receipt].
- Create Delivery Note for 5 Qty [Sales Order - > Delivery Note].
- Try to create a Material Request for the remaining 2 qty [Sales Order -> Material Request]. The item row won't get mapped as the system calculates the remaining qty as (SO Qty - MR Qty - DN Qty) => 7 - 5 - 5 = -3.

**Common Cases:**

- MR2 (0, 2, 2) => Qty comes in Material Request - 2 followed by Qty before this PR (0), Expected Qty (2), and Qty after this PR respectively (2). 

![Untitled Diagram drawio](https://github.com/frappe/erpnext/assets/63660334/62ccaf21-216c-4de8-9dcf-eacfb9e449c1)


