### PR TITLE
fix: updated logic for calculating tax_withholding_net_total in payment entry

### DIFF
--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -164,7 +164,6 @@ class PaymentEntry(AccountsController):
 		self.set_exchange_rate()
 		self.validate_mandatory()
 		self.validate_reference_documents()
-		self.set_tax_withholding()
 		self.set_amounts()
 		self.validate_amounts()
 		self.apply_taxes()
@@ -178,6 +177,7 @@ class PaymentEntry(AccountsController):
 		self.validate_allocated_amount()
 		self.validate_paid_invoices()
 		self.ensure_supplier_is_not_blocked()
+		self.set_tax_withholding()
 		self.set_status()
 		self.set_total_in_words()
 
@@ -846,9 +846,7 @@ class PaymentEntry(AccountsController):
 		if not self.apply_tax_withholding_amount:
 			return
 
-		order_amount = self.get_order_net_total()
-
-		net_total = flt(order_amount) + flt(self.unallocated_amount)
+		net_total = self.calculate_tax_withholding_net_total()
 
 		# Adding args as purchase invoice to get TDS amount
 		args = frappe._dict(
@@ -892,7 +890,26 @@ class PaymentEntry(AccountsController):
 		for d in to_remove:
 			self.remove(d)
 
-	def get_order_net_total(self):
+	def calculate_tax_withholding_net_total(self):
+		net_total = 0
+		order_details = self.get_order_wise_tax_withholding_net_total()
+
+		for d in self.references:
+			tax_withholding_net_total = order_details.get(d.reference_name)
+			if not tax_withholding_net_total:
+				continue
+
+			net_taxable_outstanding = max(
+				0, d.outstanding_amount - (d.total_amount - tax_withholding_net_total)
+			)
+
+			net_total += min(net_taxable_outstanding, d.allocated_amount)
+
+		net_total += self.unallocated_amount
+
+		return net_total
+
+	def get_order_wise_tax_withholding_net_total(self):
 		if self.party_type == "Supplier":
 			doctype = "Purchase Order"
 		else:
@@ -900,11 +917,14 @@ class PaymentEntry(AccountsController):
 
 		docnames = [d.reference_name for d in self.references if d.reference_doctype == doctype]
 
-		tax_withholding_net_total = frappe.db.get_value(
-			doctype, {"name": ["in", docnames]}, ["sum(base_tax_withholding_net_total)"]
+		return frappe._dict(
+			frappe.db.get_all(
+				doctype,
+				filters={"name": ["in", docnames]},
+				fields=["name", "base_tax_withholding_net_total"],
+				as_list=True,
+			)
 		)
-
-		return tax_withholding_net_total
 
 	def apply_taxes(self):
 		self.initialize_taxes()


### PR DESCRIPTION
Issue:

Earlier TDS was deducted on base_tax_withholding_net_total even if the allocated amount is less than base_tax_withholding_net_total amount.

For eg:
PO = 100 + 18 = 118
Base Tax Withholding Net Total = 100 
o/s amount = 118
Paid amount = 50
Net Total Amount= 100

Fix:

Now TDS will be deducted on net_payable_amount_before tax or allocated amount whichever is less.
For eg:

PO = 100 + 18 = 118
Base Tax Withholding Net Total = 100 

1st Payment Entry
o/s amount = 118
Paid amount = 50
Net Base Tax Withholding Payable = 118-18 = 100
Net Total Amount= 50

2nd Payment Entry
o/s amount = 68
Paid amount = 60
Net Base Tax Withholding Payable = 68-18 = 50
Net Total Amount= 50

3rd Payment Entry
o/s amount = 8
Paid amount = 8
Net Base Tax Withholding Payable = 0
Net Total Amount= 0

Suppot Issue: https://support.frappe.io/helpdesk/tickets/17745