### PR TITLE
fix: do not reset the basic rate for the material receipt stock entry

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -517,7 +517,12 @@ frappe.ui.form.on('Stock Entry', {
 				},
 				callback: function(r) {
 					if (!r.exc) {
-						["actual_qty", "basic_rate"].forEach((field) => {
+						let fields = ["actual_qty", "basic_rate"];
+						if (frm.doc.purpose == "Material Receipt") {
+							fields = ["actual_qty"];
+						}
+
+						fields.forEach((field) => {
 							frappe.model.set_value(cdt, cdn, field, (r.message[field] || 0.0));
 						});
 						frm.events.calculate_basic_amount(frm, child);


### PR DESCRIPTION
**Issue**
On changing of the "Default Target Warehouse" system change the basic rate 

https://github.com/frappe/erpnext/assets/8780500/b148d224-bcbb-4ae8-8a37-21faf8db741e



**Expected behaviour**

In case of material receipt stock entry the basic rate shouldn't change on changing of the "Default Target Warehouse"