### PR TITLE
fix: message for failed subscription process

### DIFF
--- a/erpnext/accounts/doctype/subscription/subscription.py
+++ b/erpnext/accounts/doctype/subscription/subscription.py
@@ -594,7 +594,7 @@ class Subscription(Document):
 		"""
 		current_invoice = self.get_current_invoice()
 		if not current_invoice:
-			frappe.throw(_("Current invoice {0} is missing").format(current_invoice.invoice))
+			frappe.throw(_("Subscription {0}: Current invoice is missing.").format(frappe.bold(self.name)))
 		else:
 			if not self.has_outstanding_invoice():
 				self.status = "Active"


### PR DESCRIPTION
**Problem**

https://github.com/frappe/erpnext/blob/317738dc362614a1fa6cc9da1a1db4b482fd67ac/erpnext/accounts/doctype/subscription/subscription.py#L595-L597

Checks if current_invoice is `None` and then tries to fetch the value for .invoice from it.
