### PR TITLE
fix: incorrect against_account upon reposting

### DIFF
--- a/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+++ b/erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
@@ -578,13 +578,17 @@ class PurchaseInvoice(BuyingController):
 		for item in self.get("items"):
 			validate_account_head(item.idx, item.expense_account, self.company, "Expense")
 
-	def set_against_expense_account(self):
+	def set_against_expense_account(self, force=False):
 		against_accounts = []
 		for item in self.get("items"):
 			if item.expense_account and (item.expense_account not in against_accounts):
 				against_accounts.append(item.expense_account)
 
 		self.against_expense_account = ",".join(against_accounts)
+
+	def force_set_against_expense_account(self):
+		self.set_against_expense_account()
+		frappe.db.set_value(self.doctype, self.name, "against_expense_account", self.against_expense_account)
 
 	def po_required(self):
 		if frappe.db.get_single_value("Buying Settings", "po_required") == "Yes":

--- a/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
+++ b/erpnext/accounts/doctype/repost_accounting_ledger/repost_accounting_ledger.py
@@ -167,6 +167,10 @@ def start_repost(account_repost_doc=str) -> None:
 						doc.make_gl_entries_on_cancel()
 
 					doc.docstatus = 1
+					if doc.doctype == "Sales Invoice":
+						doc.force_set_against_income_account()
+					else:
+						doc.force_set_against_expense_account()
 					doc.make_gl_entries()
 
 				elif doc.doctype in ["Payment Entry", "Journal Entry", "Expense Claim"]:

--- a/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
+++ b/erpnext/accounts/doctype/sales_invoice/sales_invoice.py
@@ -959,6 +959,10 @@ class SalesInvoice(SellingController):
 				against_acc.append(d.income_account)
 		self.against_income_account = ",".join(against_acc)
 
+	def force_set_against_income_account(self):
+		self.set_against_income_account()
+		frappe.db.set_value(self.doctype, self.name, "against_income_account", self.against_income_account)
+
 	def add_remarks(self):
 		if not self.remarks:
 			if self.po_no and self.po_date:


### PR DESCRIPTION
Upon repost, `against_income_account` and `against_expense_account` on Sales/Purchase Invoice should be updated. This makes sure `against_account` reflects the latest accounts in Ledger