### PR TITLE
fix: typeerror on new sites

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -8,7 +8,7 @@ $.extend(erpnext, {
 		if(!company && cur_frm)
 			company = cur_frm.doc.company;
 		if(company)
-			return frappe.get_doc(":Company", company).default_currency || frappe.boot.sysdefaults.currency;
+			return frappe.get_doc(":Company", company)?.default_currency || frappe.boot.sysdefaults.currency;
 		else
 			return frappe.boot.sysdefaults.currency;
 	},


### PR DESCRIPTION
```
TypeError: Cannot read properties of undefined (reading 'default_currency')
  at Object.get_currency(../../../../../apps/erpnext/erpnext/public/js/utils.js:11:45)
  at frappe.ui.form.Controller.get_company_currency(../../../../../apps/erpnext/erpnext/public/js/controllers/transaction.js:952:18)
  at frappe.ui.form.Controller.validate_conversion_rate(../../../../../apps/erpnext/erpnext/public/js/controllers/taxes_and_totals.js:115:31)
  at frappe.ui.form.Controller._calculate_taxes_and_totals(../../../../../apps/erpnext/erpnext/public/js/controllers/taxes_and_totals.js:100:8)
  at frappe.ui.form.Controller.calculate_taxes_and_totals(../../../../../apps/erpnext/erpnext/public/js/controllers/taxes_and_totals.js:39:8)
  at _function(../../../../../apps/erpnext/erpnext/public/js/controllers/transaction.js:741:8)
  at runner(../../../../../apps/frappe/frappe/public/js/frappe/form/script_manager.js:106:31)
  at ? (../../../../../apps/frappe/frappe/public/js/frappe/form/script_manager.js:136:22)
```