### PR TITLE
chore: patch to enable total number of booked depreciations field

### DIFF
--- a/erpnext/accounts/doctype/journal_entry/journal_entry.py
+++ b/erpnext/accounts/doctype/journal_entry/journal_entry.py
@@ -226,7 +226,7 @@ class JournalEntry(AccountsController):
 		self.unlink_inter_company_jv()
 		self.unlink_asset_adjustment_entry()
 		self.update_invoice_discounting()
-		self.update_booked_depreciation()
+		self.update_booked_depreciation(1)
 
 	def get_title(self):
 		return self.pay_to_recd_from or self.accounts[0].account
@@ -444,7 +444,7 @@ class JournalEntry(AccountsController):
 			if status:
 				inv_disc_doc.set_status(status=status)
 
-	def update_booked_depreciation(self):
+	def update_booked_depreciation(self, cancel=0):
 		for d in self.get("accounts"):
 			if (
 				self.voucher_type == "Depreciation Entry"
@@ -456,14 +456,11 @@ class JournalEntry(AccountsController):
 				asset = frappe.get_doc("Asset", d.reference_name)
 				for fb_row in asset.get("finance_books"):
 					if fb_row.finance_book == self.finance_book:
-						depr_schedule = get_depr_schedule(asset.name, "Active", fb_row.finance_book)
-						total_number_of_booked_depreciations = asset.opening_number_of_booked_depreciations
-						for je in depr_schedule:
-							if je.journal_entry:
-								total_number_of_booked_depreciations += 1
-						fb_row.db_set(
-							"total_number_of_booked_depreciations", total_number_of_booked_depreciations
-						)
+						if cancel:
+							fb_row.total_number_of_booked_depreciations -= 1
+						else:
+							fb_row.total_number_of_booked_depreciations += 1
+						fb_row.db_update()
 						break
 
 	def unlink_advance_entry_reference(self):

--- a/erpnext/patches.txt
+++ b/erpnext/patches.txt
@@ -370,3 +370,4 @@ erpnext.patches.v14_0.enable_set_priority_for_pricing_rules #1
 erpnext.patches.v15_0.rename_number_of_depreciations_booked_to_opening_booked_depreciations
 erpnext.patches.v15_0.add_default_operations
 erpnext.patches.v15_0.enable_old_serial_batch_fields
+erpnext.patches.v15_0.update_total_number_of_booked_depreciations

--- a/erpnext/patches/v15_0/update_total_number_of_booked_depreciations.py
+++ b/erpnext/patches/v15_0/update_total_number_of_booked_depreciations.py
@@ -1,0 +1,26 @@
+import frappe
+
+from erpnext.assets.doctype.asset_depreciation_schedule.asset_depreciation_schedule import (
+	get_depr_schedule,
+)
+
+
+def execute():
+	if frappe.db.has_column("Asset", "total_number_of_booked_depreciations"):
+		assets = frappe.get_all(
+			"Asset", filters={"docstatus": 1}, fields=["name", "opening_number_of_booked_depreciations"]
+		)
+
+		for asset in assets:
+			asset_doc = frappe.get_doc("Asset", asset.name)
+
+			for fb_row in asset_doc.get("finance_books"):
+				depr_schedule = get_depr_schedule(asset.name, "Active", fb_row.finance_book)
+				total_number_of_booked_depreciations = asset.opening_number_of_booked_depreciations or 0
+
+				for je in depr_schedule:
+					if je.journal_entry:
+						total_number_of_booked_depreciations += 1
+				fb_row.db_set("total_number_of_booked_depreciations", total_number_of_booked_depreciations)
+			asset_doc.save
+		frappe.db.commit()


### PR DESCRIPTION
This PR addresses a bug in the calculation of the "Total Number of Booked Depreciation" field by implementing a necessary patch that was overlooked during the initial release. Additionally, it includes optimisations to related code for improved system efficiency.
no-docs
