### PR TITLE
fix: negative batch issue

### DIFF
--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -1733,6 +1733,45 @@ class TestStockEntry(FrappeTestCase):
 		self.assertFalse(doc.is_enqueue_action())
 		frappe.flags.in_test = True
 
+	def test_negative_batch(self):
+		item_code = "Test Negative Batch Item - 001"
+		make_item(
+			item_code,
+			{"has_batch_no": 1, "create_new_batch": 1, "batch_naming_series": "Test-BCH-NNS.#####"},
+		)
+
+		se1 = make_stock_entry(
+			item_code=item_code,
+			purpose="Material Receipt",
+			qty=100,
+			target="_Test Warehouse - _TC",
+		)
+
+		se1.reload()
+
+		batch_no = get_batch_from_bundle(se1.items[0].serial_and_batch_bundle)
+
+		se2 = make_stock_entry(
+			item_code=item_code,
+			purpose="Material Issue",
+			batch_no=batch_no,
+			qty=10,
+			source="_Test Warehouse - _TC",
+		)
+
+		se2.reload()
+
+		se3 = make_stock_entry(
+			item_code=item_code,
+			purpose="Material Receipt",
+			qty=100,
+			target="_Test Warehouse - _TC",
+		)
+
+		se3.reload()
+
+		self.assertRaises(frappe.ValidationError, se1.cancel)
+
 
 def make_serialized_item(**args):
 	args = frappe._dict(args)


### PR DESCRIPTION
While cancelling the stock transactions with Batch, system don't validate negative stock

- Create a Batch Item.
- Create a Stock Entry (Material Receipt) [Qty = 100, Batch = B1].
- Create a Delivery Note for 10 Qty.
- Create another Stock Entry (Material Receipt) [Qty = 200, Batch = B2].
- Now, cancel the first Stock Entry.

Current Behaviour: The Stock Entry gets cancelled, Batch (B1) Qty get set to 0. RIV gets stuck in In Progress (the validation thrown while updating the Delivery Note bundle)

**After Fix**

User will get the validation error

<img width="744" alt="Screenshot 2023-12-12 at 3 05 27 PM" src="https://github.com/frappe/erpnext/assets/8780500/ec48f377-30be-443d-9a6f-3135cc5b37f7">

Fixed https://github.com/frappe/erpnext/issues/37728