### PR TITLE
fix(company): incorrect `mandatory_depends_on` conditions on default advance account

### DIFF
--- a/erpnext/setup/doctype/company/company.json
+++ b/erpnext/setup/doctype/company/company.json
@@ -694,7 +694,7 @@
    "fieldname": "default_advance_received_account",
    "fieldtype": "Link",
    "label": "Default Advance Received Account",
-   "mandatory_depends_on": "book_advance_payments_as_liability",
+   "mandatory_depends_on": "book_advance_payments_in_separate_party_account",
    "options": "Account"
   },
   {
@@ -702,7 +702,7 @@
    "fieldname": "default_advance_paid_account",
    "fieldtype": "Link",
    "label": "Default Advance Paid Account",
-   "mandatory_depends_on": "book_advance_payments_as_liability",
+   "mandatory_depends_on": "book_advance_payments_in_separate_party_account",
    "options": "Account"
   },
   {


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

Continues #35609

`mandatory_depends_on` conditions of the default advance account fields wasn't updated to the correct **Book Advance Payments in Separate Party Account** fieldname.
