### PR TITLE
fix: lp during ref_doc save event

### DIFF
--- a/erpnext/accounts/doctype/loyalty_program/loyalty_program.py
+++ b/erpnext/accounts/doctype/loyalty_program/loyalty_program.py
@@ -183,6 +183,8 @@ def validate_loyalty_points(ref_doc, points_to_redeem):
 
 		if not ref_doc.loyalty_amount and ref_doc.loyalty_amount != loyalty_amount:
 			ref_doc.loyalty_amount = loyalty_amount
+		if not ref_doc.loyalty_points and ref_doc.loyalty_points != points_to_redeem:
+			ref_doc.loyalty_points = points_to_redeem
 
 		if ref_doc.doctype == "Sales Invoice":
 			ref_doc.loyalty_program = loyalty_program

--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -432,7 +432,9 @@ def make_payment_request(**args):
 	"""Make payment request"""
 
 	args = frappe._dict(args)
-	if args.dt not in [
+	ref_doc = args.ref_doc or frappe.get_doc(args.dt, args.dn)
+
+	if ref_doc.doctype not in [
 		"Sales Order",
 		"Purchase Order",
 		"Sales Invoice",
@@ -440,22 +442,23 @@ def make_payment_request(**args):
 		"POS Invoice",
 		"Fees",
 	]:
-		frappe.throw(_("Payment Requests cannot be created against: {0}").format(frappe.bold(args.dt)))
+		frappe.throw(
+			_("Payment Requests cannot be created against: {0}").format(frappe.bold(ref_doc.doctype))
+		)
 
-	ref_doc = frappe.get_doc(args.dt, args.dn)
 	gateway_account = get_gateway_details(args) or frappe._dict()
 
 	grand_total = get_amount(ref_doc, gateway_account.get("payment_account"))
 	if not grand_total:
 		frappe.throw(_("Payment Entry is already created"))
-	if args.loyalty_points and args.dt == "Sales Order":
+
+	if args.loyalty_points and ref_doc.doctype == "Sales Order":
 		from erpnext.accounts.doctype.loyalty_program.loyalty_program import validate_loyalty_points
 
-		loyalty_amount = validate_loyalty_points(ref_doc, int(args.loyalty_points))
-		frappe.db.set_value(
-			"Sales Order", args.dn, "loyalty_points", int(args.loyalty_points), update_modified=False
-		)
-		frappe.db.set_value("Sales Order", args.dn, "loyalty_amount", loyalty_amount, update_modified=False)
+		loyalty_amount: Document = validate_loyalty_points(
+			ref_doc, int(args.loyalty_points)
+		)  # sets fields on ref_doc
+		loyalty_amount.db_update()
 		grand_total = grand_total - loyalty_amount
 
 	bank_account = (
@@ -464,10 +467,10 @@ def make_payment_request(**args):
 
 	draft_payment_request = frappe.db.get_value(
 		"Payment Request",
-		{"reference_doctype": args.dt, "reference_name": args.dn, "docstatus": 0},
+		{"reference_doctype": ref_doc.doctype, "reference_name": ref_doc.name, "docstatus": 0},
 	)
 
-	existing_payment_request_amount = get_existing_payment_request_amount(args.dt, args.dn)
+	existing_payment_request_amount = get_existing_payment_request_amount(ref_doc.doctype, ref_doc.name)
 
 	if existing_payment_request_amount:
 		grand_total -= existing_payment_request_amount
@@ -498,8 +501,8 @@ def make_payment_request(**args):
 				"email_to": args.recipient_id or ref_doc.owner,
 				"subject": _("Payment Request for {0}").format(args.dn),
 				"message": gateway_account.get("message") or get_dummy_message(ref_doc),
-				"reference_doctype": args.dt,
-				"reference_name": args.dn,
+				"reference_doctype": ref_doc.doctype,
+				"reference_name": ref_doc.name,
 				"company": ref_doc.get("company"),
 				"party_type": args.get("party_type") or "Customer",
 				"party": args.get("party") or ref_doc.get("customer"),


### PR DESCRIPTION
**Prior**:

1. ref_doc is passed
2. values are written in db
3. ref_doc may be saved afterwards (from the memory object without updated values)
4. values are reset into db
5. transactions finishes; no new values land in db

**Now**:
1. ref_doc is passed
2. values are written on ref_doc
3. values are also written to db
4. in case ref_doc goes through the normal document lifecycle, values are preserved (because they are correctly set on the memory object)
5. correct values remain in db