### PR TITLE
fix(portal): Call set_default_role on validate instead of on_update

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -320,10 +320,12 @@ doc_events = {
 	},
 	"User": {
 		"after_insert": "frappe.contacts.doctype.contact.contact.update_contact",
-		"validate": "erpnext.setup.doctype.employee.employee.validate_employee_role",
+		"validate": [
+			"erpnext.setup.doctype.employee.employee.validate_employee_role",
+			"erpnext.portal.utils.set_default_role",
+		],
 		"on_update": [
 			"erpnext.setup.doctype.employee.employee.update_user_permissions",
-			"erpnext.portal.utils.set_default_role",
 		],
 	},
 	"Communication": {

--- a/erpnext/portal/utils.py
+++ b/erpnext/portal/utils.py
@@ -14,9 +14,9 @@ def set_default_role(doc, method):
 		for link in contact.links:
 			frappe.flags.setting_role = True
 			if link.link_doctype == "Customer" and "Customer" not in roles:
-				doc.add_roles("Customer")
+				doc.append_roles("Customer")
 			elif link.link_doctype == "Supplier" and "Supplier" not in roles:
-				doc.add_roles("Supplier")
+				doc.append_roles("Supplier")
 
 
 def create_customer_or_supplier():


### PR DESCRIPTION
closes #36601

`user.save()` should probably not call `user.save()`, right?

When the role `Customer` or `Supplier` _fails to be added to the User_, then an **infinite loop** can occur, where `set_default_role` tries to add the role every time the User is saved, but it's saved every time it tries to add the role. Possibly, when the Customer is not in the role profile, then it's removed and thus begins the loop.

I encountered an infinite loop on a site this morning and I think this is the cause, but I did not manage to reproduce the issue. Opinions are welcome.

https://github.com/frappe/frappe/blob/e47f1d09479ea05915d3a61e51c9a2d04c566c4f/frappe/core/doctype/user/user.py#L197-L199