### PR TITLE
fix: use correct field name in accounts controller

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2691,7 +2691,7 @@ def get_advance_journal_entries(
 
 	if order_list:
 		q = q.where(
-			(journal_acc.reference_type == order_doctype) & ((journal_acc.reference_type).isin(order_list))
+			(journal_acc.reference_type == order_doctype) & ((journal_acc.reference_name).isin(order_list))
 		)
 
 	q = q.orderby(journal_entry.posting_date)


### PR DESCRIPTION
# Bug

- Not able to fetch Advance Payments in Sales Invoice and Purchase Invoice
- Field name in Query is wrong

![Screenshot from 2024-02-13 18-18-25](https://github.com/frappe/erpnext/assets/135806454/ec742b89-6f15-443f-a276-94cefe68deec)

