### PR TITLE
fix: TDS incorrectly applied when Advance is in previous FY

### DIFF
--- a/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
+++ b/erpnext/accounts/doctype/tax_withholding_category/tax_withholding_category.py
@@ -282,6 +282,14 @@ def get_tax_amount(party_type, parties, inv, tax_details, posting_date, pan_no=N
 	if taxable_vouchers:
 		tax_deducted = get_deducted_tax(taxable_vouchers, tax_details)
 
+	# If advance is outside the current tax withholding period (usually a fiscal year), `get_deducted_tax` won't fetch it.
+	# updating `tax_deducted` with correct advance tax value (from current and previous previous withholding periods), will allow the
+	# rest of the below logic to function properly
+	# ---FY 2023-------------||---------------------FY 2024-----------------------||--
+	# ---Advance-------------||---------Inv_1--------Inv_2------------------------||--
+	if tax_deducted_on_advances:
+		tax_deducted += get_advance_tax_across_fiscal_year(tax_deducted_on_advances, tax_details)
+
 	tax_amount = 0
 
 	if party_type == "Supplier":
@@ -418,7 +426,7 @@ def get_taxes_deducted_on_advances_allocated(inv, tax_details):
 				frappe.qb.from_(at)
 				.inner_join(pe)
 				.on(pe.name == at.parent)
-				.select(at.parent, at.name, at.tax_amount, at.allocated_amount)
+				.select(pe.posting_date, at.parent, at.name, at.tax_amount, at.allocated_amount)
 				.where(pe.tax_withholding_category == tax_details.get("tax_withholding_category"))
 				.where(at.parent.isin(advances))
 				.where(at.account_head == tax_details.account_head)
@@ -441,6 +449,16 @@ def get_deducted_tax(taxable_vouchers, tax_details):
 
 	entries = frappe.db.get_all("GL Entry", filters, pluck=field)
 	return sum(entries)
+
+
+def get_advance_tax_across_fiscal_year(tax_deducted_on_advances, tax_details):
+	"""
+	Only applies for Taxes deducted on Advance Payments
+	"""
+	advance_tax_from_across_fiscal_year = sum(
+		[adv.tax_amount for adv in tax_deducted_on_advances if adv.posting_date < tax_details.from_date]
+	)
+	return advance_tax_from_across_fiscal_year
 
 
 def get_tds_amount(ldc, parties, inv, tax_details, vouchers):

--- a/erpnext/accounts/doctype/tax_withholding_category/test_tax_withholding_category.py
+++ b/erpnext/accounts/doctype/tax_withholding_category/test_tax_withholding_category.py
@@ -1,18 +1,22 @@
 # Copyright (c) 2018, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
+import datetime
 import unittest
 
 import frappe
 from frappe.custom.doctype.custom_field.custom_field import create_custom_fields
-from frappe.utils import today
+from frappe.tests.utils import FrappeTestCase, change_settings
+from frappe.utils import add_days, today
 
+from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
 from erpnext.accounts.utils import get_fiscal_year
+from erpnext.buying.doctype.purchase_order.purchase_order import make_purchase_invoice
 
 test_dependencies = ["Supplier Group", "Customer Group"]
 
 
-class TestTaxWithholdingCategory(unittest.TestCase):
+class TestTaxWithholdingCategory(FrappeTestCase):
 	@classmethod
 	def setUpClass(self):
 		# create relevant supplier, etc
@@ -21,7 +25,7 @@ class TestTaxWithholdingCategory(unittest.TestCase):
 		make_pan_no_field()
 
 	def tearDown(self):
-		cancel_invoices()
+		frappe.db.rollback()
 
 	def test_cumulative_threshold_tds(self):
 		frappe.db.set_value(
@@ -317,8 +321,6 @@ class TestTaxWithholdingCategory(unittest.TestCase):
 			d.cancel()
 
 	def test_tds_deduction_for_po_via_payment_entry(self):
-		from erpnext.accounts.doctype.payment_entry.payment_entry import get_payment_entry
-
 		frappe.db.set_value(
 			"Supplier", "Test TDS Supplier8", "tax_withholding_category", "Cumulative Threshold TDS"
 		)
@@ -484,6 +486,133 @@ class TestTaxWithholdingCategory(unittest.TestCase):
 		pi1.cancel()
 		pi2.cancel()
 		pi3.cancel()
+
+	def set_previous_fy_and_tax_category(self):
+		test_company = "_Test Company"
+		category = "Cumulative Threshold TDS"
+
+		def add_company_to_fy(fy, company):
+			if not [x.company for x in fy.companies if x.company == company]:
+				fy.append("companies", {"company": company})
+				fy.save()
+
+		# setup previous fiscal year
+		fiscal_year = get_fiscal_year(today(), company=test_company)
+		if prev_fiscal_year := get_fiscal_year(add_days(fiscal_year[1], -10)):
+			self.prev_fy = frappe.get_doc("Fiscal Year", prev_fiscal_year[0])
+			add_company_to_fy(self.prev_fy, test_company)
+		else:
+			# make previous fiscal year
+			start = datetime.date(fiscal_year[1].year - 1, fiscal_year[1].month, fiscal_year[1].day)
+			end = datetime.date(fiscal_year[2].year - 1, fiscal_year[2].month, fiscal_year[2].day)
+			self.prev_fy = frappe.get_doc(
+				{
+					"doctype": "Fiscal Year",
+					"year_start_date": start,
+					"year_end_date": end,
+					"companies": [{"company": test_company}],
+				}
+			)
+			self.prev_fy.save()
+
+		# setup tax withholding category for previous fiscal year
+		cat = frappe.get_doc("Tax Withholding Category", category)
+		cat.append(
+			"rates",
+			{
+				"from_date": self.prev_fy.year_start_date,
+				"to_date": self.prev_fy.year_end_date,
+				"tax_withholding_rate": 10,
+				"single_threshold": 0,
+				"cumulative_threshold": 30000,
+			},
+		)
+		cat.save()
+
+	def test_tds_across_fiscal_year(self):
+		"""
+		Advance TDS on previous fiscal year should be properly allocated on Invoices in upcoming fiscal year
+		--||-----FY 2023-----||-----FY 2024-----||--
+		--||-----Advance-----||---Inv1---Inv2---||--
+		"""
+		self.set_previous_fy_and_tax_category()
+		supplier = "Test TDS Supplier"
+		# Cumulative threshold 30000 and tax rate 10%
+		category = "Cumulative Threshold TDS"
+		frappe.db.set_value(
+			"Supplier",
+			supplier,
+			{
+				"tax_withholding_category": category,
+				"pan": "ABCTY1234D",
+			},
+		)
+		po_and_advance_posting_date = add_days(self.prev_fy.year_end_date, -10)
+		po = create_purchase_order(supplier=supplier, qty=10, rate=10000)
+		po.transaction_date = po_and_advance_posting_date
+		po.taxes = []
+		po.apply_tds = False
+		po.tax_withholding_category = None
+		po.save().submit()
+
+		# Partial advance
+		payment = get_payment_entry(po.doctype, po.name)
+		payment.posting_date = po_and_advance_posting_date
+		payment.paid_amount = 60000
+		payment.apply_tax_withholding_amount = 1
+		payment.tax_withholding_category = category
+		payment.references = []
+		payment.taxes = []
+		payment.save().submit()
+
+		self.assertEqual(len(payment.taxes), 1)
+		self.assertEqual(payment.taxes[0].tax_amount, 6000)
+
+		# Multiple partial invoices
+		payment.reload()
+		pi1 = make_purchase_invoice(source_name=po.name)
+		pi1.apply_tds = True
+		pi1.tax_withholding_category = category
+		pi1.items[0].qty = 3
+		pi1.items[0].rate = 10000
+		advances = pi1.get_advance_entries()
+		pi1.append(
+			"advances",
+			{
+				"reference_type": advances[0].reference_type,
+				"reference_name": advances[0].reference_name,
+				"advance_amount": advances[0].amount,
+				"allocated_amount": 30000,
+			},
+		)
+		pi1.save().submit()
+		pi1.reload()
+		payment.reload()
+		self.assertEqual(pi1.taxes, [])
+		self.assertEqual(payment.taxes[0].tax_amount, 6000)
+		self.assertEqual(payment.taxes[0].allocated_amount, 3000)
+
+		pi2 = make_purchase_invoice(source_name=po.name)
+		pi2.apply_tds = True
+		pi2.tax_withholding_category = category
+		pi2.items[0].qty = 3
+		pi2.items[0].rate = 10000
+		advances = pi2.get_advance_entries()
+		pi2.append(
+			"advances",
+			{
+				"reference_type": advances[0].reference_type,
+				"reference_name": advances[0].reference_name,
+				"advance_amount": advances[0].amount,
+				"allocated_amount": 30000,
+			},
+		)
+		pi2.save().submit()
+		pi2.reload()
+		payment.reload()
+		self.assertEqual(pi2.taxes, [])
+		self.assertEqual(payment.taxes[0].tax_amount, 6000)
+		self.assertEqual(payment.taxes[0].allocated_amount, 6000)
 
 
 def cancel_invoices():


### PR DESCRIPTION
If Advance with TDS deducted is in previous fiscal year, Invoices in current fiscal year still get TDS applied, if there multiple invoices. Fixing in this PR.

Replication:
1. Purchase Order on FY2023 above cumulative threshold of TDS
2. Make 50% advance with TDS deducted for PO. Note: this 50% should be above cumulative threshold.
3. Make an Invoice against PO with 25% value and allocate Advance. => No TDS applied
4. Make another Invoice against PO with 25% value and allocate advance => TDS is applied (wrong)

The combination of the 2 invoices should breach the cumulative threshold, and the total TDS for those invoices should be greater than the TDS deducted from the Advance Payment.


ps: TCS/TDS related code are long overdue for a refactor.