### PR TITLE
fix: add in some indices to speed up Purchase Order deletion

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
+++ b/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
@@ -870,7 +870,8 @@
    "label": "Purchase Order",
    "options": "Purchase Order",
    "print_hide": 1,
-   "read_only": 1
+   "read_only": 1,
+   "search_index": 1
   },
   {
    "fieldname": "column_break_92",
@@ -926,7 +927,7 @@
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:36.139679",
+ "modified": "2024-05-23 16:36:18.970862",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice Item",

--- a/erpnext/selling/doctype/sales_order/sales_order.json
+++ b/erpnext/selling/doctype/sales_order/sales_order.json
@@ -1140,7 +1140,8 @@
    "hide_seconds": 1,
    "label": "Inter Company Order Reference",
    "options": "Purchase Order",
-   "read_only": 1
+   "read_only": 1,
+   "search_index": 1
   },
   {
    "fieldname": "project",
@@ -1658,7 +1659,7 @@
  "idx": 105,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-03-29 16:27:41.539613",
+ "modified": "2024-05-23 16:35:54.905804",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order",


### PR DESCRIPTION
Reference: https://support.frappe.io/helpdesk/tickets/11452

`tabSales Order`.`inter_company_order_reference` 81 seconds, 1089800 rows examined 
`tabSales Invoice Item`.`purchase_order` 472 seconds, 7521793 rows examined
