### PR TITLE
fix: recursion issue while submitting work order

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -264,7 +264,7 @@ class JobCard(Document):
 		if not self.has_overlap(production_capacity, time_logs):
 			return {}
 
-		if self.workstation_type and time_logs:
+		if not self.workstation and self.workstation_type and time_logs:
 			if workstation_time := self.get_workstation_based_on_available_slot(time_logs):
 				self.workstation = workstation_time.get("workstation")
 				return workstation_time
@@ -420,7 +420,7 @@ class JobCard(Document):
 		if not workstation_doc.working_hours or cint(
 			frappe.db.get_single_value("Manufacturing Settings", "allow_overtime")
 		):
-			if get_datetime(row.planned_end_time) < get_datetime(row.planned_start_time):
+			if get_datetime(row.planned_end_time) <= get_datetime(row.planned_start_time):
 				row.planned_end_time = add_to_date(row.planned_start_time, minutes=row.time_in_mins)
 				row.remaining_time_in_mins = 0.0
 			else:


### PR DESCRIPTION
While submitting the work order having operations with workstations without working hours getting the recursion error

