### PR TITLE
fix: Don't call get_fiscal_year if setup is not done yet

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -452,6 +452,9 @@ $.extend(erpnext.utils, {
 	},
 
 	get_fiscal_year: function (date, with_dates = false, boolean = false) {
+		if (!frappe.boot.setup_complete) {
+			return;
+		}
 		if (!date) {
 			date = frappe.datetime.get_today();
 		}


### PR DESCRIPTION
On Setup Wizard page, the system tries to fetch fiscal year, but the company has not yet been set up.

----

from sync AJAX call in:
https://github.com/frappe/erpnext/blob/5446ed7642934139370cf5f0a54234c9d384b044/erpnext/public/js/purchase_trends_filters.js#L31

included in:
https://github.com/frappe/erpnext/blob/5446ed7642934139370cf5f0a54234c9d384b044/erpnext/public/js/erpnext.bundle.js#L38

in:
https://github.com/frappe/erpnext/blob/5446ed7642934139370cf5f0a54234c9d384b044/erpnext/hooks.py#L15

imported in frappe:
https://github.com/frappe/frappe/blob/bef9bdc5ee642e3b8b2b5bc4b75c4582f4679df3/frappe/www/app.py#L45

in app.html:
https://github.com/frappe/frappe/blob/bef9bdc5ee642e3b8b2b5bc4b75c4582f4679df3/frappe/www/app.html#L69-L71