### PR TITLE
fix: timeout error while submitting purchase invoice

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
@@ -914,6 +914,15 @@ class PurchaseReceipt(BuyingController):
 					notify=True,
 				)
 
+	def enable_recalculate_rate_in_sles(self):
+		sle_table = frappe.qb.DocType("Stock Ledger Entry")
+		(
+			frappe.qb.update(sle_table)
+			.set(sle_table.recalculate_rate, 1)
+			.where(sle_table.voucher_no == self.name)
+			.where(sle_table.voucher_type == "Purchase Receipt")
+		).run()
+
 
 def get_stock_value_difference(voucher_no, voucher_detail_no, warehouse):
 	return frappe.db.get_value(
@@ -1086,15 +1095,10 @@ def adjust_incoming_rate_for_pr(doc):
 	for item in doc.get("items"):
 		item.db_update()
 
-	doc.docstatus = 2
-	doc.update_stock_ledger(allow_negative_stock=True, via_landed_cost_voucher=True)
-	doc.make_gl_entries_on_cancel()
+	if doc.doctype == "Purchase Receipt":
+		doc.enable_recalculate_rate_in_sles()
 
-	# update stock & gl entries for submit state of PR
-	doc.docstatus = 1
-	doc.update_stock_ledger(allow_negative_stock=True, via_landed_cost_voucher=True)
-	doc.make_gl_entries()
-	doc.repost_future_sle_and_gle()
+	doc.repost_future_sle_and_gle(force=True)
 
 
 def get_item_wise_returned_qty(pr_doc):


### PR DESCRIPTION
**Issue**

Took 256.207 => 4.27 mins to submit the invoice

```
        89494001 function calls (86884825 primitive calls) in 256.207 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    411/1    0.003    0.000  256.210  256.210 {built-in method builtins.exec}
        1    0.000    0.000  256.210  256.210 <string>:1(<module>)
   7237/1    0.020    0.000  256.210  256.210 typing_validations.py:21(wrapper)
   1257/1    0.002    0.000  256.210  256.210 document.py:1045(submit)
   1257/1    0.006    0.000  256.210  256.210 document.py:1028(_submit)
   1257/1    0.003    0.000  256.210  256.210 document.py:335(save)
   1257/1    0.009    0.000  256.210  256.210 document.py:339(_save)
 15888/17    0.106    0.000  253.957   14.939 document.py:950(run_method)
 15888/17    0.115    0.000  253.908   14.936 document.py:1312(composer)
 15888/17    0.088    0.000  253.864   14.933 document.py:1303(runner)
 15888/28    0.031    0.000  253.748    9.062 document.py:953(fn)
   1412/1    0.080    0.000  249.589  249.589 document.py:1119(run_post_save_methods)
        1    0.000    0.000  249.435  249.435 purchase_invoice.py:684(on_submit)
        1    0.012    0.012  248.507  248.507 purchase_invoice.py:1547(update_billing_status_in_pr)
      153    0.004    0.000  245.123    1.602 purchase_receipt.py:1057(update_billing_percentage)
      153    0.005    0.000  236.868    1.548 purchase_receipt.py:1092(adjust_incoming_rate_for_pr)
    36440    0.426    0.000  211.780    0.006 database.py:151(sql)
      306    0.016    0.000  210.006    0.686 buying_controller.py:491(update_stock_ledger)
```

**After fix**

Took 256.207 => 0.41 mins to submit the invoice

```
        34339840 function calls (33433949 primitive calls) in 24.998 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    405/1    0.002    0.000   24.999   24.999 {built-in method builtins.exec}
        1    0.000    0.000   24.999   24.999 <string>:1(<module>)
   1906/1    0.005    0.000   24.999   24.999 typing_validations.py:21(wrapper)
    221/1    0.000    0.000   24.999   24.999 document.py:1045(submit)
    221/1    0.001    0.000   24.999   24.999 document.py:1028(_submit)
    221/1    0.001    0.000   24.999   24.999 document.py:335(save)
    221/1    0.001    0.000   24.999   24.999 document.py:339(_save)
  4527/17    0.028    0.000   22.864    1.345 document.py:950(run_method)
  4527/17    0.030    0.000   22.812    1.342 document.py:1312(composer)
  4527/17    0.022    0.000   22.769    1.339 document.py:1303(runner)
  4527/28    0.007    0.000   22.648    0.809 document.py:953(fn)
    376/1    0.009    0.000   18.927   18.927 document.py:1119(run_post_save_methods)
        1    0.000    0.000   18.775   18.775 purchase_invoice.py:684(on_submit)
        1    0.010    0.010   17.883   17.883 purchase_invoice.py:1547(update_billing_status_in_pr)
      153    0.004    0.000   14.773    0.097 purchase_receipt.py:1066(update_billing_percentage)
    11328    0.121    0.000   10.701    0.001 database.py:151(sql)
    11328    0.022    0.000   10.033    0.001 cursors.py:133(execute)
    11328    0.026    0.000    9.728    0.001 cursors.py:319(_query)
    11328    0.033    0.000    9.665    0.001 connections.py:552(query)
     5470    0.025    0.000    9.572    0.002 database.py:550(get_values)
    11328    0.035    0.000    9.331    0.001 connections.py:810(_read_query_result)
    11328    0.033    0.000    9.280    0.001 connections.py:1198(read)
     3618    0.018    0.000    9.165    0.003 database.py:863(_get_values_from_table)
     5635    0.036    0.000    8.100    0.001 utils.py:84(execute_query)
      376    0.003    0.000    7.902    0.021 document.py:1071(run_before_save_methods)
   188905    0.529    0.000    7.546    0.000 connections.py:730(_read_packet)
      375    0.015    0.000    7.451    0.020 document.py:243(insert)
      153    0.002    0.000    7.299    0.048 purchase_receipt.py:1101(adjust_incoming_rate_for_pr)
     1170    0.005    0.000    7.208    0.006 __init__.py:1315(get_doc)
     1170    0.007    0.000    7.177    0.006 document.py:36(get_doc)
2748/1019    0.012    0.000    7.076    0.007 document.py:102(__init__)
      473    0.020    0.000    7.036    0.015 document.py:147(load_from_db)
      153    0.003    0.000    6.304    0.041 stock_controller.py:1123(repost_future_sle_and_gle)
      312    0.002    0.000    6.162    0.020 subcontracting_controller.py:23(__init__)
      312    0.001    0.000    6.159    0.020 accounts_controller.py:98(__init__)
     3748    0.010    0.000    6.101    0.002 __init__.py:2035(get_all)
     3749    0.027    0.000    6.095    0.002 __init__.py:2012(get_list)
```