### PR TITLE
fix: SBB Total Qty validation for SE

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -395,11 +395,7 @@ class StockController(AccountsController):
 		}
 
 		for row in self.get(table_name):
-			for field in [
-				"serial_and_batch_bundle",
-				"current_serial_and_batch_bundle",
-				"rejected_serial_and_batch_bundle",
-			]:
+			for field in QTY_FIELD.keys():
 				if row.get(field):
 					frappe.get_doc("Serial and Batch Bundle", row.get(field)).set_serial_and_batch_values(
 						self, row, qty_field=QTY_FIELD[field]

--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -490,8 +490,10 @@ class SerialandBatchBundle(Document):
 			qty_field = "qty"
 
 		precision = row.precision
-		if row.get("doctype") in ["Subcontracting Receipt Supplied Item"]:
+		if row.get("doctype") == "Subcontracting Receipt Supplied Item":
 			qty_field = "consumed_qty"
+		elif row.get("doctype") == "Stock Entry Detail":
+			qty_field = "transfer_qty"
 
 		qty = row.get(qty_field)
 		if qty_field == "qty" and row.get("stock_qty"):


### PR DESCRIPTION
**Internal Ref:** 8359

**Issue:** The SBB `Total Qty` should be compared with the SE `Stock Qty` (transfer_qty).

![image](https://github.com/frappe/erpnext/assets/63660334/14660fbd-ca92-4ce7-85bd-b81f73076554)

![image](https://github.com/frappe/erpnext/assets/63660334/78687f09-e6bc-495a-b434-b464ad4be858)

![image](https://github.com/frappe/erpnext/assets/63660334/9bbb7e01-e0b7-423d-9bde-ae9a85ba069c)
