### PR TITLE
fix: correcting balance sheet calculation for zero liabilities and equity

### DIFF
--- a/erpnext/accounts/report/balance_sheet/balance_sheet.py
+++ b/erpnext/accounts/report/balance_sheet/balance_sheet.py
@@ -122,14 +122,14 @@ def get_provisional_profit_loss(
 
 		for period in period_list:
 			key = period if consolidated else period.key
-			total_assets = flt(asset[-2].get(key))
+			total_assets = flt(asset[0].get(key))
 
 			if liability or equity:
 				effective_liability = 0.0
 				if liability:
-					effective_liability += flt(liability[-2].get(key))
+					effective_liability += flt(liability[0].get(key))
 				if equity:
-					effective_liability += flt(equity[-2].get(key))
+					effective_liability += flt(equity[0].get(key))
 
 				provisional_profit_loss[key] = total_assets - effective_liability
 			else:
@@ -198,11 +198,11 @@ def get_report_summary(
 	for period in period_list:
 		key = period if consolidated else period.key
 		if asset:
-			net_asset += asset[-2].get(key)
+			net_asset += asset[0].get(key)
 		if liability:
-			net_liability += liability[-2].get(key)
+			net_liability += liability[0].get(key)
 		if equity:
-			net_equity += equity[-2].get(key)
+			net_equity += equity[0].get(key)
 		if provisional_profit_loss:
 			net_provisional_profit_loss += provisional_profit_loss.get(key)
 

--- a/erpnext/accounts/report/balance_sheet/balance_sheet.py
+++ b/erpnext/accounts/report/balance_sheet/balance_sheet.py
@@ -109,7 +109,7 @@ def get_provisional_profit_loss(
 ):
 	provisional_profit_loss = {}
 	total_row = {}
-	if asset and (liability or equity):
+	if asset:
 		total = total_row_total = 0
 		currency = currency or frappe.get_cached_value("Company", company, "default_currency")
 		total_row = {
@@ -122,14 +122,20 @@ def get_provisional_profit_loss(
 
 		for period in period_list:
 			key = period if consolidated else period.key
-			effective_liability = 0.0
-			if liability:
-				effective_liability += flt(liability[0].get(key))
-			if equity:
-				effective_liability += flt(equity[0].get(key))
+			total_assets = flt(asset[-2].get(key))
 
-			provisional_profit_loss[key] = flt(asset[0].get(key)) - effective_liability
-			total_row[key] = effective_liability + provisional_profit_loss[key]
+			if liability or equity:
+				effective_liability = 0.0
+				if liability:
+					effective_liability += flt(liability[-2].get(key))
+				if equity:
+					effective_liability += flt(equity[-2].get(key))
+
+				provisional_profit_loss[key] = total_assets - effective_liability
+			else:
+				provisional_profit_loss[key] = total_assets
+
+			total_row[key] = provisional_profit_loss[key]
 
 			if provisional_profit_loss[key]:
 				has_value = True
@@ -192,11 +198,11 @@ def get_report_summary(
 	for period in period_list:
 		key = period if consolidated else period.key
 		if asset:
-			net_asset += asset[0].get(key)
+			net_asset += asset[-2].get(key)
 		if liability:
-			net_liability += liability[0].get(key)
+			net_liability += liability[-2].get(key)
 		if equity:
-			net_equity += equity[0].get(key)
+			net_equity += equity[-2].get(key)
 		if provisional_profit_loss:
 			net_provisional_profit_loss += provisional_profit_loss.get(key)
 


### PR DESCRIPTION
version 15

fixes: #41488 and https://discuss.frappe.io/t/provisional-profit-loss-credit-shows-0-despite-total-asset-value-in-balance-sheet-report/123335

**Before:**

- In the Balance Sheet report, if the Total Liability and Total Equity are both zero, the Provisional Profit/Loss (Credit) is not calculated.

![image](https://github.com/frappe/erpnext/assets/141945075/6c345bbb-b632-4d3d-b164-31b30cbfed0f)


**After:**

![image](https://github.com/frappe/erpnext/assets/141945075/1ab8859b-6c3a-4d4a-a036-bc7c18b62744)


![image](https://github.com/frappe/erpnext/assets/141945075/efb17cba-5eb0-4143-801e-1594892224fd)
