### PR TITLE
fix: batch picking in pick list based on Stock Settings

### DIFF
--- a/erpnext/stock/doctype/pick_list/pick_list.py
+++ b/erpnext/stock/doctype/pick_list/pick_list.py
@@ -963,6 +963,7 @@ def get_available_item_locations_for_batched_item(
 			{
 				"item_code": item_code,
 				"warehouse": from_warehouses,
+				"based_on": frappe.db.get_single_value("Stock Settings", "pick_serial_and_batch_based_on"),
 			}
 		)
 	)


### PR DESCRIPTION
Set "Pick Serial / Batch Based On" as "Expiry" in the stock settings, but still system picks the batch in the Pick List based on the creation date.

<img width="638" alt="image" src="https://github.com/frappe/erpnext/assets/8780500/4cdcb325-41de-48eb-9111-261e372af4a3">
