### PR TITLE
fix(return): set default return warehouse

### DIFF
--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -332,6 +332,9 @@ def make_return_doc(
 			doc.select_print_heading = frappe.get_cached_value("Print Heading", _("Debit Note"))
 			if source.tax_withholding_category:
 				doc.set_onload("supplier_tds", source.tax_withholding_category)
+		elif doctype == "Delivery Note":
+			# manual additions to the return should hit the return warehous, too
+			doc.set_warehouse = default_warehouse_for_sales_return
 
 		for tax in doc.get("taxes") or []:
 			if tax.charge_type == "Actual":


### PR DESCRIPTION
This captures the case of manual modifications to the return and ensures
that by default, the correct return warehouse will be set

# Context

- Create a dn return of a packaged good of milk and marmalade
- Return only the milk

To do this:
- remove the package from the return
- manually add the milk; set negative count

---

With this patch, the milk will be returned to the correct default sales return warehouse.
