### PR TITLE
fix: notify update when update outstanding amount

### DIFF
--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -1709,7 +1709,7 @@ def update_voucher_outstanding(voucher_type, voucher_no, account, party_type, pa
 		)
 
 		ref_doc.set_status(update=True)
-
+		ref_doc.notify_update()
 
 def delink_original_entry(pl_entry, partial_cancel=False):
 	if pl_entry:

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -1711,6 +1711,7 @@ def update_voucher_outstanding(voucher_type, voucher_no, account, party_type, pa
 		ref_doc.set_status(update=True)
 		ref_doc.notify_update()
 
+
 def delink_original_entry(pl_entry, partial_cancel=False):
 	if pl_entry:
 		ple = qb.DocType("Payment Ledger Entry")


### PR DESCRIPTION
Currently, when I create a payment for a Sales Invoice, whenever I return to the sales invoice using the browser's back button, it is necessary to manually update the page to load the document in the latest correct version, this causes a lot of inconvenience for those who create it. many invoices daily...

**Improvement:**

Call notify_update() when "outstanding_amount" changes

Therefore, whenever you update this field, it will notify this user that the change has occurred, so when you return to the invoice it will be updated with the current DB data.