### PR TITLE
fix: Missing args while fetching items from delivery note in Installation Note

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -907,11 +907,14 @@ erpnext.utils.map_current_doc = function (opts) {
 	if (opts.source_doctype) {
 		let data_fields = [];
 		if (["Purchase Receipt", "Delivery Note"].includes(opts.source_doctype)) {
-			data_fields.push({
-				fieldname: "merge_taxes",
-				fieldtype: "Check",
-				label: __("Merge taxes from multiple documents"),
-			});
+			let target_meta = frappe.get_meta(cur_frm.doc.doctype);
+			if (target_meta.fields.find((f) => f.fieldname === "taxes")) {
+				data_fields.push({
+					fieldname: "merge_taxes",
+					fieldtype: "Check",
+					label: __("Merge taxes from multiple documents"),
+				});
+			}
 		}
 		const d = new frappe.ui.form.MultiSelectDialog({
 			doctype: opts.source_doctype,

--- a/erpnext/stock/doctype/delivery_note/delivery_note.py
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.py
@@ -1093,7 +1093,7 @@ def make_delivery_trip(source_name, target_doc=None):
 
 
 @frappe.whitelist()
-def make_installation_note(source_name, target_doc=None):
+def make_installation_note(source_name, target_doc=None, kwargs=None):
 	def update_item(obj, target, source_parent):
 		target.qty = flt(obj.qty) - flt(obj.installed_qty)
 		target.serial_no = obj.serial_no


### PR DESCRIPTION
### Route

```

Form/Installation Note/new-installation-note-nwjwszzkqn

```

### Traceback

```
Traceback (most recent call last):

File "apps/frappe/frappe/[app.py](http://app.py/)", line 95, in application

response = frappe.api.handle()

File "apps/frappe/frappe/[api.py](http://api.py/)", line 55, in handle

return frappe.handler.handle()

File "apps/frappe/frappe/[handler.py](http://handler.py/)", line 48, in handle

data = execute_cmd(cmd)

File "apps/frappe/frappe/[handler.py](http://handler.py/)", line 86, in execute_cmd

return [frappe.call](http://frappe.call/)(method, **frappe.form_dict)

File "apps/frappe/frappe/__init__.py", line 1611, in call

return fn(*args, **newargs)

File "apps/frappe/frappe/model/[mapper.py](http://mapper.py/)", line 53, in map_docs

target_doc = method(*_args)

TypeError: make_installation_note() takes from 1 to 2 positional arguments but 3 were given

```
