### PR TITLE
fix: validation to prevent overallocation

### DIFF
--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -516,6 +516,10 @@ def reconcile_against_document(
 			doc.make_advance_gl_entries()
 		else:
 			gl_map = doc.build_gl_map()
+			# Make sure there is no overallocation
+			from erpnext.accounts.general_ledger import process_debit_credit_difference
+
+			process_debit_credit_difference(gl_map)
 			create_payment_ledger_entry(gl_map, update_outstanding="No", cancel=0, adv_adj=1)
 
 		# Only update outstanding for newly linked vouchers


### PR DESCRIPTION
On rare occurrences, reconciliation causes over allocation. Validation is added to prevent such action.