### PR TITLE
fix: incorrect total qty in job card

### DIFF
--- a/erpnext/manufacturing/doctype/job_card/job_card.py
+++ b/erpnext/manufacturing/doctype/job_card/job_card.py
@@ -490,7 +490,7 @@ class JobCard(Document):
 						{
 							"to_time": get_datetime(args.get("complete_time")),
 							"operation": args.get("sub_operation"),
-							"completed_qty": args.get("completed_qty") or 0.0,
+							"completed_qty": (args.get("completed_qty") if last_row.idx == row.idx else 0.0),
 						}
 					)
 		elif args.get("start_time"):


### PR DESCRIPTION
1. Assign two employees to a job card
2. Start and complete the job card with qty as 1
3. The total qty will show as 2