### PR TITLE
fix: incorrect margin calculation

### DIFF
--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -33,6 +33,7 @@ class calculate_taxes_and_totals:
 		self._items = self.filter_rows() if self.doc.doctype == "Quotation" else self.doc.get("items")
 
 		get_round_off_applicable_accounts(self.doc.company, frappe.flags.round_off_applicable_accounts)
+
 		self.calculate()
 
 	def filter_rows(self):
@@ -45,6 +46,7 @@ class calculate_taxes_and_totals:
 			return
 
 		self.discount_amount_applied = False
+
 		self._calculate()
 
 		if self.doc.meta.get_field("discount_amount"):
@@ -163,12 +165,12 @@ class calculate_taxes_and_totals:
 							item.price_list_rate * (1.0 - (item.discount_percentage / 100.0)),
 							item.precision("rate"),
 						)
-
+						
 						item.discount_amount = item.price_list_rate * (item.discount_percentage / 100.0)
 
 					elif item.discount_amount and item.pricing_rules:
 						item.rate = item.price_list_rate - item.discount_amount
-
+				
 				if item.doctype in [
 					"Quotation Item",
 					"Sales Order Item",
@@ -193,6 +195,7 @@ class calculate_taxes_and_totals:
 
 					elif flt(item.price_list_rate) > 0:
 						item.discount_amount = item.price_list_rate - item.rate
+
 				elif flt(item.price_list_rate) > 0 and not item.discount_amount:
 					item.discount_amount = item.price_list_rate - item.rate
 
@@ -216,6 +219,7 @@ class calculate_taxes_and_totals:
 				)
 
 				item.item_tax_amount = 0.0
+				
 
 	def _set_in_company_currency(self, doc, fields):
 		"""set values in base currency"""
@@ -922,12 +926,14 @@ class calculate_taxes_and_totals:
 					item.margin_type = None
 					item.margin_rate_or_amount = 0.0
 
+			margin_value = 0
 			if not item.pricing_rules and flt(item.rate) > flt(item.price_list_rate):
 				item.margin_type = "Amount"
 				item.margin_rate_or_amount = flt(
 					item.rate - item.price_list_rate, item.precision("margin_rate_or_amount")
 				)
 				item.rate_with_margin = item.rate
+				margin_value = item.rate - item.price_list_rate
 
 			elif item.margin_type and item.margin_rate_or_amount:
 				margin_value = (
@@ -935,8 +941,9 @@ class calculate_taxes_and_totals:
 					if item.margin_type == "Amount"
 					else flt(item.price_list_rate) * flt(item.margin_rate_or_amount) / 100
 				)
-				rate_with_margin = flt(item.price_list_rate) + flt(margin_value)
-				base_rate_with_margin = flt(rate_with_margin) * flt(self.doc.conversion_rate)
+
+			rate_with_margin = flt(item.price_list_rate) + flt(margin_value)
+			base_rate_with_margin = flt(rate_with_margin) * flt(self.doc.conversion_rate)
 
 		return rate_with_margin, base_rate_with_margin
 

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -163,12 +163,12 @@ class calculate_taxes_and_totals:
 							item.price_list_rate * (1.0 - (item.discount_percentage / 100.0)),
 							item.precision("rate"),
 						)
-						
+
 						item.discount_amount = item.price_list_rate * (item.discount_percentage / 100.0)
 
 					elif item.discount_amount and item.pricing_rules:
 						item.rate = item.price_list_rate - item.discount_amount
-				
+
 				if item.doctype in [
 					"Quotation Item",
 					"Sales Order Item",

--- a/erpnext/controllers/taxes_and_totals.py
+++ b/erpnext/controllers/taxes_and_totals.py
@@ -33,7 +33,6 @@ class calculate_taxes_and_totals:
 		self._items = self.filter_rows() if self.doc.doctype == "Quotation" else self.doc.get("items")
 
 		get_round_off_applicable_accounts(self.doc.company, frappe.flags.round_off_applicable_accounts)
-
 		self.calculate()
 
 	def filter_rows(self):
@@ -46,7 +45,6 @@ class calculate_taxes_and_totals:
 			return
 
 		self.discount_amount_applied = False
-
 		self._calculate()
 
 		if self.doc.meta.get_field("discount_amount"):
@@ -219,7 +217,6 @@ class calculate_taxes_and_totals:
 				)
 
 				item.item_tax_amount = 0.0
-				
 
 	def _set_in_company_currency(self, doc, fields):
 		"""set values in base currency"""

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -2130,13 +2130,12 @@ class TestSalesOrder(FrappeTestCase):
 
 	def test_discount_on_rate_greater_than_price_list(self):
 		item = make_item("_Discount Test")
-		so = make_sales_order(
-			item_code=item.name, qty=1, rate=200, price_list_rate=100, do_not_submit=True
-		)
+		so = make_sales_order(item_code=item.name, qty=1, rate=200, price_list_rate=100, do_not_submit=True)
 		so[0].rate = 120
 		so.save()
 		self.assertEqual(so[0].margin_rate_or_amount, 20)
 		self.assertEqual(so[0].discount_amount, 0)
+
 
 def automatically_fetch_payment_terms(enable=1):
 	accounts_settings = frappe.get_doc("Accounts Settings")

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -2128,6 +2128,15 @@ class TestSalesOrder(FrappeTestCase):
 		frappe.db.set_single_value("Stock Settings", "update_existing_price_list_rate", 0)
 		frappe.db.set_single_value("Stock Settings", "auto_insert_price_list_rate_if_missing", 0)
 
+	def test_discount_on_rate_greater_than_price_list(self):
+		item = make_item("_Discount Test")
+		so = make_sales_order(
+			item_code=item.name, qty=1, rate=200, price_list_rate=100, do_not_submit=True
+		)
+		so[0].rate = 120
+		so.save()
+		self.assertEqual(so[0].margin_rate_or_amount, 20)
+		self.assertEqual(so[0].discount_amount, 0)
 
 def automatically_fetch_payment_terms(enable=1):
 	accounts_settings = frappe.get_doc("Accounts Settings")


### PR DESCRIPTION
When the rate exceeds the price list rate, the margin is not calculated, resulting in a negative Discount Amount.

https://github.com/frappe/erpnext/assets/105106551/aaba9019-a89e-4591-980d-433628c6ac89

