### PR TITLE
fix: handle stock balance unbuffered_cursor error

### DIFF
--- a/erpnext/stock/report/stock_balance/stock_balance.py
+++ b/erpnext/stock/report/stock_balance/stock_balance.py
@@ -146,6 +146,8 @@ class StockBalanceReport:
 		if self.filters.get("show_stock_ageing_data"):
 			self.sle_entries = self.sle_query.run(as_dict=True)
 
+		# HACK: This is required to avoid causing db query in flt
+		_system_settings = frappe.get_cached_doc("System Settings")
 		with frappe.db.unbuffered_cursor():
 			if not self.filters.get("show_stock_ageing_data"):
 				self.sle_entries = self.sle_query.run(as_dict=True, as_iterator=True)


### PR DESCRIPTION
![image](https://github.com/frappe/erpnext/assets/9079960/de5c7415-d02f-4c3b-acd6-ede28c06baa3)


```
File "apps/frappe/frappe/database/database.py", line 321, in _return_as_iterator
while result := self._transform_result(self._cursor.fetchmany(SQL_ITERATOR_BATCH_SIZE)):
self = <frappe.database.mariadb.database.MariaDBDatabase object at 0x7fa02c70fd60>
pluck = False
as_dict = True
as_list = 0
update = None
keys = ********
File "env/lib/python3.10/site-packages/pymysql/cursors.py", line 476, in fetchmany
row = self.read_next()
self = <pymysql.cursors.SSCursor object at 0x7fa02710a740>
size = 100
rows = []
i = 0
File "env/lib/python3.10/site-packages/pymysql/cursors.py", line 438, in read_next
return self._conv_row(self._result._read_rowdata_packet_unbuffered())
self = <pymysql.cursors.SSCursor object at 0x7fa02710a740>
builtins.AttributeError: 'NoneType' object has no attribute '_read_rowdata_packet_unbuffered'
```