### PR TITLE
fix: tests for work order consumption

### DIFF
--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -1677,6 +1677,11 @@ class TestWorkOrder(FrappeTestCase):
 		)
 		self.assertEqual(manufacture_ste_doc.items[0].qty, 4.0)
 
+		bundle = manufacture_ste_doc.items[0].serial_and_batch_bundle
+		bundle_doc = frappe.get_doc("Serial and Batch Bundle", bundle)
+		sabb_entries = [e.as_dict() for e in bundle_doc.entries]
+		throw Error("Temp")
+
 	###
 	def test_non_consumed_material_return_against_work_order(self):
 		frappe.db.set_single_value(

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -1680,7 +1680,7 @@ class TestWorkOrder(FrappeTestCase):
 		bundle = manufacture_ste_doc.items[0].serial_and_batch_bundle
 		bundle_doc = frappe.get_doc("Serial and Batch Bundle", bundle)
 		sabb_entries = [e.as_dict() for e in bundle_doc.entries]
-		throw Error("Temp")
+		raise Error("Temp")
 
 	###
 	def test_non_consumed_material_return_against_work_order(self):

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -1569,7 +1569,7 @@ class TestWorkOrder(FrappeTestCase):
 		self.assertEqual(transferred_ste_doc.items[0].qty, 4.0)
 
 		# Make additional consumption and link to WO
-		consume_add_doc = test_stock_entry.make_stock_entry(
+		test_stock_entry.make_stock_entry(
 			item_code="Test Batch Battery Consumable",
 			target="Stores - _TC",
 			qty=8,
@@ -1635,7 +1635,7 @@ class TestWorkOrder(FrappeTestCase):
 		self.assertEqual(transferred_ste_doc.items[0].qty, 4.0)
 
 		# Make additional consumption and link to WO
-		consume_add_doc = test_stock_entry.make_stock_entry(
+		test_stock_entry.make_stock_entry(
 			item_code="Test Serial Battery Consumable",
 			target="Stores - _TC",
 			qty=8,
@@ -2529,7 +2529,7 @@ def prepare_data_for_backflush_based_on_materials_transferred():
 	make_bom(item=item.name, source_warehouse="Stores - _TC", raw_materials=[batch_item_doc.name])
 
 	# Make additional items not attached to a BOM
-	consumable_batch_item_doc = make_item(
+	make_item(
 		"Test Batch Battery Consumable",
 		{
 			"is_stock_item": 1,
@@ -2540,7 +2540,7 @@ def prepare_data_for_backflush_based_on_materials_transferred():
 			"stock_uom": "Nos",
 		},
 	)
-	consumable_serial_item_doc = make_item(
+	make_item(
 		"Test Serial Battery Consumable",
 		{
 			"is_stock_item": 1,

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -1531,7 +1531,8 @@ class TestWorkOrder(FrappeTestCase):
 			serial_nos.remove(d.serial_no)
 
 		self.assertFalse(serial_nos)
-###
+
+	###
 	def test_backflushed_batch_raw_materials_based_on_transferred_autosabb(self):
 		frappe.db.set_single_value(
 			"Manufacturing Settings",
@@ -1565,7 +1566,7 @@ class TestWorkOrder(FrappeTestCase):
 		self.assertEqual(
 			get_batch_from_bundle(transferred_ste_doc.items[0].serial_and_batch_bundle), batch_no
 		)
-		self.assertEqual(transferred_ste_doc.items[0].qty, -4)
+		self.assertEqual(transferred_ste_doc.items[0].qty, 4.0)
 
 		manufacture_ste_doc = frappe.get_doc(make_stock_entry(wo_doc.name, "Manufacture", 4))
 		manufacture_ste_doc.submit()
@@ -1575,7 +1576,7 @@ class TestWorkOrder(FrappeTestCase):
 		self.assertEqual(
 			get_batch_from_bundle(manufacture_ste_doc.items[0].serial_and_batch_bundle), batch_no
 		)
-		self.assertEqual(manufacture_ste_doc.items[0].qty, -4)
+		self.assertEqual(manufacture_ste_doc.items[0].qty, 4.0)
 
 	def test_backflushed_serial_no_raw_materials_based_on_transferred_autosabb(self):
 		frappe.db.set_single_value(
@@ -1610,7 +1611,7 @@ class TestWorkOrder(FrappeTestCase):
 			sorted(get_serial_nos_from_bundle(transferred_ste_doc.items[0].serial_and_batch_bundle)),
 			serial_nos_list,
 		)
-		self.assertEqual(transferred_ste_doc.items[0].qty, -4)
+		self.assertEqual(transferred_ste_doc.items[0].qty, 4.0)
 
 		manufacture_ste_doc = frappe.get_doc(make_stock_entry(wo_doc.name, "Manufacture", 4))
 		manufacture_ste_doc.submit()
@@ -1622,7 +1623,7 @@ class TestWorkOrder(FrappeTestCase):
 			sorted(get_serial_nos_from_bundle(manufacture_ste_doc.items[0].serial_and_batch_bundle)),
 			serial_nos_list,
 		)
-		self.assertEqual(manufacture_ste_doc.items[0].qty, -4)
+		self.assertEqual(manufacture_ste_doc.items[0].qty, 4.0)
 
 	def test_backflushed_serial_no_batch_raw_materials_based_on_transferred_autosabb(self):
 		frappe.db.set_single_value(
@@ -1660,7 +1661,7 @@ class TestWorkOrder(FrappeTestCase):
 		self.assertEqual(
 			get_batch_from_bundle(transferred_ste_doc.items[0].serial_and_batch_bundle), batch_no
 		)
-		self.assertEqual(transferred_ste_doc.items[0].qty, -4)
+		self.assertEqual(transferred_ste_doc.items[0].qty, 4.0)
 
 		manufacture_ste_doc = frappe.get_doc(make_stock_entry(wo_doc.name, "Manufacture", 4))
 		manufacture_ste_doc.submit()
@@ -1674,8 +1675,9 @@ class TestWorkOrder(FrappeTestCase):
 		self.assertEqual(
 			get_batch_from_bundle(manufacture_ste_doc.items[0].serial_and_batch_bundle), batch_no
 		)
-		self.assertEqual(manufacture_ste_doc.items[0].qty, -4)
-###
+		self.assertEqual(manufacture_ste_doc.items[0].qty, 4.0)
+
+	###
 	def test_non_consumed_material_return_against_work_order(self):
 		frappe.db.set_single_value(
 			"Manufacturing Settings",

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -1576,13 +1576,14 @@ class TestWorkOrder(FrappeTestCase):
 			basic_rate=3.33,
 		)
 		consume_use_doc = test_stock_entry.make_stock_entry(
-			item_code="Test Batch Battery Consumable", # consumable not linked to BOM
+			item_code="Test Batch Battery Consumable",  # consumable not linked to BOM
 			qty=1,
 			from_warehouse="Stores - _TC",
 			purpose="Material Consumption for Manufacture",
-			do_not_submit=True,
+			do_not_save=True,
 		)
 		consume_use_doc.work_order = wo_doc.name
+		consume_use_doc.fg_completed_qty = 4
 		consume_use_doc.submit()
 		consume_use_doc.reload()
 

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -1679,8 +1679,8 @@ class TestWorkOrder(FrappeTestCase):
 
 		bundle = manufacture_ste_doc.items[0].serial_and_batch_bundle
 		bundle_doc = frappe.get_doc("Serial and Batch Bundle", bundle)
-		sabb_entries = [e.as_dict() for e in bundle_doc.entries]
-		raise Error("Temp")
+		qty = sum(e.qty for e in bundle_doc.entries)
+		self.assertEqual(qty, -4.0)
 
 	###
 	def test_non_consumed_material_return_against_work_order(self):

--- a/erpnext/manufacturing/doctype/work_order/test_work_order.py
+++ b/erpnext/manufacturing/doctype/work_order/test_work_order.py
@@ -1532,7 +1532,6 @@ class TestWorkOrder(FrappeTestCase):
 
 		self.assertFalse(serial_nos)
 
-	###
 	def test_backflushed_batch_raw_materials_based_on_transferred_autosabb(self):
 		frappe.db.set_single_value(
 			"Manufacturing Settings",


### PR DESCRIPTION
Tests that reproduce the following issues:

https://github.com/frappe/erpnext/issues/41798
https://github.com/frappe/erpnext/issues/41800

These failing tests illustrate the above issues which appear to originate here when consuming materials:

https://github.com/frappe/erpnext/blob/699cfd85c64916163f6ef156d47297c5725028ac/erpnext/stock/doctype/stock_entry/stock_entry.py#L3036