### PR TITLE
fix: negative stock qty error for stock reconciliation

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -1490,6 +1490,10 @@ def get_stock_reco_qty_shift(args):
 			stock_reco_qty_shift = flt(args.qty_after_transaction) - flt(last_balance)
 		else:
 			stock_reco_qty_shift = flt(args.actual_qty)
+
+	elif args.get("serial_no") or args.get("batch_no"):
+		stock_reco_qty_shift = flt(args.actual_qty)
+
 	else:
 		# reco is being submitted
 		last_balance = get_previous_sle_of_current_voucher(args, "<=", exclude_current_voucher=True).get(
@@ -1559,6 +1563,15 @@ def get_datetime_limit_condition(detail):
 def validate_negative_qty_in_future_sle(args, allow_negative_stock=False):
 	if allow_negative_stock or is_negative_stock_allowed(item_code=args.item_code):
 		return
+
+	if (
+		args.voucher_type == "Stock Reconciliation"
+		and args.actual_qty < 0
+		and args.get("batch_no")
+		and frappe.db.get_value("Stock Reconciliation Item", args.voucher_detail_no, "qty") > 0
+	):
+		return
+
 	if not (args.actual_qty < 0 or args.voucher_type == "Stock Reconciliation"):
 		return
 


### PR DESCRIPTION
Steps To Replicate Issue

1. Create Purchase Receipt for 10 Qty with Batch Item (First Batch)
2. Create Deliver Note for 1 Qty balance qty 9 (First Batch)
3. Create Deliver Note for 1 Qty balance qty 8 (First Batch)
4. Create Deliver Note for 1 Qty balance qty 7 (First Batch)
5. Create Deliver Note for 1 Qty balance qty 6 (First Batch)
6. Create Deliver Note for 1 Qty balance qty 5 (First Batch)
7. Create Deliver Note for 1 Qty balance qty 4 (First Batch)
8. Create Purchase Receipt for 3 Qty with Batch Item  (Second Batch)
9. Create Stock Reco against the First batch and keep qty as 9
10. Create Deliver Note for 3 Qty balance qty against the second batch
11. Create Deliver Note for 3 Qty balance qty 6 (Second Batch) 
12. Create Deliver Note for 3 Qty balance qty 3 (Second Batch) 
13. Create Deliver Note for 3 Qty balance qty 0 (Second Batch) 
14. Now Cancel the delivery note which was created at step 7
15. Delivery Note get cancel but when you try to complete reposting, system will throw the negative stock error.
