### PR TITLE
fix: precision for invoice outstandings

### DIFF
--- a/erpnext/accounts/doctype/gl_entry/gl_entry.py
+++ b/erpnext/accounts/doctype/gl_entry/gl_entry.py
@@ -358,6 +358,7 @@ def update_outstanding_amt(
 	if against_voucher_type in ["Sales Invoice", "Purchase Invoice", "Fees"]:
 		ref_doc = frappe.get_doc(against_voucher_type, against_voucher)
 
+		bal = flt(bal, frappe.get_precision(against_voucher_type, "outstanding_amount"))
 		# Didn't use db_set for optimization purpose
 		ref_doc.outstanding_amount = bal
 		frappe.db.set_value(against_voucher_type, against_voucher, "outstanding_amount", bal)


### PR DESCRIPTION
**Bug**

When a payment is made against an Invoice with the allocated amount having precision more than that of the outstanding amount precision, the outstanding amount in the invoice is set to have higher precision than the currency precision. Therefore, when another payment is reconciled against this invoice, the validation for ensuring that the outstanding is correct fails.

**Screenshot**

<img width="608" alt="Screenshot 2023-11-24 at 2 57 19 PM" src="https://github.com/frappe/erpnext/assets/40693548/16d7aca4-2967-419c-aac9-3cc7786a3169">

<br>
<br>

**Fix**
Set the balance amount in `update_outstanding_amt` by using the precision for the field.