### PR TITLE
fix: Issues regarding asset cancellation and deletion

### DIFF
--- a/erpnext/assets/doctype/asset/depreciation.py
+++ b/erpnext/assets/doctype/asset/depreciation.py
@@ -561,15 +561,14 @@ def modify_depreciation_schedule_for_asset_repairs(asset, notes):
 def reverse_depreciation_entry_made_after_disposal(asset, date):
 	for row in asset.get("finance_books"):
 		asset_depr_schedule_doc = get_asset_depr_schedule_doc(asset.name, "Active", row.finance_book)
-		if not asset_depr_schedule_doc:
+		if not asset_depr_schedule_doc or not asset_depr_schedule_doc.get("depreciation_schedule"):
 			continue
 
 		for schedule_idx, schedule in enumerate(asset_depr_schedule_doc.get("depreciation_schedule")):
-			if schedule.schedule_date == date:
+			if schedule.schedule_date == date and schedule.journal_entry:
 				if not disposal_was_made_on_original_schedule_date(
 					schedule_idx, row, date
 				) or disposal_happens_in_the_future(date):
-
 					reverse_journal_entry = make_reverse_journal_entry(schedule.journal_entry)
 					reverse_journal_entry.posting_date = nowdate()
 

--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.js
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.js
@@ -6,7 +6,7 @@ frappe.provide("erpnext.assets");
 
 erpnext.assets.AssetCapitalization = class AssetCapitalization extends erpnext.stock.StockController {
 	setup() {
-		this.frm.ignore_doctypes_on_cancel_all = ['Serial and Batch Bundle'];
+		this.frm.ignore_doctypes_on_cancel_all = ['Serial and Batch Bundle', 'Asset Movement'];
 		this.setup_posting_date_time_check();
 	}
 

--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
@@ -137,6 +137,7 @@ class AssetCapitalization(StockController):
 			"Repost Item Valuation",
 			"Serial and Batch Bundle",
 			"Asset",
+			"Asset Movement",
 		)
 		self.cancel_target_asset()
 		self.update_stock_ledger()
@@ -146,7 +147,7 @@ class AssetCapitalization(StockController):
 	def cancel_target_asset(self):
 		if self.entry_type == "Capitalization" and self.target_asset:
 			asset_doc = frappe.get_doc("Asset", self.target_asset)
-			frappe.db.set_value("Asset", self.target_asset, "capitalized_in", None)
+			asset_doc.db_set("capitalized_in", None)
 			if asset_doc.docstatus == 1:
 				asset_doc.cancel()
 

--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -824,7 +824,8 @@ class BuyingController(SubcontractingController):
 		if self.doctype == "Purchase Invoice" and not self.get("update_stock"):
 			return
 
-		frappe.db.sql("delete from `tabAsset Movement` where reference_name=%s", self.name)
+		asset_movement = frappe.db.get_value("Asset Movement", {"reference_name": self.name}, "name")
+		frappe.delete_doc("Asset Movement", asset_movement, force=1)
 
 	def validate_schedule_date(self):
 		if not self.get("items"):

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -357,5 +357,4 @@ erpnext.patches.v15_0.create_advance_payment_status
 erpnext.patches.v14_0.migrate_gl_to_payment_ledger
 erpnext.stock.doctype.delivery_note.patches.drop_unused_return_against_index # 2023-12-20
 erpnext.patches.v14_0.set_maintain_stock_for_bom_item
-erpnext.patches.v15_0.set_difference_amount_in_asset_value_adjustment
 erpnext.patches.v15_0.delete_orphaned_asset_movement_item_records

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -357,3 +357,5 @@ erpnext.patches.v15_0.create_advance_payment_status
 erpnext.patches.v14_0.migrate_gl_to_payment_ledger
 erpnext.stock.doctype.delivery_note.patches.drop_unused_return_against_index # 2023-12-20
 erpnext.patches.v14_0.set_maintain_stock_for_bom_item
+erpnext.patches.v15_0.set_difference_amount_in_asset_value_adjustment
+erpnext.patches.v15_0.delete_orphaned_asset_movement_item_records

--- a/erpnext/patches/v15_0/delete_orphaned_asset_movement_item_records.py
+++ b/erpnext/patches/v15_0/delete_orphaned_asset_movement_item_records.py
@@ -1,0 +1,10 @@
+import frappe
+
+
+def execute():
+	frappe.db.sql(
+		"""
+		DELETE FROM `tabAsset Movement Item`
+		WHERE parent NOT IN (SELECT name FROM `tabAsset Movement`)
+		"""
+	)

--- a/erpnext/patches/v15_0/delete_orphaned_asset_movement_item_records.py
+++ b/erpnext/patches/v15_0/delete_orphaned_asset_movement_item_records.py
@@ -2,6 +2,7 @@ import frappe
 
 
 def execute():
+	# nosemgrep
 	frappe.db.sql(
 		"""
 		DELETE FROM `tabAsset Movement Item`


### PR DESCRIPTION
- On cancellation of asset, cancel all related documents
- On cancellation of asset purchase doc, delete movement record using ORM, earlier it used to delete only parent, not children. Added a patch to delete orphaned children.
- On cancellation of asset capitalization, reverse depreciation entry only if the journal entry exists