### PR TITLE
fix: check_credit_limit on_update_after_submit of Sales Order

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -515,6 +515,9 @@ class SalesOrder(SellingController):
 	def on_update(self):
 		pass
 
+	def on_update_after_submit(self):
+		self.check_credit_limit()
+
 	def before_update_after_submit(self):
 		self.validate_po()
 		self.validate_drop_ship()


### PR DESCRIPTION
fixes: #32671

Version 15 and 14

**Before:**

- When updating the Sales Order using 'Update Items' after submitted then credit_limit validation does not work.


https://github.com/frappe/erpnext/assets/141945075/995e9968-e2da-4cbf-af3b-e5713e6dad8a

<br>

**After:**

- After the method `on_update_after_submit`, then it works properly.


https://github.com/frappe/erpnext/assets/141945075/c35d2a82-81e9-4378-85bf-119efa78840a

<br>
Thank You!