### PR TITLE
fix(Shipment Parcel): make length, width and height non-mandatory

### DIFF
--- a/erpnext/stock/doctype/shipment_parcel/shipment_parcel.json
+++ b/erpnext/stock/doctype/shipment_parcel/shipment_parcel.json
@@ -16,22 +16,19 @@
    "fieldname": "length",
    "fieldtype": "Int",
    "in_list_view": 1,
-   "label": "Length (cm)",
-   "reqd": 1
+   "label": "Length (cm)"
   },
   {
    "fieldname": "width",
    "fieldtype": "Int",
    "in_list_view": 1,
-   "label": "Width (cm)",
-   "reqd": 1
+   "label": "Width (cm)"
   },
   {
    "fieldname": "height",
    "fieldtype": "Int",
    "in_list_view": 1,
-   "label": "Height (cm)",
-   "reqd": 1
+   "label": "Height (cm)"
   },
   {
    "fieldname": "weight",
@@ -52,7 +49,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2020-07-09 12:54:14.847170",
+ "modified": "2024-03-06 16:48:57.355757",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Shipment Parcel",
@@ -61,5 +58,6 @@
  "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "track_changes": 1
 }


### PR DESCRIPTION
It's tedious to enter all these values and some shipping providers only require the weight and quantity. Companies can always customize these fields to be mandatory, but the reverse is not possible. I'll make sure that the erpnext-shipping app does not break because of this (or fix any problems).
