### PR TITLE
Fix: Asset JS fieldname depreciation_schedule to schedules in make_schedules_editable function.

### DIFF
--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -328,10 +328,10 @@ frappe.ui.form.on('Asset', {
 			var is_shift_hence_editable = frm.doc.finance_books.filter(d => d.shift_based).length > 0
 				? true : false;
 
-			frm.toggle_enable("depreciation_schedule", is_manual_hence_editable || is_shift_hence_editable);
-			frm.fields_dict["depreciation_schedule"].grid.toggle_enable("schedule_date", is_manual_hence_editable);
-			frm.fields_dict["depreciation_schedule"].grid.toggle_enable("depreciation_amount", is_manual_hence_editable);
-			frm.fields_dict["depreciation_schedule"].grid.toggle_enable("shift", is_shift_hence_editable);
+			frm.toggle_enable("schedules", is_manual_hence_editable || is_shift_hence_editable);
+			frm.fields_dict["schedules"].grid.toggle_enable("schedule_date", is_manual_hence_editable);
+			frm.fields_dict["schedules"].grid.toggle_enable("depreciation_amount", is_manual_hence_editable);
+			frm.fields_dict["schedules"].grid.toggle_enable("shift", is_shift_hence_editable);
 		}
 	},
 


### PR DESCRIPTION
Change the depreciation_schedule fieldname to schedules in the make_schedules_editable function.

Close #38582 [v14] Asset JS fieldname depreciation_schedule is undefined
