### PR TITLE
fix: stock reco negative batch

### DIFF
--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -828,6 +828,13 @@ class SerialandBatchBundle(Document):
 		if not self.has_batch_no:
 			return
 
+		if (
+			self.voucher_type == "Stock Reconciliation"
+			and self.type_of_transaction == "Outward"
+			and frappe.db.get_value("Stock Reconciliation Item", self.voucher_detail_no, "qty") > 0
+		):
+			return
+
 		batches = [d.batch_no for d in self.entries if d.batch_no]
 		if not batches:
 			return

--- a/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
+++ b/erpnext/stock/doctype/stock_reconciliation/stock_reconciliation.py
@@ -154,7 +154,6 @@ class StockReconciliation(StockController):
 					{
 						"current_serial_and_batch_bundle": sn_doc.name,
 						"current_serial_no": "",
-						"batch_no": "",
 					}
 				)
 


### PR DESCRIPTION
While making backdated stock reconciliation for the batched item, user was getting the Negative Batch error.