### PR TITLE
fix: markdown to text editor set for supplier quotation

### DIFF
--- a/erpnext/buying/doctype/supplier_quotation/supplier_quotation.json
+++ b/erpnext/buying/doctype/supplier_quotation/supplier_quotation.json
@@ -462,7 +462,7 @@
   },
   {
    "fieldname": "other_charges_calculation",
-   "fieldtype": "Markdown Editor",
+   "fieldtype": "Text Editor",
    "label": "Taxes and Charges Calculation",
    "no_copy": 1,
    "oldfieldtype": "HTML",
@@ -928,7 +928,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:49.116641",
+ "modified": "2024-03-28 10:20:30.231915",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Supplier Quotation",

--- a/erpnext/buying/doctype/supplier_quotation/supplier_quotation.py
+++ b/erpnext/buying/doctype/supplier_quotation/supplier_quotation.py
@@ -71,7 +71,7 @@ class SupplierQuotation(BuyingController):
 		naming_series: DF.Literal["PUR-SQTN-.YYYY.-"]
 		net_total: DF.Currency
 		opportunity: DF.Link | None
-		other_charges_calculation: DF.MarkdownEditor | None
+		other_charges_calculation: DF.TextEditor | None
 		plc_conversion_rate: DF.Float
 		price_list_currency: DF.Link | None
 		pricing_rules: DF.Table[PricingRuleDetail]


### PR DESCRIPTION
**Version**

ERPNext: v15.18.1 (version-15)
Frappe Framework: v15.19.0 (version-15)

Reference PR: #40563

![image](https://github.com/frappe/erpnext/assets/141945075/8ef9c037-a0df-4eba-b727-bba79ee0aa7f)

fixes: #40694 

**Before**
- The field was still a Markdown Editor instead of a Text Editor.

![image](https://github.com/frappe/erpnext/assets/141945075/74b1e795-9e6d-45e7-b154-dc14d1d8e05b)

<br>

**After:**

![image](https://github.com/frappe/erpnext/assets/141945075/0ae937f5-d0c2-4c36-8f2e-010fc0cc660f)

<br>

Thank You!