### PR TITLE
fix: keyerror on gl and pl comparision report

### DIFF
--- a/erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py
+++ b/erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py
@@ -133,15 +133,17 @@ class General_Payment_Ledger_Comparison(object):
 			self.gle_balances = set(val.gle) | self.gle_balances
 			self.ple_balances = set(val.ple) | self.ple_balances
 
-		self.diff1 = self.gle_balances.difference(self.ple_balances)
-		self.diff2 = self.ple_balances.difference(self.gle_balances)
+		self.variation_in_payment_ledger = self.gle_balances.difference(self.ple_balances)
+		self.variation_in_general_ledger = self.ple_balances.difference(self.gle_balances)
 		self.diff = frappe._dict({})
 
-		for x in self.diff1:
+		for x in self.variation_in_payment_ledger:
 			self.diff[(x[0], x[1], x[2], x[3])] = frappe._dict({"gl_balance": x[4]})
 
-		for x in self.diff2:
-			self.diff[(x[0], x[1], x[2], x[3])].update(frappe._dict({"pl_balance": x[4]}))
+		for x in self.variation_in_general_ledger:
+			self.diff.setdefault((x[0], x[1], x[2], x[3]), frappe._dict({"gl_balance": 0.0})).update(
+				frappe._dict({"pl_balance": x[4]})
+			)
 
 	def generate_data(self):
 		self.data = []


### PR DESCRIPTION
```
Traceback (most recent call last):
File "apps/frappe/frappe/core/doctype/prepared_report/prepared_report.py", line 79, in generate_report
result = generate_report_result(report=report, filters=instance.filters, user=instance.owner)
File "apps/frappe/frappe/__init__.py", line 802, in wrapper_fn
retval = fn(*args, **get_newargs(fn, kwargs))
File "apps/frappe/frappe/desk/query_report.py", line 89, in generate_report_result
res = get_report_result(report, filters) or []
File "apps/frappe/frappe/desk/query_report.py", line 70, in get_report_result
res = report.execute_script_report(filters)
File "apps/frappe/frappe/core/doctype/report/report.py", line 131, in execute_script_report
res = self.execute_module(filters)
File "apps/frappe/frappe/core/doctype/report/report.py", line 148, in execute_module
return frappe.get_attr(method_name)(frappe._dict(filters))
File "apps/erpnext/erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py", line 219, in execute
columns, data = rpt.run()
File "apps/erpnext/erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py", line 208, in run
self.compare()
File "apps/erpnext/erpnext/accounts/report/general_and_payment_ledger_comparison/general_and_payment_ledger_comparison.py", line 144, in compare
self.diff[(x[0], x[1], x[2], x[3])].update(frappe._dict({"pl_balance": x[4]}))
```