### PR TITLE
Feat:  New payment term 'Month(s) after invoice date' added

### DIFF
--- a/erpnext/accounts/doctype/payment_term/payment_term.json
+++ b/erpnext/accounts/doctype/payment_term/payment_term.json
@@ -53,7 +53,7 @@
    "fieldname": "due_date_based_on",
    "fieldtype": "Select",
    "label": "Due Date Based On",
-   "options": "Day(s) after invoice date\nDay(s) after the end of the invoice month\nMonth(s) after the end of the invoice month"
+   "options": "Day(s) after invoice date\nDay(s) after the end of the invoice month\nMonth(s) after the end of the invoice month\nMonth(s) after invoice date"
   },
   {
    "bold": 1,
@@ -63,7 +63,7 @@
    "label": "Credit Days"
   },
   {
-   "depends_on": "eval:doc.due_date_based_on=='Month(s) after the end of the invoice month'",
+   "depends_on": "eval:in_list(['Month(s) after invoice date', 'Month(s) after the end of the invoice month'], doc.due_date_based_on)",
    "fieldname": "credit_months",
    "fieldtype": "Int",
    "label": "Credit Months"
@@ -101,7 +101,7 @@
    "fieldname": "discount_validity_based_on",
    "fieldtype": "Select",
    "label": "Discount Validity Based On",
-   "options": "Day(s) after invoice date\nDay(s) after the end of the invoice month\nMonth(s) after the end of the invoice month"
+   "options": "Day(s) after invoice date\nDay(s) after the end of the invoice month\nMonth(s) after the end of the invoice month\nMonth(s) after invoice date"
   },
   {
    "depends_on": "discount",

--- a/erpnext/accounts/doctype/payment_term/payment_term.py
+++ b/erpnext/accounts/doctype/payment_term/payment_term.py
@@ -24,11 +24,13 @@ class PaymentTerm(Document):
 			"Day(s) after invoice date",
 			"Day(s) after the end of the invoice month",
 			"Month(s) after the end of the invoice month",
+			"Month(s) after invoice date",
 		]
 		due_date_based_on: DF.Literal[
 			"Day(s) after invoice date",
 			"Day(s) after the end of the invoice month",
 			"Month(s) after the end of the invoice month",
+			"Month(s) after invoice date",
 		]
 		invoice_portion: DF.Float
 		mode_of_payment: DF.Link | None

--- a/erpnext/accounts/doctype/payment_terms_template_detail/payment_terms_template_detail.json
+++ b/erpnext/accounts/doctype/payment_terms_template_detail/payment_terms_template_detail.json
@@ -57,7 +57,7 @@
    "fieldtype": "Select",
    "in_list_view": 1,
    "label": "Due Date Based On",
-   "options": "Day(s) after invoice date\nDay(s) after the end of the invoice month\nMonth(s) after the end of the invoice month",
+   "options": "Day(s) after invoice date\nDay(s) after the end of the invoice month\nMonth(s) after the end of the invoice month\nMonth(s) after invoice date",
    "reqd": 1
   },
   {
@@ -74,7 +74,7 @@
   },
   {
    "default": "0",
-   "depends_on": "eval:doc.due_date_based_on=='Month(s) after the end of the invoice month'",
+   "depends_on": "eval:in_list(['Month(s) after invoice date', 'Month(s) after the end of the invoice month'], doc.due_date_based_on)",
    "fetch_from": "payment_term.credit_months",
    "fetch_if_empty": 1,
    "fieldname": "credit_months",
@@ -126,7 +126,7 @@
    "fieldname": "discount_validity_based_on",
    "fieldtype": "Select",
    "label": "Discount Validity Based On",
-   "options": "Day(s) after invoice date\nDay(s) after the end of the invoice month\nMonth(s) after the end of the invoice month"
+   "options": "Day(s) after invoice date\nDay(s) after the end of the invoice month\nMonth(s) after the end of the invoice month\nMonth(s) after invoice date"
   },
   {
    "collapsible": 1,

--- a/erpnext/accounts/doctype/payment_terms_template_detail/payment_terms_template_detail.py
+++ b/erpnext/accounts/doctype/payment_terms_template_detail/payment_terms_template_detail.py
@@ -24,11 +24,13 @@ class PaymentTermsTemplateDetail(Document):
 			"Day(s) after invoice date",
 			"Day(s) after the end of the invoice month",
 			"Month(s) after the end of the invoice month",
+			"Month(s) after invoice date",
 		]
 		due_date_based_on: DF.Literal[
 			"Day(s) after invoice date",
 			"Day(s) after the end of the invoice month",
 			"Month(s) after the end of the invoice month",
+			"Month(s) after invoice date",
 		]
 		invoice_portion: DF.Float
 		mode_of_payment: DF.Link | None

--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -630,6 +630,8 @@ def get_due_date_from_template(template_name, posting_date, bill_date):
 			due_date = max(due_date, add_days(due_date, term.credit_days))
 		elif term.due_date_based_on == "Day(s) after the end of the invoice month":
 			due_date = max(due_date, add_days(get_last_day(due_date), term.credit_days))
+		elif term.due_date_based_on == "Month(s) after invoice date":
+			due_date = max(due_date, add_months(due_date, term.credit_months))
 		else:
 			due_date = max(due_date, get_last_day(add_months(due_date, term.credit_months)))
 	return due_date

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2973,6 +2973,9 @@ def get_due_date(term, posting_date=None, bill_date=None):
 		due_date = add_days(get_last_day(date), term.credit_days)
 	elif term.due_date_based_on == "Month(s) after the end of the invoice month":
 		due_date = get_last_day(add_months(date, term.credit_months))
+	elif term.due_date_based_on == "Month(s) after invoice date":
+		due_date = add_months(date, term.credit_months)
+		
 	return due_date
 
 
@@ -2985,6 +2988,9 @@ def get_discount_date(term, posting_date=None, bill_date=None):
 		discount_validity = add_days(get_last_day(date), term.discount_validity)
 	elif term.discount_validity_based_on == "Month(s) after the end of the invoice month":
 		discount_validity = get_last_day(add_months(date, term.discount_validity))
+	elif term.due_date_based_on == "Month(s) after invoice date":
+		discount_validity = add_months(date, term.discount_validity)
+	
 	return discount_validity
 
 

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -2974,8 +2974,7 @@ def get_due_date(term, posting_date=None, bill_date=None):
 	elif term.due_date_based_on == "Month(s) after the end of the invoice month":
 		due_date = get_last_day(add_months(date, term.credit_months))
 	elif term.due_date_based_on == "Month(s) after invoice date":
-		due_date = add_months(date, term.credit_months)
-		
+		due_date = add_months(date, term.credit_months)	
 	return due_date
 
 
@@ -2990,7 +2989,6 @@ def get_discount_date(term, posting_date=None, bill_date=None):
 		discount_validity = get_last_day(add_months(date, term.discount_validity))
 	elif term.due_date_based_on == "Month(s) after invoice date":
 		discount_validity = add_months(date, term.discount_validity)
-	
 	return discount_validity
 
 


### PR DESCRIPTION
This solution is based on the feature request #40077 
There were only three options for payment terms before:
1.  Day(s) after invoice date
2.  Day(s) after the end of the invoice month
3.  Month(s) after the end of the invoice month

Added this option:
Month(s) after invoice date