### PR TITLE
fix: Enable multi currency when generating JV if Common Party currency is not same as company currency

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2185,6 +2185,9 @@ class AccountsController(TransactionBase):
 		jv.company = self.company
 		jv.remark = "Adjustment for {} {}".format(self.doctype, self.name)
 
+		if self.currency != self.company_currency:
+			jv.multi_currency = 1
+
 		reconcilation_entry = frappe._dict()
 		advance_entry = frappe._dict()
 


### PR DESCRIPTION
(fix: Enable multi currency when generating JV if Common Party currency is not same as company currency)

When we are creating Purchase Invoice or Sales Invoice for common Party, and the common party has an other currency than Company currency, it's not allowing to submit the Sales/ Purchase Invoice,
