### PR TITLE
fix: Show maintain-stock and is-fixed-asset checkbox in item quick entry dialog

### DIFF
--- a/erpnext/stock/doctype/item/item.json
+++ b/erpnext/stock/doctype/item/item.json
@@ -202,6 +202,7 @@
    "label": "Allow Alternative Item"
   },
   {
+   "allow_in_quick_entry": 1,
    "bold": 1,
    "default": "1",
    "depends_on": "eval:!doc.is_fixed_asset",
@@ -239,6 +240,7 @@
    "label": "Standard Selling Rate"
   },
   {
+   "allow_in_quick_entry": 1,
    "default": "0",
    "fieldname": "is_fixed_asset",
    "fieldtype": "Check",
@@ -246,6 +248,7 @@
    "set_only_once": 1
   },
   {
+   "allow_in_quick_entry": 1,
    "depends_on": "is_fixed_asset",
    "fieldname": "asset_category",
    "fieldtype": "Link",
@@ -888,7 +891,7 @@
  "index_web_pages_for_search": 1,
  "links": [],
  "make_attachments_public": 1,
- "modified": "2023-09-18 15:41:32.688051",
+ "modified": "2024-01-08 18:09:30.225085",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Item",


### PR DESCRIPTION
fixes #37505