### PR TITLE
fix: duplicate rows fetching in RFQ

### DIFF
--- a/erpnext/public/js/utils.js
+++ b/erpnext/public/js/utils.js
@@ -934,7 +934,13 @@ erpnext.utils.map_current_doc = function (opts) {
 					frappe.msgprint(__("Please select {0}", [opts.source_doctype]));
 					return;
 				}
-				opts.source_name = values;
+
+				if (values.constructor === Array) {
+					opts.source_name = [...new Set(values)];
+				} else {
+					opts.source_name = values;
+				}
+
 				if (
 					opts.allow_child_item_selection ||
 					["Purchase Receipt", "Delivery Note"].includes(opts.source_doctype)


### PR DESCRIPTION
**Issue**

1. Create 2 Material Request with same 2 items with different qty and of same item group as "Products" and submit it.
2. Create Request for Quotation using Get Item From —> Material Request.
3. Apply filter of Item Group(Material Request Item) and select Material Request. 
4. System will add same line item two times (see below GIF)


![rfq_get_items_issue](https://github.com/frappe/erpnext/assets/8780500/1b104da5-b308-4572-b715-49b09c6110ec)


**After Fix**


![rfq_get_items_after_fix](https://github.com/frappe/erpnext/assets/8780500/bc85c536-8dfe-4382-89d5-4b6aa66af585)

