### PR TITLE
fix: Link Validation Error on Dunning cancellation

### DIFF
--- a/erpnext/accounts/doctype/dunning/dunning.py
+++ b/erpnext/accounts/doctype/dunning/dunning.py
@@ -146,6 +146,10 @@ class Dunning(AccountsController):
 			)
 			row.dunning_level = len(past_dunnings) + 1
 
+	def on_cancel(self):
+		super().on_cancel()
+		self.ignore_linked_doctypes = ["GL Entry"]
+
 
 def resolve_dunning(doc, state):
 	"""


### PR DESCRIPTION
Prevent Link validation error on Dunning cancellation.
![Screenshot from 2024-04-12 09-37-02](https://github.com/frappe/erpnext/assets/3272205/7d6e142d-8b3c-4c0a-9f3f-ae140d6ce008)


regression: https://github.com/frappe/erpnext/pull/35689