### PR TITLE
fix: incorrect currency symbol in General Ledger print

### DIFF
--- a/erpnext/accounts/report/general_ledger/general_ledger.html
+++ b/erpnext/accounts/report/general_ledger/general_ledger.html
@@ -55,10 +55,10 @@
 					</span>
 				</td>
 				<td style="text-align: right">
-					{%= format_currency(data[i].debit, filters.presentation_currency) %}
+					{%= format_currency(data[i].debit, filters.presentation_currency || data[i].account_currency) %}
 				</td>
 				<td style="text-align: right">
-					{%= format_currency(data[i].credit, filters.presentation_currency) %}
+					{%= format_currency(data[i].credit, filters.presentation_currency || data[i].account_currency) %}
 				</td>
 			{% } else { %}
 				<td></td>


### PR DESCRIPTION
before:
![Screenshot from 2024-04-09 17-41-57](https://github.com/frappe/erpnext/assets/3272205/3e6f3e4a-bdbe-47f4-aa3d-fae9d5251f59)

after:
![Screenshot from 2024-04-09 17-40-29](https://github.com/frappe/erpnext/assets/3272205/d5a724d4-654b-47f6-80cb-e272fc1a0e46)
