### PR TITLE
#39472 Update on Valuation Method for Items with Moving Average

### DIFF
--- a/erpnext/__init__.py
+++ b/erpnext/__init__.py
@@ -3,7 +3,7 @@ import inspect
 
 import frappe
 
-__version__ = "15.27.6"
+__version__ = "15.27.7"
 
 
 def get_default_company(user=None):

--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -745,7 +745,7 @@ class update_entries_after:
 				if sle.get(dimension.get("fieldname")):
 					has_dimensions = True
 
-		if sle.serial_and_batch_bundle:
+		if sle.serial_and_batch_bundle and self.valuation_method != "Moving Average":
 			self.calculate_valuation_for_serial_batch_bundle(sle)
 		elif sle.serial_no and not self.args.get("sle_id"):
 			# Only run in reposting


### PR DESCRIPTION
This changes applies like this: if Moving Average is set as the default valuation method in the company, or if item is specified to use the Moving Average method, the system will now prioritize this method over the purchase rate of the Serial or Batch Bundle.

This change ensures that inventory valuation remains consistent and aligns with the preferred accounting practices set in the configurations.

Reference: #39472