### PR TITLE
perf: production plan submission

### DIFF
--- a/erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.json
+++ b/erpnext/manufacturing/doctype/material_request_plan_item/material_request_plan_item.json
@@ -38,7 +38,8 @@
    "in_list_view": 1,
    "label": "Item Code",
    "options": "Item",
-   "reqd": 1
+   "reqd": 1,
+   "search_index": 1
   },
   {
    "fieldname": "item_name",
@@ -53,7 +54,8 @@
    "in_standard_filter": 1,
    "label": "For Warehouse",
    "options": "Warehouse",
-   "reqd": 1
+   "reqd": 1,
+   "search_index": 1
   },
   {
    "columns": 1,
@@ -141,7 +143,8 @@
    "fieldname": "from_warehouse",
    "fieldtype": "Link",
    "label": "From Warehouse",
-   "options": "Warehouse"
+   "options": "Warehouse",
+   "search_index": 1
   },
   {
    "fetch_from": "item_code.safety_stock",
@@ -199,7 +202,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2023-09-12 12:09:08.358326",
+ "modified": "2024-02-11 16:21:11.977018",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Material Request Plan Item",

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.json
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.json
@@ -298,7 +298,8 @@
    "no_copy": 1,
    "options": "\nDraft\nSubmitted\nNot Started\nIn Process\nCompleted\nClosed\nCancelled\nMaterial Requested",
    "print_hide": 1,
-   "read_only": 1
+   "read_only": 1,
+   "search_index": 1
   },
   {
    "fieldname": "amended_from",
@@ -436,7 +437,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-12-26 16:31:13.740777",
+ "modified": "2024-02-11 15:42:47.642481",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Production Plan",

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -1768,23 +1768,23 @@ def get_reserved_qty_for_production_plan(item_code, warehouse):
 	return reserved_qty_for_production_plan - reserved_qty_for_production
 
 
+@frappe.request_cache
 def get_non_completed_production_plans():
 	table = frappe.qb.DocType("Production Plan")
 	child = frappe.qb.DocType("Production Plan Item")
 
-	query = (
+	return (
 		frappe.qb.from_(table)
 		.inner_join(child)
 		.on(table.name == child.parent)
 		.select(table.name)
+		.distinct()
 		.where(
 			(table.docstatus == 1)
 			& (table.status.notin(["Completed", "Closed"]))
 			& (child.planned_qty > child.ordered_qty)
 		)
-	).run(as_dict=True)
-
-	return list(set([d.name for d in query]))
+	).run(pluck="name")
 
 
 def get_raw_materials_of_sub_assembly_items(

--- a/erpnext/manufacturing/doctype/work_order/work_order.json
+++ b/erpnext/manufacturing/doctype/work_order/work_order.json
@@ -447,7 +447,8 @@
    "no_copy": 1,
    "options": "Production Plan",
    "print_hide": 1,
-   "read_only": 1
+   "read_only": 1,
+   "search_index": 1
   },
   {
    "fieldname": "production_plan_item",
@@ -592,7 +593,7 @@
  "image_field": "image",
  "is_submittable": 1,
  "links": [],
- "modified": "2023-08-11 18:35:49.852069",
+ "modified": "2024-02-11 15:47:13.454422",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Work Order",

--- a/erpnext/manufacturing/doctype/work_order_item/work_order_item.json
+++ b/erpnext/manufacturing/doctype/work_order_item/work_order_item.json
@@ -36,7 +36,8 @@
    "fieldtype": "Link",
    "in_list_view": 1,
    "label": "Item Code",
-   "options": "Item"
+   "options": "Item",
+   "search_index": 1
   },
   {
    "fieldname": "source_warehouse",
@@ -141,7 +142,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2022-09-28 10:50:43.512562",
+ "modified": "2024-02-11 15:45:32.318374",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Work Order Item",


### PR DESCRIPTION
156.526s -> 15.199s

**Before:**

```
34086815 function calls (33610353 primitive calls) in 156.526 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    128/1    0.000    0.000  156.526  156.526 {built-in method builtins.exec}
        1    0.000    0.000  156.526  156.526 <string>:1(<module>)
        1    0.005    0.005  156.526  156.526 production_plan.py:492(update_bin_qty)
      613    0.007    0.000  153.748    0.251 bin.py:30(update_reserved_qty_for_production_plan)
     4906    0.028    0.000  151.640    0.031 utils.py:84(execute_query)
      613    0.071    0.000  150.262    0.245 production_plan.py:1651(get_reserved_qty_for_production_plan)
     4906    0.043    0.000  149.184    0.030 database.py:160(sql)
     4906    0.008    0.000  148.524    0.030 cursors.py:138(execute)
     4906    0.009    0.000  148.054    0.030 cursors.py:322(_query)
     4906    0.014    0.000  148.030    0.030 connections.py:543(query)
     4906    0.009    0.000  147.881    0.030 connections.py:767(_read_query_result)
     4906    0.011    0.000  147.865    0.030 connections.py:1155(read)
   830013    1.719    0.000  143.697    0.000 connections.py:687(_read_packet)
  1660026    1.349    0.000  140.592    0.000 connections.py:732(_read_bytes)
  1660155    0.348    0.000  138.193    0.000 {method 'read' of '_io.BufferedReader' objects}
    22710  138.138    0.006  138.138    0.006 {method 'recv_into' of '_socket.socket' objects}
     6758    0.012    0.000  137.845    0.020 socket.py:691(readinto)
      613    0.057    0.000   59.210    0.097 production_plan.py:1694(get_non_completed_production_plans)
     3680    0.009    0.000   21.651    0.006 connections.py:1237(_read_result_packet)
     3680    0.796    0.000   20.079    0.005 connections.py:1270(_read_rowdata_packet)
     1839    0.009    0.000    4.143    0.002 __init__.py:1168(get_doc)
     1839    0.007    0.000    3.742    0.002 document.py:26(get_doc)
     1839    0.008    0.000    3.713    0.002 document.py:83(__init__)
     1839    0.015    0.000    3.705    0.002 document.py:130(load_from_db)
     1840    0.004    0.000    3.595    0.002 database.py:515(get_value)
     1840    0.009    0.000    3.591    0.002 database.py:585(get_values)
     1840    0.010    0.000    3.582    0.002 database.py:851(_get_values_from_table)
     1226    0.022    0.000    3.474    0.003 document.py:1121(db_set)
   760735    0.869    0.000    2.636    0.000 connections.py:1283(_read_row_from_packet)
      613    0.020    0.000    2.415    0.004 work_order.py:1527(get_reserved_qty_for_production)
     4906    0.029    0.000    2.401    0.000 utils.py:107(prepare_query)
     4906    0.017    0.000    2.348    0.000 dialects.py:129(get_sql)
     4906    0.062    0.000    2.317    0.000 queries.py:1218(get_sql)
26530/19776    0.049    0.000    2.279    0.000 {method 'join' of 'str' objects}
  1156139    0.603    0.000    2.055    0.000 protocol.py:165(read_length_coded_string)
     4906    0.012    0.000    2.001    0.000 queries.py:1451(_where_sql)
7357/2453    0.035    0.000    1.934    0.001 terms.py:970(get_sql)
     2452    0.011    0.000    1.740    0.001 terms.py:815(get_sql)
     2452    0.007    0.000    1.712    0.001 terms.py:622(get_sql)
   177770    0.203    0.000    1.673    0.000 terms.py:623(<genexpr>)
   186968    0.670    0.000    1.594    0.000 terms.py:46(get_sql)
     3680    0.139    0.000    1.558    0.000 connections.py:1302(_get_descriptions)
      613    0.002    0.000    1.483    0.002 document.py:1041(load_doc_before_save)
      613    0.001    0.000    1.388    0.002 utils.py:240(get_or_make_bin)
      613    0.001    0.000    1.387    0.002 __init__.py:1150(get_cached_value)
      613    0.002    0.000    1.385    0.002 __init__.py:1075(get_cached_doc)
    27595    0.048    0.000    1.169    0.000 utils.py:48(_copy)
     1226    0.015    0.000    1.162    0.001 database.py:913(set_value)
     3067    0.012    0.000    1.146    0.000 utils.py:58(get_query)
     3067    0.034    0.000    1.134    0.000 query.py:34(get_query)
  1680884    0.936    0.000    0.936    0.000 {method 'settimeout' of '_socket.socket' objects}
     7976    0.028    0.000    0.933    0.000 client.py:894(execute_command)
```

**After:**

```
15978916 function calls (15553847 primitive calls) in 15.199 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    128/1    0.000    0.000   15.199   15.199 {built-in method builtins.exec}
        1    0.000    0.000   15.199   15.199 <string>:1(<module>)
        1    0.004    0.004   15.199   15.199 production_plan.py:492(update_bin_qty)
      613    0.005    0.000   12.453    0.020 bin.py:30(update_reserved_qty_for_production_plan)
     4294    0.024    0.000   11.073    0.003 utils.py:84(execute_query)
      613    0.028    0.000    9.131    0.015 production_plan.py:1651(get_reserved_qty_for_production_plan)
     4294    0.035    0.000    8.735    0.002 database.py:160(sql)
     4294    0.007    0.000    8.479    0.002 cursors.py:138(execute)
     4294    0.008    0.000    8.026    0.002 cursors.py:322(_query)
     4294    0.012    0.000    8.005    0.002 connections.py:543(query)
     4294    0.008    0.000    7.879    0.002 connections.py:767(_read_query_result)
     4294    0.009    0.000    7.867    0.002 connections.py:1155(read)
    70038    0.173    0.000    7.294    0.000 connections.py:687(_read_packet)
   140076    0.128    0.000    6.181    0.000 connections.py:732(_read_bytes)
    20246    6.166    0.000    6.166    0.000 {method 'recv_into' of '_socket.socket' objects}
   140205    0.047    0.000    5.957    0.000 {method 'read' of '_io.BufferedReader' objects}
     4294    0.007    0.000    5.910    0.001 socket.py:691(readinto)
     1839    0.008    0.000    4.042    0.002 __init__.py:1168(get_doc)
     3678    0.016    0.000    3.774    0.001 caching.py:42(wrapper)
      613    0.019    0.000    3.678    0.006 work_order.py:1527(get_reserved_qty_for_production)
     1839    0.006    0.000    3.674    0.002 document.py:26(get_doc)
     1839    0.008    0.000    3.645    0.002 document.py:83(__init__)
     1839    0.014    0.000    3.637    0.002 document.py:130(load_from_db)
     1840    0.003    0.000    3.530    0.002 database.py:515(get_value)
     1840    0.008    0.000    3.526    0.002 database.py:585(get_values)
     1840    0.009    0.000    3.517    0.002 database.py:851(_get_values_from_table)
     1226    0.020    0.000    3.311    0.003 document.py:1121(db_set)
     4294    0.024    0.000    2.291    0.001 utils.py:107(prepare_query)
     4294    0.014    0.000    2.247    0.001 dialects.py:129(get_sql)
24082/17328    0.047    0.000    2.231    0.000 {method 'join' of 'str' objects}
     4294    0.053    0.000    2.220    0.001 queries.py:1218(get_sql)
     4294    0.011    0.000    1.951    0.000 queries.py:1451(_where_sql)
6133/1841    0.029    0.000    1.886    0.001 terms.py:970(get_sql)
     3068    0.005    0.000    1.866    0.001 connections.py:1237(_read_result_packet)
     1840    0.009    0.000    1.724    0.001 terms.py:815(get_sql)
     1840    0.005    0.000    1.703    0.001 terms.py:622(get_sql)
   175934    0.203    0.000    1.667    0.000 terms.py:623(<genexpr>)
   185132    0.666    0.000    1.580    0.000 terms.py:46(get_sql)
     3068    0.135    0.000    1.518    0.000 connections.py:1302(_get_descriptions)
      613    0.002    0.000    1.409    0.002 document.py:1041(load_doc_before_save)
      613    0.001    0.000    1.371    0.002 utils.py:240(get_or_make_bin)
      613    0.001    0.000    1.369    0.002 __init__.py:1150(get_cached_value)
      613    0.002    0.000    1.367    0.002 __init__.py:1075(get_cached_doc)
     3067    0.012    0.000    1.131    0.000 utils.py:58(get_query)
     3067    0.033    0.000    1.119    0.000 query.py:34(get_query)
     1226    0.015    0.000    1.112    0.001 database.py:913(set_value)
    24536    0.042    0.000    1.040    0.000 utils.py:48(_copy)
    56400    0.037    0.000    0.903    0.000 protocol.py:234(__init__)
     7976    0.027    0.000    0.868    0.000 client.py:894(execute_command)
    56400    0.173    0.000    0.854    0.000 protocol.py:238(_parse_field_descriptor)
   185132    0.194    0.000    0.728    0.000 terms.py:363(get_value_sql)
   394940    0.195    0.000    0.667    0.000 protocol.py:165(read_length_coded_string)
     2452    0.012    0.000    0.570    0.000 __init__.py:1138(clear_document_cache)
     4904    0.014    0.000    0.552    0.000 redis_wrapper.py:209(hdel)
     1841    0.007    0.000    0.541    0.000 query.py:99(apply_fields)
   185132    0.248    0.000    0.534    0.000 terms.py:366(get_formatted_value)
     4904    0.006    0.000    0.507    0.000 client.py:3000(hdel)
383366/24536    0.199    0.000    0.472    0.000 copy.py:66(copy)
     1841    0.008    0.000    0.459    0.000 query.py:304(parse_fields)
     6747    0.010    0.000    0.449    0.000 queries.py:925(where)
     4294    0.031    0.000    0.439    0.000 cursors.py:115(mogrify)
     6747    0.030    0.000    0.432    0.000 queries.py:1148(_validate_table)
     1841    0.003    0.000    0.427    0.000 query.py:274(sanitize_fields)
    23922    0.031    0.000    0.424    0.000 dialects.py:99(__copy__)
     1842    0.005    0.000    0.423    0.000 query.py:275(_sanitize_field)
     1842    0.006    0.000    0.417    0.000 __init__.py:45(format)
     1840    0.008    0.000    0.408    0.000 terms.py:187(isin)
     4294    0.008    0.000    0.408    0.000 cursors.py:105(_escape_args)
     7361    0.012    0.000    0.400    0.000 terms.py:56(fields_)
     4294    0.055    0.000    0.398    0.000 cursors.py:109(<dictcomp>)
     2452    0.012    0.000    0.394    0.000 document.py:887(run_method)
     3684    0.010    0.000    0.380    0.000 filter_stack.py:25(run)
    23922    0.126    0.000    0.360    0.000 queries.py:741(__copy__)
```