### PR TITLE
fix: landed cost voucher not submitting because of incorrect reference

### DIFF
--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -217,8 +217,8 @@ class BuyingController(SubcontractingController):
 			lc_voucher_data = frappe.db.sql(
 				"""select sum(applicable_charges), cost_center
 				from `tabLanded Cost Item`
-				where docstatus = 1 and purchase_receipt_item = %s""",
-				d.name,
+				where docstatus = 1 and purchase_receipt_item = %s and receipt_document = %s""",
+				(d.name, self.name),
 			)
 			d.landed_cost_voucher_amount = lc_voucher_data[0][0] if lc_voucher_data else 0.0
 			if not d.cost_center and lc_voucher_data and lc_voucher_data[0][1]:


### PR DESCRIPTION
1. Make two purchase receipts
2. Make two landed cost voucher and change the reference of purchase_receipt_item for the first landed cost voucher (use second purchase receipt's line item reference)
3. Submit the second landed cost voucher first
4. Then submit the first landed cost voucher 
5. System will throw the error "Debit and credit not equal"

Solution
System should not allow to put the incorrect purchase receipt item in the landed cost voucher