### PR TITLE
fix: unset discount amount based on coupon code

### DIFF
--- a/erpnext/public/js/utils/sales_common.js
+++ b/erpnext/public/js/utils/sales_common.js
@@ -369,6 +369,11 @@ erpnext.sales_common = {
 					}
 				}
 			}
+
+			coupon_code() {
+				this.frm.set_value("discount_amount", 0);
+				this.frm.set_value("additional_discount_percentage", 0);
+			}
 		};
 	}
 }


### PR DESCRIPTION
When Coupon Code is removed from the Additional Discount section for any document, unset the discount amount value from the form.