### PR TITLE
fix: do not delete batches implicitly

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -402,11 +402,6 @@ class StockController(AccountsController):
 			d.batch_no = None
 			d.db_set("batch_no", None)
 
-		for data in frappe.get_all(
-			"Batch", {"reference_name": self.name, "reference_doctype": self.doctype}
-		):
-			frappe.delete_doc("Batch", data.name)
-
 	def get_sl_entries(self, d, args):
 		sl_dict = frappe._dict(
 			{

--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -193,7 +193,6 @@ class TestPurchaseReceipt(FrappeTestCase):
 		batch_no = pr.items[0].batch_no
 		pr.cancel()
 
-		self.assertFalse(frappe.db.get_value("Batch", {"item": item.name, "reference_name": pr.name}))
 		self.assertFalse(frappe.db.get_all("Serial No", {"batch_no": batch_no}))
 
 	def test_purchase_receipt_gl_entry(self):
@@ -2171,6 +2170,19 @@ class TestPurchaseReceipt(FrappeTestCase):
 		pr_doc.save()
 		pr_doc.reload()
 		self.assertFalse(pr_doc.items[0].from_warehouse)
+
+	def test_do_not_delete_batch_implicitly(self):
+		item = make_item(
+			"_Test Item With Delete Batch",
+			{"has_batch_no": 1, "create_new_batch": 1, "batch_number_series": "TBWDB.#####"},
+		).name
+
+		pr = make_purchase_receipt(item_code=item, qty=10, rate=100)
+		batch_no = pr.items[0].batch_no
+		self.assertTrue(frappe.db.exists("Batch", batch_no))
+
+		pr.cancel()
+		self.assertTrue(frappe.db.exists("Batch", batch_no))
 
 
 def prepare_data_for_internal_transfer():

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -737,7 +737,7 @@ class TestStockEntry(FrappeTestCase):
 		self.assertEqual(batch_in_serial_no, None)
 
 		self.assertEqual(frappe.db.get_value("Serial No", serial_no, "status"), "Inactive")
-		self.assertEqual(frappe.db.exists("Batch", batch_no), None)
+		self.assertTrue(frappe.db.exists("Batch", batch_no))
 
 	def test_serial_batch_item_qty_deduction(self):
 		"""

--- a/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/test_stock_reconciliation.py
@@ -312,7 +312,7 @@ class TestStockReconciliation(FrappeTestCase, StockTestMixin):
 		sr.cancel()
 
 		self.assertEqual(frappe.db.get_value("Serial No", serial_nos[0], "status"), "Inactive")
-		self.assertEqual(frappe.db.exists("Batch", batch_no), None)
+		self.assertTrue(frappe.db.exists("Batch", batch_no))
 
 	def test_stock_reco_balance_qty_for_serial_and_batch_item(self):
 		from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry


### PR DESCRIPTION
**Issue**

1. Create automatically batch on submission of the purchase receipt 
2. Make delivery note against the respective batch
3. Cancel the delivery note (don't delete)
4. Try to cancel the Purchase Receipt (created at step 1)
5. You will get an error that "Cannot delete or cancel because Batch is linked with Delivery Note"

<img width="884" alt="image" src="https://github.com/frappe/erpnext/assets/8780500/91aebc1b-74ea-4ba9-be50-f0745121e12d">


Upon cancellation of the purchase receipt, the system attempts to delete the corresponding batches. However, as these batches are linked to other canceled documents, the system does not allow the user to cancel the purchase receipt. Ideally, the batches should not be deleted implicitly, and the user should manually delete them.