### PR TITLE
fix: possible wildcard issue on variable name

### DIFF
--- a/erpnext/accounts/report/gross_profit/gross_profit.py
+++ b/erpnext/accounts/report/gross_profit/gross_profit.py
@@ -655,13 +655,13 @@ class GrossProfitGenerator:
 			elif self.delivery_notes.get((row.parent, row.item_code), None):
 				#  check if Invoice has delivery notes
 				dn = self.delivery_notes.get((row.parent, row.item_code))
-				parenttype, parent, item_row, _warehouse = (
+				parenttype, parent, item_row, dn_warehouse = (
 					"Delivery Note",
 					dn["delivery_note"],
 					dn["item_row"],
 					dn["warehouse"],
 				)
-				my_sle = self.get_stock_ledger_entries(item_code, _warehouse)
+				my_sle = self.get_stock_ledger_entries(item_code, dn_warehouse)
 				return self.calculate_buying_amount_from_sle(
 					row, my_sle, parenttype, parent, item_row, item_code
 				)


### PR DESCRIPTION
`_warehouse` throws undefined error on v14 and v15. Fixing this by using normal variable name. 
This change is already added in original PR's [v14](https://github.com/frappe/erpnext/pull/40854) and [v15](https://github.com/frappe/erpnext/pull/40789) backports