### PR TITLE
fix: `automatically_fetch_payment_terms` resets given Posting Date

### DIFF
--- a/erpnext/selling/report/sales_order_analysis/test_sales_order_analysis.py
+++ b/erpnext/selling/report/sales_order_analysis/test_sales_order_analysis.py
@@ -252,3 +252,14 @@ class TestSalesOrderAnalysis(FrappeTestCase):
 		for key, val in expected_value.items():
 			with self.subTest(key=key, val=val):
 				self.assertEqual(data[0][key], val)
+
+	def test_08_so_autofetch_payment_terms(self):
+		from erpnext.selling.doctype.sales_order.test_sales_order import (
+			automatically_fetch_payment_terms,
+		)
+
+		automatically_fetch_payment_terms()
+		try:
+			self.test_02_so_to_deliver()
+		finally:
+			automatically_fetch_payment_terms(enable=0)


### PR DESCRIPTION
`automatically_fetch_payment_terms` resets a given (historical) Posting Date to today so validation of the Due Date will inevitably fail.

In test_02_so_to_deliver:
`transaction_date = "2021-06-01"`

In create_sales_invoice:
`sinv.posting_date = so.transaction_date`

Result:
```
due_date = datetime.date(2021, 6, 1)
posting_date = '2023-11-19'
frappe.exceptions.validationerror: Due Date cannot be before Posting / Supplier Invoice Date
```

Let‘s start with a failing test.