### PR TITLE
fix(ecom): do not create a new contact if a contact already exists

### DIFF
--- a/erpnext/e_commerce/shopping_cart/cart.py
+++ b/erpnext/e_commerce/shopping_cart/cart.py
@@ -501,6 +501,7 @@ def get_party(user=None):
 	contact_name = get_contact_name(user)
 	party = None
 
+	contact = None
 	if contact_name:
 		contact = frappe.get_doc("Contact", contact_name)
 		if contact.links:
@@ -538,11 +539,15 @@ def get_party(user=None):
 		customer.flags.ignore_mandatory = True
 		customer.insert(ignore_permissions=True)
 
-		contact = frappe.new_doc("Contact")
-		contact.update({"first_name": fullname, "email_ids": [{"email_id": user, "is_primary": 1}]})
+		if not contact:
+			contact = frappe.new_doc("Contact")
+			contact.update({"first_name": fullname, "email_ids": [{"email_id": user, "is_primary": 1}]})
+			contact.insert(ignore_permissions=True)
+			contact.reload()
+
 		contact.append("links", dict(link_doctype="Customer", link_name=customer.name))
 		contact.flags.ignore_mandatory = True
-		contact.insert(ignore_permissions=True)
+		contact.save(ignore_permissions=True)
 
 		return customer
 


### PR DESCRIPTION
**Pre-requisites:**
- Setup E-Commerce
- Enable Checkout in E Commerce Settings

**Steps to Replicate:** 
- Set default role in Portal Settings as Customer
- Signup as a new User
- Add an Item to the cart & proceed to checkout
- After checkout, you will get a permission error while viewing Sales Order

**Reason:**
- To view a Sales Order, the website user needs to have a Customer or Supplier role and the contact linked with the user must have a Customer or Supplier linked to the contact
- When the user signs up a contact is created and linked by default
- But while creating a quotation/sales order after checkout, if a contact linked to the customer is not found, a new contact is created with the proper links
- While checking permissions, the default (primary) contact is checked for customer links

**Fix:**
- Add customer link to existing contact if exists