### PR TITLE
feat: Purchase Register Report Supplier Group filter Adding

### DIFF
--- a/erpnext/accounts/report/purchase_register/purchase_register.js
+++ b/erpnext/accounts/report/purchase_register/purchase_register.js
@@ -23,6 +23,12 @@ frappe.query_reports["Purchase Register"] = {
 			"options": "Supplier"
 		},
 		{
+			"fieldname":"supplier_group",
+			"label": __("Supplier Group"),
+			"fieldtype": "Link",
+			"options": "Supplier Group"
+		},
+		{
 			"fieldname":"company",
 			"label": __("Company"),
 			"fieldtype": "Link",

--- a/erpnext/accounts/report/purchase_register/purchase_register.py
+++ b/erpnext/accounts/report/purchase_register/purchase_register.py
@@ -72,6 +72,9 @@ def _execute(filters=None, additional_table_columns=None):
 
 	data = []
 	for inv in invoice_list:
+		if filters.get("supplier_group"):
+			if filters.get("supplier_group") != supplier_details.get(inv.supplier).get("supplier_group"):
+				continue
 		# invoice details
 		purchase_order = list(set(invoice_po_pr_map.get(inv.name, {}).get("purchase_order", [])))
 		purchase_receipt = list(set(invoice_po_pr_map.get(inv.name, {}).get("purchase_receipt", [])))


### PR DESCRIPTION
Adding Supplier Group in Purchase Register
Issue: #36200 
Before Filter Adding:
![before_supplier_group_filter](https://github.com/frappe/erpnext/assets/101092028/94187e72-f2ea-4f1d-b3a3-f50d719dca7b)

After Adding Supplier Group Filter In Purchase Register Report
[purchase_register_suppliergroup.webm](https://github.com/frappe/erpnext/assets/101092028/6fda7012-2f6d-452a-8b7e-164f7faa8873)
