### PR TITLE
fix: minor Dr and Cr between Purchase Receipt and Purchase Invoice

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -1147,7 +1147,7 @@ class PurchaseInvoice(BuyingController):
 		pr_items = frappe.get_all(
 			"Purchase Receipt Item",
 			filters={"parent": ("in", linked_purchase_receipts)},
-			fields=["name", "provisional_expense_account", "qty", "base_rate"],
+			fields=["name", "provisional_expense_account", "qty", "base_rate", "rate"],
 		)
 		default_provisional_account = self.get_company_default("default_provisional_account")
 		provisional_accounts = set(
@@ -1175,6 +1175,7 @@ class PurchaseInvoice(BuyingController):
 				"provisional_account": item.provisional_expense_account or default_provisional_account,
 				"qty": item.qty,
 				"base_rate": item.base_rate,
+				"rate": item.rate,
 				"has_provisional_entry": item.name in rows_with_provisional_entries,
 			}
 
@@ -1191,7 +1192,10 @@ class PurchaseInvoice(BuyingController):
 					self.posting_date,
 					pr_item.get("provisional_account"),
 					reverse=1,
-					item_amount=(min(item.qty, pr_item.get("qty")) * pr_item.get("base_rate")),
+					item_amount=(
+						(min(item.qty, pr_item.get("qty")) * pr_item.get("rate"))
+						* purchase_receipt_doc.get("conversion_rate")
+					),
 				)
 
 	def update_gross_purchase_amount_for_linked_assets(self, item):


### PR DESCRIPTION
With `Provisional Accounting for Non-Stock Items` enabled, with high precision exchange rates and large qty in Purchase Receipt and Purchase Invoice, there will be minor debit and credit differences between them.

Ex:
For an exchange rate of 0.014783000, Purchase Receipt of 1000 qty with rate 111.11 and then a Purchase Invoice for it will post below ledger entries. There is a slight difference in Dr and Cr - `0.461`. This difference is more pronounced in higher precision exchange rates and large quantities of items.

This is due to the different ways the Dr/Cr amounts are calculated. The Provisional ledger entries created by Purchase Invoice use the individual items' `base_rate` and `qty`, while the Purchase Receipt first calculates the total in transaction currency and then converts to base currency.

# Without fix:

|Account|Voucher Type| Voucher No| Debit| Credit||
|-|-|-|-|-|-|
|Cost of Goods Sold - DSE|Purchase Receipt|PR-24-00002-3|0|1643|created by Purchase Invoice|
|Stock Received But Not Billed - DSE|Purchase Receipt|PR-24-00002-3|1643|0| created by Purchase Invoice|
|Cost of Goods Sold - DSE|Purchase Receipt|PR-24-00002-3|1642.539|0|
|Stock Received But Not Billed - DSE|Purchase Receipt|PR-24-00002-3|0|1642.539|



# With fix:

|Account|Voucher Type| Voucher No| Debit| Credit||
|-|-|-|-|-|-|
|Cost of Goods Sold - DSE|Purchase Receipt|PR-24-00002-3|0|1642.539|created by Purchase Invoice|
|Stock Received But Not Billed - DSE|Purchase Receipt|PR-24-00002-3|1642.539|0|created by Purchase Invoice|
|Cost of Goods Sold - DSE|Purchase Receipt|PR-24-00002-3|1642.539|0|
|Stock Received But Not Billed - DSE|Purchase Receipt|PR-24-00002-3|0|1642.539|