### PR TITLE
fix: do not fetch items with no active BOM in PP

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.py
@@ -452,6 +452,10 @@ class ProductionPlan(Document):
 						{"sales_order": data.parent, "sales_order_item": data.name, "qty": data.pending_qty}
 					)
 
+			bom_no = data.bom_no or item_details and item_details.bom_no or ""
+			if not bom_no:
+				continue
+
 			pi = self.append(
 				"po_items",
 				{
@@ -459,7 +463,7 @@ class ProductionPlan(Document):
 					"item_code": data.item_code,
 					"description": data.description or item_details.description,
 					"stock_uom": item_details and item_details.stock_uom or "",
-					"bom_no": data.bom_no or item_details and item_details.bom_no or "",
+					"bom_no": bom_no,
 					"planned_qty": data.pending_qty,
 					"pending_qty": data.pending_qty,
 					"planned_start_date": now_datetime(),

--- a/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
+++ b/erpnext/manufacturing/doctype/production_plan/test_production_plan.py
@@ -328,6 +328,28 @@ class TestProductionPlan(FrappeTestCase):
 
 		self.assertEqual(pln2.po_items[0].bom_no, bom2.name)
 
+	def test_production_plan_with_non_active_bom_item(self):
+		item = make_item("Test Production Item 1 for Non Active BOM", {"is_stock_item": 1}).name
+
+		so1 = make_sales_order(item_code=item, qty=1)
+
+		pln = frappe.new_doc("Production Plan")
+		pln.company = so1.company
+		pln.get_items_from = "Sales Order"
+		pln.append(
+			"sales_orders",
+			{
+				"sales_order": so1.name,
+				"sales_order_date": so1.transaction_date,
+				"customer": so1.customer,
+				"grand_total": so1.grand_total,
+			},
+		)
+
+		pln.get_items()
+
+		self.assertFalse(pln.po_items)
+
 	def test_production_plan_combine_items(self):
 		"Test combining FG items in Production Plan."
 		item = "Test Production Item 1"


### PR DESCRIPTION
**Issue**

If the item doesn't have an active BOM then the system throws an error "BOM No is Mandatory"
<img width="1069" alt="Screenshot 2024-06-10 at 11 07 53 AM" src="https://github.com/frappe/erpnext/assets/8780500/bfec2284-3ee3-47eb-9aea-98c205916afb">


**Solution**

Fetch items in the production plan which has an active BOM
