### PR TITLE
fix: Group By in Item-wise Purchase Register

### DIFF
--- a/erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py
+++ b/erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py
@@ -318,7 +318,7 @@ def get_items(filters, additional_query_columns):
 			`tabPurchase Invoice`.posting_date, `tabPurchase Invoice`.credit_to, `tabPurchase Invoice`.company,
 			`tabPurchase Invoice`.supplier, `tabPurchase Invoice`.remarks, `tabPurchase Invoice`.base_net_total,
 			`tabPurchase Invoice`.unrealized_profit_loss_account,
-			`tabPurchase Invoice Item`.`item_code`, `tabPurchase Invoice Item`.description,
+			`tabPurchase Invoice Item`.`item_code`, `tabPurchase Invoice Item`.description, `tabPurchase Invoice Item`.`item_group`,
 			`tabPurchase Invoice Item`.`item_name` as pi_item_name, `tabPurchase Invoice Item`.`item_group` as pi_item_group,
 			`tabItem`.`item_name` as i_item_name, `tabItem`.`item_group` as i_item_group,
 			`tabPurchase Invoice Item`.`project`, `tabPurchase Invoice Item`.`purchase_order`,


### PR DESCRIPTION
**Version:**

ERPNext: v15.4.0 (version-15)
Frappe Framework: v15.3.0 (version-15)
___
**It's also not working in Version-14.**
___

**Before:**

- When selecting Item Grop in Group By then faced an error in Item-wise Purchase Register because in the get_items method, Item Group (`tabPurchase Invoice Item`.`item_group`) is not defined. Reference for checking the Item-wise Sales Register report but it worked properly and also defined the Item Group (`tabSales Invoice Item`.`item_group`).


https://github.com/frappe/erpnext/assets/141945075/191aa0a4-79df-49e3-8313-e8956a54f510

 <br>

**After:**
- After updating the query in the get_items method, the report worked properly. please check it.


https://github.com/frappe/erpnext/assets/141945075/8b1673a3-28c6-4a9a-8a96-21a4b62d0626

<br>

Thank You!