### PR TITLE
refactor: optimize bulk transaction for speed

### DIFF
--- a/erpnext/utilities/bulk_transaction.py
+++ b/erpnext/utilities/bulk_transaction.py
@@ -192,9 +192,7 @@ def mark_retrired_transaction(log_doc, doc_name):
 	record = 0
 	for d in log_doc.get("logger_data"):
 		if d.transaction_name == doc_name and d.transaction_status == "Failed":
-			d.retried = 1
+			frappe.db.set_value("Bulk Transaction Log Detail", d.name, "retried", 1)
 			record = record + 1
-
-	log_doc.save()
 
 	return record


### PR DESCRIPTION
62% reduction in overall runtime of bulk operations. `mark_retrired_transaction` saves entire **log_doc** for every document the job is run on. The more bulk operation done in a single day, the worse the runtime gets - `O(n2)`, as log entries are captured in a single `Bulk Transaction Log` document for each day.


## before
```
sinvs=frappe.db.get_all("Sales Invoice", filters={"status":"Overdue"}, limit=100)
from erpnext.utilities.bulk_transaction import job
%prun -s cumulative job(sinvs, "Sales Invoice", "Payment Entry")

         118849814 function calls (116602431 primitive calls) in 42.949 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    509/1    0.001    0.000   42.949   42.949 {built-in method builtins.exec}
        1    0.001    0.001   42.949   42.949 bulk_transaction.py:31(job)
      100    0.000    0.000   35.382    0.354 bulk_transaction.py:140(update_logger)
      200    0.000    0.000   32.879    0.164 document.py:332(save)
      200    0.003    0.000   32.879    0.164 document.py:336(_save)
    55297    0.182    0.000   24.190    0.000 database.py:140(sql)
    55297    0.054    0.000   22.613    0.000 cursors.py:133(execute)
    55297    0.068    0.000   20.983    0.000 cursors.py:319(_query)
    55297    0.064    0.000   20.848    0.000 connections.py:552(query)
    55297    0.045    0.000   20.276    0.000 connections.py:810(_read_query_result)
    55297    0.055    0.000   20.205    0.000 connections.py:1198(read)
      100    0.000    0.000   16.617    0.166 bulk_transaction.py:181(record_exists)
      100    0.002    0.000   16.617    0.166 bulk_transaction.py:191(mark_retrired_transaction)
      200    0.002    0.000   16.280    0.081 document.py:415(update_children)
      200    0.040    0.000   16.277    0.081 document.py:420(update_child_table)
    50200    0.160    0.000   15.697    0.000 base_document.py:570(db_update)
   249567    0.363    0.000   15.083    0.000 connections.py:730(_read_packet)
   499134    0.265    0.000   13.707    0.000 connections.py:775(_read_bytes)
   499637    0.157    0.000   13.263    0.000 {method 'read' of '_io.BufferedReader' objects}
    58146    0.050    0.000   13.106    0.000 socket.py:691(readinto)
    60528   13.086    0.000   13.086    0.000 {method 'recv_into' of '_socket.socket' objects}
     1101    0.003    0.000   11.043    0.010 __init__.py:1238(get_doc)
     1101    0.003    0.000   10.985    0.010 document.py:33(get_doc)
80107/1303    0.100    0.000   10.951    0.008 document.py:99(__init__)
      696    0.014    0.000   10.921    0.016 document.py:144(load_from_db)
   154479    0.065    0.000    9.431    0.000 database.py:495(get_values)
     3697    0.010    0.000    9.290    0.003 database.py:798(_get_values_from_table)
     4193    0.012    0.000    8.732    0.002 utils.py:84(execute_query)
      100    0.002    0.000    7.553    0.076 bulk_transaction.py:57(task)
     4395    0.005    0.000    6.395    0.001 connections.py:1281(_read_result_packet)
 1816/904    0.002    0.000    6.249    0.007 typing_validations.py:21(wrapper)
      100    0.003    0.000    6.241    0.062 payment_entry.py:2079(get_payment_entry)
      400    0.080    0.000    5.962    0.015 document.py:553(_validate)
     4395    0.066    0.000    4.826    0.001 connections.py:1327(_read_rowdata_packet)
      400    0.001    0.000    4.795    0.012 document.py:783(check_if_latest)
      706    0.001    0.000    4.791    0.007 document.py:1093(load_doc_before_save)
      400    0.034    0.000    4.723    0.012 document.py:905(_validate_links)
    50502    0.516    0.000    4.683    0.000 base_document.py:738(get_invalid_links)
```


## after
```
In [1]: sinvs=frappe.db.get_all("Sales Invoice", filters={"status":"Overdue"}, limit=100)
   ...: from erpnext.utilities.bulk_transaction import job
   ...: %prun -s cumulative job(sinvs, "Sales Invoice", "Payment Entry")
   ...: 

         74328629 function calls (72581912 primitive calls) in 26.668 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    509/1    0.001    0.000   26.668   26.668 {built-in method builtins.exec}
        1    0.001    0.001   26.668   26.668 bulk_transaction.py:31(job)
      100    0.000    0.000   19.399    0.194 bulk_transaction.py:140(update_logger)
      100    0.000    0.000   16.830    0.168 document.py:332(save)
      100    0.001    0.000   16.830    0.168 document.py:336(_save)
    31260    0.105    0.000   15.160    0.000 database.py:140(sql)
    31260    0.028    0.000   14.258    0.000 cursors.py:133(execute)
    31260    0.036    0.000   13.376    0.000 cursors.py:319(_query)
    31260    0.035    0.000   13.302    0.000 connections.py:552(query)
    31260    0.025    0.000   12.986    0.000 connections.py:810(_read_query_result)
    31260    0.031    0.000   12.945    0.000 connections.py:1198(read)
   199680    0.276    0.000    9.284    0.000 connections.py:730(_read_packet)
      901    0.002    0.000    8.565    0.010 __init__.py:1238(get_doc)
      901    0.003    0.000    8.507    0.009 document.py:33(get_doc)
57557/1103    0.072    0.000    8.473    0.008 document.py:99(__init__)
      596    0.013    0.000    8.449    0.014 document.py:144(load_from_db)
   399360    0.200    0.000    8.084    0.000 connections.py:775(_read_bytes)
      100    0.001    0.000    8.060    0.081 document.py:415(update_children)
      100    0.022    0.000    8.059    0.081 document.py:420(update_child_table)
    26450    0.085    0.000    7.783    0.000 base_document.py:570(db_update)
   399864    0.120    0.000    7.755    0.000 {method 'read' of '_io.BufferedReader' objects}
    35971    7.640    0.000    7.640    0.000 {method 'recv_into' of '_socket.socket' objects}
    33764    0.029    0.000    7.635    0.000 socket.py:691(readinto)
    83329    0.040    0.000    7.510    0.000 database.py:495(get_values)
     3497    0.009    0.000    7.400    0.002 database.py:798(_get_values_from_table)
      100    0.002    0.000    7.257    0.073 bulk_transaction.py:57(task)
     3906    0.011    0.000    6.653    0.002 utils.py:84(execute_query)
 1716/804    0.002    0.000    6.044    0.008 typing_validations.py:21(wrapper)
      100    0.003    0.000    6.037    0.060 payment_entry.py:2079(get_payment_entry)
     4195    0.004    0.000    4.930    0.001 connections.py:1281(_read_result_packet)
     4195    0.049    0.000    3.464    0.001 connections.py:1327(_read_rowdata_packet)
      303    0.001    0.000    3.377    0.011 accounts_controller.py:88(__init__)
      202    0.001    0.000    3.371    0.017 sales_invoice.py:47(__init__)
      300    0.043    0.000    3.208    0.011 document.py:553(_validate)
    59988    0.537    0.000    3.136    0.000 connections.py:1340(_read_row_from_packet)
      300    0.018    0.000    2.720    0.009 document.py:905(_validate_links)
    26752    0.276    0.000    2.698    0.000 base_document.py:738(get_invalid_links)
      100    0.000    0.000    2.488    0.025 bulk_transaction.py:115(get_logger_doc)
      300    0.001    0.000    2.439    0.008 document.py:783(check_if_latest)
      606    0.000    0.000    2.436    0.004 document.py:1093(load_doc_before_save)
  1421261    0.409    0.000    2.264    0.000 base_document.py:204(get)
      200    0.002    0.000    1.981    0.010 utils.py:172(get_balance_on)
    81311    0.040    0.000    1.832    0.000 database.py:425(get_value)
```

