### PR TITLE
fix: auto fetch not working if bundle exists

### DIFF
--- a/erpnext/public/js/utils/serial_no_batch_selector.js
+++ b/erpnext/public/js/utils/serial_no_batch_selector.js
@@ -337,15 +337,17 @@ erpnext.SerialBatchPackageSelector = class SerialNoBatchBundleUpdate {
 	}
 
 	get_auto_data() {
+		let { qty, based_on } = this.dialog.get_values();
+
 		if (this.item.serial_and_batch_bundle || this.item.rejected_serial_and_batch_bundle) {
-			return;
+			if (qty === this.qty) {
+				return;
+			}
 		}
 
 		if (this.item.serial_no || this.item.batch_no) {
 			return;
 		}
-
-		let { qty, based_on } = this.dialog.get_values();
 
 		if (!based_on) {
 			based_on = 'FIFO';


### PR DESCRIPTION
**Issue**

If the bundle exists, then auto-fetch is not working which is fine. It should work if the user has changed the quantity in the popup.

![auto_fetch_issue](https://github.com/frappe/erpnext/assets/8780500/97444646-a70e-4e8f-88d4-d90b8f94cbda)


**After Fix**

If the user has changed the quantity in the popup then auto fetch the batch / serial nos as per the input qty.
![auto_fetch_after_fix](https://github.com/frappe/erpnext/assets/8780500/9ca3eebb-f8ca-425b-9400-52ee64424c47)

