### PR TITLE
fix: Stock Reservation Entry was not getting created

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -75,8 +75,7 @@ frappe.ui.form.on("Sales Order", {
 				if (
 					frm.doc.__onload &&
 					frm.doc.__onload.has_unreserved_stock &&
-					flt(frm.doc.per_picked) === 0 &&
-					frappe.model.can_create("Stock Reservation Entry")
+					flt(frm.doc.per_picked) === 0
 				) {
 					frm.add_custom_button(
 						__("Reserve"),


### PR DESCRIPTION
Even after logging in as Administrator, Stock Reservation Entry was not getting created and Stock Reservation Button was not appearing.

After:
![image](https://github.com/frappe/erpnext/assets/27720465/5a13175c-eeee-430a-9961-a73f1ddacb47)
