### PR TITLE
fix: Employee is now a tree DocType but has no is_group field

### DIFF
--- a/erpnext/setup/doctype/employee/employee.json
+++ b/erpnext/setup/doctype/employee/employee.json
@@ -116,6 +116,7 @@
   "feedback",
   "lft",
   "rgt",
+  "is_group",
   "old_parent",
   "connections_tab"
  ],
@@ -677,6 +678,7 @@
    "fieldtype": "Int",
    "hidden": 1,
    "label": "lft",
+   "no_copy": 1,
    "read_only": 1
   },
   {
@@ -684,6 +686,7 @@
    "fieldtype": "Int",
    "hidden": 1,
    "label": "rgt",
+   "no_copy": 1,
    "read_only": 1
   },
   {
@@ -817,6 +820,12 @@
    "fieldname": "iban",
    "fieldtype": "Data",
    "label": "IBAN"
+  },
+  {
+   "default": "0",
+   "fieldname": "is_group",
+   "fieldtype": "Check",
+   "label": "Is Group"
   }
  ],
  "icon": "fa fa-user",
@@ -824,7 +833,7 @@
  "image_field": "image",
  "is_tree": 1,
  "links": [],
- "modified": "2024-01-24 02:20:26.145996",
+ "modified": "2024-01-24 18:19:41.016397",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Employee",


### PR DESCRIPTION
closes frappe/hrms#3803

This resolves the error:
![image](https://github.com/frappe/erpnext/assets/8111634/ee3235ca-e4f8-4a39-aa20-66e5dbf834b3)
This happens when setting a value to an Employee field that is set as an accounting dimension. 
