### PR TITLE
fix: Add Stock UOM and Conversion Factor in Installation Note

### DIFF
--- a/erpnext/selling/doctype/installation_note/installation_note.js
+++ b/erpnext/selling/doctype/installation_note/installation_note.js
@@ -45,8 +45,52 @@ frappe.ui.form.on('Installation Note', {
 	},
 	contact_person: function(frm) {
 		erpnext.utils.get_contact_details(frm);
+	},
+	validate: function(frm) {
+		$.each(frm.doc.items || [], function(i, d) {
+			if (d.uom && d.item_code) {
+				getUOMDetails(d.item_code, d.uom, d.qty, function(transfer_qty) {
+					frappe.model.set_value(d.doctype, d.name, 'stock_qty', transfer_qty);
+				});
+			}
+		});
 	}
 });
+
+frappe.ui.form.on('Installation Note Item', {
+	uom: function(doc, cdt, cdn) {
+		var d = locals[cdt][cdn];
+		if (d.uom && d.item_code) {
+			getUOMDetails(d.item_code, d.uom, d.qty, function(transfer_qty) {
+				frappe.model.set_value(cdt, cdn, 'stock_qty', transfer_qty);
+			});
+		}
+	},
+	qty: function(doc, cdt, cdn) {
+		var d = locals[cdt][cdn];
+		if (d.uom && d.item_code) {
+			getUOMDetails(d.item_code, d.uom, d.qty, function(transfer_qty) {
+				frappe.model.set_value(cdt, cdn, 'stock_qty', transfer_qty);
+			});
+		}
+	}
+});
+
+function getUOMDetails(item_code, uom, qty, callback) {
+	frappe.call({
+		method: "erpnext.stock.doctype.stock_entry.stock_entry.get_uom_details",
+		args: {
+			item_code: item_code,
+			uom: uom,
+			qty: qty
+		},
+		callback: function(r) {
+			if (r.message) {
+				callback(r.message.transfer_qty);
+			}
+		}
+	});
+}
 
 frappe.provide("erpnext.selling");
 

--- a/erpnext/selling/doctype/installation_note_item/installation_note_item.json
+++ b/erpnext/selling/doctype/installation_note_item/installation_note_item.json
@@ -7,9 +7,15 @@
  "engine": "InnoDB",
  "field_order": [
   "item_code",
-  "serial_and_batch_bundle",
   "serial_no",
+  "section_break_do9t5",
   "qty",
+  "stock_uom",
+  "column_break_pqf37",
+  "uom",
+  "conversion_factor",
+  "stock_qty",
+  "section_break_en5le",
   "description",
   "prevdoc_detail_docname",
   "prevdoc_docname",
@@ -30,11 +36,10 @@
   {
    "fieldname": "serial_no",
    "fieldtype": "Small Text",
+   "in_list_view": 1,
    "label": "Serial No",
-   "no_copy": 1,
    "oldfieldname": "serial_no",
    "oldfieldtype": "Small Text",
-   "print_hide": 1,
    "print_width": "180px",
    "width": "180px"
   },
@@ -101,18 +106,47 @@
    "width": "150px"
   },
   {
-   "fieldname": "serial_and_batch_bundle",
+   "fieldname": "section_break_do9t5",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "stock_uom",
    "fieldtype": "Link",
-   "label": "Serial and Batch Bundle",
-   "no_copy": 1,
-   "options": "Serial and Batch Bundle",
-   "print_hide": 1
+   "label": "Stock UOM",
+   "options": "UOM",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_pqf37",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "uom",
+   "fieldtype": "Link",
+   "label": "UOM",
+   "options": "UOM"
+  },
+  {
+   "fieldname": "conversion_factor",
+   "fieldtype": "Float",
+   "label": "Conversion Factor",
+   "read_only": 1
+  },
+  {
+   "fieldname": "stock_qty",
+   "fieldtype": "Float",
+   "label": "Stock Qty",
+   "read_only": 1
+  },
+  {
+   "fieldname": "section_break_en5le",
+   "fieldtype": "Section Break"
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-03-12 13:47:08.257955",
+ "modified": "2023-10-18 11:12:15.482335",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Installation Note Item",

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -879,6 +879,7 @@ def make_installation_note(source_name, target_doc=None):
 	def update_item(obj, target, source_parent):
 		target.qty = flt(obj.qty) - flt(obj.installed_qty)
 		target.serial_no = obj.serial_no
+		target.stock_qty = obj.stock_qty
 
 	doclist = get_mapped_doc(
 		"Delivery Note",


### PR DESCRIPTION
Version: 14 Latest

**Before:**

- When you make an Installation Note from a Delivery Note in ERPNext, and the item has a different Conversion Factor and also has a serial number, the quantity might not match with the serial number due to the Conversion Factor difference.


https://github.com/frappe/erpnext/assets/18363620/451e446c-655f-40d2-8ad8-226b461b363c

<br>

**After:**

-  when you create an Installation Note from a Delivery Note after development, and the item has a different Conversion Factor and also has a serial number, the quantity will be adjusted to match the serial number based on the Conversion Factor.


https://github.com/frappe/erpnext/assets/18363620/c84e74d8-84b8-4af6-af68-b716adfcc53d

<br>

Thank You!