### PR TITLE
fix: project query controller logic

### DIFF
--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -355,7 +355,7 @@ def get_project_name(doctype, txt, searchfield, start, page_len, filters):
 
 	q = qb.from_(proj)
 
-	fields = get_fields("Project", ["name", "project_name"])
+	fields = get_fields(doctype, ["name", "project_name"])
 	for x in fields:
 		q = q.select(proj[x])
 

--- a/erpnext/controllers/queries.py
+++ b/erpnext/controllers/queries.py
@@ -8,9 +8,10 @@ from collections import OrderedDict, defaultdict
 import frappe
 from frappe import qb, scrub
 from frappe.desk.reportview import get_filters_cond, get_match_cond
-from frappe.query_builder import Criterion
-from frappe.query_builder.functions import Concat, Sum
+from frappe.query_builder import Criterion, CustomFunction
+from frappe.query_builder.functions import Concat, Locate, Sum
 from frappe.utils import nowdate, today, unique
+from pypika import Order
 
 import erpnext
 from erpnext.stock.get_item_details import _get_item_tax_template
@@ -348,6 +349,8 @@ def get_project_name(doctype, txt, searchfield, start, page_len, filters):
 	proj = qb.DocType("Project")
 	qb_filter_and_conditions = []
 	qb_filter_or_conditions = []
+	ifelse = CustomFunction("IF", ["condition", "then", "else"])
+
 	if filters and filters.get("customer"):
 		qb_filter_and_conditions.append(proj.customer == filters.get("customer"))
 
@@ -359,17 +362,29 @@ def get_project_name(doctype, txt, searchfield, start, page_len, filters):
 	for x in fields:
 		q = q.select(proj[x])
 
-	# ignore 'customer' and 'status' on searchfields as they must be exactly matched
+	# don't consider 'customer' and 'status' fields for pattern search, as they must be exactly matched
 	searchfields = [
 		x for x in frappe.get_meta(doctype).get_search_fields() if x not in ["customer", "status"]
 	]
+
+	# pattern search
 	if txt:
 		for x in searchfields:
 			qb_filter_or_conditions.append(proj[x].like(f"%{txt}%"))
 
 	q = q.where(Criterion.all(qb_filter_and_conditions)).where(Criterion.any(qb_filter_or_conditions))
+
+	# ordering
+	if txt:
+		# project_name containing search string 'txt' will be given higher precedence
+		q = q.orderby(ifelse(Locate(txt, proj.project_name) > 0, Locate(txt, proj.project_name), 99999))
+	q = q.orderby(proj.idx, order=Order.desc).orderby(proj.name)
+
 	if page_len:
 		q = q.limit(page_len)
+
+	if start:
+		q = q.offset(start)
 	return q.run()
 
 

--- a/erpnext/controllers/tests/test_queries.py
+++ b/erpnext/controllers/tests/test_queries.py
@@ -68,7 +68,7 @@ class TestQueries(unittest.TestCase):
 		self.assertGreaterEqual(len(query(txt="_Test Item Home Desktop Manufactured")), 1)
 
 	def test_project_query(self):
-		query = add_default_params(queries.get_project_name, "BOM")
+		query = add_default_params(queries.get_project_name, "Project")
 
 		self.assertGreaterEqual(len(query(txt="_Test Project")), 1)
 


### PR DESCRIPTION
Fixes broken/incorrect results on 'Project' field in Sales Order and Delivery Note.

Issues addressed:
1. Completed/Cancelled project's are returned in result
2. Projects aren't filters on Customer, even after selecting it in form