### PR TITLE
fix: Ignore disabling default currency field while creating new company

### DIFF
--- a/erpnext/setup/doctype/company/company.js
+++ b/erpnext/setup/doctype/company/company.js
@@ -12,10 +12,11 @@ frappe.ui.form.on("Company", {
 				}
 			});
 		}
-
-		frm.call("check_if_transactions_exist").then((r) => {
-			frm.toggle_enable("default_currency", !r.message);
-		});
+		if (!frm.doc.__islocal) {
+			frm.call("check_if_transactions_exist").then((r) => {
+				frm.toggle_enable("default_currency", !r.message);
+			});
+		}
 	},
 	setup: function (frm) {
 		frm.__rename_queue = "long";


### PR DESCRIPTION
Ignore disabling the default currency field while creating a new company, because it is not required and also gives permission error based on existing user permissions.