### PR TITLE
fix: rate change on changing of the qty

### DIFF
--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -22,7 +22,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 
 		item_rate = flt(item.rate_with_margin , precision("rate", item));
 
-		if (item.discount_percentage) {
+		if (item.discount_percentage && !item.discount_amount) {
 			item.discount_amount = flt(item.rate_with_margin) * flt(item.discount_percentage) / 100;
 		}
 


### PR DESCRIPTION
Steps to replicate issue

1. Create the purchase order for item A with qty as 20 and price list rate as 3,550.00
2. Add the discount amount as "210" > rate will set as 3,440.00 > save and submit
3. Make the purchase receipt against the above purchase order
4. Change the qty from 20 to 21
5. You will notice that the rate has changed from from 3,440.00 to 3,340.02