### PR TITLE
fix:  production plan issue with sales order

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -652,7 +652,10 @@ class ProductionPlan(Document):
 				"project": self.project,
 			}
 
-			key = (d.item_code, d.sales_order, d.warehouse)
+			key = (d.item_code, d.sales_order, d.sales_order_item, d.warehouse)
+			if self.combine_items:
+				key = (d.item_code, d.sales_order, d.warehouse)
+
 			if not d.sales_order:
 				key = (d.name, d.item_code, d.warehouse)
 


### PR DESCRIPTION
Steps to replicate issue

1. Make sales order and add same item multiple times
2. Make production plan against above sales order
3. Fetch fg items, system will add two items 
4. Disable "Consolidate Sales Order Items" checkbox
5. Submit the production plan and click on Make -> Work Order
6. System will create single work order

Expected Behaviour

If "Consolidate Sales Order Items" checkbox is disabled then create separate work order for each line item