### PR TITLE
feat: add employee number to client user bootinfo

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -637,6 +637,7 @@ additional_timeline_content = {
 
 extend_bootinfo = [
 	"erpnext.support.doctype.service_level_agreement.service_level_agreement.add_sla_doctypes",
+	"erpnext.startup.boot.bootinfo",
 ]
 
 

--- a/erpnext/startup/boot.py
+++ b/erpnext/startup/boot.py
@@ -75,3 +75,11 @@ def update_page_info(bootinfo):
 			"Sales Person Tree": {"title": "Sales Person Tree", "route": "Tree/Sales Person"},
 		}
 	)
+
+
+def bootinfo(bootinfo):
+	if bootinfo.get("user") and bootinfo["user"].get("name"):
+		bootinfo["user"]["employee"] = ""
+		employee = frappe.db.get_value("Employee", {"user_id": bootinfo["user"]["name"]}, "name", cache=True)
+		if employee:
+			bootinfo["user"]["employee"] = employee


### PR DESCRIPTION
Adding the employee name to bootinfo is useful for building HR-related personal workspaces

![Screen Shot 2023-11-30 at 17 57 10](https://github.com/frappe/erpnext/assets/110036763/13882105-21d8-4fe2-9e1f-8f134d21437b)

no-docs