### PR TITLE
fix: get available putaway capacity

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -1000,7 +1000,7 @@ class StockController(AccountsController):
 	def validate_putaway_capacity(self):
 		# if over receipt is attempted while 'apply putaway rule' is disabled
 		# and if rule was applied on the transaction, validate it.
-		from erpnext.stock.doctype.putaway_rule.putaway_rule import get_available_putaway_capacity
+		from erpnext.stock.doctype.putaway_rule.putaway_rule import get_available_putaway_capacity, get_putaway_capacity
 
 		valid_doctype = self.doctype in (
 			"Purchase Receipt",
@@ -1039,7 +1039,10 @@ class StockController(AccountsController):
 						rule_map[rule_name]["warehouse"] = item.get(warehouse_field)
 						rule_map[rule_name]["item"] = item.get("item_code")
 						rule_map[rule_name]["qty_put"] = 0
-						rule_map[rule_name]["capacity"] = get_available_putaway_capacity(rule_name)
+						if self.doctype == "Stock Reconciliation":
+							rule_map[rule_name]["capacity"] = get_putaway_capacity(rule_name)
+						else:
+							rule_map[rule_name]["capacity"] = get_available_putaway_capacity(rule_name)
 					rule_map[rule_name]["qty_put"] += flt(stock_qty)
 
 			for rule, values in rule_map.items():

--- a/erpnext/stock/doctype/putaway_rule/putaway_rule.py
+++ b/erpnext/stock/doctype/putaway_rule/putaway_rule.py
@@ -97,6 +97,9 @@ def get_available_putaway_capacity(rule):
 	free_space = flt(stock_capacity) - flt(balance_qty)
 	return free_space if free_space > 0 else 0
 
+@frappe.whitelist()
+def get_putaway_capacity(rule):
+	return flt(frappe.db.get_value("Putaway Rule", rule, "stock_capacity"))
 
 @frappe.whitelist()
 def apply_putaway_rule(doctype, items, company, sync=None, purpose=None):


### PR DESCRIPTION
If you use Storage Rule for the item, there is a problem when doing inventory reconciliation because during the movement, the verified inventory is the available quantity.

capacity = 10
actual stock = 9
inventory reconciliation qty = 8 <- must be accepted (error)
inventory reconciliation qty = 11 <- should show message (ok)

Below are images for better understanding:

![image](https://github.com/frappe/erpnext/assets/1335242/fea44b74-54b4-4f92-9990-7c26511e1091)

![image](https://github.com/frappe/erpnext/assets/1335242/a6093a19-6c73-4bd9-8e71-53088c1cc730)
