### PR TITLE
fix: #37485 closes #37485

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -824,7 +824,7 @@ class WorkOrder(Document):
 
 			for d in data:
 				if not d.fixed_time:
-					d.time_in_mins = flt(d.time_in_mins) * flt(qty)
+					d.time_in_mins = flt(d.time_in_mins) * flt(d.batch_size) * flt(qty)
 				d.status = "Pending"
 
 			return data


### PR DESCRIPTION
Incorrect operations time calculation in new Work Order from BOM.

- backport version-14-hotfix".