### PR TITLE
feat(RFQ): special properties in print preview

### DIFF
--- a/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
+++ b/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
@@ -119,6 +119,15 @@ class RequestforQuotation(BuyingController):
 			supplier.quote_status = "Pending"
 		self.send_to_supplier()
 
+	def before_print(self, settings=None):
+		"""Use the first suppliers data to render the print preview."""
+		if self.vendor or not self.suppliers:
+			# If a specific supplier is already set, via Tools > Download PDF,
+			# we don't want to override it.
+			return
+
+		self.update_supplier_part_no(self.suppliers[0].supplier)
+
 	def on_cancel(self):
 		self.db_set("status", "Cancelled")
 


### PR DESCRIPTION
In RFQ print format, we can use special properties like `doc.vendor` and `doc.items[i].supplier_part_no`.

However, these were only defined while using "Tools > Download PDF". The print preview would crash or show `None`, if the print format was not carefully designed to handle undefined values.

With this PR, we use the first supplier in an RFQ to provide data for the print preview. This way, the special properties are always available while printing. The generation via "Tools > Download PDF" works just as before.

Docs: https://docs.erpnext.com/docs/user/manual/en/request-for-quotation#special-properties