### PR TITLE
Remove Mandatory Checks to Country and State In Employee Doctype

### DIFF
--- a/erpnext/setup/doctype/employee/employee.json
+++ b/erpnext/setup/doctype/employee/employee.json
@@ -59,9 +59,11 @@
   "address_section",
   "current_address",
   "current_accommodation_type",
+  "country",
   "column_break_46",
   "permanent_address",
   "permanent_accommodation_type",
+  "state",
   "emergency_contact_details",
   "person_to_be_contacted",
   "column_break_55",
@@ -817,6 +819,17 @@
    "fieldname": "iban",
    "fieldtype": "Data",
    "label": "IBAN"
+  },
+  {
+   "fieldname": "country",
+   "fieldtype": "Link",
+   "label": "Country",
+   "options": "Country"
+  },
+  {
+   "fieldname": "state",
+   "fieldtype": "Data",
+   "label": "State"
   }
  ],
  "icon": "fa fa-user",
@@ -824,7 +837,7 @@
  "image_field": "image",
  "is_tree": 1,
  "links": [],
- "modified": "2024-03-27 13:09:36.900706",
+ "modified": "2024-05-09 09:50:04.781717",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Employee",


### PR DESCRIPTION
I have added two fields in the Employee Doctype: country and State. In my previous PR, I made the Country field mandatory, and based on the Country if it is " United States" the state field will be Mandatory.