### PR TITLE
fix: add missing disbursement account in update_old_loans patch

### DIFF
--- a/erpnext/patches/v13_0/update_old_loans.py
+++ b/erpnext/patches/v13_0/update_old_loans.py
@@ -125,6 +125,7 @@ def execute():
 			loan_type_doc.company = loan.company
 			loan_type_doc.mode_of_payment = loan.mode_of_payment
 			loan_type_doc.payment_account = loan.payment_account
+			loan_type_doc.disbursement_account = loan.payment_account
 			loan_type_doc.loan_account = loan.loan_account
 			loan_type_doc.interest_income_account = loan.interest_income_account
 			loan_type_doc.penalty_income_account = penalty_account


### PR DESCRIPTION
The patch was failing with:

```
  File "/home/frappe/frappe-bench/apps/erpnext/erpnext/patches/v13_0/update_old_loans.py", line 131, in execute
    loan_type_doc.submit()
      updated_loan_types = []
      loans_to_close = ['ACC-LOAN-2019-00001', 'ELN0004']
      loans_list = [{'parent': 'ACC-LOAN-2019-00001'}, {'parent': 'ELN0004'}]
      loans = [{'name': 'ACC-LOAN-2019-00001', 'loan_type': 'Advances', 'company': 'Greentek India Limited', 'status': 'Disbursed', 'mode_of_payment': 'Online', 'applicant_type': 'Employee', 'applicant': 'EMP/0142', 'loan_account': 'Emp Advances - GIPL', 'payment_account': 'Kotak Mahindra Bank - 05522000005884 - GIPL', 'interest_income_account': 'Interest Income - GIPL'}, {'name': 'ELN0004', 'loan_type': 'Advances', 'company': 'Greentek India Limited', 'status': 'Fully Disbursed', 'mode_of_payment': 'Cash', 'applicant_type': 'Employee', 'applicant': 'EMP/0141', 'loan_account': 'Imprest Account - GIPL', 'payment_account': 'Cash Office - GIPL', 'interest_income_account': 'Interest Income - GIPL'}]
      loan = {'name': 'ACC-LOAN-2019-00001', 'loan_type': 'Advances', 'company': 'Greentek India Limited', 'status': 'Disbursed', 'mode_of_payment': 'Online', 'applicant_type': 'Employee', 'applicant': 'EMP/0142', 'loan_account': 'Emp Advances - GIPL', 'payment_account': 'Kotak Mahindra Bank - 05522000005884 - GIPL', 'interest_income_account': 'Interest Income - GIPL'}
      loan_type_company = None
      loan_type = 'Advances'
      group_income_account = 'Indirect Income - GIPL'
      penalty_account = 'Penalty Account - GIPL'
      loan_type_doc = <LoanType: Advances docstatus=1>
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 1010, in submit
    return self._submit()
      self = <LoanType: Advances docstatus=1>
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 989, in _submit
    return self.save()
      self = <LoanType: Advances docstatus=1>
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 309, in save
    return self._save(*args, **kwargs)
      self = <LoanType: Advances docstatus=1>
      args = ()
      kwargs = {}
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 346, in _save
    self._validate()
      self = <LoanType: Advances docstatus=1>
      ignore_permissions = None
      ignore_version = None
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 533, in _validate
    self._validate_mandatory()
      self = <LoanType: Advances docstatus=1>
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 868, in _validate_mandatory
    raise frappe.MandatoryError(
      self = <LoanType: Advances docstatus=1>
      missing = [('disbursement_account', 'Error: Value missing for Loan Type: Disbursement Account')]
      fieldname = 'disbursement_account'
      msg = 'Error: Value missing for Loan Type: Disbursement Account'
frappe.exceptions.MandatoryError: [Loan Type, Advances]: disbursement_account
```

Related: https://github.com/frappe/erpnext/pull/32403