### PR TITLE
fix: Adjust amount in last row due to rounding

### DIFF
--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -513,14 +513,14 @@ class Asset(AccountsController):
 			)
 
 			# Adjust depreciation amount in the last period based on the expected value after useful life
-			if finance_book.expected_value_after_useful_life and (
+			if (
 				(
 					n == cint(final_number_of_depreciations) - 1
-					and value_after_depreciation != finance_book.expected_value_after_useful_life
+					and flt(value_after_depreciation) != flt(finance_book.expected_value_after_useful_life)
 				)
-				or value_after_depreciation < finance_book.expected_value_after_useful_life
+				or flt(value_after_depreciation) < flt(finance_book.expected_value_after_useful_life)
 			):
-				depreciation_amount += value_after_depreciation - finance_book.expected_value_after_useful_life
+				depreciation_amount += flt(value_after_depreciation) - flt(finance_book.expected_value_after_useful_life)
 				skip_row = True
 
 			if flt(depreciation_amount, self.precision("gross_purchase_amount")) > 0:

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -514,13 +514,14 @@ class Asset(AccountsController):
 
 			# Adjust depreciation amount in the last period based on the expected value after useful life
 			if (
-				(
-					n == cint(final_number_of_depreciations) - 1
-					and flt(value_after_depreciation) != flt(finance_book.expected_value_after_useful_life)
-				)
-				or flt(value_after_depreciation) < flt(finance_book.expected_value_after_useful_life)
+				n == cint(final_number_of_depreciations) - 1
+				and flt(value_after_depreciation) != flt(finance_book.expected_value_after_useful_life)
+			) or flt(value_after_depreciation) < flt(
+				finance_book.expected_value_after_useful_life
 			):
-				depreciation_amount += flt(value_after_depreciation) - flt(finance_book.expected_value_after_useful_life)
+				depreciation_amount += flt(value_after_depreciation) - flt(
+					finance_book.expected_value_after_useful_life
+				)
 				skip_row = True
 
 			if flt(depreciation_amount, self.precision("gross_purchase_amount")) > 0:

--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
@@ -83,7 +83,7 @@ class AssetCapitalization(StockController):
 		self.update_stock_ledger()
 		self.make_gl_entries()
 		self.restore_consumed_asset_items()
-	
+
 	def cancel_target_asset(self):
 		if self.entry_type == "Capitalization" and self.target_asset:
 			asset_doc = frappe.get_doc("Asset", self.target_asset)


### PR DESCRIPTION
If due to rounding issue, the total accumulated depreciation does not match to gross purchase amount, adjust the difference amount in the last row.

<img width="1031" alt="Screenshot 2024-02-13 at 9 43 55 AM" src="https://github.com/frappe/erpnext/assets/836784/209f7d2d-c06a-4a32-bb7d-c88b4564bfed">
