### PR TITLE
fix(Employee): Delete user permission, if create permission is not checked

### DIFF
--- a/erpnext/setup/doctype/employee/employee.py
+++ b/erpnext/setup/doctype/employee/employee.py
@@ -83,6 +83,8 @@ class Employee(NestedSet):
 
 	def update_user_permissions(self):
 		if not self.create_user_permission:
+			remove_user_permission("Employee", self.name, self.user_id)
+			remove_user_permission("Company", self.company, self.user_id)
 			return
 		if not has_permission("User Permission", ptype="write", raise_exception=False):
 			return


### PR DESCRIPTION
While creating or updating Employee, if `Create User Permission` is not checked, delete the user permission for that user.
<img width="538" alt="Screenshot 2023-10-17 at 3 29 24 PM" src="https://github.com/frappe/erpnext/assets/28840468/122e57c3-26a1-4875-a7be-f07bb28d244c">

fixes : https://github.com/frappe/hrms/issues/643
