### PR TITLE
fix: key error during reposting

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -439,7 +439,7 @@ def get_distinct_item_warehouse(args=None, doc=None, reposting_data=None):
 		reposting_data = get_reposting_data(doc.reposting_data_file)
 
 	if reposting_data and reposting_data.distinct_item_and_warehouse:
-		return reposting_data.distinct_item_and_warehouse
+		return parse_distinct_items_and_warehouses(reposting_data.distinct_item_and_warehouse)
 
 	distinct_item_warehouses = {}
 
@@ -455,6 +455,16 @@ def get_distinct_item_warehouse(args=None, doc=None, reposting_data=None):
 			)
 
 	return distinct_item_warehouses
+
+
+def parse_distinct_items_and_warehouses(distinct_items_and_warehouses):
+	new_dict = frappe._dict({})
+
+	# convert string keys to tuple
+	for k, v in distinct_items_and_warehouses.items():
+		new_dict[frappe.safe_eval(k)] = frappe._dict(v)
+
+	return new_dict
 
 
 def get_affected_transactions(doc, reposting_data=None) -> Set[Tuple[str, str]]:


### PR DESCRIPTION
**Issue**

Error during reposting

```
Traceback:
Traceback with variables (most recent call last): 
File "apps/erpnext/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py", line 285, 
in repost repost_sl_entries(doc) 
doc = e = KeyError(('TN.3000.C', 'MsaFG - AIL')) 
File "apps/erpnext/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py", 
line 319, in repost_sl_entries repost_future_sle( doc = File "apps/erpnext/erpnext/stock/stock_ledger.py", 
line 264, in repost_future_sle 
distinct_item_warehouses[ ('Stock Entry', 'M... i = 128 obj = builtins.KeyError: ('TN.3000.C', 'MsaFG - AIL')
```