### PR TITLE
fix(ux): Sales Order Stock Reservation Dialog

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -278,6 +278,7 @@ frappe.ui.form.on("Sales Order", {
 					label: __("Items to Reserve"),
 					allow_bulk_edit: false,
 					cannot_add_rows: true,
+					cannot_delete_rows: true,
 					data: [],
 					fields: [
 						{
@@ -346,7 +347,7 @@ frappe.ui.form.on("Sales Order", {
 			],
 			primary_action_label: __("Reserve Stock"),
 			primary_action: () => {
-				var data = { items: dialog.fields_dict.items.grid.data };
+				var data = { items: dialog.fields_dict.items.grid.get_selected_children() };
 
 				if (data.items && data.items.length > 0) {
 					frappe.call({
@@ -363,9 +364,11 @@ frappe.ui.form.on("Sales Order", {
 							frm.reload_doc();
 						},
 					});
-				}
 
-				dialog.hide();
+					dialog.hide();
+				} else {
+					frappe.msgprint(__("Please select items to reserve."));
+				}
 			},
 		});
 
@@ -380,6 +383,7 @@ frappe.ui.form.on("Sales Order", {
 
 				if (unreserved_qty > 0) {
 					dialog.fields_dict.items.df.data.push({
+						__checked: 1,
 						sales_order_item: item.name,
 						item_code: item.item_code,
 						warehouse: item.warehouse,
@@ -404,6 +408,7 @@ frappe.ui.form.on("Sales Order", {
 					label: __("Reserved Stock"),
 					allow_bulk_edit: false,
 					cannot_add_rows: true,
+					cannot_delete_rows: true,
 					in_place_edit: true,
 					data: [],
 					fields: [
@@ -447,7 +452,7 @@ frappe.ui.form.on("Sales Order", {
 			],
 			primary_action_label: __("Unreserve Stock"),
 			primary_action: () => {
-				var data = { sr_entries: dialog.fields_dict.sr_entries.grid.data };
+				var data = { sr_entries: dialog.fields_dict.sr_entries.grid.get_selected_children() };
 
 				if (data.sr_entries && data.sr_entries.length > 0) {
 					frappe.call({
@@ -463,9 +468,11 @@ frappe.ui.form.on("Sales Order", {
 							frm.reload_doc();
 						},
 					});
-				}
 
-				dialog.hide();
+					dialog.hide();
+				} else {
+					frappe.msgprint(__("Please select items to unreserve."));
+				}
 			},
 		});
 


### PR DESCRIPTION
**Source/Ref:** 12241

revert: https://github.com/frappe/erpnext/pull/38261 (Delete button adds an extra step if you do not want to reserve/unreserve all the items).

**Stock Reservation:**

![image](https://github.com/frappe/erpnext/assets/63660334/ea309411-4c42-4541-8dbc-6483d3842a8b)
All rows are selected by default.

**Stock Unreservation:**

![image](https://github.com/frappe/erpnext/assets/63660334/446c0eaa-aef8-413a-ac39-bb76a1c8ee91)

