### PR TITLE
fix(minor): set tax values for item variants

### DIFF
--- a/erpnext/stock/doctype/item/item.py
+++ b/erpnext/stock/doctype/item/item.py
@@ -255,7 +255,7 @@ class Item(Document):
 
 		# add item taxes from template
 		for d in template.get("taxes"):
-			self.append("taxes", {"item_tax_template": d.item_tax_template})
+			self.append("taxes", d)
 
 		# copy re-order table if empty
 		if not self.get("reorder_levels"):

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -268,7 +268,7 @@ def get_basic_details(args, item, overwrite_warehouse=True):
 	if not item:
 		item = frappe.get_doc("Item", args.get("item_code"))
 
-	if item.variant_of:
+	if item.variant_of and not item.taxes:
 		item.update_template_tables()
 
 	item_defaults = get_item_defaults(item.name, args.company)


### PR DESCRIPTION
**Bug**
When `get_mapped_doc` is used to create say a Sales Invoice from a Sales Order and the Order has the Variant of an Item present in it, the system tries to update the taxes for that variant. However, this takes place even if the Variant already has some rows in the taxes table. 

**Fix**

- Only update the taxes for Variant if the child table is empty.
- Set all values for the child table and not just the item tax template value, since either the `valid_from` or `maximum_net_rate` is required for sorting the taxes.


`no-docs`