### PR TITLE
fix: use local attribute range in multiple item variant dialog

### DIFF
--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -600,26 +600,12 @@ $.extend(erpnext.item, {
 						}
 					});
 				} else {
-					frappe.call({
-						method: "frappe.client.get",
-						args: {
-							doctype: "Item Attribute",
-							name: d.attribute
-						}
-					}).then((r) => {
-						if(r.message) {
-							const from = r.message.from_range;
-							const to = r.message.to_range;
-							const increment = r.message.increment;
-
-							let values = [];
-							for(var i = from; i <= to; i = flt(i + increment, 6)) {
-								values.push(i);
-							}
-							attr_val_fields[d.attribute] = values;
-							resolve();
-						}
-					});
+					let values = [];
+					for(var i = d.from_range; i <= d.to_range; i = flt(i + d.increment, 6)) {
+						values.push(i);
+					}
+					attr_val_fields[d.attribute] = values;
+					resolve();
 				}
 			});
 


### PR DESCRIPTION
**Bug**
When a numeric Item Attribute is created with a default range and added to an Item, the default range is preferred over the item-specific range defined for the attribute while adding Multiple Variants for the Item.

**Fix**
Use the item-specific range instead of the default range for generating the options in the Variants dialog. The default range is fetched when the attribute is added to the child table, so not editing it will anyway make the logic fall back to use the default range.

Resolves #38705