### PR TITLE
fix: valuation rate in report Item Prices

### DIFF
--- a/erpnext/stock/report/item_prices/item_prices.py
+++ b/erpnext/stock/report/item_prices/item_prices.py
@@ -202,7 +202,7 @@ def get_valuation_rate():
 	bin_data = (
 		frappe.qb.from_(bin)
 		.select(
-			bin.item_code, Sum(bin.actual_qty * bin.valuation_rate) / Sum(bin.actual_qty).as_("val_rate")
+			bin.item_code, (Sum(bin.actual_qty * bin.valuation_rate) / Sum(bin.actual_qty)).as_("val_rate")
 		)
 		.where(bin.actual_qty > 0)
 		.groupby(bin.item_code)


### PR DESCRIPTION
**Problem:** Valuation rates were printed as _0,00_ in the Report _Item Prices_.

**Cause:** Missing brackets.

**Effect in backend:** item_val_rate_map was a dictionary that looked like this: {item_code: None}

With the brackets it works:
![image](https://github.com/frappe/erpnext/assets/77415730/f8843732-afd0-4cc8-bfe0-11712689fe44)
