### PR TITLE
feat: selectable multiple pricing rules in transactions

### DIFF
--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.json
@@ -43,6 +43,8 @@
   "section_break_jpd0",
   "auto_reconcile_payments",
   "stale_days",
+  "section_break_tjhu",
+  "max_pricing_rules_per_item",
   "invoicing_settings_tab",
   "accounts_transactions_settings_section",
   "over_billing_allowance",
@@ -462,6 +464,18 @@
    "fieldname": "enable_immutable_ledger",
    "fieldtype": "Check",
    "label": "Enable Immutable Ledger"
+  },
+  {
+   "fieldname": "section_break_tjhu",
+   "fieldtype": "Section Break",
+   "label": "Pricing Rules"
+  },
+  {
+   "default": "1",
+   "description": "Maximum number of pricing rules applicable for a line item in a transaction",
+   "fieldname": "max_pricing_rules_per_item",
+   "fieldtype": "Int",
+   "label": "Maximum Pricing Rules per Item"
   }
  ],
  "icon": "icon-cog",
@@ -469,7 +483,7 @@
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-05-11 23:19:44.673975",
+ "modified": "2024-05-25 15:24:16.639610",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Accounts Settings",

--- a/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
+++ b/erpnext/accounts/doctype/accounts_settings/accounts_settings.py
@@ -45,6 +45,7 @@ class AccountsSettings(Document):
 		general_ledger_remarks_length: DF.Int
 		ignore_account_closing_balance: DF.Check
 		make_payment_via_journal_entry: DF.Check
+		max_pricing_rules_per_item: DF.Int
 		merge_similar_account_heads: DF.Check
 		over_billing_allowance: DF.Currency
 		post_change_gl_entries: DF.Check

--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -612,6 +612,7 @@ def remove_pricing_rule_for_item(pricing_rules, item_details, item_code=None, ra
 		item_details = json.loads(item_details)
 		item_details = frappe._dict(item_details)
 
+	item_details.remove_free_item = []
 	for d in get_applied_pricing_rules(pricing_rules):
 		if not d or not frappe.db.exists("Pricing Rule", d):
 			continue
@@ -629,8 +630,8 @@ def remove_pricing_rule_for_item(pricing_rules, item_details, item_code=None, ra
 			if pricing_rule.margin_type in ["Percentage", "Amount"]:
 				item_details.margin_rate_or_amount = 0.0
 				item_details.margin_type = None
-		elif pricing_rule.get("free_item"):
-			item_details.remove_free_item = (
+		elif pricing_rule.get("same_item") or pricing_rule.get("free_item"):
+			item_details.remove_free_item.append(
 				item_code if pricing_rule.get("same_item") else pricing_rule.get("free_item")
 			)
 

--- a/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
@@ -93,10 +93,10 @@ class TestPricingRule(unittest.TestCase):
 		details = get_item_details(args)
 		self.assertEqual(details.get("discount_percentage"), 5)
 
-		frappe.db.sql("update `tabPricing Rule` set priority=NULL where campaign='_Test Campaign'")
-		from erpnext.accounts.doctype.pricing_rule.utils import MultiplePricingRuleConflict
+		# frappe.db.sql("update `tabPricing Rule` set priority=NULL where campaign='_Test Campaign'")
+		# from erpnext.accounts.doctype.pricing_rule.utils import MultiplePricingRuleConflict
 
-		self.assertRaises(MultiplePricingRuleConflict, get_item_details, args)
+		# self.assertRaises(MultiplePricingRuleConflict, get_item_details, args)
 
 		args.item_code = "_Test Item 2"
 		details = get_item_details(args)

--- a/erpnext/accounts/doctype/pricing_rule/utils.py
+++ b/erpnext/accounts/doctype/pricing_rule/utils.py
@@ -348,8 +348,7 @@ def filter_pricing_rules(args, pricing_rules, doc=None):
 	# 			MultiplePricingRuleConflict,
 	# 		)
 
-	if pricing_rules:
-		return pricing_rules
+	return pricing_rules or []
 
 
 def validate_quantity_and_amount_for_suggestion(args, qty, amount, item_code, transaction_type):

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.json
@@ -99,6 +99,7 @@
   "sec_tax_breakup",
   "other_charges_calculation",
   "pricing_rule_details",
+  "select_pricing_rule",
   "pricing_rules",
   "packing_list",
   "packed_items",
@@ -2191,6 +2192,12 @@
    "label": "Update Outstanding for Self",
    "no_copy": 1,
    "print_hide": 1
+  },
+  {
+   "fieldname": "select_pricing_rule",
+   "fieldtype": "Button",
+   "hidden": 1,
+   "label": "Select Pricing Rule"
   }
  ],
  "icon": "fa fa-file-text",
@@ -2203,7 +2210,7 @@
    "link_fieldname": "consolidated_invoice"
   }
  ],
- "modified": "2024-05-08 18:02:28.549041",
+ "modified": "2024-05-25 21:50:24.014492",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice",

--- a/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
+++ b/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
@@ -42,11 +42,12 @@
   "rate",
   "amount",
   "item_tax_template",
+  "pricing_rules",
   "col_break3",
   "base_rate",
   "base_amount",
-  "pricing_rules",
   "stock_uom_rate",
+  "select_pricing_rule",
   "is_free_item",
   "grant_commission",
   "section_break_21",
@@ -922,12 +923,18 @@
   {
    "fieldname": "column_break_ytgd",
    "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "select_pricing_rule",
+   "fieldtype": "Button",
+   "hidden": 1,
+   "label": "Select Pricing Rule"
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-05-23 16:36:18.970862",
+ "modified": "2024-05-25 15:59:23.259961",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice Item",

--- a/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
+++ b/erpnext/accounts/doctype/sales_invoice_item/sales_invoice_item.json
@@ -47,7 +47,6 @@
   "base_rate",
   "base_amount",
   "stock_uom_rate",
-  "select_pricing_rule",
   "is_free_item",
   "grant_commission",
   "section_break_21",
@@ -923,18 +922,12 @@
   {
    "fieldname": "column_break_ytgd",
    "fieldtype": "Column Break"
-  },
-  {
-   "fieldname": "select_pricing_rule",
-   "fieldtype": "Button",
-   "hidden": 1,
-   "label": "Select Pricing Rule"
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-05-25 15:59:23.259961",
+ "modified": "2024-05-25 21:50:54.955044",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Sales Invoice Item",

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -892,7 +892,7 @@ class AccountsController(TransactionBase):
 				frappe.throw(
 					_(
 						"Multiple Price Rules exists with same criteria, please resolve conflict by assigning priority or selecting it manually in item. Price Rules: {0}"
-					).format("\n".join(d.name for d in pricing_rules)),
+					).format("\n".join(d for d in pricing_rules)),
 					MultiplePricingRuleConflict,
 				)
 

--- a/erpnext/selling/doctype/sales_order/sales_order.json
+++ b/erpnext/selling/doctype/sales_order/sales_order.json
@@ -92,6 +92,7 @@
   "packing_list",
   "packed_items",
   "pricing_rule_details",
+  "select_pricing_rule",
   "pricing_rules",
   "contact_info",
   "billing_address_column",
@@ -1653,13 +1654,19 @@
    "no_copy": 1,
    "options": "Not Requested\nRequested\nPartially Paid\nFully Paid",
    "print_hide": 1
+  },
+  {
+   "fieldname": "select_pricing_rule",
+   "fieldtype": "Button",
+   "hidden": 1,
+   "label": "Select Pricing Rule"
   }
  ],
  "icon": "fa fa-file-text",
  "idx": 105,
  "is_submittable": 1,
  "links": [],
- "modified": "2024-05-23 16:35:54.905804",
+ "modified": "2024-05-25 21:40:26.740864",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order",

--- a/erpnext/selling/doctype/sales_order_item/sales_order_item.json
+++ b/erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -45,11 +45,12 @@
   "rate",
   "amount",
   "item_tax_template",
+  "pricing_rules",
   "col_break3",
   "base_rate",
   "base_amount",
-  "pricing_rules",
   "stock_uom_rate",
+  "select_pricing_rule",
   "is_free_item",
   "grant_commission",
   "section_break_24",
@@ -905,12 +906,18 @@
    "label": "Is Stock Item",
    "print_hide": 1,
    "report_hide": 1
+  },
+  {
+   "fieldname": "select_pricing_rule",
+   "fieldtype": "Button",
+   "hidden": 1,
+   "label": "Select Pricing Rule"
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-03-27 13:10:37.177978",
+ "modified": "2024-05-25 15:54:45.924716",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order Item",

--- a/erpnext/selling/doctype/sales_order_item/sales_order_item.json
+++ b/erpnext/selling/doctype/sales_order_item/sales_order_item.json
@@ -50,7 +50,6 @@
   "base_rate",
   "base_amount",
   "stock_uom_rate",
-  "select_pricing_rule",
   "is_free_item",
   "grant_commission",
   "section_break_24",
@@ -906,18 +905,12 @@
    "label": "Is Stock Item",
    "print_hide": 1,
    "report_hide": 1
-  },
-  {
-   "fieldname": "select_pricing_rule",
-   "fieldtype": "Button",
-   "hidden": 1,
-   "label": "Select Pricing Rule"
   }
  ],
  "idx": 1,
  "istable": 1,
  "links": [],
- "modified": "2024-05-25 15:54:45.924716",
+ "modified": "2024-05-25 21:27:42.605083",
  "modified_by": "Administrator",
  "module": "Selling",
  "name": "Sales Order Item",


### PR DESCRIPTION
Accounts Settings:
![image](https://github.com/frappe/erpnext/assets/52111700/11f2762b-90d6-4311-a55c-f0e3b8ec7425)

Working of select-able pricing rule:

https://github.com/frappe/erpnext/assets/52111700/aae17d26-1089-490b-811f-e9f9fcd72c49

Upon selection of item, all applicable pricing rules are applied. User can then select whether or not to apply a specific one.
Closes https://github.com/frappe/erpnext/issues/41636

~~ToDo: fix failing pricing rule conflict test as there won't be conflicts.~~ completed 

`no-docs` temp