### PR TITLE
fix: undefined error in consolidated financial report

### DIFF
--- a/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js
+++ b/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.js
@@ -128,7 +128,7 @@ frappe.query_reports["Consolidated Financial Statement"] = {
 		}
 
 		value = default_formatter(value, row, column, data);
-		if (!data.parent_account) {
+		if (data && !data.parent_account) {
 			value = $(`<span>${value}</span>`);
 
 			var $value = $(value).css("font-weight", "bold");


### PR DESCRIPTION

```
Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'parent_account')
    at Object.formatter (consolidated_financial_statement.js:131:13)
    at format (query_report.js:1264:35)
    at CellManager.getCellContent (frappe-datatable.cjs.js:3385:31)
    at CellManager.getCellHTML (frappe-datatable.cjs.js:3349:24)
    at frappe-datatable.cjs.js:4246:52
    at Array.map (<anonymous>)
    at RowManager.getRowHTML (frappe-datatable.cjs.js:4246:23)
    at Object.generate (frappe-datatable.cjs.js:4744:49)
    at HyperList3._getRow (frappe-datatable.cjs.js:4508:25)
    at HyperList3._renderChunk (frappe-datatable.cjs.js:4591:24)
```

<img width="1552" alt="Screenshot 2023-12-28 at 5 38 19 PM" src="https://github.com/frappe/erpnext/assets/3272205/7ccfbee5-45bd-4dc4-9896-f3b6b7f3ea5e">
