### PR TITLE
fix: webpages are not showing

### DIFF
--- a/erpnext/utilities/product.py
+++ b/erpnext/utilities/product.py
@@ -51,8 +51,8 @@ def get_web_item_qty_in_stock(item_code, item_warehouse_field, warehouse=None):
 				.where((BIN.item_code == item_code) & (BIN.warehouse == warehouse))
 			).run()
 
-			stock_qty = stock_qty[0][0]
 			if stock_qty:
+				stock_qty = flt(stock_qty[0][0])
 				total_stock += adjust_qty_for_expired_items(item_code, stock_qty, warehouse)
 
 	in_stock = int(total_stock > 0)


### PR DESCRIPTION
**Issue**

<img width="785" alt="image" src="https://github.com/frappe/erpnext/assets/8780500/740b91c5-3a99-44cb-9e34-ac9f24255be2">


```
Traceback (most recent call last):
  File "apps/frappe/frappe/website/serve.py", line 18, in get_response
    response = renderer_instance.render()
  File "apps/frappe/frappe/website/page_renderers/document_page.py", line 57, in render
    html = self.get_html()
  File "apps/frappe/frappe/website/utils.py", line 517, in cache_html_decorator
    html = func(*args, **kwargs)
  File "apps/frappe/frappe/website/page_renderers/document_page.py", line 66, in get_html
    self.update_context()
  File "apps/frappe/frappe/website/page_renderers/document_page.py", line 82, in update_context
    ret = self.doc.get_context(self.context)
  File "apps/erpnext/erpnext/e_commerce/doctype/website_item/website_item.py", line 225, in get_context
    self.set_shopping_cart_data(context)
  File "apps/erpnext/erpnext/e_commerce/doctype/website_item/website_item.py", line 314, in set_shopping_cart_data
    context.shopping_cart = get_product_info_for_website(
  File "apps/erpnext/erpnext/e_commerce/shopping_cart/product_info.py", line 54, in get_product_info_for_website
    stock_status = get_web_item_qty_in_stock(item_code, "website_warehouse")
  File "apps/erpnext/erpnext/utilities/product.py", line 54, in get_web_item_qty_in_stock
    stock_qty = stock_qty[0][0]
IndexError: tuple index out of range
```