### PR TITLE
fix(customer): contact creation for companies

### DIFF
--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -309,13 +309,14 @@ class Customer(TransactionBase):
 
 def create_contact(contact, party_type, party, email):
 	"""Create contact based on given contact name"""
-	contact = contact.split(" ")
+	names = contact.split(" ")
 
 	contact = frappe.get_doc(
 		{
 			"doctype": "Contact",
-			"first_name": contact[0],
-			"last_name": len(contact) > 1 and contact[1] or "",
+			"first_name": names[0],
+			"middle_name": len(names) > 2 and " ".join(names[1:-1]) or "",
+			"last_name": len(names) > 1 and names[-1] or "",
 			"is_primary_contact": 1,
 		}
 	)
@@ -640,14 +641,28 @@ def get_credit_limit(customer, company):
 
 
 def make_contact(args, is_primary_contact=1):
-	contact = frappe.get_doc(
-		{
-			"doctype": "Contact",
-			"first_name": args.get("customer_name"),
-			"is_primary_contact": is_primary_contact,
-			"links": [{"link_doctype": args.get("doctype"), "link_name": args.get("name")}],
-		}
-	)
+	values = {
+		"doctype": "Contact",
+		"is_primary_contact": is_primary_contact,
+		"links": [{"link_doctype": args.get("doctype"), "link_name": args.get("name")}],
+	}
+	if args.customer_type == "Individual":
+		names = args.get("customer_name").split(" ")
+		values.update(
+			{
+				"first_name": names[0],
+				"middle_name": len(names) > 2 and " ".join(names[1:-1]) or "",
+				"last_name": len(names) > 1 and names[-1] or "",
+			}
+		)
+	else:
+		values.update(
+			{
+				"company_name": args.get("customer_name"),
+			}
+		)
+	contact = frappe.get_doc(values)
+
 	if args.get("email_id"):
 		contact.add_email(args.get("email_id"), is_primary=True)
 	if args.get("mobile_no"):


### PR DESCRIPTION
follow up on #37386 based on suggestion:


> Mapping customer name to first name is a bit better, but still often incorrect, especially when the customer is a company. Contact has a dedicated field for the company name.


from @barredterra [here](https://github.com/frappe/erpnext/pull/37386#issuecomment-1806848607)
