### PR TITLE
fix: incorrect work order status

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -330,6 +330,13 @@ class WorkOrder(Document):
 		else:
 			status = "Cancelled"
 
+		if (
+			self.skip_transfer
+			and self.produced_qty
+			and self.qty > (flt(self.produced_qty) + flt(self.process_loss_qty))
+		):
+			status = "In Process"
+
 		return status
 
 	def update_work_order_qty(self):


### PR DESCRIPTION
1. Make a work order with Skip Transfer for 10 qty
2. Complete 6 qty and check the status of the work order
3. Work order status will be "Not Started", ideally it should be "In Process"