### PR TITLE
fix: incorrect qty picked in the pick list

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -845,6 +845,7 @@ def filter_locations_by_picked_materials(locations, picked_item_details) -> list
 
 		picked_qty = picked_item_details.get(key, {}).get("picked_qty", 0)
 		if not picked_qty:
+			filterd_locations.append(row)
 			continue
 		if picked_qty > row.qty:
 			row.qty = 0


### PR DESCRIPTION
**Issue**

- Create a product with batch and expiry on.

- Do the material receipt for the above product in 2 batches in same warehouse location. Say 200 qty can be split in 100 qty of one batch and expiry and 100 qty of second batch and expiry.

- Create 1 sales order with 10 quantity and create another sales order with 110 quantity.

- Create picklist for 1st sales order, it will have 10 quantity of batch 1.

- Create another picklist of 2nd sales order, it will show a pop up as “20 units of Item 1 is picked in another pick list” as seen in screenshot below and this pick list will only have 90 qty of batch 1. Whereas it should have taken 90 qty from batch 1 and 20 qty from batch 2.