### PR TITLE
fix(Deferred Expenses): Pro rata calculation for first day and last day

### DIFF
--- a/erpnext/accounts/deferred_revenue.py
+++ b/erpnext/accounts/deferred_revenue.py
@@ -221,12 +221,13 @@ def calculate_monthly_amount(
 				amount = item.net_amount - already_booked_amount_in_account_currency
 
 		if get_first_day(start_date) != start_date or get_last_day(end_date) != end_date:
-			partial_month = flt(date_diff(end_date, start_date)) / flt(
+			partial_month = (flt(date_diff(end_date, start_date)) + 1) / flt(
 				date_diff(get_last_day(end_date), get_first_day(start_date))
 			)
 
-			base_amount = rounded(partial_month, 1) * base_amount
-			amount = rounded(partial_month, 1) * amount
+			precision = frappe.get_system_settings("float_precision") or 2
+			base_amount = rounded(partial_month, precision) * base_amount
+			amount = rounded(partial_month, precision) * amount
 	else:
 		already_booked_amount, already_booked_amount_in_account_currency = get_already_booked_amount(
 			doc, item


### PR DESCRIPTION
Hello,

This PR aims at correcting the pro-rata calculation for deferred income/expenses calculated on a monthly basis.
The current behavior doesn't calculate a pro-rata if an expense service start date is on the last day of month, whereas we could consider that 1 day should be counted.

Example with a service start date on 2024-01-31 and a service end date on 2025-01-30.
Currently the calculation for the first month is 0€ and it blocks the calculation for the following months as displayed below (calculation rule is 'Months'):

![2024-05-28_21-30](https://github.com/frappe/erpnext/assets/4903591/ddd4dcc5-d0a7-43d9-a1ac-359580c3664d)

If a service start date is done on the last day of the month, we should assume that one day should be prorated like:
![2024-05-28_21-21](https://github.com/frappe/erpnext/assets/4903591/b30669ae-1651-4ce5-b5c2-f74a41f8b3e6)


Therefore I propose 2 changes:

1. Always add one day to the date differences for the pro-rata calculation:
Between the 1st and the 31st we should count 31 days, and on the 31st we should count 1 day.

2. The pro-rata percentage was arbitrarily rounded with 1 decimal, I propose to round it based on the system settings.
The problem with 1 decimal is the following: 1/31 = 0.03225...
With 1 decimal, the percentage will be 0.0, which cancels the effects of the above fix.
Don't hesitate to let me know if you see a better solution for setting the precision.

Have a nice day.

