### PR TITLE
fix: enqueue demo data setup on setup complete

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -37,6 +37,7 @@ welcome_email = "erpnext.setup.utils.welcome_email"
 # setup wizard
 setup_wizard_requires = "assets/erpnext/js/setup_wizard.js"
 setup_wizard_stages = "erpnext.setup.setup_wizard.setup_wizard.get_setup_stages"
+setup_wizard_complete = "erpnext.setup.setup_wizard.setup_wizard.setup_demo"
 setup_wizard_test = "erpnext.setup.setup_wizard.test_setup_wizard.run_setup_wizard_test"
 
 before_install = [

--- a/erpnext/setup/setup_wizard/setup_wizard.py
+++ b/erpnext/setup/setup_wizard/setup_wizard.py
@@ -38,11 +38,6 @@ def get_setup_stages(args=None):
 				],
 			},
 			{
-				"status": _("Setting up demo data"),
-				"fail_msg": _("Failed to setup demo data"),
-				"tasks": [{"fn": setup_demo, "args": args, "fail_msg": _("Failed to setup demo data")}],
-			},
-			{
 				"status": _("Wrapping up"),
 				"fail_msg": _("Failed to login"),
 				"tasks": [{"fn": fin, "args": args, "fail_msg": _("Failed to login")}],


### PR DESCRIPTION
## Issue
- On setup complete, it tries to create tax templates for the company (From the India Compliance App) in Foreground
- Simultaneously, it tries to create tax templates for Demo Company, causing `QueryDeadlockError`

Ref: https://trace.frappe.cloud/share/issue/36bcc8de6e214c5580552a2663bad8c6/

## Fix

Enqueue generation of demo data on setup complete.