### PR TITLE
fix: address filter and quotation to for prospect

### DIFF
--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -188,7 +188,7 @@ def set_address_details(
 	*,
 	ignore_permissions=False,
 ):
-	billing_address_field = "customer_address" if party_type == "Lead" else party_type.lower() + "_address"
+	billing_address_field = "customer_address" if party_type in ["Lead", "Prospect"] else party_type.lower() + "_address"
 	party_details[billing_address_field] = party_address or get_default_address(party_type, party.name)
 	if doctype:
 		party_details.update(

--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -188,7 +188,9 @@ def set_address_details(
 	*,
 	ignore_permissions=False,
 ):
-	billing_address_field = "customer_address" if party_type in ["Lead", "Prospect"] else party_type.lower() + "_address"
+	billing_address_field = (
+		"customer_address" if party_type in ["Lead", "Prospect"] else party_type.lower() + "_address"
+	)
 	party_details[billing_address_field] = party_address or get_default_address(party_type, party.name)
 	if doctype:
 		party_details.update(

--- a/erpnext/selling/doctype/quotation/quotation.js
+++ b/erpnext/selling/doctype/quotation/quotation.js
@@ -71,8 +71,8 @@ frappe.ui.form.on("Quotation", {
 		frm.trigger("set_label");
 		frm.trigger("toggle_reqd_lead_customer");
 		frm.trigger("set_dynamic_field_label");
-		frm.set_value("party_name", '')
-		frm.set_value("customer_name", '')
+		frm.set_value("party_name", "")
+		frm.set_value("customer_name", "")
 	},
 
 	set_label: function (frm) {

--- a/erpnext/selling/doctype/quotation/quotation.js
+++ b/erpnext/selling/doctype/quotation/quotation.js
@@ -71,8 +71,8 @@ frappe.ui.form.on("Quotation", {
 		frm.trigger("set_label");
 		frm.trigger("toggle_reqd_lead_customer");
 		frm.trigger("set_dynamic_field_label");
-		frm.set_value("party_name", "")
-		frm.set_value("customer_name", "")
+		frm.set_value("party_name", "");
+		frm.set_value("customer_name", "");
 	},
 
 	set_label: function (frm) {

--- a/erpnext/selling/doctype/quotation/quotation.js
+++ b/erpnext/selling/doctype/quotation/quotation.js
@@ -96,18 +96,10 @@ erpnext.selling.QuotationController = class QuotationController extends erpnext.
 	}
 	refresh(doc, dt, dn) {
 		super.refresh(doc, dt, dn);
-		let doctype = "";
-		if (doc.quotation_to == "Customer") {
-			doctype = "Customer";
-		} else if (doc.quotation_to == "Lead") {
-			doctype = "Lead";
-		} else if (doc.quotation_to == "Prospect") {
-			doctype = "Prospect";
-		}
 		frappe.dynamic_link = {
 			doc: this.frm.doc,
 			fieldname: "party_name",
-			doctype: doctype,
+			doctype: doc.quotation_to,
 		};
 
 		var me = this;

--- a/erpnext/selling/doctype/quotation/quotation.js
+++ b/erpnext/selling/doctype/quotation/quotation.js
@@ -71,6 +71,8 @@ frappe.ui.form.on("Quotation", {
 		frm.trigger("set_label");
 		frm.trigger("toggle_reqd_lead_customer");
 		frm.trigger("set_dynamic_field_label");
+		frm.set_value("party_name", '')
+		frm.set_value("customer_name", '')
 	},
 
 	set_label: function (frm) {
@@ -94,10 +96,18 @@ erpnext.selling.QuotationController = class QuotationController extends erpnext.
 	}
 	refresh(doc, dt, dn) {
 		super.refresh(doc, dt, dn);
+		let doctype = "";
+		if (doc.quotation_to == "Customer") {
+			doctype = "Customer";
+		} else if (doc.quotation_to == "Lead") {
+			doctype = "Lead";
+		} else if (doc.quotation_to == "Prospect") {
+			doctype = "Prospect";
+		}
 		frappe.dynamic_link = {
 			doc: this.frm.doc,
 			fieldname: "party_name",
-			doctype: doc.quotation_to == "Customer" ? "Customer" : "Lead",
+			doctype: doctype,
 		};
 
 		var me = this;
@@ -197,6 +207,7 @@ erpnext.selling.QuotationController = class QuotationController extends erpnext.
 			};
 		} else if (this.frm.doc.quotation_to == "Prospect") {
 			this.frm.set_df_property("party_name", "label", "Prospect");
+			this.frm.fields_dict.party_name.get_query = null;
 		}
 	}
 


### PR DESCRIPTION
**Version 15**

fixes: #41015

**Before:** 

- When choosing "quotation_to" as a customer, the customer displays correctly. Similarly, when selecting "quotation_to" as the lead, the lead displays correctly. However, when "quotation_to" is set as a prospect, the lead list is shown instead. Moreover, when initially selecting "quotation_to" as a customer and then changing it to prospect, it displays properly.

- In the case where "quotation_to" is set as a prospect, the address does not appear, and the address filter does not correspond to the prospect; instead, it shows the lead address.


https://github.com/frappe/erpnext/assets/141945075/f94d506f-dea3-481b-a9d1-a77f4e9864d9

<br>

**After:**

- fix the issue, so please check the video.


https://github.com/frappe/erpnext/assets/141945075/b0796331-48e2-430e-ae9a-fe379faa11de

