### PR TITLE
fix: reposting failed status not updated

### DIFF
--- a/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
+++ b/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py
@@ -294,9 +294,20 @@ def repost(doc):
 		doc.log_error("Unable to repost item valuation")
 
 		message = frappe.message_log.pop() if frappe.message_log else ""
+		if isinstance(message, dict):
+			message = message.get("message")
+
 		if traceback:
-			message += "<br>" + "Traceback: <br>" + traceback
-		frappe.db.set_value(doc.doctype, doc.name, "error_log", message)
+			message += "<br><br>" + "<b>Traceback:</b> <br>" + traceback
+
+		frappe.db.set_value(
+			doc.doctype,
+			doc.name,
+			{
+				"error_log": message,
+				"status": "Failed",
+			},
+		)
 
 		outgoing_email_account = frappe.get_cached_value(
 			"Email Account", {"default_outgoing": 1, "enable_outgoing": 1}, "name"


### PR DESCRIPTION
If the reposting failed because of Accounting Period validation or any other validation then status was remaining as "In Progress" and not failed. User has to check the scheduled job log to check the error which is difficult for the non devs to understand.

**Issue**

The status was not updating because the frappe.message_log returns the dict in v15 where as it returns the string in the v14

```
  File "apps/erpnext/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py", line 298, in repost
    message += "<br>" + "Traceback: <br>" + traceback
      doc = <RepostItemValuation: 61631fc14b docstatus=1>
      traceback = 'Traceback with variables (most recent call last):\n  File "apps/erpnext/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py", line 281, in repost\n    repost_gl_entries(doc)\n      doc = <RepostItemValuation: 61631fc14b docstatus=1>\n      e = ClosedAccountingPeriod(\'You cannot create or cancel any accounting entries with in the closed Accounting Period test Test - FT\')\n  File "apps/erpnext/erpnext/stock/doctype/repost_item_valuation/repost_item_valuation.py", line 358, in repost_gl_entries\n    repost_gle_for_stock_vouchers(\n      doc = <RepostItemValuation: 61631fc14b docstatus=1>\n      directly_dependent_transactions = [(\'Purchase Receipt\', \'MAT-PRE-2024-00041\'), (\'Purchase Receipt\', \'MAT-PRE-2024-00040-1\'), (\'Stock Entry\', \'MAT-STE-2023-00049\'), (\'Delivery Note\', \'MAT-DN-2023-00026\'), (\'Stock Entry\', \'MAT-STE-2023-00050\'), (\'Delivery Note\', \'MAT-DN-2023-00027\'), (\'Stock Entry\', \'MAT-STE-2023-00051\'), (\'Delivery Note\', \'MAT-DN-20...
      message = {'message': 'You cannot create or cancel any accounting entries with in the closed Accounting Period <strong>test Test - FT</strong>', 'title': 'Message', 'indicator': 'red', 'raise_exception': 1, '__frappe_exc_id': 'f0e63def1182a4d21a147c3a2c776be1423280449adcb959aee7017e'}
builtins.TypeError: unsupported operand type(s) for +=: '_dict' and 'str'
```

**After Fix**

The status has changed to Failed for the repost item valuation with error log

<img width="1337" alt="Screenshot 2024-02-20 at 11 50 07 AM" src="https://github.com/frappe/erpnext/assets/8780500/7b9d2340-9c36-40fe-990f-de5136634934">
