### PR TITLE
fix: add strings for translation in sales_order_analysis.py

### DIFF
--- a/erpnext/selling/report/sales_order_analysis/sales_order_analysis.py
+++ b/erpnext/selling/report/sales_order_analysis/sales_order_analysis.py
@@ -206,7 +206,7 @@ def prepare_data(data, so_elapsed_time, filters):
 
 
 def prepare_chart_data(pending, completed):
-	labels = ["Amount to Bill", "Billed Amount"]
+	labels = [_("Amount to Bill"), _("Billed Amount")]
 
 	return {
 		"data": {"labels": labels, "datasets": [{"values": [pending, completed]}]},


### PR DESCRIPTION
fix: add strings for translation in sales_order_analysis.py

