### PR TITLE
fix: add strings for translation in sales_order.js

### DIFF
--- a/erpnext/selling/doctype/sales_order/sales_order.js
+++ b/erpnext/selling/doctype/sales_order/sales_order.js
@@ -1246,14 +1246,14 @@ erpnext.selling.SalesOrderController = class SalesOrderController extends erpnex
 					],
 				},
 			],
-			primary_action_label: "Create Purchase Order",
+			primary_action_label: __("Create Purchase Order"),
 			primary_action(args) {
 				if (!args) return;
 
 				let selected_items = dialog.fields_dict.items_for_po.grid.get_selected_children();
 				if (selected_items.length == 0) {
 					frappe.throw({
-						message: "Please select Items from the Table",
+						message: __("Please select Items from the Table"),
 						title: __("Items Required"),
 						indicator: "blue",
 					});


### PR DESCRIPTION
fix: add strings for translation in sales_order.js

