### PR TITLE
fix: e-invoice jwt verification error

### DIFF
--- a/erpnext/regional/india/e_invoice/utils.py
+++ b/erpnext/regional/india/e_invoice/utils.py
@@ -1378,7 +1378,7 @@ class GSPConnector:
 
 	def set_einvoice_data(self, res):
 		enc_signed_invoice = res.get("SignedInvoice")
-		dec_signed_invoice = jwt.decode(enc_signed_invoice, verify=False)["data"]
+		dec_signed_invoice = jwt.decode(enc_signed_invoice, options={"verify_signature": False})["data"]
 
 		self.invoice.irn = res.get("Irn")
 		self.invoice.ewaybill = res.get("EwbNo")


### PR DESCRIPTION
```
Exception:
Traceback (most recent call last):
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/regional/india/e_invoice/utils.py", line 1020, in generate_irn
    self.set_einvoice_data(irn_details)
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/regional/india/e_invoice/utils.py", line 1381, in set_einvoice_data
    dec_signed_invoice = jwt.decode(enc_signed_invoice, verify=False)["data"]
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/jwt/api_jwt.py", line 129, in decode
    decoded = self.decode_complete(jwt, key, algorithms, options, **kwargs)
  File "/home/frappe/frappe-bench/env/lib/python3.7/site-packages/jwt/api_jwt.py", line 97, in decode_complete
    'It is required that you pass in a value for the "algorithms" argument when calling decode().'
jwt.exceptions.DecodeError: It is required that you pass in a value for the "algorithms" argument when calling decode()
```