### PR TITLE
fix(SO, DN): only show permitted actions

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -325,7 +325,7 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 		}
 
 		const me = this;
-		if (!this.frm.is_new() && this.frm.doc.docstatus === 0) {
+		if (!this.frm.is_new() && this.frm.doc.docstatus === 0 && frappe.model.can_create("Quality Inspection")) {
 			this.frm.add_custom_button(__("Quality Inspection(s)"), () => {
 				me.make_quality_inspection();
 			}, __("Create"));

--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -58,7 +58,8 @@ frappe.ui.form.on("Sales Order", {
 			if (
 				frm.doc.status !== "Closed" &&
 				flt(frm.doc.per_delivered, 2) < 100 &&
-				flt(frm.doc.per_billed, 2) < 100
+				flt(frm.doc.per_billed, 2) < 100 &&
+				frm.has_perm("write")
 			) {
 				frm.add_custom_button(__("Update Items"), () => {
 					erpnext.utils.update_child_items({
@@ -74,7 +75,8 @@ frappe.ui.form.on("Sales Order", {
 				if (
 					frm.doc.__onload &&
 					frm.doc.__onload.has_unreserved_stock &&
-					flt(frm.doc.per_picked) === 0
+					flt(frm.doc.per_picked) === 0 &&
+					frappe.model.can_create("Stock Reservation Entry")
 				) {
 					frm.add_custom_button(
 						__("Reserve"),
@@ -85,7 +87,11 @@ frappe.ui.form.on("Sales Order", {
 			}
 
 			// Stock Reservation > Unreserve button will be only visible if the SO has un-delivered reserved stock.
-			if (frm.doc.__onload && frm.doc.__onload.has_reserved_stock) {
+			if (
+				frm.doc.__onload &&
+				frm.doc.__onload.has_reserved_stock &&
+				frappe.model.can_cancel("Stock Reservation Entry")
+			) {
 				frm.add_custom_button(
 					__("Unreserve"),
 					() => frm.events.cancel_stock_reservation_entries(frm),
@@ -94,7 +100,7 @@ frappe.ui.form.on("Sales Order", {
 			}
 
 			frm.doc.items.forEach((item) => {
-				if (flt(item.stock_reserved_qty) > 0) {
+				if (flt(item.stock_reserved_qty) > 0 && frappe.model.can_read("Stock Reservation Entry")) {
 					frm.add_custom_button(
 						__("Reserved Stock"),
 						() => frm.events.show_reserved_stock(frm),
@@ -142,6 +148,10 @@ frappe.ui.form.on("Sales Order", {
 	},
 
 	get_items_from_internal_purchase_order(frm) {
+		if (!frappe.model.can_read("Purchase Order")) {
+			return;
+		}
+
 		frm.add_custom_button(
 			__("Purchase Order"),
 			() => {
@@ -630,15 +640,17 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 						}
 					}
 
-					if (!doc.__onload || !doc.__onload.has_reserved_stock) {
-						// Don't show the `Reserve` button if the Sales Order has Picked Items.
-						if (flt(doc.per_picked, 2) < 100 && flt(doc.per_delivered, 2) < 100) {
-							this.frm.add_custom_button(
-								__("Pick List"),
-								() => this.create_pick_list(),
-								__("Create")
-							);
-						}
+					if (
+						(!doc.__onload || !doc.__onload.has_reserved_stock) &&
+						flt(doc.per_picked, 2) < 100 &&
+						flt(doc.per_delivered, 2) < 100 &&
+						frappe.model.can_create("Pick List")
+					) {
+						this.frm.add_custom_button(
+							__("Pick List"),
+							() => this.create_pick_list(),
+							__("Create")
+						);
 					}
 
 					const order_is_a_sale = ["Sales", "Shopping Cart"].indexOf(doc.order_type) !== -1;
@@ -653,20 +665,25 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 						(order_is_a_sale || order_is_a_custom_sale) &&
 						allow_delivery
 					) {
-						this.frm.add_custom_button(
-							__("Delivery Note"),
-							() => this.make_delivery_note_based_on_delivery_date(true),
-							__("Create")
-						);
-						this.frm.add_custom_button(
-							__("Work Order"),
-							() => this.make_work_order(),
-							__("Create")
-						);
+						if (frappe.model.can_create("Delivery Note")) {
+							this.frm.add_custom_button(
+								__("Delivery Note"),
+								() => this.make_delivery_note_based_on_delivery_date(true),
+								__("Create")
+							);
+						}
+
+						if (frappe.model.can_create("Work Order")) {
+							this.frm.add_custom_button(
+								__("Work Order"),
+								() => this.make_work_order(),
+								__("Create")
+							);
+						}
 					}
 
 					// sales invoice
-					if (flt(doc.per_billed, 2) < 100) {
+					if (flt(doc.per_billed, 2) < 100 && frappe.model.can_create("Sales Invoice")) {
 						this.frm.add_custom_button(
 							__("Sales Invoice"),
 							() => me.make_sales_invoice(),
@@ -676,8 +693,10 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 
 					// material request
 					if (
-						!doc.order_type ||
-						((order_is_a_sale || order_is_a_custom_sale) && flt(doc.per_delivered, 2) < 100)
+						(!doc.order_type ||
+							((order_is_a_sale || order_is_a_custom_sale) &&
+								flt(doc.per_delivered, 2) < 100)) &&
+						frappe.model.can_create("Material Request")
 					) {
 						this.frm.add_custom_button(
 							__("Material Request"),
@@ -692,7 +711,7 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 					}
 
 					// Make Purchase Order
-					if (!this.frm.doc.is_internal_customer) {
+					if (!this.frm.doc.is_internal_customer && frappe.model.can_create("Purchase Order")) {
 						this.frm.add_custom_button(
 							__("Purchase Order"),
 							() => this.make_purchase_order(),
@@ -702,24 +721,32 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 
 					// maintenance
 					if (flt(doc.per_delivered, 2) < 100 && (order_is_maintenance || order_is_a_custom_sale)) {
-						this.frm.add_custom_button(
-							__("Maintenance Visit"),
-							() => this.make_maintenance_visit(),
-							__("Create")
-						);
-						this.frm.add_custom_button(
-							__("Maintenance Schedule"),
-							() => this.make_maintenance_schedule(),
-							__("Create")
-						);
+						if (frappe.model.can_create("Maintenance Visit")) {
+							this.frm.add_custom_button(
+								__("Maintenance Visit"),
+								() => this.make_maintenance_visit(),
+								__("Create")
+							);
+						}
+						if (frappe.model.can_create("Maintenance Schedule")) {
+							this.frm.add_custom_button(
+								__("Maintenance Schedule"),
+								() => this.make_maintenance_schedule(),
+								__("Create")
+							);
+						}
 					}
 
 					// project
-					if (flt(doc.per_delivered, 2) < 100) {
+					if (flt(doc.per_delivered, 2) < 100 && frappe.model.can_create("Project")) {
 						this.frm.add_custom_button(__("Project"), () => this.make_project(), __("Create"));
 					}
 
-					if (doc.docstatus === 1 && !doc.inter_company_order_reference) {
+					if (
+						doc.docstatus === 1 &&
+						!doc.inter_company_order_reference &&
+						frappe.model.can_create("Purchase Order")
+					) {
 						let me = this;
 						let internal = me.frm.doc.is_internal_customer;
 						if (internal) {
@@ -743,18 +770,27 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 					flt(doc.per_billed, precision("per_billed", doc)) <
 					100 + frappe.boot.sysdefaults.over_billing_allowance
 				) {
-					this.frm.add_custom_button(
-						__("Payment Request"),
-						() => this.make_payment_request(),
-						__("Create")
-					);
-					this.frm.add_custom_button(__("Payment"), () => this.make_payment_entry(), __("Create"));
+					if (frappe.model.can_create("Payment Request")) {
+						this.frm.add_custom_button(
+							__("Payment Request"),
+							() => this.make_payment_request(),
+							__("Create")
+						);
+					}
+
+					if (frappe.model.can_create("Payment Entry")) {
+						this.frm.add_custom_button(
+							__("Payment"),
+							() => this.make_payment_entry(),
+							__("Create")
+						);
+					}
 				}
 				this.frm.page.set_inner_btn_group_as_primary(__("Create"));
 			}
 		}
 
-		if (this.frm.doc.docstatus === 0) {
+		if (this.frm.doc.docstatus === 0 && frappe.model.can_read("Quotation")) {
 			this.frm.add_custom_button(
 				__("Quotation"),
 				function () {

--- a/erpnext/stock/doctype/delivery_note/delivery_note.js
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.js
@@ -79,7 +79,12 @@ frappe.ui.form.on("Delivery Note", {
 	},
 
 	refresh: function (frm) {
-		if (frm.doc.docstatus === 1 && frm.doc.is_return === 1 && frm.doc.per_billed !== 100) {
+		if (
+			frm.doc.docstatus === 1 &&
+			frm.doc.is_return === 1 &&
+			frm.doc.per_billed !== 100 &&
+			frappe.model.can_create("Sales Invoice")
+		) {
 			frm.add_custom_button(
 				__("Credit Note"),
 				function () {
@@ -93,7 +98,11 @@ frappe.ui.form.on("Delivery Note", {
 			frm.page.set_inner_btn_group_as_primary(__("Create"));
 		}
 
-		if (frm.doc.docstatus == 1 && !frm.doc.inter_company_reference) {
+		if (
+			frm.doc.docstatus == 1 &&
+			!frm.doc.inter_company_reference &&
+			frappe.model.can_create("Purchase Receipt")
+		) {
 			let internal = frm.doc.is_internal_customer;
 			if (internal) {
 				let button_label =
@@ -140,42 +149,46 @@ erpnext.stock.DeliveryNoteController = class DeliveryNoteController extends (
 	refresh(doc, dt, dn) {
 		var me = this;
 		super.refresh();
-		if (!doc.is_return && (doc.status != "Closed" || this.frm.is_new())) {
-			if (this.frm.doc.docstatus === 0) {
-				this.frm.add_custom_button(
-					__("Sales Order"),
-					function () {
-						if (!me.frm.doc.customer) {
-							frappe.throw({
-								title: __("Mandatory"),
-								message: __("Please Select a Customer"),
-							});
-						}
-						erpnext.utils.map_current_doc({
-							method: "erpnext.selling.doctype.sales_order.sales_order.make_delivery_note",
-							args: {
-								for_reserved_stock: 1,
-							},
-							source_doctype: "Sales Order",
-							target: me.frm,
-							setters: {
-								customer: me.frm.doc.customer,
-							},
-							get_query_filters: {
-								docstatus: 1,
-								status: ["not in", ["Closed", "On Hold"]],
-								per_delivered: ["<", 99.99],
-								company: me.frm.doc.company,
-								project: me.frm.doc.project || undefined,
-							},
+		if (
+			!doc.is_return &&
+			(doc.status != "Closed" || this.frm.is_new()) &&
+			this.frm.has_perm("write") &&
+			frappe.model.can_read("Sales Order") &&
+			this.frm.doc.docstatus === 0
+		) {
+			this.frm.add_custom_button(
+				__("Sales Order"),
+				function () {
+					if (!me.frm.doc.customer) {
+						frappe.throw({
+							title: __("Mandatory"),
+							message: __("Please Select a Customer"),
 						});
-					},
-					__("Get Items From")
-				);
-			}
+					}
+					erpnext.utils.map_current_doc({
+						method: "erpnext.selling.doctype.sales_order.sales_order.make_delivery_note",
+						args: {
+							for_reserved_stock: 1,
+						},
+						source_doctype: "Sales Order",
+						target: me.frm,
+						setters: {
+							customer: me.frm.doc.customer,
+						},
+						get_query_filters: {
+							docstatus: 1,
+							status: ["not in", ["Closed", "On Hold"]],
+							per_delivered: ["<", 99.99],
+							company: me.frm.doc.company,
+							project: me.frm.doc.project || undefined,
+						},
+					});
+				},
+				__("Get Items From")
+			);
 		}
 
-		if (!doc.is_return && doc.status != "Closed") {
+		if (!doc.is_return && doc.status != "Closed" && frappe.model.can_create("Shipment")) {
 			if (doc.docstatus == 1) {
 				this.frm.add_custom_button(
 					__("Shipment"),
@@ -186,7 +199,11 @@ erpnext.stock.DeliveryNoteController = class DeliveryNoteController extends (
 				);
 			}
 
-			if (flt(doc.per_installed, 2) < 100 && doc.docstatus == 1)
+			if (
+				flt(doc.per_installed, 2) < 100 &&
+				doc.docstatus == 1 &&
+				frappe.model.can_create("Installation Note")
+			) {
 				this.frm.add_custom_button(
 					__("Installation Note"),
 					function () {
@@ -194,8 +211,9 @@ erpnext.stock.DeliveryNoteController = class DeliveryNoteController extends (
 					},
 					__("Create")
 				);
+			}
 
-			if (doc.docstatus == 1) {
+			if (doc.docstatus == 1 && this.frm.has_perm("create")) {
 				this.frm.add_custom_button(
 					__("Sales Return"),
 					function () {
@@ -205,7 +223,7 @@ erpnext.stock.DeliveryNoteController = class DeliveryNoteController extends (
 				);
 			}
 
-			if (doc.docstatus == 1) {
+			if (doc.docstatus == 1 && frappe.model.can_create("Delivery Trip")) {
 				this.frm.add_custom_button(
 					__("Delivery Trip"),
 					function () {
@@ -215,19 +233,23 @@ erpnext.stock.DeliveryNoteController = class DeliveryNoteController extends (
 				);
 			}
 
-			if (doc.docstatus == 0 && !doc.__islocal) {
-				if (doc.__onload && doc.__onload.has_unpacked_items) {
-					this.frm.add_custom_button(
-						__("Packing Slip"),
-						function () {
-							frappe.model.open_mapped_doc({
-								method: "erpnext.stock.doctype.delivery_note.delivery_note.make_packing_slip",
-								frm: me.frm,
-							});
-						},
-						__("Create")
-					);
-				}
+			if (
+				doc.docstatus == 0 &&
+				!doc.__islocal &&
+				doc.__onload &&
+				doc.__onload.has_unpacked_items &&
+				frappe.model.can_create("Packing Slip")
+			) {
+				this.frm.add_custom_button(
+					__("Packing Slip"),
+					function () {
+						frappe.model.open_mapped_doc({
+							method: "erpnext.stock.doctype.delivery_note.delivery_note.make_packing_slip",
+							frm: me.frm,
+						});
+					},
+					__("Create")
+				);
 			}
 
 			if (!doc.__islocal && doc.docstatus == 1) {
@@ -254,7 +276,13 @@ erpnext.stock.DeliveryNoteController = class DeliveryNoteController extends (
 			}
 		}
 
-		if (doc.docstatus == 1 && !doc.is_return && doc.status != "Closed" && flt(doc.per_billed) < 100) {
+		if (
+			doc.docstatus == 1 &&
+			!doc.is_return &&
+			doc.status != "Closed" &&
+			flt(doc.per_billed) < 100 &&
+			frappe.model.can_create("Sales Invoice")
+		) {
 			// show Make Invoice button only if Delivery Note is not created from Sales Invoice
 			var from_sales_invoice = false;
 			from_sales_invoice = me.frm.doc.items.some(function (item) {


### PR DESCRIPTION
Assume we have a user whose only permission is to read Sales Orders. We shouldn't display all the "Update Items" and "Create ..." buttons, because clicking them will just result in an error message and a frustrating user experience.

### Before

All actions are available, regardless of permissions.

![Bildschirmfoto 2024-05-08 um 16 21 10](https://github.com/frappe/erpnext/assets/14891507/706ac834-1159-4847-b38b-ef30931505ff)

### After

Only permitted actions are displayed (none, in this case).

![Bildschirmfoto 2024-05-08 um 16 20 45](https://github.com/frappe/erpnext/assets/14891507/4cd0fdd5-0778-4f2b-9b04-2ddbc0ce7b38)

The same applies to Delivery Note.