### PR TITLE
fix: add item name to BOM Creator tree

### DIFF
--- a/erpnext/manufacturing/doctype/bom_creator/bom_creator.py
+++ b/erpnext/manufacturing/doctype/bom_creator/bom_creator.py
@@ -343,6 +343,7 @@ def get_children(doctype=None, parent=None, **kwargs):
 
 	fields = [
 		"item_code as value",
+		"item_name as title",
 		"is_expandable as expandable",
 		"parent as parent_id",
 		"qty",


### PR DESCRIPTION
Fixes https://github.com/frappe/erpnext/issues/40573

Before:
![Screen Shot 2024-05-23 at 20 10 47](https://github.com/frappe/erpnext/assets/110036763/e2b0e2c2-1d34-4dee-a72d-087901ac05d0)


After:
![Screen Shot 2024-05-23 at 20 11 07](https://github.com/frappe/erpnext/assets/110036763/2005b8e0-2f88-4a9a-9e7c-7beceb56db42)


version-15-hotfix
