### PR TITLE
fix: report path from the Item and Putaway Rule list

### DIFF
--- a/erpnext/stock/doctype/item/item_list.js
+++ b/erpnext/stock/doctype/item/item_list.js
@@ -18,8 +18,7 @@ frappe.listview_settings['Item'] = {
 	reports: [
 		{
 			name: 'Stock Summary',
-			report_type: 'Page',
-			route: 'stock-balance'
+			route: '/app/stock-balance'
 		},
 		{
 			name: 'Stock Ledger',

--- a/erpnext/stock/doctype/putaway_rule/putaway_rule_list.js
+++ b/erpnext/stock/doctype/putaway_rule/putaway_rule_list.js
@@ -11,8 +11,7 @@ frappe.listview_settings['Putaway Rule'] = {
 	reports: [
 		{
 			name: 'Warehouse Capacity Summary',
-			report_type: 'Page',
-			route: 'warehouse-capacity-summary'
+			route: '/app/warehouse-capacity-summary'
 		}
 	]
 };


### PR DESCRIPTION
In Version 15 and 14,

- The report doesn't have the "Page" option. When you click "Stock Summary" from the Item list in the report, it doesn't redirect properly. Please watch the video to see the issue. The same issue exists for Warehouse Capacity Summary.


https://github.com/frappe/erpnext/assets/141945075/5f29ac4c-6d00-45fe-ab1b-f1b0217e4a0b

<br>

**After:**


https://github.com/frappe/erpnext/assets/141945075/c4ec0703-fecb-4d34-a120-fabba6f294fa


<br>

Thank You!