### PR TITLE
fix: GL Entries for Asset value adjustment

### DIFF
--- a/erpnext/assets/doctype/asset_value_adjustment/asset_value_adjustment.js
+++ b/erpnext/assets/doctype/asset_value_adjustment/asset_value_adjustment.js
@@ -22,6 +22,22 @@ frappe.ui.form.on("Asset Value Adjustment", {
 				},
 			};
 		});
+		frm.set_query('revaluation_surplus_account', function() {
+			return {
+				filters: {
+					company: frm.doc.company,
+					is_group: 0
+				}
+			}
+		});
+		frm.set_query('impairment_loss_account', function() {
+			return {
+				filters: {
+					company: frm.doc.company,
+					is_group: 0
+				}
+			}
+		});
 	},
 
 	onload: function (frm) {
@@ -60,4 +76,9 @@ frappe.ui.form.on("Asset Value Adjustment", {
 			});
 		}
 	},
+
+	new_asset_value: function(frm) {
+		// set difference amount
+		frm.set_value('difference_amount', flt(frm.doc.new_asset_value) - flt(frm.doc.current_asset_value));
+	}
 });

--- a/erpnext/assets/doctype/asset_value_adjustment/asset_value_adjustment.js
+++ b/erpnext/assets/doctype/asset_value_adjustment/asset_value_adjustment.js
@@ -22,21 +22,37 @@ frappe.ui.form.on("Asset Value Adjustment", {
 				},
 			};
 		});
-		frm.set_query('revaluation_surplus_account', function() {
+		frm.set_query("revaluation_surplus_account", function () {
 			return {
 				filters: {
 					company: frm.doc.company,
-					is_group: 0
-				}
-			}
+					is_group: 0,
+				},
+			};
 		});
-		frm.set_query('impairment_loss_account', function() {
+		frm.set_query("impairment_loss_account", function () {
 			return {
 				filters: {
 					company: frm.doc.company,
-					is_group: 0
-				}
-			}
+					is_group: 0,
+				},
+			};
+		});
+		frm.set_query("revaluation_surplus_account", function () {
+			return {
+				filters: {
+					company: frm.doc.company,
+					is_group: 0,
+				},
+			};
+		});
+		frm.set_query("impairment_loss_account", function () {
+			return {
+				filters: {
+					company: frm.doc.company,
+					is_group: 0,
+				},
+			};
 		});
 	},
 
@@ -77,8 +93,8 @@ frappe.ui.form.on("Asset Value Adjustment", {
 		}
 	},
 
-	new_asset_value: function(frm) {
+	new_asset_value: function (frm) {
 		// set difference amount
-		frm.set_value('difference_amount', flt(frm.doc.new_asset_value) - flt(frm.doc.current_asset_value));
-	}
+		frm.set_value("difference_amount", flt(frm.doc.new_asset_value) - flt(frm.doc.current_asset_value));
+	},
 });

--- a/erpnext/assets/doctype/asset_value_adjustment/asset_value_adjustment.json
+++ b/erpnext/assets/doctype/asset_value_adjustment/asset_value_adjustment.json
@@ -5,11 +5,11 @@
  "editable_grid": 1,
  "engine": "InnoDB",
  "field_order": [
-  "company",
   "asset",
   "asset_category",
   "column_break_4",
   "date",
+  "company",
   "finance_book",
   "amended_from",
   "value_details_section",
@@ -19,8 +19,10 @@
   "difference_amount",
   "journal_entry",
   "accounting_dimensions_section",
-  "cost_center",
-  "dimension_col_break"
+  "revaluation_surplus_account",
+  "impairment_loss_account",
+  "dimension_col_break",
+  "cost_center"
  ],
  "fields": [
   {
@@ -34,7 +36,8 @@
    "fieldtype": "Link",
    "label": "Asset",
    "options": "Asset",
-   "reqd": 1
+   "reqd": 1,
+   "search_index": 1
   },
   {
    "fetch_from": "asset.asset_category",
@@ -61,6 +64,7 @@
    "fieldtype": "Column Break"
   },
   {
+   "default": "Today",
    "fieldname": "date",
    "fieldtype": "Date",
    "label": "Date",
@@ -106,7 +110,7 @@
   {
    "fieldname": "accounting_dimensions_section",
    "fieldtype": "Section Break",
-   "label": "Accounting Dimensions"
+   "label": "Accounting"
   },
   {
    "fieldname": "dimension_col_break",
@@ -115,17 +119,33 @@
   {
    "fieldname": "value_details_section",
    "fieldtype": "Section Break",
-   "label": "Value Details"
+   "label": "Asset Value"
   },
   {
    "fieldname": "column_break_11",
    "fieldtype": "Column Break"
+  },
+  {
+   "depends_on": "eval:doc.difference_amount > 0",
+   "fieldname": "revaluation_surplus_account",
+   "fieldtype": "Link",
+   "label": "Revaluation Surplus Account",
+   "mandatory_depends_on": "eval:doc.difference_amount > 0",
+   "options": "Account"
+  },
+  {
+   "depends_on": "eval:doc.difference_amount < 0",
+   "fieldname": "impairment_loss_account",
+   "fieldtype": "Link",
+   "label": "Impairment Loss Account",
+   "mandatory_depends_on": "eval:doc.difference_amount < 0",
+   "options": "Account"
   }
  ],
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2021-01-22 14:10:23.085181",
+ "modified": "2024-02-05 16:14:20.377151",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset Value Adjustment",
@@ -177,9 +197,9 @@
    "write": 1
   }
  ],
- "quick_entry": 1,
  "sort_field": "modified",
  "sort_order": "DESC",
+ "states": [],
  "title_field": "asset",
  "track_changes": 1
 }

--- a/erpnext/assets/doctype/asset_value_adjustment/asset_value_adjustment.py
+++ b/erpnext/assets/doctype/asset_value_adjustment/asset_value_adjustment.py
@@ -36,8 +36,10 @@ class AssetValueAdjustment(Document):
 		date: DF.Date
 		difference_amount: DF.Currency
 		finance_book: DF.Link | None
+		impairment_loss_account: DF.Link | None
 		journal_entry: DF.Link | None
 		new_asset_value: DF.Currency
+		revaluation_surplus_account: DF.Link | None
 	# end: auto-generated types
 
 	def validate(self):
@@ -46,7 +48,7 @@ class AssetValueAdjustment(Document):
 		self.set_difference_amount()
 
 	def on_submit(self):
-		self.make_depreciation_entry()
+		self.make_gl_entries()
 		self.update_asset(self.new_asset_value)
 		add_asset_activity(
 			self.asset,
@@ -75,19 +77,18 @@ class AssetValueAdjustment(Document):
 			)
 
 	def set_difference_amount(self):
-		self.difference_amount = flt(self.current_asset_value - self.new_asset_value)
+		self.difference_amount = flt(self.new_asset_value - self.current_asset_value)
 
 	def set_current_asset_value(self):
 		if not self.current_asset_value and self.asset:
 			self.current_asset_value = get_asset_value_after_depreciation(self.asset, self.finance_book)
 
-	def make_depreciation_entry(self):
+	def make_gl_entries(self):
 		asset = frappe.get_doc("Asset", self.asset)
-		(
-			_,
-			accumulated_depreciation_account,
-			depreciation_expense_account,
-		) = get_depreciation_accounts(asset.asset_category, asset.company)
+
+		debit_account, credit_account = self.get_debit_and_credit_accounts(
+			asset.asset_category, asset.company
+		)
 
 		depreciation_cost_center, depreciation_series = frappe.get_cached_value(
 			"Company", asset.company, ["depreciation_cost_center", "series_for_depreciation_entry"]
@@ -98,25 +99,52 @@ class AssetValueAdjustment(Document):
 		je.naming_series = depreciation_series
 		je.posting_date = self.date
 		je.company = self.company
-		je.remark = "Depreciation Entry against {0} worth {1}".format(self.asset, self.difference_amount)
+		je.remark = "Accounting Entry against {0} worth {1}".format(self.asset, self.difference_amount)
 		je.finance_book = self.finance_book
 
-		credit_entry = {
-			"account": accumulated_depreciation_account,
-			"credit_in_account_currency": self.difference_amount,
-			"cost_center": depreciation_cost_center or self.cost_center,
-			"reference_type": "Asset",
-			"reference_name": self.asset,
-		}
-
 		debit_entry = {
-			"account": depreciation_expense_account,
-			"debit_in_account_currency": self.difference_amount,
+			"account": debit_account,
+			"debit_in_account_currency": abs(self.difference_amount),
 			"cost_center": depreciation_cost_center or self.cost_center,
 			"reference_type": "Asset",
 			"reference_name": self.asset,
 		}
 
+		credit_entry = {
+			"account": credit_account,
+			"credit_in_account_currency": abs(self.difference_amount),
+			"cost_center": depreciation_cost_center or self.cost_center,
+			"reference_type": "Asset",
+			"reference_name": self.asset,
+		}
+
+		self.update_accounting_dimensions(debit_entry, credit_entry)
+
+		je.append("accounts", credit_entry)
+		je.append("accounts", debit_entry)
+
+		je.flags.ignore_permissions = True
+		je.submit()
+
+		self.db_set("journal_entry", je.name)
+
+	def get_debit_and_credit_accounts(self, asset_category, company):
+		(
+			fixed_asset_account,
+			accumulated_depreciation_account,
+			_,
+		) = get_depreciation_accounts(asset_category, company)
+
+		if self.difference_amount > 0:
+			debit_account = fixed_asset_account
+			credit_account = self.revaluation_surplus_account
+		else:
+			debit_account = self.impairment_loss_account
+			credit_account = accumulated_depreciation_account
+
+		return debit_account, credit_account
+
+	def update_accounting_dimensions(self, debit_entry, credit_entry):
 		accounting_dimensions = get_checks_for_pl_and_bs_accounts()
 
 		for dimension in accounting_dimensions:
@@ -135,14 +163,6 @@ class AssetValueAdjustment(Document):
 						or dimension.get("default_dimension")
 					}
 				)
-
-		je.append("accounts", credit_entry)
-		je.append("accounts", debit_entry)
-
-		je.flags.ignore_permissions = True
-		je.submit()
-
-		self.db_set("journal_entry", je.name)
 
 	def update_asset(self, asset_value):
 		asset = frappe.get_doc("Asset", self.asset)

--- a/erpnext/assets/doctype/asset_value_adjustment/asset_value_adjustment.py
+++ b/erpnext/assets/doctype/asset_value_adjustment/asset_value_adjustment.py
@@ -95,7 +95,8 @@ class AssetValueAdjustment(Document):
 		)
 
 		je = frappe.new_doc("Journal Entry")
-		je.voucher_type = "Depreciation Entry"
+		if self.difference_amount < 0:
+			je.voucher_type = "Depreciation Entry"
 		je.naming_series = depreciation_series
 		je.posting_date = self.date
 		je.company = self.company

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -362,3 +362,4 @@ erpnext.stock.doctype.delivery_note.patches.drop_unused_return_against_index # 2
 erpnext.patches.v14_0.set_maintain_stock_for_bom_item
 erpnext.patches.v15_0.delete_orphaned_asset_movement_item_records
 erpnext.patches.v15_0.remove_cancelled_asset_capitalization_from_asset
+erpnext.patches.v15_0.set_difference_amount_in_asset_value_adjustment

--- a/erpnext/patches/v15_0/set_difference_amount_in_asset_value_adjustment.py
+++ b/erpnext/patches/v15_0/set_difference_amount_in_asset_value_adjustment.py
@@ -1,0 +1,14 @@
+import frappe
+
+
+def execute():
+	frappe.db.sql(
+		"""
+		UPDATE
+			`tabAsset Value Adjustment`
+		SET
+			difference_amount = -1*difference_amount
+		WHERE
+			docstatus != 2
+	"""
+	)


### PR DESCRIPTION
### GL Entries:
**Increase Asset Value:**

> Let suppose, An asset is worth Rs 50,000 originally and its accumulated depreciation till date is Rs 10,000. So, the Carrying value of the asset is Rs 40,000. it means the balances right now are as follows in the balance sheet -
> 
> Asset Ac - Debit Rs 50,000
> Accumulated Depreciation - Credit Rs 10,000
> 
> Now if revaluation happens and the Asset value is determined at Rs 60,000, then the following entry should be passed at the time of the revaluation.
> Asset Ac - Debit Rs 20,000 ( Revalued Amt minus Carrying Amount) (60,000-40,000)
> Revaluation Surplus Ac - Credit Rs 20,000

**Decrease Asset Value:**

> Let suppose, An asset is worth Rs 50,000 originally and its accumulated depreciation till date is Rs 10,000. So, the Carrying value of the asset is Rs 40,000. it means the balances right now are as follows in the balance sheet -
> Asset Ac - Debit Rs 50,000
> Accumulated Depreciation - Credit Rs 10,000
> Now if revaluation happens and the Asset value is determined at Rs 30,000, then the following entry should be passed at the time of revaluation. This is known as the Impairment of assets. The simple below entry is passed for this
> Impairment Loss Ac - Debit Rs 10,000 (Carrying amount minus revalued amount)
> Accumulated Depreciation - Credit Rs 10,000

### Depreciation
After the revaluation of an asset, the depreciation schedule should be changed based on the increased/decreased value.

closes #39560