### PR TITLE
refactor: set_as_failed method on Payment Request

### DIFF
--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -49,6 +49,7 @@ class PaymentRequest(Document):
 		cost_center: DF.Link | None
 		currency: DF.Link | None
 		email_to: DF.Data | None
+		failed_reason: DF.Data | None
 		grand_total: DF.Currency
 		iban: DF.ReadOnly | None
 		is_a_subscription: DF.Check
@@ -396,8 +397,10 @@ class PaymentRequest(Document):
 		if self.message:
 			return frappe.render_template(self.message, context)
 
-	def set_failed(self):
-		pass
+	def set_as_failed(self, reason=None):
+		self.db_set("status", "Failed")
+		if reason:
+			self.db_set("failed_reason", reason)
 
 	def set_as_cancelled(self):
 		self.db_set("status", "Cancelled")


### PR DESCRIPTION
This PR removes the `set_failed` method from the Payment Request Doctype, which did nothing and was referenced nowhere.

It replaces the `set_failed` method with a `set_as_failed` method which corresponds generally to the existing `set_as_cancelled` and `set_as_paid` methods, with the notable difference that it accepts a `reason` parameter which populates the recently-introduced `failed_reason` field.

This is somewhat related to [my recent PR#75 on the payments app](https://github.com/frappe/payments/pull/75) which attempts to incorporate payment status from GoCardless webhooks, including updating the `failed_reason` field, where applicable. In that PR I utilize the existing `set_as_cancelled` and `set_as_paid` methods for those actions, but have created a manual workaround for the absence of a `set_as_failed` method. It would be nice to have this consolidated eventually.