### PR TITLE
fix: make parameters of `create_subscription_process` optional (and other minor fixes)

### DIFF
--- a/erpnext/accounts/doctype/process_subscription/process_subscription.py
+++ b/erpnext/accounts/doctype/process_subscription/process_subscription.py
@@ -17,11 +17,10 @@ class ProcessSubscription(Document):
 
 
 def create_subscription_process(
-	subscription: str | None, posting_date: Union[str, datetime.date] | None
+	subscription: str | None = None, posting_date: Union[str, datetime.date] | None = None
 ):
 	"""Create a new Process Subscription document"""
 	doc = frappe.new_doc("Process Subscription")
 	doc.subscription = subscription
 	doc.posting_date = getdate(posting_date)
-	doc.insert(ignore_permissions=True)
 	doc.submit()

--- a/erpnext/accounts/doctype/subscription/subscription.py
+++ b/erpnext/accounts/doctype/subscription/subscription.py
@@ -676,7 +676,7 @@ def get_prorata_factor(
 
 
 def process_all(
-	subscription: str | None, posting_date: Optional["DateTimeLikeObject"] = None
+	subscription: str | None = None, posting_date: Optional["DateTimeLikeObject"] = None
 ) -> None:
 	"""
 	Task to updates the status of all `Subscription` apart from those that are cancelled

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -419,7 +419,6 @@ scheduler_events = {
 		"erpnext.projects.doctype.project.project.collect_project_status",
 	],
 	"hourly_long": [
-		"erpnext.accounts.doctype.process_subscription.process_subscription.create_subscription_process",
 		"erpnext.stock.doctype.repost_item_valuation.repost_item_valuation.repost_entries",
 		"erpnext.utilities.bulk_transaction.retry",
 	],
@@ -450,6 +449,7 @@ scheduler_events = {
 		"erpnext.accounts.utils.auto_create_exchange_rate_revaluation_weekly",
 	],
 	"daily_long": [
+		"erpnext.accounts.doctype.process_subscription.process_subscription.create_subscription_process",
 		"erpnext.setup.doctype.email_digest.email_digest.send",
 		"erpnext.manufacturing.doctype.bom_update_tool.bom_update_tool.auto_update_latest_price_in_all_boms",
 		"erpnext.crm.utils.open_leads_opportunities_based_on_todays_event",


### PR DESCRIPTION
Issue originated in https://github.com/frappe/erpnext/pull/37126
Closes https://github.com/frappe/erpnext/issues/38219

### Changes Made

- make parameters of `create_subscription_process` and `process_all` optional
- perf: remove unnecessary call to `doc.insert` (taken care of by subsequent call to `doc.submit`). also `ignore_permissions` isn't required because this function is currently only called via `scheduler_events` where Administrator has the relevant permissions already.
- move event to `daily_long` from `hourly_long` - it was previously kept in `hourly_long` for redundancy, but user can create a **Process Subscription** manually now