### PR TITLE
fix: set `First Name` in Supplier Contact

### DIFF
--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -706,7 +706,9 @@ def make_contact(args, is_primary_contact=1):
 	else:
 		values.update(
 			{
-				"first_name": args.get("customer_name"),
+				"first_name": args.get("customer_name")
+				if args.doctype == "Customer"
+				else args.get("supplier_name"),
 				"company_name": args.get(party_name_key),
 			}
 		)


### PR DESCRIPTION
**Internal Ref:** 7838

First Name is a required field in Contact (v14).

![image](https://github.com/frappe/erpnext/assets/63660334/af329e6e-892f-4362-911d-8978ce3e6721)



