### PR TITLE
feat: track Semi-finished goods (including subcontracted items) against Job Cards

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -369,7 +369,7 @@ class PurchaseOrder(BuyingController):
 									item.idx, item.fg_item
 								)
 							)
-						elif not frappe.get_value("Item", item.fg_item, "default_bom"):
+						elif not item.bom and not frappe.get_value("Item", item.fg_item, "default_bom"):
 							frappe.throw(
 								_("Row #{0}: Default BOM not found for FG Item {1}").format(
 									item.idx, item.fg_item
@@ -918,6 +918,14 @@ def get_mapped_subcontracting_order(source_name, target_doc=None):
 		else:
 			for idx, item in enumerate(target_doc.items):
 				item.warehouse = source_doc.items[idx].warehouse
+
+	for idx, item in enumerate(target_doc.items):
+		item.job_card = source_doc.items[idx].job_card
+		if not target_doc.supplier_warehouse:
+			# WIP warehouse is set as Supplier Warehouse in Job Card
+			target_doc.supplier_warehouse = frappe.get_cached_value(
+				"Job Card", item.job_card, "wip_warehouse"
+			)
 
 	return target_doc
 

--- a/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
+++ b/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
@@ -110,7 +110,9 @@
   "production_plan",
   "production_plan_item",
   "production_plan_sub_assembly_item",
-  "page_break"
+  "page_break",
+  "column_break_pjyo",
+  "job_card"
  ],
  "fields": [
   {
@@ -909,13 +911,24 @@
   {
    "fieldname": "column_break_fyqr",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "column_break_pjyo",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "job_card",
+   "fieldtype": "Link",
+   "label": "Job Card",
+   "options": "Job Card",
+   "search_index": 1
   }
  ],
  "idx": 1,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:24.979325",
+ "modified": "2024-03-27 13:11:24.979325",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Purchase Order Item",

--- a/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
+++ b/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
@@ -928,7 +928,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:11:24.979325",
+ "modified": "2024-03-27 13:12:24.979325",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Purchase Order Item",

--- a/erpnext/manufacturing/doctype/bom/bom.json
+++ b/erpnext/manufacturing/doctype/bom/bom.json
@@ -28,7 +28,7 @@
   "conversion_rate",
   "operations_section_section",
   "with_operations",
-  "make_finished_good_against_job_card",
+  "track_semi_finished_goods",
   "column_break_23",
   "transfer_material_against",
   "routing",
@@ -62,8 +62,8 @@
   "base_total_cost",
   "more_info_tab",
   "item_name",
-  "description",
   "column_break_27",
+  "description",
   "has_variants",
   "quality_inspection_section_break",
   "inspection_required",
@@ -214,7 +214,7 @@
   },
   {
    "default": "Work Order",
-   "depends_on": "eval: doc.with_operations === 1 && doc.make_finished_good_against_job_card === 0",
+   "depends_on": "eval: doc.with_operations === 1 && doc.track_semi_finished_goods === 0",
    "fieldname": "transfer_material_against",
    "fieldtype": "Select",
    "label": "Transfer Material Against",
@@ -409,8 +409,8 @@
   {
    "depends_on": "eval:!doc.__islocal",
    "fieldname": "section_break0",
-   "fieldtype": "Section Break",
-   "label": "Materials Required (Exploded)"
+   "fieldtype": "Tab Break",
+   "label": "Exploded Items"
   },
   {
    "fieldname": "exploded_items",
@@ -617,7 +617,8 @@
    "no_copy": 1,
    "options": "BOM Creator",
    "print_hide": 1,
-   "read_only": 1
+   "read_only": 1,
+   "search_index": 1
   },
   {
    "fieldname": "bom_creator_item",
@@ -625,7 +626,8 @@
    "label": "BOM Creator Item",
    "no_copy": 1,
    "print_hide": 1,
-   "read_only": 1
+   "read_only": 1,
+   "search_index": 1
   },
   {
    "fieldname": "column_break_oxbz",
@@ -634,10 +636,10 @@
   {
    "default": "0",
    "depends_on": "with_operations",
-   "description": "User can consume the raw materials, Add Semi Finished Goods /  Final Finished Good against the Operation using Job Cards",
-   "fieldname": "make_finished_good_against_job_card",
+   "description": "Users can consume raw materials and add semi-finished goods or final finished goods against the operation using job cards.",
+   "fieldname": "track_semi_finished_goods",
    "fieldtype": "Check",
-   "label": "Make Finished Good Against Job Card"
+   "label": "Track Semi Finished Goods"
   },
   {
    "fieldname": "column_break_joxb",
@@ -661,7 +663,7 @@
  "image_field": "image",
  "is_submittable": 1,
  "links": [],
- "modified": "2024-04-02 16:23:47.518411",
+ "modified": "2024-04-02 16:24:47.518411",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "BOM",

--- a/erpnext/manufacturing/doctype/bom/bom.json
+++ b/erpnext/manufacturing/doctype/bom/bom.json
@@ -26,19 +26,22 @@
   "column_break_ivyw",
   "currency",
   "conversion_rate",
-  "materials_section",
-  "items",
-  "section_break_21",
   "operations_section_section",
   "with_operations",
+  "make_finished_good_against_job_card",
   "column_break_23",
   "transfer_material_against",
   "routing",
   "fg_based_operating_cost",
+  "column_break_joxb",
+  "default_source_warehouse",
+  "default_target_warehouse",
   "fg_based_section_section",
   "operating_cost_per_bom_quantity",
   "operations_section",
   "operations",
+  "materials_section",
+  "items",
   "scrap_section",
   "scrap_items_section",
   "scrap_items",
@@ -211,7 +214,7 @@
   },
   {
    "default": "Work Order",
-   "depends_on": "with_operations",
+   "depends_on": "eval: doc.with_operations === 1 && doc.make_finished_good_against_job_card === 0",
    "fieldname": "transfer_material_against",
    "fieldtype": "Select",
    "label": "Transfer Material Against",
@@ -486,11 +489,6 @@
    "label": "Show Operations"
   },
   {
-   "fieldname": "section_break_21",
-   "fieldtype": "Tab Break",
-   "label": "Operations"
-  },
-  {
    "fieldname": "column_break_23",
    "fieldtype": "Column Break"
   },
@@ -534,6 +532,8 @@
    "show_dashboard": 1
   },
   {
+   "collapsible": 1,
+   "collapsible_depends_on": "eval:doc.with_operations",
    "fieldname": "operations_section_section",
    "fieldtype": "Section Break",
    "label": "Operations"
@@ -630,6 +630,30 @@
   {
    "fieldname": "column_break_oxbz",
    "fieldtype": "Column Break"
+  },
+  {
+   "default": "0",
+   "depends_on": "with_operations",
+   "description": "User can consume the raw materials, Add Semi Finished Goods /  Final Finished Good against the Operation using Job Cards",
+   "fieldname": "make_finished_good_against_job_card",
+   "fieldtype": "Check",
+   "label": "Make Finished Good Against Job Card"
+  },
+  {
+   "fieldname": "column_break_joxb",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "default_source_warehouse",
+   "fieldtype": "Link",
+   "label": "Default Source Warehouse",
+   "options": "Warehouse"
+  },
+  {
+   "fieldname": "default_target_warehouse",
+   "fieldtype": "Link",
+   "label": "Default Target Warehouse",
+   "options": "Warehouse"
   }
  ],
  "icon": "fa fa-sitemap",
@@ -637,7 +661,7 @@
  "image_field": "image",
  "is_submittable": 1,
  "links": [],
- "modified": "2024-04-02 16:22:47.518411",
+ "modified": "2024-04-02 16:23:47.518411",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "BOM",

--- a/erpnext/manufacturing/doctype/bom_creator/bom_creator.js
+++ b/erpnext/manufacturing/doctype/bom_creator/bom_creator.js
@@ -88,6 +88,34 @@ frappe.ui.form.on("BOM Creator", {
 					reqd: 1,
 					default: 1.0,
 				},
+				{ fieldtype: "Section Break" },
+				{
+					label: __("Track Operations"),
+					fieldtype: "Check",
+					fieldname: "track_operations",
+					onchange: (r) => {
+						let track_operations = dialog.get_value("track_operations");
+						if (r.type === "input" && !track_operations) {
+							dialog.set_value("make_finished_good_against_job_card", 0);
+						}
+					}
+				},
+				{
+					label: __("Make Finished Good Against Job Card"),
+					fieldtype: "Check",
+					fieldname: "make_finished_good_against_job_card",
+					depends_on: "eval:doc.track_operations"
+				},
+				{ fieldtype: "Column Break" },
+				{
+					label: __("Final Operation"),
+					fieldtype: "Link",
+					fieldname: "final_operation",
+					options: "Operation",
+					default: "Assembly",
+					mandatory_depends_on: "eval:doc.make_finished_good_against_job_card",
+					depends_on: "eval:doc.make_finished_good_against_job_card"
+				},
 			],
 			primary_action_label: __("Create"),
 			primary_action: (values) => {

--- a/erpnext/manufacturing/doctype/bom_creator/bom_creator.js
+++ b/erpnext/manufacturing/doctype/bom_creator/bom_creator.js
@@ -96,29 +96,69 @@ frappe.ui.form.on("BOM Creator", {
 					onchange: (r) => {
 						let track_operations = dialog.get_value("track_operations");
 						if (r.type === "input" && !track_operations) {
-							dialog.set_value("make_finished_good_against_job_card", 0);
+							dialog.set_value("track_semi_finished_goods", 0);
 						}
-					}
-				},
-				{
-					label: __("Make Finished Good Against Job Card"),
-					fieldtype: "Check",
-					fieldname: "make_finished_good_against_job_card",
-					depends_on: "eval:doc.track_operations"
+					},
 				},
 				{ fieldtype: "Column Break" },
 				{
-					label: __("Final Operation"),
+					label: __("Track Semi Finished Goods"),
+					fieldtype: "Check",
+					fieldname: "track_semi_finished_goods",
+					depends_on: "eval:doc.track_operations",
+				},
+				{
+					fieldtype: "Section Break",
+					label: __("Final Product Operation"),
+					depends_on: "eval:doc.track_semi_finished_goods",
+				},
+				{
+					label: __("Operation"),
 					fieldtype: "Link",
-					fieldname: "final_operation",
+					fieldname: "operation",
 					options: "Operation",
 					default: "Assembly",
-					mandatory_depends_on: "eval:doc.make_finished_good_against_job_card",
-					depends_on: "eval:doc.make_finished_good_against_job_card"
+					mandatory_depends_on: "eval:doc.track_semi_finished_goods",
+					depends_on: "eval:doc.track_semi_finished_goods",
+				},
+				{
+					label: __("Operation Time (in mins)"),
+					fieldtype: "Float",
+					fieldname: "operation_time",
+					mandatory_depends_on: "eval:doc.track_semi_finished_goods",
+					depends_on: "eval:doc.track_semi_finished_goods",
+				},
+				{ fieldtype: "Column Break" },
+				{
+					label: __("Workstation Type"),
+					fieldtype: "Link",
+					fieldname: "workstation_type",
+					options: "Workstation",
+					depends_on: "eval:doc.track_semi_finished_goods",
+				},
+				{
+					label: __("Workstation"),
+					fieldtype: "Link",
+					fieldname: "workstation",
+					options: "Workstation",
+					depends_on: "eval:doc.track_semi_finished_goods",
+					get_query() {
+						let workstation_type = dialog.get_value("workstation_type");
+
+						if (workstation_type) {
+							return {
+								filters: {
+									workstation_type: dialog.get_value("workstation_type"),
+								},
+							};
+						}
+					},
 				},
 			],
 			primary_action_label: __("Create"),
 			primary_action: (values) => {
+				frm.events.validate_dialog_values(frm, values);
+
 				values.doctype = frm.doc.doctype;
 				frappe.db.insert(values).then((doc) => {
 					frappe.set_route("Form", doc.doctype, doc.name);
@@ -128,6 +168,18 @@ frappe.ui.form.on("BOM Creator", {
 
 		dialog.fields_dict.item_code.get_query = "erpnext.controllers.queries.item_query";
 		dialog.show();
+	},
+
+	validate_dialog_values(frm, values) {
+		if (values.track_semi_finished_goods) {
+			if (values.final_operation_time <= 0) {
+				frappe.throw(__("Operation Time must be greater than 0"));
+			}
+
+			if (!values.workstation && !values.workstation_type) {
+				frappe.throw(__("Either Workstation or Workstation Type is mandatory"));
+			}
+		}
 	},
 
 	set_queries(frm) {
@@ -148,6 +200,16 @@ frappe.ui.form.on("BOM Creator", {
 			return {
 				query: "erpnext.controllers.queries.item_query",
 			};
+		});
+
+		frm.set_query("workstation", (doc) => {
+			if (doc.workstation_type) {
+				return {
+					filters: {
+						workstation_type: doc.workstation_type,
+					},
+				};
+			}
 		});
 	},
 

--- a/erpnext/manufacturing/doctype/bom_creator/bom_creator.json
+++ b/erpnext/manufacturing/doctype/bom_creator/bom_creator.json
@@ -37,6 +37,11 @@
   "items",
   "costing_detail",
   "raw_material_cost",
+  "configuration_section",
+  "track_operations",
+  "make_finished_good_against_job_card",
+  "column_break_obzr",
+  "final_operation",
   "remarks_tab",
   "remarks",
   "section_break_yixm",
@@ -278,6 +283,34 @@
    "fieldtype": "Text",
    "label": "Error Log",
    "read_only": 1
+  },
+  {
+   "fieldname": "configuration_section",
+   "fieldtype": "Section Break",
+   "label": "Operation"
+  },
+  {
+   "default": "0",
+   "depends_on": "track_operations",
+   "fieldname": "make_finished_good_against_job_card",
+   "fieldtype": "Check",
+   "label": "Make Finished Good Against Job Card"
+  },
+  {
+   "fieldname": "column_break_obzr",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "final_operation",
+   "fieldtype": "Link",
+   "label": "Final Operation",
+   "options": "Operation"
+  },
+  {
+   "default": "0",
+   "fieldname": "track_operations",
+   "fieldtype": "Check",
+   "label": "Track Operations"
   }
  ],
  "icon": "fa fa-sitemap",
@@ -288,7 +321,7 @@
    "link_fieldname": "bom_creator"
   }
  ],
- "modified": "2024-04-02 16:30:59.779190",
+ "modified": "2024-04-02 16:31:59.779190",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "BOM Creator",

--- a/erpnext/manufacturing/doctype/bom_creator/bom_creator.json
+++ b/erpnext/manufacturing/doctype/bom_creator/bom_creator.json
@@ -39,9 +39,21 @@
   "raw_material_cost",
   "configuration_section",
   "track_operations",
-  "make_finished_good_against_job_card",
   "column_break_obzr",
-  "final_operation",
+  "track_semi_finished_goods",
+  "final_product_operation_section",
+  "operation",
+  "operation_time",
+  "column_break_xnlu",
+  "workstation_type",
+  "workstation",
+  "final_product_warehouse_section",
+  "skip_material_transfer",
+  "backflush_from_wip_warehouse",
+  "source_warehouse",
+  "column_break_buha",
+  "wip_warehouse",
+  "fg_warehouse",
   "remarks_tab",
   "remarks",
   "section_break_yixm",
@@ -292,25 +304,95 @@
   {
    "default": "0",
    "depends_on": "track_operations",
-   "fieldname": "make_finished_good_against_job_card",
+   "fieldname": "track_semi_finished_goods",
    "fieldtype": "Check",
-   "label": "Make Finished Good Against Job Card"
+   "label": "Track Semi Finished Goods"
   },
   {
    "fieldname": "column_break_obzr",
    "fieldtype": "Column Break"
   },
   {
-   "fieldname": "final_operation",
-   "fieldtype": "Link",
-   "label": "Final Operation",
-   "options": "Operation"
-  },
-  {
    "default": "0",
    "fieldname": "track_operations",
    "fieldtype": "Check",
    "label": "Track Operations"
+  },
+  {
+   "depends_on": "eval:doc.track_semi_finished_goods === 1",
+   "fieldname": "final_product_operation_section",
+   "fieldtype": "Section Break",
+   "label": "Final Product Operation & Workstation"
+  },
+  {
+   "fieldname": "column_break_xnlu",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "operation",
+   "fieldtype": "Link",
+   "label": "Operation",
+   "options": "Operation"
+  },
+  {
+   "fieldname": "operation_time",
+   "fieldtype": "Float",
+   "label": "Operation Time (in mins)"
+  },
+  {
+   "fieldname": "workstation",
+   "fieldtype": "Link",
+   "label": "Workstation",
+   "options": "Workstation"
+  },
+  {
+   "fieldname": "workstation_type",
+   "fieldtype": "Link",
+   "label": "Workstation Type",
+   "options": "Workstation Type"
+  },
+  {
+   "depends_on": "eval:!doc.backflush_from_wip_warehouse",
+   "fieldname": "source_warehouse",
+   "fieldtype": "Link",
+   "label": "Source Warehouse",
+   "options": "Warehouse"
+  },
+  {
+   "depends_on": "eval:!doc.skip_material_transfer || doc.backflush_from_wip_warehouse",
+   "fieldname": "wip_warehouse",
+   "fieldtype": "Link",
+   "label": "Work In Progress Warehouse",
+   "options": "Warehouse"
+  },
+  {
+   "fieldname": "fg_warehouse",
+   "fieldtype": "Link",
+   "label": "Finished Good Warehouse",
+   "options": "Warehouse"
+  },
+  {
+   "depends_on": "eval:doc.track_semi_finished_goods === 1",
+   "fieldname": "final_product_warehouse_section",
+   "fieldtype": "Section Break",
+   "label": "Final Product Warehouse"
+  },
+  {
+   "default": "0",
+   "fieldname": "skip_material_transfer",
+   "fieldtype": "Check",
+   "label": "Skip Material Transfer"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.skip_material_transfer",
+   "fieldname": "backflush_from_wip_warehouse",
+   "fieldtype": "Check",
+   "label": "Backflush Materials From WIP Warehouse"
+  },
+  {
+   "fieldname": "column_break_buha",
+   "fieldtype": "Column Break"
   }
  ],
  "icon": "fa fa-sitemap",
@@ -321,7 +403,7 @@
    "link_fieldname": "bom_creator"
   }
  ],
- "modified": "2024-04-02 16:31:59.779190",
+ "modified": "2024-05-26 15:47:10.101420",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "BOM Creator",

--- a/erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
+++ b/erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
@@ -15,6 +15,11 @@
   "is_expandable",
   "sourced_by_supplier",
   "bom_created",
+  "operation_section",
+  "operation",
+  "column_break_cbnk",
+  "workstation_type",
+  "operation_time",
   "description_section",
   "description",
   "quantity_and_rate_section",
@@ -77,14 +82,15 @@
   {
    "fieldname": "source_warehouse",
    "fieldtype": "Link",
-   "in_list_view": 1,
    "label": "Source Warehouse",
    "options": "Warehouse"
   },
   {
+   "columns": 1,
    "default": "0",
    "fieldname": "is_expandable",
    "fieldtype": "Check",
+   "in_list_view": 1,
    "label": "Is Expandable",
    "read_only": 1
   },
@@ -225,12 +231,39 @@
    "label": "BOM Created",
    "no_copy": 1,
    "print_hide": 1
+  },
+  {
+   "fieldname": "operation_section",
+   "fieldtype": "Section Break",
+   "label": "Operation"
+  },
+  {
+   "fieldname": "operation",
+   "fieldtype": "Link",
+   "label": "Operation",
+   "options": "Operation"
+  },
+  {
+   "fieldname": "column_break_cbnk",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "workstation_type",
+   "fieldtype": "Link",
+   "label": "Workstation Type",
+   "options": "Workstation Type"
+  },
+  {
+   "description": "In Mins",
+   "fieldname": "operation_time",
+   "fieldtype": "Int",
+   "label": "Operation Time"
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:06:40.764747",
+ "modified": "2024-03-27 13:06:41.764747",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "BOM Creator Item",

--- a/erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
+++ b/erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.json
@@ -11,15 +11,23 @@
   "item_group",
   "column_break_f63f",
   "fg_item",
-  "source_warehouse",
   "is_expandable",
   "sourced_by_supplier",
   "bom_created",
+  "is_subcontracted",
   "operation_section",
   "operation",
+  "operation_time",
   "column_break_cbnk",
   "workstation_type",
-  "operation_time",
+  "workstation",
+  "warehouse_section",
+  "skip_material_transfer",
+  "backflush_from_wip_warehouse",
+  "source_warehouse",
+  "column_break_xutc",
+  "wip_warehouse",
+  "fg_warehouse",
   "description_section",
   "description",
   "quantity_and_rate_section",
@@ -80,6 +88,7 @@
    "reqd": 1
   },
   {
+   "depends_on": "eval:doc.skip_material_transfer && !doc.backflush_from_wip_warehouse",
    "fieldname": "source_warehouse",
    "fieldtype": "Link",
    "label": "Source Warehouse",
@@ -258,12 +267,60 @@
    "fieldname": "operation_time",
    "fieldtype": "Int",
    "label": "Operation Time"
+  },
+  {
+   "fieldname": "workstation",
+   "fieldtype": "Link",
+   "label": "Workstation",
+   "options": "Workstation"
+  },
+  {
+   "fieldname": "warehouse_section",
+   "fieldtype": "Section Break",
+   "label": "Warehouse"
+  },
+  {
+   "depends_on": "eval:!doc.skip_material_transfer || doc.backflush_from_wip_warehouse",
+   "fieldname": "wip_warehouse",
+   "fieldtype": "Link",
+   "label": "Work In Progress Warehouse",
+   "options": "Warehouse"
+  },
+  {
+   "fieldname": "column_break_xutc",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "fg_warehouse",
+   "fieldtype": "Link",
+   "label": "Finished Good Warehouse",
+   "options": "Warehouse"
+  },
+  {
+   "default": "0",
+   "fieldname": "skip_material_transfer",
+   "fieldtype": "Check",
+   "label": "Skip Material Transfer"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.skip_material_transfer",
+   "fieldname": "backflush_from_wip_warehouse",
+   "fieldtype": "Check",
+   "label": "Backflush Materials From WIP Warehouse"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_subcontracted",
+   "fieldtype": "Check",
+   "label": "Is Subcontracted",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:06:41.764747",
+ "modified": "2024-06-01 18:45:24.339532",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "BOM Creator Item",

--- a/erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.py
+++ b/erpnext/manufacturing/doctype/bom_creator_item/bom_creator_item.py
@@ -15,6 +15,7 @@ class BOMCreatorItem(Document):
 		from frappe.types import DF
 
 		amount: DF.Currency
+		backflush_from_wip_warehouse: DF.Check
 		base_amount: DF.Currency
 		base_rate: DF.Currency
 		bom_created: DF.Check
@@ -23,22 +24,30 @@ class BOMCreatorItem(Document):
 		do_not_explode: DF.Check
 		fg_item: DF.Link
 		fg_reference_id: DF.Data | None
+		fg_warehouse: DF.Link | None
 		instruction: DF.SmallText | None
 		is_expandable: DF.Check
+		is_subcontracted: DF.Check
 		item_code: DF.Link
 		item_group: DF.Link | None
 		item_name: DF.Data | None
+		operation: DF.Link | None
+		operation_time: DF.Int
 		parent: DF.Data
 		parent_row_no: DF.Data | None
 		parentfield: DF.Data
 		parenttype: DF.Data
 		qty: DF.Float
 		rate: DF.Currency
+		skip_material_transfer: DF.Check
 		source_warehouse: DF.Link | None
 		sourced_by_supplier: DF.Check
 		stock_qty: DF.Float
 		stock_uom: DF.Link | None
 		uom: DF.Link | None
+		wip_warehouse: DF.Link | None
+		workstation: DF.Link | None
+		workstation_type: DF.Link | None
 	# end: auto-generated types
 
 	pass

--- a/erpnext/manufacturing/doctype/bom_item/bom_item.json
+++ b/erpnext/manufacturing/doctype/bom_item/bom_item.json
@@ -9,6 +9,7 @@
   "item_code",
   "item_name",
   "operation",
+  "operation_row_id",
   "column_break_3",
   "do_not_explode",
   "bom_no",
@@ -293,13 +294,19 @@
    "fieldtype": "Check",
    "label": "Is Stock Item",
    "read_only": 1
+  },
+  {
+   "depends_on": "eval:parent.make_finished_good_against_job_card ==1",
+   "fieldname": "operation_row_id",
+   "fieldtype": "Int",
+   "label": "Operation Row ID"
   }
  ],
  "idx": 1,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:06:41.079752",
+ "modified": "2024-03-27 13:07:41.079752",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "BOM Item",

--- a/erpnext/manufacturing/doctype/bom_item/bom_item.json
+++ b/erpnext/manufacturing/doctype/bom_item/bom_item.json
@@ -296,17 +296,17 @@
    "read_only": 1
   },
   {
-   "depends_on": "eval:parent.make_finished_good_against_job_card ==1",
+   "depends_on": "eval:parent.track_semi_finished_goods ==1",
    "fieldname": "operation_row_id",
    "fieldtype": "Int",
-   "label": "Operation Row ID"
+   "label": "Operation ID"
   }
  ],
  "idx": 1,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:07:41.079752",
+ "modified": "2024-03-27 13:08:41.079752",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "BOM Item",

--- a/erpnext/manufacturing/doctype/bom_item/bom_item.py
+++ b/erpnext/manufacturing/doctype/bom_item/bom_item.py
@@ -25,9 +25,11 @@ class BOMItem(Document):
 		has_variants: DF.Check
 		image: DF.Attach | None
 		include_item_in_manufacturing: DF.Check
+		is_stock_item: DF.Check
 		item_code: DF.Link
 		item_name: DF.Data | None
 		operation: DF.Link | None
+		operation_row_id: DF.Int
 		original_item: DF.Link | None
 		parent: DF.Data
 		parentfield: DF.Data

--- a/erpnext/manufacturing/doctype/bom_operation/bom_operation.json
+++ b/erpnext/manufacturing/doctype/bom_operation/bom_operation.json
@@ -11,6 +11,7 @@
   "finished_good",
   "finished_good_qty",
   "bom_no",
+  "add_raw_materials",
   "col_break1",
   "workstation_type",
   "workstation",
@@ -20,9 +21,11 @@
   "is_final_finished_good",
   "set_cost_based_on_bom_qty",
   "warehouse_section",
+  "skip_material_transfer",
+  "backflush_from_wip_warehouse",
   "source_warehouse",
-  "wip_warehouse",
   "column_break_lbhy",
+  "wip_warehouse",
   "fg_warehouse",
   "costing_section",
   "hour_rate",
@@ -230,6 +233,7 @@
    "label": "Warehouse"
   },
   {
+   "depends_on": "eval:!doc.skip_material_transfer || doc.backflush_from_wip_warehouse",
    "fieldname": "wip_warehouse",
    "fieldtype": "Link",
    "label": "WIP WH",
@@ -249,6 +253,7 @@
   },
   {
    "columns": 1,
+   "depends_on": "eval:doc.skip_material_transfer && !doc.backflush_from_wip_warehouse",
    "fieldname": "source_warehouse",
    "fieldtype": "Link",
    "in_list_view": 1,
@@ -260,13 +265,32 @@
    "fieldname": "is_subcontracted",
    "fieldtype": "Check",
    "label": "Is Subcontracted"
+  },
+  {
+   "depends_on": "eval:!doc.bom_no",
+   "fieldname": "add_raw_materials",
+   "fieldtype": "Button",
+   "label": "Add Raw Materials"
+  },
+  {
+   "default": "0",
+   "fieldname": "skip_material_transfer",
+   "fieldtype": "Check",
+   "label": " Skip Material Transfer"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.skip_material_transfer",
+   "fieldname": "backflush_from_wip_warehouse",
+   "fieldtype": "Check",
+   "label": "Backflush Materials From WIP Warehouse"
   }
  ],
  "idx": 1,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:07:41.248462",
+ "modified": "2024-05-26 15:46:49.404875",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "BOM Operation",

--- a/erpnext/manufacturing/doctype/bom_operation/bom_operation.json
+++ b/erpnext/manufacturing/doctype/bom_operation/bom_operation.json
@@ -6,24 +6,33 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "sequence_id",
   "operation",
+  "sequence_id",
+  "finished_good",
+  "finished_good_qty",
+  "bom_no",
   "col_break1",
   "workstation_type",
   "workstation",
   "time_in_mins",
   "fixed_time",
+  "is_subcontracted",
+  "is_final_finished_good",
+  "set_cost_based_on_bom_qty",
+  "warehouse_section",
+  "source_warehouse",
+  "wip_warehouse",
+  "column_break_lbhy",
+  "fg_warehouse",
   "costing_section",
   "hour_rate",
   "base_hour_rate",
-  "column_break_9",
-  "operating_cost",
-  "base_operating_cost",
-  "column_break_11",
   "batch_size",
-  "set_cost_based_on_bom_qty",
+  "column_break_11",
   "cost_per_unit",
   "base_cost_per_unit",
+  "operating_cost",
+  "base_operating_cost",
   "more_information_section",
   "description",
   "column_break_18",
@@ -71,6 +80,7 @@
    "precision": "2"
   },
   {
+   "columns": 1,
    "description": "In minutes",
    "fetch_from": "operation.total_operation_time",
    "fetch_if_empty": 1,
@@ -87,7 +97,6 @@
    "description": "Operation time does not depend on quantity to produce",
    "fieldname": "fixed_time",
    "fieldtype": "Check",
-   "in_list_view": 1,
    "label": "Fixed Time"
   },
   {
@@ -173,28 +182,91 @@
    "fieldtype": "Column Break"
   },
   {
-   "fieldname": "column_break_9",
-   "fieldtype": "Column Break"
-  },
-  {
    "default": "0",
    "fieldname": "set_cost_based_on_bom_qty",
    "fieldtype": "Check",
    "label": "Set Operating Cost Based On BOM Quantity"
   },
   {
+   "columns": 1,
    "fieldname": "workstation_type",
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Workstation Type",
    "options": "Workstation Type"
+  },
+  {
+   "fieldname": "finished_good",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "FG / Semi FG Item",
+   "options": "Item"
+  },
+  {
+   "columns": 1,
+   "fieldname": "bom_no",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "BOM No",
+   "options": "BOM"
+  },
+  {
+   "columns": 1,
+   "default": "1",
+   "fieldname": "finished_good_qty",
+   "fieldtype": "Float",
+   "in_list_view": 1,
+   "label": "FG Qty"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_final_finished_good",
+   "fieldtype": "Check",
+   "label": "Is Final Finished Good"
+  },
+  {
+   "fieldname": "warehouse_section",
+   "fieldtype": "Section Break",
+   "label": "Warehouse"
+  },
+  {
+   "fieldname": "wip_warehouse",
+   "fieldtype": "Link",
+   "label": "WIP WH",
+   "options": "Warehouse"
+  },
+  {
+   "fieldname": "column_break_lbhy",
+   "fieldtype": "Column Break"
+  },
+  {
+   "columns": 1,
+   "fieldname": "fg_warehouse",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "FG WH",
+   "options": "Warehouse"
+  },
+  {
+   "columns": 1,
+   "fieldname": "source_warehouse",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Source WH",
+   "options": "Warehouse"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_subcontracted",
+   "fieldtype": "Check",
+   "label": "Is Subcontracted"
   }
  ],
  "idx": 1,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:06:41.248462",
+ "modified": "2024-03-27 13:07:41.248462",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "BOM Operation",

--- a/erpnext/manufacturing/doctype/bom_operation/bom_operation.py
+++ b/erpnext/manufacturing/doctype/bom_operation/bom_operation.py
@@ -14,15 +14,22 @@ class BOMOperation(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
+		backflush_from_wip_warehouse: DF.Check
 		base_cost_per_unit: DF.Float
 		base_hour_rate: DF.Currency
 		base_operating_cost: DF.Currency
 		batch_size: DF.Int
+		bom_no: DF.Link | None
 		cost_per_unit: DF.Float
 		description: DF.TextEditor | None
+		fg_warehouse: DF.Link | None
+		finished_good: DF.Link | None
+		finished_good_qty: DF.Float
 		fixed_time: DF.Check
 		hour_rate: DF.Currency
 		image: DF.Attach | None
+		is_final_finished_good: DF.Check
+		is_subcontracted: DF.Check
 		operating_cost: DF.Currency
 		operation: DF.Link
 		parent: DF.Data
@@ -30,7 +37,10 @@ class BOMOperation(Document):
 		parenttype: DF.Data
 		sequence_id: DF.Int
 		set_cost_based_on_bom_qty: DF.Check
+		skip_material_transfer: DF.Check
+		source_warehouse: DF.Link | None
 		time_in_mins: DF.Float
+		wip_warehouse: DF.Link | None
 		workstation: DF.Link | None
 		workstation_type: DF.Link | None
 	# end: auto-generated types

--- a/erpnext/manufacturing/doctype/job_card/job_card.json
+++ b/erpnext/manufacturing/doctype/job_card/job_card.json
@@ -8,43 +8,57 @@
  "field_order": [
   "naming_series",
   "work_order",
-  "bom_no",
-  "production_item",
   "employee",
+  "is_subcontracted",
   "column_break_4",
   "posting_date",
   "company",
-  "for_quantity",
+  "project",
+  "bom_no",
+  "semi_finished_good__finished_good_section",
+  "finished_good",
+  "production_item",
+  "semi_fg_bom",
   "total_completed_qty",
+  "column_break_mcnb",
+  "for_quantity",
+  "material_transferred_for_manufacturing",
+  "manufactured_qty",
   "process_loss_qty",
+  "production_section",
+  "operation",
+  "source_warehouse",
+  "wip_warehouse",
+  "skip_material_transfer",
+  "backflush_from_wip_warehouse",
+  "column_break_12",
+  "workstation_type",
+  "workstation",
+  "target_warehouse",
+  "section_break_8",
+  "items",
+  "quality_inspection_section",
+  "quality_inspection_template",
+  "column_break_fcmp",
+  "quality_inspection",
+  "scheduled_time_tab",
   "scheduled_time_section",
   "expected_start_date",
   "time_required",
   "column_break_jkir",
   "expected_end_date",
-  "section_break_05am",
+  "section_break_rzeo",
   "scheduled_time_logs",
   "timing_detail",
-  "time_logs",
   "section_break_13",
   "actual_start_date",
   "total_time_in_mins",
   "column_break_15",
   "actual_end_date",
-  "production_section",
-  "operation",
-  "wip_warehouse",
-  "column_break_12",
-  "workstation_type",
-  "workstation",
-  "quality_inspection_section",
-  "quality_inspection_template",
-  "column_break_fcmp",
-  "quality_inspection",
+  "section_break_jbas",
+  "time_logs",
   "section_break_21",
   "sub_operations",
-  "section_break_8",
-  "items",
   "scrap_items_section",
   "scrap_items",
   "corrective_operation_section",
@@ -54,11 +68,11 @@
   "hour_rate",
   "for_operation",
   "more_information",
-  "project",
   "item_name",
   "transferred_qty",
   "requested_qty",
   "status",
+  "operation_row_id",
   "column_break_20",
   "operation_row_number",
   "operation_id",
@@ -68,7 +82,6 @@
   "batch_no",
   "serial_no",
   "barcode",
-  "job_started",
   "started_time",
   "current_time",
   "amended_from",
@@ -86,10 +99,11 @@
    "search_index": 1
   },
   {
+   "depends_on": "eval:!doc.finished_good",
    "fetch_from": "work_order.bom_no",
    "fieldname": "bom_no",
    "fieldtype": "Link",
-   "label": "BOM No",
+   "label": "Final BOM",
    "options": "BOM",
    "read_only": 1
   },
@@ -136,16 +150,17 @@
    "fieldname": "wip_warehouse",
    "fieldtype": "Link",
    "label": "WIP Warehouse",
-   "options": "Warehouse",
-   "reqd": 1
+   "mandatory_depends_on": "eval:!doc.finished_good || doc.skip_material_transfer === 0 || (doc.skip_material_transfer && doc.backflush_from_wip_warehouse)",
+   "options": "Warehouse"
   },
   {
    "fieldname": "timing_detail",
-   "fieldtype": "Section Break",
+   "fieldtype": "Tab Break",
    "label": "Actual Time"
   },
   {
    "allow_bulk_edit": 1,
+   "allow_on_submit": 1,
    "fieldname": "time_logs",
    "fieldtype": "Table",
    "label": "Time Logs",
@@ -157,7 +172,9 @@
    "hide_border": 1
   },
   {
+   "allow_on_submit": 1,
    "default": "0",
+   "depends_on": "eval:doc.is_subcontracted===0",
    "fieldname": "total_completed_qty",
    "fieldtype": "Float",
    "label": "Total Completed Qty",
@@ -175,7 +192,7 @@
   },
   {
    "fieldname": "section_break_8",
-   "fieldtype": "Tab Break",
+   "fieldtype": "Section Break",
    "label": "Raw Materials"
   },
   {
@@ -227,6 +244,7 @@
    "fieldtype": "Column Break"
   },
   {
+   "allow_on_submit": 1,
    "default": "Open",
    "fieldname": "status",
    "fieldtype": "Select",
@@ -236,16 +254,7 @@
    "read_only": 1
   },
   {
-   "default": "0",
-   "fieldname": "job_started",
-   "fieldtype": "Check",
-   "hidden": 1,
-   "label": "Job Started",
-   "no_copy": 1,
-   "print_hide": 1,
-   "read_only": 1
-  },
-  {
+   "allow_on_submit": 1,
    "fieldname": "started_time",
    "fieldtype": "Datetime",
    "hidden": 1,
@@ -273,18 +282,19 @@
   },
   {
    "fieldname": "production_section",
-   "fieldtype": "Tab Break",
-   "label": "Operation & Workstation"
+   "fieldtype": "Section Break",
+   "label": "Operation & Materials"
   },
   {
    "fieldname": "column_break_12",
    "fieldtype": "Column Break"
   },
   {
+   "depends_on": "eval:!doc.finished_good",
    "fetch_from": "work_order.production_item",
    "fieldname": "production_item",
    "fieldtype": "Link",
-   "label": "Production Item",
+   "label": "Finished Good",
    "options": "Item",
    "read_only": 1
   },
@@ -302,6 +312,7 @@
    "label": "Item Name"
   },
   {
+   "allow_on_submit": 1,
    "fieldname": "current_time",
    "fieldtype": "Int",
    "hidden": 1,
@@ -384,6 +395,7 @@
    "options": "Operation"
   },
   {
+   "allow_on_submit": 1,
    "fieldname": "employee",
    "fieldtype": "Table MultiSelect",
    "label": "Employee",
@@ -463,6 +475,7 @@
    "show_dashboard": 1
   },
   {
+   "depends_on": "expected_start_date",
    "fieldname": "scheduled_time_section",
    "fieldtype": "Section Break",
    "label": "Scheduled Time"
@@ -475,10 +488,6 @@
    "fieldname": "time_required",
    "fieldtype": "Float",
    "label": "Expected Time Required (In Mins)"
-  },
-  {
-   "fieldname": "section_break_05am",
-   "fieldtype": "Section Break"
   },
   {
    "fieldname": "scheduled_time_logs",
@@ -507,11 +516,101 @@
   {
    "fieldname": "column_break_fcmp",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "finished_good",
+   "fieldtype": "Link",
+   "label": "Semi Finished Good",
+   "options": "Item",
+   "read_only": 1
+  },
+  {
+   "fieldname": "target_warehouse",
+   "fieldtype": "Link",
+   "label": "Target Warehouse",
+   "mandatory_depends_on": "eval:doc.finished_good",
+   "options": "Warehouse"
+  },
+  {
+   "fieldname": "operation_row_id",
+   "fieldtype": "Int",
+   "label": "Operation Row ID"
+  },
+  {
+   "depends_on": "eval:doc.is_subcontracted===0 && doc.finished_good",
+   "fieldname": "material_transferred_for_manufacturing",
+   "fieldtype": "Float",
+   "label": "Material Transferred for Manufacturing",
+   "no_copy": 1,
+   "read_only": 1
+  },
+  {
+   "fieldname": "source_warehouse",
+   "fieldtype": "Link",
+   "label": "Source Warehouse",
+   "options": "Warehouse"
+  },
+  {
+   "fieldname": "semi_finished_good__finished_good_section",
+   "fieldtype": "Section Break",
+   "label": "Semi Finished Good / Finished Good"
+  },
+  {
+   "fieldname": "semi_fg_bom",
+   "fieldtype": "Link",
+   "label": "Semi FG BOM",
+   "options": "BOM",
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "is_subcontracted",
+   "fieldtype": "Check",
+   "label": " Is Subcontracted",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_mcnb",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "section_break_rzeo",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "section_break_jbas",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "scheduled_time_tab",
+   "fieldtype": "Tab Break",
+   "label": "Scheduled Time"
+  },
+  {
+   "depends_on": "finished_good",
+   "fieldname": "manufactured_qty",
+   "fieldtype": "Float",
+   "label": "Manufactured Qty",
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.finished_good",
+   "fieldname": "skip_material_transfer",
+   "fieldtype": "Check",
+   "label": "Skip Material Transfer to WIP"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:doc.finished_good && doc.skip_material_transfer === 1",
+   "fieldname": "backflush_from_wip_warehouse",
+   "fieldtype": "Check",
+   "label": "Backflush Materials From WIP Warehouse"
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2024-03-27 13:09:56.634418",
+ "modified": "2024-03-27 13:10:56.634418",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Job Card",

--- a/erpnext/manufacturing/doctype/job_card/job_card.json
+++ b/erpnext/manufacturing/doctype/job_card/job_card.json
@@ -22,7 +22,7 @@
   "total_completed_qty",
   "column_break_mcnb",
   "for_quantity",
-  "material_transferred_for_manufacturing",
+  "transferred_qty",
   "manufactured_qty",
   "process_loss_qty",
   "production_section",
@@ -69,10 +69,10 @@
   "for_operation",
   "more_information",
   "item_name",
-  "transferred_qty",
   "requested_qty",
   "status",
   "operation_row_id",
+  "is_paused",
   "column_break_20",
   "operation_row_number",
   "operation_id",
@@ -119,6 +119,7 @@
    "fieldname": "operation",
    "fieldtype": "Link",
    "in_list_view": 1,
+   "in_preview": 1,
    "label": "Operation",
    "options": "Operation",
    "reqd": 1
@@ -144,6 +145,7 @@
    "fieldname": "for_quantity",
    "fieldtype": "Float",
    "in_list_view": 1,
+   "in_preview": 1,
    "label": "Qty To Manufacture"
   },
   {
@@ -177,6 +179,7 @@
    "depends_on": "eval:doc.is_subcontracted===0",
    "fieldname": "total_completed_qty",
    "fieldtype": "Float",
+   "in_preview": 1,
    "label": "Total Completed Qty",
    "read_only": 1
   },
@@ -216,9 +219,10 @@
   },
   {
    "default": "0",
+   "depends_on": "items",
    "fieldname": "transferred_qty",
    "fieldtype": "Float",
-   "label": "FG Qty from Transferred Raw Materials",
+   "label": "Transferred Raw Materials",
    "read_only": 1
   },
   {
@@ -294,7 +298,7 @@
    "fetch_from": "work_order.production_item",
    "fieldname": "production_item",
    "fieldtype": "Link",
-   "label": "Finished Good",
+   "label": "Final Product",
    "options": "Item",
    "read_only": 1
   },
@@ -520,7 +524,8 @@
   {
    "fieldname": "finished_good",
    "fieldtype": "Link",
-   "label": "Semi Finished Good",
+   "in_preview": 1,
+   "label": "Finished Good",
    "options": "Item",
    "read_only": 1
   },
@@ -535,14 +540,6 @@
    "fieldname": "operation_row_id",
    "fieldtype": "Int",
    "label": "Operation Row ID"
-  },
-  {
-   "depends_on": "eval:doc.is_subcontracted===0 && doc.finished_good",
-   "fieldname": "material_transferred_for_manufacturing",
-   "fieldtype": "Float",
-   "label": "Material Transferred for Manufacturing",
-   "no_copy": 1,
-   "read_only": 1
   },
   {
    "fieldname": "source_warehouse",
@@ -606,11 +603,18 @@
    "fieldname": "backflush_from_wip_warehouse",
    "fieldtype": "Check",
    "label": "Backflush Materials From WIP Warehouse"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_paused",
+   "fieldtype": "Check",
+   "label": "Is Paused",
+   "read_only": 1
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:56.634418",
+ "modified": "2024-05-26 17:44:18.324743",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Job Card",
@@ -663,6 +667,7 @@
    "write": 1
   }
  ],
+ "show_preview_popup": 1,
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/manufacturing/doctype/job_card/job_card_dashboard.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card_dashboard.py
@@ -7,6 +7,7 @@ def get_data():
 		"non_standard_fieldnames": {"Quality Inspection": "reference_name"},
 		"transactions": [
 			{"label": _("Transactions"), "items": ["Material Request", "Stock Entry"]},
+			{"label": _("Subcontracting"), "items": ["Purchase Order", "Subcontracting Order"]},
 			{"label": _("Reference"), "items": ["Quality Inspection"]},
 		],
 	}

--- a/erpnext/manufacturing/doctype/job_card_time_log/job_card_time_log.json
+++ b/erpnext/manufacturing/doctype/job_card_time_log/job_card_time_log.json
@@ -15,12 +15,14 @@
  ],
  "fields": [
   {
+   "allow_on_submit": 1,
    "fieldname": "from_time",
    "fieldtype": "Datetime",
    "in_list_view": 1,
    "label": "From Time"
   },
   {
+   "allow_on_submit": 1,
    "fieldname": "to_time",
    "fieldtype": "Datetime",
    "in_list_view": 1,
@@ -31,6 +33,7 @@
    "fieldtype": "Column Break"
   },
   {
+   "allow_on_submit": 1,
    "fieldname": "time_in_mins",
    "fieldtype": "Float",
    "in_list_view": 1,
@@ -38,6 +41,7 @@
    "read_only": 1
   },
   {
+   "allow_on_submit": 1,
    "default": "0",
    "fieldname": "completed_qty",
    "fieldtype": "Float",
@@ -63,7 +67,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-05-21 12:40:55.765860",
+ "modified": "2024-05-21 12:41:55.765860",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Job Card Time Log",

--- a/erpnext/manufacturing/doctype/operation/operation.json
+++ b/erpnext/manufacturing/doctype/operation/operation.json
@@ -40,6 +40,7 @@
   {
    "fieldname": "description",
    "fieldtype": "Text",
+   "in_preview": 1,
    "label": "Description"
   },
   {
@@ -104,7 +105,7 @@
  "icon": "fa fa-wrench",
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-03-27 13:10:06.841479",
+ "modified": "2024-05-26 17:59:44.338741",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Operation",
@@ -134,6 +135,7 @@
   }
  ],
  "quick_entry": 1,
+ "show_preview_popup": 1,
  "sort_field": "creation",
  "sort_order": "DESC",
  "states": [],

--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -143,9 +143,12 @@ frappe.ui.form.on("Work Order", {
 		}
 
 		if (frm.doc.status != "Closed") {
-			if (frm.doc.docstatus === 1 && frm.doc.status !== "Completed"
-				&& frm.doc.operations && frm.doc.operations.length) {
-
+			if (
+				frm.doc.docstatus === 1 &&
+				frm.doc.status !== "Completed" &&
+				frm.doc.operations &&
+				frm.doc.operations.length
+			) {
 				if (frm.doc.__onload?.show_create_job_card_button) {
 					frm.add_custom_button(__("Create Job Card"), () => {
 						frm.trigger("make_job_card");
@@ -268,6 +271,18 @@ frappe.ui.form.on("Work Order", {
 						label: __("Sequence Id"),
 						read_only: 1,
 					},
+					{
+						fieldtype: "Check",
+						fieldname: "skip_material_transfer",
+						label: __("Skip Material Transfer"),
+						read_only: 1,
+					},
+					{
+						fieldtype: "Check",
+						fieldname: "backflush_from_wip_warehouse",
+						label: __("Backflush Materials From WIP Warehouse"),
+						read_only: 1,
+					},
 				],
 				data: operations_data,
 				in_place_edit: true,
@@ -308,6 +323,8 @@ frappe.ui.form.on("Work Order", {
 						qty: pending_qty,
 						pending_qty: pending_qty,
 						sequence_id: data.sequence_id,
+						skip_material_transfer: data.skip_material_transfer,
+						backflush_from_wip_warehouse: data.backflush_from_wip_warehouse,
 					});
 				}
 			}
@@ -606,21 +623,21 @@ erpnext.work_order = {
 				);
 			}
 
-			if (!frm.doc.make_finished_good_against_job_card) {
-				const show_start_btn = (frm.doc.skip_transfer
-					|| frm.doc.transfer_material_against == "Job Card") ? 0 : 1;
+			if (!frm.doc.track_semi_finished_goods) {
+				const show_start_btn =
+					frm.doc.skip_transfer || frm.doc.transfer_material_against == "Job Card" ? 0 : 1;
 
 				if (show_start_btn) {
 					let pending_to_transfer = frm.doc.required_items.some(
-						item => flt(item.transferred_qty) < flt(item.required_qty)
+						(item) => flt(item.transferred_qty) < flt(item.required_qty)
 					);
 					if (pending_to_transfer && frm.doc.status != "Stopped") {
 						frm.has_start_btn = true;
-						frm.add_custom_button(__("Create Pick List"), function() {
+						frm.add_custom_button(__("Create Pick List"), function () {
 							erpnext.work_order.create_pick_list(frm);
 						});
 
-						var start_btn = frm.add_custom_button(__("Start"), function() {
+						var start_btn = frm.add_custom_button(__("Start"), function () {
 							erpnext.work_order.make_se(frm, "Material Transfer for Manufacture");
 						});
 						start_btn.addClass("btn-primary");

--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -143,19 +143,10 @@ frappe.ui.form.on("Work Order", {
 		}
 
 		if (frm.doc.status != "Closed") {
-			if (
-				frm.doc.docstatus === 1 &&
-				frm.doc.status !== "Completed" &&
-				frm.doc.operations &&
-				frm.doc.operations.length
-			) {
-				const not_completed = frm.doc.operations.filter((d) => {
-					if (d.status != "Completed") {
-						return true;
-					}
-				});
+			if (frm.doc.docstatus === 1 && frm.doc.status !== "Completed"
+				&& frm.doc.operations && frm.doc.operations.length) {
 
-				if (not_completed && not_completed.length) {
+				if (frm.doc.__onload?.show_create_job_card_button) {
 					frm.add_custom_button(__("Create Job Card"), () => {
 						frm.trigger("make_job_card");
 					}).addClass("btn-primary");
@@ -615,22 +606,25 @@ erpnext.work_order = {
 				);
 			}
 
-			const show_start_btn =
-				frm.doc.skip_transfer || frm.doc.transfer_material_against == "Job Card" ? 0 : 1;
+			if (!frm.doc.make_finished_good_against_job_card) {
+				const show_start_btn = (frm.doc.skip_transfer
+					|| frm.doc.transfer_material_against == "Job Card") ? 0 : 1;
 
-			if (show_start_btn) {
-				let pending_to_transfer = frm.doc.required_items.some(
-					(item) => flt(item.transferred_qty) < flt(item.required_qty)
-				);
-				if (pending_to_transfer && frm.doc.status != "Stopped") {
-					frm.has_start_btn = true;
-					frm.add_custom_button(__("Create Pick List"), function () {
-						erpnext.work_order.create_pick_list(frm);
-					});
-					var start_btn = frm.add_custom_button(__("Start"), function () {
-						erpnext.work_order.make_se(frm, "Material Transfer for Manufacture");
-					});
-					start_btn.addClass("btn-primary");
+				if (show_start_btn) {
+					let pending_to_transfer = frm.doc.required_items.some(
+						item => flt(item.transferred_qty) < flt(item.required_qty)
+					);
+					if (pending_to_transfer && frm.doc.status != "Stopped") {
+						frm.has_start_btn = true;
+						frm.add_custom_button(__("Create Pick List"), function() {
+							erpnext.work_order.create_pick_list(frm);
+						});
+
+						var start_btn = frm.add_custom_button(__("Start"), function() {
+							erpnext.work_order.make_se(frm, "Material Transfer for Manufacture");
+						});
+						start_btn.addClass("btn-primary");
+					}
 				}
 			}
 

--- a/erpnext/manufacturing/doctype/work_order/work_order.json
+++ b/erpnext/manufacturing/doctype/work_order/work_order.json
@@ -22,7 +22,7 @@
   "produced_qty",
   "process_loss_qty",
   "project",
-  "make_finished_good_against_job_card",
+  "track_semi_finished_goods",
   "warehouses",
   "source_warehouse",
   "wip_warehouse",
@@ -195,7 +195,7 @@
   },
   {
    "default": "0",
-   "depends_on": "eval:doc.docstatus==1 && doc.skip_transfer==0 && doc.make_finished_good_against_job_card === 0",
+   "depends_on": "eval:doc.docstatus==1 && doc.skip_transfer==0 && doc.track_semi_finished_goods === 0",
    "fieldname": "material_transferred_for_manufacturing",
    "fieldtype": "Float",
    "label": "Material Transferred for Manufacturing",
@@ -247,7 +247,7 @@
    "fieldname": "wip_warehouse",
    "fieldtype": "Link",
    "label": "Work-in-Progress Warehouse",
-   "mandatory_depends_on": "eval:(!doc.skip_transfer || doc.from_wip_warehouse) && !doc.make_finished_good_against_job_card",
+   "mandatory_depends_on": "eval:(!doc.skip_transfer || doc.from_wip_warehouse) && !doc.track_semi_finished_goods",
    "options": "Warehouse"
   },
   {
@@ -328,7 +328,7 @@
    "options": "fa fa-wrench"
   },
   {
-   "depends_on": "eval: doc.operations?.length && doc.make_finished_good_against_job_card === 0",
+   "depends_on": "eval: doc.operations?.length && doc.track_semi_finished_goods === 0",
    "fetch_from": "bom_no.transfer_material_against",
    "fetch_if_empty": 1,
    "fieldname": "transfer_material_against",
@@ -579,10 +579,10 @@
   },
   {
    "default": "0",
-   "fetch_from": "bom_no.make_finished_good_against_job_card",
-   "fieldname": "make_finished_good_against_job_card",
+   "fetch_from": "bom_no.track_semi_finished_goods",
+   "fieldname": "track_semi_finished_goods",
    "fieldtype": "Check",
-   "label": "Make Finished Good Against Job Card",
+   "label": "Track Semi Finished Goods",
    "read_only": 1
   }
  ],
@@ -591,7 +591,7 @@
  "image_field": "image",
  "is_submittable": 1,
  "links": [],
- "modified": "2024-03-27 13:12:00.129434",
+ "modified": "2024-03-27 13:13:00.129434",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Work Order",

--- a/erpnext/manufacturing/doctype/work_order/work_order.json
+++ b/erpnext/manufacturing/doctype/work_order/work_order.json
@@ -22,6 +22,16 @@
   "produced_qty",
   "process_loss_qty",
   "project",
+  "make_finished_good_against_job_card",
+  "warehouses",
+  "source_warehouse",
+  "wip_warehouse",
+  "column_break_12",
+  "fg_warehouse",
+  "scrap_warehouse",
+  "operations_section",
+  "transfer_material_against",
+  "operations",
   "section_break_ndpq",
   "required_items",
   "work_order_configuration",
@@ -32,22 +42,11 @@
   "skip_transfer",
   "from_wip_warehouse",
   "update_consumed_material_cost_in_project",
-  "warehouses",
-  "source_warehouse",
-  "wip_warehouse",
-  "column_break_12",
-  "fg_warehouse",
-  "scrap_warehouse",
   "serial_no_and_batch_for_finished_good_section",
   "has_serial_no",
   "has_batch_no",
   "column_break_18",
   "batch_size",
-  "required_items_section",
-  "materials_and_operations_tab",
-  "operations_section",
-  "transfer_material_against",
-  "operations",
   "time",
   "planned_start_date",
   "planned_end_date",
@@ -196,7 +195,7 @@
   },
   {
    "default": "0",
-   "depends_on": "eval:doc.docstatus==1 && doc.skip_transfer==0",
+   "depends_on": "eval:doc.docstatus==1 && doc.skip_transfer==0 && doc.make_finished_good_against_job_card === 0",
    "fieldname": "material_transferred_for_manufacturing",
    "fieldtype": "Float",
    "label": "Material Transferred for Manufacturing",
@@ -248,7 +247,7 @@
    "fieldname": "wip_warehouse",
    "fieldtype": "Link",
    "label": "Work-in-Progress Warehouse",
-   "mandatory_depends_on": "eval:!doc.skip_transfer || doc.from_wip_warehouse",
+   "mandatory_depends_on": "eval:(!doc.skip_transfer || doc.from_wip_warehouse) && !doc.make_finished_good_against_job_card",
    "options": "Warehouse"
   },
   {
@@ -256,8 +255,7 @@
    "fieldname": "fg_warehouse",
    "fieldtype": "Link",
    "label": "Target Warehouse",
-   "options": "Warehouse",
-   "reqd": 1
+   "options": "Warehouse"
   },
   {
    "fieldname": "column_break_12",
@@ -271,14 +269,8 @@
    "options": "Warehouse"
   },
   {
-   "fieldname": "required_items_section",
-   "fieldtype": "Section Break",
-   "label": "Required Items"
-  },
-  {
    "fieldname": "required_items",
    "fieldtype": "Table",
-   "label": "Required Items",
    "no_copy": 1,
    "options": "Work Order Item",
    "print_hide": 1
@@ -336,7 +328,7 @@
    "options": "fa fa-wrench"
   },
   {
-   "depends_on": "operations",
+   "depends_on": "eval: doc.operations?.length && doc.make_finished_good_against_job_card === 0",
    "fetch_from": "bom_no.transfer_material_against",
    "fetch_if_empty": 1,
    "fieldname": "transfer_material_against",
@@ -579,13 +571,19 @@
    "label": "Configuration"
   },
   {
-   "fieldname": "materials_and_operations_tab",
-   "fieldtype": "Tab Break",
-   "label": "Operations"
+   "collapsible": 1,
+   "collapsible_depends_on": "eval:!doc.operations?.length",
+   "fieldname": "section_break_ndpq",
+   "fieldtype": "Section Break",
+   "label": "Required Items"
   },
   {
-   "fieldname": "section_break_ndpq",
-   "fieldtype": "Section Break"
+   "default": "0",
+   "fetch_from": "bom_no.make_finished_good_against_job_card",
+   "fieldname": "make_finished_good_against_job_card",
+   "fieldtype": "Check",
+   "label": "Make Finished Good Against Job Card",
+   "read_only": 1
   }
  ],
  "icon": "fa fa-cogs",
@@ -593,7 +591,7 @@
  "image_field": "image",
  "is_submittable": 1,
  "links": [],
- "modified": "2024-03-27 13:11:00.129434",
+ "modified": "2024-03-27 13:12:00.129434",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Work Order",

--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -143,6 +143,24 @@ class WorkOrder(Document):
 		self.set_onload("material_consumption", ms.material_consumption)
 		self.set_onload("backflush_raw_materials_based_on", ms.backflush_raw_materials_based_on)
 		self.set_onload("overproduction_percentage", ms.overproduction_percentage_for_work_order)
+		self.set_onload("show_create_job_card_button", self.show_create_job_card_button())
+
+	def show_create_job_card_button(self):
+		operation_details = frappe._dict(
+			frappe.get_all(
+				"Job Card",
+				fields=["operation", "for_quantity"],
+				filters={"docstatus": ("<", 2), "work_order": self.name},
+				as_list=1,
+			)
+		)
+
+		for d in self.operations:
+			job_card_qty = self.qty - flt(operation_details.get(d.operation))
+			if job_card_qty > 0:
+				return True
+
+		return False
 
 	def validate(self):
 		self.validate_production_item()
@@ -422,15 +440,20 @@ class WorkOrder(Document):
 		self.update_status()
 		production_plan.run_method("update_produced_pending_qty", produced_qty, self.production_plan_item)
 
-	def before_submit(self):
-		self.create_serial_no_batch_no()
+	def validate_warehouse(self):
+		if self.make_finished_good_against_job_card:
+			return
 
-	def on_submit(self):
 		if not self.wip_warehouse and not self.skip_transfer:
 			frappe.throw(_("Work-in-Progress Warehouse is required before Submit"))
 		if not self.fg_warehouse:
 			frappe.throw(_("For Warehouse is required before Submit"))
 
+	def before_submit(self):
+		self.create_serial_no_batch_no()
+
+	def on_submit(self):
+		self.validate_warehouse()
 		if self.production_plan and frappe.db.exists(
 			"Production Plan Item Reference", {"parent": self.production_plan}
 		):
@@ -667,6 +690,9 @@ class WorkOrder(Document):
 			)
 
 	def update_planned_qty(self):
+		if self.make_finished_good_against_job_card:
+			return
+
 		from erpnext.manufacturing.doctype.production_plan.production_plan import (
 			get_reserved_qty_for_sub_assembly,
 		)
@@ -811,10 +837,16 @@ class WorkOrder(Document):
 					"description",
 					"workstation",
 					"idx",
+					"finished_good",
+					"is_subcontracted",
+					"wip_warehouse",
+					"source_warehouse",
+					"fg_warehouse",
 					"workstation_type",
 					"base_hour_rate as hour_rate",
 					"time_in_mins",
 					"parent as bom",
+					"bom_no",
 					"batch_size",
 					"sequence_id",
 					"fixed_time",
@@ -1084,6 +1116,7 @@ class WorkOrder(Document):
 							"required_qty": item.qty,
 							"source_warehouse": item.source_warehouse or item.default_warehouse,
 							"include_item_in_manufacturing": item.include_item_in_manufacturing,
+							"operation_row_id": item.operation_row_id,
 						},
 					)
 
@@ -1284,6 +1317,9 @@ def make_work_order(bom_no, item, qty=0, project=None, variant_items=None):
 	item_details = get_item_details(item, project)
 
 	wo_doc = frappe.new_doc("Work Order")
+	wo_doc.make_finished_good_against_job_card = frappe.db.get_value(
+		"BOM", bom_no, "make_finished_good_against_job_card"
+	)
 	wo_doc.production_item = item
 	wo_doc.update(item_details)
 	wo_doc.bom_no = bom_no
@@ -1450,12 +1486,29 @@ def make_job_card(work_order, operations):
 	work_order = frappe.get_doc("Work Order", work_order)
 	for row in operations:
 		row = frappe._dict(row)
+		row.update(get_operation_details(row.name, work_order))
+
 		validate_operation_data(row)
 		qty = row.get("qty")
 		while qty > 0:
 			qty = split_qty_based_on_batch_size(work_order, row, qty)
 			if row.job_card_qty > 0:
 				create_job_card(work_order, row, auto_create=True)
+
+
+def get_operation_details(name, work_order):
+	for row in work_order.operations:
+		if row.name == name:
+			return {
+				"workstation": row.workstation,
+				"workstation_type": row.workstation_type,
+				"source_warehouse": row.source_warehouse,
+				"fg_warehouse": row.fg_warehouse,
+				"wip_warehouse": row.wip_warehouse,
+				"finished_good": row.finished_good,
+				"bom_no": row.get("bom_no"),
+				"is_subcontracted": row.get("is_subcontracted"),
+			}
 
 
 @frappe.whitelist()
@@ -1558,6 +1611,7 @@ def create_job_card(work_order, row, enable_capacity_planning=False, auto_create
 			"workstation_type": row.get("workstation_type"),
 			"operation": row.get("operation"),
 			"workstation": row.get("workstation"),
+			"operation_row_id": cint(row.idx),
 			"posting_date": nowdate(),
 			"for_quantity": row.job_card_qty or work_order.get("qty", 0),
 			"operation_id": row.get("name"),
@@ -1565,13 +1619,20 @@ def create_job_card(work_order, row, enable_capacity_planning=False, auto_create
 			"project": work_order.project,
 			"company": work_order.company,
 			"sequence_id": row.get("sequence_id"),
-			"wip_warehouse": work_order.wip_warehouse,
 			"hour_rate": row.get("hour_rate"),
 			"serial_no": row.get("serial_no"),
+			"source_warehouse": row.get("source_warehouse"),
+			"target_warehouse": row.get("fg_warehouse"),
+			"wip_warehouse": work_order.wip_warehouse or row.get("wip_warehouse"),
+			"finished_good": row.get("finished_good"),
+			"semi_fg_bom": row.get("bom_no"),
+			"is_subcontracted": row.get("is_subcontracted"),
 		}
 	)
 
-	if work_order.transfer_material_against == "Job Card" and not work_order.skip_transfer:
+	if work_order.make_finished_good_against_job_card or (
+		work_order.transfer_material_against == "Job Card" and not work_order.skip_transfer
+	):
 		doc.get_required_items()
 
 	if auto_create:

--- a/erpnext/manufacturing/doctype/work_order_item/work_order_item.json
+++ b/erpnext/manufacturing/doctype/work_order_item/work_order_item.json
@@ -8,6 +8,7 @@
   "operation",
   "item_code",
   "source_warehouse",
+  "operation_row_id",
   "column_break_3",
   "item_name",
   "description",
@@ -138,11 +139,17 @@
    "in_list_view": 1,
    "label": "Returned Qty ",
    "read_only": 1
+  },
+  {
+   "fieldname": "operation_row_id",
+   "fieldtype": "Int",
+   "label": "Operation Row Id",
+   "read_only": 1
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:11:00.429838",
+ "modified": "2024-03-27 13:12:00.429838",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Work Order Item",

--- a/erpnext/manufacturing/doctype/work_order_operation/work_order_operation.json
+++ b/erpnext/manufacturing/doctype/work_order_operation/work_order_operation.json
@@ -15,6 +15,14 @@
   "workstation_type",
   "workstation",
   "sequence_id",
+  "section_break_insy",
+  "bom_no",
+  "finished_good",
+  "is_subcontracted",
+  "column_break_vjih",
+  "source_warehouse",
+  "wip_warehouse",
+  "fg_warehouse",
   "section_break_10",
   "description",
   "estimated_time_and_cost",
@@ -52,7 +60,6 @@
    "columns": 2,
    "fieldname": "bom",
    "fieldtype": "Link",
-   "in_list_view": 1,
    "label": "BOM",
    "no_copy": 1,
    "options": "BOM",
@@ -66,11 +73,10 @@
    "oldfieldtype": "Text"
   },
   {
-   "columns": 2,
+   "columns": 1,
    "description": "Operation completed for how many finished goods?",
    "fieldname": "completed_qty",
    "fieldtype": "Float",
-   "in_list_view": 1,
    "label": "Completed Qty",
    "no_copy": 1
   },
@@ -213,16 +219,69 @@
    "columns": 2,
    "fieldname": "process_loss_qty",
    "fieldtype": "Float",
-   "in_list_view": 1,
    "label": "Process Loss Qty",
    "no_copy": 1,
+   "read_only": 1
+  },
+  {
+   "depends_on": "eval:parent.make_finished_good_against_job_card === 1",
+   "fieldname": "section_break_insy",
+   "fieldtype": "Section Break"
+  },
+  {
+   "fieldname": "bom_no",
+   "fieldtype": "Link",
+   "label": "BOM No (For Semi-FG)",
+   "options": "BOM",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_vjih",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "finished_good",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Semi FG / FG",
+   "options": "Item",
+   "read_only": 1
+  },
+  {
+   "columns": 1,
+   "fieldname": "wip_warehouse",
+   "fieldtype": "Link",
+   "label": "WIP WH",
+   "options": "Warehouse"
+  },
+  {
+   "columns": 2,
+   "fieldname": "fg_warehouse",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "FG Warehouse",
+   "options": "Warehouse"
+  },
+  {
+   "columns": 2,
+   "fieldname": "source_warehouse",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Source Warehouse",
+   "options": "Warehouse"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_subcontracted",
+   "fieldtype": "Check",
+   "label": "Is Subcontracted",
    "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:11:00.595376",
+ "modified": "2024-03-27 13:12:00.595376",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Work Order Operation",

--- a/erpnext/manufacturing/doctype/work_order_operation/work_order_operation.json
+++ b/erpnext/manufacturing/doctype/work_order_operation/work_order_operation.json
@@ -19,6 +19,8 @@
   "bom_no",
   "finished_good",
   "is_subcontracted",
+  "skip_material_transfer",
+  "backflush_from_wip_warehouse",
   "column_break_vjih",
   "source_warehouse",
   "wip_warehouse",
@@ -224,7 +226,7 @@
    "read_only": 1
   },
   {
-   "depends_on": "eval:parent.make_finished_good_against_job_card === 1",
+   "depends_on": "eval:parent.track_semi_finished_goods === 1",
    "fieldname": "section_break_insy",
    "fieldtype": "Section Break"
   },
@@ -276,12 +278,26 @@
    "fieldtype": "Check",
    "label": "Is Subcontracted",
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "skip_material_transfer",
+   "fieldtype": "Check",
+   "label": "Skip Material Transfer",
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "fieldname": "backflush_from_wip_warehouse",
+   "fieldtype": "Check",
+   "label": "Backflush Materials From WIP Warehouse",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:12:00.595376",
+ "modified": "2024-05-26 15:57:17.958543",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Work Order Operation",

--- a/erpnext/manufacturing/doctype/work_order_operation/work_order_operation.py
+++ b/erpnext/manufacturing/doctype/work_order_operation/work_order_operation.py
@@ -18,11 +18,16 @@ class WorkOrderOperation(Document):
 		actual_operating_cost: DF.Currency
 		actual_operation_time: DF.Float
 		actual_start_time: DF.Datetime | None
+		backflush_from_wip_warehouse: DF.Check
 		batch_size: DF.Float
 		bom: DF.Link | None
+		bom_no: DF.Link | None
 		completed_qty: DF.Float
 		description: DF.TextEditor | None
+		fg_warehouse: DF.Link | None
+		finished_good: DF.Link | None
 		hour_rate: DF.Float
+		is_subcontracted: DF.Check
 		operation: DF.Link
 		parent: DF.Data
 		parentfield: DF.Data
@@ -32,8 +37,11 @@ class WorkOrderOperation(Document):
 		planned_start_time: DF.Datetime | None
 		process_loss_qty: DF.Float
 		sequence_id: DF.Int
+		skip_material_transfer: DF.Check
+		source_warehouse: DF.Link | None
 		status: DF.Literal["Pending", "Work in Progress", "Completed"]
 		time_in_mins: DF.Float
+		wip_warehouse: DF.Link | None
 		workstation: DF.Link | None
 		workstation_type: DF.Link | None
 	# end: auto-generated types

--- a/erpnext/manufacturing/doctype/workstation/workstation.js
+++ b/erpnext/manufacturing/doctype/workstation/workstation.js
@@ -105,14 +105,116 @@ class WorkstationDashboard {
 	}
 
 	render_job_cards() {
-		let template = frappe.render_template("workstation_job_card", {
+		this.template = frappe.render_template("workstation_job_card", {
 			data: this.job_cards,
 		});
 
-		this.$wrapper.html(template);
+		this.timer_job_cards = {};
+		this.$wrapper.html(this.template);
+		this.setup_qrcode_fields();
 		this.prepare_timer();
+		this.setup_menu_actions();
 		this.toggle_job_card();
 		this.bind_events();
+	}
+
+	setup_qrcode_fields() {
+		this.start_job_qrcode = frappe.ui.form.make_control({
+			df: {
+				label: __("Start Job"),
+				fieldtype: "Data",
+				options: "Barcode",
+				placeholder: __("Scan Job Card Qrcode"),
+			},
+			parent: this.$wrapper.find(".qrcode-fields"),
+			render_input: true,
+		});
+
+		this.start_job_qrcode.$wrapper.addClass("form-column col-sm-6");
+
+		this.start_job_qrcode.$input.on("input", (e) => {
+			clearTimeout(this.start_job_qrcode_search);
+			this.start_job_qrcode_search = setTimeout(() => {
+				let job_card = this.start_job_qrcode.get_value();
+				if (job_card) {
+					this.validate_job_card(job_card, "Open", (job_card, qty) => {
+						this.start_job(job_card);
+					});
+
+					this.start_job_qrcode.set_value("");
+				}
+			}, 300);
+		});
+
+		this.complete_job_qrcode = frappe.ui.form.make_control({
+			df: {
+				label: __("Complete Job"),
+				fieldtype: "Data",
+				options: "Barcode",
+				placeholder: __("Scan Job Card Qrcode"),
+			},
+			parent: this.$wrapper.find(".qrcode-fields"),
+			render_input: true,
+		});
+
+		this.complete_job_qrcode.$input.on("input", (e) => {
+			clearTimeout(this.complete_job_qrcode_search);
+			this.complete_job_qrcode_search = setTimeout(() => {
+				let job_card = this.complete_job_qrcode.get_value();
+				if (job_card) {
+					this.validate_job_card(job_card, "Work In Progress", (job_card, qty) => {
+						this.complete_job(job_card, qty);
+					});
+
+					this.complete_job_qrcode.set_value("");
+				}
+			}, 300);
+		});
+
+		this.complete_job_qrcode.$wrapper.addClass("form-column col-sm-6");
+	}
+
+	validate_job_card(job_card, status, callback) {
+		frappe.call({
+			method: "erpnext.manufacturing.doctype.workstation.workstation.validate_job_card",
+			args: {
+				job_card: job_card,
+				status: status,
+			},
+			callback(r) {
+				callback(job_card, r.message);
+			},
+		});
+	}
+
+	setup_menu_actions() {
+		let me = this;
+		this.job_cards.forEach((data) => {
+			me.menu_actions = me.$wrapper.find(`.menu-actions[data-job-card='${data.name}']`);
+			$(me.menu_actions).find(".btn-start").hide();
+			$(me.menu_actions).find(".btn-resume").hide();
+			$(me.menu_actions).find(".btn-pause").hide();
+			$(me.menu_actions).find(".btn-complete").hide();
+
+			if (
+				data.for_quantity + data.process_loss_qty > data.total_completed_qty &&
+				(data.skip_material_transfer ||
+					data.transferred_qty >= data.for_quantity + data.process_loss_qty ||
+					!data.finished_good)
+			) {
+				if (!data.time_logs?.length) {
+					$(me.menu_actions).find(".btn-start").show();
+				} else if (data.is_paused) {
+					$(me.menu_actions).find(".btn-resume").show();
+				} else if (data.for_quantity - data.manufactured_qty > 0) {
+					if (!data.is_paused) {
+						$(me.menu_actions).find(".btn-pause").show();
+					}
+
+					$(me.menu_actions).find(".btn-complete").show();
+				}
+			}
+		});
 	}
 
 	toggle_job_card() {
@@ -133,106 +235,75 @@ class WorkstationDashboard {
 	}
 
 	bind_events() {
-		this.$wrapper.find(".make-material-request").on("click", (e) => {
-			let job_card = $(e.currentTarget).attr("job-card");
+		let me = this;
+
+		this.$wrapper.find(".btn-transfer-materials").on("click", (e) => {
+			let job_card = $(e.currentTarget).closest("ul").attr("data-job-card");
 			this.make_material_request(job_card);
 		});
 
 		this.$wrapper.find(".btn-start").on("click", (e) => {
-			let job_card = $(e.currentTarget).attr("job-card");
+			let job_card = $(e.currentTarget).closest("ul").attr("data-job-card");
 			this.start_job(job_card);
 		});
 
+		this.$wrapper.find(".btn-pause").on("click", (e) => {
+			let job_card = $(e.currentTarget).closest("ul").attr("data-job-card");
+			me.update_job_card(job_card, "pause_job", {
+				end_time: frappe.datetime.now_datetime(),
+			});
+		});
+
+		this.$wrapper.find(".btn-resume").on("click", (e) => {
+			let job_card = $(e.currentTarget).closest("ul").attr("data-job-card");
+			me.update_job_card(job_card, "resume_job", {
+				start_time: frappe.datetime.now_datetime(),
+			});
+		});
+
 		this.$wrapper.find(".btn-complete").on("click", (e) => {
-			let job_card = $(e.currentTarget).attr("job-card");
-			let pending_qty = flt($(e.currentTarget).attr("pending-qty"));
-			this.complete_job(job_card, pending_qty);
+			let job_card = $(e.currentTarget).closest("ul").attr("data-job-card");
+			let for_quantity = $(e.currentTarget).attr("data-qty");
+			me.complete_job(job_card, for_quantity);
 		});
 	}
 
 	start_job(job_card) {
 		let me = this;
-		frappe.prompt(
-			[
-				{
-					fieldtype: "Datetime",
-					label: __("Start Time"),
-					fieldname: "start_time",
-					reqd: 1,
-					default: frappe.datetime.now_datetime(),
-				},
-				{
-					label: __("Operator"),
-					fieldname: "employee",
-					fieldtype: "Link",
-					options: "Employee",
-				},
-			],
-			(data) => {
-				this.frm.call({
-					method: "start_job",
-					doc: this.frm.doc,
-					args: {
-						job_card: job_card,
-						from_time: data.start_time,
-						employee: data.employee,
-					},
-					callback(r) {
-						if (r.message) {
-							me.job_cards = [r.message];
-							me.prepare_timer();
-							me.update_job_card_details();
-							me.frm.reload_doc();
-						}
-					},
-				});
-			},
-			__("Enter Value"),
-			__("Start Job")
-		);
+
+		let fields = this.get_fields_for_employee();
+
+		this.employee_dialog = frappe.prompt(fields, (values) => {
+			me.update_job_card(job_card, "start_timer", values);
+		});
+
+		let default_employee = this.job_cards[0]?.user_employee;
+		if (default_employee) {
+			this.employee_dialog.fields_dict.employees.df.data.push({
+				employee: default_employee,
+			});
+			this.employee_dialog.fields_dict.employees.grid.refresh();
+		}
 	}
 
-	complete_job(job_card, qty_to_manufacture) {
-		let me = this;
-		let fields = [
-			{
-				fieldtype: "Float",
-				label: __("Completed Quantity"),
-				fieldname: "qty",
-				reqd: 1,
-				default: flt(qty_to_manufacture || 0),
-			},
-			{
-				fieldtype: "Datetime",
-				label: __("End Time"),
-				fieldname: "end_time",
-				default: frappe.datetime.now_datetime(),
-			},
-		];
-
+	complete_job(job_card, for_quantity) {
 		frappe.prompt(
-			fields,
+			{
+				fieldname: "qty",
+				label: __("Completed Quantity"),
+				fieldtype: "Float",
+				reqd: 1,
+				default: flt(for_quantity || 0),
+			},
 			(data) => {
-				if (data.qty <= 0) {
+				if (flt(data.qty) <= 0) {
 					frappe.throw(__("Quantity should be greater than 0"));
 				}
 
-				this.frm.call({
-					method: "complete_job",
-					doc: this.frm.doc,
-					args: {
-						job_card: job_card,
-						qty: data.qty,
-						to_time: data.end_time,
-					},
-					callback: function (r) {
-						if (r.message) {
-							me.job_cards = [r.message];
-							me.prepare_timer();
-							me.update_job_card_details();
-							me.frm.reload_doc();
-						}
-					},
+				this.update_job_card(job_card, "complete_job_card", {
+					qty: flt(data.qty),
+					end_time: frappe.datetime.now_datetime(),
+					auto_submit: 1,
 				});
 			},
 			__("Enter Value"),
@@ -240,26 +311,219 @@ class WorkstationDashboard {
 		);
 	}
 
-	make_material_request(job_card) {
+	get_fields_for_employee() {
+		let me = this;
+
+		return [
+			{
+				label: __("Employee"),
+				fieldname: "employee",
+				fieldtype: "Link",
+				options: "Employee",
+				change() {
+					let employee = this.get_value();
+					let employees = me.employee_dialog.fields_dict.employees.df.data;
+
+					if (employee) {
+						let employee_exists = employees.find((d) => d.employee === employee);
+
+						if (!employee_exists) {
+							me.employee_dialog.fields_dict.employees.df.data.push({
+								employee: employee,
+							});
+
+							me.employee_dialog.fields_dict.employees.grid.refresh();
+						}
+					}
+				},
+			},
+			{
+				label: __("Start Time"),
+				fieldname: "start_time",
+				fieldtype: "Datetime",
+				default: frappe.datetime.now_datetime(),
+			},
+			{ fieldtype: "Section Break" },
+			{
+				label: __("Employees"),
+				fieldname: "employees",
+				fieldtype: "Table",
+				data: [],
+				cannot_add_rows: 1,
+				cannot_delete_rows: 1,
+				fields: [
+					{
+						label: __("Employee"),
+						fieldname: "employee",
+						fieldtype: "Link",
+						options: "Employee",
+						in_list_view: 1,
+					},
+				],
+			},
+		];
+	}
+
+	update_job_card(job_card, method, data) {
+		let me = this;
+
 		frappe.call({
-			method: "erpnext.manufacturing.doctype.job_card.job_card.make_material_request",
+			method: "erpnext.manufacturing.doctype.workstation.workstation.update_job_card",
 			args: {
-				source_name: job_card,
+				job_card: job_card,
+				method: method,
+				start_time: data.start_time || "",
+				employees: data.employees || [],
+				end_time: data.end_time || "",
+				qty: data.qty || 0,
+				auto_submit: data.auto_submit || 0,
+			},
+			callback: () => {
+				$.each(me.timer_job_cards, (index, value) => {
+					clearInterval(value);
+				});
+
+				me.frm.reload_doc();
+			},
+		});
+	}
+
+	make_material_request(job_card) {
+		let me = this;
+		frappe.call({
+			method: "erpnext.manufacturing.doctype.workstation.workstation.get_raw_materials",
+			args: {
+				job_card: job_card,
 			},
 			callback: (r) => {
 				if (r.message) {
-					var doc = frappe.model.sync(r.message)[0];
-					frappe.set_route("Form", doc.doctype, doc.name);
+					me.prepare_materials_modal(r.message, job_card, (job_card) => {
+						frappe.call({
+							method: "erpnext.manufacturing.doctype.job_card.job_card.make_stock_entry",
+							args: {
+								source_name: job_card,
+							},
+							callback: (r) => {
+								var doc = frappe.model.sync(r.message);
+								frappe.set_route("Form", doc[0].doctype, doc[0].name);
+							},
+						});
+					});
 				}
 			},
 		});
+	}
+
+	prepare_materials_modal(raw_materials, job_card, callback) {
+		let fields = this.get_raw_material_fields(raw_materials);
+
+		this.materials_dialog = new frappe.ui.Dialog({
+			title: "Raw Materials",
+			fields: fields,
+			size: "large",
+			primary_action_label: __("Make Transfer Entry"),
+			primary_action: () => {
+				this.materials_dialog.hide();
+				callback(job_card);
+			},
+		});
+
+		raw_materials.forEach((row) => {
+			this.materials_dialog.fields_dict.items.df.data.push(row);
+		});
+
+		this.materials_dialog.fields_dict.items.grid.refresh();
+		this.materials_dialog.show();
+	}
+
+	get_raw_material_fields(raw_materials) {
+		return [
+			{
+				label: __("Warehouse"),
+				fieldname: "warehouse",
+				fieldtype: "Link",
+				options: "Warehouse",
+				read_only: 1,
+				default: raw_materials[0].warehouse,
+			},
+			{ fieldtype: "Column Break" },
+			{
+				label: __("Skip Material Transfer"),
+				fieldname: "skip_material_transfer",
+				fieldtype: "Check",
+				read_only: 1,
+				default: raw_materials[0].skip_material_transfer,
+			},
+			{ fieldtype: "Section Break" },
+			{
+				label: __("Raw Materials"),
+				fieldname: "items",
+				fieldtype: "Table",
+				cannot_add_rows: 1,
+				cannot_delete_rows: 1,
+				data: [],
+				size: "extra-large",
+				fields: [
+					{
+						label: __("Item Code"),
+						fieldname: "item_code",
+						fieldtype: "Link",
+						options: "Item",
+						in_list_view: 1,
+						read_only: 1,
+						columns: 2,
+					},
+					{
+						label: __("UOM"),
+						fieldname: "uom",
+						fieldtype: "Link",
+						options: "UOM",
+						in_list_view: 1,
+						read_only: 1,
+						columns: 1,
+					},
+					{
+						label: __("Reqired Qty"),
+						fieldname: "required_qty",
+						fieldtype: "Float",
+						in_list_view: 1,
+						read_only: 1,
+						columns: 2,
+					},
+					{
+						label: __("Transferred Qty"),
+						fieldname: "transferred_qty",
+						fieldtype: "Float",
+						in_list_view: 1,
+						read_only: 1,
+						columns: 2,
+					},
+					{
+						label: __("Available Qty"),
+						fieldname: "stock_qty",
+						fieldtype: "Float",
+						in_list_view: 1,
+						read_only: 1,
+						columns: 2,
+					},
+					{
+						label: __("Available"),
+						fieldname: "material_availability_status",
+						fieldtype: "Check",
+						in_list_view: 1,
+						read_only: 1,
+						columns: 1,
+					},
+				],
+			},
+		];
 	}
 
 	prepare_timer() {
 		this.job_cards.forEach((data) => {
 			if (data.time_logs?.length) {
 				data._current_time = this.get_current_time(data);
-				if (data.time_logs[cint(data.time_logs.length) - 1].to_time) {
+				if (data.time_logs[cint(data.time_logs.length) - 1].to_time || data.is_paused) {
 					this.updateStopwatch(data);
 				} else {
 					this.initialiseTimer(data);
@@ -283,23 +547,23 @@ class WorkstationDashboard {
 				[data-name='${data.name}']`);
 
 			$(job_card_selector).find(".job-card-status").text(data.status);
-			$(job_card_selector).find(".job-card-status").css("backgroundColor", color_map[data.status]);
 
-			if (data.status === "Work In Progress") {
-				$(job_card_selector).find(".btn-start").addClass("hide");
-				$(job_card_selector).find(".btn-complete").removeClass("hide");
-			} else if (data.status === "Completed") {
-				$(job_card_selector).find(".btn-start").addClass("hide");
-				$(job_card_selector).find(".btn-complete").addClass("hide");
-			}
+			["blue", "gray", "green", "orange", "yellow"].forEach((color) => {
+				$(job_card_selector).find(".job-card-status").removeClass(color);
+			});
+
+			$(job_card_selector).find(".job-card-status").addClass(data.status_color);
+			$(job_card_selector).find(".job-card-status").css("backgroundColor", color_map[data.status]);
 		});
 	}
 
 	initialiseTimer(data) {
-		setInterval(() => {
+		let timeout = setInterval(() => {
 			data._current_time += 1;
 			this.updateStopwatch(data);
 		}, 1000);
+
+		this.timer_job_cards[data.name] = timeout;
 	}
 
 	updateStopwatch(data) {

--- a/erpnext/manufacturing/doctype/workstation/workstation.json
+++ b/erpnext/manufacturing/doctype/workstation/workstation.json
@@ -9,6 +9,7 @@
  "engine": "InnoDB",
  "field_order": [
   "dashboard_tab",
+  "section_break_mqqv",
   "workstation_dashboard",
   "details_tab",
   "workstation_name",
@@ -246,13 +247,18 @@
    "fieldname": "workstation_dashboard",
    "fieldtype": "HTML",
    "label": "Workstation Dashboard"
+  },
+  {
+   "fieldname": "section_break_mqqv",
+   "fieldtype": "Section Break",
+   "hide_border": 1
   }
  ],
  "icon": "icon-wrench",
  "idx": 1,
  "image_field": "on_status_image",
  "links": [],
- "modified": "2024-03-27 13:11:00.760717",
+ "modified": "2024-06-01 14:48:47.341354",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Workstation",

--- a/erpnext/manufacturing/doctype/workstation/workstation.py
+++ b/erpnext/manufacturing/doctype/workstation/workstation.py
@@ -55,7 +55,14 @@ class Workstation(Document):
 		hour_rate_electricity: DF.Currency
 		hour_rate_labour: DF.Currency
 		hour_rate_rent: DF.Currency
+		off_status_image: DF.AttachImage | None
+		on_status_image: DF.AttachImage | None
+		parts_per_hour: DF.Float
+		plant_floor: DF.Link | None
 		production_capacity: DF.Int
+		status: DF.Literal["Production", "Off", "Idle", "Problem", "Maintenance", "Setup"]
+		total_working_hours: DF.Float
+		warehouse: DF.Link | None
 		working_hours: DF.Table[WorkstationWorkingHour]
 		workstation_name: DF.Data
 		workstation_type: DF.Link | None
@@ -189,7 +196,7 @@ class Workstation(Document):
 
 
 @frappe.whitelist()
-def get_job_cards(workstation):
+def get_job_cards(workstation, job_card=None):
 	if frappe.has_permission("Job Card", "read"):
 		jc_data = frappe.get_all(
 			"Job Card",
@@ -200,15 +207,22 @@ def get_job_cards(workstation):
 				"operation",
 				"total_completed_qty",
 				"for_quantity",
+				"process_loss_qty",
+				"finished_good",
 				"transferred_qty",
 				"status",
 				"expected_start_date",
 				"expected_end_date",
 				"time_required",
 				"wip_warehouse",
+				"skip_material_transfer",
+				"backflush_from_wip_warehouse",
+				"is_paused",
+				"manufactured_qty",
 			],
 			filters={
 				"workstation": workstation,
+				"is_subcontracted": 0,
 				"docstatus": ("<", 2),
 				"status": ["not in", ["Completed", "Stopped"]],
 			},
@@ -216,64 +230,98 @@ def get_job_cards(workstation):
 		)
 
 		job_cards = [row.name for row in jc_data]
-		raw_materials = get_raw_materials(job_cards)
 		time_logs = get_time_logs(job_cards)
 
 		allow_excess_transfer = frappe.db.get_single_value(
 			"Manufacturing Settings", "job_card_excess_transfer"
 		)
 
+		user_employee = frappe.db.get_value("Employee", {"user_id": frappe.session.user}, "name")
+
 		for row in jc_data:
-			row.progress_percent = (
-				flt(row.total_completed_qty / row.for_quantity * 100, 2) if row.for_quantity else 0
-			)
-			row.progress_title = _("Total completed quantity: {0}").format(row.total_completed_qty)
+			item_code = row.finished_good or row.production_item
+			row.fg_uom = frappe.get_cached_value("Item", item_code, "stock_uom")
+
 			row.status_color = get_status_color(row.status)
-			row.job_card_link = get_link_to_form("Job Card", row.name)
+			row.job_card_link = f"""
+					<a class="ellipsis" data-doctype="Job Card" data-name="{row.name}" href="/app/job-card/{row.name}" title="" data-original-title="{row.name}">{row.name}</a>
+				"""
+
+			row.operation_link = f"""
+					<a class="ellipsis" data-doctype="Operation" data-name="{row.operation}" href="/app/operation/{row.operation}" title="" data-original-title="{row.operation}">{row.operation}</a>
+				"""
 			row.work_order_link = get_link_to_form("Work Order", row.work_order)
 
-			row.raw_materials = raw_materials.get(row.name, [])
 			row.time_logs = time_logs.get(row.name, [])
 			row.make_material_request = False
 			if row.for_quantity > row.transferred_qty or allow_excess_transfer:
 				row.make_material_request = True
+
+			row.user_employee = user_employee
 
 		return jc_data
 
 
 def get_status_color(status):
 	color_map = {
-		"Pending": "var(--bg-blue)",
-		"In Process": "var(--bg-yellow)",
-		"Submitted": "var(--bg-blue)",
-		"Open": "var(--bg-gray)",
-		"Closed": "var(--bg-green)",
-		"Work In Progress": "var(--bg-orange)",
+		"Pending": "blue",
+		"In Process": "yellow",
+		"Submitted": "blue",
+		"Open": "gray",
+		"Closed": "green",
+		"Work In Progress": "orange",
 	}
 
-	return color_map.get(status, "var(--bg-blue)")
+	return color_map.get(status, "blue")
 
 
-def get_raw_materials(job_cards):
-	raw_materials = {}
-
-	data = frappe.get_all(
-		"Job Card Item",
+@frappe.whitelist()
+def get_raw_materials(job_card):
+	raw_materials = frappe.get_all(
+		"Job Card",
 		fields=[
-			"parent",
-			"item_code",
-			"item_group",
-			"uom",
-			"item_name",
-			"source_warehouse",
-			"required_qty",
-			"transferred_qty",
+			"`tabJob Card`.`skip_material_transfer`",
+			"`tabJob Card`.`backflush_from_wip_warehouse`",
+			"`tabJob Card`.`wip_warehouse`",
+			"`tabJob Card Item`.`parent`",
+			"`tabJob Card Item`.`item_code`",
+			"`tabJob Card Item`.`item_group`",
+			"`tabJob Card Item`.`uom`",
+			"`tabJob Card Item`.`item_name`",
+			"`tabJob Card Item`.`source_warehouse`",
+			"`tabJob Card Item`.`required_qty`",
+			"`tabJob Card Item`.`transferred_qty`",
 		],
-		filters={"parent": ["in", job_cards]},
+		filters={"name": job_card},
 	)
 
-	for row in data:
-		raw_materials.setdefault(row.parent, []).append(row)
+	if not raw_materials:
+		return []
+
+	for row in raw_materials:
+		warehouse = row.source_warehouse
+		if row.skip_material_transfer and row.backflush_from_wip_warehouse:
+			warehouse = row.wip_warehouse
+
+		row.stock_qty = (
+			frappe.db.get_value(
+				"Bin",
+				{
+					"item_code": row.item_code,
+					"warehouse": warehouse,
+				},
+				"actual_qty",
+			)
+			or 0.0
+		)
+
+		row.warehouse = warehouse
+
+		row.material_availability_status = 0
+		if row.skip_material_transfer and row.stock_qty >= row.required_qty:
+			row.material_availability_status = 1
+		elif row.transferred_qty >= row.required_qty:
+			row.material_availability_status = 1
 
 	return raw_materials
 
@@ -392,20 +440,57 @@ def get_workstations(**kwargs):
 	data = query.run(as_dict=True)
 
 	color_map = {
-		"Production": "var(--green-600)",
-		"Off": "var(--gray-600)",
-		"Idle": "var(--gray-600)",
-		"Problem": "var(--red-600)",
-		"Maintenance": "var(--yellow-600)",
-		"Setup": "var(--blue-600)",
+		"Production": "green",
+		"Off": "gray",
+		"Idle": "gray",
+		"Problem": "red",
+		"Maintenance": "yellow",
+		"Setup": "blue",
 	}
 
 	for d in data:
 		d.workstation_name = get_link_to_form("Workstation", d.name)
 		d.status_image = d.on_status_image
-		d.background_color = color_map.get(d.status, "var(--red-600)")
+		d.color = color_map.get(d.status, "red")
 		d.workstation_link = get_url_to_form("Workstation", d.name)
 		if d.status != "Production":
 			d.status_image = d.off_status_image
 
 	return data
+
+
+@frappe.whitelist()
+def update_job_card(job_card, method, **kwargs):
+	if isinstance(kwargs, dict):
+		kwargs = frappe._dict(kwargs)
+
+	if kwargs.get("employees"):
+		kwargs.employees = frappe.parse_json(kwargs.employees)
+
+	if kwargs.qty and isinstance(kwargs.qty, str):
+		kwargs.qty = flt(kwargs.qty)
+
+	doc = frappe.get_doc("Job Card", job_card)
+	doc.run_method(method, **kwargs)
+
+
+@frappe.whitelist()
+def validate_job_card(job_card, status):
+	job_card_details = frappe.db.get_value("Job Card", job_card, ["status", "for_quantity"], as_dict=1)
+
+	current_status = job_card_details.status
+	if current_status != status:
+		if status == "Open":
+			frappe.throw(
+				_("The job card {0} is in {1} state and you cannot start it again.").format(
+					job_card, current_status
+				)
+			)
+		else:
+			frappe.throw(
+				_("The job card {0} is in {1} state and you cannot complete.").format(
+					job_card, current_status
+				)
+			)
+
+	return job_card_details.for_quantity

--- a/erpnext/manufacturing/doctype/workstation/workstation_job_card.html
+++ b/erpnext/manufacturing/doctype/workstation/workstation_job_card.html
@@ -1,6 +1,6 @@
 <style>
 	.job-card-link {
-		min-height: 100px;
+		min-height: 60px;
 	}
 
 	.section-head-job-card {
@@ -9,26 +9,31 @@
 	}
 </style>
 
-<div style = "max-height: 400px; overflow-y: auto;">
+<div>
+
+<div class="form-dashboard-section qrcode-fields col-sm-12 section-body" style="padding-left: 0px;padding-right: 25px;"></div>
+
 {% $.each(data, (idx, d) => { %}
 	<div class="row form-dashboard-section job-card-link form-links border-gray-200" data-name="{{d.name}}">
-		<div class="section-head section-head-job-card">
-			{{ d.operation }} - {{ d.production_item }}
-			<span class="ml-2 collapse-indicator-job mb-1" style="">
-				{{frappe.utils.icon("es-line-down", "sm", "mb-1")}}
-			</span>
-		</div>
-		<div class="row form-section" style="width:100%;margin-bottom:10px">
-			<div class="form-column col-sm-3">
-				<div class="frappe-control" title="{{__('Job Card')}}" style="text-decoration:underline">
+		<div class="row form-section" style="width:100%;margin-top:10px">
+			<div class="form-column col-sm-2">
+				<div class="frappe-control bold" data-doctype="Job Card" data-name="{{d.name}}" title="{{__('Job Card ID')}}">
 					{{ d.job_card_link }}
-				</div>
-				<div class="frappe-control" title="{{__('Work Order')}}" style="text-decoration:underline">
-					{{ d.work_order_link }}
 				</div>
 			</div>
 			<div class="form-column col-sm-2">
-				<div class="frappe-control timer" title="{{__('Timer')}}" style="text-align:center;font-size:14px;" data-job-card = {{escape(d.name)}}>
+				<div class="frappe-control" title="{{__('Item')}}">{{ d.finished_good || d.production_item }}</div>
+			</div>
+			<div class="form-column col-sm-1">
+				<div class="frappe-control" title="{{__('Qty')}}">{{ d.for_quantity }} {{ d.fg_uom }}</div>
+			</div>
+			<div class="form-column col-sm-2 ellipsis">
+				<div class="frappe-control" title="{{__('Operation')}}">
+					{{ d.operation_link }}
+				</div>
+			</div>
+			<div class="form-column col-sm-2">
+				<div class="frappe-control timer" title="{{__('Timer')}}" style="font-size:14px;" data-job-card = {{escape(d.name)}}>
 					<span class="hours">00</span>
 					<span class="colon">:</span>
 					<span class="minutes">00</span>
@@ -36,7 +41,7 @@
 					<span class="seconds">00</span>
 				</div>
 
-				{% if(d.status === "Open") { %}
+				<!-- {% if(d.status === "Open") { %}
 					<div class="frappe-control" title="{{__('Expected Start Date')}}" style="text-align:center;font-size:11px;padding-top: 4px;">
 						{{ frappe.format(d.expected_start_date, { fieldtype: 'Datetime' }) }}
 					</div>
@@ -44,82 +49,60 @@
 					<div class="frappe-control" title="{{__('Expected End Date')}}" style="text-align:center;font-size:11px;padding-top: 4px;">
 						{{ frappe.format(d.expected_end_date, { fieldtype: 'Datetime' }) }}
 					</div>
-				{% } %}
+				{% } %} -->
 
 			</div>
 			<div class="form-column col-sm-2">
-				<div class="frappe-control job-card-status" title="{{__('Status')}}" style="background:{{d.status_color}};text-align:center;border-radius:var(--border-radius-full)">
-					{{ d.status }}
+				<div class="frappe-control indicator-pill no-indicator-dot whitespace-nowrap job-card-status {{d.status_color}}" title="{{__('Status')}}">
+					{% if(d.status === "Open") { %}
+						{{__("Not Started")}}
+					{% } else { %}
+						{{ __(d.status) }}
+					{% } %}
 				</div>
 			</div>
-			<div class="form-column col-sm-2">
-				<div class="frappe-control" title="{{__('Qty to Manufacture')}}">
-					<div class="progress" title = "{{d.progress_title}}">
-						<div class="progress-bar progress-bar-success" style="width: {{d.progress_percent}}%">
-						</div>
-					</div>
+			<div class="form-column col-sm-1">
+				<div class="menu-btn-group">
+					<button type="button" class="btn btn-default icon-btn" data-toggle="dropdown" aria-expanded="false" aria-label="{{ __("Menu") }}">
+						<span>
+							<span class="menu-btn-group-label">
+								<svg class="icon icon-sm">
+									<use href="#icon-dot-vertical">
+									</use>
+								</svg>
+							</span>
+						</span>
+					</button>
+					<ul class="dropdown-menu dropdown-menu-right menu-actions" role="menu" data-job-card="{{d.name}}">
+						<li>
+							<a class="grey-link dropdown-item btn-start" href="#" onclick="return false;">
+								<span class="menu-item-label" data-label="Start">{{ __('Start') }}</span>
+							</a>
+						</li>
+						<li>
+							<a class="grey-link dropdown-item btn-resume" href="#" onclick="return false;">
+								<span class="menu-item-label" data-label="Resume">{{ __('Resume') }}</span>
+							</a>
+						</li>
+						<li>
+							<a class="grey-link dropdown-item btn-pause" href="#" onclick="return false;">
+								<span class="menu-item-label" data-label="Pause">{{ __('Pause') }}</span>
+							</a>
+						</li>
+						<li>
+							<a class="grey-link dropdown-item btn-complete" href="#" onclick="return false;" data-qty="{{d.for_quantity}}">
+								<span class="menu-item-label" data-label="Complete">{{ __('Complete') }}</span>
+							</a>
+						</li>
+						<li>
+							<a class="grey-link dropdown-item btn-transfer-materials" href="#" onclick="return false;">
+								<span class="menu-item-label" data-label="Transfer Materials">{{ __('Transfer Materials') }}</span>
+							</a>
+						</li>
+					</ul>
 				</div>
-				<div class="frappe-control" style="text-align: center; font-size: 10px;">
-					{{ d.for_quantity }} / {{ d.total_completed_qty }}
-				</div>
-			</div>
-			<div class="form-column col-sm-2 text-center">
-				<button style="width: 85px;" class="btn btn-default btn-start {% if(d.status !== "Open") { %} hide {% } %}" job-card="{{d.name}}"> {{__("Start")}} </button>
-				<button style="width: 85px;" class="btn btn-default btn-complete {% if(d.status === "Open") { %} hide {% } %}" job-card="{{d.name}}" pending-qty="{{d.for_quantity - d.transferred_qty}}"> {{__("Complete")}} </button>
 			</div>
 		</div>
-
-		<div class="section-body section-body-job-card form-section hide">
-			<hr>
-			<div class="row">
-				<div class="form-column col-sm-2">
-					{{ __("Raw Materials") }}
-				</div>
-				{% if(d.make_material_request) { %}
-					<div class="form-column col-sm-10 text-right">
-						<button class="btn btn-default btn-xs make-material-request" job-card="{{d.name}}">{{ __("Material Request") }}</button>
-					</div>
-				{% } %}
-			</div>
-
-			{% if(d.raw_materials) { %}
-			<table class="table table-bordered table-condensed">
-				<thead>
-					<tr>
-						<th style="width: 5%" class="table-sr">Sr</th>
-
-						<th style="width: 15%">{{ __("Item") }}</th>
-						<th style="width: 15%">{{ __("Warehouse") }}</th>
-						<th style="width: 10%">{{__("UOM")}}</th>
-						<th style="width: 15%">{{__("Item Group")}}</th>
-						<th style="width: 20%" >{{__("Required Qty")}}</th>
-						<th style="width: 20%" >{{__("Transferred Qty")}}</th>
-					</tr>
-				</thead>
-				<tbody>
-
-				{% $.each(d.raw_materials, (row_index, child_row) => { %}
-					<tr>
-						<td class="table-sr">{{ row_index+1 }}</td>
-						{% if(child_row.item_code === child_row.item_name) { %}
-							<td>{{ child_row.item_code }}</td>
-						{% } else { %}
-							<td>{{ child_row.item_code }}: {{child_row.item_name}}</td>
-						{% } %}
-						<td>{{ child_row.source_warehouse }}</td>
-						<td>{{ child_row.uom }}</td>
-						<td>{{ child_row.item_group }}</td>
-						<td>{{ child_row.required_qty }}</td>
-						<td>{{ child_row.transferred_qty }}</td>
-					</tr>
-				{% }); %}
-
-				</tbody>
-			{% } %}
-
-			</table>
-		</div>
-
 	</div>
 {% }); %}
 </div>

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -368,3 +368,4 @@ erpnext.patches.v15_0.fix_debit_credit_in_transaction_currency
 erpnext.patches.v15_0.rename_purchase_receipt_amount_to_purchase_amount
 erpnext.patches.v14_0.enable_set_priority_for_pricing_rules #1
 erpnext.patches.v15_0.rename_number_of_depreciations_booked_to_opening_booked_depreciations
+erpnext.patches.v15_0.add_default_operations

--- a/erpnext/patches/v15_0/add_default_operations.py
+++ b/erpnext/patches/v15_0/add_default_operations.py
@@ -1,0 +1,5 @@
+from erpnext.setup.install import make_default_operations
+
+
+def execute():
+	make_default_operations()

--- a/erpnext/public/js/bom_configurator/bom_configurator.bundle.js
+++ b/erpnext/public/js/bom_configurator/bom_configurator.bundle.js
@@ -33,10 +33,11 @@ class BOMConfigurator {
 			frm: this.frm,
 			add_item: this.add_item,
 			add_sub_assembly: this.add_sub_assembly,
+			set_query_for_workstation: this.set_query_for_workstation,
 			get_sub_assembly_modal_fields: this.get_sub_assembly_modal_fields,
 			convert_to_sub_assembly: this.convert_to_sub_assembly,
 			delete_node: this.delete_node,
-			edit_qty: this.edit_qty,
+			edit_bom: this.edit_bom,
 			load_tree: this.load_tree,
 			set_default_qty: this.set_default_qty,
 		};
@@ -107,15 +108,15 @@ class BOMConfigurator {
 				this.frm?.doc.docstatus === 0
 					? [
 							{
-								label: `${frappe.utils.icon("edit", "sm")} ${__("Qty")}`,
+								label: __(frappe.utils.icon("edit", "sm") + " BOM"),
 								click: function (node) {
 									let view = frappe.views.trees["BOM Configurator"];
-									view.events.edit_qty(node, view);
+									view.events.edit_bom(node, view);
 								},
 								btnClass: "hidden-xs",
 							},
 							{
-								label: `${frappe.utils.icon("add", "sm")} ${__("Raw Material")}`,
+								label: __(frappe.utils.icon("add", "sm") + " Raw Material"),
 								click: function (node) {
 									let view = frappe.views.trees["BOM Configurator"];
 									view.events.add_item(node, view);
@@ -126,7 +127,7 @@ class BOMConfigurator {
 								btnClass: "hidden-xs",
 							},
 							{
-								label: `${frappe.utils.icon("add", "sm")} ${__("Sub Assembly")}`,
+								label: __(frappe.utils.icon("add", "sm") + " Sub Assembly"),
 								click: function (node) {
 									let view = frappe.views.trees["BOM Configurator"];
 									view.events.add_sub_assembly(node, view);
@@ -156,7 +157,7 @@ class BOMConfigurator {
 								btnClass: "hidden-xs expand-all-btn",
 							},
 							{
-								label: `${frappe.utils.icon("move", "sm")} ${__("Sub Assembly")}`,
+								label: __(frappe.utils.icon("move", "sm") + " Sub Assembly"),
 								click: function (node) {
 									let view = frappe.views.trees["BOM Configurator"];
 									view.events.convert_to_sub_assembly(node, view);
@@ -167,7 +168,7 @@ class BOMConfigurator {
 								btnClass: "hidden-xs",
 							},
 							{
-								label: `${frappe.utils.icon("delete", "sm")} ${__("Item")}`,
+								label: __(frappe.utils.icon("delete", "sm") + " Item"),
 								click: function (node) {
 									let view = frappe.views.trees["BOM Configurator"];
 									view.events.delete_node(node, view);
@@ -232,17 +233,37 @@ class BOMConfigurator {
 		);
 	}
 
+	set_query_for_workstation(dialog) {
+		let workstation = dialog.fields.filter((field) => field.fieldname === "workstation");
+		if (workstation.length) {
+			workstation[0].get_query = function () {
+				let workstation_type = dialog.get_value("workstation_type");
+
+				if (workstation_type) {
+					return {
+						filters: {
+							workstation_type: dialog.get_value("workstation_type"),
+						},
+					};
+				}
+			};
+		}
+	}
+
 	add_sub_assembly(node, view) {
 		let dialog = new frappe.ui.Dialog({
-			fields: view.events.get_sub_assembly_modal_fields(node.is_root),
+			fields: view.events.get_sub_assembly_modal_fields(view, node.is_root),
 			title: __("Add Sub Assembly"),
 		});
+		view.events.set_query_for_workstation(dialog);
 
 		dialog.show();
-		view.events.set_default_qty(dialog);
-
 		dialog.set_primary_action(__("Add"), () => {
 			let bom_item = dialog.get_values();
+
+			if (dialog.operation && !dialog.workstation_type && !dialog.workstation) {
+				frappe.throw(__("Either Workstation or Workstation Type is mandatory"));
+			}
 
 			if (!node.data?.parent_id) {
 				node.data.parent_id = this.frm.doc.name;
@@ -268,57 +289,169 @@ class BOMConfigurator {
 		});
 	}
 
-	get_sub_assembly_modal_fields(is_root=false, read_only=false) {
+	get_sub_assembly_modal_fields(view, is_root = false, read_only = false, show_operations_fields = false) {
 		let fields = [
-			{ label: __("Sub Assembly Item"), fieldname: "item_code", fieldtype: "Link", options: "Item", reqd: 1, read_only: read_only },
+			{
+				label: __("Sub Assembly Item"),
+				fieldname: "item_code",
+				fieldtype: "Link",
+				options: "Item",
+				reqd: 1,
+				read_only: read_only,
+			},
 			{ fieldtype: "Column Break" },
-			{ label: __("Qty"), fieldname: "qty", default: 1.0, fieldtype: "Float", reqd: 1, read_only: read_only },
-		]
+			{
+				label: __("Qty"),
+				fieldname: "qty",
+				default: 1.0,
+				fieldtype: "Float",
+				reqd: 1,
+				read_only: read_only,
+			},
+		];
 
-		if (this.frm.doc.make_finished_good_against_job_card && is_root) {
-			fields.push(...[
-				{ fieldtype: "Section Break" },
-				{ label: __("Operation"), fieldname: "operation", fieldtype: "Link", options: "Operation", read_only: read_only, reqd: 1, },
-				{ fieldtype: "Column Break" },
-				{ label: __("Workstation Type"), fieldname: "workstation_type", fieldtype: "Link", options: "Workstation Type", read_only: read_only, reqd: 1, },
-				{ label: __("Operation Time"), fieldname: "operation_time", fieldtype: "Int", read_only: read_only, reqd: 1, },
-			])
+		if (this.frm.doc.track_operations && (is_root || show_operations_fields)) {
+			fields.push(
+				...[
+					{ fieldtype: "Section Break" },
+					{
+						label: __("Operation"),
+						fieldname: "operation",
+						fieldtype: "Link",
+						options: "Operation",
+						reqd: 1,
+					},
+					{
+						label: __("Operation Time"),
+						fieldname: "operation_time",
+						fieldtype: "Int",
+						reqd: 1,
+					},
+					{
+						label: __("Is Subcontracted"),
+						fieldname: "is_subcontracted",
+						fieldtype: "Check",
+					},
+					{ fieldtype: "Column Break" },
+					{
+						label: __("Workstation Type"),
+						fieldname: "workstation_type",
+						fieldtype: "Link",
+						options: "Workstation Type",
+					},
+					{
+						label: __("Workstation"),
+						fieldname: "workstation",
+						fieldtype: "Link",
+						options: "Workstation",
+					},
+				]
+			);
+
+			if (this.frm.doc.track_semi_finished_goods) {
+				fields.push(
+					...[
+						{ label: __("Default Warehouse"), fieldtype: "Section Break", collapsible: 1 },
+						{
+							label: __("Skip Material Transfer"),
+							fieldname: "skip_material_transfer",
+							fieldtype: "Check",
+						},
+						{
+							label: __("Backflush Materials From WIP"),
+							fieldname: "backflush_from_wip_warehouse",
+							fieldtype: "Check",
+							depends_on: "eval:doc.skip_material_transfer",
+						},
+						{
+							label: __("Source Warehouse"),
+							fieldname: "source_warehouse",
+							fieldtype: "Link",
+							options: "Warehouse",
+							depends_on: "eval:!doc.backflush_from_wip_warehouse",
+							get_query() {
+								return {
+									filters: {
+										company: view.events.frm.doc.company,
+									},
+								};
+							},
+						},
+						{ fieldtype: "Column Break" },
+						{
+							label: __("Work In Progress Warehouse"),
+							fieldname: "wip_warehouse",
+							fieldtype: "Link",
+							options: "Warehouse",
+							depends_on:
+								"eval:!doc.skip_material_transfer || doc.backflush_from_wip_warehouse",
+							get_query() {
+								return {
+									filters: {
+										company: view.events.frm.doc.company,
+									},
+								};
+							},
+						},
+						{
+							label: __("Finished Good Warehouse"),
+							fieldname: "fg_warehouse",
+							fieldtype: "Link",
+							options: "Warehouse",
+							get_query() {
+								return {
+									filters: {
+										company: view.events.frm.doc.company,
+									},
+								};
+							},
+						},
+					]
+				);
+			}
 		}
 
-		fields.push(...[
-			{ fieldtype: "Section Break" },
-			{
-				label: __("Raw Materials"),
-				fieldname: "items",
-				fieldtype: "Table",
-				reqd: 1,
-				fields: [
-					{
-						label: __("Item"),
-						fieldname: "item_code",
-						fieldtype: "Link",
-						options: "Item",
-						reqd: 1,
-						in_list_view: 1,
-					},
-					{
-						label: __("Qty"),
-						fieldname: "qty",
-						default: 1.0,
-						fieldtype: "Float",
-						reqd: 1,
-						in_list_view: 1,
-					},
-				],
-			},
-		])
+		fields.push(
+			...[
+				{ fieldtype: "Section Break" },
+				{
+					label: __("Raw Materials"),
+					fieldname: "items",
+					fieldtype: "Table",
+					reqd: 1,
+					fields: [
+						{
+							label: __("Item"),
+							fieldname: "item_code",
+							fieldtype: "Link",
+							options: "Item",
+							reqd: 1,
+							in_list_view: 1,
+							change() {
+								let doc = this.doc;
+								doc.qty = 1.0;
+								this.grid.set_value("qty", 1.0, doc);
+							},
+						},
+						{
+							label: __("Qty"),
+							fieldname: "qty",
+							default: 1.0,
+							fieldtype: "Float",
+							reqd: 1,
+							in_list_view: 1,
+						},
+					],
+				},
+			]
+		);
 
 		return fields;
 	}
 
 	convert_to_sub_assembly(node, view) {
 		let dialog = new frappe.ui.Dialog({
-			fields: view.events.get_sub_assembly_modal_fields(node.is_root, true),
+			fields: view.events.get_sub_assembly_modal_fields(view, node.is_root, true, true),
 			title: __("Add Sub Assembly"),
 		});
 
@@ -328,10 +461,12 @@ class BOMConfigurator {
 		});
 
 		dialog.show();
-		view.events.set_default_qty(dialog);
-
 		dialog.set_primary_action(__("Add"), () => {
 			let bom_item = dialog.get_values();
+
+			if (dialog.operation && !dialog.workstation_type && !dialog.workstation) {
+				frappe.throw(__("Either Workstation or Workstation Type is mandatory"));
+			}
 
 			frappe.call({
 				method: "erpnext.manufacturing.doctype.bom_creator.bom_creator.add_sub_assembly",
@@ -344,10 +479,11 @@ class BOMConfigurator {
 					operation: node.data.operation,
 					workstation_type: node.data.workstation_type,
 					operation_time: node.data.operation_time,
+					workstation: node.data.workstation,
 				},
 				callback: (r) => {
 					node.expandable = true;
-					view.events.load_tree(r, node);
+					view.events.load_tree(r, node.parent_node);
 				},
 			});
 
@@ -383,24 +519,146 @@ class BOMConfigurator {
 		});
 	}
 
-	edit_qty(node, view) {
+	edit_bom(node, view) {
+		let me = this;
 		let qty = node.data.qty || this.frm.doc.qty;
-		frappe.prompt(
-			[{ label: __("Qty"), fieldname: "qty", default: qty, fieldtype: "Float", reqd: 1 }],
+		let fields = [{ label: __("Qty"), fieldname: "qty", default: qty, fieldtype: "Float", reqd: 1 }];
+
+		if (node.expandable && this.frm.doc.track_operations) {
+			let data = node.data.operation ? node.data : this.frm.doc;
+
+			fields = [
+				...fields,
+				...[
+					{ fieldtype: "Section Break" },
+					{
+						label: __("Operation"),
+						fieldname: "operation",
+						fieldtype: "Link",
+						options: "Operation",
+						default: data.operation,
+					},
+					{
+						label: __("Operation Time"),
+						fieldname: "operation_time",
+						fieldtype: "Float",
+						default: data.operation_time,
+					},
+					{
+						label: __("Is Subcontracted"),
+						fieldname: "is_subcontracted",
+						fieldtype: "Check",
+						default: data.is_subcontracted,
+					},
+					{ fieldtype: "Column Break" },
+					{
+						label: __("Workstation Type"),
+						fieldname: "workstation_type",
+						fieldtype: "Link",
+						options: "Workstation Type",
+						default: data.workstation_type,
+					},
+					{
+						label: __("Workstation"),
+						fieldname: "workstation",
+						fieldtype: "Link",
+						options: "Workstation",
+						default: data.workstation,
+						get_query() {
+							let dialog = me.frm.edit_bom_dialog;
+							let workstation_type = dialog.get_value("workstation_type");
+
+							if (workstation_type) {
+								return {
+									filters: {
+										workstation_type: dialog.get_value("workstation_type"),
+									},
+								};
+							}
+						},
+					},
+					{ fieldtype: "Section Break" },
+					{
+						label: __("Skip Material Transfer"),
+						fieldname: "skip_material_transfer",
+						fieldtype: "Check",
+						default: data.skip_material_transfer,
+					},
+					{
+						label: __("Backflush Materials From WIP"),
+						fieldname: "backflush_from_wip_warehouse",
+						fieldtype: "Check",
+						depends_on: "eval:doc.skip_material_transfer",
+						default: data.backflush_from_wip_warehouse,
+					},
+					{
+						label: __("Source Warehouse"),
+						fieldname: "source_warehouse",
+						fieldtype: "Link",
+						options: "Warehouse",
+						default: data.source_warehouse,
+						depends_on: "eval:!doc.backflush_from_wip_warehouse",
+						get_query() {
+							return {
+								filters: {
+									company: me.frm.doc.company,
+								},
+							};
+						},
+					},
+					{ fieldtype: "Column Break" },
+					{
+						label: __("Work In Progress Warehouse"),
+						fieldname: "wip_warehouse",
+						fieldtype: "Link",
+						options: "Warehouse",
+						default: data.wip_warehouse,
+						depends_on: "eval:!doc.skip_material_transfer || doc.backflush_from_wip_warehouse",
+						get_query() {
+							return {
+								filters: {
+									company: me.frm.doc.company,
+								},
+							};
+						},
+					},
+					{
+						label: __("Finished Good Warehouse"),
+						fieldname: "fg_warehouse",
+						fieldtype: "Link",
+						options: "Warehouse",
+						default: data.fg_warehouse,
+						get_query() {
+							return {
+								filters: {
+									company: me.frm.doc.company,
+								},
+							};
+						},
+					},
+				],
+			];
+		}
+
+		this.frm.edit_bom_dialog = frappe.prompt(
+			fields,
 			(data) => {
 				let doctype = node.data.doctype || this.frm.doc.doctype;
 				let docname = node.data.name || this.frm.doc.name;
 
 				frappe.call({
-					method: "erpnext.manufacturing.doctype.bom_creator.bom_creator.edit_qty",
+					method: "erpnext.manufacturing.doctype.bom_creator.bom_creator.edit_bom_creator",
 					args: {
 						doctype: doctype,
 						docname: docname,
-						qty: data.qty,
-						parent: node.data.parent_id,
+						data: data,
+						parent: node.data.parent_id || this.frm.doc.name,
 					},
 					callback: (r) => {
-						node.data.qty = data.qty;
+						for (let key in data) {
+							node.data[key] = data[key];
+						}
+
 						let uom = node.data.uom || this.frm.doc.uom;
 						$(node.parent.get(0))
 							.find(`[data-bom-qty-docname='${docname}']`)
@@ -409,7 +667,7 @@ class BOMConfigurator {
 					},
 				});
 			},
-			__("Edit Qty"),
+			__("Edit BOM"),
 			__("Update")
 		);
 	}

--- a/erpnext/public/js/templates/visual_plant_floor_template.html
+++ b/erpnext/public/js/templates/visual_plant_floor_template.html
@@ -1,5 +1,8 @@
 {% $.each(workstations, (idx, row) => { %}
 	<div class="workstation-wrapper">
+		<div class="workstation-status text-right">
+			<span class="indicator-pill no-indicator-dot whitespace-nowrap {{row.color}}" style="margin: 3px 4px 0px 0px;"><span style="font-size:13px">{{row.status}}</span></span>
+		</div>
 		<div class="workstation-image">
 			<div class="flex items-center justify-center h-32 border-b-grey text-6xl text-grey-100">
 				<a class="workstation-image-link" href="{{row.workstation_link}}">
@@ -11,9 +14,10 @@
 				</a>
 			</div>
 		</div>
-		<div class="workstation-card text-center">
-			<p style="background-color:{{row.background_color}};color:#fff">{{row.status}}</p>
-			<div>{{row.workstation_name}}</div>
+		<div class="workstation-card" style="display: grid;">
+			<span class="ellipsis" title="{{row.name}}">
+				{{row.workstation_name}}
+			</span>
 		</div>
 	</div>
 {% }); %}

--- a/erpnext/public/scss/erpnext.scss
+++ b/erpnext/public/scss/erpnext.scss
@@ -511,6 +511,10 @@ body[data-route="pos"] {
 	padding-bottom: 25px;
 }
 
+.workstation-image-cls {
+	height: 9rem;
+}
+
 .plant-floor-filter {
 	padding-top: 10px;
 	display: flex;
@@ -519,8 +523,8 @@ body[data-route="pos"] {
 
 .plant-floor-container {
 	display: grid;
-	grid-template-columns: repeat(6, minmax(0, 1fr));
-	gap: var(--margin-xl);
+	grid-template-columns: repeat(5, minmax(0, 1fr));
+	gap: var(--margin-lg);
 }
 
 @media screen and (max-width: 620px) {
@@ -536,7 +540,7 @@ body[data-route="pos"] {
 .plant-floor-container .workstation-image-link {
 	width: 100%;
 	font-size: 50px;
-	margin: var(--margin-sm);
+	margin: var(--margin-xs);
 	min-height: 9rem;
 }
 

--- a/erpnext/setup/install.py
+++ b/erpnext/setup/install.py
@@ -32,6 +32,7 @@ def after_install():
 	add_standard_navbar_items()
 	add_app_name()
 	update_roles()
+	make_default_operations()
 	frappe.db.commit()
 
 
@@ -40,6 +41,14 @@ def check_setup_wizard_not_completed():
 		message = """ERPNext can only be installed on a fresh site where the setup wizard is not completed.
 You can reinstall this site (after saving your data) using: bench --site [sitename] reinstall"""
 		frappe.throw(message)  # nosemgrep
+
+
+def make_default_operations():
+	for operation in ["Assembly"]:
+		if not frappe.db.exists("Operation", operation):
+			doc = frappe.get_doc({"doctype": "Operation", "name": operation})
+			doc.flags.ignore_mandatory = True
+			doc.insert(ignore_permissions=True)
 
 
 def set_single_defaults():

--- a/erpnext/stock/doctype/stock_entry/stock_entry.json
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.json
@@ -14,6 +14,7 @@
   "purpose",
   "add_to_transit",
   "work_order",
+  "job_card",
   "purchase_order",
   "subcontracting_order",
   "delivery_note_no",
@@ -79,7 +80,6 @@
   "col5",
   "per_transferred",
   "total_amount",
-  "job_card",
   "amended_from",
   "credit_note",
   "is_return"

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -316,7 +316,9 @@ class StockEntry(StockController):
 
 		for row in self.items:
 			if row.is_finished_item and row.item_code != job_card.finished_good:
-				frappe.throw(_("Row #{0}: Finished Good must be {1}").format(row.idx, job_card.fininshed_good))
+				frappe.throw(
+					_("Row #{0}: Finished Good must be {1}").format(row.idx, job_card.fininshed_good)
+				)
 
 	def validate_job_card_item(self):
 		if not self.job_card or self.purpose == "Manufacture":
@@ -634,10 +636,7 @@ class StockEntry(StockController):
 			if (
 				(self.purpose == "Manufacture" or self.purpose == "Material Consumption for Manufacture")
 				and self.work_order
-				and frappe.get_cached_value(
-					"Work Order", self.work_order, "make_finished_good_against_job_card"
-				)
-				!= 1
+				and frappe.get_cached_value("Work Order", self.work_order, "track_semi_finished_goods") != 1
 			):
 				if not self.fg_completed_qty:
 					frappe.throw(_("For Quantity (Manufactured Qty) is mandatory"))

--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -211,7 +211,10 @@ class StockEntry(StockController):
 
 		if self.purpose in ("Manufacture", "Repack"):
 			self.mark_finished_and_scrap_items()
-			self.validate_finished_goods()
+			if not self.job_card:
+				self.validate_finished_goods()
+			else:
+				self.validate_job_card_fg_item()
 
 		self.validate_with_material_request()
 		self.validate_batch()
@@ -303,8 +306,20 @@ class StockEntry(StockController):
 			self.from_bom = 1
 			self.bom_no = data.bom_no
 
-	def validate_job_card_item(self):
+	def validate_job_card_fg_item(self):
 		if not self.job_card:
+			return
+
+		job_card = frappe.db.get_value(
+			"Job Card", self.job_card, ["finished_good", "manufactured_qty"], as_dict=1
+		)
+
+		for row in self.items:
+			if row.is_finished_item and row.item_code != job_card.finished_good:
+				frappe.throw(_("Row #{0}: Finished Good must be {1}").format(row.idx, job_card.fininshed_good))
+
+	def validate_job_card_item(self):
+		if not self.job_card or self.purpose == "Manufacture":
 			return
 
 		if cint(frappe.db.get_single_value("Manufacturing Settings", "job_card_excess_transfer")):
@@ -340,13 +355,6 @@ class StockEntry(StockController):
 
 		if self.purpose not in valid_purposes:
 			frappe.throw(_("Purpose must be one of {0}").format(comma_or(valid_purposes)))
-
-		if self.job_card and self.purpose not in ["Material Transfer for Manufacture", "Repack"]:
-			frappe.throw(
-				_(
-					"For job card {0}, you can only make the 'Material Transfer for Manufacture' type stock entry"
-				).format(self.job_card)
-			)
 
 	def delete_linked_stock_entry(self):
 		if self.purpose == "Send to Warehouse":
@@ -624,8 +632,13 @@ class StockEntry(StockController):
 			# check if work order is entered
 
 			if (
-				self.purpose == "Manufacture" or self.purpose == "Material Consumption for Manufacture"
-			) and self.work_order:
+				(self.purpose == "Manufacture" or self.purpose == "Material Consumption for Manufacture")
+				and self.work_order
+				and frappe.get_cached_value(
+					"Work Order", self.work_order, "make_finished_good_against_job_card"
+				)
+				!= 1
+			):
 				if not self.fg_completed_qty:
 					frappe.throw(_("For Quantity (Manufactured Qty) is mandatory"))
 				self.check_if_operations_completed()
@@ -1575,8 +1588,14 @@ class StockEntry(StockController):
 
 		if self.job_card:
 			job_doc = frappe.get_doc("Job Card", self.job_card)
-			job_doc.set_transferred_qty(update_status=True)
-			job_doc.set_transferred_qty_in_job_card_item(self)
+			if self.purpose != "Manufacture":
+				job_doc.set_transferred_qty(update_status=True)
+				job_doc.set_transferred_qty_in_job_card_item(self)
+			else:
+				job_doc.set_manufactured_qty()
+
+		if self.job_card and frappe.get_cached_value("Job Card", self.job_card, "finished_good"):
+			return
 
 		if self.work_order:
 			pro_doc = frappe.get_doc("Work Order", self.work_order)

--- a/erpnext/stock/doctype/stock_entry_type/stock_entry_type.py
+++ b/erpnext/stock/doctype/stock_entry_type/stock_entry_type.py
@@ -4,6 +4,7 @@
 
 import frappe
 from frappe.model.document import Document
+from frappe.utils import flt
 
 from erpnext.manufacturing.doctype.bom.bom import get_bom_items_as_dict
 
@@ -48,7 +49,7 @@ class ManufactureEntry:
 		self.stock_entry.from_bom = 1
 		self.stock_entry.bom_no = self.bom_no
 		self.stock_entry.use_multi_level_bom = 1
-		self.stock_entry.fg_completed_qty = self.qty_to_manufacture
+		self.stock_entry.fg_completed_qty = self.for_quantity
 		self.stock_entry.project = self.project
 		self.stock_entry.job_card = self.job_card
 		self.stock_entry.work_order = self.work_order
@@ -73,19 +74,63 @@ class ManufactureEntry:
 
 	def add_raw_materials(self):
 		if self.job_card:
-			item_dict = get_bom_items_as_dict(
-				self.bom_no,
-				self.company,
-				qty=self.qty_to_manufacture,
-				fetch_exploded=False,
-				fetch_qty_in_stock_uom=False,
-			)
+			item_dict = {}
+			# if self.bom_no:
+			# 	item_dict = get_bom_items_as_dict(
+			# 		self.bom_no,
+			# 		self.company,
+			# 		qty=self.qty_to_manufacture,
+			# 		fetch_exploded=False,
+			# 		fetch_qty_in_stock_uom=False,
+			# 	)
+
+			if not item_dict:
+				item_dict = self.get_items_from_job_card()
 
 			for item_code, _dict in item_dict.items():
 				_dict.from_warehouse = self.source_wh.get(item_code) or self.wip_warehouse
 				_dict.to_warehouse = ""
 
 			self.stock_entry.add_to_stock_entry_detail(item_dict)
+
+	def get_items_from_job_card(self):
+		item_dict = {}
+		items = frappe.get_all(
+			"Job Card Item",
+			fields=[
+				"item_code",
+				"source_warehouse",
+				"required_qty as qty",
+				"item_name",
+				"uom",
+				"stock_uom",
+				"item_group",
+				"description",
+			],
+			filters={"parent": self.job_card},
+		)
+
+		for item in items:
+			key = item.item_code
+
+			if key in item_dict:
+				item_dict[key]["qty"] += flt(item.qty)
+			else:
+				item_dict[key] = item
+
+		for item, item_details in item_dict.items():
+			for d in [
+				["Account", "expense_account", "stock_adjustment_account"],
+				["Cost Center", "cost_center", "cost_center"],
+				["Warehouse", "default_warehouse", ""],
+			]:
+				company_in_record = frappe.db.get_value(d[0], item_details.get(d[1]), "company")
+				if not item_details.get(d[1]) or (company_in_record and self.company != company_in_record):
+					item_dict[item][d[1]] = (
+						frappe.get_cached_value("Company", self.company, d[2]) if d[2] else None
+					)
+
+		return item_dict
 
 	def add_finished_good(self):
 		from erpnext.stock.doctype.item.item import get_item_defaults
@@ -95,7 +140,7 @@ class ManufactureEntry:
 		args = {
 			"to_warehouse": self.fg_warehouse,
 			"from_warehouse": "",
-			"qty": self.qty_to_manufacture,
+			"qty": self.for_quantity,
 			"item_name": item.item_name,
 			"description": item.description,
 			"stock_uom": item.stock_uom,

--- a/erpnext/stock/doctype/stock_entry_type/stock_entry_type.py
+++ b/erpnext/stock/doctype/stock_entry_type/stock_entry_type.py
@@ -2,8 +2,10 @@
 # For license information, please see license.txt
 
 
-# import frappe
+import frappe
 from frappe.model.document import Document
+
+from erpnext.manufacturing.doctype.bom.bom import get_bom_items_as_dict
 
 
 class StockEntryType(Document):
@@ -32,3 +34,74 @@ class StockEntryType(Document):
 	def validate(self):
 		if self.add_to_transit and self.purpose != "Material Transfer":
 			self.add_to_transit = 0
+
+
+class ManufactureEntry:
+	def __init__(self, kwargs) -> None:
+		for key, value in kwargs.items():
+			setattr(self, key, value)
+
+	def make_stock_entry(self):
+		self.stock_entry = frappe.new_doc("Stock Entry")
+		self.stock_entry.purpose = self.purpose
+		self.stock_entry.company = self.company
+		self.stock_entry.from_bom = 1
+		self.stock_entry.bom_no = self.bom_no
+		self.stock_entry.use_multi_level_bom = 1
+		self.stock_entry.fg_completed_qty = self.qty_to_manufacture
+		self.stock_entry.project = self.project
+		self.stock_entry.job_card = self.job_card
+		self.stock_entry.work_order = self.work_order
+		self.stock_entry.set_stock_entry_type()
+
+		self.prepare_source_warehouse()
+		self.add_raw_materials()
+		self.add_finished_good()
+
+	def prepare_source_warehouse(self):
+		self.source_wh = {}
+		if self.skip_material_transfer:
+			if not self.backflush_from_wip_warehouse:
+				self.source_wh = frappe._dict(
+					frappe.get_all(
+						"Job Card Item",
+						filters={"parent": self.job_card},
+						fields=["item_code", "source_warehouse"],
+						as_list=1,
+					)
+				)
+
+	def add_raw_materials(self):
+		if self.job_card:
+			item_dict = get_bom_items_as_dict(
+				self.bom_no,
+				self.company,
+				qty=self.qty_to_manufacture,
+				fetch_exploded=False,
+				fetch_qty_in_stock_uom=False,
+			)
+
+			for item_code, _dict in item_dict.items():
+				_dict.from_warehouse = self.source_wh.get(item_code) or self.wip_warehouse
+				_dict.to_warehouse = ""
+
+			self.stock_entry.add_to_stock_entry_detail(item_dict)
+
+	def add_finished_good(self):
+		from erpnext.stock.doctype.item.item import get_item_defaults
+
+		item = get_item_defaults(self.production_item, self.company)
+
+		args = {
+			"to_warehouse": self.fg_warehouse,
+			"from_warehouse": "",
+			"qty": self.qty_to_manufacture,
+			"item_name": item.item_name,
+			"description": item.description,
+			"stock_uom": item.stock_uom,
+			"expense_account": item.get("expense_account"),
+			"cost_center": item.get("buying_cost_center"),
+			"is_finished_item": 1,
+		}
+
+		self.stock_entry.add_to_stock_entry_detail({self.production_item: args}, bom_no=self.bom_no)

--- a/erpnext/subcontracting/doctype/subcontracting_bom/subcontracting_bom.py
+++ b/erpnext/subcontracting/doctype/subcontracting_bom/subcontracting_bom.py
@@ -99,7 +99,7 @@ def get_subcontracting_boms_for_finished_goods(fg_items: str | list) -> dict:
 			else:
 				return subcontracting_boms[0]
 
-	return {}
+	return frappe._dict({})
 
 
 @frappe.whitelist()

--- a/erpnext/subcontracting/doctype/subcontracting_order_item/subcontracting_order_item.json
+++ b/erpnext/subcontracting/doctype/subcontracting_order_item/subcontracting_order_item.json
@@ -49,6 +49,9 @@
   "cost_center",
   "dimension_col_break",
   "project",
+  "references_section",
+  "job_card",
+  "column_break_nfod",
   "section_break_34",
   "purchase_order_item",
   "page_break"
@@ -378,13 +381,29 @@
    "no_copy": 1,
    "read_only": 1,
    "search_index": 1
+  },
+  {
+   "fieldname": "references_section",
+   "fieldtype": "Section Break",
+   "label": "References"
+  },
+  {
+   "fieldname": "job_card",
+   "fieldtype": "Link",
+   "label": "Job Card",
+   "options": "Job Card",
+   "read_only": 1
+  },
+  {
+   "fieldname": "column_break_nfod",
+   "fieldtype": "Column Break"
   }
  ],
  "idx": 1,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:46.343298",
+ "modified": "2024-03-27 13:12:46.343298",
  "modified_by": "Administrator",
  "module": "Subcontracting",
  "name": "Subcontracting Order Item",

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
@@ -3,8 +3,8 @@
 
 import frappe
 from frappe import _
-from frappe.query_builder.functions import Sum
 from frappe.model.mapper import get_mapped_doc
+from frappe.query_builder.functions import Sum
 from frappe.utils import cint, flt, get_link_to_form, getdate, nowdate
 
 import erpnext

--- a/erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt_item/subcontracting_receipt_item.json
@@ -39,6 +39,7 @@
   "subcontracting_order",
   "subcontracting_order_item",
   "subcontracting_receipt_item",
+  "job_card",
   "column_break_40",
   "rejected_warehouse",
   "bom",
@@ -577,12 +578,20 @@
    "fieldname": "add_serial_batch_for_rejected_qty",
    "fieldtype": "Button",
    "label": "Add Serial / Batch No (Rejected Qty)"
+  },
+  {
+   "fieldname": "job_card",
+   "fieldtype": "Link",
+   "label": "Job Card",
+   "options": "Job Card",
+   "read_only": 1,
+   "search_index": 1
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-29 15:42:43.425544",
+ "modified": "2024-03-29 15:43:43.425544",
  "modified_by": "Administrator",
  "module": "Subcontracting",
  "name": "Subcontracting Receipt Item",


### PR DESCRIPTION
This feature will map operations with Semi-Finished Goods / Finished Goods. With this feature, users will have the option to consume raw materials and add Semi-Finished Goods / Finished Goods against the job card (operations). Additionally, this functionality will address cases where some operations are subcontracted, and users want to track Semi-Finished Goods. The feature will provide provisions to create subcontracting orders against the job card.

Example:
    To Make Bicycle we need 5 operations
    1) Brake Making -> (Brake Assembly)
    2) Wheel Making -> (Wheel Assembly)
    3) Seat Making -> (Seat Assembly)
    4) Frame Making -> (Frame Assembly)
    5) Assembly -> (Bicycle)

If seat making is a subcontracted operation, the system will provide a provision to create a subcontracting order against the seat making job card. The first four operations will produce the semi-finished goods, while the last operation will produce the final product.

### Provision to Configure Semi-finished Goods and their respective BOM against Operations

<img width="1310" alt="Screenshot 2023-11-25 at 5 12 31 PM" src="https://github.com/frappe/erpnext/assets/8780500/0b57f486-33e8-4380-b0ad-f57fb8394a0a">


###  Provision to add Operation in the BOM Creator

<img width="1223" alt="Screenshot 2023-11-25 at 5 15 04 PM" src="https://github.com/frappe/erpnext/assets/8780500/03448218-c28b-4358-9610-aa1f55bdefaa">

###  Provision to make Subcontracting PO against the JOB Card

<img width="1305" alt="image" src="https://github.com/frappe/erpnext/assets/8780500/4a05dfa7-1c10-4674-ae35-730069308f13">

###  Provision to Consume Raw Materials and add Semi-finished Goods / Finished Goods against the Job Card
![complete_job_card](https://github.com/frappe/erpnext/assets/8780500/91854a99-d97b-48a2-92ad-18508248f44f)


Docs https://docs.erpnext.com/docs/user/manual/en/track-semi-finished-goods
