### PR TITLE
fix: path of automatically updates the status of asset maintenance log

### DIFF
--- a/erpnext/hooks.py
+++ b/erpnext/hooks.py
@@ -435,7 +435,7 @@ scheduler_events = {
 		"erpnext.accounts.doctype.process_statement_of_accounts.process_statement_of_accounts.send_auto_email",
 		"erpnext.accounts.utils.auto_create_exchange_rate_revaluation_daily",
 		"erpnext.accounts.utils.run_ledger_health_checks",
-		"erpnext.assets.doctype.asset.asset_maintenance_log.update_asset_maintenance_log_status",
+		"erpnext.assets.doctype.asset_maintenance_log.asset_maintenance_log.update_asset_maintenance_log_status",
 	],
 	"weekly": [
 		"erpnext.accounts.utils.auto_create_exchange_rate_revaluation_weekly",


### PR DESCRIPTION
version 15:

fixes: #42156 & https://discuss.frappe.io/t/no-module-named-erpnext-assets-doctype-asset-asset-maintenance-log/127964

**Before:**

![image](https://github.com/frappe/erpnext/assets/141945075/f4fd5d8e-d1bc-41b0-be1f-7e74a2035f84)


**After:**

- update the path in hooks
