### PR TITLE
feat(delivery): add cutoff item date for so delivery items

### DIFF
--- a/erpnext/public/js/bulk_transaction_processing.js
+++ b/erpnext/public/js/bulk_transaction_processing.js
@@ -1,7 +1,7 @@
 frappe.provide("erpnext.bulk_transaction_processing");
 
 $.extend(erpnext.bulk_transaction_processing, {
-	create: function(listview, from_doctype, to_doctype) {
+	create: function(listview, from_doctype, to_doctype, args) {
 		let checked_items = listview.get_checked_items();
 		const doc_name = [];
 		checked_items.forEach((Item)=> {
@@ -15,7 +15,7 @@ $.extend(erpnext.bulk_transaction_processing, {
 			if (doc_name.length == 0) {
 				frappe.call({
 					method: "erpnext.utilities.bulk_transaction.transaction_processing",
-					args: {data: checked_items, from_doctype: from_doctype, to_doctype: to_doctype}
+					args: {data: checked_items, from_doctype: from_doctype, to_doctype: to_doctype, args: args}
 				}).then(()=> {
 
 				});

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -801,6 +801,8 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 		var delivery_dates = this.frm.doc.items.map(i => i.delivery_date);
 		delivery_dates = [ ...new Set(delivery_dates) ];
 
+		var today = new Date();
+
 		var item_grid = this.frm.fields_dict["items"].grid;
 		if(!item_grid.get_selected().length && delivery_dates.length > 1) {
 			var dialog = new frappe.ui.Dialog({
@@ -819,7 +821,11 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 						<div class="list-item">
 							<div class="list-item__content list-item__content--flex-2">
 								<label>
-								<input type="checkbox" data-date="${date}" checked="checked"/>
+								<input
+									type="checkbox"
+									data-date="${date}"
+									${frappe.datetime.get_day_diff(new Date(date), today) > 0 ? "" : 'checked="checked"'}
+								/>
 								${frappe.datetime.str_to_user(date)}
 								</label>
 							</div>

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -780,6 +780,9 @@ def make_delivery_note(source_name, target_doc=None, kwargs=None):
 		if frappe.flags.args and frappe.flags.args.delivery_dates:
 			if cstr(doc.delivery_date) not in frappe.flags.args.delivery_dates:
 				return False
+		if frappe.flags.args and frappe.flags.args.until_delivery_date:
+			if cstr(doc.delivery_date) > frappe.flags.args.until_delivery_date:
+				return False
 
 		return abs(doc.delivered_qty) < abs(doc.qty) and doc.delivered_by_supplier != 1
 

--- a/erpnext/selling/doctype/sales_order/sales_order_list.js
+++ b/erpnext/selling/doctype/sales_order/sales_order_list.js
@@ -53,7 +53,18 @@ frappe.listview_settings['Sales Order'] = {
 		});
 
 		listview.page.add_action_item(__("Delivery Note"), ()=>{
-			erpnext.bulk_transaction_processing.create(listview, "Sales Order", "Delivery Note");
+			var dialog = new frappe.ui.Dialog({
+				title: __("Select Items up to Delivery Date"),
+				fields: [{fieldtype: "Date", fieldname: "delivery_date", default: frappe.datetime.add_days(frappe.datetime.nowdate(), 1)}]
+			});
+			dialog.set_primary_action(__("Select"), function(values) {
+				var until_delivery_date = values.delivery_date;
+				erpnext.bulk_transaction_processing.create(listview, "Sales Order", "Delivery Note", {
+    					until_delivery_date
+				});
+				dialog.hide();
+			});
+			dialog.show();
 		});
 
 		listview.page.add_action_item(__("Advance Payment"), ()=>{

--- a/erpnext/utilities/bulk_transaction.py
+++ b/erpnext/utilities/bulk_transaction.py
@@ -6,11 +6,14 @@ from frappe import _
 
 
 @frappe.whitelist()
-def transaction_processing(data, from_doctype, to_doctype):
+def transaction_processing(data, from_doctype, to_doctype, args=None):
 	if isinstance(data, str):
 		deserialized_data = json.loads(data)
 	else:
 		deserialized_data = data
+
+	if isinstance(args, str):
+		args = frappe._dict(json.loads(args))
 
 	length_of_data = len(deserialized_data)
 
@@ -23,13 +26,18 @@ def transaction_processing(data, from_doctype, to_doctype):
 			deserialized_data=deserialized_data,
 			from_doctype=from_doctype,
 			to_doctype=to_doctype,
+			args=args,
 		)
 	else:
-		job(deserialized_data, from_doctype, to_doctype)
+		job(deserialized_data, from_doctype, to_doctype, args)
 
 
-def job(deserialized_data, from_doctype, to_doctype):
+def job(deserialized_data, from_doctype, to_doctype, args):
 	fail_count = 0
+
+	if args:
+		frappe.flags.args = args
+
 	for d in deserialized_data:
 		try:
 			doc_name = d.get("name")


### PR DESCRIPTION
# Context

1. Plan tomorrow's delivery
2. Only include delivery's up to due date "tomorrow"

Currently, when bulk-creating delivery notes, there is no way to set a cutoff date for only selecting due items.

Furthermore, when selecting due dates on a single SO creation via the date selection dialogue, the default is to check all items.


# Proposed Solution

- On single SO->DN creation: by default check dates up until "tomorrow"
- On bulk creation: add a modal to select a cutoff date (which also defaults to "tomorrow")


This way, workflows involving planned delivery schedule are made available for bulk processing which is paramount with only a couple of dozends of such SOs.
