### PR TITLE
fix: validate reorder group warehouse

### DIFF
--- a/erpnext/stock/doctype/item/test_item.py
+++ b/erpnext/stock/doctype/item/test_item.py
@@ -862,6 +862,27 @@ class TestItem(FrappeTestCase):
 		self.assertEqual(data[0].description, item.description)
 		self.assertTrue("description" in data[0])
 
+	def test_group_warehouse_for_reorder_item(self):
+		from erpnext.stock.doctype.warehouse.test_warehouse import create_warehouse
+
+		item_doc = make_item("_Test Group Warehouse For Reorder Item", {"is_stock_item": 1})
+		warehouse = create_warehouse("_Test Warehouse - _TC")
+		warehouse_doc = frappe.get_doc("Warehouse", warehouse)
+		warehouse_doc.db_set("parent_warehouse", "")
+
+		item_doc.append(
+			"reorder_levels",
+			{
+				"warehouse": warehouse,
+				"warehouse_reorder_level": 10,
+				"warehouse_reorder_qty": 100,
+				"material_request_type": "Purchase",
+				"warehouse_group": "_Test Warehouse Group - _TC",
+			},
+		)
+
+		self.assertRaises(frappe.ValidationError, item_doc.save)
+
 
 def set_item_variant_settings(fields):
 	doc = frappe.get_doc("Item Variant Settings")


### PR DESCRIPTION
**Issue**

- User has set the Group Warehouse, Warehouse, Reorder Level and Reorder Qty in the item master
- The user has set the incorrect Group Warehouse and the warehouse was not the child warehouse of the Group Warehouse
- Due to which the system has created unnecessary extra material requests even though stock exists in the warehouse.


**To Solve this Issue**

Added a validation which will ensue that the child warehouse is belongs to the Group Warehouse