### PR TITLE
fix(work order): resolve type error during job card creation

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -1511,14 +1511,14 @@ def get_serial_nos_for_work_order(work_order, production_item):
 
 
 def validate_operation_data(row):
-	if row.get("qty") <= 0:
+	if flt(row.get("qty")) <= 0:
 		frappe.throw(
 			_("Quantity to Manufacture can not be zero for the operation {0}").format(
 				frappe.bold(row.get("operation"))
 			)
 		)
 
-	if row.get("qty") > row.get("pending_qty"):
+	if flt(row.get("qty")) > flt(row.get("pending_qty")):
 		frappe.throw(
 			_("For operation {0}: Quantity ({1}) can not be greater than pending quantity({2})").format(
 				frappe.bold(row.get("operation")),


### PR DESCRIPTION
### App Versions
```
{
	"erpnext": "15.11.0",
	"frappe": "15.12.0",
	"india_compliance": "15.5.1",
	"print_designer": "1.0.0",
	"ss_enterprises": "0.0.1"
}
```
### Route
```
Form/Work Order/MFG-WO-2024-00024
```
### Traceback
```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 110, in application
    response = frappe.api.handle(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/__init__.py", line 49, in handle
    data = endpoint(**arguments)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/v1.py", line 36, in handle_rpc_call
    return frappe.handler.handle()
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 49, in handle
    data = execute_cmd(cmd)
           ^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 85, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1684, in call
    return fn(*args, **newargs)
           ^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/typing_validations.py", line 31, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/manufacturing/doctype/work_order/work_order.py", line 1429, in make_job_card
    validate_operation_data(row)
  File "apps/erpnext/erpnext/manufacturing/doctype/work_order/work_order.py", line 1521, in validate_operation_data
    if row.get("qty") > row.get("pending_qty"):
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '>' not supported between instances of 'int' and 'NoneType'

```
### Request Data
```
{
	"type": "POST",
	"args": {
		"work_order": "MFG-WO-2024-00024",
		"operations": "[{\"idx\":1,\"__islocal\":true,\"name\":\"row 1\",\"qty\":2}]"
	},
	"freeze": true,
	"headers": {},
	"error_handlers": {},
	"url": "/api/method/erpnext.manufacturing.doctype.work_order.work_order.make_job_card",
	"request_id": "b132fc6d-af6e-4eb6-a910-cb56cd6ee23d"
}
```
### Response Data
```
{
	"exception": "TypeError: '>' not supported between instances of 'int' and 'NoneType'",
	"exc_type": "TypeError",
	"_exc_source": "erpnext (app)"
}
```

`no-docs`
