### PR TITLE
fix: incorrect customer outstanding amount

### DIFF
--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -587,7 +587,8 @@ def get_customer_outstanding(
 		"""
 		select sum(debit) - sum(credit)
 		from `tabGL Entry` where party_type = 'Customer'
-		and party = %s and company=%s {0}""".format(
+  		and is_cancelled = 0 and party = %s 
+		and company=%s {0}""".format(
 			cond
 		),
 		(customer, company),

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -587,7 +587,7 @@ def get_customer_outstanding(
 		"""
 		select sum(debit) - sum(credit)
 		from `tabGL Entry` where party_type = 'Customer'
-  		and is_cancelled = 0 and party = %s 
+		and is_cancelled = 0 and party = %s
 		and company=%s {0}""".format(
 			cond
 		),


### PR DESCRIPTION
This function previously added canceled GL Entries, resulting in incorrect calculations within the Customer Credit Balance Report.


`no-docs`