### PR TITLE
fix: default accounting dimension in journal entry child table

### DIFF
--- a/erpnext/public/js/utils/dimension_tree_filter.js
+++ b/erpnext/public/js/utils/dimension_tree_filter.js
@@ -22,6 +22,7 @@ erpnext.accounts.dimensions = {
 				});
 				me.default_dimensions = r.message[1];
 				me.setup_filters(frm, doctype);
+				me.update_dimension(frm, doctype);
 			},
 		});
 	},


### PR DESCRIPTION
<!--

Some key notes before you open a PR:

 1. Select which branch should this PR be merged in?
 2. PR name follows [convention](http://karma-runner.github.io/4.0/dev/git-commit-msg.html)
 3. All tests pass locally, UI and Unit tests
 4. All business logic and validations must be on the server-side
 5. Update necessary Documentation
 6. Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes


Also, if you're new here

- Documentation Guidelines => https://github.com/frappe/erpnext/wiki/Updating-Documentation

- Contribution Guide => https://github.com/frappe/erpnext/blob/develop/.github/CONTRIBUTING.md

- Pull Request Checklist => https://github.com/frappe/erpnext/wiki/Pull-Request-Checklist

-->

> Please provide enough information so that others can review your pull request:

<!-- You can skip this if you're fixing a typo or updating existing documentation -->

> Explain the **details** for making this change. What existing problem does the pull request solve?

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

> Screenshots/GIFs

<!-- Add images/recordings to better visualize the change: expected/current behviour -->
Accounting dimensions were not applying by default while creating journal entry.
_Before-_ 
<img width="1103" alt="Screenshot 2024-03-26 at 4 40 40 PM" src="https://github.com/frappe/erpnext/assets/142375893/e6f2e9f0-b9f1-42a2-83a3-ca5bb4c444a5">

_After-_ 
<img width="1103" alt="Screenshot 2024-03-26 at 4 46 53 PM" src="https://github.com/frappe/erpnext/assets/142375893/65508460-f532-439b-916a-97c33d576ab7">

no-docs
closes https://github.com/frappe/erpnext/issues/40536#issue-2194448051