### PR TITLE
fix(ux): don't override Item Name and Description in MR

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -199,9 +199,8 @@ frappe.ui.form.on('Material Request', {
 
 	get_item_data: function(frm, item, overwrite_warehouse=false) {
 		if (item && !item.item_code) { return; }
-		frm.call({
+		frappe.call({
 			method: "erpnext.stock.get_item_details.get_item_details",
-			child: item,
 			args: {
 				args: {
 					item_code: item.item_code,


### PR DESCRIPTION
**Internal Ref:** 6545

**Steps to Replicate:** 
- Add a row in Material Request.
- Update the Item Name / Description.
- Change the Qty, and the Item Name / Description gets reset with Item Master default.

**Before:**

https://github.com/frappe/erpnext/assets/63660334/1001a426-de4a-4729-867e-60a1ff16efdd

**After:**

https://github.com/frappe/erpnext/assets/63660334/066c3ae1-26c7-4015-968f-56b665344679


