### PR TITLE
perf: timeout while submitting the purchase receipt entry

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -640,6 +640,7 @@ class PurchaseOrder(BuyingController):
 				update_sco_status(sco, "Closed" if self.status == "Closed" else None)
 
 
+@frappe.request_cache
 def item_last_purchase_rate(name, conversion_rate, item_code, conversion_factor=1.0):
 	"""get last purchase rate for an item"""
 


### PR DESCRIPTION
1. Same item added 2639 times in the purchase receipt
2. The method item_last_purchase_rate has been called 2639 times which causing the performance issue

**Solution** 

Cached the last purchase rate and set it for the next items

