### PR TITLE
fix(process_statement_of_accounts.py): report date assignment in process_statement_of_accounts uses posting_date if Accounts Receivable

### DIFF
--- a/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
+++ b/erpnext/accounts/doctype/process_statement_of_accounts/process_statement_of_accounts.py
@@ -158,7 +158,7 @@ def set_ageing(doc, entry):
 	ageing_filters = frappe._dict(
 		{
 			"company": doc.company,
-			"report_date": doc.to_date,
+			"report_date": doc.to_date if doc.report == "General Ledger" else doc.posting_date,
 			"ageing_based_on": doc.ageing_based_on,
 			"range1": 30,
 			"range2": 60,


### PR DESCRIPTION
The code for assigning the report date in the process of statement of accounts file has been modified. 

Previously, it always pulled the "to_date" regardless of the report. Now, it checks if the report is a "General Ledger" and takes "to_date"; otherwise, it will take the "posting_date" as the report date (if Accounts Receivable).

