### PR TITLE
fix: default taxable value for item not found in item list

### DIFF
--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -1029,7 +1029,7 @@ def get_itemised_tax_breakup_data(doc):
 	for item_code, taxes in itemised_tax.items():
 		itemised_tax_data.append(
 			frappe._dict(
-				{"item": item_code, "taxable_amount": itemised_taxable_amount.get(item_code), **taxes}
+				{"item": item_code, "taxable_amount": itemised_taxable_amount.get(item_code, 0), **taxes}
 			)
 		)
 


### PR DESCRIPTION
Set default taxable_amount as 0.
```
  File "apps/frappe/frappe/model/document.py", line 260, in insert
    self.run_before_save_methods()
  File "apps/frappe/frappe/model/document.py", line 1045, in run_before_save_methods
    self.run_method("validate")
  File "apps/frappe/frappe/model/document.py", line 915, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1267, in composer
    return composed(self, method, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1249, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
                              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 912, in fn
    return method_object(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/accounts/doctype/sales_invoice/sales_invoice.py", line 90, in validate
    super(SalesInvoice, self).validate()
  File "apps/erpnext/erpnext/controllers/selling_controller.py", line 32, in validate
    super(SellingController, self).validate()
  File "apps/erpnext/erpnext/controllers/stock_controller.py", line 45, in validate
    super(StockController, self).validate()
  File "apps/erpnext/erpnext/controllers/accounts_controller.py", line 174, in validate
    self.calculate_taxes_and_totals()
  File "apps/erpnext/erpnext/controllers/accounts_controller.py", line 470, in calculate_taxes_and_totals
    calculate_taxes_and_totals(self)
  File "apps/erpnext/erpnext/controllers/taxes_and_totals.py", line 32, in __init__
    self.calculate()
  File "apps/erpnext/erpnext/controllers/taxes_and_totals.py", line 63, in calculate
    self.set_item_wise_tax_breakup()
  File "apps/erpnext/erpnext/controllers/taxes_and_totals.py", line 915, in set_item_wise_tax_breakup
    self.doc.other_charges_calculation = get_itemised_tax_breakup_html(self.doc)
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/controllers/taxes_and_totals.py", line 964, in get_itemised_tax_breakup_html
    return frappe.render_template(
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/jinja.py", line 89, in render_template
    return get_jenv().get_template(template).render(context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "env/lib/python3.11/site-packages/jinja2/environment.py", line 1301, in render
    self.environment.handle_exception()
  File "env/lib/python3.11/site-packages/jinja2/environment.py", line 936, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "apps/erpnext/erpnext/templates/includes/itemised_tax_breakup.html", line 20, in top-level template code
    {{ frappe.utils.fmt_money(taxes.taxable_amount|abs, None, doc.currency) }}
    ^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: bad operand type for abs(): 'NoneType'

```