### PR TITLE
fix: subcontracting receipt -> alllow to change Batch / Serial Nos (v14)

### DIFF
--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
@@ -74,8 +74,9 @@ class SubcontractingReceipt(SubcontractingController):
 		if (
 			frappe.db.get_single_value("Buying Settings", "backflush_raw_materials_of_subcontract_based_on")
 			== "BOM"
-		):
+		) and not self.has_serial_batch_items():
 			self.supplied_items = []
+
 		super(SubcontractingReceipt, self).validate()
 		self.set_missing_values()
 		self.validate_posting_time()
@@ -124,6 +125,14 @@ class SubcontractingReceipt(SubcontractingController):
 		self.calculate_additional_costs()
 		self.calculate_supplied_items_qty_and_amount()
 		self.calculate_items_qty_and_amount()
+
+	def has_serial_batch_items(self):
+		if not self.get("supplied_items"):
+			return False
+
+		for row in self.get("supplied_items"):
+			if row.serial_no or row.batch_no:
+				return True
 
 	def set_available_qty_for_consumption(self):
 		supplied_items_details = {}


### PR DESCRIPTION
**Issue**

No able to change the Batch manually on the subcontracting receipt in case of backflush based on BOM. After the save system auto reset the batch

![issue_allow_to_chage_batch](https://github.com/frappe/erpnext/assets/8780500/32fe40b6-be1b-40fa-b652-acc845600079)



**After Fix**

![after_fix_allow_to_chage_batch](https://github.com/frappe/erpnext/assets/8780500/7f86b2b9-747d-4967-b11a-05332c5df6da)
