### PR TITLE
fix(minor): set capital WIP account before asset tests

### DIFF
--- a/erpnext/assets/doctype/asset_value_adjustment/test_asset_value_adjustment.py
+++ b/erpnext/assets/doctype/asset_value_adjustment/test_asset_value_adjustment.py
@@ -18,6 +18,9 @@ from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import make_pu
 class TestAssetValueAdjustment(unittest.TestCase):
 	def setUp(self):
 		create_asset_data()
+		frappe.db.set_value(
+			"Company", "_Test Company", "capital_work_in_progress_account", "CWIP Account - _TC"
+		)
 
 	def test_current_asset_value(self):
 		pr = make_purchase_receipt(


### PR DESCRIPTION
Fixes failing Asset Value Adjustment tests.