### PR TITLE
fix: Purchase information is not required for creating a composite asset

### DIFF
--- a/erpnext/assets/doctype/asset/asset.json
+++ b/erpnext/assets/doctype/asset/asset.json
@@ -202,9 +202,9 @@
    "fieldname": "purchase_date",
    "fieldtype": "Date",
    "label": "Purchase Date",
+   "mandatory_depends_on": "eval:!doc.is_existing_asset",
    "read_only": 1,
-   "read_only_depends_on": "eval:!doc.is_existing_asset && !doc.is_composite_asset",
-   "reqd": 1
+   "read_only_depends_on": "eval:!doc.is_existing_asset && !doc.is_composite_asset"
   },
   {
    "fieldname": "disposal_date",
@@ -227,15 +227,15 @@
    "fieldname": "gross_purchase_amount",
    "fieldtype": "Currency",
    "label": "Gross Purchase Amount",
+   "mandatory_depends_on": "eval:(!doc.is_composite_asset || doc.docstatus==1)",
    "options": "Company:company:default_currency",
-   "read_only_depends_on": "eval:!doc.is_existing_asset",
-   "reqd": 1
+   "read_only_depends_on": "eval:!doc.is_existing_asset"
   },
   {
    "fieldname": "available_for_use_date",
    "fieldtype": "Date",
    "label": "Available-for-use Date",
-   "reqd": 1
+   "mandatory_depends_on": "eval:(!doc.is_composite_asset || doc.docstatus==1)"
   },
   {
    "default": "0",
@@ -590,7 +590,7 @@
    "link_fieldname": "target_asset"
   }
  ],
- "modified": "2023-12-21 16:46:20.732869",
+ "modified": "2024-01-05 17:36:53.131512",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset",

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -57,7 +57,7 @@ class Asset(AccountsController):
 		asset_owner: DF.Literal["", "Company", "Supplier", "Customer"]
 		asset_owner_company: DF.Link | None
 		asset_quantity: DF.Int
-		available_for_use_date: DF.Date
+		available_for_use_date: DF.Date | None
 		booked_fixed_asset: DF.Check
 		calculate_depreciation: DF.Check
 		capitalized_in: DF.Link | None
@@ -92,7 +92,7 @@ class Asset(AccountsController):
 		number_of_depreciations_booked: DF.Int
 		opening_accumulated_depreciation: DF.Currency
 		policy_number: DF.Data | None
-		purchase_date: DF.Date
+		purchase_date: DF.Date | None
 		purchase_invoice: DF.Link | None
 		purchase_receipt: DF.Link | None
 		purchase_receipt_amount: DF.Currency
@@ -316,7 +316,12 @@ class Asset(AccountsController):
 			frappe.throw(_("Gross Purchase Amount is mandatory"), frappe.MandatoryError)
 
 		if is_cwip_accounting_enabled(self.asset_category):
-			if not self.is_existing_asset and not self.purchase_receipt and not self.purchase_invoice:
+			if (
+				not self.is_existing_asset
+				and not self.is_composite_asset
+				and not self.purchase_receipt
+				and not self.purchase_invoice
+			):
 				frappe.throw(
 					_("Please create purchase receipt or purchase invoice for the item {0}").format(
 						self.item_code
@@ -329,7 +334,7 @@ class Asset(AccountsController):
 				and not frappe.db.get_value("Purchase Invoice", self.purchase_invoice, "update_stock")
 			):
 				frappe.throw(
-					_("Update stock must be enable for the purchase invoice {0}").format(self.purchase_invoice)
+					_("Update stock must be enabled for the purchase invoice {0}").format(self.purchase_invoice)
 				)
 
 		if not self.calculate_depreciation:

--- a/erpnext/assets/doctype/asset_category/asset_category.py
+++ b/erpnext/assets/doctype/asset_category/asset_category.py
@@ -86,12 +86,12 @@ class AssetCategory(Document):
 					if selected_key_type not in expected_key_types:
 						frappe.throw(
 							_(
-								"Row #{}: {} of {} should be {}. Please modify the account or select a different account."
+								"Row #{0}: {1} of {2} should be {3}. Please update the {1} or select a different account."
 							).format(
 								d.idx,
 								frappe.unscrub(key_to_match),
 								frappe.bold(selected_account),
-								frappe.bold(expected_key_types),
+								frappe.bold(" or ".join(expected_key_types)),
 							),
 							title=_("Invalid Account"),
 						)


### PR DESCRIPTION
Purchase information is not required for creating a composite asset, as it will be capitalised using other parts
- Purchase Receipt
- Purchase Invoice
- Gross Purchase Amount
- Purchase Date