### PR TITLE
fix(minor): filter bank accounts in bank statement import

### DIFF
--- a/erpnext/accounts/doctype/bank_statement_import/bank_statement_import.js
+++ b/erpnext/accounts/doctype/bank_statement_import/bank_statement_import.js
@@ -2,6 +2,16 @@
 // For license information, please see license.txt
 
 frappe.ui.form.on("Bank Statement Import", {
+	onload(frm) {
+		frm.set_query("bank_account", function (doc) {
+			return {
+				filters: {
+					company: doc.company,
+				},
+			};
+		});
+	},
+
 	setup(frm) {
 		frappe.realtime.on("data_import_refresh", ({ data_import }) => {
 			frm.import_in_progress = false;


### PR DESCRIPTION
**Bug**
In Bank Statement Import DocType, the Link field for selecting a Bank Account does not filter based on the selected company.

**Fix**
Added a simple `set_query` for the Bank Account field.

`no-docs`