### PR TITLE
fix: submit JVs synchronously if in background job

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -158,14 +158,14 @@ class JournalEntry(AccountsController):
 		validate_docs_for_deferred_accounting([self.name], [])
 
 	def submit(self):
-		if len(self.accounts) > 100:
+		if len(self.accounts) > 100 and not frappe.job:
 			msgprint(_("The task has been enqueued as a background job."), alert=True)
 			self.queue_action("submit", timeout=4600)
 		else:
 			return self._submit()
 
 	def cancel(self):
-		if len(self.accounts) > 100:
+		if len(self.accounts) > 100 and not frappe.job:
 			msgprint(_("The task has been enqueued as a background job."), alert=True)
 			self.queue_action("cancel", timeout=4600)
 		else:


### PR DESCRIPTION
refer: https://github.com/frappe/frappe/pull/25318


Where JVs are submitted as side effect of some other action they shouldn't be submitted in background as the side effect can fail separately but original effect completes without any failure.
