### PR TITLE
feat: optional description on subscription item

### DIFF
--- a/erpnext/accounts/doctype/subscription/subscription.py
+++ b/erpnext/accounts/doctype/subscription/subscription.py
@@ -552,11 +552,7 @@ class Subscription(Document):
 				}
 			
 			if plan.description:
-				item.update(
-					{
-						"description": plan.description,
-					}
-				)
+				item["description"] = plan.description
 
 			if deferred:
 				item.update(

--- a/erpnext/accounts/doctype/subscription/subscription.py
+++ b/erpnext/accounts/doctype/subscription/subscription.py
@@ -550,6 +550,13 @@ class Subscription(Document):
 					),
 					"cost_center": plan_doc.cost_center,
 				}
+			
+			if plan.description:
+				item.update(
+					{
+						"description": plan.description,
+					}
+				)
 
 			if deferred:
 				item.update(

--- a/erpnext/accounts/doctype/subscription_plan_detail/subscription_plan_detail.json
+++ b/erpnext/accounts/doctype/subscription_plan_detail/subscription_plan_detail.json
@@ -6,7 +6,8 @@
  "engine": "InnoDB",
  "field_order": [
   "plan",
-  "qty"
+  "qty",
+  "description"
  ],
  "fields": [
   {
@@ -23,11 +24,17 @@
    "label": "Plan",
    "options": "Subscription Plan",
    "reqd": 1
+  },
+  {
+   "fieldname": "description",
+   "fieldtype": "Text Editor",
+   "in_list_view": 1,
+   "label": "Description"
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:48.168122",
+ "modified": "2024-04-02 15:11:53.693323",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Subscription Plan Detail",

--- a/erpnext/accounts/doctype/subscription_plan_detail/subscription_plan_detail.py
+++ b/erpnext/accounts/doctype/subscription_plan_detail/subscription_plan_detail.py
@@ -14,6 +14,7 @@ class SubscriptionPlanDetail(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
+		description: DF.TextEditor | None
 		parent: DF.Data
 		parentfield: DF.Data
 		parenttype: DF.Data


### PR DESCRIPTION
This very small patch allows for adding a custom item description to the subscription plans item list in the Subscription Doctype which is then copied over into the Sales Invoice for the given item. This is useful for specifying individual parameters or assignments for subscription line items.

Subscription Plan Detail Table (Plans field on Subscription Doctype):
![image](https://github.com/frappe/erpnext/assets/4996285/652ceb1e-8c39-4cfd-9321-7ecee5187767)

Sales Invoice Item Table (Items field on the Sales Invoice Doctype):
![image](https://github.com/frappe/erpnext/assets/4996285/df1fe5a4-09a0-4f32-b6be-cb4560dfa197)
