### PR TITLE
fix: get address if multiple companies

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -164,7 +164,7 @@ frappe.ui.form.on("Sales Order", {
 				method: "erpnext.setup.doctype.company.company.get_default_company_address",
 				args: {
 					name: frm.doc.company,
-					existing_address: frm.doc.company_address || ""
+					existing_address: frm.doc.company_address || "",
 				},
 				debounce: 2000,
 				callback: function (r) {

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -157,6 +157,27 @@ frappe.ui.form.on("Sales Order", {
 		);
 	},
 
+	// When multiple companies are set up. in case company name is changed set default company address
+	company: function (frm) {
+		if (frm.doc.company) {
+			frappe.call({
+				method: "erpnext.setup.doctype.company.company.get_default_company_address",
+				args: {
+					name: frm.doc.company,
+					existing_address: frm.doc.company_address || ""
+				},
+				debounce: 2000,
+				callback: function (r) {
+					if (r.message) {
+						frm.set_value("company_address", r.message);
+					} else {
+						frm.set_value("company_address", "");
+					}
+				},
+			});
+		}
+	},
+
 	onload: function (frm) {
 		if (!frm.doc.transaction_date) {
 			frm.set_value("transaction_date", frappe.datetime.get_today());


### PR DESCRIPTION
Version 14 and 15,

fixes: #34837

- Sales Invoice has a code that the Sales Order doesn't.

**Before:**
- When there are multiple companies, the company address loads correctly initially. However, if you change the company, the address doesn't update. 

**After:**
- So, we added code that sets the default address for the company when the user changes it. This ensures that the correct company address is displayed.

Thank You!