### PR TITLE
fix: payment entry rounding error

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -853,6 +853,7 @@ frappe.ui.form.on('Payment Entry', {
 
 			var allocated_positive_outstanding =  paid_amount + allocated_negative_outstanding;
 		} else if (in_list(["Customer", "Supplier"], frm.doc.party_type)) {
+			total_negative_outstanding = flt(total_negative_outstanding, precision("outstanding_amount"))
 			if(paid_amount > total_negative_outstanding) {
 				if(total_negative_outstanding == 0) {
 					frappe.msgprint(


### PR DESCRIPTION
Given the following Sales Invoice's
![image](https://github.com/frappe/erpnext/assets/29856401/30061f94-726e-480b-86c7-2753292f8cb6)

Payment Entry towards customer provides message due to precision error.
![image](https://github.com/frappe/erpnext/assets/29856401/3a111f31-fefb-43fc-928a-f31870faf406)
