### PR TITLE
fix: not able to save subcontracting purchase receipt (old flow)

### DIFF
--- a/erpnext/controllers/subcontracting_controller.py
+++ b/erpnext/controllers/subcontracting_controller.py
@@ -881,7 +881,9 @@ class SubcontractingController(StockController):
 							"posting_time": self.posting_time,
 							"qty": -1 * item.consumed_qty,
 							"voucher_detail_no": item.name,
-							"serial_and_batch_bundle": item.serial_and_batch_bundle,
+							"serial_and_batch_bundle": item.get("serial_and_batch_bundle"),
+							"serial_no": item.get("serial_no"),
+							"batch_no": item.get("batch_no"),
 						}
 					)
 


### PR DESCRIPTION
**Issue**

```
  File "apps/erpnext/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py", line 230, in validate
    super(PurchaseReceipt, self).validate()
  File "apps/erpnext/erpnext/controllers/buying_controller.py", line 63, in validate
    self.update_valuation_rate()
  File "apps/erpnext/erpnext/controllers/buying_controller.py", line 324, in update_valuation_rate
    item.rm_supp_cost = self.get_supplied_items_cost(item.name, reset_outgoing_rate)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/controllers/subcontracting_controller.py", line 884, in get_supplied_items_cost
    "serial_and_batch_bundle": item.serial_and_batch_bundle,
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'PurchaseReceiptItemSupplied' object has no attribute 'serial_and_batch_bundle'
```