### PR TITLE
fix: currency symbol in payment rec allocations

### DIFF
--- a/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/payment_reconciliation.py
@@ -295,6 +295,7 @@ class PaymentReconciliation(Document):
 				"amount": pay.get("amount"),
 				"allocated_amount": allocated_amount,
 				"difference_amount": pay.get("difference_amount"),
+				"currency": inv.get("currency"),
 			}
 		)
 

--- a/erpnext/accounts/doctype/payment_reconciliation_allocation/payment_reconciliation_allocation.json
+++ b/erpnext/accounts/doctype/payment_reconciliation_allocation/payment_reconciliation_allocation.json
@@ -65,7 +65,7 @@
    "fieldtype": "Currency",
    "in_list_view": 1,
    "label": "Difference Amount",
-   "options": "currency",
+   "options": "Currency",
    "read_only": 1
   },
   {
@@ -141,7 +141,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2023-11-28 15:50:42.336096",
+ "modified": "2023-11-28 16:30:43.344612",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Reconciliation Allocation",

--- a/erpnext/accounts/doctype/payment_reconciliation_allocation/payment_reconciliation_allocation.json
+++ b/erpnext/accounts/doctype/payment_reconciliation_allocation/payment_reconciliation_allocation.json
@@ -20,7 +20,8 @@
   "section_break_5",
   "difference_amount",
   "column_break_7",
-  "difference_account"
+  "difference_account",
+  "currency"
  ],
  "fields": [
   {
@@ -37,7 +38,7 @@
    "fieldtype": "Currency",
    "in_list_view": 1,
    "label": "Allocated Amount",
-   "options": "Currency",
+   "options": "currency",
    "reqd": 1
   },
   {
@@ -64,7 +65,7 @@
    "fieldtype": "Currency",
    "in_list_view": 1,
    "label": "Difference Amount",
-   "options": "Currency",
+   "options": "currency",
    "read_only": 1
   },
   {
@@ -112,7 +113,7 @@
    "fieldtype": "Currency",
    "hidden": 1,
    "label": "Unreconciled Amount",
-   "options": "Currency",
+   "options": "currency",
    "read_only": 1
   },
   {
@@ -120,7 +121,7 @@
    "fieldtype": "Currency",
    "hidden": 1,
    "label": "Amount",
-   "options": "Currency",
+   "options": "currency",
    "read_only": 1
   },
   {
@@ -129,11 +130,17 @@
    "hidden": 1,
    "label": "Reference Row",
    "read_only": 1
+  },
+  {
+   "fieldname": "currency",
+   "fieldtype": "Link",
+   "label": "Currency",
+   "options": "Currency"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2021-10-06 11:48:59.616562",
+ "modified": "2023-11-28 15:37:42.336096",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Reconciliation Allocation",

--- a/erpnext/accounts/doctype/payment_reconciliation_allocation/payment_reconciliation_allocation.json
+++ b/erpnext/accounts/doctype/payment_reconciliation_allocation/payment_reconciliation_allocation.json
@@ -134,13 +134,14 @@
   {
    "fieldname": "currency",
    "fieldtype": "Link",
+   "hidden": 1,
    "label": "Currency",
    "options": "Currency"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2023-11-28 15:37:42.336096",
+ "modified": "2023-11-28 15:50:42.336096",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Reconciliation Allocation",


### PR DESCRIPTION
**Bug**
Since Payment Reconciliation Allocation table does not have a Currency column, all the amounts shown inside rows use the default currency for the session. However, for vouchers made in another currency, the voucher currency should be used for the symbols.

**Fix**
Added a hidden currency column to show correct symbols for the allocated entries.