### PR TITLE
fix: pick list not picked materials having required qty less than 1

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -774,7 +774,7 @@ def get_available_item_locations(
 
 	if picked_item_details:
 		for location in list(locations):
-			if location["qty"] < 1:
+			if location["qty"] < 0:
 				locations.remove(location)
 
 		total_qty_available = sum(location.get("qty") for location in locations)


### PR DESCRIPTION
- Create a work order with raw materials having less than 1 qty required
- Make pick list (system will allow)
- Create another work order with raw materials having less than 1 qty required
- Try to make a pick list, system will throw below error

<img width="901" alt="Screenshot 2024-03-20 at 1 25 54 PM" src="https://github.com/frappe/erpnext/assets/8780500/8c5913f6-109e-461a-bc21-7e8d16d69812">
