### PR TITLE
refactor: disallow bank transactions on different currencies

### DIFF
--- a/erpnext/accounts/doctype/bank_reconciliation_tool/test_bank_reconciliation_tool.py
+++ b/erpnext/accounts/doctype/bank_reconciliation_tool/test_bank_reconciliation_tool.py
@@ -76,6 +76,7 @@ class TestBankReconciliationTool(AccountsTestMixin, FrappeTestCase):
 					"deposit": 100,
 					"bank_account": self.bank_account,
 					"reference_number": "123",
+					"currency": "INR",
 				}
 			)
 			.save()

--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
@@ -60,7 +60,9 @@ class BankTransaction(Document):
 
 			if self.currency != account_currency:
 				frappe.throw(
-					_("Currency {0} cannot be different from Bank Account({1}) Currency: {2}").format(
+					_(
+						"Transaction currency: {0} cannot be different from Bank Account({1}) currency: {2}"
+					).format(
 						frappe.bold(self.currency), frappe.bold(self.bank_account), frappe.bold(account_currency)
 					)
 				)

--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
@@ -48,6 +48,22 @@ class BankTransaction(Document):
 
 	def validate(self):
 		self.validate_duplicate_references()
+		self.validate_currency()
+
+	def validate_currency(self):
+		"""
+		Bank Transaction should be on the same currency as the Bank Account.
+		"""
+		if self.currency and self.bank_account:
+			account = frappe.get_cached_value("Bank Account", self.bank_account, "account")
+			account_currency = frappe.get_cached_value("Account", account, "account_currency")
+
+			if self.currency != account_currency:
+				frappe.throw(
+					_("Currency {0} cannot be different from Bank Account({1}) Currency: {2}").format(
+						frappe.bold(self.currency), frappe.bold(self.bank_account), frappe.bold(account_currency)
+					)
+				)
 
 	def set_status(self):
 		if self.docstatus == 2:


### PR DESCRIPTION
Prevent `Bank Transaction`'s on a different currency to the Bank Account currency.
<img width="1552" alt="Screenshot 2024-01-12 at 4 39 38 PM" src="https://github.com/frappe/erpnext/assets/3272205/3fcc61b9-bdfe-4a90-a23f-0eebccb26c3e">
