### PR TITLE
perf: add in some indexes

### DIFF
--- a/erpnext/selling/doctype/sales_order_item/sales_order_item.json
+++ b/erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -834,7 +834,8 @@
    "label": "Purchase Order",
    "options": "Purchase Order",
    "print_hide": 1,
-   "read_only": 1
+   "read_only": 1,
+   "search_index": 1
   },
   {
    "fieldname": "column_break_89",
@@ -909,7 +910,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-01-25 14:24:00.330219",
+ "modified": "2024-03-21 18:15:56.625005",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order Item",

--- a/erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
+++ b/erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -796,7 +796,8 @@
    "label": "Purchase Order",
    "options": "Purchase Order",
    "print_hide": 1,
-   "read_only": 1
+   "read_only": 1,
+   "search_index": 1
   },
   {
    "fieldname": "column_break_82",
@@ -912,7 +913,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-02-04 14:10:31.750340",
+ "modified": "2024-03-21 18:15:07.603672",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Note Item",


### PR DESCRIPTION
Add in some missing indices, adding them down dropped some calls down from ~864 seconds to ~20 seconds - support ticket 11452

`Sales Invoice Item.purchase_order`
`Delivery Note Item.purchase_order`


