### PR TITLE
fix: negative valuation rate in PR return

### DIFF
--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -14,7 +14,8 @@ from erpnext.buying.utils import update_last_purchase_rate, validate_for_items
 from erpnext.controllers.sales_and_purchase_return import get_rate_for_return
 from erpnext.controllers.subcontracting_controller import SubcontractingController
 from erpnext.stock.get_item_details import get_conversion_factor
-from erpnext.stock.utils import get_incoming_rate
+from erpnext.stock.stock_ledger import get_previous_sle
+from erpnext.stock.utils import get_incoming_rate, get_valuation_method
 
 
 class QtyMismatchError(ValidationError):
@@ -514,9 +515,20 @@ class BuyingController(SubcontractingController):
 					)
 
 					if self.is_return:
-						outgoing_rate = get_rate_for_return(
-							self.doctype, self.name, d.item_code, self.return_against, item_row=d
-						)
+						if get_valuation_method(d.item_code) == "Moving Average":
+							previous_sle = get_previous_sle(
+								{
+									"item_code": d.item_code,
+									"warehouse": d.warehouse,
+									"posting_date": self.posting_date,
+									"posting_time": self.posting_time,
+								}
+							)
+							outgoing_rate = flt(previous_sle.get("valuation_rate"))
+						else:
+							outgoing_rate = get_rate_for_return(
+								self.doctype, self.name, d.item_code, self.return_against, item_row=d
+							)
 
 						sle.update({"outgoing_rate": outgoing_rate, "recalculate_rate": 1})
 						if d.from_warehouse:

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -698,14 +698,16 @@ class update_entries_after(object):
 					get_rate_for_return,  # don't move this import to top
 				)
 
-				rate = get_rate_for_return(
-					sle.voucher_type,
-					sle.voucher_no,
-					sle.item_code,
-					voucher_detail_no=sle.voucher_detail_no,
-					sle=sle,
-				)
-
+				if self.valuation_method == "Moving Average":
+					rate = self.data[self.args.warehouse].previous_sle.valuation_rate
+				else:
+					rate = get_rate_for_return(
+						sle.voucher_type,
+						sle.voucher_no,
+						sle.item_code,
+						voucher_detail_no=sle.voucher_detail_no,
+						sle=sle,
+					)
 			elif (
 				sle.voucher_type in ["Purchase Receipt", "Purchase Invoice"]
 				and sle.voucher_detail_no


### PR DESCRIPTION
**Source / Ref:** 4290

**Issue:** Negative Valuation Rate in Purchase Receipt Return.

**Steps to Replicate:**
- Create an Item (Valuation Method = Moving Average)
- Create a Purchase Receipt (Qty = 10, Rate = 100)
- Create a Material Receipt Stock Entry (Qty = 100, Basic Rate = 10) i.e., the Valuation Rate will be 18.18 after Submit.
- Create a Material Issue Stock Entry (Qty = 100, Basic Rate = 18.18 [Auto Fetched])
- Now, create a Return Purchase Return (Qty = -8, Rate = 100 [Auto fetched]). Check the Stock Ledger the Valuation Rate will be -309.09

**Solution:** Set the Outgoing Rate as the previous SLE Valuation Rate.

**Before and After:**

![image](https://github.com/frappe/erpnext/assets/63660334/b0c8e76b-ee5b-45fa-ab4d-e8b79cc43a42)

