### PR TITLE
fix: `AttributeError` while saving Purchase Invoice

### DIFF
--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -440,7 +440,7 @@ class BuyingController(SubcontractingController):
 
 				if allow_to_edit_stock_qty:
 					d.stock_qty = flt(d.stock_qty, d.precision("stock_qty"))
-					if d.get("received_stock_qty"):
+					if d.get("received_stock_qty") and d.meta.get_field("received_stock_qty"):
 						d.received_stock_qty = flt(d.received_stock_qty, d.precision("received_stock_qty"))
 
 	def validate_purchase_return(self):


### PR DESCRIPTION
Although the Purchase Invoice Item doesn't have the `received_stock_qty` field but set via [this](https://github.com/frappe/erpnext/blob/3a66aefd2c6aedc1b7b6017c174261c1ed4c2907/erpnext/public/js/controllers/buying.js#L185-L196) function on the form causing the issue.

closes: https://github.com/frappe/erpnext/issues/38476

