### PR TITLE
feat: pass doctype as context when translating label

### DIFF
--- a/erpnext/accounts/print_format/sales_invoice_return/sales_invoice_return.html
+++ b/erpnext/accounts/print_format/sales_invoice_return/sales_invoice_return.html
@@ -5,7 +5,7 @@
 <div class="row {% if df.bold %}important{% endif %} data-field">
 	<div class="col-xs-{{ "9" if df.fieldtype=="Check" else "5" }}
 		{%- if doc.align_labels_right %} text-right{%- endif -%}">
-		<label>{{ _(df.label) }}</label>
+		<label>{{ _(df.label, context=df.parent) }}</label>
 	</div>
 	<div class="col-xs-{{ "3" if df.fieldtype=="Check" else "7" }} value">
 		{% if doc.get(df.fieldname) != None -%}

--- a/erpnext/stock/doctype/item_variant_settings/item_variant_settings.js
+++ b/erpnext/stock/doctype/item_variant_settings/item_variant_settings.js
@@ -15,7 +15,7 @@ frappe.ui.form.on('Item Variant Settings', {
 		frappe.model.with_doctype('Item', () => {
 			const field_label_map = {};
 			frappe.get_meta('Item').fields.forEach(d => {
-				field_label_map[d.fieldname] = __(d.label) + ` (${d.fieldname})`;
+				field_label_map[d.fieldname] = __(d.label, null, d.parent) + ` (${d.fieldname})`;
 
 				if (!in_list(exclude_field_types, d.fieldtype)
 					&& !d.no_copy && !in_list(exclude_fields, d.fieldname)) {

--- a/erpnext/templates/form_grid/includes/visible_cols.html
+++ b/erpnext/templates/form_grid/includes/visible_cols.html
@@ -3,7 +3,7 @@
 	if((df.fieldname !== "description" && df.fieldname !== "item_name") && val) { %}
 		<div class="row">
 			<div class="col-xs-4 ellipsis">
-				<strong title="{%= __(df.label) %}">{%= __(df.label) %}:</strong>
+				<strong title="{%= __(df.label, null, df.parent) %}">{%= __(df.label, null, df.parent) %}:</strong>
 			</div>
 			<div class="col-xs-8">
 				{%= doc.get_formatted(df.fieldname) %}

--- a/erpnext/templates/print_formats/includes/total.html
+++ b/erpnext/templates/print_formats/includes/total.html
@@ -7,7 +7,7 @@
 		</div>
 	{% else %}
 		<div class="col-xs-5 {%- if doc.align_labels_right %} text-right{%- endif -%}">
-			<label>{{ _(df.label) }}</label></div>
+			<label>{{ _(df.label, context=df.parent) }}</label></div>
 		<div class="col-xs-7 text-right">
 			{{ doc.get_formatted("total", doc) }}
 		</div>


### PR DESCRIPTION
Whenever a field label is translated, pass the parent doctype as context. This way, the same label can be translated differently for different doctypes. (The doctype is already passed as context when generating translation files.)

> no-docs