### PR TITLE
fix(setup): avoid duplicate entry for Analytics role

### DIFF
--- a/erpnext/setup/install.py
+++ b/erpnext/setup/install.py
@@ -18,7 +18,9 @@ default_mail_footer = """<div style="padding: 7px; text-align: right; color: #88
 
 
 def after_install():
-	frappe.get_doc({"doctype": "Role", "role_name": "Analytics"}).insert()
+	if not frappe.db.exists("Role", "Analytics"):
+		frappe.get_doc({"doctype": "Role", "role_name": "Analytics"}).insert()
+
 	set_single_defaults()
 	create_print_setting_custom_fields()
 	add_all_roles_to("Administrator")


### PR DESCRIPTION
```
Installing erpnext...
Updating DocTypes for erpnext       : [========================================] 100%
An error occurred while installing hrms: ('Role', 'Analytics', IntegrityError(1062, "Duplicate entry 'Analytics' for key 'PRIMARY'"))
```