### PR TITLE
test: add product_code in create_loan_product

### DIFF
--- a/erpnext/accounts/doctype/bank_clearance/test_bank_clearance.py
+++ b/erpnext/accounts/doctype/bank_clearance/test_bank_clearance.py
@@ -43,6 +43,7 @@ class TestBankClearance(unittest.TestCase):
 		def create_loan_masters():
 			create_loan_product(
 				"Clearance Loan",
+				"Clearance Loan",
 				2000000,
 				13.5,
 				25,

--- a/erpnext/accounts/doctype/bank_transaction/test_bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/test_bank_transaction.py
@@ -422,6 +422,7 @@ def create_loan_and_repayment():
 
 	create_loan_product(
 		"Personal Loan",
+		"Personal Loan",
 		500000,
 		8.4,
 		is_term_loan=1,


### PR DESCRIPTION
`product_code` was added in the `create_loan_product` function, hence this change.

Depends on https://github.com/frappe/lending/pull/80