### PR TITLE
fix: not able to update default supplier from Supplier Quotation Comparison report

### DIFF
--- a/erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.js
+++ b/erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.js
@@ -133,6 +133,13 @@ frappe.query_reports["Supplier Quotation Comparison"] = {
 			return row.supplier_name;
 		});
 
+		let items = [];
+		report.data.forEach((d) => {
+			if (!items.includes(d.item_code)) {
+				items.push(d.item_code);
+			}
+		});
+
 		// Create a dialog window for the user to pick their supplier
 		let dialog = new frappe.ui.Dialog({
 			title: __("Select Default Supplier"),
@@ -151,20 +158,34 @@ frappe.query_reports["Supplier Quotation Comparison"] = {
 						};
 					},
 				},
+				{
+					reqd: 1,
+					label: "Item",
+					fieldtype: "Link",
+					options: "Item",
+					fieldname: "item_code",
+					get_query: () => {
+						return {
+							filters: {
+								name: ["in", items],
+							},
+						};
+					},
+				},
 			],
 		});
 
 		dialog.set_primary_action(__("Set Default Supplier"), () => {
 			let values = dialog.get_values();
+
 			if (values) {
 				// Set the default_supplier field of the appropriate Item to the selected supplier
 				frappe.call({
-					method: "frappe.client.set_value",
+					method: "erpnext.buying.report.supplier_quotation_comparison.supplier_quotation_comparison.set_default_supplier",
 					args: {
-						doctype: "Item",
-						name: item_code,
-						fieldname: "default_supplier",
-						value: values.supplier,
+						item_code: values.item_code,
+						supplier: values.supplier,
+						company: filters.company,
 					},
 					freeze: true,
 					callback: (r) => {

--- a/erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py
+++ b/erpnext/buying/report/supplier_quotation_comparison/supplier_quotation_comparison.py
@@ -292,3 +292,13 @@ def get_message():
 		<span class="indicator red">
 		Expires today / Already Expired
 		</span>"""
+
+
+@frappe.whitelist()
+def set_default_supplier(item_code, supplier, company):
+	frappe.db.set_value(
+		"Item Default",
+		{"parent": item_code, "company": company},
+		"default_supplier",
+		supplier,
+	)


### PR DESCRIPTION
Getting below error while updating default supplier from Supplier Quotation Comparison report

<img width="753" alt="Screenshot 2024-04-19 at 3 22 28 PM" src="https://github.com/frappe/erpnext/assets/8780500/fb735680-5903-49e7-8eda-2a213efb3456">



New changes

Added item code in the popup

<img width="755" alt="image" src="https://github.com/frappe/erpnext/assets/8780500/795a29ad-a05b-4b49-9587-9e7867116134">
