### PR TITLE
fix: circular dependency error on deletion of QC and Stock Entry

### DIFF
--- a/erpnext/stock/doctype/quality_inspection/quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/quality_inspection.py
@@ -111,6 +111,9 @@ class QualityInspection(Document):
 	def on_cancel(self):
 		self.update_qc_reference()
 
+	def on_trash(self):
+		self.update_qc_reference()
+
 	def validate_readings_status_mandatory(self):
 		for reading in self.readings:
 			if not reading.status:

--- a/erpnext/stock/doctype/quality_inspection/test_quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/test_quality_inspection.py
@@ -250,6 +250,33 @@ class TestQualityInspection(FrappeTestCase):
 		qa.delete()
 		dn.delete()
 
+	def test_delete_quality_inspection_linked_with_stock_entry(self):
+		item_code = create_item("_Test Cicuular Dependecy Item with QA").name
+
+		se = make_stock_entry(
+			item_code=item_code, target="_Test Warehouse - _TC", qty=1, basic_rate=100, do_not_submit=True
+		)
+
+		se.inspection_required = 1
+		se.save()
+
+		qa = create_quality_inspection(
+			item_code=item_code, reference_type="Stock Entry", reference_name=se.name, do_not_submit=True
+		)
+
+		se.reload()
+		se.items[0].quality_inspection = qa.name
+		se.save()
+
+		qa.delete()
+
+		se.reload()
+
+		qc = se.items[0].quality_inspection
+		self.assertFalse(qc)
+
+		se.delete()
+
 
 def create_quality_inspection(**args):
 	args = frappe._dict(args)


### PR DESCRIPTION
**Steps to Replicate Issue**

- Create the material receipt stock entry and enable the "Inspection Required" (keep it in Draft State)
- Make Quality Inspection from the Stock Entry (Keep it in Draft)
- On the Stock Entry, manually select the QC in the line item table.
- Now try to delete the stock entry
- System will throw the error "Cannot delete or cancel because Stock Entry is linked with Quality Inspection"
- Now when you try to delete the QI, system will throw the error "Cannot delete or cancel because Quality Inspection is linked with Stock Entry"


While Deleting the Stock Entry
<img width="697" alt="Screenshot 2024-01-10 at 8 11 21 PM" src="https://github.com/frappe/erpnext/assets/8780500/df5e2383-41b7-4cc6-b7c9-9b79311e8234">

While Deleting the Quality Inspection
<img width="747" alt="Screenshot 2024-01-10 at 8 11 33 PM" src="https://github.com/frappe/erpnext/assets/8780500/f4af3980-3b7f-4a83-a34a-ba7ad7e7589f">

