### PR TITLE
chore: default_roles hook doesn't exist anymore

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -257,11 +257,6 @@ standard_portal_menu_items = [
 	{"title": "Appointment Booking", "route": "/book_appointment"},
 ]
 
-default_roles = [
-	{"role": "Customer", "doctype": "Contact", "email_field": "email_id"},
-	{"role": "Supplier", "doctype": "Contact", "email_field": "email_id"},
-]
-
 sounds = [
 	{"name": "incoming-call", "src": "/assets/erpnext/sounds/incoming-call.mp3", "volume": 0.2},
 	{"name": "call-disconnect", "src": "/assets/erpnext/sounds/call-disconnect.mp3", "volume": 0.2},


### PR DESCRIPTION
# Context

The `default_roles` hook as described in https://frappeframework.com/docs/user/en/guides/portal-development/portal-roles doesn't exist anymore in Frappe.

# Proposed Solution

- Remove it's noop declaration
- In order to not confuse people who read the code
- [ ] Update the docs (which I seem not to be able to in this PR)
