### PR TITLE
fix: get prorata depreciation based on total days per year

### DIFF
--- a/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
@@ -669,7 +669,7 @@ def get_straight_line_or_manual_depr_amount(
 
 
 def get_daily_prorata_based_straight_line_depr(
-	asset, row, schedule_idx, number_of_pending_depreciations, amount, total_years
+	asset, row, schedule_idx, number_of_pending_depreciations, amount
 ):
 	total_years = flt(number_of_pending_depreciations * row.frequency_of_depreciation) / 12
 	every_year_depr = amount / total_years

--- a/erpnext/assets/doctype/asset_depreciation_schedule/test_asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/test_asset_depreciation_schedule.py
@@ -3,10 +3,12 @@
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
+from frappe.utils import cstr
 
 from erpnext.assets.doctype.asset.test_asset import create_asset, create_asset_data
 from erpnext.assets.doctype.asset_depreciation_schedule.asset_depreciation_schedule import (
 	get_asset_depr_schedule_doc,
+	get_depr_schedule,
 )
 
 
@@ -25,3 +27,47 @@ class TestAssetDepreciationSchedule(FrappeTestCase):
 		)
 
 		self.assertRaises(frappe.ValidationError, second_asset_depr_schedule.insert)
+
+	def test_daily_prorata_based_depr_on_sl_methond(self):
+		asset = create_asset(
+			calculate_depreciation=1,
+			depreciation_method="Straight Line",
+			daily_prorata_based=1,
+			available_for_use_date="2020-01-01",
+			depreciation_start_date="2020-01-31",
+			frequency_of_depreciation=1,
+			total_number_of_depreciations=24,
+		)
+
+		expected_schedules = [
+			["2020-01-31", 4234.97, 4234.97],
+			["2020-02-29", 3961.75, 8196.72],
+			["2020-03-31", 4234.97, 12431.69],
+			["2020-04-30", 4098.36, 16530.05],
+			["2020-05-31", 4234.97, 20765.02],
+			["2020-06-30", 4098.36, 24863.38],
+			["2020-07-31", 4234.97, 29098.35],
+			["2020-08-31", 4234.97, 33333.32],
+			["2020-09-30", 4098.36, 37431.68],
+			["2020-10-31", 4234.97, 41666.65],
+			["2020-11-30", 4098.36, 45765.01],
+			["2020-12-31", 4234.97, 49999.98],
+			["2021-01-31", 4246.58, 54246.56],
+			["2021-02-28", 3835.62, 58082.18],
+			["2021-03-31", 4246.58, 62328.76],
+			["2021-04-30", 4109.59, 66438.35],
+			["2021-05-31", 4246.58, 70684.93],
+			["2021-06-30", 4109.59, 74794.52],
+			["2021-07-31", 4246.58, 79041.1],
+			["2021-08-31", 4246.58, 83287.68],
+			["2021-09-30", 4109.59, 87397.27],
+			["2021-10-31", 4246.58, 91643.85],
+			["2021-11-30", 4109.59, 95753.44],
+			["2021-12-31", 4246.56, 100000.0],
+		]
+
+		schedules = [
+			[cstr(d.schedule_date), d.depreciation_amount, d.accumulated_depreciation_amount]
+			for d in get_depr_schedule(asset.name, "Draft")
+		]
+		self.assertEqual(schedules, expected_schedules)


### PR DESCRIPTION
Previously depreciation calculation happens as per the total no. of days in the whole depreciation period and based on that it calculates per month depreciation.

But as per the expectation first the yearly depreciation calculation should happen then from the yearly depreciation, monthly depreciation should be calculated.
Depreciation calculation before the changes.
<img width="1053" alt="Screenshot 2024-05-14 at 11 15 28 AM" src="https://github.com/frappe/erpnext/assets/142375893/b70cd5db-d9e2-4962-8fb2-5d94f244c62c">

Depreciation calculation after changes
<img width="1053" alt="Screenshot 2024-05-14 at 11 14 44 AM" src="https://github.com/frappe/erpnext/assets/142375893/8dcfbf93-2d99-482c-b62c-ee98c6709a40">



no-docs