### PR TITLE
fix: attributes were mandatory for manufacturers

### DIFF
--- a/erpnext/stock/doctype/item/item.json
+++ b/erpnext/stock/doctype/item/item.json
@@ -504,7 +504,7 @@
    "fieldtype": "Table",
    "hidden": 1,
    "label": "Variant Attributes",
-   "mandatory_depends_on": "has_variants",
+   "mandatory_depends_on": "eval:(doc.has_variants || doc.variant_of) && doc.variant_based_on==='Item Attribute'",
    "options": "Item Variant Attribute"
   },
   {


### PR DESCRIPTION
For Variants based on Manufacturers the table of fieldname "attributes" was not shown (see depends_on). 
But the mandatory_depends_on field was deviating from that, such that it was still a mandatory field - even though it was not shown.