### PR TITLE
fix: Data too long for column 'stock_queue'

### DIFF
--- a/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.json
+++ b/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.json
@@ -230,7 +230,7 @@
   },
   {
    "fieldname": "stock_queue",
-   "fieldtype": "Text",
+   "fieldtype": "Long Text",
    "label": "FIFO Stock Queue (qty, rate)",
    "oldfieldname": "fcfs_stack",
    "oldfieldtype": "Text",
@@ -360,7 +360,7 @@
  "in_create": 1,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-02-07 09:18:13.999231",
+ "modified": "2024-03-13 09:56:13.021696",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Ledger Entry",

--- a/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py
+++ b/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py
@@ -58,7 +58,7 @@ class StockLedgerEntry(Document):
 		recalculate_rate: DF.Check
 		serial_and_batch_bundle: DF.Link | None
 		serial_no: DF.LongText | None
-		stock_queue: DF.Text | None
+		stock_queue: DF.LongText | None
 		stock_uom: DF.Link | None
 		stock_value: DF.Currency
 		stock_value_difference: DF.Currency


### PR DESCRIPTION
Getting below error during site migration

```
File "/home/frappe/frappe-bench/apps/frappe/frappe/database/schema.py", line 44, in sync
    self.alter()
      self = <frappe.database.mariadb.schema.MariaDBTable object at 0x7f75420c2d40>
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/mariadb/schema.py", line 113, in alter
    frappe.db.sql(query)
      self = <frappe.database.mariadb.schema.MariaDBTable object at 0x7f75420c2d40>
      col = <frappe.database.schema.DbColumn object at 0x7f75420c3af0>
      add_column_query = ['ADD COLUMN `is_adjustment_entry` int(1) not null default 0']
      modify_column_query = ['MODIFY `stock_value_difference` decimal(21,9) not null default 0', 'MODIFY `qty_after_transaction` decimal(21,9) not null default 0', 'MODIFY `stock_queue` text', 'MODIFY `incoming_rate` decimal(21,9) not null default 0', 'MODIFY `valuation_rate` decimal(21,9) not null default 0', 'MODIFY `outgoing_rate` decimal(21,9) not null default 0', 'MODIFY `actual_qty` decimal(21,9) not null default 0', 'MODIFY `stock_value` decimal(21,9) not null default 0']
      add_index_query = []
      drop_index_query = ['DROP INDEX `voucher_type`']
      columns_to_modify = {<frappe.database.schema.DbColumn object at 0x7f75420c2650>, <frappe.database.schema.DbColumn object at 0x7f75420c2c80>, <frappe.database.schema.DbColumn object at 0x7f75420c2ef0>, <frappe.database.schema.DbColumn object at 0x7f75420c2d10>, <frappe.database.schema.DbColumn object at 0x7f75420c2140>, <frappe.database.schema.DbColumn object at 0x7f75420c2560>, <frappe.database.schema.DbColumn object at 0x7f75420c23b0>, <frappe.database.schema.DbColumn object at 0x7f75420c37c0>}
      current_column = {'name': 'voucher_type', 'type': 'varchar(140)', 'default': 'NULL', 'index': 1, 'unique': 0}
      unique_constraint_changed = False
      index_constraint_changed = True
      index_record = {'Table': 'tabStock Ledger Entry', 'Non_unique': 1, 'Key_name': 'voucher_type', 'Seq_in_index': 1, 'Column_name': 'voucher_type', 'Collation': 'A', 'Cardinality': 10, 'Sub_part': None, 'Packed': None, 'Null': 'YES', 'Index_type': 'BTREE', 'Comment': '', 'Index_comment': '', 'Ignored': 'NO'}
      query_parts = ['MODIFY `stock_value_difference` decimal(21,9) not null default 0', 'MODIFY `qty_after_transaction` decimal(21,9) not null default 0', 'MODIFY `stock_queue` text', 'MODIFY `incoming_rate` decimal(21,9) not null default 0', 'MODIFY `valuation_rate` decimal(21,9) not null default 0', 'MODIFY `outgoing_rate` decimal(21,9) not null default 0', 'MODIFY `actual_qty` decimal(21,9) not null default 0', 'MODIFY `stock_value` decimal(21,9) not null default 0']
      query_body = 'MODIFY `stock_value_difference` decimal(21,9) not null default 0, MODIFY `qty_after_transaction` decimal(21,9) not null default 0, MODIFY `stock_queue` text, MODIFY `incoming_rate` decimal(21,9) not null default 0, MODIFY `valuation_rate` decimal(21,9) not null default 0, MODIFY `outgoing_rate` decimal(21,9) not null default 0, MODIFY `actual_qty` decimal(21,9) not null default 0, MODIFY `stock_value` decimal(21,9) not null default 0'
      query = 'ALTER TABLE `tabStock Ledger Entry` MODIFY `stock_value_difference` decimal(21,9) not null default 0, MODIFY `qty_after_transaction` decimal(21,9) not null default 0, MODIFY `stock_queue` text, MODIFY `incoming_rate` decimal(21,9) not null default 0, MODIFY `valuation_rate` decimal(21,9) not null default 0, MODIFY `outgoing_rate` decimal(21,9) not null default 0, MODIFY `actual_qty` decimal(21,9) not null default 0, MODIFY `stock_value` decimal(21,9) not null default 0'
  File "/home/frappe/frappe-bench/apps/frappe/frappe/database/database.py", line 244, in sql
    self._cursor.execute(query, values)
      self = <frappe.database.mariadb.database.MariaDBDatabase object at 0x7f7543ddfb50>
      query = 'ALTER TABLE `tabStock Ledger Entry` MODIFY `stock_value_difference` decimal(21,9) not null default 0, MODIFY `qty_after_transaction` decimal(21,9) not null default 0, MODIFY `stock_queue` text, MODIFY `incoming_rate` decimal(21,9) not null default 0, MODIFY `valuation_rate` decimal(21,9) not null default 0, MODIFY `outgoing_rate` decimal(21,9) not null default 0, MODIFY `actual_qty` decimal(21,9) not null default 0, MODIFY `stock_value` decimal(21,9) not null default 0'
      values = None
      as_dict = 0
      as_list = 0
      formatted = 0
      debug = False
      ignore_ddl = 0
      as_utf8 = 0
      auto_commit = 0
      update = None
      explain = False
      run = True
      pluck = False
      as_iterator = False
      trace_id = None
  File "/home/frappe/frappe-bench/env/lib/python3.10/site-packages/pymysql/cursors.py", line 158, in execute
    result = self._query(query)
      self = <pymysql.cursors.Cursor object at 0x7f754325a740>
      query = 'ALTER TABLE `tabStock Ledger Entry` MODIFY `stock_value_difference` decimal(21,9) not null default 0, MODIFY `qty_after_transaction` decimal(21,9) not null default 0, MODIFY `stock_queue` text, MODIFY `incoming_rate` decimal(21,9) not null default 0, MODIFY `valuation_rate` decimal(21,9) not null default 0, MODIFY `outgoing_rate` decimal(21,9) not null default 0, MODIFY `actual_qty` decimal(21,9) not null default 0, MODIFY `stock_value` decimal(21,9) not null default 0'
      args = None
  File "/home/frappe/frappe-bench/env/lib/python3.10/site-packages/pymysql/cursors.py", line 325, in _query
    conn.query(q)
      self = <pymysql.cursors.Cursor object at 0x7f754325a740>
      q = 'ALTER TABLE `tabStock Ledger Entry` MODIFY `stock_value_difference` decimal(21,9) not null default 0, MODIFY `qty_after_transaction` decimal(21,9) not null default 0, MODIFY `stock_queue` text, MODIFY `incoming_rate` decimal(21,9) not null default 0, MODIFY `valuation_rate` decimal(21,9) not null default 0, MODIFY `outgoing_rate` decimal(21,9) not null default 0, MODIFY `actual_qty` decimal(21,9) not null default 0, MODIFY `stock_value` decimal(21,9) not null default 0'
      conn = <pymysql.connections.Connection object at 0x7f754325a680>
  File "/home/frappe/frappe-bench/env/lib/python3.10/site-packages/pymysql/connections.py", line 549, in query
    self._affected_rows = self._read_query_result(unbuffered=unbuffered)
      self = <pymysql.connections.Connection object at 0x7f754325a680>
      sql = b'ALTER TABLE `tabStock Ledger Entry` MODIFY `stock_value_difference` decimal(21,9) not null default 0, MODIFY `qty_after_transaction` decimal(21,9) not null default 0, MODIFY `stock_queue` text, MODIFY `incoming_rate` decimal(21,9) not null default 0, MODIFY `valuation_rate` decimal(21,9) not null default 0, MODIFY `outgoing_rate` decimal(21,9) not null default 0, MODIFY `actual_qty` decimal(21,9) not null default 0, MODIFY `stock_value` decimal(21,9) not null default 0'
      unbuffered = False
  File "/home/frappe/frappe-bench/env/lib/python3.10/site-packages/pymysql/connections.py", line 779, in _read_query_result
    result.read()
      self = <pymysql.connections.Connection object at 0x7f754325a680>
      unbuffered = False
      result = <pymysql.connections.MySQLResult object at 0x7f75420c3040>
  File "/home/frappe/frappe-bench/env/lib/python3.10/site-packages/pymysql/connections.py", line 1157, in read
    first_packet = self.connection._read_packet()
      self = <pymysql.connections.MySQLResult object at 0x7f75420c3040>
  File "/home/frappe/frappe-bench/env/lib/python3.10/site-packages/pymysql/connections.py", line 729, in _read_packet
    packet.raise_for_error()
      self = <pymysql.connections.Connection object at 0x7f754325a680>
      packet_type = <class 'pymysql.protocol.MysqlPacket'>
      buff = bytearray(b"\xff~\x05#22001Data too long for column \'stock_queue\' at row 363195")
      packet_header = b'=\x00\x00\x01'
      btrl = 61
      btrh = 0
      packet_number = 1
      bytes_to_read = 61
      recv_data = b"\xff~\x05#22001Data too long for column 'stock_queue' at row 363195"
      packet = <pymysql.protocol.MysqlPacket object at 0x7f75420c26b0>
  File "/home/frappe/frappe-bench/env/lib/python3.10/site-packages/pymysql/protocol.py", line 221, in raise_for_error
    err.raise_mysql_exception(self._data)
      self = <pymysql.protocol.MysqlPacket object at 0x7f75420c26b0>
      errno = 1406
  File "/home/frappe/frappe-bench/env/lib/python3.10/site-packages/pymysql/err.py", line 143, in raise_mysql_exception
    raise errorclass(errno, errval)
      data = b"\xff~\x05#22001Data too long for column 'stock_queue' at row 363195"
      errno = 1406
      errval = "Data too long for column 'stock_queue' at row 363195"
      errorclass = <class 'pymysql.err.DataError'>
pymysql.err.DataError: (1406, "Data too long for column 'stock_queue' at row 363195")
```