### PR TITLE
fix: do not count completed orders towards reserved_qty

### DIFF
--- a/erpnext/stock/stock_balance.py
+++ b/erpnext/stock/stock_balance.py
@@ -130,7 +130,7 @@ def get_reserved_qty(item_code, warehouse):
 					and parenttype='Sales Order'
 					and item_code != parent_item
 					and exists (select * from `tabSales Order` so
-					where name = dnpi_in.parent and docstatus = 1 and status not in ('On Hold', 'Closed'))
+					where name = dnpi_in.parent and docstatus = 1 and status not in ('On Hold', 'Closed', 'Completed'))
 				) dnpi)
 			union
 				(select stock_qty as dnpi_qty, qty as so_item_qty,
@@ -142,7 +142,7 @@ def get_reserved_qty(item_code, warehouse):
 				and (so_item.delivered_by_supplier is null or so_item.delivered_by_supplier = 0)
 				and exists(select * from `tabSales Order` so
 					where so.name = so_item.parent and so.docstatus = 1
-					and so.status not in ('On Hold', 'Closed')))
+					and so.status not in ('On Hold', 'Closed', 'Completed')))
 			) tab
 		where
 			so_item_qty >= so_item_delivered_qty


### PR DESCRIPTION
This fixes cases, where a `Completed` Sales Order has some `returned_qty` and `dont_reserve_qty_on_return` (Stock setting) is set to false. This should also speed up the query, because less calculations need to be done.

<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->
