### PR TITLE
fix: expense account from item group not fetched

### DIFF
--- a/erpnext/stock/doctype/stock_entry/stock_entry.py
+++ b/erpnext/stock/doctype/stock_entry/stock_entry.py
@@ -1650,7 +1650,7 @@ class StockEntry(StockController):
 				"has_serial_no": item.has_serial_no,
 				"has_batch_no": item.has_batch_no,
 				"sample_quantity": item.sample_quantity,
-				"expense_account": item.expense_account,
+				"expense_account": item.expense_account or item_group_defaults.get("expense_account"),
 			}
 		)
 


### PR DESCRIPTION
expense account set in the Item group not fetching in the stock entry 