### PR TITLE
fix: serial and batch bundle company mandatory error

### DIFF
--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -1145,15 +1145,16 @@ def add_serial_batch_ledgers(entries, child_row, doc, warehouse) -> object:
 	if isinstance(entries, str):
 		entries = parse_json(entries)
 
-	if doc and isinstance(doc, str):
-		parent_doc = parse_json(doc)
+	parent_doc = doc
+	if parent_doc and isinstance(parent_doc, str):
+		parent_doc = parse_json(parent_doc)
 
 	if frappe.db.exists("Serial and Batch Bundle", child_row.serial_and_batch_bundle):
-		doc = update_serial_batch_no_ledgers(entries, child_row, parent_doc, warehouse)
+		sb_doc = update_serial_batch_no_ledgers(entries, child_row, parent_doc, warehouse)
 	else:
-		doc = create_serial_batch_no_ledgers(entries, child_row, parent_doc, warehouse)
+		sb_doc = create_serial_batch_no_ledgers(entries, child_row, parent_doc, warehouse)
 
-	return doc
+	return sb_doc
 
 
 def create_serial_batch_no_ledgers(entries, child_row, parent_doc, warehouse=None) -> object:
@@ -1177,6 +1178,7 @@ def create_serial_batch_no_ledgers(entries, child_row, parent_doc, warehouse=Non
 			"type_of_transaction": type_of_transaction,
 			"posting_date": parent_doc.get("posting_date"),
 			"posting_time": parent_doc.get("posting_time"),
+			"company": parent_doc.get("company"),
 		}
 	)
 


### PR DESCRIPTION
If user don't have permission to read the company and instance has multiple companies then while making the serial and batch bundle users are getting the company mandatory error

```
File "apps/frappe/frappe/model/[document.py](http://document.py/)", line 287, in insert

self._validate()

File "apps/frappe/frappe/model/[document.py](http://document.py/)", line 554, in _validate

self._validate_mandatory()

File "apps/frappe/frappe/model/[document.py](http://document.py/)", line 899, in validatemandatory

raise frappe.MandatoryError(

frappe.exceptions.MandatoryError: [Serial and Batch Bundle, SABB-00000133]: company
```