### PR TITLE
fix: reset the incoming rate on changing of the warehouse

### DIFF
--- a/erpnext/selling/sales_common.js
+++ b/erpnext/selling/sales_common.js
@@ -200,6 +200,10 @@ erpnext.selling.SellingController = class SellingController extends erpnext.Tran
 			item.serial_no = null;
 		}
 
+		if (doc.docstatus === 0 && doc.is_return && !doc.return_against) {
+			item.incoming_rate = 0.0;
+		}
+
 		var has_batch_no;
 		frappe.db.get_value('Item', {'item_code': item.item_code}, 'has_batch_no', (r) => {
 			has_batch_no = r && r.has_batch_no;


### PR DESCRIPTION
**Issue**

1. Create a standalone credit note entry for warehouse A
2. Based on previous stock ledger entry system will set the incoming rate
3. Now create a new warehouse Warehouse B. 
4. Change the warehouse from Warehouse A to Warehouse B in the above standalone credit note
5. System doesn't reset the incoming rate 