### PR TITLE
fix: data getting override in delivery trip

### DIFF
--- a/erpnext/stock/doctype/delivery_trip/delivery_trip.js
+++ b/erpnext/stock/doctype/delivery_trip/delivery_trip.js
@@ -51,7 +51,6 @@ frappe.ui.form.on("Delivery Trip", {
 			frm.add_custom_button(
 				__("Delivery Note"),
 				() => {
-					frm.clear_table("delivery_stops");
 					erpnext.utils.map_current_doc({
 						method: "erpnext.stock.doctype.delivery_note.delivery_note.make_delivery_trip",
 						source_doctype: "Delivery Note",


### PR DESCRIPTION
**Issue**
On click of Get Stops From > Delivery Note "The data in the child table is overwritten by new rows."

![delivery_trip_issue](https://github.com/frappe/erpnext/assets/8780500/6a243e94-f977-4bce-babd-9d5dca759d6f)
