### PR TITLE
fix(Report): Increased the column width in the Account Balance Report

### DIFF
--- a/erpnext/accounts/report/account_balance/account_balance.py
+++ b/erpnext/accounts/report/account_balance/account_balance.py
@@ -22,7 +22,7 @@ def get_columns(filters):
 			"fieldtype": "Link",
 			"fieldname": "account",
 			"options": "Account",
-			"width": 100,
+			"width": 200,
 		},
 		{
 			"label": _("Currency"),
@@ -30,7 +30,7 @@ def get_columns(filters):
 			"fieldname": "currency",
 			"options": "Currency",
 			"hidden": 1,
-			"width": 50,
+			"width": 100,
 		},
 		{
 			"label": _("Balance"),


### PR DESCRIPTION
In the Account Balance Report, the column width for the account and currency is too narrow.
![edited_img_pr](https://github.com/frappe/erpnext/assets/91895505/cba5d0ff-6bf6-44c2-9576-3bb2d999a753)

@ankush 




