### PR TITLE
feat: voucher subtype for general ledger

### DIFF
--- a/erpnext/accounts/doctype/gl_entry/gl_entry.json
+++ b/erpnext/accounts/doctype/gl_entry/gl_entry.json
@@ -23,6 +23,7 @@
   "against_voucher_type",
   "against_voucher",
   "voucher_type",
+  "voucher_subtype",
   "voucher_no",
   "voucher_detail_no",
   "project",
@@ -138,19 +139,19 @@
    "options": "DocType"
   },
   {
-    "fieldname": "against",
-    "fieldtype": "Text",
-    "in_filter": 1,
-    "label": "Against",
-    "oldfieldname": "against",
-    "oldfieldtype": "Text"
+   "fieldname": "against",
+   "fieldtype": "Text",
+   "in_filter": 1,
+   "label": "Against",
+   "oldfieldname": "against",
+   "oldfieldtype": "Text"
   },
   {
-    "fieldname": "against_link",
-    "fieldtype": "Dynamic Link",
-    "in_filter": 1,
-    "label": "Against",
-    "options": "against_type"
+   "fieldname": "against_link",
+   "fieldtype": "Dynamic Link",
+   "in_filter": 1,
+   "label": "Against",
+   "options": "against_type"
   },
   {
    "fieldname": "against_voucher_type",
@@ -296,13 +297,18 @@
    "fieldtype": "Currency",
    "label": "Credit Amount in Transaction Currency",
    "options": "transaction_currency"
+  },
+  {
+   "fieldname": "voucher_subtype",
+   "fieldtype": "Small Text",
+   "label": "Voucher Subtype"
   }
  ],
  "icon": "fa fa-list",
  "idx": 1,
  "in_create": 1,
  "links": [],
- "modified": "2023-11-08 12:20:23.031733",
+ "modified": "2023-12-18 15:38:14.006208",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "GL Entry",

--- a/erpnext/accounts/doctype/gl_entry/gl_entry.py
+++ b/erpnext/accounts/doctype/gl_entry/gl_entry.py
@@ -39,6 +39,8 @@ class GLEntry(Document):
 		account: DF.Link | None
 		account_currency: DF.Link | None
 		against: DF.Text | None
+		against_link: DF.DynamicLink | None
+		against_type: DF.Link | None
 		against_voucher: DF.DynamicLink | None
 		against_voucher_type: DF.Link | None
 		company: DF.Link | None
@@ -66,6 +68,7 @@ class GLEntry(Document):
 		transaction_exchange_rate: DF.Float
 		voucher_detail_no: DF.Data | None
 		voucher_no: DF.DynamicLink | None
+		voucher_subtype: DF.SmallText | None
 		voucher_type: DF.Link | None
 	# end: auto-generated types
 

--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -200,7 +200,7 @@ def get_gl_entries(filters, accounting_dimensions):
 		"""
 		select
 			name as gl_entry, posting_date, account, party_type, party,
-			voucher_type, voucher_no, {dimension_fields}
+			voucher_type, voucher_subtype, voucher_no, {dimension_fields}
 			cost_center, project, {transaction_currency_fields}
 			against_voucher_type, against_voucher, account_currency,
 			against_link, against, is_opening, creation {select_fields}
@@ -606,6 +606,12 @@ def get_columns(filters):
 
 	columns += [
 		{"label": _("Voucher Type"), "fieldname": "voucher_type", "width": 120},
+		{
+			"label": _("Voucher Subtype"),
+			"fieldname": "voucher_subtype",
+			"fieldtype": "Data",
+			"width": 180,
+		},
 		{
 			"label": _("Voucher No"),
 			"fieldname": "voucher_no",

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -874,6 +874,7 @@ class AccountsController(TransactionBase):
 				"project": self.get("project"),
 				"post_net_value": args.get("post_net_value"),
 				"voucher_detail_no": args.get("voucher_detail_no"),
+				"voucher_subtype": self.get_voucher_subtype(),
 			}
 		)
 
@@ -928,6 +929,25 @@ class AccountsController(TransactionBase):
 		)
 
 		return gl_dict
+
+	def get_voucher_subtype(self):
+		voucher_subtypes = {
+			"Journal Entry": "voucher_type",
+			"Payment Entry": "payment_type",
+			"Stock Entry": "stock_entry_type",
+			"Asset Capitalization": "entry_type",
+		}
+		if self.doctype in voucher_subtypes:
+			return self.get(voucher_subtypes[self.doctype])
+		elif self.is_return and self.doctype == "Purchase Receipt":
+			return "Purchase Return"
+		elif self.is_return and self.doctype == "Delivery Note":
+			return "Sales Return"
+		elif (self.is_return and self.doctype == "Sales Invoice") or self.doctype == "Purchase Invoice":
+			return "Credit Note"
+		elif (self.is_return and self.doctype == "Purchase Invoice") or self.doctype == "Sales Invoice":
+			return "Debit Note"
+		return self.doctype
 
 	def get_value_in_transaction_currency(self, account_currency, args, field):
 		if account_currency == self.get("currency"):

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -939,13 +939,13 @@ class AccountsController(TransactionBase):
 		}
 		if self.doctype in voucher_subtypes:
 			return self.get(voucher_subtypes[self.doctype])
-		elif self.is_return and self.doctype == "Purchase Receipt":
+		elif self.doctype == "Purchase Receipt" and self.is_return:
 			return "Purchase Return"
-		elif self.is_return and self.doctype == "Delivery Note":
+		elif self.doctype == "Delivery Note" and self.is_return:
 			return "Sales Return"
-		elif (self.is_return and self.doctype == "Sales Invoice") or self.doctype == "Purchase Invoice":
+		elif (self.doctype == "Sales Invoice" and self.is_return) or self.doctype == "Purchase Invoice":
 			return "Credit Note"
-		elif (self.is_return and self.doctype == "Purchase Invoice") or self.doctype == "Sales Invoice":
+		elif (self.doctype == "Purchase Invoice" and self.is_return) or self.doctype == "Sales Invoice":
 			return "Debit Note"
 		return self.doctype
 


### PR DESCRIPTION
**Description**
Show Voucher Subtypes in the General Ledger Report.

Will show :

- Whether Voucher is a normal or return voucher for SI, PI, Purchase Receipts, Delivery Notes.
- Entry Type for Journals, Stock Entry and Asset Capitalization.
- Payment Type for Payments.

Closes #38229

<br>

`no-docs`