### PR TITLE
refactor: use `json` directly instead of using `frappe.json`

### DIFF
--- a/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
+++ b/erpnext/accounts/doctype/pos_invoice_merge_log/pos_invoice_merge_log.py
@@ -481,7 +481,7 @@ def create_merge_logs(invoice_by_customer, closing_entry=None):
 		if closing_entry:
 			closing_entry.set_status(update=True, status="Failed")
 			if isinstance(error_message, list):
-				error_message = frappe.json.dumps(error_message)
+				error_message = json.dumps(error_message)
 			closing_entry.db_set("error_message", error_message)
 		raise
 

--- a/erpnext/accounts/doctype/process_payment_reconciliation/process_payment_reconciliation.py
+++ b/erpnext/accounts/doctype/process_payment_reconciliation/process_payment_reconciliation.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
+import json
+
 import frappe
 from frappe import _, qb
 from frappe.model.document import Document
@@ -502,7 +504,7 @@ def is_any_doc_running(for_filter: str | dict | None = None) -> str | None:
 	running_doc = None
 	if for_filter:
 		if isinstance(for_filter, str):
-			for_filter = frappe.json.loads(for_filter)
+			for_filter = json.loads(for_filter)
 
 		running_doc = frappe.db.get_value(
 			"Process Payment Reconciliation",

--- a/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/test_sales_invoice.py
@@ -2,6 +2,7 @@
 # License: GNU General Public License v3. See license.txt
 
 import copy
+import json
 
 import frappe
 from frappe.model.dynamic_links import get_dynamic_link_map
@@ -3733,9 +3734,9 @@ class TestSalesInvoice(FrappeTestCase):
 
 		map_docs(
 			method="erpnext.stock.doctype.delivery_note.delivery_note.make_sales_invoice",
-			source_names=frappe.json.dumps([dn1.name, dn2.name]),
+			source_names=json.dumps([dn1.name, dn2.name]),
 			target_doc=si,
-			args=frappe.json.dumps({"customer": dn1.customer, "merge_taxes": 1, "filtered_children": []}),
+			args=json.dumps({"customer": dn1.customer, "merge_taxes": 1, "filtered_children": []}),
 		)
 		si.save().submit()
 

--- a/erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.py
+++ b/erpnext/accounts/doctype/unreconcile_payment/unreconcile_payment.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2023, Frappe Technologies Pvt. Ltd. and contributors
 # For license information, please see license.txt
 
+import json
+
 import frappe
 from frappe import _, qb
 from frappe.model.document import Document
@@ -163,7 +165,7 @@ def get_linked_payments_for_doc(
 @frappe.whitelist()
 def create_unreconcile_doc_for_selection(selections=None):
 	if selections:
-		selections = frappe.json.loads(selections)
+		selections = json.loads(selections)
 		# assuming each row is a unique voucher
 		for row in selections:
 			unrecon = frappe.new_doc("Unreconcile Payment")

--- a/erpnext/accounts/utils.py
+++ b/erpnext/accounts/utils.py
@@ -56,7 +56,7 @@ def get_fiscal_year(
 	date=None, fiscal_year=None, label="Date", verbose=1, company=None, as_dict=False, boolean=False
 ):
 	if isinstance(boolean, str):
-		boolean = frappe.json.loads(boolean)
+		boolean = loads(boolean)
 
 	fiscal_years = get_fiscal_years(
 		date, fiscal_year, label, verbose, company, as_dict=as_dict, boolean=boolean
@@ -1109,7 +1109,7 @@ def get_companies():
 @frappe.whitelist()
 def get_children(doctype, parent, company, is_root=False, include_disabled=False):
 	if isinstance(include_disabled, str):
-		include_disabled = frappe.json.loads(include_disabled)
+		include_disabled = loads(include_disabled)
 	from erpnext.accounts.report.financial_statements import sort_accounts
 
 	parent_fieldname = "parent_" + doctype.lower().replace(" ", "_")

--- a/erpnext/selling/doctype/customer/test_customer.py
+++ b/erpnext/selling/doctype/customer/test_customer.py
@@ -2,6 +2,8 @@
 # License: GNU General Public License v3. See license.txt
 
 
+import json
+
 import frappe
 from frappe.test_runner import make_test_records
 from frappe.tests.utils import FrappeTestCase
@@ -321,7 +323,7 @@ class TestCustomer(FrappeTestCase):
 			frappe.ValidationError,
 			update_child_qty_rate,
 			so.doctype,
-			frappe.json.dumps([modified_item]),
+			json.dumps([modified_item]),
 			so.name,
 		)
 

--- a/erpnext/setup/doctype/department/department.py
+++ b/erpnext/setup/doctype/department/department.py
@@ -2,6 +2,8 @@
 # License: GNU General Public License v3. See license.txt
 
 
+import json
+
 import frappe
 from frappe.utils.nestedset import NestedSet, get_root_of
 
@@ -71,7 +73,7 @@ def get_abbreviated_name(name, company):
 @frappe.whitelist()
 def get_children(doctype, parent=None, company=None, is_root=False, include_disabled=False):
 	if isinstance(include_disabled, str):
-		include_disabled = frappe.json.loads(include_disabled)
+		include_disabled = json.loads(include_disabled)
 	fields = ["name as value", "is_group as expandable"]
 	filters = {}
 

--- a/erpnext/stock/doctype/warehouse/warehouse.py
+++ b/erpnext/stock/doctype/warehouse/warehouse.py
@@ -2,6 +2,8 @@
 # License: GNU General Public License v3. See license.txt
 
 
+import json
+
 import frappe
 from frappe import _, throw
 from frappe.contacts.address_and_contact import load_address_and_contact
@@ -186,7 +188,7 @@ def get_children(doctype, parent=None, company=None, is_root=False, include_disa
 		parent = ""
 
 	if isinstance(include_disabled, str):
-		include_disabled = frappe.json.loads(include_disabled)
+		include_disabled = json.loads(include_disabled)
 
 	fields = ["name as value", "is_group as expandable"]
 	filters = [


### PR DESCRIPTION
No reason to not use it directly
