### PR TITLE
fix: expense account should be fetched from related asset category

### DIFF
--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -1738,12 +1738,12 @@ def create_asset(**args):
 	return asset
 
 
-def create_asset_category():
+def create_asset_category(enable_cwip=1):
 	asset_category = frappe.new_doc("Asset Category")
 	asset_category.asset_category_name = "Computers"
 	asset_category.total_number_of_depreciations = 3
 	asset_category.frequency_of_depreciation = 3
-	asset_category.enable_cwip_accounting = 1
+	asset_category.enable_cwip_accounting = enable_cwip
 	asset_category.append(
 		"accounts",
 		{

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -778,6 +778,9 @@ class AccountsController(TransactionBase):
 								# reset pricing rule fields if pricing_rule_removed
 								item.set(fieldname, value)
 
+							elif fieldname == "expense_account" and not item.get("expense_account"):
+								item.expense_account = value
+
 					if self.doctype in ["Purchase Invoice", "Sales Invoice"] and item.meta.get_field(
 						"is_fixed_asset"
 					):

--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -712,6 +712,7 @@ class BuyingController(SubcontractingController):
 	def auto_make_assets(self, asset_items):
 		items_data = get_asset_item_details(asset_items)
 		messages = []
+		alert = False
 
 		for d in self.items:
 			if d.is_fixed_asset:
@@ -761,9 +762,10 @@ class BuyingController(SubcontractingController):
 							frappe.bold(d.item_code)
 						)
 					)
+					alert = True
 
 		for message in messages:
-			frappe.msgprint(message, title="Success", indicator="green")
+			frappe.msgprint(message, title="Success", indicator="green", alert=alert)
 
 	def make_asset(self, row, is_grouped_asset=False):
 		if not row.asset_location:

--- a/erpnext/stock/doctype/item/test_item.py
+++ b/erpnext/stock/doctype/item/test_item.py
@@ -156,6 +156,33 @@ class TestItem(FrappeTestCase):
 		for key, value in to_check.items():
 			self.assertEqual(value, details.get(key), key)
 
+	def test_get_asset_item_details(self):
+		from erpnext.assets.doctype.asset.test_asset import create_asset_category, create_fixed_asset_item
+
+		create_asset_category(0)
+		create_fixed_asset_item()
+
+		details = get_item_details(
+			{
+				"item_code": "Macbook Pro",
+				"company": "_Test Company",
+				"currency": "INR",
+				"doctype": "Purchase Receipt",
+			}
+		)
+		self.assertEqual(details.get("expense_account"), "_Test Fixed Asset - _TC")
+
+		frappe.db.set_value("Asset Category", "Computers", "enable_cwip_accounting", "1")
+		details = get_item_details(
+			{
+				"item_code": "Macbook Pro",
+				"company": "_Test Company",
+				"currency": "INR",
+				"doctype": "Purchase Receipt",
+			}
+		)
+		self.assertEqual(details.get("expense_account"), "CWIP Account - _TC")
+
 	def test_item_tax_template(self):
 		expected_item_tax_template = [
 			{

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -671,19 +671,8 @@ class PurchaseReceipt(BuyingController):
 					else self.get_company_default("stock_received_but_not_billed")
 				)
 				landed_cost_entries = get_item_account_wise_additional_cost(self.name)
-
 				if d.is_fixed_asset:
-					if is_cwip_accounting_enabled(d.asset_category):
-						stock_asset_account_name = get_asset_account(
-							"capital_work_in_progress_account",
-							asset_category=d.asset_category,
-							company=self.company,
-						)
-					else:
-						stock_asset_account_name = get_asset_category_account(
-							"fixed_asset_account", asset_category=d.asset_category, company=self.company
-						)
-
+					stock_asset_account_name = d.expense_account
 					stock_value_diff = (
 						flt(d.base_net_amount) + flt(d.item_tax_amount) + flt(d.landed_cost_voucher_amount)
 					)

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -74,7 +74,6 @@ def get_item_details(args, doc=None, for_validate=False, overwrite_warehouse=Tru
 			args["bill_date"] = doc.get("bill_date")
 
 	out = get_basic_details(args, item, overwrite_warehouse)
-
 	get_item_tax_template(args, item, out)
 	out["item_tax_rate"] = get_item_tax_map(
 		args.company,
@@ -293,12 +292,26 @@ def get_basic_details(args, item, overwrite_warehouse=True):
 
 	expense_account = None
 
-	if args.get("doctype") == "Purchase Invoice" and item.is_fixed_asset:
-		from erpnext.assets.doctype.asset_category.asset_category import get_asset_category_account
+	if item.is_fixed_asset:
+		from erpnext.assets.doctype.asset.asset import get_asset_account, is_cwip_accounting_enabled
 
-		expense_account = get_asset_category_account(
-			fieldname="fixed_asset_account", item=args.item_code, company=args.company
-		)
+		if is_cwip_accounting_enabled(item.asset_category):
+			expense_account = get_asset_account(
+				"capital_work_in_progress_account",
+				asset_category=item.asset_category,
+				company=args.company,
+			)
+		elif (
+			args.get("doctype") == "Purchase Invoice"
+			or args.get("doctype") == "Purchase Receipt"
+			or args.get("doctype") == "Purchase Order"
+			or args.get("doctype") == "Material Request"
+		):
+			from erpnext.assets.doctype.asset_category.asset_category import get_asset_category_account
+
+			expense_account = get_asset_category_account(
+				fieldname="fixed_asset_account", item=args.item_code, company=args.company
+			)
 
 	# Set the UOM to the Default Sales UOM or Default Purchase UOM if configured in the Item Master
 	if not args.get("uom"):

--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -301,11 +301,11 @@ def get_basic_details(args, item, overwrite_warehouse=True):
 				asset_category=item.asset_category,
 				company=args.company,
 			)
-		elif (
-			args.get("doctype") == "Purchase Invoice"
-			or args.get("doctype") == "Purchase Receipt"
-			or args.get("doctype") == "Purchase Order"
-			or args.get("doctype") == "Material Request"
+		elif args.get("doctype") in (
+			"Purchase Invoice",
+			"Purchase Receipt",
+			"Purchase Order",
+			"Material Request",
 		):
 			from erpnext.assets.doctype.asset_category.asset_category import get_asset_category_account
 


### PR DESCRIPTION
<!-- Add images/recordings to better visualize the change: expected/current behviour -->

There was an issue with fixed asset item, when we are making a “Material request”, “Purchase order” and "Purchase Receipt" transaction where application sets the expenses account by default in the item child table but it should fetch the correct account from the related Asset Category.

<img width="1065" alt="Screenshot 2024-04-16 at 11 07 33 AM" src="https://github.com/frappe/erpnext/assets/142375893/f58ae634-1b3d-4d7c-9040-6b0272f8bd94">
<img width="1134" alt="Screenshot 2024-04-16 at 11 08 38 AM" src="https://github.com/frappe/erpnext/assets/142375893/a56fd171-7d0b-4e54-a102-846b529d262b">
Before expense account was not fetched based on asset category.
<img width="1129" alt="Screenshot 2024-04-16 at 11 10 00 AM" src="https://github.com/frappe/erpnext/assets/142375893/6cb119db-abde-4cf1-86b1-f86e6b501ea8">

After the fix:-
<img width="1129" alt="Screenshot 2024-04-16 at 11 09 28 AM" src="https://github.com/frappe/erpnext/assets/142375893/9f792c50-0c57-4c8a-951d-7c04257aa9ac">

no-docs