### PR TITLE
fix: item_code filter in item-wise sales-purchase register

### DIFF
--- a/erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py
+++ b/erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py
@@ -289,7 +289,7 @@ def get_columns(additional_table_columns, filters):
 
 
 def apply_conditions(query, pi, pii, filters):
-	for opts in ("company", "supplier", "item_code", "mode_of_payment"):
+	for opts in ("company", "supplier", "mode_of_payment"):
 		if filters.get(opts):
 			query = query.where(pi[opts] == filters[opts])
 
@@ -298,6 +298,9 @@ def apply_conditions(query, pi, pii, filters):
 
 	if filters.get("to_date"):
 		query = query.where(pi.posting_date <= filters.get("to_date"))
+
+	if filters.get("item_code"):
+		query = query.where(pii.item_code == filters.get("item_code"))
 
 	if filters.get("item_group"):
 		query = query.where(pii.item_group == filters.get("item_group"))

--- a/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.js
+++ b/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.js
@@ -55,6 +55,12 @@ frappe.query_reports["Item-wise Sales Register"] = {
 			options: "Brand",
 		},
 		{
+			fieldname: "item_code",
+			label: __("Item"),
+			fieldtype: "Link",
+			options: "Item",
+		},
+		{
 			fieldname: "item_group",
 			label: __("Item Group"),
 			fieldtype: "Link",

--- a/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py
+++ b/erpnext/accounts/report/item_wise_sales_register/item_wise_sales_register.py
@@ -342,7 +342,7 @@ def get_columns(additional_table_columns, filters):
 
 
 def apply_conditions(query, si, sii, filters, additional_conditions=None):
-	for opts in ("company", "customer", "item_code"):
+	for opts in ("company", "customer"):
 		if filters.get(opts):
 			query = query.where(si[opts] == filters[opts])
 
@@ -370,6 +370,9 @@ def apply_conditions(query, si, sii, filters, additional_conditions=None):
 
 	if filters.get("brand"):
 		query = query.where(sii.brand == filters.get("brand"))
+
+	if filters.get("item_code"):
+		query = query.where(sii.item_code == filters.get("item_code"))
 
 	if filters.get("item_group"):
 		query = query.where(sii.item_group == filters.get("item_group"))


### PR DESCRIPTION
Version 15

fixes: #41910

**Before:**

- Item code field is in the Sales Invoice Item or Purchase Invoice Item, **is not a field of Sales Invoice or Purchase Invoice**.


https://github.com/frappe/erpnext/assets/141945075/699a4f32-e077-48e0-8e3d-9373e013c53d


**After:**

- Also add the item code filter in the item-wise sales register.

https://github.com/frappe/erpnext/assets/141945075/1e348ca0-1386-4399-b89c-2dc5fc9d6e81

