### PR TITLE
fix: MR Default Supplier search query

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -595,16 +595,27 @@ def get_default_supplier_query(doctype, txt, searchfield, start, page_len, filte
 	for d in doc.items:
 		item_list.append(d.item_code)
 
-	return frappe.db.sql(
-		"""select default_supplier
-		from `tabItem Default`
-		where parent in ({0}) and
-		default_supplier IS NOT NULL
-		""".format(
-			", ".join(["%s"] * len(item_list))
-		),
-		tuple(item_list),
+	supplier = frappe.qb.DocType("Supplier")
+	item_default = frappe.qb.DocType("Item Default")
+	query = (
+		frappe.qb.from_(supplier)
+		.left_join(item_default)
+		.on(supplier.name == item_default.default_supplier)
+		.select(item_default.default_supplier)
+		.where(
+			(item_default.parent.isin(item_list))
+			& (item_default.default_supplier.notnull())
+			& (supplier[searchfield].like(f"%{txt}%"))
+		)
+		.offset(start)
+		.limit(page_len)
 	)
+
+	meta = frappe.get_meta("Supplier")
+	if meta.show_title_field_in_link and meta.title_field:
+		query = query.select(supplier[meta.title_field])
+
+	return query.run(as_dict=False)
 
 
 @frappe.whitelist()


### PR DESCRIPTION
![image](https://github.com/frappe/erpnext/assets/63660334/65c4f7ba-0d6e-4d2b-8e1c-4eb6579c9d89)

**Before:**

https://github.com/frappe/erpnext/assets/63660334/89249a9e-ac54-40db-9ec6-fdf78f0b856d

**After:**

https://github.com/frappe/erpnext/assets/63660334/31a3603f-9e80-4738-93f5-36e65a6d2e40






closes: https://github.com/frappe/erpnext/issues/40272