### PR TITLE
fix(Timesheet): reset billing hours equal to hours if they exceed actual hours

### DIFF
--- a/erpnext/projects/doctype/timesheet/timesheet.py
+++ b/erpnext/projects/doctype/timesheet/timesheet.py
@@ -69,7 +69,7 @@ class Timesheet(Document):
 
 	def update_billing_hours(self, args):
 		if args.is_billable:
-			if flt(args.billing_hours) == 0.0:
+			if flt(args.billing_hours) == 0.0 or flt(args.billing_hours) > flt(args.hours):
 				args.billing_hours = args.hours
 		else:
 			args.billing_hours = 0


### PR DESCRIPTION
## Steps to replicate

1. Enter hours = 1, enable Is Billable, and save. This sets Billing Hours = 1 (Hours)
2. Change hours = 0.5, save. Billing hours still remain 1

<img width="1323" alt="hours" src="https://github.com/frappe/erpnext/assets/24353136/7ea8c21a-93d2-4e6f-bb81-dcb58462ae9e">

## Fix

Reset billing hours = hours if they exceed hours

P.S: should this happen silently or with a msgprint (?)