### PR TITLE
fix(Payment request): Creating draft payment entry using 'create_payment_entry' method in 'PaymentRequest' class.

### DIFF
--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -360,8 +360,9 @@ class PaymentRequest(Document):
 				},
 			)
 
+		payment_entry.insert(ignore_permissions=True)
+		
 		if submit:
-			payment_entry.insert(ignore_permissions=True)
 			payment_entry.submit()
 
 		return payment_entry


### PR DESCRIPTION
Enabled creating draft payment entry when 'submit' parameter is set to 'false' in 'create_payment_entry' method in 'PaymentRequest' class.