### PR TITLE
fix: refactor of margin and discount, breaking change, fixes #40799

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
+++ b/erpnext/accounts/doctype/pos_invoice/test_pos_invoice.py
@@ -873,12 +873,12 @@ class TestPOSInvoice(unittest.TestCase):
 		pr.save()
 
 		try:
-			pos_inv = create_pos_invoice(qty=1, do_not_submit=1)
+			pos_inv = create_pos_invoice(qty=1, do_not_submit=1, rate=0.0)
+			self.assertEqual(pos_inv.items[0].discount_percentage, 10)
 			pos_inv.items[0].rate = 300
 			pos_inv.save()
-			self.assertEqual(pos_inv.items[0].discount_percentage, 10)
 			# rate shouldn't change
-			self.assertEqual(pos_inv.items[0].rate, 405)
+			self.assertEqual(pos_inv.items[0].rate, 300)
 
 			pos_inv.ignore_pricing_rule = 1
 			pos_inv.save()

--- a/erpnext/accounts/doctype/pos_invoice_item/pos_invoice_item.json
+++ b/erpnext/accounts/doctype/pos_invoice_item/pos_invoice_item.json
@@ -32,6 +32,7 @@
   "base_price_list_rate",
   "discount_and_margin",
   "margin_type",
+  "margin_percentage",
   "margin_rate_or_amount",
   "rate_with_margin",
   "column_break_19",
@@ -275,27 +276,29 @@
   },
   {
    "collapsible": 1,
+   "collapsible_depends_on": "eval: doc.margin_rate_or_amount || doc.discount_amount",
+   "depends_on": "price_list_rate",
    "fieldname": "discount_and_margin",
    "fieldtype": "Section Break",
    "label": "Discount and Margin"
   },
   {
-   "depends_on": "price_list_rate",
    "fieldname": "margin_type",
    "fieldtype": "Select",
+   "hidden": 1,
    "label": "Margin Type",
    "options": "\nPercentage\nAmount",
    "print_hide": 1
   },
   {
-   "depends_on": "eval:doc.margin_type && doc.price_list_rate",
+   "description": "On price list rate",
    "fieldname": "margin_rate_or_amount",
-   "fieldtype": "Float",
-   "label": "Margin Rate or Amount",
+   "fieldtype": "Currency",
+   "label": "Margin Amount",
+   "options": "currency",
    "print_hide": 1
   },
   {
-   "depends_on": "eval:doc.margin_type && doc.price_list_rate && doc.margin_rate_or_amount",
    "fieldname": "rate_with_margin",
    "fieldtype": "Currency",
    "label": "Rate With Margin",
@@ -308,24 +311,22 @@
    "fieldtype": "Column Break"
   },
   {
-   "depends_on": "price_list_rate",
    "fieldname": "discount_percentage",
    "fieldtype": "Percent",
-   "label": "Discount (%) on Price List Rate with Margin",
+   "label": "Discount (%)",
    "oldfieldname": "adj_rate",
    "oldfieldtype": "Float",
-   "precision": "2",
    "print_hide": 1
   },
   {
-   "depends_on": "price_list_rate",
+   "description": "On price list rate",
    "fieldname": "discount_amount",
    "fieldtype": "Currency",
    "label": "Discount Amount",
-   "options": "currency"
+   "options": "currency",
+   "print_hide": 1
   },
   {
-   "depends_on": "eval:doc.margin_type && doc.price_list_rate && doc.margin_rate_or_amount",
    "fieldname": "base_rate_with_margin",
    "fieldtype": "Currency",
    "label": "Rate With Margin (Company Currency)",
@@ -849,11 +850,18 @@
   {
    "fieldname": "column_break_ciit",
    "fieldtype": "Column Break"
+  },
+  {
+   "columns": 1,
+   "fieldname": "margin_percentage",
+   "fieldtype": "Percent",
+   "label": "Margin (%)",
+   "print_hide": 1
   }
  ],
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:15.336778",
+ "modified": "2024-04-24 23:52:07.342691",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "POS Invoice Item",

--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -542,10 +542,18 @@ def apply_price_discount_rule(pricing_rule, item_details, args):
 		item_details.margin_type = pricing_rule.margin_type
 		item_details.has_margin = True
 
+		# bug here if multiple rules are a mixture of amount and percent
+		# item assumes one or the other
 		if pricing_rule.apply_multiple_pricing_rules and item_details.margin_rate_or_amount is not None:
-			item_details.margin_rate_or_amount += pricing_rule.margin_rate_or_amount
+			if pricing_rule.margin_type == "Percentage":
+				item_details.margin_percentage += pricing_rule.margin_rate_or_amount
+			else:
+				item_details.margin_rate_or_amount += pricing_rule.margin_rate_or_amount
 		else:
-			item_details.margin_rate_or_amount = pricing_rule.margin_rate_or_amount
+			if pricing_rule.margin_type == "Percentage":
+				item_details.margin_percentage = pricing_rule.margin_rate_or_amount
+			else:
+				item_details.margin_rate_or_amount = pricing_rule.margin_rate_or_amount
 
 	if pricing_rule.rate_or_discount == "Rate":
 		pricing_rule_rate = 0.0
@@ -565,35 +573,23 @@ def apply_price_discount_rule(pricing_rule, item_details, args):
 			)
 		item_details.update({"discount_percentage": 0.0})
 
-	for apply_on in ["Discount Amount", "Discount Percentage"]:
-		if pricing_rule.rate_or_discount != apply_on:
-			continue
-
-		field = frappe.scrub(apply_on)
-		if pricing_rule.apply_discount_on_rate and item_details.get("discount_percentage"):
-			# Apply discount on discounted rate
-			item_details[field] += (100 - item_details[field]) * (pricing_rule.get(field, 0) / 100)
-		elif args.price_list_rate:
-			value = pricing_rule.get(field, 0)
-			calculate_discount_percentage = False
-			if field == "discount_percentage":
-				field = "discount_amount"
-				value = args.price_list_rate * (value / 100)
-				calculate_discount_percentage = True
-
-			if field not in item_details:
-				item_details.setdefault(field, 0)
-
-			item_details[field] += value if pricing_rule else args.get(field, 0)
-			if calculate_discount_percentage and args.price_list_rate and item_details.discount_amount:
-				item_details.discount_percentage = flt(
-					(flt(item_details.discount_amount) / flt(args.price_list_rate)) * 100
-				)
+	if pricing_rule.rate_or_discount in ["Discount Amount", "Discount Percentage"]:
+		field = frappe.scrub(pricing_rule.rate_or_discount)
+		# bug: apply_multiple_pricing_rules is assumed true for discounts
+		if pricing_rule.apply_discount_on_rate and field == "discount_percentage":
+			if "discount_percentage" in item_details:
+				item_details[field] += (100.0 - item_details[field]) * (pricing_rule.get(field, 0.0) / 100.0)
+			else:
+				item_details["discount_amount"] += (
+					args.price_list_rate - item_details["discount_amount"]
+				) * (pricing_rule.get(field, 0.0) / 100.0)
+		elif "discount_amount" in item_details and field == "discount_percentage":
+			item_details["discount_amount"] += args.price_list_rate * (pricing_rule.get(field, 0.0) / 100.0)
+		elif "discount_percentage" in item_details and field == "discount_amount":
+			item_details["discount_percentage"] += 100.0 * pricing_rule.get(field, 0.0) / args.price_list_rate
 		else:
-			if field not in item_details:
-				item_details.setdefault(field, 0)
-
-			item_details[field] += pricing_rule.get(field, 0) if pricing_rule else args.get(field, 0)
+			item_details.setdefault(field, 0.0)
+			item_details[field] += pricing_rule.get(field, 0.0)
 
 
 @frappe.whitelist()

--- a/erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
+++ b/erpnext/accounts/doctype/purchase_invoice_item/purchase_invoice_item.json
@@ -33,6 +33,7 @@
   "base_price_list_rate",
   "section_break_26",
   "margin_type",
+  "margin_percentage",
   "margin_rate_or_amount",
   "rate_with_margin",
   "column_break_30",
@@ -254,13 +255,12 @@
    "print_hide": 1
   },
   {
-   "depends_on": "price_list_rate",
    "fieldname": "discount_percentage",
    "fieldtype": "Percent",
-   "label": "Discount on Price List Rate (%)"
+   "label": "Discount (%)"
   },
   {
-   "depends_on": "price_list_rate",
+   "description": "On price list rate",
    "fieldname": "discount_amount",
    "fieldtype": "Currency",
    "label": "Discount Amount",
@@ -835,32 +835,34 @@
   },
   {
    "collapsible": 1,
-   "collapsible_depends_on": "eval: doc.margin_type || doc.discount_amount",
+   "collapsible_depends_on": "eval: doc.margin_rate_or_amount || doc.discount_amount",
+   "depends_on": "price_list_rate",
    "fieldname": "section_break_26",
    "fieldtype": "Section Break",
    "label": "Discount and Margin"
   },
   {
-   "depends_on": "price_list_rate",
    "fieldname": "margin_type",
    "fieldtype": "Select",
+   "hidden": 1,
    "label": "Margin Type",
    "options": "\nPercentage\nAmount",
    "print_hide": 1
   },
   {
-   "depends_on": "eval:doc.margin_type && doc.price_list_rate",
+   "description": "On price list rate",
    "fieldname": "margin_rate_or_amount",
-   "fieldtype": "Float",
-   "label": "Margin Rate or Amount",
+   "fieldtype": "Currency",
+   "label": "Margin Amount",
+   "options": "currency",
    "print_hide": 1
   },
   {
-   "depends_on": "eval:doc.margin_type && doc.price_list_rate && doc.margin_rate_or_amount",
    "fieldname": "rate_with_margin",
    "fieldtype": "Currency",
    "label": "Rate With Margin",
    "options": "currency",
+   "print_hide": 1,
    "read_only": 1
   },
   {
@@ -868,7 +870,6 @@
    "fieldtype": "Column Break"
   },
   {
-   "depends_on": "eval:doc.margin_type && doc.price_list_rate && doc.margin_rate_or_amount",
    "fieldname": "base_rate_with_margin",
    "fieldtype": "Currency",
    "label": "Rate With Margin (Company Currency)",
@@ -934,12 +935,19 @@
   {
    "fieldname": "column_break_vbbb",
    "fieldtype": "Column Break"
+  },
+  {
+   "columns": 1,
+   "fieldname": "margin_percentage",
+   "fieldtype": "Percent",
+   "label": "Margin (%)",
+   "print_hide": 1
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:24.204495",
+ "modified": "2024-04-24 23:36:46.419880",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Purchase Invoice Item",

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -734,7 +734,7 @@ class TestSalesInvoice(FrappeTestCase):
 			{
 				"item_code": "_Test Item Home Desktop 100",
 				"price_list_rate": 55.56,
-				"discount_percentage": 10,
+				"discount_amount": 5.56,
 				"rate": 50,
 				"amount": 500,
 				"base_price_list_rate": 2778,
@@ -748,7 +748,7 @@ class TestSalesInvoice(FrappeTestCase):
 			{
 				"item_code": "_Test Item Home Desktop 200",
 				"price_list_rate": 187.5,
-				"discount_percentage": 20,
+				"discount_amount": 37.5,
 				"rate": 150,
 				"amount": 750,
 				"base_price_list_rate": 9375,
@@ -1852,11 +1852,12 @@ class TestSalesInvoice(FrappeTestCase):
 		price_list_rate = flt(100) * flt(si.plc_conversion_rate)
 		si.items[0].price_list_rate = price_list_rate
 		si.items[0].margin_type = "Percentage"
-		si.items[0].margin_rate_or_amount = 25
+		si.items[0].margin_percentage = 25
 		si.items[0].discount_amount = 0.0
 		si.items[0].discount_percentage = 0.0
+		si.items[0].rate = 0.0
 		si.save()
-		self.assertEqual(si.get("items")[0].rate, flt((price_list_rate * 25) / 100 + price_list_rate))
+		self.assertEqual(si.get("items")[0].rate, flt((price_list_rate * 125) / 100))
 
 	def test_outstanding_amount_after_advance_jv_cancellation(self):
 		from erpnext.accounts.doctype.journal_entry.test_journal_entry import (

--- a/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
+++ b/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
@@ -32,6 +32,7 @@
   "base_price_list_rate",
   "discount_and_margin",
   "margin_type",
+  "margin_percentage",
   "margin_rate_or_amount",
   "rate_with_margin",
   "column_break_19",
@@ -253,28 +254,29 @@
   },
   {
    "collapsible": 1,
-   "collapsible_depends_on": "eval: doc.margin_type || doc.discount_amount",
+   "collapsible_depends_on": "eval: doc.margin_rate_or_amount || doc.discount_amount",
+   "depends_on": "price_list_rate",
    "fieldname": "discount_and_margin",
    "fieldtype": "Section Break",
    "label": "Discount and Margin"
   },
   {
-   "depends_on": "price_list_rate",
    "fieldname": "margin_type",
    "fieldtype": "Select",
+   "hidden": 1,
    "label": "Margin Type",
    "options": "\nPercentage\nAmount",
    "print_hide": 1
   },
   {
-   "depends_on": "eval:doc.margin_type && doc.price_list_rate",
+   "description": "On price list rate",
    "fieldname": "margin_rate_or_amount",
-   "fieldtype": "Float",
-   "label": "Margin Rate or Amount",
+   "fieldtype": "Currency",
+   "label": "Margin Amount",
+   "options": "currency",
    "print_hide": 1
   },
   {
-   "depends_on": "eval:doc.margin_type && doc.price_list_rate && doc.margin_rate_or_amount",
    "fieldname": "rate_with_margin",
    "fieldtype": "Currency",
    "label": "Rate With Margin",
@@ -287,23 +289,22 @@
    "fieldtype": "Column Break"
   },
   {
-   "depends_on": "price_list_rate",
    "fieldname": "discount_percentage",
    "fieldtype": "Percent",
-   "label": "Discount (%) on Price List Rate with Margin",
+   "label": "Discount (%)",
    "oldfieldname": "adj_rate",
    "oldfieldtype": "Float",
    "print_hide": 1
   },
   {
-   "depends_on": "price_list_rate",
+   "description": "On price list rate",
    "fieldname": "discount_amount",
    "fieldtype": "Currency",
    "label": "Discount Amount",
-   "options": "currency"
+   "options": "currency",
+   "print_hide": 1
   },
   {
-   "depends_on": "eval:doc.margin_type && doc.price_list_rate && doc.margin_rate_or_amount",
    "fieldname": "base_rate_with_margin",
    "fieldtype": "Currency",
    "label": "Rate With Margin (Company Currency)",
@@ -921,12 +922,19 @@
   {
    "fieldname": "column_break_ytgd",
    "fieldtype": "Column Break"
+  },
+  {
+   "columns": 1,
+   "fieldname": "margin_percentage",
+   "fieldtype": "Percent",
+   "label": "Margin (%)",
+   "print_hide": 1
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:36.139679",
+ "modified": "2024-04-25 00:02:08.809997",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice Item",

--- a/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
+++ b/erpnext/buying/doctype/purchase_order_item/purchase_order_item.json
@@ -37,6 +37,7 @@
   "base_price_list_rate",
   "discount_and_margin_section",
   "margin_type",
+  "margin_percentage",
   "margin_rate_or_amount",
   "rate_with_margin",
   "column_break_28",
@@ -274,13 +275,12 @@
    "print_hide": 1
   },
   {
-   "depends_on": "price_list_rate",
    "fieldname": "discount_percentage",
    "fieldtype": "Percent",
-   "label": "Discount on Price List Rate (%)"
+   "label": "Discount (%)"
   },
   {
-   "depends_on": "price_list_rate",
+   "description": "On price list rate",
    "fieldname": "discount_amount",
    "fieldtype": "Currency",
    "label": "Discount Amount",
@@ -780,28 +780,29 @@
   },
   {
    "collapsible": 1,
-   "collapsible_depends_on": "eval: doc.margin_type || doc.discount_amount",
+   "collapsible_depends_on": "eval: doc.margin_rate_or_amount || doc.discount_amount",
+   "depends_on": "price_list_rate",
    "fieldname": "discount_and_margin_section",
    "fieldtype": "Section Break",
    "label": "Discount and Margin"
   },
   {
-   "depends_on": "price_list_rate",
    "fieldname": "margin_type",
    "fieldtype": "Select",
+   "hidden": 1,
    "label": "Margin Type",
    "options": "\nPercentage\nAmount",
    "print_hide": 1
   },
   {
-   "depends_on": "eval:doc.margin_type && doc.price_list_rate",
+   "description": "On price list rate",
    "fieldname": "margin_rate_or_amount",
-   "fieldtype": "Float",
-   "label": "Margin Rate or Amount",
+   "fieldtype": "Currency",
+   "label": "Margin Amount",
+   "options": "currency",
    "print_hide": 1
   },
   {
-   "depends_on": "eval:doc.margin_type && doc.price_list_rate && doc.margin_rate_or_amount",
    "fieldname": "rate_with_margin",
    "fieldtype": "Currency",
    "label": "Rate With Margin",
@@ -814,7 +815,6 @@
    "fieldtype": "Column Break"
   },
   {
-   "depends_on": "eval:doc.margin_type && doc.price_list_rate && doc.margin_rate_or_amount",
    "fieldname": "base_rate_with_margin",
    "fieldtype": "Currency",
    "label": "Rate With Margin (Company Currency)",
@@ -909,13 +909,20 @@
   {
    "fieldname": "column_break_fyqr",
    "fieldtype": "Column Break"
+  },
+  {
+   "columns": 1,
+   "fieldname": "margin_percentage",
+   "fieldtype": "Percent",
+   "label": "Margin (%)",
+   "print_hide": 1
   }
  ],
  "idx": 1,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:24.979325",
+ "modified": "2024-04-24 23:41:36.973696",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Purchase Order Item",

--- a/erpnext/controllers/buying_controller.py
+++ b/erpnext/controllers/buying_controller.py
@@ -122,6 +122,7 @@ class BuyingController(SubcontractingController):
 					row.discount_percentage = 0.0
 					row.discount_amount = 0.0
 					row.margin_rate_or_amount = 0.0
+					row.margin_percentage = 0.0
 
 	def set_missing_values(self, for_validate=False):
 		super().set_missing_values(for_validate)
@@ -399,6 +400,7 @@ class BuyingController(SubcontractingController):
 						d.discount_percentage = 0.0
 						d.discount_amount = 0.0
 						d.margin_rate_or_amount = 0.0
+						d.margin_percentage = 0.0
 
 	def validate_for_subcontracting(self):
 		if self.is_subcontracted and self.get("is_old_subcontracting_flow"):

--- a/erpnext/public/js/utils/sales_common.js
+++ b/erpnext/public/js/utils/sales_common.js
@@ -151,22 +151,6 @@ erpnext.sales_common = {
 				this.set_dynamic_labels();
 			}
 
-			discount_percentage(doc, cdt, cdn) {
-				var item = frappe.get_doc(cdt, cdn);
-				item.discount_amount = 0.0;
-				this.apply_discount_on_item(doc, cdt, cdn, "discount_percentage");
-			}
-
-			discount_amount(doc, cdt, cdn) {
-				if (doc.name === cdn) {
-					return;
-				}
-
-				var item = frappe.get_doc(cdt, cdn);
-				item.discount_percentage = 0.0;
-				this.apply_discount_on_item(doc, cdt, cdn, "discount_amount");
-			}
-
 			commission_rate() {
 				this.calculate_commission();
 			}

--- a/erpnext/selling/doctype/quotation/test_quotation.py
+++ b/erpnext/selling/doctype/quotation/test_quotation.py
@@ -150,9 +150,11 @@ class TestQuotation(FrappeTestCase):
 		quotation.save()
 		quotation.submit()
 
-		self.assertEqual(quotation.payment_schedule[0].payment_amount, 8906.00)
+		# Payment schedule is 50% twice of 10 * 1781.25 = 8906.25
+		# however, rounding depends on currency which is INR by default in github?
+		self.assertEqual(quotation.payment_schedule[0].payment_amount, 8906.0)
 		self.assertEqual(quotation.payment_schedule[0].due_date, quotation.transaction_date)
-		self.assertEqual(quotation.payment_schedule[1].payment_amount, 8906.00)
+		self.assertEqual(quotation.payment_schedule[1].payment_amount, 8906.0)
 		self.assertEqual(quotation.payment_schedule[1].due_date, add_days(quotation.transaction_date, 30))
 
 		sales_order = make_sales_order(quotation.name)
@@ -172,9 +174,9 @@ class TestQuotation(FrappeTestCase):
 		sales_order.set("taxes", [])
 		sales_order.save()
 
-		self.assertEqual(sales_order.payment_schedule[0].payment_amount, 8906.00)
+		self.assertEqual(sales_order.payment_schedule[0].payment_amount, 8906.0)
 		self.assertEqual(sales_order.payment_schedule[0].due_date, getdate(quotation.transaction_date))
-		self.assertEqual(sales_order.payment_schedule[1].payment_amount, 8906.00)
+		self.assertEqual(sales_order.payment_schedule[1].payment_amount, 8906.0)
 		self.assertEqual(
 			sales_order.payment_schedule[1].due_date, getdate(add_days(quotation.transaction_date, 30))
 		)
@@ -207,11 +209,13 @@ class TestQuotation(FrappeTestCase):
 			make_sales_invoice,
 		)
 
-		rate_with_margin = flt((1500 * 18.75) / 100 + 1500)
+		# 1781.25
+		rate_with_margin = flt((1500 * 118.75) / 100)
 
 		test_records[0]["items"][0]["price_list_rate"] = 1500
 		test_records[0]["items"][0]["margin_type"] = "Percentage"
-		test_records[0]["items"][0]["margin_rate_or_amount"] = 18.75
+		test_records[0]["items"][0]["margin_percentage"] = 18.75
+		test_records[0]["items"][0]["rate"] = 0.0
 
 		quotation = frappe.copy_doc(test_records[0])
 		quotation.transaction_date = nowdate()

--- a/erpnext/selling/doctype/quotation_item/quotation_item.json
+++ b/erpnext/selling/doctype/quotation_item/quotation_item.json
@@ -29,6 +29,7 @@
   "base_price_list_rate",
   "discount_and_margin",
   "margin_type",
+  "margin_percentage",
   "margin_rate_or_amount",
   "rate_with_margin",
   "column_break_18",
@@ -235,28 +236,29 @@
   },
   {
    "collapsible": 1,
-   "collapsible_depends_on": "eval: doc.margin_type || doc.discount_amount",
+   "collapsible_depends_on": "eval: doc.margin_rate_or_amount || doc.discount_amount",
+   "depends_on": "price_list_rate",
    "fieldname": "discount_and_margin",
    "fieldtype": "Section Break",
    "label": "Discount and Margin"
   },
   {
-   "depends_on": "price_list_rate",
    "fieldname": "margin_type",
    "fieldtype": "Select",
+   "hidden": 1,
    "label": "Margin Type",
    "options": "\nPercentage\nAmount",
    "print_hide": 1
   },
   {
-   "depends_on": "eval:doc.margin_type && doc.price_list_rate",
+   "description": "On price list rate",
    "fieldname": "margin_rate_or_amount",
-   "fieldtype": "Float",
-   "label": "Margin Rate or Amount",
+   "fieldtype": "Currency",
+   "label": "Margin Amount",
+   "options": "currency",
    "print_hide": 1
   },
   {
-   "depends_on": "eval:doc.margin_type && doc.price_list_rate && doc.margin_rate_or_amount",
    "fieldname": "rate_with_margin",
    "fieldtype": "Currency",
    "label": "Rate With Margin",
@@ -269,10 +271,9 @@
    "fieldtype": "Column Break"
   },
   {
-   "depends_on": "price_list_rate",
    "fieldname": "discount_percentage",
    "fieldtype": "Percent",
-   "label": "Discount (%) on Price List Rate with Margin",
+   "label": "Discount (%)",
    "oldfieldname": "adj_rate",
    "oldfieldtype": "Float",
    "print_hide": 1,
@@ -280,7 +281,7 @@
    "width": "100px"
   },
   {
-   "depends_on": "price_list_rate",
+   "description": "On price list rate",
    "fieldname": "discount_amount",
    "fieldtype": "Currency",
    "label": "Discount Amount",
@@ -662,12 +663,19 @@
    "label": "Has Alternative Item",
    "print_hide": 1,
    "read_only": 1
+  },
+  {
+   "columns": 1,
+   "fieldname": "margin_percentage",
+   "fieldtype": "Percent",
+   "label": "Margin (%)",
+   "print_hide": 1
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:31.183320",
+ "modified": "2024-04-24 23:34:58.299181",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Quotation Item",

--- a/erpnext/selling/doctype/sales_order/test_sales_order.py
+++ b/erpnext/selling/doctype/sales_order/test_sales_order.py
@@ -1210,19 +1210,20 @@ class TestSalesOrder(FrappeTestCase):
 		so = make_sales_order(item_code="_Test Item", qty=1, do_not_submit=True)
 		so.items[0].price_list_rate = price_list_rate = 100
 		so.items[0].margin_type = "Percentage"
-		so.items[0].margin_rate_or_amount = 25
+		so.items[0].margin_percentage = 25
+		so.items[0].rate = 0.0
 		so.save()
 
 		new_so = frappe.copy_doc(so)
 		new_so.save(ignore_permissions=True)
 
-		self.assertEqual(new_so.get("items")[0].rate, flt((price_list_rate * 25) / 100 + price_list_rate))
+		self.assertEqual(new_so.get("items")[0].rate, flt((price_list_rate * 125) / 100))
 		new_so.items[0].margin_rate_or_amount = 25
 		new_so.payment_schedule = []
 		new_so.save()
 		new_so.submit()
 
-		self.assertEqual(new_so.get("items")[0].rate, flt((price_list_rate * 25) / 100 + price_list_rate))
+		self.assertEqual(new_so.get("items")[0].rate, flt((price_list_rate * 125) / 100))
 
 	def test_terms_auto_added(self):
 		so = make_sales_order(do_not_save=1)

--- a/erpnext/selling/doctype/sales_order_item/sales_order_item.json
+++ b/erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -35,6 +35,7 @@
   "base_price_list_rate",
   "discount_and_margin",
   "margin_type",
+  "margin_percentage",
   "margin_rate_or_amount",
   "rate_with_margin",
   "column_break_19",
@@ -280,28 +281,29 @@
   },
   {
    "collapsible": 1,
-   "collapsible_depends_on": "eval: doc.margin_type || doc.discount_amount",
+   "collapsible_depends_on": "eval: doc.margin_rate_or_amount || doc.discount_amount",
+   "depends_on": "price_list_rate",
    "fieldname": "discount_and_margin",
    "fieldtype": "Section Break",
    "label": "Discount and Margin"
   },
   {
-   "depends_on": "price_list_rate",
    "fieldname": "margin_type",
    "fieldtype": "Select",
+   "hidden": 1,
    "label": "Margin Type",
    "options": "\nPercentage\nAmount",
    "print_hide": 1
   },
   {
-   "depends_on": "eval:doc.margin_type && doc.price_list_rate",
+   "description": "On price list rate",
    "fieldname": "margin_rate_or_amount",
-   "fieldtype": "Float",
-   "label": "Margin Rate or Amount",
+   "fieldtype": "Currency",
+   "label": "Margin Amount",
+   "options": "currency",
    "print_hide": 1
   },
   {
-   "depends_on": "eval:doc.margin_type && doc.price_list_rate && doc.margin_rate_or_amount",
    "fieldname": "rate_with_margin",
    "fieldtype": "Currency",
    "label": "Rate With Margin",
@@ -314,10 +316,9 @@
    "fieldtype": "Column Break"
   },
   {
-   "depends_on": "price_list_rate",
    "fieldname": "discount_percentage",
    "fieldtype": "Percent",
-   "label": "Discount (%) on Price List Rate with Margin",
+   "label": "Discount (%)",
    "oldfieldname": "adj_rate",
    "oldfieldtype": "Float",
    "print_hide": 1,
@@ -325,14 +326,13 @@
    "width": "70px"
   },
   {
-   "depends_on": "price_list_rate",
+   "description": "On price list rate",
    "fieldname": "discount_amount",
    "fieldtype": "Currency",
    "label": "Discount Amount",
    "options": "currency"
   },
   {
-   "depends_on": "eval:doc.margin_type && doc.price_list_rate && doc.margin_rate_or_amount",
    "fieldname": "base_rate_with_margin",
    "fieldtype": "Currency",
    "label": "Rate With Margin (Company Currency)",
@@ -905,12 +905,19 @@
    "label": "Is Stock Item",
    "print_hide": 1,
    "report_hide": 1
+  },
+  {
+   "columns": 1,
+   "fieldname": "margin_percentage",
+   "fieldtype": "Percent",
+   "label": "Margin (%)",
+   "print_hide": 1
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:37.177978",
+ "modified": "2024-04-25 00:08:24.073733",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order Item",

--- a/erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
+++ b/erpnext/stock/doctype/delivery_note_item/delivery_note_item.json
@@ -35,6 +35,7 @@
   "base_price_list_rate",
   "discount_and_margin",
   "margin_type",
+  "margin_percentage",
   "margin_rate_or_amount",
   "rate_with_margin",
   "column_break_19",
@@ -274,28 +275,29 @@
   },
   {
    "collapsible": 1,
-   "collapsible_depends_on": "eval: doc.margin_type || doc.discount_amount",
+   "collapsible_depends_on": "eval: doc.margin_rate_or_amount || doc.discount_amount",
+   "depends_on": "price_list_rate",
    "fieldname": "discount_and_margin",
    "fieldtype": "Section Break",
    "label": "Discount and Margin"
   },
   {
-   "depends_on": "price_list_rate",
    "fieldname": "margin_type",
    "fieldtype": "Select",
+   "hidden": 1,
    "label": "Margin Type",
    "options": "\nPercentage\nAmount",
    "print_hide": 1
   },
   {
-   "depends_on": "eval:doc.margin_type && doc.price_list_rate",
+   "description": "On price list rate",
    "fieldname": "margin_rate_or_amount",
-   "fieldtype": "Float",
-   "label": "Margin Rate or Amount",
+   "fieldtype": "Currency",
+   "label": "Margin Amount",
+   "options": "currency",
    "print_hide": 1
   },
   {
-   "depends_on": "eval:doc.margin_type && doc.price_list_rate && doc.margin_rate_or_amount",
    "fieldname": "rate_with_margin",
    "fieldtype": "Currency",
    "label": "Rate With Margin",
@@ -308,10 +310,9 @@
    "fieldtype": "Column Break"
   },
   {
-   "depends_on": "price_list_rate",
    "fieldname": "discount_percentage",
    "fieldtype": "Float",
-   "label": "Discount (%) on Price List Rate with Margin",
+   "label": "Discount (%)",
    "oldfieldname": "adj_rate",
    "oldfieldtype": "Float",
    "print_hide": 1,
@@ -319,14 +320,13 @@
    "width": "100px"
   },
   {
-   "depends_on": "price_list_rate",
+   "description": "On price list rate",
    "fieldname": "discount_amount",
    "fieldtype": "Currency",
    "label": "Discount Amount",
    "options": "currency"
   },
   {
-   "depends_on": "eval:doc.margin_type && doc.price_list_rate && doc.margin_rate_or_amount",
    "fieldname": "base_rate_with_margin",
    "fieldtype": "Currency",
    "label": "Rate With Margin (Company Currency)",
@@ -907,13 +907,20 @@
   {
    "fieldname": "column_break_rxvc",
    "fieldtype": "Column Break"
+  },
+  {
+   "columns": 1,
+   "fieldname": "margin_percentage",
+   "fieldtype": "Percent",
+   "label": "Margin (%)",
+   "print_hide": 1
   }
  ],
  "idx": 1,
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:06:50.061877",
+ "modified": "2024-04-24 23:33:13.596212",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Delivery Note Item",

--- a/erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
+++ b/erpnext/stock/doctype/purchase_receipt_item/purchase_receipt_item.json
@@ -43,6 +43,7 @@
   "base_price_list_rate",
   "discount_and_margin_section",
   "margin_type",
+  "margin_percentage",
   "margin_rate_or_amount",
   "rate_with_margin",
   "column_break_37",
@@ -321,14 +322,13 @@
    "print_hide": 1
   },
   {
-   "depends_on": "price_list_rate",
    "fieldname": "discount_percentage",
    "fieldtype": "Percent",
-   "label": "Discount on Price List Rate (%)",
+   "label": "Discount (%)",
    "print_hide": 1
   },
   {
-   "depends_on": "price_list_rate",
+   "description": "On price list rate",
    "fieldname": "discount_amount",
    "fieldtype": "Currency",
    "label": "Discount Amount",
@@ -909,28 +909,29 @@
   },
   {
    "collapsible": 1,
-   "collapsible_depends_on": "eval: doc.margin_type || doc.discount_amount",
+   "collapsible_depends_on": "eval: doc.margin_rate_or_amount || doc.discount_amount",
+   "depends_on": "price_list_rate",
    "fieldname": "discount_and_margin_section",
    "fieldtype": "Section Break",
    "label": "Discount and Margin"
   },
   {
-   "depends_on": "price_list_rate",
    "fieldname": "margin_type",
    "fieldtype": "Select",
+   "hidden": 1,
    "label": "Margin Type",
    "options": "\nPercentage\nAmount",
    "print_hide": 1
   },
   {
-   "depends_on": "eval:doc.margin_type && doc.price_list_rate",
+   "description": "On price list rate",
    "fieldname": "margin_rate_or_amount",
-   "fieldtype": "Float",
-   "label": "Margin Rate or Amount",
+   "fieldtype": "Currency",
+   "label": "Margin Amount",
+   "options": "currency",
    "print_hide": 1
   },
   {
-   "depends_on": "eval:doc.margin_type && doc.price_list_rate && doc.margin_rate_or_amount",
    "fieldname": "rate_with_margin",
    "fieldtype": "Currency",
    "label": "Rate With Margin",
@@ -943,11 +944,11 @@
    "fieldtype": "Column Break"
   },
   {
-   "depends_on": "eval:doc.margin_type && doc.price_list_rate && doc.margin_rate_or_amount",
    "fieldname": "base_rate_with_margin",
    "fieldtype": "Currency",
    "label": "Rate With Margin (Company Currency)",
-   "options": "Company:company:default_currency"
+   "options": "Company:company:default_currency",
+   "print_hide": 1
   },
   {
    "fieldname": "purchase_invoice",
@@ -1116,12 +1117,19 @@
    "hidden": 1,
    "label": "Apply TDS",
    "read_only": 1
+  },
+  {
+   "columns": 1,
+   "fieldname": "margin_percentage",
+   "fieldtype": "Percent",
+   "label": "Margin (%)",
+   "print_hide": 1
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-04-08 20:00:16.277292",
+ "modified": "2024-04-24 23:39:10.292431",
  "modified_by": "Administrator",
  "module": "Stock",
  "name": "Purchase Receipt Item",


### PR DESCRIPTION
fix: modify to support pricing rule
fix: percentage margin in pricing rule
fix: margin & discount fields in transactions and server-side controller calculations

fixes: #40799

Refactor of margin and discount on all transactions so that either percentage or amount can be entered (the other is calculated), are never zeroed, and both are calculated from price list rate rather than discount being after margin is added.

## margin_type field in all transactions now deprecated. Remove in version 17

A lot more intuitive and user friendly.

**Breaking Change**

![Screen Shot 2024-04-25 at 06 07 08](https://github.com/frappe/erpnext/assets/110036763/9b2909f4-6084-4416-a1f9-34bc416eebc1)

no-docs
version-14-hotfix
version-15-hotfix

PS I will change the docs if I can get access. I tried recently and couldn't create a login