### PR TITLE
fix: incorrect planned qty in PP

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -312,9 +312,10 @@ class ProductionPlan(Document):
 				so_item.parent,
 				so_item.item_code,
 				so_item.warehouse,
-				(
-					(so_item.qty - so_item.work_order_qty - so_item.delivered_qty) * so_item.conversion_factor
-				).as_("pending_qty"),
+				so_item.qty,
+				so_item.work_order_qty,
+				so_item.delivered_qty,
+				so_item.conversion_factor,
 				so_item.description,
 				so_item.name,
 				so_item.bom_no,
@@ -336,6 +337,11 @@ class ProductionPlan(Document):
 		items_query = items_query.where(ExistsCriterion(items_subquery))
 
 		items = items_query.run(as_dict=True)
+
+		for item in items:
+			item.pending_qty = (
+				flt(item.qty) - max(item.work_order_qty, item.delivered_qty, 0) * item.conversion_factor
+			)
 
 		pi = frappe.qb.DocType("Packed Item")
 


### PR DESCRIPTION
Steps to replicate:
- create SO for 4 qty.
- create PP for 2 qty.
- create DN for 2 qty.
- now, create PP[2] for SO. The FG didn't get added to the PP.