### PR TITLE
fix: prevent foreign currency  accounts as advance accounts.

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -158,6 +158,7 @@ class PaymentEntry(AccountsController):
 		self.setup_party_account_field()
 		self.set_missing_values()
 		self.set_liability_account()
+		self.validate_advance_account_currency()
 		self.set_missing_ref_details(force=True)
 		self.validate_payment_type()
 		self.validate_party_details()
@@ -239,6 +240,22 @@ class PaymentEntry(AccountsController):
 			),
 			alert=True,
 		)
+
+	def validate_advance_account_currency(self):
+		if self.book_advance_payments_in_separate_party_account is True:
+			company_currency = frappe.get_cached_value("Company", self.company, "default_currency")
+			if self.payment_type == "Receive" and self.paid_from_account_currency != company_currency:
+				frappe.throw(
+					_("Booking advances in foreign currency account: {0} ({1}) is not yet supported.").format(
+						frappe.bold(self.paid_from), frappe.bold(self.paid_from_account_currency)
+					)
+				)
+			if self.payment_type == "Pay" and self.paid_to_account_currency != company_currency:
+				frappe.throw(
+					_("Booking advances in foreign currency account: {0} ({1}) is not yet supported.").format(
+						frappe.bold(self.paid_to), frappe.bold(self.paid_to_account_currency)
+					)
+				)
 
 	def on_cancel(self):
 		self.ignore_linked_doctypes = (

--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -139,6 +139,7 @@ class Company(NestedSet):
 		self.validate_abbr()
 		self.validate_default_accounts()
 		self.validate_currency()
+		self.validate_advance_account_currency()
 		self.validate_coa_input()
 		self.validate_perpetual_inventory()
 		self.validate_provisional_account_for_non_stock_items()
@@ -190,6 +191,29 @@ class Company(NestedSet):
 						"{0} currency must be same as company's default currency. Please select another account."
 					).format(frappe.bold(account[0]))
 					frappe.throw(error_message)
+
+	def validate_advance_account_currency(self):
+		if (
+			self.default_advance_received_account
+			and frappe.get_cached_value("Account", self.default_advance_received_account, "account_currency")
+			!= self.default_currency
+		):
+			frappe.throw(
+				_("'{0}' should be in company currency {1}.").format(
+					frappe.bold("Default Advance Received Account"), frappe.bold(self.default_currency)
+				)
+			)
+
+		if (
+			self.default_advance_paid_account
+			and frappe.get_cached_value("Account", self.default_advance_paid_account, "account_currency")
+			!= self.default_currency
+		):
+			frappe.throw(
+				_("'{0}' should be in company currency {1}.").format(
+					frappe.bold("Default Advance Paid Account"), frappe.bold(self.default_currency)
+				)
+			)
 
 	def validate_currency(self):
 		if self.is_new():


### PR DESCRIPTION
Booking advances in separate party account is restricted to company currency accounts.