### PR TITLE
fix: remove cancelled payment entry from Payment Period Based On Invoice Date

### DIFF
--- a/erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.py
+++ b/erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.py
@@ -163,7 +163,7 @@ def get_entries(filters):
 		"""select
 		voucher_type, voucher_no, party_type, party, posting_date, debit, credit, remarks, against_voucher
 		from `tabGL Entry`
-		where company=%(company)s and voucher_type in ('Journal Entry', 'Payment Entry') {0}
+		where company=%(company)s and voucher_type in ('Journal Entry', 'Payment Entry') {0} and is_cancelled = 0
 	""".format(
 			get_conditions(filters)
 		),

--- a/erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.py
+++ b/erpnext/accounts/report/payment_period_based_on_invoice_date/payment_period_based_on_invoice_date.py
@@ -163,7 +163,7 @@ def get_entries(filters):
 		"""select
 		voucher_type, voucher_no, party_type, party, posting_date, debit, credit, remarks, against_voucher
 		from `tabGL Entry`
-		where company=%(company)s and voucher_type in ('Journal Entry', 'Payment Entry') {0} and is_cancelled = 0
+		where company=%(company)s and voucher_type in ('Journal Entry', 'Payment Entry') and is_cancelled = 0 {0}
 	""".format(
 			get_conditions(filters)
 		),


### PR DESCRIPTION
fixes: #30916

Version 15 and 14

Before:

- This will include canceled payment entries, even though the amount debited and credited is the same. However, these canceled entries should not be displayed because they/users can be confused when looking at the total payment. and users can also confused because the status is not shown in the report.


https://github.com/frappe/erpnext/assets/141945075/8d369de5-a5c8-4c1a-aa81-fb113e2a2454

<br>


**After:**
- Remove cancelled payment entries from the report.


https://github.com/frappe/erpnext/assets/141945075/a50cdeb8-60bd-4915-832e-0d6ebfa8f98f

<br>

Thank You!