### PR TITLE
fix(ux): sales invoice link in error message

### DIFF
--- a/erpnext/accounts/doctype/dunning/dunning.py
+++ b/erpnext/accounts/doctype/dunning/dunning.py
@@ -85,7 +85,14 @@ class Dunning(AccountsController):
 				frappe.throw(
 					_(
 						"The currency of invoice {} ({}) is different from the currency of this dunning ({})."
-					).format(row.sales_invoice, invoice_currency, self.currency)
+					).format(
+						frappe.get_desk_link(
+							"Sales Invoice",
+							row.sales_invoice,
+						),
+						invoice_currency,
+						self.currency,
+					)
 				)
 
 	def validate_overdue_payments(self):


### PR DESCRIPTION
**Before**

![Screenshot from 2024-02-10 23-10-06](https://github.com/frappe/erpnext/assets/83776819/6cff03d6-f2e3-4fe5-bb02-02037b525c2a)

**After**

![Screenshot from 2024-02-10 23-01-53](https://github.com/frappe/erpnext/assets/83776819/a63389f7-8a16-4486-848a-6a182eb065eb)

`no-docs`