### PR TITLE
feat: Sales Delivery Plan

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.json
+++ b/erpnext/selling/doctype/sales_order/sales_order.json
@@ -25,6 +25,7 @@
   "po_date",
   "company",
   "skip_delivery_note",
+  "has_delivery_plan",
   "amended_from",
   "accounting_dimensions_section",
   "cost_center",
@@ -122,6 +123,8 @@
   "terms_section_break",
   "tc_name",
   "terms",
+  "delivery_plan_tab",
+  "delivery_plan",
   "more_info",
   "section_break_78",
   "status",
@@ -1651,13 +1654,34 @@
    "no_copy": 1,
    "options": "Not Requested\nRequested\nPartially Paid\nFully Paid",
    "print_hide": 1
+  },
+  {
+   "allow_on_submit": 1,
+   "default": "0",
+   "fieldname": "has_delivery_plan",
+   "fieldtype": "Check",
+   "label": "Has Delivery Plan"
+  },
+  {
+   "allow_on_submit": 1,
+   "depends_on": "eval:doc.has_delivery_plan",
+   "fieldname": "delivery_plan_tab",
+   "fieldtype": "Tab Break",
+   "label": "Delivery Plan"
+  },
+  {
+   "allow_on_submit": 1,
+   "fieldname": "delivery_plan",
+   "fieldtype": "Table",
+   "label": "Delivery Plan",
+   "options": "Delivery Plan"
   }
  ],
  "icon": "fa fa-file-text",
  "idx": 105,
  "is_submittable": 1,
  "links": [],
- "modified": "2023-10-18 12:41:54.813462",
+ "modified": "2024-03-09 16:38:29.248942",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order",

--- a/erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
+++ b/erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -72,6 +72,7 @@
   "col_break4",
   "allow_zero_valuation_rate",
   "against_sales_order",
+  "delivery_plan",
   "so_detail",
   "against_sales_invoice",
   "si_detail",
@@ -906,7 +907,16 @@
   {
    "fieldname": "column_break_rxvc",
    "fieldtype": "Column Break"
-  }
+  },
+  {
+    "fieldname": "delivery_plan",
+    "fieldtype": "Data",
+    "hidden": 1,
+    "label": "Delivery Plan",
+    "no_copy": 1,
+    "print_hide": 1,
+    "search_index": 1
+   }
  ],
  "idx": 1,
  "index_web_pages_for_search": 1,

--- a/erpnext/stock/doctype/delivery_plan/delivery_plan.js
+++ b/erpnext/stock/doctype/delivery_plan/delivery_plan.js
@@ -1,0 +1,8 @@
+// Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and contributors
+// For license information, please see license.txt
+
+frappe.ui.form.on('Delivery Plan', {
+	// refresh: function(frm) {
+
+	// }
+});

--- a/erpnext/stock/doctype/delivery_plan/delivery_plan.json
+++ b/erpnext/stock/doctype/delivery_plan/delivery_plan.json
@@ -1,0 +1,43 @@
+{
+    "actions": [],
+    "allow_rename": 1,
+    "creation": "2023-06-02 17:31:07.215246",
+    "default_view": "List",
+    "doctype": "DocType",
+    "editable_grid": 1,
+    "engine": "InnoDB",
+    "field_order": [
+     "description",
+     "delivery_portion"
+    ],
+    "fields": [
+     {
+      "allow_on_submit": 1,
+      "fieldname": "delivery_portion",
+      "fieldtype": "Percent",
+      "in_list_view": 1,
+      "label": "Delivery Portion",
+      "reqd": 1
+     },
+     {
+      "allow_on_submit": 1,
+      "fieldname": "description",
+      "fieldtype": "Data",
+      "in_list_view": 1,
+      "label": "Description",
+      "reqd": 1
+     }
+    ],
+    "index_web_pages_for_search": 1,
+    "istable": 1,
+    "links": [],
+    "modified": "2023-08-17 14:30:09.143572",
+    "modified_by": "Administrator",
+    "module": "Stock",
+    "name": "Delivery Plan",
+    "owner": "Administrator",
+    "permissions": [],
+    "sort_field": "modified",
+    "sort_order": "DESC",
+    "states": []
+   }

--- a/erpnext/stock/doctype/delivery_plan/delivery_plan.py
+++ b/erpnext/stock/doctype/delivery_plan/delivery_plan.py
@@ -1,0 +1,8 @@
+# Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+class DeliveryPlan(Document):
+	pass

--- a/erpnext/stock/doctype/delivery_plan/test_delivery_plan.py
+++ b/erpnext/stock/doctype/delivery_plan/test_delivery_plan.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and Contributors
+# See license.txt
+
+# import frappe
+from frappe.tests.utils import FrappeTestCase
+
+
+class TestDeliveryPlan(FrappeTestCase):
+	pass


### PR DESCRIPTION
For the same in Purchase #40346

This module add new feature, Sales Delivery Planning, which normally useful if for i.e., construction where we normally pay by planned installment.

Design

* On Purchase Order, add new checkbox "Has Delivery Plan"
* If checked, user must plan delivery portions which should sum to 100%
* Validate Delivery Plan on Submit and after Submit.
* Create Sales Delivery will now has dialog for user to choose the Installment

![image](https://github.com/frappe/erpnext/assets/1973598/e3925df4-79b5-4fa5-b7d7-32fd1512e006)

![image](https://github.com/frappe/erpnext/assets/1973598/f3ffd02d-d9ec-4235-afc4-8cf17ba5c39a)

![image](https://github.com/frappe/erpnext/assets/1973598/4d309caf-859a-4833-83f8-7129a81fdb47)


