### PR TITLE
add flt() for None type error

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -839,7 +839,7 @@ class JournalEntry(AccountsController):
 					party_account_currency = d.account_currency
 
 			elif frappe.get_cached_value("Account", d.account, "account_type") in ["Bank", "Cash"]:
-				bank_amount += d.debit_in_account_currency or d.credit_in_account_currency
+				bank_amount += flt(d.debit_in_account_currency) or flt(d.credit_in_account_currency)
 				bank_account_currency = d.account_currency
 
 		if party_type and pay_to_recd_from:


### PR DESCRIPTION
[Payment Enty Submit => TypeError: unsupported operand type(s) for *: 'float' and 'NoneType'](https://github.com/frappe/erpnext/issues/37813)[#37813](https://github.com/frappe/erpnext/issues/37813)