### PR TITLE
fix: wrong currency in Stock Balance report

### DIFF
--- a/erpnext/stock/report/stock_balance/stock_balance.py
+++ b/erpnext/stock/report/stock_balance/stock_balance.py
@@ -413,7 +413,7 @@ class StockBalanceReport(object):
 					"fieldname": "bal_val",
 					"fieldtype": "Currency",
 					"width": 100,
-					"options": "currency",
+					"options": "Company:company:default_currency",
 				},
 				{
 					"label": _("Opening Qty"),
@@ -427,7 +427,7 @@ class StockBalanceReport(object):
 					"fieldname": "opening_val",
 					"fieldtype": "Currency",
 					"width": 110,
-					"options": "currency",
+					"options": "Company:company:default_currency",
 				},
 				{
 					"label": _("In Qty"),


### PR DESCRIPTION
**Internal Ref:** 7327

Fixes wrong currency symbol in the Stock Balance report. 