### PR TITLE
feat: allow to do reposting for all stock transactions (audit)

### DIFF
--- a/erpnext/controllers/stock_controller.py
+++ b/erpnext/controllers/stock_controller.py
@@ -1404,7 +1404,12 @@ def is_reposting_pending():
 	)
 
 
-def future_sle_exists(args, sl_entries=None):
+def future_sle_exists(args, sl_entries=None, allow_force_reposting=True):
+	if allow_force_reposting and frappe.db.get_single_value(
+		"Stock Reposting Settings", "do_reposting_for_each_stock_transaction"
+	):
+		return True
+
 	key = (args.voucher_type, args.voucher_no)
 	if not hasattr(frappe.local, "future_sle"):
 		frappe.local.future_sle = {}

--- a/erpnext/stock/doctype/bin/bin.py
+++ b/erpnext/stock/doctype/bin/bin.py
@@ -238,7 +238,7 @@ def update_qty(bin_name, args):
 	sle = frappe.qb.DocType("Stock Ledger Entry")
 
 	# actual qty is not up to date in case of backdated transaction
-	if future_sle_exists(args):
+	if future_sle_exists(args, allow_force_reposting=False):
 		last_sle_qty = (
 			frappe.qb.from_(sle)
 			.select(sle.qty_after_transaction)

--- a/erpnext/stock/doctype/stock_reposting_settings/stock_reposting_settings.json
+++ b/erpnext/stock/doctype/stock_reposting_settings/stock_reposting_settings.json
@@ -13,6 +13,7 @@
   "end_time",
   "limits_dont_apply_on",
   "item_based_reposting",
+  "do_reposting_for_each_stock_transaction",
   "errors_notification_section",
   "notify_reposting_error_to_role"
  ],
@@ -65,12 +66,18 @@
    "fieldname": "errors_notification_section",
    "fieldtype": "Section Break",
    "label": "Errors Notification"
+  },
+  {
+   "default": "0",
+   "fieldname": "do_reposting_for_each_stock_transaction",
+   "fieldtype": "Check",
+   "label": "Do reposting for each Stock Transaction"
   }
  ],
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-03-27 13:10:45.069645",
+ "modified": "2024-04-24 12:19:40.204888",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Stock Reposting Settings",

--- a/erpnext/stock/doctype/stock_reposting_settings/stock_reposting_settings.py
+++ b/erpnext/stock/doctype/stock_reposting_settings/stock_reposting_settings.py
@@ -16,6 +16,7 @@ class StockRepostingSettings(Document):
 	if TYPE_CHECKING:
 		from frappe.types import DF
 
+		do_reposting_for_each_stock_transaction: DF.Check
 		end_time: DF.Time | None
 		item_based_reposting: DF.Check
 		limit_reposting_timeslot: DF.Check
@@ -28,6 +29,10 @@ class StockRepostingSettings(Document):
 
 	def validate(self):
 		self.set_minimum_reposting_time_slot()
+
+	def before_save(self):
+		if self.do_reposting_for_each_stock_transaction:
+			self.item_based_reposting = 1
 
 	def set_minimum_reposting_time_slot(self):
 		"""Ensure that timeslot for reposting is at least 12 hours."""

--- a/erpnext/stock/doctype/stock_reposting_settings/test_stock_reposting_settings.py
+++ b/erpnext/stock/doctype/stock_reposting_settings/test_stock_reposting_settings.py
@@ -38,3 +38,51 @@ class TestStockRepostingSettings(unittest.TestCase):
 
 		users = get_recipients()
 		self.assertTrue(user in users)
+
+	def test_do_reposting_for_each_stock_transaction(self):
+		from erpnext.stock.doctype.item.test_item import make_item
+		from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
+
+		frappe.db.set_single_value("Stock Reposting Settings", "do_reposting_for_each_stock_transaction", 1)
+		if frappe.db.get_single_value("Stock Reposting Settings", "item_based_reposting"):
+			frappe.db.set_single_value("Stock Reposting Settings", "item_based_reposting", 0)
+
+		item = make_item(
+			"_Test item for reposting check for each transaction", properties={"is_stock_item": 1}
+		).name
+
+		stock_entry = make_stock_entry(
+			item_code=item,
+			qty=1,
+			rate=100,
+			stock_entry_type="Material Receipt",
+			target="_Test Warehouse - _TC",
+		)
+
+		riv = frappe.get_all("Repost Item Valuation", filters={"voucher_no": stock_entry.name}, pluck="name")
+		self.assertTrue(riv)
+
+		frappe.db.set_single_value("Stock Reposting Settings", "do_reposting_for_each_stock_transaction", 0)
+
+	def test_do_not_reposting_for_each_stock_transaction(self):
+		from erpnext.stock.doctype.item.test_item import make_item
+		from erpnext.stock.doctype.stock_entry.stock_entry_utils import make_stock_entry
+
+		frappe.db.set_single_value("Stock Reposting Settings", "do_reposting_for_each_stock_transaction", 0)
+		if frappe.db.get_single_value("Stock Reposting Settings", "item_based_reposting"):
+			frappe.db.set_single_value("Stock Reposting Settings", "item_based_reposting", 0)
+
+		item = make_item(
+			"_Test item for do not reposting check for each transaction", properties={"is_stock_item": 1}
+		).name
+
+		stock_entry = make_stock_entry(
+			item_code=item,
+			qty=1,
+			rate=100,
+			stock_entry_type="Material Receipt",
+			target="_Test Warehouse - _TC",
+		)
+
+		riv = frappe.get_all("Repost Item Valuation", filters={"voucher_no": stock_entry.name}, pluck="name")
+		self.assertFalse(riv)


### PR DESCRIPTION
With the "Do reposting for each Stock Transaction" configuration, system will create the Reposting Entry for each stock transaction even though future SLE doesn't exists. This will be useful for the audit, specifically when user run the reposting non working hours. 

<img width="760" alt="image" src="https://github.com/frappe/erpnext/assets/8780500/c2081816-4480-476d-aa7d-6c77edb6c1ea">


Docs https://docs.erpnext.com/docs/user/manual/en/stock-reposting-settings