### PR TITLE
fix: Series field for Project Update should be Select

### DIFF
--- a/erpnext/projects/doctype/project_update/project_update.json
+++ b/erpnext/projects/doctype/project_update/project_update.json
@@ -19,7 +19,7 @@
  "fields": [
   {
    "fieldname": "naming_series",
-   "fieldtype": "Data",
+   "fieldtype": "Select",
    "hidden": 1,
    "label": "Series",
    "options": "PROJ-UPD-.YYYY.-"


### PR DESCRIPTION
Not sure why this field is type Data, but this actually prevents any customization of the doctype, since the Options are invalid for a Data field and the type of this field cannot be customized. I didn't find any other example of a Series field being of type Data.