### PR TITLE
fix: remove `parent_field` parameter from calls to `rebuild_tree`

### DIFF
--- a/erpnext/accounts/doctype/account/chart_of_accounts/chart_of_accounts.py
+++ b/erpnext/accounts/doctype/account/chart_of_accounts/chart_of_accounts.py
@@ -74,7 +74,7 @@ def create_charts(
 		# after all accounts are already inserted.
 		frappe.local.flags.ignore_update_nsm = True
 		_import_accounts(chart, None, None, root_account=True)
-		rebuild_tree("Account", "parent_account")
+		rebuild_tree("Account")
 		frappe.local.flags.ignore_update_nsm = False
 
 

--- a/erpnext/patches/v11_0/create_department_records_for_each_company.py
+++ b/erpnext/patches/v11_0/create_department_records_for_each_company.py
@@ -35,7 +35,7 @@ def execute():
 			# append list of new department for each company
 			comp_dict[company.name][department.name] = copy_doc.name
 
-	rebuild_tree("Department", "parent_department")
+	rebuild_tree("Department")
 	doctypes = ["Asset", "Employee", "Payroll Entry", "Staffing Plan", "Job Opening"]
 
 	for d in doctypes:

--- a/erpnext/patches/v11_0/make_location_from_warehouse.py
+++ b/erpnext/patches/v11_0/make_location_from_warehouse.py
@@ -27,7 +27,7 @@ def execute():
 		except frappe.DuplicateEntryError:
 			continue
 
-	rebuild_tree("Location", "parent_location")
+	rebuild_tree("Location")
 
 
 def get_parent_warehouse_name(warehouse):

--- a/erpnext/patches/v11_0/rebuild_tree_for_company.py
+++ b/erpnext/patches/v11_0/rebuild_tree_for_company.py
@@ -4,4 +4,4 @@ from frappe.utils.nestedset import rebuild_tree
 
 def execute():
 	frappe.reload_doc("setup", "doctype", "company")
-	rebuild_tree("Company", "parent_company")
+	rebuild_tree("Company")

--- a/erpnext/patches/v11_0/rename_supplier_type_to_supplier_group.py
+++ b/erpnext/patches/v11_0/rename_supplier_type_to_supplier_group.py
@@ -41,4 +41,4 @@ def build_tree():
 			}
 		).insert(ignore_permissions=True)
 
-	rebuild_tree("Supplier Group", "parent_supplier_group")
+	rebuild_tree("Supplier Group")

--- a/erpnext/patches/v11_0/update_department_lft_rgt.py
+++ b/erpnext/patches/v11_0/update_department_lft_rgt.py
@@ -18,4 +18,4 @@ def execute():
 		)
 	)
 
-	rebuild_tree("Department", "parent_department")
+	rebuild_tree("Department")

--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -249,7 +249,7 @@ class Company(NestedSet):
 		if frappe.flags.parent_company_changed:
 			from frappe.utils.nestedset import rebuild_tree
 
-			rebuild_tree("Company", "parent_company")
+			rebuild_tree("Company")
 
 		frappe.clear_cache()
 
@@ -397,7 +397,7 @@ class Company(NestedSet):
 		frappe.local.flags.ignore_update_nsm = True
 		make_records(records)
 		frappe.local.flags.ignore_update_nsm = False
-		rebuild_tree("Department", "parent_department")
+		rebuild_tree("Department")
 
 	def validate_coa_input(self):
 		if self.create_chart_of_accounts_based_on == "Existing Company":

--- a/erpnext/setup/doctype/item_group/test_item_group.py
+++ b/erpnext/setup/doctype/item_group/test_item_group.py
@@ -79,7 +79,7 @@ class TestItem(unittest.TestCase):
 		group_b.save()
 
 	def test_rebuild_tree(self):
-		rebuild_tree("Item Group", "parent_item_group")
+		rebuild_tree("Item Group")
 		self.test_basic_tree()
 
 	def move_it_back(self):

--- a/erpnext/stock/__init__.py
+++ b/erpnext/stock/__init__.py
@@ -59,7 +59,7 @@ def get_warehouse_account(warehouse, warehouse_account=None):
 			else:
 				from frappe.utils.nestedset import rebuild_tree
 
-				rebuild_tree("Warehouse", "parent_warehouse")
+				rebuild_tree("Warehouse")
 		else:
 			account = frappe.db.sql(
 				"""


### PR DESCRIPTION
The `parent_field` parameter became redundant with https://github.com/frappe/frappe/pull/24107
