### PR TITLE
fix: Creating Asset Activity while Importing Asset

### DIFF
--- a/erpnext/assets/doctype/asset_activity/asset_activity.py
+++ b/erpnext/assets/doctype/asset_activity/asset_activity.py
@@ -3,7 +3,7 @@
 
 import frappe
 from frappe.model.document import Document
-
+from frappe.utils import now_datetime
 
 class AssetActivity(Document):
 	# begin: auto-generated types
@@ -30,5 +30,6 @@ def add_asset_activity(asset, subject):
 			"asset": asset,
 			"subject": subject,
 			"user": frappe.session.user,
+			"date": now_datetime(),
 		}
 	).insert(ignore_permissions=True, ignore_links=True)

--- a/erpnext/assets/doctype/asset_activity/asset_activity.py
+++ b/erpnext/assets/doctype/asset_activity/asset_activity.py
@@ -5,6 +5,7 @@ import frappe
 from frappe.model.document import Document
 from frappe.utils import now_datetime
 
+
 class AssetActivity(Document):
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.


### PR DESCRIPTION
closes #39101
Frappe v15.7.0
ERPNext v15.8.3

This is to solve error while importing Asset:

`{"message": "Asset Depreciation Schedules created:<br><a href=\\"https://xxxxx/app/asset-depreciation-schedule/ACC-ADS-2024-00004\\">ACC-ADS-2024-00004</a><br><br>Please check, edit if needed, and submit the Asset.", "title": "Message"}, {"message": "Error: Value missing for Asset Activity: Date", "title": "Message"}`