### PR TITLE
fix: download materials request plan in production plan

### DIFF
--- a/erpnext/manufacturing/doctype/production_plan/production_plan.js
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.js
@@ -400,10 +400,10 @@ frappe.ui.form.on("Production Plan", {
 	},
 
 	download_materials_required(frm) {
-		const warehousesData = [];
+		const warehouses_data = [];
 
 		if (frm.doc.for_warehouse) {
-			warehousesData.push({ warehouse: frm.doc.for_warehouse });
+			warehouses_data.push({ warehouse: frm.doc.for_warehouse });
 		}
 
 		const fields = [
@@ -411,7 +411,7 @@ frappe.ui.form.on("Production Plan", {
 				fieldname: "warehouses",
 				fieldtype: "Table MultiSelect",
 				label: __("Warehouses"),
-				default: warehousesData,
+				default: warehouses_data,
 				options: "Production Plan Material Request Warehouse",
 				reqd: 1,
 				get_query: function () {

--- a/erpnext/manufacturing/doctype/production_plan/production_plan.js
+++ b/erpnext/manufacturing/doctype/production_plan/production_plan.js
@@ -400,17 +400,18 @@ frappe.ui.form.on("Production Plan", {
 	},
 
 	download_materials_required(frm) {
-		const warehouses_data = [
-			{
-				warehouse: frm.doc.for_warehouse,
-			},
-		];
+		const warehousesData = [];
+
+		if (frm.doc.for_warehouse) {
+			warehousesData.push({ warehouse: frm.doc.for_warehouse });
+		}
+
 		const fields = [
 			{
 				fieldname: "warehouses",
 				fieldtype: "Table MultiSelect",
 				label: __("Warehouses"),
-				default: warehouses_data,
+				default: warehousesData,
 				options: "Production Plan Material Request Warehouse",
 				reqd: 1,
 				get_query: function () {


### PR DESCRIPTION
Version: 15 & 14

fixes: https://github.com/frappe/erpnext/issues/41862

**Issue:**
When the for_warehouse field in the form is not selected, the warehouses_data array incorrectly includes an object with warehouse: empty string(''). This results in displaying empty string('') in the UI, which is not the desired behavior.

**Changes Made:**
Updated the JavaScript code to check if frm.doc.for_warehouse is not an empty string before adding the warehouse property to the warehouses_data array.
If frm.doc.for_warehouse is an empty string, the array will not include the warehouse property, thus avoiding the display of empty string('') in the UI.

Before:
[Before.webm](https://github.com/frappe/erpnext/assets/117427350/424e4b27-e6de-4fbf-ad56-dde1097f1f28)


After:
[After.webm](https://github.com/frappe/erpnext/assets/117427350/915610a4-57ef-41a2-8af4-39639e0b7944)
