### PR TITLE
fix: `TypeError` in PR for non-stock item

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -600,11 +600,10 @@ class PurchaseReceipt(BuyingController):
 					make_rate_difference_entry(d)
 					make_sub_contracting_gl_entries(d)
 					make_divisional_loss_gl_entry(d, outgoing_amount)
-			elif (
-				d.warehouse not in warehouse_with_no_account
-				or d.rejected_warehouse not in warehouse_with_no_account
+			elif (d.warehouse and d.warehouse not in warehouse_with_no_account) or (
+				d.rejected_warehouse and d.rejected_warehouse not in warehouse_with_no_account
 			):
-				warehouse_with_no_account.append(d.warehouse)
+				warehouse_with_no_account.append(d.warehouse or d.rejected_warehouse)
 
 			if d.is_fixed_asset:
 				self.update_assets(d, d.valuation_rate)


### PR DESCRIPTION
**Source / Ref:** 5274 and 5309

**Issue:** In Purchase Receipt, Accepted and Rejected Warehouse are optional for non-stock items. If Accepted Warehouse is not set in the row, a default warehouse gets fetched from the Item Master. In a case where Default Warehouse is not set, `d.warehouse` can have a falcy (None or '') value, which throws a TypeError or [this](https://github.com/s-aga-r/erpnext/blob/c5e4e0174782222dc4bc26e3f03f5724d16c99ce/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py#L580-L584) msg without warehouse.