### PR TITLE
fix(payments): separate redirect constructor from authorization

### DIFF
--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -368,28 +368,29 @@ class PaymentRequest(Document):
 		if not status:
 			return
 
-		shopping_cart_settings = frappe.get_doc("E Commerce Settings")
-
 		if status in ["Authorized", "Completed"]:
-			redirect_to = None
 			self.set_as_paid()
+			self.on_payment_authorized_redirect()
 
-			# if shopping cart enabled and in session
-			if (
-				shopping_cart_settings.enabled
-				and hasattr(frappe.local, "session")
-				and frappe.local.session.user != "Guest"
-			) and self.payment_channel != "Phone":
+	def on_payment_authorized_redirect(self):
+		shopping_cart_settings = frappe.get_doc("E Commerce Settings")
+		redirect_to = None
+		# if shopping cart enabled and in session
+		if (
+			shopping_cart_settings.enabled
+			and hasattr(frappe.local, "session")
+			and frappe.local.session.user != "Guest"
+		) and self.payment_channel != "Phone":
 
-				success_url = shopping_cart_settings.payment_success_url
-				if success_url:
-					redirect_to = ({"Orders": "/orders", "Invoices": "/invoices", "My Account": "/me"}).get(
-						success_url, "/me"
-					)
-				else:
-					redirect_to = get_url("/orders/{0}".format(self.reference_name))
+			success_url = shopping_cart_settings.payment_success_url
+			if success_url:
+				redirect_to = ({"Orders": "/orders", "Invoices": "/invoices", "My Account": "/me"}).get(
+					success_url, "/me"
+				)
+			else:
+				redirect_to = get_url("/orders/{0}".format(self.reference_name))
 
-			return redirect_to
+		return redirect_to
 
 	def create_subscription(self, payment_provider, gateway_controller, data):
 		if payment_provider == "stripe":


### PR DESCRIPTION
# Context

Condiser a payment gateway that implements Instant Payment Notification (IPN), i.e. a request to
a custom webhook to notifiy the payment status.

Such IPN requests regularely are incoming prior to the user returning from the embedded form.

Now, those IPN endpoints in erpnext need to invoke `on_payment_authorized` on the referenc document all the while
they cannot make sense of any redirects.

What is more, as the user returns from the embedded form, they still need the redirect information, but _without_
invoking those parts of `on_payment_authorized` which would recreate state (such as: create payment entry and invoice).

Therefore, under the current implementation, implementing IPN means creating 2 payment entries, 2 invoces, etc, in those
cases wher not only the IPN returns but also the user (i.e. the user doesn't early abandon, but after having paid).

# Proposed solution

- Separate out the redirect callback so that it can be invoked independently from the user form return flow without recreating state
- Still keep it in `on_payment_authorized` in a backwards compatible manner

---

This is meant to be used in payment flow finalizers as so:
```python
		if not redirect_to:
			try:
				redirect_to = frappe.get_doc(
					reference_doctype, reference_docname,
				).run_method("on_payment_authorized_redirect")
			except:
    				pass
```