### PR TITLE
fix: define dates before usage

### DIFF
--- a/erpnext/accounts/doctype/bisect_accounting_statements/bisect_accounting_statements.py
+++ b/erpnext/accounts/doctype/bisect_accounting_statements/bisect_accounting_statements.py
@@ -138,10 +138,11 @@ class BisectAccountingStatements(Document):
 
 		# set root as current node
 		root = frappe.db.get_all("Bisect Nodes", filters={"root": ["is", "not set"]})[0]
-		self.get_report_summary()
 		self.current_node = root.name
 		self.current_from_date = self.from_date
 		self.current_to_date = self.to_date
+
+		self.get_report_summary()
 		self.save()
 
 	def get_report_summary(self):


### PR DESCRIPTION
`self.get_report_summary()` depends on `self.current_from_date` and `self.current_to_date` being available, so we should probably call it after setting these values.

But I have no idea, what was intended here, so I might well be wrong. Anyways, the undefined dates caused this error messages when trying to run "Rebuild Tree":

```
File "apps/frappe/frappe/app.py", line 110, in application
    response = frappe.api.handle(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/__init__.py", line 49, in handle
    data = endpoint(**arguments)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/api/v1.py", line 36, in handle_rpc_call
    return frappe.handler.handle()
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 49, in handle
    data = execute_cmd(cmd)
           ^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 85, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/__init__.py", line 1796, in call
    return fn(*args, **newargs)
           ^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/handler.py", line 326, in run_doc_method
    response = doc.run_method(method)
               ^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 959, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1319, in composer
    return composed(self, method, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 1301, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
                              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/model/document.py", line 956, in fn
    return method_object(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/utils/typing_validations.py", line 31, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/accounts/doctype/bisect_accounting_statements/bisect_accounting_statements.py", line 141, in build_tree
    self.get_report_summary()
  File "apps/erpnext/erpnext/accounts/doctype/bisect_accounting_statements/bisect_accounting_statements.py", line 156, in get_report_summary
    self.p_l_summary = pl_summary.execute_script_report(filters=filters)[5]
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/core/doctype/report/report.py", line 162, in execute_script_report
    res = self.execute_module(filters)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/core/doctype/report/report.py", line 179, in execute_module
    return frappe.get_attr(method_name)(frappe._dict(filters))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.py", line 18, in execute
    period_list = get_period_list(
                  ^^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/accounts/report/financial_statements.py", line 42, in get_period_list
    validate_dates(period_start_date, period_end_date)
  File "apps/erpnext/erpnext/accounts/report/financial_statements.py", line 130, in validate_dates
    frappe.throw(_("From Date and To Date are mandatory"))
  File "apps/frappe/frappe/__init__.py", line 678, in throw
    msgprint(
  File "apps/frappe/frappe/__init__.py", line 643, in msgprint
    _raise_exception()
  File "apps/frappe/frappe/__init__.py", line 594, in _raise_exception
    raise exc
frappe.exceptions.ValidationError: From Date and To Date are mandatory
```