### PR TITLE
fix(web): Add user parameter to get_parents_for_user

### DIFF
--- a/erpnext/controllers/website_list_for_contact.py
+++ b/erpnext/controllers/website_list_for_contact.py
@@ -234,8 +234,8 @@ def get_customers_suppliers(doctype, user):
 	has_supplier_field = meta.has_field("supplier")
 
 	if has_common(["Supplier", "Customer"], frappe.get_roles(user)):
-		suppliers = get_parents_for_user("Supplier")
-		customers = get_parents_for_user("Customer")
+		suppliers = get_parents_for_user("Supplier", user)
+		customers = get_parents_for_user("Customer", user)
 	elif frappe.has_permission(doctype, "read", user=user):
 		customer_list = frappe.get_list("Customer")
 		customers = suppliers = [customer.name for customer in customer_list]
@@ -243,13 +243,13 @@ def get_customers_suppliers(doctype, user):
 	return customers if has_customer_field else None, suppliers if has_supplier_field else None
 
 
-def get_parents_for_user(parenttype: str) -> list[str]:
+def get_parents_for_user(parenttype: str, user="") -> list[str]:
 	portal_user = frappe.qb.DocType("Portal User")
 
 	return (
 		frappe.qb.from_(portal_user)
 		.select(portal_user.parent)
-		.where(portal_user.user == frappe.session.user)
+		.where(portal_user.user == user or frappe.session.user)
 		.where(portal_user.parenttype == parenttype)
 	).run(pluck="name")
 


### PR DESCRIPTION
Might avoid future mistakes.

This is used for website lists of Orders, Quotations, … of a specific user. The user parameter of `get_customers_suppliers` could lead to mistakes because it was not forwarded to `get_parents_for_user`, which assumed `user=frappe.session.user`. I don't think this is an issue now, because `get_customers_suppliers` is only used with `frappe.session.user` in mind.

---

I'm starting to use this function outside of its intended use cases, because it's the only method to find Customers linked to a User, even if it's really simple to just roll out my own with a `frappe.qb.from_(Portal User…)`