### PR TITLE
fix: promotional scheme remove free item if pricing rule matches

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1523,6 +1523,8 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 	}
 
 	remove_pricing_rule_for_item(item) {
+		// capture pricing rule before removing it to delete free items
+		let removed_pricing_rule = item.pricing_rules;
 		if (item.pricing_rules){
 			let me = this;
 			return this.frm.call({
@@ -1543,7 +1545,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 				},
 				callback: function(r) {
 					if (!r.exc && r.message) {
-						me.remove_pricing_rule(r.message);
+						me.remove_pricing_rule(r.message, removed_pricing_rule);
 						me.calculate_taxes_and_totals();
 						if(me.frm.doc.apply_discount_on) me.frm.trigger("apply_discount_on");
 					}
@@ -1801,7 +1803,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		});
 	}
 
-	remove_pricing_rule(item) {
+	remove_pricing_rule(item, removed_pricing_rule) {
 		let me = this;
 		const fields = ["discount_percentage",
 			"discount_amount", "margin_rate_or_amount", "rate_with_margin"];
@@ -1810,7 +1812,8 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 			let items = [];
 
 			me.frm.doc.items.forEach(d => {
-				if(d.item_code != item.remove_free_item || !d.is_free_item) {
+				// if same item was added a free item through a different pricing rule, keep it
+				if(d.item_code != item.remove_free_item || !d.is_free_item || removed_pricing_rule?.includes(d.pricing_rules)) {
 					items.push(d);
 				}
 			});


### PR DESCRIPTION
### Bug

If same item code is added as a free item through two different promotional schemes, then on changing the quantity of one of the promotional scheme item, removes the free item introduced through the different scheme as well.

Eg: For recursive qty 12 on each of the 1st and 3rd row items a common free item is added. However, when the quantity of the third row is doubled, the second row gets deleted.



### Before 


https://github.com/frappe/erpnext/assets/40693548/5227505b-056a-4005-8b4d-b5a339405ebf

<br>
<br>

### After


https://github.com/frappe/erpnext/assets/40693548/fcf29800-a681-4ebd-8085-c44bac13fffd

