### PR TITLE
fix: sales funnel text color in light/dark theme

### DIFF
--- a/erpnext/selling/page/sales_funnel/sales_funnel.js
+++ b/erpnext/selling/page/sales_funnel/sales_funnel.js
@@ -229,7 +229,7 @@ erpnext.SalesFunnel = class SalesFunnel {
 		context.fill();
 
 		// draw text
-		context.fillStyle = "#808080";
+		context.fillStyle = "";
 		context.textBaseline = "middle";
 		context.font = "1.1em sans-serif";
 		context.fillText(__(title), width + 20, y_mid);

--- a/erpnext/selling/page/sales_funnel/sales_funnel.js
+++ b/erpnext/selling/page/sales_funnel/sales_funnel.js
@@ -229,7 +229,7 @@ erpnext.SalesFunnel = class SalesFunnel {
 		context.fill();
 
 		// draw text
-		context.fillStyle = "black";
+		context.fillStyle = "#808080";
 		context.textBaseline = "middle";
 		context.font = "1.1em sans-serif";
 		context.fillText(__(title), width + 20, y_mid);


### PR DESCRIPTION
In Version 14

fixes: #34255

**Before:**

![image](https://github.com/frappe/erpnext/assets/141945075/56285591-61b1-4c4a-ae3d-ae21fd1feef5)

![image](https://github.com/frappe/erpnext/assets/141945075/7d929246-5111-4fec-a8b8-575fda7c84db)


**After:**

![image](https://github.com/frappe/erpnext/assets/141945075/3d86ce7d-2468-4eb1-bf0d-9a5311d1f4c4)

![image](https://github.com/frappe/erpnext/assets/141945075/ea875c42-ade1-4fcd-b491-be57b34dd918)


Thank You!