### PR TITLE
refactor: remove use of `can_create` for Payment Request

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -770,13 +770,11 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 					flt(doc.per_billed, precision("per_billed", doc)) <
 					100 + frappe.boot.sysdefaults.over_billing_allowance
 				) {
-					if (frappe.model.can_create("Payment Request")) {
-						this.frm.add_custom_button(
-							__("Payment Request"),
-							() => this.make_payment_request(),
-							__("Create")
-						);
-					}
+					this.frm.add_custom_button(
+						__("Payment Request"),
+						() => this.make_payment_request(),
+						__("Create")
+					);
 
 					if (frappe.model.can_create("Payment Entry")) {
 						this.frm.add_custom_button(


### PR DESCRIPTION
regression: https://github.com/frappe/erpnext/pull/41384

`Payment Request` is configured to be 'User Cannot Create'. So, it won't be available in `can_create` list, which means the Payment Request option under the `Create` button won't be available for anyone.

## Before
![Screenshot from 2024-05-27 09-48-04](https://github.com/frappe/erpnext/assets/3272205/d4669a32-7821-496e-be20-681d9a360958)

## After
![Screenshot from 2024-05-27 09-47-35](https://github.com/frappe/erpnext/assets/3272205/5a3a6e32-735f-4e66-824b-6a3a5da1eecb)
