### PR TITLE
fix: address and contact from customer creation (backport #38055, #37386, #38060)

### DIFF
--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -711,12 +711,16 @@ def make_contact(args, is_primary_contact=1):
 		contact.add_email(args.get("email_id"), is_primary=True)
 	if args.get("mobile_no"):
 		contact.add_phone(args.get("mobile_no"), is_primary_mobile_no=True)
-	contact.insert()
+
+	if flags := args.get("flags"):
+		contact.insert(ignore_permissions=flags.get("ignore_permissions"))
+	else:
+		contact.insert()
 
 	return contact
 
 
-def make_address(args, is_primary_address=1):
+def make_address(args, is_primary_address=1, is_shipping_address=1):
 	reqd_fields = []
 	for field in ["city", "country"]:
 		if not args.get(field):
@@ -732,16 +736,23 @@ def make_address(args, is_primary_address=1):
 	address = frappe.get_doc(
 		{
 			"doctype": "Address",
-			"address_title": args.get("name"),
+			"address_title": args.get("customer_name"),
 			"address_line1": args.get("address_line1"),
 			"address_line2": args.get("address_line2"),
 			"city": args.get("city"),
 			"state": args.get("state"),
 			"pincode": args.get("pincode"),
 			"country": args.get("country"),
+			"is_primary_address": is_primary_address,
+			"is_shipping_address": is_shipping_address,
 			"links": [{"link_doctype": args.get("doctype"), "link_name": args.get("name")}],
 		}
-	).insert()
+	)
+
+	if flags := args.get("flags"):
+		address.insert(ignore_permissions=flags.get("ignore_permissions"))
+	else:
+		address.insert()
 
 	return address
 

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -307,13 +307,15 @@ class Customer(TransactionBase):
 
 def create_contact(contact, party_type, party, email):
 	"""Create contact based on given contact name"""
-	contact = contact.split(" ")
+	names = contact.split(" ")
 
 	contact = frappe.get_doc(
 		{
 			"doctype": "Contact",
-			"first_name": contact[0],
-			"last_name": len(contact) > 1 and contact[1] or "",
+			"first_name": names[0],
+			"middle_name": len(names) > 2 and " ".join(names[1:-1]) or "",
+			"last_name": len(names) > 1 and names[-1] or "",
+			"is_primary_contact": 1,
 		}
 	)
 	contact.append("email_ids", dict(email_id=email, is_primary=1))
@@ -684,14 +686,28 @@ def get_credit_limit(customer, company):
 
 
 def make_contact(args, is_primary_contact=1):
-	contact = frappe.get_doc(
-		{
-			"doctype": "Contact",
-			"first_name": args.get("name"),
-			"is_primary_contact": is_primary_contact,
-			"links": [{"link_doctype": args.get("doctype"), "link_name": args.get("name")}],
-		}
-	)
+	values = {
+		"doctype": "Contact",
+		"is_primary_contact": is_primary_contact,
+		"links": [{"link_doctype": args.get("doctype"), "link_name": args.get("name")}],
+	}
+	if args.customer_type == "Individual":
+		names = args.get("customer_name").split(" ")
+		values.update(
+			{
+				"first_name": names[0],
+				"middle_name": len(names) > 2 and " ".join(names[1:-1]) or "",
+				"last_name": len(names) > 1 and names[-1] or "",
+			}
+		)
+	else:
+		values.update(
+			{
+				"company_name": args.get("customer_name"),
+			}
+		)
+	contact = frappe.get_doc(values)
+
 	if args.get("email_id"):
 		contact.add_email(args.get("email_id"), is_primary=True)
 	if args.get("mobile_no"):

--- a/erpnext/selling/doctype/customer/test_customer.py
+++ b/erpnext/selling/doctype/customer/test_customer.py
@@ -10,7 +10,11 @@ from frappe.utils import flt
 
 from erpnext.accounts.party import get_due_date
 from erpnext.exceptions import PartyDisabled, PartyFrozen
-from erpnext.selling.doctype.customer.customer import get_credit_limit, get_customer_outstanding
+from erpnext.selling.doctype.customer.customer import (
+	get_credit_limit,
+	get_customer_outstanding,
+	parse_full_name,
+)
 from erpnext.tests.utils import create_test_contact_and_address
 
 test_ignore = ["Price List"]
@@ -372,6 +376,22 @@ class TestCustomer(FrappeTestCase):
 		self.assertTrue("territory" in data[0])
 
 		frappe.db.set_value("Selling Settings", None, "cust_master_name", "Customer Name")
+
+	def test_parse_full_name(self):
+		first, middle, last = parse_full_name("John")
+		self.assertEqual(first, "John")
+		self.assertEqual(middle, None)
+		self.assertEqual(last, None)
+
+		first, middle, last = parse_full_name("John Doe")
+		self.assertEqual(first, "John")
+		self.assertEqual(middle, None)
+		self.assertEqual(last, "Doe")
+
+		first, middle, last = parse_full_name("John Michael Doe")
+		self.assertEqual(first, "John")
+		self.assertEqual(middle, "Michael")
+		self.assertEqual(last, "Doe")
 
 
 def get_customer_dict(customer_name):


### PR DESCRIPTION
https://github.com/frappe/erpnext/issues/38055, https://github.com/frappe/erpnext/issues/37386 and https://github.com/frappe/erpnext/issues/38060 have significantly improved the creation of **Contact** and **Address** from Customer, but have been backported to v15 only.

Since these PRs built on each other, they are difficult to port individually. This one backports all of them at once.