### PR TITLE
fix: pass empty string email content of pos invoice

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_past_order_summary.js
+++ b/erpnext/selling/page/point_of_sale/pos_past_order_summary.js
@@ -259,6 +259,7 @@ erpnext.PointOfSale.PastOrderSummary = class {
 				subject: __(frm.meta.name) + ": " + doc.name,
 				doctype: doc.doctype,
 				name: doc.name,
+				content: "",
 				send_email: 1,
 				print_format,
 				sender_full_name: frappe.user.full_name(),


### PR DESCRIPTION
When complete order in point of sale (Order Summary). When we send invoice email frappe send this error:

TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'

Traceback (most recent call last):
  File "apps/frappe/frappe/app.py", line 95, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 54, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 47, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 85, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1622, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/core/doctype/communication/email.py", line 79, in make
    return _make(
  File "apps/frappe/frappe/core/doctype/communication/email.py", line 173, in _make
    comm.send_email(
  File "apps/frappe/frappe/core/doctype/communication/mixins.py", line 305, in send_email
    if input_dict := self.sendmail_input_dict(
  File "apps/frappe/frappe/core/doctype/communication/mixins.py", line 284, in sendmail_input_dict
    "content": self.get_content(print_format=print_format),
  File "apps/frappe/frappe/core/doctype/communication/mixins.py", line 142, in get_content
    return self.content + self.get_attach_link(print_format)
TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'

### Request Data
{
	"type": "POST",
	"args": {
		"recipients": "mmdanny89@gmail.com",
		"subject": "POS Invoice: ACC-PSINV-2024-00035",
		"doctype": "POS Invoice",
		"name": "ACC-PSINV-2024-00035",
		"send_email": 1,
		"print_format": "Invoice Print POS",
		"sender_full_name": "Danny Molina",
		"_lang": "es"
	},
	"headers": {},
	"error_handlers": {},
	"url": "/api/method/frappe.core.doctype.communication.email.make"
}

**In view  i added empty content for this email.make call** this slove the error