### PR TITLE
fix: incorrect TCS on customer and suppliers with same name

### DIFF
--- a/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
+++ b/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
@@ -546,6 +546,7 @@ def get_tcs_amount(parties, inv, tax_details, vouchers, adv_vouchers):
 			"GL Entry",
 			{
 				"is_cancelled": 0,
+				"party_type": "Customer",
 				"party": ["in", parties],
 				"company": inv.company,
 				"voucher_no": ["in", vouchers],
@@ -560,6 +561,7 @@ def get_tcs_amount(parties, inv, tax_details, vouchers, adv_vouchers):
 	conditions = []
 	conditions.append(ple.amount.lt(0))
 	conditions.append(ple.delinked == 0)
+	conditions.append(ple.party_type == "Customer")
 	conditions.append(ple.party.isin(parties))
 	conditions.append(ple.voucher_no == ple.against_voucher_no)
 	conditions.append(ple.company == inv.company)
@@ -579,6 +581,7 @@ def get_tcs_amount(parties, inv, tax_details, vouchers, adv_vouchers):
 			{
 				"is_cancelled": 0,
 				"credit": [">", 0],
+				"party_type": "Customer",
 				"party": ["in", parties],
 				"posting_date": ["between", (tax_details.from_date, tax_details.to_date)],
 				"company": inv.company,


### PR DESCRIPTION
If a Customer and Supplier has the same name, unallocated advances for the Supplier is being incorrectly considered in TCS amount calculation.