### PR TITLE
feat: handle payment request failure reasons

### DIFF
--- a/erpnext/accounts/doctype/payment_request/payment_request.js
+++ b/erpnext/accounts/doctype/payment_request/payment_request.js
@@ -25,6 +25,10 @@ frappe.ui.form.on("Payment Request", "onload", function(frm, dt, dn){
 })
 
 frappe.ui.form.on("Payment Request", "refresh", function(frm) {
+	if(frm.doc.status == 'Failed'){
+		frm.set_intro(__("Failure: {0}", [frm.doc.failed_reason]), "red");
+	}
+
 	if(frm.doc.payment_request_type == 'Inward' && frm.doc.payment_channel !== "Phone" &&
 		!in_list(["Initiated", "Paid"], frm.doc.status) && !frm.doc.__islocal && frm.doc.docstatus==1){
 		frm.add_custom_button(__('Resend Payment Email'), function(){

--- a/erpnext/accounts/doctype/payment_request/payment_request.json
+++ b/erpnext/accounts/doctype/payment_request/payment_request.json
@@ -7,6 +7,7 @@
  "field_order": [
   "payment_request_type",
   "transaction_date",
+  "failed_reason",
   "column_break_2",
   "naming_series",
   "mode_of_payment",
@@ -389,13 +390,22 @@
    "options": "Payment Request",
    "print_hide": 1,
    "read_only": 1
+  },
+  {
+   "fieldname": "failed_reason",
+   "fieldtype": "Data",
+   "hidden": 1,
+   "label": "Reason for Failure",
+   "no_copy": 1,
+   "print_hide": 1,
+   "read_only": 1
   }
  ],
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-09-27 09:51:42.277638",
+ "modified": "2024-01-20 00:37:06.988919",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Request",

--- a/erpnext/accounts/doctype/payment_request/payment_request_list.js
+++ b/erpnext/accounts/doctype/payment_request/payment_request_list.js
@@ -16,6 +16,9 @@ frappe.listview_settings['Payment Request'] = {
 		else if(doc.status == "Paid") {
 			return [__("Paid"), "blue", "status,=,Paid"];
 		}
+		else if(doc.status == "Failed") {
+			return [__("Failed"), "red", "status,=,Failed"];
+		}
 		else if(doc.status == "Cancelled") {
 			return [__("Cancelled"), "red", "status,=,Cancelled"];
 		}


### PR DESCRIPTION
# Context

When _Integration Request_ associated with a _Payment Request_ fails, this is a moment of truth for customers and a critical situation in the customer journey which the sales agent must manage proactively.

However, the integration request log is rather a technical visibility with (unformatted) json error blobs that does not provide good context for the sale agent.

# Proposed Solution

- [x] add `failed_reason` to _Payment Request_
- [x] expose the reason as banner (see screenshot)

This is supposed to be used with the following method, that should be invoked from a payment gateway:
```python
def on_payment_failed(self, status=None, reason=None):
	if not status:
		return

	if status in ["Failed"]:
		self.db_set("failed_reason", reason)
		self.db_set("status", status)
```

![image](https://github.com/frappe/erpnext/assets/7548295/75cc6cbc-bd33-4efd-be25-5129a540196d)
