### PR TITLE
fix: do not add qty to supplied items

### DIFF
--- a/erpnext/controllers/subcontracting_controller.py
+++ b/erpnext/controllers/subcontracting_controller.py
@@ -539,6 +539,9 @@ class SubcontractingController(StockController):
 		return serial_nos
 
 	def __add_supplied_item(self, item_row, bom_item, qty):
+		if bom_item.get("qty"):
+			bom_item.pop("qty")
+
 		bom_item.conversion_factor = item_row.conversion_factor
 		rm_obj = self.append(self.raw_material_table, bom_item)
 		if rm_obj.get("qty"):


### PR DESCRIPTION
```
File "apps/frappe/frappe/app.py", line 95, in application
    response = frappe.api.handle()
  File "apps/frappe/frappe/api.py", line 55, in handle
    return frappe.handler.handle()
  File "apps/frappe/frappe/handler.py", line 48, in handle
    data = execute_cmd(cmd)
  File "apps/frappe/frappe/handler.py", line 86, in execute_cmd
    return frappe.call(method, **frappe.form_dict)
  File "apps/frappe/frappe/__init__.py", line 1611, in call
    return fn(*args, **newargs)
  File "apps/frappe/frappe/desk/form/save.py", line 31, in savedocs
    doc.save()
  File "apps/frappe/frappe/model/document.py", line 307, in save
    return self._save(*args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 329, in _save
    return self.insert()
  File "apps/frappe/frappe/model/document.py", line 262, in insert
    self.run_before_save_methods()
  File "apps/frappe/frappe/model/document.py", line 1058, in run_before_save_methods
    self.run_method("validate")
  File "apps/frappe/frappe/model/document.py", line 928, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1280, in composer
    return composed(self, method, *args, **kwargs)
  File "apps/frappe/frappe/model/document.py", line 1262, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
  File "apps/frappe/frappe/model/document.py", line 925, in fn
    return method_object(*args, **kwargs)
  File "apps/erpnext/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py", line 129, in validate
    self.validate_uom_is_integer("uom", ["qty", "received_qty"])
  File "apps/erpnext/erpnext/utilities/transaction_base.py", line 34, in validate_uom_is_integer
    validate_uom_is_integer(self, uom_field, qty_fields)
  File "apps/erpnext/erpnext/utilities/transaction_base.py", line 215, in validate_uom_is_integer
    if abs(cint(qty) - flt(qty, d.precision(f))) > 0.0000001:
  File "apps/frappe/frappe/model/base_document.py", line 1114, in precision
    if df.fieldtype in ("Currency", "Float", "Percent"):
AttributeError: 'NoneType' object has no attribute 'fieldtype'
```