### PR TITLE
fix:Tasks with duration less than a day not displayed correctly#15554

### DIFF
--- a/erpnext/projects/doctype/task/task.js
+++ b/erpnext/projects/doctype/task/task.js
@@ -13,7 +13,6 @@ frappe.ui.form.on("Task", {
 				}),
 		};
 	},
-
 	onload: function (frm) {
 		frm.set_query("task", "depends_on", function () {
 			let filters = {

--- a/erpnext/projects/doctype/task/task.json
+++ b/erpnext/projects/doctype/task/task.json
@@ -147,7 +147,7 @@
   },
   {
    "collapsible": 1,
-   "collapsible_depends_on": "eval:doc.__islocal",
+   "collapsible_depends_on": "exp_start_date",
    "fieldname": "sb_timeline",
    "fieldtype": "Section Break",
    "label": "Timeline"
@@ -155,7 +155,7 @@
   {
    "bold": 1,
    "fieldname": "exp_start_date",
-   "fieldtype": "Date",
+   "fieldtype": "Datetime",
    "label": "Expected Start Date",
    "oldfieldname": "exp_start_date",
    "oldfieldtype": "Date"
@@ -181,7 +181,7 @@
   {
    "bold": 1,
    "fieldname": "exp_end_date",
-   "fieldtype": "Date",
+   "fieldtype": "Datetime",
    "label": "Expected End Date",
    "oldfieldname": "exp_end_date",
    "oldfieldtype": "Date",
@@ -399,7 +399,7 @@
  "is_tree": 1,
  "links": [],
  "max_attachments": 5,
- "modified": "2024-03-27 13:10:51.476856",
+ "modified": "2024-05-24 12:36:12.214577",
  "modified_by": "Administrator",
  "module": "Projects",
  "name": "Task",

--- a/erpnext/projects/doctype/task/task.py
+++ b/erpnext/projects/doctype/task/task.py
@@ -8,7 +8,7 @@ import frappe
 from frappe import _, throw
 from frappe.desk.form.assign_to import clear, close_all_assignments
 from frappe.model.mapper import get_mapped_doc
-from frappe.utils import add_days, cstr, date_diff, flt, get_link_to_form, getdate, today
+from frappe.utils import add_days, add_to_date, cstr, date_diff, flt, get_link_to_form, getdate, today
 from frappe.utils.data import format_date
 from frappe.utils.nestedset import NestedSet
 
@@ -41,8 +41,8 @@ class Task(NestedSet):
 		depends_on_tasks: DF.Code | None
 		description: DF.TextEditor | None
 		duration: DF.Int
-		exp_end_date: DF.Date | None
-		exp_start_date: DF.Date | None
+		exp_end_date: DF.Datetime | None
+		exp_start_date: DF.Datetime | None
 		expected_time: DF.Float
 		is_group: DF.Check
 		is_milestone: DF.Check
@@ -83,12 +83,17 @@ class Task(NestedSet):
 		self.update_depends_on()
 		self.validate_dependencies_for_template_task()
 		self.validate_completed_on()
+		self.set_default_end_date_if_missing()
 
 	def validate_dates(self):
 		self.validate_from_to_dates("exp_start_date", "exp_end_date")
 		self.validate_from_to_dates("act_start_date", "act_end_date")
 		self.validate_parent_expected_end_date()
 		self.validate_parent_project_dates()
+
+	def set_default_end_date_if_missing(self):
+		if self.exp_start_date and self.expected_time:
+			self.exp_end_date = add_to_date(self.exp_start_date, hours=self.expected_time)
 
 	def validate_parent_expected_end_date(self):
 		if not self.parent_task or not self.exp_end_date:
@@ -250,7 +255,7 @@ class Task(NestedSet):
 				if (
 					task.exp_start_date
 					and task.exp_end_date
-					and task.exp_start_date < getdate(end_date)
+					and task.exp_start_date < end_date
 					and task.status == "Open"
 				):
 					task_duration = date_diff(task.exp_end_date, task.exp_start_date)
@@ -288,7 +293,7 @@ class Task(NestedSet):
 		if self.status not in ("Cancelled", "Completed") and self.exp_end_date:
 			from datetime import datetime
 
-			if self.exp_end_date < datetime.now().date():
+			if self.exp_end_date < datetime.now():
 				self.db_set("status", "Overdue", update_modified=False)
 				self.update_project()
 

--- a/erpnext/projects/doctype/task/test_task.py
+++ b/erpnext/projects/doctype/task/test_task.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
-
 import unittest
+
 import frappe
 from frappe.utils import add_days, getdate, nowdate
 
@@ -43,17 +43,21 @@ class TestTask(unittest.TestCase):
 		task1.save()
 
 		self.assertEqual(
-			frappe.db.get_value("Task", task2.name, "exp_start_date"), getdate(add_days(nowdate(), 21))
-		)
-		self.assertEqual(
-			frappe.db.get_value("Task", task2.name, "exp_end_date"), getdate(add_days(nowdate(), 25))
+			getdate(frappe.db.get_value("Task", task2.name, "exp_start_date")),
+			getdate(add_days(nowdate(), 21)),
 		)
 
 		self.assertEqual(
-			frappe.db.get_value("Task", task3.name, "exp_start_date"), getdate(add_days(nowdate(), 26))
+			getdate(frappe.db.get_value("Task", task2.name, "exp_end_date")), getdate(add_days(nowdate(), 25))
 		)
+
 		self.assertEqual(
-			frappe.db.get_value("Task", task3.name, "exp_end_date"), getdate(add_days(nowdate(), 30))
+			getdate(frappe.db.get_value("Task", task3.name, "exp_start_date")),
+			getdate(add_days(nowdate(), 26)),
+		)
+
+		self.assertEqual(
+			getdate(frappe.db.get_value("Task", task3.name, "exp_end_date")), getdate(add_days(nowdate(), 30))
 		)
 
 	def test_close_assignment(self):

--- a/erpnext/projects/doctype/task/test_task.py
+++ b/erpnext/projects/doctype/task/test_task.py
@@ -2,7 +2,6 @@
 # License: GNU General Public License v3. See license.txt
 
 import unittest
-
 import frappe
 from frappe.utils import add_days, getdate, nowdate
 


### PR DESCRIPTION
There were 2 parts related to the same issue:
1. The tasks cannot be opened directly from the gantt chart when the Expected End Date is not set.
Before:
![image](https://github.com/frappe/erpnext/assets/27720465/9e21b52e-18b7-4f37-90b7-3d4c2b508734)




After:
Able to open the task from the gantt view
![image](https://github.com/frappe/erpnext/assets/27720465/b463f62d-79ad-4c4e-9649-efc972c8d430)




2. Task in the Gantt view was displaying 3 days though the Expected Time set is 2 hours.
Before:
![image](https://github.com/frappe/erpnext/assets/27720465/f9fa5ef0-c8f5-48c9-8900-4f130e7a2ae7)
![image](https://github.com/frappe/erpnext/assets/27720465/eb613f6b-fd01-4092-a322-cc3e022f5f1f)

After: 
Expected Start Date and Expected End Date are now Datetime fields  and showing the task expected time properly in the gantt view on selecting the Quarter day and all the other tabs.
![image](https://github.com/frappe/erpnext/assets/27720465/d7d832c1-02f9-400e-bedc-38ff20a86f33)
![image](https://github.com/frappe/erpnext/assets/27720465/951ae3ab-8bd9-4996-b655-d40696b5ebff)



