### PR TITLE
refactor: usage of in_list

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.js
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.js
@@ -196,7 +196,7 @@ frappe.ui.form.on("Journal Entry", {
 			!(frm.doc.accounts || []).length ||
 			((frm.doc.accounts || []).length === 1 && !frm.doc.accounts[0].account)
 		) {
-			if (in_list(["Bank Entry", "Cash Entry"], frm.doc.voucher_type)) {
+			if (["Bank Entry", "Cash Entry"].includes(frm.doc.voucher_type)) {
 				return frappe.call({
 					type: "GET",
 					method: "erpnext.accounts.doctype.journal_entry.journal_entry.get_default_bank_cash_account",
@@ -308,7 +308,7 @@ erpnext.accounts.JournalEntry = class JournalEntry extends frappe.ui.form.Contro
 				filters: [[jvd.reference_type, "docstatus", "=", 1]],
 			};
 
-			if (in_list(["Sales Invoice", "Purchase Invoice"], jvd.reference_type)) {
+			if (["Sales Invoice", "Purchase Invoice"].includes(jvd.reference_type)) {
 				out.filters.push([jvd.reference_type, "outstanding_amount", "!=", 0]);
 				// Filter by cost center
 				if (jvd.cost_center) {
@@ -320,7 +320,7 @@ erpnext.accounts.JournalEntry = class JournalEntry extends frappe.ui.form.Contro
 				out.filters.push([jvd.reference_type, party_account_field, "=", jvd.account]);
 			}
 
-			if (in_list(["Sales Order", "Purchase Order"], jvd.reference_type)) {
+			if (["Sales Order", "Purchase Order"].includes(jvd.reference_type)) {
 				// party_type and party mandatory
 				frappe.model.validate_missing(jvd, "party_type");
 				frappe.model.validate_missing(jvd, "party");

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -32,7 +32,7 @@ frappe.ui.form.on("Payment Entry", {
 		frm.set_query("paid_from", function () {
 			frm.events.validate_company(frm);
 
-			var account_types = in_list(["Pay", "Internal Transfer"], frm.doc.payment_type)
+			var account_types = ["Pay", "Internal Transfer"].includes(frm.doc.payment_type)
 				? ["Bank", "Cash"]
 				: [frappe.boot.party_account_types[frm.doc.party_type]];
 			return {
@@ -87,7 +87,7 @@ frappe.ui.form.on("Payment Entry", {
 		frm.set_query("paid_to", function () {
 			frm.events.validate_company(frm);
 
-			var account_types = in_list(["Receive", "Internal Transfer"], frm.doc.payment_type)
+			var account_types = ["Receive", "Internal Transfer"].includes(frm.doc.payment_type)
 				? ["Bank", "Cash"]
 				: [frappe.boot.party_account_types[frm.doc.party_type]];
 			return {
@@ -134,7 +134,7 @@ frappe.ui.form.on("Payment Entry", {
 		frm.set_query("payment_term", "references", function (frm, cdt, cdn) {
 			const child = locals[cdt][cdn];
 			if (
-				in_list(["Purchase Invoice", "Sales Invoice"], child.reference_doctype) &&
+				["Purchase Invoice", "Sales Invoice"].includes(child.reference_doctype) &&
 				child.reference_name
 			) {
 				return {
@@ -623,7 +623,7 @@ frappe.ui.form.on("Payment Entry", {
 		if (frm.doc.paid_from_account_currency == company_currency) {
 			frm.set_value("source_exchange_rate", 1);
 		} else if (frm.doc.paid_from) {
-			if (in_list(["Internal Transfer", "Pay"], frm.doc.payment_type)) {
+			if (["Internal Transfer", "Pay"].includes(frm.doc.payment_type)) {
 				let company_currency = frappe.get_doc(":Company", frm.doc.company).default_currency;
 				frappe.call({
 					method: "erpnext.setup.utils.get_exchange_rate",
@@ -1042,7 +1042,7 @@ frappe.ui.form.on("Payment Entry", {
 			}
 
 			var allocated_positive_outstanding = paid_amount + allocated_negative_outstanding;
-		} else if (in_list(["Customer", "Supplier"], frm.doc.party_type)) {
+		} else if (["Customer", "Supplier"].includes(frm.doc.party_type)) {
 			total_negative_outstanding = flt(total_negative_outstanding, precision("outstanding_amount"));
 			if (paid_amount > total_negative_outstanding) {
 				if (total_negative_outstanding == 0) {
@@ -1213,7 +1213,7 @@ frappe.ui.form.on("Payment Entry", {
 
 			if (
 				frm.doc.party_type == "Customer" &&
-				!in_list(["Sales Order", "Sales Invoice", "Journal Entry", "Dunning"], row.reference_doctype)
+				!["Sales Order", "Sales Invoice", "Journal Entry", "Dunning"].includes(row.reference_doctype)
 			) {
 				frappe.model.set_value(row.doctype, row.name, "reference_doctype", null);
 				frappe.msgprint(
@@ -1227,7 +1227,7 @@ frappe.ui.form.on("Payment Entry", {
 
 			if (
 				frm.doc.party_type == "Supplier" &&
-				!in_list(["Purchase Order", "Purchase Invoice", "Journal Entry"], row.reference_doctype)
+				!["Purchase Order", "Purchase Invoice", "Journal Entry"].includes(row.reference_doctype)
 			) {
 				frappe.model.set_value(row.doctype, row.name, "against_voucher_type", null);
 				frappe.msgprint(
@@ -1323,7 +1323,7 @@ frappe.ui.form.on("Payment Entry", {
 
 	bank_account: function (frm) {
 		const field = frm.doc.payment_type == "Pay" ? "paid_from" : "paid_to";
-		if (frm.doc.bank_account && in_list(["Pay", "Receive"], frm.doc.payment_type)) {
+		if (frm.doc.bank_account && ["Pay", "Receive"].includes(frm.doc.payment_type)) {
 			frappe.call({
 				method: "erpnext.accounts.doctype.bank_account.bank_account.get_bank_account_details",
 				args: {

--- a/erpnext/accounts/doctype/payment_request/payment_request.js
+++ b/erpnext/accounts/doctype/payment_request/payment_request.js
@@ -32,7 +32,7 @@ frappe.ui.form.on("Payment Request", "refresh", function (frm) {
 	if (
 		frm.doc.payment_request_type == "Inward" &&
 		frm.doc.payment_channel !== "Phone" &&
-		!in_list(["Initiated", "Paid"], frm.doc.status) &&
+		!["Initiated", "Paid"].includes(frm.doc.status) &&
 		!frm.doc.__islocal &&
 		frm.doc.docstatus == 1
 	) {

--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -79,7 +79,7 @@ frappe.ui.form.on("Asset", {
 		frm.toggle_display("next_depreciation_date", frm.doc.docstatus < 1);
 
 		if (frm.doc.docstatus == 1) {
-			if (in_list(["Submitted", "Partially Depreciated", "Fully Depreciated"], frm.doc.status)) {
+			if (["Submitted", "Partially Depreciated", "Fully Depreciated"].includes(frm.doc.status)) {
 				frm.add_custom_button(
 					__("Transfer Asset"),
 					function () {
@@ -365,7 +365,7 @@ frappe.ui.form.on("Asset", {
 				if (v.journal_entry) {
 					asset_values.push(asset_value);
 				} else {
-					if (in_list(["Scrapped", "Sold"], frm.doc.status)) {
+					if (["Scrapped", "Sold"].includes(frm.doc.status)) {
 						asset_values.push(null);
 					} else {
 						asset_values.push(asset_value);
@@ -400,7 +400,7 @@ frappe.ui.form.on("Asset", {
 			});
 		}
 
-		if (in_list(["Scrapped", "Sold"], frm.doc.status)) {
+		if (["Scrapped", "Sold"].includes(frm.doc.status)) {
 			x_intervals.push(frappe.format(frm.doc.disposal_date, { fieldtype: "Date" }));
 			asset_values.push(0);
 		}

--- a/erpnext/buying/doctype/purchase_order/purchase_order.js
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.js
@@ -291,7 +291,7 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 				this.frm.fields_dict.items_section.wrapper.removeClass("hide-border");
 			}
 
-			if (!in_list(["Closed", "Delivered"], doc.status)) {
+			if (!["Closed", "Delivered"].includes(doc.status)) {
 				if (
 					this.frm.doc.status !== "Closed" &&
 					flt(this.frm.doc.per_received, 2) < 100 &&
@@ -336,7 +336,7 @@ erpnext.buying.PurchaseOrderController = class PurchaseOrderController extends (
 
 					this.frm.page.set_inner_btn_group_as_primary(__("Status"));
 				}
-			} else if (in_list(["Closed", "Delivered"], doc.status)) {
+			} else if (["Closed", "Delivered"].includes(doc.status)) {
 				if (this.frm.has_perm("submit")) {
 					this.frm.add_custom_button(
 						__("Re-open"),

--- a/erpnext/manufacturing/doctype/bom/bom.js
+++ b/erpnext/manufacturing/doctype/bom/bom.js
@@ -400,7 +400,7 @@ frappe.ui.form.on("BOM", {
 	},
 
 	rm_cost_as_per(frm) {
-		if (in_list(["Valuation Rate", "Last Purchase Rate"], frm.doc.rm_cost_as_per)) {
+		if (["Valuation Rate", "Last Purchase Rate"].includes(frm.doc.rm_cost_as_per)) {
 			frm.set_value("plc_conversion_rate", 1.0);
 		}
 	},

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.js
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.js
@@ -129,7 +129,7 @@ frappe.ui.form.on("Production Plan", {
 				if (
 					frm.doc.mr_items &&
 					frm.doc.mr_items.length &&
-					!in_list(["Material Requested", "Closed"], frm.doc.status)
+					!["Material Requested", "Closed"].includes(frm.doc.status)
 				) {
 					frm.add_custom_button(
 						__("Material Request"),

--- a/erpnext/manufacturing/doctype/work_order/work_order.js
+++ b/erpnext/manufacturing/doctype/work_order/work_order.js
@@ -196,7 +196,7 @@ frappe.ui.form.on("Work Order", {
 	},
 
 	add_custom_button_to_return_components: function (frm) {
-		if (frm.doc.docstatus === 1 && in_list(["Closed", "Completed"], frm.doc.status)) {
+		if (frm.doc.docstatus === 1 && ["Closed", "Completed"].includes(frm.doc.status)) {
 			let non_consumed_items = frm.doc.required_items.filter((d) => {
 				return flt(d.consumed_qty) < flt(d.transferred_qty - d.returned_qty);
 			});
@@ -596,7 +596,7 @@ erpnext.work_order = {
 			);
 		}
 
-		if (doc.docstatus === 1 && !in_list(["Closed", "Completed"], doc.status)) {
+		if (doc.docstatus === 1 && !["Closed", "Completed"].includes(doc.status)) {
 			if (doc.status != "Stopped" && doc.status != "Completed") {
 				frm.add_custom_button(
 					__("Stop"),

--- a/erpnext/public/js/communication.js
+++ b/erpnext/public/js/communication.js
@@ -20,7 +20,7 @@ frappe.ui.form.on("Communication", {
 			);
 		}
 
-		if (!in_list(["Lead", "Opportunity"], frm.doc.reference_doctype)) {
+		if (!["Lead", "Opportunity"].includes(frm.doc.reference_doctype)) {
 			frm.add_custom_button(
 				__("Lead"),
 				() => {

--- a/erpnext/public/js/controllers/accounts.js
+++ b/erpnext/public/js/controllers/accounts.js
@@ -11,7 +11,7 @@ erpnext.accounts.taxes = {
 			setup: function(frm) {
 				// set conditional display for rate column in taxes
 				$(frm.wrapper).on('grid-row-render', function(e, grid_row) {
-					if(in_list(['Sales Taxes and Charges', 'Purchase Taxes and Charges'], grid_row.doc.doctype)) {
+					if(['Sales Taxes and Charges', 'Purchase Taxes and Charges'].includes(grid_row.doc.doctype)) {
 						me.set_conditional_mandatory_rate_or_amount(grid_row);
 					}
 				});

--- a/erpnext/public/js/controllers/buying.js
+++ b/erpnext/public/js/controllers/buying.js
@@ -129,7 +129,7 @@ erpnext.buying = {
 			}
 
 			toggle_subcontracting_fields() {
-				if (in_list(['Purchase Receipt', 'Purchase Invoice'], this.frm.doc.doctype)) {
+				if (['Purchase Receipt', 'Purchase Invoice'].includes(this.frm.doc.doctype)) {
 					this.frm.fields_dict.supplied_items.grid.update_docfield_property('consumed_qty',
 						'read_only', this.frm.doc.__onload && this.frm.doc.__onload.backflush_based_on === 'BOM');
 

--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -9,7 +9,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 	apply_pricing_rule_on_item(item) {
 		let effective_item_rate = item.price_list_rate;
 		let item_rate = item.rate;
-		if (in_list(["Sales Order", "Quotation"], item.parenttype) && item.blanket_order_rate) {
+		if (["Sales Order", "Quotation"].includes(item.parenttype) && item.blanket_order_rate) {
 			effective_item_rate = item.blanket_order_rate;
 		}
 		if (item.margin_type == "Percentage") {
@@ -52,7 +52,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 
 		// Advance calculation applicable to Sales/Purchase Invoice
 		if (
-			in_list(["Sales Invoice", "POS Invoice", "Purchase Invoice"], this.frm.doc.doctype)
+			["Sales Invoice", "POS Invoice", "Purchase Invoice"].includes(this.frm.doc.doctype)
 			&& this.frm.doc.docstatus < 2
 			&& !this.frm.doc.is_return
 		) {
@@ -60,7 +60,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		}
 
 		if (
-			in_list(["Sales Invoice", "POS Invoice"], this.frm.doc.doctype)
+			["Sales Invoice", "POS Invoice"].includes(this.frm.doc.doctype)
 			&& this.frm.doc.is_pos
 			&& this.frm.doc.is_return
 		) {
@@ -69,7 +69,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		}
 
 		// Sales person's commission
-		if (in_list(["Quotation", "Sales Order", "Delivery Note", "Sales Invoice"], this.frm.doc.doctype)) {
+		if (["Quotation", "Sales Order", "Delivery Note", "Sales Invoice"].includes(this.frm.doc.doctype)) {
 			this.calculate_commission();
 			this.calculate_contribution();
 		}
@@ -575,7 +575,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 			? this.frm.doc["taxes"][tax_count - 1].total + flt(this.frm.doc.grand_total_diff)
 			: this.frm.doc.net_total);
 
-		if(in_list(["Quotation", "Sales Order", "Delivery Note", "Sales Invoice", "POS Invoice"], this.frm.doc.doctype)) {
+		if(["Quotation", "Sales Order", "Delivery Note", "Sales Invoice", "POS Invoice"].includes(this.frm.doc.doctype)) {
 			this.frm.doc.base_grand_total = (this.frm.doc.total_taxes_and_charges) ?
 				flt(this.frm.doc.grand_total * this.frm.doc.conversion_rate) : this.frm.doc.base_net_total;
 		} else {
@@ -583,7 +583,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 			this.frm.doc.taxes_and_charges_added = this.frm.doc.taxes_and_charges_deducted = 0.0;
 			if(tax_count) {
 				$.each(this.frm.doc["taxes"] || [], function(i, tax) {
-					if (in_list(["Valuation and Total", "Total"], tax.category)) {
+					if (["Valuation and Total", "Total"].includes(tax.category)) {
 						if(tax.add_deduct_tax == "Add") {
 							me.frm.doc.taxes_and_charges_added += flt(tax.tax_amount_after_discount_amount);
 						} else {
@@ -729,7 +729,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 			var actual_taxes_dict = {};
 
 			$.each(this.frm.doc["taxes"] || [], function(i, tax) {
-				if (in_list(["Actual", "On Item Quantity"], tax.charge_type)) {
+				if (["Actual", "On Item Quantity"].includes(tax.charge_type)) {
 					var tax_amount = (tax.category == "Valuation") ? 0.0 : tax.tax_amount;
 					tax_amount *= (tax.add_deduct_tax == "Deduct") ? -1.0 : 1.0;
 					actual_taxes_dict[tax.idx] = tax_amount;
@@ -774,7 +774,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 		// NOTE:
 		// paid_amount and write_off_amount is only for POS/Loyalty Point Redemption Invoice
 		// total_advance is only for non POS Invoice
-		if(in_list(["Sales Invoice", "POS Invoice"], this.frm.doc.doctype) && this.frm.doc.is_return){
+		if(["Sales Invoice", "POS Invoice"].includes(this.frm.doc.doctype) && this.frm.doc.is_return){
 			this.calculate_paid_amount();
 		}
 
@@ -782,7 +782,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 
 		frappe.model.round_floats_in(this.frm.doc, ["grand_total", "total_advance", "write_off_amount"]);
 
-		if(in_list(["Sales Invoice", "POS Invoice", "Purchase Invoice"], this.frm.doc.doctype)) {
+		if(["Sales Invoice", "POS Invoice", "Purchase Invoice"].includes(this.frm.doc.doctype)) {
 			let grand_total = this.frm.doc.rounded_total || this.frm.doc.grand_total;
 			let base_grand_total = this.frm.doc.base_rounded_total || this.frm.doc.base_grand_total;
 
@@ -805,7 +805,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 				this.frm.refresh_field("base_paid_amount");
 			}
 
-			if(in_list(["Sales Invoice", "POS Invoice"], this.frm.doc.doctype)) {
+			if(["Sales Invoice", "POS Invoice"].includes(this.frm.doc.doctype)) {
 				let total_amount_for_payment = (this.frm.doc.redeem_loyalty_points && this.frm.doc.loyalty_amount)
 					? flt(total_amount_to_pay - this.frm.doc.loyalty_amount, precision("base_grand_total"))
 					: total_amount_to_pay;
@@ -909,7 +909,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 	calculate_change_amount(){
 		this.frm.doc.change_amount = 0.0;
 		this.frm.doc.base_change_amount = 0.0;
-		if(in_list(["Sales Invoice", "POS Invoice"], this.frm.doc.doctype)
+		if(["Sales Invoice", "POS Invoice"].includes(this.frm.doc.doctype)
 			&& this.frm.doc.paid_amount > this.frm.doc.grand_total && !this.frm.doc.is_return) {
 
 			var payment_types = $.map(this.frm.doc.payments, function(d) { return d.type; });

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -315,7 +315,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 	}
 
 	setup_quality_inspection() {
-		if(!in_list(["Delivery Note", "Sales Invoice", "Purchase Receipt", "Purchase Invoice", "Subcontracting Receipt"], this.frm.doc.doctype)) {
+		if(!["Delivery Note", "Sales Invoice", "Purchase Receipt", "Purchase Invoice", "Subcontracting Receipt"].includes(this.frm.doc.doctype)) {
 			return;
 		}
 
@@ -327,7 +327,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 			this.frm.page.set_inner_btn_group_as_primary(__('Create'));
 		}
 
-		const inspection_type = in_list(["Purchase Receipt", "Purchase Invoice", "Subcontracting Receipt"], this.frm.doc.doctype)
+		const inspection_type = ["Purchase Receipt", "Purchase Invoice", "Subcontracting Receipt"].includes(this.frm.doc.doctype)
 			? "Incoming" : "Outgoing";
 
 		let quality_inspection_field = this.frm.get_docfield("items", "quality_inspection");
@@ -359,7 +359,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 
 	make_payment_request() {
 		let me = this;
-		const payment_request_type = (in_list(['Sales Order', 'Sales Invoice'], this.frm.doc.doctype))
+		const payment_request_type = (['Sales Order', 'Sales Invoice'].includes(this.frm.doc.doctype))
 			? "Inward" : "Outward";
 
 		frappe.call({
@@ -474,7 +474,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 	setup_sms() {
 		var me = this;
 		let blacklist = ['Purchase Invoice', 'BOM'];
-		if(this.frm.doc.docstatus===1 && !in_list(["Lost", "Stopped", "Closed"], this.frm.doc.status)
+		if(this.frm.doc.docstatus===1 && !["Lost", "Stopped", "Closed"].includes(this.frm.doc.status)
 			&& !blacklist.includes(this.frm.doctype)) {
 			this.frm.page.add_menu_item(__('Send SMS'), function() { me.send_sms(); });
 		}
@@ -760,7 +760,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 	}
 
 	on_submit() {
-		if (in_list(["Purchase Invoice", "Sales Invoice"], this.frm.doc.doctype)
+		if (["Purchase Invoice", "Sales Invoice"].includes(this.frm.doc.doctype)
 			&& !this.frm.doc.update_stock) {
 			return;
 		}
@@ -864,7 +864,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		}
 
 		var set_party_account = function(set_pricing) {
-			if (in_list(["Sales Invoice", "Purchase Invoice"], me.frm.doc.doctype)) {
+			if (["Sales Invoice", "Purchase Invoice"].includes(me.frm.doc.doctype)) {
 				if(me.frm.doc.doctype=="Sales Invoice") {
 					var party_type = "Customer";
 					var party_account_field = 'debit_to';
@@ -899,7 +899,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		}
 
 		if (frappe.meta.get_docfield(this.frm.doctype, "shipping_address") &&
-			in_list(['Purchase Order', 'Purchase Receipt', 'Purchase Invoice'], this.frm.doctype)) {
+			['Purchase Order', 'Purchase Receipt', 'Purchase Invoice'].includes(this.frm.doctype)) {
 			erpnext.utils.get_shipping_address(this.frm, function() {
 				set_party_account(set_pricing);
 			});
@@ -1620,7 +1620,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 			"doctype": me.frm.doc.doctype,
 			"name": me.frm.doc.name,
 			"is_return": cint(me.frm.doc.is_return),
-			"update_stock": in_list(['Sales Invoice', 'Purchase Invoice'], me.frm.doc.doctype) ? cint(me.frm.doc.update_stock) : 0,
+			"update_stock": ['Sales Invoice', 'Purchase Invoice'].includes(me.frm.doc.doctype) ? cint(me.frm.doc.update_stock) : 0,
 			"conversion_factor": me.frm.doc.conversion_factor,
 			"pos_profile": me.frm.doc.doctype == 'Sales Invoice' ? me.frm.doc.pos_profile : '',
 			"coupon_code": me.frm.doc.coupon_code
@@ -2266,7 +2266,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 	get_method_for_payment() {
 		var method = "erpnext.accounts.doctype.payment_entry.payment_entry.get_payment_entry";
 		if(cur_frm.doc.__onload && cur_frm.doc.__onload.make_payment_via_journal_entry){
-			if(in_list(['Sales Invoice', 'Purchase Invoice'],  cur_frm.doc.doctype)){
+			if(['Sales Invoice', 'Purchase Invoice'].includes( cur_frm.doc.doctype)){
 				method = "erpnext.accounts.doctype.journal_entry.journal_entry.get_payment_entry_against_invoice";
 			}else {
 				method= "erpnext.accounts.doctype.journal_entry.journal_entry.get_payment_entry_against_order";
@@ -2506,7 +2506,7 @@ erpnext.show_serial_batch_selector = function (frm, item_row, callback, on_close
 	}
 
 	frappe.require("assets/erpnext/js/utils/serial_no_batch_selector.js", function() {
-		if (in_list(["Sales Invoice", "Delivery Note"], frm.doc.doctype)) {
+		if (["Sales Invoice", "Delivery Note"].includes(frm.doc.doctype)) {
 			item_row.type_of_transaction = frm.doc.is_return ? "Inward" : "Outward";
 		} else {
 			item_row.type_of_transaction = frm.doc.is_return ? "Outward" : "Inward";

--- a/erpnext/public/js/payment/payments.js
+++ b/erpnext/public/js/payment/payments.js
@@ -218,7 +218,7 @@ erpnext.payments = class payments extends erpnext.stock.StockController {
 
 	update_paid_amount(update_write_off) {
 		var me = this;
-		if (in_list(["change_amount", "write_off_amount"], this.idx)) {
+		if (["change_amount", "write_off_amount"].includes(this.idx)) {
 			var value = me.selected_mode.val();
 			if (me.idx == "change_amount") {
 				me.change_amount(value);

--- a/erpnext/public/js/sms_manager.js
+++ b/erpnext/public/js/sms_manager.js
@@ -28,11 +28,11 @@ erpnext.SMSManager = function SMSManager(doc) {
 			"Purchase Receipt": "Items has been received against purchase receipt: " + doc.name,
 		};
 
-		if (in_list(["Sales Order", "Delivery Note", "Sales Invoice"], doc.doctype))
+		if (["Sales Order", "Delivery Note", "Sales Invoice"].includes(doc.doctype))
 			this.show(doc.contact_person, "Customer", doc.customer, "", default_msg[doc.doctype]);
 		else if (doc.doctype === "Quotation")
 			this.show(doc.contact_person, "Customer", doc.party_name, "", default_msg[doc.doctype]);
-		else if (in_list(["Purchase Order", "Purchase Receipt"], doc.doctype))
+		else if (["Purchase Order", "Purchase Receipt"].includes(doc.doctype))
 			this.show(doc.contact_person, "Supplier", doc.supplier, "", default_msg[doc.doctype]);
 		else if (doc.doctype == "Lead") this.show("", "", "", doc.mobile_no, default_msg[doc.doctype]);
 		else if (doc.doctype == "Opportunity")

--- a/erpnext/public/js/utils/party.js
+++ b/erpnext/public/js/utils/party.js
@@ -14,10 +14,10 @@ erpnext.utils.get_party_details = function (frm, method, args, callback) {
 	if (!args) {
 		if (
 			(frm.doctype != "Purchase Order" && frm.doc.customer) ||
-			(frm.doc.party_name && in_list(["Quotation", "Opportunity"], frm.doc.doctype))
+			(frm.doc.party_name && ["Quotation", "Opportunity"].includes(frm.doc.doctype))
 		) {
 			let party_type = "Customer";
-			if (frm.doc.quotation_to && in_list(["Lead", "Prospect"], frm.doc.quotation_to)) {
+			if (frm.doc.quotation_to && ["Lead", "Prospect"].includes(frm.doc.quotation_to)) {
 				party_type = frm.doc.quotation_to;
 			}
 

--- a/erpnext/public/js/utils/sales_common.js
+++ b/erpnext/public/js/utils/sales_common.js
@@ -303,7 +303,7 @@ erpnext.sales_common = {
 				if ((doc.packed_items || []).length) {
 					$(this.frm.fields_dict.packing_list.row.wrapper).toggle(true);
 
-					if (in_list(["Delivery Note", "Sales Invoice"], doc.doctype)) {
+					if (["Delivery Note", "Sales Invoice"].includes(doc.doctype)) {
 						var help_msg =
 							"<div class='alert alert-warning'>" +
 							__(
@@ -315,7 +315,7 @@ erpnext.sales_common = {
 					}
 				} else {
 					$(this.frm.fields_dict.packing_list.row.wrapper).toggle(false);
-					if (in_list(["Delivery Note", "Sales Invoice"], doc.doctype)) {
+					if (["Delivery Note", "Sales Invoice"].includes(doc.doctype)) {
 						frappe.meta.get_docfield(doc.doctype, "product_bundle_help", doc.name).options = "";
 					}
 				}
@@ -416,7 +416,7 @@ erpnext.sales_common = {
 
 			project() {
 				let me = this;
-				if (in_list(["Delivery Note", "Sales Invoice", "Sales Order"], this.frm.doc.doctype)) {
+				if (["Delivery Note", "Sales Invoice", "Sales Order"].includes(this.frm.doc.doctype)) {
 					if (this.frm.doc.project) {
 						frappe.call({
 							method: "erpnext.projects.doctype.project.project.get_cost_center_name",

--- a/erpnext/regional/doctype/import_supplier_invoice/import_supplier_invoice.js
+++ b/erpnext/regional/doctype/import_supplier_invoice/import_supplier_invoice.js
@@ -34,7 +34,7 @@ frappe.ui.form.on("Import Supplier Invoice", {
 	},
 
 	toggle_read_only_fields: function (frm) {
-		if (in_list(["File Import Completed", "Processing File Data"], frm.doc.status)) {
+		if (["File Import Completed", "Processing File Data"].includes(frm.doc.status)) {
 			cur_frm.set_read_only();
 			cur_frm.refresh_fields();
 			frm.set_df_property("import_invoices", "hidden", 1);

--- a/erpnext/selling/page/point_of_sale/pos_past_order_summary.js
+++ b/erpnext/selling/page/point_of_sale/pos_past_order_summary.js
@@ -73,7 +73,7 @@ erpnext.PointOfSale.PastOrderSummary = class {
 		const { status } = doc;
 		let indicator_color = "";
 
-		in_list(["Paid", "Consolidated"], status) && (indicator_color = "green");
+		["Paid", "Consolidated"].includes(status) && (indicator_color = "green");
 		status === "Draft" && (indicator_color = "red");
 		status === "Return" && (indicator_color = "grey");
 

--- a/erpnext/stock/doctype/closing_stock_balance/closing_stock_balance.js
+++ b/erpnext/stock/doctype/closing_stock_balance/closing_stock_balance.js
@@ -8,7 +8,7 @@ frappe.ui.form.on("Closing Stock Balance", {
 	},
 
 	generate_closing_balance(frm) {
-		if (in_list(["Queued", "Failed"], frm.doc.status)) {
+		if (["Queued", "Failed"].includes(frm.doc.status)) {
 			frm.add_custom_button(__("Generate Closing Stock Balance"), () => {
 				frm.call({
 					method: "enqueue_job",

--- a/erpnext/stock/doctype/delivery_trip/delivery_trip_list.js
+++ b/erpnext/stock/doctype/delivery_trip/delivery_trip_list.js
@@ -1,9 +1,9 @@
 frappe.listview_settings["Delivery Trip"] = {
 	add_fields: ["status"],
 	get_indicator: function (doc) {
-		if (in_list(["Cancelled", "Draft"], doc.status)) {
+		if (["Cancelled", "Draft"].includes(doc.status)) {
 			return [__(doc.status), "red", "status,=," + doc.status];
-		} else if (in_list(["In Transit", "Scheduled"], doc.status)) {
+		} else if (["In Transit", "Scheduled"].includes(doc.status)) {
 			return [__(doc.status), "orange", "status,=," + doc.status];
 		} else if (doc.status === "Completed") {
 			return [__(doc.status), "green", "status,=," + doc.status];

--- a/erpnext/templates/form_grid/item_grid.html
+++ b/erpnext/templates/form_grid/item_grid.html
@@ -18,7 +18,7 @@
 					actual_qty = (frm.doc.doctype==="Sales Order"
 						? doc.projected_qty : doc.actual_qty);
                 if(flt(frm.doc.per_delivered, 2) < 100
-                    && in_list(["Sales Order Item", "Delivery Note Item"], doc.doctype)) {
+                    && ["Sales Order Item", "Delivery Note Item"].includes(doc.doctype)) {
     				if(actual_qty != undefined) {
     					if(actual_qty >= doc.qty) {
     						var color = "green";


### PR DESCRIPTION
Usage of `in_list` is discouraged by our semgrep rules. Editing theses files would lead to a warning. This PR refactors the affected files in order to avoid future semgrep failures on unrelated PRs

Bulk-replace `in_list(array, member)` with `array.includes(member)`:

- Search: `in_list\(\[(.*)\], (.+?)\)`
- Replace: `[$1].includes($2)`