### PR TITLE
fix(minor): tax amount label according to party type

### DIFF
--- a/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
+++ b/erpnext/accounts/report/tax_withholding_details/tax_withholding_details.py
@@ -242,7 +242,7 @@ def get_columns(filters):
 				"width": 120,
 			},
 			{
-				"label": _("Tax Amount"),
+				"label": _("TDS Amount") if filters.get("party_type") == "Supplier" else _("TCS Amount"),
 				"fieldname": "tax_amount",
 				"fieldtype": "Float",
 				"width": 120,


### PR DESCRIPTION
Show **TDS Amount** and **TCS Amount** labels instead of a generic Tax Amount label in Tax Report.

Closes #40093