### PR TITLE
fix(ux): don't update qty blindly

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -471,7 +471,6 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 				item.pricing_rules = ''
 				return this.frm.call({
 					method: "erpnext.stock.get_item_details.get_item_details",
-					child: item,
 					args: {
 						doc: me.frm.doc,
 						args: {
@@ -521,6 +520,19 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 					callback: function(r) {
 						if(!r.exc) {
 							frappe.run_serially([
+								() => {
+									var child = locals[cdt][cdn];
+									var std_field_list = ["doctype"]
+										.concat(frappe.model.std_fields_list)
+										.concat(frappe.model.child_table_field_list);
+
+									for (var key in r.message) {
+										if (std_field_list.indexOf(key) === -1) {
+											if (key === "qty" && child[key]) continue;
+											child[key] = r.message[key];
+										}
+									}
+								},
 								() => {
 									var d = locals[cdt][cdn];
 									me.add_taxes_from_item_tax_template(d.item_tax_rate);


### PR DESCRIPTION
**Internal Ref:** 6766

**Issue:** Qty gets reset to 1 ignoring the user's change.

**Before:**

https://github.com/frappe/erpnext/assets/63660334/e38f1d8b-a429-4362-a7c3-27792d7138ea

**After:**

https://github.com/frappe/erpnext/assets/63660334/0d533771-9e7b-41f8-94b6-e687ade01c69



