### PR TITLE
fix: Webpages not working without login

### DIFF
--- a/erpnext/setup/doctype/item_group/item_group.json
+++ b/erpnext/setup/doctype/item_group/item_group.json
@@ -1,5 +1,6 @@
 {
  "actions": [],
+ "allow_guest_to_view": 1,
  "allow_import": 1,
  "allow_rename": 1,
  "autoname": "field:item_group_name",
@@ -21,7 +22,8 @@
   "taxes",
   "lft",
   "old_parent",
-  "rgt"
+  "rgt",
+  "route"
  ],
  "fields": [
   {
@@ -127,15 +129,21 @@
    "options": "Item Group",
    "print_hide": 1,
    "report_hide": 1
+  },
+  {
+   "fieldname": "route",
+   "fieldtype": "Data",
+   "label": "Route"
   }
  ],
+ "has_web_view": 1,
  "icon": "fa fa-sitemap",
  "idx": 1,
  "image_field": "image",
  "is_tree": 1,
  "links": [],
  "max_attachments": 3,
- "modified": "2024-03-27 13:09:54.588785",
+ "modified": "2024-04-06 11:07:20.012507",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Item Group",


### PR DESCRIPTION
After fixing of security issue (https://github.com/frappe/frappe/pull/24037), user was not able to see the Items listing on the portal without login and was the getting 404 error.

<img width="1336" alt="Screenshot 2024-02-22 at 4 23 28 PM" src="https://github.com/frappe/erpnext/assets/8780500/a75deb5c-2898-4208-b338-e91e19b2f9e6">


**After Fix**
Enabled "has_web_view" and "allow_guest_to_view" properties

<img width="1355" alt="Screenshot 2024-02-22 at 4 22 21 PM" src="https://github.com/frappe/erpnext/assets/8780500/c5381b46-a2fd-4e8a-bd98-c1db30313e03">

