### PR TITLE
fix: not able to submit subcontracting receipt

### DIFF
--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
@@ -722,6 +722,7 @@ def make_purchase_receipt(source_name, target_doc=None, save=False, submit=False
 						"purchase_order": item.purchase_order,
 						"purchase_order_item": item.purchase_order_item,
 						"subcontracting_receipt_item": item.name,
+						"project": po_item.project,
 					}
 					target_doc.append("items", item_row)
 


### PR DESCRIPTION
If "Auto Create Purchase Receipt" has enabled in the Buying Settings then user not able to submit the Subcontracting Receipt and getting below error 

<img width="776" alt="Screenshot 2024-04-16 at 6 17 15 PM" src="https://github.com/frappe/erpnext/assets/8780500/0244e76a-ffa7-4b8f-8217-5776a356ddd6">
