### PR TITLE
fix: not able to delete cancelled delivery note

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -9,6 +9,8 @@ frappe.ui.form.on("Work Order", {
 			"Job Card": "Create Job Card",
 		};
 
+		frm.ignore_doctypes_on_cancel_all = ["Serial and Batch Bundle"];
+
 		// Set query for warehouses
 		frm.set_query("wip_warehouse", function () {
 			return {

--- a/erpnext/stock/doctype/delivery_note/test_delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/test_delivery_note.py
@@ -1108,9 +1108,30 @@ class TestDeliveryNote(FrappeTestCase):
 		dn.load_from_db()
 
 		batch_no = get_batch_from_bundle(dn.packed_items[0].serial_and_batch_bundle)
+		packed_name = dn.packed_items[0].name
 		self.assertTrue(batch_no)
 
+		dn.cancel()
+
+		# Cancel the reposting entry
+		reposting_entries = frappe.get_all("Repost Item Valuation", filters={"docstatus": 1})
+		for entry in reposting_entries:
+			doc = frappe.get_doc("Repost Item Valuation", entry.name)
+			doc.cancel()
+			doc.delete()
+
+		frappe.db.set_single_value("Accounts Settings", "delete_linked_ledger_entries", 1)
+
+		dn.reload()
+		dn.delete()
+
+		bundle = frappe.db.get_value(
+			"Serial and Batch Bundle", {"voucher_detail_no": packed_name}, "name"
+		)
+		self.assertFalse(bundle)
+
 		frappe.db.set_single_value("Stock Settings", "use_serial_batch_fields", 1)
+		frappe.db.set_single_value("Accounts Settings", "delete_linked_ledger_entries", 0)
 
 	def test_payment_terms_are_fetched_when_creating_sales_invoice(self):
 		from erpnext.accounts.doctype.payment_entry.test_payment_entry import (

--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -184,7 +184,11 @@ class PickList(Document):
 
 	def delink_serial_and_batch_bundle(self):
 		for row in self.locations:
-			if row.serial_and_batch_bundle:
+			if (
+				row.serial_and_batch_bundle
+				and frappe.db.get_value("Serial and Batch Bundle", row.serial_and_batch_bundle, "docstatus")
+				== 1
+			):
 				frappe.db.set_value(
 					"Serial and Batch Bundle",
 					row.serial_and_batch_bundle,

--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -778,6 +778,10 @@ class SerialandBatchBundle(Document):
 			or_filters=or_filters,
 		)
 
+		if not vouchers and self.voucher_type == "Delivery Note":
+			frappe.db.set_value("Packed Item", self.voucher_detail_no, "serial_and_batch_bundle", None)
+			return
+
 		for voucher in vouchers:
 			if voucher.get("current_serial_and_batch_bundle"):
 				frappe.db.set_value(self.child_table, voucher.name, "current_serial_and_batch_bundle", None)


### PR DESCRIPTION
Users are not able to delete delivery notes having Product Bundle with Serial and Batch materials.

<img width="914" alt="Screenshot 2024-03-18 at 12 57 50 PM" src="https://github.com/frappe/erpnext/assets/8780500/5bb55e33-b805-4493-9239-cdf36cc57396">
