### PR TITLE
fix: uom wise price in sales or purchase transaction

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1173,6 +1173,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 				},
 				callback: function(r) {
 					if(!r.exc) {
+						me.apply_price_list(item, true)
 						frappe.model.set_value(cdt, cdn, 'conversion_factor', r.message.conversion_factor);
 					}
 				}


### PR DESCRIPTION
In Version 14 and 15,

fixes: #33642

**Before:**

- When you switch the unit of measurement (UOM) in a sales or purchase transaction, the price for that specific UOM doesn't automatically get adjusted. However, if you modify the price list, select a different price list, or change the quantity, then the price for that UOM will be updated accordingly.


https://github.com/frappe/erpnext/assets/141945075/6d68f9c9-2faf-4822-9bc8-aa9f4deb53a3

<br>

**After:**

- If you want to switch the unit of measurement (UOM) for an item, and each UOM has its own price, It will ensure that when you choose or alter the UOM, the price for that specific UOM will be correctly reflected based on the price list.


https://github.com/frappe/erpnext/assets/141945075/17e523b3-d445-4215-9c73-ff94e910fc13

<br>

Thank You!