### PR TITLE
fix: load ignored doctype and include Mode of Payment Account

### DIFF
--- a/erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.js
+++ b/erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.js
@@ -29,7 +29,7 @@ frappe.ui.form.on('Transaction Deletion Record', {
 });
 
 function populate_doctypes_to_be_ignored(doctypes_to_be_ignored_array, frm) {
-	if (!(frm.doc.doctypes_to_be_ignored)) {
+	if (frm.doc.doctypes_to_be_ignored.length === 0) {
 		var i;
 		for (i = 0; i < doctypes_to_be_ignored_array.length; i++) {
 			frm.add_child('doctypes_to_be_ignored', {

--- a/erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py
+++ b/erpnext/setup/doctype/transaction_deletion_record/transaction_deletion_record.py
@@ -286,6 +286,7 @@ def get_doctypes_to_be_ignored():
 		"Bank Account",
 		"Item Tax Template",
 		"Mode of Payment",
+		"Mode of Payment Account",
 		"Item Default",
 		"Customer",
 		"Supplier",


### PR DESCRIPTION
In Version 15 and 14,

fixes: #36081

**Before:**

- **_First issue in version 15:_** When creating a Transaction Deletion Record for the company, the ignored doctype is not loaded in 'onload' time but it's working on version 14. because In JavaScript, when you use if (!(array)) to check if an array is empty, it might not work as expected because an empty array is considered a truthy value. This is because JavaScript interprets any non-falsy value as true. So, even though frm.doc.doctypes_to_be_ignored appears empty, it's still considered true in the context of the if statement. To correctly check if the array is empty, you should explicitly check its length like if (frm.doc.doctypes_to_be_ignored.length === 0). This way, you're directly checking if there are no elements in the array, ensuring the condition behaves as expected.

- **_Second Issue for both versions:_** When creating a Transaction Deletion Record and submitting it, the "Mode of Payment Account" linking is destroyed.


https://github.com/frappe/erpnext/assets/141945075/fdd4642b-d946-4040-843a-603982fdc790

<br>

**After:**

Both issues will be resolved. so please check the video.


https://github.com/frappe/erpnext/assets/141945075/979e6335-09a0-49b1-aceb-969e4896f893

<br>

Thank You!