### PR TITLE
refactor: BOM creator item selector with short description

### DIFF
--- a/erpnext/manufacturing/doctype/bom_creator/bom_creator.js
+++ b/erpnext/manufacturing/doctype/bom_creator/bom_creator.js
@@ -101,6 +101,7 @@ frappe.ui.form.on("BOM Creator", {
 			}
 		})
 
+		dialog.fields_dict.item_code.get_query = "erpnext.controllers.queries.item_query";
 		dialog.show();
 	},
 
@@ -111,6 +112,16 @@ frappe.ui.form.on("BOM Creator", {
 				filters: {
 					item: item.item_code,
 				}
+			}
+		});
+		frm.set_query("item_code", "items", function() {
+			return {
+				query: "erpnext.controllers.queries.item_query",
+			}
+		});
+		frm.set_query("fg_item", "items", function() {
+			return {
+				query: "erpnext.controllers.queries.item_query",
 			}
 		});
 	},


### PR DESCRIPTION
> Please provide enough information so that others can review your pull request:

On BOM Creator, with there is a item selector the full description is displayed, it's not ideal.
On all other DocType the method to find item use is erpnext.controllers.queries.item_query
This method use a truncate description. This give a better user experience when items are is select list input, it also display item group, etc...

> Explain the **details** for making this change. What existing problem does the pull request solve?

Add query erpnext.controllers.queries.item_query as query when it's possible
Not possible actually on "+ Raw materials" button from BOM creator tree view because
erpnext/public/js/bom_configurator/bom_configurator.bundle.js
```
add_item(node, view) {
		frappe.prompt([Fields Array])
```
Do not allow to send a query method as field declaration



> Screenshots/GIFs

Before : 
![image](https://github.com/frappe/erpnext/assets/1050053/8f5b8e72-a025-49f2-a413-d5cd4f24da78)

![image](https://github.com/frappe/erpnext/assets/1050053/8dfe9d1a-308e-4b9d-b294-4d6d65a5ab16)

![image](https://github.com/frappe/erpnext/assets/1050053/d4122448-bda5-41cb-80d3-335aec29c86b)


After :
![image](https://github.com/frappe/erpnext/assets/1050053/b29ca991-1d5d-4ee1-bcae-2b014af2192a)

![image](https://github.com/frappe/erpnext/assets/1050053/afc42ff6-41da-46fd-b542-3b699b3321bd)

![image](https://github.com/frappe/erpnext/assets/1050053/4d8798ef-8ec7-4bcf-a3ce-aa2385d5db5b)

> no-doc
> no-test