### PR TITLE
fix: rate not fetching from the item price

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -825,7 +825,6 @@ def get_price_list_rate(args, item_doc, out=None):
 		):
 			if args.price_list and args.rate:
 				insert_item_price(args)
-			return out
 
 		out.price_list_rate = (
 			flt(price_list_rate) * flt(args.plc_conversion_rate) / flt(args.conversion_rate)


### PR DESCRIPTION
If "Update Existing Price List Rate" has enabled the the rate is not fetching from the item price