### PR TITLE
fix: SO ordered qty on PO item removal

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -484,6 +484,20 @@ class PurchaseOrder(BuyingController):
 
 		return result
 
+	def update_ordered_qty_in_so_for_removed_items(self, removed_items):
+		"""
+		Updates ordered_qty in linked SO when item rows are removed using Update Items
+		"""
+		if not self.is_against_so():
+			return
+		for item in removed_items:
+			prev_ordered_qty = frappe.db.get_value(
+				"Sales Order Item", item.get("sales_order_item"), "ordered_qty"
+			)
+			frappe.db.set_value(
+				"Sales Order Item", item.get("sales_order_item"), "ordered_qty", prev_ordered_qty - item.qty
+			)
+
 
 def item_last_purchase_rate(name, conversion_rate, item_code, conversion_factor=1.0):
 	"""get last purchase rate for an item"""

--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -491,7 +491,7 @@ class PurchaseOrder(BuyingController):
 		if not self.is_against_so():
 			return
 		for item in removed_items:
-			prev_ordered_qty = frappe.db.get_value(
+			prev_ordered_qty = frappe.get_cached_value(
 				"Sales Order Item", item.get("sales_order_item"), "ordered_qty"
 			)
 			frappe.db.set_value(

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2958,6 +2958,9 @@ def validate_and_delete_children(parent, data) -> bool:
 		d.cancel()
 		d.delete()
 
+	if parent.doctype == "Purchase Order":
+		parent.update_ordered_qty_in_so_for_removed_items(deleted_children)
+
 	# need to update ordered qty in Material Request first
 	# bin uses Material Request Items to recalculate & update
 	parent.update_prevdoc_status()


### PR DESCRIPTION
**Bug**
When a PO is submitted against a SO, the `ordered_qty` gets updated for each item in the SO. However, if items are removed from an already submitted PO using **Update Items**, the `ordered_qty` is not reduced from the linked SO. This causes the system to throw an error with the message " _**Purchase Order already created for all Sales Order items**_ " and a new PO with the removed item cannot be created.


**Fix**
When items are updated in the PO, reduce the ordered quantity for all deleted rows.