### PR TITLE
fix(ux): autofill rate from item price

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -623,6 +623,29 @@ erpnext.utils.update_child_items = function(opts) {
 				query: "erpnext.controllers.queries.item_query",
 				filters: filters
 			};
+		},
+		onchange: function () {
+			const me = this;
+			if (!me.value) return;
+
+			frappe.call({
+				type: "GET",
+				method: "erpnext.stock.get_item_details.get_price_list_rate_for",
+				args: {
+					args: {
+						customer: frm.doc.customer,
+						supplier: frm.doc.supplier,
+						transaction_date: frm.doc.transaction_date,
+						selling_price_list: frm.doc.selling_price_list,
+						buying_price_list: frm.doc.buying_price_list,
+					},
+					item_code: me.value,
+				},
+				callback({message}) {
+					if (!message) return;
+					me.grid_row.on_grid_fields_dict.rate.set_value(message, true);
+				},
+			});
 		}
 	}, {
 		fieldtype:'Link',

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -921,6 +921,7 @@ def get_item_price(args, item_code, ignore_party=False):
 	return query.run()
 
 
+@frappe.whitelist(methods=["GET"])
 def get_price_list_rate_for(args, item_code):
 	"""
 	:param customer: link to Customer DocType
@@ -930,6 +931,8 @@ def get_price_list_rate_for(args, item_code):
 	:param qty: Desired Qty
 	:param transaction_date: Date of the price
 	"""
+	args = process_args(args)
+
 	item_price_args = {
 		"item_code": item_code,
 		"price_list": args.get("price_list"),


### PR DESCRIPTION
Depends on: https://github.com/frappe/frappe/pull/23706

This should apply price rules as well, but I think that is gonna be a bit more difficult. For now, pulling the rate from item price will save the user checking the item price manually.

https://github.com/frappe/erpnext/assets/29856401/26fa9515-100e-4596-84fe-8ec283fbfb2e

