### PR TITLE
fix: allow Employee role to select cost center & project (accounting dimensions)

### DIFF
--- a/erpnext/accounts/doctype/cost_center/cost_center.json
+++ b/erpnext/accounts/doctype/cost_center/cost_center.json
@@ -125,7 +125,7 @@
  "idx": 1,
  "is_tree": 1,
  "links": [],
- "modified": "2024-03-27 13:06:46.762208",
+ "modified": "2024-04-24 10:55:54.083042",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Cost Center",
@@ -163,6 +163,15 @@
   {
    "read": 1,
    "role": "Purchase User"
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "report": 1,
+   "role": "Employee",
+   "select": 1,
+   "share": 1
   }
  ],
  "search_fields": "parent_cost_center, is_group",

--- a/erpnext/projects/doctype/project/project.json
+++ b/erpnext/projects/doctype/project/project.json
@@ -454,7 +454,7 @@
  "index_web_pages_for_search": 1,
  "links": [],
  "max_attachments": 4,
- "modified": "2024-03-27 13:10:21.057163",
+ "modified": "2024-04-24 10:56:16.001032",
  "modified_by": "Administrator",
  "module": "Projects",
  "name": "Project",
@@ -489,6 +489,15 @@
    "role": "Projects Manager",
    "share": 1,
    "write": 1
+  },
+  {
+   "email": 1,
+   "export": 1,
+   "print": 1,
+   "report": 1,
+   "role": "Employee",
+   "select": 1,
+   "share": 1
   }
  ],
  "quick_entry": 1,


### PR DESCRIPTION
Added select perms for the Employee role on Cost Center & Project. These are needed during Expense Claim creation