### PR TITLE
fix(delivery): rename dt fetch stop action

### DIFF
--- a/erpnext/stock/doctype/delivery_trip/delivery_trip.js
+++ b/erpnext/stock/doctype/delivery_trip/delivery_trip.js
@@ -62,7 +62,7 @@ frappe.ui.form.on('Delivery Trip', {
 						company: frm.doc.company,
 					}
 				})
-			}, __("Get customers from"));
+			}, __("Get stops from"));
 		}
 	},
 


### PR DESCRIPTION
# Context

"Get customers from" is not a semantically sensible action in the context of preparing a delivery route and not consisent with the rest of the document naming which refers to "Delivery Stops".

# Proposed Solution

- Rename to "Get stops from"
