### PR TITLE
refactor: back calculate total amt for TDS

### DIFF
--- a/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
+++ b/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
@@ -68,7 +68,11 @@ def get_result(
 				tax_amount += entry.credit - entry.debit
 
 			if net_total_map.get(name):
-				total_amount, grand_total, base_total = net_total_map.get(name)
+				if voucher_type == "Journal Entry":
+					# back calcalute total amount from rate and tax_amount
+					total_amount = grand_total = base_total = tax_amount / (rate / 100)
+				else:
+					total_amount, grand_total, base_total = net_total_map.get(name)
 			else:
 				total_amount += entry.credit
 


### PR DESCRIPTION
For journals, instead of using `total_amount`, which on cases where the same party is debitted and credited gets inflated, back calculate the total_amount from tax rate and tax amount.