### PR TITLE
fix(Purchase Receipt): calculate `stock_value_diff`

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -686,9 +686,7 @@ class PurchaseReceipt(BuyingController):
 						)
 
 					stock_value_diff = (
-						flt(d.base_net_amount)
-						+ flt(d.item_tax_amount / self.conversion_rate)
-						+ flt(d.landed_cost_voucher_amount)
+						flt(d.base_net_amount) + flt(d.item_tax_amount) + flt(d.landed_cost_voucher_amount)
 					)
 				elif warehouse_account.get(d.warehouse):
 					stock_value_diff = get_stock_value_difference(self.name, d.name, d.warehouse)


### PR DESCRIPTION
`d.item_tax_amount` is already in base currency. Dividing it by conversion rate here will lead to a mismatch in debit / credit values.

Reproduce:

- Create a **Purchase Receipt** in a foreign currency
- Add one asset item to the items table
- Add one line for freight charges to the taxes and charges table
- Save and submit

Error:

```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 95, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 47, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 85, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1603, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/desk/form/save.py", line 31, in savedocs
    doc.save()
  File "apps/frappe/frappe/model/document.py", line 305, in save
    return self._save(*args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 357, in _save
    self.run_post_save_methods()
  File "apps/frappe/frappe/model/document.py", line 1069, in run_post_save_methods
    self.run_method("on_submit")
  File "apps/frappe/frappe/model/document.py", line 899, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1251, in composer
    return composed(self, method, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1233, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "apps/frappe/frappe/model/document.py", line 896, in fn
    return method_object(*args, **kwargs)
  File "apps/erpnext/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py", line 270, in on_submit
    self.make_gl_entries()
  File "apps/erpnext/erpnext/controllers/stock_controller.py", line 77, in make_gl_entries
    make_gl_entries(gl_entries, from_repost=from_repost)
  File "apps/erpnext/erpnext/accounts/general_ledger.py", line 47, in make_gl_entries
    save_entries(gl_map, adv_adj, update_outstanding, from_repost)
  File "apps/erpnext/erpnext/accounts/general_ledger.py", line 359, in save_entries
    process_debit_credit_difference(gl_map)
  File "apps/erpnext/erpnext/accounts/general_ledger.py", line 432, in process_debit_credit_difference
    raise_debit_credit_not_equal_error(debit_credit_diff, voucher_type, voucher_no)
  File "apps/erpnext/erpnext/accounts/general_ledger.py", line 469, in raise_debit_credit_not_equal_error
    frappe.throw(
  File "apps/frappe/frappe/__init__.py", line 536, in throw
    msgprint(
  File "apps/frappe/frappe/__init__.py", line 504, in msgprint
    _raise_exception()
  File "apps/frappe/frappe/__init__.py", line 450, in _raise_exception
    raise raise_exception(msg)
frappe.exceptions.ValidationError: Debit and Credit not equal for Purchase Receipt #MAT-PRE-2024-00021. Difference is 0.72.
```

<details>
<summary>Example Data</summary>

```json
{
	"name": "MAT-PRE-2024-00021",
	"owner": "Administrator",
	"creation": "2024-02-12 17:11:06.506708",
	"modified": "2024-02-12 17:12:17.533632",
	"modified_by": "Administrator",
	"docstatus": 0,
	"idx": 0,
	"title": "Supplier Ltd",
	"naming_series": "MAT-PRE-.YYYY.-",
	"supplier": "001",
	"supplier_name": "Supplier Ltd",
	"posting_date": "2024-02-12",
	"posting_time": "17:12:18.275081",
	"set_posting_time": 0,
	"company": "_Test Company",
	"apply_putaway_rule": 0,
	"is_return": 0,
	"currency": "USD",
	"conversion_rate": 0.92825,
	"buying_price_list": "Standard Buying",
	"price_list_currency": "EUR",
	"plc_conversion_rate": 1,
	"ignore_pricing_rule": 0,
	"is_subcontracted": 0,
	"total_qty": 1,
	"total_net_weight": 0,
	"base_total": 92.83,
	"base_net_total": 92.83,
	"total": 100,
	"net_total": 100,
	"tax_category": "",
	"base_taxes_and_charges_added": 9.28,
	"base_taxes_and_charges_deducted": 0,
	"base_total_taxes_and_charges": 9.28,
	"taxes_and_charges_added": 10,
	"taxes_and_charges_deducted": 0,
	"total_taxes_and_charges": 10,
	"base_grand_total": 102.11,
	"base_rounding_adjustment": 0,
	"base_rounded_total": 102.11,
	"base_in_words": "",
	"grand_total": 110,
	"rounding_adjustment": 0,
	"rounded_total": 110,
	"in_words": "",
	"disable_rounded_total": 0,
	"apply_discount_on": "Grand Total",
	"base_discount_amount": 0,
	"additional_discount_percentage": 0,
	"discount_amount": 0,
	"status": "Draft",
	"per_billed": 0,
	"per_returned": 0,
	"letter_head": "Standard",
	"group_same_items": 0,
	"language": "en",
	"is_internal_supplier": 0,
	"represents_company": "",
	"is_old_subcontracting_flow": 0,
	"doctype": "Purchase Receipt",
	"pricing_rules": [],
	"supplied_items": [],
	"taxes": [
		{
			"name": "054d3c9c3e",
			"owner": "Administrator",
			"creation": "2024-02-12 17:11:06.506708",
			"modified": "2024-02-12 17:12:17.533632",
			"modified_by": "Administrator",
			"docstatus": 0,
			"idx": 1,
			"category": "Valuation and Total",
			"add_deduct_tax": "Add",
			"charge_type": "Actual",
			"included_in_print_rate": 0,
			"included_in_paid_amount": 0,
			"account_head": "Freight - _TC",
			"description": "",
			"rate": 0,
			"cost_center": "Other - _TC",
			"account_currency": "EUR",
			"tax_amount": 10,
			"tax_amount_after_discount_amount": 10,
			"total": 110,
			"base_tax_amount": 9.28,
			"base_total": 102.11,
			"base_tax_amount_after_discount_amount": 9.28,
			"item_wise_tax_detail": "{\"STO-ITEM-00001\":[0,9.28]}",
			"parent": "MAT-PRE-2024-00021",
			"parentfield": "taxes",
			"parenttype": "Purchase Receipt",
			"doctype": "Purchase Taxes and Charges",
			"__unsaved": 1
		}
	],
	"items": [
		{
			"name": "f994f21859",
			"owner": "Administrator",
			"creation": "2024-02-12 17:11:06.506708",
			"modified": "2024-02-12 17:12:17.533632",
			"modified_by": "Administrator",
			"docstatus": 0,
			"idx": 1,
			"has_item_scanned": 0,
			"item_code": "STO-ITEM-00001",
			"item_name": "My Asset",
			"description": "<div><p>My Asset</p></div>",
			"brand": "",
			"item_group": "All Item Groups",
			"image": "",
			"received_qty": 1,
			"qty": 1,
			"rejected_qty": 0,
			"uom": "St",
			"stock_uom": "St",
			"conversion_factor": 1,
			"retain_sample": 0,
			"sample_quantity": 0,
			"received_stock_qty": 1,
			"stock_qty": 1,
			"returned_qty": 0,
			"price_list_rate": 0,
			"base_price_list_rate": 0,
			"margin_type": "",
			"margin_rate_or_amount": 0,
			"rate_with_margin": 0,
			"discount_percentage": 0,
			"discount_amount": 0,
			"base_rate_with_margin": 0,
			"rate": 100,
			"amount": 100,
			"base_rate": 92.83,
			"base_amount": 92.83,
			"stock_uom_rate": 100,
			"is_free_item": 0,
			"net_rate": 100,
			"net_amount": 100,
			"base_net_rate": 92.83,
			"base_net_amount": 92.83,
			"valuation_rate": 102.11,
			"item_tax_amount": 0,
			"rm_supp_cost": 0,
			"landed_cost_voucher_amount": 0,
			"rate_difference_with_purchase_invoice": 0,
			"billed_amt": 0,
			"warehouse": "Stores",
			"is_fixed_asset": 1,
			"asset_location": "Main",
			"asset_category": "Main",
			"schedule_date": "2024-02-01",
			"allow_zero_valuation_rate": 0,
			"include_exploded_items": 0,
			"item_tax_rate": "{}",
			"weight_per_unit": 0,
			"total_weight": 0,
			"expense_account": "COGS - _TC",
			"cost_center": "Other - _TC",
			"page_break": 0,
			"parent": "MAT-PRE-2024-00021",
			"parentfield": "items",
			"parenttype": "Purchase Receipt",
			"doctype": "Purchase Receipt Item",
			"__unsaved": 1
		}
	],
	"__onload": {
		"make_payment_via_journal_entry": 0,
		"backflush_based_on": "Material Transferred for Subcontract"
	}
}
```

</details>

The error is resolved with this PR.

Not sure how to add a good test for this – I can't even make the existing tests pass locally.