### PR TITLE
refactor: For advances booked in Separate account, reconciliation date can be configured

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.json
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.json
@@ -752,6 +752,7 @@
    "fieldtype": "Check",
    "hidden": 1,
    "label": "Book Advance Payments in Separate Party Account",
+   "no_copy": 1,
    "read_only": 1
   },
   {
@@ -775,6 +776,7 @@
    "fieldtype": "Check",
    "hidden": 1,
    "label": "Reconcile on Advance Payment Date",
+   "no_copy": 1,
    "read_only": 1
   }
  ],
@@ -789,7 +791,7 @@
    "table_fieldname": "payment_entries"
   }
  ],
- "modified": "2024-05-16 11:50:19.394918",
+ "modified": "2024-05-17 10:21:11.199445",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Entry",

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.json
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.json
@@ -20,6 +20,7 @@
   "party",
   "party_name",
   "book_advance_payments_in_separate_party_account",
+  "reconcile_on_advance_payment_date",
   "column_break_11",
   "bank_account",
   "party_bank_account",
@@ -766,6 +767,15 @@
    "label": "In Words",
    "print_hide": 1,
    "read_only": 1
+  },
+  {
+   "default": "0",
+   "fetch_from": "company.reconcile_on_advance_payment_date",
+   "fieldname": "reconcile_on_advance_payment_date",
+   "fieldtype": "Check",
+   "hidden": 1,
+   "label": "Reconcile on Advance Payment Date",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
@@ -779,7 +789,7 @@
    "table_fieldname": "payment_entries"
   }
  ],
- "modified": "2024-04-11 11:25:07.366347",
+ "modified": "2024-05-16 11:50:19.394918",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Entry",

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -1344,13 +1344,16 @@ class PaymentEntry(AccountsController):
 			"voucher_detail_no": invoice.name,
 		}
 
-		date_field = "posting_date"
-		if invoice.reference_doctype in ["Sales Order", "Purchase Order"]:
-			date_field = "transaction_date"
-		posting_date = frappe.db.get_value(invoice.reference_doctype, invoice.reference_name, date_field)
-
-		if getdate(posting_date) < getdate(self.posting_date):
+		if self.reconcile_on_advance_payment_date:
 			posting_date = self.posting_date
+		else:
+			date_field = "posting_date"
+			if invoice.reference_doctype in ["Sales Order", "Purchase Order"]:
+				date_field = "transaction_date"
+			posting_date = frappe.db.get_value(invoice.reference_doctype, invoice.reference_name, date_field)
+
+			if getdate(posting_date) < getdate(self.posting_date):
+				posting_date = self.posting_date
 
 		dr_or_cr, account = self.get_dr_and_account_for_advances(invoice)
 		args_dict["account"] = account

--- a/erpnext/setup/doctype/company/company.json
+++ b/erpnext/setup/doctype/company/company.json
@@ -768,6 +768,7 @@
   {
    "default": "0",
    "depends_on": "eval: doc.book_advance_payments_in_separate_party_account",
+   "description": "If <b>Enabled</b> - Reconciliation happens on the <b>Advance Payment posting date</b><br>\nIf <b>Disabled</b> - Reconciliation happens on oldest of 2 Dates: <b>Invoice Date</b> or the <b>Advance Payment posting date</b><br>\n",
    "fieldname": "reconcile_on_advance_payment_date",
    "fieldtype": "Check",
    "label": "Reconcile on Advance Payment Date"
@@ -778,7 +779,7 @@
  "image_field": "company_logo",
  "is_tree": 1,
  "links": [],
- "modified": "2024-05-16 11:52:13.067003",
+ "modified": "2024-05-16 12:39:54.694232",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Company",

--- a/erpnext/setup/doctype/company/company.json
+++ b/erpnext/setup/doctype/company/company.json
@@ -67,6 +67,7 @@
   "default_finance_book",
   "advance_payments_section",
   "book_advance_payments_in_separate_party_account",
+  "reconcile_on_advance_payment_date",
   "column_break_fwcf",
   "default_advance_received_account",
   "default_advance_paid_account",
@@ -763,6 +764,13 @@
    "fieldtype": "Tab Break",
    "label": "Dashboard",
    "show_dashboard": 1
+  },
+  {
+   "default": "0",
+   "depends_on": "eval: doc.book_advance_payments_in_separate_party_account",
+   "fieldname": "reconcile_on_advance_payment_date",
+   "fieldtype": "Check",
+   "label": "Reconcile on Advance Payment Date"
   }
  ],
  "icon": "fa fa-building",
@@ -770,7 +778,7 @@
  "image_field": "company_logo",
  "is_tree": 1,
  "links": [],
- "modified": "2024-04-23 12:38:33.173938",
+ "modified": "2024-05-16 11:52:13.067003",
  "modified_by": "Administrator",
  "module": "Setup",
  "name": "Company",

--- a/erpnext/setup/doctype/company/company.py
+++ b/erpnext/setup/doctype/company/company.py
@@ -85,6 +85,7 @@ class Company(NestedSet):
 		parent_company: DF.Link | None
 		payment_terms: DF.Link | None
 		phone_no: DF.Data | None
+		reconcile_on_advance_payment_date: DF.Check
 		registration_details: DF.Code | None
 		rgt: DF.Int
 		round_off_account: DF.Link | None


### PR DESCRIPTION
For advance payments that are booked in Separate Party account (https://docs.erpnext.com/docs/user/manual/en/advance-in-separate-party-account), reconciliation date can now be configured in Company master.

1. Reconciliation will happen either on Invoice Date or the Advance Payment date, whichever is the oldest. This is the default and expected behavior.
2. Reconciliation will always happen on the Advance Payment date. 

continues: https://github.com/frappe/erpnext/pull/35609