### PR TITLE
fix: BOM creator validation for parent row no

### DIFF
--- a/erpnext/manufacturing/doctype/bom_creator/bom_creator.py
+++ b/erpnext/manufacturing/doctype/bom_creator/bom_creator.py
@@ -80,6 +80,18 @@ class BOMCreator(Document):
 			if row.is_expandable and row.item_code == self.item_code:
 				frappe.throw(_("Item {0} cannot be added as a sub-assembly of itself").format(row.item_code))
 
+			if not row.parent_row_no and row.fg_item and row.fg_item != self.item_code:
+				frappe.throw(
+					_("At row {0}: set Parent Row No for item {1}").format(row.idx, row.item_code),
+					title=_("Set Parent Row No in Items Table"),
+				)
+
+			elif row.parent_row_no and row.fg_item == self.item_code:
+				frappe.throw(
+					_("At row {0}: Parent Row No cannot be set for item {1}").format(row.idx, row.item_code),
+					title=_("Remove Parent Row No in Items Table"),
+				)
+
 	def set_status(self, save=False):
 		self.status = {
 			0: "Draft",
@@ -410,6 +422,10 @@ def add_sub_assembly(**kwargs):
 
 		parent_row_no = item_row.idx
 		name = ""
+	else:
+		parent_row_no = [row.idx for row in doc.items if row.name == kwargs.fg_reference_id]
+		if parent_row_no:
+			parent_row_no = parent_row_no[0]
 
 	for row in bom_item.get("items"):
 		row = frappe._dict(row)


### PR DESCRIPTION
Without parent row no causing the below error 

<img width="1149" alt="Screenshot 2024-05-11 at 10 34 53 PM" src="https://github.com/frappe/erpnext/assets/8780500/5fc861cd-4a61-462c-bd54-1196817c09ab">


```
  File "apps/erpnext/erpnext/manufacturing/doctype/bom_creator/bom_creator.py", line 242, in create_boms
    production_item_wise_rm[(row.fg_item, row.fg_reference_id)]["items"].append(row)
      self = <BOMCreator: TAY-2PA_BOM_FINAL docstatus=1>
      production_item_wise_rm = OrderedDict([(('TAY-2PA', 'TAY-2PA_BOM_FINAL'), {'items': [<BOMCreatorItem: iv8g5ecjs9 docstatus=1 parent=TAY-2PA_BOM_FINAL>], 'bom_no': '', 'fg_item_data': <BOMCreator: TAY-2PA_BOM_FINAL docstatus=1>}), (('ASM-STAGE4', 'iv8g5ecjs9'), {'items': [], 'bom_no': '', 'fg_item_data': <BOMCreatorItem: iv8g5ecjs9 docstatus=1 parent=TAY-2PA_BOM_FINAL>}), (('ASM-STAGE2', 'iv8g24mbgp'), {'items': [], 'bom_no': '', 'fg_item_data': <BOMCreatorItem: iv8g24mbgp docstatus=1 parent=TAY-2PA_BOM_FINAL>})])
      row = <BOMCreatorItem: iv8g24mbgp docstatus=1 parent=TAY-2PA_BOM_FINAL>
builtins.KeyError: ('ASM-STAGE3', 'is9846sa8n')
```