### PR TITLE
fix: batch no not copied while making Material Consumption entry

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -2168,23 +2168,42 @@ class StockEntry(StockController):
 		if not qty:
 			return
 
+		use_serial_batch_fields = frappe.db.get_single_value("Stock Settings", "use_serial_batch_fields")
+
 		ste_item_details = {
 			"from_warehouse": item.warehouse,
 			"to_warehouse": "",
 			"qty": qty,
 			"item_name": item.item_name,
-			"serial_and_batch_bundle": create_serial_and_batch_bundle(self, row, item, "Outward"),
+			"serial_and_batch_bundle": create_serial_and_batch_bundle(self, row, item, "Outward")
+			if not use_serial_batch_fields
+			else "",
 			"description": item.description,
 			"stock_uom": item.stock_uom,
 			"expense_account": item.expense_account,
 			"cost_center": item.buying_cost_center,
 			"original_item": item.original_item,
+			"serial_no": "\n".join(row.serial_nos)
+			if row.serial_nos and not row.batches_to_be_consume
+			else "",
+			"use_serial_batch_fields": use_serial_batch_fields,
 		}
 
 		if self.is_return:
 			ste_item_details["to_warehouse"] = item.s_warehouse
 
-		self.add_to_stock_entry_detail({item.item_code: ste_item_details})
+		if use_serial_batch_fields and not row.serial_no and row.batches_to_be_consume:
+			for batch_no, batch_qty in row.batches_to_be_consume.items():
+				ste_item_details.update(
+					{
+						"batch_no": batch_no,
+						"qty": batch_qty,
+					}
+				)
+
+				self.add_to_stock_entry_detail({item.item_code: ste_item_details})
+		else:
+			self.add_to_stock_entry_detail({item.item_code: ste_item_details})
 
 	@staticmethod
 	def get_serial_nos_based_on_transferred_batch(batch_no, serial_nos) -> list:
@@ -2335,6 +2354,9 @@ class StockEntry(StockController):
 				"item_name",
 				"serial_and_batch_bundle",
 				"allow_zero_valuation_rate",
+				"use_serial_batch_fields",
+				"batch_no",
+				"serial_no",
 			]:
 				if item_row.get(field):
 					se_child.set(field, item_row.get(field))
@@ -2983,7 +3005,7 @@ def get_available_materials(work_order) -> dict:
 			if row.batch_no:
 				item_data.batch_details[row.batch_no] += row.qty
 
-			if row.batch_nos:
+			elif row.batch_nos:
 				for batch_no, qty in row.batch_nos.items():
 					item_data.batch_details[batch_no] += qty
 
@@ -2991,7 +3013,7 @@ def get_available_materials(work_order) -> dict:
 				item_data.serial_nos.extend(get_serial_nos(row.serial_no))
 				item_data.serial_nos.sort()
 
-			if row.serial_nos:
+			elif row.serial_nos:
 				item_data.serial_nos.extend(get_serial_nos(row.serial_nos))
 				item_data.serial_nos.sort()
 		else:
@@ -3001,7 +3023,7 @@ def get_available_materials(work_order) -> dict:
 			if row.batch_no:
 				item_data.batch_details[row.batch_no] -= row.qty
 
-			if row.batch_nos:
+			elif row.batch_nos:
 				for batch_no, qty in row.batch_nos.items():
 					item_data.batch_details[batch_no] += qty
 
@@ -3009,7 +3031,7 @@ def get_available_materials(work_order) -> dict:
 				for serial_no in get_serial_nos(row.serial_no):
 					item_data.serial_nos.remove(serial_no)
 
-			if row.serial_nos:
+			elif row.serial_nos:
 				for serial_no in get_serial_nos(row.serial_nos):
 					item_data.serial_nos.remove(serial_no)
 


### PR DESCRIPTION
"Steps to Replicate the Issue"

- Enable "Use Serial / Batch" field in Stock Settings
- Create a work order with raw materials having batches
- Make material transfer entry
- Make Material Consumption, you will notice that the batch has not set

