### PR TITLE
fix: Shipping Address Link Showing in Buying

### DIFF
--- a/erpnext/public/js/controllers/buying.js
+++ b/erpnext/public/js/controllers/buying.js
@@ -36,14 +36,14 @@ erpnext.buying = {
 
 				// no idea where me is coming from
 				if(this.frm.get_field('shipping_address')) {
-					this.frm.set_query("shipping_address", function() {
-						if(me.frm.doc.customer) {
+					this.frm.set_query("shipping_address", () => {
+						if(this.frm.doc.customer) {
 							return {
 								query: 'frappe.contacts.doctype.address.address.address_query',
-								filters: { link_doctype: 'Customer', link_name: me.frm.doc.customer }
+								filters: { link_doctype: 'Customer', link_name: this.frm.doc.customer }
 							};
 						} else
-							return erpnext.queries.company_address_query(me.frm.doc)
+							return erpnext.queries.company_address_query(this.frm.doc)
 					});
 				}
 			}


### PR DESCRIPTION
Shipping Address Link Showing Fixing
Issue : #38617 
Before:
![image](https://github.com/frappe/erpnext/assets/101092028/caa3dd00-91d4-4680-a91c-b3873a640c05)
After:
![image](https://github.com/frappe/erpnext/assets/101092028/6249f94c-71b9-4595-84ca-00fe9885c625)
