### PR TITLE
fix: Batch number not populating based on the flag in Stock Settings

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -961,6 +961,7 @@ def get_available_item_locations_for_batched_item(
 			{
 				"item_code": item_code,
 				"warehouse": from_warehouses,
+				"based_on": frappe.db.get_single_value("Stock Settings", "pick_serial_and_batch_based_on"),
 			}
 		)
 	)


### PR DESCRIPTION
In Pick list batch should get populated based on the flag (**pick_serial_and_batch_based_on**) in Stock settings, but is populating based on FIFO.