### PR TITLE
fix: throw error for incorrect delivery date in sales order

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -300,10 +300,14 @@ class SalesOrder(SellingController):
 		if self.order_type == "Sales" and not self.skip_delivery_note:
 			delivery_date_list = [d.delivery_date for d in self.get("items") if d.delivery_date]
 			max_delivery_date = max(delivery_date_list) if delivery_date_list else None
-			if (max_delivery_date and not self.delivery_date) or (
-				max_delivery_date and getdate(self.delivery_date) != getdate(max_delivery_date)
-			):
+			if max_delivery_date and not self.delivery_date:
 				self.delivery_date = max_delivery_date
+			elif max_delivery_date and getdate(self.delivery_date) != getdate(max_delivery_date):
+				frappe.throw(
+					_("Delivery Date should be {0}, which is the max of all items' delivery dates").format(
+						max_delivery_date
+					)
+				)
 			if self.delivery_date:
 				for d in self.get("items"):
 					if not d.delivery_date:


### PR DESCRIPTION
Currently if the delivery date of a sales order is incorrect (not max of all items' delivery dates), it's automatically set to the correct max one. Now an error is thrown if the date is incorrect, instead of auto setting to correct one:

Trigger: a user was using bulk edit to edit delivery dates (to incorrect dates) but nothing happened because the system auto set the dates to the correct ones. Now an error is thrown if the date is incorrect.