### PR TITLE
fix: validation error for the subcontracting receipt

### DIFF
--- a/erpnext/stock/serial_batch_bundle.py
+++ b/erpnext/stock/serial_batch_bundle.py
@@ -888,11 +888,11 @@ class SerialBatchCreation:
 		return doc
 
 	def validate_qty(self, doc):
-		if doc.type_of_transaction == "Outward":
+		if doc.type_of_transaction == "Outward" and self.actual_qty and doc.total_qty:
 			precision = doc.precision("total_qty")
 
-			total_qty = abs(flt(doc.total_qty, precision))
-			required_qty = abs(flt(self.actual_qty, precision))
+			total_qty = flt(abs(doc.total_qty), precision)
+			required_qty = flt(abs(self.actual_qty), precision)
 
 			if required_qty - total_qty > 0:
 				msg = f"For the item {bold(doc.item_code)}, the Avaliable qty {bold(total_qty)} is less than the Required Qty {bold(required_qty)} in the warehouse {bold(doc.warehouse)}. Please add sufficient qty in the warehouse."


### PR DESCRIPTION
If the FG item qty has changed in the subcontracting receipt then system throwing the negative stock error even though stock is exists.

The negative value rounding off was causing the issue
<img width="313" alt="Screenshot 2024-03-26 at 6 11 06 PM" src="https://github.com/frappe/erpnext/assets/8780500/09152ba2-c4c6-4a79-98a9-8016e80e2d64">


