### PR TITLE
chore: allow to override serial batch selector using custom app

### DIFF
--- a/erpnext/public/js/controllers/buying.js
+++ b/erpnext/public/js/controllers/buying.js
@@ -342,7 +342,6 @@ erpnext.buying = {
 			add_serial_batch_bundle(doc, cdt, cdn) {
 				let item = locals[cdt][cdn];
 				let me = this;
-				let path = "assets/erpnext/js/utils/serial_no_batch_selector.js";
 
 				frappe.db.get_value("Item", item.item_code, ["has_batch_no", "has_serial_no"])
 					.then((r) => {
@@ -352,30 +351,28 @@ erpnext.buying = {
 							item.type_of_transaction = item.qty > 0 ? "Inward" : "Outward";
 							item.is_rejected = false;
 
-							frappe.require(path, function() {
-								new erpnext.SerialBatchPackageSelector(
-									me.frm, item, (r) => {
-										if (r) {
-											let qty = Math.abs(r.total_qty);
-											if (doc.is_return) {
-												qty = qty * -1;
-											}
-
-											let update_values = {
-												"serial_and_batch_bundle": r.name,
-												"use_serial_batch_fields": 0,
-												"qty": qty / flt(item.conversion_factor || 1, precision("conversion_factor", item))
-											}
-
-											if (r.warehouse) {
-												update_values["warehouse"] = r.warehouse;
-											}
-
-											frappe.model.set_value(item.doctype, item.name, update_values);
+							new erpnext.SerialBatchPackageSelector(
+								me.frm, item, (r) => {
+									if (r) {
+										let qty = Math.abs(r.total_qty);
+										if (doc.is_return) {
+											qty = qty * -1;
 										}
+
+										let update_values = {
+											"serial_and_batch_bundle": r.name,
+											"use_serial_batch_fields": 0,
+											"qty": qty / flt(item.conversion_factor || 1, precision("conversion_factor", item))
+										}
+
+										if (r.warehouse) {
+											update_values["warehouse"] = r.warehouse;
+										}
+
+										frappe.model.set_value(item.doctype, item.name, update_values);
 									}
-								);
-							});
+								}
+							);
 						}
 					});
 			}
@@ -383,7 +380,6 @@ erpnext.buying = {
 			add_serial_batch_for_rejected_qty(doc, cdt, cdn) {
 				let item = locals[cdt][cdn];
 				let me = this;
-				let path = "assets/erpnext/js/utils/serial_no_batch_selector.js";
 
 				frappe.db.get_value("Item", item.item_code, ["has_batch_no", "has_serial_no"])
 					.then((r) => {
@@ -393,30 +389,28 @@ erpnext.buying = {
 							item.type_of_transaction = item.qty > 0 ? "Inward" : "Outward";
 							item.is_rejected = true;
 
-							frappe.require(path, function() {
-								new erpnext.SerialBatchPackageSelector(
-									me.frm, item, (r) => {
-										if (r) {
-											let qty = Math.abs(r.total_qty);
-											if (doc.is_return) {
-												qty = qty * -1;
-											}
-
-											let update_values = {
-												"serial_and_batch_bundle": r.name,
-												"use_serial_batch_fields": 0,
-												"rejected_qty": qty / flt(item.conversion_factor || 1, precision("conversion_factor", item))
-											}
-
-											if (r.warehouse) {
-												update_values["rejected_warehouse"] = r.warehouse;
-											}
-
-											frappe.model.set_value(item.doctype, item.name, update_values);
+							new erpnext.SerialBatchPackageSelector(
+								me.frm, item, (r) => {
+									if (r) {
+										let qty = Math.abs(r.total_qty);
+										if (doc.is_return) {
+											qty = qty * -1;
 										}
+
+										let update_values = {
+											"serial_and_batch_bundle": r.name,
+											"use_serial_batch_fields": 0,
+											"rejected_qty": qty / flt(item.conversion_factor || 1, precision("conversion_factor", item))
+										}
+
+										if (r.warehouse) {
+											update_values["rejected_warehouse"] = r.warehouse;
+										}
+
+										frappe.model.set_value(item.doctype, item.name, update_values);
 									}
-								);
-							});
+								}
+							);
 						}
 					});
 			}

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -2508,27 +2508,25 @@ erpnext.show_serial_batch_selector = function (frm, item_row, callback, on_close
 		}
 	}
 
-	frappe.require("assets/erpnext/js/utils/serial_no_batch_selector.js", function() {
-		if (["Sales Invoice", "Delivery Note"].includes(frm.doc.doctype)) {
-			item_row.type_of_transaction = frm.doc.is_return ? "Inward" : "Outward";
-		} else {
-			item_row.type_of_transaction = frm.doc.is_return ? "Outward" : "Inward";
-		}
+	if (["Sales Invoice", "Delivery Note"].includes(frm.doc.doctype)) {
+		item_row.type_of_transaction = frm.doc.is_return ? "Inward" : "Outward";
+	} else {
+		item_row.type_of_transaction = frm.doc.is_return ? "Outward" : "Inward";
+	}
 
-		new erpnext.SerialBatchPackageSelector(frm, item_row, (r) => {
-			if (r) {
-				let update_values = {
-					"serial_and_batch_bundle": r.name,
-					"qty": Math.abs(r.total_qty)
-				}
-
-				if (r.warehouse) {
-					update_values[warehouse_field] = r.warehouse;
-				}
-
-				frappe.model.set_value(item_row.doctype, item_row.name, update_values);
+	new erpnext.SerialBatchPackageSelector(frm, item_row, (r) => {
+		if (r) {
+			let update_values = {
+				"serial_and_batch_bundle": r.name,
+				"qty": Math.abs(r.total_qty)
 			}
-		});
+
+			if (r.warehouse) {
+				update_values[warehouse_field] = r.warehouse;
+			}
+
+			frappe.model.set_value(item_row.doctype, item_row.name, update_values);
+		}
 	});
 }
 

--- a/erpnext/public/js/erpnext.bundle.js
+++ b/erpnext/public/js/erpnext.bundle.js
@@ -4,6 +4,7 @@ import "./queries";
 import "./sms_manager";
 import "./utils/party";
 import "./controllers/stock_controller";
+import "./utils/serial_no_batch_selector";
 import "./payment/payments";
 import "./templates/visual_plant_floor_template.html";
 import "./plant_floor_visual/visual_plant";

--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -430,25 +430,23 @@ $.extend(erpnext.utils, {
 			item_row.has_batch_no = r.message.has_batch_no;
 			item_row.has_serial_no = r.message.has_serial_no;
 
-			frappe.require("assets/erpnext/js/utils/serial_no_batch_selector.js", function () {
-				new erpnext.SerialBatchPackageSelector(frm, item_row, (r) => {
-					if (r) {
-						let update_values = {
-							serial_and_batch_bundle: r.name,
-							qty: Math.abs(r.total_qty),
-						};
+			new erpnext.SerialBatchPackageSelector(frm, item_row, (r) => {
+				if (r) {
+					let update_values = {
+						serial_and_batch_bundle: r.name,
+						qty: Math.abs(r.total_qty),
+					};
 
-						if (!warehouse_field) {
-							warehouse_field = "warehouse";
-						}
-
-						if (r.warehouse) {
-							update_values[warehouse_field] = r.warehouse;
-						}
-
-						frappe.model.set_value(item_row.doctype, item_row.name, update_values);
+					if (!warehouse_field) {
+						warehouse_field = "warehouse";
 					}
-				});
+
+					if (r.warehouse) {
+						update_values[warehouse_field] = r.warehouse;
+					}
+
+					frappe.model.set_value(item_row.doctype, item_row.name, update_values);
+				}
 			});
 		});
 	},

--- a/erpnext/public/js/utils/sales_common.js
+++ b/erpnext/public/js/utils/sales_common.js
@@ -350,7 +350,6 @@ erpnext.sales_common = {
 			pick_serial_and_batch(doc, cdt, cdn) {
 				let item = locals[cdt][cdn];
 				let me = this;
-				let path = "assets/erpnext/js/utils/serial_no_batch_selector.js";
 
 				frappe.db.get_value("Item", item.item_code, ["has_batch_no", "has_serial_no"]).then((r) => {
 					if (r.message && (r.message.has_batch_no || r.message.has_serial_no)) {
@@ -364,26 +363,24 @@ erpnext.sales_common = {
 							item.title = __("Select Serial and Batch");
 						}
 
-						frappe.require(path, function () {
-							new erpnext.SerialBatchPackageSelector(me.frm, item, (r) => {
-								if (r) {
-									let qty = Math.abs(r.total_qty);
-									if (doc.is_return) {
-										qty = qty * -1;
-									}
-
-									frappe.model.set_value(item.doctype, item.name, {
-										serial_and_batch_bundle: r.name,
-										use_serial_batch_fields: 0,
-										qty:
-											qty /
-											flt(
-												item.conversion_factor || 1,
-												precision("conversion_factor", item)
-											),
-									});
+						new erpnext.SerialBatchPackageSelector(me.frm, item, (r) => {
+							if (r) {
+								let qty = Math.abs(r.total_qty);
+								if (doc.is_return) {
+									qty = qty * -1;
 								}
-							});
+
+								frappe.model.set_value(item.doctype, item.name, {
+									serial_and_batch_bundle: r.name,
+									use_serial_batch_fields: 0,
+									qty:
+										qty /
+										flt(
+											item.conversion_factor || 1,
+											precision("conversion_factor", item)
+										),
+								});
+							}
 						});
 					}
 				});

--- a/erpnext/selling/page/point_of_sale/pos_item_details.js
+++ b/erpnext/selling/page/point_of_sale/pos_item_details.js
@@ -394,19 +394,17 @@ erpnext.PointOfSale.ItemDetails = class {
 
 	bind_auto_serial_fetch_event() {
 		this.$form_container.on("click", ".auto-fetch-btn", () => {
-			frappe.require("assets/erpnext/js/utils/serial_no_batch_selector.js", () => {
-				let frm = this.events.get_frm();
-				let item_row = this.item_row;
-				item_row.type_of_transaction = "Outward";
+			let frm = this.events.get_frm();
+			let item_row = this.item_row;
+			item_row.type_of_transaction = "Outward";
 
-				new erpnext.SerialBatchPackageSelector(frm, item_row, (r) => {
-					if (r) {
-						frappe.model.set_value(item_row.doctype, item_row.name, {
-							serial_and_batch_bundle: r.name,
-							qty: Math.abs(r.total_qty),
-						});
-					}
-				});
+			new erpnext.SerialBatchPackageSelector(frm, item_row, (r) => {
+				if (r) {
+					frappe.model.set_value(item_row.doctype, item_row.name, {
+						serial_and_batch_bundle: r.name,
+						qty: Math.abs(r.total_qty),
+					});
+				}
 			});
 		});
 	}

--- a/erpnext/stock/doctype/pick_list/pick_list.js
+++ b/erpnext/stock/doctype/pick_list/pick_list.js
@@ -355,19 +355,15 @@ frappe.ui.form.on("Pick List Item", {
 					item.title = __("Select Serial and Batch");
 				}
 
-				frappe.require(path, function () {
-					new erpnext.SerialBatchPackageSelector(frm, item, (r) => {
-						if (r) {
-							let qty = Math.abs(r.total_qty);
-							frappe.model.set_value(item.doctype, item.name, {
-								serial_and_batch_bundle: r.name,
-								use_serial_batch_fields: 0,
-								qty:
-									qty /
-									flt(item.conversion_factor || 1, precision("conversion_factor", item)),
-							});
-						}
-					});
+				new erpnext.SerialBatchPackageSelector(frm, item, (r) => {
+					if (r) {
+						let qty = Math.abs(r.total_qty);
+						frappe.model.set_value(item.doctype, item.name, {
+							serial_and_batch_bundle: r.name,
+							use_serial_batch_fields: 0,
+							qty: qty / flt(item.conversion_factor || 1, precision("conversion_factor", item)),
+						});
+					}
 				});
 			}
 		});

--- a/erpnext/stock/doctype/stock_entry/stock_entry.js
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.js
@@ -1319,18 +1319,16 @@ erpnext.stock.select_batch_and_serial_no = (frm, item) => {
 			item.has_batch_no = r.message.has_batch_no;
 			item.type_of_transaction = item.s_warehouse ? "Outward" : "Inward";
 
-			frappe.require(path, function () {
-				new erpnext.SerialBatchPackageSelector(frm, item, (r) => {
-					if (r) {
-						frappe.model.set_value(item.doctype, item.name, {
-							serial_and_batch_bundle: r.name,
-							use_serial_batch_fields: 0,
-							qty:
-								Math.abs(r.total_qty) /
-								flt(item.conversion_factor || 1, precision("conversion_factor", item)),
-						});
-					}
-				});
+			new erpnext.SerialBatchPackageSelector(frm, item, (r) => {
+				if (r) {
+					frappe.model.set_value(item.doctype, item.name, {
+						serial_and_batch_bundle: r.name,
+						use_serial_batch_fields: 0,
+						qty:
+							Math.abs(r.total_qty) /
+							flt(item.conversion_factor || 1, precision("conversion_factor", item)),
+					});
+				}
 			});
 		}
 	});


### PR DESCRIPTION
- Added serial_no_batch_selector in the erpnext.bundle.js 

- With this change there is no need to explicitly define the path to include the erpnext.SerialBatchPackageSelector class in the JS code. 
- Also using custom app, developers can override the erpnext.SerialBatchPackageSelector class