### PR TITLE
fix(Employee): treeview

### DIFF
--- a/erpnext/setup/doctype/employee/employee.json
+++ b/erpnext/setup/doctype/employee/employee.json
@@ -616,8 +616,8 @@
    "fieldname": "relieving_date",
    "fieldtype": "Date",
    "label": "Relieving Date",
-   "no_copy": 1,
    "mandatory_depends_on": "eval:doc.status == \"Left\"",
+   "no_copy": 1,
    "oldfieldname": "relieving_date",
    "oldfieldtype": "Date"
   },
@@ -822,12 +822,14 @@
  "icon": "fa fa-user",
  "idx": 24,
  "image_field": "image",
+ "is_tree": 1,
  "links": [],
- "modified": "2023-10-04 10:57:05.174592",
+ "modified": "2024-01-03 17:36:20.984421",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Employee",
  "naming_rule": "By \"Naming Series\" field",
+ "nsm_parent_field": "reports_to",
  "owner": "Administrator",
  "permissions": [
   {
@@ -860,7 +862,6 @@
    "read": 1,
    "report": 1,
    "role": "HR Manager",
-   "set_user_permissions": 1,
    "share": 1,
    "write": 1
   }


### PR DESCRIPTION
**Employee** has a hierarchy defined by the _Reports To_ field:

https://github.com/frappe/erpnext/blob/351ee5b8feb789632fd01a37822cf99908c40552/erpnext/setup/doctype/employee/employee.py#L26-L27

However, this was not reflected in the DocType definition.

This PR fixes the doctype definition to be in accordance with the controller code. This is necessary for permissions and treeview utils to work correctly.

Related: https://github.com/frappe/frappe/pull/24107