### PR TITLE
fix: Patch to remove cancelled asset capitalization from asset

### DIFF
--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
@@ -144,6 +144,10 @@ class AssetCapitalization(StockController):
 		self.make_gl_entries()
 		self.restore_consumed_asset_items()
 
+	def on_trash(self):
+		frappe.db.set_value("Asset", self.target_asset, "capitalized_in", None)
+		super(AssetCapitalization, self).on_trash()
+
 	def cancel_target_asset(self):
 		if self.entry_type == "Capitalization" and self.target_asset:
 			asset_doc = frappe.get_doc("Asset", self.target_asset)

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -358,3 +358,4 @@ erpnext.patches.v14_0.migrate_gl_to_payment_ledger
 erpnext.stock.doctype.delivery_note.patches.drop_unused_return_against_index # 2023-12-20
 erpnext.patches.v14_0.set_maintain_stock_for_bom_item
 erpnext.patches.v15_0.delete_orphaned_asset_movement_item_records
+erpnext.patches.v15_0.remove_cancelled_asset_capitalization_from_asset

--- a/erpnext/patches/v15_0/remove_cancelled_asset_capitalization_from_asset.py
+++ b/erpnext/patches/v15_0/remove_cancelled_asset_capitalization_from_asset.py
@@ -1,0 +1,11 @@
+import frappe
+
+
+def execute():
+	cancelled_asset_capitalizations = frappe.get_all(
+		"Asset Capitalization",
+		filters={"docstatus": 2},
+		fields=["name", "target_asset"],
+	)
+	for asset_capitalization in cancelled_asset_capitalizations:
+		frappe.db.set_value("Asset", asset_capitalization.target_asset, "capitalized_in", None)


### PR DESCRIPTION
- Remove capitalized_in from the asset on cancellation of asset Asset Capitalization record
- Patch for existing ones