### PR TITLE
fix: not able to make purchase return

### DIFF
--- a/erpnext/controllers/sales_and_purchase_return.py
+++ b/erpnext/controllers/sales_and_purchase_return.py
@@ -146,7 +146,10 @@ def validate_returned_items(doc):
 def validate_quantity(doc, args, ref, valid_items, already_returned_items):
 	fields = ["stock_qty"]
 	if doc.doctype in ["Purchase Receipt", "Purchase Invoice", "Subcontracting Receipt"]:
-		fields.extend(["received_qty", "rejected_qty"])
+		if not args.get("return_qty_from_rejected_warehouse"):
+			fields.extend(["received_qty", "rejected_qty"])
+		else:
+			fields.extend(["received_qty"])
 
 	already_returned_data = already_returned_items.get(args.item_code) or {}
 
@@ -158,9 +161,12 @@ def validate_quantity(doc, args, ref, valid_items, already_returned_items):
 	for column in fields:
 		returned_qty = flt(already_returned_data.get(column, 0)) if len(already_returned_data) > 0 else 0
 
-		if column == "stock_qty":
+		if column == "stock_qty" and not args.get("return_qty_from_rejected_warehouse"):
 			reference_qty = ref.get(column)
 			current_stock_qty = args.get(column)
+		elif args.get("return_qty_from_rejected_warehouse"):
+			reference_qty = ref.get("rejected_qty") * ref.get("conversion_factor", 1.0)
+			current_stock_qty = args.get(column) * args.get("conversion_factor", 1.0)
 		else:
 			reference_qty = ref.get(column) * ref.get("conversion_factor", 1.0)
 			current_stock_qty = args.get(column) * args.get("conversion_factor", 1.0)

--- a/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
+++ b/erpnext/stock/doctype/purchase_receipt/test_purchase_receipt.py
@@ -3030,6 +3030,36 @@ class TestPurchaseReceipt(FrappeTestCase):
 		self.assertEqual(batch.manufacturing_date, getdate(today()))
 		self.assertEqual(batch.expiry_date, getdate(add_days(today(), 5)))
 
+	def test_purchase_return_from_rejected_warehouse(self):
+		from erpnext.stock.doctype.purchase_receipt.purchase_receipt import (
+			make_purchase_return_against_rejected_warehouse,
+		)
+
+		item_code = "_Test Item Return from Rejected Warehouse 11"
+		create_item(item_code)
+
+		warehouse = create_warehouse("_Test Warehouse Return Qty Warehouse 11")
+		rejected_warehouse = create_warehouse("_Test Rejected Warehouse Return Qty Warehouse 11")
+
+		# Step 1: Create Purchase Receipt with valuation rate 100
+		pr = make_purchase_receipt(
+			item_code=item_code,
+			warehouse=warehouse,
+			qty=24,
+			rate=100,
+			rejected_qty=31,
+			rejected_warehouse=rejected_warehouse,
+		)
+
+		pr_return = make_purchase_return_against_rejected_warehouse(pr.name)
+		pr_return.save()
+		pr_return.submit()
+
+		self.assertEqual(pr_return.items[0].warehouse, rejected_warehouse)
+		self.assertEqual(pr_return.items[0].qty, 31 * -1)
+		self.assertEqual(pr_return.items[0].rejected_qty, 0.0)
+		self.assertEqual(pr_return.items[0].rejected_warehouse, "")
+
 
 def prepare_data_for_internal_transfer():
 	from erpnext.accounts.doctype.sales_invoice.test_sales_invoice import create_internal_supplier


### PR DESCRIPTION
Steps to replicate the issue

1. Make purchase receipt set the qty as 24 and rejected qty as 31
2. Make purchase return entry against the above purchase receipt
3. While making purchase return entry enable "Return Qty from Rejected Warehouse"
4. Try to submit the purchase return entry, you will get the below error

<img width="768" alt="image" src="https://github.com/frappe/erpnext/assets/8780500/9b3a533e-61a2-428a-99a0-bc3af71a8fe7">


