### PR TITLE
fix: consistent query field name in item wise purchase register with item wise sales register

### DIFF
--- a/erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py
+++ b/erpnext/accounts/report/item_wise_purchase_register/item_wise_purchase_register.py
@@ -322,7 +322,7 @@ def get_items(filters, additional_table_columns):
 		.left_join(Item)
 		.on(pii.item_code == Item.name)
 		.select(
-			pii.name.as_("pii_name"),
+			pii.name,
 			pii.parent,
 			pi.posting_date,
 			pi.credit_to,


### PR DESCRIPTION
The get_tax_accounts function was using the invoice_item.name field, which caused an issue in the purchase register because the item name was aliased as pii_item_name. This discrepancy led to taxes not being calculated correctly in the purchase register. This PR fixes the aliasing issue to ensure proper tax calculation.

Changes Made

- Removed alias

Impact

- Accurate tax calculations in the item-wise purchase register.

Testing

- Verified that taxes are now calculated correctly in both item-wise sales and purchase registers.Item wise purchase rigster report uses same function as item wise sales register.

Support Issue: 
- https://support.frappe.io/app/hd-ticket/17213
- https://support.frappe.io/app/hd-ticket/17268


