### PR TITLE
fix: Patch to remove cancelled asset capitalization from asset

### DIFF
--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
@@ -83,6 +83,10 @@ class AssetCapitalization(StockController):
 		self.update_stock_ledger()
 		self.make_gl_entries()
 		self.restore_consumed_asset_items()
+	
+	def on_trash(self):
+		frappe.db.set_value("Asset", self.target_asset, "capitalized_in", None)
+		super(AssetCapitalization, self).on_trash()
 
 	def cancel_target_asset(self):
 		if self.entry_type == "Capitalization" and self.target_asset:

--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
@@ -83,7 +83,7 @@ class AssetCapitalization(StockController):
 		self.update_stock_ledger()
 		self.make_gl_entries()
 		self.restore_consumed_asset_items()
-	
+
 	def on_trash(self):
 		frappe.db.set_value("Asset", self.target_asset, "capitalized_in", None)
 		super(AssetCapitalization, self).on_trash()

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -359,3 +359,4 @@ erpnext.stock.doctype.delivery_note.patches.drop_unused_return_against_index # 2
 erpnext.patches.v14_0.set_maintain_stock_for_bom_item
 execute:frappe.db.set_single_value('E Commerce Settings', 'show_actual_qty', 1)
 erpnext.patches.v14_0.delete_orphaned_asset_movement_item_records
+erpnext.patches.v14_0.remove_cancelled_asset_capitalization_from_asset

--- a/erpnext/patches/v14_0/remove_cancelled_asset_capitalization_from_asset.py
+++ b/erpnext/patches/v14_0/remove_cancelled_asset_capitalization_from_asset.py
@@ -1,0 +1,10 @@
+import frappe
+
+def execute():
+    cancelled_asset_capitalizations = frappe.get_all(
+        "Asset Capitalization",
+        filters={"docstatus": 2},
+        fields=["name", "target_asset"],
+        )
+    for asset_capitalization in cancelled_asset_capitalizations:
+        frappe.db.set_value("Asset", asset_capitalization.target_asset, "capitalized_in", None)

--- a/erpnext/patches/v14_0/remove_cancelled_asset_capitalization_from_asset.py
+++ b/erpnext/patches/v14_0/remove_cancelled_asset_capitalization_from_asset.py
@@ -1,10 +1,11 @@
 import frappe
 
+
 def execute():
-    cancelled_asset_capitalizations = frappe.get_all(
-        "Asset Capitalization",
-        filters={"docstatus": 2},
-        fields=["name", "target_asset"],
-        )
-    for asset_capitalization in cancelled_asset_capitalizations:
-        frappe.db.set_value("Asset", asset_capitalization.target_asset, "capitalized_in", None)
+	cancelled_asset_capitalizations = frappe.get_all(
+		"Asset Capitalization",
+		filters={"docstatus": 2},
+		fields=["name", "target_asset"],
+	)
+	for asset_capitalization in cancelled_asset_capitalizations:
+		frappe.db.set_value("Asset", asset_capitalization.target_asset, "capitalized_in", None)


### PR DESCRIPTION
- Remove capitalized_in from the asset on cancellation of asset Asset Capitalization record
- Patch for existing ones