### PR TITLE
fix: skip setting liability account for internal transfer

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -189,7 +189,7 @@ class PaymentEntry(AccountsController):
 
 	def set_liability_account(self):
 		# Auto setting liability account should only be done during 'draft' status
-		if self.docstatus > 0:
+		if self.docstatus > 0 or self.payment_type == "Internal Transfer":
 			return
 
 		if not frappe.db.get_value(


### PR DESCRIPTION
Since **Book Advance Payments as Liability** should only capture advance payments paid / received, skip fetching and setting liability account when a payment of the type Internal Transfer is made.