### PR TITLE
fix: Correct dunnings resolving after PE submit

### DIFF
--- a/erpnext/accounts/doctype/dunning/dunning.py
+++ b/erpnext/accounts/doctype/dunning/dunning.py
@@ -196,7 +196,7 @@ def resolve_dunning(doc, state):
 					resolve = resolve and (False if (outstanding_ps > 0 and outstanding_inv > 0) else True)
 
 				new_status = "Resolved" if resolve else "Unresolved"
-				
+
 				if dunning.status != new_status:
 					dunning.status = new_status
 					dunning.save()

--- a/erpnext/accounts/doctype/dunning/dunning.py
+++ b/erpnext/accounts/doctype/dunning/dunning.py
@@ -193,10 +193,13 @@ def resolve_dunning(doc, state):
 					outstanding_ps = frappe.get_value(
 						"Payment Schedule", overdue_payment.payment_schedule, "outstanding"
 					)
-					resolve = False if (outstanding_ps > 0 and outstanding_inv > 0) else True
+					resolve = resolve and (False if (outstanding_ps > 0 and outstanding_inv > 0) else True)
 
-				dunning.status = "Resolved" if resolve else "Unresolved"
-				dunning.save()
+				new_status = "Resolved" if resolve else "Unresolved"
+				
+				if dunning.status != new_status:
+					dunning.status = new_status
+					dunning.save()
 
 
 def get_linked_dunnings_as_per_state(sales_invoice, state):


### PR DESCRIPTION
Hello,
this PR covers issue: https://github.com/frappe/erpnext/issues/41752

Before this PR the resolving of dunnings counted just with last status of overdue_payments. If the last status was "Resolved" (for example last Sales Invoice was paid) the parent Dunning was "Resolved". It didn't take care about status of previous overdue_payments.

Next change:
Dunning is saved just in case if here is status changing.


