### PR TITLE
fix(minor): show party instead of party name where naming series not set

### DIFF
--- a/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
+++ b/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
@@ -184,6 +184,16 @@ def get_columns(filters):
 				"width": 180,
 			}
 		)
+	else:
+		columns.append(
+			{
+				"label": _(filters.get("party_type")),
+				"fieldname": "party",
+				"fieldtype": "Dynamic Link",
+				"options": "party_type",
+				"width": 180,
+			}
+		)
 
 	columns.extend(
 		[


### PR DESCRIPTION
When Party Naming By is not set to Naming Series, show supplier / customer field values in Tax Withholding Details.