### PR TITLE
fix(pe): set contact fields

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -30,7 +30,7 @@ from erpnext.accounts.general_ledger import (
 	make_reverse_gl_entries,
 	process_gl_map,
 )
-from erpnext.accounts.party import get_party_account
+from erpnext.accounts.party import get_party_account, set_contact_details
 from erpnext.accounts.utils import (
 	cancel_exchange_gain_loss_journal,
 	get_account_currency,
@@ -444,6 +444,8 @@ class PaymentEntry(AccountsController):
 				self.party_name = frappe.db.get_value(self.party_type, self.party, "name")
 
 		if self.party:
+			if not self.contact_person:
+				set_contact_details(self, party=frappe._dict({"name": self.party}), party_type=self.party_type)
 			if not self.party_balance:
 				self.party_balance = get_balance_on(
 					party_type=self.party_type, party=self.party, date=self.posting_date, company=self.company


### PR DESCRIPTION
# Context

Notifications generally depend on the `contact_*` set of fields.

Payment Entries have a stump implementation that lets you select a contact.

However, unlike every other transactional document, they don't acquire the default contact, if set.

This makes communication automations which depend on the default contact property difficult to implement, because the `contact_*` set of fields are not available.

# Proposed Solution

- [x] like other tx documents, let PEs aquire default contact data, too
- [x] if there's no default contact, nothing happens
