### PR TITLE
fix: get_user_default_as_list args order

### DIFF
--- a/erpnext/__init__.py
+++ b/erpnext/__init__.py
@@ -13,7 +13,7 @@ def get_default_company(user=None):
 	if not user:
 		user = frappe.session.user
 
-	companies = get_user_default_as_list(user, "company")
+	companies = get_user_default_as_list("company", user)
 	if companies:
 		default_company = companies[0]
 	else:


### PR DESCRIPTION
Should be `key`, `user` NOT `user`, `key`

https://github.com/frappe/frappe/blob/3c843d8c1330753aa15acd29853b580d0eb2b0b0/frappe/defaults.py#L59 

Backport:

- version-15
- version-14