### PR TITLE
fix: show active bom in the dropdown while making stock entry and MR

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.js
+++ b/erpnext/stock/doctype/material_request/material_request.js
@@ -250,7 +250,7 @@ frappe.ui.form.on('Material Request', {
 			fields: [
 				{"fieldname":"bom", "fieldtype":"Link", "label":__("BOM"),
 					options:"BOM", reqd: 1, get_query: function() {
-						return {filters: { docstatus:1 }};
+						return {filters: { docstatus:1, "is_active": 1 }};
 					}},
 				{"fieldname":"warehouse", "fieldtype":"Link", "label":__("For Warehouse"),
 					options:"Warehouse", reqd: 1},

--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -543,7 +543,9 @@ frappe.ui.form.on('Stock Entry', {
 
 		let fields = [
 			{"fieldname":"bom", "fieldtype":"Link", "label":__("BOM"),
-			options:"BOM", reqd: 1, get_query: filters()},
+			options:"BOM", reqd: 1, get_query: () => {
+				return {filters: { docstatus:1, "is_active": 1 }};
+			}},
 			{"fieldname":"source_warehouse", "fieldtype":"Link", "label":__("Source Warehouse"),
 			options:"Warehouse"},
 			{"fieldname":"target_warehouse", "fieldtype":"Link", "label":__("Target Warehouse"),


### PR DESCRIPTION
**Issue**

While making the Material Request or Stock Entry, when use clicks on Get Items From -> Bill Of Materials, system shows the popup with BOM field. The issue is, In the BOM field system showing the in active BOMs.

<img width="741" alt="Screenshot 2024-02-20 at 12 27 42 PM" src="https://github.com/frappe/erpnext/assets/8780500/0deed370-8220-42d6-afe9-da6a11f06b9b">



**After Fix**

<img width="737" alt="Screenshot 2024-02-20 at 12 24 12 PM" src="https://github.com/frappe/erpnext/assets/8780500/bb89313e-d8b4-40a5-9279-3aeed71accc0">
