### PR TITLE
fix: pricing rule with and without 'apply multiple' and priority

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
@@ -1237,6 +1237,68 @@ class TestPricingRule(unittest.TestCase):
 		frappe.delete_doc_if_exists("Pricing Rule", "_Test Pricing Rule 1")
 		frappe.delete_doc_if_exists("Pricing Rule", "_Test Pricing Rule 2")
 
+	def test_pricing_rules_with_and_without_apply_multiple(self):
+		item = make_item("PR Item 99")
+
+		test_records = [
+			{
+				"doctype": "Pricing Rule",
+				"title": "_Test discount on item group",
+				"name": "_Test discount on item group",
+				"apply_on": "Item Group",
+				"item_groups": [
+					{
+						"item_group": "Products",
+					}
+				],
+				"selling": 1,
+				"price_or_product_discount": "Price",
+				"rate_or_discount": "Discount Percentage",
+				"discount_percentage": 60,
+				"has_priority": 1,
+				"company": "_Test Company",
+				"apply_multiple_pricing_rules": True,
+			},
+			{
+				"doctype": "Pricing Rule",
+				"title": "_Test fixed rate on item code",
+				"name": "_Test fixed rate on item code",
+				"apply_on": "Item Code",
+				"items": [
+					{
+						"item_code": item.name,
+					}
+				],
+				"selling": 1,
+				"price_or_product_discount": "Price",
+				"rate_or_discount": "Rate",
+				"rate": 25,
+				"has_priority": 1,
+				"company": "_Test Company",
+				"apply_multiple_pricing_rules": False,
+			},
+		]
+
+		for item_group_priority, item_code_priority in [(2, 4), (4, 2)]:
+			item_group_rule = frappe.get_doc(test_records[0].copy())
+			item_group_rule.priority = item_group_priority
+			item_group_rule.insert()
+
+			item_code_rule = frappe.get_doc(test_records[1].copy())
+			item_code_rule.priority = item_code_priority
+			item_code_rule.insert()
+
+			si = create_sales_invoice(qty=5, customer="_Test Customer 1", item=item.name, do_not_submit=True)
+			si.save()
+			self.assertEqual(len(si.pricing_rules), 1)
+			# Item Code rule should've applied as it has higher priority
+			expected_rule = item_group_rule if item_group_priority > item_code_priority else item_code_rule
+			self.assertEqual(si.pricing_rules[0].pricing_rule, expected_rule.name)
+
+			si.delete()
+			item_group_rule.delete()
+			item_code_rule.delete()
+
 
 test_dependencies = ["Campaign"]
 

--- a/erpnext/accounts/doctype/pricing_rule/utils.py
+++ b/erpnext/accounts/doctype/pricing_rule/utils.py
@@ -174,12 +174,9 @@ def _get_pricing_rules(apply_on, args, values):
 
 
 def apply_multiple_pricing_rules(pricing_rules):
-	apply_multiple_rule = [
-		d.apply_multiple_pricing_rules for d in pricing_rules if d.apply_multiple_pricing_rules
-	]
-
-	if not apply_multiple_rule:
-		return False
+	for d in pricing_rules:
+		if not d.apply_multiple_pricing_rules:
+			return False
 
 	return True
 


### PR DESCRIPTION
Change in behavior on `Apply Multiple Pricing Rules`:
`Apply Multiple Pricing Rules` only takes effect when all the pricing rules identified for an item has it enabled. Else, Priority is applied and only the highest priority takes effect.

Combining rules with and without `Apply Multiple Pricing Rules` enabled doesn't make sense. Hence the change.