### PR TITLE
fix: Supplier users not able to see RFQ on the Portal

### DIFF
--- a/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
+++ b/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
@@ -206,9 +206,29 @@ class RequestforQuotation(BuyingController):
 
 		contact.save(ignore_permissions=True)
 
+		if rfq_supplier.supplier:
+			self.update_user_in_supplier(rfq_supplier.supplier, user.name)
+
 		if not rfq_supplier.contact:
 			# return contact to later update, RFQ supplier row's contact
 			return contact.name
+
+	def update_user_in_supplier(self, supplier, user):
+		"""Update user in Supplier."""
+		if not frappe.db.exists("Portal User", {"parent": supplier, "user": user}):
+			supplier_doc = frappe.get_doc("Supplier", supplier)
+			supplier_doc.append(
+				"portal_users",
+				{
+					"user": user,
+				},
+			)
+
+			supplier_doc.flags.ignore_validate = True
+			supplier_doc.flags.ignore_mandatory = True
+			supplier_doc.flags.ignore_permissions = True
+
+			supplier_doc.save()
 
 	def create_user(self, rfq_supplier, link):
 		user = frappe.get_doc(

--- a/erpnext/buying/doctype/request_for_quotation/test_request_for_quotation.py
+++ b/erpnext/buying/doctype/request_for_quotation/test_request_for_quotation.py
@@ -149,6 +149,33 @@ class TestRequestforQuotation(FrappeTestCase):
 		get_pdf(rfq.name, rfq.get("suppliers")[0].supplier)
 		self.assertEqual(frappe.local.response.type, "pdf")
 
+	def test_portal_user_with_new_supplier(self):
+		supplier_doc = frappe.get_doc(
+			{
+				"doctype": "Supplier",
+				"supplier_name": "Test Supplier for RFQ",
+				"supplier_group": "_Test Supplier Group",
+			}
+		).insert()
+
+		self.assertFalse(supplier_doc.portal_users)
+
+		rfq = make_request_for_quotation(
+			supplier_data=[
+				{
+					"supplier": supplier_doc.name,
+					"supplier_name": supplier_doc.supplier_name,
+					"email_id": "123_testrfquser@example.com",
+				}
+			],
+			do_not_submit=True,
+		)
+		for rfq_supplier in rfq.suppliers:
+			rfq.update_supplier_contact(rfq_supplier, rfq.get_link())
+
+		supplier_doc.reload()
+		self.assertTrue(supplier_doc.portal_users[0].user)
+
 
 def make_request_for_quotation(**args) -> "RequestforQuotation":
 	"""


### PR DESCRIPTION
If the supplier user has created on submission of the RFQ then that user has not able to see any RFQ on the web portal

<img width="1309" alt="Screenshot 2024-02-27 at 6 49 35 PM" src="https://github.com/frappe/erpnext/assets/8780500/89bc9d8e-733d-4ace-911c-9bc65208d4c2">


**Why**

Because the user created on submission of the RFQ has not updated in the respective supplier's portal users list
<img width="1080" alt="Screenshot 2024-02-27 at 7 51 17 PM" src="https://github.com/frappe/erpnext/assets/8780500/e9895bc1-753a-449d-873b-3c6c339a4e6a">


**After Fix**

The user has updated in the supplier master
<img width="1058" alt="Screenshot 2024-02-27 at 7 51 45 PM" src="https://github.com/frappe/erpnext/assets/8780500/316b97ac-a642-445e-8c9f-62528742b159">


The user can able to see the RFQ list
<img width="1239" alt="image" src="https://github.com/frappe/erpnext/assets/8780500/e8f8edc3-23f2-4acb-94a2-7246d2b8d013">






