### PR TITLE
fix: stock qty validation in SCR

### DIFF
--- a/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/subcontracting_receipt.py
@@ -446,6 +446,12 @@ class SubcontractingReceipt(SubcontractingController):
 				)
 
 	def validate_available_qty_for_consumption(self):
+		if (
+			frappe.db.get_single_value("Buying Settings", "backflush_raw_materials_of_subcontract_based_on")
+			== "BOM"
+		):
+			return
+
 		for item in self.get("supplied_items"):
 			precision = item.precision("consumed_qty")
 			if (

--- a/erpnext/subcontracting/doctype/subcontracting_receipt/test_subcontracting_receipt.py
+++ b/erpnext/subcontracting/doctype/subcontracting_receipt/test_subcontracting_receipt.py
@@ -81,6 +81,7 @@ class TestSubcontractingReceipt(FrappeTestCase):
 		self.assertEqual(scr.get("items")[0].rm_supp_cost, flt(rm_supp_cost))
 
 	def test_available_qty_for_consumption(self):
+		set_backflush_based_on("BOM")
 		make_stock_entry(item_code="_Test Item", qty=100, target="_Test Warehouse 1 - _TC", basic_rate=100)
 		make_stock_entry(
 			item_code="_Test Item Home Desktop 100",
@@ -125,7 +126,7 @@ class TestSubcontractingReceipt(FrappeTestCase):
 		)
 		scr = make_subcontracting_receipt(sco.name)
 		scr.save()
-		self.assertRaises(frappe.ValidationError, scr.submit)
+		scr.submit()
 
 	def test_subcontracting_gle_fg_item_rate_zero(self):
 		from erpnext.stock.doctype.purchase_receipt.test_purchase_receipt import get_gl_entries
@@ -475,6 +476,21 @@ class TestSubcontractingReceipt(FrappeTestCase):
 
 		# consumed_qty should be (accepted_qty * qty_consumed_per_unit) = (6 * 1) = 6
 		self.assertEqual(scr.supplied_items[0].consumed_qty, 6)
+
+		# Do not transfer materials to the supplier warehouse and check whether system allows to consumed directly from the supplier's warehouse
+		sco = get_subcontracting_order(service_items=service_items)
+
+		# Transfer RM's
+		rm_items = get_rm_items(sco.supplied_items)
+		itemwise_details = make_stock_in_entry(rm_items=rm_items, warehouse="_Test Warehouse 1 - _TC")
+
+		# Create Subcontracting Receipt
+		scr = make_subcontracting_receipt(sco.name)
+		scr.submit()
+		self.assertEqual(scr.docstatus, 1)
+
+		for item in scr.supplied_items:
+			self.assertFalse(item.available_qty_for_consumption)
 
 	def test_supplied_items_cost_after_reposting(self):
 		# Set Backflush Based On as "BOM"


### PR DESCRIPTION
Steps to replicate the issue

1. User has transferred materials to the supplier
2. User has created SCO and did transferred partial materials to supplier because stock is exists at supplier's warehouse
3. Now user is trying to create the SCR but system throwing an error

