### PR TITLE
fix: inspection type when create a qc from dc

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -1361,7 +1361,7 @@ def repost_required_for_queue(doc: StockController) -> bool:
 
 
 @frappe.whitelist()
-def make_quality_inspections(doctype, docname, items):
+def make_quality_inspections(doctype, docname, items, inspection_type):
 	if isinstance(items, str):
 		items = json.loads(items)
 
@@ -1381,7 +1381,7 @@ def make_quality_inspections(doctype, docname, items):
 		quality_inspection = frappe.get_doc(
 			{
 				"doctype": "Quality Inspection",
-				"inspection_type": "Incoming",
+				"inspection_type": inspection_type,
 				"inspected_by": frappe.session.user,
 				"reference_type": doctype,
 				"reference_name": docname,

--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -2203,6 +2203,8 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		];
 
 		const me = this;
+		const inspection_type = ["Purchase Receipt", "Purchase Invoice", "Subcontracting Receipt"].includes(this.frm.doc.doctype)
+			? "Incoming" : "Outgoing";
 		const dialog = new frappe.ui.Dialog({
 			title: __("Select Items for Quality Inspection"),
 			size: "extra-large",
@@ -2214,7 +2216,8 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 					args: {
 						doctype: me.frm.doc.doctype,
 						docname: me.frm.doc.name,
-						items: data.items
+						items: data.items,
+						inspection_type: inspection_type
 					},
 					freeze: true,
 					callback: function (r) {

--- a/erpnext/stock/doctype/quality_inspection/test_quality_inspection.py
+++ b/erpnext/stock/doctype/quality_inspection/test_quality_inspection.py
@@ -138,9 +138,13 @@ class TestQualityInspection(FrappeTestCase):
 
 	def test_make_quality_inspections_from_linked_document(self):
 		dn = create_delivery_note(item_code="_Test Item with QA", do_not_submit=True)
+		if dn.doctype in ["Purchase Receipt", "Purchase Invoice", "Subcontracting Receipt"]:
+			inspection_type = "Incoming"
+		else:
+			inspection_type = "Outgoing"
 		for item in dn.items:
 			item.sample_size = item.qty
-		quality_inspections = make_quality_inspections(dn.doctype, dn.name, dn.items)
+		quality_inspections = make_quality_inspections(dn.doctype, dn.name, dn.items, inspection_type)
 		self.assertEqual(len(dn.items), len(quality_inspections))
 
 		# cleanup


### PR DESCRIPTION
Versions 15 and 14

fixes: https://discuss.frappe.io/t/create-button-in-delivery-note-not-working-properly/121130


**Before:**

- When creating a quality inspection from a delivery note, it takes an incoming inspection type because it is statically set.


https://github.com/frappe/erpnext/assets/141945075/b2ac645b-e53d-4b03-bc07-2e4d8525a20c



**After:**


https://github.com/frappe/erpnext/assets/141945075/4be1c6c1-6c21-4b4d-9594-0ff9d2fbb7d3



- Added the dynamic conditions to fix the inspection type.
