### PR TITLE
fix: naming series variable parsing for FY

### DIFF
--- a/erpnext/accounts/test/test_utils.py
+++ b/erpnext/accounts/test/test_utils.py
@@ -23,6 +23,9 @@ class TestUtils(unittest.TestCase):
 		super(TestUtils, cls).setUpClass()
 		make_test_objects("Address", ADDRESS_RECORDS)
 
+	def tearDown(self):
+		frappe.db.rollback()
+
 	def test_get_party_shipping_address(self):
 		address = get_party_shipping_address("Customer", "_Test Customer 1")
 		self.assertEqual(address, "_Test Billing Address 2 Title-Billing")
@@ -125,6 +128,38 @@ class TestUtils(unittest.TestCase):
 		payment_entry.load_from_db()
 		self.assertEqual(len(payment_entry.references), 1)
 		self.assertEqual(payment_entry.difference_amount, 0)
+
+	def test_naming_series_variable_parsing(self):
+		"""
+		Tests parsing utility used by Naming Series Variable hook for FY
+		"""
+		from frappe.custom.doctype.property_setter.property_setter import make_property_setter
+		from frappe.utils import nowdate
+
+		from erpnext.accounts.utils import get_fiscal_year
+		from erpnext.buying.doctype.supplier.test_supplier import create_supplier
+
+		# Configure Supplier Naming in Buying Settings
+		frappe.db.set_default("supp_master_name", "Auto Name")
+
+		# Configure Autoname in Supplier DocType
+		make_property_setter(
+			"Supplier", None, "naming_rule", "Expression", "Data", for_doctype="Doctype"
+		)
+		make_property_setter(
+			"Supplier", None, "autoname", "SUP-.FY.-.#####", "Data", for_doctype="Doctype"
+		)
+
+		# Create Fiscal Year for Current Year
+		fiscal_year = get_fiscal_year(nowdate())[0]
+
+		# Create Supplier
+		supplier = create_supplier()
+
+		# Check Naming Series in generated Supplier ID
+		doc_name = supplier.name.split("-")
+		self.assertEqual(len(doc_name), 3)
+		self.assertSequenceEqual(doc_name[0:2], ("SUP", fiscal_year))
 
 
 ADDRESS_RECORDS = [

--- a/erpnext/accounts/test/test_utils.py
+++ b/erpnext/accounts/test/test_utils.py
@@ -23,7 +23,8 @@ class TestUtils(unittest.TestCase):
 		super(TestUtils, cls).setUpClass()
 		make_test_objects("Address", ADDRESS_RECORDS)
 
-	def tearDown(self):
+	@classmethod
+	def tearDownClass(cls):
 		frappe.db.rollback()
 
 	def test_get_party_shipping_address(self):
@@ -150,7 +151,6 @@ class TestUtils(unittest.TestCase):
 			"Supplier", None, "autoname", "SUP-.FY.-.#####", "Data", for_doctype="Doctype"
 		)
 
-		# Create Fiscal Year for Current Year
 		fiscal_year = get_fiscal_year(nowdate())[0]
 
 		# Create Supplier
@@ -160,6 +160,7 @@ class TestUtils(unittest.TestCase):
 		doc_name = supplier.name.split("-")
 		self.assertEqual(len(doc_name), 3)
 		self.assertSequenceEqual(doc_name[0:2], ("SUP", fiscal_year))
+		frappe.db.set_default("supp_master_name", "Supplier Name")
 
 
 ADDRESS_RECORDS = [

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -1275,12 +1275,12 @@ def get_autoname_with_number(number_value, doc_title, company):
 def parse_naming_series_variable(doc, variable):
 	if variable == "FY":
 		if doc:
-			date = doc.get("posting_date") or doc.get("transaction_date")
+			date = doc.get("posting_date") or doc.get("transaction_date") or getdate()
 			company = doc.get("company")
 		else:
 			date = getdate()
 			company = None
-		return get_fiscal_year(date=date, company=company).name
+		return get_fiscal_year(date=date, company=company)[0]
 
 
 @frappe.whitelist()


### PR DESCRIPTION
Ref: https://github.com/frappe/erpnext/pull/39202#issuecomment-1885016841

**Bug**
Realized the following condition failed due to the transaction date not being set for Master documents. This led to fiscal years being returned as a `dict` instead of a `tuple` even though the as_dict condition defaulted to **False**.


https://github.com/frappe/erpnext/blob/c67b0a3a6408075785211da20603fbcd829825bb/erpnext/accounts/utils.py#L109-L110

<br>

**Solution**

- Use current date for fetching fiscal years for master documents.
- Add test to check if the naming series generates the expected name when the **FY** variable is used.