### PR TITLE
fix: undefined error in Budget Variance and Profitability report

### DIFF
--- a/erpnext/accounts/report/budget_variance_report/budget_variance_report.js
+++ b/erpnext/accounts/report/budget_variance_report/budget_variance_report.js
@@ -88,7 +88,3 @@ frappe.query_reports["Budget Variance Report"] = {
 		return value;
 	}
 }
-
-erpnext.dimension_filters.forEach((dimension) => {
-	frappe.query_reports["Budget Variance Report"].filters[4].options.push(dimension["document_type"]);
-});

--- a/erpnext/accounts/report/budget_variance_report/budget_variance_report.js
+++ b/erpnext/accounts/report/budget_variance_report/budget_variance_report.js
@@ -2,7 +2,44 @@
 // License: GNU General Public License v3. See license.txt
 
 frappe.query_reports["Budget Variance Report"] = {
-	"filters": [
+	"filters": get_filters(),
+	"formatter": function (value, row, column, data, default_formatter) {
+		value = default_formatter(value, row, column, data);
+
+		if (column.fieldname.includes(__("variance"))) {
+
+			if (data[column.fieldname] < 0) {
+				value = "<span style='color:red'>" + value + "</span>";
+			}
+			else if (data[column.fieldname] > 0) {
+				value = "<span style='color:green'>" + value + "</span>";
+			}
+		}
+
+		return value;
+	}
+}
+function get_filters() {
+	function get_dimensions() {
+		let result = [];
+		frappe.call({
+			method: "erpnext.accounts.doctype.accounting_dimension.accounting_dimension.get_dimensions",
+			args: {
+				'with_cost_center_and_project': true
+			},
+			async: false,
+			callback: function(r) {
+				if(!r.exc) {
+					result = r.message[0].map(elem => elem.document_type);
+				}
+			}
+		});
+		return result;
+	}
+
+	let budget_against_options = get_dimensions();
+
+	let filters = [
 		{
 			fieldname: "from_fiscal_year",
 			label: __("From Fiscal Year"),
@@ -44,9 +81,13 @@ frappe.query_reports["Budget Variance Report"] = {
 			fieldname: "budget_against",
 			label: __("Budget Against"),
 			fieldtype: "Select",
-			options: ["Cost Center", "Project"],
+			options: budget_against_options,
 			default: "Cost Center",
 			reqd: 1,
+			get_data: function() {
+				console.log(this.options);
+				return ["Emacs", "Rocks"];
+			},
 			on_change: function() {
 				frappe.query_report.set_filter_value("budget_against_filter", []);
 				frappe.query_report.refresh();
@@ -71,20 +112,8 @@ frappe.query_reports["Budget Variance Report"] = {
 			fieldtype: "Check",
 			default: 0,
 		},
-	],
-	"formatter": function (value, row, column, data, default_formatter) {
-		value = default_formatter(value, row, column, data);
+	]
 
-		if (column.fieldname.includes(__("variance"))) {
-
-			if (data[column.fieldname] < 0) {
-				value = "<span style='color:red'>" + value + "</span>";
-			}
-			else if (data[column.fieldname] > 0) {
-				value = "<span style='color:green'>" + value + "</span>";
-			}
-		}
-
-		return value;
-	}
+	return filters;
 }
+

--- a/erpnext/accounts/report/profitability_analysis/profitability_analysis.js
+++ b/erpnext/accounts/report/profitability_analysis/profitability_analysis.js
@@ -117,8 +117,3 @@ frappe.query_reports["Profitability Analysis"] = {
 	"parent_field": "parent_account",
 	"initial_depth": 3
 }
-
-erpnext.dimension_filters.forEach((dimension) => {
-	frappe.query_reports["Profitability Analysis"].filters[1].options.push(dimension["document_type"]);
-});
-


### PR DESCRIPTION
Removing dimensions filter setup in `Budget Variance Report` and `Profitability Analysis` reports.

1. Profitability Analysis already has dynamic dimension filter selection.
2. Branch Variance report filters are refactored to dynamically load dimensions in the drop down select.

Internal Reference: [7814](https://support.frappe.io/helpdesk/tickets/7814)