### PR TITLE
fix: show future payments consider allocated sales returns

### DIFF
--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -671,7 +671,7 @@ class ReceivablePayableReport(object):
 			else:
 				future_amount_field = "future_amount_in_base_currency"
 
-			if row.remaining_balance > 0 and future.get(future_amount_field):
+			if row.remaining_balance != 0 and future.get(future_amount_field):
 				if future.get(future_amount_field) > row.outstanding:
 					row.future_amount = row.outstanding
 					future[future_amount_field] = future.get(future_amount_field) - row.outstanding


### PR DESCRIPTION
- Added a test case to `test_future_payments` when allocating a sales return against an invoice during payment entry.
- Fixed remaining_balance condition to consider positive or negative value as long as a future amount is present

### Backport
version-15
version-14