### PR TITLE
fix:wrong time field value shown in job card summary

### DIFF
--- a/erpnext/manufacturing/report/job_card_summary/job_card_summary.py
+++ b/erpnext/manufacturing/report/job_card_summary/job_card_summary.py
@@ -33,6 +33,7 @@ def get_data(filters):
 		"total_completed_qty",
 		"workstation",
 		"operation",
+		"time_required",
 		"total_time_in_mins",
 	]
 
@@ -180,6 +181,12 @@ def get_columns(filters):
 			{"label": _("To Time"), "fieldname": "to_time", "fieldtype": "Datetime", "width": 120},
 			{
 				"label": _("Time Required (In Mins)"),
+				"fieldname": "time_required",
+				"fieldtype": "Float",
+				"width": 100,
+			},
+			{
+				"label": _("Time Taken (In Mins)"),
 				"fieldname": "total_time_in_mins",
 				"fieldtype": "Float",
 				"width": 100,

--- a/erpnext/manufacturing/report/job_card_summary/job_card_summary.py
+++ b/erpnext/manufacturing/report/job_card_summary/job_card_summary.py
@@ -180,7 +180,7 @@ def get_columns(filters):
 			{"label": _("From Time"), "fieldname": "from_time", "fieldtype": "Datetime", "width": 120},
 			{"label": _("To Time"), "fieldname": "to_time", "fieldtype": "Datetime", "width": 120},
 			{
-				"label": _("Excepted Time Required (In Mins)"),
+				"label": _("Expected Time Required (In Mins)"),
 				"fieldname": "time_required",
 				"fieldtype": "Float",
 				"width": 100,

--- a/erpnext/manufacturing/report/job_card_summary/job_card_summary.py
+++ b/erpnext/manufacturing/report/job_card_summary/job_card_summary.py
@@ -180,13 +180,13 @@ def get_columns(filters):
 			{"label": _("From Time"), "fieldname": "from_time", "fieldtype": "Datetime", "width": 120},
 			{"label": _("To Time"), "fieldname": "to_time", "fieldtype": "Datetime", "width": 120},
 			{
-				"label": _("Time Required (In Mins)"),
+				"label": _("Excepted Time Required (In Mins)"),
 				"fieldname": "time_required",
 				"fieldtype": "Float",
 				"width": 100,
 			},
 			{
-				"label": _("Time Taken (In Mins)"),
+				"label": _("Actual Time Required (In Mins)"),
 				"fieldname": "total_time_in_mins",
 				"fieldtype": "Float",
 				"width": 100,


### PR DESCRIPTION
In the Job Card Summary Report, the 'Time Required' field shows the total time taken from the job card.

Before:
![Screenshot from 2024-04-04 14-51-42](https://github.com/frappe/erpnext/assets/95607404/2b518827-fce9-4464-b554-2b4d00420c0f)

![Screenshot from 2024-04-04 14-52-49](https://github.com/frappe/erpnext/assets/95607404/f1c08860-a201-494d-93ef-f79e009df9d0)


After:
![Screenshot from 2024-04-04 14-50-48](https://github.com/frappe/erpnext/assets/95607404/5e3adcad-cdab-4209-9be5-5c4c299d6d72)
