### PR TITLE
fix: inventory dimension negative stock validation

### DIFF
--- a/erpnext/stock/doctype/inventory_dimension/inventory_dimension.py
+++ b/erpnext/stock/doctype/inventory_dimension/inventory_dimension.py
@@ -305,7 +305,7 @@ def get_evaluated_inventory_dimension(doc, sl_dict, parent_doc=None):
 	dimensions = get_document_wise_inventory_dimensions(doc.doctype)
 	filter_dimensions = []
 	for row in dimensions:
-		if row.type_of_transaction:
+		if row.type_of_transaction and row.type_of_transaction != "Both":
 			if (
 				row.type_of_transaction == "Inward"
 				if doc.docstatus == 1

--- a/erpnext/stock/doctype/inventory_dimension/test_inventory_dimension.py
+++ b/erpnext/stock/doctype/inventory_dimension/test_inventory_dimension.py
@@ -429,6 +429,14 @@ class TestInventoryDimension(FrappeTestCase):
 		)
 
 		warehouse = create_warehouse("Negative Stock Warehouse")
+
+		doc = make_stock_entry(item_code=item_code, source=warehouse, qty=10, do_not_submit=True)
+		doc.items[0].inv_site = "Site 1"
+		self.assertRaises(frappe.ValidationError, doc.submit)
+		doc.reload()
+		if doc.docstatus == 1:
+			doc.cancel()
+
 		doc = make_stock_entry(item_code=item_code, target=warehouse, qty=10, do_not_submit=True)
 
 		doc.items[0].to_inv_site = "Site 1"

--- a/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py
+++ b/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py
@@ -111,16 +111,20 @@ class StockLedgerEntry(Document):
 				"posting_date": self.posting_date,
 				"posting_time": self.posting_time,
 				"company": self.company,
+				"sle": self.name,
 			}
 		)
 
 		sle = get_previous_sle(kwargs, extra_cond=extra_cond)
+		qty_after_transaction = 0.0
+		flt_precision = cint(frappe.db.get_default("float_precision")) or 2
 		if sle:
-			flt_precision = cint(frappe.db.get_default("float_precision")) or 2
-			diff = sle.qty_after_transaction + flt(self.actual_qty)
-			diff = flt(diff, flt_precision)
-			if diff < 0 and abs(diff) > 0.0001:
-				self.throw_validation_error(diff, dimensions)
+			qty_after_transaction = sle.qty_after_transaction
+
+		diff = qty_after_transaction + flt(self.actual_qty)
+		diff = flt(diff, flt_precision)
+		if diff < 0 and abs(diff) > 0.0001:
+			self.throw_validation_error(diff, dimensions)
 
 	def throw_validation_error(self, diff, dimensions):
 		dimension_msg = _(", with the inventory {0}: {1}").format(


### PR DESCRIPTION
**Issue**
inventory dimension negative stock not validate for the first entry. To replicate the issue, create the delivery note for an item against which stock is not exists with the inventory dimension. System will allow to make the delivery note entry



