### PR TITLE
fix!: consistent template for taxes

### DIFF
--- a/erpnext/templates/print_formats/includes/taxes.html
+++ b/erpnext/templates/print_formats/includes/taxes.html
@@ -11,8 +11,7 @@
 {%- endmacro -%}
 
 <div class="row">
-	<div class="col-xs-6"></div>
-	<div class="col-xs-6">
+	<div class="col-xs-12">
 		{%- if doc.apply_discount_on == "Net Total" -%}
 			{{ render_discount_amount(doc) }}
 		{%- endif -%}


### PR DESCRIPTION
Taxes Template HTML was not consistent. Because of this, standard print formats where improper.
This can break existing print formats.

## Configuration
![image](https://github.com/frappe/erpnext/assets/10496564/4be4a0a2-e87c-4b8a-a80c-506aa50d6630)

## Before

### Print Format
![image](https://github.com/frappe/erpnext/assets/10496564/a71ad6d3-d97c-449a-8e08-1364c7e699ae)

## After

### Print Format
![image](https://github.com/frappe/erpnext/assets/10496564/9adc6598-93c2-4f12-a370-47648a442871)

## Alternate configuration tried (but hacky)
![image](https://github.com/frappe/erpnext/assets/10496564/739693c9-5085-4210-b5a8-cbd94ee1c779)
