### PR TITLE
fix: multiple pricing rules with discount amount and discount percentage not working

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -486,6 +486,22 @@ def apply_price_discount_rule(pricing_rule, item_details, args):
 		if pricing_rule.apply_discount_on_rate and item_details.get("discount_percentage"):
 			# Apply discount on discounted rate
 			item_details[field] += (100 - item_details[field]) * (pricing_rule.get(field, 0) / 100)
+		elif args.price_list_rate:
+			value = pricing_rule.get(field, 0)
+			calculate_discount_percentage = False
+			if field == "discount_percentage":
+				field = "discount_amount"
+				value = args.price_list_rate * (value / 100)
+				calculate_discount_percentage = True
+
+			if field not in item_details:
+				item_details.setdefault(field, 0)
+
+			item_details[field] += value if pricing_rule else args.get(field, 0)
+			if calculate_discount_percentage and args.price_list_rate and item_details.discount_amount:
+				item_details.discount_percentage = flt(
+					(flt(item_details.discount_amount) / flt(args.price_list_rate)) * 100
+				)
 		else:
 			if field not in item_details:
 				item_details.setdefault(field, 0)

--- a/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
@@ -978,6 +978,59 @@ class TestPricingRule(unittest.TestCase):
 		self.assertEqual(so.items[1].item_code, "_Test Item")
 		self.assertEqual(so.items[1].qty, 4)
 
+	def test_apply_multiple_pricing_rules_for_discount_percentage_and_amount(self):
+		frappe.delete_doc_if_exists("Pricing Rule", "_Test Pricing Rule 1")
+		frappe.delete_doc_if_exists("Pricing Rule", "_Test Pricing Rule 2")
+		test_record = {
+			"doctype": "Pricing Rule",
+			"title": "_Test Pricing Rule 1",
+			"name": "_Test Pricing Rule 1",
+			"apply_on": "Item Code",
+			"currency": "USD",
+			"items": [
+				{
+					"item_code": "_Test Item",
+				}
+			],
+			"selling": 1,
+			"price_or_product_discount": "Price",
+			"rate_or_discount": "Discount Percentage",
+			"discount_percentage": 10,
+			"apply_multiple_pricing_rules": 1,
+			"company": "_Test Company",
+		}
+
+		frappe.get_doc(test_record.copy()).insert()
+
+		test_record = {
+			"doctype": "Pricing Rule",
+			"title": "_Test Pricing Rule 2",
+			"name": "_Test Pricing Rule 2",
+			"apply_on": "Item Code",
+			"currency": "USD",
+			"items": [
+				{
+					"item_code": "_Test Item",
+				}
+			],
+			"selling": 1,
+			"price_or_product_discount": "Price",
+			"rate_or_discount": "Discount Amount",
+			"discount_amount": 100,
+			"apply_multiple_pricing_rules": 1,
+			"company": "_Test Company",
+		}
+
+		frappe.get_doc(test_record.copy()).insert()
+
+		so = make_sales_order(item_code="_Test Item", qty=1, price_list_rate=1000, do_not_submit=True)
+		self.assertEqual(so.items[0].discount_amount, 200)
+		self.assertEqual(so.items[0].rate, 800)
+
+		frappe.delete_doc_if_exists("Sales Order", so.name)
+		frappe.delete_doc_if_exists("Pricing Rule", "_Test Pricing Rule 1")
+		frappe.delete_doc_if_exists("Pricing Rule", "_Test Pricing Rule 2")
+
 
 test_dependencies = ["Campaign"]
 


### PR DESCRIPTION
**Issue**
Multiple pricing rules with discount amount and discount percentage not working 


1. Pricing Rule 1: Discount Percentage 10 % on item Item A
2. Pricing Rule 2: Discount Amount 100 on item Item A 
3. Create a sales order with price list rate 1000
4. You will notice that the discount amount has applied as 100 and not 200


