### PR TITLE
fix: update exploded items on root bom, fixes #38469

### DIFF
--- a/erpnext/manufacturing/doctype/bom_update_log/bom_updation_utils.py
+++ b/erpnext/manufacturing/doctype/bom_update_log/bom_updation_utils.py
@@ -19,11 +19,10 @@ def replace_bom(boms: Dict, log_name: str) -> None:
 	current_bom = boms.get("current_bom")
 	new_bom = boms.get("new_bom")
 
-	unit_cost = get_bom_unit_cost(new_bom)
-	update_new_bom_in_bom_items(unit_cost, current_bom, new_bom)
-
 	frappe.cache().delete_key("bom_children")
 	parent_boms = get_ancestor_boms(new_bom)
+
+	parent_boms.insert(0, new_bom)
 
 	for bom in parent_boms:
 		bom_obj = frappe.get_doc("BOM", bom)


### PR DESCRIPTION
The root BOM exploded items needs updating for the same reason that the cost of the root BOM is updated, child BOMs may have changed.

Fixes https://github.com/frappe/erpnext/issues/38469

https://github.com/frappe/erpnext/pull/39244 does NOT fix the issue

NOTE: `set_maintain_stock_for_bom_item.py` must have been run for BOM update to work which is a v14 patch

version-15-hotfix
version-14-hotfix
version-13-hotfix
