### PR TITLE
fix: incorrect indicator title for portal sales order

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -582,17 +582,17 @@ class SalesOrder(SellingController):
 
 	def set_indicator(self):
 		"""Set indicator for portal"""
-		if self.per_billed < 100 and self.per_delivered < 100:
-			self.indicator_color = "orange"
-			self.indicator_title = _("Not Paid and Not Delivered")
+		self.indicator_color = {
+			"Draft": "red",
+			"On Hold": "orange",
+			"To Deliver and Bill": "orange",
+			"To Bill": "orange",
+			"To Deliver": "orange",
+			"Completed": "green",
+			"Cancelled": "red",
+		}.get(self.status, "blue")
 
-		elif self.per_billed == 100 and self.per_delivered < 100:
-			self.indicator_color = "orange"
-			self.indicator_title = _("Paid and Not Delivered")
-
-		else:
-			self.indicator_color = "green"
-			self.indicator_title = _("Paid")
+		self.indicator_title = _(self.status)
 
 	def on_recurring(self, reference_doc, auto_repeat_doc):
 		def _get_delivery_date(ref_doc_delivery_date, red_doc_transaction_date, transaction_date):


### PR DESCRIPTION
**Issue**

<img width="1088" alt="Screenshot 2024-01-09 at 3 08 50 PM" src="https://github.com/frappe/erpnext/assets/8780500/7e1aeaeb-da45-455b-bca8-3cb5cee87212">


**After Fix**


<img width="1108" alt="Screenshot 2024-01-09 at 3 07 35 PM" src="https://github.com/frappe/erpnext/assets/8780500/99d1c733-5a23-4af1-b581-a065ad3b4ada">

Fixed https://github.com/frappe/erpnext/issues/38267