### PR TITLE
fix: enqueue JV submission when > 100 accounts

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -150,6 +150,20 @@ class JournalEntry(AccountsController):
 		if not self.title:
 			self.title = self.get_title()
 
+	def submit(self):
+		if len(self.accounts) > 100:
+			msgprint(_("The task has been enqueued as a background job."), alert=True)
+			self.queue_action("submit", timeout=4600)
+		else:
+			self._submit()
+
+	def cancel(self):
+		if len(self.accounts) > 100:
+			msgprint(_("The task has been enqueued as a background job."), alert=True)
+			self.queue_action("cancel", timeout=4600)
+		else:
+			self._cancel()
+
 	def on_submit(self):
 		self.validate_cheque_info()
 		self.check_credit_limit()

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -155,14 +155,14 @@ class JournalEntry(AccountsController):
 			msgprint(_("The task has been enqueued as a background job."), alert=True)
 			self.queue_action("submit", timeout=4600)
 		else:
-			self._submit()
+			return self._submit()
 
 	def cancel(self):
 		if len(self.accounts) > 100:
 			msgprint(_("The task has been enqueued as a background job."), alert=True)
 			self.queue_action("cancel", timeout=4600)
 		else:
-			self._cancel()
+			return self._cancel()
 
 	def on_submit(self):
 		self.validate_cheque_info()


### PR DESCRIPTION
The `update_voucher_outstandings` function runs into a timeout error when trying to update the voucher outstandings for a large number of vouchers referenced in the JV accounts. Submit such JVs in the background.