### PR TITLE
fix: validate sales order item with quotation

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -216,7 +216,15 @@ class SalesOrder(SellingController):
 
 	def validate_with_previous_doc(self):
 		super(SalesOrder, self).validate_with_previous_doc(
-			{"Quotation": {"ref_dn_field": "prevdoc_docname", "compare_fields": [["company", "="]]}}
+			{
+				"Quotation": {"ref_dn_field": "prevdoc_docname", "compare_fields": [["company", "="]]},
+				"Quotation Item": {
+					"ref_dn_field": "quotation_item",
+					"compare_fields": [["item_code", "="], ["uom", "="], ["conversion_factor", "="]],
+					"is_child_table": True,
+					"allow_duplicate_prev_row_id": True,
+				},
+			}
 		)
 
 		if cint(frappe.db.get_single_value("Selling Settings", "maintain_same_sales_rate")):


### PR DESCRIPTION
**Bug**

- System allows the creation of a Sales Order with items that have reference to a Quotation even when the Quotation does not consist of the item.

- This leads to a Quotation with a different set of items as the Sales Order. 

- The status of the Quotation is shown as **Partially Ordered** even though none of the items from the Quotation were actually Ordered.

**Fix**
Added validation for ensuring that if a SO Item has reference to a Quotation, it is present in the Quotation.


`no-docs`