### PR TITLE
fix(AccountsController): Use get_all to get payment requests when updating advance payment status

### DIFF
--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1942,7 +1942,7 @@ class AccountsController(TransactionBase):
 	def set_advance_payment_status(self):
 		new_status = None
 
-		stati = frappe.get_list(
+		stati = frappe.get_all(
 			"Payment Request",
 			{
 				"reference_doctype": self.doctype,


### PR DESCRIPTION
I believe there was a mistake done in https://github.com/frappe/erpnext/pull/40643, [see diff](https://github.com/frappe/erpnext/pull/40643/files#diff-70fca67b7fdc9bc43a6957ae13b3a4817eccd4e62b1cd4a1335407dfb4bc945dR1932).

`frappe.db.count` was replaced by `frappe.get_list`, which does not have the same permission model (unchecked vs checked)

https://github.com/frappe/erpnext/blob/c9c62110097b75d727b814959733402cb7ceafeb/erpnext/controllers/accounts_controller.py#L1936-L1937


/cc @blaggacao