### PR TITLE
fix: PCV validation for previous fiscal year

### DIFF
--- a/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
+++ b/erpnext/accounts/doctype/period_closing_voucher/period_closing_voucher.py
@@ -141,7 +141,8 @@ class PeriodClosingVoucher(AccountsController):
 		previous_fiscal_year = get_fiscal_year(last_year_closing, company=self.company, boolean=True)
 
 		if previous_fiscal_year and not frappe.db.exists(
-			"GL Entry", {"posting_date": ("<=", last_year_closing), "company": self.company}
+			"GL Entry",
+			{"posting_date": ("<=", last_year_closing), "company": self.company, "is_cancelled": 0},
 		):
 			return
 


### PR DESCRIPTION
**Steps to replicate bug** 

- Create a document for the previous fiscal year.
- Create a transaction in the previous fiscal year and cancel it.
- Create transactions in current fiscal year.
- Try to submit Period Closing Voucher for current fiscal year.
- The validation for PCV fails saying that the Previous Fiscal Year is not closed.

The validation checks if the previous fiscal year exists, if yes check for any GL entries created for the fiscal year, if no GL entries are created, allow submitting the PCV. If it does find GL entries it checks for a PCV for that year and considers it unclosed if no such voucher exists. However, if a cancelled GL entry exists in any of the past years then the validation still fails. 

**Fix**
Do not consider cancelled GL entries for the validation.

