### PR TITLE
refactor: use gzip library's compress() and decompress() methods directly

### DIFF
--- a/erpnext/stock/doctype/closing_stock_balance/closing_stock_balance.py
+++ b/erpnext/stock/doctype/closing_stock_balance/closing_stock_balance.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
-
+import gzip
 import json
 
 import frappe
@@ -8,7 +8,7 @@ from frappe import _
 from frappe.core.doctype.prepared_report.prepared_report import create_json_gz_file
 from frappe.desk.form.load import get_attachments
 from frappe.model.document import Document
-from frappe.utils import get_link_to_form, gzip_decompress, parse_json
+from frappe.utils import get_link_to_form, parse_json
 from frappe.utils.background_jobs import enqueue
 
 from erpnext.stock.report.stock_balance.stock_balance import execute
@@ -109,7 +109,7 @@ class ClosingStockBalance(Document):
 			attachment = attachments[0]
 			attached_file = frappe.get_doc("File", attachment.name)
 
-			data = gzip_decompress(attached_file.get_content())
+			data = gzip.decompress(attached_file.get_content())
 			if data := json.loads(data.decode("utf-8")):
 				data = data
 

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -2,6 +2,7 @@
 # License: GNU General Public License v3. See license.txt
 
 import copy
+import gzip
 import json
 from typing import Optional, Set, Tuple
 
@@ -10,17 +11,7 @@ from frappe import _, scrub
 from frappe.model.meta import get_field_precision
 from frappe.query_builder import Case
 from frappe.query_builder.functions import CombineDatetime, Sum
-from frappe.utils import (
-	cint,
-	flt,
-	get_link_to_form,
-	getdate,
-	gzip_compress,
-	gzip_decompress,
-	now,
-	nowdate,
-	parse_json,
-)
+from frappe.utils import cint, flt, get_link_to_form, getdate, now, nowdate, parse_json
 
 import erpnext
 from erpnext.stock.doctype.bin.bin import update_qty as update_bin_qty
@@ -295,7 +286,7 @@ def get_reposting_data(file_path) -> dict:
 
 	attached_file = frappe.get_doc("File", file_name)
 
-	data = gzip_decompress(attached_file.get_content())
+	data = gzip.decompress(attached_file.get_content())
 	if data := json.loads(data.decode("utf-8")):
 		data = data
 
@@ -378,7 +369,7 @@ def get_reposting_file_name(dt, dn):
 
 def create_json_gz_file(data, doc, file_name=None) -> str:
 	encoded_content = frappe.safe_encode(frappe.as_json(data))
-	compressed_content = gzip_compress(encoded_content)
+	compressed_content = gzip.compress(encoded_content)
 
 	if not file_name:
 		json_filename = f"{scrub(doc.doctype)}-{scrub(doc.name)}.json.gz"


### PR DESCRIPTION
The util methods in framework were added for python2.7 compat, so can be removed