### PR TITLE
Revert "fix: pass empty string email content of pos invoice (backport #40514)"

### DIFF
--- a/erpnext/selling/page/point_of_sale/pos_past_order_summary.js
+++ b/erpnext/selling/page/point_of_sale/pos_past_order_summary.js
@@ -264,7 +264,6 @@ erpnext.PointOfSale.PastOrderSummary = class {
 				content: content ? content : __(frm.meta.name) + ": " + doc.name,
 				doctype: doc.doctype,
 				name: doc.name,
-				content: "",
 				send_email: 1,
 				print_format,
 				sender_full_name: frappe.user.full_name(),


### PR DESCRIPTION
Reverts frappe/erpnext#40630

Reverting this because we are taking content input from the email dialogue. And if we are passing it as blank, then there is no point in taking the input only. Also, it only sends content to the server if there is any value.

@mmdanny89 