### PR TITLE
fix: negative stock error while making stock reconciliation

### DIFF
--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -909,8 +909,9 @@ class StockReconciliation(StockController):
 		if allow_negative_stock:
 			return True
 
-		if all(
-			(not d.batch_no or (d.batch_no and flt(d.qty) == flt(d.current_qty))) for d in self.items
+		if any(
+			((d.serial_and_batch_bundle or d.batch_no) and flt(d.qty) == flt(d.current_qty))
+			for d in self.items
 		):
 			allow_negative_stock = True
 


### PR DESCRIPTION
If Stock Reco has batch item then allow negative stock if user is trying to update the valuation using stock reconciliation. Do not allow negative stock if user is trying to update the Stock Quantity using stock reconciliation