### PR TITLE
fix: incorrect discount on other item

### DIFF
--- a/erpnext/public/js/controllers/transaction.js
+++ b/erpnext/public/js/controllers/transaction.js
@@ -1743,6 +1743,10 @@ erpnext.TransactionController = class TransactionController extends erpnext.taxe
 				me.frm.doc.items.forEach(d => {
 					if (in_list(JSON.parse(data.apply_rule_on_other_items), d[data.apply_rule_on])) {
 						for(var k in data) {
+							if (data.pricing_rule_for == "Discount Percentage" && data.apply_rule_on_other_items && k == "discount_amount") {
+								continue;
+							}
+
 							if (in_list(fields, k) && data[k] && (data.price_or_product_discount === 'Price' || k === 'pricing_rules')) {
 								frappe.model.set_value(d.doctype, d.name, k, data[k]);
 							}


### PR DESCRIPTION
When discount is applied on other item, don't update `discount_amount` value returned from server side, as that amount is calculated for the current items. Fixing this logic on server-side looks difficult at the moment, as the methods only work in the current items' context.

Only updating the discount percentage is enough, as the rest of the UI logic will recalculate the discounted amount for that other item.

Ex:
1. Create a Pricing rule with Discount on Other item enabled for `brand`. 
![Screenshot from 2024-06-20 12-50-47](https://github.com/frappe/erpnext/assets/3272205/1c0945d7-20e0-49f0-8339-1fc1a2d230ee)

2. Make Sales Invoice with the primary item on which the rule will be triggered and the discounted item 

Before:

https://github.com/frappe/erpnext/assets/3272205/8adffcef-d841-405e-a00c-bff92a29a6a1



After:

https://github.com/frappe/erpnext/assets/3272205/4bfc467d-1f1d-4ef4-8fee-9a61010512ac


