### PR TITLE
refactor: allow foreign currency advance accounts

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -1341,7 +1341,7 @@ class PaymentEntry(AccountsController):
 
 		dr_or_cr, account = self.get_dr_and_account_for_advances(invoice)
 		args_dict["account"] = account
-		args_dict[dr_or_cr] = invoice.allocated_amount
+		args_dict[dr_or_cr] = self.calculate_base_allocated_amount_for_reference(invoice)
 		args_dict[dr_or_cr + "_in_account_currency"] = invoice.allocated_amount
 		args_dict.update(
 			{
@@ -1360,7 +1360,7 @@ class PaymentEntry(AccountsController):
 		args_dict[dr_or_cr + "_in_account_currency"] = 0
 		dr_or_cr = "debit" if dr_or_cr == "credit" else "credit"
 		args_dict["account"] = self.party_account
-		args_dict[dr_or_cr] = invoice.allocated_amount
+		args_dict[dr_or_cr] = self.calculate_base_allocated_amount_for_reference(invoice)
 		args_dict[dr_or_cr + "_in_account_currency"] = invoice.allocated_amount
 		args_dict.update(
 			{

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -158,7 +158,6 @@ class PaymentEntry(AccountsController):
 		self.setup_party_account_field()
 		self.set_missing_values()
 		self.set_liability_account()
-		self.validate_advance_account_currency()
 		self.set_missing_ref_details(force=True)
 		self.validate_payment_type()
 		self.validate_party_details()

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -242,22 +242,6 @@ class PaymentEntry(AccountsController):
 			alert=True,
 		)
 
-	def validate_advance_account_currency(self):
-		if self.book_advance_payments_in_separate_party_account is True:
-			company_currency = frappe.get_cached_value("Company", self.company, "default_currency")
-			if self.payment_type == "Receive" and self.paid_from_account_currency != company_currency:
-				frappe.throw(
-					_("Booking advances in foreign currency account: {0} ({1}) is not yet supported.").format(
-						frappe.bold(self.paid_from), frappe.bold(self.paid_from_account_currency)
-					)
-				)
-			if self.payment_type == "Pay" and self.paid_to_account_currency != company_currency:
-				frappe.throw(
-					_("Booking advances in foreign currency account: {0} ({1}) is not yet supported.").format(
-						frappe.bold(self.paid_to), frappe.bold(self.paid_to_account_currency)
-					)
-				)
-
 	def on_cancel(self):
 		self.ignore_linked_doctypes = (
 			"GL Entry",

--- a/erpnext/accounts/doctype/subscription/test_subscription.py
+++ b/erpnext/accounts/doctype/subscription/test_subscription.py
@@ -476,7 +476,7 @@ class TestSubscription(FrappeTestCase):
 			start_date="2021-01-01",
 			submit_invoice=0,
 			generate_new_invoices_past_due_date=1,
-			party="_Test Subscription Customer",
+			party="_Test Subscription Customer John Doe",
 		)
 
 		# create invoices for the first two moths
@@ -567,6 +567,12 @@ def create_parties():
 		customer.customer_name = "_Test Subscription Customer"
 		customer.default_currency = "USD"
 		customer.append("accounts", {"company": "_Test Company", "account": "_Test Receivable USD - _TC"})
+		customer.insert()
+
+	if not frappe.db.exists("Customer", "_Test Subscription Customer John Doe"):
+		customer = frappe.new_doc("Customer")
+		customer.customer_name = "_Test Subscription Customer John Doe"
+		customer.append("accounts", {"company": "_Test Company", "account": "_Test Receivable - _TC"})
 		customer.insert()
 
 

--- a/erpnext/accounts/doctype/subscription/test_subscription.py
+++ b/erpnext/accounts/doctype/subscription/test_subscription.py
@@ -565,7 +565,7 @@ def create_parties():
 	if not frappe.db.exists("Customer", "_Test Subscription Customer"):
 		customer = frappe.new_doc("Customer")
 		customer.customer_name = "_Test Subscription Customer"
-		customer.billing_currency = "USD"
+		customer.default_currency = "USD"
 		customer.append("accounts", {"company": "_Test Company", "account": "_Test Receivable USD - _TC"})
 		customer.insert()
 

--- a/erpnext/buying/doctype/supplier/supplier.py
+++ b/erpnext/buying/doctype/supplier/supplier.py
@@ -138,6 +138,7 @@ class Supplier(TransactionBase):
 		validate_party_accounts(self)
 		self.validate_internal_supplier()
 		self.add_role_for_user()
+		self.validate_currency_for_receivable_payable_and_advance_account()
 
 	@frappe.whitelist()
 	def get_supplier_group_details(self):

--- a/erpnext/buying/doctype/supplier/test_records.json
+++ b/erpnext/buying/doctype/supplier/test_records.json
@@ -35,6 +35,7 @@
   "doctype": "Supplier",
   "supplier_name": "_Test Supplier USD",
   "supplier_group": "_Test Supplier Group",
+  "default_currency": "USD",
   "accounts": [{
     "company": "_Test Company",
     "account": "_Test Payable USD - _TC"

--- a/erpnext/controllers/accounts_controller.py
+++ b/erpnext/controllers/accounts_controller.py
@@ -1435,10 +1435,13 @@ class AccountsController(TransactionBase):
 					if d.exchange_gain_loss and (
 						(d.reference_doctype, d.reference_name, str(d.idx)) not in booked
 					):
-						if self.payment_type == "Receive":
-							party_account = self.paid_from
-						elif self.payment_type == "Pay":
-							party_account = self.paid_to
+						if self.book_advance_payments_in_separate_party_account:
+							party_account = d.account
+						else:
+							if self.payment_type == "Receive":
+								party_account = self.paid_from
+							elif self.payment_type == "Pay":
+								party_account = self.paid_to
 
 						dr_or_cr = "debit" if d.exchange_gain_loss > 0 else "credit"
 

--- a/erpnext/selling/doctype/customer/customer.py
+++ b/erpnext/selling/doctype/customer/customer.py
@@ -144,6 +144,7 @@ class Customer(TransactionBase):
 		self.validate_default_bank_account()
 		self.validate_internal_customer()
 		self.add_role_for_user()
+		self.validate_currency_for_receivable_payable_and_advance_account()
 
 		# set loyalty program tier
 		if frappe.db.exists("Customer", self.name):

--- a/erpnext/selling/doctype/customer/test_records.json
+++ b/erpnext/selling/doctype/customer/test_records.json
@@ -47,6 +47,7 @@
   "customer_type": "Individual",
   "doctype": "Customer",
   "territory": "_Test Territory",
+  "default_currency": "USD",
   "accounts": [{
 	  "company": "_Test Company",
 	  "account": "_Test Receivable USD - _TC"

--- a/erpnext/setup/doctype/customer_group/customer_group.py
+++ b/erpnext/setup/doctype/customer_group/customer_group.py
@@ -38,6 +38,53 @@ class CustomerGroup(NestedSet):
 	def validate(self):
 		if not self.parent_customer_group:
 			self.parent_customer_group = get_root_of("Customer Group")
+		self.validate_currency_for_receivable_and_advance_account()
+
+	def validate_currency_for_receivable_and_advance_account(self):
+		for x in self.accounts:
+			company_default_currency = frappe.get_cached_value("Company", x.company, "default_currency")
+			receivable_account_currency = None
+			advance_account_currency = None
+
+			if x.account:
+				receivable_account_currency = frappe.get_cached_value(
+					"Account", x.account, "account_currency"
+				)
+
+			if x.advance_account:
+				advance_account_currency = frappe.get_cached_value(
+					"Account", x.advance_account, "account_currency"
+				)
+
+			if receivable_account_currency and receivable_account_currency != company_default_currency:
+				frappe.throw(
+					_("Receivable Account: {0} must be in Company default currency: {1}").format(
+						frappe.bold(x.account),
+						frappe.bold(company_default_currency),
+					)
+				)
+
+			if advance_account_currency and advance_account_currency != company_default_currency:
+				frappe.throw(
+					_("Advance Account: {0} must be in Company default currency: {1}").format(
+						frappe.bold(x.advance_account), frappe.bold(company_default_currency)
+					)
+				)
+
+			if (
+				receivable_account_currency
+				and advance_account_currency
+				and receivable_account_currency != advance_account_currency
+			):
+				frappe.throw(
+					_(
+						"Both Receivable Account: {0} and Advance Account: {1} must be of same currency for company: {2}"
+					).format(
+						frappe.bold(x.account),
+						frappe.bold(x.advance_account),
+						frappe.bold(x.company),
+					)
+				)
 
 	def on_update(self):
 		super().on_update()

--- a/erpnext/setup/doctype/supplier_group/supplier_group.py
+++ b/erpnext/setup/doctype/supplier_group/supplier_group.py
@@ -3,6 +3,7 @@
 
 
 import frappe
+from frappe import _
 from frappe.utils.nestedset import NestedSet, get_root_of
 
 
@@ -32,6 +33,51 @@ class SupplierGroup(NestedSet):
 	def validate(self):
 		if not self.parent_supplier_group:
 			self.parent_supplier_group = get_root_of("Supplier Group")
+		self.validate_currency_for_payable_and_advance_account()
+
+	def validate_currency_for_payable_and_advance_account(self):
+		for x in self.accounts:
+			company_default_currency = frappe.get_cached_value("Company", x.company, "default_currency")
+			payable_account_currency = None
+			advance_account_currency = None
+
+			if x.account:
+				payable_account_currency = frappe.get_cached_value("Account", x.account, "account_currency")
+
+			if x.advance_account:
+				advance_account_currency = frappe.get_cached_value(
+					"Account", x.advance_account, "account_currency"
+				)
+
+			if payable_account_currency and payable_account_currency != company_default_currency:
+				frappe.throw(
+					_("Payable Account: {0} must be in Company default currency: {1}").format(
+						frappe.bold(x.account),
+						frappe.bold(company_default_currency),
+					)
+				)
+
+			if advance_account_currency and advance_account_currency != company_default_currency:
+				frappe.throw(
+					_("Advance Account: {0} must be in Company default currency: {1}").format(
+						frappe.bold(x.advance_account), frappe.bold(company_default_currency)
+					)
+				)
+
+			if (
+				payable_account_currency
+				and advance_account_currency
+				and payable_account_currency != advance_account_currency
+			):
+				frappe.throw(
+					_(
+						"Both Payable Account: {0} and Advance Account: {1} must be of same currency for company: {2}"
+					).format(
+						frappe.bold(x.account),
+						frappe.bold(x.advance_account),
+						frappe.bold(x.company),
+					)
+				)
 
 	def on_update(self):
 		NestedSet.on_update(self)

--- a/erpnext/utilities/transaction_base.py
+++ b/erpnext/utilities/transaction_base.py
@@ -191,9 +191,11 @@ class TransactionBase(StatusUpdater):
 				):
 					frappe.throw(
 						_(
-							"{0} Account must be in either customer billing currency: {1} or Company default currency: {2}"
+							"{0} Account: {1} ({2}) must be in either customer billing currency: {3} or Company default currency: {4}"
 						).format(
 							account_type,
+							frappe.bold(x.account),
+							frappe.bold(receivable_payable_account_currency),
 							frappe.bold(self.default_currency),
 							frappe.bold(company_default_currency),
 						)
@@ -205,8 +207,12 @@ class TransactionBase(StatusUpdater):
 				):
 					frappe.throw(
 						_(
-							"Advance Account must be in either customer billing currency: {0} or Company default currency: {1}"
-						).format(frappe.bold(self.default_currency), frappe.bold(company_default_currency))
+							"Advance Account: {0} must be in either customer billing currency: {1} or Company default currency: {2}"
+						).format(
+							frappe.bold(x.advance_account),
+							frappe.bold(self.default_currency),
+							frappe.bold(company_default_currency),
+						)
 					)
 
 				if (

--- a/erpnext/utilities/transaction_base.py
+++ b/erpnext/utilities/transaction_base.py
@@ -168,6 +168,63 @@ class TransactionBase(StatusUpdater):
 		if len(child_table_values) > 1:
 			self.set(default_field, None)
 
+	def validate_currency_for_receivable_payable_and_advance_account(self):
+		if self.doctype in ["Customer", "Supplier"]:
+			account_type = "Receivable" if self.doctype == "Customer" else "Payable"
+			for x in self.accounts:
+				company_default_currency = frappe.get_cached_value("Company", x.company, "default_currency")
+				receivable_payable_account_currency = None
+				advance_account_currency = None
+
+				if x.account:
+					receivable_payable_account_currency = frappe.get_cached_value(
+						"Account", x.account, "account_currency"
+					)
+
+				if x.advance_account:
+					advance_account_currency = frappe.get_cached_value(
+						"Account", x.advance_account, "account_currency"
+					)
+				if receivable_payable_account_currency and (
+					receivable_payable_account_currency != self.default_currency
+					and receivable_payable_account_currency != company_default_currency
+				):
+					frappe.throw(
+						_(
+							"{0} Account must be in either customer billing currency: {1} or Company default currency: {2}"
+						).format(
+							account_type,
+							frappe.bold(self.default_currency),
+							frappe.bold(company_default_currency),
+						)
+					)
+
+				if advance_account_currency and (
+					advance_account_currency != self.default_currency
+					and advance_account_currency != company_default_currency
+				):
+					frappe.throw(
+						_(
+							"Advance Account must be in either customer billing currency: {0} or Company default currency: {1}"
+						).format(frappe.bold(self.default_currency), frappe.bold(company_default_currency))
+					)
+
+				if (
+					receivable_payable_account_currency
+					and advance_account_currency
+					and receivable_payable_account_currency != advance_account_currency
+				):
+					frappe.throw(
+						_(
+							"Both {0} Account: {1} and Advance Account: {2} must be of same currency for company: {3}"
+						).format(
+							account_type,
+							frappe.bold(x.account),
+							frappe.bold(x.advance_account),
+							frappe.bold(x.company),
+						)
+					)
+
 
 def delete_events(ref_type, ref_name):
 	events = (


### PR DESCRIPTION
extends: https://github.com/frappe/erpnext/pull/35609

Advance accounts can be in either: Customer Billing currency or Company default currency.

Consider a customer with billing currency: USD and a company default billing currency: INR. Below configurations are allowed and supported,

| Receivable/Payable Account Currency | Advance Payment Account currency | Allowed |
|-|-|-|
| INR              | USD                              | No      |
| USD              | INR                              | No      |
| INR              | INR                              | Yes     |
| USD              | USD                              | Yes     |


Validations are added to enforce this.
