### PR TITLE
fix: validate account balance for each finance book

### DIFF
--- a/erpnext/accounts/doctype/finance_book/test_records.json
+++ b/erpnext/accounts/doctype/finance_book/test_records.json
@@ -1,0 +1,8 @@
+[
+    {
+        "finance_book_name":"Financial Accounting"
+    },
+    {
+        "finance_book_name":"Tax Accounting"
+    }
+]

--- a/erpnext/accounts/doctype/gl_entry/gl_entry.py
+++ b/erpnext/accounts/doctype/gl_entry/gl_entry.py
@@ -316,7 +316,7 @@ def validate_balance_type(account, adv_adj=False, finance_book=None):
 			IfNull(gl_entry.finance_book, "").isin(("", finance_book))
 		)
 		balance = query.run()[0][0]
-		return _validate_balance_must_be(balance_must_be, balance, account, precision)
+		return _validate_balance_must_be(balance_must_be, balance, account)
 
 	balances = dict(
 		query.select(IfNull(gl_entry.finance_book, "").as_("fb"))
@@ -327,11 +327,11 @@ def validate_balance_type(account, adv_adj=False, finance_book=None):
 
 	default_balance = balances.pop("", 0)
 	if not balances:
-		return _validate_balance_must_be(balance_must_be, default_balance, account, precision)
+		return _validate_balance_must_be(balance_must_be, default_balance, account)
 
 	for finance_book, balance in balances.items():
 		_validate_balance_must_be(
-			balance_must_be, flt(default_balance + balance, precision), account, precision, finance_book
+			balance_must_be, flt(default_balance + balance, precision), account, finance_book
 		)
 
 

--- a/erpnext/accounts/doctype/gl_entry/gl_entry.py
+++ b/erpnext/accounts/doctype/gl_entry/gl_entry.py
@@ -7,6 +7,7 @@ from frappe import _
 from frappe.model.document import Document
 from frappe.model.meta import get_field_precision
 from frappe.model.naming import set_name_from_naming_options
+from frappe.query_builder.functions import IfNull, Sum
 from frappe.utils import flt, fmt_money
 
 import erpnext
@@ -89,7 +90,7 @@ class GLEntry(Document):
 		if not self.flags.from_repost and self.voucher_type != "Period Closing Voucher":
 			self.validate_account_details(adv_adj)
 			self.validate_dimensions_for_pl_and_bs()
-			validate_balance_type(self.account, adv_adj)
+			validate_balance_type(self.account, adv_adj, self.finance_book)
 			validate_frozen_account(self.account, adv_adj)
 
 			if (
@@ -297,22 +298,47 @@ class GLEntry(Document):
 		frappe.throw(msg)
 
 
-def validate_balance_type(account, adv_adj=False):
-	if not adv_adj and account:
-		balance_must_be = frappe.get_cached_value("Account", account, "balance_must_be")
-		if balance_must_be:
-			balance = frappe.db.sql(
-				"""select sum(debit) - sum(credit)
-				from `tabGL Entry` where account = %s""",
-				account,
-			)[0][0]
+def validate_balance_type(account, adv_adj=False, finance_book=None):
+	if adv_adj or not account:
+		return
 
-			if (balance_must_be == "Debit" and flt(balance) < 0) or (
-				balance_must_be == "Credit" and flt(balance) > 0
-			):
-				frappe.throw(
-					_("Balance for Account {0} must always be {1}").format(account, _(balance_must_be))
-				)
+	balance_must_be = frappe.get_cached_value("Account", account, "balance_must_be")
+	if not balance_must_be:
+		return
+
+	gl_entry = frappe.qb.DocType("GL Entry")
+	query = frappe.qb.from_(gl_entry).where(gl_entry.account == account)
+
+	if finance_book:
+		query.select(Sum(gl_entry.debit) - Sum(gl_entry.credit)).where(
+			IfNull(gl_entry.finance_book, "") in ("", finance_book)
+		)
+		balance = query.run()[0][0]
+		return _validate_balance_must_be(balance_must_be, balance, account)
+
+	balances = dict(
+		query.select(IfNull(gl_entry.finance_book, "").as_("fb"))
+		.select(Sum(gl_entry.debit) - Sum(gl_entry.credit))
+		.groupby("fb")
+		.run()
+	)
+	default_balance = balances.pop("", 0)
+	if not balances:
+		return _validate_balance_must_be(balance_must_be, default_balance, account)
+
+	for finance_book, balance in balances.items():
+		_validate_balance_must_be(balance_must_be, default_balance + balance, account, finance_book)
+
+
+def _validate_balance_must_be(balance_must_be, balance, account, finance_book=None):
+	if (balance_must_be == "Debit" and flt(balance) < 0) or (
+		balance_must_be == "Credit" and flt(balance) > 0
+	):
+		error_message = _("Balance for Account {0} must always be {1}").format(account, _(balance_must_be))
+		if finance_book:
+			error_message += _(" (Finance Book {0})").format(finance_book)
+
+		frappe.throw(error_message)
 
 
 def update_outstanding_amt(

--- a/erpnext/accounts/doctype/gl_entry/test_gl_entry.py
+++ b/erpnext/accounts/doctype/gl_entry/test_gl_entry.py
@@ -1,14 +1,17 @@
 # Copyright (c) 2015, Frappe Technologies Pvt. Ltd. and Contributors
 # License: GNU General Public License v3. See license.txt
 
-
+import re
 import unittest
 
 import frappe
 from frappe.model.naming import parse_naming_series
 
+from erpnext.accounts.doctype.account.test_account import create_account
 from erpnext.accounts.doctype.gl_entry.gl_entry import rename_gle_sle_docs
 from erpnext.accounts.doctype.journal_entry.test_journal_entry import make_journal_entry
+
+test_dependencies = ["Company", "Account", "Finance Book"]
 
 
 class TestGLEntry(unittest.TestCase):
@@ -79,3 +82,50 @@ class TestGLEntry(unittest.TestCase):
 			"SELECT current from tabSeries where name = %s", naming_series
 		)[0][0]
 		self.assertEqual(old_naming_series_current_value + 2, new_naming_series_current_value)
+
+	def test_validate_balance_type(self):
+		fixed_asset_account_name = "_Test Fixed Asset (with FB)"
+		bank_account = "_Test Bank - _TC"
+
+		fixed_asset_account = frappe.db.get_value(
+			"Account", {"account_name": fixed_asset_account_name, "company": "_Test Company"}
+		)
+
+		if not fixed_asset_account:
+			fixed_asset_account = create_account(
+				account_name=fixed_asset_account_name,
+				parent_account="Fixed Assets - _TC",
+				company="_Test Company",
+				is_group=0,
+				account_type="Fixed Asset",
+			)
+			frappe.db.set_value("Account", fixed_asset_account, "balance_must_be", "Debit")
+		else:
+			clear_account_balance(fixed_asset_account)
+
+		make_journal_entry(fixed_asset_account, bank_account, 1000, submit=True)
+
+		financial_accounting_je = make_journal_entry(fixed_asset_account, bank_account, -1000, save=False)
+		financial_accounting_je.finance_book = "Financial Accounting"
+		financial_accounting_je.insert()
+		financial_accounting_je.submit()
+
+		tax_accounting_je1 = make_journal_entry(fixed_asset_account, bank_account, -500, save=False)
+		tax_accounting_je1.finance_book = "Tax Accounting"
+		tax_accounting_je1.insert()
+		tax_accounting_je1.submit()
+
+		tax_accounting_je2 = make_journal_entry(fixed_asset_account, bank_account, -600, save=False)
+		tax_accounting_je2.finance_book = "Tax Accounting"
+		tax_accounting_je2.insert()
+
+		self.assertRaisesRegex(
+			frappe.ValidationError,
+			re.compile(r"^(Balance for Account .* must always be Debit)"),
+			tax_accounting_je2.submit,
+		)
+
+
+def clear_account_balance(account_name):
+	gl = frappe.qb.DocType("GL Entry")
+	frappe.qb.from_(gl).delete().where(gl.account == account_name).run()

--- a/erpnext/accounts/doctype/payment_ledger_entry/payment_ledger_entry.py
+++ b/erpnext/accounts/doctype/payment_ledger_entry/payment_ledger_entry.py
@@ -166,7 +166,7 @@ class PaymentLedgerEntry(Document):
 				self.validate_account_details()
 				self.validate_dimensions_for_pl_and_bs()
 				self.validate_allowed_dimensions()
-				validate_balance_type(self.account, adv_adj)
+				validate_balance_type(self.account, adv_adj, self.finance_book)
 
 		# update outstanding amount
 		if (


### PR DESCRIPTION
The following use-case currently results in false-positive (error raised):

without finance book, i.e. for all finance books: debit 1000
finance book 1: cr. 1000
finance book 2: cr. 1000

This PR fixes that.