### PR TITLE
fix: sales partner address display Issue

### DIFF
--- a/erpnext/setup/doctype/sales_partner/sales_partner.py
+++ b/erpnext/setup/doctype/sales_partner/sales_partner.py
@@ -57,13 +57,12 @@ class SalesPartner(WebsiteGenerator):
 		address_names = frappe.db.get_all(
 			"Dynamic Link",
 			filters={"link_doctype": "Sales Partner", "link_name": self.name, "parenttype": "Address"},
-			fields=["parent"],
-			as_list=True,
+			pluck=["parent"]
 		)
 
 		addresses = []
 		for address_name in address_names:
-			address_doc = frappe.get_doc("Address", address_name[0])
+			address_doc = frappe.get_doc("Address", address_name)
 			city_state = ", ".join([item for item in [address_doc.city, address_doc.state] if item])
 			address_rows = [
 				address_doc.address_line1,

--- a/erpnext/setup/doctype/sales_partner/sales_partner.py
+++ b/erpnext/setup/doctype/sales_partner/sales_partner.py
@@ -57,7 +57,7 @@ class SalesPartner(WebsiteGenerator):
 		address_names = frappe.db.get_all(
 			"Dynamic Link",
 			filters={"link_doctype": "Sales Partner", "link_name": self.name, "parenttype": "Address"},
-			pluck=["parent"]
+			pluck=["parent"],
 		)
 
 		addresses = []

--- a/erpnext/setup/doctype/sales_partner/sales_partner.py
+++ b/erpnext/setup/doctype/sales_partner/sales_partner.py
@@ -64,7 +64,7 @@ class SalesPartner(WebsiteGenerator):
 		addresses = []
 		for address_name in address_names:
 			address_doc = frappe.get_doc("Address", address_name[0])
-			city_state = ", ".join(filter(None, [address_doc.city, address_doc.state]))
+			city_state = ", ".join([item for item in [address_doc.city, address_doc.state] if item])
 			address_rows = [
 				address_doc.address_line1,
 				address_doc.address_line2,

--- a/erpnext/setup/doctype/sales_partner/sales_partner.py
+++ b/erpnext/setup/doctype/sales_partner/sales_partner.py
@@ -54,25 +54,31 @@ class SalesPartner(WebsiteGenerator):
 			self.partner_website = "http://" + self.partner_website
 
 	def get_context(self, context):
-		address = frappe.db.get_value(
-			"Address", {"sales_partner": self.name, "is_primary_address": 1}, "*", as_dict=True
+		address_names = frappe.db.get_all(
+			"Dynamic Link",
+			filters={"link_doctype": "Sales Partner", "link_name": self.name, "parenttype": "Address"},
+			fields=["parent"],
+			as_list=True,
 		)
-		if address:
-			city_state = ", ".join(filter(None, [address.city, address.state]))
-			address_rows = [
-				address.address_line1,
-				address.address_line2,
-				city_state,
-				address.pincode,
-				address.country,
-			]
 
-			context.update(
+		addresses = []
+		for address_name in address_names:
+			address_doc = frappe.get_doc("Address", address_name[0])
+			city_state = ", ".join(filter(None, [address_doc.city, address_doc.state]))
+			address_rows = [
+				address_doc.address_line1,
+				address_doc.address_line2,
+				city_state,
+				address_doc.pincode,
+				address_doc.country,
+			]
+			addresses.append(
 				{
-					"email": address.email_id,
+					"email": address_doc.email_id,
 					"partner_address": filter_strip_join(address_rows, "\n<br>"),
-					"phone": filter_strip_join(cstr(address.phone).split(","), "\n<br>"),
+					"phone": filter_strip_join(cstr(address_doc.phone).split(","), "\n<br>"),
 				}
 			)
 
+		context["addresses"] = addresses
 		return context

--- a/erpnext/templates/generators/sales_partner.html
+++ b/erpnext/templates/generators/sales_partner.html
@@ -8,18 +8,20 @@
 <div class="partner-content" itemscope itemtype="http://schema.org/Organization">
 	<div class="row">
 		<div class="col-md-4">
-			{% if logo -%}
+			{% if logo %}
 			<img itemprop="brand" src="{{ logo }}" class="partner-logo"
 				alt="{{ partner_name }}" title="{{ partner_name }}" />
 			<br><br>
-			{%- endif %}
-			<address>
-				{% if partner_website -%}<p><a href="{{ partner_website }}"
-					target="_blank">{{ partner_website }}</a></p>{%- endif %}
-				{% if partner_address -%}<p itemprop="address">{{ partner_address }}</p>{%- endif %}
-				{% if phone -%}<p itemprop="telephone">{{ phone }}</p>{%- endif %}
-				{% if email -%}<p itemprop="email"><span class="fa fa-envelope"></span> {{ email }}</p>{%- endif %}
-			</address>
+			{% endif %}
+			{% if addresses %}
+				{% for address in addresses %}
+					<address>
+						{% if address.partner_address %}<p itemprop="address">{{ address.partner_address }}</p>{% endif %}
+						{% if address.phone %}<p itemprop="telephone">{{ address.phone }}</p>{% endif %}
+						{% if address.email %}<p itemprop="email"><span class="fa fa-envelope"></span> {{ address.email }}</p>{% endif %}
+					</address>
+				{% endfor %}
+			{% endif %}
 		</div>
 		<div class="col-md-8">
 			<p>{{ description }}</p>


### PR DESCRIPTION
In Version 15 and Version 14,

fixes: #35281

**Before:**

- When you turned on "Show In Website" for a Sales Partner and checked it with its route, there was an issue because the address didn't have a sales_partner field, causing problems.


https://github.com/frappe/erpnext/assets/141945075/4f32e692-3e4e-4682-a1bd-cec0717449b0


<br>

**After:** 

- Now, after getting the address from the Dynamic Link and checking it, it works properly. It also fetches multiple addresses if the sales partner has more than one. Additionally, the sales_partner.html field has been updated for better formatting.


https://github.com/frappe/erpnext/assets/141945075/64621c00-2761-4c4e-8d3b-33ea699aa635

<br>

Thank You!