### PR TITLE
fix: timesheet per billed state edge case

### DIFF
--- a/erpnext/projects/doctype/timesheet/timesheet.py
+++ b/erpnext/projects/doctype/timesheet/timesheet.py
@@ -83,7 +83,7 @@ class Timesheet(Document):
 	def set_status(self):
 		self.status = {"0": "Draft", "1": "Submitted", "2": "Cancelled"}[str(self.docstatus or 0)]
 
-		if self.per_billed == 100:
+		if flt(self.per_billed, self.precision("per_billed")) >= 100.0:
 			self.status = "Billed"
 
 		if self.sales_invoice:


### PR DESCRIPTION
If value is 100.0000x then it won't set status correctly but will set it the next time it's loaded from db.

closes https://github.com/frappe/erpnext/issues/40006