### PR TITLE
fix: set date format from system settings

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -351,5 +351,6 @@ erpnext.patches.v15_0.set_reserved_stock_in_bin
 erpnext.patches.v14_0.create_accounting_dimensions_in_supplier_quotation
 erpnext.patches.v14_0.update_zero_asset_quantity_field
 execute:frappe.db.set_single_value("Buying Settings", "project_update_frequency", "Each Transaction")
+execute:frappe.db.set_default("date_format", frappe.db.get_single_value("System Settings", "date_format"))
 # below migration patch should always run last
 erpnext.patches.v14_0.migrate_gl_to_payment_ledger

--- a/erpnext/setup/install.py
+++ b/erpnext/setup/install.py
@@ -85,8 +85,6 @@ def set_single_defaults():
 			except frappe.ValidationError:
 				pass
 
-	frappe.db.set_default("date_format", "dd-mm-yyyy")
-
 	setup_currency_exchange()
 
 


### PR DESCRIPTION
Same as https://github.com/frappe/hrms/pull/742 and https://github.com/frappe/hrms/pull/745 for instances without HRMS.

This is supposed to solve the following issue I've encountered on multiple sites: date format is "dd-mm-yyyy" and can't be changed via **System Settings**.