### PR TITLE
chore: delete comments and unlink attachments on company transactions deletion

### DIFF
--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -365,7 +365,7 @@ class BuyingController(SubcontractingController):
 						{
 							"item_code": d.item_code,
 							"warehouse": d.get("from_warehouse"),
-							"posting_date": self.get("posting_date") or self.get("transation_date"),
+							"posting_date": self.get("posting_date") or self.get("transaction_date"),
 							"posting_time": posting_time,
 							"qty": -1 * flt(d.get("stock_qty")),
 							"serial_and_batch_bundle": d.get("serial_and_batch_bundle"),


### PR DESCRIPTION
If a user [deletes all company transactions](https://docs.erpnext.com/docs/user/manual/en/delete_company_transactions) and then resets the series counter of all doctypes to 0, the attachments and comments of deleted documents showed up in newly created documents. For example, attachments and comments of the old, deleted PUR-ORD-2023-00003 showed up in the newly created PUR-ORD-2023-00003. This is because comments weren't deleted and attachments weren't unlinked, so fixed that.