### PR TITLE
refactor: use flt on outstanding on AR/AP summary report

### DIFF
--- a/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py
+++ b/erpnext/accounts/report/accounts_receivable_summary/accounts_receivable_summary.py
@@ -8,7 +8,7 @@ from frappe.utils import cint, flt
 
 from erpnext.accounts.party import get_partywise_advanced_payment_amount
 from erpnext.accounts.report.accounts_receivable.accounts_receivable import ReceivablePayableReport
-from erpnext.accounts.utils import get_party_types_from_account_type
+from erpnext.accounts.utils import get_currency_precision, get_party_types_from_account_type
 
 
 def execute(filters=None):
@@ -34,6 +34,7 @@ class AccountsReceivableSummary(ReceivablePayableReport):
 	def get_data(self, args):
 		self.data = []
 		self.receivables = ReceivablePayableReport(self.filters).run(args)[1]
+		self.currency_precision = get_currency_precision() or 2
 
 		self.get_party_total(args)
 
@@ -57,7 +58,7 @@ class AccountsReceivableSummary(ReceivablePayableReport):
 			gl_balance_map = get_gl_balance(self.filters.report_date, self.filters.company)
 
 		for party, party_dict in self.party_total.items():
-			if party_dict.outstanding == 0:
+			if flt(party_dict.outstanding, self.currency_precision) == 0:
 				continue
 
 			row = frappe._dict()


### PR DESCRIPTION
Prevent parties without outstanding from being reported due to rounding loss.