### PR TITLE
feat:add customer group filter in sales register

### DIFF
--- a/erpnext/accounts/report/sales_register/sales_register.js
+++ b/erpnext/accounts/report/sales_register/sales_register.js
@@ -23,6 +23,12 @@ frappe.query_reports["Sales Register"] = {
 			"options": "Customer"
 		},
 		{
+			"fieldname":"customer_group",
+			"label": __("Customer Group"),
+			"fieldtype": "Link",
+			"options": "Customer Group"
+		},
+		{
 			"fieldname":"company",
 			"label": __("Company"),
 			"fieldtype": "Link",

--- a/erpnext/accounts/report/sales_register/sales_register.py
+++ b/erpnext/accounts/report/sales_register/sales_register.py
@@ -449,6 +449,9 @@ def get_invoices(filters, additional_query_columns):
 	if filters.get("customer"):
 		query = query.where(si.customer == filters.customer)
 
+	if filters.get("customer_group"):
+		query = query.where(si.customer_group == filters.customer_group)
+
 	query = get_conditions(filters, query, "Sales Invoice")
 	query = apply_common_conditions(
 		filters, query, doctype="Sales Invoice", child_doctype="Sales Invoice Item"


### PR DESCRIPTION
Add Customer Group on Sales Register reports [#36200](tg://search_hashtag?hashtag=36200)

Before Add customer Group Filter
![Screenshot from 2023-11-27 20-18-27](https://github.com/frappe/erpnext/assets/95607404/8724a2c5-9b11-43a4-93a8-12d7bbdfb40f)
After Add customer Group Filter In Sales Register
[Screencast from 27-11-23 08:17:09 PM IST.webm](https://github.com/frappe/erpnext/assets/95607404/2047cdb6-079b-4dce-97db-9a5c3bd75d2e)




