### PR TITLE
fix: incorrect time period in asset depreciation schedule

### DIFF
--- a/erpnext/assets/doctype/asset/test_asset.py
+++ b/erpnext/assets/doctype/asset/test_asset.py
@@ -1501,19 +1501,17 @@ class TestDepreciationBasics(AssetSetup):
 		"""
 
 		asset = create_asset(calculate_depreciation=1)
-		asset.opening_accumulated_depreciation = 2000
-		asset.opening_number_of_booked_depreciations = 1
 
 		asset.finance_books[0].expected_value_after_useful_life = 100
 		asset.save()
 		asset.reload()
-		self.assertEqual(asset.finance_books[0].value_after_depreciation, 98000.0)
+		self.assertEqual(asset.finance_books[0].value_after_depreciation, 100000.0)
 
 		# changing expected_value_after_useful_life shouldn't affect value_after_depreciation
 		asset.finance_books[0].expected_value_after_useful_life = 200
 		asset.save()
 		asset.reload()
-		self.assertEqual(asset.finance_books[0].value_after_depreciation, 98000.0)
+		self.assertEqual(asset.finance_books[0].value_after_depreciation, 100000.0)
 
 	def test_asset_cost_center(self):
 		asset = create_asset(is_existing_asset=1, do_not_save=1)

--- a/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
@@ -562,7 +562,10 @@ def _check_is_pro_rata(asset_doc, row, wdv_or_dd_non_yearly=False):
 			Error: This asset already has {0} depreciation periods booked.
 			The 'depreciation start' date must be at least {1} periods after the 'available for use' date. Please correct the dates accordingly.
 			"""
-			).format(asset_doc.number_of_depreciations_booked, asset_doc.number_of_depreciations_booked)
+			).format(
+				asset_doc.opening_number_of_booked_depreciations,
+				asset_doc.opening_number_of_booked_depreciations,
+			)
 		)
 	if days < total_days:
 		has_pro_rata = True
@@ -576,10 +579,10 @@ def _get_modified_available_for_use_date(asset_doc, row, wdv_or_dd_non_yearly=Fa
 	depreciation start date = 30-04-2024
 	then from date should be 01-04-2024
 	"""
-	if asset_doc.number_of_depreciations_booked > 0:
+	if asset_doc.opening_number_of_booked_depreciations > 0:
 		from_date = add_months(
 			asset_doc.available_for_use_date,
-			(asset_doc.number_of_depreciations_booked * row.frequency_of_depreciation) - 1,
+			(asset_doc.opening_number_of_booked_depreciations * row.frequency_of_depreciation) - 1,
 		)
 		if is_last_day_of_the_month(row.depreciation_start_date):
 			return add_days(get_last_day(from_date), 1)

--- a/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
@@ -558,10 +558,9 @@ def _check_is_pro_rata(asset_doc, row, wdv_or_dd_non_yearly=False):
 	if days <= 0:
 		frappe.throw(
 			_(
-				"""
-				Error: This asset already has {0} depreciation periods booked.
-				The `depreciation start` date must be at least {1} periods after the `available for use` date. Please correct the dates accordingly.
-				"""
+				"""Error: This asset already has {0} depreciation periods booked.
+				The `depreciation start` date must be at least {1} periods after the `available for use` date.
+				Please correct the dates accordingly."""
 			).format(
 				asset_doc.opening_number_of_booked_depreciations,
 				asset_doc.opening_number_of_booked_depreciations,

--- a/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
@@ -559,9 +559,9 @@ def _check_is_pro_rata(asset_doc, row, wdv_or_dd_non_yearly=False):
 		frappe.throw(
 			_(
 				"""
-			Error: This asset already has {0} depreciation periods booked.
-			The 'depreciation start' date must be at least {1} periods after the 'available for use' date. Please correct the dates accordingly.
-			"""
+				Error: This asset already has {0} depreciation periods booked.
+				The 'depreciation start' date must be at least {1} periods after the 'available for use' date. Please correct the dates accordingly.
+				"""
 			).format(
 				asset_doc.opening_number_of_booked_depreciations,
 				asset_doc.opening_number_of_booked_depreciations,

--- a/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
@@ -560,7 +560,7 @@ def _check_is_pro_rata(asset_doc, row, wdv_or_dd_non_yearly=False):
 			_(
 				"""
 				Error: This asset already has {0} depreciation periods booked.
-				The 'depreciation start' date must be at least {1} periods after the 'available for use' date. Please correct the dates accordingly.
+				The `depreciation start` date must be at least {1} periods after the `available for use` date. Please correct the dates accordingly.
 				"""
 			).format(
 				asset_doc.opening_number_of_booked_depreciations,

--- a/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/asset_depreciation_schedule.py
@@ -555,6 +555,15 @@ def _check_is_pro_rata(asset_doc, row, wdv_or_dd_non_yearly=False):
 	from_date = _get_modified_available_for_use_date(asset_doc, row, wdv_or_dd_non_yearly=False)
 	days = date_diff(row.depreciation_start_date, from_date) + 1
 	total_days = get_total_days(row.depreciation_start_date, row.frequency_of_depreciation)
+	if days <= 0:
+		frappe.throw(
+			_(
+				"""
+			Error: This asset already has {0} depreciation periods booked.
+			The 'depreciation start' date must be at least {1} periods after the 'available for use' date. Please correct the dates accordingly.
+			"""
+			).format(asset_doc.number_of_depreciations_booked, asset_doc.number_of_depreciations_booked)
+		)
 	if days < total_days:
 		has_pro_rata = True
 	return has_pro_rata

--- a/erpnext/assets/doctype/asset_depreciation_schedule/test_asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/test_asset_depreciation_schedule.py
@@ -201,7 +201,7 @@ class TestAssetDepreciationSchedule(FrappeTestCase):
 			depreciation_method="Written Down Value",
 			available_for_use_date="2020-07-17",
 			is_existing_asset=1,
-			number_of_depreciations_booked=2,
+			opening_number_of_booked_depreciations=2,
 			opening_accumulated_depreciation=11666.67,
 			depreciation_start_date="2021-04-30",
 			total_number_of_depreciations=12,
@@ -228,3 +228,4 @@ class TestAssetDepreciationSchedule(FrappeTestCase):
 			for d in get_depr_schedule(asset.name, "Draft")
 		]
 		self.assertEqual(schedules, expected_schedules)
+

--- a/erpnext/assets/doctype/asset_depreciation_schedule/test_asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/test_asset_depreciation_schedule.py
@@ -195,6 +195,7 @@ class TestAssetDepreciationSchedule(FrappeTestCase):
 		asset.reload()
 
 		self.assertEqual(asset.finance_books[0].total_number_of_booked_depreciations, 14)
+
 	def test_schedule_for_wdv_method_for_existing_asset(self):
 		asset = create_asset(
 			calculate_depreciation=1,
@@ -228,4 +229,3 @@ class TestAssetDepreciationSchedule(FrappeTestCase):
 			for d in get_depr_schedule(asset.name, "Draft")
 		]
 		self.assertEqual(schedules, expected_schedules)
-

--- a/erpnext/assets/doctype/asset_depreciation_schedule/test_asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/test_asset_depreciation_schedule.py
@@ -172,7 +172,7 @@ class TestAssetDepreciationSchedule(FrappeTestCase):
 			opening_accumulated_depreciation=2000,
 			opening_number_of_booked_depreciations=2,
 			depreciation_method="Straight Line",
-			available_for_use_date="2020-03-01",
+			available_for_use_date="2020-01-01",
 			depreciation_start_date="2020-03-31",
 			frequency_of_depreciation=1,
 			total_number_of_depreciations=24,

--- a/erpnext/assets/doctype/asset_depreciation_schedule/test_asset_depreciation_schedule.py
+++ b/erpnext/assets/doctype/asset_depreciation_schedule/test_asset_depreciation_schedule.py
@@ -3,7 +3,7 @@
 
 import frappe
 from frappe.tests.utils import FrappeTestCase
-from frappe.utils import cstr
+from frappe.utils import cstr, flt
 
 from erpnext.assets.doctype.asset.depreciation import (
 	post_depreciation_entries,
@@ -195,3 +195,36 @@ class TestAssetDepreciationSchedule(FrappeTestCase):
 		asset.reload()
 
 		self.assertEqual(asset.finance_books[0].total_number_of_booked_depreciations, 14)
+	def test_schedule_for_wdv_method_for_existing_asset(self):
+		asset = create_asset(
+			calculate_depreciation=1,
+			depreciation_method="Written Down Value",
+			available_for_use_date="2020-07-17",
+			is_existing_asset=1,
+			number_of_depreciations_booked=2,
+			opening_accumulated_depreciation=11666.67,
+			depreciation_start_date="2021-04-30",
+			total_number_of_depreciations=12,
+			frequency_of_depreciation=3,
+			gross_purchase_amount=50000,
+			rate_of_depreciation=40,
+		)
+
+		self.assertEqual(asset.status, "Draft")
+		expected_schedules = [
+			["2021-04-30", 3833.33, 15500.0],
+			["2021-07-31", 3833.33, 19333.33],
+			["2021-10-31", 3833.33, 23166.66],
+			["2022-01-31", 3833.33, 26999.99],
+			["2022-04-30", 2300.0, 29299.99],
+			["2022-07-31", 2300.0, 31599.99],
+			["2022-10-31", 2300.0, 33899.99],
+			["2023-01-31", 2300.0, 36199.99],
+			["2023-04-30", 1380.0, 37579.99],
+			["2023-07-31", 12420.01, 50000.0],
+		]
+		schedules = [
+			[cstr(d.schedule_date), flt(d.depreciation_amount, 2), d.accumulated_depreciation_amount]
+			for d in get_depr_schedule(asset.name, "Draft")
+		]
+		self.assertEqual(schedules, expected_schedules)


### PR DESCRIPTION
Issue:
The current depreciation calculation is incorrect for existing assets with already booked depreciation. It incorrectly adds an extra month when creating the asset and calculating depreciation from the given start date.

Current Method: Adds an extra first month to adjust depreciation, which is incorrect for existing assets.
Requirement: For existing assets with booked depreciation, depreciation should start from the given start date without adding an extra month.

no-docs