### PR TITLE
fix: remove microsecond from posting datetime

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -263,7 +263,7 @@ execute:frappe.rename_doc("Report", "TDS Payable Monthly", "Tax Withholding Deta
 
 [post_model_sync]
 execute:frappe.delete_doc_if_exists('Workspace', 'ERPNext Integrations Settings')
-erpnext.patches.v14_0.update_posting_datetime_and_dropped_indexes
+erpnext.patches.v14_0.update_posting_datetime_and_dropped_indexes #22-02-2024
 erpnext.patches.v14_0.rename_ongoing_status_in_sla_documents
 erpnext.patches.v14_0.delete_shopify_doctypes
 erpnext.patches.v14_0.delete_healthcare_doctypes

--- a/erpnext/patches/v14_0/update_posting_datetime_and_dropped_indexes.py
+++ b/erpnext/patches/v14_0/update_posting_datetime_and_dropped_indexes.py
@@ -5,7 +5,7 @@ def execute():
 	frappe.db.sql(
 		"""
 		UPDATE `tabStock Ledger Entry`
-			SET posting_datetime = timestamp(posting_date, posting_time)
+			SET posting_datetime = DATE_FORMAT(timestamp(posting_date, posting_time), '%Y-%m-%d %H:%i:%s')
 	"""
 	)
 


### PR DESCRIPTION
Since we are not adding the microsecond for the posting datetime, the microsecond part should not be included for the existing SLEs when updating the posting datetime based on the posting date and posting time through patch.