### PR TITLE
fix: do not preserve whitespace in Address Template for Germany

### DIFF
--- a/erpnext/regional/address_template/templates/germany.html
+++ b/erpnext/regional/address_template/templates/germany.html
@@ -1,8 +1,8 @@
 {{ address_line1 }}<br>
-{% if address_line2 %}{{ address_line2 }}<br>{% endif -%}
-{% if country in ["Germany", "Deutschland"] %}
+{%- if address_line2 -%}{{ address_line2 }}<br>{%- endif -%}
+{%- if country in ["Germany", "Deutschland"] -%}
     {{ pincode }} {{ city }}
-{% else %}
+{%- else -%}
     {{ pincode }} {{ city | upper }}<br>
-    {{ country | upper }}
-{% endif %}
+    {{- country | upper -}}
+{%- endif -%}


### PR DESCRIPTION
`Berliner Str. 1<br>\n\n    13187 Berlin\n` becomes `Berliner Str. 1<br>13187 Berlin` - necessary since Version 15, because of https://github.com/frappe/frappe/commit/71cfeb14c0964315d2751311910785b4061d5a26 



