### PR TITLE
fix: rate changed on changing of the qty

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1249,19 +1249,20 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 			this.frm.fields_dict.items.grid.toggle_enable("conversion_factor",
 				((item.uom != item.stock_uom) && !frappe.meta.get_docfield(cur_frm.fields_dict.items.grid.doctype, "conversion_factor").read_only)? true: false);
 		}
-
 	}
 
 	qty(doc, cdt, cdn) {
-		let item = frappe.get_doc(cdt, cdn);
-		// item.pricing_rules = ''
-		frappe.run_serially([
-			() => this.remove_pricing_rule_for_item(item),
-			() => this.conversion_factor(doc, cdt, cdn, true),
-			() => this.apply_price_list(item, true), //reapply price list before applying pricing rule
-			() => this.calculate_stock_uom_rate(doc, cdt, cdn),
-			() => this.apply_pricing_rule(item, true)
-		]);
+		if (!this.frm.doc.__onload?.load_after_mapping) {
+			let item = frappe.get_doc(cdt, cdn);
+			// item.pricing_rules = ''
+			frappe.run_serially([
+				() => this.remove_pricing_rule_for_item(item),
+				() => this.conversion_factor(doc, cdt, cdn, true),
+				() => this.apply_price_list(item, true), //reapply price list before applying pricing rule
+				() => this.calculate_stock_uom_rate(doc, cdt, cdn),
+				() => this.apply_pricing_rule(item, true)
+			]);
+		}
 	}
 
 	stock_qty(doc, cdt, cdn) {


### PR DESCRIPTION
Note: This is not a proper fix, but since we don't have another solution, we've decided to go with this approach.

**Steps to replicate the issue**

1. Disable "Update Existing Price List Rate" in the stock settings
2. Make a purchase order for item A with qty 2 and rate as 100 and submit the PO
3. System will create a Item Price with 100 rate
4. Change the Item Price value from 100 to 200
5. Make a purchase receipt against the PO which was created in the step 2
6. Change the qty from 2 to 3, system will change the rate from 100 to 200
7. The rate should be same as Purchase Order rate 

**After Fix**

1. The rate won't be change if the document is not saved
2. If use is changing the qty after saving the document then the rate will be change 