### PR TITLE
fix: allow tax rule to be renamed

### DIFF
--- a/erpnext/accounts/doctype/tax_rule/tax_rule.json
+++ b/erpnext/accounts/doctype/tax_rule/tax_rule.json
@@ -1,6 +1,7 @@
 {
  "actions": [],
  "allow_import": 1,
+ "allow_rename": 1,
  "autoname": "ACC-TAX-RULE-.YYYY.-.#####",
  "creation": "2015-08-07 02:33:52.670866",
  "doctype": "DocType",
@@ -225,7 +226,7 @@
   }
  ],
  "links": [],
- "modified": "2021-06-04 23:14:27.186879",
+ "modified": "2024-03-09 08:08:27.186879",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Tax Rule",


### PR DESCRIPTION
Tax Rule isn't linked to any documents in the base system. As far as I know, the name of the tax rule has no effect on anything.

Allowing it to be renamed can help organize tax rules so they don't have to be deleted and re-created with a new name.  

Backport:
- version-15
- version-14