### PR TITLE
fix: Update Existing Price List Rate not working

### DIFF
--- a/erpnext/setup/demo_data/item.json
+++ b/erpnext/setup/demo_data/item.json
@@ -4,6 +4,7 @@
         "item_group": "Demo Item Group",
         "item_code": "SKU001",
         "item_name": "T-shirt",
+        "valuation_rate": 400.0,
         "gst_hsn_code": "999512",
         "image": "https://images.pexels.com/photos/1484808/pexels-photo-1484808.jpeg"
     },
@@ -11,6 +12,7 @@
         "doctype": "Item",
         "item_group": "Demo Item Group",
         "item_code": "SKU002",
+        "valuation_rate": 300.0,
         "item_name": "Laptop",
         "gst_hsn_code": "999512",
         "image": "https://images.pexels.com/photos/3999538/pexels-photo-3999538.jpeg"
@@ -19,6 +21,7 @@
         "doctype": "Item",
         "item_group": "Demo Item Group",
         "item_code": "SKU003",
+        "valuation_rate": 523.0,
         "item_name": "Book",
         "gst_hsn_code": "999512",
         "image": "https://images.pexels.com/photos/2422178/pexels-photo-2422178.jpeg"
@@ -27,6 +30,7 @@
         "doctype": "Item",
         "item_group": "Demo Item Group",
         "item_code": "SKU004",
+        "valuation_rate": 725.0,
         "item_name": "Smartphone",
         "gst_hsn_code": "999512",
         "image": "https://images.pexels.com/photos/1647976/pexels-photo-1647976.jpeg"
@@ -35,6 +39,7 @@
         "doctype": "Item",
         "item_group": "Demo Item Group",
         "item_code": "SKU005",
+        "valuation_rate": 222.0,
         "item_name": "Sneakers",
         "gst_hsn_code": "999512",
         "image": "https://images.pexels.com/photos/1598505/pexels-photo-1598505.jpeg"
@@ -43,6 +48,7 @@
         "doctype": "Item",
         "item_group": "Demo Item Group",
         "item_code": "SKU006",
+        "valuation_rate": 420.0,
         "item_name": "Coffee Mug",
         "gst_hsn_code": "999512",
         "image": "https://images.pexels.com/photos/585753/pexels-photo-585753.jpeg"
@@ -51,6 +57,7 @@
         "doctype": "Item",
         "item_group": "Demo Item Group",
         "item_code": "SKU007",
+        "valuation_rate": 375.0,
         "item_name": "Television",
         "gst_hsn_code": "999512",
         "image": "https://images.pexels.com/photos/8059376/pexels-photo-8059376.jpeg"
@@ -59,6 +66,7 @@
         "doctype": "Item",
         "item_group": "Demo Item Group",
         "item_code": "SKU008",
+        "valuation_rate": 333.0,
         "item_name": "Backpack",
         "gst_hsn_code": "999512",
         "image": "https://images.pexels.com/photos/3731256/pexels-photo-3731256.jpeg"
@@ -67,6 +75,7 @@
         "doctype": "Item",
         "item_group": "Demo Item Group",
         "item_code": "SKU009",
+        "valuation_rate": 700.0,
         "item_name": "Headphones",
         "gst_hsn_code": "999512",
         "image": "https://images.pexels.com/photos/3587478/pexels-photo-3587478.jpeg"
@@ -75,6 +84,7 @@
         "doctype": "Item",
         "item_group": "Demo Item Group",
         "item_code": "SKU010",
+        "valuation_rate": 500.0,
         "item_name": "Camera",
         "gst_hsn_code": "999512",
         "image": "https://images.pexels.com/photos/51383/photo-camera-subject-photographer-51383.jpeg"

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -816,7 +816,9 @@ def get_price_list_rate(args, item_doc, out=None):
 			price_list_rate = get_price_list_rate_for(args, item_doc.variant_of)
 
 		# insert in database
-		if price_list_rate is None:
+		if price_list_rate is None or frappe.db.get_single_value(
+			"Stock Settings", "update_existing_price_list_rate"
+		):
 			if args.price_list and args.rate:
 				insert_item_price(args)
 			return out


### PR DESCRIPTION
The 'Update Existing Price List Rate' checkbox has enabled in the stock settings, but still after that the rate has not updated in the item price on changing of the rate in the sales order.

Fixed https://github.com/frappe/erpnext/issues/35933