### PR TITLE
fix: flaky ecommerce test case

### DIFF
--- a/erpnext/e_commerce/doctype/item_review/test_item_review.py
+++ b/erpnext/e_commerce/doctype/item_review/test_item_review.py
@@ -5,6 +5,7 @@ import unittest
 
 import frappe
 from frappe.core.doctype.user_permission.test_user_permission import create_user
+from frappe.tests.utils import FrappeTestCase
 
 from erpnext.e_commerce.doctype.e_commerce_settings.test_e_commerce_settings import (
 	setup_e_commerce_settings,
@@ -19,7 +20,7 @@ from erpnext.e_commerce.shopping_cart.cart import get_party
 from erpnext.stock.doctype.item.test_item import make_item
 
 
-class TestItemReview(unittest.TestCase):
+class TestItemReview(FrappeTestCase):
 	def setUp(self):
 		item = make_item("Test Mobile Phone")
 		if not frappe.db.exists("Website Item", {"item_code": "Test Mobile Phone"}):
@@ -29,8 +30,7 @@ class TestItemReview(unittest.TestCase):
 		frappe.local.shopping_cart_settings = None
 
 	def tearDown(self):
-		frappe.get_cached_doc("Website Item", {"item_code": "Test Mobile Phone"}).delete()
-		setup_e_commerce_settings({"enable_reviews": 0})
+		frappe.db.rollback()
 
 	def test_add_and_get_item_reviews_from_customer(self):
 		"Add / Get Reviews from a User that is a valid customer (has added to cart or purchased in the past)"

--- a/erpnext/e_commerce/doctype/item_review/test_item_review.py
+++ b/erpnext/e_commerce/doctype/item_review/test_item_review.py
@@ -44,7 +44,7 @@ class TestItemReview(FrappeTestCase):
 
 		# post review on "Test Mobile Phone"
 		try:
-			add_item_review(web_item, "Great Product", 3, "Would recommend this product")
+			add_item_review(web_item, "Great Product", 1, "Would recommend this product")
 			review_name = frappe.db.get_value("Item Review", {"website_item": web_item})
 		except Exception:
 			self.fail(f"Error while publishing review for {web_item}")
@@ -52,8 +52,7 @@ class TestItemReview(FrappeTestCase):
 		review_data = get_item_reviews(web_item, 0, 10)
 
 		self.assertEqual(len(review_data.reviews), 1)
-		self.assertEqual(review_data.average_rating, 3)
-		self.assertEqual(review_data.reviews_per_rating[2], 100)
+		self.assertEqual(review_data.average_rating, 1)
 
 		# tear down
 		frappe.set_user("Administrator")

--- a/erpnext/e_commerce/doctype/website_item/test_website_item.py
+++ b/erpnext/e_commerce/doctype/website_item/test_website_item.py
@@ -24,8 +24,10 @@ WEBITEM_PRICE_TESTS = (
 	"test_website_item_price_for_guest_user",
 )
 
+from frappe.tests.utils import FrappeTestCase
 
-class TestWebsiteItem(unittest.TestCase):
+
+class TestWebsiteItem(FrappeTestCase):
 	@classmethod
 	def setUpClass(cls):
 		setup_e_commerce_settings(
@@ -74,6 +76,9 @@ class TestWebsiteItem(unittest.TestCase):
 				applicable_for="Customer",
 				customer="_Test Customer",
 			)
+
+	def tearDown(self):
+		frappe.db.rollback()
 
 	def test_index_creation(self):
 		"Check if index is getting created in db."

--- a/erpnext/e_commerce/doctype/website_item/test_website_item.py
+++ b/erpnext/e_commerce/doctype/website_item/test_website_item.py
@@ -28,8 +28,7 @@ from frappe.tests.utils import FrappeTestCase
 
 
 class TestWebsiteItem(FrappeTestCase):
-	@classmethod
-	def setUpClass(cls):
+	def setUp(self):
 		setup_e_commerce_settings(
 			{
 				"company": "_Test Company",
@@ -39,11 +38,6 @@ class TestWebsiteItem(FrappeTestCase):
 			}
 		)
 
-	@classmethod
-	def tearDownClass(cls):
-		frappe.db.rollback()
-
-	def setUp(self):
 		if self._testMethodName in WEBITEM_DESK_TESTS:
 			make_item(
 				"Test Web Item",


### PR DESCRIPTION
Post [this](https://github.com/frappe/frappe/pull/22633), rating value is now restricted to [0...1], which causes the below assertion to fail
https://github.com/frappe/erpnext/blob/93fe136386ba18ebef89c43b55ea2edee5dfe466/erpnext/e_commerce/doctype/item_review/test_item_review.py#L55 

