### PR TITLE
fix: item not coming in quick entry

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -408,12 +408,26 @@ frappe.ui.form.on("Stock Entry", {
 			erpnext.accounts.dimensions.update_dimension(frm, frm.doctype);
 		}
 
+		frm.events.set_route_options_for_new_doc(frm);
+	},
+
+	set_route_options_for_new_doc(frm) {
+		let batch_no_field = frm.get_docfield("items", "batch_no");
+		if (batch_no_field) {
+			batch_no_field.get_route_options_for_new_doc = function (row) {
+				return {
+					item: row.doc.item_code,
+				};
+			};
+		}
+
 		let sbb_field = frm.get_docfield("items", "serial_and_batch_bundle");
 		if (sbb_field) {
 			sbb_field.get_route_options_for_new_doc = (row) => {
 				return {
 					item_code: row.doc.item_code,
 					voucher_type: frm.doc.doctype,
+					warehouse: row.doc.s_warehouse || row.doc.t_warehouse,
 				};
 			};
 		}


### PR DESCRIPTION
While creating a new Batch from the stock entry, the item code has not mapped in the quick entry.


**After Fix**
![stock_entry_batch](https://github.com/frappe/erpnext/assets/8780500/535d0eea-a449-4737-bc19-1fcb512b8290)

