### PR TITLE
fixed: add debit in account currency in make_item_gl_entries function

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -873,6 +873,7 @@ class PurchaseInvoice(BuyingController):
 									"account": expense_account,
 									"against": self.supplier,
 									"debit": amount,
+									"debit_in_account_currency": dummy,
 									"cost_center": item.cost_center,
 									"project": item.project or self.project,
 								},


### PR DESCRIPTION
ERPNext: v14.45.4
Frappe Framework: v14.54.1

My company's currency is EUR. When I create a purchase invoice with currency YER and submit it, the debit and credit in the general ledger appear to be correct. However, the debit and credit in the account currency are not the same. Specifically, the debit in the account currency appears to be incorrect , so  i added amount of debit in account currency in make_item_gl_entries function to fix it
I have attached a screenshot below.
![fixed purchase order gl add d_i_a_c](https://github.com/frappe/erpnext/assets/10696455/d2f7e418-ed28-44fc-9eb7-d8f28c2b3851)
