### PR TITLE
fix: same Serial No get mapped while creating SO -> DN

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -617,6 +617,7 @@ class AccountsController(TransactionBase):
 
 			self.pricing_rules = []
 
+			selected_serial_nos_map = {}
 			for item in self.get("items"):
 				if item.get("item_code"):
 					args = parent_dict.copy()
@@ -628,6 +629,7 @@ class AccountsController(TransactionBase):
 					args["ignore_pricing_rule"] = (
 						self.ignore_pricing_rule if hasattr(self, "ignore_pricing_rule") else 0
 					)
+					args["ignore_serial_nos"] = selected_serial_nos_map.get(item.get("item_code"))
 
 					if not args.get("transaction_date"):
 						args["transaction_date"] = args.get("posting_date")
@@ -684,6 +686,11 @@ class AccountsController(TransactionBase):
 					if ret.get("pricing_rules"):
 						self.apply_pricing_rule_on_items(item, ret)
 						self.set_pricing_rule_details(item, ret)
+
+					if ret.get("serial_no"):
+						selected_serial_nos_map.setdefault(item.get("item_code"), []).extend(
+							ret.get("serial_no").split("\n")
+						)
 				else:
 					# Transactions line item without item code
 

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -160,6 +160,7 @@ def update_stock(args, out):
 		and out.warehouse
 		and out.stock_qty > 0
 	):
+		out["ignore_serial_nos"] = args.get("ignore_serial_nos")
 
 		if out.has_batch_no and not args.get("batch_no"):
 			out.batch_no = get_batch_no(out.item_code, out.warehouse, out.qty)
@@ -1140,6 +1141,8 @@ def get_serial_nos_by_fifo(args, sales_order=None):
 			query = query.where(sn.sales_order == sales_order)
 		if args.batch_no:
 			query = query.where(sn.batch_no == args.batch_no)
+		if args.ignore_serial_nos:
+			query = query.where(sn.name.notin(args.ignore_serial_nos))
 
 		serial_nos = query.run(as_list=True)
 		serial_nos = [s[0] for s in serial_nos]
@@ -1450,6 +1453,7 @@ def get_serial_no(args, serial_nos=None, sales_order=None):
 					"item_code": args.get("item_code"),
 					"warehouse": args.get("warehouse"),
 					"stock_qty": args.get("stock_qty"),
+					"ignore_serial_nos": args.get("ignore_serial_nos"),
 				}
 			)
 			args = process_args(args)


### PR DESCRIPTION
**Source / Ref:** 1334

**Issue:** Same Serial Nos get mapped/selected by the system in Delivery Note having repetitive items with the same warehouse.

**Steps to Reproduce:**
- Enable `Automatically Set Serial Nos Based on FIFO` in Stock Settings.
- Create a Sales Order for a serialised item, and add the same item multiple times.
- Create a Delivery Note from the Sales Order, and try to submit it.

**Sales Order:**

![image](https://github.com/frappe/erpnext/assets/63660334/79f78daf-12d6-472f-95df-295e4a38de4a)

**Before:**

https://github.com/frappe/erpnext/assets/63660334/8273371b-feb4-4469-b53e-23bb82a6235a

**After:**

https://github.com/frappe/erpnext/assets/63660334/440419ec-0559-4d27-ac46-a3393d23c94c


