### PR TITLE
feat: Add supplier invoice date in the payment entry reference

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.js
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.js
@@ -949,6 +949,7 @@ frappe.ui.form.on("Payment Entry", {
 						c.total_amount = d.invoice_amount;
 						c.outstanding_amount = d.outstanding_amount;
 						c.bill_no = d.bill_no;
+						c.bill_date = d.bill_date;
 						c.payment_term = d.payment_term;
 						c.allocated_amount = d.allocated_amount;
 						c.account = d.account;

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -1830,6 +1830,7 @@ def get_outstanding_reference_documents(args, validate=False):
 					)
 			if d.voucher_type in ("Purchase Invoice"):
 				d["bill_no"] = frappe.db.get_value(d.voucher_type, d.voucher_no, "bill_no")
+				d["bill_date"] = frappe.db.get_value(d.voucher_type, d.voucher_no, "bill_date")
 
 		# Get negative outstanding sales /purchase invoices
 		if args.get("party_type") != "Employee" and not args.get("voucher_no"):

--- a/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
@@ -1087,7 +1087,6 @@ class TestPaymentEntry(FrappeTestCase):
 			"exchange_rate": 1.0,
 			"due_date": None,
 			"bill_no": None,
-			"bill_date": None,
 		}
 		self.assertDictEqual(ref_details, expected_response)
 

--- a/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
@@ -1087,6 +1087,7 @@ class TestPaymentEntry(FrappeTestCase):
 			"exchange_rate": 1.0,
 			"due_date": None,
 			"bill_no": None,
+			"bill_date": None,
 		}
 		self.assertDictEqual(ref_details, expected_response)
 

--- a/erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json
+++ b/erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.json
@@ -9,6 +9,7 @@
   "reference_name",
   "due_date",
   "bill_no",
+  "bill_date",
   "payment_term",
   "account_type",
   "payment_type",
@@ -120,12 +121,18 @@
    "fieldname": "payment_type",
    "fieldtype": "Data",
    "label": "Payment Type"
+  },
+  {
+   "fieldname": "bill_date",
+   "fieldtype": "Date",
+   "label": "Supplier Invoice Date",
+   "read_only": 1
   }
  ],
  "index_web_pages_for_search": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-04-05 09:44:08.310593",
+ "modified": "2024-05-22 16:41:44.594416",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Entry Reference",

--- a/erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.py
+++ b/erpnext/accounts/doctype/payment_entry_reference/payment_entry_reference.py
@@ -18,6 +18,7 @@ class PaymentEntryReference(Document):
 		account_type: DF.Data | None
 		allocated_amount: DF.Float
 		bill_no: DF.Data | None
+		bill_date: DF.Date | None
 		due_date: DF.Date | None
 		exchange_gain_loss: DF.Currency
 		exchange_rate: DF.Float


### PR DESCRIPTION
fixes: #41582

Adding the Supplier Invoice Date field to the payment entry process in ERPNext would make it easier for users to see when they received invoices from suppliers. This helps them adjust payments accurately based on the dates of those invoices. It's like having a reminder of when each bill came in, so they can make sure their records match up correctly.

![image](https://github.com/frappe/erpnext/assets/141945075/bf21ec21-1033-4753-b9e2-365a677176fc)


![image](https://github.com/frappe/erpnext/assets/141945075/27e6c5f5-2f6e-4f38-b0c3-ebc3ec570ed5)

> no-docs