### PR TITLE
refactor: enabling partial TDS application on partial invoice

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.js
@@ -681,7 +681,7 @@ frappe.ui.form.on("Purchase Invoice", {
 			if (frm.doc.supplier) {
 				frm.doc.apply_tds = frm.doc.__onload.supplier_tds ? 1 : 0;
 			}
-			if (!frm.doc.__onload.supplier_tds) {
+			if (!frm.doc.__onload.enable_apply_tds) {
 				frm.set_df_property("apply_tds", "read_only", 1);
 			}
 		}

--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -348,6 +348,22 @@ class PurchaseInvoice(BuyingController):
 			self.tax_withholding_category = tds_category
 			self.set_onload("supplier_tds", tds_category)
 
+		# If Linked Purchase Order has TDS applied, enable 'apply_tds' checkbox
+		if purchase_orders := [x.purchase_order for x in self.items if x.purchase_order]:
+			po = qb.DocType("Purchase Order")
+			po_with_tds = (
+				qb.from_(po)
+				.select(po.name)
+				.where(
+					po.docstatus.eq(1)
+					& (po.name.isin(purchase_orders))
+					& (po.apply_tds.eq(1))
+					& (po.tax_withholding_category.notnull())
+				)
+				.run()
+			)
+			self.set_onload("enable_apply_tds", True if po_with_tds else False)
+
 		super().set_missing_values(for_validate)
 
 	def validate_credit_to_acc(self):


### PR DESCRIPTION
Consider a scenario where a Purchase Order has TDS applied, even though Supplier master doesn't have TDS set. On such cases, making a Partial Purchase Invoice against that PO fetched the full TDS amount from PO. This is incorrect.

By making `Apply Tax Withholding Amount` checkbox editable on such scenarios, users can make partial purchase invoice with TDS applied only for that partial amount.

Internal Ref: https://support.frappe.io/helpdesk/tickets/14976