### PR TITLE
fix:  party type for purchase request added in function set_party_type

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -2397,7 +2397,7 @@ def get_bank_cash_account(doc, bank_account):
 def set_party_type(dt):
 	if dt in ("Sales Invoice", "Sales Order", "Dunning"):
 		party_type = "Customer"
-	elif dt in ("Purchase Invoice", "Purchase Order"):
+	elif dt in ("Purchase Invoice", "Purchase Order", "Purchase Request"):
 		party_type = "Supplier"
 	return party_type
 


### PR DESCRIPTION
When creating Payment Entry from Payment Request thist error is occuring.

In this Payment Request Reference Doctype is Purchase Request, in the function (set_party_type) party_type for purchase request was not added

![image](https://github.com/frappe/erpnext/assets/91895505/6d863886-3647-42f9-9be5-45882c58cafd)
![image](https://github.com/frappe/erpnext/assets/91895505/3f8506c2-a328-46ff-bb34-0274b7e1ccca)


@deepeshgarg007 @rohitwaghchaure  please check