### PR TITLE
refactor: Consolidate duplicate zero-quantity Items checks for transactions.

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -14,7 +14,7 @@ from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_ent
 from erpnext.buying.doctype.purchase_order.purchase_order import get_mapped_purchase_invoice
 from erpnext.buying.doctype.purchase_order.test_purchase_order import create_purchase_order
 from erpnext.buying.doctype.supplier.test_supplier import create_supplier
-from erpnext.controllers.accounts_controller import get_payment_terms
+from erpnext.controllers.accounts_controller import ZeroQuantityError, get_payment_terms
 from erpnext.controllers.buying_controller import QtyMismatchError
 from erpnext.exceptions import InvalidCurrency
 from erpnext.projects.doctype.project.test_project import make_project
@@ -53,7 +53,7 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 
 	def test_pi_zero_quantity_item(self):
 		pi = make_purchase_invoice(qty=0, do_not_save=True)
-		with self.assertRaises(frappe.ValidationError):
+		with self.assertRaises(ZeroQuantityError):
 			pi.save()
 
 		# No error with qty=1

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -23,7 +23,7 @@ from erpnext.assets.doctype.asset.test_asset import create_asset, create_asset_d
 from erpnext.assets.doctype.asset_depreciation_schedule.asset_depreciation_schedule import (
 	get_depr_schedule,
 )
-from erpnext.controllers.accounts_controller import update_invoice_status
+from erpnext.controllers.accounts_controller import ZeroQuantityError, update_invoice_status
 from erpnext.controllers.taxes_and_totals import get_itemised_tax_breakup_data
 from erpnext.exceptions import InvalidAccountCurrency, InvalidCurrency
 from erpnext.selling.doctype.customer.test_customer import get_customer_dict
@@ -74,7 +74,7 @@ class TestSalesInvoice(FrappeTestCase):
 
 	def test_si_zero_quantity_item(self):
 		si = create_sales_invoice(qty=0, do_not_save=True)
-		with self.assertRaises(frappe.ValidationError):
+		with self.assertRaises(ZeroQuantityError):
 			si.save()
 
 		# No error with qty=1

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -72,6 +72,16 @@ class TestSalesInvoice(FrappeTestCase):
 	def tearDownClass(self):
 		unlink_payment_on_cancel_of_invoice(0)
 
+	def test_si_zero_quantity_item(self):
+		si = create_sales_invoice(qty=0, do_not_save=True)
+		with self.assertRaises(frappe.ValidationError):
+			si.save()
+
+		# No error with qty=1
+		si.items[0].qty = 1
+		si.save()
+		self.assertEqual(si.items[0].qty, 1)
+
 	def test_timestamp_change(self):
 		w = frappe.copy_doc(test_records[0])
 		w.docstatus = 0
@@ -3521,7 +3531,7 @@ def create_sales_invoice(**args):
 	bundle_id = None
 	if si.update_stock and (args.get("batch_no") or args.get("serial_no")):
 		batches = {}
-		qty = args.qty or 1
+		qty = args.qty if args.qty is not None else 1
 		item_code = args.item or args.item_code or "_Test Item"
 		if args.get("batch_no"):
 			batches = frappe._dict({args.batch_no: qty})
@@ -3553,7 +3563,7 @@ def create_sales_invoice(**args):
 			"description": args.description or "_Test Item",
 			"warehouse": args.warehouse or "_Test Warehouse - _TC",
 			"target_warehouse": args.target_warehouse,
-			"qty": args.qty or 1,
+			"qty": args.qty if args.qty is not None else 1,
 			"uom": args.uom or "Nos",
 			"stock_uom": args.uom or "Nos",
 			"rate": args.rate if args.get("rate") is not None else 100,

--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -16,7 +16,7 @@ from erpnext.buying.doctype.purchase_order.purchase_order import (
 	make_purchase_invoice as make_pi_from_po,
 )
 from erpnext.buying.doctype.purchase_order.purchase_order import make_purchase_receipt
-from erpnext.controllers.accounts_controller import update_child_qty_rate
+from erpnext.controllers.accounts_controller import ZeroQuantityError, update_child_qty_rate
 from erpnext.manufacturing.doctype.blanket_order.test_blanket_order import make_blanket_order
 from erpnext.stock.doctype.item.test_item import make_item
 from erpnext.stock.doctype.material_request.material_request import make_purchase_order
@@ -29,7 +29,7 @@ from erpnext.stock.doctype.purchase_receipt.purchase_receipt import (
 class TestPurchaseOrder(FrappeTestCase):
 	def test_po_zero_quantity_item(self):
 		po = create_purchase_order(qty=0, do_not_save=True)
-		with self.assertRaises(frappe.ValidationError):
+		with self.assertRaises(ZeroQuantityError):
 			po.save()
 
 		# No error with qty=1

--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -27,6 +27,16 @@ from erpnext.stock.doctype.purchase_receipt.purchase_receipt import (
 
 
 class TestPurchaseOrder(FrappeTestCase):
+	def test_po_zero_quantity_item(self):
+		po = create_purchase_order(qty=0, do_not_save=True)
+		with self.assertRaises(frappe.ValidationError):
+			po.save()
+
+		# No error with qty=1
+		po.items[0].qty = 1
+		po.save()
+		self.assertEqual(po.items[0].qty, 1)
+
 	def test_make_purchase_receipt(self):
 		po = create_purchase_order(do_not_submit=True)
 		self.assertRaises(frappe.ValidationError, make_purchase_receipt, po.name)
@@ -1061,7 +1071,7 @@ def create_purchase_order(**args):
 				"item_code": args.item or args.item_code or "_Test Item",
 				"warehouse": args.warehouse or "_Test Warehouse - _TC",
 				"from_warehouse": args.from_warehouse,
-				"qty": args.qty or 10,
+				"qty": args.qty if args.qty is not None else 10,
 				"rate": args.rate or 500,
 				"schedule_date": add_days(nowdate(), 1),
 				"include_exploded_items": args.get("include_exploded_items", 1),

--- a/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
+++ b/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
@@ -26,6 +26,7 @@ class RequestforQuotation(BuyingController):
 	def validate(self):
 		self.validate_duplicate_supplier()
 		self.validate_supplier_list()
+		super(RequestforQuotation, self).validate_qty_is_not_zero()
 		validate_for_items(self)
 		super(RequestforQuotation, self).set_qty_as_per_stock_uom()
 		self.update_email_id()

--- a/erpnext/buying/doctype/request_for_quotation/test_request_for_quotation.py
+++ b/erpnext/buying/doctype/request_for_quotation/test_request_for_quotation.py
@@ -14,6 +14,7 @@ from erpnext.buying.doctype.request_for_quotation.request_for_quotation import (
 	get_pdf,
 	make_supplier_quotation_from_rfq,
 )
+from erpnext.controllers.accounts_controller import ZeroQuantityError
 from erpnext.crm.doctype.opportunity.opportunity import make_request_for_quotation as make_rfq
 from erpnext.crm.doctype.opportunity.test_opportunity import make_opportunity
 from erpnext.stock.doctype.item.test_item import make_item
@@ -23,7 +24,7 @@ from erpnext.templates.pages.rfq import check_supplier_has_docname_access
 class TestRequestforQuotation(FrappeTestCase):
 	def test_rfq_zero_quantity_item(self):
 		rfq = make_request_for_quotation(qty=0, do_not_save=True)
-		with self.assertRaises(frappe.ValidationError):
+		with self.assertRaises(ZeroQuantityError):
 			rfq.save()
 
 		# No error with qty=1

--- a/erpnext/buying/doctype/supplier_quotation/test_supplier_quotation.py
+++ b/erpnext/buying/doctype/supplier_quotation/test_supplier_quotation.py
@@ -7,6 +7,17 @@ from frappe.tests.utils import FrappeTestCase
 
 
 class TestPurchaseOrder(FrappeTestCase):
+	def test_sq_zero_quantity_item(self):
+		sq = frappe.copy_doc(test_records[0])
+		sq.items[0].qty = 0
+		with self.assertRaises(frappe.ValidationError):
+			sq.save()
+
+		# No error with qty=1
+		sq.items[0].qty = 1
+		sq.save()
+		self.assertEqual(sq.items[0].qty, 1)
+
 	def test_make_purchase_order(self):
 		from erpnext.buying.doctype.supplier_quotation.supplier_quotation import make_purchase_order
 

--- a/erpnext/buying/doctype/supplier_quotation/test_supplier_quotation.py
+++ b/erpnext/buying/doctype/supplier_quotation/test_supplier_quotation.py
@@ -5,12 +5,14 @@
 import frappe
 from frappe.tests.utils import FrappeTestCase
 
+from erpnext.controllers.accounts_controller import ZeroQuantityError
+
 
 class TestPurchaseOrder(FrappeTestCase):
 	def test_sq_zero_quantity_item(self):
 		sq = frappe.copy_doc(test_records[0])
 		sq.items[0].qty = 0
-		with self.assertRaises(frappe.ValidationError):
+		with self.assertRaises(ZeroQuantityError):
 			sq.save()
 
 		# No error with qty=1

--- a/erpnext/buying/utils.py
+++ b/erpnext/buying/utils.py
@@ -42,12 +42,15 @@ def update_last_purchase_rate(doc, is_submit) -> None:
 
 
 def validate_for_items(doc) -> None:
+	from erpnext.controllers.accounts_controller import ZeroQuantityError
+
 	items = []
 	for d in doc.get("items"):
 		if not d.qty:
 			if doc.doctype == "Purchase Receipt" and d.rejected_qty:
 				continue
-			frappe.throw(_("Please enter quantity for Item {0}").format(d.item_code))
+			message = _("Please enter quantity for Item {0}").format(d.item_code)
+			frappe.throw(message, ZeroQuantityError)
 
 		set_stock_levels(row=d)  # update with latest quantities
 		item = validate_item_and_get_basic_data(row=d)

--- a/erpnext/buying/utils.py
+++ b/erpnext/buying/utils.py
@@ -42,16 +42,8 @@ def update_last_purchase_rate(doc, is_submit) -> None:
 
 
 def validate_for_items(doc) -> None:
-	from erpnext.controllers.accounts_controller import ZeroQuantityError
-
 	items = []
 	for d in doc.get("items"):
-		if not d.qty:
-			if doc.doctype == "Purchase Receipt" and d.rejected_qty:
-				continue
-			message = _("Please enter quantity for Item {0}").format(d.item_code)
-			frappe.throw(message, ZeroQuantityError)
-
 		set_stock_levels(row=d)  # update with latest quantities
 		item = validate_item_and_get_basic_data(row=d)
 		validate_stock_item_warehouse(row=d, item=item)

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -914,10 +914,14 @@ class AccountsController(TransactionBase):
 			return flt(args.get(field, 0) / self.get("conversion_rate", 1))
 
 	def validate_qty_is_not_zero(self):
-		if self.doctype != "Purchase Receipt":
-			for item in self.items:
-				if not item.qty:
-					frappe.throw(_("Item quantity can not be zero"), ZeroQuantityError)
+		for item in self.items:
+			if self.doctype == "Purchase Receipt" and item.rejected_qty:
+				continue
+			if not item.qty:
+				message = _("Row # {0}: Quantity for Item {1} cannot be zero").format(
+					item.idx, frappe.bold(item.item_code)
+				)
+				frappe.throw(message, ZeroQuantityError, title=_("Invalid Quantity"))
 
 	def validate_account_currency(self, account, account_currency=None):
 		valid_currency = [self.company_currency]

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -71,6 +71,10 @@ class AccountMissingError(frappe.ValidationError):
 	pass
 
 
+class ZeroQuantityError(frappe.ValidationError):
+	pass
+
+
 force_item_fields = (
 	"item_group",
 	"brand",
@@ -913,7 +917,7 @@ class AccountsController(TransactionBase):
 		if self.doctype != "Purchase Receipt":
 			for item in self.items:
 				if not item.qty:
-					frappe.throw(_("Item quantity can not be zero"))
+					frappe.throw(_("Item quantity can not be zero"), ZeroQuantityError)
 
 	def validate_account_currency(self, account, account_currency=None):
 		valid_currency = [self.company_currency]

--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -7,7 +7,7 @@ from frappe import _, bold, throw
 from frappe.utils import cint, flt, get_link_to_form, nowtime
 
 from erpnext.accounts.party import render_address
-from erpnext.controllers.accounts_controller import get_taxes_and_charges
+from erpnext.controllers.accounts_controller import ZeroQuantityError, get_taxes_and_charges
 from erpnext.controllers.sales_and_purchase_return import get_rate_for_return
 from erpnext.controllers.stock_controller import StockController
 from erpnext.stock.doctype.item.item import set_item_default
@@ -296,7 +296,8 @@ class SellingController(StockController):
 		il = []
 		for d in self.get("items"):
 			if d.qty is None:
-				frappe.throw(_("Row {0}: Qty is mandatory").format(d.idx))
+				message = _("Row {0}: Qty is mandatory").format(d.idx)
+				frappe.throw(message, ZeroQuantityError)
 
 			if self.has_product_bundle(d.item_code):
 				for p in self.get("packed_items"):

--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -7,7 +7,7 @@ from frappe import _, bold, throw
 from frappe.utils import cint, flt, get_link_to_form, nowtime
 
 from erpnext.accounts.party import render_address
-from erpnext.controllers.accounts_controller import ZeroQuantityError, get_taxes_and_charges
+from erpnext.controllers.accounts_controller import get_taxes_and_charges
 from erpnext.controllers.sales_and_purchase_return import get_rate_for_return
 from erpnext.controllers.stock_controller import StockController
 from erpnext.stock.doctype.item.item import set_item_default
@@ -295,10 +295,6 @@ class SellingController(StockController):
 	def get_item_list(self):
 		il = []
 		for d in self.get("items"):
-			if d.qty is None:
-				message = _("Row {0}: Qty is mandatory").format(d.idx)
-				frappe.throw(message, ZeroQuantityError)
-
 			if self.has_product_bundle(d.item_code):
 				for p in self.get("packed_items"):
 					if p.parent_detail_docname == d.name and p.parent_item == d.item_code:

--- a/erpnext/manufacturing/doctype/bom/test_bom.py
+++ b/erpnext/manufacturing/doctype/bom/test_bom.py
@@ -28,6 +28,28 @@ test_dependencies = ["Item", "Quality Inspection Template"]
 
 class TestBOM(FrappeTestCase):
 	@timeout
+	def test_bom_zero_quantity_item(self):
+		from erpnext.stock.doctype.item.test_item import make_item
+
+		# No error.
+		bom = frappe.new_doc("BOM")
+		item = make_item(properties={"is_stock_item": 1})
+		bom.item = fg_item.item_code
+		bom.quantity = 1
+		bom.append(
+			"items",
+			{
+				"item_code": bom_item.item_code,
+				"qty": 0,
+				"uom": bom_item.stock_uom,
+				"stock_uom": bom_item.stock_uom,
+				"rate": 100.0,
+			},
+		)
+		bom.save()
+		self.assertEqual(bom.items[0].qty, 0)
+
+	@timeout
 	def test_get_items(self):
 		from erpnext.manufacturing.doctype.bom.bom import get_bom_items_as_dict
 

--- a/erpnext/manufacturing/doctype/bom/test_bom.py
+++ b/erpnext/manufacturing/doctype/bom/test_bom.py
@@ -9,6 +9,7 @@ import frappe
 from frappe.tests.utils import FrappeTestCase, timeout
 from frappe.utils import cstr, flt
 
+from erpnext.controllers.accounts_controller import ZeroQuantityError
 from erpnext.controllers.tests.test_subcontracting_controller import (
 	make_stock_in_entry,
 	set_backflush_based_on,

--- a/erpnext/selling/doctype/quotation/test_quotation.py
+++ b/erpnext/selling/doctype/quotation/test_quotation.py
@@ -5,13 +5,15 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils import add_days, add_months, flt, getdate, nowdate
 
+from erpnext.controllers.accounts_controller import ZeroQuantityError
+
 test_dependencies = ["Product Bundle"]
 
 
 class TestQuotation(FrappeTestCase):
 	def test_qo_zero_quantity_item(self):
 		qo = make_quotation(qty=0, do_not_save=True)
-		with self.assertRaises(frappe.ValidationError):
+		with self.assertRaises(ZeroQuantityError):
 			qo.save()
 
 		# No error with qty=1

--- a/erpnext/selling/doctype/quotation/test_quotation.py
+++ b/erpnext/selling/doctype/quotation/test_quotation.py
@@ -9,6 +9,16 @@ test_dependencies = ["Product Bundle"]
 
 
 class TestQuotation(FrappeTestCase):
+	def test_qo_zero_quantity_item(self):
+		qo = make_quotation(qty=0, do_not_save=True)
+		with self.assertRaises(frappe.ValidationError):
+			qo.save()
+
+		# No error with qty=1
+		qo.items[0].qty = 1
+		qo.save()
+		self.assertEqual(qo.items[0].qty, 1)
+
 	def test_make_quotation_without_terms(self):
 		quotation = make_quotation(do_not_save=1)
 		self.assertFalse(quotation.get("payment_schedule"))
@@ -629,7 +639,7 @@ def make_quotation(**args):
 			{
 				"item_code": args.item or args.item_code or "_Test Item",
 				"warehouse": args.warehouse,
-				"qty": args.qty or 10,
+				"qty": args.qty if args.qty is not None else 10,
 				"uom": args.uom or None,
 				"rate": args.rate or 100,
 			},

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -9,7 +9,7 @@ from frappe.core.doctype.user_permission.test_user_permission import create_user
 from frappe.tests.utils import FrappeTestCase, change_settings
 from frappe.utils import add_days, flt, getdate, nowdate, today
 
-from erpnext.controllers.accounts_controller import update_child_qty_rate
+from erpnext.controllers.accounts_controller import ZeroQuantityError, update_child_qty_rate
 from erpnext.maintenance.doctype.maintenance_schedule.test_maintenance_schedule import (
 	make_maintenance_schedule,
 )
@@ -53,7 +53,7 @@ class TestSalesOrder(FrappeTestCase):
 
 	def test_so_zero_quantity_item(self):
 		so = make_sales_order(qty=0, do_not_save=True)
-		with self.assertRaises(frappe.ValidationError):
+		with self.assertRaises(ZeroQuantityError):
 			so.save()
 
 		# No error with qty=1

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -51,6 +51,16 @@ class TestSalesOrder(FrappeTestCase):
 	def tearDown(self):
 		frappe.set_user("Administrator")
 
+	def test_so_zero_quantity_item(self):
+		so = make_sales_order(qty=0, do_not_save=True)
+		with self.assertRaises(frappe.ValidationError):
+			so.save()
+
+		# No error with qty=1
+		so.items[0].qty = 1
+		so.save()
+		self.assertEqual(so.items[0].qty, 1)
+
 	def test_make_material_request(self):
 		so = make_sales_order(do_not_submit=True)
 
@@ -1986,7 +1996,7 @@ def make_sales_order(**args):
 			{
 				"item_code": args.item or args.item_code or "_Test Item",
 				"warehouse": args.warehouse,
-				"qty": args.qty or 10,
+				"qty": args.qty if args.qty is not None else 10,
 				"uom": args.uom or None,
 				"price_list_rate": args.price_list_rate or None,
 				"discount_percentage": args.discount_percentage or None,

--- a/erpnext/stock/doctype/delivery_note/test_delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/test_delivery_note.py
@@ -10,6 +10,7 @@ from frappe.utils import add_days, cstr, flt, nowdate, nowtime, today
 
 from erpnext.accounts.doctype.account.test_account import get_inventory_account
 from erpnext.accounts.utils import get_balance_on
+from erpnext.controllers.accounts_controller import ZeroQuantityError
 from erpnext.selling.doctype.product_bundle.test_product_bundle import make_product_bundle
 from erpnext.selling.doctype.sales_order.test_sales_order import (
 	automatically_fetch_payment_terms,
@@ -44,7 +45,7 @@ from erpnext.stock.stock_ledger import get_previous_sle
 class TestDeliveryNote(FrappeTestCase):
 	def test_dn_zero_quantity_item(self):
 		dn = create_delivery_note(qty=0, do_not_save=True)
-		with self.assertRaises(frappe.ValidationError):
+		with self.assertRaises(ZeroQuantityError):
 			dn.save()
 
 		# No error with qty=1

--- a/erpnext/stock/doctype/delivery_note/test_delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/test_delivery_note.py
@@ -42,6 +42,16 @@ from erpnext.stock.stock_ledger import get_previous_sle
 
 
 class TestDeliveryNote(FrappeTestCase):
+	def test_dn_zero_quantity_item(self):
+		dn = create_delivery_note(qty=0, do_not_save=True)
+		with self.assertRaises(frappe.ValidationError):
+			dn.save()
+
+		# No error with qty=1
+		dn.items[0].qty = 1
+		dn.save()
+		self.assertEqual(dn.items[0].qty, 1)
+
 	def test_over_billing_against_dn(self):
 		frappe.db.set_single_value("Stock Settings", "allow_negative_stock", 1)
 
@@ -1266,7 +1276,7 @@ def create_delivery_note(**args):
 		if dn.is_return:
 			type_of_transaction = "Inward"
 
-		qty = args.get("qty") or 1
+		qty = args.qty if args.get("qty") is not None else 1
 		qty *= -1 if type_of_transaction == "Outward" else 1
 		batches = {}
 		if args.get("batch_no"):
@@ -1294,7 +1304,7 @@ def create_delivery_note(**args):
 		{
 			"item_code": args.item or args.item_code or "_Test Item",
 			"warehouse": args.warehouse or "_Test Warehouse - _TC",
-			"qty": args.qty or 1,
+			"qty": args.qty if args.get("qty") is not None else 1,
 			"rate": args.rate if args.get("rate") is not None else 100,
 			"conversion_factor": 1.0,
 			"serial_and_batch_bundle": bundle_id,

--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -9,6 +9,7 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 from frappe.utils import flt, today
 
+from erpnext.controllers.accounts_controller import ZeroQuantityError
 from erpnext.stock.doctype.item.test_item import create_item
 from erpnext.stock.doctype.material_request.material_request import (
 	make_in_transit_stock_entry,
@@ -23,7 +24,7 @@ class TestMaterialRequest(FrappeTestCase):
 	def test_mr_zero_quantity_item(self):
 		mr = frappe.copy_doc(test_records[0])
 		mr.items[0].qty = 0
-		with self.assertRaises(frappe.ValidationError):
+		with self.assertRaises(ZeroQuantityError):
 			mr.insert()
 
 		# No error with qty=1

--- a/erpnext/stock/doctype/material_request/test_material_request.py
+++ b/erpnext/stock/doctype/material_request/test_material_request.py
@@ -20,6 +20,17 @@ from erpnext.stock.doctype.material_request.material_request import (
 
 
 class TestMaterialRequest(FrappeTestCase):
+	def test_mr_zero_quantity_item(self):
+		mr = frappe.copy_doc(test_records[0])
+		mr.items[0].qty = 0
+		with self.assertRaises(frappe.ValidationError):
+			mr.insert()
+
+		# No error with qty=1
+		mr.items[0].qty = 1
+		mr.save()
+		self.assertEqual(mr.items[0].qty, 1)
+
 	def test_make_purchase_order(self):
 		mr = frappe.copy_doc(test_records[0]).insert()
 

--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -8,6 +8,7 @@ from pypika import functions as fn
 
 import erpnext
 from erpnext.accounts.doctype.account.test_account import get_inventory_account
+from erpnext.controllers.accounts_controller import ZeroQuantityError
 from erpnext.controllers.buying_controller import QtyMismatchError
 from erpnext.stock.doctype.item.test_item import create_item, make_item
 from erpnext.stock.doctype.purchase_receipt.purchase_receipt import make_purchase_invoice
@@ -48,7 +49,7 @@ class TestPurchaseReceipt(FrappeTestCase):
 
 	def test_pr_zero_quantity_item(self):
 		pr = make_purchase_receipt(qty=0, rejected_qty=0, do_not_save=True)
-		with self.assertRaises(frappe.ValidationError):
+		with self.assertRaises(ZeroQuantityError):
 			pr.save()
 
 		# No error with qty=1

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -24,7 +24,6 @@ from frappe.utils import (
 
 import erpnext
 from erpnext.accounts.general_ledger import process_gl_map
-from erpnext.controllers.accounts_controller import ZeroQuantityError
 from erpnext.controllers.taxes_and_totals import init_landed_taxes_and_totals
 from erpnext.manufacturing.doctype.bom.bom import add_additional_cost, validate_bom_no
 from erpnext.setup.doctype.brand.brand import get_brand_defaults
@@ -313,10 +312,8 @@ class StockEntry(StockController):
 				frappe.delete_doc("Stock Entry", d.name)
 
 	def set_transfer_qty(self):
+		self.validate_qty_is_not_zero()
 		for item in self.get("items"):
-			if not flt(item.qty):
-				message = _("Row {0}: Qty is mandatory").format(item.idx)
-				frappe.throw(message, ZeroQuantityError, title=_("Zero quantity"))
 			if not flt(item.conversion_factor):
 				frappe.throw(_("Row {0}: UOM Conversion Factor is mandatory").format(item.idx))
 			item.transfer_qty = flt(

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -24,6 +24,7 @@ from frappe.utils import (
 
 import erpnext
 from erpnext.accounts.general_ledger import process_gl_map
+from erpnext.controllers.accounts_controller import ZeroQuantityError
 from erpnext.controllers.taxes_and_totals import init_landed_taxes_and_totals
 from erpnext.manufacturing.doctype.bom.bom import add_additional_cost, validate_bom_no
 from erpnext.setup.doctype.brand.brand import get_brand_defaults
@@ -314,7 +315,8 @@ class StockEntry(StockController):
 	def set_transfer_qty(self):
 		for item in self.get("items"):
 			if not flt(item.qty):
-				frappe.throw(_("Row {0}: Qty is mandatory").format(item.idx), title=_("Zero quantity"))
+				message = _("Row {0}: Qty is mandatory").format(item.idx)
+				frappe.throw(message, ZeroQuantityError, title=_("Zero quantity"))
 			if not flt(item.conversion_factor):
 				frappe.throw(_("Row {0}: UOM Conversion Factor is mandatory").format(item.idx))
 			item.transfer_qty = flt(

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -8,6 +8,7 @@ from frappe.tests.utils import FrappeTestCase, change_settings
 from frappe.utils import add_days, add_to_date, flt, nowdate, nowtime, today
 
 from erpnext.accounts.doctype.account.test_account import get_inventory_account
+from erpnext.controllers.accounts_controller import ZeroQuantityError
 from erpnext.stock.doctype.item.test_item import (
 	create_item,
 	make_item,
@@ -58,7 +59,7 @@ class TestStockEntry(FrappeTestCase):
 		item_code = "_Test Item 2"
 		warehouse = "_Test Warehouse - _TC"
 		se = make_stock_entry(item_code=item_code, target=warehouse, qty=0, do_not_save=True)
-		with self.assertRaises(frappe.ValidationError):
+		with self.assertRaises(ZeroQuantityError):
 			se.save()
 
 		# No error with qty=1

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -54,6 +54,18 @@ class TestStockEntry(FrappeTestCase):
 		frappe.db.rollback()
 		frappe.set_user("Administrator")
 
+	def test_se_zero_quantity_item(self):
+		item_code = "_Test Item 2"
+		warehouse = "_Test Warehouse - _TC"
+		se = make_stock_entry(item_code=item_code, target=warehouse, qty=0, do_not_save=True)
+		with self.assertRaises(frappe.ValidationError):
+			se.save()
+
+		# No error with qty=1
+		se.items[0].qty = 1
+		se.save()
+		self.assertEqual(se.items[0].qty, 1)
+
 	def test_fifo(self):
 		frappe.db.set_single_value("Stock Settings", "allow_negative_stock", 1)
 		item_code = "_Test Item 2"


### PR DESCRIPTION
Necessary preparation for properly implementing a zero-quantity allowance for On-Demand items with a yet to be determined quantity, as per #36012, and https://github.com/frappe/erpnext/pull/36024#issuecomment-1686541174.

Adds a ZeroQuantityError and testcases for every single transaction doctype affected.
Also removes duplication.

Fixes #37683.