### PR TITLE
fix: standard submit perm in repost ledger for editable invoices

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2269,8 +2269,8 @@ class AccountsController(TransactionBase):
 			repost_ledger = frappe.new_doc("Repost Accounting Ledger")
 			repost_ledger.company = self.company
 			repost_ledger.append("vouchers", {"voucher_type": self.doctype, "voucher_no": self.name})
-			repost_ledger.insert(ignore_permissions=True)
-			repost_ledger.save(ignore_permissions=True)
+			repost_ledger.flags.ignore_permissions = True
+			repost_ledger.insert()
 			repost_ledger.submit()
 			self.db_set("repost_required", 0)
 		else:

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2269,8 +2269,8 @@ class AccountsController(TransactionBase):
 			repost_ledger = frappe.new_doc("Repost Accounting Ledger")
 			repost_ledger.company = self.company
 			repost_ledger.append("vouchers", {"voucher_type": self.doctype, "voucher_no": self.name})
-			repost_ledger.insert()
-			repost_ledger.submit()
+			repost_ledger.insert(ignore_permissions=True)
+			repost_ledger.submit(ignore_permissions=True)
 			self.db_set("repost_required", 0)
 		else:
 			frappe.throw(_("No updates pending for reposting"))

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2270,7 +2270,8 @@ class AccountsController(TransactionBase):
 			repost_ledger.company = self.company
 			repost_ledger.append("vouchers", {"voucher_type": self.doctype, "voucher_no": self.name})
 			repost_ledger.insert(ignore_permissions=True)
-			repost_ledger.submit(ignore_permissions=True)
+			repost_ledger.save(ignore_permissions=True)
+			repost_ledger.submit()
 			self.db_set("repost_required", 0)
 		else:
 			frappe.throw(_("No updates pending for reposting"))


### PR DESCRIPTION
Ignore User Permissions while creating the Repost Accounting Ledger Document if Sales / Purchase Invoices are updated.

`no-docs`
