### PR TITLE
fix: check order paid amount before payment request

### DIFF
--- a/erpnext/templates/pages/order.html
+++ b/erpnext/templates/pages/order.html
@@ -40,7 +40,7 @@
 					<p>
 						<a href="/api/method/erpnext.accounts.doctype.payment_request.payment_request.make_payment_request?dn={{ doc.name }}&dt={{ doc.doctype }}&submit_doc=1&order_type=Shopping Cart"
 							class="btn btn-primary btn-sm" id="pay-for-order">
-							{{ _("Pay") }} {{doc.get_formatted("grand_total") }}
+							{{ _("Pay") }} {{ pay_amount }}
 						</a>
 					</p>
 				</div>

--- a/erpnext/templates/pages/order.py
+++ b/erpnext/templates/pages/order.py
@@ -4,6 +4,8 @@
 import frappe
 from frappe import _
 
+from erpnext.accounts.doctype.payment_request.payment_request import get_amount
+
 
 def get_context(context):
 	context.no_cache = 1
@@ -48,10 +50,7 @@ def get_context(context):
 			)
 			context.available_loyalty_points = int(loyalty_program_details.get("loyalty_points"))
 
-	context.show_pay_button = (
-		"payments" in frappe.get_installed_apps()
-		and frappe.db.get_single_value("Buying Settings", "show_pay_button")
-	)
+	context.show_pay_button, context.pay_amount = get_payment_details(context.doc)
 	context.show_make_pi_button = False
 	if context.doc.get("supplier"):
 		# show Make Purchase Invoice button based on permission
@@ -64,3 +63,14 @@ def get_attachments(dt, dn):
 		fields=["name", "file_name", "file_url", "is_private"],
 		filters={"attached_to_name": dn, "attached_to_doctype": dt, "is_private": 0},
 	)
+
+
+def get_payment_details(doc):
+	show_pay_button, amount = (
+		"payments" in frappe.get_installed_apps()
+		and frappe.db.get_single_value("Buying Settings", "show_pay_button")
+	), 0
+	if not show_pay_button:
+		return show_pay_button, amount
+	amount = get_amount(doc)
+	return bool(amount), amount


### PR DESCRIPTION
**Bug**

- Option to create a payment request against an order shows up even though order has been fully paid for.
- In the web portal, the pay button shows the grand total for the Order irrespective of prior payments.

**Fix**

- Even though the amount for existing payment requests is reduced from the grand total of the order, only payment requests that have status Unpaid or Partially Paid are considered. Cases with payment requests in fully paid status and payments made without requests are not included. Reduce any such payments from the Order amount before creating a new payment request.
- Show the remaining amount on the Pay button instead of full amount.