### PR TITLE
fix(minor): filter tax template based on company in subscription

### DIFF
--- a/erpnext/accounts/doctype/subscription/subscription.js
+++ b/erpnext/accounts/doctype/subscription/subscription.js
@@ -18,6 +18,14 @@ frappe.ui.form.on('Subscription', {
 				}
 			};
 		});
+
+		frm.set_query('sales_tax_template', function () {
+			return {
+				filters: {
+					company: frm.doc.company
+				}
+			};
+		});
 	},
 
 	refresh: function (frm) {


### PR DESCRIPTION
**Bug**
In Subscription DocType, the Sales Taxes and Charges Template Link field does not show options filtered based on the selected company.

**Fix**
Added a simple `set_query` for filtering the Sales Taxes and Charges Template options.

`no-docs`