### PR TITLE
fix: allow to set rate manually for service item in BOM

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -661,6 +661,9 @@ class BOM(WebsiteGenerator):
 		base_total_rm_cost = 0
 
 		for d in self.get("items"):
+			if not d.is_stock_item and self.rm_cost_as_per == "Valuation Rate":
+				continue
+
 			old_rate = d.rate
 			d.rate = self.get_rm_rate(
 				{

--- a/erpnext/manufacturing/doctype/bom_item/bom_item.json
+++ b/erpnext/manufacturing/doctype/bom_item/bom_item.json
@@ -14,6 +14,7 @@
   "bom_no",
   "source_warehouse",
   "allow_alternative_item",
+  "is_stock_item",
   "section_break_5",
   "description",
   "col_break1",
@@ -185,7 +186,7 @@
    "in_list_view": 1,
    "label": "Rate",
    "options": "currency",
-   "read_only": 1,
+   "read_only_depends_on": "eval:doc.is_stock_item == 1",
    "reqd": 1
   },
   {
@@ -284,13 +285,21 @@
    "fieldname": "do_not_explode",
    "fieldtype": "Check",
    "label": "Do Not Explode"
+  },
+  {
+   "default": "0",
+   "fetch_from": "item_code.is_stock_item",
+   "fieldname": "is_stock_item",
+   "fieldtype": "Check",
+   "label": "Is Stock Item",
+   "read_only": 1
   }
  ],
  "idx": 1,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-11-14 18:35:51.378513",
+ "modified": "2023-12-20 16:21:55.477883",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "BOM Item",

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -355,3 +355,4 @@ erpnext.patches.v14_0.clear_reconciliation_values_from_singles
 # below migration patch should always run last
 erpnext.patches.v14_0.migrate_gl_to_payment_ledger
 erpnext.stock.doctype.delivery_note.patches.drop_unused_return_against_index
+erpnext.patches.v14_0.set_maintain_stock_for_bom_item

--- a/erpnext/patches/v14_0/set_maintain_stock_for_bom_item.py
+++ b/erpnext/patches/v14_0/set_maintain_stock_for_bom_item.py
@@ -1,0 +1,19 @@
+import frappe
+
+
+def execute():
+	if not frappe.db.exists("BOM", {"docstatus": 1}):
+		return
+
+	# Added is_stock_item to handle Read Only based on condition for the rate field
+	frappe.db.sql(
+		"""
+		UPDATE
+			`tabBOM Item` boi,
+			`tabItem` i
+		SET
+			boi.is_stock_item = i.is_stock_item
+		WHERE
+			boi.item_code = i.name
+	"""
+	)


### PR DESCRIPTION
Allow to set the rate manually for the service item

![set_rate_manually](https://github.com/frappe/erpnext/assets/8780500/3de20a3f-d293-41d0-aac1-7d269687c566)
