### PR TITLE
fix: download materials request plan in PP

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.js
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.js
@@ -402,7 +402,7 @@ frappe.ui.form.on("Production Plan", {
 	download_materials_required(frm) {
 		const warehouses_data = [
 			{
-				warehouse: frm.doc.for_warehouse
+				warehouse: frm.doc.for_warehouse,
 			},
 		];
 		const fields = [

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.js
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.js
@@ -400,9 +400,11 @@ frappe.ui.form.on("Production Plan", {
 	},
 
 	download_materials_required(frm) {
-		const warehouses_data = [{
-			warehouse: frm.doc.for_warehouse
-		}];
+		const warehouses_data = [
+			{
+				warehouse: frm.doc.for_warehouse
+			},
+		];
 		const fields = [
 			{
 				fieldname: "warehouses",

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.js
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.js
@@ -400,13 +400,17 @@ frappe.ui.form.on("Production Plan", {
 	},
 
 	download_materials_required(frm) {
+		const warehouses_data = [{
+			warehouse: frm.doc.for_warehouse
+		}];
 		const fields = [
 			{
 				fieldname: "warehouses",
 				fieldtype: "Table MultiSelect",
 				label: __("Warehouses"),
-				default: frm.doc.from_warehouse,
+				default: warehouses_data,
 				options: "Production Plan Material Request Warehouse",
+				reqd: 1,
 				get_query: function () {
 					return {
 						filters: {


### PR DESCRIPTION
Version: 15 & 14

fixes: #41862


- In production plan does not have any field called `frm.doc.from_warehouse`

https://github.com/frappe/erpnext/blob/7249a691b3ab24fc6ecb80545ff9a17b8d60a12d/erpnext/manufacturing/doctype/production_plan/production_plan.js#L408

**Before:**


https://github.com/frappe/erpnext/assets/141945075/404b29bc-6b85-46e7-b193-eb2184fca3b7


**After:**


https://github.com/frappe/erpnext/assets/141945075/e67d9187-9836-4fb7-b73b-f4c71d95f5c7

