### PR TITLE
fix: search for item price in stock UOM

### DIFF
--- a/erpnext/stock/get_item_details.py
+++ b/erpnext/stock/get_item_details.py
@@ -840,7 +840,12 @@ def insert_item_price(args):
 
 			item_price = frappe.db.get_value(
 				"Item Price",
-				{"item_code": args.item_code, "price_list": args.price_list, "currency": args.currency},
+				{
+					"item_code": args.item_code,
+					"price_list": args.price_list,
+					"currency": args.currency,
+					"uom": args.stock_uom,
+				},
 				["name", "price_list_rate"],
 				as_dict=1,
 			)


### PR DESCRIPTION
Add UOM to filters when looking for existing **Item Price**.

Prices are always UOM-specific. It doesn't make sense to update an existing **Item Price** for "Liters" with a new price for "Milliliters".

Item prices are created in Stock UOM, hence we should also retrieve them in Stock UOM.