### PR TITLE
feat: Allow regionnal overrides for making gl_entries

### DIFF
--- a/erpnext/accounts/general_ledger.py
+++ b/erpnext/accounts/general_ledger.py
@@ -17,7 +17,7 @@ from erpnext.accounts.doctype.accounting_period.accounting_period import ClosedA
 from erpnext.accounts.doctype.budget.budget import validate_expense_against_budget
 from erpnext.accounts.utils import create_payment_ledger_entry
 
-
+@erpnext.allow_regional
 def make_gl_entries(
 	gl_map,
 	cancel=False,
@@ -559,7 +559,7 @@ def get_round_off_account_and_cost_center(
 
 	return round_off_account, round_off_cost_center
 
-
+@erpnext.allow_regional
 def make_reverse_gl_entries(
 	gl_entries=None,
 	voucher_type=None,


### PR DESCRIPTION
In erpnext_france module some regionalizations are made to gl_entry, so the tag must be added to customize these functions.

Please backport it in version-14 if it is possible. 

 