### PR TITLE
fix: work order created message pops up if no items are selected

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -893,6 +893,9 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 						fields: fields,
 						primary_action: function () {
 							var data = { items: d.fields_dict.items.grid.get_selected_children() };
+							if (!data) {
+								frappe.throw(__("Please select items"));
+							}
 							me.frm.call({
 								method: "make_work_orders",
 								args: {


### PR DESCRIPTION
**Work order created message pops up if no items are selected**

![work_order](https://github.com/frappe/erpnext/assets/83776819/6f718968-ef4b-431f-978a-aaa3b1cd6fd1)

**To address this issue, If no items selected i have implemented a throw message.**