### PR TITLE
fix(minor): type error in financial statements for dashboard

### DIFF
--- a/erpnext/public/js/financial_statements.js
+++ b/erpnext/public/js/financial_statements.js
@@ -74,22 +74,24 @@ erpnext.financial_statements = {
 			});
 		});
 
-		const views_menu = report.page.add_custom_button_group(__('Financial Statements'));
+		if (report.page){
+			const views_menu = report.page.add_custom_button_group(__('Financial Statements'));
 
-		report.page.add_custom_menu_item(views_menu, __("Balance Sheet"), function() {
-			var filters = report.get_values();
-			frappe.set_route('query-report', 'Balance Sheet', {company: filters.company});
-		});
+			report.page.add_custom_menu_item(views_menu, __("Balance Sheet"), function() {
+				var filters = report.get_values();
+				frappe.set_route('query-report', 'Balance Sheet', {company: filters.company});
+			});
 
-		report.page.add_custom_menu_item(views_menu, __("Profit and Loss"), function() {
-			var filters = report.get_values();
-			frappe.set_route('query-report', 'Profit and Loss Statement', {company: filters.company});
-		});
+			report.page.add_custom_menu_item(views_menu, __("Profit and Loss"), function() {
+				var filters = report.get_values();
+				frappe.set_route('query-report', 'Profit and Loss Statement', {company: filters.company});
+			});
 
-		report.page.add_custom_menu_item(views_menu, __("Cash Flow Statement"), function() {
-			var filters = report.get_values();
-			frappe.set_route('query-report', 'Cash Flow', {company: filters.company});
-		});
+			report.page.add_custom_menu_item(views_menu, __("Cash Flow Statement"), function() {
+				var filters = report.get_values();
+				frappe.set_route('query-report', 'Cash Flow', {company: filters.company});
+			});
+		}
 	}
 };
 


### PR DESCRIPTION
**Description**
When any report using the `financial_statements.js` file is filtered within the Accounts Dashboard, a TypeError is thrown because the report is part of the dashboard card and does not have a separate page object to add the custom menu to.

<br>

**Traceback**
><img width="850" alt="Screenshot 2024-01-27 at 11 33 34 PM" src="https://github.com/frappe/erpnext/assets/40693548/ce0c9ab7-77e1-4b68-aa61-e04eb8c34e0f">


<br>

**Solution**
Check for the page object before adding the custom menu group to ensure it only gets added on the report page and not in the dashboard.