### PR TITLE
fix: timeout while cancelling LCV

### DIFF
--- a/erpnext/stock/stock_ledger.py
+++ b/erpnext/stock/stock_ledger.py
@@ -1529,6 +1529,7 @@ def get_next_stock_reco(kwargs):
 			sle.batch_no,
 			sle.actual_qty,
 		)
+		.force_index("item_warehouse")
 		.where(
 			(sle.item_code == kwargs.get("item_code"))
 			& (sle.warehouse == kwargs.get("warehouse"))


### PR DESCRIPTION
During profiling found that the method "get_next_stock_reco" is taking time to execute.
This method has a query which is using posting_datetime index which was causing the issue.

<img width="598" alt="Screenshot 2024-06-25 at 5 04 24 PM" src="https://github.com/frappe/erpnext/assets/8780500/6c085f47-1f78-4470-8d3c-b81c6e0d7376">

**After Fix**

Took 20 seconds to cancel the backdated LCV
<img width="748" alt="Screenshot 2024-06-25 at 4 37 39 PM" 
src="https://github.com/frappe/erpnext/assets/8780500/f4543229-afce-4d00-b06f-35a98ec8c669">


Query Performance with item_warehouse index

<img width="1427" alt="Screenshot 2024-06-25 at 2 55 35 PM" src="https://github.com/frappe/erpnext/assets/8780500/7e6615b7-ae15-41eb-8e0f-733b8a1b19af">


<img width="1425" alt="Screenshot 2024-06-25 at 5 32 55 PM" src="https://github.com/frappe/erpnext/assets/8780500/e10fddb0-5849-4fbf-8902-cc61ca065c3d">

