### PR TITLE
fix sort_shipping_rule_conditions method

### DIFF
--- a/erpnext/accounts/doctype/shipping_rule/shipping_rule.py
+++ b/erpnext/accounts/doctype/shipping_rule/shipping_rule.py
@@ -166,8 +166,8 @@ class ShippingRule(Document):
 
 	def sort_shipping_rule_conditions(self):
 		"""Sort Shipping Rule Conditions based on increasing From Value"""
-		self.shipping_rules_conditions = sorted(self.conditions, key=lambda d: flt(d.from_value))
-		for i, d in enumerate(self.conditions):
+		sorted_shipping_rules_conditions = sorted(self.conditions, key=lambda d: flt(d.from_value))
+		for i, d in enumerate(sorted_shipping_rules_conditions):
 			d.idx = i + 1
 
 	def validate_overlapping_shipping_rule_conditions(self):


### PR DESCRIPTION
by not passing the sorted conditions to the enumerate function, it did nothing, now that we pass it the proper argument it properly sorts the conditions.