### PR TITLE
fix: negative current qty causing recursion issue

### DIFF
--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -647,7 +647,7 @@ class StockReconciliation(StockController):
 					{"voucher_detail_no": row.name, "actual_qty": ("<", 0), "is_cancelled": 0},
 					"name",
 				)
-				and current_qty
+				and current_qty > 0
 			):
 				new_sle = self.get_sle_for_items(row)
 				new_sle.actual_qty = current_qty * -1


### PR DESCRIPTION
If the Current Quantity is in negative in the backdated Stock Reconciliation for the Batch Item then system throws the recursion issue while submitting the entry

```
  File "apps/erpnext/erpnext/stock/stock_ledger.py", line 87, in make_sl_entries

    repost_current_voucher(args, allow_negative_stock, via_landed_cost_voucher)

  File "apps/erpnext/erpnext/stock/stock_ledger.py", line 103, in repost_current_voucher

    update_entries_after(

  File "apps/erpnext/erpnext/stock/stock_ledger.py", line 396, in init

    self.build()

  File "apps/erpnext/erpnext/stock/stock_ledger.py", line 444, in build

    self.process_sle_against_current_timestamp()

  File "apps/erpnext/erpnext/stock/stock_ledger.py", line 467, in process_sle_against_current_timestamp

    self.process_sle(sle)

  File "apps/erpnext/erpnext/stock/stock_ledger.py", line 576, in process_sle

    self.reset_actual_qty_for_stock_reco(sle)

  File "apps/erpnext/erpnext/stock/stock_ledger.py", line 648, in reset_actual_qty_for_stock_reco

    doc.recalculate_current_qty(sle.voucher_detail_no, sle.creation, sle.actual_qty >= 0)

  File "apps/erpnext/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py", line 659, in recalculate_current_qty

    self.make_sl_entries(sl_entries, allow_negative_stock=self.has_negative_stock_allowed())

  File "apps/erpnext/erpnext/controllers/stock_controller.py", line 513, in make_sl_entries

    make_sl_entries(sl_entries, allow_negative_stock, via_landed_cost_voucher)

  File "apps/erpnext/erpnext/stock/stock_ledger.py", line 75, in make_sl_entries

    sle_doc = make_entry(sle, allow_negative_stock, via_landed_cost_voucher)

  File "apps/erpnext/erpnext/stock/stock_ledger.py", line 202, in make_entry

    sle.submit()

  File "apps/frappe/frappe/model/document.py", line 1008, in submit

    return self._submit()

  File "apps/frappe/frappe/model/document.py", line 987, in _submit

    return self.save()

  File "apps/frappe/frappe/model/document.py", line 307, in save

    return self._save(*args, **kwargs)

  File "apps/frappe/frappe/model/document.py", line 329, in _save

    return self.insert()

  File "apps/frappe/frappe/model/document.py", line 261, in insert

    self.run_before_save_methods()

  File "apps/frappe/frappe/model/document.py", line 1056, in run_before_save_methods

    self.run_method("validate")

  File "apps/frappe/frappe/model/document.py", line 917, in run_method

    out = Document.hook(fn)(self, args, *kwargs)

  File "apps/frappe/frappe/model/document.py", line 1279, in composer

    return composed(self, method, args, *kwargs)

  File "apps/frappe/frappe/model/document.py", line 1261, in runner

    add_to_return_value(self, fn(self, args, *kwargs))

  File "apps/frappe/frappe/model/document.py", line 914, in fn

    return method_object(*args, **kwargs)

  File "apps/erpnext/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py", line 45, in validate

    self.validate_item()

  File "apps/erpnext/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py", line 173, in validate_item

    elif not frappe.db.get_value("Batch", {"item": self.item_code, "name": self.batch_no}):

  File "apps/frappe/frappe/database/database.py", line 509, in get_value

    result = self.get_values(

  File "apps/frappe/frappe/database/database.py", line 606, in get_values

    out = self._get_values_from_table(

  File "apps/frappe/frappe/database/database.py", line 822, in getvalues_from_table

    query = frappe.qb.get_query(

  File "apps/frappe/frappe/query_builder/utils.py", line 61, in get_query

    return Engine().get_query(*args, **kwargs)

  File "apps/frappe/frappe/database/query.py", line 73, in get_query

    self.apply_fields(fields)

  File "apps/frappe/frappe/database/query.py", line 101, in apply_fields

    self.fields = self.parse_fields(fields)

  File "apps/frappe/frappe/database/query.py", line 305, in parse_fields

    fields = self.sanitize_fields(fields)

  File "apps/frappe/frappe/database/query.py", line 282, in sanitize_fields

    return [_sanitize_field(field) for field in fields]

  File "apps/frappe/frappe/database/query.py", line 282, in <listcomp>

    return [_sanitize_field(field) for field in fields]

  File "apps/frappe/frappe/database/query.py", line 276, in sanitizefield

    stripped_field = sqlparse.format(field, strip_comments=True, keyword_case="lower")

  File "env/lib/python3.10/site-packages/sqlparse/__init__.py", line 59, in format

    return ''.join(stack.run(sql, encoding))

  File "env/lib/python3.10/site-packages/sqlparse/engine/filter_stack.py", line 36, in run

    stmt = grouping.group(stmt)

  File "env/lib/python3.10/site-packages/sqlparse/engine/grouping.py", line 428, in group

    func(stmt)

  File "env/lib/python3.10/site-packages/sqlparse/utils.py", line 74, in wrapped_f

    f(tlist)

  File "env/lib/python3.10/site-packages/sqlparse/engine/grouping.py", line 299, in group_comments

    tidx, token = tlist.token_next_by(t=T.Comment)

  File "env/lib/python3.10/site-packages/sqlparse/sql.py", line 266, in token_next_by

    return self._token_matching(lambda tk: imt(tk, i, m, t), idx, end)

  File "env/lib/python3.10/site-packages/sqlparse/sql.py", line 245, in tokenmatching

    if func(token):

  File "env/lib/python3.10/site-packages/sqlparse/sql.py", line 266, in <lambda>

    return self._token_matching(lambda tk: imt(tk, i, m, t), idx, end)

  File "env/lib/python3.10/site-packages/sqlparse/utils.py", line 99, in imt

    elif types and any(token.ttype in ttype for ttype in types):

  File "env/lib/python3.10/site-packages/sqlparse/utils.py", line 99, in <genexpr>

    elif types and any(token.ttype in ttype for ttype in types):

  File "env/lib/python3.10/site-packages/sqlparse/tokens.py", line 19, in contains

    return item is not None and (self is item or item[:len(self)] == self)

RecursionError: maximum recursion depth exceeded in comparison
```

