### PR TITLE
fix: purchase return without item code not working

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/test_purchase_invoice.py
@@ -1985,6 +1985,26 @@ class TestPurchaseInvoice(FrappeTestCase, StockTestMixin):
 
 		self.assertEqual(pi.items[0].cost_center, "_Test Cost Center Buying - _TC")
 
+	def test_debit_note_without_item(self):
+		pi = make_purchase_invoice(item_name="_Test Item", qty=10, do_not_submit=True)
+		pi.items[0].item_code = ""
+		pi.save()
+
+		self.assertFalse(pi.items[0].item_code)
+		pi.submit()
+
+		return_pi = make_purchase_invoice(
+			item_name="_Test Item",
+			is_return=1,
+			return_against=pi.name,
+			qty=-10,
+			do_not_save=True,
+		)
+		return_pi.items[0].item_code = ""
+		return_pi.save()
+		return_pi.submit()
+		self.assertEqual(return_pi.docstatus, 1)
+
 
 def set_advance_flag(company, flag, default_account):
 	frappe.db.set_value(
@@ -2121,6 +2141,7 @@ def make_purchase_invoice(**args):
 		"items",
 		{
 			"item_code": args.item or args.item_code or "_Test Item",
+			"item_name": args.item_name,
 			"warehouse": args.warehouse or "_Test Warehouse - _TC",
 			"qty": args.qty or 5,
 			"received_qty": args.received_qty or 0,

--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -562,16 +562,17 @@ def make_return_doc(
 			if default_warehouse_for_sales_return:
 				target_doc.warehouse = default_warehouse_for_sales_return
 
-		item_details = frappe.get_cached_value(
-			"Item", source_doc.item_code, ["has_batch_no", "has_serial_no"], as_dict=1
-		)
+		if source_doc.item_code:
+			item_details = frappe.get_cached_value(
+				"Item", source_doc.item_code, ["has_batch_no", "has_serial_no"], as_dict=1
+			)
 
-		if not item_details.has_batch_no and not item_details.has_serial_no:
-			return
+			if not item_details.has_batch_no and not item_details.has_serial_no:
+				return
 
-		for qty_field in ["stock_qty", "rejected_qty"]:
-			if target_doc.get(qty_field):
-				update_serial_batch_no(source_doc, target_doc, source_parent, item_details, qty_field)
+			for qty_field in ["stock_qty", "rejected_qty"]:
+				if target_doc.get(qty_field):
+					update_serial_batch_no(source_doc, target_doc, source_parent, item_details, qty_field)
 
 	def update_terms(source_doc, target_doc, source_parent):
 		target_doc.payment_amount = -source_doc.payment_amount


### PR DESCRIPTION
While making Debit note against the Purchase Invoice without item code, getting the below error

<img width="803" alt="Screenshot 2023-12-29 at 11 15 11 AM" src="https://github.com/frappe/erpnext/assets/8780500/3d752d51-fabe-40b8-8144-9ccaaeab32d9">
