### PR TITLE
fix: render doctype caster server-script-callable

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -33,7 +33,7 @@ jobs:
           cache: pip
 
       - name: Download Semgrep rules
-        run: git clone --depth 1 https://github.com/frappe/semgrep-rules.git frappe-semgrep-rules
+        run: git clone --depth 1 https://github.com/blaggacao/semgrep-rules.git frappe-semgrep-rules
 
       - name: Download semgrep
         run: pip install semgrep

--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -96,6 +96,8 @@ jobs:
         env:
           DB: mariadb
           TYPE: server
+          FRAPPE_USER: blaggacao
+          FRAPPE_BRANCH: feat/document-caster
 
       - name: Run Patch Tests
         run: |

--- a/.github/workflows/server-tests-mariadb.yml
+++ b/.github/workflows/server-tests-mariadb.yml
@@ -116,8 +116,8 @@ jobs:
         env:
           DB: mariadb
           TYPE: server
-          FRAPPE_USER: ${{ github.event.inputs.user }}
-          FRAPPE_BRANCH: ${{ github.event.inputs.branch }}
+          FRAPPE_USER: blaggacao
+          FRAPPE_BRANCH: feat/document-caster
 
       - name: Run Tests
         run: 'cd ~/frappe-bench/ && bench --site test_site run-parallel-tests --app erpnext --total-builds 4 --build-number ${{ matrix.container }}'

--- a/.github/workflows/server-tests-postgres.yml
+++ b/.github/workflows/server-tests-postgres.yml
@@ -103,6 +103,8 @@ jobs:
         env:
           DB: postgres
           TYPE: server
+          FRAPPE_USER: blaggacao
+          FRAPPE_BRANCH: feat/document-caster
 
       - name: Run Tests
         run: cd ~/frappe-bench/ && bench --site test_site run-parallel-tests --app erpnext --use-orchestrator

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -1170,28 +1170,25 @@ class PaymentEntry(AccountsController):
 
 		self.set("remarks", "\n".join(remarks))
 
-	def make_payment_entry(
-		self,
-		dt,
-		dn,
-		party_amount=None,
-		bank_account=None,
-		bank_amount=None,
-		party_type=None,
-		payment_type=None,
-		reference_date=None,
-	):
+	def _from_sales_order(self, so):
 		frappe.flags.new_payment_entry = self
-		return get_payment_entry(
-			dt,
-			dn,
-			party_amount=None,
-			bank_account=None,
-			bank_amount=None,
-			party_type=None,
-			payment_type=None,
-			reference_date=None,
-		)
+		return get_payment_entry(so.doctype, so.name)
+
+	def _from_sales_invoice(self, si):
+		frappe.flags.new_payment_entry = self
+		return get_payment_entry(si.doctype, si.name)
+
+	def _from_purchase_order(self, po):
+		frappe.flags.new_payment_entry = self
+		return get_payment_entry(po.doctype, po.name)
+
+	def _from_purchase_invoice(self, pi):
+		frappe.flags.new_payment_entry = self
+		return get_payment_entry(pi.doctype, pi.name)
+
+	def _from_dunning(self, d):
+		frappe.flags.new_payment_entry = self
+		return get_payment_entry(d.doctype, d.name)
 
 	def build_gl_map(self):
 		if self.payment_type in ("Receive", "Pay") and not self.get("party_account_field"):

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -525,7 +525,10 @@ class PaymentEntry(AccountsController):
 						continue
 
 					if field == "exchange_rate" or not d.get(field) or force:
-						d.db_set(field, value)
+						if self.get("_action") in ("submit", "cancel"):
+							d.db_set(field, value)
+						else:
+							d.set(field, value)
 
 	def validate_payment_type(self):
 		if self.payment_type not in ("Receive", "Pay", "Internal Transfer"):

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -1170,23 +1170,58 @@ class PaymentEntry(AccountsController):
 
 		self.set("remarks", "\n".join(remarks))
 
+	@frappe.requires_permission("Account", "read")
+	@frappe.requires_permission("Sales Order", "read")
+	@frappe.requires_permission("Payment Entry", "create")
 	def _from_sales_order(self, so):
-		frappe.flags.new_payment_entry = self
-		return get_payment_entry(so.doctype, so.name)
+		return get_payment_entry(
+			so.doctype,
+			so.name,
+			payment_type="Receive",
+			party_type="Customer",
+		)
 
+	@frappe.requires_permission("Account", "read")
+	@frappe.requires_permission("Sales Invoice", "read")
+	@frappe.requires_permission("Payment Entry", "create")
 	def _from_sales_invoice(self, si):
 		frappe.flags.new_payment_entry = self
-		return get_payment_entry(si.doctype, si.name)
+		return get_payment_entry(
+			si.doctype,
+			si.name,
+			payment_type="Receive",
+			party_type="Customer",
+		)
 
+	@frappe.requires_permission("Account", "read")
+	@frappe.requires_permission("Purchase Order", "read")
+	@frappe.requires_permission("Payment Entry", "create")
 	def _from_purchase_order(self, po):
 		frappe.flags.new_payment_entry = self
-		return get_payment_entry(po.doctype, po.name)
+		return get_payment_entry(
+			po.doctype,
+			po.name,
+			payment_type="Receive",
+			party_type="Supplier",
+		)
 
+	@frappe.requires_permission("Account", "read")
+	@frappe.requires_permission("Purchase Invoice", "read")
+	@frappe.requires_permission("Payment Entry", "create")
 	def _from_purchase_invoice(self, pi):
 		frappe.flags.new_payment_entry = self
-		return get_payment_entry(pi.doctype, pi.name)
+		return get_payment_entry(
+			pi.doctype,
+			pi.name,
+			payment_type="Receive",
+			party_type="Supplier",
+		)
 
+	@frappe.requires_permission("Account", "read")
+	@frappe.requires_permission("Dunning", "read")
+	@frappe.requires_permission("Payment Entry", "create")
 	def _from_dunning(self, d):
+		frappe.flags.ignore_account_permission = frappe.flags.ignore_permissions
 		frappe.flags.new_payment_entry = self
 		return get_payment_entry(d.doctype, d.name)
 

--- a/erpnext/accounts/doctype/payment_entry/payment_entry.py
+++ b/erpnext/accounts/doctype/payment_entry/payment_entry.py
@@ -1170,6 +1170,29 @@ class PaymentEntry(AccountsController):
 
 		self.set("remarks", "\n".join(remarks))
 
+	def make_payment_entry(
+		self,
+		dt,
+		dn,
+		party_amount=None,
+		bank_account=None,
+		bank_amount=None,
+		party_type=None,
+		payment_type=None,
+		reference_date=None,
+	):
+		frappe.flags.new_payment_entry = self
+		return get_payment_entry(
+			dt,
+			dn,
+			party_amount=None,
+			bank_account=None,
+			bank_amount=None,
+			party_type=None,
+			payment_type=None,
+			reference_date=None,
+		)
+
 	def build_gl_map(self):
 		if self.payment_type in ("Receive", "Pay") and not self.get("party_account_field"):
 			self.setup_party_account_field()
@@ -2350,7 +2373,7 @@ def get_payment_entry(
 		paid_amount, received_amount, doc, party_account_currency, reference_date
 	)
 
-	pe = frappe.new_doc("Payment Entry")
+	pe = frappe.flags.new_payment_entry or frappe.new_doc("Payment Entry")
 	pe.payment_type = payment_type
 	pe.company = doc.company
 	pe.cost_center = doc.get("cost_center")

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -741,8 +741,10 @@ class SalesOrder(SellingController):
 			voucher_type=self.doctype, voucher_no=self.name, sre_list=sre_list, notify=notify
 		)
 
-	def _into_sales_invoice(self):
-		make_sales_invoice(self.name)
+	@frappe.requires_permission("Sales Order", "read")
+	@frappe.requires_permission("Sales Invoice", "create")
+	def _into_sales_invoice(self, si):
+		make_sales_invoice(self.name, target_doc=si)
 
 
 def get_unreserved_qty(item: object, reserved_qty_details: dict) -> float:

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -741,6 +741,9 @@ class SalesOrder(SellingController):
 			voucher_type=self.doctype, voucher_no=self.name, sre_list=sre_list, notify=notify
 		)
 
+	def make_sales_invoice(self, target_doc=None, ignore_permissions=False):
+		make_sales_invoice(self.name, target_doc, ignore_permissions)
+
 
 def get_unreserved_qty(item: object, reserved_qty_details: dict) -> float:
 	"""Returns the unreserved quantity for the Sales Order Item."""

--- a/erpnext/selling/doctype/sales_order/sales_order.py
+++ b/erpnext/selling/doctype/sales_order/sales_order.py
@@ -741,8 +741,8 @@ class SalesOrder(SellingController):
 			voucher_type=self.doctype, voucher_no=self.name, sre_list=sre_list, notify=notify
 		)
 
-	def make_sales_invoice(self, target_doc=None, ignore_permissions=False):
-		make_sales_invoice(self.name, target_doc, ignore_permissions)
+	def _into_sales_invoice(self):
+		make_sales_invoice(self.name)
 
 
 def get_unreserved_qty(item: object, reserved_qty_details: dict) -> float:


### PR DESCRIPTION
# Context

**This strategy didn't work**

```py
# On Payment Charge Processed Server Script run as Guest
if doc.method == "ecommerce_integrations.ecwid.order.sync_order_from_payment_request":
 	ps = doc.flags.payment_session
 	if ps.changed:
 		payload = json.loads(doc.request_data)
 		returnUrl = payload["returnUrl"]
 		if ps.flags.status_changed_to in ps.flowstates.success:
 			si = frappe.new_doc("Sales Invoice")
 			si.allocate_advances_automatically = True
 			si = frappe.call(
          # Fails with a not-whitelisted error on Guest sessions
 			    "erpnext.selling.doctype.sales_order.sales_order.make_sales_invoice",
          source_name=doc.reference_docname,
 			    target_doc=si,
 			    ignore_permissions=True,
 			)
 			si.insert(ignore_permissions=True)
 			si.submit()
 			doc.flags.payment_result = {
 				"message": "Pago exitoso",
 				"action": {"href": returnUrl, "label": "Revisar Confirmacion"},
 			}
 		else:
 			doc.flags.payment_result = {
 				"message": "Pago fallido",
 				"action": {"href": returnUrl, "label": "Volver al Carrito"},
 			}

```

Now making things doc methods just for this is probably not the best option, but I couldn't find another sane way to achieve this.

This is probably a design flaw in how whitelisting is implemented in combination with servers scripts.

Non-Solutions include: 
- Indiscriminate privilege escalation: `frappe.set_user("Administrator")`
- Use frappe client and hard-code (admin) passwords into server scripts
- ?

Maybe there's a more elegant way though, which wouldn't require ultimately an involved refactor to solve this problem at the root?
