### PR TITLE
fix: not able to make purchase receipt

### DIFF
--- a/erpnext/controllers/subcontracting_controller.py
+++ b/erpnext/controllers/subcontracting_controller.py
@@ -539,6 +539,10 @@ class SubcontractingController(StockController):
 	def __add_supplied_item(self, item_row, bom_item, qty):
 		bom_item.conversion_factor = item_row.conversion_factor
 		rm_obj = self.append(self.raw_material_table, bom_item)
+		if rm_obj.get("qty"):
+			# Qty field not exists
+			rm_obj.qty = 0.0
+
 		rm_obj.reference_name = item_row.name
 
 		if self.doctype == self.subcontract_data.order_doctype:


### PR DESCRIPTION
While making the Purchase Receipt against the OLD Flow Subcontracting Purchase Order, getting the below error


```
Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 95, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 47, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 85, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1603, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/desk/form/save.py", line 31, in savedocs
    doc.save()
  File "apps/frappe/frappe/model/document.py", line 305, in save
    return self._save(*args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 327, in _save
    return self.insert()
  File "apps/frappe/frappe/model/document.py", line 260, in insert
    self.run_before_save_methods()
  File "apps/frappe/frappe/model/document.py", line 1029, in run_before_save_methods
    self.run_method("validate")
  File "apps/frappe/frappe/model/document.py", line 899, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1251, in composer
    return composed(self, method, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1233, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "apps/frappe/frappe/model/document.py", line 896, in fn
    return method_object(*args, **kwargs)
  File "apps/erpnext/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py", line 128, in validate
    self.validate_uom_is_integer("uom", ["qty", "received_qty"])
  File "apps/erpnext/erpnext/utilities/transaction_base.py", line 34, in validate_uom_is_integer
    validate_uom_is_integer(self, uom_field, qty_fields)
  File "apps/erpnext/erpnext/utilities/transaction_base.py", line 215, in validate_uom_is_integer
    if abs(cint(qty) - flt(qty, d.precision(f))) > 0.0000001:
  File "apps/frappe/frappe/model/base_document.py", line 1108, in precision
    if df.fieldtype in ("Currency", "Float", "Percent"):
AttributeError: 'NoneType' object has no attribute 'fieldtype'

```