### PR TITLE
remove fiscal year validation for supplier invoice no uniqueness

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -1463,7 +1463,6 @@ class PurchaseInvoice(BuyingController):
 
 		if self.bill_no:
 			if cint(frappe.db.get_single_value("Accounts Settings", "check_supplier_invoice_uniqueness")):
-				fiscal_year = get_fiscal_year(self.posting_date, company=self.company, as_dict=True)
 
 				pi = frappe.db.sql(
 					"""select name from `tabPurchase Invoice`
@@ -1477,8 +1476,6 @@ class PurchaseInvoice(BuyingController):
 						"bill_no": self.bill_no,
 						"supplier": self.supplier,
 						"name": self.name,
-						"year_start_date": fiscal_year.year_start_date,
-						"year_end_date": fiscal_year.year_end_date,
 					},
 				)
 


### PR DESCRIPTION
Maintaining unique key on - Supplier + Invoice Number + Invoice Date #36385
Remove Fiscal Year Validation for Supplier Invoice no in Purchase Invoice.Now Chaek all invoices without fiscal year validation.