### PR TITLE
fix: show currency symbol in base currency in fixed asset register report

### DIFF
--- a/erpnext/accounts/report/pos_register/pos_register.py
+++ b/erpnext/accounts/report/pos_register/pos_register.py
@@ -62,7 +62,7 @@ def get_pos_entries(filters, group_by_field):
 	return frappe.db.sql(
 		"""
 		SELECT
-			p.posting_date, p.name as pos_invoice, p.pos_profile,
+			p.posting_date, p.name as pos_invoice, p.pos_profile, p.company,
 			p.owner, p.customer, p.is_return, p.base_grand_total as grand_total {select_mop_field}
 		FROM
 			`tabPOS Invoice` p {from_sales_invoice_payment}
@@ -207,14 +207,14 @@ def get_columns(filters):
 			"label": _("Grand Total"),
 			"fieldname": "grand_total",
 			"fieldtype": "Currency",
-			"options": "company:currency",
+			"options": "Company:company:default_currency",
 			"width": 120,
 		},
 		{
 			"label": _("Paid Amount"),
 			"fieldname": "paid_amount",
 			"fieldtype": "Currency",
-			"options": "company:currency",
+			"options": "Company:company:default_currency",
 			"width": 120,
 		},
 		{
@@ -224,6 +224,13 @@ def get_columns(filters):
 			"width": 150,
 		},
 		{"label": _("Is Return"), "fieldname": "is_return", "fieldtype": "Data", "width": 80},
+		{
+			"label": _("Company"),
+			"fieldname": "company",
+			"fieldtype": "Link",
+			"options": "Company",
+			"width": 120,
+		},
 	]
 
 	return columns

--- a/erpnext/accounts/report/pos_register/pos_register.py
+++ b/erpnext/accounts/report/pos_register/pos_register.py
@@ -59,6 +59,7 @@ def get_pos_entries(filters, group_by_field):
 		order_by += ", p.{}".format(group_by_field)
 		select_mop_field = ", p.base_paid_amount - p.change_amount  as paid_amount "
 
+	# nosemgrep
 	return frappe.db.sql(
 		"""
 		SELECT

--- a/erpnext/assets/report/fixed_asset_register/fixed_asset_register.py
+++ b/erpnext/assets/report/fixed_asset_register/fixed_asset_register.py
@@ -149,6 +149,7 @@ def get_data(filters):
 			"asset_category": asset.asset_category,
 			"purchase_date": asset.purchase_date,
 			"asset_value": asset_value,
+			"company": asset.company,
 		}
 		data.append(row)
 
@@ -379,29 +380,36 @@ def get_columns(filters):
 				"label": _("Gross Purchase Amount"),
 				"fieldname": "gross_purchase_amount",
 				"fieldtype": "Currency",
-				"options": "company:currency",
+				"options": "Company:company:default_currency",
 				"width": 250,
 			},
 			{
 				"label": _("Opening Accumulated Depreciation"),
 				"fieldname": "opening_accumulated_depreciation",
 				"fieldtype": "Currency",
-				"options": "company:currency",
+				"options": "Company:company:default_currency",
 				"width": 250,
 			},
 			{
 				"label": _("Depreciated Amount"),
 				"fieldname": "depreciated_amount",
 				"fieldtype": "Currency",
-				"options": "company:currency",
+				"options": "Company:company:default_currency",
 				"width": 250,
 			},
 			{
 				"label": _("Asset Value"),
 				"fieldname": "asset_value",
 				"fieldtype": "Currency",
-				"options": "company:currency",
+				"options": "Company:company:default_currency",
 				"width": 250,
+			},
+			{
+				"label": _("Company"),
+				"fieldname": "company",
+				"fieldtype": "Link",
+				"options": "Company",
+				"width": 120,
 			},
 		]
 
@@ -433,28 +441,28 @@ def get_columns(filters):
 			"label": _("Gross Purchase Amount"),
 			"fieldname": "gross_purchase_amount",
 			"fieldtype": "Currency",
-			"options": "company:currency",
+			"options": "Company:company:default_currency",
 			"width": 100,
 		},
 		{
 			"label": _("Asset Value"),
 			"fieldname": "asset_value",
 			"fieldtype": "Currency",
-			"options": "company:currency",
+			"options": "Company:company:default_currency",
 			"width": 100,
 		},
 		{
 			"label": _("Opening Accumulated Depreciation"),
 			"fieldname": "opening_accumulated_depreciation",
 			"fieldtype": "Currency",
-			"options": "company:currency",
+			"options": "Company:company:default_currency",
 			"width": 90,
 		},
 		{
 			"label": _("Depreciated Amount"),
 			"fieldname": "depreciated_amount",
 			"fieldtype": "Currency",
-			"options": "company:currency",
+			"options": "Company:company:default_currency",
 			"width": 100,
 		},
 		{
@@ -478,5 +486,12 @@ def get_columns(filters):
 			"fieldname": "location",
 			"options": "Location",
 			"width": 100,
+		},
+		{
+			"label": _("Company"),
+			"fieldname": "company",
+			"fieldtype": "Link",
+			"options": "Company",
+			"width": 120,
 		},
 	]


### PR DESCRIPTION
**Issue:**
In the Fixed Asset Register report, the system was showing the global default currency symbol instead of the company's base currency in all the amount columns.