### PR TITLE
fix: remove applied pricing rule on qty change

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -693,7 +693,7 @@ class AccountsController(TransactionBase):
 					if self.get("is_subcontracted"):
 						args["is_subcontracted"] = self.is_subcontracted
 
-					ret = get_item_details(args, self, for_validate=True, overwrite_warehouse=False)
+					ret = get_item_details(args, self, for_validate=for_validate, overwrite_warehouse=False)
 
 					for fieldname, value in ret.items():
 						if item.meta.get_field(fieldname) and value is not None:


### PR DESCRIPTION
**Issue**: The Pricing Rule didn't get removed once applied.

**Pricing Rule:**

![image](https://github.com/frappe/erpnext/assets/63660334/a75f84bf-22e9-420a-a69a-192d9c416af6)

**Before:**

https://github.com/frappe/erpnext/assets/63660334/cbd76c07-0e73-4e13-8618-d023dd3aeb5d

**After:**

https://github.com/frappe/erpnext/assets/63660334/062bf928-f5fa-44d7-8345-59a25fd37a23




