### PR TITLE
JE Customizations from Promantia

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.json
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.json
@@ -22,6 +22,11 @@
   "company",
   "posting_date",
   "apply_tds",
+  "section_break_nq6lp",
+  "transaction_currency",
+  "column_break_uk9s7",
+  "exchange_rate",
+  "default_company_currency",
   "2_add_edit_gl_entries",
   "accounts",
   "section_break99",
@@ -543,13 +548,39 @@
    "label": "Is System Generated",
    "no_copy": 1,
    "read_only": 1
+  },
+  {
+   "fieldname": "section_break_nq6lp",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "transaction_currency",
+   "fieldtype": "Link",
+   "label": "Transaction Currency",
+   "options": "Currency"
+  },
+  {
+   "fieldname": "column_break_uk9s7",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "exchange_rate",
+   "fieldtype": "Float",
+   "label": "Exchange Rate",
+   "precision": "5"
+  },
+  {
+   "fetch_from": "company.default_currency",
+   "fieldname": "default_company_currency",
+   "fieldtype": "Data",
+   "label": "Default Company Currency"
   }
  ],
  "icon": "fa fa-file-text",
  "idx": 176,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-08-10 14:32:22.366895",
+ "modified": "2023-11-06 22:12:18.295131",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Journal Entry",

--- a/erpnext/accounts/doctype/journal_entry_account/journal_entry_account.json
+++ b/erpnext/accounts/doctype/journal_entry_account/journal_entry_account.json
@@ -19,6 +19,14 @@
   "cost_center",
   "dimension_col_break",
   "project",
+  "transaction_details_section",
+  "transaction_debit",
+  "transaction_currency",
+  "actual_transaction_date",
+  "column_break_nt7c4",
+  "transaction_credit",
+  "transaction_exchange_rate",
+  "column_break_qc5nk",
   "currency_section",
   "account_currency",
   "column_break_10",
@@ -29,6 +37,13 @@
   "col_break2",
   "credit_in_account_currency",
   "credit",
+  "company_currency_exchange_rate",
+  "local_currency_section",
+  "local_currency",
+  "debit_in_local_currency",
+  "column_break_xlf1l",
+  "local_currency_exchange_rate",
+  "credit_in_local_currency",
   "reference",
   "reference_type",
   "reference_name",
@@ -279,12 +294,92 @@
    "hidden": 1,
    "label": "Reference Detail No",
    "no_copy": 1
+  },
+  {
+   "fieldname": "transaction_details_section",
+   "fieldtype": "Section Break",
+   "label": "Transaction Details"
+  },
+  {
+   "fieldname": "transaction_debit",
+   "fieldtype": "Currency",
+   "label": "Transaction Debit",
+   "options": "transaction_currency"
+  },
+  {
+   "fieldname": "transaction_currency",
+   "fieldtype": "Link",
+   "label": "Transaction Currency",
+   "options": "Currency"
+  },
+  {
+   "fieldname": "actual_transaction_date",
+   "fieldtype": "Data",
+   "label": "Actual Transaction Date"
+  },
+  {
+   "fieldname": "column_break_nt7c4",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "transaction_credit",
+   "fieldtype": "Currency",
+   "label": "Transaction Credit",
+   "options": "transaction_currency"
+  },
+  {
+   "fieldname": "transaction_exchange_rate",
+   "fieldtype": "Float",
+   "label": "Transaction Exchange Rate",
+   "precision": "5"
+  },
+  {
+   "fieldname": "column_break_qc5nk",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "company_currency_exchange_rate",
+   "fieldtype": "Float",
+   "label": "Company Currency Exchange Rate",
+   "precision": "5"
+  },
+  {
+   "fieldname": "local_currency_section",
+   "fieldtype": "Section Break",
+   "label": "Local Currency"
+  },
+  {
+   "fieldname": "local_currency",
+   "fieldtype": "Link",
+   "label": "Local Currency",
+   "options": "Currency"
+  },
+  {
+   "fieldname": "debit_in_local_currency",
+   "fieldtype": "Currency",
+   "label": "Debit in Local Currency",
+   "options": "Company:company:tax_currency"
+  },
+  {
+   "fieldname": "column_break_xlf1l",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "local_currency_exchange_rate",
+   "fieldtype": "Currency",
+   "label": "Local Currency Exchange Rate"
+  },
+  {
+   "fieldname": "credit_in_local_currency",
+   "fieldtype": "Currency",
+   "label": "Credit in Local Currency",
+   "options": "Company:company:tax_currency"
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-06-16 14:11:13.507807",
+ "modified": "2023-11-06 22:19:12.587125",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Journal Entry Account",


### PR DESCRIPTION
**JE Header:**
In JE header , capture txn currency and txn exchange rate ( with respect to company currency i.e txn ccy amt * exch rate => amt in company currency ).
**JE Lines:**
1) Have a section to capture Txn details , which has Txn Currency , Txn Currency to company currency exchange rate, Txn Dr and Txn Cr ( editable ) as well as Txn Date. Move this section to the top ( above the other currency and amount section ) and it should be expanded by default.
2) Add Section Local Currency. It should be visible only if local currency is different from company currency and it should be collapsed by default.
3) Add Debit in Local Currency and Credit in Local currency and local currency Exchange rate ( converting reporting currency to local currency ). All fields are read-only. The local currency amount is calculated by translating txn amt to company currency and then into local currency
4) The account currency amount is translated from txn currency amount and the company currency amount is also translated from txn currency amount. These fields are also read-only
5) Preview option to view General Ledger Entry for Draft status records