### PR TITLE
refactor: Rename purchase receipt amount field to purchase amount

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -1207,7 +1207,7 @@ class PurchaseInvoice(BuyingController):
 				asset.name,
 				{
 					"gross_purchase_amount": purchase_amount,
-					"purchase_receipt_amount": purchase_amount,
+					"purchase_amount": purchase_amount,
 				},
 			)
 

--- a/erpnext/assets/doctype/asset/asset.js
+++ b/erpnext/assets/doctype/asset/asset.js
@@ -652,7 +652,7 @@ frappe.ui.form.on("Asset", {
 			);
 
 			frm.set_value("gross_purchase_amount", purchase_amount);
-			frm.set_value("purchase_receipt_amount", purchase_amount);
+			frm.set_value("purchase_amount", purchase_amount);
 			frm.set_value("asset_quantity", asset_quantity);
 			frm.set_value("cost_center", item.cost_center || purchase_doc.cost_center);
 			if (item.asset_location) {

--- a/erpnext/assets/doctype/asset/asset.json
+++ b/erpnext/assets/doctype/asset/asset.json
@@ -15,6 +15,7 @@
   "asset_owner_company",
   "is_existing_asset",
   "is_composite_asset",
+  "is_composite_component",
   "supplier",
   "customer",
   "image",
@@ -72,7 +73,7 @@
   "status",
   "booked_fixed_asset",
   "column_break_51",
-  "purchase_receipt_amount",
+  "purchase_amount",
   "default_finance_book",
   "depr_entry_posting_status",
   "amended_from",
@@ -202,8 +203,7 @@
    "fieldname": "purchase_date",
    "fieldtype": "Date",
    "label": "Purchase Date",
-   "mandatory_depends_on": "eval:!doc.is_existing_asset && !doc.is_composite_asset",
-   "read_only_depends_on": "eval:!doc.is_existing_asset && !doc.is_composite_asset"
+   "mandatory_depends_on": "eval:!doc.is_existing_asset && !doc.is_composite_asset"
   },
   {
    "fieldname": "disposal_date",
@@ -234,7 +234,7 @@
    "fieldname": "available_for_use_date",
    "fieldtype": "Date",
    "label": "Available-for-use Date",
-   "mandatory_depends_on": "eval:(!doc.is_composite_asset || doc.docstatus==1)"
+   "mandatory_depends_on": "eval:(!doc.is_composite_component && doc.docstatus==1)"
   },
   {
    "default": "0",
@@ -409,15 +409,6 @@
    "print_hide": 1
   },
   {
-   "fieldname": "purchase_receipt_amount",
-   "fieldtype": "Currency",
-   "hidden": 1,
-   "label": "Purchase Receipt Amount",
-   "no_copy": 1,
-   "print_hide": 1,
-   "read_only": 1
-  },
-  {
    "depends_on": "eval:!doc.is_composite_asset && !doc.is_existing_asset",
    "fieldname": "purchase_invoice",
    "fieldtype": "Link",
@@ -518,7 +509,7 @@
   },
   {
    "default": "0",
-   "depends_on": "eval:!doc.is_existing_asset",
+   "depends_on": "eval:(!doc.is_existing_asset && !doc.is_composite_component)",
    "fieldname": "is_composite_asset",
    "fieldtype": "Check",
    "label": "Is Composite Asset"
@@ -545,6 +536,22 @@
    "fieldtype": "Currency",
    "label": "Additional Asset Cost",
    "options": "Company:company:default_currency",
+   "read_only": 1
+  },
+  {
+   "default": "0",
+   "depends_on": "eval:(!doc.is_existing_asset && !doc.is_composite_asset)",
+   "fieldname": "is_composite_component",
+   "fieldtype": "Check",
+   "label": "Is Composite Component"
+  },
+  {
+   "fieldname": "purchase_amount",
+   "fieldtype": "Currency",
+   "hidden": 1,
+   "label": "Purchase Amount",
+   "no_copy": 1,
+   "print_hide": 1,
    "read_only": 1
   }
  ],
@@ -589,7 +596,7 @@
    "link_fieldname": "target_asset"
   }
  ],
- "modified": "2024-03-27 13:06:32.494326",
+ "modified": "2024-04-18 16:45:47.306032",
  "modified_by": "Administrator",
  "module": "Assets",
  "name": "Asset",
@@ -628,7 +635,7 @@
   }
  ],
  "show_name_in_global_search": 1,
- "sort_field": "creation",
+ "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],
  "title_field": "asset_name",

--- a/erpnext/assets/doctype/asset/asset.json
+++ b/erpnext/assets/doctype/asset/asset.json
@@ -15,7 +15,6 @@
   "asset_owner_company",
   "is_existing_asset",
   "is_composite_asset",
-  "is_composite_component",
   "supplier",
   "customer",
   "image",
@@ -203,7 +202,8 @@
    "fieldname": "purchase_date",
    "fieldtype": "Date",
    "label": "Purchase Date",
-   "mandatory_depends_on": "eval:!doc.is_existing_asset && !doc.is_composite_asset"
+   "mandatory_depends_on": "eval:!doc.is_existing_asset && !doc.is_composite_asset",
+   "read_only_depends_on": "eval:!doc.is_existing_asset && !doc.is_composite_asset"
   },
   {
    "fieldname": "disposal_date",
@@ -234,7 +234,7 @@
    "fieldname": "available_for_use_date",
    "fieldtype": "Date",
    "label": "Available-for-use Date",
-   "mandatory_depends_on": "eval:(!doc.is_composite_component && doc.docstatus==1)"
+   "mandatory_depends_on": "eval:(!doc.is_composite_asset || doc.docstatus==1)"
   },
   {
    "default": "0",
@@ -509,7 +509,7 @@
   },
   {
    "default": "0",
-   "depends_on": "eval:(!doc.is_existing_asset && !doc.is_composite_component)",
+   "depends_on": "eval:!doc.is_existing_asset",
    "fieldname": "is_composite_asset",
    "fieldtype": "Check",
    "label": "Is Composite Asset"
@@ -537,13 +537,6 @@
    "label": "Additional Asset Cost",
    "options": "Company:company:default_currency",
    "read_only": 1
-  },
-  {
-   "default": "0",
-   "depends_on": "eval:(!doc.is_existing_asset && !doc.is_composite_asset)",
-   "fieldname": "is_composite_component",
-   "fieldtype": "Check",
-   "label": "Is Composite Component"
   },
   {
    "fieldname": "purchase_amount",

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -80,6 +80,7 @@ class Asset(AccountsController):
 		insured_value: DF.Data | None
 		insurer: DF.Data | None
 		is_composite_asset: DF.Check
+		is_composite_component: DF.Check
 		is_existing_asset: DF.Check
 		is_fully_depreciated: DF.Check
 		item_code: DF.Link
@@ -92,10 +93,10 @@ class Asset(AccountsController):
 		number_of_depreciations_booked: DF.Int
 		opening_accumulated_depreciation: DF.Currency
 		policy_number: DF.Data | None
+		purchase_amount: DF.Currency
 		purchase_date: DF.Date | None
 		purchase_invoice: DF.Link | None
 		purchase_receipt: DF.Link | None
-		purchase_receipt_amount: DF.Currency
 		split_from: DF.Link | None
 		status: DF.Literal[
 			"Draft",
@@ -356,7 +357,7 @@ class Asset(AccountsController):
 		if self.is_existing_asset:
 			return
 
-		if self.gross_purchase_amount and self.gross_purchase_amount != self.purchase_receipt_amount:
+		if self.gross_purchase_amount and self.gross_purchase_amount != self.purchase_amount:
 			error_message = _(
 				"Gross Purchase Amount should be <b>equal</b> to purchase amount of one single Asset."
 			)
@@ -695,11 +696,7 @@ class Asset(AccountsController):
 		purchase_document = self.get_purchase_document()
 		fixed_asset_account, cwip_account = self.get_fixed_asset_account(), self.get_cwip_account()
 
-		if (
-			purchase_document
-			and self.purchase_receipt_amount
-			and getdate(self.available_for_use_date) <= getdate()
-		):
+		if purchase_document and self.purchase_amount and getdate(self.available_for_use_date) <= getdate():
 			gl_entries.append(
 				self.get_gl_dict(
 					{
@@ -707,8 +704,8 @@ class Asset(AccountsController):
 						"against": fixed_asset_account,
 						"remarks": self.get("remarks") or _("Accounting Entry for Asset"),
 						"posting_date": self.available_for_use_date,
-						"credit": self.purchase_receipt_amount,
-						"credit_in_account_currency": self.purchase_receipt_amount,
+						"credit": self.purchase_amount,
+						"credit_in_account_currency": self.purchase_amount,
 						"cost_center": self.cost_center,
 					},
 					item=self,
@@ -722,8 +719,8 @@ class Asset(AccountsController):
 						"against": cwip_account,
 						"remarks": self.get("remarks") or _("Accounting Entry for Asset"),
 						"posting_date": self.available_for_use_date,
-						"debit": self.purchase_receipt_amount,
-						"debit_in_account_currency": self.purchase_receipt_amount,
+						"debit": self.purchase_amount,
+						"debit_in_account_currency": self.purchase_amount,
 						"cost_center": self.cost_center,
 					},
 					item=self,
@@ -1119,8 +1116,8 @@ def create_new_asset_after_split(asset, split_qty):
 	)
 
 	new_asset.gross_purchase_amount = new_gross_purchase_amount
-	if asset.purchase_receipt_amount:
-		new_asset.purchase_receipt_amount = new_gross_purchase_amount
+	if asset.purchase_amount:
+		new_asset.purchase_amount = new_gross_purchase_amount
 	new_asset.opening_accumulated_depreciation = opening_accumulated_depreciation
 	new_asset.asset_quantity = split_qty
 	new_asset.split_from = asset.name

--- a/erpnext/assets/doctype/asset/asset.py
+++ b/erpnext/assets/doctype/asset/asset.py
@@ -80,7 +80,6 @@ class Asset(AccountsController):
 		insured_value: DF.Data | None
 		insurer: DF.Data | None
 		is_composite_asset: DF.Check
-		is_composite_component: DF.Check
 		is_existing_asset: DF.Check
 		is_fully_depreciated: DF.Check
 		item_code: DF.Link

--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -1698,7 +1698,7 @@ def create_asset(**args):
 			"opening_accumulated_depreciation": args.opening_accumulated_depreciation or 0,
 			"number_of_depreciations_booked": args.number_of_depreciations_booked or 0,
 			"gross_purchase_amount": args.gross_purchase_amount or 100000,
-			"purchase_receipt_amount": args.purchase_receipt_amount or 100000,
+			"purchase_amount": args.purchase_amount or 100000,
 			"maintenance_required": args.maintenance_required or 0,
 			"warehouse": args.warehouse or "_Test Warehouse - _TC",
 			"available_for_use_date": args.available_for_use_date or "2020-06-06",

--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
@@ -616,8 +616,8 @@ class AssetCapitalization(StockController):
 		asset_doc.available_for_use_date = self.posting_date
 		asset_doc.purchase_date = self.posting_date
 		asset_doc.gross_purchase_amount = total_target_asset_value
-		asset_doc.purchase_receipt_amount = total_target_asset_value
-		asset_doc.purchase_receipt_amount = total_target_asset_value
+		asset_doc.purchase_amount = total_target_asset_value
+		asset_doc.purchase_amount = total_target_asset_value
 		asset_doc.capitalized_in = self.name
 		asset_doc.flags.ignore_validate = True
 		asset_doc.flags.asset_created_via_asset_capitalization = True
@@ -653,7 +653,7 @@ class AssetCapitalization(StockController):
 
 		asset_doc = frappe.get_doc("Asset", self.target_asset)
 		asset_doc.gross_purchase_amount = total_target_asset_value
-		asset_doc.purchase_receipt_amount = total_target_asset_value
+		asset_doc.purchase_amount = total_target_asset_value
 		asset_doc.capitalized_in = self.name
 		asset_doc.flags.ignore_validate = True
 		asset_doc.save()

--- a/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
+++ b/erpnext/assets/doctype/asset_capitalization/asset_capitalization.py
@@ -617,7 +617,6 @@ class AssetCapitalization(StockController):
 		asset_doc.purchase_date = self.posting_date
 		asset_doc.gross_purchase_amount = total_target_asset_value
 		asset_doc.purchase_amount = total_target_asset_value
-		asset_doc.purchase_amount = total_target_asset_value
 		asset_doc.capitalized_in = self.name
 		asset_doc.flags.ignore_validate = True
 		asset_doc.flags.asset_created_via_asset_capitalization = True

--- a/erpnext/assets/doctype/asset_capitalization/test_asset_capitalization.py
+++ b/erpnext/assets/doctype/asset_capitalization/test_asset_capitalization.py
@@ -89,7 +89,7 @@ class TestAssetCapitalization(unittest.TestCase):
 		# Test Target Asset values
 		target_asset = frappe.get_doc("Asset", asset_capitalization.target_asset)
 		self.assertEqual(target_asset.gross_purchase_amount, total_amount)
-		self.assertEqual(target_asset.purchase_receipt_amount, total_amount)
+		self.assertEqual(target_asset.purchase_amount, total_amount)
 
 		# Test Consumed Asset values
 		self.assertEqual(consumed_asset.db_get("status"), "Capitalized")
@@ -179,7 +179,7 @@ class TestAssetCapitalization(unittest.TestCase):
 		# Test Target Asset values
 		target_asset = frappe.get_doc("Asset", asset_capitalization.target_asset)
 		self.assertEqual(target_asset.gross_purchase_amount, total_amount)
-		self.assertEqual(target_asset.purchase_receipt_amount, total_amount)
+		self.assertEqual(target_asset.purchase_amount, total_amount)
 
 		# Test Consumed Asset values
 		self.assertEqual(consumed_asset.db_get("status"), "Capitalized")
@@ -256,7 +256,7 @@ class TestAssetCapitalization(unittest.TestCase):
 		# Test Target Asset values
 		target_asset = frappe.get_doc("Asset", asset_capitalization.target_asset)
 		self.assertEqual(target_asset.gross_purchase_amount, total_amount)
-		self.assertEqual(target_asset.purchase_receipt_amount, total_amount)
+		self.assertEqual(target_asset.purchase_amount, total_amount)
 
 		# Test General Ledger Entries
 		expected_gle = {
@@ -526,7 +526,7 @@ def create_depreciation_asset(**args):
 	asset.available_for_use_date = args.available_for_use_date or asset.purchase_date
 
 	asset.gross_purchase_amount = args.asset_value or 100000
-	asset.purchase_receipt_amount = asset.gross_purchase_amount
+	asset.purchase_amount = asset.gross_purchase_amount
 
 	finance_book = asset.append("finance_books")
 	finance_book.depreciation_start_date = args.depreciation_start_date or "2020-12-31"

--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -789,7 +789,7 @@ class BuyingController(SubcontractingController):
 				"supplier": self.supplier,
 				"purchase_date": self.posting_date,
 				"calculate_depreciation": 0,
-				"purchase_receipt_amount": purchase_amount,
+				"purchase_amount": purchase_amount,
 				"gross_purchase_amount": purchase_amount,
 				"asset_quantity": asset_quantity,
 				"purchase_receipt": self.name if self.doctype == "Purchase Receipt" else None,

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -365,3 +365,4 @@ erpnext.patches.v14_0.set_maintain_stock_for_bom_item
 erpnext.patches.v15_0.delete_orphaned_asset_movement_item_records
 erpnext.patches.v15_0.remove_cancelled_asset_capitalization_from_asset
 erpnext.patches.v15_0.fix_debit_credit_in_transaction_currency
+erpnext.patches.v15_0.rename_purchase_receipt_amount_to_purchase_amount

--- a/erpnext/patches/v15_0/rename_purchase_receipt_amount_to_purchase_amount.py
+++ b/erpnext/patches/v15_0/rename_purchase_receipt_amount_to_purchase_amount.py
@@ -1,0 +1,8 @@
+import frappe
+from frappe.model.utils.rename_field import rename_field
+
+
+def execute():
+	frappe.reload_doc("assets", "doctype", "asset")
+	if frappe.db.has_column("Asset", "purchase_receipt_amount"):
+		rename_field("Asset", "purchase_receipt_amount", "purchase_amount")

--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -849,7 +849,7 @@ class PurchaseReceipt(BuyingController):
 				asset.name,
 				{
 					"gross_purchase_amount": purchase_amount,
-					"purchase_receipt_amount": purchase_amount,
+					"purchase_amount": purchase_amount,
 				},
 			)
 


### PR DESCRIPTION
Field "Purchase Receipt Amount" was getting the amount from purchase receipt amount or purchase invoice amount of the asset and it was misleading. So naming it "Purchase Amount" is better approach for better understanding.