### PR TITLE
fix: incorrect landed cost voucher amount

### DIFF
--- a/erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.py
+++ b/erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.py
@@ -149,6 +149,13 @@ class LandedCostVoucher(Document):
 				self.get("items")[item_count - 1].applicable_charges += diff
 
 	def validate_applicable_charges_for_item(self):
+		if self.distribute_charges_based_on == "Distribute Manually" and len(self.taxes) > 1:
+			frappe.throw(
+				_(
+					"Please keep one Applicable Charges, when 'Distribute Charges Based On' is 'Distribute Manually'. For more charges, please create another Landed Cost Voucher."
+				)
+			)
+
 		based_on = self.distribute_charges_based_on.lower()
 
 		if based_on != "distribute manually":

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -1360,16 +1360,16 @@ def get_item_account_wise_additional_cost(purchase_document):
 	for lcv in landed_cost_vouchers:
 		landed_cost_voucher_doc = frappe.get_doc("Landed Cost Voucher", lcv.parent)
 
+		based_on_field = None
 		# Use amount field for total item cost for manually cost distributed LCVs
-		if landed_cost_voucher_doc.distribute_charges_based_on == "Distribute Manually":
-			based_on_field = "amount"
-		else:
+		if landed_cost_voucher_doc.distribute_charges_based_on != "Distribute Manually":
 			based_on_field = frappe.scrub(landed_cost_voucher_doc.distribute_charges_based_on)
 
 		total_item_cost = 0
 
-		for item in landed_cost_voucher_doc.items:
-			total_item_cost += item.get(based_on_field)
+		if based_on_field:
+			for item in landed_cost_voucher_doc.items:
+				total_item_cost += item.get(based_on_field)
 
 		for item in landed_cost_voucher_doc.items:
 			if item.receipt_document == purchase_document:


### PR DESCRIPTION
- Create two purchase receipts, one will have 2 items and another one has single item.
- Create landed cost voucher and pull both above purchase receipts
- Pull all 3 items
- Set "Distribute Charges Based On" as "Distribute Manually"
- Add Applicable Charges with amount as 600
- Set the Applicable Charges as 100, 100, 200 to all 3 items respectively.
- Try to submit the landed cost voucher

You will get the below error
<img width="718" alt="Screenshot 2024-02-01 at 11 38 00 AM" src="https://github.com/frappe/erpnext/assets/8780500/a554784a-09fd-4cbe-9b04-e163eb997fc4">


**Solution**

1. If the "Distribute Charges Based On" set as "Distribute Manually" then don't allow user to add multiple Applicable Charges
2. Don't  Distribute Charges if the "Distribute Manually" option has set.
