### PR TITLE
refactor: toggle between 'http' and 'https' on exchange rate API

### DIFF
--- a/erpnext/accounts/doctype/currency_exchange_settings/currency_exchange_settings.js
+++ b/erpnext/accounts/doctype/currency_exchange_settings/currency_exchange_settings.js
@@ -3,22 +3,36 @@
 
 frappe.ui.form.on("Currency Exchange Settings", {
 	service_provider: function (frm) {
-		if (frm.doc.service_provider == "exchangerate.host") {
-			let result = ["result"];
-			let params = {
-				date: "{transaction_date}",
-				from: "{from_currency}",
-				to: "{to_currency}",
-			};
-			add_param(frm, "https://api.exchangerate.host/convert", params, result);
-		} else if (frm.doc.service_provider == "frankfurter.app") {
-			let result = ["rates", "{to_currency}"];
-			let params = {
-				base: "{from_currency}",
-				symbols: "{to_currency}",
-			};
-			add_param(frm, "https://frankfurter.app/{transaction_date}", params, result);
-		}
+		frm.call({
+			method: "erpnext.accounts.doctype.currency_exchange_settings.currency_exchange_settings.get_api_endpoint",
+			args: {
+				service_provider: frm.doc.service_provider,
+				use_http: frm.doc.use_http,
+			},
+			callback: function (r) {
+				if (r && r.message) {
+					if (frm.doc.service_provider == "exchangerate.host") {
+						let result = ["result"];
+						let params = {
+							date: "{transaction_date}",
+							from: "{from_currency}",
+							to: "{to_currency}",
+						};
+						add_param(frm, r.message, params, result);
+					} else if (frm.doc.service_provider == "frankfurter.app") {
+						let result = ["rates", "{to_currency}"];
+						let params = {
+							base: "{from_currency}",
+							symbols: "{to_currency}",
+						};
+						add_param(frm, r.message, params, result);
+					}
+				}
+			},
+		});
+	},
+	use_http: function (frm) {
+		frm.trigger("service_provider");
 	},
 });
 

--- a/erpnext/accounts/doctype/currency_exchange_settings/currency_exchange_settings.json
+++ b/erpnext/accounts/doctype/currency_exchange_settings/currency_exchange_settings.json
@@ -9,6 +9,7 @@
   "disabled",
   "service_provider",
   "api_endpoint",
+  "use_http",
   "access_key",
   "url",
   "column_break_3",
@@ -91,12 +92,19 @@
    "fieldname": "access_key",
    "fieldtype": "Data",
    "label": "Access Key"
+  },
+  {
+   "default": "0",
+   "depends_on": "eval: doc.service_provider != \"Custom\"",
+   "fieldname": "use_http",
+   "fieldtype": "Check",
+   "label": "Use HTTP Protocol"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2023-10-04 15:30:25.333860",
+ "modified": "2024-03-18 08:32:26.895076",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Currency Exchange Settings",

--- a/erpnext/accounts/doctype/currency_exchange_settings/currency_exchange_settings.py
+++ b/erpnext/accounts/doctype/currency_exchange_settings/currency_exchange_settings.py
@@ -31,6 +31,7 @@ class CurrencyExchangeSettings(Document):
 		result_key: DF.Table[CurrencyExchangeSettingsResult]
 		service_provider: DF.Literal["frankfurter.app", "exchangerate.host", "Custom"]
 		url: DF.Data | None
+		use_http: DF.Check
 	# end: auto-generated types
 
 	def validate(self):
@@ -53,7 +54,7 @@ class CurrencyExchangeSettings(Document):
 			self.set("result_key", [])
 			self.set("req_params", [])
 
-			self.api_endpoint = "https://api.exchangerate.host/convert"
+			self.api_endpoint = get_api_endpoint(self.service_provider, self.use_http)
 			self.append("result_key", {"key": "result"})
 			self.append("req_params", {"key": "access_key", "value": self.access_key})
 			self.append("req_params", {"key": "amount", "value": "1"})
@@ -64,7 +65,7 @@ class CurrencyExchangeSettings(Document):
 			self.set("result_key", [])
 			self.set("req_params", [])
 
-			self.api_endpoint = "https://frankfurter.app/{transaction_date}"
+			self.api_endpoint = get_api_endpoint(self.service_provider, self.use_http)
 			self.append("result_key", {"key": "rates"})
 			self.append("result_key", {"key": "{to_currency}"})
 			self.append("req_params", {"key": "base", "value": "{from_currency}"})
@@ -103,3 +104,19 @@ class CurrencyExchangeSettings(Document):
 			frappe.throw(_("Returned exchange rate is neither integer not float."))
 
 		self.url = response.url
+
+
+@frappe.whitelist()
+def get_api_endpoint(service_provider: str = None, use_http: bool = False):
+	if service_provider and service_provider in ["exchangerate.host", "frankfurter.app"]:
+		if service_provider == "exchangerate.host":
+			api = "api.exchangerate.host/convert"
+		elif service_provider == "frankfurter.app":
+			api = "frankfurter.app/{transaction_date}"
+
+		protocol = "https://"
+		if use_http:
+			protocol = "http://"
+
+		return protocol + api
+	return None


### PR DESCRIPTION
Checkbox to toggle between `http` and `https` protocol for the pre-configured currency exchange rate providers - exchangerate.host and frankfurter.app.
<img width="1552" alt="Screenshot 2024-03-18 at 9 23 36 AM" src="https://github.com/frappe/erpnext/assets/3272205/af2571e5-564d-4d0e-9b51-a92dc5314502">


