### PR TITLE
fix: pypika error when executing patch to update flag for return invoices

### DIFF
--- a/erpnext/patches/v14_0/update_flag_for_return_invoices.py
+++ b/erpnext/patches/v14_0/update_flag_for_return_invoices.py
@@ -22,7 +22,7 @@ def execute():
 		.where(
 			(si.creation.gte(creation_date))
 			& (si.docstatus == 1)
-			& (si.is_return is True)
+			& (si.is_return == 1)
 			& (si.return_against.notnull())
 		)
 		.run()
@@ -51,7 +51,7 @@ def execute():
 		.where(
 			(pi.creation.gte(creation_date))
 			& (pi.docstatus == 1)
-			& (pi.is_return is True)
+			& (pi.is_return == 1)
 			& (pi.return_against.notnull())
 		)
 		.run()


### PR DESCRIPTION
### Issue

```py

Traceback with variables (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
      mod_name = 'frappe.utils.bench_helper'
      alter_argv = True
      mod_spec = ModuleSpec(name='frappe.utils.bench_helper', loader=<_frozen_importlib_external.SourceFileLoader object at 0x7fc50c395850>, origin='/home/snv/Park/dev/apps/frappe/frappe/utils/bench_helper.py')
      code = <code object <module> at 0x1a679b0, file "/home/snv/Park/dev/apps/frappe/frappe/utils/bench_helper.py", line 1>
      main_globals = {'__name__': '__main__', '__doc__': None, '__package__': 'frappe.utils', '__loader__': <_frozen_importlib_external.SourceFileLoader object at 0x7fc50c395850>, '__spec__': ModuleSpec(name='frappe.utils.bench_helper', loader=<_frozen_importlib_external.SourceFileLoader object at 0x7fc50c395850>, origin='/home/snv/Park/dev/apps/frappe/frappe/utils/bench_helper.py'), '__annotations__': {}, '__builtins__': <module 'builtins' (built-in)>, '__file__': '/home/snv/Park/dev/apps/frappe/frappe/utils/bench_helper.py', '__cached__': '/home/snv/Park/dev/apps/frappe/frappe/utils/__pycache__/bench_helper.cpython-311.pyc', 'importlib': <module 'importlib' from '/usr/lib/python3.11/importlib/__init__.py'>, 'json': <module 'json' from '/usr/lib/python3.11/json/__init__.py'>, 'os': <module 'os' (frozen)>, 'traceback': <module 'traceback' from '/usr/lib/python3.11/traceback.py'>, 'warnings': <module 'warnings' from '/usr/lib/python3.11/warnings.py'>, 'dedent': <function dedent at 0x7fc50c259300>, 'click': ...
  File "<frozen runpy>", line 88, in _run_code
      code = <code object <module> at 0x1a679b0, file "/home/snv/Park/dev/apps/frappe/frappe/utils/bench_helper.py", line 1>
      run_globals = {'__name__': '__main__', '__doc__': None, '__package__': 'frappe.utils', '__loader__': <_frozen_importlib_external.SourceFileLoader object at 0x7fc50c395850>, '__spec__': ModuleSpec(name='frappe.utils.bench_helper', loader=<_frozen_importlib_external.SourceFileLoader object at 0x7fc50c395850>, origin='/home/snv/Park/dev/apps/frappe/frappe/utils/bench_helper.py'), '__annotations__': {}, '__builtins__': <module 'builtins' (built-in)>, '__file__': '/home/snv/Park/dev/apps/frappe/frappe/utils/bench_helper.py', '__cached__': '/home/snv/Park/dev/apps/frappe/frappe/utils/__pycache__/bench_helper.cpython-311.pyc', 'importlib': <module 'importlib' from '/usr/lib/python3.11/importlib/__init__.py'>, 'json': <module 'json' from '/usr/lib/python3.11/json/__init__.py'>, 'os': <module 'os' (frozen)>, 'traceback': <module 'traceback' from '/usr/lib/python3.11/traceback.py'>, 'warnings': <module 'warnings' from '/usr/lib/python3.11/warnings.py'>, 'dedent': <function dedent at 0x7fc50c259300>, 'click': ...
      init_globals = None
      mod_name = '__main__'
      mod_spec = ModuleSpec(name='frappe.utils.bench_helper', loader=<_frozen_importlib_external.SourceFileLoader object at 0x7fc50c395850>, origin='/home/snv/Park/dev/apps/frappe/frappe/utils/bench_helper.py')
      pkg_name = 'frappe.utils'
      script_name = None
      loader = <_frozen_importlib_external.SourceFileLoader object at 0x7fc50c395850>
      fname = '/home/snv/Park/dev/apps/frappe/frappe/utils/bench_helper.py'
      cached = '/home/snv/Park/dev/apps/frappe/frappe/utils/__pycache__/bench_helper.cpython-311.pyc'
  File "/home/snv/Park/dev/apps/frappe/frappe/utils/bench_helper.py", line 128, in <module>
    main()
      ...skipped... 27 vars
  File "/home/snv/Park/dev/apps/frappe/frappe/utils/bench_helper.py", line 34, in main
    FrappeCommandGroup(commands=commands)(prog_name="bench")
      commands = {'frappe': <FrappeCommandGroup frappe>, 'get-frappe-commands': <Command get-frappe-commands>, 'get-frappe-help': <Command get-frappe-help>}
  File "/home/snv/Park/dev/env/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
      self = <FrappeCommandGroup None>
      args = ()
      kwargs = {'prog_name': 'bench'}
  File "/home/snv/Park/dev/env/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
      self = <FrappeCommandGroup None>
      args = ['frappe', 'migrate']
      prog_name = 'bench'
      complete_var = None
      standalone_mode = True
      windows_expand_args = True
      extra = {}
      ctx = <click.core.Context object at 0x7fc50ae0d510>
  File "/home/snv/Park/dev/env/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
      self = <FrappeCommandGroup None>
      ctx = <click.core.Context object at 0x7fc50ae0d510>
      _process_result = <function MultiCommand.invoke.<locals>._process_result at 0x7fc50af55d00>
      args = ['migrate']
      cmd_name = 'frappe'
      cmd = <FrappeCommandGroup frappe>
      sub_ctx = <click.core.Context object at 0x7fc50af4d5d0>
      __class__ = <class 'click.core.MultiCommand'>
  File "/home/snv/Park/dev/env/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
      self = <FrappeCommandGroup frappe>
      ctx = <click.core.Context object at 0x7fc50af4d5d0>
      _process_result = <function MultiCommand.invoke.<locals>._process_result at 0x7fc50af1e200>
      args = []
      cmd_name = 'migrate'
      cmd = <Command migrate>
      sub_ctx = <click.core.Context object at 0x7fc50b692c90>
      __class__ = <class 'click.core.MultiCommand'>
  File "/home/snv/Park/dev/env/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
      self = <Command migrate>
      ctx = <click.core.Context object at 0x7fc50b692c90>
  File "/home/snv/Park/dev/env/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
      _Context__self = <click.core.Context object at 0x7fc50b692c90>
      _Context__callback = <function migrate at 0x7fc50adbc540>
      args = ()
      kwargs = {'skip_failing': False, 'skip_search_index': False}
      ctx = <click.core.Context object at 0x7fc50b692c90>
  File "/home/snv/Park/dev/env/lib/python3.11/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
      args = ()
      kwargs = {'skip_failing': False, 'skip_search_index': False}
      f = <function migrate at 0x7fc50adbc2c0>
  File "/home/snv/Park/dev/apps/frappe/frappe/commands/__init__.py", line 29, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
      ctx = <click.core.Context object at 0x7fc50b692c90>
      args = ()
      kwargs = {'skip_failing': False, 'skip_search_index': False}
      profile = False
      f = <function migrate at 0x7fc50adbc220>
  File "/home/snv/Park/dev/apps/frappe/frappe/commands/site.py", line 724, in migrate
    ).run(site=site)
      context = {'sites': ['tests.localhost'], 'force': False, 'verbose': False, 'profile': False}
      skip_failing = False
      skip_search_index = False
      activate_by_import = <module 'traceback_with_variables.activate_by_import' from '/home/snv/Park/dev/env/lib/python3.11/site-packages/traceback_with_variables/activate_by_import.py'>
      SiteMigration = <class 'frappe.migrate.SiteMigration'>
      site = 'tests.localhost'
  File "/home/snv/Park/dev/apps/frappe/frappe/migrate.py", line 186, in run
    self.run_schema_updates()
      self = <frappe.migrate.SiteMigration object at 0x7fc4f36c1490>
      site = 'tests.localhost'
      filelock = <function filelock at 0x7fc4f2bbbc40>
  File "/home/snv/Park/dev/apps/frappe/frappe/migrate.py", line 52, in wrapper
    raise e
      args = (<frappe.migrate.SiteMigration object at 0x7fc4f36c1490>,)
      kwargs = {}
      method = <function SiteMigration.run_schema_updates at 0x7fc4f2bbb6a0>
  File "/home/snv/Park/dev/apps/frappe/frappe/migrate.py", line 44, in wrapper
    ret = method(*args, **kwargs)
      args = (<frappe.migrate.SiteMigration object at 0x7fc4f36c1490>,)
      kwargs = {}
      method = <function SiteMigration.run_schema_updates at 0x7fc4f2bbb6a0>
  File "/home/snv/Park/dev/apps/frappe/frappe/migrate.py", line 121, in run_schema_updates
    frappe.modules.patch_handler.run_all(
      self = <frappe.migrate.SiteMigration object at 0x7fc4f36c1490>
  File "/home/snv/Park/dev/apps/frappe/frappe/modules/patch_handler.py", line 76, in run_all
    run_patch(patch)
      skip_failing = False
      patch_type = <PatchType.post_model_sync: 'post_model_sync'>
      executed = {'erpnext.patches.v12_0.add_einvoice_status_field #2021-03-17', 'execute:frappe.db.set_single_value("Document Naming Settings", "default_amend_naming", "Amend Counter")', 'frappe.patches.v14_0.add_manage_subscriptions_in_navbar_settings', 'india_compliance.patches.post_install.update_gst_treatment_for_taxable_nil_transaction_item', "execute:frappe.reload_doc('custom', 'doctype', 'custom_field')", 'execute:from india_compliance.gst_india.setup import create_custom_fields; create_custom_fields()', 'erpnext.patches.v13_0.update_deferred_settings', 'frappe.patches.v13_0.replace_field_target_with_open_in_new_tab', 'erpnext.patches.v12_0.set_produced_qty_field_in_sales_order_for_work_order', 'erpnext.patches.v12_0.update_end_date_and_status_in_email_campaign', 'erpnext.patches.v15_0.rename_depreciation_amount_based_on_num_days_in_month_to_daily_prorata_based', 'erpnext.patches.v14_0.show_loan_management_deprecation_warning', 'erpnext.patches.v12_0.update_price_or_product_discount', "execute:...
      run_patch = <function run_all.<locals>.run_patch at 0x7fc4f2758ea0>
      patches = ["execute:frappe.get_doc('Role', 'Guest').save() # remove desk access", 'frappe.core.doctype.role.patches.v13_set_default_desk_properties', 'frappe.patches.v14_0.update_workspace2 # 06.06.2023', 'frappe.patches.v14_0.drop_data_import_legacy', 'frappe.patches.v14_0.copy_mail_data #08.03.21', 'frappe.patches.v14_0.update_github_endpoints #08-11-2021', 'frappe.patches.v14_0.remove_db_aggregation', 'frappe.patches.v14_0.update_color_names_in_kanban_board_column', 'frappe.patches.v14_0.update_is_system_generated_flag', 'frappe.patches.v14_0.update_auto_account_deletion_duration', 'frappe.patches.v14_0.update_integration_request', 'frappe.patches.v14_0.set_document_expiry_default', 'frappe.patches.v14_0.delete_data_migration_tool', 'frappe.patches.v14_0.set_suspend_email_queue_default', 'frappe.patches.v14_0.different_encryption_key', 'frappe.patches.v14_0.update_multistep_webforms', "execute:frappe.delete_doc('Page', 'background_jobs', ignore_missing=True, force=True)", 'frappe.patches.v14_...
      patch = 'erpnext.patches.v14_0.update_flag_for_return_invoices #2024-03-23'
  File "/home/snv/Park/dev/apps/frappe/frappe/modules/patch_handler.py", line 62, in run_patch
    if not run_single(patchmodule=patch):
      patch = 'erpnext.patches.v14_0.update_flag_for_return_invoices #2024-03-23'
      skip_failing = False
  File "/home/snv/Park/dev/apps/frappe/frappe/modules/patch_handler.py", line 152, in run_single
    return execute_patch(patchmodule, method, methodargs)
      patchmodule = 'erpnext.patches.v14_0.update_flag_for_return_invoices #2024-03-23'
      method = None
      methodargs = None
      force = False
      conf = <LocalProxy unbound>
  File "/home/snv/Park/dev/apps/frappe/frappe/modules/patch_handler.py", line 188, in execute_patch
    _patch()
      patchmodule = 'erpnext.patches.v14_0.update_flag_for_return_invoices #2024-03-23'
      method = None
      methodargs = None
      has_patch_file = True
      patch = 'erpnext.patches.v14_0.update_flag_for_return_invoices.execute'
      docstring = ''
      _patch = <function execute at 0x7fc4f24745e0>
      start_time = 4825.233238494
  File "/home/snv/Park/dev/apps/erpnext/erpnext/patches/v14_0/update_flag_for_return_invoices.py", line 51, in execute
    .where(
      gle = Table('tabGL Entry')
      creation_date = '2024-01-25'
      si = Table('tabSales Invoice')
      cr_notes = ()
      pi = Table('tabPurchase Invoice')
  File "/home/snv/Park/dev/env/lib/python3.11/site-packages/pypika/utils.py", line 50, in _copy
    result = func(self_copy, *args, **kwargs)
      self = SELECT `name` FROM `tabPurchase Invoice`
      args = (<pypika.terms.ComplexCriterion object at 0x7fc4f23b6bd0>,)
      kwargs = {}
      self_copy = SELECT `name` FROM `tabPurchase Invoice`
      copy = <module 'copy' from '/usr/lib/python3.11/copy.py'>
      func = <function QueryBuilder.where at 0x7fc50b84c7c0>
  File "/home/snv/Park/dev/env/lib/python3.11/site-packages/pypika/queries.py", line 930, in where
    if not self._validate_table(criterion):
      self = SELECT `name` FROM `tabPurchase Invoice`
      criterion = <pypika.terms.ComplexCriterion object at 0x7fc4f23b6bd0>
  File "/home/snv/Park/dev/env/lib/python3.11/site-packages/pypika/queries.py", line 1155, in _validate_table
    for field in term.fields_():
      self = SELECT `name` FROM `tabPurchase Invoice`
      term = <pypika.terms.ComplexCriterion object at 0x7fc4f23b6bd0>
      base_tables = [Table('tabPurchase Invoice'), None]
  File "/home/snv/Park/dev/env/lib/python3.11/site-packages/pypika/terms.py", line 57, in fields_
    return set(self.find_(Field))
      self = <pypika.terms.ComplexCriterion object at 0x7fc4f23b6bd0>
  File "/home/snv/Park/dev/env/lib/python3.11/site-packages/pypika/terms.py", line 37, in find_
    return [node for node in self.nodes_() if isinstance(node, type)]
      self = <pypika.terms.ComplexCriterion object at 0x7fc4f23b6bd0>
      type = <class 'pypika.terms.Field'>
  File "/home/snv/Park/dev/env/lib/python3.11/site-packages/pypika/terms.py", line 37, in <listcomp>
    return [node for node in self.nodes_() if isinstance(node, type)]
      .0 = <generator object BasicCriterion.nodes_ at 0x7fc4f25e22c0>
      node = <pypika.terms.ComplexCriterion object at 0x7fc4f23b6790>
      type = <class 'pypika.terms.Field'>
  File "/home/snv/Park/dev/env/lib/python3.11/site-packages/pypika/terms.py", line 743, in nodes_
    yield from self.left.nodes_()
      self = <pypika.terms.ComplexCriterion object at 0x7fc4f23b6bd0>
  File "/home/snv/Park/dev/env/lib/python3.11/site-packages/pypika/terms.py", line 742, in nodes_
    yield from self.right.nodes_()
      self = <pypika.terms.ComplexCriterion object at 0x7fc4f23b6790>
builtins.AttributeError: 'bool' object has no attribute 'nodes_'
```