### PR TITLE
feat(UOM): add common code, symbol and description

### DIFF
--- a/erpnext/setup/doctype/uom/uom.json
+++ b/erpnext/setup/doctype/uom/uom.json
@@ -8,8 +8,12 @@
  "document_type": "Setup",
  "engine": "InnoDB",
  "field_order": [
-  "enabled",
   "uom_name",
+  "symbol",
+  "common_code",
+  "description",
+  "column_break_obth",
+  "enabled",
   "must_be_whole_number"
  ],
  "fields": [
@@ -35,12 +39,33 @@
    "fieldname": "enabled",
    "fieldtype": "Check",
    "label": "Enabled"
+  },
+  {
+   "fieldname": "symbol",
+   "fieldtype": "Data",
+   "label": "Symbol"
+  },
+  {
+   "description": "According to CEFACT/ICG/2010/IC013 or CEFACT/ICG/2010/IC010",
+   "fieldname": "common_code",
+   "fieldtype": "Data",
+   "label": "Common Code",
+   "length": 3
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Small Text",
+   "label": "Description"
+  },
+  {
+   "fieldname": "column_break_obth",
+   "fieldtype": "Column Break"
   }
  ],
  "icon": "fa fa-compass",
  "idx": 1,
  "links": [],
- "modified": "2021-10-18 14:07:43.722144",
+ "modified": "2024-03-21 14:46:48.422406",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "UOM",
@@ -78,5 +103,6 @@
  "quick_entry": 1,
  "show_name_in_global_search": 1,
  "sort_field": "modified",
- "sort_order": "ASC"
+ "sort_order": "ASC",
+ "states": []
 }

--- a/erpnext/setup/doctype/uom/uom.py
+++ b/erpnext/setup/doctype/uom/uom.py
@@ -14,8 +14,11 @@ class UOM(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
+		common_code: DF.Data | None
+		description: DF.SmallText | None
 		enabled: DF.Check
 		must_be_whole_number: DF.Check
+		symbol: DF.Data | None
 		uom_name: DF.Data
 	# end: auto-generated types
 


### PR DESCRIPTION
Example 1:

![Bildschirmfoto 2024-03-21 um 15 37 46](https://github.com/frappe/erpnext/assets/14891507/037629ed-0502-4905-8216-ab5215d40e52)

Example 2:

![Bildschirmfoto 2024-03-21 um 15 40 47](https://github.com/frappe/erpnext/assets/14891507/7390793c-6593-46f2-ae25-5df2507a505c)

The common code according to [CEFACT/ICG/2010/IC013](https://unece.org/trade/documents/session-documents/codes-units-measure-used-international-trade-recommendation) (or CEFACT/ICG/2010/IC010) will be useful for creating standardized electronic invoices.

I would also like to create this data by default for new sites. But so far, I'm lacking the related conversion factors.

> no-docs