### PR TITLE
fix: variable assignment error in make_provisional_gl_entry

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -991,12 +991,12 @@ class PurchaseInvoice(BuyingController):
 
 	def make_provisional_gl_entry(self, gl_entries, item):
 		if item.purchase_receipt:
-			if not self.provisional_enpenses_booked_in_pr:
-				pr_item = self.provisional_accounts.get(item.pr_detail, {})
-				provisional_account = pr_item.get("provisional_account")
-				pr_qty = pr_item.get("qty")
-				pr_base_rate = pr_item.get("base_rate")
+			pr_item = self.provisional_accounts.get(item.pr_detail, {})
+			provisional_account = pr_item.get("provisional_account")
+			pr_qty = pr_item.get("qty")
+			pr_base_rate = pr_item.get("base_rate")
 
+			if not self.provisional_enpenses_booked_in_pr:
 				# Post reverse entry for Stock-Received-But-Not-Billed if it is booked in Purchase Receipt
 				provision_gle_against_pr = frappe.db.get_value(
 					"GL Entry",


### PR DESCRIPTION
Error traceback
```
File "apps/frappe/frappe/model/document.py", line 1002, in submit
    return self._submit()
  File "apps/frappe/frappe/model/document.py", line 983, in _submit
    return self.save()
  File "apps/frappe/frappe/model/document.py", line 305, in save
    return self._save(*args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 357, in _save
    self.run_post_save_methods()
  File "apps/frappe/frappe/model/document.py", line 1085, in run_post_save_methods
    self.run_method("on_submit")
  File "apps/frappe/frappe/model/document.py", line 915, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1267, in composer
    return composed(self, method, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1249, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "apps/frappe/frappe/model/document.py", line 912, in fn
    return method_object(*args, **kwargs)
  File "apps/erpnext/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py", line 549, in on_submit
    self.make_gl_entries()
  File "apps/erpnext/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py", line 581, in make_gl_entries
    gl_entries = self.get_gl_entries()
  File "apps/erpnext/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py", line 641, in get_gl_entries
    self.make_item_gl_entries(gl_entries)
  File "apps/erpnext/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py", line 879, in make_item_gl_entries
    self.make_provisional_gl_entry(gl_entries, item)
  File "apps/erpnext/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py", line 1023, in make_provisional_gl_entry
    provisional_account,
UnboundLocalError: local variable 'provisional_account' referenced before assignment
```

After https://github.com/frappe/erpnext/pull/40263