### PR TITLE
fix: terms and conditions for material request

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -801,6 +801,11 @@ def get_requested_item_qty(sales_order):
 def make_material_request(source_name, target_doc=None):
 	requested_item_qty = get_requested_item_qty(source_name)
 
+	def postprocess(source, target):
+		if source.tc_name and frappe.db.get_value("Terms and Conditions", source.tc_name, "buying") != 1:
+			target.tc_name = None
+			target.terms = None
+
 	def get_remaining_qty(so_item):
 		return flt(
 			flt(so_item.qty)
@@ -856,6 +861,7 @@ def make_material_request(source_name, target_doc=None):
 			},
 		},
 		target_doc,
+		postprocess,
 	)
 
 	return doc


### PR DESCRIPTION
While making Material Request from the sales order, system copy the selling terms and conditions from sales order to material request. The material request should have terms and conditions related to Buying