### PR TITLE
fix(gp): wrong `allocated_amount` when grouped by Sales Person

### DIFF
--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -544,6 +544,8 @@ class GrossProfitGenerator(object):
 						new_row.qty += flt(row.qty)
 						new_row.buying_amount += flt(row.buying_amount, self.currency_precision)
 						new_row.base_amount += flt(row.base_amount, self.currency_precision)
+						if self.filters.get("group_by") == "Sales Person":
+							new_row.allocated_amount += flt(row.allocated_amount, self.currency_precision)
 				new_row = self.set_average_rate(new_row)
 				self.grouped_data.append(new_row)
 


### PR DESCRIPTION
GP when grouped by Sales Person shows only data(allocated amount) of a single invoice only.

Before:
![image](https://github.com/frappe/erpnext/assets/52111700/c3a80cdc-6349-4f7d-bb3b-d25f321fdd95)


After:
![image](https://github.com/frappe/erpnext/assets/52111700/aef0dbb9-8cb9-4db1-86fb-5a181140d4d1)
