### PR TITLE
fix: Billed Qty and Qty to Bill Calculation in Purchase Order Analysis

### DIFF
--- a/erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py
+++ b/erpnext/buying/report/purchase_order_analysis/purchase_order_analysis.py
@@ -39,6 +39,7 @@ def validate_filters(filters):
 def get_data(filters):
 	po = frappe.qb.DocType("Purchase Order")
 	po_item = frappe.qb.DocType("Purchase Order Item")
+	pi = frappe.qb.DocType("Purchase Invoice")
 	pi_item = frappe.qb.DocType("Purchase Invoice Item")
 
 	query = (
@@ -46,6 +47,8 @@ def get_data(filters):
 		.from_(po_item)
 		.left_join(pi_item)
 		.on(pi_item.po_detail == po_item.name)
+		.left_join(pi)
+		.on(pi.name == pi_item.parent)
 		.select(
 			po.transaction_date.as_("date"),
 			po_item.schedule_date.as_("required_date"),
@@ -69,6 +72,7 @@ def get_data(filters):
 			po_item.name,
 		)
 		.where((po_item.parent == po.name) & (po.status.notin(("Stopped", "Closed"))) & (po.docstatus == 1))
+		.where(pi.docstatus == 1)
 		.groupby(po_item.name)
 		.orderby(po.transaction_date)
 	)


### PR DESCRIPTION
Version 15

**Before:**

- Whenever we cancel and amend the purchase invoice, Billed Qty keeps increasing. As many times as you cancel and recreate, it gets added in the Billed Qty report, because the cancel condition of the purchase invoice is not added in the report.


https://github.com/frappe/erpnext/assets/141945075/ba1a8c73-941d-43af-ad6d-2937ae4555e2

**After:**

- fixed it.


https://github.com/frappe/erpnext/assets/141945075/8b022ce3-21ad-4ec1-857b-741923da6f7b

