### PR TITLE
fix: Supplier Quotation fields

### DIFF
--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -31,7 +31,12 @@ from erpnext.accounts.utils import get_fiscal_year
 from erpnext.exceptions import InvalidAccountCurrency, PartyDisabled, PartyFrozen
 from erpnext.utilities.regional import temporary_flag
 
-PURCHASE_TRANSACTION_TYPES = {"Purchase Order", "Purchase Receipt", "Purchase Invoice"}
+PURCHASE_TRANSACTION_TYPES = {
+	"Supplier Quotation",
+	"Purchase Order",
+	"Purchase Receipt",
+	"Purchase Invoice",
+}
 SALES_TRANSACTION_TYPES = {
 	"Quotation",
 	"Sales Order",

--- a/erpnext/buying/doctype/request_for_quotation/request_for_quotation.json
+++ b/erpnext/buying/doctype/request_for_quotation/request_for_quotation.json
@@ -9,6 +9,8 @@
  "field_order": [
   "naming_series",
   "company",
+  "billing_address",
+  "billing_address_display",
   "vendor",
   "column_break1",
   "transaction_date",
@@ -292,13 +294,25 @@
    "fieldtype": "Check",
    "label": "Send Document Print",
    "print_hide": 1
+  },
+  {
+   "fieldname": "billing_address",
+   "fieldtype": "Link",
+   "label": "Company Billing Address",
+   "options": "Address"
+  },
+  {
+   "fieldname": "billing_address_display",
+   "fieldtype": "Small Text",
+   "label": "Billing Address Details",
+   "read_only": 1
   }
  ],
  "icon": "fa fa-shopping-cart",
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-08-09 12:20:26.850623",
+ "modified": "2023-11-06 12:45:28.898706",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Request for Quotation",

--- a/erpnext/buying/doctype/supplier_quotation/supplier_quotation.json
+++ b/erpnext/buying/doctype/supplier_quotation/supplier_quotation.json
@@ -79,6 +79,7 @@
   "pricing_rule_details",
   "pricing_rules",
   "address_and_contact_tab",
+  "supplier_address_section",
   "supplier_address",
   "address_display",
   "column_break_72",
@@ -86,6 +87,14 @@
   "contact_display",
   "contact_mobile",
   "contact_email",
+  "shipping_address_section",
+  "shipping_address",
+  "column_break_zjaq",
+  "shipping_address_display",
+  "company_billing_address_section",
+  "billing_address",
+  "column_break_gcth",
+  "billing_address_display",
   "terms_tab",
   "tc_name",
   "terms",
@@ -838,6 +847,55 @@
    "fieldname": "named_place",
    "fieldtype": "Data",
    "label": "Named Place"
+  },
+  {
+   "fieldname": "shipping_address",
+   "fieldtype": "Link",
+   "label": "Shipping Address",
+   "options": "Address",
+   "print_hide": 1
+  },
+  {
+   "fieldname": "column_break_zjaq",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "shipping_address_display",
+   "fieldtype": "Small Text",
+   "label": "Shipping Address Details",
+   "print_hide": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "shipping_address_section",
+   "fieldtype": "Section Break",
+   "label": "Shipping Address"
+  },
+  {
+   "fieldname": "supplier_address_section",
+   "fieldtype": "Section Break",
+   "label": "Supplier Address"
+  },
+  {
+   "fieldname": "company_billing_address_section",
+   "fieldtype": "Section Break",
+   "label": "Company Billing Address"
+  },
+  {
+   "fieldname": "billing_address",
+   "fieldtype": "Link",
+   "label": "Company Billing Address",
+   "options": "Address"
+  },
+  {
+   "fieldname": "column_break_gcth",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "billing_address_display",
+   "fieldtype": "Small Text",
+   "label": "Billing Address Details",
+   "read_only": 1
   }
  ],
  "icon": "fa fa-shopping-cart",
@@ -845,7 +903,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-06-03 16:20:15.880114",
+ "modified": "2023-11-03 13:21:40.172508",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Supplier Quotation",

--- a/erpnext/public/js/utils/party.js
+++ b/erpnext/public/js/utils/party.js
@@ -4,7 +4,7 @@
 frappe.provide("erpnext.utils");
 
 const SALES_DOCTYPES = ['Quotation', 'Sales Order', 'Delivery Note', 'Sales Invoice'];
-const PURCHASE_DOCTYPES = ['Purchase Order', 'Purchase Receipt', 'Purchase Invoice'];
+const PURCHASE_DOCTYPES = ['Supplier Quotation','Purchase Order', 'Purchase Receipt', 'Purchase Invoice'];
 
 erpnext.utils.get_party_details = function(frm, method, args, callback) {
 	if (!method) {


### PR DESCRIPTION

Fields added for following Doctypes (required for : https://github.com/resilient-tech/india-compliance/issues/1206) : 

- **Request For Quotation:** 

1. Company Billing Address
2. Billing Address Details

- **Supplier Quotation:**

1. Shipping Address
2. Shipping Address Details
3. Company Billing Address
4. Billing Address Details

![image](https://github.com/frappe/erpnext/assets/78500008/4f5caff4-cb1c-4622-99ae-af50b5141671)
![image](https://github.com/frappe/erpnext/assets/78500008/50107ce7-04fb-4951-95b1-9d62772a5fd1)
