### PR TITLE
fix: set stock rbnb account for provisional accounting

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -329,10 +329,7 @@ class PurchaseReceipt(BuyingController):
 		)
 
 		stock_rbnb = None
-		if (
-			erpnext.is_perpetual_inventory_enabled(self.company)
-			or provisional_accounting_for_non_stock_items
-		):
+		if erpnext.is_perpetual_inventory_enabled(self.company):
 			stock_rbnb = self.get_company_default("stock_received_but_not_billed")
 			landed_cost_entries = get_item_account_wise_additional_cost(self.name)
 			expenses_included_in_valuation = self.get_company_default("expenses_included_in_valuation")

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -322,19 +322,23 @@ class PurchaseReceipt(BuyingController):
 			get_purchase_document_details,
 		)
 
+		provisional_accounting_for_non_stock_items = cint(
+			frappe.db.get_value(
+				"Company", self.company, "enable_provisional_accounting_for_non_stock_items"
+			)
+		)
+
 		stock_rbnb = None
-		if erpnext.is_perpetual_inventory_enabled(self.company):
+		if (
+			erpnext.is_perpetual_inventory_enabled(self.company)
+			or provisional_accounting_for_non_stock_items
+		):
 			stock_rbnb = self.get_company_default("stock_received_but_not_billed")
 			landed_cost_entries = get_item_account_wise_additional_cost(self.name)
 			expenses_included_in_valuation = self.get_company_default("expenses_included_in_valuation")
 
 		warehouse_with_no_account = []
 		stock_items = self.get_stock_items()
-		provisional_accounting_for_non_stock_items = cint(
-			frappe.db.get_value(
-				"Company", self.company, "enable_provisional_accounting_for_non_stock_items"
-			)
-		)
 
 		exchange_rate_map, net_rate_map = get_purchase_document_details(self)
 

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -419,7 +419,12 @@ class PurchaseReceipt(BuyingController):
 						credit_amount = outgoing_amount
 
 					if credit_amount:
-						account = warehouse_account[d.from_warehouse]["account"] if d.from_warehouse else stock_rbnb
+						if d.from_warehouse:
+							account = warehouse_account[d.from_warehouse]["account"]
+						elif stock_rbnb:
+							account = stock_rbnb
+						else:
+							account = self.get_company_default("stock_received_but_not_billed")
 
 						self.add_gl_entry(
 							gl_entries=gl_entries,


### PR DESCRIPTION
**Bug**
When submitting a Purchase Receipt, if **Perpetual Inventory** is disabled but **Provisional Accounting For Non Stock Items** is enabled, the `stock_rbnb` account is not set before creating the gl entries for the Purchase Receipt. Therefore, when creating the gl entry for the credit amount, the `stock_rbnb` account is used and on insertion of the entry, the following error is thrown.

<img width="1058" alt="Screenshot 2023-10-15 at 11 34 20 PM" src="https://github.com/frappe/erpnext/assets/40693548/8499bb8e-2557-4ad5-a619-4d9b185bba1f">
<br>

<br>

**Fix**
Set the value for stock_rbnb when Provisional Accounting For Non Stock Items is enabled.

`no-docs`