### PR TITLE
fix: remove validate_name_in_customer function

### DIFF
--- a/erpnext/setup/doctype/customer_group/customer_group.py
+++ b/erpnext/setup/doctype/customer_group/customer_group.py
@@ -40,13 +40,8 @@ class CustomerGroup(NestedSet):
 			self.parent_customer_group = get_root_of("Customer Group")
 
 	def on_update(self):
-		self.validate_name_with_customer()
 		super().on_update()
 		self.validate_one_root()
-
-	def validate_name_with_customer(self):
-		if frappe.db.exists("Customer", self.name):
-			frappe.msgprint(_("A customer with the same name already exists"), raise_exception=1)
 
 
 def get_parent_customer_groups(customer_group):


### PR DESCRIPTION
**Problem:**
When we create a customer group the function "validate_name_with_customer" is called which checks whether the name of customer group exists in "Customer" DocType.
For e.g.
If we create a customer group called "XYZ",  in the on_update method in customer_group.py file, the code will check whether a customer with a name of "XYZ" is already created or not. If it is created it throws an error "A customer with the same name already exists".



**Solution:**
Remove validate_name_with_customer from "customer_group.py" file.