### PR TITLE
fix: restrict Advance in separate party to customer and supplier

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -197,6 +197,7 @@ class PaymentEntry(AccountsController):
 		if self.docstatus > 0 or self.payment_type == "Internal Transfer":
 			return
 
+		self.book_advance_payments_in_separate_party_account = False
 		if self.party_type not in ("Customer", "Supplier"):
 			return
 


### PR DESCRIPTION
`Book Advance in Separate Party Account` is restricted to Customer and Supplier party types