### PR TITLE
fix: validate finance_books table length in asset

### DIFF
--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -328,10 +328,10 @@ frappe.ui.form.on('Asset', {
 			var is_shift_hence_editable = frm.doc.finance_books.filter(d => d.shift_based).length > 0
 				? true : false;
 
-			frm.toggle_enable("depreciation_schedule", is_manual_hence_editable || is_shift_hence_editable);
-			frm.fields_dict["depreciation_schedule"].grid.toggle_enable("schedule_date", is_manual_hence_editable);
-			frm.fields_dict["depreciation_schedule"].grid.toggle_enable("depreciation_amount", is_manual_hence_editable);
-			frm.fields_dict["depreciation_schedule"].grid.toggle_enable("shift", is_shift_hence_editable);
+			frm.toggle_enable("schedules", is_manual_hence_editable || is_shift_hence_editable);
+			frm.fields_dict["schedules"].grid.toggle_enable("schedule_date", is_manual_hence_editable);
+			frm.fields_dict["schedules"].grid.toggle_enable("depreciation_amount", is_manual_hence_editable);
+			frm.fields_dict["schedules"].grid.toggle_enable("shift", is_shift_hence_editable);
 		}
 	},
 

--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -322,7 +322,7 @@ frappe.ui.form.on('Asset', {
 	},
 
 	make_schedules_editable: function(frm) {
-		if (frm.doc.finance_books) {
+		if (frm.doc.finance_books.length) {
 			var is_manual_hence_editable = frm.doc.finance_books.filter(d => d.depreciation_method == "Manual").length > 0
 				? true : false;
 			var is_shift_hence_editable = frm.doc.finance_books.filter(d => d.shift_based).length > 0


### PR DESCRIPTION
### Information about bug
Manage button in Asset is not showing even after submission.

if condition is getting true even the finance books table is empty. So changed the condition to check length of table.

### Version
Frappe version - v14.57.0 (version-14)
ERPNext version - v14.48.1 (version-14-hotfix)

### Relevant log output
![Screenshot from 2023-12-05 14-08-20](https://github.com/frappe/erpnext/assets/43608142/c613b0f6-d5e6-46e0-be1a-6966efe8fc54)
![image](https://github.com/frappe/erpnext/assets/43608142/6483363d-f4be-411d-950e-185e8d5a018b)
