### PR TITLE
fix: first name error on customer creation

### DIFF
--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -702,6 +702,7 @@ def make_contact(args, is_primary_contact=1):
 	else:
 		values.update(
 			{
+				"first_name": args.get("customer_name"),
 				"company_name": args.get("customer_name"),
 			}
 		)


### PR DESCRIPTION
`Customer` creation, not of type 'Individual' with email or mobile number, throws validation error in v14. This is caused by the mandatory first_name in `Contact`.
<img width="1552" alt="Screenshot 2023-12-22 at 5 45 19 PM" src="https://github.com/frappe/erpnext/assets/3272205/2f874197-ade7-49cc-a73d-08652f8edcf3">
