### PR TITLE
fix: job card time logs overlap issue

### DIFF
--- a/erpnext/manufacturing/doctype/job_card_time_log/job_card_time_log.json
+++ b/erpnext/manufacturing/doctype/job_card_time_log/job_card_time_log.json
@@ -42,8 +42,7 @@
    "fieldname": "completed_qty",
    "fieldtype": "Float",
    "in_list_view": 1,
-   "label": "Completed Qty",
-   "reqd": 1
+   "label": "Completed Qty"
   },
   {
    "fieldname": "employee",
@@ -64,7 +63,7 @@
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:09:57.448800",
+ "modified": "2024-05-21 12:40:55.765860",
  "modified_by": "Administrator",
  "module": "Manufacturing",
  "name": "Job Card Time Log",


### PR DESCRIPTION
1. Keep job capacity as 2 in the Workstation A
2. Create a Job Card for employee A with Workstation A with from time 10:00:00 and to time 10:30:00
3. Create another Job Card for employee B with Workstation A with from time 10:00:00 and to time 10:30:00 
4. But the employee B trying to save the job card, system throwing the overlap error

<img width="676" alt="image" src="https://github.com/frappe/erpnext/assets/8780500/fdfc9778-b58d-4bbd-9cc5-b9ea6a743a2d">
