### PR TITLE
fix: asset WDV depreciation calc according to IT act [v14]

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -428,10 +428,7 @@ class Asset(AccountsController):
 				n == 0
 				and (has_pro_rata or has_wdv_or_dd_non_yearly_pro_rata)
 				and not self.opening_accumulated_depreciation
-				and get_updated_rate_of_depreciation_for_wdv_and_dd(
-					self, value_after_depreciation, finance_book, False
-				)
-				== finance_book.rate_of_depreciation
+				and not self.flags.wdv_it_act_applied
 			):
 				from_date = add_days(
 					self.available_for_use_date, -1
@@ -1378,24 +1375,14 @@ def get_depreciation_amount(
 			asset, fb_row, schedule_idx, number_of_pending_depreciations
 		)
 	else:
-		rate_of_depreciation = get_updated_rate_of_depreciation_for_wdv_and_dd(
-			asset, depreciable_value, fb_row
-		)
 		return get_wdv_or_dd_depr_amount(
+			asset,
+			fb_row,
 			depreciable_value,
-			rate_of_depreciation,
-			fb_row.frequency_of_depreciation,
 			schedule_idx,
 			prev_depreciation_amount,
 			has_wdv_or_dd_non_yearly_pro_rata,
 		)
-
-
-@erpnext.allow_regional
-def get_updated_rate_of_depreciation_for_wdv_and_dd(
-	asset, depreciable_value, fb_row, show_msg=True
-):
-	return fb_row.rate_of_depreciation
 
 
 def get_straight_line_or_manual_depr_amount(
@@ -1532,30 +1519,53 @@ def get_asset_shift_factors_map():
 	return dict(frappe.db.get_all("Asset Shift Factor", ["shift_name", "shift_factor"], as_list=True))
 
 
+@erpnext.allow_regional
 def get_wdv_or_dd_depr_amount(
+	asset,
+	fb_row,
 	depreciable_value,
-	rate_of_depreciation,
-	frequency_of_depreciation,
 	schedule_idx,
 	prev_depreciation_amount,
 	has_wdv_or_dd_non_yearly_pro_rata,
 ):
-	if cint(frequency_of_depreciation) == 12:
-		return flt(depreciable_value) * (flt(rate_of_depreciation) / 100)
+	return get_default_wdv_or_dd_depr_amount(
+		asset,
+		fb_row,
+		depreciable_value,
+		schedule_idx,
+		prev_depreciation_amount,
+		has_wdv_or_dd_non_yearly_pro_rata,
+	)
+
+
+def get_default_wdv_or_dd_depr_amount(
+	asset,
+	fb_row,
+	depreciable_value,
+	schedule_idx,
+	prev_depreciation_amount,
+	has_wdv_or_dd_non_yearly_pro_rata,
+):
+	if cint(fb_row.frequency_of_depreciation) == 12:
+		return flt(depreciable_value) * (flt(fb_row.rate_of_depreciation) / 100)
 	else:
 		if has_wdv_or_dd_non_yearly_pro_rata:
 			if schedule_idx == 0:
-				return flt(depreciable_value) * (flt(rate_of_depreciation) / 100)
-			elif schedule_idx % (12 / cint(frequency_of_depreciation)) == 1:
+				return flt(depreciable_value) * (flt(fb_row.rate_of_depreciation) / 100)
+			elif schedule_idx % (12 / cint(fb_row.frequency_of_depreciation)) == 1:
 				return (
-					flt(depreciable_value) * flt(frequency_of_depreciation) * (flt(rate_of_depreciation) / 1200)
+					flt(depreciable_value)
+					* flt(fb_row.frequency_of_depreciation)
+					* (flt(fb_row.rate_of_depreciation) / 1200)
 				)
 			else:
 				return prev_depreciation_amount
 		else:
-			if schedule_idx % (12 / cint(frequency_of_depreciation)) == 0:
+			if schedule_idx % (12 / cint(fb_row.frequency_of_depreciation)) == 0:
 				return (
-					flt(depreciable_value) * flt(frequency_of_depreciation) * (flt(rate_of_depreciation) / 1200)
+					flt(depreciable_value)
+					* flt(fb_row.frequency_of_depreciation)
+					* (flt(fb_row.rate_of_depreciation) / 1200)
 				)
 			else:
 				return prev_depreciation_amount

--- a/erpnext/assets/doctype/asset/depreciation.py
+++ b/erpnext/assets/doctype/asset/depreciation.py
@@ -19,6 +19,7 @@ from frappe.utils import (
 from frappe.utils.data import get_link_to_form
 from frappe.utils.user import get_users_with_role
 
+import erpnext
 from erpnext.accounts.doctype.accounting_dimension.accounting_dimension import (
 	get_checks_for_pl_and_bs_accounts,
 )
@@ -472,6 +473,13 @@ def depreciate_asset(asset, date):
 	asset.save()
 
 	make_depreciation_entry(asset.name, date)
+
+	cancel_depreciation_entries(asset, date)
+
+
+@erpnext.allow_regional
+def cancel_depreciation_entries(asset, date):
+	pass
 
 
 def reset_depreciation_schedule(asset, date):

--- a/erpnext/assets/doctype/asset_finance_book/asset_finance_book.json
+++ b/erpnext/assets/doctype/asset_finance_book/asset_finance_book.json
@@ -90,7 +90,6 @@
   },
   {
    "default": "0",
-   "depends_on": "eval:doc.depreciation_method == \"Straight Line\" || doc.depreciation_method == \"Manual\"",
    "fieldname": "daily_prorata_based",
    "fieldtype": "Check",
    "label": "Depreciate based on daily pro-rata"
@@ -106,7 +105,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2023-11-29 03:53:03.591098",
+ "modified": "2023-12-29 08:49:39.876439",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset Finance Book",


### PR DESCRIPTION
First year depreciation for WDV method as per Income Tax act wasn't being calculated properly. Now the depreciation calculations in ERPNext match these [calculations](https://docs.google.com/spreadsheets/d/1zD33bA5kyNmrajNpMxVmMao5eio0a09B/edit?usp=sharing&ouid=105035438770380117661&rtpof=true&sd=true) provided by a customer.

Needs to be merged with: https://github.com/resilient-tech/india-compliance/pull/1520.