### PR TITLE
fix: Opening balance in bank reconciliation tool

### DIFF
--- a/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.js
+++ b/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.js
@@ -137,7 +137,7 @@ frappe.ui.form.on("Bank Reconciliation Tool", {
 					"erpnext.accounts.doctype.bank_reconciliation_tool.bank_reconciliation_tool.get_account_balance",
 				args: {
 					bank_account: frm.doc.bank_account,
-					till_date: frm.doc.bank_statement_from_date,
+					till_date: frappe.datetime.add_days(frm.doc.bank_statement_from_date, -1)
 				},
 				callback: (response) => {
 					frm.set_value("account_opening_balance", response.message);


### PR DESCRIPTION
Opening balance in the bank reco tool should only be up one day before the from date and should not include the from date balance