### PR TITLE
fix: Email Template None not found

### DIFF
--- a/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
+++ b/erpnext/buying/doctype/request_for_quotation/request_for_quotation.py
@@ -266,6 +266,10 @@ class RequestforQuotation(BuyingController):
 				"user_fullname": full_name,
 			}
 		)
+
+		if not self.email_template:
+			return
+
 		email_template = frappe.get_doc("Email Template", self.email_template)
 		message = frappe.render_template(email_template.response_, doc_args)
 		subject = frappe.render_template(email_template.subject, doc_args)


### PR DESCRIPTION
If not email template then system throws the error "Email Template None not found"