### PR TITLE
perf: query one item price only

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -911,6 +911,7 @@ def get_item_price(args, item_code, ignore_party=False):
 		.orderby(ip.valid_from, order=frappe.qb.desc)
 		.orderby(IfNull(ip.batch_no, ""), order=frappe.qb.desc)
 		.orderby(ip.uom, order=frappe.qb.desc)
+		.limit(1)
 	)
 
 	if not ignore_party:


### PR DESCRIPTION
The code that calls this function only uses the first element and discards the others, hence we can limit the query to one item.