### PR TITLE
fix: validation error on reconciling PE to Journals as Invoice

### DIFF
--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -662,8 +662,10 @@ def update_reference_in_payment_entry(
 		"total_amount": d.grand_total,
 		"outstanding_amount": d.outstanding_amount,
 		"allocated_amount": d.allocated_amount,
-		"exchange_rate": d.exchange_rate if d.exchange_gain_loss else payment_entry.get_exchange_rate(),
-		"exchange_gain_loss": d.exchange_gain_loss,
+		"exchange_rate": d.exchange_rate
+		if d.difference_amount is not None
+		else payment_entry.get_exchange_rate(),
+		"exchange_gain_loss": d.difference_amount,
 		"account": d.account,
 	}
 


### PR DESCRIPTION
With the same exchange rate on Journal Entry and Payment Entry, reconcilition should not post exc gain/loss journal and should not throw validation error.

<img width="1552" alt="Screenshot 2023-12-15 at 12 20 00 PM" src="https://github.com/frappe/erpnext/assets/3272205/edb3caad-8d0a-4341-8f4c-855100d18e10">

