### PR TITLE
fix: filter for provisional expense account in purchase receipt

### DIFF
--- a/erpnext/stock/doctype/purchase_receipt/purchase_receipt.js
+++ b/erpnext/stock/doctype/purchase_receipt/purchase_receipt.js
@@ -39,6 +39,12 @@ frappe.ui.form.on("Purchase Receipt", {
 			};
 		});
 
+		frm.set_query("provisional_expense_account", "items", function () {
+			return {
+				filters: { company: frm.doc.company, is_group: 0},
+			};
+		});
+
 		frm.set_query("wip_composite_asset", "items", function () {
 			return {
 				filters: { is_composite_asset: 1, docstatus: 0 },


### PR DESCRIPTION
Filter for provisional expense account in purchase receipt

@rohitwaghchaure @s-aga-r please check