### PR TITLE
refactor: ignore internal doctypes on Dunning cancellation

### DIFF
--- a/erpnext/accounts/doctype/dunning/dunning.py
+++ b/erpnext/accounts/doctype/dunning/dunning.py
@@ -148,7 +148,19 @@ class Dunning(AccountsController):
 
 	def on_cancel(self):
 		super().on_cancel()
-		self.ignore_linked_doctypes = ["GL Entry"]
+		self.ignore_linked_doctypes = [
+			"GL Entry",
+			"Stock Ledger Entry",
+			"Repost Item Valuation",
+			"Repost Payment Ledger",
+			"Repost Payment Ledger Items",
+			"Repost Accounting Ledger",
+			"Repost Accounting Ledger Items",
+			"Unreconcile Payment",
+			"Unreconcile Payment Entries",
+			"Payment Ledger Entry",
+			"Serial and Batch Bundle",
+		]
 
 
 def resolve_dunning(doc, state):


### PR DESCRIPTION
continues: https://github.com/frappe/erpnext/pull/40973