### PR TITLE
Incorrect cash flow report

### DIFF
--- a/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py
+++ b/erpnext/accounts/report/consolidated_financial_statement/consolidated_financial_statement.py
@@ -272,6 +272,7 @@ def get_account_type_based_data(account_type, companies, fiscal_year, filters):
 	filters.end_date = fiscal_year.year_end_date
 
 	for company in companies:
+		filters.company = company
 		amount = get_account_type_based_gl_data(company, filters)
 
 		if amount and account_type == "Depreciation":

--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -460,7 +460,6 @@ def get_accountwise_gle(filters, accounting_dimensions, gl_entries, gle_map):
 
 	for gle in gl_entries:
 		group_by_value = gle.get(group_by)
-		gle.voucher_type = gle.voucher_type
 		gle.voucher_subtype = _(gle.voucher_subtype)
 		gle.against_voucher_type = _(gle.against_voucher_type)
 		gle.remarks = _(gle.remarks)

--- a/erpnext/accounts/report/general_ledger/general_ledger.py
+++ b/erpnext/accounts/report/general_ledger/general_ledger.py
@@ -460,7 +460,7 @@ def get_accountwise_gle(filters, accounting_dimensions, gl_entries, gle_map):
 
 	for gle in gl_entries:
 		group_by_value = gle.get(group_by)
-		gle.voucher_type = _(gle.voucher_type)
+		gle.voucher_type = gle.voucher_type
 		gle.voucher_subtype = _(gle.voucher_subtype)
 		gle.against_voucher_type = _(gle.against_voucher_type)
 		gle.remarks = _(gle.remarks)


### PR DESCRIPTION

**In consolidated financial statements, when selecting the cash flow filter, only the parent company's data and fields are displayed for all subsidiary companies.**

_Before_
<img width="1119" alt="Screenshot 2024-03-27 at 4 43 33 PM" src="https://github.com/frappe/erpnext/assets/142375893/8e255576-ae6c-48e8-b553-fce9e9e667b0">

_After_
<img width="973" alt="Screenshot 2024-03-27 at 4 44 01 PM" src="https://github.com/frappe/erpnext/assets/142375893/98a117e7-2932-4e3a-9e7f-7dd7eceb2476">
closes https://github.com/frappe/erpnext/issues/40435#issue-2183583854
no-docs