### PR TITLE
perf: dont run queries unnecessarily, improved filters

### DIFF
--- a/erpnext/controllers/subcontracting_controller.py
+++ b/erpnext/controllers/subcontracting_controller.py
@@ -301,10 +301,14 @@ class SubcontractingController(StockController):
 			return
 
 		voucher_nos = [d.voucher_no for d in consumed_materials if d.voucher_no]
-		voucher_bundle_data = get_voucher_wise_serial_batch_from_bundle(
-			voucher_no=voucher_nos,
-			is_outward=1,
-			get_subcontracted_item=("Subcontracting Receipt Supplied Item", "main_item_code"),
+		voucher_bundle_data = (
+			get_voucher_wise_serial_batch_from_bundle(
+				voucher_no=voucher_nos,
+				is_outward=1,
+				get_subcontracted_item=("Subcontracting Receipt Supplied Item", "main_item_code"),
+			)
+			if voucher_nos
+			else {}
 		)
 
 		for row in consumed_materials:
@@ -353,10 +357,14 @@ class SubcontractingController(StockController):
 		transferred_items = self.__get_transferred_items()
 
 		voucher_nos = [row.voucher_no for row in transferred_items]
-		voucher_bundle_data = get_voucher_wise_serial_batch_from_bundle(
-			voucher_no=voucher_nos,
-			is_outward=0,
-			get_subcontracted_item=("Stock Entry Detail", "subcontracted_item"),
+		voucher_bundle_data = (
+			get_voucher_wise_serial_batch_from_bundle(
+				voucher_no=voucher_nos,
+				is_outward=0,
+				get_subcontracted_item=("Stock Entry Detail", "subcontracted_item"),
+			)
+			if voucher_nos
+			else {}
 		)
 
 		for row in transferred_items:

--- a/erpnext/controllers/subcontracting_controller.py
+++ b/erpnext/controllers/subcontracting_controller.py
@@ -294,15 +294,18 @@ class SubcontractingController(StockController):
 		receipt_items = {item.name: item.get(self.subcontract_data.order_field) for item in receipt_items}
 		consumed_materials = self.__get_consumed_items(doctype, receipt_items.keys())
 
+		if return_consumed_items:
+			return (consumed_materials, receipt_items)
+
+		if not consumed_materials:
+			return
+
 		voucher_nos = [d.voucher_no for d in consumed_materials if d.voucher_no]
 		voucher_bundle_data = get_voucher_wise_serial_batch_from_bundle(
 			voucher_no=voucher_nos,
 			is_outward=1,
 			get_subcontracted_item=("Subcontracting Receipt Supplied Item", "main_item_code"),
 		)
-
-		if return_consumed_items:
-			return (consumed_materials, receipt_items)
 
 		for row in consumed_materials:
 			key = (row.rm_item_code, row.main_item_code, receipt_items.get(row.reference_name))

--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -2107,6 +2107,9 @@ def get_ledgers_from_serial_batch_bundle(**kwargs) -> list[frappe._dict]:
 		if val is None:
 			continue
 
+		if not val and isinstance(val, list):
+			return []
+
 		if key == "get_subcontracted_item":
 			continue
 

--- a/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/serial_and_batch_bundle.py
@@ -2104,10 +2104,10 @@ def get_ledgers_from_serial_batch_bundle(**kwargs) -> list[frappe._dict]:
 	)
 
 	for key, val in kwargs.items():
-		if not val:
+		if val is None:
 			continue
 
-		if key in ["get_subcontracted_item"]:
+		if key == "get_subcontracted_item":
 			continue
 
 		if key in ["name", "item_code", "warehouse", "voucher_no", "company", "voucher_detail_no"]:


### PR DESCRIPTION
Purchase Receipt that took 300 seconds to submit, now submitting in 2-3 seconds.

Internal Issue ID: **16614**

### Changes Made
- The data for `return_consumed_items` is now returned before `voucher_bundle_data` is fetched, because that is not changing the return value in any way.
- Avoiding unnecessary queries if there are no consumed materials by returning earlier.
- Some filters can be non-truthy values like `[]` (empty list) or `0`. They should still get applied in `get_ledgers_from_serial_batch_bundle`. Checking `None` values instead of non-truthy values now.