### PR TITLE
fix: make changes that enable gantt view for job cards

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.json
+++ b/erpnext/manufacturing/doctype/job_card/job_card.json
@@ -434,13 +434,11 @@
   {
    "fieldname": "expected_start_date",
    "fieldtype": "Datetime",
-   "in_list_view": 1,
    "label": "Expected Start Date"
   },
   {
    "fieldname": "expected_end_date",
    "fieldtype": "Datetime",
-   "in_list_view": 1,
    "label": "Expected End Date"
   },
   {

--- a/erpnext/manufacturing/doctype/job_card/job_card.json
+++ b/erpnext/manufacturing/doctype/job_card/job_card.json
@@ -511,7 +511,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2023-10-24 14:56:52.375153",
+ "modified": "2023-06-28 19:23:14.345214",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Job Card",

--- a/erpnext/manufacturing/doctype/job_card/job_card.json
+++ b/erpnext/manufacturing/doctype/job_card/job_card.json
@@ -434,11 +434,13 @@
   {
    "fieldname": "expected_start_date",
    "fieldtype": "Datetime",
+   "in_list_view": 1,
    "label": "Expected Start Date"
   },
   {
    "fieldname": "expected_end_date",
    "fieldtype": "Datetime",
+   "in_list_view": 1,
    "label": "Expected End Date"
   },
   {
@@ -511,7 +513,7 @@
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2023-06-28 19:23:14.345214",
+ "modified": "2023-10-24 14:56:52.375153",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Job Card",

--- a/erpnext/manufacturing/doctype/job_card/job_card_calendar.js
+++ b/erpnext/manufacturing/doctype/job_card/job_card_calendar.js
@@ -10,8 +10,8 @@ frappe.views.calendar["Job Card"] = {
 	},
 	gantt: {
 		field_map: {
-			"start": "started_time",
-			"end": "started_time",
+			"start": "expected_start_date",
+			"end": "expected_end_date",
 			"id": "name",
 			"title": "subject",
 			"color": "color",

--- a/erpnext/manufacturing/doctype/job_card/job_card_list.js
+++ b/erpnext/manufacturing/doctype/job_card/job_card_list.js
@@ -1,6 +1,6 @@
 frappe.listview_settings['Job Card'] = {
 	has_indicator_for_draft: true,
-
+	add_fields: ["expected_start_date", "expected_end_date"],
 	get_indicator: function(doc) {
 		const status_colors = {
 			"Work In Progress": "orange",


### PR DESCRIPTION
**Title: Make changes that enable gantt view for job cards**

**Description:**
This pull request fixes an issue in the Gantt View for Job Cards in ERPNext. In the current state you cant use the Gantt View at all. 

You can look at our before-after pictures, where we explain what exactly we have changed to make it work.

Thanks for considering this pull request and please backport it to version-14-hotfix and version-13-hotfix if possible. Cause we found this bug in version 14 too.


**BEFORE**
![image](https://github.com/frappe/erpnext/assets/118364772/e4a4fa50-d292-47e6-943a-94add3bb2753)




**AFTER**
![image](https://github.com/frappe/erpnext/assets/118364772/4e663fae-0f6f-48aa-a78e-ccd04fd95719)





