### PR TITLE
fix: annual income and expenses in email digest

### DIFF
--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -183,6 +183,7 @@ def get_balance_on(
 	cost_center=None,
 	ignore_account_permission=False,
 	account_type=None,
+	start_date=None,
 ):
 	if not account and frappe.form_dict.get("account"):
 		account = frappe.form_dict.get("account")
@@ -196,6 +197,8 @@ def get_balance_on(
 		cost_center = frappe.form_dict.get("cost_center")
 
 	cond = ["is_cancelled=0"]
+	if start_date:
+		cond.append("posting_date >= %s" % frappe.db.escape(cstr(start_date)))
 	if date:
 		cond.append("posting_date <= %s" % frappe.db.escape(cstr(date)))
 	else:

--- a/erpnext/setup/doctype/email_digest/email_digest.py
+++ b/erpnext/setup/doctype/email_digest/email_digest.py
@@ -382,9 +382,10 @@ class EmailDigest(Document):
 		"""Get income to date"""
 		balance = 0.0
 		count = 0
+		fy_start_date = get_fiscal_year().get("year_start_date")
 
 		for account in self.get_root_type_accounts(root_type):
-			balance += get_balance_on(account, date=self.future_to_date)
+			balance += get_balance_on(account, date=self.future_to_date, start_date=fy_start_date)
 			count += get_count_on(account, fieldname, date=self.future_to_date)
 
 		if fieldname == "income":

--- a/erpnext/setup/doctype/email_digest/email_digest.py
+++ b/erpnext/setup/doctype/email_digest/email_digest.py
@@ -382,7 +382,7 @@ class EmailDigest(Document):
 		"""Get income to date"""
 		balance = 0.0
 		count = 0
-		fy_start_date = get_fiscal_year().get("year_start_date")
+		fy_start_date = get_fiscal_year(self.future_to_date)[1]
 
 		for account in self.get_root_type_accounts(root_type):
 			balance += get_balance_on(account, date=self.future_to_date, start_date=fy_start_date)


### PR DESCRIPTION
### Bug

Email Digest calculates wrong annual income and expense values for a particular fiscal year if the PCV for the previous year has not been submitted. 

**Income for 2022-2023**
> <img width="1277" alt="Screenshot 2023-11-22 at 6 41 43 PM" src="https://github.com/frappe/erpnext/assets/40693548/401a74ed-4024-4107-b6e8-b30afcfcf88e">

<br>

**Income for 2023-2024**
> <img width="1277" alt="Screenshot 2023-11-22 at 6 41 19 PM" src="https://github.com/frappe/erpnext/assets/40693548/7c8e20b4-97ba-4e94-8893-627e466ed407">


**Email Digest sent on a date in the current fiscal year**
> <img width="1280" alt="Screenshot 2023-11-22 at 6 45 09 PM" src="https://github.com/frappe/erpnext/assets/40693548/3b48e6f4-0711-47c6-8951-d9b1e5aaf5ac">


<br>

### Fix
Consider GL Entries only from current fiscal year.