### PR TITLE
fix: Recalculate payment amounts instead of refetching the schedule.

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -1802,6 +1802,52 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 		rate = flt(sle.stock_value_difference) / flt(sle.actual_qty)
 		self.assertAlmostEqual(rate, 500)
 
+	def test_payment_allocation_for_payment_terms(self):
+		from erpnext.buying.doctype.purchase_order.test_purchase_order import (
+			create_pr_against_po,
+			create_purchase_order,
+		)
+		from erpnext.selling.doctype.sales_order.test_sales_order import (
+			automatically_fetch_payment_terms,
+		)
+		from erpnext.stock.doctype.purchase_receipt.purchase_receipt import (
+			make_purchase_invoice as make_pi_from_pr,
+		)
+
+		automatically_fetch_payment_terms()
+		frappe.db.set_value(
+			"Payment Terms Template",
+			"_Test Payment Term Template",
+			"allocate_payment_based_on_payment_terms",
+			0,
+		)
+
+		po = create_purchase_order(do_not_save=1)
+		po.payment_terms_template = "_Test Payment Term Template"
+		po.save()
+		po.submit()
+
+		pr = create_pr_against_po(po.name, received_qty=4)
+		pi = make_pi_from_pr(pr.name)
+		self.assertEqual(pi.payment_schedule[0].payment_amount, 1000)
+
+		frappe.db.set_value(
+			"Payment Terms Template",
+			"_Test Payment Term Template",
+			"allocate_payment_based_on_payment_terms",
+			1,
+		)
+		pi = make_pi_from_pr(pr.name)
+		self.assertEqual(pi.payment_schedule[0].payment_amount, 2500)
+
+		automatically_fetch_payment_terms(enable=0)
+		frappe.db.set_value(
+			"Payment Terms Template",
+			"_Test Payment Term Template",
+			"allocate_payment_based_on_payment_terms",
+			0,
+		)
+
 	def test_offsetting_entries_for_accounting_dimensions(self):
 		from erpnext.accounts.doctype.account.test_account import create_account
 		from erpnext.accounts.report.trial_balance.test_trial_balance import (

--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -1802,52 +1802,6 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 		rate = flt(sle.stock_value_difference) / flt(sle.actual_qty)
 		self.assertAlmostEqual(rate, 500)
 
-	def test_payment_allocation_for_payment_terms(self):
-		from erpnext.buying.doctype.purchase_order.test_purchase_order import (
-			create_pr_against_po,
-			create_purchase_order,
-		)
-		from erpnext.selling.doctype.sales_order.test_sales_order import (
-			automatically_fetch_payment_terms,
-		)
-		from erpnext.stock.doctype.purchase_receipt.purchase_receipt import (
-			make_purchase_invoice as make_pi_from_pr,
-		)
-
-		automatically_fetch_payment_terms()
-		frappe.db.set_value(
-			"Payment Terms Template",
-			"_Test Payment Term Template",
-			"allocate_payment_based_on_payment_terms",
-			0,
-		)
-
-		po = create_purchase_order(do_not_save=1)
-		po.payment_terms_template = "_Test Payment Term Template"
-		po.save()
-		po.submit()
-
-		pr = create_pr_against_po(po.name, received_qty=4)
-		pi = make_pi_from_pr(pr.name)
-		self.assertEqual(pi.payment_schedule[0].payment_amount, 1000)
-
-		frappe.db.set_value(
-			"Payment Terms Template",
-			"_Test Payment Term Template",
-			"allocate_payment_based_on_payment_terms",
-			1,
-		)
-		pi = make_pi_from_pr(pr.name)
-		self.assertEqual(pi.payment_schedule[0].payment_amount, 2500)
-
-		automatically_fetch_payment_terms(enable=0)
-		frappe.db.set_value(
-			"Payment Terms Template",
-			"_Test Payment Term Template",
-			"allocate_payment_based_on_payment_terms",
-			0,
-		)
-
 	def test_offsetting_entries_for_accounting_dimensions(self):
 		from erpnext.accounts.doctype.account.test_account import create_account
 		from erpnext.accounts.report.trial_balance.test_trial_balance import (

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1941,10 +1941,7 @@ class AccountsController(TransactionBase):
 				)
 				self.append("payment_schedule", data)
 
-		if not (
-			automatically_fetch_payment_terms
-			and self.linked_order_has_payment_terms(po_or_so, fieldname, doctype)
-		):
+		if not automatically_fetch_payment_terms:
 			for d in self.get("payment_schedule"):
 				if d.invoice_portion:
 					d.payment_amount = flt(

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1941,7 +1941,7 @@ class AccountsController(TransactionBase):
 				)
 				self.append("payment_schedule", data)
 
-		if not automatically_fetch_payment_terms:
+		if self.get("payment_schedule"):
 			for d in self.get("payment_schedule"):
 				if d.invoice_portion:
 					d.payment_amount = flt(

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1941,13 +1941,8 @@ class AccountsController(TransactionBase):
 				)
 				self.append("payment_schedule", data)
 
-		allocate_payment_based_on_payment_terms = frappe.db.get_value(
-			"Payment Terms Template", self.payment_terms_template, "allocate_payment_based_on_payment_terms"
-		)
-
 		if not (
 			automatically_fetch_payment_terms
-			and allocate_payment_based_on_payment_terms
 			and self.linked_order_has_payment_terms(po_or_so, fieldname, doctype)
 		):
 			for d in self.get("payment_schedule"):

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1958,9 +1958,6 @@ class AccountsController(TransactionBase):
 					d.base_payment_amount = flt(
 						d.payment_amount * self.get("conversion_rate"), d.precision("base_payment_amount")
 					)
-		else:
-			self.fetch_payment_terms_from_order(po_or_so, doctype)
-			self.ignore_default_payment_terms_template = 1
 
 	def get_order_details(self):
 		if self.doctype == "Sales Invoice":


### PR DESCRIPTION
Fixes #38030.

Reverts #35007 while still fixing the issue reported there.

Reverts #35285 while still fixing the issue reported there.

Also reverts #36440. Unsure whether `allocate_payment_based_on_payment_terms` is useful at all – either you have a schedule and allocate accordingly or you don’t. But even if turned off, we need the payment schedule to be correct. Otherwise we needed to clear the schedule altogether.

Last mostly correct commit was #34872, but we need to doublecheck if every single of the later reported cases are still covered.

Definitely needs more test cases and optimally some feedback by @ruthra-kumar, @GursheenK, and/or @deepeshgarg007.