### PR TITLE
fix: migrate lead notes

### DIFF
--- a/erpnext/patches/v14_0/migrate_existing_lead_notes_as_per_the_new_format.py
+++ b/erpnext/patches/v14_0/migrate_existing_lead_notes_as_per_the_new_format.py
@@ -9,15 +9,13 @@ def execute():
 
 		dt = frappe.qb.DocType(doctype)
 		records = (
-			frappe.qb.from_(dt)
-			.select(dt.name, dt.notes, dt.modified_by, dt.modified)
-			.where(dt.notes.isnotnull() & dt.notes != "")
+			frappe.qb.from_(dt).select(dt.name, dt.notes).where(dt.notes.isnotnull() & dt.notes != "")
 		).run(as_dict=True)
 
 		for d in records:
 			if strip_html(cstr(d.notes)).strip():
 				doc = frappe.get_doc(doctype, d.name)
-				doc.append("notes", {"note": d.notes, "added_by": d.modified_by, "added_on": d.modified})
+				doc.append("notes", {"note": d.notes})
 				doc.update_child_table("notes")
 
 		frappe.db.sql_ddl(f"alter table `tab{doctype}` drop column `notes`")

--- a/erpnext/public/js/templates/crm_notes.html
+++ b/erpnext/public/js/templates/crm_notes.html
@@ -12,6 +12,7 @@
 			{% for(var i=0, l=notes.length; i<l; i++) { %}
 				<div class="comment-content p-3 row" name="{{ notes[i].name }}">
 					<div class="mb-2 head col-xs-3">
+						{% if (notes[i].added_by && notes[i].added_on) %}
 						<div class="row">
 							<div class="col-xs-2">
 								{{ frappe.avatar(notes[i].added_by) }}
@@ -25,6 +26,7 @@
 								</div>
 							</div>
 						</div>
+						{% } %}
 					</div>
 					<div class="content col-xs-8">
 						{{ notes[i].note }}


### PR DESCRIPTION
### Reproduce

On a v13 instance,

(1) **User** _A_ creates a **Lead** and adds some notes,
(2) **User** _B_ modifies the **Lead** status,

Then, the site is migrated to v14.

### Before

**User** _B_ is set as the creator of the notes.

### After

The creator of the note and it's creation date are not set, because they are not known.

![Bildschirmfoto 2024-06-14 um 17 46 37](https://github.com/frappe/erpnext/assets/14891507/b2bf8d6a-740b-4be0-aae3-b4a07320f2eb)
