### PR TITLE
fix: difference amount in invoice returns when mapping

### DIFF
--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -358,12 +358,25 @@ class calculate_taxes_and_totals(object):
 				):
 					tax.tax_amount += current_tax_amount
 
+				tax_amount_with_precision = flt(abs(tax.tax_amount), tax.precision("tax_amount"))
+				tax.tax_amount = (
+					-tax_amount_with_precision if tax.tax_amount < 0 else tax_amount_with_precision
+				)
+
 				# store tax_amount for current item as it will be used for
 				# charge type = 'On Previous Row Amount'
 				tax.tax_amount_for_current_item = current_tax_amount
 
 				# set tax after discount
 				tax.tax_amount_after_discount_amount += current_tax_amount
+				tax_after_discount_with_precision = flt(
+					abs(tax.tax_amount_after_discount_amount), tax.precision("tax_amount_after_discount_amount")
+				)
+				tax.tax_amount_after_discount_amount = (
+					-tax_after_discount_with_precision
+					if tax.tax_amount_after_discount_amount < 0
+					else tax_after_discount_with_precision
+				)
 
 				current_tax_amount = self.get_tax_amount_if_for_valuation_or_deduction(current_tax_amount, tax)
 


### PR DESCRIPTION
**Bug**
When a Return is created against an invoice, the tax values fetched from the invoice are mapped to a new invoice document, but lose precision when calculating the tax totals. This creates a 0.01 difference between the Invoice total and Return Total only for certain amounts. Eg : when the total tax amount is 119.0249999 the Invoice has value 119.03, however, the return has tax amount as 119.02.

**Fix**
Use proper precision for tax amount and tax total for negative tax totals.