### PR TITLE
fix: move renaming of TDS report to [post_model_sync]

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -259,7 +259,6 @@ erpnext.patches.v15_0.saudi_depreciation_warning
 erpnext.patches.v15_0.delete_saudi_doctypes
 erpnext.patches.v14_0.show_loan_management_deprecation_warning
 erpnext.patches.v14_0.clear_reconciliation_values_from_singles
-execute:frappe.rename_doc("Report", "TDS Payable Monthly", "Tax Withholding Details", force=True)
 
 [post_model_sync]
 execute:frappe.delete_doc_if_exists('Workspace', 'ERPNext Integrations Settings')
@@ -328,6 +327,7 @@ execute:frappe.delete_doc('DocType', 'Cash Flow Mapping Accounts', ignore_missin
 erpnext.patches.v14_0.cleanup_workspaces
 erpnext.patches.v15_0.remove_loan_management_module #2023-07-03
 erpnext.patches.v14_0.set_report_in_process_SOA
+execute:frappe.rename_doc("Report", "TDS Payable Monthly", "Tax Withholding Details", force=True, merge=True)
 erpnext.buying.doctype.supplier.patches.migrate_supplier_portal_users
 execute:frappe.defaults.clear_default("fiscal_year")
 erpnext.patches.v15_0.remove_exotel_integration


### PR DESCRIPTION
`rename_doc` triggers a query on `tabDocType.is_virtual`, which does not exist `[pre_model_sync]`

I added the `merge=True` parameter to handle the conflict with the new report, which will already exists at the time of the patch.

Resolves https://github.com/frappe/erpnext/pull/36196/files#r1597711162