### PR TITLE
Refactor: Monetary Columns in Reports shown as float type with Precision set different to System Setting Default

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -73,7 +73,9 @@
   "remarks_section",
   "general_ledger_remarks_length",
   "column_break_lvjk",
-  "receivable_payable_remarks_length"
+  "receivable_payable_remarks_length",
+  "section_break_7aaov",
+  "monetary_columns_float_precison"
  ],
  "fields": [
   {
@@ -462,6 +464,18 @@
    "fieldname": "remarks_section",
    "fieldtype": "Section Break",
    "label": "Remarks Column Length"
+  },
+    {
+   "fieldname": "section_break_7aaov",
+   "fieldtype": "Section Break",
+   "label": "Monetary Columns Representation Precison"
+  },
+  {
+   "description": "If This set to 0  the Float Precision will be set to System Setting , So Some Columns where it representing Currency without Symbol will be shown as set here .",
+   "fieldname": "monetary_columns_float_precison",
+   "fieldtype": "Select",
+   "label": "Monetary Columns Float Precison",
+   "options": "\n2\n3\n4\n5\n6\n7\n8\n9"
   }
  ],
  "icon": "icon-cog",

--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -523,7 +523,16 @@ def get_balance(row, balance, debit_field, credit_field):
 	balance += row.get(debit_field, 0) - row.get(credit_field, 0)
 
 	return balance
-
+def get_float_precison():
+	fp = frappe.db.get_single_value(
+			"Accounts Settings", "monetary_columns_float_precison"
+		)
+	if fp !="":
+		return fp
+	else :
+		return frappe.db.get_single_value(
+			"System Settings", "float_precision"
+		) 
 
 def get_columns(filters):
 	if filters.get("presentation_currency"):
@@ -534,6 +543,7 @@ def get_columns(filters):
 		else:
 			company = get_default_company()
 			currency = get_company_currency(company)
+	float_precision = get_float_precison()
 
 	columns = [
 		{
@@ -555,18 +565,21 @@ def get_columns(filters):
 			"label": _("Debit ({0})").format(currency),
 			"fieldname": "debit",
 			"fieldtype": "Float",
+			"precision": float_precision,
 			"width": 130,
 		},
 		{
 			"label": _("Credit ({0})").format(currency),
 			"fieldname": "credit",
 			"fieldtype": "Float",
+			"precision": float_precision,
 			"width": 130,
 		},
 		{
 			"label": _("Balance ({0})").format(currency),
 			"fieldname": "balance",
 			"fieldtype": "Float",
+			"precision": float_precision,
 			"width": 130,
 		},
 		{"label": _("Voucher Type"), "fieldname": "voucher_type", "width": 120},

--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -524,15 +524,11 @@ def get_balance(row, balance, debit_field, credit_field):
 
 	return balance
 def get_float_precison():
-	fp = frappe.db.get_single_value(
-			"Accounts Settings", "monetary_columns_float_precison"
-		)
-	if fp !="":
+	fp = frappe.db.get_single_value("Accounts Settings", "monetary_columns_float_precison")
+	if fp != "":
 		return fp
-	else :
-		return frappe.db.get_single_value(
-			"System Settings", "float_precision"
-		) 
+	else:
+		return frappe.db.get_single_value("System Settings", "float_precision")
 
 def get_columns(filters):
 	if filters.get("presentation_currency"):


### PR DESCRIPTION
Representing Monetary data field as currency in many script report columns would take a lot of space and be annoying sometimes, meanwhile using Float as field type would be annoying when you set float Precision to 5 in System Settings.

Thus after apply such field many report would get some update for example General Ledger Report: def get_float_precison():
fp = frappe.db.get_single_value(
"Accounts Settings", "monetary_columns_float_precison"
)
if fp !="":
return fp
else :
return frappe.db.get_single_value(
"System Settings", "float_precision"
)

def get_columns(filters):
....

float_precision = get_float_precison()

columns = [
{
"label": _("Debit"),
"fieldname": "debit_in_account_currency",
"fieldtype": "Float",
"precision": float_precision,
"width": 130,
},

	{
		"label": _("Credit"),
		"fieldname": "credit_in_account_currency",
		"fieldtype": "Float",
		"precision": float_precision,
		"width": 130,
	},
	{
		"label": _("Balance"),
		"fieldname": "balance",
		"fieldtype": "Float",
		"precision": float_precision,
		"width": 130,
	},