### PR TITLE
fix: tests with payment gateway

### DIFF
--- a/erpnext/accounts/doctype/payment_gateway_account/test_payment_gateway_account.py
+++ b/erpnext/accounts/doctype/payment_gateway_account/test_payment_gateway_account.py
@@ -5,6 +5,8 @@ import unittest
 
 # test_records = frappe.get_test_records('Payment Gateway Account')
 
+test_ignore = ["Payment Gateway"]
+
 
 class TestPaymentGatewayAccount(unittest.TestCase):
 	pass

--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -149,35 +149,37 @@ class PaymentRequest(Document):
 					).format(self.grand_total, amount)
 				)
 
-	def on_submit(self):
-		if self.payment_request_type == "Outward":
-			self.db_set("status", "Initiated")
-			return
-		elif self.payment_request_type == "Inward":
-			self.db_set("status", "Requested")
-
-		send_mail = self.payment_gateway_validation() if self.payment_gateway else None
+	def on_change(self):
 		ref_doc = frappe.get_doc(self.reference_doctype, self.reference_name)
-
-		if (
-			hasattr(ref_doc, "order_type") and ref_doc.order_type == "Shopping Cart"
-		) or self.flags.mute_email:
-			send_mail = False
-
-		if send_mail and self.payment_channel != "Phone":
-			self.set_payment_request_url()
-			self.send_email()
-			self.make_communication_entry()
-
-		elif self.payment_channel == "Phone":
-			self.request_phone_payment()
-
 		advance_payment_doctypes = frappe.get_hooks("advance_payment_receivable_doctypes") + frappe.get_hooks(
 			"advance_payment_payable_doctypes"
 		)
 		if self.reference_doctype in advance_payment_doctypes:
 			# set advance payment status
-			ref_doc.set_total_advance_paid()
+			ref_doc.set_advance_payment_status()
+
+	def on_submit(self):
+		if self.payment_request_type == "Outward":
+			self.db_set("status", "Initiated")
+		elif self.payment_request_type == "Inward":
+			self.db_set("status", "Requested")
+
+		if self.payment_request_type == "Inward":
+			send_mail = self.payment_gateway_validation() if self.payment_gateway else None
+			ref_doc = frappe.get_doc(self.reference_doctype, self.reference_name)
+
+			if (
+				hasattr(ref_doc, "order_type") and ref_doc.order_type == "Shopping Cart"
+			) or self.flags.mute_email:
+				send_mail = False
+
+			if send_mail and self.payment_channel != "Phone":
+				self.set_payment_request_url()
+				self.send_email()
+				self.make_communication_entry()
+
+			elif self.payment_channel == "Phone":
+				self.request_phone_payment()
 
 	def request_phone_payment(self):
 		controller = _get_payment_gateway_controller(self.payment_gateway)
@@ -216,14 +218,6 @@ class PaymentRequest(Document):
 	def on_cancel(self):
 		self.check_if_payment_entry_exists()
 		self.set_as_cancelled()
-
-		ref_doc = frappe.get_doc(self.reference_doctype, self.reference_name)
-		advance_payment_doctypes = frappe.get_hooks("advance_payment_receivable_doctypes") + frappe.get_hooks(
-			"advance_payment_payable_doctypes"
-		)
-		if self.reference_doctype in advance_payment_doctypes:
-			# set advance payment status
-			ref_doc.set_total_advance_paid()
 
 	def make_invoice(self):
 		ref_doc = frappe.get_doc(self.reference_doctype, self.reference_name)

--- a/erpnext/buying/doctype/purchase_order/test_purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/test_purchase_order.py
@@ -1127,10 +1127,17 @@ class TestPurchaseOrder(FrappeTestCase):
 		po = create_purchase_order()
 		self.assertEqual(frappe.db.get_value(po.doctype, po.name, "advance_payment_status"), "Not Initiated")
 
-		pr = make_payment_request(dt=po.doctype, dn=po.name, submit_doc=True, return_doc=True)
+		pr = make_payment_request(
+			dt=po.doctype, dn=po.name, submit_doc=True, return_doc=True, payment_request_type="Outward"
+		)
+
+		po.reload()
 		self.assertEqual(frappe.db.get_value(po.doctype, po.name, "advance_payment_status"), "Initiated")
 
 		pe = get_payment_entry(po.doctype, po.name).save().submit()
+
+		pr.reload()
+		self.assertEqual(pr.status, "Paid")
 		self.assertEqual(frappe.db.get_value(po.doctype, po.name, "advance_payment_status"), "Fully Paid")
 
 		pe.reload()


### PR DESCRIPTION
- fix(pr): set adv. pay. status base on PR stati
- fix: individual accounting tests


**Designed to fix** (tested and works)
```console
❯ bench run-tests --doctype "Purchase Order" --test test_purchase_order_advance_payment_status
/nix/store/h2573jwn91is8i7z1ljmg8l4mf2z15xl-python3-3.11.8-env/lib/python3.11/site-packages/passlib/utils/__init__.py:854: DeprecationWarning: 'crypt' is deprecated and slated for removal in Python 3.13
  from crypt import crypt as _crypt
Traceback (most recent call last):
  File "/nix/store/l52q9549z2klm394bcfz969lknr3w5bn-devshell-dir/bin/bench", line 32, in <module>
    click.Group(commands=commands)(prog_name="bench")
  File "/nix/store/h2573jwn91is8i7z1ljmg8l4mf2z15xl-python3-3.11.8-env/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/h2573jwn91is8i7z1ljmg8l4mf2z15xl-python3-3.11.8-env/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/nix/store/h2573jwn91is8i7z1ljmg8l4mf2z15xl-python3-3.11.8-env/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/h2573jwn91is8i7z1ljmg8l4mf2z15xl-python3-3.11.8-env/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/h2573jwn91is8i7z1ljmg8l4mf2z15xl-python3-3.11.8-env/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/h2573jwn91is8i7z1ljmg8l4mf2z15xl-python3-3.11.8-env/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/h2573jwn91is8i7z1ljmg8l4mf2z15xl-python3-3.11.8-env/lib/python3.11/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/blaggacao/src/gitlab.com/pristina/infraestructura/apps/frappe/frappe/commands/__init__.py", line 29, in _func
    ret = f(frappe._dict(ctx.obj), *args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/blaggacao/src/gitlab.com/pristina/infraestructura/apps/frappe/frappe/commands/utils.py", line 797, in run_tests
    ret = frappe.test_runner.main(
          ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/blaggacao/src/gitlab.com/pristina/infraestructura/apps/frappe/frappe/test_runner.py", line 95, in main
    ret = run_tests_for_doctype(
          ^^^^^^^^^^^^^^^^^^^^^^
  File "/home/blaggacao/src/gitlab.com/pristina/infraestructura/apps/frappe/frappe/test_runner.py", line 231, in run_tests_for_doctype
    make_test_records(doctype, verbose=verbose, force=force, commit=True)
  File "/home/blaggacao/src/gitlab.com/pristina/infraestructura/apps/frappe/frappe/test_runner.py", line 361, in make_test_records
    make_test_records(options, verbose, force, commit=commit)
  File "/home/blaggacao/src/gitlab.com/pristina/infraestructura/apps/frappe/frappe/test_runner.py", line 361, in make_test_records
    make_test_records(options, verbose, force, commit=commit)
  File "/home/blaggacao/src/gitlab.com/pristina/infraestructura/apps/frappe/frappe/test_runner.py", line 361, in make_test_records
    make_test_records(options, verbose, force, commit=commit)
  [Previous line repeated 3 more times]
  File "/home/blaggacao/src/gitlab.com/pristina/infraestructura/apps/frappe/frappe/test_runner.py", line 355, in make_test_records
    for options in get_dependencies(doctype):
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/blaggacao/src/gitlab.com/pristina/infraestructura/apps/frappe/frappe/test_runner.py", line 378, in get_dependencies
    module, test_module = get_modules(doctype)
                          ^^^^^^^^^^^^^^^^^^^^
  File "/home/blaggacao/src/gitlab.com/pristina/infraestructura/apps/frappe/frappe/test_runner.py", line 368, in get_modules
    test_module = load_doctype_module(doctype, module, "test_")
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/blaggacao/src/gitlab.com/pristina/infraestructura/apps/frappe/frappe/modules/utils.py", line 229, in load_doctype_module
    module = module or get_doctype_module(doctype)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/blaggacao/src/gitlab.com/pristina/infraestructura/apps/frappe/frappe/modules/utils.py", line 220, in get_doctype_module
    frappe.throw(_("DocType {} not found").format(doctype), exc=frappe.DoesNotExistError)
  File "/home/blaggacao/src/gitlab.com/pristina/infraestructura/apps/frappe/frappe/__init__.py", line 683, in throw
    msgprint(
  File "/home/blaggacao/src/gitlab.com/pristina/infraestructura/apps/frappe/frappe/__init__.py", line 648, in msgprint
    _raise_exception()
  File "/home/blaggacao/src/gitlab.com/pristina/infraestructura/apps/frappe/frappe/__init__.py", line 599, in _raise_exception
    raise exc
frappe.exceptions.DoesNotExistError: DocType Payment Gateway not found```
```
