### PR TITLE
fix: Do not implicitly enable Edit Posting Date and Time for Data Import

### DIFF
--- a/erpnext/utilities/transaction_base.py
+++ b/erpnext/utilities/transaction_base.py
@@ -16,10 +16,6 @@ class UOMMustBeIntegerError(frappe.ValidationError):
 
 class TransactionBase(StatusUpdater):
 	def validate_posting_time(self):
-		# set Edit Posting Date and Time to 1 while data import
-		if frappe.flags.in_import and self.posting_date:
-			self.set_posting_time = 1
-
 		if not getattr(self, "set_posting_time", None):
 			now = now_datetime()
 			self.posting_date = now.strftime("%Y-%m-%d")


### PR DESCRIPTION
If you create the Stock Entry on a current date using Data Import tool, the system auto enable the "Edit Posting Date and Time". System shouldn't implicitly enable the checkbox "Edit Posting Date and Time" while using the Data Import tool