### PR TITLE
fix(test): project test case

### DIFF
--- a/erpnext/projects/doctype/task_depends_on/task_depends_on.json
+++ b/erpnext/projects/doctype/task_depends_on/task_depends_on.json
@@ -24,6 +24,7 @@
   },
   {
    "fetch_from": "task.subject",
+   "fetch_if_empty": 1,
    "fieldname": "subject",
    "fieldtype": "Text",
    "in_list_view": 1,
@@ -31,7 +32,6 @@
    "read_only": 1
   },
   {
-   "fetch_from": "task.project",
    "fieldname": "project",
    "fieldtype": "Text",
    "label": "Project",
@@ -40,7 +40,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2023-10-09 11:34:14.335853",
+ "modified": "2023-10-17 12:45:21.536165",
  "modified_by": "Administrator",
  "module": "Projects",
  "name": "Task Depends On",


### PR DESCRIPTION
```
======================================================================
 FAIL  test_project_template_having_parent_child_tasks (erpnext.projects.doctype.project.test_project.TestProject.test_project_template_having_parent_child_tasks)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/projects/doctype/project/test_project.py", line 91, in test_project_template_having_parent_child_tasks
    self.assertEqual(getdate(tasks[0].exp_end_date), calculate_end_date(project, 1, 10))
    project = <Project: PROJ-0002>
    project_name = 'Test Project with Template - Tasks with Parent-Child Relation'
    self = <erpnext.projects.doctype.project.test_project.TestProject testMethod=test_project_template_having_parent_child_tasks>
    task1 = <Task: TASK-2023-00005>
    task2 = <Task: TASK-2023-00006>
    task3 = <Task: TASK-2023-00007>
    tasks = [{'subject': 'Test Template Task Parent', 'exp_end_date': datetime.date(2023, 10, 31), 'depends_on_tasks': 'TASK-2023-00009,TASK-2023-00010,', 'name': 'TASK-2023-00008', 'parent_task': None}, {'subject': 'Test Template Task Child 1', 'exp_end_date': datetime.date(2023, 10, 20), 'depends_on_tasks': '', 'name': 'TASK-2023-00009', 'parent_task': 'TASK-2023-00008'}, {'subject': 'Test Template Task Child 2', 'exp_end_date': datetime.date(2023, 10, 21), 'depends_on_tasks': '', 'name': 'TASK-2023-00010', 'parent_task': 'TASK-2023-00008'}]
    template = <ProjectTemplate: Test Project Template  - Tasks with Parent-Child Relation>
AssertionError: datetime.date(2023, 10, 31) != datetime.date(2023, 10, 27)
```