### PR TITLE
fix: add strings  payment_terms_status_for_sales_order.py

### DIFF
--- a/erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py
+++ b/erpnext/selling/report/payment_terms_status_for_sales_order/payment_terms_status_for_sales_order.py
@@ -270,11 +270,11 @@ def prepare_chart(s_orders):
 				"labels": [term.payment_term for term in s_orders],
 				"datasets": [
 					{
-						"name": "Payment Amount",
+						"name": _("Payment Amount"),
 						"values": [x.base_payment_amount for x in s_orders],
 					},
 					{
-						"name": "Paid Amount",
+						"name": _("Paid Amount"),
 						"values": [x.paid_amount for x in s_orders],
 					},
 				],


### PR DESCRIPTION
fix: add strings for translation in payment_terms_status_for_sales_order.py

