### PR TITLE
fix: stock reconciliation negative qty validation

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -1728,6 +1728,10 @@ def get_stock_reco_qty_shift(args):
 			stock_reco_qty_shift = flt(args.qty_after_transaction) - flt(last_balance)
 		else:
 			stock_reco_qty_shift = flt(args.actual_qty)
+
+	elif args.get("serial_and_batch_bundle"):
+		stock_reco_qty_shift = flt(args.actual_qty)
+
 	else:
 		# reco is being submitted
 		last_balance = get_previous_sle_of_current_voucher(args, "<=", exclude_current_voucher=True).get(
@@ -1799,6 +1803,15 @@ def get_datetime_limit_condition(detail):
 def validate_negative_qty_in_future_sle(args, allow_negative_stock=False):
 	if allow_negative_stock or is_negative_stock_allowed(item_code=args.item_code):
 		return
+
+	if (
+		args.voucher_type == "Stock Reconciliation"
+		and args.actual_qty < 0
+		and args.get("serial_and_batch_bundle")
+		and frappe.db.get_value("Stock Reconciliation Item", args.voucher_detail_no, "qty") > 0
+	):
+		return
+
 	if args.actual_qty >= 0 and args.voucher_type != "Stock Reconciliation":
 		return
 


### PR DESCRIPTION
1. Make stock inward entry for batch item with 50 qty
2. Make another stock inward  entry for batch item with 50 qty 
3. Make another stock inward  entry for batch item with 100 qty 
4. Make another stock inward  entry for batch item with 100 qty 
5. So total qty is 300 with 4 batches
6. Make Backdated stock reco after the 3rd stock entry and before the 4th stock entry posting time 
7. In the stock reco make first three batches qty to zero
8. Try to submit the stock reco
9. System will throw the negative stock error