### PR TITLE
fix(Timesheet): warn user if billing hours > actual hours instead of resetting 

### DIFF
--- a/erpnext/projects/doctype/timesheet/timesheet.py
+++ b/erpnext/projects/doctype/timesheet/timesheet.py
@@ -71,6 +71,12 @@ class Timesheet(Document):
 		if args.is_billable:
 			if flt(args.billing_hours) == 0.0:
 				args.billing_hours = args.hours
+			elif flt(args.billing_hours) > flt(args.hours):
+				frappe.msgprint(
+					_("Warning - Row {0}: Billing Hours are more than Actual Hours").format(args.idx),
+					indicator="orange",
+					alert=True,
+				)
 		else:
 			args.billing_hours = 0
 

--- a/erpnext/projects/doctype/timesheet/timesheet.py
+++ b/erpnext/projects/doctype/timesheet/timesheet.py
@@ -69,7 +69,7 @@ class Timesheet(Document):
 
 	def update_billing_hours(self, args):
 		if args.is_billable:
-			if flt(args.billing_hours) == 0.0 or flt(args.billing_hours) > flt(args.hours):
+			if flt(args.billing_hours) == 0.0:
 				args.billing_hours = args.hours
 		else:
 			args.billing_hours = 0


### PR DESCRIPTION
reverting changes in https://github.com/frappe/erpnext/pull/38134 and replacing it with an alert to warn users if billing hours > actual hours to avoid oversight