### PR TITLE
fix: product filters value sorting

### DIFF
--- a/erpnext/e_commerce/product_data_engine/filters.py
+++ b/erpnext/e_commerce/product_data_engine/filters.py
@@ -84,7 +84,7 @@ class ProductFiltersBuilder:
 				values.remove(None)
 
 			if values:
-				filter_data.append([df, values])
+				filter_data.append([df, sorted(values)])
 
 		return filter_data
 
@@ -140,7 +140,7 @@ class ProductFiltersBuilder:
 
 		out = []
 		for name, values in attribute_value_map.items():
-			out.append(frappe._dict(name=name, item_attribute_values=values))
+			out.append(frappe._dict(name=name, item_attribute_values=sorted(values)))
 		return out
 
 	def get_discount_filters(self, discounts):


### PR DESCRIPTION
**Issue:**
Currently when adding filter in E Commerce SettingsField either Filters (Categories) or Attribute Filters section. The order of the values is not sorted. (See example image below)


![Untitled design](https://github.com/frappe/erpnext/assets/42670019/4f5b881a-5fe4-4ae0-b26e-94db9e46fd60)

**Proposed solution:**
Sort values returned in class ProductFiltersBuilder


![Screenshot 2024-05-14 at 10 14 23 PM](https://github.com/frappe/erpnext/assets/42670019/7dc33716-30ae-4a66-8c14-657bc12d45c7)



