### PR TITLE
fix: warehouse issue in pick list

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.js
+++ b/erpnext/stock/doctype/pick_list/pick_list.js
@@ -77,6 +77,9 @@ frappe.ui.form.on('Pick List', {
 				},
 				freeze: 1,
 				freeze_message: __("Setting Item Locations..."),
+				callback(r) {
+					refresh_field("locations");
+				}
 			});
 		}
 	},

--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -348,9 +348,9 @@ class PickList(Document):
 		picked_items_details = self.get_picked_items_details(items)
 		self.item_location_map = frappe._dict()
 
-		from_warehouses = None
+		from_warehouses = [self.parent_warehouse] if self.parent_warehouse else []
 		if self.parent_warehouse:
-			from_warehouses = get_descendants_of("Warehouse", self.parent_warehouse)
+			from_warehouses.extend(get_descendants_of("Warehouse", self.parent_warehouse))
 
 		# Create replica before resetting, to handle empty table on update after submit.
 		locations_replica = self.get("locations")


### PR DESCRIPTION
While making pick list from the sales order, system has picked incorrect warehouse and not the once which has set in the sales order.

![pick_list_before_fix](https://github.com/frappe/erpnext/assets/8780500/ec8852ea-eed7-4dd6-bc96-b79024bf7c6e)



**After Fix**

![pick_list_after_fix](https://github.com/frappe/erpnext/assets/8780500/21c2fd6d-5c49-4fc1-945c-349cf4b1c34a)
