### PR TITLE
fix: received_qty not set

### DIFF
--- a/erpnext/buying/doctype/purchase_order/purchase_order.py
+++ b/erpnext/buying/doctype/purchase_order/purchase_order.py
@@ -696,6 +696,7 @@ def set_missing_values(source, target):
 def make_purchase_receipt(source_name, target_doc=None):
 	def update_item(obj, target, source_parent):
 		target.qty = flt(obj.qty) - flt(obj.received_qty)
+		target.received_qty = target.qty
 		target.stock_qty = (flt(obj.qty) - flt(obj.received_qty)) * flt(obj.conversion_factor)
 		target.amount = (flt(obj.qty) - flt(obj.received_qty)) * flt(obj.rate)
 		target.base_amount = (


### PR DESCRIPTION
While making purchase receipt from purchase order, received_qty not set in the line item which cause the below error

<img width="507" alt="image" src="https://github.com/frappe/erpnext/assets/8780500/9a1bc185-f8e7-42f0-b88d-a1617320d53f">
