### PR TITLE
fix: wrong file name

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -18,7 +18,7 @@ app_include_js = "erpnext.bundle.js"
 app_include_css = "erpnext.bundle.css"
 web_include_js = "erpnext-web.bundle.js"
 web_include_css = "erpnext-web.bundle.css"
-email_css = "email_erpnext.bundle.css"
+email_css = "erpnext_email.bundle.scss"
 
 doctype_js = {
 	"Address": "public/js/address.js",


### PR DESCRIPTION
file name is actually reversed.

In [1]: from premailer import Premailer
   ...:
   ...: from frappe.utils.jinja_globals import bundled_asset
   ...:
   ...: # get email css files from hooks
   ...: css_files = frappe.get_hooks("email_css")
   ...: css_files = [frappe.utils.jinja_globals.bundled_asset(path) for path in
   ...: css_files]
   ...: css_files = [path.lstrip("/") for path in css_files]

In [2]: css_files
Out[2]:
['assets/frappe/dist/css/email.bundle.ELTO33N3.css',
 'email_erpnext.bundle.css',
 'assets/css/email.css']

In [3]: css_files = [css_file for css_file in css_files if os.path.exists(os.pat
   ...: h.abspath(css_file))]

In [4]: css_files
Out[4]: ['assets/frappe/dist/css/email.bundle.ELTO33N3.css', 'assets/css/email.css']
