### PR TITLE
Update bom.js

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.js
+++ b/erpnext/manufacturing/doctype/bom/bom.js
@@ -48,7 +48,6 @@ frappe.ui.form.on("BOM", {
 			return {
 				query: "erpnext.manufacturing.doctype.bom.bom.item_query",
 				filters: {
-					"include_item_in_manufacturing": 1,
 					"is_fixed_asset": 0
 				}
 			};


### PR DESCRIPTION
fix: Allow BOM items without `include_item_in_manufacturing`, small components that do not require issuing based on work orders. Instead, they are issued in bulk as a one-time batch