### PR TITLE
fix: sql error while filtering on finance book in GL

### DIFF
--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -289,7 +289,8 @@ def get_conditions(filters):
 
 	if accounting_dimensions:
 		for dimension in accounting_dimensions:
-			if not dimension.disabled:
+			# Ignore 'Finance Book' set up as dimension in below logic, as it is already handled in above section
+			if not dimension.disabled and dimension.document_type != "Finance Book":
 				if filters.get(dimension.fieldname):
 					if frappe.get_cached_value("DocType", dimension.document_type, "is_tree"):
 						filters[dimension.fieldname] = get_dimension_with_children(


### PR DESCRIPTION
On Scenario's where 'Finance Book' is setup as an Accounting Dimension, General Ledger throws SQL error when filtered on Finance Book

### App Versions
```
{
	"erpnext": "16.0.0-dev",
	"frappe": "15.0.0-dev",
	"hrms": "16.0.0-dev",
	"india_compliance": "16.0.0-dev",
	"payments": "0.0.1"
}
```
### Route
```
query-report/General Ledger
```
### Traceback
```
Syntax error in query:
select
			name as gl_entry, posting_date, account, party_type, party,
			voucher_type, voucher_no, branch, finance_book,
			cost_center, project, 
			against_voucher_type, against_voucher, account_currency,
			against, is_opening, creation , debit, credit, debit_in_account_currency,
		credit_in_account_currency 
		from `tabGL Entry`
		where company=%(company)s and voucher_no=%(voucher_no)s and (posting_date >=%(from_date)s or is_opening = 'Yes') and (posting_date <=%(to_date)s or is_opening = 'Yes') and (finance_book in (%(finance_book)s, '') OR finance_book IS NULL) and is_cancelled = 0 and branch in %(branch)s and finance_book in %(finance_book)s
		order by posting_date, creation {'company': 'Lisp 2', 'finance_book': 'EU', 'from_date': '2023-11-05', 'to_date': '2023-12-05', 'account': [], 'voucher_no': 'SINV-23-20618-1', 'party': [], 'group_by': 'Group by Voucher (Consolidated)', 'cost_center': [], 'project': [], 'branch': ['South Wing'], 'include_dimensions': 1, 'show_opening_entries': 1, 'include_default_book_entries': 1, 'company_fb': ''}
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 110, in application
    response = frappe.api.handle(request)
  File "apps/frappe/frappe/api/__init__.py", line 49, in handle
    data = endpoint(**arguments)
  File "apps/frappe/frappe/api/v1.py", line 36, in handle_rpc_call
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 49, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 85, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1678, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/utils/typing_validations.py", line 31, in wrapper
    return func(*args, **kwargs)
  File "apps/frappe/frappe/__init__.py", line 843, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "apps/frappe/frappe/desk/query_report.py", line 221, in run
    result = generate_report_result(report, filters, user, custom_columns, is_tree, parent_field)
  File "apps/frappe/frappe/__init__.py", line 843, in wrapper_fn
    retval = fn(*args, **get_newargs(fn, kwargs))
  File "apps/frappe/frappe/desk/query_report.py", line 81, in generate_report_result
    res = get_report_result(report, filters) or []
  File "apps/frappe/frappe/desk/query_report.py", line 62, in get_report_result
    res = report.execute_script_report(filters)
  File "apps/frappe/frappe/core/doctype/report/report.py", line 164, in execute_script_report
    res = self.execute_module(filters)
  File "apps/frappe/frappe/core/doctype/report/report.py", line 181, in execute_module
    return frappe.get_attr(method_name)(frappe._dict(filters))
  File "apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py", line 49, in execute
    res = get_result(filters, account_details)
  File "apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py", line 152, in get_result
    gl_entries = get_gl_entries(filters, accounting_dimensions)
  File "apps/erpnext/erpnext/accounts/report/general_ledger/general_ledger.py", line 199, in get_gl_entries
    gl_entries = frappe.db.sql(
  File "apps/frappe/frappe/database/database.py", line 217, in sql
    self._cursor.execute(query, values)
  File "env/lib/python3.10/site-packages/pymysql/cursors.py", line 153, in execute
    result = self._query(query)
  File "env/lib/python3.10/site-packages/pymysql/cursors.py", line 322, in _query
    conn.query(q)
  File "env/lib/python3.10/site-packages/pymysql/connections.py", line 558, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
  File "env/lib/python3.10/site-packages/pymysql/connections.py", line 822, in _read_query_result
    result.read()
  File "env/lib/python3.10/site-packages/pymysql/connections.py", line 1200, in read
    first_packet = self.connection._read_packet()
  File "env/lib/python3.10/site-packages/pymysql/connections.py", line 772, in _read_packet
    packet.raise_for_error()
  File "env/lib/python3.10/site-packages/pymysql/protocol.py", line 221, in raise_for_error
    err.raise_mysql_exception(self._data)
  File "env/lib/python3.10/site-packages/pymysql/err.py", line 143, in raise_mysql_exception
    raise errorclass(errno, errval)
pymysql.err.ProgrammingError: (1064, "You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ''EU'\n\t\torder by posting_date, creation' at line 9")

```
### Request Data
```
{
	"type": "GET",
	"args": {
		"report_name": "General Ledger",
		"filters": "{\"company\":\"Lisp 2\",\"finance_book\":\"EU\",\"from_date\":\"2023-11-05\",\"to_date\":\"2023-12-05\",\"account\":[],\"voucher_no\":\"SINV-23-20618-1\",\"party\":[],\"group_by\":\"Group by Voucher (Consolidated)\",\"cost_center\":[],\"project\":[],\"branch\":[\"South Wing\"],\"include_dimensions\":1,\"show_opening_entries\":1,\"include_default_book_entries\":1}",
		"ignore_prepared_report": false,
		"are_default_filters": false
	},
	"headers": {},
	"error_handlers": {},
	"url": "/api/method/frappe.desk.query_report.run",
	"request_id": null
}
```
### Response Data
```
{
	"exception": "pymysql.err.ProgrammingError: (1064, \"You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near ''EU'\\n\\t\\torder by posting_date, creation' at line 9\")",
	"exc_type": "ProgrammingError"
}
```