### PR TITLE
fix: dict can not be used as parameter

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -1196,7 +1196,11 @@ def get_previous_sle_of_current_voucher(args, operator="<", exclude_current_vouc
 		order by posting_datetime desc, creation desc
 		limit 1
 		for update""",
-		args,
+		{
+			"item_code": args.get("item_code"),
+			"warehouse": args.get("warehouse"),
+			"posting_datetime": args.get("posting_datetime"),
+		},
 		as_dict=1,
 	)
 


### PR DESCRIPTION
```
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/stock/stock_ledger.py", line 385, in initialize_previous_data
    previous_sle = get_previous_sle_of_current_voucher(args)
    args = {'item_code': '368b3b4b529f55f5', 'warehouse': '_Test Warehouse - _TC', 'posting_date': datetime.date(2022, 3, 1), 'posting_time': datetime.timedelta(seconds=13259, microseconds=567591), 'creation': None, 'distinct_item_warehouses': {('368b3b4b529f55f5', '_Test Warehouse - _TC'): {'reposting_status': False, 'sle': {'item_code': '368b3b4b529f55f5', 'warehouse': '_Test Warehouse - _TC', 'posting_date': datetime.date(2022, 3, 1), 'posting_time': datetime.timedelta(seconds=13259, microseconds=567591)}, 'args_idx': 0}}, 'posting_datetime': datetime.datetime(2022, 3, 1, 3, 40, 59)}
    self = <erpnext.stock.stock_ledger.update_entries_after object at 0x7f160340cd00>
    warehouse_dict = {}
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/stock/stock_ledger.py", line 1185, in get_previous_sle_of_current_voucher
    sle = frappe.db.sql(
    args = {'item_code': '368b3b4b529f55f5', 'warehouse': '_Test Warehouse - _TC', 'posting_date': datetime.date(2022, 3, 1), 'posting_time': datetime.timedelta(seconds=13259, microseconds=567591), 'creation': None, 'distinct_item_warehouses': {('368b3b4b529f55f5', '_Test Warehouse - _TC'): {'reposting_status': False, 'sle': {'item_code': '368b3b4b529f55f5', 'warehouse': '_Test Warehouse - _TC', 'posting_date': datetime.date(2022, 3, 1), 'posting_time': datetime.timedelta(seconds=13259, microseconds=567591)}, 'args_idx': 0}}, 'posting_datetime': datetime.datetime(2022, 3, 1, 3, 40, 59)}
  
TypeError: dict can not be used as parameter
```

{key: {key: value}} (distinct_item_warehouses) causing the issue