### PR TITLE
fix: don't update previous doc on rate change

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -3248,7 +3248,10 @@ def update_child_qty_rate(parent_doctype, trans_items, parent_doctype_name, chil
 
 	if parent_doctype == "Purchase Order":
 		update_last_purchase_rate(parent, is_submit=1)
-		parent.update_prevdoc_status()
+
+		if any_qty_changed or items_added_or_removed or any_conversion_factor_changed:
+			parent.update_prevdoc_status()
+
 		parent.update_requested_qty()
 		parent.update_ordered_qty()
 		parent.update_ordered_and_reserved_qty()


### PR DESCRIPTION
**Internal Ref:** 6325

**Steps to Replicate:**
- Set `Over Delivery/Receipt Allowance (%)` to 100 in `Stock Settings`.
- Create a Sales Order for 10 Qty.
- Create a Sales Order -> Purchase Order for 15 Qty.
- Reset the `Over Delivery/Receipt Allowance (%)` to 0.
- Try to update the Rate of Purchase Order Item via `Update Items`. 

https://github.com/frappe/erpnext/assets/63660334/6a5c69b6-8d02-45ec-9fff-e8cceaf586a5


