### PR TITLE
overproduction percentage issue

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -673,15 +673,22 @@ class JobCard(Document):
 		):
 			total_completed_qty_label = bold(_("Total Completed Qty"))
 			qty_to_manufacture = bold(_("Qty to Manufacture"))
+			wo_qty = flt(frappe.get_cached_value("Work Order", self.work_order, "qty"))
 
-			frappe.throw(
-				_("The {0} ({1}) must be equal to {2} ({3})").format(
-					total_completed_qty_label,
-					bold(flt(total_completed_qty, precision)),
-					qty_to_manufacture,
-					bold(self.for_quantity),
+			over_production_percentage = flt(frappe.db.get_single_value("Manufacturing Settings", "overproduction_percentage_for_work_order"))
+
+			wo_qty = wo_qty + (wo_qty * over_production_percentage / 100)
+			
+			if flt(qty_to_manufacture,precision) > flt(wo_qty,precision):
+
+				frappe.throw(
+					_("The {0} ({1}) must be equal to {2} ({3})").format(
+						total_completed_qty_label,
+						bold(flt(total_completed_qty, precision)),
+						qty_to_manufacture,
+						bold(self.for_quantity),
+					)
 				)
-			)
 
 	def set_expected_and_actual_time(self):
 		for child_table, start_field, end_field, time_required in [

--- a/erpnext/manufacturing/doctype/job_card/test_job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/test_job_card.py
@@ -8,7 +8,7 @@ import frappe
 from frappe.test_runner import make_test_records
 from frappe.tests.utils import FrappeTestCase, change_settings
 from frappe.utils import random_string
-from frappe.utils.data import add_to_date, now, today
+from frappe.utils.data import add_to_date, now, today, flt
 
 from erpnext.manufacturing.doctype.job_card.job_card import (
 	JobCardOverTransferError,
@@ -426,7 +426,14 @@ class TestJobCard(FrappeTestCase):
 		self.work_order.reload()
 		cost_after_cancel = self.work_order.total_operating_cost
 		self.assertEqual(cost_after_cancel, original_cost)
-
+		
+	def test_over_production_qty(self):
+		wo_qty=flt(frappe.db.get_value("Work Order",self.work_order,{"qty":7000}))
+  		over_production_percentage=flt(frappe.db.get_single_value("Manufacturing Settings", {"overproduction_percentage_for_work_order":80}))
+		wo_qty = wo_qty + (wo_qty * over_production_percentage / 100)
+  		if flt(self.total_completed_qty,precision) > flt(wo_qty,precision):
+			self.assertRaises(StockOverProductionError, self.submit)
+			
 	def test_job_card_statuses(self):
 		def assertStatus(status):
 			jc.set_status()

--- a/erpnext/manufacturing/doctype/job_card/test_job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/test_job_card.py
@@ -427,12 +427,15 @@ class TestJobCard(FrappeTestCase):
 		cost_after_cancel = self.work_order.total_operating_cost
 		self.assertEqual(cost_after_cancel, original_cost)
 		
-	def test_over_production_qty(self):
-		wo_qty=flt(frappe.db.get_value("Work Order",self.work_order,{"qty":7000}))
-  		over_production_percentage=flt(frappe.db.get_single_value("Manufacturing Settings", {"overproduction_percentage_for_work_order":80}))
-		wo_qty = wo_qty + (wo_qty * over_production_percentage / 100)
-  		if flt(self.total_completed_qty,precision) > flt(wo_qty,precision):
-			self.assertRaises(StockOverProductionError, self.submit)
+	 def test_over_production_qty(self):
+        wo_qty = flt(frappe.db.get_value("Work Order", self.work_order, {"qty": 7000}))
+        over_production_percentage = flt(frappe.db.get_single_value("Manufacturing Settings", {"overproduction_percentage_for_work_order":100}))
+        wo_qty_with_overproduction = wo_qty + (wo_qty * over_production_percentage / 100)
+        total_completed_qty = 15000
+        precision = 0.001
+        if flt(total_completed_qty, precision) > flt(wo_qty_with_overproduction, precision):
+            self.assertRaises(StockOverProductionError,self.submit())
+                
 			
 	def test_job_card_statuses(self):
 		def assertStatus(status):


### PR DESCRIPTION
https://github.com/frappe/erpnext/issues/40235
The overproduction percentage is entered in the manufacturing settings. However, the overproduction percentage is not considered on job cards, preventing the entry of overproduction quantity in the job card.
Before
[Screencast from 13-03-24 01:38:17 PM IST.webm](https://github.com/frappe/erpnext/assets/95607404/af46776c-16cf-43a1-8ec3-c386e738fe3a)

After
[Screencast from 13-03-24 01:43:00 PM IST.webm](https://github.com/frappe/erpnext/assets/95607404/133bb8d6-a2d8-466a-b06e-c66270e8ab17)

