### PR TITLE
fix: consider reserved stock while cancelling a stock transaction

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -347,5 +347,6 @@ execute:frappe.db.set_single_value("Payment Reconciliation", "invoice_limit", 50
 execute:frappe.db.set_single_value("Payment Reconciliation", "payment_limit", 50)
 erpnext.patches.v15_0.rename_daily_depreciation_to_depreciation_amount_based_on_num_days_in_month
 erpnext.patches.v15_0.rename_depreciation_amount_based_on_num_days_in_month_to_daily_prorata_based
+erpnext.patches.v15_0.set_reserved_stock_in_bin
 # below migration patch should always run last
 erpnext.patches.v14_0.migrate_gl_to_payment_ledger

--- a/erpnext/patches/v15_0/set_reserved_stock_in_bin.py
+++ b/erpnext/patches/v15_0/set_reserved_stock_in_bin.py
@@ -1,0 +1,24 @@
+import frappe
+from frappe.query_builder.functions import Sum
+
+
+def execute():
+	sre = frappe.qb.DocType("Stock Reservation Entry")
+	query = (
+		frappe.qb.from_(sre)
+		.select(
+			sre.item_code,
+			sre.warehouse,
+			Sum(sre.reserved_qty - sre.delivered_qty).as_("reserved_stock"),
+		)
+		.where((sre.docstatus == 1) & (sre.status.notin(["Delivered", "Cancelled"])))
+		.groupby(sre.item_code, sre.warehouse)
+	)
+
+	for d in query.run(as_dict=True):
+		frappe.db.set_value(
+			"Bin",
+			{"item_code": d.item_code, "warehouse": d.warehouse},
+			"reserved_stock",
+			d.reserved_stock,
+		)

--- a/erpnext/stock/doctype/bin/bin.json
+++ b/erpnext/stock/doctype/bin/bin.json
@@ -13,12 +13,13 @@
   "planned_qty",
   "indented_qty",
   "ordered_qty",
+  "projected_qty",
   "column_break_xn5j",
   "reserved_qty",
   "reserved_qty_for_production",
   "reserved_qty_for_sub_contract",
   "reserved_qty_for_production_plan",
-  "projected_qty",
+  "reserved_stock",
   "section_break_pmrs",
   "stock_uom",
   "column_break_0slj",
@@ -173,13 +174,20 @@
   {
    "fieldname": "column_break_0slj",
    "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "fieldname": "reserved_stock",
+   "fieldtype": "Float",
+   "label": "Reserved Stock",
+   "read_only": 1
   }
  ],
  "hide_toolbar": 1,
  "idx": 1,
  "in_create": 1,
  "links": [],
- "modified": "2023-11-01 15:35:51.722534",
+ "modified": "2023-11-01 16:51:17.079107",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Bin",

--- a/erpnext/stock/doctype/bin/bin.py
+++ b/erpnext/stock/doctype/bin/bin.py
@@ -148,6 +148,17 @@ class Bin(Document):
 		self.set_projected_qty()
 		self.db_set("projected_qty", self.projected_qty, update_modified=True)
 
+	def update_reserved_stock(self):
+		"""Update `Reserved Stock` on change in Reserved Qty of Stock Reservation Entry"""
+
+		from erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry import (
+			get_sre_reserved_qty_for_item_and_warehouse,
+		)
+
+		reserved_stock = get_sre_reserved_qty_for_item_and_warehouse(self.item_code, self.warehouse)
+
+		self.db_set("reserved_stock", flt(reserved_stock), update_modified=True)
+
 
 def on_doctype_update():
 	frappe.db.add_unique("Bin", ["item_code", "warehouse"], constraint_name="unique_item_warehouse")

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -365,6 +365,9 @@ class DeliveryNote(SellingController):
 					# Update Stock Reservation Entry `Status` based on `Delivered Qty`.
 					sre_doc.update_status()
 
+					# Update Reserved Stock in Bin.
+					sre_doc.update_reserved_stock_in_bin()
+
 					qty_to_deliver -= qty_can_be_deliver
 
 		if self._action == "cancel":
@@ -426,6 +429,9 @@ class DeliveryNote(SellingController):
 
 					# Update Stock Reservation Entry `Status` based on `Delivered Qty`.
 					sre_doc.update_status()
+
+					# Update Reserved Stock in Bin.
+					sre_doc.update_reserved_stock_in_bin()
 
 					qty_to_undelivered -= qty_can_be_undelivered
 

--- a/erpnext/stock/doctype/stock_reservation_entry/test_stock_reservation_entry.py
+++ b/erpnext/stock/doctype/stock_reservation_entry/test_stock_reservation_entry.py
@@ -286,6 +286,7 @@ class TestStockReservationEntry(FrappeTestCase):
 				self.assertEqual(item.stock_reserved_qty, sre_details.reserved_qty)
 				self.assertEqual(sre_details.status, "Partially Reserved")
 
+			cancel_stock_reservation_entries("Sales Order", so.name)
 			se.cancel()
 
 			# Test - 3: Stock should be fully Reserved if the Available Qty to Reserve is greater than the Un-reserved Qty.

--- a/erpnext/stock/doctype/stock_reservation_entry/test_stock_reservation_entry.py
+++ b/erpnext/stock/doctype/stock_reservation_entry/test_stock_reservation_entry.py
@@ -494,7 +494,7 @@ class TestStockReservationEntry(FrappeTestCase):
 			"pick_serial_and_batch_based_on": "FIFO",
 		},
 	)
-	def test_stock_reservation_from_pick_list(self):
+	def test_stock_reservation_from_pick_list(self) -> None:
 		items_details = create_items()
 		create_material_receipt(items_details, self.warehouse, qty=100)
 
@@ -576,7 +576,7 @@ class TestStockReservationEntry(FrappeTestCase):
 			"auto_reserve_stock_for_sales_order_on_purchase": 1,
 		},
 	)
-	def test_stock_reservation_from_purchase_receipt(self):
+	def test_stock_reservation_from_purchase_receipt(self) -> None:
 		from erpnext.buying.doctype.purchase_order.purchase_order import make_purchase_receipt
 		from erpnext.selling.doctype.sales_order.sales_order import make_material_request
 		from erpnext.stock.doctype.material_request.material_request import make_purchase_order
@@ -645,6 +645,40 @@ class TestStockReservationEntry(FrappeTestCase):
 
 				# Test - 3: Reserved Serial/Batch Nos should be equal to PR Item Serial/Batch Nos.
 				self.assertEqual(set(sb_details), set(reserved_sb_details))
+
+	@change_settings(
+		"Stock Settings",
+		{
+			"allow_negative_stock": 0,
+			"enable_stock_reservation": 1,
+			"auto_reserve_serial_and_batch": 1,
+			"pick_serial_and_batch_based_on": "FIFO",
+		},
+	)
+	def test_consider_reserved_stock_while_cancelling_an_inward_transaction(self) -> None:
+		items_details = create_items()
+		se = create_material_receipt(items_details, self.warehouse, qty=100)
+
+		item_list = []
+		for item_code, properties in items_details.items():
+			item_list.append(
+				{
+					"item_code": item_code,
+					"warehouse": self.warehouse,
+					"qty": randint(11, 100),
+					"uom": properties.stock_uom,
+					"rate": randint(10, 400),
+				}
+			)
+
+		so = make_sales_order(
+			item_list=item_list,
+			warehouse=self.warehouse,
+		)
+		so.create_stock_reservation_entries()
+
+		# Test - 1: ValidationError should be thrown as the inwarded stock is reserved.
+		self.assertRaises(frappe.ValidationError, se.cancel)
 
 	def tearDown(self) -> None:
 		cancel_all_stock_reservation_entries()

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -1833,20 +1833,20 @@ def validate_reserved_stock(kwargs):
 		elif batch_nos := [entry.batch_no for entry in sbb_entries if entry.batch_no]:
 			validate_reserved_batch_nos(kwargs.item_code, kwargs.warehouse, batch_nos)
 
-	else:
-		precision = cint(frappe.db.get_default("float_precision")) or 2
-		balance_qty = get_stock_balance(kwargs.item_code, kwargs.warehouse)
+	# Qty based validation for non-serial-batch items OR SRE with Reservation Based On Qty.
+	precision = cint(frappe.db.get_default("float_precision")) or 2
+	balance_qty = get_stock_balance(kwargs.item_code, kwargs.warehouse)
 
-		diff = flt(balance_qty - kwargs.get("reserved_stock", 0), precision)
-		if diff < 0 and abs(diff) > 0.0001:
-			msg = _("{0} units of {1} needed in {2} on {3} {4} to complete this transaction.").format(
-				abs(diff),
-				frappe.get_desk_link("Item", kwargs.item_code),
-				frappe.get_desk_link("Warehouse", kwargs.warehouse),
-				nowdate(),
-				nowtime(),
-			)
-			frappe.throw(msg, title=_("Reserved Stock"))
+	diff = flt(balance_qty - kwargs.get("reserved_stock", 0), precision)
+	if diff < 0 and abs(diff) > 0.0001:
+		msg = _("{0} units of {1} needed in {2} on {3} {4} to complete this transaction.").format(
+			abs(diff),
+			frappe.get_desk_link("Item", kwargs.item_code),
+			frappe.get_desk_link("Warehouse", kwargs.warehouse),
+			nowdate(),
+			nowtime(),
+		)
+		frappe.throw(msg, title=_("Reserved Stock"))
 
 
 def validate_reserved_serial_nos(item_code, warehouse, serial_nos):

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -11,11 +11,17 @@ from frappe import _, scrub
 from frappe.model.meta import get_field_precision
 from frappe.query_builder import Case
 from frappe.query_builder.functions import CombineDatetime, Sum
-from frappe.utils import cint, flt, get_link_to_form, getdate, now, nowdate, parse_json
+from frappe.utils import cint, flt, get_link_to_form, getdate, now, nowdate, nowtime, parse_json
 
 import erpnext
 from erpnext.stock.doctype.bin.bin import update_qty as update_bin_qty
 from erpnext.stock.doctype.inventory_dimension.inventory_dimension import get_inventory_dimensions
+from erpnext.stock.doctype.serial_and_batch_bundle.serial_and_batch_bundle import (
+	get_available_batches,
+)
+from erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry import (
+	get_sre_reserved_batch_nos_details,
+)
 from erpnext.stock.doctype.stock_reservation_entry.stock_reservation_entry import (
 	get_sre_reserved_qty_for_item_and_warehouse as get_reserved_stock,
 )
@@ -1809,6 +1815,9 @@ def validate_reserved_stock(kwargs):
 		serial_nos = kwargs.serial_no.split("\n")
 		validate_reserved_serial_nos(kwargs.item_code, kwargs.warehouse, serial_nos)
 
+	elif kwargs.batch_no:
+		validate_reserved_batch_nos(kwargs.item_code, kwargs.warehouse, [kwargs.batch_no])
+
 	elif kwargs.serial_and_batch_bundle:
 		sbb_entries = frappe.db.get_all(
 			"Serial and Batch Entry",
@@ -1817,12 +1826,13 @@ def validate_reserved_stock(kwargs):
 				"parent": kwargs.serial_and_batch_bundle,
 				"docstatus": 1,
 			},
-			["batch_no", "serial_no", "qty"],
+			["batch_no", "serial_no"],
 		)
-		serial_nos = [entry.serial_no for entry in sbb_entries if entry.serial_no]
 
-		if serial_nos:
+		if serial_nos := [entry.serial_no for entry in sbb_entries if entry.serial_no]:
 			validate_reserved_serial_nos(kwargs.item_code, kwargs.warehouse, serial_nos)
+		elif batch_nos := [entry.batch_no for entry in sbb_entries if entry.batch_no]:
+			validate_reserved_batch_nos(kwargs.item_code, kwargs.warehouse, batch_nos)
 
 
 def validate_reserved_serial_nos(item_code, warehouse, serial_nos):
@@ -1843,6 +1853,36 @@ def validate_reserved_serial_nos(item_code, warehouse, serial_nos):
 				),
 			)
 			frappe.throw(msg, title=_("Reserved Serial No."))
+
+
+def validate_reserved_batch_nos(item_code, warehouse, batch_nos):
+	if reserved_batches_map := get_sre_reserved_batch_nos_details(item_code, warehouse, batch_nos):
+		available_batches = get_available_batches(
+			frappe._dict(
+				{
+					"item_code": item_code,
+					"warehouse": warehouse,
+					"posting_date": nowdate(),
+					"posting_time": nowtime(),
+				}
+			)
+		)
+		available_batches_map = {row.batch_no: row.qty for row in available_batches}
+		precision = cint(frappe.db.get_default("float_precision")) or 2
+
+		for batch_no in batch_nos:
+			diff = flt(
+				available_batches_map.get(batch_no, 0) - reserved_batches_map.get(batch_no, 0), precision
+			)
+			if diff < 0 and abs(diff) > 0.0001:
+				msg = _("{0} units of {1} needed in {2} on {3} {4} to complete this transaction.").format(
+					abs(diff),
+					frappe.get_desk_link("Batch", batch_no),
+					frappe.get_desk_link("Warehouse", warehouse),
+					nowdate(),
+					nowtime(),
+				)
+				frappe.throw(msg, title=_("Reserved Stock for Batch"))
 
 
 def is_negative_stock_allowed(*, item_code: Optional[str] = None) -> bool:


### PR DESCRIPTION
**Issue:** Inward stock transactions should not be allowed to be cancelled if there is reserved stock.

**Steps to Reproduce (In V15 or Develop):**
- Create new Items.
- Create Stock Entry (Material Receipt) ex. 10 Qty.
- Create a Sales Order ex. 10 Qty.
- Reserve Stock for Sales Order ex. 10 Qty.
- Now, cancel the Stock Entry.

**Expected:** A validation should be performed to ensure the reserved stock available in the system at any time. However, the user can unreserve the same and cancel the inward transaction if needed.

