### PR TITLE
fix: make item field read-only in batch

### DIFF
--- a/erpnext/stock/doctype/batch/batch.json
+++ b/erpnext/stock/doctype/batch/batch.json
@@ -61,6 +61,7 @@
    "oldfieldname": "item",
    "oldfieldtype": "Link",
    "options": "Item",
+   "read_only_depends_on": "eval:!doc.__islocal",
    "reqd": 1
   },
   {
@@ -207,7 +208,7 @@
  "image_field": "image",
  "links": [],
  "max_attachments": 5,
- "modified": "2023-03-12 15:56:09.516586",
+ "modified": "2023-11-09 12:17:28.339975",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Batch",
@@ -224,7 +225,6 @@
    "read": 1,
    "report": 1,
    "role": "Item Manager",
-   "set_user_permissions": 1,
    "share": 1,
    "write": 1
   }


### PR DESCRIPTION
**Before:**

https://github.com/frappe/erpnext/assets/63660334/0b65644f-4dae-4eb7-9312-219c7743e194

**After:**

https://github.com/frappe/erpnext/assets/63660334/4b6a9b2b-1985-4c47-a76c-1d1f07b88493

