### PR TITLE
refactor: add `get_list` for virtual child doctypes

### DIFF
--- a/erpnext/accounts/doctype/payment_reconciliation_allocation/payment_reconciliation_allocation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation_allocation/payment_reconciliation_allocation.py
@@ -34,4 +34,6 @@ class PaymentReconciliationAllocation(Document):
 		unreconciled_amount: DF.Currency
 	# end: auto-generated types
 
-	pass
+	@staticmethod
+	def get_list(args):
+		pass

--- a/erpnext/accounts/doctype/payment_reconciliation_invoice/payment_reconciliation_invoice.py
+++ b/erpnext/accounts/doctype/payment_reconciliation_invoice/payment_reconciliation_invoice.py
@@ -26,4 +26,6 @@ class PaymentReconciliationInvoice(Document):
 		parenttype: DF.Data
 	# end: auto-generated types
 
-	pass
+	@staticmethod
+	def get_list(args):
+		pass

--- a/erpnext/accounts/doctype/payment_reconciliation_payment/payment_reconciliation_payment.py
+++ b/erpnext/accounts/doctype/payment_reconciliation_payment/payment_reconciliation_payment.py
@@ -30,4 +30,6 @@ class PaymentReconciliationPayment(Document):
 		remark: DF.SmallText | None
 	# end: auto-generated types
 
-	pass
+	@staticmethod
+	def get_list(args):
+		pass


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 110, in application
    response = frappe.api.handle(request)
  File "apps/frappe/frappe/api/__init__.py", line 49, in handle
    data = endpoint(**arguments)
  File "apps/frappe/frappe/api/v1.py", line 36, in handle_rpc_call
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 49, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 85, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1704, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/utils/typing_validations.py", line 31, in wrapper
    return func(*args, **kwargs)
  File "apps/frappe/frappe/desk/form/linked_with.py", line 522, in get
    linked_doctypes = get_linked_doctypes(doctype=doctype)
  File "apps/frappe/frappe/utils/typing_validations.py", line 31, in wrapper
    return func(*args, **kwargs)
  File "apps/frappe/frappe/desk/form/linked_with.py", line 541, in get_linked_doctypes
    return frappe.cache.hget("linked_doctypes", doctype, lambda: _get_linked_doctypes(doctype))
  File "apps/frappe/frappe/utils/redis_wrapper.py", line 237, in hget
    value = generator()
  File "apps/frappe/frappe/desk/form/linked_with.py", line 541, in <lambda>
    return frappe.cache.hget("linked_doctypes", doctype, lambda: _get_linked_doctypes(doctype))
  File "apps/frappe/frappe/desk/form/linked_with.py", line 548, in _get_linked_doctypes
    ret.update(get_dynamic_linked_fields(doctype, without_ignore_user_permissions_enabled))
  File "apps/frappe/frappe/desk/form/linked_with.py", line 644, in get_dynamic_linked_fields
    possible_link = frappe.get_all(
  File "apps/frappe/frappe/__init__.py", line 1995, in get_all
    return get_list(doctype, *args, **kwargs)
  File "apps/frappe/frappe/__init__.py", line 1970, in get_list
    return frappe.model.db_query.DatabaseQuery(doctype).execute(*args, **kwargs)
  File "apps/frappe/frappe/model/db_query.py", line 191, in execute
    return controller.get_list(kwargs)
AttributeError: type object 'PaymentReconciliationPayment' has no attribute 'get_list'
```