### PR TITLE
 build: specify frappe dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,6 @@ force_grid_wrap = 0
 use_parentheses = true
 ensure_newline_before_comments = true
 indent = "\t"
+
+[tool.bench.frappe-dependencies]
+frappe = ">=15.10.0,<16.0.0"


### PR DESCRIPTION
Added 15.10 as dependency because stock balance depends on https://github.com/frappe/frappe/pull/24346

