### PR TITLE
perf: sales order UI render

### DIFF
--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -83,7 +83,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 			this.frm.doc.paid_amount = flt(this.frm.doc.grand_total, precision("grand_total"));
 		}
 
-		this.frm.refresh_fields();
+		this.frm.refresh_field("taxes");
 	}
 
 	calculate_discount_amount() {
@@ -853,7 +853,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 			});
 		}
 
-		this.frm.refresh_fields();
+		this.frm.refresh_field("taxes");
 	}
 
 	set_default_payment(total_amount_to_pay, update_paid_amount) {


### PR DESCRIPTION
The refresh_fields method slows down the entry, especially when making a sales order with more than 100 line items.
<img width="1356" alt="Screenshot 2024-05-22 at 7 24 21 PM" src="https://github.com/frappe/erpnext/assets/8780500/05825cb4-0f2d-4a24-95dc-51850be651e2">
