### PR TITLE
fix: Order of items added to a Landed Cost voucher is similar to the purchase invoice/receipt

### DIFF
--- a/erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.py
+++ b/erpnext/stock/doctype/landed_cost_voucher/landed_cost_voucher.py
@@ -300,5 +300,6 @@ def get_pr_items(purchase_receipt):
 			(pr_item.parent == purchase_receipt.receipt_document)
 			& ((item.is_stock_item == 1) | (item.is_fixed_asset == 1))
 		)
+		.orderby(pr_item.idx)
 		.run(as_dict=True)
 	)


### PR DESCRIPTION
fix(woocommerce): Order of items added to a Landed Cost voucher is similar to the purchase invoice/receipt

This PR ensures that the items returned by get_items_from_purchase_receipts (get_pr_items) is ordered using the idx field of the Purchase receipt or Purchase invoice. This helps if you are pasting Landed voucher costs (distributed manually) from some spreadsheet.

