### PR TITLE
fix: groups for current accounts in German CoAs

### DIFF
--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/de_kontenplan_SKR03_gnucash.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/de_kontenplan_SKR03_gnucash.json
@@ -53,8 +53,13 @@
 				},
 				"II. Forderungen und sonstige Vermögensgegenstände": {
 					"is_group": 1,
-					"Ford. a. Lieferungen und Leistungen": {
+					"Forderungen aus Lieferungen und Leistungen mit Kontokorrent": {
 						"account_number": "1400",
+						"account_type": "Receivable",
+						"is_group": 1
+					},
+					"Forderungen aus Lieferungen und Leistungen ohne Kontokorrent": {
+						"account_number": "1410",
 						"account_type": "Receivable"
 					},
 					"Durchlaufende Posten": {
@@ -180,8 +185,13 @@
 				},
 				"IV. Verbindlichkeiten aus Lieferungen und Leistungen": {
 					"is_group": 1,
-					"Verbindlichkeiten aus Lieferungen u. Leistungen": {
+					"Verbindlichkeiten aus Lieferungen und Leistungen mit Kontokorrent": {
 						"account_number": "1600",
+						"account_type": "Payable",
+						"is_group": 1
+					},
+					"Verbindlichkeiten aus Lieferungen und Leistungen ohne Kontokorrent": {
+						"account_number": "1610",
 						"account_type": "Payable"
 					}
 				},

--- a/erpnext/accounts/doctype/account/chart_of_accounts/verified/de_kontenplan_SKR04_with_account_number.json
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/verified/de_kontenplan_SKR04_with_account_number.json
@@ -407,13 +407,10 @@
                         "Bewertungskorrektur zu Forderungen aus Lieferungen und Leistungen": {
                             "account_number": "9960"
                         },
-                        "Debitoren": {
-                            "is_group": 1,
-                            "account_number": "10000"
-                        },
-                        "Forderungen aus Lieferungen und Leistungen": {
+                        "Forderungen aus Lieferungen und Leistungen mit Kontokorrent": {
                             "account_number": "1200",
-                            "account_type": "Receivable"
+                            "account_type": "Receivable",
+                            "is_group": 1
                         },
                         "Forderungen aus Lieferungen und Leistungen ohne Kontokorrent": {
                             "account_number": "1210"
@@ -1138,17 +1135,14 @@
                     "Bewertungskorrektur zu Verb. aus Lieferungen und Leistungen": {
                         "account_number": "9964"
                     },
-                    "Kreditoren": {
-                        "account_number": "70000",
+                    "Verb. aus Lieferungen und Leistungen mit Kontokorrent": {
+                        "account_number": "3300",
+                        "account_type": "Payable",
                         "is_group": 1,
-                        "Wareneingangs-­Verrechnungskonto" : {
+                        "Wareneingangs-Verrechnungskonto" : {
                             "account_number": "70001",
                             "account_type": "Stock Received But Not Billed"
                         }
-                    },
-                    "Verb. aus Lieferungen und Leistungen": {
-                        "account_number": "3300",
-                        "account_type": "Payable"
                     },
                     "Verb. aus Lieferungen und Leistungen ohne Kontokorrent": {
                         "account_number": "3310"


### PR DESCRIPTION
- Rename "Trade receivables" to "Trade receivables with current account" and convert to group. Add single account "Trade receivables without current account".
- Rename "Trade payables" to "Trade payables with current account" and convert to group. Add single account "Trade payables without current account".
- Remove redundant "Debtors" and "Creditors" groups

This only affects new sites/companies and makes sure they start off with a more correct CoA.