### PR TITLE
chore: additional_asset_cost field

### DIFF
--- a/erpnext/assets/doctype/asset/asset.json
+++ b/erpnext/assets/doctype/asset/asset.json
@@ -36,6 +36,7 @@
   "purchase_invoice",
   "available_for_use_date",
   "total_asset_cost",
+  "additional_asset_cost",
   "column_break_23",
   "gross_purchase_amount",
   "asset_quantity",
@@ -538,6 +539,14 @@
    "label": "Total Asset Cost",
    "options": "Company:company:default_currency",
    "read_only": 1
+  },
+  {
+   "depends_on": "eval:doc.docstatus > 0",
+   "fieldname": "additional_asset_cost",
+   "fieldtype": "Currency",
+   "label": "Additional Asset Cost",
+   "options": "Company:company:default_currency",
+   "read_only": 1
   }
  ],
  "idx": 72,
@@ -581,7 +590,7 @@
    "link_fieldname": "target_asset"
   }
  ],
- "modified": "2023-12-20 16:50:21.128595",
+ "modified": "2023-12-21 16:46:20.732869",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset",

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -50,6 +50,7 @@ class Asset(AccountsController):
 
 		from erpnext.assets.doctype.asset_finance_book.asset_finance_book import AssetFinanceBook
 
+		additional_asset_cost: DF.Currency
 		amended_from: DF.Link | None
 		asset_category: DF.Link | None
 		asset_name: DF.Data
@@ -145,6 +146,7 @@ class Asset(AccountsController):
 							).format(asset_depr_schedules_links)
 						)
 
+		self.total_asset_cost = self.gross_purchase_amount
 		self.status = self.get_status()
 
 	def on_submit(self):

--- a/erpnext/assets/doctype/asset_repair/asset_repair.py
+++ b/erpnext/assets/doctype/asset_repair/asset_repair.py
@@ -95,6 +95,7 @@ class AssetRepair(AccountsController):
 
 			if self.capitalize_repair_cost:
 				self.asset_doc.total_asset_cost += self.repair_cost
+				self.asset_doc.additional_asset_cost += self.repair_cost
 
 			if self.get("stock_consumption"):
 				self.check_for_stock_items_and_warehouse()
@@ -133,6 +134,7 @@ class AssetRepair(AccountsController):
 
 			if self.capitalize_repair_cost:
 				self.asset_doc.total_asset_cost -= self.repair_cost
+				self.asset_doc.additional_asset_cost -= self.repair_cost
 
 			if self.get("stock_consumption"):
 				self.increase_stock_quantity()


### PR DESCRIPTION
Continuation of #38879. Added a `additional_asset_cost` field which reflects the additional costs added to an asset. Also, the `total_asset_cost` field wasn't set to the gross purchase amount initially, so fixed that.