### PR TITLE
refactor: validation to prevent usage of 'mixed conditions' with 'Recursive' discount/free item

### DIFF
--- a/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/pricing_rule.py
@@ -139,6 +139,7 @@ class PricingRule(Document):
 		self.validate_price_list_with_currency()
 		self.validate_dates()
 		self.validate_condition()
+		self.validate_mixed_with_recursion()
 
 		if not self.margin_type:
 			self.margin_rate_or_amount = 0.0
@@ -307,6 +308,10 @@ class PricingRule(Document):
 			and re.match(r'[\w\.:_]+\s*={1}\s*[\w\.@\'"]+', self.condition)
 		):
 			frappe.throw(_("Invalid condition expression"))
+
+	def validate_mixed_with_recursion(self):
+		if self.mixed_conditions and self.is_recursive:
+			frappe.throw(_("Recursive Discounts with Mixed condition is not supported by the system"))
 
 
 # --------------------------------------------------------------------------------

--- a/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
+++ b/erpnext/accounts/doctype/pricing_rule/test_pricing_rule.py
@@ -1299,6 +1299,18 @@ class TestPricingRule(unittest.TestCase):
 			item_group_rule.delete()
 			item_code_rule.delete()
 
+	def test_validation_on_mixed_condition_with_recursion(self):
+		pricing_rule = make_pricing_rule(
+			discount_percentage=10,
+			selling=1,
+			priority=2,
+			min_qty=4,
+			title="_Test Pricing Rule with Min Qty - 2",
+		)
+		pricing_rule.mixed_conditions = True
+		pricing_rule.is_recursive = True
+		self.assertRaises(frappe.ValidationError, pricing_rule.save)
+
 
 test_dependencies = ["Campaign"]
 

--- a/erpnext/accounts/doctype/promotional_scheme/promotional_scheme.py
+++ b/erpnext/accounts/doctype/promotional_scheme/promotional_scheme.py
@@ -146,6 +146,7 @@ class PromotionalScheme(Document):
 
 		self.validate_applicable_for()
 		self.validate_pricing_rules()
+		self.validate_mixed_with_recursion()
 
 	def validate_applicable_for(self):
 		if self.applicable_for:
@@ -177,6 +178,7 @@ class PromotionalScheme(Document):
 				frappe.delete_doc("Pricing Rule", docname.name)
 
 	def on_update(self):
+		self.validate()
 		pricing_rules = (
 			frappe.get_all(
 				"Pricing Rule",
@@ -187,6 +189,15 @@ class PromotionalScheme(Document):
 			or {}
 		)
 		self.update_pricing_rules(pricing_rules)
+
+	def validate_mixed_with_recursion(self):
+		if self.mixed_conditions:
+			if self.product_discount_slabs:
+				for slab in self.product_discount_slabs:
+					if slab.is_recursive:
+						frappe.throw(
+							_("Recursive Discounts with Mixed condition is not supported by the system")
+						)
 
 	def update_pricing_rules(self, pricing_rules):
 		rules = {}

--- a/erpnext/accounts/doctype/promotional_scheme/promotional_scheme.py
+++ b/erpnext/accounts/doctype/promotional_scheme/promotional_scheme.py
@@ -164,7 +164,7 @@ class PromotionalScheme(Document):
 		docnames = []
 
 		# If user has changed applicable for
-		if self._doc_before_save.applicable_for == self.applicable_for:
+		if self.get_doc_before_save() and self.get_doc_before_save().applicable_for == self.applicable_for:
 			return
 
 		docnames = frappe.get_all("Pricing Rule", filters={"promotional_scheme": self.name})

--- a/erpnext/accounts/doctype/promotional_scheme/test_promotional_scheme.py
+++ b/erpnext/accounts/doctype/promotional_scheme/test_promotional_scheme.py
@@ -129,6 +129,25 @@ class TestPromotionalScheme(unittest.TestCase):
 			[pr.min_qty, pr.free_item, pr.free_qty, pr.recurse_for], [12, "_Test Item 2", 1, 12]
 		)
 
+	def test_validation_on_recurse_with_mixed_condition(self):
+		ps = make_promotional_scheme()
+		ps.set("price_discount_slabs", [])
+		ps.set(
+			"product_discount_slabs",
+			[
+				{
+					"rule_description": "12+1",
+					"min_qty": 12,
+					"free_item": "_Test Item 2",
+					"free_qty": 1,
+					"is_recursive": 1,
+					"recurse_for": 12,
+				}
+			],
+		)
+		ps.mixed_conditions = True
+		self.assertRaises(frappe.ValidationError, ps.save)
+
 
 def make_promotional_scheme(**args):
 	args = frappe._dict(args)


### PR DESCRIPTION
'Mixed Condition' enabled along with Recursive discount/free item has undefined behavior.