### PR TITLE
fix: do not empty serial batch fields

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -162,6 +162,9 @@ class StockController(AccountsController):
 		from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos
 		from erpnext.stock.serial_batch_bundle import SerialBatchCreation
 
+		if self.get("_action") == "update_after_submit":
+			return
+
 		# To handle test cases
 		if frappe.flags.in_test and frappe.flags.use_serial_and_batch_fields:
 			return
@@ -219,7 +222,6 @@ class StockController(AccountsController):
 					row.db_set(
 						{
 							"rejected_serial_and_batch_bundle": sn_doc.name,
-							"rejected_serial_no": "",
 						}
 					)
 				else:
@@ -227,8 +229,6 @@ class StockController(AccountsController):
 					row.db_set(
 						{
 							"serial_and_batch_bundle": sn_doc.name,
-							"serial_no": "",
-							"batch_no": "",
 						}
 					)
 

--- a/erpnext/public/js/controllers/buying.js
+++ b/erpnext/public/js/controllers/buying.js
@@ -368,7 +368,7 @@ erpnext.buying = {
 
 											let update_values = {
 												"serial_and_batch_bundle": r.name,
-												"qty": qty
+												"qty": qty / flt(item.conversion_factor || 1, precision("conversion_factor", item))
 											}
 
 											if (r.warehouse) {
@@ -408,7 +408,7 @@ erpnext.buying = {
 
 											let update_values = {
 												"serial_and_batch_bundle": r.name,
-												"rejected_qty": qty
+												"rejected_qty": qty / flt(item.conversion_factor || 1, precision("conversion_factor", item))
 											}
 
 											if (r.warehouse) {

--- a/erpnext/public/js/utils/sales_common.js
+++ b/erpnext/public/js/utils/sales_common.js
@@ -339,7 +339,7 @@ erpnext.sales_common = {
 
 											frappe.model.set_value(item.doctype, item.name, {
 												"serial_and_batch_bundle": r.name,
-												"qty": qty
+												"qty": qty / flt(item.conversion_factor || 1, precision("conversion_factor", item))
 											});
 										}
 									}

--- a/erpnext/stock/doctype/pick_list/pick_list.js
+++ b/erpnext/stock/doctype/pick_list/pick_list.js
@@ -330,7 +330,7 @@ frappe.ui.form.on('Pick List Item', {
 									let qty = Math.abs(r.total_qty);
 									frappe.model.set_value(item.doctype, item.name, {
 										"serial_and_batch_bundle": r.name,
-										"qty": qty
+										"qty": qty / flt(item.conversion_factor || 1, precision("conversion_factor", item))
 									});
 								}
 							}

--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -2259,7 +2259,7 @@ class TestPurchaseReceipt(FrappeTestCase):
 		)
 
 		self.assertEqual(pr.items[0].use_serial_batch_fields, 1)
-		self.assertFalse(pr.items[0].serial_no)
+		self.assertTrue(pr.items[0].serial_no)
 		self.assertTrue(pr.items[0].serial_and_batch_bundle)
 
 		sbb_doc = frappe.get_doc("Serial and Batch Bundle", pr.items[0].serial_and_batch_bundle)

--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -1144,7 +1144,7 @@ erpnext.stock.select_batch_and_serial_no = (frm, item) => {
 							if (r) {
 								frappe.model.set_value(item.doctype, item.name, {
 									"serial_and_batch_bundle": r.name,
-									"qty": Math.abs(r.total_qty)
+									"qty": Math.abs(r.total_qty) / flt(item.conversion_factor || 1, precision("conversion_factor", item))
 								});
 							}
 						}

--- a/erpnext/stock/doctype/stock_entry/test_stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/test_stock_entry.py
@@ -1775,7 +1775,7 @@ class TestStockEntry(FrappeTestCase):
 		)
 
 		self.assertTrue(se.items[0].use_serial_batch_fields)
-		self.assertFalse(se.items[0].serial_no)
+		self.assertTrue(se.items[0].serial_no)
 		self.assertTrue(se.items[0].serial_and_batch_bundle)
 
 		for serial_no in serial_nos:
@@ -1793,7 +1793,7 @@ class TestStockEntry(FrappeTestCase):
 		se1.reload()
 
 		self.assertTrue(se1.items[0].use_serial_batch_fields)
-		self.assertFalse(se1.items[0].serial_no)
+		self.assertTrue(se1.items[0].serial_no)
 		self.assertTrue(se1.items[0].serial_and_batch_bundle)
 
 		for serial_no in serial_nos:


### PR DESCRIPTION
If the 'Use Serial No / Batch Fields' checkbox is enabled, the system allows users to enter serial and batch values. Upon submission of the stock transaction, when the checkbox is enabled, the system creates the Serial and Batch bundle and removes the values from the serial/batch fields. Some users have customized the serial/batch fields, and these customizations have been affected by this change. 

To fix this issue, we have decided to keep the values in the serial/batch fields if the 'Use Serial No / Batch Fields' checkbox is enabled.