### PR TITLE
refactor(Sales Invoice): move methods into child row controller

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice_item/pos_invoice_item.py
+++ b/erpnext/accounts/doctype/pos_invoice_item/pos_invoice_item.py
@@ -3,10 +3,10 @@
 
 
 # import frappe
-from frappe.model.document import Document
+from erpnext.accounts.doctype.sales_invoice_item.sales_invoice_item import SalesInvoiceItem
 
 
-class POSInvoiceItem(Document):
+class POSInvoiceItem(SalesInvoiceItem):
 	# begin: auto-generated types
 	# This code is auto-generated. Do not modify anything in this block.
 

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -591,43 +591,48 @@ class SalesInvoice(SellingController):
 		self.delete_auto_created_batches()
 
 	def update_status_updater_args(self):
-		if cint(self.update_stock):
-			self.status_updater.append(
-				{
-					"source_dt": "Sales Invoice Item",
-					"target_dt": "Sales Order Item",
-					"target_parent_dt": "Sales Order",
-					"target_parent_field": "per_delivered",
-					"target_field": "delivered_qty",
-					"target_ref_field": "qty",
-					"source_field": "qty",
-					"join_field": "so_detail",
-					"percent_join_field": "sales_order",
-					"status_field": "delivery_status",
-					"keyword": "Delivered",
-					"second_source_dt": "Delivery Note Item",
-					"second_source_field": "qty",
-					"second_join_field": "so_detail",
-					"overflow_type": "delivery",
-					"extra_cond": """ and exists(select name from `tabSales Invoice`
-					where name=`tabSales Invoice Item`.parent and update_stock = 1)""",
-				}
-			)
-			if cint(self.is_return):
-				self.status_updater.append(
-					{
-						"source_dt": "Sales Invoice Item",
-						"target_dt": "Sales Order Item",
-						"join_field": "so_detail",
-						"target_field": "returned_qty",
-						"target_parent_dt": "Sales Order",
-						"source_field": "-1 * qty",
-						"second_source_dt": "Delivery Note Item",
-						"second_source_field": "-1 * qty",
-						"second_join_field": "so_detail",
-						"extra_cond": """ and exists (select name from `tabSales Invoice` where name=`tabSales Invoice Item`.parent and update_stock=1 and is_return=1)""",
-					}
-				)
+		if not cint(self.update_stock):
+			return
+
+		self.status_updater.append(
+			{
+				"source_dt": "Sales Invoice Item",
+				"target_dt": "Sales Order Item",
+				"target_parent_dt": "Sales Order",
+				"target_parent_field": "per_delivered",
+				"target_field": "delivered_qty",
+				"target_ref_field": "qty",
+				"source_field": "qty",
+				"join_field": "so_detail",
+				"percent_join_field": "sales_order",
+				"status_field": "delivery_status",
+				"keyword": "Delivered",
+				"second_source_dt": "Delivery Note Item",
+				"second_source_field": "qty",
+				"second_join_field": "so_detail",
+				"overflow_type": "delivery",
+				"extra_cond": """ and exists(select name from `tabSales Invoice`
+				where name=`tabSales Invoice Item`.parent and update_stock = 1)""",
+			}
+		)
+
+		if not cint(self.is_return):
+			return
+
+		self.status_updater.append(
+			{
+				"source_dt": "Sales Invoice Item",
+				"target_dt": "Sales Order Item",
+				"join_field": "so_detail",
+				"target_field": "returned_qty",
+				"target_parent_dt": "Sales Order",
+				"source_field": "-1 * qty",
+				"second_source_dt": "Delivery Note Item",
+				"second_source_field": "-1 * qty",
+				"second_join_field": "so_detail",
+				"extra_cond": """ and exists (select name from `tabSales Invoice` where name=`tabSales Invoice Item`.parent and update_stock=1 and is_return=1)""",
+			}
+		)
 
 	def check_credit_limit(self):
 		from erpnext.selling.doctype.customer.customer import check_credit_limit

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -379,13 +379,7 @@ class SalesInvoice(SellingController):
 
 	def validate_item_cost_centers(self):
 		for item in self.items:
-			cost_center_company = frappe.get_cached_value("Cost Center", item.cost_center, "company")
-			if cost_center_company != self.company:
-				frappe.throw(
-					_("Row #{0}: Cost Center {1} does not belong to company {2}").format(
-						frappe.bold(item.idx), frappe.bold(item.cost_center), frappe.bold(self.company)
-					)
-				)
+			item.validate_cost_center(self.company)
 
 	def validate_income_account(self):
 		for item in self.get("items"):

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -1025,23 +1025,11 @@ class SalesInvoice(SellingController):
 					frappe.throw(_("Could not update stock, invoice contains drop shipping item."))
 
 	def update_current_stock(self):
-		for d in self.get("items"):
-			if d.item_code and d.warehouse:
-				bin = frappe.db.sql(
-					"select actual_qty from `tabBin` where item_code = %s and warehouse = %s",
-					(d.item_code, d.warehouse),
-					as_dict=1,
-				)
-				d.actual_qty = bin and flt(bin[0]["actual_qty"]) or 0
+		for item in self.items:
+			item.set_actual_qty()
 
-		for d in self.get("packed_items"):
-			bin = frappe.db.sql(
-				"select actual_qty, projected_qty from `tabBin` where item_code =	%s and warehouse = %s",
-				(d.item_code, d.warehouse),
-				as_dict=1,
-			)
-			d.actual_qty = bin and flt(bin[0]["actual_qty"]) or 0
-			d.projected_qty = bin and flt(bin[0]["projected_qty"]) or 0
+		for packed_item in self.packed_items:
+			packed_item.set_actual_and_projected_qty()
 
 	def update_packing_list(self):
 		if cint(self.update_stock) == 1:

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -652,13 +652,8 @@ class SalesInvoice(SellingController):
 	def unlink_sales_invoice_from_timesheets(self):
 		for row in self.timesheets:
 			timesheet = frappe.get_doc("Timesheet", row.time_sheet)
-			for time_log in timesheet.time_logs:
-				if time_log.sales_invoice == self.name:
-					time_log.sales_invoice = None
-			timesheet.calculate_total_amounts()
-			timesheet.calculate_percentage_billed()
+			timesheet.unlink_sales_invoice(self.name)
 			timesheet.flags.ignore_validate_update_after_submit = True
-			timesheet.set_status()
 			timesheet.db_update_all()
 
 	@frappe.whitelist()

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -28,7 +28,6 @@ from erpnext.accounts.party import get_due_date, get_party_account, get_party_de
 from erpnext.accounts.utils import cancel_exchange_gain_loss_journal, get_account_currency
 from erpnext.assets.doctype.asset.depreciation import (
 	depreciate_asset,
-	get_disposal_account_and_cost_center,
 	get_gl_entries_on_asset_disposal,
 	get_gl_entries_on_asset_regain,
 	reset_depreciation_schedule,
@@ -1118,17 +1117,8 @@ class SalesInvoice(SellingController):
 		return warehouse
 
 	def set_income_account_for_fixed_assets(self):
-		disposal_account = depreciation_cost_center = None
-		for d in self.get("items"):
-			if d.is_fixed_asset:
-				if not disposal_account:
-					disposal_account, depreciation_cost_center = get_disposal_account_and_cost_center(
-						self.company
-					)
-
-				d.income_account = disposal_account
-				if not d.cost_center:
-					d.cost_center = depreciation_cost_center
+		for item in self.items:
+			item.set_income_account_for_fixed_asset(self.company)
 
 	def check_prev_docstatus(self):
 		for d in self.get("items"):

--- a/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.py
+++ b/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.py
@@ -5,8 +5,10 @@
 import frappe
 from frappe import _
 from frappe.model.document import Document
+from frappe.utils.data import cint
 
 from erpnext.assets.doctype.asset.depreciation import get_disposal_account_and_cost_center
+from erpnext.stock.doctype.serial_no.serial_no import get_delivery_note_serial_no, get_serial_nos
 
 
 class SalesInvoiceItem(Document):
@@ -124,3 +126,39 @@ class SalesInvoiceItem(Document):
 		self.income_account = disposal_account
 		if not self.cost_center:
 			self.cost_center = depreciation_cost_center
+
+	def set_serial_no_against_delivery_note(self):
+		"""Set serial no based on delivery note."""
+		if self.serial_no and self.delivery_note and self.qty != len(get_serial_nos(self.serial_no)):
+			self.serial_no = get_delivery_note_serial_no(self.item_code, self.qty, self.delivery_note)
+
+	def validate_serial_against_delivery_note(self):
+		"""Ensure the serial numbers in this Sales Invoice Item are same as in the linked Delivery Note."""
+		if not self.delivery_note or not self.dn_detail:
+			return
+
+		serial_nos = frappe.db.get_value("Delivery Note Item", self.dn_detail, "serial_no") or ""
+		dn_serial_nos = set(get_serial_nos(serial_nos))
+
+		serial_nos = self.serial_no or ""
+		si_serial_nos = set(get_serial_nos(serial_nos))
+		serial_no_diff = si_serial_nos - dn_serial_nos
+
+		if serial_no_diff:
+			dn_link = frappe.utils.get_link_to_form("Delivery Note", self.delivery_note)
+			msg = (
+				_("Row #{0}: The following serial numbers are not present in Delivery Note {1}:").format(
+					self.idx, dn_link
+				)
+				+ " "
+				+ ", ".join(frappe.bold(d) for d in serial_no_diff)
+			)
+
+			frappe.throw(msg=msg, title=_("Serial Nos Mismatch"))
+
+		if self.serial_no and cint(self.qty) != len(si_serial_nos):
+			frappe.throw(
+				_(
+					"Row #{0}: {1} serial numbers are required for Item {2}. You have provided {3} serial numbers."
+				).format(self.idx, self.qty, self.item_code, len(si_serial_nos))
+			)

--- a/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.py
+++ b/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.py
@@ -2,6 +2,8 @@
 # License: GNU General Public License v3. See license.txt
 
 
+import frappe
+from frappe import _
 from frappe.model.document import Document
 
 
@@ -92,4 +94,11 @@ class SalesInvoiceItem(Document):
 		weight_uom: DF.Link | None
 	# end: auto-generated types
 
-	pass
+	def validate_cost_center(self, company: str):
+		cost_center_company = frappe.get_cached_value("Cost Center", self.cost_center, "company")
+		if cost_center_company != company:
+			frappe.throw(
+				_("Row #{0}: Cost Center {1} does not belong to company {2}").format(
+					frappe.bold(self.idx), frappe.bold(self.cost_center), frappe.bold(company)
+				)
+			)

--- a/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.py
+++ b/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.py
@@ -6,6 +6,8 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 
+from erpnext.assets.doctype.asset.depreciation import get_disposal_account_and_cost_center
+
 
 class SalesInvoiceItem(Document):
 	# begin: auto-generated types
@@ -111,3 +113,14 @@ class SalesInvoiceItem(Document):
 				)
 				or 0
 			)
+
+	def set_income_account_for_fixed_asset(self, company: str):
+		"""Set income account for fixed asset item based on company's disposal account and cost center."""
+		if not self.is_fixed_asset:
+			return
+
+		disposal_account, depreciation_cost_center = get_disposal_account_and_cost_center(company)
+
+		self.income_account = disposal_account
+		if not self.cost_center:
+			self.cost_center = depreciation_cost_center

--- a/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.py
+++ b/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.py
@@ -102,3 +102,12 @@ class SalesInvoiceItem(Document):
 					frappe.bold(self.idx), frappe.bold(self.cost_center), frappe.bold(company)
 				)
 			)
+
+	def set_actual_qty(self):
+		if self.item_code and self.warehouse:
+			self.actual_qty = (
+				frappe.db.get_value(
+					"Bin", {"item_code": self.item_code, "warehouse": self.warehouse}, "actual_qty"
+				)
+				or 0
+			)

--- a/erpnext/projects/doctype/timesheet/timesheet.py
+++ b/erpnext/projects/doctype/timesheet/timesheet.py
@@ -256,6 +256,16 @@ class Timesheet(Document):
 		if not ts_detail.is_billable:
 			ts_detail.billing_rate = 0.0
 
+	def unlink_sales_invoice(self, sales_invoice: str):
+		"""Remove link to Sales Invoice from all time logs."""
+		for time_log in self.time_logs:
+			if time_log.sales_invoice == sales_invoice:
+				time_log.sales_invoice = None
+
+		self.calculate_total_amounts()
+		self.calculate_percentage_billed()
+		self.set_status()
+
 
 @frappe.whitelist()
 def get_projectwise_timesheet_data(project=None, parent=None, from_time=None, to_time=None):

--- a/erpnext/stock/doctype/packed_item/packed_item.py
+++ b/erpnext/stock/doctype/packed_item/packed_item.py
@@ -51,7 +51,16 @@ class PackedItem(Document):
 		warehouse: DF.Link | None
 	# end: auto-generated types
 
-	pass
+	def set_actual_and_projected_qty(self):
+		"Set actual and projected qty based on warehouse and item_code"
+		_bin = frappe.db.get_value(
+			"Bin",
+			{"item_code": self.item_code, "warehouse": self.warehouse},
+			["actual_qty", "projected_qty"],
+			as_dict=True,
+		)
+		self.actual_qty = _bin.actual_qty if _bin else 0
+		self.projected_qty = _bin.projected_qty if _bin else 0
 
 
 def make_packing_list(doc):


### PR DESCRIPTION
In the **Sales Invoice** controller we have many (mostly validation) methods that process child table rows. This PR moves these methods from the **Sales Invoice** controller into the child table controller, improving separation of concerns and reducing mental load.

Rule of thumb: if a class method mainly accesses properties of another class, the method should probably move there.

My goal is to bring Sales Invoice closer to a state where an average python developer can understand what happens within a reasonable amount of time.

Please check the individual commits: each is a simple refactor and easier to understand than the combined diff.