### PR TITLE
feat(Item Price): validate UOM

### DIFF
--- a/erpnext/stock/doctype/item_price/item_price.py
+++ b/erpnext/stock/doctype/item_price/item_price.py
@@ -56,6 +56,11 @@ class ItemPrice(Document):
 		if not frappe.db.exists("Item", self.item_code):
 			frappe.throw(_("Item {0} not found.").format(self.item_code))
 
+		if self.uom and not frappe.db.exists(
+			"UOM Conversion Detail", {"parenttype": "Item", "parent": self.item_code, "uom": self.uom}
+		):
+			frappe.throw(_("UOM {0} not found in Item {1}").format(self.uom, self.item_code))
+
 	def validate_dates(self):
 		if self.valid_from and self.valid_upto:
 			if getdate(self.valid_from) > getdate(self.valid_upto):


### PR DESCRIPTION
If an **Item Price** is specific to a **UOM**, the **UOM** should be found in the **Item**'s UOM conversion table.

Docs: https://docs.erpnext.com/docs/user/manual/en/item-price#2-1-unit-of-measurement-uom-