### PR TITLE
chore: fix test case

### DIFF
--- a/erpnext/stock/doctype/quality_inspection_template/test_records.json
+++ b/erpnext/stock/doctype/quality_inspection_template/test_records.json
@@ -1,13 +1,17 @@
 [
- {
-     "quality_inspection_template_name" : "_Test Quality Inspection Template",
-     "doctype": "Quality Inspection Template",
-     "item_quality_inspection_parameter" : [
-           {
-            "specification": "_Test Param",
-            "doctype": "Item Quality Inspection Parameter",
-            "parentfield": "item_quality_inspection_parameter"
-           }
-     ]
- }
+	{
+		"doctype": "Quality Inspection Parameter",
+		"parameter": "_Test Param"
+	},
+	{
+		"quality_inspection_template_name" : "_Test Quality Inspection Template",
+		"doctype": "Quality Inspection Template",
+		"item_quality_inspection_parameter" : [
+			{
+				"specification": "_Test Param",
+				"doctype": "Item Quality Inspection Parameter",
+				"parentfield": "item_quality_inspection_parameter"
+			}
+		]
+	}
 ]


### PR DESCRIPTION
```
File "/home/runner/frappe-bench/apps/frappe/frappe/__init__.py", line 496, in _raise_exception
    raise exc
      exc = LinkValidationError('Could not find Row #1: Parameter: _Test Param')
      msg = 'Could not find Row #1: Parameter: _Test Param'
      out = {'message': 'Could not find Row #1: Parameter: _Test Param', 'title': 'Message', 'indicator': 'red', 'raise_exception': 1, '__frappe_exc_id': '958957e333b147f4adfd2424b28e671c4aa9de4034697b043a038b61'}
      raise_exception = <class 'frappe.exceptions.LinkValidationError'>
      ...skipped... 1 vars
frappe.exceptions.LinkValidationError: Could not find Row #1: Parameter: _Test Param
```