### PR TITLE
refactor: reduce usage of `cur_frm`

### DIFF
--- a/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.js
+++ b/erpnext/accounts/doctype/exchange_rate_revaluation/exchange_rate_revaluation.js
@@ -57,13 +57,13 @@ frappe.ui.form.on("Exchange Rate Revaluation", {
 	get_entries: function (frm, account) {
 		frappe.call({
 			method: "get_accounts_data",
-			doc: cur_frm.doc,
+			doc: frm.doc,
 			account: account,
 			callback: function (r) {
 				frappe.model.clear_table(frm.doc, "accounts");
 				if (r.message) {
 					r.message.forEach((d) => {
-						cur_frm.add_child("accounts", d);
+						frm.add_child("accounts", d);
 					});
 					frm.events.get_total_gain_loss(frm);
 					refresh_field("accounts");

--- a/erpnext/accounts/doctype/invoice_discounting/invoice_discounting.js
+++ b/erpnext/accounts/doctype/invoice_discounting/invoice_discounting.js
@@ -189,7 +189,7 @@ frappe.ui.form.on("Invoice Discounting", {
 
 	show_general_ledger: (frm) => {
 		if (frm.doc.docstatus > 0) {
-			cur_frm.add_custom_button(
+			frm.add_custom_button(
 				__("Accounting Ledger"),
 				function () {
 					frappe.route_options = {

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.js
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.js
@@ -255,7 +255,7 @@ erpnext.accounts.JournalEntry = class JournalEntry extends frappe.ui.form.Contro
 	}
 
 	onload_post_render() {
-		cur_frm.get_field("accounts").grid.set_multiple_add("account");
+		this.frm.get_field("accounts").grid.set_multiple_add("account");
 	}
 
 	load_defaults() {
@@ -402,7 +402,7 @@ erpnext.accounts.JournalEntry = class JournalEntry extends frappe.ui.form.Contro
 				row.debit = -doc.difference;
 			}
 		}
-		cur_frm.cscript.update_totals(doc);
+		this.frm.cscript.update_totals(doc);
 
 		erpnext.accounts.dimensions.copy_dimension_from_first_row(this.frm, cdt, cdn, "accounts");
 	}
@@ -469,11 +469,11 @@ frappe.ui.form.on("Journal Entry Account", {
 	},
 
 	debit: function (frm, dt, dn) {
-		cur_frm.cscript.update_totals(frm.doc);
+		frm.cscript.update_totals(frm.doc);
 	},
 
 	credit: function (frm, dt, dn) {
-		cur_frm.cscript.update_totals(frm.doc);
+		frm.cscript.update_totals(frm.doc);
 	},
 
 	exchange_rate: function (frm, cdt, cdn) {
@@ -489,7 +489,7 @@ frappe.ui.form.on("Journal Entry Account", {
 });
 
 frappe.ui.form.on("Journal Entry Account", "accounts_remove", function (frm) {
-	cur_frm.cscript.update_totals(frm.doc);
+	frm.cscript.update_totals(frm.doc);
 });
 
 $.extend(erpnext.journal_entry, {
@@ -531,7 +531,7 @@ $.extend(erpnext.journal_entry, {
 			flt(flt(row.credit_in_account_currency) * row.exchange_rate, precision("credit", row))
 		);
 
-		cur_frm.cscript.update_totals(frm.doc);
+		frm.cscript.update_totals(frm.doc);
 	},
 
 	set_exchange_rate: function (frm, cdt, cdn) {
@@ -673,10 +673,10 @@ $.extend(erpnext.journal_entry, {
 		return { filters: filters };
 	},
 
-	reverse_journal_entry: function () {
+	reverse_journal_entry: function (frm) {
 		frappe.model.open_mapped_doc({
 			method: "erpnext.accounts.doctype.journal_entry.journal_entry.make_reverse_journal_entry",
-			frm: cur_frm,
+			frm: frm,
 		});
 	},
 });

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -322,13 +322,13 @@ frappe.ui.form.on("Payment Entry", {
 			"references"
 		);
 
-		cur_frm.set_df_property(
+		frm.set_df_property(
 			"source_exchange_rate",
 			"description",
 			"1 " + frm.doc.paid_from_account_currency + " = [?] " + company_currency
 		);
 
-		cur_frm.set_df_property(
+		frm.set_df_property(
 			"target_exchange_rate",
 			"description",
 			"1 " + frm.doc.paid_to_account_currency + " = [?] " + company_currency

--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.js
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.js
@@ -193,7 +193,7 @@ erpnext.selling.POSInvoiceController = class POSInvoiceController extends erpnex
 	make_sales_return() {
 		frappe.model.open_mapped_doc({
 			method: "erpnext.accounts.doctype.pos_invoice.pos_invoice.make_sales_return",
-			frm: cur_frm,
+			frm: this.frm,
 		});
 	}
 };
@@ -293,7 +293,7 @@ frappe.ui.form.on("POS Invoice", {
 									});
 								} else if (frappe.dom.freeze_count != 0) {
 									frappe.dom.unfreeze();
-									cur_frm.reload_doc();
+									frm.reload_doc();
 									cur_pos.payment.events.submit_invoice();
 
 									frappe.show_alert({

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -131,17 +131,17 @@ erpnext.accounts.PurchaseInvoice = class PurchaseInvoice extends erpnext.buying.
 
 		if (doc.docstatus == 1 && doc.outstanding_amount != 0 && !doc.on_hold) {
 			this.frm.add_custom_button(__("Payment"), () => this.make_payment_entry(), __("Create"));
-			cur_frm.page.set_inner_btn_group_as_primary(__("Create"));
+			this.frm.page.set_inner_btn_group_as_primary(__("Create"));
 		}
 
 		if (!doc.is_return && doc.docstatus == 1) {
 			if (doc.outstanding_amount >= 0 || Math.abs(flt(doc.outstanding_amount)) < flt(doc.grand_total)) {
-				cur_frm.add_custom_button(__("Return / Debit Note"), this.make_debit_note, __("Create"));
+				this.frm.add_custom_button(__("Return / Debit Note"), this.make_debit_note, __("Create"));
 			}
 		}
 
 		if (doc.outstanding_amount > 0 && !cint(doc.is_return) && !doc.on_hold) {
-			cur_frm.add_custom_button(
+			this.frm.add_custom_button(
 				__("Payment Request"),
 				function () {
 					me.make_payment_request();
@@ -462,7 +462,7 @@ erpnext.accounts.PurchaseInvoice = class PurchaseInvoice extends erpnext.buying.
 	make_debit_note() {
 		frappe.model.open_mapped_doc({
 			method: "erpnext.accounts.doctype.purchase_invoice.purchase_invoice.make_debit_note",
-			frm: cur_frm,
+			frm: this.frm,
 		});
 	}
 };

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.js
@@ -61,9 +61,9 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 	refresh(doc, dt, dn) {
 		const me = this;
 		super.refresh();
-		if (cur_frm.msgbox && cur_frm.msgbox.$wrapper.is(":visible")) {
+		if (this.frm.msgbox && this.frm.msgbox.$wrapper.is(":visible")) {
 			// hide new msgbox
-			cur_frm.msgbox.hide();
+			this.frm.msgbox.hide();
 		}
 
 		this.frm.toggle_reqd("due_date", !this.frm.doc.is_return);
@@ -113,33 +113,33 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 		if (doc.docstatus == 1 && !doc.is_return) {
 			var is_delivered_by_supplier = false;
 
-			is_delivered_by_supplier = cur_frm.doc.items.some(function (item) {
+			is_delivered_by_supplier = this.frm.doc.items.some(function (item) {
 				return item.is_delivered_by_supplier ? true : false;
 			});
 
 			if (doc.outstanding_amount >= 0 || Math.abs(flt(doc.outstanding_amount)) < flt(doc.grand_total)) {
-				cur_frm.add_custom_button(__("Return / Credit Note"), this.make_sales_return, __("Create"));
-				cur_frm.page.set_inner_btn_group_as_primary(__("Create"));
+				this.frm.add_custom_button(__("Return / Credit Note"), this.make_sales_return, __("Create"));
+				this.frm.page.set_inner_btn_group_as_primary(__("Create"));
 			}
 
 			if (cint(doc.update_stock) != 1) {
 				// show Make Delivery Note button only if Sales Invoice is not created from Delivery Note
 				var from_delivery_note = false;
-				from_delivery_note = cur_frm.doc.items.some(function (item) {
+				from_delivery_note = this.frm.doc.items.some(function (item) {
 					return item.delivery_note ? true : false;
 				});
 
 				if (!from_delivery_note && !is_delivered_by_supplier) {
-					cur_frm.add_custom_button(
+					this.frm.add_custom_button(
 						__("Delivery"),
-						cur_frm.cscript["Make Delivery Note"],
+						this.frm.cscript["Make Delivery Note"],
 						__("Create")
 					);
 				}
 			}
 
 			if (doc.outstanding_amount > 0) {
-				cur_frm.add_custom_button(
+				this.frm.add_custom_button(
 					__("Payment Request"),
 					function () {
 						me.make_payment_request();
@@ -147,10 +147,10 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 					__("Create")
 				);
 
-				cur_frm.add_custom_button(
+				this.frm.add_custom_button(
 					__("Invoice Discounting"),
 					function () {
-						cur_frm.events.create_invoice_discounting(cur_frm);
+						this.frm.events.create_invoice_discounting(this.frm);
 					},
 					__("Create")
 				);
@@ -171,10 +171,10 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 			}
 
 			if (doc.docstatus === 1) {
-				cur_frm.add_custom_button(
+				this.frm.add_custom_button(
 					__("Maintenance Schedule"),
 					function () {
-						cur_frm.cscript.make_maintenance_schedule();
+						this.frm.cscript.make_maintenance_schedule();
 					},
 					__("Create")
 				);
@@ -182,7 +182,7 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 		}
 
 		// Show buttons only when pos view is active
-		if (cint(doc.docstatus == 0) && cur_frm.page.current_view_name !== "pos" && !doc.is_return) {
+		if (cint(doc.docstatus == 0) && this.frm.page.current_view_name !== "pos" && !doc.is_return) {
 			this.frm.cscript.sales_order_btn();
 			this.frm.cscript.delivery_note_btn();
 			this.frm.cscript.quotation_btn();
@@ -213,7 +213,7 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 	make_maintenance_schedule() {
 		frappe.model.open_mapped_doc({
 			method: "erpnext.accounts.doctype.sales_invoice.sales_invoice.make_maintenance_schedule",
-			frm: cur_frm,
+			frm: this.frm,
 		});
 	}
 
@@ -232,28 +232,27 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 
 	set_default_print_format() {
 		// set default print format to POS type or Credit Note
-		if (cur_frm.doc.is_pos) {
-			if (cur_frm.pos_print_format) {
-				cur_frm.meta._default_print_format = cur_frm.meta.default_print_format;
-				cur_frm.meta.default_print_format = cur_frm.pos_print_format;
+		if (this.frm.doc.is_pos) {
+			if (this.frm.pos_print_format) {
+				this.frm.meta._default_print_format = this.frm.meta.default_print_format;
+				this.frm.meta.default_print_format = this.frm.pos_print_format;
 			}
-		} else if (cur_frm.doc.is_return && !cur_frm.meta.default_print_format) {
-			if (cur_frm.return_print_format) {
-				cur_frm.meta._default_print_format = cur_frm.meta.default_print_format;
-				cur_frm.meta.default_print_format = cur_frm.return_print_format;
+		} else if (this.frm.doc.is_return && !this.frm.meta.default_print_format) {
+			if (this.frm.return_print_format) {
+				this.frm.meta._default_print_format = this.frm.meta.default_print_format;
+				this.frm.meta.default_print_format = this.frm.return_print_format;
 			}
 		} else {
-			if (cur_frm.meta._default_print_format) {
-				cur_frm.meta.default_print_format = cur_frm.meta._default_print_format;
-				cur_frm.meta._default_print_format = null;
+			if (this.frm.meta._default_print_format) {
+				this.frm.meta.default_print_format = this.frm.meta._default_print_format;
+				this.frm.meta._default_print_format = null;
 			} else if (
-				in_list(
-					[cur_frm.pos_print_format, cur_frm.return_print_format],
-					cur_frm.meta.default_print_format
+				[this.frm.pos_print_format, this.frm.return_print_format].includes(
+					this.frm.meta.default_print_format
 				)
 			) {
-				cur_frm.meta.default_print_format = null;
-				cur_frm.meta._default_print_format = null;
+				this.frm.meta.default_print_format = null;
+				this.frm.meta._default_print_format = null;
 			}
 		}
 	}
@@ -465,7 +464,7 @@ erpnext.accounts.SalesInvoiceController = class SalesInvoiceController extends (
 	make_sales_return() {
 		frappe.model.open_mapped_doc({
 			method: "erpnext.accounts.doctype.sales_invoice.sales_invoice.make_sales_return",
-			frm: cur_frm,
+			frm: this.frm,
 		});
 	}
 

--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -48,7 +48,7 @@ frappe.ui.form.on("Asset", {
 					method: "erpnext.assets.doctype.asset.asset.make_asset_movement",
 					freeze: true,
 					args: {
-						assets: [{ name: cur_frm.doc.name }],
+						assets: [{ name: frm.doc.name }],
 					},
 					callback: function (r) {
 						if (r.message) {
@@ -791,9 +791,7 @@ erpnext.asset.scrap_asset = function (frm) {
 				asset_name: frm.doc.name,
 			},
 			method: "erpnext.assets.doctype.asset.depreciation.scrap_asset",
-			callback: function (r) {
-				cur_frm.reload_doc();
-			},
+			callback: (r) => frm.reload_doc(),
 		});
 	});
 };
@@ -805,19 +803,17 @@ erpnext.asset.restore_asset = function (frm) {
 				asset_name: frm.doc.name,
 			},
 			method: "erpnext.assets.doctype.asset.depreciation.restore_asset",
-			callback: function (r) {
-				cur_frm.reload_doc();
-			},
+			callback: (r) => frm.reload_doc(),
 		});
 	});
 };
 
-erpnext.asset.transfer_asset = function () {
+erpnext.asset.transfer_asset = function (frm) {
 	frappe.call({
 		method: "erpnext.assets.doctype.asset.asset.make_asset_movement",
 		freeze: true,
 		args: {
-			assets: [{ name: cur_frm.doc.name }],
+			assets: [{ name: frm.doc.name }],
 			purpose: "Transfer",
 		},
 		callback: function (r) {

--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -86,7 +86,7 @@ frappe.ui.form.on("Purchase Order", {
 						args: {
 							subcontract_order: frm.doc.name,
 							rm_details: po_details,
-							order_doctype: cur_frm.doc.doctype,
+							order_doctype: frm.doc.doctype,
 						},
 						callback: function (r) {
 							if (r && r.message) {
@@ -270,8 +270,8 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 		var allow_receipt = false;
 		var is_drop_ship = false;
 
-		for (var i in cur_frm.doc.items) {
-			var item = cur_frm.doc.items[i];
+		for (var i in this.frm.doc.items) {
+			var item = this.frm.doc.items[i];
 			if (item.delivered_by_supplier !== 1) {
 				allow_receipt = true;
 			} else {
@@ -348,7 +348,7 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 			if (doc.status != "Closed") {
 				if (doc.status != "On Hold") {
 					if (flt(doc.per_received, 2) < 100 && allow_receipt) {
-						cur_frm.add_custom_button(
+						this.frm.add_custom_button(
 							__("Purchase Receipt"),
 							this.make_purchase_receipt,
 							__("Create")
@@ -356,7 +356,7 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 						if (doc.is_subcontracted) {
 							if (doc.is_old_subcontracting_flow) {
 								if (me.has_unsupplied_items()) {
-									cur_frm.add_custom_button(
+									this.frm.add_custom_button(
 										__("Material to Supplier"),
 										function () {
 											me.make_stock_entry();
@@ -365,7 +365,7 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 									);
 								}
 							} else {
-								cur_frm.add_custom_button(
+								this.frm.add_custom_button(
 									__("Subcontracting Order"),
 									this.make_subcontracting_order,
 									__("Create")
@@ -374,7 +374,7 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 						}
 					}
 					if (flt(doc.per_billed, 2) < 100)
-						cur_frm.add_custom_button(
+						this.frm.add_custom_button(
 							__("Purchase Invoice"),
 							this.make_purchase_invoice,
 							__("Create")
@@ -418,10 +418,10 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 					}
 				}
 
-				cur_frm.page.set_inner_btn_group_as_primary(__("Create"));
+				this.frm.page.set_inner_btn_group_as_primary(__("Create"));
 			}
 		} else if (doc.docstatus === 0) {
-			cur_frm.cscript.add_from_mappers();
+			this.frm.cscript.add_from_mappers();
 		}
 	}
 
@@ -458,8 +458,8 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 		frappe.call({
 			method: "erpnext.controllers.subcontracting_controller.make_rm_stock_entry",
 			args: {
-				subcontract_order: cur_frm.doc.name,
-				order_doctype: cur_frm.doc.doctype,
+				subcontract_order: this.frm.doc.name,
+				order_doctype: this.frm.doc.doctype,
 			},
 			callback: function (r) {
 				var doclist = frappe.model.sync(r.message);
@@ -478,7 +478,7 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 	make_purchase_receipt() {
 		frappe.model.open_mapped_doc({
 			method: "erpnext.buying.doctype.purchase_order.purchase_order.make_purchase_receipt",
-			frm: cur_frm,
+			frm: this.frm,
 			freeze_message: __("Creating Purchase Receipt ..."),
 		});
 	}
@@ -486,14 +486,14 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 	make_purchase_invoice() {
 		frappe.model.open_mapped_doc({
 			method: "erpnext.buying.doctype.purchase_order.purchase_order.make_purchase_invoice",
-			frm: cur_frm,
+			frm: this.frm,
 		});
 	}
 
 	make_subcontracting_order() {
 		frappe.model.open_mapped_doc({
 			method: "erpnext.buying.doctype.purchase_order.purchase_order.make_subcontracting_order",
-			frm: cur_frm,
+			frm: this.frm,
 			freeze_message: __("Creating Subcontracting Order ..."),
 		});
 	}
@@ -652,7 +652,7 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 	}
 
 	unhold_purchase_order() {
-		cur_frm.cscript.update_status("Resume", "Draft");
+		this.frm.cscript.update_status("Resume", "Draft");
 	}
 
 	hold_purchase_order() {
@@ -692,15 +692,15 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 	}
 
 	unclose_purchase_order() {
-		cur_frm.cscript.update_status("Re-open", "Submitted");
+		this.frm.cscript.update_status("Re-open", "Submitted");
 	}
 
 	close_purchase_order() {
-		cur_frm.cscript.update_status("Close", "Closed");
+		this.frm.cscript.update_status("Close", "Closed");
 	}
 
 	delivered_by_supplier() {
-		cur_frm.cscript.update_status("Deliver", "Delivered");
+		this.frm.cscript.update_status("Deliver", "Delivered");
 	}
 
 	items_on_form_rendered() {

--- a/erpnext/buying/doctype/supplier_quotation/supplier_quotation.js
+++ b/erpnext/buying/doctype/supplier_quotation/supplier_quotation.js
@@ -22,9 +22,9 @@ erpnext.buying.SupplierQuotationController = class SupplierQuotationController e
 			this.frm.set_value("valid_till", frappe.datetime.add_months(this.frm.doc.transaction_date, 1));
 		}
 		if (this.frm.doc.docstatus === 1) {
-			cur_frm.add_custom_button(__("Purchase Order"), this.make_purchase_order, __("Create"));
-			cur_frm.page.set_inner_btn_group_as_primary(__("Create"));
-			cur_frm.add_custom_button(__("Quotation"), this.make_quotation, __("Create"));
+			this.frm.add_custom_button(__("Purchase Order"), this.make_purchase_order, __("Create"));
+			this.frm.page.set_inner_btn_group_as_primary(__("Create"));
+			this.frm.add_custom_button(__("Quotation"), this.make_quotation, __("Create"));
 		} else if (this.frm.doc.docstatus === 0) {
 			this.frm.add_custom_button(
 				__("Material Request"),
@@ -87,13 +87,13 @@ erpnext.buying.SupplierQuotationController = class SupplierQuotationController e
 	make_purchase_order() {
 		frappe.model.open_mapped_doc({
 			method: "erpnext.buying.doctype.supplier_quotation.supplier_quotation.make_purchase_order",
-			frm: cur_frm,
+			frm: this.frm,
 		});
 	}
 	make_quotation() {
 		frappe.model.open_mapped_doc({
 			method: "erpnext.buying.doctype.supplier_quotation.supplier_quotation.make_quotation",
-			frm: cur_frm,
+			frm: this.frm,
 		});
 	}
 };

--- a/erpnext/crm/doctype/campaign/campaign.js
+++ b/erpnext/crm/doctype/campaign/campaign.js
@@ -11,7 +11,7 @@ frappe.ui.form.on("Campaign", {
 				frappe.boot.sysdefaults.campaign_naming_by == "Naming Series"
 			);
 		} else {
-			cur_frm.add_custom_button(
+			frm.add_custom_button(
 				__("View Leads"),
 				function () {
 					frappe.route_options = { source: "Campaign", campaign_name: frm.doc.name };

--- a/erpnext/crm/doctype/lead/lead.js
+++ b/erpnext/crm/doctype/lead/lead.js
@@ -89,32 +89,33 @@ erpnext.LeadController = class LeadController extends frappe.ui.form.Controller 
 	make_customer() {
 		frappe.model.open_mapped_doc({
 			method: "erpnext.crm.doctype.lead.lead.make_customer",
-			frm: cur_frm,
+			frm: this.frm,
 		});
 	}
 
 	make_quotation() {
 		frappe.model.open_mapped_doc({
 			method: "erpnext.crm.doctype.lead.lead.make_quotation",
-			frm: cur_frm,
+			frm: this.frm,
 		});
 	}
 
 	make_prospect() {
+		const me = this;
 		frappe.model.with_doctype("Prospect", function () {
 			let prospect = frappe.model.get_new_doc("Prospect");
-			prospect.company_name = cur_frm.doc.company_name;
-			prospect.no_of_employees = cur_frm.doc.no_of_employees;
-			prospect.industry = cur_frm.doc.industry;
-			prospect.market_segment = cur_frm.doc.market_segment;
-			prospect.territory = cur_frm.doc.territory;
-			prospect.fax = cur_frm.doc.fax;
-			prospect.website = cur_frm.doc.website;
-			prospect.prospect_owner = cur_frm.doc.lead_owner;
-			prospect.notes = cur_frm.doc.notes;
+			prospect.company_name = me.frm.doc.company_name;
+			prospect.no_of_employees = me.frm.doc.no_of_employees;
+			prospect.industry = me.frm.doc.industry;
+			prospect.market_segment = me.frm.doc.market_segment;
+			prospect.territory = me.frm.doc.territory;
+			prospect.fax = me.frm.doc.fax;
+			prospect.website = me.frm.doc.website;
+			prospect.prospect_owner = me.frm.doc.lead_owner;
+			prospect.notes = me.frm.doc.notes;
 
 			let leads_row = frappe.model.add_child(prospect, "leads");
-			leads_row.lead = cur_frm.doc.name;
+			leads_row.lead = me.frm.doc.name;
 
 			frappe.set_route("Form", "Prospect", prospect.name);
 		});

--- a/erpnext/crm/doctype/opportunity/opportunity.js
+++ b/erpnext/crm/doctype/opportunity/opportunity.js
@@ -318,14 +318,14 @@ erpnext.crm.Opportunity = class Opportunity extends frappe.ui.form.Controller {
 	create_quotation() {
 		frappe.model.open_mapped_doc({
 			method: "erpnext.crm.doctype.opportunity.opportunity.make_quotation",
-			frm: cur_frm,
+			frm: this.frm,
 		});
 	}
 
 	make_customer() {
 		frappe.model.open_mapped_doc({
 			method: "erpnext.crm.doctype.opportunity.opportunity.make_customer",
-			frm: cur_frm,
+			frm: this.frm,
 		});
 	}
 

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -2264,9 +2264,9 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 	}
 
 	get_method_for_payment() {
-		var method = "erpnext.accounts.doctype.payment_entry.payment_entry.get_payment_entry";
-		if(cur_frm.doc.__onload && cur_frm.doc.__onload.make_payment_via_journal_entry){
-			if(['Sales Invoice', 'Purchase Invoice'].includes( cur_frm.doc.doctype)){
+		let method = "erpnext.accounts.doctype.payment_entry.payment_entry.get_payment_entry";
+		if(this.frm.doc.__onload && this.frm.doc.__onload.make_payment_via_journal_entry){
+			if(['Sales Invoice', 'Purchase Invoice'].includes( this.frm.doc.doctype)){
 				method = "erpnext.accounts.doctype.journal_entry.journal_entry.get_payment_entry_against_invoice";
 			}else {
 				method= "erpnext.accounts.doctype.journal_entry.journal_entry.get_payment_entry_against_order";

--- a/erpnext/public/js/projects/timer.js
+++ b/erpnext/public/js/projects/timer.js
@@ -110,7 +110,7 @@ erpnext.timesheet.control_timer = function (frm, dialog, row, timestamp = 0) {
 
 	// Stop the timer and update the time logged by the timer on click of 'Complete' button
 	$btn_complete.click(function () {
-		var grid_row = cur_frm.fields_dict["time_logs"].grid.get_row(row.idx - 1);
+		var grid_row = frm.fields_dict["time_logs"].grid.get_row(row.idx - 1);
 		var args = dialog.get_values();
 		grid_row.doc.completed = 1;
 		grid_row.doc.activity_type = args.activity_type;


### PR DESCRIPTION
Usage of `cur_frm` is discouraged by our semgrep rules. Editing theses files would lead to a warning. This PR refactors the affected files in order to avoid future semgrep failures on unrelated PRs.

I manually replaced `cur_frm` with other `frm` references, where available