### PR TITLE
fix: update sales commission value on update Items

### DIFF
--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -139,7 +139,7 @@ class SellingController(StockController):
 			self.in_words = money_in_words(amount, self.currency)
 
 	def calculate_commission(self):
-		if not self.meta.get_field("commission_rate") or self.docstatus.is_submitted():
+		if not self.meta.get_field("commission_rate"):
 			return
 
 		self.round_floats_in(self, ("amount_eligible_for_commission", "commission_rate"))


### PR DESCRIPTION
**Version:**

ERPNext: v15.18.1 (version-15)
Frappe Framework: v15.19.0 (version-15)

fixes: #40308

**Before:**

- When an item is updated after a sales order is submitted, the Amount Eligible for Commission, Total Commission, and Sales Team table values do not update.


https://github.com/frappe/erpnext/assets/141945075/8a1123ce-1047-4c95-a9dd-38bd044b46e5

<br>

**After:**

- remove the condition `self.docstatus.is_submitted` because if the document is submitted then it will calculate the value.


https://github.com/frappe/erpnext/assets/141945075/401e7cae-b963-4075-9f1c-2f289f451103

<br>

Thank You!