### PR TITLE
fix: cost center shouldn't update debit/credit in Exc gain/loss JV

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.js
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.js
@@ -453,7 +453,10 @@ frappe.ui.form.on("Journal Entry Account", {
 		}
 	},
 	cost_center: function (frm, dt, dn) {
-		erpnext.journal_entry.set_account_details(frm, dt, dn);
+		// Don't reset for Gain/Loss type journals, as it will make Debit and Credit values '0'
+		if (frm.doc.voucher_type != "Exchange Gain Or Loss") {
+			erpnext.journal_entry.set_account_details(frm, dt, dn);
+		}
 	},
 
 	account: function (frm, dt, dn) {


### PR DESCRIPTION
Updating Cost Center in Journal Entry triggers a debit/credit recalculation. This causes issue on 'Exchange Gain Or Loss' generated by Exchange Rate Revaluation, as this is a JV type has the ability to hold values only in one currency, this recalculation make both the currencies '0'.

<img width="1552" alt="Screenshot 2024-03-29 at 11 29 04 AM" src="https://github.com/frappe/erpnext/assets/3272205/9c299abd-60d4-4779-8ec7-36e9b14ea884">
<img width="1552" alt="Screenshot 2024-03-29 at 11 29 28 AM" src="https://github.com/frappe/erpnext/assets/3272205/cf10a087-e07d-4163-a5f9-8148e20184ec">
