### PR TITLE
fix: add read permission to Buying Settings

### DIFF
--- a/erpnext/buying/doctype/buying_settings/buying_settings.json
+++ b/erpnext/buying/doctype/buying_settings/buying_settings.json
@@ -214,7 +214,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-11-28 13:01:18.403492",
+ "modified": "2024-01-05 15:26:02.320942",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Buying Settings",
@@ -238,6 +238,41 @@
    "role": "Purchase Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "Accounts User",
+   "share": 1
+  },
+  {
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "Accounts Manager",
+   "share": 1
+  },
+  {
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "Stock Manager",
+   "share": 1
+  },
+  {
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "Stock User",
+   "share": 1
+  },
+  {
+   "email": 1,
+   "print": 1,
+   "read": 1,
+   "role": "Purchase User",
+   "share": 1
   }
  ],
  "sort_field": "modified",


### PR DESCRIPTION
**Internal Ref:** 8011

**Issue:** Permission Error for Buying Settings on Purchase Receipt.

Add read permission to roles that have create permission for PR and PI.

related: https://github.com/frappe/erpnext/pull/38942