### PR TITLE
fix: indexing on Delivery Note Item

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
+++ b/erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
@@ -900,7 +900,8 @@
    "label": "Delivery Note Item",
    "no_copy": 1,
    "print_hide": 1,
-   "read_only": 1
+   "read_only": 1,
+   "search_index": 1
   },
   {
    "collapsible": 1,
@@ -1089,7 +1090,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-10-19 10:50:58.071735",
+ "modified": "2023-10-30 17:32:24.560337",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Purchase Receipt Item",


### PR DESCRIPTION
Added index on delivery note item field to improve purchase receipt submission 