### PR TITLE
fix: Data too long for column 'serial_no' at row 1

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice_item/pos_invoice_item.json
+++ b/erpnext/accounts/doctype/pos_invoice_item/pos_invoice_item.json
@@ -654,7 +654,7 @@
   {
    "depends_on": "eval:doc.use_serial_batch_fields === 1",
    "fieldname": "serial_no",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text",
    "hidden": 1,
    "in_list_view": 1,
    "label": "Serial No",
@@ -853,7 +853,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2024-02-04 16:36:25.665743",
+ "modified": "2024-02-25 15:50:17.140269",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Invoice Item",

--- a/erpnext/accounts/doctype/pos_invoice_item/pos_invoice_item.py
+++ b/erpnext/accounts/doctype/pos_invoice_item/pos_invoice_item.py
@@ -72,7 +72,7 @@ class POSInvoiceItem(Document):
 		rate_with_margin: DF.Currency
 		sales_order: DF.Link | None
 		serial_and_batch_bundle: DF.Link | None
-		serial_no: DF.SmallText | None
+		serial_no: DF.Text | None
 		service_end_date: DF.Date | None
 		service_start_date: DF.Date | None
 		service_stop_date: DF.Date | None

--- a/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
+++ b/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
@@ -625,7 +625,7 @@
   {
    "depends_on": "eval: doc.use_serial_batch_fields === 1 && parent.update_stock === 1",
    "fieldname": "serial_no",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text",
    "label": "Serial No",
    "oldfieldname": "serial_no",
    "oldfieldtype": "Small Text"
@@ -926,7 +926,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-02-04 11:52:16.106541",
+ "modified": "2024-02-25 15:56:44.828634",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice Item",

--- a/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.py
+++ b/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.py
@@ -75,7 +75,7 @@ class SalesInvoiceItem(Document):
 		sales_invoice_item: DF.Data | None
 		sales_order: DF.Link | None
 		serial_and_batch_bundle: DF.Link | None
-		serial_no: DF.SmallText | None
+		serial_no: DF.Text | None
 		service_end_date: DF.Date | None
 		service_start_date: DF.Date | None
 		service_stop_date: DF.Date | None

--- a/erpnext/assets/doctype/asset_capitalization_stock_item/asset_capitalization_stock_item.json
+++ b/erpnext/assets/doctype/asset_capitalization_stock_item/asset_capitalization_stock_item.json
@@ -107,7 +107,7 @@
   {
    "depends_on": "eval:doc.use_serial_batch_fields === 1",
    "fieldname": "serial_no",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text",
    "hidden": 1,
    "label": "Serial No",
    "print_hide": 1
@@ -178,7 +178,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-02-04 16:41:09.239762",
+ "modified": "2024-02-25 15:57:35.007501",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset Capitalization Stock Item",

--- a/erpnext/assets/doctype/asset_capitalization_stock_item/asset_capitalization_stock_item.py
+++ b/erpnext/assets/doctype/asset_capitalization_stock_item/asset_capitalization_stock_item.py
@@ -24,7 +24,7 @@ class AssetCapitalizationStockItem(Document):
 		parentfield: DF.Data
 		parenttype: DF.Data
 		serial_and_batch_bundle: DF.Link | None
-		serial_no: DF.SmallText | None
+		serial_no: DF.Text | None
 		stock_qty: DF.Float
 		stock_uom: DF.Link
 		use_serial_batch_fields: DF.Check

--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -2237,6 +2237,10 @@ class TestPurchaseReceipt(FrappeTestCase):
 			create_stock_reconciliation,
 		)
 
+		frappe.db.set_single_value(
+			"Stock Settings", "do_not_update_serial_batch_on_creation_of_auto_bundle", 0
+		)
+
 		item_code = make_item(
 			"_Test Use Serial Fields Item Serial Item",
 			properties={"has_serial_no": 1, "serial_no_series": "SNU-TSFISI-.#####"},
@@ -2316,6 +2320,10 @@ class TestPurchaseReceipt(FrappeTestCase):
 		for sn in new_serial_nos:
 			serial_no_status = frappe.db.get_value("Serial No", sn, "status")
 			self.assertTrue(serial_no_status != "Active")
+
+		frappe.db.set_single_value(
+			"Stock Settings", "do_not_update_serial_batch_on_creation_of_auto_bundle", 1
+		)
 
 	def test_sle_qty_after_transaction(self):
 		item = make_item(
@@ -2416,7 +2424,9 @@ class TestPurchaseReceipt(FrappeTestCase):
 			},
 		).name
 
-		frappe.db.set_single_value("Stock Settings", "use_serial_batch_fields", 1)
+		frappe.db.set_single_value(
+			"Stock Settings", "do_not_update_serial_batch_on_creation_of_auto_bundle", 0
+		)
 
 		pr = make_purchase_receipt(
 			item_code=item_code,
@@ -2428,7 +2438,9 @@ class TestPurchaseReceipt(FrappeTestCase):
 		batch_no = get_batch_from_bundle(pr.items[0].serial_and_batch_bundle)
 		self.assertEqual(pr.items[0].batch_no, batch_no)
 
-		frappe.db.set_single_value("Stock Settings", "use_serial_batch_fields", 0)
+		frappe.db.set_single_value(
+			"Stock Settings", "do_not_update_serial_batch_on_creation_of_auto_bundle", 1
+		)
 
 
 def prepare_data_for_internal_transfer():

--- a/erpnext/stock/doctype/stock_entry_detail/stock_entry_detail.json
+++ b/erpnext/stock/doctype/stock_entry_detail/stock_entry_detail.json
@@ -294,7 +294,7 @@
   {
    "depends_on": "eval:doc.use_serial_batch_fields === 1",
    "fieldname": "serial_no",
-   "fieldtype": "Small Text",
+   "fieldtype": "Text",
    "label": "Serial No",
    "no_copy": 1,
    "oldfieldname": "serial_no",
@@ -610,7 +610,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-02-04 16:16:47.606270",
+ "modified": "2024-02-25 15:58:40.982582",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Entry Detail",

--- a/erpnext/stock/doctype/stock_entry_detail/stock_entry_detail.py
+++ b/erpnext/stock/doctype/stock_entry_detail/stock_entry_detail.py
@@ -54,7 +54,7 @@ class StockEntryDetail(Document):
 		sample_quantity: DF.Int
 		sco_rm_detail: DF.Data | None
 		serial_and_batch_bundle: DF.Link | None
-		serial_no: DF.SmallText | None
+		serial_no: DF.Text | None
 		set_basic_rate_manually: DF.Check
 		ste_detail: DF.Data | None
 		stock_uom: DF.Link

--- a/erpnext/stock/doctype/stock_settings/stock_settings.json
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.json
@@ -51,6 +51,7 @@
   "use_naming_series",
   "naming_series_prefix",
   "use_serial_batch_fields",
+  "do_not_update_serial_batch_on_creation_of_auto_bundle",
   "stock_planning_tab",
   "auto_material_request",
   "auto_indent",
@@ -428,6 +429,14 @@
    "fieldname": "use_serial_batch_fields",
    "fieldtype": "Check",
    "label": "Use Serial / Batch Fields"
+  },
+  {
+   "default": "1",
+   "depends_on": "use_serial_batch_fields",
+   "description": "If enabled, do not update serial / batch values in the stock transactions on creation of auto Serial \n / Batch Bundle. ",
+   "fieldname": "do_not_update_serial_batch_on_creation_of_auto_bundle",
+   "fieldtype": "Check",
+   "label": "Do Not Update Serial / Batch on Creation of Auto Bundle"
   }
  ],
  "icon": "icon-cog",
@@ -435,7 +444,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-02-24 12:50:51.740097",
+ "modified": "2024-02-25 16:32:01.084453",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Settings",

--- a/erpnext/stock/doctype/stock_settings/stock_settings.py
+++ b/erpnext/stock/doctype/stock_settings/stock_settings.py
@@ -39,6 +39,7 @@ class StockSettings(Document):
 		clean_description_html: DF.Check
 		default_warehouse: DF.Link | None
 		disable_serial_no_and_batch_selector: DF.Check
+		do_not_update_serial_batch_on_creation_of_auto_bundle: DF.Check
 		enable_stock_reservation: DF.Check
 		item_group: DF.Link | None
 		item_naming_by: DF.Literal["Item Code", "Naming Series"]

--- a/erpnext/stock/serial_batch_bundle.py
+++ b/erpnext/stock/serial_batch_bundle.py
@@ -142,7 +142,9 @@ class SerialBatchBundle:
 				"serial_and_batch_bundle": sn_doc.name,
 			}
 
-			if frappe.db.get_single_value("Stock Settings", "use_serial_batch_fields"):
+			if not frappe.db.get_single_value(
+				"Stock Settings", "do_not_update_serial_batch_on_creation_of_auto_bundle"
+			):
 				if sn_doc.has_serial_no:
 					values_to_update["serial_no"] = ",".join(cstr(d.serial_no) for d in sn_doc.entries)
 				elif sn_doc.has_batch_no and len(sn_doc.entries) == 1:


### PR DESCRIPTION
- Changed fieldtype from Small Text to Text for Serial No field
- Added "Do Not Update Serial / Batch on Creation of Auto Bundle" in the stock settings, to do not update Serial / Batch on creation of auto Bundle

Fixed https://github.com/frappe/erpnext/issues/40076
Docs https://docs.erpnext.com/docs/user/manual/en/serial-and-batch-bundle#update-serial-batch-on-creation-of-auto-bundle