### PR TITLE
remove the group account option from the expense account filter.

### DIFF
--- a/erpnext/public/js/utils/landed_taxes_and_charges_common.js
+++ b/erpnext/public/js/utils/landed_taxes_and_charges_common.js
@@ -17,6 +17,7 @@ erpnext.landed_cost_taxes_and_charges = {
 								],
 							],
 							company: frm.doc.company,
+							is_group: 0,
 						},
 					};
 				});


### PR DESCRIPTION
`no-docs`