### PR TITLE
fix: party type for purchase request added in function set_party_type

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -2158,7 +2158,7 @@ def get_bank_cash_account(doc, bank_account):
 def set_party_type(dt):
 	if dt in ("Sales Invoice", "Sales Order", "Dunning"):
 		party_type = "Customer"
-	elif dt in ("Purchase Invoice", "Purchase Order"):
+	elif dt in ("Purchase Invoice", "Purchase Order", "Purchase Request"):
 		party_type = "Supplier"
 	return party_type
 


### PR DESCRIPTION
When creating Payment Entry from Payment Request thist error is occuring.

In this Payment Request Reference Doctype is Purchase Request, in the function (set_party_type) party_type for purchase request was not added.


![image](https://github.com/frappe/erpnext/assets/91895505/9c4f2cea-a2e9-4c54-9f6d-ea7631b4cc7b)
![image](https://github.com/frappe/erpnext/assets/91895505/073fb4ca-4733-4f07-9d6f-6f9a18a5ef1c)


@deepeshgarg007 @rohitwaghchaure please check

