### PR TITLE
Fix: Issue with Work Order creation from Material Request for variants

### DIFF
--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -739,7 +739,7 @@ def raise_work_orders(material_request):
 
 	for d in mr.items:
 		if (d.stock_qty - d.ordered_qty) > 0:
-			if get_item_details(d.item_code).bom:
+			if get_item_details(d.item_code).bom_no:
 				wo_order = frappe.new_doc("Work Order")
 				wo_order.update(
 					{

--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -739,7 +739,7 @@ def raise_work_orders(material_request):
 
 	for d in mr.items:
 		if (d.stock_qty - d.ordered_qty) > 0:
-			if get_item_details(d.item_code):
+			if get_item_details(d.item_code).bom:
 				wo_order = frappe.new_doc("Work Order")
 				wo_order.update(
 					{

--- a/erpnext/stock/doctype/material_request/material_request.py
+++ b/erpnext/stock/doctype/material_request/material_request.py
@@ -739,7 +739,7 @@ def raise_work_orders(material_request):
 
 	for d in mr.items:
 		if (d.stock_qty - d.ordered_qty) > 0:
-			if frappe.db.exists("BOM", {"item": d.item_code, "is_default": 1}):
+			if get_item_details(d.item_code):
 				wo_order = frappe.new_doc("Work Order")
 				wo_order.update(
 					{


### PR DESCRIPTION
### Description

Replaced line 742 to resolve an issue occurring while creating work orders from material requests for variants.

### Issue

While creating a Work Order from a Material Request, the system was displaying the following error:


This error occurs despite having a template that should allow for the creation of a Bill of Materials (BOM). Creating variant BOMs for each item takes up unnecessary space.

### Solution

By replacing line 742, the error is resolved and the system now correctly references the template to create the BOMs without needing individual variant BOMs.

### Changes Made

- **File Modified**: material_request.py
- **Line Modified**: Line 742
- **Description of Change**: Adjusted the logic to reference the BOM template correctly.

### Testing

- Tested the Work Order creation process from Material Requests for various item variants.
- Confirmed that the error no longer appears and the BOMs are generated as expected from the template.

### Additional Notes

Please review the changes and let me know if there are any further adjustments needed. Thank you!
