### PR TITLE
fix: Handling circular linking while cancelling asset capitalization

### DIFF
--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -322,7 +322,7 @@ frappe.ui.form.on('Asset', {
 	},
 
 	make_schedules_editable: function(frm) {
-		if (frm.doc.finance_books.length) {
+		if (frm.doc.finance_books && frm.doc.finance_books.length) {
 			var is_manual_hence_editable = frm.doc.finance_books.filter(d => d.depreciation_method == "Manual").length > 0
 				? true : false;
 			var is_shift_hence_editable = frm.doc.finance_books.filter(d => d.shift_based).length > 0

--- a/erpnext/assets/doctype/asset/depreciation.py
+++ b/erpnext/assets/doctype/asset/depreciation.py
@@ -508,7 +508,7 @@ def modify_depreciation_schedule_for_asset_repairs(asset):
 
 
 def reverse_depreciation_entry_made_after_disposal(asset, date):
-	if not asset.calculate_depreciation:
+	if not asset.calculate_depreciation or not asset.get("schedules"):
 		return
 
 	row = -1

--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.js
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.js
@@ -7,6 +7,7 @@ frappe.provide("erpnext.assets");
 erpnext.assets.AssetCapitalization = class AssetCapitalization extends erpnext.stock.StockController {
 	setup() {
 		this.setup_posting_date_time_check();
+		this.frm.ignore_doctypes_on_cancel_all = ["Asset Movement"];
 	}
 
 	onload() {

--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
@@ -77,17 +77,21 @@ class AssetCapitalization(StockController):
 			"Stock Ledger Entry",
 			"Repost Item Valuation",
 			"Asset",
+			"Asset Movement"
 		)
 		self.cancel_target_asset()
 		self.update_stock_ledger()
 		self.make_gl_entries()
 		self.restore_consumed_asset_items()
-
+	
 	def cancel_target_asset(self):
 		if self.entry_type == "Capitalization" and self.target_asset:
 			asset_doc = frappe.get_doc("Asset", self.target_asset)
+			asset_doc.db_set("capitalized_in", None)
 			if asset_doc.docstatus == 1:
 				asset_doc.cancel()
+			elif asset_doc.docstatus == 0:
+				asset_doc.delete()
 
 	def set_title(self):
 		self.title = self.target_asset_name or self.target_item_name or self.target_item_code

--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
@@ -90,8 +90,6 @@ class AssetCapitalization(StockController):
 			asset_doc.db_set("capitalized_in", None)
 			if asset_doc.docstatus == 1:
 				asset_doc.cancel()
-			elif asset_doc.docstatus == 0:
-				asset_doc.delete()
 
 	def set_title(self):
 		self.title = self.target_asset_name or self.target_item_name or self.target_item_code


### PR DESCRIPTION
- While cancelling asset capitalization, the system was trying to cancel linked assent movement twice.
- On cancellation, target asset should be deleted if it is in the draft and created via capitalization
- Restore depreciation schedule of consumed asset on cancellation of capitalization