### PR TITLE
fix: pricing rule rounding

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
@@ -1102,7 +1102,7 @@ class TestPricingRule(unittest.TestCase):
 		so.load_from_db()
 		self.assertEqual(so.items[1].is_free_item, 1)
 		self.assertEqual(so.items[1].item_code, "_Test Item")
-		self.assertEqual(so.items[1].qty, 4)
+		self.assertEqual(so.items[1].qty, 3)
 
 	def test_apply_multiple_pricing_rules_for_discount_percentage_and_amount(self):
 		frappe.delete_doc_if_exists("Pricing Rule", "_Test Pricing Rule 1")

--- a/erpnext/accounts/doctype/pricing_rule/utils.py
+++ b/erpnext/accounts/doctype/pricing_rule/utils.py
@@ -6,6 +6,7 @@
 
 import copy
 import json
+import math
 
 import frappe
 from frappe import _, bold
@@ -653,7 +654,7 @@ def get_product_discount_rule(pricing_rule, item_details, args=None, doc=None):
 		if transaction_qty:
 			qty = flt(transaction_qty) * qty / pricing_rule.recurse_for
 			if pricing_rule.round_free_qty:
-				qty = round(qty)
+				qty = math.floor(qty)
 
 	free_item_data_args = {
 		"item_code": free_item,


### PR DESCRIPTION
Consider a pricing rule of 20:1 with `Recursion` and `Round Free Qty` enabled, free item qty should follow the below progression

|Qty|Free item qty|
|-|-|
|0-19 |0|
|20-39 |1|
|40-59 |2|