### PR TITLE
fix: completed DC will not appear in a delivery trip

### DIFF
--- a/erpnext/stock/doctype/delivery_note/delivery_note.js
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.js
@@ -223,7 +223,7 @@ erpnext.stock.DeliveryNoteController = class DeliveryNoteController extends (
 				);
 			}
 
-			if (doc.docstatus == 1 && frappe.model.can_create("Delivery Trip")) {
+			if (doc.docstatus == 1 && doc.status == "Completed" && frappe.model.can_create("Delivery Trip")) {
 				this.frm.add_custom_button(
 					__("Delivery Trip"),
 					function () {

--- a/erpnext/stock/doctype/delivery_note/delivery_note.js
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.js
@@ -223,7 +223,7 @@ erpnext.stock.DeliveryNoteController = class DeliveryNoteController extends (
 				);
 			}
 
-			if (doc.docstatus == 1 && doc.status == "Completed" && frappe.model.can_create("Delivery Trip")) {
+			if (doc.docstatus == 1 && doc.status != "Completed" && frappe.model.can_create("Delivery Trip")) {
 				this.frm.add_custom_button(
 					__("Delivery Trip"),
 					function () {

--- a/erpnext/stock/doctype/delivery_trip/delivery_trip.js
+++ b/erpnext/stock/doctype/delivery_trip/delivery_trip.js
@@ -58,9 +58,11 @@ frappe.ui.form.on("Delivery Trip", {
 						date_field: "posting_date",
 						setters: {
 							company: frm.doc.company,
+							customer: null,
 						},
 						get_query_filters: {
 							company: frm.doc.company,
+							status: ["Not In", ["Completed", "Cancelled"]],
 						},
 					});
 				},


### PR DESCRIPTION
fixes: #41427

Set the condition for the delivery trip so that a completed Delivery Challan (DC) will not appear. Also, add the customer filter in the "Get stops from".

The `docstatus` 1 was removed from the delivery trip due to https://github.com/frappe/erpnext/pull/38559, but `docstatus` 1 is still set in `delivery_note.js`, which is confusing because it is set in one place but not in another.

Currently, I haven't made any changes related to `docstatus`, but if you request, I will also update it in `delivery_note.js`.

**Output:**


https://github.com/frappe/erpnext/assets/141945075/e082f7a1-2813-4479-a6e1-789200bccdeb

