### PR TITLE
fix: stopped mr showing in the popup

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -509,7 +509,6 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 					target: me.frm,
 					setters: {
 						schedule_date: undefined,
-						status: undefined,
 					},
 					get_query_filters: {
 						material_request_type: "Purchase",


### PR DESCRIPTION
**Issue**

Get Items From -> Material Request in the Purchase order showing stopped material requests.

<img width="921" alt="Screenshot 2024-03-15 at 4 26 40 PM" src="https://github.com/frappe/erpnext/assets/8780500/f3db65c7-da2e-4015-b96b-efd44e6ac3f7">



**After Fix**

Removed status from the filter because it have overridden the ```status: ["!=", "Stopped"]``` condition

<img width="913" alt="Screenshot 2024-03-15 at 6 12 37 PM" src="https://github.com/frappe/erpnext/assets/8780500/3673c220-0684-4cd0-9cc6-a5ced92bddc6">

