### PR TITLE
fix: permission issue when 'User Permission' restricts on company

### DIFF
--- a/erpnext/accounts/doctype/tax_withholding_account/tax_withholding_account.json
+++ b/erpnext/accounts/doctype/tax_withholding_account/tax_withholding_account.json
@@ -12,6 +12,7 @@
   {
    "fieldname": "company",
    "fieldtype": "Link",
+   "ignore_user_permissions": 1,
    "in_list_view": 1,
    "label": "Company",
    "options": "Company",
@@ -20,6 +21,7 @@
   {
    "fieldname": "account",
    "fieldtype": "Link",
+   "ignore_user_permissions": 1,
    "in_list_view": 1,
    "label": "Account",
    "options": "Account",
@@ -28,7 +30,7 @@
  ],
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:52.419915",
+ "modified": "2024-04-30 10:26:48.218294",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Tax Withholding Account",


### PR DESCRIPTION
A User who is restricted to a certain company using `User Permission` will get Permission error while opening Tax Withholding Category with multiple companies.

Since the Tax Withholding Category is only maintaining TDS accounts for different companies and on a multi-company setup this will prevent the user from updating the category for all companies, we can ignore permissions here.
