### PR TITLE
fix: correct report name in inner button

### DIFF
--- a/erpnext/accounts/doctype/account/account_tree.js
+++ b/erpnext/accounts/doctype/account/account_tree.js
@@ -222,7 +222,7 @@ frappe.treeview_settings["Account"] = {
 			"General Ledger",
 			"Balance Sheet",
 			"Profit and Loss Statement",
-			"Cash Flow Statement",
+			"Cash Flow",
 			"Accounts Payable",
 			"Accounts Receivable",
 		]) {


### PR DESCRIPTION
Previously, the report name was incorrectly listed as "Cash Flow Statement" instead of "Cash Flow". This mismatch caused the "Cash Flow" report to not open correctly in the chart of accounts tree view, as the report ID is "Cash Flow".


![Screenshot from 2024-05-21 14-14-24](https://github.com/frappe/erpnext/assets/44110258/157093eb-e4f5-4f9a-9627-d6dda47a63e2)

![Screenshot from 2024-05-21 14-15-26](https://github.com/frappe/erpnext/assets/44110258/86e2c043-eba9-491e-a595-a89a58ae297b)
