### PR TITLE
fix(Stock): Copy Table MultiSelect Values to Item Variants on Update

### DIFF
--- a/erpnext/controllers/item_variant.py
+++ b/erpnext/controllers/item_variant.py
@@ -344,6 +344,11 @@ def copy_attributes_to_variant(item, variant):
 						if row.get("name"):
 							row.name = None
 						variant.append(field.fieldname, row)
+				elif field.fieldtype == "Table MultiSelect":
+					tbl = item.get(field.fieldname)
+					for row in tbl:
+						row.name = None  # force creation of new name
+					variant.set(field.fieldname, tbl)
 				else:
 					variant.set(field.fieldname, item.get(field.fieldname))
 


### PR DESCRIPTION
The additional `elif` clause for "Table MultiSelect" fields resets each row's `name` to `None` which forces generation of new names and thereby inserts of new copies. Otherwise only the rows' parent references would be updated, i.e. the rows moved from one `Item` to another.

Having a hard time creating a test function in `erpnext/controllers/tests/test_item_variant.py` because there seem to be no APIs e.g. to create a `DocType`.

Closes #40213

Would be great if it could be backported to `version-15` (@merifyio backport version-15-hotfix).
