### PR TITLE
fix: set correct `purchase_sle` in `get_last_sle()`

### DIFF
--- a/erpnext/stock/doctype/serial_no/serial_no.py
+++ b/erpnext/stock/doctype/serial_no/serial_no.py
@@ -191,7 +191,7 @@ class SerialNo(StockController):
 		sle_dict = self.get_stock_ledger_entries(serial_no)
 		if sle_dict:
 			if sle_dict.get("incoming", []):
-				entries["purchase_sle"] = sle_dict["incoming"][0]
+				entries["purchase_sle"] = sle_dict["incoming"][-1]
 
 			if len(sle_dict.get("incoming", [])) - len(sle_dict.get("outgoing", [])) > 0:
 				entries["last_sle"] = sle_dict["incoming"][0]


### PR DESCRIPTION
When a **Serial No** is *moved* via a **Stock Entry** of type **Material Transfer**, the **Creation Document** under the **Purchase / Manufacture Details** sections is overwritten by the latest **Stock Entry Ledger**. This seems incorrect. This PR aims to fix this, but I'm uncertain if there are situations where different behaviors are expected or if the original behavior was intentional.

`sle_dict` may look like this:
```
{
  'incoming': [
    {... Stock Entry ...},
    {... Purchase Receipt ...}
  ],
  'outgoing': [
    {... Stock Entry ...}
  ]
}
```

Not relevant for version 15 and onwards.