### PR TITLE
fix: exclude some query builder lines from ruff rules

### DIFF
--- a/erpnext/patches/v14_0/update_flag_for_return_invoices.py
+++ b/erpnext/patches/v14_0/update_flag_for_return_invoices.py
@@ -22,7 +22,7 @@ def execute():
 		.where(
 			(si.creation.gte(creation_date))
 			& (si.docstatus == 1)
-			& (si.is_return is True)
+			& (si.is_return == True)  # noqa: E712
 			& (si.return_against.notnull())
 		)
 		.run()
@@ -51,7 +51,7 @@ def execute():
 		.where(
 			(pi.creation.gte(creation_date))
 			& (pi.docstatus == 1)
-			& (pi.is_return is True)
+			& (pi.is_return == True)  # noqa: E712
 			& (pi.return_against.notnull())
 		)
 		.run()

--- a/erpnext/patches/v14_0/update_flag_for_return_invoices.py
+++ b/erpnext/patches/v14_0/update_flag_for_return_invoices.py
@@ -22,7 +22,7 @@ def execute():
 		.where(
 			(si.creation.gte(creation_date))
 			& (si.docstatus == 1)
-			& (si.is_return == True)  # noqa: E712
+			& (si.is_return.eq(True))
 			& (si.return_against.notnull())
 		)
 		.run()
@@ -51,7 +51,7 @@ def execute():
 		.where(
 			(pi.creation.gte(creation_date))
 			& (pi.docstatus == 1)
-			& (pi.is_return == True)  # noqa: E712
+			& (pi.is_return.eq(True))
 			& (pi.return_against.notnull())
 		)
 		.run()

--- a/erpnext/selling/report/customer_wise_item_price/customer_wise_item_price.py
+++ b/erpnext/selling/report/customer_wise_item_price/customer_wise_item_price.py
@@ -62,10 +62,10 @@ def fetch_item_prices(
 	or_conditions = []
 	if items:
 		and_conditions.append(ip.item_code.isin([x.item_code for x in items]))
-		and_conditions.append(ip.selling is True)
+		and_conditions.append(ip.selling == True)  # noqa: E712
 
-		or_conditions.append(ip.customer is None)
-		or_conditions.append(ip.price_list is None)
+		or_conditions.append(ip.customer == None)  # noqa: E711
+		or_conditions.append(ip.price_list == None)  # noqa: E711
 
 		if customer:
 			or_conditions.append(ip.customer == customer)

--- a/erpnext/selling/report/customer_wise_item_price/customer_wise_item_price.py
+++ b/erpnext/selling/report/customer_wise_item_price/customer_wise_item_price.py
@@ -62,10 +62,10 @@ def fetch_item_prices(
 	or_conditions = []
 	if items:
 		and_conditions.append(ip.item_code.isin([x.item_code for x in items]))
-		and_conditions.append(ip.selling == True)  # noqa: E712
+		and_conditions.append(ip.selling.eq(True))
 
-		or_conditions.append(ip.customer == None)  # noqa: E711
-		or_conditions.append(ip.price_list == None)  # noqa: E711
+		or_conditions.append(ip.customer.isnull())
+		or_conditions.append(ip.price_list.isnull())
 
 		if customer:
 			or_conditions.append(ip.customer == customer)


### PR DESCRIPTION
`== None` and `== True` are intentional here

Broke in #40681
