### PR TITLE
fix: asset cancelation issue

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -453,11 +453,12 @@ class JournalEntry(AccountsController):
 
 	def unlink_asset_reference(self):
 		for d in self.get("accounts"):
+			root_type = frappe.get_value("Account", d.account, "root_type")
 			if (
 				self.voucher_type == "Depreciation Entry"
 				and d.reference_type == "Asset"
 				and d.reference_name
-				and d.account_type == "Depreciation"
+				and root_type == "Expense"
 				and d.debit
 			):
 				asset = frappe.get_doc("Asset", d.reference_name)

--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -453,12 +453,11 @@ class JournalEntry(AccountsController):
 
 	def unlink_asset_reference(self):
 		for d in self.get("accounts"):
-			root_type = frappe.get_value("Account", d.account, "root_type")
 			if (
 				self.voucher_type == "Depreciation Entry"
 				and d.reference_type == "Asset"
 				and d.reference_name
-				and root_type == "Expense"
+				and frappe.get_cached_value("Account", d.account, "root_type") == "Expense"
 				and d.debit
 			):
 				asset = frappe.get_doc("Asset", d.reference_name)


### PR DESCRIPTION
Issue: When attempting to cancel an asset, a message show to cancel the journal entry first. However, when trying to cancel the journal entry, it instructs to cancel the asset first, creating a loop that prevents the asset cancellation

no-docs