### PR TITLE
fix: invalid exchange loss booking on invoice against base accounts

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -489,7 +489,9 @@ class PaymentEntry(AccountsController):
 				ref_details = get_reference_details(
 					d.reference_doctype, d.reference_name, self.party_account_currency
 				)
-				if ref_exchange_rate:
+
+				# Only update exchange rate when the reference is Journal Entry
+				if ref_exchange_rate and d.reference_doctype == "Journal Entry":
 					ref_details.update({"exchange_rate": ref_exchange_rate})
 
 				for field, value in ref_details.items():

--- a/erpnext/accounts/doctype/payment_reconciliation/test_payment_reconciliation.py
+++ b/erpnext/accounts/doctype/payment_reconciliation/test_payment_reconciliation.py
@@ -1130,6 +1130,17 @@ class TestPaymentReconciliation(FrappeTestCase):
 		self.assertEqual(pr.allocation[0].allocated_amount, 85)
 		self.assertEqual(pr.allocation[0].difference_amount, 0)
 
+		pr.reconcile()
+		si.reload()
+		self.assertEqual(si.outstanding_amount, 0)
+		# No Exchange Gain/Loss journal should be generated
+		exc_gain_loss_journals = frappe.db.get_all(
+			"Journal Entry Account",
+			filters={"reference_type": si.doctype, "reference_name": si.name, "docstatus": 1},
+			fields=["parent"],
+		)
+		self.assertEqual(exc_gain_loss_journals, [])
+
 	def test_reconciliation_purchase_invoice_against_return(self):
 		self.supplier = "_Test Supplier USD"
 		pi = self.create_purchase_invoice(qty=5, rate=50, do_not_submit=True)


### PR DESCRIPTION
Fix issue where Exchange Gain/Loss was incorrect calculated while reconciling Invoices that post to company currency receivable account.

regression: https://github.com/frappe/erpnext/pull/40149

todo:
- [x] test case