### PR TITLE
feat: New payment term option 'Month(s) after invoice date'

### DIFF
--- a/erpnext/accounts/doctype/payment_term/payment_term.json
+++ b/erpnext/accounts/doctype/payment_term/payment_term.json
@@ -53,7 +53,7 @@
    "fieldname": "due_date_based_on",
    "fieldtype": "Select",
    "label": "Due Date Based On",
-   "options": "Day(s) after invoice date\nDay(s) after the end of the invoice month\nMonth(s) after the end of the invoice month"
+   "options": "Day(s) after invoice date\nDay(s) after the end of the invoice month\nMonth(s) after the end of the invoice month\nMonth(s) after invoice date"
   },
   {
    "bold": 1,
@@ -63,7 +63,7 @@
    "label": "Credit Days"
   },
   {
-   "depends_on": "eval:doc.due_date_based_on=='Month(s) after the end of the invoice month'",
+   "depends_on": "eval:in_list(['Month(s) after invoice date', 'Month(s) after the end of the invoice month'], doc.due_date_based_on)",
    "fieldname": "credit_months",
    "fieldtype": "Int",
    "label": "Credit Months"
@@ -101,7 +101,7 @@
    "fieldname": "discount_validity_based_on",
    "fieldtype": "Select",
    "label": "Discount Validity Based On",
-   "options": "Day(s) after invoice date\nDay(s) after the end of the invoice month\nMonth(s) after the end of the invoice month"
+   "options": "Day(s) after invoice date\nDay(s) after the end of the invoice month\nMonth(s) after the end of the invoice month\nMonth(s) after invoice date"
   },
   {
    "depends_on": "discount",
@@ -116,7 +116,7 @@
   }
  ],
  "links": [],
- "modified": "2024-03-27 13:10:11.511137",
+ "modified": "2024-04-16 18:10:50.815795",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Term",

--- a/erpnext/accounts/doctype/payment_term/payment_term.py
+++ b/erpnext/accounts/doctype/payment_term/payment_term.py
@@ -24,11 +24,13 @@ class PaymentTerm(Document):
 			"Day(s) after invoice date",
 			"Day(s) after the end of the invoice month",
 			"Month(s) after the end of the invoice month",
+			"Month(s) after invoice date",
 		]
 		due_date_based_on: DF.Literal[
 			"Day(s) after invoice date",
 			"Day(s) after the end of the invoice month",
 			"Month(s) after the end of the invoice month",
+			"Month(s) after invoice date",
 		]
 		invoice_portion: DF.Float
 		mode_of_payment: DF.Link | None

--- a/erpnext/accounts/party.py
+++ b/erpnext/accounts/party.py
@@ -606,6 +606,8 @@ def get_due_date_from_template(template_name, posting_date, bill_date):
 			due_date = max(due_date, add_days(due_date, term.credit_days))
 		elif term.due_date_based_on == "Day(s) after the end of the invoice month":
 			due_date = max(due_date, add_days(get_last_day(due_date), term.credit_days))
+		elif term.due_date_based_on == "Month(s) after invoice date":
+			due_date = max(due_date, add_months(due_date, term.credit_months))
 		else:
 			due_date = max(due_date, get_last_day(add_months(due_date, term.credit_months)))
 	return due_date

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -3002,6 +3002,8 @@ def get_due_date(term, posting_date=None, bill_date=None):
 		due_date = add_days(get_last_day(date), term.credit_days)
 	elif term.due_date_based_on == "Month(s) after the end of the invoice month":
 		due_date = get_last_day(add_months(date, term.credit_months))
+	elif term.due_date_based_on == "Month(s) after invoice date":
+		due_date = add_months(date, term.credit_months)
 	return due_date
 
 
@@ -3014,6 +3016,8 @@ def get_discount_date(term, posting_date=None, bill_date=None):
 		discount_validity = add_days(get_last_day(date), term.discount_validity)
 	elif term.discount_validity_based_on == "Month(s) after the end of the invoice month":
 		discount_validity = get_last_day(add_months(date, term.discount_validity))
+	elif term.due_date_based_on == "Month(s) after invoice date":
+		discount_validity = add_months(date, term.discount_validity)
 	return discount_validity
 
 


### PR DESCRIPTION
Documentation section Link: https://docs.erpnext.com/docs/user/manual/en/journals-and-payments-payment-terms

This pull request introduces a new option for "Due Date Based On" in the Payment Term . The new option, "Month(s) after invoice date," allows users to specify a due date that is calculated based on a certain number of months after the posting date of the invoice or order.

Description of the New Option for "Due date based on":

Month(s) after invoice date: Due date should be calculated in months concerning the posting date of the invoice. For example, if 2 is entered on the 15th of March, the due date will be on 15th May.
