### PR TITLE
fix: Webpages not working without login

### DIFF
--- a/erpnext/setup/doctype/item_group/item_group.json
+++ b/erpnext/setup/doctype/item_group/item_group.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_guest_to_view": 1,
  "allow_import": 1,
  "allow_rename": 1,
  "autoname": "field:item_group_name",
@@ -227,13 +228,14 @@
    "label": "Include Descendants"
   }
  ],
+ "has_web_view": 1,
  "icon": "fa fa-sitemap",
  "idx": 1,
  "image_field": "image",
  "is_tree": 1,
  "links": [],
  "max_attachments": 3,
- "modified": "2023-01-05 12:21:30.458628",
+ "modified": "2024-02-22 16:23:46.936496",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Item Group",

--- a/erpnext/setup/doctype/item_group/templates/item_group.html
+++ b/erpnext/setup/doctype/item_group/templates/item_group.html
@@ -1,0 +1,7 @@
+{% extends "templates/web.html" %}
+
+{% block page_content %}
+<h1>{{ title }}</h1>
+{% endblock %}
+
+<!-- this is a sample default web page template -->

--- a/erpnext/setup/doctype/item_group/templates/item_group_row.html
+++ b/erpnext/setup/doctype/item_group/templates/item_group_row.html
@@ -1,0 +1,4 @@
+<div>
+	<a href="{{ doc.route }}">{{ doc.title or doc.name }}</a>
+</div>
+<!-- this is a sample default list template -->


### PR DESCRIPTION
After fixing of security issue (https://github.com/frappe/frappe/pull/24037), user was not able to see the Items listing on the portal without login and was the getting 404 error.

<img width="1336" alt="Screenshot 2024-02-22 at 4 23 28 PM" src="https://github.com/frappe/erpnext/assets/8780500/a75deb5c-2898-4208-b338-e91e19b2f9e6">


**After Fix**
Enabled "has_web_view" and "allow_guest_to_view" properties

<img width="1355" alt="Screenshot 2024-02-22 at 4 22 21 PM" src="https://github.com/frappe/erpnext/assets/8780500/c5381b46-a2fd-4e8a-bd98-c1db30313e03">

