### PR TITLE
refactor: enforce unique GL Account for each 'Bank Account'

### DIFF
--- a/erpnext/accounts/doctype/bank_account/bank_account.py
+++ b/erpnext/accounts/doctype/bank_account/bank_account.py
@@ -9,6 +9,7 @@ from frappe.contacts.address_and_contact import (
 	load_address_and_contact,
 )
 from frappe.model.document import Document
+from frappe.utils import comma_and, get_link_to_form
 
 
 class BankAccount(Document):
@@ -52,6 +53,17 @@ class BankAccount(Document):
 	def validate(self):
 		self.validate_company()
 		self.validate_iban()
+		self.validate_account()
+
+	def validate_account(self):
+		if self.account:
+			if accounts := frappe.db.get_all("Bank Account", filters={"account": self.account}, as_list=1):
+				frappe.throw(
+					_("'{0}' account is already used by {1}. Use another account.").format(
+						frappe.bold(self.account),
+						frappe.bold(comma_and([get_link_to_form(self.doctype, x[0]) for x in accounts])),
+					)
+				)
 
 	def validate_company(self):
 		if self.is_company_account and not self.company:

--- a/erpnext/accounts/doctype/payment_order/test_payment_order.py
+++ b/erpnext/accounts/doctype/payment_order/test_payment_order.py
@@ -4,9 +4,13 @@
 import unittest
 
 import frappe
+from frappe.tests.utils import FrappeTestCase
 from frappe.utils import getdate
 
-from erpnext.accounts.doctype.bank_transaction.test_bank_transaction import create_bank_account
+from erpnext.accounts.doctype.bank_transaction.test_bank_transaction import (
+	create_bank_account,
+	create_gl_account,
+)
 from erpnext.accounts.doctype.payment_entry.payment_entry import (
 	get_payment_entry,
 	make_payment_order,
@@ -14,28 +18,32 @@ from erpnext.accounts.doctype.payment_entry.payment_entry import (
 from erpnext.accounts.doctype.purchase_invoice.test_purchase_invoice import make_purchase_invoice
 
 
-class TestPaymentOrder(unittest.TestCase):
+class TestPaymentOrder(FrappeTestCase):
 	def setUp(self):
-		create_bank_account()
+		# generate and use a uniq hash identifier for 'Bank Account' and it's linked GL 'Account' to avoid validation error
+		uniq_identifier = frappe.generate_hash(length=10)
+		self.gl_account = create_gl_account("_Test Bank " + uniq_identifier)
+		self.bank_account = create_bank_account(
+			gl_account=self.gl_account, bank_account_name="Checking Account " + uniq_identifier
+		)
 
 	def tearDown(self):
-		for bt in frappe.get_all("Payment Order"):
-			doc = frappe.get_doc("Payment Order", bt.name)
-			doc.cancel()
-			doc.delete()
+		frappe.db.rollback()
 
 	def test_payment_order_creation_against_payment_entry(self):
 		purchase_invoice = make_purchase_invoice()
 		payment_entry = get_payment_entry(
-			"Purchase Invoice", purchase_invoice.name, bank_account="_Test Bank - _TC"
+			"Purchase Invoice", purchase_invoice.name, bank_account=self.gl_account
 		)
 		payment_entry.reference_no = "_Test_Payment_Order"
 		payment_entry.reference_date = getdate()
-		payment_entry.party_bank_account = "Checking Account - Citi Bank"
+		payment_entry.party_bank_account = self.bank_account
 		payment_entry.insert()
 		payment_entry.submit()
 
-		doc = create_payment_order_against_payment_entry(payment_entry, "Payment Entry")
+		doc = create_payment_order_against_payment_entry(
+			payment_entry, "Payment Entry", self.bank_account
+		)
 		reference_doc = doc.get("references")[0]
 		self.assertEqual(reference_doc.reference_name, payment_entry.name)
 		self.assertEqual(reference_doc.reference_doctype, "Payment Entry")
@@ -43,13 +51,13 @@ class TestPaymentOrder(unittest.TestCase):
 		self.assertEqual(reference_doc.amount, 250)
 
 
-def create_payment_order_against_payment_entry(ref_doc, order_type):
+def create_payment_order_against_payment_entry(ref_doc, order_type, bank_account):
 	payment_order = frappe.get_doc(
 		dict(
 			doctype="Payment Order",
 			company="_Test Company",
 			payment_order_type=order_type,
-			company_bank_account="Checking Account - Citi Bank",
+			company_bank_account=bank_account,
 		)
 	)
 	doc = make_payment_order(ref_doc.name, payment_order)


### PR DESCRIPTION
Validation to enforce separate General Ledger account for each Bank Account.
<img width="1552" alt="Screenshot 2024-02-02 at 5 45 43 PM" src="https://github.com/frappe/erpnext/assets/3272205/b662ccce-6add-458d-8743-a3e168492635">
