### PR TITLE
fix: show material to supplier button

### DIFF
--- a/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.js
+++ b/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.js
@@ -235,9 +235,11 @@ erpnext.buying.SubcontractingOrderController = class SubcontractingOrderControll
 	}
 
 	has_unsupplied_items() {
-		return this.frm.doc["supplied_items"].some(
-			(item) => item.required_qty > item.supplied_qty - item.returned_qty
-		);
+		let over_transfer_allowance = this.frm.doc.__onload.over_transfer_allowance;
+		return this.frm.doc["supplied_items"].some((item) => {
+			let required_qty = item.required_qty + (item.required_qty * over_transfer_allowance) / 100;
+			return required_qty > item.supplied_qty - item.returned_qty;
+		});
 	}
 
 	make_subcontracting_receipt() {

--- a/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.py
+++ b/erpnext/subcontracting/doctype/subcontracting_order/subcontracting_order.py
@@ -99,6 +99,12 @@ class SubcontractingOrder(SubcontractingController):
 			}
 		]
 
+	def onload(self):
+		self.set_onload(
+			"over_transfer_allowance",
+			frappe.db.get_single_value("Buying Settings", "over_transfer_allowance"),
+		)
+
 	def before_validate(self):
 		super().before_validate()
 


### PR DESCRIPTION
**Issue**


Set over transfer allowance still Transfer -> material to supplier button not showing on the SCO

**Buying Settings**
<img width="1339" alt="Screenshot 2024-05-30 at 12 07 12 PM" src="https://github.com/frappe/erpnext/assets/8780500/6757ac45-8b99-4f36-ac34-481ce2514bfc">

**Subcontracting Order**
<img width="1317" alt="Screenshot 2024-05-30 at 11 03 21 AM" src="https://github.com/frappe/erpnext/assets/8780500/8ce98c94-f79b-4a23-b0d1-2e1ca9f5a100">



**After Fix**
<img width="1286" alt="Screenshot 2024-05-30 at 12 07 03 PM" src="https://github.com/frappe/erpnext/assets/8780500/9691bd9b-fa54-4db3-8a42-ac75917184df">




