### PR TITLE
refactor: flag to control loyalty point creation at invoice level

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
@@ -138,6 +138,7 @@
   "loyalty_amount",
   "column_break_77",
   "loyalty_program",
+  "dont_create_loyalty_points",
   "loyalty_redemption_account",
   "loyalty_redemption_cost_center",
   "contact_and_address_tab",
@@ -1041,8 +1042,7 @@
    "label": "Loyalty Program",
    "no_copy": 1,
    "options": "Loyalty Program",
-   "print_hide": 1,
-   "read_only": 1
+   "print_hide": 1
   },
   {
    "allow_on_submit": 1,
@@ -2162,6 +2162,14 @@
    "fieldname": "update_billed_amount_in_delivery_note",
    "fieldtype": "Check",
    "label": "Update Billed Amount in Delivery Note"
+  },
+  {
+   "default": "0",
+   "depends_on": "loyalty_program",
+   "fieldname": "dont_create_loyalty_points",
+   "fieldtype": "Check",
+   "label": "Don't Create Loyalty Points",
+   "no_copy": 1
   }
  ],
  "icon": "fa fa-file-text",
@@ -2174,7 +2182,7 @@
    "link_fieldname": "consolidated_invoice"
   }
  ],
- "modified": "2023-11-23 16:56:29.679499",
+ "modified": "2024-01-02 17:25:46.027523",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice",

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -117,6 +117,7 @@ class SalesInvoice(SellingController):
 		discount_amount: DF.Currency
 		dispatch_address: DF.SmallText | None
 		dispatch_address_name: DF.Link | None
+		dont_create_loyalty_points: DF.Check
 		due_date: DF.Date | None
 		from_date: DF.Date | None
 		grand_total: DF.Currency
@@ -471,7 +472,12 @@ class SalesInvoice(SellingController):
 		update_linked_doc(self.doctype, self.name, self.inter_company_invoice_reference)
 
 		# create the loyalty point ledger entry if the customer is enrolled in any loyalty program
-		if not self.is_return and not self.is_consolidated and self.loyalty_program:
+		if (
+			not self.is_return
+			and not self.is_consolidated
+			and self.loyalty_program
+			and not self.dont_create_loyalty_points
+		):
 			self.make_loyalty_point_entry()
 		elif (
 			self.is_return and self.return_against and not self.is_consolidated and self.loyalty_program


### PR DESCRIPTION
Better control on Loyalty points creation. A checkbox - `Don't Create Loyalty Points`, is added in the Loyalty Points Redemption section in Sales Invoice to allow Individual Invoice level control.