### PR TITLE
refactor: remove 'format:' based naming in internal doctypes

### DIFF
--- a/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.json
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.json
@@ -1,7 +1,5 @@
 {
  "actions": [],
- "allow_rename": 1,
- "autoname": "format:ACC-REPOST-{#####}",
  "creation": "2023-07-04 13:07:32.923675",
  "default_view": "List",
  "doctype": "DocType",
@@ -55,11 +53,10 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:32.013542",
+ "modified": "2024-05-23 17:00:42.984798",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Repost Accounting Ledger",
- "naming_rule": "Expression",
  "owner": "Administrator",
  "permissions": [
   {

--- a/erpnext/accounts/doctype/repost_payment_ledger/repost_payment_ledger.json
+++ b/erpnext/accounts/doctype/repost_payment_ledger/repost_payment_ledger.json
@@ -1,6 +1,5 @@
 {
  "actions": [],
- "allow_rename": 1,
  "creation": "2022-10-19 21:59:33.553852",
  "doctype": "DocType",
  "editable_grid": 1,
@@ -99,7 +98,7 @@
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:32.740806",
+ "modified": "2024-05-23 17:00:31.540640",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Repost Payment Ledger",


### PR DESCRIPTION
`format:` based naming is prone to error. 