### PR TITLE
fix: wrong value for total amount in payments

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/pos_invoice.py
@@ -441,6 +441,7 @@ class POSInvoice(SalesInvoice):
 
 		if self.is_return:
 			invoice_total = self.rounded_total or self.grand_total
+			total_amount_in_payments = flt(total_amount_in_payments, self.precision("grand_total"))
 			if total_amount_in_payments and total_amount_in_payments < invoice_total:
 				frappe.throw(_("Total payments amount can't be greater than {}").format(-invoice_total))
 


### PR DESCRIPTION
A made a POS Invoice with total $518,17, with two payments mode:

1. Money: 13,00
2. Credit Card: 505,17

But when i try to create a RETURN POS Invoice against the origin invoice, with same payment methods but with (-) operator, i try submit i get the following message "Total payments amount can't be greater than -518,17"

Debuging i saw a wrong value with decimal "-518.1700000000001" for variable total_amount_in_payments.

This normally happens when "+=" is used, so before comparing I need to round to the number of decimal places in the total field that will be used in the comparison.



