### PR TITLE
refactor: prevent foreign currency subscription for a party

### DIFF
--- a/erpnext/accounts/doctype/subscription/test_subscription.py
+++ b/erpnext/accounts/doctype/subscription/test_subscription.py
@@ -463,7 +463,7 @@ class TestSubscription(FrappeTestCase):
 		subscription = create_subscription(
 			start_date="2018-01-01",
 			generate_invoice_at="Beginning of the current subscription period",
-			plans=[{"plan": "_Test Plan Multicurrency", "qty": 1}],
+			plans=[{"plan": "_Test Plan Multicurrency", "qty": 1, "currency": "USD"}],
 			party="_Test Subscription Customer",
 		)
 
@@ -528,13 +528,21 @@ class TestSubscription(FrappeTestCase):
 
 
 def make_plans():
-	create_plan(plan_name="_Test Plan Name", cost=900)
-	create_plan(plan_name="_Test Plan Name 2", cost=1999)
+	create_plan(plan_name="_Test Plan Name", cost=900, currency="INR")
+	create_plan(plan_name="_Test Plan Name 2", cost=1999, currency="INR")
 	create_plan(
-		plan_name="_Test Plan Name 3", cost=1999, billing_interval="Day", billing_interval_count=14
+		plan_name="_Test Plan Name 3",
+		cost=1999,
+		billing_interval="Day",
+		billing_interval_count=14,
+		currency="INR",
 	)
 	create_plan(
-		plan_name="_Test Plan Name 4", cost=20000, billing_interval="Month", billing_interval_count=3
+		plan_name="_Test Plan Name 4",
+		cost=20000,
+		billing_interval="Month",
+		billing_interval_count=3,
+		currency="INR",
 	)
 	create_plan(
 		plan_name="_Test Plan Multicurrency", cost=50, billing_interval="Month", currency="USD"

--- a/erpnext/accounts/doctype/subscription_plan/subscription_plan.json
+++ b/erpnext/accounts/doctype/subscription_plan/subscription_plan.json
@@ -41,7 +41,8 @@
    "fieldname": "currency",
    "fieldtype": "Link",
    "label": "Currency",
-   "options": "Currency"
+   "options": "Currency",
+   "reqd": 1
   },
   {
    "fieldname": "column_break_3",
@@ -148,10 +149,11 @@
   }
  ],
  "links": [],
- "modified": "2021-12-10 15:24:15.794477",
+ "modified": "2024-01-14 17:59:34.687977",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Subscription Plan",
+ "naming_rule": "By fieldname",
  "owner": "Administrator",
  "permissions": [
   {
@@ -193,5 +195,6 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }

--- a/erpnext/accounts/doctype/subscription_plan/subscription_plan.py
+++ b/erpnext/accounts/doctype/subscription_plan/subscription_plan.py
@@ -24,7 +24,7 @@ class SubscriptionPlan(Document):
 		billing_interval_count: DF.Int
 		cost: DF.Currency
 		cost_center: DF.Link | None
-		currency: DF.Link | None
+		currency: DF.Link
 		item: DF.Link
 		payment_gateway: DF.Link | None
 		plan_name: DF.Data


### PR DESCRIPTION
Subscription currency should not differ from Party billing currency or Company default currency.

<img width="1552" alt="Screenshot 2024-01-12 at 1 21 25 PM" src="https://github.com/frappe/erpnext/assets/3272205/51ae6645-7e7a-4614-bb34-94506ad4577e">
