### PR TITLE
fix: consistent use of "Address & Contact"

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
@@ -2042,7 +2042,7 @@
   {
    "fieldname": "contact_and_address_tab",
    "fieldtype": "Tab Break",
-   "label": "Contact & Address"
+   "label": "Address & Contact"
   },
   {
    "fieldname": "payments_tab",
@@ -2203,7 +2203,7 @@
    "link_fieldname": "consolidated_invoice"
   }
  ],
- "modified": "2024-04-11 11:30:26.272441",
+ "modified": "2024-05-08 18:02:28.549041",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice",

--- a/erpnext/buying/doctype/supplier/supplier.json
+++ b/erpnext/buying/doctype/supplier/supplier.json
@@ -406,7 +406,7 @@
   {
    "fieldname": "contact_and_address_tab",
    "fieldtype": "Tab Break",
-   "label": "Contact & Address"
+   "label": "Address & Contact"
   },
   {
    "fieldname": "accounting_tab",
@@ -485,7 +485,7 @@
    "link_fieldname": "party"
   }
  ],
- "modified": "2024-03-27 13:10:48.412732",
+ "modified": "2024-05-08 18:02:57.342931",
  "modified_by": "Administrator",
  "module": "Buying",
  "name": "Supplier",

--- a/erpnext/selling/doctype/customer/customer.json
+++ b/erpnext/selling/doctype/customer/customer.json
@@ -482,7 +482,7 @@
   {
    "fieldname": "contact_and_address_tab",
    "fieldtype": "Tab Break",
-   "label": "Contact & Address"
+   "label": "Address & Contact"
   },
   {
    "fieldname": "defaults_tab",
@@ -583,7 +583,7 @@
    "link_fieldname": "party"
   }
  ],
- "modified": "2024-03-27 13:06:48.056107",
+ "modified": "2024-05-08 18:03:20.716169",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Customer",


### PR DESCRIPTION
"Address & Contact" is used everywhere, while "Contact & Address" was only used in these three DocTypes.