### PR TITLE
fix: rendering the email template when user HTML

### DIFF
--- a/erpnext/crm/doctype/email_campaign/email_campaign.py
+++ b/erpnext/crm/doctype/email_campaign/email_campaign.py
@@ -121,7 +121,7 @@ def send_mail(entry, email_campaign):
 		doctype="Email Campaign",
 		name=email_campaign.name,
 		subject=frappe.render_template(email_template.get("subject"), context),
-		content=frappe.render_template(email_template.get("response"), context),
+		content=frappe.render_template(email_template.response_, context),
 		sender=sender,
 		recipients=recipient_list,
 		communication_medium="Email",


### PR DESCRIPTION
version 15

fixes: #41168

![image](https://github.com/frappe/erpnext/assets/141945075/26a01498-165b-477c-9319-4125d723cea3)

**Before:**


- show blank

![image](https://github.com/frappe/erpnext/assets/141945075/da73644d-9bb8-4373-9c31-a834ab3c3a17)

**After:**


![image](https://github.com/frappe/erpnext/assets/141945075/4ff67793-816b-4966-963a-24bdd69c044c)
