### PR TITLE
removed deprecated keyword argument 'print_logs'

### DIFF
--- a/erpnext/setup/doctype/employee/employee.py
+++ b/erpnext/setup/doctype/employee/employee.py
@@ -87,7 +87,7 @@ class Employee(NestedSet):
 	def update_user_permissions(self):
 		if not self.create_user_permission:
 			return
-		if not has_permission("User Permission", ptype="write", print_logs=False):
+		if not has_permission("User Permission", ptype="write"):
 			return
 
 		employee_user_permission_exists = frappe.db.exists(
@@ -254,7 +254,7 @@ def validate_employee_role(doc, method=None, ignore_emp_check=False):
 def update_user_permissions(doc, method):
 	# called via User hook
 	if "Employee" in [d.role for d in doc.get("roles")]:
-		if not has_permission("User Permission", ptype="write", print_logs=False):
+		if not has_permission("User Permission", ptype="write"):
 			return
 		employee = frappe.get_doc("Employee", {"user_id": doc.name})
 		employee.update_user_permissions()


### PR DESCRIPTION
Removed deprecated keyword argument 'print_logs' from the has_permission check. Caused this error:
`has_permission() got an unexpected keyword argument 'print_logs'`

