### PR TITLE
fix: move condition for shipment

### DIFF
--- a/erpnext/stock/doctype/delivery_note/delivery_note.js
+++ b/erpnext/stock/doctype/delivery_note/delivery_note.js
@@ -188,8 +188,8 @@ erpnext.stock.DeliveryNoteController = class DeliveryNoteController extends (
 			);
 		}
 
-		if (!doc.is_return && doc.status != "Closed" && frappe.model.can_create("Shipment")) {
-			if (doc.docstatus == 1) {
+		if (!doc.is_return && doc.status != "Closed") {
+			if (doc.docstatus == 1 && frappe.model.can_create("Shipment")) {
 				this.frm.add_custom_button(
 					__("Shipment"),
 					function () {


### PR DESCRIPTION
Does not need backports (it's included in the backports of the original PR that introduced this issue).