### PR TITLE
fix: use invoice outstanding on Dunning

### DIFF
--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -2644,6 +2644,10 @@ def create_dunning(source_name, target_doc=None, ignore_permissions=False):
 				target.closing_text = letter_text.get("closing_text")
 				target.language = letter_text.get("language")
 
+		# update outstanding
+		if source.payment_schedule and len(source.payment_schedule) == 1:
+			target.overdue_payments[0].outstanding = source.get("outstanding_amount")
+
 		target.validate()
 
 	return get_mapped_doc(


### PR DESCRIPTION
Dunning should use the latest outstanding of invoice. At the moment, it is restricted to Payment Schdule with only one term / row.