### PR TITLE
feat(payment): add more payment channels than just email and phone (think: chat)

### DIFF
--- a/erpnext/accounts/doctype/payment_gateway_account/payment_gateway_account.json
+++ b/erpnext/accounts/doctype/payment_gateway_account/payment_gateway_account.json
@@ -49,7 +49,7 @@
    "label": "Currency"
   },
   {
-   "depends_on": "eval: doc.payment_channel !== \"Phone\"",
+   "depends_on": "eval: doc.payment_channel == 'Email' || (!doc.payment_channel)",
    "fieldname": "payment_request_message",
    "fieldtype": "Section Break"
   },
@@ -70,12 +70,12 @@
    "fieldname": "payment_channel",
    "fieldtype": "Select",
    "label": "Payment Channel",
-   "options": "\nEmail\nPhone"
+   "options": "\nEmail\nPhone\nOther"
   }
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-03-27 13:10:09.836254",
+ "modified": "2024-03-29 18:53:09.836254",
  "modified_by": "Administrator",
  "module": "Accounts",
  "name": "Payment Gateway Account",

--- a/erpnext/accounts/doctype/payment_request/payment_request.json
+++ b/erpnext/accounts/doctype/payment_request/payment_request.json
@@ -260,7 +260,7 @@
    "label": "Recipient Message And Payment Details"
   },
   {
-   "depends_on": "eval: doc.payment_channel != \"Phone\"",
+   "depends_on": "eval: doc.payment_channel == \"Email\" || (!doc.payment_channel)",
    "fieldname": "print_format",
    "fieldtype": "Select",
    "label": "Print Format"
@@ -272,7 +272,7 @@
    "label": "To"
   },
   {
-   "depends_on": "eval: doc.payment_channel != \"Phone\"",
+   "depends_on": "eval: doc.payment_channel == \"Email\" || (!doc.payment_channel)",
    "fieldname": "subject",
    "fieldtype": "Data",
    "in_global_search": 1,
@@ -309,18 +309,18 @@
    "read_only": 1
   },
   {
-   "depends_on": "eval: doc.payment_request_type == 'Inward' || doc.payment_channel != \"Phone\"",
+   "depends_on": "eval: doc.payment_request_type == 'Inward' || doc.payment_channel == \"Email\" || (!doc.payment_channel)",
    "fieldname": "section_break_10",
    "fieldtype": "Section Break"
   },
   {
-   "depends_on": "eval: doc.payment_channel != \"Phone\"",
+   "depends_on": "eval: doc.payment_channel == \"Email\" || (!doc.payment_channel)",
    "fieldname": "message",
    "fieldtype": "Text",
    "label": "Message"
   },
   {
-   "depends_on": "eval: doc.payment_channel != \"Phone\"",
+   "depends_on": "eval: doc.payment_channel == \"Email\" || (!doc.payment_channel)",
    "fieldname": "message_examples",
    "fieldtype": "HTML",
    "label": "Message Examples",
@@ -372,7 +372,7 @@
    "fieldname": "payment_channel",
    "fieldtype": "Select",
    "label": "Payment Channel",
-   "options": "\nEmail\nPhone",
+   "options": "\nEmail\nPhone\nOther",
    "read_only": 1
   },
   {

--- a/erpnext/accounts/doctype/payment_request/payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/payment_request.py
@@ -165,14 +165,13 @@ class PaymentRequest(Document):
 			self.status = "Requested"
 
 		if self.payment_request_type == "Inward":
-			send_mail = self.payment_gateway_validation() if self.payment_gateway else None
-			if send_mail and not (self.mute_email or self.flags.mute_email):
-				self.set_payment_request_url()
-				self.send_email()
-				self.make_communication_entry()
-
-			elif self.payment_channel == "Phone":
+			if self.payment_channel == "Phone":
 				self.request_phone_payment()
+			else:
+				self.set_payment_request_url()
+				if not (self.mute_email or self.flags.mute_email):
+					self.send_email()
+					self.make_communication_entry()
 
 	def request_phone_payment(self):
 		controller = _get_payment_gateway_controller(self.payment_gateway)
@@ -231,7 +230,7 @@ class PaymentRequest(Document):
 			return False
 
 	def set_payment_request_url(self):
-		if self.payment_account and self.payment_channel != "Phone":
+		if self.payment_account and self.payment_gateway and self.payment_gateway_validation():
 			self.payment_url = self.get_payment_url()
 
 	def get_payment_url(self):

--- a/erpnext/accounts/doctype/payment_request/test_payment_request.py
+++ b/erpnext/accounts/doctype/payment_request/test_payment_request.py
@@ -19,6 +19,7 @@ PAYMENT_URL = "https://example.com/payment"
 payment_gateways = [
 	{"doctype": "Payment Gateway", "gateway": "_Test Gateway"},
 	{"doctype": "Payment Gateway", "gateway": "_Test Gateway Phone"},
+	{"doctype": "Payment Gateway", "gateway": "_Test Gateway Other"},
 ]
 
 payment_method = [
@@ -33,6 +34,13 @@ payment_method = [
 		"doctype": "Payment Gateway Account",
 		"payment_gateway": "_Test Gateway",
 		"payment_account": "_Test Bank USD - _TC",
+		"currency": "USD",
+	},
+	{
+		"doctype": "Payment Gateway Account",
+		"payment_gateway": "_Test Gateway Other",
+		"payment_account": "_Test Bank USD - _TC",
+		"payment_channel": "Other",
 		"currency": "USD",
 	},
 	{
@@ -114,6 +122,21 @@ class TestPaymentRequest(unittest.TestCase):
 		pr = make_payment_request(
 			dt="Sales Order",
 			dn=so.name,
+			payment_gateway_account="_Test Gateway Other - USD",
+			submit_doc=True,
+			return_doc=True,
+		)
+		self.assertEqual(pr.payment_channel, "Other")
+		self.assertEqual(pr.mute_email, True)
+
+		self.assertEqual(pr.payment_url, PAYMENT_URL)
+		self.assertEqual(self.send_email.call_count, 0)
+		self.assertEqual(self._get_payment_gateway_controller.call_count, 1)
+		pr.cancel()
+
+		pr = make_payment_request(
+			dt="Sales Order",
+			dn=so.name,
 			payment_gateway_account="_Test Gateway - USD",  # email channel
 			submit_doc=False,
 			return_doc=True,
@@ -124,9 +147,9 @@ class TestPaymentRequest(unittest.TestCase):
 		self.assertEqual(pr.payment_channel, "Email")
 		self.assertEqual(pr.mute_email, False)
 
-		self.assertIsNone(pr.payment_url)
+		self.assertEqual(pr.payment_url, PAYMENT_URL)
 		self.assertEqual(self.send_email.call_count, 0)  # hence: no increment
-		self.assertEqual(self._get_payment_gateway_controller.call_count, 1)
+		self.assertEqual(self._get_payment_gateway_controller.call_count, 2)
 		pr.cancel()
 
 		pr = make_payment_request(
@@ -180,7 +203,7 @@ class TestPaymentRequest(unittest.TestCase):
 		self.assertEqual(pr.payment_channel, "Email")
 		self.assertEqual(pr.mute_email, True)
 
-		self.assertIsNone(pr.payment_url)
+		self.assertEqual(pr.payment_url, PAYMENT_URL)
 		self.assertEqual(self.send_email.call_count, 1)  # no increment on shopping cart
 		self.assertEqual(self._get_payment_gateway_controller.call_count, 5)
 		pr.cancel()


### PR DESCRIPTION
Part of https://github.com/frappe/erpnext/pull/40845

cc @ruthra-kumar

This implements an appropriate payment channel (not email or phone), which is implemented by one of the target gateways (e.g. whatsapp link or app-/push-notification-based).

None of the current channels is suitable for that business logic.
