### PR TITLE
fix(minor): make warning for previously existing SO an alert

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -251,7 +251,8 @@ class SalesOrder(SellingController):
 					frappe.msgprint(
 						_("Warning: Sales Order {0} already exists against Customer's Purchase Order {1}").format(
 							frappe.bold(so[0][0]), frappe.bold(self.po_no)
-						)
+						),
+						alert=True,
 					)
 				else:
 					frappe.throw(


### PR DESCRIPTION
Make the pop up to show that there is already a SO created against Customer's PO an alert so that it doesn’t affect users’ data entry flow.