### PR TITLE
fix: set `fg-itm-qty` based on `qty` instead of the other way round in Subcontracting POs

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -214,7 +214,7 @@ frappe.ui.form.on("Purchase Order Item", {
 		}
 	},
 
-	fg_item_qty: async function(frm, cdt, cdn) {
+	qty: async function (frm, cdt, cdn) {
 		if (frm.doc.is_subcontracted && !frm.doc.is_old_subcontracting_flow) {
 			var row = locals[cdt][cdn];
 
@@ -222,7 +222,7 @@ frappe.ui.form.on("Purchase Order Item", {
 				var result = await frm.events.get_subcontracting_boms_for_finished_goods(row.fg_item)
 
 				if (result.message && row.item_code == result.message.service_item && row.uom == result.message.service_item_uom) {
-					frappe.model.set_value(cdt, cdn, "qty", flt(row.fg_item_qty) * flt(result.message.conversion_factor));
+					frappe.model.set_value(cdt, cdn, "fg_item_qty", flt(row.qty) / flt(result.message.conversion_factor));
 				}
 			}
 		}


### PR DESCRIPTION
Currently, `qty` is set based on `fg-item-qty`. However, `fg-item-qty` is only viible in detailed view whereas `qty` field is readily accessible in list view, so it would be easier to set `fg-item-qty` based on the `qty`.

@s-aga-r lmk if this is ok