### PR TITLE
fix: ignore dimension validation for cancelled entries

### DIFF
--- a/erpnext/accounts/doctype/gl_entry/gl_entry.py
+++ b/erpnext/accounts/doctype/gl_entry/gl_entry.py
@@ -182,6 +182,7 @@ class GLEntry(Document):
 				and self.company == dimension.company
 				and dimension.mandatory_for_pl
 				and not dimension.disabled
+				and not self.is_cancelled
 			):
 				if not self.get(dimension.fieldname):
 					frappe.throw(
@@ -195,6 +196,7 @@ class GLEntry(Document):
 				and self.company == dimension.company
 				and dimension.mandatory_for_bs
 				and not dimension.disabled
+				and not self.is_cancelled
 			):
 				if not self.get(dimension.fieldname):
 					frappe.throw(


### PR DESCRIPTION
Don't validate for mandatory dimension for cancelled entries.