### PR TITLE
fix: depreciation based on daily prorata

### DIFF
--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -1000,7 +1000,7 @@ class TestDepreciationBasics(AssetSetup):
 
 		asset_depr_schedule_doc = get_asset_depr_schedule_doc(asset.name, "Active")
 
-		depreciation_amount = get_depreciation_amount(
+		depreciation_amount, prev_per_day_depr = get_depreciation_amount(
 			asset_depr_schedule_doc, asset, 100000, 100000, asset.finance_books[0]
 		)
 		self.assertEqual(depreciation_amount, 30000)
@@ -1723,6 +1723,7 @@ def create_asset(**args):
 				"depreciation_start_date": args.depreciation_start_date,
 				"daily_prorata_based": args.daily_prorata_based or 0,
 				"shift_based": args.shift_based or 0,
+				"rate_of_depreciation": args.rate_of_depreciation or 40,
 			},
 		)
 

--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -1723,7 +1723,7 @@ def create_asset(**args):
 				"depreciation_start_date": args.depreciation_start_date,
 				"daily_prorata_based": args.daily_prorata_based or 0,
 				"shift_based": args.shift_based or 0,
-				"rate_of_depreciation": args.rate_of_depreciation or 40,
+				"rate_of_depreciation": args.rate_of_depreciation or 0,
 			},
 		)
 

--- a/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
@@ -848,11 +848,10 @@ def _get_daily_prorata_based_default_wdv_or_dd_depr_amount(
 			total_days = date_diff(to_date, from_date) + 1
 			return (per_day_depr * total_days), per_day_depr
 		else:
-			from_date, to_date = get_dates(
+			from_date, days_in_month = _get_total_days(
 				fb_row.depreciation_start_date, schedule_idx, cint(fb_row.frequency_of_depreciation)
 			)
-			days_in_month = date_diff(to_date, from_date) + 1
-			return (prev_per_day_depr * days_in_month), prev_per_day_depr
+			return flt(depreciable_value) * (flt(fb_row.rate_of_depreciation) / 100), None
 
 	if has_wdv_or_dd_non_yearly_pro_rata:
 		if schedule_idx == 0:
@@ -860,36 +859,31 @@ def _get_daily_prorata_based_default_wdv_or_dd_depr_amount(
 			from_date = asset.available_for_use_date
 			to_date = add_days(fb_row.depreciation_start_date, -1)
 			total_days = date_diff(to_date, from_date) + 1
-
 			return (per_day_depr * total_days), per_day_depr
 
 		elif schedule_idx % (12 / cint(fb_row.frequency_of_depreciation)) == 1:
-			from_date, to_date = get_dates(
+			from_date, days_in_month = _get_total_days(
 				fb_row.depreciation_start_date, schedule_idx, cint(fb_row.frequency_of_depreciation)
 			)
 			per_day_depr = get_per_day_depr(fb_row, depreciable_value, from_date)
-			days_in_month = date_diff(to_date, from_date) + 1
 			return (per_day_depr * days_in_month), per_day_depr
 
 		else:
-			from_date, to_date = get_dates(
+			from_date, days_in_month = _get_total_days(
 				fb_row.depreciation_start_date, schedule_idx, cint(fb_row.frequency_of_depreciation)
 			)
-			days_in_month = date_diff(to_date, from_date) + 1
 			return (prev_per_day_depr * days_in_month), prev_per_day_depr
 	else:
 		if schedule_idx % (12 / cint(fb_row.frequency_of_depreciation)) == 0:
-			from_date, to_date = get_dates(
+			from_date, days_in_month = _get_total_days(
 				fb_row.depreciation_start_date, schedule_idx, cint(fb_row.frequency_of_depreciation)
 			)
 			per_day_depr = get_per_day_depr(fb_row, depreciable_value, from_date)
-			days_in_month = date_diff(to_date, from_date) + 1
 			return (per_day_depr * days_in_month), per_day_depr
 		else:
-			from_date, to_date = get_dates(
+			from_date, days_in_month = _get_total_days(
 				fb_row.depreciation_start_date, schedule_idx, cint(fb_row.frequency_of_depreciation)
 			)
-			days_in_month = date_diff(to_date, from_date) + 1
 			return (prev_per_day_depr * days_in_month), prev_per_day_depr
 
 
@@ -904,10 +898,13 @@ def get_per_day_depr(
 	return per_day_depr
 
 
-def get_dates(depreciation_start_date, schedule_idx, frequency_of_depreciation):
+def _get_total_days(depreciation_start_date, schedule_idx, frequency_of_depreciation):
 	from_date = add_months(depreciation_start_date, (schedule_idx - 1) * frequency_of_depreciation)
-	to_date = add_days(add_months(from_date, frequency_of_depreciation), -1)
-	return from_date, to_date
+	to_date = add_months(from_date, frequency_of_depreciation)
+	if is_last_day_of_the_month(depreciation_start_date):
+		to_date = get_last_day(to_date)
+		from_date = get_last_day(from_date)
+	return from_date, date_diff(to_date, from_date)
 
 
 def make_draft_asset_depr_schedules_if_not_present(asset_doc):

--- a/erpnext/assets/doctype/asset_depreciation_schedule/test_asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/test_asset_depreciation_schedule.py
@@ -72,8 +72,8 @@ class TestAssetDepreciationSchedule(FrappeTestCase):
 		]
 		self.assertEqual(schedules, expected_schedules)
 	# Test for Written Down Value Method
-	def test_daily_prorata_based_depreciation_for_wdv_method(self):
-		# Frequency of deprciation = 3
+	# Frequency of deprciation = 3
+	def test_for_daily_prorata_based_depreciation_wdv_method_frequency_3_months(self):
 		asset = create_asset(
 			item_code="Macbook Pro",
 			calculate_depreciation=1,
@@ -82,57 +82,80 @@ class TestAssetDepreciationSchedule(FrappeTestCase):
 			available_for_use_date="2021-02-20",
 			depreciation_start_date="2021-03-31",
 			frequency_of_depreciation=3,
-			total_number_of_depreciations=18,
+			total_number_of_depreciations=6,
 			rate_of_depreciation=40,
-			submit=1,
 		)
-		asset_depr_schedule = frappe.get_last_doc("Asset Depreciation Schedule", {"asset": asset.name})
-		self.assertEqual(asset_depr_schedule.depreciation_schedule[1].depreciation_amount, 9521.45)
 
-		# Frequency of deprciation = 6
+		expected_schedules = [
+			["2021-03-31", 4383.56, 4383.56],
+			["2021-06-30", 9535.45, 13919.01],
+			["2021-09-30", 9640.23, 23559.24],
+			["2021-12-31", 9640.23, 33199.47],
+			["2022-03-31", 9430.66, 42630.13],
+			["2022-06-30", 5721.27, 48351.4],
+			["2022-08-20", 51648.6, 100000.0],
+		]
+
+		schedules = [
+			[cstr(d.schedule_date), d.depreciation_amount, d.accumulated_depreciation_amount]
+			for d in get_depr_schedule(asset.name, "Draft")
+		]
+		self.assertEqual(schedules, expected_schedules)
+
+	# Frequency of deprciation = 6
+	def test_for_daily_prorata_based_depreciation_wdv_method_frequency_6_months(self):
 		asset = create_asset(
 			item_code="Macbook Pro",
 			calculate_depreciation=1,
 			depreciation_method="Written Down Value",
 			daily_prorata_based=1,
 			available_for_use_date="2020-02-20",
-			depreciation_start_date="2020-03-01",
+			depreciation_start_date="2020-02-29",
 			frequency_of_depreciation=6,
-			total_number_of_depreciations=18,
+			total_number_of_depreciations=6,
 			rate_of_depreciation=40,
-			submit=1,
 		)
-		asset_depr_schedule = frappe.get_last_doc("Asset Depreciation Schedule", {"asset": asset.name})
-		self.assertEqual(asset_depr_schedule.depreciation_schedule[1].depreciation_amount, 19889.52)
 
-		# Frequency of deprciation = 12
+		expected_schedules = [
+			["2020-02-29", 1092.90, 1092.90],
+			["2020-08-31", 19944.01, 21036.91],
+			["2021-02-28", 19618.83, 40655.74],
+			["2021-08-31", 11966.4, 52622.14],
+			["2022-02-28", 11771.3, 64393.44],
+			["2022-08-31", 7179.84, 71573.28],
+			["2023-02-20", 28426.72, 100000.0],
+		]
+
+		schedules = [
+			[cstr(d.schedule_date), d.depreciation_amount, d.accumulated_depreciation_amount]
+			for d in get_depr_schedule(asset.name, "Draft")
+		]
+		self.assertEqual(schedules, expected_schedules)
+
+	# Frequency of deprciation = 12
+	def test_for_daily_prorata_based_depreciation_wdv_method_frequency_12_months(self):
 		asset = create_asset(
 			item_code="Macbook Pro",
 			calculate_depreciation=1,
 			depreciation_method="Written Down Value",
 			daily_prorata_based=1,
 			available_for_use_date="2020-02-20",
-			depreciation_start_date="2020-03-01",
+			depreciation_start_date="2020-03-31",
 			frequency_of_depreciation=12,
 			total_number_of_depreciations=4,
 			rate_of_depreciation=40,
-			submit=1,
 		)
-		asset_depr_schedule = frappe.get_last_doc("Asset Depreciation Schedule", {"asset": asset.name})
-		self.assertEqual(asset_depr_schedule.depreciation_schedule[0].depreciation_amount, 1092.90)
 
-	# Test for Straight Line Method
-	def test_daily_prorata_based_depreciation_for_straight_line_method(self):
-		asset = create_asset(
-			item_code="Macbook Pro",
-			calculate_depreciation=1,
-			depreciation_method="Straight Line",
-			daily_prorata_based=0,
-			available_for_use_date="2020-02-20",
-			depreciation_start_date="2020-03-01",
-			frequency_of_depreciation=12,
-			total_number_of_depreciations=4,
-			submit=1,
-		)
-		asset_depr_schedule = frappe.get_last_doc("Asset Depreciation Schedule", {"asset": asset.name})
-		self.assertEqual(asset_depr_schedule.depreciation_schedule[0].depreciation_amount, 751.37)
+		expected_schedules = [
+			["2020-03-31", 4480.87, 4480.87],
+			["2021-03-31", 38207.65, 42688.52],
+			["2022-03-31", 22924.59, 65613.11],
+			["2023-03-31", 13754.76, 79367.87],
+			["2024-02-20", 20632.13, 100000],
+		]
+
+		schedules = [
+			[cstr(d.schedule_date), d.depreciation_amount, d.accumulated_depreciation_amount]
+			for d in get_depr_schedule(asset.name, "Draft")
+		]
+		self.assertEqual(schedules, expected_schedules)

--- a/erpnext/assets/doctype/asset_depreciation_schedule/test_asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/test_asset_depreciation_schedule.py
@@ -71,3 +71,68 @@ class TestAssetDepreciationSchedule(FrappeTestCase):
 			for d in get_depr_schedule(asset.name, "Draft")
 		]
 		self.assertEqual(schedules, expected_schedules)
+	# Test for Written Down Value Method
+	def test_daily_prorata_based_depreciation_for_wdv_method(self):
+		# Frequency of deprciation = 3
+		asset = create_asset(
+			item_code="Macbook Pro",
+			calculate_depreciation=1,
+			depreciation_method="Written Down Value",
+			daily_prorata_based=1,
+			available_for_use_date="2021-02-20",
+			depreciation_start_date="2021-03-31",
+			frequency_of_depreciation=3,
+			total_number_of_depreciations=18,
+			rate_of_depreciation=40,
+			submit=1,
+		)
+		asset_depr_schedule = frappe.get_last_doc("Asset Depreciation Schedule", {"asset": asset.name})
+		self.assertEqual(asset_depr_schedule.depreciation_schedule[1].depreciation_amount, 9521.45)
+
+		# Frequency of deprciation = 6
+		asset = create_asset(
+			item_code="Macbook Pro",
+			calculate_depreciation=1,
+			depreciation_method="Written Down Value",
+			daily_prorata_based=1,
+			available_for_use_date="2020-02-20",
+			depreciation_start_date="2020-03-01",
+			frequency_of_depreciation=6,
+			total_number_of_depreciations=18,
+			rate_of_depreciation=40,
+			submit=1,
+		)
+		asset_depr_schedule = frappe.get_last_doc("Asset Depreciation Schedule", {"asset": asset.name})
+		self.assertEqual(asset_depr_schedule.depreciation_schedule[1].depreciation_amount, 19889.52)
+
+		# Frequency of deprciation = 12
+		asset = create_asset(
+			item_code="Macbook Pro",
+			calculate_depreciation=1,
+			depreciation_method="Written Down Value",
+			daily_prorata_based=1,
+			available_for_use_date="2020-02-20",
+			depreciation_start_date="2020-03-01",
+			frequency_of_depreciation=12,
+			total_number_of_depreciations=4,
+			rate_of_depreciation=40,
+			submit=1,
+		)
+		asset_depr_schedule = frappe.get_last_doc("Asset Depreciation Schedule", {"asset": asset.name})
+		self.assertEqual(asset_depr_schedule.depreciation_schedule[0].depreciation_amount, 1092.90)
+
+	# Test for Straight Line Method
+	def test_daily_prorata_based_depreciation_for_straight_line_method(self):
+		asset = create_asset(
+			item_code="Macbook Pro",
+			calculate_depreciation=1,
+			depreciation_method="Straight Line",
+			daily_prorata_based=0,
+			available_for_use_date="2020-02-20",
+			depreciation_start_date="2020-03-01",
+			frequency_of_depreciation=12,
+			total_number_of_depreciations=4,
+			submit=1,
+		)
+		asset_depr_schedule = frappe.get_last_doc("Asset Depreciation Schedule", {"asset": asset.name})
+		self.assertEqual(asset_depr_schedule.depreciation_schedule[0].depreciation_amount, 751.37)

--- a/erpnext/assets/doctype/asset_depreciation_schedule/test_asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/test_asset_depreciation_schedule.py
@@ -71,6 +71,7 @@ class TestAssetDepreciationSchedule(FrappeTestCase):
 			for d in get_depr_schedule(asset.name, "Draft")
 		]
 		self.assertEqual(schedules, expected_schedules)
+
 	# Test for Written Down Value Method
 	# Frequency of deprciation = 3
 	def test_for_daily_prorata_based_depreciation_wdv_method_frequency_3_months(self):


### PR DESCRIPTION
Bug: On the selection of depreciation based on daily prorata, it should happen on the basis of prorata.
<img width="1083" alt="Screenshot 2024-04-29 at 4 32 24 PM" src="https://github.com/frappe/erpnext/assets/142375893/12c9fe14-825c-4b01-a0f1-92ed76193f9e">

Fix: After the fix it will get the per day depreciation by dividing the whole year depreciation with the number of days that year. And then depreciation amount will be calculated on the basis of frequency of depreciation and "total number of depreciation".
<img width="1299" alt="Screenshot 2024-05-07 at 11 24 27 AM" src="https://github.com/frappe/erpnext/assets/142375893/8d47c500-2e08-4eac-86d0-77b09509dd7d">
<img width="1299" alt="Screenshot 2024-05-07 at 11 25 58 AM" src="https://github.com/frappe/erpnext/assets/142375893/95ee2cf6-4000-4cf0-9243-d459ef850c39">
no-docs