### PR TITLE
fix: incorrect stock valuation in case of return

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -1113,7 +1113,8 @@ def adjust_incoming_rate_for_returns(doc):
 				"rate_difference_with_purchase_invoice",
 				-1
 				* flt(
-					(flt(item_valuation_map.get(item.item_code)) * flt(item.qty)) - flt(item.base_net_amount)
+					(flt(item_valuation_map.get(item.item_code)) * flt(item.stock_qty))
+					- flt(item.base_net_amount)
 				),
 				update_modified=False,
 			)


### PR DESCRIPTION
Steps to replicate:
1. Enabled `set_landed_cost_based_on_purchase_invoice_rate` in Buying Settings
2. Create a Purchase Receipt for 100 qty with rate as 1000
3. Create a return against that receipt for 20 qty
4. Raise a purchase invoice against the initial receipt for 80 qty (as 20 qty is already returned back, no need to bill it)
5. Check the stock and general ledger
    5.1 Stock Ledger shows wrong stock valuation
    5.2 General Ledger shows a balance in the SRBNB account

<hr>

After this PR:
1. The rate as per invoice is also reflected in the return and it's accounting and stock ledgers are re-posted with the correct value

TODO:
- [ ] Need to accomodate LCV