### PR TITLE
feat(delivery): link to delivery notes list view from delivery trip

### DIFF
--- a/erpnext/stock/doctype/delivery_trip/delivery_trip.js
+++ b/erpnext/stock/doctype/delivery_trip/delivery_trip.js
@@ -64,6 +64,11 @@ frappe.ui.form.on('Delivery Trip', {
 				})
 			}, __("Get customers from"));
 		}
+		frm.add_custom_button(__("Delivery Notes"), function () {
+			frappe.set_route("List", "Delivery Note",
+					{'name': ["in", frm.doc.delivery_stops.map((stop) => {return stop.delivery_note;})]}
+			);
+		}, __("View"));
 	},
 
 	calculate_arrival_time: function (frm) {


### PR DESCRIPTION
# Context

Consider a delivery manager who is following up on the delivery stops.

To review comments left by dispatch on delivery notes (think: assignments), who are specific to a particular trip, they need a quick way to find the DNs associated with the DT.

However, there is no stable / fixed link (besides the indirection of the Driver / Vehicle).

# Proposed Solution

- Add a view link in the delivery trip form which allows quick navigation to the DNs part of this DT

![image](https://github.com/frappe/erpnext/assets/7548295/3e2c6689-e3ae-4840-bf01-d79b91ae880f)

