### PR TITLE
chore: rename depreciation_amount_based_on_num_days_in_month to daily_prorata_based [v14]

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -1216,7 +1216,7 @@ def get_item_details(item_code, asset_category, gross_purchase_amount):
 				"depreciation_method": d.depreciation_method,
 				"total_number_of_depreciations": d.total_number_of_depreciations,
 				"frequency_of_depreciation": d.frequency_of_depreciation,
-				"depreciation_amount_based_on_num_days_in_month": d.depreciation_amount_based_on_num_days_in_month,
+				"daily_prorata_based": d.daily_prorata_based,
 				"salvage_value_percentage": d.salvage_value_percentage,
 				"expected_value_after_useful_life": flt(gross_purchase_amount)
 				* flt(d.salvage_value_percentage / 100),
@@ -1396,7 +1396,7 @@ def get_straight_line_or_manual_depr_amount(
 		)
 	# if the Depreciation Schedule is being modified after Asset Value Adjustment due to decrease in asset value
 	elif asset.flags.decrease_in_asset_value_due_to_value_adjustment:
-		if row.depreciation_amount_based_on_num_days_in_month:
+		if row.daily_prorata_based:
 			daily_depr_amount = (
 				flt(row.value_after_depreciation) - flt(row.expected_value_after_useful_life)
 			) / date_diff(
@@ -1441,7 +1441,7 @@ def get_straight_line_or_manual_depr_amount(
 			) / number_of_pending_depreciations
 	# if the Depreciation Schedule is being prepared for the first time
 	else:
-		if row.depreciation_amount_based_on_num_days_in_month:
+		if row.daily_prorata_based:
 			daily_depr_amount = (
 				flt(asset.gross_purchase_amount)
 				- flt(asset.opening_accumulated_depreciation)

--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -731,7 +731,7 @@ class TestDepreciationMethods(AssetSetup):
 
 		self.assertEqual(schedules, expected_schedules)
 
-	def test_schedule_for_straight_line_method_with_depreciation_amount_based_on_num_days_in_month(
+	def test_schedule_for_straight_line_method_with_daily_prorata_based(
 		self,
 	):
 		asset = create_asset(
@@ -742,7 +742,7 @@ class TestDepreciationMethods(AssetSetup):
 			depreciation_start_date="2023-01-31",
 			total_number_of_depreciations=12,
 			frequency_of_depreciation=1,
-			depreciation_amount_based_on_num_days_in_month=1,
+			daily_prorata_based=1,
 		)
 
 		expected_schedules = [
@@ -1705,8 +1705,7 @@ def create_asset(**args):
 				"total_number_of_depreciations": args.total_number_of_depreciations or 5,
 				"expected_value_after_useful_life": args.expected_value_after_useful_life or 0,
 				"depreciation_start_date": args.depreciation_start_date,
-				"depreciation_amount_based_on_num_days_in_month": args.depreciation_amount_based_on_num_days_in_month
-				or 0,
+				"daily_prorata_based": args.daily_prorata_based or 0,
 			},
 		)
 

--- a/erpnext/assets/doctype/asset_finance_book/asset_finance_book.json
+++ b/erpnext/assets/doctype/asset_finance_book/asset_finance_book.json
@@ -8,7 +8,7 @@
   "finance_book",
   "depreciation_method",
   "total_number_of_depreciations",
-  "depreciation_amount_based_on_num_days_in_month",
+  "daily_prorata_based",
   "column_break_5",
   "frequency_of_depreciation",
   "depreciation_start_date",
@@ -90,9 +90,9 @@
   {
    "default": "0",
    "depends_on": "eval:doc.depreciation_method == \"Straight Line\" || doc.depreciation_method == \"Manual\"",
-   "fieldname": "depreciation_amount_based_on_num_days_in_month",
+   "fieldname": "daily_prorata_based",
    "fieldtype": "Check",
-   "label": "Depreciation amount based on number of days in the month"
+   "label": "Depreciate based on daily pro-rata"
   }
  ],
  "index_web_pages_for_search": 1,

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -347,5 +347,6 @@ erpnext.patches.v14_0.migrate_delivery_stop_lock_field
 execute:frappe.db.set_single_value("Payment Reconciliation", "invoice_limit", 50)
 execute:frappe.db.set_single_value("Payment Reconciliation", "payment_limit", 50)
 erpnext.patches.v14_0.rename_daily_depreciation_to_depreciation_amount_based_on_num_days_in_month
+erpnext.patches.v14_0.rename_depreciation_amount_based_on_num_days_in_month_to_daily_prorata_based
 # below migration patch should always run last
 erpnext.patches.v14_0.migrate_gl_to_payment_ledger

--- a/erpnext/patches/v14_0/rename_depreciation_amount_based_on_num_days_in_month_to_daily_prorata_based.py
+++ b/erpnext/patches/v14_0/rename_depreciation_amount_based_on_num_days_in_month_to_daily_prorata_based.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and Contributors
+# License: GNU General Public License v3. See license.txt
+
+
+from frappe.model.utils.rename_field import rename_field
+
+
+def execute():
+	try:
+		rename_field(
+			"Asset Finance Book", "depreciation_amount_based_on_num_days_in_month", "daily_prorata_based"
+		)
+
+	except Exception as e:
+		if e.args[0] != 1054:
+			raise


### PR DESCRIPTION
Renaming `depreciation_amount_based_on_num_days_in_month` in asset's finance book table to `daily_prorata_based`.

Ref: https://github.com/frappe/erpnext/pull/37893#issuecomment-1792985151