### PR TITLE
fix(payments): incoming payment requests aren't supposed to be in 'initiated' state (only outgoing are)

### DIFF
--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -180,13 +180,6 @@ class PaymentRequest(Document):
 		if self.payment_url:
 			self.db_set("payment_url", self.payment_url)
 
-		if (
-			self.payment_url
-			or not self.payment_gateway_account
-			or (self.payment_gateway_account and self.payment_channel == "Phone")
-		):
-			self.db_set("status", "Initiated")
-
 	def get_payment_url(self):
 		if self.reference_doctype != "Fees":
 			data = frappe.db.get_value(


### PR DESCRIPTION
# Context

As can be seen from the `on_submit` of payment requests, the "Initiated" status is semantically reserved for _outgoing_ payments.

However, the gateway integration had misunderstood that semnatics and wongly used "Initiated" status to signify "Requested" instead of using "Requested".

This is in further confustion to the "iniation" status of the Integration Request that is triggered from a payment request.

Likely the original author confounded these and wanted to express that the Integration Request may have been initiated. However, this is a question that lies entierly within the domain an lifecycle of the payment gateway integarion and can therefore not be dealt with from the payment request itself.

As a consequence of this error, users would find:
- Incoming _Gateway Requests_ as well as _Outgoing Requests_ as _Initiated_
- All other incoming requests as _Requested_

While user shoul consistently find:

- Outgoing requests: Initiated
- Incoming requests: Requested

# Proposed Solution

- Don't set payment gateway requests to "initiated" when they are already considered "requested" on submit.
- Leave the Integration Request cycle within the domain of the payment gateway integration.


# Impact

This wrong semantic assignation has been a significant source of misunderstanding while working with the codebase and implementing a payment gateway myself.
Just with this error removed, things would become a lot more consistent and clear to the developer and user alike.
