### PR TITLE
Set default warehouse for pos invoice

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_controller.js
+++ b/erpnext/selling/page/point_of_sale/pos_controller.js
@@ -547,6 +547,8 @@ erpnext.PointOfSale.Controller = class {
 
 	async on_cart_update(args) {
 		frappe.dom.freeze();
+		if (this.frm.doc.set_warehouse != this.settings.warehouse)
+			this.frm.doc.set_warehouse = this.settings.warehouse;
 		let item_row = undefined;
 		try {
 			let { field, value, item } = args;


### PR DESCRIPTION
In some cases the Warehouse of POS Profile does't load in POS Invoice, when item is selected on point of sale page.
The error is:
**Item Code: item_code is not available under warehouse .**

This occur because the default warehouse in posprofile, is no loaded correctly on invoice, then is empty.