### PR TITLE
fix: update transferred_qty on work order if alternate used

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/work_order.py
@@ -1115,7 +1115,11 @@ class WorkOrder(Document):
 		)
 
 		data = query.run(as_dict=1) or []
-		transferred_items = frappe._dict({d.original_item or d.item_code: d.qty for d in data})
+		transferred_items = {}
+		for d in data:
+			item_to_update = d.original_item or d.item_code
+			transferred_items[item_to_update] = transferred_items.get(item_to_update,0) + d.qty
+
 
 		for row in self.required_items:
 			row.db_set(


### PR DESCRIPTION
when using an alternate item on a work order. The transferred qty for the original item is not updated properly.

This pr ensures that the transferred qty of the original item is updated.

Example of problem:
Work order requires:
1. Part 1 - 100 qty

Part 1 has alternate Part 2
2. User moves 50qty of Part 2 using the alternate item button.

Part 1 - still says 0 qty transferred
