### PR TITLE
fix: display term name for single term invoices in AR/AP

### DIFF
--- a/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
+++ b/erpnext/accounts/report/accounts_receivable/accounts_receivable.py
@@ -501,8 +501,9 @@ class ReceivablePayableReport:
 		# Deduct that from paid amount pre allocation
 		row.paid -= flt(payment_terms_details[0].total_advance)
 
-		# If no or single payment terms, no need to split the row
-		if len(payment_terms_details) <= 1:
+		# If single payment terms, no need to split the row
+		if len(payment_terms_details) == 1 and payment_terms_details[0].payment_term:
+			self.append_payment_term(row, payment_terms_details[0], original_row)
 			return
 
 		for d in payment_terms_details:


### PR DESCRIPTION
Invoices with single payment term, with a pre built term, will also be displayed in AR/AP report.