### PR TITLE
Update asset_maintenance_log_list.js

### DIFF
--- a/erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log_list.js
+++ b/erpnext/assets/doctype/asset_maintenance_log/asset_maintenance_log_list.js
@@ -3,13 +3,13 @@ frappe.listview_settings["Asset Maintenance Log"] = {
 	has_indicator_for_draft: 1,
 	get_indicator: function (doc) {
 		if (doc.maintenance_status == "Planned") {
-			return [__(doc.maintenance_status), "orange", "status,=," + doc.maintenance_status];
+			return [__(doc.maintenance_status), "orange", "maintenance_status,=," + doc.maintenance_status];
 		} else if (doc.maintenance_status == "Completed") {
-			return [__(doc.maintenance_status), "green", "status,=," + doc.maintenance_status];
+			return [__(doc.maintenance_status), "green", "maintenance_status,=," + doc.maintenance_status];
 		} else if (doc.maintenance_status == "Cancelled") {
-			return [__(doc.maintenance_status), "red", "status,=," + doc.maintenance_status];
+			return [__(doc.maintenance_status), "red", "maintenance_status,=," + doc.maintenance_status];
 		} else if (doc.maintenance_status == "Overdue") {
-			return [__(doc.maintenance_status), "red", "status,=," + doc.maintenance_status];
+			return [__(doc.maintenance_status), "red", "maintenance_status,=," + doc.maintenance_status];
 		}
 	},
 };


### PR DESCRIPTION
The Asset Maintenance Log Filter name was wrong.so it raise the server on listview - "Invalid filter: status" and report view - "Field not permitted in query: tabAsset Maintenance Log.status"
![Screenshot from 2024-05-24 15-15-49](https://github.com/frappe/erpnext/assets/48587404/0205ffb4-d0a4-4959-bfd9-f7f00439e252)

