### PR TITLE
fix: create custom field for accounting dimensions only if the field not exists already

### DIFF
--- a/erpnext/patches/v13_0/create_accounting_dimensions_for_asset_repair.py
+++ b/erpnext/patches/v13_0/create_accounting_dimensions_for_asset_repair.py
@@ -13,8 +13,9 @@ def execute():
 	for d in accounting_dimensions:
 		doctype = "Asset Repair"
 		field = frappe.db.get_value("Custom Field", {"dt": doctype, "fieldname": d.fieldname})
+		docfield = frappe.db.get_value("DocField", {"parent": doctype, "fieldname": d.fieldname})
 
-		if field:
+		if field or docfield:
 			continue
 
 		df = {


### PR DESCRIPTION
User has create accounting dimension based on purchase invoice. But purchase invoice field already exists in Asset Repair doctype. And that's why, the patch was failing.