### PR TITLE
fix: attribute error

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -572,8 +572,8 @@ def get_item_tax_template(args, item, out):
 			item_tax_template = _get_item_tax_template(args, item_group_doc.taxes, out)
 			item_group = item_group_doc.parent_item_group
 
-	if args.child_doctype and item_tax_template:
-		out.update(get_fetch_values(args.child_doctype, "item_tax_template", item_tax_template))
+	if args.get("child_doctype") and item_tax_template:
+		out.update(get_fetch_values(args.get("child_doctype"), "item_tax_template", item_tax_template))
 
 
 def _get_item_tax_template(args, taxes, out=None, for_validate=False):


### PR DESCRIPTION
Resolves https://github.com/frappe/erpnext/pull/38284/files#r1420408550

`args` can be of type `dict`, so we cannot use dot-notation to access values.

https://github.com/frappe/erpnext/blob/a045916acabc8a1a241b49a4439c58a5379a816a/erpnext/stock/get_item_details.py#L540-L544