### PR TITLE
fix: removed max discount validation for sales return

### DIFF
--- a/erpnext/controllers/selling_controller.py
+++ b/erpnext/controllers/selling_controller.py
@@ -28,7 +28,7 @@ class SellingController(StockController):
 	def validate(self):
 		super().validate()
 		self.validate_items()
-		if not self.get("is_debit_note"):
+		if not (self.get("is_debit_note") or self.get("is_return")):
 			self.validate_max_discount()
 		self.validate_selling_price()
 		self.set_qty_as_per_stock_uom()


### PR DESCRIPTION
Max item discount validation is not required for sales returns.

Closes : https://github.com/frappe/erpnext/issues/41893
FRappe Support Issue: https://support.frappe.io/app/hd-ticket/16627

