### PR TITLE
fix: add regional support to extend purchase gl entries

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -1066,7 +1066,7 @@ class PurchaseInvoice(BuyingController):
 								"debit_in_account_currency": (
 									base_asset_amount if cwip_account_currency == self.company_currency else asset_amount
 								),
-								"cost_center": self.cost_center,
+								"cost_center": item.cost_center or self.cost_center,
 								"project": item.project or self.project,
 							},
 							item=item,

--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -76,6 +76,7 @@ class StockController(AccountsController):
 		elif self.doctype in ["Purchase Receipt", "Purchase Invoice"] and self.docstatus == 1:
 			gl_entries = []
 			gl_entries = self.get_asset_gl_entry(gl_entries)
+			update_regional_gl_entries(gl_entries, self)
 			make_gl_entries(gl_entries, from_repost=from_repost)
 
 	def validate_serialized_batch(self):
@@ -855,8 +856,9 @@ class StockController(AccountsController):
 
 @frappe.whitelist()
 def show_accounting_ledger_preview(company, doctype, docname):
-	filters = {"company": company, "include_dimensions": 1}
+	filters = frappe._dict(company=company, include_dimensions=1)
 	doc = frappe.get_doc(doctype, docname)
+	doc.run_method("before_gl_preview")
 
 	gl_columns, gl_data = get_accounting_ledger_preview(doc, filters)
 
@@ -867,8 +869,9 @@ def show_accounting_ledger_preview(company, doctype, docname):
 
 @frappe.whitelist()
 def show_stock_ledger_preview(company, doctype, docname):
-	filters = {"company": company}
+	filters = frappe._dict(company=company)
 	doc = frappe.get_doc(doctype, docname)
+	doc.run_method("before_sl_preview")
 
 	sl_columns, sl_data = get_stock_ledger_preview(doc, filters)
 
@@ -1216,3 +1219,8 @@ def create_item_wise_repost_entries(voucher_type, voucher_no, allow_zero_rate=Fa
 		repost_entries.append(repost_entry)
 
 	return repost_entries
+
+
+@erpnext.allow_regional
+def update_regional_gl_entries(gl_list, doc):
+	return

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -822,14 +822,14 @@ class PurchaseReceipt(BuyingController):
 				po_details.append(d.purchase_order_item)
 
 		if po_details:
-			updated_pr += update_billed_amount_based_on_po(po_details, update_modified)
+			updated_pr += update_billed_amount_based_on_po(po_details, update_modified, self)
 
 		for pr in set(updated_pr):
 			pr_doc = self if (pr == self.name) else frappe.get_doc("Purchase Receipt", pr)
 			update_billing_percentage(pr_doc, update_modified=update_modified)
 
 
-def update_billed_amount_based_on_po(po_details, update_modified=True):
+def update_billed_amount_based_on_po(po_details, update_modified=True, pr_doc=None):
 	po_billed_amt_details = get_billed_amount_against_po(po_details)
 
 	# Get all Purchase Receipt Item rows against the Purchase Order Items
@@ -858,13 +858,19 @@ def update_billed_amount_based_on_po(po_details, update_modified=True):
 		po_billed_amt_details[pr_item.purchase_order_item] = billed_against_po
 
 		if pr_item.billed_amt != billed_amt_agianst_pr:
-			frappe.db.set_value(
-				"Purchase Receipt Item",
-				pr_item.name,
-				"billed_amt",
-				billed_amt_agianst_pr,
-				update_modified=update_modified,
-			)
+			# update existing doc if possible
+			if pr_doc and pr_item.parent == pr_doc.name:
+				pr_item = next((item for item in pr_doc.items if item.name == pr_item.name), None)
+				pr_item.db_set("billed_amt", billed_amt_agianst_pr, update_modified=update_modified)
+
+			else:
+				frappe.db.set_value(
+					"Purchase Receipt Item",
+					pr_item.name,
+					"billed_amt",
+					billed_amt_agianst_pr,
+					update_modified=update_modified,
+				)
 
 			updated_pr.append(pr_item.parent)
 


### PR DESCRIPTION
## Changes Made
- Regional overrides to update GL Entry in Purchase Receipt and Stock Controller
- Fallback for cost-center for fixed assets for consistency
- Introduced doc hooks `before_gl_preview` and `before_sl_preview`
- Filters as frappe._dict to avoid errors where dot notation was used in the report
- Removed load_from_db for Purchase receipt as it was no longer required

![image_2023-10-19_19-01-23](https://github.com/frappe/erpnext/assets/10496564/ff9c95a7-2c2c-452b-9ec8-36f3f5bed708)

### Additional Fix
Earlier existing doc was updated from `update_billed_amount_based_on_po` using `set_value` requiring `load_from_db`. Now trying to update the existing doc with db_set.
