### PR TITLE
fix: set empty value for tax template in item details

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
@@ -6,6 +6,7 @@ import unittest
 
 import frappe
 from frappe import _
+from frappe.utils import add_days, nowdate
 
 from erpnext.accounts.doctype.pos_invoice.pos_invoice import make_sales_return
 from erpnext.accounts.doctype.pos_profile.test_pos_profile import make_pos_profile
@@ -125,70 +126,64 @@ class TestPOSInvoice(unittest.TestCase):
 		self.assertEqual(inv.grand_total, 5474.0)
 
 	def test_tax_calculation_with_item_tax_template(self):
-		inv = create_pos_invoice(qty=84, rate=4.6, do_not_save=1)
-		item_row = inv.get("items")[0]
+		import json
 
-		add_items = [
-			(54, "_Test Account Excise Duty @ 12 - _TC"),
-			(288, "_Test Account Excise Duty @ 15 - _TC"),
-			(144, "_Test Account Excise Duty @ 20 - _TC"),
-			(430, "_Test Item Tax Template 1 - _TC"),
+		from erpnext.stock.get_item_details import get_item_details
+
+		# set tax template in item
+		item = frappe.get_cached_doc("Item", "_Test Item")
+		item.set(
+			"taxes",
+			[
+				{
+					"item_tax_template": "_Test Account Excise Duty @ 15 - _TC",
+					"valid_from": add_days(nowdate(), -5),
+				}
+			],
+		)
+		item.save()
+
+		# create POS invoice with item
+		pos_inv = create_pos_invoice(qty=84, rate=4.6, do_not_save=True)
+		item_details = get_item_details(
+			doc=pos_inv,
+			args={
+				"item_code": item.item_code,
+				"company": pos_inv.company,
+				"doctype": "POS Invoice",
+				"conversion_rate": 1.0,
+			},
+		)
+		tax_map = json.loads(item_details.item_tax_rate)
+		for tax in tax_map:
+			pos_inv.append(
+				"taxes",
+				{
+					"charge_type": "On Net Total",
+					"account_head": tax,
+					"rate": tax_map[tax],
+					"description": "Test",
+					"cost_center": "_Test Cost Center - _TC",
+				},
+			)
+		pos_inv.submit()
+		pos_inv.load_from_db()
+
+		# check if correct tax values are applied from tax template
+		self.assertEqual(pos_inv.net_total, 386.4)
+
+		expected_taxes = [
+			{
+				"tax_amount": 57.96,
+				"total": 444.36,
+			},
 		]
-		for qty, item_tax_template in add_items:
-			item_row_copy = copy.deepcopy(item_row)
-			item_row_copy.qty = qty
-			item_row_copy.item_tax_template = item_tax_template
-			inv.append("items", item_row_copy)
 
-		inv.append(
-			"taxes",
-			{
-				"account_head": "_Test Account Excise Duty - _TC",
-				"charge_type": "On Net Total",
-				"cost_center": "_Test Cost Center - _TC",
-				"description": "Excise Duty",
-				"doctype": "Sales Taxes and Charges",
-				"rate": 11,
-			},
-		)
-		inv.append(
-			"taxes",
-			{
-				"account_head": "_Test Account Education Cess - _TC",
-				"charge_type": "On Net Total",
-				"cost_center": "_Test Cost Center - _TC",
-				"description": "Education Cess",
-				"doctype": "Sales Taxes and Charges",
-				"rate": 0,
-			},
-		)
-		inv.append(
-			"taxes",
-			{
-				"account_head": "_Test Account S&H Education Cess - _TC",
-				"charge_type": "On Net Total",
-				"cost_center": "_Test Cost Center - _TC",
-				"description": "S&H Education Cess",
-				"doctype": "Sales Taxes and Charges",
-				"rate": 3,
-			},
-		)
-		inv.insert()
+		for i in range(len(expected_taxes)):
+			for key in expected_taxes[i]:
+				self.assertEqual(expected_taxes[i][key], pos_inv.get("taxes")[i].get(key))
 
-		self.assertEqual(inv.net_total, 4600)
-
-		self.assertEqual(inv.get("taxes")[0].tax_amount, 502.41)
-		self.assertEqual(inv.get("taxes")[0].total, 5102.41)
-
-		self.assertEqual(inv.get("taxes")[1].tax_amount, 197.80)
-		self.assertEqual(inv.get("taxes")[1].total, 5300.21)
-
-		self.assertEqual(inv.get("taxes")[2].tax_amount, 375.36)
-		self.assertEqual(inv.get("taxes")[2].total, 5675.57)
-
-		self.assertEqual(inv.grand_total, 5675.57)
-		self.assertEqual(inv.rounding_adjustment, 0.43)
-		self.assertEqual(inv.rounded_total, 5676.0)
+		self.assertEqual(pos_inv.get("base_total_taxes_and_charges"), 57.96)
 
 	def test_tax_calculation_with_multiple_items_and_discount(self):
 		inv = create_pos_invoice(qty=1, rate=75, do_not_save=True)

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -511,70 +511,72 @@ class TestSalesInvoice(unittest.TestCase):
 		self.assertEqual(si.grand_total, 5474.0)
 
 	def test_tax_calculation_with_item_tax_template(self):
+		import json
+
+		from erpnext.stock.get_item_details import get_item_details
+
+		# set tax template in item
+		item = frappe.get_cached_doc("Item", "_Test Item")
+		item.set(
+			"taxes",
+			[
+				{
+					"item_tax_template": "_Test Item Tax Template 1 - _TC",
+					"valid_from": add_days(nowdate(), -5),
+				}
+			],
+		)
+		item.save()
+
+		# create sales invoice with item
 		si = create_sales_invoice(qty=84, rate=4.6, do_not_save=True)
-		item_row = si.get("items")[0]
+		item_details = get_item_details(
+			doc=si,
+			args={
+				"item_code": item.item_code,
+				"company": si.company,
+				"doctype": "Sales Invoice",
+				"conversion_rate": 1.0,
+			},
+		)
+		tax_map = json.loads(item_details.item_tax_rate)
+		for tax in tax_map:
+			si.append(
+				"taxes",
+				{
+					"charge_type": "On Net Total",
+					"account_head": tax,
+					"rate": tax_map[tax],
+					"description": "Test",
+					"cost_center": "_Test Cost Center - _TC",
+				},
+			)
+		si.submit()
+		si.load_from_db()
 
-		add_items = [
-			(54, "_Test Account Excise Duty @ 12 - _TC"),
-			(288, "_Test Account Excise Duty @ 15 - _TC"),
-			(144, "_Test Account Excise Duty @ 20 - _TC"),
-			(430, "_Test Item Tax Template 1 - _TC"),
+		# check if correct tax values are applied from tax template
+		self.assertEqual(si.net_total, 386.4)
+
+		expected_taxes = [
+			{
+				"tax_amount": 19.32,
+				"total": 405.72,
+			},
+			{
+				"tax_amount": 38.64,
+				"total": 444.36,
+			},
+			{
+				"tax_amount": 57.96,
+				"total": 502.32,
+			},
 		]
-		for qty, item_tax_template in add_items:
-			item_row_copy = copy.deepcopy(item_row)
-			item_row_copy.qty = qty
-			item_row_copy.item_tax_template = item_tax_template
-			si.append("items", item_row_copy)
 
-		si.append(
-			"taxes",
-			{
-				"account_head": "_Test Account Excise Duty - _TC",
-				"charge_type": "On Net Total",
-				"cost_center": "_Test Cost Center - _TC",
-				"description": "Excise Duty",
-				"doctype": "Sales Taxes and Charges",
-				"rate": 11,
-			},
-		)
-		si.append(
-			"taxes",
-			{
-				"account_head": "_Test Account Education Cess - _TC",
-				"charge_type": "On Net Total",
-				"cost_center": "_Test Cost Center - _TC",
-				"description": "Education Cess",
-				"doctype": "Sales Taxes and Charges",
-				"rate": 0,
-			},
-		)
-		si.append(
-			"taxes",
-			{
-				"account_head": "_Test Account S&H Education Cess - _TC",
-				"charge_type": "On Net Total",
-				"cost_center": "_Test Cost Center - _TC",
-				"description": "S&H Education Cess",
-				"doctype": "Sales Taxes and Charges",
-				"rate": 3,
-			},
-		)
-		si.insert()
+		for i in range(len(expected_taxes)):
+			for key in expected_taxes[i]:
+				self.assertEqual(expected_taxes[i][key], si.get("taxes")[i].get(key))
 
-		self.assertEqual(si.net_total, 4600)
-
-		self.assertEqual(si.get("taxes")[0].tax_amount, 502.41)
-		self.assertEqual(si.get("taxes")[0].total, 5102.41)
-
-		self.assertEqual(si.get("taxes")[1].tax_amount, 197.80)
-		self.assertEqual(si.get("taxes")[1].total, 5300.21)
-
-		self.assertEqual(si.get("taxes")[2].tax_amount, 375.36)
-		self.assertEqual(si.get("taxes")[2].total, 5675.57)
-
-		self.assertEqual(si.grand_total, 5675.57)
-		self.assertEqual(si.rounding_adjustment, 0.43)
-		self.assertEqual(si.rounded_total, 5676.0)
+		self.assertEqual(si.get("base_total_taxes_and_charges"), 115.92)
 
 	def test_tax_calculation_with_multiple_items_and_discount(self):
 		si = create_sales_invoice(qty=1, rate=75, do_not_save=True)

--- a/erpnext/stock/doctype/item/test_item.py
+++ b/erpnext/stock/doctype/item/test_item.py
@@ -163,7 +163,7 @@ class TestItem(FrappeTestCase):
 			{
 				"item_code": "_Test Item With Item Tax Template",
 				"tax_category": "_Test Tax Category 2",
-				"item_tax_template": None,
+				"item_tax_template": "",
 			},
 			{
 				"item_code": "_Test Item Inherit Group Item Tax Template 1",
@@ -178,7 +178,7 @@ class TestItem(FrappeTestCase):
 			{
 				"item_code": "_Test Item Inherit Group Item Tax Template 1",
 				"tax_category": "_Test Tax Category 2",
-				"item_tax_template": None,
+				"item_tax_template": "",
 			},
 			{
 				"item_code": "_Test Item Inherit Group Item Tax Template 2",
@@ -193,7 +193,7 @@ class TestItem(FrappeTestCase):
 			{
 				"item_code": "_Test Item Inherit Group Item Tax Template 2",
 				"tax_category": "_Test Tax Category 2",
-				"item_tax_template": None,
+				"item_tax_template": "",
 			},
 			{
 				"item_code": "_Test Item Override Group Item Tax Template",
@@ -208,12 +208,12 @@ class TestItem(FrappeTestCase):
 			{
 				"item_code": "_Test Item Override Group Item Tax Template",
 				"tax_category": "_Test Tax Category 2",
-				"item_tax_template": None,
+				"item_tax_template": "",
 			},
 		]
 
 		expected_item_tax_map = {
-			None: {},
+			"": {},
 			"_Test Account Excise Duty @ 10 - _TC": {"_Test Account Excise Duty - _TC": 10},
 			"_Test Account Excise Duty @ 12 - _TC": {"_Test Account Excise Duty - _TC": 12},
 			"_Test Account Excise Duty @ 15 - _TC": {"_Test Account Excise Duty - _TC": 15},

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -606,6 +606,7 @@ def _get_item_tax_template(args, taxes, out=None, for_validate=False):
 
 	# all templates have validity and no template is valid
 	if not taxes_with_validity and (not taxes_with_no_validity):
+		out["item_tax_template"] = ""
 		return None
 
 	# do not change if already a valid template


### PR DESCRIPTION
**Bug**
When fetching Item Details from the Item Code, the Item Tax Template value does not reset when the fetched Item does not have any tax templates set.


https://github.com/frappe/erpnext/assets/40693548/869f6480-3223-4888-9dee-786feb0c8afa


<br>

**Fix**
Set an empty string when Items with no valid tax templates return `None`.


**Notes for reviewer**
Previously, the tests for verifying the tax values from item tax templates did not check the values that `get_item_details` actually returned. Have made changes to verify the returned values. If these tests were intended for something else please mention.

`no-docs`