### PR TITLE
fix: make adjustment entry using stock reconciliation

### DIFF
--- a/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.json
+++ b/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.json
@@ -11,6 +11,7 @@
   "warehouse",
   "posting_date",
   "posting_time",
+  "is_adjustment_entry",
   "column_break_6",
   "voucher_type",
   "voucher_no",
@@ -333,6 +334,12 @@
    "fieldname": "has_serial_no",
    "fieldtype": "Check",
    "label": "Has Serial No"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_adjustment_entry",
+   "fieldtype": "Check",
+   "label": "Is Adjustment Entry"
   }
  ],
  "hide_toolbar": 1,
@@ -341,7 +348,7 @@
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2023-04-03 16:33:16.270722",
+ "modified": "2023-10-23 18:07:42.063615",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Ledger Entry",

--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -442,6 +442,11 @@ class StockReconciliation(StockController):
 
 		sl_entries = []
 		for row in self.items:
+
+			if not row.qty and not row.valuation_rate and not row.current_qty:
+				self.make_adjustment_entry(row, sl_entries)
+				continue
+
 			item = frappe.get_cached_value(
 				"Item", row.item_code, ["has_serial_no", "has_batch_no"], as_dict=1
 			)
@@ -491,6 +496,21 @@ class StockReconciliation(StockController):
 				frappe.db.get_single_value("Stock Settings", "allow_negative_stock")
 			)
 			self.make_sl_entries(sl_entries, allow_negative_stock=allow_negative_stock)
+
+	def make_adjustment_entry(self, row, sl_entries):
+		from erpnext.stock.stock_ledger import get_stock_value_difference
+
+		difference_amount = get_stock_value_difference(
+			row.item_code, row.warehouse, self.posting_date, self.posting_time
+		)
+
+		if not difference_amount:
+			return
+
+		args = self.get_sle_for_items(row)
+		args.update({"stock_value_difference": -1 * difference_amount, "is_adjustment_entry": 1})
+
+		sl_entries.append(args)
 
 	def get_sle_for_serialized_items(self, row, sl_entries):
 		if row.current_serial_and_batch_bundle:

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -759,9 +759,11 @@ class update_entries_after(object):
 		sle.valuation_rate = self.wh_data.valuation_rate
 		sle.stock_value = self.wh_data.stock_value
 		sle.stock_queue = json.dumps(self.wh_data.stock_queue)
-		sle.stock_value_difference = stock_value_difference
-		sle.doctype = "Stock Ledger Entry"
 
+		if not sle.is_adjustment_entry or not self.args.get("sle_id"):
+			sle.stock_value_difference = stock_value_difference
+
+		sle.doctype = "Stock Ledger Entry"
 		frappe.get_doc(sle).db_update()
 
 		if not self.args.get("sle_id"):
@@ -1939,3 +1941,27 @@ def is_internal_transfer(sle):
 
 	if data.is_internal_supplier and data.represents_company == data.company:
 		return True
+
+
+def get_stock_value_difference(item_code, warehouse, posting_date, posting_time, voucher_no=None):
+	table = frappe.qb.DocType("Stock Ledger Entry")
+
+	query = (
+		frappe.qb.from_(table)
+		.select(Sum(table.stock_value_difference).as_("value"))
+		.where(
+			(table.is_cancelled == 0)
+			& (table.item_code == item_code)
+			& (table.warehouse == warehouse)
+			& (
+				(table.posting_date < posting_date)
+				| ((table.posting_date == posting_date) & (table.posting_time <= posting_time))
+			)
+		)
+	)
+
+	if voucher_no:
+		query = query.where(table.voucher_no != voucher_no)
+
+	difference_amount = query.run()
+	return flt(difference_amount[0][0]) if difference_amount else 0


### PR DESCRIPTION
**Issue**

<img width="1316" alt="Screenshot 2023-11-08 at 10 46 57 PM" src="https://github.com/frappe/erpnext/assets/8780500/29623aeb-1455-4ed7-ab60-1615df47f49c">

Zero Balance Qty but Non Zero Stock Balance

These types of issues are resolved by reposting the incorrect ledger entries, but if the period has already closed, the user can't make a reposting entry. 

n that case, the only option to fix this issue on the current date is Stock Reconciliation. However, earlier, the user was unable to resolve this issue using Stock Reconciliation. After this fix, the user can now address the 'Non Zero Stock Balance' issue using Stock Reconciliation.

To fix the "Non Zero Stock Balance" issue user has to create the stock reconciliation for Zero Quantity and Zero Valuation Rate.