### PR TITLE
fix(minor): financial statements period end date

### DIFF
--- a/erpnext/accounts/report/financial_statements.py
+++ b/erpnext/accounts/report/financial_statements.py
@@ -8,7 +8,17 @@ import re
 
 import frappe
 from frappe import _
-from frappe.utils import add_days, add_months, cint, cstr, flt, formatdate, get_first_day, getdate
+from frappe.utils import (
+	add_days,
+	add_months,
+	cint,
+	cstr,
+	flt,
+	formatdate,
+	get_first_day,
+	getdate,
+	today,
+)
 
 from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
 	get_accounting_dimensions,
@@ -42,6 +52,8 @@ def get_period_list(
 		validate_dates(period_start_date, period_end_date)
 		year_start_date = getdate(period_start_date)
 		year_end_date = getdate(period_end_date)
+
+	year_end_date = getdate(today()) if year_end_date > getdate(today()) else year_end_date
 
 	months_to_add = {"Yearly": 12, "Half-Yearly": 6, "Quarterly": 3, "Monthly": 1}[periodicity]
 


### PR DESCRIPTION
**Bug** 
In Financial Statement Reports like Profit and Loss Statement, if the records are filtered based on Fiscal year and the periodicity is set to Monthly, Quarterly or Half Yearly, the report shows incorrect values for the months that come after the current date.

**Screenshot**

Current date is in Dec 2023, yet, for Jan - March 2024, values from Dec are added to the totals of the report.
<br>
<img width="1302" alt="Screenshot 2023-12-04 at 4 50 30 PM" src="https://github.com/frappe/erpnext/assets/40693548/7e6d757f-13ac-49b7-87e0-85a6125cbbcb">


<br>
<br>

**Fix**
Check for the period end date and limit it to the current date.
