### PR TITLE
fix: use serial batch fields not enabled for new stock entry

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -234,7 +234,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 	}
 
 	set_fields_onload_for_line_item() {
-		if (this.frm.is_new && this.frm.doc?.items) {
+		if (this.frm.is_new() && this.frm.doc?.items) {
 			this.frm.doc.items.forEach(item => {
 				if (item.docstatus === 0
 					&& frappe.meta.has_field(item.doctype, "use_serial_batch_fields")


### PR DESCRIPTION
- On new stock entry enable "Use Serial No / Batch Fields" if the "Use Serial / Batch fields" enabled in the stock settings
- Serial no scan set the qty based on scanned serial numbers.