### PR TITLE
fix: show item name as title instead of item group in BOM

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -1395,7 +1395,7 @@ def item_query(doctype, txt, searchfield, start, page_len, filters):
 
 	order_by = "idx desc, name, item_name"
 
-	fields = ["name", "item_group", "item_name", "description"]
+	fields = ["name", "item_name", "item_group", "description"]
 	fields.extend(
 		[field for field in searchfields if not field in ["name", "item_group", "description"]]
 	)


### PR DESCRIPTION
Fixes: #36224

Item fields in BOM used to show Item Group when Items were set to `Show Title in Link Fields`. Now they show Item Name instead.

Point to note: This change doesn't respect the actual field set to be shown as title in Item, but neither did the old version. However, none of the Item fields in SO, SI, PO and PI (and possibly other places) respect that setting, so this PR just makes the behaviour of Item fields in BOM consistent with other Doctypes. 
Also, I've tested this on my system and it works, but since I stumbled upon this through trial and error, I don't actually know why it works. Please review with that in mind.