### PR TITLE
fix: serial no valuation rate

### DIFF
--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -2118,7 +2118,7 @@ def is_serial_batch_no_exists(item_code, type_of_transaction, serial_no=None, ba
 
 		make_serial_no(serial_no, item_code)
 
-	if batch_no and frappe.db.exists("Batch", batch_no):
+	if batch_no and not frappe.db.exists("Batch", batch_no):
 		if type_of_transaction != "Inward":
 			frappe.throw(_("Batch No {0} does not exists").format(batch_no))
 

--- a/erpnext/stock/doctype/serial_and_batch_bundle/test_serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/test_serial_and_batch_bundle.py
@@ -540,6 +540,110 @@ class TestSerialandBatchBundle(FrappeTestCase):
 
 		self.assertRaises(frappe.exceptions.ValidationError, pr2.save)
 
+	def test_serial_no_valuation_for_legacy_ledgers(self):
+		sn_item = make_item(
+			"Test Serial No Valuation for Legacy Ledgers",
+			properties={"has_serial_no": 1, "serial_no_series": "SNN-TSNVL.-#####"},
+		).name
+
+		serial_nos = []
+		for serial_no in [f"{sn_item}-0001", f"{sn_item}-0002"]:
+			if not frappe.db.exists("Serial No", serial_no):
+				sn_doc = frappe.get_doc(
+					{
+						"doctype": "Serial No",
+						"serial_no": serial_no,
+						"item_code": sn_item,
+					}
+				).insert(ignore_permissions=True)
+				serial_nos.append(serial_no)
+
+		frappe.flags.ignore_serial_batch_bundle_validation = True
+
+		qty_after_transaction = 0.0
+		stock_value = 0.0
+		for row in [{"qty": 2, "rate": 100}, {"qty": -2, "rate": 100}, {"qty": 2, "rate": 200}]:
+			row = frappe._dict(row)
+			qty_after_transaction += row.qty
+			stock_value += row.rate * row.qty
+
+			doc = frappe.get_doc(
+				{
+					"doctype": "Stock Ledger Entry",
+					"posting_date": today(),
+					"posting_time": nowtime(),
+					"incoming_rate": row.rate if row.qty > 0 else 0,
+					"qty_after_transaction": qty_after_transaction,
+					"stock_value_difference": row.rate * row.qty,
+					"stock_value": stock_value,
+					"valuation_rate": row.rate,
+					"actual_qty": row.qty,
+					"item_code": sn_item,
+					"warehouse": "_Test Warehouse - _TC",
+					"serial_no": "\n".join(serial_nos),
+					"company": "_Test Company",
+				}
+			)
+			doc.flags.ignore_permissions = True
+			doc.flags.ignore_mandatory = True
+			doc.flags.ignore_links = True
+			doc.flags.ignore_validate = True
+			doc.submit()
+
+			for sn in serial_nos:
+				sn_doc = frappe.get_doc("Serial No", sn)
+				if row.qty > 0:
+					sn_doc.db_set("warehouse", "_Test Warehouse - _TC")
+				else:
+					sn_doc.db_set("warehouse", "")
+
+		frappe.flags.ignore_serial_batch_bundle_validation = False
+
+		se = make_stock_entry(
+			item_code=sn_item,
+			qty=2,
+			source="_Test Warehouse - _TC",
+			serial_no="\n".join(serial_nos),
+			use_serial_batch_fields=True,
+			do_not_submit=True,
+		)
+
+		se.save()
+		se.submit()
+
+		stock_value_difference = frappe.db.get_value(
+			"Stock Ledger Entry",
+			{"voucher_no": se.name, "is_cancelled": 0, "voucher_type": "Stock Entry"},
+			"stock_value_difference",
+		)
+
+		self.assertEqual(flt(stock_value_difference, 2), 400.0 * -1)
+
+		se = make_stock_entry(
+			item_code=sn_item,
+			qty=1,
+			rate=353,
+			target="_Test Warehouse - _TC",
+		)
+
+		serial_no = get_serial_nos_from_bundle(se.items[0].serial_and_batch_bundle)[0]
+
+		se = make_stock_entry(
+			item_code=sn_item,
+			qty=1,
+			source="_Test Warehouse - _TC",
+			serial_no=serial_no,
+			use_serial_batch_fields=True,
+		)
+
+		stock_value_difference = frappe.db.get_value(
+			"Stock Ledger Entry",
+			{"voucher_no": se.name, "is_cancelled": 0, "voucher_type": "Stock Entry"},
+			"stock_value_difference",
+		)
+
+		self.assertEqual(flt(stock_value_difference, 2), 353.0 * -1)
+
 
 def get_batch_from_bundle(bundle):
 	from erpnext.stock.serial_batch_bundle import get_batch_nos


### PR DESCRIPTION
If serial nos are available in the Stock Ledger Entries and while making the outward entry using serial and batch bundle, the valuation rate has not calculated correctly.