### PR TITLE
fix: incorrect operator causing incorrect validation

### DIFF
--- a/erpnext/stock/doctype/closing_stock_balance/closing_stock_balance.py
+++ b/erpnext/stock/doctype/closing_stock_balance/closing_stock_balance.py
@@ -65,7 +65,7 @@ class ClosingStockBalance(Document):
 				& (
 					(table.from_date.between(self.from_date, self.to_date))
 					| (table.to_date.between(self.from_date, self.to_date))
-					| (table.from_date >= self.from_date and table.to_date >= self.to_date)
+					| ((table.from_date >= self.from_date) & (table.to_date >= self.to_date))
 				)
 			)
 		)


### PR DESCRIPTION
Getting below validation even the record is not duplicate 

<img width="821" alt="image" src="https://github.com/frappe/erpnext/assets/8780500/eda4147a-fbe8-48bd-b490-a3b8f682633d">
