### PR TITLE
fix: rate reset to zero

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -826,6 +826,9 @@ def get_price_list_rate(args, item_doc, out=None):
 			if args.price_list and args.rate:
 				insert_item_price(args)
 
+			if not price_list_rate:
+				return out
+
 		out.price_list_rate = (
 			flt(price_list_rate) * flt(args.plc_conversion_rate) / flt(args.conversion_rate)
 		)


### PR DESCRIPTION
**Issue**

Created a delivery note against the sales order and changed the qty. On changing of the qty the rate has become zero

![rate_changing_to_zero](https://github.com/frappe/erpnext/assets/8780500/94dbc3be-0ba8-4f5d-bc35-2a7a4ef52ee6)
