### PR TITLE
fix: do not throw validation for canceled SLE

### DIFF
--- a/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py
+++ b/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py
@@ -93,6 +93,9 @@ class StockLedgerEntry(Document):
 		self.validate_inventory_dimension_negative_stock()
 
 	def validate_inventory_dimension_negative_stock(self):
+		if self.is_cancelled:
+			return
+
 		extra_cond = ""
 		kwargs = {}
 


### PR DESCRIPTION
While cancelling the purchase receipt system throwing Negative stock error, even though stock is exists.

