### PR TITLE
upload option in employee education

### DIFF
--- a/erpnext/setup/doctype/employee_education/employee_education.json
+++ b/erpnext/setup/doctype/employee_education/employee_education.json
@@ -10,6 +10,7 @@
   "level",
   "year_of_passing",
   "class_per",
+  "upload_certificate",
   "maj_opt_subj"
  ],
  "fields": [
@@ -63,6 +64,12 @@
    "label": "Major/Optional Subjects",
    "oldfieldname": "maj_opt_subj",
    "oldfieldtype": "Text"
+  },
+  {
+   "fieldname": "upload_certificate",
+   "fieldtype": "Attach",
+   "in_list_view": 1,
+   "label": "Upload Certificate"
   }
  ],
  "idx": 1,


### PR DESCRIPTION

![edu](https://github.com/frappe/erpnext/assets/75559468/91fecffe-5055-413b-a6e9-764f625e52ea)
Employee can attach their education certificate and other datas in education child table
