### PR TITLE
fix: typeerror on pos order summary to new order screen

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_item_cart.js
+++ b/erpnext/selling/page/point_of_sale/pos_item_cart.js
@@ -520,7 +520,7 @@ erpnext.PointOfSale.ItemCart = class {
 	}
 
 	render_taxes(taxes) {
-		if (taxes.length) {
+		if (taxes && taxes.length) {
 			const currency = this.events.get_frm().doc.currency;
 			const taxes_html = taxes.map(t => {
 				if (t.tax_amount_after_discount_amount == 0.0) return;


### PR DESCRIPTION
<img width="864" alt="Screenshot 2023-12-21 at 12 16 58 PM" src="https://github.com/frappe/erpnext/assets/3272205/4d476feb-a84c-40ef-b3eb-86fb57053ee0">

Replication:
1. Place an Order and checkout
2. Navigate to New order screen from the checkout summary screen

Internal Reference: [7256](https://support.frappe.io/helpdesk/tickets/7256)