### PR TITLE
fix: Ignore UP on "allowed to transact with"

### DIFF
--- a/erpnext/accounts/doctype/allowed_to_transact_with/allowed_to_transact_with.json
+++ b/erpnext/accounts/doctype/allowed_to_transact_with/allowed_to_transact_with.json
@@ -11,6 +11,7 @@
   {
    "fieldname": "company",
    "fieldtype": "Link",
+   "ignore_user_permissions": 1,
    "in_list_view": 1,
    "label": "Company",
    "options": "Company",
@@ -19,7 +20,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2020-05-01 12:32:34.044911",
+ "modified": "2024-01-03 11:13:02.669632",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Allowed To Transact With",
@@ -28,5 +29,6 @@
  "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }


### PR DESCRIPTION
If a customer is allowed to transact with some company it usually
doesn't imply that customer is somehow "linked with" that company.
