### PR TITLE
feat: added horizontal report view in p&l statement

### DIFF
--- a/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.js
+++ b/erpnext/accounts/report/profit_and_loss_statement/profit_and_loss_statement.js
@@ -16,8 +16,22 @@ frappe.query_reports["Profit and Loss Statement"]["filters"].push({
 	],
 	default: "Report",
 	reqd: 1,
+	on_change: function () {
+		let filter_based_on = frappe.query_reports.get_filter_value("selected_view");
+		frappe.query_reports.toggle_filter_display("report_view", filter_based_on === "Report");
+		frappe.query_reports.refresh();
+	},
 });
 
+frappe.query_reports["Profit and Loss Statement"]["filters"].push({
+	fieldname: "report_view",
+	label: __("Report View"),
+	fieldtype: "Select",
+	options: ["Horizontal", "Vertical"],
+	default: ["Vertical"],
+	reqd: 1,
+	depends_on: "eval:doc.selected_view == 'Report'",
+});
 frappe.query_reports["Profit and Loss Statement"]["filters"].push({
 	fieldname: "accumulated_values",
 	label: __("Accumulated Values"),

--- a/erpnext/public/js/financial_statements.js
+++ b/erpnext/public/js/financial_statements.js
@@ -52,6 +52,35 @@ erpnext.financial_statements = {
 			}
 		}
 
+		if (frappe.query_report.get_filter_value("report_view") == "Horizontal") {
+			if (value == data["expense_account"]) {
+				value = data["expense_indent"] + value;
+				value = $(`<span>${value}</span>`);
+				if (data["expense_indent"] == "") {
+					var $value = $(value).css("font-weight", "bold");
+				} else {
+					$value = $(value);
+				}
+			} else if (value == data["income_account"]) {
+				value = data["income_indent"] + value;
+				value = $(`<span>${value}</span>`);
+				if (data["income_indent"] == "") {
+					$value = $(value).css("font-weight", "bold");
+				} else {
+					$value = $(value);
+				}
+			} else {
+				value = $(`<span>${value}</span>`);
+				$value = $(value);
+			}
+			if (data.warn_if_negative && data[column.fieldname] < 0) {
+				$value.addClass("text-danger");
+			}
+
+			value = $value.wrap("<p></p>").parent().html();
+			return value;
+		}
+
 		if (data && column.fieldname == "account") {
 			value = data.account_name || value;
 
@@ -73,7 +102,7 @@ erpnext.financial_statements = {
 		if (data && !data.parent_account) {
 			value = $(`<span>${value}</span>`);
 
-			var $value = $(value).css("font-weight", "bold");
+			$value = $(value).css("font-weight", "bold");
 			if (data.warn_if_negative && data[column.fieldname] < 0) {
 				$value.addClass("text-danger");
 			}
@@ -230,6 +259,7 @@ function get_filters() {
 			],
 			default: "Yearly",
 			reqd: 1,
+			depends_on: "eval:doc.report_view != 'Horizontal'",
 		},
 		// Note:
 		// If you are modifying this array such that the presentation_currency object

--- a/erpnext/public/js/financial_statements.js
+++ b/erpnext/public/js/financial_statements.js
@@ -53,31 +53,34 @@ erpnext.financial_statements = {
 		}
 
 		if (frappe.query_report.get_filter_value("report_view") == "Horizontal") {
-			if (value == data["expense_account"]) {
-				value = data["expense_indent"] + value;
-				value = $(`<span>${value}</span>`);
-				if (data["expense_indent"] == "") {
-					var $value = $(value).css("font-weight", "bold");
-				} else {
-					$value = $(value);
-				}
-			} else if (value == data["income_account"]) {
-				value = data["income_indent"] + value;
-				value = $(`<span>${value}</span>`);
-				if (data["income_indent"] == "") {
-					$value = $(value).css("font-weight", "bold");
-				} else {
-					$value = $(value);
-				}
+			if (+value) {
+				value = default_formatter(value, row, column, data);
 			} else {
-				value = $(`<span>${value}</span>`);
-				$value = $(value);
+				if (value == data["expense_account"]) {
+					value = data["expense_indent"] + value;
+					value = $(`<span>${value}</span>`);
+					if (data["expense_indent"] == "") {
+						var $value = $(value).css("font-weight", "bold");
+					} else {
+						$value = $(value);
+					}
+				} else if (value == data["income_account"]) {
+					value = data["income_indent"] + value;
+					value = $(`<span>${value}</span>`);
+					if (data["income_indent"] == "") {
+						$value = $(value).css("font-weight", "bold");
+					} else {
+						$value = $(value);
+					}
+				} else {
+					value = $(`<span>${value}</span>`);
+					$value = $(value);
+				}
+				if (data.warn_if_negative && data[column.fieldname] < 0) {
+					$value.addClass("text-danger");
+				}
+				value = $value.wrap("<p></p>").parent().html();
 			}
-			if (data.warn_if_negative && data[column.fieldname] < 0) {
-				$value.addClass("text-danger");
-			}
-
-			value = $value.wrap("<p></p>").parent().html();
 			return value;
 		}
 
@@ -96,7 +99,6 @@ erpnext.financial_statements = {
 			}
 			column.is_tree = true;
 		}
-
 		value = default_formatter(value, row, column, data);
 
 		if (data && !data.parent_account) {


### PR DESCRIPTION
Added filter in Profit & Loss Statement to select report view to vertical or horizontal.
_Before-_
<img width="389" alt="Screenshot 2024-03-26 at 2 51 52 PM" src="https://github.com/frappe/erpnext/assets/142375893/e9c7f23d-177f-4f3c-ab30-845f75430696">
_After-_ 
<img width="389" alt="Screenshot 2024-03-26 at 2 52 27 PM" src="https://github.com/frappe/erpnext/assets/142375893/95a13148-420f-43ce-856f-8daf22e42b19">

So based on the selection P&L will be shown to the user.

**Horizontal View-**

<img width="1059" alt="Screenshot 2024-03-28 at 2 37 03 PM" src="https://github.com/frappe/erpnext/assets/142375893/c8dade43-7d21-475b-8203-306ab7e8e0a8">

closes https://github.com/frappe/erpnext/issues/37445#issue-1935961680
no-docs
