### PR TITLE
feat: provision to select the qty field for Product Page

### DIFF
--- a/erpnext/e_commerce/doctype/e_commerce_settings/e_commerce_settings.json
+++ b/erpnext/e_commerce/doctype/e_commerce_settings/e_commerce_settings.json
@@ -31,6 +31,7 @@
   "column_break_21",
   "default_customer_group",
   "quotation_series",
+  "show_actual_qty",
   "checkout_settings_section",
   "enable_checkout",
   "show_price_in_quotation",
@@ -366,12 +367,19 @@
    "fieldtype": "Check",
    "label": "Enable Redisearch",
    "read_only_depends_on": "eval:!doc.is_redisearch_loaded"
+  },
+  {
+   "default": "1",
+   "description": "If enabled Actual Qty will be shown as <b>In Stock</b> on the product page instead of Projected Qty.",
+   "fieldname": "show_actual_qty",
+   "fieldtype": "Check",
+   "label": "Show Actual Qty"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2022-04-01 18:35:56.106756",
+ "modified": "2024-01-10 21:06:45.386977",
  "modified_by": "Administrator",
  "module": "E-commerce",
  "name": "E Commerce Settings",

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -357,3 +357,4 @@ erpnext.patches.v14_0.update_total_asset_cost_field
 erpnext.patches.v14_0.migrate_gl_to_payment_ledger
 erpnext.stock.doctype.delivery_note.patches.drop_unused_return_against_index # 2023-12-20
 erpnext.patches.v14_0.set_maintain_stock_for_bom_item
+execute:frappe.db.set_single_value('E Commerce Settings', 'show_actual_qty', 1)

--- a/erpnext/utilities/product.py
+++ b/erpnext/utilities/product.py
@@ -2,6 +2,7 @@
 # License: GNU General Public License v3. See license.txt
 
 import frappe
+from frappe.query_builder.functions import IfNull
 from frappe.utils import cint, flt, fmt_money, getdate, nowdate
 
 from erpnext.accounts.doctype.pricing_rule.pricing_rule import get_pricing_rule_for_item
@@ -30,16 +31,26 @@ def get_web_item_qty_in_stock(item_code, item_warehouse_field, warehouse=None):
 
 	total_stock = 0.0
 	if warehouses:
+		qty_field = (
+			"actual_qty"
+			if frappe.db.get_single_value("E Commerce Settings", "show_actual_qty")
+			else "projected_qty"
+		)
+
+		BIN = frappe.qb.DocType("Bin")
+		ITEM = frappe.qb.DocType("Item")
+		UOM = frappe.qb.DocType("UOM Conversion Detail")
+
 		for warehouse in warehouses:
-			stock_qty = frappe.db.sql(
-				"""
-				select S.actual_qty / IFNULL(C.conversion_factor, 1)
-				from tabBin S
-				inner join `tabItem` I on S.item_code = I.Item_code
-				left join `tabUOM Conversion Detail` C on I.sales_uom = C.uom and C.parent = I.Item_code
-				where S.item_code=%s and S.warehouse=%s""",
-				(item_code, warehouse),
-			)
+			stock_qty = (
+				frappe.qb.from_(BIN)
+				.select(BIN[qty_field] / IfNull(UOM.conversion_factor, 1))
+				.inner_join(ITEM)
+				.on(BIN.item_code == ITEM.item_code)
+				.left_join(UOM)
+				.on((ITEM.sales_uom == UOM.uom) & (UOM.parent == ITEM.item_code))
+				.where((BIN.item_code == item_code) & (BIN.warehouse == warehouse))
+			).run()
 
 			if stock_qty:
 				total_stock += adjust_qty_for_expired_items(item_code, stock_qty, warehouse)


### PR DESCRIPTION
**Internal Ref:** 8221

**Issue:** The Stock shown on the Website (e-commerce) should not consider reserved qty.

**Example:** 
- Actual Qty is 100.
- One SO created for 70 Qty, Reserved Qty in Bin increased by 70.
- On the website the Available Stock is still shown as 100 means a user can buy X item's 100 Qty.

![image](https://github.com/frappe/erpnext/assets/63660334/54431407-4b9b-44d6-84ce-4c85003ef5e6)

`no-docs`
