### PR TITLE
fix: broken dimension filters in Sales/Purchase register

### DIFF
--- a/erpnext/accounts/report/utils.py
+++ b/erpnext/accounts/report/utils.py
@@ -368,7 +368,7 @@ def filter_invoices_based_on_dimensions(filters, query, parent_doc):
 						dimension.document_type, filters.get(dimension.fieldname)
 					)
 				fieldname = dimension.fieldname
-				query = query.where(parent_doc[fieldname] == filters.fieldname)
+				query = query.where(parent_doc[fieldname].isin(filters[fieldname]))
 	return query
 
 


### PR DESCRIPTION
before:
<img width="1552" alt="Screenshot 2024-01-11 at 4 26 44 PM" src="https://github.com/frappe/erpnext/assets/3272205/7373094d-a70d-4ae2-a242-9a3d74a71fb3">


after:
<img width="1552" alt="Screenshot 2024-01-11 at 4 26 16 PM" src="https://github.com/frappe/erpnext/assets/3272205/a79a1d03-6a06-4158-8e19-3dea18367822">
