### PR TITLE
fix: added validation message for low gross purchase amount

### DIFF
--- a/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
@@ -363,6 +363,16 @@ class AssetDepreciationSchedule(Document):
 					row.depreciation_start_date,
 					has_wdv_or_dd_non_yearly_pro_rata,
 				)
+				if flt(depreciation_amount, asset_doc.precision("gross_purchase_amount")) <= 0:
+					frappe.throw(
+						_(
+							"Gross Purchase Amount Too Low: {0} cannot be depreciated over {1} cycles with a frequency of {2} depreciations."
+						).format(
+							frappe.bold(asset_doc.gross_purchase_amount),
+							frappe.bold(row.total_number_of_depreciations),
+							frappe.bold(row.frequency_of_depreciation),
+						)
+					)
 			elif n == 0 and has_wdv_or_dd_non_yearly_pro_rata and self.opening_accumulated_depreciation:
 				if not is_first_day_of_the_month(getdate(asset_doc.available_for_use_date)):
 					from_date = get_last_day(


### PR DESCRIPTION
When an asset has an extremely low purchase amount, system was not calculating depreciation over the initially planned number of periods at the current frequency. 
Adjustments to the number of depreciation periods or the frequency of depreciation may be needed to better align with the asset's value.
So improved the validation error message for this particular scenario to make it more user-friendly.

no-docs