### PR TITLE
fix: incorrect sql error if account name has '%'

### DIFF
--- a/erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py
+++ b/erpnext/accounts/report/customer_ledger_summary/customer_ledger_summary.py
@@ -376,6 +376,10 @@ class PartyLedgerSummaryReport(object):
 		if not income_or_expense_accounts:
 			# prevent empty 'in' condition
 			income_or_expense_accounts.append("")
+		else:
+			# escape '%' in account name
+			# ignoring frappe.db.escape as it replaces single quotes with double quotes
+			income_or_expense_accounts = [x.replace("%", "%%") for x in income_or_expense_accounts]
 
 		accounts_query = (
 			qb.from_(gl)


### PR DESCRIPTION
Handle `%` in account name on Customer Ledger Summary.
<img width="1552" alt="Screenshot 2024-01-14 at 5 40 13 PM" src="https://github.com/frappe/erpnext/assets/3272205/0c78fe25-5de7-46bf-877f-963a7c7976ee">
