### PR TITLE
fix: consolidate GL entries based on voucher

### DIFF
--- a/erpnext/accounts/report/general_ledger/test_general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/test_general_ledger.py
@@ -146,5 +146,5 @@ class TestGeneralLedger(FrappeTestCase):
 		self.assertEqual(data[1]["credit"], 0)
 		self.assertEqual(data[2]["debit"], 0)
 		self.assertEqual(data[2]["credit"], 900)
-		self.assertEqual(data[3]["debit"], 100)
 		self.assertEqual(data[3]["credit"], 100)
+		self.assertEqual(data[4]["debit"], 100)


### PR DESCRIPTION
Create a payment entry `without any references`. Reconcile the same against multiple invoices using payment reconciliation tool.
![Screenshot 2023-11-25 at 14-46-46 Dany - ACC-PAY-2023-00004-1](https://github.com/frappe/erpnext/assets/52111700/1706c5a6-d835-4031-a9b5-b1bd59ce08b6)

Create another payment entry, this time allocate the amounts in the payment entry itself.
![Screenshot 2023-11-25 at 14-47-27 Dany - ACC-PAY-2023-00005](https://github.com/frappe/erpnext/assets/52111700/59d32c1b-6feb-4ee4-8b3f-5fe41d3a6c27)

Look at the General Ledger:
![Screenshot 2023-11-25 at 14-47-44 General Ledger](https://github.com/frappe/erpnext/assets/52111700/b170524a-a76c-418f-9967-0c8c8f8a9170)


Even though both payment entry records look the same, they differ in the General Ledger, while the first one has only 2 entries, the second one has n-number of entries(n being the number of unique references).

This PR consolidates it based on voucher and account, if the `group_by` is `Group by Voucher (Consolidated)`

General Ledger after this PR:
![image](https://github.com/frappe/erpnext/assets/52111700/e2b4fcd8-43fd-4f00-b388-1548379deb0d)

Also removes debit and credit being on the same line.