### PR TITLE
fix: fixed name for doctype 'Unreconcile Payments'

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -1516,7 +1516,7 @@ class PurchaseInvoice(BuyingController):
 			"Repost Payment Ledger Items",
 			"Repost Accounting Ledger",
 			"Repost Accounting Ledger Items",
-			"Unreconcile Payment",
+			"Unreconcile Payments",
 			"Unreconcile Payment Entries",
 			"Payment Ledger Entry",
 			"Tax Withheld Vouchers",


### PR DESCRIPTION
The doctype was written without the 's' at the end.

Correct name: Unreconcile Payments