### PR TITLE
add supplier group filter in purchase register

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.json
@@ -189,6 +189,7 @@
   "additional_info_section",
   "is_internal_supplier",
   "represents_company",
+  "supplier_group",
   "column_break_147",
   "inter_company_invoice_reference",
   "is_old_subcontracting_flow",
@@ -1598,13 +1599,20 @@
    "fieldtype": "Check",
    "label": "Use Transaction Date Exchange Rate",
    "read_only": 1
+  },
+  {
+   "fetch_from": "supplier.supplier_group",
+   "fieldname": "supplier_group",
+   "fieldtype": "Link",
+   "label": "Supplier Group",
+   "options": "Supplier Group"
   }
  ],
  "icon": "fa fa-file-text",
  "idx": 204,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-11-03 15:47:30.319200",
+ "modified": "2023-11-29 15:35:44.697496",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Purchase Invoice",

--- a/erpnext/accounts/report/purchase_register/purchase_register.js
+++ b/erpnext/accounts/report/purchase_register/purchase_register.js
@@ -23,6 +23,12 @@ frappe.query_reports["Purchase Register"] = {
 			"options": "Supplier"
 		},
 		{
+			"fieldname":"supplier_group",
+			"label": __("Supplier"),
+			"fieldtype": "Link",
+			"options": "Supplier Group"
+		},
+		{
 			"fieldname":"company",
 			"label": __("Company"),
 			"fieldtype": "Link",

--- a/erpnext/accounts/report/purchase_register/purchase_register.js
+++ b/erpnext/accounts/report/purchase_register/purchase_register.js
@@ -24,7 +24,7 @@ frappe.query_reports["Purchase Register"] = {
 		},
 		{
 			"fieldname":"supplier_group",
-			"label": __("Supplier"),
+			"label": __("Supplier Group"),
 			"fieldtype": "Link",
 			"options": "Supplier Group"
 		},

--- a/erpnext/accounts/report/purchase_register/purchase_register.py
+++ b/erpnext/accounts/report/purchase_register/purchase_register.py
@@ -407,6 +407,8 @@ def get_invoices(filters, additional_query_columns):
 
 	if filters.get("supplier"):
 		query = query.where(pi.supplier == filters.supplier)
+	if filters.get("supplier_group"):
+		query = query.where(pi.supplier_group == filters.supplier_group)
 
 	query = get_conditions(filters, query, "Purchase Invoice")
 


### PR DESCRIPTION
Add Supplier Group Filter on Purchase Register [#36200](tg://search_hashtag?hashtag=36200)

Before Add Supplier Group Filter
![Screenshot from 2023-11-29 15-45-55](https://github.com/frappe/erpnext/assets/95607404/92daad24-bd80-4b16-a6a9-3d6d79fc51d3)

After Add Supplier Group Filter
[Uploading Screencast from 29-11-23 03:44:16 PM IST.webm…]()
