### PR TITLE
feat: Adding Country and State fields In Employee doctype

### DIFF
--- a/erpnext/setup/doctype/employee/employee.json
+++ b/erpnext/setup/doctype/employee/employee.json
@@ -824,14 +824,12 @@
    "fieldname": "country",
    "fieldtype": "Link",
    "label": "Country",
-   "options": "Country",
-   "reqd": 1
+   "options": "Country"
   },
   {
    "fieldname": "state",
    "fieldtype": "Data",
-   "label": "State",
-   "mandatory_depends_on": "eval:doc.country==\"United States\""
+   "label": "State"
   }
  ],
  "icon": "fa fa-user",
@@ -839,7 +837,7 @@
  "image_field": "image",
  "is_tree": 1,
  "links": [],
- "modified": "2024-05-08 14:52:59.536017",
+ "modified": "2024-05-09 13:04:26.792523",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Employee",

--- a/erpnext/setup/doctype/employee/employee.json
+++ b/erpnext/setup/doctype/employee/employee.json
@@ -59,9 +59,11 @@
   "address_section",
   "current_address",
   "current_accommodation_type",
+  "country",
   "column_break_46",
   "permanent_address",
   "permanent_accommodation_type",
+  "state",
   "emergency_contact_details",
   "person_to_be_contacted",
   "column_break_55",
@@ -817,6 +819,19 @@
    "fieldname": "iban",
    "fieldtype": "Data",
    "label": "IBAN"
+  },
+  {
+   "fieldname": "country",
+   "fieldtype": "Link",
+   "label": "Country",
+   "options": "Country",
+   "reqd": 1
+  },
+  {
+   "fieldname": "state",
+   "fieldtype": "Data",
+   "label": "State",
+   "mandatory_depends_on": "eval:doc.country==\"United States\""
   }
  ],
  "icon": "fa fa-user",
@@ -824,7 +839,7 @@
  "image_field": "image",
  "is_tree": 1,
  "links": [],
- "modified": "2024-03-27 13:09:36.900706",
+ "modified": "2024-05-08 14:52:59.536017",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Employee",


### PR DESCRIPTION
I am Working on a US-Payroll App. It Requires a Country and State for Every Employee.
I have added these fields in Employee Doctype in the Address and Contacts Tab and the Address Section. The country is the Link Field to Country Doctype and the state is the Data Field. If the country is equal to the United States, the state will be mandatory as Taxes are calculated based on the state for the "United States" Country
![image](https://github.com/frappe/erpnext/assets/131749534/bd1d0761-f8e9-468f-b2f2-0aea25b77f36)
![image](https://github.com/frappe/erpnext/assets/131749534/7e8bacdb-2287-45b7-b8ec-7c67f03a16ef)

`no-docs`