### PR TITLE
fix: calculate totals and taxes

### DIFF
--- a/erpnext/public/js/controllers/taxes_and_totals.js
+++ b/erpnext/public/js/controllers/taxes_and_totals.js
@@ -83,7 +83,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 			this.frm.doc.paid_amount = flt(this.frm.doc.grand_total, precision("grand_total"));
 		}
 
-		this.frm.refresh_field("taxes");
+		this.frm.refresh_fields();
 	}
 
 	calculate_discount_amount() {
@@ -853,7 +853,7 @@ erpnext.taxes_and_totals = class TaxesAndTotals extends erpnext.payments {
 			});
 		}
 
-		this.frm.refresh_field("taxes");
+		this.frm.refresh_fields();
 	}
 
 	set_default_payment(total_amount_to_pay, update_paid_amount) {


### PR DESCRIPTION
version 15

fixes: #41779 , #41799 
- https://discuss.frappe.io/t/total-auto-calculation-not-working-on-screen-it-works-while-saving/124758?u=ncp
- https://discuss.frappe.io/t/after-update-the-amount-not-changes-when-rate-or-qty-update/126344?u=ncp

**Before:** 

https://github.com/frappe/erpnext/pull/41591 I know the `refresh_fields` method slows down the entry, but the totals and taxes are not calculated when the quantity and rate are changed.



https://github.com/frappe/erpnext/assets/141945075/1c0417ba-58d5-47c4-8a44-8f275f47b9d7

**After:**


https://github.com/frappe/erpnext/assets/141945075/e78c88f8-a053-4bdb-9f87-ca65b2cf72bc
