### PR TITLE
fix: Select both account number and company in the account form

### DIFF
--- a/erpnext/accounts/doctype/account/account.js
+++ b/erpnext/accounts/doctype/account/account.js
@@ -22,9 +22,6 @@ frappe.ui.form.on("Account", {
 		// hide fields if group
 		frm.toggle_display(["tax_rate"], cint(frm.doc.is_group) == 0);
 
-		// disable fields
-		frm.toggle_enable(["is_group", "company"], false);
-
 		if (cint(frm.doc.is_group) == 0) {
 			frm.toggle_display("freeze_account", frm.doc.__onload && frm.doc.__onload.can_freeze_account);
 		}

--- a/erpnext/accounts/doctype/account/account.js
+++ b/erpnext/accounts/doctype/account/account.js
@@ -22,6 +22,8 @@ frappe.ui.form.on("Account", {
 		// hide fields if group
 		frm.toggle_display(["tax_rate"], cint(frm.doc.is_group) == 0);
 
+		frm.toggle_enable(["is_group", "company", "account_number"], frm.is_new());
+
 		if (cint(frm.doc.is_group) == 0) {
 			frm.toggle_display("freeze_account", frm.doc.__onload && frm.doc.__onload.can_freeze_account);
 		}

--- a/erpnext/accounts/doctype/account/account.json
+++ b/erpnext/accounts/doctype/account/account.json
@@ -55,8 +55,7 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "in_standard_filter": 1,
-   "label": "Account Number",
-   "read_only": 1
+   "label": "Account Number"
   },
   {
    "default": "0",
@@ -74,7 +73,6 @@
    "oldfieldname": "company",
    "oldfieldtype": "Link",
    "options": "Company",
-   "read_only": 1,
    "remember_last_selected_value": 1,
    "reqd": 1
   },


### PR DESCRIPTION
fixes: #41695

**Before:**

![image](https://github.com/frappe/erpnext/assets/141945075/90152ed8-74ad-4c8d-9081-9b4bd303f7ed)

**After:**

- Both account number and company should be selected in the account form. This is important because if the user wants to change the company, the account form needs to have a way to set the company. Additionally, each user selects by going to the account doctype instead of adding the account in the chart of accounts tree, so in this case, users have the right to select the company.

![image](https://github.com/frappe/erpnext/assets/141945075/afd847ee-450c-4659-94d6-40582a751cb3)
