### PR TITLE
chore: patch to enable old serial/batch fields

### DIFF
--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -369,3 +369,4 @@ erpnext.patches.v15_0.rename_purchase_receipt_amount_to_purchase_amount
 erpnext.patches.v14_0.enable_set_priority_for_pricing_rules #1
 erpnext.patches.v15_0.rename_number_of_depreciations_booked_to_opening_booked_depreciations
 erpnext.patches.v15_0.add_default_operations
+erpnext.patches.v15_0.enable_old_serial_batch_fields

--- a/erpnext/patches/v15_0/enable_old_serial_batch_fields.py
+++ b/erpnext/patches/v15_0/enable_old_serial_batch_fields.py
@@ -5,4 +5,3 @@ def execute():
 	sabb = frappe.get_all("Serial and Batch Bundle", filters={"docstatus": ("<", 2)}, limit=1)
 	if not sabb:
 		frappe.db.set_single_value("Stock Settings", "use_serial_batch_fields", 1)
-

--- a/erpnext/patches/v15_0/enable_old_serial_batch_fields.py
+++ b/erpnext/patches/v15_0/enable_old_serial_batch_fields.py
@@ -1,0 +1,8 @@
+import frappe
+
+
+def execute():
+	sabb = frappe.get_all("Serial and Batch Bundle", filters={"docstatus": ("<", 2)}, limit=1)
+	if not sabb:
+		frappe.db.set_single_value("Stock Settings", "use_serial_batch_fields", 1)
+


### PR DESCRIPTION
From converting v13 to v15 or v14 to v15 added a patch to enable "Use Serial / Batch Fields" in Stock Settings 