### PR TITLE
fix: Delete linked asset movement record on cancellation of purchase receipt/invoice

### DIFF
--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -811,7 +811,8 @@ class BuyingController(SubcontractingController):
 		if self.doctype == "Purchase Invoice" and not self.get("update_stock"):
 			return
 
-		frappe.db.sql("delete from `tabAsset Movement` where reference_name=%s", self.name)
+		asset_movement = frappe.db.get_value("Asset Movement", {"reference_name": self.name}, "name")
+		frappe.delete_doc("Asset Movement", asset_movement, force=1)
 
 	def validate_schedule_date(self):
 		if not self.get("items"):

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -358,3 +358,4 @@ erpnext.patches.v14_0.migrate_gl_to_payment_ledger
 erpnext.stock.doctype.delivery_note.patches.drop_unused_return_against_index # 2023-12-20
 erpnext.patches.v14_0.set_maintain_stock_for_bom_item
 execute:frappe.db.set_single_value('E Commerce Settings', 'show_actual_qty', 1)
+erpnext.patches.v14_0.delete_orphaned_asset_movement_item_records

--- a/erpnext/patches/v14_0/delete_orphaned_asset_movement_item_records.py
+++ b/erpnext/patches/v14_0/delete_orphaned_asset_movement_item_records.py
@@ -1,7 +1,11 @@
 import frappe
 
+
 def execute():
-    frappe.db.sql("""
-        DELETE FROM `tabAsset Movement Item`
-        WHERE parent NOT IN (SELECT name FROM `tabAsset Movement`)
-    """)
+	# nosemgrep
+	frappe.db.sql(
+		"""
+		DELETE FROM `tabAsset Movement Item`
+		WHERE parent NOT IN (SELECT name FROM `tabAsset Movement`)
+		"""
+	)

--- a/erpnext/patches/v14_0/delete_orphaned_asset_movement_item_records.py
+++ b/erpnext/patches/v14_0/delete_orphaned_asset_movement_item_records.py
@@ -1,0 +1,7 @@
+import frappe
+
+def execute():
+    frappe.db.sql("""
+        DELETE FROM `tabAsset Movement Item`
+        WHERE parent NOT IN (SELECT name FROM `tabAsset Movement`)
+    """)


### PR DESCRIPTION
Issue: Earlier while deleting asset movement records, the system was deleting only parent records without children.