### PR TITLE
fix: close employee loan on write off

### DIFF
--- a/erpnext/loan_management/doctype/loan/loan.py
+++ b/erpnext/loan_management/doctype/loan/loan.py
@@ -411,11 +411,6 @@ def close_unsecured_term_loan(loan):
 		frappe.throw(_("Cannot close this loan until full repayment"))
 
 
-def close_loan(loan, total_amount_paid):
-	frappe.db.set_value("Loan", loan, "total_amount_paid", total_amount_paid)
-	frappe.db.set_value("Loan", loan, "status", "Closed")
-
-
 @frappe.whitelist()
 def make_loan_disbursement(loan, company, applicant_type, applicant, pending_amount=0, as_dict=0):
 	disbursement_entry = frappe.new_doc("Loan Disbursement")

--- a/erpnext/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/erpnext/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -755,12 +755,8 @@ def get_amounts(amounts, against_loan, posting_date):
 		)
 		unaccrued_interest += pending_days * per_day_interest
 
-	written_off_amount = flt(against_loan_doc.written_off_amount, precision)
-
 	amounts["pending_principal_amount"] = flt(pending_principal_amount, precision)
-	amounts["payable_principal_amount"] = flt(
-		max(payable_principal_amount - written_off_amount, 0), precision
-	)
+	amounts["payable_principal_amount"] = flt(payable_principal_amount, precision)
 	amounts["interest_amount"] = flt(total_pending_interest, precision)
 	amounts["penalty_amount"] = flt(penalty_amount + pending_penalty_amount, precision)
 	amounts["payable_amount"] = flt(
@@ -768,7 +764,7 @@ def get_amounts(amounts, against_loan, posting_date):
 	)
 	amounts["pending_accrual_entries"] = pending_accrual_entries
 	amounts["unaccrued_interest"] = flt(unaccrued_interest, precision)
-	amounts["written_off_amount"] = written_off_amount
+	amounts["written_off_amount"] = flt(against_loan_doc.written_off_amount, precision)
 
 	if final_due_date:
 		amounts["due_date"] = final_due_date

--- a/erpnext/loan_management/doctype/loan_repayment/loan_repayment.py
+++ b/erpnext/loan_management/doctype/loan_repayment/loan_repayment.py
@@ -755,8 +755,12 @@ def get_amounts(amounts, against_loan, posting_date):
 		)
 		unaccrued_interest += pending_days * per_day_interest
 
+	written_off_amount = flt(against_loan_doc.written_off_amount, precision)
+
 	amounts["pending_principal_amount"] = flt(pending_principal_amount, precision)
-	amounts["payable_principal_amount"] = flt(payable_principal_amount, precision)
+	amounts["payable_principal_amount"] = flt(
+		max(payable_principal_amount - written_off_amount, 0), precision
+	)
 	amounts["interest_amount"] = flt(total_pending_interest, precision)
 	amounts["penalty_amount"] = flt(penalty_amount + pending_penalty_amount, precision)
 	amounts["payable_amount"] = flt(
@@ -764,7 +768,7 @@ def get_amounts(amounts, against_loan, posting_date):
 	)
 	amounts["pending_accrual_entries"] = pending_accrual_entries
 	amounts["unaccrued_interest"] = flt(unaccrued_interest, precision)
-	amounts["written_off_amount"] = flt(against_loan_doc.written_off_amount, precision)
+	amounts["written_off_amount"] = written_off_amount
 
 	if final_due_date:
 		amounts["due_date"] = final_due_date

--- a/erpnext/loan_management/doctype/loan_write_off/loan_write_off.py
+++ b/erpnext/loan_management/doctype/loan_write_off/loan_write_off.py
@@ -9,6 +9,9 @@ from frappe.utils import cint, flt, getdate
 import erpnext
 from erpnext.accounts.general_ledger import make_gl_entries
 from erpnext.controllers.accounts_controller import AccountsController
+from erpnext.loan_management.doctype.loan_repayment.loan_repayment import (
+	get_pending_principal_amount,
+)
 
 
 class LoanWriteOff(AccountsController):
@@ -39,11 +42,13 @@ class LoanWriteOff(AccountsController):
 	def on_submit(self):
 		self.update_outstanding_amount()
 		self.make_gl_entries()
+		self.close_employee_loan()
 
 	def on_cancel(self):
 		self.update_outstanding_amount(cancel=1)
 		self.ignore_linked_doctypes = ["GL Entry", "Payment Ledger Entry"]
 		self.make_gl_entries(cancel=1)
+		self.close_employee_loan(cancel=1)
 
 	def update_outstanding_amount(self, cancel=0):
 		written_off_amount = frappe.db.get_value("Loan", self.loan, "written_off_amount")
@@ -94,3 +99,39 @@ class LoanWriteOff(AccountsController):
 		)
 
 		make_gl_entries(gl_entries, cancel=cancel, merge_entries=False)
+
+	def close_employee_loan(self, cancel=0):
+		if not frappe.db.has_column("Loan", "repay_from_salary"):
+			return
+
+		loan = frappe.get_value(
+			"Loan",
+			self.loan,
+			[
+				"total_payment",
+				"total_principal_paid",
+				"loan_amount",
+				"total_interest_payable",
+				"written_off_amount",
+				"disbursed_amount",
+				"status",
+				"is_secured_loan",
+				"repay_from_salary",
+				"name",
+			],
+			as_dict=1,
+		)
+
+		if loan.is_secured_loan or not loan.repay_from_salary:
+			return
+
+		if not cancel:
+			pending_principal_amount = get_pending_principal_amount(loan)
+
+			precision = cint(frappe.db.get_default("currency_precision")) or 2
+
+			if flt(pending_principal_amount, precision) <= 0:
+				frappe.db.set_value("Loan", loan.name, "status", "Closed")
+				frappe.msgprint(_("Loan {0} closed").format(loan.name))
+		else:
+			frappe.db.set_value("Loan", loan.loan, "status", "Disbursed")


### PR DESCRIPTION
A user did a write off for a loan but when he runs the payroll through Frappe HR, the system still fetches the loan which had been written off. The reason was that the loan wasn't closed after write off. Now, the loan would be closed after a write off if there's no pending principal amount.