### PR TITLE
fix: no fstring in translation

### DIFF
--- a/erpnext/stock/report/stock_and_account_value_comparison/stock_and_account_value_comparison.py
+++ b/erpnext/stock/report/stock_and_account_value_comparison/stock_and_account_value_comparison.py
@@ -166,4 +166,4 @@ def create_reposting_entries(rows, company):
 
 	if entries:
 		entries = ", ".join(entries)
-		frappe.msgprint(_(f"Reposting entries created: {entries}"))
+		frappe.msgprint(_("Reposting entries created: {0}").format(entries))


### PR DESCRIPTION
Using f-strings in translations (1) doesn't translate and (2) breaks translatable string extraction.