### PR TITLE
fix: incorrectly treating normal payment as advance

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -104,9 +104,17 @@ class PaymentEntry(AccountsController):
 		self.set_status()
 
 	def set_liability_account(self):
-		if not self.book_advance_payments_in_separate_party_account:
+		# Auto setting liability account should only be done during 'draft' status
+		if self.docstatus > 0:
 			return
 
+		if not frappe.db.get_value(
+			"Company", self.company, "book_advance_payments_in_separate_party_account"
+		):
+			return
+
+		# Important to set this flag for the gl building logic to work properly
+		self.book_advance_payments_in_separate_party_account = True
 		account_type = frappe.get_value(
 			"Account", {"name": self.party_account, "company": self.company}, "account_type"
 		)
@@ -116,11 +124,13 @@ class PaymentEntry(AccountsController):
 		):
 			return
 
-		if self.unallocated_amount == 0:
-			for d in self.references:
-				if d.reference_doctype in ["Sales Order", "Purchase Order"]:
-					break
-			else:
+		if self.references:
+			allowed_types = frozenset(["Sales Order", "Purchase Order"])
+			reference_types = set([x.reference_doctype for x in self.references])
+
+			# If there are referencers other than `allowed_types`, treat this as a normal payment entry
+			if reference_types - allowed_types:
+				self.book_advance_payments_in_separate_party_account = False
 				return
 
 		liability_account = get_party_account(


### PR DESCRIPTION
With `book_advance_payments_in_separate_party_account` enabled in company master, making full payment against an invoice, posts duplicate ledger entries that causes confusion.

This happens as the logic to handle moving amount from Liability account to a normal Debtors/Creditors account incorrectly Debit's and Credit's the same account due to this flag `book_advance_payments_in_separate_party_account`.
<img width="1552" alt="Screenshot 2023-11-30 at 11 20 55 AM" src="https://github.com/frappe/erpnext/assets/3272205/ea1251f2-64ad-46e7-807f-47015971d114">

