### PR TITLE
feat: accept apply write off amount on Point of sale and use this to send to sales invoice

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
@@ -174,6 +174,7 @@ class POSInvoiceMergeLog(Document):
 
 		rounding_adjustment, base_rounding_adjustment = 0, 0
 		rounded_total, base_rounded_total = 0, 0
+		base_write_off_amount, write_off_amount = 0, 0
 
 		loyalty_amount_sum, loyalty_points_sum, idx = 0, 0, 1
 
@@ -247,8 +248,10 @@ class POSInvoiceMergeLog(Document):
 
 			rounding_adjustment += doc.rounding_adjustment
 			rounded_total += doc.rounded_total
+			write_off_amount += doc.write_off_amount
 			base_rounding_adjustment += doc.base_rounding_adjustment
 			base_rounded_total += doc.base_rounded_total
+			base_write_off_amount += doc.base_write_off_amount
 
 		if loyalty_points_sum:
 			invoice.redeem_loyalty_points = 1
@@ -262,6 +265,8 @@ class POSInvoiceMergeLog(Document):
 		invoice.set("base_rounding_adjustment", base_rounding_adjustment)
 		invoice.set("rounded_total", rounded_total)
 		invoice.set("base_rounded_total", base_rounded_total)
+		invoice.set("write_off_amount", write_off_amount)
+		invoice.set("base_write_off_amount", base_write_off_amount)
 		invoice.additional_discount_percentage = 0
 		invoice.discount_amount = 0.0
 		invoice.taxes_and_charges = None

--- a/erpnext/selling/page/point_of_sale/pos_payment.js
+++ b/erpnext/selling/page/point_of_sale/pos_payment.js
@@ -586,6 +586,9 @@ erpnext.PointOfSale.Payment = class {
 		const currency = doc.currency;
 		const label = change ? __("Change") : __("To Be Paid");
 
+		doc.write_off_amount = 0;
+		doc.base_write_off_amount = 0;
+
 		this.$totals.html(
 			`<div class="col">
 				<div class="total-label">${__("Grand Total")}</div>
@@ -599,9 +602,50 @@ erpnext.PointOfSale.Payment = class {
 			<div class="seperator-y"></div>
 			<div class="col">
 				<div class="total-label">${label}</div>
-				<div class="value">${format_currency(change || remaining, currency)}</div>
-			</div>`
+				<div class="value total_difference">${format_currency(change || remaining, currency)}</div>
+			</div>
+			<div class="seperator-y"></div>
+			<div class="col">
+				<div class="total-label">${__("Write Off")}</div>
+				<div class="value total_write_off">${format_currency(doc.write_off_amount, currency)}</div>
+			</div>
+			`
 		);
+		this.$totals.find(".total_difference").attr("contenteditable", remaining < 0 ? "true" : "false");
+		this.add_write_off_events(doc, remaining, change, currency);
+	}
+
+	add_write_off_events(doc, remaining, change, currency) {
+		let me = this;
+
+		this.$totals
+			.find(".total_difference")
+			.on("focus", function () {
+				var range = document.createRange();
+				range.selectNodeContents(this);
+				var selection = window.getSelection();
+				selection.removeAllRanges();
+				selection.addRange(range);
+			})
+			.on("focusout", function () {
+				let new_difference_value = flt($(this).text());
+				if (remaining < 0 && new_difference_value <= -1 * remaining && new_difference_value >= 0) {
+					change = new_difference_value;
+				}
+				$(this).text(format_currency(change, currency));
+				doc.write_off_amount = flt(remaining + change, precision("write_off_amount", doc));
+				doc.base_write_off_amount = flt(
+					doc.write_off_amount * doc.conversion_rate,
+					precision("base_write_off_amount", doc)
+				);
+
+				me.$totals.find(".total_write_off").text(format_currency(doc.write_off_amount, currency));
+			})
+			.on("keypress", function (e) {
+				if (e.which == 13) {
+					$(this).blur();
+				}
+			});
 	}
 
 	toggle_component(show) {


### PR DESCRIPTION
The objective is allow the POS user to inform how much change was passed to the customer, and add the difference to the write-off amount.

**pos_payment.js:**
-> A new column hes been added to totals for the write-off amount. 
-> In the total change column, if there is change value, it div becames editable, allowing the user to input the actual change value.
-> The write-off amount will be calculed based in the change column that the user edited, using the focus and focusout events.

![Animation](https://github.com/frappe/erpnext/assets/103958767/c3f409df-ca66-4dda-8755-67b1ae757992)

**pos_invoice_merge_log.py:**
-> When mergin a POS Invoice to Sales Invoice, the write_off_amount and base_write_off_amount values are added for consolidation

![Media 2](https://github.com/frappe/erpnext/assets/103958767/fda5dc90-f11f-443f-b065-dd861b9fc1df)

#no-docs