### PR TITLE
fix: ignore cancelled payments in Sales/Purchase Register

### DIFF
--- a/erpnext/accounts/report/utils.py
+++ b/erpnext/accounts/report/utils.py
@@ -251,6 +251,7 @@ def get_journal_entries(filters, args):
 		)
 		.where(
 			(je.voucher_type == "Journal Entry")
+			& (je.docstatus == 1)
 			& (journal_account.party == filters.get(args.party))
 			& (journal_account.account.isin(args.party_account))
 		)
@@ -281,7 +282,9 @@ def get_payment_entries(filters, args):
 			pe.cost_center,
 		)
 		.where(
-			(pe.party == filters.get(args.party)) & (pe[args.account_fieldname].isin(args.party_account))
+			(pe.docstatus == 1)
+			& (pe.party == filters.get(args.party))
+			& (pe[args.account_fieldname].isin(args.party_account))
 		)
 		.orderby(pe.posting_date, pe.name, order=Order.desc)
 	)


### PR DESCRIPTION
Sales/Purchase Register's were reporting cancelled Payment/Journal Entries when `Show Ledger View` is enabled. Fixing here.