### PR TITLE
fix: unique GL account for plaid bank accounts

### DIFF
--- a/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.py
+++ b/erpnext/erpnext_integrations/doctype/plaid_settings/plaid_settings.py
@@ -10,7 +10,6 @@ from frappe.model.document import Document
 from frappe.utils import add_months, formatdate, getdate, sbool, today
 from plaid.errors import ItemError
 
-from erpnext.accounts.doctype.journal_entry.journal_entry import get_default_bank_cash_account
 from erpnext.erpnext_integrations.doctype.plaid_settings.plaid_connector import PlaidConnector
 
 
@@ -90,9 +89,15 @@ def add_bank_accounts(response, bank, company):
 		bank = json.loads(bank)
 	result = []
 
-	default_gl_account = get_default_bank_cash_account(company, "Bank")
-	if not default_gl_account:
-		frappe.throw(_("Please setup a default bank account for company {0}").format(company))
+	parent_gl_account = frappe.db.get_all(
+		"Account", {"company": company, "account_type": "Bank", "is_group": 1, "disabled": 0}
+	)
+	if not parent_gl_account:
+		frappe.throw(
+			_(
+				"Please setup and enable a group account with the Account Type - {0} for the company {1}"
+			).format(frappe.bold("Bank"), company)
+		)
 
 	for account in response["accounts"]:
 		acc_type = frappe.db.get_value("Bank Account Type", account["type"])
@@ -108,11 +113,22 @@ def add_bank_accounts(response, bank, company):
 
 		if not existing_bank_account:
 			try:
+				gl_account = frappe.get_doc(
+					{
+						"doctype": "Account",
+						"account_name": account["name"] + " - " + response["institution"]["name"],
+						"parent_account": parent_gl_account[0].name,
+						"account_type": "Bank",
+						"company": company,
+					}
+				)
+				gl_account.insert(ignore_if_duplicate=True)
+
 				new_account = frappe.get_doc(
 					{
 						"doctype": "Bank Account",
 						"bank": bank["bank_name"],
-						"account": default_gl_account.account,
+						"account": gl_account.name,
 						"account_name": account["name"],
 						"account_type": account.get("type", ""),
 						"account_subtype": account.get("subtype", ""),

--- a/erpnext/erpnext_integrations/doctype/plaid_settings/test_plaid_settings.py
+++ b/erpnext/erpnext_integrations/doctype/plaid_settings/test_plaid_settings.py
@@ -7,7 +7,6 @@ import unittest
 import frappe
 from frappe.utils.response import json_handler
 
-from erpnext.accounts.doctype.journal_entry.journal_entry import get_default_bank_cash_account
 from erpnext.erpnext_integrations.doctype.plaid_settings.plaid_settings import (
 	add_account_subtype,
 	add_account_type,
@@ -71,14 +70,6 @@ class TestPlaidSettings(unittest.TestCase):
 
 		bank = json.dumps(frappe.get_doc("Bank", "Citi").as_dict(), default=json_handler)
 		company = frappe.db.get_single_value("Global Defaults", "default_company")
-
-		if frappe.db.get_value("Company", company, "default_bank_account") is None:
-			frappe.db.set_value(
-				"Company",
-				company,
-				"default_bank_account",
-				get_default_bank_cash_account(company, "Cash").get("account"),
-			)
 
 		add_bank_accounts(bank_accounts, bank, company)
 


### PR DESCRIPTION
### Problem

Whenever new bank accounts are added using Plaid, the system creates a new Bank Account doc which has `is_company_account` enabled. 

Since this setting enforces mentioning the linked GL account to the Bank account, the system previously used to take the Default Bank Account mentioned in the Company master as the newly created bank account's GL account.

However, recently since a Unique GL Account for each Bank Account was enforced (**ref**: https://github.com/frappe/erpnext/pull/39694), as soon as the user tries to add more than 1 account through Plaid, the unique validation fails since the default GL account got used up in the first account itself.


### Fix

- Check if the group bank account exists for the company. If not, ask the user to setup and enable a group node.

- Add a new GL account mapped to each new bank account added by Plaid.

- If the exact same GL account is already present, the creation of the Bank Account will go through normally, meaning, it will check if the GL account is linked to any bank accounts. If not, link the newly created Bank Account to the GL account. If yes, throw ValidationError saying that the account is already linked.
