### PR TITLE
fix: delete PLE containing invoice in against

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -345,7 +345,12 @@ class AccountsController(TransactionBase):
 			ple = frappe.qb.DocType("Payment Ledger Entry")
 			frappe.qb.from_(ple).delete().where(
 				(ple.voucher_type == self.doctype) & (ple.voucher_no == self.name)
-				| ((ple.against_voucher_type == self.doctype) & (ple.against_voucher_no == self.name))
+				| (
+					(ple.against_voucher_type == self.doctype)
+					& (ple.against_voucher_no == self.name)
+					& ple.delinked
+					== 1
+				)
 			).run()
 			frappe.db.sql(
 				"delete from `tabGL Entry` where voucher_type=%s and voucher_no=%s", (self.doctype, self.name)

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -345,6 +345,7 @@ class AccountsController(TransactionBase):
 			ple = frappe.qb.DocType("Payment Ledger Entry")
 			frappe.qb.from_(ple).delete().where(
 				(ple.voucher_type == self.doctype) & (ple.voucher_no == self.name)
+				| ((ple.against_voucher_type == self.doctype) & (ple.against_voucher_no == self.name))
 			).run()
 			frappe.db.sql(
 				"delete from `tabGL Entry` where voucher_type=%s and voucher_no=%s", (self.doctype, self.name)


### PR DESCRIPTION
**Steps to replicate**

1. Make sure **Unlink Payment on Cancellation of Invoice** and **Delete Accounting and Stock Ledger Entries on deletion of Transaction** are enabled in the Accounts Settings.
2. Create an Invoice. 
3. Create a payment against the invoice.
4. Cancel the Payment Entry and amend it to not have the reference of the previous invoice but some other invoice / no references.
5. Cancel the invoice created in step 2. Try deleting the invoice.

Since the payment ledger entry created by the payment has the invoice in the against field as a link, the deletion of the invoice fails because a link to that invoice is still present in the system.

**Screenshot**

<img width="1439" alt="Screenshot 2024-02-22 at 3 21 23 PM" src="https://github.com/frappe/erpnext/assets/40693548/73bdd079-2ac7-43e8-ac28-d432a71f9ecd">

<br>
<br>

**Fix**

On deletion of transaction accounting entries, delete PLEs having the transaction as the voucher_no OR as against_voucher_no.