### PR TITLE
feat: Quantity based calculation in shipping rule

### DIFF
--- a/erpnext/accounts/doctype/shipping_rule/shipping_rule.js
+++ b/erpnext/accounts/doctype/shipping_rule/shipping_rule.js
@@ -28,6 +28,7 @@ frappe.ui.form.on("Shipping Rule", {
 	},
 	toggle_reqd: function (frm) {
 		frm.toggle_reqd("shipping_amount", frm.doc.calculate_based_on === "Fixed");
-		frm.toggle_reqd("conditions", frm.doc.calculate_based_on !== "Fixed");
+		frm.toggle_reqd("conditions", frm.doc.calculate_based_on !== "Fixed" && frm.doc.calculate_based_on !== "Quantity");
+		frm.toggle_reqd("shipping_amount_per_item", frm.doc.calculate_based_on === "Quantity");
 	},
 });

--- a/erpnext/accounts/doctype/shipping_rule/shipping_rule.js
+++ b/erpnext/accounts/doctype/shipping_rule/shipping_rule.js
@@ -28,7 +28,10 @@ frappe.ui.form.on("Shipping Rule", {
 	},
 	toggle_reqd: function (frm) {
 		frm.toggle_reqd("shipping_amount", frm.doc.calculate_based_on === "Fixed");
-		frm.toggle_reqd("conditions", frm.doc.calculate_based_on !== "Fixed" && frm.doc.calculate_based_on !== "Quantity");
+		frm.toggle_reqd(
+			"conditions",
+			frm.doc.calculate_based_on !== "Fixed" && frm.doc.calculate_based_on !== "Quantity"
+		);
 		frm.toggle_reqd("shipping_amount_per_item", frm.doc.calculate_based_on === "Quantity");
 	},
 });

--- a/erpnext/accounts/doctype/shipping_rule/shipping_rule.json
+++ b/erpnext/accounts/doctype/shipping_rule/shipping_rule.json
@@ -24,6 +24,11 @@
   "shipping_amount",
   "rule_conditions_section",
   "conditions",
+  "shipping_rule_quantity_section",
+  "shipping_amount_per_item",
+  "column_break_6",
+  "shipping_limit",
+  "discount_per_item",
   "section_break_6",
   "countries"
  ],
@@ -95,7 +100,7 @@
    "in_list_view": 1,
    "in_standard_filter": 1,
    "label": "Calculate Based On",
-   "options": "Fixed\nNet Total\nNet Weight"
+   "options": "Fixed\nNet Total\nNet Weight\nQuantity"
   },
   {
    "fieldname": "column_break_8",
@@ -108,7 +113,7 @@
    "label": "Shipping Amount"
   },
   {
-   "depends_on": "eval:doc.calculate_based_on!=='Fixed'",
+   "depends_on": "eval:doc.calculate_based_on!=='Fixed' && doc.calculate_based_on !== 'Quantity'",
    "fieldname": "rule_conditions_section",
    "fieldtype": "Section Break",
    "label": "Shipping Rule Conditions"
@@ -138,12 +143,32 @@
   {
    "fieldname": "dimension_col_break",
    "fieldtype": "Column Break"
-  }
+  },
+  {
+    "fieldname": "shipping_amount_per_item",
+    "fieldtype": "Currency",
+    "label": "Shipping Amount Per Item",
+    "mandatory_depends_on": "eval: doc.calculate_based_on === 'Quantity'"
+   },
+   {
+    "fieldname": "shipping_limit",
+    "fieldtype": "Currency",
+    "label": "Shipping Limit"
+   },
+   {
+    "fieldname": "discount_per_item",
+    "fieldtype": "Percent",
+    "label": "Discount Per Item"
+   },
+   {
+    "fieldname": "column_break_6",
+    "fieldtype": "Column Break"
+   }
  ],
  "icon": "fa fa-truck",
  "idx": 1,
  "links": [],
- "modified": "2024-03-27 13:10:41.653314",
+ "modified": "2024-04-26 19:08:50.915833",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Shipping Rule",

--- a/erpnext/accounts/doctype/shipping_rule/shipping_rule.py
+++ b/erpnext/accounts/doctype/shipping_rule/shipping_rule.py
@@ -126,7 +126,7 @@ class ShippingRule(Document):
 				return condition.shipping_amount
 
 		return 0.0
-		
+
 	def get_shipping_amount_from_quantity(self, qty):
 		# If quantity is not provided, return 0.0 as shipping amount
 		if qty is None:
@@ -142,14 +142,13 @@ class ShippingRule(Document):
 		if self.discount_per_item:
 			# Limit discount to maximum 100%
 			discount = min(self.discount_per_item * (qty - 1) * 0.01, 1)
-			shipping_amount *= (1 - discount)
+			shipping_amount *= 1 - discount
 
 		# Apply shipping limit if set
 		if self.shipping_limit:
 			shipping_amount = min(shipping_amount, self.shipping_limit)
 
 		return shipping_amount
-
 
 	def validate_countries(self, doc):
 		# validate applicable countries


### PR DESCRIPTION
Documentation Link: https://docs.erpnext.com/docs/user/manual/en/setup-shipping-rule

Quantity-based Calculation: Users can now specify shipping charges per item and apply discounts or limits based on the quantity ordered. This provides more flexibility in determining shipping costs, especially for scenarios where shipping charges vary based on order quantity.
Enhanced Flexibility: By introducing quantity-based calculation, this enhancement caters to a wider range of business requirements, allowing users to define shipping rules that better align with their shipping policies and pricing strategies.

Feature request : #39824 