### PR TITLE
fix: update the task status from timesheet

### DIFF
--- a/erpnext/projects/doctype/task/task.py
+++ b/erpnext/projects/doctype/task/task.py
@@ -199,8 +199,6 @@ class Task(NestedSet):
 			self.name,
 			as_dict=1,
 		)[0]
-		if self.status == "Open":
-			self.status = "Working"
 		self.total_costing_amount = tl.total_costing_amount
 		self.total_billing_amount = tl.total_billing_amount
 		self.actual_time = tl.time

--- a/erpnext/projects/doctype/timesheet/timesheet.py
+++ b/erpnext/projects/doctype/timesheet/timesheet.py
@@ -126,6 +126,12 @@ class Timesheet(Document):
 			if data.task and data.task not in tasks:
 				task = frappe.get_doc("Task", data.task)
 				task.update_time_and_costing()
+				time_logs_completed = all(tl.completed for tl in self.time_logs if tl.task == task.name)
+
+				if time_logs_completed:
+					task.status = "Completed"
+				else:
+					task.status = "Working"
 				task.save()
 				tasks.append(data.task)
 


### PR DESCRIPTION
Versions 15 and 14

fixes: #34064

**Before:**
- If you added a task to the timesheet and ticked the 'completed' checkbox and submitted the timesheet, then the task status was set to "working," but it should be "completed".


https://github.com/frappe/erpnext/assets/141945075/4718b0ad-ee40-495f-ac99-7813b4d9c196

<br>

**After:**

- If you added a task with multiple activities, if all activity tasks ticked the 'completed' checkbox and submitted the timesheet, then the task status will update as "completed", but if there are three activities linked to one task and two are 'completed' and one is not 'completed', then the task status will update as "working".


https://github.com/frappe/erpnext/assets/141945075/0ec51fc9-0df1-4429-ad73-de0b28a3d2ea

