### PR TITLE
fix: bank reconcilation tool cost center company filter adding

### DIFF
--- a/erpnext/public/js/bank_reconciliation_tool/dialog_manager.js
+++ b/erpnext/public/js/bank_reconciliation_tool/dialog_manager.js
@@ -374,6 +374,13 @@ erpnext.accounts.bank_reconciliation.DialogManager = class DialogManager {
 				label: "Cost Center",
 				options: "Cost Center",
 				depends_on: "eval:doc.action=='Create Voucher' && doc.document_type=='Payment Entry'",
+				get_query: () => {
+					return {
+						filters: {
+							company: this.company,
+						},
+					};
+				},
 			},
 			{
 				fieldtype: "Section Break",


### PR DESCRIPTION
Bank Reconciliation Tool Create Voucher Cost Center Company Filter Adding
Issue: #42113
Before Company Filter:
[before_company_filter.webm](https://github.com/frappe/erpnext/assets/101092028/d88c13e5-91f1-4b42-8bfc-57b64b9dcbb9)
After Company Filter:
[after_company_filter.webm](https://github.com/frappe/erpnext/assets/101092028/7aebb742-d3b6-4787-84f3-5227c517fca0)
