### PR TITLE
Update pick_list.py

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -33,7 +33,7 @@ class PickList(Document):
 		self.set_item_locations()
 
 		# set percentage picked in SO
-		for location in self.get("locations"):
+		for location in self.locations:
 			if (
 				location.sales_order
 				and frappe.db.get_value("Sales Order", location.sales_order, "per_picked", cache=True) == 100


### PR DESCRIPTION

Subject: Fix Pick List Error: 'TypeError: 'NoneType' object is not iterable'

Description:
This pull request addresses the issue in the Pick List (STO-PICK-2023-02476) where a 'TypeError: 'NoneType' object is not iterable' was occurring during the before_save method. The problem was traced to the use of self.get("locations"), which could return None. This pull request replaces it with self.location to avoid the error and handle the Pick List items correctly.

Changes Made:

Modified the code in pick_list.py to replace self.get("locations") with self.location.
Ensured that the code handles Pick List items properly, preventing the 'NoneType' error.
Testing:

Tested the changes locally to ensure that the Pick List can be saved without encountering the 'TypeError' issue.
Verified that the modifications do not introduce any new errors or affect existing functionality.
Screenshots/GIFs:
![Screenshot 2023-12-22 at 9 14 14 PM](https://github.com/frappe/erpnext/assets/61617746/7aa1b617-fac9-4f84-b2a8-09f47cebb63e)

Additional Notes:

This pull request resolves the reported issue and ensures smooth handling of Pick List items without encountering the 'NoneType' error.