### PR TITLE
fix(UX): enable `automatically_fetch_payment_terms` on default

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -178,7 +178,7 @@
    "label": "Stale Days"
   },
   {
-   "default": "0",
+   "default": "1",
    "description": "Payment Terms from orders will be fetched into the invoices as is",
    "fieldname": "automatically_fetch_payment_terms",
    "fieldtype": "Check",

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -941,11 +941,12 @@ def make_sales_invoice(source_name, target_doc=None, ignore_permissions=False):
 		ignore_permissions=ignore_permissions,
 	)
 
-	automatically_fetch_payment_terms = cint(
-		frappe.db.get_single_value("Accounts Settings", "automatically_fetch_payment_terms")
-	)
-	if automatically_fetch_payment_terms:
-		doclist.set_payment_schedule()
+	if doclist.get("items"):
+		automatically_fetch_payment_terms = cint(
+			frappe.db.get_single_value("Accounts Settings", "automatically_fetch_payment_terms")
+		)
+		if automatically_fetch_payment_terms:
+			doclist.set_payment_schedule()
 
 	doclist.set_onload("ignore_price_list", True)
 

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -125,9 +125,11 @@ class TestSalesOrder(FrappeTestCase):
 		si.save()
 
 		self.assertEqual(si.payment_schedule[0].payment_amount, 500.0)
-		self.assertEqual(si.payment_schedule[0].due_date, so.transaction_date)
+		self.assertEqual(getdate(si.payment_schedule[0].due_date), getdate(so.transaction_date))
 		self.assertEqual(si.payment_schedule[1].payment_amount, 500.0)
-		self.assertEqual(si.payment_schedule[1].due_date, add_days(so.transaction_date, 30))
+		self.assertEqual(
+			getdate(si.payment_schedule[1].due_date), getdate(add_days(so.transaction_date, 30))
+		)
 
 		si.submit()
 

--- a/erpnext/selling/report/sales_order_analysis/test_sales_order_analysis.py
+++ b/erpnext/selling/report/sales_order_analysis/test_sales_order_analysis.py
@@ -32,6 +32,7 @@ class TestSalesOrderAnalysis(FrappeTestCase):
 
 	def create_sales_invoice(self, so, do_not_save=False, do_not_submit=False):
 		sinv = make_sales_invoice(so.name)
+		sinv.set_posting_time = True
 		sinv.posting_date = so.transaction_date
 		sinv.taxes_and_charges = ""
 		sinv.taxes = ""


### PR DESCRIPTION
Relaunch of @rohitwaghchaure‘s #32617. Fixes #38029.

Enabling this setting by default makes a lot of sense. One might even ask why this switch exists at all.

It is really hard to see a reason someone would create a Sales Order with Payment Terms, but then wouldn‘t want these Payment Terms be preserved when creating the Sales Invoice.

See for example this: #36108. Even devops don‘t expect this to be just an optional feature. It‘s so much expected that people would try and come up with a PR to implement a feature deemed missing.

There used to be a few rough edges, but most of them have been fixed, and remaining ones such as #38030 will have to be fixed anyway.

`defer backport`