### PR TITLE
fix: AttributeError in Bank Statement Import

### DIFF
--- a/erpnext/accounts/doctype/bank_statement_import/bank_statement_import.py
+++ b/erpnext/accounts/doctype/bank_statement_import/bank_statement_import.py
@@ -149,6 +149,9 @@ def start_import(
 	import_file = ImportFile("Bank Transaction", file=file, import_type="Insert New Records")
 
 	data = parse_data_from_template(import_file.raw_data)
+	# Importer expects 'Data Import' class, which has 'payload_count' attribute
+	if not data_import.get("payload_count"):
+		data_import.payload_count = len(data) - 1
 
 	if import_file_path:
 		add_bank_account(data, bank_account)

--- a/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
+++ b/erpnext/accounts/doctype/bank_transaction/bank_transaction.py
@@ -56,17 +56,17 @@ class BankTransaction(Document):
 		Bank Transaction should be on the same currency as the Bank Account.
 		"""
 		if self.currency and self.bank_account:
-			account = frappe.get_cached_value("Bank Account", self.bank_account, "account")
-			account_currency = frappe.get_cached_value("Account", account, "account_currency")
+			if account := frappe.get_cached_value("Bank Account", self.bank_account, "account"):
+				account_currency = frappe.get_cached_value("Account", account, "account_currency")
 
-			if self.currency != account_currency:
-				frappe.throw(
-					_(
-						"Transaction currency: {0} cannot be different from Bank Account({1}) currency: {2}"
-					).format(
-						frappe.bold(self.currency), frappe.bold(self.bank_account), frappe.bold(account_currency)
+				if self.currency != account_currency:
+					frappe.throw(
+						_(
+							"Transaction currency: {0} cannot be different from Bank Account({1}) currency: {2}"
+						).format(
+							frappe.bold(self.currency), frappe.bold(self.bank_account), frappe.bold(account_currency)
+						)
 					)
-				)
 
 	def set_status(self):
 		if self.docstatus == 2:


### PR DESCRIPTION
This issue is a combination of 2 different bugs.
1. https://github.com/frappe/erpnext/pull/39336 A bug in a recently added validation on Bank Transaction currency
2. A dormant initialization bug in `Bank Statement Import`



### Scenario on which error occur
This 'AttributeError' only shows up if there were any errors during import, which now it does due to [1] above.
Now, when you retry the import, you'll get the AttributeError due to the uninitialized 'payload_count'.

### Cause

['Bank Statement Import' inherits 'Data Import'](https://github.com/frappe/erpnext/blob/2fadfd7cfcf7e018f31a97c1816550ab931f42de/erpnext/accounts/doctype/bank_statement_import/bank_statement_import.py#L22), which has 'payload_count' attribute.
But, It looks like 'Bank Statment Import' is not properly initializing 'Data Import' fields[2]. Since, the [Importer class](https://github.com/frappe/frappe/blob/develop/frappe/core/doctype/data_import/importer.py) heavly relies on the object being of class 'Data Import', any missing attributes of that class causes hard to debug issues like this.

```
Traceback with variables (most recent call last):
  File "apps/erpnext/erpnext/accounts/doctype/bank_statement_import/bank_statement_import.py", line 159, in start_import
    i.import_data()
      data_import = <BankStatementImport: Bank Statement Import on 2024-03-17 06:36:39.938968>
      bank_account = 'Feynman Acc - HDFC'
      import_file_path = '/files/Bank Transaction.csv'
      google_sheets_url = None
      bank = 'HDFC'
      template_options = '{"column_to_field_map": {"7": "name"}}'
      file = '/files/Bank Transaction.csv'
      import_file = <frappe.core.doctype.data_import.importer.ImportFile object at 0x109663af0>
      data = [['Date', 'Deposit', 'Withdrawal', 'Description', 'Reference Number', 'Bank Account', 'Currency'], ['2024-02-08', '1344', None, None, 'POS Invoice 1', 'Feynman Acc - HDFC', 'INR']]
      i = <frappe.core.doctype.data_import.importer.Importer object at 0x109663370>
  File "apps/frappe/frappe/core/doctype/data_import/importer.py", line 105, in import_data
    if self.data_import.status == "Partial Success" and len(import_log) >= self.data_import.payload_count:
      self = <frappe.core.doctype.data_import.importer.Importer object at 0x109663370>
      payloads = [{'doc': {'naming_series': 'ACC-BTN-.YYYY.-', 'date': datetime.datetime(2024, 2, 8, 0, 0), 'status': 'Pending', 'bank_account': 'Feynman Acc - HDFC', 'company': 'Lisp 2', 'amended_from': None, 'deposit': 1344.0, 'withdrawal': None, 'currency': 'INR', 'description': None, 'reference_number': 'POS Invoice 1', 'transaction_id': None, 'transaction_type': None, 'allocated_amount': None, 'unallocated_amount': None, 'party_type': None, 'party': None, 'bank_party_name': None, 'bank_party_account_number': None, 'bank_party_iban': None, '__unsaved': 1}, 'rows': [<frappe.core.doctype.data_import.importer.Row object at 0x1099ee620>]}]
      warnings = []
      import_log = [{'row_indexes': '[2]', 'success': 1, 'log_index': 0}]
      log_index = 0
builtins.AttributeError: 'BankStatementImport' object has no attribute 'payload_count'
```

