### PR TITLE
feat(autoname): Make deferred naming for GL entry and Stock Ledger entry optional

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -43,6 +43,8 @@
   "section_break_jpd0",
   "auto_reconcile_payments",
   "stale_days",
+  "database_performance_optimizations_section",
+  "deferred_naming_for_stock_ledger_entry_and_gl_entry",
   "invoicing_settings_tab",
   "accounts_transactions_settings_section",
   "over_billing_allowance",
@@ -462,6 +464,18 @@
    "fieldname": "enable_immutable_ledger",
    "fieldtype": "Check",
    "label": "Enable Immutable Ledger"
+  },
+  {
+   "fieldname": "database_performance_optimizations_section",
+   "fieldtype": "Section Break",
+   "label": "Database Performance Optimizations"
+  },
+  {
+   "default": "0",
+   "description": "If selected the names of Stock Ledger and General Ledger entries will be generated via a hourly scheduled job, instead of being generated on creation. This improves performance of creation and submission of accounting documents, but makes names inconsistent. Consistent names may be needed for custom applications.",
+   "fieldname": "deferred_naming_for_stock_ledger_entry_and_gl_entry",
+   "fieldtype": "Check",
+   "label": "Deferred naming for Stock Ledger Entry and GL Entry"
   }
  ],
  "icon": "icon-cog",

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
@@ -35,6 +35,7 @@ class AccountsSettings(Document):
 		book_tax_discount_loss: DF.Check
 		check_supplier_invoice_uniqueness: DF.Check
 		credit_controller: DF.Link | None
+		deferred_naming_for_stock_ledger_entry_and_gl_entry: DF.Check
 		delete_linked_ledger_entries: DF.Check
 		determine_address_tax_category_from: DF.Literal["Billing Address", "Shipping Address"]
 		enable_common_party_accounting: DF.Check

--- a/erpnext/accounts/doctype/gl_entry/gl_entry.py
+++ b/erpnext/accounts/doctype/gl_entry/gl_entry.py
@@ -67,9 +67,14 @@ class GLEntry(Document):
 		"""
 		Temporarily name doc for fast insertion
 		name will be changed using autoname options (in a scheduled job)
+		This feature is enabled in Accounts Settings by setting the corresponding checkbox
+		This method does nothing if the checkbox is not checked. By default the name is generated using the given naming scheme
 		"""
-		self.name = frappe.generate_hash(txt="", length=10)
-		if self.meta.autoname == "hash":
+		if frappe.db.get_single_value("Accounts Settings", "deferred_naming_for_stock_ledger_entry_and_gl_entry"):
+			self.name = frappe.generate_hash(txt="", length=10)
+			if self.meta.autoname == "hash":
+				self.to_rename = 0
+		else:
 			self.to_rename = 0
 
 	def validate(self):

--- a/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py
+++ b/erpnext/stock/doctype/stock_ledger_entry/stock_ledger_entry.py
@@ -74,9 +74,14 @@ class StockLedgerEntry(Document):
 		"""
 		Temporarily name doc for fast insertion
 		name will be changed using autoname options (in a scheduled job)
+		This feature is enabled in Accounts Settings by setting the corresponding checkbox
+		This method does nothing if the checkbox is not checked. By default the name is generated using the given naming scheme
 		"""
-		self.name = frappe.generate_hash(txt="", length=10)
-		if self.meta.autoname == "hash":
+		if frappe.db.get_single_value("Accounts Settings", "deferred_naming_for_stock_ledger_entry_and_gl_entry"):
+			self.name = frappe.generate_hash(txt="", length=10)
+			if self.meta.autoname == "hash":
+				self.to_rename = 0
+		else:
 			self.to_rename = 0
 
 	def validate(self):


### PR DESCRIPTION
Stock Ledger Entry and GL Entry use a naming system where the final name is only generated by a scheduled job, which makes the naming unstable. This has the tendency to break external applications relying on the naming scheme being final, due to hooks on document submission. Therefore this should be an optional feature, which can be enabled in the accounts settings if needed due to low database performance. This feature also causes a lot of confusion and not much benefit currently, which means by default this should be off.
This got included in #16358

`closes #36337` by giving the fix of names being immediately aligned to the scheme
