### PR TITLE
feat: significant enhancements to sales analytics report to support charts

### DIFF
--- a/erpnext/selling/report/sales_analytics/sales_analytics.js
+++ b/erpnext/selling/report/sales_analytics/sales_analytics.js
@@ -21,9 +21,17 @@ frappe.query_reports["Sales Analytics"] = {
 		},
 		{
 			fieldname: "doc_type",
-			label: __("based_on"),
+			label: __("Based On"),
 			fieldtype: "Select",
-			options: ["Sales Order", "Delivery Note", "Sales Invoice"],
+			options: [
+				"All",
+				"Quotation",
+				"Sales Order",
+				"Delivery Note",
+				"Sales Invoice",
+				"Sales Invoice (due)",
+				"Payment Entry",
+			],
 			default: "Sales Invoice",
 			reqd: 1,
 		},
@@ -42,14 +50,18 @@ frappe.query_reports["Sales Analytics"] = {
 			fieldname: "from_date",
 			label: __("From Date"),
 			fieldtype: "Date",
-			default: erpnext.utils.get_fiscal_year(frappe.datetime.get_today(), true)[1],
+			default:
+				frappe.defaults.get_user_default("sales_start_date") ||
+				erpnext.utils.get_fiscal_year(frappe.datetime.get_today(), true)[1],
 			reqd: 1,
 		},
 		{
 			fieldname: "to_date",
 			label: __("To Date"),
 			fieldtype: "Date",
-			default: erpnext.utils.get_fiscal_year(frappe.datetime.get_today(), true)[2],
+			default:
+				frappe.defaults.get_user_default("sales_end_date") ||
+				erpnext.utils.get_fiscal_year(frappe.datetime.get_today(), true)[2],
 			reqd: 1,
 		},
 		{
@@ -71,6 +83,19 @@ frappe.query_reports["Sales Analytics"] = {
 				{ value: "Yearly", label: __("Yearly") },
 			],
 			default: "Monthly",
+			reqd: 1,
+		},
+		{
+			fieldname: "curves",
+			label: __("Curves"),
+			fieldtype: "Select",
+			options: [
+				{ value: "select", label: __("Select") },
+				{ value: "all", label: __("All") },
+				{ value: "non-zeros", label: __("Non-Zeros") },
+				{ value: "total", label: __("Total Only") },
+			],
+			default: "select",
 			reqd: 1,
 		},
 	],


### PR DESCRIPTION
The Sales Analytics report currently only shows charts if the data rows are selected in the datatable in the browser. This means it is incompatible with dashboard charts which expect the data to be delivered server-side.

The data is also arranged in the wrong orientation for dashboard charts which expect the X axis labels to be in the data vertically, but are horizontal in this report, which means you cannot use the report data output either.

All added features:

- An extra 'Curves' filter which defaults to 'Select' to support old behaviour, but has the following additional modes to support dashboard charts (generated server-side):

    - All - shows all data rows on the chart
    - Non-Zeros - shows only non-zero data rows
    - Total Only - shows a single curve which is the total of the data rows

- A special 'All' document mode (shown below) which shows all Sales cycle documents in Customer, Value and Total Only mode, over the time period
- Quotations supported
- Sales Invoice (by due date) supported
- Payment Entry supported
- The Fiscal Year dynamic from/to filter can be overridden by setting two user defaults in JS:

```javascript
// used by sales_analytics report to give a custom time period in charts
const wk = frappe.datetime.week_start();
frappe.defaults.set_user_default_local('sales_start_date', frappe.datetime.add_months(wk,-2));
frappe.defaults.set_user_default_local('sales_end_date',   frappe.datetime.add_months(wk,1));
```

One known issue: Payment entries do not 'know about' the taxes (the other reports show net amounts), so will always be more than the other document values.

![Screen Shot 2024-03-29 at 18 19 47](https://github.com/frappe/erpnext/assets/110036763/7122d7a3-7202-44ac-b206-b267418c58fd)

fixes #40751 

version-15-hotfix
(not compatible with version-14-hotfix due to missing erpnext.utils.get_fiscal_year)