### PR TITLE
fix: incorrect ordered qty for Subcontracting Order

### DIFF
--- a/erpnext/controllers/tests/test_subcontracting_controller.py
+++ b/erpnext/controllers/tests/test_subcontracting_controller.py
@@ -1001,6 +1001,7 @@ def make_subcontracted_items():
 		"Subcontracted Item SA5": {},
 		"Subcontracted Item SA6": {},
 		"Subcontracted Item SA7": {},
+		"Subcontracted Item SA8": {},
 	}
 
 	for item, properties in sub_contracted_items.items():
@@ -1020,6 +1021,7 @@ def make_raw_materials():
 		},
 		"Subcontracted SRM Item 4": {"has_serial_no": 1, "serial_no_series": "SRII.####"},
 		"Subcontracted SRM Item 5": {"has_serial_no": 1, "serial_no_series": "SRIID.####"},
+		"Subcontracted SRM Item 8": {},
 	}
 
 	for item, properties in raw_materials.items():
@@ -1043,6 +1045,7 @@ def make_service_items():
 		"Subcontracted Service Item 5": {},
 		"Subcontracted Service Item 6": {},
 		"Subcontracted Service Item 7": {},
+		"Subcontracted Service Item 8": {},
 	}
 
 	for item, properties in service_items.items():
@@ -1066,6 +1069,7 @@ def make_bom_for_subcontracted_items():
 		"Subcontracted Item SA5": ["Subcontracted SRM Item 5"],
 		"Subcontracted Item SA6": ["Subcontracted SRM Item 3"],
 		"Subcontracted Item SA7": ["Subcontracted SRM Item 1"],
+		"Subcontracted Item SA8": ["Subcontracted SRM Item 8"],
 	}
 
 	for item_code, raw_materials in boms.items():

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
@@ -95,12 +95,12 @@ class SubcontractingReceipt(SubcontractingController):
 		)
 		self.update_status_updater_args()
 		self.update_prevdoc_status()
-		self.update_stock_ledger()
-		self.make_gl_entries_on_cancel()
-		self.repost_future_sle_and_gle()
 		self.delete_auto_created_batches()
 		self.set_consumed_qty_in_subcontract_order()
 		self.set_subcontracting_order_status()
+		self.update_stock_ledger()
+		self.make_gl_entries_on_cancel()
+		self.repost_future_sle_and_gle()
 		self.update_status()
 
 	def validate_items_qty(self):


### PR DESCRIPTION
**Issue**

1. Create subcontracting order and check the BIN for the Finished Good
2. System has not set "Ordered Qty" in the Bin for the Finished Good