### PR TITLE
feat: new hook `fields_for_group_similar_items` to group additional fields for print formats

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -636,4 +636,4 @@ default_log_clearing_doctypes = {
 
 export_python_type_annotations = True
 
-group_similar_item_fields = ["qty", "amount"]
+fields_for_group_similar_items = ["qty", "amount"]

--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -635,3 +635,5 @@ default_log_clearing_doctypes = {
 }
 
 export_python_type_annotations = True
+
+group_similar_item_fields = ["qty", "amount"]


### PR DESCRIPTION
Only select fields (rate / qty / amount) were grouped for transactions where `Group same items` was checked.

With this, additional fields could be added through hooks.

eg use case: item discounts / base net amount etc.

Sample Implementation: https://github.com/resilient-tech/india-compliance/pull/1966

Backport Request: v15, v14

Frappe Issue Reference: [11830](https://support.frappe.io/app/hd-ticket/11830)