### PR TITLE
fix: test for asset depreciation

### DIFF
--- a/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
@@ -764,17 +764,14 @@ def get_wdv_or_dd_depr_amount(
 	has_wdv_or_dd_non_yearly_pro_rata,
 	asset_depr_schedule,
 ):
-	return (
-		get_default_wdv_or_dd_depr_amount(
-			asset,
-			fb_row,
-			depreciable_value,
-			schedule_idx,
-			prev_depreciation_amount,
-			has_wdv_or_dd_non_yearly_pro_rata,
-			asset_depr_schedule,
-		),
-		None,
+	return get_default_wdv_or_dd_depr_amount(
+		asset,
+		fb_row,
+		depreciable_value,
+		schedule_idx,
+		prev_depreciation_amount,
+		has_wdv_or_dd_non_yearly_pro_rata,
+		asset_depr_schedule,
 	)
 
 


### PR DESCRIPTION
```
ERROR: test_depreciation_entry_for_wdv_without_pro_rata (erpnext.assets.doctype.asset.test_asset.TestDepreciationMethods)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/nabinhait/projects/frappe-bench/apps/erpnext/erpnext/assets/doctype/asset/test_asset.py", line 845, in test_depreciation_entry_for_wdv_without_pro_rata
    asset = create_asset(
  File "/Users/nabinhait/projects/frappe-bench/apps/erpnext/erpnext/assets/doctype/asset/test_asset.py", line 1745, in create_asset
    asset.insert(ignore_if_duplicate=True)
  File "/Users/nabinhait/projects/frappe-bench/apps/frappe/frappe/model/document.py", line 303, in insert
    self.run_method("after_insert")
  File "/Users/nabinhait/projects/frappe-bench/apps/frappe/frappe/model/document.py", line 954, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "/Users/nabinhait/projects/frappe-bench/apps/frappe/frappe/model/document.py", line 1320, in composer
    return composed(self, method, *args, **kwargs)
  File "/Users/nabinhait/projects/frappe-bench/apps/frappe/frappe/model/document.py", line 1302, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "/Users/nabinhait/projects/frappe-bench/apps/frappe/frappe/model/document.py", line 951, in fn
    return method_object(*args, **kwargs)
  File "/Users/nabinhait/projects/frappe-bench/apps/erpnext/erpnext/assets/doctype/asset/asset.py", line 176, in after_insert
    asset_depr_schedules_names = make_draft_asset_depr_schedules(self)
  File "/Users/nabinhait/projects/frappe-bench/apps/erpnext/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py", line 839, in make_draft_asset_depr_schedules
    name = make_draft_asset_depr_schedule(asset_doc, row)
  File "/Users/nabinhait/projects/frappe-bench/apps/erpnext/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py", line 848, in make_draft_asset_depr_schedule
    asset_depr_schedule_doc.prepare_draft_asset_depr_schedule_data(asset_doc, row)
  File "/Users/nabinhait/projects/frappe-bench/apps/erpnext/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py", line 157, in prepare_draft_asset_depr_schedule_data
    self.make_depr_schedule(asset_doc, row, date_of_disposal, update_asset_finance_book_row)
  File "/Users/nabinhait/projects/frappe-bench/apps/erpnext/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py", line 224, in make_depr_schedule
    self._make_depr_schedule(
  File "/Users/nabinhait/projects/frappe-bench/apps/erpnext/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py", line 429, in _make_depr_schedule
    depreciation_amount += value_after_depreciation - row.expected_value_after_useful_life
TypeError: can only concatenate tuple (not "float") to tuple
```