### PR TITLE
fix: Wrong company name when get Stock balance report from warehouse directly.

### DIFF
--- a/erpnext/stock/doctype/warehouse/warehouse.js
+++ b/erpnext/stock/doctype/warehouse/warehouse.js
@@ -49,6 +49,7 @@ frappe.ui.form.on("Warehouse", {
 			frm.add_custom_button(__("Stock Balance"), function () {
 				frappe.set_route("query-report", "Stock Balance", {
 					warehouse: frm.doc.name,
+					company: frm.doc.company,
 				});
 			});
 


### PR DESCRIPTION
![wh](https://github.com/frappe/erpnext/assets/56191568/73bd0edd-0a49-43a6-afa5-e2d76d65a180)

clicking on 'Stock Balance' gives report with selected warehouse and default company. 

But, When company linked to warehouse is other then default company. it should fetch company name from warehouse form. 