### PR TITLE
feat: `Company` filter in `Stock Ledger Variance` report

### DIFF
--- a/erpnext/stock/report/stock_ledger_variance/stock_ledger_variance.js
+++ b/erpnext/stock/report/stock_ledger_variance/stock_ledger_variance.js
@@ -14,9 +14,17 @@ const DIFFERENCE_FIELD_NAMES = [
 frappe.query_reports["Stock Ledger Variance"] = {
 	"filters": [
 		{
+			"fieldname": "company",
+			"label": __("Company"),
+			"fieldtype": "Link",
+			"options": "Company",
+			"reqd": 1,
+			"default": frappe.defaults.get_user_default("Company")
+		},
+		{
 			"fieldname": "item_code",
 			"fieldtype": "Link",
-			"label": "Item",
+			"label": __("Item"),
 			"options": "Item",
 			get_query: function() {
 				return {
@@ -27,7 +35,7 @@ frappe.query_reports["Stock Ledger Variance"] = {
 		{
 			"fieldname": "warehouse",
 			"fieldtype": "Link",
-			"label": "Warehouse",
+			"label": __("Warehouse"),
 			"options": "Warehouse",
 			get_query: function() {
 				return {
@@ -38,7 +46,7 @@ frappe.query_reports["Stock Ledger Variance"] = {
 		{
 			"fieldname": "difference_in",
 			"fieldtype": "Select",
-			"label": "Difference In",
+			"label": __("Difference In"),
 			"options": [
 				"",
 				"Qty",
@@ -49,7 +57,7 @@ frappe.query_reports["Stock Ledger Variance"] = {
 		{
 			"fieldname": "include_disabled",
 			"fieldtype": "Check",
-			"label": "Include Disabled",
+			"label": __("Include Disabled"),
 		}
 	],
 

--- a/erpnext/stock/report/stock_ledger_variance/stock_ledger_variance.py
+++ b/erpnext/stock/report/stock_ledger_variance/stock_ledger_variance.py
@@ -230,7 +230,12 @@ def get_item_warehouse_combinations(filters: dict = None) -> dict:
 			bin.item_code,
 			bin.warehouse,
 		)
-		.where((item.is_stock_item == 1) & (item.has_serial_no == 0) & (warehouse.is_group == 0))
+		.where(
+			(item.is_stock_item == 1)
+			& (item.has_serial_no == 0)
+			& (warehouse.is_group == 0)
+			& (warehouse.company == filters.company)
+		)
 	)
 
 	if filters.item_code:


### PR DESCRIPTION
**Before:**

![image](https://github.com/frappe/erpnext/assets/63660334/8ec4c465-8571-41ca-91ab-5f62dfd5e84b)

**After:**

![image](https://github.com/frappe/erpnext/assets/63660334/50090ab9-4582-4618-8d35-6e7d35f328f0)

`no-docs`
