### PR TITLE
feat: Purchase Receipt Planning

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -307,7 +307,13 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends e
 			if(doc.status != "Closed") {
 				if (doc.status != "On Hold") {
 					if(flt(doc.per_received, 2) < 100 && allow_receipt) {
-						cur_frm.add_custom_button(__('Purchase Receipt'), this.make_purchase_receipt, __('Create'));
+						if (doc.has_receipt_plan) {
+							cur_frm.add_custom_button(__('Purchase Receipt'), function() {
+								me.make_purchase_receipt_by_plan();
+							}, __('Create'));
+						} else {
+							cur_frm.add_custom_button(__('Purchase Receipt'), this.make_purchase_receipt, __('Create'));
+						}
 						if (doc.is_subcontracted) {
 							if (doc.is_old_subcontracting_flow) {
 								if (me.has_unsupplied_items()) {
@@ -413,6 +419,85 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends e
 			frm: cur_frm,
 			freeze_message: __("Creating Purchase Receipt ...")
 		})
+	}
+
+	make_purchase_receipt_by_plan() {
+		frappe.call({
+			method: "erpnext.buying.doctype.purchase_order.purchase_order.get_used_receipt_plan",
+			args: {
+				purchase_order: cur_frm.doc.name,
+			},
+			callback(r) {
+				let plans = cur_frm.doc.receipt_plan.map(plan => {
+					return {...plan, done: r.message.includes(plan.name)};
+				});
+				var dialog = new frappe.ui.Dialog({
+					title: __("Select Receipt Plan"),
+					fields: [{
+						fieldname: 'receipt_plan',
+						fieldtype: 'Table',
+						label: __("Installments"),
+						cannot_add_rows: 1,
+						fields: [
+							{
+								fieldtype: 'Data',
+								fieldname: 'idx',
+								label: __('No.'),
+								read_only: 1,
+								in_list_view: 1
+							},
+							{
+								fieldtype: 'Data',
+								fieldname: 'name',
+								label: __('Name'),
+								read_only: 1,
+								in_list_view: 0
+							},
+							{
+								fieldtype: 'Data',
+								fieldname: 'description',
+								label: __('Description'),
+								read_only: 1,
+								in_list_view: 1
+							},
+							{
+								fieldtype: 'Percent',
+								fieldname: 'receipt_portion',
+								label: __('Receipt Portion'),
+								read_only: 1,
+								in_list_view: 1
+							},
+							{
+								fieldtype: 'Check',
+								fieldname: 'done',
+								label: __('Done'),
+								read_only: 1,
+								in_list_view: 1
+							},
+						],
+						data: plans
+					}]
+				});
+				dialog.set_primary_action(__('Create Purchase Receipt'), function() {
+					var selected_plans = dialog.fields_dict.receipt_plan.grid.get_selected_children();
+					if (selected_plans.length != 1) { frappe.throw(__('Please select only 1 installment')); }
+					for (let plan of selected_plans) {
+						if (plan.done) {
+							frappe.throw(__('Installment {0} is already created', [plan.idx]));
+						}
+					}
+					frappe.model.open_mapped_doc({
+						method: "erpnext.buying.doctype.purchase_order.purchase_order.make_purchase_receipt",
+						frm: cur_frm,
+						args: {
+							plan: selected_plans[0].name,
+							portion: selected_plans[0].receipt_portion
+						},
+					})
+				})
+				dialog.show();
+			},
+		});
 	}
 
 	make_purchase_invoice() {

--- a/erpnext/buying/doctype/purchase_order/purchase_order.json
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.json
@@ -24,6 +24,7 @@
   "apply_tds",
   "tax_withholding_category",
   "is_subcontracted",
+  "has_receipt_plan",
   "supplier_warehouse",
   "amended_from",
   "accounting_dimensions_section",
@@ -131,6 +132,8 @@
   "terms_section_break",
   "tc_name",
   "terms",
+  "receipt_plan_tab",
+  "receipt_plan",
   "more_info_tab",
   "tracking_section",
   "status",
@@ -1282,6 +1285,26 @@
    "oldfieldtype": "Select",
    "options": "Not Initiated\nInitiated\nPartially Paid\nFully Paid",
    "print_hide": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "default": "0",
+   "fieldname": "has_receipt_plan",
+   "fieldtype": "Check",
+   "label": "Has Receipt Plan"
+  },
+  {
+   "depends_on": "eval:doc.has_receipt_plan",
+   "fieldname": "receipt_plan_tab",
+   "fieldtype": "Tab Break",
+   "label": "Receipt Plan"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "receipt_plan",
+   "fieldtype": "Table",
+   "label": "Receipt Plan",
+   "options": "Receipt Plan"
   }
  ],
  "icon": "fa fa-file-text",

--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -450,6 +450,12 @@ class PurchaseOrder(BuyingController):
 				raise_exception=True,
 			)
 
+	def validate_receipt_plan(self):
+		if self.has_receipt_plan:
+			total = sum([d.receipt_portion for d in self.receipt_plan])
+			if total != 100:
+				frappe.throw(_("Total Receipt Plan must be 100%"))
+
 	def update_status(self, status):
 		self.check_modified_date()
 		self.set_status(update=True, status=status)
@@ -480,10 +486,14 @@ class PurchaseOrder(BuyingController):
 		)
 
 		self.update_blanket_order()
+		self.validate_receipt_plan()
 
 		update_linked_doc(self.doctype, self.name, self.inter_company_order_reference)
 
 		self.auto_create_subcontracting_order()
+
+	def on_update_after_submit(self):
+		self.validate_receipt_plan()
 
 	def on_cancel(self):
 		self.ignore_linked_doctypes = ("GL Entry", "Payment Ledger Entry")
@@ -691,12 +701,16 @@ def set_missing_values(source, target):
 @frappe.whitelist()
 def make_purchase_receipt(source_name, target_doc=None):
 	def update_item(obj, target, source_parent):
-		target.qty = flt(obj.qty) - flt(obj.received_qty)
-		target.stock_qty = (flt(obj.qty) - flt(obj.received_qty)) * flt(obj.conversion_factor)
-		target.amount = (flt(obj.qty) - flt(obj.received_qty)) * flt(obj.rate)
-		target.base_amount = (
-			(flt(obj.qty) - flt(obj.received_qty)) * flt(obj.rate) * flt(source_parent.conversion_rate)
-		)
+		qty = qty_remain = flt(obj.qty) - flt(obj.received_qty)
+		args = frappe.flags.args
+		if args and args.plan and args.portion:
+			qty = flt(obj.qty) * flt(args.portion) / 100
+			qty = qty_remain if (qty > qty_remain) else qty
+			target.receipt_plan = args.plan
+		target.qty = qty
+		target.stock_qty = qty * flt(obj.conversion_factor)
+		target.amount = qty * flt(obj.rate)
+		target.base_amount = qty * flt(obj.rate) * flt(source_parent.conversion_rate)
 
 	doc = get_mapped_doc(
 		"Purchase Order",
@@ -732,6 +746,19 @@ def make_purchase_receipt(source_name, target_doc=None):
 	)
 
 	return doc
+
+
+@frappe.whitelist()
+def get_used_receipt_plan(purchase_order):
+	receipt_plans = frappe.get_all(
+		"Purchase Receipt Item",
+		filters={
+			"purchase_order": purchase_order,
+			"docstatus": ["!=", 2],
+		},
+		pluck="receipt_plan",
+	)
+	return receipt_plans
 
 
 @frappe.whitelist()

--- a/erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
+++ b/erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
@@ -87,6 +87,7 @@
   "quality_inspection",
   "material_request_item",
   "purchase_order_item",
+  "receipt_plan",
   "purchase_invoice_item",
   "purchase_receipt_item",
   "delivery_note_item",
@@ -1107,7 +1108,16 @@
    "fieldname": "use_serial_batch_fields",
    "fieldtype": "Check",
    "label": "Use Serial No / Batch Fields"
-  }
+  },
+  {
+    "fieldname": "receipt_plan",
+    "fieldtype": "Data",
+    "hidden": 1,
+    "label": "Receipt Plan",
+    "no_copy": 1,
+    "print_hide": 1,
+    "search_index": 1
+   }
  ],
  "idx": 1,
  "istable": 1,

--- a/erpnext/stock/doctype/receipt_plan/receipt_plan.js
+++ b/erpnext/stock/doctype/receipt_plan/receipt_plan.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('Receipt Plan', {
+	// refresh: function(frm) {
+
+	// }
+});

--- a/erpnext/stock/doctype/receipt_plan/receipt_plan.json
+++ b/erpnext/stock/doctype/receipt_plan/receipt_plan.json
@@ -1,0 +1,43 @@
+{
+    "actions": [],
+    "allow_rename": 1,
+    "creation": "2023-06-02 17:31:07.215246",
+    "default_view": "List",
+    "doctype": "DocType",
+    "editable_grid": 1,
+    "engine": "InnoDB",
+    "field_order": [
+     "description",
+     "receipt_portion"
+    ],
+    "fields": [
+     {
+      "allow_on_submit": 1,
+      "fieldname": "receipt_portion",
+      "fieldtype": "Percent",
+      "in_list_view": 1,
+      "label": "Receipt Portion",
+      "reqd": 1
+     },
+     {
+      "allow_on_submit": 1,
+      "fieldname": "description",
+      "fieldtype": "Data",
+      "in_list_view": 1,
+      "label": "Description",
+      "reqd": 1
+     }
+    ],
+    "index_web_pages_for_search": 1,
+    "istable": 1,
+    "links": [],
+    "modified": "2023-08-17 14:30:09.143572",
+    "modified_by": "Administrator",
+    "module": "Stock",
+    "name": "Receipt Plan",
+    "owner": "Administrator",
+    "permissions": [],
+    "sort_field": "modified",
+    "sort_order": "DESC",
+    "states": []
+   }

--- a/erpnext/stock/doctype/receipt_plan/receipt_plan.py
+++ b/erpnext/stock/doctype/receipt_plan/receipt_plan.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+class ReceiptPlan(Document):
+	pass

--- a/erpnext/stock/doctype/receipt_plan/test_receipt_plan.py
+++ b/erpnext/stock/doctype/receipt_plan/test_receipt_plan.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestReceiptPlan(FrappeTestCase):
+	pass


### PR DESCRIPTION
This PR is moved from #35559
For the same in Sales #40348

This module add new feature, Purchase Receipt Planning, which normally useful if for i.e., construction where we normally pay by planned installment.

Design

* On Purchase Order, add new checkbox "Has Receipt Plan"
* If checked, user must plan receipt portions which should sum to 100%
* Validate Receipt Plan on Submit and after Submit.
* Create Purchase Receipt will now has dialog for user to choose the Installment

![pic1](https://github.com/frappe/erpnext/assets/1973598/6b748346-08c5-45ca-a719-230adfa7a0a6)
![pic3](https://github.com/frappe/erpnext/assets/1973598/e8c578c1-29e0-433d-be31-ee39015f5c1e)
![pic2](https://github.com/frappe/erpnext/assets/1973598/4f750606-1dee-4e07-adfc-d70a2dbaedfe)
