### PR TITLE
fix: fixed the doc not defined issue.

### DIFF
--- a/erpnext/public/js/controllers/accounts.js
+++ b/erpnext/public/js/controllers/accounts.js
@@ -116,7 +116,7 @@ erpnext.accounts.taxes = {
 			account_head: function(frm, cdt, cdn) {
 				let d = locals[cdt][cdn];
 
-				if (doc.docstatus == 1) {
+				if (d.docstatus == 1) {
 					// Should not trigger any changes on change post submit
 					return;
 				}


### PR DESCRIPTION
## Description
`doc` variable was not defined in the `accounts.js` file instead, `d ` variable was used for the same purpose.

## Fixed by:
I replaced the instance (line no. 119) where `doc` was used with `d`.

Closes #37231