### PR TITLE
fix: Warehouse linked company name in multicompany setup

### DIFF
--- a/erpnext/stock/doctype/warehouse/warehouse.js
+++ b/erpnext/stock/doctype/warehouse/warehouse.js
@@ -49,6 +49,7 @@ frappe.ui.form.on("Warehouse", {
 			frm.add_custom_button(__("Stock Balance"), function () {
 				frappe.set_route("query-report", "Stock Balance", {
 					warehouse: frm.doc.name,
+					company: frm.doc.company,
 				});
 			});
 


### PR DESCRIPTION
![image](https://github.com/frappe/erpnext/assets/56191568/0bbd5a13-8211-4767-8fea-aadabcc735a1)

If company linked to warehouse is other then default company, Stock balance report filter company name should be fetch from warehouse instead default company name.