### PR TITLE
fix: GL Entries not getting created for PR Return

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -339,7 +339,7 @@ class PurchaseReceipt(BuyingController):
 		exchange_rate_map, net_rate_map = get_purchase_document_details(self)
 
 		for d in self.get("items"):
-			if d.item_code in stock_items and flt(d.valuation_rate) and flt(d.qty):
+			if d.item_code in stock_items and flt(d.qty) and (flt(d.valuation_rate) or self.is_return):
 				if warehouse_account.get(d.warehouse):
 					stock_value_diff = frappe.db.get_value(
 						"Stock Ledger Entry",

--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -2086,6 +2086,64 @@ class TestPurchaseReceipt(FrappeTestCase):
 		return_pr.reload()
 		self.assertEqual(return_pr.status, "Completed")
 
+	def test_purchase_return_with_zero_rate(self):
+		company = "_Test Company with perpetual inventory"
+
+		# Step - 1: Create Item
+		item, warehouse = (
+			make_item(properties={"is_stock_item": 1, "valuation_method": "Moving Average"}).name,
+			"Stores - TCP1",
+		)
+
+		# Step - 2: Create Stock Entry (Material Receipt)
+		from erpnext.stock.doctype.stock_entry.test_stock_entry import make_stock_entry
+
+		se = make_stock_entry(
+			purpose="Material Receipt",
+			item_code=item,
+			qty=100,
+			basic_rate=100,
+			to_warehouse=warehouse,
+			company=company,
+		)
+
+		# Step - 3: Create Purchase Receipt
+		pr = make_purchase_receipt(
+			item_code=item,
+			qty=5,
+			rate=0,
+			warehouse=warehouse,
+			company=company,
+		)
+
+		# Step - 4: Create Purchase Return
+		from erpnext.controllers.sales_and_purchase_return import make_return_doc
+
+		pr_return = make_return_doc("Purchase Receipt", pr.name)
+		pr_return.save()
+		pr_return.submit()
+
+		sl_entries = get_sl_entries(pr_return.doctype, pr_return.name)
+		gl_entries = get_gl_entries(pr_return.doctype, pr_return.name)
+
+		# Test - 1: SLE Stock Value Difference should be equal to Qty * Average Rate
+		average_rate = (
+			(se.items[0].qty * se.items[0].basic_rate) + (pr.items[0].qty * pr.items[0].rate)
+		) / (se.items[0].qty + pr.items[0].qty)
+		expected_stock_value_difference = pr_return.items[0].qty * average_rate
+		self.assertEqual(
+			flt(sl_entries[0].stock_value_difference, 2), flt(expected_stock_value_difference, 2)
+		)
+
+		# Test - 2: GL Entries should be created for Stock Value Difference
+		self.assertEqual(len(gl_entries), 2)
+
+		# Test - 3: SLE Stock Value Difference should be equal to Debit or Credit of GL Entries.
+		for entry in gl_entries:
+			self.assertEqual(abs(entry.debit + entry.credit), abs(sl_entries[0].stock_value_difference))
+
+		self.assertIsNotNone(get_gl_entries(pr_return.doctype, pr_return.name))
+
 
 def prepare_data_for_internal_transfer():
 	from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_internal_supplier


### PR DESCRIPTION
**Source / Ref:** 4388

**Issue:** Accounting Entries (GL Entries) not getting created for Purchase Return with 0 Rate, creating a difference between stock and account.

**Steps to Reproduce:**
- Create a Purchase Receipt ex. Qty = 5, Rate = 100.
- Create a Purchase Return ex. Qty = -5, Rate = 0.
- Check the SLE and GL Entries

Typically, the return rate matches the purchase rate. For instance, let's consider an example where the Valuation Method is set to Moving Average. The current Purchase Rate is 0, and the Moving Average is 50. When you initiate a Purchase Return, the rate will remain at 0. This action will result in a stock adjustment of -250 units (calculated as -5 * 50), and no GL Entries will be generated which will create a difference of 250.

_**Purchase Receipt:**_

![image](https://github.com/frappe/erpnext/assets/63660334/14ed5a44-65eb-4c90-9aac-8029616d430f)

_**Purchase Return:**_

![image](https://github.com/frappe/erpnext/assets/63660334/0a569fcf-51c5-4cb4-a37b-b8eaf210f455)

_**Before:**_

![image](https://github.com/frappe/erpnext/assets/63660334/83605899-49b0-4227-83ba-ee5fb9d6a9f0)

_**After:**_

![image](https://github.com/frappe/erpnext/assets/63660334/3319c3c0-c2de-4f3c-bb8f-d0c0bcae9a22)
