### PR TITLE
fix: show zero stock items filter in the stock balance report

### DIFF
--- a/erpnext/stock/report/stock_balance/stock_balance.js
+++ b/erpnext/stock/report/stock_balance/stock_balance.js
@@ -101,6 +101,12 @@ frappe.query_reports["Stock Balance"] = {
 			fieldtype: "Check",
 			default: 0,
 		},
+		{
+			fieldname: "include_zero_stock_items",
+			label: __("Include Zero Stock Items"),
+			fieldtype: "Check",
+			default: 0,
+		},
 	],
 
 	formatter: function (value, row, column, data, default_formatter) {

--- a/erpnext/stock/report/stock_balance/stock_balance.py
+++ b/erpnext/stock/report/stock_balance/stock_balance.py
@@ -138,7 +138,12 @@ class StockBalanceReport:
 				{"reserved_stock": sre_details.get((report_data.item_code, report_data.warehouse), 0.0)}
 			)
 
-			if report_data and report_data.bal_qty == 0 and report_data.bal_val == 0:
+			if (
+				not self.filters.get("include_zero_stock_items")
+				and report_data
+				and report_data.bal_qty == 0
+				and report_data.bal_val == 0
+			):
 				continue
 
 			self.data.append(report_data)


### PR DESCRIPTION
Without "Include Zero Stock Items" filter
<img width="1329" alt="Screenshot 2024-07-02 at 7 07 58 PM" src="https://github.com/frappe/erpnext/assets/8780500/bd63ba0f-f116-4899-b8ea-20089e35d4f7">

 
With "Include Zero Stock Items" filter
<img width="1310" alt="Screenshot 2024-07-02 at 7 08 03 PM" src="https://github.com/frappe/erpnext/assets/8780500/d6a0fb27-65d5-4e81-ac6d-0773cb547250">
