### PR TITLE
fix: validate finance_books table length in asset

### DIFF
--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -322,7 +322,7 @@ frappe.ui.form.on('Asset', {
 	},
 
 	make_schedules_editable: function(frm) {
-		if (frm.doc.finance_books) {
+		if (frm.doc.finance_books.length) {
 			var is_manual_hence_editable = frm.doc.finance_books.filter(d => d.depreciation_method == "Manual").length > 0
 				? true : false;
 			var is_shift_hence_editable = frm.doc.finance_books.filter(d => d.shift_based).length > 0


### PR DESCRIPTION
### Information about bug
Manage button in Asset is not showing even after submission.

if condition is getting true even the finance books table is empty. So changed the condition to check length of table.

### Version
Frappe version - v14.57.0 (version-14)
ERPNext version - v14.48.1 (version-14-hotfix)