### PR TITLE
fix: patch - Duplicate entry quality inspection parameter

### DIFF
--- a/erpnext/patches/v13_0/convert_qi_parameter_to_link_field.py
+++ b/erpnext/patches/v13_0/convert_qi_parameter_to_link_field.py
@@ -21,6 +21,9 @@ def execute():
 	params = set({x.casefold(): x for x in params}.values())
 
 	for parameter in params:
+		if frappe.db.exists("Quality Inspection Parameter", parameter):
+			continue
+
 		frappe.get_doc(
 			{"doctype": "Quality Inspection Parameter", "parameter": parameter, "description": parameter}
 		).insert(ignore_permissions=True)


### PR DESCRIPTION
**convert_qi_parameter_to_link_field Patch failing** 

```
File "/home/frappe/frappe-bench/apps/erpnext/erpnext/patches/v13_0/convert_qi_parameter_to_link_field.py", line 26, in execute
    ).insert(ignore_permissions=True)
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 278, in insert
    raise e
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/document.py", line 275, in insert
    self.db_insert()
  File "/home/frappe/frappe-bench/apps/frappe/frappe/model/base_document.py", line 436, in db_insert
    raise frappe.DuplicateEntryError(self.doctype, self.name, e)
frappe.exceptions.DuplicateEntryError: ('Quality Inspection Parameter', 'Dimension 3: PCB side height', IntegrityError(1062, "Duplicate entry 'Dimension 3: PCB side height' for key 'PRIMARY'"))
```