### PR TITLE
fix(pe): show split alert only on splitting

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -1698,12 +1698,13 @@ def split_invoices_based_on_payment_terms(outstanding_invoices, company) -> list
 				if not split_rows:
 					continue
 
-				frappe.msgprint(
-					_("Splitting {0} {1} into {2} rows as per Payment Terms").format(
-						_(entry.voucher_type), frappe.bold(entry.voucher_no), len(split_rows)
-					),
-					alert=True,
-				)
+				if len(split_rows) > 1:
+					frappe.msgprint(
+						_("Splitting {0} {1} into {2} rows as per Payment Terms").format(
+							_(entry.voucher_type), frappe.bold(entry.voucher_no), len(split_rows)
+						),
+						alert=True,
+					)
 				outstanding_invoices_after_split += split_rows
 				continue
 


### PR DESCRIPTION
Introduced via: https://github.com/frappe/erpnext/pull/37859

Split message pops up even if there is no payment terms wise splitting.