### PR TITLE
fix: don't attempt to set gender from salutation

### DIFF
--- a/erpnext/setup/doctype/employee/employee.js
+++ b/erpnext/setup/doctype/employee/employee.js
@@ -18,18 +18,6 @@ erpnext.setup.EmployeeController = class EmployeeController extends frappe.ui.fo
 	refresh() {
 		erpnext.toggle_naming_series();
 	}
-
-	salutation() {
-		if (this.frm.doc.salutation) {
-			this.frm.set_value(
-				"gender",
-				{
-					Mr: "Male",
-					Ms: "Female",
-				}[this.frm.doc.salutation]
-			);
-		}
-	}
 };
 
 frappe.ui.form.on("Employee", {


### PR DESCRIPTION
This code assumed that these salutations and genders exist, which is not guaranteed. If they don't exist, this resets the gender, which is not desired.

A better approach, if needed, would be that every Salutation can be linked to a Gender and we then use "fetch from".