### PR TITLE
fix: not able to save BOM (duplicate key error)

### DIFF
--- a/erpnext/manufacturing/doctype/bom/bom.py
+++ b/erpnext/manufacturing/doctype/bom/bom.py
@@ -176,8 +176,10 @@ class BOM(WebsiteGenerator):
 
 	def autoname(self):
 		# ignore amended documents while calculating current index
+
+		search_key = f"{self.doctype}-{self.item}%"
 		existing_boms = frappe.get_all(
-			"BOM", filters={"item": self.item, "amended_from": ["is", "not set"]}, pluck="name"
+			"BOM", filters={"name": ("like", search_key), "amended_from": ["is", "not set"]}, pluck="name"
 		)
 
 		if existing_boms:


### PR DESCRIPTION
While creating the new BOM, user getting the below error

<img width="799" alt="image" src="https://github.com/frappe/erpnext/assets/8780500/ba8155b7-9d7d-475a-a970-0adc9d1bf214">
