### PR TITLE
fix: key error for stock ledger report

### DIFF
--- a/erpnext/stock/report/stock_ledger/stock_ledger.py
+++ b/erpnext/stock/report/stock_ledger/stock_ledger.py
@@ -67,7 +67,12 @@ def execute(filters=None):
 		if filters.get("batch_no") or inventory_dimension_filters_applied:
 			actual_qty += flt(sle.actual_qty, precision)
 			stock_value += sle.stock_value_difference
-			batch_balance_dict[sle.batch_no] += sle.actual_qty
+			if sle.batch_no:
+				if not batch_balance_dict.get(sle.batch_no):
+					batch_balance_dict[sle.batch_no] = 0
+
+				batch_balance_dict[sle.batch_no] += sle.actual_qty
+
 			if filters.get("segregate_serial_batch_bundle"):
 				actual_qty = batch_balance_dict[sle.batch_no]
 


### PR DESCRIPTION
**Issue**

```
  File "apps/frappe/frappe/core/doctype/report/report.py", line 162, in execute_script_report
    res = self.execute_module(filters)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/frappe/frappe/core/doctype/report/report.py", line 179, in execute_module
    return frappe.get_attr(method_name)(frappe._dict(filters))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "apps/erpnext/erpnext/stock/report/stock_ledger/stock_ledger.py", line 70, in execute
    batch_balance_dict[sle.batch_no] += sle.actual_qty
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
KeyError: None
```