### PR TITLE
fix: get dynamic link with parenttype contact

### DIFF
--- a/erpnext/crm/doctype/lead/lead.py
+++ b/erpnext/crm/doctype/lead/lead.py
@@ -105,7 +105,7 @@ class Lead(SellingController, CRMNote):
 			if self.source == "Existing Customer" and self.customer:
 				contact = frappe.db.get_value(
 					"Dynamic Link",
-					{"link_doctype": "Customer", "link_name": self.customer},
+					{"link_doctype": "Customer", "parenttype": "Contact", "link_name": self.customer},
 					"parent",
 				)
 				if contact:


### PR DESCRIPTION
Missed in PR: https://github.com/frappe/erpnext/pull/38398