### PR TITLE
fix: batch reset while making SABB

### DIFF
--- a/erpnext/stock/doctype/serial_and_batch_bundle/test_serial_and_batch_bundle.py
+++ b/erpnext/stock/doctype/serial_and_batch_bundle/test_serial_and_batch_bundle.py
@@ -646,6 +646,61 @@ class TestSerialandBatchBundle(FrappeTestCase):
 
 		self.assertEqual(flt(stock_value_difference, 2), 353.0 * -1)
 
+	def test_pick_serial_nos_for_batch_item(self):
+		item_code = make_item(
+			"Test Pick Serial Nos for Batch Item 1",
+			properties={
+				"is_stock_item": 1,
+				"has_batch_no": 1,
+				"create_new_batch": 1,
+				"batch_no_series": "PSNBI-TSNVL-.#####",
+				"has_serial_no": 1,
+				"serial_no_series": "SN-PSNBI-TSNVL-.#####",
+			},
+		).name
+
+		se = make_stock_entry(
+			item_code=item_code,
+			qty=10,
+			target="_Test Warehouse - _TC",
+			rate=500,
+		)
+
+		batch1 = get_batch_from_bundle(se.items[0].serial_and_batch_bundle)
+		serial_nos1 = get_serial_nos_from_bundle(se.items[0].serial_and_batch_bundle)
+
+		se = make_stock_entry(
+			item_code=item_code,
+			qty=10,
+			target="_Test Warehouse - _TC",
+			rate=500,
+		)
+
+		batch2 = get_batch_from_bundle(se.items[0].serial_and_batch_bundle)
+		serial_nos2 = get_serial_nos_from_bundle(se.items[0].serial_and_batch_bundle)
+
+		se = make_stock_entry(
+			item_code=item_code,
+			qty=10,
+			source="_Test Warehouse - _TC",
+			use_serial_batch_fields=True,
+			batch_no=batch2,
+		)
+
+		serial_nos = get_serial_nos_from_bundle(se.items[0].serial_and_batch_bundle)
+		self.assertEqual(serial_nos, serial_nos2)
+
+		se = make_stock_entry(
+			item_code=item_code,
+			qty=10,
+			source="_Test Warehouse - _TC",
+			use_serial_batch_fields=True,
+			batch_no=batch1,
+		)
+
+		serial_nos = get_serial_nos_from_bundle(se.items[0].serial_and_batch_bundle)
+		self.assertEqual(serial_nos, serial_nos1)
+
 
 def get_batch_from_bundle(bundle):
 	from erpnext.stock.serial_batch_bundle import get_batch_nos

--- a/erpnext/stock/serial_batch_bundle.py
+++ b/erpnext/stock/serial_batch_bundle.py
@@ -950,7 +950,17 @@ class SerialBatchCreation:
 		if self.get("ignore_serial_nos"):
 			kwargs["ignore_serial_nos"] = self.ignore_serial_nos
 
-		if self.has_serial_no and not self.get("serial_nos"):
+		if (
+			self.has_serial_no
+			and self.has_batch_no
+			and not self.get("serial_nos")
+			and self.get("batches")
+			and len(self.get("batches")) == 1
+		):
+			# If only one batch is available and no serial no is available
+			kwargs["batches"] = next(iter(self.get("batches").keys()))
+			self.serial_nos = get_serial_nos_for_outward(kwargs)
+		elif self.has_serial_no and not self.get("serial_nos"):
 			self.serial_nos = get_serial_nos_for_outward(kwargs)
 		elif not self.has_serial_no and self.has_batch_no and not self.get("batches"):
 			self.batches = get_available_batches(kwargs)


### PR DESCRIPTION
Steps to replicate issue

- Create an item and enable Has Serial No and Has Batch No
- Inward two batches of 10 qty each
- Make stock entry to consume both batches
- In the stock entry add both batches in separate line item and enable "Use Serial and Batch Fields"
- Do not set the serial no and try to submit the entry
- System will reset the batch and throw the negative stock error