### PR TITLE
feat: allow to pick manually qty / batches / serial nos

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.json
+++ b/erpnext/stock/doctype/pick_list/pick_list.json
@@ -18,6 +18,7 @@
   "parent_warehouse",
   "consider_rejected_warehouses",
   "get_item_locations",
+  "pick_manually",
   "section_break_6",
   "scan_barcode",
   "column_break_13",
@@ -192,11 +193,18 @@
    "fieldname": "consider_rejected_warehouses",
    "fieldtype": "Check",
    "label": "Consider Rejected Warehouses"
+  },
+  {
+   "default": "0",
+   "description": "If enabled then system won't override the picked qty / batches / serial numbers.",
+   "fieldname": "pick_manually",
+   "fieldtype": "Check",
+   "label": "Pick Manually"
   }
  ],
  "is_submittable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:13.177072",
+ "modified": "2024-03-27 22:49:16.954637",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Pick List",
@@ -264,7 +272,7 @@
    "write": 1
   }
  ],
- "sort_field": "creation",
+ "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],
  "track_changes": 1

--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -41,6 +41,7 @@ class PickList(Document):
 
 		amended_from: DF.Link | None
 		company: DF.Link
+		consider_rejected_warehouses: DF.Check
 		customer: DF.Link | None
 		customer_name: DF.Data | None
 		for_qty: DF.Float
@@ -49,6 +50,7 @@ class PickList(Document):
 		material_request: DF.Link | None
 		naming_series: DF.Literal["STO-PICK-.YYYY.-"]
 		parent_warehouse: DF.Link | None
+		pick_manually: DF.Check
 		prompt_qty: DF.Check
 		purpose: DF.Literal["Material Transfer for Manufacture", "Material Transfer", "Delivery"]
 		scan_barcode: DF.Data | None
@@ -70,7 +72,8 @@ class PickList(Document):
 
 	def before_save(self):
 		self.update_status()
-		self.set_item_locations()
+		if not self.pick_manually:
+			self.set_item_locations()
 
 		if self.get("locations"):
 			self.validate_sales_order_percentage()


### PR DESCRIPTION
In the pick list, if a user manually selects batches, the system overrides the changes upon saving the pick list. To solve this issue added a new checkbox 'Pick Manually' in the pick list. If this checkbox is enabled, the system will not override the user's changes in the pick list.

![pick_manually](https://github.com/frappe/erpnext/assets/8780500/bad2e0a9-5690-490a-b3ce-faffe9afe869)

Fixed https://github.com/frappe/erpnext/issues/40686

Docs https://docs.erpnext.com/docs/user/manual/en/pick-list#4-pick-manually