### PR TITLE
fix: indentation issue in the Production Plan Summary report

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.js
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.js
@@ -89,10 +89,6 @@ frappe.ui.form.on('Production Plan', {
 			frm.trigger("show_progress");
 
 			if (frm.doc.status !== "Completed") {
-				frm.add_custom_button(__("Work Order Tree"), ()=> {
-					frappe.set_route('Tree', 'Work Order', {production_plan: frm.doc.name});
-				}, __('View'));
-
 				frm.add_custom_button(__("Production Plan Summary"), ()=> {
 					frappe.set_route('query-report', 'Production Plan Summary', {production_plan: frm.doc.name});
 				}, __('View'));

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -828,8 +828,6 @@ class ProductionPlan(Document):
 			# Combine subassembly items
 			sub_assembly_items_store = self.combine_subassembly_items(sub_assembly_items_store)
 
-		sub_assembly_items_store.sort(key=lambda d: d.bom_level, reverse=True)  # sort by bom level
-
 		for idx, row in enumerate(sub_assembly_items_store):
 			row.idx = idx + 1
 			self.append("sub_assembly_items", row)

--- a/erpnext/manufacturing/report/production_plan_summary/production_plan_summary.js
+++ b/erpnext/manufacturing/report/production_plan_summary/production_plan_summary.js
@@ -22,9 +22,9 @@ frappe.query_reports["Production Plan Summary"] = {
 	"formatter": function(value, row, column, data, default_formatter) {
 		value = default_formatter(value, row, column, data);
 
-		if (column.fieldname == "document_name") {
+		if (column.fieldname == "item_code") {
 			var color = data.pending_qty > 0 ? 'red': 'green';
-			value = `<a style='color:${color}' href="#Form/${data['document_type']}/${data['document_name']}" data-doctype="${data['document_type']}">${data['document_name']}</a>`;
+			value = `<a style='color:${color}' href="/app/item/${data['item_code']}" data-doctype="Item">${data['item_code']}</a>`;
 		}
 
 		return value;

--- a/erpnext/manufacturing/report/production_plan_summary/production_plan_summary.py
+++ b/erpnext/manufacturing/report/production_plan_summary/production_plan_summary.py
@@ -44,6 +44,7 @@ def get_production_plan_item_details(filters, data, order_details):
 			{
 				"indent": 0,
 				"item_code": row.item_code,
+				"sales_order": row.get("sales_order"),
 				"item_name": frappe.get_cached_value("Item", row.item_code, "item_name"),
 				"qty": row.planned_qty,
 				"document_type": "Work Order",
@@ -80,7 +81,7 @@ def get_production_plan_sub_assembly_item_details(
 
 			data.append(
 				{
-					"indent": 1,
+					"indent": 1 + item.indent,
 					"item_code": item.production_item,
 					"item_name": item.item_name,
 					"qty": item.qty,
@@ -98,7 +99,7 @@ def get_work_order_details(filters, order_details):
 	for row in frappe.get_all(
 		"Work Order",
 		filters={"production_plan": filters.get("production_plan")},
-		fields=["name", "produced_qty", "production_plan", "production_item"],
+		fields=["name", "produced_qty", "production_plan", "production_item", "sales_order"],
 	):
 		order_details.setdefault((row.name, row.production_item), row)
 
@@ -118,10 +119,17 @@ def get_column(filters):
 			"label": _("Finished Good"),
 			"fieldtype": "Link",
 			"fieldname": "item_code",
-			"width": 300,
+			"width": 240,
 			"options": "Item",
 		},
-		{"label": _("Item Name"), "fieldtype": "data", "fieldname": "item_name", "width": 100},
+		{"label": _("Item Name"), "fieldtype": "data", "fieldname": "item_name", "width": 150},
+		{
+			"label": _("Sales Order"),
+			"options": "Sales Order",
+			"fieldtype": "Link",
+			"fieldname": "sales_order",
+			"width": 100,
+		},
 		{
 			"label": _("Document Type"),
 			"fieldtype": "Link",
@@ -133,10 +141,16 @@ def get_column(filters):
 			"label": _("Document Name"),
 			"fieldtype": "Dynamic Link",
 			"fieldname": "document_name",
-			"width": 150,
+			"options": "document_type",
+			"width": 180,
 		},
 		{"label": _("BOM Level"), "fieldtype": "Int", "fieldname": "bom_level", "width": 100},
 		{"label": _("Order Qty"), "fieldtype": "Float", "fieldname": "qty", "width": 120},
-		{"label": _("Received Qty"), "fieldtype": "Float", "fieldname": "produced_qty", "width": 160},
+		{
+			"label": _("Produced / Received Qty"),
+			"fieldtype": "Float",
+			"fieldname": "produced_qty",
+			"width": 200,
+		},
 		{"label": _("Pending Qty"), "fieldtype": "Float", "fieldname": "pending_qty", "width": 110},
 	]


### PR DESCRIPTION
**Issue**

Indentation not showing properly 

<img width="1315" alt="image" src="https://github.com/frappe/erpnext/assets/8780500/78c670c2-4f1c-431e-9bc5-7bf6afc4f8c9">

**After Fix**

<img width="1326" alt="Screenshot 2023-11-09 at 3 42 47 PM" src="https://github.com/frappe/erpnext/assets/8780500/6f369f94-30d7-4cb2-a5e0-872972eefd52">

Also added new column Sales Order