### PR TITLE
fix: outstanding amount field out if conditions

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -1922,7 +1922,7 @@ def get_reference_details(reference_doctype, reference_name, party_account_curre
 			)
 		else:
 			exchange_rate = 1
-			outstanding_amount = get_outstanding_on_journal_entry(reference_name)
+		outstanding_amount = get_outstanding_on_journal_entry(reference_name)
 
 	elif reference_doctype != "Journal Entry":
 		if not total_amount:


### PR DESCRIPTION

it should be the calculated outstanding amount field is out conditions because if the reference doctype is a journal entry and is multi-currency the outstanding amount is not calculated in the reference of  payment entry doctype