### PR TITLE
feat: create variant with/without image

### DIFF
--- a/erpnext/controllers/item_variant.py
+++ b/erpnext/controllers/item_variant.py
@@ -41,7 +41,7 @@ def get_variant(template, args=None, variant=None, manufacturer=None, manufactur
 	if isinstance(args, str):
 		args = json.loads(args)
 
-	attribute_args = {k: v for k, v in args.items() if k != "use_same_image"}
+	attribute_args = {k: v for k, v in args.items() if k != "use_template_image"}
 	if not attribute_args:
 		frappe.throw(_("Please specify at least one attribute in the Attributes table"))
 
@@ -198,8 +198,8 @@ def find_variant(template, args, variant_item_code=None):
 
 
 @frappe.whitelist()
-def create_variant(item, args, use_same_image=False):
-	use_same_image = frappe.parse_json(use_same_image)
+def create_variant(item, args, use_template_image=False):
+	use_template_image = frappe.parse_json(use_template_image)
 	if isinstance(args, str):
 		args = json.loads(args)
 
@@ -214,7 +214,7 @@ def create_variant(item, args, use_same_image=False):
 	variant.set("attributes", variant_attributes)
 	copy_attributes_to_variant(template, variant)
 
-	if use_same_image and template.image:
+	if use_template_image and template.image:
 		variant.image = template.image
 
 	make_variant_item_code(template.item_code, template.item_name, variant)
@@ -223,8 +223,8 @@ def create_variant(item, args, use_same_image=False):
 
 
 @frappe.whitelist()
-def enqueue_multiple_variant_creation(item, args, use_same_image=False):
-	use_same_image = frappe.parse_json(use_same_image)
+def enqueue_multiple_variant_creation(item, args, use_template_image=False):
+	use_template_image = frappe.parse_json(use_template_image)
 	# There can be innumerable attribute combinations, enqueue
 	if isinstance(args, str):
 		variants = json.loads(args)
@@ -235,19 +235,19 @@ def enqueue_multiple_variant_creation(item, args, use_same_image=False):
 		frappe.throw(_("Please do not create more than 500 items at a time"))
 		return
 	if total_variants < 10:
-		return create_multiple_variants(item, args, use_same_image)
+		return create_multiple_variants(item, args, use_template_image)
 	else:
 		frappe.enqueue(
 			"erpnext.controllers.item_variant.create_multiple_variants",
 			item=item,
 			args=args,
-			use_same_image=use_same_image,
+			use_template_image=use_template_image,
 			now=frappe.flags.in_test,
 		)
 		return "queued"
 
 
-def create_multiple_variants(item, args, use_same_image=False):
+def create_multiple_variants(item, args, use_template_image=False):
 	count = 0
 	if isinstance(args, str):
 		args = json.loads(args)
@@ -258,7 +258,7 @@ def create_multiple_variants(item, args, use_same_image=False):
 	for attribute_values in args_set:
 		if not get_variant(item, args=attribute_values):
 			variant = create_variant(item, attribute_values)
-			if use_same_image and template_item.image:
+			if use_template_image and template_item.image:
 				variant.image = template_item.image
 			variant.save()
 			count += 1

--- a/erpnext/controllers/item_variant.py
+++ b/erpnext/controllers/item_variant.py
@@ -41,7 +41,8 @@ def get_variant(template, args=None, variant=None, manufacturer=None, manufactur
 	if isinstance(args, str):
 		args = json.loads(args)
 
-	if not args:
+	attribute_args = {k: v for k, v in args.items() if k != 'use_same_image'}
+	if not attribute_args:
 		frappe.throw(_("Please specify at least one attribute in the Attributes table"))
 
 	return find_variant(template, args, variant)
@@ -197,7 +198,8 @@ def find_variant(template, args, variant_item_code=None):
 
 
 @frappe.whitelist()
-def create_variant(item, args):
+def create_variant(item, args, use_same_image=False):
+	use_same_image = frappe.parse_json(use_same_image)
 	if isinstance(args, str):
 		args = json.loads(args)
 
@@ -211,13 +213,18 @@ def create_variant(item, args):
 
 	variant.set("attributes", variant_attributes)
 	copy_attributes_to_variant(template, variant)
+
+	if use_same_image and template.image:
+		variant.image = template.image
+
 	make_variant_item_code(template.item_code, template.item_name, variant)
 
 	return variant
 
 
 @frappe.whitelist()
-def enqueue_multiple_variant_creation(item, args):
+def enqueue_multiple_variant_creation(item, args, use_same_image=False):
+	use_same_image = frappe.parse_json(use_same_image)
 	# There can be innumerable attribute combinations, enqueue
 	if isinstance(args, str):
 		variants = json.loads(args)
@@ -228,27 +235,31 @@ def enqueue_multiple_variant_creation(item, args):
 		frappe.throw(_("Please do not create more than 500 items at a time"))
 		return
 	if total_variants < 10:
-		return create_multiple_variants(item, args)
+		return create_multiple_variants(item, args, use_same_image)
 	else:
 		frappe.enqueue(
 			"erpnext.controllers.item_variant.create_multiple_variants",
 			item=item,
 			args=args,
+			use_same_image=use_same_image,
 			now=frappe.flags.in_test,
 		)
 		return "queued"
 
 
-def create_multiple_variants(item, args):
+def create_multiple_variants(item, args, use_same_image=False):
 	count = 0
 	if isinstance(args, str):
 		args = json.loads(args)
 
+	template_item = frappe.get_doc("Item", item)
 	args_set = generate_keyed_value_combinations(args)
 
 	for attribute_values in args_set:
 		if not get_variant(item, args=attribute_values):
 			variant = create_variant(item, attribute_values)
+			if use_same_image and template_item.image:
+				variant.image = template_item.image
 			variant.save()
 			count += 1
 

--- a/erpnext/controllers/item_variant.py
+++ b/erpnext/controllers/item_variant.py
@@ -41,7 +41,7 @@ def get_variant(template, args=None, variant=None, manufacturer=None, manufactur
 	if isinstance(args, str):
 		args = json.loads(args)
 
-	attribute_args = {k: v for k, v in args.items() if k != 'use_same_image'}
+	attribute_args = {k: v for k, v in args.items() if k != "use_same_image"}
 	if not attribute_args:
 		frappe.throw(_("Please specify at least one attribute in the Attributes table"))
 

--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -588,13 +588,13 @@ $.extend(erpnext.item, {
 				title: __("Select Attribute Values"),
 				fields: [
 					frm.doc.image
-					? {
-						fieldtype: "Check",
-						label: __("Create a variant with the template image."),
-						fieldname: "use_same_image",
-						default: 0,
-					}
-					: null,
+						? {
+							fieldtype: "Check",
+							label: __("Create a variant with the template image."),
+							fieldname: "use_same_image",
+							default: 0,
+						}
+						: null,
 					{
 						fieldtype: "HTML",
 						fieldname: "help",
@@ -602,8 +602,9 @@ $.extend(erpnext.item, {
 							${__("Select at least one value from each of the attributes.")}
 						</label>`,
 					},
-				].concat(fields)
-				.filter(Boolean),
+				]
+					.concat(fields)
+					.filter(Boolean),
 			});
 
 			me.multiple_variant_dialog.set_primary_action(__("Create Variants"), () => {

--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -591,7 +591,7 @@ $.extend(erpnext.item, {
 						? {
 								fieldtype: "Check",
 								label: __("Create a variant with the template image."),
-								fieldname: "use_same_image",
+								fieldname: "use_template_image",
 								default: 0,
 						  }
 						: null,
@@ -609,7 +609,7 @@ $.extend(erpnext.item, {
 
 			me.multiple_variant_dialog.set_primary_action(__("Create Variants"), () => {
 				let selected_attributes = get_selected_attributes();
-				let use_same_image = me.multiple_variant_dialog.get_value("use_same_image");
+				let use_template_image = me.multiple_variant_dialog.get_value("use_template_image");
 
 				me.multiple_variant_dialog.hide();
 				frappe.call({
@@ -617,7 +617,7 @@ $.extend(erpnext.item, {
 					args: {
 						item: frm.doc.name,
 						args: selected_attributes,
-						use_same_image: use_same_image,
+						use_template_image: use_template_image,
 					},
 					callback: function (r) {
 						if (r.message === "queued") {
@@ -736,7 +736,7 @@ $.extend(erpnext.item, {
 			fields.push({
 				fieldtype: "Check",
 				label: __("Create a variant with the template image."),
-				fieldname: "use_same_image",
+				fieldname: "use_template_image",
 				default: 0,
 			});
 		}
@@ -782,7 +782,7 @@ $.extend(erpnext.item, {
 							args: {
 								item: frm.doc.name,
 								args: d.get_values(),
-								use_same_image: args.use_same_image,
+								use_template_image: args.use_template_image,
 							},
 							callback: function (r) {
 								var doclist = frappe.model.sync(r.message);

--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -587,12 +587,14 @@ $.extend(erpnext.item, {
 			me.multiple_variant_dialog = new frappe.ui.Dialog({
 				title: __("Select Attribute Values"),
 				fields: [
-					frm.doc.image ? {
+					frm.doc.image
+					? {
 						fieldtype: "Check",
 						label: __("Create a variant with the template image."),
 						fieldname: "use_same_image",
-						default: 0
-					} : null,
+						default: 0,
+					}
+					: null,
 					{
 						fieldtype: "HTML",
 						fieldname: "help",
@@ -600,12 +602,13 @@ $.extend(erpnext.item, {
 							${__("Select at least one value from each of the attributes.")}
 						</label>`,
 					},
-				].concat(fields).filter(Boolean),
+				].concat(fields)
+				.filter(Boolean),
 			});
 
 			me.multiple_variant_dialog.set_primary_action(__("Create Variants"), () => {
 				let selected_attributes = get_selected_attributes();
-				let use_same_image = me.multiple_variant_dialog.get_value('use_same_image');
+				let use_same_image = me.multiple_variant_dialog.get_value("use_same_image");
 
 				me.multiple_variant_dialog.hide();
 				frappe.call({
@@ -613,7 +616,7 @@ $.extend(erpnext.item, {
 					args: {
 						item: frm.doc.name,
 						args: selected_attributes,
-						use_same_image: use_same_image
+						use_same_image: use_same_image,
 					},
 					callback: function (r) {
 						if (r.message === "queued") {
@@ -730,10 +733,10 @@ $.extend(erpnext.item, {
 
 		if (frm.doc.image) {
 			fields.push({
-				fieldtype: 'Check',
-				label: __('Create a variant with the template image.'),
-				fieldname: 'use_same_image',
-				default: 0
+				fieldtype: "Check",
+				label: __("Create a variant with the template image."),
+				fieldname: "use_same_image",
+				default: 0,
 			});
 		}
 
@@ -778,7 +781,7 @@ $.extend(erpnext.item, {
 							args: {
 								item: frm.doc.name,
 								args: d.get_values(),
-								use_same_image: args.use_same_image
+								use_same_image: args.use_same_image,
 							},
 							callback: function (r) {
 								var doclist = frappe.model.sync(r.message);

--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -589,11 +589,11 @@ $.extend(erpnext.item, {
 				fields: [
 					frm.doc.image
 						? {
-							fieldtype: "Check",
-							label: __("Create a variant with the template image."),
-							fieldname: "use_same_image",
-							default: 0,
-						}
+								fieldtype: "Check",
+								label: __("Create a variant with the template image."),
+								fieldname: "use_same_image",
+								default: 0,
+							}
 						: null,
 					{
 						fieldtype: "HTML",

--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -593,7 +593,7 @@ $.extend(erpnext.item, {
 								label: __("Create a variant with the template image."),
 								fieldname: "use_same_image",
 								default: 0,
-						}
+						  }
 						: null,
 					{
 						fieldtype: "HTML",

--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -587,6 +587,12 @@ $.extend(erpnext.item, {
 			me.multiple_variant_dialog = new frappe.ui.Dialog({
 				title: __("Select Attribute Values"),
 				fields: [
+					frm.doc.image ? {
+						fieldtype: "Check",
+						label: __("Create a variant with the template image."),
+						fieldname: "use_same_image",
+						default: 0
+					} : null,
 					{
 						fieldtype: "HTML",
 						fieldname: "help",
@@ -594,11 +600,12 @@ $.extend(erpnext.item, {
 							${__("Select at least one value from each of the attributes.")}
 						</label>`,
 					},
-				].concat(fields),
+				].concat(fields).filter(Boolean),
 			});
 
 			me.multiple_variant_dialog.set_primary_action(__("Create Variants"), () => {
 				let selected_attributes = get_selected_attributes();
+				let use_same_image = me.multiple_variant_dialog.get_value('use_same_image');
 
 				me.multiple_variant_dialog.hide();
 				frappe.call({
@@ -606,6 +613,7 @@ $.extend(erpnext.item, {
 					args: {
 						item: frm.doc.name,
 						args: selected_attributes,
+						use_same_image: use_same_image
 					},
 					callback: function (r) {
 						if (r.message === "queued") {
@@ -720,6 +728,15 @@ $.extend(erpnext.item, {
 			});
 		}
 
+		if (frm.doc.image) {
+			fields.push({
+				fieldtype: 'Check',
+				label: __('Create a variant with the template image.'),
+				fieldname: 'use_same_image',
+				default: 0
+			});
+		}
+
 		var d = new frappe.ui.Dialog({
 			title: __("Create Variant"),
 			fields: fields,
@@ -761,6 +778,7 @@ $.extend(erpnext.item, {
 							args: {
 								item: frm.doc.name,
 								args: d.get_values(),
+								use_same_image: args.use_same_image
 							},
 							callback: function (r) {
 								var doclist = frappe.model.sync(r.message);

--- a/erpnext/stock/doctype/item/item.js
+++ b/erpnext/stock/doctype/item/item.js
@@ -593,7 +593,7 @@ $.extend(erpnext.item, {
 								label: __("Create a variant with the template image."),
 								fieldname: "use_same_image",
 								default: 0,
-							}
+						}
 						: null,
 					{
 						fieldtype: "HTML",


### PR DESCRIPTION
Earlier, when creating a variant, it was not created with an image. Yes, I understand we can set fields in the item variant setting, but we can't set images in it. But I have created a flexible feature in which when you create a single variant or multiple variants, add a checkbox. If you tick that checkbox, the variant will be created with the image that is in the template of that variant. The purpose of creating this feature was that, as an example, suppose there is a book but the image is the same in all the editions of that book, then why should we upload all the images one by one by opening all the items. And it's a bit of a headache. So in the feature, you can create multiple variants with the same image. There are many other examples in which this feature is useful, like a sofa or a chair, but the image will be the same. Only the size has to be mentioned.


https://github.com/frappe/erpnext/assets/141945075/28832f7a-6b05-4754-86ad-2fbae5b200e5


Documentation Link: https://docs.erpnext.com/docs/user/manual/en/item-variants