### PR TITLE
fix: don't set rate for non-stock item in Internal Transfer

### DIFF
--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -432,6 +432,9 @@ class SellingController(StockController):
 
 		items = self.get("items") + (self.get("packed_items") or [])
 		for d in items:
+			if not frappe.get_cached_value("Item", d.item_code, "is_stock_item"):
+				continue
+
 			if not self.get("return_against") or (
 				get_valuation_method(d.item_code) == "Moving Average" and self.get("is_return")
 			):

--- a/erpnext/stock/doctype/delivery_note/test_delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/test_delivery_note.py
@@ -1518,6 +1518,25 @@ class TestDeliveryNote(FrappeTestCase):
 			"Stock Settings", "auto_create_serial_and_batch_bundle_for_outward", 0
 		)
 
+	def test_internal_transfer_for_non_stock_item(self):
+		from erpnext.selling.doctype.customer.test_customer import create_internal_customer
+		from erpnext.selling.doctype.sales_order.sales_order import make_delivery_note
+
+		item = make_item(properties={"is_stock_item": 0}).name
+		warehouse = "_Test Warehouse - _TC"
+		target = "Stores - _TC"
+		company = "_Test Company"
+		customer = create_internal_customer(represents_company=company)
+		rate = 100
+
+		so = make_sales_order(item_code=item, qty=1, rate=rate, customer=customer, warehouse=warehouse)
+		dn = make_delivery_note(so.name)
+		dn.items[0].target_warehouse = target
+		dn.save().submit()
+
+		self.assertEqual(so.items[0].rate, rate)
+		self.assertEqual(dn.items[0].rate, so.items[0].rate)
+
 
 def create_delivery_note(**args):
 	dn = frappe.new_doc("Delivery Note")


### PR DESCRIPTION
Internal Ref: 8018

Steps to Replicate:
- Create an Internal Sales Order for non-stock items (Rate = 100).
- Create a Delivery Note from the Sales Order. The Rate gets reset to 0 on save.

![image](https://github.com/frappe/erpnext/assets/63660334/5a6f7288-1ba5-41cc-9975-f0751694d259)

![image](https://github.com/frappe/erpnext/assets/63660334/38016dbf-38ab-4fc7-a2e6-d8fd09679cc6)
