### PR TITLE
  feat: New financial views - Growth and margin views for P&L and balance sheet (manually merging #39588 in version14)

### DIFF
--- a/erpnext/accounts/report/balance_sheet/balance_sheet.js
+++ b/erpnext/accounts/report/balance_sheet/balance_sheet.js
@@ -6,6 +6,19 @@ frappe.require("assets/erpnext/js/financial_statements.js", function() {
 
 	erpnext.utils.add_dimensions('Balance Sheet', 10);
 
+	frappe.query_reports["Balance Sheet"]["filters"].push(
+		{
+			"fieldname": "selected_view",
+			"label": __("Select View"),
+			"fieldtype": "Select",
+			"options": [
+				{ "value": "Report", "label": __("Report View") },
+				{ "value": "Growth", "label": __("Growth View") }
+			],
+			"default": "Report",
+			"reqd": 1
+		},
+	);
 	frappe.query_reports["Balance Sheet"]["filters"].push({
 		"fieldname": "accumulated_values",
 		"label": __("Accumulated Values"),

--- a/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.js
+++ b/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.js
@@ -10,6 +10,21 @@ frappe.require("assets/erpnext/js/financial_statements.js", function() {
 
 	frappe.query_reports["Profit and Loss Statement"]["filters"].push(
 		{
+			"fieldname": "selected_view",
+			"label": __("Select View"),
+			"fieldtype": "Select",
+			"options": [
+				{ "value": "Report", "label": __("Report View") },
+				{ "value": "Growth", "label": __("Growth View") },
+				{ "value": "Margin", "label": __("Margin View") },
+			],
+			"default": "Report",
+			"reqd": 1
+		},
+	);
+
+	frappe.query_reports["Profit and Loss Statement"]["filters"].push(
+		{
 			"fieldname": "include_default_book_entries",
 			"label": __("Include Default Book Entries"),
 			"fieldtype": "Check",

--- a/erpnext/public/js/financial_statements.js
+++ b/erpnext/public/js/financial_statements.js
@@ -2,7 +2,57 @@ frappe.provide("erpnext.financial_statements");
 
 erpnext.financial_statements = {
 	"filters": get_filters(),
+	"baseData": null,
 	"formatter": function(value, row, column, data, default_formatter, filter) {
+		if(frappe.query_report.get_filter_value("selected_view") == "Growth" && data && column.colIndex >= 3){
+			//Assuming that the first three columns are s.no, account name and the very first year of the accounting values, to calculate the relative percentage values of the successive columns.
+			const lastAnnualValue = row[column.colIndex - 1].content;
+			const currentAnnualvalue = data[column.fieldname];
+			if(currentAnnualvalue == undefined) return 'NA'; //making this not applicable for undefined/null values
+			let annualGrowth = 0;
+			if(lastAnnualValue == 0 && currentAnnualvalue > 0){
+				//If the previous year value is 0 and the current value is greater than 0
+				annualGrowth = 1;
+			}
+			else if(lastAnnualValue > 0){
+				annualGrowth  = (currentAnnualvalue - lastAnnualValue) / lastAnnualValue;
+			}
+
+			const growthPercent = (Math.round(annualGrowth*10000)/100); //calculating the rounded off percentage
+
+			value = $(`<span>${((growthPercent >=0)? '+':'' )+growthPercent+'%'}</span>`);
+			if(growthPercent < 0){
+				value = $(value).addClass("text-danger");
+			}
+			else{
+				value = $(value).addClass("text-success");
+			}
+			value = $(value).wrap("<p></p>").parent().html();
+
+			return value;
+		}
+		else if(frappe.query_report.get_filter_value("selected_view") == "Margin" && data){
+			if(column.fieldname =="account" && data.account_name == __("Income")){
+				//Taking the total income from each column (for all the financial years) as the base (100%)
+				this.baseData = row;
+			}
+			if(column.colIndex >= 2){
+				//Assuming that the first two columns are s.no and account name, to calculate the relative percentage values of the successive columns.
+				const currentAnnualvalue = data[column.fieldname];
+				const baseValue = this.baseData[column.colIndex].content;
+				if(currentAnnualvalue == undefined || baseValue <= 0) return 'NA';
+				const marginPercent = Math.round((currentAnnualvalue/baseValue)*10000)/100;
+
+				value = $(`<span>${marginPercent+'%'}</span>`);
+				if(marginPercent < 0)
+					value = $(value).addClass("text-danger");
+				else
+					value = $(value).addClass("text-success");
+				value = $(value).wrap("<p></p>").parent().html();
+				return value;
+			}
+
+		}
 		if (data && column.fieldname=="account") {
 			value = data.account_name || value;
 


### PR DESCRIPTION
This PR adds two new views in P&L and one new view in Balance Sheet reports in ERPNext. The views are very much similar to Ticker Tape's financial views of public companies.

Financial performance of the company needs to be seen in term of growth and margin also. This view can save time for the financial management team.

For P&L, it adds- Growth View and Margin View
For Balance Sheet, it adds- Growth View

Growth View- Uses the base value from the very first financial year in ERPNext and shows relative growth in % for successive financial years
Margin View- Uses the total sales revenue (income) as the base value for a year, it shows the relative income and expense values in % displaying the final P&L in % for the given financial year.

This change is done in collaboration with Sapcon Instruments Pvt Ltd

Please check the below screenshots of the updated views:
![balance_sheet_growth_view](https://github.com/frappe/erpnext/assets/51705792/bacb7848-2693-4be9-8f8a-5d7c7e7f9a4b)
![profit_loss_growth_view](https://github.com/frappe/erpnext/assets/51705792/44b8a1d7-1232-435b-a6a3-3923a7be6067)
![profit_loss_margin_view_quarterly](https://github.com/frappe/erpnext/assets/51705792/6473ca62-afa1-432e-b748-027bb2ae42bd)
![profit_loss_margin_view](https://github.com/frappe/erpnext/assets/51705792/3cd6eb52-309a-4626-bd8e-302253ffaaaf)
![profit_loss_report_view](https://github.com/frappe/erpnext/assets/51705792/9abd1665-5719-4f66-a51d-0cfc0150d337)
![profit_loss_report_view_quarterly](https://github.com/frappe/erpnext/assets/51705792/1488b3c2-9bbc-4d0a-96be-e5594f450b68)
![balance_sheet_report_view](https://github.com/frappe/erpnext/assets/51705792/37cb3a9b-d3ba-4b07-9816-440452494445)
