### PR TITLE
refactor: reset update_outstanding_for_self flag for old records

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
@@ -2180,7 +2180,8 @@
    "fieldname": "update_outstanding_for_self",
    "fieldtype": "Check",
    "label": "Update Outstanding for Self",
-   "no_copy": 1
+   "no_copy": 1,
+   "print_hide": 1
   }
  ],
  "icon": "fa fa-file-text",
@@ -2193,7 +2194,7 @@
    "link_fieldname": "consolidated_invoice"
   }
  ],
- "modified": "2024-03-20 16:02:52.237732",
+ "modified": "2024-03-22 17:50:34.395602",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice",

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -356,7 +356,7 @@ erpnext.patches.v14_0.update_total_asset_cost_field
 erpnext.patches.v15_0.create_advance_payment_status
 erpnext.patches.v15_0.allow_on_submit_dimensions_for_repostable_doctypes
 erpnext.patches.v14_0.create_accounting_dimensions_in_reconciliation_tool
-erpnext.patches.v14_0.update_flag_for_return_invoices
+erpnext.patches.v14_0.update_flag_for_return_invoices #2024-03-22
 # below migration patch should always run last
 erpnext.patches.v14_0.migrate_gl_to_payment_ledger
 erpnext.stock.doctype.delivery_note.patches.drop_unused_return_against_index # 2023-12-20

--- a/erpnext/patches/v14_0/update_flag_for_return_invoices.py
+++ b/erpnext/patches/v14_0/update_flag_for_return_invoices.py
@@ -12,6 +12,10 @@ def execute():
 	creation_date = "2024-01-25"
 
 	si = qb.DocType("Sales Invoice")
+
+	# unset flag, as migration would have set it for all records, as the field was introduced with default '1'
+	qb.update(si).set(si.update_outstanding_for_self, False).run()
+
 	if cr_notes := (
 		qb.from_(si)
 		.select(si.name)
@@ -37,6 +41,10 @@ def execute():
 			).run()
 
 	pi = qb.DocType("Purchase Invoice")
+
+	# unset flag, as migration would have set it for all records, as the field was introduced with default '1'
+	qb.update(pi).set(pi.update_outstanding_for_self, False).run()
+
 	if dr_notes := (
 		qb.from_(pi)
 		.select(pi.name)


### PR DESCRIPTION
Old Cr/Dr Notes will have `update_outstanding_for_self` flag incorrectly set as True, as the field was introduced with default True. Patch has been modified to unset before updating the ones created post backport.
introduced: https://github.com/frappe/erpnext/pull/40372