### PR TITLE
fix: JV GLEs for auto-set against accounts

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -765,6 +765,7 @@ class JournalEntry(AccountsController):
 			self.get_debited_credited_accounts()
 			if len(self.accounts_credited) > 1 and len(self.accounts_debited) > 1:
 				self.auto_set_against_accounts()
+				self.separate_against_account_entries = 0
 				return
 			self.get_against_accounts()
 
@@ -1035,7 +1036,7 @@ class JournalEntry(AccountsController):
 		transaction_currency_map = self.get_transaction_currency_map()
 		company_currency = erpnext.get_company_currency(self.company)
 
-		self.get_against_accounts()
+		self.set_against_account()
 		for d in self.get("accounts"):
 			if d.debit or d.credit or (self.voucher_type == "Exchange Gain Or Loss"):
 				r = [d.user_remark, self.remark]


### PR DESCRIPTION
**Bug**
When a JV is created from the backend and submitted, eg - accrual JV from Payroll Entry, the against accounts do not get auto-set correctly leading to missing GL entries against the JV.

**Fix**
Correctly set the flag for `separate_against_account_entries` after setting the against account when submit is triggered.