### PR TITLE
fix(minor): do not auto-populate item delivery date from qtn

### DIFF
--- a/erpnext/selling/doctype/quotation/quotation.py
+++ b/erpnext/selling/doctype/quotation/quotation.py
@@ -391,7 +391,6 @@ def _make_sales_order(source_name, target_doc=None, ignore_permissions=False):
 		balance_qty = obj.qty - ordered_items.get(obj.item_code, 0.0)
 		target.qty = balance_qty if balance_qty > 0 else 0
 		target.stock_qty = flt(target.qty) * flt(obj.conversion_factor)
-		target.delivery_date = nowdate()
 
 		if obj.against_blanket_order:
 			target.against_blanket_order = obj.against_blanket_order

--- a/erpnext/selling/doctype/quotation/test_quotation.py
+++ b/erpnext/selling/doctype/quotation/test_quotation.py
@@ -99,7 +99,6 @@ class TestQuotation(FrappeTestCase):
 		self.assertEqual(sales_order.get("items")[0].prevdoc_docname, quotation.name)
 		self.assertEqual(sales_order.customer, "_Test Customer")
 
-		sales_order.delivery_date = "2014-01-01"
 		sales_order.naming_series = "_T-Quotation-"
 		sales_order.transaction_date = nowdate()
 		sales_order.insert()
@@ -132,7 +131,6 @@ class TestQuotation(FrappeTestCase):
 		self.assertEqual(sales_order.get("items")[0].prevdoc_docname, quotation.name)
 		self.assertEqual(sales_order.customer, "_Test Customer")
 
-		sales_order.delivery_date = "2014-01-01"
 		sales_order.naming_series = "_T-Quotation-"
 		sales_order.transaction_date = nowdate()
 		sales_order.insert()


### PR DESCRIPTION
### Description
When a Sales Order is created from a Quotation, the Item level delivery date is set to the current date automatically. If there are many items and the user wants to change the delivery date, changing it on the invoice level doesn't work because the new values don't get overwritten over existing values. The user has to manually clear the delivery date on each row.
<br>

### Screen Recording


https://github.com/frappe/erpnext/assets/40693548/aaaa5145-d06a-4580-8e39-5e59cb1a8fc0


<br>

### Changes

Allow user to explicitly set the delivery date instead of auto-populating it.