### PR TITLE
fix: bank transaction status upon reconciliation

### DIFF
--- a/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.py
+++ b/erpnext/accounts/doctype/bank_reconciliation_tool/bank_reconciliation_tool.py
@@ -444,6 +444,10 @@ def reconcile_vouchers(bank_transaction_name, vouchers):
 	vouchers = json.loads(vouchers)
 	transaction = frappe.get_doc("Bank Transaction", bank_transaction_name)
 	transaction.add_payment_entries(vouchers)
+	transaction.validate_duplicate_references()
+	transaction.allocate_payment_entries()
+	transaction.update_allocated_amount()
+	transaction.set_status()
 	transaction.save()
 
 	return transaction

--- a/erpnext/controllers/status_updater.py
+++ b/erpnext/controllers/status_updater.py
@@ -131,11 +131,6 @@ status_map = {
 			"eval:self.status != 'Stopped' and self.per_ordered == 100 and self.docstatus == 1 and self.material_request_type == 'Manufacture'",
 		],
 	],
-	"Bank Transaction": [
-		["Unreconciled", "eval:self.docstatus == 1 and self.unallocated_amount>0"],
-		["Reconciled", "eval:self.docstatus == 1 and self.unallocated_amount<=0"],
-		["Cancelled", "eval:self.docstatus == 2"],
-	],
 	"POS Opening Entry": [
 		["Draft", None],
 		["Open", "eval:self.docstatus == 1 and not self.pos_closing_entry"],


### PR DESCRIPTION
Bank Transaction has incorrect `status` value even upon full allocation. 

Cause: `set_status` in `StatusUpdater` controller class only updates the instance and not the DB. For submitted documents, updating values in instance will not reflect in DB.