### PR TITLE
refactor: add `Is opening` flag for payment entry

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.json
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.json
@@ -782,6 +782,7 @@
   },
   {
    "default": "No",
+   "depends_on": "eval: doc.book_advance_payments_in_separate_party_account == 1",
    "fieldname": "is_opening",
    "fieldtype": "Select",
    "label": "Is Opening",
@@ -801,7 +802,7 @@
    "table_fieldname": "payment_entries"
   }
  ],
- "modified": "2024-05-31 16:54:59.618516",
+ "modified": "2024-05-31 17:07:06.197249",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Entry",

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.json
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.json
@@ -89,6 +89,7 @@
   "custom_remarks",
   "remarks",
   "base_in_words",
+  "is_opening",
   "column_break_16",
   "letter_head",
   "print_heading",
@@ -778,6 +779,15 @@
    "label": "Reconcile on Advance Payment Date",
    "no_copy": 1,
    "read_only": 1
+  },
+  {
+   "default": "No",
+   "fieldname": "is_opening",
+   "fieldtype": "Select",
+   "label": "Is Opening",
+   "options": "No\nYes",
+   "print_hide": 1,
+   "search_index": 1
   }
  ],
  "index_web_pages_for_search": 1,
@@ -791,7 +801,7 @@
    "table_fieldname": "payment_entries"
   }
  ],
- "modified": "2024-05-17 10:21:11.199445",
+ "modified": "2024-05-31 16:54:59.618516",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Entry",

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -199,11 +199,13 @@ class PaymentEntry(AccountsController):
 
 		self.book_advance_payments_in_separate_party_account = False
 		if self.party_type not in ("Customer", "Supplier"):
+			self.is_opening = "No"
 			return
 
 		if not frappe.db.get_value(
 			"Company", self.company, "book_advance_payments_in_separate_party_account"
 		):
+			self.is_opening = "No"
 			return
 
 		# Important to set this flag for the gl building logic to work properly
@@ -215,6 +217,7 @@ class PaymentEntry(AccountsController):
 		if (account_type == "Payable" and self.party_type == "Customer") or (
 			account_type == "Receivable" and self.party_type == "Supplier"
 		):
+			self.is_opening = "No"
 			return
 
 		if self.references:
@@ -224,6 +227,7 @@ class PaymentEntry(AccountsController):
 			# If there are referencers other than `allowed_types`, treat this as a normal payment entry
 			if reference_types - allowed_types:
 				self.book_advance_payments_in_separate_party_account = False
+				self.is_opening = "No"
 				return
 
 		liability_account = get_party_account(

--- a/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/test_payment_entry.py
@@ -1729,6 +1729,68 @@ class TestPaymentEntry(FrappeTestCase):
 		self.check_gl_entries()
 		self.check_pl_entries()
 
+	def test_opening_flag_for_advance_as_liability(self):
+		company = "_Test Company"
+
+		advance_account = create_account(
+			parent_account="Current Assets - _TC",
+			account_name="Advances Received",
+			company=company,
+			account_type="Receivable",
+		)
+
+		# Enable Advance in separate party account
+		frappe.db.set_value(
+			"Company",
+			company,
+			{
+				"book_advance_payments_in_separate_party_account": 1,
+				"default_advance_received_account": advance_account,
+			},
+		)
+		# Advance Payment
+		adv = create_payment_entry(
+			party_type="Customer",
+			party="_Test Customer",
+			payment_type="Receive",
+			paid_from="Debtors - _TC",
+			paid_to="_Test Cash - _TC",
+		)
+		adv.is_opening = "Yes"
+		adv.save()  # use save() to trigger set_liability_account()
+		adv.submit()
+
+		gl_with_opening_set = frappe.db.get_all(
+			"GL Entry", filters={"voucher_no": adv.name, "is_opening": "Yes"}
+		)
+		# 'Is Opening' can be 'Yes' for Advances in separate party account
+		self.assertNotEqual(gl_with_opening_set, [])
+
+		# Disable Advance in separate party account
+		frappe.db.set_value(
+			"Company",
+			company,
+			{
+				"book_advance_payments_in_separate_party_account": 0,
+				"default_advance_received_account": None,
+			},
+		)
+		payment = create_payment_entry(
+			party_type="Customer",
+			party="_Test Customer",
+			payment_type="Receive",
+			paid_from="Debtors - _TC",
+			paid_to="_Test Cash - _TC",
+		)
+		payment.is_opening = "Yes"
+		payment.save()
+		payment.submit()
+		gl_with_opening_set = frappe.db.get_all(
+			"GL Entry", filters={"voucher_no": payment.name, "is_opening": "Yes"}
+		)
+		# 'Is Opening' should always be 'No' for normal advance payments
+		self.assertEqual(gl_with_opening_set, [])
+
 
 def create_payment_entry(**args):
 	payment_entry = frappe.new_doc("Payment Entry")


### PR DESCRIPTION
Similar to Sales/Purchase Invoice and Journal, Payment Entry will have 'Is Opening' flag. It will be restricted to `Advance in Separate Party Account` type Payment Entries.