### PR TITLE
fix(Stock Reconciliation): #39777 qty_after_transaction nonetype error

### DIFF
--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -695,6 +695,9 @@ class StockReconciliation(StockController):
 			data.actual_qty = row.qty
 			data.qty_after_transaction = 0.0
 			data.incoming_rate = flt(row.valuation_rate)
+		
+		if not data.qty_after_transaction:
+			data.qty_after_transaction = 0.0
 
 		self.update_inventory_dimensions(row, data)
 


### PR DESCRIPTION
Error while submitting or cancelling Stock reconciliation for items with batch and serial no. #39777

File "apps/erpnext/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py", line 467, in merge_similar_item_serial_nos
data.qty_after_transaction += d.qty_after_transaction
TypeError: unsupported operand type(s) for +=: 'NoneType' and 'NoneType'

 @rohitwaghchaure  @s-aga-r Please Check