### PR TITLE
fix: set default asset quantity as 1 [v14]

### DIFF
--- a/erpnext/assets/doctype/asset/asset.json
+++ b/erpnext/assets/doctype/asset/asset.json
@@ -495,6 +495,7 @@
    "read_only": 1
   },
   {
+   "default": "1",
    "fieldname": "asset_quantity",
    "fieldtype": "Int",
    "label": "Asset Quantity",
@@ -564,7 +565,7 @@
    "link_fieldname": "target_asset"
   }
  ],
- "modified": "2023-11-15 17:40:17.315203",
+ "modified": "2023-11-20 21:05:45.216899",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset",

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -1221,6 +1221,7 @@ def get_item_details(item_code, asset_category, gross_purchase_amount):
 				"expected_value_after_useful_life": flt(gross_purchase_amount)
 				* flt(d.salvage_value_percentage / 100),
 				"depreciation_start_date": d.depreciation_start_date or nowdate(),
+				"rate_of_depreciation": d.rate_of_depreciation,
 			}
 		)
 

--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -746,7 +746,7 @@ class BuyingController(SubcontractingController):
 				"calculate_depreciation": 1,
 				"purchase_receipt_amount": purchase_amount,
 				"gross_purchase_amount": purchase_amount,
-				"asset_quantity": row.qty if is_grouped_asset else 0,
+				"asset_quantity": row.qty if is_grouped_asset else 1,
 				"purchase_receipt": self.name if self.doctype == "Purchase Receipt" else None,
 				"purchase_invoice": self.name if self.doctype == "Purchase Invoice" else None,
 				"cost_center": row.cost_center,

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -350,5 +350,6 @@ erpnext.patches.v14_0.rename_daily_depreciation_to_depreciation_amount_based_on_
 erpnext.patches.v14_0.rename_depreciation_amount_based_on_num_days_in_month_to_daily_prorata_based
 erpnext.patches.v14_0.add_default_for_repost_settings
 erpnext.patches.v14_0.create_accounting_dimensions_in_supplier_quotation
+erpnext.patches.v14_0.update_zero_asset_quantity_field
 # below migration patch should always run last
 erpnext.patches.v14_0.migrate_gl_to_payment_ledger

--- a/erpnext/patches/v14_0/update_zero_asset_quantity_field.py
+++ b/erpnext/patches/v14_0/update_zero_asset_quantity_field.py
@@ -1,0 +1,6 @@
+import frappe
+
+
+def execute():
+	asset = frappe.qb.DocType("Asset")
+	frappe.qb.update(asset).set(asset.asset_quantity, 1).where(asset.asset_quantity == 0).run()


### PR DESCRIPTION
 - setting default asset quantity as 1 when auto-created from purchase receipt; earlier it was 0, which is incorrect
 - setting default asset quantity as 1 when created from desk
 - unrelated: get rate_of_depreciation from asset category for asset auto-creation