### PR TITLE
fix(minor): repost ledger settings perm for system manager

### DIFF
--- a/erpnext/accounts/doctype/repost_accounting_ledger_settings/repost_accounting_ledger_settings.json
+++ b/erpnext/accounts/doctype/repost_accounting_ledger_settings/repost_accounting_ledger_settings.json
@@ -17,7 +17,7 @@
  "in_create": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-11-07 14:24:13.321522",
+ "modified": "2023-11-14 13:23:20.192530",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Repost Accounting Ledger Settings",
@@ -34,9 +34,12 @@
    "write": 1
   },
   {
+   "create": 1,
+   "delete": 1,
    "read": 1,
    "role": "System Manager",
-   "select": 1
+   "select": 1,
+   "write": 1
   }
  ],
  "sort_field": "modified",


### PR DESCRIPTION
Added default write permission for System Manager in the Repost Accounting Ledger Settings.

`no-docs`