### PR TITLE
fix: Remove superfluous 'Invoice Portion' field from Payment Term.

### DIFF
--- a/erpnext/accounts/doctype/payment_term/payment_term.json
+++ b/erpnext/accounts/doctype/payment_term/payment_term.json
@@ -9,7 +9,6 @@
  "engine": "InnoDB",
  "field_order": [
   "payment_term_name",
-  "invoice_portion",
   "mode_of_payment",
   "column_break_3",
   "due_date_based_on",
@@ -31,12 +30,6 @@
    "fieldtype": "Data",
    "label": "Payment Term Name",
    "unique": 1
-  },
-  {
-   "bold": 1,
-   "fieldname": "invoice_portion",
-   "fieldtype": "Float",
-   "label": "Invoice Portion (%)"
   },
   {
    "fieldname": "mode_of_payment",
@@ -116,10 +109,11 @@
   }
  ],
  "links": [],
- "modified": "2021-02-15 20:30:56.256403",
+ "modified": "2023-11-09 18:51:00.761013",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Term",
+ "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [
   {
@@ -162,5 +156,6 @@
  "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/erpnext/accounts/doctype/payment_terms_template_detail/payment_terms_template_detail.json
+++ b/erpnext/accounts/doctype/payment_terms_template_detail/payment_terms_template_detail.json
@@ -41,8 +41,6 @@
   },
   {
    "columns": 2,
-   "fetch_from": "payment_term.invoice_portion",
-   "fetch_if_empty": 1,
    "fieldname": "invoice_portion",
    "fieldtype": "Float",
    "in_list_view": 1,
@@ -151,7 +149,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2021-02-24 11:56:12.410807",
+ "modified": "2023-11-09 18:54:25.437797",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Terms Template Detail",
@@ -160,5 +158,6 @@
  "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }


### PR DESCRIPTION
Not a big deal, but adding to unnecessary UI complexity, data duplication and inconsistency, while not really helping much or at all.

As the field seems useless, I don’t think there is any useful data to preserve. “Fetch if empty” made sure the data was copied over to any Payment Terms Template Detail using the individual Payment Term. So just removing it should IMHO be okay, unless someone comes up with a reasonable case.

Closes #38027.