### PR TITLE
fix: creation of return/debit note from purchase invoice

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -136,7 +136,7 @@ erpnext.accounts.PurchaseInvoice = class PurchaseInvoice extends erpnext.buying.
 
 		if (!doc.is_return && doc.docstatus == 1) {
 			if (doc.outstanding_amount >= 0 || Math.abs(flt(doc.outstanding_amount)) < flt(doc.grand_total)) {
-				this.frm.add_custom_button(__("Return / Debit Note"), this.make_debit_note, __("Create"));
+				this.frm.add_custom_button(__("Return / Debit Note"), this.make_debit_note.bind(this), __("Create"));
 			}
 		}
 

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -136,7 +136,11 @@ erpnext.accounts.PurchaseInvoice = class PurchaseInvoice extends erpnext.buying.
 
 		if (!doc.is_return && doc.docstatus == 1) {
 			if (doc.outstanding_amount >= 0 || Math.abs(flt(doc.outstanding_amount)) < flt(doc.grand_total)) {
-				this.frm.add_custom_button(__("Return / Debit Note"), this.make_debit_note.bind(this), __("Create"));
+				this.frm.add_custom_button(
+					__("Return / Debit Note"),
+					this.make_debit_note.bind(this),
+					__("Create")
+				);
 			}
 		}
 


### PR DESCRIPTION
Version: develop

fixes: https://discuss.frappe.io/t/create-button-return-debit-note-in-sales-invoice-not-working/120851

**Before:**


https://github.com/frappe/erpnext/assets/141945075/03b4c983-0938-47a7-9904-621006b7412a


**After**


https://github.com/frappe/erpnext/assets/141945075/b4760ce9-a80a-42c2-8341-86b721c62cdf


___

Also, same issue in the sales invoice time. Check the PR: #40941